### PR TITLE
Use git remotes as base repo in `repo view`

### DIFF
--- a/command/repo.go
+++ b/command/repo.go
@@ -389,7 +389,7 @@ func repoView(cmd *cobra.Command, args []string) error {
 	var toView ghrepo.Interface
 	if len(args) == 0 {
 		var err error
-		toView, err = determineBaseRepo(cmd, ctx)
+		toView, err = ctx.BaseRepo()
 		if err != nil {
 			return err
 		}

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -579,11 +579,9 @@ func TestRepoCreate_orgWithTeam(t *testing.T) {
 	}
 }
 
-
 func TestRepoView(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ }
 	`))


### PR DESCRIPTION
We used to do `determineBaseRepo` here, but I think that advanced base repository resolution to potentially discover the parent repository as base is not really needed in this command.

If I was in a cloned fork, for example, and did `repo view`, I would expect that my fork's repository page is viewed instead of that of the parent. But I'm not 100% sure whether this is correct assumption either. Thoughts?