### PR TITLE
small refactor around prompting for runs

### DIFF
--- a/pkg/cmd/job/view/view.go
+++ b/pkg/cmd/job/view/view.go
@@ -96,7 +96,12 @@ func runView(opts *ViewOptions) error {
 
 	jobID := opts.JobID
 	if opts.Prompt {
-		runID, err := shared.PromptForRun(cs, client, repo)
+		// TODO arbitrary limit
+		runs, err := shared.GetRuns(client, repo, 10)
+		if err != nil {
+			return fmt.Errorf("failed to get runs: %w", err)
+		}
+		runID, err := shared.PromptForRun(cs, runs)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -218,13 +218,7 @@ func GetJobs(client *api.Client, repo ghrepo.Interface, run Run) ([]Job, error) 
 	return result.Jobs, nil
 }
 
-func PromptForRun(cs *iostreams.ColorScheme, client *api.Client, repo ghrepo.Interface) (string, error) {
-	// TODO arbitrary limit
-	runs, err := GetRuns(client, repo, 10)
-	if err != nil {
-		return "", err
-	}
-
+func PromptForRun(cs *iostreams.ColorScheme, runs []Run) (string, error) {
 	var selected int
 
 	candidates := []string{}
@@ -237,7 +231,7 @@ func PromptForRun(cs *iostreams.ColorScheme, client *api.Client, repo ghrepo.Int
 
 	// TODO consider custom filter so it's fuzzier. right now matches start anywhere in string but
 	// become contiguous
-	err = prompt.SurveyAskOne(&survey.Select{
+	err := prompt.SurveyAskOne(&survey.Select{
 		Message:  "Select a workflow run",
 		Options:  candidates,
 		PageSize: 10,

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -92,7 +92,12 @@ func runView(opts *ViewOptions) error {
 
 	if opts.Prompt {
 		cs := opts.IO.ColorScheme()
-		runID, err = shared.PromptForRun(cs, client, repo)
+		// TODO arbitrary limit
+		runs, err := shared.GetRuns(client, repo, 10)
+		if err != nil {
+			return fmt.Errorf("failed to get runs: %w", err)
+		}
+		runID, err = shared.PromptForRun(cs, runs)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Given that mislav is also about to be poking around in `run view` I wanted to quickly split up this function so that I can add a second version of `GetRuns` that can filter by status/conclusion.

No functional changes.
