### PR TITLE
Suggest `brew upgrade gh` when new version detected

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -18,8 +18,9 @@ var gitDescribeSuffixRE = regexp.MustCompile(`\d+-\d+-g[a-f0-9]{8}$`)
 
 // ReleaseInfo stores information about a release
 type ReleaseInfo struct {
-	Version string `json:"tag_name"`
-	URL     string `json:"html_url"`
+	Version     string    `json:"tag_name"`
+	URL         string    `json:"html_url"`
+	PublishedAt time.Time `json:"published_at"`
 }
 
 type StateEntry struct {


### PR DESCRIPTION
When the update notifier is enabled and a new version was detected, show a Homebrew upgrade notice if:
- the release was at least 24 hours ago; and
- the current `gh` binary is under the Homebrew prefix.

<img width="476" alt="Screen Shot 2021-02-08 at 13 56 41" src="https://user-images.githubusercontent.com/887/107223562-9d8cb080-6a16-11eb-8e2a-def0d90cfa17.png">

Followup TODO:
- [x] Submit a PR to homebrew-core to enable our update notifier

Fixes #2855, ref. #166
