### PR TITLE
support auth login --web

### DIFF
--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -81,8 +81,9 @@ func Test_NewCmdLogin(t *testing.T) {
 			stdinTTY: true,
 			cli:      "--hostname barry.burton",
 			wants: LoginOptions{
-				Hostname: "barry.burton",
-				Token:    "",
+				Hostname:    "barry.burton",
+				Token:       "",
+				Interactive: true,
 			},
 		},
 		{
@@ -90,9 +91,32 @@ func Test_NewCmdLogin(t *testing.T) {
 			stdinTTY: true,
 			cli:      "",
 			wants: LoginOptions{
-				Hostname: "",
-				Token:    "",
+				Hostname:    "",
+				Token:       "",
+				Interactive: true,
 			},
+		},
+		{
+			name:     "tty web",
+			stdinTTY: true,
+			cli:      "--web",
+			wants: LoginOptions{
+				Hostname: "github.com",
+				Web:      true,
+			},
+		},
+		{
+			name: "nontty web",
+			cli:  "--web",
+			wants: LoginOptions{
+				Hostname: "github.com",
+				Web:      true,
+			},
+		},
+		{
+			name:     "web and with-token",
+			cli:      "--web --with-token",
+			wantsErr: true,
 		},
 	}
 
@@ -134,6 +158,8 @@ func Test_NewCmdLogin(t *testing.T) {
 
 			assert.Equal(t, tt.wants.Token, gotOpts.Token)
 			assert.Equal(t, tt.wants.Hostname, gotOpts.Hostname)
+			assert.Equal(t, tt.wants.Web, gotOpts.Web)
+			assert.Equal(t, tt.wants.Interactive, gotOpts.Interactive)
 		})
 	}
 }
@@ -262,6 +288,9 @@ func Test_loginRun_Survey(t *testing.T) {
 	}{
 		{
 			name: "already authenticated",
+			opts: &LoginOptions{
+				Interactive: true,
+			},
 			cfg: func(cfg config.Config) {
 				_ = cfg.Set("github.com", "oauth_token", "ghi789")
 			},
@@ -280,7 +309,8 @@ func Test_loginRun_Survey(t *testing.T) {
 		{
 			name: "hostname set",
 			opts: &LoginOptions{
-				Hostname: "rebecca.chambers",
+				Hostname:    "rebecca.chambers",
+				Interactive: true,
 			},
 			wantHosts: "rebecca.chambers:\n    oauth_token: def456\n    git_protocol: https\n    user: jillv\n",
 			askStubs: func(as *prompt.AskStubber) {
@@ -298,6 +328,9 @@ func Test_loginRun_Survey(t *testing.T) {
 		{
 			name:      "choose enterprise",
 			wantHosts: "brad.vickers:\n    oauth_token: def456\n    git_protocol: https\n    user: jillv\n",
+			opts: &LoginOptions{
+				Interactive: true,
+			},
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubOne(1)              // host type enterprise
 				as.StubOne("brad.vickers") // hostname
@@ -315,6 +348,9 @@ func Test_loginRun_Survey(t *testing.T) {
 		{
 			name:      "choose github.com",
 			wantHosts: "github.com:\n    oauth_token: def456\n    git_protocol: https\n    user: jillv\n",
+			opts: &LoginOptions{
+				Interactive: true,
+			},
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubOne(0)        // host type github.com
 				as.StubOne(1)        // auth mode: token
@@ -325,6 +361,9 @@ func Test_loginRun_Survey(t *testing.T) {
 		{
 			name:      "sets git_protocol",
 			wantHosts: "github.com:\n    oauth_token: def456\n    git_protocol: ssh\n    user: jillv\n",
+			opts: &LoginOptions{
+				Interactive: true,
+			},
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubOne(0)        // host type github.com
 				as.StubOne(1)        // auth mode: token


### PR DESCRIPTION
After mislav's feedback and talking through this with amanda I decided to go with `--web` just skipping all prompts. It felt wrong to do anything else messing with this myself in the terminal and now `--with-token` and `--web` are more symmetric.

The end result is something like:
![image](https://user-images.githubusercontent.com/98482/92957117-a9efeb80-f42d-11ea-937e-670a888570b5.png)

I chose to be explicit about setting the `git_protocol` value so that a user gets a hint about how to change it if they desire `ssh`.


closes #1604
