### PR TITLE
Fix gist ID extraction from url

### DIFF
--- a/pkg/cmd/gist/edit/edit.go
+++ b/pkg/cmd/gist/edit/edit.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"sort"
 	"strings"
 
@@ -69,11 +68,12 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 func editRun(opts *EditOptions) error {
 	gistID := opts.Selector
 
-	u, err := url.Parse(opts.Selector)
-	if err == nil {
-		if strings.HasPrefix(u.Path, "/") {
-			gistID = u.Path[1:]
+	if strings.Contains(gistID, "/") {
+		id, err := shared.GistIDFromURL(gistID)
+		if err != nil {
+			return err
 		}
+		gistID = id
 	}
 
 	client, err := opts.HttpClient()

--- a/pkg/cmd/gist/shared/shared.go
+++ b/pkg/cmd/gist/shared/shared.go
@@ -3,6 +3,8 @@ package shared
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/cli/cli/api"
@@ -36,4 +38,21 @@ func GetGist(client *http.Client, hostname, gistID string) (*Gist, error) {
 	}
 
 	return &gist, nil
+}
+
+func GistIDFromURL(gistURL string) (string, error) {
+	u, err := url.Parse(gistURL)
+	if err == nil && strings.HasPrefix(u.Path, "/") {
+		split := strings.Split(u.Path, "/")
+
+		if len(split) > 2 {
+			return split[2], nil
+		}
+
+		if len(split) == 2 && split[1] != "" {
+			return split[1], nil
+		}
+	}
+
+	return "", fmt.Errorf("Invalid gist URL %s", u)
 }

--- a/pkg/cmd/gist/shared/shared_test.go
+++ b/pkg/cmd/gist/shared/shared_test.go
@@ -1,0 +1,52 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetGistIDFromURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "url",
+			url:  "https://gist.github.com/1234",
+			want: "1234",
+		},
+		{
+			name: "url with username",
+			url:  "https://gist.github.com/octocat/1234",
+			want: "1234",
+		},
+		{
+			name: "url, specific file",
+			url:  "https://gist.github.com/1234#file-test-md",
+			want: "1234",
+		},
+		{
+			name:    "invalid url",
+			url:     "https://gist.github.com",
+			wantErr: true,
+			want:    "Invalid gist URL https://gist.github.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := GistIDFromURL(tt.url)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.want)
+				return
+			}
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.want, id)
+		})
+	}
+}

--- a/pkg/cmd/gist/view/view.go
+++ b/pkg/cmd/gist/view/view.go
@@ -3,7 +3,6 @@ package view
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"sort"
 	"strings"
 
@@ -72,16 +71,11 @@ func viewRun(opts *ViewOptions) error {
 	}
 
 	if strings.Contains(gistID, "/") {
-		u, err := url.Parse(opts.Selector)
-		if err == nil && strings.HasPrefix(u.Path, "/") {
-			split := strings.Split(u.Path, "/")
-
-			if len(split) > 2 && split[2] != "" {
-				gistID = strings.Split(u.Path, "/")[2]
-			} else {
-				return fmt.Errorf("Invalid gist URL %s", u)
-			}
+		id, err := shared.GistIDFromURL(gistID)
+		if err != nil {
+			return err
 		}
+		gistID = id
 	}
 
 	client, err := opts.HttpClient()

--- a/pkg/cmd/gist/view/view.go
+++ b/pkg/cmd/gist/view/view.go
@@ -71,10 +71,16 @@ func viewRun(opts *ViewOptions) error {
 		return utils.OpenInBrowser(gistURL)
 	}
 
-	u, err := url.Parse(opts.Selector)
-	if err == nil {
-		if strings.HasPrefix(u.Path, "/") {
-			gistID = strings.Split(u.Path, "/")[2]
+	if strings.Contains(gistID, "/") {
+		u, err := url.Parse(opts.Selector)
+		if err == nil && strings.HasPrefix(u.Path, "/") {
+			split := strings.Split(u.Path, "/")
+
+			if len(split) > 2 && split[2] != "" {
+				gistID = strings.Split(u.Path, "/")[2]
+			} else {
+				return fmt.Errorf("Invalid gist URL %s", u)
+			}
 		}
 	}
 

--- a/pkg/cmd/gist/view/view.go
+++ b/pkg/cmd/gist/view/view.go
@@ -74,7 +74,7 @@ func viewRun(opts *ViewOptions) error {
 	u, err := url.Parse(opts.Selector)
 	if err == nil {
 		if strings.HasPrefix(u.Path, "/") {
-			gistID = u.Path[1:]
+			gistID = strings.Split(u.Path, "/")[2]
 		}
 	}
 

--- a/pkg/cmd/gist/view/view_test.go
+++ b/pkg/cmd/gist/view/view_test.go
@@ -91,11 +91,17 @@ func Test_viewRun(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:    "no such gist",
+			name: "no such gist",
+			opts: &ViewOptions{
+				Selector: "1234",
+			},
 			wantErr: true,
 		},
 		{
 			name: "one file",
+			opts: &ViewOptions{
+				Selector: "1234",
+			},
 			gist: &shared.Gist{
 				Files: map[string]*shared.GistFile{
 					"cicada.txt": {
@@ -109,6 +115,7 @@ func Test_viewRun(t *testing.T) {
 		{
 			name: "filename selected",
 			opts: &ViewOptions{
+				Selector: "1234",
 				Filename: "cicada.txt",
 			},
 			gist: &shared.Gist{
@@ -127,6 +134,9 @@ func Test_viewRun(t *testing.T) {
 		},
 		{
 			name: "multiple files, no description",
+			opts: &ViewOptions{
+				Selector: "1234",
+			},
 			gist: &shared.Gist{
 				Files: map[string]*shared.GistFile{
 					"cicada.txt": {
@@ -143,6 +153,9 @@ func Test_viewRun(t *testing.T) {
 		},
 		{
 			name: "multiple files, description",
+			opts: &ViewOptions{
+				Selector: "1234",
+			},
 			gist: &shared.Gist{
 				Description: "some files",
 				Files: map[string]*shared.GistFile{
@@ -161,7 +174,8 @@ func Test_viewRun(t *testing.T) {
 		{
 			name: "raw",
 			opts: &ViewOptions{
-				Raw: true,
+				Selector: "1234",
+				Raw:      true,
 			},
 			gist: &shared.Gist{
 				Description: "some files",
@@ -216,10 +230,6 @@ func Test_viewRun(t *testing.T) {
 		io, _, stdout, _ := iostreams.Test()
 		io.SetStdoutTTY(true)
 		tt.opts.IO = io
-
-		if tt.opts.Selector == "" {
-			tt.opts.Selector = "1234"
-		}
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := viewRun(tt.opts)

--- a/pkg/cmd/gist/view/view_test.go
+++ b/pkg/cmd/gist/view/view_test.go
@@ -83,12 +83,11 @@ func TestNewCmdView(t *testing.T) {
 
 func Test_viewRun(t *testing.T) {
 	tests := []struct {
-		name       string
-		opts       *ViewOptions
-		wantOut    string
-		wantStderr string
-		gist       *shared.Gist
-		wantErr    bool
+		name    string
+		opts    *ViewOptions
+		wantOut string
+		gist    *shared.Gist
+		wantErr bool
 	}{
 		{
 			name: "no such gist",
@@ -192,22 +191,6 @@ func Test_viewRun(t *testing.T) {
 			},
 			wantOut: "some files\ncicada.txt\n\nbwhiizzzbwhuiiizzzz\n\nfoo.md\n\n- foo\n\n",
 		},
-		{
-			name: "url",
-			opts: &ViewOptions{
-				Selector: "https://gist.github.com/octocat/1234",
-			},
-			wantErr:    true,
-			wantStderr: "HTTP 404 (https://api.github.com/gists/1234)",
-		},
-		{
-			name: "invalid url",
-			opts: &ViewOptions{
-				Selector: "https://gist.github.com/octocat",
-			},
-			wantErr:    true,
-			wantStderr: "Invalid gist URL https://gist.github.com/octocat",
-		},
 	}
 
 	for _, tt := range tests {
@@ -235,9 +218,6 @@ func Test_viewRun(t *testing.T) {
 			err := viewRun(tt.opts)
 			if tt.wantErr {
 				assert.Error(t, err)
-				if tt.wantStderr != "" {
-					assert.EqualError(t, err, tt.wantStderr)
-				}
 				return
 			}
 			assert.NoError(t, err)


### PR DESCRIPTION
When extracting the gist id from a url it gets `username/id` instead of only `id`.

```
gh gist view https://gist.github.com/cristiand391/baf3ae0ee13b1f6846e6dea88bdfdc39

HTTP 404: Not Found (https://api.github.com/gists/cristiand391/baf3ae0ee13b1f6846e6dea88bdfdc39)
```