### PR TITLE
Clarify pre-existing token env var error during login

### DIFF
--- a/internal/config/from_env.go
+++ b/internal/config/from_env.go
@@ -56,7 +56,7 @@ func (c *envConfig) GetWithSource(hostname, key string) (string, string, error) 
 func (c *envConfig) CheckWriteable(hostname, key string) error {
 	if hostname != "" && key == "oauth_token" {
 		if token, env := AuthTokenFromEnv(hostname); token != "" {
-			return fmt.Errorf("read-only token in %s cannot be modified", env)
+			return fmt.Errorf("The '%s' environment variable is not empty, please clear it to save authentication data", env)
 		}
 	}
 


### PR DESCRIPTION
<!--
Please make sure you read our contributing guidelines at
https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md
before opening a pull request. Thanks!
-->

## Summary

Clarifies the error and steps to remedy it when the GITHUB_TOKEN (or enterprise token) environment variable is set before ``gh auth login``.

closes #2304

## Details

Based on suggested text by @georgettica in #2304
