### PR TITLE
Fix detecting display width of common punctuation characters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/text v0.3.2
+	golang.org/x/text v0.3.3
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200506231410-2ff61e1afc86
 )

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 h1:opSr2sbRXk5X5/givKrrKj9HX
 golang.org/x/sys v0.0.0-20200413165638-669c56c373c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
-golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/text/truncate.go
+++ b/pkg/text/truncate.go
@@ -53,7 +53,24 @@ func Truncate(max int, s string) string {
 	return res
 }
 
+var runeDisplayWidthOverrides = map[rune]int{
+	'“': 1,
+	'”': 1,
+	'‘': 1,
+	'’': 1,
+	'–': 1, // en dash
+	'—': 1, // em dash
+	'→': 1,
+	'…': 1,
+	'•': 1, // bullet
+	'·': 1, // middle dot
+}
+
 func runeDisplayWidth(r rune) int {
+	if w, ok := runeDisplayWidthOverrides[r]; ok {
+		return w
+	}
+
 	switch width.LookupRune(r).Kind() {
 	case width.EastAsianWide, width.EastAsianAmbiguous, width.EastAsianFullwidth:
 		return 2

--- a/pkg/text/truncate_test.go
+++ b/pkg/text/truncate_test.go
@@ -1,6 +1,8 @@
 package text
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestTruncate(t *testing.T) {
 	type args struct {
@@ -65,6 +67,72 @@ func TestTruncate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := Truncate(tt.args.max, tt.args.s); got != tt.want {
 				t.Errorf("Truncate() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDisplayWidth(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want int
+	}{
+		{
+			name: "check mark",
+			text: `✓`,
+			want: 1,
+		},
+		{
+			name: "bullet icon",
+			text: `•`,
+			want: 1,
+		},
+		{
+			name: "middle dot",
+			text: `·`,
+			want: 1,
+		},
+		{
+			name: "ellipsis",
+			text: `…`,
+			want: 1,
+		},
+		{
+			name: "right arrow",
+			text: `→`,
+			want: 1,
+		},
+		{
+			name: "smart double quotes",
+			text: `“”`,
+			want: 2,
+		},
+		{
+			name: "smart single quotes",
+			text: `‘’`,
+			want: 2,
+		},
+		{
+			name: "em dash",
+			text: `—`,
+			want: 1,
+		},
+		{
+			name: "en dash",
+			text: `–`,
+			want: 1,
+		},
+		{
+			name: "emoji",
+			text: `👍`,
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DisplayWidth(tt.text); got != tt.want {
+				t.Errorf("DisplayWidth() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
These characters get classified as "EastAsianAmbiguous" by Go's `text/width` package, and thus assumed that their printed version occupies a width of 2 characters, whereas they each only occupy one.

I'm not sure why they are classified as East Asian, but I did not have the energy to dive into Go's Unicode tables, so here is a workaround based on an exclusion list.

This affects all TablePrinter output, therefore commands such as `issue/pr list`.