### PR TITLE
add arm build for raspberry pi

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
   - <<: *build_defaults
     id: linux
     goos: [linux]
-    goarch: [386, amd64, arm64]
+    goarch: [386, arm, amd64, arm64]
 
   - <<: *build_defaults
     id: windows

--- a/script/distributions
+++ b/script/distributions
@@ -1,7 +1,7 @@
 Origin: gh
 Label: gh
 Codename: stable
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian stable repo
 SignWith: C99B11DEB97541F0
@@ -9,7 +9,7 @@ SignWith: C99B11DEB97541F0
 Origin: gh
 Label: gh
 Codename: oldstable
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian oldstable repo
 SignWith: C99B11DEB97541F0
@@ -17,7 +17,7 @@ SignWith: C99B11DEB97541F0
 Origin: gh
 Label: gh
 Codename: testing
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian testing repo
 SignWith: C99B11DEB97541F0
@@ -25,7 +25,7 @@ SignWith: C99B11DEB97541F0
 Origin: gh
 Label: gh
 Codename: unstable
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian unstable repo
 SignWith: C99B11DEB97541F0
@@ -33,7 +33,7 @@ SignWith: C99B11DEB97541F0
 Origin: gh
 Label: gh
 Codename: buster
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian buster repo
 SignWith: C99B11DEB97541F0
@@ -41,7 +41,7 @@ SignWith: C99B11DEB97541F0
 Origin: gh
 Label: gh
 Codename: bullseye
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian bullseye repo
 SignWith: C99B11DEB97541F0
@@ -49,7 +49,7 @@ SignWith: C99B11DEB97541F0
 Origin: gh
 Label: gh
 Codename: stretch
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian stretch repo
 SignWith: C99B11DEB97541F0
@@ -57,7 +57,7 @@ SignWith: C99B11DEB97541F0
 Origin: gh
 Label: gh
 Codename: jessie
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian jessie repo
 SignWith: C99B11DEB97541F0
@@ -65,7 +65,7 @@ SignWith: C99B11DEB97541F0
 Origin: gh
 Label: gh
 Codename: focal
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu focal repo
 SignWith: C99B11DEB97541F0
@@ -74,7 +74,7 @@ DebOverride: override.ubuntu
 Origin: gh
 Label: gh
 Codename: precise
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu precise repo
 SignWith: C99B11DEB97541F0
@@ -83,7 +83,7 @@ DebOverride: override.ubuntu
 Origin: gh
 Label: gh
 Codename: bionic
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu bionic repo
 SignWith: C99B11DEB97541F0
@@ -92,7 +92,7 @@ DebOverride: override.ubuntu
 Origin: gh
 Label: gh
 Codename: trusty
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu trusty repo
 SignWith: C99B11DEB97541F0
@@ -101,7 +101,7 @@ DebOverride: override.ubuntu
 Origin: gh
 Label: gh
 Codename: xenial
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu xenial repo
 SignWith: C99B11DEB97541F0
@@ -110,7 +110,7 @@ DebOverride: override.ubuntu
 Origin: gh
 Label: gh
 Codename: groovy
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu groovy repo
 SignWith: C99B11DEB97541F0
@@ -119,7 +119,7 @@ DebOverride: override.ubuntu
 Origin: gh
 Label: gh
 Codename: eoan
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu eoan repo
 SignWith: C99B11DEB97541F0
@@ -128,7 +128,7 @@ DebOverride: override.ubuntu
 Origin: gh
 Label: gh
 Codename: disco
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu disco repo
 SignWith: C99B11DEB97541F0
@@ -137,7 +137,7 @@ DebOverride: override.ubuntu
 Origin: gh
 Label: gh
 Codename: cosmic
-Architectures: i386 amd64 arm64
+Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu cosmic repo
 SignWith: C99B11DEB97541F0


### PR DESCRIPTION
Adds `arm` to our arch list; this makes it easier to use `gh` on a raspberry pi.

Fixes #1960
