### PR TITLE
Added new section to gh api examples for headers

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -116,6 +116,9 @@ original query accepts an '$endCursor: String' variable and that it fetches the
 			    }
 			  }
 			'
+			
+			$ etag="$(gh api -i https://api.github.com/users/defunkt | grep -i ^etag: | cut -d: -f2)"
+			$ gh api -i https://api.github.com/users/defunkt -H "If-None-Match:$etag"
 		`),
 		Annotations: map[string]string{
 			"help:environment": heredoc.Doc(`


### PR DESCRIPTION
Added example originally shared in #2941. Demonstrates passing an extra header to the API. This specific example turns the API call into a conditional request.

Not sure if this is an example you'd want to have in your documentation, but I figured that I'd draft it up since there aren't any other examples using the `gh api -H` tag. It surely would've helped me!