### PR TITLE
Add workflow for automated PR linting

### DIFF
--- a/.github/workflows/prauto.yml
+++ b/.github/workflows/prauto.yml
@@ -1,0 +1,65 @@
+name: PR Automation
+on:
+  pull_request:
+    types: [ready_for_review, opened, reopened]
+jobs:
+  bash-redux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: lint pr
+        env:
+          REPO: "cli/cli"
+          NEEDSREVIEWCOL: "MDEzOlByb2plY3RDb2x1bW43MTEwMTI4"
+          PRID: ${{ github.event.pull_request.node_id }}
+          PRBODY: ${{ github.event.pull_request.body }}
+          STAFF: "vilmibm,mislav,samcoe,billygriffin,ampinsk"
+          PRNUM: ${{ github.event.pull_request.number }}
+          PRBASE: ${{ github.event.pull_request.base.ref }}
+          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+          # Testing data:
+          #REPO: "vilmibm/testing"
+          #NEEDSREVIEWCOL: "MDEzOlByb2plY3RDb2x1bW4xMTAzNTA3Ng==" # vilmibm/testing "good" column
+        run: |
+          commentPR () {
+            gh -R$REPO pr comment $PRNUM -b "${1}"
+          }
+
+          closePR () {
+            gh -R$REPO pr close $PRNUM
+          }
+
+          addToBoard () {
+            # this exec is an attempt to fix some quote highlighting issues i was having in my editor.
+            bash -c 'gh api graphql -f query="mutation { addProjectCard(input: { projectColumnId: \"$NEEDSREVIEWCOL\", contentId: \"$PRID\" }) { clientMutationId } }"'
+          }
+
+          if echo $STAFF | grep $PRAUTHOR
+          then
+            addToBoard
+            exit 0
+          fi
+
+          if echo $PRBODY | wc -w | grep '^[0-9]$'
+          then
+            commentPR "Thanks for the PR! We're a small team and it's helpful to have context around community submissions in order to review them appropriately. Our automation has closed this PR since the body appears to be lacking much content; please add a more descriptive PR body as well as any issues it closes and reopen. Thanks again!"
+            closePR
+            exit 0
+          fi
+
+          if echo $PRBASE | grep -Ev "^trunk$"
+          then
+            commentPR "This pull request should probably be targeting trunk; since it isn't, our automation has closed it. Please reopen with an appropriate base branch if this was in error."
+            closePR
+            exit 0
+          fi
+
+          if echo $PRBODY | grep -Ev " \#\d+ "
+          then
+            commentPR "Hi! Thanks for the PR. Please ensure that this PR is related to an issue by mentioning its issue number in the PR body. If this PR would close the issue, please put 'Fixes #<issue number>' somewhere in the PR body. If this is a tiny change like fixing a typo, feel free to ignore this message."
+            # TODO should this be close-worthy? I feel like sometimes it's ok
+            # to not have an issue (like a tiny typo fix) so we should have
+            # this be a warning.
+          fi
+
+          addToBoard
+          exit 0

--- a/.github/workflows/prauto.yml
+++ b/.github/workflows/prauto.yml
@@ -10,7 +10,6 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEEDSREVIEWCOL: "MDEzOlByb2plY3RDb2x1bW43MTEwMTI4"
           PRID: ${{ github.event.pull_request.node_id }}
           PRBODY: ${{ github.event.pull_request.body }}
           PRNUM: ${{ github.event.pull_request.number }}
@@ -26,10 +25,21 @@ jobs:
             gh pr close $PRNUM
           }
 
+          colID () {
+            gh api graphql -f query='query($owner:String!, $repo:String!) {
+              repository(owner:$owner, name:$repo) {
+                project(number:1) {
+                  columns(first:10) { nodes {id,name} }
+                }
+              }
+            }' -F owner=:owner -F repo=:repo \
+              -q ".data.repository.project.columns.nodes[] | select(.name | startswith(\"$1\")) | .id"
+          }
+
           addToBoard () {
             gh api graphql --silent -f query='
               mutation($colID:ID!, $pr:ID!) { addProjectCard(input: { projectColumnId: $colID, contentId: $prID }) { clientMutationId } }
-            ' -f colID="$NEEDSREVIEWCOL" -f prID="$PRID"
+            ' -f colID="$(colID "Needs review")" -f prID="$PRID"
           }
 
           if gh api orgs/cli/public_members/$PRAUTHOR --silent 2>/dev/null

--- a/.github/workflows/prauto.yml
+++ b/.github/workflows/prauto.yml
@@ -16,6 +16,7 @@ jobs:
           PRNUM: ${{ github.event.pull_request.number }}
           PRBASE: ${{ github.event.pull_request.base.ref }}
           GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+          PRAUTHOR: ${{ github.event.pull_request.user.login }}
           # Testing data:
           #REPO: "vilmibm/testing"
           #NEEDSREVIEWCOL: "MDEzOlByb2plY3RDb2x1bW4xMTAzNTA3Ng==" # vilmibm/testing "good" column
@@ -35,6 +36,7 @@ jobs:
 
           if echo $STAFF | grep $PRAUTHOR
           then
+            # TODO this errors if it's already on the board...
             addToBoard
             exit 0
           fi

--- a/.github/workflows/prauto.yml
+++ b/.github/workflows/prauto.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [ready_for_review, opened, reopened]
 jobs:
-  bash-redux:
+  pr-auto:
     runs-on: ubuntu-latest
     steps:
       - name: lint pr

--- a/.github/workflows/prauto.yml
+++ b/.github/workflows/prauto.yml
@@ -39,23 +39,23 @@ jobs:
             exit 0
           fi
 
-          if echo $PRBODY | wc -w | grep '^[0-9]$'
+          if echo "${PRBODY}" | wc -w | grep -E '^[0-9]$'
           then
             commentPR "Thanks for the PR! We're a small team and it's helpful to have context around community submissions in order to review them appropriately. Our automation has closed this PR since the body appears to be lacking much content; please add a more descriptive PR body as well as any issues it closes and reopen. Thanks again!"
             closePR
             exit 0
           fi
 
-          if echo $PRBASE | grep -Ev "^trunk$"
+          if echo "${PRBASE}" | grep -Ev "^trunk$"
           then
             commentPR "This pull request should probably be targeting trunk; since it isn't, our automation has closed it. Please reopen with an appropriate base branch if this was in error."
             closePR
             exit 0
           fi
 
-          if echo $PRBODY | grep -Ev " \#\d+ "
+          if echo "${PRBODY}" | grep -Ev " \#\d+ "
           then
-            commentPR "Hi! Thanks for the PR. Please ensure that this PR is related to an issue by mentioning its issue number in the PR body. If this PR would close the issue, please put 'Fixes #<issue number>' somewhere in the PR body. If this is a tiny change like fixing a typo, feel free to ignore this message."
+            commentPR "Hi! Thanks for the PR. Please ensure that this PR is related to an issue by mentioning its issue number in the PR body. If this PR would close the issue, please put the word 'Fixes' before the issue number somewhere in the PR body. If this is a tiny change like fixing a typo, feel free to ignore this message."
             # TODO should this be close-worthy? I feel like sometimes it's ok
             # to not have an issue (like a tiny typo fix) so we should have
             # this be a warning.

--- a/.github/workflows/prauto.yml
+++ b/.github/workflows/prauto.yml
@@ -8,59 +8,53 @@ jobs:
     steps:
       - name: lint pr
         env:
-          REPO: "cli/cli"
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEEDSREVIEWCOL: "MDEzOlByb2plY3RDb2x1bW43MTEwMTI4"
           PRID: ${{ github.event.pull_request.node_id }}
           PRBODY: ${{ github.event.pull_request.body }}
-          STAFF: "vilmibm,mislav,samcoe,billygriffin,ampinsk"
           PRNUM: ${{ github.event.pull_request.number }}
-          PRBASE: ${{ github.event.pull_request.base.ref }}
-          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+          PRHEAD: ${{ github.event.pull_request.head.label }}
           PRAUTHOR: ${{ github.event.pull_request.user.login }}
-          # Testing data:
-          #REPO: "vilmibm/testing"
-          #NEEDSREVIEWCOL: "MDEzOlByb2plY3RDb2x1bW4xMTAzNTA3Ng==" # vilmibm/testing "good" column
+        if: "!github.event.pull_request.draft"
         run: |
           commentPR () {
-            gh -R$REPO pr comment $PRNUM -b "${1}"
+            gh pr comment $PRNUM -b "${1}"
           }
 
           closePR () {
-            gh -R$REPO pr close $PRNUM
+            gh pr close $PRNUM
           }
 
           addToBoard () {
-            # this exec is an attempt to fix some quote highlighting issues i was having in my editor.
-            bash -c 'gh api graphql -f query="mutation { addProjectCard(input: { projectColumnId: \"$NEEDSREVIEWCOL\", contentId: \"$PRID\" }) { clientMutationId } }"'
+            gh api graphql --silent -f query='
+              mutation($colID:ID!, $pr:ID!) { addProjectCard(input: { projectColumnId: $colID, contentId: $prID }) { clientMutationId } }
+            ' -f colID="$NEEDSREVIEWCOL" -f prID="$PRID"
           }
 
-          if echo $STAFF | grep $PRAUTHOR
+          if gh api orgs/cli/public_members/$PRAUTHOR --silent 2>/dev/null
           then
             # TODO this errors if it's already on the board...
             addToBoard
             exit 0
           fi
 
-          if echo "${PRBODY}" | wc -w | grep -E '^[0-9]$'
+          if [ "$PRHEAD" = "cli:trunk" ]
           then
-            commentPR "Thanks for the PR! We're a small team and it's helpful to have context around community submissions in order to review them appropriately. Our automation has closed this PR since the body appears to be lacking much content; please add a more descriptive PR body as well as any issues it closes and reopen. Thanks again!"
             closePR
             exit 0
           fi
 
-          if echo "${PRBASE}" | grep -Ev '^trunk$'
+          if [ $(wc -c <<<"$PRBODY") -lt 10 ]
           then
-            commentPR "This pull request should probably be targeting trunk; since it isn't, our automation has closed it. Please reopen with an appropriate base branch if this was in error."
+            commentPR "Thanks for the pull request! We're a small team and it's helpful to have context around community submissions in order to review them appropriately. Our automation has closed this pull request since it does not have an adequate description. Please edit the body of this pull request to describe what this does, then reopen it."
             closePR
             exit 0
           fi
 
-          if echo "${PRBODY}" | grep -Ev '#[0-9]+'
+          if ! grep -Eq '(#|issues/)[0-9]+' <<<"$PRBODY"
           then
-            commentPR "Hi! Thanks for the PR. Please ensure that this PR is related to an issue by mentioning its issue number in the PR body. If this PR would close the issue, please put the word 'Fixes' before the issue number somewhere in the PR body. If this is a tiny change like fixing a typo, feel free to ignore this message."
-            # TODO should this be close-worthy? I feel like sometimes it's ok
-            # to not have an issue (like a tiny typo fix) so we should have
-            # this be a warning.
+            commentPR "Hi! Thanks for the pull request. Please ensure that this change is linked to an issue by mentioning an issue number in the description of the pull request. If this pull request would close the issue, please put the word 'Fixes' before the issue number somewhere in the pull request body. If this is a tiny change like fixing a typo, feel free to ignore this message."
           fi
 
           addToBoard

--- a/.github/workflows/prauto.yml
+++ b/.github/workflows/prauto.yml
@@ -46,14 +46,14 @@ jobs:
             exit 0
           fi
 
-          if echo "${PRBASE}" | grep -Ev "^trunk$"
+          if echo "${PRBASE}" | grep -Ev '^trunk$'
           then
             commentPR "This pull request should probably be targeting trunk; since it isn't, our automation has closed it. Please reopen with an appropriate base branch if this was in error."
             closePR
             exit 0
           fi
 
-          if echo "${PRBODY}" | grep -Ev " \#\d+ "
+          if echo "${PRBODY}" | grep -Ev '#[0-9]+'
           then
             commentPR "Hi! Thanks for the PR. Please ensure that this PR is related to an issue by mentioning its issue number in the PR body. If this PR would close the issue, please put the word 'Fixes' before the issue number somewhere in the PR body. If this is a tiny change like fixing a typo, feel free to ignore this message."
             # TODO should this be close-worthy? I feel like sometimes it's ok


### PR DESCRIPTION
This PR adds a single workflow to be run on pull request open, reopen, and ready for review.

- If the PR is authored by a CLI core team member, it's automatically added to the Needs Review column.
- If it's not, this workflow checks:
  - if the PR has a substantial body, closing if not
  - if the PR is not targeting `trunk`, closing if not
  - if the PR does not mention an issue, warning if not.

If the community PR passes each check, it's added to Needs Review.

All of this runs under a new GH account, `cliAutomation`. You can see it in action (closing its own PR lol) [in my testing repo](https://github.com/vilmibm/testing/pull/129)

NB: I also wanted to include a check for whether or not a PR had any "real" commits from the PR author since a common spam PR approach is opening PRs full of the commits of others. This ended up being very annoying to determine since linking from a GitHub username (all I know about a PR author) to a commit (which just has name and email) is not easy. I noticed all of our recent spam would have been caught by either of the other two checks, so I punted for now.

## Open questions

- Is merely warning about lack of issue number sufficient?
- Is adding directly to Needs Review if a community PR passes this linting correct, or do we merely want to leave it open for a first responder to notice?
- Should this ignore draft PRs?

