### PR TITLE
support --workflow in run list

### DIFF
--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -150,7 +150,17 @@ type RunsPayload struct {
 	WorkflowRuns []Run `json:"workflow_runs"`
 }
 
+func GetRunsByWorkflow(client *api.Client, repo ghrepo.Interface, limit, workflowID int) ([]Run, error) {
+	path := fmt.Sprintf("repos/%s/actions/workflows/%d/runs", ghrepo.FullName(repo), workflowID)
+	return getRuns(client, repo, path, limit)
+}
+
 func GetRuns(client *api.Client, repo ghrepo.Interface, limit int) ([]Run, error) {
+	path := fmt.Sprintf("repos/%s/actions/runs", ghrepo.FullName(repo))
+	return getRuns(client, repo, path, limit)
+}
+
+func getRuns(client *api.Client, repo ghrepo.Interface, path string, limit int) ([]Run, error) {
 	perPage := limit
 	page := 1
 	if limit > 100 {
@@ -162,9 +172,9 @@ func GetRuns(client *api.Client, repo ghrepo.Interface, limit int) ([]Run, error
 	for len(runs) < limit {
 		var result RunsPayload
 
-		path := fmt.Sprintf("repos/%s/actions/runs?per_page=%d&page=%d", ghrepo.FullName(repo), perPage, page)
+		pagedPath := fmt.Sprintf("%s?per_page=%d&page=%d", path, perPage, page)
 
-		err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
+		err := client.REST(repo.RepoHost(), "GET", pagedPath, nil, &result)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/run/shared/test.go
+++ b/pkg/cmd/run/shared/test.go
@@ -55,6 +55,12 @@ var TestRuns []Run = []Run{
 	TestRun("stale", 10, Completed, Stale),
 }
 
+var WorkflowRuns []Run = []Run{
+	TestRun("in progress", 2, InProgress, ""),
+	SuccessfulRun,
+	FailedRun,
+}
+
 var SuccessfulJob Job = Job{
 	ID:          10,
 	Status:      Completed,


### PR DESCRIPTION
This PR adds `--workflow` to `gh run list`, allowing to filter the run list by workflow. It reuses the same workflow resolution as the workflow commands, so names, filenames, and IDs are all supported.

This allows us to give users hint about how to see the workflow they just manually dispatched as well as showing runs in the upcoming `workflow view`.

Part of #2889
