### PR TITLE
Report HTTP and Markdown errors in `repo view`

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -134,6 +134,10 @@ type NotFoundError struct {
 	error
 }
 
+func (err *NotFoundError) Unwrap() error {
+	return err.error
+}
+
 func (pr PullRequest) HeadLabel() string {
 	if pr.IsCrossRepository {
 		return fmt.Sprintf("%s:%s", pr.HeadRepositoryOwner.Login, pr.HeadRefName)

--- a/command/repo_test.go
+++ b/command/repo_test.go
@@ -912,6 +912,9 @@ func TestRepoView_blanks(t *testing.T) {
 	http := initFakeHTTP()
 	http.StubRepoResponse("OWNER", "REPO")
 	http.Register(httpmock.GraphQL(`query RepositoryInfo\b`), httpmock.StringResponse("{}"))
+	http.Register(
+		httpmock.REST("GET", "repos/OWNER/REPO/readme"),
+		httpmock.StatusStringResponse(404, `{}`))
 
 	output, err := RunCommand("repo view")
 	if err != nil {
@@ -921,6 +924,6 @@ func TestRepoView_blanks(t *testing.T) {
 	test.ExpectLines(t, output.String(),
 		"OWNER/REPO",
 		"No description provided",
-		"No README provided",
+		"This repository does not have a README",
 		"View this repository on GitHub: https://github.com/OWNER/REPO")
 }


### PR DESCRIPTION
If there is a `dark` file in the current directory, `gh repo view` will display `No README provided` even for repositories that have a README. This is due to Glamour trying to read style files from disk, and failing if `dark` did not contain style information as JSON. https://github.com/cli/cli/pull/1402

Any errors from fetching and rendering the README were silenced and ignored in `repo view`. This change:

- Tolerates HTTP 404, but will raise exceptions for any other error;
- Moves markdown rendering from `api` package to command implementation;
- Ensures markdown rendering errors are correctly reported.