### PR TITLE
pr diff

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"strings"
 
 	"github.com/shurcooL/githubv4"
@@ -199,6 +201,30 @@ func (pr *PullRequest) ChecksStatus() (summary PullRequestChecksStatus) {
 		summary.Total++
 	}
 	return
+}
+
+func (c Client) PullRequestDiff(baseRepo ghrepo.Interface, prNum int) (string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/pulls/%d",
+		ghrepo.FullName(baseRepo), prNum)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3.diff; charset=utf-8")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
 }
 
 func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, currentPRHeadRef, currentUsername string) (*PullRequestsPayload, error) {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -224,7 +225,16 @@ func (c Client) PullRequestDiff(baseRepo ghrepo.Interface, prNum int) (string, e
 		return "", err
 	}
 
-	return string(b), nil
+	if resp.StatusCode == 200 {
+		return string(b), nil
+	}
+
+	if resp.StatusCode == 404 {
+		return "", &NotFoundError{errors.New("pull request not found")}
+	}
+
+	return "", errors.New("pull request diff lookup failed")
+
 }
 
 func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, currentPRHeadRef, currentUsername string) (*PullRequestsPayload, error) {

--- a/command/pr_diff.go
+++ b/command/pr_diff.go
@@ -98,10 +98,18 @@ func prDiff(cmd *cobra.Command, args []string) error {
 	switch color {
 	case "always":
 		out = colorableOut(cmd)
-		rendered, err := utils.RenderMarkdown(fmt.Sprintf("```diff\n%s\n```", diff))
-		fmt.Fprintf(out, rendered)
-		if err != nil {
-			return fmt.Errorf("failed to colorize diff: %w", err)
+		for _, diffLine := range strings.Split(diff, "\n") {
+			output := diffLine
+			switch {
+			case bold(diffLine):
+				output = utils.Bold(diffLine)
+			case green(diffLine):
+				output = utils.Green(diffLine)
+			case red(diffLine):
+				output = utils.Red(diffLine)
+			}
+
+			fmt.Fprintln(out, output)
 		}
 	case "never":
 		out := cmd.OutOrStdout()
@@ -111,4 +119,22 @@ func prDiff(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func bold(dl string) bool {
+	prefixes := []string{"+++", "---", "diff", "index"}
+	for _, p := range prefixes {
+		if strings.HasPrefix(dl, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func red(dl string) bool {
+	return strings.HasPrefix(dl, "-")
+}
+
+func green(dl string) bool {
+	return strings.HasPrefix(dl, "+")
 }

--- a/command/pr_diff.go
+++ b/command/pr_diff.go
@@ -1,0 +1,75 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cli/cli/api"
+	"github.com/spf13/cobra"
+)
+
+var prDiffCmd = &cobra.Command{
+	Use:   "diff {<number> | <url>}",
+	Short: "View a pull request's changes.",
+	RunE:  prDiff,
+}
+
+func init() {
+	prDiffCmd.Flags().StringP("color", "c", "auto", "Whether or not to output color: {always|never|auto}")
+
+	prCmd.AddCommand(prDiffCmd)
+}
+
+func prDiff(cmd *cobra.Command, args []string) error {
+	ctx := contextForCommand(cmd)
+	apiClient, err := apiClientForContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	baseRepo, err := determineBaseRepo(apiClient, cmd, ctx)
+	if err != nil {
+		return fmt.Errorf("could not determine base repo: %w", err)
+	}
+
+	var prNum int
+	branchWithOwner := ""
+
+	if len(args) == 0 {
+		prNum, branchWithOwner, err = prSelectorForCurrentBranch(ctx, baseRepo)
+		if err != nil {
+			return fmt.Errorf("could not query for pull request for current branch: %w", err)
+		}
+	} else {
+		prArg, repo := prFromURL(args[0])
+		if repo != nil {
+			baseRepo = repo
+		} else {
+			prArg = strings.TrimPrefix(args[0], "#")
+		}
+		prNum, err = strconv.Atoi(prArg)
+		if err != nil {
+			return errors.New("could not parse pull request argument")
+		}
+	}
+
+	var pr *api.PullRequest
+	if prNum > 0 {
+		pr, err = api.PullRequestByNumber(apiClient, baseRepo, prNum)
+		if err != nil {
+			return fmt.Errorf("could not find pull request: %w", err)
+		}
+	} else {
+		pr, err = api.PullRequestForBranch(apiClient, baseRepo, "", branchWithOwner)
+		if err != nil {
+			return fmt.Errorf("could not find pull request: %w", err)
+		}
+		prNum = pr.Number
+	}
+
+	fmt.Println(pr.Title)
+
+	return nil
+}

--- a/command/pr_diff.go
+++ b/command/pr_diff.go
@@ -25,6 +25,14 @@ func init() {
 }
 
 func prDiff(cmd *cobra.Command, args []string) error {
+	color, err := cmd.Flags().GetString("color")
+	if err != nil {
+		return err
+	}
+	if !validColor(color) {
+		return fmt.Errorf("did not understand color: %q. Expected one of always, never, or auto", color)
+	}
+
 	ctx := contextForCommand(cmd)
 	apiClient, err := apiClientForContext(ctx)
 	if err != nil {
@@ -76,14 +84,6 @@ func prDiff(cmd *cobra.Command, args []string) error {
 	diff, err := apiClient.PullRequestDiff(baseRepo, prNum)
 	if err != nil {
 		return err
-	}
-
-	color, err := cmd.Flags().GetString("color")
-	if err != nil {
-		return err
-	}
-	if !validColor(color) {
-		return fmt.Errorf("did not understand color: %q. Expected one of always, never, or auto", color)
 	}
 
 	out := cmd.OutOrStdout()

--- a/command/pr_diff.go
+++ b/command/pr_diff.go
@@ -66,14 +66,8 @@ func prDiff(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	var pr *api.PullRequest
-	if prNum > 0 {
-		pr, err = api.PullRequestByNumber(apiClient, baseRepo, prNum)
-		if err != nil {
-			return fmt.Errorf("could not find pull request: %w", err)
-		}
-	} else {
-		pr, err = api.PullRequestForBranch(apiClient, baseRepo, "", branchWithOwner)
+	if prNum < 1 {
+		pr, err := api.PullRequestForBranch(apiClient, baseRepo, "", branchWithOwner)
 		if err != nil {
 			return fmt.Errorf("could not find pull request: %w", err)
 		}

--- a/command/pr_diff.go
+++ b/command/pr_diff.go
@@ -29,7 +29,7 @@ func prDiff(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if !validColor(color) {
+	if !validColorFlag(color) {
 		return fmt.Errorf("did not understand color: %q. Expected one of always, never, or auto", color)
 	}
 
@@ -101,11 +101,11 @@ func prDiff(cmd *cobra.Command, args []string) error {
 	for _, diffLine := range strings.Split(diff, "\n") {
 		output := diffLine
 		switch {
-		case bold(diffLine):
+		case isHeaderLine(diffLine):
 			output = utils.Bold(diffLine)
-		case green(diffLine):
+		case isAdditionLine(diffLine):
 			output = utils.Green(diffLine)
-		case red(diffLine):
+		case isRemovalLine(diffLine):
 			output = utils.Red(diffLine)
 		}
 
@@ -115,7 +115,7 @@ func prDiff(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func bold(dl string) bool {
+func isHeaderLine(dl string) bool {
 	prefixes := []string{"+++", "---", "diff", "index"}
 	for _, p := range prefixes {
 		if strings.HasPrefix(dl, p) {
@@ -125,14 +125,14 @@ func bold(dl string) bool {
 	return false
 }
 
-func red(dl string) bool {
-	return strings.HasPrefix(dl, "-")
-}
-
-func green(dl string) bool {
+func isAdditionLine(dl string) bool {
 	return strings.HasPrefix(dl, "+")
 }
 
-func validColor(c string) bool {
+func isRemovalLine(dl string) bool {
+	return strings.HasPrefix(dl, "-")
+}
+
+func validColorFlag(c string) bool {
 	return c == "auto" || c == "always" || c == "never"
 }

--- a/command/pr_diff.go
+++ b/command/pr_diff.go
@@ -77,7 +77,7 @@ func prDiff(cmd *cobra.Command, args []string) error {
 
 	diff, err := apiClient.PullRequestDiff(baseRepo, prNum)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not find pull request diff: %w", err)
 	}
 
 	out := cmd.OutOrStdout()

--- a/command/pr_diff_test.go
+++ b/command/pr_diff_test.go
@@ -1,0 +1,67 @@
+package command
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPRDiff_validation(t *testing.T) {
+	_, err := RunCommand("pr diff --color=doublerainbow")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	eq(t, err.Error(), `did not understand color: "doublerainbow". Expected one of always, never, or auto`)
+}
+
+func TestPRDiff(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "feature")
+	http := initFakeHTTP()
+	http.StubRepoResponse("OWNER", "REPO")
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repository": { "pullRequests": { "nodes": [
+			{ "url": "https://github.com/OWNER/REPO/pull/123",
+			  "number": 123,
+			  "id": "foobar123",
+			  "headRefName": "feature",
+				"baseRefName": "master" }
+		] } } } }`))
+	http.StubResponse(200, bytes.NewBufferString(testDiff))
+	output, err := RunCommand("pr diff")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	eq(t, testDiff, output.String())
+}
+
+const testDiff = `diff --git a/.github/workflows/releases.yml b/.github/workflows/releases.yml
+index 73974448..b7fc0154 100644
+--- a/.github/workflows/releases.yml
++++ b/.github/workflows/releases.yml
+@@ -44,6 +44,11 @@ jobs:
+           token: ${{secrets.SITE_GITHUB_TOKEN}}
+       - name: Publish documentation site
+         if: "!contains(github.ref, '-')" # skip prereleases
++        env:
++          GIT_COMMITTER_NAME: cli automation
++          GIT_AUTHOR_NAME: cli automation
++          GIT_COMMITTER_EMAIL: noreply@github.com
++          GIT_AUTHOR_EMAIL: noreply@github.com
+         run: make site-publish
+       - name: Move project cards
+         if: "!contains(github.ref, '-')" # skip prereleases
+diff --git a/Makefile b/Makefile
+index f2b4805c..3d7bd0f9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -22,8 +22,8 @@ test:
+ 	go test ./...
+ .PHONY: test
+ 
+-site:
+-	git clone https://github.com/github/cli.github.com.git "$@"
++site: bin/gh
++	bin/gh repo clone github/cli.github.com "$@"
+ 
+ site-docs: site
+ 	git -C site pull
+`


### PR DESCRIPTION
<!--
Please make sure you read our contributing guidelines at
https://github.com/cli/cli/blob/master/.github/CONTRIBUTING.md
before opening opening a pull request. Thanks!
-->

## Summary

closes #917

This is a first pass on a `gh pr diff` command. It can be invoked on the current branch's PR, a URL,
or a pr number.

It does not call out to a pager like `git diff` does.

You can control its use of color with `--color={always|never|auto}`. It won't colorize in
non-interactive settings.

![image](https://user-images.githubusercontent.com/98482/82266353-13a03300-992f-11ea-8d71-2a0995707f87.png)

