### PR TITLE
Gracefully handle "422: Reference does not exist" when deleting remote branch

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -47,9 +47,15 @@ func TestGraphQLError(t *testing.T) {
 	client := NewClient(ReplaceTripper(http))
 
 	response := struct{}{}
-	http.StubResponse(200, bytes.NewBufferString(`{"errors":[{"message":"OH NO"}]}`))
+	http.StubResponse(200, bytes.NewBufferString(`
+	{ "errors": [
+		{"message":"OH NO"},
+		{"message":"this is fine"}
+	  ]
+	}`))
+
 	err := client.GraphQL("", nil, &response)
-	if err == nil || err.Error() != "graphql error: 'OH NO'" {
+	if err == nil || err.Error() != "GraphQL error: OH NO\nthis is fine" {
 		t.Fatalf("got %q", err.Error())
 	}
 }
@@ -75,8 +81,15 @@ func TestRESTError(t *testing.T) {
 	http.StubResponse(422, bytes.NewBufferString(`{"message": "OH NO"}`))
 
 	var httpErr HTTPError
-	err := client.REST("DELETE", "/repos/branch", nil, nil)
-	if err == nil || !errors.As(err, &httpErr) || httpErr.Code != 422 {
-		t.Fatalf("got %q", err.Error())
+	err := client.REST("DELETE", "repos/branch", nil, nil)
+	if err == nil || !errors.As(err, &httpErr) {
+		t.Fatalf("got %v", err)
+	}
+
+	if httpErr.StatusCode != 422 {
+		t.Errorf("expected status code 422, got %d", httpErr.StatusCode)
+	}
+	if httpErr.Error() != "HTTP 422: OH NO (https://api.github.com/repos/branch)" {
+		t.Errorf("got %q", httpErr.Error())
 	}
 }

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -1011,20 +1011,8 @@ func PullRequestReady(client *Client, repo ghrepo.Interface, pr *PullRequest) er
 }
 
 func BranchDeleteRemote(client *Client, repo ghrepo.Interface, branch string) error {
-	var response struct {
-		NodeID string `json:"node_id"`
-	}
 	path := fmt.Sprintf("repos/%s/%s/git/refs/heads/%s", repo.RepoOwner(), repo.RepoName(), branch)
-	err := client.REST("DELETE", path, nil, &response)
-	if err != nil {
-		var httpErr HTTPError
-		// The ref might have already been deleted by GitHub
-		if !errors.As(err, &httpErr) || httpErr.Code != 422 {
-			return err
-		}
-	}
-
-	return nil
+	return client.REST("DELETE", path, nil, nil)
 }
 
 func min(a, b int) int {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -1015,7 +1015,16 @@ func BranchDeleteRemote(client *Client, repo ghrepo.Interface, branch string) er
 		NodeID string `json:"node_id"`
 	}
 	path := fmt.Sprintf("repos/%s/%s/git/refs/heads/%s", repo.RepoOwner(), repo.RepoName(), branch)
-	return client.REST("DELETE", path, nil, &response)
+	err := client.REST("DELETE", path, nil, &response)
+	if err != nil {
+		var httpErr HTTPError
+		// The ref might have already been deleted by GitHub
+		if !errors.As(err, &httpErr) || httpErr.Code != 422 {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func min(a, b int) int {

--- a/api/queries_pr_test.go
+++ b/api/queries_pr_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/httpmock"
+)
+
+func TestBranchDeleteRemote(t *testing.T) {
+	var tests = []struct {
+		name        string
+		code        int
+		body        string
+		expectError bool
+	}{
+		{name: "success", code: 204, body: "", expectError: false},
+		{name: "error", code: 500, body: `{"message": "oh no"}`, expectError: true},
+		{
+			name:        "already_deleted",
+			code:        422,
+			body:        `{"message": "Reference does not exist"}`,
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			http := &httpmock.Registry{}
+			client := NewClient(ReplaceTripper(http))
+
+			http.StubResponse(tc.code, bytes.NewBufferString(tc.body))
+			repo, _ := ghrepo.FromFullName("OWNER/REPO")
+			err := BranchDeleteRemote(client, repo, "branch")
+			if isError := err != nil; isError != tc.expectError {
+				t.Fatalf("unexpected result: %v", err)
+			}
+		})
+	}
+}

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -402,7 +402,7 @@ func TestIssueView_web_notFound(t *testing.T) {
 	defer restoreCmd()
 
 	_, err := RunCommand("issue view -w 9999")
-	if err == nil || err.Error() != "graphql error: 'Could not resolve to an Issue with the number of 9999.'" {
+	if err == nil || err.Error() != "GraphQL error: Could not resolve to an Issue with the number of 9999." {
 		t.Errorf("error running command `issue view`: %v", err)
 	}
 

--- a/command/pr.go
+++ b/command/pr.go
@@ -523,7 +523,9 @@ func prMerge(cmd *cobra.Command, args []string) error {
 
 		if !crossRepoPR {
 			err = api.BranchDeleteRemote(apiClient, baseRepo, pr.HeadRefName)
-			if err != nil {
+			var httpErr api.HTTPError
+			// The ref might have already been deleted by GitHub
+			if err != nil && (!errors.As(err, &httpErr) || httpErr.StatusCode != 422) {
 				err = fmt.Errorf("failed to delete remote branch %s: %w", utils.Cyan(pr.HeadRefName), err)
 				return err
 			}

--- a/pkg/httpmock/legacy.go
+++ b/pkg/httpmock/legacy.go
@@ -12,19 +12,19 @@ import (
 // TODO: clean up methods in this file when there are no more callers
 
 func (r *Registry) StubResponse(status int, body io.Reader) {
-	r.Register(MatchAny, func(*http.Request) (*http.Response, error) {
-		return httpResponse(status, body), nil
+	r.Register(MatchAny, func(req *http.Request) (*http.Response, error) {
+		return httpResponse(status, req, body), nil
 	})
 }
 
 func (r *Registry) StubWithFixture(status int, fixtureFileName string) func() {
 	fixturePath := path.Join("../test/fixtures/", fixtureFileName)
 	fixtureFile, err := os.Open(fixturePath)
-	r.Register(MatchAny, func(*http.Request) (*http.Response, error) {
+	r.Register(MatchAny, func(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			return nil, err
 		}
-		return httpResponse(200, fixtureFile), nil
+		return httpResponse(200, req, fixtureFile), nil
 	})
 	return func() {
 		if err == nil {

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -59,15 +59,15 @@ func decodeJSONBody(req *http.Request, dest interface{}) error {
 }
 
 func StringResponse(body string) Responder {
-	return func(*http.Request) (*http.Response, error) {
-		return httpResponse(200, bytes.NewBufferString(body)), nil
+	return func(req *http.Request) (*http.Response, error) {
+		return httpResponse(200, req, bytes.NewBufferString(body)), nil
 	}
 }
 
 func JSONResponse(body interface{}) Responder {
-	return func(*http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
 		b, _ := json.Marshal(body)
-		return httpResponse(200, bytes.NewBuffer(b)), nil
+		return httpResponse(200, req, bytes.NewBuffer(b)), nil
 	}
 }
 
@@ -84,7 +84,7 @@ func GraphQLMutation(body string, cb func(map[string]interface{})) Responder {
 		}
 		cb(bodyData.Variables.Input)
 
-		return httpResponse(200, bytes.NewBufferString(body)), nil
+		return httpResponse(200, req, bytes.NewBufferString(body)), nil
 	}
 }
 
@@ -100,13 +100,14 @@ func GraphQLQuery(body string, cb func(string, map[string]interface{})) Responde
 		}
 		cb(bodyData.Query, bodyData.Variables)
 
-		return httpResponse(200, bytes.NewBufferString(body)), nil
+		return httpResponse(200, req, bytes.NewBufferString(body)), nil
 	}
 }
 
-func httpResponse(status int, body io.Reader) *http.Response {
+func httpResponse(status int, req *http.Request, body io.Reader) *http.Response {
 	return &http.Response{
 		StatusCode: status,
+		Request:    req,
 		Body:       ioutil.NopCloser(body),
 	}
 }

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -64,6 +64,12 @@ func StringResponse(body string) Responder {
 	}
 }
 
+func StatusStringResponse(status int, body string) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		return httpResponse(status, req, bytes.NewBufferString(body)), nil
+	}
+}
+
 func JSONResponse(body interface{}) Responder {
 	return func(req *http.Request) (*http.Response, error) {
 		b, _ := json.Marshal(body)


### PR DESCRIPTION
<!--
Please make sure you read our contributing guidelines at
https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md
before opening a pull request. Thanks!
-->

## Summary

This PR modifies `BrachDeleteRemote` to gracefully handle the case when remote branch has already been automatically
deleted by GitHub.

Closes #1010
