### PR TITLE
Migrate gh formula to homebrew/core

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,32 +49,6 @@ archives:
     files:
       - LICENSE
 
-brews:
-  - name: gh
-    ids: [nix]
-    github:
-      owner: github
-      name: homebrew-gh
-    skip_upload: auto
-    description: GitHub CLI
-    homepage: https://github.com/cli/cli
-    folder: Formula
-    custom_block: |
-      head do
-        url "https://github.com/cli/cli.git", :branch => "trunk"
-        depends_on "go"
-      end
-    install: |
-      system "make", "bin/gh", "manpages" if build.head?
-      bin.install "bin/gh"
-      man1.install Dir["./share/man/man1/gh*.1"]
-      (bash_completion/"gh.sh").write `#{bin}/gh completion -s bash`
-      (zsh_completion/"_gh").write `#{bin}/gh completion -s zsh`
-      (fish_completion/"gh.fish").write `#{bin}/gh completion -s fish`
-    test: |
-      help_text = shell_output("#{bin}/gh --help")
-      assert_includes help_text, "Usage:"
-
 nfpms:
   - license: MIT
     maintainer: GitHub

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ tool. Check out our [more detailed explanation](/docs/gh-vs-hub.md) to learn mor
 Install:
 
 ```bash
-brew install github/gh/gh
+brew install gh
 ```
 
 Upgrade:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -22,7 +22,6 @@ To test out the build system, publish a prerelease tag with a name such as `vX.Y
 
 A successful build will result in changes across several repositories:
 * <https://github.com/github/cli.github.com>
-* <https://github.com/github/homebrew-gh>
 * <https://github.com/Homebrew/homebrew-core/pulls>
 * <https://github.com/cli/scoop-gh>
 


### PR DESCRIPTION
Congratulations! 🎉 The formula `gh` has been migrated to `homebrew-core` 🍺 
This means that the `homebrew` community will co-author the formula and the formula is even easier to install (via `brew install gh`).

## What does this PR do?

This PR removes the custom tap configuration from `.goreleaser.yml` because along with https://github.com/github/homebrew-gh/pull/13 it is not required any more. Upon merging the `tap_migrations.json` in the tap repo even commands like `brew upgrade github/gh/gh´ will use the formula in `homebrew-core`.

Your GH action `Bump homebrew-core formula` already creates a PR against https://github.com/Homebrew/homebrew-core when you release a new version.

## Related PRs
- https://github.com/github/homebrew-gh/pull/13

Signed-off-by: Alexander Zigelski <ali@crunchtime.dev>