### PR TITLE
Add command line syntax doc

### DIFF
--- a/docs/command-line-syntax.md
+++ b/docs/command-line-syntax.md
@@ -51,7 +51,7 @@ _optional argument with placeholder:_
 `command sub-command [<arg>]`
 
 _required argument with mutually exclusive options:_
-`command sub-command <{path | string}>`
+`command sub-command {<path> | <string> | literal}`
 
 _optional argument with mutually exclusive options:_
-`command sub-command [{<path> | <string>}]`
+`command sub-command [<path> | <string>]`

--- a/docs/command-line-syntax.md
+++ b/docs/command-line-syntax.md
@@ -14,7 +14,7 @@ Use angled brackets to represent a value the user must supply
 
 _*example:*_
 `gh pr view <issueNumber>`
-Replace `<issueNumber>` with an issue number
+Replace `<issue-number>` with an issue number
 
 ## Optional arguments
 

--- a/docs/command-line-syntax.md
+++ b/docs/command-line-syntax.md
@@ -1,6 +1,6 @@
 # How we document our command line syntax
 
-## Required text
+## Literal text
 
 Use plain text for parts of the command that cannot be changed
 
@@ -10,7 +10,7 @@ The argument help is required in this command
 
 ## Placeholder values
 
-Use angled brackets to represent a value the user must replace
+Use angled brackets to represent a value the user must replace. No other expressions can be contained within the angeled brackets.
 
 _example:_
 `gh pr view <issue-number>`
@@ -18,15 +18,18 @@ Replace `<issue-number>` with an issue number
 
 ## Optional arguments
 
-Place optional arguments in square brackets
+Place optional arguments in square brackets. Mutually exclusive arguments can be included inside square brackets if they are separated with vertical bars.
 
 _example:_
 `gh pr checkout [--web]`
 The argument `--web` is optional.
 
-## Mutually exclusive arguments
+`gh pr view [<number> | <url>]`
+The `<number>` and `<url>` arguments are optional.
 
-Place mutually exclusive arguments inside braces, separate arguments with vertical bars.
+## Required mutually exclusive arguments
+
+Place required mutually exclusive arguments inside braces, separate arguments with vertical bars.
 
 _example:_
 `gh pr {view | create}`

--- a/docs/command-line-syntax.md
+++ b/docs/command-line-syntax.md
@@ -1,8 +1,8 @@
 # How we document our command line syntax
 
-## Required arguments
+## Required text
 
-Use plain text
+Use plain text for any part of the command that can not be changed
 
 _*example:*_
 `gh help`
@@ -36,7 +36,7 @@ _*example:*_
 Ellipsis represent arguments that can appear multiple times
 
 _*example:*_
-`gh pr close <numbers … >`
+`gh pr close <numbers>...`
 
 ## Variable naming
 
@@ -44,3 +44,11 @@ For multi-word variables use dash-case (all lower case with words seperated by d
 
 _*example:*_
 `gh pr checkout <issue-number>`
+
+## Complex examples
+
+_*required argument with mutually exclusive optoins:*_
+`gh pr close <{number | url}>`
+
+_*optional argument with mutually exclusive optoins:*_
+`gh pr close [{<number> | <url>}]`

--- a/docs/command-line-syntax.md
+++ b/docs/command-line-syntax.md
@@ -6,11 +6,11 @@ Use plain text
 
 _*example:*_
 `gh help`
-help is a required argument in this command
+The argument help is required in this command
 
 ## Placeholder values
 
-Use Angled brackets to represent text that you must supply
+Use angled brackets to represent text that a user must supply
 
 _*example:*_
 `gh pr view <issueNumber>`
@@ -22,18 +22,18 @@ Place optional arguments in square brackets
 
 _*example:*_
 `gh pr checkout [--web]`
-Replace `--web` is an optional argument
+The argument `--web` is optional.
 
 ## Mutually exclusive arguments
 
-Place mutually exclusive arguments inside braces separated by a vertical bar.
+Place mutually exclusive arguments inside braces, separate arguments with vertical bars.
 
 _*example:*_
 `gh pr {view | create}`
 
 ## Repeatable arguements
 
-One or more arguments can replace arguments with ellipsis
+Ellipsis represent arguments that can appear multiple times
 
 _*example:*_
 `gh pr close <numbers … >`

--- a/docs/command-line-syntax.md
+++ b/docs/command-line-syntax.md
@@ -1,0 +1,39 @@
+# How we document our command line syntax
+
+## Required arguments
+
+Use plain text
+
+_*example:*_
+`gh help`
+help is a required argument in this command
+
+## Placeholder values
+
+Use Angled brackets to represent text that you must supply
+
+_*example:*_
+`gh pr view <issueNumber>`
+Replace `<issueNumber>` with an issue number
+
+## Optional arguments
+
+Place optional arguments in square brackets
+
+_*example:*_
+`gh pr checkout [--web]`
+Replace `--web` is an optional argument
+
+## Mutually exclusive arguments
+
+Place mutually exclusive arguments inside braces separated by a vertical bar.
+
+_*example:*_
+`gh pr {view | create}`
+
+## Repeatable arguements
+
+One or more arguments can replace arguments with ellipsis
+
+_*example:*_
+`gh pr close <numbers … >`

--- a/docs/command-line-syntax.md
+++ b/docs/command-line-syntax.md
@@ -37,3 +37,10 @@ Ellipsis represent arguments that can appear multiple times
 
 _*example:*_
 `gh pr close <numbers … >`
+
+## Variable naming
+
+For multi-word variables use dash-case (all lower case with words seperated by dashes)
+
+_*example:*_
+`gh pr checkout <issue-number>`

--- a/docs/command-line-syntax.md
+++ b/docs/command-line-syntax.md
@@ -10,7 +10,7 @@ The argument help is required in this command
 
 ## Placeholder values
 
-Use angled brackets to represent text that a user must supply
+Use angled brackets to represent a value the user must supply
 
 _*example:*_
 `gh pr view <issueNumber>`

--- a/docs/command-line-syntax.md
+++ b/docs/command-line-syntax.md
@@ -2,25 +2,25 @@
 
 ## Required text
 
-Use plain text for any part of the command that can not be changed
+Use plain text for parts of the command that cannot be changed
 
-_*example:*_
+_example:_
 `gh help`
 The argument help is required in this command
 
 ## Placeholder values
 
-Use angled brackets to represent a value the user must supply
+Use angled brackets to represent a value the user must replace
 
-_*example:*_
-`gh pr view <issueNumber>`
+_example:_
+`gh pr view <issue-number>`
 Replace `<issue-number>` with an issue number
 
 ## Optional arguments
 
 Place optional arguments in square brackets
 
-_*example:*_
+_example:_
 `gh pr checkout [--web]`
 The argument `--web` is optional.
 
@@ -28,27 +28,30 @@ The argument `--web` is optional.
 
 Place mutually exclusive arguments inside braces, separate arguments with vertical bars.
 
-_*example:*_
+_example:_
 `gh pr {view | create}`
 
-## Repeatable arguements
+## Repeatable arguments
 
 Ellipsis represent arguments that can appear multiple times
 
-_*example:*_
-`gh pr close <numbers>...`
+_example:_
+`gh pr close <pr-number>...`
 
 ## Variable naming
 
-For multi-word variables use dash-case (all lower case with words seperated by dashes)
+For multi-word variables use dash-case (all lower case with words separated by dashes)
 
-_*example:*_
+_example:_
 `gh pr checkout <issue-number>`
 
-## Complex examples
+## Additional examples
 
-_*required argument with mutually exclusive optoins:*_
-`gh pr close <{number | url}>`
+_optional argument with placeholder:_
+`command sub-command [<arg>]`
 
-_*optional argument with mutually exclusive optoins:*_
-`gh pr close [{<number> | <url>}]`
+_required argument with mutually exclusive options:_
+`command sub-command <{path | string}>`
+
+_optional argument with mutually exclusive options:_
+`command sub-command [{<path> | <string>}]`


### PR DESCRIPTION
Here is my first pass at some documentation for how we use this. 

**Questions:**
- We don't have good examples for some simple patterns, like mutually exclusive arguments. We have examples, but they are kind of complicated. 
- Do we want to include more examples of things like "a required flag with mutually exclusive placeholder arguments"

References:
[google](https://developers.google.com/style/code-syntax) - pretty thorough, but doesn't follow the standards we've been using
[microsoft](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/command-line-syntax-key) - very simple, but matches what we have
[ibm](https://publib.boulder.ibm.com/tividd/td/tec/SC32-1232-00/en_US/HTML/ecormst15.htm) - like microsoft's but with more examples