### PR TITLE
Don't override user provided title and body when --fill is used

### DIFF
--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -71,6 +71,7 @@ func runCommandWithRootDirOverridden(rt http.RoundTripper, remotes context.Remot
 
 	cmd := NewCmdCreate(factory, func(opts *CreateOptions) error {
 		opts.RootDirOverride = rootDir
+		// TODO(msfjarvis): Fix this case
 		return createRun(opts)
 	})
 	cmd.PersistentFlags().StringP("repo", "R", "", "")

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -71,7 +71,6 @@ func runCommandWithRootDirOverridden(rt http.RoundTripper, remotes context.Remot
 
 	cmd := NewCmdCreate(factory, func(opts *CreateOptions) error {
 		opts.RootDirOverride = rootDir
-		// TODO(msfjarvis): Fix this case
 		return createRun(opts)
 	})
 	cmd.PersistentFlags().StringP("repo", "R", "", "")


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/1400

I'm not a Go developer and couldn't find any pre-existing tests for the `--fill` flag so haven't added any in this PR. Existing tests (ran using `make test`) still pass.

I created this PR using my generated binary with this command: `./bin/gh pr create -t "Don't override user provided title and body when --fill is used" --fill -d` so I guess that is a test in itself :D 