### PR TITLE
Fix pasting Personal Access Token to `auth login` for GHE

### DIFF
--- a/pkg/cmd/auth/shared/login_flow_test.go
+++ b/pkg/cmd/auth/shared/login_flow_test.go
@@ -101,3 +101,55 @@ func TestLogin_ssh(t *testing.T) {
 	assert.Equal(t, "ATOKEN", cfg["example.com:oauth_token"])
 	assert.Equal(t, "ssh", cfg["example.com:git_protocol"])
 }
+
+func Test_scopesSentence(t *testing.T) {
+	type args struct {
+		scopes       []string
+		isEnterprise bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "basic scopes",
+			args: args{
+				scopes:       []string{"repo", "read:org"},
+				isEnterprise: false,
+			},
+			want: "'repo', 'read:org'",
+		},
+		{
+			name: "empty",
+			args: args{
+				scopes:       []string(nil),
+				isEnterprise: false,
+			},
+			want: "",
+		},
+		{
+			name: "workflow scope for dotcom",
+			args: args{
+				scopes:       []string{"repo", "workflow"},
+				isEnterprise: false,
+			},
+			want: "'repo', 'workflow'",
+		},
+		{
+			name: "workflow scope for GHE",
+			args: args{
+				scopes:       []string{"repo", "workflow"},
+				isEnterprise: true,
+			},
+			want: "'repo', 'workflow' (GHE 3.0+)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scopesSentence(tt.args.scopes, tt.args.isEnterprise); got != tt.want {
+				t.Errorf("scopesSentence() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cmd/auth/shared/oauth_scopes.go
+++ b/pkg/cmd/auth/shared/oauth_scopes.go
@@ -40,7 +40,7 @@ func HasMinimumScopes(httpClient httpClient, hostname, authToken string) error {
 		return err
 	}
 
-	req.Header.Set("Autorization", "token "+authToken)
+	req.Header.Set("Authorization", "token "+authToken)
 
 	res, err := httpClient.Do(req)
 	if err != nil {

--- a/pkg/cmd/auth/shared/oauth_scopes_test.go
+++ b/pkg/cmd/auth/shared/oauth_scopes_test.go
@@ -52,7 +52,9 @@ func Test_HasMinimumScopes(t *testing.T) {
 			fakehttp := &httpmock.Registry{}
 			defer fakehttp.Verify(t)
 
+			var gotAuthorization string
 			fakehttp.Register(httpmock.REST("GET", ""), func(req *http.Request) (*http.Response, error) {
+				gotAuthorization = req.Header.Get("authorization")
 				return &http.Response{
 					Request:    req,
 					StatusCode: 200,
@@ -70,6 +72,7 @@ func Test_HasMinimumScopes(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+			assert.Equal(t, gotAuthorization, "token ATOKEN")
 		})
 	}
 


### PR DESCRIPTION
After pasting a Personal Access Token during `auth login`, the flow would error out while trying to verify that the token has correct scopes. This was because of a malformed `Authorization` header. GitHub.com users were not affected because the API endpoint that was contacted is public and works without `Authorization`.

Additionally, the `workflow` scope is not present in GHE versions 2.x. Since we do not know which version of GHE the user plans to authenticate to, suggest in the UI that the `workflow` scope is only applicable to GHE 3.x:
```
$ gh auth login -h ghe.io
? What is your preferred protocol for Git operations? HTTPS
? Authenticate Git with your GitHub credentials? Yes
? How would you like to authenticate GitHub CLI? Paste an authentication token
Tip: you can generate a Personal Access Token here https://ghe.io/settings/tokens
The minimum required scopes are 'repo', 'read:org', 'workflow' (GHE 3.0+).
? Paste your authentication token:
```

Fixes #3014
Regression from https://github.com/cli/cli/pull/2892