### PR TITLE
add Debian install variant without add-apt-repository

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -13,7 +13,7 @@ If none of our official binaries, packages, repositories, nor community sources 
 
 ### Debian, Ubuntu Linux (apt)
 
-Install:
+Install (Using apt-key):
 
 ```bash
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
@@ -29,6 +29,13 @@ sudo apt install gh
 **Note**: most systems will have `apt-add-repository` already. If you get a _command not found_
 error, try running `sudo apt install software-properties-common` and trying these steps again.
 
+Install (without add-apt-repository, with limited keyring scope):
+```bash
+sudo apt-key --keyring /usr/share/keyrings/githubcli-archive-keyring.gpg adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/github-cli2.list > /dev/null
+sudo apt update
+sudo apt install gh
+```
 
 Upgrade:
 


### PR DESCRIPTION
The Debian docs [recommend installing third-party repos with limited keyring scopes](https://wiki.debian.org/DebianRepository/UseThirdParty) these days.

This PR adds a variant to the install instruction for Debian-compatible distros that uses this method (and doesn't require `software-properties-common`) since `add-apt-key` is deprecated.