### PR TITLE
Add `pr create --body-file` flag

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -3,7 +3,6 @@ package create
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -113,7 +112,6 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 		Args: cmdutil.NoArgsQuoteReminder,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.TitleProvided = cmd.Flags().Changed("title")
-			opts.BodyProvided = cmd.Flags().Changed("body")
 			opts.RepoOverride, _ = cmd.Flags().GetString("repo")
 			noMaintainerEdit, _ := cmd.Flags().GetBool("no-maintainer-edit")
 			opts.MaintainerCanModify = !noMaintainerEdit
@@ -136,14 +134,9 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return errors.New("the `--no-maintainer-edit` flag is not supported with `--web`")
 			}
 
+			opts.BodyProvided = cmd.Flags().Changed("body")
 			if bodyFile != "" {
-				var b []byte
-				var err error
-				if bodyFile == "-" {
-					b, err = ioutil.ReadAll(opts.IO.In)
-				} else {
-					b, err = ioutil.ReadFile(bodyFile)
-				}
+				b, err := cmdutil.ReadFile(bodyFile, opts.IO.In)
 				if err != nil {
 					return err
 				}
@@ -162,7 +155,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	fl.BoolVarP(&opts.IsDraft, "draft", "d", false, "Mark pull request as a draft")
 	fl.StringVarP(&opts.Title, "title", "t", "", "Title for the pull request")
 	fl.StringVarP(&opts.Body, "body", "b", "", "Body for the pull request")
-	fl.StringVarP(&bodyFile, "body-file", "F", "", "Read body from file. Use - to read the body from the standard input.")
+	fl.StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file`")
 	fl.StringVarP(&opts.BaseBranch, "base", "B", "", "The `branch` into which you want your code merged")
 	fl.StringVarP(&opts.HeadBranch, "head", "H", "", "The `branch` that contains commits for your pull request (default: current branch)")
 	fl.BoolVarP(&opts.WebMode, "web", "w", false, "Open the web browser to create a pull request")

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -3,7 +3,6 @@ package create
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -106,12 +105,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			opts.BodyProvided = cmd.Flags().Changed("notes")
 			if notesFile != "" {
-				var b []byte
-				if notesFile == "-" {
-					b, err = ioutil.ReadAll(opts.IO.In)
-				} else {
-					b, err = ioutil.ReadFile(notesFile)
-				}
+				b, err := cmdutil.ReadFile(notesFile, opts.IO.In)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmdutil/file_input.go
+++ b/pkg/cmdutil/file_input.go
@@ -1,0 +1,16 @@
+package cmdutil
+
+import (
+	"io"
+	"io/ioutil"
+)
+
+func ReadFile(filename string, stdin io.ReadCloser) ([]byte, error) {
+	if filename == "-" {
+		b, err := ioutil.ReadAll(stdin)
+		_ = stdin.Close()
+		return b, err
+	}
+
+	return ioutil.ReadFile(filename)
+}


### PR DESCRIPTION
The `--body-file` flag helps to create long bodies or multi-line bodies.
In particular, it avoids the "filename or extension is too long" problem in Windows environments.

I refer to the following comments.
https://github.com/cli/cli/issues/595#issuecomment-608368316