### PR TITLE
PR merge improvements: auto-merge, edit commit body

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -88,8 +88,6 @@ type PullRequest struct {
 	ReactionGroups ReactionGroups
 	Reviews        PullRequestReviews
 	ReviewRequests ReviewRequests
-
-	ViewerMergeBodyText string
 }
 
 type ReviewRequests struct {
@@ -578,7 +576,6 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 				milestone{
 					title
 				}
-				viewerMergeBodyText
 				` + commentsFragment() + `
 				` + reactionGroupsFragment() + `
 			}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -88,6 +88,8 @@ type PullRequest struct {
 	ReactionGroups ReactionGroups
 	Reviews        PullRequestReviews
 	ReviewRequests ReviewRequests
+
+	ViewerMergeBodyText string
 }
 
 type ReviewRequests struct {
@@ -584,6 +586,7 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 				milestone{
 					title
 				}
+				viewerMergeBodyText
 				` + commentsFragment() + `
 				` + reactionGroupsFragment() + `
 			}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -88,6 +88,9 @@ type PullRequest struct {
 	ReactionGroups ReactionGroups
 	Reviews        PullRequestReviews
 	ReviewRequests ReviewRequests
+
+	ViewerMergeBodyText     string
+	ViewerMergeHeadlineText string
 }
 
 type ReviewRequests struct {
@@ -584,6 +587,8 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 				milestone{
 					title
 				}
+				viewerMergeBodyText
+				viewerMergeHeadlineText
 				` + commentsFragment() + `
 				` + reactionGroupsFragment() + `
 			}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -88,9 +88,6 @@ type PullRequest struct {
 	ReactionGroups ReactionGroups
 	Reviews        PullRequestReviews
 	ReviewRequests ReviewRequests
-
-	ViewerMergeBodyText     string
-	ViewerMergeHeadlineText string
 }
 
 type ReviewRequests struct {
@@ -587,8 +584,6 @@ func PullRequestByNumber(client *Client, repo ghrepo.Interface, number int) (*Pu
 				milestone{
 					title
 				}
-				viewerMergeBodyText
-				viewerMergeHeadlineText
 				` + commentsFragment() + `
 				` + reactionGroupsFragment() + `
 			}

--- a/pkg/cmd/pr/merge/http.go
+++ b/pkg/cmd/pr/merge/http.go
@@ -1,0 +1,100 @@
+package merge
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cli/cli/internal/ghinstance"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/shurcooL/githubv4"
+	"github.com/shurcooL/graphql"
+)
+
+type PullRequestMergeMethod int
+
+const (
+	PullRequestMergeMethodMerge PullRequestMergeMethod = iota
+	PullRequestMergeMethodRebase
+	PullRequestMergeMethodSquash
+)
+
+type mergePayload struct {
+	repo             ghrepo.Interface
+	pullRequestID    string
+	method           PullRequestMergeMethod
+	auto             bool
+	commitSubject    string
+	setCommitSubject bool
+	commitBody       string
+	setCommitBody    bool
+}
+
+// TODO: drop after githubv4 gets updated
+type EnablePullRequestAutoMergeInput struct {
+	githubv4.MergePullRequestInput
+}
+
+func mergePullRequest(client *http.Client, payload mergePayload) error {
+	input := githubv4.MergePullRequestInput{
+		PullRequestID: githubv4.ID(payload.pullRequestID),
+	}
+
+	switch payload.method {
+	case PullRequestMergeMethodMerge:
+		m := githubv4.PullRequestMergeMethodMerge
+		input.MergeMethod = &m
+	case PullRequestMergeMethodRebase:
+		m := githubv4.PullRequestMergeMethodRebase
+		input.MergeMethod = &m
+	case PullRequestMergeMethodSquash:
+		m := githubv4.PullRequestMergeMethodSquash
+		input.MergeMethod = &m
+	}
+
+	if payload.setCommitSubject {
+		commitHeadline := githubv4.String(payload.commitSubject)
+		input.CommitHeadline = &commitHeadline
+	}
+	if payload.setCommitBody {
+		commitBody := githubv4.String(payload.commitBody)
+		input.CommitBody = &commitBody
+	}
+
+	variables := map[string]interface{}{
+		"input": input,
+	}
+
+	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(payload.repo.RepoHost()), client)
+
+	if payload.auto {
+		var mutation struct {
+			AnablePullRequestAutoMerge struct {
+				ClientMutationId string
+			} `graphql:"enablePullRequestAutoMerge(input: $input)"`
+		}
+		variables["input"] = EnablePullRequestAutoMergeInput{input}
+		return gql.MutateNamed(context.Background(), "PullRequestAutoMerge", &mutation, variables)
+	}
+
+	var mutation struct {
+		MergePullRequest struct {
+			ClientMutationId string
+		} `graphql:"mergePullRequest(input: $input)"`
+	}
+	return gql.MutateNamed(context.Background(), "PullRequestMerge", &mutation, variables)
+}
+
+func disableAutoMerge(client *http.Client, repo ghrepo.Interface, prID string) error {
+	var mutation struct {
+		DisablePullRequestAutoMerge struct {
+			ClientMutationId string
+		} `graphql:"disablePullRequestAutoMerge(input: {pullRequestId: $prID})"`
+	}
+
+	variables := map[string]interface{}{
+		"prID": githubv4.ID(prID),
+	}
+
+	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), client)
+	return gql.MutateNamed(context.Background(), "PullRequestAutoMergeDisable", &mutation, variables)
+}

--- a/pkg/cmd/pr/merge/http.go
+++ b/pkg/cmd/pr/merge/http.go
@@ -69,7 +69,7 @@ func mergePullRequest(client *http.Client, payload mergePayload) error {
 
 	if payload.auto {
 		var mutation struct {
-			AnablePullRequestAutoMerge struct {
+			EnablePullRequestAutoMerge struct {
 				ClientMutationId string
 			} `graphql:"enablePullRequestAutoMerge(input: $input)"`
 		}

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -32,7 +32,7 @@ type MergeOptions struct {
 	DeleteBranch bool
 	MergeMethod  PullRequestMergeMethod
 
-	AutoMerge        bool
+	AutoMergeEnable  bool
 	AutoMergeDisable bool
 
 	Body    string
@@ -115,7 +115,7 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 	cmd.Flags().BoolVarP(&flagMerge, "merge", "m", false, "Merge the commits with the base branch")
 	cmd.Flags().BoolVarP(&flagRebase, "rebase", "r", false, "Rebase the commits onto the base branch")
 	cmd.Flags().BoolVarP(&flagSquash, "squash", "s", false, "Squash the commits into one commit and merge it into the base branch")
-	cmd.Flags().BoolVar(&opts.AutoMerge, "auto", false, "Automatically merge only after necessary requirements are met")
+	cmd.Flags().BoolVar(&opts.AutoMergeEnable, "auto", false, "Automatically merge only after necessary requirements are met")
 	cmd.Flags().BoolVar(&opts.AutoMergeDisable, "disable-auto", false, "Disable auto-merge for this pull request")
 	return cmd
 }
@@ -171,7 +171,7 @@ func mergeRun(opts *MergeOptions) error {
 			repo:          baseRepo,
 			pullRequestID: pr.ID,
 			method:        opts.MergeMethod,
-			auto:          opts.AutoMerge,
+			auto:          opts.AutoMergeEnable,
 			commitBody:    opts.Body,
 			setCommitBody: opts.BodySet,
 		}
@@ -254,7 +254,7 @@ func mergeRun(opts *MergeOptions) error {
 				fmt.Fprintf(opts.IO.ErrOut, "%s %s pull request #%d (%s)\n", cs.SuccessIconWithColor(cs.Magenta), action, pr.Number, pr.Title)
 			}
 		}
-	} else if !opts.IsDeleteBranchIndicated && opts.InteractiveMode && !crossRepoPR && !opts.AutoMerge {
+	} else if !opts.IsDeleteBranchIndicated && opts.InteractiveMode && !crossRepoPR && !opts.AutoMergeEnable {
 		err := prompt.SurveyAskOne(&survey.Confirm{
 			Message: fmt.Sprintf("Pull request #%d was already merged. Delete the branch locally?", pr.Number),
 			Default: false,
@@ -266,7 +266,7 @@ func mergeRun(opts *MergeOptions) error {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d was already merged\n", cs.WarningIcon(), pr.Number)
 	}
 
-	if !deleteBranch || crossRepoPR || opts.AutoMerge {
+	if !deleteBranch || crossRepoPR || opts.AutoMergeEnable {
 		return nil
 	}
 

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -243,7 +243,7 @@ func mergeRun(opts *MergeOptions) error {
 				case PullRequestMergeMethodSquash:
 					method = " via squash"
 				}
-				fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d will automatically get merged%s when all requiremenets are met\n", cs.SuccessIconWithColor(cs.Green), pr.Number, method)
+				fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d will automatically get merged%s when all requirements are met\n", cs.SuccessIconWithColor(cs.Green), pr.Number, method)
 			} else {
 				action := "Merged"
 				switch payload.method {

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -204,11 +204,10 @@ func mergeRun(opts *MergeOptions) error {
 					return err
 				}
 
-				if payload.commitBody == "" {
-					if payload.method == PullRequestMergeMethodMerge {
-						payload.commitBody = pr.Title
-					} else {
-						payload.commitBody = pr.ViewerMergeBodyText
+				if !payload.setCommitBody {
+					payload.commitBody, err = getMergeText(httpClient, baseRepo, pr.ID, payload.method)
+					if err != nil {
+						return err
 					}
 				}
 

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -35,7 +35,8 @@ type MergeOptions struct {
 	AutoMerge        bool
 	AutoMergeDisable bool
 
-	Body string
+	Body    string
+	BodySet bool
 
 	IsDeleteBranchIndicated bool
 	CanDeleteLocalBranch    bool
@@ -100,6 +101,7 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 
 			opts.IsDeleteBranchIndicated = cmd.Flags().Changed("delete-branch")
 			opts.CanDeleteLocalBranch = !cmd.Flags().Changed("repo")
+			opts.BodySet = cmd.Flags().Changed("body")
 
 			if runF != nil {
 				return runF(opts)
@@ -109,7 +111,7 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 	}
 
 	cmd.Flags().BoolVarP(&opts.DeleteBranch, "delete-branch", "d", false, "Delete the local and remote branch after merge")
-	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Body for merge commit")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Body `text` for the merge commit")
 	cmd.Flags().BoolVarP(&flagMerge, "merge", "m", false, "Merge the commits with the base branch")
 	cmd.Flags().BoolVarP(&flagRebase, "rebase", "r", false, "Rebase the commits onto the base branch")
 	cmd.Flags().BoolVarP(&flagSquash, "squash", "s", false, "Squash the commits into one commit and merge it into the base branch")
@@ -171,9 +173,7 @@ func mergeRun(opts *MergeOptions) error {
 			method:        opts.MergeMethod,
 			auto:          opts.AutoMerge,
 			commitBody:    opts.Body,
-		}
-		if opts.Body != "" {
-			payload.setCommitBody = true
+			setCommitBody: opts.BodySet,
 		}
 
 		if opts.InteractiveMode {

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -243,7 +243,7 @@ func mergeRun(opts *MergeOptions) error {
 				case PullRequestMergeMethodSquash:
 					method = " via squash"
 				}
-				fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d will automatically get merged%s when all requirements are met\n", cs.SuccessIconWithColor(cs.Green), pr.Number, method)
+				fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d will be automatically merged%s when all requirements are met\n", cs.SuccessIconWithColor(cs.Green), pr.Number, method)
 			} else {
 				action := "Merged"
 				switch payload.method {

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -32,8 +32,7 @@ type MergeOptions struct {
 	DeleteBranch bool
 	MergeMethod  api.PullRequestMergeMethod
 
-	Body         string
-	BodyProvided bool
+	Body string
 
 	IsDeleteBranchIndicated bool
 	CanDeleteLocalBranch    bool
@@ -98,10 +97,6 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 
 			opts.IsDeleteBranchIndicated = cmd.Flags().Changed("delete-branch")
 			opts.CanDeleteLocalBranch = !cmd.Flags().Changed("repo")
-
-			if cmd.Flags().Changed("body") {
-				opts.BodyProvided = true
-			}
 
 			if runF != nil {
 				return runF(opts)
@@ -169,7 +164,7 @@ func mergeRun(opts *MergeOptions) error {
 				return err
 			}
 
-			allowEditMsg := (mergeMethod != api.PullRequestMergeMethodRebase) && !opts.BodyProvided
+			allowEditMsg := mergeMethod != api.PullRequestMergeMethodRebase
 
 			action, err := confirmSurvey(allowEditMsg)
 			if err != nil {
@@ -183,12 +178,19 @@ func mergeRun(opts *MergeOptions) error {
 					return err
 				}
 
-				msg, err := commitMsgSurvey(editorCommand)
+				if opts.Body == "" {
+					if mergeMethod == api.PullRequestMergeMethodMerge {
+						opts.Body = pr.Title
+					} else {
+						opts.Body = pr.ViewerMergeBodyText
+					}
+				}
+
+				msg, err := commitMsgSurvey(opts.Body, editorCommand)
 				if err != nil {
 					return err
 				}
 				opts.Body = msg
-				opts.BodyProvided = true
 
 				action, err = confirmSurvey(false)
 				if err != nil {
@@ -202,7 +204,7 @@ func mergeRun(opts *MergeOptions) error {
 		}
 
 		var body *string
-		if opts.BodyProvided {
+		if opts.Body != "" {
 			body = &opts.Body
 		}
 
@@ -378,13 +380,15 @@ func confirmSurvey(allowEditMsg bool) (shared.Action, error) {
 	}
 }
 
-func commitMsgSurvey(editorCommand string) (string, error) {
+func commitMsgSurvey(msg string, editorCommand string) (string, error) {
 	var result string
 	q := &surveyext.GhEditor{
 		EditorCommand: editorCommand,
 		Editor: &survey.Editor{
-			Message:  "Body",
-			FileName: "*.md",
+			Message:       "Body",
+			AppendDefault: true,
+			Default:       msg,
+			FileName:      "*.md",
 		},
 	}
 	err := prompt.SurveyAskOne(q, &result)

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -229,11 +229,6 @@ func mergeRun(opts *MergeOptions) error {
 			}
 		}
 
-		if !payload.setCommitSubject && payload.method == PullRequestMergeMethodSquash {
-			payload.commitSubject = fmt.Sprintf("%s (#%d)", pr.Title, pr.Number)
-			payload.setCommitSubject = true
-		}
-
 		err = mergePullRequest(httpClient, payload)
 		if err != nil {
 			return err

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -42,7 +42,7 @@ func Test_NewCmdMerge(t *testing.T) {
 				DeleteBranch:            false,
 				IsDeleteBranchIndicated: false,
 				CanDeleteLocalBranch:    true,
-				MergeMethod:             api.PullRequestMergeMethodMerge,
+				MergeMethod:             PullRequestMergeMethodMerge,
 				InteractiveMode:         true,
 			},
 		},
@@ -55,7 +55,7 @@ func Test_NewCmdMerge(t *testing.T) {
 				DeleteBranch:            false,
 				IsDeleteBranchIndicated: true,
 				CanDeleteLocalBranch:    true,
-				MergeMethod:             api.PullRequestMergeMethodMerge,
+				MergeMethod:             PullRequestMergeMethodMerge,
 				InteractiveMode:         true,
 			},
 		},
@@ -68,7 +68,7 @@ func Test_NewCmdMerge(t *testing.T) {
 				DeleteBranch:            false,
 				IsDeleteBranchIndicated: false,
 				CanDeleteLocalBranch:    true,
-				MergeMethod:             api.PullRequestMergeMethodMerge,
+				MergeMethod:             PullRequestMergeMethodMerge,
 				InteractiveMode:         true,
 				Body:                    "cool",
 			},
@@ -787,5 +787,5 @@ func Test_mergeMethodSurvey(t *testing.T) {
 	as.StubOne(0) // Select first option which is rebase merge
 	method, err := mergeMethodSurvey(repo)
 	assert.Nil(t, err)
-	assert.Equal(t, api.PullRequestMergeMethodRebase, method)
+	assert.Equal(t, PullRequestMergeMethodRebase, method)
 }

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -704,6 +704,12 @@ func TestPRMerge_interactiveSquashEditCommitMsg(t *testing.T) {
 			"squashMergeAllowed": true
 		} } }`))
 	http.Register(
+		httpmock.GraphQL(`query PullRequestMergeText\b`),
+		httpmock.StringResponse(`
+		{ "data": { "node": {
+			"viewerMergeBodyText": ""
+		} } }`))
+	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
 		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -44,6 +44,8 @@ func Test_NewCmdMerge(t *testing.T) {
 				CanDeleteLocalBranch:    true,
 				MergeMethod:             PullRequestMergeMethodMerge,
 				InteractiveMode:         true,
+				Body:                    "",
+				BodySet:                 false,
 			},
 		},
 		{
@@ -57,6 +59,8 @@ func Test_NewCmdMerge(t *testing.T) {
 				CanDeleteLocalBranch:    true,
 				MergeMethod:             PullRequestMergeMethodMerge,
 				InteractiveMode:         true,
+				Body:                    "",
+				BodySet:                 false,
 			},
 		},
 		{
@@ -71,6 +75,7 @@ func Test_NewCmdMerge(t *testing.T) {
 				MergeMethod:             PullRequestMergeMethodMerge,
 				InteractiveMode:         true,
 				Body:                    "cool",
+				BodySet:                 true,
 			},
 		},
 		{
@@ -138,6 +143,7 @@ func Test_NewCmdMerge(t *testing.T) {
 			assert.Equal(t, tt.want.MergeMethod, opts.MergeMethod)
 			assert.Equal(t, tt.want.InteractiveMode, opts.InteractiveMode)
 			assert.Equal(t, tt.want.Body, opts.Body)
+			assert.Equal(t, tt.want.BodySet, opts.BodySet)
 		})
 	}
 }

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -500,7 +500,7 @@ func TestPrMerge_squash(t *testing.T) {
 		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 			assert.Equal(t, "SQUASH", input["mergeMethod"].(string))
-			assert.Equal(t, "The title of the PR (#3)", input["commitHeadline"].(string))
+			assert.NotContains(t, input, "commitHeadline")
 		}))
 
 	_, cmdTeardown := run.Stub()

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -71,7 +71,6 @@ func Test_NewCmdMerge(t *testing.T) {
 				MergeMethod:             api.PullRequestMergeMethodMerge,
 				InteractiveMode:         true,
 				Body:                    "cool",
-				BodyProvided:            true,
 			},
 		},
 		{
@@ -139,7 +138,6 @@ func Test_NewCmdMerge(t *testing.T) {
 			assert.Equal(t, tt.want.MergeMethod, opts.MergeMethod)
 			assert.Equal(t, tt.want.InteractiveMode, opts.InteractiveMode)
 			assert.Equal(t, tt.want.Body, opts.Body)
-			assert.Equal(t, tt.want.BodyProvided, opts.BodyProvided)
 		})
 	}
 }

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -21,6 +21,7 @@ const (
 	PreviewAction
 	CancelAction
 	MetadataAction
+	EditCommitMessageAction
 
 	noMilestone = "(none)"
 )


### PR DESCRIPTION
- Adds `pr merge --auto`, `pr merge --disable-auto` modes
- Folds in https://github.com/cli/cli/pull/2896

```
$ gh pr merge --auto --squash 40
✓ Pull request #40 will automatically get merged via squash when all requirements are met

$ gh pr merge --disable-auto 40
✓ Auto-merge disabled for pull request #40
```

Questions:
- The confirmation checkmark for `merge --auto` is green. Should it be purple?
- The confirmation checkmark for `merge --disable-auto` is green. Should it be red?

Fixes https://github.com/cli/cli/issues/2619
Fixes https://github.com/cli/cli/issues/1023
Reverts #1627, reasoning https://github.com/cli/cli/issues/2954#issuecomment-779390768, ref. https://github.com/cli/cli/issues/1621

TODO:
- [x] tests for `--auto`
- [x] tests for `--disable-auto`
- [x] GHE compatibility for `viewerMergeBodyText` GraphQL field