### PR TITLE
Fix injecting git version information into development build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILD_FILES = $(shell go list -f '{{range .GoFiles}}{{$$.Dir}}/{{.}}\
 {{end}}' ./...)
 
-GH_VERSION = $(shell go describe --tags 2>/dev/null || git rev-parse --short HEAD)
+GH_VERSION = $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
 LDFLAGS := -X github.com/github/gh-cli/command.Version=$(GH_VERSION) $(LDFLAGS)
 LDFLAGS := -X github.com/github/gh-cli/command.BuildDate=$(shell date +%Y-%m-%d) $(LDFLAGS)
 ifdef GH_OAUTH_CLIENT_SECRET


### PR DESCRIPTION
This was a typo; thanks @probablycorey https://github.slack.com/archives/CLLG3RMAR/p1574118953426200

`git describe --tags` outputs a description of the current git ref relative to the latest reachable git tag.

Note that Makefile is only used for building a development version after cloning from git; the tagged release process uses `.goreleaser.yml` and skips the Makefile.