### PR TITLE
restore tty settings after gh repo garden

### DIFF
--- a/pkg/cmd/repo/garden/garden.go
+++ b/pkg/cmd/repo/garden/garden.go
@@ -178,6 +178,18 @@ func gardenRun(opts *GardenOptions) error {
 	}
 
 	maxCommits := (geo.Width * geo.Height) / 2
+	
+	sttyFileArg := "-F"
+	if runtime.GOOS == "darwin" {
+		sttyFileArg = "-f"
+	}
+	
+	oldTTYCommand := exec.Command("stty", sttyFileArg, "/dev/tty", "-g")
+	oldTTYSettings, err := oldTTYCommand.CombinedOutput()
+	if err != nil {
+		fmt.Fprintln(out, "getting TTY setings failed:", string(oldTTYSettings))
+		return err
+	}
 
 	opts.IO.StartProgressIndicator()
 	fmt.Fprintln(out, "gathering commits; this could take a minute...")
@@ -201,13 +213,8 @@ func gardenRun(opts *GardenOptions) error {
 	drawGarden(out, garden, player)
 
 	// thanks stackoverflow https://stackoverflow.com/a/17278776
-	if runtime.GOOS == "darwin" {
-		_ = exec.Command("stty", "-f", "/dev/tty", "cbreak", "min", "1").Run()
-		_ = exec.Command("stty", "-f", "/dev/tty", "-echo").Run()
-	} else {
-		_ = exec.Command("stty", "-F", "/dev/tty", "cbreak", "min", "1").Run()
-		_ = exec.Command("stty", "-F", "/dev/tty", "-echo").Run()
-	}
+	_ = exec.Command("stty", sttyFileArg, "/dev/tty", "cbreak", "min", "1").Run()
+	_ = exec.Command("stty", sttyFileArg, "/dev/tty", "-echo").Run()
 
 	var b []byte = make([]byte, 3)
 	for {
@@ -291,6 +298,7 @@ func gardenRun(opts *GardenOptions) error {
 
 	clear(opts.IO)
 	fmt.Fprint(out, "\033[?25h")
+	_ = exec.Command("stty", sttyFileArg, "/dev/tty", strings.TrimSpace(string(oldTTYSettings))).Run()
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, utils.Bold("You turn and walk away from the wildflower garden..."))
 

--- a/pkg/cmd/repo/garden/garden.go
+++ b/pkg/cmd/repo/garden/garden.go
@@ -178,12 +178,12 @@ func gardenRun(opts *GardenOptions) error {
 	}
 
 	maxCommits := (geo.Width * geo.Height) / 2
-	
+
 	sttyFileArg := "-F"
 	if runtime.GOOS == "darwin" {
 		sttyFileArg = "-f"
 	}
-	
+
 	oldTTYCommand := exec.Command("stty", sttyFileArg, "/dev/tty", "-g")
 	oldTTYSettings, err := oldTTYCommand.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
the command 'gh repo garden' used to leave the bash in noecho mode when exiting.

This restores the tty settings to the state they had before running 'gh repo garden' when ending the program.

This fixes one problem in #2068 