### PR TITLE
Update confusing prompt

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -364,9 +364,9 @@ func confirmSubmission(repoName string, repoOwner string, isConfirmFlagPassed *b
 
 	promptString := ""
 	if repoOwner != "" {
-		promptString = fmt.Sprintf("This will create '%s/%s' in your current directory. Continue? ", repoOwner, repoName)
+		promptString = fmt.Sprintf("Create '%s/%s' on Github? ", repoOwner, repoName)
 	} else {
-		promptString = fmt.Sprintf("This will create '%s' in your current directory. Continue? ", repoName)
+		promptString = fmt.Sprintf("Create '%s' on Github? ", repoName)
 	}
 
 	confirmSubmitQuestion := &survey.Question{


### PR DESCRIPTION
Fixes #1913 , #2180 

Updates the final confirmation string to reflect what we wanted it to be, a confirmation step before submitting to Github. The create a local directory now works in sync as in 

1. Pass the confirmation to create the repo on Github
2. Ask for creating a local directory if not already.