### PR TITLE
Adding support for list command

### DIFF
--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -43,3 +43,37 @@ func Test_RepoCreate(t *testing.T) {
 		t.Errorf("expected homepageUrl to be %q, got %q", "http://example.com", homepage)
 	}
 }
+
+func Test_GetAllRepositories(t *testing.T) {
+	http := &FakeHTTP{}
+	client := NewClient(ReplaceTripper(http))
+
+	http.StubResponse(200, bytes.NewBufferString(`{
+		"data":{
+			"viewer":{
+				"repositories":{
+					"totalCount":3,
+					"nodes":[
+						{"nameWithOwner":"repo1"},
+						{"nameWithOwner":"repo2"},
+						{"nameWithOwner":"repo3"}
+					]
+				}
+			}
+		}
+	}`))
+
+	response, err := Repositories(client, 10)
+
+	if err != nil {
+		t.Errorf("expected error to be nil, got %q", err)
+	}
+
+	if response.TotalCount != 3 {
+		t.Errorf("expected totalCount to be %q, got %q", 3, response.TotalCount)
+	}
+
+	if len(response.Nodes) != 3 {
+		t.Errorf("expected %q repositories in response, got %q", 3, response.Nodes)
+	}
+}

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -73,7 +73,7 @@ func Test_GetAllRepositories(t *testing.T) {
 		t.Errorf("expected totalCount to be %q, got %q", 3, response.TotalCount)
 	}
 
-	if len(response.Nodes) != 3 {
-		t.Errorf("expected %q repositories in response, got %q", 3, response.Nodes)
+	if len(response.Repositories) != 3 {
+		t.Errorf("expected %q repositories in response, got %q", 3, response.Repositories)
 	}
 }

--- a/command/list.go
+++ b/command/list.go
@@ -52,13 +52,13 @@ func listRepos(cmd *cobra.Command, args []string) error {
 	}
 
 	if !raw {
-		title := fmt.Sprintf("Showing %d of %d repositories.", len(repos.Nodes), repos.TotalCount)
+		title := fmt.Sprintf("Showing %d of %d repositories.", len(repos.Repositories), repos.TotalCount)
 		fmt.Fprintf(colorableErr(cmd), "\n%s\n\n", title)
 	}
 
 	table := utils.NewTablePrinter(cmd.OutOrStdout())
-	for i := range repos.Nodes {
-		table.AddField(repos.Nodes[i].NameWithOwner, nil, nil)
+	for i := range repos.Repositories {
+		table.AddField(repos.Repositories[i], nil, nil)
 		table.EndRow()
 	}
 	err = table.Render()

--- a/command/list.go
+++ b/command/list.go
@@ -1,0 +1,70 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(listCmd)
+	listCmd.AddCommand(listRepoCmd)
+
+	listRepoCmd.Flags().IntP("limit", "L", 30, "Maximum number of items to fetch")
+	listRepoCmd.Flags().BoolP("raw", "", false, "Display raw output")
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List organizations or repositories",
+}
+
+var listRepoCmd = &cobra.Command{
+	Use:   "repo",
+	Short: "List repositories",
+	RunE:  listRepos,
+}
+
+func listRepos(cmd *cobra.Command, args []string) error {
+	ctx := contextForCommand(cmd)
+	apiClient, err := apiClientForContext(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	limit, err := cmd.Flags().GetInt("limit")
+	if err != nil {
+		return err
+	}
+
+	repos, err := api.Repositories(apiClient, limit)
+
+	if err != nil {
+		return err
+	}
+
+	raw, err := cmd.Flags().GetBool("raw")
+	if err != nil {
+		return err
+	}
+
+	if !raw {
+		title := fmt.Sprintf("Showing %d of %d repositories.", len(repos.Nodes), repos.TotalCount)
+		fmt.Fprintf(colorableErr(cmd), "\n%s\n\n", title)
+	}
+
+	table := utils.NewTablePrinter(cmd.OutOrStdout())
+	for i := range repos.Nodes {
+		table.AddField(repos.Nodes[i].NameWithOwner, nil, nil)
+		table.EndRow()
+	}
+	err = table.Render()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is an initial draft to support list command. The idea is to have
a common list command for the repos, orgs etc..

### List repos

- List repositories with default limit(30)
```bash
$ gh list repo

Showing 30 of 173 repositories.

bdpiparva/deb-repo-query
bdpiparva/deb-repo-poller
bdpiparva/ansible-gocd
...
```

- List repositories with custom limit

```bash
$ gh list repo -L 10

Showing 10 of 173 repositories.

bdpiparva/deb-repo-query
bdpiparva/deb-repo-poller
bdpiparva/ansible-gocd
...
```

- Print raw result for scripting

```bash
$ gh list repo --raw
bdpiparva/deb-repo-query
bdpiparva/deb-repo-poller
bapiparva/ansible-gocd
...
```

- List repositories for a organisation

```bash
$ gh list repo --org Area51

//Output
```

**NOTE:** Related issue(s) for the PR: #642, #645

## TODO
- [ ] Add support to list organization for the loggedin user

```bash
$ gh list org