### PR TITLE
respect GH_HOST when resolving remotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,7 @@
 # macOS
 .DS_Store
 
+# vim
+*.swp
+
 vendor/

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/internal/ghinstance"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
@@ -31,11 +33,16 @@ func New(appVersion string) *cmdutil.Factory {
 		return cachedConfig, configError
 	}
 
+	hostOverride := ""
+	if !strings.EqualFold(ghinstance.Default(), ghinstance.OverridableDefault()) {
+		hostOverride = ghinstance.OverridableDefault()
+	}
+
 	rr := &remoteResolver{
 		readRemotes: git.Remotes,
 		getConfig:   configFunc,
 	}
-	remotesFunc := rr.Resolver()
+	remotesFunc := rr.Resolver(hostOverride)
 
 	return &cmdutil.Factory{
 		IOStreams: io,

--- a/pkg/cmd/factory/remote_resolver.go
+++ b/pkg/cmd/factory/remote_resolver.go
@@ -69,7 +69,7 @@ func (rr *remoteResolver) Resolver(hostOverride string) func() (context.Remotes,
 			}
 
 			if len(cachedRemotes) == 0 {
-				remotesError = errors.New("none of the git remotes configured for this repository correspond to the GH_HOST environment variable. Try either add a matching remote or unset the variable.")
+				remotesError = errors.New("none of the git remotes configured for this repository correspond to the GH_HOST environment variable. Try adding a matching remote or unsetting the variable.")
 				return nil, remotesError
 			}
 

--- a/pkg/cmd/factory/remote_resolver_test.go
+++ b/pkg/cmd/factory/remote_resolver_test.go
@@ -40,3 +40,5 @@ func Test_remoteResolver(t *testing.T) {
 	assert.Equal(t, "upstream", remotes[0].Name)
 	assert.Equal(t, "fork", remotes[1].Name)
 }
+
+// TODO test

--- a/pkg/cmd/factory/remote_resolver_test.go
+++ b/pkg/cmd/factory/remote_resolver_test.go
@@ -32,7 +32,7 @@ func Test_remoteResolver(t *testing.T) {
 		},
 	}
 
-	resolver := rr.Resolver()
+	resolver := rr.Resolver("")
 	remotes, err := resolver()
 	require.NoError(t, err)
 	require.Equal(t, 2, len(remotes))
@@ -41,4 +41,31 @@ func Test_remoteResolver(t *testing.T) {
 	assert.Equal(t, "fork", remotes[1].Name)
 }
 
-// TODO test
+func Test_remoteResolverOverride(t *testing.T) {
+	rr := &remoteResolver{
+		readRemotes: func() (git.RemoteSet, error) {
+			return git.RemoteSet{
+				git.NewRemote("fork", "https://example.org/ghe-owner/ghe-fork.git"),
+				git.NewRemote("origin", "https://github.com/owner/repo.git"),
+				git.NewRemote("upstream", "https://example.org/ghe-owner/ghe-repo.git"),
+			}, nil
+		},
+		getConfig: func() (config.Config, error) {
+			return config.NewFromString(heredoc.Doc(`
+				hosts:
+				  example.org:
+				    oauth_token: GHETOKEN
+			`)), nil
+		},
+		urlTranslator: func(u *url.URL) *url.URL {
+			return u
+		},
+	}
+
+	resolver := rr.Resolver("github.com")
+	remotes, err := resolver()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(remotes))
+
+	assert.Equal(t, "origin", remotes[0].Name)
+}


### PR DESCRIPTION
closes #1668 

This pull request notices when GH_HOST has been set and then only resolves local remotes that match the set hostname. With this in place, a heterogeneous mix of hosts in a local remote file will not cause GH_HOST to be ignored.

An error is returned if the hostname specified in GH_HOST is not present in the local remotes.