### PR TITLE
Document supported environment variables

### DIFF
--- a/command/help.go
+++ b/command/help.go
@@ -131,6 +131,9 @@ func rootHelpFunc(command *cobra.Command, args []string) {
 	if command.Example != "" {
 		helpEntries = append(helpEntries, helpEntry{"EXAMPLES", command.Example})
 	}
+	if _, ok := command.Annotations["help:environment"]; ok {
+		helpEntries = append(helpEntries, helpEntry{"ENVIRONMENT VARIABLES", command.Annotations["help:environment"]})
+	}
 	helpEntries = append(helpEntries, helpEntry{"LEARN MORE", `
 Use "gh <command> <subcommand> --help" for more information about a command.
 Read the manual at https://cli.github.com/manual`})

--- a/command/root.go
+++ b/command/root.go
@@ -111,9 +111,28 @@ var RootCmd = &cobra.Command{
 	$ gh pr checkout 321
 	`),
 	Annotations: map[string]string{
-		"help:feedback": `
-Fill out our feedback form https://forms.gle/umxd3h31c7aMQFKG7
-Open an issue using “gh issue create -R cli/cli”`},
+		"help:feedback": heredoc.Doc(`
+			Fill out our feedback form https://forms.gle/umxd3h31c7aMQFKG7
+			Open an issue using “gh issue create -R cli/cli”
+		`),
+		"help:environment": heredoc.Doc(`
+			GITHUB_TOKEN: an authentication token for API requests. Setting this avoids being
+			prompted to authenticate and overrides any previously stored credentials.
+
+			GH_REPO: specify the GitHub repository in "OWNER/REPO" format for commands that
+			otherwise operate on a local repository.
+
+			GH_EDITOR, GIT_EDITOR, VISUAL, EDITOR (in order of precedence): the editor tool to use
+			for authoring text.
+
+			BROWSER: the web browser to use for opening links.
+
+			DEBUG: set to any value to enable verbose output to standard error. Include values "api"
+			or "oauth" to print detailed information about HTTP requests or authentication flow.
+
+			NO_COLOR: avoid printing ANSI escape sequences for color output.
+		`),
+	},
 }
 
 var versionCmd = &cobra.Command{

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -109,6 +109,11 @@ original query accepts an '$endCursor: String' variable and that it fetches the
 				}
 			'
 		`),
+		Annotations: map[string]string{
+			"help:environment": heredoc.Doc(`
+				GITHUB_TOKEN: an authentication token for API requests.
+			`),
+		},
 		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.RequestPath = args[0]

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -86,27 +86,27 @@ original query accepts an '$endCursor: String' variable and that it fetches the
 			$ gh api repos/:owner/:repo/releases
 
 			$ gh api graphql -F owner=':owner' -F name=':repo' -f query='
-				query($name: String!, $owner: String!) {
-					repository(owner: $owner, name: $name) {
-						releases(last: 3) {
-							nodes { tagName }
-						}
-					}
-				}
+			  query($name: String!, $owner: String!) {
+			    repository(owner: $owner, name: $name) {
+			      releases(last: 3) {
+			        nodes { tagName }
+			      }
+			    }
+			  }
 			'
 			
 			$ gh api graphql --paginate -f query='
-				query($endCursor: String) {
-					viewer {
-						repositories(first: 100, after: $endCursor) {
-							nodes { nameWithOwner }
-							pageInfo {
-								hasNextPage
-								endCursor
-							}
-						}
-					}
-				}
+			  query($endCursor: String) {
+			    viewer {
+			      repositories(first: 100, after: $endCursor) {
+			        nodes { nameWithOwner }
+			        pageInfo {
+			          hasNextPage
+			          endCursor
+			        }
+			      }
+			    }
+			  }
 			'
 		`),
 		Annotations: map[string]string{


### PR DESCRIPTION
`gh help` now includes this section for the "root" command:

```
ENVIRONMENT VARIABLES
  GITHUB_TOKEN: an authentication token for API requests. Setting this avoids being
  prompted to authenticate and overrides any previously stored credentials.

  GH_REPO: specify the GitHub repository in "OWNER/REPO" format for commands that
  otherwise operate on a local repository.

  GH_EDITOR, GIT_EDITOR, VISUAL, EDITOR (in order of precedence): the editor tool to use
  for authoring text.

  BROWSER: the web browser to use for opening links.

  DEBUG: set to any value to enable verbose output to standard error. Include values "api"
  or "oauth" to print detailed information about HTTP requests or authentication flow.

  NO_COLOR: avoid printing ANSI escape sequences for color output.
```

Fixes #1086, ref. #1319

To address as follow-up: make sure that this get rendered on the web site as well. Right now it won't be present on web because it's embedded in command annotations.