### PR TITLE
Fix error when Milestone is empty during PR create

### DIFF
--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -371,10 +371,8 @@ func titleBodySurvey(cmd *cobra.Command, issueState *issueMetadataState, apiClie
 		issueState.Assignees = values.Assignees
 		issueState.Labels = values.Labels
 		issueState.Projects = values.Projects
-		issueState.Milestones = []string{values.Milestone}
-
-		if len(issueState.Milestones) > 0 && issueState.Milestones[0] == noMilestone {
-			issueState.Milestones = issueState.Milestones[0:0]
+		if values.Milestone != "" && values.Milestone != noMilestone {
+			issueState.Milestones = []string{values.Milestone}
 		}
 
 		allowPreview = !issueState.HasMetadata()


### PR DESCRIPTION
## Summary

Replaces #1159
Fixes bug introduced in #1124

## Details
I missed the corner case in #1124. Thanks @mislav and @vilmibm for pointing it out!
