### PR TITLE
Swap "open in browser" to "view in browser" for view cmd

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -24,7 +24,7 @@ func init() {
 		&cobra.Command{
 			Use:   "view <issue-number>",
 			Args:  cobra.MinimumNArgs(1),
-			Short: "Open an issue in the browser",
+			Short: "View an issue in the browser",
 			RunE:  issueView,
 		},
 	)

--- a/command/pr.go
+++ b/command/pr.go
@@ -40,7 +40,7 @@ var prStatusCmd = &cobra.Command{
 }
 var prViewCmd = &cobra.Command{
 	Use:   "view [pr-number]",
-	Short: "Open a pull request in the browser",
+	Short: "View a pull request in the browser",
 	RunE:  prView,
 }
 


### PR DESCRIPTION
Closes #61 

This aligns `pr view` and `issue view` help text to use "view" instead of "open" based on feedback we got in usability testing.