### PR TITLE
Avoding --short option in git symbolic-ref for getting the current branch

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -294,9 +294,5 @@ func firstLine(output []byte) string {
 
 func getBranchShortName(output []byte) string {
 	branch := firstLine(output)
-	prefix := "refs/heads/"
-	if i := strings.Index(branch, prefix); i != -1 {
-		return branch[i+len(prefix):]
-	}
-	return branch
+	return strings.TrimPrefix(branch, "refs/heads/")
 }

--- a/git/git.go
+++ b/git/git.go
@@ -56,9 +56,16 @@ func ShowRefs(ref ...string) ([]Ref, error) {
 
 // CurrentBranch reads the checked-out branch for the git repository
 func CurrentBranch() (string, error) {
-	refCmd := GitCommand("symbolic-ref", "--quiet", "--short", "HEAD")
+	// Available from Git 2.22 and above
+	branchCmd := GitCommand("branch", "--show-current")
+	output, err := run.PrepareCmd(branchCmd).Output()
 
-	output, err := run.PrepareCmd(refCmd).Output()
+	// Fallback to symbolic-ref
+	if err != nil {
+		refCmd := GitCommand("symbolic-ref", "--quiet", "--short", "HEAD")
+		output, err = run.PrepareCmd(refCmd).Output()
+	}
+
 	if err == nil {
 		// Found the branch name
 		return firstLine(output), nil

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -58,10 +58,31 @@ func Test_CurrentBranch(t *testing.T) {
 	}
 }
 
+func Test_CurrentBranch_show_current_error(t *testing.T) {
+	cs, teardown := test.InitCmdStubber()
+	defer teardown()
+
+	cs.StubError("")
+	expected := "branch-name"
+	cs.Stub(expected)
+
+	result, err := CurrentBranch()
+	if err != nil {
+		t.Errorf("got unexpected error: %w", err)
+	}
+	if len(cs.Calls) != 2 {
+		t.Errorf("expected 2 git calls, saw %d", len(cs.Calls))
+	}
+	if result != expected {
+		t.Errorf("unexpected branch name: %s instead of %s", result, expected)
+	}
+}
+
 func Test_CurrentBranch_detached_head(t *testing.T) {
 	cs, teardown := test.InitCmdStubber()
 	defer teardown()
 
+	cs.StubError("")
 	cs.StubError("")
 
 	_, err := CurrentBranch()
@@ -71,8 +92,8 @@ func Test_CurrentBranch_detached_head(t *testing.T) {
 	if err != ErrNotOnAnyBranch {
 		t.Errorf("got unexpected error: %s instead of %s", err, ErrNotOnAnyBranch)
 	}
-	if len(cs.Calls) != 1 {
-		t.Errorf("expected 1 git call, saw %d", len(cs.Calls))
+	if len(cs.Calls) != 2 {
+		t.Errorf("expected 2 git calls, saw %d", len(cs.Calls))
 	}
 }
 
@@ -80,6 +101,7 @@ func Test_CurrentBranch_unexpected_error(t *testing.T) {
 	cs, teardown := test.InitCmdStubber()
 	defer teardown()
 
+	cs.StubError("lol")
 	cs.StubError("lol")
 
 	expectedError := "lol\nstub: lol"
@@ -91,8 +113,8 @@ func Test_CurrentBranch_unexpected_error(t *testing.T) {
 	if err.Error() != expectedError {
 		t.Errorf("got unexpected error: %s instead of %s", err.Error(), expectedError)
 	}
-	if len(cs.Calls) != 1 {
-		t.Errorf("expected 1 git call, saw %d", len(cs.Calls))
+	if len(cs.Calls) != 2 {
+		t.Errorf("expected 2 git calls, saw %d", len(cs.Calls))
 	}
 }
 

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -39,42 +39,36 @@ func Test_UncommittedChangeCount(t *testing.T) {
 }
 
 func Test_CurrentBranch(t *testing.T) {
-	cs, teardown := test.InitCmdStubber()
-	defer teardown()
-
-	expected := "branch-name"
-
-	cs.Stub(expected)
-
-	result, err := CurrentBranch()
-	if err != nil {
-		t.Errorf("got unexpected error: %w", err)
+	type c struct {
+		Stub     string
+		Expected string
 	}
-	if len(cs.Calls) != 1 {
-		t.Errorf("expected 1 git call, saw %d", len(cs.Calls))
+	cases := []c{
+		{
+			Stub:     "branch-name",
+			Expected: "branch-name",
+		},
+		{
+			Stub:     "refs/heads/branch-name",
+			Expected: "branch-name",
+		},
 	}
-	if result != expected {
-		t.Errorf("unexpected branch name: %s instead of %s", result, expected)
-	}
-}
 
-func Test_CurrentBranch_show_current_error(t *testing.T) {
-	cs, teardown := test.InitCmdStubber()
-	defer teardown()
+	for _, v := range cases {
+		cs, teardown := test.InitCmdStubber()
+		cs.Stub(v.Stub)
 
-	cs.StubError("")
-	expected := "branch-name"
-	cs.Stub(expected)
-
-	result, err := CurrentBranch()
-	if err != nil {
-		t.Errorf("got unexpected error: %w", err)
-	}
-	if len(cs.Calls) != 2 {
-		t.Errorf("expected 2 git calls, saw %d", len(cs.Calls))
-	}
-	if result != expected {
-		t.Errorf("unexpected branch name: %s instead of %s", result, expected)
+		result, err := CurrentBranch()
+		if err != nil {
+			t.Errorf("got unexpected error: %w", err)
+		}
+		if len(cs.Calls) != 1 {
+			t.Errorf("expected 1 git call, saw %d", len(cs.Calls))
+		}
+		if result != v.Expected {
+			t.Errorf("unexpected branch name: %s instead of %s", result, v.Expected)
+		}
+		teardown()
 	}
 }
 
@@ -82,7 +76,6 @@ func Test_CurrentBranch_detached_head(t *testing.T) {
 	cs, teardown := test.InitCmdStubber()
 	defer teardown()
 
-	cs.StubError("")
 	cs.StubError("")
 
 	_, err := CurrentBranch()
@@ -92,8 +85,8 @@ func Test_CurrentBranch_detached_head(t *testing.T) {
 	if err != ErrNotOnAnyBranch {
 		t.Errorf("got unexpected error: %s instead of %s", err, ErrNotOnAnyBranch)
 	}
-	if len(cs.Calls) != 2 {
-		t.Errorf("expected 2 git calls, saw %d", len(cs.Calls))
+	if len(cs.Calls) != 1 {
+		t.Errorf("expected 1 git call, saw %d", len(cs.Calls))
 	}
 }
 
@@ -101,7 +94,6 @@ func Test_CurrentBranch_unexpected_error(t *testing.T) {
 	cs, teardown := test.InitCmdStubber()
 	defer teardown()
 
-	cs.StubError("lol")
 	cs.StubError("lol")
 
 	expectedError := "lol\nstub: lol"
@@ -113,8 +105,8 @@ func Test_CurrentBranch_unexpected_error(t *testing.T) {
 	if err.Error() != expectedError {
 		t.Errorf("got unexpected error: %s instead of %s", err.Error(), expectedError)
 	}
-	if len(cs.Calls) != 2 {
-		t.Errorf("expected 2 git calls, saw %d", len(cs.Calls))
+	if len(cs.Calls) != 1 {
+		t.Errorf("expected 1 git call, saw %d", len(cs.Calls))
 	}
 }
 

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -45,12 +45,16 @@ func Test_CurrentBranch(t *testing.T) {
 	}
 	cases := []c{
 		{
-			Stub:     "branch-name",
+			Stub:     "branch-name\n",
 			Expected: "branch-name",
 		},
 		{
-			Stub:     "refs/heads/branch-name",
+			Stub:     "refs/heads/branch-name\n",
 			Expected: "branch-name",
+		},
+		{
+			Stub:     "refs/heads/branch\u00A0with\u00A0non\u00A0breaking\u00A0space\n",
+			Expected: "branch\u00A0with\u00A0non\u00A0breaking\u00A0space",
 		},
 	}
 


### PR DESCRIPTION
Closes #1897 