### PR TITLE
Fix creating gists from stdin with argument

### DIFF
--- a/command/gist.go
+++ b/command/gist.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
+	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -52,6 +53,22 @@ By default, gists are private; use '--public' to make publicly listed ones.`,
 	# create a gist from output piped from another command
 	$ cat cool.txt | gh gist create
 	`),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return nil
+		}
+
+		info, err := os.Stdin.Stat()
+		if err != nil {
+			return fmt.Errorf("failed to check STDIN: %w", err)
+		}
+
+		stdinIsTTY := (info.Mode() & os.ModeCharDevice) == os.ModeCharDevice
+		if stdinIsTTY {
+			return cmdutil.FlagError{Err: errors.New("no filenames passed and nothing on STDIN")}
+		}
+		return nil
+	},
 	RunE: gistCreate,
 }
 
@@ -83,15 +100,12 @@ func gistCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("did not understand arguments: %w", err)
 	}
 
-	info, err := os.Stdin.Stat()
-	if err != nil {
-		return fmt.Errorf("failed to check STDIN: %w", err)
-	}
-	if (info.Mode() & os.ModeCharDevice) != os.ModeCharDevice {
-		args = append(args, "-")
+	fileArgs := args
+	if len(args) == 0 {
+		fileArgs = []string{"-"}
 	}
 
-	files, err := processFiles(os.Stdin, args)
+	files, err := processFiles(os.Stdin, fileArgs)
 	if err != nil {
 		return fmt.Errorf("failed to collect files for posting: %w", err)
 	}
@@ -128,11 +142,11 @@ func processOpts(cmd *cobra.Command) (*Opts, error) {
 	}, err
 }
 
-func processFiles(stdin io.Reader, filenames []string) (map[string]string, error) {
+func processFiles(stdin io.ReadCloser, filenames []string) (map[string]string, error) {
 	fs := map[string]string{}
 
 	if len(filenames) == 0 {
-		return fs, errors.New("no filenames passed and nothing on STDIN")
+		return nil, errors.New("no files passed")
 	}
 
 	for i, f := range filenames {
@@ -145,6 +159,7 @@ func processFiles(stdin io.Reader, filenames []string) (map[string]string, error
 			if err != nil {
 				return fs, fmt.Errorf("failed to read from stdin: %w", err)
 			}
+			stdin.Close()
 		} else {
 			content, err = ioutil.ReadFile(f)
 			if err != nil {

--- a/command/gist.go
+++ b/command/gist.go
@@ -19,7 +19,7 @@ func init() {
 	RootCmd.AddCommand(gistCmd)
 	gistCmd.AddCommand(gistCreateCmd)
 	gistCreateCmd.Flags().StringP("desc", "d", "", "A description for this gist")
-	gistCreateCmd.Flags().BoolP("public", "p", false, "When true, the gist will be public and available for anyone to see (default: private)")
+	gistCreateCmd.Flags().BoolP("public", "p", false, "List the gist publicly (default: private)")
 }
 
 var gistCmd = &cobra.Command{

--- a/command/gist.go
+++ b/command/gist.go
@@ -65,7 +65,7 @@ By default, gists are private; use '--public' to make publicly listed ones.`,
 
 		stdinIsTTY := (info.Mode() & os.ModeCharDevice) == os.ModeCharDevice
 		if stdinIsTTY {
-			return cmdutil.FlagError{Err: errors.New("no filenames passed and nothing on STDIN")}
+			return &cmdutil.FlagError{Err: errors.New("no filenames passed and nothing on STDIN")}
 		}
 		return nil
 	},

--- a/command/gist_test.go
+++ b/command/gist_test.go
@@ -1,12 +1,12 @@
 package command
 
 import (
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,33 +14,34 @@ func TestGistCreate(t *testing.T) {
 	initBlankContext("", "OWNER/REPO", "trunk")
 
 	http := initFakeHTTP()
-	http.StubResponse(200, bytes.NewBufferString(`
+	http.Register(httpmock.REST("POST", "gists"), httpmock.StringResponse(`
 	{
 		"html_url": "https://gist.github.com/aa5a315d61ae9438b18d"
 	}
 	`))
 
 	output, err := RunCommand(`gist create "../test/fixtures/gistCreate.json" -d "Gist description" --public`)
-	eq(t, err, nil)
+	assert.NoError(t, err)
 
 	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
-	reqBody := struct {
-		Description string
-		Public      bool
-		Files       map[string]struct {
-			Content string
-		}
-	}{}
-
+	reqBody := make(map[string]interface{})
 	err = json.Unmarshal(bodyBytes, &reqBody)
 	if err != nil {
-		t.Fatalf("unexpected json error: %s", err)
+		t.Fatalf("error decoding JSON: %v", err)
 	}
 
-	eq(t, reqBody.Description, "Gist description")
-	eq(t, reqBody.Public, true)
-	eq(t, reqBody.Files["gistCreate.json"].Content, "{}")
-	eq(t, output.String(), "https://gist.github.com/aa5a315d61ae9438b18d\n")
+	expectParams := map[string]interface{}{
+		"description": "Gist description",
+		"files": map[string]interface{}{
+			"gistCreate.json": map[string]interface{}{
+				"content": "{}",
+			},
+		},
+		"public": true,
+	}
+
+	assert.Equal(t, expectParams, reqBody)
+	assert.Equal(t, "https://gist.github.com/aa5a315d61ae9438b18d\n", output.String())
 }
 
 func TestGistCreate_stdin(t *testing.T) {

--- a/command/gist_test.go
+++ b/command/gist_test.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGistCreate(t *testing.T) {
@@ -43,10 +45,11 @@ func TestGistCreate(t *testing.T) {
 
 func TestGistCreate_stdin(t *testing.T) {
 	fakeStdin := strings.NewReader("hey cool how is it going")
-	files, err := processFiles(fakeStdin, []string{"-"})
+	files, err := processFiles(ioutil.NopCloser(fakeStdin), []string{"-"})
 	if err != nil {
 		t.Fatalf("unexpected error processing files: %s", err)
 	}
 
-	eq(t, files["gistfile0.txt"], "hey cool how is it going")
+	assert.Equal(t, 1, len(files))
+	assert.Equal(t, "hey cool how is it going", files["gistfile0.txt"])
 }


### PR DESCRIPTION
Fixes #1377

Bonus: prints usage information when passing no arguments and nothing on stdin
```
$ gh gist create
no filenames passed and nothing on STDIN

Usage:  gh gist create [<filename>... | -] [flags]

Flags:
  -d, --desc string   A description for this gist
  -p, --public        List the gist publicly (default: private)
```

Also:
- avoids unnecessarily `Stat`-ing stdin if any filename arguments are passed
- raises clearer error in case `-` is passed multiple times as a filename
- uses new syntax for HTTP stubs in test