### PR TITLE
Config Documentation - VS Code Example

### DIFF
--- a/command/config.go
+++ b/command/config.go
@@ -48,6 +48,7 @@ var configSetCmd = &cobra.Command{
 	Short: "Update configuration with a value for the given key",
 	Example: heredoc.Doc(`
 	$ gh config set editor vim
+	$ gh config set editor "code --wait"
 	`),
 	Args: cobra.ExactArgs(2),
 	RunE: configSet,


### PR DESCRIPTION
Added a documentation example for how to set Visual Studio Code as the default editor using `gh config set`. 

This utilizes the VS code CLI. The `--wait` flag ensures the gh cli waits for the user to finishing editing in VS code before asking for next steps. 

Question:
MacOS users will need to add the VS Code executable to their `$PATH` env variable. Is that worth noting somewhere in the cli documentation?

Fixes #1068