### PR TITLE
Fallback browser when `xdg-open` does not exist

### DIFF
--- a/pkg/browser/browser.go
+++ b/pkg/browser/browser.go
@@ -30,10 +30,10 @@ func ForOS(goos, url string) *exec.Cmd {
 		r := strings.NewReplacer("&", "^&")
 		args = append(args, "/c", "start", r.Replace(url))
 	default:
-		if findExe("xdg-open") {
-			exe = "xdg-open"
-		} else {
+		if findExe("wslview") {
 			exe = "wslview"
+		} else {
+			exe = "xdg-open"
 		}
 		args = append(args, url)
 	}
@@ -58,9 +58,5 @@ func FromLauncher(launcher, url string) (*exec.Cmd, error) {
 
 var findExe = func(command string) bool {
 	_, err := exec.LookPath(command)
-	if err != nil {
-		return false
-	} else {
-		return true
-	}
+	return err == nil
 }

--- a/pkg/browser/browser.go
+++ b/pkg/browser/browser.go
@@ -52,15 +52,18 @@ func FromLauncher(launcher, url string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
-var linuxExe = func() string {
+func linuxExe() string {
 	exe := "xdg-open"
-	if !findExe("xdg-open") && findExe("wslview") {
-		exe = "wslview"
+
+	_, err := lookPath(exe)
+	if err != nil {
+		_, err := lookPath("wslview")
+		if err == nil {
+			exe = "wslview"
+		}
 	}
+
 	return exe
 }
 
-func findExe(command string) bool {
-	_, err := exec.LookPath(command)
-	return err == nil
-}
+var lookPath = exec.LookPath

--- a/pkg/browser/browser.go
+++ b/pkg/browser/browser.go
@@ -30,11 +30,7 @@ func ForOS(goos, url string) *exec.Cmd {
 		r := strings.NewReplacer("&", "^&")
 		args = append(args, "/c", "start", r.Replace(url))
 	default:
-		if findExe("wslview") {
-			exe = "wslview"
-		} else {
-			exe = "xdg-open"
-		}
+		exe = linuxExe()
 		args = append(args, url)
 	}
 
@@ -56,7 +52,15 @@ func FromLauncher(launcher, url string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
-var findExe = func(command string) bool {
+var linuxExe = func() string {
+	exe := "xdg-open"
+	if !findExe("xdg-open") && findExe("wslview") {
+		exe = "wslview"
+	}
+	return exe
+}
+
+func findExe(command string) bool {
 	_, err := exec.LookPath(command)
 	return err == nil
 }

--- a/pkg/browser/browser.go
+++ b/pkg/browser/browser.go
@@ -1,7 +1,6 @@
 package browser
 
 import (
-	"bufio"
 	"os"
 	"os/exec"
 	"runtime"
@@ -31,10 +30,10 @@ func ForOS(goos, url string) *exec.Cmd {
 		r := strings.NewReplacer("&", "^&")
 		args = append(args, "/c", "start", r.Replace(url))
 	default:
-		if inWsl() {
-			exe = "wslview"
-		} else {
+		if findExe("xdg-open") {
 			exe = "xdg-open"
+		} else {
+			exe = "wslview"
 		}
 		args = append(args, url)
 	}
@@ -57,20 +56,11 @@ func FromLauncher(launcher, url string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
-// Determine if gh is running inside of WSL2
-func inWsl() bool {
-	file, err := os.Open("/proc/sys/kernel/osrelease")
+var findExe = func(command string) bool {
+	_, err := exec.LookPath(command)
 	if err != nil {
 		return false
+	} else {
+		return true
 	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	scanner.Scan() // Read single line
-	if err := scanner.Err(); err != nil {
-		return false
-	}
-
-	os := scanner.Text()
-	return strings.Contains(os, "microsoft-WSL2")
 }

--- a/pkg/browser/browser_test.go
+++ b/pkg/browser/browser_test.go
@@ -1,6 +1,7 @@
 package browser
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -52,8 +53,15 @@ func TestForOS(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		lookPath = func(file string) (string, error) {
+			if file == tt.exe {
+				return file, nil
+			} else {
+				return "", errors.New("not found")
+			}
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
-			linuxExe = func() string { return tt.exe }
 			if cmd := ForOS(tt.args.goos, tt.args.url); !reflect.DeepEqual(cmd.Args, tt.want) {
 				t.Errorf("ForOS() = %v, want %v", cmd.Args, tt.want)
 			}

--- a/pkg/browser/browser_test.go
+++ b/pkg/browser/browser_test.go
@@ -30,7 +30,7 @@ func TestForOS(t *testing.T) {
 				goos: "linux",
 				url:  "https://example.com/path?a=1&b=2",
 			},
-			findExe: true,
+			findExe: false, // wslview does not exist on standard Linux
 			want:    []string{"xdg-open", "https://example.com/path?a=1&b=2"},
 		},
 		{
@@ -39,7 +39,7 @@ func TestForOS(t *testing.T) {
 				goos: "linux",
 				url:  "https://example.com/path?a=1&b=2",
 			},
-			findExe: false,
+			findExe: true, // wslview exists on WSL
 			want:    []string{"wslview", "https://example.com/path?a=1&b=2"},
 		},
 		{

--- a/pkg/browser/browser_test.go
+++ b/pkg/browser/browser_test.go
@@ -11,9 +11,10 @@ func TestForOS(t *testing.T) {
 		url  string
 	}
 	tests := []struct {
-		name string
-		args args
-		want []string
+		name    string
+		args    args
+		findExe bool
+		want    []string
 	}{
 		{
 			name: "macOS",
@@ -29,7 +30,17 @@ func TestForOS(t *testing.T) {
 				goos: "linux",
 				url:  "https://example.com/path?a=1&b=2",
 			},
-			want: []string{"xdg-open", "https://example.com/path?a=1&b=2"},
+			findExe: true,
+			want:    []string{"xdg-open", "https://example.com/path?a=1&b=2"},
+		},
+		{
+			name: "WSL",
+			args: args{
+				goos: "linux",
+				url:  "https://example.com/path?a=1&b=2",
+			},
+			findExe: false,
+			want:    []string{"wslview", "https://example.com/path?a=1&b=2"},
 		},
 		{
 			name: "Windows",
@@ -42,6 +53,7 @@ func TestForOS(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			findExe = func(string) bool { return tt.findExe }
 			if cmd := ForOS(tt.args.goos, tt.args.url); !reflect.DeepEqual(cmd.Args, tt.want) {
 				t.Errorf("ForOS() = %v, want %v", cmd.Args, tt.want)
 			}

--- a/pkg/browser/browser_test.go
+++ b/pkg/browser/browser_test.go
@@ -11,10 +11,10 @@ func TestForOS(t *testing.T) {
 		url  string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		findExe bool
-		want    []string
+		name string
+		args args
+		exe  string
+		want []string
 	}{
 		{
 			name: "macOS",
@@ -30,8 +30,8 @@ func TestForOS(t *testing.T) {
 				goos: "linux",
 				url:  "https://example.com/path?a=1&b=2",
 			},
-			findExe: false, // wslview does not exist on standard Linux
-			want:    []string{"xdg-open", "https://example.com/path?a=1&b=2"},
+			exe:  "xdg-open",
+			want: []string{"xdg-open", "https://example.com/path?a=1&b=2"},
 		},
 		{
 			name: "WSL",
@@ -39,8 +39,8 @@ func TestForOS(t *testing.T) {
 				goos: "linux",
 				url:  "https://example.com/path?a=1&b=2",
 			},
-			findExe: true, // wslview exists on WSL
-			want:    []string{"wslview", "https://example.com/path?a=1&b=2"},
+			exe:  "wslview",
+			want: []string{"wslview", "https://example.com/path?a=1&b=2"},
 		},
 		{
 			name: "Windows",
@@ -53,7 +53,7 @@ func TestForOS(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			findExe = func(string) bool { return tt.findExe }
+			linuxExe = func() string { return tt.exe }
 			if cmd := ForOS(tt.args.goos, tt.args.url); !reflect.DeepEqual(cmd.Args, tt.want) {
 				t.Errorf("ForOS() = %v, want %v", cmd.Args, tt.want)
 			}


### PR DESCRIPTION
## Summary

closes #826

## Details

- ~~Look at `/proc/sys/kernel/osrelease` to determine if `gh` is running inside WSL2. WSL1 detection is more complicated and not deterministic, so for now we will only detect WSL2.~~
- ~~https://github.com/Microsoft/WSL/issues/423#issuecomment-611086412~~
- ~~If in WSL2 then use `wslview` instead of `xdg-open` which is not available in WSL2~~
- Look up if `xdg-open` exists in `PATH` and if not fallback to using `wslview`.