### PR TITLE
Isolate test suite from environment variables

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,27 @@ jobs:
 
       - name: Run tests
         run: go test -race ./...
+        # catch tests that are not well-isolated from the user's environment
+        env:
+          GH_TOKEN: ENVTOKEN
+          GITHUB_TOKEN: ENVTOKEN
+          GH_ENTERPRISE_TOKEN: ENVTOKEN
+          GITHUB_ENTERPRISE_TOKEN: ENVTOKEN
+          GH_REPO: ENVOWNER/ENVREPO
+          GH_HOST: envhost.net
+          GH_EDITOR: env-editor
+          GIT_EDITOR: env-editor
+          VISUAL: env-editor
+          EDITOR: env-editor
+          BROWSER: env-browser
+          DEBUG: 1
+          GH_PAGER: envpager
+          PAGER: envpager
+          GLAMOUR_STYLE: envstyle.json
+          NO_COLOR: 1
+          CLICOLOR: 1
+          CLICOLOR_FORCE: 1
+          GH_NO_UPDATE_NOTIFIER: 1
 
       - name: Build
         run: go build -v ./cmd/gh

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -6,15 +6,17 @@ import (
 	"testing"
 
 	"github.com/cli/cli/internal/run"
+	"github.com/cli/cli/pkg/env"
 )
 
 func setGitDir(t *testing.T, dir string) {
-	// TODO: also set XDG_CONFIG_HOME, GIT_CONFIG_NOSYSTEM
-	old_GIT_DIR := os.Getenv("GIT_DIR")
-	os.Setenv("GIT_DIR", dir)
-	t.Cleanup(func() {
-		os.Setenv("GIT_DIR", old_GIT_DIR)
+	wd, _ := os.Getwd()
+	reset := env.WithEnv(map[string]string{
+		"GIT_DIR":             dir,
+		"XDG_CONFIG_HOME":     wd,
+		"GIT_CONFIG_NOSYSTEM": "1",
 	})
+	t.Cleanup(reset)
 }
 
 func TestLastCommit(t *testing.T) {

--- a/internal/config/from_env_test.go
+++ b/internal/config/from_env_test.go
@@ -1,25 +1,14 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/pkg/env"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInheritEnv(t *testing.T) {
-	orig_GITHUB_TOKEN := os.Getenv("GITHUB_TOKEN")
-	orig_GITHUB_ENTERPRISE_TOKEN := os.Getenv("GITHUB_ENTERPRISE_TOKEN")
-	orig_GH_TOKEN := os.Getenv("GH_TOKEN")
-	orig_GH_ENTERPRISE_TOKEN := os.Getenv("GH_ENTERPRISE_TOKEN")
-	t.Cleanup(func() {
-		os.Setenv("GITHUB_TOKEN", orig_GITHUB_TOKEN)
-		os.Setenv("GITHUB_ENTERPRISE_TOKEN", orig_GITHUB_ENTERPRISE_TOKEN)
-		os.Setenv("GH_TOKEN", orig_GH_TOKEN)
-		os.Setenv("GH_ENTERPRISE_TOKEN", orig_GH_ENTERPRISE_TOKEN)
-	})
-
 	type wants struct {
 		hosts     []string
 		token     string
@@ -260,10 +249,12 @@ func TestInheritEnv(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("GITHUB_TOKEN", tt.GITHUB_TOKEN)
-			os.Setenv("GITHUB_ENTERPRISE_TOKEN", tt.GITHUB_ENTERPRISE_TOKEN)
-			os.Setenv("GH_TOKEN", tt.GH_TOKEN)
-			os.Setenv("GH_ENTERPRISE_TOKEN", tt.GH_ENTERPRISE_TOKEN)
+			t.Cleanup(env.WithEnv(map[string]string{
+				"GITHUB_TOKEN":            tt.GITHUB_TOKEN,
+				"GITHUB_ENTERPRISE_TOKEN": tt.GITHUB_ENTERPRISE_TOKEN,
+				"GH_TOKEN":                tt.GH_TOKEN,
+				"GH_ENTERPRISE_TOKEN":     tt.GH_ENTERPRISE_TOKEN,
+			}))
 
 			baseCfg := NewFromString(tt.baseConfig)
 			cfg := InheritEnv(baseCfg)
@@ -287,17 +278,6 @@ func TestInheritEnv(t *testing.T) {
 }
 
 func TestAuthTokenProvidedFromEnv(t *testing.T) {
-	orig_GITHUB_TOKEN := os.Getenv("GITHUB_TOKEN")
-	orig_GITHUB_ENTERPRISE_TOKEN := os.Getenv("GITHUB_ENTERPRISE_TOKEN")
-	orig_GH_TOKEN := os.Getenv("GH_TOKEN")
-	orig_GH_ENTERPRISE_TOKEN := os.Getenv("GH_ENTERPRISE_TOKEN")
-	t.Cleanup(func() {
-		os.Setenv("GITHUB_TOKEN", orig_GITHUB_TOKEN)
-		os.Setenv("GITHUB_ENTERPRISE_TOKEN", orig_GITHUB_ENTERPRISE_TOKEN)
-		os.Setenv("GH_TOKEN", orig_GH_TOKEN)
-		os.Setenv("GH_ENTERPRISE_TOKEN", orig_GH_ENTERPRISE_TOKEN)
-	})
-
 	tests := []struct {
 		name                    string
 		GITHUB_TOKEN            string
@@ -334,10 +314,12 @@ func TestAuthTokenProvidedFromEnv(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("GITHUB_TOKEN", tt.GITHUB_TOKEN)
-			os.Setenv("GITHUB_ENTERPRISE_TOKEN", tt.GITHUB_ENTERPRISE_TOKEN)
-			os.Setenv("GH_TOKEN", tt.GH_TOKEN)
-			os.Setenv("GH_ENTERPRISE_TOKEN", tt.GH_ENTERPRISE_TOKEN)
+			t.Cleanup(env.WithEnv(map[string]string{
+				"GITHUB_TOKEN":            tt.GITHUB_TOKEN,
+				"GITHUB_ENTERPRISE_TOKEN": tt.GITHUB_ENTERPRISE_TOKEN,
+				"GH_TOKEN":                tt.GH_TOKEN,
+				"GH_ENTERPRISE_TOKEN":     tt.GH_ENTERPRISE_TOKEN,
+			}))
 			assert.Equal(t, tt.provided, AuthTokenProvidedFromEnv())
 		})
 	}

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -3,7 +3,6 @@ package login
 import (
 	"bytes"
 	"net/http"
-	"os"
 	"regexp"
 	"testing"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/cli/cli/internal/config"
 	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/env"
 	"github.com/cli/cli/pkg/httpmock"
 	"github.com/cli/cli/pkg/iostreams"
 	"github.com/cli/cli/pkg/prompt"
@@ -204,6 +204,12 @@ func Test_loginRun_nontty(t *testing.T) {
 				Hostname: "github.com",
 				Token:    "abc123",
 			},
+			env: map[string]string{
+				"GH_TOKEN":                "",
+				"GITHUB_TOKEN":            "",
+				"GH_ENTERPRISE_TOKEN":     "",
+				"GITHUB_ENTERPRISE_TOKEN": "",
+			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
 			},
@@ -214,6 +220,12 @@ func Test_loginRun_nontty(t *testing.T) {
 			opts: &LoginOptions{
 				Hostname: "albert.wesker",
 				Token:    "abc123",
+			},
+			env: map[string]string{
+				"GH_TOKEN":                "",
+				"GITHUB_TOKEN":            "",
+				"GH_ENTERPRISE_TOKEN":     "",
+				"GITHUB_ENTERPRISE_TOKEN": "",
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.ScopesResponder("repo,read:org"))
@@ -226,6 +238,12 @@ func Test_loginRun_nontty(t *testing.T) {
 				Hostname: "github.com",
 				Token:    "abc456",
 			},
+			env: map[string]string{
+				"GH_TOKEN":                "",
+				"GITHUB_TOKEN":            "",
+				"GH_ENTERPRISE_TOKEN":     "",
+				"GITHUB_ENTERPRISE_TOKEN": "",
+			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("read:org"))
 			},
@@ -237,6 +255,12 @@ func Test_loginRun_nontty(t *testing.T) {
 				Hostname: "github.com",
 				Token:    "abc456",
 			},
+			env: map[string]string{
+				"GH_TOKEN":                "",
+				"GITHUB_TOKEN":            "",
+				"GH_ENTERPRISE_TOKEN":     "",
+				"GITHUB_ENTERPRISE_TOKEN": "",
+			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo"))
 			},
@@ -247,6 +271,12 @@ func Test_loginRun_nontty(t *testing.T) {
 			opts: &LoginOptions{
 				Hostname: "github.com",
 				Token:    "abc456",
+			},
+			env: map[string]string{
+				"GH_TOKEN":                "",
+				"GITHUB_TOKEN":            "",
+				"GH_ENTERPRISE_TOKEN":     "",
+				"GITHUB_ENTERPRISE_TOKEN": "",
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,admin:org"))
@@ -260,7 +290,10 @@ func Test_loginRun_nontty(t *testing.T) {
 				Token:    "abc456",
 			},
 			env: map[string]string{
-				"GH_TOKEN": "value_from_env",
+				"GH_TOKEN":                "ENVTOKEN",
+				"GITHUB_TOKEN":            "",
+				"GH_ENTERPRISE_TOKEN":     "",
+				"GITHUB_ENTERPRISE_TOKEN": "",
 			},
 			wantErr: "SilentError",
 			wantStderr: heredoc.Doc(`
@@ -275,7 +308,10 @@ func Test_loginRun_nontty(t *testing.T) {
 				Token:    "abc456",
 			},
 			env: map[string]string{
-				"GH_ENTERPRISE_TOKEN": "value_from_env",
+				"GH_TOKEN":                "",
+				"GITHUB_TOKEN":            "",
+				"GH_ENTERPRISE_TOKEN":     "ENVTOKEN",
+				"GITHUB_ENTERPRISE_TOKEN": "",
 			},
 			wantErr: "SilentError",
 			wantStderr: heredoc.Doc(`
@@ -303,20 +339,7 @@ func Test_loginRun_nontty(t *testing.T) {
 				return &http.Client{Transport: reg}, nil
 			}
 
-			old_GH_TOKEN := os.Getenv("GH_TOKEN")
-			os.Setenv("GH_TOKEN", tt.env["GH_TOKEN"])
-			old_GITHUB_TOKEN := os.Getenv("GITHUB_TOKEN")
-			os.Setenv("GITHUB_TOKEN", tt.env["GITHUB_TOKEN"])
-			old_GH_ENTERPRISE_TOKEN := os.Getenv("GH_ENTERPRISE_TOKEN")
-			os.Setenv("GH_ENTERPRISE_TOKEN", tt.env["GH_ENTERPRISE_TOKEN"])
-			old_GITHUB_ENTERPRISE_TOKEN := os.Getenv("GITHUB_ENTERPRISE_TOKEN")
-			os.Setenv("GITHUB_ENTERPRISE_TOKEN", tt.env["GITHUB_ENTERPRISE_TOKEN"])
-			defer func() {
-				os.Setenv("GH_TOKEN", old_GH_TOKEN)
-				os.Setenv("GITHUB_TOKEN", old_GITHUB_TOKEN)
-				os.Setenv("GH_ENTERPRISE_TOKEN", old_GH_ENTERPRISE_TOKEN)
-				os.Setenv("GITHUB_ENTERPRISE_TOKEN", old_GITHUB_ENTERPRISE_TOKEN)
-			}()
+			t.Cleanup(env.WithEnv(tt.env))
 
 			if tt.httpStubs != nil {
 				tt.httpStubs(reg)

--- a/pkg/cmdutil/auth_check_test.go
+++ b/pkg/cmdutil/auth_check_test.go
@@ -1,19 +1,14 @@
 package cmdutil
 
 import (
-	"os"
 	"testing"
 
 	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/pkg/env"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_CheckAuth(t *testing.T) {
-	orig_GITHUB_TOKEN := os.Getenv("GITHUB_TOKEN")
-	t.Cleanup(func() {
-		os.Setenv("GITHUB_TOKEN", orig_GITHUB_TOKEN)
-	})
-
 	tests := []struct {
 		name     string
 		cfg      func(config.Config)
@@ -51,11 +46,13 @@ func Test_CheckAuth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tokenValue := ""
 			if tt.envToken {
-				os.Setenv("GITHUB_TOKEN", "TOKEN")
-			} else {
-				os.Setenv("GITHUB_TOKEN", "")
+				tokenValue = "TOKEN"
 			}
+			t.Cleanup(env.WithEnv(map[string]string{
+				"GITHUB_TOKEN": tokenValue,
+			}))
 
 			cfg := config.NewBlankConfig()
 			tt.cfg(cfg)

--- a/pkg/cmdutil/auth_check_test.go
+++ b/pkg/cmdutil/auth_check_test.go
@@ -51,7 +51,10 @@ func Test_CheckAuth(t *testing.T) {
 				tokenValue = "TOKEN"
 			}
 			t.Cleanup(env.WithEnv(map[string]string{
-				"GITHUB_TOKEN": tokenValue,
+				"GH_TOKEN":                tokenValue,
+				"GITHUB_TOKEN":            "",
+				"GH_ENTERPRISE_TOKEN":     "",
+				"GITHUB_ENTERPRISE_TOKEN": "",
 			}))
 
 			cfg := config.NewBlankConfig()

--- a/pkg/env/with_env.go
+++ b/pkg/env/with_env.go
@@ -1,0 +1,26 @@
+package env
+
+import "os"
+
+// WithEnv changes environment variables and returns a function to restore them to their original values.
+func WithEnv(vars map[string]string) func() {
+	originalValues := map[string]*string{}
+	for name, value := range vars {
+		if oldValue, ok := os.LookupEnv(name); ok {
+			originalValues[name] = &oldValue
+		} else {
+			originalValues[name] = nil
+		}
+		os.Setenv(name, value)
+	}
+
+	return func() {
+		for name, oldValue := range originalValues {
+			if oldValue == nil {
+				os.Unsetenv(name)
+			} else {
+				os.Setenv(name, *oldValue)
+			}
+		}
+	}
+}

--- a/pkg/iostreams/color_test.go
+++ b/pkg/iostreams/color_test.go
@@ -1,20 +1,12 @@
 package iostreams
 
 import (
-	"os"
 	"testing"
+
+	"github.com/cli/cli/pkg/env"
 )
 
 func TestEnvColorDisabled(t *testing.T) {
-	orig_NO_COLOR := os.Getenv("NO_COLOR")
-	orig_CLICOLOR := os.Getenv("CLICOLOR")
-	orig_CLICOLOR_FORCE := os.Getenv("CLICOLOR_FORCE")
-	t.Cleanup(func() {
-		os.Setenv("NO_COLOR", orig_NO_COLOR)
-		os.Setenv("CLICOLOR", orig_CLICOLOR)
-		os.Setenv("CLICOLOR_FORCE", orig_CLICOLOR_FORCE)
-	})
-
 	tests := []struct {
 		name           string
 		NO_COLOR       string
@@ -60,10 +52,11 @@ func TestEnvColorDisabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("NO_COLOR", tt.NO_COLOR)
-			os.Setenv("CLICOLOR", tt.CLICOLOR)
-			os.Setenv("CLICOLOR_FORCE", tt.CLICOLOR_FORCE)
-
+			t.Cleanup(env.WithEnv(map[string]string{
+				"CLICOLOR":       tt.CLICOLOR,
+				"NO_COLOR":       tt.NO_COLOR,
+				"CLICOLOR_FORCE": tt.CLICOLOR_FORCE,
+			}))
 			if got := EnvColorDisabled(); got != tt.want {
 				t.Errorf("EnvColorDisabled(): want %v, got %v", tt.want, got)
 			}
@@ -72,15 +65,6 @@ func TestEnvColorDisabled(t *testing.T) {
 }
 
 func TestEnvColorForced(t *testing.T) {
-	orig_NO_COLOR := os.Getenv("NO_COLOR")
-	orig_CLICOLOR := os.Getenv("CLICOLOR")
-	orig_CLICOLOR_FORCE := os.Getenv("CLICOLOR_FORCE")
-	t.Cleanup(func() {
-		os.Setenv("NO_COLOR", orig_NO_COLOR)
-		os.Setenv("CLICOLOR", orig_CLICOLOR)
-		os.Setenv("CLICOLOR_FORCE", orig_CLICOLOR_FORCE)
-	})
-
 	tests := []struct {
 		name           string
 		NO_COLOR       string
@@ -133,10 +117,11 @@ func TestEnvColorForced(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("NO_COLOR", tt.NO_COLOR)
-			os.Setenv("CLICOLOR", tt.CLICOLOR)
-			os.Setenv("CLICOLOR_FORCE", tt.CLICOLOR_FORCE)
-
+			t.Cleanup(env.WithEnv(map[string]string{
+				"CLICOLOR":       tt.CLICOLOR,
+				"NO_COLOR":       tt.NO_COLOR,
+				"CLICOLOR_FORCE": tt.CLICOLOR_FORCE,
+			}))
 			if got := EnvColorForced(); got != tt.want {
 				t.Errorf("EnvColorForced(): want %v, got %v", tt.want, got)
 			}


### PR DESCRIPTION
A user who runs this repository's test suite could also reasonably have variables like `BROWSER` or `GLAMOUR_STYLE` set in their environment. Some of our tests fail because those outside environment variables bleed into tests.

This change introduces a helper to safely stub environment variable values with, as well as configures out test suite in CI to run in an environment with a bunch of values that could possibly affect gh runtime, but shouldn't do so for tests.