### PR TITLE
Add `api --paginate` option

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -143,6 +143,7 @@ func apiRun(opts *ApiOptions) error {
 		return err
 	}
 
+	isGraphQL := opts.RequestPath == "graphql"
 	requestPath, err := fillPlaceholders(opts.RequestPath, opts)
 	if err != nil {
 		return fmt.Errorf("unable to expand placeholder in path: %w", err)
@@ -153,6 +154,10 @@ func apiRun(opts *ApiOptions) error {
 
 	if !opts.RequestMethodPassed && (len(params) > 0 || opts.RequestInputFile != "") {
 		method = "POST"
+	}
+
+	if opts.Paginate && !isGraphQL {
+		requestPath = addPerPage(requestPath, 100, params)
 	}
 
 	if opts.RequestInputFile != "" {
@@ -189,7 +194,7 @@ func apiRun(opts *ApiOptions) error {
 			break
 		}
 
-		if opts.RequestPath == "graphql" {
+		if isGraphQL {
 			hasNextPage = endCursor != ""
 			if hasNextPage {
 				params["endCursor"] = endCursor

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -343,7 +343,7 @@ func Test_apiRun_paginationREST(t *testing.T) {
 	assert.Equal(t, `{"page":1}{"page":2}{"page":3}`, stdout.String(), "stdout")
 	assert.Equal(t, "", stderr.String(), "stderr")
 
-	assert.Equal(t, "https://api.github.com/issues", responses[0].Request.URL.String())
+	assert.Equal(t, "https://api.github.com/issues?per_page=100", responses[0].Request.URL.String())
 	assert.Equal(t, "https://api.github.com/repositories/1227/issues?page=2", responses[1].Request.URL.String())
 	assert.Equal(t, "https://api.github.com/repositories/1227/issues?page=3", responses[2].Request.URL.String())
 }

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -331,7 +331,8 @@ func Test_apiRun_pagination(t *testing.T) {
 			return &http.Client{Transport: tr}, nil
 		},
 
-		Paginate: true,
+		RequestPath: "issues",
+		Paginate:    true,
 	}
 
 	err := apiRun(&options)
@@ -340,6 +341,7 @@ func Test_apiRun_pagination(t *testing.T) {
 	assert.Equal(t, `{"page":1}{"page":2}{"page":3}`, stdout.String(), "stdout")
 	assert.Equal(t, "", stderr.String(), "stderr")
 
+	assert.Equal(t, "https://api.github.com/issues", responses[0].Request.URL.String())
 	assert.Equal(t, "https://api.github.com/repositories/1227/issues?page=2", responses[1].Request.URL.String())
 	assert.Equal(t, "https://api.github.com/repositories/1227/issues?page=3", responses[2].Request.URL.String())
 }

--- a/pkg/cmd/api/pagination.go
+++ b/pkg/cmd/api/pagination.go
@@ -2,9 +2,12 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
+	"strings"
 )
 
 var linkRE = regexp.MustCompile(`<([^>]+)>;\s*rel="([^"]+)"`)
@@ -84,4 +87,22 @@ loop:
 		return endCursor
 	}
 	return ""
+}
+
+func addPerPage(p string, perPage int, params map[string]interface{}) string {
+	if _, hasPerPage := params["per_page"]; hasPerPage {
+		return p
+	}
+
+	idx := strings.IndexRune(p, '?')
+	sep := "?"
+
+	if idx >= 0 {
+		if qp, err := url.ParseQuery(p[idx+1:]); err == nil && qp.Get("per_page") != "" {
+			return p
+		}
+		sep = "&"
+	}
+
+	return fmt.Sprintf("%s%sper_page=%d", p, sep, perPage)
 }

--- a/pkg/cmd/api/pagination.go
+++ b/pkg/cmd/api/pagination.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"regexp"
+)
+
+var linkRE = regexp.MustCompile(`<([^>]+)>;\s*rel="([^"]+)"`)
+
+func findNextPage(resp *http.Response) (string, bool) {
+	for _, m := range linkRE.FindAllStringSubmatch(resp.Header.Get("Link"), -1) {
+		if len(m) >= 2 && m[2] == "next" {
+			return m[1], true
+		}
+	}
+	return "", false
+}
+
+func findEndCursor(r io.Reader) string {
+	dec := json.NewDecoder(r)
+
+	var idx int
+	var stack []json.Delim
+	var lastKey string
+	var contextKey string
+
+	var endCursor string
+	var hasNextPage bool
+	var foundEndCursor bool
+	var foundNextPage bool
+
+loop:
+	for {
+		t, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return ""
+		}
+
+		switch tt := t.(type) {
+		case json.Delim:
+			switch tt {
+			case '{', '[':
+				stack = append(stack, tt)
+				contextKey = lastKey
+				idx = 0
+			case '}', ']':
+				stack = stack[:len(stack)-1]
+				contextKey = ""
+				idx = 0
+			}
+		default:
+			isKey := len(stack) > 0 && stack[len(stack)-1] == '{' && idx%2 == 0
+			idx++
+
+			switch tt := t.(type) {
+			case string:
+				if isKey {
+					lastKey = tt
+				} else if contextKey == "pageInfo" && lastKey == "endCursor" {
+					endCursor = tt
+					foundEndCursor = true
+					if foundNextPage {
+						break loop
+					}
+				}
+			case bool:
+				if contextKey == "pageInfo" && lastKey == "hasNextPage" {
+					hasNextPage = tt
+					foundNextPage = true
+					if foundEndCursor {
+						break loop
+					}
+				}
+			}
+		}
+	}
+
+	if hasNextPage {
+		return endCursor
+	}
+	return ""
+}

--- a/pkg/cmd/api/pagination_test.go
+++ b/pkg/cmd/api/pagination_test.go
@@ -116,3 +116,54 @@ func Test_findEndCursor(t *testing.T) {
 		})
 	}
 }
+
+func Test_addPerPage(t *testing.T) {
+	type args struct {
+		p       string
+		perPage int
+		params  map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "adds per_page",
+			args: args{
+				p:       "items",
+				perPage: 13,
+				params:  nil,
+			},
+			want: "items?per_page=13",
+		},
+		{
+			name: "avoids adding per_page if already in params",
+			args: args{
+				p:       "items",
+				perPage: 13,
+				params: map[string]interface{}{
+					"state":    "open",
+					"per_page": 99,
+				},
+			},
+			want: "items",
+		},
+		{
+			name: "avoids adding per_page if already in query",
+			args: args{
+				p:       "items?per_page=6&state=open",
+				perPage: 13,
+				params:  nil,
+			},
+			want: "items?per_page=6&state=open",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := addPerPage(tt.args.p, tt.args.perPage, tt.args.params); got != tt.want {
+				t.Errorf("addPerPage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cmd/api/pagination_test.go
+++ b/pkg/cmd/api/pagination_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func Test_findNextPage(t *testing.T) {
+	tests := []struct {
+		name  string
+		resp  *http.Response
+		want  string
+		want1 bool
+	}{
+		{
+			name:  "no Link header",
+			resp:  &http.Response{},
+			want:  "",
+			want1: false,
+		},
+		{
+			name: "no next page in Link",
+			resp: &http.Response{
+				Header: http.Header{
+					"Link": []string{`<https://api.github.com/issues?page=3>; rel="last"`},
+				},
+			},
+			want:  "",
+			want1: false,
+		},
+		{
+			name: "has next page",
+			resp: &http.Response{
+				Header: http.Header{
+					"Link": []string{`<https://api.github.com/issues?page=2>; rel="next", <https://api.github.com/issues?page=3>; rel="last"`},
+				},
+			},
+			want:  "https://api.github.com/issues?page=2",
+			want1: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := findNextPage(tt.resp)
+			if got != tt.want {
+				t.Errorf("findNextPage() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("findNextPage() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func Test_findEndCursor(t *testing.T) {
+	tests := []struct {
+		name string
+		json io.Reader
+		want string
+	}{
+		{
+			name: "blank",
+			json: bytes.NewBufferString(`{}`),
+			want: "",
+		},
+		{
+			name: "unrelated fields",
+			json: bytes.NewBufferString(`{
+				"hasNextPage": true,
+				"endCursor": "THE_END"
+			}`),
+			want: "",
+		},
+		{
+			name: "has next page",
+			json: bytes.NewBufferString(`{
+				"pageInfo": {
+					"hasNextPage": true,
+					"endCursor": "THE_END"
+				}
+			}`),
+			want: "THE_END",
+		},
+		{
+			name: "more pageInfo blocks",
+			json: bytes.NewBufferString(`{
+				"pageInfo": {
+					"hasNextPage": true,
+					"endCursor": "THE_END"
+				},
+				"pageInfo": {
+					"hasNextPage": true,
+					"endCursor": "NOT_THIS"
+				}
+			}`),
+			want: "THE_END",
+		},
+		{
+			name: "no next page",
+			json: bytes.NewBufferString(`{
+				"pageInfo": {
+					"hasNextPage": false,
+					"endCursor": "THE_END"
+				}
+			}`),
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findEndCursor(tt.json); got != tt.want {
+				t.Errorf("findEndCursor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`gh api --paginate repos/:owner/:repo/issues` automatically fetches and prints all pages of all results until there are no more pages.

TODO:
- [x] GraphQL pagination
- [x] automatically set `per_page=100` in pagination mode?

Fixes https://github.com/cli/cli/issues/1184