### PR TITLE
Update documentation site on release

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -33,13 +33,23 @@ jobs:
           formula-name: gh
         env:
           COMMITTER_TOKEN: ${{ secrets.UPLOAD_GITHUB_TOKEN }}
-      - name: move cards
-        if: "!contains(github.ref, '-')"
+      - name: Checkout documentation site
+        if: "!contains(github.ref, '-')" # skip prereleases
+        uses: actions/checkout@v2
+        with:
+          repository: github/cli.github.com
+          path: site
+          fetch-depth: 0
+          token: ${{secrets.SITE_GITHUB_TOKEN}}
+      - name: Publish documentation site
+        if: "!contains(github.ref, '-')" # skip prereleases
+        run: make site-publish
+      - name: Move project cards
+        if: "!contains(github.ref, '-')" # skip prereleases
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           PENDING_COLUMN: 8189733
           DONE_COLUMN: 7110130
-        shell: bash
         run: |
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
           api() { bin/hub api -H 'accept: application/vnd.github.inertia-preview+json' "$@"; }

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -26,6 +26,13 @@ jobs:
           args: release --release-notes=CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{secrets.UPLOAD_GITHUB_TOKEN}}
+      - name: Bump homebrew-core formula
+        uses: mislav/bump-homebrew-formula-action@v1
+        if: "!contains(github.ref, '-')" # skip prereleases
+        with:
+          formula-name: gh
+        env:
+          COMMITTER_TOKEN: ${{ secrets.UPLOAD_GITHUB_TOKEN }}
       - name: move cards
         if: "!contains(github.ref, '-')"
         env:
@@ -38,13 +45,6 @@ jobs:
           api() { bin/hub api -H 'accept: application/vnd.github.inertia-preview+json' "$@"; }
           cards=$(api projects/columns/$PENDING_COLUMN/cards | jq ".[].id")
           for card in $cards; do api projects/columns/cards/$card/moves --field position=top --field column_id=$DONE_COLUMN; done
-      - name: Bump homebrew-core formula
-        uses: mislav/bump-homebrew-formula-action@v1
-        if: "!contains(github.ref, '-')" # skip prereleases
-        with:
-          formula-name: gh
-        env:
-          COMMITTER_TOKEN: ${{ secrets.UPLOAD_GITHUB_TOKEN }}
   msi:
     needs: goreleaser
     runs-on: windows-latest

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,13 @@ site-docs: site
 	git -C site add 'manual/gh*.md'
 	git -C site commit -m 'update help docs'
 .PHONY: site-docs
+
+site-publish: site-docs
+ifndef GITHUB_REF
+	$(error GITHUB_REF is not set)
+endif
+	sed -i.bak -E 's/(assign version = )".+"/\1"$(GITHUB_REF:refs/tags/v%=%)"/' site/index.html
+	rm -f site/index.html.bak
+	git -C site commit -m '$(GITHUB_REF:refs/tags/v%=%)' index.html
+	git -C site push
+.PHONY: site-publish

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ site-docs: site
 	for f in site/manual/gh*.md; do sed -i.bak -e '/^### SEE ALSO/,$$d' "$$f"; done
 	rm -f site/manual/*.bak
 	git -C site add 'manual/gh*.md'
-	git -C site commit -m 'update help docs'
+	git -C site commit -m 'update help docs' || true
 .PHONY: site-docs
 
 site-publish: site-docs

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,27 +1,17 @@
 # Releasing
 
-## Test Locally
+## Release to production
 
-`go test ./...`
+This can all be done from your local terminal.
 
-## Push new docs
-
-build docs locally: `make site`
-
-build and push docs to production: `make site-docs`
+1. `git tag v1.2.3`
+2. `git push origin v1.2.3`
+3. Wait a few minutes for the build to run <https://github.com/cli/cli/actions>
+4. Check <https://github.com/cli/cli/releases>
 
 ## Release locally for debugging
 
 A local release can be created for testing without creating anything official on the release page.
 
-1. `env GH_OAUTH_CLIENT_SECRET= GH_OAUTH_CLIENT_ID= goreleaser --skip-validate --skip-publish --rm-dist`
+1. `goreleaser --skip-validate --skip-publish --rm-dist`
 2. Check and test files in `dist/`
-
-## Release to production
-
-This can all be done from your local terminal.
-
-1. `git tag 'vVERSION_NUMBER' # example git tag 'v0.0.1'`
-2. `git push origin vVERSION_NUMBER`
-3. Wait a few minutes for the build to run and CI to pass. Look at the [actions tab](https://github.com/cli/cli/actions) to check the progress.
-4. Go to <https://github.com/cli/cli/releases> and look at the release


### PR DESCRIPTION
Runs `make site-publish` upon every (non-pre)release. This generates man pages, bumps the version number in `index.html` and pushes to the site repo.