### PR TITLE
Clarify our Go version requirements

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,8 @@ Please avoid:
 ## Building the project
 
 Prerequisites:
-- Go 1.14
+- Go 1.13+ for building the binary
+- Go 1.14+ for running the test suite
 
 Build with: `make` or `go build -o bin/gh ./cmd/gh`
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,3 +25,18 @@ jobs:
 
       - name: Build
         run: go build -v ./cmd/gh
+
+  build-minimum:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.13
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: go build -v ./cmd/gh

--- a/docs/source.md
+++ b/docs/source.md
@@ -1,10 +1,9 @@
 # Installation from source
 
-0. Verify that you have Go 1.15+ installed
+0. Verify that you have Go 1.13+ installed
 
    ```sh
    $ go version
-   go version go1.14
    ```
 
    If `go` is not installed, follow instructions on [the Go website](https://golang.org/doc/install).


### PR DESCRIPTION
* We are trying to keep the binary building on Go 1.13 to support building the project on Ubuntu 20.04 LTS #1317
* Go 1.14+ is required to run the test suite
* We build our releases on Go 1.15 https://github.com/cli/cli/issues/1518#issuecomment-673428328

This adds a CI check that verifies that the project at least compiles on Go 1.13.

Closes #1595