### PR TITLE
Remove functionality to add, view and edit binary files in gists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cli/safeexec v1.0.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/enescakir/emoji v1.0.0
+	github.com/gabriel-vasile/mimetype v1.1.2
 	github.com/google/go-cmp v0.5.2
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-version v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/enescakir/emoji v1.0.0/go.mod h1:Bt1EKuLnKDTYpLALApstIkAjdDrS/8IAgTkK
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gabriel-vasile/mimetype v1.1.2 h1:gaPnPcNor5aZSVCJVSGipcpbgMWiAAj9z182ocSGbHU=
+github.com/gabriel-vasile/mimetype v1.1.2/go.mod h1:6CDPel/o/3/s4+bp6kIbsWATq8pmgOisOPG40CJa6To=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -30,8 +30,7 @@ type CreateOptions struct {
 	Public           bool
 	Filenames        []string
 	FilenameOverride string
-
-	WebMode bool
+	WebMode          bool
 
 	HttpClient func() (*http.Client, error)
 }
@@ -164,6 +163,8 @@ func processFiles(stdin io.ReadCloser, filenameOverride string, filenames []stri
 		var filename string
 		var content []byte
 		var err error
+		var isBinary bool
+
 		if f == "-" {
 			if filenameOverride != "" {
 				filename = filenameOverride
@@ -180,6 +181,16 @@ func processFiles(stdin io.ReadCloser, filenameOverride string, filenames []stri
 			if err != nil {
 				return fs, fmt.Errorf("failed to read file %s: %w", f, err)
 			}
+
+			isBinary, err = shared.IsBinaryContents(content)
+			if err != nil {
+				return nil, err
+			}
+
+			if isBinary {
+				return nil, fmt.Errorf("binary file not supported")
+			}
+
 			filename = path.Base(f)
 		}
 

--- a/pkg/cmd/gist/edit/edit.go
+++ b/pkg/cmd/gist/edit/edit.go
@@ -144,31 +144,25 @@ func editRun(opts *EditOptions) error {
 			}
 		}
 
-		if _, ok := gist.Files[filename]; !ok {
+		gistFile, found := gist.Files[filename]
+		if !found {
 			return fmt.Errorf("gist has no file %q", filename)
 		}
-
-		isBinary, err := shared.IsBinaryContents([]byte(gist.Files[filename].Content))
-		if err != nil {
-			return err
-		}
-
-		if isBinary {
-			return fmt.Errorf("Editing binary files not supported")
+		if shared.IsBinaryContents([]byte(gistFile.Content)) {
+			return fmt.Errorf("editing binary files not supported")
 		}
 
 		editorCommand, err := cmdutil.DetermineEditor(opts.Config)
 		if err != nil {
 			return err
 		}
-		text, err := opts.Edit(editorCommand, filename, gist.Files[filename].Content, opts.IO)
+		text, err := opts.Edit(editorCommand, filename, gistFile.Content, opts.IO)
 
 		if err != nil {
 			return err
 		}
 
-		if text != gist.Files[filename].Content {
-			gistFile := gist.Files[filename]
+		if text != gistFile.Content {
 			gistFile.Content = text // so it appears if they re-edit
 			filesToUpdate[filename] = text
 		}

--- a/pkg/cmd/gist/edit/edit.go
+++ b/pkg/cmd/gist/edit/edit.go
@@ -245,6 +245,14 @@ func updateGist(apiClient *api.Client, hostname string, gist *shared.Gist) error
 }
 
 func getFilesToAdd(file string) (map[string]*shared.GistFile, error) {
+	isBinary, err := shared.IsBinaryFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %s: %w", file, err)
+	}
+	if isBinary {
+		return nil, fmt.Errorf("failed to upload %s: binary file not supported", file)
+	}
+
 	content, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %s: %w", file, err)

--- a/pkg/cmd/gist/edit/edit.go
+++ b/pkg/cmd/gist/edit/edit.go
@@ -148,6 +148,15 @@ func editRun(opts *EditOptions) error {
 			return fmt.Errorf("gist has no file %q", filename)
 		}
 
+		isBinary, err := shared.IsBinaryContents([]byte(gist.Files[filename].Content))
+		if err != nil {
+			return err
+		}
+
+		if isBinary {
+			return fmt.Errorf("Editing binary files not supported")
+		}
+
 		editorCommand, err := cmdutil.DetermineEditor(opts.Config)
 		if err != nil {
 			return err

--- a/pkg/cmd/gist/edit/edit_test.go
+++ b/pkg/cmd/gist/edit/edit_test.go
@@ -301,7 +301,6 @@ func Test_editRun(t *testing.T) {
 		io.SetStdoutTTY(!tt.nontty)
 		io.SetStdinTTY(!tt.nontty)
 		tt.opts.IO = io
-
 		tt.opts.Selector = "1234"
 
 		tt.opts.Config = func() (config.Config, error) {

--- a/pkg/cmd/gist/shared/shared.go
+++ b/pkg/cmd/gist/shared/shared.go
@@ -4,17 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/gabriel-vasile/mimetype"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/ghinstance"
+	"github.com/gabriel-vasile/mimetype"
 	"github.com/shurcooL/githubv4"
 	"github.com/shurcooL/graphql"
-
-	"github.com/cli/cli/api"
 )
 
 type GistFile struct {
@@ -156,26 +155,22 @@ func IsBinaryFile(file string) (bool, error) {
 	}
 
 	isBinary := true
-
 	for mime := detectedMime; mime != nil; mime = mime.Parent() {
 		if mime.Is("text/plain") {
 			isBinary = false
+			break
 		}
 	}
-
 	return isBinary, nil
 }
 
-func IsBinaryContents(contents []byte) (bool, error) {
-	detectedMime := mimetype.Detect(contents)
-
+func IsBinaryContents(contents []byte) bool {
 	isBinary := true
-
-	for mime := detectedMime; mime != nil; mime = mime.Parent() {
+	for mime := mimetype.Detect(contents); mime != nil; mime = mime.Parent() {
 		if mime.Is("text/plain") {
 			isBinary = false
+			break
 		}
 	}
-
-	return isBinary, nil
+	return isBinary
 }

--- a/pkg/cmd/gist/shared/shared.go
+++ b/pkg/cmd/gist/shared/shared.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/gabriel-vasile/mimetype"
 	"net/http"
 	"net/url"
 	"strings"
@@ -146,4 +147,35 @@ pagination:
 	}
 
 	return gists, nil
+}
+
+func IsBinaryFile(file string) (bool, error) {
+	detectedMime, err := mimetype.DetectFile(file)
+	if err != nil {
+		return false, err
+	}
+
+	isBinary := true
+
+	for mime := detectedMime; mime != nil; mime = mime.Parent() {
+		if mime.Is("text/plain") {
+			isBinary = false
+		}
+	}
+
+	return isBinary, nil
+}
+
+func IsBinaryContents(contents []byte) (bool, error) {
+	detectedMime := mimetype.Detect(contents)
+
+	isBinary := true
+
+	for mime := detectedMime; mime != nil; mime = mime.Parent() {
+		if mime.Is("text/plain") {
+			isBinary = false
+		}
+	}
+
+	return isBinary, nil
 }

--- a/pkg/cmd/gist/shared/shared_test.go
+++ b/pkg/cmd/gist/shared/shared_test.go
@@ -61,6 +61,14 @@ func TestIsBinaryContents(t *testing.T) {
 			fileContent: []byte("package main"),
 		},
 		{
+			want:        false,
+			fileContent: []byte(""),
+		},
+		{
+			want:        false,
+			fileContent: []byte(nil),
+		},
+		{
 			want: true,
 			fileContent: []byte{239, 191, 189, 239, 191, 189, 239, 191, 189, 239,
 				191, 189, 239, 191, 189, 16, 74, 70, 73, 70, 239, 191, 189, 1, 1, 1,
@@ -74,10 +82,6 @@ func TestIsBinaryContents(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		isBinary, err := IsBinaryContents(tt.fileContent)
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, tt.want, isBinary)
+		assert.Equal(t, tt.want, IsBinaryContents(tt.fileContent))
 	}
 }

--- a/pkg/cmd/gist/shared/shared_test.go
+++ b/pkg/cmd/gist/shared/shared_test.go
@@ -50,3 +50,34 @@ func Test_GetGistIDFromURL(t *testing.T) {
 		})
 	}
 }
+
+func TestIsBinaryContents(t *testing.T) {
+	tests := []struct {
+		fileContent []byte
+		want        bool
+	}{
+		{
+			want:        false,
+			fileContent: []byte("package main"),
+		},
+		{
+			want: true,
+			fileContent: []byte{239, 191, 189, 239, 191, 189, 239, 191, 189, 239,
+				191, 189, 239, 191, 189, 16, 74, 70, 73, 70, 239, 191, 189, 1, 1, 1,
+				1, 44, 1, 44, 239, 191, 189, 239, 191, 189, 239, 191, 189, 239, 191,
+				189, 239, 191, 189, 67, 239, 191, 189, 8, 6, 6, 7, 6, 5, 8, 7, 7, 7,
+				9, 9, 8, 10, 12, 20, 10, 12, 11, 11, 12, 25, 18, 19, 15, 20, 29, 26,
+				31, 30, 29, 26, 28, 28, 32, 36, 46, 39, 32, 34, 44, 35, 28, 28, 40,
+				55, 41, 44, 48, 49, 52, 52, 52, 31, 39, 57, 61, 56, 50, 60, 46, 51,
+				52, 50, 239, 191, 189, 239, 191, 189, 239, 191, 189, 67, 1, 9, 9, 9, 12},
+		},
+	}
+
+	for _, tt := range tests {
+		isBinary, err := IsBinaryContents(tt.fileContent)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, tt.want, isBinary)
+	}
+}

--- a/pkg/cmd/gist/view/view.go
+++ b/pkg/cmd/gist/view/view.go
@@ -164,7 +164,10 @@ func viewRun(opts *ViewOptions) error {
 		filenames = append(filenames, fn)
 	}
 
-	sort.Strings(filenames)
+	sort.Slice(filenames, func(i, j int) bool {
+		return strings.ToLower(filenames[i]) < strings.ToLower(filenames[j])
+	})
+
 	if opts.ListFiles {
 		for _, fn := range filenames {
 			fmt.Fprintln(opts.IO.Out, fn)


### PR DESCRIPTION
This commit adds file validation to check if file contents are binary in nature, and if so halts creation, edition and rendering of contents directly to stdout.

Closes https://github.com/cli/cli/issues/2998