### PR TITLE
Tweak CONTRIBUTING docs to clarify our stance about installation instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,21 +12,31 @@ Please do:
 
 * open an issue if things aren't working as expected
 * open an issue to propose a significant change
-* open a PR to fix a bug
-* open a PR if a member of the GitHub CLI team has given the ok after discussion in an issue
+* open a pull request to fix a bug
+* open a pull request if a member of the GitHub CLI team has given the ok after discussion in an issue
+
+## Building the project
+
+Prerequisites:
+- Go 1.13
+
+Build with: `make` or `go build -o bin/gh ./cmd/gh`
+
+Run the new binary as: `./bin/gh`
+
+Run tests with: `make test` or `go test ./...`
 
 ## Submitting a pull request
 
-0. Clone this repository
-0. Create a new branch: `git checkout -b my-branch-name`
-0. Make your change, add tests, and ensure tests pass
-0. Make a PR: `gh pr create --web`
+1. Create a new branch: `git checkout -b my-branch-name`
+1. Make your change, add tests, and ensure tests pass
+1. Submit a pull request: `gh pr create --web`
 
 Contributions to this project are [released][legal] to the public under the [project's open source license][license].
 
 Please note that this project adheres to a [Contributor Code of Conduct][code-of-conduct]. By participating in this project you agree to abide by its terms.
 
-We generate manual pages from source on every release! You do not need to submit PRs for those specifically; the docs will get updated if your PR gets accepted.
+We generate manual pages from source on every release. You do not need to submit pull requests for documentation specifically; manual pages for commands will automatically get updated after your pull requests gets accepted.
 
 ## Resources
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,7 +13,12 @@ Please do:
 * open an issue if things aren't working as expected
 * open an issue to propose a significant change
 * open a pull request to fix a bug
+* open a pull request to fix documentation about a command
 * open a pull request if a member of the GitHub CLI team has given the ok after discussion in an issue
+
+Please avoid:
+
+* adding installation instructions specifically for your OS/package manager
 
 ## Building the project
 


### PR DESCRIPTION
Clarify that we would prefer to not get contributions adding installation instructions for any OS or package manager that isn't in the few major ones that we've already covered.

Bonus:
- "PR" 👉 "pull request"
- add section about building and testing