### PR TITLE
Move pending release cards into done on release

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -30,14 +30,14 @@ jobs:
         if: "!contains(github.ref, '-')"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          HUB: 'bin/hub api -HACCEPT:application/vnd.github.inertia-preview+json '
           PENDING_COLUMN: 8189733
           DONE_COLUMN: 7110130
         shell: bash
         run: |
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          cards=$($HUB projects/columns/$PENDING_COLUMN/cards | jq "map(.id)|.[]")
-          for card in $cards; do $HUB projects/columns/cards/$card/moves --field position=top --field column_id=$DONE_COLUMN; done
+          api() { bin/hub api -H 'accept: application/vnd.github.inertia-preview+json' "$@"; }
+          cards=$(api projects/columns/$PENDING_COLUMN/cards | jq ".[].id")
+          for card in $cards; do api projects/columns/cards/$card/moves --field position=top --field column_id=$DONE_COLUMN; done
   msi:
     needs: goreleaser
     runs-on: windows-latest

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -26,17 +26,13 @@ jobs:
           args: release --release-notes=CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{secrets.UPLOAD_GITHUB_TOKEN}}
-  cards:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    if: ${!contains(github.ref, "-")}
-    env:
-      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      HUB: 'bin/hub api -HACCEPT:application/vnd.github.inertia-preview+json '
-      PENDING_COLUMN: 8189733
-      DONE_COLUMN: 7110130
-    steps:
       - name: move cards
+        if: ${!contains(github.ref, "-")}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          HUB: 'bin/hub api -HACCEPT:application/vnd.github.inertia-preview+json '
+          PENDING_COLUMN: 8189733
+          DONE_COLUMN: 7110130
         shell: bash
         run: |
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.UPLOAD_GITHUB_TOKEN}}
       - name: move cards
-        if: ${!contains(github.ref, "-")}
+        if: "!contains(github.ref, '-')"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           HUB: 'bin/hub api -HACCEPT:application/vnd.github.inertia-preview+json '

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -26,6 +26,22 @@ jobs:
           args: release --release-notes=CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{secrets.UPLOAD_GITHUB_TOKEN}}
+  cards:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    if: ${!contains(github.ref, "-")}
+    env:
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      HUB: 'bin/hub api -HACCEPT:application/vnd.github.inertia-preview+json '
+      PENDING_COLUMN: 8189733
+      DONE_COLUMN: 7110130
+    steps:
+      - name: move cards
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
+          cards=$($HUB projects/columns/$PENDING_COLUMN/cards | jq "map(.id)|.[]")
+          for card in $cards; do $HUB projects/columns/cards/$card/moves --field position=top --field column_id=$DONE_COLUMN; done
   msi:
     needs: goreleaser
     runs-on: windows-latest


### PR DESCRIPTION
closes #569

adds a workflow step for releasing that moves anything from the Pending Release column over to the
Done column.

I, uh, tested it on a local Ubuntu machine but haven't actually tested it in prod. I figure I'll
debug it if needed during the next release.

There might be a better way to skip for prerelease but I think what I have works.
