### PR TITLE
Fix auto-forking scenario in `pr create`

### DIFF
--- a/api/fake_http.go
+++ b/api/fake_http.go
@@ -48,6 +48,10 @@ func (f *FakeHTTP) StubWithFixture(status int, fixtureFileName string) func() {
 }
 
 func (f *FakeHTTP) StubRepoResponse(owner, repo string) {
+	f.StubRepoResponseWithPermission(owner, repo, "WRITE")
+}
+
+func (f *FakeHTTP) StubRepoResponseWithPermission(owner, repo, permission string) {
 	body := bytes.NewBufferString(fmt.Sprintf(`
 		{ "data": { "repo_000": {
 			"id": "REPOID",
@@ -56,9 +60,9 @@ func (f *FakeHTTP) StubRepoResponse(owner, repo string) {
 			"defaultBranchRef": {
 				"name": "master"
 			},
-			"viewerPermission": "WRITE"
+			"viewerPermission": "%s"
 		} } }
-	`, repo, owner))
+	`, repo, owner, permission))
 	resp := &http.Response{
 		StatusCode: 200,
 		Body:       ioutil.NopCloser(body),


### PR DESCRIPTION
When an existing `headRepo` couldn't be detected, it's time to auto-fork one. Unfortunately, an obscure Go behavior made it seem like `headRepo` was a non-nil value, where in fact it did contain a nil pointer which would crash the process.

This avoids ever assigning nil pointers to `var headRepo ghrepo.Interface`. https://golang.org/doc/faq#nil_error

Fixes #722