### PR TITLE
initialize a non-empty config

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -165,10 +165,7 @@ func (c *fsContext) Config() (config.Config, error) {
 	if c.config == nil {
 		cfg, err := config.ParseDefaultConfig()
 		if errors.Is(err, os.ErrNotExist) {
-			cfg, err = config.InitDefaultConfig()
-			if err != nil {
-				return nil, fmt.Errorf("could not create default config: %w", err)
-			}
+			cfg = config.NewBlankConfig()
 		} else if err != nil {
 			return nil, err
 		}

--- a/context/context.go
+++ b/context/context.go
@@ -165,7 +165,10 @@ func (c *fsContext) Config() (config.Config, error) {
 	if c.config == nil {
 		cfg, err := config.ParseDefaultConfig()
 		if errors.Is(err, os.ErrNotExist) {
-			cfg = config.NewBlankConfig()
+			cfg, err = config.InitDefaultConfig()
+			if err != nil {
+				return nil, fmt.Errorf("could not create default config: %w", err)
+			}
 		} else if err != nil {
 			return nil, err
 		}

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
 
@@ -96,16 +97,16 @@ github.com:
 	defer StubBackupConfig()()
 
 	_, err := ParseConfig("config.yml")
-	eq(t, err, nil)
+	assert.Nil(t, err)
 
-	expectedMain := ""
+	expectedMain := "# What protocol to use when performing git operations. Supported values: ssh, https\ngit_protocol: https\n# What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.\neditor:\n# Aliases allow you to create nicknames for gh commands\naliases:\n    co: pr checkout\n"
 	expectedHosts := `github.com:
     user: keiyuri
     oauth_token: "123456"
 `
 
-	eq(t, mainBuf.String(), expectedMain)
-	eq(t, hostsBuf.String(), expectedHosts)
+	assert.Equal(t, expectedMain, mainBuf.String())
+	assert.Equal(t, expectedHosts, hostsBuf.String())
 }
 
 func Test_parseConfigFile(t *testing.T) {

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -122,8 +122,8 @@ func NewConfig(root *yaml.Node) Config {
 	}
 }
 
-func InitDefaultConfig() (Config, error) {
-	cfg := NewConfig(&yaml.Node{
+func NewBlankConfig() Config {
+	return NewConfig(&yaml.Node{
 		Kind: yaml.DocumentNode,
 		Content: []*yaml.Node{
 			{
@@ -168,21 +168,6 @@ func InitDefaultConfig() (Config, error) {
 				},
 			},
 		},
-	})
-
-	err := cfg.Write()
-	if err != nil {
-		return nil, err
-	}
-
-	return cfg, nil
-
-}
-
-func NewBlankConfig() Config {
-	return NewConfig(&yaml.Node{
-		Kind:    yaml.DocumentNode,
-		Content: []*yaml.Node{{Kind: yaml.MappingNode}},
 	})
 }
 

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -122,6 +122,63 @@ func NewConfig(root *yaml.Node) Config {
 	}
 }
 
+func InitDefaultConfig() (Config, error) {
+	cfg := NewConfig(&yaml.Node{
+		Kind: yaml.DocumentNode,
+		Content: []*yaml.Node{
+			{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					{
+						HeadComment: "What protocol to use when performing git operations. Supported values: ssh, https",
+						Kind:        yaml.ScalarNode,
+						Value:       "git_protocol",
+					},
+					{
+						Kind:  yaml.ScalarNode,
+						Value: "https",
+					},
+					{
+						HeadComment: "What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.",
+						Kind:        yaml.ScalarNode,
+						Value:       "editor",
+					},
+					{
+						Kind:  yaml.ScalarNode,
+						Value: "",
+					},
+					{
+						HeadComment: "Aliases allow you to create nicknames for gh commands",
+						Kind:        yaml.ScalarNode,
+						Value:       "aliases",
+					},
+					{
+						Kind: yaml.MappingNode,
+						Content: []*yaml.Node{
+							{
+								Kind:  yaml.ScalarNode,
+								Value: "co",
+							},
+							{
+								Kind:  yaml.ScalarNode,
+								Value: "pr checkout",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	err := cfg.Write()
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+
+}
+
 func NewBlankConfig() Config {
 	return NewConfig(&yaml.Node{
 		Kind:    yaml.DocumentNode,


### PR DESCRIPTION
This PR initializes a non-empty config. Should a user desire an empty config, they can delete the contents of `config.yml` while leaving the file itself in place.

The default config contents are:

```yaml
# What protocol to use when performing git operations. Supported values: ssh, https
git_protocol: https
# What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.
editor:
# Aliases allow you to create nicknames for gh commands
aliases:
    co: pr checkout
```

Closes #1127
Closes #803 

## TODO

- [x] add a test