### PR TITLE
Help goreleaser find the correct git tag during release

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -17,6 +17,7 @@ jobs:
           go-version: 1.13
       - name: Generate changelog
         run: |
+          echo ::set-env name=GORELEASER_CURRENT_TAG::${GITHUB_REF#refs/tags/}
           git fetch --unshallow
           script/changelog | tee CHANGELOG.md
       - name: Run GoReleaser


### PR DESCRIPTION
This fixes our release process when there is more than one git tag pointing to a commit.

https://github.com/cli/cli/runs/610170624?check_suite_focus=true
https://github.com/goreleaser/goreleaser/pull/1327