### PR TITLE
Specify minimum required token scopes in `gh help auth login`

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -43,13 +43,14 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 		Use:   "login",
 		Args:  cobra.ExactArgs(0),
 		Short: "Authenticate with a GitHub host",
-		Long: heredoc.Doc(`Authenticate with a GitHub host.
+		Long: heredoc.Docf(`
+			Authenticate with a GitHub host.
 
-			This interactive command initializes your authentication state either by helping you log into
-			GitHub via browser-based OAuth or by accepting a Personal Access Token.
+			The default authentication mode is a web-based browser flow.
 
-			The interactivity can be avoided by specifying --with-token and passing a token on STDIN.
-		`),
+			Alternatively, pass in a token on standard input by using %[1]s--with-token%[1]s.
+			The minimum required scopes for the token are: "repo", "read:org".
+		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh auth login
 			# => do an interactive setup

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -52,14 +52,14 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			The minimum required scopes for the token are: "repo", "read:org".
 		`, "`"),
 		Example: heredoc.Doc(`
+			# start interactive setup
 			$ gh auth login
-			# => do an interactive setup
 
+			# authenticate against github.com by reading the token from a file
 			$ gh auth login --with-token < mytoken.txt
-			# => read token from mytoken.txt and authenticate against github.com
 
-			$ gh auth login --hostname enterprise.internal --with-token < mytoken.txt
-			# => read token from mytoken.txt and authenticate against a GitHub Enterprise Server instance
+			# authenticate with a specific GitHub Enterprise Server instance
+			$ gh auth login --hostname enterprise.internal
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !opts.IO.CanPrompt() && !(tokenStdin || opts.Web) {


### PR DESCRIPTION
Fixes #1815