### PR TITLE
Docs: add note related to installation on Fedora Silverblue (#1747)

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -46,6 +46,8 @@ sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.re
 sudo dnf install gh
 ```
 
+**Note**: In case of immutable operating systems like Fedora Silverblue, it is recommended to install `gh` within a [toolbox container](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox).
+
 Upgrade:
 
 ```bash


### PR DESCRIPTION
Adding a note to the install instructions to avoid issues like #1747.

*Background:* Fedora Silverblue doesn't encourage installing tools within the host operating system if it can be avoided.
Recommended way of installing tooling as inteded by the authors is within a [toolbox container](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/).