### PR TITLE
Preemptively share code from gh run view

### DIFF
--- a/pkg/cmd/run/shared/presentation.go
+++ b/pkg/cmd/run/shared/presentation.go
@@ -36,3 +36,14 @@ func RenderJobs(cs *iostreams.ColorScheme, jobs []Job, verbose bool) string {
 
 	return strings.Join(lines, "\n")
 }
+
+func RenderAnnotations(cs *iostreams.ColorScheme, annotations []Annotation) string {
+	lines := []string{}
+
+	for _, a := range annotations {
+		lines = append(lines, fmt.Sprintf("%s %s", AnnotationSymbol(cs, a), a.Message))
+		lines = append(lines, cs.Grayf("%s: %s#%d\n", a.JobName, a.Path, a.StartLine))
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/pkg/cmd/run/shared/presentation.go
+++ b/pkg/cmd/run/shared/presentation.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cli/cli/pkg/iostreams"
 )
@@ -17,4 +18,21 @@ func RenderRunHeader(cs *iostreams.ColorScheme, run Run, ago, prNumber string) s
 	header += fmt.Sprintf("Triggered via %s %s", run.Event, ago)
 
 	return header
+}
+
+func RenderJobs(cs *iostreams.ColorScheme, jobs []Job, verbose bool) string {
+	lines := []string{}
+	for _, job := range jobs {
+		symbol, symbolColor := Symbol(cs, job.Status, job.Conclusion)
+		id := cs.Cyanf("%d", job.ID)
+		lines = append(lines, fmt.Sprintf("%s %s (ID %s)", symbolColor(symbol), job.Name, id))
+		if verbose || IsFailureState(job.Conclusion) {
+			for _, step := range job.Steps {
+				stepSymbol, stepSymColor := Symbol(cs, step.Status, step.Conclusion)
+				lines = append(lines, fmt.Sprintf("  %s %s", stepSymColor(stepSymbol), step.Name))
+			}
+		}
+	}
+
+	return strings.Join(lines, "\n")
 }

--- a/pkg/cmd/run/shared/presentation.go
+++ b/pkg/cmd/run/shared/presentation.go
@@ -1,0 +1,20 @@
+package shared
+
+import (
+	"fmt"
+
+	"github.com/cli/cli/pkg/iostreams"
+)
+
+func RenderRunHeader(cs *iostreams.ColorScheme, run Run, ago, prNumber string) string {
+	title := fmt.Sprintf("%s %s%s",
+		cs.Bold(run.HeadBranch), run.Name, prNumber)
+	symbol, symbolColor := Symbol(cs, run.Status, run.Conclusion)
+	id := cs.Cyanf("%d", run.ID)
+
+	header := ""
+	header += fmt.Sprintf("%s %s · %s\n", symbolColor(symbol), title, id)
+	header += fmt.Sprintf("Triggered via %s %s", run.Event, ago)
+
+	return header
+}

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -270,3 +270,71 @@ func Symbol(cs *iostreams.ColorScheme, status Status, conclusion Conclusion) (st
 
 	return "-", cs.Yellow
 }
+
+func PullRequestForRun(client *api.Client, repo ghrepo.Interface, run Run) (int, error) {
+	type response struct {
+		Repository struct {
+			PullRequests struct {
+				Nodes []struct {
+					Number         int
+					HeadRepository struct {
+						Owner struct {
+							Login string
+						}
+						Name string
+					}
+				}
+			}
+		}
+		Number int
+	}
+
+	variables := map[string]interface{}{
+		"owner":       repo.RepoOwner(),
+		"repo":        repo.RepoName(),
+		"headRefName": run.HeadBranch,
+	}
+
+	query := `
+		query PullRequestForRun($owner: String!, $repo: String!, $headRefName: String!) {
+			repository(owner: $owner, name: $repo) {
+				pullRequests(headRefName: $headRefName, first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {
+					nodes {
+						number
+						headRepository {
+							owner {
+								login
+							}
+							name
+						}
+					}
+				}
+			}
+		}`
+
+	var resp response
+
+	err := client.GraphQL(repo.RepoHost(), query, variables, &resp)
+	if err != nil {
+		return -1, err
+	}
+
+	prs := resp.Repository.PullRequests.Nodes
+	if len(prs) == 0 {
+		return -1, fmt.Errorf("no matching PR found for %s", run.HeadBranch)
+	}
+
+	number := -1
+
+	for _, pr := range prs {
+		if pr.HeadRepository.Owner.Login == run.HeadRepository.Owner.Login && pr.HeadRepository.Name == run.HeadRepository.Name {
+			number = pr.Number
+		}
+	}
+
+	if number == -1 {
+		return number, fmt.Errorf("no matching PR found for %s", run.HeadBranch)
+	}
+
+	return number, nil
+}

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -159,17 +159,7 @@ func runView(opts *ViewOptions) error {
 
 	fmt.Fprintln(out, cs.Bold("JOBS"))
 
-	for _, job := range jobs {
-		symbol, symbolColor := shared.Symbol(cs, job.Status, job.Conclusion)
-		id := cs.Cyanf("%d", job.ID)
-		fmt.Fprintf(out, "%s %s (ID %s)\n", symbolColor(symbol), job.Name, id)
-		if opts.Verbose || shared.IsFailureState(job.Conclusion) {
-			for _, step := range job.Steps {
-				stepSymbol, stepSymColor := shared.Symbol(cs, step.Status, step.Conclusion)
-				fmt.Fprintf(out, "  %s %s\n", stepSymColor(stepSymbol), step.Name)
-			}
-		}
-	}
+	fmt.Fprintln(out, shared.RenderJobs(cs, jobs, opts.Verbose))
 
 	if len(annotations) > 0 {
 		fmt.Fprintln(out)

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -137,17 +137,10 @@ func runView(opts *ViewOptions) error {
 	out := opts.IO.Out
 	cs := opts.IO.ColorScheme()
 
-	title := fmt.Sprintf("%s %s%s",
-		cs.Bold(run.HeadBranch), run.Name, prNumber)
-	symbol, symbolColor := shared.Symbol(cs, run.Status, run.Conclusion)
-	id := cs.Cyanf("%d", run.ID)
-
-	fmt.Fprintln(out)
-	fmt.Fprintf(out, "%s %s · %s\n", symbolColor(symbol), title, id)
-
 	ago := opts.Now().Sub(run.CreatedAt)
 
-	fmt.Fprintf(out, "Triggered via %s %s\n", run.Event, utils.FuzzyAgo(ago))
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, shared.RenderRunHeader(cs, *run, utils.FuzzyAgo(ago), prNumber))
 	fmt.Fprintln(out)
 
 	if len(jobs) == 0 && run.Conclusion == shared.Failure {

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -164,12 +164,8 @@ func runView(opts *ViewOptions) error {
 	if len(annotations) > 0 {
 		fmt.Fprintln(out)
 		fmt.Fprintln(out, cs.Bold("ANNOTATIONS"))
+		fmt.Fprintln(out, shared.RenderAnnotations(cs, annotations))
 
-		for _, a := range annotations {
-			fmt.Fprintf(out, "%s %s\n", shared.AnnotationSymbol(cs, a), a.Message)
-			fmt.Fprintln(out, cs.Grayf("%s: %s#%d\n",
-				a.JobName, a.Path, a.StartLine))
-		}
 	}
 
 	fmt.Fprintln(out)


### PR DESCRIPTION
This pull request:

- shares run header printing
- shares job list printing
- shares annotation list printing
- shares prForRun

The new command `gh run watch` will need this rendering code and I wanted to cleanly extract it before Mislav begins working in parallel on adding an `ARTIFACTS` subsection to `gh run view` as part of #3321 .

This PR is pure refactor and has zero functional changes.
