### PR TITLE
Ability to differentiate pull requests by their state

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -150,6 +150,7 @@ func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, cu
 	fragment pr on PullRequest {
 		number
 		title
+		state
 		url
 		headRefName
 		headRepositoryOwner {
@@ -185,7 +186,7 @@ func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, cu
 	queryPrefix := `
 	query($owner: String!, $repo: String!, $headRefName: String!, $viewerQuery: String!, $reviewerQuery: String!, $per_page: Int = 10) {
 		repository(owner: $owner, name: $repo) {
-			pullRequests(headRefName: $headRefName, states: OPEN, first: $per_page) {
+			pullRequests(headRefName: $headRefName, first: $per_page) {
 				totalCount
 				edges {
 					node {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -186,7 +186,7 @@ func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, cu
 	queryPrefix := `
 	query($owner: String!, $repo: String!, $headRefName: String!, $viewerQuery: String!, $reviewerQuery: String!, $per_page: Int = 10) {
 		repository(owner: $owner, name: $repo) {
-			pullRequests(headRefName: $headRefName, first: $per_page) {
+			pullRequests(headRefName: $headRefName, first: $per_page, orderBy: { field: CREATED_AT, direction: DESC }) {
 				totalCount
 				edges {
 					node {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -10,7 +10,7 @@ import (
 type PullRequestsPayload struct {
 	ViewerCreated   PullRequestAndTotalCount
 	ReviewRequested PullRequestAndTotalCount
-	CurrentPR       *PullRequest
+	CurrentPRs      []PullRequest
 }
 
 type PullRequestAndTotalCount struct {
@@ -262,11 +262,13 @@ func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, cu
 		reviewRequested = append(reviewRequested, edge.Node)
 	}
 
-	var currentPR = resp.Repository.PullRequest
-	if currentPR == nil {
+	var currentPRs []PullRequest
+	if resp.Repository.PullRequest != nil {
+		currentPRs = append(currentPRs, *resp.Repository.PullRequest)
+	} else {
 		for _, edge := range resp.Repository.PullRequests.Edges {
 			if edge.Node.HeadLabel() == currentPRHeadRef {
-				currentPR = &edge.Node
+				currentPRs = append(currentPRs, edge.Node)
 			}
 		}
 	}
@@ -280,7 +282,7 @@ func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, cu
 			PullRequests: reviewRequested,
 			TotalCount:   resp.ReviewRequested.TotalCount,
 		},
-		CurrentPR: currentPR,
+		CurrentPRs: currentPRs,
 	}
 
 	return &payload, nil

--- a/command/pr.go
+++ b/command/pr.go
@@ -97,8 +97,8 @@ func prStatus(cmd *cobra.Command, args []string) error {
 	fmt.Fprintln(out, "")
 
 	printHeader(out, "Current branch")
-	if prPayload.CurrentPR != nil {
-		printPrs(out, 0, *prPayload.CurrentPR)
+	if prPayload.CurrentPRs != nil {
+		printPrs(out, 0, prPayload.CurrentPRs...)
 	} else {
 		message := fmt.Sprintf("  There is no pull request associated with %s", utils.Cyan("["+currentPRHeadRef+"]"))
 		printMessage(out, message)

--- a/command/pr.go
+++ b/command/pr.go
@@ -387,7 +387,13 @@ func printPrs(w io.Writer, totalCount int, printStatus bool, prs ...api.PullRequ
 		prNumber := fmt.Sprintf("#%d", pr.Number)
 		fmt.Fprintf(w, "  %s  %s %s", utils.Green(prNumber), text.Truncate(50, replaceExcessiveWhitespace(pr.Title)), utils.Cyan("["+pr.HeadLabel()+"]"))
 		if printStatus {
-			fmt.Fprintf(w, " (%s)", pr.State)
+			if pr.State == "OPEN" {
+				fmt.Fprintf(w, " %s", utils.Green("(OPEN)"))
+			} else if pr.State == "MERGED" {
+				fmt.Fprintf(w, " %s", utils.Magenta("(MERGED)"))
+			} else if pr.State == "CLOSED" {
+				fmt.Fprintf(w, " %s", utils.Red("(CLOSED)"))
+			}
 		}
 
 		checks := pr.ChecksStatus()

--- a/command/pr.go
+++ b/command/pr.go
@@ -98,7 +98,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 
 	printHeader(out, "Current branch")
 	if prPayload.CurrentPR != nil {
-		printPrs(out, 0, true, *prPayload.CurrentPR)
+		printPrs(out, 0, *prPayload.CurrentPR)
 	} else {
 		message := fmt.Sprintf("  There is no pull request associated with %s", utils.Cyan("["+currentPRHeadRef+"]"))
 		printMessage(out, message)
@@ -107,7 +107,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 
 	printHeader(out, "Created by you")
 	if prPayload.ViewerCreated.TotalCount > 0 {
-		printPrs(out, prPayload.ViewerCreated.TotalCount, false, prPayload.ViewerCreated.PullRequests...)
+		printPrs(out, prPayload.ViewerCreated.TotalCount, prPayload.ViewerCreated.PullRequests...)
 	} else {
 		printMessage(out, "  You have no open pull requests")
 	}
@@ -115,7 +115,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 
 	printHeader(out, "Requesting a code review from you")
 	if prPayload.ReviewRequested.TotalCount > 0 {
-		printPrs(out, prPayload.ReviewRequested.TotalCount, false, prPayload.ReviewRequested.PullRequests...)
+		printPrs(out, prPayload.ReviewRequested.TotalCount, prPayload.ReviewRequested.PullRequests...)
 	} else {
 		printMessage(out, "  You have no pull requests to review")
 	}
@@ -382,19 +382,17 @@ func prSelectorForCurrentBranch(ctx context.Context) (prNumber int, prHeadRef st
 	return
 }
 
-func printPrs(w io.Writer, totalCount int, printStatus bool, prs ...api.PullRequest) {
+func printPrs(w io.Writer, totalCount int, prs ...api.PullRequest) {
 	for _, pr := range prs {
 		prNumber := fmt.Sprintf("#%d", pr.Number)
-		fmt.Fprintf(w, "  %s  %s %s", utils.Green(prNumber), text.Truncate(50, replaceExcessiveWhitespace(pr.Title)), utils.Cyan("["+pr.HeadLabel()+"]"))
-		if printStatus {
-			if pr.State == "OPEN" {
-				fmt.Fprintf(w, " %s", utils.Green("(OPEN)"))
-			} else if pr.State == "MERGED" {
-				fmt.Fprintf(w, " %s", utils.Magenta("(MERGED)"))
-			} else if pr.State == "CLOSED" {
-				fmt.Fprintf(w, " %s", utils.Red("(CLOSED)"))
-			}
+		if pr.State == "OPEN" {
+			fmt.Fprintf(w, "  %s", utils.Green(prNumber))
+		} else if pr.State == "MERGED" {
+			fmt.Fprintf(w, "  %s", utils.Magenta(prNumber))
+		} else if pr.State == "CLOSED" {
+			fmt.Fprintf(w, "  %s", utils.Red(prNumber))
 		}
+		fmt.Fprintf(w, "  %s %s", text.Truncate(50, replaceExcessiveWhitespace(pr.Title)), utils.Cyan("["+pr.HeadLabel()+"]"))
 
 		checks := pr.ChecksStatus()
 		reviews := pr.ReviewStatus()

--- a/command/pr.go
+++ b/command/pr.go
@@ -98,7 +98,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 
 	printHeader(out, "Current branch")
 	if prPayload.CurrentPR != nil {
-		printPrs(out, 0, *prPayload.CurrentPR)
+		printPrs(out, 0, true, *prPayload.CurrentPR)
 	} else {
 		message := fmt.Sprintf("  There is no pull request associated with %s", utils.Cyan("["+currentPRHeadRef+"]"))
 		printMessage(out, message)
@@ -107,7 +107,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 
 	printHeader(out, "Created by you")
 	if prPayload.ViewerCreated.TotalCount > 0 {
-		printPrs(out, prPayload.ViewerCreated.TotalCount, prPayload.ViewerCreated.PullRequests...)
+		printPrs(out, prPayload.ViewerCreated.TotalCount, false, prPayload.ViewerCreated.PullRequests...)
 	} else {
 		printMessage(out, "  You have no open pull requests")
 	}
@@ -115,7 +115,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 
 	printHeader(out, "Requesting a code review from you")
 	if prPayload.ReviewRequested.TotalCount > 0 {
-		printPrs(out, prPayload.ReviewRequested.TotalCount, prPayload.ReviewRequested.PullRequests...)
+		printPrs(out, prPayload.ReviewRequested.TotalCount, false, prPayload.ReviewRequested.PullRequests...)
 	} else {
 		printMessage(out, "  You have no pull requests to review")
 	}
@@ -382,10 +382,13 @@ func prSelectorForCurrentBranch(ctx context.Context) (prNumber int, prHeadRef st
 	return
 }
 
-func printPrs(w io.Writer, totalCount int, prs ...api.PullRequest) {
+func printPrs(w io.Writer, totalCount int, printStatus bool, prs ...api.PullRequest) {
 	for _, pr := range prs {
 		prNumber := fmt.Sprintf("#%d", pr.Number)
 		fmt.Fprintf(w, "  %s  %s %s", utils.Green(prNumber), text.Truncate(50, replaceExcessiveWhitespace(pr.Title)), utils.Cyan("["+pr.HeadLabel()+"]"))
+		if printStatus {
+			fmt.Fprintf(w, " (%s)", pr.State)
+		}
 
 		checks := pr.ChecksStatus()
 		reviews := pr.ReviewStatus()


### PR DESCRIPTION
Fixes #467

I took a look at #467 and figured out a way to print a PR state of the current branch.

I simply added the state at the end of the line for now.

### Merged PR
```
$ gh pr status

Relevant pull requests in doi-t/cli-test

Current branch
  #1  Test 467 [test467] (MERGED)

Created by you
  #2  Test 2 [test-2]

Requesting a code review from you
  You have no pull requests to review
```

### Open PR
```
$ gh pr status

Relevant pull requests in doi-t/cli-test

Current branch
  #2  Test 2 [test-2] (OPEN)

Created by you
  #2  Test 2 [test-2]

Requesting a code review from you
  You have no pull requests to review
```

### Closed PR
```
$ gh pr status

Relevant pull requests in doi-t/cli-test

Current branch
  #3  Test 3 [test-3] (CLOSED)

Created by you
  #2  Test 2 [test-2]

Requesting a code review from you
  You have no pull requests to review
```

Please let me know anything I'm missing.