### PR TITLE
hotfix: create cache dir in run view

### DIFF
--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -45,6 +45,11 @@ func (rlc) Exists(path string) bool {
 	return true
 }
 func (rlc) Create(path string, content io.ReadCloser) error {
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	if err != nil {
+		return fmt.Errorf("could not create cache: %w", err)
+	}
+
 	out, err := os.Create(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
Running `run view --log` or `run view --log-failed` breaks on a cold gh cli cache; this creates the cache dir if it's not already there.

as this is an urgent hot fix we'll worry about covering with tests later.
