### PR TITLE
Enable adding to GO_LDFLAGS without having to replace them all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ ifndef CGO_LDFLAGS
     export CGO_LDFLAGS := $(LDFLAGS)
 endif
 
-GO_LDFLAGS := -X github.com/cli/cli/command.Version=$(GH_VERSION)
-GO_LDFLAGS += -X github.com/cli/cli/command.BuildDate=$(BUILD_DATE)
+GO_LDFLAGS := -X github.com/cli/cli/command.Version=$(GH_VERSION) $(GO_LDFLAGS)
+GO_LDFLAGS := -X github.com/cli/cli/command.BuildDate=$(BUILD_DATE) $(GO_LDFLAGS)
 ifdef GH_OAUTH_CLIENT_SECRET
-	GO_LDFLAGS += -X github.com/cli/cli/internal/config.oauthClientID=$(GH_OAUTH_CLIENT_ID)
-	GO_LDFLAGS += -X github.com/cli/cli/internal/config.oauthClientSecret=$(GH_OAUTH_CLIENT_SECRET)
+	GO_LDFLAGS := -X github.com/cli/cli/internal/config.oauthClientID=$(GH_OAUTH_CLIENT_ID) $(GO_LDFLAGS)
+	GO_LDFLAGS := -X github.com/cli/cli/internal/config.oauthClientSecret=$(GH_OAUTH_CLIENT_SECRET) $(GO_LDFLAGS)
 endif
 
 bin/gh: $(BUILD_FILES)


### PR DESCRIPTION
To produce a slimmer binary outside of the context of a git repo, this is now supported:

    GO_LDFLAGS="-s -w" GH_VERSION="vX.Y.Z" make

Followup to #1307 #1334 /cc @eli-schwartz 
Ref. https://github.com/Homebrew/homebrew-core/pull/58094