### PR TITLE
reenable skipping body prompt for pr/issue

### DIFF
--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -159,6 +159,7 @@ func titleBodySurvey(cmd *cobra.Command, issueState *issueMetadataState, apiClie
 	bodyQuestion := &survey.Question{
 		Name: "body",
 		Prompt: &surveyext.GhEditor{
+			BlankAllowed:  true,
 			EditorCommand: editorCommand,
 			Editor: &survey.Editor{
 				Message:       "Body",


### PR DESCRIPTION
I introduced a regression in my `pr review` work by allowing `GhEditor` to be unskippable in
instances where a body is required (namely, a comment or request changes review). I didn't go back
and explicitly re-allow blank bodies on the title/body helper that issues and prs use.
