### PR TITLE
Add support for multiple labels when filtering with assignee

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -547,11 +547,10 @@ func PullRequestList(client *Client, vars map[string]interface{}, limit int) ([]
 				search = append(search, "is:merged")
 			}
 		}
-		if labels, ok := vars["labels"].([]string); ok && len(labels) > 0 {
-			if len(labels) > 1 {
-				return nil, fmt.Errorf("multiple labels with --assignee are not supported")
+		if labels, ok := vars["labels"].([]string); ok {
+			for _, label := range labels {
+				search = append(search, fmt.Sprintf(`label:"%s"`, label))
 			}
-			search = append(search, fmt.Sprintf(`label:"%s"`, labels[0]))
 		}
 		if baseBranch, ok := vars["baseBranch"].(string); ok {
 			search = append(search, fmt.Sprintf(`base:"%s"`, baseBranch))

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -297,9 +297,19 @@ func TestPRList_filteringAssigneeLabels(t *testing.T) {
 	http.StubResponse(200, respBody)
 
 	_, err := RunCommand(prListCmd, `pr list -l one,two -a hubot`)
-	if err == nil && err.Error() != "multiple labels with --assignee are not supported" {
+	if err != nil {
 		t.Fatal(err)
 	}
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[1].Body)
+	reqBody := struct {
+		Variables struct {
+			Q string
+		}
+	}{}
+	json.Unmarshal(bodyBytes, &reqBody)
+
+	eq(t, reqBody.Variables.Q, `repo:OWNER/REPO assignee:hubot is:pr sort:created-desc state:open label:"one" label:"two"`)
 }
 
 func TestPRView_preview(t *testing.T) {


### PR DESCRIPTION
This PR allows us to use multiple labels when filtering pull requests using assignee parameter.