### PR TITLE
create git initialize check

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -36,10 +36,7 @@ func (r TrackingRef) String() string {
 func IsRepositoryInitialized() bool {
 	showCmd := GitCommand("status")
 	_, err := run.PrepareCmd(showCmd).Output()
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func Init() error {

--- a/git/git.go
+++ b/git/git.go
@@ -33,6 +33,24 @@ func (r TrackingRef) String() string {
 	return "refs/remotes/" + r.RemoteName + "/" + r.BranchName
 }
 
+func IsRepositoryInitialized() bool {
+	showCmd := GitCommand("status")
+	_, err := run.PrepareCmd(showCmd).Output()
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+func Init() error {
+	showCmd := GitCommand("init")
+	_, err := run.PrepareCmd(showCmd).Output()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // ShowRefs resolves fully-qualified refs to commit hashes
 func ShowRefs(ref ...string) ([]Ref, error) {
 	args := append([]string{"show-ref", "--verify", "--"}, ref...)


### PR DESCRIPTION
This pr solves issue https://github.com/cli/cli/issues/2099

## Changes

it checks if the current folder has initialized a local git repository; if it hasn't, it will ask the user if the gh cli can initialize it. Also if the -y or --confirm flags are used, it will assume that it should initialize without prompting