### PR TITLE
Handle case when a cross-repo PR was already merged

### DIFF
--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -551,7 +551,7 @@ func TestPrMerge_alreadyMerged_nonInteractive(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "", output.Stderr())
+	assert.Equal(t, "! Pull request #4 was already merged\n", output.Stderr())
 }
 
 func TestPRMerge_interactive(t *testing.T) {


### PR DESCRIPTION
In this case, do not ever offer to delete the branch.

Followup to #2789
