### PR TITLE
Write per-host config info to `hosts.yml` instead of `config.yml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ endif
 LDFLAGS := -X github.com/cli/cli/command.Version=$(GH_VERSION) $(LDFLAGS)
 LDFLAGS := -X github.com/cli/cli/command.BuildDate=$(BUILD_DATE) $(LDFLAGS)
 ifdef GH_OAUTH_CLIENT_SECRET
-	LDFLAGS := -X github.com/cli/cli/context.oauthClientID=$(GH_OAUTH_CLIENT_ID) $(LDFLAGS)
-	LDFLAGS := -X github.com/cli/cli/context.oauthClientSecret=$(GH_OAUTH_CLIENT_SECRET) $(LDFLAGS)
+	LDFLAGS := -X github.com/cli/cli/internal/config.oauthClientID=$(GH_OAUTH_CLIENT_ID) $(LDFLAGS)
+	LDFLAGS := -X github.com/cli/cli/internal/config.oauthClientSecret=$(GH_OAUTH_CLIENT_SECRET) $(LDFLAGS)
 endif
 
 bin/gh: $(BUILD_FILES)

--- a/api/client.go
+++ b/api/client.go
@@ -165,6 +165,10 @@ func (c Client) HasScopes(wantedScopes ...string) (bool, string, error) {
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode != 200 {
+		return false, "", handleHTTPError(res)
+	}
+
 	appID := res.Header.Get("X-Oauth-Client-Id")
 	hasScopes := strings.Split(res.Header.Get("X-Oauth-Scopes"), ",")
 

--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -66,9 +66,9 @@ func (oa *OAuthFlow) ObtainAccessToken() (accessToken string, err error) {
 		fmt.Fprintf(os.Stderr, "Please open the following URL manually:\n%s\n", startURL)
 		fmt.Fprintf(os.Stderr, "")
 		// TODO: Temporary workaround for https://github.com/cli/cli/issues/297
-		fmt.Fprintf(os.Stderr, "If you are on a server or other headless system, use this workaround instead:")
-		fmt.Fprintf(os.Stderr, "  1. Complete authentication on a GUI system")
-		fmt.Fprintf(os.Stderr, "  2. Copy the contents of ~/.config/gh/config.yml to this system")
+		fmt.Fprintf(os.Stderr, "If you are on a server or other headless system, use this workaround instead:\n")
+		fmt.Fprintf(os.Stderr, "  1. Complete authentication on a GUI system;\n")
+		fmt.Fprintf(os.Stderr, "  2. Copy the contents of `~/.config/gh/hosts.yml` to this system.\n")
 	}
 
 	_ = http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/command/config_test.go
+++ b/command/config_test.go
@@ -49,23 +49,31 @@ func TestConfigGet_not_found(t *testing.T) {
 func TestConfigSet(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "master")
 
-	buf := bytes.NewBufferString("")
-	defer config.StubWriteConfig(buf, nil)()
+	mainBuf := bytes.Buffer{}
+	hostsBuf := bytes.Buffer{}
+	defer config.StubWriteConfig(&mainBuf, &hostsBuf)()
+
 	output, err := RunCommand("config set editor ed")
 	if err != nil {
 		t.Fatalf("error running command `config set editor ed`: %v", err)
 	}
 
-	eq(t, output.String(), "")
+	if len(output.String()) > 0 {
+		t.Errorf("expected output to be blank: %q", output.String())
+	}
 
-	expected := `hosts:
-    github.com:
-        user: OWNER
-        oauth_token: 1234567890
-editor: ed
+	expectedMain := "editor: ed\n"
+	expectedHosts := `github.com:
+    user: OWNER
+    oauth_token: "1234567890"
 `
 
-	eq(t, buf.String(), expected)
+	if mainBuf.String() != expectedMain {
+		t.Errorf("expected config.yml to be %q, got %q", expectedMain, mainBuf.String())
+	}
+	if hostsBuf.String() != expectedHosts {
+		t.Errorf("expected hosts.yml to be %q, got %q", expectedHosts, hostsBuf.String())
+	}
 }
 
 func TestConfigSet_update(t *testing.T) {
@@ -79,23 +87,31 @@ editor: ed
 
 	initBlankContext(cfg, "OWNER/REPO", "master")
 
-	buf := bytes.NewBufferString("")
-	defer config.StubWriteConfig(buf, nil)()
+	mainBuf := bytes.Buffer{}
+	hostsBuf := bytes.Buffer{}
+	defer config.StubWriteConfig(&mainBuf, &hostsBuf)()
 
 	output, err := RunCommand("config set editor vim")
 	if err != nil {
 		t.Fatalf("error running command `config get editor`: %v", err)
 	}
 
-	eq(t, output.String(), "")
+	if len(output.String()) > 0 {
+		t.Errorf("expected output to be blank: %q", output.String())
+	}
 
-	expected := `hosts:
-    github.com:
-        user: OWNER
-        oauth_token: MUSTBEHIGHCUZIMATOKEN
-editor: vim
+	expectedMain := "editor: vim\n"
+	expectedHosts := `github.com:
+    user: OWNER
+    oauth_token: MUSTBEHIGHCUZIMATOKEN
 `
-	eq(t, buf.String(), expected)
+
+	if mainBuf.String() != expectedMain {
+		t.Errorf("expected config.yml to be %q, got %q", expectedMain, mainBuf.String())
+	}
+	if hostsBuf.String() != expectedHosts {
+		t.Errorf("expected hosts.yml to be %q, got %q", expectedHosts, hostsBuf.String())
+	}
 }
 
 func TestConfigGetHost(t *testing.T) {
@@ -141,23 +157,32 @@ git_protocol: ssh
 func TestConfigSetHost(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "master")
 
-	buf := bytes.NewBufferString("")
-	defer config.StubWriteConfig(buf, nil)()
+	mainBuf := bytes.Buffer{}
+	hostsBuf := bytes.Buffer{}
+	defer config.StubWriteConfig(&mainBuf, &hostsBuf)()
+
 	output, err := RunCommand("config set -hgithub.com git_protocol ssh")
 	if err != nil {
 		t.Fatalf("error running command `config set editor ed`: %v", err)
 	}
 
-	eq(t, output.String(), "")
+	if len(output.String()) > 0 {
+		t.Errorf("expected output to be blank: %q", output.String())
+	}
 
-	expected := `hosts:
-    github.com:
-        user: OWNER
-        oauth_token: 1234567890
-        git_protocol: ssh
+	expectedMain := ""
+	expectedHosts := `github.com:
+    user: OWNER
+    oauth_token: "1234567890"
+    git_protocol: ssh
 `
 
-	eq(t, buf.String(), expected)
+	if mainBuf.String() != expectedMain {
+		t.Errorf("expected config.yml to be %q, got %q", expectedMain, mainBuf.String())
+	}
+	if hostsBuf.String() != expectedHosts {
+		t.Errorf("expected hosts.yml to be %q, got %q", expectedHosts, hostsBuf.String())
+	}
 }
 
 func TestConfigSetHost_update(t *testing.T) {
@@ -171,21 +196,30 @@ hosts:
 
 	initBlankContext(cfg, "OWNER/REPO", "master")
 
-	buf := bytes.NewBufferString("")
-	defer config.StubWriteConfig(buf, nil)()
+	mainBuf := bytes.Buffer{}
+	hostsBuf := bytes.Buffer{}
+	defer config.StubWriteConfig(&mainBuf, &hostsBuf)()
 
 	output, err := RunCommand("config set -hgithub.com git_protocol https")
 	if err != nil {
 		t.Fatalf("error running command `config get editor`: %v", err)
 	}
 
-	eq(t, output.String(), "")
+	if len(output.String()) > 0 {
+		t.Errorf("expected output to be blank: %q", output.String())
+	}
 
-	expected := `hosts:
-    github.com:
-        git_protocol: https
-        user: OWNER
-        oauth_token: MUSTBEHIGHCUZIMATOKEN
+	expectedMain := ""
+	expectedHosts := `github.com:
+    git_protocol: https
+    user: OWNER
+    oauth_token: MUSTBEHIGHCUZIMATOKEN
 `
-	eq(t, buf.String(), expected)
+
+	if mainBuf.String() != expectedMain {
+		t.Errorf("expected config.yml to be %q, got %q", expectedMain, mainBuf.String())
+	}
+	if hostsBuf.String() != expectedHosts {
+		t.Errorf("expected hosts.yml to be %q, got %q", expectedHosts, hostsBuf.String())
+	}
 }

--- a/command/config_test.go
+++ b/command/config_test.go
@@ -50,7 +50,7 @@ func TestConfigSet(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "master")
 
 	buf := bytes.NewBufferString("")
-	defer config.StubWriteConfig(buf)()
+	defer config.StubWriteConfig(buf, nil)()
 	output, err := RunCommand("config set editor ed")
 	if err != nil {
 		t.Fatalf("error running command `config set editor ed`: %v", err)
@@ -80,7 +80,7 @@ editor: ed
 	initBlankContext(cfg, "OWNER/REPO", "master")
 
 	buf := bytes.NewBufferString("")
-	defer config.StubWriteConfig(buf)()
+	defer config.StubWriteConfig(buf, nil)()
 
 	output, err := RunCommand("config set editor vim")
 	if err != nil {
@@ -142,7 +142,7 @@ func TestConfigSetHost(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "master")
 
 	buf := bytes.NewBufferString("")
-	defer config.StubWriteConfig(buf)()
+	defer config.StubWriteConfig(buf, nil)()
 	output, err := RunCommand("config set -hgithub.com git_protocol ssh")
 	if err != nil {
 		t.Fatalf("error running command `config set editor ed`: %v", err)
@@ -172,7 +172,7 @@ hosts:
 	initBlankContext(cfg, "OWNER/REPO", "master")
 
 	buf := bytes.NewBufferString("")
-	defer config.StubWriteConfig(buf)()
+	defer config.StubWriteConfig(buf, nil)()
 
 	output, err := RunCommand("config set -hgithub.com git_protocol https")
 	if err != nil {

--- a/command/root.go
+++ b/command/root.go
@@ -180,24 +180,16 @@ var apiClientForContext = func(ctx context.Context) (*api.Client, error) {
 
 	checkScopesFunc := func(appID string) error {
 		if config.IsGitHubApp(appID) && !tokenFromEnv() && utils.IsTerminal(os.Stdin) && utils.IsTerminal(os.Stderr) {
-			newToken, loginHandle, err := config.AuthFlow("Notice: additional authorization required")
-			if err != nil {
-				return err
-			}
 			cfg, err := ctx.Config()
 			if err != nil {
 				return err
 			}
-			_ = cfg.Set(defaultHostname, "oauth_token", newToken)
-			_ = cfg.Set(defaultHostname, "user", loginHandle)
-			// update config file on disk
-			err = cfg.Write()
+			newToken, err := config.AuthFlowWithConfig(cfg, defaultHostname, "Notice: additional authorization required")
 			if err != nil {
 				return err
 			}
 			// update configuration in memory
 			token = newToken
-			config.AuthFlowComplete()
 		} else {
 			fmt.Fprintln(os.Stderr, "Warning: gh now requires the `read:org` OAuth scope.")
 			fmt.Fprintln(os.Stderr, "Visit https://github.com/settings/tokens and edit your token to enable `read:org`")
@@ -234,28 +226,19 @@ var ensureScopes = func(ctx context.Context, client *api.Client, wantedScopes ..
 	tokenFromEnv := len(os.Getenv("GITHUB_TOKEN")) > 0
 
 	if config.IsGitHubApp(appID) && !tokenFromEnv && utils.IsTerminal(os.Stdin) && utils.IsTerminal(os.Stderr) {
-		newToken, loginHandle, err := config.AuthFlow("Notice: additional authorization required")
-		if err != nil {
-			return client, err
-		}
 		cfg, err := ctx.Config()
 		if err != nil {
-			return client, err
+			return nil, err
 		}
-		_ = cfg.Set(defaultHostname, "oauth_token", newToken)
-		_ = cfg.Set(defaultHostname, "user", loginHandle)
-		// update config file on disk
-		err = cfg.Write()
+		_, err = config.AuthFlowWithConfig(cfg, defaultHostname, "Notice: additional authorization required")
 		if err != nil {
-			return client, err
+			return nil, err
 		}
-		// update configuration in memory
-		config.AuthFlowComplete()
+
 		reloadedClient, err := apiClientForContext(ctx)
 		if err != nil {
 			return client, err
 		}
-
 		return reloadedClient, nil
 	} else {
 		fmt.Fprintln(os.Stderr, fmt.Sprintf("Warning: gh now requires %s OAuth scopes.", wantedScopes))

--- a/command/testing.go
+++ b/command/testing.go
@@ -88,7 +88,7 @@ func initBlankContext(cfg, repo, branch string) {
 
 		// NOTE we are not restoring the original readConfig; we never want to touch the config file on
 		// disk during tests.
-		config.StubConfig(cfg)
+		config.StubConfig(cfg, "")
 
 		return ctx
 	}

--- a/command/testing.go
+++ b/command/testing.go
@@ -19,7 +19,7 @@ import (
 const defaultTestConfig = `hosts:
   github.com:
     user: OWNER
-    oauth_token: 1234567890
+    oauth_token: "1234567890"
 `
 
 type askStubber struct {

--- a/context/blank_context.go
+++ b/context/blank_context.go
@@ -23,7 +23,7 @@ type blankContext struct {
 }
 
 func (c *blankContext) Config() (config.Config, error) {
-	cfg, err := config.ParseConfig("boom.txt")
+	cfg, err := config.ParseConfig("config.yml")
 	if err != nil {
 		panic(fmt.Sprintf("failed to parse config during tests. did you remember to stub? error: %s", err))
 	}

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -108,7 +108,7 @@ func migrateConfig(filename string) error {
 		return err
 	}
 
-	var hosts map[string][]map[string]string
+	var hosts map[string][]yaml.Node
 	err = yaml.Unmarshal(b, &hosts)
 	if err != nil {
 		return fmt.Errorf("error decoding legacy format: %w", err)
@@ -119,8 +119,9 @@ func migrateConfig(filename string) error {
 		if len(entries) < 1 {
 			continue
 		}
-		for key, value := range entries[0] {
-			if err := cfg.Set(hostname, key, value); err != nil {
+		mapContent := entries[0].Content
+		for i := 0; i < len(mapContent)-1; i += 2 {
+			if err := cfg.Set(hostname, mapContent[i].Value, mapContent[i+1].Value); err != nil {
 				return err
 			}
 		}

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -76,8 +76,11 @@ func parseConfigFile(fn string) ([]byte, *yaml.Node, error) {
 	if err != nil {
 		return data, nil, err
 	}
-	if len(root.Content) < 1 {
-		return data, &root, fmt.Errorf("malformed config")
+	if len(root.Content) == 0 {
+		return data, &yaml.Node{
+			Kind:    yaml.DocumentNode,
+			Content: []*yaml.Node{{Kind: yaml.MappingNode}},
+		}, nil
 	}
 	if root.Content[0].Kind != yaml.MappingNode {
 		return data, &root, fmt.Errorf("expected a top level map")

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
 	"gopkg.in/yaml.v3"
@@ -49,7 +50,12 @@ var ReadConfigFile = func(fn string) ([]byte, error) {
 }
 
 var WriteConfigFile = func(fn string, data []byte) error {
-	cfgFile, err := os.OpenFile(ConfigFile(), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600) // cargo coded from setup
+	err := os.MkdirAll(filepath.Dir(fn), 0771)
+	if err != nil {
+		return err
+	}
+
+	cfgFile, err := os.OpenFile(fn, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600) // cargo coded from setup
 	if err != nil {
 		return err
 	}

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -22,14 +22,6 @@ func ConfigFile() string {
 	return path.Join(ConfigDir(), "config.yml")
 }
 
-func ParseOrSetupConfigFile(fn string) (Config, error) {
-	config, err := ParseConfig(fn)
-	if err != nil && errors.Is(err, os.ErrNotExist) {
-		return setupConfigFile(fn)
-	}
-	return config, err
-}
-
 func ParseDefaultConfig() (Config, error) {
 	return ParseConfig(ConfigFile())
 }

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -93,4 +94,17 @@ github.com:
 `
 
 	eq(t, buf.String(), expected)
+}
+
+func Test_parseConfigFile(t *testing.T) {
+	fileContents := []string{"", " ", "\n"}
+	for _, contents := range fileContents {
+		t.Run(fmt.Sprintf("contents: %q", contents), func(t *testing.T) {
+			defer StubConfig(contents, "")()
+			_, yamlRoot, err := parseConfigFile("config.yml")
+			eq(t, err, nil)
+			eq(t, yamlRoot.Content[0].Kind, yaml.MappingNode)
+			eq(t, len(yamlRoot.Content[0].Content), 0)
+		})
+	}
 }

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -22,8 +22,8 @@ hosts:
   github.com:
     user: monalisa
     oauth_token: OTOKEN
-`)()
-	config, err := ParseConfig("filename")
+`, "")()
+	config, err := ParseConfig("config.yml")
 	eq(t, err, nil)
 	user, err := config.Get("github.com", "user")
 	eq(t, err, nil)
@@ -42,8 +42,8 @@ hosts:
   github.com:
     user: monalisa
     oauth_token: OTOKEN
-`)()
-	config, err := ParseConfig("filename")
+`, "")()
+	config, err := ParseConfig("config.yml")
 	eq(t, err, nil)
 	user, err := config.Get("github.com", "user")
 	eq(t, err, nil)
@@ -59,8 +59,8 @@ hosts:
   example.com:
     user: wronguser
     oauth_token: NOTTHIS
-`)()
-	config, err := ParseConfig("filename")
+`, "")()
+	config, err := ParseConfig("config.yml")
 	eq(t, err, nil)
 	_, err = config.Get("github.com", "user")
 	eq(t, err, errors.New(`could not find config entry for "github.com"`))
@@ -79,11 +79,11 @@ github.com:
 	}
 
 	buf := bytes.NewBufferString("")
-	defer StubWriteConfig(buf)()
+	defer StubWriteConfig(buf, nil)()
 
 	defer StubBackupConfig()()
 
-	err = migrateConfig("boom.txt", &root)
+	err = migrateConfig("config.yml", &root)
 	eq(t, err, nil)
 
 	expected := `hosts:

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -63,7 +63,7 @@ hosts:
 	config, err := ParseConfig("config.yml")
 	eq(t, err, nil)
 	_, err = config.Get("github.com", "user")
-	eq(t, err, errors.New(`could not find config entry for "github.com"`))
+	eq(t, err, &NotFoundError{errors.New(`could not find config entry for "github.com"`)})
 }
 
 func Test_migrateConfig(t *testing.T) {

--- a/internal/config/config_setup.go
+++ b/internal/config/config_setup.go
@@ -26,7 +26,7 @@ func IsGitHubApp(id string) bool {
 }
 
 func AuthFlowWithConfig(cfg Config, hostname, notice string) (string, error) {
-	token, userLogin, err := AuthFlow(hostname, notice)
+	token, userLogin, err := authFlow(hostname, notice)
 	if err != nil {
 		return "", err
 	}
@@ -49,7 +49,7 @@ func AuthFlowWithConfig(cfg Config, hostname, notice string) (string, error) {
 	return token, nil
 }
 
-func AuthFlow(oauthHost, notice string) (string, string, error) {
+func authFlow(oauthHost, notice string) (string, string, error) {
 	var verboseStream io.Writer
 	if strings.Contains(os.Getenv("DEBUG"), "oauth") {
 		verboseStream = os.Stderr

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -12,7 +12,6 @@ const defaultGitProtocol = "https"
 
 // This interface describes interacting with some persistent configuration for gh.
 type Config interface {
-	Hosts() ([]*HostConfig, error)
 	Get(string, string) (string, error)
 	Set(string, string, string) error
 	Write() error
@@ -145,7 +144,7 @@ func (c *fileConfig) Set(hostname, key, value string) error {
 }
 
 func (c *fileConfig) configForHost(hostname string) (*HostConfig, error) {
-	hosts, err := c.Hosts()
+	hosts, err := c.hostEntries()
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse hosts config: %w", err)
 	}
@@ -167,7 +166,7 @@ func (c *fileConfig) Write() error {
 	return WriteConfigFile(ConfigFile(), marshalled)
 }
 
-func (c *fileConfig) Hosts() ([]*HostConfig, error) {
+func (c *fileConfig) hostEntries() ([]*HostConfig, error) {
 	if len(c.hosts) > 0 {
 		return c.hosts, nil
 	}

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -8,7 +8,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const defaultHostname = "github.com"
 const defaultGitProtocol = "https"
 
 // This interface describes interacting with some persistent configuration for gh.

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -99,7 +99,6 @@ func NewBlankConfig() Config {
 type fileConfig struct {
 	ConfigMap
 	documentRoot *yaml.Node
-	hosts        []*HostConfig
 }
 
 func (c *fileConfig) Get(hostname, key string) (string, error) {
@@ -177,23 +176,12 @@ func (c *fileConfig) Write() error {
 }
 
 func (c *fileConfig) hostEntries() ([]*HostConfig, error) {
-	if len(c.hosts) > 0 {
-		return c.hosts, nil
-	}
-
 	_, hostsEntry, err := c.FindEntry("hosts")
 	if err != nil {
 		return nil, fmt.Errorf("could not find hosts config: %w", err)
 	}
 
-	hostConfigs, err := c.parseHosts(hostsEntry)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse hosts config: %w", err)
-	}
-
-	c.hosts = hostConfigs
-
-	return hostConfigs, nil
+	return c.parseHosts(hostsEntry)
 }
 
 func (c *fileConfig) makeConfigForHost(hostname string) *HostConfig {

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 
@@ -170,6 +171,10 @@ func (c *fileConfig) Write() error {
 	marshalled, err := yaml.Marshal(c.documentRoot)
 	if err != nil {
 		return err
+	}
+
+	if bytes.Equal(marshalled, []byte("{}\n")) {
+		marshalled = []byte{}
 	}
 
 	return WriteConfigFile(ConfigFile(), marshalled)

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -185,8 +185,8 @@ func (c *fileConfig) Write() error {
 		return err
 	}
 
-	fn := ConfigFile()
-	err = WriteConfigFile(fn, yamlNormalize(mainBytes))
+	filename := ConfigFile()
+	err = WriteConfigFile(filename, yamlNormalize(mainBytes))
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func (c *fileConfig) Write() error {
 		return err
 	}
 
-	return WriteConfigFile(hostsConfigFile(fn), yamlNormalize(hostsBytes))
+	return WriteConfigFile(hostsConfigFile(filename), yamlNormalize(hostsBytes))
 }
 
 func yamlNormalize(b []byte) []byte {

--- a/internal/config/config_type_test.go
+++ b/internal/config/config_type_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_fileConfig_Set(t *testing.T) {
+	cb := bytes.Buffer{}
+	StubWriteConfig(&cb, nil)
+
+	c := NewBlankConfig()
+	assert.NoError(t, c.Set("", "editor", "nano"))
+	assert.NoError(t, c.Set("github.com", "git_protocol", "ssh"))
+	assert.NoError(t, c.Set("example.com", "editor", "vim"))
+	assert.NoError(t, c.Set("github.com", "user", "hubot"))
+	assert.NoError(t, c.Write())
+
+	assert.Equal(t, `editor: nano
+hosts:
+    github.com:
+        git_protocol: ssh
+        user: hubot
+    example.com:
+        editor: vim
+`, cb.String())
+}

--- a/internal/config/config_type_test.go
+++ b/internal/config/config_type_test.go
@@ -27,3 +27,13 @@ hosts:
         editor: vim
 `, cb.String())
 }
+
+func Test_fileConfig_Write(t *testing.T) {
+	cb := bytes.Buffer{}
+	StubWriteConfig(&cb, nil)
+
+	c := NewBlankConfig()
+	assert.NoError(t, c.Write())
+
+	assert.Equal(t, "", cb.String())
+}

--- a/internal/config/config_type_test.go
+++ b/internal/config/config_type_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 func Test_fileConfig_Set(t *testing.T) {
-	cb := bytes.Buffer{}
-	StubWriteConfig(&cb, nil)
+	mainBuf := bytes.Buffer{}
+	hostsBuf := bytes.Buffer{}
+	defer StubWriteConfig(&mainBuf, &hostsBuf)()
 
 	c := NewBlankConfig()
 	assert.NoError(t, c.Set("", "editor", "nano"))
@@ -18,22 +19,23 @@ func Test_fileConfig_Set(t *testing.T) {
 	assert.NoError(t, c.Set("github.com", "user", "hubot"))
 	assert.NoError(t, c.Write())
 
-	assert.Equal(t, `editor: nano
-hosts:
-    github.com:
-        git_protocol: ssh
-        user: hubot
-    example.com:
-        editor: vim
-`, cb.String())
+	assert.Equal(t, "editor: nano\n", mainBuf.String())
+	assert.Equal(t, `github.com:
+    git_protocol: ssh
+    user: hubot
+example.com:
+    editor: vim
+`, hostsBuf.String())
 }
 
 func Test_fileConfig_Write(t *testing.T) {
-	cb := bytes.Buffer{}
-	StubWriteConfig(&cb, nil)
+	mainBuf := bytes.Buffer{}
+	hostsBuf := bytes.Buffer{}
+	defer StubWriteConfig(&mainBuf, &hostsBuf)()
 
 	c := NewBlankConfig()
 	assert.NoError(t, c.Write())
 
-	assert.Equal(t, "", cb.String())
+	assert.Equal(t, "", mainBuf.String())
+	assert.Equal(t, "", hostsBuf.String())
 }


### PR DESCRIPTION
All per-host configuration info, including authentication credentials, is now written to `hosts.yml` instead of to `config.yml`. This is to make `config.yml` safe to check into version control and share. The migration from old to new config style is done whenever new configuration is written to disk.

The biggest functional change that I've done as part of this PR is that accessing the Config object does _not_ trigger authentication process anymore if the config file is missing. Instead, a blank Config object is returned. This is to facilitate reading configuration such as aliases #970 without triggering any side-effects.

Authentication is now triggered whenever `context.AuthToken()` is accessed, but when there is no `oauth_token` for the current hostname.

Another change in this PR is that the config implementation does not hardcode `github.com` anymore and handles well when other hostnames are written to and read from. This is mainly to pave the way to Enterprise compatibility #273.

Fixes #937 