### PR TITLE
Style all commands like the root help command

### DIFF
--- a/command/help.go
+++ b/command/help.go
@@ -46,6 +46,10 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 		if c.Short == "" {
 			continue
 		}
+		if c.Hidden {
+			continue
+		}
+
 		s := rpad(c.Name()+":", c.NamePadding()) + c.Short
 		if _, ok := c.Annotations["IsCore"]; ok {
 			coreCommands = append(coreCommands, s)

--- a/command/help.go
+++ b/command/help.go
@@ -79,8 +79,8 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 	if command.HasLocalFlags() {
 		helpEntries = append(helpEntries, helpEntry{"FLAGS", strings.TrimRight(command.LocalFlags().FlagUsages(), "\n")})
 	}
-	if _, ok := command.Annotations["help:examples"]; ok {
-		helpEntries = append(helpEntries, helpEntry{"EXAMPLES", command.Annotations["help:examples"]})
+	if command.Example != "" {
+		helpEntries = append(helpEntries, helpEntry{"EXAMPLES", command.Example})
 	}
 	if _, ok := command.Annotations["help:learnmore"]; ok {
 		helpEntries = append(helpEntries, helpEntry{"LEARN MORE", command.Annotations["help:learnmore"]})

--- a/command/help.go
+++ b/command/help.go
@@ -1,0 +1,117 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+func rootDisplayCommandTypoHelp(command *cobra.Command, args []string) {
+	if command != RootCmd {
+		// Display helpful error message in case subcommand name was mistyped.
+		// This matches Cobra's behavior for root command, which Cobra
+		// confusingly doesn't apply to nested commands.
+		if command.Parent() == RootCmd && len(args) >= 2 {
+			if command.SuggestionsMinimumDistance <= 0 {
+				command.SuggestionsMinimumDistance = 2
+			}
+			candidates := command.SuggestionsFor(args[1])
+
+			errOut := command.OutOrStderr()
+			fmt.Fprintf(errOut, "unknown command %q for %q\n", args[1], "gh "+args[0])
+
+			if len(candidates) > 0 {
+				fmt.Fprint(errOut, "\nDid you mean this?\n")
+				for _, c := range candidates {
+					fmt.Fprintf(errOut, "\t%s\n", c)
+				}
+				fmt.Fprint(errOut, "\n")
+			}
+
+			oldOut := command.OutOrStdout()
+			command.SetOut(errOut)
+			defer command.SetOut(oldOut)
+		}
+	}
+}
+
+func rootHelpFunc(command *cobra.Command, args []string) {
+	rootDisplayCommandTypoHelp(command, args)
+
+	coreCommands := []string{}
+	additionalCommands := []string{}
+	for _, c := range command.Commands() {
+		if c.Short == "" {
+			continue
+		}
+		s := rpad(c.Name()+":", c.NamePadding()) + c.Short
+		if _, ok := c.Annotations["IsCore"]; ok {
+			coreCommands = append(coreCommands, s)
+		} else {
+			additionalCommands = append(additionalCommands, s)
+		}
+	}
+
+	// If there are no core commands, assume everything is a core command
+	if len(coreCommands) == 0 {
+		coreCommands = additionalCommands
+		additionalCommands = []string{}
+	}
+
+	type helpEntry struct {
+		Title string
+		Body  string
+	}
+
+	helpEntries := []helpEntry{
+		{"", command.Long},
+		{"USAGE", command.Use},
+	}
+
+	if len(coreCommands) > 0 {
+		helpEntries = append(helpEntries, helpEntry{"CORE COMMANDS", strings.Join(coreCommands, "\n")})
+	}
+	if len(additionalCommands) > 0 {
+		helpEntries = append(helpEntries, helpEntry{"ADDITIONAL COMMANDS", strings.Join(additionalCommands, "\n")})
+	}
+	if command.HasLocalFlags() {
+		helpEntries = append(helpEntries, helpEntry{"FLAGS", strings.TrimRight(command.LocalFlags().FlagUsages(), "\n")})
+	}
+	if _, ok := command.Annotations["help:examples"]; ok {
+		helpEntries = append(helpEntries, helpEntry{"EXAMPLES", command.Annotations["help:examples"]})
+	}
+	if _, ok := command.Annotations["help:learnmore"]; ok {
+		helpEntries = append(helpEntries, helpEntry{"LEARN MORE", command.Annotations["help:learnmore"]})
+	}
+	if _, ok := command.Annotations["help:feedback"]; ok {
+		helpEntries = append(helpEntries, helpEntry{"FEEDBACK", command.Annotations["help:feedback"]})
+	}
+
+	out := colorableOut(command)
+	for _, e := range helpEntries {
+		if e.Title != "" {
+			// If there is a title, add indentation to each line in the body
+			fmt.Fprintln(out, utils.Bold(e.Title))
+
+			for _, l := range strings.Split(e.Body, "\n") {
+				l = strings.Trim(l, " \n\r")
+				if l == "" {
+					continue
+				}
+				fmt.Fprintln(out, "  "+l)
+			}
+		} else {
+			// If there is no title print the body as is
+			fmt.Fprintln(out, e.Body)
+		}
+		fmt.Fprintln(out)
+	}
+}
+
+// rpad adds padding to the right of a string.
+func rpad(s string, padding int) string {
+	template := fmt.Sprintf("%%-%ds ", padding)
+	return fmt.Sprintf(template, s)
+}

--- a/command/help.go
+++ b/command/help.go
@@ -8,11 +8,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func rootDisplayCommandTypoHelp(command *cobra.Command, args []string) {
+func rootHelpFunc(command *cobra.Command, args []string) {
+	// Display helpful error message in case subcommand name was mistyped.
+	// This matches Cobra's behavior for root command, which Cobra
+	// confusingly doesn't apply to nested commands.
 	if command != RootCmd {
-		// Display helpful error message in case subcommand name was mistyped.
-		// This matches Cobra's behavior for root command, which Cobra
-		// confusingly doesn't apply to nested commands.
 		if command.Parent() == RootCmd && len(args) >= 2 {
 			if command.SuggestionsMinimumDistance <= 0 {
 				command.SuggestionsMinimumDistance = 2
@@ -32,13 +32,9 @@ func rootDisplayCommandTypoHelp(command *cobra.Command, args []string) {
 
 			oldOut := command.OutOrStdout()
 			command.SetOut(errOut)
-			command.SetOut(oldOut)
+			defer command.SetOut(oldOut)
 		}
 	}
-}
-
-func rootHelpFunc(command *cobra.Command, args []string) {
-	rootDisplayCommandTypoHelp(command, args)
 
 	coreCommands := []string{}
 	additionalCommands := []string{}

--- a/command/help.go
+++ b/command/help.go
@@ -32,7 +32,7 @@ func rootDisplayCommandTypoHelp(command *cobra.Command, args []string) {
 
 			oldOut := command.OutOrStdout()
 			command.SetOut(errOut)
-			defer command.SetOut(oldOut)
+			command.SetOut(oldOut)
 		}
 	}
 }
@@ -65,11 +65,13 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 		Body  string
 	}
 
-	helpEntries := []helpEntry{
-		{"", command.Long},
-		{"USAGE", command.Use},
+	helpEntries := []helpEntry{}
+	if command.Long != "" {
+		helpEntries = append(helpEntries, helpEntry{"", command.Long})
+	} else if command.Short != "" {
+		helpEntries = append(helpEntries, helpEntry{"", command.Short})
 	}
-
+	helpEntries = append(helpEntries, helpEntry{"USAGE", command.UseLine()})
 	if len(coreCommands) > 0 {
 		helpEntries = append(helpEntries, helpEntry{"CORE COMMANDS", strings.Join(coreCommands, "\n")})
 	}
@@ -98,11 +100,8 @@ Read the manual at <http://cli.github.com/manual>`})
 			// If there is a title, add indentation to each line in the body
 			fmt.Fprintln(out, utils.Bold(e.Title))
 
-			for _, l := range strings.Split(e.Body, "\n") {
+			for _, l := range strings.Split(strings.Trim(e.Body, "\n\r"), "\n") {
 				l = strings.Trim(l, " \n\r")
-				if l == "" {
-					continue
-				}
 				fmt.Fprintln(out, "  "+l)
 			}
 		} else {

--- a/command/help.go
+++ b/command/help.go
@@ -79,12 +79,15 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 	if command.HasLocalFlags() {
 		helpEntries = append(helpEntries, helpEntry{"FLAGS", strings.TrimRight(command.LocalFlags().FlagUsages(), "\n")})
 	}
+	if _, ok := command.Annotations["help:arguments"]; ok {
+		helpEntries = append(helpEntries, helpEntry{"ARGUMENTS", command.Annotations["help:arguments"]})
+	}
 	if command.Example != "" {
 		helpEntries = append(helpEntries, helpEntry{"EXAMPLES", command.Example})
 	}
-	if _, ok := command.Annotations["help:learnmore"]; ok {
-		helpEntries = append(helpEntries, helpEntry{"LEARN MORE", command.Annotations["help:learnmore"]})
-	}
+	helpEntries = append(helpEntries, helpEntry{"LEARN MORE", `
+Use "gh <command> <subcommand> --help" for more information about a command.
+Read the manual at <http://cli.github.com/manual>`})
 	if _, ok := command.Annotations["help:feedback"]; ok {
 		helpEntries = append(helpEntries, helpEntry{"FEEDBACK", command.Annotations["help:feedback"]})
 	}

--- a/command/help.go
+++ b/command/help.go
@@ -93,7 +93,7 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 	}
 	helpEntries = append(helpEntries, helpEntry{"LEARN MORE", `
 Use "gh <command> <subcommand> --help" for more information about a command.
-Read the manual at <http://cli.github.com/manual>`})
+Read the manual at http://cli.github.com/manual`})
 	if _, ok := command.Annotations["help:feedback"]; ok {
 		helpEntries = append(helpEntries, helpEntry{"FEEDBACK", command.Annotations["help:feedback"]})
 	}

--- a/command/issue.go
+++ b/command/issue.go
@@ -49,14 +49,17 @@ func init() {
 }
 
 var issueCmd = &cobra.Command{
-	Use:   "issue",
+	Use:   "issue <command> [flags]",
 	Short: "Create and view issues",
-	Long: `Work with GitHub issues.
-
-An issue can be supplied as argument in any of the following formats:
+	Long:  `Work with GitHub issues.`,
+	Example: `$ gh issue list
+$ gh issue create --fill
+$ gh issue view --web`,
+	Annotations: map[string]string{
+		"IsCore": "true",
+		"help:arguments": `An issue can be supplied as argument in any of the following formats:
 - by number, e.g. "123"; or
-- by URL, e.g. "https://github.com/OWNER/REPO/issues/123".`,
-	Annotations: map[string]string{"IsCore": "true"},
+- by URL, e.g. "https://github.com/OWNER/REPO/issues/123".`},
 }
 var issueCreateCmd = &cobra.Command{
 	Use:   "create",

--- a/command/issue.go
+++ b/command/issue.go
@@ -51,7 +51,7 @@ func init() {
 var issueCmd = &cobra.Command{
 	Use:   "issue <command> [flags]",
 	Short: "Create and view issues",
-	Long:  `Work with GitHub issues.`,
+	Long:  `Work with GitHub issues`,
 	Example: `$ gh issue list
 $ gh issue create --fill
 $ gh issue view --web`,

--- a/command/issue.go
+++ b/command/issue.go
@@ -56,6 +56,7 @@ var issueCmd = &cobra.Command{
 An issue can be supplied as argument in any of the following formats:
 - by number, e.g. "123"; or
 - by URL, e.g. "https://github.com/OWNER/REPO/issues/123".`,
+	Annotations: map[string]string{"IsCore": "true"},
 }
 var issueCreateCmd = &cobra.Command{
 	Use:   "create",

--- a/command/issue.go
+++ b/command/issue.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 var issueCmd = &cobra.Command{
-	Use:   "issue <command> [flags]",
+	Use:   "issue <command>",
 	Short: "Create and view issues",
 	Long:  `Work with GitHub issues`,
 	Example: `$ gh issue list

--- a/command/pr.go
+++ b/command/pr.go
@@ -46,15 +46,19 @@ func init() {
 }
 
 var prCmd = &cobra.Command{
-	Use:   "pr",
+	Use:   "pr <command> [flags]",
 	Short: "Create, view, and checkout pull requests",
-	Long: `Work with GitHub pull requests.
-
-A pull request can be supplied as argument in any of the following formats:
+	Long:  `Work with GitHub pull requests.`,
+	Example: `$ gh pr checkout 353
+$ gh pr checkout bug-fix-branch
+$ gh pr create --fill
+$ gh pr view --web`,
+	Annotations: map[string]string{
+		"IsCore": "true",
+		"help:arguments": `A pull request can be supplied as argument in any of the following formats:
 - by number, e.g. "123";
 - by URL, e.g. "https://github.com/OWNER/REPO/pull/123"; or
-- by the name of its head branch, e.g. "patch-1" or "OWNER:patch-1".`,
-	Annotations: map[string]string{"IsCore": "true"},
+- by the name of its head branch, e.g. "patch-1" or "OWNER:patch-1".`},
 }
 var prListCmd = &cobra.Command{
 	Use:   "list",

--- a/command/pr.go
+++ b/command/pr.go
@@ -46,7 +46,7 @@ func init() {
 }
 
 var prCmd = &cobra.Command{
-	Use:   "pr <command> [flags]",
+	Use:   "pr <command>",
 	Short: "Create, view, and checkout pull requests",
 	Long:  `Work with GitHub pull requests`,
 	Example: `$ gh pr checkout 353
@@ -63,7 +63,10 @@ $ gh pr view --web`,
 var prListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List and filter pull requests in this repository",
-	RunE:  prList,
+	Example: `$ gh pr list --limit all
+$ gh pr list --state closed
+$ gh pr list --label “priority 1” “bug”`,
+	RunE: prList,
 }
 var prStatusCmd = &cobra.Command{
 	Use:   "status",

--- a/command/pr.go
+++ b/command/pr.go
@@ -56,9 +56,10 @@ A pull request can be supplied as argument in any of the following formats:
 - by the name of its head branch, e.g. "patch-1" or "OWNER:patch-1".`,
 }
 var prListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List and filter pull requests in this repository",
-	RunE:  prList,
+	Use:         "list",
+	Short:       "List and filter pull requests in this repository",
+	RunE:        prList,
+	Annotations: map[string]string{"IsCore": "true"},
 }
 var prStatusCmd = &cobra.Command{
 	Use:   "status",

--- a/command/pr.go
+++ b/command/pr.go
@@ -54,12 +54,12 @@ A pull request can be supplied as argument in any of the following formats:
 - by number, e.g. "123";
 - by URL, e.g. "https://github.com/OWNER/REPO/pull/123"; or
 - by the name of its head branch, e.g. "patch-1" or "OWNER:patch-1".`,
+	Annotations: map[string]string{"IsCore": "true"},
 }
 var prListCmd = &cobra.Command{
-	Use:         "list",
-	Short:       "List and filter pull requests in this repository",
-	RunE:        prList,
-	Annotations: map[string]string{"IsCore": "true"},
+	Use:   "list",
+	Short: "List and filter pull requests in this repository",
+	RunE:  prList,
 }
 var prStatusCmd = &cobra.Command{
 	Use:   "status",

--- a/command/pr.go
+++ b/command/pr.go
@@ -48,7 +48,7 @@ func init() {
 var prCmd = &cobra.Command{
 	Use:   "pr <command> [flags]",
 	Short: "Create, view, and checkout pull requests",
-	Long:  `Work with GitHub pull requests.`,
+	Long:  `Work with GitHub pull requests`,
 	Example: `$ gh pr checkout 353
 $ gh pr checkout bug-fix-branch
 $ gh pr create --fill

--- a/command/repo.go
+++ b/command/repo.go
@@ -41,14 +41,19 @@ func init() {
 }
 
 var repoCmd = &cobra.Command{
-	Use:   "repo",
+	Use:   "repo <command> [flags]",
 	Short: "Create, clone, fork, and view repositories",
-	Long: `Work with GitHub repositories.
-
+	Long:  `Work with GitHub repositories`,
+	Example: `$ gh repo create
+$ gh repo clone cli/cli 
+$ gh repo view --web
+`,
+	Annotations: map[string]string{
+		"IsCore": "true",
+		"help:arguments": `
 A repository can be supplied as an argument in any of the following formats:
 - "OWNER/REPO"
-- by URL, e.g. "https://github.com/OWNER/REPO"`,
-	Annotations: map[string]string{"IsCore": "true"},
+- by URL, e.g. "https://github.com/OWNER/REPO"`},
 }
 
 var repoCloneCmd = &cobra.Command{

--- a/command/repo.go
+++ b/command/repo.go
@@ -48,6 +48,7 @@ var repoCmd = &cobra.Command{
 A repository can be supplied as an argument in any of the following formats:
 - "OWNER/REPO"
 - by URL, e.g. "https://github.com/OWNER/REPO"`,
+	Annotations: map[string]string{"IsCore": "true"},
 }
 
 var repoCloneCmd = &cobra.Command{

--- a/command/repo.go
+++ b/command/repo.go
@@ -41,7 +41,7 @@ func init() {
 }
 
 var repoCmd = &cobra.Command{
-	Use:   "repo <command> [flags]",
+	Use:   "repo <command>",
 	Short: "Create, clone, fork, and view repositories",
 	Long:  `Work with GitHub repositories`,
 	Example: `$ gh repo create
@@ -69,9 +69,18 @@ To pass 'git clone' flags, separate them with '--'.`,
 var repoCreateCmd = &cobra.Command{
 	Use:   "create [<name>]",
 	Short: "Create a new repository",
-	Long: `Create a new GitHub repository.
+	Long:  `Create a new GitHub repository`,
+	Example: utils.Bold("$ gh repo create") + `
+Will create a repository on your account using the name of your current directory
 
-Use the "ORG/NAME" syntax to create a repository within your organization.`,
+` + utils.Bold("$ gh repo create my-project") + `
+Will create a repository on your account using the name 'my-project'
+
+` + utils.Bold("$ gh repo create cli/my-project") + `
+Will create a repository in the organization 'cli' using the name 'my-project'`,
+	Annotations: map[string]string{"help:arguments": `A repository can be supplied as an argument in any of the following formats:
+- <OWNER/REPO>
+- by URL, e.g. "https://github.com/OWNER/REPO"`},
 	RunE: repoCreate,
 }
 

--- a/command/root.go
+++ b/command/root.go
@@ -59,6 +59,9 @@ func init() {
 
 	RootCmd.SetHelpFunc(rootHelpFunc)
 
+	// This will silence the usage func on error
+	RootCmd.SetUsageFunc(func(_ *cobra.Command) error { return nil })
+
 	RootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		if err == pflag.ErrHelp {
 			return err

--- a/command/root.go
+++ b/command/root.go
@@ -93,12 +93,10 @@ var RootCmd = &cobra.Command{
 
 	SilenceErrors: true,
 	SilenceUsage:  true,
-
-	Annotations: map[string]string{
-		"help:examples": `
-$ gh issue create
+	Example: `$ gh issue create
 $ gh repo clone
 $ gh pr checkout 321`,
+	Annotations: map[string]string{
 		"help:learnmore": `
 Use "gh <command> <subcommand> --help" for more information about a command.
 Read the manual at <http://cli.github.com/manual>`,

--- a/command/root.go
+++ b/command/root.go
@@ -34,7 +34,6 @@ var Version = "DEV"
 var BuildDate = "" // YYYY-MM-DD
 
 var versionOutput = ""
-var cobraDefaultHelpFunc func(*cobra.Command, []string)
 
 func init() {
 	if Version == "DEV" {
@@ -58,7 +57,6 @@ func init() {
 	// TODO:
 	// RootCmd.PersistentFlags().BoolP("verbose", "V", false, "enable verbose output")
 
-	cobraDefaultHelpFunc = RootCmd.HelpFunc()
 	RootCmd.SetHelpFunc(rootHelpFunc)
 
 	RootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
@@ -95,6 +93,18 @@ var RootCmd = &cobra.Command{
 
 	SilenceErrors: true,
 	SilenceUsage:  true,
+
+	Annotations: map[string]string{
+		"help:examples": `
+$ gh issue create
+$ gh repo clone
+$ gh pr checkout 321`,
+		"help:learnmore": `
+Use "gh <command> <subcommand> --help" for more information about a command.
+Read the manual at <http://cli.github.com/manual>`,
+		"help:feedback": `
+Fill out our feedback form <https://forms.gle/umxd3h31c7aMQFKG7>
+Open an issue using “gh issue create -R cli/cli”`},
 }
 
 var versionCmd = &cobra.Command{
@@ -318,100 +328,6 @@ func determineBaseRepo(apiClient *api.Client, cmd *cobra.Command, ctx context.Co
 	}
 
 	return baseRepo, nil
-}
-
-func rootHelpFunc(command *cobra.Command, args []string) {
-	if command != RootCmd {
-		// Display helpful error message in case subcommand name was mistyped.
-		// This matches Cobra's behavior for root command, which Cobra
-		// confusingly doesn't apply to nested commands.
-		if command.Parent() == RootCmd && len(args) >= 2 {
-			if command.SuggestionsMinimumDistance <= 0 {
-				command.SuggestionsMinimumDistance = 2
-			}
-			candidates := command.SuggestionsFor(args[1])
-
-			errOut := command.OutOrStderr()
-			fmt.Fprintf(errOut, "unknown command %q for %q\n", args[1], "gh "+args[0])
-
-			if len(candidates) > 0 {
-				fmt.Fprint(errOut, "\nDid you mean this?\n")
-				for _, c := range candidates {
-					fmt.Fprintf(errOut, "\t%s\n", c)
-				}
-				fmt.Fprint(errOut, "\n")
-			}
-
-			oldOut := command.OutOrStdout()
-			command.SetOut(errOut)
-			defer command.SetOut(oldOut)
-		}
-		cobraDefaultHelpFunc(command, args)
-		return
-	}
-
-	type helpEntry struct {
-		Title string
-		Body  string
-	}
-
-	coreCommandNames := []string{"issue", "pr", "repo"}
-	var coreCommands []string
-	var additionalCommands []string
-	for _, c := range command.Commands() {
-		if c.Short == "" {
-			continue
-		}
-		s := "  " + rpad(c.Name()+":", c.NamePadding()) + c.Short
-		if includes(coreCommandNames, c.Name()) {
-			coreCommands = append(coreCommands, s)
-		} else if c != creditsCmd {
-			additionalCommands = append(additionalCommands, s)
-		}
-	}
-
-	helpEntries := []helpEntry{
-		{
-			"",
-			command.Long},
-		{"USAGE", command.Use},
-		{"CORE COMMANDS", strings.Join(coreCommands, "\n")},
-		{"ADDITIONAL COMMANDS", strings.Join(additionalCommands, "\n")},
-		{"FLAGS", strings.TrimRight(command.LocalFlags().FlagUsages(), "\n")},
-		{"EXAMPLES", `
-  $ gh issue create
-  $ gh repo clone
-  $ gh pr checkout 321`},
-		{"LEARN MORE", `
-  Use "gh <command> <subcommand> --help" for more information about a command.
-  Read the manual at <http://cli.github.com/manual>`},
-		{"FEEDBACK", `
-  Fill out our feedback form <https://forms.gle/umxd3h31c7aMQFKG7>
-  Open an issue using “gh issue create -R cli/cli”`},
-	}
-
-	out := colorableOut(command)
-	for _, e := range helpEntries {
-		if e.Title != "" {
-			fmt.Fprintln(out, utils.Bold(e.Title))
-		}
-		fmt.Fprintln(out, strings.TrimLeft(e.Body, "\n")+"\n")
-	}
-}
-
-// rpad adds padding to the right of a string.
-func rpad(s string, padding int) string {
-	template := fmt.Sprintf("%%-%ds ", padding)
-	return fmt.Sprintf(template, s)
-}
-
-func includes(a []string, s string) bool {
-	for _, x := range a {
-		if x == s {
-			return true
-		}
-	}
-	return false
 }
 
 func formatRemoteURL(cmd *cobra.Command, fullRepoName string) string {

--- a/command/root.go
+++ b/command/root.go
@@ -98,7 +98,7 @@ $ gh repo clone
 $ gh pr checkout 321`,
 	Annotations: map[string]string{
 		"help:feedback": `
-Fill out our feedback form <https://forms.gle/umxd3h31c7aMQFKG7>
+Fill out our feedback form https://forms.gle/umxd3h31c7aMQFKG7
 Open an issue using “gh issue create -R cli/cli”`},
 }
 

--- a/command/root.go
+++ b/command/root.go
@@ -97,9 +97,6 @@ var RootCmd = &cobra.Command{
 $ gh repo clone
 $ gh pr checkout 321`,
 	Annotations: map[string]string{
-		"help:learnmore": `
-Use "gh <command> <subcommand> --help" for more information about a command.
-Read the manual at <http://cli.github.com/manual>`,
 		"help:feedback": `
 Fill out our feedback form <https://forms.gle/umxd3h31c7aMQFKG7>
 Open an issue using “gh issue create -R cli/cli”`},


### PR DESCRIPTION
This is my proposal to have consistent styling on all of our commands. @ampinsk and me have wanted something like this, but last time I looked into it I ran into technical problems. Specifically, I couldn't figure out a clean way to distinguish the "core" and "additional" sub commands in Go.

After digging to the cobra code I found out about the `Annotations map[string]string` field on every `cobra.Command`. I'm not sure how I missed it before, but it works very well for our needs.

Below is the output for `gh help` `gh help pr` `gh help issue` `gh help repo` `gh help pr list` and `gh help repo create`

![](https://cln.sh/Q8vbiP+)

For commands that weren't edited, they will look like this:

<img width="958" alt="CleanShot 2020-06-09 at 11 16 03@2x" src="https://user-images.githubusercontent.com/596/84184662-a0c43c80-aa42-11ea-8c3d-577760307b53.png">