### PR TITLE
Support `issue list --limit=N` where N is greater than 100

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -185,21 +185,21 @@ func IssueList(client *Client, repo ghrepo.Interface, state string, labels []str
 	}
 
 	query := fragments + `
-    query($owner: String!, $repo: String!, $limit: Int, $endCursor: String, $states: [IssueState!] = OPEN, $labels: [String!], $assignee: String) {
-      repository(owner: $owner, name: $repo) {
-		hasIssuesEnabled
-        issues(first: $limit, after: $endCursor, orderBy: {field: CREATED_AT, direction: DESC}, states: $states, labels: $labels, filterBy: {assignee: $assignee}) {
-          nodes {
-            ...issue
-          }
-          pageInfo {
-            hasNextPage
-            endCursor
-          }
-        }
-      }
-    }
-  `
+	query($owner: String!, $repo: String!, $limit: Int, $endCursor: String, $states: [IssueState!] = OPEN, $labels: [String!], $assignee: String) {
+		repository(owner: $owner, name: $repo) {
+			hasIssuesEnabled
+			issues(first: $limit, after: $endCursor, orderBy: {field: CREATED_AT, direction: DESC}, states: $states, labels: $labels, filterBy: {assignee: $assignee}) {
+				nodes {
+					...issue
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}
+	}
+	`
 
 	variables := map[string]interface{}{
 		"owner":  repo.RepoOwner(),

--- a/api/queries_issue_test.go
+++ b/api/queries_issue_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/cli/cli/internal/ghrepo"
+)
+
+func TestIssueList(t *testing.T) {
+	http := &FakeHTTP{}
+	client := NewClient(ReplaceTripper(http))
+
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": {
+		"hasIssuesEnabled": true,
+		"issues": {
+			"nodes": [],
+			"pageInfo": {
+				"hasNextPage": true,
+				"endCursor": "ENDCURSOR"
+			}
+		}
+	} } }
+	`))
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": {
+		"hasIssuesEnabled": true,
+		"issues": {
+			"nodes": [],
+			"pageInfo": {
+				"hasNextPage": false,
+				"endCursor": "ENDCURSOR"
+			}
+		}
+	} } }
+	`))
+
+	_, err := IssueList(client, ghrepo.FromFullName("OWNER/REPO"), "open", []string{}, "", 251)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(http.Requests) != 2 {
+		t.Fatalf("expected 2 HTTP requests, seen %d", len(http.Requests))
+	}
+	var reqBody struct {
+		Query     string
+		Variables map[string]interface{}
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+	json.Unmarshal(bodyBytes, &reqBody)
+	if reqLimit := reqBody.Variables["limit"].(float64); reqLimit != 100 {
+		t.Errorf("expected 100, got %v", reqLimit)
+	}
+	if _, cursorPresent := reqBody.Variables["endCursor"]; cursorPresent {
+		t.Error("did not expect first request to pass 'endCursor'")
+	}
+
+	bodyBytes, _ = ioutil.ReadAll(http.Requests[1].Body)
+	json.Unmarshal(bodyBytes, &reqBody)
+	if endCursor := reqBody.Variables["endCursor"].(string); endCursor != "ENDCURSOR" {
+		t.Errorf("expected %q, got %q", "ENDCURSOR", endCursor)
+	}
+}


### PR DESCRIPTION
This mimics the `pr list` implementation where any `--limit` value larger than 100 triggers API pagination. Subsequent pages are fetched until the `--limit` value has been reached or until there are no more records.

Followup to https://github.com/cli/cli/pull/540