### PR TITLE
Fix exporting `milestone` for issues and PRs

### DIFF
--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -6,7 +6,6 @@ import (
 )
 
 func (issue *Issue) ExportData(fields []string) *map[string]interface{} {
-	v := reflect.ValueOf(issue).Elem()
 	data := map[string]interface{}{}
 
 	for _, f := range fields {
@@ -26,6 +25,7 @@ func (issue *Issue) ExportData(fields []string) *map[string]interface{} {
 		case "projectCards":
 			data[f] = issue.ProjectCards.Nodes
 		default:
+			v := reflect.ValueOf(issue).Elem()
 			sf := fieldByName(v, f)
 			data[f] = sf.Interface()
 		}
@@ -35,7 +35,6 @@ func (issue *Issue) ExportData(fields []string) *map[string]interface{} {
 }
 
 func (pr *PullRequest) ExportData(fields []string) *map[string]interface{} {
-	v := reflect.ValueOf(pr).Elem()
 	data := map[string]interface{}{}
 
 	for _, f := range fields {
@@ -76,6 +75,7 @@ func (pr *PullRequest) ExportData(fields []string) *map[string]interface{} {
 			}
 			data[f] = &requests
 		default:
+			v := reflect.ValueOf(pr).Elem()
 			sf := fieldByName(v, f)
 			data[f] = sf.Interface()
 		}
@@ -86,16 +86,16 @@ func (pr *PullRequest) ExportData(fields []string) *map[string]interface{} {
 
 func ExportIssues(issues []Issue, fields []string) *[]interface{} {
 	data := make([]interface{}, len(issues))
-	for i, issue := range issues {
-		data[i] = issue.ExportData(fields)
+	for i := range issues {
+		data[i] = issues[i].ExportData(fields)
 	}
 	return &data
 }
 
 func ExportPRs(prs []PullRequest, fields []string) *[]interface{} {
 	data := make([]interface{}, len(prs))
-	for i, pr := range prs {
-		data[i] = pr.ExportData(fields)
+	for i := range prs {
+		data[i] = prs[i].ExportData(fields)
 	}
 	return &data
 }

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -32,6 +32,21 @@ func TestIssue_ExportData(t *testing.T) {
 			`),
 		},
 		{
+			name:   "milestone",
+			fields: []string{"number", "milestone"},
+			inputJSON: heredoc.Doc(`
+				{ "number": 2345, "milestone": {"title": "The next big thing"} }
+			`),
+			outputJSON: heredoc.Doc(`
+				{
+					"milestone": {
+						"title": "The next big thing"
+					},
+					"number": 2345
+				}
+			`),
+		},
+		{
 			name:   "project cards",
 			fields: []string{"projectCards"},
 			inputJSON: heredoc.Doc(`
@@ -75,6 +90,31 @@ func TestIssue_ExportData(t *testing.T) {
 	}
 }
 
+func TestExportIssues(t *testing.T) {
+	issues := []Issue{
+		{Milestone: Milestone{Title: "hi"}},
+		{},
+	}
+	exported := ExportIssues(issues, []string{"milestone"})
+
+	buf := bytes.Buffer{}
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "\t")
+	require.NoError(t, enc.Encode(exported))
+	assert.Equal(t, heredoc.Doc(`
+		[
+			{
+				"milestone": {
+					"title": "hi"
+				}
+			},
+			{
+				"milestone": null
+			}
+		]
+	`), buf.String())
+}
+
 func TestPullRequest_ExportData(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -92,6 +132,21 @@ func TestPullRequest_ExportData(t *testing.T) {
 				{
 					"number": 2345,
 					"title": "Bugs hugs"
+				}
+			`),
+		},
+		{
+			name:   "milestone",
+			fields: []string{"number", "milestone"},
+			inputJSON: heredoc.Doc(`
+				{ "number": 2345, "milestone": {"title": "The next big thing"} }
+			`),
+			outputJSON: heredoc.Doc(`
+				{
+					"milestone": {
+						"title": "The next big thing"
+					},
+					"number": 2345
 				}
 			`),
 		},


### PR DESCRIPTION
There was a weird pointer bug which would cause a null milestone to erase "milestone" fields for previous entries in the list.

Fixes #3516
