### PR TITLE
Hide closed/merged PRs from default branch

### DIFF
--- a/api/fake_http.go
+++ b/api/fake_http.go
@@ -70,6 +70,25 @@ func (f *FakeHTTP) StubRepoResponseWithPermission(owner, repo, permission string
 	f.responseStubs = append(f.responseStubs, resp)
 }
 
+func (f *FakeHTTP) StubRepoResponseWithDefaultBranch(owner, repo, defaultBranch string) {
+	body := bytes.NewBufferString(fmt.Sprintf(`
+		{ "data": { "repo_000": {
+			"id": "REPOID",
+			"name": "%s",
+			"owner": {"login": "%s"},
+			"defaultBranchRef": {
+				"name": "%s"
+			},
+			"viewerPermission": "READ"
+		} } }
+	`, repo, owner, defaultBranch))
+	resp := &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(body),
+	}
+	f.responseStubs = append(f.responseStubs, resp)
+}
+
 func (f *FakeHTTP) StubForkedRepoResponse(forkFullName, parentFullName string) {
 	forkRepo := strings.SplitN(forkFullName, "/", 2)
 	parentRepo := strings.SplitN(parentFullName, "/", 2)

--- a/command/pr.go
+++ b/command/pr.go
@@ -83,8 +83,9 @@ func prStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepoOverride, _ := cmd.Flags().GetString("repo")
-	repoContext, err := context.ResolveRemotesToRepos(remotes, apiClient, baseRepoOverride)
+	repoOverride, _ := cmd.Flags().GetString("repo")
+
+	remoteContext, err := context.ResolveRemotesToRepos(remotes, apiClient, repoOverride)
 	if err != nil {
 		return err
 	}
@@ -94,7 +95,6 @@ func prStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	repoOverride, _ := cmd.Flags().GetString("repo")
 	currentPRNumber, currentPRHeadRef, err := prSelectorForCurrentBranch(ctx, baseRepo)
 	if err != nil && repoOverride == "" && err.Error() != "git: not on any branch" {
 		return fmt.Errorf("could not query for pull request for current branch: %w", err)
@@ -114,7 +114,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 	printHeader(out, "Current branch")
 	currentPR := prPayload.CurrentPR
 	currentBranch, _ := ctx.Branch()
-	remoteRepo, _ := repoContext.BaseRepo()
+	remoteRepo, _ := remoteContext.BaseRepo()
 	noPRMessage := fmt.Sprintf("  There is no pull request associated with %s", utils.Cyan("["+currentPRHeadRef+"]"))
 	if currentPR != nil {
 		if remoteRepo.DefaultBranchRef.Name == currentBranch && currentPR.State != "OPEN" {

--- a/command/pr.go
+++ b/command/pr.go
@@ -73,19 +73,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	remotes, err := ctx.Remotes()
-	if err != nil {
-		return err
-	}
-
 	currentUser, err := ctx.AuthLogin()
-	if err != nil {
-		return err
-	}
-
-	repoOverride, _ := cmd.Flags().GetString("repo")
-
-	remoteContext, err := context.ResolveRemotesToRepos(remotes, apiClient, repoOverride)
 	if err != nil {
 		return err
 	}
@@ -95,6 +83,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	repoOverride, _ := cmd.Flags().GetString("repo")
 	currentPRNumber, currentPRHeadRef, err := prSelectorForCurrentBranch(ctx, baseRepo)
 	if err != nil && repoOverride == "" && err.Error() != "git: not on any branch" {
 		return fmt.Errorf("could not query for pull request for current branch: %w", err)
@@ -114,10 +103,9 @@ func prStatus(cmd *cobra.Command, args []string) error {
 	printHeader(out, "Current branch")
 	currentPR := prPayload.CurrentPR
 	currentBranch, _ := ctx.Branch()
-	remoteRepo, _ := remoteContext.BaseRepo()
 	noPRMessage := fmt.Sprintf("  There is no pull request associated with %s", utils.Cyan("["+currentPRHeadRef+"]"))
 	if currentPR != nil {
-		if remoteRepo.DefaultBranchRef.Name == currentBranch && currentPR.State != "OPEN" {
+		if baseRepo.(*api.Repository).DefaultBranchRef.Name == currentBranch && currentPR.State != "OPEN" {
 			printMessage(out, noPRMessage)
 		} else {
 			printPrs(out, 0, *currentPR)

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -77,6 +77,7 @@ func TestPRStatus(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
+	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatus.json")
 	defer jsonFile.Close()
@@ -104,6 +105,7 @@ func TestPRStatus(t *testing.T) {
 func TestPRStatus_fork(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
+	http.StubForkedRepoResponse("OWNER/REPO", "PARENT/REPO")
 	http.StubForkedRepoResponse("OWNER/REPO", "PARENT/REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusFork.json")
@@ -135,6 +137,7 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
+	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusChecks.json")
 	defer jsonFile.Close()
@@ -161,6 +164,7 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 func TestPRStatus_currentBranch_showTheMostRecentPR(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranch.json")
@@ -190,9 +194,32 @@ func TestPRStatus_currentBranch_showTheMostRecentPR(t *testing.T) {
 	}
 }
 
+func TestPRStatus_currentBranch_defaultBranch(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "blueberries")
+	http := initFakeHTTP()
+	http.StubRepoResponseWithDefaultBranch("OWNER", "REPO", "blueberries")
+	http.StubRepoResponse("OWNER", "REPO")
+
+	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranch.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
+
+	output, err := RunCommand(prStatusCmd, "pr status")
+	if err != nil {
+		t.Errorf("error running command `pr status`: %v", err)
+	}
+
+	expectedLine := regexp.MustCompile(`#10  Blueberries are certainly a good fruit \[blueberries\]`)
+	if !expectedLine.MatchString(output.String()) {
+		t.Errorf("output did not match regexp /%s/\n> output\n%s\n", expectedLine, output)
+		return
+	}
+}
+
 func TestPRStatus_currentBranch_Closed(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchClosed.json")
@@ -211,9 +238,32 @@ func TestPRStatus_currentBranch_Closed(t *testing.T) {
 	}
 }
 
+func TestPRStatus_currentBranch_Closed_defaultBranch(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "blueberries")
+	http := initFakeHTTP()
+	http.StubRepoResponseWithDefaultBranch("OWNER", "REPO", "blueberries")
+	http.StubRepoResponse("OWNER", "REPO")
+
+	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchClosed.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
+
+	output, err := RunCommand(prStatusCmd, "pr status")
+	if err != nil {
+		t.Errorf("error running command `pr status`: %v", err)
+	}
+
+	expectedLine := regexp.MustCompile(`There is no pull request associated with \[blueberries\]`)
+	if !expectedLine.MatchString(output.String()) {
+		t.Errorf("output did not match regexp /%s/\n> output\n%s\n", expectedLine, output)
+		return
+	}
+}
+
 func TestPRStatus_currentBranch_Merged(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchMerged.json")
@@ -232,9 +282,32 @@ func TestPRStatus_currentBranch_Merged(t *testing.T) {
 	}
 }
 
+func TestPRStatus_currentBranch_Merged_defaultBranch(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "blueberries")
+	http := initFakeHTTP()
+	http.StubRepoResponseWithDefaultBranch("OWNER", "REPO", "blueberries")
+	http.StubRepoResponse("OWNER", "REPO")
+
+	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchMerged.json")
+	defer jsonFile.Close()
+	http.StubResponse(200, jsonFile)
+
+	output, err := RunCommand(prStatusCmd, "pr status")
+	if err != nil {
+		t.Errorf("error running command `pr status`: %v", err)
+	}
+
+	expectedLine := regexp.MustCompile(`There is no pull request associated with \[blueberries\]`)
+	if !expectedLine.MatchString(output.String()) {
+		t.Errorf("output did not match regexp /%s/\n> output\n%s\n", expectedLine, output)
+		return
+	}
+}
+
 func TestPRStatus_blankSlate(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
 	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -77,7 +77,6 @@ func TestPRStatus(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
-	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatus.json")
 	defer jsonFile.Close()
@@ -105,7 +104,6 @@ func TestPRStatus(t *testing.T) {
 func TestPRStatus_fork(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-	http.StubForkedRepoResponse("OWNER/REPO", "PARENT/REPO")
 	http.StubForkedRepoResponse("OWNER/REPO", "PARENT/REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusFork.json")
@@ -137,7 +135,6 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
-	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusChecks.json")
 	defer jsonFile.Close()
@@ -164,7 +161,6 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 func TestPRStatus_currentBranch_showTheMostRecentPR(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-	http.StubRepoResponse("OWNER", "REPO")
 	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranch.json")
@@ -198,7 +194,6 @@ func TestPRStatus_currentBranch_defaultBranch(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponseWithDefaultBranch("OWNER", "REPO", "blueberries")
-	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranch.json")
 	defer jsonFile.Close()
@@ -219,7 +214,6 @@ func TestPRStatus_currentBranch_defaultBranch(t *testing.T) {
 func TestPRStatus_currentBranch_Closed(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-	http.StubRepoResponse("OWNER", "REPO")
 	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchClosed.json")
@@ -242,7 +236,6 @@ func TestPRStatus_currentBranch_Closed_defaultBranch(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponseWithDefaultBranch("OWNER", "REPO", "blueberries")
-	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchClosed.json")
 	defer jsonFile.Close()
@@ -263,7 +256,6 @@ func TestPRStatus_currentBranch_Closed_defaultBranch(t *testing.T) {
 func TestPRStatus_currentBranch_Merged(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-	http.StubRepoResponse("OWNER", "REPO")
 	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchMerged.json")
@@ -286,7 +278,6 @@ func TestPRStatus_currentBranch_Merged_defaultBranch(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponseWithDefaultBranch("OWNER", "REPO", "blueberries")
-	http.StubRepoResponse("OWNER", "REPO")
 
 	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchMerged.json")
 	defer jsonFile.Close()
@@ -307,7 +298,6 @@ func TestPRStatus_currentBranch_Merged_defaultBranch(t *testing.T) {
 func TestPRStatus_blankSlate(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-	http.StubRepoResponse("OWNER", "REPO")
 	http.StubRepoResponse("OWNER", "REPO")
 
 	http.StubResponse(200, bytes.NewBufferString(`


### PR DESCRIPTION
Fixes #805

We should not display closed/merged PRs under the `Current Branch` heading if the current branch is also the default branch - otherwise they will always show up when running `gh pr status` from the default branch

This can occur is someone accidentally gets the branches around the wrong way trying to make a PR and does `master/default -> branch`