### PR TITLE
Fix pr create not using .github/pull_request_template.md

### DIFF
--- a/command/title_body_survey.go
+++ b/command/title_body_survey.go
@@ -164,7 +164,8 @@ func titleBodySurvey(cmd *cobra.Command, issueState *issueMetadataState, apiClie
 			}
 			issueState.Body = templateContents
 		} else if legacyTemplatePath != nil {
-			issueState.Body = string(githubtemplate.ExtractContents(*legacyTemplatePath))
+			templateContents = string(githubtemplate.ExtractContents(*legacyTemplatePath))
+			issueState.Body = templateContents
 		} else {
 			issueState.Body = defs.Body
 		}


### PR DESCRIPTION
## Summary

closes #1219

## Details
The `templateContents` string was not filled when selecting a legacyTemplate.  
And when the user did not use an editor to edit the body, the `issueState.Body` was also blank  
This resulted in a blank body.

This is avoided by filling the `templateContents` string with the default template
