### PR TITLE
Add support for command extensions

### DIFF
--- a/command/root_custom.go
+++ b/command/root_custom.go
@@ -1,0 +1,130 @@
+package command
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/cli/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.Args = cobra.ArbitraryArgs
+	RootCmd.RunE = customCommandFallback
+	RootCmd.ValidArgsFunction = customCommandCompletion
+}
+
+func customCommandFallback(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		cmd.HelpFunc()(cmd, args)
+		return nil
+	}
+
+	cmdExe, err := findCustomCommand(args[0])
+	if err != nil {
+		return err
+	}
+
+	ctx := contextForCommand(cmd)
+	authToken, err := ctx.AuthToken()
+	if err != nil {
+		return err
+	}
+
+	env := append(os.Environ(), "GITHUB_TOKEN="+authToken)
+
+	if baseRepo, err := ctx.BaseRepo(); err == nil {
+		env = append(env, fmt.Sprintf("GH_BASEREPO=%s/%s", baseRepo.RepoOwner(), baseRepo.RepoName()))
+	}
+
+	externalCmd := exec.Command(cmdExe, args[1:]...)
+	externalCmd.Env = env
+	externalCmd.Stdin = os.Stdin
+	externalCmd.Stdout = os.Stdout
+	externalCmd.Stderr = os.Stderr
+	return externalCmd.Run()
+}
+
+func customCommandCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	directive := cobra.ShellCompDirectiveDefault
+
+	if len(args) == 0 {
+		return findCustomCommands(toComplete), directive
+	}
+
+	var results []string
+	cmdExe, err := findCustomCommand(args[0])
+	if err != nil {
+		return results, directive
+	}
+
+	cmdArgs := append([]string{"__complete"}, args[1:]...)
+	cmdArgs = append(cmdArgs, toComplete)
+	buf := bytes.Buffer{}
+
+	// TODO: scan the file to guess whether it supports completions
+	externalCmd := exec.Command(cmdExe, cmdArgs...)
+	externalCmd.Stdout = &buf
+	if err := externalCmd.Run(); err != nil {
+		return results, directive
+	}
+
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if len(strings.TrimSpace(line)) > 0 {
+			results = append(results, line)
+		}
+	}
+	return results, directive
+}
+
+func findCustomCommand(name string) (string, error) {
+	cmdName := "gh-" + stripPathComponent(name)
+
+	if found, _ := filepath.Glob(path.Join(config.ConfigDir(), "gh-commands", "*", cmdName)); len(found) > 0 {
+		return found[0], nil
+	}
+
+	if found, err := exec.LookPath(cmdName); err == nil {
+		return found, nil
+	}
+
+	return "", fmt.Errorf("unknown command %q", name)
+}
+
+func findCustomCommands(prefix string) []string {
+	var results []string
+	globName := "gh-" + stripPathComponent(prefix) + "*"
+
+	if found, err := filepath.Glob(filepath.Join(config.ConfigDir(), "gh-commands", "*", globName)); err == nil {
+		for _, f := range found {
+			base := strings.TrimPrefix(filepath.Base(f), "gh-")
+			results = append(results, base)
+		}
+	}
+
+	paths := os.Getenv("PATH")
+	for _, dir := range filepath.SplitList(paths) {
+		found, err := filepath.Glob(filepath.Join(dir, globName))
+		if err != nil {
+			continue
+		}
+		for _, f := range found {
+			base := strings.TrimPrefix(filepath.Base(f), "gh-")
+			results = append(results, base)
+		}
+	}
+
+	return results
+}
+
+func stripPathComponent(arg string) string {
+	if idx := strings.IndexRune(arg, filepath.Separator); idx >= 0 {
+		return arg[0:idx]
+	}
+	return arg
+}


### PR DESCRIPTION
When executing `gh <cmd>`, if `<cmd>` is not a built-in command, this searches `~/.config/gh/gh-commands/*` and in PATH for executables named `gh-<cmd>` and runs the first one found.

All arguments are forwarded to the executable and the following environment variables are set:

- GITHUB_TOKEN for API calls;
- GH_BASEREPO (if available) with the `<owner>/<repo>` pair determined from git remotes.

Example: command to identify the authenticated user
```sh
#!/bin/bash
exec gh api user | jq -r .login
```

If saved as `gh-whoami` somewhere in the user's PATH, the command is invoked like so:
```sh
$ gh whoami
mislav
```

All custom commands are listed in shell completions for the `gh` command; e.g. typing `gh who<Tab>` will expand to `gh whoami`.

Additionally, the executable may provide its own shell completions by respecting when the 1st argument is `__complete` and writing completion options as separate lines of output:
```sh
#!/bin/bash
set -e

if [ "${1:-}" = "__complete" ]; then
  echo --some-flag
  echo --another-flag
  exit 0
fi

# ...the rest of the implementation
```

TODO:
- [x] provide a command to easily install other person's command extensions with
- [x] provide a command to update previously downloaded extensions
- [x] handle case in which multiple commands of the same name are found under `~/.config/gh/gh-commands/*`
- [ ] avoid asking for shell completions if the executable doesn't look like it implements `__complete`
- [ ] fix `gh __complete <cmd> ''` returning extra results
- [x] write more example commands
