### PR TITLE
Update `make site-docs` to reflect latest setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,11 @@ site:
 
 site-docs: site
 	git -C site pull
-	git -C site rm 'gh*.md' 2>/dev/null || true
-	go run ./cmd/gen-docs site
-	git -C site add 'gh*.md'
+	git -C site rm 'manual/gh*.md' 2>/dev/null || true
+	go run ./cmd/gen-docs site/manual
+	for f in site/manual/gh*.md; do sed -i.bak -e '/^### SEE ALSO/,$$d' "$$f"; done
+	rm -f site/manual/*.bak
+	git -C site add 'manual/gh*.md'
 	git -C site commit -m 'update help docs'
 	git -C site push
 .PHONY: site-docs

--- a/cmd/gen-docs/main.go
+++ b/cmd/gen-docs/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/cli/cli/command"
 	"github.com/spf13/cobra/doc"
@@ -28,13 +29,14 @@ func main() {
 func filePrepender(filename string) string {
 	return `---
 layout: page
+permalink: /:path/:basename
 ---
 
 `
 }
 
 func linkHandler(name string) string {
-	return fmt.Sprintf("{{site.baseurl}}{%% link %s %%}", name)
+	return fmt.Sprintf("./%s", strings.TrimSuffix(name, ".md"))
 }
 
 func fatal(msg interface{}) {


### PR DESCRIPTION
- Man pages are now placed under `/manual/`
- Use Jekyll `permalink` to avoid the `.html` extension
- Strip "SEE ALSO" and everything after it

Works in tandem with https://github.com/cli/cli/pull/236