### PR TITLE
Add host back into repo flag description

### DIFF
--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -8,7 +8,7 @@ import (
 )
 
 func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
-	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `OWNER/REPO` format")
+	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `[HOST/]OWNER/REPO` format")
 
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		repoOverride, _ := cmd.Flags().GetString("repo")


### PR DESCRIPTION
Reverts https://github.com/cli/cli/pull/1707 now that we have updated `spf13/cobra`. 