### PR TITLE
context: use the real oauth credentials

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -25,8 +25,6 @@ jobs:
           version: latest
           args: release --release-notes=CHANGELOG.md
         env:
-          GH_OAUTH_CLIENT_ID: 178c6fc778ccc68e1d6a
-          GH_OAUTH_CLIENT_SECRET: ${{secrets.OAUTH_CLIENT_SECRET}}
           GITHUB_TOKEN: ${{secrets.UPLOAD_GITHUB_TOKEN}}
   msi:
     needs: goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,8 +13,6 @@ builds:
       main: ./cmd/gh
       ldflags:
         - -s -w -X github.com/cli/cli/command.Version={{.Version}} -X github.com/cli/cli/command.BuildDate={{time "2006-01-02"}}
-        - -X github.com/cli/cli/context.oauthClientID={{.Env.GH_OAUTH_CLIENT_ID}}
-        - -X github.com/cli/cli/context.oauthClientSecret={{.Env.GH_OAUTH_CLIENT_SECRET}}
         - -X main.updaterEnabled=cli/cli
     id: macos
     goos: [darwin]

--- a/context/config_setup.go
+++ b/context/config_setup.go
@@ -18,7 +18,9 @@ const (
 )
 
 var (
-	oauthClientID     = "178c6fc778ccc68e1d6a"
+	// The "GitHub CLI" OAuth app
+	oauthClientID = "178c6fc778ccc68e1d6a"
+	// This value is safe to be embedded in version control
 	oauthClientSecret = "34ddeff2b558a23d38fba8a6de74f086ede1cc0b"
 )
 

--- a/context/config_setup.go
+++ b/context/config_setup.go
@@ -18,10 +18,8 @@ const (
 )
 
 var (
-	// The GitHub app that is meant for development
-	oauthClientID = "4d747ba5675d5d66553f"
-	// This value is safe to be embedded in version control
-	oauthClientSecret = "d4fee7b3f9c2ef4284a5ca7be0ee200cf15b6f8d"
+	oauthClientID     = "178c6fc778ccc68e1d6a"
+	oauthClientSecret = "34ddeff2b558a23d38fba8a6de74f086ede1cc0b"
 )
 
 // TODO: have a conversation about whether this belongs in the "context" package


### PR DESCRIPTION
It is trivial to extract this information from the released artefacts,
thus there is no security benefit to the safe/development credentials.
This approach also prevents users from using go-get to install.

As proof of concept, and to enable go-get, this change embeds
the GitHub CLI credentials, instead of GitHub CLI (dev).