### PR TITLE
updated new github doc. link

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -23,7 +23,6 @@ type IssuesAndTotalCount struct {
 	TotalCount int
 }
 
-// Ref. Please see Github GraphQL object issue reference page
 type Issue struct {
 	ID        string
 	Number    int

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -23,7 +23,7 @@ type IssuesAndTotalCount struct {
 	TotalCount int
 }
 
-// Ref. https://developer.github.com/v4/object/issue/
+// Ref. https://docs.github.com/v4/object/issue
 type Issue struct {
 	ID        string
 	Number    int

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -23,7 +23,7 @@ type IssuesAndTotalCount struct {
 	TotalCount int
 }
 
-// Ref. https://docs.github.com/v4/object/issue
+// Ref. Please see Github GraphQL object issue reference page
 type Issue struct {
 	ID        string
 	Number    int

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -191,7 +191,7 @@ func printHumanPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 	return nil
 }
 
-// Ref. https://developer.github.com/v4/enum/pullrequestreviewstate/
+// Ref. https://docs.github.com/v4/enum/pullrequestreviewstate/
 const (
 	requestedReviewState        = "REQUESTED" // This is our own state for review request
 	approvedReviewState         = "APPROVED"
@@ -250,7 +250,7 @@ func prReviewerList(pr api.PullRequest) string {
 	return reviewerList
 }
 
-// Ref. https://developer.github.com/v4/union/requestedreviewer/
+// Ref. https://docs.github.com/v4/enum/pullrequestreviewstate/
 const teamTypeName = "Team"
 
 const ghostName = "ghost"

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -191,7 +191,6 @@ func printHumanPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 	return nil
 }
 
-// Ref. Please see Github GraphQL PullRequestReviewState reference page
 const (
 	requestedReviewState        = "REQUESTED" // This is our own state for review request
 	approvedReviewState         = "APPROVED"
@@ -250,7 +249,6 @@ func prReviewerList(pr api.PullRequest) string {
 	return reviewerList
 }
 
-// Ref. Please see Github GraphQL PullRequestReviewState reference page
 const teamTypeName = "Team"
 
 const ghostName = "ghost"

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -191,7 +191,7 @@ func printHumanPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 	return nil
 }
 
-// Ref. https://docs.github.com/v4/enum/pullrequestreviewstate/
+// Ref. Please see Github GraphQL PullRequestReviewState reference page
 const (
 	requestedReviewState        = "REQUESTED" // This is our own state for review request
 	approvedReviewState         = "APPROVED"
@@ -250,7 +250,7 @@ func prReviewerList(pr api.PullRequest) string {
 	return reviewerList
 }
 
-// Ref. https://docs.github.com/v4/enum/pullrequestreviewstate/
+// Ref. Please see Github GraphQL PullRequestReviewState reference page
 const teamTypeName = "Team"
 
 const ghostName = "ghost"


### PR DESCRIPTION
I changed `https://developer.github.com/` to `https://docs.github.com/` because "the content on developer.github.com site may be out of date." 