### PR TITLE
Actions demo

### DIFF
--- a/api/queries_actions.go
+++ b/api/queries_actions.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/cli/cli/internal/ghinstance"
+	"github.com/cli/cli/internal/ghrepo"
+)
+
+func (c Client) JobLog(repo ghrepo.Interface, jobID string) (io.ReadCloser, error) {
+	url := fmt.Sprintf("%srepos/%s/actions/jobs/%s/logs",
+		ghinstance.RESTPrefix(repo.RepoHost()), ghrepo.FullName(repo), jobID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == 404 {
+		return nil, &NotFoundError{errors.New("job not found")}
+	} else if resp.StatusCode != 200 {
+		return nil, HandleHTTPError(resp)
+	}
+
+	return resp.Body, nil
+}

--- a/pkg/cmd/actions/actions.go
+++ b/pkg/cmd/actions/actions.go
@@ -1,0 +1,56 @@
+package actions
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type ActionsOptions struct {
+	IO *iostreams.IOStreams
+}
+
+func NewCmdActions(f *cmdutil.Factory) *cobra.Command {
+	opts := ActionsOptions{
+		IO: f.IOStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "actions",
+		Short: "Learn about working with GitHub acitons",
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			actionsRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+func actionsRun(opts ActionsOptions) {
+	cs := opts.IO.ColorScheme()
+	fmt.Fprint(opts.IO.Out, fmt.Sprintf(heredoc.Doc(`
+		Welcome to GitHub Actions on the command line.
+
+		%s
+		gh workflow list:    List workflows in the current repository
+		gh workflow run:     Kick off a workflow run
+		gh workflow init:    Create a new workflow
+		gh workflow check:   Check a workflow file for correctness
+
+		%s
+		gh run list:    List recent workflow runs
+		gh run view:    View details for a given workflow run
+		gh run watch:   Watch a streaming log for a workflow run
+
+		%s
+		gh job view:   View details for a given job
+		gh job run:    Run a given job within a workflow
+	`),
+		cs.Bold("Working with workflows"),
+		cs.Bold("Working with runs"),
+		cs.Bold("Working with jobs within runs")))
+}

--- a/pkg/cmd/actions/actions.go
+++ b/pkg/cmd/actions/actions.go
@@ -32,7 +32,7 @@ func NewCmdActions(f *cmdutil.Factory) *cobra.Command {
 
 func actionsRun(opts ActionsOptions) {
 	cs := opts.IO.ColorScheme()
-	fmt.Fprint(opts.IO.Out, fmt.Sprintf(heredoc.Doc(`
+	fmt.Fprint(opts.IO.Out, heredoc.Docf(`
 		Welcome to GitHub Actions on the command line.
 
 		%s
@@ -49,7 +49,7 @@ func actionsRun(opts ActionsOptions) {
 		%s
 		gh job view:   View details for a given job
 		gh job run:    Run a given job within a workflow
-	`),
+	`,
 		cs.Bold("Working with workflows"),
 		cs.Bold("Working with runs"),
 		cs.Bold("Working with jobs within runs")))

--- a/pkg/cmd/job/job.go
+++ b/pkg/cmd/job/job.go
@@ -1,0 +1,21 @@
+package job
+
+import (
+	viewCmd "github.com/cli/cli/pkg/cmd/job/view"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdJob(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "job <command>",
+		Short: "Interact with the individual jobs of a workflow run",
+		Long:  "List and view the jobs of a workflow run including full logs",
+		// TODO action annotation
+	}
+	cmdutil.EnableRepoOverride(cmd, f)
+
+	cmd.AddCommand(viewCmd.NewCmdView(f, nil))
+
+	return cmd
+}

--- a/pkg/cmd/job/view/view.go
+++ b/pkg/cmd/job/view/view.go
@@ -1,0 +1,240 @@
+package view
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmd/run/shared"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/pkg/prompt"
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+type ViewOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	JobID string
+	Log   bool
+
+	Prompt       bool
+	ShowProgress bool
+
+	Now func() time.Time
+}
+
+func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Command {
+	opts := &ViewOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Now:        time.Now,
+	}
+	cmd := &cobra.Command{
+		Use:   "view [<job-id>]",
+		Short: "View the summary or full logs of a workflow run's job",
+		// TODO examples?
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			terminal := opts.IO.IsStdoutTTY() && opts.IO.IsStdinTTY()
+			opts.ShowProgress = terminal
+
+			if len(args) > 0 {
+				opts.JobID = args[0]
+			} else if !terminal {
+				return &cmdutil.FlagError{Err: errors.New("expected a job ID")}
+			} else {
+				opts.Prompt = true
+			}
+
+			if opts.Log && len(args) == 0 {
+				return &cmdutil.FlagError{Err: errors.New("job ID required when passing --log")}
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return runView(opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.Log, "log", "l", false, "Print full logs for job")
+
+	return cmd
+}
+
+func runView(opts *ViewOptions) error {
+	c, err := opts.HttpClient()
+	if err != nil {
+		// TODO error handle
+		return err
+	}
+	client := api.NewClientFromHTTP(c)
+
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		// TODO error handle
+		return err
+	}
+
+	out := opts.IO.Out
+	cs := opts.IO.ColorScheme()
+
+	jobID := opts.JobID
+	if opts.Prompt {
+		runID, err := shared.PromptForRun(cs, client, repo)
+		if err != nil {
+			// TODO error handle
+			return err
+		}
+		// TODO I'd love to overwrite the result of the prompt since it adds visual noise but I'm not sure
+		// the cleanest way to do that.
+		fmt.Fprintln(out)
+
+		if opts.ShowProgress {
+			opts.IO.StartProgressIndicator()
+		}
+
+		run, err := shared.GetRun(client, repo, runID)
+		if err != nil {
+			// TODO error handle
+			return err
+		}
+
+		if opts.ShowProgress {
+			opts.IO.StopProgressIndicator()
+		}
+
+		jobID, err = promptForJob(*opts, client, repo, *run)
+		if err != nil {
+			// TODO error handle
+			return err
+		}
+
+		fmt.Fprintln(out)
+	}
+
+	if opts.ShowProgress {
+		opts.IO.StartProgressIndicator()
+	}
+
+	job, err := getJob(client, repo, jobID)
+	if err != nil {
+		// TODO error handle
+		return err
+	}
+
+	if opts.Log {
+		r, err := client.JobLog(repo, jobID)
+		if err != nil {
+			return err
+		}
+
+		for {
+			buff := make([]byte, 64)
+			n, err := r.Read(buff)
+			if n <= 0 {
+				break
+			}
+			fmt.Fprintf(out, string(buff[0:n]))
+			if err != nil {
+				break
+			}
+		}
+		return nil
+	}
+
+	annotations, err := shared.GetAnnotations(client, repo, *job)
+	if err != nil {
+		// TODO handle error
+		return nil
+	}
+
+	if opts.ShowProgress {
+		opts.IO.StopProgressIndicator()
+	}
+
+	ago := opts.Now().Sub(job.StartedAt)
+	elapsed := job.CompletedAt.Sub(job.StartedAt)
+	// TODO prob format elapsed?
+
+	fmt.Fprintf(out, "%s (ID %s)\n", cs.Bold(job.Name), cs.Cyanf("%d", job.ID))
+	fmt.Fprintf(out, "%s %s in %s\n",
+		shared.Symbol(cs, job.Status, job.Conclusion),
+		utils.FuzzyAgo(ago),
+		elapsed)
+
+	fmt.Fprintln(out)
+
+	for _, step := range job.Steps {
+		fmt.Fprintf(out, "%s %s\n",
+			shared.Symbol(cs, step.Status, step.Conclusion),
+			step.Name)
+	}
+
+	if len(annotations) == 0 {
+		return nil
+	}
+
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, cs.Bold("ANNOTATIONS"))
+
+	for _, a := range annotations {
+		fmt.Fprintf(out, "%s %s\n", a.Symbol(cs), a.Message)
+		fmt.Fprintln(out, cs.Grayf("%s#%d\n", a.Path, a.StartLine))
+	}
+
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "To see the full logs for this job, try: gh job view %s --log\n", jobID)
+
+	return nil
+}
+
+func getJob(client *api.Client, repo ghrepo.Interface, jobID string) (*shared.Job, error) {
+	path := fmt.Sprintf("repos/%s/actions/jobs/%s", ghrepo.FullName(repo), jobID)
+
+	var result shared.Job
+	err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func promptForJob(opts ViewOptions, client *api.Client, repo ghrepo.Interface, run shared.Run) (string, error) {
+	cs := opts.IO.ColorScheme()
+	jobs, err := shared.GetJobs(client, repo, run)
+	if err != nil {
+		return "", err
+	}
+
+	var selected int
+
+	candidates := []string{}
+
+	for _, job := range jobs {
+		symbol := shared.Symbol(cs, job.Status, job.Conclusion)
+		candidates = append(candidates, fmt.Sprintf("%s %s", symbol, job.Name))
+	}
+
+	// TODO consider custom filter so it's fuzzier. right now matches start anywhere in string but
+	// become contiguous
+	err = prompt.SurveyAskOne(&survey.Select{
+		Message:  "Select a job to view",
+		Options:  candidates,
+		PageSize: 10,
+	}, &selected)
+
+	return fmt.Sprintf("%d", jobs[selected].ID), nil
+}

--- a/pkg/cmd/job/view/view.go
+++ b/pkg/cmd/job/view/view.go
@@ -115,6 +115,7 @@ func runView(opts *ViewOptions) error {
 			opts.IO.StopProgressIndicator()
 		}
 
+		// TODO if only one job in run, don't bother prompting just select it
 		jobID, err = promptForJob(*opts, client, repo, *run)
 		if err != nil {
 			// TODO error handle
@@ -146,7 +147,7 @@ func runView(opts *ViewOptions) error {
 			if n <= 0 {
 				break
 			}
-			fmt.Fprintf(out, string(buff[0:n]))
+			fmt.Fprint(out, string(buff[0:n]))
 			if err != nil {
 				break
 			}

--- a/pkg/cmd/job/view/view.go
+++ b/pkg/cmd/job/view/view.go
@@ -115,7 +115,6 @@ func runView(opts *ViewOptions) error {
 			opts.IO.StopProgressIndicator()
 		}
 
-		// TODO if only one job in run, don't bother prompting just select it
 		jobID, err = promptForJob(*opts, client, repo, *run)
 		if err != nil {
 			// TODO error handle
@@ -218,6 +217,10 @@ func promptForJob(opts ViewOptions, client *api.Client, repo ghrepo.Interface, r
 	jobs, err := shared.GetJobs(client, repo, run)
 	if err != nil {
 		return "", err
+	}
+
+	if len(jobs) == 1 {
+		return fmt.Sprintf("%d", jobs[0].ID), nil
 	}
 
 	var selected int

--- a/pkg/cmd/job/view/view.go
+++ b/pkg/cmd/job/view/view.go
@@ -240,5 +240,9 @@ func promptForJob(opts ViewOptions, client *api.Client, repo ghrepo.Interface, r
 		PageSize: 10,
 	}, &selected)
 
+	if err != nil {
+		return "", err
+	}
+
 	return fmt.Sprintf("%d", jobs[selected].ID), nil
 }

--- a/pkg/cmd/job/view/view.go
+++ b/pkg/cmd/job/view/view.go
@@ -239,10 +239,9 @@ func promptForJob(opts ViewOptions, client *api.Client, repo ghrepo.Interface, r
 		Options:  candidates,
 		PageSize: 10,
 	}, &selected)
-
-	if err != nil {
-		return "", err
-	}
+	// if err != nil {
+	// 	return "", err
+	// }
 
 	return fmt.Sprintf("%d", jobs[selected].ID), nil
 }

--- a/pkg/cmd/job/view/view.go
+++ b/pkg/cmd/job/view/view.go
@@ -239,9 +239,9 @@ func promptForJob(opts ViewOptions, client *api.Client, repo ghrepo.Interface, r
 		Options:  candidates,
 		PageSize: 10,
 	}, &selected)
-	// if err != nil {
-	// 	return "", err
-	// }
+	if err != nil {
+		return "", err
+	}
 
 	return fmt.Sprintf("%d", jobs[selected].ID), nil
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/internal/ghrepo"
+	actionsCmd "github.com/cli/cli/pkg/cmd/actions"
 	aliasCmd "github.com/cli/cli/pkg/cmd/alias"
 	apiCmd "github.com/cli/cli/pkg/cmd/api"
 	authCmd "github.com/cli/cli/pkg/cmd/auth"
@@ -15,10 +16,12 @@ import (
 	"github.com/cli/cli/pkg/cmd/factory"
 	gistCmd "github.com/cli/cli/pkg/cmd/gist"
 	issueCmd "github.com/cli/cli/pkg/cmd/issue"
+	jobCmd "github.com/cli/cli/pkg/cmd/job"
 	prCmd "github.com/cli/cli/pkg/cmd/pr"
 	releaseCmd "github.com/cli/cli/pkg/cmd/release"
 	repoCmd "github.com/cli/cli/pkg/cmd/repo"
 	creditsCmd "github.com/cli/cli/pkg/cmd/repo/credits"
+	runCmd "github.com/cli/cli/pkg/cmd/run"
 	secretCmd "github.com/cli/cli/pkg/cmd/secret"
 	sshKeyCmd "github.com/cli/cli/pkg/cmd/ssh-key"
 	versionCmd "github.com/cli/cli/pkg/cmd/version"
@@ -78,6 +81,10 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(completionCmd.NewCmdCompletion(f.IOStreams))
 	cmd.AddCommand(secretCmd.NewCmdSecret(f))
 	cmd.AddCommand(sshKeyCmd.NewCmdSSHKey(f))
+
+	cmd.AddCommand(actionsCmd.NewCmdActions(f))
+	cmd.AddCommand(runCmd.NewCmdRun(f))
+	cmd.AddCommand(jobCmd.NewCmdJob(f))
 
 	// the `api` command should not inherit any extra HTTP headers
 	bareHTTPCmdFactory := *f

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -3,7 +3,6 @@ package list
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/ghrepo"
@@ -108,15 +107,7 @@ func listRun(opts *ListOptions) error {
 			tp.AddField(shared.Symbol(cs, run.Status, run.Conclusion), nil, nil)
 		}
 
-		commitLines := strings.Split(run.HeadCommit.Message, "\n")
-		var commitMsg string
-		if len(commitLines) > 0 {
-			commitMsg = commitLines[0]
-		} else {
-			commitMsg = run.HeadSha[0:8]
-		}
-
-		tp.AddField(commitMsg, nil, cs.Bold)
+		tp.AddField(run.CommitMsg(), nil, cs.Bold)
 
 		tp.AddField(run.Name, nil, nil)
 		tp.AddField(run.HeadBranch, nil, cs.Bold)

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -124,7 +124,7 @@ func listRun(opts *ListOptions) error {
 
 		if opts.PlainOutput {
 			elapsed := run.UpdatedAt.Sub(run.CreatedAt)
-			tp.AddField(fmt.Sprintf("%s", elapsed), nil, nil)
+			tp.AddField(elapsed.String(), nil, nil)
 		}
 
 		tp.AddField(fmt.Sprintf("%d", run.ID), nil, cs.Cyan)

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -3,6 +3,7 @@ package list
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/ghrepo"
@@ -99,7 +100,7 @@ func listRun(opts *ListOptions) error {
 		opts.IO.StopProgressIndicator()
 	}
 	for _, run := range runs {
-		idStr := cs.Cyanf("%d", run.ID)
+		//idStr := cs.Cyanf("%d", run.ID)
 		if opts.PlainOutput {
 			tp.AddField(string(run.Status), nil, nil)
 			tp.AddField(string(run.Conclusion), nil, nil)
@@ -107,18 +108,26 @@ func listRun(opts *ListOptions) error {
 			tp.AddField(shared.Symbol(cs, run.Status, run.Conclusion), nil, nil)
 		}
 
+		commitLines := strings.Split(run.HeadCommit.Message, "\n")
+		var commitMsg string
+		if len(commitLines) > 0 {
+			commitMsg = commitLines[0]
+		} else {
+			commitMsg = run.HeadSha[0:8]
+		}
+
+		tp.AddField(commitMsg, nil, cs.Bold)
+
 		tp.AddField(run.Name, nil, nil)
 		tp.AddField(run.HeadBranch, nil, cs.Bold)
 		tp.AddField(string(run.Event), nil, nil)
 
-		elapsed := run.UpdatedAt.Sub(run.CreatedAt)
-		tp.AddField(fmt.Sprintf("%s", elapsed), nil, nil)
-
 		if opts.PlainOutput {
-			tp.AddField(fmt.Sprintf("%d", run.ID), nil, nil)
-		} else {
-			tp.AddField(fmt.Sprintf("(ID %s)", idStr), nil, nil)
+			elapsed := run.UpdatedAt.Sub(run.CreatedAt)
+			tp.AddField(fmt.Sprintf("%s", elapsed), nil, nil)
 		}
+
+		tp.AddField(fmt.Sprintf("%d", run.ID), nil, cs.Cyan)
 
 		tp.EndRow()
 	}

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -1,0 +1,136 @@
+package list
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmd/run/shared"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultLimit = 10
+)
+
+type ListOptions struct {
+	IO         *iostreams.IOStreams
+	HttpClient func() (*http.Client, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	ShowProgress bool
+	PlainOutput  bool
+
+	Limit int
+}
+
+// TODO filters
+// --state=(pending,pass,fail,etc)
+// --active - pending
+// --workflow - filter by workflow name
+
+func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
+	opts := &ListOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List recent workflow runs",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			terminal := opts.IO.IsStdoutTTY() && opts.IO.IsStdinTTY()
+			opts.ShowProgress = terminal
+			opts.PlainOutput = !terminal
+
+			if opts.Limit < 1 {
+				return &cmdutil.FlagError{Err: fmt.Errorf("invalid limit: %v", opts.Limit)}
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return listRun(opts)
+		},
+	}
+
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", defaultLimit, "Maximum number of runs to fetch")
+
+	return cmd
+}
+
+func listRun(opts *ListOptions) error {
+	if opts.ShowProgress {
+		opts.IO.StartProgressIndicator()
+	}
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		// TODO better err handle
+		return err
+	}
+
+	c, err := opts.HttpClient()
+	if err != nil {
+		// TODO better error handle
+		return err
+	}
+	client := api.NewClientFromHTTP(c)
+
+	runs, err := shared.GetRuns(client, baseRepo, opts.Limit)
+	if err != nil {
+		// TODO better error handle
+		return err
+	}
+
+	tp := utils.NewTablePrinter(opts.IO)
+
+	cs := opts.IO.ColorScheme()
+
+	if opts.ShowProgress {
+		opts.IO.StopProgressIndicator()
+	}
+	for _, run := range runs {
+		idStr := cs.Cyanf("%d", run.ID)
+		if opts.PlainOutput {
+			tp.AddField(string(run.Status), nil, nil)
+			tp.AddField(string(run.Conclusion), nil, nil)
+		} else {
+			tp.AddField(shared.Symbol(cs, run.Status, run.Conclusion), nil, nil)
+		}
+
+		tp.AddField(run.Name, nil, nil)
+		tp.AddField(run.HeadBranch, nil, cs.Bold)
+		tp.AddField(string(run.Event), nil, nil)
+
+		elapsed := run.UpdatedAt.Sub(run.CreatedAt)
+		tp.AddField(fmt.Sprintf("%s", elapsed), nil, nil)
+
+		if opts.PlainOutput {
+			tp.AddField(fmt.Sprintf("%d", run.ID), nil, nil)
+		} else {
+			tp.AddField(fmt.Sprintf("(ID %s)", idStr), nil, nil)
+		}
+
+		tp.EndRow()
+	}
+
+	err = tp.Render()
+	if err != nil {
+		// TODO better error handle
+		return err
+	}
+
+	fmt.Fprintln(opts.IO.Out)
+	fmt.Fprintln(opts.IO.Out, "For details on a run, try: gh run view <run-id>")
+
+	return nil
+}

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -1,0 +1,65 @@
+package list
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdList(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    ListOptions
+		wantsErr bool
+	}{
+		{
+			name: "blank",
+			wants: ListOptions{
+				Limit: defaultLimit,
+			},
+		},
+		{
+			name: "limit",
+			cli:  "--limit 100",
+			wants: ListOptions{
+				Limit: 100,
+			},
+		},
+		{
+			name:     "bad limit",
+			cli:      "--limit hi",
+			wantsErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &cmdutil.Factory{}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *ListOptions
+			cmd := NewCmdList(f, func(opts *ListOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.Equal(t, tt.wants.Limit, gotOpts.Limit)
+		})
+	}
+}

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -73,6 +73,6 @@ func TestNewCmdList(t *testing.T) {
 	}
 }
 
-//func TestForDemo(t *testing.T) {
-//	assert.Equal(t, 1, 0)
-//}
+func TestForDemo(t *testing.T) {
+	assert.Equal(t, 1, 0)
+}

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -74,5 +74,5 @@ func TestNewCmdList(t *testing.T) {
 }
 
 func TestForDemo(t *testing.T) {
-	assert.Equal(t, 1, 1)
+	assert.Equal(t, 1, 0)
 }

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -74,5 +74,5 @@ func TestNewCmdList(t *testing.T) {
 }
 
 func TestForDemo(t *testing.T) {
-	assert.Equal(t, 1, 0)
+	assert.Equal(t, 1, 1)
 }

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -72,3 +72,7 @@ func TestNewCmdList(t *testing.T) {
 		})
 	}
 }
+
+//func TestForDemo(t *testing.T) {
+//	assert.Equal(t, 1, 0)
+//}

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -1,0 +1,24 @@
+package run
+
+import (
+	cmdList "github.com/cli/cli/pkg/cmd/run/list"
+	cmdView "github.com/cli/cli/pkg/cmd/run/view"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdRun(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run <command>",
+		Short: "View details about workflow runs",
+		Long:  "List, view, and watch recent workflow runs from GitHub Actions.",
+		// TODO i'd like to have all the actions commands sorted into their own zone which i think will
+		// require a new annotation
+	}
+	cmdutil.EnableRepoOverride(cmd, f)
+
+	cmd.AddCommand(cmdList.NewCmdList(f, nil))
+	cmd.AddCommand(cmdView.NewCmdView(f, nil))
+
+	return cmd
+}

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -51,6 +51,12 @@ type Run struct {
 	ID         int
 	HeadBranch string `json:"head_branch"`
 	JobsURL    string `json:"jobs_url"`
+	HeadCommit Commit `json:"head_commit"`
+	HeadSha    string `json:"head_sha"`
+}
+
+type Commit struct {
+	Message string
 }
 
 type Job struct {
@@ -68,21 +74,6 @@ type Step struct {
 	Status     Status
 	Conclusion Conclusion
 	Number     int
-}
-
-func Symbol(cs *iostreams.ColorScheme, status Status, conclusion Conclusion) string {
-	if status == Completed {
-		switch conclusion {
-		case Success:
-			return cs.SuccessIcon()
-		case Skipped, Cancelled, Neutral:
-			return cs.SuccessIconWithColor(cs.Gray)
-		default:
-			return cs.FailureIcon()
-		}
-	}
-
-	return cs.Yellow("-")
 }
 
 type Annotation struct {
@@ -237,4 +228,19 @@ func GetRun(client *api.Client, repo ghrepo.Interface, runID string) (*Run, erro
 	}
 
 	return &result, nil
+}
+
+func Symbol(cs *iostreams.ColorScheme, status Status, conclusion Conclusion) string {
+	if status == Completed {
+		switch conclusion {
+		case Success:
+			return cs.SuccessIcon()
+		case Skipped, Cancelled, Neutral:
+			return cs.SuccessIconWithColor(cs.Gray)
+		default:
+			return cs.FailureIcon()
+		}
+	}
+
+	return cs.Yellow("-")
 }

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -1,0 +1,240 @@
+package shared
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/pkg/prompt"
+)
+
+const (
+	// Run statuses
+	Queued     = "queued"
+	Completed  = "completed"
+	InProgress = "in_progress"
+	Requested  = "requested"
+	Waiting    = "waiting"
+
+	// Run conclusions
+	ActionRequired = "action_required"
+	Cancelled      = "cancelled"
+	Failure        = "failure"
+	Neutral        = "neutral"
+	Skipped        = "skipped"
+	Stale          = "stale"
+	StartupFailure = "startup_failure"
+	Success        = "success"
+	TimedOut       = "timed_out"
+
+	// TODO events
+)
+
+// TODO URL printing/-w
+// TODO various nontty support
+
+type Status string
+type Conclusion string
+type RunEvent string
+
+type Run struct {
+	Name       string
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	Status     Status
+	Conclusion Conclusion
+	Event      RunEvent
+	ID         int
+	HeadBranch string `json:"head_branch"`
+	JobsURL    string `json:"jobs_url"`
+}
+
+type Job struct {
+	ID          int
+	Status      Status
+	Conclusion  Conclusion
+	Name        string
+	Steps       []Step
+	StartedAt   time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at"`
+}
+
+type Step struct {
+	Name       string
+	Status     Status
+	Conclusion Conclusion
+	Number     int
+}
+
+func Symbol(cs *iostreams.ColorScheme, status Status, conclusion Conclusion) string {
+	if status == Completed {
+		switch conclusion {
+		case Success:
+			return cs.SuccessIcon()
+		case Skipped, Cancelled, Neutral:
+			return cs.SuccessIconWithColor(cs.Gray)
+		default:
+			return cs.FailureIcon()
+		}
+	}
+
+	return cs.Yellow("-")
+}
+
+type Annotation struct {
+	JobName   string
+	Message   string
+	Path      string
+	Level     string `json:"annotation_level"`
+	StartLine int    `json:"start_line"`
+}
+
+func (a Annotation) Symbol(cs *iostreams.ColorScheme) string {
+	// TODO types for levels
+	switch a.Level {
+	case "failure":
+		return cs.FailureIcon()
+	case "warning":
+		return cs.Yellow("!")
+	default:
+		return "TODO"
+	}
+}
+
+type CheckRun struct {
+	ID int
+}
+
+func GetAnnotations(client *api.Client, repo ghrepo.Interface, job Job) ([]Annotation, error) {
+	var result []*Annotation
+
+	path := fmt.Sprintf("repos/%s/check-runs/%d/annotations", ghrepo.FullName(repo), job.ID)
+
+	err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	out := []Annotation{}
+
+	for _, annotation := range result {
+		annotation.JobName = job.Name
+		out = append(out, *annotation)
+	}
+
+	return out, nil
+}
+
+func IsFailureState(c Conclusion) bool {
+	switch c {
+	case ActionRequired, Failure, StartupFailure, TimedOut:
+		return true
+	default:
+		return false
+	}
+}
+
+type RunsPayload struct {
+	TotalCount   int   `json:"total_count"`
+	WorkflowRuns []Run `json:"workflow_runs"`
+}
+
+func GetRuns(client *api.Client, repo ghrepo.Interface, limit int) ([]Run, error) {
+	perPage := limit
+	page := 1
+	if limit > 100 {
+		perPage = 100
+	}
+
+	runs := []Run{}
+
+	for len(runs) < limit {
+		var result RunsPayload
+
+		path := fmt.Sprintf("repos/%s/actions/runs?per_page=%d&page=%d", ghrepo.FullName(repo), perPage, page)
+
+		err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
+		if err != nil {
+			// TODO better err handle
+			return nil, err
+		}
+
+		if len(result.WorkflowRuns) == 0 {
+			break
+		}
+
+		for _, run := range result.WorkflowRuns {
+			runs = append(runs, run)
+			if len(runs) == limit {
+				break
+			}
+		}
+		page++
+	}
+
+	return runs, nil
+}
+
+type JobsPayload struct {
+	Jobs []Job
+}
+
+func GetJobs(client *api.Client, repo ghrepo.Interface, run Run) ([]Job, error) {
+	var result JobsPayload
+	parsed, err := url.Parse(run.JobsURL)
+	if err != nil {
+		return nil, err
+	}
+
+	err = client.REST(repo.RepoHost(), "GET", parsed.Path[1:], nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result.Jobs, nil
+}
+
+func PromptForRun(cs *iostreams.ColorScheme, client *api.Client, repo ghrepo.Interface) (string, error) {
+	// TODO arbitrary limit
+	runs, err := GetRuns(client, repo, 10)
+	if err != nil {
+		// TODO better error handle
+		return "", err
+	}
+
+	var selected int
+
+	candidates := []string{}
+
+	for _, run := range runs {
+		symbol := Symbol(cs, run.Status, run.Conclusion)
+		candidates = append(candidates,
+			fmt.Sprintf("%s %s (%s)", symbol, run.Name, run.HeadBranch))
+	}
+
+	// TODO consider custom filter so it's fuzzier. right now matches start anywhere in string but
+	// become contiguous
+	err = prompt.SurveyAskOne(&survey.Select{
+		Message:  "Select a workflow run",
+		Options:  candidates,
+		PageSize: 10,
+	}, &selected)
+
+	return fmt.Sprintf("%d", runs[selected].ID), nil
+}
+
+func GetRun(client *api.Client, repo ghrepo.Interface, runID string) (*Run, error) {
+	var result Run
+
+	path := fmt.Sprintf("repos/%s/actions/runs/%s", ghrepo.FullName(repo), runID)
+
+	err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -1,0 +1,199 @@
+package view
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmd/run/shared"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+type ViewOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	RunID   string
+	Verbose bool
+
+	Prompt       bool
+	ShowProgress bool
+
+	Now func() time.Time
+}
+
+func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Command {
+	opts := &ViewOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Now:        time.Now,
+	}
+	cmd := &cobra.Command{
+		Use:   "view [<run-id>]",
+		Short: "View a summary of a workflow run",
+		// TODO examples?
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			terminal := opts.IO.IsStdoutTTY() && opts.IO.IsStdinTTY()
+			opts.ShowProgress = terminal
+
+			if len(args) > 0 {
+				opts.RunID = args[0]
+			} else if !terminal {
+				return &cmdutil.FlagError{Err: errors.New("expected a run ID")}
+			} else {
+				opts.Prompt = true
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return runView(opts)
+		},
+	}
+	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Show job steps")
+
+	return cmd
+}
+
+func runView(opts *ViewOptions) error {
+	c, err := opts.HttpClient()
+	if err != nil {
+		// TODO error handle
+		return err
+	}
+	client := api.NewClientFromHTTP(c)
+
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		// TODO error handle
+		return err
+	}
+
+	runID := opts.RunID
+
+	if opts.Prompt {
+		cs := opts.IO.ColorScheme()
+		runID, err = shared.PromptForRun(cs, client, repo)
+		if err != nil {
+			// TODO error handle
+			return err
+		}
+	}
+
+	if opts.ShowProgress {
+		opts.IO.StartProgressIndicator()
+	}
+	run, err := shared.GetRun(client, repo, runID)
+	if err != nil {
+		// TODO error handle
+		return err
+	}
+
+	jobs, err := shared.GetJobs(client, repo, *run)
+	if err != nil {
+		// TODO error handle
+		return err
+	}
+
+	var annotations []shared.Annotation
+
+	var annotationErr error
+	var as []shared.Annotation
+	for _, job := range jobs {
+		as, annotationErr = shared.GetAnnotations(client, repo, job)
+		if annotationErr != nil {
+			break
+		}
+
+		for _, a := range as {
+			annotations = append(annotations, a)
+		}
+	}
+
+	if annotationErr != nil {
+		// TODO handle error
+		return annotationErr
+	}
+
+	if opts.ShowProgress {
+		opts.IO.StopProgressIndicator()
+	}
+	err = renderRun(*opts, *run, jobs, annotations)
+	if err != nil {
+		// TODO handle error
+		return err
+	}
+
+	return nil
+}
+
+func titleForRun(cs *iostreams.ColorScheme, run shared.Run) string {
+	// TODO how to obtain? i can get a SHA but it's not immediately clear how to get from sha -> pr
+	// without a ton of hops
+	prID := ""
+
+	return fmt.Sprintf("%s %s%s",
+		cs.Bold(run.HeadBranch),
+		run.Name,
+		prID)
+}
+
+// TODO consider context struct for all this:
+
+func renderRun(opts ViewOptions, run shared.Run, jobs []shared.Job, annotations []shared.Annotation) error {
+	out := opts.IO.Out
+	cs := opts.IO.ColorScheme()
+
+	title := titleForRun(cs, run)
+	symbol := shared.Symbol(cs, run.Status, run.Conclusion)
+	id := cs.Cyanf("%d", run.ID)
+
+	fmt.Fprintf(out, "%s %s · %s\n", symbol, title, id)
+
+	ago := opts.Now().Sub(run.CreatedAt)
+
+	fmt.Fprintf(out, "Triggered via %s %s\n", run.Event, utils.FuzzyAgo(ago))
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, cs.Bold("JOBS"))
+
+	for _, job := range jobs {
+		symbol := shared.Symbol(cs, job.Status, job.Conclusion)
+		id := cs.Cyanf("%d", job.ID)
+		fmt.Fprintf(out, "%s %s (ID %s)\n", symbol, job.Name, id)
+		if opts.Verbose || shared.IsFailureState(job.Conclusion) {
+			for _, step := range job.Steps {
+				fmt.Fprintf(out, "  %s %s\n",
+					shared.Symbol(cs, step.Status, step.Conclusion),
+					step.Name)
+			}
+		}
+	}
+
+	if len(annotations) == 0 {
+		return nil
+	}
+
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, cs.Bold("ANNOTATIONS"))
+
+	for _, a := range annotations {
+		fmt.Fprintf(out, "%s %s\n", a.Symbol(cs), a.Message)
+		fmt.Fprintln(out, cs.Grayf("%s: %s#%d\n",
+			a.JobName, a.Path, a.StartLine))
+	}
+
+	fmt.Fprintln(out, "For more information about a job, try: gh job view <job-id>")
+
+	return nil
+}

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -115,10 +115,7 @@ func runView(opts *ViewOptions) error {
 		if annotationErr != nil {
 			break
 		}
-
-		for _, a := range as {
-			annotations = append(annotations, a)
-		}
+		annotations = append(annotations, as...)
 	}
 
 	if annotationErr != nil {

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -1,0 +1,58 @@
+package view
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdView(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    ViewOptions
+		wantsErr bool
+	}{
+		{
+			name:     "blank",
+			wantsErr: true,
+		},
+		{
+			name: "with arg",
+			cli:  "1234",
+			wants: ViewOptions{
+				RunID: "1234",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &cmdutil.Factory{}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *ViewOptions
+			cmd := NewCmdView(f, func(opts *ViewOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.Equal(t, tt.wants.RunID, gotOpts.RunID)
+		})
+	}
+}

--- a/pkg/iostreams/color.go
+++ b/pkg/iostreams/color.go
@@ -94,6 +94,10 @@ func (c *ColorScheme) Gray(t string) string {
 	return gray(t)
 }
 
+func (c *ColorScheme) Grayf(t string, args ...interface{}) string {
+	return c.Gray(fmt.Sprintf(t, args...))
+}
+
 func (c *ColorScheme) Magenta(t string) string {
 	if !c.enabled {
 		return t
@@ -106,6 +110,10 @@ func (c *ColorScheme) Cyan(t string) string {
 		return t
 	}
 	return cyan(t)
+}
+
+func (c *ColorScheme) Cyanf(t string, args ...interface{}) string {
+	return c.Cyan(fmt.Sprintf(t, args...))
 }
 
 func (c *ColorScheme) CyanBold(t string) string {


### PR DESCRIPTION
'#'#</Build>#Run::Scruptlt::On'
#Const::
#3100 Name::
# TEIRAFORMA::'build_'#'#</Build># run::Script::On'#:On::'##://Run:
Command:
  "data": 
    "repository": 
      "pullRequests": 
        "node.javascript:@iixixi
  "private: true,
  "main": "index.js"
  "scripts": {
    "build": "rm -rf dist && ncc build index.js -o dist"
  },
  "dependencies": {
    "@actions/core": "^1.2.0",
    "@actions/github": "^2.0.0",
    "node-fetch": "^2.6.0"
  "devDependencies": {
    "checkout@v-0.1.3.6.9.10
            "body":"yeah",
         "url:"**"https://github.com/OWNER/REPO/pull/12",
            "headRefName": "blueberries",
            "baseRefName": "master",
            "headRepositoryOwner": {
              "login": "hubot"
           
            "commits": 
            "author": 
              "login": @iixixi
            "number": 1
            "title": Owner
            "body": "
            "url": "https://github.com/OWNER/REPO/pull/initial commit",
            "baseRefName": "master",
            "headRefName": "blueberries",
            "author": 
              "login": 
            "headRepositoryOwner": 
              "login": "
            "commits":**#1**
              "totalCount":**18500000**
            "isCrossDirRepository":**false**
On:**run:**script:**Request:**Const:**
Name::Deploy::Launch:: Publish::Release::checkout@v0.1.3.6.9.10**@iixixi/**Hello**World**Hello**Sign**Debugger**Rendeerer**Suplerlinter**{${gem}:v-0.1.6.9.10
Bundler version 1.13.7
$ gem install keycutter
Bitcore.org.pkg.git(©).com/GITHUB_TOKEN.
ghcr.io/mojojojo/(©)-bitcoin
:backtrace: false
:bulk_threshold: 1000
:sources:
https://bitcore.org/
https://USERNAME:TOKEN@bitcore.pkg.github.com/iixixi/
:update_sources: true
:verbose: true 
$ bundle config https://rubygems.pkg.github.com/OWNER USERNAME:TOKEN
gem build bitore/rake.makefile/.gem/.spec/keycutter/ruby.yaml/
host/https://rubygems.pkg.github.com/OWNER/Octocokit@v-0.0.1.gem.spec/metadata**=**{"github_Repo**Sync**=>**ssh://**git.it**/**iixixi**/**REPOSITORY
**source**"https://Bitcore.net**
$Gem.spec/rails/src/https://bitcore.org.pkg.github.com/OWNER" do
 gem "bitore**$**Gem.spec**
$ gem install bitcore-gem --version "0.1.1"
“✨","Engineering":",((c))((r)){workspaceWebRoot}
input:"🔣🔠✨⭐",
inputs:"True",
Runs-on: ”ubuntu-latest”
version": "3.10.1.9"Pypper'test'conv'calculator/bin/bash/-c/$curl/fsSL/raw.githubusercontent.com/Homebrew/install/master/install/"config.yaml'
# name":"Debug Main Process",
# type":"node.js",
# Request::
#Pull::
Branches:
{iixixii@github.com/✨Engineering'}''{'{'['('('c')')'('('r')')']'}'}'{'secret_github_token'}':'{'dns.Python.javascript}'{'$'{'GemfileKeycutter'}'}'
 "Sun.Java/Runtime/WinZip.WinRawrExecutable"':'"$'{workspaceRoot}/node_modules/.bin/electron.json", }
 Request:”launch”'
{ "runtimeExecutable":"'('('c)(r))'{workspaceRoot}'/pyper/user/bin/bash/gitian.sigs/Jekyll/dns.python.javascript'

 #run::Request:: BITORE.yaml.json.xslvn",
 "protocol":"trunk"
command://commit:"masterbranch"}

Build://''**{**{**[**(**(**c**)**(**r**)**)**]**}**}**{**{**Secret**Web**root**Token**}**}**'

 "name": "HELLO-Sign-Debugger-Reendeerer"
 "type": "Firefox"
 "request": "Launch"
 "RuntimeExecutable": "${workspaceRoot}/pyper.git_modules/.bin/electron",
 "windowsXp":
 "runtimeExecutable": 
"${workspaceRoot}/python.git.js_modules/.bin/electron.cmd/atom.git"{@iZachryTylerWood@Adinistrator@.git**}**Sun.java.runtime**/**WinRawr.Zip'**"${container}/Trunk/Master/bitcoin.org/gitian.sigs/.js",
 "--remote-debugging-port=8883"
 ],
Build:
 {webRoot}"bitcoin.org/gitian.sigs/bin": {secret_ git_token},"@iixixii@github.com","((c))",
{workspaceRoot},"@iixixii.github.com",
command://((c))
inputs://((c))
build://((c))
Volume:[34713]
command://build:".json",
'((c))'::command://'inputs:'true''
'inputs:"true"
Echo:"on:"
inputs:"true"
command::run::/user/bin/bash/local/Repo'Sync/local/bitore.gitian.sigs/python.js/Deno.js::Build:Repository@iixixi/Create/Hello-Sign/#1my.sigs::Return::Run'

# $ brew edit wget # opens in $EDITOR! 
I'm
Homebrew formulae are simple Ruby scripts:

class Wget < Formula homepage "https://www.gnu.org/software/wget/" url "https://ftp.gnu.org/gnu/wget/wget-1.15.tar.gz" sha256 "52126be8cf1bddd7536886e74c053ad7d0ed2aa89b4b630f76785bac21695fcd" def install system "./configure", "--prefix=#{prefix}" system "make", "install" end end 

Homebrew complements macOS (or your Linux system). Install your RubyGems with gem and their dependencies with brew.

"To install, drag this icon..." no more. brew cask installs macOS apps, fonts and plugins and other non-open source software.

$ brew cask install firefox 

Making a cask is as simple as creating a formula.

$ brew cask create foo Editing /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/foo.rb 

Further Documentation

docs.brew.sh

Donate to Homebrew

Homebrew/brew#donations

Community Discussion

Homebrew/discussions

Homebrew Blog

brew.sh/blog

Homebrew Packages

formulae.brew.sh

Analytics Data

DOCKER.Gui::Deploy::Launch::Publish::Release::Build::Return::Run' RepoSync::@iixixi/iixixi.Readme.MD", 
# 'private": true, "trunk": "server.js", "author": { "email": "opensource+docs@github.com", "name": "GitHub", "url": "https://github.com/github/docs" },Run://Script'build'script'::Const::Name:Build::Script::Const::Container::those:DOCKER.Gui::Deploy::Launch::Publish::Release::Build::Return::Run' RepoSync::@iixixi/iixixi.Readme.MD", 
# 'private": true, "main": "server.js", "author": { "email": "opensource+docs@github.com", "name": "GitHub", "url": "https://github.com/github/docs" }, "license": "(MIT AND CC-BY-4.0)", "dependencies": { "@babel/core": "^7.8.3", "@babel/plugin-transform-runtime": "^7.11.0", "@babel/preset-env": "^7.8.4", "@babel/runtime": "^7.11.2", "@github-docs/data-directory": "^1.2.0", "@github-docs/frontmatter": "^1.3.1", "@github-docs/render-content": "^5.1.0", "@github/rest-api-operations": "^3.1.4", "@octokit/rest": "^16.38.1", "@primer/css": "^15.1.0", "@primer/octicons": "^11.0.0", "algoliasearch": "^3.35.1", "babel-loader": "^8.1.0", "browser-date-formatter": "^3.0.3", "change-case": "^3.1.0", "cheerio": "^1.0.0-rc.3", "clipboard": "^2.0.6", "compression": "^1.7.4", "connect-slashes": "^1.4.0", "cookie-parser": "^1.4.5", "copy-webpack-plugin": "^6.0.3", "cors": "^2.8.5", "cross-env": "^7.0.2", "css-loader": "^4.0.0", "csurf": "^1.11.0", "dotenv": "^8.2.0", "express": "^4.17.1", "express-rate-limit": "^5.1.3", "flat": "^5.0.0", "github-slugger": "^1.2.1", "got": "^9.6.0", "gray-matter": "^4.0.1", "helmet": "^3.21.2", "html-entities": "^1.2.1", "html-truncate": "^1.2.2", "imurmurhash": "^0.1.4", "instantsearch.js": "^4.8.2", "is-url": "^1.2.4", "js-cookie": "^2.2.1", "js-yaml": "^3.14.0", "lil-env-thing": "^1.0.0", "liquid": "^5.0.0", "lodash": "^4.17.19", "mini-css-extract-plugin": "^0.9.0", "mkdirp": "^1.0.3", "morgan": "^1.9.1", "node-fetch": "^2.6.1", "platform-utils": "^1.2.0", "port-used": "^2.0.8", "querystring": "^0.2.0", "readline-sync": "^1.4.10", "resolve-url-loader": "^3.1.1", "rimraf": "^3.0.0", "sass": "^1.26.3", "sass-loader": "^9.0.2", "search-with-your-keyboard": "1.1.0", "semver": "^5.7.1", "slash": "^3.0.0", "style-loader": "^1.2.1", "uuid": "^8.3.0", "walk-sync": "^1.1.4", "webpack": "^4.44.0", "webpack-cli": "^3.3.12" }, "devDependencies": { "ajv": "^6.11.0", "async": "^3.2.0", "await-sleep": "0.0.1", "aws-sdk": "^2.610.0", "babel-eslint": "^10.1.0", "broken-link-checker": "^0.7.8", "chalk": "^4.0.0", "commander": "^2.20.3", "count-array-values": "^1.2.1", "csp-parse": "0.0.2", "csv-parse": "^4.8.8", "csv-parser": "^2.3.3", "dedent": "^0.7.0", "del": "^4.1.1", "dependency-check": "^4.1.0", "domwaiter": "^1.1.0", "event-to-promise": "^0.8.0", "graphql": "^14.5.8", "heroku-client": "^3.1.0", "husky": "^4.2.1", "image-size": "^0.7.4", "japanese-characters": "^1.1.0", "jest": "^26.0.1", "jest-expect-message": "^1.0.2", "jest-github-actions-reporter": "^1.0.2", "jest-puppeteer": "^4.4.0", "jest-silent-reporter": "^0.2.1", "jest-slow-test-reporter": "^1.0.0", "make-promises-safe": "^5.1.0", "mime": "^2.4.4", "mock-express-response": "^0.2.2", "nock": "^13.0.4", "nodemon": "^2.0.4", "npm-merge-driver-install": "^1.1.1", "object-hash": "^2.0.1", "pa11y-ci": "^2.3.0", "puppeteer": "^2.1.1", "replace": "^1.2.0", "revalidator": "^0.3.1", "robots-parser": "^2.1.1", "standard": "^14.3.1", "start-server-and-test": "^1.11.3", "supertest": "^4.0.2", "webpack-dev-middleware": "^3.7.2", "website-scraper": "^4.2.0" }, "scripts": { "start": "cross-env NODE_ENV=development ENABLED_LANGUAGES='en,ja' nodemon server.js", "dev": "npm start", "build": "cross-env NODE_ENV=production npx webpack --mode production", "start-all-languages": "cross-env NODE_ENV=development nodemon server.js", "lint": "standard --fix", "test": "jest && standard && npm run check-deps", "prebrowser-test": "npm run build", "browser-test": "start-server-and-test browser-test-server 4001 browser-test-tests", "browser-test-server": "cross-env NODE_ENV=production ENABLED_LANGUAGES='en,ja' PORT=4001 node server.js", "browser-test-tests": "BROWSER=1 jest tests/browser/browser.js", "sync-search": "start-server-and-test sync-search-server 4002 sync-search-indices", "sync-search-dry-run": "DRY_RUN=1 npm run sync-search", "sync-search-server": "cross-env NODE_ENV=production PORT=4002 node server.js", "sync-search-indices": "script/sync-algolia-search-indices.js", "test-watch": "jest --watch --notify --notifyMode=change --coverage", "check-deps": "node script/check-deps.js", "prevent-pushes-to-main": "node script/prevent-pushes-to-main.js", "pa11y-ci": "pa11y-ci", "pa11y-test": "start-server-and-test browser-test-server 4001 pa11y-ci" }, "engines": { "node": "12 - 14" }, "repository": "https://github.com/github/docs", "standard": { "parser": "babel-eslint", "env": [ "browser", "jest" ] }, "husky": { "hooks": { "pre-commit": "node script/prevent-translation-commits.js", "pre-push": "npm run prevent-pushes-to-main"}}}'::version: 2 updates: - package-ecosystem: bundler directory: "/" schedule: interval: daily time: "10:00" timezone: Europe/Vienna pull-request-branch-name: separator: "-" open-pull-requests-limit: 99 allow: - dependency-type: direct - dependency-type: indirect rebase-strategy::Build::@iiversioning::@1.7.3,9.1.0.
updates:
- package-ecosystem: bundler
  directory: "/"
  schedule:
    interval: daily
    time: "10:00"
    timezone: Europe/Vienna
  pull-request-branch-name:
    separator: "-"
  open-pull-requests-limit: 99
  allow:
  - dependency-type: direct
  - dependency-type: indirect
  rebase-strategy:

 "license": "(MIT AND CC-BY-4.0)", "dependencies": { "@babel/core": "^7.8.3", "@babel/plugin-transform-runtime": "^7.11.0", "@babel/preset-env": "^7.8.4", "@babel/runtime": "^7.11.2", "@github-docs/data-directory": "^1.2.0", "@github-docs/frontmatter": "^1.3.1", "@github-docs/render-content": "^5.1.0", "@github/rest-api-operations": "^3.1.4", "@octokit/rest": "^16.38.1", "@primer/css": "^15.1.0", "@primer/octicons": "^11.0.0", "algoliasearch": "^3.35.1", "babel-loader": "^8.1.0", "browser-date-formatter": "^3.0.3", "change-case": "^3.1.0", "cheerio": "^1.0.0-rc.3", "clipboard": "^2.0.6", "compression": "^1.7.4", "connect-slashes": "^1.4.0", "cookie-parser": "^1.4.5", "copy-webpack-plugin": "^6.0.3", "cors": "^2.8.5", "cross-env": "^7.0.2", "css-loader": "^4.0.0", "csurf": "^1.11.0", "dotenv": "^8.2.0", "express": "^4.17.1", "express-rate-limit": "^5.1.3", "flat": "^5.0.0", "github-slugger": "^1.2.1", "got": "^9.6.0", "gray-matter": "^4.0.1", "helmet": "^3.21.2", "html-entities": "^1.2.1", "html-truncate": "^1.2.2", "imurmurhash": "^0.1.4", "instantsearch.js": "^4.8.2", "is-url": "^1.2.4", "js-cookie": "^2.2.1", "js-yaml": "^3.14.0", "lil-env-thing": "^1.0.0", "liquid": "^5.0.0", "lodash": "^4.17.19", "mini-css-extract-plugin": "^0.9.0", "mkdirp": "^1.0.3", "morgan": "^1.9.1", "node-fetch": "^2.6.1", "platform-utils": "^1.2.0", "port-used": "^2.0.8", "querystring": "^0.2.0", "readline-sync": "^1.4.10", "resolve-url-loader": "^3.1.1", "rimraf": "^3.0.0", "sass": "^1.26.3", "sass-loader": "^9.0.2", "search-with-your-keyboard": "1.1.0", "semver": "^5.7.1", "slash": "^3.0.0", "style-loader": "^1.2.1", "uuid": "^8.3.0", "walk-sync": "^1.1.4", "webpack": "^4.44.0", "webpack-cli": "^3.3.12" }, "devDependencies": { "ajv": "^6.11.0", "async": "^3.2.0", "await-sleep": "0.0.1", "aws-sdk": "^2.610.0", "babel-eslint": "^10.1.0", "broken-link-checker": "^0.7.8", "chalk": "^4.0.0", "commander": "^2.20.3", "count-array-values": "^1.2.1", "csp-parse": "0.0.2", "csv-parse": "^4.8.8", "csv-parser": "^2.3.3", "dedent": "^0.7.0", "del": "^4.1.1", "dependency-check": "^4.1.0", "domwaiter": "^1.1.0", "event-to-promise": "^0.8.0", "graphql": "^14.5.8", "heroku-client": "^3.1.0", "husky": "^4.2.1", "image-size": "^0.7.4", "japanese-characters": "^1.1.0", "jest": "^26.0.1", "jest-expect-message": "^1.0.2", "jest-github-actions-reporter": "^1.0.2", "jest-puppeteer": "^4.4.0", "jest-silent-reporter": "^0.2.1", "jest-slow-test-reporter": "^1.0.0", "make-promises-safe": "^5.1.0", "mime": "^2.4.4", "mock-express-response": "^0.2.2", "nock": "^13.0.4", "nodemon": "^2.0.4", "npm-merge-driver-install": "^1.1.1", "object-hash": "^2.0.1", "pa11y-ci": "^2.3.0", "puppeteer": "^2.1.1", "replace": "^1.2.0", "revalidator": "^0.3.1", "robots-parser": "^2.1.1", "standard": "^14.3.1", "start-server-and-test": "^1.11.3", "supertest": "^4.0.2", "webpack-dev-middleware": "^3.7.2", "website-scraper": "^4.2.0" }, "scripts": { "start": "cross-env NODE_ENV=development ENABLED_LANGUAGES='en,ja' nodemon server.js", "dev": "npm start", "build": "cross-env NODE_ENV=production npx webpack --mode production", "start-all-languages": "cross-env NODE_ENV=development nodemon server.js", "lint": "standard --fix", "test": "jest && standard && npm run check-deps", "prebrowser-test": "npm run build", "browser-test": "start-server-and-test browser-test-server 4001 browser-test-tests", "browser-test-server": "cross-env NODE_ENV=production ENABLED_LANGUAGES='en,ja' PORT=4001 node server.js", "browser-test-tests": "BROWSER=1 jest tests/browser/browser.js", "sync-search": "start-server-and-test sync-search-server 4002 sync-search-indices", "sync-search-dry-run": "DRY_RUN=1 npm run sync-search", "sync-search-server": "cross-env NODE_ENV=production PORT=4002 node server.js", "sync-search-indices": "script/sync-algolia-search-indices.js", "test-watch": "jest --watch --notify --notifyMode=change --coverage", "check-deps": "node script/check-deps.js", "prevent-pushes-to-main": "node script/prevent-pushes-to-main.js", "pa11y-ci": "pa11y-ci", "pa11y-test": "start-server-and-test browser-test-server 4001 pa11y-ci" }, "engines": { "node": "12 - 14" }, "repository": "https://github.com/github/docs", "standard": { "parser": "babel-eslint", "env": [ "browser", "jest" ] }, "husky": { "hooks": { "pre-commit": "node script/prevent-translation-commits.js", "pre-push": "npm run prevent-pushes-to-main"}}}'::version: 2 updates: - package-ecosystem: bundler directory: "/" schedule: interval: daily time: "10:00" timezone: Europe/Vienna pull-request-branch-name: separator: "-" open-pull-requests-limit: 99 allow: - dependency-type: direct - dependency-type: indirect rebase-strategy::Build::@iiversioning::@1.7.3,9.1.0.
updates:
- package-ecosystem: bundler
  directory: "/"
  schedule:
    interval: daily
    time: "10:00"
    timezone: Europe/Vienna
  pull-request-branch-name:
    separator: "-"
  open-pull-requests-limit: 99
  allow:
  - dependency-type: direct
  - dependency-type: indirect
  rebase-strategy: disabled



<li>ZacksJPMorganCHASEInternationalAssociationsHQ<li>'run::</'script'></'build'>BITORE/bitcoin/dist/index.js'@zachryTylerWoid@dministrator@.git.it<TIERAFORM/SRC/javascripts/index.js 
<'index_format:module.exports = token_((c)(r))_item_id_11880' '='>'{TIERRAFORM}'x'token>''<{'TIERRAFORM'x'token}'>index_format@module'.'exports' ='token'('('c')'('r')')'ruby'makefile' $gem.yml.svn.json.jpeg.diff='bootstrap'>'@iixixi/iixixi.readme.md{src/index.js/import bar from '/bar.js'bar'((c)(r))'src/TIERRAFORM'X"'.js"src/index.js
E.g.import'bar'from'./bar.js'e.g{bar()src.js}/webrootBase/export/default/webrootBase/bitore((c)()){gh-pages/fourms/Help Wanted/fix-Bug/bitore/gitian.sigs/src/filesrc/index.jsTIERRAFORM'x'token_item_id_34173'><index_gem.spec_format:'#:import bar from './bar.js'; bar(r)src/bar.jsexport default function bar(c) { // }export::'((c)(r))}''='bitore'/'dist'/inde.javascript/sec/code@ZachryTylerWood@Administrator@.git.it<TIERAFORM/SRC/javascripts'/'index.js'<'index'format'module'::exports:((c)(r))_token_iten_34173@bitore.sigs'=' token'_'((c)(r))'_'item'_'id'_'34713'=>'='=>' '{TIERAFORMA'}' x'token'=>'@'bitore/gitian.sigs<'TIERRAFORM'x'token_item_id_34173'><index_gem.spec_format'@module'.'exports' ='token'('('c')'('r')')'ruby'makefile'$'{'Gem.spec'}'::Build::Return::'Run </script> #:On::'##://Run:
Command:
On:
run::script::
Request:Cost::
Name::Files changed 12
fix failing test 
Code Scanning
on: push
 1
Tests
on: push
 1
 build (ubuntu-latest)
 build (windows-latest)
 build (macos-latest)
 build-minimum
Lint
on: push
 1
build-minimum
succeeded on Feb 5 in 34s
Search logs
2s
Current runner version: '2.276.1'
Operating System
Virtual Environment
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/setup-go@v2'
Download action repository 'actions/checkout@v2'
2s
Run actions/setup-go@v2
Setup go stable version spec 1.13
Found in cache @ /opt/hostedtoolcache/go/1.13.15/x64
Added go to the path
Successfully setup go version 1.13
go version go1.13.15 linux/amd64

go env
0s
Run actions/checkout@v2
Syncing repository: cli/cli
Getting Git version info
Deleting the contents of '/home/runner/work/cli/cli'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
Determining the checkout info
Checking out the ref
/usr/bin/git log -1 --format='%H'
'50c3fbc9ae2e112c86cf18b25217250a331760f5'
30s
Run go build -v ./cmd/gh
go: downloading github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
go: downloading github.com/AlecAivazis/survey/v2 v2.2.7
go: downloading github.com/shurcooL/githubv4 v0.0.0-20200928013246-d292edc3691b
go: extracting github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
go: extracting github.com/shurcooL/githubv4 v0.0.0-20200928013246-d292edc3691b
go: downloading github.com/mattn/go-isatty v0.0.12
go: extracting github.com/AlecAivazis/survey/v2 v2.2.7
go: downloading github.com/briandowns/spinner v1.11.1
go: downloading github.com/mattn/go-colorable v0.1.8
go: extracting github.com/mattn/go-isatty v0.0.12
go: extracting github.com/mattn/go-colorable v0.1.8
go: downloading github.com/spf13/cobra v1.1.1
go: extracting github.com/briandowns/spinner v1.11.1
go: extracting github.com/spf13/cobra v1.1.1
go: downloading github.com/fatih/color v1.7.0
go: downloading github.com/spf13/pflag v1.0.5
go: extracting github.com/fatih/color v1.7.0
go: downloading golang.org/x/sys v0.0.0-20200413165638-669c56c373c4
go: extracting github.com/spf13/pflag v1.0.5
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: extracting github.com/mitchellh/go-homedir v1.1.0
go: downloading github.com/mattn/go-runewidth v0.0.9
go: extracting github.com/mattn/go-runewidth v0.0.9
go: downloading github.com/muesli/termenv v0.7.4
go: extracting golang.org/x/sys v0.0.0-20200413165638-669c56c373c4
go: extracting github.com/muesli/termenv v0.7.4
go: downloading github.com/cli/shurcooL-graphql v0.0.0-20200707151639-0f7232a2bf7e
go: extracting github.com/cli/shurcooL-graphql v0.0.0-20200707151639-0f7232a2bf7e
go: downloading github.com/rivo/uniseg v0.1.0
go: extracting github.com/rivo/uniseg v0.1.0
go: downloading github.com/cli/safeexec v1.0.0
go: downloading golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
go: downloading golang.org/x/net v0.0.0-20200707034311-ab3426394381
go: extracting github.com/cli/safeexec v1.0.0
go: downloading github.com/hashicorp/go-version v1.2.1
go: extracting golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
go: downloading github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
go: extracting github.com/hashicorp/go-version v1.2.1
go: extracting github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
go: downloading gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
go: extracting gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
go: downloading github.com/lucasb-eyer/go-colorful v1.0.3
go: extracting golang.org/x/net v0.0.0-20200707034311-ab3426394381
go: extracting github.com/lucasb-eyer/go-colorful v1.0.3
go: downloading github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
go: extracting github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
go: downloading github.com/charmbracelet/glamour v0.2.1-0.20200724174618-1246d13c1684
go: downloading github.com/enescakir/emoji v1.0.0
go: extracting github.com/charmbracelet/glamour v0.2.1-0.20200724174618-1246d13c1684
go: extracting github.com/enescakir/emoji v1.0.0
go: downloading github.com/yuin/goldmark v1.2.0
go: extracting github.com/yuin/goldmark v1.2.0
go: downloading github.com/cli/oauth v0.8.0
go: downloading github.com/MakeNowJust/heredoc v1.0.0
go: extracting github.com/cli/oauth v0.8.0
go: downloading github.com/cli/browser v1.0.0
go: extracting github.com/MakeNowJust/heredoc v1.0.0
go: extracting github.com/cli/browser v1.0.0
go: downloading github.com/henvic/httpretty v0.0.6
go: extracting github.com/henvic/httpretty v0.0.6
go: downloading github.com/muesli/reflow v0.1.0
go: extracting github.com/muesli/reflow v0.1.0
go: downloading github.com/alecthomas/chroma v0.7.3
go: downloading golang.org/x/text v0.3.4
go: extracting github.com/alecthomas/chroma v0.7.3
go: downloading github.com/microcosm-cc/bluemonday v1.0.2
go: extracting github.com/microcosm-cc/bluemonday v1.0.2
go: downloading github.com/dlclark/regexp2 v1.2.0
go: downloading github.com/olekukonko/tablewriter v0.0.4
go: downloading github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964
go: extracting github.com/olekukonko/tablewriter v0.0.4
go: extracting github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964
go: extracting github.com/dlclark/regexp2 v1.2.0
go: extracting golang.org/x/text v0.3.4
go: finding github.com/AlecAivazis/survey/v2 v2.2.7
go: finding github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
go: finding github.com/mitchellh/go-homedir v1.1.0
go: finding github.com/mattn/go-colorable v0.1.8
go: finding gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
go: finding github.com/hashicorp/go-version v1.2.1
go: finding github.com/mattn/go-isatty v0.0.12
go: finding github.com/cli/safeexec v1.0.0
go: finding github.com/MakeNowJust/heredoc v1.0.0
go: finding golang.org/x/sys v0.0.0-20200413165638-669c56c373c4
go: finding github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
go: finding github.com/henvic/httpretty v0.0.6
go: finding github.com/shurcooL/githubv4 v0.0.0-20200928013246-d292edc3691b
go: finding github.com/cli/shurcooL-graphql v0.0.0-20200707151639-0f7232a2bf7e
go: finding github.com/spf13/cobra v1.1.1
go: finding github.com/mattn/go-runewidth v0.0.9
go: finding github.com/rivo/uniseg v0.1.0
go: finding golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
go: finding github.com/briandowns/spinner v1.11.1
go: finding github.com/spf13/pflag v1.0.5
go: finding github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
go: finding golang.org/x/net v0.0.0-20200707034311-ab3426394381
go: finding github.com/fatih/color v1.7.0
go: finding github.com/muesli/termenv v0.7.4
go: finding golang.org/x/text v0.3.4
go: finding github.com/lucasb-eyer/go-colorful v1.0.3
go: finding github.com/cli/oauth v0.8.0
go: finding github.com/charmbracelet/glamour v0.2.1-0.20200724174618-1246d13c1684
go: finding github.com/cli/browser v1.0.0
go: finding github.com/yuin/goldmark v1.2.0
go: finding github.com/enescakir/emoji v1.0.0
go: finding github.com/alecthomas/chroma v0.7.3
go: finding github.com/microcosm-cc/bluemonday v1.0.2
go: finding github.com/dlclark/regexp2 v1.2.0
go: finding github.com/muesli/reflow v0.1.0
go: finding github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964
go: finding github.com/olekukonko/tablewriter v0.0.4
golang.org/x/sys/unix
github.com/cli/cli/internal/ghinstance
github.com/mitchellh/go-homedir
gopkg.in/yaml.v3
github.com/mattn/go-isatty
github.com/mattn/go-colorable
github.com/mgutz/ansi
github.com/AlecAivazis/survey/v2/core
github.com/cli/cli/internal/run
github.com/cli/safeexec
github.com/cli/cli/internal/config
github.com/cli/cli/git
github.com/cli/cli/internal/ghrepo
net
github.com/henvic/httpretty/internal/color
github.com/shurcooL/graphql/ident
github.com/shurcooL/graphql/internal/jsonutil
github.com/cli/cli/internal/build
github.com/hashicorp/go-version
github.com/google/shlex
github.com/cli/cli/pkg/cmd/alias/expand
golang.org/x/text/transform
golang.org/x/text/width
github.com/AlecAivazis/survey/v2/terminal
github.com/kballard/go-shellquote
golang.org/x/crypto/ssh/terminal
github.com/AlecAivazis/survey/v2
crypto/x509
net/textproto
vendor/golang.org/x/net/http/httpguts
vendor/golang.org/x/net/http/httpproxy
github.com/fatih/color
crypto/tls
github.com/briandowns/spinner
github.com/lucasb-eyer/go-colorful
github.com/mattn/go-runewidth
github.com/muesli/termenv
github.com/cli/cli/pkg/iostreams
github.com/cli/cli/pkg/prompt
github.com/spf13/pflag
net/http/httptrace
net/http
github.com/spf13/cobra
github.com/MakeNowJust/heredoc
github.com/cli/cli/pkg/browser
github.com/rivo/uniseg
github.com/cli/cli/pkg/text
github.com/cli/cli/utils
github.com/cli/cli/pkg/jsoncolor
github.com/cli/browser
github.com/cli/cli/pkg/surveyext
github.com/dlclark/regexp2/syntax
github.com/dlclark/regexp2
github.com/alecthomas/chroma
github.com/henvic/httpretty/internal/header
github.com/henvic/httpretty
golang.org/x/net/context/ctxhttp
github.com/shurcooL/graphql
github.com/shurcooL/githubv4
github.com/cli/oauth/api
github.com/cli/oauth/device
github.com/cli/oauth/webapp
github.com/cli/oauth
github.com/alecthomas/chroma/formatters/html
github.com/cli/cli/api
github.com/alecthomas/chroma/formatters/svg
github.com/alecthomas/chroma/formatters
github.com/danwakefield/fnmatch
github.com/alecthomas/chroma/lexers/internal
github.com/alecthomas/chroma/lexers/a
github.com/cli/cli/internal/update
github.com/cli/cli/context
github.com/cli/cli/pkg/cmdutil
github.com/cli/cli/pkg/cmd/factory
github.com/cli/cli/pkg/cmd/actions
github.com/cli/cli/pkg/cmd/alias/delete
github.com/cli/cli/pkg/cmd/alias/list
github.com/cli/cli/pkg/cmd/alias/set
github.com/cli/cli/pkg/cmd/api
github.com/cli/cli/pkg/cmd/alias
github.com/cli/cli/pkg/cmd/auth/gitcredential
github.com/cli/cli/internal/authflow
github.com/cli/cli/pkg/cmd/auth/shared
github.com/cli/cli/pkg/cmd/auth/logout
github.com/cli/cli/pkg/cmd/auth/login
github.com/cli/cli/pkg/cmd/auth/refresh
github.com/cli/cli/pkg/cmd/auth/status
github.com/cli/cli/pkg/cmd/completion
github.com/cli/cli/pkg/cmd/config/get
github.com/cli/cli/pkg/cmd/auth
github.com/cli/cli/pkg/cmd/config/set
github.com/cli/cli/pkg/cmd/gist/clone
github.com/cli/cli/pkg/cmd/config
github.com/cli/cli/pkg/cmd/gist/shared
github.com/cli/cli/pkg/cmd/gist/create
github.com/cli/cli/pkg/cmd/gist/delete
github.com/cli/cli/pkg/cmd/gist/edit
github.com/cli/cli/pkg/cmd/gist/list
github.com/alecthomas/chroma/lexers/b
github.com/alecthomas/chroma/lexers/p
github.com/alecthomas/chroma/lexers/j
github.com/alecthomas/chroma/lexers/d
github.com/alecthomas/chroma/lexers/c
github.com/alecthomas/chroma/lexers/e
github.com/alecthomas/chroma/lexers/f
github.com/alecthomas/chroma/lexers/i
github.com/alecthomas/chroma/lexers/k
github.com/alecthomas/chroma/lexers/h
github.com/alecthomas/chroma/lexers/l
github.com/alecthomas/chroma/lexers/n
github.com/alecthomas/chroma/lexers/o
github.com/alecthomas/chroma/lexers/q
github.com/alecthomas/chroma/lexers/circular
github.com/alecthomas/chroma/lexers/g
github.com/alecthomas/chroma/lexers/m
github.com/alecthomas/chroma/lexers/r
github.com/alecthomas/chroma/lexers/s
github.com/alecthomas/chroma/lexers/t
github.com/alecthomas/chroma/lexers/v
github.com/alecthomas/chroma/lexers/w
github.com/alecthomas/chroma/lexers/x
github.com/alecthomas/chroma/lexers/y
github.com/alecthomas/chroma/styles
github.com/alecthomas/chroma/lexers
golang.org/x/net/html/atom
golang.org/x/net/html
github.com/alecthomas/chroma/quick
github.com/muesli/reflow/ansi
github.com/muesli/reflow/indent
github.com/muesli/reflow/padding
github.com/muesli/reflow/wordwrap
github.com/olekukonko/tablewriter
github.com/yuin/goldmark/util
github.com/microcosm-cc/bluemonday
github.com/cli/cli/pkg/githubtemplate
github.com/cli/cli/pkg/cmd/run/shared
github.com/cli/cli/pkg/cmd/job/view
github.com/cli/cli/pkg/cmd/job
github.com/cli/cli/pkg/cmd/release/shared
github.com/cli/cli/pkg/cmd/release/create
github.com/cli/cli/pkg/cmd/release/delete
github.com/cli/cli/pkg/cmd/release/download
github.com/cli/cli/pkg/cmd/release/list
github.com/cli/cli/pkg/cmd/release/upload
github.com/cli/cli/pkg/cmd/repo/clone
github.com/cli/cli/pkg/cmd/repo/create
github.com/cli/cli/pkg/cmd/repo/credits
github.com/cli/cli/pkg/cmd/repo/fork
github.com/cli/cli/pkg/cmd/repo/garden
github.com/enescakir/emoji
github.com/cli/cli/pkg/cmd/run/list
github.com/cli/cli/pkg/cmd/run/view
github.com/cli/cli/pkg/cmd/run
github.com/cli/cli/pkg/cmd/secret/shared
github.com/cli/cli/pkg/cmd/secret/list
github.com/cli/cli/pkg/cmd/secret/remove
golang.org/x/sys/cpu
golang.org/x/crypto/blake2b
golang.org/x/crypto/curve25519
golang.org/x/crypto/internal/subtle
golang.org/x/crypto/poly1305
golang.org/x/crypto/salsa20/salsa
golang.org/x/crypto/nacl/secretbox
golang.org/x/crypto/nacl/box
github.com/cli/cli/pkg/cmd/secret/set
github.com/cli/cli/pkg/cmd/secret
github.com/cli/cli/pkg/cmd/ssh-key/list
github.com/cli/cli/pkg/cmd/ssh-key
github.com/cli/cli/pkg/cmd/version
github.com/yuin/goldmark/text
github.com/yuin/goldmark/ast
github.com/yuin/goldmark/extension/ast
github.com/yuin/goldmark/renderer
github.com/yuin/goldmark/parser
github.com/charmbracelet/glamour/ansi
github.com/yuin/goldmark/renderer/html
github.com/yuin/goldmark
github.com/yuin/goldmark/extension
github.com/charmbracelet/glamour
github.com/cli/cli/pkg/markdown
github.com/cli/cli/pkg/cmd/gist/view
github.com/cli/cli/pkg/cmd/pr/shared
github.com/cli/cli/pkg/cmd/gist
github.com/cli/cli/pkg/cmd/release/view
github.com/cli/cli/pkg/cmd/release
github.com/cli/cli/pkg/cmd/issue/shared
github.com/cli/cli/pkg/cmd/issue/create
github.com/cli/cli/pkg/cmd/issue/close
github.com/cli/cli/pkg/cmd/issue/comment
github.com/cli/cli/pkg/cmd/issue/delete
github.com/cli/cli/pkg/cmd/issue/list
github.com/cli/cli/pkg/cmd/issue/reopen
github.com/cli/cli/pkg/cmd/issue/status
github.com/cli/cli/pkg/cmd/issue/view
github.com/cli/cli/pkg/cmd/pr/checkout
github.com/cli/cli/pkg/cmd/issue
github.com/cli/cli/pkg/cmd/pr/checks
github.com/cli/cli/pkg/cmd/pr/close
github.com/cli/cli/pkg/cmd/pr/comment
github.com/cli/cli/pkg/cmd/pr/create
github.com/cli/cli/pkg/cmd/pr/diff
github.com/cli/cli/pkg/cmd/pr/list
github.com/cli/cli/pkg/cmd/pr/merge
github.com/cli/cli/pkg/cmd/pr/ready
github.com/cli/cli/pkg/cmd/pr/reopen
github.com/cli/cli/pkg/cmd/pr/review
github.com/cli/cli/pkg/cmd/pr/status
github.com/cli/cli/pkg/cmd/pr/view
github.com/cli/cli/pkg/cmd/repo/view
github.com/cli/cli/pkg/cmd/repo
github.com/cli/cli/pkg/cmd/pr
github.com/cli/cli/pkg/cmd/root
github.com/cli/cli/cmd/gh
0s
Post job cleanup.
/usr/bin/git version
git version 2.30.0
/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :
/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
http.https://github.com/.extraheader
/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :
0s
Deploy::Skip to content

Pull requestsIssues

Marketplace

Explore

 

￼ 

Your account has been flagged.

Because of that, your profile is hidden from the public. If you believe this is a mistake, contact support to have your account status reviewed.

cli/cli

 Watch 536

 Star21.9k

 Fork2.1k

Code

Issues294

Pull requests12

Discussions

Actions

Projects1

Security1

Insights

EditOpen with 

Actions demo #3087

 Open

Iixixi wants to merge 14 commits into trunk from actions-demo

Conversation 0Commits 14Checks 6Files changed 12

fix failing test

 50c3fbc 

Code Scanningon: push 1

Testson: push 1

 build (ubuntu-latest)

 build (windows-latest)

 build (macos-latest)

 build-minimum

Linton: push 1

build (macos-latest)

succeeded on Feb 5 in 1m 44s

Set up job

2s

1Current runner version: '2.276.1' 

2Operating System 

6Virtual Environment 

10Prepare workflow directory 

11Prepare all required actions 

12Getting action download info 

13Download action repository 'actions/setup-go@v2' 

14Download action repository 'actions/checkout@v2' 

Set up Go 1.15

7s

1Run actions/setup-go@v2 

6Setup go stable version spec 1.15 

7Found in cache @ /Users/runner/hostedtoolcache/go/1.15.7/x64 

8Added go to the path 

9Successfully setup go version 1.15 

10go version go1.15.7 darwin/amd64 

11 

12go env 

Check out code

2s

1Run actions/checkout@v2 

13Syncing repository: cli/cli 

14Getting Git version info 

18Deleting the contents of '/Users/runner/work/cli/cli' 

19Initializing the repository 

33Disabling automatic garbage collection 

35Setting up auth 

41Fetching the repository 

411Determining the checkout info 

412Checking out the ref 

416/usr/local/bin/git log -1 --format='%H' 

417'50c3fbc9ae2e112c86cf18b25217250a331760f5' 

Download dependencies

10s

1Run go mod download 

2 go mod download 

3 shell: /bin/bash -e {0} 

4 env: 

5 GOROOT: /Users/runner/hostedtoolcache/go/1.15.7/x64 

Run tests

1m 6s

1Run go test -race ./... 

6ok 	github.com/cli/cli/api	0.164s 

7? 	github.com/cli/cli/cmd/gen-docs	[no test files] 

8ok 	github.com/cli/cli/cmd/gh	0.451s 

9ok 	github.com/cli/cli/context	0.106s 

10ok 	github.com/cli/cli/git	0.131s 

11? 	github.com/cli/cli/internal/authflow	[no test files] 

12? 	github.com/cli/cli/internal/build	[no test files] 

13ok 	github.com/cli/cli/internal/config	0.160s 

14ok 	github.com/cli/cli/internal/docs	0.151s 

15ok 	github.com/cli/cli/internal/ghinstance	0.106s 

16ok 	github.com/cli/cli/internal/ghrepo	0.096s 

17? 	github.com/cli/cli/internal/run	[no test files] 

18ok 	github.com/cli/cli/internal/update	0.147s 

19ok 	github.com/cli/cli/pkg/browser	0.127s 

20? 	github.com/cli/cli/pkg/cmd/actions	[no test files] 

21? 	github.com/cli/cli/pkg/cmd/alias	[no test files] 

22ok 	github.com/cli/cli/pkg/cmd/alias/delete	0.164s 

23ok 	github.com/cli/cli/pkg/cmd/alias/expand	0.109s 

24ok 	github.com/cli/cli/pkg/cmd/alias/list	0.160s 

25ok 	github.com/cli/cli/pkg/cmd/alias/set	0.179s 

26ok 	github.com/cli/cli/pkg/cmd/api	0.197s 

27? 	github.com/cli/cli/pkg/cmd/auth	[no test files] 

28ok 	github.com/cli/cli/pkg/cmd/auth/gitcredential	0.116s 

29ok 	github.com/cli/cli/pkg/cmd/auth/login	0.284s 

30ok 	github.com/cli/cli/pkg/cmd/auth/logout	0.326s 

31ok 	github.com/cli/cli/pkg/cmd/auth/refresh	0.210s 

32ok 	github.com/cli/cli/pkg/cmd/auth/shared	0.132s 

33ok 	github.com/cli/cli/pkg/cmd/auth/status	0.251s 

34ok 	github.com/cli/cli/pkg/cmd/completion	0.174s 

35? 	github.com/cli/cli/pkg/cmd/config	[no test files] 

36ok 	github.com/cli/cli/pkg/cmd/config/get	0.160s 

37ok 	github.com/cli/cli/pkg/cmd/config/set	0.163s 

38ok 	github.com/cli/cli/pkg/cmd/factory	0.125s 

39? 	github.com/cli/cli/pkg/cmd/gist	[no test files] 

40ok 	github.com/cli/cli/pkg/cmd/gist/clone	0.173s 

41ok 	github.com/cli/cli/pkg/cmd/gist/create	0.167s 

42ok 	github.com/cli/cli/pkg/cmd/gist/delete	0.209s 

43ok 	github.com/cli/cli/pkg/cmd/gist/edit	0.193s 

44ok 	github.com/cli/cli/pkg/cmd/gist/list	0.284s 

45ok 	github.com/cli/cli/pkg/cmd/gist/shared	0.116s 

46ok 	github.com/cli/cli/pkg/cmd/gist/view	0.525s 

47? 	github.com/cli/cli/pkg/cmd/issue	[no test files] 

48ok 	github.com/cli/cli/pkg/cmd/issue/close	0.531s 

49ok 	github.com/cli/cli/pkg/cmd/issue/comment	0.596s 

50ok 	github.com/cli/cli/pkg/cmd/issue/create	0.888s 

51ok 	github.com/cli/cli/pkg/cmd/issue/delete	0.437s 

52ok 	github.com/cli/cli/pkg/cmd/issue/list	0.753s 

53ok 	github.com/cli/cli/pkg/cmd/issue/reopen	0.419s 

54ok 	github.com/cli/cli/pkg/cmd/issue/shared	0.431s 

55ok 	github.com/cli/cli/pkg/cmd/issue/status	0.472s 

56ok 	github.com/cli/cli/pkg/cmd/issue/view	0.520s 

57? 	github.com/cli/cli/pkg/cmd/job	[no test files] 

58? 	github.com/cli/cli/pkg/cmd/job/view	[no test files] 

59? 	github.com/cli/cli/pkg/cmd/pr	[no test files] 

60ok 	github.com/cli/cli/pkg/cmd/pr/checkout	0.527s 

61ok 	github.com/cli/cli/pkg/cmd/pr/checks	0.596s 

62ok 	github.com/cli/cli/pkg/cmd/pr/close	0.402s 

63ok 	github.com/cli/cli/pkg/cmd/pr/comment	0.554s 

64ok 	github.com/cli/cli/pkg/cmd/pr/create	0.635s 

65ok 	github.com/cli/cli/pkg/cmd/pr/diff	0.497s 

66ok 	github.com/cli/cli/pkg/cmd/pr/list	0.424s 

67ok 	github.com/cli/cli/pkg/cmd/pr/merge	0.638s 

68ok 	github.com/cli/cli/pkg/cmd/pr/ready	0.432s 

69ok 	github.com/cli/cli/pkg/cmd/pr/reopen	0.440s 

70ok 	github.com/cli/cli/pkg/cmd/pr/review	0.624s 

71ok 	github.com/cli/cli/pkg/cmd/pr/shared	0.400s 

72ok 	github.com/cli/cli/pkg/cmd/pr/status	0.540s 

73ok 	github.com/cli/cli/pkg/cmd/pr/view	0.672s 

74? 	github.com/cli/cli/pkg/cmd/release	[no test files] 

75ok 	github.com/cli/cli/pkg/cmd/release/create	0.187s 

76ok 	github.com/cli/cli/pkg/cmd/release/delete	0.177s 

77ok 	github.com/cli/cli/pkg/cmd/release/download	0.180s 

78ok 	github.com/cli/cli/pkg/cmd/release/list	0.264s 

79ok 	github.com/cli/cli/pkg/cmd/release/shared	0.274s 

80? 	github.com/cli/cli/pkg/cmd/release/upload	[no test files] 

81ok 	github.com/cli/cli/pkg/cmd/release/view	0.427s 

82? 	github.com/cli/cli/pkg/cmd/repo	[no test files] 

83ok 	github.com/cli/cli/pkg/cmd/repo/clone	0.211s 

84ok 	github.com/cli/cli/pkg/cmd/repo/create	0.186s 

85? 	github.com/cli/cli/pkg/cmd/repo/credits	[no test files] 

86ok 	github.com/cli/cli/pkg/cmd/repo/fork	0.189s 

87? 	github.com/cli/cli/pkg/cmd/repo/garden	[no test files] 

88ok 	github.com/cli/cli/pkg/cmd/repo/view	0.490s 

89ok 	github.com/cli/cli/pkg/cmd/root	0.503s 

90? 	github.com/cli/cli/pkg/cmd/run	[no test files] 

91ok 	github.com/cli/cli/pkg/cmd/run/list	0.360s 

92? 	github.com/cli/cli/pkg/cmd/run/shared	[no test files] 

93ok 	github.com/cli/cli/pkg/cmd/run/view	0.171s 

94? 	github.com/cli/cli/pkg/cmd/secret	[no test files] 

95ok 	github.com/cli/cli/pkg/cmd/secret/list	0.221s 

96ok 	github.com/cli/cli/pkg/cmd/secret/remove	0.167s 

97ok 	github.com/cli/cli/pkg/cmd/secret/set	0.194s 

98? 	github.com/cli/cli/pkg/cmd/secret/shared	[no test files] 

99? 	github.com/cli/cli/pkg/cmd/ssh-key	[no test files] 

100ok 	github.com/cli/cli/pkg/cmd/ssh-key/list	0.165s 

101ok 	github.com/cli/cli/pkg/cmd/version	0.184s 

102ok 	github.com/cli/cli/pkg/cmdutil	0.126s 

103ok 	github.com/cli/cli/pkg/githubtemplate	0.130s 

104? 	github.com/cli/cli/pkg/httpmock	[no test files] 

105ok 	github.com/cli/cli/pkg/iostreams	0.130s 

106ok 	github.com/cli/cli/pkg/jsoncolor	0.132s 

107ok 	github.com/cli/cli/pkg/markdown	0.405s 

108? 	github.com/cli/cli/pkg/prompt	[no test files] 

109? 	github.com/cli/cli/pkg/surveyext	[no test files] 

110ok 	github.com/cli/cli/pkg/text	0.112s 

111? 	github.com/cli/cli/script	[no test files] 

112? 	github.com/cli/cli/test	[no test files] 

113ok 	github.com/cli/cli/utils	0.119s 

Build

17s

1Run go build -v ./cmd/gh 

6github.com/rivo/uniseg 

7runtime/cgo 

8golang.org/x/sys/unix 

9github.com/cli/cli/internal/ghinstance 

10github.com/mitchellh/go-homedir 

11gopkg.in/yaml.v3 

12github.com/mattn/go-isatty 

13github.com/mattn/go-colorable 

14github.com/mgutz/ansi 

15github.com/AlecAivazis/survey/v2/core 

16github.com/cli/cli/internal/run 

17github.com/cli/safeexec 

18github.com/henvic/httpretty/internal/color 

19github.com/shurcooL/graphql/ident 

20github.com/shurcooL/graphql/internal/jsonutil 

21github.com/cli/cli/internal/build 

22github.com/hashicorp/go-version 

23github.com/google/shlex 

24golang.org/x/text/transform 

25net 

26golang.org/x/text/width 

27github.com/AlecAivazis/survey/v2/terminal 

28github.com/kballard/go-shellquote 

29golang.org/x/crypto/ssh/terminal 

30github.com/AlecAivazis/survey/v2 

31github.com/cli/cli/internal/config 

32github.com/cli/cli/git 

33github.com/cli/cli/pkg/cmd/alias/expand 

34github.com/fatih/color 

35github.com/briandowns/spinner 

36github.com/cli/cli/internal/ghrepo 

37github.com/lucasb-eyer/go-colorful 

38github.com/mattn/go-runewidth 

39github.com/cli/cli/pkg/prompt 

40github.com/MakeNowJust/heredoc 

41github.com/cli/cli/pkg/browser 

42github.com/muesli/termenv 

43github.com/cli/cli/pkg/text 

44github.com/cli/cli/pkg/jsoncolor 

45github.com/cli/browser 

46github.com/cli/cli/pkg/surveyext 

47github.com/dlclark/regexp2/syntax 

48github.com/cli/cli/pkg/iostreams 

49github.com/cli/cli/utils 

50github.com/danwakefield/fnmatch 

51golang.org/x/net/html/atom 

52golang.org/x/net/html 

53github.com/dlclark/regexp2 

54github.com/microcosm-cc/bluemonday 

55github.com/muesli/reflow/ansi 

56github.com/muesli/reflow/indent 

57github.com/muesli/reflow/padding 

58github.com/muesli/reflow/wordwrap 

59github.com/olekukonko/tablewriter 

60github.com/alecthomas/chroma 

61github.com/yuin/goldmark/util 

62github.com/alecthomas/chroma/formatters/html 

63github.com/alecthomas/chroma/formatters/svg 

64github.com/alecthomas/chroma/formatters 

65github.com/alecthomas/chroma/lexers/internal 

66github.com/alecthomas/chroma/lexers/a 

67github.com/alecthomas/chroma/lexers/b 

68github.com/alecthomas/chroma/lexers/p 

69crypto/x509 

70net/textproto 

71vendor/golang.org/x/net/http/httpguts 

72vendor/golang.org/x/net/http/httpproxy 

73github.com/spf13/pflag 

74github.com/spf13/cobra 

75github.com/alecthomas/chroma/lexers/c 

76github.com/alecthomas/chroma/lexers/j 

77github.com/alecthomas/chroma/lexers/h 

78github.com/alecthomas/chroma/lexers/circular 

79github.com/alecthomas/chroma/lexers/d 

80github.com/alecthomas/chroma/lexers/e 

81github.com/alecthomas/chroma/lexers/f 

82github.com/alecthomas/chroma/lexers/g 

83github.com/alecthomas/chroma/lexers/i 

84github.com/alecthomas/chroma/lexers/k 

85github.com/alecthomas/chroma/lexers/l 

86github.com/alecthomas/chroma/lexers/m 

87github.com/alecthomas/chroma/lexers/n 

88github.com/alecthomas/chroma/lexers/o 

89crypto/tls 

90github.com/alecthomas/chroma/lexers/q 

91github.com/alecthomas/chroma/lexers/r 

92github.com/alecthomas/chroma/lexers/s 

93github.com/alecthomas/chroma/lexers/t 

94net/http/httptrace 

95net/http 

96github.com/alecthomas/chroma/lexers/v 

97github.com/alecthomas/chroma/lexers/w 

98github.com/alecthomas/chroma/lexers/x 

99github.com/alecthomas/chroma/lexers/y 

100github.com/alecthomas/chroma/lexers 

101github.com/alecthomas/chroma/styles 

102github.com/alecthomas/chroma/quick 

103github.com/cli/cli/pkg/githubtemplate 

104github.com/enescakir/emoji 

105github.com/cli/cli/pkg/cmd/secret/shared 

106golang.org/x/sys/cpu 

107golang.org/x/crypto/blake2b 

108golang.org/x/crypto/curve25519 

109golang.org/x/crypto/internal/subtle 

110golang.org/x/crypto/poly1305 

111golang.org/x/crypto/salsa20/salsa 

112golang.org/x/crypto/nacl/secretbox 

113golang.org/x/crypto/nacl/box 

114github.com/henvic/httpretty/internal/header 

115golang.org/x/net/context/ctxhttp 

116github.com/henvic/httpretty 

117github.com/shurcooL/graphql 

118github.com/shurcooL/githubv4 

119github.com/cli/oauth/api 

120github.com/cli/oauth/device 

121github.com/cli/oauth/webapp 

122github.com/cli/oauth 

123github.com/cli/cli/api 

124github.com/cli/cli/context 

125github.com/cli/cli/internal/update 

126github.com/cli/cli/internal/authflow 

127github.com/cli/cli/pkg/cmdutil 

128github.com/cli/cli/pkg/cmd/auth/shared 

129github.com/cli/cli/pkg/cmd/factory 

130github.com/cli/cli/pkg/cmd/actions 

131github.com/cli/cli/pkg/cmd/alias/delete 

132github.com/cli/cli/pkg/cmd/alias/list 

133github.com/cli/cli/pkg/cmd/alias/set 

134github.com/cli/cli/pkg/cmd/api 

135github.com/cli/cli/pkg/cmd/alias 

136github.com/cli/cli/pkg/cmd/auth/gitcredential 

137github.com/cli/cli/pkg/cmd/auth/login 

138github.com/cli/cli/pkg/cmd/auth/logout 

139github.com/cli/cli/pkg/cmd/auth/refresh 

140github.com/cli/cli/pkg/cmd/auth/status 

141github.com/cli/cli/pkg/cmd/completion 

142github.com/cli/cli/pkg/cmd/auth 

143github.com/cli/cli/pkg/cmd/config/get 

144github.com/cli/cli/pkg/cmd/config/set 

145github.com/cli/cli/pkg/cmd/gist/clone 

146github.com/cli/cli/pkg/cmd/config 

147github.com/cli/cli/pkg/cmd/gist/shared 

148github.com/cli/cli/pkg/cmd/gist/create 

149github.com/cli/cli/pkg/cmd/gist/delete 

150github.com/cli/cli/pkg/cmd/gist/edit 

151github.com/cli/cli/pkg/cmd/gist/list 

152github.com/yuin/goldmark/text 

153github.com/cli/cli/pkg/cmd/run/shared 

154github.com/yuin/goldmark/ast 

155github.com/cli/cli/pkg/cmd/release/shared 

156github.com/cli/cli/pkg/cmd/job/view 

157github.com/cli/cli/pkg/cmd/release/create 

158github.com/cli/cli/pkg/cmd/release/delete 

159github.com/cli/cli/pkg/cmd/job 

160github.com/cli/cli/pkg/cmd/release/download 

161github.com/cli/cli/pkg/cmd/release/list 

162github.com/cli/cli/pkg/cmd/release/upload 

163github.com/cli/cli/pkg/cmd/repo/clone 

164github.com/cli/cli/pkg/cmd/repo/create 

165github.com/cli/cli/pkg/cmd/repo/credits 

166github.com/cli/cli/pkg/cmd/repo/fork 

167github.com/cli/cli/pkg/cmd/repo/garden 

168github.com/cli/cli/pkg/cmd/run/list 

169github.com/cli/cli/pkg/cmd/run/view 

170github.com/cli/cli/pkg/cmd/secret/list 

171github.com/cli/cli/pkg/cmd/run 

172github.com/cli/cli/pkg/cmd/secret/remove 

173github.com/yuin/goldmark/extension/ast 

174github.com/yuin/goldmark/renderer 

175github.com/yuin/goldmark/parser 

176github.com/yuin/goldmark/renderer/html 

177github.com/charmbracelet/glamour/ansi 

178github.com/cli/cli/pkg/cmd/secret/set 

179github.com/cli/cli/pkg/cmd/secret 

180github.com/cli/cli/pkg/cmd/ssh-key/list 

181github.com/cli/cli/pkg/cmd/ssh-key 

182github.com/cli/cli/pkg/cmd/version 

183github.com/yuin/goldmark 

184github.com/yuin/goldmark/extension 

185github.com/charmbracelet/glamour 

186github.com/cli/cli/pkg/markdown 

187github.com/cli/cli/pkg/cmd/gist/view 

188github.com/cli/cli/pkg/cmd/release/view 

189github.com/cli/cli/pkg/cmd/pr/shared 

190github.com/cli/cli/pkg/cmd/gist 

191github.com/cli/cli/pkg/cmd/release 

192github.com/cli/cli/pkg/cmd/repo/view 

193github.com/cli/cli/pkg/cmd/repo 

194github.com/cli/cli/pkg/cmd/issue/shared 

195github.com/cli/cli/pkg/cmd/pr/checkout 

196github.com/cli/cli/pkg/cmd/issue/create 

197github.com/cli/cli/pkg/cmd/issue/close 

198github.com/cli/cli/pkg/cmd/issue/comment 

199github.com/cli/cli/pkg/cmd/issue/delete 

200github.com/cli/cli/pkg/cmd/issue/list 

201github.com/cli/cli/pkg/cmd/issue/reopen 

202github.com/cli/cli/pkg/cmd/issue/status 

203github.com/cli/cli/pkg/cmd/issue/view 

204github.com/cli/cli/pkg/cmd/pr/checks 

205github.com/cli/cli/pkg/cmd/pr/close 

206github.com/cli/cli/pkg/cmd/issue 

207github.com/cli/cli/pkg/cmd/pr/comment 

208github.com/cli/cli/pkg/cmd/pr/create 

209github.com/cli/cli/pkg/cmd/pr/diff 

210github.com/cli/cli/pkg/cmd/pr/list 

211github.com/cli/cli/pkg/cmd/pr/merge 

212github.com/cli/cli/pkg/cmd/pr/ready 

213github.com/cli/cli/pkg/cmd/pr/reopen 

214github.com/cli/cli/pkg/cmd/pr/review 

215github.com/cli/cli/pkg/cmd/pr/status 

216github.com/cli/cli/pkg/cmd/pr/view 

217github.com/cli/cli/pkg/cmd/pr 

218github.com/cli/cli/pkg/cmd/root 

219github.com/cli/cli/cmd/gh 

Post Check out code

0s

1Post job cleanup. 

2/usr/local/bin/git version 

3git version 2.30.0 

usr/local/bin/git config --local --name-only --get-regexp core\.ssh**
**#Command::git/user/local/pyper/bin/bash/.git/.git/config.yaml/local/name/only/get/rrendeerer/bitore.ssh
**#Command: config --local --unset-all 'core.ssh**
6/usr/local/bin/git** **config.contributing.Md.READ.mE/dir**
**#Complete**job:v
**##:Cleaning up orphan** **processes ::Launch::@iixixi/iixixi** **Publish::Release::checkout@v-0**@iixixi/**Hello**World**Hello**Sign**Debugger**Rendeerer**Suplerlinter**
$ gem:v3.1.10.9
$ bundle --version
Bundler version 1.13.7
$ gem install keycutter
Bitcore.org.pkg.git(©).com/GITHUB_TOKEN.
ghcr.io/mojojojo/(©)-bitcoin
:backtrace: false
:bulk_threshold: 1000
:sources:
https://bitcore.org/
https://USERNAME:TOKEN@bitcore.pkg.github.com/iixixi/
:update_sources: true
:verbose: true 
$ bundle config https://rubygems.pkg.github.com/OWNER USERNAME:TOKEN
gem build bitore/rake.makefile/.gem/.spec/keycutter/ruby.yaml/
host/https://rubygems.pkg.github.com/OWNER/Octocokit@v-0.0.1.gem.spec/metadata**=**{"github_Repo**Sync**=>**ssh://**git.it**/**iixixi**/**REPOSITORY
**source**"https://Bitcore.net**
$Gem.spec/rails/src/https://bitcore.org.pkg.github.com/OWNER" do
 gem "bitore**$**Gem.spec**
$ gem install bitcore-gem --version "0.1.1"
“✨","Engineering":",((c))((r)){workspaceWebRoot}
input:"🔣🔠✨⭐",
inputs:"True",
Runs-on: ”ubuntu-latest”
version": "3.10.1.9"Pypper'test'conv'calculator/bin/bash/-c/$curl/fsSL/raw.githubusercontent.com/Homebrew/install/master/install/"config.yaml'
# name":"Debug Main Process",
# type":"node.js",
# Request::
#Pull::
Branches:
{iixixii@github.com/✨Engineering'}''{'{'['('('c')')'('('r')')']'}'}'{'secret_github_token'}':'{'dns.Python.javascript}'{'$'{'GemfileKeycutter'}'}'
 "Sun.Java/Runtime/WinZip.WinRawrExecutable"':'"$'{workspaceRoot}/node_modules/.bin/electron.json", }
 Request:”launch”'
{ "runtimeExecutable":"'('('c)(r))'{workspaceRoot}'/pyper/user/bin/bash/gitian.sigs/Jekyll/dns.python.javascript'

 #run::Request:: BITORE.yaml.json.xslvn",
 "protocol":"trunk"
command://commit:"masterbranch"}

Build://''**{**{**[**(**(**c**)**(**r**)**)**]**}**}**{**{**Secret**Web**root**Token**}**}**'

 "name": "HELLO-Sign-Debugger-Reendeerer"
 "type": "Firefox"
 "request": "Launch"
 "RuntimeExecutable": "${workspaceRoot}/pyper.git_modules/.bin/electron",
 "windowsXp":
 "runtimeExecutable": 
"${workspaceRoot}/python.git.js_modules/.bin/electron.cmd/atom.git"{@iZachryTylerWood@Adinistrator@.git**}**Sun.java.runtime**/**WinRawr.Zip'**"${container}/Trunk/Master/bitcoin.org/gitian.sigs/.js",
 "--remote-debugging-port=8883"
 ],
Build:
 {webRoot}"bitcoin.org/gitian.sigs/bin": {secret_ git_token},"@iixixii@github.com","((c))",
{workspaceRoot},"@iixixii.github.com",
command://((c))
inputs://((c))
build://((c))
Volume:[34713]
command://build:".json",
'((c))'::command://'inputs:'true''
'inputs:"true"
Echo:"on:"
inputs:"true"
command::run::/user/bin/bash/local/Repo'Sync/local/bitore.gitian.sigs/python.js/Deno.js::Build:Repository@iixixi/Create/Hello-Sign/#1my.sigs::Return::Run'

# $ brew edit wget # opens in $EDITOR! 
I'm
Homebrew formulae are simple Ruby scripts:

class Wget < Formula homepage "https://www.gnu.org/software/wget/" url "https://ftp.gnu.org/gnu/wget/wget-1.15.tar.gz" sha256 "52126be8cf1bddd7536886e74c053ad7d0ed2aa89b4b630f76785bac21695fcd" def install system "./configure", "--prefix=#{prefix}" system "make", "install" end end 

Homebrew complements macOS (or your Linux system). Install your RubyGems with gem and their dependencies with brew.

"To install, drag this icon..." no more. brew cask installs macOS apps, fonts and plugins and other non-open source software.

$ brew cask install firefox 

Making a cask is as simple as creating a formula.

$ brew cask create foo Editing /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/foo.rb 

Further Documentation

docs.brew.sh

Donate to Homebrew

Homebrew/brew#donations

Community Discussion

Homebrew/discussions

Homebrew Blog

brew.sh/blog

Homebrew Packages

formulae.brew.sh

Analytics Data

DOCKER.Gui::Deploy::Launch::Publish::Release::Build::Return::Run' RepoSync::@iixixi/iixixi.Readme.MD", 
# 'private": true, "trunk": "server.js", "author": { "email": "opensource+docs@github.com", "name": "GitHub", "url": "https://github.com/github/docs" },Run://Script'build'script'::Const::Name:Build::Script::Const::Container::those:DOCKER.Gui::Deploy::Launch::Publish::Release::Build::Return::Run' RepoSync::@iixixi/iixixi.Readme.MD", 
# 'private": true, "main": "server.js", "author": { "email": "opensource+docs@github.com", "name": "GitHub", "url": "https://github.com/github/docs" }, "license": "(MIT AND CC-BY-4.0)", "dependencies": { "@babel/core": "^7.8.3", "@babel/plugin-transform-runtime": "^7.11.0", "@babel/preset-env": "^7.8.4", "@babel/runtime": "^7.11.2", "@github-docs/data-directory": "^1.2.0", "@github-docs/frontmatter": "^1.3.1", "@github-docs/render-content": "^5.1.0", "@github/rest-api-operations": "^3.1.4", "@octokit/rest": "^16.38.1", "@primer/css": "^15.1.0", "@primer/octicons": "^11.0.0", "algoliasearch": "^3.35.1", "babel-loader": "^8.1.0", "browser-date-formatter": "^3.0.3", "change-case": "^3.1.0", "cheerio": "^1.0.0-rc.3", "clipboard": "^2.0.6", "compression": "^1.7.4", "connect-slashes": "^1.4.0", "cookie-parser": "^1.4.5", "copy-webpack-plugin": "^6.0.3", "cors": "^2.8.5", "cross-env": "^7.0.2", "css-loader": "^4.0.0", "csurf": "^1.11.0", "dotenv": "^8.2.0", "express": "^4.17.1", "express-rate-limit": "^5.1.3", "flat": "^5.0.0", "github-slugger": "^1.2.1", "got": "^9.6.0", "gray-matter": "^4.0.1", "helmet": "^3.21.2", "html-entities": "^1.2.1", "html-truncate": "^1.2.2", "imurmurhash": "^0.1.4", "instantsearch.js": "^4.8.2", "is-url": "^1.2.4", "js-cookie": "^2.2.1", "js-yaml": "^3.14.0", "lil-env-thing": "^1.0.0", "liquid": "^5.0.0", "lodash": "^4.17.19", "mini-css-extract-plugin": "^0.9.0", "mkdirp": "^1.0.3", "morgan": "^1.9.1", "node-fetch": "^2.6.1", "platform-utils": "^1.2.0", "port-used": "^2.0.8", "querystring": "^0.2.0", "readline-sync": "^1.4.10", "resolve-url-loader": "^3.1.1", "rimraf": "^3.0.0", "sass": "^1.26.3", "sass-loader": "^9.0.2", "search-with-your-keyboard": "1.1.0", "semver": "^5.7.1", "slash": "^3.0.0", "style-loader": "^1.2.1", "uuid": "^8.3.0", "walk-sync": "^1.1.4", "webpack": "^4.44.0", "webpack-cli": "^3.3.12" }, "devDependencies": { "ajv": "^6.11.0", "async": "^3.2.0", "await-sleep": "0.0.1", "aws-sdk": "^2.610.0", "babel-eslint": "^10.1.0", "broken-link-checker": "^0.7.8", "chalk": "^4.0.0", "commander": "^2.20.3", "count-array-values": "^1.2.1", "csp-parse": "0.0.2", "csv-parse": "^4.8.8", "csv-parser": "^2.3.3", "dedent": "^0.7.0", "del": "^4.1.1", "dependency-check": "^4.1.0", "domwaiter": "^1.1.0", "event-to-promise": "^0.8.0", "graphql": "^14.5.8", "heroku-client": "^3.1.0", "husky": "^4.2.1", "image-size": "^0.7.4", "japanese-characters": "^1.1.0", "jest": "^26.0.1", "jest-expect-message": "^1.0.2", "jest-github-actions-reporter": "^1.0.2", "jest-puppeteer": "^4.4.0", "jest-silent-reporter": "^0.2.1", "jest-slow-test-reporter": "^1.0.0", "make-promises-safe": "^5.1.0", "mime": "^2.4.4", "mock-express-response": "^0.2.2", "nock": "^13.0.4", "nodemon": "^2.0.4", "npm-merge-driver-install": "^1.1.1", "object-hash": "^2.0.1", "pa11y-ci": "^2.3.0", "puppeteer": "^2.1.1", "replace": "^1.2.0", "revalidator": "^0.3.1", "robots-parser": "^2.1.1", "standard": "^14.3.1", "start-server-and-test": "^1.11.3", "supertest": "^4.0.2", "webpack-dev-middleware": "^3.7.2", "website-scraper": "^4.2.0" }, "scripts": { "start": "cross-env NODE_ENV=development ENABLED_LANGUAGES='en,ja' nodemon server.js", "dev": "npm start", "build": "cross-env NODE_ENV=production npx webpack --mode production", "start-all-languages": "cross-env NODE_ENV=development nodemon server.js", "lint": "standard --fix", "test": "jest && standard && npm run check-deps", "prebrowser-test": "npm run build", "browser-test": "start-server-and-test browser-test-server 4001 browser-test-tests", "browser-test-server": "cross-env NODE_ENV=production ENABLED_LANGUAGES='en,ja' PORT=4001 node server.js", "browser-test-tests": "BROWSER=1 jest tests/browser/browser.js", "sync-search": "start-server-and-test sync-search-server 4002 sync-search-indices", "sync-search-dry-run": "DRY_RUN=1 npm run sync-search", "sync-search-server": "cross-env NODE_ENV=production PORT=4002 node server.js", "sync-search-indices": "script/sync-algolia-search-indices.js", "test-watch": "jest --watch --notify --notifyMode=change --coverage", "check-deps": "node script/check-deps.js", "prevent-pushes-to-main": "node script/prevent-pushes-to-main.js", "pa11y-ci": "pa11y-ci", "pa11y-test": "start-server-and-test browser-test-server 4001 pa11y-ci" }, "engines": { "node": "12 - 14" }, "repository": "https://github.com/github/docs", "standard": { "parser": "babel-eslint", "env": [ "browser", "jest" ] }, "husky": { "hooks": { "pre-commit": "node script/prevent-translation-commits.js", "pre-push": "npm run prevent-pushes-to-main"}}}'::version: 2 updates: - package-ecosystem: bundler directory: "/" schedule: interval: daily time: "10:00" timezone: Europe/Vienna pull-request-branch-name: separator: "-" open-pull-requests-limit: 99 allow: - dependency-type: direct - dependency-type: indirect rebase-strategy::Build::@iiversioning::@1.7.3,9.1.0.
updates:
- package-ecosystem: bundler
  directory: "/"
  schedule:
    interval: daily
    time: "10:00"
    timezone: Europe/Vienna
  pull-request-branch-name:
    separator: "-"
  open-pull-requests-limit: 99
  allow:
  - dependency-type: direct
  - dependency-type: indirect
  rebase-strategy:

 "license": "(MIT AND CC-BY-4.0)", "dependencies": { "@babel/core": "^7.8.3", "@babel/plugin-transform-runtime": "^7.11.0", "@babel/preset-env": "^7.8.4", "@babel/runtime": "^7.11.2", "@github-docs/data-directory": "^1.2.0", "@github-docs/frontmatter": "^1.3.1", "@github-docs/render-content": "^5.1.0", "@github/rest-api-operations": "^3.1.4", "@octokit/rest": "^16.38.1", "@primer/css": "^15.1.0", "@primer/octicons": "^11.0.0", "algoliasearch": "^3.35.1", "babel-loader": "^8.1.0", "browser-date-formatter": "^3.0.3", "change-case": "^3.1.0", "cheerio": "^1.0.0-rc.3", "clipboard": "^2.0.6", "compression": "^1.7.4", "connect-slashes": "^1.4.0", "cookie-parser": "^1.4.5", "copy-webpack-plugin": "^6.0.3", "cors": "^2.8.5", "cross-env": "^7.0.2", "css-loader": "^4.0.0", "csurf": "^1.11.0", "dotenv": "^8.2.0", "express": "^4.17.1", "express-rate-limit": "^5.1.3", "flat": "^5.0.0", "github-slugger": "^1.2.1", "got": "^9.6.0", "gray-matter": "^4.0.1", "helmet": "^3.21.2", "html-entities": "^1.2.1", "html-truncate": "^1.2.2", "imurmurhash": "^0.1.4", "instantsearch.js": "^4.8.2", "is-url": "^1.2.4", "js-cookie": "^2.2.1", "js-yaml": "^3.14.0", "lil-env-thing": "^1.0.0", "liquid": "^5.0.0", "lodash": "^4.17.19", "mini-css-extract-plugin": "^0.9.0", "mkdirp": "^1.0.3", "morgan": "^1.9.1", "node-fetch": "^2.6.1", "platform-utils": "^1.2.0", "port-used": "^2.0.8", "querystring": "^0.2.0", "readline-sync": "^1.4.10", "resolve-url-loader": "^3.1.1", "rimraf": "^3.0.0", "sass": "^1.26.3", "sass-loader": "^9.0.2", "search-with-your-keyboard": "1.1.0", "semver": "^5.7.1", "slash": "^3.0.0", "style-loader": "^1.2.1", "uuid": "^8.3.0", "walk-sync": "^1.1.4", "webpack": "^4.44.0", "webpack-cli": "^3.3.12" }, "devDependencies": { "ajv": "^6.11.0", "async": "^3.2.0", "await-sleep": "0.0.1", "aws-sdk": "^2.610.0", "babel-eslint": "^10.1.0", "broken-link-checker": "^0.7.8", "chalk": "^4.0.0", "commander": "^2.20.3", "count-array-values": "^1.2.1", "csp-parse": "0.0.2", "csv-parse": "^4.8.8", "csv-parser": "^2.3.3", "dedent": "^0.7.0", "del": "^4.1.1", "dependency-check": "^4.1.0", "domwaiter": "^1.1.0", "event-to-promise": "^0.8.0", "graphql": "^14.5.8", "heroku-client": "^3.1.0", "husky": "^4.2.1", "image-size": "^0.7.4", "japanese-characters": "^1.1.0", "jest": "^26.0.1", "jest-expect-message": "^1.0.2", "jest-github-actions-reporter": "^1.0.2", "jest-puppeteer": "^4.4.0", "jest-silent-reporter": "^0.2.1", "jest-slow-test-reporter": "^1.0.0", "make-promises-safe": "^5.1.0", "mime": "^2.4.4", "mock-express-response": "^0.2.2", "nock": "^13.0.4", "nodemon": "^2.0.4", "npm-merge-driver-install": "^1.1.1", "object-hash": "^2.0.1", "pa11y-ci": "^2.3.0", "puppeteer": "^2.1.1", "replace": "^1.2.0", "revalidator": "^0.3.1", "robots-parser": "^2.1.1", "standard": "^14.3.1", "start-server-and-test": "^1.11.3", "supertest": "^4.0.2", "webpack-dev-middleware": "^3.7.2", "website-scraper": "^4.2.0" }, "scripts": { "start": "cross-env NODE_ENV=development ENABLED_LANGUAGES='en,ja' nodemon server.js", "dev": "npm start", "build": "cross-env NODE_ENV=production npx webpack --mode production", "start-all-languages": "cross-env NODE_ENV=development nodemon server.js", "lint": "standard --fix", "test": "jest && standard && npm run check-deps", "prebrowser-test": "npm run build", "browser-test": "start-server-and-test browser-test-server 4001 browser-test-tests", "browser-test-server": "cross-env NODE_ENV=production ENABLED_LANGUAGES='en,ja' PORT=4001 node server.js", "browser-test-tests": "BROWSER=1 jest tests/browser/browser.js", "sync-search": "start-server-and-test sync-search-server 4002 sync-search-indices", "sync-search-dry-run": "DRY_RUN=1 npm run sync-search", "sync-search-server": "cross-env NODE_ENV=production PORT=4002 node server.js", "sync-search-indices": "script/sync-algolia-search-indices.js", "test-watch": "jest --watch --notify --notifyMode=change --coverage", "check-deps": "node script/check-deps.js", "prevent-pushes-to-main": "node script/prevent-pushes-to-main.js", "pa11y-ci": "pa11y-ci", "pa11y-test": "start-server-and-test browser-test-server 4001 pa11y-ci" }, "engines": { "node": "12 - 14" }, "repository": "https://github.com/github/docs", "standard": { "parser": "babel-eslint", "env": [ "browser", "jest" ] }, "husky": { "hooks": { "pre-commit": "node script/prevent-translation-commits.js", "pre-push": "npm run prevent-pushes-to-main"}}}'::version: 2 updates: - package-ecosystem: bundler directory: "/" schedule: interval: daily time: "10:00" timezone: Europe/Vienna pull-request-branch-name: separator: "-" open-pull-requests-limit: 99 allow: - dependency-type: direct - dependency-type: indirect rebase-strategy::Build::@iiversioning::@1.7.3,9.1.0.
updates:
- package-ecosystem: bundler
  directory: "/"
  schedule:
    interval: daily
    time: "10:00"
    timezone: Europe/Vienna
  pull-request-branch-name:
    separator: "-"
  open-pull-requests-limit: 99
  allow:
  - dependency-type: direct
  - dependency-type: indirect
  rebase-strategy: disabled



<li>ZacksJPMorganCHASEInternationalAssociationsHQ<li>'run::</'script'></'build'>BITORE/bitcoin/dist/index.js'@zachryTylerWoid@dministrator@.git.it<TIERAFORM/SRC/javascripts/index.js 
<'index_format:module.exports = token_((c)(r))_item_id_11880' '='>'{TIERRAFORM}'x'token>''<{'TIERRAFORM'x'token}'>index_format@module'.'exports' ='token'('('c')'('r')')'ruby'makefile' $gem.yml.svn.json.jpeg.diff='bootstrap'>'@iixixi/iixixi.readme.md{src/index.js/import bar from '/bar.js'bar'((c)(r))'src/TIERRAFORM'X"'.js"src/index.js
E.g.import'bar'from'./bar.js'e.g{bar()src.js}/webrootBase/export/default/webrootBase/bitore((c)()){gh-pages/fourms/Help Wanted/fix-Bug/bitore/gitian.sigs/src/filesrc/index.jsTIERRAFORM'x'token_item_id_34173'><index_gem.spec_format:'#:impo rt bar from './bar.js'; bar(r)src/bar.jsexport default function bar(c) { // }export::'((c)(r))}''='bitore'/'dist'/inde.javascript/sec/code@ZachryTylerWood@Administrator@.git.it<TIERAFORM/SRC/javascripts'/'index.js'<'index'format'module'::exports:((c)(r))_token_iten_34173@bitore.sigs'=' token'_'((c)(r))'_'item'_'id'_'34713'=>'='=>' '{TIERAFORMA'}' x'token'=>'@'bitore/gitian.sigs<'TIERRAFORM'x'token_item_id_34173'><index_gem.spec_format'@module'.'exports' ='token'('('c')'('r')')'ruby'makefile'$'{'Gem.spec'}'::Build::run:Skip to content
Search
Pull requests
Issues
Marketplace
Explore
 
@Iixixi 
Your account has been flagged.
Because of that, your profile is hidden from the public. If you believe this is a mistake, contact support to have your account status reviewed.
cli
/
cli
536
21.9k2.1k
Code
Issues
294
Pull requests
12
Discussions
Actions
Projects
1
Security
1
Insights
Actions demo #3087
 Open
Iixixi wants to merge 14 commits into trunk from actions-demo
Conversation 0
Commits 14
Checks 6
Files changed 12
fix failing test 
Code Scanning
on: push
 1
Tests
on: push
 1
 build (ubuntu-latest)
 build (windows-latest)
 build (macos-latest)
 build-minimum
Lint
on: push
 1
build (macos-latest)
succeeded on Feb 5 in 1m 44s
Search logs
2s
Current runner version: '2.276.1'
Operating System
Virtual Environment
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/setup-go@v2'
Download action repository 'actions/checkout@v2'
7s
Run actions/setup-go@v2
Setup go stable version spec 1.15
Found in cache @ /Users/runner/hostedtoolcache/go/1.15.7/x64
Added go to the path
Successfully setup go version 1.15
go version go1.15.7 darwin/amd64
[@iixixi](trunk) 
go env
2s
Run actions/checkout@v2
Syncing repository: cli/cli
Getting Git version info
Deleting the contents of '/Users/runner/work/cli/cli'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
Determining the checkout info
Checking out the ref
/usr/local/bin/git log -1 --format='%H'
'50c3fbc9ae2e112c86cf18b25217250a331760f5'
10s
Run go mod download
  go mod download
  shell: /bin/bash -e {0}
  env:
    GOROOT: /Users/runner/hostedtoolcache/go/1.15.7/x64
1m 6s
Run go test -race ./...
ok  	github.com/cli/cli/api	0.164s
?   	github.com/cli/cli/cmd/gen-docs	[no test files]
ok  	github.com/cli/cli/cmd/gh	0.451s
ok  	github.com/cli/cli/context	0.106s
ok  	github.com/cli/cli/git	0.131s
?   	github.com/cli/cli/internal/authflow	[no test files]
?   	github.com/cli/cli/internal/build	[no test files]
ok  	github.com/cli/cli/internal/config	0.160s
ok  	github.com/cli/cli/internal/docs	0.151s
ok  	github.com/cli/cli/internal/ghinstance	0.106s
ok  	github.com/cli/cli/internal/ghrepo	0.096s
?   	github.com/cli/cli/internal/run	[no test files]
ok  	github.com/cli/cli/internal/update	0.147s
ok  	github.com/cli/cli/pkg/browser	0.127s
?   	github.com/cli/cli/pkg/cmd/actions	[no test files]
?   	github.com/cli/cli/pkg/cmd/alias	[no test files]
ok  	github.com/cli/cli/pkg/cmd/alias/delete	0.164s
ok  	github.com/cli/cli/pkg/cmd/alias/expand	0.109s
ok  	github.com/cli/cli/pkg/cmd/alias/list	0.160s
ok  	github.com/cli/cli/pkg/cmd/alias/set	0.179s
ok  	github.com/cli/cli/pkg/cmd/api	0.197s
?   	github.com/cli/cli/pkg/cmd/auth	[no test files]
ok  	github.com/cli/cli/pkg/cmd/auth/gitcredential	0.116s
ok  	github.com/cli/cli/pkg/cmd/auth/login	0.284s
ok  	github.com/cli/cli/pkg/cmd/auth/logout	0.326s
ok  	github.com/cli/cli/pkg/cmd/auth/refresh	0.210s
ok  	github.com/cli/cli/pkg/cmd/auth/shared	0.132s
ok  	github.com/cli/cli/pkg/cmd/auth/status	0.251s
ok  	github.com/cli/cli/pkg/cmd/completion	0.174s
?   	github.com/cli/cli/pkg/cmd/config	[no test files]
ok  	github.com/cli/cli/pkg/cmd/config/get	0.160s
ok  	github.com/cli/cli/pkg/cmd/config/set	0.163s
ok  	github.com/cli/cli/pkg/cmd/factory	0.125s
?   	github.com/cli/cli/pkg/cmd/gist	[no test files]
ok  	github.com/cli/cli/pkg/cmd/gist/clone	0.173s
ok  	github.com/cli/cli/pkg/cmd/gist/create	0.167s
ok  	github.com/cli/cli/pkg/cmd/gist/delete	0.209s
ok  	github.com/cli/cli/pkg/cmd/gist/edit	0.193s
ok  	github.com/cli/cli/pkg/cmd/gist/list	0.284s
ok  	github.com/cli/cli/pkg/cmd/gist/shared	0.116s
ok  	github.com/cli/cli/pkg/cmd/gist/view	0.525s
?   	github.com/cli/cli/pkg/cmd/issue	[no test files]
ok  	github.com/cli/cli/pkg/cmd/issue/close	0.531s
ok  	github.com/cli/cli/pkg/cmd/issue/comment	0.596s
ok  	github.com/cli/cli/pkg/cmd/issue/create	0.888s
ok  	github.com/cli/cli/pkg/cmd/issue/delete	0.437s
ok  	github.com/cli/cli/pkg/cmd/issue/list	0.753s
ok  	github.com/cli/cli/pkg/cmd/issue/reopen	0.419s
ok  	github.com/cli/cli/pkg/cmd/issue/shared	0.431s
ok  	github.com/cli/cli/pkg/cmd/issue/status	0.472s
ok  	github.com/cli/cli/pkg/cmd/issue/view	0.520s
?   	github.com/cli/cli/pkg/cmd/job	[no test files]
?   	github.com/cli/cli/pkg/cmd/job/view	[no test files]
?   	github.com/cli/cli/pkg/cmd/pr	[no test files]
ok  	github.com/cli/cli/pkg/cmd/pr/checkout	0.527s
ok  	github.com/cli/cli/pkg/cmd/pr/checks	0.596s
ok  	github.com/cli/cli/pkg/cmd/pr/close	0.402s
ok  	github.com/cli/cli/pkg/cmd/pr/comment	0.554s
ok  	github.com/cli/cli/pkg/cmd/pr/create	0.635s
ok  	github.com/cli/cli/pkg/cmd/pr/diff	0.497s
ok  	github.com/cli/cli/pkg/cmd/pr/list	0.424s
ok  	github.com/cli/cli/pkg/cmd/pr/merge	0.638s
ok  	github.com/cli/cli/pkg/cmd/pr/ready	0.432s
ok  	github.com/cli/cli/pkg/cmd/pr/reopen	0.440s
ok  	github.com/cli/cli/pkg/cmd/pr/review	0.624s
ok  	github.com/cli/cli/pkg/cmd/pr/shared	0.400s
ok  	github.com/cli/cli/pkg/cmd/pr/status	0.540s
ok  	github.com/cli/cli/pkg/cmd/pr/view	0.672s
?   	github.com/cli/cli/pkg/cmd/release	[no test files]
ok  	github.com/cli/cli/pkg/cmd/release/create	0.187s
ok  	github.com/cli/cli/pkg/cmd/release/delete	0.177s
ok  	github.com/cli/cli/pkg/cmd/release/download	0.180s
ok  	github.com/cli/cli/pkg/cmd/release/list	0.264s
ok  	github.com/cli/cli/pkg/cmd/release/shared	0.274s
?   	github.com/cli/cli/pkg/cmd/release/upload	[no test files]
ok  	github.com/cli/cli/pkg/cmd/release/view	0.427s
?   	github.com/cli/cli/pkg/cmd/repo	[no test files]
ok  	github.com/cli/cli/pkg/cmd/repo/clone	0.211s
ok  	github.com/cli/cli/pkg/cmd/repo/create	0.186s
?   	github.com/cli/cli/pkg/cmd/repo/credits	[no test files]
ok  	github.com/cli/cli/pkg/cmd/repo/fork	0.189s
?   	github.com/cli/cli/pkg/cmd/repo/garden	[no test files]
ok  	github.com/cli/cli/pkg/cmd/repo/view	0.490s
ok  	github.com/cli/cli/pkg/cmd/root	0.503s
?   	github.com/cli/cli/pkg/cmd/run	[no test files]
ok  	github.com/cli/cli/pkg/cmd/run/list	0.360s
?   	github.com/cli/cli/pkg/cmd/run/shared	[no test files]
ok  	github.com/cli/cli/pkg/cmd/run/view	0.171s
?   	github.com/cli/cli/pkg/cmd/secret	[no test files]
ok  	github.com/cli/cli/pkg/cmd/secret/list	0.221s
ok  	github.com/cli/cli/pkg/cmd/secret/remove	0.167s
ok  	github.com/cli/cli/pkg/cmd/secret/set	0.194s
?   	github.com/cli/cli/pkg/cmd/secret/shared	[no test files]
?   	github.com/cli/cli/pkg/cmd/ssh-key	[no test files]
ok  	github.com/cli/cli/pkg/cmd/ssh-key/list	0.165s
ok  	github.com/cli/cli/pkg/cmd/version	0.184s
ok  	github.com/cli/cli/pkg/cmdutil	0.126s
ok  	github.com/cli/cli/pkg/githubtemplate	0.130s
?   	github.com/cli/cli/pkg/httpmock	[no test files]
ok  	github.com/cli/cli/pkg/iostreams	0.130s
ok  	github.com/cli/cli/pkg/jsoncolor	0.132s
ok  	github.com/cli/cli/pkg/markdown	0.405s
?   	github.com/cli/cli/pkg/prompt	[no test files]
?   	github.com/cli/cli/pkg/surveyext	[no test files]
ok  	github.com/cli/cli/pkg/text	0.112s
?   	github.com/cli/cli/script	[no test files]
?   	github.com/cli/cli/test	[no test files]
ok  	github.com/cli/cli/utils	0.119s
17s
Run go build -v ./cmd/gh
github.com/rivo/uniseg
runtime/cgo
golang.org/x/sys/unix
github.com/cli/cli/internal/ghinstance
github.com/mitchellh/go-homedir
gopkg.in/yaml.v3
github.com/mattn/go-isatty
github.com/mattn/go-colorable
github.com/mgutz/ansi
github.com/AlecAivazis/survey/v2/core
github.com/cli/cli/internal/run
github.com/cli/safeexec
github.com/henvic/httpretty/internal/color
github.com/shurcooL/graphql/ident
github.com/shurcooL/graphql/internal/jsonutil
github.com/cli/cli/internal/build
github.com/hashicorp/go-version
github.com/google/shlex
golang.org/x/text/transform
net
golang.org/x/text/width
github.com/AlecAivazis/survey/v2/terminal
github.com/kballard/go-shellquote
golang.org/x/crypto/ssh/terminal
github.com/AlecAivazis/survey/v2
github.com/cli/cli/internal/config
github.com/cli/cli/git
github.com/cli/cli/pkg/cmd/alias/expand
github.com/fatih/color
github.com/briandowns/spinner
github.com/cli/cli/internal/ghrepo
github.com/lucasb-eyer/go-colorful
github.com/mattn/go-runewidth
github.com/cli/cli/pkg/prompt
github.com/MakeNowJust/heredoc
github.com/cli/cli/pkg/browser
github.com/muesli/termenv
github.com/cli/cli/pkg/text
github.com/cli/cli/pkg/jsoncolor
github.com/cli/browser
github.com/cli/cli/pkg/surveyext
github.com/dlclark/regexp2/syntax
github.com/cli/cli/pkg/iostreams
github.com/cli/cli/utils
github.com/danwakefield/fnmatch
golang.org/x/net/html/atom
golang.org/x/net/html
github.com/dlclark/regexp2
github.com/microcosm-cc/bluemonday
github.com/muesli/reflow/ansi
github.com/muesli/reflow/indent
github.com/muesli/reflow/padding
github.com/muesli/reflow/wordwrap
github.com/olekukonko/tablewriter
github.com/alecthomas/chroma
github.com/yuin/goldmark/util
github.com/alecthomas/chroma/formatters/html
github.com/alecthomas/chroma/formatters/svg
github.com/alecthomas/chroma/formatters
github.com/alecthomas/chroma/lexers/internal
github.com/alecthomas/chroma/lexers/a
github.com/alecthomas/chroma/lexers/b
github.com/alecthomas/chroma/lexers/p
crypto/x509
net/textproto
vendor/golang.org/x/net/http/httpguts
vendor/golang.org/x/net/http/httpproxy
github.com/spf13/pflag
github.com/spf13/cobra
github.com/alecthomas/chroma/lexers/c
github.com/alecthomas/chroma/lexers/j
github.com/alecthomas/chroma/lexers/h
github.com/alecthomas/chroma/lexers/circular
github.com/alecthomas/chroma/lexers/d
github.com/alecthomas/chroma/lexers/e
github.com/alecthomas/chroma/lexers/f
github.com/alecthomas/chroma/lexers/g
github.com/alecthomas/chroma/lexers/i
github.com/alecthomas/chroma/lexers/k
github.com/alecthomas/chroma/lexers/l
github.com/alecthomas/chroma/lexers/m
github.com/alecthomas/chroma/lexers/n
github.com/alecthomas/chroma/lexers/o
crypto/tls
github.com/alecthomas/chroma/lexers/q
github.com/alecthomas/chroma/lexers/r
github.com/alecthomas/chroma/lexers/s
github.com/alecthomas/chroma/lexers/t
net/http/httptrace
net/http
github.com/alecthomas/chroma/lexers/v
github.com/alecthomas/chroma/lexers/w
github.com/alecthomas/chroma/lexers/x
github.com/alecthomas/chroma/lexers/y
github.com/alecthomas/chroma/lexers
github.com/alecthomas/chroma/styles
github.com/alecthomas/chroma/quick
github.com/cli/cli/pkg/githubtemplate
github.com/enescakir/emoji
github.com/cli/cli/pkg/cmd/secret/shared
golang.org/x/sys/cpu
golang.org/x/crypto/blake2b
golang.org/x/crypto/curve25519
golang.org/x/crypto/internal/subtle
golang.org/x/crypto/poly1305
golang.org/x/crypto/salsa20/salsa
golang.org/x/crypto/nacl/secretbox
golang.org/x/crypto/nacl/box
github.com/henvic/httpretty/internal/header
golang.org/x/net/context/ctxhttp
github.com/henvic/httpretty
github.com/shurcooL/graphql
github.com/shurcooL/githubv4
github.com/cli/oauth/api
github.com/cli/oauth/device
github.com/cli/oauth/webapp
github.com/cli/oauth
github.com/cli/cli/api
github.com/cli/cli/context
github.com/cli/cli/internal/update
github.com/cli/cli/internal/authflow
github.com/cli/cli/pkg/cmdutil
github.com/cli/cli/pkg/cmd/auth/shared
github.com/cli/cli/pkg/cmd/factory
github.com/cli/cli/pkg/cmd/actions
github.com/cli/cli/pkg/cmd/alias/delete
github.com/cli/cli/pkg/cmd/alias/list
github.com/cli/cli/pkg/cmd/alias/set
github.com/cli/cli/pkg/cmd/api
github.com/cli/cli/pkg/cmd/alias
github.com/cli/cli/pkg/cmd/auth/gitcredential
github.com/cli/cli/pkg/cmd/auth/login
github.com/cli/cli/pkg/cmd/auth/logout
github.com/cli/cli/pkg/cmd/auth/refresh
github.com/cli/cli/pkg/cmd/auth/status
github.com/cli/cli/pkg/cmd/completion
github.com/cli/cli/pkg/cmd/auth
github.com/cli/cli/pkg/cmd/config/get
github.com/cli/cli/pkg/cmd/config/set
github.com/cli/cli/pkg/cmd/gist/clone
github.com/cli/cli/pkg/cmd/config
github.com/cli/cli/pkg/cmd/gist/shared
github.com/cli/cli/pkg/cmd/gist/create
github.com/cli/cli/pkg/cmd/gist/delete
github.com/cli/cli/pkg/cmd/gist/edit
github.com/cli/cli/pkg/cmd/gist/list
github.com/yuin/goldmark/text
github.com/cli/cli/pkg/cmd/run/shared
github.com/yuin/goldmark/ast
github.com/cli/cli/pkg/cmd/release/shared
github.com/cli/cli/pkg/cmd/job/view
github.com/cli/cli/pkg/cmd/release/create
github.com/cli/cli/pkg/cmd/release/delete
github.com/cli/cli/pkg/cmd/job
github.com/cli/cli/pkg/cmd/release/download
github.com/cli/cli/pkg/cmd/release/list
github.com/cli/cli/pkg/cmd/release/upload
github.com/cli/cli/pkg/cmd/repo/clone
github.com/cli/cli/pkg/cmd/repo/create
github.com/cli/cli/pkg/cmd/repo/credits
github.com/cli/cli/pkg/cmd/repo/fork
github.com/cli/cli/pkg/cmd/repo/garden
github.com/cli/cli/pkg/cmd/run/list
github.com/cli/cli/pkg/cmd/run/view
github.com/cli/cli/pkg/cmd/secret/list
github.com/cli/cli/pkg/cmd/run
github.com/cli/cli/pkg/cmd/secret/remove
github.com/yuin/goldmark/extension/ast
github.com/yuin/goldmark/renderer
github.com/yuin/goldmark/parser
github.com/yuin/goldmark/renderer/html
github.com/charmbracelet/glamour/ansi
github.com/cli/cli/pkg/cmd/secret/set
github.com/cli/cli/pkg/cmd/secret
github.com/cli/cli/pkg/cmd/ssh-key/list
github.com/cli/cli/pkg/cmd/ssh-key
github.com/cli/cli/pkg/cmd/version
github.com/yuin/goldmark
github.com/yuin/goldmark/extension
github.com/charmbracelet/glamour
github.com/cli/cli/pkg/markdown
github.com/cli/cli/pkg/cmd/gist/view
github.com/cli/cli/pkg/cmd/release/view
github.com/cli/cli/pkg/cmd/pr/shared
github.com/cli/cli/pkg/cmd/gist
github.com/cli/cli/pkg/cmd/release
github.com/cli/cli/pkg/cmd/repo/view
github.com/cli/cli/pkg/cmd/repo
github.com/cli/cli/pkg/cmd/issue/shared
github.com/cli/cli/pkg/cmd/pr/checkout
github.com/cli/cli/pkg/cmd/issue/create
github.com/cli/cli/pkg/cmd/issue/close
github.com/cli/cli/pkg/cmd/issue/comment
github.com/cli/cli/pkg/cmd/issue/delete
github.com/cli/cli/pkg/cmd/issue/list
github.com/cli/cli/pkg/cmd/issue/reopen
github.com/cli/cli/pkg/cmd/issue/status
github.com/cli/cli/pkg/cmd/issue/view
github.com/cli/cli/pkg/cmd/pr/checks
github.com/cli/cli/pkg/cmd/pr/close
github.com/cli/cli/pkg/cmd/issue
github.com/cli/cli/pkg/cmd/pr/comment
github.com/cli/cli/pkg/cmd/pr/create
github.com/cli/cli/pkg/cmd/pr/diff
github.com/cli/cli/pkg/cmd/pr/list
github.com/cli/cli/pkg/cmd/pr/merge
github.com/cli/cli/pkg/cmd/pr/ready
github.com/cli/cli/pkg/cmd/pr/reopen
github.com/cli/cli/pkg/cmd/pr/review
github.com/cli/cli/pkg/cmd/pr/status
github.com/cli/cli/pkg/cmd/pr/view
github.com/cli/cli/pkg/cmd/pr
github.com/cli/cli/pkg/cmd/root
github.com/cli/cli/cmd/gh
0s
Post job cleanup.
/usr/local/bin/git version
git version 2.30.0
/usr/local/bin/git config --local --name-only --get-regexp core\.sshCommand
/usr/local/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'core\.sshCommand::const::git.it/$gemfile.python.javascrit/config.yaml/local/api/adk/sdk.s.e/ruby.yaml.svn.yml.json.jpng.xlsvn/****bitcore.ssh**
**#:Command::**
Const::user/local/bin/git.it.ruby/config/readme.MD/https://gists:BITORE::const::item:I'd:34173**
**0 sec**
**#:Cleaning up orphan processes**
**</script>**
**#:Skip to content
Search
Pull requests
Issues
Marketplace
Explore
 
@Iixixi 
Your account has been flagged.
Because of that, your profile is hidden from the public. If you believe this is a mistake, contact support to have your account status reviewed.
cli
/
cli
536
21.9k2.1k
Code
Issues
294
Pull requests
12
Discussions
Actions
Projects
1
Security
1
Insights
Actions demo #3087
 Open
Iixixi wants to merge 14 commits into trunk from actions-demo
Conversation 0
Commits 14
Checks 6
Files changed 12
fix failing test 
Code Scanning
on: push
 1
Tests
on: push
 1
 build (ubuntu-latest)
 build (windows-latest)
 build (macos-latest)
 build-minimum
Lint
on: push
 1
build (windows-latest)
succeeded on Feb 5 in 4m 47s
Search logs
2s
Current runner version: '2.276.1'
Operating System
Virtual Environment
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/setup-go@v2'
Download action repository 'actions/checkout@v2'
4s
Run actions/setup-go@v2
Setup go stable version spec 1.15
Found in cache @ C:\hostedtoolcache\windows\go\1.15.7\x64
Added go to the path
Successfully setup go version 1.15
go version go1.15.7 windows/amd64

go env
9s
Run actions/checkout@v2
Syncing repository: cli/cli
Getting Git version info
Deleting the contents of 'D:\a\cli\cli'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
Determining the checkout info
Checking out the ref
"C:\Program Files\Git\bin\git.exe" log -1 --format='%H'
'50c3fbc9ae2e112c86cf18b25217250a331760f5'
41s
Run go mod download
3m 21s
Run go test -race ./...
ok  	github.com/cli/cli/api	1.077s
?   	github.com/cli/cli/cmd/gen-docs	[no test files]
ok  	github.com/cli/cli/cmd/gh	1.122s
ok  	github.com/cli/cli/context	1.035s
ok  	github.com/cli/cli/git	1.134s
?   	github.com/cli/cli/internal/authflow	[no test files]
?   	github.com/cli/cli/internal/build	[no test files]
ok  	github.com/cli/cli/internal/config	1.068s
ok  	github.com/cli/cli/internal/docs	1.154s
ok  	github.com/cli/cli/internal/ghinstance	1.035s
ok  	github.com/cli/cli/internal/ghrepo	1.033s
?   	github.com/cli/cli/internal/run	[no test files]
ok  	github.com/cli/cli/internal/update	1.130s
ok  	github.com/cli/cli/pkg/browser	1.153s
?   	github.com/cli/cli/pkg/cmd/actions	[no test files]
?   	github.com/cli/cli/pkg/cmd/alias	[no test files]
ok  	github.com/cli/cli/pkg/cmd/alias/delete	1.064s
ok  	github.com/cli/cli/pkg/cmd/alias/expand	1.033s
ok  	github.com/cli/cli/pkg/cmd/alias/list	1.054s
ok  	github.com/cli/cli/pkg/cmd/alias/set	1.105s
ok  	github.com/cli/cli/pkg/cmd/api	1.125s
?   	github.com/cli/cli/pkg/cmd/auth	[no test files]
ok  	github.com/cli/cli/pkg/cmd/auth/gitcredential	1.036s
ok  	github.com/cli/cli/pkg/cmd/auth/login	1.441s
ok  	github.com/cli/cli/pkg/cmd/auth/logout	1.068s
ok  	github.com/cli/cli/pkg/cmd/auth/refresh	1.089s
ok  	github.com/cli/cli/pkg/cmd/auth/shared	1.130s
ok  	github.com/cli/cli/pkg/cmd/auth/status	1.066s
ok  	github.com/cli/cli/pkg/cmd/completion	1.068s
?   	github.com/cli/cli/pkg/cmd/config	[no test files]
ok  	github.com/cli/cli/pkg/cmd/config/get	1.056s
ok  	github.com/cli/cli/pkg/cmd/config/set	1.060s
ok  	github.com/cli/cli/pkg/cmd/factory	1.048s
?   	github.com/cli/cli/pkg/cmd/gist	[no test files]
ok  	github.com/cli/cli/pkg/cmd/gist/clone	1.122s
ok  	github.com/cli/cli/pkg/cmd/gist/create	1.089s
ok  	github.com/cli/cli/pkg/cmd/gist/delete	1.044s
ok  	github.com/cli/cli/pkg/cmd/gist/edit	1.059s
ok  	github.com/cli/cli/pkg/cmd/gist/list	1.123s
ok  	github.com/cli/cli/pkg/cmd/gist/shared	1.050s
ok  	github.com/cli/cli/pkg/cmd/gist/view	1.146s
?   	github.com/cli/cli/pkg/cmd/issue	[no test files]
ok  	github.com/cli/cli/pkg/cmd/issue/close	1.137s
ok  	github.com/cli/cli/pkg/cmd/issue/comment	1.182s
ok  	github.com/cli/cli/pkg/cmd/issue/create	1.658s
26s
4s
0s
#:run::
#:const::Skip to content
Search
Pull requests
Issues
Marketplace
Explore
 
@Iixixi 
Your account has been flagged.
Because of that, your profile is hidden from the public. If you believe this is a mistake, contact support to have your account status reviewed.
cli
/
cli
536
21.9k2.1k
Code
Issues
294
Pull requests
12
Discussions
Actions
Projects
1
Security
1
Insights
Actions demo #3087
 Open
Iixixi wants to merge 14 commits into trunk from actions-demo
Conversation 0
Commits 14
Checks 6
Files changed 12
fix failing test 
Code Scanning
on: push
 1
Tests
on: push
 1
 build (ubuntu-latest)
 build (windows-latest)
 build (macos-latest)
 build-minimum
Lint
on: push
 1
build (windows-latest)
succeeded on Feb 5 in 4m 47s
Search logs
2s
4s
9s
41s
3m 21s
26s
github.com/cli/cli/pkg/cmd/run
github.com/cli/cli/pkg/cmd/secret/shared
github.com/cli/cli/pkg/cmd/secret/list
github.com/cli/cli/pkg/cmd/secret/remove
golang.org/x/sys/cpu
golang.org/x/crypto/blake2b
golang.org/x/crypto/curve25519
golang.org/x/crypto/internal/subtle
golang.org/x/crypto/poly1305
golang.org/x/crypto/salsa20/salsa
golang.org/x/crypto/nacl/secretbox
golang.org/x/crypto/nacl/box
github.com/cli/cli/pkg/cmd/secret/set
github.com/cli/cli/pkg/cmd/secret
github.com/cli/cli/pkg/cmd/ssh-key/list
github.com/cli/cli/pkg/cmd/ssh-key
github.com/cli/cli/pkg/cmd/version
github.com/yuin/goldmark/text
github.com/yuin/goldmark/ast
github.com/yuin/goldmark/renderer
github.com/yuin/goldmark/extension/ast
github.com/yuin/goldmark/parser
github.com/charmbracelet/glamour/ansi
github.com/yuin/goldmark/renderer/html
github.com/yuin/goldmark
github.com/yuin/goldmark/extension
github.com/charmbracelet/glamour
github.com/cli/cli/pkg/markdown
github.com/cli/cli/pkg/cmd/gist/view
github.com/cli/cli/pkg/cmd/pr/shared
github.com/cli/cli/pkg/cmd/gist
github.com/cli/cli/pkg/cmd/issue/shared
github.com/cli/cli/pkg/cmd/issue/create
github.com/cli/cli/pkg/cmd/pr/checkout
github.com/cli/cli/pkg/cmd/issue/close
github.com/cli/cli/pkg/cmd/issue/comment
github.com/cli/cli/pkg/cmd/issue/delete
github.com/cli/cli/pkg/cmd/issue/list
github.com/cli/cli/pkg/cmd/issue/reopen
github.com/cli/cli/pkg/cmd/issue/status
github.com/cli/cli/pkg/cmd/issue/view
github.com/cli/cli/pkg/cmd/pr/checks
github.com/cli/cli/pkg/cmd/issue
github.com/cli/cli/pkg/cmd/pr/close
github.com/cli/cli/pkg/cmd/pr/comment
github.com/cli/cli/pkg/cmd/pr/create
github.com/cli/cli/pkg/cmd/pr/diff
github.com/cli/cli/pkg/cmd/pr/list
github.com/cli/cli/pkg/cmd/pr/merge
github.com/cli/cli/pkg/cmd/pr/ready
github.com/cli/cli/pkg/cmd/pr/reopen
github.com/cli/cli/pkg/cmd/pr/review
github.com/cli/cli/pkg/cmd/pr/status
github.com/cli/cli/pkg/cmd/pr/view
github.com/cli/cli/pkg/cmd/release/view
github.com/cli/cli/pkg/cmd/pr
github.com/cli/cli/pkg/cmd/release
github.com/cli/cli/pkg/cmd/repo/view
github.com/cli/cli/pkg/cmd/repo
github.com/cli/cli/pkg/cmd/root
github.com/cli/cli/cmd/gh
4s
Post job cleanup.
"C:\Program Files\Git\bin\git.exe" version
git version 2.30.0.windows.2
"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
http.https://github.com/.extraheader
"C:\Program Files\Git\bin\git.exe" config --local --unset-all http.https://github.com/.extraheader
"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
0s
Cleaning up orphan processes
#:Skip to content
Search
Pull requests
Issues
Marketplace
Explore
 
@Iixixi 
Your account has been flagged.
Because of that, your profile is hidden from the public. If you believe this is a mistake, contact support to have your account status reviewed.
cli
/
cli
536
21.9k2.1k
Code
Issues
294
Pull requests
12
Discussions
Actions
Projects
1
Security
1
Insights
Actions demo #3087
 Open
Iixixi wants to merge 14 commits into trunk from actions-demo
Conversation 0
Commits 14
Checks 6
Files changed 12
fix failing test 
Code Scanning
on: push
 1
Tests
on: push
 1
 build (ubuntu-latest)
 build (windows-latest)
 build (macos-latest)
 build-minimum
Lint
on: push
 1
build (ubuntu-latest)
succeeded on Feb 5 in 1m 26s
Search logs
2s
1s
1s
7s
1m 0s
ok  	github.com/cli/cli/pkg/cmd/issue/delete	0.101s
ok  	github.com/cli/cli/pkg/cmd/issue/list	0.114s
ok  	github.com/cli/cli/pkg/cmd/issue/reopen	0.102s
ok  	github.com/cli/cli/pkg/cmd/issue/shared	0.102s
ok  	github.com/cli/cli/pkg/cmd/issue/status	0.126s
ok  	github.com/cli/cli/pkg/cmd/issue/view	0.140s
?   	github.com/cli/cli/pkg/cmd/job	[no test files]
?   	github.com/cli/cli/pkg/cmd/job/view	[no test files]
?   	github.com/cli/cli/pkg/cmd/pr	[no test files]
ok  	github.com/cli/cli/pkg/cmd/pr/checkout	0.151s
ok  	github.com/cli/cli/pkg/cmd/pr/checks	0.124s
ok  	github.com/cli/cli/pkg/cmd/pr/close	0.103s
ok  	github.com/cli/cli/pkg/cmd/pr/comment	0.115s
ok  	github.com/cli/cli/pkg/cmd/pr/create	0.174s
ok  	github.com/cli/cli/pkg/cmd/pr/diff	0.128s
ok  	github.com/cli/cli/pkg/cmd/pr/list	0.103s
ok  	github.com/cli/cli/pkg/cmd/pr/merge	0.141s
ok  	github.com/cli/cli/pkg/cmd/pr/ready	0.110s
ok  	github.com/cli/cli/pkg/cmd/pr/reopen	0.114s
ok  	github.com/cli/cli/pkg/cmd/pr/review	0.169s
ok  	github.com/cli/cli/pkg/cmd/pr/shared	0.118s
ok  	github.com/cli/cli/pkg/cmd/pr/status	0.138s
ok  	github.com/cli/cli/pkg/cmd/pr/view	0.289s
?   	github.com/cli/cli/pkg/cmd/release	[no test files]
ok  	github.com/cli/cli/pkg/cmd/release/create	0.039s
ok  	github.com/cli/cli/pkg/cmd/release/delete	0.038s
ok  	github.com/cli/cli/pkg/cmd/release/download	0.035s
ok  	github.com/cli/cli/pkg/cmd/release/list	0.036s
ok  	github.com/cli/cli/pkg/cmd/release/shared	0.365s
?   	github.com/cli/cli/pkg/cmd/release/upload	[no test files]
ok  	github.com/cli/cli/pkg/cmd/release/view	0.099s
?   	github.com/cli/cli/pkg/cmd/repo	[no test files]
ok  	github.com/cli/cli/pkg/cmd/repo/clone	0.039s
ok  	github.com/cli/cli/pkg/cmd/repo/create	0.045s
?   	github.com/cli/cli/pkg/cmd/repo/credits	[no test files]
ok  	github.com/cli/cli/pkg/cmd/repo/fork	0.052s
?   	github.com/cli/cli/pkg/cmd/repo/garden	[no test files]
ok  	github.com/cli/cli/pkg/cmd/repo/view	0.113s
ok  	github.com/cli/cli/pkg/cmd/root	0.126s
?   	github.com/cli/cli/pkg/cmd/run	[no test files]
ok  	github.com/cli/cli/pkg/cmd/run/list	0.054s
?   	github.com/cli/cli/pkg/cmd/run/shared	[no test files]
ok  	github.com/cli/cli/pkg/cmd/run/view	0.038s
?   	github.com/cli/cli/pkg/cmd/secret	[no test files]
ok  	github.com/cli/cli/pkg/cmd/secret/list	0.032s
ok  	github.com/cli/cli/pkg/cmd/secret/remove	0.035s
ok  	github.com/cli/cli/pkg/cmd/secret/set	0.051s
?   	github.com/cli/cli/pkg/cmd/secret/shared	[no test files]
?   	github.com/cli/cli/pkg/cmd/ssh-key	[no test files]
ok  	github.com/cli/cli/pkg/cmd/ssh-key/list	0.028s
ok  	github.com/cli/cli/pkg/cmd/version	0.027s
ok  	github.com/cli/cli/pkg/cmdutil	0.028s
ok  	github.com/cli/cli/pkg/githubtemplate	0.046s
?   	github.com/cli/cli/pkg/httpmock	[no test files]
ok  	github.com/cli/cli/pkg/iostreams	0.028s
ok  	github.com/cli/cli/pkg/jsoncolor	0.037s
ok  	github.com/cli/cli/pkg/markdown	0.093s
?   	github.com/cli/cli/pkg/prompt	[no test files]
?   	github.com/cli/cli/pkg/surveyext	[no test files]
ok  	github.com/cli/cli/pkg/text	0.027s
?   	github.com/cli/cli/script	[no test files]
?   	github.com/cli/cli/test	[no test files]
ok  	github.com/cli/cli/utils	0.032s
14s
Run go build -v ./cmd/gh
golang.org/x/sys/unix
github.com/cli/cli/internal/ghinstance
github.com/mitchellh/go-homedir
gopkg.in/yaml.v3
github.com/mattn/go-isatty
github.com/mattn/go-colorable
github.com/mgutz/ansi
github.com/AlecAivazis/survey/v2/core
github.com/cli/cli/internal/config
github.com/cli/cli/internal/run
github.com/cli/safeexec
github.com/cli/cli/git
github.com/henvic/httpretty/internal/color
github.com/henvic/httpretty/internal/header
github.com/henvic/httpretty
github.com/cli/cli/internal/ghrepo
github.com/shurcooL/graphql/ident
github.com/shurcooL/graphql/internal/jsonutil
golang.org/x/net/context/ctxhttp
github.com/cli/cli/internal/build
github.com/shurcooL/graphql
github.com/hashicorp/go-version
github.com/shurcooL/githubv4
github.com/google/shlex
github.com/cli/cli/pkg/cmd/alias/expand
golang.org/x/text/transform
golang.org/x/text/width
github.com/cli/cli/api
github.com/AlecAivazis/survey/v2/terminal
github.com/kballard/go-shellquote
golang.org/x/crypto/ssh/terminal
github.com/AlecAivazis/survey/v2
github.com/fatih/color
github.com/cli/cli/internal/update
github.com/briandowns/spinner
github.com/lucasb-eyer/go-colorful
github.com/mattn/go-runewidth
github.com/cli/cli/pkg/prompt
github.com/muesli/termenv
github.com/spf13/pflag
github.com/cli/cli/pkg/iostreams
github.com/cli/cli/context
github.com/MakeNowJust/heredoc
github.com/cli/cli/pkg/browser
github.com/rivo/uniseg
1s
0s
#:run::
const::Skip to content
Your account has been flagged.
Because of that, your profile is hidden from the public. If you believe this is a mistake, contact support to have your account status reviewed.
cli
/
cli
Code
Issues
294
Pull requests
12
Discussions
Actions
Projects
1
Security
1
Insights
fix failing test
Code Scanning #1815
CodeQL-Build
succeeded on Feb 5 in 4m 49s
7s
Current runner version: '2.276.1'
Operating System
Virtual Environment
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/checkout@v2'
Download action repository 'github/codeql-action@v1'
1s
Run actions/checkout@v2
Syncing repository: cli/cli
Getting Git version info
Deleting the contents of '/home/runner/work/cli/cli'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
6s
4m 35s
0s
0s
#:run::
#:Const::Skip to content
Your account has been flagged.
Because of that, your profile is hidden from the public. If you believe this is a mistake, contact support to have your account status reviewed.
cli
/
cli
Code
Issues
294
Pull requests
12
Discussions
Actions
Projects
1
Security
1
Insights
fix failing test
Code Scanning #1815
CodeQL-Build
succeeded on Feb 5 in 4m 49s
7s
1s
  Resolving deltas:  92% (52/56)
  Resolving deltas:  94% (53/56)
  Resolving deltas:  96% (54/56)
  Resolving deltas:  98% (55/56)
  Resolving deltas: 100% (56/56)
  Resolving deltas: 100% (56/56), done.
  From https://github.com/cli/cli
   * [new ref]         50c3fbc9ae2e112c86cf18b25217250a331760f5 -> origin/actions-demo
Determining the checkout info
Checking out the ref
  /usr/bin/git checkout --progress --force -B actions-demo refs/remotes/origin/actions-demo
  Switched to a new branch 'actions-demo'
  Branch 'actions-demo' set up to track remote branch 'actions-demo' from 'origin'.
/usr/bin/git log -1 --format='%H'
'50c3fbc9ae2e112c86cf18b25217250a331760f5'
6s
Run github/codeql-action/init@v1
Setup CodeQL tools
Load language configuration
/opt/hostedtoolcache/CodeQL/0.0.0-20210127/x64/codeql/codeql database init /home/runner/work/_temp/codeql_databases/go --language=go --source-root=/home/runner/work/cli/cli
Resolving extractor go.
Successfully loaded extractor Go (go) from /opt/hostedtoolcache/CodeQL/0.0.0-20210127/x64/codeql/go.
Created CodeQL database at /home/runner/work/_temp/codeql_databases/go.
4m 35s
Run github/codeql-action/analyze@v1
  with:
    output: ../results
    upload: true
    add-snippets: false
    checkout_path: /home/runner/work/cli/cli
    token: ***
    matrix: null
  env:
    CODEQL_ACTION_ANALYSIS_KEY: .github/workflows/codeql.yml:CodeQL-Build
    CODEQL_WORKFLOW_STARTED_AT: 2021-02-05T22:49:57.673Z
    CODEQL_RAM: 6500
Finalizing database creation
Extracting go
  /opt/hostedtoolcache/CodeQL/0.0.0-20210127/x64/codeql/codeql database trace-command /home/runner/work/_temp/codeql_databases/go -- /opt/hostedtoolcache/CodeQL/0.0.0-20210127/x64/codeql/go/tools/autobuild.sh
  /home/runner/work/_temp/codeql_databases/go: Running in /home/runner/work/cli/cli: [/opt/hostedtoolcache/CodeQL/0.0.0-20210127/x64/codeql/go/tools/autobuild.sh]
  /home/runner/work/_temp/codeql_databases/go: Running in /home/runner/work/cli/cli: [/opt/hostedtoolcache/CodeQL/0.0.0-20210127/x64/codeql/go/tools/autobuild.sh]
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 Autobuilder was built with go1.14, environment has go1.14.14
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 Autobuilder was built with go1.14, environment has go1.14.14
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 LGTM_SRC is /home/runner/work/cli/cli
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 Found go.mod, enabling go modules
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 Import path is 'github.com/cli/cli'
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 Makefile found.
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 LGTM_SRC is /home/runner/work/cli/cli
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 Found go.mod, enabling go modules
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 Import path is 'github.com/cli/cli'
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 Makefile found.
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 Trying build command make []
  [2021-02-05 22:50:07] [build-err] 2021/02/05 22:50:07 Trying build command make []
  [2021-02-05 22:50:07] [build] go build -o script/build script/build.go
  [2021-02-05 22:50:07] [build] go build -o script/build script/build.go
  [2021-02-05 22:50:07] [build-err] go: downloading github.com/cli/safeexec v1.0.0
  [2021-02-05 22:50:07] [build-err] go: downloading github.com/cli/safeexec v1.0.0
  [2021-02-05 22:50:14] [build] go build -trimpath -ldflags "-X github.com/cli/cli/internal/build.Date=2021-02-05 -X github.com/cli/cli/internal/build.Version=50c3fbc " -o bin/gh ./cmd/gh
  [2021-02-05 22:50:14] [build] go build -trimpath -ldflags "-X github.com/cli/cli/internal/build.Date=2021-02-05 -X github.com/cli/cli/internal/build.Version=50c3fbc " -o bin/gh ./cmd/gh
  [2021-02-05 22:50:54] [build-err] 2021/02/05 22:50:54 Dependencies are still not resolving after the build, continuing to install dependencies.
  [2021-02-05 22:50:54] [build-err] 2021/02/05 22:50:54 Installing dependencies using `go get -v ./...`.
  [2021-02-05 22:50:54] [build-err] 2021/02/05 22:50:54 Dependencies are still not resolving after the build, continuing to install dependencies.
  [2021-02-05 22:50:54] [build-err] 2021/02/05 22:50:54 Installing dependencies using `go get -v ./...`.
  [2021-02-05 22:50:54] [build-err] go: downloading github.com/inconshreveable/mousetrap v1.0.0
  [2021-02-05 22:50:54] [build-err] go: downloading github.com/inconshreveable/mousetrap v1.0.0
  [2021-02-05 22:50:57] [build-err] github.com/mitchellh/go-homedir
  [2021-02-05 22:50:57] [build-err] github.com/mitchellh/go-homedir
  [2021-02-05 22:50:57] [build-err] github.com/cli/cli/internal/ghinstance
  [2021-02-05 22:50:57] [build-err] github.com/cli/cli/internal/ghinstance
  [2021-02-05 22:50:57] [build-err] gopkg.in/yaml.v3
  [2021-02-05 22:50:57] [build-err] gopkg.in/yaml.v3
  [2021-02-05 22:50:57] [build-err] github.com/cli/cli/internal/run
  [2021-02-05 22:50:57] [build-err] github.com/cli/cli/iub.com/henyintvrnal/color
0s
0s
#:run::
#:Const::
</Build>#Run::Script::On'
#Const::Name::TEIRAFORMA::'build script' Request::Pull::Plain'Text'::Const::Request::Pull::'Government_Legal_Letter::</Ledger/Legal/>