### PR TITLE
Disable cancelling other CI builds after one fails

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,7 @@ on: [push]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Our builds are fast and we don't gain much from having other builds in the same job matrix cancelled after a single build fails. If builds on all platforms fail (e.g. due to a broken feature), I think it's much nicer to see a set of equally "failed" builds rather than one "failed" and all others "cancelled".

[Docs for fail-fast](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)

Followup to https://github.com/github/gh-cli/pull/198