### PR TITLE
Update install_linux.md

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -16,6 +16,7 @@ Install:
 ```bash
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
 sudo apt-add-repository https://cli.github.com/packages
+sudo apt update
 sudo apt install gh
 ```
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -15,7 +15,7 @@ Install:
 
 ```bash
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-sudo apt-add-repository -u https://cli.github.com/packages
+sudo apt-add-repository https://cli.github.com/packages
 sudo apt install gh
 ```
 


### PR DESCRIPTION
Remove non-existant option: -u

`$ sudo apt-add-repository -u https://cli.github.com/packages
Usage: apt-add-repository [options] repository

apt-add-repository: error: no such option: -u
 `

This does not work on Mint and older versions of Ubuntu, so removing the -you and manually doing the apt update should cover all the bases. 