### PR TITLE
Implement --web for gh pr checks

### DIFF
--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -24,6 +24,8 @@ type ChecksOptions struct {
 	Branch     func() (string, error)
 	Remotes    func() (context.Remotes, error)
 
+	WebMode bool
+
 	SelectorArg string
 }
 
@@ -60,6 +62,8 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 		},
 	}
 
+	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open the web browser to show details about checks")
+
 	return cmd
 }
 
@@ -70,7 +74,7 @@ func checksRun(opts *ChecksOptions) error {
 	}
 	apiClient := api.NewClientFromHTTP(httpClient)
 
-	pr, _, err := shared.PRFromArgs(apiClient, opts.BaseRepo, opts.Branch, opts.Remotes, opts.SelectorArg)
+	pr, baseRepo, err := shared.PRFromArgs(apiClient, opts.BaseRepo, opts.Branch, opts.Remotes, opts.SelectorArg)
 	if err != nil {
 		return err
 	}
@@ -82,6 +86,16 @@ func checksRun(opts *ChecksOptions) error {
 	rollup := pr.Commits.Nodes[0].Commit.StatusCheckRollup.Contexts.Nodes
 	if len(rollup) == 0 {
 		return nil
+	}
+
+	isTerminal := opts.IO.IsStdoutTTY()
+
+	if opts.WebMode {
+		openURL := ghrepo.GenerateRepoURL(baseRepo, "pull/%d/checks", pr.Number)
+		if isTerminal {
+			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", utils.DisplayURL(openURL))
+		}
+		return utils.OpenInBrowser(openURL)
 	}
 
 	passing := 0
@@ -162,9 +176,8 @@ func checksRun(opts *ChecksOptions) error {
 		if b0 == b1 {
 			if n0 == n1 {
 				return l0 < l1
-			} else {
-				return n0 < n1
 			}
+			return n0 < n1
 		}
 
 		return (b0 == "fail") || (b0 == "pending" && b1 == "success")
@@ -173,7 +186,7 @@ func checksRun(opts *ChecksOptions) error {
 	tp := utils.NewTablePrinter(opts.IO)
 
 	for _, o := range outputs {
-		if opts.IO.IsStdoutTTY() {
+		if isTerminal {
 			tp.AddField(o.mark, nil, o.markColor)
 			tp.AddField(o.name, nil, nil)
 			tp.AddField(o.elapsed, nil, nil)
@@ -209,7 +222,7 @@ func checksRun(opts *ChecksOptions) error {
 		summary = fmt.Sprintf("%s\n%s", utils.Bold(summary), tallies)
 	}
 
-	if opts.IO.IsStdoutTTY() {
+	if isTerminal {
 		fmt.Fprintln(opts.IO.Out, summary)
 		fmt.Fprintln(opts.IO.Out)
 	}

--- a/pkg/cmd/pr/checks/checks_test.go
+++ b/pkg/cmd/pr/checks/checks_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/httpmock"
 	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/test"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
 )
@@ -205,6 +206,66 @@ func Test_checksRun(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.wantOut, stdout.String())
+			reg.Verify(t)
+		})
+	}
+}
+
+func TestChecksRun_web(t *testing.T) {
+	tests := []struct {
+		name       string
+		isTTY      bool
+		wantStderr string
+		wantStdout string
+	}{
+		{
+			name:       "tty",
+			isTTY:      true,
+			wantStderr: "Opening github.com/OWNER/REPO/pull/123/checks in your browser.\n",
+			wantStdout: "",
+		},
+		{
+			name:       "nontty",
+			isTTY:      false,
+			wantStderr: "",
+			wantStdout: "",
+		},
+	}
+
+	reg := &httpmock.Registry{}
+
+	opts := &ChecksOptions{
+		WebMode: true,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.New("OWNER", "REPO"), nil
+		},
+		SelectorArg: "123",
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reg.Register(
+				httpmock.GraphQL(`query PullRequestByNumber\b`), httpmock.FileResponse("./fixtures/allPassing.json"))
+
+			io, _, stdout, stderr := iostreams.Test()
+			io.SetStdoutTTY(tc.isTTY)
+			io.SetStdinTTY(tc.isTTY)
+			io.SetStderrTTY(tc.isTTY)
+
+			opts.IO = io
+
+			cs, teardown := test.InitCmdStubber()
+			defer teardown()
+
+			cs.Stub("") // browser open
+
+			err := checksRun(opts)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantStdout, stdout.String())
+			assert.Equal(t, tc.wantStderr, stderr.String())
 			reg.Verify(t)
 		})
 	}


### PR DESCRIPTION
Closes #1682. 

Add optional flag:

```
gh pr checks [--web | -w]
```
which redirects in case of existing checks to `[repo/owner]/pull/[pr-number]/checks` in `github.com`.

I've left previous behaviour in case of no checks are configured - cli silently pass without any message.