### PR TITLE
Consistent interface for getting a PR

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -287,7 +287,11 @@ func colorFuncForState(state string) func(string) string {
 }
 
 func prView(cmd *cobra.Command, args []string) error {
-	pr, err := getPr(cmd, args[0])
+	var prString string
+	if len(args) > 0 {
+		prString = args[0]
+	}
+	pr, err := getPr(cmd, prString)
 	if err != nil {
 		return err
 	}
@@ -318,7 +322,11 @@ func prClose(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	pr, err := getPr(cmd, args[0])
+	var prString string
+	if len(args) > 0 {
+		prString = args[0]
+	}
+	pr, err := getPr(cmd, prString)
 	if err != nil {
 		return err
 	}
@@ -353,7 +361,11 @@ func prReopen(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	pr, err := getPr(cmd, args[0])
+	var prString string
+	if len(args) > 0 {
+		prString = args[0]
+	}
+	pr, err := getPr(cmd, prString)
 	if err != nil {
 		return err
 	}
@@ -390,7 +402,11 @@ func prMerge(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	pr, err := getPr(cmd, args[0])
+	var prString string
+	if len(args) > 0 {
+		prString = args[0]
+	}
+	pr, err := getPr(cmd, prString)
 	if err != nil {
 		return err
 	}

--- a/command/pr.go
+++ b/command/pr.go
@@ -304,10 +304,10 @@ func prView(cmd *cobra.Command, args []string) error {
 	if web {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Opening %s in your browser.\n", pr.URL)
 		return utils.OpenInBrowser(pr.URL)
+	} else {
+		out := colorableOut(cmd)
+		return printPrPreview(out, pr)
 	}
-
-	out := colorableOut(cmd)
-	return printPrPreview(out, pr)
 }
 
 func prClose(cmd *cobra.Command, args []string) error {

--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -36,10 +36,7 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo = repoFromPr(pr)
-
 	baseRemote, _ := remotes.FindByRepo(baseRepo.RepoOwner(), baseRepo.RepoName())
-	fmt.Printf("🌭 baseRemote: %+v\n", baseRemote)
 	// baseRemoteSpec is a repository URL or a remote name to be used in git fetch
 	baseURLOrName := formatRemoteURL(cmd, ghrepo.FullName(baseRepo))
 	if baseRemote != nil {
@@ -51,7 +48,6 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 		headRemote, _ = remotes.FindByRepo(pr.HeadRepositoryOwner.Login, pr.HeadRepository.Name)
 	}
 
-	fmt.Printf("🌭 headRemote: %+v\n", headRemote)
 	var cmdQueue [][]string
 	newBranchName := pr.HeadRefName
 	if headRemote != nil {

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -76,7 +76,7 @@ func TestPRCheckout_urlArg(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
-
+	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
@@ -116,6 +116,7 @@ func TestPRCheckout_urlArg(t *testing.T) {
 }
 
 func TestPRCheckout_urlArg_differentBase(t *testing.T) {
+	t.Skip()
 	ctx := context.NewBlank()
 	ctx.SetBranch("master")
 	ctx.SetRemotes(map[string]string{
@@ -125,7 +126,7 @@ func TestPRCheckout_urlArg_differentBase(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
-
+	http.StubRepoResponse("OWNER", "REPO")
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
@@ -188,7 +189,6 @@ func TestPRCheckout_branchArg(t *testing.T) {
 	}
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
-
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequests": { "nodes": [
 		{ "number": 123,

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -30,7 +30,7 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 		"number": 123,
 		"headRefName": "feature",
 		"headRepositoryOwner": {
-			"login": "hubot"
+			"login": "OWNER"
 		},
 		"headRepository": {
 			"name": "REPO",

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -77,6 +77,7 @@ func TestPRCheckout_urlArg(t *testing.T) {
 	}
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
+
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
@@ -116,7 +117,6 @@ func TestPRCheckout_urlArg(t *testing.T) {
 }
 
 func TestPRCheckout_urlArg_differentBase(t *testing.T) {
-	t.Skip()
 	ctx := context.NewBlank()
 	ctx.SetBranch("master")
 	ctx.SetRemotes(map[string]string{
@@ -189,6 +189,7 @@ func TestPRCheckout_branchArg(t *testing.T) {
 	}
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
+
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": { "repository": { "pullRequests": { "nodes": [
 		{ "number": 123,

--- a/command/pr_lookup.go
+++ b/command/pr_lookup.go
@@ -20,7 +20,6 @@ func getPr(cmd *cobra.Command, prString string) (*api.PullRequest, error) {
 		return nil, err
 	}
 
-	fmt.Printf("🌭 %+v\n", "NEA")
 	baseRepo, err := determineBaseRepo(cmd, ctx)
 	if err != nil {
 		return nil, err

--- a/command/pr_lookup.go
+++ b/command/pr_lookup.go
@@ -1,0 +1,122 @@
+package command
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/context"
+	"github.com/cli/cli/git"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/spf13/cobra"
+)
+
+func getPr(cmd *cobra.Command, prNumber string) (*api.PullRequest, error) {
+	ctx := contextForCommand(cmd)
+	apiClient, err := apiClientForContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	baseRepo, err := determineBaseRepo(cmd, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// This assumes the first arg is the pr number
+	if prNumber != "" {
+		pr, err := prFromString(apiClient, baseRepo, prNumber)
+		return pr, err
+	} else {
+		pr, err := prFromContext(ctx, baseRepo)
+		return pr, err
+	}
+	return nil, nil
+}
+
+func prNumberAndRepoFromURL(url string) (int, ghrepo.Interface) {
+	if m := prURLRE.FindStringSubmatch(url); m != nil {
+		prNumber, err := strconv.Atoi(m[3])
+		if err == nil {
+			return prNumber, ghrepo.New(m[1], m[2])
+		}
+	}
+	return 0, nil
+}
+
+func prFromString(apiClient *api.Client, baseRepo ghrepo.Interface, prString string) (*api.PullRequest, error) {
+	if prNumber, err := strconv.Atoi(strings.TrimPrefix(prString, "#")); err == nil {
+		return api.PullRequestByNumber(apiClient, baseRepo, prNumber)
+	} else if prNumber, r := prNumberAndRepoFromURL(prString); r != nil {
+		return api.PullRequestByNumber(apiClient, r, prNumber)
+	}
+
+	return api.PullRequestForBranch(apiClient, baseRepo, "", prString)
+}
+
+func repoFromPr(pr *api.PullRequest) ghrepo.Interface {
+	return ghrepo.New(pr.HeadRepositoryOwner.Login, pr.HeadRepository.Name)
+}
+
+func prFromContext(ctx context.Context, baseRepo ghrepo.Interface) (*api.PullRequest, error) {
+	prNumber, branchWithOwner, err := prSelectorForCurrentBranch(ctx, baseRepo)
+	if err != nil {
+		return nil, err
+	}
+
+	apiClient, err := apiClientForContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if prNumber != 0 {
+		pr, err := api.PullRequestByNumber(apiClient, baseRepo, prNumber)
+		return pr, err
+	}
+
+	pr, err := api.PullRequestForBranch(apiClient, baseRepo, "", branchWithOwner)
+	return pr, err
+}
+
+func prSelectorForCurrentBranch(ctx context.Context, baseRepo ghrepo.Interface) (prNumber int, prHeadRef string, err error) {
+	prHeadRef, err = ctx.Branch()
+	if err != nil {
+		return
+	}
+	branchConfig := git.ReadBranchConfig(prHeadRef)
+
+	// the branch is configured to merge a special PR head ref
+	prHeadRE := regexp.MustCompile(`^refs/pull/(\d+)/head$`)
+	if m := prHeadRE.FindStringSubmatch(branchConfig.MergeRef); m != nil {
+		prNumber, _ = strconv.Atoi(m[1])
+		return
+	}
+
+	var branchOwner string
+	if branchConfig.RemoteURL != nil {
+		// the branch merges from a remote specified by URL
+		if r, err := ghrepo.FromURL(branchConfig.RemoteURL); err == nil {
+			branchOwner = r.RepoOwner()
+		}
+	} else if branchConfig.RemoteName != "" {
+		// the branch merges from a remote specified by name
+		rem, _ := ctx.Remotes()
+		if r, err := rem.FindByName(branchConfig.RemoteName); err == nil {
+			branchOwner = r.RepoOwner()
+		}
+	}
+
+	if branchOwner != "" {
+		if strings.HasPrefix(branchConfig.MergeRef, "refs/heads/") {
+			prHeadRef = strings.TrimPrefix(branchConfig.MergeRef, "refs/heads/")
+		}
+		// prepend `OWNER:` if this branch is pushed to a fork
+		if !strings.EqualFold(branchOwner, baseRepo.RepoOwner()) {
+			prHeadRef = fmt.Sprintf("%s:%s", branchOwner, prHeadRef)
+		}
+	}
+
+	return
+}

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -95,7 +95,11 @@ func prReview(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("did not understand desired review action: %w", err)
 	}
 
-	pr, err := getPr(cmd, args[0])
+	var prString string
+	if len(args) > 0 {
+		prString = args[0]
+	}
+	pr, err := getPr(cmd, prString)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There are several ways to look up PRs, and we've been repeating that code in a few places. It's now getting more complicated so I wanted to clean that up a bit by having a consistent func that will return a PR in these formats.

1. If the arg is a string check if it is a url, branch, or number. Look up the PR based on that.
2. If there is no arg, look up the PR associated with the current branch

This seems simple, but I ran into enough problems that I want to verify the interface before I go any further. I'm proposing this...

`func getPr(cmd *cobra.Command, prString string) (*api.PullRequest, error)`

**pros**
A consistent interface for looking up a PR based on an arg

**cons**
It will almost always do a graphql lookup on the PR because many methods rely on some PR metadata. This will make our tests a little more complicated because we need to stub that out. It will also make `pr view` a little bit slower because it now makes an api call.

**problems**
I can't get `TestPRCheckout_urlArg_differentBase` to run correctly. The code used to change the base branch if a url was passed to checkout but not if a number or branch was. But that seems inconsistent now. I'm having trouble coming up with a situation where you'd need to change the base branch when a url was passed.