### PR TITLE
Add section in help for actions commands

### DIFF
--- a/pkg/cmd/actions/actions.go
+++ b/pkg/cmd/actions/actions.go
@@ -26,6 +26,9 @@ func NewCmdActions(f *cmdutil.Factory) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			actionsRun(opts)
 		},
+		Annotations: map[string]string{
+			"IsActions": "true",
+		},
 	}
 
 	return cmd

--- a/pkg/cmd/root/help.go
+++ b/pkg/cmd/root/help.go
@@ -88,6 +88,7 @@ func rootHelpFunc(cs *iostreams.ColorScheme, command *cobra.Command, args []stri
 	}
 
 	coreCommands := []string{}
+	actionsCommands := []string{}
 	additionalCommands := []string{}
 	for _, c := range command.Commands() {
 		if c.Short == "" {
@@ -100,6 +101,8 @@ func rootHelpFunc(cs *iostreams.ColorScheme, command *cobra.Command, args []stri
 		s := rpad(c.Name()+":", c.NamePadding()) + c.Short
 		if _, ok := c.Annotations["IsCore"]; ok {
 			coreCommands = append(coreCommands, s)
+		} else if _, ok := c.Annotations["IsActions"]; ok {
+			actionsCommands = append(actionsCommands, s)
 		} else {
 			additionalCommands = append(additionalCommands, s)
 		}
@@ -125,6 +128,9 @@ func rootHelpFunc(cs *iostreams.ColorScheme, command *cobra.Command, args []stri
 	helpEntries = append(helpEntries, helpEntry{"USAGE", command.UseLine()})
 	if len(coreCommands) > 0 {
 		helpEntries = append(helpEntries, helpEntry{"CORE COMMANDS", strings.Join(coreCommands, "\n")})
+	}
+	if len(actionsCommands) > 0 {
+		helpEntries = append(helpEntries, helpEntry{"ACTIONS COMMANDS", strings.Join(actionsCommands, "\n")})
 	}
 	if len(additionalCommands) > 0 {
 		helpEntries = append(helpEntries, helpEntry{"ADDITIONAL COMMANDS", strings.Join(additionalCommands, "\n")})

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -11,10 +11,11 @@ func NewCmdRun(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "run <command>",
 		Short:  "View details about workflow runs",
-		Hidden: true,
 		Long:   "List, view, and watch recent workflow runs from GitHub Actions.",
-		// TODO i'd like to have all the actions commands sorted into their own zone which i think will
-		// require a new annotation
+		Hidden: true,
+		Annotations: map[string]string{
+			"IsActions": "true",
+		},
 	}
 	cmdutil.EnableRepoOverride(cmd, f)
 

--- a/pkg/cmd/workflow/workflow.go
+++ b/pkg/cmd/workflow/workflow.go
@@ -12,10 +12,11 @@ func NewCmdWorkflow(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "workflow <command>",
 		Short:  "View details about GitHub Actions workflows",
-		Hidden: true,
 		Long:   "List, view, and run workflows in GitHub Actions.",
-		// TODO i'd like to have all the actions commands sorted into their own zone which i think will
-		// require a new annotation
+		Hidden: true,
+		Annotations: map[string]string{
+			"IsActions": "true",
+		},
 	}
 	cmdutil.EnableRepoOverride(cmd, f)
 


### PR DESCRIPTION
This PR adds a section to the help command specifically for listing actions commands. While these commands are hidden they will not show up in the actions command list.

<img width="896" alt="Screen Shot 2021-03-31 at 9 04 13 PM" src="https://user-images.githubusercontent.com/7969779/113242006-c6863080-9264-11eb-9359-63f06bfe05b4.png">

