### PR TITLE
api command: support `{owner}` and `{repo}` placeholders

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -75,14 +75,21 @@ func init() {
 		HttpClient: func() (*http.Client, error) {
 			token := os.Getenv("GITHUB_TOKEN")
 			if len(token) == 0 {
+				// TODO: decouple from `context`
 				ctx := context.New()
 				var err error
+				// TODO: pass IOStreams to this so that the auth flow knows if it's interactive or not
 				token, err = ctx.AuthToken()
 				if err != nil {
 					return nil, err
 				}
 			}
 			return httpClient(token), nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			// TODO: decouple from `context`
+			ctx := context.New()
+			return ctx.BaseRepo()
 		},
 	}
 	RootCmd.AddCommand(apiCmd.NewCmdApi(cmdFactory, nil))

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.0.7
+	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/briandowns/spinner v1.11.1
 	github.com/charmbracelet/glamour v0.1.1-0.20200320173916-301d3bcf3058
 	github.com/dlclark/regexp2 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/AlecAivazis/survey/v2 v2.0.7 h1:+f825XHLse/hWd2tE/V5df04WFGimk34Eyg/z
 github.com/AlecAivazis/survey/v2 v2.0.7/go.mod h1:mlizQTaPjnR4jcpwRSaSlkbsRfYFEyKgLQvYTzxxiHA=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
@@ -48,13 +49,16 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 		Short: "Make an authenticated GitHub API request",
 		Long: `Makes an authenticated HTTP request to the GitHub API and prints the response.
 
-The <endpoint> argument should either be a path of a GitHub API v3 endpoint, or
+The endpoint argument should either be a path of a GitHub API v3 endpoint, or
 "graphql" to access the GitHub API v4.
+
+Placeholder values ":owner" and ":repo" in the endpoint argument will get replaced
+with values from the repository of the current directory.
 
 The default HTTP request method is "GET" normally and "POST" if any parameters
 were added. Override the method with '--method'.
 
-Pass one or more '--raw-field' values in "<key>=<value>" format to add
+Pass one or more '--raw-field' values in "key=value" format to add
 JSON-encoded string parameters to the POST body.
 
 The '--field' flag behaves like '--raw-field' with magic type conversion based
@@ -62,6 +66,8 @@ on the format of the value:
 
 - literal values "true", "false", "null", and integer numbers get converted to
   appropriate JSON types;
+- placeholder values ":owner" and ":repo" get populated with values from the
+  repository of the current directory;
 - if the value starts with "@", the rest of the value is interpreted as a
   filename to read the value from. Pass "-" to read from standard input.
 
@@ -69,6 +75,19 @@ Raw request body may be passed from the outside via a file specified by '--input
 Pass "-" to read from standard input. In this mode, parameters specified via
 '--field' flags are serialized into URL query parameters.
 `,
+		Example: heredoc.Doc(`
+			$ gh api repos/:owner/:repo/releases
+
+			$ gh api graphql -F owner=':owner' -F name=':repo' -f query='
+				query($name: String!, $owner: String!) {
+					repository(owner: $owner, name: $name) {
+						releases(last: 3) {
+							nodes { tagName }
+						}
+					}
+				}
+			'
+		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.RequestPath = args[0]
@@ -96,9 +115,9 @@ func apiRun(opts *ApiOptions) error {
 		return err
 	}
 
-	requestPath, params, err := fillPlaceholders(opts, params)
+	requestPath, err := fillPlaceholders(opts.RequestPath, opts)
 	if err != nil {
-		return fmt.Errorf("unable to expand `{...}` placeholders in query: %w", err)
+		return fmt.Errorf("unable to expand placeholder in path: %w", err)
 	}
 	method := opts.RequestMethod
 	requestHeaders := opts.RequestHeaders
@@ -176,35 +195,31 @@ func apiRun(opts *ApiOptions) error {
 	return nil
 }
 
-// fillPlaceholders replaces `{owner}` and `{repo}` placeholders with values from the current repository
-func fillPlaceholders(opts *ApiOptions, params map[string]interface{}) (string, map[string]interface{}, error) {
-	query := opts.RequestPath
-	isGraphQL := opts.RequestPath == "graphql"
+var placeholderRE = regexp.MustCompile(`\:(owner|repo)\b`)
 
-	if isGraphQL {
-		if q, ok := params["query"].(string); ok {
-			query = q
-		}
-	}
-
-	if !strings.Contains(query, "{owner}") && !strings.Contains(query, "{repo}") {
-		return opts.RequestPath, params, nil
+// fillPlaceholders populates `:owner` and `:repo` placeholders with values from the current repository
+func fillPlaceholders(value string, opts *ApiOptions) (string, error) {
+	if !placeholderRE.MatchString(value) {
+		return value, nil
 	}
 
 	baseRepo, err := opts.BaseRepo()
 	if err != nil {
-		return opts.RequestPath, params, err
+		return value, err
 	}
 
-	query = strings.ReplaceAll(query, "{owner}", baseRepo.RepoOwner())
-	query = strings.ReplaceAll(query, "{repo}", baseRepo.RepoName())
+	value = placeholderRE.ReplaceAllStringFunc(value, func(m string) string {
+		switch m {
+		case ":owner":
+			return baseRepo.RepoOwner()
+		case ":repo":
+			return baseRepo.RepoName()
+		default:
+			panic(fmt.Sprintf("invalid placeholder: %q", m))
+		}
+	})
 
-	if isGraphQL {
-		params["query"] = query
-		return opts.RequestPath, params, nil
-	}
-
-	return query, params, nil
+	return value, nil
 }
 
 func printHeaders(w io.Writer, headers http.Header, colorize bool) {
@@ -241,7 +256,7 @@ func parseFields(opts *ApiOptions) (map[string]interface{}, error) {
 		if err != nil {
 			return params, err
 		}
-		value, err := magicFieldValue(strValue, opts.IO.In)
+		value, err := magicFieldValue(strValue, opts)
 		if err != nil {
 			return params, fmt.Errorf("error parsing %q value: %w", key, err)
 		}
@@ -258,9 +273,9 @@ func parseField(f string) (string, string, error) {
 	return f[0:idx], f[idx+1:], nil
 }
 
-func magicFieldValue(v string, stdin io.ReadCloser) (interface{}, error) {
+func magicFieldValue(v string, opts *ApiOptions) (interface{}, error) {
 	if strings.HasPrefix(v, "@") {
-		return readUserFile(v[1:], stdin)
+		return readUserFile(v[1:], opts.IO.In)
 	}
 
 	if n, err := strconv.Atoi(v); err == nil {
@@ -275,7 +290,7 @@ func magicFieldValue(v string, stdin io.ReadCloser) (interface{}, error) {
 	case "null":
 		return nil, nil
 	default:
-		return v, nil
+		return fillPlaceholders(v, opts)
 	}
 }
 

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -3,10 +3,12 @@ package cmdutil
 import (
 	"net/http"
 
+	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/iostreams"
 )
 
 type Factory struct {
 	IOStreams  *iostreams.IOStreams
 	HttpClient func() (*http.Client, error)
+	BaseRepo   func() (ghrepo.Interface, error)
 }


### PR DESCRIPTION
When `:owner` and `:repo` strings are found in request path (for REST requests) or `--field, -F` values, expand them with appropriate values for the current repository. This makes it easier to make requests against local repositories without having to spell out the full repository name.

Examples:

```sh
$ gh api repos/:owner}/:repo/releases

```

TODO:
- [x] Discuss: is this placeholder syntax understandable? I've borrowed it from hub, but I don't think it has any precedent elsewhere. GitHub's REST API documentation has placeholders in the `repos/:owner/:repo` syntax, which I think looks nice in URLs, but likely odd anywhere else (such as in a GraphQL query).
- [x] Mention placeholders in `api` command docs

Ref. #332