### PR TITLE
Fix parsing non-GitHub remotes

### DIFF
--- a/context/remote.go
+++ b/context/remote.go
@@ -81,6 +81,9 @@ func translateRemotes(gitRemotes git.RemoteSet, urlTranslate func(*url.URL) *url
 		if r.PushURL != nil && repo == nil {
 			repo, _ = ghrepo.FromURL(urlTranslate(r.PushURL))
 		}
+		if repo == nil {
+			continue
+		}
 		remotes = append(remotes, &Remote{
 			Remote: r,
 			Owner:  repo.RepoOwner(),

--- a/context/remote_test.go
+++ b/context/remote_test.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"errors"
+	"net/url"
 	"testing"
 
 	"github.com/cli/cli/git"
@@ -24,4 +25,35 @@ func Test_Remotes_FindByName(t *testing.T) {
 
 	_, err = list.FindByName("nonexist")
 	eq(t, err, errors.New(`no GitHub remotes found`))
+}
+
+func Test_translateRemotes(t *testing.T) {
+	publicURL, _ := url.Parse("https://github.com/monalisa/hello")
+	originURL, _ := url.Parse("http://example.com/repo")
+
+	gitRemotes := git.RemoteSet{
+		&git.Remote{
+			Name:     "origin",
+			FetchURL: originURL,
+		},
+		&git.Remote{
+			Name:     "public",
+			FetchURL: publicURL,
+		},
+	}
+
+	identityURL := func(u *url.URL) *url.URL {
+		return u
+	}
+	result := translateRemotes(gitRemotes, identityURL)
+
+	if len(result) != 1 {
+		t.Errorf("got %d results", len(result))
+	}
+	if result[0].Name != "public" {
+		t.Errorf("got %q", result[0].Name)
+	}
+	if result[0].RepoName() != "hello" {
+		t.Errorf("got %q", result[0].RepoName())
+	}
 }


### PR DESCRIPTION
Otherwise, the remote URL translation mechanism had crashed when encountering a non-Github.com git remote.