### PR TITLE
Fix gh config examples in documentations

### DIFF
--- a/command/config.go
+++ b/command/config.go
@@ -36,6 +36,7 @@ var configGetCmd = &cobra.Command{
 	Long: `Get the value for a given configuration key.
 
 Examples:
+
   $ gh config get git_protocol
   https
 `,
@@ -49,6 +50,7 @@ var configSetCmd = &cobra.Command{
 	Long: `Update the configuration by setting a key to a value.
 
 Examples:
+
   $ gh config set editor vim
 `,
 	Args: cobra.ExactArgs(2),


### PR DESCRIPTION
<!--
Please make sure you read our contributing guidelines at
https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md
before opening opening a pull request. Thanks!
-->

## Summary

The examples of [`gh config get`](https://cli.github.com/manual/gh_config_get) and [`gh config set`](https://cli.github.com/manual/gh_config_set) are missing empty lines so it's been incorrectly rendered.

### Screenshots:

![Screenshot 2020-06-11 at 19 49 54](https://user-images.githubusercontent.com/21333876/84377377-74b0e300-ac1d-11ea-893a-09d88a566f94.png)

![Screenshot 2020-06-11 at 19 50 00](https://user-images.githubusercontent.com/21333876/84377256-4a5f2580-ac1d-11ea-861e-23df1c6ffcb8.png)

## Details

N/A