### PR TITLE
minor credits polish

### DIFF
--- a/cmd/gen-docs/main.go
+++ b/cmd/gen-docs/main.go
@@ -19,12 +19,6 @@ func main() {
 	dir := docCmd.StringP("doc-path", "", "", "Path directory where you want generate doc files")
 	help := docCmd.BoolP("help", "h", false, "Help about any command")
 
-	for _, cmd := range command.RootCmd.Commands() {
-		if _, hidden := cmd.Annotations["hidden"]; hidden {
-			command.RootCmd.RemoveCommand(cmd)
-		}
-	}
-
 	if err := docCmd.Parse(os.Args); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/gen-docs/main.go
+++ b/cmd/gen-docs/main.go
@@ -19,6 +19,12 @@ func main() {
 	dir := docCmd.StringP("doc-path", "", "", "Path directory where you want generate doc files")
 	help := docCmd.BoolP("help", "h", false, "Help about any command")
 
+	for _, cmd := range command.RootCmd.Commands() {
+		if _, hidden := cmd.Annotations["hidden"]; hidden {
+			command.RootCmd.RemoveCommand(cmd)
+		}
+	}
+
 	if err := docCmd.Parse(os.Args); err != nil {
 		os.Exit(1)
 	}

--- a/command/credits.go
+++ b/command/credits.go
@@ -49,9 +49,9 @@ var creditsCmd = &cobra.Command{
   gh credits -s         # display a non-animated thank you
   gh credits | cat      # just print the contributors, one per line
 `,
-	Args:        cobra.ExactArgs(0),
-	RunE:        ghCredits,
-	Annotations: map[string]string{"hidden": "true"},
+	Args:   cobra.ExactArgs(0),
+	RunE:   ghCredits,
+	Hidden: true,
 }
 
 func ghCredits(cmd *cobra.Command, _ []string) error {

--- a/command/credits.go
+++ b/command/credits.go
@@ -51,6 +51,7 @@ var creditsCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(0),
 	RunE: ghCredits,
+	Annotations: map[string]string{"hidden":"true"},
 }
 
 func ghCredits(cmd *cobra.Command, args []string) error {

--- a/command/credits.go
+++ b/command/credits.go
@@ -54,8 +54,8 @@ var creditsCmd = &cobra.Command{
 	Annotations: map[string]string{"hidden": "true"},
 }
 
-func ghCredits(cmd *cobra.Command, args []string) error {
-	args = []string{"cli/cli"}
+func ghCredits(cmd *cobra.Command, _ []string) error {
+	args := []string{"cli/cli"}
 	return credits(cmd, args)
 }
 

--- a/command/credits.go
+++ b/command/credits.go
@@ -41,19 +41,21 @@ func init() {
 }
 
 var creditsCmd = &cobra.Command{
-	Use:   "credits [repository]",
-	Short: "View project's credits",
-	Long: `View animated credits for this or another project.
-
-Examples:
-
-  gh credits            # see a credits animation for this project
+	Use:   "credits",
+	Short: "View credits for this tool",
+	Long: `View animated credits for gh, the tool you are currently using :)`,
+	Example: `gh credits            # see a credits animation for this project
   gh credits owner/repo # see a credits animation for owner/repo
   gh credits -s         # display a non-animated thank you
   gh credits | cat      # just print the contributors, one per line
 `,
-	Args: cobra.MaximumNArgs(1),
-	RunE: credits,
+	Args: cobra.ExactArgs(0),
+	RunE: ghCredits,
+}
+
+func ghCredits(cmd *cobra.Command, args []string) error {
+	args = []string{"cli/cli"}
+	return credits(cmd, args)
 }
 
 func credits(cmd *cobra.Command, args []string) error {
@@ -64,9 +66,18 @@ func credits(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	owner := "cli"
-	repo := "cli"
-	if len(args) > 0 {
+	var owner string
+	var repo string
+
+	if len(args) == 0 {
+	  baseRepo, err := determineBaseRepo(client, cmd, ctx)
+	  if err != nil {
+			return err
+	  }
+
+	  owner = baseRepo.RepoOwner()
+	  repo = baseRepo.RepoName()
+	} else {
 		parts := strings.SplitN(args[0], "/", 2)
 		owner = parts[0]
 		repo = parts[1]

--- a/command/credits.go
+++ b/command/credits.go
@@ -43,15 +43,15 @@ func init() {
 var creditsCmd = &cobra.Command{
 	Use:   "credits",
 	Short: "View credits for this tool",
-	Long: `View animated credits for gh, the tool you are currently using :)`,
+	Long:  `View animated credits for gh, the tool you are currently using :)`,
 	Example: `gh credits            # see a credits animation for this project
   gh credits owner/repo # see a credits animation for owner/repo
   gh credits -s         # display a non-animated thank you
   gh credits | cat      # just print the contributors, one per line
 `,
-	Args: cobra.ExactArgs(0),
-	RunE: ghCredits,
-	Annotations: map[string]string{"hidden":"true"},
+	Args:        cobra.ExactArgs(0),
+	RunE:        ghCredits,
+	Annotations: map[string]string{"hidden": "true"},
 }
 
 func ghCredits(cmd *cobra.Command, args []string) error {
@@ -71,13 +71,13 @@ func credits(cmd *cobra.Command, args []string) error {
 	var repo string
 
 	if len(args) == 0 {
-	  baseRepo, err := determineBaseRepo(client, cmd, ctx)
-	  if err != nil {
+		baseRepo, err := determineBaseRepo(client, cmd, ctx)
+		if err != nil {
 			return err
-	  }
+		}
 
-	  owner = baseRepo.RepoOwner()
-	  repo = baseRepo.RepoName()
+		owner = baseRepo.RepoOwner()
+		repo = baseRepo.RepoName()
 	} else {
 		parts := strings.SplitN(args[0], "/", 2)
 		owner = parts[0]

--- a/command/repo.go
+++ b/command/repo.go
@@ -38,6 +38,9 @@ func init() {
 
 	repoCmd.AddCommand(repoViewCmd)
 	repoViewCmd.Flags().BoolP("web", "w", false, "Open a repository in the browser")
+
+	repoCmd.AddCommand(repoCreditsCmd)
+	repoCreditsCmd.Flags().BoolP("static", "s", false, "Print a static version of the credits")
 }
 
 var repoCmd = &cobra.Command{
@@ -87,6 +90,18 @@ With no argument, the repository for the current directory is displayed.
 
 With '--web', open the repository in a web browser instead.`,
 	RunE: repoView,
+}
+
+var repoCreditsCmd = &cobra.Command{
+	Use: "credits [repository]",
+	Short: "View credits for a repository",
+	Example: `$ gh repo credits           # view credits for the current repository
+$ gh repo credits cool/repo # view credits for cool/repo
+$ gh repo credits -s        # print a non-animated thank you
+$ gh repo credits | cat     # pipe to just print the contributors, one per line
+`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: repoCredits,
 }
 
 func parseCloneArgs(extraArgs []string) (args []string, target string) {
@@ -586,4 +601,8 @@ func repoView(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func repoCredits(cmd *cobra.Command, args []string) error {
+	return credits(cmd, args)
 }

--- a/command/repo.go
+++ b/command/repo.go
@@ -100,10 +100,9 @@ $ gh repo credits cool/repo # view credits for cool/repo
 $ gh repo credits -s        # print a non-animated thank you
 $ gh repo credits | cat     # pipe to just print the contributors, one per line
 `,
-	Args: cobra.MaximumNArgs(1),
-	RunE: repoCredits,
-	// NB will actually be hidden once https://github.com/cli/cli/pull/1106 is in
-	Annotations: map[string]string{"hidden": "true"},
+	Args:   cobra.MaximumNArgs(1),
+	RunE:   repoCredits,
+	Hidden: true,
 }
 
 func parseCloneArgs(extraArgs []string) (args []string, target string) {

--- a/command/repo.go
+++ b/command/repo.go
@@ -93,7 +93,7 @@ With '--web', open the repository in a web browser instead.`,
 }
 
 var repoCreditsCmd = &cobra.Command{
-	Use:   "credits [repository]",
+	Use:   "credits [<repository>]",
 	Short: "View credits for a repository",
 	Example: `$ gh repo credits           # view credits for the current repository
 $ gh repo credits cool/repo # view credits for cool/repo

--- a/command/repo.go
+++ b/command/repo.go
@@ -93,7 +93,7 @@ With '--web', open the repository in a web browser instead.`,
 }
 
 var repoCreditsCmd = &cobra.Command{
-	Use: "credits [repository]",
+	Use:   "credits [repository]",
 	Short: "View credits for a repository",
 	Example: `$ gh repo credits           # view credits for the current repository
 $ gh repo credits cool/repo # view credits for cool/repo
@@ -103,7 +103,7 @@ $ gh repo credits | cat     # pipe to just print the contributors, one per line
 	Args: cobra.MaximumNArgs(1),
 	RunE: repoCredits,
 	// NB will actually be hidden once https://github.com/cli/cli/pull/1106 is in
-	Annotations: map[string]string{"hidden":"true"},
+	Annotations: map[string]string{"hidden": "true"},
 }
 
 func parseCloneArgs(extraArgs []string) (args []string, target string) {

--- a/command/repo.go
+++ b/command/repo.go
@@ -102,6 +102,8 @@ $ gh repo credits | cat     # pipe to just print the contributors, one per line
 `,
 	Args: cobra.MaximumNArgs(1),
 	RunE: repoCredits,
+	// NB will actually be hidden once https://github.com/cli/cli/pull/1106 is in
+	Annotations: map[string]string{"hidden":"true"},
 }
 
 func parseCloneArgs(extraArgs []string) (args []string, target string) {

--- a/command/root.go
+++ b/command/root.go
@@ -363,10 +363,9 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 			continue
 		}
 		s := "  " + rpad(c.Name()+":", c.NamePadding()) + c.Short
-		_, hidden := c.Annotations["hidden"]
 		if includes(coreCommandNames, c.Name()) {
 			coreCommands = append(coreCommands, s)
-		} else if !hidden {
+		} else if !c.Hidden {
 			additionalCommands = append(additionalCommands, s)
 		}
 	}

--- a/command/root.go
+++ b/command/root.go
@@ -363,9 +363,10 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 			continue
 		}
 		s := "  " + rpad(c.Name()+":", c.NamePadding()) + c.Short
+		_, hidden := c.Annotations["hidden"]
 		if includes(coreCommandNames, c.Name()) {
 			coreCommands = append(coreCommands, s)
-		} else if c != creditsCmd {
+		} else if !hidden {
 			additionalCommands = append(additionalCommands, s)
 		}
 	}


### PR DESCRIPTION
This PR:

- adds `gh repo credits [repo]` which behaves the same as `gh credits` does now in 0.9.0
- changes `gh credits` so that it doesn't take an argument and only prints credits for `gh` itself
- makes use of cobra's `Annotations` to mark commands as hidden
- hides hidden commands from manual website and manpages

NB: as of right now I don't know how to exclude things from a subcommands generated usage, but I
believe it will be easy to support once https://github.com/cli/cli/pull/1106 is farther alone.

closes #907
