### PR TITLE
Fix continue browser for branch slash names

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -554,11 +554,7 @@ func determineTrackingBranch(remotes context.Remotes, headBranch string) *git.Tr
 }
 
 func generateCompareURL(r ghrepo.Interface, base, head, title, body string, assignees, labels, projects []string, milestones []string) (string, error) {
-	// This is to fix issues with names like "branch/#123"
-	b := url.QueryEscape(base)
-	h := url.QueryEscape(head)
-
-	u := ghrepo.GenerateRepoURL(r, "compare/%s...%s?expand=1", b, h)
+	u := ghrepo.GenerateRepoURL(r, "compare/%s...%s?expand=1", url.QueryEscape(base), url.QueryEscape(head))
 	url, err := shared.WithPrAndIssueQueryParams(u, title, body, assignees, labels, projects, milestones)
 	if err != nil {
 		return "", err

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -553,7 +554,11 @@ func determineTrackingBranch(remotes context.Remotes, headBranch string) *git.Tr
 }
 
 func generateCompareURL(r ghrepo.Interface, base, head, title, body string, assignees, labels, projects []string, milestones []string) (string, error) {
-	u := ghrepo.GenerateRepoURL(r, "compare/%s...%s?expand=1", base, head)
+	// This is to fix issues with names like "branch/#123"
+	b := url.QueryEscape(base)
+	h := url.QueryEscape(head)
+
+	u := ghrepo.GenerateRepoURL(r, "compare/%s...%s?expand=1", b, h)
 	url, err := shared.WithPrAndIssueQueryParams(u, title, body, assignees, labels, projects, milestones)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary
closes #2243

## Details
If you try to `Continue in browser` using the command `gh pr create` and your branch's name is like `branch/#123`, is opened a bad url in browser mixing the path with query params like `title` and displaying an unexpected prompt message.

__Example:__
`https://github.com/ephelsa/SOME-REPO/compare/master...branch/?title=branch%2F%23123#123?expand=1`
Prompt message: `Opening github.com/ephelsa/SOME-REPO/compare/master...branch/ in your browser.`

__After the solution:__
`https://github.com/ephelsa/SOME-REPO/compare/master...branch%2F%23123?expand=1&title=branch%2F%23123`
Prompt message: `Opening github.com/ephelsa/SOME-REPO/compare/master...branch/#123 in your browser.`
