### PR TITLE
Put scoop in a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,9 @@ See [Linux installation docs](/docs/install_linux.md).
 
 #### scoop
 
-Install:
-
-```powershell
-scoop bucket add github-gh https://github.com/cli/scoop-gh.git
-scoop install gh
-```
-
-Upgrade:
-
-```powershell
-scoop update gh
-```
+|Install:|Upgrade:|
+|---|---|
+|`scoop bucket add github-gh https://github.com/cli/scoop-gh.git` and afterwards `scoop install gh`|`scoop update gh`|
 
 #### Chocolatey
 


### PR DESCRIPTION
## Changes:

- This commit puts `scoop` in a table as well.

## Context:

The other installation/upgrade instructions are in a table format.
By putting `scoop` in a table, we're consistent in the whole README.

---

## Making a prettier table?

I tried making a table like this, but I was not successful:

```
| Installation   | Upgrade |
------------------------------------
| Scoop step 1   | Upgrade scoop |
| Scoop step 2   | empty |
```

Does anyone know if this is possible with GitHub flavored markdown?