### PR TITLE
linuxbrew details added in linux installation docs.

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -103,7 +103,7 @@ Android 7+ users can install via [Termux](https://wiki.termux.com/wiki/Main_Page
 pkg install gh
 ```
 
-### Homebrew(Linuxbrew)
+### Homebrew (Linuxbrew)
 
 Linuxbrew user can install it as a [brew package](https://formulae.brew.sh/formula/gh#default):
 ```bash

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -105,7 +105,7 @@ pkg install gh
 
 ### Homebrew (Linuxbrew)
 
-Linuxbrew user can install it as a [brew package](https://formulae.brew.sh/formula/gh#default):
+Linuxbrew users can install it as a [brew package](https://formulae.brew.sh/formula/gh#default):
 ```bash
 brew install gh
 ```

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -103,6 +103,13 @@ Android 7+ users can install via [Termux](https://wiki.termux.com/wiki/Main_Page
 pkg install gh
 ```
 
+### Homebrew(Linuxbrew)
+
+Linuxbrew user can install it as a [brew package](https://formulae.brew.sh/formula/gh#default):
+```bash
+brew install gh
+```
+
 ### FreeBSD
 
 FreeBSD users can install from the [ports collection](https://www.freshports.org/devel/gh/):


### PR DESCRIPTION
Installations with linuxbrew is listed in `Readme.md` [here](https://github.com/cli/cli#linux).
But not listed in [Linux installation docs](https://github.com/cli/cli/blob/trunk/docs/install_linux.md).

Linuxbrew is very popular as it help to handle things efficiently.


### whats added?
brew added in linux installations docs.

### whats removed?
Nothing.