### PR TITLE
Creating a PR now always prioritizes an existing fork as a push target

### DIFF
--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -221,7 +221,7 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 		// TODO: support non-HTTPS git remote URLs
 		headRepoURL := fmt.Sprintf("https://github.com/%s.git", ghrepo.FullName(headRepo))
 		// TODO: prevent clashes with another remote of a same name
-		gitRemote, err := git.AddRemote("fork", headRepoURL, "")
+		gitRemote, err := git.AddRemote("fork", headRepoURL)
 		if err != nil {
 			return fmt.Errorf("error adding remote: %w", err)
 		}

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -97,6 +97,10 @@ func TestPRCreate_alreadyExistsDifferentBase(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "forks": { "nodes": [
+	] } } } }
+	`))
+	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": { "pullRequests": { "nodes": [
 			{ "url": "https://github.com/OWNER/REPO/pull/123",
 			  "headRefName": "feature",

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -15,6 +15,10 @@ func TestPRCreate(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "forks": { "nodes": [
+	] } } } }
+	`))
+	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": { "pullRequests": { "nodes" : [
 		] } } } }
 	`))
@@ -34,7 +38,7 @@ func TestPRCreate(t *testing.T) {
 	output, err := RunCommand(prCreateCmd, `pr create -t "my title" -b "my body"`)
 	eq(t, err, nil)
 
-	bodyBytes, _ := ioutil.ReadAll(http.Requests[2].Body)
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[3].Body)
 	reqBody := struct {
 		Variables struct {
 			Input struct {
@@ -62,6 +66,10 @@ func TestPRCreate_alreadyExists(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "forks": { "nodes": [
+	] } } } }
+	`))
+	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": { "pullRequests": { "nodes": [
 			{ "url": "https://github.com/OWNER/REPO/pull/123",
 			  "headRefName": "feature" }
@@ -87,6 +95,10 @@ func TestPRCreate_web(t *testing.T) {
 	initBlankContext("OWNER/REPO", "feature")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "forks": { "nodes": [
+	] } } } }
+	`))
 
 	cs, cmdTeardown := initCmdStubber()
 	defer cmdTeardown()
@@ -113,6 +125,10 @@ func TestPRCreate_ReportsUncommittedChanges(t *testing.T) {
 	http := initFakeHTTP()
 
 	http.StubRepoResponse("OWNER", "REPO")
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "forks": { "nodes": [
+	] } } } }
+	`))
 	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": { "pullRequests": { "nodes" : [
 		] } } } }
@@ -233,6 +249,10 @@ func TestPRCreate_survey_defaults_multicommit(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "forks": { "nodes": [
+	] } } } }
+	`))
+	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": { "pullRequests": { "nodes" : [
 		] } } } }
 	`))
@@ -273,7 +293,7 @@ func TestPRCreate_survey_defaults_multicommit(t *testing.T) {
 	output, err := RunCommand(prCreateCmd, `pr create`)
 	eq(t, err, nil)
 
-	bodyBytes, _ := ioutil.ReadAll(http.Requests[2].Body)
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[3].Body)
 	reqBody := struct {
 		Variables struct {
 			Input struct {
@@ -302,6 +322,10 @@ func TestPRCreate_survey_defaults_monocommit(t *testing.T) {
 	initBlankContext("OWNER/REPO", "feature")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "forks": { "nodes": [
+	] } } } }
+	`))
 	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": { "pullRequests": { "nodes" : [
 		] } } } }
@@ -344,7 +368,7 @@ func TestPRCreate_survey_defaults_monocommit(t *testing.T) {
 	output, err := RunCommand(prCreateCmd, `pr create`)
 	eq(t, err, nil)
 
-	bodyBytes, _ := ioutil.ReadAll(http.Requests[2].Body)
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[3].Body)
 	reqBody := struct {
 		Variables struct {
 			Input struct {
@@ -374,6 +398,10 @@ func TestPRCreate_survey_autofill(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "forks": { "nodes": [
+	] } } } }
+	`))
+	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "repository": { "pullRequests": { "nodes" : [
 		] } } } }
 	`))
@@ -396,7 +424,7 @@ func TestPRCreate_survey_autofill(t *testing.T) {
 	output, err := RunCommand(prCreateCmd, `pr create -f`)
 	eq(t, err, nil)
 
-	bodyBytes, _ := ioutil.ReadAll(http.Requests[2].Body)
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[3].Body)
 	reqBody := struct {
 		Variables struct {
 			Input struct {
@@ -457,6 +485,10 @@ func TestPRCreate_defaults_error_interactive(t *testing.T) {
 	initBlankContext("OWNER/REPO", "feature")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "forks": { "nodes": [
+	] } } } }
+	`))
 	http.StubResponse(200, bytes.NewBufferString(`
 		{ "data": { "createPullRequest": { "pullRequest": {
 			"URL": "https://github.com/OWNER/REPO/pull/12"

--- a/command/repo.go
+++ b/command/repo.go
@@ -344,7 +344,7 @@ func repoFork(cmd *cobra.Command, args []string) error {
 			}
 		}
 		if remoteDesired {
-			_, err := git.AddRemote("fork", forkedRepo.CloneURL, "")
+			_, err := git.AddRemote("fork", forkedRepo.CloneURL)
 			if err != nil {
 				return fmt.Errorf("failed to add remote: %w", err)
 			}

--- a/context/remote_test.go
+++ b/context/remote_test.go
@@ -137,7 +137,8 @@ func Test_resolvedRemotes_forkLookup(t *testing.T) {
 		{ "id": "FORKID",
 		  "url": "https://github.com/FORKOWNER/REPO",
 		  "name": "REPO",
-		  "owner": { "login": "FORKOWNER" }
+		  "owner": { "login": "FORKOWNER" },
+		  "viewerPermission": "WRITE"
 		}
 	] } } } }
 	`))

--- a/context/remote_test.go
+++ b/context/remote_test.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"bytes"
 	"errors"
 	"net/url"
 	"testing"
@@ -61,6 +62,14 @@ func Test_translateRemotes(t *testing.T) {
 }
 
 func Test_resolvedRemotes_triangularSetup(t *testing.T) {
+	http := &api.FakeHTTP{}
+	apiClient := api.NewClient(api.ReplaceTripper(http))
+
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "forks": { "nodes": [
+	] } } } }
+	`))
+
 	resolved := ResolvedRemotes{
 		BaseOverride: nil,
 		Remotes: Remotes{
@@ -89,6 +98,7 @@ func Test_resolvedRemotes_triangularSetup(t *testing.T) {
 				},
 			},
 		},
+		apiClient: apiClient,
 	}
 
 	baseRepo, err := resolved.BaseRepo()
@@ -115,6 +125,52 @@ func Test_resolvedRemotes_triangularSetup(t *testing.T) {
 	}
 	if headRemote.Name != "fork" {
 		t.Errorf("got remote %q", headRemote.Name)
+	}
+}
+
+func Test_resolvedRemotes_forkLookup(t *testing.T) {
+	http := &api.FakeHTTP{}
+	apiClient := api.NewClient(api.ReplaceTripper(http))
+
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": { "forks": { "nodes": [
+		{ "id": "FORKID",
+		  "url": "https://github.com/FORKOWNER/REPO",
+		  "name": "REPO",
+		  "owner": { "login": "FORKOWNER" }
+		}
+	] } } } }
+	`))
+
+	resolved := ResolvedRemotes{
+		BaseOverride: nil,
+		Remotes: Remotes{
+			&Remote{
+				Remote: &git.Remote{Name: "origin"},
+				Owner:  "OWNER",
+				Repo:   "REPO",
+			},
+		},
+		Network: api.RepoNetworkResult{
+			Repositories: []*api.Repository{
+				&api.Repository{
+					Name:             "NEWNAME",
+					Owner:            api.RepositoryOwner{Login: "NEWOWNER"},
+					ViewerPermission: "READ",
+				},
+			},
+		},
+		apiClient: apiClient,
+	}
+
+	headRepo, err := resolved.HeadRepo()
+	if err != nil {
+		t.Fatalf("got %v", err)
+	}
+	eq(t, ghrepo.FullName(headRepo), "FORKOWNER/REPO")
+	_, err = resolved.RemoteForRepo(headRepo)
+	if err == nil {
+		t.Fatal("expected to not find a matching remote")
 	}
 }
 

--- a/git/remote.go
+++ b/git/remote.go
@@ -71,34 +71,22 @@ func parseRemotes(gitRemotes []string) (remotes RemoteSet) {
 	return
 }
 
-// AddRemote adds a new git remote. The initURL is the remote URL with which the
-// automatic fetch is made and finalURL, if non-blank, is set as the remote URL
-// after the fetch.
-func AddRemote(name, initURL, finalURL string) (*Remote, error) {
-	addCmd := exec.Command("git", "remote", "add", "-f", name, initURL)
+// AddRemote adds a new git remote and auto-fetches objects from it
+func AddRemote(name, u string) (*Remote, error) {
+	addCmd := exec.Command("git", "remote", "add", "-f", name, u)
 	err := utils.PrepareCmd(addCmd).Run()
 	if err != nil {
 		return nil, err
 	}
 
-	if finalURL == "" {
-		finalURL = initURL
-	} else {
-		setCmd := exec.Command("git", "remote", "set-url", name, finalURL)
-		err := utils.PrepareCmd(setCmd).Run()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	finalURLParsed, err := url.Parse(finalURL)
+	urlParsed, err := url.Parse(u)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Remote{
 		Name:     name,
-		FetchURL: finalURLParsed,
-		PushURL:  finalURLParsed,
+		FetchURL: urlParsed,
+		PushURL:  urlParsed,
 	}, nil
 }


### PR DESCRIPTION
Before: the default push target for the current branch in `pr create` was **the first repository found among git remotes that I have write access to**, even if it is the same as the base repository.

Now: the default push target is **the fork of the base repo, if said fork exists** and I have write access to it (even if it's not listed among git remotes), falling back to old behavior otherwise.

This change in the default is to facilitate contributions to projects that have a hard requirement that all pull requests (even those opened by people with write access to the project) always come from forks. If a fork exists, it will automatically get used as a push target.

Fixes https://github.com/cli/cli/issues/350