### PR TITLE
fork: Ask what protocol to use when git_protocol and remote disagree

### DIFF
--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -650,6 +650,8 @@ func TestRepoFork_in_parent_match_protocol(t *testing.T) {
 		},
 	}
 
+	// defer prompt.StubAskOne("ssh")()
+
 	output, err := runCommand(httpClient, remotes, true, "--remote --remote-name=fork")
 	if err != nil {
 		t.Errorf("error running command `repo fork`: %v", err)


### PR DESCRIPTION
Even after setting `git_protocol` in the settings - both globally and specifically for the GitHub host - to `ssh`, gh keeps adding a fork created with `gh repo fork` using `https`.  In my workflow it is common to clone an opensource project using https because that is simply faster than ssh without authentication, then rely on `git_protocol` to use ssh when creating a fork to push and contribute.  The current order of precedence makes that impossible.

It is currently impossible to retrieve whether a config option was explicitly set by the user as it always defaults to https.  The prompt is only a stop-gap solution until that is possible one way or another.  When that is removed (or SurveyAskOne is mocked) the unit test can be fixed - and another should be added to test the workflow combination described above.

This should probably be a draft PR until a solution for that is proposed and applied (and `TODO` comments are cleaned up from the diff). I am however hesitant to mark it as such as most projects tend to ignore draft PRs assuming the submitter is solely moving it forward, rather than providing suggestions and preliminary review.

Fixes: #2711