### PR TITLE
support --web in gh run view

### DIFF
--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -94,7 +94,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 			}
 
 			if opts.Web && opts.Log {
-				return &cmdutil.FlagError{Err: errors.New("only one of --web or --log can be passed at a time")}
+				return &cmdutil.FlagError{Err: errors.New("specify only one of --web or --log")}
 			}
 
 			if runF != nil {

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -20,16 +20,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type browser interface {
+	Browse(string) error
+}
+
 type ViewOptions struct {
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
 	BaseRepo   func() (ghrepo.Interface, error)
+	Browser    browser
 
 	RunID      string
 	JobID      string
 	Verbose    bool
 	ExitStatus bool
 	Log        bool
+	Web        bool
 
 	Prompt bool
 
@@ -41,6 +47,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
 		Now:        time.Now,
+		Browser:    f.Browser,
 	}
 	cmd := &cobra.Command{
 		Use:    "view [<run-id>]",
@@ -86,6 +93,10 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 				}
 			}
 
+			if opts.Web && opts.Log {
+				return &cmdutil.FlagError{Err: errors.New("only one of --web or --log can be passed at a time")}
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -97,6 +108,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	cmd.Flags().BoolVar(&opts.ExitStatus, "exit-status", false, "Exit with non-zero status if run failed")
 	cmd.Flags().StringVarP(&opts.JobID, "job", "j", "", "View a specific job ID from a run")
 	cmd.Flags().BoolVar(&opts.Log, "log", false, "View full log for either a run or specific job")
+	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open run in the browser")
 
 	return cmd
 }
@@ -153,6 +165,14 @@ func runView(opts *ViewOptions) error {
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("failed to get run: %w", err)
+	}
+
+	if opts.Web {
+		if opts.IO.IsStdoutTTY() {
+			fmt.Fprintf(opts.IO.Out, "Opening %s in your browser.\n", utils.DisplayURL(run.URL))
+		}
+
+		return opts.Browser.Browse(run.URL)
 	}
 
 	if opts.Prompt {

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -167,14 +167,6 @@ func runView(opts *ViewOptions) error {
 		return fmt.Errorf("failed to get run: %w", err)
 	}
 
-	if opts.Web {
-		if opts.IO.IsStdoutTTY() {
-			fmt.Fprintf(opts.IO.Out, "Opening %s in your browser.\n", utils.DisplayURL(run.URL))
-		}
-
-		return opts.Browser.Browse(run.URL)
-	}
-
 	if opts.Prompt {
 		opts.IO.StartProgressIndicator()
 		jobs, err = shared.GetJobs(client, repo, *run)
@@ -188,6 +180,18 @@ func runView(opts *ViewOptions) error {
 				return err
 			}
 		}
+	}
+
+	if opts.Web {
+		url := run.URL
+		if selectedJob != nil {
+			url = selectedJob.URL + "?check_suite_focus=true"
+		}
+		if opts.IO.IsStdoutTTY() {
+			fmt.Fprintf(opts.IO.Out, "Opening %s in your browser.\n", utils.DisplayURL(url))
+		}
+
+		return opts.Browser.Browse(url)
 	}
 
 	opts.IO.StartProgressIndicator()

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -456,7 +456,7 @@ func TestViewRun(t *testing.T) {
 			wantOut: "\n✓ trunk successful · 3\nTriggered via push about 59 minutes ago\n\n✓ cool job in 4m34s (ID 10)\n  ✓ fob the barz\n  ✓ barz the fob\n\nTo see the full job log, try: gh run view --log --job=10\nview this run on GitHub: runs/3\n",
 		},
 		{
-			name: "web",
+			name: "web run",
 			tty:  true,
 			opts: &ViewOptions{
 				RunID: "3",
@@ -469,6 +469,24 @@ func TestViewRun(t *testing.T) {
 			},
 			browsedURL: "runs/3",
 			wantOut:    "Opening runs/3 in your browser.\n",
+		},
+		{
+			name: "web job",
+			tty:  true,
+			opts: &ViewOptions{
+				JobID: "10",
+				Web:   true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/jobs/10"),
+					httpmock.JSONResponse(shared.SuccessfulJob))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/3"),
+					httpmock.JSONResponse(shared.SuccessfulRun))
+			},
+			browsedURL: "jobs/10?check_suite_focus=true",
+			wantOut:    "Opening jobs/10 in your browser.\n",
 		},
 	}
 


### PR DESCRIPTION
Part of #2889

This PR adds support for `--web` in `gh run view`. It will focus on the selected job if a job is specified through either `--job` or via the interactive job select prompt.
