### PR TITLE
Don't open PRs in the finder

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -230,7 +230,6 @@ func prView(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-
 		openURL = pr.URL
 	} else {
 		prNumber, branchWithOwner, err := prSelectorForCurrentBranch(ctx)


### PR DESCRIPTION
This fixes https://github.com/github/gh-cli/issues/137. The problem was we weren't returning the URL in graphql, the computer tries to open an empty string, and that triggers the Finder to open.

I considered making some PR graphql fragments that all the PR queries can use, but wanted to see if others thought it was necessary before I refactored all the PR queries.