### PR TITLE
Improve showing help message

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cli/cli/utils"
 	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var updaterEnabled = ""
@@ -58,14 +59,29 @@ func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
 		return
 	}
 
+	var flagError *command.FlagError
+	if errors.As(err, &flagError) {
+		if flagError.Err == pflag.ErrHelp {
+			fmt.Fprintln(out, cmd.UsageString())
+			return
+		}
+
+		fmt.Fprintln(out, flagError)
+		if !strings.HasSuffix(flagError.Error(), "\n") {
+			fmt.Fprintln(out)
+		}
+		fmt.Fprintln(out, cmd.UsageString())
+		return
+	}
+
 	fmt.Fprintln(out, err)
 
-	var flagError *command.FlagError
-	if errors.As(err, &flagError) || strings.HasPrefix(err.Error(), "unknown command ") {
+	if strings.HasPrefix(err.Error(), "unknown command ") {
 		if !strings.HasSuffix(err.Error(), "\n") {
 			fmt.Fprintln(out)
 		}
 		fmt.Fprintln(out, cmd.UsageString())
+		return
 	}
 }
 

--- a/cmd/gh/main_test.go
+++ b/cmd/gh/main_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cli/cli/command"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func Test_printError(t *testing.T) {
@@ -63,6 +64,15 @@ check your internet connection or githubstatus.com
 				debug: false,
 			},
 			wantOut: "unknown command foo\n\nUsage:\n\n",
+		},
+		{
+			name: "pflag help error",
+			args: args{
+				err:   &command.FlagError{Err: pflag.ErrHelp},
+				cmd:   cmd,
+				debug: false,
+			},
+			wantOut: "Usage:\n\n",
 		},
 	}
 


### PR DESCRIPTION
The help flag always displays "pflag: help requested". It should not be displayed.

**before:**

```
$ gh -h 2>&1 | head -n 5
pflag: help requested

Usage:
  gh [command]

```

**after:**

```
bin/gh -h 2>&1 | head -n 5
Usage:
  gh [command]

Available Commands:
  help        Help about any command
```