### PR TITLE
Allow disabling pager by setting it to ""

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -73,7 +73,7 @@ func main() {
 		cmdFactory.IOStreams.SetNeverPrompt(true)
 	}
 
-	if pager, _ := cfg.Get("", "pager"); pager != "" {
+	if pager, source, _ := cfg.GetWithSource("", "pager"); pager != "" || source != config.DefaultSource {
 		cmdFactory.IOStreams.SetPager(pager)
 	}
 

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	DefaultSource      = "default"
 	defaultGitProtocol = "https"
 	PromptsDisabled    = "disabled"
 	PromptsEnabled     = "enabled"
@@ -252,23 +253,23 @@ func (c *fileConfig) GetWithSource(hostname, key string) (string, string, error)
 	}
 
 	// TODO: avoid hardcoding this
-	defaultSource := "~/.config/gh/config.yml"
+	defaultConfigFileSource := "~/.config/gh/config.yml"
 
 	value, err := c.GetStringValue(key)
 
 	var notFound *NotFoundError
 
 	if err != nil && errors.As(err, &notFound) {
-		return defaultFor(key), defaultSource, nil
+		return defaultFor(key), DefaultSource, nil
 	} else if err != nil {
-		return "", defaultSource, err
+		return "", "", err
 	}
 
 	if value == "" {
-		return defaultFor(key), defaultSource, nil
+		return defaultFor(key), defaultConfigFileSource, nil
 	}
 
-	return value, defaultSource, nil
+	return value, defaultConfigFileSource, nil
 }
 
 func (c *fileConfig) Set(hostname, key, value string) error {
@@ -494,7 +495,7 @@ func (c *fileConfig) parseHosts(hostsEntry *yaml.Node) ([]*HostConfig, error) {
 }
 
 func defaultFor(key string) string {
-	// we only have a set default for one setting right now
+	// we only have a set default for two setting right now
 	switch key {
 	case "git_protocol":
 		return defaultGitProtocol

--- a/internal/config/from_env_test.go
+++ b/internal/config/from_env_test.go
@@ -40,7 +40,24 @@ func TestInheritEnv(t *testing.T) {
 			wants: wants{
 				hosts:     []string(nil),
 				token:     "",
-				source:    "~/.config/gh/config.yml",
+				source:    "default",
+				writeable: true,
+			},
+		},
+		{
+			name: "default value from file",
+			baseConfig: heredoc.Doc(`
+			hosts:
+			  github.com:
+			    oauth_token:
+			`),
+			GITHUB_TOKEN:            "",
+			GITHUB_ENTERPRISE_TOKEN: "",
+			hostname:                "github.com",
+			wants: wants{
+				hosts:     []string{"github.com"},
+				token:     "",
+				source:    "default",
 				writeable: true,
 			},
 		},
@@ -66,7 +83,7 @@ func TestInheritEnv(t *testing.T) {
 			wants: wants{
 				hosts:     []string{"github.com"},
 				token:     "",
-				source:    "~/.config/gh/config.yml",
+				source:    "default",
 				writeable: true,
 			},
 		},


### PR DESCRIPTION
Allow setting `pager` in config file to an empty string.  This disables
the pager completely and all output will be unpaged regardless of
the PAGER environment variable.

This replicates the behaviour of the `core.pager` Git configuration
option.