### PR TITLE
Add multigraphql package for batching several GraphQL queries in one …

### DIFF
--- a/pkg/multigraphql/decode.go
+++ b/pkg/multigraphql/decode.go
@@ -1,0 +1,46 @@
+package multigraphql
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+type graphqlResponse struct {
+	Data   map[string]*json.RawMessage
+	Errors []struct {
+		Message string
+	}
+}
+
+// Decode parses the GraphQL JSON response
+func Decode(r io.Reader, destinations []interface{}) error {
+	resp := graphqlResponse{}
+	if err := json.NewDecoder(r).Decode(&resp); err != nil {
+		return err
+	}
+
+	if len(resp.Errors) > 0 {
+		messages := []string{}
+		for _, e := range resp.Errors {
+			messages = append(messages, e.Message)
+		}
+		return fmt.Errorf("GraphQL error: %s", strings.Join(messages, "; "))
+	}
+
+	for alias, value := range resp.Data {
+		if !strings.HasPrefix(alias, "multi_") {
+			continue
+		}
+		i, _ := strconv.Atoi(strings.TrimPrefix(alias, "multi_"))
+		dec := json.NewDecoder(bytes.NewReader([]byte(*value)))
+		if err := dec.Decode(destinations[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/multigraphql/decode_test.go
+++ b/pkg/multigraphql/decode_test.go
@@ -1,0 +1,54 @@
+package multigraphql
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDecode(t *testing.T) {
+	buf := bytes.NewBufferString(`
+	{ "extensions": [],
+	  "data": {
+		"multi_000": { "world": true },
+		"multi_001": { "machines": "are learning" }
+	} }
+	`)
+
+	hello := struct {
+		World bool
+	}{}
+	ai := struct {
+		Machines string
+	}{}
+
+	err := Decode(buf, []interface{}{&hello, &ai})
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+
+	if !hello.World {
+		t.Errorf("expected World to be true")
+	}
+	if ai.Machines != "are learning" {
+		t.Errorf("expected machines to be learning, got %q", ai.Machines)
+	}
+}
+
+func TestDecode_errors(t *testing.T) {
+	buf := bytes.NewBufferString(`
+	{ "extensions": [],
+	  "errors": [
+		{ "message": "boom" },
+		{ "message": "shutting down" }
+	] }
+	`)
+
+	hello := struct {
+		World bool
+	}{}
+
+	err := Decode(buf, []interface{}{&hello})
+	if err == nil || err.Error() != "GraphQL error: boom; shutting down" {
+		t.Fatalf("got error: %v", err)
+	}
+}

--- a/pkg/multigraphql/merge.go
+++ b/pkg/multigraphql/merge.go
@@ -1,0 +1,94 @@
+package multigraphql
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// PreparedQuery represents a Query with associated variable values
+type PreparedQuery struct {
+	variableValues map[string]interface{}
+	Query
+}
+
+var identifier = regexp.MustCompile(`\$[a-zA-Z]\w*`)
+
+// Merge combines multiple queries into one while avoiding variable collisions
+func Merge(queries ...PreparedQuery) (string, map[string]interface{}) {
+	out := &bytes.Buffer{}
+	queryStrings := []string{}
+	allVariables := map[string]string{}
+	allValues := map[string]interface{}{}
+	seenFragments := map[string]struct{}{"": {}}
+
+	for i, q := range queries {
+		renames := mergeVariables(allVariables, q.variables, func(k string) string {
+			return fmt.Sprintf("%s_%03d", k, i)
+		})
+
+		for key, value := range q.variableValues {
+			if newKey, exists := renames[key]; exists {
+				key = newKey
+			}
+			allValues[key] = value
+		}
+
+		if _, seen := seenFragments[q.fragments]; !seen {
+			fmt.Fprintln(out, q.fragments)
+			seenFragments[q.fragments] = struct{}{}
+		}
+
+		finalQuery := renameVariables(q.query, renames)
+		queryStrings = append(queryStrings, fmt.Sprintf("multi_%03d: %s", i, finalQuery))
+	}
+
+	fmt.Fprint(out, "query")
+	writeVariables(out, allVariables)
+	fmt.Fprintf(out, " {\n\t%s\n}", strings.Join(queryStrings, "\n\t"))
+
+	return out.String(), allValues
+}
+
+func mergeVariables(dest, src map[string]string, keyGen func(string) string) map[string]string {
+	renames := map[string]string{}
+	for key, value := range src {
+		if _, exists := dest[key]; exists {
+			newKey := keyGen(key)
+			renames[key] = newKey
+			key = newKey
+		}
+		dest[key] = value
+	}
+	return renames
+}
+
+func renameVariables(q string, dictionary map[string]string) string {
+	return identifier.ReplaceAllStringFunc(q, func(v string) string {
+		if newName, exists := dictionary[v[1:]]; exists {
+			return "$" + newName
+		}
+		return v
+	})
+}
+
+func writeVariables(out io.Writer, variables map[string]string) {
+	if len(variables) == 0 {
+		return
+	}
+
+	vars := []string{}
+	for key, value := range variables {
+		vars = append(vars, fmt.Sprintf("$%s: %s", key, value))
+	}
+	sort.Sort(sort.StringSlice(vars))
+
+	fmt.Fprint(out, "(\n")
+	for _, v := range vars {
+		fmt.Fprintf(out, "\t%s\n", v)
+	}
+	fmt.Fprint(out, ")")
+}

--- a/pkg/multigraphql/merge_test.go
+++ b/pkg/multigraphql/merge_test.go
@@ -1,0 +1,156 @@
+package multigraphql
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMerge(t *testing.T) {
+	type args struct {
+		queries []PreparedQuery
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantQuery  string
+		wantValues map[string]interface{}
+	}{
+		{
+			name: "A single query",
+			args: args{
+				queries: []PreparedQuery{
+					PreparedQuery{
+						variableValues: map[string]interface{}{
+							"owner": "monalisa",
+							"repo":  "hello-world",
+						},
+						Query: Query{
+							query:     `repository(owner: $owner, name: $repo) { id }`,
+							variables: map[string]string{"owner": "String!", "repo": "String"},
+						},
+					},
+				},
+			},
+			wantQuery: `query(
+	$owner: String!
+	$repo: String
+) {
+	multi_000: repository(owner: $owner, name: $repo) { id }
+}`,
+			wantValues: map[string]interface{}{
+				"owner": "monalisa",
+				"repo":  "hello-world",
+			},
+		},
+		{
+			name: "Multiple queries",
+			args: args{
+				queries: []PreparedQuery{
+					PreparedQuery{
+						variableValues: map[string]interface{}{
+							"owner": "monalisa",
+							"repo":  "hello-world",
+						},
+						Query: Query{
+							query:     `repository(owner: $owner, name: $repo) { id }`,
+							variables: map[string]string{"owner": "String!", "repo": "String"},
+						},
+					},
+					PreparedQuery{
+						variableValues: map[string]interface{}{
+							"owner": "hubot",
+							"repo":  "chatops",
+							"user":  "octocat",
+						},
+						Query: Query{
+							query:     `repository(owner: $owner, name: $repo, assignee: $user) { id }`,
+							variables: map[string]string{"owner": "String", "repo": "String!", "user": "String"},
+						},
+					},
+					PreparedQuery{
+						variableValues: map[string]interface{}{
+							"owner": "github",
+							"user":  "ghost",
+						},
+						Query: Query{
+							query:     `repository(owner: $owner, assignee: $user) { id }`,
+							variables: map[string]string{"owner": "String", "user": "String!"},
+						},
+					},
+				},
+			},
+			wantQuery: `query(
+	$owner: String!
+	$owner_001: String
+	$owner_002: String
+	$repo: String
+	$repo_001: String!
+	$user: String
+	$user_002: String!
+) {
+	multi_000: repository(owner: $owner, name: $repo) { id }
+	multi_001: repository(owner: $owner_001, name: $repo_001, assignee: $user) { id }
+	multi_002: repository(owner: $owner_002, assignee: $user_002) { id }
+}`,
+			wantValues: map[string]interface{}{
+				"owner":     "monalisa",
+				"repo":      "hello-world",
+				"owner_001": "hubot",
+				"repo_001":  "chatops",
+				"user":      "octocat",
+				"owner_002": "github",
+				"user_002":  "ghost",
+			},
+		},
+		{
+			name: "Queries with fragments",
+			args: args{
+				queries: []PreparedQuery{
+					PreparedQuery{
+						variableValues: map[string]interface{}{},
+						Query: Query{
+							query:     `a { ...b }`,
+							fragments: `fragment b on B { boo }`,
+							variables: map[string]string{},
+						},
+					},
+					PreparedQuery{
+						variableValues: map[string]interface{}{},
+						Query: Query{
+							query:     `c { ...b }`,
+							fragments: `fragment b on B { boo }`,
+							variables: map[string]string{},
+						},
+					},
+					PreparedQuery{
+						variableValues: map[string]interface{}{},
+						Query: Query{
+							query:     `d { ...e }`,
+							fragments: `fragment e on E { eeek }`,
+							variables: map[string]string{},
+						},
+					},
+				},
+			},
+			wantQuery: `fragment b on B { boo }
+fragment e on E { eeek }
+query {
+	multi_000: a { ...b }
+	multi_001: c { ...b }
+	multi_002: d { ...e }
+}`,
+			wantValues: map[string]interface{}{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := Merge(tt.args.queries...)
+			if got != tt.wantQuery {
+				t.Errorf("Merge() got = %#v, want %#v", got, tt.wantQuery)
+			}
+			if !reflect.DeepEqual(got1, tt.wantValues) {
+				t.Errorf("Merge() got1 = %v, want %v", got1, tt.wantValues)
+			}
+		})
+	}
+}

--- a/pkg/multigraphql/parse.go
+++ b/pkg/multigraphql/parse.go
@@ -1,0 +1,61 @@
+package multigraphql
+
+import (
+	"regexp"
+	"strings"
+)
+
+// A Query is a parsed GraphQL query
+type Query struct {
+	query     string
+	fragments string
+	variables map[string]string
+}
+
+var (
+	// matches opening `query(...) {`
+	queryStart = regexp.MustCompile(`(?m)^\s*(?:query(?:\s*\(([^)]+)\))?\s*)?\{[ \t]*(\r?\n)?`)
+	// matches trailing `}`
+	queryEnd = regexp.MustCompile(`\s*\}\s*$`)
+)
+
+// Parse splits a GraphQL query into parts
+func Parse(q string) Query {
+	var fragments string
+	queryStr := q
+
+	m := queryStart.FindStringSubmatchIndex(q)
+	if len(m) > 0 {
+		fragments = q[0:m[0]]
+		queryStr = queryEnd.ReplaceAllLiteralString(q[m[1]:], "")
+	}
+
+	result := Query{
+		query:     queryStr,
+		fragments: fragments,
+		variables: make(map[string]string),
+	}
+
+	if len(m) > 2 && m[2] > -1 {
+		parseVariables(result.variables, q[m[2]:m[3]])
+	}
+
+	return result
+}
+
+func parseVariables(dest map[string]string, vars string) {
+	// parse query variables, e.g. `$foo: String!, $bar: Int = 5`
+	for _, v := range strings.Split(vars, "$") {
+		keyValue := strings.SplitN(v, ":", 2)
+		key := graphqlTrim(keyValue[0])
+		if key == "" || len(keyValue) < 2 {
+			continue
+		}
+		value := graphqlTrim(keyValue[1])
+		dest[key] = value
+	}
+}
+
+func graphqlTrim(s string) string {
+	return strings.Trim(s, " \t\r\n,")
+}

--- a/pkg/multigraphql/parse_test.go
+++ b/pkg/multigraphql/parse_test.go
@@ -1,0 +1,129 @@
+package multigraphql
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	type args struct {
+		q string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Query
+	}{
+		{
+			name: "Query with variables",
+			args: args{
+				q: `
+query($name: String!, $perPage: Int = 30) {
+	a { b }
+}
+`,
+			},
+			want: Query{
+				query:     "\ta { b }",
+				fragments: "",
+				variables: map[string]string{
+					"name":    "String!",
+					"perPage": "Int = 30",
+				},
+			},
+		},
+		{
+			name: "Query with multi-line variables",
+			args: args{
+				q: `
+query(
+	$name: String!,
+	$perPage: Int = 30,
+) {
+	a { b }
+}
+`,
+			},
+			want: Query{
+				query:     "\ta { b }",
+				fragments: "",
+				variables: map[string]string{
+					"name":    "String!",
+					"perPage": "Int = 30",
+				},
+			},
+		},
+		{
+			name: "Query with comma-less variables",
+			args: args{
+				q: `
+query($name: String!$perPage: Int = 30,
+	$user : String
+	$state : [State!] = OPEN
+) {
+	a { b }
+}
+`,
+			},
+			want: Query{
+				query:     "\ta { b }",
+				fragments: "",
+				variables: map[string]string{
+					"name":    "String!",
+					"perPage": "Int = 30",
+					"user":    "String",
+					"state":   "[State!] = OPEN",
+				},
+			},
+		},
+		{
+			name: "Query with fragments",
+			args: args{
+				q: `
+fragment a on A { foo }
+fragment b on B { bar }
+query {
+	a { ...b }
+}
+`,
+			},
+			want: Query{
+				query:     "\ta { ...b }",
+				fragments: "\nfragment a on A { foo }\nfragment b on B { bar }\n",
+				variables: map[string]string{},
+			},
+		},
+		{
+			name: "Query with no keyword",
+			args: args{
+				q: `
+fragment b on B { bar }
+{ a { ...b } }
+`,
+			},
+			want: Query{
+				query:     "a { ...b }",
+				fragments: "\nfragment b on B { bar }\n",
+				variables: map[string]string{},
+			},
+		},
+		{
+			name: "Malformed query",
+			args: args{
+				q: `a { b }`,
+			},
+			want: Query{
+				query:     "a { b }",
+				fragments: "",
+				variables: map[string]string{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Parse(tt.args.q); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> …request


Some of the upcoming gh features depend on querying information about an
arbitrary number of repositories (determined at runtime). GraphQL (in
theory) allows us to perform all those lookups in a single query, rather
than over N individual queries, but we don't yet have a great mechanism
for combining several GraphQL queries into one and parsing the combined
result. This implements a potential approach:

1. The `Parse(str)` function returns a Query;
2. A PreparedQuery combines that with scalar values ("variables") for the query;
3. `Merge(queries...)` returns the final GraphQL query string + combined variables for the request;
4. `Decode(body, destinations)` segments the JSON response into corresponding destination interfaces.