### PR TITLE
Landing page fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,3 @@
-title: GitHub CLI
-description: TODO
-
-cli-latest-version: 0.4.0
-
 twitter:
   username: github
 
@@ -11,6 +6,7 @@ plugins:
   - jekyll-octicons
   - jekyll-seo-tag
   - jekyll-sitemap
+  - jekyll-github-metadata
 
 sass:
   load_paths:

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -92,6 +92,7 @@
 <!-- <script src="{{ "/assets/js/github/google-analytics.js" | relative_url }}"></script> -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/typed.js@2.0.11"></script>
+<script src="{{ site.baseurl }}/assets/js/user-select-contain.js"></script>
 <script src="{{ site.baseurl }}/assets/js/marketing-nav.js"></script>
 <script src="{{ site.baseurl }}/assets/js/downloader.js"></script>
 <script src="{{ site.baseurl }}/assets/js/terminal.js"></script>

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -91,7 +91,6 @@
 <!-- TODO -->
 <!-- <script src="{{ "/assets/js/github/google-analytics.js" | relative_url }}"></script> -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/typed.js@2.0.11"></script>
 <script src="{{ site.baseurl }}/assets/js/user-select-contain.js"></script>
 <script src="{{ site.baseurl }}/assets/js/marketing-nav.js"></script>
 <script src="{{ site.baseurl }}/assets/js/downloader.js"></script>

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -90,7 +90,6 @@
 
 <!-- TODO -->
 <!-- <script src="{{ "/assets/js/github/google-analytics.js" | relative_url }}"></script> -->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script src="{{ site.baseurl }}/assets/js/user-select-contain.js"></script>
 <script src="{{ site.baseurl }}/assets/js/marketing-nav.js"></script>
 <script src="{{ site.baseurl }}/assets/js/downloader.js"></script>

--- a/_includes/marketing-nav.html
+++ b/_includes/marketing-nav.html
@@ -118,10 +118,10 @@
             </ul>
           </nav>
 
-          <div class="d-lg-flex flex-items-center px-3 px-lg-0 text-center text-lg-left">
+          <!--<div class="d-lg-flex flex-items-center px-3 px-lg-0 text-center text-lg-left">
             <a class="HeaderMenu-link no-underline mr-3" href="https://github.com/login?return_to=%2Fjoin%3Fsource%3Dheader-home" data-ga-click="GitHub CLI, go to Sign in, CLI landing page main nav">Sign&nbsp;in</a>
             <a class="HeaderMenu-link d-inline-block no-underline border border-gray-dark rounded-1 px-2 py-1" href="https://github.com/join?source=header-home" data-ga-click="GitHub CLI, go to Sign up, CLI landing page main nav">Sign&nbsp;up</a>
-          </div>
+          </div>-->
         </div>
       </div>
   </header>

--- a/_includes/marketing-nav.html
+++ b/_includes/marketing-nav.html
@@ -130,9 +130,8 @@
 <div class="bg-white border-bottom" style="position: sticky; position: -webkit-sticky; top: 0; z-index: 5;">
   <nav class="d-flex container-xl mx-auto px-3 px-md-4">
     <div class="d-flex flex-auto flex-items-center flex-justify-end">
-      <a href="{{ site.baseurl }}" class="d-none d-sm-inline-block h5-mktg text-normal link-gray-dark py-3 mr-4 no-underline">Release notes</a>
-      <a href="{{ site.baseurl }}" class="d-none d-sm-inline-block h5-mktg text-normal link-gray-dark py-3 mr-4 no-underline">Manual</a>
-      <a href="{{ site.baseurl }}" class="d-none d-sm-inline-block h5-mktg text-normal link-gray-dark py-3 no-underline">Docs</a>
+      <a href="{{ "/manual/" | relative_url }}" class="d-none d-sm-inline-block h5-mktg text-normal link-gray-dark py-3 mr-4 no-underline">Manual</a>
+      <a href="{{ site.github.latest_release.html_url }}" class="d-none d-sm-inline-block h5-mktg text-normal link-gray-dark py-3 mr-4 no-underline">Release notes</a>
     </div>
   </nav>
 </div>

--- a/_sass/landing.scss
+++ b/_sass/landing.scss
@@ -70,3 +70,8 @@
 .command-pill-command {
   color: $gray-400;
 }
+
+.user-select-contain {
+  -ms-user-select: contain;
+  user-select: contain;
+}

--- a/assets/js/downloader.js
+++ b/assets/js/downloader.js
@@ -1,19 +1,17 @@
 // Show downloader on landing page for user's OS
 
-$( document ).ready(function() {
-  var os = '';
+var os = '';
 
-  if (navigator.appVersion.indexOf('Win') != -1) {
-    os = 'windows';
-  }
-  if (navigator.appVersion.indexOf('Mac') != -1) {
-    os = 'mac';
-  }
-  if (navigator.appVersion.indexOf("Linux") != -1) {
-    os = 'linux'
-  }
+if (navigator.appVersion.indexOf('Win') != -1) {
+  os = 'windows';
+}
+if (navigator.appVersion.indexOf('Mac') != -1) {
+  os = 'mac';
+}
+if (navigator.appVersion.indexOf('Linux') != -1) {
+  os = 'linux'
+}
 
-  $( '.download-' + os ).each(function( i, downloader ) {
-    $(downloader).removeClass('d-none');
-  });
-});
+Array.from(document.querySelectorAll('.download-' + os)).forEach(function(el) {
+  el.classList.remove('d-none')
+})

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1,83 +1,52 @@
-$( document ).ready(function() {
+var keystrokeDelay = 60  // ms between keystrokes
+var outputDelay = 300    // ms before command output is shown
+var cycleDelay = 8000    // ms between going to next command
 
-  var commands = $('.command-header').find('.command');
-  var activeCommandIndex = 1;
+var numCommands = document.querySelectorAll('.command-header .command').length
 
-  function showCommand (index) {
-    switch(index) {
-      case 1:
-        var typedHeader = new Typed('.command-header-1', {
-          strings: ['gh pr status'],
-          showCursor: false,
-          typeSpeed: 40
-        });
+function showCommand(index) {
+  if (index > numCommands) index = 1
 
-        var typedOutput = new Typed('.command-output-1', {
-          strings: ['<span class="text-white">gh pr status</span>^1000\n `<br><strong class="text-white">Current branch</strong><br><span class="pl-3">There is no pull request associated with <span class="text-blue-light">[fix-homepage-bug]</span></span><br><br><strong class="text-white">Created by you</strong><br><span class="pl-3">You have no open pull requests</span><br><br><strong class="text-white">Requesting a code review from you</strong><br><span class="pl-3"><span style="color: yellow;">#100</span>  <span class="text-white">Fix footer on homepage</span> <span class="text-blue-light">[fix-homepage-footer]</span></span><br><span class="pl-5">- <span style="color: chartreuse;">Checks passing</span> - Approved</span>`'],
-          showCursor: false,
-          typeSpeed: 40
-        });
-        break;
-      case 2:
-        var typedHeader = new Typed('.command-header-2', {
-          strings: ['gh issue list'],
-          showCursor: false,
-          typeSpeed: 40
-        });
-        // TODO update this terminal output
-        var typedOutput = new Typed('.command-output-2', {
-          strings: ['<span class="text-white">gh issue list</span>^1000\n `<br><strong class="text-white">Current branch</strong><br><span class="pl-3">There is no pull request associated with <span class="text-blue-light">[fix-homepage-bug]</span></span><br><br><strong class="text-white">Created by you</strong><br><span class="pl-3">You have no open pull requests</span><br><br><strong class="text-white">Requesting a code review from you</strong><br><span class="pl-3"><span style="color: yellow;">#100</span>  <span class="text-white">Fix footer on homepage</span> <span class="text-blue-light">[fix-homepage-footer]</span></span><br><span class="pl-5">- <span style="color: chartreuse;">Checks passing</span> - Approved</span>`'],
-          showCursor: false,
-          typeSpeed: 40
-        });
-        break;
-      case 3:
-        var typedHeader = new Typed('.command-header-3', {
-          strings: ['gh pr create'],
-          showCursor: false,
-          typeSpeed: 40
-        });
-        // TODO update this terminal output
-        var typedOutput = new Typed('.command-output-3', {
-          strings: ['<span class="text-white">gh pr create</span>^1000\n `<br><strong class="text-white">Current branch</strong><br><span class="pl-3">There is no pull request associated with <span class="text-blue-light">[fix-homepage-bug]</span></span><br><br><strong class="text-white">Created by you</strong><br><span class="pl-3">You have no open pull requests</span><br><br><strong class="text-white">Requesting a code review from you</strong><br><span class="pl-3"><span style="color: yellow;">#100</span>  <span class="text-white">Fix footer on homepage</span> <span class="text-blue-light">[fix-homepage-footer]</span></span><br><span class="pl-5">- <span style="color: chartreuse;">Checks passing</span> - Approved</span>`'],
-          showCursor: false,
-          typeSpeed: 40
-        });
-        break;
-      case 4:
-        var typedHeader = new Typed('.command-header-4', {
-          strings: ['gh pr checkout'],
-          showCursor: false,
-          typeSpeed: 40
-        });
-        // TODO update this terminal output
-        var typedOutput = new Typed('.command-output-4', {
-          strings: ['<span class="text-white">gh pr checkout</span>^1000\n `<br><strong class="text-white">Current branch</strong><br><span class="pl-3">There is no pull request associated with <span class="text-blue-light">[fix-homepage-bug]</span></span><br><br><strong class="text-white">Created by you</strong><br><span class="pl-3">You have no open pull requests</span><br><br><strong class="text-white">Requesting a code review from you</strong><br><span class="pl-3"><span style="color: yellow;">#100</span>  <span class="text-white">Fix footer on homepage</span> <span class="text-blue-light">[fix-homepage-footer]</span></span><br><span class="pl-5">- <span style="color: chartreuse;">Checks passing</span> - Approved</span>`'],
-          showCursor: false,
-          typeSpeed: 40
-        });
-        break;
+  // hide previous commands
+  Array.from(document.querySelectorAll('.command')).forEach(function(el) {
+    el.classList.add('d-none')
+  })
+
+  // show current command while respecting animated ones
+  Array.from(document.querySelectorAll('.command-'+index)).forEach(function(el) {
+    if (el.classList.contains('type-animate-done')) return
+    if (el.classList.contains('type-animate')) {
+      typeAnimate(el, function() {
+        var doneEl = el.nextElementSibling
+        if (doneEl && doneEl.classList.contains('type-animate-done')) {
+          setTimeout(function() {
+            doneEl.classList.remove('d-none')
+          }, outputDelay)
+        }
+      })
     }
-  }
+    el.classList.remove('d-none')
+  })
 
-  function showNextCommand () {
-    // hide and clear div contents of prev command
-    console.log('clearing', activeCommandIndex - 1);
-    $('.command-' + (activeCommandIndex - 1)).toggleClass('d-none');
-    $('.command-header-' + (activeCommandIndex - 1)).html('');
-    $('.command-output-' + (activeCommandIndex - 1)).html('');
+  // force "layout"
+  document.querySelector('.command-header').clientLeft
 
-    // if at the end of index, then start at 1
-    if (activeCommandIndex == commands.length + 1) {
-      activeCommandIndex = 1;
+  setTimeout(function() { showCommand(index+1) }, cycleDelay)
+}
+
+function typeAnimate(el, callback) {
+  var chars = el.textContent.split('')
+  el.textContent = ''
+
+  var typeIndex = 1
+  var interval = setInterval(function() {
+    el.textContent = chars.slice(0, typeIndex++).join('')
+    if (typeIndex > chars.length) {
+      clearInterval(interval)
+      interval = null
+      callback()
     }
+  }, keystrokeDelay)
+}
 
-    $('.command-' + activeCommandIndex).toggleClass('d-none');
-    showCommand(activeCommandIndex);
-    activeCommandIndex += 1;
-
-    setTimeout(function(){ showNextCommand(); }, 8000);
-  }
-
-  showNextCommand();
-});
+showCommand(1)

--- a/assets/js/user-select-contain.js
+++ b/assets/js/user-select-contain.js
@@ -1,0 +1,29 @@
+// https://github.com/github/user-select-contain-polyfill/blob/master/user-select-contain.js
+function supportsUserSelectContain() {
+  const el = document.createElement("div");
+  el.style.cssText = "-ms-user-select: element; user-select: contain;";
+  return (
+    el.style.getPropertyValue("-ms-user-select") === "element" ||
+    el.style.getPropertyValue("-ms-user-select") === "contain" ||
+    el.style.getPropertyValue("user-select") === "contain"
+  );
+}
+
+function handleUserSelectContain(event) {
+  if (!(event.target instanceof Element)) return;
+
+  const currentTarget = event.target.closest(".user-select-contain");
+  if (!currentTarget) return;
+
+  const selection = window.getSelection();
+  if (!selection.rangeCount) return;
+
+  const container = selection.getRangeAt(0).commonAncestorContainer;
+  if (currentTarget.contains(container)) return;
+
+  selection.selectAllChildren(currentTarget);
+}
+
+if (window.getSelection && !supportsUserSelectContain()) {
+  document.addEventListener("click", handleUserSelectContain);
+}

--- a/index.html
+++ b/index.html
@@ -2,6 +2,12 @@
 layout: default
 ---
 
+{% assign asset_mac = site.github.latest_release.assets | where_exp: "asset", "asset.name contains 'macOS_amd64.tar'" | first %}
+{% assign asset_windows = site.github.latest_release.assets | where_exp: "asset", "asset.name contains 'windows_amd64.msi'" | first %}
+{% assign asset_linux_tar = site.github.latest_release.assets | where_exp: "asset", "asset.name contains 'linux_amd64.tar'" | first %}
+{% assign asset_linux_deb = site.github.latest_release.assets | where_exp: "asset", "asset.name contains 'linux_amd64.deb'" | first %}
+{% assign asset_linux_rpm = site.github.latest_release.assets | where_exp: "asset", "asset.name contains 'linux_amd64.rpm'" | first %}
+
 <main class="">
   <div class="container-xl mx-auto px-3 px-md-4 pt-8">
     <div class="d-flex flex-column flex-justify-center flex-items-center mb-8">
@@ -27,7 +33,7 @@ layout: default
 
       <!-- if windows -->
       <div class="download-windows d-none">
-        <a class="btn-mktg" href="https://github.com/github/gh-cli/releases/latest/download/gh_{{ site.cli-latest-version }}_windows_amd64.msi">Download for Windows</a>
+        <a class="btn-mktg" href="{{ asset_windows.browser_download_url }}">Download for Windows</a>
       </div>
 
       <!-- if linux -->
@@ -42,9 +48,9 @@ layout: default
           </summary>
 
           <ul class="dropdown-menu dropdown-menu-se width-full">
-            <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="https://github.com/github/gh-cli/releases/latest/download/gh_{{ site.cli-latest-version }}_linux_amd64.deb">Debian/Ubuntu</a></li>
-            <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="https://github.com/github/gh-cli/releases/latest/download/gh_{{ site.cli-latest-version }}_linux_amd64.rpm">Fedora/Centos</a></li>
-            <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="https://github.com/github/gh-cli/releases/latest/download/gh_{{ site.cli-latest-version }}_linux_amd64.tar.gz">Other</a></li>
+            <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="{{ asset_linux_deb.browser_download_url }}">Debian/Ubuntu</a></li>
+            <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="{{ asset_linux_rpm.browser_download_url }}">Fedora/Centos</a></li>
+            <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="{{ asset_linux_tar.browser_download_url }}">Other</a></li>
           </ul>
         </details>
       </div>
@@ -57,7 +63,7 @@ layout: default
       <div class="position-absolute bottom-0 width-full">
         <p class="f4 text-center text-gray">Check out our docs for more info and view all GitHub CLI commands.</p>
         <div class="d-flex flex-justify-center mb-6 px-3">
-          <a class="h4-mktg text-blue-mktg Bump-link mx-auto mx-lg-0 no-underline" href="/TODO">Read our documentation <span class="Bump-link-symbol">→</span></a>
+          <a class="h4-mktg text-blue-mktg Bump-link mx-auto mx-lg-0 no-underline" href="{{ "/manual/" | relative_url }}">Read the manual <span class="Bump-link-symbol">→</span></a>
         </div>
       </div>
 
@@ -231,12 +237,12 @@ layout: default
               </code>
               <span class="text-gray mx-2 mb-2 d-inline-block">or</span>
             </div>
-            <a class="btn-mktg p-3" href="https://github.com/github/gh-cli/releases/latest/download/gh_{{ site.cli-latest-version }}_macOS_amd64.tar.gz">Download for Mac</a>
+            <a class="btn-mktg p-3" href="{{ asset_mac.browser_download_url }}">Download for Mac</a>
           </div>
 
           <!-- if windows -->
           <div class="download-windows d-none">
-            <a class="btn-mktg" href="https://github.com/github/gh-cli/releases/latest/download/gh_{{ site.cli-latest-version }}_windows_amd64.msi">Download for Windows</a>
+            <a class="btn-mktg" href="{{ asset_windows.browser_download_url }}">Download for Windows</a>
           </div>
 
           <!-- if linux -->
@@ -250,14 +256,14 @@ layout: default
               </summary>
 
               <ul class="dropdown-menu dropdown-menu-se width-full">
-                <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="https://github.com/github/gh-cli/releases/latest/download/gh_{{ site.cli-latest-version }}_linux_amd64.deb">Debian/Ubuntu</a></li>
-                <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="https://github.com/github/gh-cli/releases/latest/download/gh_{{ site.cli-latest-version }}_linux_amd64.rpm">Fedora/Centos</a></li>
-                <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="https://github.com/github/gh-cli/releases/latest/download/gh_{{ site.cli-latest-version }}_linux_amd64.tar.gz">Other</a></li>
+                <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="{{ asset_linux_deb.browser_download_url }}">Debian/Ubuntu</a></li>
+                <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="{{ asset_linux_rpm.browser_download_url }}">Fedora/Centos</a></li>
+                <li><a class="dropdown-item d-block pt-2 pb-2 px-4 text-semibold" href="{{ asset_linux_tar.browser_download_url }}">Other</a></li>
               </ul>
             </details>
           </div>
 
-          <a class="mt-2 d-block f5 text-blue-mktg Bump-link mx-auto mx-lg-0 no-underline" href="/TODO">View installation instructions <span class="Bump-link-symbol">→</span></a>
+          <a class="mt-2 d-block f5 text-blue-mktg Bump-link mx-auto mx-lg-0 no-underline" href="{{ site.github.repository_url }}#installation">View installation instructions <span class="Bump-link-symbol">→</span></a>
 
           <div class="mt-4">
             <img alt="Windows" class="mr-4" style="width: 24px;" src="/assets/images/icon-windows.svg">
@@ -271,9 +277,9 @@ layout: default
         <div class="lp-contribute-section position-relative bg-white border rounded-2 p-6 offset-md-n1">
           <h3 class="h3-mktg mb-1">Contribute and learn&nbsp;more</h3>
           <p class="text-gray-light f5">Help us make GitHub CLI fit the way you work by sharing feedback. And find more information about how to use it in our manual and release notes.</p>
-          <a class="d-block h5-mktg text-blue-mktg Bump-link mx-auto mx-lg-0 no-underline" href="/TODO">Share your feedback in our repository <span class="Bump-link-symbol">→</span></a>
-          <a class="d-block h5-mktg text-blue-mktg Bump-link mx-auto mx-lg-0 no-underline" href="/TODO">Explore the manual <span class="Bump-link-symbol">→</span></a>
-          <a class="d-block h5-mktg text-blue-mktg Bump-link mx-auto mx-lg-0 no-underline" href="/TODO">Check out the release notes <span class="Bump-link-symbol">→</span></a>
+          <a class="d-block h5-mktg text-blue-mktg Bump-link mx-auto mx-lg-0 no-underline" href="{{ site.github.repository_url }}#we-need-your-feedback">Share your feedback in our repository <span class="Bump-link-symbol">→</span></a>
+          <a class="d-block h5-mktg text-blue-mktg Bump-link mx-auto mx-lg-0 no-underline" href="{{ "/manual/" | relative_url }}">Read the manual <span class="Bump-link-symbol">→</span></a>
+          <a class="d-block h5-mktg text-blue-mktg Bump-link mx-auto mx-lg-0 no-underline" href="{{ site.github.latest_release.html_url }}">Check out the release notes <span class="Bump-link-symbol">→</span></a>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,14 @@ layout: default
       <!-- if mac -->
       <div class="download-mac d-none f5 text-center">
         <div class="d-inline-block">
-          <span class="text-gray mr-2">Run</span> <code class="d-inline-block mb-2 text-blue-mktg f5 p-3 rounded-1" style="background-color: #F1F8FF;">brew install github/gh/gh</code>
+          <span class="text-gray mr-2">Run</span>
+          <code class="d-inline-block mb-2 text-blue-mktg f5 p-3 rounded-1 user-select-contain" style="background-color: #F1F8FF;">
+            brew install github/gh/gh
+          </code>
         </div>
         <div class="d-inline-block">
-          <span class="text-gray mx-2 mb-2 d-inline-block">or</span><a class="btn-mktg" href="https://github.com/github/gh-cli/releases/latest/download/gh_{{ site.cli-latest-version }}_macOS_amd64.tar.gz">Download for Mac</a>
+          <span class="text-gray mx-2 mb-2 d-inline-block">or</span>
+          <a class="btn-mktg" href="{{ asset_mac.browser_download_url }}">Download for Mac</a>
         </div>
       </div>
 
@@ -212,7 +216,7 @@ layout: default
 
   <div class="container-xl mx-auto px-3 px-md-4 pt-6 pb-8">
     <div class="d-flex flex-justify-between gutter-spacious text-center text-md-left">
-      <div class="col-12 col-md-6 col-lg-5 mb-6 mt-md-3">
+      <div class="col-12 col-md-6 col-lg-6 mb-6 mt-md-3">
         <div class="pl-lg-7">
           <span title="Label: Beta" class="Label Label--outline Label--outline-green text-mono position-relative bottom-1">Beta</span>
           <h2 class="h2-mktg mb-1">Try GitHub on the command&nbsp;line</h2>
@@ -221,7 +225,11 @@ layout: default
           <!-- if mac -->
           <div class="download-mac d-none f5 text-center text-md-left">
             <div class="d-inline-block">
-              <span class="text-gray mr-2">Run</span> <code class="d-inline-block mb-2 text-blue-mktg p-3 rounded-1" style="background-color: #F1F8FF;">brew install github/gh/gh</code><span class="text-gray mx-2 mb-2 d-inline-block">or</span>
+              <span class="text-gray mr-2">Run</span>
+              <code class="d-inline-block mb-2 text-blue-mktg p-3 rounded-1 user-select-contain" style="background-color: #F1F8FF;">
+                brew install github/gh/gh
+              </code>
+              <span class="text-gray mx-2 mb-2 d-inline-block">or</span>
             </div>
             <a class="btn-mktg p-3" href="https://github.com/github/gh-cli/releases/latest/download/gh_{{ site.cli-latest-version }}_macOS_amd64.tar.gz">Download for Mac</a>
           </div>

--- a/index.html
+++ b/index.html
@@ -158,19 +158,17 @@ layout: default
 
     <div class="container-xl mx-auto px-3 px-md-4 mb-12">
       <!-- Terminal -->
-      <!-- gh pr status -->
       <h3 class="command-header text-mono f2 text-normal text-center mb-2">
         <span class="text-blue-mktg mr-2">$</span>
-        <!-- gh pr status -->
-        <span class="command command-1 command-header-1 d-none"></span>
-        <span class="command command-2 command-header-2 d-none"></span>
-        <span class="command command-3 command-header-3 d-none"></span>
-        <span class="command command-4 command-header-4 d-none"></span>
+        <span class="command command-1 type-animate d-none">gh pr status</span>
+        <span class="command command-2 type-animate d-none">gh issue list</span>
+        <span class="command command-3 type-animate d-none">gh pr create</span>
+        <span class="command command-4 type-animate d-none">gh pr checkout</span>
       </h3>
-      <p class="command-1 command-desc-1 d-none f4 text-gray text-center mb-4">Check on the status of your pull requests.</p>
-      <p class="command-2 command-desc-2 d-none f4 text-gray text-center mb-4">View and filter a repository’s open issues.</p>
-      <p class="command-3 command-desc-3 d-none f4 text-gray text-center mb-4">Create a pull request.</p>
-      <p class="command-4 command-desc-4 d-none f4 text-gray text-center mb-4">Check out pull requests locally.</p>
+      <p class="command command-1 d-none f4 text-gray text-center mb-4">Check on the status of your pull requests.</p>
+      <p class="command command-2 d-none f4 text-gray text-center mb-4">View and filter a repository’s open issues.</p>
+      <p class="command command-3 d-none f4 text-gray text-center mb-4">Create a pull request.</p>
+      <p class="command command-4 d-none f4 text-gray text-center mb-4">Check out pull requests locally.</p>
 
       <div class="col-12 col-lg-8 mx-auto bg-blue-dark rounded-2 box-shadow-large position-relative cli-window" style="height: 430px;">
         <div class="py-2 px-3 text-center">
@@ -181,14 +179,30 @@ layout: default
           </div>
         </div>
 
-
         <div class="f5 px-5 text-white-fade text-mono mt-5">
-          <!-- gh pr status -->
           <span class="text-white mr-1">$</span>
-          <span class="command-1 command-output-1 d-none"></span>
-          <span class="command-2 command-output-2 d-none"></span>
-          <span class="command-3 command-output-3 d-none"></span>
-          <span class="command-4 command-output-4 d-none"></span>
+
+          <span class="command command-1 type-animate text-white d-none">gh pr status</span>
+          <div class="command command-1 type-animate-done d-none">
+            <strong class="text-white">Current branch</strong><br>
+            <span class="pl-3">There is no pull request associated with <span class="text-blue-light">[fix-homepage-bug]</span></span><br>
+            <br>
+            <strong class="text-white">Created by you</strong><br>
+            <span class="pl-3">You have no open pull requests</span><br>
+            <br>
+            <strong class="text-white">Requesting a code review from you</strong><br>
+            <span class="pl-3"><span style="color: yellow;">#100</span>  <span class="text-white">Fix footer on homepage</span> <span class="text-blue-light">[fix-homepage-footer]</span></span><br>
+            <span class="pl-5">- <span style="color: chartreuse;">Checks passing</span> - Approved</span>
+          </div>
+
+          <span class="command command-2 type-animate text-white d-none">gh issue list</span>
+          <div class="command command-2 type-animate-done d-none">TODO list</div>
+
+          <span class="command command-3 type-animate text-white d-none">gh pr create</span>
+          <div class="command command-3 type-animate-done d-none">TODO create</div>
+
+          <span class="command command-4 type-animate text-white d-none">gh pr checkout 123</span>
+          <div class="command command-4 type-animate-done d-none">TODO checkout</div>
         </div>
       </div><!-- /Terminal -->
     </div>


### PR DESCRIPTION
* Fixes typing animation
  * Makes animated terminal section easier to understand & maintain
  * Remove jQuery since it's no longer needed

* Dynamically generate repo & download URLs instead of hardcoding them

* Remove “Sign in, Sign up” links from navigation bar

* Make it easier for user to ~copy~ <ins>select</ins> `brew install` instructions by triple-clicking them on macOS