### PR TITLE
Indicate that repo owner can be user or organization

### DIFF
--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -45,7 +45,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	)
 
 	cmd := &cobra.Command{
-		Use:   "list [<owner>]",
+		Use:   "list [<owner (user or organization)>]",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "List repositories owned by user or organization",
 		RunE: func(c *cobra.Command, args []string) error {


### PR DESCRIPTION
    Indicate that repo owner can be user or organization

    This might seem obvious, but it wasn't obvious to me at all.

    Closes cli#3373.