### PR TITLE
Fix crash in `issue/pr list` for narrow terminals

### DIFF
--- a/utils/table_printer.go
+++ b/utils/table_printer.go
@@ -176,7 +176,10 @@ func (t *tsvTablePrinter) Render() error {
 
 func truncate(maxLength int, title string) string {
 	if len(title) > maxLength {
-		return title[0:maxLength-3] + "..."
+		if maxLength > 3 {
+			return title[0:maxLength-3] + "..."
+		}
+		return title[0:maxLength]
 	}
 	return title
 }

--- a/utils/table_printer_test.go
+++ b/utils/table_printer_test.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"bytes"
+	"testing"
+)
+
+func Test_ttyTablePrinter_truncate(t *testing.T) {
+	buf := bytes.Buffer{}
+	tp := &ttyTablePrinter{
+		out:      &buf,
+		maxWidth: 5,
+	}
+
+	tp.AddField("1", nil, nil)
+	tp.AddField("hello", nil, nil)
+	tp.EndRow()
+	tp.AddField("2", nil, nil)
+	tp.AddField("world", nil, nil)
+	tp.EndRow()
+
+	err := tp.Render()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "1  he\n2  wo\n"
+	if buf.String() != expected {
+		t.Errorf("expected: %q, got: %q", expected, buf.String())
+	}
+}


### PR DESCRIPTION
If the available column width is smaller than 3, don't try to truncate with ellipsis (`...`). Instead, just truncate to available width.

Fixes #431