### PR TITLE
Reduce minimum reuqired Go version from 1.14 to 1.13.8.

### DIFF
--- a/docs/source.md
+++ b/docs/source.md
@@ -1,6 +1,6 @@
 # Installation from source
 
-0. Verify that you have Go 1.14+ installed
+0. Verify that you have Go 1.13.8+ installed
 
    ```sh
    $ go version


### PR DESCRIPTION
1.13.8 is the version that ships with Ubuntu 20.04 Long Term Support release and it works for me.