### PR TITLE
Fix `make` rebuilding when dependencies have changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-BUILD_FILES = $(shell go list -f '{{range .GoFiles}}{{$$.Dir}}/{{.}}\
-{{end}}' ./...)
+BUILD_FILES = go.mod go.sum $(shell go list -f '{{range .GoFiles}}{{. | printf "%s/%s\n" $$.Dir}}{{end}}' ./...)
 
 GH_VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --short HEAD)
 DATE_FMT = +%Y-%m-%d


### PR DESCRIPTION
List `go.mod` and `go.sum` as files whose timestamps are checked when
deciding whether `make` should rebuild the `bin/hub` executable.

Additionally, use printf to avoid having to have a literal newline in
the `go list` format string.
