### PR TITLE
prevent graphql error

### DIFF
--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -175,7 +175,7 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 
 	if action == SubmitAction {
 		if title == "" {
-			return fmt.Errorf("Can't create a PR without a title.")
+			return fmt.Errorf("pull request title must not be blank")
 		}
 
 		params := map[string]interface{}{


### PR DESCRIPTION
this PR catches what would become a graphql error -- a blank PR title upon attempt to create it via the API. A blank title is still legal when previewing in browser (and encouraged, as the expectation is that the user will be filling the title in via the web).

We could take this chance to do something fancy like create a default PR title out of a single commit message but I didn't feel like making a UX decision on that right now; it seemed like handling the graphql error more humanely was good enough for now.

Closes #146 