### PR TITLE
catch mintty error and add help for it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/**/gh.exe
 /bin
 /share/man/man1
 /gh-cli

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/**/gh.exe
 /bin
 /share/man/man1
 /gh-cli

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -176,6 +176,12 @@ func mainRun() exitCode {
 
 		printError(stderr, err, cmd, hasDebug)
 
+		if strings.Contains(err.Error(), "Incorrect function") {
+			fmt.Fprintln(stderr, "You appear to be running in MinTTY without pseudo terminal support.")
+			fmt.Fprintln(stderr, "To learn about workarounds for this error, gh help mintty")
+			return exitError
+		}
+
 		var httpErr api.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == 401 {
 			fmt.Fprintln(stderr, "hint: try authenticating with `gh auth login`")

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -178,7 +178,7 @@ func mainRun() exitCode {
 
 		if strings.Contains(err.Error(), "Incorrect function") {
 			fmt.Fprintln(stderr, "You appear to be running in MinTTY without pseudo terminal support.")
-			fmt.Fprintln(stderr, "To learn about workarounds for this error, gh help mintty")
+			fmt.Fprintln(stderr, "To learn about workarounds for this error, run: gh help mintty")
 			return exitError
 		}
 

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -6,6 +6,12 @@ import (
 )
 
 var HelpTopics = map[string]map[string]string{
+	"mintty": {
+		"short": "Information about using gh with MinTTY",
+		"long": heredoc.Doc(`
+			TODO
+		`),
+	},
 	"environment": {
 		"short": "Environment variables that can be used with gh",
 		"long": heredoc.Doc(`

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -15,11 +15,11 @@ var HelpTopics = map[string]map[string]string{
 
 			There are a few workarounds to make gh work with MinTTY:
 
-			- Reinstall Git for Windows. 
-			  Be sure to check the box "Enable experimental support for pseudo consoles".
+			- Reinstall Git for Windows, checking "Enable experimental support for pseudo consoles".
 
-			- Use a different terminal emulator with Git for Windows like Windows Terminal or cmd.exe.
-			  Try running "C:\Program Files\Git\bin\bash.exe" in one of those other terminal emulators.
+			- Use a different terminal emulator with Git for Windows like Windows Terminal.
+			  You can run "C:\Program Files\Git\bin\bash.exe" from any terminal emulator to continue
+			  using all of the tooling in Git For Windows without MinTTY.
 
 			- Prefix invocations of gh with winpty, eg: "winpty gh auth login".
 			  NOTE: this can lead to some UI bugs.

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -9,7 +9,20 @@ var HelpTopics = map[string]map[string]string{
 	"mintty": {
 		"short": "Information about using gh with MinTTY",
 		"long": heredoc.Doc(`
-			TODO
+			MinTTY is the terminal emulator that comes by default with Git
+			for Windows.  It has known issues with gh's ability to prompt a
+			user for input.
+
+			There are a few workarounds to make gh work with MinTTY:
+
+			- Reinstall Git for Windows. 
+			  Be sure to check the box "Enable experimental support for pseudo consoles".
+
+			- Use a different terminal emulator with Git for Windows like Windows Terminal or cmd.exe.
+			  Try running "C:\Program Files\Git\bin\bash.exe" in one of those other terminal emulators.
+
+			- Prefix invocations of gh with winpty, eg: "winpty gh auth login".
+			  NOTE: this can lead to some UI bugs.
 		`),
 	},
 	"environment": {

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -103,6 +103,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	// Help topics
 	cmd.AddCommand(NewHelpTopic("environment"))
 	cmd.AddCommand(NewHelpTopic("formatting"))
+	cmd.AddCommand(NewHelpTopic("mintty"))
 	referenceCmd := NewHelpTopic("reference")
 	referenceCmd.SetHelpFunc(referenceHelpFn(f.IOStreams))
 	cmd.AddCommand(referenceCmd)


### PR DESCRIPTION
This PR notices when MinTTY fails to gather input with "Incorrect function" and then suggests the user run "gh help mintty" to learn about workarounds.

I've tested each workaround (including running git+bash via Windows Terminal) on my Windows machine.

Ref. https://github.com/cli/cli/issues/404
