### PR TITLE
Use strings.Builder for more efficient string concatenation

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -501,11 +501,11 @@ func computeDefaults(baseRef, headRef string) (shared.Defaults, error) {
 	} else {
 		out.Title = utils.Humanize(headRef)
 
-		body := ""
+		var body strings.Builder
 		for i := len(commits) - 1; i >= 0; i-- {
-			body += fmt.Sprintf("- %s\n", commits[i].Title)
+			fmt.Fprintf(&body, "- %s\n", commits[i].Title)
 		}
-		out.Body = body
+		out.Body = body.String()
 	}
 
 	return out, nil


### PR DESCRIPTION
This change helps minimizes memory copying.

There are other places in the codebase where we can make similar change, but seems to me only this part of code may benefit a bit more significantly from making this change.

Reference: https://golang.org/pkg/strings/#Builder