### PR TITLE
Enable tests to capture spinner output

### DIFF
--- a/command/repo.go
+++ b/command/repo.go
@@ -295,7 +295,7 @@ func repoFork(cmd *cobra.Command, args []string) error {
 
 	greenCheck := utils.Green("✓")
 	out := colorableOut(cmd)
-	s := utils.Spinner()
+	s := utils.Spinner(out)
 	loading := utils.Gray("Forking ") + utils.Bold(utils.Gray(ghrepo.FullName(toFork))) + utils.Gray("...")
 	s.Suffix = " " + loading
 	s.FinalMSG = utils.Gray(fmt.Sprintf("- %s\n", loading))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -68,6 +69,8 @@ func Humanize(s string) string {
 	return strings.Map(h, s)
 }
 
-func Spinner() *spinner.Spinner {
-	return spinner.New(spinner.CharSets[11], 400*time.Millisecond)
+func Spinner(w io.Writer) *spinner.Spinner {
+	s := spinner.New(spinner.CharSets[11], 400*time.Millisecond)
+	s.Writer = w
+	return s
 }


### PR DESCRIPTION
Explicitly assign the writer stream for the progress spinner so that tests may override it.

The default when not in testing stays the same: the output stream is the colorable stdout.

I spotted this by seeing `- Forking OWNER/REPO...` output mixed together with a failure of a test unrelated to `repo fork`.