### PR TITLE
gh workflow list

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -25,6 +25,7 @@ import (
 	secretCmd "github.com/cli/cli/pkg/cmd/secret"
 	sshKeyCmd "github.com/cli/cli/pkg/cmd/ssh-key"
 	versionCmd "github.com/cli/cli/pkg/cmd/version"
+	workflowCmd "github.com/cli/cli/pkg/cmd/workflow"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -85,6 +86,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(actionsCmd.NewCmdActions(f))
 	cmd.AddCommand(runCmd.NewCmdRun(f))
 	cmd.AddCommand(jobCmd.NewCmdJob(f))
+	cmd.AddCommand(workflowCmd.NewCmdWorkflow(f))
 
 	// the `api` command should not inherit any extra HTTP headers
 	bareHTTPCmdFactory := *f

--- a/pkg/cmd/workflow/list/list.go
+++ b/pkg/cmd/workflow/list/list.go
@@ -1,0 +1,165 @@
+package list
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/utils"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultLimit = 10
+
+	Active           WorkflowState = "active"
+	DisabledManually WorkflowState = "disabled_manually"
+)
+
+type ListOptions struct {
+	IO         *iostreams.IOStreams
+	HttpClient func() (*http.Client, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	PlainOutput bool
+
+	All   bool
+	Limit int
+}
+
+func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
+	opts := &ListOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:    "list",
+		Short:  "List GitHub Actions workflows",
+		Args:   cobra.NoArgs,
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			terminal := opts.IO.IsStdoutTTY() && opts.IO.IsStdinTTY()
+			opts.PlainOutput = !terminal
+
+			if opts.Limit < 1 {
+				return &cmdutil.FlagError{Err: fmt.Errorf("invalid limit: %v", opts.Limit)}
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return listRun(opts)
+		},
+	}
+
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", defaultLimit, "Maximum number of workflows to fetch")
+	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "Show all workflows, including disabled workflows")
+
+	return cmd
+}
+
+func listRun(opts *ListOptions) error {
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return fmt.Errorf("could not determine base repo: %w", err)
+	}
+
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not create http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(httpClient)
+
+	opts.IO.StartProgressIndicator()
+	workflows, err := getWorkflows(client, repo, opts.Limit)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return fmt.Errorf("could not get workflows: %w", err)
+	}
+
+	if len(workflows) == 0 {
+		if !opts.PlainOutput {
+			fmt.Fprintln(opts.IO.ErrOut, "No workflows found")
+		}
+		return nil
+	}
+
+	tp := utils.NewTablePrinter(opts.IO)
+	cs := opts.IO.ColorScheme()
+
+	for _, workflow := range workflows {
+		if workflow.Disabled() && !opts.All {
+			continue
+		}
+		tp.AddField(workflow.Name, nil, cs.Bold)
+		tp.AddField(string(workflow.State), nil, nil)
+		tp.AddField(fmt.Sprintf("%d", workflow.ID), nil, cs.Cyan)
+		tp.EndRow()
+	}
+
+	return tp.Render()
+}
+
+type WorkflowState string
+
+type Workflow struct {
+	Name  string
+	ID    int
+	State WorkflowState
+}
+
+func (w *Workflow) Disabled() bool {
+	return w.State != Active
+}
+
+type WorkflowsPayload struct {
+	Workflows []Workflow
+}
+
+func getWorkflows(client *api.Client, repo ghrepo.Interface, limit int) ([]Workflow, error) {
+	perPage := limit
+	page := 1
+	if limit > 100 {
+		perPage = 100
+	}
+
+	workflows := []Workflow{}
+
+	for len(workflows) < limit {
+		var result WorkflowsPayload
+
+		path := fmt.Sprintf("repos/%s/actions/workflows?per_page=%d&page=%d", ghrepo.FullName(repo), perPage, page)
+
+		err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(result.Workflows) == 0 {
+			break
+		}
+
+		for _, workflow := range result.Workflows {
+			workflows = append(workflows, workflow)
+			if len(workflows) == limit {
+				break
+			}
+		}
+
+		if len(result.Workflows) < perPage {
+			break
+		}
+
+		page++
+	}
+
+	return workflows, nil
+}

--- a/pkg/cmd/workflow/list/list_test.go
+++ b/pkg/cmd/workflow/list/list_test.go
@@ -1,0 +1,252 @@
+package list
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/httpmock"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewCmdList(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		tty      bool
+		wants    ListOptions
+		wantsErr bool
+	}{
+		{
+			name: "blank tty",
+			tty:  true,
+			wants: ListOptions{
+				Limit: defaultLimit,
+			},
+		},
+		{
+			name: "blank nontty",
+			wants: ListOptions{
+				Limit:       defaultLimit,
+				PlainOutput: true,
+			},
+		},
+		{
+			name: "all",
+			cli:  "--all",
+			wants: ListOptions{
+				Limit:       defaultLimit,
+				PlainOutput: true,
+				All:         true,
+			},
+		},
+		{
+			name: "limit",
+			cli:  "--limit 100",
+			wants: ListOptions{
+				Limit:       100,
+				PlainOutput: true,
+			},
+		},
+		{
+			name:     "bad limit",
+			cli:      "--limit hi",
+			wantsErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, _, _ := iostreams.Test()
+			io.SetStdinTTY(tt.tty)
+			io.SetStdoutTTY(tt.tty)
+
+			f := &cmdutil.Factory{
+				IOStreams: io,
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *ListOptions
+			cmd := NewCmdList(f, func(opts *ListOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(ioutil.Discard)
+			cmd.SetErr(ioutil.Discard)
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.Equal(t, tt.wants.Limit, gotOpts.Limit)
+			assert.Equal(t, tt.wants.PlainOutput, gotOpts.PlainOutput)
+		})
+	}
+}
+
+func TestListRun(t *testing.T) {
+	workflows := []Workflow{
+		{
+			Name:  "Go",
+			State: Active,
+			ID:    707,
+		},
+		{
+			Name:  "Linter",
+			State: Active,
+			ID:    666,
+		},
+		{
+			Name:  "Release",
+			State: DisabledManually,
+			ID:    451,
+		},
+	}
+	payload := WorkflowsPayload{Workflows: workflows}
+
+	tests := []struct {
+		name       string
+		opts       *ListOptions
+		wantOut    string
+		wantErrOut string
+		stubs      func(*httpmock.Registry)
+		tty        bool
+	}{
+		{
+			name: "blank tty",
+			tty:  true,
+			opts: &ListOptions{
+				Limit: defaultLimit,
+			},
+			wantOut: "Go      active  707\nLinter  active  666\n",
+		},
+		{
+			name: "blank nontty",
+			opts: &ListOptions{
+				Limit:       defaultLimit,
+				PlainOutput: true,
+			},
+			wantOut: "Go\tactive\t707\nLinter\tactive\t666\n",
+		},
+		{
+			name: "pagination",
+			opts: &ListOptions{
+				Limit: 101,
+			},
+			stubs: func(reg *httpmock.Registry) {
+				workflows := []Workflow{}
+				for flowID := 0; flowID < 103; flowID++ {
+					workflows = append(workflows, Workflow{
+						ID:    flowID,
+						Name:  fmt.Sprintf("flow %d", flowID),
+						State: Active,
+					})
+				}
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
+					httpmock.JSONResponse(WorkflowsPayload{
+						Workflows: workflows[0:100],
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
+					httpmock.JSONResponse(WorkflowsPayload{
+						Workflows: workflows[100:],
+					}))
+			},
+			wantOut: longOutput,
+		},
+		{
+			name: "no results nontty",
+			opts: &ListOptions{
+				Limit:       defaultLimit,
+				PlainOutput: true,
+			},
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
+					httpmock.JSONResponse(WorkflowsPayload{}),
+				)
+			},
+			wantOut: "",
+		},
+		{
+			name: "no results tty",
+			opts: &ListOptions{
+				Limit: defaultLimit,
+			},
+			tty: true,
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
+					httpmock.JSONResponse(WorkflowsPayload{}),
+				)
+			},
+			wantOut:    "",
+			wantErrOut: "No workflows found\n",
+		},
+		{
+			name: "show all workflows",
+			opts: &ListOptions{
+				Limit: defaultLimit,
+				All:   true,
+			},
+			tty:     true,
+			wantOut: "Go       active             707\nLinter   active             666\nRelease  disabled_manually  451\n",
+		},
+		{
+			name: "respects limit",
+			opts: &ListOptions{
+				Limit: 1,
+				All:   true,
+			},
+			tty:     true,
+			wantOut: "Go  active  707\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			if tt.stubs == nil {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
+					httpmock.JSONResponse(payload),
+				)
+			} else {
+				tt.stubs(reg)
+			}
+
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+
+			io, _, stdout, stderr := iostreams.Test()
+			io.SetStdoutTTY(tt.tty)
+			tt.opts.IO = io
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("OWNER/REPO")
+			}
+
+			err := listRun(tt.opts)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wantOut, stdout.String())
+			assert.Equal(t, tt.wantErrOut, stderr.String())
+			reg.Verify(t)
+		})
+	}
+}
+
+const longOutput = "flow 0\tactive\t0\nflow 1\tactive\t1\nflow 2\tactive\t2\nflow 3\tactive\t3\nflow 4\tactive\t4\nflow 5\tactive\t5\nflow 6\tactive\t6\nflow 7\tactive\t7\nflow 8\tactive\t8\nflow 9\tactive\t9\nflow 10\tactive\t10\nflow 11\tactive\t11\nflow 12\tactive\t12\nflow 13\tactive\t13\nflow 14\tactive\t14\nflow 15\tactive\t15\nflow 16\tactive\t16\nflow 17\tactive\t17\nflow 18\tactive\t18\nflow 19\tactive\t19\nflow 20\tactive\t20\nflow 21\tactive\t21\nflow 22\tactive\t22\nflow 23\tactive\t23\nflow 24\tactive\t24\nflow 25\tactive\t25\nflow 26\tactive\t26\nflow 27\tactive\t27\nflow 28\tactive\t28\nflow 29\tactive\t29\nflow 30\tactive\t30\nflow 31\tactive\t31\nflow 32\tactive\t32\nflow 33\tactive\t33\nflow 34\tactive\t34\nflow 35\tactive\t35\nflow 36\tactive\t36\nflow 37\tactive\t37\nflow 38\tactive\t38\nflow 39\tactive\t39\nflow 40\tactive\t40\nflow 41\tactive\t41\nflow 42\tactive\t42\nflow 43\tactive\t43\nflow 44\tactive\t44\nflow 45\tactive\t45\nflow 46\tactive\t46\nflow 47\tactive\t47\nflow 48\tactive\t48\nflow 49\tactive\t49\nflow 50\tactive\t50\nflow 51\tactive\t51\nflow 52\tactive\t52\nflow 53\tactive\t53\nflow 54\tactive\t54\nflow 55\tactive\t55\nflow 56\tactive\t56\nflow 57\tactive\t57\nflow 58\tactive\t58\nflow 59\tactive\t59\nflow 60\tactive\t60\nflow 61\tactive\t61\nflow 62\tactive\t62\nflow 63\tactive\t63\nflow 64\tactive\t64\nflow 65\tactive\t65\nflow 66\tactive\t66\nflow 67\tactive\t67\nflow 68\tactive\t68\nflow 69\tactive\t69\nflow 70\tactive\t70\nflow 71\tactive\t71\nflow 72\tactive\t72\nflow 73\tactive\t73\nflow 74\tactive\t74\nflow 75\tactive\t75\nflow 76\tactive\t76\nflow 77\tactive\t77\nflow 78\tactive\t78\nflow 79\tactive\t79\nflow 80\tactive\t80\nflow 81\tactive\t81\nflow 82\tactive\t82\nflow 83\tactive\t83\nflow 84\tactive\t84\nflow 85\tactive\t85\nflow 86\tactive\t86\nflow 87\tactive\t87\nflow 88\tactive\t88\nflow 89\tactive\t89\nflow 90\tactive\t90\nflow 91\tactive\t91\nflow 92\tactive\t92\nflow 93\tactive\t93\nflow 94\tactive\t94\nflow 95\tactive\t95\nflow 96\tactive\t96\nflow 97\tactive\t97\nflow 98\tactive\t98\nflow 99\tactive\t99\nflow 100\tactive\t100\n"

--- a/pkg/cmd/workflow/workflow.go
+++ b/pkg/cmd/workflow/workflow.go
@@ -1,0 +1,23 @@
+package workflow
+
+import (
+	cmdList "github.com/cli/cli/pkg/cmd/workflow/list"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdWorkflow(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "workflow <command>",
+		Short:  "View details about GitHub Actions workflows",
+		Hidden: true,
+		Long:   "List, view, and run workflows in GitHub Actions.",
+		// TODO i'd like to have all the actions commands sorted into their own zone which i think will
+		// require a new annotation
+	}
+	cmdutil.EnableRepoOverride(cmd, f)
+
+	cmd.AddCommand(cmdList.NewCmdList(f, nil))
+
+	return cmd
+}


### PR DESCRIPTION
Part of #2889

This PR adds `gh workflow list`, a simple command that lists workflows for a given repository along with their IDs and state (active vs. disabled).

It supports the normal `--limit` argument as well as `--all`, which shows even disabled workflows. By default only `active` workflows are listed.

Next up is `workflow view`.

![image](https://user-images.githubusercontent.com/98482/110978544-21450000-8329-11eb-8ac3-545e87932f2b.png)

