### PR TITLE
Make approval statuses sentence case

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -400,11 +400,11 @@ func printPrs(w io.Writer, totalCount int, prs ...api.PullRequest) {
 		}
 
 		if reviews.ChangesRequested {
-			fmt.Fprintf(w, " - %s", utils.Red("changes requested"))
+			fmt.Fprintf(w, " - %s", utils.Red("Changes requested"))
 		} else if reviews.ReviewRequired {
-			fmt.Fprintf(w, " - %s", utils.Yellow("review required"))
+			fmt.Fprintf(w, " - %s", utils.Yellow("Review required"))
 		} else if reviews.Approved {
-			fmt.Fprintf(w, " - %s", utils.Green("approved"))
+			fmt.Fprintf(w, " - %s", utils.Green("Approved"))
 		}
 
 		fmt.Fprint(w, "\n")

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -111,9 +111,9 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 	}
 
 	expected := []string{
-		"- Checks passing - changes requested",
-		"- Checks pending - approved",
-		"- 1/3 checks failing - review required",
+		"- Checks passing - Changes requested",
+		"- Checks pending - Approved",
+		"- 1/3 checks failing - Review required",
 	}
 
 	for _, line := range expected {


### PR DESCRIPTION
Tiny thing, but kept bugging me that the checks statuses were capitalized but approval statuses weren't!