### PR TITLE
feat: print after url when created repository

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -22,6 +22,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const defaultGitProtocol = "https"
+
 type CreateOptions struct {
 	HttpClient func() (*http.Client, error)
 	Config     func() (config.Config, error)
@@ -251,6 +253,7 @@ func createRun(opts *CreateOptions) error {
 
 		if isTTY {
 			fmt.Fprintf(stderr, "%s Created repository %s on GitHub\n", greenCheck, ghrepo.FullName(repo))
+			fmt.Fprintf(stderr, "%s The url repository %s on GitHub\n", greenCheck, ghrepo.FormatRemoteURL(repo, defaultGitProtocol))
 		} else {
 			fmt.Fprintln(stdout, repo.URL)
 		}

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -112,7 +112,7 @@ func TestRepoCreate(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n", output.Stderr())
+	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ The url repository https://github.com/OWNER/REPO.git on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n", output.Stderr())
 
 	if seenCmd == nil {
 		t.Fatal("expected a command to run")
@@ -194,7 +194,7 @@ func TestRepoCreate_org(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Created repository ORG/REPO on GitHub\n✓ Added remote https://github.com/ORG/REPO.git\n", output.Stderr())
+	assert.Equal(t, "✓ Created repository ORG/REPO on GitHub\n✓ The url repository https://github.com/ORG/REPO.git on GitHub\n✓ Added remote https://github.com/ORG/REPO.git\n", output.Stderr())
 
 	if seenCmd == nil {
 		t.Fatal("expected a command to run")
@@ -276,7 +276,7 @@ func TestRepoCreate_orgWithTeam(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Created repository ORG/REPO on GitHub\n✓ Added remote https://github.com/ORG/REPO.git\n", output.Stderr())
+	assert.Equal(t, "✓ Created repository ORG/REPO on GitHub\n✓ The url repository https://github.com/ORG/REPO.git on GitHub\n✓ Added remote https://github.com/ORG/REPO.git\n", output.Stderr())
 
 	if seenCmd == nil {
 		t.Fatal("expected a command to run")
@@ -359,7 +359,7 @@ func TestRepoCreate_template(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n", output.Stderr())
+	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ The url repository https://github.com/OWNER/REPO.git on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n", output.Stderr())
 
 	if seenCmd == nil {
 		t.Fatal("expected a command to run")
@@ -447,7 +447,7 @@ func TestRepoCreate_withoutNameArg(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n", output.Stderr())
+	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ The url repository https://github.com/OWNER/REPO.git on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n", output.Stderr())
 
 	if seenCmd == nil {
 		t.Fatal("expected a command to run")


### PR DESCRIPTION
Minor change. It should print the URL from the created repository

![image](https://user-images.githubusercontent.com/17230930/97080833-82915e80-1628-11eb-9313-59afd7a8c647.png)
