### PR TITLE
tyop fix + stricter switch

### DIFF
--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -194,13 +194,17 @@ func reviewSurvey(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 		return nil, err
 	}
 
-	reviewState := api.ReviewComment
+	var reviewState api.PullRequestReviewState
 
 	switch typeAnswers.ReviewType {
 	case "Approve":
 		reviewState = api.ReviewApprove
-	case "Request Changes":
+	case "Request changes":
 		reviewState = api.ReviewRequestChanges
+	case "Comment":
+		reviewState = api.ReviewComment
+	default:
+		panic("unreachable state")
 	}
 
 	bodyAnswers := struct {

--- a/command/pr_review_test.go
+++ b/command/pr_review_test.go
@@ -315,7 +315,7 @@ func TestPRReview_interactive_no_body(t *testing.T) {
 	as.Stub([]*QuestionStub{
 		{
 			Name:  "reviewType",
-			Value: "Request Changes",
+			Value: "Request changes",
 		},
 	})
 	as.Stub([]*QuestionStub{


### PR DESCRIPTION
this pr fixed a small but irritating bug in the `pr review` code. it was in the blindspot for tests
and magnified by my lax switch statement.
