### PR TITLE
Add `repo clone <repo>` command

### DIFF
--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -2,11 +2,64 @@ package command
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/utils"
 )
+
+func TestRepoClone(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		{
+			name: "shorthand",
+			args: "repo clone OWNER/REPO",
+			want: "git clone https://github.com/OWNER/REPO.git",
+		},
+		{
+			name: "clone arguments",
+			args: "repo clone OWNER/REPO -- -o upstream --depth 1",
+			want: "git clone -o upstream --depth 1 https://github.com/OWNER/REPO.git",
+		},
+		{
+			name: "HTTPS URL",
+			args: "repo clone https://github.com/OWNER/REPO",
+			want: "git clone https://github.com/OWNER/REPO",
+		},
+		{
+			name: "SSH URL",
+			args: "repo clone git@github.com:OWNER/REPO.git",
+			want: "git clone git@github.com:OWNER/REPO.git",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var seenCmd *exec.Cmd
+			restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+				seenCmd = cmd
+				return &outputStub{}
+			})
+			defer restoreCmd()
+
+			output, err := RunCommand(repoViewCmd, tt.args)
+			if err != nil {
+				t.Fatalf("error running command `repo clone`: %v", err)
+			}
+
+			eq(t, output.String(), "")
+			eq(t, output.Stderr(), "")
+
+			if seenCmd == nil {
+				t.Fatal("expected a command to run")
+			}
+			eq(t, strings.Join(seenCmd.Args, " "), tt.want)
+		})
+	}
+}
 
 func TestRepoView(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")


### PR DESCRIPTION
Example usage:
- `gh repo clone OWNER/REPO`
- `gh repo clone OWNER/REPO -- -o upstream --depth 1`
- `gh repo clone https://github.com/OWNER/REPO.git`
- `gh repo clone git@github.com:OWNER/REPO.git`

Discuss:
- Should we make the `OWNER/` portion optional? In that case, what do we default to? https://github.com/cli/cli/issues/333#issuecomment-590566300
- Should we accept optional 2nd argument as directory destination like `git clone` does?
- There is currenly zero benefit for the user passing the full clone URL to `gh repo clone` over doing it with plain `git clone`. Should we still support the URL argument?
- Currently the shorthand `OWNER/REPO` expands to an HTTPS clone URL. How do we acommodate people who would prefer SSH clone URLs by default?

Fixes #333