### PR TITLE
Allow retrying HTTP/2 uploads for release assets

### DIFF
--- a/pkg/cmd/release/shared/upload.go
+++ b/pkg/cmd/release/shared/upload.go
@@ -170,6 +170,7 @@ func uploadAsset(httpClient *http.Client, uploadURL string, asset AssetForUpload
 	}
 	req.ContentLength = asset.Size
 	req.Header.Set("Content-Type", asset.MIMEType)
+	req.GetBody = asset.Open
 
 	resp, err := httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
The `Request.GetBody` func allows the retry mechanism to reopen the file that's being uploaded as the request body in case the body of the previous request has already started to be read.

Fixes part of #3252

Ref. https://github.com/golang/net/blob/d523dce5a7f4b994f7ed0531dbe44cd8fd803e26/http2/transport.go#L554