### PR TITLE
Explicitly replace empty body with default template

### DIFF
--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -79,9 +79,11 @@ func selectTemplate(templatePaths []string) (string, error) {
 
 func titleBodySurvey(cmd *cobra.Command, providedTitle string, providedBody string, templatePaths []string) (*titleBody, error) {
 	inProgress := titleBody{}
+	templateContents := ""
 
 	if providedBody == "" && len(templatePaths) > 0 {
-		templateContents, err := selectTemplate(templatePaths)
+		var err error
+		templateContents, err = selectTemplate(templatePaths)
 		if err != nil {
 			return nil, err
 		}
@@ -119,6 +121,10 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle string, providedBody stri
 	err := survey.Ask(qs, &inProgress)
 	if err != nil {
 		return nil, fmt.Errorf("could not prompt: %w", err)
+	}
+
+	if inProgress.Body == "" {
+		inProgress.Body = templateContents
 	}
 
 	confirmA, err := confirm()


### PR DESCRIPTION
This pr fixes [388](https://github.com/cli/cli/issues/388).

Survey editor returns an empty string if we skip the prompt [editor.go:98](https://github.com/cli/cli/blob/4a5135d820e27a10ec7739d680476e7f95aea54f/pkg/surveyext/editor.go#L98). In this Pr we explicitly set the body equal to template if body is empty and the template content is available.