### PR TITLE
match parent repo protocol when forking

### DIFF
--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -195,6 +195,13 @@ func forkRun(opts *ForkOptions) error {
 		if err != nil {
 			return err
 		}
+
+		if remote, err := remotes.FindByRepo(repoToFork.RepoOwner(), repoToFork.RepoName()); err == nil {
+			if remote.FetchURL.Scheme == "https" || remote.FetchURL.Scheme == "ssh" {
+				protocol = remote.FetchURL.Scheme
+			}
+		}
+
 		if remote, err := remotes.FindByRepo(forkedRepo.RepoOwner(), forkedRepo.RepoName()); err == nil {
 			if connectedToTerminal {
 				fmt.Fprintf(stderr, "%s Using existing remote %s\n", cs.SuccessIcon(), cs.Bold(remote.Name))

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -197,8 +197,16 @@ func forkRun(opts *ForkOptions) error {
 		}
 
 		if remote, err := remotes.FindByRepo(repoToFork.RepoOwner(), repoToFork.RepoName()); err == nil {
-			if remote.FetchURL.Scheme == "https" || remote.FetchURL.Scheme == "ssh" {
-				protocol = remote.FetchURL.Scheme
+
+			scheme := ""
+			if remote.FetchURL != nil {
+				scheme = remote.FetchURL.Scheme
+			}
+			if remote.PushURL != nil {
+				scheme = remote.PushURL.Scheme
+			}
+			if scheme != "" {
+				protocol = scheme
 			}
 		}
 

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -484,7 +484,7 @@ func TestRepoFork_in_parent_match_protocol(t *testing.T) {
 
 	remotes := []*context.Remote{
 		{
-			Remote: &git.Remote{Name: "origin", FetchURL: &url.URL{
+			Remote: &git.Remote{Name: "origin", PushURL: &url.URL{
 				Scheme: "ssh",
 			}},
 			Repo: ghrepo.New("OWNER", "REPO"),

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -2,6 +2,7 @@ package fork
 
 import (
 	"net/http"
+	"net/url"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -44,8 +45,11 @@ func runCommand(httpClient *http.Client, remotes []*context.Remote, isTTY bool, 
 			if remotes == nil {
 				return []*context.Remote{
 					{
-						Remote: &git.Remote{Name: "origin"},
-						Repo:   ghrepo.New("OWNER", "REPO"),
+						Remote: &git.Remote{
+							Name:     "origin",
+							FetchURL: &url.URL{},
+						},
+						Repo: ghrepo.New("OWNER", "REPO"),
 					},
 				}, nil
 			}
@@ -179,11 +183,11 @@ func TestRepoFork_reuseRemote(t *testing.T) {
 	stubSpinner()
 	remotes := []*context.Remote{
 		{
-			Remote: &git.Remote{Name: "origin"},
+			Remote: &git.Remote{Name: "origin", FetchURL: &url.URL{}},
 			Repo:   ghrepo.New("someone", "REPO"),
 		},
 		{
-			Remote: &git.Remote{Name: "upstream"},
+			Remote: &git.Remote{Name: "upstream", FetchURL: &url.URL{}},
 			Repo:   ghrepo.New("OWNER", "REPO"),
 		},
 	}
@@ -462,6 +466,50 @@ func TestRepoFork_in_parent_survey_no(t *testing.T) {
 		t.Errorf("output did not match regexp /%s/\n> output\n%s\n", r, output)
 		return
 	}
+	reg.Verify(t)
+}
+
+func TestRepoFork_in_parent_match_protocol(t *testing.T) {
+	stubSpinner()
+	defer stubSince(2 * time.Second)()
+	reg := &httpmock.Registry{}
+	defer reg.StubWithFixturePath(200, "./forkResult.json")()
+	httpClient := &http.Client{Transport: reg}
+
+	var seenCmds []*exec.Cmd
+	defer run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
+		seenCmds = append(seenCmds, cmd)
+		return &test.OutputStub{}
+	})()
+
+	remotes := []*context.Remote{
+		{
+			Remote: &git.Remote{Name: "origin", FetchURL: &url.URL{
+				Scheme: "ssh",
+			}},
+			Repo: ghrepo.New("OWNER", "REPO"),
+		},
+	}
+
+	output, err := runCommand(httpClient, remotes, true, "--remote")
+	if err != nil {
+		t.Errorf("error running command `repo fork`: %v", err)
+	}
+
+	expectedCmds := []string{
+		"git remote rename origin upstream",
+		"git remote add -f origin git@github.com:someone/REPO.git",
+	}
+
+	for x, cmd := range seenCmds {
+		assert.Equal(t, expectedCmds[x], strings.Join(cmd.Args, " "))
+	}
+
+	assert.Equal(t, "", output.String())
+
+	test.ExpectLines(t, output.Stderr(),
+		"Created fork.*someone/REPO",
+		"Added remote.*origin")
 	reg.Verify(t)
 }
 


### PR DESCRIPTION
closes #1056

when "in" a parent repo and we do a fork, check the parent's entry in remotes and make the new
fork's git protocol match accordingly.

