### PR TITLE
gh api: fix passing file/stdin contents via field arguments

### DIFF
--- a/pkg/cmd/api/http.go
+++ b/pkg/cmd/api/http.go
@@ -22,6 +22,12 @@ func httpRequest(client *http.Client, method string, p string, params interface{
 		if strings.EqualFold(method, "GET") {
 			url = addQuery(url, pp)
 		} else {
+			for key, value := range pp {
+				switch vv := value.(type) {
+				case []byte:
+					pp[key] = string(vv)
+				}
+			}
 			if isGraphQL {
 				pp = groupGraphQLVariables(pp)
 			}

--- a/pkg/cmd/api/http_test.go
+++ b/pkg/cmd/api/http_test.go
@@ -157,7 +157,7 @@ func Test_httpRequest(t *testing.T) {
 				method: "POST",
 				p:      "graphql",
 				params: map[string]interface{}{
-					"a": "b",
+					"a": []byte("b"),
 				},
 				headers: []string{},
 			},


### PR DESCRIPTION
Reading from file via `-F foo=@myfile.txt` syntax would result in `[]byte` Go type, which by default gets serialized to JSON in base64 format, which we don't want here.

Traverse all parameters and convert any `[]byte` into `string` before JSON serialization.

Followup to https://github.com/cli/cli/pull/909