### PR TITLE
Tweak gh config examples in help output

### DIFF
--- a/command/config.go
+++ b/command/config.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -21,11 +22,11 @@ func init() {
 
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Set and get gh settings",
-	Long: `Get and set key/value strings.
+	Short: "Manage configuration for gh",
+	Long: `Display or change configuration settings for gh.
 
 Current respected settings:
-- git_protocol: https or ssh. Default is https.
+- git_protocol: "https" or "ssh". Default is "https".
 - editor: if unset, defaults to environment variables.
 `,
 }

--- a/command/config.go
+++ b/command/config.go
@@ -32,13 +32,10 @@ Current respected settings:
 
 var configGetCmd = &cobra.Command{
 	Use:   "get <key>",
-	Short: "Prints the value of a given configuration key",
-	Long: `Get the value for a given configuration key.
-
-Examples:
-
-  $ gh config get git_protocol
-  https
+	Short: "Print the value of a given configuration key",
+	Example: `
+	$ gh config get git_protocol
+	https
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: configGet,
@@ -46,12 +43,9 @@ Examples:
 
 var configSetCmd = &cobra.Command{
 	Use:   "set <key> <value>",
-	Short: "Updates configuration with the value of a given key",
-	Long: `Update the configuration by setting a key to a value.
-
-Examples:
-
-  $ gh config set editor vim
+	Short: "Update configuration with a value for the given key",
+	Example: `
+	$ gh config set editor vim
 `,
 	Args: cobra.ExactArgs(2),
 	RunE: configSet,

--- a/command/config.go
+++ b/command/config.go
@@ -36,6 +36,7 @@ var configGetCmd = &cobra.Command{
 	Long: `Get the value for a given configuration key.
 
 Examples:
+
   $ gh config get git_protocol
   https
 `,
@@ -49,6 +50,7 @@ var configSetCmd = &cobra.Command{
 	Long: `Update the configuration by setting a key to a value.
 
 Examples:
+
   $ gh config set editor vim
 `,
 	Args: cobra.ExactArgs(2),


### PR DESCRIPTION
This is an extension of #1162 to fix HTML rendering of `gh config` examples.