### PR TITLE
Add branch name to `gh pr list`

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -482,6 +482,7 @@ func project() github.Project {
 	if repoFromEnv := os.Getenv("GH_REPO"); repoFromEnv != "" {
 		repoURL, err := url.Parse(fmt.Sprintf("https://github.com/%s.git", repoFromEnv))
 		if err != nil {
+			panic(err)
 		}
 		project, err := github.NewProjectFromURL(repoURL)
 		if err != nil {


### PR DESCRIPTION
It was bugging me that our text prototypes had the branch name in the PR list but our prototype didn't. Now that we use graphql to get PR information we **can** display the branch names!

Here is what it looks like in this PR.
![](https://d.pr/i/x5TWoM+)