### PR TITLE
Update docs to update list of available packages

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -16,6 +16,7 @@ Install:
 ```bash
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
 sudo apt-add-repository -u https://cli.github.com/packages
+sudo apt update
 sudo apt install gh
 ```
 


### PR DESCRIPTION
Without updating the list of available packages, the installation results in;
`E: Unable to locate package gh`

When adding a package source, the latest packages should always be updated.

