### PR TITLE
Fix short description of `gist`

### DIFF
--- a/pkg/cmd/gist/gist.go
+++ b/pkg/cmd/gist/gist.go
@@ -13,7 +13,7 @@ import (
 func NewCmdGist(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gist",
-		Short: "Create gists",
+		Short: "Manage gists",
 		Long:  `Work with GitHub gists.`,
 		Annotations: map[string]string{
 			"IsCore": "true",


### PR DESCRIPTION
The `gist` command allows doing other operations than `create`(like `edit`, `view`, etc).  So I think that `manage` is more appropriate to the description.