### PR TITLE
shell aliases

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -40,14 +40,19 @@ func main() {
 	cmd, _, err := command.RootCmd.Traverse(expandedArgs)
 	if err != nil || cmd == command.RootCmd {
 		originalArgs := expandedArgs
-		expandedArgs, err = command.ExpandAlias(os.Args)
+		expandedArgs, isShell, err := command.ExpandAlias(os.Args)
 		if err != nil {
 			fmt.Fprintf(stderr, "failed to process aliases:  %s\n", err)
 			os.Exit(2)
 		}
 
-		if expandedArgs == nil && err == nil {
-			// It was an external alias; we ran it and are now done.
+		if isShell {
+			err = command.ExecuteShellAlias(expandedArgs)
+			if err != nil {
+				fmt.Fprintf(stderr, "failed to run alias %q: %s\n", expandedArgs, err)
+				os.Exit(3)
+			}
+
 			os.Exit(0)
 		}
 

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -45,6 +45,12 @@ func main() {
 			fmt.Fprintf(stderr, "failed to process aliases:  %s\n", err)
 			os.Exit(2)
 		}
+
+		if expandedArgs == nil && err == nil {
+			// It was an external alias; we ran it and are now done.
+			os.Exit(0)
+		}
+
 		if hasDebug {
 			fmt.Fprintf(stderr, "%v -> %v\n", originalArgs, expandedArgs)
 		}

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path"
 	"strings"
 
@@ -49,7 +50,11 @@ func main() {
 		if isShell {
 			err = command.ExecuteShellAlias(expandedArgs)
 			if err != nil {
-				fmt.Fprintf(stderr, "failed to run alias %q: %s\n", expandedArgs, err)
+				if ee, ok := err.(*exec.ExitError); ok {
+					os.Exit(ee.ExitCode())
+				}
+
+				fmt.Fprintf(stderr, "failed to run external command: %s", err)
 				os.Exit(3)
 			}
 

--- a/command/alias.go
+++ b/command/alias.go
@@ -16,21 +16,35 @@ func init() {
 	aliasCmd.AddCommand(aliasSetCmd)
 	aliasCmd.AddCommand(aliasListCmd)
 	aliasCmd.AddCommand(aliasDeleteCmd)
+
+	aliasSetCmd.Flags().BoolP("shell", "s", false, "Declare an alias to be passed through a shell interpreter")
 }
 
 var aliasCmd = &cobra.Command{
 	Use:   "alias",
-	Short: "Create shortcuts for gh commands",
+	Short: "Create command shortcuts",
+	Long: heredoc.Doc(`
+	Aliases can be used to make shortcuts for gh commands or to compose multiple commands.
+
+	Run "gh help alias set" to learn more.
+	`),
 }
 
 var aliasSetCmd = &cobra.Command{
 	Use:   "set <alias> <expansion>",
 	Short: "Create a shortcut for a gh command",
-	Long: `Declare a word as a command alias that will expand to the specified command.
+	Long: heredoc.Doc(`
+	Declare a word as a command alias that will expand to the specified command(s).
 
-The expansion may specify additional arguments and flags. If the expansion
-includes positional placeholders such as '$1', '$2', etc., any extra arguments
-that follow the invocation of an alias will be inserted appropriately.`,
+	The expansion may specify additional arguments and flags. If the expansion
+	includes positional placeholders such as '$1', '$2', etc., any extra arguments
+	that follow the invocation of an alias will be inserted appropriately.
+
+	If '--shell' is specified, the alias will be run through a shell interpreter (sh). This allows you
+	to compose commands with "|" or redirect output with ">". Note that extra arguments are not passed
+	to shell-interpreted aliases; only placeholders ("$1", "$2", etc) are supported.
+
+	Quotes must always be used when defining a command as in the examples.`),
 	Example: heredoc.Doc(`
 	$ gh alias set pv 'pr view'
 	$ gh pv -w 123
@@ -41,13 +55,12 @@ that follow the invocation of an alias will be inserted appropriately.`,
 	$ gh alias set epicsBy 'issue list --author="$1" --label="epic"'
 	$ gh epicsBy vilmibm
 	#=> gh issue list --author="vilmibm" --label="epic"
-	`),
-	Args: cobra.MinimumNArgs(2),
-	RunE: aliasSet,
 
-	// NB: this allows a user to eschew quotes when specifying an alias expansion. We'll have to
-	// revisit it if we ever want to add flags to alias set but we have no current plans for that.
-	DisableFlagParsing: true,
+	$ gh alias set --shell igrep 'gh issue list --label="$1" | grep $2'
+	$ gh igrep epic foo
+	#=> gh issue list --label="epic" | grep "foo"`),
+	Args: cobra.ExactArgs(2),
+	RunE: aliasSet,
 }
 
 func aliasSet(cmd *cobra.Command, args []string) error {
@@ -63,19 +76,26 @@ func aliasSet(cmd *cobra.Command, args []string) error {
 	}
 
 	alias := args[0]
-	expansion := processArgs(args[1:])
-
-	expansionStr := strings.Join(expansion, " ")
+	expansion := args[1]
 
 	out := colorableOut(cmd)
-	fmt.Fprintf(out, "- Adding alias for %s: %s\n", utils.Bold(alias), utils.Bold(expansionStr))
+	fmt.Fprintf(out, "- Adding alias for %s: %s\n", utils.Bold(alias), utils.Bold(expansion))
 
-	if validCommand([]string{alias}) {
+	shell, err := cmd.Flags().GetBool("shell")
+	if err != nil {
+		return err
+	}
+	if shell && !strings.HasPrefix(expansion, "!") {
+		expansion = "!" + expansion
+	}
+	isExternal := strings.HasPrefix(expansion, "!")
+
+	if validCommand(alias) {
 		return fmt.Errorf("could not create alias: %q is already a gh command", alias)
 	}
 
-	if !validCommand(expansion) {
-		return fmt.Errorf("could not create alias: %s does not correspond to a gh command", utils.Bold(expansionStr))
+	if !isExternal && !validCommand(expansion) {
+		return fmt.Errorf("could not create alias: %s does not correspond to a gh command", expansion)
 	}
 
 	successMsg := fmt.Sprintf("%s Added alias.", utils.Green("✓"))
@@ -86,11 +106,11 @@ func aliasSet(cmd *cobra.Command, args []string) error {
 			utils.Green("✓"),
 			utils.Bold(alias),
 			utils.Bold(oldExpansion),
-			utils.Bold(expansionStr),
+			utils.Bold(expansion),
 		)
 	}
 
-	err = aliasCfg.Add(alias, expansionStr)
+	err = aliasCfg.Add(alias, expansion)
 	if err != nil {
 		return fmt.Errorf("could not create alias: %s", err)
 	}
@@ -100,26 +120,13 @@ func aliasSet(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func validCommand(expansion []string) bool {
-	cmd, _, err := RootCmd.Traverse(expansion)
+func validCommand(expansion string) bool {
+	split, err := shlex.Split(expansion)
+	if err != nil {
+		return false
+	}
+	cmd, _, err := RootCmd.Traverse(split)
 	return err == nil && cmd != RootCmd
-}
-
-func processArgs(args []string) []string {
-	if len(args) == 1 {
-		split, _ := shlex.Split(args[0])
-		return split
-	}
-
-	newArgs := []string{}
-	for _, a := range args {
-		if !strings.HasPrefix(a, "-") && strings.Contains(a, " ") {
-			a = fmt.Sprintf("%q", a)
-		}
-		newArgs = append(newArgs, a)
-	}
-
-	return newArgs
 }
 
 var aliasListCmd = &cobra.Command{

--- a/command/alias.go
+++ b/command/alias.go
@@ -41,9 +41,9 @@ var aliasSetCmd = &cobra.Command{
 	that follow the invocation of an alias will be inserted appropriately.
 
 	If '--shell' is specified, the alias will be run through a shell interpreter (sh or pwsh). This allows you
-	to compose commands with "|" or redirect output. Note that extra arguments are not passed to
-	shell-interpreted aliases; only placeholders ("$1", "$2" on *nix, "$args" in powershell) are
-	supported.
+	to compose commands with "|" or redirect output. Note that extra arguments following the alias
+	will not be automatically passed to the expanded expression. To have a shell alias receive
+	arguments, you must explicitly accept them using "$1", "$2", etc or "$@" to accept all of them.
 
 	Quotes must always be used when defining a command as in the examples.`),
 	Example: heredoc.Doc(`

--- a/command/alias.go
+++ b/command/alias.go
@@ -40,10 +40,10 @@ var aliasSetCmd = &cobra.Command{
 	includes positional placeholders such as '$1', '$2', etc., any extra arguments
 	that follow the invocation of an alias will be inserted appropriately.
 
-	If '--shell' is specified, the alias will be run through a shell interpreter (sh or pwsh). This allows you
+	If '--shell' is specified, the alias will be run through a shell interpreter (sh). This allows you
 	to compose commands with "|" or redirect with ">". Note that extra arguments following the alias
 	will not be automatically passed to the expanded expression. To have a shell alias receive
-	arguments, you must explicitly accept them using "$1", "$2", etc or "$@" to accept all of them.
+	arguments, you must explicitly accept them using "$1", "$2", etc., or "$@" to accept all of them.
 
 	Platform note: on Windows, shell aliases are executed via "sh" as installed by Git For Windows. If
 	you have installed git on Windows in some other way, shell aliases may not work for you.

--- a/command/alias.go
+++ b/command/alias.go
@@ -41,9 +41,12 @@ var aliasSetCmd = &cobra.Command{
 	that follow the invocation of an alias will be inserted appropriately.
 
 	If '--shell' is specified, the alias will be run through a shell interpreter (sh or pwsh). This allows you
-	to compose commands with "|" or redirect output. Note that extra arguments following the alias
+	to compose commands with "|" or redirect with ">". Note that extra arguments following the alias
 	will not be automatically passed to the expanded expression. To have a shell alias receive
 	arguments, you must explicitly accept them using "$1", "$2", etc or "$@" to accept all of them.
+
+	Platform note: on Windows, shell aliases are executed via "sh" as installed by Git For Windows. If
+	you have installed git on Windows in some other way, shell aliases may not work for you.
 
 	Quotes must always be used when defining a command as in the examples.`),
 	Example: heredoc.Doc(`
@@ -57,15 +60,9 @@ var aliasSetCmd = &cobra.Command{
 	$ gh epicsBy vilmibm
 	#=> gh issue list --author="vilmibm" --label="epic"
 
-	# On macOS and Linux:
 	$ gh alias set --shell igrep 'gh issue list --label="$1" | grep $2'
 	$ gh igrep epic foo
-	#=> gh issue list --label="epic" | grep "foo"
-
-	# On Windows (Powershell):
-	$ gh alias set --shell igrep 'gh issue list --label=$args[0] | Select-String -Pattern $args[1]
-	$ gh igrep epic foo
-	#=> gh issue list --label=epic | Select-String -Pattern foo`),
+	#=> gh issue list --label="epic" | grep "foo"`),
 	Args: cobra.ExactArgs(2),
 	RunE: aliasSet,
 }

--- a/command/alias.go
+++ b/command/alias.go
@@ -40,9 +40,10 @@ var aliasSetCmd = &cobra.Command{
 	includes positional placeholders such as '$1', '$2', etc., any extra arguments
 	that follow the invocation of an alias will be inserted appropriately.
 
-	If '--shell' is specified, the alias will be run through a shell interpreter (sh). This allows you
-	to compose commands with "|" or redirect output with ">". Note that extra arguments are not passed
-	to shell-interpreted aliases; only placeholders ("$1", "$2", etc) are supported.
+	If '--shell' is specified, the alias will be run through a shell interpreter (sh or pwsh). This allows you
+	to compose commands with "|" or redirect output. Note that extra arguments are not passed to
+	shell-interpreted aliases; only placeholders ("$1", "$2" on *nix, "$args" in powershell) are
+	supported.
 
 	Quotes must always be used when defining a command as in the examples.`),
 	Example: heredoc.Doc(`
@@ -56,9 +57,15 @@ var aliasSetCmd = &cobra.Command{
 	$ gh epicsBy vilmibm
 	#=> gh issue list --author="vilmibm" --label="epic"
 
+	# On macOS and Linux:
 	$ gh alias set --shell igrep 'gh issue list --label="$1" | grep $2'
 	$ gh igrep epic foo
-	#=> gh issue list --label="epic" | grep "foo"`),
+	#=> gh issue list --label="epic" | grep "foo"
+
+	# On Windows (Powershell):
+	$ gh alias set --shell igrep 'gh issue list --label=$args[0] | Select-String -Pattern $args[1]
+	$ gh igrep epic foo
+	#=> gh issue list --label=epic | Select-String -Pattern foo`),
 	Args: cobra.ExactArgs(2),
 	RunE: aliasSet,
 }

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -195,7 +195,7 @@ aliases:
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	expected := []string{"sh", "-c", "gh issue list | grep cool"}
+	expected := []string{"/usr/bin/sh", "-c", "gh issue list | grep cool"}
 
 	assert.Equal(t, expected, expanded)
 }
@@ -218,7 +218,7 @@ aliases:
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	expected := []string{"sh", "-c", "gh issue list --label=$1 | grep", "--", "bug", "foo"}
+	expected := []string{"/usr/bin/sh", "-c", "gh issue list --label=$1 | grep", "--", "bug", "foo"}
 
 	assert.Equal(t, expected, expanded)
 }

--- a/command/alias_test.go
+++ b/command/alias_test.go
@@ -229,7 +229,7 @@ func TestExpandAlias_shell_windows(t *testing.T) {
 	}
 	cfg := `---
 aliases:
-  ig: '!gh issue list | select-string -Pattern cool'
+  ig: '!gh issue list | grep cool'
 `
 	initBlankContext(cfg, "OWNER/REPO", "trunk")
 
@@ -245,7 +245,7 @@ aliases:
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	expected := []string{"pwsh", "-Command", "Invoke-Command -ScriptBlock { gh issue list | select-string -Pattern cool } "}
+	expected := []string{"C:\\Program Files\\Git\\bin\\sh.exe", "-c", "gh issue list | grep cool"}
 
 	assert.Equal(t, expected, expanded)
 }
@@ -257,7 +257,7 @@ func TestExpandAlias_shell_windows_extra_args(t *testing.T) {
 	cfg := `---
 aliases:
   co: pr checkout
-  ig: '!gh issue list --label=$args[0] | select-string -Pattern $args[1]'
+  ig: '!gh issue list --label=$1 | grep $2'
 `
 	initBlankContext(cfg, "OWNER/REPO", "trunk")
 
@@ -269,7 +269,7 @@ aliases:
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	expected := []string{"pwsh", "-Command", "Invoke-Command -ScriptBlock { gh issue list --label=$args[0] | select-string -Pattern $args[1] }  -ArgumentList @('bug','foo')"}
+	expected := []string{"C:\\Program Files\\Git\\bin\\sh.exe", "-c", "gh issue list --label=$1 | grep $2", "--", "bug", "foo"}
 
 	assert.Equal(t, expected, expanded)
 }

--- a/command/root.go
+++ b/command/root.go
@@ -410,19 +410,27 @@ func ExpandAlias(args []string) (expanded []string, isShell bool, err error) {
 			isShell = true
 			expanded = []string{"sh", "-c", expansion[1:]}
 			if runtime.GOOS == "windows" {
-				argList := ""
-				if len(args[2:]) > 0 {
-					argList = " -ArgumentList @("
-					for i, arg := range args[2:] {
-						argList += fmt.Sprintf("'%s'", arg)
-						if i < len(args[2:])-1 {
-							argList += ","
-						}
-					}
-					argList += ")"
+				//argList := ""
+				//if len(args[2:]) > 0 {
+				//	argList = " -ArgumentList @("
+				//	for i, arg := range args[2:] {
+				//		argList += fmt.Sprintf("'%s'", arg)
+				//		if i < len(args[2:])-1 {
+				//			argList += ","
+				//		}
+				//	}
+				//	argList += ")"
+				//}
+				//invoke := fmt.Sprintf("Invoke-Command -ScriptBlock { %s } %s", expansion[1:], argList)
+				//expanded = []string{"pwsh", "-Command", invoke}
+				executable, err := os.Executable()
+				if err != nil {
+					return
 				}
-				invoke := fmt.Sprintf("Invoke-Command -ScriptBlock { %s } %s", expansion[1:], argList)
-				expanded = []string{"pwsh", "-Command", invoke}
+				invoke := fmt.Sprintf("gh () { %s \"$@\" }; %s", executable, expansion[1:])
+
+				expanded = []string{"bash", "--posix", "-c", invoke, "--"}
+				expanded = append(expanded, args[2:]...)
 			} else {
 				if len(args[2:]) > 0 {
 					expanded = append(expanded, "--")

--- a/command/root.go
+++ b/command/root.go
@@ -377,7 +377,7 @@ func ExecuteShellAlias(args []string) error {
 	return preparedCmd.Run()
 }
 
-func findSh() (string, error) {
+var findSh = func() (string, error) {
 	shPath, err := exec.LookPath("sh")
 	if err == nil {
 		return shPath, nil

--- a/command/root.go
+++ b/command/root.go
@@ -374,12 +374,7 @@ func ExecuteShellAlias(args []string) error {
 	externalCmd.Stdin = os.Stdin
 	preparedCmd := run.PrepareCmd(externalCmd)
 
-	err := preparedCmd.Run()
-	if err != nil {
-		return fmt.Errorf("failed to run external command: %w", err)
-	}
-
-	return nil
+	return preparedCmd.Run()
 }
 
 func findSh() (string, error) {

--- a/command/root.go
+++ b/command/root.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"runtime/debug"
@@ -410,32 +411,23 @@ func ExpandAlias(args []string) (expanded []string, isShell bool, err error) {
 			isShell = true
 			expanded = []string{"sh", "-c", expansion[1:]}
 			if runtime.GOOS == "windows" {
-				//argList := ""
-				//if len(args[2:]) > 0 {
-				//	argList = " -ArgumentList @("
-				//	for i, arg := range args[2:] {
-				//		argList += fmt.Sprintf("'%s'", arg)
-				//		if i < len(args[2:])-1 {
-				//			argList += ","
-				//		}
-				//	}
-				//	argList += ")"
-				//}
-				//invoke := fmt.Sprintf("Invoke-Command -ScriptBlock { %s } %s", expansion[1:], argList)
-				//expanded = []string{"pwsh", "-Command", invoke}
-				executable, err := os.Executable()
-				if err != nil {
-					return
+				// Need to use absolute path for sh on windows
+				shPath, lookErr := exec.LookPath("sh")
+				if lookErr != nil {
+					gitPath, lookErr := exec.LookPath("git")
+					if lookErr != nil {
+						// TODO this error could be better probably
+						err = fmt.Errorf("unable to find sh. you will not be able to use shell aliases on this platform.")
+						return
+					}
+					shPath = filepath.Join(filepath.Dir(gitPath), "..", "bin", "sh.exe")
 				}
-				invoke := fmt.Sprintf("gh () { %s \"$@\" }; %s", executable, expansion[1:])
+				expanded[0] = shPath
+			}
 
-				expanded = []string{"bash", "--posix", "-c", invoke, "--"}
+			if len(args[2:]) > 0 {
+				expanded = append(expanded, "--")
 				expanded = append(expanded, args[2:]...)
-			} else {
-				if len(args[2:]) > 0 {
-					expanded = append(expanded, "--")
-					expanded = append(expanded, args[2:]...)
-				}
 			}
 
 			return


### PR DESCRIPTION
This PR augments `gh pr alias set` with the ability to accept `-s/--shell`. Shell aliases are executed through `$SHELL` and allow executing various commands in composition instead of just rewriting invocations of gh subcommands.

It works like this:

```
$ gh alias set -s checklist 'gh issue list -l$1 | sed "s/^/- [ ] /" > checklist.md'
- Adding alias for checklist: gh issue list -l$1 | sed "s/^/- [ ] /" > checklist.md
✓ Added alias.
$ gh checklist epic

Showing 2 of 2 issues in cli/cli that match your search

$ cat checklist.md
- [ ] 957       [Tracking issue] Improve GitHub authentication via GitHub CLI   enhancement, epic       about 4 days ago
- [ ] 939       Alias support phase 2   aliases, epic   about 12 days ago
```



Below is the initial sketch/discussion about this feature:

---

```
$ gh alias set igrep '!sh -c "gh issue list -L100 | grep $1"'
$ gh igrep alias

Showing 100 of 206 issues in cli/cli

1128    completions for aliases aliases, enhancement    about 18 minutes ago
1045    Share and consume gh aliases    enhancement     about 9 days ago
941     shell version of `gh alias set` aliases about 3 hours ago
940     Scriptability audit     aliases, tech-debt      about 9 days ago
939     Alias support phase 2   aliases, epic   about 2 hours ago
```

But the caveats:

## ! character

Enclosing the expansion in single quotes is necessary. both `bash` and `zsh` interpret `!` as a
special character and it will not make it into `gh`, which will lead to potentially confusing errors
for users who forget to use single quotes when using `!` style aliases.

Potential alternatives:

- Use a different character. None really felt right to me and just about every special character
  means _something_ to shells.
- Have `gh alias set` respect a `--external` flag. This is circular because to support this we'd have
  to re-enable flag parsing on `gh alias set`. In other words, to support `--external`, this would
  no longer work: `gh alias set co pr checkout`.
- Assume an external alias if the expansion does not map to a `gh` command. I don't love this;
  losing that bit of validation for non-external aliases seems not worth it.

**my opinion:** we're not going to do better than `!` and requiring single quotes is acceptable.

## quote madness

There are a lot of quote characters in `gh alias set igrep '!sh -c "gh issue list | grep $1"'`.

The `sh -c` in `!sh -c "command goes here"` is not needed in all cases. It's only necessary when you
want to compose commands.

For example, this works fine:

```
$ gh alias set echo '!echo'
$ gh echo hi how are you
hi how are you
```

But this won't do what you want:

```
$ gh alias set igrep '!gh issue list | grep $1'
$ gh igrep alias

# (...just runs issue list and discards subsequent |...)
```

My concern here is that it's cognitively confusing for people who aren't used to scripting in
shells. The `sh -c` is probably confusing and the need to put what they _actually_ want to run in
the double quotes when they're already wrapping everything in single quotes could lead users to
frustration.

Potential alternative:

- always wrapping `!` aliases in `sh -c "<expansion>"`. I've hacked this together and it seems to
  work well; the downside is that users are now stuck invoking their composed commands via `sh`.
  They might prefer to run things through `zsh` or `bash` to pick up their own shell aliases (i.e.
  aliases they've defined in their shells, not gh aliases). We could expose the shell for external
  aliases as a config option with a default of `sh`.

That could lead to something like this:

```
# In ZSH:
$ alias g=grep
$ gh alias set ig '!gh issue list | g $1'
$ gh ig alias
external alias failed: sh: 1: command not found: g

$ gh config set shell zsh
$ gh ig alias
# ... expected output ...
```

**my opinion:** I'm really intrigued by always wrapping in a `sh -c "<...>"`. I like combining it with the new config setting.

## Multiline input

I started experimenting with accepting an `--input <filename>` argument with an alias expansion in
it so that alias definitions could be written on multiple lines. This felt kind of bad; I wasn't
sure if suddenly having to worry about newlines in alias expansions was worth it.

Potential paths:

- Continue trying to allow for file input and handling newlines appropriately when setting up
  commands.
- Leave as-is and worry about more complex scripting in @mislav's extensions hack day proposal.

**my opinion:** we can punt on this for now.

# If you read this far

I'd love feedback on the above three caveats as well as any other thoughts y'all have about this.

tl;dr:

- is the `!` character ok for signalling to `gh` that the user wants an external alias?
- should we wrap all external aliases in `sh -c "<expansion>"`?
- should we worry about multi-line input at this point?
