### PR TITLE
Improve issue status detection

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -26,7 +26,6 @@ type Issue struct {
 	Title          string
 	URL            string
 	State          string
-	Closed         bool
 	Body           string
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
@@ -237,7 +236,6 @@ func IssueByNumber(client *Client, repo ghrepo.Interface, number int) (*Issue, e
 				id
 				title
 				state
-				closed
 				body
 				author {
 					login

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -26,6 +26,7 @@ type Issue struct {
 	Title          string
 	URL            string
 	State          string
+	Closed         bool
 	Body           string
 	CreatedAt      time.Time
 	UpdatedAt      time.Time

--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -65,7 +65,7 @@ func closeRun(opts *CloseOptions) error {
 		return err
 	}
 
-	if issue.Closed {
+	if issue.State == "CLOSED" {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Issue #%d (%s) is already closed\n", cs.Yellow("!"), issue.Number, issue.Title)
 		return nil
 	}

--- a/pkg/cmd/issue/close/close_test.go
+++ b/pkg/cmd/issue/close/close_test.go
@@ -96,7 +96,7 @@ func TestIssueClose_alreadyClosed(t *testing.T) {
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
 				"hasIssuesEnabled": true,
-				"issue": { "number": 13, "title": "The title of the issue", "closed": true}
+				"issue": { "number": 13, "title": "The title of the issue", "state": "CLOSED"}
 			} } }`),
 	)
 

--- a/pkg/cmd/issue/reopen/reopen.go
+++ b/pkg/cmd/issue/reopen/reopen.go
@@ -65,7 +65,7 @@ func reopenRun(opts *ReopenOptions) error {
 		return err
 	}
 
-	if !issue.Closed {
+	if issue.State == "OPEN" {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Issue #%d (%s) is already open\n", cs.Yellow("!"), issue.Number, issue.Title)
 		return nil
 	}

--- a/pkg/cmd/issue/reopen/reopen_test.go
+++ b/pkg/cmd/issue/reopen/reopen_test.go
@@ -64,7 +64,7 @@ func TestIssueReopen(t *testing.T) {
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
 				"hasIssuesEnabled": true,
-				"issue": { "id": "THE-ID", "number": 2, "closed": true, "title": "The title of the issue"}
+				"issue": { "id": "THE-ID", "number": 2, "state": "CLOSED", "title": "The title of the issue"}
 			} } }`),
 	)
 	http.Register(
@@ -96,7 +96,7 @@ func TestIssueReopen_alreadyOpen(t *testing.T) {
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
 				"hasIssuesEnabled": true,
-				"issue": { "number": 2, "closed": false, "title": "The title of the issue"}
+				"issue": { "number": 2, "state": "OPEN", "title": "The title of the issue"}
 			} } }`),
 	)
 

--- a/pkg/cmd/issue/transfer/transfer_test.go
+++ b/pkg/cmd/issue/transfer/transfer_test.go
@@ -118,7 +118,7 @@ func Test_transferRunSuccessfulIssueTransfer(t *testing.T) {
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
 				"hasIssuesEnabled": true,
-				"issue": { "id": "THE-ID", "number": 1234, "closed": true, "title": "The title of the issue"}
+				"issue": { "id": "THE-ID", "number": 1234, "title": "The title of the issue"}
 			} } }`))
 
 	http.Register(


### PR DESCRIPTION
This PR makes `gh` rely on the `state` field to detect the current issue status (either `OPEN` or `CLOSED`) instead of the `closed` field.

See #3351 