### PR TITLE
Faster resolve assignees, reviewers, labels on create via flags

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -580,6 +580,106 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 	return &result, err
 }
 
+type RepoResolveInput struct {
+	Assignees  []string
+	Reviewers  []string
+	Labels     []string
+	Projects   []string
+	Milestones []string
+}
+
+// RepoResolveMetadataIDs looks up GraphQL node IDs in bulk
+func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoResolveInput) (*RepoMetadataResult, error) {
+	users := input.Assignees
+	hasUser := func(target string) bool {
+		for _, u := range users {
+			if strings.EqualFold(u, target) {
+				return true
+			}
+		}
+		return false
+	}
+
+	var teams []string
+	for _, r := range input.Reviewers {
+		if i := strings.IndexRune(r, '/'); i > -1 {
+			teams = append(teams, r[i+1:])
+		} else if !hasUser(r) {
+			users = append(users, r)
+		}
+	}
+
+	// there is no way to look up projects nor milestones by name, so preload them all
+	mi := RepoMetadataInput{
+		Projects:   len(input.Projects) > 0,
+		Milestones: len(input.Milestones) > 0,
+	}
+	result, err := RepoMetadata(client, repo, mi)
+	if err != nil {
+		return result, err
+	}
+	if len(users) == 0 && len(teams) == 0 && len(input.Labels) == 0 {
+		return result, nil
+	}
+
+	query := &bytes.Buffer{}
+	for i, u := range users {
+		fmt.Fprintf(query, "u%03d: user(login:%q){id,login}\n", i, u)
+	}
+	if len(input.Labels) > 0 {
+		fmt.Fprintf(query, "repository(owner:%q,name:%q){\n", repo.RepoOwner(), repo.RepoName())
+		for i, l := range input.Labels {
+			fmt.Fprintf(query, "l%03d: label(name:%q){id,name}\n", i, l)
+		}
+		fmt.Fprint(query, "}\n")
+	}
+	if len(teams) > 0 {
+		fmt.Fprintf(query, "organization(login:%q){\n", repo.RepoOwner())
+		for i, t := range teams {
+			fmt.Fprintf(query, "t%03d: team(slug:%q){id,slug}\n", i, t)
+		}
+		fmt.Fprint(query, "}\n")
+	}
+
+	response := make(map[string]json.RawMessage)
+	err = client.GraphQL(query.String(), nil, &response)
+	if err != nil {
+		return result, err
+	}
+
+	for key, v := range response {
+		switch key {
+		case "repository":
+			repoResponse := make(map[string]RepoLabel)
+			err := json.Unmarshal(v, &repoResponse)
+			if err != nil {
+				return result, err
+			}
+			for _, l := range repoResponse {
+				result.Labels = append(result.Labels, l)
+			}
+		case "organization":
+			orgResponse := make(map[string]OrgTeam)
+			err := json.Unmarshal(v, &orgResponse)
+			if err != nil {
+				return result, err
+			}
+			for _, t := range orgResponse {
+				result.Teams = append(result.Teams, t)
+			}
+		default:
+			user := RepoAssignee{}
+			err := json.Unmarshal(v, &user)
+			if err != nil {
+				return result, err
+			}
+			result.AssignableUsers = append(result.AssignableUsers, user)
+		}
+	}
+
+	return result, nil
+}
+
 type RepoProject struct {
 	ID   string
 	Name string

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -623,6 +623,7 @@ func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoRes
 	}
 
 	query := &bytes.Buffer{}
+	fmt.Fprint(query, "{\n")
 	for i, u := range users {
 		fmt.Fprintf(query, "u%03d: user(login:%q){id,login}\n", i, u)
 	}
@@ -640,6 +641,7 @@ func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoRes
 		}
 		fmt.Fprint(query, "}\n")
 	}
+	fmt.Fprint(query, "}\n")
 
 	response := make(map[string]json.RawMessage)
 	err = client.GraphQL(query.String(), nil, &response)

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/httpmock"
 )
 
@@ -44,4 +45,98 @@ func Test_RepoCreate(t *testing.T) {
 	if homepage := reqBody.Variables.Input["homepageUrl"].(string); homepage != "http://example.com" {
 		t.Errorf("expected homepageUrl to be %q, got %q", "http://example.com", homepage)
 	}
+}
+
+func Test_RepoResolveMetadataIDs(t *testing.T) {
+	http := &httpmock.Registry{}
+	client := NewClient(ReplaceTripper(http))
+
+	repo := ghrepo.FromFullName("OWNER/REPO")
+	input := RepoResolveInput{
+		Assignees: []string{"monalisa", "hubot"},
+		Reviewers: []string{"monalisa", "octocat", "OWNER/core", "/robots"},
+		Labels:    []string{"bug", "help wanted"},
+	}
+
+	expectedQuery := `u000: user(login:"monalisa"){id,login}
+u001: user(login:"hubot"){id,login}
+u002: user(login:"octocat"){id,login}
+repository(owner:"OWNER",name:"REPO"){
+l000: label(name:"bug"){id,name}
+l001: label(name:"help wanted"){id,name}
+}
+organization(login:"OWNER"){
+t000: team(slug:"core"){id,slug}
+t001: team(slug:"robots"){id,slug}
+}
+`
+	responseJSON := `
+	{ "data": {
+		"u000": { "login": "MonaLisa", "id": "MONAID" },
+		"u001": { "login": "hubot", "id": "HUBOTID" },
+		"u002": { "login": "octocat", "id": "OCTOID" },
+		"repository": {
+			"l000": { "name": "bug", "id": "BUGID" },
+			"l001": { "name": "Help Wanted", "id": "HELPID" }
+		},
+		"organization": {
+			"t000": { "slug": "core", "id": "COREID" },
+			"t001": { "slug": "Robots", "id": "ROBOTID" }
+		}
+	} }
+	`
+
+	http.Register(
+		httpmock.MatchAny,
+		httpmock.GraphQLQuery(responseJSON, func(q string, _ map[string]interface{}) {
+			if q != expectedQuery {
+				t.Errorf("expected query %q, got %q", expectedQuery, q)
+			}
+		}))
+
+	result, err := RepoResolveMetadataIDs(client, repo, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedMemberIDs := []string{"MONAID", "HUBOTID", "OCTOID"}
+	memberIDs, err := result.MembersToIDs([]string{"monalisa", "hubot", "octocat"})
+	if err != nil {
+		t.Errorf("error resolving members: %v", err)
+	}
+	if !sliceEqual(memberIDs, expectedMemberIDs) {
+		t.Errorf("expected members %v, got %v", expectedMemberIDs, memberIDs)
+	}
+
+	expectedTeamIDs := []string{"COREID", "ROBOTID"}
+	teamIDs, err := result.TeamsToIDs([]string{"/core", "/robots"})
+	if err != nil {
+		t.Errorf("error resolving teams: %v", err)
+	}
+	if !sliceEqual(teamIDs, expectedTeamIDs) {
+		t.Errorf("expected members %v, got %v", expectedTeamIDs, teamIDs)
+	}
+
+	expectedLabelIDs := []string{"BUGID", "HELPID"}
+	labelIDs, err := result.LabelsToIDs([]string{"bug", "help wanted"})
+	if err != nil {
+		t.Errorf("error resolving labels: %v", err)
+	}
+	if !sliceEqual(labelIDs, expectedLabelIDs) {
+		t.Errorf("expected members %v, got %v", expectedLabelIDs, labelIDs)
+	}
+}
+
+func sliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -188,7 +188,8 @@ func Test_RepoResolveMetadataIDs(t *testing.T) {
 		Labels:    []string{"bug", "help wanted"},
 	}
 
-	expectedQuery := `u000: user(login:"monalisa"){id,login}
+	expectedQuery := `{
+u000: user(login:"monalisa"){id,login}
 u001: user(login:"hubot"){id,login}
 u002: user(login:"octocat"){id,login}
 repository(owner:"OWNER",name:"REPO"){
@@ -198,6 +199,7 @@ l001: label(name:"help wanted"){id,name}
 organization(login:"OWNER"){
 t000: team(slug:"core"){id,slug}
 t001: team(slug:"robots"){id,slug}
+}
 }
 `
 	responseJSON := `

--- a/command/issue.go
+++ b/command/issue.go
@@ -473,15 +473,14 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 
 		if tb.HasMetadata() {
 			if tb.MetadataResult == nil {
-				metadataInput := api.RepoMetadataInput{
-					Assignees:  len(tb.Assignees) > 0,
-					Labels:     len(tb.Labels) > 0,
-					Projects:   len(tb.Projects) > 0,
-					Milestones: len(tb.Milestones) > 0,
+				resolveInput := api.RepoResolveInput{
+					Assignees:  tb.Assignees,
+					Labels:     tb.Labels,
+					Projects:   tb.Projects,
+					Milestones: tb.Milestones,
 				}
 
-				// TODO: for non-interactive mode, only translate given objects to GraphQL IDs
-				tb.MetadataResult, err = api.RepoMetadata(apiClient, baseRepo, metadataInput)
+				tb.MetadataResult, err = api.RepoResolveMetadataIDs(apiClient, baseRepo, resolveInput)
 				if err != nil {
 					return err
 				}

--- a/command/issue.go
+++ b/command/issue.go
@@ -546,7 +546,7 @@ func addMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, par
 		if strings.ContainsRune(r, '/') {
 			teamReviewers = append(teamReviewers, r)
 		} else {
-			userReviewers = append(teamReviewers, r)
+			userReviewers = append(userReviewers, r)
 		}
 	}
 

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -500,27 +500,15 @@ func TestIssueCreate_metadata(t *testing.T) {
 		} } }
 		`))
 	http.Register(
-		httpmock.GraphQL(`\bassignableUsers\(`),
+		httpmock.GraphQL(`\bu000:`),
 		httpmock.StringResponse(`
-		{ "data": { "repository": { "assignableUsers": {
-			"nodes": [
-				{ "login": "hubot", "id": "HUBOTID" },
-				{ "login": "MonaLisa", "id": "MONAID" }
-			],
-			"pageInfo": { "hasNextPage": false }
-		} } } }
-		`))
-	http.Register(
-		httpmock.GraphQL(`\blabels\(`),
-		httpmock.StringResponse(`
-		{ "data": { "repository": { "labels": {
-			"nodes": [
-				{ "name": "feature", "id": "FEATUREID" },
-				{ "name": "TODO", "id": "TODOID" },
-				{ "name": "bug", "id": "BUGID" }
-			],
-			"pageInfo": { "hasNextPage": false }
-		} } } }
+		{ "data": {
+			"u000": { "login": "MonaLisa", "id": "MONAID" },
+			"repository": {
+				"l000": { "name": "bug", "id": "BUGID" },
+				"l001": { "name": "TODO", "id": "TODOID" }
+			}
+		} }
 		`))
 	http.Register(
 		httpmock.GraphQL(`\bmilestones\(`),

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -556,6 +556,12 @@ func TestIssueCreate_metadata(t *testing.T) {
 			eq(t, inputs["labelIds"], []interface{}{"BUGID", "TODOID"})
 			eq(t, inputs["projectIds"], []interface{}{"ROADMAPID"})
 			eq(t, inputs["milestoneId"], "BIGONEID")
+			if v, ok := inputs["userIds"]; ok {
+				t.Errorf("did not expect userIds: %v", v)
+			}
+			if v, ok := inputs["teamIds"]; ok {
+				t.Errorf("did not expect teamIds: %v", v)
+			}
 		}))
 
 	output, err := RunCommand(`issue create -t TITLE -b BODY -a monalisa -l bug -l todo -p roadmap -m 'big one.oh'`)

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -325,16 +325,19 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 
 		if tb.HasMetadata() {
 			if tb.MetadataResult == nil {
-				metadataInput := api.RepoMetadataInput{
-					Reviewers:  len(tb.Reviewers) > 0,
-					Assignees:  len(tb.Assignees) > 0,
-					Labels:     len(tb.Labels) > 0,
-					Projects:   len(tb.Projects) > 0,
-					Milestones: tb.Milestone != "",
+				var milestones []string
+				if tb.Milestone != "" {
+					milestones = append(milestones, tb.Milestone)
+				}
+				resolveInput := api.RepoResolveInput{
+					Reviewers:  tb.Reviewers,
+					Assignees:  tb.Assignees,
+					Labels:     tb.Labels,
+					Projects:   tb.Projects,
+					Milestones: milestones,
 				}
 
-				// TODO: for non-interactive mode, only translate given objects to GraphQL IDs
-				tb.MetadataResult, err = api.RepoMetadata(client, baseRepo, metadataInput)
+				tb.MetadataResult, err = api.RepoResolveMetadataIDs(client, baseRepo, resolveInput)
 				if err != nil {
 					return err
 				}

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -325,48 +325,9 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 			"headRefName": headBranchLabel,
 		}
 
-		if tb.HasMetadata() {
-			if tb.MetadataResult == nil {
-				resolveInput := api.RepoResolveInput{
-					Reviewers:  tb.Reviewers,
-					Assignees:  tb.Assignees,
-					Labels:     tb.Labels,
-					Projects:   tb.Projects,
-					Milestones: tb.Milestones,
-				}
-
-				tb.MetadataResult, err = api.RepoResolveMetadataIDs(client, baseRepo, resolveInput)
-				if err != nil {
-					return err
-				}
-			}
-
-			err = addMetadataToIssueParams(params, tb.MetadataResult, tb.Assignees, tb.Labels, tb.Projects, tb.Milestones)
-			if err != nil {
-				return err
-			}
-
-			var userReviewers []string
-			var teamReviewers []string
-			for _, r := range tb.Reviewers {
-				if strings.ContainsRune(r, '/') {
-					teamReviewers = append(teamReviewers, r)
-				} else {
-					userReviewers = append(teamReviewers, r)
-				}
-			}
-
-			userReviewerIDs, err := tb.MetadataResult.MembersToIDs(userReviewers)
-			if err != nil {
-				return fmt.Errorf("could not request reviewer: %w", err)
-			}
-			params["userReviewerIds"] = userReviewerIDs
-
-			teamReviewerIDs, err := tb.MetadataResult.TeamsToIDs(teamReviewers)
-			if err != nil {
-				return fmt.Errorf("could not request reviewer: %w", err)
-			}
-			params["teamReviewerIds"] = teamReviewerIDs
+		err = addMetadataToIssueParams(client, baseRepo, params, &tb)
+		if err != nil {
+			return err
 		}
 
 		pr, err := api.CreatePullRequest(client, baseRepo, params)

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -97,7 +97,8 @@ func TestPRCreate_metadata(t *testing.T) {
 				"l001": { "name": "TODO", "id": "TODOID" }
 			},
 			"organization": {
-				"t000": { "slug": "core", "id": "COREID" }
+				"t000": { "slug": "core", "id": "COREID" },
+				"t001": { "slug": "robots", "id": "ROBOTID" }
 			}
 		} }
 		`))
@@ -169,8 +170,8 @@ func TestPRCreate_metadata(t *testing.T) {
 		} } }
 	`, func(inputs map[string]interface{}) {
 			eq(t, inputs["pullRequestId"], "NEWPULLID")
-			eq(t, inputs["userIds"], []interface{}{"HUBOTID"})
-			eq(t, inputs["teamIds"], []interface{}{"COREID"})
+			eq(t, inputs["userIds"], []interface{}{"HUBOTID", "MONAID"})
+			eq(t, inputs["teamIds"], []interface{}{"COREID", "ROBOTID"})
 		}))
 
 	cs, cmdTeardown := test.InitCmdStubber()
@@ -182,7 +183,7 @@ func TestPRCreate_metadata(t *testing.T) {
 	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
 	cs.Stub("")                                         // git push
 
-	output, err := RunCommand(`pr create -t TITLE -b BODY -a monalisa -l bug -l todo -p roadmap -m 'big one.oh' -r hubot -r /core`)
+	output, err := RunCommand(`pr create -t TITLE -b BODY -a monalisa -l bug -l todo -p roadmap -m 'big one.oh' -r hubot -r monalisa -r /core -r /robots`)
 	eq(t, err, nil)
 
 	eq(t, output.String(), "https://github.com/OWNER/REPO/pull/12\n")

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -87,27 +87,19 @@ func TestPRCreate_metadata(t *testing.T) {
 		] } } } }
 		`))
 	http.Register(
-		httpmock.GraphQL(`\bassignableUsers\(`),
+		httpmock.GraphQL(`\bteam\(`),
 		httpmock.StringResponse(`
-		{ "data": { "repository": { "assignableUsers": {
-			"nodes": [
-				{ "login": "hubot", "id": "HUBOTID" },
-				{ "login": "MonaLisa", "id": "MONAID" }
-			],
-			"pageInfo": { "hasNextPage": false }
-		} } } }
-		`))
-	http.Register(
-		httpmock.GraphQL(`\blabels\(`),
-		httpmock.StringResponse(`
-		{ "data": { "repository": { "labels": {
-			"nodes": [
-				{ "name": "feature", "id": "FEATUREID" },
-				{ "name": "TODO", "id": "TODOID" },
-				{ "name": "bug", "id": "BUGID" }
-			],
-			"pageInfo": { "hasNextPage": false }
-		} } } }
+		{ "data": {
+			"u000": { "login": "MonaLisa", "id": "MONAID" },
+			"u001": { "login": "hubot", "id": "HUBOTID" },
+			"repository": {
+				"l000": { "name": "bug", "id": "BUGID" },
+				"l001": { "name": "TODO", "id": "TODOID" }
+			},
+			"organization": {
+				"t000": { "slug": "core", "id": "COREID" }
+			}
+		} }
 		`))
 	http.Register(
 		httpmock.GraphQL(`\bmilestones\(`),
@@ -136,17 +128,6 @@ func TestPRCreate_metadata(t *testing.T) {
 		httpmock.StringResponse(`
 		{ "data": { "organization": { "projects": {
 			"nodes": [],
-			"pageInfo": { "hasNextPage": false }
-		} } } }
-		`))
-	http.Register(
-		httpmock.GraphQL(`\borganization\(.+\bteams\(`),
-		httpmock.StringResponse(`
-		{ "data": { "organization": { "teams": {
-			"nodes": [
-				{ "slug": "owners", "id": "OWNERSID" },
-				{ "slug": "Core", "id": "COREID" }
-			],
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -141,6 +141,12 @@ func TestPRCreate_metadata(t *testing.T) {
 	`, func(inputs map[string]interface{}) {
 			eq(t, inputs["title"], "TITLE")
 			eq(t, inputs["body"], "BODY")
+			if v, ok := inputs["assigneeIds"]; ok {
+				t.Errorf("did not expect assigneeIds: %v", v)
+			}
+			if v, ok := inputs["userIds"]; ok {
+				t.Errorf("did not expect userIds: %v", v)
+			}
 		}))
 	http.Register(
 		httpmock.GraphQL(`\bupdatePullRequest\(`),

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -88,6 +88,22 @@ func GraphQLMutation(body string, cb func(map[string]interface{})) Responder {
 	}
 }
 
+func GraphQLQuery(body string, cb func(string, map[string]interface{})) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		var bodyData struct {
+			Query     string
+			Variables map[string]interface{}
+		}
+		err := decodeJSONBody(req, &bodyData)
+		if err != nil {
+			return nil, err
+		}
+		cb(bodyData.Query, bodyData.Variables)
+
+		return httpResponse(200, bytes.NewBufferString(body)), nil
+	}
+}
+
 func httpResponse(status int, body io.Reader) *http.Response {
 	return &http.Response{
 		StatusCode: status,


### PR DESCRIPTION
Command tested:
```
gh pr create -R github/github -t 'title' -b 'body' -a hubot -r github/<team> -l bug
```

Results:
- before: **18.420s** spent in metadata resolve
- after: **0.411s** spent in resolve

This is achieved by avoiding preloading all org users and teams (as it would if assignees or reviewers were requested in interactive mode) and manually assembling a query that resolves an assortment of GraphQL nodes to IDs in bulk.

Followup to https://github.com/cli/cli/pull/787