### PR TITLE
Update Debian instructions for modern apt versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ MSI installers are available for download on the [releases page][].
 Install and upgrade:
 
 1. Download the `.deb` file from the [releases page][]
-2. `sudo apt install git && sudo dpkg -i gh_*_linux_amd64.deb`  install the downloaded file
+2. `sudo apt install ./gh_*_linux_amd64.deb` install the downloaded file
 
 ### Fedora Linux
 


### PR DESCRIPTION
apt can now install local .deb files too, with dependencies.