### PR TITLE
In pr create, default to pushing to base repo if possible

### DIFF
--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -95,7 +95,11 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 
 	// otherwise, determine the head repository with info obtained from the API
 	if headRepo == nil {
-		if r, err := repoContext.HeadRepo(); err == nil {
+		// If we can push to the base repo, choose it. Otherwise
+		// look for a fork that we can push to.
+		if br, err := repoContext.BaseRepo(); err == nil && br.ViewerCanPush() {
+			headRepo = br
+		} else if r, err := repoContext.HeadRepo(); err == nil {
 			headRepo = r
 		}
 	}

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -42,7 +42,7 @@ func TestPRCreate(t *testing.T) {
 	output, err := RunCommand(prCreateCmd, `pr create -t "my title" -b "my body"`)
 	eq(t, err, nil)
 
-	bodyBytes, _ := ioutil.ReadAll(http.Requests[3].Body)
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[len(http.Requests)-1].Body)
 	reqBody := struct {
 		Variables struct {
 			Input struct {


### PR DESCRIPTION
## Summary

closes #800

## Details

Lots of contributors have write access to the base repository
and don't rely on personal forks. If the base repository is ignored
when selecting the default repository for pr create, it might
have (IMHO) unexpected results like pushing to a new branch in someone
else's fork that gave you push access.