### PR TITLE
Fix printing network error in case for failed HTTP requests

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -104,9 +104,13 @@ func CheckScopes(wantedScope string, cb func(string) error) ClientOption {
 	return func(tr http.RoundTripper) http.RoundTripper {
 		return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
 			res, err := tr.RoundTrip(req)
-			_, hasHeader := res.Header[httpOAuthAppID]
-			if err != nil || res.StatusCode > 299 || !hasHeader || issuedScopesWarning {
+			if err != nil || res.StatusCode > 299 || issuedScopesWarning {
 				return res, err
+			}
+
+			_, hasHeader := res.Header[httpOAuthAppID]
+			if !hasHeader {
+				return res, nil
 			}
 
 			appID := res.Header.Get(httpOAuthAppID)


### PR DESCRIPTION
The CheckScopes middleware tried to read from `res.Headers` before it verified that `res` is available, which would result in a crash. It only affected users who were experiencing network errors.

Addresses https://github.com/cli/cli/issues/1380
Followup to #1359 