### PR TITLE
fix: inconsistent format between issue list and status

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/githubtemplate"
-	"github.com/cli/cli/pkg/text"
 	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -395,7 +394,7 @@ func printIssues(w io.Writer, prefix string, totalCount int, issues []api.Issue)
 		now := time.Now()
 		ago := now.Sub(issue.UpdatedAt)
 		table.AddField(issueNum, nil, colorFuncForState(issue.State))
-		table.AddField(text.Truncate(70, replaceExcessiveWhitespace(issue.Title)), nil, nil)
+		table.AddField(replaceExcessiveWhitespace(issue.Title), nil, nil)
 		table.AddField(labels, nil, utils.Gray)
 		table.AddField(utils.FuzzyAgo(ago), nil, utils.Gray)
 		table.EndRow()

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -27,10 +27,10 @@ func TestIssueStatus(t *testing.T) {
 	}
 
 	expectedIssues := []*regexp.Regexp{
-		regexp.MustCompile(`#8.*carrots`),
-		regexp.MustCompile(`#9.*squash`),
-		regexp.MustCompile(`#10.*broccoli`),
-		regexp.MustCompile(`#11.*swiss chard`),
+		regexp.MustCompile(`(?m)8.*carrots.*about.*ago`),
+		regexp.MustCompile(`(?m)9.*squash.*about.*ago`),
+		regexp.MustCompile(`(?m)10.*broccoli.*about.*ago`),
+		regexp.MustCompile(`(?m)11.*swiss chard.*about.*ago`),
 	}
 
 	for _, r := range expectedIssues {


### PR DESCRIPTION
Currently, `issue list` and `issue status` have different printing formats.

This PR adds the `age` section for `issue list` and uses the `tablewriter` for `issue status` to keep the format consistency between them.

## Current version

<img width="706" alt="Screen Shot 2020-02-23 at 6 41 08 PM" src="https://user-images.githubusercontent.com/6178510/75110032-2545a780-566c-11ea-988b-f7a78323a758.png">

## Fixed version

<img width="728" alt="Screen Shot 2020-02-23 at 6 41 00 PM" src="https://user-images.githubusercontent.com/6178510/75110028-21b22080-566c-11ea-97f0-452ab7197098.png">
