### PR TITLE
Add opensuse zypper installation steps

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -43,8 +43,20 @@ sudo dnf install gh
 
 ### openSUSE/SUSE Linux (zypper)
 
-It's possible that https://cli.github.com/packages/rpm/gh-cli.repo will work with zypper, but
-this hasn't been tested.
+Install:
+
+```bash
+sudo zypper addrepo https://cli.github.com/packages/rpm/gh-cli.repo
+sudo zypper ref
+sudo zypper install gh
+```
+
+Upgrade:
+
+```bash
+sudo zypper ref
+sudo zypper update gh
+```
 
 ## Manual installation
 


### PR DESCRIPTION
Referencing and Fixing #1655 

gh cli seems to works seamlessly with zypper on openSUSE and thus updating the [Installation gh on Linux](https://github.com/cli/cli/blob/trunk/docs/install_linux.md) with the installation steps for zypper as shown in the referenced issue.