### PR TITLE
remove package level terminal check state

### DIFF
--- a/command/issue_test.go
+++ b/command/issue_test.go
@@ -438,7 +438,7 @@ func TestIssueView_tty_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/issueView_preview.json",
 			expectedOutputs: []string{
 				`ix of coins`,
-				`Open • marseilles opened about 292 years ago • 9 comments`,
+				`Open.*marseilles opened about 292 years ago.*9 comments`,
 				`bold story`,
 				`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`,
 			},
@@ -449,11 +449,11 @@ func TestIssueView_tty_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/issueView_previewWithMetadata.json",
 			expectedOutputs: []string{
 				`ix of coins`,
-				`Open • marseilles opened about 292 years ago • 9 comments`,
-				`Assignees: marseilles, monaco\n`,
-				`Labels: one, two, three, four, five\n`,
-				`Projects: Project 1 \(column A\), Project 2 \(column B\), Project 3 \(column C\), Project 4 \(Awaiting triage\)\n`,
-				`Milestone: uluru\n`,
+				`Open.*marseilles opened about 292 years ago.*9 comments`,
+				`Assignees:.*marseilles, monaco\n`,
+				`Labels:.*one, two, three, four, five\n`,
+				`Projects:.*Project 1 \(column A\), Project 2 \(column B\), Project 3 \(column C\), Project 4 \(Awaiting triage\)\n`,
+				`Milestone:.*uluru\n`,
 				`bold story`,
 				`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`,
 			},
@@ -464,7 +464,7 @@ func TestIssueView_tty_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/issueView_previewWithEmptyBody.json",
 			expectedOutputs: []string{
 				`ix of coins`,
-				`Open • marseilles opened about 292 years ago • 9 comments`,
+				`Open.*marseilles opened about 292 years ago.*9 comments`,
 				`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`,
 			},
 		},
@@ -474,7 +474,7 @@ func TestIssueView_tty_Preview(t *testing.T) {
 			fixture:   "../test/fixtures/issueView_previewClosedState.json",
 			expectedOutputs: []string{
 				`ix of coins`,
-				`Closed • marseilles opened about 292 years ago • 9 comments`,
+				`Closed.*marseilles opened about 292 years ago.*9 comments`,
 				`bold story`,
 				`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`,
 			},

--- a/utils/color.go
+++ b/utils/color.go
@@ -9,8 +9,6 @@ import (
 )
 
 var (
-	_isStdoutTerminal, checkedTerminal bool
-
 	// Outputs ANSI color if stdout is a tty
 	Magenta = makeColorFunc("magenta")
 	Cyan    = makeColorFunc("cyan")
@@ -45,5 +43,6 @@ func isColorEnabled() bool {
 		return false
 	}
 
-	return isStdoutTerminal()
+	// TODO ignores cmd.OutOrStdout
+	return IsTerminal(os.Stdout)
 }

--- a/utils/terminal.go
+++ b/utils/terminal.go
@@ -8,14 +8,6 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-func isStdoutTerminal() bool {
-	if !checkedTerminal {
-		_isStdoutTerminal = IsTerminal(os.Stdout)
-		checkedTerminal = true
-	}
-	return _isStdoutTerminal
-}
-
 // TODO I don't like this use of interface{} but we need to accept both io.Writer and io.Reader
 // interfaces.
 


### PR DESCRIPTION
In doing some minor changes for the scriptability work I noticed that the cached `IsTerminal` check
persists between tests, making testing non-tty and tty behaviors difficult.

I did some benchmarking with `gh issue list -L200`, a command that produces a large amount of color
output, and discovered that this caching has no detectable effect on performance: in fact, even with
dozens of runs I could not detect anything statistically significant between cached and uncached.

We do intend to migrate to the new command format specified in `gh api`'s implementation which will
fix these issues, but I wanted to knock out the scriptability improvements before starting on that
migration so this PR allows that.
