### PR TITLE
respect -B when checking for existing pull requests

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -288,7 +288,7 @@ func prView(cmd *cobra.Command, args []string) error {
 				}
 			}
 		} else {
-			pr, err = api.PullRequestForBranch(apiClient, baseRepo, branchWithOwner)
+			pr, err = api.PullRequestForBranch(apiClient, baseRepo, "", branchWithOwner)
 			if err != nil {
 				return err
 			}
@@ -341,7 +341,7 @@ func prFromArg(apiClient *api.Client, baseRepo ghrepo.Interface, arg string) (*a
 		return api.PullRequestByNumber(apiClient, baseRepo, prNumber)
 	}
 
-	return api.PullRequestForBranch(apiClient, baseRepo, arg)
+	return api.PullRequestForBranch(apiClient, baseRepo, "", arg)
 }
 
 func prSelectorForCurrentBranch(ctx context.Context, baseRepo ghrepo.Interface) (prNumber int, prHeadRef string, err error) {

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -132,13 +132,13 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 		if headRepo != nil && !ghrepo.IsSame(baseRepo, headRepo) {
 			headBranchLabel = fmt.Sprintf("%s:%s", headRepo.RepoOwner(), headBranch)
 		}
-		existingPR, err := api.PullRequestForBranch(client, baseRepo, headBranchLabel)
+		existingPR, err := api.PullRequestForBranch(client, baseRepo, baseBranch, headBranchLabel)
 		var notFound *api.NotFoundError
 		if err != nil && !errors.As(err, &notFound) {
 			return fmt.Errorf("error checking for existing pull request: %w", err)
 		}
 		if err == nil {
-			return fmt.Errorf("a pull request for branch %q already exists:\n%s", headBranchLabel, existingPR.URL)
+			return fmt.Errorf("a pull request for branch %q into branch %q already exists:\n%s", headBranchLabel, baseBranch, existingPR.URL)
 		}
 	}
 


### PR DESCRIPTION
closes #686

when checking for existing pull requests for a given branch we weren't taking the base branch into
account, thus preventing -B from being useful once a pull request existed for a given branch.
