### PR TITLE
Small readability and code organization refactors

### DIFF
--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -1,4 +1,4 @@
-package root
+package completion
 
 import (
 	"errors"
@@ -6,11 +6,11 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/pkg/cmdutil"
-	"github.com/cli/cli/pkg/iostreams"
 	"github.com/spf13/cobra"
 )
 
-func NewCmdCompletion(io *iostreams.IOStreams) *cobra.Command {
+func NewCmdCompletion(f *cmdutil.Factory) *cobra.Command {
+	io := f.IOStreams
 	var shellType string
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
 	"github.com/spf13/cobra"
 )
 
-func NewCmdCompletion(f *cmdutil.Factory) *cobra.Command {
-	io := f.IOStreams
+func NewCmdCompletion(io *iostreams.IOStreams) *cobra.Command {
 	var shellType string
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/completion/completion_test.go
+++ b/pkg/cmd/completion/completion_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
@@ -46,10 +45,7 @@ func TestNewCmdCompletion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			io, _, stdout, stderr := iostreams.Test()
-			f := &cmdutil.Factory{
-				IOStreams: io,
-			}
-			completeCmd := NewCmdCompletion(f)
+			completeCmd := NewCmdCompletion(io)
 			rootCmd := &cobra.Command{Use: "gh"}
 			rootCmd.AddCommand(completeCmd)
 

--- a/pkg/cmd/completion/completion_test.go
+++ b/pkg/cmd/completion/completion_test.go
@@ -1,9 +1,10 @@
-package root
+package completion
 
 import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
@@ -45,7 +46,10 @@ func TestNewCmdCompletion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			io, _, stdout, stderr := iostreams.Test()
-			completeCmd := NewCmdCompletion(io)
+			f := &cmdutil.Factory{
+				IOStreams: io,
+			}
+			completeCmd := NewCmdCompletion(f)
 			rootCmd := &cobra.Command{Use: "gh"}
 			rootCmd.AddCommand(completeCmd)
 

--- a/pkg/cmd/root/help.go
+++ b/pkg/cmd/root/help.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/text"
 	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func rootUsageFunc(command *cobra.Command) error {
@@ -31,6 +33,13 @@ func rootUsageFunc(command *cobra.Command) error {
 		command.Print(text.Indent(dedent(flagUsages), "  "))
 	}
 	return nil
+}
+
+func rootFlagErrrorFunc(cmd *cobra.Command, err error) error {
+	if err == pflag.ErrHelp {
+		return err
+	}
+	return &cmdutil.FlagError{Err: err}
 }
 
 var hasFailed bool

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -67,7 +67,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(configCmd.NewCmdConfig(f))
 	cmd.AddCommand(creditsCmd.NewCmdCredits(f, nil))
 	cmd.AddCommand(gistCmd.NewCmdGist(f))
-	cmd.AddCommand(completionCmd.NewCmdCompletion(f))
+	cmd.AddCommand(completionCmd.NewCmdCompletion(f.IOStreams))
 
 	// the `api` command should not inherit any extra HTTP headers
 	bareHTTPCmdFactory := *f

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -24,7 +24,6 @@ import (
 	creditsCmd "github.com/cli/cli/pkg/cmd/repo/credits"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
@@ -73,13 +72,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.PersistentFlags().Bool("help", false, "Show help for command")
 	cmd.SetHelpFunc(rootHelpFunc)
 	cmd.SetUsageFunc(rootUsageFunc)
-
-	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		if err == pflag.ErrHelp {
-			return err
-		}
-		return &cmdutil.FlagError{Err: err}
-	})
+	cmd.SetFlagErrorFunc(rootFlagErrrorFunc)
 
 	cmdutil.DisableAuthCheck(cmd)
 
@@ -90,9 +83,6 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(creditsCmd.NewCmdCredits(f, nil))
 	cmd.AddCommand(gistCmd.NewCmdGist(f))
 	cmd.AddCommand(completionCmd.NewCmdCompletion(f))
-
-	// Help topics
-	cmd.AddCommand(NewHelpTopic("environment"))
 
 	// the `api` command should not inherit any extra HTTP headers
 	bareHTTPCmdFactory := *f
@@ -108,6 +98,9 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(issueCmd.NewCmdIssue(&repoResolvingCmdFactory))
 	cmd.AddCommand(releaseCmd.NewCmdRelease(&repoResolvingCmdFactory))
 	cmd.AddCommand(repoCmd.NewCmdRepo(&repoResolvingCmdFactory))
+
+	// Help topics
+	cmd.AddCommand(NewHelpTopic("environment"))
 
 	return cmd
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -74,8 +74,6 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.SetUsageFunc(rootUsageFunc)
 	cmd.SetFlagErrorFunc(rootFlagErrrorFunc)
 
-	cmdutil.DisableAuthCheck(cmd)
-
 	// Child commands
 	cmd.AddCommand(aliasCmd.NewCmdAlias(f))
 	cmd.AddCommand(authCmd.NewCmdAuth(f))
@@ -101,6 +99,8 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 
 	// Help topics
 	cmd.AddCommand(NewHelpTopic("environment"))
+
+	cmdutil.DisableAuthCheck(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -13,6 +13,7 @@ import (
 	aliasCmd "github.com/cli/cli/pkg/cmd/alias"
 	apiCmd "github.com/cli/cli/pkg/cmd/api"
 	authCmd "github.com/cli/cli/pkg/cmd/auth"
+	completionCmd "github.com/cli/cli/pkg/cmd/completion"
 	configCmd "github.com/cli/cli/pkg/cmd/config"
 	"github.com/cli/cli/pkg/cmd/factory"
 	gistCmd "github.com/cli/cli/pkg/cmd/gist"
@@ -88,7 +89,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(configCmd.NewCmdConfig(f))
 	cmd.AddCommand(creditsCmd.NewCmdCredits(f, nil))
 	cmd.AddCommand(gistCmd.NewCmdGist(f))
-	cmd.AddCommand(NewCmdCompletion(f.IOStreams))
+	cmd.AddCommand(completionCmd.NewCmdCompletion(f))
 
 	// Help topics
 	cmd.AddCommand(NewHelpTopic("environment"))

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -95,13 +95,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 
 	// the `api` command should not inherit any extra HTTP headers
 	bareHTTPCmdFactory := *f
-	bareHTTPCmdFactory.HttpClient = func() (*http.Client, error) {
-		cfg, err := bareHTTPCmdFactory.Config()
-		if err != nil {
-			return nil, err
-		}
-		return factory.NewHTTPClient(bareHTTPCmdFactory.IOStreams, cfg, version, false), nil
-	}
+	bareHTTPCmdFactory.HttpClient = bareHTTPClient(f, version)
 
 	cmd.AddCommand(apiCmd.NewCmdApi(&bareHTTPCmdFactory, nil))
 
@@ -115,6 +109,16 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(repoCmd.NewCmdRepo(&repoResolvingCmdFactory))
 
 	return cmd
+}
+
+func bareHTTPClient(f *cmdutil.Factory, version string) func() (*http.Client, error) {
+	return func() (*http.Client, error) {
+		cfg, err := f.Config()
+		if err != nil {
+			return nil, err
+		}
+		return factory.NewHTTPClient(f.IOStreams, cfg, version, false), nil
+	}
 }
 
 func resolvedBaseRepo(f *cmdutil.Factory) func() (ghrepo.Interface, error) {

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -1,0 +1,45 @@
+package version
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdVersion(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "version",
+		Hidden: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprint(f.IOStreams.Out, Format(version, buildDate))
+		},
+	}
+
+	cmdutil.DisableAuthCheck(cmd)
+
+	return cmd
+}
+
+func Format(version, buildDate string) string {
+	version = strings.TrimPrefix(version, "v")
+
+	if buildDate != "" {
+		version = fmt.Sprintf("%s (%s)", version, buildDate)
+	}
+
+	return fmt.Sprintf("gh version %s\n%s\n", version, changelogURL(version))
+}
+
+func changelogURL(version string) string {
+	path := "https://github.com/cli/cli"
+	r := regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[\w.]+)?$`)
+	if !r.MatchString(version) {
+		return fmt.Sprintf("%s/releases/latest", path)
+	}
+
+	url := fmt.Sprintf("%s/releases/tag/v%s", path, strings.TrimPrefix(version, "v"))
+	return url
+}

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -1,4 +1,4 @@
-package root
+package version
 
 import (
 	"testing"


### PR DESCRIPTION
I was exploring the `root` command a bit and noticed a few things that could be cleaned up for improved readability and better code organization. These are completely opinion based style changes and have no functionality differences.

* Extracted `bareHTTPClient` into its own function
* Moved the `completion` command out of root package into its own to match other commands
* Moved the `version` command out of root package into its own to match other commands
* Extract `rootFlagErrrorFunc` out of root into root help along with the other root functions
* Moved the disable auth check to bottom of setting up root command