### PR TITLE
repo fork: reuse existing git remote if available

### DIFF
--- a/command/repo.go
+++ b/command/repo.go
@@ -328,6 +328,15 @@ func repoFork(cmd *cobra.Command, args []string) error {
 	}
 
 	if inParent {
+		remotes, err := ctx.Remotes()
+		if err != nil {
+			return err
+		}
+		if remote, err := remotes.FindByRepo(forkedRepo.RepoOwner(), forkedRepo.RepoName()); err == nil {
+			fmt.Fprintf(out, "%s Using existing remote %s\n", greenCheck, utils.Bold(remote.Name))
+			return nil
+		}
+
 		remoteDesired := remotePref == "true"
 		if remotePref == "prompt" {
 			err = Confirm("Would you like to add a remote for the fork?", &remoteDesired)

--- a/command/repo.go
+++ b/command/repo.go
@@ -301,14 +301,6 @@ func repoFork(cmd *cobra.Command, args []string) error {
 	s.FinalMSG = utils.Gray(fmt.Sprintf("- %s\n", loading))
 	s.Start()
 
-	authLogin, err := ctx.AuthLogin()
-	if err != nil {
-		s.Stop()
-		return fmt.Errorf("could not determine current username: %w", err)
-	}
-
-	possibleFork := ghrepo.New(authLogin, toFork.RepoName())
-
 	forkedRepo, err := api.ForkRepo(apiClient, toFork)
 	if err != nil {
 		s.Stop()
@@ -325,7 +317,7 @@ func repoFork(cmd *cobra.Command, args []string) error {
 	if created_ago > time.Minute {
 		fmt.Fprintf(out, "%s %s %s\n",
 			utils.Yellow("!"),
-			utils.Bold(ghrepo.FullName(possibleFork)),
+			utils.Bold(ghrepo.FullName(forkedRepo)),
 			"already exists")
 	} else {
 		fmt.Fprintf(out, "%s Created fork %s\n", greenCheck, utils.Bold(ghrepo.FullName(forkedRepo)))

--- a/command/repo.go
+++ b/command/repo.go
@@ -313,8 +313,8 @@ func repoFork(cmd *cobra.Command, args []string) error {
 	// returns the fork repo data even if it already exists -- with no change in status code or
 	// anything. We thus check the created time to see if the repo is brand new or not; if it's not,
 	// we assume the fork already existed and report an error.
-	created_ago := Since(forkedRepo.CreatedAt)
-	if created_ago > time.Minute {
+	createdAgo := Since(forkedRepo.CreatedAt)
+	if createdAgo > time.Minute {
 		fmt.Fprintf(out, "%s %s %s\n",
 			utils.Yellow("!"),
 			utils.Bold(ghrepo.FullName(forkedRepo)),

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -18,9 +18,8 @@ import (
 func TestRepoFork_already_forked(t *testing.T) {
 	initContext = func() context.Context {
 		ctx := context.NewBlank()
-		ctx.SetBaseRepo("REPO")
+		ctx.SetBaseRepo("OWNER/REPO")
 		ctx.SetBranch("master")
-		ctx.SetAuthLogin("someone")
 		ctx.SetRemotes(map[string]string{
 			"origin": "OWNER/REPO",
 		})


### PR DESCRIPTION
Avoid adding a new git remote for a fork if an existing remote is found that points to the exact forked repo.

Fixes #580