### PR TITLE
Accept only one argument when deleting a gist

### DIFF
--- a/pkg/cmd/gist/delete/delete.go
+++ b/pkg/cmd/gist/delete/delete.go
@@ -29,7 +29,7 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "delete {<id> | <url>}",
 		Short: "Delete a gist",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.ExactArgs(1, "cannot delete: gist argument required"),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.Selector = args[0]
 			if runF != nil {

--- a/pkg/cmd/gist/delete/delete.go
+++ b/pkg/cmd/gist/delete/delete.go
@@ -29,7 +29,7 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "delete {<id> | <url>}",
 		Short: "Delete a gist",
-		Args:  cmdutil.MinimumArgs(1, "cannot delete: gist argument required"),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.Selector = args[0]
 			if runF != nil {

--- a/pkg/cmd/gist/edit/edit.go
+++ b/pkg/cmd/gist/edit/edit.go
@@ -49,7 +49,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "edit {<id> | <url>}",
 		Short: "Edit one of your gists",
-		Args:  cmdutil.MinimumArgs(1, "cannot edit: gist argument required"),
+		Args:  cmdutil.ExactArgs(1, "cannot edit: gist argument required"),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.Selector = args[0]
 

--- a/pkg/cmd/gist/view/view.go
+++ b/pkg/cmd/gist/view/view.go
@@ -35,7 +35,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "view {<id> | <url>}",
 		Short: "View a gist",
-		Args:  cmdutil.MinimumArgs(1, "cannot view: gist argument required"),
+		Args:  cmdutil.ExactArgs(1, "cannot view: gist argument required"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Selector = args[0]
 

--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -46,7 +46,7 @@ func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobr
 	cmd := &cobra.Command{
 		Use:   "checkout {<number> | <url> | <branch>}",
 		Short: "Check out a pull request in git",
-		Args:  cmdutil.MinimumArgs(1, "argument required"),
+		Args:  cmdutil.ExactArgs(1, "argument required"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmdutil/args.go
+++ b/pkg/cmdutil/args.go
@@ -22,9 +22,6 @@ func MinimumArgs(n int, msg string) cobra.PositionalArgs {
 }
 
 func ExactArgs(n int, msg string) cobra.PositionalArgs {
-	if msg == "" {
-		return cobra.MinimumNArgs(1)
-	}
 
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) > n {
@@ -32,7 +29,7 @@ func ExactArgs(n int, msg string) cobra.PositionalArgs {
 		}
 
 		if len(args) < n {
-			return &FlagError{Err: errors.New("not enough arguments")}
+			return &FlagError{Err: errors.New(msg)}
 		}
 
 		return nil

--- a/pkg/cmdutil/args.go
+++ b/pkg/cmdutil/args.go
@@ -21,6 +21,24 @@ func MinimumArgs(n int, msg string) cobra.PositionalArgs {
 	}
 }
 
+func ExactArgs(n int, msg string) cobra.PositionalArgs {
+	if msg == "" {
+		return cobra.MinimumNArgs(1)
+	}
+
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) > n {
+			return &FlagError{Err: errors.New("too many arguments")}
+		}
+
+		if len(args) < n {
+			return &FlagError{Err: errors.New("not enough arguments")}
+		}
+
+		return nil
+	}
+}
+
 func NoArgsQuoteReminder(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return nil


### PR DESCRIPTION
This commit adds a validation to check if multiple gist urls/ids are passed during deletion. It accepts only one url/id. Ref. https://github.com/cli/cli/issues/3015