### PR TITLE
Clarify user's desire during repo create when already in repo with origin remote

### DIFF
--- a/command/repo.go
+++ b/command/repo.go
@@ -179,6 +179,23 @@ func addUpstreamRemote(cmd *cobra.Command, parentRepo ghrepo.Interface, cloneDir
 func repoCreate(cmd *cobra.Command, args []string) error {
 	projectDir, projectDirErr := git.ToplevelDir()
 
+	if projectDirErr == nil {
+		remoteExist, err := git.CheckRemoteExist()
+		if err != nil {
+			return err
+		}
+
+		err = Confirm(fmt.Sprintf("There is a remote URL configured for directory, would like to create the repository?"), &remoteExist)
+		if err != nil {
+			return err
+		}
+
+		if !remoteExist {
+			fmt.Printf("%s The repository was not created.\n", utils.Yellow("!"))
+			return nil
+		}
+	}
+
 	orgName := ""
 	teamSlug, err := cmd.Flags().GetString("team")
 	if err != nil {

--- a/command/repo.go
+++ b/command/repo.go
@@ -288,7 +288,8 @@ func repoCreate(cmd *cobra.Command, args []string) error {
 	if projectDirErr == nil {
 		_, err = git.AddRemote("origin", remoteURL)
 		if err != nil {
-			return err
+			fmt.Printf("%s The remote wasn't configured for this repository.\n", utils.Yellow("!"))
+			return nil
 		}
 		if isTTY {
 			fmt.Fprintf(out, "%s Added remote %s\n", greenCheck, remoteURL)

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -529,6 +529,14 @@ func TestRepoCreate(t *testing.T) {
 	} } }
 	`))
 
+	doConfirm := Confirm
+	Confirm = func(_ string, result *bool) error {
+		*result = true
+		return nil
+	}
+
+	defer func() { Confirm = doConfirm }()
+
 	var seenCmd *exec.Cmd
 	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
@@ -598,6 +606,14 @@ func TestRepoCreate_org(t *testing.T) {
 	} } }
 	`))
 
+	doConfirm := Confirm
+	Confirm = func(_ string, result *bool) error {
+		*result = true
+		return nil
+	}
+
+	defer func() { Confirm = doConfirm }()
+
 	var seenCmd *exec.Cmd
 	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
@@ -666,6 +682,14 @@ func TestRepoCreate_orgWithTeam(t *testing.T) {
 		}
 	} } }
 	`))
+
+	doConfirm := Confirm
+	Confirm = func(_ string, result *bool) error {
+		*result = true
+		return nil
+	}
+
+	defer func() { Confirm = doConfirm }()
 
 	var seenCmd *exec.Cmd
 	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {

--- a/git/remote.go
+++ b/git/remote.go
@@ -100,3 +100,14 @@ func AddRemote(name, u string) (*Remote, error) {
 		PushURL:  urlParsed,
 	}, nil
 }
+
+//CheckRemoteExist it's will verify with there is a remote configured at directory
+func CheckRemoteExist() (bool, error) {
+	out, err := exec.Command("git", "remote", "-v").Output()
+
+	if err != nil || out != nil {
+		return false, nil
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
As #893, the idea of this feature is to check if there is a remote URL configured at directory and display for the user an option to create or not create the repository. 
If the user accept to create the repository, a friendly message will be display for the user.