### PR TITLE
Fix segmentation violation at previewing an issue without description

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -279,5 +279,10 @@ func IssueByNumber(client *Client, repo ghrepo.Interface, number int) (*Issue, e
 		return nil, fmt.Errorf("the '%s' repository has disabled issues", ghrepo.FullName(repo))
 	}
 
-	return &resp.Repository.Issue, nil
+	issue := resp.Repository.Issue
+	if issue.Body == "" {
+		issue.Body = "_No description provided._"
+	}
+
+	return &issue, nil
 }

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -288,6 +288,52 @@ func TestIssueView_preview(t *testing.T) {
 	}
 }
 
+func TestIssueView_previewEmptyBodyIssue(t *testing.T) {
+	initBlankContext("OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {
+		"number": 123,
+		"body": "",
+		"title": "ix of coins",
+		"author": {
+			"login": "marseilles"
+		},
+		"labels": {
+			"nodes": [
+				{"name": "tarot"}
+			]
+		},
+		"comments": {
+		  "totalCount": 9
+		},
+		"url": "https://github.com/OWNER/REPO/issues/123"
+	} } } }
+	`))
+
+	output, err := RunCommand(issueViewCmd, "issue view -p 123")
+	if err != nil {
+		t.Errorf("error running command `issue view`: %v", err)
+	}
+
+	eq(t, output.Stderr(), "")
+
+	expectedLines := []*regexp.Regexp{
+		regexp.MustCompile(`ix of coins`),
+		regexp.MustCompile(`opened by marseilles. 9 comments. \(tarot\)`),
+		regexp.MustCompile(`No description provided.`),
+		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
+	}
+	for _, r := range expectedLines {
+		if !r.MatchString(output.String()) {
+			t.Errorf("output did not match regexp /%s/\n> output\n%s\n", r, output)
+			return
+		}
+	}
+}
+
 func TestIssueView_notFound(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()


### PR DESCRIPTION
close #393

`_No description provided._` comes from GitHub default value.

![スクリーンショット 2020-02-13 18 40 29](https://user-images.githubusercontent.com/10938548/74421470-6da4de80-4e90-11ea-9cd8-1c0458e70bbd.png)
