### PR TITLE
Improve `site-docs` make task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ site:
 	git worktree add site gh-pages
 
 site-docs: site
+	git -C site pull
 	git -C site rm 'gh*.md' 2>/dev/null || true
 	go run ./cmd/gen-docs site
 	git -C site add 'gh*.md'


### PR DESCRIPTION
This ensures that upstream changes to the `gh-pages` branches are pulled before trying to upload new site docs.