### PR TITLE
add MacPorts usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@ tool. Check out our [more detailed explanation](/docs/gh-vs-hub.md) to learn mor
 
 ### macOS
 
-`gh` is available via [brew][] and [MacPorts][].
+`gh` is available via Homebrew and MacPorts.
 
-#### brew
+#### Homebrew
 
 Install: `brew install github/gh/gh`
 
-Upgrade: `brew update && brew upgrade gh`
+Upgrade: `brew upgrade gh`
 
 #### MacPorts
 
-Install `sudo port install gh`
+Install: `sudo port install gh`
 
 Upgrade: `sudo port selfupdate && sudo port upgrade gh`
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,19 @@ tool. Check out our [more detailed explanation](/docs/gh-vs-hub.md) to learn mor
 
 ### macOS
 
+`gh` is available via [brew][] and [MacPorts][].
+
+#### brew
+
 Install: `brew install github/gh/gh`
 
 Upgrade: `brew update && brew upgrade gh`
+
+#### MacPorts
+
+Install `sudo port install gh`
+
+Upgrade: `sudo port selfupdate && sudo port upgrade gh`
 
 ### Windows
 


### PR DESCRIPTION
Addresses #367 , even if it's been discussed and closed.

MacPorts has had 'gh' since Feb 13 (version 0.5.4). I understand the 'gh' developers have chosen "to support Homebrew for macOS officially", and you will not provide support for MacPorts.

We in MacPorts will support our own, as we do already for what we provide. When relevant, we push upstream fixes we have developed or determined appropriate to use -- contributing back to the greater good -- as well as keep projects updated in MacPorts as best our times allows.

This gh change is purely to the top-level ReadMe, noting that gh is available from both Brew and MacPorts, and how to install and update it for both. If you would prefer language that you officially support Brew and not MacPorts, that's your option. But, I don't see anything lost by noting MacPorts support for gh.

Thank you for considering this change.