### PR TITLE
Add information about AUR

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -93,6 +93,8 @@ Arch Linux users can install from the [community repo][arch linux repo]:
 sudo pacman -S github-cli
 ```
 
+Or if you want to build it from source use the [unofficial AUR package](arch linux aur)
+
 ### Android
 
 Android 7+ users can install via [Termux](https://wiki.termux.com/wiki/Main_Page):
@@ -167,3 +169,4 @@ sudo snap install --edge gh && snap connect gh:ssh-keys
 
 [releases page]: https://github.com/cli/cli/releases/latest
 [arch linux repo]: https://www.archlinux.org/packages/community/x86_64/github-cli
+[arch linux aur]: https://aur.archlinux.org/packages/github-cli-git

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -93,7 +93,7 @@ Arch Linux users can install from the [community repo][arch linux repo]:
 sudo pacman -S github-cli
 ```
 
-Or if you want to build it from source use the [unofficial AUR package](arch linux aur)
+Or if you want to build it from source use the [unofficial AUR package][arch linux aur]
 
 ### Android
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -93,7 +93,7 @@ Arch Linux users can install from the [community repo][arch linux repo]:
 sudo pacman -S github-cli
 ```
 
-Or if you want to build it from source use the [unofficial AUR package][arch linux aur]
+Alternatively, use the [unofficial AUR package][arch linux aur] to build GitHub CLI from source.
 
 ### Android
 


### PR DESCRIPTION
The AUR is a community-based location for PKGBUILDs, Arch's Install scripts.

There is a unofficial PKGBUILD for building and installing `gh` from the git repo.

https://aur.archlinux.org/packages/github-cli-git

The AUR introduction was replaced with the community repo introduction with https://github.com/cli/cli/pull/1432. But since 2020-02-19 the git AUR package exist.

I don't added a command for installing it, cause there is not **the** AUR helper. `yay` is maybe the largest, but not the official supported by Arch Linux.