### PR TITLE
respect configured editor

### DIFF
--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -87,7 +87,7 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, def
 	if err != nil {
 		return nil, fmt.Errorf("could not read config: %w", err)
 	}
-	editorName, _ := cfg.Get(defaultHostname, "editor")
+	editorCommand, _ := cfg.Get(defaultHostname, "editor")
 
 	var inProgress titleBody
 	inProgress.Title = defs.Title
@@ -116,7 +116,7 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, def
 	bodyQuestion := &survey.Question{
 		Name: "body",
 		Prompt: &surveyext.GhEditor{
-			EditorName: editorName,
+			EditorCommand: editorCommand,
 			Editor: &survey.Editor{
 				Message:       "Body",
 				FileName:      "*.md",

--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/cli/cli/pkg/githubtemplate"
@@ -82,12 +83,15 @@ func selectTemplate(templatePaths []string) (string, error) {
 }
 
 func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, defs defaults, templatePaths []string) (*titleBody, error) {
-	ctx := contextForCommand(cmd)
-	cfg, err := ctx.Config()
-	if err != nil {
-		return nil, fmt.Errorf("could not read config: %w", err)
+	editorCommand := os.Getenv("GH_EDITOR")
+	if editorCommand == "" {
+		ctx := contextForCommand(cmd)
+		cfg, err := ctx.Config()
+		if err != nil {
+			return nil, fmt.Errorf("could not read config: %w", err)
+		}
+		editorCommand, _ = cfg.Get(defaultHostname, "editor")
 	}
-	editorCommand, _ := cfg.Get(defaultHostname, "editor")
 
 	var inProgress titleBody
 	inProgress.Title = defs.Title
@@ -135,7 +139,7 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, def
 		qs = append(qs, bodyQuestion)
 	}
 
-	err = SurveyAsk(qs, &inProgress)
+	err := SurveyAsk(qs, &inProgress)
 	if err != nil {
 		return nil, fmt.Errorf("could not prompt: %w", err)
 	}

--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -82,6 +82,13 @@ func selectTemplate(templatePaths []string) (string, error) {
 }
 
 func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, defs defaults, templatePaths []string) (*titleBody, error) {
+	ctx := contextForCommand(cmd)
+	cfg, err := ctx.Config()
+	if err != nil {
+		return nil, fmt.Errorf("could not read config: %w", err)
+	}
+	editorName, _ := cfg.Get(defaultHostname, "editor")
+
 	var inProgress titleBody
 	inProgress.Title = defs.Title
 	templateContents := ""
@@ -109,6 +116,7 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, def
 	bodyQuestion := &survey.Question{
 		Name: "body",
 		Prompt: &surveyext.GhEditor{
+			EditorName: editorName,
 			Editor: &survey.Editor{
 				Message:       "Body",
 				FileName:      "*.md",
@@ -127,7 +135,7 @@ func titleBodySurvey(cmd *cobra.Command, providedTitle, providedBody string, def
 		qs = append(qs, bodyQuestion)
 	}
 
-	err := SurveyAsk(qs, &inProgress)
+	err = SurveyAsk(qs, &inProgress)
 	if err != nil {
 		return nil, fmt.Errorf("could not prompt: %w", err)
 	}

--- a/pkg/surveyext/editor.go
+++ b/pkg/surveyext/editor.go
@@ -37,15 +37,15 @@ func init() {
 // EXTENDED to enable different prompting behavior
 type GhEditor struct {
 	*survey.Editor
-	EditorName string
+	EditorCommand string
 }
 
-func (e *GhEditor) editorName() string {
-	if e.EditorName == "" {
+func (e *GhEditor) editorCommand() string {
+	if e.EditorCommand == "" {
 		return defaultEditor
 	}
 
-	return e.EditorName
+	return e.EditorCommand
 }
 
 // EXTENDED to change prompt text
@@ -58,17 +58,17 @@ var EditorQuestionTemplate = `
 {{- else }}
   {{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ .Config.HelpInput }} for help]{{color "reset"}} {{end}}
   {{- if and .Default (not .HideDefault)}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
-	{{- color "cyan"}}[(e) to launch {{ .EditorName }}, enter to skip] {{color "reset"}}
+	{{- color "cyan"}}[(e) to launch {{ .EditorCommand }}, enter to skip] {{color "reset"}}
 {{- end}}`
 
 // EXTENDED to pass editor name (to use in prompt)
 type EditorTemplateData struct {
 	survey.Editor
-	EditorName string
-	Answer     string
-	ShowAnswer bool
-	ShowHelp   bool
-	Config     *survey.PromptConfig
+	EditorCommand string
+	Answer        string
+	ShowAnswer    bool
+	ShowHelp      bool
+	Config        *survey.PromptConfig
 }
 
 // EXTENDED to augment prompt text and keypress handling
@@ -77,9 +77,9 @@ func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (int
 		EditorQuestionTemplate,
 		// EXTENDED to support printing editor in prompt
 		EditorTemplateData{
-			Editor:     *e.Editor,
-			EditorName: filepath.Base(e.editorName()),
-			Config:     config,
+			Editor:        *e.Editor,
+			EditorCommand: filepath.Base(e.editorCommand()),
+			Config:        config,
 		},
 	)
 	if err != nil {
@@ -118,10 +118,10 @@ func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (int
 				EditorQuestionTemplate,
 				EditorTemplateData{
 					// EXTENDED to support printing editor in prompt
-					Editor:     *e.Editor,
-					EditorName: filepath.Base(e.editorName()),
-					ShowHelp:   true,
-					Config:     config,
+					Editor:        *e.Editor,
+					EditorCommand: filepath.Base(e.editorCommand()),
+					ShowHelp:      true,
+					Config:        config,
 				},
 			)
 			if err != nil {
@@ -164,7 +164,7 @@ func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (int
 
 	stdio := e.Stdio()
 
-	args, err := shellquote.Split(e.editorName())
+	args, err := shellquote.Split(e.editorCommand())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
fixes #308 

gh now respects and prioritizes whatever is set with `gh config set editor ...`. it chooses an editor in this way:

- set in GH_EDITOR?
- explicitly configured via `gh config`?
- set in GIT_EDITOR?
- set in VISUAL?
- set in EDITOR?
- nano (!windows), notepad (windows)

unfortunately adding tests did not make sense as the relevant change is below the level at which we can reasonably test survey code. the surface area is small and i think the risk is low.