### PR TITLE
Fix ubuntu installation docs

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -17,6 +17,7 @@ Install:
 
 ```bash
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+sudo apt-get install software-properties-common
 sudo apt-add-repository https://cli.github.com/packages
 sudo apt update
 sudo apt install gh


### PR DESCRIPTION
`apt-add-repository` is not necessarily installed by default. This package installs it.

citation: https://itsfoss.com/add-apt-repository-command-not-found/