### PR TITLE
Fix link in `version` output

### DIFF
--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -26,11 +26,12 @@ func NewCmdVersion(f *cmdutil.Factory, version, buildDate string) *cobra.Command
 func Format(version, buildDate string) string {
 	version = strings.TrimPrefix(version, "v")
 
+	var dateStr string
 	if buildDate != "" {
-		version = fmt.Sprintf("%s (%s)", version, buildDate)
+		dateStr = fmt.Sprintf(" (%s)", buildDate)
 	}
 
-	return fmt.Sprintf("gh version %s\n%s\n", version, changelogURL(version))
+	return fmt.Sprintf("gh version %s%s\n%s\n", version, dateStr, changelogURL(version))
 }
 
 func changelogURL(version string) string {

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -4,6 +4,13 @@ import (
 	"testing"
 )
 
+func TestFormat(t *testing.T) {
+	expects := "gh version 1.4.0 (2020-12-15)\nhttps://github.com/cli/cli/releases/tag/v1.4.0\n"
+	if got := Format("1.4.0", "2020-12-15"); got != expects {
+		t.Errorf("Format() = %q, wants %q", got, expects)
+	}
+}
+
 func TestChangelogURL(t *testing.T) {
 	tag := "0.3.2"
 	url := "https://github.com/cli/cli/releases/tag/v0.3.2"


### PR DESCRIPTION
`gh version` output now correctly links to the tagged release instead of to the latest release.
