### PR TITLE
Fix filtering of PR list

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -126,14 +126,16 @@ func prList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var graphqlState string
+	var graphqlState []string
 	switch state {
 	case "open":
-		graphqlState = "OPEN"
+		graphqlState = []string{"OPEN"}
 	case "closed":
-		graphqlState = "CLOSED"
+		graphqlState = []string{"CLOSED"}
+	case "merged":
+		graphqlState = []string{"MERGED"}
 	case "all":
-		graphqlState = "ALL"
+		graphqlState = []string{"OPEN", "CLOSED", "MERGED"}
 	default:
 		return fmt.Errorf("invalid state: %s", state)
 	}

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -87,13 +87,13 @@ func TestPRList_filtering(t *testing.T) {
 	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
 	reqBody := struct {
 		Variables struct {
-			State  string
+			State  []string
 			Labels []string
 		}
 	}{}
 	json.Unmarshal(bodyBytes, &reqBody)
 
-	eq(t, reqBody.Variables.State, "ALL")
+	eq(t, reqBody.Variables.State, []string{"OPEN", "CLOSED", "MERGED"})
 	eq(t, reqBody.Variables.Labels, []string{"one", "two"})
 }
 


### PR DESCRIPTION
unfortunately there is no `ALL` state for filtering pull requests; you have to specify all of the types (or specify nothing, but we have a default of `OPEN`).

This PR tweaks the PR filtering to match what graphql ultimately wants -- an array of pull request states.