### PR TITLE
Rename "master" to "trunk" in various links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,6 +1,6 @@
 <!--
 Please make sure you read our contributing guidelines at
-https://github.com/cli/cli/blob/master/.github/CONTRIBUTING.md
+https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md
 before opening opening a pull request. Thanks!
 -->
 

--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ Install a prebuilt binary from the [releases page][]
 [Chocolatey]: https://chocolatey.org
 [releases page]: https://github.com/cli/cli/releases/latest
 [hub]: https://github.com/github/hub
-[contributing page]: https://github.com/cli/cli/blob/master/.github/CONTRIBUTING.md
+[contributing page]: https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md

--- a/wix.json
+++ b/wix.json
@@ -27,6 +27,6 @@
     "description": "Use GitHub from the CLI",
     "project-url": "https://github.com/cli/cli",
     "tags": "github cli git",
-    "license-url": "https://github.com/cli/cli/blob/master/LICENSE"
+    "license-url": "https://github.com/cli/cli/blob/trunk/LICENSE"
   }
 }


### PR DESCRIPTION
Ref. #929