### PR TITLE
Avoid setting a default `Accept` header in `api` command

### DIFF
--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -46,8 +46,7 @@ func New(appVersion string) *cmdutil.Factory {
 				return nil, err
 			}
 
-			// TODO: avoid setting Accept header for `api` command
-			return httpClient(io, cfg, appVersion, true), nil
+			return NewHTTPClient(io, cfg, appVersion, true), nil
 		},
 		BaseRepo: func() (ghrepo.Interface, error) {
 			remotes, err := remotesFunc()

--- a/pkg/cmd/factory/http.go
+++ b/pkg/cmd/factory/http.go
@@ -13,7 +13,7 @@ import (
 )
 
 // generic authenticated HTTP client for commands
-func httpClient(io *iostreams.IOStreams, cfg config.Config, appVersion string, setAccept bool) *http.Client {
+func NewHTTPClient(io *iostreams.IOStreams, cfg config.Config, appVersion string, setAccept bool) *http.Client {
 	var opts []api.ClientOption
 	if verbose := os.Getenv("DEBUG"); verbose != "" {
 		logTraffic := strings.Contains(verbose, "api")

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 
@@ -13,6 +14,7 @@ import (
 	apiCmd "github.com/cli/cli/pkg/cmd/api"
 	authCmd "github.com/cli/cli/pkg/cmd/auth"
 	configCmd "github.com/cli/cli/pkg/cmd/config"
+	"github.com/cli/cli/pkg/cmd/factory"
 	gistCmd "github.com/cli/cli/pkg/cmd/gist"
 	issueCmd "github.com/cli/cli/pkg/cmd/issue"
 	prCmd "github.com/cli/cli/pkg/cmd/pr"
@@ -102,12 +104,23 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	// CHILD COMMANDS
 
 	cmd.AddCommand(aliasCmd.NewCmdAlias(f))
-	cmd.AddCommand(apiCmd.NewCmdApi(f, nil))
 	cmd.AddCommand(authCmd.NewCmdAuth(f))
 	cmd.AddCommand(configCmd.NewCmdConfig(f))
 	cmd.AddCommand(creditsCmd.NewCmdCredits(f, nil))
 	cmd.AddCommand(gistCmd.NewCmdGist(f))
 	cmd.AddCommand(NewCmdCompletion(f.IOStreams))
+
+	// the `api` command should not inherit any extra HTTP headers
+	bareHTTPCmdFactory := *f
+	bareHTTPCmdFactory.HttpClient = func() (*http.Client, error) {
+		cfg, err := bareHTTPCmdFactory.Config()
+		if err != nil {
+			return nil, err
+		}
+		return factory.NewHTTPClient(bareHTTPCmdFactory.IOStreams, cfg, version, false), nil
+	}
+
+	cmd.AddCommand(apiCmd.NewCmdApi(&bareHTTPCmdFactory, nil))
 
 	// below here at the commands that require the "intelligent" BaseRepo resolver
 	repoResolvingCmdFactory := *f


### PR DESCRIPTION
Due to our HTTP client default behavior passed down by the global Factory object, an `Accept` header is added to all API requests. This is fine for all commands except `gh api`, where the user should ideally have fine-grained control over most aspects of HTTP requests and where there should be little to no defaults in general.