### PR TITLE
Disable preview option in prompts if URL size is too long

### DIFF
--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -166,14 +166,11 @@ func createRun(opts *CreateOptions) (err error) {
 				return
 			}
 			if !utils.ValidURL(openURL) {
-				err = fmt.Errorf("Failed to create URL: maximum URL length exceeded")
+				err = fmt.Errorf("cannot open in browser: maximum URL length exceeded")
 				return
 			}
 		} else if ok, _ := tpl.HasTemplates(); ok {
 			openURL = ghrepo.GenerateRepoURL(baseRepo, "issues/new/choose")
-			if err != nil {
-				return
-			}
 		}
 		if isTerminal {
 			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", utils.DisplayURL(openURL))
@@ -247,7 +244,6 @@ func createRun(opts *CreateOptions) (err error) {
 		}
 
 		allowPreview := !tb.HasMetadata() && utils.ValidURL(openURL)
-
 		action, err = prShared.ConfirmSubmission(allowPreview, repo.ViewerCanTriage())
 		if err != nil {
 			err = fmt.Errorf("unable to confirm: %w", err)
@@ -319,10 +315,5 @@ func createRun(opts *CreateOptions) (err error) {
 
 func generatePreviewURL(apiClient *api.Client, baseRepo ghrepo.Interface, tb shared.IssueMetadataState) (string, error) {
 	openURL := ghrepo.GenerateRepoURL(baseRepo, "issues/new")
-	openURL, err := prShared.WithPrAndIssueQueryParams(apiClient, baseRepo, openURL, tb)
-	if err != nil {
-		return "", err
-	}
-
-	return openURL, nil
+	return prShared.WithPrAndIssueQueryParams(apiClient, baseRepo, openURL, tb)
 }

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -538,7 +538,7 @@ func TestIssueCreate_webLongURL(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = runCommand(nil, true, fmt.Sprintf("-F '%s' --web", longBodyFile))
-	require.EqualError(t, err, "Failed to create URL: maximum URL length exceeded")
+	require.EqualError(t, err, "cannot open in browser: maximum URL length exceeded")
 }
 
 func TestIssueCreate_webTitleBody(t *testing.T) {

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -532,6 +532,15 @@ func TestIssueCreate_web(t *testing.T) {
 	assert.Equal(t, "https://github.com/OWNER/REPO/issues/new?assignees=MonaLisa", output.BrowsedURL)
 }
 
+func TestIssueCreate_webLongURL(t *testing.T) {
+	longBodyFile := filepath.Join(t.TempDir(), "long-body.txt")
+	err := ioutil.WriteFile(longBodyFile, make([]byte, 9216), 0600)
+	require.NoError(t, err)
+
+	_, err = runCommand(nil, true, fmt.Sprintf("-F '%s' --web", longBodyFile))
+	require.EqualError(t, err, "Failed to create URL: maximum URL length exceeded")
+}
+
 func TestIssueCreate_webTitleBody(t *testing.T) {
 	http := &httpmock.Registry{}
 	defer http.Verify(t)

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -190,6 +190,8 @@ func createRun(opts *CreateOptions) (err error) {
 		return
 	}
 
+	var openURL string
+
 	if opts.WebMode {
 		if !opts.Autofill {
 			state.Title = opts.Title
@@ -199,7 +201,15 @@ func createRun(opts *CreateOptions) (err error) {
 		if err != nil {
 			return
 		}
-		return previewPR(*opts, *ctx, *state)
+		openURL, err = generatePreviewURL(*ctx, *state)
+		if err != nil {
+			return
+		}
+		if !utils.ValidURL(openURL) {
+			err = fmt.Errorf("Failed to create URL: maximum URL length exceeded")
+			return
+		}
+		return previewPR(*opts, openURL)
 	}
 
 	if opts.TitleProvided {
@@ -291,8 +301,15 @@ func createRun(opts *CreateOptions) (err error) {
 		}
 	}
 
+	openURL, err = generatePreviewURL(*ctx, *state)
+	if err != nil {
+		return
+	}
+
 	allowMetadata := ctx.BaseRepo.ViewerCanTriage()
-	action, err := shared.ConfirmSubmission(!state.HasMetadata(), allowMetadata)
+	allowPreview := !state.HasMetadata() && utils.ValidURL(openURL)
+
+	action, err := shared.ConfirmSubmission(allowPreview, allowMetadata)
 	if err != nil {
 		return fmt.Errorf("unable to confirm: %w", err)
 	}
@@ -327,7 +344,7 @@ func createRun(opts *CreateOptions) (err error) {
 	}
 
 	if action == shared.PreviewAction {
-		return previewPR(*opts, *ctx, *state)
+		return previewPR(*opts, openURL)
 	}
 
 	if action == shared.SubmitAction {
@@ -639,20 +656,7 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 	return nil
 }
 
-func previewPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataState) error {
-	if len(state.Projects) > 0 {
-		var err error
-		state.Projects, err = api.ProjectNamesToPaths(ctx.Client, ctx.BaseRepo, state.Projects)
-		if err != nil {
-			return fmt.Errorf("could not add to project: %w", err)
-		}
-	}
-
-	openURL, err := generateCompareURL(ctx, state)
-	if err != nil {
-		return err
-	}
-
+func previewPR(opts CreateOptions, openURL string) error {
 	if opts.IO.IsStdinTTY() && opts.IO.IsStdoutTTY() {
 		fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", utils.DisplayURL(openURL))
 	}
@@ -750,7 +754,7 @@ func generateCompareURL(ctx CreateContext, state shared.IssueMetadataState) (str
 		ctx.BaseRepo,
 		"compare/%s...%s?expand=1",
 		url.QueryEscape(ctx.BaseBranch), url.QueryEscape(ctx.HeadBranchLabel))
-	url, err := shared.WithPrAndIssueQueryParams(u, state)
+	url, err := shared.WithPrAndIssueQueryParams(ctx.Client, ctx.BaseRepo, u, state)
 	if err != nil {
 		return "", err
 	}
@@ -758,3 +762,12 @@ func generateCompareURL(ctx CreateContext, state shared.IssueMetadataState) (str
 }
 
 var gitPushRegexp = regexp.MustCompile("^remote: (Create a pull request.*by visiting|[[:space:]]*https://.*/pull/new/).*\n?$")
+
+func generatePreviewURL(ctx CreateContext, state shared.IssueMetadataState) (string, error) {
+	openURL, err := generateCompareURL(ctx, state)
+	if err != nil {
+		return "", err
+	}
+
+	return openURL, nil
+}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -201,12 +201,12 @@ func createRun(opts *CreateOptions) (err error) {
 		if err != nil {
 			return
 		}
-		openURL, err = generatePreviewURL(*ctx, *state)
+		openURL, err = generateCompareURL(*ctx, *state)
 		if err != nil {
 			return
 		}
 		if !utils.ValidURL(openURL) {
-			err = fmt.Errorf("Failed to create URL: maximum URL length exceeded")
+			err = fmt.Errorf("cannot open in browser: maximum URL length exceeded")
 			return
 		}
 		return previewPR(*opts, openURL)
@@ -301,14 +301,13 @@ func createRun(opts *CreateOptions) (err error) {
 		}
 	}
 
-	openURL, err = generatePreviewURL(*ctx, *state)
+	openURL, err = generateCompareURL(*ctx, *state)
 	if err != nil {
 		return
 	}
 
-	allowMetadata := ctx.BaseRepo.ViewerCanTriage()
 	allowPreview := !state.HasMetadata() && utils.ValidURL(openURL)
-
+	allowMetadata := ctx.BaseRepo.ViewerCanTriage()
 	action, err := shared.ConfirmSubmission(allowPreview, allowMetadata)
 	if err != nil {
 		return fmt.Errorf("unable to confirm: %w", err)
@@ -762,12 +761,3 @@ func generateCompareURL(ctx CreateContext, state shared.IssueMetadataState) (str
 }
 
 var gitPushRegexp = regexp.MustCompile("^remote: (Create a pull request.*by visiting|[[:space:]]*https://.*/pull/new/).*\n?$")
-
-func generatePreviewURL(ctx CreateContext, state shared.IssueMetadataState) (string, error) {
-	openURL, err := generateCompareURL(ctx, state)
-	if err != nil {
-		return "", err
-	}
-
-	return openURL, nil
-}

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -852,7 +852,7 @@ func TestPRCreate_webLongURL(t *testing.T) {
 	cs.Register(`git( .+)? log( .+)? origin/master\.\.\.feature`, 0, "")
 
 	_, err = runCommand(http, nil, "feature", false, fmt.Sprintf("--body-file '%s' --web --head=feature", longBodyFile))
-	require.EqualError(t, err, "Failed to create URL: maximum URL length exceeded")
+	require.EqualError(t, err, "cannot open in browser: maximum URL length exceeded")
 }
 
 func TestPRCreate_webProject(t *testing.T) {

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -835,6 +835,26 @@ func TestPRCreate_web(t *testing.T) {
 	assert.Equal(t, "https://github.com/OWNER/REPO/compare/master...feature?expand=1", output.BrowsedURL)
 }
 
+func TestPRCreate_webLongURL(t *testing.T) {
+	longBodyFile := filepath.Join(t.TempDir(), "long-body.txt")
+	err := ioutil.WriteFile(longBodyFile, make([]byte, 9216), 0600)
+	require.NoError(t, err)
+
+	http := initFakeHTTP()
+	defer http.Verify(t)
+
+	http.StubRepoInfoResponse("OWNER", "REPO", "master")
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	cs.Register(`git status --porcelain`, 0, "")
+	cs.Register(`git( .+)? log( .+)? origin/master\.\.\.feature`, 0, "")
+
+	_, err = runCommand(http, nil, "feature", false, fmt.Sprintf("--body-file '%s' --web --head=feature", longBodyFile))
+	require.EqualError(t, err, "Failed to create URL: maximum URL length exceeded")
+}
+
 func TestPRCreate_webProject(t *testing.T) {
 	http := initFakeHTTP()
 	defer http.Verify(t)

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -29,12 +29,11 @@ func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, ba
 		q.Set("labels", strings.Join(state.Labels, ","))
 	}
 	if len(state.Projects) > 0 {
-		var err error
-		state.Projects, err = api.ProjectNamesToPaths(client, baseRepo, state.Projects)
+		projectPaths, err := api.ProjectNamesToPaths(client, baseRepo, state.Projects)
 		if err != nil {
 			return "", fmt.Errorf("could not add to project: %w", err)
 		}
-		q.Set("projects", strings.Join(state.Projects, ","))
+		q.Set("projects", strings.Join(projectPaths, ","))
 	}
 	if len(state.Milestones) > 0 {
 		q.Set("milestone", state.Milestones[0])

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cli/cli/pkg/githubsearch"
 )
 
-func WithPrAndIssueQueryParams(baseURL string, state IssueMetadataState) (string, error) {
+func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, baseURL string, state IssueMetadataState) (string, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return "", err
@@ -29,6 +29,11 @@ func WithPrAndIssueQueryParams(baseURL string, state IssueMetadataState) (string
 		q.Set("labels", strings.Join(state.Labels, ","))
 	}
 	if len(state.Projects) > 0 {
+		var err error
+		state.Projects, err = api.ProjectNamesToPaths(client, baseRepo, state.Projects)
+		if err != nil {
+			return "", fmt.Errorf("could not add to project: %w", err)
+		}
 		q.Set("projects", strings.Join(state.Projects, ","))
 	}
 	if len(state.Milestones) > 0 {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -78,3 +78,8 @@ func DisplayURL(urlStr string) string {
 	}
 	return u.Hostname() + u.Path
 }
+
+// Maximum length of a URL: 8192 bytes
+func ValidURL(urlStr string) bool {
+	return len(urlStr) < 8192
+}


### PR DESCRIPTION
Fixes #1575 

This PR adds an additional check to `pr/issue create` to disable `Continue in browser` option if the preview URL max size (8192 bytes) is exceeded.