### PR TITLE
Improve `completion` command

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -70,7 +70,11 @@ func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
 }
 
 func shouldCheckForUpdate() bool {
-	return updaterEnabled != "" && utils.IsTerminal(os.Stderr)
+	return updaterEnabled != "" && !isCompletionCommand() && utils.IsTerminal(os.Stderr)
+}
+
+func isCompletionCommand() bool {
+	return len(os.Args) > 1 && os.Args[1] == "completion"
 }
 
 func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {

--- a/command/completion.go
+++ b/command/completion.go
@@ -1,15 +1,18 @@
 package command
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/cli/cli/internal/cobrafish"
+	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	RootCmd.AddCommand(completionCmd)
-	completionCmd.Flags().StringP("shell", "s", "bash", "Shell type: {bash|zsh|fish|powershell}")
+	completionCmd.Flags().StringP("shell", "s", "", "Shell type: {bash|zsh|fish|powershell}")
 }
 
 var completionCmd = &cobra.Command{
@@ -17,9 +20,12 @@ var completionCmd = &cobra.Command{
 	Short: "Generate shell completion scripts",
 	Long: `Generate shell completion scripts for GitHub CLI commands.
 
+The output of this command will be computer code and is meant to be saved to a
+file or immediately evaluated by an interactive shell.
+
 For example, for bash you could add this to your '~/.bash_profile':
 
-	eval "$(gh completion)"
+	eval "$(gh completion -s bash)"
 
 When installing GitHub CLI through a package manager, however, it's possible that
 no additional shell configuration is necessary to gain completion support. For
@@ -29,6 +35,19 @@ Homebrew, see <https://docs.brew.sh/Shell-Completion>
 		shellType, err := cmd.Flags().GetString("shell")
 		if err != nil {
 			return err
+		}
+
+		if shellType == "" {
+			out := cmd.OutOrStdout()
+			isTTY := false
+			if outFile, isFile := out.(*os.File); isFile {
+				isTTY = utils.IsTerminal(outFile)
+			}
+
+			if isTTY {
+				return errors.New("error: the value for `--shell` is required\nsee `gh help completion` for more information")
+			}
+			shellType = "bash"
 		}
 
 		switch shellType {


### PR DESCRIPTION
* Improve user-friendliness of `completion` command

  When ran directly in the terminal, the command now errors out with:

      $ gh completion
      error: the value for `--shell` is required
      see `gh completion --help` for more information

  This is to avoid the previously default bash code output confusing the user if they ran the command out of curiousity.

  A backwards compatibility layer is present here: if stdout is not a terminal, then output bash code like before. This is to support users who have already added a line like this to their bash profile:

      eval "$(gh completion)"

* Avoid checking for updates during `gh completion`

  This is due to the fact that `gh completion` can be programatically used during shell startup and we definitely don't want to:
  1. slow down people's startup time;
  2. show any upgrade notice until the user has invoked `gh` manually.

* Clarifies `gh completion` docs by explaining what the output is intended for.

Fixes https://github.com/cli/cli/issues/712, fixes https://github.com/cli/cli/issues/747