### PR TITLE
Fix `release download`

### DIFF
--- a/pkg/cmd/factory/http.go
+++ b/pkg/cmd/factory/http.go
@@ -24,7 +24,7 @@ func NewHTTPClient(io *iostreams.IOStreams, cfg config.Config, appVersion string
 		api.AddHeader("User-Agent", fmt.Sprintf("GitHub CLI %s", appVersion)),
 		api.AddHeaderFunc("Authorization", func(req *http.Request) (string, error) {
 			hostname := ghinstance.NormalizeHostname(req.URL.Hostname())
-			if token, err := cfg.Get(hostname, "oauth_token"); err == nil || token != "" {
+			if token, err := cfg.Get(hostname, "oauth_token"); err == nil && token != "" {
 				return fmt.Sprintf("token %s", token), nil
 			}
 			return "", nil


### PR DESCRIPTION
Requesting an asset from Amazon S3 would fail because we erroneously set the `Authorization: token` header with a blank token.

Now, only ever try to set an `Authorization` request header to hosts that we have OAuth credentials for; skip the header otherwise.

Fixes #1695, followup to https://github.com/cli/cli/pull/1552#discussion_r481314653