### PR TITLE
Add `bulk` command

### DIFF
--- a/api/queries_bulk.go
+++ b/api/queries_bulk.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cli/cli/internal/ghrepo"
+)
+
+type BulkInput struct {
+	Number     int
+	Repository ghrepo.Interface
+
+	Label        string
+	RepositoryID string
+}
+
+type ResolveResult struct {
+	ID    string
+	Issue struct {
+		ID string
+	} `json:"issueOrPullRequest"`
+	Label struct {
+		ID string
+	}
+}
+
+func ResolveNodeIDs(client *Client, inputs []BulkInput) ([]ResolveResult, error) {
+	var queries []string
+	for i, input := range inputs {
+		if input.Number > 0 {
+			queries = append(queries, fmt.Sprintf(`
+				r%03d: repository(owner:%q, name:%q) {
+					id
+					issueOrPullRequest(number:%d) {
+						...on Issue { id }
+						...on PullRequest { id }
+					}
+				}
+			`, i, input.Repository.RepoOwner(), input.Repository.RepoName(), input.Number))
+		} else if input.Label != "" {
+			queries = append(queries, fmt.Sprintf(`
+				r%03d: node(id:%q) {
+					...on Repository {
+						id
+						label(name:%q) { id }
+					}
+				}
+			`, i, input.RepositoryID, input.Label))
+		} else {
+			queries = append(queries, fmt.Sprintf(`
+				r%03d: repository(owner:%q, name:%q) { id }
+			`, i, input.Repository.RepoOwner(), input.Repository.RepoName()))
+		}
+	}
+
+	result := make(map[string]ResolveResult)
+	var ids []ResolveResult
+
+	err := client.GraphQL(fmt.Sprintf(`{%s}`, strings.Join(queries, "")), nil, &result)
+	if err != nil {
+		return ids, err
+	}
+
+	// NOTE: iteration is not ordered
+	for _, v := range result {
+		ids = append(ids, v)
+	}
+
+	return ids, nil
+}
+
+func BulkAddLabels(client *Client, inputs []BulkInput, labelNames []string) error {
+	ids, err := ResolveNodeIDs(client, inputs)
+	if err != nil {
+		return err
+	}
+
+	var mutations []string
+	cache := make(map[string][]ResolveResult)
+
+	for i, id := range ids {
+		labelIDs, ok := cache[id.ID]
+		if !ok {
+			var labelInputs []BulkInput
+			for _, l := range labelNames {
+				labelInputs = append(labelInputs, BulkInput{
+					RepositoryID: id.ID,
+					Label:        l,
+				})
+			}
+			labelIDs, err = ResolveNodeIDs(client, labelInputs)
+			if err != nil {
+				return err
+			}
+			cache[id.ID] = labelIDs
+		}
+
+		var labelIDsSerialized []string
+		for _, l := range labelIDs {
+			labelIDsSerialized = append(labelIDsSerialized, fmt.Sprintf("%q", l.Label.ID))
+		}
+
+		mutations = append(mutations, fmt.Sprintf(`
+			m%03d: addLabelsToLabelable(input: {
+				labelableId: %q
+				labelIds: [%s]
+			}) { clientMutationId }
+		`, i, id.Issue.ID, strings.Join(labelIDsSerialized, ",")))
+	}
+
+	err = client.GraphQL(fmt.Sprintf(`mutation{%s}`, strings.Join(mutations, "")), nil, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/command/bulk.go
+++ b/command/bulk.go
@@ -1,0 +1,122 @@
+package command
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(bulkCmd)
+	bulkCmd.Flags().StringSliceP("label", "l", nil, "Add label")
+}
+
+var bulkCmd = &cobra.Command{
+	Use:   "bulk {add|open|close|browse}",
+	Args:  cobra.ExactArgs(1),
+	Short: "Perform operation on a set of objects",
+	Long: `Perform bulk operation on a set of objects passed in via standard input.
+
+The first word of every line of input is interpreted like so:
+- number, e.g. "123": an issue number in the current repository
+- repo with number, e.g. "owner/repo#123": an issue in a specific repository
+- repo, e.g. "owner/repo": a specific repository
+
+Valid operations are:
+- "add": add labels
+- "close": set issue state to closed
+- "open": set issue state to open
+- "browse": open items in the web browser
+
+Examples:
+
+	$ gh issue list -L 10 | gh bulk add --label "triage"`,
+	RunE: bulk,
+}
+
+func bulk(cmd *cobra.Command, args []string) error {
+	ctx := contextForCommand(cmd)
+
+	baseRepo, err := ctx.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	client, err := apiClientForContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	input := bufio.NewScanner(os.Stdin)
+	var inputItems []api.BulkInput
+
+	repoWithIssueRE := regexp.MustCompile(`^([^/]+/[^/]+)#(\d+)$`)
+	repoNameRE := regexp.MustCompile(`^([^/]+/[^/]+)$`)
+
+	for input.Scan() {
+		line := input.Text()
+		tokens := strings.Fields(line)
+		if len(tokens) < 1 {
+			continue
+		}
+
+		if issueNum, err := strconv.Atoi(tokens[0]); err == nil {
+			inputItems = append(inputItems, api.BulkInput{
+				Number:     issueNum,
+				Repository: baseRepo,
+			})
+			continue
+		}
+
+		if m := repoWithIssueRE.FindAllStringSubmatch(tokens[0], 1); len(m) > 0 {
+			repo := ghrepo.FromFullName(m[0][1])
+			issueNum, _ := strconv.Atoi(m[0][2])
+			inputItems = append(inputItems, api.BulkInput{
+				Number:     issueNum,
+				Repository: repo,
+			})
+			continue
+		}
+
+		if m := repoNameRE.FindAllStringSubmatch(tokens[0], 1); len(m) > 0 {
+			repo := ghrepo.FromFullName(m[0][1])
+			inputItems = append(inputItems, api.BulkInput{
+				Repository: repo,
+			})
+			continue
+		}
+
+		return fmt.Errorf("unrecognized input format: %q", tokens[0])
+	}
+
+	labels, err := cmd.Flags().GetStringSlice("label")
+	if err != nil {
+		return err
+	}
+
+	operation := args[0]
+	// TODO: open, close
+	switch operation {
+	case "add":
+		return api.BulkAddLabels(client, inputItems, labels)
+	case "browse":
+		for _, item := range inputItems {
+			url := fmt.Sprintf("https://github.com/%s/%s", item.Repository.RepoOwner(), item.Repository.RepoName())
+			if item.Number > 0 {
+				url += fmt.Sprintf("/issues/%d", item.Number)
+			}
+			_ = utils.OpenInBrowser(url)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unrecognized operation: %q", operation)
+	}
+}

--- a/command/bulk.go
+++ b/command/bulk.go
@@ -103,10 +103,11 @@ func bulk(cmd *cobra.Command, args []string) error {
 	}
 
 	operation := args[0]
-	// TODO: open, close
 	switch operation {
 	case "add":
 		return api.BulkAddLabels(client, inputItems, labels)
+	case "open", "close":
+		return api.BulkChangeState(client, inputItems, operation)
 	case "browse":
 		for _, item := range inputItems {
 			url := fmt.Sprintf("https://github.com/%s/%s", item.Repository.RepoOwner(), item.Repository.RepoName())


### PR DESCRIPTION
The "bulk" command receives a list of identifiers on standard input and performs a bulk operation on them. The features proposed here did not pass any design phase yet.

Synopsis:

    gh bulk {add|browse|open|close}

Valid operations:

- [x] `add`: adds all labels specified by `--label`
- [x] `browse`: opens all items in the web browser
- [x] `open`: changes issue states to "open"
- [x] `close`: changes issue states to "closed"

Works well with `search` output https://github.com/cli/cli/pull/830

Examples:

    $ gh issue list | gh bulk add --label "new" --label "help wanted"

    $ gh search repos '...' | gh bulk browse