### PR TITLE
Add search command for repositories

### DIFF
--- a/command/search.go
+++ b/command/search.go
@@ -1,0 +1,36 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(searchCmd)
+	searchCmd.AddCommand(repoSearch)
+
+	repoSearch.Flags().StringP("sort", "s", "stars", "Sort by (default: stars)")
+	repoSearch.Flags().Int16P("count", "c", 10, "Retrieve quantity (default: 10)")
+}
+
+var searchCmd = &cobra.Command{
+	Use:   "search",
+	Short: "Search for users or repositories by keyword",
+	Long: `Search users or repositories.
+
+A keyword can be supplied as an argument as any of the following formats:
+- keyword
+- "a long keyword string"
+`,
+}
+
+var repoSearch = &cobra.Command{
+	Use:   "repo",
+	Args:  cobra.MinimumNArgs(1),
+	Short: "Search a repository by keyword",
+	RunE:  searchRepo,
+}
+
+func searchRepo(cmd *cobra.Command, args []string) error {
+	// keyword := args[0]
+	return nil
+}

--- a/command/search_test.go
+++ b/command/search_test.go
@@ -1,0 +1,10 @@
+package command
+
+import (
+	"testing"
+)
+
+func TestSearchRepo(t *testing.T) {
+	_, err := RunCommand(`search repo "docker"`)
+	eq(t, err, nil)
+}


### PR DESCRIPTION
## 🎩  What? Why?
Include the search functionality

The Idea is to provide a way to search repositories from the command line:

```
gh search repo docker
```

and return by default 10 results sorted by stars count.

## 🧾 Related with

- #1004 