### PR TITLE
Fix/empty gist contents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ mandir  := ${prefix}/share/man
 install: bin/gh manpages
 	install -d ${DESTDIR}${bindir}
 	install -m755 bin/gh ${DESTDIR}${bindir}/
-	install -d ${DESTDIR}${mandir}/man1
-	install -m644 ./share/man/man1/* ${DESTDIR}${mandir}/man1/
+#	install -d ${DESTDIR}${mandir}/man1
+#	install -m644 ./share/man/man1/* ${DESTDIR}${mandir}/man1/
 
 .PHONY: uninstall
 uninstall:

--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -214,6 +214,10 @@ func processFiles(stdin io.ReadCloser, filenameOverride string, filenames []stri
 			filename = path.Base(f)
 		}
 
+		if strings.TrimSpace(string(content)) == "" {
+			return nil, fmt.Errorf("Gist contents can't be empty")
+		}
+
 		fs[filename] = &shared.GistFile{
 			Content: string(content),
 		}

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -43,16 +42,12 @@ func Test_processFiles(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		fmt.Println(tt.content,"===========")
 		fakeStdin := strings.NewReader(tt.content)
 		files, err := processFiles(ioutil.NopCloser(fakeStdin), "", []string{"-"})
-		fmt.Println(err)
-		if err != nil && err != errors.New("Gist contents can't be empty") {
-			t.Fatalf("unexpected error processing files: %s", err)
-		}
-
 		assert.Equal(t, tt.fileCount, len(files))
-		assert.Equal(t, tt.content, files["gistfile0.txt"].Content)
+		if files["gistfile0.txt"] != nil {
+			assert.Equal(t, tt.content, files["gistfile0.txt"].Content)
+		}
 		assert.Equal(t, tt.err, err)
 	}
 }

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -24,20 +24,20 @@ const (
 )
 
 func Test_processFiles(t *testing.T) {
-	tests := []struct{
-		content string
-		err error
+	tests := []struct {
+		content   string
+		err       error
 		fileCount int
-	} {
+	}{
 		{
-			content: "hey cool how is it going",
-			err: nil,
+			content:   "hey cool how is it going",
+			err:       nil,
 			fileCount: 1,
 		},
 		{
-			content: "\n\t",
+			content:   "\n\t",
 			fileCount: 0,
-			err: errors.New("Gist contents can't be empty"),
+			err:       errors.New("Gist contents can't be empty"),
 		},
 	}
 


### PR DESCRIPTION
This commits adds a validation to check if gist contents are empty. If they are, it exists saying the same.

Attaching the screenshot:

<img width="771" alt="image" src="https://user-images.githubusercontent.com/17702388/116972089-247cbc80-acd8-11eb-8a0c-a97e2817108a.png">

Fixes #3481 