### PR TITLE
fix branch detection on empty repo

### DIFF
--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/test"
-	"github.com/cli/cli/utils"
 )
 
 func TestIssueStatus(t *testing.T) {
@@ -229,7 +229,7 @@ func TestIssueView(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -263,7 +263,7 @@ func TestIssueView_numberArgWithHash(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -386,7 +386,7 @@ func TestIssueView_notFound(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -433,7 +433,7 @@ func TestIssueView_urlArg(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -518,7 +518,7 @@ func TestIssueCreate_web(t *testing.T) {
 	http.StubRepoResponse("OWNER", "REPO")
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -544,7 +544,7 @@ func TestIssueCreate_webTitleBody(t *testing.T) {
 	http.StubRepoResponse("OWNER", "REPO")
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})

--- a/command/pr.go
+++ b/command/pr.go
@@ -84,7 +84,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 	repoOverride, _ := cmd.Flags().GetString("repo")
 	currentPRNumber, currentPRHeadRef, err := prSelectorForCurrentBranch(ctx, baseRepo)
 	if err != nil && repoOverride == "" && err.Error() != "git: not on any branch" {
-		return err
+		return fmt.Errorf("could not query for pull request for current branch: %w", err)
 	}
 
 	prPayload, err := api.PullRequests(apiClient, baseRepo, currentPRNumber, currentPRHeadRef, currentUser)

--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/cli/cli/git"
-	"github.com/cli/cli/utils"
+	"github.com/cli/cli/internal/run"
 	"github.com/spf13/cobra"
 )
 
@@ -91,7 +91,7 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		if err := utils.PrepareCmd(cmd).Run(); err != nil {
+		if err := run.PrepareCmd(cmd).Run(); err != nil {
 			return err
 		}
 	}

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -350,7 +350,7 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git config branch.feature.merge":
-			return &test.OutputStub{[]byte("refs/heads/feature\n")}
+			return &test.OutputStub{[]byte("refs/heads/feature\n"), nil}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
 			return &test.OutputStub{}
@@ -400,7 +400,7 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git config branch.feature.merge":
-			return &test.OutputStub{[]byte("refs/heads/feature\n")}
+			return &test.OutputStub{[]byte("refs/heads/feature\n"), nil}
 		default:
 			ranCommands = append(ranCommands, cmd.Args)
 			return &test.OutputStub{}

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -145,7 +145,7 @@ func TestPRCheckout_urlArg_differentBase(t *testing.T) {
 	`))
 
 	ranCommands := [][]string{}
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git show-ref --verify --quiet refs/heads/feature":
 			return &errorStub{"exit status: 1"}

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/cli/cli/context"
+	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/test"
-	"github.com/cli/cli/utils"
 )
 
 func TestPRCheckout_sameRepo(t *testing.T) {
@@ -41,7 +41,7 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 	`))
 
 	ranCommands := [][]string{}
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git show-ref --verify --quiet refs/heads/feature":
 			return &errorStub{"exit status: 1"}
@@ -93,7 +93,7 @@ func TestPRCheckout_urlArg(t *testing.T) {
 	`))
 
 	ranCommands := [][]string{}
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git show-ref --verify --quiet refs/heads/feature":
 			return &errorStub{"exit status: 1"}
@@ -142,7 +142,7 @@ func TestPRCheckout_branchArg(t *testing.T) {
 	`))
 
 	ranCommands := [][]string{}
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git show-ref --verify --quiet refs/heads/feature":
 			return &errorStub{"exit status: 1"}
@@ -191,7 +191,7 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 	`))
 
 	ranCommands := [][]string{}
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git show-ref --verify --quiet refs/heads/feature":
 			return &test.OutputStub{}
@@ -243,7 +243,7 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 	`))
 
 	ranCommands := [][]string{}
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git show-ref --verify --quiet refs/heads/feature":
 			return &errorStub{"exit status: 1"}
@@ -295,7 +295,7 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 	`))
 
 	ranCommands := [][]string{}
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git config branch.feature.merge":
 			return &errorStub{"exit status 1"}
@@ -347,7 +347,7 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 	`))
 
 	ranCommands := [][]string{}
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git config branch.feature.merge":
 			return &test.OutputStub{[]byte("refs/heads/feature\n")}
@@ -397,7 +397,7 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 	`))
 
 	ranCommands := [][]string{}
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git config branch.feature.merge":
 			return &test.OutputStub{[]byte("refs/heads/feature\n")}
@@ -447,7 +447,7 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 	`))
 
 	ranCommands := [][]string{}
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case "git config branch.feature.merge":
 			return &errorStub{"exit status 1"}

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -98,7 +98,7 @@ func TestPRCreate_alreadyExistsDifferentBase(t *testing.T) {
 	`))
 	http.StubResponse(200, bytes.NewBufferString("{}"))
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("")                                         // git status

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -589,7 +589,7 @@ func TestPRCreate_defaults_error_interactive(t *testing.T) {
 }
 
 func Test_determineTrackingBranch_empty(t *testing.T) {
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	remotes := context.Remotes{}
@@ -604,7 +604,7 @@ func Test_determineTrackingBranch_empty(t *testing.T) {
 }
 
 func Test_determineTrackingBranch_noMatch(t *testing.T) {
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	remotes := context.Remotes{
@@ -631,7 +631,7 @@ deadb00f refs/remotes/origin/feature`) // git show-ref --verify (ShowRefs)
 }
 
 func Test_determineTrackingBranch_hasMatch(t *testing.T) {
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	remotes := context.Remotes{
@@ -664,7 +664,7 @@ deadbeef refs/remotes/upstream/feature`) // git show-ref --verify (ShowRefs)
 }
 
 func Test_determineTrackingBranch_respectTrackingConfig(t *testing.T) {
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	remotes := context.Remotes{

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/context"
+	"github.com/cli/cli/test"
 )
 
 func TestPRCreate(t *testing.T) {
@@ -24,7 +25,7 @@ func TestPRCreate(t *testing.T) {
 		} } } }
 	`))
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("")                                         // git status
@@ -68,7 +69,7 @@ func TestPRCreate_alreadyExists(t *testing.T) {
 		] } } } }
 	`))
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("")                                         // git status
@@ -88,7 +89,7 @@ func TestPRCreate_web(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("")                                         // git status
@@ -123,7 +124,7 @@ func TestPRCreate_ReportsUncommittedChanges(t *testing.T) {
 		} } } }
 	`))
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub(" M git/git.go")                            // git status
@@ -193,7 +194,7 @@ func TestPRCreate_cross_repo_same_branch(t *testing.T) {
 		} } } }
 	`))
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("")                                         // git status
@@ -242,7 +243,7 @@ func TestPRCreate_survey_defaults_multicommit(t *testing.T) {
 		} } } }
 	`))
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("")                                         // git status
@@ -312,7 +313,7 @@ func TestPRCreate_survey_defaults_monocommit(t *testing.T) {
 		} } } }
 	`))
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("")                                                        // git status
@@ -383,7 +384,7 @@ func TestPRCreate_survey_autofill(t *testing.T) {
 		} } } }
 	`))
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("")                                                        // git status
@@ -426,7 +427,7 @@ func TestPRCreate_defaults_error_autofill(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("") // git status
@@ -442,7 +443,7 @@ func TestPRCreate_defaults_error_web(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("") // git status
@@ -463,7 +464,7 @@ func TestPRCreate_defaults_error_interactive(t *testing.T) {
 		} } } }
 	`))
 
-	cs, cmdTeardown := initCmdStubber()
+	cs, cmdTeardown := test.InitCmdStubber()
 	defer cmdTeardown()
 
 	cs.Stub("") // git status

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/test"
-	"github.com/cli/cli/utils"
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -108,7 +108,7 @@ func TestPRStatus_fork(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	defer run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case `git config --get-regexp ^branch\.blueberries\.(remote|merge)$`:
 			return &test.OutputStub{[]byte(`branch.blueberries.remote origin
@@ -439,7 +439,7 @@ func TestPRView_previewCurrentBranch(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		return &test.OutputStub{}
 	})
 	defer restoreCmd()
@@ -474,7 +474,7 @@ func TestPRView_previewCurrentBranchWithEmptyBody(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		return &test.OutputStub{}
 	})
 	defer restoreCmd()
@@ -509,7 +509,7 @@ func TestPRView_currentBranch(t *testing.T) {
 	http.StubResponse(200, jsonFile)
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case `git config --get-regexp ^branch\.blueberries\.(remote|merge)$`:
 			return &test.OutputStub{}
@@ -547,7 +547,7 @@ func TestPRView_noResultsForBranch(t *testing.T) {
 	http.StubResponse(200, jsonFile)
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
 		case `git config --get-regexp ^branch\.blueberries\.(remote|merge)$`:
 			return &test.OutputStub{}
@@ -580,7 +580,7 @@ func TestPRView_numberArg(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -612,7 +612,7 @@ func TestPRView_numberArgWithHash(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -644,7 +644,7 @@ func TestPRView_urlArg(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -678,7 +678,7 @@ func TestPRView_branchArg(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -713,7 +713,7 @@ func TestPRView_branchWithOwnerArg(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -112,7 +112,7 @@ func TestPRStatus_fork(t *testing.T) {
 		switch strings.Join(cmd.Args, " ") {
 		case `git config --get-regexp ^branch\.blueberries\.(remote|merge)$`:
 			return &test.OutputStub{[]byte(`branch.blueberries.remote origin
-branch.blueberries.merge refs/heads/blueberries`)}
+branch.blueberries.merge refs/heads/blueberries`), nil}
 		default:
 			panic("not implemented")
 		}

--- a/command/repo.go
+++ b/command/repo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -98,7 +99,7 @@ func repoClone(cmd *cobra.Command, args []string) error {
 	cloneCmd.Stdin = os.Stdin
 	cloneCmd.Stdout = os.Stdout
 	cloneCmd.Stderr = os.Stderr
-	return utils.PrepareCmd(cloneCmd).Run()
+	return run.PrepareCmd(cloneCmd).Run()
 }
 
 func repoCreate(cmd *cobra.Command, args []string) error {
@@ -198,7 +199,7 @@ func repoCreate(cmd *cobra.Command, args []string) error {
 		remoteAdd := git.GitCommand("remote", "add", "origin", remoteURL)
 		remoteAdd.Stdout = os.Stdout
 		remoteAdd.Stderr = os.Stderr
-		err = utils.PrepareCmd(remoteAdd).Run()
+		err = run.PrepareCmd(remoteAdd).Run()
 		if err != nil {
 			return err
 		}
@@ -218,14 +219,14 @@ func repoCreate(cmd *cobra.Command, args []string) error {
 			gitInit := git.GitCommand("init", path)
 			gitInit.Stdout = os.Stdout
 			gitInit.Stderr = os.Stderr
-			err = utils.PrepareCmd(gitInit).Run()
+			err = run.PrepareCmd(gitInit).Run()
 			if err != nil {
 				return err
 			}
 			gitRemoteAdd := git.GitCommand("-C", path, "remote", "add", "origin", remoteURL)
 			gitRemoteAdd.Stdout = os.Stdout
 			gitRemoteAdd.Stderr = os.Stderr
-			err = utils.PrepareCmd(gitRemoteAdd).Run()
+			err = run.PrepareCmd(gitRemoteAdd).Run()
 			if err != nil {
 				return err
 			}
@@ -364,7 +365,7 @@ func repoFork(cmd *cobra.Command, args []string) error {
 			cloneCmd.Stdin = os.Stdin
 			cloneCmd.Stdout = os.Stdout
 			cloneCmd.Stderr = os.Stderr
-			err = utils.PrepareCmd(cloneCmd).Run()
+			err = run.PrepareCmd(cloneCmd).Run()
 			if err != nil {
 				return fmt.Errorf("failed to clone fork: %w", err)
 			}

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/cli/cli/context"
+	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/test"
-	"github.com/cli/cli/utils"
 )
 
 func TestRepoFork_already_forked(t *testing.T) {
@@ -116,7 +116,7 @@ func TestRepoFork_in_parent_yes(t *testing.T) {
 	defer http.StubWithFixture(200, "forkResult.json")()
 
 	var seenCmds []*exec.Cmd
-	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	defer run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmds = append(seenCmds, cmd)
 		return &test.OutputStub{}
 	})()
@@ -155,7 +155,7 @@ func TestRepoFork_outside_yes(t *testing.T) {
 	defer http.StubWithFixture(200, "forkResult.json")()
 
 	var seenCmd *exec.Cmd
-	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	defer run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})()
@@ -187,7 +187,7 @@ func TestRepoFork_outside_survey_yes(t *testing.T) {
 	defer http.StubWithFixture(200, "forkResult.json")()
 
 	var seenCmd *exec.Cmd
-	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	defer run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})()
@@ -226,7 +226,7 @@ func TestRepoFork_outside_survey_no(t *testing.T) {
 	defer http.StubWithFixture(200, "forkResult.json")()
 
 	cmdRun := false
-	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	defer run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		cmdRun = true
 		return &test.OutputStub{}
 	})()
@@ -262,7 +262,7 @@ func TestRepoFork_in_parent_survey_yes(t *testing.T) {
 	defer http.StubWithFixture(200, "forkResult.json")()
 
 	var seenCmds []*exec.Cmd
-	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	defer run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmds = append(seenCmds, cmd)
 		return &test.OutputStub{}
 	})()
@@ -310,7 +310,7 @@ func TestRepoFork_in_parent_survey_no(t *testing.T) {
 	defer http.StubWithFixture(200, "forkResult.json")()
 
 	cmdRun := false
-	defer utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	defer run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		cmdRun = true
 		return &test.OutputStub{}
 	})()
@@ -368,7 +368,7 @@ func TestRepoClone(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var seenCmd *exec.Cmd
-			restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+			restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 				seenCmd = cmd
 				return &test.OutputStub{}
 			})
@@ -408,7 +408,7 @@ func TestRepoCreate(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -473,7 +473,7 @@ func TestRepoCreate_org(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -538,7 +538,7 @@ func TestRepoCreate_orgWithTeam(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -580,7 +580,6 @@ func TestRepoCreate_orgWithTeam(t *testing.T) {
 	}
 }
 
-
 func TestRepoView(t *testing.T) {
 	initBlankContext("OWNER/REPO", "master")
 	http := initFakeHTTP()
@@ -590,7 +589,7 @@ func TestRepoView(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -623,7 +622,7 @@ func TestRepoView_ownerRepo(t *testing.T) {
 	`))
 
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})
@@ -655,7 +654,7 @@ func TestRepoView_fullURL(t *testing.T) {
 	{ }
 	`))
 	var seenCmd *exec.Cmd
-	restoreCmd := utils.SetPrepareCmd(func(cmd *exec.Cmd) utils.Runnable {
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
 		return &test.OutputStub{}
 	})

--- a/command/testing.go
+++ b/command/testing.go
@@ -3,7 +3,6 @@ package command
 import (
 	"errors"
 	"fmt"
-	"os/exec"
 	"reflect"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -11,42 +10,7 @@ import (
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
-	"github.com/cli/cli/internal/run"
-	"github.com/cli/cli/test"
 )
-
-// TODO this is split between here and test/helpers.go. I did that because otherwise our test
-// package would have to import utils (for utils.Runnable) which felt wrong. while utils_test
-// currently doesn't import test helpers, i don't see why that ought to be precluded.
-// I'm wondering if this is a case for having a global package just for storing Interfaces.
-type CmdStubber struct {
-	Stubs []*test.OutputStub
-	Count int
-	Calls []*exec.Cmd
-}
-
-func initCmdStubber() (*CmdStubber, func()) {
-	cs := CmdStubber{}
-	teardown := run.SetPrepareCmd(createStubbedPrepareCmd(&cs))
-	return &cs, teardown
-}
-
-func (cs *CmdStubber) Stub(desiredOutput string) {
-	// TODO maybe have some kind of command mapping but going simple for now
-	cs.Stubs = append(cs.Stubs, &test.OutputStub{[]byte(desiredOutput)})
-}
-
-func createStubbedPrepareCmd(cs *CmdStubber) func(*exec.Cmd) run.Runnable {
-	return func(cmd *exec.Cmd) run.Runnable {
-		cs.Calls = append(cs.Calls, cmd)
-		call := cs.Count
-		cs.Count += 1
-		if call >= len(cs.Stubs) {
-			panic(fmt.Sprintf("more execs than stubs. most recent call: %v", cmd))
-		}
-		return cs.Stubs[call]
-	}
-}
 
 type askStubber struct {
 	Asks  [][]*survey.Question

--- a/command/testing.go
+++ b/command/testing.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
+	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/test"
-	"github.com/cli/cli/utils"
 )
 
 // TODO this is split between here and test/helpers.go. I did that because otherwise our test
@@ -27,7 +27,7 @@ type CmdStubber struct {
 
 func initCmdStubber() (*CmdStubber, func()) {
 	cs := CmdStubber{}
-	teardown := utils.SetPrepareCmd(createStubbedPrepareCmd(&cs))
+	teardown := run.SetPrepareCmd(createStubbedPrepareCmd(&cs))
 	return &cs, teardown
 }
 
@@ -36,8 +36,8 @@ func (cs *CmdStubber) Stub(desiredOutput string) {
 	cs.Stubs = append(cs.Stubs, &test.OutputStub{[]byte(desiredOutput)})
 }
 
-func createStubbedPrepareCmd(cs *CmdStubber) func(*exec.Cmd) utils.Runnable {
-	return func(cmd *exec.Cmd) utils.Runnable {
+func createStubbedPrepareCmd(cs *CmdStubber) func(*exec.Cmd) run.Runnable {
+	return func(cmd *exec.Cmd) run.Runnable {
 		cs.Calls = append(cs.Calls, cmd)
 		call := cs.Count
 		cs.Count += 1

--- a/context/context.go
+++ b/context/context.go
@@ -184,7 +184,7 @@ func (c *fsContext) Branch() (string, error) {
 
 	currentBranch, err := git.CurrentBranch()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("could not determine current branch: %w", err)
 	}
 
 	c.branch = currentBranch

--- a/git/git.go
+++ b/git/git.go
@@ -29,10 +29,12 @@ func CurrentBranch() (string, error) {
 		return firstLine(output), nil
 	}
 
-	ce := err.(*run.CmdError)
-	if ce.Stderr.Len() == 0 {
-		// Detached head
-		return "", errors.New("git: not on any branch")
+	var cmdErr *run.CmdError
+	if errors.As(err, &cmdErr) {
+		if cmdErr.Stderr.Len() == 0 {
+			// Detached head
+			return "", errors.New("git: not on any branch")
+		}
 	}
 
 	// Unknown error

--- a/git/git.go
+++ b/git/git.go
@@ -21,6 +21,15 @@ func VerifyRef(ref string) bool {
 
 // CurrentBranch reads the checked-out branch for the git repository
 func CurrentBranch() (string, error) {
+	err := utils.PrepareCmd(GitCommand("log")).Run()
+	if err != nil {
+		// this is a hack.
+		errRe := regexp.MustCompile("your current branch '([^']+)' does not have any commits yet")
+		matches := errRe.FindAllStringSubmatch(err.Error(), -1)
+		if len(matches) > 0 && matches[0][1] != "" {
+			return matches[0][1], nil
+		}
+	}
 	// we avoid using `git branch --show-current` for compatibility with git < 2.22
 	branchCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	output, err := utils.PrepareCmd(branchCmd).Output()

--- a/git/git.go
+++ b/git/git.go
@@ -21,7 +21,6 @@ func VerifyRef(ref string) bool {
 
 // CurrentBranch reads the checked-out branch for the git repository
 func CurrentBranch() (string, error) {
-
 	refCmd := GitCommand("symbolic-ref", "--quiet", "--short", "HEAD")
 
 	output, err := run.PrepareCmd(refCmd).Output()

--- a/git/git.go
+++ b/git/git.go
@@ -28,7 +28,7 @@ func CurrentBranch() (string, error) {
 		matches := errRe.FindAllStringSubmatch(err.Error(), -1)
 		if len(matches) > 0 && matches[0][1] != "" {
 			return matches[0][1], nil
-		}
+		} // else we continue on. it's weird that git log failed but we'll let other errors surface.
 	}
 	// we avoid using `git branch --show-current` for compatibility with git < 2.22
 	branchCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -37,27 +37,6 @@ func Test_UncommittedChangeCount(t *testing.T) {
 	}
 }
 
-func Test_CurrentBranch_no_commits(t *testing.T) {
-	cs, teardown := test.InitCmdStubber()
-	defer teardown()
-
-	expected := "branch-name"
-
-	cs.StubError("")
-	cs.Stub(expected)
-
-	result, err := CurrentBranch()
-	if err != nil {
-		t.Errorf("got unexpected error: %w", err)
-	}
-	if len(cs.Calls) != 2 {
-		t.Errorf("expected 2 git calls, saw %d", len(cs.Calls))
-	}
-	if result != expected {
-		t.Errorf("unexpected branch name: %s instead of %s", result, expected)
-	}
-}
-
 func Test_CurrentBranch(t *testing.T) {
 	cs, teardown := test.InitCmdStubber()
 	defer teardown()
@@ -82,13 +61,33 @@ func Test_CurrentBranch_detached_head(t *testing.T) {
 	cs, teardown := test.InitCmdStubber()
 	defer teardown()
 
-	cs.Stub("HEAD")
+	cs.StubError("")
 
 	_, err := CurrentBranch()
 	if err == nil {
 		t.Errorf("expected an error")
 	}
 	expectedError := "git: not on any branch"
+	if err.Error() != expectedError {
+		t.Errorf("got unexpected error: %s instead of %s", err.Error(), expectedError)
+	}
+	if len(cs.Calls) != 1 {
+		t.Errorf("expected 1 git call, saw %d", len(cs.Calls))
+	}
+}
+
+func Test_CurrentBranch_unexpected_error(t *testing.T) {
+	cs, teardown := test.InitCmdStubber()
+	defer teardown()
+
+	cs.StubError("lol")
+
+	expectedError := "lol\nstub: lol"
+
+	_, err := CurrentBranch()
+	if err == nil {
+		t.Errorf("expected an error")
+	}
 	if err.Error() != expectedError {
 		t.Errorf("got unexpected error: %s instead of %s", err.Error(), expectedError)
 	}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -27,7 +27,7 @@ func Test_UncommittedChangeCount(t *testing.T) {
 
 	for _, v := range cases {
 		_ = run.SetPrepareCmd(func(*exec.Cmd) run.Runnable {
-			return &test.OutputStub{[]byte(v.Output)}
+			return &test.OutputStub{[]byte(v.Output), nil}
 		})
 		ucc, _ := UncommittedChangeCount()
 

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -4,8 +4,8 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/test"
-	"github.com/cli/cli/utils"
 )
 
 func Test_UncommittedChangeCount(t *testing.T) {
@@ -20,13 +20,13 @@ func Test_UncommittedChangeCount(t *testing.T) {
 		c{Label: "untracked file", Expected: 2, Output: " M poem.txt\n?? new.txt"},
 	}
 
-	teardown := utils.SetPrepareCmd(func(*exec.Cmd) utils.Runnable {
+	teardown := run.SetPrepareCmd(func(*exec.Cmd) run.Runnable {
 		return &test.OutputStub{}
 	})
 	defer teardown()
 
 	for _, v := range cases {
-		_ = utils.SetPrepareCmd(func(*exec.Cmd) utils.Runnable {
+		_ = run.SetPrepareCmd(func(*exec.Cmd) run.Runnable {
 			return &test.OutputStub{[]byte(v.Output)}
 		})
 		ucc, _ := UncommittedChangeCount()

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"os/exec"
 	"testing"
 
@@ -35,4 +36,22 @@ func Test_UncommittedChangeCount(t *testing.T) {
 			t.Errorf("got unexpected ucc value: %d for case %s", ucc, v.Label)
 		}
 	}
+}
+
+func Test_CurrentBranch_no_commits(t *testing.T) {
+	cs, teardown := test.InitCmdStubber()
+	defer teardown()
+
+	expected := "cool_branch-name"
+
+	cs.StubError(fmt.Sprintf("fatal: your current branch '%s' does not have any commits yet", expected))
+
+	result, err := CurrentBranch()
+	if err != nil {
+		t.Errorf("got unexpected error: %w", err)
+	}
+	if result != expected {
+		t.Errorf("unexpected branch name: %s instead of %s", result, expected)
+	}
+
 }

--- a/git/remote.go
+++ b/git/remote.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cli/cli/utils"
+	"github.com/cli/cli/internal/run"
 )
 
 var remoteRE = regexp.MustCompile(`(.+)\s+(.+)\s+\((push|fetch)\)`)
@@ -76,7 +76,7 @@ func parseRemotes(gitRemotes []string) (remotes RemoteSet) {
 // after the fetch.
 func AddRemote(name, initURL, finalURL string) (*Remote, error) {
 	addCmd := exec.Command("git", "remote", "add", "-f", name, initURL)
-	err := utils.PrepareCmd(addCmd).Run()
+	err := run.PrepareCmd(addCmd).Run()
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func AddRemote(name, initURL, finalURL string) (*Remote, error) {
 		finalURL = initURL
 	} else {
 		setCmd := exec.Command("git", "remote", "set-url", name, finalURL)
-		err := utils.PrepareCmd(setCmd).Run()
+		err := run.PrepareCmd(setCmd).Run()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -1,4 +1,4 @@
-package utils
+package run
 
 import (
 	"bytes"

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1,13 +1,5 @@
 package test
 
-import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"path/filepath"
-)
-
 // OutputStub implements a simple utils.Runnable
 type OutputStub struct {
 	Out []byte
@@ -19,58 +11,4 @@ func (s OutputStub) Output() ([]byte, error) {
 
 func (s OutputStub) Run() error {
 	return nil
-}
-
-type TempGitRepo struct {
-	Remote   string
-	TearDown func()
-}
-
-func UseTempGitRepo() *TempGitRepo {
-	pwd, _ := os.Getwd()
-	oldEnv := make(map[string]string)
-	overrideEnv := func(name, value string) {
-		oldEnv[name] = os.Getenv(name)
-		os.Setenv(name, value)
-	}
-
-	remotePath := filepath.Join(pwd, "..", "test", "fixtures", "test.git")
-	home, err := ioutil.TempDir("", "test-repo")
-	if err != nil {
-		panic(err)
-	}
-
-	overrideEnv("HOME", home)
-	overrideEnv("XDG_CONFIG_HOME", "")
-	overrideEnv("XDG_CONFIG_DIRS", "")
-
-	targetPath := filepath.Join(home, "test.git")
-	cmd := exec.Command("git", "clone", remotePath, targetPath)
-	if output, err := cmd.Output(); err != nil {
-		panic(fmt.Errorf("error running %s\n%s\n%s", cmd, err, output))
-	}
-
-	if err = os.Chdir(targetPath); err != nil {
-		panic(err)
-	}
-
-	// Our libs expect the origin to be a github url
-	cmd = exec.Command("git", "remote", "set-url", "origin", "https://github.com/github/FAKE-GITHUB-REPO-NAME")
-	if output, err := cmd.Output(); err != nil {
-		panic(fmt.Errorf("error running %s\n%s\n%s", cmd, err, output))
-	}
-
-	tearDown := func() {
-		if err := os.Chdir(pwd); err != nil {
-			panic(err)
-		}
-		for name, value := range oldEnv {
-			os.Setenv(name, value)
-		}
-		if err = os.RemoveAll(home); err != nil {
-			panic(err)
-		}
-	}
-
-	return &TempGitRepo{Remote: remotePath, TearDown: tearDown}
 }

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -13,7 +14,7 @@ import (
 // OutputStub implements a simple utils.Runnable
 type OutputStub struct {
 	Out   []byte
-	Error error
+	Error *run.CmdError
 }
 
 func (s OutputStub) Output() ([]byte, error) {
@@ -47,9 +48,11 @@ func (cs *CmdStubber) Stub(desiredOutput string) {
 	cs.Stubs = append(cs.Stubs, &OutputStub{[]byte(desiredOutput), nil})
 }
 
-func (cs *CmdStubber) StubError(msg string) {
-	// TODO consider handling CmdErr instead of a raw error
-	cs.Stubs = append(cs.Stubs, &OutputStub{[]byte{}, errors.New(msg)})
+func (cs *CmdStubber) StubError(errText string) {
+	stderrBuff := bytes.NewBufferString(errText)
+	args := []string{"stub"} // TODO make more real?
+	err := errors.New(errText)
+	cs.Stubs = append(cs.Stubs, &OutputStub{[]byte{}, &run.CmdError{stderrBuff, args, err}})
 }
 
 func createStubbedPrepareCmd(cs *CmdStubber) func(*exec.Cmd) run.Runnable {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1,5 +1,12 @@
 package test
 
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/cli/cli/internal/run"
+)
+
 // OutputStub implements a simple utils.Runnable
 type OutputStub struct {
 	Out []byte
@@ -11,4 +18,33 @@ func (s OutputStub) Output() ([]byte, error) {
 
 func (s OutputStub) Run() error {
 	return nil
+}
+
+type CmdStubber struct {
+	Stubs []*OutputStub
+	Count int
+	Calls []*exec.Cmd
+}
+
+func InitCmdStubber() (*CmdStubber, func()) {
+	cs := CmdStubber{}
+	teardown := run.SetPrepareCmd(createStubbedPrepareCmd(&cs))
+	return &cs, teardown
+}
+
+func (cs *CmdStubber) Stub(desiredOutput string) {
+	// TODO maybe have some kind of command mapping but going simple for now
+	cs.Stubs = append(cs.Stubs, &OutputStub{[]byte(desiredOutput)})
+}
+
+func createStubbedPrepareCmd(cs *CmdStubber) func(*exec.Cmd) run.Runnable {
+	return func(cmd *exec.Cmd) run.Runnable {
+		cs.Calls = append(cs.Calls, cmd)
+		call := cs.Count
+		cs.Count += 1
+		if call >= len(cs.Stubs) {
+			panic(fmt.Sprintf("more execs than stubs. most recent call: %v", cmd))
+		}
+		return cs.Stubs[call]
+	}
 }

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -14,7 +14,7 @@ import (
 // OutputStub implements a simple utils.Runnable
 type OutputStub struct {
 	Out   []byte
-	Error *run.CmdError
+	Error error
 }
 
 func (s OutputStub) Output() ([]byte, error) {
@@ -49,6 +49,7 @@ func (cs *CmdStubber) Stub(desiredOutput string) {
 }
 
 func (cs *CmdStubber) StubError(errText string) {
+	// TODO support error types beyond CmdError
 	stderrBuff := bytes.NewBufferString(errText)
 	args := []string{"stub"} // TODO make more real?
 	err := errors.New(errText)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/charmbracelet/glamour"
+	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/pkg/browser"
 )
 
@@ -16,7 +17,7 @@ func OpenInBrowser(url string) error {
 	if err != nil {
 		return err
 	}
-	return PrepareCmd(browseCmd).Run()
+	return run.PrepareCmd(browseCmd).Run()
 }
 
 func RenderMarkdown(text string) (string, error) {


### PR DESCRIPTION
closes #682

~This adds a kind of gross hack to enable branch detection on a repo with no commits. You are "on" a
branch; but without commits `rev-parse` fails. `branch` is also not helpful. i noticed that `log`
tells you the branch you are on (that is lacking commits), so I extracted the branch name from the
error.~

This adds a fallback to `symbolic-ref` when doing branch detection so that it works on an empty repository. `symbolic-ref` is defined as far back as git 1.9.

## testing changes

I took this opportunity to touch `utils.Runnable` and `CmdStubber` some more:

- moved the prepare cmd stuff (including the `Runnable` interface) into its own package,
  `internal/run`
- added `StubError` to `CmdStubber`. This is primitive in that it's working with a raw `error`
  instead of `CmdErr` but I figure it was enough for now.
