### PR TITLE
Only use hosts user is authenticated against when resolving repo

### DIFF
--- a/pkg/cmd/factory/remote_resolver.go
+++ b/pkg/cmd/factory/remote_resolver.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/config"
-	"github.com/cli/cli/internal/ghinstance"
 )
 
 type remoteResolver struct {
@@ -49,7 +48,6 @@ func (rr *remoteResolver) Resolver(hostOverride string) func() (context.Remotes,
 		}
 
 		knownHosts := map[string]bool{}
-		knownHosts[ghinstance.Default()] = true
 		if authenticatedHosts, err := cfg.Hosts(); err == nil {
 			for _, h := range authenticatedHosts {
 				knownHosts[h] = true
@@ -92,6 +90,7 @@ func (rr *remoteResolver) Resolver(hostOverride string) func() (context.Remotes,
 			remotesError = errors.New("none of the git remotes configured for this repository point to a known GitHub host. To tell gh about a new GitHub host, please use `gh auth login`")
 			return nil, remotesError
 		}
+
 		return cachedRemotes, nil
 	}
 }

--- a/pkg/cmd/factory/remote_resolver_test.go
+++ b/pkg/cmd/factory/remote_resolver_test.go
@@ -8,64 +8,215 @@ import (
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/config"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_remoteResolver(t *testing.T) {
-	rr := &remoteResolver{
-		readRemotes: func() (git.RemoteSet, error) {
-			return git.RemoteSet{
-				git.NewRemote("fork", "https://example.org/ghe-owner/ghe-fork.git"),
-				git.NewRemote("origin", "https://github.com/owner/repo.git"),
-				git.NewRemote("upstream", "https://example.org/ghe-owner/ghe-repo.git"),
-			}, nil
+	tests := []struct {
+		name     string
+		remotes  func() (git.RemoteSet, error)
+		config   func() (config.Config, error)
+		override string
+		output   []string
+		wantsErr bool
+	}{
+		{
+			name: "no authenticated hosts",
+			remotes: func() (git.RemoteSet, error) {
+				return git.RemoteSet{
+					git.NewRemote("origin", "https://github.com/owner/repo.git"),
+				}, nil
+			},
+			config: func() (config.Config, error) {
+				return config.NewFromString(heredoc.Doc(``)), nil
+			},
+			wantsErr: true,
 		},
-		getConfig: func() (config.Config, error) {
-			return config.NewFromString(heredoc.Doc(`
-				hosts:
-				  example.org:
-				    oauth_token: GHETOKEN
-			`)), nil
+		{
+			name: "no git remotes",
+			remotes: func() (git.RemoteSet, error) {
+				return git.RemoteSet{}, nil
+			},
+			config: func() (config.Config, error) {
+				return config.NewFromString(heredoc.Doc(``)), nil
+			},
+			wantsErr: true,
 		},
-		urlTranslator: func(u *url.URL) *url.URL {
-			return u
+		{
+			name: "one authenticated host with no matching git remote",
+			remotes: func() (git.RemoteSet, error) {
+				return git.RemoteSet{
+					git.NewRemote("origin", "https://github.com/owner/repo.git"),
+				}, nil
+			},
+			config: func() (config.Config, error) {
+				return config.NewFromString(heredoc.Doc(`
+				  hosts:
+				    example.com:
+				      oauth_token: GHETOKEN
+				`)), nil
+			},
+			wantsErr: true,
+		},
+		{
+			name: "one authenticated host with matching git remote",
+			remotes: func() (git.RemoteSet, error) {
+				return git.RemoteSet{
+					git.NewRemote("upstream", "https://github.com/owner/repo.git"),
+					git.NewRemote("origin", "https://example.com/owner/repo.git"),
+				}, nil
+			},
+			config: func() (config.Config, error) {
+				return config.NewFromString(heredoc.Doc(`
+				  hosts:
+				    example.com:
+				      oauth_token: GHETOKEN
+				`)), nil
+			},
+			output: []string{"origin"},
+		},
+		{
+			name: "one authenticated host with multiple matching git remotes",
+			remotes: func() (git.RemoteSet, error) {
+				return git.RemoteSet{
+					git.NewRemote("upstream", "https://example.com/owner/repo.git"),
+					git.NewRemote("github", "https://example.com/owner/repo.git"),
+					git.NewRemote("origin", "https://example.com/owner/repo.git"),
+					git.NewRemote("fork", "https://example.com/owner/repo.git"),
+				}, nil
+			},
+			config: func() (config.Config, error) {
+				return config.NewFromString(heredoc.Doc(`
+				  hosts:
+				    example.com:
+				      oauth_token: GHETOKEN
+				`)), nil
+			},
+			output: []string{"upstream", "github", "origin", "fork"},
+		},
+		{
+			name: "multiple authenticated hosts with no matching git remote",
+			remotes: func() (git.RemoteSet, error) {
+				return git.RemoteSet{
+					git.NewRemote("origin", "https://test.com/owner/repo.git"),
+				}, nil
+			},
+			config: func() (config.Config, error) {
+				return config.NewFromString(heredoc.Doc(`
+				  hosts:
+				    example.com:
+				      oauth_token: GHETOKEN
+				    github.com:
+				      oauth_token: GHTOKEN
+				`)), nil
+			},
+			wantsErr: true,
+		},
+		{
+			name: "multiple authenticated hosts with one matching git remote",
+			remotes: func() (git.RemoteSet, error) {
+				return git.RemoteSet{
+					git.NewRemote("upstream", "https://test.com/owner/repo.git"),
+					git.NewRemote("origin", "https://example.com/owner/repo.git"),
+				}, nil
+			},
+			config: func() (config.Config, error) {
+				return config.NewFromString(heredoc.Doc(`
+				  hosts:
+				    example.com:
+				      oauth_token: GHETOKEN
+				    github.com:
+				      oauth_token: GHTOKEN
+				`)), nil
+			},
+			output: []string{"origin"},
+		},
+		{
+			name: "multiple authenticated hosts with multiple matching git remotes",
+			remotes: func() (git.RemoteSet, error) {
+				return git.RemoteSet{
+					git.NewRemote("upstream", "https://example.com/owner/repo.git"),
+					git.NewRemote("github", "https://github.com/owner/repo.git"),
+					git.NewRemote("origin", "https://example.com/owner/repo.git"),
+					git.NewRemote("fork", "https://github.com/owner/repo.git"),
+					git.NewRemote("test", "https://test.com/owner/repo.git"),
+				}, nil
+			},
+			config: func() (config.Config, error) {
+				return config.NewFromString(heredoc.Doc(`
+				  hosts:
+				    example.com:
+				      oauth_token: GHETOKEN
+				    github.com:
+				      oauth_token: GHTOKEN
+				`)), nil
+			},
+			output: []string{"upstream", "origin"},
+		},
+		{
+			name: "override hostname with no matching git remotes",
+			remotes: func() (git.RemoteSet, error) {
+				return git.RemoteSet{
+					git.NewRemote("origin", "https://example.com/owner/repo.git"),
+				}, nil
+			},
+			config: func() (config.Config, error) {
+				return config.NewFromString(heredoc.Doc(``)), nil
+			},
+			override: "test.com",
+			wantsErr: true,
+		},
+		{
+			name: "override hostname with one matching git remote",
+			remotes: func() (git.RemoteSet, error) {
+				return git.RemoteSet{
+					git.NewRemote("upstream", "https://github.com/owner/repo.git"),
+					git.NewRemote("origin", "https://example.com/owner/repo.git"),
+				}, nil
+			},
+			config: func() (config.Config, error) {
+				return config.NewFromString(heredoc.Doc(``)), nil
+			},
+			override: "example.com",
+			output:   []string{"origin"},
+		},
+		{
+			name: "override hostname with multiple matching git remotes",
+			remotes: func() (git.RemoteSet, error) {
+				return git.RemoteSet{
+					git.NewRemote("upstream", "https://example.com/owner/repo.git"),
+					git.NewRemote("github", "https://github.com/owner/repo.git"),
+					git.NewRemote("origin", "https://example.com/owner/repo.git"),
+				}, nil
+			},
+			config: func() (config.Config, error) {
+				return config.NewFromString(heredoc.Doc(``)), nil
+			},
+			override: "example.com",
+			output:   []string{"upstream", "origin"},
 		},
 	}
 
-	resolver := rr.Resolver("")
-	remotes, err := resolver()
-	require.NoError(t, err)
-	require.Equal(t, 2, len(remotes))
-
-	assert.Equal(t, "upstream", remotes[0].Name)
-	assert.Equal(t, "fork", remotes[1].Name)
-}
-
-func Test_remoteResolverOverride(t *testing.T) {
-	rr := &remoteResolver{
-		readRemotes: func() (git.RemoteSet, error) {
-			return git.RemoteSet{
-				git.NewRemote("fork", "https://example.org/ghe-owner/ghe-fork.git"),
-				git.NewRemote("origin", "https://github.com/owner/repo.git"),
-				git.NewRemote("upstream", "https://example.org/ghe-owner/ghe-repo.git"),
-			}, nil
-		},
-		getConfig: func() (config.Config, error) {
-			return config.NewFromString(heredoc.Doc(`
-				hosts:
-				  example.org:
-				    oauth_token: GHETOKEN
-			`)), nil
-		},
-		urlTranslator: func(u *url.URL) *url.URL {
-			return u
-		},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := &remoteResolver{
+				readRemotes: tt.remotes,
+				getConfig:   tt.config,
+				urlTranslator: func(u *url.URL) *url.URL {
+					return u
+				},
+			}
+			resolver := rr.Resolver(tt.override)
+			remotes, err := resolver()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			names := []string{}
+			for _, r := range remotes {
+				names = append(names, r.Name)
+			}
+			assert.Equal(t, tt.output, names)
+		})
 	}
-
-	resolver := rr.Resolver("github.com")
-	remotes, err := resolver()
-	require.NoError(t, err)
-	require.Equal(t, 1, len(remotes))
-
-	assert.Equal(t, "origin", remotes[0].Name)
 }


### PR DESCRIPTION
This PR removes the assumption that our users are authenticated against dotcom when resolving the target repo for a command effectively allowing for a "default" host when a user is authenticated against only a single host. This PR is actually a one line change but I felt that the tests were not comprehensive enough so I added a bunch to codify the new behavior. 

closes https://github.com/cli/cli/issues/1745