### PR TITLE
Fix `brew install github/gh/gh --HEAD`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,7 +61,7 @@ brews:
     folder: Formula
     custom_block: |
       head do
-        url "https://github.com/cli/cli.git"
+        url "https://github.com/cli/cli.git", :branch => "trunk"
         depends_on "go"
       end
     install: |


### PR DESCRIPTION
The default behavior tried to download the "master" branch, so this retargets it.

Ref. https://github.com/github/homebrew-gh/pull/12
Followup to https://github.com/cli/cli/issues/929