### PR TITLE
gh alias set

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -30,6 +30,16 @@ func main() {
 
 	hasDebug := os.Getenv("DEBUG") != ""
 
+	stderr := utils.NewColorable(os.Stderr)
+
+	expandedArgs, err := command.ExpandAlias(os.Args)
+	if err != nil {
+		fmt.Fprintf(stderr, "failed to process aliases:  %s\n", err)
+		os.Exit(2)
+	}
+
+	command.RootCmd.SetArgs(expandedArgs)
+
 	if cmd, err := command.RootCmd.ExecuteC(); err != nil {
 		printError(os.Stderr, err, cmd, hasDebug)
 		os.Exit(1)

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -32,10 +32,18 @@ func main() {
 
 	stderr := utils.NewColorable(os.Stderr)
 
-	expandedArgs, err := command.ExpandAlias(os.Args)
-	if err != nil {
-		fmt.Fprintf(stderr, "failed to process aliases:  %s\n", err)
-		os.Exit(2)
+	expandedArgs := []string{}
+	if len(os.Args) > 0 {
+		expandedArgs = os.Args[1:]
+	}
+
+	cmd, _, err := command.RootCmd.Traverse(expandedArgs)
+	if err != nil || cmd == command.RootCmd {
+		expandedArgs, err = command.ExpandAlias(os.Args)
+		if err != nil {
+			fmt.Fprintf(stderr, "failed to process aliases:  %s\n", err)
+			os.Exit(2)
+		}
 	}
 
 	command.RootCmd.SetArgs(expandedArgs)

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -39,10 +39,14 @@ func main() {
 
 	cmd, _, err := command.RootCmd.Traverse(expandedArgs)
 	if err != nil || cmd == command.RootCmd {
+		originalArgs := expandedArgs
 		expandedArgs, err = command.ExpandAlias(os.Args)
 		if err != nil {
 			fmt.Fprintf(stderr, "failed to process aliases:  %s\n", err)
 			os.Exit(2)
+		}
+		if hasDebug {
+			fmt.Fprintf(stderr, "%v -> %v\n", originalArgs, expandedArgs)
 		}
 	}
 

--- a/command/alias.go
+++ b/command/alias.go
@@ -27,8 +27,7 @@ var aliasSetCmd = &cobra.Command{
 	// linux in various shells against cobra 1.0; others on macos did /not/ see the same behavior.
 	DisableFlagParsing: true,
 	Short:              "Create a shortcut for a gh command",
-	Long: `
-This command lets you write your own shortcuts for running gh. They can be simple strings or accept placeholder arguments.`,
+	Long: `This command lets you write your own shortcuts for running gh. They can be simple strings or accept placeholder arguments.`,
 	Example: `
 	gh alias set pv 'pr view'
 	# gh pv -w 123 -> gh pr view -w 123.

--- a/command/alias.go
+++ b/command/alias.go
@@ -17,7 +17,6 @@ func init() {
 var aliasCmd = &cobra.Command{
 	Use:   "alias",
 	Short: "Create shortcuts for gh commands",
-	Long:  `TODO`,
 }
 
 var aliasSetCmd = &cobra.Command{
@@ -30,10 +29,8 @@ var aliasSetCmd = &cobra.Command{
 	Short:              "Create a shortcut for a gh command",
 	Long: `gh alias set <alias> <expansion>
 
-This command lets you write your own shortcuts for running gh. They can be simple strings or accept placeholder arguments.
-
-Examples:
-
+This command lets you write your own shortcuts for running gh. They can be simple strings or accept placeholder arguments.`,
+	Example: `
 	gh alias set pv 'pr view'
 	# gh pv -w 123 -> gh pr view -w 123.
 

--- a/command/alias.go
+++ b/command/alias.go
@@ -21,10 +21,10 @@ var aliasCmd = &cobra.Command{
 
 var aliasSetCmd = &cobra.Command{
 	Use: "set <alias> <expansion>",
-	// TODO HACK: even when inside of a single-quoted string, cobra was noticing and parsing any flags
+	// NB: Even when inside of a single-quoted string, cobra was noticing and parsing any flags
 	// used in an alias expansion string argument. Since this command needs no flags, I disabled their
-	// parsing. If we ever want to add flags to alias set we'll have to figure this out. I haven't
-	// checked if this is fixed in a new cobra.
+	// parsing. If we ever want to add flags to alias set we'll have to figure this out. I tested on
+	// linux in various shells against cobra 1.0; others on macos did /not/ see the same behavior.
 	DisableFlagParsing: true,
 	Short:              "Create a shortcut for a gh command",
 	Long: `

--- a/command/alias.go
+++ b/command/alias.go
@@ -12,9 +12,9 @@ import (
 // TODO
 // - [ ] DEBUG support
 // - [ ] prevent overriding existing gh command
-// - [ ] allow overwriting alias
-// - [ ] forward extra arguments
-// - [ ] allow duplication of placeholder
+// - [x] allow overwriting alias
+// - [x] forward extra arguments
+// - [x] allow duplication of placeholder
 
 func init() {
 	RootCmd.AddCommand(aliasCmd)
@@ -68,12 +68,19 @@ func aliasSet(cmd *cobra.Command, args []string) error {
 	out := colorableOut(cmd)
 	fmt.Fprintf(out, "- Adding alias for %s: %s\n", utils.Bold(alias), utils.Bold(expansion))
 
-	if aliasCfg.Exists(alias) {
-		return fmt.Errorf("alias %s already exists", alias)
-	}
-
 	if !validCommand(expansion) {
 		return fmt.Errorf("could not create alias: %s does not correspond to a gh command", utils.Bold(expansion))
+	}
+
+	successMsg := fmt.Sprintf("%s Added alias.", utils.Green("✓"))
+
+	if aliasCfg.Exists(alias) {
+		successMsg = fmt.Sprintf("%s Changed alias %s from %s to %s",
+			utils.Green("✓"),
+			utils.Bold(alias),
+			utils.Bold(aliasCfg.Get(alias)),
+			utils.Bold(expansion),
+		)
 	}
 
 	err = aliasCfg.Add(alias, expansion)
@@ -81,7 +88,7 @@ func aliasSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not create alias: %s", err)
 	}
 
-	fmt.Fprintf(out, "%s Added alias.\n", utils.Green("✓"))
+	fmt.Fprintln(out, successMsg)
 
 	return nil
 }

--- a/command/alias.go
+++ b/command/alias.go
@@ -1,0 +1,98 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cli/cli/utils"
+	"github.com/google/shlex"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(aliasCmd)
+	aliasCmd.AddCommand(aliasSetCmd)
+}
+
+var aliasCmd = &cobra.Command{
+	Use:   "alias",
+	Short: "Create shortcuts for gh commands",
+	Long:  `TODO`,
+}
+
+var aliasSetCmd = &cobra.Command{
+	Use: "set <alias> <expansion>",
+	// TODO HACK: even when inside of a single-quoted string, cobra was noticing and parsing any flags
+	// used in an alias expansion string argument. Since this command needs no flags, I disabled their
+	// parsing. If we ever want to add flags to alias set we'll have to figure this out. I haven't
+	// checked if this is fixed in a new cobra.
+	DisableFlagParsing: true,
+	Short:              "Create a shortcut for a gh command",
+	Long: `gh alias set <alias> <expansion>
+
+This command lets you write your own shortcuts for running gh. They can be simple strings or accept placeholder arguments.
+
+Examples:
+
+	gh alias set pv 'pr view'
+	# gh pv -w 123 -> gh pr view -w 123.
+
+	gh alias set bugs 'issue list --label="bugs"'
+	# gh bugs -> gh issue list --label="bugs".
+
+	gh alias set epicsBy 'issue list --author="$1" --label="epic"'
+	# gh epicsBy vilmibm -> gh issue list --author="$1" --label="epic"
+`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: aliasSet,
+}
+
+func aliasSet(cmd *cobra.Command, args []string) error {
+	ctx := contextForCommand(cmd)
+	cfg, err := ctx.Config()
+	if err != nil {
+		return err
+	}
+
+	aliasCfg, err := cfg.Aliases()
+	if err != nil {
+		return err
+	}
+
+	alias := args[0]
+	expansion := processArgs(args[1:])
+
+	out := colorableOut(cmd)
+	fmt.Fprintf(out, "- Adding alias for %s: %s\n", utils.Bold(alias), utils.Bold(expansion))
+
+	if aliasCfg.Exists(alias) {
+		return fmt.Errorf("alias %s already exists", alias)
+	}
+
+	if !validCommand(expansion) {
+		return fmt.Errorf("could not create alias: %s does not correspond to a gh command", utils.Bold(expansion))
+	}
+
+	err = aliasCfg.Add(alias, expansion)
+	if err != nil {
+		return fmt.Errorf("could not create alias: %s", err)
+	}
+
+	fmt.Fprintf(out, "%s Added alias.\n", utils.Green("✓"))
+
+	return nil
+}
+
+func validCommand(expansion string) bool {
+	split, _ := shlex.Split(expansion)
+	cmd, _, err := RootCmd.Traverse(split)
+	return err == nil && cmd != RootCmd
+}
+
+func processArgs(args []string) string {
+	if len(args) == 1 {
+		return args[0]
+	}
+
+	return strings.Join(args, " ")
+}

--- a/command/alias.go
+++ b/command/alias.go
@@ -27,8 +27,7 @@ var aliasSetCmd = &cobra.Command{
 	// checked if this is fixed in a new cobra.
 	DisableFlagParsing: true,
 	Short:              "Create a shortcut for a gh command",
-	Long: `gh alias set <alias> <expansion>
-
+	Long: `
 This command lets you write your own shortcuts for running gh. They can be simple strings or accept placeholder arguments.`,
 	Example: `
 	gh alias set pv 'pr view'

--- a/command/alias.go
+++ b/command/alias.go
@@ -9,15 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TODO
-// - [ ] DEBUG support
-// - [x] blank aliases stanza
-// - [x] give our commands precedence
-// - [x] prevent overriding existing gh command
-// - [x] allow overwriting alias
-// - [x] forward extra arguments
-// - [x] allow duplication of placeholder
-
 func init() {
 	RootCmd.AddCommand(aliasCmd)
 	aliasCmd.AddCommand(aliasSetCmd)

--- a/command/alias.go
+++ b/command/alias.go
@@ -11,6 +11,7 @@ import (
 
 // TODO
 // - [ ] DEBUG support
+// - [ ] blank aliases stanza
 // - [x] give our commands precedence
 // - [x] prevent overriding existing gh command
 // - [x] allow overwriting alias

--- a/command/alias.go
+++ b/command/alias.go
@@ -11,7 +11,7 @@ import (
 
 // TODO
 // - [ ] DEBUG support
-// - [ ] give our commands precedence
+// - [x] give our commands precedence
 // - [x] prevent overriding existing gh command
 // - [x] allow overwriting alias
 // - [x] forward extra arguments

--- a/command/alias.go
+++ b/command/alias.go
@@ -11,7 +11,7 @@ import (
 
 // TODO
 // - [ ] DEBUG support
-// - [ ] blank aliases stanza
+// - [x] blank aliases stanza
 // - [x] give our commands precedence
 // - [x] prevent overriding existing gh command
 // - [x] allow overwriting alias

--- a/command/alias.go
+++ b/command/alias.go
@@ -11,7 +11,7 @@ import (
 
 // TODO
 // - [ ] DEBUG support
-// - [ ] prevent overriding existing gh command
+// - [x] prevent overriding existing gh command
 // - [x] allow overwriting alias
 // - [x] forward extra arguments
 // - [x] allow duplication of placeholder
@@ -67,6 +67,10 @@ func aliasSet(cmd *cobra.Command, args []string) error {
 
 	out := colorableOut(cmd)
 	fmt.Fprintf(out, "- Adding alias for %s: %s\n", utils.Bold(alias), utils.Bold(expansion))
+
+	if validCommand(alias) {
+		return fmt.Errorf("could not create alias: %q is already a gh command", alias)
+	}
 
 	if !validCommand(expansion) {
 		return fmt.Errorf("could not create alias: %s does not correspond to a gh command", utils.Bold(expansion))

--- a/command/alias.go
+++ b/command/alias.go
@@ -9,6 +9,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// TODO
+// - [ ] DEBUG support
+// - [ ] prevent overriding existing gh command
+// - [ ] allow overwriting alias
+// - [ ] forward extra arguments
+// - [ ] allow duplication of placeholder
+
 func init() {
 	RootCmd.AddCommand(aliasCmd)
 	aliasCmd.AddCommand(aliasSetCmd)

--- a/command/alias.go
+++ b/command/alias.go
@@ -11,6 +11,7 @@ import (
 
 // TODO
 // - [ ] DEBUG support
+// - [ ] give our commands precedence
 // - [x] prevent overriding existing gh command
 // - [x] allow overwriting alias
 // - [x] forward extra arguments

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -35,15 +35,22 @@ hosts:
 
 	buf := bytes.NewBufferString("")
 	defer config.StubWriteConfig(buf)()
-	output, err := RunCommand("alias set co pr checkout -Rcool/repo")
+	output, err := RunCommand("alias set co pr checkout")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	test.ExpectLines(t, output.String(), "TODO")
+	test.ExpectLines(t, output.String(), "Added alias")
 
-	// TODO
+	expected := `aliases:
+    co: pr checkout
+hosts:
+    github.com:
+        user: OWNER
+        oauth_token: token123
+`
+	eq(t, buf.String(), expected)
 }
 
 func TestAliasSet_existing_alias(t *testing.T) {

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -9,6 +9,17 @@ import (
 	"github.com/cli/cli/test"
 )
 
+func TestAliasSet_gh_command(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "trunk")
+
+	_, err := RunCommand("alias set pr pr status")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	eq(t, err.Error(), `could not create alias: "pr" is already a gh command`)
+}
+
 func TestAliasSet_existing_alias(t *testing.T) {
 	cfg := `---
 hosts:

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -138,6 +138,7 @@ hosts:
 aliases:
   co: pr checkout
   il: issue list --author="$1" --label="$2"
+  ia: issue list --author="$1" --assignee="$1"
 `
 	initBlankContext(cfg, "OWNER/REPO", "trunk")
 	for _, c := range []struct {
@@ -150,6 +151,8 @@ aliases:
 		{"gh il vilmibm", nil, `not enough arguments for alias: issue list --author="vilmibm" --label="$2"`},
 		{"gh co 123", []string{"pr", "checkout", "123"}, ""},
 		{"gh il vilmibm epic", []string{"issue", "list", `--author=vilmibm`, `--label=epic`}, ""},
+		{"gh ia vilmibm", []string{"issue", "list", `--author=vilmibm`, `--assignee=vilmibm`}, ""},
+		{"gh ia $coolmoney$", []string{"issue", "list", `--author=$coolmoney$`, `--assignee=$coolmoney$`}, ""},
 		{"gh pr status", []string{"pr", "status"}, ""},
 		{"gh dne", []string{"dne"}, ""},
 		{"gh", []string{}, ""},

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -152,8 +152,15 @@ aliases:
 		{"gh pr status", []string{"pr", "status"}, ""},
 		{"gh dne", []string{"dne"}, ""},
 		{"gh", []string{}, ""},
+		{"", []string{}, ""},
 	} {
-		out, err := ExpandAlias(strings.Split(c.Args, " "))
+		args := []string{}
+		if c.Args != "" {
+			args = strings.Split(c.Args, " ")
+		}
+
+		out, err := ExpandAlias(args)
+
 		if err == nil && c.Err != "" {
 			t.Errorf("expected error %s for %s", c.Err, c.Args)
 			continue

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -20,13 +20,13 @@ aliases:
 `
 	initBlankContext(cfg, "OWNER/REPO", "trunk")
 
-	_, err := RunCommand("alias set co pr checkout")
+	output, err := RunCommand("alias set co pr checkout -Rcool/repo")
 
-	if err == nil {
-		t.Fatal("expected error")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
 	}
 
-	eq(t, err.Error(), "alias co already exists")
+	test.ExpectLines(t, output.String(), "Changed alias co from pr checkout to pr checkout -Rcool/repo")
 }
 
 func TestAliasSet_arg_processing(t *testing.T) {

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -12,6 +12,9 @@ import (
 func TestAliasSet_gh_command(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "trunk")
 
+	buf := bytes.NewBufferString("")
+	defer config.StubWriteConfig(buf)()
+
 	_, err := RunCommand("alias set pr pr status")
 	if err == nil {
 		t.Fatal("expected error")
@@ -31,6 +34,8 @@ aliases:
 `
 	initBlankContext(cfg, "OWNER/REPO", "trunk")
 
+	buf := bytes.NewBufferString("")
+	defer config.StubWriteConfig(buf)()
 	output, err := RunCommand("alias set co pr checkout -Rcool/repo")
 
 	if err != nil {

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -1,0 +1,179 @@
+package command
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/test"
+)
+
+func TestAliasSet_existing_alias(t *testing.T) {
+	cfg := `---
+hosts:
+  github.com:
+    user: OWNER
+    oauth_token: token123
+aliases:
+  co: pr checkout
+`
+	initBlankContext(cfg, "OWNER/REPO", "trunk")
+
+	_, err := RunCommand("alias set co pr checkout")
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	eq(t, err.Error(), "alias co already exists")
+}
+
+func TestAliasSet_arg_processing(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "trunk")
+	cases := []struct {
+		Cmd                string
+		ExpectedOutputLine string
+		ExpectedConfigLine string
+	}{
+		{"alias set co pr checkout", "- Adding alias for co: pr checkout", "co: pr checkout"},
+
+		{`alias set il "issue list"`, "- Adding alias for il: issue list", "il: issue list"},
+
+		{`alias set iz 'issue list'`, "- Adding alias for iz: issue list", "iz: issue list"},
+
+		{`alias set iy issue list --author=\$1 --label=\$2`,
+			`- Adding alias for iy: issue list --author=\$1 --label=\$2`,
+			`iy: issue list --author=\$1 --label=\$2`},
+
+		{`alias set ii 'issue list --author="$1" --label="$2"'`,
+			`- Adding alias for ii: issue list --author="\$1" --label="\$2"`,
+			`ii: issue list --author="\$1" --label="\$2"`},
+
+		{`alias set ix issue list --author='$1' --label='$2'`,
+			`- Adding alias for ix: issue list --author=\$1 --label=\$2`,
+			`ix: issue list --author=\$1 --label=\$2`},
+	}
+
+	var buf *bytes.Buffer
+	for _, c := range cases {
+		buf = bytes.NewBufferString("")
+		defer config.StubWriteConfig(buf)()
+		output, err := RunCommand(c.Cmd)
+		if err != nil {
+			t.Fatalf("got unexpected error running %s: %s", c.Cmd, err)
+		}
+
+		test.ExpectLines(t, output.String(), c.ExpectedOutputLine)
+		test.ExpectLines(t, buf.String(), c.ExpectedConfigLine)
+	}
+}
+
+func TestAliasSet_init_alias_cfg(t *testing.T) {
+	cfg := `---
+hosts:
+  github.com:
+    user: OWNER
+    oauth_token: token123
+`
+	initBlankContext(cfg, "OWNER/REPO", "trunk")
+
+	buf := bytes.NewBufferString("")
+	defer config.StubWriteConfig(buf)()
+
+	output, err := RunCommand("alias set diff pr diff")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	expected := `hosts:
+    github.com:
+        user: OWNER
+        oauth_token: token123
+aliases:
+    diff: pr diff
+`
+
+	test.ExpectLines(t, output.String(), "Adding alias for diff: pr diff", "Added alias.")
+	eq(t, buf.String(), expected)
+}
+
+func TestAliasSet_existing_aliases(t *testing.T) {
+	cfg := `---
+hosts:
+  github.com:
+    user: OWNER
+    oauth_token: token123
+aliases:
+    foo: bar
+`
+	initBlankContext(cfg, "OWNER/REPO", "trunk")
+
+	buf := bytes.NewBufferString("")
+	defer config.StubWriteConfig(buf)()
+
+	output, err := RunCommand("alias set view pr view")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	expected := `hosts:
+    github.com:
+        user: OWNER
+        oauth_token: token123
+aliases:
+    foo: bar
+    view: pr view
+`
+
+	test.ExpectLines(t, output.String(), "Adding alias for view: pr view", "Added alias.")
+	eq(t, buf.String(), expected)
+
+}
+
+func TestExpandAlias(t *testing.T) {
+	cfg := `---
+hosts:
+  github.com:
+    user: OWNER
+    oauth_token: token123
+aliases:
+  co: pr checkout
+  il: issue list --author="$1" --label="$2"
+`
+	initBlankContext(cfg, "OWNER/REPO", "trunk")
+	for _, c := range []struct {
+		Args         string
+		ExpectedArgs []string
+		Err          string
+	}{
+		{"gh co", []string{"pr", "checkout"}, ""},
+		{"gh il", nil, `not enough arguments for alias: issue list --author="$1" --label="$2"`},
+		{"gh il vilmibm", nil, `not enough arguments for alias: issue list --author="vilmibm" --label="$2"`},
+		{"gh il vilmibm epic", []string{"issue", "list", `--author=vilmibm`, `--label=epic`}, ""},
+		{"gh pr status", []string{"pr", "status"}, ""},
+		{"gh dne", []string{"dne"}, ""},
+		{"gh", []string{}, ""},
+	} {
+		out, err := ExpandAlias(strings.Split(c.Args, " "))
+		if err == nil && c.Err != "" {
+			t.Errorf("expected error %s for %s", c.Err, c.Args)
+			continue
+		}
+
+		if err != nil {
+			eq(t, err.Error(), c.Err)
+			continue
+		}
+
+		eq(t, out, c.ExpectedArgs)
+	}
+}
+
+func TestAliasSet_invalid_command(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "trunk")
+	_, err := RunCommand("alias set co pe checkout")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	eq(t, err.Error(), "could not create alias: pe checkout does not correspond to a gh command")
+}

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -200,6 +200,7 @@ aliases:
 		{"gh ia vilmibm", []string{"issue", "list", `--author=vilmibm`, `--assignee=vilmibm`}, ""},
 		{"gh ia $coolmoney$", []string{"issue", "list", `--author=$coolmoney$`, `--assignee=$coolmoney$`}, ""},
 		{"gh pr status", []string{"pr", "status"}, ""},
+		{"gh il vilmibm epic -R vilmibm/testing", []string{"issue", "list", "--author=vilmibm", "--label=epic", "-R", "vilmibm/testing"}, ""},
 		{"gh dne", []string{"dne"}, ""},
 		{"gh", []string{}, ""},
 		{"", []string{}, ""},

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -75,6 +75,23 @@ aliases:
 	test.ExpectLines(t, output.String(), "Changed alias co from pr checkout to pr checkout -Rcool/repo")
 }
 
+func TestAliasSet_space_args(t *testing.T) {
+	initBlankContext("", "OWNER/REPO", "trunk")
+
+	buf := bytes.NewBufferString("")
+	defer config.StubWriteConfig(buf)()
+
+	output, err := RunCommand(`alias set il issue list -l 'cool story'`)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	test.ExpectLines(t, output.String(), `Adding alias for il: issue list -l "cool story"`)
+
+	test.ExpectLines(t, buf.String(), `il: issue list -l "cool story"`)
+}
+
 func TestAliasSet_arg_processing(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "trunk")
 	cases := []struct {
@@ -93,8 +110,8 @@ func TestAliasSet_arg_processing(t *testing.T) {
 			`iy: issue list --author=\$1 --label=\$2`},
 
 		{`alias set ii 'issue list --author="$1" --label="$2"'`,
-			`- Adding alias for ii: issue list --author="\$1" --label="\$2"`,
-			`ii: issue list --author="\$1" --label="\$2"`},
+			`- Adding alias for ii: issue list --author=\$1 --label=\$2`,
+			`ii: issue list --author=\$1 --label=\$2`},
 
 		{`alias set ix issue list --author='$1' --label='$2'`,
 			`- Adding alias for ix: issue list --author=\$1 --label=\$2`,

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -23,6 +23,29 @@ func TestAliasSet_gh_command(t *testing.T) {
 	eq(t, err.Error(), `could not create alias: "pr" is already a gh command`)
 }
 
+func TestAliasSet_empty_aliases(t *testing.T) {
+	cfg := `---
+aliases:
+hosts:
+  github.com:
+    user: OWNER
+    oauth_token: token123
+`
+	initBlankContext(cfg, "OWNER/REPO", "trunk")
+
+	buf := bytes.NewBufferString("")
+	defer config.StubWriteConfig(buf)()
+	output, err := RunCommand("alias set co pr checkout -Rcool/repo")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	test.ExpectLines(t, output.String(), "TODO")
+
+	// TODO
+}
+
 func TestAliasSet_existing_alias(t *testing.T) {
 	cfg := `---
 hosts:

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -148,6 +148,7 @@ aliases:
 		{"gh co", []string{"pr", "checkout"}, ""},
 		{"gh il", nil, `not enough arguments for alias: issue list --author="$1" --label="$2"`},
 		{"gh il vilmibm", nil, `not enough arguments for alias: issue list --author="vilmibm" --label="$2"`},
+		{"gh co 123", []string{"pr", "checkout", "123"}, ""},
 		{"gh il vilmibm epic", []string{"issue", "list", `--author=vilmibm`, `--label=epic`}, ""},
 		{"gh pr status", []string{"pr", "status"}, ""},
 		{"gh dne", []string{"dne"}, ""},

--- a/command/root.go
+++ b/command/root.go
@@ -490,7 +490,8 @@ func ExpandAlias(args []string) ([]string, error) {
 				expansion = strings.ReplaceAll(expansion, fmt.Sprintf("$%d", i+1), a)
 			}
 		}
-		if strings.Contains(expansion, "$") {
+		lingeringRE := regexp.MustCompile(`\$\d`)
+		if lingeringRE.MatchString(expansion) {
 			return empty, fmt.Errorf("not enough arguments for alias: %s", expansion)
 		}
 		return shlex.Split(expansion)

--- a/command/root.go
+++ b/command/root.go
@@ -482,7 +482,7 @@ func ExpandAlias(args []string) ([]string, error) {
 	}
 
 	if aliases.Exists(args[1]) {
-		extraArgs  := []string{}
+		extraArgs := []string{}
 		expansion := aliases.Get(args[1])
 		for i, a := range args[2:] {
 			if !strings.Contains(expansion, "$") {

--- a/command/root.go
+++ b/command/root.go
@@ -465,21 +465,20 @@ func determineEditor(cmd *cobra.Command) (string, error) {
 }
 
 func ExpandAlias(args []string) ([]string, error) {
-	// TODO i don't love that context is being init'd twice. My reading of the code is that it is
-	// idempotent and okay but I don't know if that's ok to depend on.
-	if len(args) == 1 {
+	empty := []string{}
+	if len(args) < 2 {
 		// the command is lacking a subcommand
-		return []string{}, nil
+		return empty, nil
 	}
 
 	ctx := initContext()
 	cfg, err := ctx.Config()
 	if err != nil {
-		return []string{}, err
+		return empty, err
 	}
 	aliases, err := cfg.Aliases()
 	if err != nil {
-		return []string{}, err
+		return empty, err
 	}
 
 	if aliases.Exists(args[1]) {
@@ -489,7 +488,7 @@ func ExpandAlias(args []string) ([]string, error) {
 				expansion = strings.Replace(expansion, fmt.Sprintf("$%d", i+1), a, 1)
 			}
 			if strings.Contains(expansion, "$") {
-				return []string{}, fmt.Errorf("not enough arguments for alias: %s", expansion)
+				return empty, fmt.Errorf("not enough arguments for alias: %s", expansion)
 			}
 		}
 		return shlex.Split(expansion)

--- a/command/root.go
+++ b/command/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
 	"github.com/cli/cli/utils"
+	"github.com/google/shlex"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -461,4 +462,38 @@ func determineEditor(cmd *cobra.Command) (string, error) {
 	}
 
 	return editorCommand, nil
+}
+
+func ExpandAlias(args []string) ([]string, error) {
+	// TODO i don't love that context is being init'd twice. My reading of the code is that it is
+	// idempotent and okay but I don't know if that's ok to depend on.
+	if len(args) == 1 {
+		// the command is lacking a subcommand
+		return []string{}, nil
+	}
+
+	ctx := initContext()
+	cfg, err := ctx.Config()
+	if err != nil {
+		return []string{}, err
+	}
+	aliases, err := cfg.Aliases()
+	if err != nil {
+		return []string{}, err
+	}
+
+	if aliases.Exists(args[1]) {
+		expansion := aliases.Get(args[1])
+		if strings.Contains(expansion, "$") {
+			for i, a := range args[2:] {
+				expansion = strings.Replace(expansion, fmt.Sprintf("$%d", i+1), a, 1)
+			}
+			if strings.Contains(expansion, "$") {
+				return []string{}, fmt.Errorf("not enough arguments for alias: %s", expansion)
+			}
+		}
+		return shlex.Split(expansion)
+	}
+
+	return args[1:], nil
 }

--- a/command/root.go
+++ b/command/root.go
@@ -482,10 +482,11 @@ func ExpandAlias(args []string) ([]string, error) {
 	}
 
 	if aliases.Exists(args[1]) {
+		extraArgs  := []string{}
 		expansion := aliases.Get(args[1])
 		for i, a := range args[2:] {
 			if !strings.Contains(expansion, "$") {
-				expansion += " " + a
+				extraArgs = append(extraArgs, a)
 			} else {
 				expansion = strings.ReplaceAll(expansion, fmt.Sprintf("$%d", i+1), a)
 			}
@@ -494,7 +495,15 @@ func ExpandAlias(args []string) ([]string, error) {
 		if lingeringRE.MatchString(expansion) {
 			return empty, fmt.Errorf("not enough arguments for alias: %s", expansion)
 		}
-		return shlex.Split(expansion)
+
+		newArgs, err := shlex.Split(expansion)
+		if err != nil {
+			return nil, err
+		}
+
+		newArgs = append(newArgs, extraArgs...)
+
+		return newArgs, nil
 	}
 
 	return args[1:], nil

--- a/command/root.go
+++ b/command/root.go
@@ -483,13 +483,15 @@ func ExpandAlias(args []string) ([]string, error) {
 
 	if aliases.Exists(args[1]) {
 		expansion := aliases.Get(args[1])
+		for i, a := range args[2:] {
+			if !strings.Contains(expansion, "$") {
+				expansion += " " + a
+			} else {
+				expansion = strings.ReplaceAll(expansion, fmt.Sprintf("$%d", i+1), a)
+			}
+		}
 		if strings.Contains(expansion, "$") {
-			for i, a := range args[2:] {
-				expansion = strings.Replace(expansion, fmt.Sprintf("$%d", i+1), a, 1)
-			}
-			if strings.Contains(expansion, "$") {
-				return empty, fmt.Errorf("not enough arguments for alias: %s", expansion)
-			}
+			return empty, fmt.Errorf("not enough arguments for alias: %s", expansion)
 		}
 		return shlex.Split(expansion)
 	}

--- a/internal/config/alias_config.go
+++ b/internal/config/alias_config.go
@@ -1,10 +1,7 @@
 package config
 
 import (
-	"errors"
 	"fmt"
-
-	"gopkg.in/yaml.v3"
 )
 
 type AliasConfig struct {
@@ -28,44 +25,6 @@ func (a *AliasConfig) Get(alias string) string {
 }
 
 func (a *AliasConfig) Add(alias, expansion string) error {
-	if a.Root == nil {
-		// TODO awful hack bad type conversion i'm sorry. this is to support an empty aliases key and
-		// ought to be generalized into ConfigMap or fileConfig (via Config interface) itself.
-		entry, err := a.Parent.(*fileConfig).FindEntry("aliases")
-
-		var notFound *NotFoundError
-
-		if err != nil && !errors.As(err, &notFound) {
-			return err
-		}
-		valueNode := &yaml.Node{
-			Kind:  yaml.MappingNode,
-			Value: "",
-		}
-
-		a.Root = valueNode
-		if errors.As(err, &notFound) {
-			// No aliases: key; just append new aliases key and empty map to end
-			keyNode := &yaml.Node{
-				Kind:  yaml.ScalarNode,
-				Value: "aliases",
-			}
-			a.Parent.Root().Content = append(a.Parent.Root().Content, keyNode, valueNode)
-		} else {
-			// Empty aliases; inject new value node after existing aliases key
-			newContent := []*yaml.Node{}
-			for i := 0; i < len(a.Parent.Root().Content); i++ {
-				if i == entry.Index {
-					newContent = append(newContent, entry.KeyNode, valueNode)
-					i++
-				} else {
-					newContent = append(newContent, a.Parent.Root().Content[i])
-				}
-			}
-			a.Parent.Root().Content = newContent
-		}
-	}
-
 	err := a.SetStringValue(alias, expansion)
 	if err != nil {
 		return fmt.Errorf("failed to update config: %w", err)

--- a/internal/config/alias_config.go
+++ b/internal/config/alias_config.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+type AliasConfig struct {
+	ConfigMap
+	Parent Config
+}
+
+// TODO at what point should the alias top level be added? Lazily on first write, I think;
+// but then we aren't initializing the default aliases that we want. also want to ensure that we
+// don't re-add the default aliases if people delete them.
+//
+// I think I'm not going to worry about it for now; config setup will add the aliases and existing
+// users can take some step later on to add them if they want them. we'll otherwise lazily create
+// the aliases: section on first write.
+
+func (a *AliasConfig) Exists(alias string) bool {
+	if a.Empty() {
+		return false
+	}
+	value, _ := a.GetStringValue(alias)
+
+	return value != ""
+}
+
+func (a *AliasConfig) Get(alias string) string {
+	value, _ := a.GetStringValue(alias)
+
+	return value
+}
+
+func (a *AliasConfig) Add(alias, expansion string) error {
+	if a.Root == nil {
+		// then we don't actually have an aliases stanza in the config yet.
+		keyNode := &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: "aliases",
+		}
+		valueNode := &yaml.Node{
+			Kind:  yaml.MappingNode,
+			Value: "",
+		}
+
+		a.Root = valueNode
+		a.Parent.Root().Content = append(a.Parent.Root().Content, keyNode, valueNode)
+	}
+
+	err := a.SetStringValue(alias, expansion)
+	if err != nil {
+		return fmt.Errorf("failed to update config: %w", err)
+	}
+
+	err = a.Parent.Write()
+	if err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	return nil
+}
+
+func (a *AliasConfig) Delete(alias string) error {
+	// TODO when we get to gh alias delete
+	return nil
+}

--- a/internal/config/alias_config.go
+++ b/internal/config/alias_config.go
@@ -30,7 +30,7 @@ func (a *AliasConfig) Get(alias string) string {
 func (a *AliasConfig) Add(alias, expansion string) error {
 	if a.Root == nil {
 		// TODO awful hack bad type conversion i'm sorry
-		entry, err := a.Parent.(*fileConfig).FindEntryPrime("aliases")
+		entry, err := a.Parent.(*fileConfig).FindEntry("aliases")
 
 		var notFound *NotFoundError
 
@@ -54,9 +54,6 @@ func (a *AliasConfig) Add(alias, expansion string) error {
 			// Empty aliases; inject new value node after existing aliases key
 			newContent := []*yaml.Node{}
 			for i := 0; i < len(a.Parent.Root().Content); i++ {
-				node := a.Parent.Root().Content[i]
-				if i == entry.Index {
-				}
 				if i == entry.Index {
 					newContent = append(newContent, entry.KeyNode, valueNode)
 					i++

--- a/internal/config/alias_config.go
+++ b/internal/config/alias_config.go
@@ -29,7 +29,8 @@ func (a *AliasConfig) Get(alias string) string {
 
 func (a *AliasConfig) Add(alias, expansion string) error {
 	if a.Root == nil {
-		// TODO awful hack bad type conversion i'm sorry
+		// TODO awful hack bad type conversion i'm sorry. this is to support an empty aliases key and
+		// ought to be generalized into ConfigMap or fileConfig (via Config interface) itself.
 		entry, err := a.Parent.(*fileConfig).FindEntry("aliases")
 
 		var notFound *NotFoundError

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -12,9 +12,11 @@ const defaultGitProtocol = "https"
 
 // This interface describes interacting with some persistent configuration for gh.
 type Config interface {
+	Root() *yaml.Node
 	Hosts() ([]*HostConfig, error)
 	Get(string, string) (string, error)
 	Set(string, string, string) error
+	Aliases() (*AliasConfig, error)
 	Write() error
 }
 
@@ -32,6 +34,10 @@ type HostConfig struct {
 // comments that were present when the yaml waas parsed.
 type ConfigMap struct {
 	Root *yaml.Node
+}
+
+func (cm *ConfigMap) Empty() bool {
+	return cm.Root == nil || len(cm.Root.Content) == 0
 }
 
 func (cm *ConfigMap) GetStringValue(key string) (string, error) {
@@ -94,6 +100,10 @@ type fileConfig struct {
 	ConfigMap
 	documentRoot *yaml.Node
 	hosts        []*HostConfig
+}
+
+func (c *fileConfig) Root() *yaml.Node {
+	return c.ConfigMap.Root
 }
 
 func (c *fileConfig) Get(hostname, key string) (string, error) {
@@ -165,6 +175,35 @@ func (c *fileConfig) Write() error {
 	}
 
 	return WriteConfigFile(ConfigFile(), marshalled)
+}
+
+func (c *fileConfig) Aliases() (*AliasConfig, error) {
+	_, aliasesEntry, err := c.FindEntry("aliases")
+	var nfe *NotFoundError
+	if err != nil && errors.As(err, &nfe) {
+		// TODO does this make sense at all? want to simulate existing but empty key.
+		return &AliasConfig{Parent: c}, nil
+	}
+
+	aliasConfig, err := c.parseAliasConfig(aliasesEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	return aliasConfig, nil
+}
+
+func (c *fileConfig) parseAliasConfig(aliasesEntry *yaml.Node) (*AliasConfig, error) {
+	if aliasesEntry.Kind != yaml.MappingNode {
+		return nil, errors.New("expected aliases to be a map")
+	}
+
+	aliasConfig := AliasConfig{
+		Parent:    c,
+		ConfigMap: ConfigMap{Root: aliasesEntry},
+	}
+
+	return &aliasConfig, nil
 }
 
 func (c *fileConfig) Hosts() ([]*HostConfig, error) {

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -12,7 +12,6 @@ const defaultGitProtocol = "https"
 
 // This interface describes interacting with some persistent configuration for gh.
 type Config interface {
-	Root() *yaml.Node
 	Hosts() ([]*HostConfig, error)
 	Get(string, string) (string, error)
 	Set(string, string, string) error


### PR DESCRIPTION
This PR adds `gh alias set`.

## what this PR does

- allows creating aliases, including ones with placeholder arguments (e.g. `$1`)
- validates that you can't set an alias for a non-existent command
- adds a new top level `aliases` section to our config which is created on first use of `alias set`

## what this PR doesn't do

- allow for composition of commands (see #941 )
- allow for deleting, listing, importing, nor exporting of aliases (see #936)

## considerations

I did two things I'm nervous about in this PR.

0. modified `main.go` to initialize a `Context`, check the config, and rewrite `argv` if an alias is found.
1. disabled flag parsing for `alias set`. I encountered what I think is a bug where cobra would treat flags inside of single quoted strings as something it should parse (eg `alias set il 'issue list --label="bug"'`). Disabling flag processing for this command fixed the problem but if we ever want `alias set` to accept flags we'll need to revisit this.

I'm open to feedback on those things.

## demo

(right click view image to make more legible)

![aliasdemo](https://user-images.githubusercontent.com/98482/82709544-70109480-9c46-11ea-83e4-d696d6841649.gif)

## ~todo~ todid

- [x] add command
- [x] process args properly
- [x] expose aliases through config
- [x] error if alias already exist
- [x] initialize aliases on disk on first set
- [x] actual alias dispatching
- [x] error if expand to illegal command
- [x] documentation
- [x] finish tests
  - [x] arg processing
  - [x] already exists
  - [x] illegal command
  - [x] proper dispatching
  - [x] lazy initialization on first set
- [x] clean up hacks
  - [x] context handling (maybe it's fine?? initContext seems sufficiently idempotent)
  - [ ] disabling of flag processing on `alias set` (though it might be fine to ship initially)
  - [x] more resilient expansion code

closes #938

