### PR TITLE
Fix typo in `pr ready` help

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -96,7 +96,7 @@ var prMergeCmd = &cobra.Command{
 }
 var prReadyCmd = &cobra.Command{
 	Use:   "ready [<number> | <url> | <branch>]",
-	Short: "Make a pull request as ready for review",
+	Short: "Mark a pull request as ready for review",
 	Args:  cobra.MaximumNArgs(1),
 	RunE:  prReady,
 }


### PR DESCRIPTION
Just spotted this! Changed `Make a pull request as ready for review` -> `Mark a pull request as ready for review`