### PR TITLE
Fix parsing some issue template names

### DIFF
--- a/pkg/githubtemplate/github_template.go
+++ b/pkg/githubtemplate/github_template.go
@@ -66,11 +66,12 @@ mainLoop:
 // ExtractName returns the name of the template from YAML front-matter
 func ExtractName(filePath string) string {
 	contents, err := ioutil.ReadFile(filePath)
-	if err == nil && detectFrontmatter(contents)[0] == 0 {
+	frontmatterBoundaries := detectFrontmatter(contents)
+	if err == nil && frontmatterBoundaries[0] == 0 {
 		templateData := struct {
 			Name string
 		}{}
-		if err := yaml.Unmarshal(contents, &templateData); err == nil && templateData.Name != "" {
+		if err := yaml.Unmarshal(contents[0:frontmatterBoundaries[1]], &templateData); err == nil && templateData.Name != "" {
 			return templateData.Name
 		}
 	}

--- a/pkg/githubtemplate/github_template_test.go
+++ b/pkg/githubtemplate/github_template_test.go
@@ -148,9 +148,7 @@ name: Bug Report
 about: This is how you report bugs
 ---
 
-Template contents
----
-More of template
+**Template contents**
 `,
 			args: args{
 				filePath: tmpfile.Name(),


### PR DESCRIPTION
YAML parsing sometimes gets sabotaged by asterisks that follow the end of frontmatter (`---`). We now scope YAML parsing to only frontmatter and we don't pass any contents that follow.

Fixes #832