### PR TITLE
Adds Branch Up to Date Status

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -239,7 +239,6 @@ func (c Client) GraphQL(hostname string, query string, variables map[string]inte
 	}
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	req.Header.Set("Accept", "application/vnd.github.merge-info-preview+json")
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/api/client.go
+++ b/api/client.go
@@ -239,6 +239,7 @@ func (c Client) GraphQL(hostname string, query string, variables map[string]inte
 	}
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Accept", "application/vnd.github.merge-info-preview+json")
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -28,17 +28,17 @@ type PullRequestAndTotalCount struct {
 }
 
 type PullRequest struct {
-	ID          string
-	Number      int
-	Title       string
-	State       string
-	Closed      bool
-	URL         string
-	BaseRefName string
-	HeadRefName string
-	Body        string
-	Mergeable   string
-	MergeStateStatus   string
+	ID               string
+	Number           int
+	Title            string
+	State            string
+	Closed           bool
+	URL              string
+	BaseRefName      string
+	HeadRefName      string
+	Body             string
+	Mergeable        string
+	MergeStateStatus string
 
 	Author struct {
 		Login string

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -38,6 +38,7 @@ type PullRequest struct {
 	HeadRefName string
 	Body        string
 	Mergeable   string
+	MergeStateStatus   string
 
 	Author struct {
 		Login string
@@ -353,6 +354,7 @@ func PullRequests(client *Client, repo ghrepo.Interface, currentPRNumber int, cu
 		state
 		url
 		headRefName
+		mergeStateStatus
 		headRepositoryOwner {
 			login
 		}

--- a/pkg/cmd/factory/http.go
+++ b/pkg/cmd/factory/http.go
@@ -87,6 +87,8 @@ func NewHTTPClient(io *iostreams.IOStreams, cfg config.Config, appVersion string
 			api.AddHeaderFunc("Accept", func(req *http.Request) (string, error) {
 				// antiope-preview: Checks
 				accept := "application/vnd.github.antiope-preview+json"
+				// introduced for #2952: pr branch up to date status
+				accept += ", application/vnd.github.merge-info-preview+json"
 				if ghinstance.IsEnterprise(req.URL.Hostname()) {
 					// shadow-cat-preview: Draft pull requests
 					accept += ", application/vnd.github.shadow-cat-preview"

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -227,6 +227,16 @@ func printPrs(io *iostreams.IOStreams, totalCount int, prs ...api.PullRequest) {
 			} else if reviews.Approved {
 				fmt.Fprint(w, cs.Green("✓ Approved"))
 			}
+
+			// add padding between reviews & merge status
+			fmt.Fprint(w, " ")
+
+			if pr.MergeStateStatus == "BEHIND" {
+				fmt.Fprint(w, cs.Yellow("- Not up to date"))
+			} else {
+				fmt.Fprint(w, cs.Green("✓ Up to date"))
+			}
+
 		} else {
 			fmt.Fprintf(w, " - %s", shared.StateTitleWithColor(cs, pr))
 		}

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -114,7 +114,7 @@ func statusRun(opts *StatusOptions) error {
 		currentPR = nil
 	}
 	if currentPR != nil {
-		printPrs(opts.IO, 1, *currentPR)
+		printPrs(opts.IO, 1, prPayload.StrictProtection, *currentPR)
 	} else if currentPRHeadRef == "" {
 		shared.PrintMessage(opts.IO, "  There is no current branch")
 	} else {
@@ -124,7 +124,7 @@ func statusRun(opts *StatusOptions) error {
 
 	shared.PrintHeader(opts.IO, "Created by you")
 	if prPayload.ViewerCreated.TotalCount > 0 {
-		printPrs(opts.IO, prPayload.ViewerCreated.TotalCount, prPayload.ViewerCreated.PullRequests...)
+		printPrs(opts.IO, prPayload.ViewerCreated.TotalCount, prPayload.StrictProtection, prPayload.ViewerCreated.PullRequests...)
 	} else {
 		shared.PrintMessage(opts.IO, "  You have no open pull requests")
 	}
@@ -132,7 +132,7 @@ func statusRun(opts *StatusOptions) error {
 
 	shared.PrintHeader(opts.IO, "Requesting a code review from you")
 	if prPayload.ReviewRequested.TotalCount > 0 {
-		printPrs(opts.IO, prPayload.ReviewRequested.TotalCount, prPayload.ReviewRequested.PullRequests...)
+		printPrs(opts.IO, prPayload.ReviewRequested.TotalCount, prPayload.StrictProtection, prPayload.ReviewRequested.PullRequests...)
 	} else {
 		shared.PrintMessage(opts.IO, "  You have no pull requests to review")
 	}
@@ -178,7 +178,7 @@ func prSelectorForCurrentBranch(baseRepo ghrepo.Interface, prHeadRef string, rem
 	return
 }
 
-func printPrs(io *iostreams.IOStreams, totalCount int, prs ...api.PullRequest) {
+func printPrs(io *iostreams.IOStreams, totalCount int, strictProtection bool, prs ...api.PullRequest) {
 	w := io.Out
 	cs := io.ColorScheme()
 
@@ -228,13 +228,16 @@ func printPrs(io *iostreams.IOStreams, totalCount int, prs ...api.PullRequest) {
 				fmt.Fprint(w, cs.Green("✓ Approved"))
 			}
 
-			// add padding between reviews & merge status
-			fmt.Fprint(w, " ")
+			// only check if the "up to date" setting is checked in repo settings
+			if strictProtection {
+				// add padding between reviews & merge status
+				fmt.Fprint(w, " ")
 
-			if pr.MergeStateStatus == "BEHIND" {
-				fmt.Fprint(w, cs.Yellow("- Not up to date"))
-			} else {
-				fmt.Fprint(w, cs.Green("✓ Up to date"))
+				if pr.MergeStateStatus == "BEHIND" {
+					fmt.Fprint(w, cs.Yellow("- Not up to date"))
+				} else {
+					fmt.Fprint(w, cs.Green("✓ Up to date"))
+				}
 			}
 
 		} else {


### PR DESCRIPTION
This shows whether the current head branch is behind the base branch similar to the web GUI. 

<img width="834" alt="Screen Shot 2021-02-11 at 4 25 26 PM" src="https://user-images.githubusercontent.com/2659478/107701031-51e03e00-6c86-11eb-9157-cf92787ca829.png">

Uses the preview API here: https://docs.github.com/en/graphql/reference/enums#mergestatestatus

Closes #2945 