### PR TITLE
Add first draft of contributing.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 ## Contributing
 
+[legal]: https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
+[license]: ../LICENSE
 [code-of-conduct]: CODE-OF-CONDUCT.md
 
 Hi! Thanks for your interest in contributing to the GitHub CLI!
@@ -20,7 +22,7 @@ Please do:
 0. Make your change, add tests, and ensure tests pass
 0. Make a PR: `gh pr create --web`
 
-Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.md).
+Contributions to this project are [released][legal] to the public under the [project's open source license][license].
 
 Please note that this project adheres to a [Contributor Code of Conduct][code-of-conduct]. By participating in this project you agree to abide by its terms.
 


### PR DESCRIPTION
Closes #191 

This PR adds a modified version of our [`contributing.md` template](https://raw.githubusercontent.com/github/open-source-releases/master/templates/CONTRIBUTING.md) under the `.github` directory.

**Note:** It looks like there's a todo item to [discuss the project's contribution philosophy](https://github.com/github/gh-cli/projects/1#card-30396998), so I suspect this will change.