### PR TITLE
Do not html escape repo view output

### DIFF
--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -2,9 +2,9 @@ package view
 
 import (
 	"fmt"
-	"html/template"
 	"net/http"
 	"strings"
+	"text/template"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"


### PR DESCRIPTION
This PR fixes the bug where `repo view` was HTML escaping its output. The fix was to change from using `html/template` package to `text/template` package which does not do any sort of escaping.

https://golang.org/pkg/text/template/

Before:
<img width="637" alt="Screen Shot 2020-09-10 at 9 26 23 AM" src="https://user-images.githubusercontent.com/7969779/92696893-df6fd880-f34a-11ea-9670-de36209096bb.png">

After:
<img width="640" alt="Screen Shot 2020-09-10 at 9 26 03 AM" src="https://user-images.githubusercontent.com/7969779/92696913-e5fe5000-f34a-11ea-82f8-80524337ac5e.png">


cc https://github.com/github/client-apps/discussions/23#discussioncomment-75188