### PR TITLE
Emoji parsing in Readme content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/briandowns/spinner v1.11.1
 	github.com/charmbracelet/glamour v0.2.1-0.20200724174618-1246d13c1684
+	github.com/enescakir/emoji v1.0.0
 	github.com/google/go-cmp v0.5.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-version v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk=
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
+github.com/enescakir/emoji v1.0.0 h1:W+HsNql8swfCQFtioDGDHCHri8nudlK1n5p2rHCJoog=
+github.com/enescakir/emoji v1.0.0/go.mod h1:Bt1EKuLnKDTYpLALApstIkAjdDrS/8IAgTkKp+WKFD0=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cli/cli/pkg/iostreams"
 	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
+	"github.com/enescakir/emoji"
 )
 
 type ViewOptions struct {
@@ -156,8 +157,9 @@ func viewRun(opts *ViewOptions) error {
 		if err != nil {
 			return fmt.Errorf("error rendering markdown: %w", err)
 		}
+		readmeContent = emoji.Parse(readmeContent)
 	} else {
-		readmeContent = readme.Content
+		readmeContent = emoji.Parse(readme.Content)
 	}
 
 	description := repo.Description

--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -15,8 +15,8 @@ import (
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
 	"github.com/cli/cli/utils"
-	"github.com/spf13/cobra"
 	"github.com/enescakir/emoji"
+	"github.com/spf13/cobra"
 )
 
 type ViewOptions struct {


### PR DESCRIPTION
Closes #1771 

Installed [emoji](https://github.com/enescakir/emoji), an emoji library in go which has additional emoji aliases from [gemoji](https://github.com/github/gemoji/blob/master/db/emoji.json) (used by github) and extra features. It fixes the bug of emoji parsing in displaying readme content.

![emojiParsing](https://user-images.githubusercontent.com/31686586/93635512-0d6eb000-fa10-11ea-9578-03c519df120d.png)

