### PR TITLE
Allow url output using pr view

### DIFF
--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -199,7 +199,7 @@ func printHumanPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 
 	// Footer
 	fmt.Fprint(out, utils.Gray("View this pull request on GitHub: "))
-	fmt.Fprintf(out, utils.Underline(fmt.Sprintf("%s\n", pr.URL)))
+	fmt.Fprint(out, utils.Underline(fmt.Sprintf("%s\n", pr.URL)))
 	return nil
 }
 

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -31,6 +31,7 @@ type ViewOptions struct {
 
 	SelectorArg string
 	BrowserMode bool
+	UrlOnly     bool
 }
 
 func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Command {
@@ -74,6 +75,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	}
 
 	cmd.Flags().BoolVarP(&opts.BrowserMode, "web", "w", false, "Open a pull request in the browser")
+	cmd.Flags().BoolVarP(&opts.UrlOnly, "url-only", "u", false, "Display only the URL")
 
 	return cmd
 }
@@ -98,6 +100,15 @@ func viewRun(opts *ViewOptions) error {
 			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", utils.DisplayURL(openURL))
 		}
 		return utils.OpenInBrowser(openURL)
+	}
+
+	if opts.UrlOnly {
+		url := pr.URL
+		if connectedToTerminal {
+			url = fmt.Sprintf("\n%s\n", url)
+		}
+		fmt.Fprintf(opts.IO.Out, utils.Underline(url))
+		return nil
 	}
 
 	opts.IO.DetectTerminalTheme()
@@ -187,7 +198,8 @@ func printHumanPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 	fmt.Fprintln(out)
 
 	// Footer
-	fmt.Fprintf(out, utils.Gray("View this pull request on GitHub: %s\n"), pr.URL)
+	fmt.Fprintf(out, utils.Gray("View this pull request on GitHub: "))
+	fmt.Fprintln(out, utils.Underline(fmt.Sprintf("%s\n", pr.URL)))
 	return nil
 }
 

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -107,7 +107,7 @@ func viewRun(opts *ViewOptions) error {
 		if connectedToTerminal {
 			url = fmt.Sprintf("\n%s\n", url)
 		}
-		fmt.Fprintf(opts.IO.Out, utils.Underline(url))
+		fmt.Fprint(opts.IO.Out, utils.Underline(url))
 		return nil
 	}
 
@@ -198,8 +198,8 @@ func printHumanPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 	fmt.Fprintln(out)
 
 	// Footer
-	fmt.Fprintf(out, utils.Gray("View this pull request on GitHub: "))
-	fmt.Fprintln(out, utils.Underline(fmt.Sprintf("%s\n", pr.URL)))
+	fmt.Fprint(out, utils.Gray("View this pull request on GitHub: "))
+	fmt.Fprintf(out, utils.Underline(fmt.Sprintf("%s\n", pr.URL)))
 	return nil
 }
 

--- a/utils/color.go
+++ b/utils/color.go
@@ -12,14 +12,15 @@ import (
 
 var (
 	// Outputs ANSI color if stdout is a tty
-	Magenta = makeColorFunc("magenta")
-	Cyan    = makeColorFunc("cyan")
-	Red     = makeColorFunc("red")
-	Yellow  = makeColorFunc("yellow")
-	Blue    = makeColorFunc("blue")
-	Green   = makeColorFunc("green")
-	Gray    = makeColorFunc("black+h")
-	Bold    = makeColorFunc("default+b")
+	Magenta   = makeColorFunc("magenta")
+	Cyan      = makeColorFunc("cyan")
+	Red       = makeColorFunc("red")
+	Yellow    = makeColorFunc("yellow")
+	Blue      = makeColorFunc("blue")
+	Green     = makeColorFunc("green")
+	Gray      = makeColorFunc("black+h")
+	Bold      = makeColorFunc("default+b")
+	Underline = makeColorFunc("default+u")
 )
 
 // NewColorable returns an output stream that handles ANSI color sequences on Windows


### PR DESCRIPTION
## Summary
closes #2140 

## Details
Added `--url-only` or `-u` flag for `pr view`, to display only full URL of a PR.  

<img width="640" alt="url-only terminal" src="https://user-images.githubusercontent.com/25624035/96952222-f0684980-14b3-11eb-9bc0-620dc99e1053.png">

Helps to copy directly from terminal (for example ` | pbcopy` it will copy without jumplines) or to show without open a pager.

## _On the other hand_
Added an _underline_ to the URL displayed without flags to improve readability 😅.

<img width="640" alt="underline prview" src="https://user-images.githubusercontent.com/25624035/96952378-548b0d80-14b4-11eb-9513-e7fb72db384d.png">
