### PR TITLE
Improve error message for issue URL with no args

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -69,7 +69,7 @@ var issueViewCmd = &cobra.Command{
 	Use: "view {<number> | <url> | <branch>}",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return FlagError{errors.New("issue required as argument")}
+			return FlagError{errors.New("issue integer or URL required as argument")}
 		}
 		return nil
 	},

--- a/command/issue.go
+++ b/command/issue.go
@@ -69,7 +69,7 @@ var issueViewCmd = &cobra.Command{
 	Use: "view {<number> | <url> | <branch>}",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return FlagError{errors.New("issue integer or URL required as argument")}
+			return FlagError{errors.New("issue number or URL required as argument")}
 		}
 		return nil
 	},


### PR DESCRIPTION
As a followup of #474, there's an opportunity to improve the error message for when there are no arguments (or we don't think there are no arguments as in the case if someone uses a #). This just adds a bit more to the error message to specify that it should use either the issue number or the URL as an argument.