### PR TITLE
Filter gh credits for humans

### DIFF
--- a/pkg/cmd/repo/credits/credits.go
+++ b/pkg/cmd/repo/credits/credits.go
@@ -135,6 +135,7 @@ func creditsRun(opts *CreditsOptions) error {
 
 	type Contributor struct {
 		Login string
+		Type  string
 	}
 
 	type Result []Contributor
@@ -161,6 +162,10 @@ func creditsRun(opts *CreditsOptions) error {
 
 	logins := []string{}
 	for x, c := range result {
+		if c.Type != "User" {
+			continue
+		}
+
 		if isTTY && !static {
 			logins = append(logins, getColor(x)(c.Login))
 		} else {


### PR DESCRIPTION
# What is this?
The top maintainers on my project are dependabot-preview[bot] and gh-action[bot]. I am opening this PR in response to  https://github.com/cli/cli/issues/1597. 

# Solution

I added another condition to leave out logins that are not humans (Users). 

I ran the test in a Codespace and they passed, let me know if a new test is needed for this condition. 

![Screen Shot 2020-09-04 at 8 19 57 AM](https://user-images.githubusercontent.com/5713670/92256377-7db1f900-ee88-11ea-939a-7f4065f36048.png)

# Screenshot

_no bots_

![Screen Shot 2020-09-04 at 9 10 07 AM](https://user-images.githubusercontent.com/5713670/92261583-7f7ebb00-ee8e-11ea-99f8-56089ababe4a.png)
