### PR TITLE
Simplify BUILD_DATE and make it more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,13 @@ BUILD_FILES = $(shell go list -f '{{range .GoFiles}}{{$$.Dir}}/{{.}}\
 
 GH_VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
 DATE_FMT = +%Y-%m-%d
-ifdef SOURCE_DATE_EPOCH
-    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
-else
-    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
-endif
+BUILD_DATE ?= $(shell \
+	test -n "${SOURCE_DATE_EPOCH}" &&
+	2>/dev/null \
+	date -u -j -f %s "${SOURCE_DATE_EPOCH}" "${DATE_FMT}" || \
+	2>/dev/null \
+	date -u -d "@${SOURCE_DATE_EPOCH}" "${DATE_FMT}" || \
+	date -u "${DATE_FMT}")
 
 CGO_CPPFLAGS ?= ${CPPFLAGS}
 export CGO_CPPFLAGS


### PR DESCRIPTION
Use a simpler approach and add compatibility with the *BSD date command.

Instead of using ifdef, just try with SOURCE_DATE_EPOCH, and if that
fails, fall back to the current date.

On top of that, try with BSD-style and GNU-style flags, to make it work
with both types of systems.

Solves: https://github.com/cli/cli/issues/2578