### PR TITLE
Remove period from gh alias --help's output

### DIFF
--- a/command/alias.go
+++ b/command/alias.go
@@ -193,7 +193,7 @@ func aliasList(cmd *cobra.Command, args []string) error {
 
 var aliasDeleteCmd = &cobra.Command{
 	Use:   "delete <alias>",
-	Short: "Delete an alias.",
+	Short: "Delete an alias",
 	Args:  cobra.ExactArgs(1),
 	RunE:  aliasDelete,
 }


### PR DESCRIPTION
This PR simply removes a period from the output of `gh alias --help`. The short description for `delete` ends with a period, where as every other command's short description does not.

```
$ gh alias --help                         

Aliases can be used to make shortcuts for gh commands or to compose multiple commands.

Run "gh help alias set" to learn more.


USAGE
  gh alias [flags]

CORE COMMANDS
  delete:     Delete an alias. 👀 
  list:       List your aliases
  set:        Create a shortcut for a gh command

INHERITED FLAGS
  --help   Show help for command

LEARN MORE
  Use "gh <command> <subcommand> --help" for more information about a command.
  Read the manual at https://cli.github.com/manual
```

My greatest contribution to open source. Ever. 💪🏼 