### PR TITLE
Add usage to README for repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ And if you spot bugs or have features that you'd really like to see in `gh`, ple
 
 - `gh pr [status, list, view, checkout, create]`
 - `gh issue [status, list, view, create]`
+- `gh repo [view, create, clone, fork]`
 - `gh help`
 
 Check out the [docs][] for more information.


### PR DESCRIPTION
We just shipped repo commands but they're not present in our README, so this adds that.