### PR TITLE
Remove redundant type declarations for composite struct literals

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+linters:
+  enable:
+    gofmt

--- a/context/remote_test.go
+++ b/context/remote_test.go
@@ -95,12 +95,12 @@ func Test_resolvedRemotes_triangularSetup(t *testing.T) {
 		},
 		Network: api.RepoNetworkResult{
 			Repositories: []*api.Repository{
-				&api.Repository{
+				{
 					Name:             "NEWNAME",
 					Owner:            api.RepositoryOwner{Login: "NEWOWNER"},
 					ViewerPermission: "READ",
 				},
-				&api.Repository{
+				{
 					Name:             "REPO",
 					Owner:            api.RepositoryOwner{Login: "MYSELF"},
 					ViewerPermission: "ADMIN",
@@ -163,7 +163,7 @@ func Test_resolvedRemotes_forkLookup(t *testing.T) {
 		},
 		Network: api.RepoNetworkResult{
 			Repositories: []*api.Repository{
-				&api.Repository{
+				{
 					Name:             "NEWNAME",
 					Owner:            api.RepositoryOwner{Login: "NEWOWNER"},
 					ViewerPermission: "READ",
@@ -196,7 +196,7 @@ func Test_resolvedRemotes_clonedFork(t *testing.T) {
 		},
 		Network: api.RepoNetworkResult{
 			Repositories: []*api.Repository{
-				&api.Repository{
+				{
 					Name:             "REPO",
 					Owner:            api.RepositoryOwner{Login: "OWNER"},
 					ViewerPermission: "ADMIN",

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -15,9 +15,9 @@ func Test_UncommittedChangeCount(t *testing.T) {
 		Output   string
 	}
 	cases := []c{
-		c{Label: "no changes", Expected: 0, Output: ""},
-		c{Label: "one change", Expected: 1, Output: " M poem.txt"},
-		c{Label: "untracked file", Expected: 2, Output: " M poem.txt\n?? new.txt"},
+		{Label: "no changes", Expected: 0, Output: ""},
+		{Label: "one change", Expected: 1, Output: " M poem.txt"},
+		{Label: "untracked file", Expected: 2, Output: " M poem.txt\n?? new.txt"},
 	}
 
 	teardown := run.SetPrepareCmd(func(*exec.Cmd) run.Runnable {

--- a/git/ssh_config_test.go
+++ b/git/ssh_config_test.go
@@ -36,9 +36,9 @@ func Test_Translator(t *testing.T) {
 	tr := m.Translator()
 
 	cases := [][]string{
-		[]string{"ssh://gh/o/r", "ssh://github.com/o/r"},
-		[]string{"ssh://github.com/o/r", "ssh://github.com/o/r"},
-		[]string{"https://gh/o/r", "https://gh/o/r"},
+		{"ssh://gh/o/r", "ssh://github.com/o/r"},
+		{"ssh://github.com/o/r", "ssh://github.com/o/r"},
+		{"https://gh/o/r", "https://gh/o/r"},
 	}
 	for _, c := range cases {
 		u, _ := url.Parse(c[0])


### PR DESCRIPTION
and [ensure via CI check](https://github.com/cli/cli/runs/765657712?check_suite_focus=true) that they don't pop up again.

Extension of #1176