### PR TITLE
Avoid saying "number as argument" for `issue/pr view`

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -68,7 +68,7 @@ var issueViewCmd = &cobra.Command{
 	Use: "view {<number> | <url> | <branch>}",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return errors.New("requires an issue number as an argument")
+			return FlagError{errors.New("issue required as argument")}
 		}
 		return nil
 	},

--- a/command/pr.go
+++ b/command/pr.go
@@ -285,10 +285,6 @@ func prView(cmd *cobra.Command, args []string) error {
 		} else {
 			pr, err = api.PullRequestForBranch(apiClient, baseRepo, branchWithOwner)
 			if err != nil {
-				var notFoundErr *api.NotFoundError
-				if errors.As(err, &notFoundErr) {
-					return fmt.Errorf("%s. To open a specific pull request use the pull request's number as an argument", err)
-				}
 				return err
 			}
 

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -359,7 +359,7 @@ func TestPRView_noResultsForBranch(t *testing.T) {
 	defer restoreCmd()
 
 	_, err := RunCommand(prViewCmd, "pr view")
-	if err == nil || err.Error() != `no open pull requests found for branch "blueberries". To open a specific pull request use the pull request's number as an argument` {
+	if err == nil || err.Error() != `no open pull requests found for branch "blueberries"` {
 		t.Errorf("error running command `pr view`: %v", err)
 	}
 


### PR DESCRIPTION
Since issue URLs, PR URLs, and PR branch names are all accepted as arguments, avoid explicitly requesting "number" as argument.

Fixes #169