### PR TITLE
Run CI on macos and windows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Tests
 on: [push]
 jobs:
   build-linux:


### PR DESCRIPTION
Previously we were only running our test suite on Linux. This allowed failing tests to make it into
master for windows.

This PR duplicates our Go build/test job for windows and macos.

Closes #187 
