### PR TITLE
Properly check env auth tokens in CheckAuth

### DIFF
--- a/internal/config/from_env.go
+++ b/internal/config/from_env.go
@@ -78,3 +78,10 @@ func AuthTokenFromEnv(hostname string) (string, string) {
 
 	return os.Getenv(GITHUB_TOKEN), GITHUB_TOKEN
 }
+
+func AuthTokenProvidedFromEnv() bool {
+	return os.Getenv(GH_ENTERPRISE_TOKEN) != "" ||
+		os.Getenv(GITHUB_ENTERPRISE_TOKEN) != "" ||
+		os.Getenv(GH_TOKEN) != "" ||
+		os.Getenv(GITHUB_TOKEN) != ""
+}

--- a/internal/config/from_env_test.go
+++ b/internal/config/from_env_test.go
@@ -283,3 +283,60 @@ func TestInheritEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestAuthTokenProvidedFromEnv(t *testing.T) {
+	orig_GITHUB_TOKEN := os.Getenv("GITHUB_TOKEN")
+	orig_GITHUB_ENTERPRISE_TOKEN := os.Getenv("GITHUB_ENTERPRISE_TOKEN")
+	orig_GH_TOKEN := os.Getenv("GH_TOKEN")
+	orig_GH_ENTERPRISE_TOKEN := os.Getenv("GH_ENTERPRISE_TOKEN")
+	t.Cleanup(func() {
+		os.Setenv("GITHUB_TOKEN", orig_GITHUB_TOKEN)
+		os.Setenv("GITHUB_ENTERPRISE_TOKEN", orig_GITHUB_ENTERPRISE_TOKEN)
+		os.Setenv("GH_TOKEN", orig_GH_TOKEN)
+		os.Setenv("GH_ENTERPRISE_TOKEN", orig_GH_ENTERPRISE_TOKEN)
+	})
+
+	tests := []struct {
+		name                    string
+		GITHUB_TOKEN            string
+		GITHUB_ENTERPRISE_TOKEN string
+		GH_TOKEN                string
+		GH_ENTERPRISE_TOKEN     string
+		provided                bool
+	}{
+		{
+			name:     "no env tokens",
+			provided: false,
+		},
+		{
+			name:     "GH_TOKEN",
+			GH_TOKEN: "TOKEN",
+			provided: true,
+		},
+		{
+			name:         "GITHUB_TOKEN",
+			GITHUB_TOKEN: "TOKEN",
+			provided:     true,
+		},
+		{
+			name:                "GH_ENTERPRISE_TOKEN",
+			GH_ENTERPRISE_TOKEN: "TOKEN",
+			provided:            true,
+		},
+		{
+			name:                    "GITHUB_ENTERPRISE_TOKEN",
+			GITHUB_ENTERPRISE_TOKEN: "TOKEN",
+			provided:                true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("GITHUB_TOKEN", tt.GITHUB_TOKEN)
+			os.Setenv("GITHUB_ENTERPRISE_TOKEN", tt.GITHUB_ENTERPRISE_TOKEN)
+			os.Setenv("GH_TOKEN", tt.GH_TOKEN)
+			os.Setenv("GH_ENTERPRISE_TOKEN", tt.GH_ENTERPRISE_TOKEN)
+			assert.Equal(t, tt.provided, AuthTokenProvidedFromEnv())
+		})
+	}
+}

--- a/pkg/cmdutil/auth_check.go
+++ b/pkg/cmdutil/auth_check.go
@@ -17,6 +17,10 @@ func DisableAuthCheck(cmd *cobra.Command) {
 }
 
 func CheckAuth(cfg config.Config) bool {
+	if config.AuthTokenProvidedFromEnv() {
+		return true
+	}
+
 	hosts, err := cfg.Hosts()
 	if err != nil {
 		return false

--- a/pkg/cmdutil/auth_check_test.go
+++ b/pkg/cmdutil/auth_check_test.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"os"
 	"testing"
 
 	"github.com/cli/cli/internal/config"
@@ -8,21 +9,34 @@ import (
 )
 
 func Test_CheckAuth(t *testing.T) {
+	orig_GITHUB_TOKEN := os.Getenv("GITHUB_TOKEN")
+	t.Cleanup(func() {
+		os.Setenv("GITHUB_TOKEN", orig_GITHUB_TOKEN)
+	})
+
 	tests := []struct {
 		name     string
 		cfg      func(config.Config)
+		envToken bool
 		expected bool
 	}{
 		{
 			name:     "no hosts",
 			cfg:      func(c config.Config) {},
+			envToken: false,
 			expected: false,
+		},
+		{name: "no hosts, env auth token",
+			cfg:      func(c config.Config) {},
+			envToken: true,
+			expected: true,
 		},
 		{
 			name: "host, no token",
 			cfg: func(c config.Config) {
 				_ = c.Set("github.com", "oauth_token", "")
 			},
+			envToken: false,
 			expected: false,
 		},
 		{
@@ -30,12 +44,19 @@ func Test_CheckAuth(t *testing.T) {
 			cfg: func(c config.Config) {
 				_ = c.Set("github.com", "oauth_token", "a token")
 			},
+			envToken: false,
 			expected: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.envToken {
+				os.Setenv("GITHUB_TOKEN", "TOKEN")
+			} else {
+				os.Setenv("GITHUB_TOKEN", "")
+			}
+
 			cfg := config.NewBlankConfig()
 			tt.cfg(cfg)
 			result := CheckAuth(cfg)


### PR DESCRIPTION
The PR fixes a regression found in #2388 by reintroducing explicit checks for environment variable auth tokens. I added tests so these checks are not removed again in the future. 

closes https://github.com/cli/cli/issues/2517