### PR TITLE
Use `OWNER:BRANCH` syntax for cross-repo PRs

### DIFF
--- a/api/queries.go
+++ b/api/queries.go
@@ -17,7 +17,13 @@ type PullRequest struct {
 	State       string
 	URL         string
 	HeadRefName string
-	Reviews     struct {
+
+	IsCrossRepository   bool
+	HeadRepositoryOwner struct {
+		Login string
+	}
+
+	Reviews struct {
 		Nodes []struct {
 			State  string
 			Author struct {
@@ -25,6 +31,7 @@ type PullRequest struct {
 			}
 		}
 	}
+
 	Commits struct {
 		Nodes []struct {
 			Commit struct {
@@ -45,6 +52,13 @@ type PullRequest struct {
 			}
 		}
 	}
+}
+
+func (pr PullRequest) HeadLabel() string {
+	if pr.IsCrossRepository {
+		return fmt.Sprintf("%s:%s", pr.HeadRepositoryOwner.Login, pr.HeadRefName)
+	}
+	return pr.HeadRefName
 }
 
 type PullRequestReviewStatus struct {
@@ -245,6 +259,11 @@ func PullRequests(client *Client, ghRepo Repo, currentBranch, currentUsername st
 		title
 		url
 		headRefName
+		headRefName
+		headRepositoryOwner {
+			login
+		}
+		isCrossRepository
 		commits(last: 1) {
 			nodes {
 				commit {
@@ -442,6 +461,10 @@ func PullRequestList(client *Client, vars map[string]interface{}, limit int) ([]
 				state
 				url
 				headRefName
+				headRepositoryOwner {
+					login
+				}
+				isCrossRepository
             }
 		  }
 		  pageInfo {

--- a/command/pr.go
+++ b/command/pr.go
@@ -199,10 +199,10 @@ func prList(cmd *cobra.Command, args []string) error {
 			case "MERGED":
 				prNum = utils.Magenta(prNum)
 			}
-			prBranch := utils.Cyan(truncate(branchWidth, pr.HeadRefName))
+			prBranch := utils.Cyan(truncate(branchWidth, pr.HeadLabel()))
 			fmt.Fprintf(out, "%s  %-*s  %s\n", prNum, titleWidth, truncate(titleWidth, pr.Title), prBranch)
 		} else {
-			fmt.Fprintf(out, "%d\t%s\t%s\n", pr.Number, pr.Title, pr.HeadRefName)
+			fmt.Fprintf(out, "%d\t%s\t%s\n", pr.Number, pr.Title, pr.HeadLabel())
 		}
 	}
 	return nil
@@ -249,7 +249,7 @@ func prView(cmd *cobra.Command, args []string) error {
 func printPrs(prs ...api.PullRequest) {
 	for _, pr := range prs {
 		prNumber := fmt.Sprintf("#%d", pr.Number)
-		fmt.Printf("  %s  %s %s", utils.Yellow(prNumber), truncate(50, pr.Title), utils.Cyan("["+pr.HeadRefName+"]"))
+		fmt.Printf("  %s  %s %s", utils.Yellow(prNumber), truncate(50, pr.Title), utils.Cyan("["+pr.HeadLabel()+"]"))
 
 		checks := pr.ChecksStatus()
 		reviews := pr.ReviewStatus()

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -66,7 +66,7 @@ func TestPRList(t *testing.T) {
 	}
 
 	eq(t, out.String(), `32	New feature	feature
-29	Fixed bad bug	bug-fix
+29	Fixed bad bug	hubot:bug-fix
 28	Improve documentation	docs
 `)
 }

--- a/test/fixtures/prList.json
+++ b/test/fixtures/prList.json
@@ -16,7 +16,11 @@
               "number": 29,
               "title": "Fixed bad bug",
               "url": "https://github.com/monalisa/hello/pull/29",
-              "headRefName": "bug-fix"
+              "headRefName": "bug-fix",
+              "isCrossRepository": true,
+              "headRepositoryOwner": {
+                "login": "hubot"
+              }
             }
           },
           {


### PR DESCRIPTION
This affects `pr status` and `pr list`.