### PR TITLE
Quick fix: respect default hostname when parsing `owner/repo` pairs

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cli/cli/internal/build"
 	"github.com/cli/cli/internal/config"
 	"github.com/cli/cli/internal/ghinstance"
+	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/internal/run"
 	"github.com/cli/cli/internal/update"
 	"github.com/cli/cli/pkg/cmd/alias/expand"
@@ -98,6 +99,11 @@ func mainRun() exitCode {
 
 	if pager, _ := cfg.Get("", "pager"); pager != "" {
 		cmdFactory.IOStreams.SetPager(pager)
+	}
+
+	// TODO: remove after FromFullName has been revisited
+	if host, err := cfg.DefaultHost(); err == nil {
+		ghrepo.SetDefaultHost(host)
 	}
 
 	expandedArgs := []string{}

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -35,6 +35,21 @@ func FullName(r Interface) string {
 	return fmt.Sprintf("%s/%s", r.RepoOwner(), r.RepoName())
 }
 
+var defaultHostOverride string
+
+func defaultHost() string {
+	if defaultHostOverride != "" {
+		return defaultHostOverride
+	}
+	return ghinstance.Default()
+}
+
+// SetDefaultHost overrides the default GitHub hostname for FromFullName.
+// TODO: remove after FromFullName approach is revisited
+func SetDefaultHost(host string) {
+	defaultHostOverride = host
+}
+
 // FromFullName extracts the GitHub repository information from the following
 // formats: "OWNER/REPO", "HOST/OWNER/REPO", and a full URL.
 func FromFullName(nwo string) (Interface, error) {
@@ -54,9 +69,9 @@ func FromFullName(nwo string) (Interface, error) {
 	}
 	switch len(parts) {
 	case 3:
-		return NewWithHost(parts[1], parts[2], normalizeHostname(parts[0])), nil
+		return NewWithHost(parts[1], parts[2], parts[0]), nil
 	case 2:
-		return New(parts[0], parts[1]), nil
+		return NewWithHost(parts[0], parts[1], defaultHost()), nil
 	default:
 		return nil, fmt.Errorf(`expected the "[HOST/]OWNER/REPO" format, got %q`, nwo)
 	}

--- a/internal/ghrepo/repo_test.go
+++ b/internal/ghrepo/repo_test.go
@@ -117,12 +117,13 @@ func Test_repoFromURL(t *testing.T) {
 
 func TestFromFullName(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantOwner string
-		wantName  string
-		wantHost  string
-		wantErr   error
+		name         string
+		input        string
+		hostOverride string
+		wantOwner    string
+		wantName     string
+		wantHost     string
+		wantErr      error
 	}{
 		{
 			name:      "OWNER/REPO combo",
@@ -171,9 +172,30 @@ func TestFromFullName(t *testing.T) {
 			wantName:  "REPO",
 			wantErr:   nil,
 		},
+		{
+			name:         "OWNER/REPO with default host override",
+			input:        "OWNER/REPO",
+			hostOverride: "override.com",
+			wantHost:     "override.com",
+			wantOwner:    "OWNER",
+			wantName:     "REPO",
+			wantErr:      nil,
+		},
+		{
+			name:         "HOST/OWNER/REPO with default host override",
+			input:        "example.com/OWNER/REPO",
+			hostOverride: "override.com",
+			wantHost:     "example.com",
+			wantOwner:    "OWNER",
+			wantName:     "REPO",
+			wantErr:      nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.hostOverride != "" {
+				SetDefaultHost(tt.hostOverride)
+			}
 			r, err := FromFullName(tt.input)
 			if tt.wantErr != nil {
 				if err == nil {


### PR DESCRIPTION
This re-enables using GH_HOST to set a default hostname when supplying repo argument like `gh repo clone owner/repo`.

Closes https://github.com/cli/cli/issues/3339
Superseeds https://github.com/cli/cli/pull/3340