### PR TITLE
Assert that running `go fmt` or `go mod tidy` produces no changes in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Verify dependencies
-        run: go mod verify
+        shell: bash
+        run: |
+          go mod verify
+          go mod download
 
       - name: Run tests
         shell: bash

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,8 +20,24 @@ jobs:
       - name: Verify dependencies
         run: go mod verify
 
-      - name: Build
+      - name: Run tests
         shell: bash
         run: |
-          go test -race ./...
-          go build -v ./cmd/gh
+          assert-nothing-changed() {
+            local diff
+            git checkout -- .
+            "$@" >/dev/null || true
+            if ! diff="$(git diff --exit-code)"; then
+              printf '\n\e[31mError: running `\e[31;1m%s\e[31;22m` results in modifications that you must check into version control:\e[0m\n%s\n' "$*" "$diff" >&2
+              return 1
+            fi
+          }
+
+          STATUS=0
+          go test -race ./... || STATUS=$?
+          assert-nothing-changed go fmt ./... || STATUS=$?
+          assert-nothing-changed go mod tidy || STATUS=$?
+          exit $STATUS
+
+      - name: Build
+        run: go build -v ./cmd/gh

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
             local diff
             git checkout -- .
             "$@" >/dev/null || true
-            if ! diff="$(git diff --exit-code)"; then
+            if ! diff="$(git diff -U1 --color --exit-code)"; then
               printf '\n\e[31mError: running `\e[31;1m%s\e[31;22m` results in modifications that you must check into version control:\e[0m\n%s\n' "$*" "$diff" >&2
               return 1
             fi

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
             git checkout -- .
             "$@" >/dev/null || true
             if ! diff="$(git diff -U1 --color --exit-code)"; then
-              printf '\n\e[31mError: running `\e[31;1m%s\e[31;22m` results in modifications that you must check into version control:\e[0m\n%s\n' "$*" "$diff" >&2
+              printf '\n\e[31mError: running `\e[1m%s\e[22m` results in modifications that you must check into version control:\e[0m\n%s\n' "$*" "$diff" >&2
               return 1
             fi
           }


### PR DESCRIPTION
This will help avoid introducing code changes that are not properly formatted, or `go mod` dependency changes that are untidy.

[Example failure output](https://github.com/cli/cli/runs/551915751?check_suite_focus=true)

Ref. 0680bb5c6c230ea6adccbc63c1374fe56d11d971