### PR TITLE
pr view, status, list parent repo instead of fork

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -32,8 +32,12 @@ func init() {
 	prListCmd.Flags().StringP("base", "B", "", "Filter by base branch")
 	prListCmd.Flags().StringSliceP("label", "l", nil, "Filter by label")
 	prListCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
+	prListCmd.Flags().BoolP("self", "S", false, "Query current repository instead of forked parent")
 
 	prViewCmd.Flags().BoolP("preview", "p", false, "Display preview of pull request content")
+	prViewCmd.Flags().BoolP("self", "S", false, "Query current repository instead of forked parent")
+
+	prStatusCmd.Flags().BoolP("self", "S", false, "Query current repository instead of forked parent")
 }
 
 var prCmd = &cobra.Command{
@@ -84,7 +88,12 @@ func prStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := ctx.BaseRepo()
+	referSelf, _ := cmd.Flags().GetBool("self")
+	if referSelf == false {
+		ctx = context.ExpandOnline(ctx, apiClient)
+	}
+
+	baseRepo, err := context.DetermineRepo(ctx, referSelf)
 	if err != nil {
 		return err
 	}
@@ -143,7 +152,12 @@ func prList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := ctx.BaseRepo()
+	referSelf, _ := cmd.Flags().GetBool("self")
+	if referSelf == false {
+		ctx = context.ExpandOnline(ctx, apiClient)
+	}
+
+	baseRepo, err := context.DetermineRepo(ctx, referSelf)
 	if err != nil {
 		return err
 	}
@@ -254,12 +268,18 @@ func colorFuncForState(state string) func(string) string {
 
 func prView(cmd *cobra.Command, args []string) error {
 	ctx := contextForCommand(cmd)
-	baseRepo, err := ctx.BaseRepo()
+
+	apiClient, err := apiClientForContext(ctx)
 	if err != nil {
 		return err
 	}
 
-	apiClient, err := apiClientForContext(ctx)
+	referSelf, _ := cmd.Flags().GetBool("self")
+	if referSelf == false {
+		ctx = context.ExpandOnline(ctx, apiClient)
+	}
+
+	baseRepo, err := context.DetermineRepo(ctx, referSelf)
 	if err != nil {
 		return err
 	}

--- a/context/context.go
+++ b/context/context.go
@@ -1,8 +1,10 @@
 package context
 
 import (
+	"errors"
 	"path"
 
+	"github.com/cli/cli/api"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/mitchellh/go-homedir"
@@ -20,9 +22,43 @@ type Context interface {
 	SetBaseRepo(string)
 }
 
+type OnlineContext interface {
+	Context
+	ParentRepos() ([]ghrepo.Interface, error)
+}
+
 // New initializes a Context that reads from the filesystem
 func New() Context {
 	return &fsContext{}
+}
+
+func ExpandOnline(ctx Context, apiClient *api.Client) OnlineContext {
+	return &apiContext{
+		Context:   ctx,
+		apiClient: *apiClient,
+	}
+}
+
+func DetermineRepo(ctx Context, self bool) (ghrepo.Interface, error) {
+	if self == true {
+		return ctx.BaseRepo()
+	}
+
+	onlineCtx, isOnline := ctx.(OnlineContext)
+	if !isOnline {
+		return nil, errors.New("context not online")
+	}
+
+	repos, err := onlineCtx.ParentRepos()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(repos) < 1 {
+		return ctx.BaseRepo()
+	}
+
+	return repos[0], nil
 }
 
 // A Context implementation that queries the filesystem
@@ -129,4 +165,36 @@ func (c *fsContext) BaseRepo() (ghrepo.Interface, error) {
 
 func (c *fsContext) SetBaseRepo(nwo string) {
 	c.baseRepo = ghrepo.FromFullName(nwo)
+}
+
+type apiContext struct {
+	Context
+	apiClient api.Client
+}
+
+func (c *apiContext) ParentRepos() ([]ghrepo.Interface, error) {
+	baseRepo, err := c.BaseRepo()
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := api.RepoNetwork(&c.apiClient, []ghrepo.Interface{baseRepo})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.Repositories) < 1 {
+		return nil, errors.New("network request returned 0 repositories")
+	}
+
+	var repos []ghrepo.Interface
+
+	var repo api.Repository = *result.Repositories[0]
+
+	for repo.IsFork() {
+		repo = *repo.Parent
+		repos = append(repos, repo)
+	}
+
+	return repos, nil
 }


### PR DESCRIPTION
This PR opens up the gh CLI tool for querying PRs of the parent repositories instead of the forked one.
This PR is related to #251 

Left to do
- [ ] Write tests
- [ ] Test the code a bit more, perhaps consider different naming for some things
- [ ] Consider implementing caching