### PR TITLE
GHE 2.20 compatibility for `pr` commands

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -21,39 +23,79 @@ func makeCachedClient(httpClient *http.Client, cacheTTL time.Duration) *http.Cli
 	}
 }
 
+func isCacheableRequest(req *http.Request) bool {
+	if strings.EqualFold(req.Method, "GET") || strings.EqualFold(req.Method, "HEAD") {
+		return true
+	}
+
+	if strings.EqualFold(req.Method, "POST") && (req.URL.Path == "/graphql" || req.URL.Path == "/api/graphql") {
+		return true
+	}
+
+	return false
+}
+
+func isCacheableResponse(res *http.Response) bool {
+	return res.StatusCode < 500 && res.StatusCode != 403
+}
+
 // CacheReponse produces a RoundTripper that caches HTTP responses to disk for a specified amount of time
 func CacheReponse(ttl time.Duration, dir string) ClientOption {
+	fs := fileStorage{
+		dir: dir,
+		ttl: ttl,
+		mu:  &sync.RWMutex{},
+	}
+
 	return func(tr http.RoundTripper) http.RoundTripper {
 		return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+			if !isCacheableRequest(req) {
+				return tr.RoundTrip(req)
+			}
+
 			key, keyErr := cacheKey(req)
-			cacheFile := filepath.Join(dir, key)
 			if keyErr == nil {
-				// TODO: make thread-safe
-				if res, err := readCache(ttl, cacheFile, req); err == nil {
+				if res, err := fs.read(key); err == nil {
+					res.Request = req
 					return res, nil
 				}
 			}
+
 			res, err := tr.RoundTrip(req)
-			if err == nil && keyErr == nil {
-				// TODO: make thread-safe
-				_ = writeCache(cacheFile, res)
+			if err == nil && keyErr == nil && isCacheableResponse(res) {
+				_ = fs.store(key, res)
 			}
 			return res, err
 		}}
 	}
 }
 
+func copyStream(r io.ReadCloser) (io.ReadCloser, io.ReadCloser) {
+	b := &bytes.Buffer{}
+	nr := io.TeeReader(r, b)
+	return ioutil.NopCloser(b), &readCloser{
+		Reader: nr,
+		Closer: r,
+	}
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
 func cacheKey(req *http.Request) (string, error) {
 	h := sha256.New()
 	fmt.Fprintf(h, "%s:", req.Method)
 	fmt.Fprintf(h, "%s:", req.URL.String())
+	fmt.Fprintf(h, "%s:", req.Header.Get("Accept"))
+	fmt.Fprintf(h, "%s:", req.Header.Get("Authorization"))
 
 	if req.Body != nil {
-		bodyCopy := &bytes.Buffer{}
-		defer req.Body.Close()
-		_, err := io.Copy(h, io.TeeReader(req.Body, bodyCopy))
-		req.Body = ioutil.NopCloser(bodyCopy)
-		if err != nil {
+		var bodyCopy io.ReadCloser
+		req.Body, bodyCopy = copyStream(req.Body)
+		defer bodyCopy.Close()
+		if _, err := io.Copy(h, bodyCopy); err != nil {
 			return "", err
 		}
 	}
@@ -62,20 +104,38 @@ func cacheKey(req *http.Request) (string, error) {
 	return fmt.Sprintf("%x", digest), nil
 }
 
-func readCache(ttl time.Duration, cacheFile string, req *http.Request) (*http.Response, error) {
+type fileStorage struct {
+	dir string
+	ttl time.Duration
+	mu  *sync.RWMutex
+}
+
+func (fs *fileStorage) filePath(key string) string {
+	if len(key) >= 6 {
+		return filepath.Join(fs.dir, key[0:2], key[2:4], key[4:])
+	}
+	return filepath.Join(fs.dir, key)
+}
+
+func (fs *fileStorage) read(key string) (*http.Response, error) {
+	cacheFile := fs.filePath(key)
+
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
 	f, err := os.Open(cacheFile)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 
-	fs, err := f.Stat()
+	stat, err := f.Stat()
 	if err != nil {
 		return nil, err
 	}
 
-	age := time.Since(fs.ModTime())
-	if age > ttl {
+	age := time.Since(stat.ModTime())
+	if age > fs.ttl {
 		return nil, errors.New("cache expired")
 	}
 
@@ -85,11 +145,16 @@ func readCache(ttl time.Duration, cacheFile string, req *http.Request) (*http.Re
 		return nil, err
 	}
 
-	res, err := http.ReadResponse(bufio.NewReader(body), req)
+	res, err := http.ReadResponse(bufio.NewReader(body), nil)
 	return res, err
 }
 
-func writeCache(cacheFile string, res *http.Response) error {
+func (fs *fileStorage) store(key string, res *http.Response) error {
+	cacheFile := fs.filePath(key)
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
 	err := os.MkdirAll(filepath.Dir(cacheFile), 0755)
 	if err != nil {
 		return err
@@ -101,10 +166,10 @@ func writeCache(cacheFile string, res *http.Response) error {
 	}
 	defer f.Close()
 
-	bodyCopy := &bytes.Buffer{}
+	var origBody io.ReadCloser
+	origBody, res.Body = copyStream(res.Body)
 	defer res.Body.Close()
-	res.Body = ioutil.NopCloser(io.TeeReader(res.Body, bodyCopy))
 	err = res.Write(f)
-	res.Body = ioutil.NopCloser(bodyCopy)
+	res.Body = origBody
 	return err
 }

--- a/api/cache.go
+++ b/api/cache.go
@@ -84,11 +84,13 @@ func readCache(ttl time.Duration, cacheFile string, req *http.Request) (*http.Re
 	}
 
 	res, err := http.ReadResponse(bufio.NewReader(f), req)
-	if res != nil {
+	if res == nil {
 		res.Body = &readCloser{
 			Reader: res.Body,
 			Closer: f,
 		}
+	} else {
+		f.Close()
 	}
 	return res, err
 }

--- a/api/cache.go
+++ b/api/cache.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// CacheReponse produces a RoundTripper that caches HTTP responses to disk for a specified amount of time
+func CacheReponse(ttl time.Duration, dir string) ClientOption {
+	return func(tr http.RoundTripper) http.RoundTripper {
+		return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+			key, keyErr := cacheKey(req)
+			cacheFile := filepath.Join(dir, key)
+			if keyErr == nil {
+				if res, err := readCache(ttl, cacheFile, req); err == nil {
+					return res, nil
+				}
+			}
+			res, err := tr.RoundTrip(req)
+			if err == nil && keyErr == nil {
+				_ = writeCache(cacheFile, res)
+			}
+			return res, err
+		}}
+	}
+}
+
+func cacheKey(req *http.Request) (string, error) {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s:", req.Method)
+	fmt.Fprintf(h, "%s:", req.URL.String())
+
+	if req.Body != nil {
+		bodyCopy := &bytes.Buffer{}
+		defer req.Body.Close()
+		_, err := io.Copy(h, io.TeeReader(req.Body, bodyCopy))
+		req.Body = ioutil.NopCloser(bodyCopy)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	digest := h.Sum(nil)
+	return fmt.Sprintf("%x", digest), nil
+}
+
+func readCache(ttl time.Duration, cacheFile string, req *http.Request) (*http.Response, error) {
+	f, err := os.Open(cacheFile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	fs, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	age := time.Since(fs.ModTime())
+	if age > ttl {
+		return nil, errors.New("cache expired")
+	}
+
+	return http.ReadResponse(bufio.NewReader(f), req)
+}
+
+func writeCache(cacheFile string, res *http.Response) error {
+	err := os.MkdirAll(filepath.Dir(cacheFile), 0755)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(cacheFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	bodyCopy := &bytes.Buffer{}
+	defer res.Body.Close()
+	res.Body = ioutil.NopCloser(io.TeeReader(res.Body, bodyCopy))
+	err = res.Write(f)
+	res.Body = ioutil.NopCloser(bodyCopy)
+	return err
+}

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CacheReponse(t *testing.T) {
+	counter := 0
+	fakeHTTP := funcTripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			counter += 1
+			body := fmt.Sprintf("%d: %s %s", counter, req.Method, req.URL.String())
+			return &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+			}, nil
+		},
+	}
+
+	cacheDir := filepath.Join(t.TempDir(), "gh-cli-cache")
+	httpClient := NewHTTPClient(ReplaceTripper(fakeHTTP), CacheReponse(time.Minute, cacheDir))
+
+	do := func(method, url string, body io.Reader) (string, error) {
+		req, err := http.NewRequest(method, url, body)
+		if err != nil {
+			return "", err
+		}
+		res, err := httpClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		resBody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			err = fmt.Errorf("ReadAll: %w", err)
+		}
+		return string(resBody), err
+	}
+
+	res1, err := do("GET", "http://example.com/path", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "1: GET http://example.com/path", res1)
+	res2, err := do("GET", "http://example.com/path", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "1: GET http://example.com/path", res2)
+
+	res3, err := do("GET", "http://example.com/path2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "2: GET http://example.com/path2", res3)
+
+	res4, err := do("POST", "http://example.com/path", bytes.NewBufferString(`hello`))
+	require.NoError(t, err)
+	assert.Equal(t, "3: POST http://example.com/path", res4)
+	res5, err := do("POST", "http://example.com/path", bytes.NewBufferString(`hello`))
+	require.NoError(t, err)
+	assert.Equal(t, "3: POST http://example.com/path", res5)
+
+	res6, err := do("POST", "http://example.com/path", bytes.NewBufferString(`hello2`))
+	require.NoError(t, err)
+	assert.Equal(t, "4: POST http://example.com/path", res6)
+}

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -39,6 +39,7 @@ func Test_CacheReponse(t *testing.T) {
 		if err != nil {
 			return "", err
 		}
+		defer res.Body.Close()
 		resBody, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			err = fmt.Errorf("ReadAll: %w", err)

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -408,6 +408,13 @@ func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, cu
     }
 	`
 
+	if currentUsername == "@me" && ghinstance.IsEnterprise(repo.RepoHost()) {
+		currentUsername, err = CurrentLoginName(client, repo.RepoHost())
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	viewerQuery := fmt.Sprintf("repo:%s state:open is:pr author:%s", ghrepo.FullName(repo), currentUsername)
 	reviewerQuery := fmt.Sprintf("repo:%s state:open review-requested:%s", ghrepo.FullName(repo), currentUsername)
 

--- a/api/queries_pr_test.go
+++ b/api/queries_pr_test.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"reflect"
 	"testing"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/httpmock"
 )
@@ -41,6 +43,97 @@ func TestBranchDeleteRemote(t *testing.T) {
 			err := BranchDeleteRemote(client, repo, "branch")
 			if (err != nil) != tt.expectError {
 				t.Fatalf("unexpected result: %v", err)
+			}
+		})
+	}
+}
+
+func Test_determinePullRequestFeatures(t *testing.T) {
+	tests := []struct {
+		name           string
+		hostname       string
+		queryResponse  string
+		wantPrFeatures pullRequestFeature
+		wantErr        bool
+	}{
+		{
+			name:     "github.com",
+			hostname: "github.com",
+			wantPrFeatures: pullRequestFeature{
+				HasReviewDecision:    true,
+				HasStatusCheckRollup: true,
+			},
+			wantErr: false,
+		},
+		{
+			name:     "GHE empty response",
+			hostname: "git.my.org",
+			queryResponse: heredoc.Doc(`
+			{"data": {}}
+			`),
+			wantPrFeatures: pullRequestFeature{
+				HasReviewDecision:    false,
+				HasStatusCheckRollup: false,
+			},
+			wantErr: false,
+		},
+		{
+			name:     "GHE has reviewDecision",
+			hostname: "git.my.org",
+			queryResponse: heredoc.Doc(`
+			{"data": {
+				"PullRequest": {
+					"fields": [
+						{"name": "foo"},
+						{"name": "reviewDecision"}
+					]
+				}
+			} }
+			`),
+			wantPrFeatures: pullRequestFeature{
+				HasReviewDecision:    true,
+				HasStatusCheckRollup: false,
+			},
+			wantErr: false,
+		},
+		{
+			name:     "GHE has statusCheckRollup",
+			hostname: "git.my.org",
+			queryResponse: heredoc.Doc(`
+			{"data": {
+				"Commit": {
+					"fields": [
+						{"name": "foo"},
+						{"name": "statusCheckRollup"}
+					]
+				}
+			} }
+			`),
+			wantPrFeatures: pullRequestFeature{
+				HasReviewDecision:    false,
+				HasStatusCheckRollup: true,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeHTTP := &httpmock.Registry{}
+			httpClient := NewHTTPClient(ReplaceTripper(fakeHTTP))
+
+			if tt.queryResponse != "" {
+				fakeHTTP.Register(
+					httpmock.GraphQL(`query PullRequest_fields\b`),
+					httpmock.StringResponse(tt.queryResponse))
+			}
+
+			gotPrFeatures, err := determinePullRequestFeatures(httpClient, tt.hostname)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("determinePullRequestFeatures() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotPrFeatures, tt.wantPrFeatures) {
+				t.Errorf("determinePullRequestFeatures() = %v, want %v", gotPrFeatures, tt.wantPrFeatures)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes
- `gh pr status`
- `gh pr view`
- `gh pr create`

for GHE versions where `statusCheckRollup` or `reviewDecision` are unavailable.

To avoid the overhead of GraphQL schema introspection queries every time, their result is cached on disk per-host for 24 hours.

Fixes #1709, closes #1102