### PR TITLE
Add a new config validation key called `prompt`

### DIFF
--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -18,7 +18,7 @@ const (
 
 var configValues = map[string][]string{
 	"git_protocol": {"ssh", "https"},
-	"prompt": {"enabled", "disabled"},
+	"prompt":       {"enabled", "disabled"},
 }
 
 // This interface describes interacting with some persistent configuration for gh.

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -18,6 +18,7 @@ const (
 
 var configValues = map[string][]string{
 	"git_protocol": {"ssh", "https"},
+	"prompt": {"enabled", "disabled"},
 }
 
 // This interface describes interacting with some persistent configuration for gh.


### PR DESCRIPTION
This pull request adds a new config validation key called `prompt` with values: `enabled`, `disabled`; along with the `git_protocol`