### PR TITLE
Make run selection unique

### DIFF
--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -257,6 +257,7 @@ func GetJobs(client *api.Client, repo ghrepo.Interface, run Run) ([]Job, error) 
 
 func PromptForRun(cs *iostreams.ColorScheme, runs []Run) (string, error) {
 	var selected int
+	now := time.Now()
 
 	candidates := []string{}
 
@@ -264,7 +265,7 @@ func PromptForRun(cs *iostreams.ColorScheme, runs []Run) (string, error) {
 		symbol, _ := Symbol(cs, run.Status, run.Conclusion)
 		candidates = append(candidates,
 			// TODO truncate commit message, long ones look terrible
-			fmt.Sprintf("%s %s, %s (%s)", symbol, run.CommitMsg(), run.Name, run.HeadBranch))
+			fmt.Sprintf("%s %s, %s (%s) %s", symbol, run.CommitMsg(), run.Name, run.HeadBranch, preciseAgo(now, run.CreatedAt)))
 	}
 
 	// TODO consider custom filter so it's fuzzier. right now matches start anywhere in string but
@@ -379,4 +380,15 @@ func PullRequestForRun(client *api.Client, repo ghrepo.Interface, run Run) (int,
 	}
 
 	return number, nil
+}
+
+func preciseAgo(now time.Time, createdAt time.Time) string {
+	ago := now.Sub(createdAt)
+
+	if ago < 30*24*time.Hour {
+		s := ago.Truncate(time.Second).String()
+		return fmt.Sprintf("%s ago", s)
+	}
+
+	return createdAt.Format("Jan _2, 2006")
 }

--- a/pkg/cmd/run/shared/shared_test.go
+++ b/pkg/cmd/run/shared/shared_test.go
@@ -1,0 +1,31 @@
+package shared
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPreciseAgo(t *testing.T) {
+	const form = "2006-Jan-02 15:04:05"
+	now, _ := time.Parse(form, "2021-Apr-12 14:00:00")
+
+	cases := map[string]string{
+		"2021-Apr-12 14:00:00": "0s ago",
+		"2021-Apr-12 13:59:30": "30s ago",
+		"2021-Apr-12 13:59:00": "1m0s ago",
+		"2021-Apr-12 13:30:15": "29m45s ago",
+		"2021-Apr-12 13:00:00": "1h0m0s ago",
+		"2021-Apr-12 02:30:45": "11h29m15s ago",
+		"2021-Apr-11 14:00:00": "24h0m0s ago",
+		"2021-Apr-01 14:00:00": "264h0m0s ago",
+		"2021-Mar-12 14:00:00": "Mar 12, 2021",
+	}
+
+	for createdAt, expected := range cases {
+		d, _ := time.Parse(form, createdAt)
+		got := preciseAgo(now, d)
+		if got != expected {
+			t.Errorf("expected %s but got %s for %s", expected, got, createdAt)
+		}
+	}
+}

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -498,6 +498,9 @@ func displayRunLog(io *iostreams.IOStreams, jobs []shared.Job, failed bool) erro
 			if failed && !shared.IsFailureState(step.Conclusion) {
 				continue
 			}
+			if step.Log == nil {
+				continue
+			}
 			prefix := fmt.Sprintf("%s\t%s\t", job.Name, step.Name)
 			f, err := step.Log.Open()
 			if err != nil {

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -256,7 +256,7 @@ func runView(opts *ViewOptions) error {
 		}
 
 		opts.IO.StartProgressIndicator()
-		runLogZip, err := getRunLog(opts.RunLogCache, httpClient, repo, run.ID)
+		runLogZip, err := getRunLog(opts.RunLogCache, httpClient, repo, run)
 		opts.IO.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to get run log: %w", err)
@@ -408,13 +408,13 @@ func getLog(httpClient *http.Client, logURL string) (io.ReadCloser, error) {
 	return resp.Body, nil
 }
 
-func getRunLog(cache runLogCache, httpClient *http.Client, repo ghrepo.Interface, runID int) (*zip.ReadCloser, error) {
-	filename := fmt.Sprintf("run-log-%d.zip", runID)
+func getRunLog(cache runLogCache, httpClient *http.Client, repo ghrepo.Interface, run *shared.Run) (*zip.ReadCloser, error) {
+	filename := fmt.Sprintf("run-log-%d-%d.zip", run.ID, run.CreatedAt.Unix())
 	filepath := filepath.Join(os.TempDir(), "gh-cli-cache", filename)
 	if !cache.Exists(filepath) {
 		// Run log does not exist in cache so retrieve and store it
 		logURL := fmt.Sprintf("%srepos/%s/actions/runs/%d/logs",
-			ghinstance.RESTPrefix(repo.RepoHost()), ghrepo.FullName(repo), runID)
+			ghinstance.RESTPrefix(repo.RepoHost()), ghrepo.FullName(repo), run.ID)
 
 		resp, err := getLog(httpClient, logURL)
 		if err != nil {


### PR DESCRIPTION
This PR adds a timestamp to the end of the run selection prompt to make the options more unique since survey does not properly handle the case when an options are exactly the same string. 

<img width="776" alt="Screen Shot 2021-04-12 at 4 06 46 PM" src="https://user-images.githubusercontent.com/7969779/114473441-193ae300-9ba9-11eb-9bd3-a619e5da9499.png">

This PR also adds two small fixes to `--log`. The first is that we will no longer try to read from a non-existent log file. The second is adding the unix timestamp to the run log cache key since the run id can be reused. 

Closes https://github.com/cli/cli/issues/3406