### PR TITLE
Fixed: section in help docs slightly wrong

### DIFF
--- a/command/help.go
+++ b/command/help.go
@@ -92,7 +92,7 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 		helpEntries = append(helpEntries, helpEntry{"EXAMPLES", command.Example})
 	}
 	helpEntries = append(helpEntries, helpEntry{"LEARN MORE", `
-Use "gh <command> <subcommand> --help" for more information about a command.
+Use "gh help <command> <subcommand>" for more information about a command.
 Read the manual at http://cli.github.com/manual`})
 	if _, ok := command.Annotations["help:feedback"]; ok {
 		helpEntries = append(helpEntries, helpEntry{"FEEDBACK", command.Annotations["help:feedback"]})

--- a/context/remote_test.go
+++ b/context/remote_test.go
@@ -95,12 +95,12 @@ func Test_resolvedRemotes_triangularSetup(t *testing.T) {
 		},
 		Network: api.RepoNetworkResult{
 			Repositories: []*api.Repository{
-				&api.Repository{
+				{
 					Name:             "NEWNAME",
 					Owner:            api.RepositoryOwner{Login: "NEWOWNER"},
 					ViewerPermission: "READ",
 				},
-				&api.Repository{
+				{
 					Name:             "REPO",
 					Owner:            api.RepositoryOwner{Login: "MYSELF"},
 					ViewerPermission: "ADMIN",
@@ -163,7 +163,7 @@ func Test_resolvedRemotes_forkLookup(t *testing.T) {
 		},
 		Network: api.RepoNetworkResult{
 			Repositories: []*api.Repository{
-				&api.Repository{
+				{
 					Name:             "NEWNAME",
 					Owner:            api.RepositoryOwner{Login: "NEWOWNER"},
 					ViewerPermission: "READ",
@@ -196,7 +196,7 @@ func Test_resolvedRemotes_clonedFork(t *testing.T) {
 		},
 		Network: api.RepoNetworkResult{
 			Repositories: []*api.Repository{
-				&api.Repository{
+				{
 					Name:             "REPO",
 					Owner:            api.RepositoryOwner{Login: "OWNER"},
 					ViewerPermission: "ADMIN",

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -15,9 +15,9 @@ func Test_UncommittedChangeCount(t *testing.T) {
 		Output   string
 	}
 	cases := []c{
-		c{Label: "no changes", Expected: 0, Output: ""},
-		c{Label: "one change", Expected: 1, Output: " M poem.txt"},
-		c{Label: "untracked file", Expected: 2, Output: " M poem.txt\n?? new.txt"},
+		{Label: "no changes", Expected: 0, Output: ""},
+		{Label: "one change", Expected: 1, Output: " M poem.txt"},
+		{Label: "untracked file", Expected: 2, Output: " M poem.txt\n?? new.txt"},
 	}
 
 	teardown := run.SetPrepareCmd(func(*exec.Cmd) run.Runnable {

--- a/git/ssh_config_test.go
+++ b/git/ssh_config_test.go
@@ -36,9 +36,9 @@ func Test_Translator(t *testing.T) {
 	tr := m.Translator()
 
 	cases := [][]string{
-		[]string{"ssh://gh/o/r", "ssh://github.com/o/r"},
-		[]string{"ssh://github.com/o/r", "ssh://github.com/o/r"},
-		[]string{"https://gh/o/r", "https://gh/o/r"},
+		{"ssh://gh/o/r", "ssh://github.com/o/r"},
+		{"ssh://github.com/o/r", "ssh://github.com/o/r"},
+		{"https://gh/o/r", "https://gh/o/r"},
 	}
 	for _, c := range cases {
 		u, _ := url.Parse(c[0])


### PR DESCRIPTION
## Summary :

This PR fixes a few issues section in help docs (as noted here https://github.com/cli/cli/issues/1169).

## Changelog :

**Fixed**

- [Bug][Redundant] - Redundant type composite literal
- [Docs][Help] - Section in help docs slightly wrong

## Testing :

- [x] `$ go version`
`go version go1.14.4 darwin/amd64`

- [x] `$ make && cd bin`
Build the project and go to `bin` directory

- [x] `$ ./gh help pr status`
<img width="621" alt="Screen Shot 2020-06-12 at 12 56 31" src="https://user-images.githubusercontent.com/1158185/84466538-2860b400-acac-11ea-8635-13f3a2686aab.png">


 
