### PR TITLE
Add ability to view comments with `pr view`

### DIFF
--- a/api/queries_comments.go
+++ b/api/queries_comments.go
@@ -63,3 +63,39 @@ func CommentsForIssue(client *Client, repo ghrepo.Interface, issue *Issue) (*Com
 
 	return &Comments{Nodes: comments, TotalCount: len(comments)}, nil
 }
+
+func CommentsForPullRequest(client *Client, repo ghrepo.Interface, pr *PullRequest) (*Comments, error) {
+	type response struct {
+		Repository struct {
+			PullRequest struct {
+				Comments Comments `graphql:"comments(first: 100, after: $endCursor)"`
+			} `graphql:"pullRequest(number: $number)"`
+		} `graphql:"repository(owner: $owner, name: $repo)"`
+	}
+
+	variables := map[string]interface{}{
+		"owner":     githubv4.String(repo.RepoOwner()),
+		"repo":      githubv4.String(repo.RepoName()),
+		"number":    githubv4.Int(pr.Number),
+		"endCursor": (*githubv4.String)(nil),
+	}
+
+	gql := graphQLClient(client.http, repo.RepoHost())
+
+	var comments []Comment
+	for {
+		var query response
+		err := gql.QueryNamed(context.Background(), "CommentsForPullRequest", &query, variables)
+		if err != nil {
+			return nil, err
+		}
+
+		comments = append(comments, query.Repository.PullRequest.Comments.Nodes...)
+		if !query.Repository.PullRequest.Comments.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Repository.PullRequest.Comments.PageInfo.EndCursor)
+	}
+
+	return &Comments{Nodes: comments, TotalCount: len(comments)}, nil
+}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -137,6 +137,8 @@ type PullRequest struct {
 	Milestone struct {
 		Title string
 	}
+	Comments       Comments
+	ReactionGroups ReactionGroups
 }
 
 type NotFoundError struct {
@@ -603,6 +605,30 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 				milestone{
 					title
 				}
+				comments(last: 1) {
+					nodes {
+						author {
+							login
+						}
+						authorAssociation
+						body
+						createdAt
+						includesCreatedEdit
+						reactionGroups {
+							content
+							users {
+								totalCount
+							}
+						}
+					}
+					totalCount
+				}
+				reactionGroups {
+					content
+					users {
+						totalCount
+					}
+				}
 			}
 		}
 	}`
@@ -711,6 +737,30 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, baseBranch, hea
 					}
 					milestone{
 						title
+					}
+					comments(last: 1) {
+						nodes {
+							author {
+								login
+							}
+							authorAssociation
+							body
+							createdAt
+							includesCreatedEdit
+							reactionGroups {
+								content
+								users {
+									totalCount
+								}
+							}
+						}
+						totalCount
+					}
+					reactionGroups {
+						content
+						users {
+							totalCount
+						}
 					}
 				}
 			}

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -123,7 +123,8 @@ func viewRun(opts *ViewOptions) error {
 	}
 
 	if opts.Comments {
-		return printRawIssueComments(opts.IO.Out, issue)
+		fmt.Fprint(opts.IO.Out, prShared.RawCommentList(issue.Comments))
+		return nil
 	}
 
 	return printRawIssuePreview(opts.IO.Out, issue)
@@ -149,26 +150,6 @@ func printRawIssuePreview(out io.Writer, issue *api.Issue) error {
 	return nil
 }
 
-func printRawIssueComments(out io.Writer, issue *api.Issue) error {
-	var b strings.Builder
-	for _, comment := range issue.Comments.Nodes {
-		fmt.Fprint(&b, formatRawIssueComment(comment))
-	}
-	fmt.Fprint(out, b.String())
-	return nil
-}
-
-func formatRawIssueComment(comment api.Comment) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "author:\t%s\n", comment.Author.Login)
-	fmt.Fprintf(&b, "association:\t%s\n", strings.ToLower(comment.AuthorAssociation))
-	fmt.Fprintf(&b, "edited:\t%t\n", comment.IncludesCreatedEdit)
-	fmt.Fprintln(&b, "--")
-	fmt.Fprintln(&b, comment.Body)
-	fmt.Fprintln(&b, "--")
-	return b.String()
-}
-
 func printHumanIssuePreview(io *iostreams.IOStreams, issue *api.Issue) error {
 	out := io.Out
 	now := time.Now()
@@ -186,7 +167,7 @@ func printHumanIssuePreview(io *iostreams.IOStreams, issue *api.Issue) error {
 	)
 
 	// Reactions
-	if reactions := reactionGroupList(issue.ReactionGroups); reactions != "" {
+	if reactions := prShared.ReactionGroupList(issue.ReactionGroups); reactions != "" {
 		fmt.Fprint(out, reactions)
 		fmt.Fprintln(out)
 	}
@@ -224,7 +205,7 @@ func printHumanIssuePreview(io *iostreams.IOStreams, issue *api.Issue) error {
 
 	// Comments
 	if issue.Comments.TotalCount > 0 {
-		comments, err := issueCommentList(io, issue.Comments)
+		comments, err := prShared.CommentList(io, issue.Comments)
 		if err != nil {
 			return err
 		}
@@ -235,75 +216,6 @@ func printHumanIssuePreview(io *iostreams.IOStreams, issue *api.Issue) error {
 	fmt.Fprintf(out, cs.Gray("View this issue on GitHub: %s"), issue.URL)
 
 	return nil
-}
-
-func issueCommentList(io *iostreams.IOStreams, comments api.Comments) (string, error) {
-	var b strings.Builder
-	cs := io.ColorScheme()
-	retrievedCount := len(comments.Nodes)
-	hiddenCount := comments.TotalCount - retrievedCount
-
-	if hiddenCount > 0 {
-		fmt.Fprint(&b, cs.Gray(fmt.Sprintf("———————— Not showing %s ————————", utils.Pluralize(hiddenCount, "comment"))))
-		fmt.Fprintf(&b, "\n\n\n")
-	}
-
-	for i, comment := range comments.Nodes {
-		last := i+1 == retrievedCount
-		cmt, err := formatIssueComment(io, comment, last)
-		if err != nil {
-			return "", err
-		}
-		fmt.Fprint(&b, cmt)
-		if last {
-			fmt.Fprintln(&b)
-		}
-	}
-
-	if hiddenCount > 0 {
-		fmt.Fprint(&b, cs.Gray("Use --comments to view the full conversation"))
-		fmt.Fprintln(&b)
-	}
-
-	return b.String(), nil
-}
-
-func formatIssueComment(io *iostreams.IOStreams, comment api.Comment, newest bool) (string, error) {
-	var b strings.Builder
-	cs := io.ColorScheme()
-
-	// Header
-	fmt.Fprint(&b, cs.Bold(comment.Author.Login))
-	if comment.AuthorAssociation != "NONE" {
-		fmt.Fprint(&b, cs.Bold(fmt.Sprintf(" (%s)", strings.ToLower(comment.AuthorAssociation))))
-	}
-	fmt.Fprint(&b, cs.Bold(fmt.Sprintf(" • %s", utils.FuzzyAgoAbbr(time.Now(), comment.CreatedAt))))
-	if comment.IncludesCreatedEdit {
-		fmt.Fprint(&b, cs.Bold(" • edited"))
-	}
-	if newest {
-		fmt.Fprint(&b, cs.Bold(" • "))
-		fmt.Fprint(&b, cs.CyanBold("Newest comment"))
-	}
-	fmt.Fprintln(&b)
-
-	// Reactions
-	if reactions := reactionGroupList(comment.ReactionGroups); reactions != "" {
-		fmt.Fprint(&b, reactions)
-		fmt.Fprintln(&b)
-	}
-
-	// Body
-	if comment.Body != "" {
-		style := markdown.GetStyle(io.TerminalTheme())
-		md, err := markdown.Render(comment.Body, style, "")
-		if err != nil {
-			return "", err
-		}
-		fmt.Fprint(&b, md)
-	}
-
-	return b.String(), nil
 }
 
 func issueStateTitleWithColor(cs *iostreams.ColorScheme, state string) string {
@@ -347,28 +259,4 @@ func issueProjectList(issue api.Issue) string {
 		list += ", …"
 	}
 	return list
-}
-
-func reactionGroupList(rgs api.ReactionGroups) string {
-	var rs []string
-
-	for _, rg := range rgs {
-		if r := formatReactionGroup(rg); r != "" {
-			rs = append(rs, r)
-		}
-	}
-
-	return strings.Join(rs, " • ")
-}
-
-func formatReactionGroup(rg api.ReactionGroup) string {
-	c := rg.Count()
-	if c == 0 {
-		return ""
-	}
-	e := rg.Emoji()
-	if e == "" {
-		return ""
-	}
-	return fmt.Sprintf("%v %s", c, e)
 }

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -152,13 +152,13 @@ func printRawIssuePreview(out io.Writer, issue *api.Issue) error {
 func printRawIssueComments(out io.Writer, issue *api.Issue) error {
 	var b strings.Builder
 	for _, comment := range issue.Comments.Nodes {
-		fmt.Fprint(&b, rawIssueComment(comment))
+		fmt.Fprint(&b, formatRawIssueComment(comment))
 	}
 	fmt.Fprint(out, b.String())
 	return nil
 }
 
-func rawIssueComment(comment api.Comment) string {
+func formatRawIssueComment(comment api.Comment) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "author:\t%s\n", comment.Author.Login)
 	fmt.Fprintf(&b, "association:\t%s\n", strings.ToLower(comment.AuthorAssociation))

--- a/pkg/cmd/pr/shared/comments.go
+++ b/pkg/cmd/pr/shared/comments.go
@@ -1,0 +1,100 @@
+package shared
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/pkg/markdown"
+	"github.com/cli/cli/utils"
+)
+
+func RawCommentList(comments api.Comments) string {
+	var b strings.Builder
+	for _, comment := range comments.Nodes {
+		fmt.Fprint(&b, formatRawComment(comment))
+	}
+	return b.String()
+}
+
+func formatRawComment(comment api.Comment) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "author:\t%s\n", comment.Author.Login)
+	fmt.Fprintf(&b, "association:\t%s\n", strings.ToLower(comment.AuthorAssociation))
+	fmt.Fprintf(&b, "edited:\t%t\n", comment.IncludesCreatedEdit)
+	fmt.Fprintln(&b, "--")
+	fmt.Fprintln(&b, comment.Body)
+	fmt.Fprintln(&b, "--")
+	return b.String()
+}
+
+func CommentList(io *iostreams.IOStreams, comments api.Comments) (string, error) {
+	var b strings.Builder
+	cs := io.ColorScheme()
+	retrievedCount := len(comments.Nodes)
+	hiddenCount := comments.TotalCount - retrievedCount
+
+	if hiddenCount > 0 {
+		fmt.Fprint(&b, cs.Gray(fmt.Sprintf("———————— Not showing %s ————————", utils.Pluralize(hiddenCount, "comment"))))
+		fmt.Fprintf(&b, "\n\n\n")
+	}
+
+	for i, comment := range comments.Nodes {
+		last := i+1 == retrievedCount
+		cmt, err := formatComment(io, comment, last)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprint(&b, cmt)
+		if last {
+			fmt.Fprintln(&b)
+		}
+	}
+
+	if hiddenCount > 0 {
+		fmt.Fprint(&b, cs.Gray("Use --comments to view the full conversation"))
+		fmt.Fprintln(&b)
+	}
+
+	return b.String(), nil
+}
+
+func formatComment(io *iostreams.IOStreams, comment api.Comment, newest bool) (string, error) {
+	var b strings.Builder
+	cs := io.ColorScheme()
+
+	// Header
+	fmt.Fprint(&b, cs.Bold(comment.Author.Login))
+	if comment.AuthorAssociation != "NONE" {
+		fmt.Fprint(&b, cs.Bold(fmt.Sprintf(" (%s)", strings.ToLower(comment.AuthorAssociation))))
+	}
+	fmt.Fprint(&b, cs.Bold(fmt.Sprintf(" • %s", utils.FuzzyAgoAbbr(time.Now(), comment.CreatedAt))))
+	if comment.IncludesCreatedEdit {
+		fmt.Fprint(&b, cs.Bold(" • edited"))
+	}
+	if newest {
+		fmt.Fprint(&b, cs.Bold(" • "))
+		fmt.Fprint(&b, cs.CyanBold("Newest comment"))
+	}
+	fmt.Fprintln(&b)
+
+	// Reactions
+	if reactions := ReactionGroupList(comment.ReactionGroups); reactions != "" {
+		fmt.Fprint(&b, reactions)
+		fmt.Fprintln(&b)
+	}
+
+	// Body
+	if comment.Body != "" {
+		style := markdown.GetStyle(io.TerminalTheme())
+		md, err := markdown.Render(comment.Body, style, "")
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprint(&b, md)
+	}
+
+	return b.String(), nil
+}

--- a/pkg/cmd/pr/shared/reaction_groups.go
+++ b/pkg/cmd/pr/shared/reaction_groups.go
@@ -1,0 +1,32 @@
+package shared
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cli/cli/api"
+)
+
+func ReactionGroupList(rgs api.ReactionGroups) string {
+	var rs []string
+
+	for _, rg := range rgs {
+		if r := formatReactionGroup(rg); r != "" {
+			rs = append(rs, r)
+		}
+	}
+
+	return strings.Join(rs, " • ")
+}
+
+func formatReactionGroup(rg api.ReactionGroup) string {
+	c := rg.Count()
+	if c == 0 {
+		return ""
+	}
+	e := rg.Emoji()
+	if e == "" {
+		return ""
+	}
+	return fmt.Sprintf("%v %s", c, e)
+}

--- a/pkg/cmd/pr/view/fixtures/prViewPreviewFullComments.json
+++ b/pkg/cmd/pr/view/fixtures/prViewPreviewFullComments.json
@@ -1,0 +1,308 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "comments": {
+          "nodes": [
+            {
+              "author": {
+                "login": "monalisa"
+              },
+              "authorAssociation": "NONE",
+              "body": "Comment 1",
+              "createdAt": "2020-01-01T12:00:00Z",
+              "includesCreatedEdit": true,
+              "reactionGroups": [
+                {
+                  "content": "CONFUSED",
+                  "users": {
+                    "totalCount": 1
+                  }
+                },
+                {
+                  "content": "EYES",
+                  "users": {
+                    "totalCount": 2
+                  }
+                },
+                {
+                  "content": "HEART",
+                  "users": {
+                    "totalCount": 3
+                  }
+                },
+                {
+                  "content": "HOORAY",
+                  "users": {
+                    "totalCount": 4
+                  }
+                },
+                {
+                  "content": "LAUGH",
+                  "users": {
+                    "totalCount": 5
+                  }
+                },
+                {
+                  "content": "ROCKET",
+                  "users": {
+                    "totalCount": 6
+                  }
+                },
+                {
+                  "content": "THUMBS_DOWN",
+                  "users": {
+                    "totalCount": 7
+                  }
+                },
+                {
+                  "content": "THUMBS_UP",
+                  "users": {
+                    "totalCount": 8
+                  }
+                }
+              ]
+            },
+            {
+              "author": {
+                "login": "johnnytest"
+              },
+              "authorAssociation": "CONTRIBUTOR",
+              "body": "Comment 2",
+              "createdAt": "2020-01-01T12:00:00Z",
+              "includesCreatedEdit": false,
+              "reactionGroups": [
+                {
+                  "content": "CONFUSED",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "EYES",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "HEART",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "HOORAY",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "LAUGH",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "ROCKET",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "THUMBS_DOWN",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "THUMBS_UP",
+                  "users": {
+                    "totalCount": 0
+                  }
+                }
+              ]
+            },
+            {
+              "author": {
+                "login": "elvisp"
+              },
+              "authorAssociation": "MEMBER",
+              "body": "Comment 3",
+              "createdAt": "2020-01-01T12:00:00Z",
+              "includesCreatedEdit": false,
+              "reactionGroups": [
+                {
+                  "content": "CONFUSED",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "EYES",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "HEART",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "HOORAY",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "LAUGH",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "ROCKET",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "THUMBS_DOWN",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "THUMBS_UP",
+                  "users": {
+                    "totalCount": 0
+                  }
+                }
+              ]
+            },
+            {
+              "author": {
+                "login": "loislane"
+              },
+              "authorAssociation": "OWNER",
+              "body": "Comment 4",
+              "createdAt": "2020-01-01T12:00:00Z",
+              "includesCreatedEdit": false,
+              "reactionGroups": [
+                {
+                  "content": "CONFUSED",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "EYES",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "HEART",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "HOORAY",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "LAUGH",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "ROCKET",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "THUMBS_DOWN",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "THUMBS_UP",
+                  "users": {
+                    "totalCount": 0
+                  }
+                }
+              ]
+            },
+            {
+              "author": {
+                "login": "marseilles"
+              },
+              "authorAssociation": "COLLABORATOR",
+              "body": "Comment 5",
+              "createdAt": "2020-01-01T12:00:00Z",
+              "includesCreatedEdit": false,
+              "reactionGroups": [
+                {
+                  "content": "CONFUSED",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "EYES",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "HEART",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "HOORAY",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "LAUGH",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "ROCKET",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "THUMBS_DOWN",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "THUMBS_UP",
+                  "users": {
+                    "totalCount": 0
+                  }
+                }
+              ]
+            }
+          ],
+          "totalCount": 5
+        }
+      }
+    }
+  }
+}

--- a/pkg/cmd/pr/view/fixtures/prViewPreviewSingleComment.json
+++ b/pkg/cmd/pr/view/fixtures/prViewPreviewSingleComment.json
@@ -1,0 +1,155 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "number": 12,
+        "title": "some title",
+        "state": "OPEN",
+        "body": "some body",
+        "url": "https://github.com/OWNER/REPO/pull/12",
+        "author": {
+          "login": "nobody"
+        },
+        "assignees": {
+          "nodes": [],
+          "totalcount": 0
+        },
+        "labels": {
+          "nodes": [],
+          "totalcount": 0
+        },
+        "projectcards": {
+          "nodes": [],
+          "totalcount": 0
+        },
+        "milestone": {
+          "title": ""
+        },
+        "commits": {
+          "totalCount": 12
+        },
+        "baseRefName": "master",
+        "headRefName": "blueberries",
+        "headRepositoryOwner": {
+          "login": "hubot"
+        },
+        "isCrossRepository": true,
+        "isDraft": false,
+        "reactionGroups": [
+          {
+            "content": "CONFUSED",
+            "users": {
+              "totalCount": 1
+            }
+          },
+          {
+            "content": "EYES",
+            "users": {
+              "totalCount": 2
+            }
+          },
+          {
+            "content": "HEART",
+            "users": {
+              "totalCount": 3
+            }
+          },
+          {
+            "content": "HOORAY",
+            "users": {
+              "totalCount": 0
+            }
+          },
+          {
+            "content": "LAUGH",
+            "users": {
+              "totalCount": 0
+            }
+          },
+          {
+            "content": "ROCKET",
+            "users": {
+              "totalCount": 0
+            }
+          },
+          {
+            "content": "THUMBS_DOWN",
+            "users": {
+              "totalCount": 0
+            }
+          },
+          {
+            "content": "THUMBS_UP",
+            "users": {
+              "totalCount": 0
+            }
+          }
+        ],
+        "comments": {
+          "nodes": [
+            {
+              "author": {
+                "login": "marseilles"
+              },
+              "authorAssociation": "COLLABORATOR",
+              "body": "Comment 5",
+              "createdAt": "2020-01-01T12:00:00Z",
+              "includesCreatedEdit": false,
+              "reactionGroups": [
+                {
+                  "content": "CONFUSED",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "EYES",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "HEART",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "HOORAY",
+                  "users": {
+                    "totalCount": 4
+                  }
+                },
+                {
+                  "content": "LAUGH",
+                  "users": {
+                    "totalCount": 5
+                  }
+                },
+                {
+                  "content": "ROCKET",
+                  "users": {
+                    "totalCount": 6
+                  }
+                },
+                {
+                  "content": "THUMBS_DOWN",
+                  "users": {
+                    "totalCount": 0
+                  }
+                },
+                {
+                  "content": "THUMBS_UP",
+                  "users": {
+                    "totalCount": 0
+                  }
+                }
+              ]
+            }
+          ],
+          "totalCount": 5
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the ability to view issue comments in `gh pr view`. The PR is not actually as long as the line count suggests, it is mostly due to test fixtures. There were not any major design or technical choices here as most were discussed and decided upon in https://github.com/cli/cli/pull/2462. This is mostly just copying logic and functionality from `gh issue view` into `gh pr view`. There is quite a bit of duplicate comment viewing code from `gh issue view`. It would be nice to come up with a pattern to share this code.

cc #1009