### PR TITLE
Fix extracting workflow artifact to a relative path

### DIFF
--- a/pkg/cmd/run/download/zip.go
+++ b/pkg/cmd/run/download/zip.go
@@ -16,9 +16,13 @@ const (
 )
 
 func extractZip(zr *zip.Reader, destDir string) error {
-	pathPrefix := filepath.Clean(destDir) + string(filepath.Separator)
+	destDirAbs, err := filepath.Abs(destDir)
+	if err != nil {
+		return err
+	}
+	pathPrefix := destDirAbs + string(filepath.Separator)
 	for _, zf := range zr.File {
-		fpath := filepath.Join(destDir, filepath.FromSlash(zf.Name))
+		fpath := filepath.Join(destDirAbs, filepath.FromSlash(zf.Name))
 		if !strings.HasPrefix(fpath, pathPrefix) {
 			continue
 		}

--- a/pkg/cmd/run/download/zip_test.go
+++ b/pkg/cmd/run/download/zip_test.go
@@ -1,0 +1,32 @@
+package download
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_extractZip(t *testing.T) {
+	tmpDir := t.TempDir()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	zipFile, err := zip.OpenReader("./fixtures/myproject.zip")
+	require.NoError(t, err)
+	defer zipFile.Close()
+
+	extractPath := filepath.Join(tmpDir, "artifact")
+	err = os.MkdirAll(extractPath, 0700)
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(extractPath))
+
+	err = extractZip(&zipFile.Reader, ".")
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join("src", "main.go"))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
To prevent zipslip, we verify that each extracted file would fall strictly under the prefix of the path to extract to. However, this yielded a false positive when extracting to `.`, which is the default for downloading a single archive.

Bug reported by @vilmibm
