### PR TITLE
Fix language stats for this repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.github/actions/copy-release-to-another-repo/lib/* linguist-generated


### PR DESCRIPTION
Right now, this repository is being reported as ~90% JavaScript (rather than Go)
due to large generated Actions files that are not being detected as such.

The offending files are:
`.github/actions/copy-release-to-another-repo/lib/index.js`
`.github/actions/copy-release-to-another-repo/lib/sourcemap-register.js`

For me, Linguist locally _correctly_ detects the first one as being generated
due to its `sourceMappingURL` directive, but somehow it still gets counted in
language stats for the repo.

This change ensures that both files are explicitly marked as generated.

https://github.slack.com/archives/CLLG3RMAR/p1573579347349500
https://github.com/github/linguist#overrides
https://github.com/github/linguist/blob/ccb71a915a8be343466a176b1309040c9541795c/lib/linguist/generated.rb#L157