### PR TITLE
Respect interactive repo name input on create

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -111,29 +111,17 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 func createRun(opts *CreateOptions) error {
 	projectDir, projectDirErr := git.ToplevelDir()
-
-	var repoToCreate ghrepo.Interface
-
 	isNameAnArg := false
 	isDescEmpty := opts.Description == ""
 	isVisibilityPassed := false
 
 	if opts.Name != "" {
 		isNameAnArg = true
-		if strings.Contains(opts.Name, "/") {
-			var err error
-			repoToCreate, err = ghrepo.FromFullName(opts.Name)
-			if err != nil {
-				return fmt.Errorf("argument error: %w", err)
-			}
-		} else {
-			repoToCreate = ghrepo.New("", opts.Name)
-		}
 	} else {
 		if projectDirErr != nil {
 			return projectDirErr
 		}
-		repoToCreate = ghrepo.New("", path.Base(projectDir))
+		opts.Name = path.Base(projectDir)
 	}
 
 	enabledFlagCount := 0
@@ -159,7 +147,7 @@ func createRun(opts *CreateOptions) error {
 
 	// Trigger interactive prompt if name is not passed
 	if !isNameAnArg {
-		newName, newDesc, newVisibility, err := interactiveRepoCreate(isDescEmpty, isVisibilityPassed, repoToCreate.RepoName())
+		newName, newDesc, newVisibility, err := interactiveRepoCreate(isDescEmpty, isVisibilityPassed, opts.Name)
 		if err != nil {
 			return err
 		}
@@ -181,6 +169,18 @@ func createRun(opts *CreateOptions) error {
 			}
 			visibility = newVisibility
 		}
+	}
+
+	var repoToCreate ghrepo.Interface
+
+	if strings.Contains(opts.Name, "/") {
+		var err error
+		repoToCreate, err = ghrepo.FromFullName(opts.Name)
+		if err != nil {
+			return fmt.Errorf("argument error: %w", err)
+		}
+	} else {
+		repoToCreate = ghrepo.New("", opts.Name)
 	}
 
 	// Find template repo ID
@@ -303,6 +303,7 @@ func createRun(opts *CreateOptions) error {
 				fmt.Fprintf(stderr, "%s Initialized repository in './%s/'\n", utils.GreenCheck(), path)
 			}
 		}
+
 		return nil
 	}
 	fmt.Fprintln(opts.IO.Out, "Discarding...")
@@ -312,14 +313,14 @@ func createRun(opts *CreateOptions) error {
 func interactiveRepoCreate(isDescEmpty bool, isVisibilityPassed bool, repoName string) (string, string, string, error) {
 	qs := []*survey.Question{}
 
-	repoOwnerQuestion := &survey.Question{
-		Name: "repoOwner",
+	repoNameQuestion := &survey.Question{
+		Name: "repoName",
 		Prompt: &survey.Input{
 			Message: "Repository name",
 			Default: repoName,
 		},
 	}
-	qs = append(qs, repoOwnerQuestion)
+	qs = append(qs, repoNameQuestion)
 
 	if isDescEmpty {
 		repoDescriptionQuestion := &survey.Question{
@@ -344,7 +345,7 @@ func interactiveRepoCreate(isDescEmpty bool, isVisibilityPassed bool, repoName s
 	}
 
 	answers := struct {
-		RepoOwner       string
+		RepoName        string
 		RepoDescription string
 		RepoVisibility  string
 	}{}
@@ -355,8 +356,7 @@ func interactiveRepoCreate(isDescEmpty bool, isVisibilityPassed bool, repoName s
 		return "", "", "", err
 	}
 
-	return answers.RepoOwner, answers.RepoDescription, strings.ToUpper(answers.RepoVisibility), nil
-
+	return answers.RepoName, answers.RepoDescription, strings.ToUpper(answers.RepoVisibility), nil
 }
 
 func confirmSubmission(repoName string, repoOwner string, isConfirmFlagPassed *bool) (bool, error) {


### PR DESCRIPTION
This PR fixes the bug where the repo create interactive name prompt was being ignored. It also cleans up some variable naming in `interactiveRepoCreate` to be more accurate.

closes https://github.com/cli/cli/issues/1768