### PR TITLE
Change angular brackets with single quotes

### DIFF
--- a/command/completion.go
+++ b/command/completion.go
@@ -28,7 +28,7 @@ For example, for bash you could add this to your '~/.bash_profile':
 
 When installing GitHub CLI through a package manager, however, it's possible that
 no additional shell configuration is necessary to gain completion support. For
-Homebrew, see 'https://docs.brew.sh/Shell-Completion'
+Homebrew, see https://docs.brew.sh/Shell-Completion
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		shellType, err := cmd.Flags().GetString("shell")

--- a/command/completion.go
+++ b/command/completion.go
@@ -28,7 +28,7 @@ For example, for bash you could add this to your '~/.bash_profile':
 
 When installing GitHub CLI through a package manager, however, it's possible that
 no additional shell configuration is necessary to gain completion support. For
-Homebrew, see <https://docs.brew.sh/Shell-Completion>
+Homebrew, see 'https://docs.brew.sh/Shell-Completion'
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		shellType, err := cmd.Flags().GetString("shell")


### PR DESCRIPTION
printing the following on a terminal:
https://github.com/cli/cli/blob/59580e6ac70343ee68ad86736ba43f617c8e98b8/command/completion.go#L31
would result in a clickable link that leads to an inexistent page: [https://docs.brew.sh/Shell-Completion>](https://docs.brew.sh/Shell-Completion%3E). Notice the trailing `>` at the end of the string.
