### PR TITLE
Go 1.15+ is required to run the test suit

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Please avoid:
 
 Prerequisites:
 - Go 1.13+ for building the binary
-- Go 1.14+ for running the test suite
+- Go 1.15+ for running the test suite
 
 Build with: `make` or `go build -o bin/gh ./cmd/gh`
 


### PR DESCRIPTION
I was trying to run the test suit with Go 1.14 and found some tests failed because they use the method `T.TempDir` [which was introduced in Go 1.15](https://golang.org/doc/go1.15#testing).  I've updated CONTRIBUTING.md to clarify the version requirements for testing.

```
# github.com/cli/cli/pkg/cmd/release/download [github.com/cli/cli/pkg/cmd/release/download.test]
pkg/cmd/release/download/download_test.go:190:16: t.TempDir undefined (type *testing.T has no field or method TempDir)
# github.com/cli/cli/pkg/cmd/release/create [github.com/cli/cli/pkg/cmd/release/create.test]
pkg/cmd/release/create/create_test.go:25:14: t.TempDir undefined (type *testing.T has no field or method TempDir)
````