### PR TITLE
Improve OAuth flow

### DIFF
--- a/context/config_setup.go
+++ b/context/config_setup.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/github/gh-cli/api"
 	"github.com/github/gh-cli/auth"
@@ -26,6 +27,11 @@ var (
 // TODO: have a conversation about whether this belongs in the "context" package
 // FIXME: make testable
 func setupConfigFile(filename string) (*configEntry, error) {
+	var verboseStream io.Writer
+	if strings.Contains(os.Getenv("DEBUG"), "oauth") {
+		verboseStream = os.Stderr
+	}
+
 	flow := &auth.OAuthFlow{
 		Hostname:     oauthHost,
 		ClientID:     oauthClientID,
@@ -33,6 +39,7 @@ func setupConfigFile(filename string) (*configEntry, error) {
 		WriteSuccessHTML: func(w io.Writer) {
 			fmt.Fprintln(w, oauthSuccessPage)
 		},
+		VerboseStream: verboseStream,
 	}
 
 	fmt.Fprintln(os.Stderr, "Notice: authentication required")


### PR DESCRIPTION
- More explicit error handling around OAuth flow will catch and report inconsistent states sooner;
- Improve local server handler to ignore requests other than the OAuth callback;
- When running with `DEBUG=oauth`, output more debugging info to stderr.

Ref. https://github.com/github/gh-cli/issues/220 https://github.com/github/gh-cli/issues/214