### PR TITLE
impr(verbose): using package httpretty to log requests on DEBUG.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -38,12 +38,15 @@ func AddHeader(name, value string) ClientOption {
 }
 
 // VerboseLog enables request/response logging within a RoundTripper
-func VerboseLog(out io.Writer, logBodies bool) ClientOption {
+func VerboseLog(out io.Writer, logTraffic bool, colorize bool) ClientOption {
 	logger := &httpretty.Logger{
-		RequestHeader:  true,
-		RequestBody:    logBodies,
-		ResponseHeader: true,
-		ResponseBody:   logBodies,
+		Time:           true,
+		TLS:            false,
+		Colors:         colorize,
+		RequestHeader:  logTraffic,
+		RequestBody:    logTraffic,
+		ResponseHeader: logTraffic,
+		ResponseBody:   logTraffic,
 		Formatters:     []httpretty.Formatter{&httpretty.JSONFormatter{}},
 	}
 	logger.SetOutput(out)

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/update"
 	"github.com/cli/cli/utils"
-	"github.com/mattn/go-isatty"
 	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
 )
@@ -71,8 +70,7 @@ func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
 }
 
 func shouldCheckForUpdate() bool {
-	errFd := os.Stderr.Fd()
-	return updaterEnabled != "" && (isatty.IsTerminal(errFd) || isatty.IsCygwinTerminal(errFd))
+	return updaterEnabled != "" && utils.IsTerminal(os.Stderr)
 }
 
 func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-version v1.2.0
+	github.com/henvic/httpretty v0.0.3
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-colorable v0.1.4
 	github.com/mattn/go-isatty v0.0.12

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/henvic/httpretty v0.0.3 h1:oHTreVv2lcdRYUNm4h3cgbrGN0dTieO9H8UnxEZNlvw=
+github.com/henvic/httpretty v0.0.3/go.mod h1:X38wLjWXHkXT7r2+uK8LjCMne9rsuNaBLJ+5cU2/Pmo=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDGgJGQpNflI3+MJSBhsgT5PCtzBQ=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/utils/color.go
+++ b/utils/color.go
@@ -14,11 +14,15 @@ var checkedTerminal = false
 
 func isStdoutTerminal() bool {
 	if !checkedTerminal {
-		fd := os.Stdout.Fd()
-		_isStdoutTerminal = isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+		_isStdoutTerminal = IsTerminal(os.Stdout)
 		checkedTerminal = true
 	}
 	return _isStdoutTerminal
+}
+
+// IsTerminal reports whether the file descriptor is connected to a terminal
+func IsTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
 }
 
 // NewColorable returns an output stream that handles ANSI color sequences on Windows

--- a/utils/table_printer.go
+++ b/utils/table_printer.go
@@ -22,6 +22,7 @@ type TablePrinter interface {
 
 func NewTablePrinter(w io.Writer) TablePrinter {
 	if outFile, isFile := w.(*os.File); isFile {
+		// TODO: use utils.IsTerminal()
 		isCygwin := isatty.IsCygwinTerminal(outFile.Fd())
 		if isatty.IsTerminal(outFile.Fd()) || isCygwin {
 			ttyWidth := 80


### PR DESCRIPTION
Hi, a few days ago I released this package called [httpretty](https://github.com/henvic/httpretty) that I think would be useful for debugging the GitHub CLI instead of the burden of dealing with it directly.

[![asciicast](https://asciinema.org/a/297429.svg)](https://asciinema.org/a/297429)

What do you think about it? If you like the idea, I probably need to add support for skipping content so that the inspectableMIMEType can still be used.

btw, I was the main maintainer of [NodeGH](http://nodegh.io) for a while (written using NodeJS years ago) but I've since moved to Go (and spent a quite a while working with Go + cobra + git for [deployments](https://asciinema.org/a/192043)), and I'm really excited seeing this CLI written in Go o/ :)

Feel free to ask anything!