### PR TITLE
Allow explicitly setting hostname for gh operations

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cli/cli/command"
 	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/internal/ghinstance"
 	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/pkg/cmd/alias/expand"
 	"github.com/cli/cli/pkg/cmd/factory"
@@ -34,6 +35,10 @@ func main() {
 	}()
 
 	hasDebug := os.Getenv("DEBUG") != ""
+
+	if hostFromEnv := os.Getenv("GH_HOST"); hostFromEnv != "" {
+		ghinstance.OverrideDefault(hostFromEnv)
+	}
 
 	cmdFactory := factory.New(command.Version)
 	stderr := cmdFactory.IOStreams.ErrOut

--- a/context/context.go
+++ b/context/context.go
@@ -40,7 +40,7 @@ func ResolveRemotesToRepos(remotes Remotes, client *api.Client, base string) (Re
 			continue
 		}
 		repos = append(repos, r)
-		if ghrepo.IsSame(r, baseOverride) {
+		if baseOverride != nil && ghrepo.IsSame(r, baseOverride) {
 			foundBaseOverride = true
 		}
 		if len(repos) == maxRemotesForLookup {

--- a/git/remote.go
+++ b/git/remote.go
@@ -14,6 +14,15 @@ var remoteRE = regexp.MustCompile(`(.+)\s+(.+)\s+\((push|fetch)\)`)
 // RemoteSet is a slice of git remotes
 type RemoteSet []*Remote
 
+func NewRemote(name string, u string) *Remote {
+	pu, _ := url.Parse(u)
+	return &Remote{
+		Name:     name,
+		FetchURL: pu,
+		PushURL:  pu,
+	}
+}
+
 // Remote is a parsed git remote
 type Remote struct {
 	Name     string

--- a/git/url.go
+++ b/git/url.go
@@ -10,6 +10,10 @@ var (
 	protocolRe = regexp.MustCompile("^[a-zA-Z_+-]+://")
 )
 
+func IsURL(u string) bool {
+	return strings.HasPrefix(u, "git@") || protocolRe.MatchString(u)
+}
+
 // ParseURL normalizes git remote urls
 func ParseURL(rawURL string) (u *url.URL, err error) {
 	if !protocolRe.MatchString(rawURL) &&

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -201,16 +201,19 @@ func (c *fileConfig) Root() *yaml.Node {
 
 func (c *fileConfig) Get(hostname, key string) (string, error) {
 	if hostname != "" {
+		var notFound *NotFoundError
+
 		hostCfg, err := c.configForHost(hostname)
-		if err != nil {
+		if err != nil && !errors.As(err, &notFound) {
 			return "", err
 		}
 
-		hostValue, err := hostCfg.GetStringValue(key)
-		var notFound *NotFoundError
-
-		if err != nil && !errors.As(err, &notFound) {
-			return "", err
+		var hostValue string
+		if hostCfg != nil {
+			hostValue, err = hostCfg.GetStringValue(key)
+			if err != nil && !errors.As(err, &notFound) {
+				return "", err
+			}
 		}
 
 		if hostValue != "" {
@@ -385,7 +388,7 @@ func (c *fileConfig) hostEntries() ([]*HostConfig, error) {
 	return hostConfigs, nil
 }
 
-// Hosts returns a list of all known hostnames configred in hosts.yml
+// Hosts returns a list of all known hostnames configured in hosts.yml
 func (c *fileConfig) Hosts() ([]string, error) {
 	entries, err := c.hostEntries()
 	if err != nil {

--- a/internal/ghinstance/host.go
+++ b/internal/ghinstance/host.go
@@ -7,9 +7,25 @@ import (
 
 const defaultHostname = "github.com"
 
+var hostnameOverride string
+
 // Default returns the host name of the default GitHub instance
 func Default() string {
 	return defaultHostname
+}
+
+// OverridableDefault is like Default, except it is overridable by the GH_HOST environment variable
+func OverridableDefault() string {
+	if hostnameOverride != "" {
+		return hostnameOverride
+	}
+	return defaultHostname
+}
+
+// OverrideDefault overrides the value returned from OverridableDefault. This should only ever be
+// called from the main runtime path, not tests.
+func OverrideDefault(newhost string) {
+	hostnameOverride = newhost
 }
 
 // IsEnterprise reports whether a non-normalized host name looks like a GHE instance

--- a/internal/ghinstance/host_test.go
+++ b/internal/ghinstance/host_test.go
@@ -4,6 +4,29 @@ import (
 	"testing"
 )
 
+func TestOverridableDefault(t *testing.T) {
+	oldOverride := hostnameOverride
+	t.Cleanup(func() {
+		hostnameOverride = oldOverride
+	})
+
+	host := OverridableDefault()
+	if host != "github.com" {
+		t.Errorf("expected github.com, got %q", host)
+	}
+
+	OverrideDefault("example.org")
+
+	host = OverridableDefault()
+	if host != "example.org" {
+		t.Errorf("expected example.org, got %q", host)
+	}
+	host = Default()
+	if host != "github.com" {
+		t.Errorf("expected github.com, got %q", host)
+	}
+}
+
 func TestIsEnterprise(t *testing.T) {
 	tests := []struct {
 		host string

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-)
 
-const defaultHostname = "github.com"
+	"github.com/cli/cli/git"
+	"github.com/cli/cli/internal/ghinstance"
+)
 
 // Interface describes an object that represents a GitHub repository
 type Interface interface {
@@ -17,10 +18,7 @@ type Interface interface {
 
 // New instantiates a GitHub repository from owner and name arguments
 func New(owner, repo string) Interface {
-	return &ghRepo{
-		owner: owner,
-		name:  repo,
-	}
+	return NewWithHost(owner, repo, ghinstance.OverridableDefault())
 }
 
 // NewWithHost is like New with an explicit host name
@@ -28,7 +26,7 @@ func NewWithHost(owner, repo, hostname string) Interface {
 	return &ghRepo{
 		owner:    owner,
 		name:     repo,
-		hostname: hostname,
+		hostname: normalizeHostname(hostname),
 	}
 }
 
@@ -37,15 +35,31 @@ func FullName(r Interface) string {
 	return fmt.Sprintf("%s/%s", r.RepoOwner(), r.RepoName())
 }
 
-// FromFullName extracts the GitHub repository information from an "OWNER/REPO" string
+// FromFullName extracts the GitHub repository information from the following
+// formats: "OWNER/REPO", "HOST/OWNER/REPO", and a full URL.
 func FromFullName(nwo string) (Interface, error) {
-	var r ghRepo
-	parts := strings.SplitN(nwo, "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return &r, fmt.Errorf("expected OWNER/REPO format, got %q", nwo)
+	if git.IsURL(nwo) {
+		u, err := git.ParseURL(nwo)
+		if err != nil {
+			return nil, err
+		}
+		return FromURL(u)
 	}
-	r.owner, r.name = parts[0], parts[1]
-	return &r, nil
+
+	parts := strings.SplitN(nwo, "/", 4)
+	for _, p := range parts {
+		if len(p) == 0 {
+			return nil, fmt.Errorf(`expected the "[HOST/]OWNER/REPO" format, got %q`, nwo)
+		}
+	}
+	switch len(parts) {
+	case 3:
+		return NewWithHost(parts[1], parts[2], normalizeHostname(parts[0])), nil
+	case 2:
+		return New(parts[0], parts[1]), nil
+	default:
+		return nil, fmt.Errorf(`expected the "[HOST/]OWNER/REPO" format, got %q`, nwo)
+	}
 }
 
 // FromURL extracts the GitHub repository information from a git remote URL
@@ -59,11 +73,7 @@ func FromURL(u *url.URL) (Interface, error) {
 		return nil, fmt.Errorf("invalid path: %s", u.Path)
 	}
 
-	return &ghRepo{
-		owner:    parts[0],
-		name:     strings.TrimSuffix(parts[1], ".git"),
-		hostname: normalizeHostname(u.Hostname()),
-	}, nil
+	return NewWithHost(parts[0], strings.TrimSuffix(parts[1], ".git"), u.Hostname()), nil
 }
 
 func normalizeHostname(h string) string {
@@ -109,8 +119,5 @@ func (r ghRepo) RepoName() string {
 }
 
 func (r ghRepo) RepoHost() string {
-	if r.hostname != "" {
-		return r.hostname
-	}
-	return defaultHostname
+	return r.hostname
 }

--- a/internal/ghrepo/repo_test.go
+++ b/internal/ghrepo/repo_test.go
@@ -114,3 +114,87 @@ func Test_repoFromURL(t *testing.T) {
 		})
 	}
 }
+
+func TestFromFullName(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantOwner string
+		wantName  string
+		wantHost  string
+		wantErr   error
+	}{
+		{
+			name:      "OWNER/REPO combo",
+			input:     "OWNER/REPO",
+			wantHost:  "github.com",
+			wantOwner: "OWNER",
+			wantName:  "REPO",
+			wantErr:   nil,
+		},
+		{
+			name:    "too few elements",
+			input:   "OWNER",
+			wantErr: errors.New(`expected the "[HOST/]OWNER/REPO" format, got "OWNER"`),
+		},
+		{
+			name:    "too many elements",
+			input:   "a/b/c/d",
+			wantErr: errors.New(`expected the "[HOST/]OWNER/REPO" format, got "a/b/c/d"`),
+		},
+		{
+			name:    "blank value",
+			input:   "a/",
+			wantErr: errors.New(`expected the "[HOST/]OWNER/REPO" format, got "a/"`),
+		},
+		{
+			name:      "with hostname",
+			input:     "example.org/OWNER/REPO",
+			wantHost:  "example.org",
+			wantOwner: "OWNER",
+			wantName:  "REPO",
+			wantErr:   nil,
+		},
+		{
+			name:      "full URL",
+			input:     "https://example.org/OWNER/REPO.git",
+			wantHost:  "example.org",
+			wantOwner: "OWNER",
+			wantName:  "REPO",
+			wantErr:   nil,
+		},
+		{
+			name:      "SSH URL",
+			input:     "git@example.org:OWNER/REPO.git",
+			wantHost:  "example.org",
+			wantOwner: "OWNER",
+			wantName:  "REPO",
+			wantErr:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := FromFullName(tt.input)
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Fatalf("no error in result, expected %v", tt.wantErr)
+				} else if err.Error() != tt.wantErr.Error() {
+					t.Fatalf("expected error %q, got %q", tt.wantErr.Error(), err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("got error %v", err)
+			}
+			if r.RepoHost() != tt.wantHost {
+				t.Errorf("expected host %q, got %q", tt.wantHost, r.RepoHost())
+			}
+			if r.RepoOwner() != tt.wantOwner {
+				t.Errorf("expected owner %q, got %q", tt.wantOwner, r.RepoOwner())
+			}
+			if r.RepoName() != tt.wantName {
+				t.Errorf("expected name %q, got %q", tt.wantName, r.RepoName())
+			}
+		})
+	}
+}

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/internal/ghinstance"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
@@ -195,9 +196,11 @@ func apiRun(opts *ApiOptions) error {
 		opts.IO.Out = ioutil.Discard
 	}
 
+	host := ghinstance.OverridableDefault()
+
 	hasNextPage := true
 	for hasNextPage {
-		resp, err := httpRequest(httpClient, method, requestPath, requestBody, requestHeaders)
+		resp, err := httpRequest(httpClient, host, method, requestPath, requestBody, requestHeaders)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/api/http.go
+++ b/pkg/cmd/api/http.go
@@ -9,20 +9,23 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/cli/cli/internal/ghinstance"
 )
 
-func httpRequest(client *http.Client, method string, p string, params interface{}, headers []string) (*http.Response, error) {
+func httpRequest(client *http.Client, hostname string, method string, p string, params interface{}, headers []string) (*http.Response, error) {
+	isGraphQL := p == "graphql"
 	var requestURL string
 	if strings.Contains(p, "://") {
 		requestURL = p
+	} else if isGraphQL {
+		requestURL = ghinstance.GraphQLEndpoint(hostname)
 	} else {
-		// TODO: GHE support
-		requestURL = "https://api.github.com/" + p
+		requestURL = ghinstance.RESTPrefix(hostname) + strings.TrimPrefix(p, "/")
 	}
 
 	var body io.Reader
 	var bodyIsJSON bool
-	isGraphQL := p == "graphql"
 
 	switch pp := params.(type) {
 	case map[string]interface{}:

--- a/pkg/cmd/api/http_test.go
+++ b/pkg/cmd/api/http_test.go
@@ -93,6 +93,7 @@ func Test_httpRequest(t *testing.T) {
 
 	type args struct {
 		client  *http.Client
+		host    string
 		method  string
 		p       string
 		params  interface{}
@@ -114,6 +115,7 @@ func Test_httpRequest(t *testing.T) {
 			name: "simple GET",
 			args: args{
 				client:  &httpClient,
+				host:    "github.com",
 				method:  "GET",
 				p:       "repos/octocat/spoon-knife",
 				params:  nil,
@@ -128,9 +130,46 @@ func Test_httpRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "GET with leading slash",
+			args: args{
+				client:  &httpClient,
+				host:    "github.com",
+				method:  "GET",
+				p:       "/repos/octocat/spoon-knife",
+				params:  nil,
+				headers: []string{},
+			},
+			wantErr: false,
+			want: expects{
+				method:  "GET",
+				u:       "https://api.github.com/repos/octocat/spoon-knife",
+				body:    "",
+				headers: "",
+			},
+		},
+		{
+			name: "Enterprise REST",
+			args: args{
+				client:  &httpClient,
+				host:    "example.org",
+				method:  "GET",
+				p:       "repos/octocat/spoon-knife",
+				params:  nil,
+				headers: []string{},
+			},
+			wantErr: false,
+			want: expects{
+				method:  "GET",
+				u:       "https://example.org/api/v3/repos/octocat/spoon-knife",
+				body:    "",
+				headers: "",
+			},
+		},
+		{
 			name: "GET with params",
 			args: args{
 				client: &httpClient,
+				host:   "github.com",
 				method: "GET",
 				p:      "repos/octocat/spoon-knife",
 				params: map[string]interface{}{
@@ -150,6 +189,7 @@ func Test_httpRequest(t *testing.T) {
 			name: "POST with params",
 			args: args{
 				client: &httpClient,
+				host:   "github.com",
 				method: "POST",
 				p:      "repos",
 				params: map[string]interface{}{
@@ -169,6 +209,7 @@ func Test_httpRequest(t *testing.T) {
 			name: "POST GraphQL",
 			args: args{
 				client: &httpClient,
+				host:   "github.com",
 				method: "POST",
 				p:      "graphql",
 				params: map[string]interface{}{
@@ -185,9 +226,28 @@ func Test_httpRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "Enterprise GraphQL",
+			args: args{
+				client:  &httpClient,
+				host:    "example.org",
+				method:  "POST",
+				p:       "graphql",
+				params:  map[string]interface{}{},
+				headers: []string{},
+			},
+			wantErr: false,
+			want: expects{
+				method:  "POST",
+				u:       "https://example.org/api/graphql",
+				body:    `{}`,
+				headers: "Content-Type: application/json; charset=utf-8\r\n",
+			},
+		},
+		{
 			name: "POST with body and type",
 			args: args{
 				client: &httpClient,
+				host:   "github.com",
 				method: "POST",
 				p:      "repos",
 				params: bytes.NewBufferString("CUSTOM"),
@@ -207,7 +267,7 @@ func Test_httpRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := httpRequest(tt.args.client, tt.args.method, tt.args.p, tt.args.params, tt.args.headers)
+			got, err := httpRequest(tt.args.client, tt.args.host, tt.args.method, tt.args.p, tt.args.params, tt.args.headers)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("httpRequest() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cmd/factory/remote_resolver.go
+++ b/pkg/cmd/factory/remote_resolver.go
@@ -1,0 +1,80 @@
+package factory
+
+import (
+	"errors"
+	"net/url"
+	"sort"
+
+	"github.com/cli/cli/context"
+	"github.com/cli/cli/git"
+	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/internal/ghinstance"
+)
+
+type remoteResolver struct {
+	readRemotes   func() (git.RemoteSet, error)
+	getConfig     func() (config.Config, error)
+	urlTranslator func(*url.URL) *url.URL
+}
+
+func (rr *remoteResolver) Resolver() func() (context.Remotes, error) {
+	var cachedRemotes context.Remotes
+	var remotesError error
+
+	return func() (context.Remotes, error) {
+		if cachedRemotes != nil || remotesError != nil {
+			return cachedRemotes, remotesError
+		}
+
+		gitRemotes, err := rr.readRemotes()
+		if err != nil {
+			remotesError = err
+			return nil, err
+		}
+		if len(gitRemotes) == 0 {
+			remotesError = errors.New("no git remotes found")
+			return nil, remotesError
+		}
+
+		sshTranslate := rr.urlTranslator
+		if sshTranslate == nil {
+			sshTranslate = git.ParseSSHConfig().Translator()
+		}
+		resolvedRemotes := context.TranslateRemotes(gitRemotes, sshTranslate)
+
+		cfg, err := rr.getConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		knownHosts := map[string]bool{}
+		knownHosts[ghinstance.Default()] = true
+		if authenticatedHosts, err := cfg.Hosts(); err == nil {
+			for _, h := range authenticatedHosts {
+				knownHosts[h] = true
+			}
+		}
+
+		// filter remotes to only those sharing a single, known hostname
+		var hostname string
+		cachedRemotes = context.Remotes{}
+		sort.Sort(resolvedRemotes)
+		for _, r := range resolvedRemotes {
+			if hostname == "" {
+				if !knownHosts[r.RepoHost()] {
+					continue
+				}
+				hostname = r.RepoHost()
+			} else if r.RepoHost() != hostname {
+				continue
+			}
+			cachedRemotes = append(cachedRemotes, r)
+		}
+
+		if len(cachedRemotes) == 0 {
+			remotesError = errors.New("none of the git remotes point to a known GitHub host")
+			return nil, remotesError
+		}
+		return cachedRemotes, nil
+	}
+}

--- a/pkg/cmd/factory/remote_resolver_test.go
+++ b/pkg/cmd/factory/remote_resolver_test.go
@@ -1,0 +1,42 @@
+package factory
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/git"
+	"github.com/cli/cli/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_remoteResolver(t *testing.T) {
+	rr := &remoteResolver{
+		readRemotes: func() (git.RemoteSet, error) {
+			return git.RemoteSet{
+				git.NewRemote("fork", "https://example.org/ghe-owner/ghe-fork.git"),
+				git.NewRemote("origin", "https://github.com/owner/repo.git"),
+				git.NewRemote("upstream", "https://example.org/ghe-owner/ghe-repo.git"),
+			}, nil
+		},
+		getConfig: func() (config.Config, error) {
+			return config.NewFromString(heredoc.Doc(`
+				hosts:
+				  example.org:
+				    oauth_token: GHETOKEN
+			`)), nil
+		},
+		urlTranslator: func(u *url.URL) *url.URL {
+			return u
+		},
+	}
+
+	resolver := rr.Resolver()
+	remotes, err := resolver()
+	require.NoError(t, err)
+	require.Equal(t, 2, len(remotes))
+
+	assert.Equal(t, "upstream", remotes[0].Name)
+	assert.Equal(t, "fork", remotes[1].Name)
+}

--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -104,7 +104,6 @@ func createRun(opts *CreateOptions) error {
 		return err
 	}
 
-	// TODO: GHE support
 	gist, err := apiCreate(httpClient, ghinstance.OverridableDefault(), opts.Description, opts.Public, files)
 	if err != nil {
 		var httpError api.HTTPError

--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -105,7 +105,7 @@ func createRun(opts *CreateOptions) error {
 	}
 
 	// TODO: GHE support
-	gist, err := apiCreate(httpClient, ghinstance.Default(), opts.Description, opts.Public, files)
+	gist, err := apiCreate(httpClient, ghinstance.OverridableDefault(), opts.Description, opts.Public, files)
 	if err != nil {
 		var httpError api.HTTPError
 		if errors.As(err, &httpError) {

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -76,13 +76,7 @@ func cloneRun(opts *CloneOptions) error {
 		return err
 	}
 
-	// TODO This is overly wordy and I'd like to streamline this.
 	cfg, err := opts.Config()
-	if err != nil {
-		return err
-	}
-	// TODO: GHE support
-	protocol, err := cfg.Get("", "git_protocol")
 	if err != nil {
 		return err
 	}
@@ -91,8 +85,7 @@ func cloneRun(opts *CloneOptions) error {
 	cloneURL := opts.Repository
 	if !strings.Contains(cloneURL, ":") {
 		if !strings.Contains(cloneURL, "/") {
-			// TODO: GHE compat
-			currentUser, err := api.CurrentLoginName(apiClient, ghinstance.Default())
+			currentUser, err := api.CurrentLoginName(apiClient, ghinstance.OverridableDefault())
 			if err != nil {
 				return err
 			}
@@ -103,6 +96,10 @@ func cloneRun(opts *CloneOptions) error {
 			return err
 		}
 
+		protocol, err := cfg.Get(repo.RepoHost(), "git_protocol")
+		if err != nil {
+			return err
+		}
 		cloneURL = ghrepo.FormatRemoteURL(repo, protocol)
 	}
 
@@ -128,9 +125,13 @@ func cloneRun(opts *CloneOptions) error {
 	}
 
 	if parentRepo != nil {
+		protocol, err := cfg.Get(parentRepo.RepoHost(), "git_protocol")
+		if err != nil {
+			return err
+		}
 		upstreamURL := ghrepo.FormatRemoteURL(parentRepo, protocol)
 
-		err := git.AddUpstreamRemote(upstreamURL, cloneDir)
+		err = git.AddUpstreamRemote(upstreamURL, cloneDir)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -86,23 +86,23 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 func createRun(opts *CreateOptions) error {
 	projectDir, projectDirErr := git.ToplevelDir()
 
-	orgName := ""
-	name := opts.Name
+	var repoToCreate ghrepo.Interface
 
-	if name != "" {
-		if strings.Contains(name, "/") {
-			newRepo, err := ghrepo.FromFullName(name)
+	if opts.Name != "" {
+		if strings.Contains(opts.Name, "/") {
+			var err error
+			repoToCreate, err = ghrepo.FromFullName(opts.Name)
 			if err != nil {
 				return fmt.Errorf("argument error: %w", err)
 			}
-			orgName = newRepo.RepoOwner()
-			name = newRepo.RepoName()
+		} else {
+			repoToCreate = ghrepo.New("", opts.Name)
 		}
 	} else {
 		if projectDirErr != nil {
 			return projectDirErr
 		}
-		name = path.Base(projectDir)
+		repoToCreate = ghrepo.New("", path.Base(projectDir))
 	}
 
 	visibility := "PRIVATE"
@@ -111,9 +111,9 @@ func createRun(opts *CreateOptions) error {
 	}
 
 	input := repoCreateInput{
-		Name:             name,
+		Name:             repoToCreate.RepoName(),
 		Visibility:       visibility,
-		OwnerID:          orgName,
+		OwnerID:          repoToCreate.RepoOwner(),
 		TeamID:           opts.Team,
 		Description:      opts.Description,
 		HomepageURL:      opts.Homepage,
@@ -126,7 +126,7 @@ func createRun(opts *CreateOptions) error {
 		return err
 	}
 
-	repo, err := repoCreate(httpClient, input)
+	repo, err := repoCreate(httpClient, repoToCreate.RepoHost(), input)
 	if err != nil {
 		return err
 	}
@@ -146,8 +146,7 @@ func createRun(opts *CreateOptions) error {
 	if err != nil {
 		return err
 	}
-	// TODO: GHE support
-	protocol, err := cfg.Get("", "git_protocol")
+	protocol, err := cfg.Get(repo.RepoHost(), "git_protocol")
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -21,7 +21,7 @@ func Test_RepoCreate(t *testing.T) {
 		HomepageURL: "http://example.com",
 	}
 
-	_, err := repoCreate(httpClient, input)
+	_, err := repoCreate(httpClient, "github.com", input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -180,13 +180,11 @@ func forkRun(opts *ForkOptions) error {
 		return nil
 	}
 
-	// TODO This is overly wordy and I'd like to streamline this.
 	cfg, err := opts.Config()
 	if err != nil {
 		return err
 	}
-	// TODO: GHE support
-	protocol, err := cfg.Get("", "git_protocol")
+	protocol, err := cfg.Get(repoToFork.RepoHost(), "git_protocol")
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -71,22 +70,10 @@ func viewRun(opts *ViewOptions) error {
 			return err
 		}
 	} else {
-		if utils.IsURL(opts.RepoArg) {
-			parsedURL, err := url.Parse(opts.RepoArg)
-			if err != nil {
-				return fmt.Errorf("did not understand argument: %w", err)
-			}
-
-			toView, err = ghrepo.FromURL(parsedURL)
-			if err != nil {
-				return fmt.Errorf("did not understand argument: %w", err)
-			}
-		} else {
-			var err error
-			toView, err = ghrepo.FromFullName(opts.RepoArg)
-			if err != nil {
-				return fmt.Errorf("argument error: %w", err)
-			}
+		var err error
+		toView, err = ghrepo.FromFullName(opts.RepoArg)
+		if err != nil {
+			return fmt.Errorf("argument error: %w", err)
 		}
 	}
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -45,8 +45,11 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 				GITHUB_TOKEN: an authentication token for API requests. Setting this avoids being
 				prompted to authenticate and overrides any previously stored credentials.
 	
-				GH_REPO: specify the GitHub repository in "OWNER/REPO" format for commands that
-				otherwise operate on a local repository.
+				GH_REPO: specify the GitHub repository in the "[HOST/]OWNER/REPO" format for commands
+				that otherwise operate on a local repository.
+
+				GH_HOST: specify the GitHub hostname for commands that would otherwise assume
+				the "github.com" host when not in a context of an existing repository.
 	
 				GH_EDITOR, GIT_EDITOR, VISUAL, EDITOR (in order of precedence): the editor tool to use
 				for authoring text.

--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -8,7 +8,7 @@ import (
 )
 
 func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
-	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `OWNER/REPO` format")
+	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `[HOST/]OWNER/REPO` format")
 
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		repoOverride, _ := cmd.Flags().GetString("repo")


### PR DESCRIPTION
This adds the missing bit of GitHub Enterprise support in which users can select a hostname to perform the operation against when that hostname cannot be inferred from an existing git repository.

* The `-R, --repo` flag to override the repository for issue/PR operations now accepts the `HOST/OWNER/REPO` format, as well as full URLs;
* The GH_REPO environment variable now supports all format that the `--repo` flag does;
* The new GH_HOST environment variable can be used to change the default host away from `github.com`. This affects operations such as `gh api`, `gh gist create`, `gh repo clone myrepo`, etc.

Examples:

    $ gh auth login -h example.org

    $ gh repo clone example.org/owner/repo
    $ GH_HOST=example.org gh repo clone repo

    $ GH_HOST=example.org gh api user
    $ GH_HOST=example.org gh gist create myfile.txt

    $ gh issue list -R example.org/owner/repo
    $ gh issue list -R https://example.org/owner/repo.git
    $ GH_REPO=example.org/owner/repo gh issue list

Fixes #1180, fixes https://github.com/cli/cli/issues/1505, closes #273