### PR TITLE
add search feature in listing issues

### DIFF
--- a/pkg/cmd/issue/list/fixtures/issueSearch.json
+++ b/pkg/cmd/issue/list/fixtures/issueSearch.json
@@ -5,53 +5,47 @@
     },
     "search": {
       "issueCount": 3,
-      "edges": [
+      "nodes": [
         {
-          "node": {
-            "number": 1,
-            "title": "number won",
-            "url": "https://wow.com",
-            "updatedAt": "2011-01-26T19:01:12Z",
-            "labels": {
-              "nodes": [
-                {
-                  "name": "label"
-                }
-              ],
-              "totalCount": 1
-            }
+          "number": 1,
+          "title": "number won",
+          "url": "https://wow.com",
+          "updatedAt": "2011-01-26T19:01:12Z",
+          "labels": {
+            "nodes": [
+              {
+                "name": "label"
+              }
+            ],
+            "totalCount": 1
           }
         },
         {
-          "node": {
-            "number": 2,
-            "title": "number too",
-            "url": "https://wow.com",
-            "updatedAt": "2011-01-26T19:01:12Z",
-            "labels": {
-              "nodes": [
-                {
-                  "name": "label"
-                }
-              ],
-              "totalCount": 1
-            }
+          "number": 2,
+          "title": "number too",
+          "url": "https://wow.com",
+          "updatedAt": "2011-01-26T19:01:12Z",
+          "labels": {
+            "nodes": [
+              {
+                "name": "label"
+              }
+            ],
+            "totalCount": 1
           }
         },
         {
-          "node": {
-            "number": 4,
-            "title": "number fore",
-            "url": "https://wow.com",
-            "updatedAt": "2011-01-26T19:01:12Z",
-            "labels": {
-              "nodes": [
-                {
-                  "name": "label"
-                }
-              ],
-              "totalCount": 1
-            }
+          "number": 4,
+          "title": "number fore",
+          "url": "https://wow.com",
+          "updatedAt": "2011-01-26T19:01:12Z",
+          "labels": {
+            "nodes": [
+              {
+                "name": "label"
+              }
+            ],
+            "totalCount": 1
           }
         }
       ]

--- a/pkg/cmd/issue/list/fixtures/issueSearch.json
+++ b/pkg/cmd/issue/list/fixtures/issueSearch.json
@@ -1,11 +1,13 @@
 {
   "data": {
     "repository": {
-      "hasIssuesEnabled": true,
-      "issues": {
-        "totalCount": 3,
-        "nodes": [
-          {
+      "hasIssuesEnabled": true
+    },
+    "search": {
+      "issueCount": 3,
+      "edges": [
+        {
+          "node": {
             "number": 1,
             "title": "number won",
             "url": "https://wow.com",
@@ -18,8 +20,10 @@
               ],
               "totalCount": 1
             }
-          },
-          {
+          }
+        },
+        {
+          "node": {
             "number": 2,
             "title": "number too",
             "url": "https://wow.com",
@@ -32,8 +36,10 @@
               ],
               "totalCount": 1
             }
-          },
-          {
+          }
+        },
+        {
+          "node": {
             "number": 4,
             "title": "number fore",
             "url": "https://wow.com",
@@ -47,8 +53,8 @@
               "totalCount": 1
             }
           }
-        ]
-      }
+        }
+      ]
     }
   }
 }

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -153,7 +153,7 @@ func issueList(client *http.Client, repo ghrepo.Interface, filters prShared.Filt
 			filters.Milestone = milestone.Title
 		}
 
-		searchQuery := prShared.IssueSearchBuild(filters)
+		searchQuery := prShared.SearchQueryBuild(filters)
 		return api.IssueSearch(apiClient, repo, searchQuery, limit)
 	}
 

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -165,7 +165,7 @@ func TestPRList_filteringAssignee(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`query PullRequestList\b`),
 		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
-			assert.Equal(t, `repo:OWNER/REPO assignee:hubot is:pr sort:created-desc is:merged label:"needs tests" base:"develop"`, params["q"].(string))
+			assert.Equal(t, `repo:OWNER/REPO is:pr is:merged assignee:hubot label:"needs tests" base:develop sort:created-desc`, params["q"].(string))
 		}))
 
 	_, err := runCommand(http, true, `-s merged -l "needs tests" -a hubot -B develop`)

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -157,17 +157,17 @@ func ListURLWithQuery(listURL string, options FilterOptions) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	query := IssueSearchBuild(options)
 
-	q := u.Query()
-	q.Set("q", strings.TrimSuffix(query, " "))
-	u.RawQuery = q.Encode()
+	params := u.Query()
+	params.Set("q", IssueSearchBuild(options))
+	u.RawQuery = params.Encode()
+
 	return u.String(), nil
 }
 
 func IssueSearchBuild(options FilterOptions) string {
-
 	query := fmt.Sprintf("is:%s ", options.Entity)
+
 	if options.State != "all" {
 		query += fmt.Sprintf("is:%s ", options.State)
 	}
@@ -181,7 +181,7 @@ func IssueSearchBuild(options FilterOptions) string {
 		query += fmt.Sprintf("author:%s ", options.Author)
 	}
 	if options.BaseBranch != "" {
-		query += fmt.Sprintf("base:%s ", options.BaseBranch)
+		query += fmt.Sprintf("base:%s ", quoteValueForQuery(options.BaseBranch))
 	}
 	if options.Mention != "" {
 		query += fmt.Sprintf("mentions:%s ", options.Mention)
@@ -193,7 +193,7 @@ func IssueSearchBuild(options FilterOptions) string {
 		query += options.Search
 	}
 
-	return query
+	return strings.TrimSpace(query)
 }
 
 func quoteValueForQuery(v string) string {

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -149,6 +149,7 @@ type FilterOptions struct {
 	BaseBranch string
 	Mention    string
 	Milestone  string
+	Search     string
 }
 
 func ListURLWithQuery(listURL string, options FilterOptions) (string, error) {
@@ -156,6 +157,16 @@ func ListURLWithQuery(listURL string, options FilterOptions) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	query := IssueSearchBuild(options)
+
+	q := u.Query()
+	q.Set("q", strings.TrimSuffix(query, " "))
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func IssueSearchBuild(options FilterOptions) string {
+
 	query := fmt.Sprintf("is:%s ", options.Entity)
 	if options.State != "all" {
 		query += fmt.Sprintf("is:%s ", options.State)
@@ -178,10 +189,11 @@ func ListURLWithQuery(listURL string, options FilterOptions) (string, error) {
 	if options.Milestone != "" {
 		query += fmt.Sprintf("milestone:%s ", quoteValueForQuery(options.Milestone))
 	}
-	q := u.Query()
-	q.Set("q", strings.TrimSuffix(query, " "))
-	u.RawQuery = q.Encode()
-	return u.String(), nil
+	if options.Search != "" {
+		query += options.Search
+	}
+
+	return query
 }
 
 func quoteValueForQuery(v string) string {

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -159,13 +159,13 @@ func ListURLWithQuery(listURL string, options FilterOptions) (string, error) {
 	}
 
 	params := u.Query()
-	params.Set("q", IssueSearchBuild(options))
+	params.Set("q", SearchQueryBuild(options))
 	u.RawQuery = params.Encode()
 
 	return u.String(), nil
 }
 
-func IssueSearchBuild(options FilterOptions) string {
+func SearchQueryBuild(options FilterOptions) string {
 	query := fmt.Sprintf("is:%s ", options.Entity)
 
 	if options.State != "all" {

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -46,7 +46,7 @@ func Test_listURLWithQuery(t *testing.T) {
 					Mention:    "nu",
 				},
 			},
-			want:    "https://example.com/path?q=is%3Aissue+is%3Aopen+assignee%3Abo+author%3Aka+base%3Atrunk+mentions%3Anu",
+			want:    "https://example.com/path?q=is%3Aissue+is%3Aopen+assignee%3Abo+author%3Aka+mentions%3Anu+base%3Atrunk",
 			wantErr: false,
 		},
 		{

--- a/pkg/cmd/repo/list/http_test.go
+++ b/pkg/cmd/repo/list/http_test.go
@@ -57,7 +57,7 @@ func Test_listReposWithLanguage(t *testing.T) {
 	assert.Equal(t, "octocat/hello-world", res.Repositories[0].NameWithOwner)
 
 	assert.Equal(t, float64(10), searchData.Variables["perPage"])
-	assert.Equal(t, `sort:updated-desc user:@me fork:true language:"go"`, searchData.Variables["query"])
+	assert.Equal(t, `user:@me language:go fork:true sort:updated-desc`, searchData.Variables["query"])
 }
 
 func Test_searchQuery(t *testing.T) {
@@ -72,14 +72,14 @@ func Test_searchQuery(t *testing.T) {
 	}{
 		{
 			name: "blank",
-			want: "sort:updated-desc user:@me fork:true",
+			want: "user:@me fork:true sort:updated-desc",
 		},
 		{
 			name: "in org",
 			args: args{
 				owner: "cli",
 			},
-			want: "sort:updated-desc user:cli fork:true",
+			want: "user:cli fork:true sort:updated-desc",
 		},
 		{
 			name: "only public",
@@ -89,7 +89,7 @@ func Test_searchQuery(t *testing.T) {
 					Visibility: "public",
 				},
 			},
-			want: "sort:updated-desc user:@me fork:true is:public",
+			want: "user:@me is:public fork:true sort:updated-desc",
 		},
 		{
 			name: "only private",
@@ -99,7 +99,7 @@ func Test_searchQuery(t *testing.T) {
 					Visibility: "private",
 				},
 			},
-			want: "sort:updated-desc user:@me fork:true is:private",
+			want: "user:@me is:private fork:true sort:updated-desc",
 		},
 		{
 			name: "only forks",
@@ -109,7 +109,7 @@ func Test_searchQuery(t *testing.T) {
 					Fork: true,
 				},
 			},
-			want: "sort:updated-desc user:@me fork:only",
+			want: "user:@me fork:only sort:updated-desc",
 		},
 		{
 			name: "no forks",
@@ -119,7 +119,7 @@ func Test_searchQuery(t *testing.T) {
 					Source: true,
 				},
 			},
-			want: "sort:updated-desc user:@me fork:false",
+			want: "user:@me fork:false sort:updated-desc",
 		},
 		{
 			name: "with language",
@@ -129,7 +129,7 @@ func Test_searchQuery(t *testing.T) {
 					Language: "ruby",
 				},
 			},
-			want: "sort:updated-desc user:@me fork:true language:\"ruby\"",
+			want: `user:@me language:ruby fork:true sort:updated-desc`,
 		},
 		{
 			name: "only archived",
@@ -139,7 +139,7 @@ func Test_searchQuery(t *testing.T) {
 					Archived: true,
 				},
 			},
-			want: "sort:updated-desc user:@me fork:true archived:true",
+			want: "user:@me fork:true archived:true sort:updated-desc",
 		},
 		{
 			name: "only non-archived",
@@ -149,7 +149,7 @@ func Test_searchQuery(t *testing.T) {
 					NonArchived: true,
 				},
 			},
-			want: "sort:updated-desc user:@me fork:true archived:false",
+			want: "user:@me fork:true archived:false sort:updated-desc",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/githubsearch/query.go
+++ b/pkg/githubsearch/query.go
@@ -1,0 +1,205 @@
+package githubsearch
+
+import (
+	"fmt"
+	"strings"
+)
+
+type EntityType string
+type State string
+type RepoVisibility string
+type SortField string
+type SortDirection int
+
+const (
+	Asc SortDirection = iota
+	Desc
+
+	UpdatedAt SortField = "updated"
+	CreatedAt SortField = "created"
+
+	Issue       EntityType = "issue"
+	PullRequest EntityType = "pr"
+
+	Open   State = "open"
+	Closed State = "closed"
+	Merged State = "merged"
+
+	Public  RepoVisibility = "public"
+	Private RepoVisibility = "private"
+)
+
+func NewQuery() *Query {
+	return &Query{}
+}
+
+type Query struct {
+	repo  string
+	owner string
+	sort  string
+	query string
+
+	entity     string
+	state      string
+	baseBranch string
+	headBranch string
+	labels     []string
+	assignee   string
+	author     string
+	mentions   string
+	milestone  string
+
+	language   string
+	forkState  string
+	visibility string
+	isArchived *bool
+}
+
+func (q *Query) InRepository(nameWithOwner string) {
+	q.repo = nameWithOwner
+}
+
+func (q *Query) OwnedBy(owner string) {
+	q.owner = owner
+}
+
+func (q *Query) SortBy(field SortField, direction SortDirection) {
+	var dir string
+	switch direction {
+	case Asc:
+		dir = "asc"
+	case Desc:
+		dir = "desc"
+	}
+	q.sort = fmt.Sprintf("%s-%s", field, dir)
+}
+
+func (q *Query) AddQuery(query string) {
+	q.query = query
+}
+
+func (q *Query) SetType(t EntityType) {
+	q.entity = string(t)
+}
+
+func (q *Query) SetState(s State) {
+	q.state = string(s)
+}
+
+func (q *Query) SetBaseBranch(name string) {
+	q.baseBranch = name
+}
+
+func (q *Query) SetHeadBranch(name string) {
+	q.headBranch = name
+}
+
+func (q *Query) AssignedTo(user string) {
+	q.assignee = user
+}
+
+func (q *Query) AuthoredBy(user string) {
+	q.author = user
+}
+
+func (q *Query) Mentions(handle string) {
+	q.mentions = handle
+}
+
+func (q *Query) InMilestone(title string) {
+	q.milestone = title
+}
+
+func (q *Query) AddLabel(name string) {
+	q.labels = append(q.labels, name)
+}
+
+func (q *Query) SetLanguage(name string) {
+	q.language = name
+}
+
+func (q *Query) SetVisibility(visibility RepoVisibility) {
+	q.visibility = string(visibility)
+}
+
+func (q *Query) OnlyForks() {
+	q.forkState = "only"
+}
+
+func (q *Query) IncludeForks(include bool) {
+	q.forkState = fmt.Sprintf("%v", include)
+}
+
+func (q *Query) SetArchived(isArchived bool) {
+	q.isArchived = &isArchived
+}
+
+func (q *Query) String() string {
+	var qs string
+
+	// context
+	if q.repo != "" {
+		qs += fmt.Sprintf("repo:%s ", q.repo)
+	} else if q.owner != "" {
+		qs += fmt.Sprintf("user:%s ", q.owner)
+	}
+
+	// type
+	if q.entity != "" {
+		qs += fmt.Sprintf("is:%s ", q.entity)
+	}
+	if q.state != "" {
+		qs += fmt.Sprintf("is:%s ", q.state)
+	}
+
+	// repositories
+	if q.visibility != "" {
+		qs += fmt.Sprintf("is:%s ", q.visibility)
+	}
+	if q.language != "" {
+		qs += fmt.Sprintf("language:%s ", quote(q.language))
+	}
+	if q.forkState != "" {
+		qs += fmt.Sprintf("fork:%s ", q.forkState)
+	}
+	if q.isArchived != nil {
+		qs += fmt.Sprintf("archived:%v ", *q.isArchived)
+	}
+
+	// issues
+	if q.assignee != "" {
+		qs += fmt.Sprintf("assignee:%s ", q.assignee)
+	}
+	for _, label := range q.labels {
+		qs += fmt.Sprintf("label:%s ", quote(label))
+	}
+	if q.author != "" {
+		qs += fmt.Sprintf("author:%s ", q.author)
+	}
+	if q.mentions != "" {
+		qs += fmt.Sprintf("mentions:%s ", q.mentions)
+	}
+	if q.milestone != "" {
+		qs += fmt.Sprintf("milestone:%s ", quote(q.milestone))
+	}
+
+	// pull requests
+	if q.baseBranch != "" {
+		qs += fmt.Sprintf("base:%s ", quote(q.baseBranch))
+	}
+	if q.headBranch != "" {
+		qs += fmt.Sprintf("head:%s ", quote(q.headBranch))
+	}
+
+	if q.sort != "" {
+		qs += fmt.Sprintf("sort:%s ", q.sort)
+	}
+	return strings.TrimRight(qs+q.query, " ")
+}
+
+func quote(v string) string {
+	if strings.ContainsAny(v, " \"\t\r\n") {
+		return fmt.Sprintf("%q", v)
+	}
+	return v
+}


### PR DESCRIPTION
This commit adds a `--search` flag to `gh issues list` which uses the Search API. This isn't final. Just an initial trial on the implementation, needs changes and is open to feedback.

Implements a filtering option in https://github.com/cli/cli/issues/641