### PR TITLE
Disable interactive mode for `issue create` if all flags are passed

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -383,7 +383,7 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 
 	action := SubmitAction
 
-	interactive := !cmd.Flags().Changed("title") || !cmd.Flags().Changed("body")
+	interactive := !cmd.Flags().Changed("title") && !cmd.Flags().Changed("body")
 
 	if interactive {
 		tb, err := titleBodySurvey(cmd, title, body, defaults{}, templateFiles)
@@ -404,6 +404,10 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 		}
 		if body == "" {
 			body = tb.Body
+		}
+	} else {
+		if title == "" {
+			return fmt.Errorf("title can't be blank")
 		}
 	}
 

--- a/command/issue.go
+++ b/command/issue.go
@@ -383,7 +383,7 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 
 	action := SubmitAction
 
-	interactive := title == "" || body == ""
+	interactive := !cmd.Flags().Changed("title") || !cmd.Flags().Changed("body")
 
 	if interactive {
 		tb, err := titleBodySurvey(cmd, title, body, defaults{}, templateFiles)

--- a/command/issue.go
+++ b/command/issue.go
@@ -383,7 +383,7 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 
 	action := SubmitAction
 
-	interactive := !cmd.Flags().Changed("title") && !cmd.Flags().Changed("body")
+	interactive := !(cmd.Flags().Changed("title") && cmd.Flags().Changed("body"))
 
 	if interactive {
 		tb, err := titleBodySurvey(cmd, title, body, defaults{}, templateFiles)


### PR DESCRIPTION
Another possibility is to not prompt the user interactively if `title` is passed. See @mislav [comment](https://github.com/cli/cli/issues/807#issuecomment-616490656) in the issue.

Closes #807