### PR TITLE
Update notifier: avoid false positives when gh is built from source

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -3,6 +3,9 @@ package update
 import (
 	"fmt"
 	"io/ioutil"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cli/cli/api"
@@ -10,6 +13,8 @@ import (
 	"github.com/hashicorp/go-version"
 	"gopkg.in/yaml.v3"
 )
+
+var gitDescribeSuffixRE = regexp.MustCompile(`\d+-\d+-g[a-f0-9]{8}$`)
 
 // ReleaseInfo stores information about a release
 type ReleaseInfo struct {
@@ -83,6 +88,12 @@ func setStateEntry(stateFilePath string, t time.Time, r ReleaseInfo) error {
 }
 
 func versionGreaterThan(v, w string) bool {
+	w = gitDescribeSuffixRE.ReplaceAllStringFunc(w, func(m string) string {
+		idx := strings.IndexRune(m, '-')
+		n, _ := strconv.Atoi(m[0:idx])
+		return fmt.Sprintf("%d-pre.0", n+1)
+	})
+
 	vv, ve := version.NewVersion(v)
 	vw, we := version.NewVersion(w)
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -34,6 +34,27 @@ func TestCheckForUpdate(t *testing.T) {
 			ExpectsResult:  true,
 		},
 		{
+			Name:           "current is built from source",
+			CurrentVersion: "v1.2.3-123-gdeadbeef",
+			LatestVersion:  "v1.2.3",
+			LatestURL:      "https://www.spacejam.com/archive/spacejam/movie/jam.htm",
+			ExpectsResult:  false,
+		},
+		{
+			Name:           "current is built from source after a prerelease",
+			CurrentVersion: "v1.2.3-rc.1-123-gdeadbeef",
+			LatestVersion:  "v1.2.3",
+			LatestURL:      "https://www.spacejam.com/archive/spacejam/movie/jam.htm",
+			ExpectsResult:  true,
+		},
+		{
+			Name:           "latest is newer than version build from source",
+			CurrentVersion: "v1.2.3-123-gdeadbeef",
+			LatestVersion:  "v1.2.4",
+			LatestURL:      "https://www.spacejam.com/archive/spacejam/movie/jam.htm",
+			ExpectsResult:  true,
+		},
+		{
 			Name:           "latest is current",
 			CurrentVersion: "v1.0.0",
 			LatestVersion:  "v1.0.0",


### PR DESCRIPTION
When gh was built from source, the version number will look something like this since it's taken from `git describe`:

    v1.4.0-34-g{SHA}

When compared as semver against `v1.4.0`, the latter version is falsely reported as newer. This is because the output of `git describe` wasn't meant to be interpreted as semver.

The solution is to translate the `git describe` string to faux-semver so it can be safely compared with the version reported from the server.

Fixes this case:

    A new release of gh is available: v1.4.0-41-g2f9e4cb1 → v1.4.0
    https://github.com/cli/cli/releases/tag/v1.4.0
