### PR TITLE
Comment on pull requests

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -481,3 +481,11 @@ func milestoneNodeIdToDatabaseId(nodeId string) (string, error) {
 	}
 	return splitted[1], nil
 }
+
+func (i Issue) Link() string {
+	return i.URL
+}
+
+func (i Issue) Identifier() string {
+	return i.ID
+}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -136,6 +136,14 @@ func (pr PullRequest) HeadLabel() string {
 	return pr.HeadRefName
 }
 
+func (pr PullRequest) Link() string {
+	return pr.URL
+}
+
+func (pr PullRequest) Identifier() string {
+	return pr.ID
+}
+
 type PullRequestReviewStatus struct {
 	ChangesRequested bool
 	Approved         bool

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -1,0 +1,78 @@
+package comment
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/context"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmd/pr/shared"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) error) *cobra.Command {
+	opts := &shared.CommentableOptions{
+		IO:                    f.IOStreams,
+		HttpClient:            f.HttpClient,
+		EditSurvey:            shared.CommentableEditSurvey(f.Config, f.IOStreams),
+		InteractiveEditSurvey: shared.CommentableInteractiveEditSurvey(f.Config, f.IOStreams),
+		ConfirmSubmitSurvey:   shared.CommentableConfirmSubmitSurvey,
+		OpenInBrowser:         utils.OpenInBrowser,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "comment [<number> | <url> | <branch>]",
+		Short: "Create a new pr comment",
+		Example: heredoc.Doc(`
+			$ gh pr comment 22 --body "This looks great, lets get it deployed."
+		`),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if repoOverride, _ := cmd.Flags().GetString("repo"); repoOverride != "" && len(args) == 0 {
+				return &cmdutil.FlagError{Err: errors.New("argument required when using the --repo flag")}
+			}
+			var selector string
+			if len(args) > 0 {
+				selector = args[0]
+			}
+			opts.RetrieveCommentable = retrievePR(f.HttpClient, f.BaseRepo, f.Branch, f.Remotes, selector)
+			return shared.CommentablePreRun(cmd, opts)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if runF != nil {
+				return runF(opts)
+			}
+			return shared.CommentableRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Supply a body. Will prompt for one otherwise.")
+	cmd.Flags().BoolP("editor", "e", false, "Add body using editor")
+	cmd.Flags().BoolP("web", "w", false, "Add body in browser")
+
+	return cmd
+}
+
+func retrievePR(httpClient func() (*http.Client, error),
+	baseRepo func() (ghrepo.Interface, error),
+	branch func() (string, error),
+	remotes func() (context.Remotes, error),
+	selector string) func() (shared.Commentable, ghrepo.Interface, error) {
+	return func() (shared.Commentable, ghrepo.Interface, error) {
+		httpClient, err := httpClient()
+		if err != nil {
+			return nil, nil, err
+		}
+		apiClient := api.NewClientFromHTTP(httpClient)
+
+		pr, repo, err := shared.PRFromArgs(apiClient, baseRepo, branch, remotes, selector)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return pr, repo, nil
+	}
+}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -5,6 +5,7 @@ import (
 	cmdCheckout "github.com/cli/cli/pkg/cmd/pr/checkout"
 	cmdChecks "github.com/cli/cli/pkg/cmd/pr/checks"
 	cmdClose "github.com/cli/cli/pkg/cmd/pr/close"
+	cmdComment "github.com/cli/cli/pkg/cmd/pr/comment"
 	cmdCreate "github.com/cli/cli/pkg/cmd/pr/create"
 	cmdDiff "github.com/cli/cli/pkg/cmd/pr/diff"
 	cmdList "github.com/cli/cli/pkg/cmd/pr/list"
@@ -53,6 +54,7 @@ func NewCmdPR(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(cmdStatus.NewCmdStatus(f, nil))
 	cmd.AddCommand(cmdView.NewCmdView(f, nil))
 	cmd.AddCommand(cmdChecks.NewCmdChecks(f, nil))
+	cmd.AddCommand(cmdComment.NewCmdComment(f, nil))
 
 	return cmd
 }

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -1,0 +1,168 @@
+package shared
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/pkg/surveyext"
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+type InputType int
+
+const (
+	InputTypeEditor InputType = iota
+	InputTypeInline
+	InputTypeWeb
+)
+
+type Commentable interface {
+	Link() string
+	Identifier() string
+}
+
+type CommentableOptions struct {
+	IO                    *iostreams.IOStreams
+	HttpClient            func() (*http.Client, error)
+	RetrieveCommentable   func() (Commentable, ghrepo.Interface, error)
+	EditSurvey            func() (string, error)
+	InteractiveEditSurvey func() (string, error)
+	ConfirmSubmitSurvey   func() (bool, error)
+	OpenInBrowser         func(string) error
+	Interactive           bool
+	InputType             InputType
+	Body                  string
+}
+
+func CommentablePreRun(cmd *cobra.Command, opts *CommentableOptions) error {
+	inputFlags := 0
+	if cmd.Flags().Changed("body") {
+		opts.InputType = InputTypeInline
+		inputFlags++
+	}
+	if web, _ := cmd.Flags().GetBool("web"); web {
+		opts.InputType = InputTypeWeb
+		inputFlags++
+	}
+	if editor, _ := cmd.Flags().GetBool("editor"); editor {
+		opts.InputType = InputTypeEditor
+		inputFlags++
+	}
+
+	if inputFlags == 0 {
+		if !opts.IO.CanPrompt() {
+			return &cmdutil.FlagError{Err: errors.New("--body or --web required when not running interactively")}
+		}
+		opts.Interactive = true
+	} else if inputFlags == 1 {
+		if !opts.IO.CanPrompt() && opts.InputType == InputTypeEditor {
+			return &cmdutil.FlagError{Err: errors.New("--body or --web required when not running interactively")}
+		}
+	} else if inputFlags > 1 {
+		return &cmdutil.FlagError{Err: fmt.Errorf("specify only one of --body, --editor, or --web")}
+	}
+
+	return nil
+}
+
+func CommentableRun(opts *CommentableOptions) error {
+	commentable, repo, err := opts.RetrieveCommentable()
+	if err != nil {
+		return err
+	}
+
+	switch opts.InputType {
+	case InputTypeWeb:
+		openURL := commentable.Link() + "#issuecomment-new"
+		if opts.IO.IsStdoutTTY() {
+			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", utils.DisplayURL(openURL))
+		}
+		return opts.OpenInBrowser(openURL)
+	case InputTypeEditor:
+		var body string
+		if opts.Interactive {
+			body, err = opts.InteractiveEditSurvey()
+		} else {
+			body, err = opts.EditSurvey()
+		}
+		if err != nil {
+			return err
+		}
+		opts.Body = body
+	}
+
+	if opts.Interactive {
+		cont, err := opts.ConfirmSubmitSurvey()
+		if err != nil {
+			return err
+		}
+		if !cont {
+			return errors.New("Discarding...")
+		}
+	}
+
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+	apiClient := api.NewClientFromHTTP(httpClient)
+	params := api.CommentCreateInput{Body: opts.Body, SubjectId: commentable.Identifier()}
+	url, err := api.CommentCreate(apiClient, repo.RepoHost(), params)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(opts.IO.Out, url)
+	return nil
+}
+
+func CommentableConfirmSubmitSurvey() (bool, error) {
+	var confirm bool
+	submit := &survey.Confirm{
+		Message: "Submit?",
+		Default: true,
+	}
+	err := survey.AskOne(submit, &confirm)
+	return confirm, err
+}
+
+func CommentableInteractiveEditSurvey(cf func() (config.Config, error), io *iostreams.IOStreams) func() (string, error) {
+	return func() (string, error) {
+		editorCommand, err := cmdutil.DetermineEditor(cf)
+		if err != nil {
+			return "", err
+		}
+		if editorCommand == "" {
+			editorCommand = surveyext.DefaultEditorName()
+		}
+		cs := io.ColorScheme()
+		fmt.Fprintf(io.Out, "Press %s to draft your comment in %s.", cs.Bold("enter"), cs.Bold(editorCommand))
+		_ = waitForEnter(io.In)
+		return surveyext.Edit(editorCommand, "*.md", "", io.In, io.Out, io.ErrOut, nil)
+	}
+}
+
+func CommentableEditSurvey(cf func() (config.Config, error), io *iostreams.IOStreams) func() (string, error) {
+	return func() (string, error) {
+		editorCommand, err := cmdutil.DetermineEditor(cf)
+		if err != nil {
+			return "", err
+		}
+		return surveyext.Edit(editorCommand, "*.md", "", io.In, io.Out, io.ErrOut, nil)
+	}
+}
+
+func waitForEnter(r io.Reader) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Scan()
+	return scanner.Err()
+}

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -145,7 +145,7 @@ func CommentableInteractiveEditSurvey(cf func() (config.Config, error), io *iost
 			editorCommand = surveyext.DefaultEditorName()
 		}
 		cs := io.ColorScheme()
-		fmt.Fprintf(io.Out, "Press %s to draft your comment in %s.", cs.Bold("enter"), cs.Bold(editorCommand))
+		fmt.Fprintf(io.Out, "- %s to draft your comment in %s... ", cs.Bold("Press Enter"), cs.Bold(editorCommand))
 		_ = waitForEnter(io.In)
 		return surveyext.Edit(editorCommand, "*.md", "", io.In, io.Out, io.ErrOut, nil)
 	}

--- a/pkg/surveyext/editor.go
+++ b/pkg/surveyext/editor.go
@@ -157,3 +157,7 @@ func (e *GhEditor) Prompt(config *survey.PromptConfig) (interface{}, error) {
 	}
 	return e.prompt(initialValue, config)
 }
+
+func DefaultEditorName() string {
+	return filepath.Base(defaultEditor)
+}


### PR DESCRIPTION
This PR allows for commenting on pull requests. The commenting code for issues and pull requests was very similar so I refactored to extract the `commentable.go` file which contains the shared functionality.

Additionally after talking with @ampinsk we decided that the initial input type survey was not serving much of a purpose and we decided to replace it with the standard editor survey that prompts the user to open their editor.

closes https://github.com/cli/cli/issues/517