### PR TITLE
fix and tweak for site build

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -44,6 +44,11 @@ jobs:
           token: ${{secrets.SITE_GITHUB_TOKEN}}
       - name: Publish documentation site
         if: "!contains(github.ref, '-')" # skip prereleases
+        env:
+          GIT_COMMITTER_NAME: cli automation
+          GIT_AUTHOR_NAME: cli automation
+          GIT_COMMITTER_EMAIL: noreply@github.com
+          GIT_AUTHOR_EMAIL: noreply@github.com
         run: make site-publish
       - name: Move project cards
         if: "!contains(github.ref, '-')" # skip prereleases

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test:
 .PHONY: test
 
 site:
-	git clone https://github.com/github/cli.github.com.git "$@"
+	(which gh 2>/dev/null && gh repo clone github/cli.github.com "$@") || git clone https://github.com/github/cli.github.com.git "$@"
 
 site-docs: site
 	git -C site pull

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test:
 .PHONY: test
 
 site: bin/gh
-	gh repo clone github/cli.github.com "$@"
+	bin/gh repo clone github/cli.github.com "$@"
 
 site-docs: site
 	git -C site pull

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ test:
 	go test ./...
 .PHONY: test
 
-site:
-	(which gh 2>/dev/null && gh repo clone github/cli.github.com "$@") || git clone https://github.com/github/cli.github.com.git "$@"
+site: bin/gh
+	gh repo clone github/cli.github.com "$@"
 
 site-docs: site
 	git -C site pull

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ site-docs: site
 	for f in site/manual/gh*.md; do sed -i.bak -e '/^### SEE ALSO/,$$d' "$$f"; done
 	rm -f site/manual/*.bak
 	git -C site add 'manual/gh*.md'
-	git -C site commit --author "cli automation <noreply@github.com>" -m 'update help docs' || true
+	git -C site commit -m 'update help docs' || true
 .PHONY: site-docs
 
 site-publish: site-docs
@@ -41,6 +41,6 @@ ifndef GITHUB_REF
 endif
 	sed -i.bak -E 's/(assign version = )".+"/\1"$(GITHUB_REF:refs/tags/v%=%)"/' site/index.html
 	rm -f site/index.html.bak
-	git -C site commit --author "cli automation <noreply@github.com>" -m '$(GITHUB_REF:refs/tags/v%=%)' index.html
+	git -C site commit -m '$(GITHUB_REF:refs/tags/v%=%)' index.html
 	git -C site push
 .PHONY: site-publish

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ site-docs: site
 	for f in site/manual/gh*.md; do sed -i.bak -e '/^### SEE ALSO/,$$d' "$$f"; done
 	rm -f site/manual/*.bak
 	git -C site add 'manual/gh*.md'
-	git -C site commit -m 'update help docs' || true
+	git -C site commit --author "cli automation <noreply@github.com>" -m 'update help docs' || true
 .PHONY: site-docs
 
 site-publish: site-docs
@@ -41,6 +41,6 @@ ifndef GITHUB_REF
 endif
 	sed -i.bak -E 's/(assign version = )".+"/\1"$(GITHUB_REF:refs/tags/v%=%)"/' site/index.html
 	rm -f site/index.html.bak
-	git -C site commit -m '$(GITHUB_REF:refs/tags/v%=%)' index.html
+	git -C site commit --author "cli automation <noreply@github.com>" -m '$(GITHUB_REF:refs/tags/v%=%)' index.html
 	git -C site push
 .PHONY: site-publish


### PR DESCRIPTION
Fixes #898

This PR:

- theoretically fixes building our docs site in CI by telling git what author to use when making
  commits
- does a small quality of life thing; when cloning the site repo, `gh` is used if it is available.
  this is mainly for me locally when I'd rather not have an https url used. it should have no
  effect in CI.
