### PR TITLE
properly check for tty when in powershell

### DIFF
--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -103,12 +103,20 @@ func (s *IOStreams) TerminalWidth() int {
 }
 
 func System() *IOStreams {
-	return &IOStreams{
+	stdoutIsTTY := isTerminal(os.Stdout)
+	stderrIsTTY := isTerminal(os.Stderr)
+
+	io := &IOStreams{
 		In:           os.Stdin,
 		Out:          colorable.NewColorable(os.Stdout),
 		ErrOut:       colorable.NewColorable(os.Stderr),
-		colorEnabled: os.Getenv("NO_COLOR") == "" && isTerminal(os.Stdout),
+		colorEnabled: os.Getenv("NO_COLOR") == "" && stdoutIsTTY,
 	}
+
+	// prevent duplicate isTerminal queries now that we know the answer
+	io.SetStdoutTTY(stdoutIsTTY)
+	io.SetStderrTTY(stderrIsTTY)
+	return io
 }
 
 func Test() (*IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {


### PR DESCRIPTION
<!--
Please make sure you read our contributing guidelines at
https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md
before opening a pull request. Thanks!
-->

closes #1581

Only under Powershell we were failing to accurately tell if a command was running attached to a tty or not due to our use of colorableOut. This PR ~tweaks the check to account for this~ backports a change made in #1552 that cached the isTerminal check prior to creating a colorable, avoiding the bug.

~I had to do a gross hack to fix this and am open to suggestion. `colorable` only builds the `colorable.Writer` type if built on windows; this made detecting the above scenario very difficult. I had to make a shim type that is conditionally built in order to get this compiling on all of our CI test nodes.~