### PR TITLE
Remove square brackets from persistent flag description to fix zsh autocomplete

### DIFF
--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -8,7 +8,7 @@ import (
 )
 
 func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
-	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `[HOST/]OWNER/REPO` format")
+	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `OWNER/REPO` format")
 
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		repoOverride, _ := cmd.Flags().GetString("repo")


### PR DESCRIPTION
## Summary

closes #1703

## Details

The square brackets in repo `PersistentFlags` description is causing ZSH autocomplete to break. Cobra should be escaping them properly when generating the autocomplete file but that seems to be broken. Temporarily removing `[HOST/]` until we come up with a more permanent solution.

Looks like this issue will be fixed with the next release of Cobra https://github.com/spf13/cobra/pull/1070