### PR TITLE
Remove feedback survey from README

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 [license]: ../LICENSE
 [code-of-conduct]: CODE-OF-CONDUCT.md
 [bug issues]: https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+label%3Abug
-[feature request issues]: https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+label%3A+label%3Aenhancement
+[feature request issues]: https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement
 
 Hi! Thanks for your interest in contributing to the GitHub CLI!
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,6 +3,8 @@
 [legal]: https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
 [license]: ../LICENSE
 [code-of-conduct]: CODE-OF-CONDUCT.md
+[bug issues]: https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+label%3Abug
+[feature request issues]: https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+label%3A+label%3Aenhancement
 
 Hi! Thanks for your interest in contributing to the GitHub CLI!
 
@@ -10,7 +12,7 @@ We accept pull requests for bug fixes and features where we've discussed the app
 
 Please do:
 
-* check existing issues to verify that the bug or feature request has not already been submitted
+* check existing issues to verify that the [bug][bug issues] or [feature request][feature request issues] has not already been submitted
 * open an issue if things aren't working as expected
 * open an issue to propose a significant change
 * open a pull request to fix a bug

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,6 +10,7 @@ We accept pull requests for bug fixes and features where we've discussed the app
 
 Please do:
 
+* check existing issues to verify that the bug or feature request has not already been submitted
 * open an issue if things aren't working as expected
 * open an issue to propose a significant change
 * open a pull request to fix a bug

--- a/README.md
+++ b/README.md
@@ -9,13 +9,9 @@ the terminal next to where you are already working with `git` and your code.
 
 While in beta, GitHub CLI is available for repos hosted on GitHub.com only. It currently does not support repositories hosted on GitHub Enterprise Server or other hosting providers. We are planning on adding support for GitHub Enterprise Server after GitHub CLI is out of beta (likely towards the end of 2020), and we want to ensure that the API endpoints we use are more widely available for GHES versions that most GitHub customers are on.
 
-## We need your feedback
+## Feedback
 
-GitHub CLI is currently in its early development stages, and we're hoping to get feedback from people using it.
-
-If you've installed and used `gh`, we'd love for you to take a short survey here (no more than five minutes): https://forms.gle/umxd3h31c7aMQFKG7
-
-And if you spot bugs or have features that you'd really like to see in `gh`, please check out the [contributing page][]
+We love to hear feedback about `gh`. If you spot bugs or have features that you'd really like to see in `gh`, please check out the [contributing page][].
 
 ## Usage
 
@@ -128,7 +124,7 @@ Install and upgrade:
 Install and upgrade:
 
 1. Download the `.rpm` file from the [releases page][];
-2. Install the downloaded file: `sudo yum localinstall gh_*_linux_amd64.rpm` 
+2. Install the downloaded file: `sudo yum localinstall gh_*_linux_amd64.rpm`
 
 ### openSUSE/SUSE Linux
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ While in beta, GitHub CLI is available for repos hosted on GitHub.com only. It c
 
 ## We want your feedback
 
-We'd love to hear your feedback about `gh`. If you spot bugs or have features that you'd really like to see in `gh`, please open an [issue][] and check out the [contributing page][].
+We'd love to hear your feedback about `gh`. If you spot bugs or have features that you'd really like to see in `gh`, please check out the [contributing page][].
 
 ## Usage
 
@@ -30,7 +30,7 @@ Read the [official docs][] for more information.
 For many years, [hub][] was the unofficial GitHub CLI tool. `gh` is a new project that helps us explore
 what an official GitHub CLI tool can look like with a fundamentally different design. While both
 tools bring GitHub to the terminal, `hub` behaves as a proxy to `git`, and `gh` is a standalone
-tool. Check out our [more detailed explanation][] to learn more.
+tool. Check out our [more detailed explanation][gh-vs-hub] to learn more.
 
 
 <!-- this anchor is linked to from elsewhere, so avoid renaming it -->
@@ -135,7 +135,7 @@ Install and upgrade:
 
 ### Arch Linux
 
-Arch Linux users can install from the [community repo][]:
+Arch Linux users can install from the [community repo][arch linux repo]:
 
 ```bash
 pacman -S github-cli
@@ -155,7 +155,7 @@ Download packaged binaries from the [releases page][].
 
 ### Build from source
 
-See here on how to [build GitHub CLI from source][].
+See here on how to [build GitHub CLI from source][build from source].
 
 [official docs]: https://cli.github.com/manual
 [scoop]: https://scoop.sh
@@ -163,7 +163,6 @@ See here on how to [build GitHub CLI from source][].
 [releases page]: https://github.com/cli/cli/releases/latest
 [hub]: https://github.com/github/hub
 [contributing page]: https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md
-[issue]: https://github.com/cli/cli/issues/new/choose
-[more detailed explanation]: /docs/gh-vs-hub.md
-[community repo]: https://www.archlinux.org/packages/community/x86_64/github-cli/
-[build GitHub CLI from source]: /docs/source.md
+[gh-vs-hub]: /docs/gh-vs-hub.md
+[arch linux repo]: https://www.archlinux.org/packages/community/x86_64/github-cli
+[build from source]: /docs/source.md

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ the terminal next to where you are already working with `git` and your code.
 
 While in beta, GitHub CLI is available for repos hosted on GitHub.com only. It currently does not support repositories hosted on GitHub Enterprise Server or other hosting providers. We are planning on adding support for GitHub Enterprise Server after GitHub CLI is out of beta (likely towards the end of 2020), and we want to ensure that the API endpoints we use are more widely available for GHES versions that most GitHub customers are on.
 
-## Feedback
+## We want your feedback
 
-We love to hear feedback about `gh`. If you spot bugs or have features that you'd really like to see in `gh`, please check out the [contributing page][].
+We'd love to hear your feedback about `gh`. If you spot bugs or have features that you'd really like to see in `gh`, please open an [issue][] and check out the [contributing page][].
 
 ## Usage
 
@@ -23,14 +23,14 @@ We love to hear feedback about `gh`. If you spot bugs or have features that you'
 
 ## Documentation
 
-Read the [official docs](https://cli.github.com/manual/) for more information.
+Read the [official docs][] for more information.
 
 ## Comparison with hub
 
 For many years, [hub][] was the unofficial GitHub CLI tool. `gh` is a new project that helps us explore
 what an official GitHub CLI tool can look like with a fundamentally different design. While both
 tools bring GitHub to the terminal, `hub` behaves as a proxy to `git`, and `gh` is a standalone
-tool. Check out our [more detailed explanation](/docs/gh-vs-hub.md) to learn more.
+tool. Check out our [more detailed explanation][] to learn more.
 
 
 <!-- this anchor is linked to from elsewhere, so avoid renaming it -->
@@ -135,7 +135,7 @@ Install and upgrade:
 
 ### Arch Linux
 
-Arch Linux users can install from the [community repo](https://www.archlinux.org/packages/community/x86_64/github-cli/):
+Arch Linux users can install from the [community repo][]:
 
 ```bash
 pacman -S github-cli
@@ -155,11 +155,15 @@ Download packaged binaries from the [releases page][].
 
 ### Build from source
 
-See here on how to [build GitHub CLI from source](/docs/source.md).
+See here on how to [build GitHub CLI from source][].
 
-[docs]: https://cli.github.com/manual
+[official docs]: https://cli.github.com/manual
 [scoop]: https://scoop.sh
 [Chocolatey]: https://chocolatey.org
 [releases page]: https://github.com/cli/cli/releases/latest
 [hub]: https://github.com/github/hub
 [contributing page]: https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md
+[issue]: https://github.com/cli/cli/issues/new/choose
+[more detailed explanation]: /docs/gh-vs-hub.md
+[community repo]: https://www.archlinux.org/packages/community/x86_64/github-cli/
+[build GitHub CLI from source]: /docs/source.md


### PR DESCRIPTION
This PR updates the README doc to remove the feedback survey. I also cleans up the links in README to all follow the link reference definition pattern. Lastly, it adds instructions to check existing issues for bugs/feature requests before opening a new issue.

cc https://github.com/cli/cli/issues/1586