### PR TITLE
Fix `gh version` printing the correct changelog link

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -24,7 +24,7 @@ var versionOutput = ""
 
 func init() {
 	RootCmd.Version = fmt.Sprintf("%s (%s)", strings.TrimPrefix(Version, "v"), BuildDate)
-	versionOutput = fmt.Sprintf("gh version %s\n%s\n", RootCmd.Version, changelogURL(RootCmd.Version))
+	versionOutput = fmt.Sprintf("gh version %s\n%s\n", RootCmd.Version, changelogURL(Version))
 	RootCmd.AddCommand(versionCmd)
 	RootCmd.SetVersionTemplate(versionOutput)
 
@@ -143,11 +143,11 @@ func colorableErr(cmd *cobra.Command) io.Writer {
 
 func changelogURL(version string) string {
 	path := "https://github.com/cli/cli"
-	r := regexp.MustCompile(`^\d+\.\d+.\d+(-[\w.]+)?$`)
+	r := regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[\w.]+)?$`)
 	if !r.MatchString(version) {
 		return fmt.Sprintf("%s/releases/latest", path)
 	}
 
-	url := fmt.Sprintf("%s/releases/tag/v%s", path, version)
+	url := fmt.Sprintf("%s/releases/tag/v%s", path, strings.TrimPrefix(version, "v"))
 	return url
 }

--- a/command/root_test.go
+++ b/command/root_test.go
@@ -13,6 +13,13 @@ func TestChangelogURL(t *testing.T) {
 		t.Errorf("expected %s to create url %s but got %s", tag, url, result)
 	}
 
+	tag = "v0.3.2"
+	url = fmt.Sprintf("https://github.com/cli/cli/releases/tag/v0.3.2")
+	result = changelogURL(tag)
+	if result != url {
+		t.Errorf("expected %s to create url %s but got %s", tag, url, result)
+	}
+
 	tag = "0.3.2-pre.1"
 	url = fmt.Sprintf("https://github.com/cli/cli/releases/tag/v0.3.2-pre.1")
 	result = changelogURL(tag)


### PR DESCRIPTION
Previously, the version string didn't match the `vX.Y.Z` pattern because the wrong variable was passed to `changelogURL`.

Followup to #264, ref. #270