### PR TITLE
feat(repo): auto pick clone protocol

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -69,6 +69,8 @@ func GitHubRepo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 		repository(owner: $owner, name: $name) {
 			id
 			hasIssuesEnabled
+			isPrivate
+			viewerPermission
 		}
 	}`
 	variables := map[string]interface{}{


### PR DESCRIPTION
Implements a handy feature from inspired by `hub`, where the protocol
for cloning is automatically set so a sensible default:

- `ssh://` for everything private or if you have push access. SSH is
most common in this case.
- `git://` for everything else so you can clone without an SSH key
available

Using the new flag `--protocol` / `-p` this behavior can be overridden.