### PR TITLE
Clarify repo-create confirmation prompt

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -369,9 +369,9 @@ func confirmSubmission(repoName string, repoOwner string, isConfirmFlagPassed *b
 
 	promptString := ""
 	if repoOwner != "" {
-		promptString = fmt.Sprintf("This will create '%s/%s' in your current directory. Continue? ", repoOwner, repoName)
+		promptString = fmt.Sprintf("This will create '%s/%s' and add it as remote for your current directory. Continue? ", repoOwner, repoName)
 	} else {
-		promptString = fmt.Sprintf("This will create '%s' in your current directory. Continue? ", repoName)
+		promptString = fmt.Sprintf("This will create '%s' and add it as remote for your current directory. Continue? ", repoName)
 	}
 
 	confirmSubmitQuestion := &survey.Question{


### PR DESCRIPTION
When I read the message I thought the command would create a new directory for the new repository in my current directory. I think the message should make clear that no new directory is created, but the new GitHub repository is added as remote `origin` to the current directory's git repo.

If anyone has better suggestions for formulating this in a concise way, I'm happy to change the wording in this PR.