### PR TITLE
Installation Guide on Linux

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -22,7 +22,7 @@ sudo apt update
 sudo apt install gh
 ```
 
-**Note**: If you are behind a firewall, the connection to `keyserver.ubuntu.com` might fail. In that case, try running `sudo apt-key adv --keyserver keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0`.
+**Note**: If you are behind a firewall, the connection to `keyserver.ubuntu.com` might fail. In that case, try running `sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0`.
 
 **Note**: most systems will have `apt-add-repository` already. If you get a _command not found_
 error, try running `sudo apt install software-properties-common` and trying these steps again.


### PR DESCRIPTION
With reference to a solution from the issue,  [Installation failed on Ubuntu 20 #1799](https://github.com/cli/cli/issues/1799), I have updated the installation guide.

When you run `sudo apt-key adv --keyserver keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0`, it doesn't really work unless you replace `keyserver.ubuntu.com:80 ` with `hkp://keyserver.ubuntu.com:80`