### PR TITLE
Filter flags taken from LDFLAGS into CGO_LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CGO_CPPFLAGS ?= ${CPPFLAGS}
 export CGO_CPPFLAGS
 CGO_CFLAGS ?= ${CFLAGS}
 export CGO_CFLAGS
-CGO_LDFLAGS ?= ${LDFLAGS}
+CGO_LDFLAGS ?= $(filter -g -L% -l% -O%,${LDFLAGS})
 export CGO_LDFLAGS
 
 GO_LDFLAGS := -X github.com/cli/cli/internal/build.Version=$(GH_VERSION) $(GO_LDFLAGS)


### PR DESCRIPTION
Make sure we take only flags compatible with cgo.

Solves: https://github.com/cli/cli/issues/2577