### PR TITLE
Pretty-print JSON in `api` command output

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -100,8 +100,13 @@ func apiRun(opts *ApiOptions) error {
 	}
 
 	if opts.ShowResponseHeaders {
+		var headerColor, headerColorReset string
+		if opts.IO.ColorEnabled() {
+			headerColor = "\x1b[1;34m" // bright blue
+			headerColorReset = "\x1b[m"
+		}
 		for name, vals := range resp.Header {
-			fmt.Fprintf(opts.IO.Out, "%s: %s\r\n", name, strings.Join(vals, ", "))
+			fmt.Fprintf(opts.IO.Out, "%s%s%s: %s\r\n", headerColor, name, headerColorReset, strings.Join(vals, ", "))
 		}
 		fmt.Fprint(opts.IO.Out, "\r\n")
 	}

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -140,12 +140,14 @@ func Test_apiRun(t *testing.T) {
 				ShowResponseHeaders: true,
 			},
 			httpResponse: &http.Response{
+				Proto:      "HTTP/1.1",
+				Status:     "200 Okey-dokey",
 				StatusCode: 200,
 				Body:       ioutil.NopCloser(bytes.NewBufferString(`body`)),
 				Header:     http.Header{"Content-Type": []string{"text/plain"}},
 			},
 			err:    nil,
-			stdout: "Content-Type: text/plain\r\n\r\nbody",
+			stdout: "HTTP/1.1 200 Okey-dokey\nContent-Type: text/plain\r\n\r\nbody",
 			stderr: ``,
 		},
 		{

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -159,6 +159,31 @@ func Test_apiRun(t *testing.T) {
 			stderr: ``,
 		},
 		{
+			name: "REST error",
+			httpResponse: &http.Response{
+				StatusCode: 400,
+				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"message": "THIS IS FINE"}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+			},
+			err:    cmdutil.SilentError,
+			stdout: `{"message": "THIS IS FINE"}`,
+			stderr: "gh: THIS IS FINE (HTTP 400)\n",
+		},
+		{
+			name: "GraphQL error",
+			options: ApiOptions{
+				RequestPath: "graphql",
+			},
+			httpResponse: &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"errors": [{"message":"AGAIN"}, {"message":"FINE"}]}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+			},
+			err:    cmdutil.SilentError,
+			stdout: `{"errors": [{"message":"AGAIN"}, {"message":"FINE"}]}`,
+			stderr: "gh: AGAIN\nFINE\n",
+		},
+		{
 			name: "failure",
 			httpResponse: &http.Response{
 				StatusCode: 502,
@@ -166,7 +191,7 @@ func Test_apiRun(t *testing.T) {
 			},
 			err:    cmdutil.SilentError,
 			stdout: `gateway timeout`,
-			stderr: ``,
+			stderr: "gh: HTTP 502\n",
 		},
 	}
 

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -5,19 +5,36 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+
+	"github.com/mattn/go-colorable"
+	"github.com/mattn/go-isatty"
 )
 
 type IOStreams struct {
 	In     io.ReadCloser
 	Out    io.Writer
 	ErrOut io.Writer
+
+	colorEnabled bool
+}
+
+func (s *IOStreams) ColorEnabled() bool {
+	return s.colorEnabled
 }
 
 func System() *IOStreams {
+	var out io.Writer = os.Stdout
+	var colorEnabled bool
+	if os.Getenv("NO_COLOR") == "" && isTerminal(os.Stdout) {
+		out = colorable.NewColorable(os.Stdout)
+		colorEnabled = true
+	}
+
 	return &IOStreams{
-		In:     os.Stdin,
-		Out:    os.Stdout,
-		ErrOut: os.Stderr,
+		In:           os.Stdin,
+		Out:          out,
+		ErrOut:       os.Stderr,
+		colorEnabled: colorEnabled,
 	}
 }
 
@@ -30,4 +47,8 @@ func Test() (*IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
 		Out:    out,
 		ErrOut: errOut,
 	}, in, out, errOut
+}
+
+func isTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
 }

--- a/pkg/jsoncolor/jsoncolor.go
+++ b/pkg/jsoncolor/jsoncolor.go
@@ -1,0 +1,95 @@
+package jsoncolor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	colorDelim  = "1;38" // bright white
+	colorKey    = "1;34" // bright blue
+	colorNull   = "1;30" // gray
+	colorString = "32"   // green
+	colorBool   = "33"   // yellow
+)
+
+func Write(w io.Writer, r io.Reader, indent string) error {
+	dec := json.NewDecoder(r)
+	dec.UseNumber()
+
+	var idx int
+	var stack []json.Delim
+
+	for {
+		t, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		switch tt := t.(type) {
+		case json.Delim:
+			switch tt {
+			case '{', '[':
+				stack = append(stack, tt)
+				idx = 0
+				fmt.Fprintf(w, "\x1b[%sm%s\x1b[m", colorDelim, tt)
+				if dec.More() {
+					fmt.Fprint(w, "\n", strings.Repeat(indent, len(stack)))
+				}
+				continue
+			case '}', ']':
+				stack = stack[:len(stack)-1]
+				idx = 0
+				fmt.Fprintf(w, "\x1b[%sm%s\x1b[m", colorDelim, tt)
+			}
+		default:
+			b, err := json.Marshal(tt)
+			if err != nil {
+				return err
+			}
+
+			isKey := len(stack) > 0 && stack[len(stack)-1] == '{' && idx%2 == 0
+			idx++
+
+			var color string
+			if isKey {
+				color = colorKey
+			} else if tt == nil {
+				color = colorNull
+			} else {
+				switch t.(type) {
+				case string:
+					color = colorString
+				case bool:
+					color = colorBool
+				}
+			}
+
+			if color == "" {
+				_, _ = w.Write(b)
+			} else {
+				fmt.Fprintf(w, "\x1b[%sm%s\x1b[m", color, b)
+			}
+
+			if isKey {
+				fmt.Fprintf(w, "\x1b[%sm:\x1b[m ", colorDelim)
+				continue
+			}
+		}
+
+		if dec.More() {
+			fmt.Fprintf(w, "\x1b[%sm,\x1b[m\n%s", colorDelim, strings.Repeat(indent, len(stack)))
+		} else if len(stack) > 0 {
+			fmt.Fprint(w, "\n", strings.Repeat(indent, len(stack)-1))
+		} else {
+			fmt.Fprint(w, "\n")
+		}
+	}
+
+	return nil
+}

--- a/pkg/jsoncolor/jsoncolor.go
+++ b/pkg/jsoncolor/jsoncolor.go
@@ -15,6 +15,7 @@ const (
 	colorBool   = "33"   // yellow
 )
 
+// Write colorized JSON output parsed from reader
 func Write(w io.Writer, r io.Reader, indent string) error {
 	dec := json.NewDecoder(r)
 	dec.UseNumber()

--- a/pkg/jsoncolor/jsoncolor_test.go
+++ b/pkg/jsoncolor/jsoncolor_test.go
@@ -1,0 +1,83 @@
+package jsoncolor
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestWrite(t *testing.T) {
+	type args struct {
+		r      io.Reader
+		indent string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantW   string
+		wantErr bool
+	}{
+		{
+			name: "blank",
+			args: args{
+				r:      bytes.NewBufferString(``),
+				indent: "",
+			},
+			wantW:   "",
+			wantErr: false,
+		},
+		{
+			name: "empty object",
+			args: args{
+				r:      bytes.NewBufferString(`{}`),
+				indent: "",
+			},
+			wantW:   "\x1b[1;38m{\x1b[m\x1b[1;38m}\x1b[m\n",
+			wantErr: false,
+		},
+		{
+			name: "nested object",
+			args: args{
+				r:      bytes.NewBufferString(`{"hash":{"a":1,"b":2},"array":[3,4]}`),
+				indent: "\t",
+			},
+			wantW: "\x1b[1;38m{\x1b[m\n\t\x1b[1;34m\"hash\"\x1b[m\x1b[1;38m:\x1b[m " +
+				"\x1b[1;38m{\x1b[m\n\t\t\x1b[1;34m\"a\"\x1b[m\x1b[1;38m:\x1b[m 1\x1b[1;38m,\x1b[m\n\t\t\x1b[1;34m\"b\"\x1b[m\x1b[1;38m:\x1b[m 2\n\t\x1b[1;38m}\x1b[m\x1b[1;38m,\x1b[m" +
+				"\n\t\x1b[1;34m\"array\"\x1b[m\x1b[1;38m:\x1b[m \x1b[1;38m[\x1b[m\n\t\t3\x1b[1;38m,\x1b[m\n\t\t4\n\t\x1b[1;38m]\x1b[m\n\x1b[1;38m}\x1b[m\n",
+			wantErr: false,
+		},
+		{
+			name: "string",
+			args: args{
+				r:      bytes.NewBufferString(`"foo"`),
+				indent: "",
+			},
+			wantW:   "\x1b[32m\"foo\"\x1b[m\n",
+			wantErr: false,
+		},
+		{
+			name: "error",
+			args: args{
+				r:      bytes.NewBufferString(`{{`),
+				indent: "",
+			},
+			wantW:   "\x1b[1;38m{\x1b[m\n",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			if err := Write(w, tt.args.r, tt.args.indent); (err != nil) != tt.wantErr {
+				t.Errorf("Write() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			diff := cmp.Diff(tt.wantW, w.String())
+			if diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Before:
```
{"data":{"viewer":{"login":"mislav","following":{"totalCount":22},"isSiteAdmin":true}}}
```
After:
<img width="309" alt="Screen Shot 2020-06-05 at 5 44 42 PM" src="https://user-images.githubusercontent.com/887/83896333-44b49c00-a754-11ea-8c35-875c18042f93.png">

This should make it easier on the eyes when playing around with GitHub API. When the output is piped to a script, the data returned from the server is as before (unprocessed).

Ref. https://github.com/cli/cli/issues/332