### PR TITLE
`pr status`: avoid printing a lonely "1" when there is only one Check

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -364,17 +364,17 @@ func printPrs(prs ...api.PullRequest) {
 		if checks.Total > 0 {
 			var summary string
 			if checks.Failing > 0 {
-				if checks.Total > 1 {
-					summary = utils.Red(fmt.Sprintf("%d/%d failing", checks.Failing, checks.Total))
+				if checks.Failing == checks.Total {
+					summary = utils.Red("All checks failing")
 				} else {
-					summary = utils.Red("failing")
+					summary = utils.Red(fmt.Sprintf("%d/%d checks failing", checks.Failing, checks.Total))
 				}
 			} else if checks.Pending > 0 {
-				summary = utils.Yellow("pending")
+				summary = utils.Yellow("Checks pending")
 			} else if checks.Passing == checks.Total {
-				summary = utils.Green("success")
+				summary = utils.Green("Checks passing")
 			}
-			fmt.Printf(" - checks: %s", summary)
+			fmt.Printf(" - %s", summary)
 		}
 
 		if reviews.ChangesRequested {


### PR DESCRIPTION
In a repository that only has a single Check configured (e.g. this repo), we would print "checks: 1" for PRs where the CI is passing. This looks akward when repeated for each PR and provides little useful information.

This avoids ever printing "1" and instead prints "failing", "pending", or "success", respectively. We now only show numbers for PRs that have more than one Check run.

<img width="657" alt="Screen Shot 2019-11-15 at 12 46 52 PM" src="https://user-images.githubusercontent.com/887/68941401-11a1bf80-07a6-11ea-8b6b-c98666e349a3.png">
