### PR TITLE
Ensure `pr create` validates all inputs before forking+pushing

### DIFF
--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -119,6 +119,9 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("could not parse draft: %w", err)
 	}
+	if isDraft && isWeb {
+		return errors.New("the --draft flag is not supported with --web")
+	}
 
 	didForkRepo := false
 	var headRemote *context.Remote


### PR DESCRIPTION
If there are any errors related to user input, or if the PR create operation has been cancelled via the interactive survey, avoid forking the repo or pushing the branch.

The diff might seem large, but this only swaps the old implemenation around.

Fixes #482, fixes #558, closes #615