### PR TITLE
Handle runtime error on bad user input

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -51,11 +51,7 @@ func main() {
 	}
 
 	cmd, _, err := rootCmd.Traverse(expandedArgs)
-	if err != nil {
-		fmt.Fprintf(stderr, "failed to parse the command:  %s\n", err)
-		os.Exit(2)
-	}
-	{
+	if err != nil || cmd == rootCmd {
 		originalArgs := expandedArgs
 		isShell := false
 
@@ -94,6 +90,11 @@ func main() {
 
 			os.Exit(0)
 		}
+	}
+
+	if cmd == nil {
+		fmt.Fprintf(stderr, "failed to parse command, %s\n", err)
+		os.Exit(2)
 	}
 
 	authCheckEnabled := os.Getenv("GITHUB_TOKEN") == "" &&

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -51,7 +51,11 @@ func main() {
 	}
 
 	cmd, _, err := rootCmd.Traverse(expandedArgs)
-	if err != nil || cmd == rootCmd {
+	if err != nil {
+		fmt.Fprintf(stderr, "failed to parse the command:  %s\n", err)
+		os.Exit(2)
+	}
+	{
 		originalArgs := expandedArgs
 		isShell := false
 

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -92,14 +92,9 @@ func main() {
 		}
 	}
 
-	if cmd == nil {
-		fmt.Fprintf(stderr, "failed to parse command, %s\n", err)
-		os.Exit(2)
-	}
-
 	authCheckEnabled := os.Getenv("GITHUB_TOKEN") == "" &&
 		os.Getenv("GITHUB_ENTERPRISE_TOKEN") == "" &&
-		cmdutil.IsAuthCheckEnabled(cmd)
+		cmd != nil && cmdutil.IsAuthCheckEnabled(cmd)
 	if authCheckEnabled {
 		cfg, err := cmdFactory.Config()
 		if err != nil {


### PR DESCRIPTION
As mentioned in [#1651](https://github.com/cli/cli/issues/1651), the error occurs here:

https://github.com/cli/cli/blob/33e11f02e46339a4cab0d85da0f368bd8e8df480/cmd/gh/main.go#L53-L97

After some debugging I think we can break up the if statement and handle the error. Here is my reasoning:

* `err != nil` if and only if the `ParseFlags()` function in `Traverse()` returns nil. 

* `ParseFlags()` returning nil, **implies an error occurred when traversing the command tree and parsing flags**. This error doesn't imply there is an error in the config, alias and shell checks. Hence currently the error is not handled.

Therefore we should have a separate conditional statement to deal with errors from `Traverse()`.

Secondly, this pull request also removes the conditional `if rootCmd == cmd` and wraps the checks in a local block. 
After quite some thinking I don't see why the checks shouldn't be made by all commands. If this conditional is in fact needed, then the local block easily can be wrapped in an `else if` statement.

The code has been tested locally and works. I wasn't sure if a test function was necessary, as the bug is quite simple and there no similar user input tests in `main_test.go`. 

:)

closes #1651

