### PR TITLE
Update scoop install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,9 @@ For more information and distro-specific instructions, see the [Linux installati
 
 #### scoop
 
-Install:
-
-```powershell
-scoop install gh
-```
-
-Upgrade:
-
-```powershell
-scoop update gh
-```
+| Install:           | Upgrade:           |
+| ------------------ | ------------------ |
+| `scoop install gh` | `scoop update gh`  |
 
 #### Chocolatey
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ For more information and distro-specific instructions, see the [Linux installati
 Install:
 
 ```powershell
-scoop bucket add github-gh https://github.com/cli/scoop-gh.git
 scoop install gh
 ```
 


### PR DESCRIPTION
[gh](https://github.com/ScoopInstaller/Main/blob/master/bucket/gh.json) has been added to the main bucket of scoop.