### PR TITLE
Support passing raw POST body in `api` command

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -35,7 +35,11 @@ func NewClient(opts ...ClientOption) *Client {
 func AddHeader(name, value string) ClientOption {
 	return func(tr http.RoundTripper) http.RoundTripper {
 		return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
-			req.Header.Add(name, value)
+			// prevent the token from leaking to non-GitHub hosts
+			// TODO: GHE support
+			if !strings.EqualFold(name, "Authorization") || strings.HasSuffix(req.URL.Hostname(), ".github.com") {
+				req.Header.Add(name, value)
+			}
 			return tr.RoundTrip(req)
 		}}
 	}
@@ -45,7 +49,11 @@ func AddHeader(name, value string) ClientOption {
 func AddHeaderFunc(name string, value func() string) ClientOption {
 	return func(tr http.RoundTripper) http.RoundTripper {
 		return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
-			req.Header.Add(name, value())
+			// prevent the token from leaking to non-GitHub hosts
+			// TODO: GHE support
+			if !strings.EqualFold(name, "Authorization") || strings.HasSuffix(req.URL.Hostname(), ".github.com") {
+				req.Header.Add(name, value())
+			}
 			return tr.RoundTrip(req)
 		}}
 	}

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -20,6 +20,7 @@ type ApiOptions struct {
 	RequestMethod       string
 	RequestMethodPassed bool
 	RequestPath         string
+	RequestInputFile    string
 	MagicFields         []string
 	RawFields           []string
 	RequestHeaders      []string
@@ -55,6 +56,10 @@ on the format of the value:
   appropriate JSON types;
 - if the value starts with "@", the rest of the value is interpreted as a
   filename to read the value from. Pass "-" to read from standard input.
+
+Raw request body may be passed from the outside via a file specified by '--input'.
+Pass "-" to read from standard input. In this mode, parameters specified via
+'--field' flags are serialized into URL query parameters.
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
@@ -73,6 +78,7 @@ on the format of the value:
 	cmd.Flags().StringArrayVarP(&opts.RawFields, "raw-field", "f", nil, "Add a string parameter")
 	cmd.Flags().StringArrayVarP(&opts.RequestHeaders, "header", "H", nil, "Add an additional HTTP request header")
 	cmd.Flags().BoolVarP(&opts.ShowResponseHeaders, "include", "i", false, "Include HTTP response headers in the output")
+	cmd.Flags().StringVar(&opts.RequestInputFile, "input", "", "The file to use as body for the HTTP request")
 	return cmd
 }
 
@@ -83,8 +89,25 @@ func apiRun(opts *ApiOptions) error {
 	}
 
 	method := opts.RequestMethod
-	if len(params) > 0 && !opts.RequestMethodPassed {
+	requestPath := opts.RequestPath
+	requestHeaders := opts.RequestHeaders
+	var requestBody interface{} = params
+
+	if !opts.RequestMethodPassed && (len(params) > 0 || opts.RequestInputFile != "") {
 		method = "POST"
+	}
+
+	if opts.RequestInputFile != "" {
+		file, size, err := openUserFile(opts.RequestInputFile, opts.IO.In)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		requestPath = addQuery(requestPath, params)
+		requestBody = file
+		if size > 0 {
+			requestHeaders = append(requestHeaders, fmt.Sprintf("Content-Length: %d", size))
+		}
 	}
 
 	httpClient, err := opts.HttpClient()
@@ -92,7 +115,7 @@ func apiRun(opts *ApiOptions) error {
 		return err
 	}
 
-	resp, err := httpRequest(httpClient, method, opts.RequestPath, params, opts.RequestHeaders)
+	resp, err := httpRequest(httpClient, method, requestPath, requestBody, requestHeaders)
 	if err != nil {
 		return err
 	}
@@ -187,4 +210,22 @@ func readUserFile(fn string, stdin io.ReadCloser) ([]byte, error) {
 	}
 	defer r.Close()
 	return ioutil.ReadAll(r)
+}
+
+func openUserFile(fn string, stdin io.ReadCloser) (io.ReadCloser, int64, error) {
+	if fn == "-" {
+		return stdin, 0, nil
+	}
+
+	r, err := os.Open(fn)
+	if err != nil {
+		return r, 0, err
+	}
+
+	s, err := os.Stat(fn)
+	if err != nil {
+		return r, 0, err
+	}
+
+	return r, s.Size(), nil
 }

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -248,7 +248,6 @@ func readUserFile(fn string, stdin io.ReadCloser) ([]byte, error) {
 	return ioutil.ReadAll(r)
 }
 
-
 func openUserFile(fn string, stdin io.ReadCloser) (io.ReadCloser, error) {
 	if fn == "-" {
 		return stdin, nil

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -373,7 +373,7 @@ func Test_openUserFile(t *testing.T) {
 	f.Close()
 	t.Cleanup(func() { os.Remove(f.Name()) })
 
-	file, length, err := openUserFile(f.Name(), nil)
+	file, err := openUserFile(f.Name(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -384,6 +384,5 @@ func Test_openUserFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, int64(13), length)
 	assert.Equal(t, "file contents", string(fb))
 }

--- a/pkg/cmd/api/http.go
+++ b/pkg/cmd/api/http.go
@@ -11,8 +11,14 @@ import (
 )
 
 func httpRequest(client *http.Client, method string, p string, params interface{}, headers []string) (*http.Response, error) {
+	var requestURL string
 	// TODO: GHE support
-	url := "https://api.github.com/" + p
+	if strings.Contains(p, "://") {
+		requestURL = p
+	} else {
+		requestURL = "https://api.github.com/" + p
+	}
+
 	var body io.Reader
 	var bodyIsJSON bool
 	isGraphQL := p == "graphql"
@@ -20,7 +26,7 @@ func httpRequest(client *http.Client, method string, p string, params interface{
 	switch pp := params.(type) {
 	case map[string]interface{}:
 		if strings.EqualFold(method, "GET") {
-			url = addQuery(url, pp)
+			requestURL = addQuery(requestURL, pp)
 		} else {
 			for key, value := range pp {
 				switch vv := value.(type) {
@@ -46,7 +52,7 @@ func httpRequest(client *http.Client, method string, p string, params interface{
 		return nil, fmt.Errorf("unrecognized parameters type: %v", params)
 	}
 
-	req, err := http.NewRequest(method, url, body)
+	req, err := http.NewRequest(method, requestURL, body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is to enable:
- file uploads
- constructing and passing in a complex JSON body that could not be constructed via `--field`

Examples:
```sh
# with content-type
$ gh api path/to/endpoint --input myfile.zip -H 'content-type application/zip'

# full hostname
$ gh api https://upload.github.com/path/to/endpoint --input myfile.zip

# from stdin
$ gh api path/to/endpoint --input -
```

Questions:
- [ ] I've adopted `--input` from hub, but is there a better/more descriptive name for this flag? 

Ref. #332