### PR TITLE
start on a manpage

### DIFF
--- a/doc/gh.1.md
+++ b/doc/gh.1.md
@@ -1,0 +1,88 @@
+% GH(1) Version 0.0.0 | GitHub on the CLI Documentation
+
+NAME
+====
+
+**gh** — Interact with GitHub from the CLI
+
+SYNOPSIS
+========
+
+| **gh** \[**global options**...] \[**command**] \[**command options**...]
+| **gh** \[**-R|--repo** _owner/repo_|**-B|--current-branch** _branch_] \[**pr|issue|help**] \[**command options**...]
+| **gh** \[**-h**|**--help**] 
+
+
+DESCRIPTION
+===========
+
+Do thinks with GitHub using your terminal.
+
+gh is intended to be run while currently in a git repository that has a GitHub
+remote. An initial authentication wizard will guide you on first run to connect
+gh to your GitHub account.
+
+Interact with GitHub objects via subcommands like _gh issue create_ or _gh pr
+status_.
+
+Global Options
+--------------
+
+-h, --help
+
+:   Prints brief usage information.
+
+-R, --repo "owner/name"
+
+:   Select a repo other than the current directory to work with
+
+-B, --current-branch "branch"
+
+:   Select a branch to work from other than the currently checked out branch
+
+Commands
+--------
+
+pr checkout "pr-number"
+
+:   Locally check out a given Pull Request
+
+pr create
+
+pr create --draft
+
+pr create --title "a title" --body "short body"
+
+: Create a PR. Will prompt you for title and body if not provided. Uses $EDITOR
+or $VISUAL to open PR body for editing. Pushes branch if not already pushed and
+warns about uncommited changes.
+
+TODO add rest of commands / more examples
+
+FILES
+=====
+
+*~/.config/gh*
+
+:   Config file and auth storage for gh
+
+ENVIRONMENT
+===========
+
+TODO
+
+BUGS
+====
+
+See GitHub Issues: <https://github.com/github/gh-cli/issues>
+
+AUTHOR
+======
+
+GitHub <https://github.com/github>
+
+SEE ALSO
+========
+
+**git(1)**
+


### PR DESCRIPTION
# start on a man page

This PR starts work on a manpage written in markdown. The ultimate goal is to use something like
https://github.com/maxheld83/pandoc to convert to proper markdown format as part of automated
release packaging.

I've been using this post as reference:
https://eddieantonio.ca/blog/2015/12/18/authoring-manpages-in-markdown-with-pandoc/

I'm shelving this work for now as we're not considering a manpage necessary for the alpha deadline.

@ampinsk, I wonder if you'd like to take a look at this and see if the approach makes sense? You're
welcome to add more content if that makes sense!
