### PR TITLE
Add availability section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ the terminal next to where you are already working with `git` and your code.
 
 ![screenshot](https://user-images.githubusercontent.com/98482/73286699-9f922180-41bd-11ea-87c9-60a2d31fd0ac.png)
 
+## Availability
+
+While in beta, GitHub CLI is available for repos hosted on GitHub.com only. It does not currently support repositories hosted on GitHub Enterprise Server or other hosting providers.
+
 ## We need your feedback
 
 GitHub CLI is currently early in its development, and we're hoping to get feedback from people using it.


### PR DESCRIPTION
We've gotten a bunch of issues relating to GitHub Enterprise Server (GHES) support, which isn't currently available in `gh`, despite the existence of #273. This is an attempt to clarify that repos not hosted on GitHub.com will not currently work with `gh`.

I'm not wedded to this route of doing it and there may be an opportunity to clarify in the product itself to help avoid confusion, so open to thoughts from others.