### PR TITLE
Build and watch script

### DIFF
--- a/script/build
+++ b/script/build
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+GH_PATH=./bin/gh
+
+echo -n -e "\033]0;🚧\007"
+
+if make ; then
+  echo -n -e "\033]0;✳️\007"
+else
+  echo -e "#!/usr/bin/env bash\necho build errors prevented gh from being built" > $GH_PATH
+  echo -n -e "\033]0;🛑\007"
+fi

--- a/script/build-and-watch
+++ b/script/build-and-watch
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+# check if notifyloop is installed
+if ! command -v notifyloop >/dev/null; then
+  echo "You don't have the notifyloop command installed. Run this brew command to install it:"
+  echo "$ brew install fsevents-tools "
+  exit 1
+fi
+
+notifyloop . ./script/build


### PR DESCRIPTION
I've been annoyed with how tedious it is to build and test this app against real repos.

**Option 1:** One solution is to add a `-C` command that will run the commands against a specific directory. Then you can run `go run . -C some-dir` to test the app.

**Option 2:** My other idea was to have a `build-and-watch` script that would watch for changes and then build the app. Then I symlinked the binary to `~/bin/` and then I could run `gh` wherever I wanted. 

This PR builds option 2.
Now run `script/build-and-watch` Every time you change your code it will recompile.

- As it is building there is a status indicator in the terminal’s title. 🚧 for building, ✳️ for success, and 🛑 for error. 
- If there is an error it will replace `gh` with a command that says there was a build failure.
- If there is a success you’ll have a new build of `gh` ready to use!

But as I am writing this up I think option 2 might be a better idea. I'm still opening a draft PR so we have something to talk about.