### PR TITLE
Avoid long first line of gh help

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -43,7 +43,10 @@ type FlagError struct {
 var RootCmd = &cobra.Command{
 	Use:   "gh",
 	Short: "GitHub CLI",
-	Long:  `Work seamlessly with GitHub from the command line. GitHub CLI is in early stages of development, and we'd love to hear your feedback at https://forms.gle/pBt3kujJi7nXZmcM6`,
+	Long: `Work seamlessly with GitHub from the command line.
+
+GitHub CLI is in early stages of development, and we'd love to hear your
+feedback at <https://forms.gle/pBt3kujJi7nXZmcM6>`,
 
 	SilenceErrors: true,
 	SilenceUsage:  true,


### PR DESCRIPTION
This splits help text over paragraphs and lines to make the output of `gh` easier to read. It takes care not to go over 80 characters in width and wraps the URL in `<...>` which will help the URL get auto-linked when these docs are converted to man and HTML formats.

<img width="738" alt="Screen Shot 2019-12-16 at 4 05 27 PM" src="https://user-images.githubusercontent.com/887/70917609-eff25d00-201d-11ea-9393-ba123750198a.png">

Ref. #128