### PR TITLE
Improve error message for "gh release create" command

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -2,6 +2,7 @@ package create
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -76,7 +77,13 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			# upload a release asset with a display label
 			$ gh release create v1.2.3 '/path/to/asset.zip#My display label'
 		`),
-		Args: cobra.MinimumNArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return nil
+			}
+
+			return &cmdutil.FlagError{Err: errors.New("could not create: no tag name provided")}
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -158,7 +158,7 @@ func Test_NewCmdCreate(t *testing.T) {
 			name:    "no arguments",
 			args:    "",
 			isTTY:   true,
-			wantErr: "requires at least 1 arg(s), only received 0",
+			wantErr: "could not create: no tag name provided",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### What?
It makes the error message for the `gh release create` command clearer when a tag name is not passed in


It fixes #2327
