### PR TITLE
Only show the most recent PR for the current branch

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -98,8 +98,8 @@ func prStatus(cmd *cobra.Command, args []string) error {
 	fmt.Fprintln(out, "")
 
 	printHeader(out, "Current branch")
-	if prPayload.CurrentPRs != nil {
-		printPrs(out, 0, prPayload.CurrentPRs[0]) // Assume it is the most recent PR for the current branch
+	if prPayload.CurrentPR != nil {
+		printPrs(out, 0, *prPayload.CurrentPR)
 	} else {
 		message := fmt.Sprintf("  There is no pull request associated with %s", utils.Cyan("["+currentPRHeadRef+"]"))
 		printMessage(out, message)

--- a/command/pr.go
+++ b/command/pr.go
@@ -99,7 +99,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 
 	printHeader(out, "Current branch")
 	if prPayload.CurrentPRs != nil {
-		printPrs(out, 0, prPayload.CurrentPRs...)
+		printPrs(out, 0, prPayload.CurrentPRs[0]) // Assume it is the most recent PR for the current branch
 	} else {
 		message := fmt.Sprintf("  There is no pull request associated with %s", utils.Cyan("["+currentPRHeadRef+"]"))
 		printMessage(out, message)

--- a/test/fixtures/prStatusClosedMerged.json
+++ b/test/fixtures/prStatusClosedMerged.json
@@ -1,66 +1,65 @@
 {
-	"data": {
-	  "repository": {
-		"pullRequests": {
-		  "totalCount": 1,
-		  "edges": [
-			{
-				"node": {
-				  "number": 8,
-				  "title": "Blueberries are a good fruit",
-				  "state": "OPEN",
-				  "url": "https://github.com/cli/cli/pull/8",
-				  "headRefName": "blueberries",
-				  "reviewDecision": "CHANGES_REQUESTED",
-				  "commits": {
-					"nodes": [
-					  {
-						"commit": {
-						  "statusCheckRollup": {
-							"contexts": {
-							  "nodes": [
-								{
-								  "state": "SUCCESS"
-								}
-							  ]
-							}
-						  }
-						}
-					  }
-					]
-				  }
-				}
-			  }
-		  ]
-		}
-	  },
-	  "viewerCreated": {
-		"totalCount": 1,
-		"edges": [
-		  {
-			"node": {
-			  "number": 8,
-			  "state": "CLOSED",
-			  "title": "Strawberries are not actually berries",
-			  "url": "https://github.com/cli/cli/pull/8",
-			  "headRefName": "strawberries"
-			}
-		  },
-		  {
-			"node": {
-			  "number": 8,
-			  "state": "MERGED",
-			  "title": "Bananas are berries",
-			  "url": "https://github.com/cli/cli/pull/8",
-			  "headRefName": "banananana"
-			}
-		  }
-		]
-	  },
-	  "reviewRequested": {
-		"totalCount": 0,
-		"edges": []
-	  }
-	}
+  "data": {
+    "repository": {
+      "pullRequests": {
+        "totalCount": 1,
+        "edges": [
+          {
+            "node": {
+              "number": 8,
+              "title": "Blueberries are a good fruit",
+              "state": "OPEN",
+              "url": "https://github.com/cli/cli/pull/8",
+              "headRefName": "blueberries",
+              "reviewDecision": "CHANGES_REQUESTED",
+              "commits": {
+                "nodes": [
+                  {
+                    "commit": {
+                      "statusCheckRollup": {
+                        "contexts": {
+                          "nodes": [
+                            {
+                              "state": "SUCCESS"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "viewerCreated": {
+      "totalCount": 1,
+      "edges": [
+        {
+          "node": {
+            "number": 10,
+            "state": "CLOSED",
+            "title": "Strawberries are not actually berries",
+            "url": "https://github.com/cli/cli/pull/10",
+            "headRefName": "strawberries"
+          }
+        },
+        {
+          "node": {
+            "number": 9,
+            "state": "MERGED",
+            "title": "Bananas are berries",
+            "url": "https://github.com/cli/cli/pull/9",
+            "headRefName": "banananana"
+          }
+        }
+      ]
+    },
+    "reviewRequested": {
+      "totalCount": 0,
+      "edges": []
+    }
   }
-  
+}

--- a/test/fixtures/prStatusCurrentBranch.json
+++ b/test/fixtures/prStatusCurrentBranch.json
@@ -1,0 +1,61 @@
+{
+  "data": {
+    "repository": {
+      "pullRequests": {
+        "totalCount": 3,
+        "edges": [
+          {
+            "node": {
+              "number": 10,
+              "title": "Blueberries are certainly a good fruit",
+              "state": "OPEN",
+              "url": "https://github.com/PARENT/REPO/pull/10",
+              "headRefName": "blueberries",
+              "isDraft": false,
+              "headRepositoryOwner": {
+                "login": "OWNER/REPO"
+              },
+              "isCrossRepository": false
+            }
+          },
+          {
+            "node": {
+              "number": 9,
+              "title": "Blueberries are a good fruit",
+              "state": "MERGED",
+              "url": "https://github.com/PARENT/REPO/pull/9",
+              "headRefName": "blueberries",
+              "isDraft": false,
+              "headRepositoryOwner": {
+                "login": "OWNER/REPO"
+              },
+              "isCrossRepository": false
+            }
+          },
+          {
+            "node": {
+              "number": 8,
+              "title": "Blueberries are probably a good fruit",
+              "state": "CLOSED",
+              "url": "https://github.com/PARENT/REPO/pull/8",
+              "headRefName": "blueberries",
+              "isDraft": false,
+              "headRepositoryOwner": {
+                "login": "OWNER/REPO"
+              },
+              "isCrossRepository": false
+            }
+          }
+        ]
+      }
+    },
+    "viewerCreated": {
+      "totalCount": 0,
+      "edges": []
+    },
+    "reviewRequested": {
+      "totalCount": 0,
+      "edges": []
+    }
+  }
+}


### PR DESCRIPTION
Closes #621

With this fix, `gh` only shows the most recent PR for the current branch as shown below (`foo` branch has `Merged` and `Closed` PRs in this case). I added a test along with a new test data (`test/fixtures/prStatusCurrentBranch.json`) to verify it.
![Screenshot 2020-03-12 at 22 58 24](https://user-images.githubusercontent.com/5877477/76529214-5409ad80-64b5-11ea-82d2-6b3c568a63be.png)

It shows the most recent PR regardless its status.
![Screenshot 2020-03-12 at 22 58 50](https://user-images.githubusercontent.com/5877477/76529578-d09c8c00-64b5-11ea-98f4-067001ba59d0.png)
![Screenshot 2020-03-12 at 22 58 33](https://user-images.githubusercontent.com/5877477/76529583-d1cdb900-64b5-11ea-8d03-b89fc2b24170.png)
![Screenshot 2020-03-12 at 22 58 15](https://user-images.githubusercontent.com/5877477/76529598-d6926d00-64b5-11ea-9673-65c4cba570c6.png)
![Screenshot 2020-03-13 at 9 56 37](https://user-images.githubusercontent.com/5877477/76579817-f440f000-6510-11ea-96b5-3750fac45ae4.png)



(Changes on `test/fixtures/prStatusClosedMerged.json` are only for indentations and PR numbers.)