### PR TITLE
Fixing 2 typos

### DIFF
--- a/api/fake_http.go
+++ b/api/fake_http.go
@@ -13,7 +13,7 @@ import (
 
 // FakeHTTP provides a mechanism by which to stub HTTP responses through
 type FakeHTTP struct {
-	// Requests stores references to sequental requests that RoundTrip has received
+	// Requests stores references to sequential requests that RoundTrip has received
 	Requests      []*http.Request
 	count         int
 	responseStubs []*http.Response

--- a/context/context.go
+++ b/context/context.go
@@ -25,7 +25,7 @@ type Context interface {
 }
 
 // cap the number of git remotes looked up, since the user might have an
-// unusally large number of git remotes
+// unusually large number of git remotes
 const maxRemotesForLookup = 5
 
 func ResolveRemotesToRepos(remotes Remotes, client *api.Client, base string) (ResolvedRemotes, error) {


### PR DESCRIPTION
I ran a [typo checker](https://github.com/marketplace/typo-ci) over the codebase & spotted two spelling mistakes within the code.  

This PR corrects them (They were in comments, so not a big change).