### PR TITLE
Support standard path variable replacement syntax

### DIFF
--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -978,7 +978,7 @@ func Test_fillPlaceholders(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "has substitutes",
+			name: "has substitutes (colon)",
 			args: args{
 				value: "repos/:owner/:repo/releases",
 				opts: &ApiOptions{
@@ -991,39 +991,37 @@ func Test_fillPlaceholders(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "has branch placeholder",
+			name: "has branch placeholder (colon)",
 			args: args{
-				value: "repos/cli/cli/branches/:branch/protection/required_status_checks",
+				value: "repos/owner/repo/branches/:branch/protection/required_status_checks",
 				opts: &ApiOptions{
-					BaseRepo: func() (ghrepo.Interface, error) {
-						return ghrepo.New("cli", "cli"), nil
-					},
+					BaseRepo: nil,
 					Branch: func() (string, error) {
 						return "trunk", nil
 					},
 				},
 			},
-			want:    "repos/cli/cli/branches/trunk/protection/required_status_checks",
+			want:    "repos/owner/repo/branches/trunk/protection/required_status_checks",
 			wantErr: false,
 		},
 		{
-			name: "has branch placeholder and git is in detached head",
+			name: "has branch placeholder and git is in detached head (colon)",
 			args: args{
 				value: "repos/:owner/:repo/branches/:branch",
 				opts: &ApiOptions{
 					BaseRepo: func() (ghrepo.Interface, error) {
-						return ghrepo.New("cli", "cli"), nil
+						return ghrepo.New("hubot", "robot-uprising"), nil
 					},
 					Branch: func() (string, error) {
 						return "", git.ErrNotOnAnyBranch
 					},
 				},
 			},
-			want:    "repos/:owner/:repo/branches/:branch",
+			want:    "repos/hubot/robot-uprising/branches/:branch",
 			wantErr: true,
 		},
 		{
-			name: "has substitutes (braces)",
+			name: "has substitutes",
 			args: args{
 				value: "repos/{owner}/{repo}/releases",
 				opts: &ApiOptions{
@@ -1036,39 +1034,53 @@ func Test_fillPlaceholders(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "has branch placeholder (braces)",
+			name: "has branch placeholder",
 			args: args{
-				value: "repos/cli/cli/branches/{branch}/protection/required_status_checks",
+				value: "repos/owner/repo/branches/{branch}/protection/required_status_checks",
 				opts: &ApiOptions{
-					BaseRepo: func() (ghrepo.Interface, error) {
-						return ghrepo.New("cli", "cli"), nil
-					},
+					BaseRepo: nil,
 					Branch: func() (string, error) {
 						return "trunk", nil
 					},
 				},
 			},
-			want:    "repos/cli/cli/branches/trunk/protection/required_status_checks",
+			want:    "repos/owner/repo/branches/trunk/protection/required_status_checks",
 			wantErr: false,
 		},
 		{
-			name: "has branch placeholder and git is in detached head (braces)",
+			name: "has branch placeholder and git is in detached head",
 			args: args{
 				value: "repos/{owner}/{repo}/branches/{branch}",
 				opts: &ApiOptions{
 					BaseRepo: func() (ghrepo.Interface, error) {
-						return ghrepo.New("cli", "cli"), nil
+						return ghrepo.New("hubot", "robot-uprising"), nil
 					},
 					Branch: func() (string, error) {
 						return "", git.ErrNotOnAnyBranch
 					},
 				},
 			},
-			want:    "repos/{owner}/{repo}/branches/{branch}",
+			want:    "repos/hubot/robot-uprising/branches/{branch}",
 			wantErr: true,
 		},
 		{
-			name: "no greedy substitutes",
+			name: "surfaces errors in earlier placeholders",
+			args: args{
+				value: "{branch}-{owner}",
+				opts: &ApiOptions{
+					BaseRepo: func() (ghrepo.Interface, error) {
+						return ghrepo.New("hubot", "robot-uprising"), nil
+					},
+					Branch: func() (string, error) {
+						return "", git.ErrNotOnAnyBranch
+					},
+				},
+			},
+			want:    "{branch}-hubot",
+			wantErr: true,
+		},
+		{
+			name: "no greedy substitutes (colon)",
 			args: args{
 				value: ":ownership/:repository",
 				opts: &ApiOptions{
@@ -1076,6 +1088,17 @@ func Test_fillPlaceholders(t *testing.T) {
 				},
 			},
 			want:    ":ownership/:repository",
+			wantErr: false,
+		},
+		{
+			name: "non-placeholders are left intact",
+			args: args{
+				value: "{}{ownership}/{repository}",
+				opts: &ApiOptions{
+					BaseRepo: nil,
+				},
+			},
+			want:    "{}{ownership}/{repository}",
 			wantErr: false,
 		},
 	}

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -870,9 +870,23 @@ func Test_magicFieldValue(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "placeholder",
+			name: "placeholder colon",
 			args: args{
 				v: ":owner",
+				opts: &ApiOptions{
+					IO: io,
+					BaseRepo: func() (ghrepo.Interface, error) {
+						return ghrepo.New("hubot", "robot-uprising"), nil
+					},
+				},
+			},
+			want:    "hubot",
+			wantErr: false,
+		},
+		{
+			name: "placeholder braces",
+			args: args{
+				v: "{owner}",
 				opts: &ApiOptions{
 					IO: io,
 					BaseRepo: func() (ghrepo.Interface, error) {
@@ -1006,6 +1020,51 @@ func Test_fillPlaceholders(t *testing.T) {
 				},
 			},
 			want:    "repos/:owner/:repo/branches/:branch",
+			wantErr: true,
+		},
+		{
+			name: "has substitutes (braces)",
+			args: args{
+				value: "repos/{owner}/{repo}/releases",
+				opts: &ApiOptions{
+					BaseRepo: func() (ghrepo.Interface, error) {
+						return ghrepo.New("hubot", "robot-uprising"), nil
+					},
+				},
+			},
+			want:    "repos/hubot/robot-uprising/releases",
+			wantErr: false,
+		},
+		{
+			name: "has branch placeholder (braces)",
+			args: args{
+				value: "repos/cli/cli/branches/{branch}/protection/required_status_checks",
+				opts: &ApiOptions{
+					BaseRepo: func() (ghrepo.Interface, error) {
+						return ghrepo.New("cli", "cli"), nil
+					},
+					Branch: func() (string, error) {
+						return "trunk", nil
+					},
+				},
+			},
+			want:    "repos/cli/cli/branches/trunk/protection/required_status_checks",
+			wantErr: false,
+		},
+		{
+			name: "has branch placeholder and git is in detached head (braces)",
+			args: args{
+				value: "repos/{owner}/{repo}/branches/{branch}",
+				opts: &ApiOptions{
+					BaseRepo: func() (ghrepo.Interface, error) {
+						return ghrepo.New("cli", "cli"), nil
+					},
+					Branch: func() (string, error) {
+						return "", git.ErrNotOnAnyBranch
+					},
+				},
+			},
+			want:    "repos/{owner}/{repo}/branches/{branch}",
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
Add support for the following synonyms:

{owner} for :owner
{repo} for :repo
{branch} for :branch

If accepted in principle I would like to also update the example docs in this file to use the `{var}` syntax, perhaps with a note that `:var` is also supported. I would also extend the test cases.

The motivation for this change is that `:var` is a Rails-ism, and `{var}` is [more standard](https://tools.ietf.org/html/rfc6570#section-3.2.2). I was particularly motivated to submit this as docs.github.com changed to use `{var}`, which means that it is not currently possible to cut and paste a URL from the API docs (e.g. [Code Scanning](https://docs.github.com/en/rest/reference/code-scanning#list-code-scanning-analyses-for-a-repository)) right to the command line.

