### PR TITLE
Clone repos using canonical username/repo name capitalization

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -88,16 +88,23 @@ func (r Repository) ViewerCanTriage() bool {
 
 func GitHubRepo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 	query := `
+	fragment repo on Repository {
+		id
+		name
+		owner { login }
+		hasIssuesEnabled
+		description
+		viewerPermission
+		defaultBranchRef {
+			name
+		}
+	}
+
 	query RepositoryInfo($owner: String!, $name: String!) {
 		repository(owner: $owner, name: $name) {
-			id
-			name
-			owner { login }
-			hasIssuesEnabled
-			description
-			viewerPermission
-			defaultBranchRef {
-				name
+			...repo
+			parent {
+				...repo
 			}
 		}
 	}`

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -82,44 +82,65 @@ func cloneRun(opts *CloneOptions) error {
 	}
 
 	apiClient := api.NewClientFromHTTP(httpClient)
-	cloneURL := opts.Repository
-	if !strings.Contains(cloneURL, ":") {
-		if !strings.Contains(cloneURL, "/") {
+
+	respositoryIsURL := strings.Contains(opts.Repository, ":")
+	repositoryIsFullName := !respositoryIsURL && strings.Contains(opts.Repository, "/")
+
+	var repo ghrepo.Interface
+	var protocol string
+	if respositoryIsURL {
+		repoURL, err := git.ParseURL(opts.Repository)
+		if err != nil {
+			return err
+		}
+		repo, err = ghrepo.FromURL(repoURL)
+		if err != nil {
+			return err
+		}
+		if repoURL.Scheme == "git+ssh" {
+			repoURL.Scheme = "ssh"
+		}
+		protocol = repoURL.Scheme
+	} else {
+		var fullName string
+		if repositoryIsFullName {
+			fullName = opts.Repository
+		} else {
 			currentUser, err := api.CurrentLoginName(apiClient, ghinstance.OverridableDefault())
 			if err != nil {
 				return err
 			}
-			cloneURL = currentUser + "/" + cloneURL
+			fullName = currentUser + "/" + opts.Repository
 		}
-		repo, err := ghrepo.FromFullName(cloneURL)
+
+		repo, err = ghrepo.FromFullName(fullName)
 		if err != nil {
 			return err
 		}
 
-		protocol, err := cfg.Get(repo.RepoHost(), "git_protocol")
+		protocol, err = cfg.Get(repo.RepoHost(), "git_protocol")
 		if err != nil {
 			return err
 		}
-		cloneURL = ghrepo.FormatRemoteURL(repo, protocol)
 	}
 
-	var repo ghrepo.Interface
+	// Load the repo from the API to get the username/repo name in its
+	// canonical capitalization
+	var canonicalRepo ghrepo.Interface
+	canonicalRepo, err = api.GitHubRepo(apiClient, repo)
+	if err != nil {
+		return err
+	}
+	canonicalCloneURL := ghrepo.FormatRemoteURL(canonicalRepo, protocol)
+
+	cloneDir, err := git.RunClone(canonicalCloneURL, opts.GitArgs)
+	if err != nil {
+		return err
+	}
+
+	// If the repo is a fork, add the parent as an upstream
 	var parentRepo ghrepo.Interface
-
-	// TODO: consider caching and reusing `git.ParseSSHConfig().Translator()`
-	// here to handle hostname aliases in SSH remotes
-	if u, err := git.ParseURL(cloneURL); err == nil {
-		repo, _ = ghrepo.FromURL(u)
-	}
-
-	if repo != nil {
-		parentRepo, err = api.RepoParent(apiClient, repo)
-		if err != nil {
-			return err
-		}
-	}
-
-	cloneDir, err := git.RunClone(cloneURL, opts.GitArgs)
+	parentRepo, err = api.RepoParent(apiClient, canonicalRepo)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -126,8 +126,7 @@ func cloneRun(opts *CloneOptions) error {
 
 	// Load the repo from the API to get the username/repo name in its
 	// canonical capitalization
-	var canonicalRepo ghrepo.Interface
-	canonicalRepo, err = api.GitHubRepo(apiClient, repo)
+	canonicalRepo, err := api.GitHubRepo(apiClient, repo)
 	if err != nil {
 		return err
 	}
@@ -139,18 +138,12 @@ func cloneRun(opts *CloneOptions) error {
 	}
 
 	// If the repo is a fork, add the parent as an upstream
-	var parentRepo ghrepo.Interface
-	parentRepo, err = api.RepoParent(apiClient, canonicalRepo)
-	if err != nil {
-		return err
-	}
-
-	if parentRepo != nil {
-		protocol, err := cfg.Get(parentRepo.RepoHost(), "git_protocol")
+	if canonicalRepo.Parent != nil {
+		protocol, err := cfg.Get(canonicalRepo.Parent.RepoHost(), "git_protocol")
 		if err != nil {
 			return err
 		}
-		upstreamURL := ghrepo.FormatRemoteURL(parentRepo, protocol)
+		upstreamURL := ghrepo.FormatRemoteURL(canonicalRepo.Parent, protocol)
 
 		err = git.AddUpstreamRemote(upstreamURL, cloneDir)
 		if err != nil {

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -86,8 +86,8 @@ func Test_RepoClone(t *testing.T) {
 		},
 		{
 			name: "Non-canonical capitalization",
-			args: "git@github.com:Ower/Repo.git",
-			want: "git clone git@github.com:OWNER/REPO.git",
+			args: "Owner/Repo",
+			want: "git clone https://github.com/OWNER/REPO.git",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -103,13 +103,6 @@ func Test_RepoClone(t *testing.T) {
 					}
 				} } }
 				`))
-			reg.Register(
-				httpmock.GraphQL(`query RepositoryFindParent\b`),
-				httpmock.StringResponse(`
-				{ "data": { "repository": {
-					"parent": null
-				} } }
-				`))
 
 			httpClient := &http.Client{Transport: reg}
 
@@ -141,19 +134,15 @@ func Test_RepoClone_hasParent(t *testing.T) {
 					"name": "REPO",
 					"owner": {
 						"login": "OWNER"
+					},
+					"parent": {
+						"name": "ORIG",
+						"owner": {
+							"login": "hubot"
+						}
 					}
 				} } }
 				`))
-	reg.Register(
-		httpmock.GraphQL(`query RepositoryFindParent\b`),
-		httpmock.StringResponse(`
-		{ "data": { "repository": {
-			"parent": {
-				"owner": {"login": "hubot"},
-				"name": "ORIG"
-			}
-		} } }
-		`))
 
 	httpClient := &http.Client{Transport: reg}
 


### PR DESCRIPTION
GitHub user/repo names are case insentitive. This can cause issues when dealing with
repos programmatically using systems that aren't aware of this (e.g. go packages).

This commit updates the cloning logic of the CLI to query the API for the canonical
capitalization and uses that for the clone operation.

Fixes: #1845