### PR TITLE
Silence Cobra usage on errors

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -19,13 +18,14 @@ func init() {
 	// RootCmd.PersistentFlags().BoolP("verbose", "V", false, "enable verbose output")
 
 	RootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		cmd.Println(err)
-		cmd.Println(cmd.UsageString())
-		return SilentErr
+		return FlagError{err}
 	})
 }
 
-var SilentErr = errors.New("SilentErr")
+// FlagError is the kind of error raised in flag processing
+type FlagError struct {
+	error
+}
 
 // RootCmd is the entry point of command-line execution
 var RootCmd = &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -3,14 +3,17 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/github/gh-cli/command"
 )
 
 func main() {
-	if err := command.RootCmd.Execute(); err != nil {
-		if err != command.SilentErr {
-			fmt.Fprintln(os.Stderr, err)
+	if cmd, err := command.RootCmd.ExecuteC(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		_, isFlagError := err.(command.FlagError)
+		if isFlagError || strings.HasPrefix(err.Error(), "unknown command ") {
+			fmt.Fprintln(os.Stderr, cmd.UsageString())
 		}
 		os.Exit(1)
 	}


### PR DESCRIPTION
When an error occurs anywhere in a command, Cobra used to print the error itself and command usage help.

We already print error in `main()`, and we don't want to use command usage string on anything other than flag-parsing errors.

This also fixes the double output of each error.