### PR TITLE
Add google form link to root help description

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -43,7 +43,7 @@ type FlagError struct {
 var RootCmd = &cobra.Command{
 	Use:   "gh",
 	Short: "GitHub CLI",
-	Long:  `Work seamlessly with GitHub from the command line`,
+	Long:  `Work seamlessly with GitHub from the command line. GitHub CLI is in early stages of development, and we'd love to hear your feedback at https://forms.gle/pBt3kujJi7nXZmcM6`,
 
 	SilenceErrors: true,
 	SilenceUsage:  true,


### PR DESCRIPTION
As discussed in https://github.com/github/gh-cli/pull/98#discussion_r349237660, and noted in [this card](https://github.com/github/gh-cli/projects/1#card-30012176), we thought this would be a lightweight, easy way to gather feedback. 

Easy link to the form itself: https://forms.gle/pBt3kujJi7nXZmcM6

Does this place make sense to link this? Is there another, better place we haven't thought of?
