### PR TITLE
Support for --web when using gist create

### DIFF
--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -31,6 +31,8 @@ type CreateOptions struct {
 	Filenames        []string
 	FilenameOverride string
 
+	WebMode bool
+
 	HttpClient func() (*http.Client, error)
 }
 
@@ -87,6 +89,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	}
 
 	cmd.Flags().StringVarP(&opts.Description, "desc", "d", "", "A description for this gist")
+	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open the web browser with created gist")
 	cmd.Flags().BoolVarP(&opts.Public, "public", "p", false, "List the gist publicly (default: private)")
 	cmd.Flags().StringVarP(&opts.FilenameOverride, "filename", "f", "", "Provide a filename to be used when reading from STDIN")
 	return cmd
@@ -136,6 +139,12 @@ func createRun(opts *CreateOptions) error {
 	}
 
 	fmt.Fprintf(errOut, "%s %s\n", utils.Green("✓"), completionMessage)
+
+	if opts.WebMode {
+		fmt.Fprintf(opts.IO.Out, "Opening %s in your browser.\n", utils.DisplayURL(gist.HTMLURL))
+
+		return utils.OpenInBrowser(gist.HTMLURL)
+	}
 
 	fmt.Fprintln(opts.IO.Out, gist.HTMLURL)
 

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -316,7 +316,8 @@ func Test_createRun(t *testing.T) {
 			assert.Equal(t, tt.wantParams, reqBody)
 
 			if tt.name == "web arg" {
-				assert.Equal(t, cs.Calls[0].Args[1], "https://gist.github.com/aa5a315d61ae9438b18d")
+				browserCall := cs.Calls[0].Args
+				assert.Equal(t, browserCall[len(browserCall)-1], "https://gist.github.com/aa5a315d61ae9438b18d")
 			}
 
 			reg.Verify(t)

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -292,10 +292,9 @@ func Test_createRun(t *testing.T) {
 		tt.opts.IO = io
 
 		cs, cmdTeardown := test.InitCmdStubber()
+		defer cmdTeardown()
 
-		if tt.name == "web arg" {
-			defer cmdTeardown()
-
+		if tt.opts.WebMode {
 			cs.Stub("")
 		}
 
@@ -315,7 +314,7 @@ func Test_createRun(t *testing.T) {
 			assert.Equal(t, tt.wantStderr, stderr.String())
 			assert.Equal(t, tt.wantParams, reqBody)
 
-			if tt.name == "web arg" {
+			if tt.opts.WebMode {
 				browserCall := cs.Calls[0].Args
 				assert.Equal(t, browserCall[len(browserCall)-1], "https://gist.github.com/aa5a315d61ae9438b18d")
 			}


### PR DESCRIPTION
Proposal to close #2071

Added support for `gh gist create [<filename>... | -] --web`
Added test to `gist/create/create_test.go` for `--web` argument

Thought it would be fun and took a stab at it.

