### PR TITLE
Add `search` command

### DIFF
--- a/api/queries_search.go
+++ b/api/queries_search.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/shurcooL/githubv4"
+)
+
+type SearchRepoResult struct {
+	NameWithOwner string
+	Description   string
+	Stargazers    struct {
+		TotalCount int
+	}
+}
+
+func SearchRepos(client *Client, q string, limit int) ([]SearchRepoResult, error) {
+	var query struct {
+		Search struct {
+			Nodes []struct {
+				Repository SearchRepoResult `graphql:"...on Repository"`
+			}
+			PageInfo struct {
+				HasNextPage bool
+				EndCursor   string
+			}
+		} `graphql:"search(query: $query, type: REPOSITORY, first: $limit, after: $endCursor)"`
+	}
+
+	perPage := limit
+	if perPage > 100 {
+		perPage = 100
+	}
+	variables := map[string]interface{}{
+		"query":     githubv4.String(q),
+		"limit":     githubv4.Int(perPage),
+		"endCursor": (*githubv4.String)(nil),
+	}
+
+	v4 := githubv4.NewClient(client.http)
+
+	var results []SearchRepoResult
+
+pagination:
+	for {
+		err := v4.Query(context.Background(), &query, variables)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range query.Search.Nodes {
+			results = append(results, n.Repository)
+			if len(results) == limit {
+				break pagination
+			}
+		}
+		if !query.Search.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Search.PageInfo.EndCursor)
+	}
+
+	return results, nil
+}
+
+type SearchIssueResult struct {
+	Title      string
+	Number     int
+	State      string
+	CreatedAt  time.Time
+	Repository struct {
+		NameWithOwner string
+	}
+}
+
+func SearchIssues(client *Client, q string, limit int) ([]SearchIssueResult, error) {
+	var query struct {
+		Search struct {
+			Nodes []struct {
+				Issue       SearchIssueResult `graphql:"...on Issue"`
+				PullRequest SearchIssueResult `graphql:"...on PullRequest"`
+			}
+			PageInfo struct {
+				HasNextPage bool
+				EndCursor   string
+			}
+		} `graphql:"search(query: $query, type: ISSUE, first: $limit, after: $endCursor)"`
+	}
+
+	perPage := limit
+	if perPage > 100 {
+		perPage = 100
+	}
+	variables := map[string]interface{}{
+		"query":     githubv4.String(q),
+		"limit":     githubv4.Int(perPage),
+		"endCursor": (*githubv4.String)(nil),
+	}
+
+	v4 := githubv4.NewClient(client.http)
+
+	var results []SearchIssueResult
+
+pagination:
+	for {
+		err := v4.Query(context.Background(), &query, variables)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range query.Search.Nodes {
+			if n.Issue.Number > 0 {
+				results = append(results, n.Issue)
+			} else {
+				results = append(results, n.PullRequest)
+			}
+			if len(results) == limit {
+				break pagination
+			}
+		}
+		if !query.Search.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Search.PageInfo.EndCursor)
+	}
+
+	return results, nil
+}

--- a/command/search.go
+++ b/command/search.go
@@ -1,0 +1,104 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(searchCmd)
+	searchCmd.Flags().IntP("limit", "L", 10, "limit the number of results")
+}
+
+var searchCmd = &cobra.Command{
+	Use:   "search {repos|issues} <query>",
+	Args:  cobra.ExactArgs(2),
+	Short: "Search GitHub",
+	Long: `Search GitHub repositories or issues using terms in a query string.
+
+The literal string "{baseRepo}" inside the search string will be substituted with
+the full name of the current repository. Similarly, "{owner}" will be replaced with
+the handle of the owner for the current repository.
+
+Examples:
+
+	$ gh search repos 'in:readme "GitHub CLI"'
+	$ gh search repos 'org:microsoft stars:>=15000'
+
+	$ gh search issues 'repo:cli/cli editor'
+	$ gh search issues 'repo:{baseRepo} is:open team:{owner}/robots'
+	$ gh search issues 'repo:{baseRepo} is:pr is:open review-requested:@me'
+
+See <https://help.github.com/en/github/searching-for-information-on-github>`,
+	RunE: search,
+}
+
+func search(cmd *cobra.Command, args []string) error {
+	ctx := contextForCommand(cmd)
+
+	baseRepo, err := ctx.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	client, err := apiClientForContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	searchType := args[0]
+	searchTerm := strings.ReplaceAll(args[1], "{baseRepo}", ghrepo.FullName(baseRepo))
+	searchTerm = strings.ReplaceAll(searchTerm, "{owner}", baseRepo.RepoOwner())
+
+	limit, err := cmd.Flags().GetInt("limit")
+	if err != nil {
+		return err
+	}
+
+	switch searchType {
+	case "repos":
+		results, err := api.SearchRepos(client, searchTerm, limit)
+		if err != nil {
+			return err
+		}
+
+		table := utils.NewTablePrinter(cmd.OutOrStdout())
+		for _, r := range results {
+			table.AddField(r.NameWithOwner, nil, nil)
+			table.AddField(fmt.Sprintf("%d", r.Stargazers.TotalCount), nil, utils.Yellow)
+			table.AddField(replaceExcessiveWhitespace(r.Description), nil, nil)
+			table.EndRow()
+		}
+		_ = table.Render()
+	case "issues":
+		results, err := api.SearchIssues(client, searchTerm, limit)
+		if err != nil {
+			return err
+		}
+
+		table := utils.NewTablePrinter(cmd.OutOrStdout())
+		for _, i := range results {
+			issueID := fmt.Sprintf("%s#%d", i.Repository.NameWithOwner, i.Number)
+			createdAt := i.CreatedAt.Format(time.RFC3339)
+			if table.IsTTY() {
+				createdAt = utils.FuzzyAgo(time.Since(i.CreatedAt))
+			}
+
+			table.AddField(issueID, nil, colorFuncForState(i.State))
+			table.AddField(replaceExcessiveWhitespace(i.Title), nil, nil)
+			table.AddField(createdAt, nil, utils.Gray)
+			table.EndRow()
+		}
+		_ = table.Render()
+	default:
+		return fmt.Errorf("unrecognized search type: %q", searchType)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is a preliminary spike for a `gh search` command to access the Search API. The features proposed here did not pass any design phase yet.

Synopsis:

    gh search {issues|repos} <query>

Examples:

    $ gh search repos 'org:microsoft stars:>=15000'

    $ gh search issues 'is:open golang crash'

    $ gh search issues 'repo:{baseRepo} is:pr is:open review-requested:@me'

<img width="970" alt="Screen Shot 2020-04-24 at 6 49 52 PM" src="https://user-images.githubusercontent.com/887/80237149-8550ce00-865c-11ea-943b-335fbacb35ee.png">

<img width="907" alt="Screen Shot 2020-04-24 at 6 49 13 PM" src="https://user-images.githubusercontent.com/887/80237150-871a9180-865c-11ea-92a6-9bd56b34da2c.png">
