### PR TITLE
Build PowerPC64LE binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
   - <<: *build_defaults
     id: linux
     goos: [linux]
-    goarch: [386, amd64, arm64]
+    goarch: [386, amd64, arm64, ppc64le]
 
   - <<: *build_defaults
     id: windows


### PR DESCRIPTION
## Context

OpenPOWER platform and GitHub has been very popular with researchers and developers. I personally have been using GH CLI for few months on Linux PowerPC64 Litte Endian without any hiccup. I think it would be great to ship ppc64le binary in every release.

## Changes

* Add ppc64le build target