### PR TITLE
check for disabled issues in issue view

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -215,14 +215,6 @@ func issueView(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	issuesEnabled, err := api.HasIssuesEnabled(apiClient, baseRepo)
-	if err != nil {
-		return err
-	}
-	if !issuesEnabled {
-		return fmt.Errorf("the '%s/%s' repository has disabled issues", baseRepo.RepoOwner(), baseRepo.RepoName())
-	}
-
 	issue, err := issueFromArg(apiClient, baseRepo, args[0])
 	if err != nil {
 		return err

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -203,14 +203,7 @@ func TestIssueView(t *testing.T) {
 	http := initFakeHTTP()
 
 	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repository": {
-			"id": "REPOID",
-			"hasIssuesEnabled": true
-		} } }
-	`))
-
-	http.StubResponse(200, bytes.NewBufferString(`
-	{ "data": { "repository": { "issue": {
+	{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {
 		"number": 123,
 		"url": "https://github.com/OWNER/REPO/issues/123"
 	} } } }
@@ -243,14 +236,7 @@ func TestIssueView_preview(t *testing.T) {
 	http := initFakeHTTP()
 
 	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repository": {
-			"id": "REPOID",
-			"hasIssuesEnabled": true
-		} } }
-	`))
-
-	http.StubResponse(200, bytes.NewBufferString(`
-	{ "data": { "repository": { "issue": {
+		{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {
 		"number": 123,
 		"body": "**bold story**",
 		"title": "ix of coins",
@@ -293,13 +279,6 @@ func TestIssueView_preview(t *testing.T) {
 func TestIssueView_notFound(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repository": {
-			"id": "REPOID",
-			"hasIssuesEnabled": true
-		} } }
-	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "errors": [
@@ -346,14 +325,7 @@ func TestIssueView_urlArg(t *testing.T) {
 	http := initFakeHTTP()
 
 	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repository": {
-			"id": "REPOID",
-			"hasIssuesEnabled": true
-		} } }
-	`))
-
-	http.StubResponse(200, bytes.NewBufferString(`
-	{ "data": { "repository": { "issue": {
+	{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {
 		"number": 123,
 		"url": "https://github.com/OWNER/REPO/issues/123"
 	} } } }


### PR DESCRIPTION
closes #226

this PR adds another graphql query to `gh issue view` to ensure that a repo actually has issues
enabled before trying to query issues.

    ~/s/testing $ gh issue view 16
    the 'vilmibm/testing' repository has disabled issues

