### PR TITLE
Support multiple accounts

### DIFF
--- a/api/queries_user.go
+++ b/api/queries_user.go
@@ -2,9 +2,23 @@ package api
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 )
 
-func CurrentLoginName(client *Client, hostname string) (string, error) {
+func CurrentLoginNameFor(client *Client, hostname string, token string) (string, error) {
+	if token != "" {
+		originalTr := client.http.Transport
+		client.http = &http.Client{
+			Transport: &funcTripper{
+				roundTrip: func(req *http.Request) (*http.Response, error) {
+					req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
+					return originalTr.RoundTrip(req)
+				},
+			},
+		}
+	}
+
 	var query struct {
 		Viewer struct {
 			Login string
@@ -13,6 +27,10 @@ func CurrentLoginName(client *Client, hostname string) (string, error) {
 	gql := graphQLClient(client.http, hostname)
 	err := gql.QueryNamed(context.Background(), "UserCurrent", &query, nil)
 	return query.Viewer.Login, err
+}
+
+func CurrentLoginName(client *Client, hostname string) (string, error) {
+	return CurrentLoginNameFor(client, hostname, "")
 }
 
 func CurrentUserID(client *Client, hostname string) (string, error) {

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -61,6 +63,22 @@ func mainRun() exitCode {
 
 	if hostFromEnv := os.Getenv("GH_HOST"); hostFromEnv != "" {
 		ghinstance.OverrideDefault(hostFromEnv)
+	}
+
+	if ghinstance.OverridableDefault() == ghinstance.Default() {
+		if url, err := cmdOutput("git", "config", "remote.origin.url"); err == nil {
+			if domainUserOrg, err := extractDomainUserOrg(url); err == nil {
+				if c, err := config.ParseDefaultConfig(); err == nil {
+					if hosts, err := c.Hosts(); err == nil {
+						for _, host := range hosts {
+							if host == domainUserOrg {
+								ghinstance.OverrideDefault(host)
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 
 	cmdFactory := factory.New(buildVersion)
@@ -306,4 +324,29 @@ func isUnderHomebrew(ghBinary string) bool {
 
 	brewBinPrefix := filepath.Join(strings.TrimSpace(string(brewPrefixBytes)), "bin") + string(filepath.Separator)
 	return strings.HasPrefix(ghBinary, brewBinPrefix)
+}
+
+func cmdOutput(args ...string) (string, error) {
+	exe, err := safeexec.LookPath(args[0])
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command(exe, args[1:]...)
+	cmd.Stderr = ioutil.Discard
+	out, err := cmd.Output()
+	return strings.TrimSuffix(string(out), "\n"), err
+}
+
+func extractDomainUserOrg(url string) (string, error) {
+	var gitRe = regexp.MustCompile(`^(?:[^@]+@)?([^:]+):([^/]+)/.*$`)
+	if groups := gitRe.FindStringSubmatch(url); len(groups) > 0 {
+		return fmt.Sprintf("%s/%s", groups[1], groups[2]), nil
+	}
+
+	var httpsRe = regexp.MustCompile(`^https://([^/]+)/([^/]+)/.*$`)
+	if groups := httpsRe.FindStringSubmatch(url); len(groups) > 0 {
+		return fmt.Sprintf("%s/%s", groups[1], groups[2]), nil
+	}
+
+	return "", errors.New("remote.origin.url can't be matched")
 }

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -129,7 +129,7 @@ func authFlow(oauthHost string, IO *iostreams.IOStreams, notice string, addition
 
 func getViewer(hostname, token string) (string, error) {
 	http := api.NewClient(api.AddHeader("Authorization", fmt.Sprintf("token %s", token)))
-	return api.CurrentLoginName(http, hostname)
+	return api.CurrentLoginNameFor(http, hostname, token)
 }
 
 func waitForEnter(r io.Reader) error {

--- a/internal/ghinstance/host.go
+++ b/internal/ghinstance/host.go
@@ -36,11 +36,19 @@ func IsEnterprise(h string) bool {
 
 // NormalizeHostname returns the canonical host name of a GitHub instance
 func NormalizeHostname(h string) string {
-	hostname := strings.ToLower(h)
+	hostname := ExtractHostname(strings.ToLower(h))
 	if strings.HasSuffix(hostname, "."+defaultHostname) {
 		return defaultHostname
 	}
 	return hostname
+}
+
+func ExtractHostname(hostname string) string {
+	extractedHostname := hostname
+	if idx := strings.IndexByte(hostname, '/'); idx >= 0 {
+		extractedHostname = hostname[:idx]
+	}
+	return extractedHostname
 }
 
 func HostnameValidator(v interface{}) error {
@@ -60,21 +68,21 @@ func HostnameValidator(v interface{}) error {
 
 func GraphQLEndpoint(hostname string) string {
 	if IsEnterprise(hostname) {
-		return fmt.Sprintf("https://%s/api/graphql", hostname)
+		return fmt.Sprintf("https://%s/api/graphql", ExtractHostname(hostname))
 	}
 	return "https://api.github.com/graphql"
 }
 
 func RESTPrefix(hostname string) string {
 	if IsEnterprise(hostname) {
-		return fmt.Sprintf("https://%s/api/v3/", hostname)
+		return fmt.Sprintf("https://%s/api/v3/", ExtractHostname(hostname))
 	}
 	return "https://api.github.com/"
 }
 
 func GistPrefix(hostname string) string {
 	if IsEnterprise(hostname) {
-		return fmt.Sprintf("https://%s/gist/", hostname)
+		return fmt.Sprintf("https://%s/gist/", ExtractHostname(hostname))
 	}
-	return fmt.Sprintf("https://gist.%s/", hostname)
+	return fmt.Sprintf("https://gist.%s/", ExtractHostname(hostname))
 }

--- a/internal/ghinstance/host.go
+++ b/internal/ghinstance/host.go
@@ -60,7 +60,7 @@ func HostnameValidator(v interface{}) error {
 	if len(strings.TrimSpace(hostname)) < 1 {
 		return errors.New("a value is required")
 	}
-	if strings.ContainsRune(hostname, '/') || strings.ContainsRune(hostname, ':') {
+	if strings.ContainsRune(hostname, ':') {
 		return errors.New("invalid hostname")
 	}
 	return nil

--- a/internal/ghinstance/host_test.go
+++ b/internal/ghinstance/host_test.go
@@ -111,9 +111,9 @@ func TestHostnameValidator(t *testing.T) {
 			wantsErr: false,
 		},
 		{
-			name:     "hostname with slashes",
+			name:     "valid hostname with slashes",
 			input:    "//internal.instance",
-			wantsErr: true,
+			wantsErr: false,
 		},
 		{
 			name:     "empty hostname",

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -120,7 +120,11 @@ func logoutRun(opts *LogoutOptions) error {
 	}
 	apiClient := api.NewClientFromHTTP(httpClient)
 
-	username, err := api.CurrentLoginName(apiClient, hostname)
+	var username string
+	token, err := cfg.Get(hostname, "token")
+	if err == nil {
+		username, err = api.CurrentLoginNameFor(apiClient, hostname, token)
+	}
 	if err != nil {
 		// suppressing; the user is trying to delete this token and it might be bad.
 		// we'll see if the username is in the config and fall back to that.

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -151,7 +151,7 @@ func Login(opts *LoginOptions) error {
 	} else {
 		apiClient := api.NewClientFromHTTP(httpClient)
 		var err error
-		username, err = api.CurrentLoginName(apiClient, hostname)
+		username, err = api.CurrentLoginNameFor(apiClient, hostname, authToken)
 		if err != nil {
 			return fmt.Errorf("error using api: %w", err)
 		}

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/internal/ghinstance"
 	"github.com/cli/cli/pkg/cmd/auth/shared"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
@@ -35,7 +36,7 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 		Args:  cobra.ExactArgs(0),
 		Short: "View authentication status",
 		Long: heredoc.Doc(`Verifies and displays information about your authentication state.
-			
+
 			This command will test your authentication state for each GitHub host that gh knows about and
 			report on any issues.
 		`),
@@ -97,7 +98,8 @@ func statusRun(opts *StatusOptions) error {
 			statusInfo[hostname] = append(statusInfo[hostname], fmt.Sprintf(x, ys...))
 		}
 
-		if err := shared.HasMinimumScopes(httpClient, hostname, token); err != nil {
+		extractedHostname := ghinstance.ExtractHostname(hostname)
+		if err := shared.HasMinimumScopes(httpClient, extractedHostname, token); err != nil {
 			var missingScopes *shared.MissingScopesError
 			if errors.As(err, &missingScopes) {
 				addMsg("%s %s: the token in %s is %s", cs.Red("X"), hostname, tokenSource, err)

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -121,7 +121,7 @@ func statusRun(opts *StatusOptions) error {
 			failed = true
 		} else {
 			apiClient := api.NewClientFromHTTP(httpClient)
-			username, err := api.CurrentLoginName(apiClient, hostname)
+			username, err := api.CurrentLoginNameFor(apiClient, hostname, token)
 			if err != nil {
 				addMsg("%s %s: api call failed: %s", cs.Red("X"), hostname, err)
 			}

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -58,8 +58,12 @@ func New(appVersion string) *cmdutil.Factory {
 			if err != nil {
 				return nil, err
 			}
+			token, err := cfg.Get(ghinstance.OverridableDefault(), "oauth_token")
+			if err != nil {
+				return nil, err
+			}
 
-			return NewHTTPClient(io, cfg, appVersion, true), nil
+			return NewHTTPClient(io, token, appVersion, true), nil
 		},
 		BaseRepo: func() (ghrepo.Interface, error) {
 			remotes, err := remotesFunc()

--- a/pkg/cmd/factory/http.go
+++ b/pkg/cmd/factory/http.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/cli/cli/api"
-	"github.com/cli/cli/internal/config"
 	"github.com/cli/cli/internal/ghinstance"
 	"github.com/cli/cli/pkg/iostreams"
 )
@@ -54,7 +53,7 @@ var timezoneNames = map[int]string{
 }
 
 // generic authenticated HTTP client for commands
-func NewHTTPClient(io *iostreams.IOStreams, cfg config.Config, appVersion string, setAccept bool) *http.Client {
+func NewHTTPClient(io *iostreams.IOStreams, token string, appVersion string, setAccept bool) *http.Client {
 	var opts []api.ClientOption
 	if verbose := os.Getenv("DEBUG"); verbose != "" {
 		logTraffic := strings.Contains(verbose, "api")
@@ -63,13 +62,7 @@ func NewHTTPClient(io *iostreams.IOStreams, cfg config.Config, appVersion string
 
 	opts = append(opts,
 		api.AddHeader("User-Agent", fmt.Sprintf("GitHub CLI %s", appVersion)),
-		api.AddHeaderFunc("Authorization", func(req *http.Request) (string, error) {
-			hostname := ghinstance.NormalizeHostname(req.URL.Hostname())
-			if token, err := cfg.Get(hostname, "oauth_token"); err == nil && token != "" {
-				return fmt.Sprintf("token %s", token), nil
-			}
-			return "", nil
-		}),
+		api.AddHeader("Authorization", fmt.Sprintf("token %s", token)),
 		api.AddHeaderFunc("Time-Zone", func(req *http.Request) (string, error) {
 			if req.Method != "GET" && req.Method != "HEAD" {
 				if time.Local.String() != "Local" {

--- a/pkg/cmd/factory/remote_resolver.go
+++ b/pkg/cmd/factory/remote_resolver.go
@@ -62,8 +62,9 @@ func (rr *remoteResolver) Resolver(hostOverride string) func() (context.Remotes,
 		sort.Sort(resolvedRemotes)
 
 		if hostOverride != "" {
+			extractedHost := ghinstance.ExtractHostname(hostOverride)
 			for _, r := range resolvedRemotes {
-				if strings.EqualFold(r.RepoHost(), hostOverride) {
+				if strings.EqualFold(r.RepoHost(), extractedHost) {
 					cachedRemotes = append(cachedRemotes, r)
 				}
 			}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
+	"github.com/cli/cli/internal/ghinstance"
 	"github.com/cli/cli/internal/ghrepo"
 	actionsCmd "github.com/cli/cli/pkg/cmd/actions"
 	aliasCmd "github.com/cli/cli/pkg/cmd/alias"
@@ -122,7 +123,12 @@ func bareHTTPClient(f *cmdutil.Factory, version string) func() (*http.Client, er
 		if err != nil {
 			return nil, err
 		}
-		return factory.NewHTTPClient(f.IOStreams, cfg, version, false), nil
+		token, err := cfg.Get(ghinstance.OverridableDefault(), "oauth_token")
+		if err != nil {
+			return nil, err
+		}
+
+		return factory.NewHTTPClient(f.IOStreams, token, version, false), nil
 	}
 }
 


### PR DESCRIPTION
Now hosts.yml supports user/organization part in a host section name that allows to tune credentials based on a github user or an organization instead of just a host name.

Example:

```yaml
github.com:
    user: personal-account
    oauth_token: personal-token
github.com/acme:
    user: work-account
    oauth_token: work-token
```

So when `gh` is running in the directory related to any repository of _acme_ organization, it will use _work-account_. In all other cases _personal-account_ will be used. A repository is treated as related to _acme_ organization if git config property `remote.origin.url` matches one of two forms:

* `git@github.com:acme/repo.git`
* `https://github.com/acme/repo.git`

Refer #326 