### PR TITLE
update upgrade command for updating the CLI for Debian, Ubuntu Linux (apt)

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -32,7 +32,7 @@ Upgrade:
 
 ```bash
 sudo apt update
-sudo apt install gh
+sudo apt upgrade gh 
 ```
 
 ### Fedora, Centos, Red Hat Linux (dnf)


### PR DESCRIPTION
With [reference](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-apt) to the instruction for updating the CLI for Debian, Ubuntu Linux (apt)

**Changes Made**

- Update the upgrade command from `sudo apt install gh` to `sudo apt upgrade gh`