### PR TITLE
Add `completion` script

### DIFF
--- a/command/completion.go
+++ b/command/completion.go
@@ -2,16 +2,13 @@ package command
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
 
-var shellType string
-
 func init() {
 	RootCmd.AddCommand(completionCmd)
-	completionCmd.Flags().StringVarP(&shellType, "shell", "s", "bash", "The type of shell")
+	completionCmd.Flags().StringP("shell", "s", "bash", "The type of shell")
 }
 
 var completionCmd = &cobra.Command{
@@ -28,11 +25,16 @@ start a new shell.
 When installing with Homebrew, see https://docs.brew.sh/Shell-Completion
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		shellType, err := cmd.Flags().GetString("shell")
+		if err != nil {
+			return err
+		}
+
 		switch shellType {
 		case "bash":
-			RootCmd.GenBashCompletion(os.Stdout)
+			RootCmd.GenBashCompletion(cmd.OutOrStdout())
 		case "zsh":
-			RootCmd.GenZshCompletion(os.Stdout)
+			RootCmd.GenZshCompletion(cmd.OutOrStdout())
 		default:
 			return fmt.Errorf("unsupported shell type: %s", shellType)
 		}

--- a/command/completion_test.go
+++ b/command/completion_test.go
@@ -1,0 +1,50 @@
+package command
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCompletion_bash(t *testing.T) {
+	out := bytes.Buffer{}
+	completionCmd.SetOut(&out)
+
+	RootCmd.SetArgs([]string{"completion"})
+	_, err := RootCmd.ExecuteC()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outStr := out.String()
+	if !strings.Contains(outStr, "complete -o default -F __start_gh gh") {
+		t.Errorf("problem in bash completion:\n%s", outStr)
+	}
+}
+
+func TestCompletion_zsh(t *testing.T) {
+	out := bytes.Buffer{}
+	completionCmd.SetOut(&out)
+
+	RootCmd.SetArgs([]string{"completion", "-s", "zsh"})
+	_, err := RootCmd.ExecuteC()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outStr := out.String()
+	if !strings.Contains(outStr, "#compdef _gh gh") {
+		t.Errorf("problem in zsh completion:\n%s", outStr)
+	}
+}
+
+func TestCompletion_unsupported(t *testing.T) {
+	out := bytes.Buffer{}
+	completionCmd.SetOut(&out)
+
+	RootCmd.SetArgs([]string{"completion", "-s", "fish"})
+	_, err := RootCmd.ExecuteC()
+	if err == nil || err.Error() != "unsupported shell type: fish" {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
From the `prototype-2019-10-14` branch.

Completions for bash and zsh are automatically wired up when using Homebrew
https://github.com/github/homebrew-gh/blob/b4fcb99f4f5d2dbea2304ebd22a60afcedb00fbb/Formula/gh.rb#L10-L11