### PR TITLE
put homebrew formula back in the right place

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,6 +52,7 @@ brews:
     skip_upload: auto
     description: GitHub CLI
     homepage: https://github.com/cli/cli
+    folder: Formula
     custom_block: |
       head do
         url "https://github.com/cli/cli.git"


### PR DESCRIPTION
gh.rb is being written to the root of the homebrew tap where it used to be in the Formula directory;
this PR configures goreleaser to use the Formula directory again.

Closes #299
