### PR TITLE
Minor fix in USAGE help info for some commands

### DIFF
--- a/pkg/cmd/alias/alias.go
+++ b/pkg/cmd/alias/alias.go
@@ -11,7 +11,7 @@ import (
 
 func NewCmdAlias(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "alias",
+		Use:   "alias <command>",
 		Short: "Create command shortcuts",
 		Long: heredoc.Doc(`
 			Aliases can be used to make shortcuts for gh commands or to compose multiple commands.

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -24,7 +24,7 @@ func NewCmdConfig(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "config",
+		Use:   "config <command>",
 		Short: "Manage configuration for gh",
 		Long:  longDoc.String(),
 	}

--- a/pkg/cmd/gist/gist.go
+++ b/pkg/cmd/gist/gist.go
@@ -12,7 +12,7 @@ import (
 
 func NewCmdGist(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "gist",
+		Use:   "gist <command>",
 		Short: "Manage gists",
 		Long:  `Work with GitHub gists.`,
 		Annotations: map[string]string{


### PR DESCRIPTION
Some `gh` commands help info print `gh <command> [flags]` instead of `gh <command> <subcommand> [flags]`.
This PR fixes that for `alias`, `config` and `gist` commands.


Example:
```
gh gist --help

...
USAGE
  gh gist [flags]        <-- this should be `gh gist <command> [flags]`

CORE COMMANDS
  create:     Create a new gist
...
```