### PR TITLE
Fix `pr checkout OWNER:BRANCH` when maintainer can modify

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -540,8 +540,12 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, baseBranch, hea
 					headRepositoryOwner {
 						login
 					}
+					headRepository {
+						name
+					}
 					isCrossRepository
 					isDraft
+					maintainerCanModify
 					reviewRequests(first: 100) {
 						nodes {
 							requestedReviewer {


### PR DESCRIPTION
We did not request the necessary GraphQL fields to determine whether the PR in question can be modified by maintainers (i.e. pushed back to). This fixes that.

```sh
$ gh pr checkout OWNER:BRANCH
#=> checked out BRANCH

# (...made some commits)
$ git push
#=> now works!
```

The `pr checkout <number>` syntax was never affected by this bug, so it doesn't need to get fixed.