### PR TITLE
Support `pr checkout` without argument

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -665,6 +665,10 @@ func checkoutMenu() error {
 		prOptions = append(prOptions, fmt.Sprintf("#%d - %s [%s]", pr.Number, pr.Title, pr.HeadRefName))
 	}
 
+	if len(prOptions) == 0 {
+		return fmt.Errorf("no open pull requests found")
+	}
+
 	qs := []*survey.Question{
 		{
 			Name: "pr",


### PR DESCRIPTION
Now interactively prompts for an open PR to checkout:

<img width="781" alt="Screen Shot 2019-10-11 at 4 13 03 PM" src="https://user-images.githubusercontent.com/887/66658564-06f18900-ec42-11e9-8d23-dde6c7abb672.png">
