### PR TITLE
Add int32 validation to milestone numbers

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -251,8 +251,8 @@ func IssueList(client *Client, repo ghrepo.Interface, state string, labels []str
 
 	if milestoneString != "" {
 		var milestone *RepoMilestone
-		if milestoneNumber, err := strconv.Atoi(milestoneString); err == nil {
-			milestone, err = MilestoneByNumber(client, repo, milestoneNumber)
+		if milestoneNumber, err := strconv.ParseInt(milestoneString, 10, 32); err == nil {
+			milestone, err = MilestoneByNumber(client, repo, int32(milestoneNumber))
 			if err != nil {
 				return nil, err
 			}

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -840,7 +840,7 @@ func MilestoneByTitle(client *Client, repo ghrepo.Interface, title string) (*Rep
 	return nil, fmt.Errorf("no milestone found with title %q", title)
 }
 
-func MilestoneByNumber(client *Client, repo ghrepo.Interface, number int) (*RepoMilestone, error) {
+func MilestoneByNumber(client *Client, repo ghrepo.Interface, number int32) (*RepoMilestone, error) {
 	var query struct {
 		Repository struct {
 			Milestone *RepoMilestone `graphql:"milestone(number: $number)"`


### PR DESCRIPTION
Fixes #2154 

The 32-bit version of `ParseInt` makes it easy to verify if milestoneString is a 32-bit integer or not.

If the input number is valid for int32, it will be used as an intergar milestone.
Prior to this patch, int64 was used for integer validation.

```sh
$ make
$ DEBUG=api ./bin/gh issue list -m 2147483647 2>&1 | grep '"number"'
        "number": 2147483647,
$ DEBUG=api ./bin/gh issue list -m 2147483648 2>&1 | grep '"number"'
$ 
```