### PR TITLE
The ultimate help/arguments handler

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -56,6 +56,9 @@ func main() {
 		printError(os.Stderr, err, cmd, hasDebug)
 		os.Exit(1)
 	}
+	if command.HasFailed() {
+		os.Exit(1)
+	}
 
 	newRelease := <-updateMessageChan
 	if newRelease != nil {

--- a/command/help.go
+++ b/command/help.go
@@ -95,6 +95,11 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 		dedent := regexp.MustCompile(`(?m)^  `)
 		helpEntries = append(helpEntries, helpEntry{"FLAGS", dedent.ReplaceAllString(flagUsages, "")})
 	}
+	inheritedFlagUsages := command.InheritedFlags().FlagUsages()
+	if inheritedFlagUsages != "" {
+		dedent := regexp.MustCompile(`(?m)^  `)
+		helpEntries = append(helpEntries, helpEntry{"INHERITED FLAGS", dedent.ReplaceAllString(inheritedFlagUsages, "")})
+	}
 	if _, ok := command.Annotations["help:arguments"]; ok {
 		helpEntries = append(helpEntries, helpEntry{"ARGUMENTS", command.Annotations["help:arguments"]})
 	}

--- a/command/help.go
+++ b/command/help.go
@@ -9,6 +9,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func rootUsageFunc(command *cobra.Command) error {
+	command.Printf("Usage:  %s", command.UseLine())
+
+	flagUsages := command.LocalFlags().FlagUsages()
+	if flagUsages != "" {
+		command.Printf("\n\nFlags:\n%s", flagUsages)
+	}
+	return nil
+}
+
 func rootHelpFunc(command *cobra.Command, args []string) {
 	// Display helpful error message in case subcommand name was mistyped.
 	// This matches Cobra's behavior for root command, which Cobra

--- a/command/help.go
+++ b/command/help.go
@@ -12,6 +12,18 @@ import (
 func rootUsageFunc(command *cobra.Command) error {
 	command.Printf("Usage:  %s", command.UseLine())
 
+	subcommands := command.Commands()
+	if len(subcommands) > 0 {
+		command.Print("\n\nAvailable commands:\n")
+		for _, c := range subcommands {
+			if c.Hidden {
+				continue
+			}
+			command.Printf("  %s\n", c.Name())
+		}
+		return nil
+	}
+
 	flagUsages := command.LocalFlags().FlagUsages()
 	if flagUsages != "" {
 		command.Printf("\n\nFlags:\n%s", flagUsages)
@@ -19,32 +31,40 @@ func rootUsageFunc(command *cobra.Command) error {
 	return nil
 }
 
-func rootHelpFunc(command *cobra.Command, args []string) {
-	// Display helpful error message in case subcommand name was mistyped.
-	// This matches Cobra's behavior for root command, which Cobra
-	// confusingly doesn't apply to nested commands.
-	if command != RootCmd {
-		if command.Parent() == RootCmd && len(args) >= 2 {
-			if command.SuggestionsMinimumDistance <= 0 {
-				command.SuggestionsMinimumDistance = 2
-			}
-			candidates := command.SuggestionsFor(args[1])
+var hasFailed bool
 
-			errOut := command.OutOrStderr()
-			fmt.Fprintf(errOut, "unknown command %q for %q\n", args[1], "gh "+args[0])
+// HasFailed signals that the main process should exit with non-zero status
+func HasFailed() bool {
+	return hasFailed
+}
 
-			if len(candidates) > 0 {
-				fmt.Fprint(errOut, "\nDid you mean this?\n")
-				for _, c := range candidates {
-					fmt.Fprintf(errOut, "\t%s\n", c)
-				}
-				fmt.Fprint(errOut, "\n")
-			}
+// Display helpful error message in case subcommand name was mistyped.
+// This matches Cobra's behavior for root command, which Cobra
+// confusingly doesn't apply to nested commands.
+func nestedSuggestFunc(command *cobra.Command, arg string) {
+	command.Printf("unknown command %q for `%s`\n", arg, command.UseLine())
 
-			oldOut := command.OutOrStdout()
-			command.SetOut(errOut)
-			defer command.SetOut(oldOut)
+	if command.SuggestionsMinimumDistance <= 0 {
+		command.SuggestionsMinimumDistance = 2
+	}
+	candidates := command.SuggestionsFor(arg)
+
+	if len(candidates) > 0 {
+		command.Print("\nDid you mean this?\n")
+		for _, c := range candidates {
+			command.Printf("\t%s\n", c)
 		}
+		command.Print("\n")
+	}
+
+	_ = rootUsageFunc(command)
+}
+
+func rootHelpFunc(command *cobra.Command, args []string) {
+	if command.Parent() == RootCmd && len(args) >= 2 && args[1] != "--help" && args[1] != "-h" {
+		nestedSuggestFunc(command, args[1])
+		hasFailed = true
+		return
 	}
 
 	coreCommands := []string{}

--- a/command/help.go
+++ b/command/help.go
@@ -42,21 +42,26 @@ func HasFailed() bool {
 // This matches Cobra's behavior for root command, which Cobra
 // confusingly doesn't apply to nested commands.
 func nestedSuggestFunc(command *cobra.Command, arg string) {
-	command.Printf("unknown command %q for `%s`\n", arg, command.UseLine())
+	command.Printf("unknown command %q for %q\n", arg, command.CommandPath())
 
-	if command.SuggestionsMinimumDistance <= 0 {
-		command.SuggestionsMinimumDistance = 2
+	var candidates []string
+	if arg == "help" {
+		candidates = []string{"--help"}
+	} else {
+		if command.SuggestionsMinimumDistance <= 0 {
+			command.SuggestionsMinimumDistance = 2
+		}
+		candidates = command.SuggestionsFor(arg)
 	}
-	candidates := command.SuggestionsFor(arg)
 
 	if len(candidates) > 0 {
 		command.Print("\nDid you mean this?\n")
 		for _, c := range candidates {
 			command.Printf("\t%s\n", c)
 		}
-		command.Print("\n")
 	}
 
+	command.Print("\n")
 	_ = rootUsageFunc(command)
 }
 

--- a/command/root.go
+++ b/command/root.go
@@ -59,9 +59,7 @@ func init() {
 	// RootCmd.PersistentFlags().BoolP("verbose", "V", false, "enable verbose output")
 
 	RootCmd.SetHelpFunc(rootHelpFunc)
-
-	// This will silence the usage func on error
-	RootCmd.SetUsageFunc(func(_ *cobra.Command) error { return nil })
+	RootCmd.SetUsageFunc(rootUsageFunc)
 
 	RootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		if err == pflag.ErrHelp {


### PR DESCRIPTION
- `gh <command> --help` is equivalent to `gh help <command>` across the board
- `gh <command> -h` is equivalent to `--help` for commands that don't define their own `-h` flag
- `gh <command> help` shows a notice on stderr `Did you mean this? --help` and exits with nonzero status
- `gh <command> <typo>` now exits with nonzero status
- any command usage error now prints short command usage information on stderr instead of full help output

```
$ gh pr create --foo
unknown flag: --foo

Usage:  gh pr create [flags]

Flags:
  -a, --assignee login   Assign a person by their login
  -B, --base string      The branch into which you want your code merged
  -b, --body string      Supply a body. Will prompt for one otherwise.
  -d, --draft            Mark pull request as a draft
  -f, --fill             Do not prompt for title/body and just use commit info
  -l, --label name       Add a label by name
  -m, --milestone name   Add the pull request to a milestone by name
  -p, --project name     Add the pull request to a project by name
  -r, --reviewer login   Request a review from someone by their login
  -t, --title string     Supply a title. Will prompt for one otherwise.
  -w, --web              Open the web browser to create a pull request

exit code: 1
```
```
$ gh pr lis
unknown command "lis" for "gh pr"

Did you mean this?
        list

Usage:  gh pr <command> [flags]

Available commands:
  checkout
  close
  create
  diff
  list
  merge
  ready
  reopen
  review
  status
  view

exit code: 1
```

Fixes #1169
Closes #1185
Pairs well with https://github.com/cli/cli/pull/1218