### PR TITLE
shared/upload: Add .tar format

### DIFF
--- a/pkg/cmd/release/shared/upload.go
+++ b/pkg/cmd/release/shared/upload.go
@@ -62,6 +62,8 @@ func typeForFilename(fn string) string {
 		return "application/zip"
 	case ".js":
 		return "application/javascript"
+	case ".tar":
+		return "application/x-tar"
 	case ".tgz", ".tar.gz":
 		return "application/x-gtar"
 	case ".bz2":


### PR DESCRIPTION
Currently the mimecap package is an requirement to pass the test suite,
as we need /etc/mime.types to recognize the tar extension. A better idea
is to inline all of the basic test cases for the test suite.

Signed-off-by: Morten Linderud <morten@linderud.pw>