### PR TITLE
Respect base repository when passing URL argument to `pr checkout/view`

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -255,9 +255,21 @@ func prView(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := determineBaseRepo(cmd, ctx)
-	if err != nil {
-		return err
+	var baseRepo ghrepo.Interface
+	var prArg string
+	if len(args) > 0 {
+		prArg = args[0]
+		if prNum, repo := prFromURL(prArg); repo != nil {
+			prArg = prNum
+			baseRepo = repo
+		}
+	}
+
+	if baseRepo == nil {
+		baseRepo, err = determineBaseRepo(cmd, ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	preview, err := cmd.Flags().GetBool("preview")
@@ -268,7 +280,7 @@ func prView(cmd *cobra.Command, args []string) error {
 	var openURL string
 	var pr *api.PullRequest
 	if len(args) > 0 {
-		pr, err = prFromArg(apiClient, baseRepo, args[0])
+		pr, err = prFromArg(apiClient, baseRepo, prArg)
 		if err != nil {
 			return err
 		}
@@ -331,13 +343,15 @@ func printPrPreview(out io.Writer, pr *api.PullRequest) error {
 
 var prURLRE = regexp.MustCompile(`^https://github\.com/([^/]+)/([^/]+)/pull/(\d+)`)
 
+func prFromURL(arg string) (string, ghrepo.Interface) {
+	if m := prURLRE.FindStringSubmatch(arg); m != nil {
+		return m[3], ghrepo.New(m[1], m[2])
+	}
+	return "", nil
+}
+
 func prFromArg(apiClient *api.Client, baseRepo ghrepo.Interface, arg string) (*api.PullRequest, error) {
 	if prNumber, err := strconv.Atoi(strings.TrimPrefix(arg, "#")); err == nil {
-		return api.PullRequestByNumber(apiClient, baseRepo, prNumber)
-	}
-
-	if m := prURLRE.FindStringSubmatch(arg); m != nil {
-		prNumber, _ := strconv.Atoi(m[3])
 		return api.PullRequestByNumber(apiClient, baseRepo, prNumber)
 	}
 

--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/cli/cli/git"
+	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -18,19 +19,36 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	// FIXME: duplicates logic from fsContext.BaseRepo
-	baseRemote, err := remotes.FindByName("upstream", "github", "origin", "*")
-	if err != nil {
-		return err
-	}
+
 	apiClient, err := apiClientForContext(ctx)
 	if err != nil {
 		return err
 	}
 
-	pr, err := prFromArg(apiClient, baseRemote, args[0])
+	var baseRepo ghrepo.Interface
+	prArg := args[0]
+	if prNum, repo := prFromURL(prArg); repo != nil {
+		prArg = prNum
+		baseRepo = repo
+	}
+
+	if baseRepo == nil {
+		baseRepo, err = determineBaseRepo(cmd, ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	pr, err := prFromArg(apiClient, baseRepo, prArg)
 	if err != nil {
 		return err
+	}
+
+	baseRemote, _ := remotes.FindByRepo(baseRepo.RepoOwner(), baseRepo.RepoName())
+	// baseRemoteSpec is a repository URL or a remote name to be used in git fetch
+	baseURLOrName := fmt.Sprintf("https://github.com/%s.git", ghrepo.FullName(baseRepo))
+	if baseRemote != nil {
+		baseURLOrName = baseRemote.Name
 	}
 
 	headRemote := baseRemote
@@ -67,15 +85,15 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 		ref := fmt.Sprintf("refs/pull/%d/head", pr.Number)
 		if newBranchName == currentBranch {
 			// PR head matches currently checked out branch
-			cmdQueue = append(cmdQueue, []string{"git", "fetch", baseRemote.Name, ref})
+			cmdQueue = append(cmdQueue, []string{"git", "fetch", baseURLOrName, ref})
 			cmdQueue = append(cmdQueue, []string{"git", "merge", "--ff-only", "FETCH_HEAD"})
 		} else {
 			// create a new branch
-			cmdQueue = append(cmdQueue, []string{"git", "fetch", baseRemote.Name, fmt.Sprintf("%s:%s", ref, newBranchName)})
+			cmdQueue = append(cmdQueue, []string{"git", "fetch", baseURLOrName, fmt.Sprintf("%s:%s", ref, newBranchName)})
 			cmdQueue = append(cmdQueue, []string{"git", "checkout", newBranchName})
 		}
 
-		remote := baseRemote.Name
+		remote := baseURLOrName
 		mergeRef := ref
 		if pr.MaintainerCanModify {
 			remote = fmt.Sprintf("https://github.com/%s/%s.git", pr.HeadRepositoryOwner.Login, pr.HeadRepository.Name)

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -635,7 +635,6 @@ func TestPRView_numberArgWithHash(t *testing.T) {
 func TestPRView_urlArg(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
-	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequest": {


### PR DESCRIPTION
Previously, the repository owner+name component of the URL was ignored and only the pull request number was read. Now, the URL dictates which base repository will be used.

As a bonus fix, the global `--repo` argument is now respected for `pr checkout`. https://github.com/cli/cli/pull/633#issuecomment-597825711

Fixes https://github.com/cli/cli/issues/408