### PR TITLE
RFC: Make `RunCommand` less brittle

### DIFF
--- a/command/completion_test.go
+++ b/command/completion_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCompletion_bash(t *testing.T) {
-	output, err := RunCommand(completionCmd, `completion`)
+	output, err := RunCommand(`completion`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -17,7 +17,7 @@ func TestCompletion_bash(t *testing.T) {
 }
 
 func TestCompletion_zsh(t *testing.T) {
-	output, err := RunCommand(completionCmd, `completion -s zsh`)
+	output, err := RunCommand(`completion -s zsh`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func TestCompletion_zsh(t *testing.T) {
 }
 
 func TestCompletion_fish(t *testing.T) {
-	output, err := RunCommand(completionCmd, `completion -s fish`)
+	output, err := RunCommand(`completion -s fish`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestCompletion_fish(t *testing.T) {
 }
 
 func TestCompletion_powerShell(t *testing.T) {
-	output, err := RunCommand(completionCmd, `completion -s powershell`)
+	output, err := RunCommand(`completion -s powershell`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestCompletion_powerShell(t *testing.T) {
 }
 
 func TestCompletion_unsupported(t *testing.T) {
-	_, err := RunCommand(completionCmd, `completion -s csh`)
+	_, err := RunCommand(`completion -s csh`)
 	if err == nil || err.Error() != `unsupported shell type "csh"` {
 		t.Fatal(err)
 	}

--- a/command/config_test.go
+++ b/command/config_test.go
@@ -17,7 +17,7 @@ editor: ed
 `
 	initBlankContext(cfg, "OWNER/REPO", "master")
 
-	output, err := RunCommand(configGetCmd, "config get editor")
+	output, err := RunCommand("config get editor")
 	if err != nil {
 		t.Fatalf("error running command `config get editor`: %v", err)
 	}
@@ -27,7 +27,7 @@ editor: ed
 
 func TestConfigGet_default(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "master")
-	output, err := RunCommand(configGetCmd, "config get git_protocol")
+	output, err := RunCommand("config get git_protocol")
 	if err != nil {
 		t.Fatalf("error running command `config get git_protocol`: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestConfigGet_default(t *testing.T) {
 func TestConfigGet_not_found(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "master")
 
-	output, err := RunCommand(configGetCmd, "config get missing")
+	output, err := RunCommand("config get missing")
 	if err != nil {
 		t.Fatalf("error running command `config get missing`: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestConfigSet(t *testing.T) {
 
 	buf := bytes.NewBufferString("")
 	defer config.StubWriteConfig(buf)()
-	output, err := RunCommand(configSetCmd, "config set editor ed")
+	output, err := RunCommand("config set editor ed")
 	if err != nil {
 		t.Fatalf("error running command `config set editor ed`: %v", err)
 	}
@@ -82,7 +82,7 @@ editor: ed
 	buf := bytes.NewBufferString("")
 	defer config.StubWriteConfig(buf)()
 
-	output, err := RunCommand(configSetCmd, "config set editor vim")
+	output, err := RunCommand("config set editor vim")
 	if err != nil {
 		t.Fatalf("error running command `config get editor`: %v", err)
 	}
@@ -110,7 +110,7 @@ git_protocol: https
 `
 	initBlankContext(cfg, "OWNER/REPO", "master")
 
-	output, err := RunCommand(configGetCmd, "config get -hgithub.com git_protocol")
+	output, err := RunCommand("config get -hgithub.com git_protocol")
 	if err != nil {
 		t.Fatalf("error running command `config get editor`: %v", err)
 	}
@@ -130,7 +130,7 @@ git_protocol: ssh
 `
 	initBlankContext(cfg, "OWNER/REPO", "master")
 
-	output, err := RunCommand(configGetCmd, "config get -hgithub.com git_protocol")
+	output, err := RunCommand("config get -hgithub.com git_protocol")
 	if err != nil {
 		t.Fatalf("error running command `config get -hgithub.com git_protocol`: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestConfigSetHost(t *testing.T) {
 
 	buf := bytes.NewBufferString("")
 	defer config.StubWriteConfig(buf)()
-	output, err := RunCommand(configSetCmd, "config set -hgithub.com git_protocol ssh")
+	output, err := RunCommand("config set -hgithub.com git_protocol ssh")
 	if err != nil {
 		t.Fatalf("error running command `config set editor ed`: %v", err)
 	}
@@ -174,7 +174,7 @@ hosts:
 	buf := bytes.NewBufferString("")
 	defer config.StubWriteConfig(buf)()
 
-	output, err := RunCommand(configSetCmd, "config set -hgithub.com git_protocol https")
+	output, err := RunCommand("config set -hgithub.com git_protocol https")
 	if err != nil {
 		t.Fatalf("error running command `config get editor`: %v", err)
 	}

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -24,7 +24,7 @@ func TestIssueStatus(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	output, err := RunCommand(issueStatusCmd, "issue status")
+	output, err := RunCommand("issue status")
 	if err != nil {
 		t.Errorf("error running command `issue status`: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestIssueStatus_blankSlate(t *testing.T) {
 	} } }
 	`))
 
-	output, err := RunCommand(issueStatusCmd, "issue status")
+	output, err := RunCommand("issue status")
 	if err != nil {
 		t.Errorf("error running command `issue status`: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestIssueStatus_disabledIssues(t *testing.T) {
 	} } }
 	`))
 
-	_, err := RunCommand(issueStatusCmd, "issue status")
+	_, err := RunCommand("issue status")
 	if err == nil || err.Error() != "the 'OWNER/REPO' repository has disabled issues" {
 		t.Errorf("error running command `issue status`: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestIssueList(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	output, err := RunCommand(issueListCmd, "issue list")
+	output, err := RunCommand("issue list")
 	if err != nil {
 		t.Errorf("error running command `issue list`: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestIssueList_withFlags(t *testing.T) {
 	} } }
 	`))
 
-	output, err := RunCommand(issueListCmd, "issue list -a probablyCher -l web,bug -s open -A foo")
+	output, err := RunCommand("issue list -a probablyCher -l web,bug -s open -A foo")
 	if err != nil {
 		t.Errorf("error running command `issue list`: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestIssueList_nullAssigneeLabels(t *testing.T) {
 	} } }
 	`))
 
-	_, err := RunCommand(issueListCmd, "issue list")
+	_, err := RunCommand("issue list")
 	if err != nil {
 		t.Errorf("error running command `issue list`: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestIssueList_disabledIssues(t *testing.T) {
 	} } }
 	`))
 
-	_, err := RunCommand(issueListCmd, "issue list")
+	_, err := RunCommand("issue list")
 	if err == nil || err.Error() != "the 'OWNER/REPO' repository has disabled issues" {
 		t.Errorf("error running command `issue list`: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestIssueView_web(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(issueViewCmd, "issue view -w 123")
+	output, err := RunCommand("issue view -w 123")
 	if err != nil {
 		t.Errorf("error running command `issue view`: %v", err)
 	}
@@ -270,7 +270,7 @@ func TestIssueView_web_numberArgWithHash(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(issueViewCmd, "issue view -w \"#123\"")
+	output, err := RunCommand("issue view -w \"#123\"")
 	if err != nil {
 		t.Errorf("error running command `issue view`: %v", err)
 	}
@@ -350,7 +350,7 @@ func TestIssueView_Preview(t *testing.T) {
 			defer jsonFile.Close()
 			http.StubResponse(200, jsonFile)
 
-			output, err := RunCommand(issueViewCmd, tc.command)
+			output, err := RunCommand(tc.command)
 			if err != nil {
 				t.Errorf("error running command `%v`: %v", tc.command, err)
 			}
@@ -379,7 +379,7 @@ func TestIssueView_web_notFound(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	_, err := RunCommand(issueViewCmd, "issue view -w 9999")
+	_, err := RunCommand("issue view -w 9999")
 	if err == nil || err.Error() != "graphql error: 'Could not resolve to an Issue with the number of 9999.'" {
 		t.Errorf("error running command `issue view`: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestIssueView_disabledIssues(t *testing.T) {
 		} } }
 	`))
 
-	_, err := RunCommand(issueViewCmd, `issue view 6666`)
+	_, err := RunCommand(`issue view 6666`)
 	if err == nil || err.Error() != "the 'OWNER/REPO' repository has disabled issues" {
 		t.Errorf("error running command `issue view`: %v", err)
 	}
@@ -426,7 +426,7 @@ func TestIssueView_web_urlArg(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(issueViewCmd, "issue view -w https://github.com/OWNER/REPO/issues/123")
+	output, err := RunCommand("issue view -w https://github.com/OWNER/REPO/issues/123")
 	if err != nil {
 		t.Errorf("error running command `issue view`: %v", err)
 	}
@@ -457,7 +457,7 @@ func TestIssueCreate(t *testing.T) {
 		} } } }
 	`))
 
-	output, err := RunCommand(issueCreateCmd, `issue create -t hello -b "cash rules everything around me"`)
+	output, err := RunCommand(`issue create -t hello -b "cash rules everything around me"`)
 	if err != nil {
 		t.Errorf("error running command `issue create`: %v", err)
 	}
@@ -493,7 +493,7 @@ func TestIssueCreate_disabledIssues(t *testing.T) {
 		} } }
 	`))
 
-	_, err := RunCommand(issueCreateCmd, `issue create -t heres -b johnny`)
+	_, err := RunCommand(`issue create -t heres -b johnny`)
 	if err == nil || err.Error() != "the 'OWNER/REPO' repository has disabled issues" {
 		t.Errorf("error running command `issue create`: %v", err)
 	}
@@ -511,7 +511,7 @@ func TestIssueCreate_web(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(issueCreateCmd, `issue create --web`)
+	output, err := RunCommand(`issue create --web`)
 	if err != nil {
 		t.Errorf("error running command `issue create`: %v", err)
 	}
@@ -537,7 +537,7 @@ func TestIssueCreate_webTitleBody(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(issueCreateCmd, `issue create -w -t mytitle -b mybody`)
+	output, err := RunCommand(`issue create -w -t mytitle -b mybody`)
 	if err != nil {
 		t.Errorf("error running command `issue create`: %v", err)
 	}
@@ -695,7 +695,7 @@ func TestIssueClose(t *testing.T) {
 
 	http.StubResponse(200, bytes.NewBufferString(`{"id": "THE-ID"}`))
 
-	output, err := RunCommand(issueCloseCmd, "issue close 13")
+	output, err := RunCommand("issue close 13")
 	if err != nil {
 		t.Fatalf("error running command `issue close`: %v", err)
 	}
@@ -721,7 +721,7 @@ func TestIssueClose_alreadyClosed(t *testing.T) {
 
 	http.StubResponse(200, bytes.NewBufferString(`{"id": "THE-ID"}`))
 
-	output, err := RunCommand(issueCloseCmd, "issue close 13")
+	output, err := RunCommand("issue close 13")
 	if err != nil {
 		t.Fatalf("error running command `issue close`: %v", err)
 	}
@@ -744,7 +744,7 @@ func TestIssueClose_issuesDisabled(t *testing.T) {
 	} } }
 	`))
 
-	_, err := RunCommand(issueCloseCmd, "issue close 13")
+	_, err := RunCommand("issue close 13")
 	if err == nil {
 		t.Fatalf("expected error when issues are disabled")
 	}
@@ -768,7 +768,7 @@ func TestIssueReopen(t *testing.T) {
 
 	http.StubResponse(200, bytes.NewBufferString(`{"id": "THE-ID"}`))
 
-	output, err := RunCommand(issueReopenCmd, "issue reopen 2")
+	output, err := RunCommand("issue reopen 2")
 	if err != nil {
 		t.Fatalf("error running command `issue reopen`: %v", err)
 	}
@@ -794,7 +794,7 @@ func TestIssueReopen_alreadyOpen(t *testing.T) {
 
 	http.StubResponse(200, bytes.NewBufferString(`{"id": "THE-ID"}`))
 
-	output, err := RunCommand(issueReopenCmd, "issue reopen 2")
+	output, err := RunCommand("issue reopen 2")
 	if err != nil {
 		t.Fatalf("error running command `issue reopen`: %v", err)
 	}
@@ -817,7 +817,7 @@ func TestIssueReopen_issuesDisabled(t *testing.T) {
 	} } }
 	`))
 
-	_, err := RunCommand(issueReopenCmd, "issue reopen 2")
+	_, err := RunCommand("issue reopen 2")
 	if err == nil {
 		t.Fatalf("expected error when issues are disabled")
 	}

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -55,7 +55,7 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prCheckoutCmd, `pr checkout 123`)
+	output, err := RunCommand(`pr checkout 123`)
 	eq(t, err, nil)
 	eq(t, output.String(), "")
 
@@ -107,7 +107,7 @@ func TestPRCheckout_urlArg(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prCheckoutCmd, `pr checkout https://github.com/OWNER/REPO/pull/123/files`)
+	output, err := RunCommand(`pr checkout https://github.com/OWNER/REPO/pull/123/files`)
 	eq(t, err, nil)
 	eq(t, output.String(), "")
 
@@ -156,7 +156,7 @@ func TestPRCheckout_urlArg_differentBase(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prCheckoutCmd, `pr checkout https://github.com/OTHER/POE/pull/123/files`)
+	output, err := RunCommand(`pr checkout https://github.com/OTHER/POE/pull/123/files`)
 	eq(t, err, nil)
 	eq(t, output.String(), "")
 
@@ -219,7 +219,7 @@ func TestPRCheckout_branchArg(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prCheckoutCmd, `pr checkout hubot:feature`)
+	output, err := RunCommand(`pr checkout hubot:feature`)
 	eq(t, err, nil)
 	eq(t, output.String(), "")
 
@@ -269,7 +269,7 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prCheckoutCmd, `pr checkout 123`)
+	output, err := RunCommand(`pr checkout 123`)
 	eq(t, err, nil)
 	eq(t, output.String(), "")
 
@@ -322,7 +322,7 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prCheckoutCmd, `pr checkout 123`)
+	output, err := RunCommand(`pr checkout 123`)
 	eq(t, err, nil)
 	eq(t, output.String(), "")
 
@@ -375,7 +375,7 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prCheckoutCmd, `pr checkout 123`)
+	output, err := RunCommand(`pr checkout 123`)
 	eq(t, err, nil)
 	eq(t, output.String(), "")
 
@@ -428,7 +428,7 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prCheckoutCmd, `pr checkout 123`)
+	output, err := RunCommand(`pr checkout 123`)
 	eq(t, err, nil)
 	eq(t, output.String(), "")
 
@@ -479,7 +479,7 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prCheckoutCmd, `pr checkout 123`)
+	output, err := RunCommand(`pr checkout 123`)
 	eq(t, err, nil)
 	eq(t, output.String(), "")
 
@@ -530,7 +530,7 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prCheckoutCmd, `pr checkout 123`)
+	output, err := RunCommand(`pr checkout 123`)
 	eq(t, err, nil)
 	eq(t, output.String(), "")
 

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -39,7 +39,7 @@ func TestPRCreate(t *testing.T) {
 	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
 	cs.Stub("")                                         // git push
 
-	output, err := RunCommand(prCreateCmd, `pr create -t "my title" -b "my body"`)
+	output, err := RunCommand(`pr create -t "my title" -b "my body"`)
 	eq(t, err, nil)
 
 	bodyBytes, _ := ioutil.ReadAll(http.Requests[3].Body)
@@ -101,7 +101,7 @@ func TestPRCreate_withForking(t *testing.T) {
 	cs.Stub("")                                         // git remote add
 	cs.Stub("")                                         // git push
 
-	output, err := RunCommand(prCreateCmd, `pr create -t title -b body`)
+	output, err := RunCommand(`pr create -t title -b body`)
 	eq(t, err, nil)
 
 	eq(t, http.Requests[3].URL.Path, "/repos/OWNER/REPO/forks")
@@ -132,7 +132,7 @@ func TestPRCreate_alreadyExists(t *testing.T) {
 	cs.Stub("")                                         // git status
 	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
 
-	_, err := RunCommand(prCreateCmd, `pr create`)
+	_, err := RunCommand(`pr create`)
 	if err == nil {
 		t.Fatal("error expected, got nil")
 	}
@@ -167,7 +167,7 @@ func TestPRCreate_alreadyExistsDifferentBase(t *testing.T) {
 	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
 	cs.Stub("")                                         // git rev-parse
 
-	_, err := RunCommand(prCreateCmd, `pr create -BanotherBase -t"cool" -b"nah"`)
+	_, err := RunCommand(`pr create -BanotherBase -t"cool" -b"nah"`)
 	if err != nil {
 		t.Errorf("got unexpected error %q", err)
 	}
@@ -192,7 +192,7 @@ func TestPRCreate_web(t *testing.T) {
 	cs.Stub("")                                         // git push
 	cs.Stub("")                                         // browser
 
-	output, err := RunCommand(prCreateCmd, `pr create --web`)
+	output, err := RunCommand(`pr create --web`)
 	eq(t, err, nil)
 
 	eq(t, output.String(), "")
@@ -232,7 +232,7 @@ func TestPRCreate_ReportsUncommittedChanges(t *testing.T) {
 	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
 	cs.Stub("")                                         // git push
 
-	output, err := RunCommand(prCreateCmd, `pr create -t "my title" -b "my body"`)
+	output, err := RunCommand(`pr create -t "my title" -b "my body"`)
 	eq(t, err, nil)
 
 	eq(t, output.String(), "https://github.com/OWNER/REPO/pull/12\n")
@@ -301,7 +301,7 @@ func TestPRCreate_cross_repo_same_branch(t *testing.T) {
 	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
 	cs.Stub("")                                         // git push
 
-	output, err := RunCommand(prCreateCmd, `pr create -t "cross repo" -b "same branch"`)
+	output, err := RunCommand(`pr create -t "cross repo" -b "same branch"`)
 	eq(t, err, nil)
 
 	bodyBytes, _ := ioutil.ReadAll(http.Requests[2].Body)
@@ -377,7 +377,7 @@ func TestPRCreate_survey_defaults_multicommit(t *testing.T) {
 		},
 	})
 
-	output, err := RunCommand(prCreateCmd, `pr create`)
+	output, err := RunCommand(`pr create`)
 	eq(t, err, nil)
 
 	bodyBytes, _ := ioutil.ReadAll(http.Requests[3].Body)
@@ -454,7 +454,7 @@ func TestPRCreate_survey_defaults_monocommit(t *testing.T) {
 		},
 	})
 
-	output, err := RunCommand(prCreateCmd, `pr create`)
+	output, err := RunCommand(`pr create`)
 	eq(t, err, nil)
 
 	bodyBytes, _ := ioutil.ReadAll(http.Requests[3].Body)
@@ -512,7 +512,7 @@ func TestPRCreate_survey_autofill(t *testing.T) {
 	cs.Stub("")                                                        // git push
 	cs.Stub("")                                                        // browser open
 
-	output, err := RunCommand(prCreateCmd, `pr create -f`)
+	output, err := RunCommand(`pr create -f`)
 	eq(t, err, nil)
 
 	bodyBytes, _ := ioutil.ReadAll(http.Requests[3].Body)
@@ -553,7 +553,7 @@ func TestPRCreate_defaults_error_autofill(t *testing.T) {
 	cs.Stub("") // git status
 	cs.Stub("") // git log
 
-	_, err := RunCommand(prCreateCmd, "pr create -f")
+	_, err := RunCommand("pr create -f")
 
 	eq(t, err.Error(), "could not compute title or body defaults: could not find any commits between origin/master and feature")
 }
@@ -571,7 +571,7 @@ func TestPRCreate_defaults_error_web(t *testing.T) {
 	cs.Stub("") // git status
 	cs.Stub("") // git log
 
-	_, err := RunCommand(prCreateCmd, "pr create -w")
+	_, err := RunCommand("pr create -w")
 
 	eq(t, err.Error(), "could not compute title or body defaults: could not find any commits between origin/master and feature")
 }
@@ -621,7 +621,7 @@ func TestPRCreate_defaults_error_interactive(t *testing.T) {
 		},
 	})
 
-	output, err := RunCommand(prCreateCmd, `pr create`)
+	output, err := RunCommand(`pr create`)
 	eq(t, err, nil)
 
 	stderr := string(output.Stderr())

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -15,9 +15,6 @@ import (
 	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/test"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/shlex"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func eq(t *testing.T, got interface{}, expected interface{}) {
@@ -25,52 +22,6 @@ func eq(t *testing.T, got interface{}, expected interface{}) {
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("expected: %v, got: %v", expected, got)
 	}
-}
-
-type cmdOut struct {
-	outBuf, errBuf *bytes.Buffer
-}
-
-func (c cmdOut) String() string {
-	return c.outBuf.String()
-}
-
-func (c cmdOut) Stderr() string {
-	return c.errBuf.String()
-}
-
-func RunCommand(cmd *cobra.Command, args string) (*cmdOut, error) {
-	rootCmd := cmd.Root()
-	argv, err := shlex.Split(args)
-	if err != nil {
-		return nil, err
-	}
-	rootCmd.SetArgs(argv)
-
-	outBuf := bytes.Buffer{}
-	cmd.SetOut(&outBuf)
-	errBuf := bytes.Buffer{}
-	cmd.SetErr(&errBuf)
-
-	// Reset flag values so they don't leak between tests
-	// FIXME: change how we initialize Cobra commands to render this hack unnecessary
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		switch v := f.Value.(type) {
-		case pflag.SliceValue:
-			_ = v.Replace([]string{})
-		default:
-			switch v.Type() {
-			case "bool", "string", "int":
-				_ = v.Set(f.DefValue)
-			}
-		}
-	})
-
-	_, err = rootCmd.ExecuteC()
-	cmd.SetOut(nil)
-	cmd.SetErr(nil)
-
-	return &cmdOut{&outBuf, &errBuf}, err
 }
 
 func TestPRStatus(t *testing.T) {

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -33,7 +33,7 @@ func TestPRStatus(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	output, err := RunCommand(prStatusCmd, "pr status")
+	output, err := RunCommand("pr status")
 	if err != nil {
 		t.Errorf("error running command `pr status`: %v", err)
 	}
@@ -71,7 +71,7 @@ branch.blueberries.merge refs/heads/blueberries`)}
 		}
 	})()
 
-	output, err := RunCommand(prStatusCmd, "pr status")
+	output, err := RunCommand("pr status")
 	if err != nil {
 		t.Fatalf("error running command `pr status`: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	output, err := RunCommand(prStatusCmd, "pr status")
+	output, err := RunCommand("pr status")
 	if err != nil {
 		t.Errorf("error running command `pr status`: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestPRStatus_currentBranch_showTheMostRecentPR(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	output, err := RunCommand(prStatusCmd, "pr status")
+	output, err := RunCommand("pr status")
 	if err != nil {
 		t.Errorf("error running command `pr status`: %v", err)
 	}
@@ -150,7 +150,7 @@ func TestPRStatus_currentBranch_Closed(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	output, err := RunCommand(prStatusCmd, "pr status")
+	output, err := RunCommand("pr status")
 	if err != nil {
 		t.Errorf("error running command `pr status`: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestPRStatus_currentBranch_Merged(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	output, err := RunCommand(prStatusCmd, "pr status")
+	output, err := RunCommand("pr status")
 	if err != nil {
 		t.Errorf("error running command `pr status`: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestPRStatus_blankSlate(t *testing.T) {
 	{ "data": {} }
 	`))
 
-	output, err := RunCommand(prStatusCmd, "pr status")
+	output, err := RunCommand("pr status")
 	if err != nil {
 		t.Errorf("error running command `pr status`: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestPRList(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	output, err := RunCommand(prListCmd, "pr list")
+	output, err := RunCommand("pr list")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,7 +247,7 @@ func TestPRList_filtering(t *testing.T) {
 	respBody := bytes.NewBufferString(`{ "data": {} }`)
 	http.StubResponse(200, respBody)
 
-	output, err := RunCommand(prListCmd, `pr list -s all -l one,two -l three`)
+	output, err := RunCommand(`pr list -s all -l one,two -l three`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestPRList_filteringRemoveDuplicate(t *testing.T) {
 	defer jsonFile.Close()
 	http.StubResponse(200, jsonFile)
 
-	output, err := RunCommand(prListCmd, "pr list -l one,two")
+	output, err := RunCommand("pr list -l one,two")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +299,7 @@ func TestPRList_filteringClosed(t *testing.T) {
 	respBody := bytes.NewBufferString(`{ "data": {} }`)
 	http.StubResponse(200, respBody)
 
-	_, err := RunCommand(prListCmd, `pr list -s closed`)
+	_, err := RunCommand(`pr list -s closed`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +323,7 @@ func TestPRList_filteringAssignee(t *testing.T) {
 	respBody := bytes.NewBufferString(`{ "data": {} }`)
 	http.StubResponse(200, respBody)
 
-	_, err := RunCommand(prListCmd, `pr list -s merged -l "needs tests" -a hubot -B develop`)
+	_, err := RunCommand(`pr list -s merged -l "needs tests" -a hubot -B develop`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +347,7 @@ func TestPRList_filteringAssigneeLabels(t *testing.T) {
 	respBody := bytes.NewBufferString(`{ "data": {} }`)
 	http.StubResponse(200, respBody)
 
-	_, err := RunCommand(prListCmd, `pr list -l one,two -a hubot`)
+	_, err := RunCommand(`pr list -l one,two -a hubot`)
 	if err == nil && err.Error() != "multiple labels with --assignee are not supported" {
 		t.Fatal(err)
 	}
@@ -478,7 +478,7 @@ func TestPRView_Preview(t *testing.T) {
 			defer jsonFile.Close()
 			http.StubResponse(200, jsonFile)
 
-			output, err := RunCommand(prViewCmd, tc.args)
+			output, err := RunCommand(tc.args)
 			if err != nil {
 				t.Errorf("error running command `%v`: %v", tc.args, err)
 			}
@@ -511,7 +511,7 @@ func TestPRView_web_currentBranch(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prViewCmd, "pr view -w")
+	output, err := RunCommand("pr view -w")
 	if err != nil {
 		t.Errorf("error running command `pr view`: %v", err)
 	}
@@ -549,7 +549,7 @@ func TestPRView_web_noResultsForBranch(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	_, err := RunCommand(prViewCmd, "pr view -w")
+	_, err := RunCommand("pr view -w")
 	if err == nil || err.Error() != `no open pull requests found for branch "blueberries"` {
 		t.Errorf("error running command `pr view`: %v", err)
 	}
@@ -577,7 +577,7 @@ func TestPRView_web_numberArg(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prViewCmd, "pr view -w 23")
+	output, err := RunCommand("pr view -w 23")
 	if err != nil {
 		t.Errorf("error running command `pr view`: %v", err)
 	}
@@ -609,7 +609,7 @@ func TestPRView_web_numberArgWithHash(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prViewCmd, "pr view -w \"#23\"")
+	output, err := RunCommand("pr view -w \"#23\"")
 	if err != nil {
 		t.Errorf("error running command `pr view`: %v", err)
 	}
@@ -640,7 +640,7 @@ func TestPRView_web_urlArg(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prViewCmd, "pr view -w https://github.com/OWNER/REPO/pull/23/files")
+	output, err := RunCommand("pr view -w https://github.com/OWNER/REPO/pull/23/files")
 	if err != nil {
 		t.Errorf("error running command `pr view`: %v", err)
 	}
@@ -674,7 +674,7 @@ func TestPRView_web_branchArg(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prViewCmd, "pr view -w blueberries")
+	output, err := RunCommand("pr view -w blueberries")
 	if err != nil {
 		t.Errorf("error running command `pr view`: %v", err)
 	}
@@ -709,7 +709,7 @@ func TestPRView_web_branchWithOwnerArg(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(prViewCmd, "pr view -w hubot:blueberries")
+	output, err := RunCommand("pr view -w hubot:blueberries")
 	if err != nil {
 		t.Errorf("error running command `pr view`: %v", err)
 	}

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -42,7 +42,7 @@ func TestRepoFork_already_forked(t *testing.T) {
 	http.StubRepoResponse("OWNER", "REPO")
 	defer http.StubWithFixture(200, "forkResult.json")()
 
-	output, err := RunCommand(repoForkCmd, "repo fork --remote=false")
+	output, err := RunCommand("repo fork --remote=false")
 	if err != nil {
 		t.Errorf("got unexpected error: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestRepoFork_reuseRemote(t *testing.T) {
 	http.StubRepoResponse("OWNER", "REPO")
 	defer http.StubWithFixture(200, "forkResult.json")()
 
-	output, err := RunCommand(repoForkCmd, "repo fork")
+	output, err := RunCommand("repo fork")
 	if err != nil {
 		t.Errorf("got unexpected error: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestRepoFork_in_parent(t *testing.T) {
 	http.StubRepoResponse("OWNER", "REPO")
 	defer http.StubWithFixture(200, "forkResult.json")()
 
-	output, err := RunCommand(repoForkCmd, "repo fork --remote=false")
+	output, err := RunCommand("repo fork --remote=false")
 	if err != nil {
 		t.Errorf("error running command `repo fork`: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestRepoFork_outside(t *testing.T) {
 			http := initFakeHTTP()
 			defer http.StubWithFixture(200, "forkResult.json")()
 
-			output, err := RunCommand(repoForkCmd, tt.args)
+			output, err := RunCommand(tt.args)
 			if err != nil {
 				t.Errorf("error running command `repo fork`: %v", err)
 			}
@@ -162,7 +162,7 @@ func TestRepoFork_in_parent_yes(t *testing.T) {
 		return &test.OutputStub{}
 	})()
 
-	output, err := RunCommand(repoForkCmd, "repo fork --remote")
+	output, err := RunCommand("repo fork --remote")
 	if err != nil {
 		t.Errorf("error running command `repo fork`: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestRepoFork_outside_yes(t *testing.T) {
 	cs.Stub("") // git clone
 	cs.Stub("") // git remote add
 
-	output, err := RunCommand(repoForkCmd, "repo fork --clone OWNER/REPO")
+	output, err := RunCommand("repo fork --clone OWNER/REPO")
 	if err != nil {
 		t.Errorf("error running command `repo fork`: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestRepoFork_outside_survey_yes(t *testing.T) {
 	}
 	defer func() { Confirm = oldConfirm }()
 
-	output, err := RunCommand(repoForkCmd, "repo fork OWNER/REPO")
+	output, err := RunCommand("repo fork OWNER/REPO")
 	if err != nil {
 		t.Errorf("error running command `repo fork`: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestRepoFork_outside_survey_no(t *testing.T) {
 	}
 	defer func() { Confirm = oldConfirm }()
 
-	output, err := RunCommand(repoForkCmd, "repo fork OWNER/REPO")
+	output, err := RunCommand("repo fork OWNER/REPO")
 	if err != nil {
 		t.Errorf("error running command `repo fork`: %v", err)
 	}
@@ -300,7 +300,7 @@ func TestRepoFork_in_parent_survey_yes(t *testing.T) {
 	}
 	defer func() { Confirm = oldConfirm }()
 
-	output, err := RunCommand(repoForkCmd, "repo fork")
+	output, err := RunCommand("repo fork")
 	if err != nil {
 		t.Errorf("error running command `repo fork`: %v", err)
 	}
@@ -343,7 +343,7 @@ func TestRepoFork_in_parent_survey_no(t *testing.T) {
 	}
 	defer func() { Confirm = oldConfirm }()
 
-	output, err := RunCommand(repoForkCmd, "repo fork")
+	output, err := RunCommand("repo fork")
 	if err != nil {
 		t.Errorf("error running command `repo fork`: %v", err)
 	}
@@ -469,7 +469,7 @@ func TestRepoClone(t *testing.T) {
 
 			cs.Stub("") // git clone
 
-			output, err := RunCommand(repoCloneCmd, tt.args)
+			output, err := RunCommand(tt.args)
 			if err != nil {
 				t.Fatalf("error running command `repo clone`: %v", err)
 			}
@@ -499,7 +499,7 @@ func TestRepoClone_hasParent(t *testing.T) {
 	cs.Stub("") // git clone
 	cs.Stub("") // git remote add
 
-	_, err := RunCommand(repoCloneCmd, "repo clone OWNER/REPO")
+	_, err := RunCommand("repo clone OWNER/REPO")
 	if err != nil {
 		t.Fatalf("error running command `repo clone`: %v", err)
 	}
@@ -536,7 +536,7 @@ func TestRepoCreate(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(repoCreateCmd, "repo create REPO")
+	output, err := RunCommand("repo create REPO")
 	if err != nil {
 		t.Errorf("error running command `repo create`: %v", err)
 	}
@@ -605,7 +605,7 @@ func TestRepoCreate_org(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(repoCreateCmd, "repo create ORG/REPO")
+	output, err := RunCommand("repo create ORG/REPO")
 	if err != nil {
 		t.Errorf("error running command `repo create`: %v", err)
 	}
@@ -674,7 +674,7 @@ func TestRepoCreate_orgWithTeam(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(repoCreateCmd, "repo create ORG/REPO --team monkeys")
+	output, err := RunCommand("repo create ORG/REPO --team monkeys")
 	if err != nil {
 		t.Errorf("error running command `repo create`: %v", err)
 	}
@@ -725,7 +725,7 @@ func TestRepoView_web(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(repoViewCmd, "repo view -w")
+	output, err := RunCommand("repo view -w")
 	if err != nil {
 		t.Errorf("error running command `repo view`: %v", err)
 	}
@@ -758,7 +758,7 @@ func TestRepoView_web_ownerRepo(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(repoViewCmd, "repo view -w cli/cli")
+	output, err := RunCommand("repo view -w cli/cli")
 	if err != nil {
 		t.Errorf("error running command `repo view`: %v", err)
 	}
@@ -790,7 +790,7 @@ func TestRepoView_web_fullURL(t *testing.T) {
 	})
 	defer restoreCmd()
 
-	output, err := RunCommand(repoViewCmd, "repo view -w https://github.com/cli/cli")
+	output, err := RunCommand("repo view -w https://github.com/cli/cli")
 	if err != nil {
 		t.Errorf("error running command `repo view`: %v", err)
 	}
@@ -820,7 +820,7 @@ func TestRepoView(t *testing.T) {
 		  "content": "IyB0cnVseSBjb29sIHJlYWRtZSBjaGVjayBpdCBvdXQ="}
 	`))
 
-	output, err := RunCommand(repoViewCmd, "repo view")
+	output, err := RunCommand("repo view")
 	if err != nil {
 		t.Errorf("error running command `repo view`: %v", err)
 	}
@@ -848,7 +848,7 @@ func TestRepoView_nonmarkdown_readme(t *testing.T) {
 		  "content": "IyB0cnVseSBjb29sIHJlYWRtZSBjaGVjayBpdCBvdXQ="}
 	`))
 
-	output, err := RunCommand(repoViewCmd, "repo view")
+	output, err := RunCommand("repo view")
 	if err != nil {
 		t.Errorf("error running command `repo view`: %v", err)
 	}
@@ -867,7 +867,7 @@ func TestRepoView_blanks(t *testing.T) {
 	http.StubResponse(200, bytes.NewBufferString("{}"))
 	http.StubResponse(200, bytes.NewBufferString("{}"))
 
-	output, err := RunCommand(repoViewCmd, "repo view")
+	output, err := RunCommand("repo view")
 	if err != nil {
 		t.Errorf("error running command `repo view`: %v", err)
 	}

--- a/command/testing.go
+++ b/command/testing.go
@@ -8,13 +8,11 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
-	"github.com/google/shlex"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/internal/config"
+	"github.com/google/shlex"
+	"github.com/spf13/pflag"
 )
 
 const defaultTestConfig = `hosts:
@@ -115,13 +113,19 @@ func (c cmdOut) Stderr() string {
 	return c.errBuf.String()
 }
 
-func RunCommand(cmd *cobra.Command, args string) (*cmdOut, error) {
-	rootCmd := cmd.Root()
-	argv, err := shlex.Split(args)
+func RunCommand(args string) (*cmdOut, error) {
+	rootCmd := RootCmd
+	rootArgv, err := shlex.Split(args)
 	if err != nil {
 		return nil, err
 	}
-	rootCmd.SetArgs(argv)
+
+	cmd, _, err := rootCmd.Traverse(rootArgv)
+	if err != nil {
+		return nil, err
+	}
+
+	rootCmd.SetArgs(rootArgv)
 
 	outBuf := bytes.Buffer{}
 	cmd.SetOut(&outBuf)


### PR DESCRIPTION
In our tests we call RunCommand like this `output, err := RunCommand(issueListCmd, "issue list")`. I was running into a problem where I would call RunCommand with the wrong command! For example, instead of `RunCommand(issueListCmd, "issue list")` I would call `RunCommand(OMGWrongCmd, "issue list")`. This caused lots of problems because stderr and stdout weren't being captured in a way I could see. I was very confused.

Could I have avoided this problem I was more thorough? Yes, but as we all know humans make errors especially if their name is @probablycorey. So I propose we protect our future selves by changing the arguments to `RunCommand` to `func RunCommand(args string) (*cmdOut, error)`. We can use cobra's ability to parse raw strings to figure out which command should be run.

@mislav @vilmibm what do you think?

P.S. Moving `RunCommand` to testing.go seems to make sense too.