### PR TITLE
Stop requiring vendored dependencies in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,8 +20,6 @@ jobs:
       run: go mod verify
 
     - name: Build
-      env:
-        GOFLAGS: -mod=vendor
       run: |
         go test ./...
         go build -v .


### PR DESCRIPTION
We started vendoring dependencies because this was a practice that the Go community had for a while now to:

1. Speed up builds - no need to fetch dependencies every time;
2. Guard against 3rd-party downtime - CI passes even if hosts such as `gopkg.in` are down, or if someone deletes their GitHub repo/account hosting a particular module.

With Go 1.13 and GitHub Actions, however, we have these problems solved for free:
- The built-in goproxy caches dependencies and speeds up downloads;
- Octofactory ensures that dependencies are cached on our own infrastructure, guarding us from 3rd-party downtime. https://github.com/github/go-lang/issues/99

With all this in mind, I feel that we don't have to require vendoring dependencies anymore.