### PR TITLE
non-interactive gh pr review

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -470,6 +470,7 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, baseBranch, hea
 		repository(owner: $owner, name: $repo) {
 			pullRequests(headRefName: $headRefName, states: OPEN, first: 30) {
 				nodes {
+					id
 					number
 					title
 					state

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -53,7 +53,7 @@ func processReviewOpt(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 	}
 
 	if found != 1 {
-		return nil, errors.New("need exactly one of approve, request-changes, or comment")
+		return nil, errors.New("need exactly one of --approve, --request-changes, or --comment")
 	}
 
 	val, err := cmd.Flags().GetString(flag)

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -1,0 +1,128 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cli/cli/api"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	prCmd.AddCommand(prReviewCmd)
+
+	prReviewCmd.Flags().StringP("approve", "a", "", "Approve pull request")
+	prReviewCmd.Flags().StringP("request-changes", "r", "", "Request changes on a pull request")
+	prReviewCmd.Flags().StringP("comment", "c", "", "Comment on a pull request")
+
+	// this is required; without it pflag complains that you must pass a string to string flags.
+	prReviewCmd.Flags().Lookup("approve").NoOptDefVal = " "
+	prReviewCmd.Flags().Lookup("request-changes").NoOptDefVal = " "
+	prReviewCmd.Flags().Lookup("comment").NoOptDefVal = " "
+}
+
+var prReviewCmd = &cobra.Command{
+	Use:   "review",
+	Short: "TODO",
+	Args:  cobra.MaximumNArgs(1),
+	Long:  "TODO",
+	RunE:  prReview,
+}
+
+func processReviewOpt(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
+	found := 0
+	flag := ""
+	var state api.PullRequestReviewState
+
+	if cmd.Flags().Changed("approve") {
+		found++
+		flag = "approve"
+		state = api.ReviewApprove
+	}
+	if cmd.Flags().Changed("request-changes") {
+		found++
+		flag = "request-changes"
+		state = api.ReviewRequestChanges
+	}
+	if cmd.Flags().Changed("comment") {
+		found++
+		flag = "comment"
+		state = api.ReviewComment
+	}
+
+	if found != 1 {
+		return nil, errors.New("need exactly one of approve, request-changes, or comment")
+	}
+
+	val, err := cmd.Flags().GetString(flag)
+	if err != nil {
+		return nil, err
+	}
+
+	body := ""
+	if val != " " {
+		body = val
+	}
+
+	if flag == "comment" && (body == " " || len(body) == 0) {
+		return nil, errors.New("cannot leave blank comment")
+	}
+
+	return &api.PullRequestReviewInput{
+		Body:  body,
+		State: state,
+	}, nil
+}
+
+func prReview(cmd *cobra.Command, args []string) error {
+	ctx := contextForCommand(cmd)
+	baseRepo, err := determineBaseRepo(cmd, ctx)
+	if err != nil {
+		return fmt.Errorf("could not determine base repo: %w", err)
+	}
+
+	apiClient, err := apiClientForContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	var prNum int
+
+	if len(args) == 0 {
+		prNum, _, err = prSelectorForCurrentBranch(ctx, baseRepo)
+		if err != nil {
+			return fmt.Errorf("could not query for pull request for current branch: %w", err)
+		}
+	} else {
+		prArg, repo := prFromURL(args[0])
+		if repo != nil {
+			baseRepo = repo
+			// TODO handle malformed URL; it falls through to Atoi
+		} else {
+			prArg = strings.TrimPrefix(args[0], "#")
+		}
+		prNum, err = strconv.Atoi(prArg)
+		if err != nil {
+			return fmt.Errorf("could not parse pull request number: %w", err)
+		}
+	}
+
+	input, err := processReviewOpt(cmd)
+	if err != nil {
+		return fmt.Errorf("did not understand desired review action: %w", err)
+	}
+
+	pr, err := api.PullRequestByNumber(apiClient, baseRepo, prNum)
+	if err != nil {
+		return fmt.Errorf("could not find pull request: %w", err)
+	}
+
+	err = api.AddReview(apiClient, pr, input)
+	if err != nil {
+		return fmt.Errorf("failed to create review: %w", err)
+	}
+
+	return nil
+}

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -89,9 +89,10 @@ func prReview(cmd *cobra.Command, args []string) error {
 	}
 
 	var prNum int
+	branchWithOwner := ""
 
 	if len(args) == 0 {
-		prNum, _, err = prSelectorForCurrentBranch(ctx, baseRepo)
+		prNum, branchWithOwner, err = prSelectorForCurrentBranch(ctx, baseRepo)
 		if err != nil {
 			return fmt.Errorf("could not query for pull request for current branch: %w", err)
 		}
@@ -114,9 +115,17 @@ func prReview(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("did not understand desired review action: %w", err)
 	}
 
-	pr, err := api.PullRequestByNumber(apiClient, baseRepo, prNum)
-	if err != nil {
-		return fmt.Errorf("could not find pull request: %w", err)
+	var pr *api.PullRequest
+	if prNum > 0 {
+		pr, err = api.PullRequestByNumber(apiClient, baseRepo, prNum)
+		if err != nil {
+			return fmt.Errorf("could not find pull request: %w", err)
+		}
+	} else {
+		pr, err = api.PullRequestForBranch(apiClient, baseRepo, "", branchWithOwner)
+		if err != nil {
+			return fmt.Errorf("could not find pull request: %w", err)
+		}
 	}
 
 	err = api.AddReview(apiClient, pr, input)

--- a/command/pr_review_test.go
+++ b/command/pr_review_test.go
@@ -1,0 +1,224 @@
+package command
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+)
+
+func TestPRReview_validation(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "master")
+	http := initFakeHTTP()
+	for _, cmd := range []string{
+		`pr review 123`,
+		`pr review --approve --comment 123`,
+		`pr review --approve="cool" --comment="rad" 123`,
+	} {
+		http.StubRepoResponse("OWNER", "REPO")
+		_, err := RunCommand(cmd)
+		eq(t, err.Error(), "did not understand desired review action: need exactly one of approve, request-changes, or comment")
+	}
+}
+
+func TestPRReview_url_arg(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repository": { "pullRequest": {
+			"id": "foobar123",
+			"number": 123,
+			"headRefName": "feature",
+			"headRepositoryOwner": {
+				"login": "hubot"
+			},
+			"headRepository": {
+				"name": "REPO",
+				"defaultBranchRef": {
+					"name": "master"
+				}
+			},
+			"isCrossRepository": false,
+			"maintainerCanModify": false
+		} } } } `))
+	http.StubResponse(200, bytes.NewBufferString(`{"data": {} }`))
+
+	_, err := RunCommand("pr review --approve https://github.com/OWNER/REPO/pull/123")
+	if err != nil {
+		t.Fatalf("error running pr review: %s", err)
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[2].Body)
+	reqBody := struct {
+		Variables struct {
+			Input struct {
+				PullRequestID string
+				Event         string
+				Body          string
+			}
+		}
+	}{}
+	_ = json.Unmarshal(bodyBytes, &reqBody)
+
+	eq(t, reqBody.Variables.Input.PullRequestID, "foobar123")
+	eq(t, reqBody.Variables.Input.Event, "APPROVE")
+	eq(t, reqBody.Variables.Input.Body, "")
+}
+
+func TestPRReview_number_arg(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repository": { "pullRequest": {
+			"id": "foobar123",
+			"number": 123,
+			"headRefName": "feature",
+			"headRepositoryOwner": {
+				"login": "hubot"
+			},
+			"headRepository": {
+				"name": "REPO",
+				"defaultBranchRef": {
+					"name": "master"
+				}
+			},
+			"isCrossRepository": false,
+			"maintainerCanModify": false
+		} } } } `))
+	http.StubResponse(200, bytes.NewBufferString(`{"data": {} }`))
+
+	_, err := RunCommand("pr review --request-changes 123")
+	if err != nil {
+		t.Fatalf("error running pr review: %s", err)
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[2].Body)
+	reqBody := struct {
+		Variables struct {
+			Input struct {
+				PullRequestID string
+				Event         string
+				Body          string
+			}
+		}
+	}{}
+	_ = json.Unmarshal(bodyBytes, &reqBody)
+
+	eq(t, reqBody.Variables.Input.PullRequestID, "foobar123")
+	eq(t, reqBody.Variables.Input.Event, "REQUEST_CHANGES")
+	eq(t, reqBody.Variables.Input.Body, "")
+}
+
+func TestPRReview_no_arg(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repository": { "pullRequest": {
+			"id": "foobar123",
+			"number": 123,
+			"headRefName": "feature",
+			"headRepositoryOwner": {
+				"login": "hubot"
+			},
+			"headRepository": {
+				"name": "REPO",
+				"defaultBranchRef": {
+					"name": "master"
+				}
+			},
+			"isCrossRepository": false,
+			"maintainerCanModify": false
+		} } } } `))
+	http.StubResponse(200, bytes.NewBufferString(`{"data": {} }`))
+
+	_, err := RunCommand(`pr review --comment="cool story"`)
+	if err != nil {
+		t.Fatalf("error running pr review: %s", err)
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[2].Body)
+	reqBody := struct {
+		Variables struct {
+			Input struct {
+				PullRequestID string
+				Event         string
+				Body          string
+			}
+		}
+	}{}
+	_ = json.Unmarshal(bodyBytes, &reqBody)
+
+	eq(t, reqBody.Variables.Input.PullRequestID, "foobar123")
+	eq(t, reqBody.Variables.Input.Event, "COMMENT")
+	eq(t, reqBody.Variables.Input.Body, "cool story")
+}
+
+func TestPRReview_blank_comment(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "master")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+
+	_, err := RunCommand(`pr review --comment 123`)
+	eq(t, err.Error(), "did not understand desired review action: cannot leave blank comment")
+}
+
+func TestPRReview(t *testing.T) {
+	type c struct {
+		Cmd           string
+		ExpectedEvent string
+		ExpectedBody  string
+	}
+	cases := []c{
+		c{`pr review --request-changes="bad"`, "REQUEST_CHANGES", "bad"},
+		c{`pr review --request-changes`, "REQUEST_CHANGES", ""},
+		c{`pr review --approve`, "APPROVE", ""},
+		c{`pr review --approve="hot damn"`, "APPROVE", "hot damn"},
+		c{`pr review --comment="i donno"`, "COMMENT", "i donno"},
+	}
+
+	for _, kase := range cases {
+		initBlankContext("", "OWNER/REPO", "master")
+		http := initFakeHTTP()
+		http.StubRepoResponse("OWNER", "REPO")
+		http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repository": { "pullRequest": {
+			"id": "foobar123",
+			"number": 123,
+			"headRefName": "feature",
+			"headRepositoryOwner": {
+				"login": "hubot"
+			},
+			"headRepository": {
+				"name": "REPO",
+				"defaultBranchRef": {
+					"name": "master"
+				}
+			},
+			"isCrossRepository": false,
+			"maintainerCanModify": false
+		} } } } `))
+		http.StubResponse(200, bytes.NewBufferString(`{"data": {} }`))
+
+		_, err := RunCommand(kase.Cmd)
+		if err != nil {
+			t.Fatalf("got unexpected error running %s: %s", kase.Cmd, err)
+		}
+
+		bodyBytes, _ := ioutil.ReadAll(http.Requests[2].Body)
+		reqBody := struct {
+			Variables struct {
+				Input struct {
+					Event string
+					Body  string
+				}
+			}
+		}{}
+		_ = json.Unmarshal(bodyBytes, &reqBody)
+
+		eq(t, reqBody.Variables.Input.Event, kase.ExpectedEvent)
+		eq(t, reqBody.Variables.Input.Body, kase.ExpectedBody)
+	}
+}

--- a/command/pr_review_test.go
+++ b/command/pr_review_test.go
@@ -17,7 +17,7 @@ func TestPRReview_validation(t *testing.T) {
 	} {
 		http.StubRepoResponse("OWNER", "REPO")
 		_, err := RunCommand(cmd)
-		eq(t, err.Error(), "did not understand desired review action: need exactly one of approve, request-changes, or comment")
+		eq(t, err.Error(), "did not understand desired review action: need exactly one of --approve, --request-changes, or --comment")
 	}
 }
 

--- a/command/pr_review_test.go
+++ b/command/pr_review_test.go
@@ -112,26 +112,17 @@ func TestPRReview_number_arg(t *testing.T) {
 }
 
 func TestPRReview_no_arg(t *testing.T) {
-	initBlankContext("", "OWNER/REPO", "master")
+	initBlankContext("", "OWNER/REPO", "feature")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repository": { "pullRequest": {
-			"id": "foobar123",
-			"number": 123,
-			"headRefName": "feature",
-			"headRepositoryOwner": {
-				"login": "hubot"
-			},
-			"headRepository": {
-				"name": "REPO",
-				"defaultBranchRef": {
-					"name": "master"
-				}
-			},
-			"isCrossRepository": false,
-			"maintainerCanModify": false
-		} } } } `))
+		{ "data": { "repository": { "pullRequests": { "nodes": [
+			{ "url": "https://github.com/OWNER/REPO/pull/123",
+			  "id": "foobar123",
+			  "headRefName": "feature",
+				"baseRefName": "master" }
+		] } } } }
+	`))
 	http.StubResponse(200, bytes.NewBufferString(`{"data": {} }`))
 
 	_, err := RunCommand(`pr review --comment="cool story"`)
@@ -180,26 +171,17 @@ func TestPRReview(t *testing.T) {
 	}
 
 	for _, kase := range cases {
-		initBlankContext("", "OWNER/REPO", "master")
+		initBlankContext("", "OWNER/REPO", "feature")
 		http := initFakeHTTP()
 		http.StubRepoResponse("OWNER", "REPO")
 		http.StubResponse(200, bytes.NewBufferString(`
-		{ "data": { "repository": { "pullRequest": {
-			"id": "foobar123",
-			"number": 123,
-			"headRefName": "feature",
-			"headRepositoryOwner": {
-				"login": "hubot"
-			},
-			"headRepository": {
-				"name": "REPO",
-				"defaultBranchRef": {
-					"name": "master"
-				}
-			},
-			"isCrossRepository": false,
-			"maintainerCanModify": false
-		} } } } `))
+		{ "data": { "repository": { "pullRequests": { "nodes": [
+			{ "url": "https://github.com/OWNER/REPO/pull/123",
+			  "id": "foobar123",
+			  "headRefName": "feature",
+				"baseRefName": "master" }
+		] } } } }
+	`))
 		http.StubResponse(200, bytes.NewBufferString(`{"data": {} }`))
 
 		_, err := RunCommand(kase.Cmd)

--- a/command/testing.go
+++ b/command/testing.go
@@ -135,6 +135,7 @@ func RunCommand(args string) (*cmdOut, error) {
 	// Reset flag values so they don't leak between tests
 	// FIXME: change how we initialize Cobra commands to render this hack unnecessary
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		f.Changed = false
 		switch v := f.Value.(type) {
 		case pflag.SliceValue:
 			_ = v.Replace([]string{})


### PR DESCRIPTION
This PR implements part of the lightweight reviewing (scenario B) designed here: https://docs.google.com/document/d/1lk4C5nqNWuOHxy0CDQKLbbrl6GRm4Y3f3FU4xTXgdhI/edit specifically with using boolean flags + a `--body` string flag

For now it's just the non-interactive component; given that this PR was getting a little long I'm doing the survey case in a follow-up.

examples:

```
gh pr review -a                               # mark the current branch's pull request as approved
gh pr review -c -b "interesting"              # comment on the current branch's pull request
gh pr review 123 -r -b"needs more ascii art"  # request changes on pull request 123
```

Related to #434 
