### PR TITLE
Update shouldCheckForUpdate

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -186,9 +186,17 @@ func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
 }
 
 func shouldCheckForUpdate() bool {
-	isCIEnvironment := (os.Getenv("CI") != "") || (os.Getenv("BUILD_NUMBER") != "") || (os.Getenv("RUN_ID") != "")
-	isGlobalDisabled := os.Getenv("GH_NO_UPDATE_NOTIFIER") != ""
-	return updaterEnabled != "" && !isCompletionCommand() && utils.IsTerminal(os.Stderr) && !isCIEnvironment && !isGlobalDisabled
+	if os.Getenv("GH_NO_UPDATE_NOTIFIER") != "" {
+		return false
+	}
+	return updaterEnabled != "" && !isCI() && !isCompletionCommand() && utils.IsTerminal(os.Stderr)
+}
+
+// based on https://github.com/watson/ci-info/blob/HEAD/index.js
+func isCI() bool {
+	return os.Getenv("CI") != "" || // GitHub Actions, Travis CI, CircleCI, Cirrus CI, GitLab CI, AppVeyor, CodeShip, dsari
+		os.Getenv("BUILD_NUMBER") != "" || // Jenkins, TeamCity
+		os.Getenv("RUN_ID") != "" // TaskCluster, dsari
 }
 
 func isCompletionCommand() bool {

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -187,7 +187,7 @@ func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
 
 func shouldCheckForUpdate() bool {
 	isCIEnvironment := (os.Getenv("CI") != "") || (os.Getenv("BUILD_NUMBER") != "") || (os.Getenv("RUN_ID") != "")
-	isGlobalDisabled := os.Getenv("GH_NO_UPDATE_NOTIFIER") == "disabled"
+	isGlobalDisabled := os.Getenv("GH_NO_UPDATE_NOTIFIER") != ""
 	return updaterEnabled != "" && !isCompletionCommand() && utils.IsTerminal(os.Stderr) && !isCIEnvironment && !isGlobalDisabled
 }
 

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -186,7 +186,9 @@ func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
 }
 
 func shouldCheckForUpdate() bool {
-	return updaterEnabled != "" && !isCompletionCommand() && utils.IsTerminal(os.Stderr)
+	isCIEnvironment := (os.Getenv("CI") != "") || (os.Getenv("BUILD_NUMBER") != "") || (os.Getenv("RUN_ID") != "")
+	isGlobalDisabled := os.Getenv("GH_NO_UPDATE_NOTIFIER") == "disabled"
+	return updaterEnabled != "" && !isCompletionCommand() && utils.IsTerminal(os.Stderr) && !isCIEnvironment && !isGlobalDisabled
 }
 
 func isCompletionCommand() bool {

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -11,11 +11,9 @@ import (
 )
 
 const (
-	defaultGitProtocol  = "https"
-	PromptsDisabled     = "disabled"
-	PromptsEnabled      = "enabled"
-	UpdateCheckEnabled  = "enabled"
-	UpdateCheckDisabled = "disabled"
+	defaultGitProtocol = "https"
+	PromptsDisabled    = "disabled"
+	PromptsEnabled     = "enabled"
 )
 
 // This interface describes interacting with some persistent configuration for gh.

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -11,9 +11,11 @@ import (
 )
 
 const (
-	defaultGitProtocol = "https"
-	PromptsDisabled    = "disabled"
-	PromptsEnabled     = "enabled"
+	defaultGitProtocol  = "https"
+	PromptsDisabled     = "disabled"
+	PromptsEnabled      = "enabled"
+	UpdateCheckEnabled  = "enabled"
+	UpdateCheckDisabled = "disabled"
 )
 
 // This interface describes interacting with some persistent configuration for gh.

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -40,7 +40,9 @@ func NewHelpTopic(topic string) *cobra.Command {
 		CLICOLOR_FORCE: set to a value other than "0" to keep ANSI colors in output
 		even when the output is piped.
 
-		GH_NO_UPDATE_NOTIFIER: set to "1" to disable checking for updates.
+		GH_NO_UPDATE_NOTIFIER: set to any value to disable update notifications. By default, gh
+		checks for new releases once every 24 hours and displays an upgrade notice on standard
+		error if a newer version was found.
 	`)
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -39,6 +39,8 @@ func NewHelpTopic(topic string) *cobra.Command {
 
 		CLICOLOR_FORCE: set to a value other than "0" to keep ANSI colors in output
 		even when the output is piped.
+
+		GH_NO_UPDATE_NOTIFIER: set to "1" to disable checking for updates.
 	`)
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
Fixes #743

1. Checks if CI Environment by checking if CI, BUILD_MANAGER, RUN_ID is non blank.
2. Checks if Update Env is globally closed through GH_NO_UPDATE_NOTIFIER is "disabled"﻿
