### PR TITLE
Handle edge cases in GHE auth

### DIFF
--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -69,7 +69,7 @@ func (oa *OAuthFlow) ObtainAccessToken() (accessToken string, err error) {
 		}
 	}
 
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusPaymentRequired ||
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden ||
 		resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnprocessableEntity ||
 		(resp.StatusCode == http.StatusBadRequest && values != nil && values.Get("error") == "unauthorized_client") {
 		// OAuth Device Flow is not available; continue with OAuth browser flow with a

--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -40,6 +40,21 @@ type OAuthFlow struct {
 	TimeSleep        func(time.Duration)
 }
 
+func detectDeviceFlow(statusCode int, values url.Values) (bool, error) {
+	if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden ||
+		statusCode == http.StatusNotFound || statusCode == http.StatusUnprocessableEntity ||
+		(statusCode == http.StatusOK && values == nil) ||
+		(statusCode == http.StatusBadRequest && values != nil && values.Get("error") == "unauthorized_client") {
+		return true, nil
+	} else if statusCode != http.StatusOK {
+		if values != nil && values.Get("error_description") != "" {
+			return false, fmt.Errorf("HTTP %d: %s", statusCode, values.Get("error_description"))
+		}
+		return false, fmt.Errorf("error: HTTP %d", statusCode)
+	}
+	return false, nil
+}
+
 // ObtainAccessToken guides the user through the browser OAuth flow on GitHub
 // and returns the OAuth access token upon completion.
 func (oa *OAuthFlow) ObtainAccessToken() (accessToken string, err error) {
@@ -58,28 +73,24 @@ func (oa *OAuthFlow) ObtainAccessToken() (accessToken string, err error) {
 	defer resp.Body.Close()
 
 	var values url.Values
-	bb, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return
-	}
-	if resp.StatusCode == http.StatusOK || strings.HasPrefix(resp.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+	if strings.Contains(resp.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+		var bb []byte
+		bb, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return
+		}
 		values, err = url.ParseQuery(string(bb))
 		if err != nil {
 			return
 		}
 	}
 
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden ||
-		resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnprocessableEntity ||
-		(resp.StatusCode == http.StatusBadRequest && values != nil && values.Get("error") == "unauthorized_client") {
+	if doFallback, err := detectDeviceFlow(resp.StatusCode, values); doFallback {
 		// OAuth Device Flow is not available; continue with OAuth browser flow with a
 		// local server endpoint as callback target
 		return oa.localServerFlow()
-	} else if resp.StatusCode != http.StatusOK {
-		if values != nil && values.Get("error_description") != "" {
-			return "", fmt.Errorf("HTTP %d: %s (%s)", resp.StatusCode, values.Get("error_description"), initURL)
-		}
-		return "", fmt.Errorf("error: HTTP %d (%s)", resp.StatusCode, initURL)
+	} else if err != nil {
+		return "", fmt.Errorf("%v (%s)", err, initURL)
 	}
 
 	timeNow := oa.TimeNow

--- a/auth/oauth_test.go
+++ b/auth/oauth_test.go
@@ -189,6 +189,15 @@ func Test_detectDeviceFlow(t *testing.T) {
 			wantErr:    "",
 		},
 		{
+			name: "402 payment required",
+			args: args{
+				statusCode: 402,
+				values:     nil,
+			},
+			doFallback: false,
+			wantErr:    "error: HTTP 402",
+		},
+		{
 			name: "400 bad request",
 			args: args{
 				statusCode: 400,


### PR DESCRIPTION
When `POST https://HOST/login/device/code` returns a HTTP 200 with a wrong `Content-Type`, we now fallback to old OAuth flow. Fixes #2014

Correctly handle HTTP 403 response code from GHE. Fixes regression from #1824
