### PR TITLE
Add labels to `gh issue status`

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -39,24 +39,20 @@ type apiIssues struct {
 	}
 }
 
-var fragments string
-
-func init() {
-	fragments = `
-		fragment issue on Issue {
-			number
-			title
-			labels(first: 3) {
-				edges {
-					node {
-						name
-					}
+const fragments = `
+	fragment issue on Issue {
+		number
+		title
+		labels(first: 3) {
+			edges {
+				node {
+					name
 				}
-				totalCount
 			}
+			totalCount
 		}
-	`
-}
+	}
+`
 
 func IssueCreate(client *Client, ghRepo Repo, params map[string]interface{}) (*Issue, error) {
 	repoID, err := GitHubRepoId(client, ghRepo)


### PR DESCRIPTION
The `gh issue status` output didn't include labels, now it does.