### PR TITLE
Fix linter in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,15 @@
 name: Lint
 on:
-  push: &paths
+  push:
     paths:
       - "**.go"
       - go.mod
       - go.sum
   pull_request:
-    <<: *paths
+    paths:
+      - "**.go"
+      - go.mod
+      - go.sum
 
 jobs:
   lint:


### PR DESCRIPTION
It turns out that YAML anchors are not supported https://github.com/cli/cli/actions/runs/115915028

Followup to https://github.com/cli/cli/pull/988