### PR TITLE
Use the GreenCheck/RedX functions

### DIFF
--- a/pkg/cmd/alias/set/set.go
+++ b/pkg/cmd/alias/set/set.go
@@ -114,10 +114,10 @@ func setRun(opts *SetOptions) error {
 		return fmt.Errorf("could not create alias: %s does not correspond to a gh command", expansion)
 	}
 
-	successMsg := fmt.Sprintf("%s Added alias.", utils.Green("✓"))
+	successMsg := fmt.Sprintf("%s Added alias.", utils.GreenCheck())
 	if oldExpansion, ok := aliasCfg.Get(opts.Name); ok {
 		successMsg = fmt.Sprintf("%s Changed alias %s from %s to %s",
-			utils.Green("✓"),
+			utils.GreenCheck(),
 			utils.Bold(opts.Name),
 			utils.Bold(oldExpansion),
 			utils.Bold(expansion),

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -96,14 +96,14 @@ func statusRun(opts *StatusOptions) error {
 		if err != nil {
 			var missingScopes *api.MissingScopesError
 			if errors.As(err, &missingScopes) {
-				addMsg("%s %s: %s", utils.Red("X"), hostname, err)
+				addMsg("%s %s: %s", utils.RedX(), hostname, err)
 				if tokenIsWriteable {
 					addMsg("- To request missing scopes, run: %s %s\n",
 						utils.Bold("gh auth refresh -h"),
 						utils.Bold(hostname))
 				}
 			} else {
-				addMsg("%s %s: authentication failed", utils.Red("X"), hostname)
+				addMsg("%s %s: authentication failed", utils.RedX(), hostname)
 				addMsg("- The %s token in %s is no longer valid.", utils.Bold(hostname), tokenSource)
 				if tokenIsWriteable {
 					addMsg("- To re-authenticate, run: %s %s",

--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -129,10 +129,10 @@ func createRun(opts *CreateOptions) error {
 				return fmt.Errorf("This command requires the 'gist' OAuth scope.\nPlease re-authenticate by doing `gh config set -h github.com oauth_token ''` and running the command again.")
 			}
 		}
-		return fmt.Errorf("%s Failed to create gist: %w", utils.Red("X"), err)
+		return fmt.Errorf("%s Failed to create gist: %w", utils.RedX(), err)
 	}
 
-	fmt.Fprintf(errOut, "%s %s\n", utils.Green("✓"), completionMessage)
+	fmt.Fprintf(errOut, "%s %s\n", utils.GreenCheck(), completionMessage)
 
 	fmt.Fprintln(opts.IO.Out, gist.HTMLURL)
 

--- a/pkg/cmd/pr/review/review.go
+++ b/pkg/cmd/pr/review/review.go
@@ -175,7 +175,7 @@ func reviewRun(opts *ReviewOptions) error {
 	case api.ReviewComment:
 		fmt.Fprintf(opts.IO.ErrOut, "%s Reviewed pull request #%d\n", utils.Gray("-"), pr.Number)
 	case api.ReviewApprove:
-		fmt.Fprintf(opts.IO.ErrOut, "%s Approved pull request #%d\n", utils.Green("✓"), pr.Number)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Approved pull request #%d\n", utils.GreenCheck(), pr.Number)
 	case api.ReviewRequestChanges:
 		fmt.Fprintf(opts.IO.ErrOut, "%s Requested changes to pull request #%d\n", utils.Red("+"), pr.Number)
 	}

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -246,7 +246,7 @@ func createRun(opts *CreateOptions) error {
 
 		stderr := opts.IO.ErrOut
 		stdout := opts.IO.Out
-		greenCheck := utils.Green("✓")
+		greenCheck := utils.GreenCheck()
 		isTTY := opts.IO.IsStdoutTTY()
 
 		if isTTY {


### PR DESCRIPTION
Not really a bug but some pieces of code use `utils.Green("✓")` when there's a `utils.GreenCheck()` available. Same with `utils.Red("X")` / `utils.RedX()`.

Filtered through the code for these and made the changes.