### PR TITLE
Preliminary support for GitHub Enterprise

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 
@@ -104,6 +105,10 @@ func (gr GraphQLErrorResponse) Error() string {
 // GraphQL performs a GraphQL request and parses the response
 func (c Client) GraphQL(query string, variables map[string]interface{}, data interface{}) error {
 	url := "https://api.github.com/graphql"
+	if gheHostname := os.Getenv("GITHUB_HOST"); gheHostname != "" {
+		url = fmt.Sprintf("https://%s/api/graphql", gheHostname)
+	}
+
 	reqBody, err := json.Marshal(map[string]interface{}{"query": query, "variables": variables})
 	if err != nil {
 		return err
@@ -128,6 +133,10 @@ func (c Client) GraphQL(query string, variables map[string]interface{}, data int
 // REST performs a REST request and parses the response.
 func (c Client) REST(method string, p string, body io.Reader, data interface{}) error {
 	url := "https://api.github.com/" + p
+	if gheHostname := os.Getenv("GITHUB_HOST"); gheHostname != "" {
+		url = fmt.Sprintf("https://%s/api/v3/%s", gheHostname, p)
+	}
+
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return err

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -110,7 +111,13 @@ func RepoParent(client *Client, repo ghrepo.Interface) (ghrepo.Interface, error)
 		"name":  githubv4.String(repo.RepoName()),
 	}
 
-	v4 := githubv4.NewClient(client.http)
+	var v4 *githubv4.Client
+	if gheHostname := os.Getenv("GITHUB_HOST"); gheHostname != "" {
+		v4 = githubv4.NewEnterpriseClient(fmt.Sprintf("https://%s/api/graphql", gheHostname), client.http)
+	} else {
+		v4 = githubv4.NewClient(client.http)
+	}
+
 	err := v4.Query(context.Background(), &query, variables)
 	if err != nil {
 		return nil, err

--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -45,9 +45,16 @@ func (oa *OAuthFlow) ObtainAccessToken() (accessToken string, err error) {
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
 
+	redirectURI := "http://127.0.0.1:%d/callback"
+	callbackPath := "/callback"
+	if gheHostname := os.Getenv("GITHUB_HOST"); gheHostname != "" {
+		redirectURI = "http://localhost:%d"
+		callbackPath = "/"
+	}
+
 	q := url.Values{}
 	q.Set("client_id", oa.ClientID)
-	q.Set("redirect_uri", fmt.Sprintf("http://127.0.0.1:%d/callback", port))
+	q.Set("redirect_uri", fmt.Sprintf(redirectURI, port))
 	// TODO: make scopes configurable
 	q.Set("scope", "repo")
 	q.Set("state", state)
@@ -67,7 +74,7 @@ func (oa *OAuthFlow) ObtainAccessToken() (accessToken string, err error) {
 
 	_ = http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		oa.logf("server handler: %s\n", r.URL.Path)
-		if r.URL.Path != "/callback" {
+		if r.URL.Path != callbackPath {
 			w.WriteHeader(404)
 			return
 		}

--- a/command/root.go
+++ b/command/root.go
@@ -19,7 +19,7 @@ import (
 )
 
 // TODO these are sprinkled across command, context, config, and ghrepo
-const defaultHostname = "github.com"
+var defaultHostname = "github.com"
 
 // Version is dynamically set by the toolchain or overridden by the Makefile.
 var Version = "DEV"
@@ -30,6 +30,10 @@ var BuildDate = "" // YYYY-MM-DD
 var versionOutput = ""
 
 func init() {
+	if gheHostname := os.Getenv("GITHUB_HOST"); gheHostname != "" {
+		defaultHostname = gheHostname
+	}
+
 	if Version == "DEV" {
 		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
 			Version = info.Main.Version

--- a/context/context.go
+++ b/context/context.go
@@ -3,6 +3,7 @@ package context
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/cli/cli/api"
@@ -12,7 +13,13 @@ import (
 )
 
 // TODO these are sprinkled across command, context, config, and ghrepo
-const defaultHostname = "github.com"
+var defaultHostname = "github.com"
+
+func init() {
+	if gheHostname := os.Getenv("GITHUB_HOST"); gheHostname != "" {
+		defaultHostname = gheHostname
+	}
+}
 
 // Context represents the interface for querying information about the current environment
 type Context interface {

--- a/internal/config/config_setup.go
+++ b/internal/config/config_setup.go
@@ -13,16 +13,20 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	oauthHost = "github.com"
-)
-
 var (
+	oauthHost = "github.com"
+
 	// The "GitHub CLI" OAuth app
 	oauthClientID = "178c6fc778ccc68e1d6a"
 	// This value is safe to be embedded in version control
 	oauthClientSecret = "34ddeff2b558a23d38fba8a6de74f086ede1cc0b"
 )
+
+func init() {
+	if gheHostname := os.Getenv("GITHUB_HOST"); gheHostname != "" {
+		oauthHost = gheHostname
+	}
+}
 
 // TODO: have a conversation about whether this belongs in the "context" package
 // FIXME: make testable


### PR DESCRIPTION
This is a rough code spike to explore GitHub Enterprise compatibility. The experience in this branch isn't very user-friendly yet: you have to manually juggle your config files and you have to set the GITHUB_HOST environment variable to your GHE hostname while testing (i.e. the Enterprise hostname will not get automatically picked up from your existing git remotes). But, it works!

How to test:

- backup your old config: `cp ~/.config/gh/config.yml{,.bak}`
- clear the config file `rm ~/.config/gh/config.yml`
- set `export GITHUB_HOST=ghe.example.com` to your GHE hostname
- build gh with `make`
- run a `bin/gh` command
- restore your old config when done testing this branch `mv ~/.config/gh/config.yml{.bak,}`

Ref. #273 