### PR TITLE
fix variable shadowing

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -41,7 +41,8 @@ func main() {
 	cmd, _, err := command.RootCmd.Traverse(expandedArgs)
 	if err != nil || cmd == command.RootCmd {
 		originalArgs := expandedArgs
-		expandedArgs, isShell, err := command.ExpandAlias(os.Args)
+		isShell := false
+		expandedArgs, isShell, err = command.ExpandAlias(os.Args)
 		if err != nil {
 			fmt.Fprintf(stderr, "failed to process aliases:  %s\n", err)
 			os.Exit(2)


### PR DESCRIPTION
I broke non-shell aliases with my recent merge; the `expandedArgs` variable was accidentally being
shadowed when I thought I was mutating it in the outer scope.

This PR fixes the problem, but I'd like to follow up with a refactor that makes more of this
testable.
