### PR TITLE
Switch to mgutz/ansi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/github/gh-cli
 go 1.13
 
 require (
-	github.com/gookit/color v1.2.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-colorable v0.1.2
 	github.com/mattn/go-isatty v0.0.9
+	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v0.0.5
 	gopkg.in/yaml.v3 v3.0.0-20191010095647-fc94e3f71652

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/gookit/color v1.2.0 h1:lHA77Kuyi5JpBnA9ESvwkY+nanLjRZ0mHbWQXRYk2Lk=
-github.com/gookit/color v1.2.0/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
@@ -22,6 +20,8 @@ github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/utils/color.go
+++ b/utils/color.go
@@ -1,43 +1,24 @@
 package utils
 
-import "github.com/gookit/color"
+import "github.com/mgutz/ansi"
 
-func Black(a ...interface{}) string {
-	return color.Black.Render(a...)
+var Black = ansi.ColorFunc("black")
+var White = ansi.ColorFunc("white")
+
+func Gray(arg string) string {
+	return ansi.Color(ansi.LightBlack+arg, "")
 }
 
-func White(a ...interface{}) string {
-	return color.White.Render(a...)
-}
+var Red = ansi.ColorFunc("red")
+var Green = ansi.ColorFunc("green")
+var Yellow = ansi.ColorFunc("yellow")
+var Blue = ansi.ColorFunc("blue")
+var Magenta = ansi.ColorFunc("magenta")
+var Cyan = ansi.ColorFunc("cyan")
 
-func Gray(a ...interface{}) string {
-	return color.Gray.Render(a...)
-}
-
-func Red(a ...interface{}) string {
-	return color.Red.Render(a...)
-}
-
-func Green(a ...interface{}) string {
-	return color.Green.Render(a...)
-}
-
-func Yellow(a ...interface{}) string {
-	return color.Yellow.Render(a...)
-}
-
-func Blue(a ...interface{}) string {
-	return color.Blue.Render(a...)
-}
-
-func Magenta(a ...interface{}) string {
-	return color.Magenta.Render(a...)
-}
-
-func Cyan(a ...interface{}) string {
-	return color.Cyan.Render(a...)
-}
-
-func Bold(a ...interface{}) string {
-	return color.Bold.Render(a...)
+func Bold(arg string) string {
+	// This is really annoying.  If you just define Bold as ColorFunc("+b") it will properly bold but
+	// will not use the default color, resulting in black and probably unreadable text. This forces
+	// the default color before bolding.
+	return ansi.Color(ansi.DefaultFG+arg, "+b")
 }


### PR DESCRIPTION
Due to a few issues with gookit/color, this PR switches us to mgutz/ansi. The latter is more flexible and better in a few ways; we initially rejected it because we thought ansi wasn't supported on windows at all. Turns out it is, so switching to `mgutz/ansi` fixes some problems (like getting color output while using tmux).