### PR TITLE
run createrepo via docker

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -57,7 +57,7 @@ jobs:
           echo "moved ${#cards[@]} cards to the Done column"
       
       - name: Install packaging dependencies
-        run: sudo apt-get install -y createrepo rpm reprepro
+        run: sudo apt-get install -y rpm reprepro
       - name: Set up GPG
         run: |
           gpg --import --no-tty --batch --yes < script/pubkey.asc

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -74,7 +74,7 @@ jobs:
           mkdir -p site/packages/rpm
           cp dist/*.rpm site/packages/rpm/
           ./script/createrepo.sh
-          mv repodata site/packages/rpm/
+          cp -r repodata site/packages/rpm/
           pushd site/packages/rpm
           gpg --yes --detach-sign --armor repodata/repomd.xml
           popd

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -73,7 +73,8 @@ jobs:
         run: |
           mkdir -p site/packages/rpm
           cp dist/*.rpm site/packages/rpm/
-          createrepo site/packages/rpm
+          ./script/createrepo.sh
+          mv repodata site/packages/rpm/
           pushd site/packages/rpm
           gpg --yes --detach-sign --armor repodata/repomd.xml
           popd

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -74,7 +74,7 @@ jobs:
           mkdir -p site/packages/rpm
           cp dist/*.rpm site/packages/rpm/
           ./script/createrepo.sh
-          cp -r repodata site/packages/rpm/
+          cp -r dist/repodata site/packages/rpm/
           pushd site/packages/rpm
           gpg --yes --detach-sign --armor repodata/repomd.xml
           popd

--- a/script/createrepo.sh
+++ b/script/createrepo.sh
@@ -22,3 +22,4 @@ docker build -t createrepo createrepo/
 docker create -ti --name runcreaterepo createrepo bash
 docker cp runcreaterepo:/packages/repodata .
 docker rm -f runcreaterepo
+rm -rf createrepo

--- a/script/createrepo.sh
+++ b/script/createrepo.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+# This script:
+
+# - creates a dockerfile
+# - prepares a docker image that can run `createrepo` that has the latest release rpms
+# - "runs" the image by creating a throwaay container
+# - copies the result of createrepo out of the throwaway container
+# - destroys the throwaway container
+mkdir -p createrepo/dist
+cat > createrepo/Dockerfile << EOF
+FROM fedora:32
+RUN yum install -y createrepo_c
+RUN mkdir /packages
+CMD touch /tmp/foo
+COPY dist/*.rpm /packages/
+RUN createrepo /packages
+EOF
+
+cp dist/*.rpm createrepo/dist/
+docker build -t createrepo createrepo/
+docker create -ti --name runcreaterepo createrepo bash
+docker cp runcreaterepo:/packages/repodata .
+docker rm -f runcreaterepo

--- a/script/createrepo.sh
+++ b/script/createrepo.sh
@@ -12,7 +12,6 @@ cat > createrepo/Dockerfile << EOF
 FROM fedora:32
 RUN yum install -y createrepo_c
 RUN mkdir /packages
-CMD touch /tmp/foo
 COPY dist/*.rpm /packages/
 RUN createrepo /packages
 EOF


### PR DESCRIPTION
Fixes #2851

As of Ubuntu 20.04, the `createrepo` command is no longer installable via official packages.

We'd like to run our linux packaging automation on Ubuntu 20.04, so we needed a new way of running
`createrepo` until it's re-packaged in Ubuntu 21.04.

This PR adds a script that users Docker to run a precompiled C version of createrepo in a Fedora
environment.

**OPEN QUESTION** : should we speed up the docker stuff, here? In theory I'd like to avoid having to re-pull the fedora base every run of our release pipeline. Is a docker hub image the answer? or is there another approach? I'll point out though that it didn't "feel" like it took that long in my prerelease test runs.