### PR TITLE
Stop opting into API previews that have since shipped

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -136,7 +136,6 @@ var apiClientForContext = func(ctx context.Context) (*api.Client, error) {
 		// antiope-preview: Checks
 		// shadow-cat-preview: Draft pull requests
 		api.AddHeader("Accept", "application/vnd.github.antiope-preview+json, application/vnd.github.shadow-cat-preview"),
-		api.AddHeader("GraphQL-Features", "pe_mobile"),
 	)
 
 	return api.NewClient(opts...), nil

--- a/command/root.go
+++ b/command/root.go
@@ -134,8 +134,7 @@ var apiClientForContext = func(ctx context.Context) (*api.Client, error) {
 		api.AddHeader("Authorization", fmt.Sprintf("token %s", token)),
 		api.AddHeader("User-Agent", fmt.Sprintf("GitHub CLI %s", Version)),
 		// antiope-preview: Checks
-		// shadow-cat-preview: Draft pull requests
-		api.AddHeader("Accept", "application/vnd.github.antiope-preview+json, application/vnd.github.shadow-cat-preview"),
+		api.AddHeader("Accept", "application/vnd.github.antiope-preview+json"),
 	)
 
 	return api.NewClient(opts...), nil


### PR DESCRIPTION
- Draft pull requests (previously under `shadow-cat` preview) are now fully available
- PR `reviewDecision` and `statusCheckRollup` (previously under `pe_mobile` feature flag) are now fully available, although the latter still requires `antiope` preview for the time being

No longer relying on the `pe_mobile` feature flag means that people can now use Personal Access Tokens with GitHub CLI https://github.com/cli/cli/issues/297#issuecomment-587708363 https://github.com/cli/cli/issues/273#issuecomment-587703737