### PR TITLE
Support multi-account configuration

### DIFF
--- a/internal/ghinstance/host.go
+++ b/internal/ghinstance/host.go
@@ -36,11 +36,19 @@ func IsEnterprise(h string) bool {
 
 // NormalizeHostname returns the canonical host name of a GitHub instance
 func NormalizeHostname(h string) string {
-	hostname := strings.ToLower(h)
+	hostname := ExtractHostname(strings.ToLower(h))
 	if strings.HasSuffix(hostname, "."+defaultHostname) {
 		return defaultHostname
 	}
 	return hostname
+}
+
+func ExtractHostname(hostname string) string {
+	extractedHostname := hostname
+	if idx := strings.IndexByte(hostname, '/'); idx >= 0 {
+		extractedHostname = hostname[:idx]
+	}
+	return extractedHostname
 }
 
 func HostnameValidator(v interface{}) error {
@@ -60,21 +68,21 @@ func HostnameValidator(v interface{}) error {
 
 func GraphQLEndpoint(hostname string) string {
 	if IsEnterprise(hostname) {
-		return fmt.Sprintf("https://%s/api/graphql", hostname)
+		return fmt.Sprintf("https://%s/api/graphql", ExtractHostname(hostname))
 	}
 	return "https://api.github.com/graphql"
 }
 
 func RESTPrefix(hostname string) string {
 	if IsEnterprise(hostname) {
-		return fmt.Sprintf("https://%s/api/v3/", hostname)
+		return fmt.Sprintf("https://%s/api/v3/", ExtractHostname(hostname))
 	}
 	return "https://api.github.com/"
 }
 
 func GistPrefix(hostname string) string {
 	if IsEnterprise(hostname) {
-		return fmt.Sprintf("https://%s/gist/", hostname)
+		return fmt.Sprintf("https://%s/gist/", ExtractHostname(hostname))
 	}
-	return fmt.Sprintf("https://gist.%s/", hostname)
+	return fmt.Sprintf("https://gist.%s/", ExtractHostname(hostname))
 }

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/internal/ghinstance"
 	"github.com/cli/cli/pkg/cmd/auth/shared"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
@@ -35,7 +36,7 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 		Args:  cobra.ExactArgs(0),
 		Short: "View authentication status",
 		Long: heredoc.Doc(`Verifies and displays information about your authentication state.
-			
+
 			This command will test your authentication state for each GitHub host that gh knows about and
 			report on any issues.
 		`),
@@ -97,7 +98,8 @@ func statusRun(opts *StatusOptions) error {
 			statusInfo[hostname] = append(statusInfo[hostname], fmt.Sprintf(x, ys...))
 		}
 
-		if err := shared.HasMinimumScopes(httpClient, hostname, token); err != nil {
+		extractedHostname := ghinstance.ExtractHostname(hostname)
+		if err := shared.HasMinimumScopes(httpClient, extractedHostname, token); err != nil {
 			var missingScopes *shared.MissingScopesError
 			if errors.As(err, &missingScopes) {
 				addMsg("%s %s: the token in %s is %s", cs.Red("X"), hostname, tokenSource, err)

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -58,8 +58,12 @@ func New(appVersion string) *cmdutil.Factory {
 			if err != nil {
 				return nil, err
 			}
+			token, err := cfg.Get(ghinstance.OverridableDefault(), "oauth_token")
+			if err != nil {
+				return nil, err
+			}
 
-			return NewHTTPClient(io, cfg, appVersion, true), nil
+			return NewHTTPClient(io, token, appVersion, true), nil
 		},
 		BaseRepo: func() (ghrepo.Interface, error) {
 			remotes, err := remotesFunc()

--- a/pkg/cmd/factory/http.go
+++ b/pkg/cmd/factory/http.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/cli/cli/api"
-	"github.com/cli/cli/internal/config"
 	"github.com/cli/cli/internal/ghinstance"
 	"github.com/cli/cli/pkg/iostreams"
 )
@@ -54,7 +53,7 @@ var timezoneNames = map[int]string{
 }
 
 // generic authenticated HTTP client for commands
-func NewHTTPClient(io *iostreams.IOStreams, cfg config.Config, appVersion string, setAccept bool) *http.Client {
+func NewHTTPClient(io *iostreams.IOStreams, token string, appVersion string, setAccept bool) *http.Client {
 	var opts []api.ClientOption
 	if verbose := os.Getenv("DEBUG"); verbose != "" {
 		logTraffic := strings.Contains(verbose, "api")
@@ -63,13 +62,7 @@ func NewHTTPClient(io *iostreams.IOStreams, cfg config.Config, appVersion string
 
 	opts = append(opts,
 		api.AddHeader("User-Agent", fmt.Sprintf("GitHub CLI %s", appVersion)),
-		api.AddHeaderFunc("Authorization", func(req *http.Request) (string, error) {
-			hostname := ghinstance.NormalizeHostname(req.URL.Hostname())
-			if token, err := cfg.Get(hostname, "oauth_token"); err == nil && token != "" {
-				return fmt.Sprintf("token %s", token), nil
-			}
-			return "", nil
-		}),
+		api.AddHeader("Authorization", fmt.Sprintf("token %s", token)),
 		api.AddHeaderFunc("Time-Zone", func(req *http.Request) (string, error) {
 			if req.Method != "GET" && req.Method != "HEAD" {
 				if time.Local.String() != "Local" {

--- a/pkg/cmd/factory/remote_resolver.go
+++ b/pkg/cmd/factory/remote_resolver.go
@@ -62,8 +62,9 @@ func (rr *remoteResolver) Resolver(hostOverride string) func() (context.Remotes,
 		sort.Sort(resolvedRemotes)
 
 		if hostOverride != "" {
+			extractedHost := ghinstance.ExtractHostname(hostOverride)
 			for _, r := range resolvedRemotes {
-				if strings.EqualFold(r.RepoHost(), hostOverride) {
+				if strings.EqualFold(r.RepoHost(), extractedHost) {
 					cachedRemotes = append(cachedRemotes, r)
 				}
 			}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
+	"github.com/cli/cli/internal/ghinstance"
 	"github.com/cli/cli/internal/ghrepo"
 	actionsCmd "github.com/cli/cli/pkg/cmd/actions"
 	aliasCmd "github.com/cli/cli/pkg/cmd/alias"
@@ -122,7 +123,12 @@ func bareHTTPClient(f *cmdutil.Factory, version string) func() (*http.Client, er
 		if err != nil {
 			return nil, err
 		}
-		return factory.NewHTTPClient(f.IOStreams, cfg, version, false), nil
+		token, err := cfg.Get(ghinstance.OverridableDefault(), "oauth_token")
+		if err != nil {
+			return nil, err
+		}
+
+		return factory.NewHTTPClient(f.IOStreams, token, version, false), nil
 	}
 }
 


### PR DESCRIPTION
Now hosts.yml supports user/organization part in a host section name that allows to tune credentials based on a github user or an organization instead of just a host name.

Example:

```yaml
github.com:
    user: personal-account
    oauth_token: personal-token
github.com/acme:
    user: work-account
    oauth_token: work-token
```

So when `gh` is running in the directory related to any repository of _acme_ organization, it will use _work-account_. In all other cases _personal-account_ will be used. A repository is treated as related to _acme_ organization if git config property `remote.origin.url` matches one of two forms:

* `git@github.com:acme/repo.git`
* `https://github.com/acme/repo.git`

Known bugs:

Since gh-cli uses global config, `gh auth status` use the same credentials for all github.com hosts.