### PR TITLE
Print friendly error when 'gh gist <command>' is missing required argument

### DIFF
--- a/pkg/cmd/gist/delete/delete.go
+++ b/pkg/cmd/gist/delete/delete.go
@@ -2,14 +2,15 @@ package delete
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/ghinstance"
 	"github.com/cli/cli/pkg/cmd/gist/shared"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
 	"github.com/spf13/cobra"
-	"net/http"
-	"strings"
 )
 
 type DeleteOptions struct {
@@ -28,7 +29,7 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "delete {<gist ID> | <gist URL>}",
 		Short: "Delete a gist",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.MinimumArgs(1, "cannot delete: gist argument required"),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.Selector = args[0]
 			if runF != nil {

--- a/pkg/cmd/gist/edit/edit.go
+++ b/pkg/cmd/gist/edit/edit.go
@@ -49,7 +49,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "edit {<gist ID> | <gist URL>}",
 		Short: "Edit one of your gists",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.MinimumArgs(1, "cannot edit: gist argument required"),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.Selector = args[0]
 

--- a/pkg/cmd/gist/view/view.go
+++ b/pkg/cmd/gist/view/view.go
@@ -34,7 +34,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "view {<gist id> | <gist url>}",
 		Short: "View a gist",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.MinimumArgs(1, "cannot view: gist argument required"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Selector = args[0]
 


### PR DESCRIPTION
Just saw that [`gh gist clone`](https://github.com/cli/cli/blob/230441e1a594eea80d0f3384488925ddae074155/pkg/cmd/gist/clone/clone.go#L38) has it so I added it for `gh gist delete/edit/view`.