### PR TITLE
added prerequisite to prevent command not found error

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -15,6 +15,7 @@ Install:
 
 ```bash
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+sudo apt-get install software-properties-common 
 sudo apt-add-repository https://cli.github.com/packages
 sudo apt update
 sudo apt install gh


### PR DESCRIPTION
Running `sudo apt-add-repository https://cli.github.com/packages` causes `command not found `error. To resolve that issue, run 
`sudo apt-get install software-properties-common `. 

Reference:  https://phoenixnap.com/kb/add-apt-repository-command-not-found-ubuntu