### PR TITLE
Correctly handle and set empty and/or default issue & pr body

### DIFF
--- a/command/issue.go
+++ b/command/issue.go
@@ -489,10 +489,9 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 
 		title = tb.Title
 		body = tb.Body
-	} else {
-		if title == "" {
-			return fmt.Errorf("title can't be blank")
-		}
+	}
+	if title == "" {
+		return fmt.Errorf("title can't be blank")
 	}
 
 	if action == PreviewAction {

--- a/command/issue.go
+++ b/command/issue.go
@@ -487,12 +487,8 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		if title == "" {
-			title = tb.Title
-		}
-		if body == "" {
-			body = tb.Body
-		}
+		title = tb.Title
+		body = tb.Body
 	} else {
 		if title == "" {
 			return fmt.Errorf("title can't be blank")

--- a/command/issue.go
+++ b/command/issue.go
@@ -462,7 +462,9 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 		Milestones: milestoneTitles,
 	}
 
-	interactive := !(cmd.Flags().Changed("title") && cmd.Flags().Changed("body"))
+	titleWasExplicitlySet := cmd.Flags().Changed("title")
+	bodyWasExplicitlySet := cmd.Flags().Changed("body")
+	interactive := !(titleWasExplicitlySet && bodyWasExplicitlySet)
 
 	if interactive {
 		var legacyTemplateFile *string
@@ -472,7 +474,7 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 				legacyTemplateFile = githubtemplate.FindLegacy(rootDir, "ISSUE_TEMPLATE")
 			}
 		}
-		err := titleBodySurvey(cmd, &tb, apiClient, baseRepo, title, body, defaults{}, nonLegacyTemplateFiles, legacyTemplateFile, false, repo.ViewerCanTriage())
+		err := titleBodySurvey(cmd, &tb, apiClient, baseRepo, !titleWasExplicitlySet, !bodyWasExplicitlySet, defaults{}, nonLegacyTemplateFiles, legacyTemplateFile, false, repo.ViewerCanTriage())
 		if err != nil {
 			return fmt.Errorf("could not collect title and/or body: %w", err)
 		}

--- a/command/issue.go
+++ b/command/issue.go
@@ -487,10 +487,10 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		if title == "" {
+		if !titleWasExplicitlySet {
 			title = tb.Title
 		}
-		if body == "" {
+		if !bodyWasExplicitlySet {
 			body = tb.Body
 		}
 	}

--- a/command/issue.go
+++ b/command/issue.go
@@ -487,8 +487,12 @@ func issueCreate(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		title = tb.Title
-		body = tb.Body
+		if title == "" {
+			title = tb.Title
+		}
+		if body == "" {
+			body = tb.Body
+		}
 	}
 	if title == "" {
 		return fmt.Errorf("title can't be blank")

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -247,12 +247,8 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 			return nil
 		}
 
-		if title == "" {
-			title = tb.Title
-		}
-		if body == "" {
-			body = tb.Body
-		}
+		title = tb.Title
+		body = tb.Body
 	}
 
 	if action == SubmitAction && title == "" {

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -223,7 +223,9 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 		Milestones: milestoneTitles,
 	}
 
-	interactive := !(cmd.Flags().Changed("title") && cmd.Flags().Changed("body"))
+	titleWasExplicitlySet := cmd.Flags().Changed("title")
+	bodyWasExplicitlySet := cmd.Flags().Changed("body")
+	interactive := !(titleWasExplicitlySet && bodyWasExplicitlySet)
 
 	if !isWeb && !autofill && interactive {
 		var nonLegacyTemplateFiles []string
@@ -233,7 +235,7 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 			nonLegacyTemplateFiles = githubtemplate.FindNonLegacy(rootDir, "PULL_REQUEST_TEMPLATE")
 			legacyTemplateFile = githubtemplate.FindLegacy(rootDir, "PULL_REQUEST_TEMPLATE")
 		}
-		err := titleBodySurvey(cmd, &tb, client, baseRepo, title, body, defs, nonLegacyTemplateFiles, legacyTemplateFile, true, baseRepo.ViewerCanTriage())
+		err := titleBodySurvey(cmd, &tb, client, baseRepo, !titleWasExplicitlySet, !bodyWasExplicitlySet, defs, nonLegacyTemplateFiles, legacyTemplateFile, true, baseRepo.ViewerCanTriage())
 		if err != nil {
 			return fmt.Errorf("could not collect title and/or body: %w", err)
 		}

--- a/command/pr_create.go
+++ b/command/pr_create.go
@@ -247,8 +247,12 @@ func prCreate(cmd *cobra.Command, _ []string) error {
 			return nil
 		}
 
-		title = tb.Title
-		body = tb.Body
+		if title == "" {
+			title = tb.Title
+		}
+		if body == "" {
+			body = tb.Body
+		}
 	}
 
 	if action == SubmitAction && title == "" {

--- a/command/pr_create_test.go
+++ b/command/pr_create_test.go
@@ -519,11 +519,9 @@ func TestPRCreate_survey_defaults_multicommit(t *testing.T) {
 	}{}
 	_ = json.Unmarshal(bodyBytes, &reqBody)
 
-	expectedBody := "- commit 1\n- commit 0\n"
-
 	eq(t, reqBody.Variables.Input.RepositoryID, "REPOID")
 	eq(t, reqBody.Variables.Input.Title, "cool bug fixes")
-	eq(t, reqBody.Variables.Input.Body, expectedBody)
+	eq(t, reqBody.Variables.Input.Body, "")
 	eq(t, reqBody.Variables.Input.BaseRefName, "master")
 	eq(t, reqBody.Variables.Input.HeadRefName, "cool_bug-fixes")
 
@@ -550,7 +548,7 @@ func TestPRCreate_survey_defaults_monocommit(t *testing.T) {
 	`, func(inputs map[string]interface{}) {
 		eq(t, inputs["repositoryId"], "REPOID")
 		eq(t, inputs["title"], "the sky above the port")
-		eq(t, inputs["body"], "was the color of a television, turned to a dead channel")
+		eq(t, inputs["body"], "")
 		eq(t, inputs["baseRefName"], "master")
 		eq(t, inputs["headRefName"], "feature")
 	}))

--- a/pkg/surveyext/editor.go
+++ b/pkg/surveyext/editor.go
@@ -59,7 +59,9 @@ var EditorQuestionTemplate = `
 {{- else }}
   {{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ .Config.HelpInput }} for help]{{color "reset"}} {{end}}
   {{- if and .Default (not .HideDefault)}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
-	{{- color "cyan"}}[(e) to launch {{ .EditorCommand }}{{- if .BlankAllowed }}, enter to skip{{ end }}] {{color "reset"}}
+	{{- color "cyan"}}[(e) to launch {{ .EditorCommand }}
+	{{- if .BlankAllowed }}, (enter/return) to keep empty{{ end }}
+	{{- if .Default }}, (d) to accept default{{ end }}] {{color "reset"}}
 {{- end}}`
 
 // EXTENDED to pass editor name (to use in prompt)
@@ -99,7 +101,7 @@ func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (int
 	defer cursor.Show()
 
 	for {
-		// EXTENDED to handle the e to edit / enter to skip behavior + BlankAllowed
+		// EXTENDED to handle the e to edit / enter to keep blank / d to accept default behavior + BlankAllowed
 		r, _, err := rr.ReadRune()
 		if err != nil {
 			return "", err
@@ -113,6 +115,9 @@ func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (int
 			} else {
 				continue
 			}
+		}
+		if r == 'd' {
+			return e.Default, nil
 		}
 		if r == terminal.KeyInterrupt {
 			return "", terminal.InterruptErr

--- a/pkg/surveyext/editor.go
+++ b/pkg/surveyext/editor.go
@@ -117,7 +117,11 @@ func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (int
 			}
 		}
 		if r == 'd' {
-			return e.Default, nil
+			if len(e.Default) > 0 {
+				return e.Default, nil
+			} else {
+				continue
+			}
 		}
 		if r == terminal.KeyInterrupt {
 			return "", terminal.InterruptErr


### PR DESCRIPTION
Fixes #674  
Fixes #1294 
Addresses https://github.com/cli/cli/pull/1243#issuecomment-657640903

Currently, our 'editor' gives 2 options to the user, `(e) to edit and (enter) to skip`. However, skip is ambiguous (it was setting the body as blank). While some users want it to keep the body as blank, some want it to set the default contents.  
This PR removes the 'skip' option, and adds the 'default' and 'empty' options instead, which are much more explicit.  

Also, we were initially using a manual override (empty check), to set the body and title.
However, the case when the body had to be intentionally left empty (`-b ""`) was breaking because of this.