### PR TITLE
Add note on supported value types in raw-fields

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -76,8 +76,10 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 			The default HTTP request method is "GET" normally and "POST" if any parameters
 			were added. Override the method with %[1]s--method%[1]s.
 
-			Pass one or more %[1]s--raw-field%[1]s values in "key=value" format to add
-			JSON-encoded string parameters to the POST body.
+			Pass one or more %[1]s--raw-field%[1]s values in "key=value" format to add string 
+			parameters to the request payload. To add non-string parameters, see %[1]s--field%[1]s below. 
+			Note that adding request parameters will automatically switch the request method to POST. 
+			To send the parameters as a GET query string instead, use %[1]s--method%[1]s GET.
 
 			The %[1]s--field%[1]s flag behaves like %[1]s--raw-field%[1]s with magic type conversion based
 			on the format of the value:


### PR DESCRIPTION
Proposing a slight amendment to the `gh api` field docs to clarify the current limitation around "complex" field values, e.g. arrays/objects.

Related: #1484