### PR TITLE
Improve support for legacy issue/PR template names

### DIFF
--- a/pkg/githubtemplate/github_template.go
+++ b/pkg/githubtemplate/github_template.go
@@ -1,6 +1,7 @@
 package githubtemplate
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path"
 	"regexp"
@@ -53,6 +54,8 @@ mainLoop:
 
 // FindLegacy returns the file path of the default(legacy) template
 func FindLegacy(rootDir string, name string) *string {
+	namePattern := regexp.MustCompile(fmt.Sprintf(`(?i)^%s(\.|$)`, strings.ReplaceAll(name, "_", "[_-]")))
+
 	// https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository
 	candidateDirs := []string{
 		path.Join(rootDir, ".github"),
@@ -67,7 +70,7 @@ func FindLegacy(rootDir string, name string) *string {
 
 		// detect a single template file
 		for _, file := range files {
-			if strings.EqualFold(file.Name(), name+".md") {
+			if namePattern.MatchString(file.Name()) && !file.IsDir() {
 				result := path.Join(dir, file.Name())
 				return &result
 			}

--- a/pkg/githubtemplate/github_template_test.go
+++ b/pkg/githubtemplate/github_template_test.go
@@ -160,7 +160,6 @@ func TestFindLegacy(t *testing.T) {
 			name: "Template in root",
 			prepare: []string{
 				"README.md",
-				"ISSUE_TEMPLATE",
 				"issue_template.md",
 				"issue_template.txt",
 				"pull_request_template.md",
@@ -171,6 +170,32 @@ func TestFindLegacy(t *testing.T) {
 				name:    "ISSUE_TEMPLATE",
 			},
 			want: path.Join(tmpdir, "issue_template.md"),
+		},
+		{
+			name: "No extension",
+			prepare: []string{
+				"README.md",
+				"issue_template",
+				"docs/issue_template.md",
+			},
+			args: args{
+				rootDir: tmpdir,
+				name:    "ISSUE_TEMPLATE",
+			},
+			want: path.Join(tmpdir, "issue_template"),
+		},
+		{
+			name: "Dash instead of underscore",
+			prepare: []string{
+				"README.md",
+				"issue-template.txt",
+				"docs/issue_template.md",
+			},
+			args: args{
+				rootDir: tmpdir,
+				name:    "ISSUE_TEMPLATE",
+			},
+			want: path.Join(tmpdir, "issue-template.txt"),
 		},
 		{
 			name: "Template in .github takes precedence",
@@ -224,8 +249,11 @@ func TestFindLegacy(t *testing.T) {
 				file.Close()
 			}
 
-			if got := FindLegacy(tt.args.rootDir, tt.args.name); *got != tt.want {
-				t.Errorf("Find() = %v, want %v", got, tt.want)
+			got := FindLegacy(tt.args.rootDir, tt.args.name)
+			if got == nil {
+				t.Errorf("FindLegacy() = nil, want %v", tt.want)
+			} else if *got != tt.want {
+				t.Errorf("FindLegacy() = %v, want %v", *got, tt.want)
 			}
 		})
 		os.RemoveAll(tmpdir)


### PR DESCRIPTION
Now supports names such as `PULL-REQUEST-TEMPLATE` (dashes instead of underscores) and `issue_template.txt` (any file extension, including no extension). It turns out these were supported all along by GitHub as part of its "legacy" issue template naming scheme.

Fixes #1292