### PR TITLE
pass apiClient to determineBaseRepo

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -106,7 +106,7 @@ func issueList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := determineBaseRepo(cmd, ctx)
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func issueStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := determineBaseRepo(cmd, ctx)
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 	if err != nil {
 		return err
 	}
@@ -224,7 +224,7 @@ func issueView(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := determineBaseRepo(cmd, ctx)
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 	if err != nil {
 		return err
 	}
@@ -340,9 +340,13 @@ func issueFromArg(apiClient *api.Client, baseRepo ghrepo.Interface, arg string) 
 
 func issueCreate(cmd *cobra.Command, args []string) error {
 	ctx := contextForCommand(cmd)
+	apiClient, err := apiClientForContext(ctx)
+	if err != nil {
+		return err
+	}
 
 	// NB no auto forking like over in pr create
-	baseRepo, err := determineBaseRepo(cmd, ctx)
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 	if err != nil {
 		return err
 	}
@@ -405,11 +409,6 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(colorableErr(cmd), "\nCreating issue in %s\n\n", ghrepo.FullName(baseRepo))
-
-	apiClient, err := apiClientForContext(ctx)
-	if err != nil {
-		return err
-	}
 
 	repo, err := api.GitHubRepo(apiClient, baseRepo)
 	if err != nil {
@@ -654,7 +653,7 @@ func issueClose(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := determineBaseRepo(cmd, ctx)
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 	if err != nil {
 		return err
 	}
@@ -689,7 +688,7 @@ func issueReopen(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := determineBaseRepo(cmd, ctx)
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 	if err != nil {
 		return err
 	}

--- a/command/pr.go
+++ b/command/pr.go
@@ -104,7 +104,7 @@ func prStatus(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := determineBaseRepo(cmd, ctx)
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func prList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := determineBaseRepo(cmd, ctx)
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 	if err != nil {
 		return err
 	}
@@ -307,7 +307,7 @@ func prView(cmd *cobra.Command, args []string) error {
 	}
 
 	if baseRepo == nil {
-		baseRepo, err = determineBaseRepo(cmd, ctx)
+		baseRepo, err = determineBaseRepo(apiClient, cmd, ctx)
 		if err != nil {
 			return err
 		}
@@ -366,7 +366,7 @@ func prClose(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := determineBaseRepo(cmd, ctx)
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 	if err != nil {
 		return err
 	}
@@ -401,7 +401,7 @@ func prReopen(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := determineBaseRepo(cmd, ctx)
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 	if err != nil {
 		return err
 	}
@@ -438,7 +438,7 @@ func prMerge(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	baseRepo, err := determineBaseRepo(cmd, ctx)
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 	if err != nil {
 		return err
 	}

--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -34,7 +34,7 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 	}
 
 	if baseRepo == nil {
-		baseRepo, err = determineBaseRepo(cmd, ctx)
+		baseRepo, err = determineBaseRepo(apiClient, cmd, ctx)
 		if err != nil {
 			return err
 		}

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -86,14 +86,14 @@ func processReviewOpt(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 
 func prReview(cmd *cobra.Command, args []string) error {
 	ctx := contextForCommand(cmd)
-	baseRepo, err := determineBaseRepo(cmd, ctx)
-	if err != nil {
-		return fmt.Errorf("could not determine base repo: %w", err)
-	}
-
 	apiClient, err := apiClientForContext(ctx)
 	if err != nil {
 		return err
+	}
+
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
+	if err != nil {
+		return fmt.Errorf("could not determine base repo: %w", err)
 	}
 
 	var prNum int

--- a/command/repo.go
+++ b/command/repo.go
@@ -336,7 +336,7 @@ func repoFork(cmd *cobra.Command, args []string) error {
 	var repoToFork ghrepo.Interface
 	inParent := false // whether or not we're forking the repo we're currently "in"
 	if len(args) == 0 {
-		baseRepo, err := determineBaseRepo(cmd, ctx)
+		baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
 		if err != nil {
 			return fmt.Errorf("unable to determine base repository: %w", err)
 		}
@@ -487,11 +487,15 @@ var Confirm = func(prompt string, result *bool) error {
 
 func repoView(cmd *cobra.Command, args []string) error {
 	ctx := contextForCommand(cmd)
+	apiClient, err := apiClientForContext(ctx)
+	if err != nil {
+		return err
+	}
 
 	var toView ghrepo.Interface
 	if len(args) == 0 {
 		var err error
-		toView, err = determineBaseRepo(cmd, ctx)
+		toView, err = determineBaseRepo(apiClient, cmd, ctx)
 		if err != nil {
 			return err
 		}
@@ -512,10 +516,6 @@ func repoView(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	apiClient, err := apiClientForContext(ctx)
-	if err != nil {
-		return err
-	}
 	repo, err := api.GitHubRepo(apiClient, toView)
 	if err != nil {
 		return err

--- a/command/root.go
+++ b/command/root.go
@@ -216,15 +216,10 @@ func changelogURL(version string) string {
 	return url
 }
 
-func determineBaseRepo(cmd *cobra.Command, ctx context.Context) (ghrepo.Interface, error) {
+func determineBaseRepo(apiClient *api.Client, cmd *cobra.Command, ctx context.Context) (ghrepo.Interface, error) {
 	repo, err := cmd.Flags().GetString("repo")
 	if err == nil && repo != "" {
 		return ghrepo.FromFullName(repo), nil
-	}
-
-	apiClient, err := apiClientForContext(ctx)
-	if err != nil {
-		return nil, err
 	}
 
 	baseOverride, err := cmd.Flags().GetString("repo")


### PR DESCRIPTION
Fixes #914

It is Mislav's and my hypothesis that the failed reauth issue was caused by having multiple
`apiClient` instances during a command's lifetime. The second `apiClient`s are created inside of
`determineBaseRepo`; this PR changes `determineBaseRepo` to just accept a pre-existing `apiClient`.
It was only creating its own to begin with in an attempt to reduce the length of its function
signature and for no other reason.
