### PR TITLE
actions wrap up

### DIFF
--- a/pkg/cmd/actions/actions.go
+++ b/pkg/cmd/actions/actions.go
@@ -47,7 +47,7 @@ func actionsExplainer(cs *iostreams.ColorScheme) string {
 	return heredoc.Docf(`
 			%s
 
-			gh integrates with Actions to help you manage runs and workflows.
+			GitHub CLI integrates with Actions to help you manage runs and workflows.
 
 			%s
 			gh run list:      List recent workflow runs

--- a/pkg/cmd/actions/actions.go
+++ b/pkg/cmd/actions/actions.go
@@ -19,10 +19,9 @@ func NewCmdActions(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:    "actions",
-		Short:  "Learn about working with GitHub actions",
-		Long:   actionsExplainer(nil),
-		Hidden: true,
+		Use:   "actions",
+		Short: "Learn about working with GitHub actions",
+		Long:  actionsExplainer(nil),
 		Run: func(cmd *cobra.Command, args []string) {
 			actionsRun(opts)
 		},

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultLimit = 10
+	defaultLimit = 20
 )
 
 type ListOptions struct {

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -36,10 +36,9 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:    "list",
-		Short:  "List recent workflow runs",
-		Args:   cobra.NoArgs,
-		Hidden: true,
+		Use:   "list",
+		Short: "List recent workflow runs",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -31,7 +31,7 @@ func NewCmdRerun(f *cmdutil.Factory, runF func(*RerunOptions) error) *cobra.Comm
 
 	cmd := &cobra.Command{
 		Use:   "rerun [<run-id>]",
-		Short: "Rerun a given run",
+		Short: "Rerun a failed run",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override

--- a/pkg/cmd/run/run.go
+++ b/pkg/cmd/run/run.go
@@ -12,10 +12,9 @@ import (
 
 func NewCmdRun(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "run <command>",
-		Short:  "View details about workflow runs",
-		Long:   "List, view, and watch recent workflow runs from GitHub Actions.",
-		Hidden: true,
+		Use:   "run <command>",
+		Short: "View details about workflow runs",
+		Long:  "List, view, and watch recent workflow runs from GitHub Actions.",
 		Annotations: map[string]string{
 			"IsActions": "true",
 		},

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -87,10 +87,9 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:    "view [<run-id>]",
-		Short:  "View a summary of a workflow run",
-		Args:   cobra.MaximumNArgs(1),
-		Hidden: true,
+		Use:   "view [<run-id>]",
+		Short: "View a summary of a workflow run",
+		Args:  cobra.MaximumNArgs(1),
 		Example: heredoc.Doc(`
 		  # Interactively select a run to view, optionally drilling down to a job
 		  $ gh run view

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -308,7 +308,7 @@ func runView(opts *ViewOptions) error {
 	fmt.Fprintln(out, shared.RenderRunHeader(cs, *run, utils.FuzzyAgo(ago), prNumber))
 	fmt.Fprintln(out)
 
-	if len(jobs) == 0 && run.Conclusion == shared.Failure {
+	if len(jobs) == 0 && run.Conclusion == shared.Failure || run.Conclusion == shared.StartupFailure {
 		fmt.Fprintf(out, "%s %s\n",
 			cs.FailureIcon(),
 			cs.Bold("This run likely failed because of a workflow file issue."))

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -91,20 +91,20 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 		Short: "View a summary of a workflow run",
 		Args:  cobra.MaximumNArgs(1),
 		Example: heredoc.Doc(`
-		  # Interactively select a run to view, optionally drilling down to a job
-		  $ gh run view
-
-		  # View a specific run
-		  $ gh run view 12345
-
+			# Interactively select a run to view, optionally selecting a single job
+			$ gh run view
+			
+			# View a specific run
+			$ gh run view 12345
+			
 			# View a specific job within a run
 			$ gh run view --job 456789
-
+			
 			# View the full log for a specific job
 			$ gh run view --log --job 456789
-
-		  # Exit non-zero if a run failed
-		  $ gh run view 0451 --exit-status && echo "run pending or passed"
+			
+			# Exit non-zero if a run failed
+			$ gh run view 0451 --exit-status && echo "run pending or passed"
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -771,6 +771,44 @@ func TestViewRun(t *testing.T) {
 			browsedURL: "jobs/10?check_suite_focus=true",
 			wantOut:    "Opening jobs/10 in your browser.\n",
 		},
+		{
+			name: "hide job header, failure",
+			tty:  true,
+			opts: &ViewOptions{
+				RunID: "123",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/123"),
+					httpmock.JSONResponse(shared.TestRun("failed no job", 123, shared.Completed, shared.Failure)))
+				reg.Register(
+					httpmock.REST("GET", "runs/123/jobs"),
+					httpmock.JSONResponse(shared.JobsPayload{Jobs: []shared.Job{}}))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/123/artifacts"),
+					httpmock.StringResponse(`{}`))
+			},
+			wantOut: "\nX trunk failed no job · 123\nTriggered via push about 59 minutes ago\n\nX This run likely failed because of a workflow file issue.\n\nFor more information, see: runs/123\n",
+		},
+		{
+			name: "hide job header, startup_failure",
+			tty:  true,
+			opts: &ViewOptions{
+				RunID: "123",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/123"),
+					httpmock.JSONResponse(shared.TestRun("failed no job", 123, shared.Completed, shared.StartupFailure)))
+				reg.Register(
+					httpmock.REST("GET", "runs/123/jobs"),
+					httpmock.JSONResponse(shared.JobsPayload{Jobs: []shared.Job{}}))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/123/artifacts"),
+					httpmock.StringResponse(`{}`))
+			},
+			wantOut: "\nX trunk failed no job · 123\nTriggered via push about 59 minutes ago\n\nX This run likely failed because of a workflow file issue.\n\nFor more information, see: runs/123\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -42,9 +42,6 @@ func NewCmdWatch(f *cmdutil.Factory, runF func(*WatchOptions) error) *cobra.Comm
 	cmd := &cobra.Command{
 		Use:   "watch <run-selector>",
 		Short: "Watch a run until it completes, showing its progress",
-		Annotations: map[string]string{
-			"IsActions": "true",
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/cmd/run/shared"
@@ -40,8 +41,15 @@ func NewCmdWatch(f *cmdutil.Factory, runF func(*WatchOptions) error) *cobra.Comm
 	}
 
 	cmd := &cobra.Command{
-		Use:   "watch <run-selector>",
+		Use:   "watch <run-id>",
 		Short: "Watch a run until it completes, showing its progress",
+		Example: heredoc.Doc(`
+			# Watch a run until it's done
+			gh run watch
+
+			# Run some other command when the run is finished
+			gh run watch && notify-send "run is done!"
+		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/workflow/disable/disable.go
+++ b/pkg/cmd/workflow/disable/disable.go
@@ -31,6 +31,7 @@ func NewCmdDisable(f *cmdutil.Factory, runF func(*DisableOptions) error) *cobra.
 	cmd := &cobra.Command{
 		Use:   "disable [<workflow ID> | <workflow name>]",
 		Short: "Disable a workflow",
+		Long:  "Disable a workflow, preventing it from running or showing up when listing workflows.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override

--- a/pkg/cmd/workflow/disable/disable.go
+++ b/pkg/cmd/workflow/disable/disable.go
@@ -29,7 +29,7 @@ func NewCmdDisable(f *cmdutil.Factory, runF func(*DisableOptions) error) *cobra.
 	}
 
 	cmd := &cobra.Command{
-		Use:   "disable [<workflow ID> | <workflow name>]",
+		Use:   "disable [<workflow-id> | <workflow-name>]",
 		Short: "Disable a workflow",
 		Long:  "Disable a workflow, preventing it from running or showing up when listing workflows.",
 		Args:  cobra.MaximumNArgs(1),

--- a/pkg/cmd/workflow/enable/enable.go
+++ b/pkg/cmd/workflow/enable/enable.go
@@ -29,7 +29,7 @@ func NewCmdEnable(f *cmdutil.Factory, runF func(*EnableOptions) error) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Use:   "enable [<workflow ID> | <workflow name>]",
+		Use:   "enable [<workflow-id> | <workflow-name>]",
 		Short: "Enable a workflow",
 		Long:  "Enable a workflow, allowing it to be run and show up when listing workflows.",
 		Args:  cobra.MaximumNArgs(1),

--- a/pkg/cmd/workflow/enable/enable.go
+++ b/pkg/cmd/workflow/enable/enable.go
@@ -31,6 +31,7 @@ func NewCmdEnable(f *cmdutil.Factory, runF func(*EnableOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "enable [<workflow ID> | <workflow name>]",
 		Short: "Enable a workflow",
+		Long:  "Enable a workflow, allowing it to be run and show up when listing workflows.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override

--- a/pkg/cmd/workflow/list/list.go
+++ b/pkg/cmd/workflow/list/list.go
@@ -34,7 +34,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List GitHub Actions workflows",
+		Short: "List workflows",
+		Long:  "List workflow files, hiding disabled workflows by default.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -47,7 +47,7 @@ func NewCmdRun(f *cmdutil.Factory, runF func(*RunOptions) error) *cobra.Command 
 
 	cmd := &cobra.Command{
 		Use:   "run [<workflow-ID> | <workflow-name>]",
-		Short: "Create a dispatch event for a workflow, starting a run",
+		Short: "Run a workflow by creating a workflow_dispatch event",
 		Long: heredoc.Doc(`
 			Create a workflow_dispatch event for a given workflow.
 

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -46,7 +46,7 @@ func NewCmdRun(f *cmdutil.Factory, runF func(*RunOptions) error) *cobra.Command 
 	}
 
 	cmd := &cobra.Command{
-		Use:   "run [<workflow-ID> | <workflow-name>]",
+		Use:   "run [<workflow-id> | <workflow-name>]",
 		Short: "Run a workflow by creating a workflow_dispatch event",
 		Long: heredoc.Doc(`
 			Create a workflow_dispatch event for a given workflow.

--- a/pkg/cmd/workflow/view/view.go
+++ b/pkg/cmd/workflow/view/view.go
@@ -40,7 +40,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "view [<workflow-id> | <workflow name> | <file name>]",
+		Use:   "view [<workflow-id> | <workflow-name> | <filename>]",
 		Short: "View the summary of a workflow",
 		Args:  cobra.MaximumNArgs(1),
 		Example: heredoc.Doc(`

--- a/pkg/cmd/workflow/view/view.go
+++ b/pkg/cmd/workflow/view/view.go
@@ -40,10 +40,9 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:    "view [<workflow-id> | <workflow name> | <file name>]",
-		Short:  "View the summary of a workflow",
-		Args:   cobra.MaximumNArgs(1),
-		Hidden: true,
+		Use:   "view [<workflow-id> | <workflow name> | <file name>]",
+		Short: "View the summary of a workflow",
+		Args:  cobra.MaximumNArgs(1),
 		Example: heredoc.Doc(`
 		  # Interactively select a workflow to view
 		  $ gh workflow view

--- a/pkg/cmd/workflow/workflow.go
+++ b/pkg/cmd/workflow/workflow.go
@@ -12,10 +12,9 @@ import (
 
 func NewCmdWorkflow(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "workflow <command>",
-		Short:  "View details about GitHub Actions workflows",
-		Long:   "List, view, and run workflows in GitHub Actions.",
-		Hidden: true,
+		Use:   "workflow <command>",
+		Short: "View details about GitHub Actions workflows",
+		Long:  "List, view, and run workflows in GitHub Actions.",
 		Annotations: map[string]string{
 			"IsActions": "true",
 		},


### PR DESCRIPTION
This PR includes a flurry of small fixes for gh+actions.

- Unhides actions commands for release
- Accounts for a conclusion of `startup_failure` in `run view` which can happen when a workflow file is broken. Also adds tests to cover this behavior.
- Wording change in `gh actions` i missed when ampinsk reviewed the `gh actions` PR yesterday.
- Fixes some misplaced annotations and hidings
- Updates or clarifies usage for all new commands
