### PR TITLE
Fix global `--repo`, `--current-branch` functionality

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -17,7 +17,9 @@ var (
 func init() {
 	RootCmd.PersistentFlags().StringVarP(&currentRepo, "repo", "R", "", "current GitHub repository")
 	RootCmd.PersistentFlags().StringVarP(&currentBranch, "current-branch", "B", "", "current git branch")
+}
 
+func initContext() {
 	ctx := context.InitDefaultContext()
 	ctx.SetBranch(currentBranch)
 	repo := currentRepo
@@ -35,6 +37,9 @@ var RootCmd = &cobra.Command{
 	Short: "GitHub CLI",
 	Long:  `Do things with GitHub from your terminal`,
 	Args:  cobra.MinimumNArgs(1),
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		initContext()
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("root")
 	},


### PR DESCRIPTION
Turns out I've tried to use the flags' value too early: they are not yet parsed out at package `init()` time.