### PR TITLE
Handle properly passed #<num> as equivalent to <num> for PRs and Issues

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -273,7 +273,7 @@ func printIssuePreview(out io.Writer, issue *api.Issue) error {
 var issueURLRE = regexp.MustCompile(`^https://github\.com/([^/]+)/([^/]+)/issues/(\d+)`)
 
 func issueFromArg(apiClient *api.Client, baseRepo ghrepo.Interface, arg string) (*api.Issue, error) {
-	if issueNumber, err := strconv.Atoi(arg); err == nil {
+	if issueNumber, err := strconv.Atoi(strings.TrimPrefix(arg, "#")); err == nil {
 		return api.IssueByNumber(apiClient, baseRepo, issueNumber)
 	}
 

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -243,6 +243,39 @@ func TestIssueView(t *testing.T) {
 	eq(t, url, "https://github.com/OWNER/REPO/issues/123")
 }
 
+func TestIssueViewWithHash(t *testing.T) {
+	initBlankContext("OWNER/REPO", "master")
+	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {
+		"number": 123,
+		"url": "https://github.com/OWNER/REPO/issues/123"
+	} } } }
+	`))
+
+	var seenCmd *exec.Cmd
+	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+		seenCmd = cmd
+		return &outputStub{}
+	})
+	defer restoreCmd()
+
+	output, err := RunCommand(issueViewCmd, "issue view \"#123\"")
+	if err != nil {
+		t.Errorf("error running command `issue view`: %v", err)
+	}
+
+	eq(t, output.String(), "")
+	eq(t, output.Stderr(), "Opening https://github.com/OWNER/REPO/issues/123 in your browser.\n")
+
+	if seenCmd == nil {
+		t.Fatal("expected a command to run")
+	}
+	url := seenCmd.Args[len(seenCmd.Args)-1]
+	eq(t, url, "https://github.com/OWNER/REPO/issues/123")
+}
+
 func TestIssueView_preview(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -243,9 +243,10 @@ func TestIssueView(t *testing.T) {
 	eq(t, url, "https://github.com/OWNER/REPO/issues/123")
 }
 
-func TestIssueViewWithHash(t *testing.T) {
+func TestIssueView_numberArgWithHash(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {

--- a/command/pr.go
+++ b/command/pr.go
@@ -325,7 +325,7 @@ func printPrPreview(out io.Writer, pr *api.PullRequest) error {
 var prURLRE = regexp.MustCompile(`^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)`)
 
 func prFromArg(apiClient *api.Client, baseRepo ghrepo.Interface, arg string) (*api.PullRequest, error) {
-	if prNumber, err := strconv.Atoi(arg); err == nil {
+	if prNumber, err := strconv.Atoi(strings.TrimPrefix(arg, "#")); err == nil {
 		return api.PullRequestByNumber(apiClient, baseRepo, prNumber)
 	}
 

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -475,6 +475,7 @@ func TestPRView_numberArg(t *testing.T) {
 func TestPRView_numberArgWithHash(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequest": {

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -472,6 +472,37 @@ func TestPRView_numberArg(t *testing.T) {
 	eq(t, url, "https://github.com/OWNER/REPO/pull/23")
 }
 
+func TestPRView_numberArgWithHash(t *testing.T) {
+	initBlankContext("OWNER/REPO", "master")
+	http := initFakeHTTP()
+
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "pullRequest": {
+		"url": "https://github.com/OWNER/REPO/pull/23"
+	} } } }
+	`))
+
+	var seenCmd *exec.Cmd
+	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+		seenCmd = cmd
+		return &outputStub{}
+	})
+	defer restoreCmd()
+
+	output, err := RunCommand(prViewCmd, "pr view \"#23\"")
+	if err != nil {
+		t.Errorf("error running command `pr view`: %v", err)
+	}
+
+	eq(t, output.String(), "")
+
+	if seenCmd == nil {
+		t.Fatal("expected a command to run")
+	}
+	url := seenCmd.Args[len(seenCmd.Args)-1]
+	eq(t, url, "https://github.com/OWNER/REPO/pull/23")
+}
+
 func TestPRView_urlArg(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()


### PR DESCRIPTION
Previously, entering a PR or Issue number as listed and as displayed on GitHub web site (with a leading "#") would fail. Bash and some other shells treat "#" as a comment, so the only way to actually enter a #<num> is by escaping or quoting it in any case.

Now, if the user managed to get a PR or issue number with a leading "#" past their shell and into the program, it will be treated the same as a plain number.

Additionally, some help text is added to point out the problem of "#" marking the start of a comment

Fixes #315