### PR TITLE
Fixed gh issue close and gh issue reopen when issue number invalid

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -709,7 +709,7 @@ func issueClose(cmd *cobra.Command, args []string) error {
 	if errors.As(err, &idErr) {
 		return fmt.Errorf("issues disabled for %s", ghrepo.FullName(baseRepo))
 	} else if err != nil {
-		return fmt.Errorf("failed to find issue #%d: %w", issue.Number, err)
+		return err
 	}
 
 	if issue.Closed {
@@ -744,7 +744,7 @@ func issueReopen(cmd *cobra.Command, args []string) error {
 	if errors.As(err, &idErr) {
 		return fmt.Errorf("issues disabled for %s", ghrepo.FullName(baseRepo))
 	} else if err != nil {
-		return fmt.Errorf("failed to find issue #%d: %w", issue.Number, err)
+		return err
 	}
 
 	if !issue.Closed {


### PR DESCRIPTION
<!--
Please make sure you read our contributing guidelines at
https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md
before opening a pull request. Thanks!
-->

## Summary

closes #1325

## Details

- The `gh issue close` and `gh issue reopen` had a code stub that displayed a formatted error string. But the problem was that if the issue number is invalid, then the code would throw nilPointer exception.

Currently, I have returned the error as is. If we need a custom message, we can do that as well

