### PR TITLE
spell out PR text

### DIFF
--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -123,7 +123,7 @@ var prCheckoutCmd = &cobra.Command{
 	Short: "Check out a pull request in Git",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return errors.New("requires a PR number as an argument")
+			return errors.New("requires a pull request number as an argument")
 		}
 		return nil
 	},

--- a/command/repo.go
+++ b/command/repo.go
@@ -51,7 +51,7 @@ A repository can be supplied as an argument in any of the following formats:
 }
 
 var repoCloneCmd = &cobra.Command{
-	Use:   "clone <repo> [<directory>]",
+	Use:   "clone <repository> [<directory>]",
 	Args:  cobra.MinimumNArgs(1),
 	Short: "Clone a repository locally",
 	Long: `Clone a GitHub repository locally.


### PR DESCRIPTION
changes "PR" ---> "pull request" for consistency and clarity

Also, changes "repo" to "repository"

ready for review