### PR TITLE
[Makefile] Support reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,21 @@ BUILD_FILES = $(shell go list -f '{{range .GoFiles}}{{$$.Dir}}/{{.}}\
 {{end}}' ./...)
 
 GH_VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
+DATE_FMT = +%Y-%m-%d
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
 LDFLAGS := -X github.com/cli/cli/command.Version=$(GH_VERSION) $(LDFLAGS)
-LDFLAGS := -X github.com/cli/cli/command.BuildDate=$(shell date +%Y-%m-%d) $(LDFLAGS)
+LDFLAGS := -X github.com/cli/cli/command.BuildDate=$(BUILD_DATE) $(LDFLAGS)
 ifdef GH_OAUTH_CLIENT_SECRET
 	LDFLAGS := -X github.com/cli/cli/context.oauthClientID=$(GH_OAUTH_CLIENT_ID) $(LDFLAGS)
 	LDFLAGS := -X github.com/cli/cli/context.oauthClientSecret=$(GH_OAUTH_CLIENT_SECRET) $(LDFLAGS)
 endif
 
 bin/gh: $(BUILD_FILES)
-	@go build -ldflags "$(LDFLAGS)" -o "$@" ./cmd/gh
+	@go build -trimpath -ldflags "$(LDFLAGS)" -o "$@" ./cmd/gh
 
 test:
 	go test ./...


### PR DESCRIPTION
It's bad form to embed timestamps in binaries as it prevents
reproducible builds of the resulting binary.

The Reproducible Builds project defines SOURCE_DATE_EPOCH to help
reproduce binaries by allowing the date format to be overridden. This
patch adds support for this for GNU and BSD date.

Go 1.13 introduces `-trimpath` which strips build paths from all
compiled binaries. This enables people to reproduce the distributed cli
binary without having to recreate the build path.

https://reproducible-builds.org/specs/source-date-epoch/
https://reproducible-builds.org/docs/build-path/

Signed-off-by: Morten Linderud <morten@linderud.pw>