### PR TITLE
Slice initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # VS Code
 .vscode
 
+# IntelliJ
+.idea
+
 # macOS
 .DS_Store
 

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -80,7 +80,7 @@ type PullRequestReviewStatus struct {
 }
 
 func (pr *PullRequest) ReviewStatus() PullRequestReviewStatus {
-	status := PullRequestReviewStatus{}
+	var status PullRequestReviewStatus
 	switch pr.ReviewDecision {
 	case "CHANGES_REQUESTED":
 		status.ChangesRequested = true

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -112,8 +112,8 @@ func RepoNetwork(client *Client, repos []ghrepo.Interface) (RepoNetworkResult, e
 	// Since the query is constructed dynamically, we can't parse a response
 	// format using a static struct. Instead, hold the raw JSON data until we
 	// decide how to parse it manually.
-	graphqlResult := map[string]*json.RawMessage{}
-	result := RepoNetworkResult{}
+	graphqlResult := make(map[string]*json.RawMessage)
+	var result RepoNetworkResult
 
 	err := client.GraphQL(fmt.Sprintf(`
 	fragment repo on Repository {
@@ -175,8 +175,8 @@ func RepoNetwork(client *Client, repos []ghrepo.Interface) (RepoNetworkResult, e
 				result.Repositories = append(result.Repositories, nil)
 				continue
 			}
-			repo := Repository{}
-			decoder := json.NewDecoder(bytes.NewReader([]byte(*jsonMessage)))
+			var repo Repository
+			decoder := json.NewDecoder(bytes.NewReader(*jsonMessage))
 			if err := decoder.Decode(&repo); err != nil {
 				return result, err
 			}

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -97,7 +97,7 @@ type RepoNetworkResult struct {
 
 // RepoNetwork inspects the relationship between multiple GitHub repositories
 func RepoNetwork(client *Client, repos []ghrepo.Interface) (RepoNetworkResult, error) {
-	queries := []string{}
+	queries := make([]string, 0, len(repos))
 	for i, repo := range repos {
 		queries = append(queries, fmt.Sprintf(`
 		repo_%03d: repository(owner: %q, name: %q) {
@@ -150,7 +150,7 @@ func RepoNetwork(client *Client, repos []ghrepo.Interface) (RepoNetworkResult, e
 		return result, err
 	}
 
-	keys := []string{}
+	keys := make([]string, 0, len(graphqlResult))
 	for key := range graphqlResult {
 		keys = append(keys, key)
 	}

--- a/command/issue.go
+++ b/command/issue.go
@@ -429,7 +429,7 @@ func labelList(issue api.Issue) string {
 		return ""
 	}
 
-	labelNames := []string{}
+	labelNames := make([]string, 0, len(issue.Labels.Nodes))
 	for _, label := range issue.Labels.Nodes {
 		labelNames = append(labelNames, label.Name)
 	}

--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -38,8 +38,7 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 		headRemote, _ = remotes.FindByRepo(pr.HeadRepositoryOwner.Login, pr.HeadRepository.Name)
 	}
 
-	cmdQueue := [][]string{}
-
+	cmdQueue := make([][]string, 0, 4)
 	newBranchName := pr.HeadRefName
 	if headRemote != nil {
 		// there is an existing git remote for PR head

--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -38,7 +38,7 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 		headRemote, _ = remotes.FindByRepo(pr.HeadRepositoryOwner.Login, pr.HeadRepository.Name)
 	}
 
-	cmdQueue := make([][]string, 0, 4)
+	var cmdQueue [][]string
 	newBranchName := pr.HeadRefName
 	if headRemote != nil {
 		// there is an existing git remote for PR head

--- a/command/root.go
+++ b/command/root.go
@@ -97,7 +97,7 @@ var initContext = func() context.Context {
 // BasicClient returns an API client that borrows from but does not depend on
 // user configuration
 func BasicClient() (*api.Client, error) {
-	opts := make([]api.ClientOption, 0, 1)
+	var opts []api.ClientOption
 	if verbose := os.Getenv("DEBUG"); verbose != "" {
 		opts = append(opts, apiVerboseLog())
 	}
@@ -122,7 +122,7 @@ var apiClientForContext = func(ctx context.Context) (*api.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	opts := make([]api.ClientOption, 0, 4)
+	var opts []api.ClientOption
 	if verbose := os.Getenv("DEBUG"); verbose != "" {
 		opts = append(opts, apiVerboseLog())
 	}

--- a/command/root.go
+++ b/command/root.go
@@ -97,7 +97,7 @@ var initContext = func() context.Context {
 // BasicClient returns an API client that borrows from but does not depend on
 // user configuration
 func BasicClient() (*api.Client, error) {
-	opts := []api.ClientOption{}
+	opts := make([]api.ClientOption, 0, 1)
 	if verbose := os.Getenv("DEBUG"); verbose != "" {
 		opts = append(opts, apiVerboseLog())
 	}
@@ -122,7 +122,7 @@ var apiClientForContext = func(ctx context.Context) (*api.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	opts := []api.ClientOption{}
+	opts := make([]api.ClientOption, 0, 4)
 	if verbose := os.Getenv("DEBUG"); verbose != "" {
 		opts = append(opts, apiVerboseLog())
 	}

--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -54,7 +54,7 @@ func selectTemplate(templatePaths []string) (string, error) {
 		Index int
 	}{}
 	if len(templatePaths) > 1 {
-		templateNames := []string{}
+		templateNames := make([]string, 0, len(templatePaths))
 		for _, p := range templatePaths {
 			templateNames = append(templateNames, githubtemplate.ExtractName(p))
 		}
@@ -110,7 +110,7 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle string, providedBody stri
 		},
 	}
 
-	qs := []*survey.Question{}
+	var qs = []*survey.Question{}
 	if providedTitle == "" {
 		qs = append(qs, titleQuestion)
 	}

--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -78,7 +78,7 @@ func selectTemplate(templatePaths []string) (string, error) {
 }
 
 func titleBodySurvey(cmd *cobra.Command, providedTitle string, providedBody string, templatePaths []string) (*titleBody, error) {
-	inProgress := titleBody{}
+	var inProgress titleBody
 	templateContents := ""
 
 	if providedBody == "" && len(templatePaths) > 0 {
@@ -110,7 +110,7 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle string, providedBody stri
 		},
 	}
 
-	var qs = []*survey.Question{}
+	var qs []*survey.Question
 	if providedTitle == "" {
 		qs = append(qs, titleQuestion)
 	}

--- a/context/blank_context.go
+++ b/context/blank_context.go
@@ -53,7 +53,7 @@ func (c *blankContext) Remotes() (Remotes, error) {
 }
 
 func (c *blankContext) SetRemotes(stubs map[string]string) {
-	c.remotes = Remotes{}
+	c.remotes = make([]*Remote, 0, len(stubs))
 	for remoteName, repo := range stubs {
 		ownerWithName := strings.SplitN(repo, "/", 2)
 		c.remotes = append(c.remotes, &Remote{

--- a/context/context.go
+++ b/context/context.go
@@ -38,7 +38,7 @@ func ResolveRemotesToRepos(remotes Remotes, client *api.Client, base string) (Re
 	hasBaseOverride := base != ""
 	baseOverride := ghrepo.FromFullName(base)
 	foundBaseOverride := false
-	repos := []ghrepo.Interface{}
+	repos := make([]ghrepo.Interface, 0, lenRemotesForLookup)
 	for _, r := range remotes[:lenRemotesForLookup] {
 		repos = append(repos, r)
 		if ghrepo.IsSame(r, baseOverride) {

--- a/git/ssh_config.go
+++ b/git/ssh_config.go
@@ -70,7 +70,7 @@ func ParseSSHConfig() SSHAliasMap {
 }
 
 func sshParse(r ...io.Reader) SSHAliasMap {
-	config := SSHAliasMap{}
+	config := make(SSHAliasMap)
 	for _, file := range r {
 		sshParseConfig(config, file)
 	}

--- a/git/ssh_config.go
+++ b/git/ssh_config.go
@@ -57,7 +57,7 @@ func ParseSSHConfig() SSHAliasMap {
 		configFiles = append([]string{userConfig}, configFiles...)
 	}
 
-	openFiles := []io.Reader{}
+	openFiles := make([]io.Reader, 0, len(configFiles))
 	for _, file := range configFiles {
 		f, err := os.Open(file)
 		if err != nil {

--- a/internal/cobrafish/completion.go
+++ b/internal/cobrafish/completion.go
@@ -117,7 +117,7 @@ func flagRequiresArgumentCompletion(flag *pflag.Flag) string {
 }
 
 func subCommandPath(rootCmd *cobra.Command, cmd *cobra.Command) string {
-	path := []string{}
+	path := make([]string, 0, 1)
 	currentCmd := cmd
 	if rootCmd == cmd {
 		return ""
@@ -142,7 +142,7 @@ func rangeCommands(cmd *cobra.Command, callback func(subCmd *cobra.Command)) {
 
 func commandCompletionCondition(rootCmd, cmd *cobra.Command) string {
 	localNonPersistentFlags := cmd.LocalNonPersistentFlags()
-	bareConditions := []string{}
+	bareConditions := make([]string, 0, 1)
 	if rootCmd != cmd {
 		bareConditions = append(bareConditions, fmt.Sprintf("__fish_%s_seen_subcommand_path %s", rootCmd.Name(), subCommandPath(rootCmd, cmd)))
 	} else {

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -24,7 +24,7 @@ func FullName(r Interface) string {
 }
 
 func FromFullName(nwo string) Interface {
-	r := ghRepo{}
+	var r ghRepo
 	parts := strings.SplitN(nwo, "/", 2)
 	if len(parts) == 2 {
 		r.owner, r.name = parts[0], parts[1]

--- a/update/update.go
+++ b/update/update.go
@@ -41,7 +41,7 @@ func getLatestReleaseInfo(client *api.Client, stateFilePath, repo, currentVersio
 		return &stateEntry.LatestRelease, nil
 	}
 
-	latestRelease := ReleaseInfo{}
+	var latestRelease ReleaseInfo
 	err = client.REST("GET", fmt.Sprintf("repos/%s/releases/latest", repo), nil, &latestRelease)
 	if err != nil {
 		return nil, err

--- a/utils/table_printer.go
+++ b/utils/table_printer.go
@@ -69,7 +69,7 @@ func (t *ttyTablePrinter) AddField(s string, truncateFunc func(int, string) stri
 		truncateFunc = text.Truncate
 	}
 	if t.rows == nil {
-		t.rows = [][]tableField{[]tableField{}}
+		t.rows = make([][]tableField, 1, 1)
 	}
 	rowI := len(t.rows) - 1
 	field := tableField{


### PR DESCRIPTION
It's micro optimization which in this project doesn't make sense.
I just prefer it, maybe it's just my personal opinion, so I get it if it will be rejected.

When empty struct needs to be created, I prefer
```go
var myStruct MyStruct
```
vs
```go
myStruct := MyStruct{}
```

And when we're doing "map" from some object to another in slice, we can specify capacity in advance to avoid multiple reallocations.
```go
results := make([]Result, 0, len(in))
for _, obj := range in {
    results = append(results, obj.toResult())
}
```
vs
```go
results := []Result{}
for _, obj := range in {
    results = append(results, obj.toResult())
}
```

When slice could be empty, we can just declare it
```go
var results []Result
```
vs
```go
results := []Result{}
```
this
```go
t.rows = [][]tableField{[]tableField{}}	
```
could be simplified to
```go
t.rows = [][]tableField{{}}	
```
type doesn't need to be explicitly specified.

And the last one, which is not covered by this PR is error handling.

```go
func sshParse(r ...io.Reader) SSHAliasMap {
	config := make(SSHAliasMap)
	for _, file := range r {
		sshParseConfig(config, file)
	}
	return config
}
```
`sshParseConfig` is returning error. I prefer to specify that we are ignoring error knowingly by assigning it to `_`, we are then sure we didn't forgotten to handle error.
```go
_ = sshParseConfig(config, file)
```


Maybe you decided that code as is written is for you more readable, which is fine, these tips are more style preference than optimization.