### PR TITLE
add description default private for repo create

### DIFF
--- a/command/repo.go
+++ b/command/repo.go
@@ -28,7 +28,7 @@ func init() {
 	repoCreateCmd.Flags().StringP("team", "t", "", "The name of the organization team to be granted access")
 	repoCreateCmd.Flags().Bool("enable-issues", true, "Enable issues in the new repository")
 	repoCreateCmd.Flags().Bool("enable-wiki", true, "Enable wiki in the new repository")
-	repoCreateCmd.Flags().Bool("public", false, "Make the new repository public")
+	repoCreateCmd.Flags().Bool("public", false, "Make the new repository public (default: private)")
 
 	repoCmd.AddCommand(repoForkCmd)
 	repoForkCmd.Flags().String("clone", "prompt", "Clone fork: {true|false|prompt}")


### PR DESCRIPTION
I suggest using simple information on help command like (default: private) that it can be clean for users to understand that the repository will be created as private.

Fixes #890 