### PR TITLE
Revert to ignoring non-github.com git remotes

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -240,10 +240,22 @@ func (c *fsContext) Remotes() (Remotes, error) {
 		}
 
 		sshTranslate := git.ParseSSHConfig().Translator()
-		c.remotes = translateRemotes(gitRemotes, sshTranslate)
+		resolvedRemotes := translateRemotes(gitRemotes, sshTranslate)
+
+		// ignore non-github.com remotes
+		// TODO: GHE compatibility
+		filteredRemotes := Remotes{}
+		for _, r := range resolvedRemotes {
+			if r.RepoHost() != defaultHostname {
+				continue
+			}
+			filteredRemotes = append(filteredRemotes, r)
+		}
+		c.remotes = filteredRemotes
 	}
 
 	if len(c.remotes) == 0 {
+		// TODO: GHE compatibility
 		return nil, errors.New("no git remote found for a github.com repository")
 	}
 	return c.remotes, nil


### PR DESCRIPTION
This fixes a regression where extra git remotes pointing to non-`github.com` hostnames could result in gh trying to parse repository information from them.

To reproduce:
```sh
$ git remote add upstream 'https://example.com/BOOM/ASPLODE'
$ gh issue list
not found  #=> it was trying to query for `BOOM/ASPLODE` repo on GitHub.com
```

This reverts to simply ignoring non-`github.com` remotes. We do have better support for other hostnames now, but until we decide on specific onboarding logic for dealing with mixed remotes #1180, it's best to ignore them for now to avoid causing disruption to our users.

Followup to #1258 