### PR TITLE
Improved error message when "owner/repo" format not provided

### DIFF
--- a/api/queries_issue_test.go
+++ b/api/queries_issue_test.go
@@ -39,7 +39,8 @@ func TestIssueList(t *testing.T) {
 	} } }
 	`))
 
-	_, err := IssueList(client, ghrepo.FromFullName("OWNER/REPO"), "open", []string{}, "", 251, "")
+	repo, _ := ghrepo.FromFullName("OWNER/REPO")
+	_, err := IssueList(client, repo, "open", []string{}, "", 251, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -50,7 +50,7 @@ func Test_RepoMetadata(t *testing.T) {
 	http := &httpmock.Registry{}
 	client := NewClient(ReplaceTripper(http))
 
-	repo := ghrepo.FromFullName("OWNER/REPO")
+	repo, _ := ghrepo.FromFullName("OWNER/REPO")
 	input := RepoMetadataInput{
 		Assignees:  true,
 		Reviewers:  true,
@@ -181,7 +181,7 @@ func Test_RepoResolveMetadataIDs(t *testing.T) {
 	http := &httpmock.Registry{}
 	client := NewClient(ReplaceTripper(http))
 
-	repo := ghrepo.FromFullName("OWNER/REPO")
+	repo, _ := ghrepo.FromFullName("OWNER/REPO")
 	input := RepoResolveInput{
 		Assignees: []string{"monalisa", "hubot"},
 		Reviewers: []string{"monalisa", "octocat", "OWNER/core", "/robots"},

--- a/command/repo.go
+++ b/command/repo.go
@@ -369,9 +369,9 @@ func repoFork(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("did not understand argument: %w", err)
 			}
 		} else {
-			repoToFork, _ = ghrepo.FromFullName(repoArg)
-			if repoToFork.RepoName() == "" || repoToFork.RepoOwner() == "" {
-				return fmt.Errorf("could not parse owner or repo name from %s", repoArg)
+			repoToFork, err = ghrepo.FromFullName(repoArg)
+			if err != nil {
+				return fmt.Errorf("argument error: %w", err)
 			}
 		}
 	}

--- a/command/repo.go
+++ b/command/repo.go
@@ -189,7 +189,6 @@ func repoCreate(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		name = args[0]
 		if strings.Contains(name, "/") {
-			var err error
 			newRepo, err := ghrepo.FromFullName(name)
 			if err != nil {
 				return fmt.Errorf("argument error: %w", err)

--- a/command/repo.go
+++ b/command/repo.go
@@ -189,7 +189,11 @@ func repoCreate(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		name = args[0]
 		if strings.Contains(name, "/") {
-			newRepo, _ := ghrepo.FromFullName(name)
+			var err error
+			newRepo, err := ghrepo.FromFullName(name)
+			if err != nil {
+				return fmt.Errorf("argument error: %w", err)
+			}
 			orgName = newRepo.RepoOwner()
 			name = newRepo.RepoName()
 		}

--- a/command/repo.go
+++ b/command/repo.go
@@ -511,7 +511,7 @@ func repoView(cmd *cobra.Command, args []string) error {
 			var err error
 			toView, err = ghrepo.FromFullName(repoArg)
 			if err != nil {
-				return fmt.Errorf("did not understand argument: %w", err)
+				return fmt.Errorf("argument error: %w", err)
 			}
 		}
 	}

--- a/command/repo.go
+++ b/command/repo.go
@@ -189,7 +189,7 @@ func repoCreate(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		name = args[0]
 		if strings.Contains(name, "/") {
-			newRepo := ghrepo.FromFullName(name)
+			newRepo, _ := ghrepo.FromFullName(name)
 			orgName = newRepo.RepoOwner()
 			name = newRepo.RepoName()
 		}
@@ -366,7 +366,7 @@ func repoFork(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("did not understand argument: %w", err)
 			}
 		} else {
-			repoToFork = ghrepo.FromFullName(repoArg)
+			repoToFork, _ = ghrepo.FromFullName(repoArg)
 			if repoToFork.RepoName() == "" || repoToFork.RepoOwner() == "" {
 				return fmt.Errorf("could not parse owner or repo name from %s", repoArg)
 			}
@@ -508,7 +508,11 @@ func repoView(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("did not understand argument: %w", err)
 			}
 		} else {
-			toView = ghrepo.FromFullName(repoArg)
+			var err error
+			toView, err = ghrepo.FromFullName(repoArg)
+			if err != nil {
+				return fmt.Errorf("did not understand argument: %w", err)
+			}
 		}
 	}
 

--- a/command/root.go
+++ b/command/root.go
@@ -217,7 +217,8 @@ func changelogURL(version string) string {
 func determineBaseRepo(cmd *cobra.Command, ctx context.Context) (ghrepo.Interface, error) {
 	repo, err := cmd.Flags().GetString("repo")
 	if err == nil && repo != "" {
-		return ghrepo.FromFullName(repo), nil
+		baseRepo, _ := ghrepo.FromFullName(repo)
+		return baseRepo, nil
 	}
 
 	apiClient, err := apiClientForContext(ctx)

--- a/command/root.go
+++ b/command/root.go
@@ -219,7 +219,10 @@ func changelogURL(version string) string {
 func determineBaseRepo(cmd *cobra.Command, ctx context.Context) (ghrepo.Interface, error) {
 	repo, err := cmd.Flags().GetString("repo")
 	if err == nil && repo != "" {
-		baseRepo, _ := ghrepo.FromFullName(repo)
+		baseRepo, err := ghrepo.FromFullName(repo)
+		if err != nil {
+			return nil, fmt.Errorf("argument error: %w", err)
+		}
 		return baseRepo, nil
 	}
 

--- a/context/blank_context.go
+++ b/context/blank_context.go
@@ -92,5 +92,6 @@ func (c *blankContext) BaseRepo() (ghrepo.Interface, error) {
 }
 
 func (c *blankContext) SetBaseRepo(nwo string) {
-	c.baseRepo = ghrepo.FromFullName(nwo)
+	repo, _ := ghrepo.FromFullName(nwo)
+	c.baseRepo = repo
 }

--- a/context/context.go
+++ b/context/context.go
@@ -39,7 +39,8 @@ func ResolveRemotesToRepos(remotes Remotes, client *api.Client, base string) (Re
 	}
 
 	hasBaseOverride := base != ""
-	baseOverride := ghrepo.FromFullName(base)
+	var err error
+	baseOverride, _ := ghrepo.FromFullName(base)
 	foundBaseOverride := false
 	repos := make([]ghrepo.Interface, 0, lenRemotesForLookup)
 	for _, r := range remotes[:lenRemotesForLookup] {
@@ -266,5 +267,5 @@ func (c *fsContext) BaseRepo() (ghrepo.Interface, error) {
 }
 
 func (c *fsContext) SetBaseRepo(nwo string) {
-	c.baseRepo = ghrepo.FromFullName(nwo)
+	c.baseRepo, _ = ghrepo.FromFullName(nwo)
 }

--- a/context/context.go
+++ b/context/context.go
@@ -39,7 +39,6 @@ func ResolveRemotesToRepos(remotes Remotes, client *api.Client, base string) (Re
 	}
 
 	hasBaseOverride := base != ""
-	var err error
 	baseOverride, _ := ghrepo.FromFullName(base)
 	foundBaseOverride := false
 	repos := make([]ghrepo.Interface, 0, lenRemotesForLookup)

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -32,7 +32,7 @@ func FullName(r Interface) string {
 func FromFullName(nwo string) (Interface, error) {
 	var r ghRepo
 	parts := strings.SplitN(nwo, "/", 2)
-	if len(parts) != 2 {
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return &r, fmt.Errorf("expected OWNER/REPO format, got \"%s\"", nwo)
 	}
 	r.owner, r.name = parts[0], parts[1]

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -33,7 +33,7 @@ func FromFullName(nwo string) (Interface, error) {
 	var r ghRepo
 	parts := strings.SplitN(nwo, "/", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return &r, fmt.Errorf("expected OWNER/REPO format, got \"%s\"", nwo)
+		return &r, fmt.Errorf("expected OWNER/REPO format, got %q", nwo)
 	}
 	r.owner, r.name = parts[0], parts[1]
 	return &r, nil

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -33,7 +33,7 @@ func FromFullName(nwo string) (Interface, error) {
 	var r ghRepo
 	parts := strings.SplitN(nwo, "/", 2)
 	if len(parts) != 2 {
-		return &r, fmt.Errorf("argument must be in format of OWNER/REPO")
+		return &r, fmt.Errorf("expected OWNER/REPO format, got \"%s\"", nwo)
 	}
 	r.owner, r.name = parts[0], parts[1]
 	return &r, nil

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -28,7 +28,7 @@ func FullName(r Interface) string {
 	return fmt.Sprintf("%s/%s", r.RepoOwner(), r.RepoName())
 }
 
-// FromFullName extracts the GitHub repository inforation from an "OWNER/REPO" string
+// FromFullName extracts the GitHub repository information from an "OWNER/REPO" string
 func FromFullName(nwo string) (Interface, error) {
 	var r ghRepo
 	parts := strings.SplitN(nwo, "/", 2)

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -29,13 +29,14 @@ func FullName(r Interface) string {
 }
 
 // FromFullName extracts the GitHub repository inforation from an "OWNER/REPO" string
-func FromFullName(nwo string) Interface {
+func FromFullName(nwo string) (Interface, error) {
 	var r ghRepo
 	parts := strings.SplitN(nwo, "/", 2)
-	if len(parts) == 2 {
-		r.owner, r.name = parts[0], parts[1]
+	if len(parts) != 2 {
+		return &r, fmt.Errorf("argument must be in format of OWNER/REPO")
 	}
-	return &r
+	r.owner, r.name = parts[0], parts[1]
+	return &r, nil
 }
 
 // FromURL extracts the GitHub repository information from a URL


### PR DESCRIPTION
As per https://github.com/cli/cli/issues/882, here's the associated PR. It ended up requiring a little more refactoring than I initially anticipated 😄That said I ended up mirroring the behavior of `FromUrl` (https://github.com/cli/cli/blob/master/internal/ghrepo/repo.go#L42) given it's functionally similar. All current tests pass (and figured no new ones needed). Any queries, just let me know 👍 