### PR TITLE
Generate help docs to GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-bin/gh
+/bin
 /gh-cli
 .envrc
 /dist
+/site

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,15 @@ bin/gh: $(BUILD_FILES)
 
 test:
 	go test ./...
-
 .PHONY: test
+
+site:
+	git worktree add site gh-pages
+
+site-docs: site
+	git -C site rm 'gh*.md' 2>/dev/null || true
+	go run ./cmd/gen-docs site
+	git -C site add 'gh*.md'
+	git -C site commit -m 'update help docs'
+	git -C site push
+.PHONY: site-docs

--- a/cmd/gen-docs/main.go
+++ b/cmd/gen-docs/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/github/gh-cli/command"
+	"github.com/spf13/cobra/doc"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fatal("Usage: gen-docs <destination-dir>")
+	}
+	dir := os.Args[1]
+
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		fatal(err)
+	}
+
+	err = doc.GenMarkdownTreeCustom(command.RootCmd, dir, filePrepender, linkHandler)
+	if err != nil {
+		fatal(err)
+	}
+}
+
+func filePrepender(filename string) string {
+	return `---
+layout: page
+---
+
+`
+}
+
+func linkHandler(name string) string {
+	return fmt.Sprintf("{{site.baseurl}}{%% link %s %%}", name)
+}
+
+func fatal(msg interface{}) {
+	fmt.Fprintln(os.Stderr, msg)
+	os.Exit(1)
+}

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -38,6 +39,7 @@ github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=


### PR DESCRIPTION
`make site-docs`:
1. checks out the `gh-pages` branch into the `site/` directory;
2. regenerates `.md` help pages using Cobra;
3. commits and publishes updates.

Voilà: https://github.github.com/gh-cli/gh_issue_list.html

<img width="855" alt="Screen Shot 2019-11-28 at 4 47 52 PM" src="https://user-images.githubusercontent.com/887/69819309-f0f25480-11fe-11ea-8089-84412b534806.png">

TODO:
- [ ] auto-run this task whenever there is a tagged release

