### PR TITLE
Add support for GITHUB_REPOSITORY

### DIFF
--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -35,8 +35,8 @@ var HelpTopics = map[string]map[string]string{
 			GH_ENTERPRISE_TOKEN, GITHUB_ENTERPRISE_TOKEN (in order of precedence): an authentication
 			token for API requests to GitHub Enterprise.
 
-			GH_REPO: specify the GitHub repository in the "[HOST/]OWNER/REPO" format for commands
-			that otherwise operate on a local repository.
+			GH_REPO, GITHUB_REPOSITORY (in order of precedence): specify the GitHub repository in the
+			"[HOST/]OWNER/REPO" format for commands that otherwise operate on a local repository.
 
 			GH_HOST: specify the GitHub hostname for commands that would otherwise assume
 			the "github.com" host when not in a context of an existing repository.

--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -14,6 +14,8 @@ func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
 		repoOverride, _ := cmd.Flags().GetString("repo")
 		if repoFromEnv := os.Getenv("GH_REPO"); repoOverride == "" && repoFromEnv != "" {
 			repoOverride = repoFromEnv
+		} else if repoFromEnv := os.Getenv("GITHUB_REPOSITORY"); repoOverride == "" && repoFromEnv != "" {
+			repoOverride = repoFromEnv
 		}
 		if repoOverride != "" {
 			// NOTE: this mutates the factory

--- a/pkg/cmdutil/repo_override_test.go
+++ b/pkg/cmdutil/repo_override_test.go
@@ -1,0 +1,64 @@
+package cmdutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cli/cli/internal/ghrepo"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_EnableRepoOverride(t *testing.T) {
+	originalGhRepo := os.Getenv("GH_REPO")
+	originalGithubRepository := os.Getenv("GITHUB_REPOSITORY")
+	t.Cleanup(func() {
+		_ = os.Setenv("GH_REPO", originalGhRepo)
+		_ = os.Setenv("GITHUB_REPOSITORY", originalGithubRepository)
+	})
+
+	tests := []struct {
+		name     string
+		gh       string
+		github   string
+		expected string
+	}{
+		{
+			name:     "GH_REPO",
+			gh:       "gh/repo",
+			github:   "",
+			expected: "gh/repo",
+		},
+		{
+			name:     "GITHUB_REPOSITORY",
+			gh:       "",
+			github:   "github/repository",
+			expected: "github/repository",
+		},
+		{
+			name:     "GH_REPO, GITHUB_REPOSITORY",
+			gh:       "gh/repo",
+			github:   "github/repository",
+			expected: "gh/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = os.Setenv("GH_REPO", tt.gh)
+			_ = os.Setenv("GITHUB_REPOSITORY", tt.github)
+
+			factory := &Factory{}
+			cmd := &cobra.Command{Run: func(*cobra.Command, []string) {}}
+			EnableRepoOverride(cmd, factory)
+
+			err := cmd.Execute()
+			assert.NoError(t, err)
+
+			repo, err := factory.BaseRepo()
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expected, ghrepo.FullName(repo))
+		})
+	}
+}


### PR DESCRIPTION
GitHub Actions sets a default [`GITHUB_REPOSITORY`][docs] environment variable with the owner and repository name (e.g. `octocat/Hello-World`).

This PR adds support to read the `GITHUB_REPOSITORY` environment variable as a fallback when the `GH_REPO` environment variable is not set. If both environment variables are set, `GH_REPO` takes precedence over `GITHUB_REPOSITORY`, mirroring the behavior of `GH_TOKEN` and `GITHUB_TOKEN`.

[docs]: https://docs.github.com/actions/reference/environment-variables

Fixes: #3556

_(This is my first time working in Go, so I've tried to match existing style, but have surely missed something, so very open to any/all nits.)_