### PR TITLE
pr checkout fixes for branch names

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -432,9 +432,6 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 				}
 				headRepository {
 					name
-					defaultBranchRef {
-						name
-					}
 				}
 				isCrossRepository
 				isDraft

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -114,6 +114,18 @@ func GitHubRepo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 	return initRepoHostname(&result.Repository, repo.RepoHost()), nil
 }
 
+func RepoDefaultBranch(client *Client, repo ghrepo.Interface) (string, error) {
+	if r, ok := repo.(*Repository); ok && r.DefaultBranchRef.Name != "" {
+		return r.DefaultBranchRef.Name, nil
+	}
+
+	r, err := GitHubRepo(client, repo)
+	if err != nil {
+		return "", err
+	}
+	return r.DefaultBranchRef.Name, nil
+}
+
 // RepoParent finds out the parent repository of a fork
 func RepoParent(client *Client, repo ghrepo.Interface) (ghrepo.Interface, error) {
 	var query struct {

--- a/command/pr.go
+++ b/command/pr.go
@@ -493,23 +493,21 @@ func prMerge(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(colorableOut(cmd), "%s %s pull request #%d (%s)\n", utils.Magenta("✔"), action, pr.Number, pr.Title)
 
 	if deleteBranch {
-		repo, err := api.GitHubRepo(apiClient, baseRepo)
-		if err != nil {
-			return err
-		}
-
-		currentBranch, err := ctx.Branch()
-		if err != nil {
-			return err
-		}
-
 		branchSwitchString := ""
 
 		if deleteLocalBranch && !crossRepoPR {
+			currentBranch, err := ctx.Branch()
+			if err != nil {
+				return err
+			}
+
 			var branchToSwitchTo string
 			if currentBranch == pr.HeadRefName {
-				branchToSwitchTo = repo.DefaultBranchRef.Name
-				err = git.CheckoutBranch(repo.DefaultBranchRef.Name)
+				branchToSwitchTo, err = api.RepoDefaultBranch(apiClient, baseRepo)
+				if err != nil {
+					return err
+				}
+				err = git.CheckoutBranch(branchToSwitchTo)
 				if err != nil {
 					return err
 				}

--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -46,6 +47,9 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 
 	var cmdQueue [][]string
 	newBranchName := pr.HeadRefName
+	if strings.HasPrefix(newBranchName, "-") {
+		return fmt.Errorf("invalid branch name: %q", newBranchName)
+	}
 
 	if headRemote != nil {
 		// there is an existing git remote for PR head

--- a/command/pr_checkout.go
+++ b/command/pr_checkout.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cli/cli/api"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/internal/run"
@@ -65,8 +66,13 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 	} else {
 		// no git remote for PR head
 
+		defaultBranchName, err := api.RepoDefaultBranch(apiClient, baseRepo)
+		if err != nil {
+			return err
+		}
+
 		// avoid naming the new branch the same as the default branch
-		if newBranchName == pr.HeadRepository.DefaultBranchRef.Name {
+		if newBranchName == defaultBranchName {
 			newBranchName = fmt.Sprintf("%s/%s", pr.HeadRepositoryOwner.Login, newBranchName)
 		}
 

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -33,10 +33,7 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 			"login": "hubot"
 		},
 		"headRepository": {
-			"name": "REPO",
-			"defaultBranchRef": {
-				"name": "master"
-			}
+			"name": "REPO"
 		},
 		"isCrossRepository": false,
 		"maintainerCanModify": false
@@ -84,10 +81,7 @@ func TestPRCheckout_urlArg(t *testing.T) {
 			"login": "hubot"
 		},
 		"headRepository": {
-			"name": "REPO",
-			"defaultBranchRef": {
-				"name": "master"
-			}
+			"name": "REPO"
 		},
 		"isCrossRepository": false,
 		"maintainerCanModify": false
@@ -132,14 +126,16 @@ func TestPRCheckout_urlArg_differentBase(t *testing.T) {
 			"login": "hubot"
 		},
 		"headRepository": {
-			"name": "POE",
-			"defaultBranchRef": {
-				"name": "master"
-			}
+			"name": "POE"
 		},
 		"isCrossRepository": false,
 		"maintainerCanModify": false
 	} } } }
+	`))
+	http.Register(httpmock.GraphQL(`query RepositoryInfo\b`), httpmock.StringResponse(`
+	{ "data": { "repository": {
+		"defaultBranchRef": {"name": "master"}
+	} } }
 	`))
 
 	ranCommands := [][]string{}
@@ -195,10 +191,7 @@ func TestPRCheckout_branchArg(t *testing.T) {
 		  	"login": "hubot"
 		  },
 		  "headRepository": {
-		  	"name": "REPO",
-		  	"defaultBranchRef": {
-		  		"name": "master"
-		  	}
+		  	"name": "REPO"
 		  },
 		  "isCrossRepository": true,
 		  "maintainerCanModify": false }
@@ -245,10 +238,7 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 			"login": "hubot"
 		},
 		"headRepository": {
-			"name": "REPO",
-			"defaultBranchRef": {
-				"name": "master"
-			}
+			"name": "REPO"
 		},
 		"isCrossRepository": false,
 		"maintainerCanModify": false
@@ -298,10 +288,7 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 			"login": "hubot"
 		},
 		"headRepository": {
-			"name": "REPO",
-			"defaultBranchRef": {
-				"name": "master"
-			}
+			"name": "REPO"
 		},
 		"isCrossRepository": true,
 		"maintainerCanModify": false
@@ -351,10 +338,7 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 			"login": "hubot"
 		},
 		"headRepository": {
-			"name": "REPO",
-			"defaultBranchRef": {
-				"name": "master"
-			}
+			"name": "REPO"
 		},
 		"isCrossRepository": true,
 		"maintainerCanModify": false
@@ -404,10 +388,7 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 			"login": "hubot"
 		},
 		"headRepository": {
-			"name": "REPO",
-			"defaultBranchRef": {
-				"name": "master"
-			}
+			"name": "REPO"
 		},
 		"isCrossRepository": true,
 		"maintainerCanModify": false
@@ -455,10 +436,7 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 			"login": "hubot"
 		},
 		"headRepository": {
-			"name": "REPO",
-			"defaultBranchRef": {
-				"name": "master"
-			}
+			"name": "REPO"
 		},
 		"isCrossRepository": true,
 		"maintainerCanModify": false
@@ -506,10 +484,7 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 			"login": "hubot"
 		},
 		"headRepository": {
-			"name": "REPO",
-			"defaultBranchRef": {
-				"name": "master"
-			}
+			"name": "REPO"
 		},
 		"isCrossRepository": true,
 		"maintainerCanModify": true

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -24,6 +24,7 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
+	defer http.Verify(t)
 	http.StubRepoResponse("OWNER", "REPO")
 
 	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
@@ -74,6 +75,7 @@ func TestPRCheckout_urlArg(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
+	defer http.Verify(t)
 	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
@@ -119,6 +121,7 @@ func TestPRCheckout_urlArg_differentBase(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
+	defer http.Verify(t)
 	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
@@ -182,6 +185,7 @@ func TestPRCheckout_branchArg(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
+	defer http.Verify(t)
 	http.StubRepoResponse("OWNER", "REPO")
 
 	http.Register(httpmock.GraphQL(`query PullRequestForBranch\b`), httpmock.StringResponse(`
@@ -229,6 +233,7 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
+	defer http.Verify(t)
 	http.StubRepoResponse("OWNER", "REPO")
 
 	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
@@ -279,6 +284,7 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
+	defer http.Verify(t)
 	http.StubRepoResponse("OWNER", "REPO")
 
 	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
@@ -329,6 +335,7 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
+	defer http.Verify(t)
 	http.StubRepoResponse("OWNER", "REPO")
 
 	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
@@ -379,6 +386,7 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
+	defer http.Verify(t)
 	http.StubRepoResponse("OWNER", "REPO")
 
 	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
@@ -427,6 +435,7 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
+	defer http.Verify(t)
 	http.StubRepoResponse("OWNER", "REPO")
 
 	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
@@ -516,6 +525,7 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
+	defer http.Verify(t)
 	http.StubRepoResponse("OWNER", "REPO")
 
 	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`

--- a/command/pr_checkout_test.go
+++ b/command/pr_checkout_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"os/exec"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/internal/run"
+	"github.com/cli/cli/pkg/httpmock"
 	"github.com/cli/cli/test"
 )
 
@@ -25,7 +25,7 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	http.StubResponse(200, bytes.NewBufferString(`
+	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
 		"headRefName": "feature",
@@ -76,7 +76,7 @@ func TestPRCheckout_urlArg(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
-	http.StubResponse(200, bytes.NewBufferString(`
+	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
 		"headRefName": "feature",
@@ -124,7 +124,7 @@ func TestPRCheckout_urlArg_differentBase(t *testing.T) {
 		return ctx
 	}
 	http := initFakeHTTP()
-	http.StubResponse(200, bytes.NewBufferString(`
+	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
 		"headRefName": "feature",
@@ -187,7 +187,7 @@ func TestPRCheckout_branchArg(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	http.StubResponse(200, bytes.NewBufferString(`
+	http.Register(httpmock.GraphQL(`query PullRequestForBranch\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequests": { "nodes": [
 		{ "number": 123,
 		  "headRefName": "feature",
@@ -237,7 +237,7 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	http.StubResponse(200, bytes.NewBufferString(`
+	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
 		"headRefName": "feature",
@@ -290,7 +290,7 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	http.StubResponse(200, bytes.NewBufferString(`
+	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
 		"headRefName": "feature",
@@ -343,7 +343,7 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	http.StubResponse(200, bytes.NewBufferString(`
+	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
 		"headRefName": "feature",
@@ -396,7 +396,7 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	http.StubResponse(200, bytes.NewBufferString(`
+	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
 		"headRefName": "feature",
@@ -447,7 +447,7 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	http.StubResponse(200, bytes.NewBufferString(`
+	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
 		"headRefName": "feature",
@@ -498,7 +498,7 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
-	http.StubResponse(200, bytes.NewBufferString(`
+	http.Register(httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.StringResponse(`
 	{ "data": { "repository": { "pullRequest": {
 		"number": 123,
 		"headRefName": "feature",

--- a/pkg/httpmock/registry.go
+++ b/pkg/httpmock/registry.go
@@ -21,6 +21,7 @@ func (r *Registry) Register(m Matcher, resp Responder) {
 
 type Testing interface {
 	Errorf(string, ...interface{})
+	Helper()
 }
 
 func (r *Registry) Verify(t Testing) {
@@ -31,6 +32,7 @@ func (r *Registry) Verify(t Testing) {
 		}
 	}
 	if n > 0 {
+		t.Helper()
 		// NOTE: stubs offer no useful reflection, so we can't print details
 		// about dead stubs and what they were trying to match
 		t.Errorf("%d unmatched HTTP stubs", n)


### PR DESCRIPTION
* Fix `pr checkout OWNER:BRANCH` when BRANCH matches the default branch of the base repo
* Abort `pr checkout` when the head branch of the PR has an invalid name
* Avoid extra API request in `pr merge` if it's not needed
* Verify integrity of HTTP test stubs related to `pr merge/checkout`