### PR TITLE
Verify repository before viewing in the browser #598

### DIFF
--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -579,10 +579,14 @@ func TestRepoCreate_orgWithTeam(t *testing.T) {
 	}
 }
 
+
 func TestRepoView(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ }
+	`))
 
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
@@ -606,13 +610,17 @@ func TestRepoView(t *testing.T) {
 	eq(t, url, "https://github.com/OWNER/REPO")
 }
 
+
 func TestRepoView_ownerRepo(t *testing.T) {
 	ctx := context.NewBlank()
 	ctx.SetBranch("master")
 	initContext = func() context.Context {
 		return ctx
 	}
-	initFakeHTTP()
+	http := initFakeHTTP()
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ }
+	`))
 
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
@@ -642,8 +650,10 @@ func TestRepoView_fullURL(t *testing.T) {
 	initContext = func() context.Context {
 		return ctx
 	}
-	initFakeHTTP()
-
+	http := initFakeHTTP()
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ }
+	`))
 	var seenCmd *exec.Cmd
 	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
 		seenCmd = cmd

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -610,7 +610,6 @@ func TestRepoView(t *testing.T) {
 	eq(t, url, "https://github.com/OWNER/REPO")
 }
 
-
 func TestRepoView_ownerRepo(t *testing.T) {
 	ctx := context.NewBlank()
 	ctx.SetBranch("master")


### PR DESCRIPTION
To block or ignore the invalid/ fake repo URL from opening the browser while running,
`gh repo view [repo_url]`

Fixes #598 
