### PR TITLE
handle 404 for annotations

### DIFF
--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -133,6 +134,11 @@ func GetAnnotations(client *api.Client, repo ghrepo.Interface, job Job) ([]Annot
 
 	err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
 	if err != nil {
+		var notFound *api.NotFoundError
+		if !errors.As(err, &notFound) {
+			return []Annotation{}, nil
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #3474

Sometimes when a run is still going, annotations can 404 for its jobs. That should just be ignored.
