### PR TITLE
Use absolute path when configuring gh as git credential

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -163,10 +163,7 @@ func main() {
 
 	newRelease := <-updateMessageChan
 	if newRelease != nil {
-		isHomebrew := false
-		if ghExe, err := os.Executable(); err == nil {
-			isHomebrew = isUnderHomebrew(ghExe)
-		}
+		isHomebrew := isUnderHomebrew(cmdFactory.Executable)
 		if isHomebrew && isRecentRelease(newRelease.PublishedAt) {
 			// do not notify Homebrew users before the version bump had a chance to get merged into homebrew-core
 			return

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -23,6 +23,8 @@ type LoginOptions struct {
 	Config     func() (config.Config, error)
 	HttpClient func() (*http.Client, error)
 
+	MainExecutable string
+
 	Interactive bool
 
 	Hostname string
@@ -36,6 +38,8 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 		IO:         f.IOStreams,
 		Config:     f.Config,
 		HttpClient: f.HttpClient,
+
+		MainExecutable: f.Executable,
 	}
 
 	var tokenStdin bool
@@ -189,6 +193,7 @@ func loginRun(opts *LoginOptions) error {
 		Interactive: opts.Interactive,
 		Web:         opts.Web,
 		Scopes:      opts.Scopes,
+		Executable:  opts.MainExecutable,
 	})
 }
 

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -19,6 +19,8 @@ type RefreshOptions struct {
 	IO     *iostreams.IOStreams
 	Config func() (config.Config, error)
 
+	MainExecutable string
+
 	Hostname string
 	Scopes   []string
 	AuthFlow func(config.Config, *iostreams.IOStreams, string, []string) error
@@ -34,6 +36,7 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 			_, err := authflow.AuthFlowWithConfig(cfg, io, hostname, "", scopes)
 			return err
 		},
+		MainExecutable: f.Executable,
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/auth/shared/git_credential_test.go
+++ b/pkg/cmd/auth/shared/git_credential_test.go
@@ -12,7 +12,12 @@ func TestGitCredentialSetup_configureExisting(t *testing.T) {
 	cs.Register(`git credential reject`, 0, "")
 	cs.Register(`git credential approve`, 0, "")
 
-	if err := GitCredentialSetup("example.com", "monalisa", "PASSWD", "osxkeychain"); err != nil {
+	f := GitCredentialFlow{
+		Executable: "gh",
+		helper:     "osxkeychain",
+	}
+
+	if err := f.gitCredentialSetup("example.com", "monalisa", "PASSWD"); err != nil {
 		t.Errorf("GitCredentialSetup() error = %v", err)
 	}
 }
@@ -20,13 +25,29 @@ func TestGitCredentialSetup_configureExisting(t *testing.T) {
 func TestGitCredentialSetup_setOurs(t *testing.T) {
 	cs, restoreRun := run.Stub()
 	defer restoreRun(t)
-	cs.Register(`git config --global credential\.https://example\.com\.helper`, 0, "", func(args []string) {
-		if val := args[len(args)-1]; val != "!gh auth git-credential" {
+	cs.Register(`git config --global credential\.`, 0, "", func(args []string) {
+		if key := args[len(args)-2]; key != "credential.https://example.com.helper" {
+			t.Errorf("git config key was %q", key)
+		}
+		if val := args[len(args)-1]; val != "" {
+			t.Errorf("global credential helper configured to %q", val)
+		}
+	})
+	cs.Register(`git config --global --add credential\.`, 0, "", func(args []string) {
+		if key := args[len(args)-2]; key != "credential.https://example.com.helper" {
+			t.Errorf("git config key was %q", key)
+		}
+		if val := args[len(args)-1]; val != "!/path/to/gh auth git-credential" {
 			t.Errorf("global credential helper configured to %q", val)
 		}
 	})
 
-	if err := GitCredentialSetup("example.com", "monalisa", "PASSWD", ""); err != nil {
+	f := GitCredentialFlow{
+		Executable: "/path/to/gh",
+		helper:     "",
+	}
+
+	if err := f.gitCredentialSetup("example.com", "monalisa", "PASSWD"); err != nil {
 		t.Errorf("GitCredentialSetup() error = %v", err)
 	}
 }

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -28,6 +28,7 @@ type LoginOptions struct {
 	Interactive bool
 	Web         bool
 	Scopes      []string
+	Executable  string
 
 	sshContext sshContext
 }
@@ -56,7 +57,7 @@ func Login(opts *LoginOptions) error {
 
 	var additionalScopes []string
 
-	credentialFlow := &GitCredentialFlow{}
+	credentialFlow := &GitCredentialFlow{Executable: opts.Executable}
 	if opts.Interactive && gitProtocol == "https" {
 		if err := credentialFlow.Prompt(hostname); err != nil {
 			return err

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -44,6 +44,11 @@ func New(appVersion string) *cmdutil.Factory {
 	}
 	remotesFunc := rr.Resolver(hostOverride)
 
+	ghExecutable := "gh"
+	if exe, err := os.Executable(); err == nil {
+		ghExecutable = exe
+	}
+
 	return &cmdutil.Factory{
 		IOStreams: io,
 		Config:    configFunc,
@@ -70,5 +75,6 @@ func New(appVersion string) *cmdutil.Factory {
 			}
 			return currentBranch, nil
 		},
+		Executable: ghExecutable,
 	}
 }

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -16,4 +16,7 @@ type Factory struct {
 	Remotes    func() (context.Remotes, error)
 	Config     func() (config.Config, error)
 	Branch     func() (string, error)
+
+	// Executable is the path to the currently invoked gh binary
+	Executable string
 }


### PR DESCRIPTION
This keeps git operations working even when PATH is modified, e.g. `brew update` will work even though Homebrew runs the command explicitly without `/usr/local/bin` in PATH.

Additionally, this inserts a blank value for `credential.*.helper` to instruct git to ignore previously configured credential helpers, i.e. those that might have been set up in system configuration files. We do this because otherwise, git will store the credential obtained from gh in every other credential helper in the chain, which we want to avoid.

Before:

    git config --global credential.https://github.com.helper '!gh auth git-credential'

After:

    git config --global credential.https://github.com.helper ''
    git config --global --add credential.https://github.com.helper '!/path/to/gh auth git-credential'

Fixes https://github.com/cli/cli/issues/2995