### PR TITLE
Cross repo pr create

### DIFF
--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -176,12 +176,17 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("pull request title must not be blank")
 		}
 
+		headRefName := headBranch
+		if !ghrepo.IsSame(headRemote, baseRepo) {
+			headRefName = fmt.Sprintf("%s:%s", headRemote.RepoOwner(), headBranch)
+		}
+
 		params := map[string]interface{}{
 			"title":       title,
 			"body":        body,
 			"draft":       isDraft,
 			"baseRefName": baseBranch,
-			"headRefName": headBranch,
+			"headRefName": headRefName,
 		}
 
 		pr, err := api.CreatePullRequest(client, baseRepo, params)

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/context"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/test"
 	"github.com/cli/cli/utils"
@@ -130,4 +131,86 @@ func TestPRCreate_ReportsUncommittedChanges(t *testing.T) {
 Creating pull request for feature into master in OWNER/REPO
 
 `)
+}
+func TestPRCreate_cross_repo_same_branch(t *testing.T) {
+	ctx := context.NewBlank()
+	ctx.SetBranch("default")
+	ctx.SetRemotes(map[string]string{
+		"origin": "OWNER/REPO",
+		"fork":   "MYSELF/REPO",
+	})
+	initContext = func() context.Context {
+		return ctx
+	}
+	http := initFakeHTTP()
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repo_000": {
+									"id": "REPOID0",
+									"name": "REPO",
+									"owner": {"login": "OWNER"},
+									"defaultBranchRef": {
+										"name": "default",
+										"target": {"oid": "deadbeef"}
+									},
+									"viewerPermission": "READ"
+								},
+								"repo_001" : {
+									"parent": {
+										"id": "REPOID0",
+										"name": "REPO",
+										"owner": {"login": "OWNER"},
+										"defaultBranchRef": {
+											"name": "default",
+											"target": {"oid": "deadbeef"}
+										},
+										"viewerPermission": "READ"
+									},
+									"id": "REPOID1",
+									"name": "REPO",
+									"owner": {"login": "MYSELF"},
+									"defaultBranchRef": {
+										"name": "default",
+										"target": {"oid": "deadbeef"}
+									},
+									"viewerPermission": "WRITE"
+		} } }
+	`))
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "createPullRequest": { "pullRequest": {
+			"URL": "https://github.com/OWNER/REPO/pull/12"
+		} } } }
+	`))
+
+	origGitCommand := git.GitCommand
+	git.GitCommand = test.StubExecCommand("TestPrCreateHelperProcess", "clean")
+	defer func() {
+		git.GitCommand = origGitCommand
+	}()
+
+	output, err := RunCommand(prCreateCmd, `pr create -t "cross repo" -b "same branch"`)
+	eq(t, err, nil)
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[1].Body)
+	reqBody := struct {
+		Variables struct {
+			Input struct {
+				RepositoryID string
+				Title        string
+				Body         string
+				BaseRefName  string
+				HeadRefName  string
+			}
+		}
+	}{}
+	json.Unmarshal(bodyBytes, &reqBody)
+
+	eq(t, reqBody.Variables.Input.RepositoryID, "REPOID0")
+	eq(t, reqBody.Variables.Input.Title, "cross repo")
+	eq(t, reqBody.Variables.Input.Body, "same branch")
+	eq(t, reqBody.Variables.Input.BaseRefName, "default")
+	eq(t, reqBody.Variables.Input.HeadRefName, "MYSELF:default")
+
+	eq(t, output.String(), "https://github.com/OWNER/REPO/pull/12\n")
+
+	// goal: only care that gql is formatted properly
 }


### PR DESCRIPTION
Closes #354 

Currently we improperly specify the head ref when submitting a PR cross-repo. This PR fixes that.

Preview in browser and `-w` were and continue to be fine.

Most of the diff is testing.