### PR TITLE
Preserve CODEOWNERS reviewers in `pr create`

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -667,6 +667,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 			requestReviews(input: $input) { clientMutationId }
 		}`
 		reviewParams["pullRequestId"] = pr.ID
+		reviewParams["union"] = true
 		variables := map[string]interface{}{
 			"input": reviewParams,
 		}

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -184,6 +184,7 @@ func TestPRCreate_metadata(t *testing.T) {
 			eq(t, inputs["pullRequestId"], "NEWPULLID")
 			eq(t, inputs["userIds"], []interface{}{"HUBOTID"})
 			eq(t, inputs["teamIds"], []interface{}{"COREID"})
+			eq(t, inputs["union"], true)
 		}))
 
 	cs, cmdTeardown := test.InitCmdStubber()


### PR DESCRIPTION
When reviewers were requested on a PR, they would apparently overwrite the current set of reviewers. A fresh PR will already have reviewers if it was assigned some by CODEOWNERS rules.

The fix is to [only ever add additional reviewers](https://developer.github.com/v4/input_object/requestreviewsinput/) and not overwrite the entire set. 

Fixes #910