### PR TITLE
README: Document `brew install gh` and that Homebrew works on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ tool.
 
 ## Installation and Upgrading
 
-### macOS
+### macOS and Linux via Homebrew
 
-Install: `brew install github/gh/gh`
+Install: `brew install gh`
 
 Upgrade: `brew update && brew upgrade gh`
 


### PR DESCRIPTION
- Thanks for building this tool! <3
- A contributor to Homebrew added `gh` to the Homebrew/homebrew-core
  tap, so I've replaced the third-party tap instructions with the
  standard ones.
- Less to maintain for you, maybe?
- Also, Homebrew works on Linux.