### PR TITLE
Fix `pr create` when branch was already pushed to a non-base remote

### DIFF
--- a/internal/run/stub.go
+++ b/internal/run/stub.go
@@ -1,0 +1,91 @@
+package run
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+type T interface {
+	Helper()
+	Errorf(string, ...interface{})
+}
+
+func Stub() (*CommandStubber, func(T)) {
+	cs := &CommandStubber{}
+	teardown := SetPrepareCmd(func(cmd *exec.Cmd) Runnable {
+		s := cs.find(cmd.Args)
+		if s == nil {
+			panic(fmt.Sprintf("no exec stub for `%s`", strings.Join(cmd.Args, " ")))
+		}
+		for _, c := range s.callbacks {
+			c(cmd.Args)
+		}
+		s.matched = true
+		return s
+	})
+
+	return cs, func(t T) {
+		defer teardown()
+		var unmatched []string
+		for _, s := range cs.stubs {
+			if s.matched {
+				continue
+			}
+			unmatched = append(unmatched, s.pattern.String())
+		}
+		if len(unmatched) == 0 {
+			return
+		}
+		t.Helper()
+		t.Errorf("umatched stubs (%d): %s", len(unmatched), strings.Join(unmatched, ", "))
+	}
+}
+
+type CommandStubber struct {
+	stubs []*commandStub
+}
+
+func (cs *CommandStubber) Register(p string, exitStatus int, output string, callbacks ...CommandCallback) {
+	cs.stubs = append(cs.stubs, &commandStub{
+		pattern:    regexp.MustCompile(p),
+		exitStatus: exitStatus,
+		stdout:     output,
+		callbacks:  callbacks,
+	})
+}
+
+func (cs *CommandStubber) find(args []string) *commandStub {
+	line := strings.Join(args, " ")
+	for _, s := range cs.stubs {
+		if !s.matched && s.pattern.MatchString(line) {
+			return s
+		}
+	}
+	return nil
+}
+
+type CommandCallback func([]string)
+
+type commandStub struct {
+	pattern    *regexp.Regexp
+	matched    bool
+	exitStatus int
+	stdout     string
+	callbacks  []CommandCallback
+}
+
+func (s *commandStub) Run() error {
+	if s.exitStatus != 0 {
+		return fmt.Errorf("%s exited with status %d", s.pattern, s.exitStatus)
+	}
+	return nil
+}
+
+func (s *commandStub) Output() ([]byte, error) {
+	if s.exitStatus != 0 {
+		return []byte(nil), fmt.Errorf("%s exited with status %d", s.pattern, s.exitStatus)
+	}
+	return []byte(s.stdout), nil
+}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -181,13 +181,12 @@ func createRun(opts *CreateOptions) error {
 		// determine whether the head branch is already pushed to a remote
 		if pushedTo := determineTrackingBranch(remotes, headBranch); pushedTo != nil {
 			isPushEnabled = false
-			for _, r := range remotes {
-				if r.Name != pushedTo.RemoteName {
-					continue
-				}
+			if r, err := remotes.FindByName(pushedTo.RemoteName); err == nil {
 				headRepo = r
 				headRemote = r
-				break
+				if !ghrepo.IsSame(baseRepo, headRepo) {
+					headBranchLabel = fmt.Sprintf("%s:%s", headRepo.RepoOwner(), headBranch)
+				}
 			}
 		}
 	}
@@ -315,7 +314,7 @@ func createRun(opts *CreateOptions) error {
 
 		if isTerminal {
 			fmt.Fprintf(opts.IO.ErrOut, message,
-				utils.Cyan(headBranch),
+				utils.Cyan(headBranchLabel),
 				utils.Cyan(baseBranch),
 				ghrepo.FullName(baseRepo))
 			if (title == "" || body == "") && defaultsErr != nil {

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -184,8 +184,9 @@ func createRun(opts *CreateOptions) error {
 			if r, err := remotes.FindByName(pushedTo.RemoteName); err == nil {
 				headRepo = r
 				headRemote = r
+				headBranchLabel = pushedTo.BranchName
 				if !ghrepo.IsSame(baseRepo, headRepo) {
-					headBranchLabel = fmt.Sprintf("%s:%s", headRepo.RepoOwner(), headBranch)
+					headBranchLabel = fmt.Sprintf("%s:%s", headRepo.RepoOwner(), pushedTo.BranchName)
 				}
 			}
 		}

--- a/pkg/prompt/stubber.go
+++ b/pkg/prompt/stubber.go
@@ -26,7 +26,7 @@ func InitAskStubber() (*AskStubber, func()) {
 		as.AskOnes = append(as.AskOnes, &p)
 		count := as.OneCount
 		as.OneCount += 1
-		if count > len(as.StubOnes) {
+		if count >= len(as.StubOnes) {
 			panic(fmt.Sprintf("more asks than stubs. most recent call: %v", p))
 		}
 		stubbedPrompt := as.StubOnes[count]


### PR DESCRIPTION
Bonus: also proposes a new command stubber for tests, one that matches commands by their invocation instead of sequentially and also asserts that all stubs have matched at the end of the test.

Fixes #1820, fixes #1762, fixes #1869, fixes #2001