### PR TITLE
autofill title/body for PRs

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -358,7 +358,7 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 	interactive := title == "" || body == ""
 
 	if interactive {
-		tb, err := titleBodySurvey(cmd, title, body, templateFiles)
+		tb, err := titleBodySurvey(cmd, title, body, defaults{}, templateFiles)
 		if err != nil {
 			return fmt.Errorf("could not collect title and/or body: %w", err)
 		}

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/test"
 	"github.com/cli/cli/utils"
 )
 
@@ -226,7 +227,7 @@ func TestIssueView(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -260,7 +261,7 @@ func TestIssueView_numberArgWithHash(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -383,7 +384,7 @@ func TestIssueView_notFound(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -430,7 +431,7 @@ func TestIssueView_urlArg(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -515,7 +516,7 @@ func TestIssueCreate_web(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -541,7 +542,7 @@ func TestIssueCreate_webTitleBody(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/context"
+	"github.com/cli/cli/test"
 	"github.com/cli/cli/utils"
 )
 
@@ -46,7 +47,7 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 			return &errorStub{"exit status: 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
-			return &outputStub{}
+			return &test.OutputStub{}
 		}
 	})
 	defer restoreCmd()
@@ -98,7 +99,7 @@ func TestPRCheckout_urlArg(t *testing.T) {
 			return &errorStub{"exit status: 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
-			return &outputStub{}
+			return &test.OutputStub{}
 		}
 	})
 	defer restoreCmd()
@@ -147,7 +148,7 @@ func TestPRCheckout_branchArg(t *testing.T) {
 			return &errorStub{"exit status: 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
-			return &outputStub{}
+			return &test.OutputStub{}
 		}
 	})
 	defer restoreCmd()
@@ -193,10 +194,10 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git show-ref --verify --quiet refs/heads/feature":
-			return &outputStub{}
+			return &test.OutputStub{}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
-			return &outputStub{}
+			return &test.OutputStub{}
 		}
 	})
 	defer restoreCmd()
@@ -248,7 +249,7 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 			return &errorStub{"exit status: 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
-			return &outputStub{}
+			return &test.OutputStub{}
 		}
 	})
 	defer restoreCmd()
@@ -300,7 +301,7 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 			return &errorStub{"exit status 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
-			return &outputStub{}
+			return &test.OutputStub{}
 		}
 	})
 	defer restoreCmd()
@@ -349,10 +350,10 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git config branch.feature.merge":
-			return &outputStub{[]byte("refs/heads/feature\n")}
+			return &test.OutputStub{[]byte("refs/heads/feature\n")}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
-			return &outputStub{}
+			return &test.OutputStub{}
 		}
 	})
 	defer restoreCmd()
@@ -399,10 +400,10 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git config branch.feature.merge":
-			return &outputStub{[]byte("refs/heads/feature\n")}
+			return &test.OutputStub{[]byte("refs/heads/feature\n")}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
-			return &outputStub{}
+			return &test.OutputStub{}
 		}
 	})
 	defer restoreCmd()
@@ -452,7 +453,7 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 			return &errorStub{"exit status 1"}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
-			return &outputStub{}
+			return &test.OutputStub{}
 		}
 	})
 	defer restoreCmd()

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -36,7 +36,7 @@ func computeDefaults(baseRef, headRef string) (defaults, error) {
 		}
 		out.Body = body
 	} else {
-		out.Title = headRef // TODO format or something?
+		out.Title = utils.Humanize(headRef)
 
 		body := ""
 		for _, c := range commits {

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -15,6 +15,39 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type defaults struct {
+	Title string
+	Body  string
+}
+
+func computeDefaults(baseRef, headRef string) (defaults, error) {
+	commits, err := git.Commits(baseRef, headRef)
+	if err != nil {
+		return defaults{}, err
+	}
+
+	out := defaults{}
+
+	if len(commits) == 1 {
+		out.Title = commits[0].Title
+		body, err := git.CommitBody(commits[0].Sha)
+		if err != nil {
+			return defaults{}, err
+		}
+		out.Body = body
+	} else {
+		out.Title = headRef // TODO format or something?
+
+		body := fmt.Sprintf("---\n%d commits:\n\n", len(commits))
+		for _, c := range commits {
+			body += fmt.Sprintf("- %s %s\n", c.Sha[0:5], c.Title)
+		}
+		out.Body = body
+	}
+
+	return out, nil
+}
+
 func prCreate(cmd *cobra.Command, _ []string) error {
 	ctx := contextForCommand(cmd)
 	remotes, err := ctx.Remotes()
@@ -68,6 +101,11 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not parse body: %w", err)
 	}
 
+	defs, err := computeDefaults(baseBranch, headBranch)
+	if err != nil {
+		return fmt.Errorf("could not compute title or body defaults:  %w", err)
+	}
+
 	isWeb, err := cmd.Flags().GetBool("web")
 	if err != nil {
 		return fmt.Errorf("could not parse web: %q", err)
@@ -91,7 +129,7 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 			templateFiles = githubtemplate.Find(rootDir, "PULL_REQUEST_TEMPLATE")
 		}
 
-		tb, err := titleBodySurvey(cmd, title, body, templateFiles)
+		tb, err := titleBodySurvey(cmd, title, body, defs, templateFiles)
 		if err != nil {
 			return fmt.Errorf("could not collect title and/or body: %w", err)
 		}

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -38,9 +38,9 @@ func computeDefaults(baseRef, headRef string) (defaults, error) {
 	} else {
 		out.Title = headRef // TODO format or something?
 
-		body := fmt.Sprintf("---\n%d commits:\n\n", len(commits))
+		body := ""
 		for _, c := range commits {
-			body += fmt.Sprintf("- %s %s\n", c.Sha[0:5], c.Title)
+			body += fmt.Sprintf("- %s\n", c.Title)
 		}
 		out.Body = body
 	}
@@ -103,7 +103,7 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 
 	defs, err := computeDefaults(baseBranch, headBranch)
 	if err != nil {
-		return fmt.Errorf("could not compute title or body defaults:  %w", err)
+		fmt.Fprintf(colorableErr(cmd), "%s warning: could not compute title or body defaults:  %w\n", utils.Yellow("!"), err)
 	}
 
 	isWeb, err := cmd.Flags().GetBool("web")

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -111,9 +111,18 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not parse web: %q", err)
 	}
 
+	autofill, err := cmd.Flags().GetBool("fill")
+	if err != nil {
+		return fmt.Errorf("could not parse fill: %q", err)
+	}
+
 	action := SubmitAction
 	if isWeb {
 		action = PreviewAction
+	} else if autofill {
+		action = SubmitAction
+		title = defs.Title
+		body = defs.Body
 	} else {
 		fmt.Fprintf(colorableErr(cmd), "\nCreating pull request for %s into %s in %s\n\n",
 			utils.Cyan(headBranch),
@@ -122,7 +131,7 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 	}
 
 	// TODO: only drop into interactive mode if stdin & stdout are a tty
-	if !isWeb && (title == "" || body == "") {
+	if !isWeb && !autofill && (title == "" || body == "") {
 		var templateFiles []string
 		if rootDir, err := git.ToplevelDir(); err == nil {
 			// TODO: figure out how to stub this in tests
@@ -276,4 +285,5 @@ func init() {
 	prCreateCmd.Flags().StringP("base", "B", "",
 		"The branch into which you want your code merged")
 	prCreateCmd.Flags().BoolP("web", "w", false, "Open the web browser to create a pull request")
+	prCreateCmd.Flags().BoolP("fill", "f", false, "Do not prompt for title/body and just use commit info")
 }

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -23,6 +23,8 @@ func TestPrCreateHelperProcess(*testing.T) {
 
 	args := test.GetTestHelperProcessArgs()
 	switch args[1] {
+	case "log":
+		fmt.Println("123,cool,\"\"")
 	case "status":
 		switch args[0] {
 		case "clean":
@@ -100,9 +102,9 @@ func TestPRCreate_web(t *testing.T) {
 	eq(t, output.String(), "")
 	eq(t, output.Stderr(), "Opening github.com/OWNER/REPO/compare/master...feature in your browser.\n")
 
-	eq(t, len(ranCommands), 3)
+	eq(t, len(ranCommands), 4)
 	eq(t, strings.Join(ranCommands[1], " "), "git push --set-upstream origin HEAD:feature")
-	eq(t, ranCommands[2][len(ranCommands[2])-1], "https://github.com/OWNER/REPO/compare/master...feature?expand=1")
+	eq(t, ranCommands[3][len(ranCommands[3])-1], "https://github.com/OWNER/REPO/compare/master...feature?expand=1")
 }
 
 func TestPRCreate_ReportsUncommittedChanges(t *testing.T) {
@@ -213,4 +215,32 @@ func TestPRCreate_cross_repo_same_branch(t *testing.T) {
 	eq(t, output.String(), "https://github.com/OWNER/REPO/pull/12\n")
 
 	// goal: only care that gql is formatted properly
+}
+
+/*
+ We aren't testing the survey code paths /at all/.
+
+ so if we want to test those code paths, some cases:
+
+ - user supplies no -t/-b and wants to preview in browser
+ - user supplies no -t/-b and wants to submit directly
+ - user supplies no -t/-b and wants to edit the title
+ - user supplies no -t/-b and wants to edit the body
+
+ for defaults:
+
+ - one commit
+ - multiple commits
+
+ checking that defaults are generated appropriately each time.
+
+ it seems that each survey prompt needs to be an injectable hook.
+*/
+
+func PRCreate_survey_preview_defaults(t *testing.T) {
+	// there are going to be calls to:
+	// - git status
+	// - git push
+	// - git rev-parse
+	// - git log
 }

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -191,7 +191,7 @@ func TestPRCreate_cross_repo_same_branch(t *testing.T) {
 }
 
 func TestPRCreate_survey_defaults_multicommit(t *testing.T) {
-	initBlankContext("OWNER/REPO", "feature")
+	initBlankContext("OWNER/REPO", "cool_bug-fixes")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
@@ -248,10 +248,10 @@ func TestPRCreate_survey_defaults_multicommit(t *testing.T) {
 	expectedBody := "- commit 0\n- commit 1\n"
 
 	eq(t, reqBody.Variables.Input.RepositoryID, "REPOID")
-	eq(t, reqBody.Variables.Input.Title, "feature")
+	eq(t, reqBody.Variables.Input.Title, "cool bug fixes")
 	eq(t, reqBody.Variables.Input.Body, expectedBody)
 	eq(t, reqBody.Variables.Input.BaseRefName, "master")
-	eq(t, reqBody.Variables.Input.HeadRefName, "feature")
+	eq(t, reqBody.Variables.Input.HeadRefName, "cool_bug-fixes")
 
 	eq(t, output.String(), "https://github.com/OWNER/REPO/pull/12\n")
 }

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/cli/cli/context"
-	"github.com/cli/cli/utils"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
@@ -26,9 +25,8 @@ func TestPRCreate(t *testing.T) {
 		} } } }
 	`))
 
-	cs := CmdStubber{}
-	teardown := utils.SetPrepareCmd(createStubbedPrepareCmd(&cs))
-	defer teardown()
+	cs, cmdTeardown := InitCmdStubber()
+	defer cmdTeardown()
 
 	cs.Stub("")                                         // git status
 	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
@@ -65,9 +63,8 @@ func TestPRCreate_web(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	cs := CmdStubber{}
-	teardown := utils.SetPrepareCmd(createStubbedPrepareCmd(&cs))
-	defer teardown()
+	cs, cmdTeardown := InitCmdStubber()
+	defer cmdTeardown()
 
 	cs.Stub("")                                         // git status
 	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
@@ -97,9 +94,8 @@ func TestPRCreate_ReportsUncommittedChanges(t *testing.T) {
 		} } } }
 	`))
 
-	cs := CmdStubber{}
-	teardown := utils.SetPrepareCmd(createStubbedPrepareCmd(&cs))
-	defer teardown()
+	cs, cmdTeardown := InitCmdStubber()
+	defer cmdTeardown()
 
 	cs.Stub(" M git/git.go")                            // git status
 	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
@@ -164,9 +160,8 @@ func TestPRCreate_cross_repo_same_branch(t *testing.T) {
 		} } } }
 	`))
 
-	cs := CmdStubber{}
-	teardown := utils.SetPrepareCmd(createStubbedPrepareCmd(&cs))
-	defer teardown()
+	cs, cmdTeardown := InitCmdStubber()
+	defer cmdTeardown()
 
 	cs.Stub("")                                         // git status
 	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
@@ -300,9 +295,7 @@ func TestPRCreate_survey_preview_defaults(t *testing.T) {
 		} } } }
 	`))
 
-	// TODO initCmdStubber in command/testing
-	cs := CmdStubber{}
-	cmdTeardown := utils.SetPrepareCmd(createStubbedPrepareCmd(&cs))
+	cs, cmdTeardown := InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("")                                         // git status

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -245,7 +245,7 @@ func TestPRCreate_survey_defaults_multicommit(t *testing.T) {
 	}{}
 	json.Unmarshal(bodyBytes, &reqBody)
 
-	expectedBody := "---\n2 commits:\n\n- 12345 commit 0\n- 23456 commit 1\n"
+	expectedBody := "- commit 0\n- commit 1\n"
 
 	eq(t, reqBody.Variables.Input.RepositoryID, "REPOID")
 	eq(t, reqBody.Variables.Input.Title, "feature")
@@ -321,23 +321,4 @@ func TestPRCreate_survey_defaults_monocommit(t *testing.T) {
 	eq(t, reqBody.Variables.Input.HeadRefName, "feature")
 
 	eq(t, output.String(), "https://github.com/OWNER/REPO/pull/12\n")
-}
-
-func TestPRCreate_survey_defaults_no_changes(t *testing.T) {
-	initBlankContext("OWNER/REPO", "feature")
-
-	http := initFakeHTTP()
-	http.StubRepoResponse("OWNER", "REPO")
-
-	cs, cmdTeardown := initCmdStubber()
-	defer cmdTeardown()
-
-	cs.Stub("") // git status
-	cs.Stub("") // git log
-
-	_, err := RunCommand(prCreateCmd, `pr create`)
-	if err == nil {
-		t.Error("expected error")
-	}
-	eq(t, err.Error(), "could not compute title or body defaults:  could not find any commits between master and feature")
 }

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -3,12 +3,17 @@ package command
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/utils"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
 )
 
 func TestPRCreate(t *testing.T) {
@@ -215,10 +220,143 @@ func TestPRCreate_cross_repo_same_branch(t *testing.T) {
  it seems that each survey prompt needs to be an injectable hook.
 */
 
-func PRCreate_survey_preview_defaults(t *testing.T) {
-	// there are going to be calls to:
-	// - git status
-	// - git push
-	// - git rev-parse
-	// - git log
+type askStubber struct {
+	Asks  [][]*survey.Question
+	Count int
+	Stubs [][]*QuestionStub
+}
+
+func initAskStubber() (*askStubber, func()) {
+	origSurveyAsk := SurveyAsk
+	as := askStubber{}
+	SurveyAsk = func(qs []*survey.Question, response interface{}, opts ...survey.AskOpt) error {
+		as.Asks = append(as.Asks, qs)
+		count := as.Count
+		as.Count += 1
+		if count >= len(as.Stubs) {
+			panic(fmt.Sprintf("more asks than stubs. most recent call: %v", qs))
+		}
+
+		// actually set response
+		stubbedQuestions := as.Stubs[count]
+		for i, sq := range stubbedQuestions {
+			q := qs[i]
+			if q.Name != sq.Name {
+				panic(fmt.Sprintf("stubbed question mismatch: %s != %s", q.Name, sq.Name))
+			}
+			if sq.Default {
+				defaultValue := reflect.ValueOf(q.Prompt).Elem().FieldByName("Default")
+				core.WriteAnswer(response, q.Name, defaultValue)
+			} else {
+				core.WriteAnswer(response, q.Name, sq.Value)
+			}
+		}
+
+		return nil
+	}
+	teardown := func() {
+		SurveyAsk = origSurveyAsk
+	}
+	return &as, teardown
+}
+
+type QuestionStub struct {
+	Name    string
+	Value   interface{}
+	Default bool
+}
+
+func (as *askStubber) Stub(stubbedQuestions []*QuestionStub) {
+	// A call to .Ask takes a list of questions; a stub is then a list of questions in the same order.
+	as.Stubs = append(as.Stubs, stubbedQuestions)
+}
+
+func (as *askStubber) StubWithDefaults() {
+	as.Stubs = append(as.Stubs, nil)
+}
+
+/*
+ there are going to be calls to:
+ - git status
+ - git push
+ - git rev-parse
+ - git log
+
+ I can handle all that with the new CmdStubber.
+
+ For survey, there is going to be:
+ - potentially template select Ask
+ - title, body Ask
+ - Confirm Action Ask
+
+*/
+func TestPRCreate_survey_preview_defaults(t *testing.T) {
+	initBlankContext("OWNER/REPO", "feature")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "createPullRequest": { "pullRequest": {
+			"URL": "https://github.com/OWNER/REPO/pull/12"
+		} } } }
+	`))
+
+	// TODO initCmdStubber in command/testing
+	cs := CmdStubber{}
+	cmdTeardown := utils.SetPrepareCmd(createStubbedPrepareCmd(&cs))
+	defer cmdTeardown()
+
+	cs.Stub("")                                         // git status
+	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
+	cs.Stub("")                                         // git rev-parse
+	cs.Stub("")                                         // git push
+
+	as, surveyTeardown := initAskStubber()
+	defer surveyTeardown()
+
+	// so here is a problem: we lose survey's default detection. This works for specifying what a user
+	// has typed in, but not for simulating when a user inputs nothing.
+	// so; how to simulate when a user inputs nothing? can have a special method for that--even just
+	// "all defaults" would be ok -- but need to figure out if we can even /access/ what the default
+	// values would be.
+	as.Stub([]*QuestionStub{
+		&QuestionStub{
+			Name:    "title",
+			Default: true,
+		},
+		&QuestionStub{
+			Name:    "body",
+			Default: true,
+		},
+	})
+	as.Stub([]*QuestionStub{
+		&QuestionStub{
+			Name:  "confirmation",
+			Value: 1,
+		},
+	})
+
+	output, err := RunCommand(prCreateCmd, `pr create`)
+	eq(t, err, nil)
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[1].Body)
+	reqBody := struct {
+		Variables struct {
+			Input struct {
+				RepositoryID string
+				Title        string
+				Body         string
+				BaseRefName  string
+				HeadRefName  string
+			}
+		}
+	}{}
+	json.Unmarshal(bodyBytes, &reqBody)
+
+	eq(t, reqBody.Variables.Input.RepositoryID, "REPOID")
+	eq(t, reqBody.Variables.Input.Title, "my title")
+	eq(t, reqBody.Variables.Input.Body, "my body lies")
+	eq(t, reqBody.Variables.Input.BaseRefName, "master")
+	eq(t, reqBody.Variables.Input.HeadRefName, "feature")
+
+	eq(t, output.String(), "https://github.com/OWNER/REPO/pull/12\n")
 }

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/test"
 	"github.com/cli/cli/utils"
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
@@ -110,7 +111,7 @@ func TestPRStatus_fork(t *testing.T) {
 	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case `git config --get-regexp ^branch\.blueberries\.(remote|merge)$`:
-			return &outputStub{[]byte(`branch.blueberries.remote origin
+			return &test.OutputStub{[]byte(`branch.blueberries.remote origin
 branch.blueberries.merge refs/heads/blueberries`)}
 		default:
 			panic("not implemented")
@@ -421,7 +422,7 @@ func TestPRView_previewCurrentBranch(t *testing.T) {
 	http.StubResponse(200, jsonFile)
 
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -456,7 +457,7 @@ func TestPRView_previewCurrentBranchWithEmptyBody(t *testing.T) {
 	http.StubResponse(200, jsonFile)
 
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -493,10 +494,10 @@ func TestPRView_currentBranch(t *testing.T) {
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case `git config --get-regexp ^branch\.blueberries\.(remote|merge)$`:
-			return &outputStub{}
+			return &test.OutputStub{}
 		default:
 			seenCmd = cmd
-			return &outputStub{}
+			return &test.OutputStub{}
 		}
 	})
 	defer restoreCmd()
@@ -531,10 +532,10 @@ func TestPRView_noResultsForBranch(t *testing.T) {
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case `git config --get-regexp ^branch\.blueberries\.(remote|merge)$`:
-			return &outputStub{}
+			return &test.OutputStub{}
 		default:
 			seenCmd = cmd
-			return &outputStub{}
+			return &test.OutputStub{}
 		}
 	})
 	defer restoreCmd()
@@ -563,7 +564,7 @@ func TestPRView_numberArg(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -595,7 +596,7 @@ func TestPRView_numberArgWithHash(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -627,7 +628,7 @@ func TestPRView_urlArg(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -661,7 +662,7 @@ func TestPRView_branchArg(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -696,7 +697,7 @@ func TestPRView_branchWithOwnerArg(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cli/cli/context"
+	"github.com/cli/cli/test"
 	"github.com/cli/cli/utils"
 )
 
@@ -117,7 +118,7 @@ func TestRepoFork_in_parent_yes(t *testing.T) {
 	var seenCmds []*exec.Cmd
 	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmds = append(seenCmds, cmd)
-		return &outputStub{}
+		return &test.OutputStub{}
 	})()
 
 	output, err := RunCommand(repoForkCmd, "repo fork --remote")
@@ -156,7 +157,7 @@ func TestRepoFork_outside_yes(t *testing.T) {
 	var seenCmd *exec.Cmd
 	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})()
 
 	output, err := RunCommand(repoForkCmd, "repo fork --clone OWNER/REPO")
@@ -188,7 +189,7 @@ func TestRepoFork_outside_survey_yes(t *testing.T) {
 	var seenCmd *exec.Cmd
 	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})()
 
 	oldConfirm := Confirm
@@ -227,7 +228,7 @@ func TestRepoFork_outside_survey_no(t *testing.T) {
 	cmdRun := false
 	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		cmdRun = true
-		return &outputStub{}
+		return &test.OutputStub{}
 	})()
 
 	oldConfirm := Confirm
@@ -263,7 +264,7 @@ func TestRepoFork_in_parent_survey_yes(t *testing.T) {
 	var seenCmds []*exec.Cmd
 	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmds = append(seenCmds, cmd)
-		return &outputStub{}
+		return &test.OutputStub{}
 	})()
 
 	oldConfirm := Confirm
@@ -311,7 +312,7 @@ func TestRepoFork_in_parent_survey_no(t *testing.T) {
 	cmdRun := false
 	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		cmdRun = true
-		return &outputStub{}
+		return &test.OutputStub{}
 	})()
 
 	oldConfirm := Confirm
@@ -369,7 +370,7 @@ func TestRepoClone(t *testing.T) {
 			var seenCmd *exec.Cmd
 			restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 				seenCmd = cmd
-				return &outputStub{}
+				return &test.OutputStub{}
 			})
 			defer restoreCmd()
 
@@ -409,7 +410,7 @@ func TestRepoCreate(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -474,7 +475,7 @@ func TestRepoCreate_org(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -539,7 +540,7 @@ func TestRepoCreate_orgWithTeam(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -591,7 +592,7 @@ func TestRepoView(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -624,7 +625,7 @@ func TestRepoView_ownerRepo(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 
@@ -656,7 +657,7 @@ func TestRepoView_fullURL(t *testing.T) {
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd
-		return &outputStub{}
+		return &test.OutputStub{}
 	})
 	defer restoreCmd()
 

--- a/command/testing.go
+++ b/command/testing.go
@@ -4,6 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"reflect"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
@@ -21,7 +25,7 @@ type CmdStubber struct {
 	Calls []*exec.Cmd
 }
 
-func InitCmdStubber() (*CmdStubber, func()) {
+func initCmdStubber() (*CmdStubber, func()) {
 	cs := CmdStubber{}
 	teardown := utils.SetPrepareCmd(createStubbedPrepareCmd(&cs))
 	return &cs, teardown
@@ -42,6 +46,57 @@ func createStubbedPrepareCmd(cs *CmdStubber) func(*exec.Cmd) utils.Runnable {
 		}
 		return cs.Stubs[call]
 	}
+}
+
+type askStubber struct {
+	Asks  [][]*survey.Question
+	Count int
+	Stubs [][]*QuestionStub
+}
+
+func initAskStubber() (*askStubber, func()) {
+	origSurveyAsk := SurveyAsk
+	as := askStubber{}
+	SurveyAsk = func(qs []*survey.Question, response interface{}, opts ...survey.AskOpt) error {
+		as.Asks = append(as.Asks, qs)
+		count := as.Count
+		as.Count += 1
+		if count >= len(as.Stubs) {
+			panic(fmt.Sprintf("more asks than stubs. most recent call: %v", qs))
+		}
+
+		// actually set response
+		stubbedQuestions := as.Stubs[count]
+		for i, sq := range stubbedQuestions {
+			q := qs[i]
+			if q.Name != sq.Name {
+				panic(fmt.Sprintf("stubbed question mismatch: %s != %s", q.Name, sq.Name))
+			}
+			if sq.Default {
+				defaultValue := reflect.ValueOf(q.Prompt).Elem().FieldByName("Default")
+				core.WriteAnswer(response, q.Name, defaultValue)
+			} else {
+				core.WriteAnswer(response, q.Name, sq.Value)
+			}
+		}
+
+		return nil
+	}
+	teardown := func() {
+		SurveyAsk = origSurveyAsk
+	}
+	return &as, teardown
+}
+
+type QuestionStub struct {
+	Name    string
+	Value   interface{}
+	Default bool
+}
+
+func (as *askStubber) Stub(stubbedQuestions []*QuestionStub) {
+	// A call to .Ask takes a list of questions; a stub is then a list of questions in the same order.
+	as.Stubs = append(as.Stubs, stubbedQuestions)
 }
 
 func initBlankContext(repo, branch string) {

--- a/command/testing.go
+++ b/command/testing.go
@@ -21,6 +21,12 @@ type CmdStubber struct {
 	Calls []*exec.Cmd
 }
 
+func InitCmdStubber() (*CmdStubber, func()) {
+	cs := CmdStubber{}
+	teardown := utils.SetPrepareCmd(createStubbedPrepareCmd(&cs))
+	return &cs, teardown
+}
+
 func (cs *CmdStubber) Stub(desiredOutput string) {
 	// TODO maybe have some kind of command mapping but going simple for now
 	cs.Stubs = append(cs.Stubs, &test.OutputStub{[]byte(desiredOutput)})

--- a/command/testing.go
+++ b/command/testing.go
@@ -2,10 +2,41 @@ package command
 
 import (
 	"errors"
+	"fmt"
+	"os/exec"
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
+	"github.com/cli/cli/test"
+	"github.com/cli/cli/utils"
 )
+
+// TODO this is split between here and test/helpers.go. I did that because otherwise our test
+// package would have to import utils (for utils.Runnable) which felt wrong. while utils_test
+// currently doesn't import test helpers, i don't see why that ought to be precluded.
+// I'm wondering if this is a case for having a global package just for storing Interfaces.
+type CmdStubber struct {
+	Stubs []*test.OutputStub
+	Count int
+	Calls []*exec.Cmd
+}
+
+func (cs *CmdStubber) Stub(desiredOutput string) {
+	// TODO maybe have some kind of command mapping but going simple for now
+	cs.Stubs = append(cs.Stubs, &test.OutputStub{[]byte(desiredOutput)})
+}
+
+func createStubbedPrepareCmd(cs *CmdStubber) func(*exec.Cmd) utils.Runnable {
+	return func(cmd *exec.Cmd) utils.Runnable {
+		cs.Calls = append(cs.Calls, cmd)
+		call := cs.Count
+		cs.Count += 1
+		if call >= len(cs.Stubs) {
+			panic(fmt.Sprintf("more execs than stubs. most recent call: %v", cmd))
+		}
+		return cs.Stubs[call]
+	}
+}
 
 func initBlankContext(repo, branch string) {
 	initContext = func() context.Context {
@@ -25,19 +56,6 @@ func initFakeHTTP() *api.FakeHTTP {
 		return api.NewClient(api.ReplaceTripper(http)), nil
 	}
 	return http
-}
-
-// outputStub implements a simple utils.Runnable
-type outputStub struct {
-	output []byte
-}
-
-func (s outputStub) Output() ([]byte, error) {
-	return s.output, nil
-}
-
-func (s outputStub) Run() error {
-	return nil
 }
 
 type errorStub struct {

--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -27,7 +27,7 @@ var SurveyAsk = func(qs []*survey.Question, response interface{}, opts ...survey
 	return survey.Ask(qs, response, opts...)
 }
 
-var ConfirmSubmission = func() (Action, error) {
+func confirmSubmission() (Action, error) {
 	confirmAnswers := struct {
 		Confirmation int
 	}{}
@@ -53,7 +53,7 @@ var ConfirmSubmission = func() (Action, error) {
 	return Action(confirmAnswers.Confirmation), nil
 }
 
-var SelectTemplate = func(templatePaths []string) (string, error) {
+func selectTemplate(templatePaths []string) (string, error) {
 	templateResponse := struct {
 		Index int
 	}{}
@@ -89,7 +89,7 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, def
 	if providedBody == "" {
 		if len(templatePaths) > 0 {
 			var err error
-			templateContents, err = SelectTemplate(templatePaths)
+			templateContents, err = selectTemplate(templatePaths)
 			if err != nil {
 				return nil, err
 			}
@@ -136,7 +136,7 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, def
 		inProgress.Body = templateContents
 	}
 
-	confirmA, err := ConfirmSubmission()
+	confirmA, err := confirmSubmission()
 	if err != nil {
 		return nil, fmt.Errorf("unable to confirm: %w", err)
 	}

--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -23,7 +23,7 @@ const (
 	CancelAction
 )
 
-func confirm() (Action, error) {
+var ConfirmSubmission = func() (Action, error) {
 	confirmAnswers := struct {
 		Confirmation int
 	}{}
@@ -49,7 +49,7 @@ func confirm() (Action, error) {
 	return Action(confirmAnswers.Confirmation), nil
 }
 
-func selectTemplate(templatePaths []string) (string, error) {
+var SelectTemplate = func(templatePaths []string) (string, error) {
 	templateResponse := struct {
 		Index int
 	}{}
@@ -77,17 +77,26 @@ func selectTemplate(templatePaths []string) (string, error) {
 	return string(templateContents), nil
 }
 
-func titleBodySurvey(cmd *cobra.Command, providedTitle string, providedBody string, templatePaths []string) (*titleBody, error) {
+var SurveyAsk = func(qs []*survey.Question, response interface{}, opts ...survey.AskOpt) error {
+	return survey.Ask(qs, response, opts...)
+}
+
+func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, defs defaults, templatePaths []string) (*titleBody, error) {
 	var inProgress titleBody
+	inProgress.Title = defs.Title
 	templateContents := ""
 
-	if providedBody == "" && len(templatePaths) > 0 {
-		var err error
-		templateContents, err = selectTemplate(templatePaths)
-		if err != nil {
-			return nil, err
+	if providedBody == "" {
+		if len(templatePaths) > 0 {
+			var err error
+			templateContents, err = SelectTemplate(templatePaths)
+			if err != nil {
+				return nil, err
+			}
+			inProgress.Body = templateContents
+		} else {
+			inProgress.Body = defs.Body
 		}
-		inProgress.Body = templateContents
 	}
 
 	titleQuestion := &survey.Question{
@@ -127,7 +136,7 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle string, providedBody stri
 		inProgress.Body = templateContents
 	}
 
-	confirmA, err := confirm()
+	confirmA, err := ConfirmSubmission()
 	if err != nil {
 		return nil, fmt.Errorf("unable to confirm: %w", err)
 	}

--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -50,8 +50,6 @@ var ConfirmSubmission = func() (Action, error) {
 		return -1, fmt.Errorf("could not prompt: %w", err)
 	}
 
-	fmt.Printf("GOTTA NUMBER %d\n", confirmAnswers.Confirmation)
-
 	return Action(confirmAnswers.Confirmation), nil
 }
 

--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -23,6 +23,10 @@ const (
 	CancelAction
 )
 
+var SurveyAsk = func(qs []*survey.Question, response interface{}, opts ...survey.AskOpt) error {
+	return survey.Ask(qs, response, opts...)
+}
+
 var ConfirmSubmission = func() (Action, error) {
 	confirmAnswers := struct {
 		Confirmation int
@@ -41,10 +45,12 @@ var ConfirmSubmission = func() (Action, error) {
 		},
 	}
 
-	err := survey.Ask(confirmQs, &confirmAnswers)
+	err := SurveyAsk(confirmQs, &confirmAnswers)
 	if err != nil {
 		return -1, fmt.Errorf("could not prompt: %w", err)
 	}
+
+	fmt.Printf("GOTTA NUMBER %d\n", confirmAnswers.Confirmation)
 
 	return Action(confirmAnswers.Confirmation), nil
 }
@@ -68,17 +74,13 @@ var SelectTemplate = func(templatePaths []string) (string, error) {
 				},
 			},
 		}
-		if err := survey.Ask(selectQs, &templateResponse); err != nil {
+		if err := SurveyAsk(selectQs, &templateResponse); err != nil {
 			return "", fmt.Errorf("could not prompt: %w", err)
 		}
 	}
 
 	templateContents := githubtemplate.ExtractContents(templatePaths[templateResponse.Index])
 	return string(templateContents), nil
-}
-
-var SurveyAsk = func(qs []*survey.Question, response interface{}, opts ...survey.AskOpt) error {
-	return survey.Ask(qs, response, opts...)
 }
 
 func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, defs defaults, templatePaths []string) (*titleBody, error) {
@@ -127,7 +129,7 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, def
 		qs = append(qs, bodyQuestion)
 	}
 
-	err := survey.Ask(qs, &inProgress)
+	err := SurveyAsk(qs, &inProgress)
 	if err != nil {
 		return nil, fmt.Errorf("could not prompt: %w", err)
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -71,6 +71,50 @@ func UncommittedChangeCount() (int, error) {
 	return count, nil
 }
 
+type Commit struct {
+	Sha   string
+	Title string
+}
+
+func Commits(baseRef, headRef string) ([]*Commit, error) {
+	logCmd := GitCommand(
+		"log", "--pretty=format:%H,%s",
+		fmt.Sprintf("%s..%s", baseRef, headRef))
+	output, err := utils.PrepareCmd(logCmd).Output()
+	if err != nil {
+		return []*Commit{}, err
+	}
+
+	commits := []*Commit{}
+	sha := 0
+	title := 1
+	for _, line := range outputLines(output) {
+		split := strings.SplitN(line, ",", 2)
+		if len(split) != 2 {
+			continue
+		}
+		commits = append(commits, &Commit{
+			Sha:   split[sha],
+			Title: split[title],
+		})
+	}
+
+	if len(commits) == 0 {
+		return commits, fmt.Errorf("could not find any commits between %s and %s", baseRef, headRef)
+	}
+
+	return commits, nil
+}
+
+func CommitBody(sha string) (string, error) {
+	showCmd := GitCommand("show", "-s", "--pretty=format:%b", sha)
+	output, err := utils.PrepareCmd(showCmd).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
 // Push publishes a git ref to a remote and sets up upstream configuration
 func Push(remote string, ref string) error {
 	pushCmd := GitCommand("push", "--set-upstream", remote, ref)

--- a/git/git.go
+++ b/git/git.go
@@ -78,8 +78,9 @@ type Commit struct {
 
 func Commits(baseRef, headRef string) ([]*Commit, error) {
 	logCmd := GitCommand(
+		"-c", "log.ShowSignature=false",
 		"log", "--pretty=format:%H,%s",
-		fmt.Sprintf("%s..%s", baseRef, headRef))
+		"--cherry", fmt.Sprintf("%s...%s", baseRef, headRef))
 	output, err := utils.PrepareCmd(logCmd).Output()
 	if err != nil {
 		return []*Commit{}, err
@@ -107,7 +108,7 @@ func Commits(baseRef, headRef string) ([]*Commit, error) {
 }
 
 func CommitBody(sha string) (string, error) {
-	showCmd := GitCommand("show", "-s", "--pretty=format:%b", sha)
+	showCmd := GitCommand("-c", "log.ShowSignature=false", "show", "-s", "--pretty=format:%b", sha)
 	output, err := utils.PrepareCmd(showCmd).Output()
 	if err != nil {
 		return "", err

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -1,58 +1,38 @@
 package git
 
 import (
-	"fmt"
-	"os"
-	"regexp"
+	"os/exec"
 	"testing"
 
 	"github.com/cli/cli/test"
+	"github.com/cli/cli/utils"
 )
 
-func TestGitStatusHelperProcess(*testing.T) {
-	if test.SkipTestHelperProcess() {
-		return
-	}
-
-	args := test.GetTestHelperProcessArgs()
-	switch args[0] {
-	case "no changes":
-	case "one change":
-		fmt.Println(" M poem.txt")
-	case "untracked file":
-		fmt.Println(" M poem.txt")
-		fmt.Println("?? new.txt")
-	case "boom":
-		os.Exit(1)
-	}
-	os.Exit(0)
-}
-
 func Test_UncommittedChangeCount(t *testing.T) {
-	origGitCommand := GitCommand
-	defer func() {
-		GitCommand = origGitCommand
-	}()
-
-	cases := map[string]int{
-		"no changes":     0,
-		"one change":     1,
-		"untracked file": 2,
+	type c struct {
+		Label    string
+		Expected int
+		Output   string
+	}
+	cases := []c{
+		c{Label: "no changes", Expected: 0, Output: ""}, // TODO will this fail and be seen as one newline?
+		c{Label: "one change", Expected: 1, Output: " M poem.txt"},
+		c{Label: "untracked file", Expected: 2, Output: " M poem.txt\n?? new.txt"},
 	}
 
-	for k, v := range cases {
-		GitCommand = test.StubExecCommand("TestGitStatusHelperProcess", k)
+	teardown := utils.SetPrepareCmd(func(*exec.Cmd) utils.Runnable {
+		return &test.OutputStub{}
+	})
+	defer teardown()
+
+	for _, v := range cases {
+		_ = utils.SetPrepareCmd(func(*exec.Cmd) utils.Runnable {
+			return &test.OutputStub{[]byte(v.Output)}
+		})
 		ucc, _ := UncommittedChangeCount()
 
-		if ucc != v {
-			t.Errorf("got unexpected ucc value: %d for case %s", ucc, k)
+		if ucc != v.Expected {
+			t.Errorf("got unexpected ucc value: %d for case %s", ucc, v.Label)
 		}
-	}
-
-	GitCommand = test.StubExecCommand("TestGitStatusHelperProcess", "boom")
-	_, err := UncommittedChangeCount()
-	errorRE := regexp.MustCompile(`git\.test(\.exe)?: exit status 1$`)
-	if !errorRE.MatchString(err.Error()) {
-		t.Errorf("got unexpected error message: %s", err)
 	}
 }

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -15,7 +15,7 @@ func Test_UncommittedChangeCount(t *testing.T) {
 		Output   string
 	}
 	cases := []c{
-		c{Label: "no changes", Expected: 0, Output: ""}, // TODO will this fail and be seen as one newline?
+		c{Label: "no changes", Expected: 0, Output: ""},
 		c{Label: "one change", Expected: 1, Output: " M poem.txt"},
 		c{Label: "untracked file", Expected: 2, Output: " M poem.txt\n?? new.txt"},
 	}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -8,36 +8,17 @@ import (
 	"path/filepath"
 )
 
-func GetTestHelperProcessArgs() []string {
-	args := os.Args
-	for len(args) > 0 {
-		if args[0] == "--" {
-			args = args[1:]
-			break
-		}
-		args = args[1:]
-	}
-	return args
+// OutputStub implements a simple utils.Runnable
+type OutputStub struct {
+	Out []byte
 }
 
-func SkipTestHelperProcess() bool {
-	return os.Getenv("GO_WANT_HELPER_PROCESS") != "1"
+func (s OutputStub) Output() ([]byte, error) {
+	return s.Out, nil
 }
 
-func StubExecCommand(testHelper string, desiredOutput string) func(...string) *exec.Cmd {
-	return func(args ...string) *exec.Cmd {
-		cs := []string{
-			fmt.Sprintf("-test.run=%s", testHelper),
-			"--", desiredOutput}
-		cs = append(cs, args...)
-		env := []string{
-			"GO_WANT_HELPER_PROCESS=1",
-		}
-
-		cmd := exec.Command(os.Args[0], cs...)
-		cmd.Env = append(env, os.Environ()...)
-		return cmd
-	}
+func (s OutputStub) Run() error {
+	return nil
 }
 
 type TempGitRepo struct {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -52,6 +53,19 @@ func FuzzyAgo(ago time.Duration) string {
 	}
 
 	return fmtDuration(int(ago.Hours()/24/365), "year")
+}
+
+func Humanize(s string) string {
+	// Replaces - and _ with spaces.
+	replace := "_-"
+	h := func(r rune) rune {
+		if strings.ContainsRune(replace, r) {
+			return ' '
+		}
+		return r
+	}
+
+	return strings.Map(h, s)
 }
 
 func Spinner() *spinner.Spinner {


### PR DESCRIPTION
closes #216

This PR provides defaults for title/body in a PR based on commits.

If 1 commit: PR title is commit message, body is commit body
If >1 commits: PR title is branch, body is listing of commits

Note that in both cases, PR templates supersede the body generation.

## Test suite changes

This PR also adds two improvements to our test suite:

- `AskStubber`. This can be used to simulate user input to a prompt created by `survey`. You can either specify specific values that a user would input or just have  `survey` use the default. 
- `CmdStubber`. This allows us to set up a number of expected calls to external commands. It's pretty simple for now and is intended to just replace the hacky ExecStubber thing that was there previously and add the ability to stub multiple times (instead of a single call to `SetPrepareCmd`.

I didn't add any new test coverage beside the coverage for computing PR defaults but we can now exercise more code paths than we could previously as we had no utility for stubbing `survey.Ask`.

## Demo gif

![defaults](https://user-images.githubusercontent.com/98482/76657197-47319c00-653f-11ea-9a45-9f7244d7ecd8.gif)
