### PR TITLE
using filepath.Join() instead of path.Join() to fix wrong filepath on Windows

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -259,7 +258,7 @@ func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {
 	}
 
 	repo := updaterEnabled
-	stateFilePath := path.Join(config.ConfigDir(), "state.yml")
+	stateFilePath := filepath.Join(config.ConfigDir(), "state.yml")
 	return update.CheckForUpdate(client, stateFilePath, repo, currentVersion)
 }
 

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -28,11 +28,11 @@ func ConfigDir() string {
 }
 
 func ConfigFile() string {
-	return path.Join(ConfigDir(), "config.yml")
+	return filepath.Join(ConfigDir(), "config.yml")
 }
 
 func HostsConfigFile() string {
-	return path.Join(ConfigDir(), "hosts.yml")
+	return filepath.Join(ConfigDir(), "hosts.yml")
 }
 
 func ParseDefaultConfig() (Config, error) {

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_parseConfig(t *testing.T) {
-	defer StubConfig(`---
+	defer stubConfig(`---
 hosts:
   github.com:
     user: monalisa
@@ -28,7 +28,7 @@ hosts:
 }
 
 func Test_parseConfig_multipleHosts(t *testing.T) {
-	defer StubConfig(`---
+	defer stubConfig(`---
 hosts:
   example.com:
     user: wronguser
@@ -48,7 +48,7 @@ hosts:
 }
 
 func Test_parseConfig_hostsFile(t *testing.T) {
-	defer StubConfig("", `---
+	defer stubConfig("", `---
 github.com:
   user: monalisa
   oauth_token: OTOKEN
@@ -64,7 +64,7 @@ github.com:
 }
 
 func Test_parseConfig_hostFallback(t *testing.T) {
-	defer StubConfig(`---
+	defer stubConfig(`---
 git_protocol: ssh
 `, `---
 github.com:
@@ -89,7 +89,7 @@ example.com:
 }
 
 func Test_parseConfig_migrateConfig(t *testing.T) {
-	defer StubConfig(`---
+	defer stubConfig(`---
 github.com:
   - user: keiyuri
     oauth_token: 123456
@@ -134,7 +134,7 @@ func Test_parseConfigFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("contents: %q", tt.contents), func(t *testing.T) {
-			defer StubConfig(tt.contents, "")()
+			defer stubConfig(tt.contents, "")()
 			_, yamlRoot, err := parseConfigFile("config.yml")
 			if tt.wantsErr != (err != nil) {
 				t.Fatalf("got error: %v", err)

--- a/internal/config/testing.go
+++ b/internal/config/testing.go
@@ -37,7 +37,7 @@ func StubWriteConfig(wc io.Writer, wh io.Writer) func() {
 	}
 }
 
-func StubConfig(main, hosts string) func() {
+func stubConfig(main, hosts string) func() {
 	orig := ReadConfigFile
 	ReadConfigFile = func(fn string) ([]byte, error) {
 		switch path.Base(fn) {

--- a/internal/config/testing.go
+++ b/internal/config/testing.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 )
 
 func StubBackupConfig() func() {
@@ -21,7 +21,7 @@ func StubBackupConfig() func() {
 func StubWriteConfig(wc io.Writer, wh io.Writer) func() {
 	orig := WriteConfigFile
 	WriteConfigFile = func(fn string, data []byte) error {
-		switch path.Base(fn) {
+		switch filepath.Base(fn) {
 		case "config.yml":
 			_, err := wc.Write(data)
 			return err
@@ -40,7 +40,7 @@ func StubWriteConfig(wc io.Writer, wh io.Writer) func() {
 func stubConfig(main, hosts string) func() {
 	orig := ReadConfigFile
 	ReadConfigFile = func(fn string) ([]byte, error) {
-		switch path.Base(fn) {
+		switch filepath.Base(fn) {
 		case "config.yml":
 			if main == "" {
 				return []byte(nil), os.ErrNotExist


### PR DESCRIPTION
PS C:\Users\Junjie Yuan> gh auth status
github.com
  ✓ Logged in to github.com as junjieyuan (C:\Users\Junjie Yuan\.config\gh/hosts.yml)
  ✓ Git operations for github.com configured to use https protocol.
  ✓ Token: *******************

Signed-off-by: Junjie Yuan <yuan@junjie.pro>