### PR TITLE
Add support for `gh pr merge`

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -815,7 +815,7 @@ func PullRequestSquash(client *Client, repo ghrepo.Interface, pr *PullRequest) e
 
 func merge(client *Client, repo ghrepo.Interface, pr *PullRequest, mergeMethod githubv4.PullRequestMergeMethod) error {
 	var mutation struct {
-		ReopenPullRequest struct {
+		MergePullRequest struct {
 			PullRequest struct {
 				ID githubv4.ID
 			}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -130,6 +130,14 @@ type PullRequestReviewStatus struct {
 	ReviewRequired   bool
 }
 
+type PullRequestMergeMethod int
+
+const (
+	PullRequestMergeMethodMerge PullRequestMergeMethod = iota
+	PullRequestMergeMethodRebase
+	PullRequestMergeMethodSquash
+)
+
 func (pr *PullRequest) ReviewStatus() PullRequestReviewStatus {
 	var status PullRequestReviewStatus
 	switch pr.ReviewDecision {
@@ -801,19 +809,15 @@ func PullRequestReopen(client *Client, repo ghrepo.Interface, pr *PullRequest) e
 	return err
 }
 
-func PullRequestMerge(client *Client, repo ghrepo.Interface, pr *PullRequest) error {
-	return merge(client, repo, pr, githubv4.PullRequestMergeMethodMerge)
-}
+func PullRequestMerge(client *Client, repo ghrepo.Interface, pr *PullRequest, m PullRequestMergeMethod) error {
+	mergeMethod := githubv4.PullRequestMergeMethodMerge
+	switch m {
+	case PullRequestMergeMethodRebase:
+		mergeMethod = githubv4.PullRequestMergeMethodRebase
+	case PullRequestMergeMethodSquash:
+		mergeMethod = githubv4.PullRequestMergeMethodSquash
+	}
 
-func PullRequestRebase(client *Client, repo ghrepo.Interface, pr *PullRequest) error {
-	return merge(client, repo, pr, githubv4.PullRequestMergeMethodRebase)
-}
-
-func PullRequestSquash(client *Client, repo ghrepo.Interface, pr *PullRequest) error {
-	return merge(client, repo, pr, githubv4.PullRequestMergeMethodSquash)
-}
-
-func merge(client *Client, repo ghrepo.Interface, pr *PullRequest, mergeMethod githubv4.PullRequestMergeMethod) error {
 	var mutation struct {
 		MergePullRequest struct {
 			PullRequest struct {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -446,6 +446,7 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, baseBranch, hea
 	type response struct {
 		Repository struct {
 			PullRequests struct {
+				ID    githubv4.ID
 				Nodes []PullRequest
 			}
 		}
@@ -456,6 +457,7 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, baseBranch, hea
 		repository(owner: $owner, name: $repo) {
 			pullRequests(headRefName: $headRefName, states: OPEN, first: 30) {
 				nodes {
+					id
 					number
 					title
 					state

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -800,6 +800,18 @@ func PullRequestReopen(client *Client, repo ghrepo.Interface, pr *PullRequest) e
 }
 
 func PullRequestMerge(client *Client, repo ghrepo.Interface, pr *PullRequest) error {
+	return merge(client, repo, pr, githubv4.PullRequestMergeMethodMerge)
+}
+
+func PullRequestRebase(client *Client, repo ghrepo.Interface, pr *PullRequest) error {
+	return merge(client, repo, pr, githubv4.PullRequestMergeMethodRebase)
+}
+
+func PullRequestSquash(client *Client, repo ghrepo.Interface, pr *PullRequest) error {
+	return merge(client, repo, pr, githubv4.PullRequestMergeMethodSquash)
+}
+
+func merge(client *Client, repo ghrepo.Interface, pr *PullRequest, mergeMethod githubv4.PullRequestMergeMethod) error {
 	var mutation struct {
 		ReopenPullRequest struct {
 			PullRequest struct {
@@ -810,6 +822,7 @@ func PullRequestMerge(client *Client, repo ghrepo.Interface, pr *PullRequest) er
 
 	input := githubv4.MergePullRequestInput{
 		PullRequestID: pr.ID,
+		MergeMethod:   &mergeMethod,
 	}
 
 	v4 := githubv4.NewClient(client.http)

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -799,6 +799,25 @@ func PullRequestReopen(client *Client, repo ghrepo.Interface, pr *PullRequest) e
 	return err
 }
 
+func PullRequestMerge(client *Client, repo ghrepo.Interface, pr *PullRequest) error {
+	var mutation struct {
+		ReopenPullRequest struct {
+			PullRequest struct {
+				ID githubv4.ID
+			}
+		} `graphql:"mergePullRequest(input: $input)"`
+	}
+
+	input := githubv4.MergePullRequestInput{
+		PullRequestID: pr.ID,
+	}
+
+	v4 := githubv4.NewClient(client.http)
+	err := v4.Mutate(context.Background(), &mutation, input, nil)
+
+	return err
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/command/pr.go
+++ b/command/pr.go
@@ -482,7 +482,7 @@ func prMerge(cmd *cobra.Command, args []string) error {
 
 	var output string
 	if rebase {
-		output = fmt.Sprintf("%s Rebased pull request #%d\n", utils.Green("✔"), pr.Number)
+		output = fmt.Sprintf("%s Rebased and merged pull request #%d\n", utils.Green("✔"), pr.Number)
 		err = api.PullRequestRebase(apiClient, baseRepo, pr)
 	} else if squash {
 		output = fmt.Sprintf("%s Squashed and merged pull request #%d\n", utils.Green("✔"), pr.Number)

--- a/command/pr.go
+++ b/command/pr.go
@@ -61,7 +61,7 @@ var prStatusCmd = &cobra.Command{
 	RunE:  prStatus,
 }
 var prViewCmd = &cobra.Command{
-	Use:   "view [{<number> | <url> | <branch>}]",
+	Use:   "view [<number> | <url> | <branch>]",
 	Short: "View a pull request",
 	Long: `Display the title, body, and other information about a pull request.
 
@@ -72,20 +72,20 @@ With '--web', open the pull request in a web browser instead.`,
 	RunE: prView,
 }
 var prCloseCmd = &cobra.Command{
-	Use:   "close <number | url>",
+	Use:   "close {<number> | <url> | <branch>}",
 	Short: "Close a pull request",
 	Args:  cobra.ExactArgs(1),
 	RunE:  prClose,
 }
 var prReopenCmd = &cobra.Command{
-	Use:   "reopen <number | url>",
+	Use:   "reopen {<number> | <url> | <branch>}",
 	Short: "Reopen a pull request",
 	Args:  cobra.ExactArgs(1),
 	RunE:  prReopen,
 }
 
 var prMergeCmd = &cobra.Command{
-	Use:   "merge [{<number> | <url>}] [<flags>]",
+	Use:   "merge [<number> | <url> | <branch>]",
 	Short: "Merge a pull request",
 	Args:  cobra.MaximumNArgs(1),
 	RunE:  prMerge,

--- a/command/pr.go
+++ b/command/pr.go
@@ -61,7 +61,7 @@ var prStatusCmd = &cobra.Command{
 	RunE:  prStatus,
 }
 var prViewCmd = &cobra.Command{
-	Use:   "view <{<number> | <url> | <branch>}>",
+	Use:   "view [{<number> | <url> | <branch>}]",
 	Short: "View a pull request",
 	Long: `Display the title, body, and other information about a pull request.
 

--- a/command/pr.go
+++ b/command/pr.go
@@ -492,7 +492,7 @@ func prMerge(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("API call failed: %w", err)
 	}
 
-	fmt.Fprintf(colorableErr(cmd), output)
+	fmt.Fprint(colorableErr(cmd), output)
 
 	return nil
 }

--- a/command/pr.go
+++ b/command/pr.go
@@ -483,13 +483,13 @@ func prMerge(cmd *cobra.Command, args []string) error {
 	var output string
 	if rebase {
 		output = fmt.Sprintf("%s Rebased and merged pull request #%d\n", utils.Green("✔"), pr.Number)
-		err = api.PullRequestRebase(apiClient, baseRepo, pr)
+		err = api.PullRequestMerge(apiClient, baseRepo, pr, api.PullRequestMergeMethodRebase)
 	} else if squash {
 		output = fmt.Sprintf("%s Squashed and merged pull request #%d\n", utils.Green("✔"), pr.Number)
-		err = api.PullRequestSquash(apiClient, baseRepo, pr)
+		err = api.PullRequestMerge(apiClient, baseRepo, pr, api.PullRequestMergeMethodSquash)
 	} else {
 		output = fmt.Sprintf("%s Merged pull request #%d\n", utils.Green("✔"), pr.Number)
-		err = api.PullRequestMerge(apiClient, baseRepo, pr)
+		err = api.PullRequestMerge(apiClient, baseRepo, pr, api.PullRequestMergeMethodMerge)
 	}
 
 	if err != nil {

--- a/command/pr.go
+++ b/command/pr.go
@@ -85,7 +85,7 @@ var prReopenCmd = &cobra.Command{
 }
 
 var prMergeCmd = &cobra.Command{
-	Use:   "merge [number | url] [--rebase | --merge | --squash]",
+	Use:   "merge [{<number> | <url>}] [<flags>]",
 	Short: "Merge a pull request",
 	Args:  cobra.MaximumNArgs(1),
 	RunE:  prMerge,

--- a/command/pr.go
+++ b/command/pr.go
@@ -450,7 +450,7 @@ func prMerge(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = api.PullRequestClose(apiClient, baseRepo, pr)
+	err = api.PullRequestMerge(apiClient, baseRepo, pr)
 	if err != nil {
 		return fmt.Errorf("API call failed: %w", err)
 	}

--- a/command/pr.go
+++ b/command/pr.go
@@ -496,7 +496,7 @@ func prMerge(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("API call failed: %w", err)
 	}
 
-	fmt.Fprint(colorableErr(cmd), output)
+	fmt.Fprint(colorableOut(cmd), output)
 
 	return nil
 }

--- a/command/pr.go
+++ b/command/pr.go
@@ -25,7 +25,7 @@ func init() {
 	prCmd.AddCommand(prCloseCmd)
 	prCmd.AddCommand(prReopenCmd)
 	prCmd.AddCommand(prMergeCmd)
-	prMergeCmd.Flags().BoolP("merge", "m", true, "merge the commits with the base branch")
+	prMergeCmd.Flags().BoolP("merge", "m", true, "Merge the commits with the base branch")
 	prMergeCmd.Flags().BoolP("rebase", "r", false, "Rebase the commits onto the base branch")
 	prMergeCmd.Flags().BoolP("squash", "s", false, "Squash the commits into one commit and merge it into the base branch")
 

--- a/command/pr.go
+++ b/command/pr.go
@@ -451,12 +451,16 @@ func prMerge(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		_, branchWithOwner, err := prSelectorForCurrentBranch(ctx, baseRepo)
+		prNumber, branchWithOwner, err := prSelectorForCurrentBranch(ctx, baseRepo)
 		if err != nil {
 			return err
 		}
 
-		pr, err = api.PullRequestForBranch(apiClient, baseRepo, "", branchWithOwner)
+		if prNumber != 0 {
+			pr, err = api.PullRequestByNumber(apiClient, baseRepo, prNumber)
+		} else {
+			pr, err = api.PullRequestForBranch(apiClient, baseRepo, "", branchWithOwner)
+		}
 		if err != nil {
 			return err
 		}

--- a/command/pr.go
+++ b/command/pr.go
@@ -457,7 +457,6 @@ func prMerge(cmd *cobra.Command, args []string) error {
 		}
 
 		pr, err = api.PullRequestForBranch(apiClient, baseRepo, "", branchWithOwner)
-		fmt.Printf("🌭 %+v\n", pr)
 		if err != nil {
 			return err
 		}

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -971,7 +971,7 @@ func TestPrMerge(t *testing.T) {
 
 	r := regexp.MustCompile(`Merged pull request #1`)
 
-	if !r.MatchString(output.Stderr()) {
+	if !r.MatchString(output.String()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
@@ -997,7 +997,7 @@ func TestPrMerge_noPrNumberGiven(t *testing.T) {
 
 	r := regexp.MustCompile(`Merged pull request #10`)
 
-	if !r.MatchString(output.Stderr()) {
+	if !r.MatchString(output.String()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
@@ -1015,9 +1015,9 @@ func TestPrMerge_rebase(t *testing.T) {
 		t.Fatalf("error running command `pr merge`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Rebased pull request #2`)
+	r := regexp.MustCompile(`Rebased and merged pull request #2`)
 
-	if !r.MatchString(output.Stderr()) {
+	if !r.MatchString(output.String()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
@@ -1037,7 +1037,7 @@ func TestPrMerge_squash(t *testing.T) {
 
 	r := regexp.MustCompile(`Squashed and merged pull request #3`)
 
-	if !r.MatchString(output.Stderr()) {
+	if !r.MatchString(output.String()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -976,6 +976,26 @@ func TestPrMerge(t *testing.T) {
 	}
 }
 
+func TestPrMerge_noPrNumberGiven(t *testing.T) {
+	initWithStubs(
+		stubResponse{200, bytes.NewBufferString(`{ "data": { "repository": {
+			"pullRequest": { "number": 100, "closed": false, "state": "OPEN"}
+		} } }`)},
+		stubResponse{200, bytes.NewBufferString(`{"id": "THE-ID"}`)},
+	)
+
+	output, err := RunCommand("pr merge")
+	if err != nil {
+		t.Fatalf("error running command `pr merge`: %v", err)
+	}
+
+	r := regexp.MustCompile(`Merged pull request #100`)
+
+	if !r.MatchString(output.Stderr()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
+	}
+}
+
 func TestPrMerge_rebase(t *testing.T) {
 	initWithStubs(
 		stubResponse{200, bytes.NewBufferString(`{ "data": { "repository": {

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -975,3 +975,43 @@ func TestPrMerge(t *testing.T) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
+
+func TestPrMerge_rebase(t *testing.T) {
+	initWithStubs(
+		stubResponse{200, bytes.NewBufferString(`{ "data": { "repository": {
+			"pullRequest": { "number": 2, "closed": false, "state": "OPEN"}
+		} } }`)},
+		stubResponse{200, bytes.NewBufferString(`{"id": "THE-ID"}`)},
+	)
+
+	output, err := RunCommand("pr merge 2 --rebase")
+	if err != nil {
+		t.Fatalf("error running command `pr merge`: %v", err)
+	}
+
+	r := regexp.MustCompile(`Rebased pull request #2`)
+
+	if !r.MatchString(output.Stderr()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
+	}
+}
+
+func TestPrMerge_squash(t *testing.T) {
+	initWithStubs(
+		stubResponse{200, bytes.NewBufferString(`{ "data": { "repository": {
+			"pullRequest": { "number": 3, "closed": false, "state": "OPEN"}
+		} } }`)},
+		stubResponse{200, bytes.NewBufferString(`{"id": "THE-ID"}`)},
+	)
+
+	output, err := RunCommand("pr merge 3 --squash")
+	if err != nil {
+		t.Fatalf("error running command `pr merge`: %v", err)
+	}
+
+	r := regexp.MustCompile(`Squashed and merged pull request #3`)
+
+	if !r.MatchString(output.Stderr()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
+	}
+}

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -1015,3 +1015,23 @@ func TestPrMerge_squash(t *testing.T) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
+
+func TestPrMerge_alreadyMerged(t *testing.T) {
+	initWithStubs(
+		stubResponse{200, bytes.NewBufferString(`{ "data": { "repository": {
+			"pullRequest": { "number": 4, "closed": true, "state": "MERGED"}
+		} } }`)},
+		stubResponse{200, bytes.NewBufferString(`{"id": "THE-ID"}`)},
+	)
+
+	output, err := RunCommand("pr merge 4")
+	if err == nil {
+		t.Fatalf("expected an error running command `pr merge`: %v", err)
+	}
+
+	r := regexp.MustCompile(`Pull request #4 was already merged`)
+
+	if !r.MatchString(err.Error()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
+	}
+}


### PR DESCRIPTION
This adds the `gh pr merge` command and it works like this.

`gh pr merge` merges the current PR
`gh pr merge 54` merges PR #54 

It has three mutually exclusive flags `--rebase`, `--merge`, and `--squash`. The default flag is `--merge`

Here is what it looks like:

<img width="599" alt="CleanShot 2020-05-06 at 11 24 03@2x" src="https://user-images.githubusercontent.com/596/81214058-20667380-8f8c-11ea-925c-e59227807499.png">
<img width="597" alt="CleanShot 2020-05-06 at 11 24 21@2x" src="https://user-images.githubusercontent.com/596/81214082-28beae80-8f8c-11ea-9c83-715d932bf8f8.png">

**What will be in follow up PRs**

1. Making `gh pr merge [number | url]` interactive if there are no flags
2. Investigate how much work it is to follow the merge rules setup for a branch

Part 1 of closing #373 