### PR TITLE
Fix detecting PR status when passing branch as arg

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -672,6 +672,7 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, baseBranch, hea
 					number
 					title
 					state
+					closed
 					body
 					mergeable
 					additions

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -33,7 +33,6 @@ type PullRequest struct {
 	Number           int
 	Title            string
 	State            string
-	Closed           bool
 	URL              string
 	BaseRefName      string
 	HeadRefName      string
@@ -140,6 +139,10 @@ func (pr PullRequest) Link() string {
 
 func (pr PullRequest) Identifier() string {
 	return pr.ID
+}
+
+func (pr PullRequest) IsOpen() bool {
+	return pr.State == "OPEN"
 }
 
 type PullRequestReviewStatus struct {
@@ -672,7 +675,6 @@ func PullRequestForBranch(client *Client, repo ghrepo.Interface, baseBranch, hea
 					number
 					title
 					state
-					closed
 					body
 					mergeable
 					additions

--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -76,7 +76,7 @@ func closeRun(opts *CloseOptions) error {
 	if pr.State == "MERGED" {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d (%s) can't be closed because it was already merged", cs.Red("!"), pr.Number, pr.Title)
 		return cmdutil.SilentError
-	} else if pr.Closed {
+	} else if !pr.IsOpen() {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d (%s) is already closed\n", cs.Yellow("!"), pr.Number, pr.Title)
 		return nil
 	}

--- a/pkg/cmd/pr/close/close_test.go
+++ b/pkg/cmd/pr/close/close_test.go
@@ -67,7 +67,7 @@ func TestPrClose(t *testing.T) {
 		httpmock.GraphQL(`query PullRequestByNumber\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
-				"pullRequest": { "id": "THE-ID", "number": 96, "title": "The title of the PR" }
+				"pullRequest": { "id": "THE-ID", "number": 96, "title": "The title of the PR", "state": "OPEN" }
 			} } }`),
 	)
 	http.Register(
@@ -98,7 +98,7 @@ func TestPrClose_alreadyClosed(t *testing.T) {
 		httpmock.GraphQL(`query PullRequestByNumber\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
-				"pullRequest": { "number": 101, "title": "The title of the PR", "closed": true }
+				"pullRequest": { "number": 101, "title": "The title of the PR", "state": "CLOSED" }
 			} } }`),
 	)
 
@@ -121,8 +121,13 @@ func TestPrClose_deleteBranch(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`query PullRequestByNumber\b`),
 		httpmock.StringResponse(`
-			{ "data": { "repository": {
-				"pullRequest": { "id": "THE-ID", "number": 96, "title": "The title of the PR", "headRefName":"blueberries", "headRepositoryOwner": {"login": "OWNER"}}
+			{ "data": { "repository": { "pullRequest": {
+				"id": "THE-ID",
+				"number": 96, 
+				"title": "The title of the PR", 
+				"headRefName":"blueberries", 
+				"headRepositoryOwner": {"login": "OWNER"},
+				"state": "OPEN" }
 			} } }`),
 	)
 	http.Register(

--- a/pkg/cmd/pr/ready/ready.go
+++ b/pkg/cmd/pr/ready/ready.go
@@ -75,7 +75,7 @@ func readyRun(opts *ReadyOptions) error {
 		return err
 	}
 
-	if pr.Closed {
+	if !pr.IsOpen() {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d is closed. Only draft pull requests can be marked as \"ready for review\"", cs.Red("!"), pr.Number)
 		return cmdutil.SilentError
 	} else if !pr.IsDraft {

--- a/pkg/cmd/pr/ready/ready_test.go
+++ b/pkg/cmd/pr/ready/ready_test.go
@@ -147,7 +147,7 @@ func TestPRReady(t *testing.T) {
 		httpmock.GraphQL(`query PullRequestByNumber\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
-				"pullRequest": { "id": "THE-ID", "number": 444, "closed": false, "isDraft": true}
+				"pullRequest": { "id": "THE-ID", "number": 444, "state": "OPEN", "isDraft": true}
 			} } }`),
 	)
 	http.Register(
@@ -178,7 +178,7 @@ func TestPRReady_alreadyReady(t *testing.T) {
 		httpmock.GraphQL(`query PullRequestByNumber\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
-				"pullRequest": { "number": 445, "closed": false, "isDraft": false}
+				"pullRequest": { "number": 445, "state": "OPEN", "isDraft": false}
 			} } }`),
 	)
 
@@ -202,7 +202,7 @@ func TestPRReady_closed(t *testing.T) {
 		httpmock.GraphQL(`query PullRequestByNumber\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
-				"pullRequest": { "number": 446, "closed": true, "isDraft": true}
+				"pullRequest": { "number": 446, "state": "CLOSED", "isDraft": true}
 			} } }`),
 	)
 

--- a/pkg/cmd/pr/reopen/reopen.go
+++ b/pkg/cmd/pr/reopen/reopen.go
@@ -70,7 +70,7 @@ func reopenRun(opts *ReopenOptions) error {
 		return cmdutil.SilentError
 	}
 
-	if !pr.Closed {
+	if pr.IsOpen() {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d (%s) is already open\n", cs.Yellow("!"), pr.Number, pr.Title)
 		return nil
 	}

--- a/pkg/cmd/pr/reopen/reopen_test.go
+++ b/pkg/cmd/pr/reopen/reopen_test.go
@@ -63,7 +63,7 @@ func TestPRReopen(t *testing.T) {
 		httpmock.GraphQL(`query PullRequestByNumber\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
-				"pullRequest": { "id": "THE-ID", "number": 666, "title": "The title of the PR", "closed": true}
+				"pullRequest": { "id": "THE-ID", "number": 666, "title": "The title of the PR", "state": "CLOSED" }
 			} } }`),
 	)
 	http.Register(
@@ -95,7 +95,7 @@ func TestPRReopen_BranchArg(t *testing.T) {
 		httpmock.StringResponse(`
 			{ "data": { "repository": { "pullRequests": {
 				"nodes": [
-					{ "id": "THE-ID", "number": 666, "title": "The title of the PR", "headRefName": "fix-bug", "closed": true }
+					{ "id": "THE-ID", "number": 666, "title": "The title of the PR", "headRefName": "fix-bug", "state": "CLOSED" }
 				]
 			} } } }`),
 	)
@@ -127,7 +127,7 @@ func TestPRReopen_alreadyOpen(t *testing.T) {
 		httpmock.GraphQL(`query PullRequestByNumber\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
-				"pullRequest": { "number": 666,  "title": "The title of the PR", "closed": false}
+				"pullRequest": { "number": 666,  "title": "The title of the PR", "state": "OPEN" }
 			} } }`),
 	)
 
@@ -151,7 +151,7 @@ func TestPRReopen_alreadyMerged(t *testing.T) {
 		httpmock.GraphQL(`query PullRequestByNumber\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
-				"pullRequest": { "number": 666, "title": "The title of the PR", "closed": true, "state": "MERGED"}
+				"pullRequest": { "number": 666, "title": "The title of the PR", "state": "MERGED"}
 			} } }`),
 	)
 


### PR DESCRIPTION
Fixes #3350

`PullRequestForBranch` wasn't fetching the `closed` field thus [making `gh pr reopen <branch>`](https://github.com/cli/cli/blob/216cfb631f6d1b34e7fc0529344fa367faee59c6/pkg/cmd/pr/reopen/reopen.go#L73) detect a closed PR as already open (`pr.Closed` zero value = false).

Edit:
This PR makes `gh` rely only on the `state` field to detect the current PR status (either `CLOSED`, `MERGED` or `OPEN`) (thanks Mislav).