### PR TITLE
Check for $EDITOR before $VISUAL

### DIFF
--- a/pkg/surveyext/editor.go
+++ b/pkg/surveyext/editor.go
@@ -27,10 +27,10 @@ func init() {
 		editor = "notepad"
 	} else if g := os.Getenv("GIT_EDITOR"); g != "" {
 		editor = g
-	} else if v := os.Getenv("VISUAL"); v != "" {
-		editor = v
 	} else if e := os.Getenv("EDITOR"); e != "" {
 		editor = e
+	} else if v := os.Getenv("VISUAL"); v != "" {
+		editor = v
 	}
 }
 


### PR DESCRIPTION
I've been trying to figure out why `gh` kept offering to use `vim` instead of `micro`, which I had defined as `EDITOR` in my shell config. I discovered that something seems to have set `VISUAL` to `vim`, and `gh` was giving precedence to it over `EDITOR`.

I actually didn't even know about this variable until I read @gabeguz's [comment](https://github.com/cli/cli/issues/308#issuecomment-583444787) while looking for solutions to this. From [what I could tell](https://unix.stackexchange.com/questions/4859/visual-vs-editor-what-s-the-difference), the distinction of these two variables is not as relevant in modern systems as it used to be, so it's likely that many people will simply use `EDITOR` instead of `VISUAL`.

In that light, I'm proposing to change the precedence of those variables in `gh`'s behavior, hoping that it may help others who may find themselves in similar situations.