### PR TITLE
strip '\r' from text in markdown

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -26,7 +26,8 @@ func RenderMarkdown(text string) (string, error) {
 	if isColorEnabled() {
 		style = "dark"
 	}
-	text = strings.Map(filterCarriageReturn, text)
+	// This ensures that carriage returns before the newlines are omitted
+	text = strings.ReplaceAll(text, "\r\n", "\n")
 	return glamour.Render(text, style)
 }
 
@@ -87,11 +88,4 @@ var StopSpinner = func(s *spinner.Spinner) {
 
 func Spinner(w io.Writer) *spinner.Spinner {
 	return spinner.New(spinner.CharSets[11], 400*time.Millisecond, spinner.WithWriter(w))
-}
-
-func filterCarriageReturn(r rune) rune {
-	if r == '\r' {
-		return -1
-	}
-	return r
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -26,6 +26,7 @@ func RenderMarkdown(text string) (string, error) {
 	if isColorEnabled() {
 		style = "dark"
 	}
+	text = strings.Map(filterCarriageReturn, text)
 	return glamour.Render(text, style)
 }
 
@@ -86,4 +87,11 @@ var StopSpinner = func(s *spinner.Spinner) {
 
 func Spinner(w io.Writer) *spinner.Spinner {
 	return spinner.New(spinner.CharSets[11], 400*time.Millisecond, spinner.WithWriter(w))
+}
+
+func filterCarriageReturn(r rune) rune {
+	if r == '\r' {
+		return -1
+	}
+	return r
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -26,7 +26,8 @@ func RenderMarkdown(text string) (string, error) {
 	if isColorEnabled() {
 		style = "dark"
 	}
-	// This ensures that carriage returns before the newlines are omitted
+	// Glamour rendering preserves carriage return characters in code blocks, but
+	// we need to ensure that no such characters are present in the output.
 	text = strings.ReplaceAll(text, "\r\n", "\n")
 	return glamour.Render(text, style)
 }


### PR DESCRIPTION
<!--
Please make sure you read our contributing guidelines at
https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md
before opening a pull request. Thanks!
-->

## Summary

closes #1336

## Details

- Added a map that strips of '\r' from text before it goes for markdown rendering.
