### PR TITLE
Update Scoop installation method (related to #691)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,14 @@ Upgrade: `sudo port selfupdate && sudo port upgrade gh`
 Install:
 
 ```
-scoop bucket add github-gh https://github.com/cli/scoop-gh.git
 scoop install gh
 ```
 
-Upgrade: `scoop update gh`
+Upgrade:
+
+```
+scoop update gh
+```
 
 #### Chocolatey
 


### PR DESCRIPTION
Since the Scoop manifest got published to the main bucket (#691), the README can now be updated to reflect the change. (This basically just removes one step.)