### PR TITLE
Fix issue listing misalignment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,15 +14,17 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-colorable v0.1.7
 	github.com/mattn/go-isatty v0.0.12
+	github.com/mattn/go-runewidth v0.0.9
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/rivo/uniseg v0.1.0
 	github.com/shurcooL/githubv4 v0.0.0-20200802174311-f27d2ca7f6d5
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
-	golang.org/x/text v0.3.3
+	golang.org/x/text v0.3.3 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/text/truncate_test.go
+++ b/pkg/text/truncate_test.go
@@ -62,6 +62,22 @@ func TestTruncate(t *testing.T) {
 			},
 			want: "a프로젝... ",
 		},
+		{
+			name: "Emoji",
+			args: args{
+				max: 11,
+				s:   "💡💡💡💡💡💡💡💡💡💡💡💡",
+			},
+			want: "💡💡💡💡...",
+		},
+		{
+			name: "Accented characters",
+			args: args{
+				max: 11,
+				s:   "é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́é́́",
+			},
+			want: "é́́é́́é́́é́́é́́é́́é́́é́́...",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -127,6 +143,11 @@ func TestDisplayWidth(t *testing.T) {
 			name: "emoji",
 			text: `👍`,
 			want: 2,
+		},
+		{
+			name: "accent character",
+			text: `é́́`,
+			want: 1,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Improve logic for determining string truncation and string display width. This new logic uses a combination of https://github.com/mattn/go-runewidth and https://github.com/rivo/uniseg. This should result in better alignment when using the issue list command.

Note: `func graphemeWidth` is not always 100% accurate so there might still be some misalignment cases that exist but it has more robust rune recognition (due to go-runewidth) than our previous implementation. 

closes https://github.com/cli/cli/issues/1454