### PR TITLE
Change feedback repo to github.com/cli/cli instead of cli/cli

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -39,7 +39,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 		`),
 		Annotations: map[string]string{
 			"help:feedback": heredoc.Doc(`
-				Open an issue using 'gh issue create -R cli/cli'
+				Open an issue using 'gh issue create -R github.com/cli/cli'
 			`),
 			"help:environment": heredoc.Doc(`
 				See 'gh help environment' for the list of supported environment variables.


### PR DESCRIPTION
Fixes #2258 

I added `github.com/` to the feedback command at the help document.

```sh
$ make; ./bin/gh | grep FEEDBACK -A1
FEEDBACK
  Open an issue using 'gh issue create -R github.com/cli/cli'
```