### PR TITLE
Fix showing "Authentication complete" notice after OAuth dance

### DIFF
--- a/internal/config/config_setup.go
+++ b/internal/config/config_setup.go
@@ -110,6 +110,8 @@ func setupConfigFile(filename string) (Config, error) {
 		return nil, err
 	}
 
+	AuthFlowComplete()
+
 	// TODO cleaner error handling? this "should" always work given that we /just/ wrote the file...
 	return ParseConfig(filename)
 }


### PR DESCRIPTION
After OAuth flow completes, show this line and wait for Enter to be pressed:
```
Authentication complete. Press Enter to continue...
```

We've had this until I unintentionally disabled it in #786. It does not make a big difference either way, but I think waiting on a keypress before continuing with the CLI operation is a nice touch that helps reduce disorientation when switching to and from their web browser.