### PR TITLE
Remote repository configured 

### DIFF
--- a/command/repo.go
+++ b/command/repo.go
@@ -179,6 +179,21 @@ func addUpstreamRemote(cmd *cobra.Command, parentRepo ghrepo.Interface, cloneDir
 func repoCreate(cmd *cobra.Command, args []string) error {
 	projectDir, projectDirErr := git.ToplevelDir()
 
+	if projectDirErr == nil {
+		remoteExist, err := git.CheckRemoteExist()
+		if err != nil {
+			return err
+		}
+
+		err = Confirm(fmt.Sprintf("There is a remote URL configured for directory, would like to create the repository?"), &remoteExist)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%s The repository was not created.", utils.Yellow("!"))
+		return nil
+	}
+
 	orgName := ""
 	teamSlug, err := cmd.Flags().GetString("team")
 	if err != nil {

--- a/command/repo.go
+++ b/command/repo.go
@@ -190,8 +190,10 @@ func repoCreate(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		fmt.Printf("%s The repository was not created.", utils.Yellow("!"))
-		return nil
+		if !remoteExist {
+			fmt.Printf("%s The repository was not created.", utils.Yellow("!"))
+			return nil
+		}
 	}
 
 	orgName := ""
@@ -286,7 +288,8 @@ func repoCreate(cmd *cobra.Command, args []string) error {
 	if projectDirErr == nil {
 		_, err = git.AddRemote("origin", remoteURL)
 		if err != nil {
-			return err
+			fmt.Printf("%s The remote wasn't configured for this repository.", utils.Yellow("!"))
+			return nil
 		}
 		if isTTY {
 			fmt.Fprintf(out, "%s Added remote %s\n", greenCheck, remoteURL)

--- a/command/repo.go
+++ b/command/repo.go
@@ -191,7 +191,7 @@ func repoCreate(cmd *cobra.Command, args []string) error {
 		}
 
 		if !remoteExist {
-			fmt.Printf("%s The repository was not created.", utils.Yellow("!"))
+			fmt.Printf("%s The repository was not created.\n", utils.Yellow("!"))
 			return nil
 		}
 	}
@@ -288,7 +288,7 @@ func repoCreate(cmd *cobra.Command, args []string) error {
 	if projectDirErr == nil {
 		_, err = git.AddRemote("origin", remoteURL)
 		if err != nil {
-			fmt.Printf("%s The remote wasn't configured for this repository.", utils.Yellow("!"))
+			fmt.Printf("%s The remote wasn't configured for this repository.\n", utils.Yellow("!"))
 			return nil
 		}
 		if isTTY {

--- a/git/remote.go
+++ b/git/remote.go
@@ -100,3 +100,14 @@ func AddRemote(name, u string) (*Remote, error) {
 		PushURL:  urlParsed,
 	}, nil
 }
+
+//CheckRemoteExist it's will verify with there is a remote configured at directory
+func CheckRemoteExist() (bool, error) {
+	out, err := exec.Command("git", "remote", "-v").Output()
+
+	if err != nil || out != nil {
+		return false, nil
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
As #893, the idea is just to be clear with the user when the repository have been creating and there is a remote URL configured as well.