### PR TITLE
Allow editing commit msg when squash merging a PR

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -116,11 +116,9 @@ type PullRequest struct {
 	Milestone struct {
 		Title string
 	}
-	Comments                Comments
-	ReactionGroups          ReactionGroups
-	Reviews                 PullRequestReviews
-	ViewerMergeBodyText     string
-	ViewerMergeHeadlineText string
+	Comments       Comments
+	ReactionGroups ReactionGroups
+	Reviews        PullRequestReviews
 }
 
 type NotFoundError struct {
@@ -598,8 +596,6 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 				milestone{
 					title
 				}
-				viewerMergeBodyText
-				viewerMergeHeadlineText
 				` + commentsFragment() + `
 				` + reactionGroupsFragment() + `
 			}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -116,9 +116,11 @@ type PullRequest struct {
 	Milestone struct {
 		Title string
 	}
-	Comments       Comments
-	ReactionGroups ReactionGroups
-	Reviews        PullRequestReviews
+	Comments                Comments
+	ReactionGroups          ReactionGroups
+	Reviews                 PullRequestReviews
+	ViewerMergeBodyText     string
+	ViewerMergeHeadlineText string
 }
 
 type NotFoundError struct {
@@ -596,6 +598,8 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 				milestone{
 					title
 				}
+				viewerMergeBodyText
+				viewerMergeHeadlineText
 				` + commentsFragment() + `
 				` + reactionGroupsFragment() + `
 			}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -116,9 +116,10 @@ type PullRequest struct {
 	Milestone struct {
 		Title string
 	}
-	Comments       Comments
-	ReactionGroups ReactionGroups
-	Reviews        PullRequestReviews
+	Comments            Comments
+	ReactionGroups      ReactionGroups
+	Reviews             PullRequestReviews
+	ViewerMergeBodyText string
 }
 
 type NotFoundError struct {
@@ -596,6 +597,7 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 				milestone{
 					title
 				}
+				viewerMergeBodyText
 				` + commentsFragment() + `
 				` + reactionGroupsFragment() + `
 			}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -38,7 +38,7 @@ type PullRequest struct {
 	HeadRefName         string
 	Body                string
 	Mergeable           string
-  ViewerMergeBodyText string
+	ViewerMergeBodyText string
 
 	Author struct {
 		Login string

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -32,8 +32,7 @@ type MergeOptions struct {
 	DeleteBranch bool
 	MergeMethod  api.PullRequestMergeMethod
 
-	Body         string
-	BodyProvided bool
+	Body string
 
 	IsDeleteBranchIndicated bool
 	CanDeleteLocalBranch    bool
@@ -98,10 +97,6 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 
 			opts.IsDeleteBranchIndicated = cmd.Flags().Changed("delete-branch")
 			opts.CanDeleteLocalBranch = !cmd.Flags().Changed("repo")
-
-			if cmd.Flags().Changed("body") {
-				opts.BodyProvided = true
-			}
 
 			if runF != nil {
 				return runF(opts)
@@ -169,7 +164,7 @@ func mergeRun(opts *MergeOptions) error {
 				return err
 			}
 
-			allowEditMsg := (mergeMethod != api.PullRequestMergeMethodRebase) && !opts.BodyProvided
+			allowEditMsg := mergeMethod != api.PullRequestMergeMethodRebase
 
 			action, err := confirmSurvey(allowEditMsg)
 			if err != nil {
@@ -183,7 +178,7 @@ func mergeRun(opts *MergeOptions) error {
 					return err
 				}
 
-				if !opts.BodyProvided {
+				if opts.Body == "" {
 					if mergeMethod == api.PullRequestMergeMethodMerge {
 						opts.Body = pr.Title
 					} else {
@@ -196,7 +191,6 @@ func mergeRun(opts *MergeOptions) error {
 					return err
 				}
 				opts.Body = msg
-				opts.BodyProvided = true
 
 				action, err = confirmSurvey(false)
 				if err != nil {
@@ -210,7 +204,7 @@ func mergeRun(opts *MergeOptions) error {
 		}
 
 		var body *string
-		if opts.BodyProvided {
+		if opts.Body != "" {
 			body = &opts.Body
 		}
 

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -183,7 +183,15 @@ func mergeRun(opts *MergeOptions) error {
 					return err
 				}
 
-				msg, err := commitMsgSurvey(editorCommand)
+				if !opts.BodyProvided {
+					if mergeMethod == api.PullRequestMergeMethodMerge {
+						opts.Body = pr.Title
+					} else {
+						opts.Body = pr.ViewerMergeBodyText
+					}
+				}
+
+				msg, err := commitMsgSurvey(opts.Body, editorCommand)
 				if err != nil {
 					return err
 				}
@@ -378,13 +386,15 @@ func confirmSurvey(allowEditMsg bool) (shared.Action, error) {
 	}
 }
 
-func commitMsgSurvey(editorCommand string) (string, error) {
+func commitMsgSurvey(msg string, editorCommand string) (string, error) {
 	var result string
 	q := &surveyext.GhEditor{
 		EditorCommand: editorCommand,
 		Editor: &survey.Editor{
-			Message:  "Body",
-			FileName: "*.md",
+			Message:       "Body",
+			AppendDefault: true,
+			Default:       msg,
+			FileName:      "*.md",
 		},
 	}
 	err := prompt.SurveyAskOne(q, &result)

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -71,7 +71,6 @@ func Test_NewCmdMerge(t *testing.T) {
 				MergeMethod:             api.PullRequestMergeMethodMerge,
 				InteractiveMode:         true,
 				Body:                    "cool",
-				BodyProvided:            true,
 			},
 		},
 		{
@@ -139,7 +138,6 @@ func Test_NewCmdMerge(t *testing.T) {
 			assert.Equal(t, tt.want.MergeMethod, opts.MergeMethod)
 			assert.Equal(t, tt.want.InteractiveMode, opts.InteractiveMode)
 			assert.Equal(t, tt.want.Body, opts.Body)
-			assert.Equal(t, tt.want.BodyProvided, opts.BodyProvided)
 		})
 	}
 }

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -27,12 +27,11 @@ import (
 
 func Test_NewCmdMerge(t *testing.T) {
 	tests := []struct {
-		name     string
-		args     string
-		isTTY    bool
-		want     MergeOptions
-		wantBody string
-		wantErr  string
+		name    string
+		args    string
+		isTTY   bool
+		want    MergeOptions
+		wantErr string
 	}{
 		{
 			name:  "number argument",
@@ -71,8 +70,9 @@ func Test_NewCmdMerge(t *testing.T) {
 				CanDeleteLocalBranch:    true,
 				MergeMethod:             api.PullRequestMergeMethodMerge,
 				InteractiveMode:         true,
+				Body:                    "cool",
+				BodyProvided:            true,
 			},
-			wantBody: "cool",
 		},
 		{
 			name:    "no argument with --repo override",
@@ -138,12 +138,8 @@ func Test_NewCmdMerge(t *testing.T) {
 			assert.Equal(t, tt.want.CanDeleteLocalBranch, opts.CanDeleteLocalBranch)
 			assert.Equal(t, tt.want.MergeMethod, opts.MergeMethod)
 			assert.Equal(t, tt.want.InteractiveMode, opts.InteractiveMode)
-
-			if tt.wantBody == "" {
-				assert.Nil(t, opts.Body)
-			} else {
-				assert.Equal(t, tt.wantBody, *opts.Body)
-			}
+			assert.Equal(t, tt.want.Body, opts.Body)
+			assert.Equal(t, tt.want.BodyProvided, opts.BodyProvided)
 		})
 	}
 }
@@ -610,30 +606,19 @@ func TestPRMerge_interactive(t *testing.T) {
 			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 			assert.NotContains(t, input, "commitHeadline")
 		}))
-	http.Register(
-		httpmock.REST("DELETE", "repos/OWNER/REPO/git/refs/heads/blueberries"),
-		httpmock.StringResponse(`{}`))
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
 	cs.Register("git -c log.ShowSignature=false log --pretty=format:%H,%s -1", 0, "")
 	cs.Register(`git config --get-regexp.+branch\\\.blueberries\\\.`, 0, "")
-	cs.Register(`git checkout master`, 0, "")
-	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
-	cs.Register(`git branch -D blueberries`, 0, "")
 
 	as, surveyTeardown := prompt.InitAskStubber()
 	defer surveyTeardown()
 
-	as.StubOne(0)                   // Merge method survey
-	as.StubOne(true)                // Delete branch survey
-	as.Stub([]*prompt.QuestionStub{ // Confirm submit survey
-		{
-			Name:  "confirmation",
-			Value: 0,
-		},
-	})
+	as.StubOne(0)        // Merge method survey
+	as.StubOne(false)    // Delete branch survey
+	as.StubOne("Submit") // Confirm submit survey
 
 	output, err := runCommand(http, "blueberries", true, "")
 	if err != nil {
@@ -687,14 +672,8 @@ func TestPRMerge_interactiveWithDeleteBranch(t *testing.T) {
 	as, surveyTeardown := prompt.InitAskStubber()
 	defer surveyTeardown()
 
-	as.StubOne(0)                   // Merge method survey
-	as.StubOne(true)                // Confirm submit survey
-	as.Stub([]*prompt.QuestionStub{ // Confirm submit survey
-		{
-			Name:  "confirmation",
-			Value: 0,
-		},
-	})
+	as.StubOne(0)        // Merge method survey
+	as.StubOne("Submit") // Confirm submit survey
 
 	output, err := runCommand(http, "blueberries", true, "-d")
 	if err != nil {
@@ -715,7 +694,8 @@ func TestPRMerge_interactiveSquashEditCommitMsg(t *testing.T) {
 			"headRefName": "blueberries",
 			"headRepositoryOwner": {"login": "OWNER"},
 			"id": "THE-ID",
-			"number": 3
+			"number": 3,
+			"title": "title"
 		}] } } } }`))
 	http.Register(
 		httpmock.GraphQL(`query RepositoryInfo\b`),
@@ -741,100 +721,18 @@ func TestPRMerge_interactiveSquashEditCommitMsg(t *testing.T) {
 	as, surveyTeardown := prompt.InitAskStubber()
 	defer surveyTeardown()
 
-	as.StubOne(2)                   // Merge method survey
-	as.StubOne(false)               // Delete branch survey
-	as.Stub([]*prompt.QuestionStub{ // Confirm submit survey
-		{
-			Name:  "confirmation",
-			Value: 1,
-		},
-	})
-	as.Stub([]*prompt.QuestionStub{ // Edit Commit Msg editor survey
-		{
-			Name:  "body",
-			Value: "cool story",
-		},
-	})
-	as.Stub([]*prompt.QuestionStub{ // Confirm submit survey
-		{
-			Name:  "confirmation",
-			Value: 0,
-		},
-	})
+	as.StubOne(2)                     // Merge method survey
+	as.StubOne(false)                 // Delete branch survey
+	as.StubOne("Edit commit message") // Confirm submit survey
+	as.StubOne("cool story")          // Edit commit message survey
+	as.StubOne("Submit")              // Confirm submit survey
 
 	output, err := runCommand(http, "blueberries", true, "")
 	if err != nil {
 		t.Fatalf("Got unexpected error running `pr merge` %s", err)
 	}
 
-	assert.Equal(t, "✔ Squashed and merged pull request #3 ()\n", output.Stderr())
-}
-
-func TestPRMerge_interactiveSquashEditCommitMsgDefaultBody(t *testing.T) {
-	http := initFakeHTTP()
-	defer http.Verify(t)
-	http.Register(
-		httpmock.GraphQL(`query PullRequestForBranch\b`),
-		httpmock.StringResponse(`
-		{ "data": { "repository": { "pullRequests": { "nodes": [{
-			"headRefName": "blueberries",
-			"headRepositoryOwner": {"login": "OWNER"},
-			"id": "THE-ID",
-			"number": 3,
-			"viewerMergeBodyText": "Co-authored by: Octocat <octocat@github.com>",
-			"viewerMergeHeadlineText": "Add new feat (#33)"
-		}] } } } }`))
-	http.Register(
-		httpmock.GraphQL(`query RepositoryInfo\b`),
-		httpmock.StringResponse(`
-		{ "data": { "repository": {
-			"mergeCommitAllowed": true,
-			"rebaseMergeAllowed": true,
-			"squashMergeAllowed": true
-		} } }`))
-	http.Register(
-		httpmock.GraphQL(`mutation PullRequestMerge\b`),
-		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
-			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
-			assert.Equal(t, "SQUASH", input["mergeMethod"].(string))
-			assert.Equal(t, "Add new feat (#33)\n\nCo-authored by: Octocat <octocat@github.com>", input["commitBody"])
-		}))
-
-	cs, cmdTeardown := run.Stub()
-	defer cmdTeardown(t)
-
-	cs.Register(`git config --get-regexp.+branch\\\.blueberries\\\.`, 0, "")
-
-	as, surveyTeardown := prompt.InitAskStubber()
-	defer surveyTeardown()
-
-	as.StubOne(2)                   // Merge method survey
-	as.StubOne(false)               // Delete branch survey
-	as.Stub([]*prompt.QuestionStub{ // Confirm submit survey
-		{
-			Name:  "confirmation",
-			Value: 1,
-		},
-	})
-	as.Stub([]*prompt.QuestionStub{ // Edit Commit Msg editor survey
-		{
-			Name:    "body",
-			Default: true,
-		},
-	})
-	as.Stub([]*prompt.QuestionStub{ // Confirm submit survey
-		{
-			Name:  "confirmation",
-			Value: 0,
-		},
-	})
-
-	output, err := runCommand(http, "blueberries", true, "")
-	if err != nil {
-		t.Fatalf("Got unexpected error running `pr merge` %s", err)
-	}
-
-	assert.Equal(t, "✔ Squashed and merged pull request #3 ()\n", output.Stderr())
+	assert.Equal(t, "✓ Squashed and merged pull request #3 (title)\n", output.Stderr())
 }
 
 func TestPRMerge_interactiveCancelled(t *testing.T) {
@@ -867,14 +765,9 @@ func TestPRMerge_interactiveCancelled(t *testing.T) {
 	as, surveyTeardown := prompt.InitAskStubber()
 	defer surveyTeardown()
 
-	as.StubOne(0)                   // Merge method survey
-	as.StubOne(true)                // Delete branch survey
-	as.Stub([]*prompt.QuestionStub{ // Confirm submit survey
-		{
-			Name:  "confirmation",
-			Value: 2,
-		},
-	})
+	as.StubOne(0)        // Merge method survey
+	as.StubOne(true)     // Delete branch survey
+	as.StubOne("Cancel") // Confirm submit survey
 
 	output, err := runCommand(http, "blueberries", true, "")
 	if !errors.Is(err, cmdutil.SilentError) {

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -716,6 +716,7 @@ func TestPRMerge_interactiveSquashEditCommitMsg(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
+	cs.Register("git -c log.ShowSignature=false log --pretty=format:%H,%s -1", 0, "")
 	cs.Register(`git config --get-regexp.+branch\\\.blueberries\\\.`, 0, "")
 
 	as, surveyTeardown := prompt.InitAskStubber()

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -21,6 +21,7 @@ const (
 	PreviewAction
 	CancelAction
 	MetadataAction
+	EditCommitMessageAction
 
 	noMilestone = "(none)"
 )


### PR DESCRIPTION
Closes #1023 

This PR adds support for editing the commit message when squash merging a PR.

Spec: https://github.com/cli/cli/issues/1023#issuecomment-765799502
> The spec for this is converting the confirmation prompt from a y/N prompt to a select with options:

> Submit
  Edit Commit Message
  Edit Commit Author
  Cancel

The GraphQL API fails when trying to merge a PR with `authorEmail` field set, so I avoided adding it for now, would be great if anyone in the `cli` team can help reporting this to GitHub.
https://github.community/t/graphql-api-fails-when-trying-to-merge-a-pull-request-with-authoremail-field-set/158421