### PR TITLE
remove `scoop bucket add` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ See [Linux installation docs](/docs/install_linux.md).
 Install:
 
 ```powershell
-scoop bucket add github-gh https://github.com/cli/scoop-gh.git
 scoop install gh
 ```
 


### PR DESCRIPTION
Just a very small PR to remove that line. It doesn't seem like [the bucket](https://github.com/cli/scoop-gh) is maintained anymore (it is outdated) and there is [one in the Main bucket](https://github.com/ScoopInstaller/Main/blob/master/bucket/gh.json). I got very confused because `gh` was telling me there was a new version but `scoop update gh` said I had the latest version. Just hoping to save somebody else from the confusion as the one in the [Main bucket](https://github.com/ScoopInstaller/Main) is on the latest version.

*Note: I also opened a [PR](https://github.com/cli/scoop-gh/pull/9) in the [the bucket](https://github.com/cli/scoop-gh) in case the user doesn't check the README.