### PR TITLE
pr command scriptability improvements

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -517,7 +517,9 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 		} else if len(nonLegacyTemplateFiles) > 1 {
 			openURL += "/choose"
 		}
-		cmd.Printf("Opening %s in your browser.\n", displayURL(openURL))
+		if connectedToTerminal(cmd) {
+			cmd.Printf("Opening %s in your browser.\n", displayURL(openURL))
+		}
 		return utils.OpenInBrowser(openURL)
 	}
 

--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -753,6 +753,8 @@ func TestIssueCreate_web(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 
+	defer stubTerminal(true)()
+
 	var seenCmd *exec.Cmd
 	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
 		seenCmd = cmd
@@ -778,6 +780,8 @@ func TestIssueCreate_webTitleBody(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "master")
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
+
+	defer stubTerminal(true)()
 
 	var seenCmd *exec.Cmd
 	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {

--- a/command/pr.go
+++ b/command/pr.go
@@ -529,7 +529,7 @@ func prMerge(cmd *cobra.Command, args []string) error {
 	}
 
 	if connectedToTerminal(cmd) {
-		fmt.Fprintf(colorableOut(cmd), "%s %s pull request #%d (%s)\n", utils.Magenta("✔"), action, pr.Number, pr.Title)
+		fmt.Fprintf(colorableErr(cmd), "%s %s pull request #%d (%s)\n", utils.Magenta("✔"), action, pr.Number, pr.Title)
 	}
 
 	if deleteBranch {
@@ -578,7 +578,7 @@ func prMerge(cmd *cobra.Command, args []string) error {
 		}
 
 		if connectedToTerminal(cmd) {
-			fmt.Fprintf(colorableOut(cmd), "%s Deleted branch %s%s\n", utils.Red("✔"), utils.Cyan(pr.HeadRefName), branchSwitchString)
+			fmt.Fprintf(colorableErr(cmd), "%s Deleted branch %s%s\n", utils.Red("✔"), utils.Cyan(pr.HeadRefName), branchSwitchString)
 		}
 	}
 
@@ -639,6 +639,7 @@ func prInteractiveMerge(deleteLocalBranch bool, crossRepoPR bool) (api.PullReque
 	return mergeMethod, deleteBranch, nil
 }
 
+// TODO merge OPEN and DRAFT states; use this in nontty list/view
 func prReadyState(pr *api.PullRequest) string {
 	switch pr.State {
 	case "OPEN":

--- a/command/pr.go
+++ b/command/pr.go
@@ -362,10 +362,6 @@ func prView(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if web && !connectedToTerminal(cmd) {
-		return errors.New("--web unsupported when not attached to a tty")
-	}
-
 	pr, _, err := prFromArgs(ctx, apiClient, cmd, args)
 	if err != nil {
 		return err
@@ -373,7 +369,9 @@ func prView(cmd *cobra.Command, args []string) error {
 	openURL := pr.URL
 
 	if web {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Opening %s in your browser.\n", openURL)
+		if connectedToTerminal(cmd) {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Opening %s in your browser.\n", openURL)
+		}
 		return utils.OpenInBrowser(openURL)
 	}
 

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -226,10 +226,7 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !connectedToTerminal(cmd) {
-		if isWeb {
-			return errors.New("--web unsupported when not attached to a tty")
-		}
-		if !cmd.Flags().Changed("title") && !autofill {
+		if !isWeb && (!cmd.Flags().Changed("title") && !autofill) {
 			return errors.New("--title or --fill required when not attached to a tty")
 		}
 	}
@@ -368,8 +365,10 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
-		// TODO could exceed max url length for explorer
-		fmt.Fprintf(cmd.ErrOrStderr(), "Opening %s in your browser.\n", displayURL(openURL))
+		if connectedToTerminal(cmd) {
+			// TODO could exceed max url length for explorer
+			fmt.Fprintf(cmd.ErrOrStderr(), "Opening %s in your browser.\n", displayURL(openURL))
+		}
 		return utils.OpenInBrowser(openURL)
 	} else {
 		panic("Unreachable state")

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -482,12 +482,9 @@ func TestPRCreate_ReportsUncommittedChanges(t *testing.T) {
 	eq(t, err, nil)
 
 	eq(t, output.String(), "https://github.com/OWNER/REPO/pull/12\n")
-	eq(t, output.Stderr(), `Warning: 1 uncommitted change
-
-Creating pull request for feature into master in OWNER/REPO
-
-`)
+	test.ExpectLines(t, output.Stderr(), `Warning: 1 uncommitted change`, `Creating pull request for.*feature.*into.*master.*in OWNER/REPO`)
 }
+
 func TestPRCreate_cross_repo_same_branch(t *testing.T) {
 	defer stubTerminal(true)()
 	ctx := context.NewBlank()

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -109,7 +109,7 @@ func prReview(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("did not understand desired review action: %w", err)
 	}
 
-	stderr := cmd.ErrOrStderr()
+	stderr := colorableErr(cmd)
 
 	if reviewData == nil {
 		reviewData, err = reviewSurvey(cmd)

--- a/command/pr_review.go
+++ b/command/pr_review.go
@@ -72,7 +72,10 @@ func processReviewOpt(cmd *cobra.Command) (*api.PullRequestReviewInput, error) {
 	}
 
 	if found == 0 && body == "" {
-		return nil, nil // signal interactive mode
+		if connectedToTerminal(cmd) {
+			return nil, nil // signal interactive mode
+		}
+		return nil, errors.New("--approve, --request-changes, or --comment required when not attached to a tty")
 	} else if found == 0 && body != "" {
 		return nil, errors.New("--body unsupported without --approve, --request-changes, or --comment")
 	} else if found > 1 {
@@ -106,7 +109,7 @@ func prReview(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("did not understand desired review action: %w", err)
 	}
 
-	out := colorableOut(cmd)
+	stderr := cmd.ErrOrStderr()
 
 	if reviewData == nil {
 		reviewData, err = reviewSurvey(cmd)
@@ -114,7 +117,7 @@ func prReview(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if reviewData == nil && err == nil {
-			fmt.Fprint(out, "Discarding.\n")
+			fmt.Fprint(stderr, "Discarding.\n")
 			return nil
 		}
 	}
@@ -124,13 +127,17 @@ func prReview(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create review: %w", err)
 	}
 
+	if !connectedToTerminal(cmd) {
+		return nil
+	}
+
 	switch reviewData.State {
 	case api.ReviewComment:
-		fmt.Fprintf(out, "%s Reviewed pull request #%d\n", utils.Gray("-"), pr.Number)
+		fmt.Fprintf(stderr, "%s Reviewed pull request #%d\n", utils.Gray("-"), pr.Number)
 	case api.ReviewApprove:
-		fmt.Fprintf(out, "%s Approved pull request #%d\n", utils.Green("✓"), pr.Number)
+		fmt.Fprintf(stderr, "%s Approved pull request #%d\n", utils.Green("✓"), pr.Number)
 	case api.ReviewRequestChanges:
-		fmt.Fprintf(out, "%s Requested changes to pull request #%d\n", utils.Red("+"), pr.Number)
+		fmt.Fprintf(stderr, "%s Requested changes to pull request #%d\n", utils.Red("+"), pr.Number)
 	}
 
 	return nil

--- a/command/pr_review_test.go
+++ b/command/pr_review_test.go
@@ -163,7 +163,7 @@ func TestPRReview_no_arg(t *testing.T) {
 		t.Fatalf("error running pr review: %s", err)
 	}
 
-	test.ExpectLines(t, output.Stderr(), "- Reviewed pull request #123")
+	test.ExpectLines(t, output.Stderr(), "Reviewed pull request #123")
 
 	bodyBytes, _ := ioutil.ReadAll(http.Requests[2].Body)
 	reqBody := struct {

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -338,9 +338,9 @@ func TestPRList_nontty(t *testing.T) {
 
 	assert.Equal(t, "", output.Stderr())
 
-	assert.Equal(t, `32	OPEN	draft	New feature	feature
-29	OPEN	ready	Fixed bad bug	hubot:bug-fix
-28	MERGED	unreviewable	Improve documentation	docs
+	assert.Equal(t, `32	New feature	feature	DRAFT
+29	Fixed bad bug	hubot:bug-fix	OPEN
+28	Improve documentation	docs	MERGED
 `, output.String())
 }
 
@@ -500,7 +500,6 @@ func TestPRView_Preview_nontty(t *testing.T) {
 				`state:\tOPEN\n`,
 				`author:\tnobody\n`,
 				`labels:\t\n`,
-				`ready:\tready\n`,
 				`assignees:\t\n`,
 				`reviewers:\t\n`,
 				`projects:\t\n`,
@@ -517,7 +516,6 @@ func TestPRView_Preview_nontty(t *testing.T) {
 				`reviewers:\t2 \(Approved\), 3 \(Commented\), 1 \(Requested\)\n`,
 				`assignees:\tmarseilles, monaco\n`,
 				`labels:\tone, two, three, four, five\n`,
-				`ready:\tready\n`,
 				`projects:\tProject 1 \(column A\), Project 2 \(column B\), Project 3 \(column C\), Project 4 \(Awaiting triage\)\n`,
 				`milestone:\tuluru\n`,
 				`\*\*blueberries taste good\*\*`,
@@ -534,7 +532,6 @@ func TestPRView_Preview_nontty(t *testing.T) {
 				`labels:\t\n`,
 				`assignees:\t\n`,
 				`projects:\t\n`,
-				`ready:\tready\n`,
 				`milestone:\t\n`,
 				`reviewers:\tDEF \(Commented\), def \(Changes requested\), ghost \(Approved\), hubot \(Commented\), xyz \(Approved\), 123 \(Requested\), Team 1 \(Requested\), abc \(Requested\)\n`,
 				`\*\*blueberries taste good\*\*`,
@@ -549,7 +546,6 @@ func TestPRView_Preview_nontty(t *testing.T) {
 				`state:\tOPEN`,
 				`author:\tnobody`,
 				`assignees:\tmarseilles, monaco\n`,
-				`ready:\tready\n`,
 				`labels:\tone, two, three, four, five\n`,
 				`projects:\tProject 1 \(column A\), Project 2 \(column B\), Project 3 \(column C\)\n`,
 				`milestone:\tuluru\n`,
@@ -564,7 +560,6 @@ func TestPRView_Preview_nontty(t *testing.T) {
 				`title:\tBlueberries are a good fruit`,
 				`state:\tOPEN`,
 				`author:\tnobody`,
-				`ready:\tready\n`,
 				`assignees:\t\n`,
 				`labels:\t\n`,
 				`projects:\t\n`,
@@ -579,7 +574,6 @@ func TestPRView_Preview_nontty(t *testing.T) {
 			expectedOutputs: []string{
 				`title:\tBlueberries are a good fruit`,
 				`state:\tOPEN`,
-				`ready:\tready\n`,
 				`author:\tnobody`,
 				`assignees:\t\n`,
 				`labels:\t\n`,
@@ -595,7 +589,6 @@ func TestPRView_Preview_nontty(t *testing.T) {
 				`state:\tCLOSED\n`,
 				`author:\tnobody\n`,
 				`labels:\t\n`,
-				`ready:\tunreviewable\n`,
 				`assignees:\t\n`,
 				`reviewers:\t\n`,
 				`projects:\t\n`,
@@ -612,7 +605,6 @@ func TestPRView_Preview_nontty(t *testing.T) {
 				`author:\tnobody\n`,
 				`labels:\t\n`,
 				`assignees:\t\n`,
-				`ready:\tunreviewable\n`,
 				`reviewers:\t\n`,
 				`projects:\t\n`,
 				`milestone:\t\n`,
@@ -625,10 +617,9 @@ func TestPRView_Preview_nontty(t *testing.T) {
 			fixture:   "../test/fixtures/prViewPreviewDraftState.json",
 			expectedOutputs: []string{
 				`title:\tBlueberries are from a fork\n`,
-				`state:\tOPEN\n`,
+				`state:\tDRAFT\n`,
 				`author:\tnobody\n`,
 				`labels:`,
-				`ready:\tdraft\n`,
 				`assignees:`,
 				`projects:`,
 				`milestone:`,
@@ -641,10 +632,9 @@ func TestPRView_Preview_nontty(t *testing.T) {
 			fixture:   "../test/fixtures/prViewPreviewDraftStatebyBranch.json",
 			expectedOutputs: []string{
 				`title:\tBlueberries are a good fruit\n`,
-				`state:\tOPEN\n`,
+				`state:\tDRAFT\n`,
 				`author:\tnobody\n`,
 				`labels:`,
-				`ready:\tdraft\n`,
 				`assignees:`,
 				`projects:`,
 				`milestone:`,

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -1035,21 +1035,6 @@ func TestPRView_web_branchWithOwnerArg(t *testing.T) {
 	eq(t, url, "https://github.com/hubot/REPO/pull/23")
 }
 
-func TestPrView_web_nontty(t *testing.T) {
-	initBlankContext("", "OWNER/REPO", "master")
-	defer stubTerminal(false)()
-	http := initFakeHTTP()
-	http.StubRepoResponse("OWNER", "REPO")
-
-	output, err := RunCommand("pr view -w")
-	if err == nil {
-		t.Fatal("expected error")
-	}
-
-	assert.Equal(t, "--web unsupported when not attached to a tty", err.Error())
-	assert.Equal(t, "", output.String())
-}
-
 func TestReplaceExcessiveWhitespace(t *testing.T) {
 	eq(t, replaceExcessiveWhitespace("hello\ngoodbye"), "hello goodbye")
 	eq(t, replaceExcessiveWhitespace("  hello goodbye  "), "hello goodbye")

--- a/command/pr_test.go
+++ b/command/pr_test.go
@@ -310,10 +310,18 @@ Showing 3 of 3 pull requests in OWNER/REPO
 
 `, output.Stderr())
 
-	assert.Equal(t, `#32  New feature            feature
-#29  Fixed bad bug          hubot:bug-fix
-#28  Improve documentation  docs
-`, output.String())
+	lines := strings.Split(output.String(), "\n")
+	res := []*regexp.Regexp{
+		regexp.MustCompile(`#32.*New feature.*feature`),
+		regexp.MustCompile(`#29.*Fixed bad bug.*hubot:bug-fix`),
+		regexp.MustCompile(`#28.*Improve documentation.*docs`),
+	}
+
+	for i, r := range res {
+		if !r.MatchString(lines[i]) {
+			t.Errorf("%s did not match %s", lines[i], r)
+		}
+	}
 }
 
 func TestPRList_nontty(t *testing.T) {
@@ -374,10 +382,19 @@ func TestPRList_filteringRemoveDuplicate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, `#32  New feature            feature
-#29  Fixed bad bug          hubot:bug-fix
-#28  Improve documentation  docs
-`, output.String())
+	lines := strings.Split(output.String(), "\n")
+
+	res := []*regexp.Regexp{
+		regexp.MustCompile(`#32.*New feature.*feature`),
+		regexp.MustCompile(`#29.*Fixed bad bug.*hubot:bug-fix`),
+		regexp.MustCompile(`#28.*Improve documentation.*docs`),
+	}
+
+	for i, r := range res {
+		if !r.MatchString(lines[i]) {
+			t.Errorf("%s did not match %s", lines[i], r)
+		}
+	}
 }
 
 func TestPRList_filteringClosed(t *testing.T) {
@@ -669,7 +686,7 @@ func TestPRView_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/prViewPreview.json",
 			expectedOutputs: []string{
 				`Blueberries are from a fork`,
-				`Open • nobody wants to merge 12 commits into master from blueberries`,
+				`Open.*nobody wants to merge 12 commits into master from blueberries`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`,
 			},
@@ -680,12 +697,12 @@ func TestPRView_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/prViewPreviewWithMetadataByNumber.json",
 			expectedOutputs: []string{
 				`Blueberries are from a fork`,
-				`Open • nobody wants to merge 12 commits into master from blueberries`,
-				`Reviewers: 2 \(Approved\), 3 \(Commented\), 1 \(Requested\)\n`,
-				`Assignees: marseilles, monaco\n`,
-				`Labels: one, two, three, four, five\n`,
-				`Projects: Project 1 \(column A\), Project 2 \(column B\), Project 3 \(column C\), Project 4 \(Awaiting triage\)\n`,
-				`Milestone: uluru\n`,
+				`Open.*nobody wants to merge 12 commits into master from blueberries`,
+				`Reviewers:.*2 \(.*Approved.*\), 3 \(Commented\), 1 \(.*Requested.*\)\n`,
+				`Assignees:.*marseilles, monaco\n`,
+				`Labels:.*one, two, three, four, five\n`,
+				`Projects:.*Project 1 \(column A\), Project 2 \(column B\), Project 3 \(column C\), Project 4 \(Awaiting triage\)\n`,
+				`Milestone:.*uluru\n`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12\n`,
 			},
@@ -696,7 +713,7 @@ func TestPRView_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/prViewPreviewWithReviewersByNumber.json",
 			expectedOutputs: []string{
 				`Blueberries are from a fork`,
-				`Reviewers: DEF \(Commented\), def \(Changes requested\), ghost \(Approved\), hubot \(Commented\), xyz \(Approved\), 123 \(Requested\), Team 1 \(Requested\), abc \(Requested\)\n`,
+				`Reviewers:.*DEF \(.*Commented.*\), def \(.*Changes requested.*\), ghost \(.*Approved.*\), hubot \(Commented\), xyz \(.*Approved.*\), 123 \(.*Requested.*\), Team 1 \(.*Requested.*\), abc \(.*Requested.*\)\n`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12\n`,
 			},
@@ -707,11 +724,11 @@ func TestPRView_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/prViewPreviewWithMetadataByBranch.json",
 			expectedOutputs: []string{
 				`Blueberries are a good fruit`,
-				`Open • nobody wants to merge 8 commits into master from blueberries`,
-				`Assignees: marseilles, monaco\n`,
-				`Labels: one, two, three, four, five\n`,
-				`Projects: Project 1 \(column A\), Project 2 \(column B\), Project 3 \(column C\)\n`,
-				`Milestone: uluru\n`,
+				`Open.*nobody wants to merge 8 commits into master from blueberries`,
+				`Assignees:.*marseilles, monaco\n`,
+				`Labels:.*one, two, three, four, five\n`,
+				`Projects:.*Project 1 \(column A\), Project 2 \(column B\), Project 3 \(column C\)\n`,
+				`Milestone:.*uluru\n`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10\n`,
 			},
@@ -722,7 +739,7 @@ func TestPRView_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/prView.json",
 			expectedOutputs: []string{
 				`Blueberries are a good fruit`,
-				`Open • nobody wants to merge 8 commits into master from blueberries`,
+				`Open.*nobody wants to merge 8 commits into master from blueberries`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`,
 			},
@@ -733,7 +750,7 @@ func TestPRView_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/prView_EmptyBody.json",
 			expectedOutputs: []string{
 				`Blueberries are a good fruit`,
-				`Open • nobody wants to merge 8 commits into master from blueberries`,
+				`Open.*nobody wants to merge 8 commits into master from blueberries`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`,
 			},
 		},
@@ -743,7 +760,7 @@ func TestPRView_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/prViewPreviewClosedState.json",
 			expectedOutputs: []string{
 				`Blueberries are from a fork`,
-				`Closed • nobody wants to merge 12 commits into master from blueberries`,
+				`Closed.*nobody wants to merge 12 commits into master from blueberries`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`,
 			},
@@ -754,7 +771,7 @@ func TestPRView_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/prViewPreviewMergedState.json",
 			expectedOutputs: []string{
 				`Blueberries are from a fork`,
-				`Merged • nobody wants to merge 12 commits into master from blueberries`,
+				`Merged.*nobody wants to merge 12 commits into master from blueberries`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`,
 			},
@@ -765,7 +782,7 @@ func TestPRView_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/prViewPreviewDraftState.json",
 			expectedOutputs: []string{
 				`Blueberries are from a fork`,
-				`Draft • nobody wants to merge 12 commits into master from blueberries`,
+				`Draft.*nobody wants to merge 12 commits into master from blueberries`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`,
 			},
@@ -776,7 +793,7 @@ func TestPRView_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/prViewPreviewDraftStatebyBranch.json",
 			expectedOutputs: []string{
 				`Blueberries are a good fruit`,
-				`Draft • nobody wants to merge 8 commits into master from blueberries`,
+				`Draft.*nobody wants to merge 8 commits into master from blueberries`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/10`,
 			},
@@ -1232,8 +1249,8 @@ func TestPrMerge(t *testing.T) {
 
 	r := regexp.MustCompile(`Merged pull request #1 \(The title of the PR\)`)
 
-	if !r.MatchString(output.String()) {
-		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.String())
+	if !r.MatchString(output.Stderr()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
 
@@ -1339,8 +1356,8 @@ func TestPrMerge_withRepoFlag(t *testing.T) {
 
 	r := regexp.MustCompile(`Merged pull request #1 \(The title of the PR\)`)
 
-	if !r.MatchString(output.String()) {
-		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.String())
+	if !r.MatchString(output.Stderr()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
 
@@ -1377,7 +1394,7 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 		t.Fatalf("Got unexpected error running `pr merge` %s", err)
 	}
 
-	test.ExpectLines(t, output.String(), `Merged pull request #10 \(Blueberries are a good fruit\)`, "Deleted branch blueberries")
+	test.ExpectLines(t, output.Stderr(), `Merged pull request #10 \(Blueberries are a good fruit\)`, `Deleted branch.*blueberries`)
 }
 
 func TestPrMerge_deleteNonCurrentBranch(t *testing.T) {
@@ -1411,7 +1428,7 @@ func TestPrMerge_deleteNonCurrentBranch(t *testing.T) {
 		t.Fatalf("Got unexpected error running `pr merge` %s", err)
 	}
 
-	test.ExpectLines(t, output.String(), `Merged pull request #10 \(Blueberries are a good fruit\)`, "Deleted branch blueberries")
+	test.ExpectLines(t, output.Stderr(), `Merged pull request #10 \(Blueberries are a good fruit\)`, `Deleted branch.*blueberries`)
 }
 
 func TestPrMerge_noPrNumberGiven(t *testing.T) {
@@ -1449,8 +1466,8 @@ func TestPrMerge_noPrNumberGiven(t *testing.T) {
 
 	r := regexp.MustCompile(`Merged pull request #10 \(Blueberries are a good fruit\)`)
 
-	if !r.MatchString(output.String()) {
-		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.String())
+	if !r.MatchString(output.Stderr()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
 
@@ -1496,8 +1513,8 @@ func TestPrMerge_rebase(t *testing.T) {
 
 	r := regexp.MustCompile(`Rebased and merged pull request #2 \(The title of the PR\)`)
 
-	if !r.MatchString(output.String()) {
-		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.String())
+	if !r.MatchString(output.Stderr()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
 	}
 }
 
@@ -1541,8 +1558,7 @@ func TestPrMerge_squash(t *testing.T) {
 		t.Fatalf("error running command `pr merge`: %v", err)
 	}
 
-	expected := "✔ Squashed and merged pull request #3 (The title of the PR)\n✔ Deleted branch blueberries\n"
-	assert.Equal(t, expected, output.String())
+	test.ExpectLines(t, output.Stderr(), "Squashed and merged pull request #3", `Deleted branch.*blueberries`)
 }
 
 func TestPrMerge_alreadyMerged(t *testing.T) {
@@ -1631,7 +1647,7 @@ func TestPRMerge_interactive(t *testing.T) {
 		t.Fatalf("Got unexpected error running `pr merge` %s", err)
 	}
 
-	test.ExpectLines(t, output.String(), "Merged pull request #3", "Deleted branch blueberries")
+	test.ExpectLines(t, output.Stderr(), "Merged pull request #3", `Deleted branch.*blueberries`)
 }
 
 func TestPrMerge_multipleMergeMethods(t *testing.T) {

--- a/test/fixtures/prList.json
+++ b/test/fixtures/prList.json
@@ -9,7 +9,9 @@
               "number": 32,
               "title": "New feature",
               "url": "https://github.com/monalisa/hello/pull/32",
-              "headRefName": "feature"
+              "headRefName": "feature",
+              "state": "OPEN",
+              "isDraft": true
             }
           },
           {
@@ -18,6 +20,8 @@
               "title": "Fixed bad bug",
               "url": "https://github.com/monalisa/hello/pull/29",
               "headRefName": "bug-fix",
+              "state": "OPEN",
+              "isDraft": false,
               "isCrossRepository": true,
               "headRepositoryOwner": {
                 "login": "hubot"
@@ -27,6 +31,8 @@
           {
             "node": {
               "number": 28,
+              "state": "MERGED",
+              "isDraft": false,
               "title": "Improve documentation",
               "url": "https://github.com/monalisa/hello/pull/28",
               "headRefName": "docs"


### PR DESCRIPTION
This PR came out of the research in #940 and consists of several small changes to pr commands that
make them more amenable to scripting.

In this PR, when run unattached to a TTY:

- pr create clearly errors if -t or -f are missing
- pr create clearly errors if -w is specified
- pr list prints more machine readable output, including draft status
- pr view prints raw pr body + linewise metadata, including draft status
- various human-oriented informational messages are suppressed

Closes #1297
Part of #1082
Part of #939

