### PR TITLE
Add `:branch` placeholder for API calls

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -300,8 +300,6 @@ func fillPlaceholders(value string, opts *ApiOptions) (string, error) {
 		return value, err
 	}
 
-	var branch string
-
 	filled := placeholderRE.ReplaceAllStringFunc(value, func(m string) string {
 		switch m {
 		case ":owner":
@@ -309,7 +307,10 @@ func fillPlaceholders(value string, opts *ApiOptions) (string, error) {
 		case ":repo":
 			return baseRepo.RepoName()
 		case ":branch":
-			branch, err = opts.Branch()
+			branch, e := opts.Branch()
+			if e != nil {
+				err = e
+			}
 			return branch
 		default:
 			panic(fmt.Sprintf("invalid placeholder: %q", m))

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -301,6 +301,14 @@ func fillPlaceholders(value string, opts *ApiOptions) (string, error) {
 		return value, err
 	}
 
+	var branch string
+	if strings.Contains(value, ":branch") {
+		branch, err = opts.CurrentBranch()
+		if err != nil {
+			return value, err
+		}
+	}
+
 	value = placeholderRE.ReplaceAllStringFunc(value, func(m string) string {
 		switch m {
 		case ":owner":
@@ -308,10 +316,6 @@ func fillPlaceholders(value string, opts *ApiOptions) (string, error) {
 		case ":repo":
 			return baseRepo.RepoName()
 		case ":branch":
-			branch, err := opts.CurrentBranch()
-			if err != nil {
-				panic(err)
-			}
 			return branch
 		default:
 			panic(fmt.Sprintf("invalid placeholder: %q", m))

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
@@ -756,18 +757,34 @@ func Test_fillPlaceholders(t *testing.T) {
 		{
 			name: "has branch placeholder",
 			args: args{
-				value: "repos/:owner/:repo/branches/:branch",
+				value: "repos/cli/cli/branches/:branch",
 				opts: &ApiOptions{
 					BaseRepo: func() (ghrepo.Interface, error) {
 						return ghrepo.New("hubot", "robot-uprising"), nil
 					},
 					CurrentBranch: func() (string, error) {
-						return "feature", nil
+						return "trunk", nil
 					},
 				},
 			},
-			want:    "repos/hubot/robot-uprising/branches/feature",
+			want:    "repos/cli/cli/branches/trunk",
 			wantErr: false,
+		},
+		{
+			name: "has branch placeholder and git is on detached head",
+			args: args{
+				value: "repos/cli/cli/branches/:branch",
+				opts: &ApiOptions{
+					BaseRepo: func() (ghrepo.Interface, error) {
+						return ghrepo.New("cli", "cli"), nil
+					},
+					CurrentBranch: func() (string, error) {
+						return "", git.ErrNotOnAnyBranch
+					},
+				},
+			},
+			want:    "repos/cli/cli/branches/:branch",
+			wantErr: true,
 		},
 		{
 			name: "no greedy substitutes",

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -754,6 +754,22 @@ func Test_fillPlaceholders(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "has branch placeholder",
+			args: args{
+				value: "repos/:owner/:repo/branches/:branch",
+				opts: &ApiOptions{
+					BaseRepo: func() (ghrepo.Interface, error) {
+						return ghrepo.New("hubot", "robot-uprising"), nil
+					},
+					CurrentBranch: func() (string, error) {
+						return "feature", nil
+					},
+				},
+			},
+			want:    "repos/hubot/robot-uprising/branches/feature",
+			wantErr: false,
+		},
+		{
 			name: "no greedy substitutes",
 			args: args{
 				value: ":ownership/:repository",

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -757,7 +757,7 @@ func Test_fillPlaceholders(t *testing.T) {
 		{
 			name: "has branch placeholder",
 			args: args{
-				value: "repos/cli/cli/branches/:branch",
+				value: "repos/cli/cli/branches/:branch/protection/required_status_checks",
 				opts: &ApiOptions{
 					BaseRepo: func() (ghrepo.Interface, error) {
 						return ghrepo.New("cli", "cli"), nil
@@ -767,13 +767,13 @@ func Test_fillPlaceholders(t *testing.T) {
 					},
 				},
 			},
-			want:    "repos/cli/cli/branches/trunk",
+			want:    "repos/cli/cli/branches/trunk/protection/required_status_checks",
 			wantErr: false,
 		},
 		{
-			name: "has branch placeholder and git is on detached head",
+			name: "has branch placeholder and git is in detached head",
 			args: args{
-				value: "repos/cli/cli/branches/:branch",
+				value: "repos/:owner/:repo/branches/:branch",
 				opts: &ApiOptions{
 					BaseRepo: func() (ghrepo.Interface, error) {
 						return ghrepo.New("cli", "cli"), nil
@@ -783,7 +783,7 @@ func Test_fillPlaceholders(t *testing.T) {
 					},
 				},
 			},
-			want:    "repos/cli/cli/branches/:branch",
+			want:    "repos/:owner/:repo/branches/:branch",
 			wantErr: true,
 		},
 		{

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -760,9 +760,9 @@ func Test_fillPlaceholders(t *testing.T) {
 				value: "repos/cli/cli/branches/:branch",
 				opts: &ApiOptions{
 					BaseRepo: func() (ghrepo.Interface, error) {
-						return ghrepo.New("hubot", "robot-uprising"), nil
+						return ghrepo.New("cli", "cli"), nil
 					},
-					CurrentBranch: func() (string, error) {
+					Branch: func() (string, error) {
 						return "trunk", nil
 					},
 				},
@@ -778,7 +778,7 @@ func Test_fillPlaceholders(t *testing.T) {
 					BaseRepo: func() (ghrepo.Interface, error) {
 						return ghrepo.New("cli", "cli"), nil
 					},
-					CurrentBranch: func() (string, error) {
+					Branch: func() (string, error) {
 						return "", git.ErrNotOnAnyBranch
 					},
 				},


### PR DESCRIPTION
As discussed in #1288, this PR allows for the use of the `:branch` placeholder on the `api` command.

The placeholder is substituted with the current git branch name.

Closes #1288 