### PR TITLE
Avoid crash in `pr view` with reviewers

### DIFF
--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -477,7 +477,7 @@ func TestPRView_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/prViewPreviewWithReviewersByNumber.json",
 			expectedOutputs: []string{
 				`Blueberries are from a fork`,
-				`Reviewers: DEF \(Commented\), def \(Changes requested\), ghost \(Approved\), xyz \(Approved\), 123 \(Requested\), Team 1 \(Requested\), abc \(Requested\)\n`,
+				`Reviewers: DEF \(Commented\), def \(Changes requested\), ghost \(Approved\), hubot \(Commented\), xyz \(Approved\), 123 \(Requested\), Team 1 \(Requested\), abc \(Requested\)\n`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12\n`,
 			},

--- a/test/fixtures/prViewPreviewWithReviewersByNumber.json
+++ b/test/fixtures/prViewPreviewWithReviewersByNumber.json
@@ -70,6 +70,24 @@
                 "login": ""
               },
               "state": "APPROVED"
+            },
+            {
+              "author": {
+                "login": "hubot"
+              },
+              "state": "CHANGES_REQUESTED"
+            },
+            {
+              "author": {
+                "login": "hubot"
+              },
+              "state": "DISMISSED"
+            },
+            {
+              "author": {
+                "login": "monalisa"
+              },
+              "state": "PENDING"
             }
           ]
         },


### PR DESCRIPTION
Now handling the "DISMISSED" and "PENDING" states.

I have no evidence that "PENDING" can be returned from API in this context, but it's listed among the possible states in GitHub API docs, so better be safe than sorry. Reviewers with "PENDING" states are omitted from display.

Fixes #934, followup to #762 /cc @doi-t 