### PR TITLE
Simplify date format in gh version information

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ before:
 builds:
   - binary: bin/gh
     ldflags:
-      - -s -w -X github.com/github/gh-cli/command.Version={{.Version}} -X github.com/github/gh-cli/command.BuildDate={{.Date}}
+      - -s -w -X github.com/github/gh-cli/command.Version={{.Version}} -X github.com/github/gh-cli/command.BuildDate={{time "2006-01-02"}}
       - -X github.com/github/gh-cli/context.oauthClientID={{.Env.GH_OAUTH_CLIENT_ID}}
       - -X github.com/github/gh-cli/context.oauthClientSecret={{.Env.GH_OAUTH_CLIENT_SECRET}}
       - -X main.updaterEnabled=github/homebrew-gh


### PR DESCRIPTION
Currently, goreleaser injects the date that includes time & timezone information, but this is visually noisy:

```
gh version 0.3.5 (2019-12-13T16:15:54Z)
```

Since the precise time of the release is not relevant, this configures goreleaser to inject the simpler `2019-12-13` date format into the build, which also matches what our Makefile does in development.