### PR TITLE
Correct remote sort order

### DIFF
--- a/context/remote.go
+++ b/context/remote.go
@@ -51,7 +51,7 @@ func remoteNameSortScore(name string) int {
 func (r Remotes) Len() int      { return len(r) }
 func (r Remotes) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
 func (r Remotes) Less(i, j int) bool {
-	return remoteNameSortScore(r[i].Name) > remoteNameSortScore(r[j].Name)
+	return remoteNameSortScore(r[i].Name) < remoteNameSortScore(r[j].Name)
 }
 
 // Remote represents a git remote mapped to a GitHub repository

--- a/pkg/cmd/factory/remote_resolver_test.go
+++ b/pkg/cmd/factory/remote_resolver_test.go
@@ -41,6 +41,39 @@ func Test_remoteResolver(t *testing.T) {
 	assert.Equal(t, "upstream", remotes[1].Name)
 }
 
+func Test_remoteResolverPriority(t *testing.T) {
+	rr := &remoteResolver{
+		readRemotes: func() (git.RemoteSet, error) {
+			return git.RemoteSet{
+				git.NewRemote("origin", "https://github.com/origin-owner/repo.git"),
+				git.NewRemote("github", "https://github.com/gh-owner/gh-repo.git"),
+				git.NewRemote("custom", "https://github.com/foo/bar.git"),
+				git.NewRemote("upstream", "https://github.com/upstream-owner/repo.git"),
+			}, nil
+		},
+		getConfig: func() (config.Config, error) {
+			return config.NewFromString(heredoc.Doc(`
+				hosts:
+				  example.org:
+				    oauth_token: GHETOKEN
+			`)), nil
+		},
+		urlTranslator: func(u *url.URL) *url.URL {
+			return u
+		},
+	}
+
+	resolver := rr.Resolver("")
+	remotes, err := resolver()
+	require.NoError(t, err)
+	require.Equal(t, 4, len(remotes))
+
+	assert.Equal(t, "custom", remotes[0].Name)
+	assert.Equal(t, "origin", remotes[1].Name)
+	assert.Equal(t, "github", remotes[2].Name)
+	assert.Equal(t, "upstream", remotes[3].Name)
+}
+
 func Test_remoteResolverOverride(t *testing.T) {
 	rr := &remoteResolver{
 		readRemotes: func() (git.RemoteSet, error) {

--- a/pkg/cmd/factory/remote_resolver_test.go
+++ b/pkg/cmd/factory/remote_resolver_test.go
@@ -37,8 +37,8 @@ func Test_remoteResolver(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, len(remotes))
 
-	assert.Equal(t, "upstream", remotes[0].Name)
-	assert.Equal(t, "fork", remotes[1].Name)
+	assert.Equal(t, "fork", remotes[0].Name)
+	assert.Equal(t, "upstream", remotes[1].Name)
 }
 
 func Test_remoteResolverOverride(t *testing.T) {


### PR DESCRIPTION
According to the docs at https://golang.org/pkg/sort/#Interface

> // Less reports whether the element with
> // index i should sort before the element with index j.
> Less(i, j int) bool

A consistent comparison would then be i < j so, e.g., 1 is sorted before 2. In this case we need to ensure, `(origin = 1) < (upstream = 3)`

Fixes https://github.com/cli/cli/issues/2657

Side note, the way this is at the moment, any "custom" remote name that is not `origin`, `github`, or `upstream` will always sort to the front of the list (and "win"). Was this the intended behavior or were custom origin names meant to be selected last?