### PR TITLE
Add SSH remote if maintainer can modify

### DIFF
--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -78,6 +78,9 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 		remote := baseRemote.Name
 		mergeRef := ref
 		if pr.MaintainerCanModify {
+			remote = fmt.Sprintf("git@github.com:%s/%s.git", pr.HeadRepositoryOwner.Login, pr.HeadRepository.Name)
+			mergeRef = fmt.Sprintf("refs/heads/%s", pr.HeadRefName)
+		} else {
 			remote = fmt.Sprintf("https://github.com/%s/%s.git", pr.HeadRepositoryOwner.Login, pr.HeadRepository.Name)
 			mergeRef = fmt.Sprintf("refs/heads/%s", pr.HeadRefName)
 		}

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -312,8 +312,8 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 	eq(t, len(ranCommands), 4)
 	eq(t, strings.Join(ranCommands[0], " "), "git fetch origin refs/pull/123/head:feature")
 	eq(t, strings.Join(ranCommands[1], " "), "git checkout feature")
-	eq(t, strings.Join(ranCommands[2], " "), "git config branch.feature.remote origin")
-	eq(t, strings.Join(ranCommands[3], " "), "git config branch.feature.merge refs/pull/123/head")
+	eq(t, strings.Join(ranCommands[2], " "), "git config branch.feature.remote https://github.com/hubot/REPO.git")
+	eq(t, strings.Join(ranCommands[3], " "), "git config branch.feature.merge refs/heads/feature")
 }
 
 func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
@@ -464,6 +464,6 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 	eq(t, len(ranCommands), 4)
 	eq(t, strings.Join(ranCommands[0], " "), "git fetch origin refs/pull/123/head:feature")
 	eq(t, strings.Join(ranCommands[1], " "), "git checkout feature")
-	eq(t, strings.Join(ranCommands[2], " "), "git config branch.feature.remote https://github.com/hubot/REPO.git")
+	eq(t, strings.Join(ranCommands[2], " "), "git config branch.feature.remote git@github.com:hubot/REPO.git")
 	eq(t, strings.Join(ranCommands[3], " "), "git config branch.feature.merge refs/heads/feature")
 }


### PR DESCRIPTION
`hub` already adds the remote with SSH url, would be nice to have the same functionality in `gh`.