### PR TITLE
Use non-gendered third person pronoun

### DIFF
--- a/docs/gh-vs-hub.md
+++ b/docs/gh-vs-hub.md
@@ -14,7 +14,7 @@ The GitHub CLI team is focused solely on building out the new tool, `gh`. We are
 
 GitHub CLI is built and maintained by a team of people who work on the tool on behalf of GitHub. When there’s something wrong with it, people can reach out to GitHub support or create an issue in the issue tracker, where an employee at GitHub will respond. 
 
-`hub` is a project whose maintainer also happens to be a GitHub employee. He chooses to maintain `hub` in his spare time, as many of our employees do with open source projects.
+`hub` is a project whose maintainer also happens to be a GitHub employee. They choose to maintain `hub` in their spare time, as many of our employees do with open source projects.
 
 ## Should I use `gh` or `hub`?
 


### PR DESCRIPTION
Since the `hub` maintainer is not mentioned by name, their gender is irrelevant.