### PR TITLE
Prefix branch names when checking out a PR locally

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -1,11 +1,8 @@
 package command
 
 import (
-	"errors"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -45,17 +42,6 @@ A pull request can be supplied as argument in any of the following formats:
 - by number, e.g. "123";
 - by URL, e.g. "https://github.com/OWNER/REPO/pull/123"; or
 - by the name of its head branch, e.g. "patch-1" or "OWNER:patch-1".`,
-}
-var prCheckoutCmd = &cobra.Command{
-	Use:   "checkout {<number> | <url> | <branch>}",
-	Short: "Check out a pull request in Git",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return errors.New("requires a PR number as an argument")
-		}
-		return nil
-	},
-	RunE: prCheckout,
 }
 var prListCmd = &cobra.Command{
 	Use:   "list",
@@ -384,95 +370,6 @@ func prSelectorForCurrentBranch(ctx context.Context) (prNumber int, prHeadRef st
 	}
 
 	return
-}
-
-func prCheckout(cmd *cobra.Command, args []string) error {
-	ctx := contextForCommand(cmd)
-	currentBranch, _ := ctx.Branch()
-	remotes, err := ctx.Remotes()
-	if err != nil {
-		return err
-	}
-	// FIXME: duplicates logic from fsContext.BaseRepo
-	baseRemote, err := remotes.FindByName("upstream", "github", "origin", "*")
-	if err != nil {
-		return err
-	}
-	apiClient, err := apiClientForContext(ctx)
-	if err != nil {
-		return err
-	}
-
-	pr, err := prFromArg(apiClient, baseRemote, args[0])
-	if err != nil {
-		return err
-	}
-
-	headRemote := baseRemote
-	if pr.IsCrossRepository {
-		headRemote, _ = remotes.FindByRepo(pr.HeadRepositoryOwner.Login, pr.HeadRepository.Name)
-	}
-
-	cmdQueue := [][]string{}
-
-	newBranchName := pr.HeadRefName
-	if headRemote != nil {
-		// there is an existing git remote for PR head
-		remoteBranch := fmt.Sprintf("%s/%s", headRemote.Name, pr.HeadRefName)
-		refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s", pr.HeadRefName, remoteBranch)
-
-		cmdQueue = append(cmdQueue, []string{"git", "fetch", headRemote.Name, refSpec})
-
-		// local branch already exists
-		if git.VerifyRef("refs/heads/" + newBranchName) {
-			cmdQueue = append(cmdQueue, []string{"git", "checkout", newBranchName})
-			cmdQueue = append(cmdQueue, []string{"git", "merge", "--ff-only", fmt.Sprintf("refs/remotes/%s", remoteBranch)})
-		} else {
-			cmdQueue = append(cmdQueue, []string{"git", "checkout", "-b", newBranchName, "--no-track", remoteBranch})
-			cmdQueue = append(cmdQueue, []string{"git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), headRemote.Name})
-			cmdQueue = append(cmdQueue, []string{"git", "config", fmt.Sprintf("branch.%s.merge", newBranchName), "refs/heads/" + pr.HeadRefName})
-		}
-	} else {
-		// no git remote for PR head
-
-		// avoid naming the new branch the same as the default branch
-		if newBranchName == pr.HeadRepository.DefaultBranchRef.Name {
-			newBranchName = fmt.Sprintf("%s/%s", pr.HeadRepositoryOwner.Login, newBranchName)
-		}
-
-		ref := fmt.Sprintf("refs/pull/%d/head", pr.Number)
-		if newBranchName == currentBranch {
-			// PR head matches currently checked out branch
-			cmdQueue = append(cmdQueue, []string{"git", "fetch", baseRemote.Name, ref})
-			cmdQueue = append(cmdQueue, []string{"git", "merge", "--ff-only", "FETCH_HEAD"})
-		} else {
-			// create a new branch
-			cmdQueue = append(cmdQueue, []string{"git", "fetch", baseRemote.Name, fmt.Sprintf("%s:%s", ref, newBranchName)})
-			cmdQueue = append(cmdQueue, []string{"git", "checkout", newBranchName})
-		}
-
-		remote := baseRemote.Name
-		mergeRef := ref
-		if pr.MaintainerCanModify {
-			remote = fmt.Sprintf("https://github.com/%s/%s.git", pr.HeadRepositoryOwner.Login, pr.HeadRepository.Name)
-			mergeRef = fmt.Sprintf("refs/heads/%s", pr.HeadRefName)
-		}
-		if mc, err := git.Config(fmt.Sprintf("branch.%s.merge", newBranchName)); err != nil || mc == "" {
-			cmdQueue = append(cmdQueue, []string{"git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), remote})
-			cmdQueue = append(cmdQueue, []string{"git", "config", fmt.Sprintf("branch.%s.merge", newBranchName), mergeRef})
-		}
-	}
-
-	for _, args := range cmdQueue {
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := utils.PrepareCmd(cmd).Run(); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func printPrs(w io.Writer, totalCount int, prs ...api.PullRequest) {

--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -1,0 +1,113 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/cli/cli/git"
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+func prCheckout(cmd *cobra.Command, args []string) error {
+	ctx := contextForCommand(cmd)
+	currentBranch, _ := ctx.Branch()
+	remotes, err := ctx.Remotes()
+	if err != nil {
+		return err
+	}
+	// FIXME: duplicates logic from fsContext.BaseRepo
+	baseRemote, err := remotes.FindByName("upstream", "github", "origin", "*")
+	if err != nil {
+		return err
+	}
+	apiClient, err := apiClientForContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	pr, err := prFromArg(apiClient, baseRemote, args[0])
+	if err != nil {
+		return err
+	}
+
+	headRemote := baseRemote
+	if pr.IsCrossRepository {
+		headRemote, _ = remotes.FindByRepo(pr.HeadRepositoryOwner.Login, pr.HeadRepository.Name)
+	}
+
+	cmdQueue := [][]string{}
+
+	newBranchName := pr.HeadRefName
+	if headRemote != nil {
+		// there is an existing git remote for PR head
+		remoteBranch := fmt.Sprintf("%s/%s", headRemote.Name, pr.HeadRefName)
+		refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s", pr.HeadRefName, remoteBranch)
+
+		cmdQueue = append(cmdQueue, []string{"git", "fetch", headRemote.Name, refSpec})
+
+		// local branch already exists
+		if git.VerifyRef("refs/heads/" + newBranchName) {
+			cmdQueue = append(cmdQueue, []string{"git", "checkout", newBranchName})
+			cmdQueue = append(cmdQueue, []string{"git", "merge", "--ff-only", fmt.Sprintf("refs/remotes/%s", remoteBranch)})
+		} else {
+			cmdQueue = append(cmdQueue, []string{"git", "checkout", "-b", newBranchName, "--no-track", remoteBranch})
+			cmdQueue = append(cmdQueue, []string{"git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), headRemote.Name})
+			cmdQueue = append(cmdQueue, []string{"git", "config", fmt.Sprintf("branch.%s.merge", newBranchName), "refs/heads/" + pr.HeadRefName})
+		}
+	} else {
+		// no git remote for PR head
+
+		// avoid naming the new branch the same as the default branch
+		if newBranchName == pr.HeadRepository.DefaultBranchRef.Name {
+			newBranchName = fmt.Sprintf("%s/%s", pr.HeadRepositoryOwner.Login, newBranchName)
+		}
+
+		ref := fmt.Sprintf("refs/pull/%d/head", pr.Number)
+		if newBranchName == currentBranch {
+			// PR head matches currently checked out branch
+			cmdQueue = append(cmdQueue, []string{"git", "fetch", baseRemote.Name, ref})
+			cmdQueue = append(cmdQueue, []string{"git", "merge", "--ff-only", "FETCH_HEAD"})
+		} else {
+			// create a new branch
+			cmdQueue = append(cmdQueue, []string{"git", "fetch", baseRemote.Name, fmt.Sprintf("%s:%s", ref, newBranchName)})
+			cmdQueue = append(cmdQueue, []string{"git", "checkout", newBranchName})
+		}
+
+		remote := baseRemote.Name
+		mergeRef := ref
+		if pr.MaintainerCanModify {
+			remote = fmt.Sprintf("https://github.com/%s/%s.git", pr.HeadRepositoryOwner.Login, pr.HeadRepository.Name)
+			mergeRef = fmt.Sprintf("refs/heads/%s", pr.HeadRefName)
+		}
+		if mc, err := git.Config(fmt.Sprintf("branch.%s.merge", newBranchName)); err != nil || mc == "" {
+			cmdQueue = append(cmdQueue, []string{"git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), remote})
+			cmdQueue = append(cmdQueue, []string{"git", "config", fmt.Sprintf("branch.%s.merge", newBranchName), mergeRef})
+		}
+	}
+
+	for _, args := range cmdQueue {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := utils.PrepareCmd(cmd).Run(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+var prCheckoutCmd = &cobra.Command{
+	Use:   "checkout {<number> | <url> | <branch>}",
+	Short: "Check out a pull request in Git",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errors.New("requires a PR number as an argument")
+		}
+		return nil
+	},
+	RunE: prCheckout,
+}

--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -40,7 +40,8 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 
 	cmdQueue := [][]string{}
 
-	newBranchName := pr.HeadRefName
+	// namespace PR checkout branches to avoid local branch name collisions
+	newBranchName := fmt.Sprintf("pr/%d/%s", pr.Number, pr.HeadRefName)
 	if headRemote != nil {
 		// there is an existing git remote for PR head
 		remoteBranch := fmt.Sprintf("%s/%s", headRemote.Name, pr.HeadRefName)

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -42,7 +42,7 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 	ranCommands := [][]string{}
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
-		case "git show-ref --verify --quiet refs/heads/feature":
+		case "git show-ref --verify --quiet refs/heads/pr/123/feature":
 			return &errorStub{"exit status: 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
@@ -57,9 +57,9 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 
 	eq(t, len(ranCommands), 4)
 	eq(t, strings.Join(ranCommands[0], " "), "git fetch origin +refs/heads/feature:refs/remotes/origin/feature")
-	eq(t, strings.Join(ranCommands[1], " "), "git checkout -b feature --no-track origin/feature")
-	eq(t, strings.Join(ranCommands[2], " "), "git config branch.feature.remote origin")
-	eq(t, strings.Join(ranCommands[3], " "), "git config branch.feature.merge refs/heads/feature")
+	eq(t, strings.Join(ranCommands[1], " "), "git checkout -b pr/123/feature --no-track origin/feature")
+	eq(t, strings.Join(ranCommands[2], " "), "git config branch.pr/123/feature.remote origin")
+	eq(t, strings.Join(ranCommands[3], " "), "git config branch.pr/123/feature.merge refs/heads/feature")
 }
 
 func TestPRCheckout_urlArg(t *testing.T) {
@@ -94,7 +94,7 @@ func TestPRCheckout_urlArg(t *testing.T) {
 	ranCommands := [][]string{}
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
-		case "git show-ref --verify --quiet refs/heads/feature":
+		case "git show-ref --verify --quiet refs/heads/pr/123/feature":
 			return &errorStub{"exit status: 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
@@ -108,7 +108,7 @@ func TestPRCheckout_urlArg(t *testing.T) {
 	eq(t, output.String(), "")
 
 	eq(t, len(ranCommands), 4)
-	eq(t, strings.Join(ranCommands[1], " "), "git checkout -b feature --no-track origin/feature")
+	eq(t, strings.Join(ranCommands[1], " "), "git checkout -b pr/123/feature --no-track origin/feature")
 }
 
 func TestPRCheckout_branchArg(t *testing.T) {
@@ -143,7 +143,7 @@ func TestPRCheckout_branchArg(t *testing.T) {
 	ranCommands := [][]string{}
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
-		case "git show-ref --verify --quiet refs/heads/feature":
+		case "git show-ref --verify --quiet refs/heads/pr/123/feature":
 			return &errorStub{"exit status: 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
@@ -157,7 +157,7 @@ func TestPRCheckout_branchArg(t *testing.T) {
 	eq(t, output.String(), "")
 
 	eq(t, len(ranCommands), 5)
-	eq(t, strings.Join(ranCommands[1], " "), "git fetch origin refs/pull/123/head:feature")
+	eq(t, strings.Join(ranCommands[1], " "), "git fetch origin refs/pull/123/head:pr/123/feature")
 }
 
 func TestPRCheckout_existingBranch(t *testing.T) {
@@ -192,7 +192,7 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 	ranCommands := [][]string{}
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
-		case "git show-ref --verify --quiet refs/heads/feature":
+		case "git show-ref --verify --quiet refs/heads/pr/123/feature":
 			return &outputStub{}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
@@ -207,7 +207,7 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 
 	eq(t, len(ranCommands), 3)
 	eq(t, strings.Join(ranCommands[0], " "), "git fetch origin +refs/heads/feature:refs/remotes/origin/feature")
-	eq(t, strings.Join(ranCommands[1], " "), "git checkout feature")
+	eq(t, strings.Join(ranCommands[1], " "), "git checkout pr/123/feature")
 	eq(t, strings.Join(ranCommands[2], " "), "git merge --ff-only refs/remotes/origin/feature")
 }
 
@@ -244,7 +244,7 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 	ranCommands := [][]string{}
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
-		case "git show-ref --verify --quiet refs/heads/feature":
+		case "git show-ref --verify --quiet refs/heads/pr/123/feature":
 			return &errorStub{"exit status: 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
@@ -259,9 +259,9 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 
 	eq(t, len(ranCommands), 4)
 	eq(t, strings.Join(ranCommands[0], " "), "git fetch robot-fork +refs/heads/feature:refs/remotes/robot-fork/feature")
-	eq(t, strings.Join(ranCommands[1], " "), "git checkout -b feature --no-track robot-fork/feature")
-	eq(t, strings.Join(ranCommands[2], " "), "git config branch.feature.remote robot-fork")
-	eq(t, strings.Join(ranCommands[3], " "), "git config branch.feature.merge refs/heads/feature")
+	eq(t, strings.Join(ranCommands[1], " "), "git checkout -b pr/123/feature --no-track robot-fork/feature")
+	eq(t, strings.Join(ranCommands[2], " "), "git config branch.pr/123/feature.remote robot-fork")
+	eq(t, strings.Join(ranCommands[3], " "), "git config branch.pr/123/feature.merge refs/heads/feature")
 }
 
 func TestPRCheckout_differentRepo(t *testing.T) {
@@ -296,7 +296,7 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 	ranCommands := [][]string{}
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
-		case "git config branch.feature.merge":
+		case "git config branch.pr/123/feature.merge":
 			return &errorStub{"exit status 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
@@ -310,10 +310,10 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 	eq(t, output.String(), "")
 
 	eq(t, len(ranCommands), 4)
-	eq(t, strings.Join(ranCommands[0], " "), "git fetch origin refs/pull/123/head:feature")
-	eq(t, strings.Join(ranCommands[1], " "), "git checkout feature")
-	eq(t, strings.Join(ranCommands[2], " "), "git config branch.feature.remote origin")
-	eq(t, strings.Join(ranCommands[3], " "), "git config branch.feature.merge refs/pull/123/head")
+	eq(t, strings.Join(ranCommands[0], " "), "git fetch origin refs/pull/123/head:pr/123/feature")
+	eq(t, strings.Join(ranCommands[1], " "), "git checkout pr/123/feature")
+	eq(t, strings.Join(ranCommands[2], " "), "git config branch.pr/123/feature.remote origin")
+	eq(t, strings.Join(ranCommands[3], " "), "git config branch.pr/123/feature.merge refs/pull/123/head")
 }
 
 func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
@@ -348,7 +348,7 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 	ranCommands := [][]string{}
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
-		case "git config branch.feature.merge":
+		case "git config branch.pr/123/feature.merge":
 			return &outputStub{[]byte("refs/heads/feature\n")}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
@@ -362,13 +362,13 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 	eq(t, output.String(), "")
 
 	eq(t, len(ranCommands), 2)
-	eq(t, strings.Join(ranCommands[0], " "), "git fetch origin refs/pull/123/head:feature")
-	eq(t, strings.Join(ranCommands[1], " "), "git checkout feature")
+	eq(t, strings.Join(ranCommands[0], " "), "git fetch origin refs/pull/123/head:pr/123/feature")
+	eq(t, strings.Join(ranCommands[1], " "), "git checkout pr/123/feature")
 }
 
 func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 	ctx := context.NewBlank()
-	ctx.SetBranch("feature")
+	ctx.SetBranch("pr/123/feature")
 	ctx.SetRemotes(map[string]string{
 		"origin": "OWNER/REPO",
 	})
@@ -398,7 +398,7 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 	ranCommands := [][]string{}
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
-		case "git config branch.feature.merge":
+		case "git config branch.pr/123/feature.merge":
 			return &outputStub{[]byte("refs/heads/feature\n")}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
@@ -448,7 +448,7 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 	ranCommands := [][]string{}
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
-		case "git config branch.feature.merge":
+		case "git config branch.pr/123/feature.merge":
 			return &errorStub{"exit status 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
@@ -462,8 +462,8 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 	eq(t, output.String(), "")
 
 	eq(t, len(ranCommands), 4)
-	eq(t, strings.Join(ranCommands[0], " "), "git fetch origin refs/pull/123/head:feature")
-	eq(t, strings.Join(ranCommands[1], " "), "git checkout feature")
-	eq(t, strings.Join(ranCommands[2], " "), "git config branch.feature.remote https://github.com/hubot/REPO.git")
-	eq(t, strings.Join(ranCommands[3], " "), "git config branch.feature.merge refs/heads/feature")
+	eq(t, strings.Join(ranCommands[0], " "), "git fetch origin refs/pull/123/head:pr/123/feature")
+	eq(t, strings.Join(ranCommands[1], " "), "git checkout pr/123/feature")
+	eq(t, strings.Join(ranCommands[2], " "), "git config branch.pr/123/feature.remote https://github.com/hubot/REPO.git")
+	eq(t, strings.Join(ranCommands[3], " "), "git config branch.pr/123/feature.merge refs/heads/feature")
 }


### PR DESCRIPTION
This PR changes the behavior of `gh pr checkout` to _always_ prefix local branch names with
`pr/<id>/<branch name>`. This prevents branch name collisions locally, which currently result in an
ugly git error.

![image](https://user-images.githubusercontent.com/98482/73798075-676b7f80-4777-11ea-97b8-52da30da1e22.png)

I also took the opportunity to split `prCheckout` into its own file. I have liked having `prCreate` split out like that and given how long `pr.go` has become it seemed like a good idea to split some more.


Closes #233
