### PR TITLE
More nuanced handling of parent/fork in various commands

### DIFF
--- a/api/fake_http.go
+++ b/api/fake_http.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -34,4 +35,24 @@ func (f *FakeHTTP) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp.Request = req
 	f.Requests = append(f.Requests, req)
 	return resp, nil
+}
+
+func (f *FakeHTTP) StubRepoResponse(owner, repo string) {
+	body := bytes.NewBufferString(fmt.Sprintf(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "%s",
+			"owner": {"login": "%s"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`, repo, owner))
+	resp := &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(body),
+	}
+	f.responseStubs = append(f.responseStubs, resp)
 }

--- a/command/issue.go
+++ b/command/issue.go
@@ -287,10 +287,17 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(colorableErr(cmd), "\nCreating issue in %s\n\n", ghrepo.FullName(*baseRepo))
 
+	baseOverride, err := cmd.Flags().GetString("repo")
+	if err != nil {
+		return err
+	}
+
 	var templateFiles []string
-	if rootDir, err := git.ToplevelDir(); err == nil {
-		// TODO: figure out how to stub this in tests
-		templateFiles = githubtemplate.Find(rootDir, "ISSUE_TEMPLATE")
+	if baseOverride == "" {
+		if rootDir, err := git.ToplevelDir(); err == nil {
+			// TODO: figure out how to stub this in tests
+			templateFiles = githubtemplate.Find(rootDir, "ISSUE_TEMPLATE")
+		}
 	}
 
 	if isWeb, err := cmd.Flags().GetBool("web"); err == nil && isWeb {

--- a/command/issue.go
+++ b/command/issue.go
@@ -30,19 +30,14 @@ func init() {
 	issueCreateCmd.Flags().StringP("body", "b", "",
 		"Supply a body. Will prompt for one otherwise.")
 	issueCreateCmd.Flags().BoolP("web", "w", false, "Open the browser to create an issue")
-	issueCreateCmd.Flags().BoolP("self", "S", false, "Query current repository instead of forked parent")
 
 	issueCmd.AddCommand(issueListCmd)
 	issueListCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
 	issueListCmd.Flags().StringSliceP("label", "l", nil, "Filter by label")
 	issueListCmd.Flags().StringP("state", "s", "", "Filter by state: {open|closed|all}")
 	issueListCmd.Flags().IntP("limit", "L", 30, "Maximum number of issues to fetch")
-	issueListCmd.Flags().BoolP("self", "S", false, "Query current repository instead of forked parent")
 
 	issueViewCmd.Flags().BoolP("preview", "p", false, "Display preview of issue content")
-	issueViewCmd.Flags().BoolP("self", "S", false, "Query current repository instead of forked parent")
-
-	issueStatusCmd.Flags().BoolP("self", "S", false, "Query current repository instead of forked parent")
 }
 
 var issueCmd = &cobra.Command{

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -258,8 +258,28 @@ No issues match your search
 }
 
 func TestIssueList_nullAssigneeLabels(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": {	"repository": {
@@ -456,8 +476,28 @@ func TestIssueView_urlArg(t *testing.T) {
 }
 
 func TestIssueCreate(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": {
@@ -496,8 +536,28 @@ func TestIssueCreate(t *testing.T) {
 }
 
 func TestIssueCreate_disabledIssues(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": {
@@ -513,8 +573,28 @@ func TestIssueCreate_disabledIssues(t *testing.T) {
 }
 
 func TestIssueCreate_web(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
-	initFakeHTTP()
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
+	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -9,13 +9,33 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/cli/cli/context"
 	"github.com/cli/cli/utils"
 )
 
 func TestIssueStatus(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
 
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 	jsonFile, _ := os.Open("../test/fixtures/issueStatus.json")
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
@@ -41,8 +61,28 @@ func TestIssueStatus(t *testing.T) {
 }
 
 func TestIssueStatus_blankSlate(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": {
@@ -77,8 +117,28 @@ Issues opened by you
 }
 
 func TestIssueStatus_disabledIssues(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": {
@@ -93,8 +153,28 @@ func TestIssueStatus_disabledIssues(t *testing.T) {
 }
 
 func TestIssueList(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	jsonFile, _ := os.Open("../test/fixtures/issueList.json")
 	defer jsonFile.Close()
@@ -120,8 +200,28 @@ func TestIssueList(t *testing.T) {
 }
 
 func TestIssueList_withFlags(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": {	"repository": {

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -9,33 +9,14 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/cli/cli/context"
 	"github.com/cli/cli/utils"
 )
 
 func TestIssueStatus(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
 	jsonFile, _ := os.Open("../test/fixtures/issueStatus.json")
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
@@ -61,28 +42,9 @@ func TestIssueStatus(t *testing.T) {
 }
 
 func TestIssueStatus_blankSlate(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": {
@@ -117,28 +79,9 @@ Issues opened by you
 }
 
 func TestIssueStatus_disabledIssues(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": {
@@ -153,28 +96,9 @@ func TestIssueStatus_disabledIssues(t *testing.T) {
 }
 
 func TestIssueList(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/issueList.json")
 	defer jsonFile.Close()
@@ -200,28 +124,9 @@ func TestIssueList(t *testing.T) {
 }
 
 func TestIssueList_withFlags(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": {	"repository": {
@@ -242,7 +147,7 @@ Issues for OWNER/REPO
 No issues match your search
 `)
 
-	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[1].Body)
 	reqBody := struct {
 		Variables struct {
 			Assignee string
@@ -258,28 +163,9 @@ No issues match your search
 }
 
 func TestIssueList_nullAssigneeLabels(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": {	"repository": {
@@ -293,7 +179,7 @@ func TestIssueList_nullAssigneeLabels(t *testing.T) {
 		t.Errorf("error running command `issue list`: %v", err)
 	}
 
-	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[1].Body)
 	reqBody := struct {
 		Variables map[string]interface{}
 	}{}
@@ -308,6 +194,7 @@ func TestIssueList_nullAssigneeLabels(t *testing.T) {
 func TestIssueList_disabledIssues(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": {	"repository": {
@@ -324,6 +211,7 @@ func TestIssueList_disabledIssues(t *testing.T) {
 func TestIssueView(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {
@@ -357,6 +245,7 @@ func TestIssueView(t *testing.T) {
 func TestIssueView_preview(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {
@@ -429,6 +318,7 @@ func TestIssueView_notFound(t *testing.T) {
 func TestIssueView_disabledIssues(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": {
@@ -446,6 +336,7 @@ func TestIssueView_disabledIssues(t *testing.T) {
 func TestIssueView_urlArg(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {
@@ -476,28 +367,9 @@ func TestIssueView_urlArg(t *testing.T) {
 }
 
 func TestIssueCreate(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": {
@@ -516,7 +388,7 @@ func TestIssueCreate(t *testing.T) {
 		t.Errorf("error running command `issue create`: %v", err)
 	}
 
-	bodyBytes, _ := ioutil.ReadAll(http.Requests[1].Body)
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[2].Body)
 	reqBody := struct {
 		Variables struct {
 			Input struct {
@@ -536,28 +408,9 @@ func TestIssueCreate(t *testing.T) {
 }
 
 func TestIssueCreate_disabledIssues(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": {
@@ -573,28 +426,9 @@ func TestIssueCreate_disabledIssues(t *testing.T) {
 }
 
 func TestIssueCreate_web(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {

--- a/command/pr.go
+++ b/command/pr.go
@@ -94,6 +94,11 @@ func determineBaseRepo(cmd *cobra.Command, ctx context.Context) (*ghrepo.Interfa
 			return nil, err
 		}
 
+		// TODO given remotes:
+		// [upstream] cli/cli
+		// [origin] vilmibm/cli
+		// we're picking the wrong thing. i think preferSelf needs to be threaded through to
+		// ResolveRemotesToRepos in the same way as baseOverride.
 		repoContext, err := context.ResolveRemotesToRepos(remotes, apiClient, baseOverride)
 		if err != nil {
 			return nil, err

--- a/command/pr.go
+++ b/command/pr.go
@@ -67,50 +67,6 @@ branch is opened.`,
 	RunE: prView,
 }
 
-func determineBaseRepo(cmd *cobra.Command, ctx context.Context) (*ghrepo.Interface, error) {
-	apiClient, err := apiClientForContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	baseOverride, err := cmd.Flags().GetString("repo")
-	if err != nil {
-		return nil, err
-	}
-
-	baseRepo, err := ctx.BaseRepo()
-	if err != nil {
-		return nil, err
-	}
-
-	preferSelf, err := cmd.Flags().GetBool("self")
-	if err != nil {
-		return nil, err
-	}
-
-	if preferSelf == false {
-		remotes, err := ctx.Remotes()
-		if err != nil {
-			return nil, err
-		}
-
-		// TODO given remotes:
-		// [upstream] cli/cli
-		// [origin] vilmibm/cli
-		// we're picking the wrong thing. i think preferSelf needs to be threaded through to
-		// ResolveRemotesToRepos in the same way as baseOverride.
-		repoContext, err := context.ResolveRemotesToRepos(remotes, apiClient, baseOverride)
-		if err != nil {
-			return nil, err
-		}
-		baseRepo, err = repoContext.BaseRepo()
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &baseRepo, nil
-}
-
 func prStatus(cmd *cobra.Command, args []string) error {
 	ctx := contextForCommand(cmd)
 	apiClient, err := apiClientForContext(ctx)

--- a/command/pr.go
+++ b/command/pr.go
@@ -29,12 +29,8 @@ func init() {
 	prListCmd.Flags().StringP("base", "B", "", "Filter by base branch")
 	prListCmd.Flags().StringSliceP("label", "l", nil, "Filter by label")
 	prListCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
-	prListCmd.Flags().BoolP("self", "S", false, "Query current repository instead of forked parent")
 
 	prViewCmd.Flags().BoolP("preview", "p", false, "Display preview of pull request content")
-	prViewCmd.Flags().BoolP("self", "S", false, "Query current repository instead of forked parent")
-
-	prStatusCmd.Flags().BoolP("self", "S", false, "Query current repository instead of forked parent")
 }
 
 var prCmd = &cobra.Command{

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cli/cli/context"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/test"
 	"github.com/cli/cli/utils"
@@ -41,28 +40,9 @@ func TestPrCreateHelperProcess(*testing.T) {
 }
 
 func TestPRCreate(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("feature")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "feature")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "createPullRequest": { "pullRequest": {
 			"URL": "https://github.com/OWNER/REPO/pull/12"
@@ -102,28 +82,9 @@ func TestPRCreate(t *testing.T) {
 }
 
 func TestPRCreate_web(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("feature")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "feature")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	ranCommands := [][]string{}
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
@@ -144,28 +105,10 @@ func TestPRCreate_web(t *testing.T) {
 }
 
 func TestPRCreate_ReportsUncommittedChanges(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("feature")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "feature")
 	http := initFakeHTTP()
 
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "createPullRequest": { "pullRequest": {
 			"URL": "https://github.com/OWNER/REPO/pull/12"

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/context"
 	"github.com/cli/cli/utils"
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
@@ -71,8 +72,28 @@ func RunCommand(cmd *cobra.Command, args string) (*cmdOut, error) {
 }
 
 func TestPRStatus(t *testing.T) {
-	initBlankContext("OWNER/REPO", "blueberries")
+	ctx := context.NewBlank()
+	ctx.SetBranch("blueberries")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatus.json")
 	defer jsonFile.Close()
@@ -98,8 +119,28 @@ func TestPRStatus(t *testing.T) {
 }
 
 func TestPRStatus_reviewsAndChecks(t *testing.T) {
-	initBlankContext("OWNER/REPO", "blueberries")
+	ctx := context.NewBlank()
+	ctx.SetBranch("blueberries")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusChecks.json")
 	defer jsonFile.Close()
@@ -124,8 +165,28 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 }
 
 func TestPRStatus_blankSlate(t *testing.T) {
-	initBlankContext("OWNER/REPO", "blueberries")
+	ctx := context.NewBlank()
+	ctx.SetBranch("blueberries")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": {} }
@@ -155,8 +216,28 @@ Requesting a code review from you
 }
 
 func TestPRList(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	jsonFile, _ := os.Open("../test/fixtures/prList.json")
 	defer jsonFile.Close()
@@ -174,8 +255,28 @@ func TestPRList(t *testing.T) {
 }
 
 func TestPRList_filtering(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	respBody := bytes.NewBufferString(`{ "data": {} }`)
 	http.StubResponse(200, respBody)
@@ -206,8 +307,28 @@ No pull requests match your search
 }
 
 func TestPRList_filteringAssignee(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	respBody := bytes.NewBufferString(`{ "data": {} }`)
 	http.StubResponse(200, respBody)
@@ -242,8 +363,28 @@ func TestPRList_filteringAssigneeLabels(t *testing.T) {
 }
 
 func TestPRView_preview(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	jsonFile, _ := os.Open("../test/fixtures/prViewPreview.json")
 	defer jsonFile.Close()
@@ -271,8 +412,28 @@ func TestPRView_preview(t *testing.T) {
 }
 
 func TestPRView_previewCurrentBranch(t *testing.T) {
-	initBlankContext("OWNER/REPO", "blueberries")
+	ctx := context.NewBlank()
+	ctx.SetBranch("blueberries")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	jsonFile, _ := os.Open("../test/fixtures/prView.json")
 	defer jsonFile.Close()
@@ -305,8 +466,28 @@ func TestPRView_previewCurrentBranch(t *testing.T) {
 }
 
 func TestPRView_currentBranch(t *testing.T) {
-	initBlankContext("OWNER/REPO", "blueberries")
+	ctx := context.NewBlank()
+	ctx.SetBranch("blueberries")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	jsonFile, _ := os.Open("../test/fixtures/prView.json")
 	defer jsonFile.Close()
@@ -342,8 +523,28 @@ func TestPRView_currentBranch(t *testing.T) {
 }
 
 func TestPRView_noResultsForBranch(t *testing.T) {
-	initBlankContext("OWNER/REPO", "blueberries")
+	ctx := context.NewBlank()
+	ctx.SetBranch("blueberries")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	jsonFile, _ := os.Open("../test/fixtures/prView_NoActiveBranch.json")
 	defer jsonFile.Close()
@@ -372,8 +573,28 @@ func TestPRView_noResultsForBranch(t *testing.T) {
 }
 
 func TestPRView_numberArg(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequest": {
@@ -403,8 +624,28 @@ func TestPRView_numberArg(t *testing.T) {
 }
 
 func TestPRView_urlArg(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequest": {
@@ -434,8 +675,28 @@ func TestPRView_urlArg(t *testing.T) {
 }
 
 func TestPRView_branchArg(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequests": { "nodes": [
@@ -467,8 +728,28 @@ func TestPRView_branchArg(t *testing.T) {
 }
 
 func TestPRView_branchWithOwnerArg(t *testing.T) {
-	initBlankContext("OWNER/REPO", "master")
+	ctx := context.NewBlank()
+	ctx.SetBranch("master")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
 	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"defaultBranchRef": {
+				"name": "master",
+				"target": {"oid": "deadbeef"}
+			},
+			"viewerPermission": "WRITE"
+		} } }
+	`))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequests": { "nodes": [

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cli/cli/context"
 	"github.com/cli/cli/utils"
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
@@ -72,28 +71,9 @@ func RunCommand(cmd *cobra.Command, args string) (*cmdOut, error) {
 }
 
 func TestPRStatus(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("blueberries")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatus.json")
 	defer jsonFile.Close()
@@ -119,28 +99,9 @@ func TestPRStatus(t *testing.T) {
 }
 
 func TestPRStatus_reviewsAndChecks(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("blueberries")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusChecks.json")
 	defer jsonFile.Close()
@@ -165,28 +126,9 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 }
 
 func TestPRStatus_blankSlate(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("blueberries")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": {} }
@@ -216,28 +158,9 @@ Requesting a code review from you
 }
 
 func TestPRList(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prList.json")
 	defer jsonFile.Close()
@@ -255,28 +178,9 @@ func TestPRList(t *testing.T) {
 }
 
 func TestPRList_filtering(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	respBody := bytes.NewBufferString(`{ "data": {} }`)
 	http.StubResponse(200, respBody)
@@ -293,7 +197,7 @@ Pull requests for OWNER/REPO
 No pull requests match your search
 `)
 
-	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[1].Body)
 	reqBody := struct {
 		Variables struct {
 			State  []string
@@ -307,28 +211,9 @@ No pull requests match your search
 }
 
 func TestPRList_filteringAssignee(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	respBody := bytes.NewBufferString(`{ "data": {} }`)
 	http.StubResponse(200, respBody)
@@ -338,7 +223,7 @@ func TestPRList_filteringAssignee(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[1].Body)
 	reqBody := struct {
 		Variables struct {
 			Q string
@@ -352,6 +237,7 @@ func TestPRList_filteringAssignee(t *testing.T) {
 func TestPRList_filteringAssigneeLabels(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 
 	respBody := bytes.NewBufferString(`{ "data": {} }`)
 	http.StubResponse(200, respBody)
@@ -363,28 +249,9 @@ func TestPRList_filteringAssigneeLabels(t *testing.T) {
 }
 
 func TestPRView_preview(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prViewPreview.json")
 	defer jsonFile.Close()
@@ -412,28 +279,9 @@ func TestPRView_preview(t *testing.T) {
 }
 
 func TestPRView_previewCurrentBranch(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("blueberries")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prView.json")
 	defer jsonFile.Close()
@@ -466,28 +314,9 @@ func TestPRView_previewCurrentBranch(t *testing.T) {
 }
 
 func TestPRView_currentBranch(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("blueberries")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prView.json")
 	defer jsonFile.Close()
@@ -523,28 +352,9 @@ func TestPRView_currentBranch(t *testing.T) {
 }
 
 func TestPRView_noResultsForBranch(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("blueberries")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prView_NoActiveBranch.json")
 	defer jsonFile.Close()
@@ -573,28 +383,9 @@ func TestPRView_noResultsForBranch(t *testing.T) {
 }
 
 func TestPRView_numberArg(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequest": {
@@ -624,28 +415,9 @@ func TestPRView_numberArg(t *testing.T) {
 }
 
 func TestPRView_urlArg(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequest": {
@@ -675,28 +447,9 @@ func TestPRView_urlArg(t *testing.T) {
 }
 
 func TestPRView_branchArg(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequests": { "nodes": [
@@ -728,28 +481,9 @@ func TestPRView_branchArg(t *testing.T) {
 }
 
 func TestPRView_branchWithOwnerArg(t *testing.T) {
-	ctx := context.NewBlank()
-	ctx.SetBranch("master")
-	ctx.SetRemotes(map[string]string{
-		"origin": "OWNER/REPO",
-	})
-	initContext = func() context.Context {
-		return ctx
-	}
+	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repo_000": {
-			"id": "REPOID",
-			"name": "REPO",
-			"owner": {"login": "OWNER"},
-			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
-			},
-			"viewerPermission": "WRITE"
-		} } }
-	`))
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequests": { "nodes": [

--- a/command/root.go
+++ b/command/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
+	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/utils"
 
 	"github.com/spf13/cobra"
@@ -150,4 +151,48 @@ func changelogURL(version string) string {
 
 	url := fmt.Sprintf("%s/releases/tag/v%s", path, strings.TrimPrefix(version, "v"))
 	return url
+}
+
+func determineBaseRepo(cmd *cobra.Command, ctx context.Context) (*ghrepo.Interface, error) {
+	apiClient, err := apiClientForContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	baseOverride, err := cmd.Flags().GetString("repo")
+	if err != nil {
+		return nil, err
+	}
+
+	baseRepo, err := ctx.BaseRepo()
+	if err != nil {
+		return nil, err
+	}
+
+	preferSelf, err := cmd.Flags().GetBool("self")
+	if err != nil {
+		return nil, err
+	}
+
+	if preferSelf == false {
+		remotes, err := ctx.Remotes()
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO given remotes:
+		// [upstream] cli/cli
+		// [origin] vilmibm/cli
+		// we're picking the wrong thing. i think preferSelf needs to be threaded through to
+		// ResolveRemotesToRepos in the same way as baseOverride.
+		repoContext, err := context.ResolveRemotesToRepos(remotes, apiClient, baseOverride)
+		if err != nil {
+			return nil, err
+		}
+		baseRepo, err = repoContext.BaseRepo()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &baseRepo, nil
 }

--- a/command/root.go
+++ b/command/root.go
@@ -173,6 +173,7 @@ func determineBaseRepo(cmd *cobra.Command, ctx context.Context) (*ghrepo.Interfa
 	if err != nil {
 		return nil, err
 	}
+
 	var baseRepo ghrepo.Interface
 	baseRepo, err = repoContext.BaseRepo()
 	if err != nil {

--- a/command/root.go
+++ b/command/root.go
@@ -164,35 +164,20 @@ func determineBaseRepo(cmd *cobra.Command, ctx context.Context) (*ghrepo.Interfa
 		return nil, err
 	}
 
-	baseRepo, err := ctx.BaseRepo()
+	remotes, err := ctx.Remotes()
 	if err != nil {
 		return nil, err
 	}
 
-	preferSelf, err := cmd.Flags().GetBool("self")
+	repoContext, err := context.ResolveRemotesToRepos(remotes, apiClient, baseOverride)
+	if err != nil {
+		return nil, err
+	}
+	var baseRepo ghrepo.Interface
+	baseRepo, err = repoContext.BaseRepo()
 	if err != nil {
 		return nil, err
 	}
 
-	if preferSelf == false {
-		remotes, err := ctx.Remotes()
-		if err != nil {
-			return nil, err
-		}
-
-		// TODO given remotes:
-		// [upstream] cli/cli
-		// [origin] vilmibm/cli
-		// we're picking the wrong thing. i think preferSelf needs to be threaded through to
-		// ResolveRemotesToRepos in the same way as baseOverride.
-		repoContext, err := context.ResolveRemotesToRepos(remotes, apiClient, baseOverride)
-		if err != nil {
-			return nil, err
-		}
-		baseRepo, err = repoContext.BaseRepo()
-	}
-	if err != nil {
-		return nil, err
-	}
 	return &baseRepo, nil
 }

--- a/command/testing.go
+++ b/command/testing.go
@@ -12,6 +12,9 @@ func initBlankContext(repo, branch string) {
 		ctx := context.NewBlank()
 		ctx.SetBaseRepo(repo)
 		ctx.SetBranch(branch)
+		ctx.SetRemotes(map[string]string{
+			"origin": "OWNER/REPO",
+		})
 		return ctx
 	}
 }

--- a/context/context.go
+++ b/context/context.go
@@ -2,7 +2,9 @@ package context
 
 import (
 	"errors"
+	"fmt"
 	"path"
+	"sort"
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/git"
@@ -20,6 +22,100 @@ type Context interface {
 	Remotes() (Remotes, error)
 	BaseRepo() (ghrepo.Interface, error)
 	SetBaseRepo(string)
+}
+
+// cap the number of git remotes looked up, since the user might have an
+// unusally large number of git remotes
+const maxRemotesForLookup = 5
+
+func ResolveRemotesToRepos(remotes Remotes, client *api.Client, base string) (ResolvedRemotes, error) {
+	sort.Stable(remotes)
+	lenRemotesForLookup := len(remotes)
+	if lenRemotesForLookup > maxRemotesForLookup {
+		lenRemotesForLookup = maxRemotesForLookup
+	}
+
+	hasBaseOverride := base != ""
+	baseOverride := ghrepo.FromFullName(base)
+	foundBaseOverride := false
+	repos := []ghrepo.Interface{}
+	for _, r := range remotes[:lenRemotesForLookup] {
+		repos = append(repos, r)
+		if ghrepo.IsSame(r, baseOverride) {
+			foundBaseOverride = true
+		}
+	}
+	if hasBaseOverride && !foundBaseOverride {
+		// additionally, look up the explicitly specified base repo if it's not
+		// already covered by git remotes
+		repos = append(repos, baseOverride)
+	}
+
+	result := ResolvedRemotes{remotes: remotes}
+	if hasBaseOverride {
+		result.baseOverride = baseOverride
+	}
+	networkResult, err := api.RepoNetwork(client, repos)
+	if err != nil {
+		return result, err
+	}
+	result.network = networkResult
+	return result, nil
+}
+
+type ResolvedRemotes struct {
+	baseOverride ghrepo.Interface
+	remotes      Remotes
+	network      api.RepoNetworkResult
+}
+
+// BaseRepo is the first found repository in the "upstream", "github", "origin"
+// git remote order, resolved to the parent repo if the git remote points to a fork
+func (r ResolvedRemotes) BaseRepo() (*api.Repository, error) {
+	if r.baseOverride != nil {
+		for _, repo := range r.network.Repositories {
+			if repo != nil && ghrepo.IsSame(repo, r.baseOverride) {
+				return repo, nil
+			}
+		}
+		return nil, fmt.Errorf("failed looking up information about the '%s' repository",
+			ghrepo.FullName(r.baseOverride))
+	}
+
+	for _, repo := range r.network.Repositories {
+		if repo == nil {
+			continue
+		}
+		if repo.IsFork() {
+			return repo.Parent, nil
+		}
+		return repo, nil
+	}
+
+	return nil, errors.New("not found")
+}
+
+// HeadRepo is the first found repository that has push access
+func (r ResolvedRemotes) HeadRepo() (*api.Repository, error) {
+	for _, repo := range r.network.Repositories {
+		if repo != nil && repo.ViewerCanPush() {
+			return repo, nil
+		}
+	}
+	return nil, errors.New("none of the repositories have push access")
+}
+
+// RemoteForRepo finds the git remote that points to a repository
+func (r ResolvedRemotes) RemoteForRepo(repo ghrepo.Interface) (*Remote, error) {
+	for i, remote := range r.remotes {
+		if ghrepo.IsSame(remote, repo) ||
+			// additionally, look up the resolved repository name in case this
+			// git remote points to this repository via a redirect
+			(r.network.Repositories[i] != nil && ghrepo.IsSame(r.network.Repositories[i], repo)) {
+			return remote, nil
+		}
+	}
+	return nil, errors.New("not found")
 }
 
 type OnlineContext interface {

--- a/context/context.go
+++ b/context/context.go
@@ -1,8 +1,10 @@
 package context
 
 import (
+	"errors"
 	"path"
 
+	"github.com/cli/cli/api"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/mitchellh/go-homedir"
@@ -20,9 +22,43 @@ type Context interface {
 	SetBaseRepo(string)
 }
 
+type OnlineContext interface {
+	Context
+	ParentRepos() ([]ghrepo.Interface, error)
+}
+
 // New initializes a Context that reads from the filesystem
 func New() Context {
 	return &fsContext{}
+}
+
+func ExpandOnline(ctx Context, apiClient *api.Client) OnlineContext {
+	return &apiContext{
+		Context:   ctx,
+		apiClient: *apiClient,
+	}
+}
+
+func DetermineRepo(ctx Context, self bool) (ghrepo.Interface, error) {
+	if self == true {
+		return ctx.BaseRepo()
+	}
+
+	onlineCtx, isOnline := ctx.(OnlineContext)
+	if !isOnline {
+		return nil, errors.New("context not online")
+	}
+
+	repos, err := onlineCtx.ParentRepos()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(repos) < 1 {
+		return ctx.BaseRepo()
+	}
+
+	return repos[0], nil
 }
 
 // A Context implementation that queries the filesystem
@@ -129,4 +165,36 @@ func (c *fsContext) BaseRepo() (ghrepo.Interface, error) {
 
 func (c *fsContext) SetBaseRepo(nwo string) {
 	c.baseRepo = ghrepo.FromFullName(nwo)
+}
+
+type apiContext struct {
+	Context
+	apiClient api.Client
+}
+
+func (c *apiContext) ParentRepos() ([]ghrepo.Interface, error) {
+	baseRepo, err := c.BaseRepo()
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := api.RepoNetwork(&c.apiClient, []ghrepo.Interface{baseRepo})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.Repositories) < 1 {
+		return nil, errors.New("network request returned 0 repositories")
+	}
+
+	var repos []ghrepo.Interface
+
+	var repo api.Repository = *result.Repositories[0]
+
+	for repo.IsFork() {
+		repo = *repo.Parent
+		repos = append(repos, repo)
+	}
+
+	return repos, nil
 }

--- a/context/remote_test.go
+++ b/context/remote_test.go
@@ -5,7 +5,9 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/cli/cli/api"
 	"github.com/cli/cli/git"
+	"github.com/cli/cli/internal/ghrepo"
 )
 
 func Test_Remotes_FindByName(t *testing.T) {
@@ -55,5 +57,113 @@ func Test_translateRemotes(t *testing.T) {
 	}
 	if result[0].RepoName() != "hello" {
 		t.Errorf("got %q", result[0].RepoName())
+	}
+}
+
+func Test_resolvedRemotes_triangularSetup(t *testing.T) {
+	resolved := ResolvedRemotes{
+		BaseOverride: nil,
+		Remotes: Remotes{
+			&Remote{
+				Remote: &git.Remote{Name: "origin"},
+				Owner:  "OWNER",
+				Repo:   "REPO",
+			},
+			&Remote{
+				Remote: &git.Remote{Name: "fork"},
+				Owner:  "MYSELF",
+				Repo:   "REPO",
+			},
+		},
+		Network: api.RepoNetworkResult{
+			Repositories: []*api.Repository{
+				&api.Repository{
+					Name:             "NEWNAME",
+					Owner:            api.RepositoryOwner{Login: "NEWOWNER"},
+					ViewerPermission: "READ",
+				},
+				&api.Repository{
+					Name:             "REPO",
+					Owner:            api.RepositoryOwner{Login: "MYSELF"},
+					ViewerPermission: "ADMIN",
+				},
+			},
+		},
+	}
+
+	baseRepo, err := resolved.BaseRepo()
+	if err != nil {
+		t.Fatalf("got %v", err)
+	}
+	eq(t, ghrepo.FullName(baseRepo), "NEWOWNER/NEWNAME")
+	baseRemote, err := resolved.RemoteForRepo(baseRepo)
+	if err != nil {
+		t.Fatalf("got %v", err)
+	}
+	if baseRemote.Name != "origin" {
+		t.Errorf("got remote %q", baseRemote.Name)
+	}
+
+	headRepo, err := resolved.HeadRepo()
+	if err != nil {
+		t.Fatalf("got %v", err)
+	}
+	eq(t, ghrepo.FullName(headRepo), "MYSELF/REPO")
+	headRemote, err := resolved.RemoteForRepo(headRepo)
+	if err != nil {
+		t.Fatalf("got %v", err)
+	}
+	if headRemote.Name != "fork" {
+		t.Errorf("got remote %q", headRemote.Name)
+	}
+}
+
+func Test_resolvedRemotes_clonedFork(t *testing.T) {
+	resolved := ResolvedRemotes{
+		BaseOverride: nil,
+		Remotes: Remotes{
+			&Remote{
+				Remote: &git.Remote{Name: "origin"},
+				Owner:  "OWNER",
+				Repo:   "REPO",
+			},
+		},
+		Network: api.RepoNetworkResult{
+			Repositories: []*api.Repository{
+				&api.Repository{
+					Name:             "REPO",
+					Owner:            api.RepositoryOwner{Login: "OWNER"},
+					ViewerPermission: "ADMIN",
+					Parent: &api.Repository{
+						Name:             "REPO",
+						Owner:            api.RepositoryOwner{Login: "PARENTOWNER"},
+						ViewerPermission: "READ",
+					},
+				},
+			},
+		},
+	}
+
+	baseRepo, err := resolved.BaseRepo()
+	if err != nil {
+		t.Fatalf("got %v", err)
+	}
+	eq(t, ghrepo.FullName(baseRepo), "PARENTOWNER/REPO")
+	baseRemote, err := resolved.RemoteForRepo(baseRepo)
+	if baseRemote != nil || err == nil {
+		t.Error("did not expect any remote for base")
+	}
+
+	headRepo, err := resolved.HeadRepo()
+	if err != nil {
+		t.Fatalf("got %v", err)
+	}
+	eq(t, ghrepo.FullName(headRepo), "OWNER/REPO")
+	headRemote, err := resolved.RemoteForRepo(headRepo)
+	if err != nil {
+		t.Fatalf("got %v", err)
+	}
+	if headRemote.Name != "origin" {
+		t.Errorf("got remote %q", headRemote.Name)
 	}
 }


### PR DESCRIPTION
This PR:

- [x] moves the code @mislav added for detecting parent/fork relationships in `pr create` to the `context` package
- [x] wraps that code in a helper in the `command` package
- [x] improves support for respecting `--repo`/`-R`
- [x] uses the wrapper in `pr` `list`, `status`, `view`
- ~uses the wrapper in `pr checkout`~ i'm going to leave this alone for now since it has slightly different behavior
- [x] uses the wrapper in the `issue` commands
- [x] fixes tests

closes #251 

## performance note

I unscientifically benchmarked the before/after of doing this check. The time hit averaged about .2 sec on my machine/wifi. subjectively it was imperceptible and I don't think caching is urgent.

Originally based on #348 