### PR TITLE
:sparkles: Add curated list of subcommands to core `Short`

### DIFF
--- a/pkg/cmd/gist/gist.go
+++ b/pkg/cmd/gist/gist.go
@@ -13,7 +13,6 @@ import (
 func NewCmdGist(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gist",
-		Short: "Manage gists",
 		Long:  `Work with GitHub gists.`,
 		Annotations: map[string]string{
 			"IsCore": "true",
@@ -29,6 +28,8 @@ func NewCmdGist(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(gistListCmd.NewCmdList(f, nil))
 	cmd.AddCommand(gistViewCmd.NewCmdView(f, nil))
 	cmd.AddCommand(gistEditCmd.NewCmdEdit(f, nil))
+	
+	cmdutil.ApplyCuratedShort(cmd, "Gists", []string{"create", "view", "edit"})
 
 	return cmd
 }

--- a/pkg/cmd/gist/gist.go
+++ b/pkg/cmd/gist/gist.go
@@ -12,8 +12,8 @@ import (
 
 func NewCmdGist(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "gist",
-		Long:  `Work with GitHub gists.`,
+		Use:  "gist",
+		Long: `Work with GitHub gists.`,
 		Annotations: map[string]string{
 			"IsCore": "true",
 			"help:arguments": heredoc.Doc(`
@@ -28,7 +28,7 @@ func NewCmdGist(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(gistListCmd.NewCmdList(f, nil))
 	cmd.AddCommand(gistViewCmd.NewCmdView(f, nil))
 	cmd.AddCommand(gistEditCmd.NewCmdEdit(f, nil))
-	
+
 	cmdutil.ApplyCuratedShort(cmd, "Gists", []string{"create", "view", "edit"})
 
 	return cmd

--- a/pkg/cmd/issue/issue.go
+++ b/pkg/cmd/issue/issue.go
@@ -14,8 +14,8 @@ import (
 
 func NewCmdIssue(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "issue <command>",
-		Long:  `Work with GitHub issues`,
+		Use:  "issue <command>",
+		Long: `Work with GitHub issues`,
 		Example: heredoc.Doc(`
 			$ gh issue list
 			$ gh issue create --label bug
@@ -39,7 +39,7 @@ func NewCmdIssue(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(cmdReopen.NewCmdReopen(f, nil))
 	cmd.AddCommand(cmdStatus.NewCmdStatus(f, nil))
 	cmd.AddCommand(cmdView.NewCmdView(f, nil))
-	
+
 	cmdutil.ApplyCuratedShort(cmd, "Issues", []string{"create", "view", "close"})
 
 	return cmd

--- a/pkg/cmd/issue/issue.go
+++ b/pkg/cmd/issue/issue.go
@@ -15,7 +15,6 @@ import (
 func NewCmdIssue(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "issue <command>",
-		Short: "Manage issues",
 		Long:  `Work with GitHub issues`,
 		Example: heredoc.Doc(`
 			$ gh issue list
@@ -40,6 +39,8 @@ func NewCmdIssue(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(cmdReopen.NewCmdReopen(f, nil))
 	cmd.AddCommand(cmdStatus.NewCmdStatus(f, nil))
 	cmd.AddCommand(cmdView.NewCmdView(f, nil))
+	
+	cmdutil.ApplyCuratedShort(cmd, "Issues", []string{"create", "view", "close"})
 
 	return cmd
 }

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -21,7 +21,6 @@ import (
 func NewCmdPR(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pr <command>",
-		Short: "Manage pull requests",
 		Long:  "Work with GitHub pull requests",
 		Example: heredoc.Doc(`
 			$ gh pr checkout 353
@@ -53,6 +52,8 @@ func NewCmdPR(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(cmdStatus.NewCmdStatus(f, nil))
 	cmd.AddCommand(cmdView.NewCmdView(f, nil))
 	cmd.AddCommand(cmdChecks.NewCmdChecks(f, nil))
+	
+	cmdutil.ApplyCuratedShort(cmd, "Pull Requests", []string{"create", "review", "merge"})
 
 	return cmd
 }

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -20,8 +20,8 @@ import (
 
 func NewCmdPR(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "pr <command>",
-		Long:  "Work with GitHub pull requests",
+		Use:  "pr <command>",
+		Long: "Work with GitHub pull requests",
 		Example: heredoc.Doc(`
 			$ gh pr checkout 353
 			$ gh pr create --fill
@@ -52,7 +52,7 @@ func NewCmdPR(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(cmdStatus.NewCmdStatus(f, nil))
 	cmd.AddCommand(cmdView.NewCmdView(f, nil))
 	cmd.AddCommand(cmdChecks.NewCmdChecks(f, nil))
-	
+
 	cmdutil.ApplyCuratedShort(cmd, "Pull Requests", []string{"create", "review", "merge"})
 
 	return cmd

--- a/pkg/cmd/release/release.go
+++ b/pkg/cmd/release/release.go
@@ -13,7 +13,7 @@ import (
 
 func NewCmdRelease(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "release <command>",
+		Use: "release <command>",
 		Annotations: map[string]string{
 			"IsCore": "true",
 		},
@@ -27,7 +27,7 @@ func NewCmdRelease(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(cmdList.NewCmdList(f, nil))
 	cmd.AddCommand(cmdView.NewCmdView(f, nil))
 	cmd.AddCommand(cmdUpload.NewCmdUpload(f, nil))
-	
+
 	cmdutil.ApplyCuratedShort(cmd, "Releases", []string{"create", "view", "download"})
 
 	return cmd

--- a/pkg/cmd/release/release.go
+++ b/pkg/cmd/release/release.go
@@ -14,7 +14,6 @@ import (
 func NewCmdRelease(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "release <command>",
-		Short: "Manage GitHub releases",
 		Annotations: map[string]string{
 			"IsCore": "true",
 		},
@@ -28,6 +27,8 @@ func NewCmdRelease(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(cmdList.NewCmdList(f, nil))
 	cmd.AddCommand(cmdView.NewCmdView(f, nil))
 	cmd.AddCommand(cmdUpload.NewCmdUpload(f, nil))
+	
+	cmdutil.ApplyCuratedShort(cmd, "Releases", []string{"create", "view", "download"})
 
 	return cmd
 }

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -38,6 +38,8 @@ func NewCmdRepo(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(repoCreateCmd.NewCmdCreate(f, nil))
 	cmd.AddCommand(creditsCmd.NewCmdRepoCredits(f, nil))
 	cmd.AddCommand(gardenCmd.NewCmdGarden(f, nil))
+	
+	cmdutil.ApplyCuratedShort(cmd, "Repositories", []string{"create", "fork", "garden"})
 
 	return cmd
 }

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -38,7 +38,7 @@ func NewCmdRepo(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(repoCreateCmd.NewCmdCreate(f, nil))
 	cmd.AddCommand(creditsCmd.NewCmdRepoCredits(f, nil))
 	cmd.AddCommand(gardenCmd.NewCmdGarden(f, nil))
-	
+
 	cmdutil.ApplyCuratedShort(cmd, "Repositories", []string{"create", "fork", "garden"})
 
 	return cmd

--- a/pkg/cmdutil/short.go
+++ b/pkg/cmdutil/short.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ApplyCuratedShort(cmd *cobra.Command, resource string, commands []string) error {
-	commands = validCommandList(cmd, commands)
+	commands = filterValidChoices(cmd, commands)
 
 	if len(commands) == 0 {
 		return nil
@@ -21,7 +21,7 @@ func ApplyCuratedShort(cmd *cobra.Command, resource string, commands []string) e
 		commandList = fmt.Sprintf("%s and %s", strings.Join(front, ", "), back)
 	}
 
-	short := strings.Join([]string{commandList, resource}, " ")
+	short := commandList + " " + resource
 
 	if additional := len(cmd.Commands()) - len(commands); additional >= 1 {
 		short += fmt.Sprintf(" (+%v more)", additional)
@@ -32,21 +32,21 @@ func ApplyCuratedShort(cmd *cobra.Command, resource string, commands []string) e
 	return nil
 }
 
-func validCommandList(cmd *cobra.Command, commands []string) []string {
-	valid := commands[:0]
-	subCommands := []string{}
+func filterValidChoices(cmd *cobra.Command, commands []string) []string {
+	validChoices := []string{}
+	validOptions := []string{}
 
 	for _, sub := range cmd.Commands() {
-		subCommands = append(subCommands, sub.Name())
+		validOptions = append(validOptions, sub.Name())
 	}
 
 	for _, command := range commands {
-		for _, subCommand := range subCommands {
+		for _, subCommand := range validOptions {
 			if strings.EqualFold(command, subCommand) {
-				valid = append(valid, command)
+				validChoices = append(validChoices, command)
 			}
 		}
 	}
 
-	return valid
+	return validChoices
 }

--- a/pkg/cmdutil/short.go
+++ b/pkg/cmdutil/short.go
@@ -1,0 +1,52 @@
+package cmdutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func ApplyCuratedShort(cmd *cobra.Command, resource string, commands []string) error {
+	commands = validCommandList(cmd, commands)
+
+	if len(commands) == 0 {
+		return nil
+	}
+
+	commandList := commands[0]
+
+	if len(commands) > 1 {
+		back, front := commands[len(commands)-1], commands[:len(commands)-1]
+		commandList = fmt.Sprintf("%s and %s", strings.Join(front, ", "), back)
+	}
+
+	short := strings.Join([]string{commandList, resource}, " ")
+
+	if additional := len(cmd.Commands()) - len(commands); additional >= 1 {
+		short += fmt.Sprintf(" (+%v more)", additional)
+	}
+
+	cmd.Short = short
+
+	return nil
+}
+
+func validCommandList(cmd *cobra.Command, commands []string) []string {
+	valid := commands[:0]
+	subCommands := []string{}
+
+	for _, sub := range cmd.Commands() {
+		subCommands = append(subCommands, sub.Name())
+	}
+
+	for _, command := range commands {
+		for _, subCommand := range subCommands {
+			if strings.EqualFold(command, subCommand) {
+				valid = append(valid, command)
+			}
+		}
+	}
+
+	return valid
+}

--- a/pkg/cmdutil/short.go
+++ b/pkg/cmdutil/short.go
@@ -7,11 +7,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func ApplyCuratedShort(cmd *cobra.Command, resource string, commands []string) error {
+func ApplyCuratedShort(cmd *cobra.Command, resource string, commands []string) {
 	commands = filterValidChoices(cmd, commands)
 
 	if len(commands) == 0 {
-		return nil
+		return
 	}
 
 	commandList := commands[0]
@@ -28,8 +28,6 @@ func ApplyCuratedShort(cmd *cobra.Command, resource string, commands []string) e
 	}
 
 	cmd.Short = short
-
-	return nil
 }
 
 func filterValidChoices(cmd *cobra.Command, commands []string) []string {

--- a/pkg/cmdutil/short_test.go
+++ b/pkg/cmdutil/short_test.go
@@ -8,11 +8,11 @@ import (
 
 func TestCreateCuratedShortDescription(t *testing.T) {
 	exampleCommands := map[string]*cobra.Command{
-		"list":   &cobra.Command{Use: "list"},
-		"view":   &cobra.Command{Use: "view"},
-		"create": &cobra.Command{Use: "create"},
-		"edit":   &cobra.Command{Use: "edit"},
-		"delete": &cobra.Command{Use: "delete"},
+		"list":   {Use: "list"},
+		"view":   {Use: "view"},
+		"create": {Use: "create"},
+		"edit":   {Use: "edit"},
+		"delete": {Use: "delete"},
 	}
 
 	tests := []struct {

--- a/pkg/cmdutil/short_test.go
+++ b/pkg/cmdutil/short_test.go
@@ -1,0 +1,100 @@
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCreateCuratedShortDescription(t *testing.T) {
+	exampleCommands := map[string]*cobra.Command{
+		"list":   &cobra.Command{Use: "list"},
+		"view":   &cobra.Command{Use: "view"},
+		"create": &cobra.Command{Use: "create"},
+		"edit":   &cobra.Command{Use: "edit"},
+		"delete": &cobra.Command{Use: "delete"},
+	}
+
+	tests := []struct {
+		name        string
+		subCommands []string
+		curatedList []string
+		resource    string
+		want        string
+	}{
+		{
+			name:        "Lists only available subcommand",
+			subCommands: []string{"list"},
+			curatedList: []string{"list"},
+			resource:    "Somethings",
+			want:        "list Somethings",
+		},
+		{
+			name:        "Lists 2 subcommands",
+			subCommands: []string{"list", "view"},
+			curatedList: []string{"list", "view"},
+			resource:    "Somethings",
+			want:        "list and view Somethings",
+		},
+		{
+			name:        "Lists 3 subcommands",
+			subCommands: []string{"list", "view", "create"},
+			curatedList: []string{"list", "view", "create"},
+			resource:    "Somethings",
+			want:        "list, view and create Somethings",
+		},
+		{
+			name:        "Describes 1 additional subcommand",
+			subCommands: []string{"list", "view", "create", "delete"},
+			curatedList: []string{"list", "view", "create"},
+			resource:    "Somethings",
+			want:        "list, view and create Somethings (+1 more)",
+		},
+		{
+			name:        "Describes 2 additional subcommands",
+			subCommands: []string{"list", "view", "create", "edit", "delete"},
+			curatedList: []string{"list", "view", "create"},
+			resource:    "Somethings",
+			want:        "list, view and create Somethings (+2 more)",
+		},
+		{
+			name:        "Filters command that does not exist",
+			subCommands: []string{"list", "view"},
+			curatedList: []string{"list", "does-not-exist", "view"},
+			resource:    "Somethings",
+			want:        "list and view Somethings",
+		},
+		{
+			name:        "Does not change Short when no commands are provided",
+			subCommands: []string{"list", "view"},
+			curatedList: []string{},
+			resource:    "Somethings",
+			want:        "Default Short description.",
+		},
+		{
+			name:        "Allows case-change in command list",
+			subCommands: []string{"list", "view"},
+			curatedList: []string{"List", "view"},
+			resource:    "Somethings",
+			want:        "List and view Somethings",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{
+				Short: "Default Short description.",
+			}
+
+			for _, subCommand := range tt.subCommands {
+				cmd.AddCommand(exampleCommands[subCommand])
+			}
+
+			ApplyCuratedShort(cmd, tt.resource, tt.curatedList)
+
+			if got := cmd.Short; string(got) != tt.want {
+				t.Errorf("ApplyCuratedShort() = %v, want %v", string(got), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds `cmdutil.ApplyCuratedShort` which accepts a command, a resource name (e.g: `Pull Requests`) and a list of subcommand names which are then used to generate a human friendly list of subcommands supported for the `Short` description of the command.

Note: this is a speculative example to be reviewed by @ampinsk  -- in response to their [comment](https://github.com/cli/cli/issues/1777#issuecomment-698358094) on #1777. The PR is ready to go but marked as Draft so it isn't merged before @ampinsk has decided if this is the right direction :-) 

```console
CORE COMMANDS
  gist:       create, view and edit Gists (+1 more)
  issue:      create, view and close Issues (+3 more)
  pr:         create, review and merge Pull Requests (+9 more)
  release:    create, view and download Releases (+3 more)
  repo:       create, fork and garden Repositories (+3 more)
```

`ApplyCuratedShort` is explicitly added to a command _after_ the subcommands have been registered, e.g:

```go
//                              Resource             Curated list of commands
cmdutil.ApplyCuratedShort(cmd, "Releases", []string{"create", "view", "download"})
```

Some additional examples (as captured in the test cases):

1 command, all curated:

```console
  pr:         list Pull Requests
```

2 commands, all curated:

```console
  pr:         list and view Pull Requests
```

3 commands, all curated:

```console
  pr:         list, view and create Pull Requests
```

4 commands, 3 curated:

```console
  pr:         list, view and create Pull Requests (+1 more)
```

5 commands, 3 curated:

```console
  pr:         list, view and create Pull Requests (+2 more)
```

2 commands, 2 curated, `List` capitalised:

```console
  pr:         List and view Pull Requests
```

I added the curated list to each of the core commands, choosing the subcommands that best represent the breadth of functionality supported for that resource. 

Also, if this PR does make it into consideration, worth noting that this is my first _real world_ contribution in Go so I'd recommend a close review 🔎 

Thanks!