### PR TITLE
Escape special characters when rendering a markdown

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"html"
 	"io"
 	"net/url"
 	"strings"
@@ -26,6 +27,8 @@ func RenderMarkdown(text string) (string, error) {
 	// Glamour rendering preserves carriage return characters in code blocks, but
 	// we need to ensure that no such characters are present in the output.
 	text = strings.ReplaceAll(text, "\r\n", "\n")
+
+	text = html.EscapeString(text)
 
 	renderStyle := glamour.WithStandardStyle("notty")
 	// TODO: make color an input parameter

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -33,6 +34,24 @@ func TestFuzzyAgo(t *testing.T) {
 		fuzzy := FuzzyAgo(d)
 		if fuzzy != expected {
 			t.Errorf("unexpected fuzzy duration value: %s for %s", fuzzy, duration)
+		}
+	}
+}
+
+func TestRenderMarkdown(t *testing.T) {
+	cases := map[string]string{
+		"<details>details</details>": "<details>details</details>",
+	}
+
+	for text, expected := range cases {
+		markdown, e := RenderMarkdown(text)
+		if e != nil {
+			t.Errorf("failed to render a markdown: %s", e)
+		}
+
+		markdown = strings.TrimSpace(markdown)
+		if markdown != expected {
+			t.Errorf("unexpected markdown value: %s for %s", markdown, text)
 		}
 	}
 }


### PR DESCRIPTION
Without this, HTML inside a text will be removed by `glamour`.