### PR TITLE
Avoid crash when parsing in-progress CheckRuns

### DIFF
--- a/api/pull_request_test.go
+++ b/api/pull_request_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPullRequest_ChecksStatus(t *testing.T) {
+	pr := PullRequest{}
+	payload := `
+	{ "commits": { "nodes": [{ "commit": {
+		"statusCheckRollup": {
+			"contexts": {
+				"nodes": [
+					{ "state": "SUCCESS" },
+					{ "state": "PENDING" },
+					{ "state": "FAILURE" },
+					{ "status": "IN_PROGRESS",
+					  "conclusion": null },
+					{ "status": "COMPLETED",
+					  "conclusion": "SUCCESS" },
+					{ "status": "COMPLETED",
+					  "conclusion": "FAILURE" },
+					{ "status": "COMPLETED",
+					  "conclusion": "ACTION_REQUIRED" }
+				]
+			}
+		}
+	} }] } }
+	`
+	err := json.Unmarshal([]byte(payload), &pr)
+	eq(t, err, nil)
+
+	checks := pr.ChecksStatus()
+	eq(t, checks.Total, 7)
+	eq(t, checks.Pending, 2)
+	eq(t, checks.Failing, 3)
+	eq(t, checks.Passing, 2)
+}


### PR DESCRIPTION
Fixes `panic: unsupported status: ""` #66

This occurs when a CheckRun has status "IN_PROGRESS" (or any other than "COMPLETED") and when its `conclusion` would be null. I previously didn't account for this.

This adds support for parsing state of an in-progress CheckRun.
