### PR TITLE
Add design system docs to contributing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,6 +44,10 @@ Please note that this project adheres to a [Contributor Code of Conduct][code-of
 
 We generate manual pages from source on every release. You do not need to submit pull requests for documentation specifically; manual pages for commands will automatically get updated after your pull requests gets accepted.
 
+## Design guidelines
+
+You may reference the [CLI Design System][] when suggesting features, and are welcome to use our [Google Docs Template][] to suggest designs.
+
 ## Resources
 
 - [How to Contribute to Open Source][]
@@ -61,3 +65,5 @@ We generate manual pages from source on every release. You do not need to submit
 [How to Contribute to Open Source]: https://opensource.guide/how-to-contribute/
 [Using Pull Requests]: https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests
 [GitHub Help]: https://docs.github.com/
+[CLI Design System]: https://primer.style/cli/
+[Google Docs Template]: https://docs.google.com/document/d/1JIRErIUuJ6fTgabiFYfCH3x91pyHuytbfa0QLnTfXKM/edit#heading=h.or54sa47ylpg


### PR DESCRIPTION
An idea to add the design system docs and the docs template! Open to better wording or a better place to link these! 

cc @billygriffin @mislav @vilmibm @samcoe 