### PR TITLE
Number and URL included in scriptable output

### DIFF
--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -48,7 +48,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 
 			Without an argument, the pull request that belongs to the current branch
 			is displayed.
-			
+
 			With '--web', open the pull request in a web browser instead.
     	`),
 		Args: cobra.MaximumNArgs(1),
@@ -114,6 +114,8 @@ func printRawPrPreview(out io.Writer, pr *api.PullRequest) error {
 	fmt.Fprintf(out, "reviewers:\t%s\n", reviewers)
 	fmt.Fprintf(out, "projects:\t%s\n", projects)
 	fmt.Fprintf(out, "milestone:\t%s\n", pr.Milestone.Title)
+	fmt.Fprintf(out, "number:\t%d\n", pr.Number)
+	fmt.Fprintf(out, "url:\t%s\n", pr.URL)
 
 	fmt.Fprintln(out, "--")
 	fmt.Fprintln(out, pr.Body)

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -97,6 +97,8 @@ func TestPRView_Preview_nontty(t *testing.T) {
 				`reviewers:\t\n`,
 				`projects:\t\n`,
 				`milestone:\t\n`,
+				`url:\thttps://github.com/OWNER/REPO/pull/12\n`,
+				`number:\t12\n`,
 				`blueberries taste good`,
 			},
 		},


### PR DESCRIPTION
Adds the PR number and the PR URL in the output provided to non-TTY outputs.

Closes #1532

<details open><summary>Example on this PR</summary>

```
title:	Number and URL included in scriptable output
state:	OPEN
author:	dan1elhughes
labels:	
assignees:	
reviewers:	
projects:	
milestone:	
number:	1580
url:	https://github.com/cli/cli/pull/1580
--
Adds the PR number and the PR URL in the output provided to non-TTY outputs.

Closes #1532
```
</details>