### PR TITLE
Remove use of deprecated test.InitCmdStubber

### DIFF
--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -98,24 +98,18 @@ func TestPRCreate_nontty_web(t *testing.T) {
 
 	http.StubRepoInfoResponse("OWNER", "REPO", "master")
 
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
 
-	cs.Stub("")                                         // git status
-	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
-	cs.Stub("")                                         // browser
+	cs.Register(`git status --porcelain`, 0, "")
+	cs.Register(`git -c log.ShowSignature=false log --pretty=format:%H,%s --cherry origin/master...feature`, 0, "")
+	cs.Register(``, 0, "") // browser
 
 	output, err := runCommand(http, nil, "feature", false, `--web --head=feature`)
 	require.NoError(t, err)
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, "", output.Stderr())
-
-	assert.Equal(t, 3, len(cs.Calls))
-	browserCall := cs.Calls[2].Args
-	assert.Equal(t, "https://github.com/OWNER/REPO/compare/master...feature?expand=1", browserCall[len(browserCall)-1])
-
 }
 
 func TestPRCreate_nontty_insufficient_flags(t *testing.T) {
@@ -168,12 +162,11 @@ func TestPRCreate_recover(t *testing.T) {
 			assert.Equal(t, "recovered body", input["body"].(string))
 		}))
 
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
 
-	cs.Stub("")                                         // git status
-	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
+	cs.Register(`git status --porcelain`, 0, "")
+	cs.Register(`git -c log.ShowSignature=false log --pretty=format:\%H,\%s --cherry origin/master...feature`, 0, "")
 
 	as, teardown := prompt.InitAskStubber()
 	defer teardown()
@@ -245,12 +238,10 @@ func TestPRCreate_nontty(t *testing.T) {
 			}),
 	)
 
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
 
-	cs.Stub("")                                         // git status
-	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
+	cs.Register(`git status --porcelain`, 0, "")
 
 	output, err := runCommand(http, nil, "feature", false, `-t "my title" -b "my body" -H feature`)
 	require.NoError(t, err)
@@ -288,15 +279,13 @@ func TestPRCreate(t *testing.T) {
 			assert.Equal(t, "feature", input["headRefName"].(string))
 		}))
 
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
 
-	cs.Stub("")                                         // git config --get-regexp (determineTrackingBranch)
-	cs.Stub("")                                         // git show-ref --verify   (determineTrackingBranch)
-	cs.Stub("")                                         // git status
-	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
-	cs.Stub("")                                         // git push
+	cs.Register(`git status --porcelain`, 0, "")
+	cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
+	cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
 
 	ask, cleanupAsk := prompt.InitAskStubber()
 	defer cleanupAsk()
@@ -396,15 +385,14 @@ func TestPRCreate_createFork(t *testing.T) {
 			assert.Equal(t, "monalisa:feature", input["headRefName"].(string))
 		}))
 
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
 
-	cs.Stub("") // git config --get-regexp (determineTrackingBranch)
-	cs.Stub("") // git show-ref --verify   (determineTrackingBranch)
-	cs.Stub("") // git status
-	cs.Stub("") // git remote add
-	cs.Stub("") // git push
+	cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
+	cs.Register(`git status --porcelain`, 0, "")
+	cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git remote add -f fork https://github.com/monalisa/REPO.git`, 0, "")
+	cs.Register(`git push --set-upstream fork HEAD:feature`, 0, "")
 
 	ask, cleanupAsk := prompt.InitAskStubber()
 	defer cleanupAsk()
@@ -412,9 +400,6 @@ func TestPRCreate_createFork(t *testing.T) {
 
 	output, err := runCommand(http, nil, "feature", true, `-t title -b body`)
 	require.NoError(t, err)
-
-	assert.Equal(t, []string{"git", "remote", "add", "-f", "fork", "https://github.com/monalisa/REPO.git"}, cs.Calls[3].Args)
-	assert.Equal(t, []string{"git", "push", "--set-upstream", "fork", "HEAD:feature"}, cs.Calls[4].Args)
 
 	assert.Equal(t, "https://github.com/OWNER/REPO/pull/12\n", output.String())
 }
@@ -548,12 +533,11 @@ func TestPRCreate_nonLegacyTemplate(t *testing.T) {
 			assert.Equal(t, "- commit 1\n- commit 0\n\nFixes a bug and Closes an issue", input["body"].(string))
 		}))
 
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
 
-	cs.Stub("")                                         // git status
-	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
+	cs.Register(`git -c log.ShowSignature=false log --pretty=format:%H,%s --cherry origin/master...feature`, 0, "1234567890,commit 0\n2345678901,commit 1")
+	cs.Register(`git status --porcelain`, 0, "")
 
 	as, teardown := prompt.InitAskStubber()
 	defer teardown()
@@ -682,13 +666,6 @@ func TestPRCreate_metadata(t *testing.T) {
 			assert.Equal(t, true, inputs["union"])
 		}))
 
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
-
-	cs.Stub("")                                         // git status
-	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
-
 	output, err := runCommand(http, nil, "feature", true, `-t TITLE -b BODY -H feature -a monalisa -l bug -l todo -p roadmap -m 'big one.oh' -r hubot -r monalisa -r /core -r /robots`)
 	assert.NoError(t, err)
 
@@ -710,15 +687,7 @@ func TestPRCreate_alreadyExists(t *testing.T) {
 			] } } } }`),
 	)
 
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
-
-	cs.Stub("") // git config --get-regexp (determineTrackingBranch)
-	cs.Stub("") // git show-ref --verify   (determineTrackingBranch)
-	cs.Stub("") // git status
-
-	_, err := runCommand(http, nil, "feature", true, `-ttitle -bbody -H feature`)
+	_, err := runCommand(http, nil, "feature", true, `-title -body -H feature`)
 	if err == nil {
 		t.Fatal("error expected, got nil")
 	}
@@ -737,16 +706,15 @@ func TestPRCreate_web(t *testing.T) {
 		httpmock.GraphQL(`query UserCurrent\b`),
 		httpmock.StringResponse(`{"data": {"viewer": {"login": "OWNER"} } }`))
 
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
 
-	cs.Stub("")                                         // git config --get-regexp (determineTrackingBranch)
-	cs.Stub("")                                         // git show-ref --verify   (determineTrackingBranch)
-	cs.Stub("")                                         // git status
-	cs.Stub("1234567890,commit 0\n2345678901,commit 1") // git log
-	cs.Stub("")                                         // git push
-	cs.Stub("")                                         // browser
+	cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
+	cs.Register(`git status --porcelain`, 0, "")
+	cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git -c log.ShowSignature=false log --pretty=format:%H,%s --cherry origin/master...feature`, 0, "")
+	cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
+	cs.Register(``, 0, "") // browser
 
 	ask, cleanupAsk := prompt.InitAskStubber()
 	defer cleanupAsk()
@@ -757,11 +725,6 @@ func TestPRCreate_web(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, "Opening github.com/OWNER/REPO/compare/master...feature in your browser.\n", output.Stderr())
-
-	assert.Equal(t, 6, len(cs.Calls))
-	assert.Equal(t, "git push --set-upstream origin HEAD:feature", strings.Join(cs.Calls[4].Args, " "))
-	browserCall := cs.Calls[5].Args
-	assert.Equal(t, "https://github.com/OWNER/REPO/compare/master...feature?expand=1", browserCall[len(browserCall)-1])
 }
 
 func TestPRCreate_webProject(t *testing.T) {
@@ -823,14 +786,13 @@ func TestPRCreate_webProject(t *testing.T) {
 }
 
 func Test_determineTrackingBranch_empty(t *testing.T) {
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
+	cs.Register(`git show-ref --verify -- HEAD`, 0, "abc HEAD")
 
 	remotes := context.Remotes{}
-
-	cs.Stub("")              // git config --get-regexp (ReadBranchConfig)
-	cs.Stub("deadbeef HEAD") // git show-ref --verify   (ShowRefs)
 
 	ref := determineTrackingBranch(remotes, "feature")
 	if ref != nil {
@@ -839,9 +801,11 @@ func Test_determineTrackingBranch_empty(t *testing.T) {
 }
 
 func Test_determineTrackingBranch_noMatch(t *testing.T) {
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
+	cs.Register("git show-ref --verify -- HEAD refs/remotes/origin/feature refs/remotes/upstream/feature", 0, "abc HEAD\nbca refs/remotes/origin/feature")
 
 	remotes := context.Remotes{
 		&context.Remote{
@@ -853,10 +817,6 @@ func Test_determineTrackingBranch_noMatch(t *testing.T) {
 			Repo:   ghrepo.New("octocat", "Spoon-Knife"),
 		},
 	}
-
-	cs.Stub("") // git config --get-regexp (ReadBranchConfig)
-	cs.Stub(`deadbeef HEAD
-deadb00f refs/remotes/origin/feature`) // git show-ref --verify (ShowRefs)
 
 	ref := determineTrackingBranch(remotes, "feature")
 	if ref != nil {
@@ -865,9 +825,11 @@ deadb00f refs/remotes/origin/feature`) // git show-ref --verify (ShowRefs)
 }
 
 func Test_determineTrackingBranch_hasMatch(t *testing.T) {
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
+	cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature refs/remotes/upstream/feature`, 0, "abc HEAD\nbca refs/remotes/origin/feature\nabc refs/remotes/upstream/feature")
 
 	remotes := context.Remotes{
 		&context.Remote{
@@ -880,26 +842,21 @@ func Test_determineTrackingBranch_hasMatch(t *testing.T) {
 		},
 	}
 
-	cs.Stub("") // git config --get-regexp (ReadBranchConfig)
-	cs.Stub(`deadbeef HEAD
-deadb00f refs/remotes/origin/feature
-deadbeef refs/remotes/upstream/feature`) // git show-ref --verify (ShowRefs)
-
 	ref := determineTrackingBranch(remotes, "feature")
 	if ref == nil {
 		t.Fatal("expected result, got nil")
 	}
-
-	assert.Equal(t, []string{"git", "show-ref", "--verify", "--", "HEAD", "refs/remotes/origin/feature", "refs/remotes/upstream/feature"}, cs.Calls[1].Args)
 
 	assert.Equal(t, "upstream", ref.RemoteName)
 	assert.Equal(t, "feature", ref.BranchName)
 }
 
 func Test_determineTrackingBranch_respectTrackingConfig(t *testing.T) {
-	//nolint:staticcheck // SA1019 TODO: rewrite to use run.Stub
-	cs, cmdTeardown := test.InitCmdStubber()
-	defer cmdTeardown()
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
+	cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "abc HEAD\nbca refs/remotes/origin/feature")
 
 	remotes := context.Remotes{
 		&context.Remote{
@@ -908,17 +865,10 @@ func Test_determineTrackingBranch_respectTrackingConfig(t *testing.T) {
 		},
 	}
 
-	cs.Stub(`branch.feature.remote origin
-branch.feature.merge refs/heads/great-feat`) // git config --get-regexp (ReadBranchConfig)
-	cs.Stub(`deadbeef HEAD
-deadb00f refs/remotes/origin/feature`) // git show-ref --verify (ShowRefs)
-
 	ref := determineTrackingBranch(remotes, "feature")
 	if ref != nil {
 		t.Errorf("expected nil result, got %v", ref)
 	}
-
-	assert.Equal(t, []string{"git", "show-ref", "--verify", "--", "HEAD", "refs/remotes/origin/great-feat", "refs/remotes/origin/feature"}, cs.Calls[1].Args)
 }
 
 func Test_generateCompareURL(t *testing.T) {


### PR DESCRIPTION
Follow up to #2801 to cleanup the TODOs around deprecating test.InitCmdStubber.