### PR TITLE
tweak secret set to allow prompting

### DIFF
--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/httpmock"
 	"github.com/cli/cli/pkg/iostreams"
+	"github.com/cli/cli/pkg/prompt"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
 )
@@ -49,12 +50,6 @@ func TestNewCmdSet(t *testing.T) {
 		{
 			name:     "multiple names",
 			cli:      "cool_secret good_secret",
-			wantsErr: true,
-		},
-		{
-			name:     "no body, stdin is terminal",
-			cli:      "cool_secret",
-			stdinTTY: true,
 			wantsErr: true,
 		},
 		{
@@ -325,4 +320,22 @@ func Test_getBody(t *testing.T) {
 			assert.Equal(t, string(body), tt.want)
 		})
 	}
+}
+
+func Test_getBodyPrompt(t *testing.T) {
+	io, _, _, _ := iostreams.Test()
+
+	io.SetStdinTTY(true)
+	io.SetStdoutTTY(true)
+
+	as, teardown := prompt.InitAskStubber()
+	defer teardown()
+
+	as.StubOne("cool secret")
+
+	body, err := getBody(&SetOptions{
+		IO: io,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, string(body), "cool secret")
 }


### PR DESCRIPTION
This PR augments `gh secret set` to prompt in the event that no secret body is provided. This case was formerly an error, so I don't think it qualifies as a breaking change.

This closes a gap in `secret set` I've been meaning to get to since it initially released. Originally I had a whole interactive wizard for this, but realized all anyone really wants is the ability to paste a secret body (instead of putting it in a file).

Before:

```bash
gh secret set foo
# => error since nothing on STDIN and no --body
```

After:
```bash
gh secret set foo
? Paste your secret: *****
✓ Set secret foo for vilmibm/testing
```

Using STDIN still works as before (`gh secret set foo < secret.txt`).

There's no issue for this (I think), it's just been taking up space in my mental TODO list for months.
