### PR TITLE
Prevent crash when encountering "STALE" check conclusion

### DIFF
--- a/api/pull_request_test.go
+++ b/api/pull_request_test.go
@@ -22,7 +22,9 @@ func TestPullRequest_ChecksStatus(t *testing.T) {
 					{ "status": "COMPLETED",
 					  "conclusion": "FAILURE" },
 					{ "status": "COMPLETED",
-					  "conclusion": "ACTION_REQUIRED" }
+					  "conclusion": "ACTION_REQUIRED" },
+					{ "status": "COMPLETED",
+					  "conclusion": "STALE" }
 				]
 			}
 		}
@@ -32,8 +34,8 @@ func TestPullRequest_ChecksStatus(t *testing.T) {
 	eq(t, err, nil)
 
 	checks := pr.ChecksStatus()
-	eq(t, checks.Total, 7)
-	eq(t, checks.Pending, 2)
+	eq(t, checks.Total, 8)
+	eq(t, checks.Pending, 3)
 	eq(t, checks.Failing, 3)
 	eq(t, checks.Passing, 2)
 }

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -120,7 +120,7 @@ func (pr *PullRequest) ChecksStatus() (summary PullRequestChecksStatus) {
 			summary.Passing++
 		case "ERROR", "FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED":
 			summary.Failing++
-		case "EXPECTED", "REQUESTED", "QUEUED", "PENDING", "IN_PROGRESS":
+		case "EXPECTED", "REQUESTED", "QUEUED", "PENDING", "IN_PROGRESS", "STALE":
 			summary.Pending++
 		default:
 			panic(fmt.Errorf("unsupported status: %q", state))


### PR DESCRIPTION
The "STALE" conclusion had shipped this January and is basically a conclusion that can only be reported by GitHub and not explicitly set by any integrations.

I could not decide whether to map it to a "success" or a "failure" state, so I chose "pending" instead.

Fixes #705