### PR TITLE
Added examples and custom error message for space separated issues

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -67,13 +67,13 @@ var issueListCmd = &cobra.Command{
 	Short: "List and filter issues in this repository",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
-			return fmt.Errorf("unknown command %q for %q. Please include whitespace separated issue names within quotes if necessary", args[0], cmd.CommandPath())
+			return fmt.Errorf("unknown argument %q for %q: Please quote all flag values that contain spaces.", args[0], cmd.CommandPath())
 		}
 		return nil
 	},
 	Example: `
-	gh issue list
-	gh issue list -l "help wanted"
+	$ gh issue list -l "help wanted"
+	$ gh issue list -A "some author"
 	`,
 	RunE: issueList,
 }

--- a/command/issue.go
+++ b/command/issue.go
@@ -65,7 +65,17 @@ var issueCreateCmd = &cobra.Command{
 var issueListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List and filter issues in this repository",
-	RunE:  issueList,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return fmt.Errorf("unknown command %q for %q. Please include whitespace separated issue names within quotes if necessary", args[0], cmd.CommandPath())
+		}
+		return nil
+	},
+	Example: `
+	gh issue list
+	gh issue list -l "help wanted"
+	`,
+	RunE: issueList,
 }
 var issueStatusCmd = &cobra.Command{
 	Use:   "status",

--- a/command/issue.go
+++ b/command/issue.go
@@ -84,6 +84,7 @@ var issueListCmd = &cobra.Command{
 var issueStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show status of relevant issues",
+	Args:  cmdutil.NoArgsQuoteReminder,
 	RunE:  issueStatus,
 }
 var issueViewCmd = &cobra.Command{

--- a/command/issue.go
+++ b/command/issue.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/githubtemplate"
 	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
@@ -67,21 +68,17 @@ var issueCmd = &cobra.Command{
 var issueCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new issue",
+	Args:  cmdutil.NoArgsQuoteReminder,
 	RunE:  issueCreate,
 }
 var issueListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List and filter issues in this repository",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 0 {
-			return fmt.Errorf("unknown argument %q for %q: Please quote all flag values that contain spaces.", args[0], cmd.CommandPath())
-		}
-		return nil
-	},
-	Example: `
+	Example: heredoc.Doc(`
 	$ gh issue list -l "help wanted"
-	$ gh issue list -A "some author"
-	`,
+	$ gh issue list -A monalisa
+	`),
+	Args: cmdutil.NoArgsQuoteReminder,
 	RunE: issueList,
 }
 var issueStatusCmd = &cobra.Command{

--- a/command/pr.go
+++ b/command/pr.go
@@ -77,6 +77,7 @@ var prListCmd = &cobra.Command{
 var prStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show status of relevant pull requests",
+	Args:  cmdutil.NoArgsQuoteReminder,
 	RunE:  prStatus,
 }
 var prViewCmd = &cobra.Command{

--- a/command/pr.go
+++ b/command/pr.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/text"
 	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
@@ -65,6 +66,7 @@ var prCmd = &cobra.Command{
 var prListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List and filter pull requests in this repository",
+	Args:  cmdutil.NoArgsQuoteReminder,
 	Example: heredoc.Doc(`
 	$ gh pr list --limit 999
 	$ gh pr list --state closed

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/githubtemplate"
 	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
@@ -452,6 +453,7 @@ func generateCompareURL(r ghrepo.Interface, base, head, title, body string, assi
 var prCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a pull request",
+	Args:  cmdutil.NoArgsQuoteReminder,
 	RunE:  prCreate,
 }
 

--- a/pkg/cmdutil/args.go
+++ b/pkg/cmdutil/args.go
@@ -1,0 +1,33 @@
+package cmdutil
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func NoArgsQuoteReminder(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return nil
+	}
+
+	errMsg := fmt.Sprintf("unknown argument %q", args[0])
+	if len(args) > 1 {
+		errMsg = fmt.Sprintf("unknown arguments %q", args)
+	}
+
+	hasValueFlag := false
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		if f.Value.Type() != "bool" {
+			hasValueFlag = true
+		}
+	})
+
+	if hasValueFlag {
+		errMsg += "; please quote all values that have spaces"
+	}
+
+	return &FlagError{Err: errors.New(errMsg)}
+}


### PR DESCRIPTION
Fixes #756 

This adds a custom message if user forgets to enclose space separated names within quotations. Didn't update the listHeader function since this takes care of the function entirely. Added 2 examples in `issueList.Example` category to explain the same.

Please let me know if we need to add tests for this. I'll be glad to do so. I currently abstained from doing since this is just a reference indicator.