### PR TITLE
Compare full head label for determining current PR

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -264,11 +264,11 @@ func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, cu
 	var currentPR = resp.Repository.PullRequest
 	if currentPR == nil {
 		for _, edge := range resp.Repository.PullRequests.Edges {
-			currHeadLabel := currentPRHeadRef
+			currentPRHeadLabel := currentPRHeadRef
 			if edge.Node.IsCrossRepository {
-				currHeadLabel = fmt.Sprintf("%s:%s", currentUsername, currentPRHeadRef)
+				currentPRHeadLabel = fmt.Sprintf("%s:%s", currentUsername, currentPRHeadRef)
 			}
-			if edge.Node.HeadLabel() == currHeadLabel {
+			if edge.Node.HeadLabel() == currentPRHeadLabel {
 				currentPR = &edge.Node
 			}
 		}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -264,7 +264,11 @@ func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, cu
 	var currentPR = resp.Repository.PullRequest
 	if currentPR == nil {
 		for _, edge := range resp.Repository.PullRequests.Edges {
-			if edge.Node.HeadLabel() == currentPRHeadRef {
+			currHeadLabel := currentPRHeadRef
+			if edge.Node.IsCrossRepository {
+				currHeadLabel = fmt.Sprintf("%s:%s", currentUsername, currentPRHeadRef)
+			}
+			if edge.Node.HeadLabel() == currHeadLabel {
 				currentPR = &edge.Node
 			}
 		}


### PR DESCRIPTION
I took a look at #561, it wouldn't work for any branch name (regardless of a dot) in forked repos. Traced it to here, `pr.HeadLabel()` was compared to `currentPRHeadRef` which for cross repo PRs would be `rista404:test-branch == test-branch`. Now it's compared to the full label. Tested it in forked and my own repos.

Closes #561 