### PR TITLE
Installation Guide on Linux - missing dependency

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -24,6 +24,8 @@ sudo apt install gh
 
 **Note**: If you are behind a firewall, the connection to `keyserver.ubuntu.com` might fail. In that case, try running `sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0`.
 
+**Note**: If you get _"gpg: failed to start the dirmngr '/usr/bin/dirmngr': No such file or directory"_ error, try installing the `dirmngr` package. Run `sudo apt-get install dirmngr` and repeat the steps above.  
+
 **Note**: most systems will have `apt-add-repository` already. If you get a _command not found_
 error, try running `sudo apt install software-properties-common` and trying these steps again.
 


### PR DESCRIPTION
Not sure if this is a common error or if this is the best way to describe the fix but thought I would add something to help others.

OS Version: Debian GNU/Linux 9.13 (stretch)

Error running first command of Debian install : `sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0`

Full error message:
```
Executing: /tmp/apt-key-gpghome.Fuep9VI9UN/gpg.1.sh --keyserver hkp://keyserver$
gpg: failed to start the dirmngr '/usr/bin/dirmngr': No such file or directory
gpg: connecting dirmngr at '/tmp/apt-key-gpghome.Fuep9VI9UN/S.dirmngr' failed: $
gpg: keyserver receive failed: No dirmngr
```
Reason:  Missing dependency `dirmngr`

solution: install `dirmngr` by running: `sudo apt-get install dirmngr`