### PR TITLE
[Feature] Create repositories from a template repo

### DIFF
--- a/api/queries_user.go
+++ b/api/queries_user.go
@@ -14,3 +14,14 @@ func CurrentLoginName(client *Client, hostname string) (string, error) {
 	err := gql.QueryNamed(context.Background(), "UserCurrent", &query, nil)
 	return query.Viewer.Login, err
 }
+
+func CurrentUserID(client *Client, hostname string) (string, error) {
+	var query struct {
+		Viewer struct {
+			ID string
+		}
+	}
+	gql := graphQLClient(client.http, hostname)
+	err := gql.QueryNamed(context.Background(), "UserCurrent", &query, nil)
+	return query.Viewer.ID, err
+}

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -78,7 +78,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			}
 
 			if opts.Template != "" && (opts.Homepage != "" || opts.Team != "" || !opts.EnableIssues || !opts.EnableWiki) {
-				return &cmdutil.FlagError{Err: errors.New(`the '--template' option is not supported with '--homepage, --team, --enable-issues or --enable-wiki'`)}
+				return &cmdutil.FlagError{Err: errors.New(`The '--template' option is not supported with '--homepage, --team, --enable-issues or --enable-wiki'`)}
 			}
 
 			return createRun(opts)
@@ -173,8 +173,7 @@ func createRun(opts *CreateOptions) error {
 		}
 	}
 
-	// find template ID
-
+	// Find template repo ID
 	if opts.Template != "" {
 		httpClient, err := opts.HttpClient()
 		if err != nil {
@@ -210,7 +209,6 @@ func createRun(opts *CreateOptions) error {
 		Visibility:       visibility,
 		OwnerID:          repoToCreate.RepoOwner(),
 		TeamID:           opts.Team,
-		RepositoryID:     opts.Template,
 		Description:      opts.Description,
 		HomepageURL:      opts.Homepage,
 		HasIssuesEnabled: opts.EnableIssues,
@@ -231,7 +229,7 @@ func createRun(opts *CreateOptions) error {
 	}
 
 	if opts.ConfirmSubmit {
-		repo, err := repoCreate(httpClient, repoToCreate.RepoHost(), input)
+		repo, err := repoCreate(httpClient, repoToCreate.RepoHost(), input, opts.Template)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -181,24 +181,23 @@ func createRun(opts *CreateOptions) error {
 			return err
 		}
 
-		var toView ghrepo.Interface
+		var toClone ghrepo.Interface
 		apiClient := api.NewClientFromHTTP(httpClient)
 
-		// var err errors
-		viewURL := opts.Template
-		if !strings.Contains(viewURL, "/") {
+		cloneURL := opts.Template
+		if !strings.Contains(cloneURL, "/") {
 			currentUser, err := api.CurrentLoginName(apiClient, ghinstance.Default())
 			if err != nil {
 				return err
 			}
-			viewURL = currentUser + "/" + viewURL
+			cloneURL = currentUser + "/" + cloneURL
 		}
-		toView, err = ghrepo.FromFullName(viewURL)
+		toClone, err = ghrepo.FromFullName(cloneURL)
 		if err != nil {
 			return fmt.Errorf("argument error: %w", err)
 		}
 
-		repo, err := api.GitHubRepo(apiClient, toView)
+		repo, err := api.GitHubRepo(apiClient, toClone)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"path"
@@ -74,6 +75,10 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			if runF != nil {
 				return runF(opts)
+			}
+
+			if opts.Template != "" && (opts.Homepage != "" || opts.Team != "" || !opts.EnableIssues || !opts.EnableWiki) {
+				return &cmdutil.FlagError{Err: errors.New(`the '--template' option is not supported with '--homepage, --team, --enable-issues or --enable-wiki'`)}
 			}
 
 			return createRun(opts)

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -379,7 +379,7 @@ func TestRepoCreate_template(t *testing.T) {
 	}
 
 	if len(reg.Requests) != 3 {
-		t.Fatalf("expected 3 HTTP request, got %d", len(reg.Requests))
+		t.Fatalf("expected 3 HTTP requests, got %d", len(reg.Requests))
 	}
 
 	bodyBytes, _ := ioutil.ReadAll(reg.Requests[2].Body)

--- a/pkg/cmd/repo/create/http.go
+++ b/pkg/cmd/repo/create/http.go
@@ -29,6 +29,7 @@ type repoTemplateInput struct {
 	OwnerID    string `json:"ownerId,omitempty"`
 
 	RepositoryID string `json:"repositoryId,omitempty"`
+	Description  string `json:"description,omitempty"`
 }
 
 // repoCreate creates a new GitHub repository

--- a/pkg/cmd/repo/create/http.go
+++ b/pkg/cmd/repo/create/http.go
@@ -14,8 +14,6 @@ type repoCreateInput struct {
 	HomepageURL string `json:"homepageUrl,omitempty"`
 	Description string `json:"description,omitempty"`
 
-	RepositoryID string `json:"repositoryId,omitempty"`
-
 	OwnerID string `json:"ownerId,omitempty"`
 	TeamID  string `json:"teamId,omitempty"`
 
@@ -33,7 +31,7 @@ type repoTemplateInput struct {
 }
 
 // repoCreate creates a new GitHub repository
-func repoCreate(client *http.Client, hostname string, input repoCreateInput) (*api.Repository, error) {
+func repoCreate(client *http.Client, hostname string, input repoCreateInput, templateRepositoryID string) (*api.Repository, error) {
 	apiClient := api.NewClientFromHTTP(client)
 
 	if input.TeamID != "" {
@@ -51,7 +49,7 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput) (*a
 		input.OwnerID = orgID
 	}
 
-	if input.RepositoryID != "" {
+	if templateRepositoryID != "" {
 		var response struct {
 			CloneTemplateRepository struct {
 				Repository api.Repository
@@ -70,7 +68,7 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput) (*a
 			Name:         input.Name,
 			Visibility:   input.Visibility,
 			OwnerID:      input.OwnerID,
-			RepositoryID: input.RepositoryID,
+			RepositoryID: templateRepositoryID,
 		}
 
 		variables := map[string]interface{}{

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -21,7 +21,7 @@ func Test_RepoCreate(t *testing.T) {
 		HomepageURL: "http://example.com",
 	}
 
-	_, err := repoCreate(httpClient, "github.com", input)
+	_, err := repoCreate(httpClient, "github.com", input, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
Closes https://github.com/cli/cli/issues/1578

In this PR, I added functionality to use the following command to create a new repo from a template:

`gh repo create <new-repo-name> --template="<link-to-template-repo> OR <owner/template-repo>"`

## Changes
I used the `cloneTemplateRepository` mutation from the public GraphQL API to achieve this functionality. You can read more about it here: [GraphQL Docs](https://docs.github.com/en/graphql/reference/mutations#clonetemplaterepository)

A limitation of using this mutation is that it does not fully support all of the inputs that the `createRepository` mutation does. Therefore, I had to add some ad-hoc input processing to warn the user about passing incompatible flags with `--template`.

This seemed to be the most straightforward approach, as we do not want to modify the `createRepository` mutation to support this existing functionality.

## Example

```Shell
$ gh repo create hello_world --template username/template-example --homepage="example.com"
the '--template' option is not supported with '--homepage, --team, --enable-issues or --enable-wiki'
```

Note: `--enable-wiki="true"` or `--enable-issues="true"` will not throw an error, as those are repo defaults. However, if you pass `false`, it will raise this `FlagError`.

## Demo

![ScreenFlow](https://user-images.githubusercontent.com/11053683/91505162-ee5f8100-e89c-11ea-964b-3a0a429154ff.gif)

## Checklist

- [x] Basic Functionality
- [x] Error Handling
- [x] Tests