### PR TITLE
Only fetch default branch when adding upstream remote

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -308,8 +308,13 @@ func RunClone(cloneURL string, args []string) (target string, err error) {
 	return
 }
 
-func AddUpstreamRemote(upstreamURL, cloneDir string) error {
-	cloneCmd, err := GitCommand("-C", cloneDir, "remote", "add", "-f", "upstream", upstreamURL)
+func AddUpstreamRemote(upstreamURL, cloneDir string, branches []string) error {
+	args := []string{"-C", cloneDir, "remote", "add"}
+	for _, branch := range branches {
+		args = append(args, "-t", branch)
+	}
+	args = append(args, "-f", "upstream", upstreamURL)
+	cloneCmd, err := GitCommand(args...)
 	if err != nil {
 		return err
 	}

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -3,12 +3,10 @@ package git
 import (
 	"os/exec"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/test"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_UncommittedChangeCount(t *testing.T) {
@@ -199,18 +197,15 @@ func TestAddUpstreamRemote(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cs, restore := test.InitCmdStubber()
-			defer restore()
+			cs, cmdTeardown := run.Stub()
+			defer cmdTeardown(t)
 
-			cs.Stub("") // git remote add -f
+			cs.Register(tt.want, 0, "")
 
 			err := AddUpstreamRemote(tt.upstreamURL, tt.cloneDir, tt.branches)
 			if err != nil {
 				t.Fatalf("error running command `git remote add -f`: %v", err)
 			}
-
-			assert.Equal(t, 1, cs.Count)
-			assert.Equal(t, tt.want, strings.Join(cs.Calls[0].Args, " "))
 		})
 	}
 }

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -144,7 +144,7 @@ func cloneRun(opts *CloneOptions) error {
 		}
 		upstreamURL := ghrepo.FormatRemoteURL(canonicalRepo.Parent, protocol)
 
-		err = git.AddUpstreamRemote(upstreamURL, cloneDir)
+		err = git.AddUpstreamRemote(upstreamURL, cloneDir, []string{canonicalRepo.Parent.DefaultBranchRef.Name})
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -221,7 +221,7 @@ func Test_RepoClone_hasParent(t *testing.T) {
 							"login": "hubot"
 						},
 						"defaultBranchRef": {
-							"name": "master"
+							"name": "trunk"
 						}
 					}
 				} } }
@@ -233,7 +233,7 @@ func Test_RepoClone_hasParent(t *testing.T) {
 	defer cmdTeardown(t)
 
 	cs.Register(`git clone https://github.com/OWNER/REPO.git`, 0, "")
-	cs.Register(`git -C REPO remote add -t master -f upstream https://github.com/hubot/ORIG.git`, 0, "")
+	cs.Register(`git -C REPO remote add -t trunk -f upstream https://github.com/hubot/ORIG.git`, 0, "")
 
 	_, err := runCloneCommand(httpClient, "OWNER/REPO")
 	if err != nil {

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -218,6 +218,9 @@ func Test_RepoClone_hasParent(t *testing.T) {
 						"name": "ORIG",
 						"owner": {
 							"login": "hubot"
+						},
+						"defaultBranchRef": {
+							"name": "master"
 						}
 					}
 				} } }
@@ -237,7 +240,7 @@ func Test_RepoClone_hasParent(t *testing.T) {
 	}
 
 	assert.Equal(t, 2, cs.Count)
-	assert.Equal(t, "git -C REPO remote add -f upstream https://github.com/hubot/ORIG.git", strings.Join(cs.Calls[1].Args, " "))
+	assert.Equal(t, "git -C REPO remote add -t master -f upstream https://github.com/hubot/ORIG.git", strings.Join(cs.Calls[1].Args, " "))
 }
 
 func Test_RepoClone_withoutUsername(t *testing.T) {

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -273,7 +273,7 @@ func forkRun(opts *ForkOptions) error {
 			}
 
 			upstreamURL := ghrepo.FormatRemoteURL(repoToFork, protocol)
-			err = git.AddUpstreamRemote(upstreamURL, cloneDir)
+			err = git.AddUpstreamRemote(upstreamURL, cloneDir, []string{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR modifies the `git remote add -f upstream` command run during `gh repo clone`. Previously it would fetch all all branch references. I have modified it to only fetch the default upstream branch.

See the linked issue for more details.

Fixes: #2557

--
cc: @mislav, @samcoe