### PR TITLE
Add supports for terminal hyperlinks in output

### DIFF
--- a/pkg/cmd/gist/view/view_test.go
+++ b/pkg/cmd/gist/view/view_test.go
@@ -443,7 +443,7 @@ func Test_promptGists(t *testing.T) {
 	}
 
 	io, _, _, _ := iostreams.Test()
-	cs := iostreams.NewColorScheme(io.ColorEnabled(), io.ColorSupport256())
+	cs := io.ColorScheme()
 
 	for _, tt := range tests {
 		reg := &httpmock.Registry{}

--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -28,7 +28,11 @@ func PrintIssues(io *iostreams.IOStreams, prefix string, totalCount int, issues 
 		}
 		now := time.Now()
 		ago := now.Sub(issue.UpdatedAt)
-		table.AddField(issueNum, nil, cs.ColorFromString(prShared.ColorForState(issue.State)))
+		colorFunc := cs.ColorFromString(prShared.ColorForState(issue.State))
+		issueURL := issue.URL
+		table.AddField(issueNum, nil, func(t string) string {
+			return colorFunc(cs.Hyperlink(t, issueURL))
+		})
 		if !table.IsTTY() {
 			table.AddField(issue.State, nil, nil)
 		}

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -190,9 +190,18 @@ func checksRun(opts *ChecksOptions) error {
 	for _, o := range outputs {
 		if isTerminal {
 			tp.AddField(o.mark, nil, o.markColor)
-			tp.AddField(o.name, nil, nil)
+			var linkFunc func(string) string
+			if opts.IO.IsLinkEnabled() {
+				url := o.link
+				linkFunc = func(t string) string {
+					return cs.Hyperlink(t, url)
+				}
+			}
+			tp.AddField(o.name, nil, linkFunc)
 			tp.AddField(o.elapsed, nil, nil)
-			tp.AddField(o.link, nil, nil)
+			if !opts.IO.IsLinkEnabled() {
+				tp.AddField(o.link, nil, nil)
+			}
 		} else {
 			tp.AddField(o.name, nil, nil)
 			tp.AddField(o.bucket, nil, nil)

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -131,7 +131,11 @@ func listRun(opts *ListOptions) error {
 		if table.IsTTY() {
 			prNum = "#" + prNum
 		}
-		table.AddField(prNum, nil, cs.ColorFromString(shared.ColorForPR(pr)))
+		prURL := pr.URL
+		colorFunc := cs.ColorFromString(shared.ColorForPR(pr))
+		table.AddField(prNum, nil, func(t string) string {
+			return colorFunc(cs.Hyperlink(t, prURL))
+		})
 		table.AddField(text.ReplaceExcessiveWhitespace(pr.Title), nil, nil)
 		table.AddField(pr.HeadLabel(), nil, cs.Cyan)
 		if !table.IsTTY() {

--- a/pkg/iostreams/color.go
+++ b/pkg/iostreams/color.go
@@ -44,16 +44,18 @@ func Is256ColorSupported() bool {
 		strings.Contains(colorterm, "truecolor")
 }
 
-func NewColorScheme(enabled, is256enabled bool) *ColorScheme {
+func NewColorScheme(enabled, is256enabled, isLinkEnabled bool) *ColorScheme {
 	return &ColorScheme{
 		enabled:      enabled,
 		is256enabled: is256enabled,
+		linkEnabled:  isLinkEnabled,
 	}
 }
 
 type ColorScheme struct {
 	enabled      bool
 	is256enabled bool
+	linkEnabled  bool
 }
 
 func (c *ColorScheme) Bold(t string) string {
@@ -201,4 +203,12 @@ func (c *ColorScheme) ColorFromString(s string) func(string) string {
 	}
 
 	return fn
+}
+
+func (c *ColorScheme) Hyperlink(text, url string) string {
+	if !c.linkEnabled {
+		return text
+	}
+	// https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", url, text)
 }

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -30,6 +30,7 @@ type IOStreams struct {
 	colorEnabled  bool
 	is256enabled  bool
 	terminalTheme string
+	linkEnabled   bool
 
 	progressIndicatorEnabled bool
 	progressIndicator        *spinner.Spinner
@@ -89,6 +90,10 @@ func (s *IOStreams) TerminalTheme() string {
 	}
 
 	return s.terminalTheme
+}
+
+func (s *IOStreams) IsLinkEnabled() bool {
+	return s.linkEnabled
 }
 
 func (s *IOStreams) SetStdinTTY(isTTY bool) {
@@ -252,7 +257,7 @@ func (s *IOStreams) TerminalWidth() int {
 }
 
 func (s *IOStreams) ColorScheme() *ColorScheme {
-	return NewColorScheme(s.ColorEnabled(), s.ColorSupport256())
+	return NewColorScheme(s.ColorEnabled(), s.ColorSupport256(), s.IsLinkEnabled())
 }
 
 func (s *IOStreams) ReadUserFile(fn string) ([]byte, error) {
@@ -295,6 +300,7 @@ func System() *IOStreams {
 		ErrOut:       colorable.NewColorable(os.Stderr),
 		colorEnabled: EnvColorForced() || (!EnvColorDisabled() && stdoutIsTTY),
 		is256enabled: Is256ColorSupported(),
+		linkEnabled:  os.Getenv("GH_HYPERLINK") != "",
 		pagerCommand: pagerCommand,
 	}
 

--- a/utils/table_printer.go
+++ b/utils/table_printer.go
@@ -109,14 +109,14 @@ func (t *ttyTablePrinter) Render() error {
 				}
 			}
 			truncVal := field.TruncateFunc(colWidths[col], field.Text)
+			if field.ColorFunc != nil {
+				truncVal = field.ColorFunc(truncVal)
+			}
 			if col < numCols-1 {
 				// pad value with spaces on the right
 				if padWidth := colWidths[col] - text.DisplayWidth(field.Text); padWidth > 0 {
 					truncVal += strings.Repeat(" ", padWidth)
 				}
-			}
-			if field.ColorFunc != nil {
-				truncVal = field.ColorFunc(truncVal)
 			}
 			_, err := fmt.Fprint(t.out, truncVal)
 			if err != nil {


### PR DESCRIPTION
In supporting terminals (e.g. iTerm), the identifier field of table-based output like `issue/pr list` and `pr checks` can now be a link that can be followed in a browser by Cmd-clicking it.

<img width="995" alt="Screen Shot 2021-03-26 at 19 01 06" src="https://user-images.githubusercontent.com/887/112674474-46c42480-8e66-11eb-8c31-a2cad87f8cd9.png">

This feature needs to be explicitly enabled via environment variable because we are typically not able to detect whether the current terminal environment supports it.

It works really well for `pr checks` where we are then able to drop the final URL column in favor of hyperlinks:

<img width="472" alt="Screen Shot 2021-03-26 at 19 00 15" src="https://user-images.githubusercontent.com/887/112674486-4a57ab80-8e66-11eb-8ddf-d756d977713c.png">

Drawbacks so far:

- It doesn't look great 🤪 but the presentation is the responsibility of the terminal emulator anyway. (The screenshots are iTerm)
- The popular pager program `less -R` mangles hyperlinks. It might be that other pager programs would do so as well;
- I can't get these links to work within tmux, even though tmux was reported as supporting these kind of links.

The spec: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
Ref. https://github.com/cli/cli/issues/601
