### PR TITLE
Add --scopes to login

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -27,6 +27,7 @@ type LoginOptions struct {
 	Interactive bool
 
 	Hostname string
+	Scopes   []string
 	Token    string
 	Web      bool
 }
@@ -50,6 +51,9 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 
 			Alternatively, pass in a token on standard input by using %[1]s--with-token%[1]s.
 			The minimum required scopes for the token are: "repo", "read:org".
+
+			The --scopes flag accepts a comma separated list of scopes you want your gh credentials to have. If
+			absent, this command ensures that gh has access to a minimum set of scopes.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# start interactive setup
@@ -104,6 +108,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 	}
 
 	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "The hostname of the GitHub instance to authenticate with")
+	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", nil, "Additional authentication scopes for gh to have")
 	cmd.Flags().BoolVar(&tokenStdin, "with-token", false, "Read token from standard input")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open a browser to authenticate")
 
@@ -223,7 +228,7 @@ func loginRun(opts *LoginOptions) error {
 	}
 
 	if authMode == 0 {
-		_, err := authflow.AuthFlowWithConfig(cfg, hostname, "", []string{})
+		_, err := authflow.AuthFlowWithConfig(cfg, hostname, "", opts.Scopes)
 		if err != nil {
 			return fmt.Errorf("failed to authenticate via web browser: %w", err)
 		}

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -118,6 +118,28 @@ func Test_NewCmdLogin(t *testing.T) {
 			cli:      "--web --with-token",
 			wantsErr: true,
 		},
+		{
+			name:     "tty one scope",
+			stdinTTY: true,
+			cli:      "--scopes repo:invite",
+			wants: LoginOptions{
+				Hostname:    "",
+				Scopes:      []string{"repo:invite"},
+				Token:       "",
+				Interactive: true,
+			},
+		},
+		{
+			name:     "tty scopes",
+			stdinTTY: true,
+			cli:      "--scopes repo:invite,read:public_key",
+			wants: LoginOptions{
+				Hostname:    "",
+				Scopes:      []string{"repo:invite", "read:public_key"},
+				Token:       "",
+				Interactive: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -160,6 +182,7 @@ func Test_NewCmdLogin(t *testing.T) {
 			assert.Equal(t, tt.wants.Hostname, gotOpts.Hostname)
 			assert.Equal(t, tt.wants.Web, gotOpts.Web)
 			assert.Equal(t, tt.wants.Interactive, gotOpts.Interactive)
+			assert.Equal(t, tt.wants.Scopes, gotOpts.Scopes)
 		})
 	}
 }


### PR DESCRIPTION
This PR adds the `--scopes` (and `-s`) flag to the `login` command so that you can provide additional scopes when logging in with `gh`.

How I tested (beyond actual tests):

- `gh auth login --scopes repo:invite,read:public_key`
- Go through web auth flow
- Web OAuth flow prompts with additional scopes when logging in
- Return to CLI

Closes https://github.com/cli/cli/issues/2195