### PR TITLE
Align `bump-homebrew-formula` config for updated formula format

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -32,6 +32,7 @@ jobs:
         if: "!contains(github.ref, '-')" # skip prereleases
         with:
           formula-name: gh
+          download-url: https://github.com/cli/cli.git
         env:
           COMMITTER_TOKEN: ${{ secrets.UPLOAD_GITHUB_TOKEN }}
       - name: Checkout documentation site


### PR DESCRIPTION
The new bump-homebrew-formula v1.7 release now supports supplying `download-url` as a git clone URL. In this mode, the `url` and `sha256` fields are not updated, but `tag` and `revision` fields are.

Ref. https://github.com/Homebrew/homebrew-core/pull/58734#issuecomment-666643042