### PR TITLE
Allow users to view an issue or PR even when the object provided is incorrect

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cli/cli/internal/ghrepo"
@@ -357,6 +359,9 @@ func IssueByNumber(client *Client, repo ghrepo.Interface, number int) (*Issue, e
 	var resp response
 	err := client.GraphQL(query, variables, &resp)
 	if err != nil {
+		if strings.HasPrefix(err.Error(), "graphql error: 'Could not resolve to an Issue with the number of ") {
+			return nil, &NotFoundError{errors.New("no such issue")}
+		}
 		return nil, err
 	}
 

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -183,7 +183,7 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 			headBranchLabel = fmt.Sprintf("%s:%s", headRepo.RepoOwner(), headBranch)
 		}
 		existingPR, err := api.PullRequestForBranch(client, baseRepo, baseBranch, headBranchLabel)
-		var notFound *api.NotFoundError
+		var notFound *api.PRNotFoundError
 		if err != nil && !errors.As(err, &notFound) {
 			return fmt.Errorf("error checking for existing pull request: %w", err)
 		}


### PR DESCRIPTION
Closes #1131 

I have tested it out, and it works.

![image](https://user-images.githubusercontent.com/32998057/84409621-4afeb880-ac2b-11ea-9819-1b14227d9c30.png)
@billygriffin @mislav is this in accordance with what you had in mind?

