### PR TITLE
Fix detecting terminal under Git Bash on Windows

### DIFF
--- a/utils/table_printer.go
+++ b/utils/table_printer.go
@@ -4,7 +4,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"strconv"
+	"strings"
 
+	"github.com/mattn/go-isatty"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -17,11 +21,19 @@ type TablePrinter interface {
 
 func NewTablePrinter(w io.Writer) TablePrinter {
 	if outFile, isFile := w.(*os.File); isFile {
-		fd := int(outFile.Fd())
-		if terminal.IsTerminal(fd) {
+		isCygwin := isatty.IsCygwinTerminal(outFile.Fd())
+		if isatty.IsTerminal(outFile.Fd()) || isCygwin {
 			ttyWidth := 80
-			if w, _, err := terminal.GetSize(fd); err == nil {
+			if w, _, err := terminal.GetSize(int(outFile.Fd())); err == nil {
 				ttyWidth = w
+			} else if isCygwin {
+				tputCmd := exec.Command("tput", "cols")
+				tputCmd.Stdin = os.Stdin
+				if out, err := tputCmd.Output(); err == nil {
+					if w, err := strconv.Atoi(strings.TrimSpace(string(out))); err == nil {
+						ttyWidth = w
+					}
+				}
 			}
 			return &ttyTablePrinter{
 				out:      w,


### PR DESCRIPTION
Git Bash is, to me, a very useful terminal emulator that comes with Git for Windows.

It looks like `IsTerminal()` from `golang.org/x/crypto/ssh/terminal` returns a false negative for Git Bash. I have switched to `IsCygwinTerminal()` from `github.com/mattn/go-isatty` and query `tput cols` to get terminal width.