### PR TITLE
fix: merging a PR should checkout the base branch, not the default

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -550,11 +550,6 @@ func prMerge(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(colorableOut(cmd), "%s %s pull request #%d\n", utils.Magenta("✔"), action, pr.Number)
 
 	if deleteBranch {
-		repo, err := api.GitHubRepo(apiClient, baseRepo)
-		if err != nil {
-			return err
-		}
-
 		currentBranch, err := ctx.Branch()
 		if err != nil {
 			return err
@@ -565,8 +560,8 @@ func prMerge(cmd *cobra.Command, args []string) error {
 		if deleteLocalBranch && !crossRepoPR {
 			var branchToSwitchTo string
 			if currentBranch == pr.HeadRefName {
-				branchToSwitchTo = repo.DefaultBranchRef.Name
-				err = git.CheckoutBranch(repo.DefaultBranchRef.Name)
+				branchToSwitchTo = pr.BaseRefName
+				err = git.CheckoutBranch(branchToSwitchTo)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Thanks for making such a great tool!

In my usage, I've found it would be a more convenient default to switch to the base branch of a PR upon merge instead of the default branch for the repository.

Though, I can see how some would prefer to switch to the base branch instead. Happy to open an issue as well and continue any discussion there if need be.

I haven't modified any tests because I didn't see any where the merge command was tested.