### PR TITLE
Edit pull request command

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -835,6 +835,34 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 	return pr, nil
 }
 
+func UpdatePullRequest(client *Client, repo ghrepo.Interface, params githubv4.UpdatePullRequestInput) error {
+	var mutation struct {
+		UpdatePullRequest struct {
+			PullRequest struct {
+				ID string
+			}
+		} `graphql:"updatePullRequest(input: $input)"`
+	}
+	variables := map[string]interface{}{"input": params}
+	gql := graphQLClient(client.http, repo.RepoHost())
+	err := gql.MutateNamed(context.Background(), "PullRequestUpdate", &mutation, variables)
+	return err
+}
+
+func UpdatePullRequestReviews(client *Client, repo ghrepo.Interface, params githubv4.RequestReviewsInput) error {
+	var mutation struct {
+		RequestReviews struct {
+			PullRequest struct {
+				ID string
+			}
+		} `graphql:"requestReviews(input: $input)"`
+	}
+	variables := map[string]interface{}{"input": params}
+	gql := graphQLClient(client.http, repo.RepoHost())
+	err := gql.MutateNamed(context.Background(), "PullRequestUpdateRequestReviews", &mutation, variables)
+	return err
+}
+
 func isBlank(v interface{}) bool {
 	switch vv := v.(type) {
 	case string:

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -1,0 +1,259 @@
+package edit
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/context"
+	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/internal/ghrepo"
+	shared "github.com/cli/cli/pkg/cmd/pr/shared"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/shurcooL/githubv4"
+	"github.com/spf13/cobra"
+)
+
+type EditOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (ghrepo.Interface, error)
+	Remotes    func() (context.Remotes, error)
+	Branch     func() (string, error)
+
+	Surveyor        Surveyor
+	Fetcher         EditableOptionsFetcher
+	EditorRetriever EditorRetriever
+
+	SelectorArg string
+	Interactive bool
+
+	shared.Editable
+}
+
+func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Command {
+	opts := &EditOptions{
+		IO:              f.IOStreams,
+		HttpClient:      f.HttpClient,
+		Remotes:         f.Remotes,
+		Branch:          f.Branch,
+		Surveyor:        surveyor{},
+		Fetcher:         fetcher{},
+		EditorRetriever: editorRetriever{config: f.Config},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "edit {<number> | <url>}",
+		Short: "Edit a pull request",
+		Example: heredoc.Doc(`
+			$ gh pr edit 23 --title "I found a bug" --body "Nothing works"
+			$ gh pr edit 23 --label "bug,help wanted"
+			$ gh pr edit 23 --label bug --label "help wanted"
+			$ gh pr edit 23 --reviewer monalisa,hubot  --reviewer myorg/team-name
+			$ gh pr edit 23 --assignee monalisa,hubot
+			$ gh pr edit 23 --assignee @me
+			$ gh pr edit 23 --project "Roadmap"
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			opts.SelectorArg = args[0]
+
+			flags := cmd.Flags()
+			if flags.Changed("title") {
+				opts.Editable.TitleEdited = true
+			}
+			if flags.Changed("body") {
+				opts.Editable.BodyEdited = true
+			}
+			if flags.Changed("reviewer") {
+				opts.Editable.ReviewersEdited = true
+			}
+			if flags.Changed("assignee") {
+				opts.Editable.AssigneesEdited = true
+			}
+			if flags.Changed("label") {
+				opts.Editable.LabelsEdited = true
+			}
+			if flags.Changed("project") {
+				opts.Editable.ProjectsEdited = true
+			}
+			if flags.Changed("milestone") {
+				opts.Editable.MilestoneEdited = true
+			}
+
+			if !opts.Editable.Dirty() {
+				opts.Interactive = true
+			}
+
+			if opts.Interactive && !opts.IO.CanPrompt() {
+				return &cmdutil.FlagError{Err: errors.New("--tile, --body, --reviewer, --assignee, --label, --project, or --milestone required when not running interactively")}
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return editRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Editable.Title, "title", "t", "", "Revise the pr title.")
+	cmd.Flags().StringVarP(&opts.Editable.Body, "body", "b", "", "Revise the pr body.")
+	cmd.Flags().StringSliceVarP(&opts.Editable.Reviewers, "reviewer", "r", nil, "Request reviews from people or teams by their `handle`")
+	cmd.Flags().StringSliceVarP(&opts.Editable.Assignees, "assignee", "a", nil, "Set assigned people by their `login`. Use \"@me\" to self-assign.")
+	cmd.Flags().StringSliceVarP(&opts.Editable.Labels, "label", "l", nil, "Set the pr labels by `name`")
+	cmd.Flags().StringSliceVarP(&opts.Editable.Projects, "project", "p", nil, "Set the projects the pr belongs to by `name`")
+	cmd.Flags().StringVarP(&opts.Editable.Milestone, "milestone", "m", "", "Set the milestone the pr belongs to by `name`")
+
+	return cmd
+}
+
+func editRun(opts *EditOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+	apiClient := api.NewClientFromHTTP(httpClient)
+
+	pr, repo, err := shared.PRFromArgs(apiClient, opts.BaseRepo, opts.Branch, opts.Remotes, opts.SelectorArg)
+	if err != nil {
+		return err
+	}
+
+	editable := opts.Editable
+	editable.ReviewersAllowed = true
+	editable.TitleDefault = pr.Title
+	editable.BodyDefault = pr.Body
+	editable.ReviewersDefault = pr.ReviewRequests
+	editable.AssigneesDefault = pr.Assignees
+	editable.LabelsDefault = pr.Labels
+	editable.ProjectsDefault = pr.ProjectCards
+	editable.MilestoneDefault = pr.Milestone
+
+	if opts.Interactive {
+		err = opts.Surveyor.FieldsToEdit(&editable)
+		if err != nil {
+			return err
+		}
+	}
+
+	opts.IO.StartProgressIndicator()
+	err = opts.Fetcher.EditableOptionsFetch(apiClient, repo, &editable)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return err
+	}
+
+	if opts.Interactive {
+		editorCommand, err := opts.EditorRetriever.Retrieve()
+		if err != nil {
+			return err
+		}
+		err = opts.Surveyor.EditFields(&editable, editorCommand)
+		if err != nil {
+			return err
+		}
+	}
+
+	opts.IO.StartProgressIndicator()
+	err = updatePullRequest(apiClient, repo, pr.ID, editable)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(opts.IO.Out, pr.URL)
+
+	return nil
+}
+
+func updatePullRequest(client *api.Client, repo ghrepo.Interface, id string, editable shared.Editable) error {
+	var err error
+	params := githubv4.UpdatePullRequestInput{
+		PullRequestID: id,
+		Title:         editable.TitleParam(),
+		Body:          editable.BodyParam(),
+	}
+	params.AssigneeIDs, err = editable.AssigneesParam(client, repo)
+	if err != nil {
+		return err
+	}
+	params.LabelIDs, err = editable.LabelsParam()
+	if err != nil {
+		return err
+	}
+	params.ProjectIDs, err = editable.ProjectsParam()
+	if err != nil {
+		return err
+	}
+	params.MilestoneID, err = editable.MilestoneParam()
+	if err != nil {
+		return err
+	}
+	err = api.UpdatePullRequest(client, repo, params)
+	if err != nil {
+		return err
+	}
+	return updatePullRequestReviews(client, repo, id, editable)
+}
+
+func updatePullRequestReviews(client *api.Client, repo ghrepo.Interface, id string, editable shared.Editable) error {
+	if !editable.ReviewersEdited {
+		return nil
+	}
+	userIds, teamIds, err := editable.ReviewersParams()
+	if err != nil {
+		return err
+	}
+	union := githubv4.Boolean(false)
+	reviewsRequestParams := githubv4.RequestReviewsInput{
+		PullRequestID: id,
+		Union:         &union,
+		UserIDs:       userIds,
+		TeamIDs:       teamIds,
+	}
+	return api.UpdatePullRequestReviews(client, repo, reviewsRequestParams)
+}
+
+type Surveyor interface {
+	FieldsToEdit(*shared.Editable) error
+	EditFields(*shared.Editable, string) error
+}
+
+type surveyor struct{}
+
+func (s surveyor) FieldsToEdit(editable *shared.Editable) error {
+	return shared.FieldsToEditSurvey(editable)
+}
+
+func (s surveyor) EditFields(editable *shared.Editable, editorCmd string) error {
+	return shared.EditFieldsSurvey(editable, editorCmd)
+}
+
+type EditableOptionsFetcher interface {
+	EditableOptionsFetch(*api.Client, ghrepo.Interface, *shared.Editable) error
+}
+
+type fetcher struct{}
+
+func (f fetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable) error {
+	return shared.FetchOptions(client, repo, opts)
+}
+
+type EditorRetriever interface {
+	Retrieve() (string, error)
+}
+
+type editorRetriever struct {
+	config func() (config.Config, error)
+}
+
+func (e editorRetriever) Retrieve() (string, error) {
+	return cmdutil.DetermineEditor(e.config)
+}

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -8,6 +8,7 @@ import (
 	cmdComment "github.com/cli/cli/pkg/cmd/pr/comment"
 	cmdCreate "github.com/cli/cli/pkg/cmd/pr/create"
 	cmdDiff "github.com/cli/cli/pkg/cmd/pr/diff"
+	cmdEdit "github.com/cli/cli/pkg/cmd/pr/edit"
 	cmdList "github.com/cli/cli/pkg/cmd/pr/list"
 	cmdMerge "github.com/cli/cli/pkg/cmd/pr/merge"
 	cmdReady "github.com/cli/cli/pkg/cmd/pr/ready"
@@ -55,6 +56,7 @@ func NewCmdPR(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(cmdView.NewCmdView(f, nil))
 	cmd.AddCommand(cmdChecks.NewCmdChecks(f, nil))
 	cmd.AddCommand(cmdComment.NewCmdComment(f, nil))
+	cmd.AddCommand(cmdEdit.NewCmdEdit(f, nil))
 
 	return cmd
 }


### PR DESCRIPTION
This PR implements the  `pr edit` command allowing the ability to edit a pull request after it has been created. There are some small changes to the `issue edit` command due to refactoring and renaming in the shared `editable` code.  

<img width="949" alt="Screen Shot 2021-02-10 at 10 13 22 AM" src="https://user-images.githubusercontent.com/7969779/107552722-bcab4f80-6b88-11eb-80d9-da9a0987fc58.png">

<img width="763" alt="Screen Shot 2021-02-10 at 10 13 58 AM" src="https://user-images.githubusercontent.com/7969779/107552730-bf0da980-6b88-11eb-9b36-6402ea53916a.png">

closes https://github.com/cli/cli/issues/1349
follow ups https://github.com/cli/cli/pull/2949