### PR TITLE
Use remote tracking branch for base when detecting commits for `pr create`

### DIFF
--- a/api/fake_http.go
+++ b/api/fake_http.go
@@ -54,8 +54,7 @@ func (f *FakeHTTP) StubRepoResponse(owner, repo string) {
 			"name": "%s",
 			"owner": {"login": "%s"},
 			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
+				"name": "master"
 			},
 			"viewerPermission": "WRITE"
 		} } }
@@ -76,8 +75,7 @@ func (f *FakeHTTP) StubForkedRepoResponse(forkFullName, parentFullName string) {
 			"name": "%s",
 			"owner": {"login": "%s"},
 			"defaultBranchRef": {
-				"name": "master",
-				"target": {"oid": "deadbeef"}
+				"name": "master"
 			},
 			"viewerPermission": "ADMIN",
 			"parent": {
@@ -85,8 +83,7 @@ func (f *FakeHTTP) StubForkedRepoResponse(forkFullName, parentFullName string) {
 				"name": "%s",
 				"owner": {"login": "%s"},
 				"defaultBranchRef": {
-					"name": "master",
-					"target": {"oid": "deadbeef"}
+					"name": "master"
 				},
 				"viewerPermission": "READ"
 			}

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -28,10 +28,7 @@ type Repository struct {
 	HasIssuesEnabled bool
 	ViewerPermission string
 	DefaultBranchRef struct {
-		Name   string
-		Target struct {
-			OID string
-		}
+		Name string
 	}
 
 	Parent *Repository
@@ -127,7 +124,6 @@ func RepoNetwork(client *Client, repos []ghrepo.Interface) (RepoNetworkResult, e
 		viewerPermission
 		defaultBranchRef {
 			name
-			target { oid }
 		}
 		isPrivate
 	}

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -122,7 +122,11 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not parse body: %w", err)
 	}
 
-	defs, defaultsErr := computeDefaults(baseBranch, headBranch)
+	baseTrackingBranch := baseBranch
+	if baseRemote, err := remotes.FindByRepo(baseRepo.RepoOwner(), baseRepo.RepoName()); err == nil {
+		baseTrackingBranch = fmt.Sprintf("%s/%s", baseRemote.Name, baseBranch)
+	}
+	defs, defaultsErr := computeDefaults(baseTrackingBranch, headBranch)
 
 	isWeb, err := cmd.Flags().GetBool("web")
 	if err != nil {

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -514,7 +514,7 @@ func TestPRCreate_defaults_error_autofill(t *testing.T) {
 
 	_, err := RunCommand(prCreateCmd, "pr create -f")
 
-	eq(t, err.Error(), "could not compute title or body defaults: could not find any commits between master and feature")
+	eq(t, err.Error(), "could not compute title or body defaults: could not find any commits between origin/master and feature")
 }
 
 func TestPRCreate_defaults_error_web(t *testing.T) {
@@ -532,7 +532,7 @@ func TestPRCreate_defaults_error_web(t *testing.T) {
 
 	_, err := RunCommand(prCreateCmd, "pr create -w")
 
-	eq(t, err.Error(), "could not compute title or body defaults: could not find any commits between master and feature")
+	eq(t, err.Error(), "could not compute title or body defaults: could not find any commits between origin/master and feature")
 }
 
 func TestPRCreate_defaults_error_interactive(t *testing.T) {

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -215,8 +215,7 @@ func TestPRCreate_cross_repo_same_branch(t *testing.T) {
 									"name": "REPO",
 									"owner": {"login": "OWNER"},
 									"defaultBranchRef": {
-										"name": "default",
-										"target": {"oid": "deadbeef"}
+										"name": "default"
 									},
 									"viewerPermission": "READ"
 								},
@@ -226,8 +225,7 @@ func TestPRCreate_cross_repo_same_branch(t *testing.T) {
 										"name": "REPO",
 										"owner": {"login": "OWNER"},
 										"defaultBranchRef": {
-											"name": "default",
-											"target": {"oid": "deadbeef"}
+											"name": "default"
 										},
 										"viewerPermission": "READ"
 									},
@@ -235,8 +233,7 @@ func TestPRCreate_cross_repo_same_branch(t *testing.T) {
 									"name": "REPO",
 									"owner": {"login": "MYSELF"},
 									"defaultBranchRef": {
-										"name": "default",
-										"target": {"oid": "deadbeef"}
+										"name": "default"
 									},
 									"viewerPermission": "WRITE"
 		} } }


### PR DESCRIPTION
This is to avoid errors when a local base branch is missing or out of date.

Fixes #710, closes #713