### PR TITLE
use int64 explicitly in Actions support

### DIFF
--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -132,7 +132,7 @@ func TestListRun(t *testing.T) {
 				Limit: 101,
 			},
 			stubs: func(reg *httpmock.Registry) {
-				runID := 0
+				var runID int64
 				runs := []shared.Run{}
 				for runID < 103 {
 					runs = append(runs, shared.TestRun(fmt.Sprintf("%d", runID), runID, shared.InProgress, ""))

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -48,7 +48,7 @@ type Run struct {
 	Status         Status
 	Conclusion     Conclusion
 	Event          string
-	ID             int
+	ID             int64
 	HeadBranch     string `json:"head_branch"`
 	JobsURL        string `json:"jobs_url"`
 	HeadCommit     Commit `json:"head_commit"`
@@ -78,7 +78,7 @@ func (r Run) CommitMsg() string {
 }
 
 type Job struct {
-	ID          int
+	ID          int64
 	Status      Status
 	Conclusion  Conclusion
 	Name        string
@@ -86,7 +86,7 @@ type Job struct {
 	StartedAt   time.Time `json:"started_at"`
 	CompletedAt time.Time `json:"completed_at"`
 	URL         string    `json:"html_url"`
-	RunID       int       `json:"run_id"`
+	RunID       int64     `json:"run_id"`
 }
 
 type Step struct {
@@ -123,7 +123,7 @@ func AnnotationSymbol(cs *iostreams.ColorScheme, a Annotation) string {
 }
 
 type CheckRun struct {
-	ID int
+	ID int64
 }
 
 func GetAnnotations(client *api.Client, repo ghrepo.Interface, job Job) ([]Annotation, error) {
@@ -179,7 +179,7 @@ func GetRunsWithFilter(client *api.Client, repo ghrepo.Interface, limit int, f f
 	return filtered, nil
 }
 
-func GetRunsByWorkflow(client *api.Client, repo ghrepo.Interface, limit, workflowID int) ([]Run, error) {
+func GetRunsByWorkflow(client *api.Client, repo ghrepo.Interface, limit int, workflowID int64) ([]Run, error) {
 	path := fmt.Sprintf("repos/%s/actions/workflows/%d/runs", ghrepo.FullName(repo), workflowID)
 	return getRuns(client, repo, path, limit)
 }

--- a/pkg/cmd/run/shared/test.go
+++ b/pkg/cmd/run/shared/test.go
@@ -16,7 +16,7 @@ func updated() time.Time {
 	return updated
 }
 
-func TestRun(name string, id int, s Status, c Conclusion) Run {
+func TestRun(name string, id int64, s Status, c Conclusion) Run {
 	return Run{
 		Name:       name,
 		ID:         id,

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -280,7 +280,7 @@ func runView(opts *ViewOptions) error {
 
 	var artifacts []shared.Artifact
 	if selectedJob == nil {
-		artifacts, err = shared.ListArtifacts(httpClient, repo, strconv.Itoa(run.ID))
+		artifacts, err = shared.ListArtifacts(httpClient, repo, strconv.FormatInt(int64(run.ID), 10))
 		if err != nil {
 			return fmt.Errorf("failed to get artifacts: %w", err)
 		}

--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -136,7 +136,7 @@ func watchRun(opts *WatchOptions) error {
 	// clear entire screen
 	fmt.Fprintf(out, "\x1b[2J")
 
-	annotationCache := map[int][]shared.Annotation{}
+	annotationCache := map[int64][]shared.Annotation{}
 
 	duration, err := time.ParseDuration(fmt.Sprintf("%ds", opts.Interval))
 	if err != nil {
@@ -166,7 +166,7 @@ func watchRun(opts *WatchOptions) error {
 	return nil
 }
 
-func renderRun(opts WatchOptions, client *api.Client, repo ghrepo.Interface, run *shared.Run, prNumber string, annotationCache map[int][]shared.Annotation) (*shared.Run, error) {
+func renderRun(opts WatchOptions, client *api.Client, repo ghrepo.Interface, run *shared.Run, prNumber string, annotationCache map[int64][]shared.Annotation) (*shared.Run, error) {
 	out := opts.IO.Out
 	cs := opts.IO.ColorScheme()
 

--- a/pkg/cmd/workflow/list/list_test.go
+++ b/pkg/cmd/workflow/list/list_test.go
@@ -148,7 +148,8 @@ func TestListRun(t *testing.T) {
 			},
 			stubs: func(reg *httpmock.Registry) {
 				workflows := []shared.Workflow{}
-				for flowID := 0; flowID < 103; flowID++ {
+				var flowID int64
+				for flowID = 0; flowID < 103; flowID++ {
 					workflows = append(workflows, shared.Workflow{
 						ID:    flowID,
 						Name:  fmt.Sprintf("flow %d", flowID),

--- a/pkg/cmd/workflow/shared/shared.go
+++ b/pkg/cmd/workflow/shared/shared.go
@@ -24,7 +24,7 @@ type WorkflowState string
 
 type Workflow struct {
 	Name  string
-	ID    int
+	ID    int64
 	Path  string
 	State WorkflowState
 }


### PR DESCRIPTION
A user reported in #3431 that they were unable to use new Actions features on a
32bit OS. The most immediate fix was to just change from the default `int` to
explicit `int64` for run, workflow, and checkrun IDs.

Question:

- Is there a more elegant approach here?
- Can we have a 32bit runner in our build matrix? If so, is it worth the additional build overhead?
- Are we comfortable continuing to support 32bit OSes?

I'll adapt this PR based on the discussion.

