### PR TITLE
Fix gh updater mechanism for unauthenticated users

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -111,20 +111,11 @@ func BasicClient() (*api.Client, error) {
 	}
 	opts = append(opts, api.AddHeader("User-Agent", fmt.Sprintf("GitHub CLI %s", Version)))
 
-	c, err := config.ParseDefaultConfig()
-	if err != nil {
-		return nil, err
+	if c, err := config.ParseDefaultConfig(); err == nil {
+		if token, _ := c.Get(defaultHostname, "oauth_token"); token != "" {
+			opts = append(opts, api.AddHeader("Authorization", fmt.Sprintf("token %s", token)))
+		}
 	}
-
-	token, err := c.Get(defaultHostname, "oauth_token")
-	if err != nil {
-		return nil, err
-	}
-	if token == "" {
-		return nil, fmt.Errorf("no oauth_token set in config")
-	}
-
-	opts = append(opts, api.AddHeader("Authorization", fmt.Sprintf("token %s", token)))
 	return api.NewClient(opts...), nil
 }
 


### PR DESCRIPTION
Per code documentation: "BasicClient returns an API client that borrows from but does not depend on user configuration". This means that any errors while reading `oauth_token` should be tolerated.