### PR TITLE
switch to cli.github.com in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ Install a prebuilt binary from the [releases page][]
 
 ### [Build from source](/source.md)
 
-<!-- TODO eventually we'll have https://cli.github.com/manual -->
-[docs]: https://cli.github.io/cli/manual/gh
+[docs]: https://cli.github.com/manual/gh
 [scoop]: https://scoop.sh
 [releases page]: https://github.com/cli/cli/releases/latest
 [hub]: https://github.com/github/hub


### PR DESCRIPTION
this PR switches the docs link to the new cli.github.com domain set up today.

NB: it will likely need to change again once `/manual` has an index.html and `gh.html` isn't a thing
anymore
