### PR TITLE
issue create: Add special @me assignee (self)

### DIFF
--- a/pkg/cmd/alias/set/set.go
+++ b/pkg/cmd/alias/set/set.go
@@ -54,6 +54,10 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 			#=> gh pr view -w 123
 			
 			$ gh alias set bugs 'issue list --label="bugs"'
+			$ gh bugs
+
+			$ gh alias set homework 'issue list --assigned @me'
+			$ gh homework
 
 			$ gh alias set epicsBy 'issue list --author="$1" --label="epic"'
 			$ gh epicsBy vilmibm

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -86,7 +86,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmd.Flags().StringVarP(&opts.Title, "title", "t", "", "Supply a title. Will prompt for one otherwise.")
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Supply a body. Will prompt for one otherwise.")
 	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open the browser to create an issue")
-	cmd.Flags().StringSliceVarP(&opts.Assignees, "assignee", "a", nil, "Assign people by their `login`, use @me to self assign.")
+	cmd.Flags().StringSliceVarP(&opts.Assignees, "assignee", "a", nil, "Assign people by their `login`. Use \"@me\" to self-assign.")
 	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Add labels by `name`")
 	cmd.Flags().StringSliceVarP(&opts.Projects, "project", "p", nil, "Add the issue to projects by `name`")
 	cmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Add the issue to a milestone by `name`")

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/config"
 	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmd/pr/shared"
 	prShared "github.com/cli/cli/pkg/cmd/pr/shared"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
@@ -115,9 +116,15 @@ func createRun(opts *CreateOptions) (err error) {
 		milestones = []string{opts.Milestone}
 	}
 
+	meReplacer := shared.NewMeReplacer(apiClient, baseRepo.RepoHost())
+	assignees, err := meReplacer.ReplaceSlice(opts.Assignees)
+	if err != nil {
+		return err
+	}
+
 	tb := prShared.IssueMetadataState{
 		Type:       prShared.IssueMetadata,
-		Assignees:  opts.Assignees,
+		Assignees:  assignees,
 		Labels:     opts.Labels,
 		Projects:   opts.Projects,
 		Milestones: milestones,
@@ -131,11 +138,6 @@ func createRun(opts *CreateOptions) (err error) {
 			err = fmt.Errorf("failed to recover input: %w", err)
 			return
 		}
-	}
-
-	opts.Assignees, err = prShared.ReplaceAtMeLogin(opts.Assignees, apiClient, baseRepo)
-	if err != nil {
-		return err
 	}
 
 	if opts.WebMode {

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cli/cli/internal/config"
 	"github.com/cli/cli/internal/ghrepo"
 	issueShared "github.com/cli/cli/pkg/cmd/issue/shared"
+	"github.com/cli/cli/pkg/cmd/pr/shared"
 	prShared "github.com/cli/cli/pkg/cmd/pr/shared"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
@@ -91,15 +92,29 @@ func listRun(opts *ListOptions) error {
 
 	isTerminal := opts.IO.IsStdoutTTY()
 
+	meReplacer := shared.NewMeReplacer(apiClient, baseRepo.RepoHost())
+	filterAssignee, err := meReplacer.Replace(opts.Assignee)
+	if err != nil {
+		return err
+	}
+	filterAuthor, err := meReplacer.Replace(opts.Author)
+	if err != nil {
+		return err
+	}
+	filterMention, err := meReplacer.Replace(opts.Mention)
+	if err != nil {
+		return err
+	}
+
 	if opts.WebMode {
 		issueListURL := ghrepo.GenerateRepoURL(baseRepo, "issues")
 		openURL, err := prShared.ListURLWithQuery(issueListURL, prShared.FilterOptions{
 			Entity:    "issue",
 			State:     opts.State,
-			Assignee:  opts.Assignee,
+			Assignee:  filterAssignee,
 			Labels:    opts.Labels,
-			Author:    opts.Author,
-			Mention:   opts.Mention,
+			Author:    filterAuthor,
+			Mention:   filterMention,
 			Milestone: opts.Milestone,
 		})
 		if err != nil {
@@ -111,7 +126,7 @@ func listRun(opts *ListOptions) error {
 		return utils.OpenInBrowser(openURL)
 	}
 
-	listResult, err := api.IssueList(apiClient, baseRepo, opts.State, opts.Labels, opts.Assignee, opts.LimitResults, opts.Author, opts.Mention, opts.Milestone)
+	listResult, err := api.IssueList(apiClient, baseRepo, opts.State, opts.Labels, filterAssignee, opts.LimitResults, filterAuthor, filterMention, opts.Milestone)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -47,6 +47,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Example: heredoc.Doc(`
 			$ gh issue list -l "help wanted"
 			$ gh issue list -A monalisa
+			$ gh issue list -a @me
 			$ gh issue list --web
 			$ gh issue list --milestone 'MVP'
 		`),

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -146,7 +146,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	fl.BoolVarP(&opts.WebMode, "web", "w", false, "Open the web browser to create a pull request")
 	fl.BoolVarP(&opts.Autofill, "fill", "f", false, "Do not prompt for title/body and just use commit info")
 	fl.StringSliceVarP(&opts.Reviewers, "reviewer", "r", nil, "Request reviews from people or teams by their `handle`")
-	fl.StringSliceVarP(&opts.Assignees, "assignee", "a", nil, "Assign people by their `login`")
+	fl.StringSliceVarP(&opts.Assignees, "assignee", "a", nil, "Assign people by their `login`. Use \"@me\" to self-assign.")
 	fl.StringSliceVarP(&opts.Labels, "label", "l", nil, "Add labels by `name`")
 	fl.StringSliceVarP(&opts.Projects, "project", "p", nil, "Add the pull request to projects by `name`")
 	fl.StringVarP(&opts.Milestone, "milestone", "m", "", "Add the pull request to a milestone by `name`")

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -61,7 +61,7 @@ type CreateContext struct {
 	// This struct stores contextual data about the creation process and is for building up enough
 	// data to create a pull request
 	RepoContext        *context.ResolvedRemotes
-	BaseRepo           ghrepo.Interface
+	BaseRepo           *api.Repository
 	HeadRepo           ghrepo.Interface
 	BaseTrackingBranch string
 	BaseBranch         string
@@ -264,7 +264,7 @@ func createRun(opts *CreateOptions) (err error) {
 		}
 	}
 
-	allowMetadata := ctx.BaseRepo.(*api.Repository).ViewerCanTriage()
+	allowMetadata := ctx.BaseRepo.ViewerCanTriage()
 	action, err := shared.ConfirmSubmission(!state.HasMetadata(), allowMetadata)
 	if err != nil {
 		return fmt.Errorf("unable to confirm: %w", err)
@@ -597,7 +597,7 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 	}
 
 	opts.IO.StartProgressIndicator()
-	pr, err := api.CreatePullRequest(client, ctx.BaseRepo.(*api.Repository), params)
+	pr, err := api.CreatePullRequest(client, ctx.BaseRepo, params)
 	opts.IO.StopProgressIndicator()
 	if pr != nil {
 		fmt.Fprintln(opts.IO.Out, pr.URL)

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -386,10 +386,16 @@ func NewIssueState(ctx CreateContext, opts CreateOptions) (*shared.IssueMetadata
 		milestoneTitles = []string{opts.Milestone}
 	}
 
+	meReplacer := shared.NewMeReplacer(ctx.Client, ctx.BaseRepo.RepoHost())
+	assignees, err := meReplacer.ReplaceSlice(opts.Assignees)
+	if err != nil {
+		return nil, err
+	}
+
 	state := &shared.IssueMetadataState{
 		Type:       shared.PRMetadata,
 		Reviewers:  opts.Reviewers,
-		Assignees:  opts.Assignees,
+		Assignees:  assignees,
 		Labels:     opts.Labels,
 		Projects:   opts.Projects,
 		Milestones: milestoneTitles,

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/config"
@@ -873,7 +874,7 @@ func Test_generateCompareURL(t *testing.T) {
 		{
 			name: "basic",
 			ctx: CreateContext{
-				BaseRepo:        ghrepo.New("OWNER", "REPO"),
+				BaseRepo:        api.InitRepoHostname(&api.Repository{Name: "REPO", Owner: api.RepositoryOwner{Login: "OWNER"}}, "github.com"),
 				BaseBranch:      "main",
 				HeadBranchLabel: "feature",
 			},
@@ -883,7 +884,7 @@ func Test_generateCompareURL(t *testing.T) {
 		{
 			name: "with labels",
 			ctx: CreateContext{
-				BaseRepo:        ghrepo.New("OWNER", "REPO"),
+				BaseRepo:        api.InitRepoHostname(&api.Repository{Name: "REPO", Owner: api.RepositoryOwner{Login: "OWNER"}}, "github.com"),
 				BaseBranch:      "a",
 				HeadBranchLabel: "b",
 			},
@@ -896,7 +897,7 @@ func Test_generateCompareURL(t *testing.T) {
 		{
 			name: "complex branch names",
 			ctx: CreateContext{
-				BaseRepo:        ghrepo.New("OWNER", "REPO"),
+				BaseRepo:        api.InitRepoHostname(&api.Repository{Name: "REPO", Owner: api.RepositoryOwner{Login: "OWNER"}}, "github.com"),
 				BaseBranch:      "main/trunk",
 				HeadBranchLabel: "owner:feature",
 			},

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -78,7 +78,7 @@ func Test_listURLWithQuery(t *testing.T) {
 	}
 }
 
-func TestReplaceAtMeLogin(t *testing.T) {
+func TestMeReplacer_Replace(t *testing.T) {
 	rtSuccess := &httpmock.Registry{}
 	rtSuccess.Register(
 		httpmock.GraphQL(`query UserCurrent\b`),
@@ -129,13 +129,14 @@ func TestReplaceAtMeLogin(t *testing.T) {
 				logins: []string{"some", "@me", "other"},
 			},
 			verify:  rtFailure.Verify,
-			want:    []string{"some", "@me", "other"},
+			want:    []string(nil),
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ReplaceAtMeLogin(tt.args.logins, tt.args.client, tt.args.repo)
+			me := NewMeReplacer(tt.args.client, tt.args.repo.RepoHost())
+			got, err := me.ReplaceSlice(tt.args.logins)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReplaceAtMeLogin() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -1,6 +1,14 @@
 package shared
 
-import "testing"
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/httpmock"
+)
 
 func Test_listURLWithQuery(t *testing.T) {
 	type args struct {
@@ -65,6 +73,79 @@ func Test_listURLWithQuery(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("listURLWithQuery() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReplaceAtMeLogin(t *testing.T) {
+	rtSuccess := &httpmock.Registry{}
+	rtSuccess.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StringResponse(`
+		{ "data": {
+			"viewer": { "login": "ResolvedLogin" }
+		} }
+		`),
+	)
+
+	rtFailure := &httpmock.Registry{}
+	rtFailure.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StatusStringResponse(500, `
+		{ "data": {
+			"viewer": { }
+		} }
+		`),
+	)
+
+	type args struct {
+		logins []string
+		client *api.Client
+		repo   ghrepo.Interface
+	}
+	tests := []struct {
+		name    string
+		args    args
+		verify  func(t httpmock.Testing)
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "succeeds resolving the userlogin",
+			args: args{
+				client: api.NewClientFromHTTP(&http.Client{Transport: rtSuccess}),
+				repo:   ghrepo.New("OWNER", "REPO"),
+				logins: []string{"some", "@me", "other"},
+			},
+			verify: rtSuccess.Verify,
+			want:   []string{"some", "ResolvedLogin", "other"},
+		},
+		{
+			name: "fails resolving the userlogin",
+			args: args{
+				client: api.NewClientFromHTTP(&http.Client{Transport: rtFailure}),
+				repo:   ghrepo.New("OWNER", "REPO"),
+				logins: []string{"some", "@me", "other"},
+			},
+			verify:  rtFailure.Verify,
+			want:    []string{"some", "@me", "other"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReplaceAtMeLogin(tt.args.logins, tt.args.client, tt.args.repo)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReplaceAtMeLogin() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReplaceAtMeLogin() = %v, want %v", got, tt.want)
+			}
+
+			if tt.verify != nil {
+				tt.verify(t)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
This patch adds a new special handling of the `@me` string when it is
passed as an assignee, to resolve to the currently authenticated user
login which is then resolved to ID using the already existing flow.

## Related issues
Closes #965