### PR TITLE
Use gray color for PR number if PR is a draft

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -40,6 +40,7 @@ type PullRequest struct {
 		}
 	}
 	IsCrossRepository   bool
+	IsDraft             bool
 	MaintainerCanModify bool
 
 	ReviewDecision string
@@ -156,6 +157,7 @@ func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, cu
 			login
 		}
 		isCrossRepository
+		isDraft
 		commits(last: 1) {
 			nodes {
 				commit {
@@ -366,6 +368,7 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, branch string) 
 						login
 					}
 					isCrossRepository
+					isDraft
 				}
 			}
 		}
@@ -460,6 +463,7 @@ func PullRequestList(client *Client, vars map[string]interface{}, limit int) ([]
 			login
 		}
 		isCrossRepository
+		isDraft
 	}
 	`
 


### PR DESCRIPTION
Closes #212 

I like @ampinsk's idea, let me know if you need anything changed!

Screenshots:

<img width="647" alt="image" src="https://user-images.githubusercontent.com/8061997/75274246-cd8d7480-5802-11ea-8d43-c8ff75eca6e9.png">


<img width="660" alt="image" src="https://user-images.githubusercontent.com/8061997/75274388-12b1a680-5803-11ea-9570-f7dadd7c0b64.png">

<img width="945" alt="image" src="https://user-images.githubusercontent.com/8061997/75274671-8d7ac180-5803-11ea-8eb6-271bb7a92603.png">


