### PR TITLE
Issue #1178 - Direct users to https url for manual

### DIFF
--- a/command/help.go
+++ b/command/help.go
@@ -93,7 +93,7 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 	}
 	helpEntries = append(helpEntries, helpEntry{"LEARN MORE", `
 Use "gh <command> <subcommand> --help" for more information about a command.
-Read the manual at http://cli.github.com/manual`})
+Read the manual at https://cli.github.com/manual`})
 	if _, ok := command.Annotations["help:feedback"]; ok {
 		helpEntries = append(helpEntries, helpEntry{"FEEDBACK", command.Annotations["help:feedback"]})
 	}


### PR DESCRIPTION
Resolves #1178  by changing the printed protocol for the manual url from http to https.