### PR TITLE
Improve randomString function

### DIFF
--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -20,7 +21,7 @@ func randomString(length int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%x", b), nil
+	return hex.EncodeToString(b), nil
 }
 
 // OAuthFlow represents the setup for authenticating with GitHub


### PR DESCRIPTION
Hi!
I noticed that you use `Sprintf` to return a hex string. But it is slower because it has to parse the format string first. This patch brings `EncodeToString` from `encoding/hex` package to improve `randomString` function.