### PR TITLE
final isolation repo cleanup

### DIFF
--- a/command/repo.go
+++ b/command/repo.go
@@ -5,11 +5,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	repoCmd.AddCommand(repoCreditsCmd)
-	repoCreditsCmd.Flags().BoolP("static", "s", false, "Print a static version of the credits")
-}
-
 var repoCmd = &cobra.Command{
 	Use:   "repo <command>",
 	Short: "Create, clone, fork, and view repositories",
@@ -25,29 +20,4 @@ var repoCmd = &cobra.Command{
 A repository can be supplied as an argument in any of the following formats:
 - "OWNER/REPO"
 - by URL, e.g. "https://github.com/OWNER/REPO"`},
-}
-
-var repoCreditsCmd = &cobra.Command{
-	Use:   "credits [<repository>]",
-	Short: "View credits for a repository",
-	Example: heredoc.Doc(`
-     # view credits for the current repository
-     $ gh repo credits
-
-     # view credits for a specific repository
-     $ gh repo credits cool/repo
-
-     # print a non-animated thank you
-     $ gh repo credits -s
-
-     # pipe to just print the contributors, one per line
-     $ gh repo credits | cat
-  `),
-	Args:   cobra.MaximumNArgs(1),
-	RunE:   repoCredits,
-	Hidden: true,
-}
-
-func repoCredits(cmd *cobra.Command, args []string) error {
-	return credits(cmd, args)
 }

--- a/command/root.go
+++ b/command/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cli/cli/internal/run"
 	apiCmd "github.com/cli/cli/pkg/cmd/api"
 	gistCreateCmd "github.com/cli/cli/pkg/cmd/gist/create"
+	repoCmd "github.com/cli/cli/pkg/cmd/repo"
 	repoCloneCmd "github.com/cli/cli/pkg/cmd/repo/clone"
 	repoCreateCmd "github.com/cli/cli/pkg/cmd/repo/create"
 	creditsCmd "github.com/cli/cli/pkg/cmd/repo/credits"
@@ -152,12 +153,12 @@ func init() {
 
 	repoResolvingCmdFactory.BaseRepo = resolvedBaseRepo
 
-	RootCmd.AddCommand(repoCmd)
-	repoCmd.AddCommand(repoViewCmd.NewCmdView(&repoResolvingCmdFactory, nil))
-	repoCmd.AddCommand(repoForkCmd.NewCmdFork(&repoResolvingCmdFactory, nil))
-	repoCmd.AddCommand(repoCloneCmd.NewCmdClone(cmdFactory, nil))
-	repoCmd.AddCommand(repoCreateCmd.NewCmdCreate(cmdFactory, nil))
-	repoCmd.AddCommand(creditsCmd.NewCmdRepoCredits(&repoResolvingCmdFactory, nil))
+	RootCmd.AddCommand(repoCmd.Cmd)
+	repoCmd.Cmd.AddCommand(repoViewCmd.NewCmdView(&repoResolvingCmdFactory, nil))
+	repoCmd.Cmd.AddCommand(repoForkCmd.NewCmdFork(&repoResolvingCmdFactory, nil))
+	repoCmd.Cmd.AddCommand(repoCloneCmd.NewCmdClone(cmdFactory, nil))
+	repoCmd.Cmd.AddCommand(repoCreateCmd.NewCmdCreate(cmdFactory, nil))
+	repoCmd.Cmd.AddCommand(creditsCmd.NewCmdRepoCredits(&repoResolvingCmdFactory, nil))
 
 	RootCmd.AddCommand(creditsCmd.NewCmdCredits(cmdFactory, nil))
 }

--- a/command/root.go
+++ b/command/root.go
@@ -23,6 +23,7 @@ import (
 	gistCreateCmd "github.com/cli/cli/pkg/cmd/gist/create"
 	repoCloneCmd "github.com/cli/cli/pkg/cmd/repo/clone"
 	repoCreateCmd "github.com/cli/cli/pkg/cmd/repo/create"
+	creditsCmd "github.com/cli/cli/pkg/cmd/repo/credits"
 	repoForkCmd "github.com/cli/cli/pkg/cmd/repo/fork"
 	repoViewCmd "github.com/cli/cli/pkg/cmd/repo/view"
 	"github.com/cli/cli/pkg/cmdutil"
@@ -156,6 +157,9 @@ func init() {
 	repoCmd.AddCommand(repoForkCmd.NewCmdFork(&repoResolvingCmdFactory, nil))
 	repoCmd.AddCommand(repoCloneCmd.NewCmdClone(cmdFactory, nil))
 	repoCmd.AddCommand(repoCreateCmd.NewCmdCreate(cmdFactory, nil))
+	repoCmd.AddCommand(creditsCmd.NewCmdRepoCredits(&repoResolvingCmdFactory, nil))
+
+	RootCmd.AddCommand(creditsCmd.NewCmdCredits(cmdFactory, nil))
 }
 
 // RootCmd is the entry point of command-line execution

--- a/pkg/cmd/repo/credits/credits.go
+++ b/pkg/cmd/repo/credits/credits.go
@@ -1,10 +1,11 @@
-package command
+package credits
 
 import (
 	"bytes"
 	"fmt"
 	"math"
 	"math/rand"
+	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
@@ -12,72 +13,118 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
-
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
 	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
 )
 
-var thankYou = `
-     _                    _
-    | |                  | |
-_|_ | |     __,   _  _   | |           __
- |  |/ \   /  |  / |/ |  |/_)   |   | /  \_|   |
- |_/|   |_/\_/|_/  |  |_/| \_/   \_/|/\__/  \_/|_/
-                                   /|
-                                   \|
-                              _
-                           o | |                           |
- __   __   _  _  _|_  ,_     | |        _|_  __   ,_    ,  |
-/    /  \_/ |/ |  |  /  |  | |/ \_|   |  |  /  \_/  |  / \_|
-\___/\__/   |  |_/|_/   |_/|_/\_/  \_/|_/|_/\__/    |_/ \/ o
+type CreditsOptions struct {
+	HttpClient func() (*http.Client, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+	IO         *iostreams.IOStreams
 
-
-`
-
-func init() {
-	RootCmd.AddCommand(creditsCmd)
-
-	creditsCmd.Flags().BoolP("static", "s", false, "Print a static version of the credits")
+	Repository string
+	Static     bool
 }
 
-var creditsCmd = &cobra.Command{
-	Use:   "credits",
-	Short: "View credits for this tool",
-	Long:  `View animated credits for gh, the tool you are currently using :)`,
-	Example: heredoc.Doc(`
-	# see a credits animation for this project
-	$ gh credits
-	
-	# display a non-animated thank you
-	$ gh credits -s
-	
-	# just print the contributors, one per line
-	$ gh credits | cat
-	`),
-	Args:   cobra.ExactArgs(0),
-	RunE:   ghCredits,
-	Hidden: true,
+func NewCmdCredits(f *cmdutil.Factory, runF func(*CreditsOptions) error) *cobra.Command {
+	opts := &CreditsOptions{
+		HttpClient: f.HttpClient,
+		IO:         f.IOStreams,
+		BaseRepo:   f.BaseRepo,
+		Repository: "cli/cli",
+	}
+
+	cmd := &cobra.Command{
+		Use:   "credits",
+		Short: "View credits for this tool",
+		Long:  `View animated credits for gh, the tool you are currently using :)`,
+		Example: heredoc.Doc(`
+			# see a credits animation for this project
+			$ gh credits
+			
+			# display a non-animated thank you
+			$ gh credits -s
+			
+			# just print the contributors, one per line
+			$ gh credits | cat
+		`),
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return creditsRun(opts)
+		},
+		Hidden: true,
+	}
+
+	cmd.Flags().BoolVarP(&opts.Static, "static", "s", false, "Print a static version of the credits")
+
+	return cmd
 }
 
-func ghCredits(cmd *cobra.Command, _ []string) error {
-	args := []string{"cli/cli"}
-	return credits(cmd, args)
+func NewCmdRepoCredits(f *cmdutil.Factory, runF func(*CreditsOptions) error) *cobra.Command {
+	opts := &CreditsOptions{
+		HttpClient: f.HttpClient,
+		BaseRepo:   f.BaseRepo,
+		IO:         f.IOStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "credits [<repository>]",
+		Short: "View credits for a repository",
+		Example: heredoc.Doc(`
+      # view credits for the current repository
+      $ gh repo credits
+
+      # view credits for a specific repository
+      $ gh repo credits cool/repo
+
+      # print a non-animated thank you
+      $ gh repo credits -s
+
+      # pipe to just print the contributors, one per line
+      $ gh repo credits | cat
+    `),
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.Repository = args[0]
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return creditsRun(opts)
+		},
+		Hidden: true,
+	}
+
+	cmd.Flags().BoolVarP(&opts.Static, "static", "s", false, "Print a static version of the credits")
+
+	return cmd
 }
 
-func credits(cmd *cobra.Command, args []string) error {
+func creditsRun(opts *CreditsOptions) error {
 	isWindows := runtime.GOOS == "windows"
-	ctx := contextForCommand(cmd)
-	client, err := apiClientForContext(ctx)
+	httpClient, err := opts.HttpClient()
 	if err != nil {
 		return err
 	}
 
+	client := api.NewClientFromHTTP(httpClient)
+
 	var owner string
 	var repo string
 
-	if len(args) == 0 {
-		baseRepo, err := determineBaseRepo(client, cmd, ctx)
+	if opts.Repository == "" {
+		baseRepo, err := opts.BaseRepo()
 		if err != nil {
 			return err
 		}
@@ -85,7 +132,7 @@ func credits(cmd *cobra.Command, args []string) error {
 		owner = baseRepo.RepoOwner()
 		repo = baseRepo.RepoName()
 	} else {
-		parts := strings.SplitN(args[0], "/", 2)
+		parts := strings.SplitN(opts.Repository, "/", 2)
 		owner = parts[0]
 		repo = parts[1]
 	}
@@ -105,27 +152,15 @@ func credits(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	out := cmd.OutOrStdout()
-	isTTY := false
-	outFile, isFile := out.(*os.File)
-	if isFile {
-		isTTY = utils.IsTerminal(outFile)
-		if isTTY {
-			// FIXME: duplicates colorableOut
-			out = utils.NewColorable(outFile)
-		}
-	}
+	isTTY := opts.IO.IsStdoutTTY()
 
-	static, err := cmd.Flags().GetBool("static")
-	if err != nil {
-		return err
-	}
+	static := opts.Static || isWindows
 
-	static = static || isWindows
+	out := opts.IO.Out
 
 	if isTTY && static {
 		fmt.Fprintln(out, "THANK YOU CONTRIBUTORS!!! <3")
-		fmt.Println()
+		fmt.Fprintln(out, "")
 	}
 
 	logins := []string{}
@@ -153,7 +188,8 @@ func credits(cmd *cobra.Command, args []string) error {
 	lines = append(lines, logins...)
 	lines = append(lines, "( <3 press ctrl-c to quit <3 )")
 
-	termWidth, termHeight, err := terminal.GetSize(int(outFile.Fd()))
+	termWidth, termHeight, err := utils.TerminalSize(out)
+	//termWidth, termHeight, err := terminal.GetSize(int(outFile.Fd()))
 	if err != nil {
 		return err
 	}
@@ -262,3 +298,20 @@ func clear() {
 	cmd.Stdout = os.Stdout
 	_ = cmd.Run()
 }
+
+var thankYou = `
+     _                    _
+    | |                  | |
+_|_ | |     __,   _  _   | |           __
+ |  |/ \   /  |  / |/ |  |/_)   |   | /  \_|   |
+ |_/|   |_/\_/|_/  |  |_/| \_/   \_/|/\__/  \_/|_/
+                                   /|
+                                   \|
+                              _
+                           o | |                           |
+ __   __   _  _  _|_  ,_     | |        _|_  __   ,_    ,  |
+/    /  \_/ |/ |  |  /  |  | |/ \_|   |  |  /  \_/  |  / \_|
+\___/\__/   |  |_/|_/   |_/|_/\_/  \_/|_/|_/\__/    |_/ \/ o
+
+
+`

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -1,11 +1,11 @@
-package command
+package repo
 
 import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 )
 
-var repoCmd = &cobra.Command{
+var Cmd = &cobra.Command{
 	Use:   "repo <command>",
 	Short: "Create, clone, fork, and view repositories",
 	Long:  `Work with GitHub repositories`,


### PR DESCRIPTION
Closes #1405
Part of #1082 

This PR:

- isolates the repo credits easter egg
- removes command/repo.go in favor of pkg/cmd/repo/repo.go

I could have gone farther and re-exported the various `NewCmd*` functions from the new repo package
but it didn't seem worth it right now.

