### PR TITLE
[#1971]  fixed to view the readme file in the current branch

### DIFF
--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -3,14 +3,14 @@ package view
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"text/template"
-	"os"
-	"io/ioutil"
-	"path/filepath"
-	"regexp"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
@@ -146,6 +146,10 @@ func viewRun(opts *ViewOptions) error {
 		topLevelDir, _ := git.ToplevelDir()
 		var files string
 		filepath.Walk(topLevelDir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil
+			}
+
 			files = files + " " + path
 			return nil
 		})
@@ -160,7 +164,7 @@ func viewRun(opts *ViewOptions) error {
 		isRemoteReadme = false
 		readme = &RepoReadme{
 			Filename: readmePath,
-			Content: string(readmeContent),
+			Content:  string(readmeContent),
 		}
 	}
 
@@ -222,7 +226,7 @@ func viewRun(opts *ViewOptions) error {
 		description = utils.Gray("No description provided")
 	}
 
-	branchPattern := "";
+	branchPattern := ""
 	if branchName != "" {
 		branchPattern = "tree/%s"
 	}
@@ -236,13 +240,13 @@ func viewRun(opts *ViewOptions) error {
 
 	repoData := struct {
 		FullName    string
-		ReadmeFile	string
+		ReadmeFile  string
 		Description string
 		Readme      string
 		View        string
 	}{
 		FullName:    utils.Bold(fullName),
-		ReadmeFile:	 readmeFileDescription,
+		ReadmeFile:  readmeFileDescription,
 		Description: description,
 		Readme:      readmeContent,
 		View:        utils.Gray(fmt.Sprintf("View this repository on GitHub: %s", openURL)),

--- a/pkg/cmd/repo/view/view_test.go
+++ b/pkg/cmd/repo/view/view_test.go
@@ -229,7 +229,7 @@ func Test_ViewRun(t *testing.T) {
 			`),
 		},
 		{
-			name: "dot arg",
+			name:      "dot arg",
 			repoName: ".",
 			opts: &ViewOptions{
 				RepoArg: ".",

--- a/pkg/cmd/repo/view/view_test.go
+++ b/pkg/cmd/repo/view/view_test.go
@@ -178,6 +178,7 @@ func Test_ViewRun(t *testing.T) {
 			stdoutTTY: true,
 			wantOut: heredoc.Doc(`
 				jill/valentine
+				https://github.com/jill/valentine (remote)
 				social distancing
 
 
@@ -197,6 +198,7 @@ func Test_ViewRun(t *testing.T) {
 			stdoutTTY: true,
 			wantOut: heredoc.Doc(`
 				jill/valentine
+				https://github.com/jill/valentine (remote)
 				social distancing
 
 
@@ -215,6 +217,7 @@ func Test_ViewRun(t *testing.T) {
 			stdoutTTY: true,
 			wantOut: heredoc.Doc(`
 				OWNER/REPO
+				https://github.com/OWNER/REPO/tree/feat/awesome (remote)
 				social distancing
 
 
@@ -226,10 +229,24 @@ func Test_ViewRun(t *testing.T) {
 			`),
 		},
 		{
+			name: "dot arg",
+			repoName: ".",
+			opts: &ViewOptions{
+				RepoArg: ".",
+			},
+			wantOut: heredoc.Doc(`
+				name:	OWNER/REPO
+				description:	social distancing
+				--
+				# truly cool readme check it out
+				`),
+		},
+		{
 			name:      "no args",
 			stdoutTTY: true,
 			wantOut: heredoc.Doc(`
 				OWNER/REPO
+				https://github.com/OWNER/REPO (remote)
 				social distancing
 
 
@@ -246,7 +263,7 @@ func Test_ViewRun(t *testing.T) {
 			tt.opts = &ViewOptions{}
 		}
 
-		if tt.repoName == "" {
+		if tt.repoName == "" || tt.repoName == "." {
 			tt.repoName = "OWNER/REPO"
 		}
 
@@ -268,6 +285,15 @@ func Test_ViewRun(t *testing.T) {
 			httpmock.StringResponse(`
 		{ "name": "readme.md",
 		"content": "IyB0cnVseSBjb29sIHJlYWRtZSBjaGVjayBpdCBvdXQ="}`))
+
+		if tt.opts.RepoArg == "." {
+			reg.Register(
+				httpmock.GraphQL(`query UserCurrent\b`),
+				httpmock.StringResponse(`
+				{ "data": { "viewer": {
+					"login": "OWNER"
+			}}}`))
+		}
 
 		tt.opts.HttpClient = func() (*http.Client, error) {
 			return &http.Client{Transport: reg}, nil
@@ -299,6 +325,7 @@ func Test_ViewRun_NonMarkdownReadme(t *testing.T) {
 			name: "tty",
 			wantOut: heredoc.Doc(`
 			OWNER/REPO
+			https://github.com/OWNER/REPO (remote)
 			social distancing
 
 			# truly cool readme check it out
@@ -369,6 +396,7 @@ func Test_ViewRun_NoReadme(t *testing.T) {
 			name: "tty",
 			wantOut: heredoc.Doc(`
 			OWNER/REPO
+			https://github.com/OWNER/REPO (remote)
 			social distancing
 
 			This repository does not have a README
@@ -435,6 +463,7 @@ func Test_ViewRun_NoDescription(t *testing.T) {
 			name: "tty",
 			wantOut: heredoc.Doc(`
 			OWNER/REPO
+			https://github.com/OWNER/REPO (remote)
 			No description provided
 
 			# truly cool readme check it out
@@ -565,6 +594,7 @@ func Test_ViewRun_HandlesSpecialCharacters(t *testing.T) {
 			stdoutTTY: true,
 			wantOut: heredoc.Doc(`
 				OWNER/REPO
+				https://github.com/OWNER/REPO (remote)
 				Some basic special characters " & / < > '
 
 


### PR DESCRIPTION
<!--
Please make sure you read our contributing guidelines at
https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md
before opening a pull request. Thanks!
-->

## Summary

closes #1971

## Details

Added a dot option to view the current branch's readme.md file

`gh repo view .`


* takes the remote branch of the current user if exist
* otherwise takes the readme file in my local

Also added the description in the view if the displayed readme file is taken from remote or local

:tada: This is my first PR to this project! :raised_hands: 
