### PR TITLE
Use text/template instead of http/template.

### DIFF
--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -2,9 +2,9 @@ package view
 
 import (
 	"fmt"
-	"html/template"
 	"net/http"
 	"strings"
+	"text/template"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
@@ -124,9 +124,9 @@ func viewRun(opts *ViewOptions) error {
 	repoTmpl := heredoc.Doc(`
 		{{.FullName}}
 		{{.Description}}
-		
+
 		{{.Readme}}
-		
+
 		{{.View}}
 	`)
 


### PR DESCRIPTION
http/tempate results in html -unsafe characters like angle brackets, quotes, etc being escaped e.g.

```
gh repo view cli/cli
...
  ## We want your feedback

  We&#39;d love to hear your feedback about  gh . If you spot bugs or have
  features that you&#39;d really like to see in  gh , please check out the
  contributing page
...
```

Note that `We&#39;d` and `you&#39;d`.

This affected only standard terminals, for which an HTML template renderer was used.