### PR TITLE
Don't send a request when the contents haven't changed

### DIFF
--- a/pkg/cmd/gist/edit/edit.go
+++ b/pkg/cmd/gist/edit/edit.go
@@ -174,6 +174,10 @@ func editRun(opts *EditOptions) error {
 		}
 	}
 
+	if len(filesToUpdate) == 0 {
+		return nil
+	}
+
 	err = updateGist(client, ghinstance.OverridableDefault(), gist)
 	if err != nil {
 		return err

--- a/pkg/cmd/gist/edit/edit_test.go
+++ b/pkg/cmd/gist/edit/edit_test.go
@@ -177,6 +177,19 @@ func Test_editRun(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "not change",
+			gist: &shared.Gist{
+				ID: "1234",
+				Files: map[string]*shared.GistFile{
+					"cicada.txt": {
+						Filename: "cicada.txt",
+						Content:  "new file content",
+						Type:     "text/plain",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
By doing this, the command will finish faster if the user canceled the editing.