### PR TITLE
Fix wrong repo url being used for pushing

### DIFF
--- a/git/remote.go
+++ b/git/remote.go
@@ -91,7 +91,7 @@ func AddRemote(name, initURL, finalURL string) (*Remote, error) {
 		}
 	}
 
-	finalURLParsed, err := url.Parse(initURL)
+	finalURLParsed, err := url.Parse(finalURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
afaik this should be finalURL (the fork) and not initURL (the upstream),
otherwise a bit of the code above can be removed.