### PR TITLE
Upgrade to Go 1.14 in CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Please avoid:
 ## Building the project
 
 Prerequisites:
-- Go 1.13
+- Go 1.14
 
 Build with: `make` or `go build -o bin/gh ./cmd/gh`
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go 1.14
         uses: actions/setup-go@v2-beta
         with:
-          go-version: 1.13
+          go-version: 1.14
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           go mod verify
           go mod download
 
-          LINT_VERSION=1.24.0
+          LINT_VERSION=1.26.0
           curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v${LINT_VERSION}/golangci-lint-${LINT_VERSION}-linux-amd64.tar.gz | \
             tar xz --strip-components 1 --wildcards \*/golangci-lint
           mkdir -p bin && mv golangci-lint bin/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go 1.14
         uses: actions/setup-go@v2-beta
         with:
-          go-version: 1.13
+          go-version: 1.14
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Go 1.13
+      - name: Set up Go 1.14
         uses: actions/setup-go@v2-beta
         with:
-          go-version: 1.13
+          go-version: 1.14
       - name: Generate changelog
         run: |
           echo ::set-env name=GORELEASER_CURRENT_TAG::${GITHUB_REF#refs/tags/}

--- a/docs/source.md
+++ b/docs/source.md
@@ -1,9 +1,9 @@
 # Installation from source
 
-0. Verify that you have Go 1.13+ installed
+0. Verify that you have Go 1.14+ installed
 ```
 $ go version
-go version go1.13.7
+go version go1.14
 ```
 
 1. Clone cli into `~/.githubcli`


### PR DESCRIPTION
This ensures that we're testing against and compiling binaries for releases using the newest version of Go.

Ref. https://github.com/cli/cli/issues/514