### PR TITLE
hackday: project support brainstorm

### DIFF
--- a/api/queries_project.go
+++ b/api/queries_project.go
@@ -57,3 +57,7 @@ func (c Client) GetProjectCards(baseRepo ghrepo.Interface, columnID int) ([]byte
 
 	return c.projectREST(url)
 }
+
+func (c Client) GetProjectCardContent(contentURL string) ([]byte, error) {
+	return c.projectREST(contentURL)
+}

--- a/api/queries_project.go
+++ b/api/queries_project.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cli/cli/internal/ghinstance"
+	"github.com/cli/cli/internal/ghrepo"
+)
+
+func (c Client) GetProject(baseRepo ghrepo.Interface, projectID string) ([]byte, error) {
+	url := fmt.Sprintf("%sprojects/%s",
+		ghinstance.RESTPrefix(baseRepo.RepoHost()), projectID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO api() { gh api -H 'accept: application/vnd.github.inertia-preview+json' "$@"; }
+	req.Header.Set("Accept", "application/vnd.github.inertia-preview+json; charset=utf-8")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == 404 {
+		return nil, &NotFoundError{errors.New("pull request not found")}
+	} else if resp.StatusCode != 200 {
+		return nil, HandleHTTPError(resp)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/api/queries_project.go
+++ b/api/queries_project.go
@@ -10,16 +10,12 @@ import (
 	"github.com/cli/cli/internal/ghrepo"
 )
 
-func (c Client) GetProject(baseRepo ghrepo.Interface, projectID string) ([]byte, error) {
-	url := fmt.Sprintf("%sprojects/%s",
-		ghinstance.RESTPrefix(baseRepo.RepoHost()), projectID)
-
+func (c Client) projectREST(url string) ([]byte, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO api() { gh api -H 'accept: application/vnd.github.inertia-preview+json' "$@"; }
 	req.Header.Set("Accept", "application/vnd.github.inertia-preview+json; charset=utf-8")
 
 	resp, err := c.http.Do(req)
@@ -39,4 +35,25 @@ func (c Client) GetProject(baseRepo ghrepo.Interface, projectID string) ([]byte,
 	}
 
 	return data, nil
+}
+
+func (c Client) GetProject(baseRepo ghrepo.Interface, projectID int) ([]byte, error) {
+	url := fmt.Sprintf("%sprojects/%d", ghinstance.RESTPrefix(baseRepo.RepoHost()), projectID)
+
+	return c.projectREST(url)
+}
+
+func (c Client) GetProjectColumns(baseRepo ghrepo.Interface, projectID int) ([]byte, error) {
+	url := fmt.Sprintf("%sprojects/%d/columns",
+		ghinstance.RESTPrefix(baseRepo.RepoHost()), projectID)
+
+	return c.projectREST(url)
+
+}
+
+func (c Client) GetProjectCards(baseRepo ghrepo.Interface, columnID int) ([]byte, error) {
+	url := fmt.Sprintf("%sprojects/columns/%d/cards",
+		ghinstance.RESTPrefix(baseRepo.RepoHost()), columnID)
+
+	return c.projectREST(url)
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cli/safeexec v1.0.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/enescakir/emoji v1.0.0
+	github.com/gdamore/tcell/v2 v2.0.0
 	github.com/google/go-cmp v0.5.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-version v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,11 @@ github.com/enescakir/emoji v1.0.0/go.mod h1:Bt1EKuLnKDTYpLALApstIkAjdDrS/8IAgTkK
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
+github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
+github.com/gdamore/tcell v1.4.0 h1:vUnHwJRvcPQa3tzi+0QI4U9JINXYJlOz9yiaiPQ2wMU=
+github.com/gdamore/tcell/v2 v2.0.0 h1:GRWG8aLfWAlekj9Q6W29bVvkHENc6hp79XOqG4AWDOs=
+github.com/gdamore/tcell/v2 v2.0.0/go.mod h1:vSVL/GV5mCSlPC6thFP5kfOFdM9MGZcalipmpTxTgQA=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -343,6 +348,7 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190530182044-ad28b68e88f1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/cmd/project/http.go
+++ b/pkg/cmd/project/http.go
@@ -30,10 +30,6 @@ func getProject(client *api.Client, baseRepo ghrepo.Interface, projectID int) (*
 		return nil, err
 	}
 
-	titled := struct {
-		Title string
-	}{}
-
 	for _, column := range project.Columns {
 		data, err := client.GetProjectCards(baseRepo, column.ID)
 		if err != nil {
@@ -53,11 +49,10 @@ func getProject(client *api.Client, baseRepo ghrepo.Interface, projectID int) (*
 					return nil, err
 				}
 
-				err = json.Unmarshal(data, &titled)
+				err = json.Unmarshal(data, &card.Content)
 				if err != nil {
 					return nil, err
 				}
-				card.Note = titled.Title
 			}
 		}
 	}

--- a/pkg/cmd/project/http.go
+++ b/pkg/cmd/project/http.go
@@ -1,0 +1,46 @@
+package project
+
+import (
+	"encoding/json"
+
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+)
+
+func getProject(client *api.Client, baseRepo ghrepo.Interface, projectID int) (*Project, error) {
+	data, err := client.GetProject(baseRepo, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	project := &Project{}
+
+	err = json.Unmarshal(data, project)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err = client.GetProjectColumns(baseRepo, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(data, &project.Columns)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, column := range project.Columns {
+		data, err := client.GetProjectCards(baseRepo, column.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(data, &column.Cards)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return project, nil
+}

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -1,8 +1,11 @@
 package project
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 
+	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
@@ -29,14 +32,11 @@ func NewCmdProject(f *cmdutil.Factory, runF func(*ProjectOptions) error) *cobra.
 		Short:  "Interact with a GitHub project",
 		Long:   "Enter an interactive UI for viewing and modifying a GitHub project",
 		Hidden: true,
-		Args:   cobra.MaximumNArgs(1),
+		Args:   cobra.NoArgs,
 		RunE: func(c *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo
 
-			if len(args) > 0 {
-				opts.Selector = args[0]
-			}
 			if runF != nil {
 				return runF(&opts)
 			}
@@ -48,5 +48,46 @@ func NewCmdProject(f *cmdutil.Factory, runF func(*ProjectOptions) error) *cobra.
 }
 
 func projectRun(opts *ProjectOptions) error {
+	// TODO interactively ask which project they want since these IDs are not easy to get
+	projectID := "3514315"
+
+	c, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+	client := api.NewClientFromHTTP(c)
+
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(client, baseRepo, projectID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("DBG %#v\n", project)
+
 	return nil
+}
+
+type Project struct {
+	Name string
+}
+
+func getProject(client *api.Client, baseRepo ghrepo.Interface, projectID string) (*Project, error) {
+	data, err := client.GetProject(baseRepo, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	project := &Project{}
+
+	err = json.Unmarshal(data, project)
+	if err != nil {
+		return nil, err
+	}
+
+	return project, nil
 }

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -125,7 +125,7 @@ func projectRun(opts *ProjectOptions) error {
 						selectedCard--
 					}
 				case 's':
-					if selectedCard < cardsToShow-1 {
+					if selectedCard < cardsToShow {
 						selectedCard++
 					}
 				case 'a':
@@ -133,7 +133,7 @@ func projectRun(opts *ProjectOptions) error {
 						selectedColumn--
 					}
 				case 'd':
-					if selectedColumn < colsToShow-1 {
+					if selectedColumn < colsToShow {
 						selectedColumn++
 					}
 				}
@@ -149,6 +149,8 @@ func projectRun(opts *ProjectOptions) error {
 			}
 		}
 	}()
+
+	var cardInfo *Card
 
 loop:
 	for {
@@ -167,6 +169,9 @@ loop:
 			colY := 1
 			drawRect(s, style, colX, colY, colWidth, colHeight, false)
 			drawStr(s, colX+1, colY+1, style, col.Name)
+			if selectedColumn == ix && selectedCard >= len(col.Cards) {
+				selectedCard = len(col.Cards) - 1
+			}
 			for ic, card := range col.Cards {
 				if ic == cardsToShow {
 					break
@@ -176,6 +181,7 @@ loop:
 				if selectedColumn == ix && selectedCard == ic {
 					cardStyle = style.Foreground(tcell.ColorGreen)
 					bold = true
+					cardInfo = card
 				}
 				drawRect(s, cardStyle, colX+1, (ic*cardHeight)+colY+2, cardWidth, cardHeight, bold)
 				cardNote := card.Note
@@ -187,6 +193,15 @@ loop:
 				drawStr(s, colX+2, (ic*cardHeight)+colY+3, style, cardNote)
 			}
 		}
+
+		// Info box
+		infoX := colWidth * colsToShow
+		infoY := 1
+		infoWidth := colWidth * 2
+		infoHeight := colHeight
+		drawRect(s, style, infoX, infoY, infoWidth, infoHeight, true)
+		drawStr(s, infoX+1, infoY+1, style, cardInfo.Note)
+
 		s.Show()
 	}
 

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -132,6 +132,9 @@ func projectRun(opts *ProjectOptions) error {
 	cardHeight := 5
 	cardsToShow := 7
 
+	selectedColumn := 0
+	selectedCard := 0
+
 loop:
 	for {
 		select {
@@ -153,7 +156,11 @@ loop:
 				if ic == cardsToShow {
 					break
 				}
-				drawRect(s, style, colX+1, (ic*cardHeight)+colY+2, cardWidth, cardHeight)
+				cardStyle := style
+				if selectedColumn == ix && selectedCard == ic {
+					cardStyle = style.Foreground(tcell.ColorGreen)
+				}
+				drawRect(s, cardStyle, colX+1, (ic*cardHeight)+colY+2, cardWidth, cardHeight)
 				cardNote := card.Note
 				if len(card.Note) > cardWidth-2 {
 					cardNote = cardNote[0 : cardWidth-2]

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -98,7 +98,17 @@ func projectRun(opts *ProjectOptions) error {
 
 	s.SetStyle(style)
 
-	// some kind of controller struct to track modal state?
+	// TODO some kind of controller struct to track modal state?
+	colWidth := 30
+	colHeight := 40
+	colsToShow := 7
+
+	cardWidth := colWidth - 2
+	cardHeight := 5
+	cardsToShow := 7
+
+	selectedColumn := 0
+	selectedCard := 0
 
 	quit := make(chan struct{})
 	go func() {
@@ -110,6 +120,22 @@ func projectRun(opts *ProjectOptions) error {
 				case 'q':
 					close(quit)
 					return
+				case 'w':
+					if selectedCard > 0 {
+						selectedCard--
+					}
+				case 's':
+					if selectedCard < cardsToShow {
+						selectedCard++
+					}
+				case 'a':
+					if selectedColumn > 0 {
+						selectedColumn--
+					}
+				case 'd':
+					if selectedColumn < colsToShow {
+						selectedColumn++
+					}
 				}
 				switch ev.Key() {
 				case tcell.KeyEscape:
@@ -123,17 +149,6 @@ func projectRun(opts *ProjectOptions) error {
 			}
 		}
 	}()
-
-	colWidth := 30
-	colHeight := 40
-	colsToShow := 7
-
-	cardWidth := colWidth - 2
-	cardHeight := 5
-	cardsToShow := 7
-
-	selectedColumn := 0
-	selectedCard := 0
 
 loop:
 	for {

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -1,0 +1,52 @@
+package project
+
+import (
+	"net/http"
+
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type ProjectOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	Selector string
+}
+
+func NewCmdProject(f *cmdutil.Factory, runF func(*ProjectOptions) error) *cobra.Command {
+	opts := ProjectOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		BaseRepo:   f.BaseRepo,
+	}
+
+	cmd := &cobra.Command{
+		Use:    "project [<project id>]",
+		Short:  "Interact with a GitHub project",
+		Long:   "Enter an interactive UI for viewing and modifying a GitHub project",
+		Hidden: true,
+		Args:   cobra.MaximumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			if len(args) > 0 {
+				opts.Selector = args[0]
+			}
+			if runF != nil {
+				return runF(&opts)
+			}
+			return projectRun(&opts)
+		},
+	}
+
+	return cmd
+}
+
+func projectRun(opts *ProjectOptions) error {
+	return nil
+}

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -101,7 +101,7 @@ func projectRun(opts *ProjectOptions) error {
 	// TODO some kind of controller struct to track modal state?
 	colWidth := 30
 	colHeight := 40
-	colsToShow := 7
+	colsToShow := 3
 
 	cardWidth := colWidth - 2
 	cardHeight := 5
@@ -125,7 +125,7 @@ func projectRun(opts *ProjectOptions) error {
 						selectedCard--
 					}
 				case 's':
-					if selectedCard < cardsToShow {
+					if selectedCard < cardsToShow-1 {
 						selectedCard++
 					}
 				case 'a':
@@ -133,7 +133,7 @@ func projectRun(opts *ProjectOptions) error {
 						selectedColumn--
 					}
 				case 'd':
-					if selectedColumn < colsToShow {
+					if selectedColumn < colsToShow-1 {
 						selectedColumn++
 					}
 				}
@@ -155,7 +155,7 @@ loop:
 		select {
 		case <-quit:
 			break loop
-		case <-time.After(time.Millisecond * 500):
+		case <-time.After(time.Millisecond * 100):
 		}
 		s.Clear()
 		drawStr(s, 0, 0, style, project.Name)
@@ -165,17 +165,19 @@ loop:
 			}
 			colX := colWidth * ix
 			colY := 1
-			drawRect(s, style, colX, colY, colWidth, colHeight)
+			drawRect(s, style, colX, colY, colWidth, colHeight, false)
 			drawStr(s, colX+1, colY+1, style, col.Name)
 			for ic, card := range col.Cards {
 				if ic == cardsToShow {
 					break
 				}
 				cardStyle := style
+				bold := false
 				if selectedColumn == ix && selectedCard == ic {
 					cardStyle = style.Foreground(tcell.ColorGreen)
+					bold = true
 				}
-				drawRect(s, cardStyle, colX+1, (ic*cardHeight)+colY+2, cardWidth, cardHeight)
+				drawRect(s, cardStyle, colX+1, (ic*cardHeight)+colY+2, cardWidth, cardHeight, bold)
 				cardNote := card.Note
 				if len(card.Note) > cardWidth-2 {
 					cardNote = cardNote[0 : cardWidth-2]
@@ -207,16 +209,23 @@ func drawStr(s tcell.Screen, x, y int, style tcell.Style, str string) {
 	}
 }
 
-func drawRect(s tcell.Screen, style tcell.Style, x, y, w, h int) {
+func drawRect(s tcell.Screen, style tcell.Style, x, y, w, h int, bold bool) {
 	// TODO could consolidate these now that I have the correct unicode characters
 	topLeftCorner := '┌'
 	botLeftCorner := '└'
 	topRightCorner := '┐'
 	botRightCorner := '┘'
-	leftLine := '│'
-	rightLine := '│'
-	topLine := '─'
-	botLine := '─'
+	vertiLine := '│'
+	horizLine := '─'
+
+	if bold {
+		topLeftCorner = '┏'
+		botLeftCorner = '┗'
+		topRightCorner = '┓'
+		botRightCorner = '┛'
+		vertiLine = '┃'
+		horizLine = '━'
+	}
 
 	for ix := x; ix < x+w; ix++ {
 		for iy := y; iy < y+h; iy++ {
@@ -226,17 +235,17 @@ func drawRect(s tcell.Screen, style tcell.Style, x, y, w, h int) {
 			} else if ix == x && iy == y+h-1 {
 				c = botLeftCorner
 			} else if ix == x {
-				c = leftLine
+				c = vertiLine
 			} else if ix == x+w-1 && iy == y {
 				c = topRightCorner
 			} else if ix == x+w-1 && iy == y+h-1 {
 				c = botRightCorner
 			} else if ix == x+w-1 {
-				c = rightLine
+				c = vertiLine
 			} else if iy == y {
-				c = topLine
+				c = horizLine
 			} else if iy == y+h-1 {
-				c = botLine
+				c = horizLine
 			} else {
 				continue
 			}

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -49,8 +49,9 @@ func NewCmdProject(f *cmdutil.Factory, runF func(*ProjectOptions) error) *cobra.
 }
 
 type Card struct {
-	Note string
-	ID   int
+	Note       string
+	ID         int
+	ContentURL string `json:"content_url"`
 }
 
 type Column struct {
@@ -157,7 +158,7 @@ loop:
 				if len(card.Note) > cardWidth-2 {
 					cardNote = cardNote[0 : cardWidth-2]
 				} else if cardNote == "" {
-					cardNote = "TODO ISSUE"
+					cardNote = `¯\_(ツ)_/¯`
 				}
 				drawStr(s, colX+2, (ic*cardHeight)+colY+3, style, cardNote)
 			}

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -123,6 +123,14 @@ func projectRun(opts *ProjectOptions) error {
 		}
 	}()
 
+	colWidth := 30
+	colHeight := 40
+	colsToShow := 7
+
+	cardWidth := colWidth - 2
+	cardHeight := 5
+	cardsToShow := 7
+
 loop:
 	for {
 		select {
@@ -132,6 +140,28 @@ loop:
 		}
 		s.Clear()
 		drawStr(s, 0, 0, style, project.Name)
+		for ix, col := range project.Columns {
+			if ix == colsToShow {
+				break
+			}
+			colX := colWidth * ix
+			colY := 1
+			drawRect(s, style, colX, colY, colWidth, colHeight)
+			drawStr(s, colX+1, colY+1, style, col.Name)
+			for ic, card := range col.Cards {
+				if ic == cardsToShow {
+					break
+				}
+				drawRect(s, style, colX+1, (ic*cardHeight)+colY+2, cardWidth, cardHeight)
+				cardNote := card.Note
+				if len(card.Note) > cardWidth-2 {
+					cardNote = cardNote[0 : cardWidth-2]
+				} else if cardNote == "" {
+					cardNote = "TODO ISSUE"
+				}
+				drawStr(s, colX+2, (ic*cardHeight)+colY+3, style, cardNote)
+			}
+		}
 		s.Show()
 	}
 
@@ -152,4 +182,44 @@ func drawStr(s tcell.Screen, x, y int, style tcell.Style, str string) {
 		s.SetContent(x, y, c, comb, style)
 		x += w
 	}
+}
+
+func drawRect(s tcell.Screen, style tcell.Style, x, y, w, h int) {
+	// TODO could consolidate these now that I have the correct unicode characters
+	topLeftCorner := '┌'
+	botLeftCorner := '└'
+	topRightCorner := '┐'
+	botRightCorner := '┘'
+	leftLine := '│'
+	rightLine := '│'
+	topLine := '─'
+	botLine := '─'
+
+	for ix := x; ix < x+w; ix++ {
+		for iy := y; iy < y+h; iy++ {
+			var c rune
+			if ix == x && iy == y {
+				c = topLeftCorner
+			} else if ix == x && iy == y+h-1 {
+				c = botLeftCorner
+			} else if ix == x {
+				c = leftLine
+			} else if ix == x+w-1 && iy == y {
+				c = topRightCorner
+			} else if ix == x+w-1 && iy == y+h-1 {
+				c = botRightCorner
+			} else if ix == x+w-1 {
+				c = rightLine
+			} else if iy == y {
+				c = topLine
+			} else if iy == y+h-1 {
+				c = botLine
+			} else {
+				continue
+			}
+
+			s.SetContent(ix, iy, c, nil, style)
+		}
+	}
+
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -16,6 +16,7 @@ import (
 	gistCmd "github.com/cli/cli/pkg/cmd/gist"
 	issueCmd "github.com/cli/cli/pkg/cmd/issue"
 	prCmd "github.com/cli/cli/pkg/cmd/pr"
+	projectCmd "github.com/cli/cli/pkg/cmd/project"
 	releaseCmd "github.com/cli/cli/pkg/cmd/release"
 	repoCmd "github.com/cli/cli/pkg/cmd/repo"
 	creditsCmd "github.com/cli/cli/pkg/cmd/repo/credits"
@@ -72,6 +73,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(authCmd.NewCmdAuth(f))
 	cmd.AddCommand(configCmd.NewCmdConfig(f))
 	cmd.AddCommand(creditsCmd.NewCmdCredits(f, nil))
+	cmd.AddCommand(projectCmd.NewCmdProject(f, nil))
 	cmd.AddCommand(gistCmd.NewCmdGist(f))
 	cmd.AddCommand(completionCmd.NewCmdCompletion(f.IOStreams))
 


### PR DESCRIPTION
NB: this is not merge-able and is only being posted for the sake of discussion.

This PR implements project support doing something we agreed we definitely didn't want to do. I did it as a hack day project so it's something to talk about and use as a counterpoint for anything we decide we _do_ want to do.

It renders a project board using unicode drawing characters and allows navigation from card to card with WADS and previews each card in a sidebar.

Observations:

- it's brutally slow because it uses the REST API. Every column and card gets its own request and it takes forever; it ought to use GraphQL or parallelize requests.
- it has serious rendering issues. I'm using raw tcell and foolishly am counting string width by character and not rune width, which leads to garbled displays. If we revisit this we'd need to either switch to something more all-in-one like tview or just counting runewidth correctly.

that said, I enjoyed bringing up a project board and moving around it. 
