### PR TITLE
Add `gh pr reopen <numberOrURL>`

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -780,6 +780,25 @@ func PullRequestClose(client *Client, repo ghrepo.Interface, pr PullRequest) err
 	return err
 }
 
+func PullRequestReopen(client *Client, repo ghrepo.Interface, pr PullRequest) error {
+	var mutation struct {
+		ReopenPullRequest struct {
+			PullRequest struct {
+				ID githubv4.ID
+			}
+		} `graphql:"reopenPullRequest(input: $input)"`
+	}
+
+	input := githubv4.ReopenPullRequestInput{
+		PullRequestID: pr.ID,
+	}
+
+	v4 := githubv4.NewClient(client.http)
+	err := v4.Mutate(context.Background(), &mutation, input, nil)
+
+	return err
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/command/pr.go
+++ b/command/pr.go
@@ -392,11 +392,11 @@ func prReopen(cmd *cobra.Command, args []string) error {
 	}
 
 	if pr.State == "MERGED" {
-		fmt.Fprintf(colorableErr(cmd), "%s Pull request #%d can't be reopened because it was merged.", utils.Red("!"), pr.Number)
+		fmt.Fprintf(colorableErr(cmd), "%s Pull request #%d can't be reopened because it was already merged.\n", utils.Red("!"), pr.Number)
 		return nil
 	}
 
-	if pr.Closed == false {
+	if !pr.Closed {
 		fmt.Fprintf(colorableErr(cmd), "%s Pull request #%d is already open\n", utils.Yellow("!"), pr.Number)
 		return nil
 	}

--- a/command/pr.go
+++ b/command/pr.go
@@ -401,7 +401,7 @@ func prReopen(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("API call failed:%w", err)
 	}
 
-	fmt.Fprintf(colorableErr(cmd), "%s Reopened pull request #%d\n", utils.Red("✔"), pr.Number)
+	fmt.Fprintf(colorableErr(cmd), "%s Reopened pull request #%d\n", utils.Green("✔"), pr.Number)
 
 	return nil
 }

--- a/command/pr.go
+++ b/command/pr.go
@@ -391,6 +391,11 @@ func prReopen(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if pr.State == "MERGED" {
+		fmt.Fprintf(colorableErr(cmd), "%s Pull request #%d can't be reopened because it was merged.", utils.Red("!"), pr.Number)
+		return nil
+	}
+
 	if pr.Closed == false {
 		fmt.Fprintf(colorableErr(cmd), "%s Pull request #%d is already open\n", utils.Yellow("!"), pr.Number)
 		return nil

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -899,3 +899,28 @@ func TestPRReopen_alreadyOpen(t *testing.T) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
+
+func TestPRReopen_merged(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": {
+		"pullRequest": { "number": 666, "closed": true, "state": "MERGED"}
+	} } }
+	`))
+
+	http.StubResponse(200, bytes.NewBufferString(`{"id": "THE-ID"}`))
+
+	output, err := RunCommand(prReopenCmd, "pr reopen 666")
+	if err != nil {
+		t.Fatalf("error running command `pr reopen`: %v", err)
+	}
+
+	r := regexp.MustCompile(`Pull request #666 can't be reopened because it was merged.`)
+
+	if !r.MatchString(output.Stderr()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
+	}
+}

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -874,3 +874,28 @@ func TestPRReopen(t *testing.T) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
+
+func TestPRReopen_alreadyOpen(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": {
+		"pullRequest": { "number": 666, "closed": false}
+	} } }
+	`))
+
+	http.StubResponse(200, bytes.NewBufferString(`{"id": "THE-ID"}`))
+
+	output, err := RunCommand(prReopenCmd, "pr reopen 666")
+	if err != nil {
+		t.Fatalf("error running command `pr reopen`: %v", err)
+	}
+
+	r := regexp.MustCompile(`Pull request #666 is already open`)
+
+	if !r.MatchString(output.Stderr()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
+	}
+}

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -918,9 +918,10 @@ func TestPRReopen_alreadyMerged(t *testing.T) {
 		t.Fatalf("error running command `pr reopen`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Pull request #666 can't be reopened because it was merged.`)
+	r := regexp.MustCompile(`Pull request #666 can't be reopened because it was already merged.`)
 
 	if !r.MatchString(output.Stderr()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
+
 }

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -849,3 +849,28 @@ func TestPrClose_alreadyClosed(t *testing.T) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
+
+func TestPRReopen(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "data": { "repository": {
+		"pullRequest": { "number": 666, "closed": true}
+	} } }
+	`))
+
+	http.StubResponse(200, bytes.NewBufferString(`{"id": "THE-ID"}`))
+
+	output, err := RunCommand(prReopenCmd, "pr reopen 666")
+	if err != nil {
+		t.Fatalf("error running command `pr reopen`: %v", err)
+	}
+
+	r := regexp.MustCompile(`Reopened pull request #666`)
+
+	if !r.MatchString(output.Stderr()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
+	}
+}

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -900,7 +900,7 @@ func TestPRReopen_alreadyOpen(t *testing.T) {
 	}
 }
 
-func TestPRReopen_merged(t *testing.T) {
+func TestPRReopen_alreadyMerged(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "master")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")


### PR DESCRIPTION
Relies on #854

Here is what it looks like

<img width="657" alt="CleanShot 2020-05-01 at 14 14 21@2x" src="https://user-images.githubusercontent.com/596/80842301-17edf180-8bb6-11ea-8fe7-e918f1f2ec52.png">

This command isn't as straight forward as that though because the PR could be merged. If it is we show the message below.

<img width="815" alt="CleanShot 2020-05-01 at 14 09 20@2x" src="https://user-images.githubusercontent.com/596/80841996-651d9380-8bb5-11ea-8312-ccce40db7129.png">

Closes #413 