### PR TITLE
Add filter issues by author

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -55,9 +55,6 @@ const fragments = `
 			}
 			totalCount
 		}
-		author {
-			login
-		}
 	}
 `
 

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -55,6 +55,9 @@ const fragments = `
 			}
 			totalCount
 		}
+		author {
+			login
+		}
 	}
 `
 
@@ -171,7 +174,7 @@ func IssueStatus(client *Client, repo ghrepo.Interface, currentUsername string) 
 	return &payload, nil
 }
 
-func IssueList(client *Client, repo ghrepo.Interface, state string, labels []string, assigneeString string, limit int) ([]Issue, error) {
+func IssueList(client *Client, repo ghrepo.Interface, state string, labels []string, assigneeString string, limit int, authorString string) ([]Issue, error) {
 	var states []string
 	switch state {
 	case "open", "":
@@ -185,10 +188,10 @@ func IssueList(client *Client, repo ghrepo.Interface, state string, labels []str
 	}
 
 	query := fragments + `
-	query($owner: String!, $repo: String!, $limit: Int, $endCursor: String, $states: [IssueState!] = OPEN, $labels: [String!], $assignee: String) {
+	query($owner: String!, $repo: String!, $limit: Int, $endCursor: String, $states: [IssueState!] = OPEN, $labels: [String!], $assignee: String, $author: String) {
 		repository(owner: $owner, name: $repo) {
 			hasIssuesEnabled
-			issues(first: $limit, after: $endCursor, orderBy: {field: CREATED_AT, direction: DESC}, states: $states, labels: $labels, filterBy: {assignee: $assignee}) {
+			issues(first: $limit, after: $endCursor, orderBy: {field: CREATED_AT, direction: DESC}, states: $states, labels: $labels, filterBy: {assignee: $assignee, createdBy: $author}) {
 				nodes {
 					...issue
 				}
@@ -211,6 +214,9 @@ func IssueList(client *Client, repo ghrepo.Interface, state string, labels []str
 	}
 	if assigneeString != "" {
 		variables["assignee"] = assigneeString
+	}
+	if authorString != "" {
+		variables["author"] = authorString
 	}
 
 	var response struct {

--- a/api/queries_issue_test.go
+++ b/api/queries_issue_test.go
@@ -38,7 +38,7 @@ func TestIssueList(t *testing.T) {
 	} } }
 	`))
 
-	_, err := IssueList(client, ghrepo.FromFullName("OWNER/REPO"), "open", []string{}, "", 251)
+	_, err := IssueList(client, ghrepo.FromFullName("OWNER/REPO"), "open", []string{}, "", 251, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/command/issue.go
+++ b/command/issue.go
@@ -37,6 +37,7 @@ func init() {
 	issueListCmd.Flags().StringSliceP("label", "l", nil, "Filter by label")
 	issueListCmd.Flags().StringP("state", "s", "", "Filter by state: {open|closed|all}")
 	issueListCmd.Flags().IntP("limit", "L", 30, "Maximum number of issues to fetch")
+	issueListCmd.Flags().StringP("author", "A", "", "Filter by author")
 
 	issueViewCmd.Flags().BoolP("preview", "p", false, "Display preview of issue content")
 }
@@ -109,9 +110,14 @@ func issueList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	author, err := cmd.Flags().GetString("author")
+	if err != nil {
+		return err
+	}
+
 	fmt.Fprintf(colorableErr(cmd), "\nIssues for %s\n\n", ghrepo.FullName(baseRepo))
 
-	issues, err := api.IssueList(apiClient, baseRepo, state, labels, assignee, limit)
+	issues, err := api.IssueList(apiClient, baseRepo, state, labels, assignee, limit, author)
 	if err != nil {
 		return err
 	}

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -136,7 +136,7 @@ func TestIssueList_withFlags(t *testing.T) {
 	} } }
 	`))
 
-	output, err := RunCommand(issueListCmd, "issue list -a probablyCher -l web,bug -s open")
+	output, err := RunCommand(issueListCmd, "issue list -a probablyCher -l web,bug -s open -A foo")
 	if err != nil {
 		t.Errorf("error running command `issue list`: %v", err)
 	}
@@ -154,6 +154,7 @@ No issues match your search
 			Assignee string
 			Labels   []string
 			States   []string
+			Author   string
 		}
 	}{}
 	json.Unmarshal(bodyBytes, &reqBody)
@@ -161,6 +162,7 @@ No issues match your search
 	eq(t, reqBody.Variables.Assignee, "probablyCher")
 	eq(t, reqBody.Variables.Labels, []string{"web", "bug"})
 	eq(t, reqBody.Variables.States, []string{"OPEN"})
+	eq(t, reqBody.Variables.Author, "foo")
 }
 
 func TestIssueList_nullAssigneeLabels(t *testing.T) {

--- a/test/fixtures/issueList.json
+++ b/test/fixtures/issueList.json
@@ -15,9 +15,6 @@
                   }
                 ],
                 "totalCount": 1
-              },
-              "author": {
-                "login": "foo"
               }
           },
           {
@@ -31,9 +28,6 @@
                   }
                 ],
                 "totalCount": 1
-              },
-              "author": {
-                "login": "bar"
               }
           },
           {
@@ -47,9 +41,6 @@
                   }
                 ],
                 "totalCount": 1
-              },
-              "author": {
-                "login": "bar"
               }
           }
         ]

--- a/test/fixtures/issueList.json
+++ b/test/fixtures/issueList.json
@@ -15,6 +15,9 @@
                   }
                 ],
                 "totalCount": 1
+              },
+              "author": {
+                "login": "foo"
               }
           },
           {
@@ -28,6 +31,9 @@
                   }
                 ],
                 "totalCount": 1
+              },
+              "author": {
+                "login": "bar"
               }
           },
           {
@@ -41,6 +47,9 @@
                   }
                 ],
                 "totalCount": 1
+              },
+              "author": {
+                "login": "bar"
               }
           }
         ]


### PR DESCRIPTION
This provides support for filtering issues by author with the `issue list` command.

The flags are `-A` and `--author`. Fixes #389.

Edit: PR support for filtering by author isn't available from the API so that'll need to happen in a follow up PR. I (Billy) updated #389 to just be scoped to issues so this can close that issue when it's merged.