### PR TITLE
Support GraphQL `operationName` in `gh api` command

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -74,6 +74,9 @@ on the format of the value:
 - if the value starts with "@", the rest of the value is interpreted as a
   filename to read the value from. Pass "-" to read from standard input.
 
+For GraphQL requests, all fields other than "query" and "operationName" are
+interpreted as GraphQL variables.
+
 Raw request body may be passed from the outside via a file specified by '--input'.
 Pass "-" to read from standard input. In this mode, parameters specified via
 '--field' flags are serialized into URL query parameters.

--- a/pkg/cmd/api/http.go
+++ b/pkg/cmd/api/http.go
@@ -87,7 +87,7 @@ func groupGraphQLVariables(params map[string]interface{}) map[string]interface{}
 
 	for key, val := range params {
 		switch key {
-		case "query":
+		case "query", "operationName":
 			topLevel[key] = val
 		default:
 			variables[key] = val

--- a/pkg/cmd/api/http_test.go
+++ b/pkg/cmd/api/http_test.go
@@ -55,6 +55,21 @@ func Test_groupGraphQLVariables(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "query + operationName + variables",
+			args: map[string]interface{}{
+				"query":         "query Q1{} query Q2{}",
+				"operationName": "Q1",
+				"power":         9001,
+			},
+			want: map[string]interface{}{
+				"query":         "query Q1{} query Q2{}",
+				"operationName": "Q1",
+				"variables": map[string]interface{}{
+					"power": 9001,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
GraphQL supports supplying multiple queries in the `query` parameter,
but an additional `operationName` parameter is then required to select
the query to execute.

Previously, it was impossible to pass `operationName` since it would get
serialized under `variables`, but it needs to be a top-level parameter.
With this change, `operationName` is a special GraphQL parameter name
just like `query` already is.

```sh
$ cat queries.graphql
query Q1 { ... }
query Q2 { ... }

$ gh api graphql -f operationName=Q1 -F query=@queries.graphql
```
