### PR TITLE
Accept `--body-file` flag if `--body` is supported

### DIFF
--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -35,6 +35,14 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 			return prShared.CommentablePreRun(cmd, opts)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
+			if opts.BodyFile != "" {
+				b, err := cmdutil.ReadFile(opts.BodyFile, opts.IO.In)
+				if err != nil {
+					return err
+				}
+				opts.Body = string(b)
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -43,6 +51,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 	}
 
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Supply a body. Will prompt for one otherwise.")
+	cmd.Flags().StringVarP(&opts.BodyFile, "body-file", "F", "", "Read body text from `file`")
 	cmd.Flags().BoolP("editor", "e", false, "Add body using editor")
 	cmd.Flags().BoolP("web", "w", false, "Add body in browser")
 

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -23,6 +23,8 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 		OpenInBrowser:         utils.OpenInBrowser,
 	}
 
+	var bodyFile string
+
 	cmd := &cobra.Command{
 		Use:   "comment {<number> | <url>}",
 		Short: "Create a new issue comment",
@@ -35,8 +37,8 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 			return prShared.CommentablePreRun(cmd, opts)
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			if opts.BodyFile != "" {
-				b, err := cmdutil.ReadFile(opts.BodyFile, opts.IO.In)
+			if bodyFile != "" {
+				b, err := cmdutil.ReadFile(bodyFile, opts.IO.In)
 				if err != nil {
 					return err
 				}
@@ -51,7 +53,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 	}
 
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Supply a body. Will prompt for one otherwise.")
-	cmd.Flags().StringVarP(&opts.BodyFile, "body-file", "F", "", "Read body text from `file`")
+	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file`")
 	cmd.Flags().BoolP("editor", "e", false, "Add body using editor")
 	cmd.Flags().BoolP("web", "w", false, "Add body in browser")
 

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -2,7 +2,10 @@ package comment
 
 import (
 	"bytes"
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"path/filepath"
 	"testing"
 
 	"github.com/cli/cli/internal/ghrepo"
@@ -12,12 +15,18 @@ import (
 	"github.com/cli/cli/pkg/iostreams"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewCmdComment(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "my-body.md")
+	err := ioutil.WriteFile(tmpFile, []byte("a body from file"), 0600)
+	require.NoError(t, err)
+
 	tests := []struct {
 		name     string
 		input    string
+		stdin    string
 		output   shared.CommentableOptions
 		wantsErr bool
 	}{
@@ -58,6 +67,27 @@ func TestNewCmdComment(t *testing.T) {
 			wantsErr: false,
 		},
 		{
+			name:  "body from stdin",
+			input: "1 --body-file -",
+			stdin: "this is on standard input",
+			output: shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeInline,
+				Body:        "this is on standard input",
+			},
+			wantsErr: false,
+		},
+		{
+			name:  "body from file",
+			input: fmt.Sprintf("1 --body-file '%s'", tmpFile),
+			output: shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeInline,
+				Body:        "a body from file",
+			},
+			wantsErr: false,
+		},
+		{
 			name:  "editor flag",
 			input: "1 --editor",
 			output: shared.CommentableOptions{
@@ -76,6 +106,12 @@ func TestNewCmdComment(t *testing.T) {
 				Body:        "",
 			},
 			wantsErr: false,
+		},
+		{
+			name:     "body and body-file flags",
+			input:    "1 --body 'test' --body-file 'test-file.txt'",
+			output:   shared.CommentableOptions{},
+			wantsErr: true,
 		},
 		{
 			name:     "editor and web flags",
@@ -105,10 +141,14 @@ func TestNewCmdComment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			io, stdin, _, _ := iostreams.Test()
 			io.SetStdoutTTY(true)
 			io.SetStdinTTY(true)
 			io.SetStderrTTY(true)
+
+			if tt.stdin != "" {
+				_, _ = stdin.WriteString(tt.stdin)
+			}
 
 			f := &cmdutil.Factory{
 				IOStreams: io,

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -24,6 +24,8 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 		OpenInBrowser:         utils.OpenInBrowser,
 	}
 
+	var bodyFile string
+
 	cmd := &cobra.Command{
 		Use:   "comment [<number> | <url> | <branch>]",
 		Short: "Create a new pr comment",
@@ -43,8 +45,8 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 			return shared.CommentablePreRun(cmd, opts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if opts.BodyFile != "" {
-				b, err := cmdutil.ReadFile(opts.BodyFile, opts.IO.In)
+			if bodyFile != "" {
+				b, err := cmdutil.ReadFile(bodyFile, opts.IO.In)
 				if err != nil {
 					return err
 				}
@@ -59,7 +61,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 	}
 
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Supply a body. Will prompt for one otherwise.")
-	cmd.Flags().StringVarP(&opts.BodyFile, "body-file", "F", "", "Read body text from `file`")
+	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file`")
 	cmd.Flags().BoolP("editor", "e", false, "Add body using editor")
 	cmd.Flags().BoolP("web", "w", false, "Add body in browser")
 

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -43,6 +43,14 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 			return shared.CommentablePreRun(cmd, opts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.BodyFile != "" {
+				b, err := cmdutil.ReadFile(opts.BodyFile, opts.IO.In)
+				if err != nil {
+					return err
+				}
+				opts.Body = string(b)
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -51,6 +59,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 	}
 
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Supply a body. Will prompt for one otherwise.")
+	cmd.Flags().StringVarP(&opts.BodyFile, "body-file", "F", "", "Read body text from `file`")
 	cmd.Flags().BoolP("editor", "e", false, "Add body using editor")
 	cmd.Flags().BoolP("web", "w", false, "Add body in browser")
 

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -63,6 +63,8 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 		flagRebase bool
 	)
 
+	var bodyFile string
+
 	cmd := &cobra.Command{
 		Use:   "merge [<number> | <url> | <branch>]",
 		Short: "Merge a pull request",
@@ -106,7 +108,28 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 
 			opts.IsDeleteBranchIndicated = cmd.Flags().Changed("delete-branch")
 			opts.CanDeleteLocalBranch = !cmd.Flags().Changed("repo")
-			opts.BodySet = cmd.Flags().Changed("body")
+
+			bodyProvided := cmd.Flags().Changed("body")
+			bodyFileProvided := bodyFile != ""
+
+			if err := cmdutil.MutuallyExclusive(
+				"specify only one of `--body` or `--body-file`",
+				bodyProvided,
+				bodyFileProvided,
+			); err != nil {
+				return err
+			}
+			if bodyProvided || bodyFileProvided {
+				opts.BodySet = true
+				if bodyFileProvided {
+					b, err := cmdutil.ReadFile(bodyFile, opts.IO.In)
+					if err != nil {
+						return err
+					}
+					opts.Body = string(b)
+				}
+
+			}
 
 			opts.Editor = &userEditor{
 				io:     opts.IO,
@@ -122,6 +145,7 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 
 	cmd.Flags().BoolVarP(&opts.DeleteBranch, "delete-branch", "d", false, "Delete the local and remote branch after merge")
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Body `text` for the merge commit")
+	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file`")
 	cmd.Flags().BoolVarP(&flagMerge, "merge", "m", false, "Merge the commits with the base branch")
 	cmd.Flags().BoolVarP(&flagRebase, "rebase", "r", false, "Rebase the commits onto the base branch")
 	cmd.Flags().BoolVarP(&flagSquash, "squash", "s", false, "Squash the commits into one commit and merge it into the base branch")

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -42,7 +42,6 @@ type CommentableOptions struct {
 	Interactive           bool
 	InputType             InputType
 	Body                  string
-	BodyFile              string
 }
 
 func CommentablePreRun(cmd *cobra.Command, opts *CommentableOptions) error {

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -42,11 +42,16 @@ type CommentableOptions struct {
 	Interactive           bool
 	InputType             InputType
 	Body                  string
+	BodyFile              string
 }
 
 func CommentablePreRun(cmd *cobra.Command, opts *CommentableOptions) error {
 	inputFlags := 0
 	if cmd.Flags().Changed("body") {
+		opts.InputType = InputTypeInline
+		inputFlags++
+	}
+	if cmd.Flags().Changed("body-file") {
 		opts.InputType = InputTypeInline
 		inputFlags++
 	}
@@ -61,15 +66,15 @@ func CommentablePreRun(cmd *cobra.Command, opts *CommentableOptions) error {
 
 	if inputFlags == 0 {
 		if !opts.IO.CanPrompt() {
-			return &cmdutil.FlagError{Err: errors.New("--body or --web required when not running interactively")}
+			return &cmdutil.FlagError{Err: errors.New("`--body`, `--body-file` or `--web` required when not running interactively")}
 		}
 		opts.Interactive = true
 	} else if inputFlags == 1 {
 		if !opts.IO.CanPrompt() && opts.InputType == InputTypeEditor {
-			return &cmdutil.FlagError{Err: errors.New("--body or --web required when not running interactively")}
+			return &cmdutil.FlagError{Err: errors.New("`--body`, `--body-file` or `--web` required when not running interactively")}
 		}
 	} else if inputFlags > 1 {
-		return &cmdutil.FlagError{Err: fmt.Errorf("specify only one of --body, --editor, or --web")}
+		return &cmdutil.FlagError{Err: fmt.Errorf("specify only one of `--body`, `--body-file`, `--editor`, or `--web`")}
 	}
 
 	return nil


### PR DESCRIPTION
Closes #3187 

When providing both `--body-file` and `--body` all commands will throw an error.
