### PR TITLE
Include merged PRs with `list --state=closed`

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -256,13 +256,13 @@ func printIssuePreview(out io.Writer, issue *api.Issue) error {
 	)))
 
 	if issue.Body != "" {
-    fmt.Fprintln(out)
-	  md, err := utils.RenderMarkdown(issue.Body)
-	  if err != nil {
-		  return err
-	  }
-	  fmt.Fprintln(out, md)
-	  fmt.Fprintln(out)
+		fmt.Fprintln(out)
+		md, err := utils.RenderMarkdown(issue.Body)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(out, md)
+		fmt.Fprintln(out)
 	}
 
 	fmt.Fprintf(out, utils.Gray("View this issue on GitHub: %s\n"), issue.URL)

--- a/command/pr.go
+++ b/command/pr.go
@@ -309,12 +309,12 @@ func printPrPreview(out io.Writer, pr *api.PullRequest) error {
 	)))
 	if pr.Body != "" {
 		fmt.Fprintln(out)
-	  md, err := utils.RenderMarkdown(pr.Body)
-	  if err != nil {
-	  	return err
-	  }
-  	fmt.Fprintln(out, md)
-	  fmt.Fprintln(out)
+		md, err := utils.RenderMarkdown(pr.Body)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(out, md)
+		fmt.Fprintln(out)
 	}
 
 	fmt.Fprintf(out, utils.Gray("View this pull request on GitHub: %s\n"), pr.URL)

--- a/command/pr.go
+++ b/command/pr.go
@@ -163,7 +163,7 @@ func prList(cmd *cobra.Command, args []string) error {
 	case "open":
 		graphqlState = []string{"OPEN"}
 	case "closed":
-		graphqlState = []string{"CLOSED"}
+		graphqlState = []string{"CLOSED", "MERGED"}
 	case "merged":
 		graphqlState = []string{"MERGED"}
 	case "all":

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -210,6 +210,30 @@ No pull requests match your search
 	eq(t, reqBody.Variables.Labels, []string{"one", "two", "three"})
 }
 
+func TestPRList_filteringClosed(t *testing.T) {
+	initBlankContext("OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	respBody := bytes.NewBufferString(`{ "data": {} }`)
+	http.StubResponse(200, respBody)
+
+	_, err := RunCommand(prListCmd, `pr list -s closed`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[1].Body)
+	reqBody := struct {
+		Variables struct {
+			State []string
+		}
+	}{}
+	json.Unmarshal(bodyBytes, &reqBody)
+
+	eq(t, reqBody.Variables.State, []string{"CLOSED", "MERGED"})
+}
+
 func TestPRList_filteringAssignee(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()


### PR DESCRIPTION
Since we currently offer no way of querying PRs by combining multiple states with an OR, the best way to handle the `closed` state is to match what the web UI is doing; that is to include merged PRs.

Fixes #475