### PR TITLE
Spike on new options resolver pattern

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -20,6 +20,7 @@ import (
 	repoCmd "github.com/cli/cli/pkg/cmd/repo"
 	creditsCmd "github.com/cli/cli/pkg/cmd/repo/credits"
 	versionCmd "github.com/cli/cli/pkg/cmd/version"
+	whatCmd "github.com/cli/cli/pkg/cmd/what"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -92,6 +93,8 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 
 	// Help topics
 	cmd.AddCommand(NewHelpTopic("environment"))
+
+	cmd.AddCommand(whatCmd.NewCmdWhat(f, nil))
 
 	cmdutil.DisableAuthCheck(cmd)
 

--- a/pkg/cmd/what/what.go
+++ b/pkg/cmd/what/what.go
@@ -1,0 +1,150 @@
+package what
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/pkg/prompt"
+	"github.com/cli/cli/pkg/resolver"
+	"github.com/spf13/cobra"
+)
+
+type CreateOptions struct {
+	HttpClient         func() (*http.Client, error)
+	Config             func() (config.Config, error)
+	IO                 *iostreams.IOStreams
+	NameResolver       resolver.ResolverFunction
+	VisibilityResolver resolver.ResolverFunction
+	Resolver           *resolver.Resolver
+	Description        string
+}
+
+func NewCmdWhat(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
+	opts := &CreateOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Config:     f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:  "what [<name>]",
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			opts.NameResolver = resolver.ResolverFunc(resolver.EnvStrat("REPO_NAME"), resolver.ArgsStrat(args, 0), promptNameStrat(opts.IO.CanPrompt()))
+
+			r := resolver.New()
+
+			r.AddStrat("visibility", resolver.MutuallyExclusiveBoolFlagsStrat(cmd, "public", "private", "internal"))
+			r.AddStrat("visibility", promptVisibilityStrat(opts.IO.CanPrompt()))
+
+			r.AddStrat("editor", resolver.StringFlagStrat(cmd, "editor"))
+			r.AddStrat("editor", resolver.ConfigStrat(opts.Config, "", "editor"))
+			r.AddStrat("editor", resolver.ValueStrat("cat"))
+
+			opts.VisibilityResolver = r.ResolverFunc("visibility")
+			opts.Resolver = r
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return createRun(opts)
+		},
+	}
+
+	cmd.Flags().StringP("editor", "e", "", "some editor")
+	cmd.Flags().Bool("public", false, "some visibility")
+	cmd.Flags().Bool("private", false, "less visibility")
+	cmd.Flags().Bool("internal", false, "no visibility")
+	cmd.Flags().StringVarP(&opts.Description, "description", "d", "", "Description of repository")
+
+	return cmd
+}
+
+func createRun(opts *CreateOptions) error {
+	name, err := opts.NameResolver()
+	if err != nil {
+		return err
+	}
+
+	visibility, err := opts.VisibilityResolver()
+	if err != nil {
+		return err
+	}
+
+	editor, err := opts.Resolver.Resolve("editor")
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(opts.IO.Out, "%s - %s - %s", name, visibility, editor)
+
+	return nil
+}
+
+func promptNameStrat(canPrompt bool) resolver.Strat {
+	return func() (interface{}, error) {
+		if !canPrompt {
+			return nil, errors.New("name argument required when not running interactively")
+		}
+
+		qs := []*survey.Question{}
+		getNameQuestion := &survey.Question{
+			Name: "repoName",
+			Prompt: &survey.Input{
+				Message: "Repo name",
+			},
+		}
+		qs = append(qs, getNameQuestion)
+
+		answer := struct {
+			RepoName string
+		}{}
+
+		err := prompt.SurveyAsk(qs, &answer)
+		if err != nil {
+			return nil, err
+		}
+
+		return answer.RepoName, nil
+	}
+}
+
+func promptVisibilityStrat(canPrompt bool) resolver.Strat {
+	return func() (interface{}, error) {
+		if !canPrompt {
+			return nil, errors.New("visibility argument required when not running interactively")
+		}
+
+		qs := []*survey.Question{}
+
+		getVisibilityQuestion := &survey.Question{
+			Name: "repoVisibility",
+			Prompt: &survey.Select{
+				Message: "Visibility",
+				Options: []string{"Public", "Private", "Internal"},
+			},
+		}
+		qs = append(qs, getVisibilityQuestion)
+
+		answer := struct {
+			RepoVisibility string
+		}{}
+
+		err := prompt.SurveyAsk(qs, &answer)
+		if err != nil {
+			return nil, err
+		}
+
+		return strings.ToUpper(answer.RepoVisibility), nil
+	}
+}

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -1,0 +1,154 @@
+package resolver
+
+import (
+	"errors"
+	"os"
+
+	"github.com/cli/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+type Strat func() (interface{}, error)
+
+type ResolverFunction func() (interface{}, error)
+
+type Resolver struct {
+	strats map[string][]Strat
+}
+
+func New() *Resolver {
+	return &Resolver{
+		strats: make(map[string][]Strat),
+	}
+}
+
+func (r *Resolver) AddStrat(name string, strat Strat) {
+	r.strats[name] = append(r.strats[name], strat)
+}
+
+func (r *Resolver) GetStrats(name string) []Strat {
+	return r.strats[name]
+}
+
+func (r *Resolver) ResolverFunc(name string) ResolverFunction {
+	return ResolverFunc(r.GetStrats(name)...)
+}
+
+func (r *Resolver) Resolve(name string) (interface{}, error) {
+	return ResolverFunc(r.GetStrats(name)...)()
+}
+
+func ResolverFunc(strategies ...Strat) ResolverFunction {
+	return func() (interface{}, error) {
+		for _, strat := range strategies {
+			out, err := strat()
+			if err != nil {
+				return nil, err
+			}
+
+			if out != nil {
+				return out, nil
+			}
+		}
+
+		return "", errors.New("No strategies resulted in output")
+	}
+}
+
+func EnvStrat(name string) Strat {
+	return func() (interface{}, error) {
+		val, ok := os.LookupEnv(name)
+		if !ok {
+			return nil, nil
+		} else {
+			return val, nil
+		}
+	}
+}
+
+func ConfigStrat(config func() (config.Config, error), hostname, name string) Strat {
+	return func() (interface{}, error) {
+		cfg, err := config()
+		if err != nil {
+			return nil, err
+		}
+
+		return cfg.Get(hostname, name)
+	}
+}
+
+func ArgsStrat(args []string, index int) Strat {
+	return func() (interface{}, error) {
+		if len(args) > index {
+			return args[index], nil
+		}
+		return nil, nil
+	}
+}
+
+func StringFlagStrat(cmd *cobra.Command, name string) Strat {
+	return func() (interface{}, error) {
+		if !cmd.Flags().Changed(name) {
+			return nil, nil
+		}
+		return cmd.Flags().GetString(name)
+	}
+}
+
+func BoolFlagStrat(cmd *cobra.Command, name string) Strat {
+	return func() (interface{}, error) {
+		return cmd.Flags().GetBool(name)
+	}
+}
+
+func StringSliceFlagsStrat(cmd *cobra.Command, name string) Strat {
+	return func() (interface{}, error) {
+		if !cmd.Flags().Changed(name) {
+			return nil, nil
+		}
+		return cmd.Flags().GetStringSlice(name)
+	}
+}
+
+func MutuallyExclusiveBoolFlagsStrat(cmd *cobra.Command, names ...string) Strat {
+	return func() (interface{}, error) {
+		flags := cmd.Flags()
+		enabledFlagCount := 0
+		enabledFlag := ""
+		for _, name := range names {
+			val, err := flags.GetBool(name)
+			if err != nil {
+				return nil, err
+			}
+
+			if val {
+				enabledFlagCount = enabledFlagCount + 1
+				enabledFlag = name
+			}
+
+			if enabledFlagCount > 1 {
+				break
+			}
+		}
+
+		if enabledFlagCount == 0 {
+			return nil, nil
+		} else if enabledFlagCount == 1 {
+			return enabledFlag, nil
+		}
+
+		return nil, errors.New("expected exactly one of boolean flags to be true")
+	}
+}
+
+func ValueStrat(name string) Strat {
+	return func() (interface{}, error) {
+		return name, nil
+	}
+}
+
+func ErrorStrat(err error) Strat {
+	return func() (interface{}, error) {
+		return nil, err
+	}
+}


### PR DESCRIPTION
**DO NOT MERGE**

This PR is a spike meant to start a discussion and will not be merged!

**Problem:** 
Many of our commands have options that can be set in multiple places, and from various sources (environment variables, configuration files, command arguments, command flags, command prompts, and default values). This is most commonly seen in the pattern of looking for a specific command flag or command argument and if it does not exist then prompting the user for that information. That case is not particularly difficult since it only involves one branching condition but often our use case is not that simple and involves checking more sources for values for the option. I have found it difficult at times to follow how an option is being set, where it is being set, and what the priorities are of the various sources for an option. I would like to come up with a way that makes all of that more clear and is easy to use.

**Solution Inspiration:**
[urfave/cli](https://github.com/urfave/cli/blob/master/docs/v2/manual.md#values-from-the-environment)
[alecthomas/kong](https://github.com/alecthomas/kong#resolver---support-for-default-values-from-external-sources)
[spf13/viper](https://github.com/spf13/viper)

**Solution:**
See PR. Note that the `what` command is a bogus command used to show off the various `resolver` use cases.

**Pros:**
- Flexible for uses outside of just commands
- Highly configurable using composable strategies 
- Can be used in conjunction with current implementation

**Cons:**
- Strategies might not be as re-usable due specific conditions needed in each use case, for example error messaging

**Both:**
- Laziness of resolving options

**Questions:**
- Does this provide value?
- How much better/worse is it than current implentation?
- How much effort would it be to implement?
- Are there alternative solutions? 
- Is this a common pattern that already has a Go pkg? (i.e. reinventing the wheel)