### PR TITLE
Respect clone target

### DIFF
--- a/command/repo.go
+++ b/command/repo.go
@@ -56,9 +56,7 @@ var repoCloneCmd = &cobra.Command{
 	Short: "Clone a repository locally",
 	Long: `Clone a GitHub repository locally.
 
-To pass 'git clone' options, separate them with '--'.
-
-In order to clone to a specific directory, provide it before the '--' instead of after the other additional options.`,
+To pass 'git clone' flags, separate them with '--'.`,
 	RunE: repoClone,
 }
 

--- a/command/repo.go
+++ b/command/repo.go
@@ -87,7 +87,7 @@ With no argument, the repository for the current directory is displayed.`,
 	RunE: repoView,
 }
 
-func parseExtraArgs(extraArgs []string) (args []string, target string) {
+func parseCloneArgs(extraArgs []string) (args []string, target string) {
 	args = extraArgs
 
 	if len(args) > 0 {
@@ -99,7 +99,7 @@ func parseExtraArgs(extraArgs []string) (args []string, target string) {
 }
 
 func runClone(cloneURL string, args []string) (target string, err error) {
-	cloneArgs, target := parseExtraArgs(args)
+	cloneArgs, target := parseCloneArgs(args)
 
 	cloneArgs = append(cloneArgs, cloneURL)
 

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -383,7 +383,7 @@ func TestParseExtraArgs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args, dir := parseExtraArgs(tt.args)
+			args, dir := parseCloneArgs(tt.args)
 			got := Wanted{
 				args: args,
 				dir:  dir,

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os/exec"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -337,6 +338,65 @@ func TestRepoFork_in_parent_survey_no(t *testing.T) {
 	}
 }
 
+func TestParseExtraArgs(t *testing.T) {
+	type Wanted struct {
+		args []string
+		dir  string
+	}
+	tests := []struct {
+		name string
+		args []string
+		want Wanted
+	}{
+		{
+			name: "args and target",
+			args: []string{"target_directory", "-o", "upstream", "--depth", "1"},
+			want: Wanted{
+				args: []string{"-o", "upstream", "--depth", "1"},
+				dir:  "target_directory",
+			},
+		},
+		{
+			name: "only args",
+			args: []string{"-o", "upstream", "--depth", "1"},
+			want: Wanted{
+				args: []string{"-o", "upstream", "--depth", "1"},
+				dir:  "",
+			},
+		},
+		{
+			name: "only target",
+			args: []string{"target_directory"},
+			want: Wanted{
+				args: []string{},
+				dir:  "target_directory",
+			},
+		},
+		{
+			name: "no args",
+			args: []string{},
+			want: Wanted{
+				args: []string{},
+				dir:  "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, dir := parseExtraArgs(tt.args)
+			got := Wanted{
+				args: args,
+				dir:  dir,
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %#v want %#v", got, tt.want)
+			}
+		})
+	}
+
+}
+
 func TestRepoClone(t *testing.T) {
 	tests := []struct {
 		name string
@@ -349,9 +409,19 @@ func TestRepoClone(t *testing.T) {
 			want: "git clone https://github.com/OWNER/REPO.git",
 		},
 		{
+			name: "shorthand with directory",
+			args: "repo clone OWNER/REPO target_directory",
+			want: "git clone https://github.com/OWNER/REPO.git target_directory",
+		},
+		{
 			name: "clone arguments",
 			args: "repo clone OWNER/REPO -- -o upstream --depth 1",
 			want: "git clone -o upstream --depth 1 https://github.com/OWNER/REPO.git",
+		},
+		{
+			name: "clone arguments with directory",
+			args: "repo clone OWNER/REPO target_directory -- -o upstream --depth 1",
+			want: "git clone -o upstream --depth 1 https://github.com/OWNER/REPO.git target_directory",
 		},
 		{
 			name: "HTTPS URL",


### PR DESCRIPTION
Fixes #653 

This allows a user to specify the target directory to clone to as part of the additional arguments.

It's not the prettiest implementation, but it works. It essentially parses the extra args to find any orphaned ones, Ideally we could somehow leverage git's actual command line arg parsing, maybe through something like this. But this is pretty much my first go code, so I wasn't really sure how to go about doing that.

Based on conversation in #721, this functionality was separated into it's own feature.