### PR TITLE
Increase linter timeout from 1min to 3min

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           go mod verify
           go mod download
 
-          LINT_VERSION=1.34.1
+          LINT_VERSION=1.39.0
           curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v${LINT_VERSION}/golangci-lint-${LINT_VERSION}-linux-amd64.tar.gz | \
             tar xz --strip-components 1 --wildcards \*/golangci-lint
           mkdir -p bin && mv golangci-lint bin/
@@ -50,6 +50,6 @@ jobs:
           assert-nothing-changed go fmt ./...
           assert-nothing-changed go mod tidy
 
-          bin/golangci-lint run --out-format github-actions || STATUS=$?
+          bin/golangci-lint run --out-format=github-actions --timeout=3m || STATUS=$?
 
           exit $STATUS


### PR DESCRIPTION
Hopefully avoids CI failures like https://github.com/cli/cli/runs/2379956774