### PR TITLE
Display url for pr status

### DIFF
--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -236,6 +236,8 @@ func printPrs(w io.Writer, totalCount int, prs ...api.PullRequest) {
 			fmt.Fprintf(w, " - %s", shared.StateTitleWithColor(pr))
 		}
 
+		fmt.Fprintf(w, " %s", pr.URL)
+
 		fmt.Fprint(w, "\n")
 	}
 	remaining := totalCount - len(prs)


### PR DESCRIPTION
I think this is convenient to display url in `gh pr status` 😄 
![image](https://user-images.githubusercontent.com/18569016/94452583-a957a300-01ea-11eb-8959-b46914862a77.png)
