### PR TITLE
Change behavior of slice flags for issue edit and pr edit commands

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -49,11 +49,27 @@ type Assignees struct {
 	TotalCount int
 }
 
+func (a Assignees) Logins() []string {
+	logins := make([]string, len(a.Nodes))
+	for i, a := range a.Nodes {
+		logins[i] = a.Login
+	}
+	return logins
+}
+
 type Labels struct {
 	Nodes []struct {
 		Name string
 	}
 	TotalCount int
+}
+
+func (l Labels) Names() []string {
+	names := make([]string, len(l.Nodes))
+	for i, l := range l.Nodes {
+		names[i] = l.Name
+	}
+	return names
 }
 
 type ProjectCards struct {
@@ -66,6 +82,14 @@ type ProjectCards struct {
 		}
 	}
 	TotalCount int
+}
+
+func (p ProjectCards) ProjectNames() []string {
+	names := make([]string, len(p.Nodes))
+	for i, c := range p.Nodes {
+		names[i] = c.Project.Name
+	}
+	return names
 }
 
 type Milestone struct {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -80,32 +80,10 @@ type PullRequest struct {
 			}
 		}
 	}
-	Assignees struct {
-		Nodes []struct {
-			Login string
-		}
-		TotalCount int
-	}
-	Labels struct {
-		Nodes []struct {
-			Name string
-		}
-		TotalCount int
-	}
-	ProjectCards struct {
-		Nodes []struct {
-			Project struct {
-				Name string
-			}
-			Column struct {
-				Name string
-			}
-		}
-		TotalCount int
-	}
-	Milestone struct {
-		Title string
-	}
+	Assignees      Assignees
+	Labels         Labels
+	ProjectCards   ProjectCards
+	Milestone      Milestone
 	Comments       Comments
 	ReactionGroups ReactionGroups
 	Reviews        PullRequestReviews
@@ -121,6 +99,14 @@ type ReviewRequests struct {
 		}
 	}
 	TotalCount int
+}
+
+func (r ReviewRequests) Logins() []string {
+	logins := make([]string, len(r.Nodes))
+	for i, a := range r.Nodes {
+		logins[i] = a.RequestedReviewer.Login
+	}
+	return logins
 }
 
 type NotFoundError struct {
@@ -816,6 +802,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 		reviewParams["teamIds"] = ids
 	}
 
+	//TODO: How much work to extract this into own method and use for create and edit?
 	if len(reviewParams) > 0 {
 		reviewQuery := `
 		mutation PullRequestCreateRequestReviews($input: RequestReviewsInput!) {

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -497,7 +496,7 @@ func (m *RepoMetadataResult) MilestoneToID(title string) (string, error) {
 			return m.ID, nil
 		}
 	}
-	return "", errors.New("not found")
+	return "", fmt.Errorf("'%s' not found", title)
 }
 
 func (m *RepoMetadataResult) Merge(m2 *RepoMetadataResult) {

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -42,8 +42,10 @@ func TestNewCmdEdit(t *testing.T) {
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: prShared.Editable{
-					Title:       "test",
-					TitleEdited: true,
+					Title: prShared.EditableString{
+						Value:  "test",
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
@@ -54,44 +56,94 @@ func TestNewCmdEdit(t *testing.T) {
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: prShared.Editable{
-					Body:       "test",
-					BodyEdited: true,
+					Body: prShared.EditableString{
+						Value:  "test",
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
 		},
 		{
-			name:  "assignee flag",
-			input: "23 --assignee monalisa,hubot",
+			name:  "add-assignee flag",
+			input: "23 --add-assignee monalisa,hubot",
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: prShared.Editable{
-					Assignees:       []string{"monalisa", "hubot"},
-					AssigneesEdited: true,
+					Assignees: prShared.EditableSlice{
+						Add:    []string{"monalisa", "hubot"},
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
 		},
 		{
-			name:  "label flag",
-			input: "23 --label feature,TODO,bug",
+			name:  "remove-assignee flag",
+			input: "23 --remove-assignee monalisa,hubot",
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: prShared.Editable{
-					Labels:       []string{"feature", "TODO", "bug"},
-					LabelsEdited: true,
+					Assignees: prShared.EditableSlice{
+						Remove: []string{"monalisa", "hubot"},
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
 		},
 		{
-			name:  "project flag",
-			input: "23 --project Cleanup,Roadmap",
+			name:  "add-label flag",
+			input: "23 --add-label feature,TODO,bug",
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: prShared.Editable{
-					Projects:       []string{"Cleanup", "Roadmap"},
-					ProjectsEdited: true,
+					Labels: prShared.EditableSlice{
+						Add:    []string{"feature", "TODO", "bug"},
+						Edited: true,
+					},
+				},
+			},
+			wantsErr: false,
+		},
+		{
+			name:  "remove-label flag",
+			input: "23 --remove-label feature,TODO,bug",
+			output: EditOptions{
+				SelectorArg: "23",
+				Editable: prShared.Editable{
+					Labels: prShared.EditableSlice{
+						Remove: []string{"feature", "TODO", "bug"},
+						Edited: true,
+					},
+				},
+			},
+			wantsErr: false,
+		},
+		{
+			name:  "add-project flag",
+			input: "23 --add-project Cleanup,Roadmap",
+			output: EditOptions{
+				SelectorArg: "23",
+				Editable: prShared.Editable{
+					Projects: prShared.EditableSlice{
+						Add:    []string{"Cleanup", "Roadmap"},
+						Edited: true,
+					},
+				},
+			},
+			wantsErr: false,
+		},
+		{
+			name:  "remove-project flag",
+			input: "23 --remove-project Cleanup,Roadmap",
+			output: EditOptions{
+				SelectorArg: "23",
+				Editable: prShared.Editable{
+					Projects: prShared.EditableSlice{
+						Remove: []string{"Cleanup", "Roadmap"},
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
@@ -102,8 +154,10 @@ func TestNewCmdEdit(t *testing.T) {
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: prShared.Editable{
-					Milestone:       "GA",
-					MilestoneEdited: true,
+					Milestone: prShared.EditableString{
+						Value:  "GA",
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
@@ -163,18 +217,33 @@ func Test_editRun(t *testing.T) {
 				SelectorArg: "123",
 				Interactive: false,
 				Editable: prShared.Editable{
-					Title:           "new title",
-					TitleEdited:     true,
-					Body:            "new body",
-					BodyEdited:      true,
-					Assignees:       []string{"monalisa", "hubot"},
-					AssigneesEdited: true,
-					Labels:          []string{"feature", "TODO", "bug"},
-					LabelsEdited:    true,
-					Projects:        []string{"Cleanup", "Roadmap"},
-					ProjectsEdited:  true,
-					Milestone:       "GA",
-					MilestoneEdited: true,
+					Title: prShared.EditableString{
+						Value:  "new title",
+						Edited: true,
+					},
+					Body: prShared.EditableString{
+						Value:  "new body",
+						Edited: true,
+					},
+					Assignees: prShared.EditableSlice{
+						Add:    []string{"monalisa", "hubot"},
+						Remove: []string{"octocat"},
+						Edited: true,
+					},
+					Labels: prShared.EditableSlice{
+						Add:    []string{"feature", "TODO", "bug"},
+						Remove: []string{"docs"},
+						Edited: true,
+					},
+					Projects: prShared.EditableSlice{
+						Add:    []string{"Cleanup", "Roadmap"},
+						Remove: []string{"Features"},
+						Edited: true,
+					},
+					Milestone: prShared.EditableString{
+						Value:  "GA",
+						Edited: true,
+					},
 				},
 				FetchOptions: prShared.FetchOptions,
 			},
@@ -191,21 +260,21 @@ func Test_editRun(t *testing.T) {
 				SelectorArg: "123",
 				Interactive: true,
 				FieldsToEditSurvey: func(eo *prShared.Editable) error {
-					eo.TitleEdited = true
-					eo.BodyEdited = true
-					eo.AssigneesEdited = true
-					eo.LabelsEdited = true
-					eo.ProjectsEdited = true
-					eo.MilestoneEdited = true
+					eo.Title.Edited = true
+					eo.Body.Edited = true
+					eo.Assignees.Edited = true
+					eo.Labels.Edited = true
+					eo.Projects.Edited = true
+					eo.Milestone.Edited = true
 					return nil
 				},
 				EditFieldsSurvey: func(eo *prShared.Editable, _ string) error {
-					eo.Title = "new title"
-					eo.Body = "new body"
-					eo.Assignees = []string{"monalisa", "hubot"}
-					eo.Labels = []string{"feature", "TODO", "bug"}
-					eo.Projects = []string{"Cleanup", "Roadmap"}
-					eo.Milestone = "GA"
+					eo.Title.Value = "new title"
+					eo.Body.Value = "new body"
+					eo.Assignees.Value = []string{"monalisa", "hubot"}
+					eo.Labels.Value = []string{"feature", "TODO", "bug"}
+					eo.Projects.Value = []string{"Cleanup", "Roadmap"}
+					eo.Milestone.Value = "GA"
 					return nil
 				},
 				FetchOptions:    prShared.FetchOptions,

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -50,12 +50,11 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 		Short: "Edit a pull request",
 		Example: heredoc.Doc(`
 			$ gh pr edit 23 --title "I found a bug" --body "Nothing works"
-			$ gh pr edit 23 --label "bug,help wanted"
-			$ gh pr edit 23 --label bug --label "help wanted"
-			$ gh pr edit 23 --reviewer monalisa,hubot  --reviewer myorg/team-name
-			$ gh pr edit 23 --assignee monalisa,hubot
-			$ gh pr edit 23 --assignee @me
-			$ gh pr edit 23 --project "Roadmap"
+			$ gh pr edit 23 --add-label "bug,help wanted" --remove-label "core"
+			$ gh pr edit 23 --add-reviewer monalisa,hubot  --remove-reviewer myorg/team-name
+			$ gh pr edit 23 --add-assignee @me --remove-assignee monalisa,hubot
+			$ gh pr edit 23 --add-project "Roadmap" --remove-project v1,v2
+			$ gh pr edit 23 --milestone "Version 1"
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -66,25 +65,25 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 
 			flags := cmd.Flags()
 			if flags.Changed("title") {
-				opts.Editable.TitleEdited = true
+				opts.Editable.Title.Edited = true
 			}
 			if flags.Changed("body") {
-				opts.Editable.BodyEdited = true
+				opts.Editable.Body.Edited = true
 			}
-			if flags.Changed("reviewer") {
-				opts.Editable.ReviewersEdited = true
+			if flags.Changed("add-reviewer") || flags.Changed("remove-reviewer") {
+				opts.Editable.Reviewers.Edited = true
 			}
-			if flags.Changed("assignee") {
-				opts.Editable.AssigneesEdited = true
+			if flags.Changed("add-assignee") || flags.Changed("remove-assignee") {
+				opts.Editable.Assignees.Edited = true
 			}
-			if flags.Changed("label") {
-				opts.Editable.LabelsEdited = true
+			if flags.Changed("add-label") || flags.Changed("remove-label") {
+				opts.Editable.Labels.Edited = true
 			}
-			if flags.Changed("project") {
-				opts.Editable.ProjectsEdited = true
+			if flags.Changed("add-project") || flags.Changed("remove-project") {
+				opts.Editable.Projects.Edited = true
 			}
 			if flags.Changed("milestone") {
-				opts.Editable.MilestoneEdited = true
+				opts.Editable.Milestone.Edited = true
 			}
 
 			if !opts.Editable.Dirty() {
@@ -103,13 +102,17 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Editable.Title, "title", "t", "", "Revise the pr title.")
-	cmd.Flags().StringVarP(&opts.Editable.Body, "body", "b", "", "Revise the pr body.")
-	cmd.Flags().StringSliceVarP(&opts.Editable.Reviewers, "reviewer", "r", nil, "Request reviews from people or teams by their `handle`")
-	cmd.Flags().StringSliceVarP(&opts.Editable.Assignees, "assignee", "a", nil, "Set assigned people by their `login`. Use \"@me\" to self-assign.")
-	cmd.Flags().StringSliceVarP(&opts.Editable.Labels, "label", "l", nil, "Set the pr labels by `name`")
-	cmd.Flags().StringSliceVarP(&opts.Editable.Projects, "project", "p", nil, "Set the projects the pr belongs to by `name`")
-	cmd.Flags().StringVarP(&opts.Editable.Milestone, "milestone", "m", "", "Set the milestone the pr belongs to by `name`")
+	cmd.Flags().StringVarP(&opts.Editable.Title.Value, "title", "t", "", "Set the new title.")
+	cmd.Flags().StringVarP(&opts.Editable.Body.Value, "body", "b", "", "Set the new body.")
+	cmd.Flags().StringSliceVar(&opts.Editable.Reviewers.Add, "add-reviewer", nil, "Add reviewers by their `login`.")
+	cmd.Flags().StringSliceVar(&opts.Editable.Reviewers.Remove, "remove-reviewer", nil, "Remove reviewers by their `login`.")
+	cmd.Flags().StringSliceVar(&opts.Editable.Assignees.Add, "add-assignee", nil, "Add assigned users by their `login`. Use \"@me\" to assign yourself.")
+	cmd.Flags().StringSliceVar(&opts.Editable.Assignees.Remove, "remove-assignee", nil, "Remove assigned users by their `login`. Use \"@me\" to unassign yourself.")
+	cmd.Flags().StringSliceVar(&opts.Editable.Labels.Add, "add-label", nil, "Add labels by `name`")
+	cmd.Flags().StringSliceVar(&opts.Editable.Labels.Remove, "remove-label", nil, "Remove labels by `name`")
+	cmd.Flags().StringSliceVar(&opts.Editable.Projects.Add, "add-project", nil, "Add the pull request to projects by `name`")
+	cmd.Flags().StringSliceVar(&opts.Editable.Projects.Remove, "remove-project", nil, "Remove the pull request from projects by `name`")
+	cmd.Flags().StringVarP(&opts.Editable.Milestone.Value, "milestone", "m", "", "Edit the milestone the pull request belongs to by `name`")
 
 	return cmd
 }
@@ -127,14 +130,14 @@ func editRun(opts *EditOptions) error {
 	}
 
 	editable := opts.Editable
-	editable.ReviewersAllowed = true
-	editable.TitleDefault = pr.Title
-	editable.BodyDefault = pr.Body
-	editable.ReviewersDefault = pr.ReviewRequests
-	editable.AssigneesDefault = pr.Assignees
-	editable.LabelsDefault = pr.Labels
-	editable.ProjectsDefault = pr.ProjectCards
-	editable.MilestoneDefault = pr.Milestone
+	editable.Reviewers.Allowed = true
+	editable.Title.Default = pr.Title
+	editable.Body.Default = pr.Body
+	editable.Reviewers.Default = pr.ReviewRequests.Logins()
+	editable.Assignees.Default = pr.Assignees.Logins()
+	editable.Labels.Default = pr.Labels.Names()
+	editable.Projects.Default = pr.ProjectCards.ProjectNames()
+	editable.Milestone.Default = pr.Milestone.Title
 
 	if opts.Interactive {
 		err = opts.Surveyor.FieldsToEdit(&editable)
@@ -177,25 +180,29 @@ func updatePullRequest(client *api.Client, repo ghrepo.Interface, id string, edi
 	var err error
 	params := githubv4.UpdatePullRequestInput{
 		PullRequestID: id,
-		Title:         editable.TitleParam(),
-		Body:          editable.BodyParam(),
+		Title:         ghString(editable.TitleValue()),
+		Body:          ghString(editable.BodyValue()),
 	}
-	params.AssigneeIDs, err = editable.AssigneesParam(client, repo)
+	assigneeIds, err := editable.AssigneeIds(client, repo)
 	if err != nil {
 		return err
 	}
-	params.LabelIDs, err = editable.LabelsParam()
+	params.AssigneeIDs = ghIds(assigneeIds)
+	labelIds, err := editable.LabelIds()
 	if err != nil {
 		return err
 	}
-	params.ProjectIDs, err = editable.ProjectsParam()
+	params.LabelIDs = ghIds(labelIds)
+	projectIds, err := editable.ProjectIds()
 	if err != nil {
 		return err
 	}
-	params.MilestoneID, err = editable.MilestoneParam()
+	params.ProjectIDs = ghIds(projectIds)
+	milestoneId, err := editable.MilestoneId()
 	if err != nil {
 		return err
 	}
+	params.MilestoneID = ghId(milestoneId)
 	err = api.UpdatePullRequest(client, repo, params)
 	if err != nil {
 		return err
@@ -204,10 +211,10 @@ func updatePullRequest(client *api.Client, repo ghrepo.Interface, id string, edi
 }
 
 func updatePullRequestReviews(client *api.Client, repo ghrepo.Interface, id string, editable shared.Editable) error {
-	if !editable.ReviewersEdited {
+	if !editable.Reviewers.Edited {
 		return nil
 	}
-	userIds, teamIds, err := editable.ReviewersParams()
+	userIds, teamIds, err := editable.ReviewerIds()
 	if err != nil {
 		return err
 	}
@@ -215,8 +222,8 @@ func updatePullRequestReviews(client *api.Client, repo ghrepo.Interface, id stri
 	reviewsRequestParams := githubv4.RequestReviewsInput{
 		PullRequestID: id,
 		Union:         &union,
-		UserIDs:       userIds,
-		TeamIDs:       teamIds,
+		UserIDs:       ghIds(userIds),
+		TeamIDs:       ghIds(teamIds),
 	}
 	return api.UpdatePullRequestReviews(client, repo, reviewsRequestParams)
 }
@@ -256,4 +263,35 @@ type editorRetriever struct {
 
 func (e editorRetriever) Retrieve() (string, error) {
 	return cmdutil.DetermineEditor(e.config)
+}
+
+func ghIds(s *[]string) *[]githubv4.ID {
+	if s == nil {
+		return nil
+	}
+	ids := make([]githubv4.ID, len(*s))
+	for i, v := range *s {
+		ids[i] = v
+	}
+	return &ids
+}
+
+func ghId(s *string) *githubv4.ID {
+	if s == nil {
+		return nil
+	}
+	if *s == "" {
+		r := githubv4.ID(nil)
+		return &r
+	}
+	r := githubv4.ID(*s)
+	return &r
+}
+
+func ghString(s *string) *githubv4.String {
+	if s == nil {
+		return nil
+	}
+	r := githubv4.String(*s)
+	return &r
 }

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -29,7 +29,7 @@ func TestNewCmdEdit(t *testing.T) {
 			wantsErr: true,
 		},
 		{
-			name:  "issue number argument",
+			name:  "pull request number argument",
 			input: "23",
 			output: EditOptions{
 				SelectorArg: "23",
@@ -43,8 +43,10 @@ func TestNewCmdEdit(t *testing.T) {
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: shared.Editable{
-					Title:       "test",
-					TitleEdited: true,
+					Title: shared.EditableString{
+						Value:  "test",
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
@@ -55,56 +57,122 @@ func TestNewCmdEdit(t *testing.T) {
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: shared.Editable{
-					Body:       "test",
-					BodyEdited: true,
+					Body: shared.EditableString{
+						Value:  "test",
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
 		},
 		{
-			name:  "reviewer flag",
-			input: "23 --reviewer owner/team,monalisa",
+			name:  "add-reviewer flag",
+			input: "23 --add-reviewer monalisa,owner/core",
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: shared.Editable{
-					Reviewers:       []string{"owner/team", "monalisa"},
-					ReviewersEdited: true,
+					Reviewers: shared.EditableSlice{
+						Add:    []string{"monalisa", "owner/core"},
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
 		},
 		{
-			name:  "assignee flag",
-			input: "23 --assignee monalisa,hubot",
+			name:  "remove-reviewer flag",
+			input: "23 --remove-reviewer monalisa,owner/core",
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: shared.Editable{
-					Assignees:       []string{"monalisa", "hubot"},
-					AssigneesEdited: true,
+					Reviewers: shared.EditableSlice{
+						Remove: []string{"monalisa", "owner/core"},
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
 		},
 		{
-			name:  "label flag",
-			input: "23 --label feature,TODO,bug",
+			name:  "add-assignee flag",
+			input: "23 --add-assignee monalisa,hubot",
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: shared.Editable{
-					Labels:       []string{"feature", "TODO", "bug"},
-					LabelsEdited: true,
+					Assignees: shared.EditableSlice{
+						Add:    []string{"monalisa", "hubot"},
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
 		},
 		{
-			name:  "project flag",
-			input: "23 --project Cleanup,Roadmap",
+			name:  "remove-assignee flag",
+			input: "23 --remove-assignee monalisa,hubot",
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: shared.Editable{
-					Projects:       []string{"Cleanup", "Roadmap"},
-					ProjectsEdited: true,
+					Assignees: shared.EditableSlice{
+						Remove: []string{"monalisa", "hubot"},
+						Edited: true,
+					},
+				},
+			},
+			wantsErr: false,
+		},
+		{
+			name:  "add-label flag",
+			input: "23 --add-label feature,TODO,bug",
+			output: EditOptions{
+				SelectorArg: "23",
+				Editable: shared.Editable{
+					Labels: shared.EditableSlice{
+						Add:    []string{"feature", "TODO", "bug"},
+						Edited: true,
+					},
+				},
+			},
+			wantsErr: false,
+		},
+		{
+			name:  "remove-label flag",
+			input: "23 --remove-label feature,TODO,bug",
+			output: EditOptions{
+				SelectorArg: "23",
+				Editable: shared.Editable{
+					Labels: shared.EditableSlice{
+						Remove: []string{"feature", "TODO", "bug"},
+						Edited: true,
+					},
+				},
+			},
+			wantsErr: false,
+		},
+		{
+			name:  "add-project flag",
+			input: "23 --add-project Cleanup,Roadmap",
+			output: EditOptions{
+				SelectorArg: "23",
+				Editable: shared.Editable{
+					Projects: shared.EditableSlice{
+						Add:    []string{"Cleanup", "Roadmap"},
+						Edited: true,
+					},
+				},
+			},
+			wantsErr: false,
+		},
+		{
+			name:  "remove-project flag",
+			input: "23 --remove-project Cleanup,Roadmap",
+			output: EditOptions{
+				SelectorArg: "23",
+				Editable: shared.Editable{
+					Projects: shared.EditableSlice{
+						Remove: []string{"Cleanup", "Roadmap"},
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
@@ -115,8 +183,10 @@ func TestNewCmdEdit(t *testing.T) {
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: shared.Editable{
-					Milestone:       "GA",
-					MilestoneEdited: true,
+					Milestone: shared.EditableString{
+						Value:  "GA",
+						Edited: true,
+					},
 				},
 			},
 			wantsErr: false,
@@ -176,20 +246,38 @@ func Test_editRun(t *testing.T) {
 				SelectorArg: "123",
 				Interactive: false,
 				Editable: shared.Editable{
-					Title:           "new title",
-					TitleEdited:     true,
-					Body:            "new body",
-					BodyEdited:      true,
-					Reviewers:       []string{"OWNER/core", "OWNER/external", "monalisa", "hubot"},
-					ReviewersEdited: true,
-					Assignees:       []string{"monalisa", "hubot"},
-					AssigneesEdited: true,
-					Labels:          []string{"feature", "TODO", "bug"},
-					LabelsEdited:    true,
-					Projects:        []string{"Cleanup", "Roadmap"},
-					ProjectsEdited:  true,
-					Milestone:       "GA",
-					MilestoneEdited: true,
+					Title: shared.EditableString{
+						Value:  "new title",
+						Edited: true,
+					},
+					Body: shared.EditableString{
+						Value:  "new body",
+						Edited: true,
+					},
+					Reviewers: shared.EditableSlice{
+						Add:    []string{"OWNER/core", "OWNER/external", "monalisa", "hubot"},
+						Remove: []string{"dependabot"},
+						Edited: true,
+					},
+					Assignees: shared.EditableSlice{
+						Add:    []string{"monalisa", "hubot"},
+						Remove: []string{"octocat"},
+						Edited: true,
+					},
+					Labels: shared.EditableSlice{
+						Add:    []string{"feature", "TODO", "bug"},
+						Remove: []string{"docs"},
+						Edited: true,
+					},
+					Projects: shared.EditableSlice{
+						Add:    []string{"Cleanup", "Roadmap"},
+						Remove: []string{"Features"},
+						Edited: true,
+					},
+					Milestone: shared.EditableString{
+						Value:  "GA",
+						Edited: true,
+					},
 				},
 				Fetcher: testFetcher{},
 			},
@@ -207,18 +295,33 @@ func Test_editRun(t *testing.T) {
 				SelectorArg: "123",
 				Interactive: false,
 				Editable: shared.Editable{
-					Title:           "new title",
-					TitleEdited:     true,
-					Body:            "new body",
-					BodyEdited:      true,
-					Assignees:       []string{"monalisa", "hubot"},
-					AssigneesEdited: true,
-					Labels:          []string{"feature", "TODO", "bug"},
-					LabelsEdited:    true,
-					Projects:        []string{"Cleanup", "Roadmap"},
-					ProjectsEdited:  true,
-					Milestone:       "GA",
-					MilestoneEdited: true,
+					Title: shared.EditableString{
+						Value:  "new title",
+						Edited: true,
+					},
+					Body: shared.EditableString{
+						Value:  "new body",
+						Edited: true,
+					},
+					Assignees: shared.EditableSlice{
+						Add:    []string{"monalisa", "hubot"},
+						Remove: []string{"octocat"},
+						Edited: true,
+					},
+					Labels: shared.EditableSlice{
+						Value:  []string{"feature", "TODO", "bug"},
+						Remove: []string{"docs"},
+						Edited: true,
+					},
+					Projects: shared.EditableSlice{
+						Value:  []string{"Cleanup", "Roadmap"},
+						Remove: []string{"Features"},
+						Edited: true,
+					},
+					Milestone: shared.EditableString{
+						Value:  "GA",
+						Edited: true,
+					},
 				},
 				Fetcher: testFetcher{},
 			},
@@ -405,28 +508,28 @@ func (f testFetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interf
 }
 
 func (s testSurveyor) FieldsToEdit(e *shared.Editable) error {
-	e.TitleEdited = true
-	e.BodyEdited = true
+	e.Title.Edited = true
+	e.Body.Edited = true
 	if !s.skipReviewers {
-		e.ReviewersEdited = true
+		e.Reviewers.Edited = true
 	}
-	e.AssigneesEdited = true
-	e.LabelsEdited = true
-	e.ProjectsEdited = true
-	e.MilestoneEdited = true
+	e.Assignees.Edited = true
+	e.Labels.Edited = true
+	e.Projects.Edited = true
+	e.Milestone.Edited = true
 	return nil
 }
 
 func (s testSurveyor) EditFields(e *shared.Editable, _ string) error {
-	e.Title = "new title"
-	e.Body = "new body"
+	e.Title.Value = "new title"
+	e.Body.Value = "new body"
 	if !s.skipReviewers {
-		e.Reviewers = []string{"monalisa", "hubot", "OWNER/core", "OWNER/external"}
+		e.Reviewers.Value = []string{"monalisa", "hubot", "OWNER/core", "OWNER/external"}
 	}
-	e.Assignees = []string{"monalisa", "hubot"}
-	e.Labels = []string{"feature", "TODO", "bug"}
-	e.Projects = []string{"Cleanup", "Roadmap"}
-	e.Milestone = "GA"
+	e.Assignees.Value = []string{"monalisa", "hubot"}
+	e.Labels.Value = []string{"feature", "TODO", "bug"}
+	e.Projects.Value = []string{"Cleanup", "Roadmap"}
+	e.Milestone.Value = "GA"
 	return nil
 }
 

--- a/pkg/set/string_set.go
+++ b/pkg/set/string_set.go
@@ -1,0 +1,46 @@
+package set
+
+var exists = struct{}{}
+
+type stringSet struct {
+	m map[string]struct{}
+}
+
+func NewStringSet() *stringSet {
+	s := &stringSet{}
+	s.m = make(map[string]struct{})
+	return s
+}
+
+func (s *stringSet) Add(value string) {
+	s.m[value] = exists
+}
+
+func (s *stringSet) AddValues(values []string) {
+	for _, v := range values {
+		s.Add(v)
+	}
+}
+
+func (s *stringSet) Remove(value string) {
+	delete(s.m, value)
+}
+
+func (s *stringSet) RemoveValues(values []string) {
+	for _, v := range values {
+		s.Remove(v)
+	}
+}
+
+func (s *stringSet) Contains(value string) bool {
+	_, c := s.m[value]
+	return c
+}
+
+func (s *stringSet) ToSlice() []string {
+	r := make([]string, 0, len(s.m))
+	for k := range s.m {
+		r = append(r, k)
+	}
+	return r
+}


### PR DESCRIPTION
This PR changes `issue edit` and `pr edit` flags behavior. Previously, flags that accepted arrays of values (`--label`, `--reviewer`, `--project`, and `--assignee`) would overwrite the current values for these fields, this changes those flags to now be piecemeal changes to these fields through the definition of `--add` and `--remove` variations of those flags.

For example: The `--label` flag is now split into two flags `--add-label` and `--remove-label`.