### PR TITLE
Add badge command

### DIFF
--- a/command/badge.go
+++ b/command/badge.go
@@ -1,0 +1,25 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	RootCmd.AddCommand(badgeCmd)
+
+	badgeCmd.Flags().BoolP("link", "l", true, "Badge wrapped in link to badge")
+}
+
+var badgeCmd = &cobra.Command{
+	Use:   "badge [GitHub username] [Repository name] [Action file name]",
+	Short: "Generate a README badge for a GitHub action",
+	Long: `Generate a markdown viewable badge for the given GitHub action.
+
+Examples:
+
+  gh badge twbs bootstrap test.yml
+  gh badge cli cli lint.yml
+`,
+	Args: cobra.MaximumNArgs(3),
+	RunE: credits,
+}

--- a/command/badge.go
+++ b/command/badge.go
@@ -1,13 +1,20 @@
 package command
 
 import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/atotto/clipboard"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
 	RootCmd.AddCommand(badgeCmd)
 
-	badgeCmd.Flags().BoolP("link", "l", true, "Badge wrapped in link to badge")
+	badgeCmd.Flags().BoolP("no-link", "n", false, "Don't wrap badge in link to action")
+	badgeCmd.Flags().BoolP("output", "o", false, "Don't copy badge to clipboard, just output it")
 }
 
 var badgeCmd = &cobra.Command{
@@ -21,5 +28,50 @@ Examples:
   gh badge cli cli lint.yml
 `,
 	Args: cobra.MaximumNArgs(3),
-	RunE: credits,
+	RunE: badge,
+}
+
+func badge(cmd *cobra.Command, args []string) error {
+	username := args[0]
+	repository := args[1]
+	fileName := args[2]
+
+	bytes, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return err
+	}
+	var yamlContents map[string]string
+	err = yaml.Unmarshal(bytes, &yamlContents)
+	if err != nil {
+		return err
+	}
+	actionName := yamlContents["name"]
+
+	var badge string
+	badge = fmt.Sprintf("![%v](https://github.com/%v/%v/workflows/%v/badge.svg)", actionName, username, repository, strings.ReplaceAll(actionName, " ", "%20"))
+
+	link, err := cmd.Flags().GetBool("no-link")
+	if err != nil {
+		return err
+	}
+	if link {
+		badge = fmt.Sprintf(`[%v](https://github.com/%v/%v/actions?query=workflow%%3A"%v")`, badge, username, repository, strings.ReplaceAll(actionName, " ", "+"))
+	}
+
+	output, err := cmd.Flags().GetBool("output")
+	if err != nil {
+		return err
+	}
+
+	if output {
+		fmt.Println(badge)
+	} else {
+		err := clipboard.WriteAll(badge)
+		if err != nil {
+			return err
+		}
+		fmt.Println("Badge copied to clipboard!")
+	}
+
+	return nil
 }

--- a/command/gist.go
+++ b/command/gist.go
@@ -33,7 +33,7 @@ var gistCreateCmd = &cobra.Command{
 
 Gists can be created from one or many files. This command can also read from STDIN. By default, gists are private; use --public to change this.
 
-Examples
+Examples:
 
     gh gist create hello.py                   # turn file hello.py into a gist
     gh gist create --public hello.py          # turn file hello.py into a public gist

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.0.7
+	github.com/atotto/clipboard v0.1.2
 	github.com/briandowns/spinner v1.10.1-0.20200410162419-bf6cf7ae6727
 	github.com/charmbracelet/glamour v0.1.1-0.20200320173916-301d3bcf3058
 	github.com/dlclark/regexp2 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/alecthomas/repr v0.0.0-20180818092828-117648cd9897/go.mod h1:xTS7Pm1p
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzbY=
+github.com/atotto/clipboard v0.1.2/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/briandowns/spinner v1.10.1-0.20200410162419-bf6cf7ae6727 h1:DOyHtIQZmwFEOt/makVyey2RMTPkpi1IQsWsWX0OcGE=


### PR DESCRIPTION
This command allows the user to create the badge for the given GitHub action directly from the command line with ease. The format is `gh badge [USERNAME] [REPO NAME] [PATH TO LOCAL YAML ACTION FILE]`. This command also allows you to wrap the badge in a link to a filter on github.com only showing you that action by adding the `--link` flag. Once it generates the badge it copies it to the user's clipboard. If the user doesn't want it to go to the clipboard they can simply output it to the console by adding the `--output flag`. At the moment this command doesn't have a unit test and just let me know in the review if you want me to add one. Thank you for your time and thanks for making this awesome product!