### PR TITLE
Fix `auth git-credential` when the token comes from environment

### DIFF
--- a/pkg/cmd/auth/gitcredential/helper.go
+++ b/pkg/cmd/auth/gitcredential/helper.go
@@ -11,8 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const tokenUser = "x-access-token"
+
 type config interface {
-	Get(string, string) (string, error)
+	GetWithSource(string, string) (string, string, error)
 }
 
 type CredentialOptions struct {
@@ -98,13 +100,19 @@ func helperRun(opts *CredentialOptions) error {
 		return err
 	}
 
-	gotUser, _ := cfg.Get(wants["host"], "user")
-	gotToken, _ := cfg.Get(wants["host"], "oauth_token")
+	var gotUser string
+	gotToken, source, _ := cfg.GetWithSource(wants["host"], "oauth_token")
+	if strings.HasSuffix(source, "_TOKEN") {
+		gotUser = tokenUser
+	} else {
+		gotUser, _, _ = cfg.GetWithSource(wants["host"], "user")
+	}
+
 	if gotUser == "" || gotToken == "" {
 		return cmdutil.SilentError
 	}
 
-	if wants["username"] != "" && !strings.EqualFold(wants["username"], gotUser) {
+	if wants["username"] != "" && gotUser != tokenUser && !strings.EqualFold(wants["username"], gotUser) {
 		return cmdutil.SilentError
 	}
 

--- a/pkg/cmd/auth/gitcredential/helper_test.go
+++ b/pkg/cmd/auth/gitcredential/helper_test.go
@@ -10,8 +10,8 @@ import (
 
 type tinyConfig map[string]string
 
-func (c tinyConfig) Get(host, key string) (string, error) {
-	return c[fmt.Sprintf("%s:%s", host, key)], nil
+func (c tinyConfig) GetWithSource(host, key string) (string, string, error) {
+	return c[fmt.Sprintf("%s:%s", host, key)], c["_source"], nil
 }
 
 func Test_helperRun(t *testing.T) {
@@ -29,6 +29,7 @@ func Test_helperRun(t *testing.T) {
 				Operation: "get",
 				Config: func() (config, error) {
 					return tinyConfig{
+						"_source":                 "/Users/monalisa/.config/gh/hosts.yml",
 						"example.com:user":        "monalisa",
 						"example.com:oauth_token": "OTOKEN",
 					}, nil
@@ -53,6 +54,7 @@ func Test_helperRun(t *testing.T) {
 				Operation: "get",
 				Config: func() (config, error) {
 					return tinyConfig{
+						"_source":                 "/Users/monalisa/.config/gh/hosts.yml",
 						"example.com:user":        "monalisa",
 						"example.com:oauth_token": "OTOKEN",
 					}, nil
@@ -78,6 +80,7 @@ func Test_helperRun(t *testing.T) {
 				Operation: "get",
 				Config: func() (config, error) {
 					return tinyConfig{
+						"_source":                 "/Users/monalisa/.config/gh/hosts.yml",
 						"example.com:user":        "monalisa",
 						"example.com:oauth_token": "OTOKEN",
 					}, nil
@@ -101,6 +104,7 @@ func Test_helperRun(t *testing.T) {
 				Operation: "get",
 				Config: func() (config, error) {
 					return tinyConfig{
+						"_source":          "/Users/monalisa/.config/gh/hosts.yml",
 						"example.com:user": "monalisa",
 					}, nil
 				},
@@ -119,6 +123,7 @@ func Test_helperRun(t *testing.T) {
 				Operation: "get",
 				Config: func() (config, error) {
 					return tinyConfig{
+						"_source":                 "/Users/monalisa/.config/gh/hosts.yml",
 						"example.com:user":        "monalisa",
 						"example.com:oauth_token": "OTOKEN",
 					}, nil
@@ -131,6 +136,31 @@ func Test_helperRun(t *testing.T) {
 			`),
 			wantErr:    true,
 			wantStdout: "",
+			wantStderr: "",
+		},
+		{
+			name: "token from env",
+			opts: CredentialOptions{
+				Operation: "get",
+				Config: func() (config, error) {
+					return tinyConfig{
+						"_source":                 "GITHUB_ENTERPRISE_TOKEN",
+						"example.com:oauth_token": "OTOKEN",
+					}, nil
+				},
+			},
+			input: heredoc.Doc(`
+				protocol=https
+				host=example.com
+				username=hubot
+			`),
+			wantErr: false,
+			wantStdout: heredoc.Doc(`
+				protocol=https
+				host=example.com
+				username=x-access-token
+				password=OTOKEN
+			`),
 			wantStderr: "",
 		},
 	}


### PR DESCRIPTION
When a token such as GH_TOKEN is set through environment variables and `~/.config/gh/hosts.yml` is non-existent, the `auth git-credential get` command used to fail due to missing username.

Since GitHub username isn't at all required for token authentication, use the `x-access-token` faux username instead of trying to obtain one from a config file.

Fixes https://github.com/cli/cli/issues/2708#issuecomment-778111651