### PR TITLE
Enforce deprecation of the `api.Client.GraphQL()` method

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -101,7 +101,9 @@ func (gr GraphQLErrorResponse) Error() string {
 	return fmt.Sprintf("graphql error: '%s'", strings.Join(errorMessages, ", "))
 }
 
-// GraphQL performs a GraphQL request and parses the response
+// GraphQL performs a GraphQL request and parses the response.
+//
+// Deprecated: the `githubv4` library should be used instead
 func (c Client) GraphQL(query string, variables map[string]interface{}, data interface{}) error {
 	url := "https://api.github.com/graphql"
 	reqBody, err := json.Marshal(map[string]interface{}{"query": query, "variables": variables})


### PR DESCRIPTION
We want to deprecate manually writing GraphQL strings in favor of using the `githubv4` library.

The staticcheck linter (invoked as part of `golangci-lint`) should in theory fail CI on attempted invocations of a deprecated method, but this seems to only discover one invocation of this method in our project and not any others. I suspect that staticcheck has a bug around this https://github.com/dominikh/go-tools/issues/607

Furthermore, per staticcheck docs we should be able to use the `//lint:ignore` directive to disable the linter failure for current usage of `Client.GraphQL()` until we rewrite them, but that doesn't seem to work with `golangci-lint` https://github.com/golangci/golangci-lint/issues/741 (it does work when I invoke latest `staticcheck` directly)

Ref. #757