### PR TITLE
handle array type for on: in workflow file

### DIFF
--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -369,6 +369,13 @@ func findInputs(yamlContent []byte) (map[string]WorkflowInput, error) {
 						dispatchKeyNode = node
 					}
 				}
+			} else if node.Kind == yaml.SequenceNode {
+				for _, node := range node.Content {
+					if node.Value == "workflow_dispatch" {
+						dispatchKeyNode = node
+						break
+					}
+				}
 			} else if node.Kind == yaml.ScalarNode {
 				if node.Value == "workflow_dispatch" {
 					dispatchKeyNode = node

--- a/pkg/cmd/workflow/run/run_test.go
+++ b/pkg/cmd/workflow/run/run_test.go
@@ -247,6 +247,11 @@ func Test_findInputs(t *testing.T) {
 			wantOut: map[string]WorkflowInput{},
 		},
 		{
+			name:    "array of events",
+			YAML:    []byte("name: workflow\non: [pull_request, workflow_dispatch]\n"),
+			wantOut: map[string]WorkflowInput{},
+		},
+		{
 			name: "inputs",
 			YAML: []byte(`name: workflow
 on:


### PR DESCRIPTION
`on` in a workflow file can have three forms; this adds support for the third and final form.