### PR TITLE
Fix respecting chosen action in interactive `issue create`

### DIFF
--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -199,7 +199,6 @@ func createRun(opts *CreateOptions) (err error) {
 			}
 		}
 
-		var action prShared.Action
 		action, err = prShared.ConfirmSubmission(!tb.HasMetadata(), repo.ViewerCanTriage())
 		if err != nil {
 			err = fmt.Errorf("unable to confirm: %w", err)

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -327,7 +327,7 @@ func TestIssueCreate_continueInBrowser(t *testing.T) {
 	if seenCmd == nil {
 		t.Fatal("expected a command to run")
 	}
-	url := seenCmd.Args[len(seenCmd.Args)-1]
+	url := strings.ReplaceAll(seenCmd.Args[len(seenCmd.Args)-1], "^", "")
 	assert.Equal(t, "https://github.com/OWNER/REPO/issues/new?body=body&title=hello", url)
 }
 

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/internal/config"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/internal/run"
@@ -272,6 +273,62 @@ func TestIssueCreate_nonLegacyTemplate(t *testing.T) {
 	eq(t, reqBody.Variables.Input.Body, "I have a suggestion for an enhancement")
 
 	eq(t, output.String(), "https://github.com/OWNER/REPO/issues/12\n")
+}
+
+func TestIssueCreate_continueInBrowser(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.StubResponse(200, bytes.NewBufferString(`
+		{ "data": { "repository": {
+			"id": "REPOID",
+			"hasIssuesEnabled": true
+		} } }
+	`))
+
+	as, teardown := prompt.InitAskStubber()
+	defer teardown()
+
+	// title
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:  "Title",
+			Value: "hello",
+		},
+	})
+	// confirm
+	as.Stub([]*prompt.QuestionStub{
+		{
+			Name:  "confirmation",
+			Value: 1,
+		},
+	})
+
+	var seenCmd *exec.Cmd
+	restoreCmd := run.SetPrepareCmd(func(cmd *exec.Cmd) run.Runnable {
+		seenCmd = cmd
+		return &test.OutputStub{}
+	})
+	defer restoreCmd()
+
+	output, err := runCommand(http, true, `-b body`)
+	if err != nil {
+		t.Errorf("error running command `issue create`: %v", err)
+	}
+
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, heredoc.Doc(`
+		
+		Creating issue in OWNER/REPO
+		
+		Opening github.com/OWNER/REPO/issues/new in your browser.
+	`), output.Stderr())
+
+	if seenCmd == nil {
+		t.Fatal("expected a command to run")
+	}
+	url := seenCmd.Args[len(seenCmd.Args)-1]
+	assert.Equal(t, "https://github.com/OWNER/REPO/issues/new?body=body&title=hello", url)
 }
 
 func TestIssueCreate_metadata(t *testing.T) {

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -684,7 +684,7 @@ func generateCompareURL(ctx CreateContext, state shared.IssueMetadataState) (str
 	u := ghrepo.GenerateRepoURL(
 		ctx.BaseRepo,
 		"compare/%s...%s?expand=1",
-		url.QueryEscape(ctx.BaseBranch), url.QueryEscape(ctx.HeadBranch))
+		url.QueryEscape(ctx.BaseBranch), url.QueryEscape(ctx.HeadBranchLabel))
 	url, err := shared.WithPrAndIssueQueryParams(u, state)
 	if err != nil {
 		return "", err

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -827,9 +827,9 @@ func Test_generateCompareURL(t *testing.T) {
 		{
 			name: "basic",
 			ctx: CreateContext{
-				BaseRepo:   ghrepo.New("OWNER", "REPO"),
-				BaseBranch: "main",
-				HeadBranch: "feature",
+				BaseRepo:        ghrepo.New("OWNER", "REPO"),
+				BaseBranch:      "main",
+				HeadBranchLabel: "feature",
 			},
 			want:    "https://github.com/OWNER/REPO/compare/main...feature?expand=1",
 			wantErr: false,
@@ -837,9 +837,9 @@ func Test_generateCompareURL(t *testing.T) {
 		{
 			name: "with labels",
 			ctx: CreateContext{
-				BaseRepo:   ghrepo.New("OWNER", "REPO"),
-				BaseBranch: "a",
-				HeadBranch: "b",
+				BaseRepo:        ghrepo.New("OWNER", "REPO"),
+				BaseBranch:      "a",
+				HeadBranchLabel: "b",
 			},
 			state: prShared.IssueMetadataState{
 				Labels: []string{"one", "two three"},
@@ -850,9 +850,9 @@ func Test_generateCompareURL(t *testing.T) {
 		{
 			name: "complex branch names",
 			ctx: CreateContext{
-				BaseRepo:   ghrepo.New("OWNER", "REPO"),
-				BaseBranch: "main/trunk",
-				HeadBranch: "owner:feature",
+				BaseRepo:        ghrepo.New("OWNER", "REPO"),
+				BaseBranch:      "main/trunk",
+				HeadBranchLabel: "owner:feature",
 			},
 			want:    "https://github.com/OWNER/REPO/compare/main%2Ftrunk...owner%3Afeature?expand=1",
 			wantErr: false,


### PR DESCRIPTION
The `action` variable started being shadowed in the `if` block in 6671106448ed7b342797b426e15af032dfe3b1be

Fixes #2509

Bonus: fixes the `owner` branch prefix being included for `pr create`
fixes https://github.com/cli/cli/pull/1926#issuecomment-735236485
fixes https://github.com/cli/cli/issues/2001#issuecomment-734004770