### PR TITLE
Bring back `#installation` anchor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ tools bring GitHub to the terminal, `hub` behaves as a proxy to `git` and `gh` i
 tool. Check out our [more detailed explanation](/docs/gh-vs-hub.md) to learn more.
 
 
-## Installation and Upgrading
+<!-- this anchor is linked to from elsewhere, so avoid renaming it -->
+## Installation
 
 ### macOS
 


### PR DESCRIPTION
This is linked to from GitHub.com call-to-action to install CLI.

Ref. 53b5c22478fedab746d41b2d62ebc4abef855879