### PR TITLE
scoop config for gh

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,3 +77,14 @@ nfpms:
     formats:
       - deb
       - rpm
+
+scoop:
+  bucket:
+    owner: cli
+    name: scoop-gh
+  commit_author:
+    name: vilmibm
+    email: vilmibm@github.com
+  homepage: https://github.com/cli/cli
+  description: GitHub CLI
+  license: MIT

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Install:
 
 ```
 scoop bucket add github-gh https://github.com/cli/scoop-gh.git
-scoop installl gh
+scoop install gh
 ```
 
 Upgrade: `scoop update gh`

--- a/README.md
+++ b/README.md
@@ -30,22 +30,38 @@ tools bring GitHub to the terminal, `hub` behaves as a proxy to `git` and `gh` i
 tool.
 
 
-## Installation
+## Installation and Upgrading
 
 ### macOS
 
-`brew install github/gh/gh`
+Install: `brew install github/gh/gh`
+Upgrade: `brew update && brew upgrade gh`
 
 ### Windows
 
-MSI installers are available on the [releases page][].
+`gh` is available via [scoop][]:
+
+Install:
+
+```
+scoop bucket add github-gh https://github.com/cli/scoop-gh.git
+scoop installl gh
+```
+
+Upgrade: `scoop update gh`
+
+Signed MSI installers are also available on the [releases page][].
 
 ### Debian/Ubuntu Linux
+
+Install and upgrade:
 
 1. Download the `.deb` file from the [releases page][]
 2. `sudo apt install git && sudo dpkg -i gh_*_linux_amd64.deb`  install the downloaded file
 
 ### Fedora/Centos Linux
+
+Install and upgrade:
 
 1. Download the `.rpm` file from the [releases page][]
 2. `sudo yum localinstall gh_*_linux_amd64.rpm` install the downloaded file
@@ -57,6 +73,7 @@ project directory.
 
 <!-- TODO eventually we'll have https://cli.github.com/manual -->
 [docs]: https://cli.github.io/cli/gh
+[scoop]: https://scoop.sh
 [releases page]: https://github.com/cli/cli/releases/latest
 [hub]: https://github.com/github/hub
 [contributing page]: https://github.com/cli/cli/blob/master/.github/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ tool.
 ### macOS
 
 Install: `brew install github/gh/gh`
+
 Upgrade: `brew update && brew upgrade gh`
 
 ### Windows


### PR DESCRIPTION
This PR, along with the new repo https://github.com/cli/scoop-gh , enables `gh` to be installable
and update-able via [scoop](https://scoop.sh).

Closes #280

I also took the opportunity to explicitly say how to upgrade gh in the readme.
