### PR TITLE
Treat unrecognized PR Checks statuses as "pending"

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -188,10 +188,8 @@ func (pr *PullRequest) ChecksStatus() (summary PullRequestChecksStatus) {
 			summary.Passing++
 		case "ERROR", "FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED":
 			summary.Failing++
-		case "EXPECTED", "REQUESTED", "QUEUED", "PENDING", "IN_PROGRESS", "STALE":
+		default: // "EXPECTED", "REQUESTED", "WAITING", "QUEUED", "PENDING", "IN_PROGRESS", "STALE"
 			summary.Pending++
-		default:
-			panic(fmt.Errorf("unsupported status: %q", state))
 		}
 		summary.Total++
 	}

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -141,13 +141,11 @@ func checksRun(opts *ChecksOptions) error {
 			markColor = cs.Red
 			failing++
 			bucket = "fail"
-		case "EXPECTED", "REQUESTED", "QUEUED", "PENDING", "IN_PROGRESS", "STALE":
+		default: // "EXPECTED", "REQUESTED", "WAITING", "QUEUED", "PENDING", "IN_PROGRESS", "STALE"
 			mark = "-"
 			markColor = cs.Yellow
 			pending++
 			bucket = "pending"
-		default:
-			panic(fmt.Errorf("unsupported status: %q", state))
 		}
 
 		elapsed := ""


### PR DESCRIPTION
Previously, unrecognized Checks statuses would crash the program. For the sake of supporting the "WAITING" status and for forward-compatibility, this treats any unrecognized status as "pending".

Fixes #3335
