### PR TITLE
add a line feed to the gitignore and ignore the `.idea` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 
 # macOS
 .DS_Store
+
+/.idea/


### PR DESCRIPTION
if you open the repository with an Intellij based editor, the IDE creates a directory `./idea` (like  `.vscode`).