### PR TITLE
Remove unused embedded struct

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -50,10 +50,7 @@ type PullRequest struct {
 		Login string
 	}
 	HeadRepository struct {
-		Name             string
-		DefaultBranchRef struct {
-			Name string
-		}
+		Name string
 	}
 	IsCrossRepository   bool
 	IsDraft             bool


### PR DESCRIPTION
This PR removes an unused embedded struct declared in `type PullRequest struct`.

It looks like the linter used by `golangci-lint` to found unused struct fields [doesn't handle embedded structs yet](https://github.com/golangci/check#known-limitations).