### PR TITLE
shorthand of clone without username

### DIFF
--- a/command/repo.go
+++ b/command/repo.go
@@ -125,16 +125,20 @@ func runClone(cloneURL string, args []string) (target string, err error) {
 }
 
 func repoClone(cmd *cobra.Command, args []string) error {
+	ctx := contextForCommand(cmd)
+	apiClient, err := apiClientForContext(ctx)
+	if err != nil {
+		return err
+	}
+
 	cloneURL := args[0]
 	if !strings.Contains(cloneURL, ":") {
 		if !strings.Contains(cloneURL, "/") {
-			ctx := contextForCommand(cmd)
-			currentUsername, err := ctx.AuthLogin()
+			currentUser, err := api.CurrentLoginName(apiClient)
 			if err != nil {
 				return err
 			}
-			fmt.Printf("currentUesrname: %s\n", currentUsername)
-			cloneURL = currentUsername + "/" + cloneURL
+			cloneURL = currentUser + "/" + cloneURL
 		}
 		cloneURL = formatRemoteURL(cmd, cloneURL)
 	}
@@ -149,12 +153,6 @@ func repoClone(cmd *cobra.Command, args []string) error {
 	}
 
 	if repo != nil {
-		ctx := contextForCommand(cmd)
-		apiClient, err := apiClientForContext(ctx)
-		if err != nil {
-			return err
-		}
-
 		parentRepo, err = api.RepoParent(apiClient, repo)
 		if err != nil {
 			return err

--- a/command/repo.go
+++ b/command/repo.go
@@ -127,6 +127,15 @@ func runClone(cloneURL string, args []string) (target string, err error) {
 func repoClone(cmd *cobra.Command, args []string) error {
 	cloneURL := args[0]
 	if !strings.Contains(cloneURL, ":") {
+		if !strings.Contains(cloneURL, "/") {
+			ctx := contextForCommand(cmd)
+			currentUsername, err := ctx.AuthLogin()
+			if err != nil {
+				return err
+			}
+			fmt.Printf("currentUesrname: %s\n", currentUsername)
+			cloneURL = currentUsername + "/" + cloneURL
+		}
 		cloneURL = formatRemoteURL(cmd, cloneURL)
 	}
 

--- a/command/repo.go
+++ b/command/repo.go
@@ -56,6 +56,8 @@ var repoCloneCmd = &cobra.Command{
 	Short: "Clone a repository locally",
 	Long: `Clone a GitHub repository locally.
 
+Without username, e.g. "gh repo clone REPO", clones a presonal repository.
+
 To pass 'git clone' flags, separate them with '--'.`,
 	RunE: repoClone,
 }

--- a/command/repo.go
+++ b/command/repo.go
@@ -56,7 +56,8 @@ var repoCloneCmd = &cobra.Command{
 	Short: "Clone a repository locally",
 	Long: `Clone a GitHub repository locally.
 
-Without username, e.g. "gh repo clone REPO", clones a presonal repository.
+If the "OWNER/" portion of the "OWNER/REPO" repository argument is omitted, it
+defaults to the name of the authenticating user.
 
 To pass 'git clone' flags, separate them with '--'.`,
 	RunE: repoClone,

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -430,6 +430,11 @@ func TestRepoClone(t *testing.T) {
 			want: "git clone https://github.com/OWNER/REPO.git",
 		},
 		{
+			name: "shorthand without username",
+			args: "repo clone REPO",
+			want: "git clone https://github.com/OWNER/REPO.git",
+		},
+		{
 			name: "shorthand with directory",
 			args: "repo clone OWNER/REPO target_directory",
 			want: "git clone https://github.com/OWNER/REPO.git target_directory",
@@ -457,6 +462,11 @@ func TestRepoClone(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.NewBlank()
+			ctx.SetAuthLogin("OWNER")
+			initContext = func() context.Context {
+				return ctx
+			}
 			http := initFakeHTTP()
 			http.StubResponse(200, bytes.NewBufferString(`
 			{ "data": { "repository": {

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -517,11 +517,12 @@ func TestRepo_withoutUsername(t *testing.T) {
 		{ "data": { "viewer": {
 			"login": "OWNER"
 		}}}`))
-	http.StubResponse(200, bytes.NewBufferString(`
-	{ "data": { "repository": {
-		"parent": null
-	} } }
-	`))
+	http.Register(
+		httpmock.GraphQL(`\brepository\(`),
+		httpmock.StringResponse(`
+		{ "data": { "repository": {
+			"parent": null
+		} } }`))
 
 	cs, restore := test.InitCmdStubber()
 	defer restore()


### PR DESCRIPTION
Resolves: #860 
Enable the shorthand of cloning private repository by omitting username.