### PR TITLE
Avoid redirecting to `localhost` during authorization flow

### DIFF
--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -47,7 +47,7 @@ func (oa *OAuthFlow) ObtainAccessToken() (accessToken string, err error) {
 
 	q := url.Values{}
 	q.Set("client_id", oa.ClientID)
-	q.Set("redirect_uri", fmt.Sprintf("http://localhost:%d/callback", port))
+	q.Set("redirect_uri", fmt.Sprintf("http://127.0.0.1:%d/callback", port))
 	// TODO: make scopes configurable
 	q.Set("scope", "repo")
 	q.Set("state", state)


### PR DESCRIPTION
Web developers who have had at any previous point ran an application on `http://localhost` that enabled HSTS (HTTP Strict Transport Security) will find themselves unable to authenticate because their browser (typically Safari) will keep redirecting them to `https://localhost`, which isn't handled by our local server.

This switches the authorization callback to be to `127.0.0.1`, which should be equivalent to `localhost`, but not subject to HSTS.

The GitHub CLI OAuth apps have been edited to add `http://127.0.0.1/callback` as an additional allow-listed callback URL. /cc @ptoomey3

Fixes #616