### PR TITLE
Add make (un)install targets for POSIX systems 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /site
 .github/**/node_modules
 /CHANGELOG.md
+/manpages.list
 
 # VS Code
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 /site
 .github/**/node_modules
 /CHANGELOG.md
-/manpages.list
 
 # VS Code
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ ifdef GH_OAUTH_CLIENT_SECRET
 	GO_LDFLAGS := -X github.com/cli/cli/internal/authflow.oauthClientSecret=$(GH_OAUTH_CLIENT_SECRET) $(GO_LDFLAGS)
 endif
 
+install-bins += bin/gh
 bin/gh: $(BUILD_FILES)
 	@go build -trimpath -ldflags "$(GO_LDFLAGS)" -o "$@" ./cmd/gh
 
@@ -62,3 +63,20 @@ endif
 .PHONY: manpages
 manpages:
 	go run ./cmd/gen-docs --man-page --doc-path ./share/man/man1/
+
+DESTDIR :=
+prefix  := /usr/local
+bindir  := ${prefix}/bin
+
+.PHONY: install install-strip uninstall
+INSTALL_STRIP_FLAG =
+install-strip:
+	@${MAKE} INSTALL_STRIP_FLAG=-s install
+
+install: ${install-bins}
+	install -d ${DESTDIR}${bindir}
+	install -m555 ${INSTALL_STRIP_FLAG} ${install-bins} ${DESTDIR}${bindir}/
+
+remove-bins := ${install-bins:bin/%=${DESTDIR}${bindir}/%}
+uninstall:
+	rm -f ${remove-bins}

--- a/Makefile
+++ b/Makefile
@@ -61,22 +61,28 @@ endif
 
 
 .PHONY: manpages
-manpages:
+manpages: manpages.list
+manpages.list:
 	go run ./cmd/gen-docs --man-page --doc-path ./share/man/man1/
+	find share/man -type f > $@
 
 DESTDIR :=
 prefix  := /usr/local
 bindir  := ${prefix}/bin
+mandir  := ${prefix}/share/man
 
 .PHONY: install install-strip uninstall
 INSTALL_STRIP_FLAG =
 install-strip:
 	@${MAKE} INSTALL_STRIP_FLAG=-s install
 
-install: ${install-bins}
+install: ${install-bins} manpages.list
 	install -d ${DESTDIR}${bindir}
 	install -m555 ${INSTALL_STRIP_FLAG} ${install-bins} ${DESTDIR}${bindir}/
+	install -d ${DESTDIR}${mandir}/man1
+	install -m444 $(shell cat manpages.list) ${DESTDIR}${mandir}/man1/
 
 remove-bins := ${install-bins:bin/%=${DESTDIR}${bindir}/%}
-uninstall:
+uninstall: manpages.list
 	rm -f ${remove-bins}
+	rm -f $(patsubst share/man/%,${DESTDIR}${mandir}/%,$(shell cat manpages.list))

--- a/docs/source.md
+++ b/docs/source.md
@@ -15,16 +15,18 @@
    $ cd gh-cli
    ```
 
-2. Build the project
-
-   ```
-   $ make
-   ```
-
-3. Move the resulting `bin/gh` executable to somewhere in your PATH
+2. Build and install
 
    ```sh
-   $ sudo mv ./bin/gh /usr/local/bin/
+   # installs to '/usr/local' by default; sudo may be required
+   $ make install
    ```
 
-4. Run `gh version` to check if it worked.
+   To install to a different location:
+   ```sh
+   $ make install prefix=/path/to/gh
+   ```
+
+   Make sure that the `${prefix}/bin` directory is in your PATH.
+
+3. Run `gh version` to check if it worked.


### PR DESCRIPTION
The implementation imitates the behavior of build-systems generated by GNU Automake.

Installs and uninstalls binaries and manual pages.

Implemented targets:
- `install`
- `install-strip`
- `uninstall`

Implemented variables:
- `DESTDIR` 
- `prefix` (default: `/usr/local`)
- `bindir` (default: `${prefix}/bin`)
- `mandir` (default: `${prefix}/share/man`)
- `INSTALL_STRIP_FLAG`