### PR TITLE
Improvements to checking OAuth scopes

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -125,11 +125,21 @@ func Test_CheckScopes(t *testing.T) {
 			responseScopes: "repo, admin:org, gist",
 			expectCallback: false,
 		},
+		{
+			name:           "no scopes in response",
+			wantScope:      "read:org",
+			responseApp:    "",
+			responseScopes: "",
+			expectCallback: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tr := &httpmock.Registry{}
 			tr.Register(httpmock.MatchAny, func(*http.Request) (*http.Response, error) {
+				if tt.responseScopes == "" {
+					return &http.Response{StatusCode: 200}, nil
+				}
 				return &http.Response{
 					StatusCode: 200,
 					Header: http.Header{


### PR DESCRIPTION
* Don't warn about needing `read:org` scope if the current token has `admin:org` scope. Fixes #1026

* Don't check required OAuth scopes if the response does not contain the `X-Oauth-Scopes` header at all, which silences the warning when gh is used in GitHub Actions with `secrets.GITHUB_TOKEN`. Ref. #1314