### PR TITLE
view: Add missing newline

### DIFF
--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -204,7 +204,7 @@ func printHumanIssuePreview(io *iostreams.IOStreams, issue *api.Issue) error {
 	}
 
 	// Footer
-	fmt.Fprintf(out, cs.Gray("View this issue on GitHub: %s"), issue.URL)
+	fmt.Fprintf(out, cs.Gray("View this issue on GitHub: %s\n"), issue.URL)
 
 	return nil
 }

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -223,7 +223,7 @@ func printHumanPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 	}
 
 	// Footer
-	fmt.Fprintf(out, cs.Gray("View this pull request on GitHub: %s"), pr.URL)
+	fmt.Fprintf(out, cs.Gray("View this pull request on GitHub: %s\n"), pr.URL)
 
 	return nil
 }


### PR DESCRIPTION
Fixes #2674. Fixes #2706.

Add a newline at the end of the 'View this {issue, pull request} on
GitHub' message. `gh repo view` already had a newline at the end, so
this only changes `issue view` and `pr view`.
