### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+**
+
+!.git
+!/api
+!/auth
+!/cmd
+!/command
+!/context
+!/git
+!/internal
+!/pkg
+!/test
+!/update
+!/utils
+!/Makefile
+!/go.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:alpine AS builder
+
+# Get build dependencies
+RUN apk --no-cache add git make gcc musl-dev
+
+# Build the cli
+WORKDIR /go/gh-cli
+COPY .git .git
+COPY api api
+COPY auth auth
+COPY cmd cmd
+COPY command command
+COPY context context
+COPY git git
+COPY internal internal
+COPY pkg pkg
+COPY test test
+COPY update update
+COPY utils utils
+COPY Makefile .
+COPY go.* .
+RUN ["make"]
+
+FROM alpine:3.12 AS runner
+COPY --from=builder /go/gh-cli/bin/gh /usr/local/bin
+ENTRYPOINT [ "gh" ]
+CMD [ "help" ]


### PR DESCRIPTION
Added a Dockerfile so `gh` could be used as a container!

To build, run:

`docker build -t gh .`

To use it:

`docker run -it --rm gh help`

I recommend adding `docker build` and `docker push` to the build pipeline.