### PR TITLE
gh workflow run

### DIFF
--- a/pkg/cmd/run/rerun/rerun_test.go
+++ b/pkg/cmd/run/rerun/rerun_test.go
@@ -98,7 +98,7 @@ func TestRerun(t *testing.T) {
 		opts      *RerunOptions
 		tty       bool
 		wantErr   bool
-		ErrOut    string
+		errOut    string
 		wantOut   string
 	}{
 		{
@@ -157,7 +157,7 @@ func TestRerun(t *testing.T) {
 						}}))
 			},
 			wantErr: true,
-			ErrOut:  "no recent runs have failed; please specify a specific run ID",
+			errOut:  "no recent runs have failed; please specify a specific run ID",
 		},
 		{
 			name: "unrerunnable",
@@ -174,7 +174,7 @@ func TestRerun(t *testing.T) {
 					httpmock.StatusStringResponse(403, "no"))
 			},
 			wantErr: true,
-			ErrOut:  "run 3 cannot be rerun; its workflow file may be broken.",
+			errOut:  "run 3 cannot be rerun; its workflow file may be broken.",
 		},
 	}
 
@@ -203,7 +203,7 @@ func TestRerun(t *testing.T) {
 			err := runRerun(tt.opts)
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.Equal(t, tt.ErrOut, err.Error())
+				assert.Equal(t, tt.errOut, err.Error())
 				return
 			}
 			assert.NoError(t, err)

--- a/pkg/cmd/workflow/disable/disable.go
+++ b/pkg/cmd/workflow/disable/disable.go
@@ -29,10 +29,9 @@ func NewCmdDisable(f *cmdutil.Factory, runF func(*DisableOptions) error) *cobra.
 	}
 
 	cmd := &cobra.Command{
-		Use:    "disable [<workflow ID> | <workflow name>]",
-		Short:  "Disable a workflow",
-		Args:   cobra.MaximumNArgs(1),
-		Hidden: true,
+		Use:   "disable [<workflow ID> | <workflow name>]",
+		Short: "Disable a workflow",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/workflow/enable/enable.go
+++ b/pkg/cmd/workflow/enable/enable.go
@@ -29,10 +29,9 @@ func NewCmdEnable(f *cmdutil.Factory, runF func(*EnableOptions) error) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Use:    "enable [<workflow ID> | <workflow name>]",
-		Short:  "Enable a workflow",
-		Args:   cobra.MaximumNArgs(1),
-		Hidden: true,
+		Use:   "enable [<workflow ID> | <workflow name>]",
+		Short: "Enable a workflow",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/workflow/list/list.go
+++ b/pkg/cmd/workflow/list/list.go
@@ -33,10 +33,9 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:    "list",
-		Short:  "List GitHub Actions workflows",
-		Args:   cobra.NoArgs,
-		Hidden: true,
+		Use:   "list",
+		Short: "List GitHub Actions workflows",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -341,7 +341,7 @@ func findInputs(yamlContent []byte) (map[string]WorkflowInput, error) {
 	}
 
 	if len(rootNode.Content) != 1 {
-		return nil, errors.New("invalid yaml file")
+		return nil, errors.New("invalid YAML file")
 	}
 
 	var onKeyNode *yaml.Node

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -1,0 +1,382 @@
+package run
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmd/workflow/shared"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/pkg/prompt"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
+)
+
+type RunOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	Selector string
+	Ref      string
+	JSON     string
+
+	InputArgs []string
+
+	Prompt bool
+}
+
+func NewCmdRun(f *cmdutil.Factory, runF func(*RunOptions) error) *cobra.Command {
+	opts := &RunOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "run [<workflow ID> | <workflow name>]",
+		Short: "Create a dispatch event for a workflow, starting a run",
+		Long: heredoc.Doc(`
+			Create a workflow_dispatch event for a given workflow.
+
+			This command will trigger GitHub Actions to run a given workflow file.  The given workflow file must
+			support a workflow_dispatch 'on' trigger in order to be run in this way.
+
+			If the workflow file supports inputs, they can be specified in a few ways:
+
+			- Interactively
+			- As command line arguments specified after --
+			- As JSON, via STDIN
+			- As JSON, via --json
+    `),
+		Example: heredoc.Doc(`
+			# Have gh prompt you for what workflow you'd like to run
+			$ gh workflow run
+
+			# Run the workflow file 'triage.yml' at the remote's default branch, interactively providing inputs
+			$ gh workflow run triage.yml
+
+			# Run the workflow file 'triage.yml' at a specified ref, interactively providing inputs
+			$ gh workflow run triage.yml --ref=myBranch
+
+			# Run the workflow file 'triage.yml' with command line inputs
+			$ gh workflow run triage.yml -- --name=scully --greeting=hello
+
+			# Run the workflow file 'triage.yml' with JSON via STDIN
+			$ echo '{"name":"scully", "greeting":"hello"}' | gh workflow run triage.yml
+
+			# Run the workflow file 'triage.yml' with JSON via --json
+			$ gh workflow run triage.yml --json='{"name":"scully", "greeting":"hello"}'
+		`),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if cmd.ArgsLenAtDash() == 0 && len(args[1:]) > 0 {
+				return cmdutil.FlagError{Err: fmt.Errorf("workflow argument required when passing input flags")}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			if len(args) > 0 {
+				opts.Selector = args[0]
+				opts.InputArgs = args[1:]
+			} else if !opts.IO.CanPrompt() {
+				return &cmdutil.FlagError{Err: errors.New("workflow ID, name, or filename required when not running interactively")}
+			} else {
+				opts.Prompt = true
+			}
+
+			if !opts.IO.IsStdinTTY() {
+				if opts.JSON != "" {
+					return errors.New("JSON can only be passed on one of STDIN or --json at a time")
+				}
+				jsonIn, err := ioutil.ReadAll(opts.IO.In)
+				if err != nil {
+					return errors.New("failed to read from STDIN")
+				}
+				opts.JSON = string(jsonIn)
+			}
+
+			if opts.Selector == "" {
+				if opts.JSON != "" {
+					return &cmdutil.FlagError{Err: errors.New("workflow argument required when passing JSON")}
+				}
+			} else {
+				if opts.JSON != "" && len(opts.InputArgs) > 0 {
+					return &cmdutil.FlagError{Err: errors.New("only one of JSON or input arguments can be passed at a time")}
+				}
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return runRun(opts)
+		},
+	}
+	cmd.Flags().StringVarP(&opts.Ref, "ref", "r", "", "The branch or tag name which contains the version of the workflow file you'd like to run")
+	cmd.Flags().StringVar(&opts.JSON, "json", "", "Provide workflow inputs as JSON")
+
+	return cmd
+}
+
+type InputAnswer struct {
+	providedInputs map[string]string
+}
+
+func (ia *InputAnswer) WriteAnswer(name string, value interface{}) error {
+	if s, ok := value.(string); ok {
+		ia.providedInputs[name] = s
+		return nil
+	}
+
+	// TODO i hate this; this is to make tests work:
+	if rv, ok := value.(reflect.Value); ok {
+		ia.providedInputs[name] = rv.String()
+		return nil
+	}
+
+	return fmt.Errorf("unexpected value type: %v", value)
+}
+
+func runRun(opts *RunOptions) error {
+	c, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not build http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(c)
+
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return fmt.Errorf("could not determine base repo: %w", err)
+	}
+
+	states := []shared.WorkflowState{shared.Active}
+	workflow, err := shared.ResolveWorkflow(
+		opts.IO, client, repo, opts.Prompt, opts.Selector, states)
+	if err != nil {
+		var fae shared.FilteredAllError
+		if errors.As(err, &fae) {
+			return errors.New("no workflows are enabled on this repository")
+		}
+		return err
+	}
+
+	ref := opts.Ref
+
+	if ref == "" {
+		ref, err = api.RepoDefaultBranch(client, repo)
+		if err != nil {
+			return fmt.Errorf("unable to determine default branch for %s: %w", ghrepo.FullName(repo), err)
+		}
+	}
+
+	yamlContent, err := getWorkflowContent(client, repo, workflow, ref)
+	if err != nil {
+		return fmt.Errorf("unable to fetch workflow file content: %w", err)
+	}
+
+	inputs, err := findInputs(yamlContent)
+	if err != nil {
+		return err
+	}
+
+	providedInputs := map[string]string{}
+
+	if opts.Prompt {
+		qs := []*survey.Question{}
+		for inputName, input := range inputs {
+			q := &survey.Question{
+				Name: inputName,
+				Prompt: &survey.Input{
+					Message: inputName,
+					Default: input.Default,
+				},
+			}
+			if input.Required {
+				q.Validate = survey.Required
+			}
+			qs = append(qs, q)
+		}
+
+		sort.Slice(qs, func(i, j int) bool {
+			return qs[i].Name < qs[j].Name
+		})
+
+		inputAnswer := InputAnswer{
+			providedInputs: providedInputs,
+		}
+		err = prompt.SurveyAsk(qs, &inputAnswer)
+		if err != nil {
+			return err
+		}
+	} else {
+		if opts.JSON != "" {
+			err := json.Unmarshal([]byte(opts.JSON), &providedInputs)
+			if err != nil {
+				return fmt.Errorf("could not parse provided JSON: %w", err)
+			}
+		}
+
+		if len(opts.InputArgs) > 0 {
+			fs := pflag.FlagSet{}
+			for inputName, input := range inputs {
+				fs.String(inputName, input.Default, input.Description)
+			}
+			err = fs.Parse(opts.InputArgs)
+			if err != nil {
+				return fmt.Errorf("could not parse input args: %w", err)
+			}
+			for inputName := range inputs {
+				providedValue, _ := fs.GetString(inputName)
+				providedInputs[inputName] = providedValue
+			}
+		}
+	}
+
+	for inputName, inputValue := range inputs {
+		if inputValue.Required && providedInputs[inputName] == "" {
+			return fmt.Errorf("missing required input '%s'", inputName)
+		}
+	}
+
+	path := fmt.Sprintf("repos/%s/actions/workflows/%d/dispatches",
+		ghrepo.FullName(repo), workflow.ID)
+
+	requestByte, err := json.Marshal(struct {
+		Ref    string            `json:"ref"`
+		Inputs map[string]string `json:"inputs"`
+	}{
+		Ref:    ref,
+		Inputs: providedInputs,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to serialize workflow inputs: %w", err)
+	}
+
+	body := bytes.NewReader(requestByte)
+
+	err = client.REST(repo.RepoHost(), "POST", path, body, nil)
+	if err != nil {
+		return fmt.Errorf("could not create workflow dispatch event: %w", err)
+	}
+
+	if opts.IO.CanPrompt() {
+		out := opts.IO.Out
+		cs := opts.IO.ColorScheme()
+		fmt.Fprintf(out, "%s Created workflow_dispatch event for %s at %s\n",
+			cs.SuccessIcon(), cs.Cyan(workflow.Base()), cs.Bold(ref))
+
+		fmt.Fprintln(out)
+
+		fmt.Fprintf(out, "To see runs for this workflow, try: %s\n",
+			cs.Boldf("gh run list --workflow=%s", workflow.Base()))
+	}
+
+	return nil
+}
+
+type WorkflowInput struct {
+	Required    bool
+	Default     string
+	Description string
+}
+
+func findInputs(yamlContent []byte) (map[string]WorkflowInput, error) {
+	var rootNode yaml.Node
+	err := yaml.Unmarshal(yamlContent, &rootNode)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse workflow YAML: %w", err)
+	}
+
+	if len(rootNode.Content) != 1 {
+		return nil, errors.New("invalid yaml file")
+	}
+
+	var onKeyNode *yaml.Node
+	var dispatchKeyNode *yaml.Node
+	var inputsKeyNode *yaml.Node
+	var inputsMapNode *yaml.Node
+
+	// TODO this is pretty hideous
+	for _, node := range rootNode.Content[0].Content {
+		if onKeyNode != nil {
+			for _, node := range node.Content {
+				if dispatchKeyNode != nil {
+					for _, node := range node.Content {
+						if inputsKeyNode != nil {
+							inputsMapNode = node
+							break
+						}
+						if node.Value == "inputs" {
+							inputsKeyNode = node
+						}
+					}
+					break
+				}
+				if node.Value == "workflow_dispatch" {
+					dispatchKeyNode = node
+				}
+			}
+			break
+		}
+		if strings.EqualFold(node.Value, "on") {
+			onKeyNode = node
+		}
+	}
+
+	if onKeyNode == nil {
+		return nil, errors.New("invalid workflow: no 'on' key")
+	}
+
+	if dispatchKeyNode == nil {
+		return nil, errors.New("unable to manually run a workflow without a workflow_dispatch event")
+	}
+
+	out := map[string]WorkflowInput{}
+
+	if inputsKeyNode == nil || inputsMapNode == nil {
+		return out, nil
+	}
+
+	err = inputsMapNode.Decode(&out)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode workflow inputs: %w", err)
+	}
+
+	return out, nil
+}
+
+func getWorkflowContent(client *api.Client, repo ghrepo.Interface, workflow *shared.Workflow, ref string) ([]byte, error) {
+	path := fmt.Sprintf("repos/%s/contents/%s?ref=%s", ghrepo.FullName(repo), workflow.Path, url.QueryEscape(ref))
+
+	type Result struct {
+		Content string
+	}
+
+	var result Result
+	err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(result.Content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode workflow file: %w", err)
+	}
+
+	return decoded, nil
+}

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -61,13 +61,13 @@ func NewCmdRun(f *cmdutil.Factory, runF func(*RunOptions) error) *cobra.Command 
 			- As JSON, via STDIN
     `),
 		Example: heredoc.Doc(`
-			# Have gh prompt you for what workflow you'd like to run
+			# Have gh prompt you for what workflow you'd like to run and interactively collect inputs
 			$ gh workflow run
 
-			# Run the workflow file 'triage.yml' at the remote's default branch, interactively providing inputs
+			# Run the workflow file 'triage.yml' at the remote's default branch
 			$ gh workflow run triage.yml
 
-			# Run the workflow file 'triage.yml' at a specified ref, interactively providing inputs
+			# Run the workflow file 'triage.yml' at a specified ref
 			$ gh workflow run triage.yml --ref my-branch
 
 			# Run the workflow file 'triage.yml' with command line inputs
@@ -76,7 +76,6 @@ func NewCmdRun(f *cmdutil.Factory, runF func(*RunOptions) error) *cobra.Command 
 			# Run the workflow file 'triage.yml' with JSON via standard input
 			$ echo '{"name":"scully", "greeting":"hello"}' | gh workflow run triage.yml --json
 		`),
-		// TODO if selector is supplied we don't go interactive. is that what we actually want? correct docs if it is
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(opts.MagicFields)+len(opts.RawFields) > 0 && len(args) == 0 {
 				return cmdutil.FlagError{Err: fmt.Errorf("workflow argument required when passing -f or -F")}

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -46,7 +46,7 @@ func NewCmdRun(f *cmdutil.Factory, runF func(*RunOptions) error) *cobra.Command 
 	}
 
 	cmd := &cobra.Command{
-		Use:   "run [<workflow ID> | <workflow name>]",
+		Use:   "run [<workflow-ID> | <workflow-name>]",
 		Short: "Create a dispatch event for a workflow, starting a run",
 		Long: heredoc.Doc(`
 			Create a workflow_dispatch event for a given workflow.

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -2,13 +2,11 @@ package run
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"reflect"
 	"sort"
 	"strings"
@@ -285,7 +283,7 @@ func runRun(opts *RunOptions) error {
 	}
 
 	if opts.Prompt {
-		yamlContent, err := getWorkflowContent(client, repo, workflow, ref)
+		yamlContent, err := shared.GetWorkflowContent(client, repo, *workflow, ref)
 		if err != nil {
 			return fmt.Errorf("unable to fetch workflow file content: %w", err)
 		}
@@ -407,25 +405,4 @@ func findInputs(yamlContent []byte) (map[string]WorkflowInput, error) {
 	}
 
 	return out, nil
-}
-
-func getWorkflowContent(client *api.Client, repo ghrepo.Interface, workflow *shared.Workflow, ref string) ([]byte, error) {
-	path := fmt.Sprintf("repos/%s/contents/%s?ref=%s", ghrepo.FullName(repo), workflow.Path, url.QueryEscape(ref))
-
-	type Result struct {
-		Content string
-	}
-
-	var result Result
-	err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	decoded, err := base64.StdEncoding.DecodeString(result.Content)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode workflow file: %w", err)
-	}
-
-	return decoded, nil
 }

--- a/pkg/cmd/workflow/run/run_test.go
+++ b/pkg/cmd/workflow/run/run_test.go
@@ -1,0 +1,492 @@
+package run
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/api"
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/cli/cli/pkg/cmd/workflow/shared"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/httpmock"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/pkg/prompt"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdRun(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		tty      bool
+		wants    RunOptions
+		wantsErr bool
+		errMsg   string
+		stdin    string
+	}{
+		{
+			name:     "blank nontty",
+			wantsErr: true,
+			errMsg:   "workflow ID, name, or filename required when not running interactively",
+		},
+		{
+			name: "blank tty",
+			tty:  true,
+			wants: RunOptions{
+				Prompt: true,
+			},
+		},
+		{
+			name: "ref flag",
+			tty:  true,
+			cli:  "--ref 12345abc",
+			wants: RunOptions{
+				Prompt: true,
+				Ref:    "12345abc",
+			},
+		},
+		{
+			name: "extra args",
+			tty:  true,
+			cli:  `workflow.yml -- --cool=nah --foo bar`,
+			wants: RunOptions{
+				InputArgs: []string{"--cool=nah", "--foo", "bar"},
+				Selector:  "workflow.yml",
+			},
+		},
+		{
+			name:     "both json on STDIN and json arg",
+			cli:      `workflow.yml --json '{"cool":"yeah"}'`,
+			stdin:    `{"cool":"yeah"}`,
+			wantsErr: true,
+			errMsg:   "JSON can only be passed on one of STDIN or --json at a time",
+		},
+		{
+			name:     "both json on STDIN and extra args",
+			cli:      `workflow.yml -- --cool=nah`,
+			stdin:    `{"cool":"yeah"}`,
+			errMsg:   "only one of JSON or input arguments can be passed at a time",
+			wantsErr: true,
+		},
+		{
+			name:     "both json arg and extra args",
+			tty:      true,
+			cli:      `workflow.yml --json '{"cool":"yeah"}' -- --cool=nah`,
+			errMsg:   "only one of JSON or input arguments can be passed at a time",
+			wantsErr: true,
+		},
+		{
+			name: "json via argument",
+			cli:  `workflow.yml --json '{"cool":"yeah"}'`,
+			tty:  true,
+			wants: RunOptions{
+				JSON:     `{"cool":"yeah"}`,
+				Selector: "workflow.yml",
+			},
+		},
+		{
+			name:  "json on STDIN",
+			cli:   "workflow.yml",
+			stdin: `{"cool":"yeah"}`,
+			wants: RunOptions{
+				JSON:     `{"cool":"yeah"}`,
+				Selector: "workflow.yml",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, stdin, _, _ := iostreams.Test()
+			if tt.stdin == "" {
+				io.SetStdinTTY(tt.tty)
+			} else {
+				stdin.WriteString(tt.stdin)
+			}
+			io.SetStdoutTTY(tt.tty)
+
+			f := &cmdutil.Factory{
+				IOStreams: io,
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *RunOptions
+			cmd := NewCmdRun(f, func(opts *RunOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(ioutil.Discard)
+			cmd.SetErr(ioutil.Discard)
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Equal(t, tt.errMsg, err.Error())
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.Selector, gotOpts.Selector)
+			assert.Equal(t, tt.wants.Prompt, gotOpts.Prompt)
+			assert.Equal(t, tt.wants.JSON, gotOpts.JSON)
+			assert.Equal(t, tt.wants.Ref, gotOpts.Ref)
+			assert.ElementsMatch(t, tt.wants.InputArgs, gotOpts.InputArgs)
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	yamlContent := []byte(`
+name: a workflow
+on:
+  workflow_dispatch:
+    inputs:
+      greeting:
+        default: hi
+        description: a greeting
+      name:
+        required: true
+        description: a name
+jobs:
+  greet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: perform the greet
+        run: |
+          echo "${{ github.event.inputs.greeting}}, ${{ github.events.inputs.name }}!"`)
+
+	encodedYamlContent := base64.StdEncoding.EncodeToString(yamlContent)
+
+	stubs := func(reg *httpmock.Registry) {
+		reg.Register(
+			httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/workflow.yml"),
+			httpmock.JSONResponse(shared.Workflow{
+				Path: ".github/workflows/workflow.yml",
+				ID:   12345,
+			}))
+		reg.Register(
+			httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/workflows/workflow.yml"),
+			httpmock.JSONResponse(struct{ Content string }{
+				Content: encodedYamlContent,
+			}))
+		reg.Register(
+			httpmock.REST("POST", "repos/OWNER/REPO/actions/workflows/12345/dispatches"),
+			httpmock.StatusStringResponse(204, "cool"))
+	}
+
+	tests := []struct {
+		name      string
+		opts      *RunOptions
+		tty       bool
+		wantErr   bool
+		errOut    string
+		wantOut   string
+		wantBody  map[string]interface{}
+		httpStubs func(*httpmock.Registry)
+		askStubs  func(*prompt.AskStubber)
+	}{
+		{
+			name: "bad JSON",
+			opts: &RunOptions{
+				Selector: "workflow.yml",
+				JSON:     `{"bad":"corrupt"`,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/workflow.yml"),
+					httpmock.JSONResponse(shared.Workflow{
+						Path: ".github/workflows/workflow.yml",
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/workflows/workflow.yml"),
+					httpmock.JSONResponse(struct{ Content string }{
+						Content: encodedYamlContent,
+					}))
+			},
+			wantErr: true,
+			errOut:  "could not parse provided JSON: unexpected end of JSON input",
+		},
+		{
+			name: "good JSON",
+			tty:  true,
+			opts: &RunOptions{
+				Selector: "workflow.yml",
+				JSON:     `{"name":"scully"}`,
+			},
+			wantBody: map[string]interface{}{
+				"inputs": map[string]interface{}{
+					"name": "scully",
+				},
+				"ref": "trunk",
+			},
+			httpStubs: stubs,
+			wantOut:   "✓ Created workflow_dispatch event for workflow.yml at trunk\n\nTo see runs for this workflow, try: gh run list --workflow=workflow.yml\n",
+		},
+		{
+			name: "nontty good JSON",
+			opts: &RunOptions{
+				Selector: "workflow.yml",
+				JSON:     `{"name":"scully"}`,
+			},
+			wantBody: map[string]interface{}{
+				"inputs": map[string]interface{}{
+					"name": "scully",
+				},
+				"ref": "trunk",
+			},
+			httpStubs: stubs,
+		},
+		{
+			name: "respects ref",
+			tty:  true,
+			opts: &RunOptions{
+				Selector: "workflow.yml",
+				JSON:     `{"name":"scully"}`,
+				Ref:      "good-branch",
+			},
+			wantBody: map[string]interface{}{
+				"inputs": map[string]interface{}{
+					"name": "scully",
+				},
+				"ref": "good-branch",
+			},
+			httpStubs: stubs,
+			wantOut:   "✓ Created workflow_dispatch event for workflow.yml at good-branch\n\nTo see runs for this workflow, try: gh run list --workflow=workflow.yml\n",
+		},
+		{
+			name: "good JSON, missing required input",
+			tty:  true,
+			opts: &RunOptions{
+				Selector: "workflow.yml",
+				JSON:     `{"greeting":"hello there"}`,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/workflow.yml"),
+					httpmock.JSONResponse(shared.Workflow{
+						Path: ".github/workflows/workflow.yml",
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/workflows/workflow.yml"),
+					httpmock.JSONResponse(struct{ Content string }{
+						Content: encodedYamlContent,
+					}))
+			},
+			wantErr: true,
+			errOut:  "missing required input 'name'",
+		},
+		{
+			name:      "input arguments",
+			httpStubs: stubs,
+			tty:       true,
+			opts: &RunOptions{
+				Selector:  "workflow.yml",
+				InputArgs: []string{"--name", "scully"},
+			},
+			wantBody: map[string]interface{}{
+				"inputs": map[string]interface{}{
+					"name":     "scully",
+					"greeting": "hi",
+				},
+				"ref": "trunk",
+			},
+			wantOut: "✓ Created workflow_dispatch event for workflow.yml at trunk\n\nTo see runs for this workflow, try: gh run list --workflow=workflow.yml\n",
+		},
+		{
+			name: "good JSON, missing required input",
+			tty:  true,
+			opts: &RunOptions{
+				Selector:  "workflow.yml",
+				InputArgs: []string{"--greeting=hey"},
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/workflow.yml"),
+					httpmock.JSONResponse(shared.Workflow{
+						Path: ".github/workflows/workflow.yml",
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/workflows/workflow.yml"),
+					httpmock.JSONResponse(struct{ Content string }{
+						Content: encodedYamlContent,
+					}))
+			},
+			wantErr: true,
+			errOut:  "missing required input 'name'",
+		},
+		{
+			name: "good JSON, missing required input",
+			tty:  true,
+			opts: &RunOptions{
+				Selector:  "workflow.yml",
+				InputArgs: []string{"--name=scully", "--bad=corrupt"},
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/workflow.yml"),
+					httpmock.JSONResponse(shared.Workflow{
+						Path: ".github/workflows/workflow.yml",
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/workflows/workflow.yml"),
+					httpmock.JSONResponse(struct{ Content string }{
+						Content: encodedYamlContent,
+					}))
+			},
+			wantErr: true,
+			errOut:  "could not parse input args: unknown flag: --bad",
+		},
+		{
+			name: "prompt, no workflows enabled",
+			tty:  true,
+			opts: &RunOptions{
+				Prompt: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
+					httpmock.JSONResponse(shared.WorkflowsPayload{
+						Workflows: []shared.Workflow{
+							{
+								Name:  "disabled",
+								State: shared.DisabledManually,
+								ID:    102,
+							},
+						},
+					}))
+			},
+			wantErr: true,
+			errOut:  "no workflows are enabled on this repository",
+		},
+		{
+			name: "prompt, no workflows",
+			tty:  true,
+			opts: &RunOptions{
+				Prompt: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
+					httpmock.JSONResponse(shared.WorkflowsPayload{
+						Workflows: []shared.Workflow{},
+					}))
+			},
+			wantErr: true,
+			errOut:  "could not fetch workflows for OWNER/REPO: no workflows are enabled",
+		},
+		{
+			name: "prompt",
+			tty:  true,
+			opts: &RunOptions{
+				Prompt: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
+					httpmock.JSONResponse(shared.WorkflowsPayload{
+						Workflows: []shared.Workflow{
+							{
+								Name:  "a workflow",
+								ID:    12345,
+								State: shared.Active,
+								Path:  ".github/workflows/workflow.yml",
+							},
+						},
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/contents/.github/workflows/workflow.yml"),
+					httpmock.JSONResponse(struct{ Content string }{
+						Content: encodedYamlContent,
+					}))
+				reg.Register(
+					httpmock.REST("POST", "repos/OWNER/REPO/actions/workflows/12345/dispatches"),
+					httpmock.StatusStringResponse(204, "cool"))
+			},
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne(0)
+				as.Stub([]*prompt.QuestionStub{
+					{
+						Name:    "greeting",
+						Default: true,
+					},
+					{
+						Name:  "name",
+						Value: "scully",
+					},
+				})
+			},
+			wantBody: map[string]interface{}{
+				"inputs": map[string]interface{}{
+					"name":     "scully",
+					"greeting": "hi",
+				},
+				"ref": "trunk",
+			},
+			wantOut: "✓ Created workflow_dispatch event for workflow.yml at trunk\n\nTo see runs for this workflow, try: gh run list --workflow=workflow.yml\n",
+		},
+	}
+
+	for _, tt := range tests {
+		reg := &httpmock.Registry{}
+		if tt.httpStubs != nil {
+			tt.httpStubs(reg)
+		}
+		tt.opts.HttpClient = func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		}
+
+		io, _, stdout, _ := iostreams.Test()
+		io.SetStdinTTY(tt.tty)
+		io.SetStdoutTTY(tt.tty)
+		tt.opts.IO = io
+		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+			return api.InitRepoHostname(&api.Repository{
+				Name:             "REPO",
+				Owner:            api.RepositoryOwner{Login: "OWNER"},
+				DefaultBranchRef: api.BranchRef{Name: "trunk"},
+			}, "github.com"), nil
+		}
+
+		as, teardown := prompt.InitAskStubber()
+		defer teardown()
+		if tt.askStubs != nil {
+			tt.askStubs(as)
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			err := runRun(tt.opts)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, tt.errOut, err.Error())
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantOut, stdout.String())
+			reg.Verify(t)
+
+			if len(reg.Requests) > 0 {
+				lastRequest := reg.Requests[len(reg.Requests)-1]
+				if lastRequest.Method == "POST" {
+					bodyBytes, _ := ioutil.ReadAll(lastRequest.Body)
+					reqBody := make(map[string]interface{})
+					err := json.Unmarshal(bodyBytes, &reqBody)
+					if err != nil {
+						t.Fatalf("error decoding JSON: %v", err)
+					}
+					assert.Equal(t, tt.wantBody, reqBody)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cmd/workflow/run/run_test.go
+++ b/pkg/cmd/workflow/run/run_test.go
@@ -55,7 +55,7 @@ func TestNewCmdRun(t *testing.T) {
 		{
 			name:     "both STDIN and input fields",
 			stdin:    "some json",
-			cli:      "workflow.yml -fhey=there",
+			cli:      "workflow.yml -fhey=there --json",
 			errMsg:   "only one of STDIN or -f/-F can be passed",
 			wantsErr: true,
 		},
@@ -89,11 +89,12 @@ func TestNewCmdRun(t *testing.T) {
 		},
 		{
 			name:  "json on STDIN",
-			cli:   "workflow.yml",
+			cli:   "workflow.yml --json",
 			stdin: `{"cool":"yeah"}`,
 			wants: RunOptions{
-				JSON:     `{"cool":"yeah"}`,
-				Selector: "workflow.yml",
+				JSON:      true,
+				JSONInput: `{"cool":"yeah"}`,
+				Selector:  "workflow.yml",
 			},
 		},
 	}
@@ -138,6 +139,7 @@ func TestNewCmdRun(t *testing.T) {
 
 			assert.Equal(t, tt.wants.Selector, gotOpts.Selector)
 			assert.Equal(t, tt.wants.Prompt, gotOpts.Prompt)
+			assert.Equal(t, tt.wants.JSONInput, gotOpts.JSONInput)
 			assert.Equal(t, tt.wants.JSON, gotOpts.JSON)
 			assert.Equal(t, tt.wants.Ref, gotOpts.Ref)
 			assert.ElementsMatch(t, tt.wants.RawFields, gotOpts.RawFields)
@@ -267,8 +269,8 @@ jobs:
 		{
 			name: "bad JSON",
 			opts: &RunOptions{
-				Selector: "workflow.yml",
-				JSON:     `{"bad":"corrupt"`,
+				Selector:  "workflow.yml",
+				JSONInput: `{"bad":"corrupt"`,
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
@@ -284,8 +286,8 @@ jobs:
 			name: "good JSON",
 			tty:  true,
 			opts: &RunOptions{
-				Selector: "workflow.yml",
-				JSON:     `{"name":"scully"}`,
+				Selector:  "workflow.yml",
+				JSONInput: `{"name":"scully"}`,
 			},
 			wantBody: map[string]interface{}{
 				"inputs": map[string]interface{}{
@@ -299,8 +301,8 @@ jobs:
 		{
 			name: "nontty good JSON",
 			opts: &RunOptions{
-				Selector: "workflow.yml",
-				JSON:     `{"name":"scully"}`,
+				Selector:  "workflow.yml",
+				JSONInput: `{"name":"scully"}`,
 			},
 			wantBody: map[string]interface{}{
 				"inputs": map[string]interface{}{
@@ -330,9 +332,9 @@ jobs:
 			name: "respects ref",
 			tty:  true,
 			opts: &RunOptions{
-				Selector: "workflow.yml",
-				JSON:     `{"name":"scully"}`,
-				Ref:      "good-branch",
+				Selector:  "workflow.yml",
+				JSONInput: `{"name":"scully"}`,
+				Ref:       "good-branch",
 			},
 			wantBody: map[string]interface{}{
 				"inputs": map[string]interface{}{
@@ -348,8 +350,8 @@ jobs:
 			name: "good JSON, missing required input",
 			tty:  true,
 			opts: &RunOptions{
-				Selector: "workflow.yml",
-				JSON:     `{"greeting":"hello there"}`,
+				Selector:  "workflow.yml",
+				JSONInput: `{"greeting":"hello there"}`,
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(

--- a/pkg/cmd/workflow/view/http.go
+++ b/pkg/cmd/workflow/view/http.go
@@ -1,9 +1,7 @@
 package view
 
 import (
-	"encoding/base64"
 	"fmt"
-	"net/url"
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/ghrepo"
@@ -14,31 +12,6 @@ import (
 type workflowRuns struct {
 	Total int
 	Runs  []runShared.Run
-}
-
-func getWorkflowContent(client *api.Client, repo ghrepo.Interface, ref string, workflow *shared.Workflow) (string, error) {
-	path := fmt.Sprintf("repos/%s/contents/%s", ghrepo.FullName(repo), workflow.Path)
-	if ref != "" {
-		q := fmt.Sprintf("?ref=%s", url.QueryEscape(ref))
-		path = path + q
-	}
-
-	type Result struct {
-		Content string
-	}
-
-	var result Result
-	err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
-	if err != nil {
-		return "", err
-	}
-
-	decoded, err := base64.StdEncoding.DecodeString(result.Content)
-	if err != nil {
-		return "", fmt.Errorf("failed to decode workflow file: %w", err)
-	}
-
-	return string(decoded), nil
 }
 
 func getWorkflowRuns(client *api.Client, repo ghrepo.Interface, workflow *shared.Workflow) (workflowRuns, error) {

--- a/pkg/cmd/workflow/view/view.go
+++ b/pkg/cmd/workflow/view/view.go
@@ -143,7 +143,7 @@ func viewWorkflowContent(opts *ViewOptions, client *api.Client, workflow *shared
 	}
 
 	opts.IO.StartProgressIndicator()
-	yaml, err := getWorkflowContent(client, repo, opts.Ref, workflow)
+	yamlBytes, err := shared.GetWorkflowContent(client, repo, *workflow, opts.Ref)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		if s, ok := err.(api.HTTPError); ok && s.StatusCode == 404 {
@@ -154,6 +154,8 @@ func viewWorkflowContent(opts *ViewOptions, client *api.Client, workflow *shared
 		}
 		return fmt.Errorf("could not get workflow file content: %w", err)
 	}
+
+	yaml := string(yamlBytes)
 
 	theme := opts.IO.DetectTerminalTheme()
 	markdownStyle := markdown.GetStyle(theme)

--- a/pkg/cmd/workflow/workflow.go
+++ b/pkg/cmd/workflow/workflow.go
@@ -4,6 +4,7 @@ import (
 	cmdDisable "github.com/cli/cli/pkg/cmd/workflow/disable"
 	cmdEnable "github.com/cli/cli/pkg/cmd/workflow/enable"
 	cmdList "github.com/cli/cli/pkg/cmd/workflow/list"
+	cmdRun "github.com/cli/cli/pkg/cmd/workflow/run"
 	cmdView "github.com/cli/cli/pkg/cmd/workflow/view"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -25,6 +26,7 @@ func NewCmdWorkflow(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(cmdEnable.NewCmdEnable(f, nil))
 	cmd.AddCommand(cmdDisable.NewCmdDisable(f, nil))
 	cmd.AddCommand(cmdView.NewCmdView(f, nil))
+	cmd.AddCommand(cmdRun.NewCmdRun(f, nil))
 
 	return cmd
 }


### PR DESCRIPTION
This PR implements `gh workflow run`, a command for creating `workflow_dispatch` events for workflows that support them.

It accepts workflow input in one of four ways:

- JSON via STDIN
- `-f` and `-F` flags that mimic `gh api` raw/magic fields
- dynamic input prompts (video demo: https://youtu.be/oTAoNvbT9Tk )

If no arguments are provided, the user can interactively select an enabled workflow and 
then interactively provide inputs.

If any arguments are present, no interactivity is assumed.

The workflow file may be run from a different ref than the repo's default branch via `--ref`.


