### PR TITLE
README.MD: Fix Arch's install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ Install and upgrade:
 
 ### Arch Linux
 
-Arch Linux users can install from the AUR: https://aur.archlinux.org/packages/github-cli/
+Arch Linux users can install from the community repo: https://www.archlinux.org/packages/community/x86_64/github-cli/
 
 ```bash
-yay -S github-cli
+pacman -S github-cli
 ```
 
 ### Other platforms


### PR DESCRIPTION
As the package was moved from AUR to community repo the command needs update as well.
The AUR packge page throws 404 at the time of writing.