### PR TITLE
Add final newline back to `pr view`

### DIFF
--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -223,7 +223,7 @@ func printHumanPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 	}
 
 	// Footer
-	fmt.Fprintf(out, cs.Gray("View this pull request on GitHub: %s"), pr.URL)
+	fmt.Fprintf(out, cs.Gray("View this pull request on GitHub: %s\n"), pr.URL)
 
 	return nil
 }


### PR DESCRIPTION
Looks like the last newline in `pr view` got removed in #2575. This PR just adds it back.

Fixes https://github.com/cli/cli/issues/2674