### PR TITLE
Allow nested clone

### DIFF
--- a/command/repo.go
+++ b/command/repo.go
@@ -21,6 +21,7 @@ import (
 func init() {
 	RootCmd.AddCommand(repoCmd)
 	repoCmd.AddCommand(repoCloneCmd)
+	repoCloneCmd.Flags().Bool("clone-nested", false, "Create nested diretories")
 
 	repoCmd.AddCommand(repoCreateCmd)
 	repoCreateCmd.Flags().StringP("description", "d", "", "Description of repository")
@@ -115,15 +116,23 @@ func repoClone(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	cloneNested, err := cmd.Flags().GetBool("clone-nested")
+	if err != nil {
+		return err
+	}
+
 	cloneArgs := []string{"clone"}
 	cloneArgs = append(cloneArgs, args[1:]...)
 	cloneArgs = append(cloneArgs, cloneURL)
+	if cloneNested {
+		cloneArgs = append(cloneArgs, ghrepo.FullName(repo))
+	}
 
 	cloneCmd := git.GitCommand(cloneArgs...)
 	cloneCmd.Stdin = os.Stdin
 	cloneCmd.Stdout = os.Stdout
 	cloneCmd.Stderr = os.Stderr
-	err := run.PrepareCmd(cloneCmd).Run()
+	err = run.PrepareCmd(cloneCmd).Run()
 	if err != nil {
 		return err
 	}

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -349,6 +349,11 @@ func TestRepoClone(t *testing.T) {
 			want: "git clone https://github.com/OWNER/REPO.git",
 		},
 		{
+			name: "shorthand with nested",
+			args: "repo clone OWNER/REPO --clone-nested",
+			want: "git clone https://github.com/OWNER/REPO.git OWNER/REPO",
+		},
+		{
 			name: "clone arguments",
 			args: "repo clone OWNER/REPO -- -o upstream --depth 1",
 			want: "git clone -o upstream --depth 1 https://github.com/OWNER/REPO.git",

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -210,8 +210,8 @@ func TestRepoFork_outside_yes_nested(t *testing.T) {
 
 	eq(t, output.Stderr(), "")
 
-	eq(t, strings.Join(cs.Calls[0].Args, " "), "git clone https://github.com/someone/repo.git someone/repo")
-	eq(t, strings.Join(cs.Calls[1].Args, " "), "git -C someone/repo remote add upstream https://github.com/OWNER/REPO.git")
+	eq(t, strings.Join(cs.Calls[0].Args, " "), "git clone https://github.com/someone/repo.git someone/REPO")
+	eq(t, strings.Join(cs.Calls[1].Args, " "), "git -C someone/REPO remote add upstream https://github.com/OWNER/REPO.git")
 
 	test.ExpectLines(t, output.String(),
 		"Created fork someone/REPO",
@@ -276,8 +276,8 @@ func TestRepoFork_outside_survey_yes_nested(t *testing.T) {
 
 	eq(t, output.Stderr(), "")
 
-	eq(t, strings.Join(cs.Calls[0].Args, " "), "git clone https://github.com/someone/repo.git someone/repo")
-	eq(t, strings.Join(cs.Calls[1].Args, " "), "git -C someone/repo remote add upstream https://github.com/OWNER/REPO.git")
+	eq(t, strings.Join(cs.Calls[0].Args, " "), "git clone https://github.com/someone/repo.git someone/REPO")
+	eq(t, strings.Join(cs.Calls[1].Args, " "), "git -C someone/REPO remote add upstream https://github.com/OWNER/REPO.git")
 
 	test.ExpectLines(t, output.String(),
 		"Created fork someone/REPO",


### PR DESCRIPTION
Add an option `--clone-nested` to clone the repo to `owner/repo` (naming things is hard, I'm open to suggestions).

This helps for some use cases of https://github.com/cli/cli/issues/653 where people may want to keep their source directory mirroring the org structure. Some tools like [ghq](https://github.com/x-motemen/ghq) do this as well.