### PR TITLE
Remove unneeded command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ sudo port selfupdate && sudo port upgrade gh
 Install:
 
 ```powershell
-scoop bucket add github-gh https://github.com/cli/scoop-gh.git
 scoop install gh
 ```
 


### PR DESCRIPTION
gh is in scoop’s main bucket now: https://github.com/ScoopInstaller/Main/blob/master/bucket/gh.json

This app is preferred, as it will autoupdate.