### PR TITLE
Handle HTTP 422 response to OAuth Device flow detection

### DIFF
--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -69,7 +69,7 @@ func (oa *OAuthFlow) ObtainAccessToken() (accessToken string, err error) {
 		}
 	}
 
-	if resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 404 ||
+	if resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 404 || resp.StatusCode == 422 ||
 		(resp.StatusCode == 400 && values != nil && values.Get("error") == "unauthorized_client") {
 		// OAuth Device Flow is not available; continue with OAuth browser flow with a
 		// local server endpoint as callback target

--- a/internal/config/config_setup.go
+++ b/internal/config/config_setup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cli/cli/auth"
 	"github.com/cli/cli/pkg/browser"
 	"github.com/cli/cli/utils"
+	"github.com/mattn/go-colorable"
 )
 
 var (
@@ -29,7 +30,9 @@ func IsGitHubApp(id string) bool {
 }
 
 func AuthFlowWithConfig(cfg Config, hostname, notice string, additionalScopes []string) (string, error) {
-	token, userLogin, err := authFlow(hostname, notice, additionalScopes)
+	stderr := colorable.NewColorableStderr()
+
+	token, userLogin, err := authFlow(hostname, stderr, notice, additionalScopes)
 	if err != nil {
 		return "", err
 	}
@@ -48,14 +51,17 @@ func AuthFlowWithConfig(cfg Config, hostname, notice string, additionalScopes []
 		return "", err
 	}
 
-	AuthFlowComplete()
+	fmt.Fprintf(stderr, "%s Authentication complete. %s to continue...\n",
+		utils.GreenCheck(), utils.Bold("Press Enter"))
+	_ = waitForEnter(os.Stdin)
+
 	return token, nil
 }
 
-func authFlow(oauthHost, notice string, additionalScopes []string) (string, string, error) {
+func authFlow(oauthHost string, w io.Writer, notice string, additionalScopes []string) (string, string, error) {
 	var verboseStream io.Writer
 	if strings.Contains(os.Getenv("DEBUG"), "oauth") {
-		verboseStream = os.Stderr
+		verboseStream = w
 	}
 
 	minimumScopes := []string{"repo", "read:org", "gist"}
@@ -73,9 +79,9 @@ func authFlow(oauthHost, notice string, additionalScopes []string) (string, stri
 		HTTPClient:    http.DefaultClient,
 		OpenInBrowser: func(url, code string) error {
 			if code != "" {
-				fmt.Fprintf(os.Stderr, "%s First copy your one-time code: %s\n", utils.Yellow("!"), utils.Bold(code))
+				fmt.Fprintf(w, "%s First copy your one-time code: %s\n", utils.Yellow("!"), utils.Bold(code))
 			}
-			fmt.Fprintf(os.Stderr, "- %s to open %s in your browser... ", utils.Bold("Press Enter"), oauthHost)
+			fmt.Fprintf(w, "- %s to open %s in your browser... ", utils.Bold("Press Enter"), oauthHost)
 			_ = waitForEnter(os.Stdin)
 
 			browseCmd, err := browser.Command(url)
@@ -84,15 +90,15 @@ func authFlow(oauthHost, notice string, additionalScopes []string) (string, stri
 			}
 			err = browseCmd.Run()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "%s Failed opening a web browser at %s\n", utils.Red("!"), url)
-				fmt.Fprintf(os.Stderr, "  %s\n", err)
-				fmt.Fprint(os.Stderr, "  Please try entering the URL in your browser manually\n")
+				fmt.Fprintf(w, "%s Failed opening a web browser at %s\n", utils.Red("!"), url)
+				fmt.Fprintf(w, "  %s\n", err)
+				fmt.Fprint(w, "  Please try entering the URL in your browser manually\n")
 			}
 			return nil
 		},
 	}
 
-	fmt.Fprintln(os.Stderr, notice)
+	fmt.Fprintln(w, notice)
 
 	token, err := flow.ObtainAccessToken()
 	if err != nil {
@@ -105,12 +111,6 @@ func authFlow(oauthHost, notice string, additionalScopes []string) (string, stri
 	}
 
 	return token, userLogin, nil
-}
-
-func AuthFlowComplete() {
-	fmt.Fprintf(os.Stderr, "%s Authentication complete. %s to continue...\n",
-		utils.GreenCheck(), utils.Bold("Press Enter"))
-	_ = waitForEnter(os.Stdin)
 }
 
 func getViewer(hostname, token string) (string, error) {

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -262,7 +262,7 @@ func loginRun(opts *LoginOptions) error {
 
 	gitProtocol = strings.ToLower(gitProtocol)
 
-	fmt.Fprintf(opts.IO.ErrOut, "- gh config set -h%s git_protocol %s\n", hostname, gitProtocol)
+	fmt.Fprintf(opts.IO.ErrOut, "- gh config set -h %s git_protocol %s\n", hostname, gitProtocol)
 	err = cfg.Set(hostname, "git_protocol", gitProtocol)
 	if err != nil {
 		return err

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -156,7 +156,7 @@ func loginRun(opts *LoginOptions) error {
 		if isEnterprise {
 			err := prompt.SurveyAskOne(&survey.Input{
 				Message: "GHE hostname:",
-			}, &hostname, survey.WithValidator(survey.Required))
+			}, &hostname, survey.WithValidator(hostnameValidator))
 			if err != nil {
 				return fmt.Errorf("could not prompt: %w", err)
 			}
@@ -286,5 +286,16 @@ func loginRun(opts *LoginOptions) error {
 
 	fmt.Fprintf(opts.IO.ErrOut, "%s Logged in as %s\n", utils.GreenCheck(), utils.Bold(username))
 
+	return nil
+}
+
+func hostnameValidator(v interface{}) error {
+	val := v.(string)
+	if len(strings.TrimSpace(val)) < 1 {
+		return errors.New("a value is required")
+	}
+	if strings.ContainsRune(val, '/') || strings.ContainsRune(val, ':') {
+		return errors.New("invalid hostname")
+	}
 	return nil
 }

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -87,6 +87,10 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 				}
 			}
 
+			if err := hostnameValidator(opts.Hostname); err != nil {
+				return &cmdutil.FlagError{Err: fmt.Errorf("error parsing --hostname: %w", err)}
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -87,8 +87,10 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 				}
 			}
 
-			if err := hostnameValidator(opts.Hostname); err != nil {
-				return &cmdutil.FlagError{Err: fmt.Errorf("error parsing --hostname: %w", err)}
+			if cmd.Flags().Changed("hostname") {
+				if err := hostnameValidator(opts.Hostname); err != nil {
+					return &cmdutil.FlagError{Err: fmt.Errorf("error parsing --hostname: %w", err)}
+				}
 			}
 
 			if runF != nil {


### PR DESCRIPTION
If HTTP 422 is encountered, assume that OAuth Device Flow is unavailable and fall back to OAuth app authorization flow.