### PR TITLE
Be transparent about which part of `pr create` flow failed

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -683,7 +683,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 		}
 		err := client.GraphQL(repo.RepoHost(), updateQuery, variables, &result)
 		if err != nil {
-			return nil, err
+			return pr, err
 		}
 	}
 
@@ -708,7 +708,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 		}
 		err := client.GraphQL(repo.RepoHost(), reviewQuery, variables, &result)
 		if err != nil {
-			return nil, err
+			return pr, err
 		}
 	}
 

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -366,11 +366,15 @@ func createRun(opts *CreateOptions) error {
 		}
 
 		pr, err := api.CreatePullRequest(client, baseRepo, params)
-		if err != nil {
-			return fmt.Errorf("failed to create pull request: %w", err)
+		if pr != nil {
+			fmt.Fprintln(opts.IO.Out, pr.URL)
 		}
-
-		fmt.Fprintln(opts.IO.Out, pr.URL)
+		if err != nil {
+			if pr != nil {
+				return fmt.Errorf("pull request update failed: %w", err)
+			}
+			return fmt.Errorf("pull request create failed: %w", err)
+		}
 	} else if action == shared.PreviewAction {
 		openURL, err := generateCompareURL(baseRepo, baseBranch, headBranchLabel, title, body, tb.Assignees, tb.Labels, tb.Projects, tb.Milestones)
 		if err != nil {


### PR DESCRIPTION
When applying metadata to the new PR such as assignees or reviewers, if the operation fails, an error message would get printed:

    failed to create pull request: <API error text>

This was misleading, because the PR did get created; it's just that updating it failed. The new error message is:

    https://github.com/OWNER/REPO/pull/123
    pull request update failed: <API error text>

The PR URL is printed on stdout and the error message is printed on stderr. In case of any errors, the exit code is still non-zero.

Fixes #1576