### PR TITLE
Allow `gh pr view <closed_pr_branch_name>` to view closed PRs

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -626,7 +626,6 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, baseBranch, hea
 	type response struct {
 		Repository struct {
 			PullRequests struct {
-				ID    githubv4.ID
 				Nodes []PullRequest
 			}
 		}
@@ -740,12 +739,7 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, baseBranch, hea
 	sortPullRequestsByState(prs)
 
 	for _, pr := range prs {
-		if pr.HeadLabel() == headBranch {
-			if baseBranch != "" {
-				if pr.BaseRefName != baseBranch {
-					continue
-				}
-			}
+		if pr.HeadLabel() == headBranch && (baseBranch == "" || pr.BaseRefName == baseBranch) {
 			return &pr, nil
 		}
 	}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -748,7 +748,7 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, baseBranch, hea
 		}
 	}
 
-	return nil, &NotFoundError{fmt.Errorf("no open pull requests found for branch %q", headBranch)}
+	return nil, &NotFoundError{fmt.Errorf("no pull requests found for branch %q", headBranch)}
 }
 
 // CreatePullRequest creates a pull request in a GitHub repository

--- a/api/queries_pr_test.go
+++ b/api/queries_pr_test.go
@@ -139,22 +139,31 @@ func Test_determinePullRequestFeatures(t *testing.T) {
 	}
 }
 
-func Test_sortPullRequestsByPrecedence(t *testing.T) {
-	prs := sortPullRequestsByState([]PullRequest{
+func Test_sortPullRequestsByState(t *testing.T) {
+	prs := []PullRequest{
 		{
-			BaseRefName: "test-PR",
+			BaseRefName: "test1",
 			State:       "MERGED",
 		},
 		{
-			BaseRefName: "test-PR",
+			BaseRefName: "test2",
 			State:       "CLOSED",
 		},
 		{
-			BaseRefName: "test-PR",
+			BaseRefName: "test3",
 			State:       "OPEN",
 		},
-	})
-	if prs[0].State != "OPEN" {
-		t.Errorf("sortPullRequestsByPrecedence() = got %s, want \"OPEN\"", prs[0].State)
+	}
+
+	sortPullRequestsByState(prs)
+
+	if prs[0].BaseRefName != "test3" {
+		t.Errorf("prs[0]: got %s, want %q", prs[0].BaseRefName, "test3")
+	}
+	if prs[1].BaseRefName != "test1" {
+		t.Errorf("prs[1]: got %s, want %q", prs[1].BaseRefName, "test1")
+	}
+	if prs[2].BaseRefName != "test2" {
+		t.Errorf("prs[2]: got %s, want %q", prs[2].BaseRefName, "test2")
 	}
 }

--- a/api/queries_pr_test.go
+++ b/api/queries_pr_test.go
@@ -138,3 +138,23 @@ func Test_determinePullRequestFeatures(t *testing.T) {
 		})
 	}
 }
+
+func Test_sortPullRequestsByPrecedence(t *testing.T) {
+	prs := sortPullRequestsByState([]PullRequest{
+		{
+			BaseRefName: "test-PR",
+			State:       "MERGED",
+		},
+		{
+			BaseRefName: "test-PR",
+			State:       "CLOSED",
+		},
+		{
+			BaseRefName: "test-PR",
+			State:       "OPEN",
+		},
+	})
+	if prs[0].State != "OPEN" {
+		t.Errorf("sortPullRequestsByPrecedence() = got %s, want \"OPEN\"", prs[0].State)
+	}
+}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -303,7 +303,7 @@ func createRun(opts *CreateOptions) error {
 	}
 
 	if !opts.WebMode {
-		existingPR, err := api.PullRequestForBranch(client, baseRepo, baseBranch, headBranchLabel)
+		existingPR, err := api.PullRequestForBranch(client, baseRepo, baseBranch, headBranchLabel, []string{"OPEN"})
 		var notFound *api.NotFoundError
 		if err != nil && !errors.As(err, &notFound) {
 			return fmt.Errorf("error checking for existing pull request: %w", err)

--- a/pkg/cmd/pr/diff/diff_test.go
+++ b/pkg/cmd/pr/diff/diff_test.go
@@ -171,7 +171,7 @@ func TestPRDiff_no_current_pr(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	assert.Equal(t, `no open pull requests found for branch "feature"`, err.Error())
+	assert.Equal(t, `no pull requests found for branch "feature"`, err.Error())
 }
 
 func TestPRDiff_argument_not_found(t *testing.T) {

--- a/pkg/cmd/pr/shared/lookup.go
+++ b/pkg/cmd/pr/shared/lookup.go
@@ -43,7 +43,7 @@ func PRFromArgs(apiClient *api.Client, baseRepoFn func() (ghrepo.Interface, erro
 		}
 
 		// Last see if it is a branch name
-		pr, err = api.PullRequestForBranch(apiClient, repo, "", arg)
+		pr, err = api.PullRequestForBranch(apiClient, repo, "", arg, nil)
 		return pr, repo, err
 	}
 }
@@ -117,5 +117,5 @@ func prForCurrentBranch(apiClient *api.Client, repo ghrepo.Interface, branchFn f
 		}
 	}
 
-	return api.PullRequestForBranch(apiClient, repo, "", prHeadRef)
+	return api.PullRequestForBranch(apiClient, repo, "", prHeadRef, nil)
 }

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -536,7 +536,7 @@ func TestPRView_web_noResultsForBranch(t *testing.T) {
 	defer restoreCmd()
 
 	_, err := runCommand(http, "blueberries", true, "-w")
-	if err == nil || err.Error() != `no open pull requests found for branch "blueberries"` {
+	if err == nil || err.Error() != `no pull requests found for branch "blueberries"` {
 		t.Errorf("error running command `pr view`: %v", err)
 	}
 


### PR DESCRIPTION
Hello 👋   This is my first PR being raised here, so please let me know if I'm getting something wrong 😄 

Currently, you can't view closed PRs by branch. This is due to a `states: OPEN` filter in the graphql query.

However, viewing the closed PR by number does work as the query does not have this condition [here](https://github.com/ianbillett/cli/blob/3e4d904df967b5f206c51a16fa94130b3edec08e/api/queries_pr.go#L532).

This PR removes this condition from the `PullRequestForBranch` function.

Before this change
```
➜  cli git:(c8b7dad) go run cmd/gh/main.go pr view quiye:issue-report -R cli/cli --web
no open pull requests found for branch "quiye:issue-report"
```
After this change
```
➜  cli git:(view-closed-prs) go run cmd/gh/main.go pr view quiye:issue-report -R cli/cli --web
Opening github.com/cli/cli/pull/2262 in your browser.
```

This closes https://github.com/cli/cli/issues/2270