### PR TITLE
Fix: Nil pointer dereference while previewing PR and Issues with empty body

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -255,9 +255,11 @@ func printIssuePreview(out io.Writer, issue *api.Issue) {
 		utils.Pluralize(issue.Comments.TotalCount, "comment"),
 		coloredLabels,
 	)))
-	fmt.Fprintln(out)
-	fmt.Fprintln(out, utils.RenderMarkdown(issue.Body))
-	fmt.Fprintln(out)
+	if issue.Body != "" {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, utils.RenderMarkdown(issue.Body))
+		fmt.Fprintln(out)
+	}
 	fmt.Fprintf(out, utils.Gray("View this issue on GitHub: %s\n"), issue.URL)
 }
 

--- a/command/pr.go
+++ b/command/pr.go
@@ -308,9 +308,11 @@ func printPrPreview(out io.Writer, pr *api.PullRequest) {
 		pr.BaseRefName,
 		pr.HeadRefName,
 	)))
-	fmt.Fprintln(out)
-	fmt.Fprintln(out, utils.RenderMarkdown(pr.Body))
-	fmt.Fprintln(out)
+	if pr.Body != "" {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, utils.RenderMarkdown(pr.Body))
+		fmt.Fprintln(out)
+	}
 	fmt.Fprintf(out, utils.Gray("View this pull request on GitHub: %s\n"), pr.URL)
 }
 

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -313,6 +313,40 @@ func TestPRView_previewCurrentBranch(t *testing.T) {
 	}
 }
 
+func TestPRView_previewCurrentBranchWithEmptyBody(t *testing.T) {
+	initBlankContext("OWNER/REPO", "blueberries")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	jsonFile, _ := os.Open("../test/fixtures/prView_EmptyBody.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
+
+	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+		return &outputStub{}
+	})
+	defer restoreCmd()
+
+	output, err := RunCommand(prViewCmd, "pr view -p")
+	if err != nil {
+		t.Errorf("error running command `pr view`: %v", err)
+	}
+
+	eq(t, output.Stderr(), "")
+
+	expectedLines := []*regexp.Regexp{
+		regexp.MustCompile(`Blueberries are a good fruit`),
+		regexp.MustCompile(`nobody wants to merge 8 commits into master from blueberries`),
+		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`),
+	}
+	for _, r := range expectedLines {
+		if !r.MatchString(output.String()) {
+			t.Errorf("output did not match regexp /%s/\n> output\n%s\n", r, output)
+			return
+		}
+	}
+}
+
 func TestPRView_currentBranch(t *testing.T) {
 	initBlankContext("OWNER/REPO", "blueberries")
 	http := initFakeHTTP()

--- a/test/fixtures/prView_EmptyBody.json
+++ b/test/fixtures/prView_EmptyBody.json
@@ -1,0 +1,46 @@
+{
+  "data": {
+    "repository": {
+      "pullRequests": {
+        "nodes": [
+          {
+            "number": 12,
+            "title": "Blueberries are from a fork",
+            "body": "yeah",
+            "url": "https://github.com/OWNER/REPO/pull/12",
+            "headRefName": "blueberries",
+            "baseRefName": "master",
+            "headRepositoryOwner": {
+              "login": "hubot"
+            },
+            "commits": {
+              "totalCount": 12
+            },
+            "author": {
+              "login": "nobody"
+            },
+            "isCrossRepository": true
+          },
+          {
+            "number": 10,
+            "title": "Blueberries are a good fruit",
+            "body": "",
+            "url": "https://github.com/OWNER/REPO/pull/10",
+            "baseRefName": "master",
+            "headRefName": "blueberries",
+            "author": {
+              "login": "nobody"
+            },
+            "headRepositoryOwner": {
+              "login": "OWNER"
+            },
+            "commits": {
+              "totalCount": 8
+            },
+            "isCrossRepository": false
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
closes #403

## Details
The commit added an empty body check for both issues and PR for preview.
The code ignores the body and the formatting around it if body is empty

#### PR output
```
> ./bin/gh pr view -p 2 -R arkentos/tableturner
This is a test PR with empty body
arkentos wants to merge 1 commit into master from README
View this pull request on GitHub: https://github.com/arkentos/tableturner/pull/2
```

#### Issue output
```
./bin/gh issue view -p 1 -R arkentos/tableturner
This is a test issue with empty body
opened by arkentos. 0 comments.
View this issue on GitHub: https://github.com/arkentos/tableturner/issues/1
```