### PR TITLE
Show the state (open, closed, merged) in issue view and pr view

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -24,6 +24,7 @@ type Issue struct {
 	URL       string
 	State     string
 	Body      string
+	CreatedAt time.Time
 	UpdatedAt time.Time
 	Comments  struct {
 		TotalCount int
@@ -275,6 +276,7 @@ func IssueByNumber(client *Client, repo ghrepo.Interface, number int) (*Issue, e
 			hasIssuesEnabled
 			issue(number: $issue_number) {
 				title
+				state
 				body
 				author {
 					login
@@ -289,6 +291,7 @@ func IssueByNumber(client *Client, repo ghrepo.Interface, number int) (*Issue, e
 				}
 				number
 				url
+				createdAt
 			}
 		}
 	}`

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -301,6 +301,7 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 				url
 				number
 				title
+				state
 				body
 				author {
 				  login
@@ -356,6 +357,7 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, branch string) 
 				nodes {
 					number
 					title
+					state
 					body
 					author {
 						login

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -321,6 +321,7 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 					}
 				}
 				isCrossRepository
+				isDraft
 				maintainerCanModify
 			}
 		}

--- a/command/issue.go
+++ b/command/issue.go
@@ -261,13 +261,13 @@ func printIssuePreview(out io.Writer, issue *api.Issue) error {
 	fmt.Fprintln(out, utils.Bold(issue.Title))
 	fmt.Fprintf(out, "%s", issueStateColorFunc(issue.State))
 	fmt.Fprint(out, utils.Gray(fmt.Sprintf(
-		" • %s opened %s • %s • ",
+		" • %s opened %s • %s",
 		issue.Author.Login,
 		utils.FuzzyAgo(ago),
 		utils.Pluralize(issue.Comments.TotalCount, "comment"),
 	)))
 	if coloredLabels != "" {
-		fmt.Fprintf(out, "%s", utils.Gray(coloredLabels))
+		fmt.Fprintf(out, utils.Gray(fmt.Sprintf(" • %s", coloredLabels)))
 	}
 	fmt.Fprintf(out, "\n")
 

--- a/command/issue.go
+++ b/command/issue.go
@@ -248,7 +248,7 @@ func issueView(cmd *cobra.Command, args []string) error {
 
 }
 
-func IssueStateTitleWithColor(state string) string {
+func issueStateTitleWithColor(state string) string {
 	colorFunc := utils.ColorFuncForState(state)
 	return colorFunc(strings.Title(strings.ToLower(state)))
 }
@@ -258,7 +258,7 @@ func printIssuePreview(out io.Writer, issue *api.Issue) error {
 	ago := now.Sub(issue.CreatedAt)
 
 	fmt.Fprintln(out, utils.Bold(issue.Title))
-	fmt.Fprintf(out, "%s", IssueStateTitleWithColor(issue.State))
+	fmt.Fprintf(out, "%s", issueStateTitleWithColor(issue.State))
 	fmt.Fprintln(out, utils.Gray(fmt.Sprintf(
 		" • %s opened %s • %s",
 		issue.Author.Login,

--- a/command/issue.go
+++ b/command/issue.go
@@ -254,26 +254,17 @@ func IssueStateTitleWithColor(state string) string {
 }
 
 func printIssuePreview(out io.Writer, issue *api.Issue) error {
-	coloredLabels := labelList(*issue)
-	if coloredLabels != "" {
-		coloredLabels = fmt.Sprintf("%s", coloredLabels)
-	}
-
 	now := time.Now()
 	ago := now.Sub(issue.CreatedAt)
 
 	fmt.Fprintln(out, utils.Bold(issue.Title))
 	fmt.Fprintf(out, "%s", IssueStateTitleWithColor(issue.State))
-	fmt.Fprint(out, utils.Gray(fmt.Sprintf(
+	fmt.Fprintln(out, utils.Gray(fmt.Sprintf(
 		" • %s opened %s • %s",
 		issue.Author.Login,
 		utils.FuzzyAgo(ago),
 		utils.Pluralize(issue.Comments.TotalCount, "comment"),
 	)))
-	if coloredLabels != "" {
-		fmt.Fprintf(out, utils.Gray(fmt.Sprintf(" • %s", coloredLabels)))
-	}
-	fmt.Fprintf(out, "\n")
 
 	if issue.Body != "" {
 		fmt.Fprintln(out)

--- a/command/issue.go
+++ b/command/issue.go
@@ -251,16 +251,25 @@ func issueView(cmd *cobra.Command, args []string) error {
 func printIssuePreview(out io.Writer, issue *api.Issue) error {
 	coloredLabels := labelList(*issue)
 	if coloredLabels != "" {
-		coloredLabels = utils.Gray(fmt.Sprintf("(%s)", coloredLabels))
+		coloredLabels = fmt.Sprintf("%s", coloredLabels)
 	}
 
+	now := time.Now()
+	ago := now.Sub(issue.CreatedAt)
+	issueStateColorFunc := utils.ColorFuncForState(issue.State)
+
 	fmt.Fprintln(out, utils.Bold(issue.Title))
-	fmt.Fprintln(out, utils.Gray(fmt.Sprintf(
-		"opened by %s. %s. %s",
+	fmt.Fprintf(out, "%s", issueStateColorFunc(issue.State))
+	fmt.Fprint(out, utils.Gray(fmt.Sprintf(
+		" • %s opened %s • %s • ",
 		issue.Author.Login,
+		utils.FuzzyAgo(ago),
 		utils.Pluralize(issue.Comments.TotalCount, "comment"),
-		coloredLabels,
 	)))
+	if coloredLabels != "" {
+		fmt.Fprintf(out, "%s", utils.Gray(coloredLabels))
+	}
+	fmt.Fprintf(out, "\n")
 
 	if issue.Body != "" {
 		fmt.Fprintln(out)

--- a/command/issue.go
+++ b/command/issue.go
@@ -148,7 +148,7 @@ func issueList(cmd *cobra.Command, args []string) error {
 		if labels != "" && table.IsTTY() {
 			labels = fmt.Sprintf("(%s)", labels)
 		}
-		table.AddField(issueNum, nil, colorFuncForState(issue.State))
+		table.AddField(issueNum, nil, utils.ColorFuncForState(issue.State))
 		table.AddField(replaceExcessiveWhitespace(issue.Title), nil, nil)
 		table.AddField(labels, nil, utils.Gray)
 		table.EndRow()

--- a/command/issue.go
+++ b/command/issue.go
@@ -229,7 +229,7 @@ func issueView(cmd *cobra.Command, args []string) error {
 }
 
 func issueStateTitleWithColor(state string) string {
-	colorFunc := utils.ColorFuncForState(state)
+	colorFunc := colorFuncForState(state)
 	return colorFunc(strings.Title(strings.ToLower(state)))
 }
 
@@ -425,7 +425,7 @@ func printIssues(w io.Writer, prefix string, totalCount int, issues []api.Issue)
 		}
 		now := time.Now()
 		ago := now.Sub(issue.UpdatedAt)
-		table.AddField(issueNum, nil, utils.ColorFuncForState(issue.State))
+		table.AddField(issueNum, nil, colorFuncForState(issue.State))
 		table.AddField(replaceExcessiveWhitespace(issue.Title), nil, nil)
 		table.AddField(labels, nil, utils.Gray)
 		table.AddField(utils.FuzzyAgo(ago), nil, utils.Gray)

--- a/command/issue.go
+++ b/command/issue.go
@@ -248,6 +248,11 @@ func issueView(cmd *cobra.Command, args []string) error {
 
 }
 
+func IssueStateTitleWithColor(state string) string {
+	colorFunc := utils.ColorFuncForState(state)
+	return colorFunc(strings.Title(strings.ToLower(state)))
+}
+
 func printIssuePreview(out io.Writer, issue *api.Issue) error {
 	coloredLabels := labelList(*issue)
 	if coloredLabels != "" {
@@ -256,10 +261,9 @@ func printIssuePreview(out io.Writer, issue *api.Issue) error {
 
 	now := time.Now()
 	ago := now.Sub(issue.CreatedAt)
-	issueStateColorFunc := utils.ColorFuncForState(issue.State)
 
 	fmt.Fprintln(out, utils.Bold(issue.Title))
-	fmt.Fprintf(out, "%s", issueStateColorFunc(issue.State))
+	fmt.Fprintf(out, "%s", IssueStateTitleWithColor(issue.State))
 	fmt.Fprint(out, utils.Gray(fmt.Sprintf(
 		" • %s opened %s • %s",
 		issue.Author.Login,

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -309,6 +309,36 @@ func TestIssueView_preview(t *testing.T) {
 	}
 }
 
+func TestIssueView_previewClosedState(t *testing.T) {
+	initBlankContext("OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	jsonFile, _ := os.Open("../test/fixtures/issueView_previewClosedState.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
+
+	output, err := RunCommand(issueViewCmd, "issue view -p 123")
+	if err != nil {
+		t.Errorf("error running command `issue view`: %v", err)
+	}
+
+	eq(t, output.Stderr(), "")
+
+	expectedLines := []*regexp.Regexp{
+		regexp.MustCompile(`ix of coins`),
+		regexp.MustCompile(`CLOSED • marseilles opened about 292 years ago • 9 comments • tarot`),
+		regexp.MustCompile(`bold story`),
+		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
+	}
+	for _, r := range expectedLines {
+		if !r.MatchString(output.String()) {
+			t.Errorf("output did not match regexp /%s/\n> output\n%s\n", r, output)
+			return
+		}
+	}
+}
+
 func TestIssueView_previewWithEmptyBody(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -309,6 +309,36 @@ func TestIssueView_preview(t *testing.T) {
 	}
 }
 
+func TestIssueView_previewNoLabel(t *testing.T) {
+	initBlankContext("OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	jsonFile, _ := os.Open("../test/fixtures/issueView_previewNoLabel.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
+
+	output, err := RunCommand(issueViewCmd, "issue view -p 123")
+	if err != nil {
+		t.Errorf("error running command `issue view`: %v", err)
+	}
+
+	eq(t, output.Stderr(), "")
+
+	expectedLines := []*regexp.Regexp{
+		regexp.MustCompile(`ix of coins`),
+		regexp.MustCompile(`OPEN • marseilles opened about 292 years ago • 9 comments`),
+		regexp.MustCompile(`bold story`),
+		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
+	}
+	for _, r := range expectedLines {
+		if !r.MatchString(output.String()) {
+			t.Errorf("output did not match regexp /%s/\n> output\n%s\n", r, output)
+			return
+		}
+	}
+}
+
 func TestIssueView_previewClosedState(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -297,7 +297,7 @@ func TestIssueView_preview(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`ix of coins`),
-		regexp.MustCompile(`Open • marseilles opened about 292 years ago • 9 comments • tarot`),
+		regexp.MustCompile(`Open • marseilles opened about 292 years ago • 9 comments`),
 		regexp.MustCompile(`bold story`),
 		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
 	}
@@ -357,7 +357,7 @@ func TestIssueView_previewClosedState(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`ix of coins`),
-		regexp.MustCompile(`Closed • marseilles opened about 292 years ago • 9 comments • tarot`),
+		regexp.MustCompile(`Closed • marseilles opened about 292 years ago • 9 comments`),
 		regexp.MustCompile(`bold story`),
 		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
 	}
@@ -387,7 +387,7 @@ func TestIssueView_previewWithEmptyBody(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`ix of coins`),
-		regexp.MustCompile(`Open • marseilles opened about 292 years ago • 9 comments • tarot`),
+		regexp.MustCompile(`Open • marseilles opened about 292 years ago • 9 comments`),
 		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
 	}
 	for _, r := range expectedLines {

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -289,6 +289,8 @@ func TestIssueView_preview(t *testing.T) {
 		"number": 123,
 		"body": "**bold story**",
 		"title": "ix of coins",
+		"state": "OPEN",
+		"created_at": "2011-01-26T19:01:12Z",
 		"author": {
 			"login": "marseilles"
 		},
@@ -313,7 +315,7 @@ func TestIssueView_preview(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`ix of coins`),
-		regexp.MustCompile(`opened by marseilles. 9 comments. \(tarot\)`),
+		regexp.MustCompile(`OPEN • marseilles opened about 292 years ago • 9 comments • tarot`),
 		regexp.MustCompile(`bold story`),
 		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
 	}
@@ -335,6 +337,8 @@ func TestIssueView_previewWithEmptyBody(t *testing.T) {
 		"number": 123,
 		"body": "",
 		"title": "ix of coins",
+		"state": "OPEN",
+		"created_at": "2011-01-26T19:01:12Z",
 		"author": {
 			"login": "marseilles"
 		},
@@ -359,7 +363,7 @@ func TestIssueView_previewWithEmptyBody(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`ix of coins`),
-		regexp.MustCompile(`opened by marseilles. 9 comments. \(tarot\)`),
+		regexp.MustCompile(`OPEN • marseilles opened about 292 years ago • 9 comments • tarot`),
 		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
 	}
 	for _, r := range expectedLines {

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -284,27 +284,9 @@ func TestIssueView_preview(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {
-		"number": 123,
-		"body": "**bold story**",
-		"title": "ix of coins",
-		"state": "OPEN",
-		"created_at": "2011-01-26T19:01:12Z",
-		"author": {
-			"login": "marseilles"
-		},
-		"labels": {
-			"nodes": [
-				{"name": "tarot"}
-			]
-		},
-		"comments": {
-		  "totalCount": 9
-		},
-		"url": "https://github.com/OWNER/REPO/issues/123"
-	} } } }
-	`))
+	jsonFile, _ := os.Open("../test/fixtures/issueView_preview.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
 
 	output, err := RunCommand(issueViewCmd, "issue view -p 123")
 	if err != nil {
@@ -332,27 +314,9 @@ func TestIssueView_previewWithEmptyBody(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repository": { "hasIssuesEnabled": true, "issue": {
-		"number": 123,
-		"body": "",
-		"title": "ix of coins",
-		"state": "OPEN",
-		"created_at": "2011-01-26T19:01:12Z",
-		"author": {
-			"login": "marseilles"
-		},
-		"labels": {
-			"nodes": [
-				{"name": "tarot"}
-			]
-		},
-		"comments": {
-		  "totalCount": 9
-		},
-		"url": "https://github.com/OWNER/REPO/issues/123"
-	} } } }
-	`))
+	jsonFile, _ := os.Open("../test/fixtures/issueView_previewWithEmptyBody.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
 
 	output, err := RunCommand(issueViewCmd, "issue view -p 123")
 	if err != nil {

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -290,49 +290,49 @@ func TestIssueView_Preview(t *testing.T) {
 		ownerRepo       string
 		command         string
 		fixture         string
-		expectedOutputs []*regexp.Regexp
+		expectedOutputs []string
 	}{
 		"Open issue": {
 			ownerRepo: "master",
 			command:   "issue view 123",
 			fixture:   "../test/fixtures/issueView_preview.json",
-			expectedOutputs: []*regexp.Regexp{
-				regexp.MustCompile(`ix of coins`),
-				regexp.MustCompile(`Open • marseilles opened about 292 years ago • 9 comments`),
-				regexp.MustCompile(`bold story`),
-				regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
+			expectedOutputs: []string{
+				"ix of coins",
+				"Open • marseilles opened about 292 years ago • 9 comments",
+				"bold story",
+				"View this issue on GitHub: https://github.com/OWNER/REPO/issues/123",
 			},
 		},
 		"Open issue with no label": {
 			ownerRepo: "master",
 			command:   "issue view 123",
 			fixture:   "../test/fixtures/issueView_previewNoLabel.json",
-			expectedOutputs: []*regexp.Regexp{
-				regexp.MustCompile(`ix of coins`),
-				regexp.MustCompile(`Open • marseilles opened about 292 years ago • 9 comments`),
-				regexp.MustCompile(`bold story`),
-				regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
+			expectedOutputs: []string{
+				"ix of coins",
+				"Open • marseilles opened about 292 years ago • 9 comments",
+				"bold story",
+				"View this issue on GitHub: https://github.com/OWNER/REPO/issues/123",
 			},
 		},
 		"Open issue with empty body": {
 			ownerRepo: "master",
 			command:   "issue view 123",
 			fixture:   "../test/fixtures/issueView_previewWithEmptyBody.json",
-			expectedOutputs: []*regexp.Regexp{
-				regexp.MustCompile(`ix of coins`),
-				regexp.MustCompile(`Open • marseilles opened about 292 years ago • 9 comments`),
-				regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
+			expectedOutputs: []string{
+				"ix of coins",
+				"Open • marseilles opened about 292 years ago • 9 comments",
+				"View this issue on GitHub: https://github.com/OWNER/REPO/issues/123",
 			},
 		},
 		"Closed issue": {
 			ownerRepo: "master",
 			command:   "issue view 123",
 			fixture:   "../test/fixtures/issueView_previewClosedState.json",
-			expectedOutputs: []*regexp.Regexp{
-				regexp.MustCompile(`ix of coins`),
-				regexp.MustCompile(`Closed • marseilles opened about 292 years ago • 9 comments`),
-				regexp.MustCompile(`bold story`),
-				regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
+			expectedOutputs: []string{
+				"ix of coins",
+				"Closed • marseilles opened about 292 years ago • 9 comments",
+				"bold story",
+				"View this issue on GitHub: https://github.com/OWNER/REPO/issues/123",
 			},
 		},
 	}
@@ -353,12 +353,7 @@ func TestIssueView_Preview(t *testing.T) {
 
 			eq(t, output.Stderr(), "")
 
-			for _, r := range tc.expectedOutputs {
-				if !r.MatchString(output.String()) {
-					t.Errorf("output did not match regexp /%s/\n> output\n%s\n", r, output)
-					return
-				}
-			}
+			test.ExpectLines(t, output.String(), tc.expectedOutputs...)
 		})
 	}
 }

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/utils"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestIssueStatus(t *testing.T) {
@@ -584,4 +585,25 @@ func TestIssueCreate_webTitleBody(t *testing.T) {
 	url := strings.ReplaceAll(seenCmd.Args[len(seenCmd.Args)-1], "^", "")
 	eq(t, url, "https://github.com/OWNER/REPO/issues/new?title=mytitle&body=mybody")
 	eq(t, output.String(), "Opening github.com/OWNER/REPO/issues/new in your browser.\n")
+}
+
+func TestIssueStateTitleWithColor(t *testing.T) {
+	tests := map[string]struct {
+		state string
+		want  string
+	}{
+
+		"Open state":   {state: "OPEN", want: "Open"},
+		"Closed state": {state: "CLOSED", want: "Closed"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := issueStateTitleWithColor(tc.state)
+			diff := cmp.Diff(tc.want, got)
+			if diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
 }

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -297,7 +297,7 @@ func TestIssueView_preview(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`ix of coins`),
-		regexp.MustCompile(`OPEN • marseilles opened about 292 years ago • 9 comments • tarot`),
+		regexp.MustCompile(`Open • marseilles opened about 292 years ago • 9 comments • tarot`),
 		regexp.MustCompile(`bold story`),
 		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
 	}
@@ -327,7 +327,7 @@ func TestIssueView_previewNoLabel(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`ix of coins`),
-		regexp.MustCompile(`OPEN • marseilles opened about 292 years ago • 9 comments`),
+		regexp.MustCompile(`Open • marseilles opened about 292 years ago • 9 comments`),
 		regexp.MustCompile(`bold story`),
 		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
 	}
@@ -357,7 +357,7 @@ func TestIssueView_previewClosedState(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`ix of coins`),
-		regexp.MustCompile(`CLOSED • marseilles opened about 292 years ago • 9 comments • tarot`),
+		regexp.MustCompile(`Closed • marseilles opened about 292 years ago • 9 comments • tarot`),
 		regexp.MustCompile(`bold story`),
 		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
 	}
@@ -387,7 +387,7 @@ func TestIssueView_previewWithEmptyBody(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`ix of coins`),
-		regexp.MustCompile(`OPEN • marseilles opened about 292 years ago • 9 comments • tarot`),
+		regexp.MustCompile(`Open • marseilles opened about 292 years ago • 9 comments • tarot`),
 		regexp.MustCompile(`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`),
 	}
 	for _, r := range expectedLines {

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -593,7 +593,6 @@ func TestIssueStateTitleWithColor(t *testing.T) {
 		state string
 		want  string
 	}{
-
 		"Open state":   {state: "OPEN", want: "Open"},
 		"Closed state": {state: "CLOSED", want: "Closed"},
 	}

--- a/command/pr.go
+++ b/command/pr.go
@@ -296,9 +296,12 @@ func prView(cmd *cobra.Command, args []string) error {
 }
 
 func printPrPreview(out io.Writer, pr *api.PullRequest) error {
+	prStateColorFunc := colorFuncForPR(*pr)
+
 	fmt.Fprintln(out, utils.Bold(pr.Title))
+	fmt.Fprintf(out, "%s", prStateColorFunc(pr.State))
 	fmt.Fprintln(out, utils.Gray(fmt.Sprintf(
-		"%s wants to merge %s into %s from %s",
+		" • %s wants to merge %s into %s from %s",
 		pr.Author.Login,
 		utils.Pluralize(pr.Commits.TotalCount, "commit"),
 		pr.BaseRefName,

--- a/command/pr.go
+++ b/command/pr.go
@@ -228,7 +228,7 @@ func prList(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func PRStateTitleWithColor(pr api.PullRequest) string {
+func prStateTitleWithColor(pr api.PullRequest) string {
 	prStateColorFunc := colorFuncForPR(pr)
 	return prStateColorFunc(strings.Title(strings.ToLower(pr.State)))
 }
@@ -302,7 +302,7 @@ func prView(cmd *cobra.Command, args []string) error {
 
 func printPrPreview(out io.Writer, pr *api.PullRequest) error {
 	fmt.Fprintln(out, utils.Bold(pr.Title))
-	fmt.Fprintf(out, "%s", PRStateTitleWithColor(*pr))
+	fmt.Fprintf(out, "%s", prStateTitleWithColor(*pr))
 	fmt.Fprintln(out, utils.Gray(fmt.Sprintf(
 		" • %s wants to merge %s into %s from %s",
 		pr.Author.Login,
@@ -427,7 +427,7 @@ func printPrs(w io.Writer, totalCount int, prs ...api.PullRequest) {
 				fmt.Fprintf(w, " - %s", utils.Green("Approved"))
 			}
 		} else {
-			fmt.Fprintf(w, " - %s", PRStateTitleWithColor(pr))
+			fmt.Fprintf(w, " - %s", prStateTitleWithColor(pr))
 		}
 
 		fmt.Fprint(w, "\n")

--- a/command/pr.go
+++ b/command/pr.go
@@ -230,6 +230,9 @@ func prList(cmd *cobra.Command, args []string) error {
 
 func prStateTitleWithColor(pr api.PullRequest) string {
 	prStateColorFunc := colorFuncForPR(pr)
+	if pr.State == "OPEN" && pr.IsDraft {
+		return prStateColorFunc(strings.Title(strings.ToLower("Draft")))
+	}
 	return prStateColorFunc(strings.Title(strings.ToLower(pr.State)))
 }
 

--- a/command/pr.go
+++ b/command/pr.go
@@ -236,9 +236,8 @@ func prStateTitleWithColor(pr api.PullRequest) string {
 func colorFuncForPR(pr api.PullRequest) func(string) string {
 	if pr.State == "OPEN" && pr.IsDraft {
 		return utils.Gray
-	} else {
-		return utils.ColorFuncForState(pr.State)
 	}
+	return utils.ColorFuncForState(pr.State)
 }
 
 func prView(cmd *cobra.Command, args []string) error {

--- a/command/pr.go
+++ b/command/pr.go
@@ -232,20 +232,7 @@ func colorFuncForPR(pr api.PullRequest) func(string) string {
 	if pr.State == "OPEN" && pr.IsDraft {
 		return utils.Gray
 	} else {
-		return colorFuncForState(pr.State)
-	}
-}
-
-func colorFuncForState(state string) func(string) string {
-	switch state {
-	case "OPEN":
-		return utils.Green
-	case "CLOSED":
-		return utils.Red
-	case "MERGED":
-		return utils.Magenta
-	default:
-		return nil
+		return utils.ColorFuncForState(pr.State)
 	}
 }
 

--- a/command/pr.go
+++ b/command/pr.go
@@ -228,6 +228,11 @@ func prList(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func PRStateTitleWithColor(pr api.PullRequest) string {
+	prStateColorFunc := colorFuncForPR(pr)
+	return prStateColorFunc(strings.Title(strings.ToLower(pr.State)))
+}
+
 func colorFuncForPR(pr api.PullRequest) func(string) string {
 	if pr.State == "OPEN" && pr.IsDraft {
 		return utils.Gray
@@ -296,10 +301,8 @@ func prView(cmd *cobra.Command, args []string) error {
 }
 
 func printPrPreview(out io.Writer, pr *api.PullRequest) error {
-	prStateColorFunc := colorFuncForPR(*pr)
-
 	fmt.Fprintln(out, utils.Bold(pr.Title))
-	fmt.Fprintf(out, "%s", prStateColorFunc(pr.State))
+	fmt.Fprintf(out, "%s", PRStateTitleWithColor(*pr))
 	fmt.Fprintln(out, utils.Gray(fmt.Sprintf(
 		" • %s wants to merge %s into %s from %s",
 		pr.Author.Login,
@@ -424,8 +427,7 @@ func printPrs(w io.Writer, totalCount int, prs ...api.PullRequest) {
 				fmt.Fprintf(w, " - %s", utils.Green("Approved"))
 			}
 		} else {
-			s := strings.Title(strings.ToLower(pr.State))
-			fmt.Fprintf(w, " - %s", prStateColorFunc(s))
+			fmt.Fprintf(w, " - %s", PRStateTitleWithColor(pr))
 		}
 
 		fmt.Fprint(w, "\n")

--- a/command/pr.go
+++ b/command/pr.go
@@ -238,7 +238,21 @@ func colorFuncForPR(pr api.PullRequest) func(string) string {
 	if pr.State == "OPEN" && pr.IsDraft {
 		return utils.Gray
 	}
-	return utils.ColorFuncForState(pr.State)
+	return colorFuncForState(pr.State)
+}
+
+// colorFuncForState returns a color function for a PR/Issue state
+func colorFuncForState(state string) func(string) string {
+	switch state {
+	case "OPEN":
+		return utils.Green
+	case "CLOSED":
+		return utils.Red
+	case "MERGED":
+		return utils.Magenta
+	default:
+		return nil
+	}
 }
 
 func prView(cmd *cobra.Command, args []string) error {

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -845,12 +845,10 @@ func TestReplaceExcessiveWhitespace(t *testing.T) {
 }
 
 func TestPrStateTitleWithColor(t *testing.T) {
-
 	tests := map[string]struct {
 		pr   api.PullRequest
 		want string
 	}{
-
 		"Format OPEN state":              {pr: api.PullRequest{State: "OPEN", IsDraft: false}, want: "Open"},
 		"Format OPEN state for Draft PR": {pr: api.PullRequest{State: "OPEN", IsDraft: true}, want: "Draft"},
 		"Format CLOSED state":            {pr: api.PullRequest{State: "CLOSED", IsDraft: false}, want: "Closed"},

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -411,6 +411,66 @@ func TestPRView_preview(t *testing.T) {
 	}
 }
 
+func TestPRView_previewClosedState(t *testing.T) {
+	initBlankContext("OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	jsonFile, _ := os.Open("../test/fixtures/prViewPreviewClosedState.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
+
+	output, err := RunCommand(prViewCmd, "pr view -p 12")
+	if err != nil {
+		t.Errorf("error running command `pr view`: %v", err)
+	}
+
+	eq(t, output.Stderr(), "")
+
+	expectedLines := []*regexp.Regexp{
+		regexp.MustCompile(`Blueberries are from a fork`),
+		regexp.MustCompile(`CLOSED • nobody wants to merge 12 commits into master from blueberries`),
+		regexp.MustCompile(`blueberries taste good`),
+		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`),
+	}
+	for _, r := range expectedLines {
+		if !r.MatchString(output.String()) {
+			t.Errorf("output did not match regexp /%s/\n> output\n%s\n", r, output)
+			return
+		}
+	}
+}
+
+func TestPRView_previewMergedState(t *testing.T) {
+	initBlankContext("OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	jsonFile, _ := os.Open("../test/fixtures/prViewPreviewMergedState.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
+
+	output, err := RunCommand(prViewCmd, "pr view -p 12")
+	if err != nil {
+		t.Errorf("error running command `pr view`: %v", err)
+	}
+
+	eq(t, output.Stderr(), "")
+
+	expectedLines := []*regexp.Regexp{
+		regexp.MustCompile(`Blueberries are from a fork`),
+		regexp.MustCompile(`MERGED • nobody wants to merge 12 commits into master from blueberries`),
+		regexp.MustCompile(`blueberries taste good`),
+		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`),
+	}
+	for _, r := range expectedLines {
+		if !r.MatchString(output.String()) {
+			t.Errorf("output did not match regexp /%s/\n> output\n%s\n", r, output)
+			return
+		}
+	}
+}
+
 func TestPRView_previewCurrentBranch(t *testing.T) {
 	initBlankContext("OWNER/REPO", "blueberries")
 	http := initFakeHTTP()

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -407,82 +407,82 @@ func TestPRView_Preview(t *testing.T) {
 		ownerRepo       string
 		args            string
 		fixture         string
-		expectedOutputs []*regexp.Regexp
+		expectedOutputs []string
 	}{
 		"Open PR": {
 			ownerRepo: "master",
 			args:      "pr view 12",
 			fixture:   "../test/fixtures/prViewPreview.json",
-			expectedOutputs: []*regexp.Regexp{
-				regexp.MustCompile(`Blueberries are from a fork`),
-				regexp.MustCompile(`Open • nobody wants to merge 12 commits into master from blueberries`),
-				regexp.MustCompile(`blueberries taste good`),
-				regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`),
+			expectedOutputs: []string{
+				"Blueberries are from a fork",
+				"Open • nobody wants to merge 12 commits into master from blueberries",
+				"blueberries taste good",
+				"View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12",
 			},
 		},
 		"Open PR for the current branch": {
 			ownerRepo: "blueberries",
 			args:      "pr view",
 			fixture:   "../test/fixtures/prView.json",
-			expectedOutputs: []*regexp.Regexp{
-				regexp.MustCompile(`Blueberries are a good fruit`),
-				regexp.MustCompile(`Open • nobody wants to merge 8 commits into master from blueberries`),
-				regexp.MustCompile(`blueberries taste good`),
-				regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`),
+			expectedOutputs: []string{
+				"Blueberries are a good fruit",
+				"Open • nobody wants to merge 8 commits into master from blueberries",
+				"blueberries taste good",
+				"View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10",
 			},
 		},
 		"Open PR wth empty body for the current branch": {
 			ownerRepo: "blueberries",
 			args:      "pr view",
 			fixture:   "../test/fixtures/prView_EmptyBody.json",
-			expectedOutputs: []*regexp.Regexp{
-				regexp.MustCompile(`Blueberries are a good fruit`),
-				regexp.MustCompile(`Open • nobody wants to merge 8 commits into master from blueberries`),
-				regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`),
+			expectedOutputs: []string{
+				"Blueberries are a good fruit",
+				"Open • nobody wants to merge 8 commits into master from blueberries",
+				"View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10",
 			},
 		},
 		"Closed PR": {
 			ownerRepo: "master",
 			args:      "pr view 12",
 			fixture:   "../test/fixtures/prViewPreviewClosedState.json",
-			expectedOutputs: []*regexp.Regexp{
-				regexp.MustCompile(`Blueberries are from a fork`),
-				regexp.MustCompile(`Closed • nobody wants to merge 12 commits into master from blueberries`),
-				regexp.MustCompile(`blueberries taste good`),
-				regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`),
+			expectedOutputs: []string{
+				"Blueberries are from a fork",
+				"Closed • nobody wants to merge 12 commits into master from blueberries",
+				"blueberries taste good",
+				"View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12",
 			},
 		},
 		"Merged PR": {
 			ownerRepo: "master",
 			args:      "pr view 12",
 			fixture:   "../test/fixtures/prViewPreviewMergedState.json",
-			expectedOutputs: []*regexp.Regexp{
-				regexp.MustCompile(`Blueberries are from a fork`),
-				regexp.MustCompile(`Merged • nobody wants to merge 12 commits into master from blueberries`),
-				regexp.MustCompile(`blueberries taste good`),
-				regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`),
+			expectedOutputs: []string{
+				"Blueberries are from a fork",
+				"Merged • nobody wants to merge 12 commits into master from blueberries",
+				"blueberries taste good",
+				"View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12",
 			},
 		},
 		"Draft PR": {
 			ownerRepo: "master",
 			args:      "pr view 12",
 			fixture:   "../test/fixtures/prViewPreviewDraftState.json",
-			expectedOutputs: []*regexp.Regexp{
-				regexp.MustCompile(`Blueberries are from a fork`),
-				regexp.MustCompile(`Draft • nobody wants to merge 12 commits into master from blueberries`),
-				regexp.MustCompile(`blueberries taste good`),
-				regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`),
+			expectedOutputs: []string{
+				"Blueberries are from a fork",
+				"Draft • nobody wants to merge 12 commits into master from blueberries",
+				"blueberries taste good",
+				"View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12",
 			},
 		},
 		"Draft PR by branch": {
 			ownerRepo: "master",
 			args:      "pr view blueberries",
 			fixture:   "../test/fixtures/prViewPreviewDraftStatebyBranch.json",
-			expectedOutputs: []*regexp.Regexp{
-				regexp.MustCompile(`Blueberries are a good fruit`),
-				regexp.MustCompile(`Draft • nobody wants to merge 8 commits into master from blueberries`),
-				regexp.MustCompile(`blueberries taste good`),
-				regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`),
+			expectedOutputs: []string{
+				"Blueberries are a good fruit",
+				"Draft • nobody wants to merge 8 commits into master from blueberries",
+				"blueberries taste good",
+				"View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10",
 			},
 		},
 	}
@@ -504,12 +504,7 @@ func TestPRView_Preview(t *testing.T) {
 
 			eq(t, output.Stderr(), "")
 
-			for _, r := range tc.expectedOutputs {
-				if !r.MatchString(output.String()) {
-					t.Errorf("output did not match regexp /%s/\n> output\n%s\n", r, output)
-					return
-				}
-			}
+			test.ExpectLines(t, output.String(), tc.expectedOutputs...)
 		})
 	}
 }

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -399,7 +399,7 @@ func TestPRView_preview(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`Blueberries are from a fork`),
-		regexp.MustCompile(`nobody wants to merge 12 commits into master from blueberries`),
+		regexp.MustCompile(`OPEN • nobody wants to merge 12 commits into master from blueberries`),
 		regexp.MustCompile(`blueberries taste good`),
 		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`),
 	}
@@ -434,7 +434,7 @@ func TestPRView_previewCurrentBranch(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`Blueberries are a good fruit`),
-		regexp.MustCompile(`nobody wants to merge 8 commits into master from blueberries`),
+		regexp.MustCompile(`OPEN • nobody wants to merge 8 commits into master from blueberries`),
 		regexp.MustCompile(`blueberries taste good`),
 		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`),
 	}
@@ -469,7 +469,7 @@ func TestPRView_previewCurrentBranchWithEmptyBody(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`Blueberries are a good fruit`),
-		regexp.MustCompile(`nobody wants to merge 8 commits into master from blueberries`),
+		regexp.MustCompile(`OPEN • nobody wants to merge 8 commits into master from blueberries`),
 		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`),
 	}
 	for _, r := range expectedLines {

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/utils"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -779,4 +780,26 @@ func TestReplaceExcessiveWhitespace(t *testing.T) {
 	eq(t, replaceExcessiveWhitespace("  hello goodbye  "), "hello goodbye")
 	eq(t, replaceExcessiveWhitespace("hello   goodbye"), "hello goodbye")
 	eq(t, replaceExcessiveWhitespace("   hello \n goodbye   "), "hello goodbye")
+}
+
+func TestPrStateTitleWithColor(t *testing.T) {
+	tests := map[string]struct {
+		state string
+		want  string
+	}{
+
+		"Format OPEN state":   {state: "OPEN", want: "Open"},
+		"Format CLOSED state": {state: "CLOSED", want: "Closed"},
+		"Format MERGED state": {state: "MERGED", want: "Merged"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := issueStateTitleWithColor(tc.state)
+			diff := cmp.Diff(tc.want, got)
+			if diff != "" {
+				t.Fatalf(diff)
+			}
+		})
+	}
 }

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -399,7 +399,7 @@ func TestPRView_preview(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`Blueberries are from a fork`),
-		regexp.MustCompile(`OPEN • nobody wants to merge 12 commits into master from blueberries`),
+		regexp.MustCompile(`Open • nobody wants to merge 12 commits into master from blueberries`),
 		regexp.MustCompile(`blueberries taste good`),
 		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`),
 	}
@@ -429,7 +429,7 @@ func TestPRView_previewClosedState(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`Blueberries are from a fork`),
-		regexp.MustCompile(`CLOSED • nobody wants to merge 12 commits into master from blueberries`),
+		regexp.MustCompile(`Closed • nobody wants to merge 12 commits into master from blueberries`),
 		regexp.MustCompile(`blueberries taste good`),
 		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`),
 	}
@@ -459,7 +459,7 @@ func TestPRView_previewMergedState(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`Blueberries are from a fork`),
-		regexp.MustCompile(`MERGED • nobody wants to merge 12 commits into master from blueberries`),
+		regexp.MustCompile(`Merged • nobody wants to merge 12 commits into master from blueberries`),
 		regexp.MustCompile(`blueberries taste good`),
 		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`),
 	}
@@ -494,7 +494,7 @@ func TestPRView_previewCurrentBranch(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`Blueberries are a good fruit`),
-		regexp.MustCompile(`OPEN • nobody wants to merge 8 commits into master from blueberries`),
+		regexp.MustCompile(`Open • nobody wants to merge 8 commits into master from blueberries`),
 		regexp.MustCompile(`blueberries taste good`),
 		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`),
 	}
@@ -529,7 +529,7 @@ func TestPRView_previewCurrentBranchWithEmptyBody(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`Blueberries are a good fruit`),
-		regexp.MustCompile(`OPEN • nobody wants to merge 8 commits into master from blueberries`),
+		regexp.MustCompile(`Open • nobody wants to merge 8 commits into master from blueberries`),
 		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`),
 	}
 	for _, r := range expectedLines {

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/api"
 	"github.com/cli/cli/test"
 	"github.com/cli/cli/utils"
 	"github.com/google/go-cmp/cmp"
@@ -491,7 +492,7 @@ func TestPRView_previewDraftState(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`Blueberries are from a fork`),
-		regexp.MustCompile(`Open • nobody wants to merge 12 commits into master from blueberries`),
+		regexp.MustCompile(`Draft • nobody wants to merge 12 commits into master from blueberries`),
 		regexp.MustCompile(`blueberries taste good`),
 		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`),
 	}
@@ -556,7 +557,7 @@ func TestPRView_previewDraftStatebyBranch(t *testing.T) {
 
 	expectedLines := []*regexp.Regexp{
 		regexp.MustCompile(`Blueberries are a good fruit`),
-		regexp.MustCompile(`Open • nobody wants to merge 8 commits into master from blueberries`),
+		regexp.MustCompile(`Draft • nobody wants to merge 8 commits into master from blueberries`),
 		regexp.MustCompile(`blueberries taste good`),
 		regexp.MustCompile(`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`),
 	}
@@ -844,19 +845,21 @@ func TestReplaceExcessiveWhitespace(t *testing.T) {
 }
 
 func TestPrStateTitleWithColor(t *testing.T) {
+
 	tests := map[string]struct {
-		state string
-		want  string
+		pr   api.PullRequest
+		want string
 	}{
 
-		"Format OPEN state":   {state: "OPEN", want: "Open"},
-		"Format CLOSED state": {state: "CLOSED", want: "Closed"},
-		"Format MERGED state": {state: "MERGED", want: "Merged"},
+		"Format OPEN state":              {pr: api.PullRequest{State: "OPEN", IsDraft: false}, want: "Open"},
+		"Format OPEN state for Draft PR": {pr: api.PullRequest{State: "OPEN", IsDraft: true}, want: "Draft"},
+		"Format CLOSED state":            {pr: api.PullRequest{State: "CLOSED", IsDraft: false}, want: "Closed"},
+		"Format MERGED state":            {pr: api.PullRequest{State: "MERGED", IsDraft: false}, want: "Merged"},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := issueStateTitleWithColor(tc.state)
+			got := prStateTitleWithColor(tc.pr)
 			diff := cmp.Diff(tc.want, got)
 			if diff != "" {
 				t.Fatalf(diff)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/briandowns/spinner v1.9.0
 	github.com/charmbracelet/glamour v0.1.1-0.20200304134224-7e5c90143acc
 	github.com/dlclark/regexp2 v1.2.0 // indirect
+	github.com/google/go-cmp v0.2.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-version v1.2.0
 	github.com/henvic/httpretty v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f h1:5CjVwnuUcp5adK4gmY6i72gpVFVnZDP2h5TmPScB6u4=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=

--- a/test/fixtures/issueView_preview.json
+++ b/test/fixtures/issueView_preview.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "repository": {
+      "hasIssuesEnabled": true,
+      "issue": {
+        "number": 123,
+        "body": "**bold story**",
+        "title": "ix of coins",
+        "state": "OPEN",
+        "created_at": "2011-01-26T19:01:12Z",
+        "author": {
+          "login": "marseilles"
+        },
+        "labels": {
+          "nodes": [
+            {
+              "name": "tarot"
+            }
+          ]
+        },
+        "comments": {
+          "totalCount": 9
+        },
+        "url": "https://github.com/OWNER/REPO/issues/123"
+      }
+    }
+  }
+}

--- a/test/fixtures/issueView_previewClosedState.json
+++ b/test/fixtures/issueView_previewClosedState.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "repository": {
+      "hasIssuesEnabled": true,
+      "issue": {
+        "number": 123,
+        "body": "**bold story**",
+        "title": "ix of coins",
+        "state": "CLOSED",
+        "created_at": "2011-01-26T19:01:12Z",
+        "author": {
+          "login": "marseilles"
+        },
+        "labels": {
+          "nodes": [
+            {
+              "name": "tarot"
+            }
+          ]
+        },
+        "comments": {
+          "totalCount": 9
+        },
+        "url": "https://github.com/OWNER/REPO/issues/123"
+      }
+    }
+  }
+}

--- a/test/fixtures/issueView_previewNoLabel.json
+++ b/test/fixtures/issueView_previewNoLabel.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "repository": {
+      "hasIssuesEnabled": true,
+      "issue": {
+        "number": 123,
+        "body": "**bold story**",
+        "title": "ix of coins",
+        "state": "OPEN",
+        "created_at": "2011-01-26T19:01:12Z",
+        "author": {
+          "login": "marseilles"
+        },
+        "labels": {
+          "nodes": [
+          ]
+        },
+        "comments": {
+          "totalCount": 9
+        },
+        "url": "https://github.com/OWNER/REPO/issues/123"
+      }
+    }
+  }
+}

--- a/test/fixtures/issueView_previewWithEmptyBody.json
+++ b/test/fixtures/issueView_previewWithEmptyBody.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "repository": {
+      "hasIssuesEnabled": true,
+      "issue": {
+        "number": 123,
+        "body": "",
+        "title": "ix of coins",
+        "state": "OPEN",
+        "created_at": "2011-01-26T19:01:12Z",
+        "author": {
+          "login": "marseilles"
+        },
+        "labels": {
+          "nodes": [
+            {
+              "name": "tarot"
+            }
+          ]
+        },
+        "comments": {
+          "totalCount": 9
+        },
+        "url": "https://github.com/OWNER/REPO/issues/123"
+      }
+    }
+  }
+}

--- a/test/fixtures/prStatus.json
+++ b/test/fixtures/prStatus.json
@@ -8,8 +8,10 @@
             "node": {
               "number": 10,
               "title": "Blueberries are a good fruit",
+              "state": "OPEN",
               "url": "https://github.com/cli/cli/pull/10",
               "headRefName": "blueberries",
+              "isDraft": false,
               "headRepositoryOwner": {
                 "login": "OWNER"
               },
@@ -26,8 +28,10 @@
           "node": {
             "number": 8,
             "title": "Strawberries are not actually berries",
+            "state": "OPEN",
             "url": "https://github.com/cli/cli/pull/8",
-            "headRefName": "strawberries"
+            "headRefName": "strawberries",
+            "isDraft": false
           }
         }
       ]
@@ -39,16 +43,18 @@
           "node": {
             "number": 9,
             "title": "Apples are tasty",
+            "state": "OPEN",
             "url": "https://github.com/cli/cli/pull/9",
-            "headRefName": "apples"
-          }
-        },
-        {
+            "headRefName": "apples",
+            "isDraft": false
+          } }, {
           "node": {
             "number": 11,
             "title": "Figs are my favorite",
+            "state": "OPEN",
             "url": "https://github.com/cli/cli/pull/1",
-            "headRefName": "figs"
+            "headRefName": "figs",
+            "isDraft": true
           }
         }
       ]

--- a/test/fixtures/prStatusFork.json
+++ b/test/fixtures/prStatusFork.json
@@ -8,8 +8,10 @@
             "node": {
               "number": 10,
               "title": "Blueberries are a good fruit",
+              "state": "OPEN",
               "url": "https://github.com/PARENT/REPO/pull/10",
               "headRefName": "blueberries",
+              "isDraft": false,
               "headRepositoryOwner": {
                 "login": "OWNER"
               },

--- a/test/fixtures/prView.json
+++ b/test/fixtures/prView.json
@@ -6,6 +6,7 @@
           {
             "number": 12,
             "title": "Blueberries are from a fork",
+            "state": "OPEN",
             "body": "yeah",
             "url": "https://github.com/OWNER/REPO/pull/12",
             "headRefName": "blueberries",
@@ -24,6 +25,7 @@
           {
             "number": 10,
             "title": "Blueberries are a good fruit",
+            "state": "OPEN",
             "body": "**blueberries taste good**",
             "url": "https://github.com/OWNER/REPO/pull/10",
             "baseRefName": "master",

--- a/test/fixtures/prView.json
+++ b/test/fixtures/prView.json
@@ -20,7 +20,8 @@
             "author": {
               "login": "nobody"
             },
-            "isCrossRepository": true
+            "isCrossRepository": true,
+            "isDraft": false
           },
           {
             "number": 10,
@@ -39,7 +40,8 @@
             "commits": {
               "totalCount": 8
             },
-            "isCrossRepository": false
+            "isCrossRepository": false,
+            "isDraft": false
           }
         ]
       }

--- a/test/fixtures/prViewPreview.json
+++ b/test/fixtures/prViewPreview.json
@@ -4,6 +4,7 @@
       "pullRequest": {
         "number": 12,
         "title": "Blueberries are from a fork",
+        "state": "OPEN",
         "body": "**blueberries taste good**",
         "url": "https://github.com/OWNER/REPO/pull/12",
         "author": {

--- a/test/fixtures/prViewPreview.json
+++ b/test/fixtures/prViewPreview.json
@@ -18,7 +18,8 @@
         "headRepositoryOwner": {
           "login": "hubot"
         },
-        "isCrossRepository": true
+        "isCrossRepository": true,
+        "isDraft": false
       }
     }
   }

--- a/test/fixtures/prViewPreviewClosedState.json
+++ b/test/fixtures/prViewPreviewClosedState.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "number": 12,
+        "title": "Blueberries are from a fork",
+        "state": "CLOSED",
+        "body": "**blueberries taste good**",
+        "url": "https://github.com/OWNER/REPO/pull/12",
+        "author": {
+          "login": "nobody"
+        },
+        "commits": {
+          "totalCount": 12
+        },
+        "baseRefName": "master",
+        "headRefName": "blueberries",
+        "headRepositoryOwner": {
+          "login": "hubot"
+        },
+        "isCrossRepository": true
+      }
+    }
+  }
+}

--- a/test/fixtures/prViewPreviewDraftState.json
+++ b/test/fixtures/prViewPreviewDraftState.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "number": 12,
+        "title": "Blueberries are from a fork",
+        "state": "OPEN",
+        "body": "**blueberries taste good**",
+        "url": "https://github.com/OWNER/REPO/pull/12",
+        "author": {
+          "login": "nobody"
+        },
+        "commits": {
+          "totalCount": 12
+        },
+        "baseRefName": "master",
+        "headRefName": "blueberries",
+        "headRepositoryOwner": {
+          "login": "hubot"
+        },
+        "isCrossRepository": true,
+        "isDraft": true
+      }
+    }
+  }
+}

--- a/test/fixtures/prViewPreviewDraftStatebyBranch.json
+++ b/test/fixtures/prViewPreviewDraftStatebyBranch.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "repository": {
+      "pullRequests": {
+        "nodes": [
+          {
+            "number": 12,
+            "title": "Blueberries are from a fork",
+            "state": "OPEN",
+            "body": "yeah",
+            "url": "https://github.com/OWNER/REPO/pull/12",
+            "headRefName": "blueberries",
+            "baseRefName": "master",
+            "headRepositoryOwner": {
+              "login": "hubot"
+            },
+            "commits": {
+              "totalCount": 12
+            },
+            "author": {
+              "login": "nobody"
+            },
+            "isCrossRepository": true,
+            "isDraft": false
+          },
+          {
+            "number": 10,
+            "title": "Blueberries are a good fruit",
+            "state": "OPEN",
+            "body": "**blueberries taste good**",
+            "url": "https://github.com/OWNER/REPO/pull/10",
+            "baseRefName": "master",
+            "headRefName": "blueberries",
+            "author": {
+              "login": "nobody"
+            },
+            "headRepositoryOwner": {
+              "login": "OWNER"
+            },
+            "commits": {
+              "totalCount": 8
+            },
+            "isCrossRepository": false,
+            "isDraft": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/prViewPreviewMergedState.json
+++ b/test/fixtures/prViewPreviewMergedState.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "number": 12,
+        "title": "Blueberries are from a fork",
+        "state": "MERGED",
+        "body": "**blueberries taste good**",
+        "url": "https://github.com/OWNER/REPO/pull/12",
+        "author": {
+          "login": "nobody"
+        },
+        "commits": {
+          "totalCount": 12
+        },
+        "baseRefName": "master",
+        "headRefName": "blueberries",
+        "headRepositoryOwner": {
+          "login": "hubot"
+        },
+        "isCrossRepository": true
+      }
+    }
+  }
+}

--- a/test/fixtures/prView_EmptyBody.json
+++ b/test/fixtures/prView_EmptyBody.json
@@ -6,6 +6,7 @@
           {
             "number": 12,
             "title": "Blueberries are from a fork",
+            "state": "OPEN",
             "body": "yeah",
             "url": "https://github.com/OWNER/REPO/pull/12",
             "headRefName": "blueberries",
@@ -24,6 +25,7 @@
           {
             "number": 10,
             "title": "Blueberries are a good fruit",
+            "state": "OPEN",
             "body": "",
             "url": "https://github.com/OWNER/REPO/pull/10",
             "baseRefName": "master",

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -57,3 +57,17 @@ func FuzzyAgo(ago time.Duration) string {
 func Spinner() *spinner.Spinner {
 	return spinner.New(spinner.CharSets[11], 400*time.Millisecond)
 }
+
+// ColorFuncForState returns a color function for a PR/Issue state
+func ColorFuncForState(state string) func(string) string {
+	switch state {
+	case "OPEN":
+		return Green
+	case "CLOSED":
+		return Red
+	case "MERGED":
+		return Magenta
+	default:
+		return nil
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -75,17 +75,3 @@ func Spinner(w io.Writer) *spinner.Spinner {
 	s.Writer = w
 	return s
 }
-
-// ColorFuncForState returns a color function for a PR/Issue state
-func ColorFuncForState(state string) func(string) string {
-	switch state {
-	case "OPEN":
-		return Green
-	case "CLOSED":
-		return Red
-	case "MERGED":
-		return Magenta
-	default:
-		return nil
-	}
-}


### PR DESCRIPTION
Closes #652

Mostly tests for each state. Changes for the core logics are a few lines in `command/issue.go`, `command/pr.go` and GraphQL queries.

Since colors matter, I tried to test PR/Issue states with ansi escape sequence to compare colors along with its string but couldn't figure out an efficient way to do... I might be missing something for it.

## Test cases for `gh [pr|issue] view --preview`
I use `•` (Bullet: `U+2022`) as a separator. It is a bit ugly in below captures but I think it is my terminal font problem. 💦 

- [x] Open issue
![Screen Shot 2020-03-18 at 6 57 53](https://user-images.githubusercontent.com/5877477/76908383-e19d3100-68eb-11ea-933f-bd6303660710.png)

- [x] Closed issue
![Screen Shot 2020-03-18 at 6 59 48](https://user-images.githubusercontent.com/5877477/76908401-e82ba880-68eb-11ea-94b0-689261e5e21f.png)

- Open PR
    - [x] Query by number
![Screen Shot 2020-03-18 at 7 17 05](https://user-images.githubusercontent.com/5877477/76908444-098c9480-68ec-11ea-90d9-a0d576d46b98.png)
    - [x] Query by branch name
![Screen Shot 2020-03-18 at 7 17 32](https://user-images.githubusercontent.com/5877477/76908457-10b3a280-68ec-11ea-8f62-4413dcd4b5bc.png)

- Draft PR
    - [x] Query by number
![Screen Shot 2020-03-18 at 7 14 55](https://user-images.githubusercontent.com/5877477/76910641-ed8bf180-68f1-11ea-9176-d87d718e43bf.png)
    - [x] Query by branch name
![Screen Shot 2020-03-18 at 7 15 07](https://user-images.githubusercontent.com/5877477/76910667-fda3d100-68f1-11ea-9b25-99d16109fa86.png)
    -  (idea) We could change `Open` to `Draft` like below if it is more appropriate
![Screen Shot 2020-03-18 at 9 19 43](https://user-images.githubusercontent.com/5877477/76913223-b3bee900-68f9-11ea-84ab-3403d840ff2b.png)

- Closed PR
    - [x] Query by number
![Screen Shot 2020-03-18 at 7 04 47](https://user-images.githubusercontent.com/5877477/76910686-085e6600-68f2-11ea-8fb0-6e32389286e7.png)
    - [x] Query by branch name
![Screen Shot 2020-03-18 at 7 20 27](https://user-images.githubusercontent.com/5877477/76910695-0f857400-68f2-11ea-858d-6897466fe73e.png)
- Merged PR
    - [x] Query by number
![Screen Shot 2020-03-18 at 7 00 45](https://user-images.githubusercontent.com/5877477/76910717-1ad89f80-68f2-11ea-9b21-b7631e7765d3.png)
    - [x] Query by branch name
![Screen Shot 2020-03-18 at 7 15 45](https://user-images.githubusercontent.com/5877477/76910733-24fa9e00-68f2-11ea-8b9f-75986a0b0e04.png)
