### PR TITLE
Allow API request to be made if a PR is in an "UNKNOWN" state

### DIFF
--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -123,9 +123,6 @@ func mergeRun(opts *MergeOptions) error {
 	if pr.Mergeable == "CONFLICTING" {
 		err := fmt.Errorf("%s Pull request #%d (%s) has conflicts and isn't mergeable ", cs.Red("!"), pr.Number, pr.Title)
 		return err
-	} else if pr.Mergeable == "UNKNOWN" {
-		err := fmt.Errorf("%s Pull request #%d (%s) can't be merged right now; try again in a few seconds", cs.Red("!"), pr.Number, pr.Title)
-		return err
 	} else if pr.State == "MERGED" {
 		err := fmt.Errorf("%s Pull request #%d (%s) was already merged", cs.Red("!"), pr.Number, pr.Title)
 		return err


### PR DESCRIPTION
As @mislav mentioned in #2544, the UNKNOWN state normally means that mergeability is still being calculated. Instead of giving the user an undescriptive error, we can be optimistic and assume that the PR is ok to merge. It has a chance of succeeding but if it does fail the API error message will give a better description.

Solves: #2544