### PR TITLE
Remove reference to feedback form

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -38,7 +38,6 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 		`),
 		Annotations: map[string]string{
 			"help:feedback": heredoc.Doc(`
-				Fill out our feedback form https://forms.gle/umxd3h31c7aMQFKG7
 				Open an issue using “gh issue create -R cli/cli”
 			`),
 			"help:environment": heredoc.Doc(`


### PR DESCRIPTION
This PR removes the `help` command's reference to the feedback form that is no longer is use. Preferring to receive feedback using issues in this repository.

Before: 
<img width="639" alt="Screen Shot 2020-08-28 at 9 14 27 AM" src="https://user-images.githubusercontent.com/7969779/91532709-f6580900-e90e-11ea-9cc7-0be7b6bee83d.png">

After:
<img width="655" alt="Screen Shot 2020-08-28 at 9 13 54 AM" src="https://user-images.githubusercontent.com/7969779/91532719-fa842680-e90e-11ea-8f26-7cc00cc38e0c.png">

cc https://github.com/cli/cli/issues/1586