### PR TITLE
Add support for PowerShell completion

### DIFF
--- a/command/completion.go
+++ b/command/completion.go
@@ -9,21 +9,21 @@ import (
 
 func init() {
 	RootCmd.AddCommand(completionCmd)
-	completionCmd.Flags().StringP("shell", "s", "bash", "The type of shell")
+	completionCmd.Flags().StringP("shell", "s", "bash", "Shell type: {bash|zsh|fish|powershell}")
 }
 
 var completionCmd = &cobra.Command{
-	Use:    "completion",
-	Hidden: true,
-	Short:  "Generates completion scripts",
-	Long: `To enable completion in your shell, run:
+	Use:   "completion",
+	Short: "Generate shell completion scripts",
+	Long: `Generate shell completion scripts for GitHub CLI commands.
 
-  eval "$(gh completion)"
+For example, for bash you could add this to your '~/.bash_profile':
 
-You can add that to your '~/.bash_profile' to enable completion whenever you
-start a new shell.
+	eval "$(gh completion)"
 
-When installing with Homebrew, see https://docs.brew.sh/Shell-Completion
+When installing GitHub CLI through a package manager, however, it's possible that
+no additional shell configuration is necessary to gain completion support. For
+Homebrew, see <https://docs.brew.sh/Shell-Completion>
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		shellType, err := cmd.Flags().GetString("shell")

--- a/command/completion.go
+++ b/command/completion.go
@@ -36,6 +36,8 @@ When installing with Homebrew, see https://docs.brew.sh/Shell-Completion
 			return RootCmd.GenBashCompletion(cmd.OutOrStdout())
 		case "zsh":
 			return RootCmd.GenZshCompletion(cmd.OutOrStdout())
+		case "powershell":
+			return RootCmd.GenPowerShellCompletion(cmd.OutOrStdout())
 		case "fish":
 			return cobrafish.GenCompletion(RootCmd, cmd.OutOrStdout())
 		default:

--- a/command/completion_test.go
+++ b/command/completion_test.go
@@ -38,6 +38,17 @@ func TestCompletion_fish(t *testing.T) {
 	}
 }
 
+func TestCompletion_powerShell(t *testing.T) {
+	output, err := RunCommand(completionCmd, `completion -s powershell`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(output.String(), "Register-ArgumentCompleter") {
+		t.Errorf("problem in fish completion:\n%s", output)
+	}
+}
+
 func TestCompletion_unsupported(t *testing.T) {
 	_, err := RunCommand(completionCmd, `completion -s csh`)
 	if err == nil || err.Error() != `unsupported shell type "csh"` {


### PR DESCRIPTION
This also un-hides the `completion` command so it appears in `gh help` and is thus more discoverable.