### PR TITLE
Generate changelog on release

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -16,11 +16,13 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.13
+      - name: Generate changelog
+        run: script/changelog | tee CHANGELOG.md
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
-          args: release
+          args: release --release-notes=CHANGELOG.md
         env:
           GH_OAUTH_CLIENT_ID: 178c6fc778ccc68e1d6a
           GH_OAUTH_CLIENT_SECRET: ${{secrets.OAUTH_CLIENT_SECRET}}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /dist
 /site
 .github/**/node_modules
+/CHANGELOG.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,10 +39,3 @@ nfpms:
     formats:
       - deb
       - rpm
-
-changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"

--- a/script/changelog
+++ b/script/changelog
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+current_tag="${GITHUB_REF#refs/tags/}"
+start_ref="HEAD"
+
+# Find the previous release on the same branch, skipping prereleases if the
+# current tag is a full release
+previous_tag=""
+while [[ -z $previous_tag || ( $previous_tag == *-* && $current_tag != *-* ) ]]; do
+  previous_tag="$(git describe --tags "$start_ref"^ --abbrev=0)"
+  start_ref="$previous_tag"
+done
+
+git log "$previous_tag".. --reverse --merges --oneline --grep='Merge pull request #' | \
+  while read -r sha title; do
+    pr_num="$(grep -o '#[[:digit:]]\+' <<<"$title")"
+    pr_desc="$(git show -s --format=%b "$sha" | sed -n '1,/^$/p' | tr $'\n' ' ')"
+    printf "* %s %s\n\n" "$pr_desc" "$pr_num"
+  done


### PR DESCRIPTION
The changelog is generated using the git log of pull request merges since the last tagged release, and is in the following format:

```
* {PR title} #{PR number}
```

For example, currently the changelog is as such:


```
* Fix displaying "There are no issues assigned to you" notice  #159

* Avoid long first line of gh help  #162

* Add "Opening URL in your browser" notice to `issue create --web`  #158

* Simplify date format in gh version information  #163

* Consolidate references to the config dir  #156

...
```

Ref. #111