### PR TITLE
Show MousetrapHelpText when double-clicking gh.exe

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -64,9 +64,11 @@ func main() {
 		}
 	}
 
-	// Enable running gh from explorer.exe. Without this, the user is told to stop and run from a
+	// Enable running gh from Windows File Explorer's address bar. Without this, the user is told to stop and run from a
 	// terminal. With this, a user can clone a repo (or take other actions) directly from explorer.
-	cobra.MousetrapHelpText = ""
+	if len(os.Args) > 1 && os.Args[1] != "" {
+		cobra.MousetrapHelpText = ""
+	}
 
 	rootCmd := root.NewCmdRoot(cmdFactory, buildVersion, buildDate)
 


### PR DESCRIPTION
Ref https://github.com/cli/cli/pull/2076#issuecomment-708062355

The first argument is the path to the program, so if `os.Args[1]` doesn't exist we can assume the user double-clicked `gh.exe`.

Demo:

![gh-windows](https://user-images.githubusercontent.com/6853656/98536179-3f1d2e00-227f-11eb-972f-f75f07f2b369.gif)
