### PR TITLE
Fix PR status with -R flag to work outside git repo

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -70,8 +70,15 @@ func prStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	currentPRNumber, currentPRHeadRef, err := prSelectorForCurrentBranch(ctx)
+	baseOverride, err := cmd.Flags().GetString("repo")
 	if err != nil {
+		return err
+	}
+	hasBaseOverride := baseOverride != ""
+	currentPRNumber, currentPRHeadRef, err := prSelectorForCurrentBranch(ctx)
+	// Ignore error if has baseRepo is specified
+	// https://github.com/cli/cli/issues/339
+	if !hasBaseOverride && err != nil {
 		return err
 	}
 	currentUser, err := ctx.AuthLogin()

--- a/command/root.go
+++ b/command/root.go
@@ -163,9 +163,12 @@ func determineBaseRepo(cmd *cobra.Command, ctx context.Context) (*ghrepo.Interfa
 	if err != nil {
 		return nil, err
 	}
+	hasBaseOverride := baseOverride != ""
 
 	remotes, err := ctx.Remotes()
-	if err != nil {
+	// Ignore error for remotes if has baseRepo is specified
+	// https://github.com/cli/cli/issues/339
+	if !hasBaseOverride && err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
closes #339 

`gh pr status` with the `-R` flag should work outside of any git repo.

for more detailed info on the issue, please check the issue mentioned above