### PR TITLE
Add note about current branch detection

### DIFF
--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/internal/ghrepo"
@@ -47,7 +48,13 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "checks [<number> | <url> | <branch>]",
 		Short: "Show CI status for a single pull request",
-		Args:  cobra.MaximumNArgs(1),
+		Long: heredoc.Doc(`
+			Show CI status for a single pull request.
+
+			Without an argument, the pull request that belongs to the current branch
+			is selected.			
+		`),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -28,6 +28,14 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 	cmd := &cobra.Command{
 		Use:   "comment [<number> | <url> | <branch>]",
 		Short: "Create a new pr comment",
+		Long: heredoc.Doc(`
+			Create a new pr comment.
+
+			Without an argument, the pull request that belongs to the current branch
+			is selected.			
+
+			With '--web', comment on the pull request in a web browser instead.
+		`),
 		Example: heredoc.Doc(`
 			$ gh pr comment 22 --body "This looks great, lets get it deployed."
 		`),

--- a/pkg/cmd/pr/diff/diff.go
+++ b/pkg/cmd/pr/diff/diff.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/internal/ghrepo"
@@ -40,7 +41,13 @@ func NewCmdDiff(f *cmdutil.Factory, runF func(*DiffOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "diff [<number> | <url> | <branch>]",
 		Short: "View changes in a pull request",
-		Args:  cobra.MaximumNArgs(1),
+		Long: heredoc.Doc(`
+			View changes in a pull request. 
+
+			Without an argument, the pull request that belongs to the current branch
+			is selected.			
+		`),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -50,6 +50,12 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "edit [<number> | <url> | <branch>]",
 		Short: "Edit a pull request",
+		Long: heredoc.Doc(`
+			Edit a pull request.
+
+			Without an argument, the pull request that belongs to the current branch
+			is selected.
+		`),
 		Example: heredoc.Doc(`
 			$ gh pr edit 23 --title "I found a bug" --body "Nothing works"
 			$ gh pr edit 23 --add-label "bug,help wanted" --remove-label "core"

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -70,6 +70,9 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 		Short: "Merge a pull request",
 		Long: heredoc.Doc(`
 			Merge a pull request on GitHub.
+
+			Without an argument, the pull request that belongs to the current branch
+			is selected.			
     	`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/pr/ready/ready.go
+++ b/pkg/cmd/pr/ready/ready.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/context"
 	"github.com/cli/cli/internal/config"
@@ -38,7 +39,13 @@ func NewCmdReady(f *cmdutil.Factory, runF func(*ReadyOptions) error) *cobra.Comm
 	cmd := &cobra.Command{
 		Use:   "ready [<number> | <url> | <branch>]",
 		Short: "Mark a pull request as ready for review",
-		Args:  cobra.MaximumNArgs(1),
+		Long: heredoc.Doc(`
+			Mark a pull request as ready for review
+
+			Without an argument, the pull request that belongs to the current branch
+			is displayed.
+		`),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo


### PR DESCRIPTION
While digging into the code I found some `gh pr` subcommands already detect the current branch you are in when an argument isn't provided, but there wasn't any mention about it in their help text, this PR updates the help text for:

- `pr checks`
- `pr comment`
- `pr diff`
- `pr edit`
- `pr merge`
- `pr ready`

I've been using some of these subcommands this way for some time now but I guess new users may not know about it.