### PR TITLE
Update references to the `help wanted` label after rename

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,11 +1,5 @@
 ## Contributing
 
-[legal]: https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license
-[license]: ../LICENSE
-[code-of-conduct]: CODE-OF-CONDUCT.md
-[bug issues]: https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+label%3Abug
-[feature request issues]: https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement
-
 Hi! Thanks for your interest in contributing to the GitHub CLI!
 
 We accept pull requests for bug fixes and features where we've discussed the approach in an issue and given the go-ahead for a community member to work on it. We'd also love to hear about ideas for new features as issues.
@@ -17,7 +11,7 @@ Please do:
 * Open an issue to propose a significant change.
 * Open a pull request to fix a bug.
 * Open a pull request to fix documentation about a command.
-* Open a pull request for an issue with the `help-wanted` label and leave a comment claiming it.
+* Open a pull request for an issue with the [`help wanted`][] label and leave a comment claiming it.
 
 Please avoid:
 
@@ -52,6 +46,17 @@ We generate manual pages from source on every release. You do not need to submit
 
 ## Resources
 
-- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
-- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
-- [GitHub Help](https://help.github.com)
+- [How to Contribute to Open Source][]
+- [Using Pull Requests][]
+- [GitHub Help][]
+
+
+[bug issues]: https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+label%3Abug
+[feature request issues]: https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement
+[help wanted]: https://github.com/cli/cli/labels/help%20wanted
+[legal]: https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-terms-of-service#6-contributions-under-repository-license
+[license]: ../LICENSE
+[code-of-conduct]: ./CODE-OF-CONDUCT.md
+[How to Contribute to Open Source]: https://opensource.guide/how-to-contribute/
+[Using Pull Requests]: https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests
+[GitHub Help]: https://docs.github.com/

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -28,7 +28,7 @@ just imagine a flowchart
 - do we want someone in the community to do it?
   - e.g. the task is relatively straightforward, but no people on our team have the bandwidth to take it on at the moment
   - ensure that the thread contains all the context necessary for someone new to pick this up
-  - add `help-wanted` label
+  - add `help wanted` label
 - do we want to do it, but not in the next year?
   - comment acknowledging it, but that we don't plan on working on it this year.
   - add `future` label


### PR DESCRIPTION
>   

> @#`GitHub` has some special behavior for the `help wanted` label, but not

the `help-wanted` label, so I've renamed ours.

Bonus: updated links to docs.github.com