### PR TITLE
Auth status

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -196,6 +196,10 @@ func (err HTTPError) Error() string {
 	return fmt.Sprintf("HTTP %d (%s)", err.StatusCode, err.RequestURL)
 }
 
+type MissingScopesError struct {
+	error
+}
+
 func (c Client) HasMinimumScopes(hostname string) (bool, error) {
 	apiEndpoint := ghinstance.RESTPrefix(hostname)
 
@@ -243,11 +247,10 @@ func (c Client) HasMinimumScopes(hostname string) (bool, error) {
 	}
 
 	if len(errorMsgs) > 0 {
-		return false, errors.New(strings.Join(errorMsgs, ";"))
+		return false, &MissingScopesError{error: errors.New(strings.Join(errorMsgs, ";"))}
 	}
 
 	return true, nil
-
 }
 
 // GraphQL performs a GraphQL request and parses the response

--- a/command/root.go
+++ b/command/root.go
@@ -25,6 +25,7 @@ import (
 	authCmd "github.com/cli/cli/pkg/cmd/auth"
 	authLoginCmd "github.com/cli/cli/pkg/cmd/auth/login"
 	authLogoutCmd "github.com/cli/cli/pkg/cmd/auth/logout"
+	authStatusCmd "github.com/cli/cli/pkg/cmd/auth/status"
 	gistCreateCmd "github.com/cli/cli/pkg/cmd/gist/create"
 	prCheckoutCmd "github.com/cli/cli/pkg/cmd/pr/checkout"
 	prDiffCmd "github.com/cli/cli/pkg/cmd/pr/diff"
@@ -140,6 +141,7 @@ func init() {
 	RootCmd.AddCommand(authCmd.Cmd)
 	authCmd.Cmd.AddCommand(authLoginCmd.NewCmdLogin(cmdFactory, nil))
 	authCmd.Cmd.AddCommand(authLogoutCmd.NewCmdLogout(cmdFactory, nil))
+	authCmd.Cmd.AddCommand(authStatusCmd.NewCmdStatus(cmdFactory, nil))
 
 	resolvedBaseRepo := func() (ghrepo.Interface, error) {
 		httpClient, err := cmdFactory.HttpClient()

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -8,11 +8,4 @@ var Cmd = &cobra.Command{
 	Use:   "auth <command>",
 	Short: "Login, logout, and refresh your authentication",
 	Long:  `Manage gh's authentication state.`,
-	// TODO this all doesn't exist yet
-	//Example: heredoc.Doc(`
-	//	$ gh auth login
-	//	$ gh auth status
-	//	$ gh auth refresh --scopes gist
-	//	$ gh auth logout
-	//`),
 }

--- a/pkg/cmd/auth/client/client.go
+++ b/pkg/cmd/auth/client/client.go
@@ -1,4 +1,4 @@
-package login
+package client
 
 import (
 	"fmt"
@@ -8,8 +8,8 @@ import (
 	"github.com/cli/cli/internal/config"
 )
 
-func validateHostCfg(hostname string, cfg config.Config) error {
-	apiClient, err := clientFromCfg(hostname, cfg)
+func ValidateHostCfg(hostname string, cfg config.Config) error {
+	apiClient, err := ClientFromCfg(hostname, cfg)
 	if err != nil {
 		return err
 	}
@@ -22,7 +22,7 @@ func validateHostCfg(hostname string, cfg config.Config) error {
 	return nil
 }
 
-var clientFromCfg = func(hostname string, cfg config.Config) (*api.Client, error) {
+var ClientFromCfg = func(hostname string, cfg config.Config) (*api.Client, error) {
 	var opts []api.ClientOption
 
 	token, err := cfg.Get(hostname, "oauth_token")

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/config"
 	"github.com/cli/cli/internal/ghinstance"
+	"github.com/cli/cli/pkg/cmd/auth/client"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
 	"github.com/cli/cli/pkg/prompt"
@@ -119,7 +120,7 @@ func loginRun(opts *LoginOptions) error {
 			return err
 		}
 
-		err = validateHostCfg(opts.Hostname, cfg)
+		err = client.ValidateHostCfg(opts.Hostname, cfg)
 		if err != nil {
 			return err
 		}
@@ -167,9 +168,9 @@ func loginRun(opts *LoginOptions) error {
 	existingToken, _ := cfg.Get(hostname, "oauth_token")
 
 	if existingToken != "" {
-		err := validateHostCfg(hostname, cfg)
+		err := client.ValidateHostCfg(hostname, cfg)
 		if err == nil {
-			apiClient, err := clientFromCfg(hostname, cfg)
+			apiClient, err := client.ClientFromCfg(hostname, cfg)
 			if err != nil {
 				return err
 			}
@@ -235,7 +236,7 @@ func loginRun(opts *LoginOptions) error {
 			return err
 		}
 
-		err = validateHostCfg(hostname, cfg)
+		err = client.ValidateHostCfg(hostname, cfg)
 		if err != nil {
 			return err
 		}
@@ -263,7 +264,7 @@ func loginRun(opts *LoginOptions) error {
 
 	fmt.Fprintf(opts.IO.ErrOut, "%s Configured git protocol\n", utils.GreenCheck())
 
-	apiClient, err := clientFromCfg(hostname, cfg)
+	apiClient, err := client.ClientFromCfg(hostname, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/pkg/cmd/auth/client"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/httpmock"
 	"github.com/cli/cli/pkg/iostreams"
@@ -252,11 +253,11 @@ func Test_loginRun_nontty(t *testing.T) {
 		tt.opts.IO = io
 		t.Run(tt.name, func(t *testing.T) {
 			reg := &httpmock.Registry{}
-			origClientFromCfg := clientFromCfg
+			origClientFromCfg := client.ClientFromCfg
 			defer func() {
-				clientFromCfg = origClientFromCfg
+				client.ClientFromCfg = origClientFromCfg
 			}()
-			clientFromCfg = func(_ string, _ config.Config) (*api.Client, error) {
+			client.ClientFromCfg = func(_ string, _ config.Config) (*api.Client, error) {
 				httpClient := &http.Client{Transport: reg}
 				return api.NewClientFromHTTP(httpClient), nil
 			}
@@ -397,11 +398,11 @@ func Test_loginRun_Survey(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			reg := &httpmock.Registry{}
-			origClientFromCfg := clientFromCfg
+			origClientFromCfg := client.ClientFromCfg
 			defer func() {
-				clientFromCfg = origClientFromCfg
+				client.ClientFromCfg = origClientFromCfg
 			}()
-			clientFromCfg = func(_ string, _ config.Config) (*api.Client, error) {
+			client.ClientFromCfg = func(_ string, _ config.Config) (*api.Client, error) {
 				httpClient := &http.Client{Transport: reg}
 				return api.NewClientFromHTTP(httpClient), nil
 			}

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -1,14 +1,103 @@
 package status
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
 )
 
 type StatusOptions struct {
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
 	Config     func() (config.Config, error)
+}
+
+func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Command {
+	opts := &StatusOptions{
+		HttpClient: f.HttpClient,
+		IO:         f.IOStreams,
+		Config:     f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Args:  cobra.ExactArgs(0),
+		Short: "View authentication status",
+		Long: heredoc.Doc(`Verifies and displays information about your authentication state.
+			
+			This command will test your authentication state for each GitHub host that gh knows about and
+			report on any issues.
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return statusRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+func statusRun(opts *StatusOptions) error {
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	stderr := opts.IO.ErrOut
+
+	hostnames, err := cfg.Hosts()
+	if len(hostnames) == 0 || err != nil {
+		fmt.Fprintf(stderr, "You are not logged into any GitHub hosts. Run 'gh auth login' to authenticate.\n")
+		return nil
+	}
+
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+	apiClient := api.NewClientFromHTTP(httpClient)
+
+	var failed bool
+
+	for _, hostname := range hostnames {
+		// what are the questions I'm trying to answer:
+		// - does the token work at all?
+		// - does it work but have the wrong scopes?
+		username, err := api.CurrentLoginName(apiClient, hostname)
+
+		_, err = apiClient.HasMinimumScopes(hostname)
+		if err != nil {
+			var missingScopes *api.MissingScopesError
+			if errors.As(err, &missingScopes) {
+				fmt.Fprintf(stderr, "%s %s: %s\n", utils.Red("X"), hostname, err)
+			} else {
+				fmt.Fprintf(stderr, "%s %s: authentication failed\n", utils.Red("X"), hostname)
+			}
+			failed = true
+		} else {
+			fmt.Fprintf(stderr, "%s Logged into %s as %s\n", utils.GreenCheck(), hostname, utils.Bold(username))
+		}
+
+		// NB we could take this opportunity to add or fix the "user" key in the hosts config. I chose
+		// not to since I wanted this command to be read-only.
+	}
+
+	if failed {
+		// TODO unsure about this; want non-zero exit but don't need to print anything more. Is the
+		// non-zero exit worth it? Should we tweak error handling to not print "" errors?
+		return errors.New("")
+	}
+
+	return nil
 }

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -1,0 +1,14 @@
+package status
+
+import (
+	"net/http"
+
+	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/pkg/iostreams"
+)
+
+type StatusOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	Config     func() (config.Config, error)
+}


### PR DESCRIPTION
package api

import (
	"bytes"
	"encoding/json"
	"errors"
	"fmt"
	"io"
	"io/ioutil"
	"net/http"
	"net/url"
	"regexp"
	"strings"

	"github.com/cli/cli/internal/ghinstance"
	"github.com/henvic/httpretty"
	"github.com/shurcooL/graphql"
)

// ClientOption represents an argument to NewClient
type ClientOption = func(http.RoundTripper) http.RoundTripper

// NewHTTPClient initializes an http.Client
func NewHTTPClient(opts ...ClientOption) *http.Client {
	tr := http.DefaultTransport
	for _, opt := range opts {
		tr = opt(tr)
	}
	return &http.Client{Transport: tr}
}

// NewClient initializes a Client
func NewClient(opts ...ClientOption) *Client {
	client := &Client{http: NewHTTPClient(opts...)}
	return client
}

// NewClientFromHTTP takes in an http.Client instance
func NewClientFromHTTP(httpClient *http.Client) *Client {
	client := &Client{http: httpClient}
	return client
}

// AddHeader turns a RoundTripper into one that adds a request header
func AddHeader(name, value string) ClientOption {
	return func(tr http.RoundTripper) http.RoundTripper {
		return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
			req.Header.Add(name, value)
			return tr.RoundTrip(req)
		}}
	}
}

// AddHeaderFunc is an AddHeader that gets the string value from a function
func AddHeaderFunc(name string, getValue func(*http.Request) (string, error)) ClientOption {
	return func(tr http.RoundTripper) http.RoundTripper {
		return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
			value, err := getValue(req)
			if err != nil {
				return nil, err
			}
			req.Header.Add(name, value)
			return tr.RoundTrip(req)
		}}
	}
}

// VerboseLog enables request/response logging within a RoundTripper
func VerboseLog(out io.Writer, logTraffic bool, colorize bool) ClientOption {
	logger := &httpretty.Logger{
		Time:           true,
		TLS:            false,
		Colors:         colorize,
		RequestHeader:  logTraffic,
		RequestBody:    logTraffic,
		ResponseHeader: logTraffic,
		ResponseBody:   logTraffic,
		Formatters:     []httpretty.Formatter{&httpretty.JSONFormatter{}},
	}
	logger.SetOutput(out)
	logger.SetBodyFilter(func(h http.Header) (skip bool, err error) {
		return !inspectableMIMEType(h.Get("Content-Type")), nil
	})
	return logger.RoundTripper
}

// ReplaceTripper substitutes the underlying RoundTripper with a custom one
func ReplaceTripper(tr http.RoundTripper) ClientOption {
	return func(http.RoundTripper) http.RoundTripper {
		return tr
	}
}

var issuedScopesWarning bool

const (
	httpOAuthAppID  = "X-Oauth-Client-Id"
	httpOAuthScopes = "X-Oauth-Scopes"
)

// CheckScopes checks whether an OAuth scope is present in a response
func CheckScopes(wantedScope string, cb func(string) error) ClientOption {
	wantedCandidates := []string{wantedScope}
	if strings.HasPrefix(wantedScope, "read:") {
		wantedCandidates = append(wantedCandidates, "admin:"+strings.TrimPrefix(wantedScope, "read:"))
	}

	return func(tr http.RoundTripper) http.RoundTripper {
		return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
			res, err := tr.RoundTrip(req)
			if err != nil || res.StatusCode > 299 || issuedScopesWarning {
				return res, err
			}

			_, hasHeader := res.Header[httpOAuthAppID]
			if !hasHeader {
				return res, nil
			}

			appID := res.Header.Get(httpOAuthAppID)
			hasScopes := strings.Split(res.Header.Get(httpOAuthScopes), ",")

			hasWanted := false
		outer:
			for _, s := range hasScopes {
				for _, w := range wantedCandidates {
					if w == strings.TrimSpace(s) {
						hasWanted = true
						break outer
					}
				}
			}

			if !hasWanted {
				if err := cb(appID); err != nil {
					return res, err
				}
				issuedScopesWarning = true
			}

			return res, nil
		}}
	}
}

type funcTripper struct {
	roundTrip func(*http.Request) (*http.Response, error)
}

func (tr funcTripper) RoundTrip(req *http.Request) (*http.Response, error) {
	return tr.roundTrip(req)
}

// Client facilitates making HTTP requests to the GitHub API
type Client struct {
	http *http.Client
}

type graphQLResponse struct {
	Data   interface{}
	Errors []GraphQLError
}

// GraphQLError is a single error returned in a GraphQL response
type GraphQLError struct {
	Type    string
	Path    []string
	Message string
}

// GraphQLErrorResponse contains errors returned in a GraphQL response
type GraphQLErrorResponse struct {
	Errors []GraphQLError
}

func (gr GraphQLErrorResponse) Error() string {
	errorMessages := make([]string, 0, len(gr.Errors))
	for _, e := range gr.Errors {
		errorMessages = append(errorMessages, e.Message)
	}
	return fmt.Sprintf("GraphQL error: %s", strings.Join(errorMessages, "\n"))
}

// HTTPError is an error returned by a failed API call
type HTTPError struct {
	StatusCode  int
	RequestURL  *url.URL
	Message     string
	OAuthScopes string
}

func (err HTTPError) Error() string {
	if err.Message != "" {
		return fmt.Sprintf("HTTP %d: %s (%s)", err.StatusCode, err.Message, err.RequestURL)
	}
	return fmt.Sprintf("HTTP %d (%s)", err.StatusCode, err.RequestURL)
}

type MissingScopesError struct {
	error
}

func (c Client) HasMinimumScopes(hostname string) (bool, error) {
	apiEndpoint := ghinstance.RESTPrefix(hostname)

	req, err := http.NewRequest("GET", apiEndpoint, nil)
	if err != nil {
		return false, err
	}

	req.Header.Set("Content-Type", "application/json; charset=utf-8")
	res, err := c.http.Do(req)
	if err != nil {
		return false, err
	}

	defer func() {
		// Ensure the response body is fully read and closed
		// before we reconnect, so that we reuse the same TCPconnection.
		_, _ = io.Copy(ioutil.Discard, res.Body)
		res.Body.Close()
	}()

	if res.StatusCode != 200 {
		return false, handleHTTPError(res)
	}

	hasScopes := strings.Split(res.Header.Get("X-Oauth-Scopes"), ",")

	search := map[string]bool{
		"repo":      false,
		"read:org":  false,
		"admin:org": false,
	}

	for _, s := range hasScopes {
		search[strings.TrimSpace(s)] = true
	}

	errorMsgs := []string{}
	if !search["repo"] {
		errorMsgs = append(errorMsgs, "missing required scope 'repo'")
	}

	if !search["read:org"] && !search["admin:org"] {
		errorMsgs = append(errorMsgs, "missing required scope 'read:org'")
	}

	if len(errorMsgs) > 0 {
		return false, &MissingScopesError{error: errors.New(strings.Join(errorMsgs, ";"))}
	}

	return true, nil
}

// GraphQL performs a GraphQL request and parses the response
func (c Client) GraphQL(hostname string, query string, variables map[string]interface{}, data interface{}) error {
	reqBody, err := json.Marshal(map[string]interface{}{"query": query, "variables": variables})
	if err != nil {
		return err
	}

	req, err := http.NewRequest("POST", ghinstance.GraphQLEndpoint(hostname), bytes.NewBuffer(reqBody))
	if err != nil {
		return err
	}

	req.Header.Set("Content-Type", "application/json; charset=utf-8")

	resp, err := c.http.Do(req)
	if err != nil {
		return err
	}
	defer resp.Body.Close()

	return handleResponse(resp, data)
}

func graphQLClient(h *http.Client, hostname string) *graphql.Client {
	return graphql.NewClient(ghinstance.GraphQLEndpoint(hostname), h)
}

// REST performs a REST request and parses the response.
func (c Client) REST(hostname string, method string, p string, body io.Reader, data interface{}) error {
	url := ghinstance.RESTPrefix(hostname) + p
	req, err := http.NewRequest(method, url, body)
	if err != nil {
		return err
	}

	req.Header.Set("Content-Type", "application/json; charset=utf-8")

	resp, err := c.http.Do(req)
	if err != nil {
		return err
	}
	defer resp.Body.Close()

	success := resp.StatusCode >= 200 && resp.StatusCode < 300
	if !success {
		return handleHTTPError(resp)
	}

	if resp.StatusCode == http.StatusNoContent {
		return nil
	}

	b, err := ioutil.ReadAll(resp.Body)
	if err != nil {
		return err
	}

	err = json.Unmarshal(b, &data)
	if err != nil {
		return err
	}

	return nil
}

func handleResponse(resp *http.Response, data interface{}) error {
	success := resp.StatusCode >= 200 && resp.StatusCode < 300

	if !success {
		return handleHTTPError(resp)
	}

	body, err := ioutil.ReadAll(resp.Body)
	if err != nil {
		return err
	}

	gr := &graphQLResponse{Data: data}
	err = json.Unmarshal(body, &gr)
	if err != nil {
		return err
	}

	if len(gr.Errors) > 0 {
		return &GraphQLErrorResponse{Errors: gr.Errors}
	}
	return nil
}

func handleHTTPError(resp *http.Response) error {
	httpError := HTTPError{
		StatusCode:  resp.StatusCode,
		RequestURL:  resp.Request.URL,
		OAuthScopes: resp.Header.Get("X-Oauth-Scopes"),
	}

	body, err := ioutil.ReadAll(resp.Body)
	if err != nil {
		httpError.Message = err.Error()
		return httpError
	}

	var parsedBody struct {
		Message string `json:"message"`
	}
	if err := json.Unmarshal(body, &parsedBody); err == nil {
		httpError.Message = parsedBody.Message
	}

	return httpError
}

var jsonTypeRE = regexp.MustCompile(`[/+]json($|;)`)

func inspectableMIMEType(t string) bool {
	return strings.HasPrefix(t, "text/") || jsonTypeRE.MatchString(t)
}