### PR TITLE
Get open and closed milestones when milestones are filtered by title

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -257,7 +257,7 @@ func IssueList(client *Client, repo ghrepo.Interface, state string, labels []str
 				return nil, err
 			}
 		} else {
-			milestone, err = MilestoneByTitle(client, repo, milestoneString)
+			milestone, err = MilestoneByTitle(client, repo, "all", milestoneString)
 			if err != nil {
 				return nil, err
 			}

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -529,7 +529,7 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 	if input.Milestones {
 		count++
 		go func() {
-			milestones, err := RepoMilestones(client, repo)
+			milestones, err := RepoMilestones(client, repo, "open")
 			if err != nil {
 				err = fmt.Errorf("error fetching milestones: %w", err)
 			}
@@ -790,8 +790,8 @@ type RepoMilestone struct {
 	Title string
 }
 
-// RepoMilestones fetches all open milestones in a repository
-func RepoMilestones(client *Client, repo ghrepo.Interface) ([]RepoMilestone, error) {
+// RepoMilestones fetches milestones in a repository
+func RepoMilestones(client *Client, repo ghrepo.Interface, state string) ([]RepoMilestone, error) {
 	type responseData struct {
 		Repository struct {
 			Milestones struct {
@@ -800,13 +800,26 @@ func RepoMilestones(client *Client, repo ghrepo.Interface) ([]RepoMilestone, err
 					HasNextPage bool
 					EndCursor   string
 				}
-			} `graphql:"milestones(states: [OPEN], first: 100, after: $endCursor)"`
+			} `graphql:"milestones(states: $states, first: 100, after: $endCursor)"`
 		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	var states []githubv4.MilestoneState
+	switch state {
+	case "open":
+		states = []githubv4.MilestoneState{"OPEN"}
+	case "closed":
+		states = []githubv4.MilestoneState{"CLOSED"}
+	case "all":
+		states = []githubv4.MilestoneState{"OPEN", "CLOSED"}
+	default:
+		return nil, fmt.Errorf("invalid state: %s", state)
 	}
 
 	variables := map[string]interface{}{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
+		"states":    states,
 		"endCursor": (*githubv4.String)(nil),
 	}
 
@@ -830,8 +843,8 @@ func RepoMilestones(client *Client, repo ghrepo.Interface) ([]RepoMilestone, err
 	return milestones, nil
 }
 
-func MilestoneByTitle(client *Client, repo ghrepo.Interface, title string) (*RepoMilestone, error) {
-	milestones, err := RepoMilestones(client, repo)
+func MilestoneByTitle(client *Client, repo ghrepo.Interface, state, title string) (*RepoMilestone, error) {
+	milestones, err := RepoMilestones(client, repo, state)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #2192

I added `state` to arguments of `MilestoneByTitle`.


Before
---
```
$ gh issue list -R kubernetes/kubernetes -s all --milestone v1.4
no milestone found with title "v1.4"
```

After
---
```
$ ./bin/gh issue list -R kubernetes/kubernetes -s all --milestone v1.4 | head -1
50452   CLOSED  'pull-kubernetes-e2e-kops-aws' failing on release-1.4 branch, preventing merges kind/bug, sig/testing   2017-08-10 15:45:54 +0000 UTC
```