### PR TITLE
Add better usage docs for `gh pr view` `gh pr checkout` `gh issue view`

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -37,7 +37,11 @@ func init() {
 var issueCmd = &cobra.Command{
 	Use:   "issue",
 	Short: "Create and view issues",
-	Long:  `Work with GitHub issues`,
+	Long: `Work with GitHub issues.
+
+An issue can be supplied as argument in any of the following formats:
+- by number, e.g. "123"; or
+- by URL, e.g. "https://github.com/<owner>/<repo>/issues/123".`,
 }
 var issueCreateCmd = &cobra.Command{
 	Use:   "create",

--- a/command/pr.go
+++ b/command/pr.go
@@ -34,7 +34,12 @@ func init() {
 var prCmd = &cobra.Command{
 	Use:   "pr",
 	Short: "Create, view, and checkout pull requests",
-	Long:  `Work with GitHub pull requests.`,
+	Long: `Work with GitHub pull requests.
+
+A pull request can be supplied as argument in any of the following formats:
+- by number, e.g. "123";
+- by URL, e.g. "https://github.com/<owner>/<repo>/pull/123"; or
+- by the name of its head branch, e.g. "patch-1" or "<owner>:patch-1".`,
 }
 var prCheckoutCmd = &cobra.Command{
 	Use:   "checkout {<number> | <url> | <branch>}",


### PR DESCRIPTION
This updates to help docs to match the changes made in https://github.com/github/gh-cli/pull/129

I left out the `owner:branch-name` pattern for branches because I couldn’t figure out how to describe it in the limited space, and `owner:branch-name` felt too cryptic.

```
View a pull request in the browser

Usage:
  gh pr view {pr-number | url | branch-name} [flags]

Global Flags:
      —help          Show help for command
  -R, —repo string   Current GitHub repository
```

I used the IBM standards for cli documenting because the internet told me these are the standard and they are documented! https://www.ibm.com/support/knowledgecenter/en/STAV45/com.ibm.sonas.doc/sonas_manpages_syntax.html

Closes https://github.com/github/gh-cli/issues/139