### PR TITLE
GHE compatibility for `pr list/status`

### DIFF
--- a/command/pr.go
+++ b/command/pr.go
@@ -40,6 +40,7 @@ func init() {
 	prListCmd.Flags().StringP("base", "B", "", "Filter by base branch")
 	prListCmd.Flags().StringSliceP("label", "l", nil, "Filter by label")
 	prListCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
+	prListCmd.Flags().StringP("author", "A", "", "Filter by author")
 
 	prCmd.AddCommand(prViewCmd)
 	prViewCmd.Flags().BoolP("web", "w", false, "Open a pull request in the browser")
@@ -199,6 +200,10 @@ func prList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	author, err := cmd.Flags().GetString("author")
+	if err != nil {
+		return err
+	}
 
 	var graphqlState []string
 	switch state {
@@ -227,6 +232,9 @@ func prList(cmd *cobra.Command, args []string) error {
 	}
 	if assignee != "" {
 		params["assignee"] = assignee
+	}
+	if author != "" {
+		params["author"] = author
 	}
 
 	listResult, err := api.PullRequestList(apiClient, params, limit)

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/run"
+	"github.com/cli/cli/pkg/httpmock"
 	"github.com/cli/cli/test"
 	"github.com/google/go-cmp/cmp"
 )
@@ -29,10 +30,8 @@ func TestPRStatus(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
-
-	jsonFile, _ := os.Open("../test/fixtures/prStatus.json")
-	defer jsonFile.Close()
-	http.StubResponse(200, jsonFile)
+	http.Register(httpmock.GraphQL(`\b__type\b`), httpmock.FileResponse("../test/fixtures/prIntrospection.json"))
+	http.Register(httpmock.GraphQL(`query PullRequestStatus\b`), httpmock.FileResponse("../test/fixtures/prStatus.json"))
 
 	output, err := RunCommand("pr status")
 	if err != nil {
@@ -57,10 +56,8 @@ func TestPRStatus_fork(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubForkedRepoResponse("OWNER/REPO", "PARENT/REPO")
-
-	jsonFile, _ := os.Open("../test/fixtures/prStatusFork.json")
-	defer jsonFile.Close()
-	http.StubResponse(200, jsonFile)
+	http.Register(httpmock.GraphQL(`\b__type\b`), httpmock.FileResponse("../test/fixtures/prIntrospection.json"))
+	http.Register(httpmock.GraphQL(`query PullRequestStatus\b`), httpmock.FileResponse("../test/fixtures/prStatusFork.json"))
 
 	defer run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		switch strings.Join(cmd.Args, " ") {
@@ -87,10 +84,8 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
-
-	jsonFile, _ := os.Open("../test/fixtures/prStatusChecks.json")
-	defer jsonFile.Close()
-	http.StubResponse(200, jsonFile)
+	http.Register(httpmock.GraphQL(`\b__type\b`), httpmock.FileResponse("../test/fixtures/prIntrospection.json"))
+	http.Register(httpmock.GraphQL(`query PullRequestStatus\b`), httpmock.FileResponse("../test/fixtures/prStatusChecks.json"))
 
 	output, err := RunCommand("pr status")
 	if err != nil {
@@ -114,10 +109,8 @@ func TestPRStatus_currentBranch_showTheMostRecentPR(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
-
-	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranch.json")
-	defer jsonFile.Close()
-	http.StubResponse(200, jsonFile)
+	http.Register(httpmock.GraphQL(`\b__type\b`), httpmock.FileResponse("../test/fixtures/prIntrospection.json"))
+	http.Register(httpmock.GraphQL(`query PullRequestStatus\b`), httpmock.FileResponse("../test/fixtures/prStatusCurrentBranch.json"))
 
 	output, err := RunCommand("pr status")
 	if err != nil {
@@ -146,10 +139,8 @@ func TestPRStatus_currentBranch_defaultBranch(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponseWithDefaultBranch("OWNER", "REPO", "blueberries")
-
-	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranch.json")
-	defer jsonFile.Close()
-	http.StubResponse(200, jsonFile)
+	http.Register(httpmock.GraphQL(`\b__type\b`), httpmock.FileResponse("../test/fixtures/prIntrospection.json"))
+	http.Register(httpmock.GraphQL(`query PullRequestStatus\b`), httpmock.FileResponse("../test/fixtures/prStatusCurrentBranch.json"))
 
 	output, err := RunCommand("pr status")
 	if err != nil {
@@ -166,10 +157,8 @@ func TestPRStatus_currentBranch_defaultBranch(t *testing.T) {
 func TestPRStatus_currentBranch_defaultBranch_repoFlag(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
-
-	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchClosedOnDefaultBranch.json")
-	defer jsonFile.Close()
-	http.StubResponse(200, jsonFile)
+	http.Register(httpmock.GraphQL(`\b__type\b`), httpmock.FileResponse("../test/fixtures/prIntrospection.json"))
+	http.Register(httpmock.GraphQL(`query PullRequestStatus\b`), httpmock.FileResponse("../test/fixtures/prStatusCurrentBranchClosedOnDefaultBranch.json"))
 
 	output, err := RunCommand("pr status -R OWNER/REPO")
 	if err != nil {
@@ -187,10 +176,8 @@ func TestPRStatus_currentBranch_Closed(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
-
-	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchClosed.json")
-	defer jsonFile.Close()
-	http.StubResponse(200, jsonFile)
+	http.Register(httpmock.GraphQL(`\b__type\b`), httpmock.FileResponse("../test/fixtures/prIntrospection.json"))
+	http.Register(httpmock.GraphQL(`query PullRequestStatus\b`), httpmock.FileResponse("../test/fixtures/prStatusCurrentBranchClosed.json"))
 
 	output, err := RunCommand("pr status")
 	if err != nil {
@@ -208,10 +195,8 @@ func TestPRStatus_currentBranch_Closed_defaultBranch(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponseWithDefaultBranch("OWNER", "REPO", "blueberries")
-
-	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchClosedOnDefaultBranch.json")
-	defer jsonFile.Close()
-	http.StubResponse(200, jsonFile)
+	http.Register(httpmock.GraphQL(`\b__type\b`), httpmock.FileResponse("../test/fixtures/prIntrospection.json"))
+	http.Register(httpmock.GraphQL(`query PullRequestStatus\b`), httpmock.FileResponse("../test/fixtures/prStatusCurrentBranchClosedOnDefaultBranch.json"))
 
 	output, err := RunCommand("pr status")
 	if err != nil {
@@ -229,10 +214,8 @@ func TestPRStatus_currentBranch_Merged(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
-
-	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchMerged.json")
-	defer jsonFile.Close()
-	http.StubResponse(200, jsonFile)
+	http.Register(httpmock.GraphQL(`\b__type\b`), httpmock.FileResponse("../test/fixtures/prIntrospection.json"))
+	http.Register(httpmock.GraphQL(`query PullRequestStatus\b`), httpmock.FileResponse("../test/fixtures/prStatusCurrentBranchMerged.json"))
 
 	output, err := RunCommand("pr status")
 	if err != nil {
@@ -250,10 +233,8 @@ func TestPRStatus_currentBranch_Merged_defaultBranch(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponseWithDefaultBranch("OWNER", "REPO", "blueberries")
-
-	jsonFile, _ := os.Open("../test/fixtures/prStatusCurrentBranchMergedOnDefaultBranch.json")
-	defer jsonFile.Close()
-	http.StubResponse(200, jsonFile)
+	http.Register(httpmock.GraphQL(`\b__type\b`), httpmock.FileResponse("../test/fixtures/prIntrospection.json"))
+	http.Register(httpmock.GraphQL(`query PullRequestStatus\b`), httpmock.FileResponse("../test/fixtures/prStatusCurrentBranchMergedOnDefaultBranch.json"))
 
 	output, err := RunCommand("pr status")
 	if err != nil {
@@ -271,6 +252,7 @@ func TestPRStatus_blankSlate(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "blueberries")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
+	http.Register(httpmock.GraphQL(`\b__type\b`), httpmock.FileResponse("../test/fixtures/prIntrospection.json"))
 
 	http.StubResponse(200, bytes.NewBufferString(`
 	{ "data": {} }

--- a/command/root.go
+++ b/command/root.go
@@ -210,6 +210,8 @@ var apiClientForContext = func(ctx context.Context) (*api.Client, error) {
 		// antiope-preview: Checks
 		// shadow-cat-preview: Draft pull requests
 		api.AddHeader("Accept", "application/vnd.github.antiope-preview+json, application/vnd.github.shadow-cat-preview"),
+		// request feature-flagged APIs via OAuth app
+		api.AddHeader("GraphQL-Features", "pe_mobile,gh_cli"),
 	)
 
 	return api.NewClient(opts...), nil

--- a/command/root.go
+++ b/command/root.go
@@ -208,7 +208,8 @@ var apiClientForContext = func(ctx context.Context) (*api.Client, error) {
 		api.AddHeaderFunc("Authorization", getAuthValue),
 		api.AddHeader("User-Agent", fmt.Sprintf("GitHub CLI %s", Version)),
 		// antiope-preview: Checks
-		api.AddHeader("Accept", "application/vnd.github.antiope-preview+json"),
+		// shadow-cat-preview: Draft pull requests
+		api.AddHeader("Accept", "application/vnd.github.antiope-preview+json, application/vnd.github.shadow-cat-preview"),
 	)
 
 	return api.NewClient(opts...), nil

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 )
@@ -68,6 +69,16 @@ func JSONResponse(body interface{}) Responder {
 	return func(*http.Request) (*http.Response, error) {
 		b, _ := json.Marshal(body)
 		return httpResponse(200, bytes.NewBuffer(b)), nil
+	}
+}
+
+func FileResponse(filename string) Responder {
+	return func(*http.Request) (*http.Response, error) {
+		f, err := os.Open(filename)
+		if err != nil {
+			return nil, err
+		}
+		return httpResponse(200, f), nil
 	}
 }
 

--- a/test/fixtures/prIntrospection.json
+++ b/test/fixtures/prIntrospection.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "PullRequest": {
+      "fields": [{ "name": "isDraft" }, { "name": "reviewDecision" }]
+    },
+    "Commit": {
+      "fields": [{ "name": "statusCheckRollup" }]
+    }
+  }
+}

--- a/test/fixtures/prListIntrospection.json
+++ b/test/fixtures/prListIntrospection.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "PullRequest": {
+      "fields": [{ "name": "isDraft" }]
+    },
+    "PullRequestFilters": {
+      "inputFields": [
+        { "name": "assignee" },
+        { "name": "author" },
+        { "name": "labels" },
+        { "name": "state" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This uses GraphQL introspection to query the API functionality of the server and adjust the query accordingly (i.e. never include fields or filters that are unsupported). This approach allows us to conditionally adopt new or feature-flagged APIs in CLI without breaking compatibility with GitHub instances that don't offer the same APIs.

This PR addresses:
- `pr list`
  - provide `assignee` and `author` filtering via `pullRequests.filterBy` feature-flagged API https://github.com/cli/cli/issues/641
  - cleans up the previous Search-powered hack to query by `assignee`
  - avoids querying `isDraft` if it's not available
- `pr status`
  - avoids querying `isDraft` if it's not available
  - omits `reviewDecision` info if not available
  - omits `statusCheckRollup` info if not available

My findings and feelings:
- this works well and was easier to implement than I initially thought
- a slightly modified approach will need to be taken for queries done via the `githubv4` GraphQL library

If we were to go this way, than the remaining API surface to cover wouldn't be large:
1. we would need to stop passing `draft` input to `pr create` unless it's supported
2. upcoming issue templates work https://github.com/cli/cli/issues/875 could make use of the conditional approach

To resolve before this can be merged:
- [ ] is the 500–700ms overhead of API introspection acceptable for commands such as `pr list/status`? should we cache the result locally?
- [x] the `pullRequests.filterBy` API isn't yet ready for adoption due to inconsistencies with different filtering combinations

Ref. https://github.com/cli/cli/pull/823#issuecomment-624241406 https://github.com/cli/cli/issues/273