### PR TITLE
command: default to toolchain version

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"runtime/debug"
 	"strings"
 
 	"github.com/cli/cli/api"
@@ -15,16 +16,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Version is dynamically set at build time in the Makefile
-var Version = "DEV"
+// Version is dynamically set by the toolchain or overriden by the Makefile.
+var Version = func(info *debug.BuildInfo, ok bool) string {
+	if !ok {
+		return "(devel)"
+	}
+	return info.Main.Version
+}(debug.ReadBuildInfo())
 
-// BuildDate is dynamically set at build time in the Makefile
-var BuildDate = "YYYY-MM-DD"
+// BuildDate is dynamically set at build time in the Makefile.
+var BuildDate = "" // YYYY-MM-DD
 
 var versionOutput = ""
 
 func init() {
-	RootCmd.Version = fmt.Sprintf("%s (%s)", strings.TrimPrefix(Version, "v"), BuildDate)
+	Version = strings.TrimPrefix(info.Main.Version, "v")
+	if BuildDate == "" {
+		RootCmd.Version = Version
+	} else {
+		RootCmd.Version = fmt.Sprintf("%s (%s)", Version, BuildDate)
+	}
 	versionOutput = fmt.Sprintf("gh version %s\n%s\n", RootCmd.Version, changelogURL(Version))
 	RootCmd.AddCommand(versionCmd)
 	RootCmd.SetVersionTemplate(versionOutput)

--- a/command/root.go
+++ b/command/root.go
@@ -17,12 +17,7 @@ import (
 )
 
 // Version is dynamically set by the toolchain or overriden by the Makefile.
-var Version = func(info *debug.BuildInfo, ok bool) string {
-	if !ok {
-		return "(devel)"
-	}
-	return info.Main.Version
-}(debug.ReadBuildInfo())
+var Version = "DEV"
 
 // BuildDate is dynamically set at build time in the Makefile.
 var BuildDate = "" // YYYY-MM-DD
@@ -30,7 +25,12 @@ var BuildDate = "" // YYYY-MM-DD
 var versionOutput = ""
 
 func init() {
-	Version = strings.TrimPrefix(info.Main.Version, "v")
+	if Version == "DEV" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
+			Version = info.Main.Version
+		}
+	}
+	Version = strings.TrimPrefix(Version, "v")
 	if BuildDate == "" {
 		RootCmd.Version = Version
 	} else {


### PR DESCRIPTION
Since the Go toolchain is able to extract the module version at build
time, we should use that as a default instead of DEV. This means
customers installing via go-get will get the correct version.

Unfortunately, the toolchain does not store when the build occurs, so
BuildTime now defaults to the empty string. It is still set if build
officially, just not for go-get.