### PR TITLE
Fix doc EXAMPLES formatting for HTML

### DIFF
--- a/command/alias.go
+++ b/command/alias.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/utils"
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
@@ -30,7 +31,7 @@ var aliasSetCmd = &cobra.Command{
 The expansion may specify additional arguments and flags. If the expansion
 includes positional placeholders such as '$1', '$2', etc., any extra arguments
 that follow the invocation of an alias will be inserted appropriately.`,
-	Example: `
+	Example: heredoc.Doc(`
 	$ gh alias set pv 'pr view'
 	$ gh pv -w 123
 	#=> gh pr view -w 123
@@ -40,7 +41,7 @@ that follow the invocation of an alias will be inserted appropriately.`,
 	$ gh alias set epicsBy 'issue list --author="$1" --label="epic"'
 	$ gh epicsBy vilmibm
 	#=> gh issue list --author="vilmibm" --label="epic"
-`,
+	`),
 	Args: cobra.MinimumNArgs(2),
 	RunE: aliasSet,
 

--- a/command/alias.go
+++ b/command/alias.go
@@ -23,24 +23,30 @@ var aliasCmd = &cobra.Command{
 }
 
 var aliasSetCmd = &cobra.Command{
-	Use: "set <alias> <expansion>",
-	// NB: this allows a user to eschew quotes when specifiying an alias expansion. We'll have to
-	// revisit it if we ever want to add flags to alias set but we have no current plans for that.
-	DisableFlagParsing: true,
-	Short:              "Create a shortcut for a gh command",
-	Long:               `This command lets you write your own shortcuts for running gh. They can be simple strings or accept placeholder arguments.`,
+	Use:   "set <alias> <expansion>",
+	Short: "Create a shortcut for a gh command",
+	Long: `Declare a word as a command alias that will expand to the specified command.
+
+The expansion may specify additional arguments and flags. If the expansion
+includes positional placeholders such as '$1', '$2', etc., any extra arguments
+that follow the invocation of an alias will be inserted appropriately.`,
 	Example: `
-	gh alias set pv 'pr view'
-	# gh pv -w 123 -> gh pr view -w 123.
+	$ gh alias set pv 'pr view'
+	$ gh pv -w 123
+	#=> gh pr view -w 123
+	
+	$ gh alias set bugs 'issue list --label="bugs"'
 
-	gh alias set bugs 'issue list --label="bugs"'
-	# gh bugs -> gh issue list --label="bugs".
-
-	gh alias set epicsBy 'issue list --author="$1" --label="epic"'
-	# gh epicsBy vilmibm -> gh issue list --author="$1" --label="epic"
+	$ gh alias set epicsBy 'issue list --author="$1" --label="epic"'
+	$ gh epicsBy vilmibm
+	#=> gh issue list --author="vilmibm" --label="epic"
 `,
 	Args: cobra.MinimumNArgs(2),
 	RunE: aliasSet,
+
+	// NB: this allows a user to eschew quotes when specifiying an alias expansion. We'll have to
+	// revisit it if we ever want to add flags to alias set but we have no current plans for that.
+	DisableFlagParsing: true,
 }
 
 func aliasSet(cmd *cobra.Command, args []string) error {
@@ -168,11 +174,10 @@ func aliasList(cmd *cobra.Command, args []string) error {
 }
 
 var aliasDeleteCmd = &cobra.Command{
-	Use:     "delete <alias>",
-	Short:   "Delete an alias.",
-	Args:    cobra.ExactArgs(1),
-	Example: "gh alias delete co",
-	RunE:    aliasDelete,
+	Use:   "delete <alias>",
+	Short: "Delete an alias.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  aliasDelete,
 }
 
 func aliasDelete(cmd *cobra.Command, args []string) error {

--- a/command/config.go
+++ b/command/config.go
@@ -3,6 +3,7 @@ package command
 import (
 	"fmt"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 )
 
@@ -34,10 +35,10 @@ Current respected settings:
 var configGetCmd = &cobra.Command{
 	Use:   "get <key>",
 	Short: "Print the value of a given configuration key",
-	Example: `
+	Example: heredoc.Doc(`
 	$ gh config get git_protocol
 	https
-`,
+	`),
 	Args: cobra.ExactArgs(1),
 	RunE: configGet,
 }
@@ -45,9 +46,9 @@ var configGetCmd = &cobra.Command{
 var configSetCmd = &cobra.Command{
 	Use:   "set <key> <value>",
 	Short: "Update configuration with a value for the given key",
-	Example: `
+	Example: heredoc.Doc(`
 	$ gh config set editor vim
-`,
+	`),
 	Args: cobra.ExactArgs(2),
 	RunE: configSet,
 }

--- a/command/credits.go
+++ b/command/credits.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 
@@ -44,7 +45,7 @@ var creditsCmd = &cobra.Command{
 	Use:   "credits",
 	Short: "View credits for this tool",
 	Long:  `View animated credits for gh, the tool you are currently using :)`,
-	Example: `
+	Example: heredoc.Doc(`
 	# see a credits animation for this project
 	$ gh credits
 	
@@ -53,7 +54,7 @@ var creditsCmd = &cobra.Command{
 	
 	# just print the contributors, one per line
 	$ gh credits | cat
-`,
+	`),
 	Args:   cobra.ExactArgs(0),
 	RunE:   ghCredits,
 	Hidden: true,

--- a/command/credits.go
+++ b/command/credits.go
@@ -44,10 +44,15 @@ var creditsCmd = &cobra.Command{
 	Use:   "credits",
 	Short: "View credits for this tool",
 	Long:  `View animated credits for gh, the tool you are currently using :)`,
-	Example: `gh credits            # see a credits animation for this project
-  gh credits owner/repo # see a credits animation for owner/repo
-  gh credits -s         # display a non-animated thank you
-  gh credits | cat      # just print the contributors, one per line
+	Example: `
+	# see a credits animation for this project
+	$ gh credits
+	
+	# display a non-animated thank you
+	$ gh credits -s
+	
+	# just print the contributors, one per line
+	$ gh credits | cat
 `,
 	Args:   cobra.ExactArgs(0),
 	RunE:   ghCredits,

--- a/command/gist.go
+++ b/command/gist.go
@@ -27,20 +27,29 @@ var gistCmd = &cobra.Command{
 }
 
 var gistCreateCmd = &cobra.Command{
-	Use:   `create {<filename>|-}...`,
+	Use:   `create [<filename>... | -]`,
 	Short: "Create a new gist",
-	Long: `gh gist create: create gists
+	Long: `Create a new GitHub gist with given contents.
 
-Gists can be created from one or many files. This command can also read from STDIN. By default, gists are private; use --public to change this.
+Gists can be created from one or multiple files. Alternatively, pass "-" as
+file name to read from standard input.
 
-Examples
+By default, gists are private; use '--public' to make publicly listed ones.`,
+	Example: `
+	# publish file 'hello.py' as a public gist
+	$ gh gist create --public hello.py
+	
+	# create a gist with a description
+	$ gh gist create hello.py -d "my Hello-World program in Python"
 
-    gh gist create hello.py                   # turn file hello.py into a gist
-    gh gist create --public hello.py          # turn file hello.py into a public gist
-    gh gist create -d"a file!" hello.py       # turn file hello.py into a gist, with description
-    gh gist create hello.py world.py cool.txt # make a gist out of several files
-    gh gist create -                          # read from STDIN to create a gist
-    cat cool.txt | gh gist create             # read the output of another command and make a gist out of it
+	# create a gist containing several files
+	$ gh gist create hello.py world.py cool.txt
+	
+	# read from standard input to create a gist
+	$ gh gist create -
+	
+	# create a gist from output piped from another command
+	$ cat cool.txt | gh gist create
 `,
 	RunE: gistCreate,
 }

--- a/command/gist.go
+++ b/command/gist.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
@@ -35,7 +36,7 @@ Gists can be created from one or multiple files. Alternatively, pass "-" as
 file name to read from standard input.
 
 By default, gists are private; use '--public' to make publicly listed ones.`,
-	Example: `
+	Example: heredoc.Doc(`
 	# publish file 'hello.py' as a public gist
 	$ gh gist create --public hello.py
 	
@@ -50,7 +51,7 @@ By default, gists are private; use '--public' to make publicly listed ones.`,
 	
 	# create a gist from output piped from another command
 	$ cat cool.txt | gh gist create
-`,
+	`),
 	RunE: gistCreate,
 }
 

--- a/command/help.go
+++ b/command/help.go
@@ -79,10 +79,11 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 	if len(additionalCommands) > 0 {
 		helpEntries = append(helpEntries, helpEntry{"ADDITIONAL COMMANDS", strings.Join(additionalCommands, "\n")})
 	}
-	dedent := regexp.MustCompile(`(?m)^  `)
-	flagUsages := dedent.ReplaceAllString(command.LocalFlags().FlagUsages(), "")
+
+	flagUsages := command.LocalFlags().FlagUsages()
 	if flagUsages != "" {
-		helpEntries = append(helpEntries, helpEntry{"FLAGS", flagUsages})
+		dedent := regexp.MustCompile(`(?m)^  `)
+		helpEntries = append(helpEntries, helpEntry{"FLAGS", dedent.ReplaceAllString(flagUsages, "")})
 	}
 	if _, ok := command.Annotations["help:arguments"]; ok {
 		helpEntries = append(helpEntries, helpEntry{"ARGUMENTS", command.Annotations["help:arguments"]})

--- a/command/help.go
+++ b/command/help.go
@@ -78,8 +78,9 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 	if len(additionalCommands) > 0 {
 		helpEntries = append(helpEntries, helpEntry{"ADDITIONAL COMMANDS", strings.Join(additionalCommands, "\n")})
 	}
-	if command.HasLocalFlags() {
-		helpEntries = append(helpEntries, helpEntry{"FLAGS", strings.TrimRight(command.LocalFlags().FlagUsages(), "\n")})
+	flagUsages := strings.TrimRight(command.LocalFlags().FlagUsages(), "\n")
+	if flagUsages != "" {
+		helpEntries = append(helpEntries, helpEntry{"FLAGS", flagUsages})
 	}
 	if _, ok := command.Annotations["help:arguments"]; ok {
 		helpEntries = append(helpEntries, helpEntry{"ARGUMENTS", command.Annotations["help:arguments"]})

--- a/command/help.go
+++ b/command/help.go
@@ -101,7 +101,9 @@ Read the manual at http://cli.github.com/manual`})
 			fmt.Fprintln(out, utils.Bold(e.Title))
 
 			for _, l := range strings.Split(strings.Trim(e.Body, "\n\r"), "\n") {
-				l = strings.Trim(l, " \n\r")
+				if e.Title == "EXAMPLES" {
+					l = strings.TrimPrefix(l, "\t")
+				}
 				fmt.Fprintln(out, "  "+l)
 			}
 		} else {

--- a/command/help.go
+++ b/command/help.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/cli/cli/utils"
@@ -78,7 +79,8 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 	if len(additionalCommands) > 0 {
 		helpEntries = append(helpEntries, helpEntry{"ADDITIONAL COMMANDS", strings.Join(additionalCommands, "\n")})
 	}
-	flagUsages := strings.TrimRight(command.LocalFlags().FlagUsages(), "\n")
+	dedent := regexp.MustCompile(`(?m)^  `)
+	flagUsages := dedent.ReplaceAllString(command.LocalFlags().FlagUsages(), "")
 	if flagUsages != "" {
 		helpEntries = append(helpEntries, helpEntry{"FLAGS", flagUsages})
 	}
@@ -102,9 +104,6 @@ Read the manual at http://cli.github.com/manual`})
 			fmt.Fprintln(out, utils.Bold(e.Title))
 
 			for _, l := range strings.Split(strings.Trim(e.Body, "\n\r"), "\n") {
-				if e.Title == "EXAMPLES" {
-					l = strings.TrimPrefix(l, "\t")
-				}
 				fmt.Fprintln(out, "  "+l)
 			}
 		} else {

--- a/command/issue.go
+++ b/command/issue.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
@@ -52,11 +53,11 @@ var issueCmd = &cobra.Command{
 	Use:   "issue <command>",
 	Short: "Create and view issues",
 	Long:  `Work with GitHub issues`,
-	Example: `
+	Example: heredoc.Doc(`
 	$ gh issue list
 	$ gh issue create --label bug
 	$ gh issue view --web
-`,
+	`),
 	Annotations: map[string]string{
 		"IsCore": "true",
 		"help:arguments": `An issue can be supplied as argument in any of the following formats:

--- a/command/issue.go
+++ b/command/issue.go
@@ -52,9 +52,11 @@ var issueCmd = &cobra.Command{
 	Use:   "issue <command>",
 	Short: "Create and view issues",
 	Long:  `Work with GitHub issues`,
-	Example: `$ gh issue list
-$ gh issue create --fill
-$ gh issue view --web`,
+	Example: `
+	$ gh issue list
+	$ gh issue create --label bug
+	$ gh issue view --web
+`,
 	Annotations: map[string]string{
 		"IsCore": "true",
 		"help:arguments": `An issue can be supplied as argument in any of the following formats:

--- a/command/pr.go
+++ b/command/pr.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/git"
@@ -49,11 +50,11 @@ var prCmd = &cobra.Command{
 	Use:   "pr <command>",
 	Short: "Create, view, and checkout pull requests",
 	Long:  `Work with GitHub pull requests`,
-	Example: `
+	Example: heredoc.Doc(`
 	$ gh pr checkout 353
 	$ gh pr create --fill
 	$ gh pr view --web
-`,
+	`),
 	Annotations: map[string]string{
 		"IsCore": "true",
 		"help:arguments": `A pull request can be supplied as argument in any of the following formats:
@@ -64,11 +65,11 @@ var prCmd = &cobra.Command{
 var prListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List and filter pull requests in this repository",
-	Example: `
+	Example: heredoc.Doc(`
 	$ gh pr list --limit 999
 	$ gh pr list --state closed
 	$ gh pr list --label "priority 1" --label "bug"
-`,
+	`),
 	RunE: prList,
 }
 var prStatusCmd = &cobra.Command{

--- a/command/pr.go
+++ b/command/pr.go
@@ -49,10 +49,11 @@ var prCmd = &cobra.Command{
 	Use:   "pr <command>",
 	Short: "Create, view, and checkout pull requests",
 	Long:  `Work with GitHub pull requests`,
-	Example: `$ gh pr checkout 353
-$ gh pr checkout bug-fix-branch
-$ gh pr create --fill
-$ gh pr view --web`,
+	Example: `
+	$ gh pr checkout 353
+	$ gh pr create --fill
+	$ gh pr view --web
+`,
 	Annotations: map[string]string{
 		"IsCore": "true",
 		"help:arguments": `A pull request can be supplied as argument in any of the following formats:
@@ -63,9 +64,11 @@ $ gh pr view --web`,
 var prListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List and filter pull requests in this repository",
-	Example: `$ gh pr list --limit all
-$ gh pr list --state closed
-$ gh pr list --label “priority 1” “bug”`,
+	Example: `
+	$ gh pr list --limit 999
+	$ gh pr list --state closed
+	$ gh pr list --label "priority 1" --label "bug"
+`,
 	RunE: prList,
 }
 var prStatusCmd = &cobra.Command{

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -23,18 +23,24 @@ func init() {
 
 var prReviewCmd = &cobra.Command{
 	Use:   "review [<number> | <url> | <branch>]",
-	Short: "Add a review to a pull request.",
-	Args:  cobra.MaximumNArgs(1),
-	Long: `Add a review to either a specified pull request or the pull request associated with the current branch.
+	Short: "Add a review to a pull request",
+	Long: `Add a review to a pull request.
 
-Examples:
-
-	gh pr review                                  # add a review for the current branch's pull request
-	gh pr review 123                              # add a review for pull request 123
-	gh pr review -a                               # mark the current branch's pull request as approved
-	gh pr review -c -b "interesting"              # comment on the current branch's pull request
-	gh pr review 123 -r -b "needs more ascii art" # request changes on pull request 123
-	`,
+Without an argument, the pull request that belongs to the current branch is reviewed.`,
+	Example: `
+	# approve the pull request of the current branch
+	$ gh pr review --approve
+	
+	# leave a review comment for the current branch
+	$ gh pr review --comment -b "interesting"
+	
+	# add a review for a specific pull request
+	$ gh pr review 123
+	
+	# request changes on a specific pull request
+	$ gh pr review 123 -r -b "needs more ASCII art"
+`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: prReview,
 }
 

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
 	"github.com/cli/cli/api"
@@ -27,7 +28,7 @@ var prReviewCmd = &cobra.Command{
 	Long: `Add a review to a pull request.
 
 Without an argument, the pull request that belongs to the current branch is reviewed.`,
-	Example: `
+	Example: heredoc.Doc(`
 	# approve the pull request of the current branch
 	$ gh pr review --approve
 	
@@ -39,7 +40,7 @@ Without an argument, the pull request that belongs to the current branch is revi
 	
 	# request changes on a specific pull request
 	$ gh pr review 123 -r -b "needs more ASCII art"
-`,
+	`),
 	Args: cobra.MaximumNArgs(1),
 	RunE: prReview,
 }

--- a/command/repo.go
+++ b/command/repo.go
@@ -47,9 +47,10 @@ var repoCmd = &cobra.Command{
 	Use:   "repo <command>",
 	Short: "Create, clone, fork, and view repositories",
 	Long:  `Work with GitHub repositories`,
-	Example: `$ gh repo create
-$ gh repo clone cli/cli 
-$ gh repo view --web
+	Example: `
+	$ gh repo create
+	$ gh repo clone cli/cli
+	$ gh repo view --web
 `,
 	Annotations: map[string]string{
 		"IsCore": "true",
@@ -75,15 +76,17 @@ To pass 'git clone' flags, separate them with '--'.`,
 var repoCreateCmd = &cobra.Command{
 	Use:   "create [<name>]",
 	Short: "Create a new repository",
-	Long:  `Create a new GitHub repository`,
-	Example: utils.Bold("$ gh repo create") + `
-Will create a repository on your account using the name of your current directory
+	Long:  `Create a new GitHub repository.`,
+	Example: `
+	# create a repository under your account using the current directory name
+	$ gh repo create
 
-` + utils.Bold("$ gh repo create my-project") + `
-Will create a repository on your account using the name 'my-project'
+	# create a repository with a specific name
+	$ gh repo create my-project
 
-` + utils.Bold("$ gh repo create cli/my-project") + `
-Will create a repository in the organization 'cli' using the name 'my-project'`,
+	# create a repository in an organization
+	$ gh repo create cli/my-project
+`,
 	Annotations: map[string]string{"help:arguments": `A repository can be supplied as an argument in any of the following formats:
 - <OWNER/REPO>
 - by URL, e.g. "https://github.com/OWNER/REPO"`},
@@ -113,10 +116,18 @@ With '--web', open the repository in a web browser instead.`,
 var repoCreditsCmd = &cobra.Command{
 	Use:   "credits [<repository>]",
 	Short: "View credits for a repository",
-	Example: `$ gh repo credits           # view credits for the current repository
-$ gh repo credits cool/repo # view credits for cool/repo
-$ gh repo credits -s        # print a non-animated thank you
-$ gh repo credits | cat     # pipe to just print the contributors, one per line
+	Example: `
+	# view credits for the current repository
+	$ gh repo credits
+	
+	# view credits for a specific repository
+	$ gh repo credits cool/repo
+
+	# print a non-animated thank you
+	$ gh repo credits -s
+	
+	# pipe to just print the contributors, one per line
+	$ gh repo credits | cat
 `,
 	Args:   cobra.MaximumNArgs(1),
 	RunE:   repoCredits,

--- a/command/repo.go
+++ b/command/repo.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
@@ -47,11 +48,11 @@ var repoCmd = &cobra.Command{
 	Use:   "repo <command>",
 	Short: "Create, clone, fork, and view repositories",
 	Long:  `Work with GitHub repositories`,
-	Example: `
+	Example: heredoc.Doc(`
 	$ gh repo create
 	$ gh repo clone cli/cli
 	$ gh repo view --web
-`,
+	`),
 	Annotations: map[string]string{
 		"IsCore": "true",
 		"help:arguments": `
@@ -77,7 +78,7 @@ var repoCreateCmd = &cobra.Command{
 	Use:   "create [<name>]",
 	Short: "Create a new repository",
 	Long:  `Create a new GitHub repository.`,
-	Example: `
+	Example: heredoc.Doc(`
 	# create a repository under your account using the current directory name
 	$ gh repo create
 
@@ -86,7 +87,7 @@ var repoCreateCmd = &cobra.Command{
 
 	# create a repository in an organization
 	$ gh repo create cli/my-project
-`,
+	`),
 	Annotations: map[string]string{"help:arguments": `A repository can be supplied as an argument in any of the following formats:
 - <OWNER/REPO>
 - by URL, e.g. "https://github.com/OWNER/REPO"`},
@@ -116,7 +117,7 @@ With '--web', open the repository in a web browser instead.`,
 var repoCreditsCmd = &cobra.Command{
 	Use:   "credits [<repository>]",
 	Short: "View credits for a repository",
-	Example: `
+	Example: heredoc.Doc(`
 	# view credits for the current repository
 	$ gh repo credits
 	
@@ -128,7 +129,7 @@ var repoCreditsCmd = &cobra.Command{
 	
 	# pipe to just print the contributors, one per line
 	$ gh repo credits | cat
-`,
+	`),
 	Args:   cobra.MaximumNArgs(1),
 	RunE:   repoCredits,
 	Hidden: true,

--- a/command/root.go
+++ b/command/root.go
@@ -10,6 +10,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/internal/config"
@@ -96,11 +97,11 @@ var RootCmd = &cobra.Command{
 
 	SilenceErrors: true,
 	SilenceUsage:  true,
-	Example: `
+	Example: heredoc.Doc(`
 	$ gh issue create
 	$ gh repo clone cli/cli
 	$ gh pr checkout 321
-`,
+	`),
 	Annotations: map[string]string{
 		"help:feedback": `
 Fill out our feedback form https://forms.gle/umxd3h31c7aMQFKG7

--- a/command/root.go
+++ b/command/root.go
@@ -96,9 +96,11 @@ var RootCmd = &cobra.Command{
 
 	SilenceErrors: true,
 	SilenceUsage:  true,
-	Example: `$ gh issue create
-$ gh repo clone
-$ gh pr checkout 321`,
+	Example: `
+	$ gh issue create
+	$ gh repo clone cli/cli
+	$ gh pr checkout 321
+`,
 	Annotations: map[string]string{
 		"help:feedback": `
 Fill out our feedback form https://forms.gle/umxd3h31c7aMQFKG7

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.0.7
+	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/briandowns/spinner v1.11.1
 	github.com/charmbracelet/glamour v0.1.1-0.20200320173916-301d3bcf3058
 	github.com/dlclark/regexp2 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/AlecAivazis/survey/v2 v2.0.7 h1:+f825XHLse/hWd2tE/V5df04WFGimk34Eyg/z
 github.com/AlecAivazis/survey/v2 v2.0.7/go.mod h1:mlizQTaPjnR4jcpwRSaSlkbsRfYFEyKgLQvYTzxxiHA=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
Example contents like below ~~should be intended per Markdown syntax for code blocks~~ so they don't get rendered as prose (all on the same line) in our web docs:
```
$ gh issue list
$ gh pr create
```

Also, there were some incorrect docs.

Followup to #1106
Ref. #1166