### PR TITLE
Render links as absolute URLs in `repo view`

### DIFF
--- a/pkg/cmd/gist/view/view.go
+++ b/pkg/cmd/gist/view/view.go
@@ -117,7 +117,7 @@ func viewRun(opts *ViewOptions) error {
 		content := gistFile.Content
 		if strings.Contains(gistFile.Type, "markdown") && !opts.Raw {
 			style := markdown.GetStyle(opts.IO.DetectTerminalTheme())
-			rendered, err := markdown.Render(gistFile.Content, style)
+			rendered, err := markdown.Render(gistFile.Content, style, "")
 			if err == nil {
 				content = rendered
 			}

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -164,7 +164,7 @@ func printHumanIssuePreview(io *iostreams.IOStreams, issue *api.Issue) error {
 	if issue.Body != "" {
 		fmt.Fprintln(out)
 		style := markdown.GetStyle(io.TerminalTheme())
-		md, err := markdown.Render(issue.Body, style)
+		md, err := markdown.Render(issue.Body, style, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pr/review/review.go
+++ b/pkg/cmd/pr/review/review.go
@@ -255,7 +255,7 @@ func reviewSurvey(io *iostreams.IOStreams, editorCommand string) (*api.PullReque
 
 	if len(bodyAnswers.Body) > 0 {
 		style := markdown.GetStyle(io.DetectTerminalTheme())
-		renderedBody, err := markdown.Render(bodyAnswers.Body, style)
+		renderedBody, err := markdown.Render(bodyAnswers.Body, style, "")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -183,7 +183,7 @@ func printHumanPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 	if pr.Body != "" {
 		fmt.Fprintln(out)
 		style := markdown.GetStyle(io.TerminalTheme())
-		md, err := markdown.Render(pr.Body, style)
+		md, err := markdown.Render(pr.Body, style, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/release/view/view.go
+++ b/pkg/cmd/release/view/view.go
@@ -124,7 +124,7 @@ func renderReleaseTTY(io *iostreams.IOStreams, release *shared.Release) error {
 	}
 
 	style := markdown.GetStyle(io.DetectTerminalTheme())
-	renderedDescription, err := markdown.Render(release.Body, style)
+	renderedDescription, err := markdown.Render(release.Body, style, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/view/http.go
+++ b/pkg/cmd/repo/view/http.go
@@ -21,9 +21,9 @@ type RepoReadme struct {
 func RepositoryReadme(client *http.Client, repo ghrepo.Interface, branch string) (*RepoReadme, error) {
 	apiClient := api.NewClientFromHTTP(client)
 	var response struct {
-		Name     string
-		Content  string
-		Html_url string
+		Name    string
+		Content string
+		HTMLURL string `json:"html_url"`
 	}
 
 	err := apiClient.REST(repo.RepoHost(), "GET", getReadmePath(repo, branch), nil, &response)
@@ -43,7 +43,7 @@ func RepositoryReadme(client *http.Client, repo ghrepo.Interface, branch string)
 	return &RepoReadme{
 		Filename: response.Name,
 		Content:  string(decoded),
-		BaseURL:  response.Html_url,
+		BaseURL:  response.HTMLURL,
 	}, nil
 }
 

--- a/pkg/cmd/repo/view/http.go
+++ b/pkg/cmd/repo/view/http.go
@@ -15,13 +15,15 @@ var NotFoundError = errors.New("not found")
 type RepoReadme struct {
 	Filename string
 	Content  string
+	BaseURL  string
 }
 
 func RepositoryReadme(client *http.Client, repo ghrepo.Interface, branch string) (*RepoReadme, error) {
 	apiClient := api.NewClientFromHTTP(client)
 	var response struct {
-		Name    string
-		Content string
+		Name     string
+		Content  string
+		Html_url string
 	}
 
 	err := apiClient.REST(repo.RepoHost(), "GET", getReadmePath(repo, branch), nil, &response)
@@ -41,6 +43,7 @@ func RepositoryReadme(client *http.Client, repo ghrepo.Interface, branch string)
 	return &RepoReadme{
 		Filename: response.Name,
 		Content:  string(decoded),
+		BaseURL:  response.Html_url,
 	}, nil
 }
 

--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -159,7 +159,7 @@ func viewRun(opts *ViewOptions) error {
 	} else if isMarkdownFile(readme.Filename) {
 		var err error
 		style := markdown.GetStyle(opts.IO.TerminalTheme())
-		readmeContent, err = markdown.Render(readme.Content, style)
+		readmeContent, err = markdown.Render(readme.Content, style, readme.BaseURL)
 		if err != nil {
 			return fmt.Errorf("error rendering markdown: %w", err)
 		}

--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -7,14 +7,14 @@ import (
 	"github.com/charmbracelet/glamour"
 )
 
-func Render(text, style string) (string, error) {
+func Render(text, style string, baseURL string) (string, error) {
 	// Glamour rendering preserves carriage return characters in code blocks, but
 	// we need to ensure that no such characters are present in the output.
 	text = strings.ReplaceAll(text, "\r\n", "\n")
 
 	tr, err := glamour.NewTermRenderer(
 		glamour.WithStylePath(style),
-		// glamour.WithBaseURL(""),  // TODO: make configurable
+		glamour.WithBaseURL(baseURL),
 		// glamour.WithWordWrap(80), // TODO: make configurable
 	)
 	if err != nil {

--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -43,7 +43,7 @@ func Test_Render(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := Render(tt.input.text, tt.input.style)
+			_, err := Render(tt.input.text, tt.input.style, "")
 			if tt.output.wantsErr {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
Fix #2357 

`gh repo view` command isn't passing a base URL to Glamour and thus only renders links as they are in the readme file.

This PR fix that by passing the `html_url` key in the API endpoint response `https://api.github.com/repos/OWNER/REPO/readme` as the base URL, that way it'll work for both the default branch and when specifying a different one with `gh repo view cli/cli --branch=test`


Example: `gh repo view cli/cli`

![gh-view](https://user-images.githubusercontent.com/6853656/98240209-fa348700-1f60-11eb-8439-68536c05dd39.png)
