### PR TITLE
Add body argument to `pr merge` command.

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -1144,7 +1144,7 @@ func PullRequestReopen(client *Client, repo ghrepo.Interface, pr *PullRequest) e
 	return err
 }
 
-func PullRequestMerge(client *Client, repo ghrepo.Interface, pr *PullRequest, m PullRequestMergeMethod) error {
+func PullRequestMerge(client *Client, repo ghrepo.Interface, pr *PullRequest, m PullRequestMergeMethod, body *string) error {
 	mergeMethod := githubv4.PullRequestMergeMethodMerge
 	switch m {
 	case PullRequestMergeMethodRebase:
@@ -1169,6 +1169,10 @@ func PullRequestMerge(client *Client, repo ghrepo.Interface, pr *PullRequest, m 
 	if m == PullRequestMergeMethodSquash {
 		commitHeadline := githubv4.String(fmt.Sprintf("%s (#%d)", pr.Title, pr.Number))
 		input.CommitHeadline = &commitHeadline
+	}
+	if body != nil {
+		commitBody := githubv4.String(*body)
+		input.CommitBody = &commitBody
 	}
 
 	variables := map[string]interface{}{

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -27,11 +27,12 @@ import (
 
 func Test_NewCmdMerge(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    string
-		isTTY   bool
-		want    MergeOptions
-		wantErr string
+		name     string
+		args     string
+		isTTY    bool
+		want     MergeOptions
+		wantBody string
+		wantErr  string
 	}{
 		{
 			name:  "number argument",
@@ -58,6 +59,20 @@ func Test_NewCmdMerge(t *testing.T) {
 				MergeMethod:             api.PullRequestMergeMethodMerge,
 				InteractiveMode:         true,
 			},
+		},
+		{
+			name:  "body",
+			args:  "123 -bcool",
+			isTTY: true,
+			want: MergeOptions{
+				SelectorArg:             "123",
+				DeleteBranch:            false,
+				IsDeleteBranchIndicated: false,
+				CanDeleteLocalBranch:    true,
+				MergeMethod:             api.PullRequestMergeMethodMerge,
+				InteractiveMode:         true,
+			},
+			wantBody: "cool",
 		},
 		{
 			name:    "no argument with --repo override",
@@ -123,6 +138,12 @@ func Test_NewCmdMerge(t *testing.T) {
 			assert.Equal(t, tt.want.CanDeleteLocalBranch, opts.CanDeleteLocalBranch)
 			assert.Equal(t, tt.want.MergeMethod, opts.MergeMethod)
 			assert.Equal(t, tt.want.InteractiveMode, opts.InteractiveMode)
+
+			if tt.wantBody == "" {
+				assert.Nil(t, opts.Body)
+			} else {
+				assert.Equal(t, tt.wantBody, *opts.Body)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This allows the user to specify the contents of the commit message when merging.

Especially useful when squashing commits, where github by default will contact the message of all commits into the body.

partially addresses #1023 