### PR TITLE
Fix measuring terminal width for output

### DIFF
--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -20,6 +20,8 @@ type IOStreams struct {
 	Out    io.Writer
 	ErrOut io.Writer
 
+	// the original (non-colorable) output stream
+	originalOut  io.Writer
 	colorEnabled bool
 
 	stdinTTYOverride  bool
@@ -81,15 +83,16 @@ func (s *IOStreams) IsStderrTTY() bool {
 
 func (s *IOStreams) TerminalWidth() int {
 	defaultWidth := 80
-	if s.stdoutTTYOverride {
-		return defaultWidth
+	out := s.Out
+	if s.originalOut != nil {
+		out = s.originalOut
 	}
 
-	if w, _, err := terminalSize(s.Out); err == nil {
+	if w, _, err := terminalSize(out); err == nil {
 		return w
 	}
 
-	if isCygwinTerminal(s.Out) {
+	if isCygwinTerminal(out) {
 		tputCmd := exec.Command("tput", "cols")
 		tputCmd.Stdin = os.Stdin
 		if out, err := tputCmd.Output(); err == nil {
@@ -108,6 +111,7 @@ func System() *IOStreams {
 
 	io := &IOStreams{
 		In:           os.Stdin,
+		originalOut:  os.Stdout,
 		Out:          colorable.NewColorable(os.Stdout),
 		ErrOut:       colorable.NewColorable(os.Stderr),
 		colorEnabled: os.Getenv("NO_COLOR") == "" && stdoutIsTTY,


### PR DESCRIPTION
Preserve a reference to original `os.Stdout` (pre-colorable) so we can use it to measure terminal width.

Fixes #1618 
Followup to https://github.com/cli/cli/pull/1607