### PR TITLE
Fix referring to loopback interface in OAuth flow

### DIFF
--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -41,7 +41,7 @@ func (oa *OAuthFlow) ObtainAccessToken() (accessToken string, err error) {
 	state, _ := randomString(20)
 
 	code := ""
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Avoids the error when `localhost` was resolved to something else other than `127.0.0.1`:

    listen tcp 192.168.1.*:0: bind: can't assign requested address

Fixes #1012 /cc @liamchampton