### PR TITLE
Add unit tests for Closed and Merged states of the current branch

### DIFF
--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -156,33 +156,6 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 	}
 }
 
-func TestPRStatus_closedMerged(t *testing.T) {
-	initBlankContext("OWNER/REPO", "blueberries")
-	http := initFakeHTTP()
-	http.StubRepoResponse("OWNER", "REPO")
-
-	jsonFile, _ := os.Open("../test/fixtures/prStatusClosedMerged.json")
-	defer jsonFile.Close()
-	http.StubResponse(200, jsonFile)
-
-	output, err := RunCommand(prStatusCmd, "pr status")
-	if err != nil {
-		t.Errorf("error running command `pr status`: %v", err)
-	}
-
-	expected := []string{
-		"- Checks passing - Changes requested",
-		"- Closed",
-		"- Merged",
-	}
-
-	for _, line := range expected {
-		if !strings.Contains(output.String(), line) {
-			t.Errorf("output did not contain %q: %q", line, output.String())
-		}
-	}
-}
-
 func TestPRStatus_currentBranch_showTheMostRecentPR(t *testing.T) {
 	initBlankContext("OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
@@ -212,6 +185,48 @@ func TestPRStatus_currentBranch_showTheMostRecentPR(t *testing.T) {
 			t.Errorf("output unexpectedly match regexp /%s/\n> output\n%s\n", r, output)
 			return
 		}
+	}
+}
+
+func TestPRStatus_currentBranch_Closed(t *testing.T) {
+	initBlankContext("OWNER/REPO", "blueberries")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchClosed.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
+
+	output, err := RunCommand(prStatusCmd, "pr status")
+	if err != nil {
+		t.Errorf("error running command `pr status`: %v", err)
+	}
+
+	expectedLine := regexp.MustCompile(`#8  Blueberries are a good fruit \[blueberries\] - Closed`)
+	if !expectedLine.MatchString(output.String()) {
+		t.Errorf("output did not match regexp /%s/\n> output\n%s\n", expectedLine, output)
+		return
+	}
+}
+
+func TestPRStatus_currentBranch_Merged(t *testing.T) {
+	initBlankContext("OWNER/REPO", "blueberries")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchMerged.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
+
+	output, err := RunCommand(prStatusCmd, "pr status")
+	if err != nil {
+		t.Errorf("error running command `pr status`: %v", err)
+	}
+
+	expectedLine := regexp.MustCompile(`#8  Blueberries are a good fruit \[blueberries\] - Merged`)
+	if !expectedLine.MatchString(output.String()) {
+		t.Errorf("output did not match regexp /%s/\n> output\n%s\n", expectedLine, output)
+		return
 	}
 }
 

--- a/test/fixtures/prStatusCurrentBranchClosed.json
+++ b/test/fixtures/prStatusCurrentBranchClosed.json
@@ -8,7 +8,7 @@
             "node": {
               "number": 8,
               "title": "Blueberries are a good fruit",
-              "state": "OPEN",
+              "state": "CLOSED",
               "url": "https://github.com/cli/cli/pull/8",
               "headRefName": "blueberries",
               "reviewDecision": "CHANGES_REQUESTED",
@@ -35,27 +35,8 @@
       }
     },
     "viewerCreated": {
-      "totalCount": 1,
-      "edges": [
-        {
-          "node": {
-            "number": 10,
-            "state": "CLOSED",
-            "title": "Strawberries are not actually berries",
-            "url": "https://github.com/cli/cli/pull/10",
-            "headRefName": "strawberries"
-          }
-        },
-        {
-          "node": {
-            "number": 9,
-            "state": "MERGED",
-            "title": "Bananas are berries",
-            "url": "https://github.com/cli/cli/pull/9",
-            "headRefName": "banananana"
-          }
-        }
-      ]
+      "totalCount": 0,
+      "edges": []
     },
     "reviewRequested": {
       "totalCount": 0,

--- a/test/fixtures/prStatusCurrentBranchMerged.json
+++ b/test/fixtures/prStatusCurrentBranchMerged.json
@@ -1,0 +1,46 @@
+{
+  "data": {
+    "repository": {
+      "pullRequests": {
+        "totalCount": 1,
+        "edges": [
+          {
+            "node": {
+              "number": 8,
+              "title": "Blueberries are a good fruit",
+              "state": "MERGED",
+              "url": "https://github.com/cli/cli/pull/8",
+              "headRefName": "blueberries",
+              "reviewDecision": "CHANGES_REQUESTED",
+              "commits": {
+                "nodes": [
+                  {
+                    "commit": {
+                      "statusCheckRollup": {
+                        "contexts": {
+                          "nodes": [
+                            {
+                              "state": "SUCCESS"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "viewerCreated": {
+      "totalCount": 0,
+      "edges": []
+    },
+    "reviewRequested": {
+      "totalCount": 0,
+      "edges": []
+    }
+  }
+}


### PR DESCRIPTION
This PR is a follow-up of #638 

#624 and #638 introduced `Closed` and `Merged` states of the current branch. However, I didn't add tests for each new state. This PR adds unit tests that checks the most recent `Closed` and `Merged` states of the current branch.

There is no core logic changes in this PR.

Since gh command returns [opening "reviewRequested" and "viewerCreated" PRs](https://github.com/doi-t/cli/blob/74a2a241045d9e6df3bbe288f81911b4361871cd/api/queries_pr.go#L232-L233) for `gh pr status`, I removed `TestPRStatus_closedMerged` which had `CLOSED` and `MERGED` PRs for `viewerCreated` in the fixture.