### PR TITLE
gh repo create improvements

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -40,7 +40,7 @@ func ShowRefs(ref ...string) ([]Ref, error) {
 	output, err := run.PrepareCmd(showRef).Output()
 
 	var refs []Ref
-	for _, line := range outputLines(output) {
+	for _, line := range OutputLines(output) {
 		parts := strings.SplitN(line, " ", 2)
 		if len(parts) < 2 {
 			continue
@@ -79,7 +79,7 @@ func CurrentBranch() (string, error) {
 func listRemotes() ([]string, error) {
 	remoteCmd := exec.Command("git", "remote", "-v")
 	output, err := run.PrepareCmd(remoteCmd).Output()
-	return outputLines(output), err
+	return OutputLines(output), err
 }
 
 func Config(name string) (string, error) {
@@ -134,7 +134,7 @@ func Commits(baseRef, headRef string) ([]*Commit, error) {
 	commits := []*Commit{}
 	sha := 0
 	title := 1
-	for _, line := range outputLines(output) {
+	for _, line := range OutputLines(output) {
 		split := strings.SplitN(line, ",", 2)
 		if len(split) != 2 {
 			continue
@@ -183,7 +183,7 @@ func ReadBranchConfig(branch string) (cfg BranchConfig) {
 	if err != nil {
 		return
 	}
-	for _, line := range outputLines(output) {
+	for _, line := range OutputLines(output) {
 		parts := strings.SplitN(line, " ", 2)
 		if len(parts) < 2 {
 			continue
@@ -279,7 +279,7 @@ func ToplevelDir() (string, error) {
 
 }
 
-func outputLines(output []byte) []string {
+func OutputLines(output []byte) []string {
 	lines := strings.TrimSuffix(string(output), "\n")
 	return strings.Split(lines, "\n")
 

--- a/git/remote.go
+++ b/git/remote.go
@@ -42,12 +42,12 @@ func Remotes() (RemoteSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	remotes := parseRemotes(list)
+	remotes := ParseRemotes(list)
 
 	// this is affected by SetRemoteResolution
 	remoteCmd := exec.Command("git", "config", "--get-regexp", `^remote\..*\.gh-resolved$`)
 	output, _ := run.PrepareCmd(remoteCmd).Output()
-	for _, l := range outputLines(output) {
+	for _, l := range OutputLines(output) {
 		parts := strings.SplitN(l, " ", 2)
 		if len(parts) < 2 {
 			continue
@@ -68,7 +68,7 @@ func Remotes() (RemoteSet, error) {
 	return remotes, nil
 }
 
-func parseRemotes(gitRemotes []string) (remotes RemoteSet) {
+func ParseRemotes(gitRemotes []string) (remotes RemoteSet) {
 	for _, r := range gitRemotes {
 		match := remoteRE.FindStringSubmatch(r)
 		if match == nil {

--- a/git/remote_test.go
+++ b/git/remote_test.go
@@ -11,7 +11,7 @@ func Test_parseRemotes(t *testing.T) {
 		"upstream\thttps://github.com/hubot/tools (push)",
 		"zardoz\thttps://example.com/zed.git (push)",
 	}
-	r := parseRemotes(remoteList)
+	r := ParseRemotes(remoteList)
 	eq(t, len(r), 4)
 
 	eq(t, r[0].Name, "mona")

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -146,6 +146,9 @@ func createRun(opts *CreateOptions) error {
 				},
 			},
 		}, &answer)
+		if err != nil {
+			return err
+		}
 
 		if answer {
 			remoteName, remoteURL, err := interactiveAddRemote("", remotes)

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"path"
+	"reflect"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -110,18 +112,60 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 }
 
 func createRun(opts *CreateOptions) error {
-	projectDir, projectDirErr := git.ToplevelDir()
+	_, projectDirErr := git.ToplevelDir()
 	isNameAnArg := false
 	isDescEmpty := opts.Description == ""
 	isVisibilityPassed := false
 
+	workDir, workDirErr := os.Getwd()
+	if workDirErr != nil {
+		return workDirErr
+	}
+
 	if opts.Name != "" {
 		isNameAnArg = true
 	} else {
-		if projectDirErr != nil {
-			return projectDirErr
+		opts.Name = path.Base(workDir)
+	}
+
+	if projectDirErr == nil {
+		remotes, err := remotesOfProject(true, opts.Name)
+		if err != nil {
+			return err
 		}
-		opts.Name = path.Base(projectDir)
+
+		fmt.Fprintf(opts.IO.Out, "Detected a project with these remotes: %s\n", remotes)
+
+		answer := true
+		err = prompt.SurveyAsk([]*survey.Question{
+			{
+				Name: "addNewRemote",
+				Prompt: &survey.Confirm{
+					Message: "Do you want to add a new remote?",
+					Default: answer,
+				},
+			},
+		}, &answer)
+
+		if answer {
+			remoteName, remoteURL, err := interactiveAddRemote("", remotes)
+			if err != nil {
+				return err
+			}
+
+			err = addRemoteForProject(true, opts.Name, remoteName, remoteURL)
+			if err != nil {
+				return err
+			}
+
+			if opts.IO.IsStdoutTTY() {
+				fmt.Fprintf(opts.IO.ErrOut, "%s Added remote %s %s\n", utils.GreenCheck(), remoteName, remoteURL)
+			}
+
+			return nil
+		} else {
+			fmt.Fprintf(opts.IO.Out, "\n%s\n", utils.Bold("Create a new project..."))
+		}
 	}
 
 	enabledFlagCount := 0
@@ -230,9 +274,8 @@ func createRun(opts *CreateOptions) error {
 		return err
 	}
 
-	createLocalDirectory := opts.ConfirmSubmit
 	if !opts.ConfirmSubmit {
-		opts.ConfirmSubmit, err = confirmSubmission(input.Name, input.OwnerID, &opts.ConfirmSubmit)
+		opts.ConfirmSubmit, err = confirmSubmission(input.Name, input.OwnerID)
 		if err != nil {
 			return err
 		}
@@ -246,7 +289,7 @@ func createRun(opts *CreateOptions) error {
 
 		stderr := opts.IO.ErrOut
 		stdout := opts.IO.Out
-		greenCheck := utils.Green("✓")
+		greenCheck := utils.GreenCheck()
 		isTTY := opts.IO.IsStdoutTTY()
 
 		if isTTY {
@@ -266,48 +309,199 @@ func createRun(opts *CreateOptions) error {
 		}
 		remoteURL := ghrepo.FormatRemoteURL(repo, protocol)
 
-		if projectDirErr == nil {
-			_, err = git.AddRemote("origin", remoteURL)
+		useCurrentDir, dirName := false, repo.Name
+		if projectDirErr != nil {
+			useCurrentDir, dirName, err = interactiveCreateProjectDir(repo.Name)
 			if err != nil {
 				return err
 			}
-			if isTTY {
-				fmt.Fprintf(stderr, "%s Added remote %s\n", greenCheck, remoteURL)
-			}
-		} else if opts.IO.CanPrompt() {
-			doSetup := createLocalDirectory
-			if !doSetup {
-				err := prompt.Confirm(fmt.Sprintf("Create a local project directory for %s?", ghrepo.FullName(repo)), &doSetup)
-				if err != nil {
-					return err
-				}
-			}
-			if doSetup {
-				path := repo.Name
-
-				gitInit := git.GitCommand("init", path)
-				gitInit.Stdout = stdout
-				gitInit.Stderr = stderr
-				err = run.PrepareCmd(gitInit).Run()
-				if err != nil {
-					return err
-				}
-				gitRemoteAdd := git.GitCommand("-C", path, "remote", "add", "origin", remoteURL)
-				gitRemoteAdd.Stdout = stdout
-				gitRemoteAdd.Stderr = stderr
-				err = run.PrepareCmd(gitRemoteAdd).Run()
-				if err != nil {
-					return err
-				}
-
-				fmt.Fprintf(stderr, "%s Initialized repository in './%s/'\n", utils.GreenCheck(), path)
-			}
 		}
 
+		if opts.IO.CanPrompt() {
+			gitInit := git.GitCommand("init", dirName)
+			if useCurrentDir {
+				gitInit = git.GitCommand("init")
+			}
+			gitInit.Stdout = stdout
+			gitInit.Stderr = stderr
+			err = run.PrepareCmd(gitInit).Run()
+			if err != nil {
+				return err
+			}
+
+			remotes, err := remotesOfProject(useCurrentDir, dirName)
+			if err != nil {
+				return err
+			}
+
+			remoteName, remoteURL, err := interactiveAddRemote(remoteURL, remotes)
+			if err != nil {
+				return err
+			}
+
+			err = addRemoteForProject(useCurrentDir, dirName, remoteName, remoteURL)
+			if err != nil {
+				return err
+			}
+
+			msg := fmt.Sprintf("%s Initialized repository in './%s/'\n", utils.GreenCheck(), repo.Name)
+			if useCurrentDir {
+				msg = fmt.Sprintf("%s Initialized repository in current directory\n", utils.GreenCheck())
+			}
+			fmt.Fprint(stderr, msg)
+		}
 		return nil
 	}
+
 	fmt.Fprintln(opts.IO.Out, "Discarding...")
 	return nil
+}
+
+func remotesOfProject(useCurr bool, dirName string) (git.RemoteSet, error) {
+	remoteCmd := git.GitCommand("-C", dirName, "remote", "-v")
+	if useCurr {
+		remoteCmd = git.GitCommand("remote", "-v")
+	}
+	output, err := run.PrepareCmd(remoteCmd).Output()
+	if err != nil {
+		return []*git.Remote{}, err
+	}
+
+	remoteList := git.OutputLines(output)
+
+	return git.ParseRemotes(remoteList), nil
+}
+
+func addRemoteForProject(useCurr bool, dirName string, remoName string, remoURL string) error {
+	addRemoCmd := git.GitCommand("-C", dirName, "remote", "add", remoName, remoURL)
+	if useCurr {
+		addRemoCmd = git.GitCommand("remote", "add", remoName, remoURL)
+	}
+	err := run.PrepareCmd(addRemoCmd).Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func interactiveCreateProjectDir(projectName string) (bool, string, error) {
+	answers := struct {
+		UseCurrentDir bool
+		DirName       string
+	}{
+		UseCurrentDir: true,
+		DirName:       projectName,
+	}
+
+	useCurrentDirQuestion := &survey.Confirm{
+		Message: "Use the current directory for the project?",
+		Default: answers.UseCurrentDir,
+	}
+
+	dirErr := prompt.SurveyAskOne(useCurrentDirQuestion, &answers.UseCurrentDir)
+	if dirErr != nil {
+		return false, "", dirErr
+	}
+
+	if !answers.UseCurrentDir {
+		dirNameQuestion := &survey.Input{
+			Message: "Name for the directory's project",
+			Default: answers.DirName,
+		}
+
+		nameErr := prompt.SurveyAskOne(dirNameQuestion, &answers.DirName)
+		if nameErr != nil {
+			return false, "", nameErr
+		}
+	}
+
+	return answers.UseCurrentDir, answers.DirName, nil
+}
+
+func interactiveAddRemote(originRemote string, remotes git.RemoteSet) (string, string, error) {
+	hasOrigin := false
+
+	for _, v := range remotes {
+		if v.Name == "origin" {
+			hasOrigin = true
+			break
+		}
+	}
+
+	addOrigin := false
+	answers := struct {
+		RemoteName string
+		RemoteURL  string
+	}{
+		RemoteName: "origin",
+		RemoteURL:  "",
+	}
+
+	if !hasOrigin {
+		addOriginQuestion := &survey.Question{
+			Name: "addOrigin",
+			Prompt: &survey.Confirm{
+				Message: "Do you want to add origin?",
+				Default: true,
+			},
+		}
+
+		qs := []*survey.Question{addOriginQuestion}
+
+		err := prompt.SurveyAsk(qs, &addOrigin)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	var qs []*survey.Question
+
+	if !addOrigin {
+		remoteNameQuestion := &survey.Question{
+			Name: "remoteName",
+			Prompt: &survey.Input{
+				Message: "Remote name",
+			},
+			Validate: survey.ComposeValidators(survey.Required, func(val interface{}) error {
+				value := reflect.ValueOf(val)
+
+				for _, v := range remotes {
+					if v.Name == value.String() {
+						return fmt.Errorf("\n\"%s\" already exists with url %s", v.Name, v.PushURL)
+					}
+				}
+				return nil
+			}),
+		}
+
+		qs = append(qs, remoteNameQuestion)
+	} else {
+		answers.RemoteURL = originRemote
+	}
+
+	label := "Remote url"
+	if addOrigin {
+		label = fmt.Sprintf("Remote url for %s", answers.RemoteName)
+	}
+
+	addUrlQuestion := &survey.Question{
+		Name: "remoteUrl",
+		Prompt: &survey.Input{
+			Message: label,
+			Default: answers.RemoteURL,
+		},
+		Validate: survey.Required,
+	}
+
+	qs = append(qs, addUrlQuestion)
+
+	err := prompt.SurveyAsk(qs, &answers)
+	if err != nil {
+		return "", "", err
+	}
+
+	return answers.RemoteName, answers.RemoteURL, nil
 }
 
 func interactiveRepoCreate(isDescEmpty bool, isVisibilityPassed bool, repoName string) (string, string, string, error) {
@@ -359,14 +553,14 @@ func interactiveRepoCreate(isDescEmpty bool, isVisibilityPassed bool, repoName s
 	return answers.RepoName, answers.RepoDescription, strings.ToUpper(answers.RepoVisibility), nil
 }
 
-func confirmSubmission(repoName string, repoOwner string, isConfirmFlagPassed *bool) (bool, error) {
+func confirmSubmission(repoName string, repoOwner string) (bool, error) {
 	qs := []*survey.Question{}
 
 	promptString := ""
 	if repoOwner != "" {
-		promptString = fmt.Sprintf("This will create '%s/%s' in your current directory. Continue? ", repoOwner, repoName)
+		promptString = fmt.Sprintf("Create '%s/%s' on Github? ", repoOwner, repoName)
 	} else {
-		promptString = fmt.Sprintf("This will create '%s' in your current directory. Continue? ", repoName)
+		promptString = fmt.Sprintf("Create '%s' on Github? ", repoName)
 	}
 
 	confirmSubmitQuestion := &survey.Question{

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -95,6 +95,12 @@ func TestRepoCreate(t *testing.T) {
 
 	as.Stub([]*prompt.QuestionStub{
 		{
+			Name:  "addNewRemote",
+			Value: false,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
 			Name:  "repoVisibility",
 			Value: "PRIVATE",
 		},
@@ -105,19 +111,37 @@ func TestRepoCreate(t *testing.T) {
 			Value: true,
 		},
 	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:  "addOrigin",
+			Value: true,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:    "remoteUrl",
+			Default: true,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:    "remoteName",
+			Default: true,
+		},
+	})
 
 	output, err := runCommand(httpClient, "REPO")
 	if err != nil {
 		t.Errorf("error running command `repo create`: %v", err)
 	}
 
-	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n", output.Stderr())
+	assert.Equal(t, "Detected a project with these remotes: []\n\nCreate a new project...\n", output.String())
+	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ Initialized repository in './REPO/'\n", output.Stderr())
 
 	if seenCmd == nil {
 		t.Fatal("expected a command to run")
 	}
-	assert.Equal(t, "git remote add -f origin https://github.com/OWNER/REPO.git", strings.Join(seenCmd.Args, " "))
+	assert.Equal(t, "git -C REPO remote add origin https://github.com/OWNER/REPO.git", strings.Join(seenCmd.Args, " "))
 
 	var reqBody struct {
 		Query     string
@@ -177,6 +201,12 @@ func TestRepoCreate_org(t *testing.T) {
 
 	as.Stub([]*prompt.QuestionStub{
 		{
+			Name:  "addNewRemote",
+			Value: false,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
 			Name:  "repoVisibility",
 			Value: "PRIVATE",
 		},
@@ -187,19 +217,37 @@ func TestRepoCreate_org(t *testing.T) {
 			Value: true,
 		},
 	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:  "addOrigin",
+			Value: true,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:    "remoteUrl",
+			Default: true,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:    "remoteName",
+			Default: true,
+		},
+	})
 
 	output, err := runCommand(httpClient, "ORG/REPO")
 	if err != nil {
 		t.Errorf("error running command `repo create`: %v", err)
 	}
 
-	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Created repository ORG/REPO on GitHub\n✓ Added remote https://github.com/ORG/REPO.git\n", output.Stderr())
+	assert.Equal(t, "Detected a project with these remotes: []\n\nCreate a new project...\n", output.String())
+	assert.Equal(t, "✓ Created repository ORG/REPO on GitHub\n✓ Initialized repository in './REPO/'\n", output.Stderr())
 
 	if seenCmd == nil {
 		t.Fatal("expected a command to run")
 	}
-	assert.Equal(t, "git remote add -f origin https://github.com/ORG/REPO.git", strings.Join(seenCmd.Args, " "))
+	assert.Equal(t, "git -C REPO remote add origin https://github.com/ORG/REPO.git", strings.Join(seenCmd.Args, " "))
 
 	var reqBody struct {
 		Query     string
@@ -259,6 +307,12 @@ func TestRepoCreate_orgWithTeam(t *testing.T) {
 
 	as.Stub([]*prompt.QuestionStub{
 		{
+			Name:  "addNewRemote",
+			Value: false,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
 			Name:  "repoVisibility",
 			Value: "PRIVATE",
 		},
@@ -269,19 +323,31 @@ func TestRepoCreate_orgWithTeam(t *testing.T) {
 			Value: true,
 		},
 	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:  "addOrigin",
+			Value: true,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:    "remoteUrl",
+			Default: true,
+		},
+	})
 
 	output, err := runCommand(httpClient, "ORG/REPO --team monkeys")
 	if err != nil {
 		t.Errorf("error running command `repo create`: %v", err)
 	}
 
-	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Created repository ORG/REPO on GitHub\n✓ Added remote https://github.com/ORG/REPO.git\n", output.Stderr())
+	assert.Equal(t, "Detected a project with these remotes: []\n\nCreate a new project...\n", output.String())
+	assert.Equal(t, "✓ Created repository ORG/REPO on GitHub\n✓ Initialized repository in './REPO/'\n", output.Stderr())
 
 	if seenCmd == nil {
 		t.Fatal("expected a command to run")
 	}
-	assert.Equal(t, "git remote add -f origin https://github.com/ORG/REPO.git", strings.Join(seenCmd.Args, " "))
+	assert.Equal(t, "git -C REPO remote add origin https://github.com/ORG/REPO.git", strings.Join(seenCmd.Args, " "))
 
 	var reqBody struct {
 		Query     string
@@ -342,6 +408,12 @@ func TestRepoCreate_template(t *testing.T) {
 
 	as.Stub([]*prompt.QuestionStub{
 		{
+			Name:  "addNewRemote",
+			Value: false,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
 			Name:  "repoVisibility",
 			Value: "PRIVATE",
 		},
@@ -352,19 +424,31 @@ func TestRepoCreate_template(t *testing.T) {
 			Value: true,
 		},
 	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:  "addOrigin",
+			Value: true,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:    "remoteUrl",
+			Default: true,
+		},
+	})
 
 	output, err := runCommand(httpClient, "REPO --template='OWNER/REPO'")
 	if err != nil {
 		t.Errorf("error running command `repo create`: %v", err)
 	}
 
-	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n", output.Stderr())
+	assert.Equal(t, "Detected a project with these remotes: []\n\nCreate a new project...\n", output.String())
+	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ Initialized repository in './REPO/'\n", output.Stderr())
 
 	if seenCmd == nil {
 		t.Fatal("expected a command to run")
 	}
-	assert.Equal(t, "git remote add -f origin https://github.com/OWNER/REPO.git", strings.Join(seenCmd.Args, " "))
+	assert.Equal(t, "git -C REPO remote add origin https://github.com/OWNER/REPO.git", strings.Join(seenCmd.Args, " "))
 
 	var reqBody struct {
 		Query     string
@@ -422,6 +506,12 @@ func TestRepoCreate_withoutNameArg(t *testing.T) {
 
 	as.Stub([]*prompt.QuestionStub{
 		{
+			Name:  "addNewRemote",
+			Value: false,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
 			Name:  "repoName",
 			Value: "OWNER/REPO",
 		},
@@ -440,19 +530,31 @@ func TestRepoCreate_withoutNameArg(t *testing.T) {
 			Value: true,
 		},
 	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:  "addOrigin",
+			Value: true,
+		},
+	})
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:  "remoteUrl",
+			Value: "https://github.com/OWNER/REPO.git",
+		},
+	})
 
 	output, err := runCommand(httpClient, "")
 	if err != nil {
 		t.Errorf("error running command `repo create`: %v", err)
 	}
 
-	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n", output.Stderr())
+	assert.Equal(t, "Detected a project with these remotes: []\n\nCreate a new project...\n", output.String())
+	assert.Equal(t, "✓ Created repository OWNER/REPO on GitHub\n✓ Initialized repository in './REPO/'\n", output.Stderr())
 
 	if seenCmd == nil {
 		t.Fatal("expected a command to run")
 	}
-	assert.Equal(t, "git remote add -f origin https://github.com/OWNER/REPO.git", strings.Join(seenCmd.Args, " "))
+	assert.Equal(t, "git -C REPO remote add origin https://github.com/OWNER/REPO.git", strings.Join(seenCmd.Args, " "))
 
 	var reqBody struct {
 		Query     string

--- a/utils/color.go
+++ b/utils/color.go
@@ -12,14 +12,15 @@ import (
 
 var (
 	// Outputs ANSI color if stdout is a tty
-	Magenta = makeColorFunc("magenta")
-	Cyan    = makeColorFunc("cyan")
-	Red     = makeColorFunc("red")
-	Yellow  = makeColorFunc("yellow")
-	Blue    = makeColorFunc("blue")
-	Green   = makeColorFunc("green")
-	Gray    = makeColorFunc("black+h")
-	Bold    = makeColorFunc("default+b")
+	Magenta   = makeColorFunc("magenta")
+	Cyan      = makeColorFunc("cyan")
+	Red       = makeColorFunc("red")
+	Yellow    = makeColorFunc("yellow")
+	Blue      = makeColorFunc("blue")
+	Green     = makeColorFunc("green")
+	Gray      = makeColorFunc("black+h")
+	Bold      = makeColorFunc("default+b")
+	Underline = makeColorFunc("default+u")
 )
 
 // NewColorable returns an output stream that handles ANSI color sequences on Windows


### PR DESCRIPTION
## Summary
closes #1913 , #2180, #2059, #2166, #893, #2026

## Details

1. If you are in a project initialized you have the options to add a new remote or create a new repository inside.
2. origin repo is suggested every if doesn't exist. If the project is created previously, don't suggest a url, else, then suggest the url located in github.com.
3. You have options to create a dir for the project.
4. Fixed the confused Github repo creation.