### PR TITLE
patch review prototype

### DIFF
--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -21,6 +21,8 @@ func init() {
 	prReviewCmd.Flags().BoolP("request-changes", "r", false, "Request changes on a pull request")
 	prReviewCmd.Flags().BoolP("comment", "c", false, "Comment on a pull request")
 	prReviewCmd.Flags().StringP("body", "b", "", "Specify the body of a review")
+
+	prReviewCmd.Flags().BoolP("patch", "p", false, "Review interactively in patch mode")
 }
 
 var prReviewCmd = &cobra.Command{
@@ -137,9 +139,19 @@ func prReview(cmd *cobra.Command, args []string) error {
 	}
 
 	out := colorableOut(cmd)
+	patchMode, err := cmd.Flags().GetBool("patch")
+	if err != nil {
+		return err
+	}
+
+	if patchMode {
+		fmt.Fprintln(out, "FLIP MODE")
+		return nil
+	}
 
 	if reviewData == nil {
 		reviewData, err = reviewSurvey(cmd)
+
 		if err != nil {
 			return err
 		}

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -439,7 +439,7 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 
 		fmt.Fprintln(out, rendered)
 
-		fmt.Fprint(out, "s: skip, f: skip file, c: comment, q: quit ")
+		fmt.Fprint(out, "s: skip, f: skip file, v: view diff, c: comment, q: quit ")
 
 		action, err := patchSurvey()
 		if err != nil {

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -431,17 +431,17 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 
 		fmt.Fprintln(out, rendered)
 
-		fmt.Fprintln(out)
-
-		fmt.Fprintln(out, "s: skip, f: skip file, c: comment, u: suggest, q: quit")
+		fmt.Fprint(out, "s: skip, f: skip file, c: comment, u: suggest, q: quit ")
 
 		action, err := patchSurvey()
 		if err != nil {
 			return nil, err
 		}
 
-		fmt.Fprintf(out, "GOT ACTION %d\n", action)
-
+		if action == HunkActionQuit {
+			fmt.Fprintln(out, "Quitting.")
+			return nil, nil
+		}
 	}
 
 	fmt.Fprintln(out)
@@ -478,9 +478,20 @@ func patchSurvey() (HunkAction, error) {
 		if err != nil {
 			return -1, err
 		}
-		fmt.Println(r)
-		break
-
+		switch {
+		case r == 's':
+			return HunkActionSkip, nil
+		case r == 'f':
+			return HunkActionSkipFile, nil
+		case r == 'c':
+			return HunkActionComment, nil
+		case r == 'u':
+			return HunkActionSuggest, nil
+		case r == 'q':
+			return HunkActionQuit, nil
+		case r == sterm.KeyInterrupt:
+			return -1, sterm.InterruptErr
+		}
 	}
 
 	return -1, nil

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -313,7 +313,7 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
  
  	prReviewCmd.Flags().BoolP("approve", "a", false, "Approve pull request")
  	prReviewCmd.Flags().BoolP("request-changes", "r", false, "Request changes on a pull request")
-		`},
+		`, ""},
 		{"diff --git a/command/pr_review_test.go b/command/pr_review_test.go",
 			`@@ -8,6 +8,7 @@ import (
  )
@@ -323,7 +323,7 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
  	initBlankContext("", "OWNER/REPO", "master")
  	http := initFakeHTTP()
  	for _, cmd := range []string{
-		`},
+		`, ""},
 		{"diff --git a/command/pr_review_test.go b/command/pr_review_test.go",
 			`@@ -22,6 +23,7 @@ func TestPRReview_validation(t *testing.T) {
  }
@@ -333,7 +333,7 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
  	initBlankContext("", "OWNER/REPO", "master")
  	http := initFakeHTTP()
  	http.StubRepoResponse("OWNER", "REPO")
-		`},
+		`, ""},
 		{"diff --git a/command/pr_review_test.go b/command/pr_review_test.go",
 			`@@ -67,6 +69,7 @@ func TestPRReview_url_arg(t *testing.T) {
  }
@@ -343,7 +343,7 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
  	initBlankContext("", "OWNER/REPO", "master")
  	http := initFakeHTTP()
  	http.StubRepoResponse("OWNER", "REPO")
-		`},
+		`, ""},
 		{"diff --git a/command/pr_review_test.go b/command/pr_review_test.go",
 			`@@ -112,6 +115,7 @@ func TestPRReview_number_arg(t *testing.T) {
  }
@@ -353,7 +353,7 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
  	initBlankContext("", "OWNER/REPO", "feature")
  	http := initFakeHTTP()
  	http.StubRepoResponse("OWNER", "REPO")
-		`},
+		`, ""},
 		{"diff --git a/command/pr_review_test.go b/command/pr_review_test.go",
 			`@@ -147,6 +151,7 @@ func TestPRReview_no_arg(t *testing.T) {
  }
@@ -362,7 +362,8 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 +	t.Skip("skipping until release is done")
  	initBlankContext("", "OWNER/REPO", "master")
  	http := initFakeHTTP()
- 	http.StubRepoResponse("OWNER", "REPO")`},
+ 	http.StubRepoResponse("OWNER", "REPO")`,
+			""},
 
 		{"diff --git a/command/pr_review_test.go b/command/pr_review_test.go",
 			`@@ -156,6 +161,7 @@ func TestPRReview_blank_comment(t *testing.T) {
@@ -375,7 +376,7 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
  	http.StubRepoResponse("OWNER", "REPO")
  }
 
-		`},
+		`, ""},
 
 		{"diff --git a/command/pr_review_test.go b/command/pr_review_test.go",
 			`@@ -165,6 +171,7 @@ func TestPRReview_blank_request_changes(t *testing.T) {
@@ -384,7 +385,7 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
  	type c struct {
  		Cmd           string
  		ExpectedEvent string
-		`},
+		`, ""},
 
 		{"diff --git a/command/root.go b/command/root.go",
 			`@@ -271,7 +271,7 @@ func rootHelpFunc(command *cobra.Command, s []string) {
@@ -395,7 +396,7 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 +		} else if c != creditsCmd {
  			additionalCommands = append(additionalCommands, s)
  		}
- 	}`},
+ 	}`, ""},
 	}
 	out := colorableOut(cmd)
 
@@ -422,7 +423,16 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 		return nil, nil
 	}
 
+	skipFile := false
+	var skipping string
 	for _, hunk := range hunks {
+		if skipFile {
+			if skipping == hunk.File {
+				continue
+			} else {
+				skipFile = false
+			}
+		}
 		fmt.Fprintf(out, "%s\n\n", utils.Bold(hunk.File))
 		md := fmt.Sprintf("```diff\n%s\n```", hunk.Diff)
 		rendered, err := utils.RenderMarkdown(md)
@@ -437,6 +447,11 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 		action, err := patchSurvey()
 		if err != nil {
 			return nil, err
+		}
+
+		if action == HunkActionSkipFile {
+			skipFile = true
+			skipping = hunk.File
 		}
 
 		if action == HunkActionComment {

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -153,7 +153,6 @@ func prReview(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		// for now just return
-		fmt.Fprintln(out, "done with patch mode, stopping here for now")
 		return nil
 	}
 
@@ -429,7 +428,7 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 				skipFile = false
 			}
 		}
-		fmt.Fprintf(out, "%s\n\n", utils.Bold(hunk.File))
+		fmt.Fprintf(out, "\n%s\n", utils.Bold(hunk.File))
 		md := fmt.Sprintf("```diff\n%s\n```", hunk.Diff)
 		rendered, err := utils.RenderMarkdown(md)
 		if err != nil {
@@ -497,8 +496,8 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 		}
 	}
 
-	// TODO commentsMade ending up at 0, debug the string helpers.
-	fmt.Fprintf(out, "\nWrapping up a review with %s comments.\n", utils.Bold(fmt.Sprintf("%d", commentsMade)))
+	fmt.Fprintf(out, "\n\nWrapping up a review with %s.\n",
+		utils.Bold(utils.Pluralize(commentsMade, "comment")))
 
 	reviewData, err := reviewSurvey(cmd)
 
@@ -573,6 +572,6 @@ func trimBody(body string) string {
 
 func isBlank(body string) bool {
 	fmt.Println(body)
-	r := regexp.MustCompile(`(?s)\w*`)
+	r := regexp.MustCompile(`(?s)^\s*$`)
 	return r.MatchString(body)
 }

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -438,6 +438,10 @@ func patchReview(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 			return nil, err
 		}
 
+		if action == HunkActionComment {
+			// TODO collect via survey's editor widget. it's bootleg but does a lot for us.
+		}
+
 		if action == HunkActionQuit {
 			fmt.Fprintln(out, "Quitting.")
 			return nil, nil


### PR DESCRIPTION
NARRATED VIDEO DEMO: https://www.youtube.com/watch?v=LFeuKxolMUg

This PR is a prototype of a "patch mode" approach to reviewing. You can `gh pr checkout` this and
run it with `gh pr review -p 123`. It will never try to post an actual review.

What functions in the prototype:

- making comments
- making an overall review decision
- skipping a change
- skipping a file

what is mocked but not functioning:

- saving in progress review
- displaying a diff on demand

what is not mocked but part of the idea:

- suggestions
- resuming an in progress review
- canceling an in progress review


I'm curious if people have any feedback, up to and including whether or not this is worth fleshing
out more and putting on a roadmap.

(It hopefully goes without saying that the code is a nightmare and very little of it should ever actually be merged)
