### PR TITLE
Revert "Fix error while adding Milestone Metadata to PR during create"

### DIFF
--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -280,13 +280,6 @@ func titleBodySurvey(cmd *cobra.Command, issueState *issueMetadataState, apiClie
 			milestones = append(milestones, m.Title)
 		}
 
-		type metadataValues struct {
-			Reviewers []string
-			Assignees []string
-			Labels    []string
-			Projects  []string
-			Milestone string
-		}
 		var mqs []*survey.Question
 		if isChosen("Reviewers") {
 			if len(users) > 0 || len(teams) > 0 {
@@ -346,7 +339,7 @@ func titleBodySurvey(cmd *cobra.Command, issueState *issueMetadataState, apiClie
 		}
 		if isChosen("Milestone") {
 			if len(milestones) > 1 {
-				var milestoneDefault string
+				var milestoneDefault interface{}
 				if len(issueState.Milestones) > 0 {
 					milestoneDefault = issueState.Milestones[0]
 				}
@@ -362,16 +355,11 @@ func titleBodySurvey(cmd *cobra.Command, issueState *issueMetadataState, apiClie
 				cmd.PrintErrln("warning: no milestones in the repository")
 			}
 		}
-		values := metadataValues{}
-		err = SurveyAsk(mqs, &values, survey.WithKeepFilter(true))
+
+		err = SurveyAsk(mqs, issueState, survey.WithKeepFilter(true))
 		if err != nil {
 			return fmt.Errorf("could not prompt: %w", err)
 		}
-		issueState.Reviewers = values.Reviewers
-		issueState.Assignees = values.Assignees
-		issueState.Labels = values.Labels
-		issueState.Projects = values.Projects
-		issueState.Milestones = []string{values.Milestone}
 
 		if len(issueState.Milestones) > 0 && issueState.Milestones[0] == noMilestone {
 			issueState.Milestones = issueState.Milestones[0:0]


### PR DESCRIPTION
Reverts cli/cli#1124

This is on me; I didn't test `pr create` locally and turns out this breaks it.

cc @AliabbasMerchant 