### PR TITLE
Restyle auth page

### DIFF
--- a/context/config_success.go
+++ b/context/config_success.go
@@ -6,27 +6,37 @@ const oauthSuccessPage = `
 <title>Success: GitHub CLI</title>
 <style type="text/css">
 body {
-    color: #333;
-    font-size: 14px;
-    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
-    line-height: 1.5;
-    max-width: 461px;
-    margin: 2em auto;
-    text-align: center;
+  color: #1B1F23;
+  background: #F6F8FA;
+  font-size: 14px;
+  font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  max-width: 620px;
+  margin: 28px auto;
+  text-align: center;
 }
+
 h1 {
-    color: #555;
-    font-size: 22px;
-    letter-spacing: 1px;
+  font-size: 24px;
+  margin-bottom: 0;
+}
+
+p {
+  margin-top: 0;
+}
+
+.box {
+  border: 1px solid #E1E4E8;
+  background: white;
+  padding: 24px;
+  margin: 28px;
 }
 </style>
-
 <body>
-    <h1>Authentication successful.</h1>
-    <p>
-        You have completed logging into GitHub CLI.<br>
-        You may now <strong>close this tab and return to the terminal</strong>.
-    </p>
-    <img alt="" src="https://octodex.github.com/images/daftpunktocat-guy.gif" height="461">
+  <svg height="52" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="52" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
+  <div class="box">
+    <h1>Successfully authenticated GitHub CLI</h1>
+    <p>You may now close this tab and return to the terminal.</p>
+  </div>
 </body>
 `


### PR DESCRIPTION
Closes #245 

Just did a pass to make this feel a little bit more like Primer and GitHub.com! Used our SSO/security login flows as an example to follow.

|Before|After|
|---|---|
|![Screen Shot 2020-01-22 at 2 50 46 PM](https://user-images.githubusercontent.com/10404068/72941745-9ff66c80-3d26-11ea-9674-d95659a078c4.png)|![Screen Shot 2020-01-22 at 2 50 16 PM](https://user-images.githubusercontent.com/10404068/72941761-a71d7a80-3d26-11ea-8e5d-4f99b185037b.png)|