### PR TITLE
Configuration path can come from environment.

### DIFF
--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -14,6 +14,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	GH_CONFIG_DIR = "GH_CONFIG_DIR"
+)
+
 func ConfigDir() string {
 	homeDir, _ := homeDirAutoMigrate()
 	return homeDir
@@ -262,4 +266,11 @@ func findRegularFile(p string) string {
 		p = newPath
 	}
 	return ""
+}
+
+func configPath() string {
+	if v := os.Getenv(GH_CONFIG_DIR); v != "" {
+		return v
+	}
+	return "~/.config/gh"
 }

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -143,6 +144,26 @@ func Test_parseConfigFile(t *testing.T) {
 			}
 			assert.Equal(t, yaml.MappingNode, yamlRoot.Content[0].Kind)
 			assert.Equal(t, 0, len(yamlRoot.Content[0].Content))
+		})
+	}
+}
+
+func Test_configPath(t *testing.T) {
+	tests := []struct {
+		envVar string
+		want   string
+	}{
+		{"/tmp/gh", "/tmp/gh"},
+		{"", "~/.config/gh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("envVar: %q", tt.envVar), func(t *testing.T) {
+			if tt.envVar != "" {
+				os.Setenv(GH_CONFIG_DIR, tt.envVar)
+				defer os.Unsetenv(GH_CONFIG_DIR)
+			}
+			eq(t, configPath(), tt.want)
 		})
 	}
 }

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -17,7 +17,7 @@ hosts:
     user: monalisa
     oauth_token: OTOKEN
 `, "")()
-	config, err := ParseConfig("config.yml")
+	config, err := parseConfig("config.yml")
 	assert.NoError(t, err)
 	user, err := config.Get("github.com", "user")
 	assert.NoError(t, err)
@@ -37,7 +37,7 @@ hosts:
     user: monalisa
     oauth_token: OTOKEN
 `, "")()
-	config, err := ParseConfig("config.yml")
+	config, err := parseConfig("config.yml")
 	assert.NoError(t, err)
 	user, err := config.Get("github.com", "user")
 	assert.NoError(t, err)
@@ -53,7 +53,7 @@ github.com:
   user: monalisa
   oauth_token: OTOKEN
 `)()
-	config, err := ParseConfig("config.yml")
+	config, err := parseConfig("config.yml")
 	assert.NoError(t, err)
 	user, err := config.Get("github.com", "user")
 	assert.NoError(t, err)
@@ -75,7 +75,7 @@ example.com:
     oauth_token: NOTTHIS
     git_protocol: https
 `)()
-	config, err := ParseConfig("config.yml")
+	config, err := parseConfig("config.yml")
 	assert.NoError(t, err)
 	val, err := config.Get("example.com", "git_protocol")
 	assert.NoError(t, err)
@@ -88,7 +88,7 @@ example.com:
 	assert.Equal(t, "ssh", val)
 }
 
-func Test_ParseConfig_migrateConfig(t *testing.T) {
+func Test_parseConfig_migrateConfig(t *testing.T) {
 	defer StubConfig(`---
 github.com:
   - user: keiyuri
@@ -100,7 +100,7 @@ github.com:
 	defer StubWriteConfig(&mainBuf, &hostsBuf)()
 	defer StubBackupConfig()()
 
-	_, err := ParseConfig("config.yml")
+	_, err := parseConfig("config.yml")
 	assert.NoError(t, err)
 
 	expectedHosts := `github.com:
@@ -148,13 +148,13 @@ func Test_parseConfigFile(t *testing.T) {
 	}
 }
 
-func Test_configPath(t *testing.T) {
+func Test_ConfigDir(t *testing.T) {
 	tests := []struct {
 		envVar string
 		want   string
 	}{
-		{"/tmp/gh", "/tmp/gh"},
-		{"", "~/.config/gh"},
+		{"/tmp/gh", ".tmp.gh"},
+		{"", ".config.gh"},
 	}
 
 	for _, tt := range tests {
@@ -163,7 +163,7 @@ func Test_configPath(t *testing.T) {
 				os.Setenv(GH_CONFIG_DIR, tt.envVar)
 				defer os.Unsetenv(GH_CONFIG_DIR)
 			}
-			eq(t, configPath(), tt.want)
+			assert.Regexp(t, tt.want, ConfigDir())
 		})
 	}
 }

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -318,13 +318,11 @@ func (c *fileConfig) GetWithSource(hostname, key string) (string, string, error)
 		}
 
 		if hostValue != "" {
-			// TODO: avoid hardcoding this
-			return hostValue, "~/.config/gh/hosts.yml", nil
+			return hostValue, HostsConfigFile(), nil
 		}
 	}
 
-	// TODO: avoid hardcoding this
-	defaultSource := "~/.config/gh/config.yml"
+	defaultSource := ConfigFile()
 
 	value, err := c.GetStringValue(key)
 
@@ -420,7 +418,7 @@ func (c *fileConfig) Write() error {
 		return err
 	}
 
-	return WriteConfigFile(hostsConfigFile(filename), yamlNormalize(hostsBytes))
+	return WriteConfigFile(HostsConfigFile(), yamlNormalize(hostsBytes))
 }
 
 func yamlNormalize(b []byte) []byte {

--- a/internal/config/from_env_test.go
+++ b/internal/config/from_env_test.go
@@ -44,7 +44,7 @@ func TestInheritEnv(t *testing.T) {
 			wants: wants{
 				hosts:     []string(nil),
 				token:     "",
-				source:    "~/.config/gh/config.yml",
+				source:    ".config.gh.config.yml",
 				writeable: true,
 			},
 		},
@@ -80,7 +80,7 @@ func TestInheritEnv(t *testing.T) {
 			wants: wants{
 				hosts:     []string{"github.com"},
 				token:     "",
-				source:    "~/.config/gh/config.yml",
+				source:    ".config.gh.config.yml",
 				writeable: true,
 			},
 		},
@@ -92,7 +92,7 @@ func TestInheritEnv(t *testing.T) {
 			wants: wants{
 				hosts:     []string{"github.com"},
 				token:     "",
-				source:    "~/.config/gh/config.yml",
+				source:    ".config.gh.config.yml",
 				writeable: true,
 			},
 		},
@@ -131,7 +131,7 @@ func TestInheritEnv(t *testing.T) {
 			wants: wants{
 				hosts:     []string{"github.com"},
 				token:     "OTOKEN",
-				source:    "~/.config/gh/hosts.yml",
+				source:    ".config.gh.hosts.yml",
 				writeable: true,
 			},
 		},
@@ -273,7 +273,7 @@ func TestInheritEnv(t *testing.T) {
 
 			val, source, _ := cfg.GetWithSource(tt.hostname, "oauth_token")
 			assert.Equal(t, tt.wants.token, val)
-			assert.Equal(t, tt.wants.source, source)
+			assert.Regexp(t, tt.wants.source, source)
 
 			val, _ = cfg.Get(tt.hostname, "oauth_token")
 			assert.Equal(t, tt.wants.token, val)


### PR DESCRIPTION
This adds support for using the GH_CONFIG_DIR environment variable to determine
where the config files are written, this is useful for cases where the homedir
is not writable.