### PR TITLE
Fix setting homepage URL in `repo create`

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -224,7 +224,7 @@ func ForkRepo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 type RepoCreateInput struct {
 	Name        string `json:"name"`
 	Visibility  string `json:"visibility"`
-	Homepage    string `json:"homepage,omitempty"`
+	HomepageURL string `json:"homepageUrl,omitempty"`
 	Description string `json:"description,omitempty"`
 
 	OwnerID string `json:"ownerId,omitempty"`

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+)
+
+func Test_RepoCreate(t *testing.T) {
+	http := &FakeHTTP{}
+	client := NewClient(ReplaceTripper(http))
+
+	http.StubResponse(200, bytes.NewBufferString(`{}`))
+
+	input := RepoCreateInput{
+		Description: "roasted chesnuts",
+		HomepageURL: "http://example.com",
+	}
+
+	_, err := RepoCreate(client, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(http.Requests) != 1 {
+		t.Fatalf("expected 1 HTTP request, seen %d", len(http.Requests))
+	}
+
+	var reqBody struct {
+		Query     string
+		Variables struct {
+			Input map[string]interface{}
+		}
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+	json.Unmarshal(bodyBytes, &reqBody)
+	if description := reqBody.Variables.Input["description"].(string); description != "roasted chesnuts" {
+		t.Errorf("expected description to be %q, got %q", "roasted chesnuts", description)
+	}
+	if homepage := reqBody.Variables.Input["homepageUrl"].(string); homepage != "http://example.com" {
+		t.Errorf("expected homepageUrl to be %q, got %q", "http://example.com", homepage)
+	}
+}

--- a/command/repo.go
+++ b/command/repo.go
@@ -158,7 +158,7 @@ func repoCreate(cmd *cobra.Command, args []string) error {
 		OwnerID:          orgName,
 		TeamID:           teamSlug,
 		Description:      description,
-		Homepage:         homepage,
+		HomepageURL:      homepage,
 		HasIssuesEnabled: hasIssuesEnabled,
 		HasWikiEnabled:   hasWikiEnabled,
 	}


### PR DESCRIPTION
We were passing the wrong parameter name.

Fixes #608, followup  to https://github.com/cli/cli/pull/547