### PR TITLE
Avoid checking for new releases when authenticating git

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -236,7 +236,7 @@ func shouldCheckForUpdate() bool {
 	if os.Getenv("CODESPACES") != "" {
 		return false
 	}
-	return updaterEnabled != "" && !isCI() && !isCompletionCommand() && utils.IsTerminal(os.Stderr)
+	return updaterEnabled != "" && !isCI() && utils.IsTerminal(os.Stdout) && utils.IsTerminal(os.Stderr)
 }
 
 // based on https://github.com/watson/ci-info/blob/HEAD/index.js
@@ -244,10 +244,6 @@ func isCI() bool {
 	return os.Getenv("CI") != "" || // GitHub Actions, Travis CI, CircleCI, Cirrus CI, GitLab CI, AppVeyor, CodeShip, dsari
 		os.Getenv("BUILD_NUMBER") != "" || // Jenkins, TeamCity
 		os.Getenv("RUN_ID") != "" // TaskCluster, dsari
-}
-
-func isCompletionCommand() bool {
-	return len(os.Args) > 1 && os.Args[1] == "completion"
 }
 
 func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {


### PR DESCRIPTION
In general, avoid displaying upgrade notice if _any_ output is redirected, not just stderr. This also alleviates the need to specifically check for `gh completion -s <shell>`, `gh __complete`, and other scripting scenarios where we absolutely don't want to trigger any upgrade checks or notices.

Fixes #3080