### PR TITLE
pr status: show number of approvals

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -373,8 +373,8 @@ func PullRequestStatus(client *Client, repo ghrepo.Interface, options StatusOpti
 	queryPrefix := `
 	query PullRequestStatus($owner: String!, $repo: String!, $headRefName: String!, $viewerQuery: String!, $reviewerQuery: String!, $per_page: Int = 10) {
 		repository(owner: $owner, name: $repo) {
-			defaultBranchRef { 
-				name 
+			defaultBranchRef {
+				name
 			}
 			pullRequests(headRefName: $headRefName, first: $per_page, orderBy: { field: CREATED_AT, direction: DESC }) {
 				totalCount
@@ -390,8 +390,8 @@ func PullRequestStatus(client *Client, repo ghrepo.Interface, options StatusOpti
 		queryPrefix = `
 		query PullRequestStatus($owner: String!, $repo: String!, $number: Int!, $viewerQuery: String!, $reviewerQuery: String!, $per_page: Int = 10) {
 			repository(owner: $owner, name: $repo) {
-				defaultBranchRef { 
-					name 
+				defaultBranchRef {
+					name
 				}
 				pullRequest(number: $number) {
 					...prWithReviews

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -69,7 +69,8 @@ type PullRequest struct {
 
 	BaseRef struct {
 		BranchProtectionRule struct {
-			RequiresStrictStatusChecks bool
+			RequiresStrictStatusChecks   bool
+			RequiredApprovingReviewCount int
 		}
 	}
 
@@ -395,6 +396,11 @@ func PullRequestStatus(client *Client, repo ghrepo.Interface, options StatusOpti
 				}
 				pullRequest(number: $number) {
 					...prWithReviews
+					baseRef {
+						branchProtectionRule {
+							requiredApprovingReviewCount
+						}
+					}
 				}
 			}
 		`

--- a/pkg/cmd/pr/status/fixtures/prStatusChecks.json
+++ b/pkg/cmd/pr/status/fixtures/prStatusChecks.json
@@ -44,6 +44,34 @@
             "url": "https://github.com/cli/cli/pull/7",
             "headRefName": "banananana",
             "reviewDecision": "APPROVED",
+            "reviews": {
+              "nodes": [
+                {
+                  "author": {
+                    "login": "bob"
+                  },
+                  "state": "APPROVED"
+                },
+                {
+                  "author": {
+                    "login": "bob"
+                  },
+                  "state": "CHANGES_REQUESTED"
+                },
+                {
+                  "author": {
+                    "login": "bob"
+                  },
+                  "state": "APPROVED"
+                },
+                {
+                  "author": {
+                    "login": "alice"
+                  },
+                  "state": "APPROVED"
+                }
+              ]
+            },
             "commits": {
               "nodes": [
                 {

--- a/pkg/cmd/pr/status/fixtures/prStatusChecks.json
+++ b/pkg/cmd/pr/status/fixtures/prStatusChecks.json
@@ -44,6 +44,11 @@
             "url": "https://github.com/cli/cli/pull/7",
             "headRefName": "banananana",
             "reviewDecision": "APPROVED",
+            "baseRef": {
+              "branchProtectionRule": {
+                "requiredApprovingReviewCount": 0
+              }
+            },
             "reviews": {
               "nodes": [
                 {

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -199,6 +199,30 @@ func prSelectorForCurrentBranch(baseRepo ghrepo.Interface, prHeadRef string, rem
 	return
 }
 
+// Users can review PRs multiple times. To get an accurate count of current
+// approvals of a PR, this code doesn't count duplicate approvals by the same
+// user, and ensures only the chronologically latest review is considered for
+// each user.
+func effectiveApprovals(pr *api.PullRequest) int {
+	// Map of names who have approved the PR and the state of their review.
+	reviewerStates := make(map[string]string)
+
+	approvals := 0
+
+	for _, review := range pr.Reviews.Nodes {
+		reviewerStates[review.Author.Login] = review.State
+	}
+
+	// Count the approvals
+	for _, reviewState := range reviewerStates {
+		if reviewState == "APPROVED" {
+			approvals++
+		}
+	}
+
+	return approvals
+}
+
 func printPrs(io *iostreams.IOStreams, totalCount int, prs ...api.PullRequest) {
 	w := io.Out
 	cs := io.ColorScheme()
@@ -246,7 +270,8 @@ func printPrs(io *iostreams.IOStreams, totalCount int, prs ...api.PullRequest) {
 			} else if reviews.ReviewRequired {
 				fmt.Fprint(w, cs.Yellow("- Review required"))
 			} else if reviews.Approved {
-				fmt.Fprint(w, cs.Green("✓ Approved"))
+				totalApprovals := effectiveApprovals(&pr)
+				fmt.Fprint(w, cs.Green("✓ "+strconv.Itoa(totalApprovals)+" Approved"))
 			}
 
 			if pr.BaseRef.BranchProtectionRule.RequiresStrictStatusChecks {

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -270,8 +270,15 @@ func printPrs(io *iostreams.IOStreams, totalCount int, prs ...api.PullRequest) {
 			} else if reviews.ReviewRequired {
 				fmt.Fprint(w, cs.Yellow("- Review required"))
 			} else if reviews.Approved {
-				totalApprovals := effectiveApprovals(&pr)
-				fmt.Fprint(w, cs.Green("✓ "+strconv.Itoa(totalApprovals)+" Approved"))
+				reqApprovals := pr.BaseRef.BranchProtectionRule.RequiredApprovingReviewCount
+				approvals := effectiveApprovals(&pr)
+				s := cs.Green(fmt.Sprintf("✓ %d", approvals))
+
+				if reqApprovals > 0 {
+					s = cs.Green(fmt.Sprintf("✓ %d/%d", approvals, reqApprovals))
+				}
+
+				fmt.Fprint(w, s+" Approved")
 			}
 
 			if pr.BaseRef.BranchProtectionRule.RequiresStrictStatusChecks {

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -112,7 +112,7 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 
 	expected := []string{
 		"✓ Checks passing + Changes requested",
-		"- Checks pending ✓ 0 Approved",
+		"- Checks pending ✓ 2 Approved",
 		"× 1/3 checks failing - Review required",
 	}
 

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -112,7 +112,7 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 
 	expected := []string{
 		"✓ Checks passing + Changes requested",
-		"- Checks pending ✓ Approved",
+		"- Checks pending ✓ 0 Approved",
 		"× 1/3 checks failing - Review required",
 	}
 


### PR DESCRIPTION
closes #2210 

This commit adds the total count of PR approvals in the `pr status` command output.