### PR TITLE
Use `T.TempDir` for temporary dirs in tests

### DIFF
--- a/internal/docs/man_test.go
+++ b/internal/docs/man_test.go
@@ -175,11 +175,10 @@ func assertNextLineEquals(scanner *bufio.Scanner, expectedLine string) error {
 }
 
 func BenchmarkGenManToFile(b *testing.B) {
-	file, err := ioutil.TempFile("", "")
+	file, err := ioutil.TempFile(b.TempDir(), "")
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.Remove(file.Name())
 	defer file.Close()
 
 	b.ResetTimer()

--- a/internal/docs/markdown_test.go
+++ b/internal/docs/markdown_test.go
@@ -83,11 +83,10 @@ func TestGenMdTree(t *testing.T) {
 }
 
 func BenchmarkGenMarkdownToFile(b *testing.B) {
-	file, err := ioutil.TempFile("", "")
+	file, err := ioutil.TempFile(b.TempDir(), "")
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.Remove(file.Name())
 	defer file.Close()
 
 	b.ResetTimer()

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -708,7 +710,7 @@ func Test_apiRun_inputFile(t *testing.T) {
 					t.Fatal(err)
 				}
 				_, _ = f.Write(tt.inputContents)
-				f.Close()
+				defer f.Close()
 				inputFile = f.Name()
 			}
 
@@ -773,6 +775,11 @@ func Test_apiRun_cache(t *testing.T) {
 		CacheTTL:    time.Minute,
 	}
 
+	t.Cleanup(func() {
+		cacheDir := filepath.Join(os.TempDir(), "gh-cli-cache")
+		os.RemoveAll(cacheDir)
+	})
+
 	err := apiRun(&options)
 	assert.NoError(t, err)
 	err = apiRun(&options)
@@ -824,8 +831,9 @@ func Test_magicFieldValue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
+
 	fmt.Fprint(f, "file contents")
-	f.Close()
 
 	io, _, _, _ := iostreams.Test()
 
@@ -930,8 +938,9 @@ func Test_openUserFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
+
 	fmt.Fprint(f, "file contents")
-	f.Close()
 
 	file, length, err := openUserFile(f.Name(), nil)
 	if err != nil {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -691,6 +691,9 @@ func Test_apiRun_inputFile(t *testing.T) {
 			contentLength: 10,
 		},
 	}
+
+	tempDir := t.TempDir()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			io, stdin, _, _ := iostreams.Test()
@@ -700,7 +703,7 @@ func Test_apiRun_inputFile(t *testing.T) {
 			if tt.inputFile == "-" {
 				_, _ = stdin.Write(tt.inputContents)
 			} else {
-				f, err := ioutil.TempFile(t.TempDir(), tt.inputFile)
+				f, err := ioutil.TempFile(tempDir, tt.inputFile)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -702,13 +700,12 @@ func Test_apiRun_inputFile(t *testing.T) {
 			if tt.inputFile == "-" {
 				_, _ = stdin.Write(tt.inputContents)
 			} else {
-				f, err := ioutil.TempFile("", tt.inputFile)
+				f, err := ioutil.TempFile(t.TempDir(), tt.inputFile)
 				if err != nil {
 					t.Fatal(err)
 				}
 				_, _ = f.Write(tt.inputContents)
 				f.Close()
-				t.Cleanup(func() { os.Remove(f.Name()) })
 				inputFile = f.Name()
 			}
 
@@ -773,11 +770,6 @@ func Test_apiRun_cache(t *testing.T) {
 		CacheTTL:    time.Minute,
 	}
 
-	t.Cleanup(func() {
-		cacheDir := filepath.Join(os.TempDir(), "gh-cli-cache")
-		os.RemoveAll(cacheDir)
-	})
-
 	err := apiRun(&options)
 	assert.NoError(t, err)
 	err = apiRun(&options)
@@ -825,13 +817,12 @@ func Test_parseFields(t *testing.T) {
 }
 
 func Test_magicFieldValue(t *testing.T) {
-	f, err := ioutil.TempFile("", "gh-test")
+	f, err := ioutil.TempFile(t.TempDir(), "gh-test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	fmt.Fprint(f, "file contents")
 	f.Close()
-	t.Cleanup(func() { os.Remove(f.Name()) })
 
 	io, _, _, _ := iostreams.Test()
 
@@ -932,13 +923,12 @@ func Test_magicFieldValue(t *testing.T) {
 }
 
 func Test_openUserFile(t *testing.T) {
-	f, err := ioutil.TempFile("", "gh-test")
+	f, err := ioutil.TempFile(t.TempDir(), "gh-test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	fmt.Fprint(f, "file contents")
 	f.Close()
-	t.Cleanup(func() { os.Remove(f.Name()) })
 
 	file, length, err := openUserFile(f.Name(), nil)
 	if err != nil {

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -423,6 +423,7 @@ func TestIssueCreate_recover(t *testing.T) {
 
 	tmpfile, err := ioutil.TempFile(t.TempDir(), "testrecover*")
 	assert.NoError(t, err)
+	defer tmpfile.Close()
 
 	state := prShared.IssueMetadataState{
 		Title:  "recovered title",
@@ -435,8 +436,6 @@ func TestIssueCreate_recover(t *testing.T) {
 
 	_, err = tmpfile.Write(data)
 	assert.NoError(t, err)
-
-	tmpfile.Close()
 
 	args := fmt.Sprintf("--recover '%s'", tmpfile.Name())
 

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -422,7 +421,7 @@ func TestIssueCreate_recover(t *testing.T) {
 		},
 	})
 
-	tmpfile, err := ioutil.TempFile(os.TempDir(), "testrecover*")
+	tmpfile, err := ioutil.TempFile(t.TempDir(), "testrecover*")
 	assert.NoError(t, err)
 
 	state := prShared.IssueMetadataState{
@@ -436,6 +435,8 @@ func TestIssueCreate_recover(t *testing.T) {
 
 	_, err = tmpfile.Write(data)
 	assert.NoError(t, err)
+
+	tmpfile.Close()
 
 	args := fmt.Sprintf("--recover '%s'", tmpfile.Name())
 

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -310,6 +310,7 @@ func TestPRCreate_recover(t *testing.T) {
 
 	tmpfile, err := ioutil.TempFile(t.TempDir(), "testrecover*")
 	assert.NoError(t, err)
+	defer tmpfile.Close()
 
 	state := prShared.IssueMetadataState{
 		Title:     "recovered title",
@@ -322,8 +323,6 @@ func TestPRCreate_recover(t *testing.T) {
 
 	_, err = tmpfile.Write(data)
 	assert.NoError(t, err)
-
-	tmpfile.Close()
 
 	args := fmt.Sprintf("--recover '%s' -Hfeature", tmpfile.Name())
 

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -309,7 +308,7 @@ func TestPRCreate_recover(t *testing.T) {
 		},
 	})
 
-	tmpfile, err := ioutil.TempFile(os.TempDir(), "testrecover*")
+	tmpfile, err := ioutil.TempFile(t.TempDir(), "testrecover*")
 	assert.NoError(t, err)
 
 	state := prShared.IssueMetadataState{
@@ -323,6 +322,8 @@ func TestPRCreate_recover(t *testing.T) {
 
 	_, err = tmpfile.Write(data)
 	assert.NoError(t, err)
+
+	tmpfile.Close()
 
 	args := fmt.Sprintf("--recover '%s' -Hfeature", tmpfile.Name())
 

--- a/pkg/cmd/pr/shared/preserve_test.go
+++ b/pkg/cmd/pr/shared/preserve_test.go
@@ -78,9 +78,8 @@ func Test_PreserveInput(t *testing.T) {
 
 			io, _, _, errOut := iostreams.Test()
 
-			tf, tferr := tmpfile()
+			tf, tferr := tmpfile(t)
 			assert.NoError(t, tferr)
-			defer os.Remove(tf.Name())
 
 			io.TempFileOverride = tf
 
@@ -97,6 +96,8 @@ func Test_PreserveInput(t *testing.T) {
 			data, err := ioutil.ReadAll(tf)
 			assert.NoError(t, err)
 
+			tf.Close()
+
 			if tt.wantPreservation {
 				//nolint:staticcheck // prefer exact matchers over ExpectLines
 				test.ExpectLines(t, errOut.String(), tt.wantErrLine)
@@ -112,9 +113,8 @@ func Test_PreserveInput(t *testing.T) {
 	}
 }
 
-func tmpfile() (*os.File, error) {
-	dir := os.TempDir()
-	tmpfile, err := ioutil.TempFile(dir, "testfile*")
+func tmpfile(t *testing.T) (*os.File, error) {
+	tmpfile, err := ioutil.TempFile(t.TempDir(), "testfile*")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/workflow/run/run_test.go
+++ b/pkg/cmd/workflow/run/run_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/cli/cli/api"
@@ -149,13 +148,12 @@ func TestNewCmdRun(t *testing.T) {
 }
 
 func Test_magicFieldValue(t *testing.T) {
-	f, err := ioutil.TempFile("", "gh-test")
+	f, err := ioutil.TempFile(t.TempDir(), "gh-test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	fmt.Fprint(f, "file contents")
 	f.Close()
-	t.Cleanup(func() { os.Remove(f.Name()) })
 
 	io, _, _, _ := iostreams.Test()
 

--- a/pkg/cmd/workflow/run/run_test.go
+++ b/pkg/cmd/workflow/run/run_test.go
@@ -152,8 +152,9 @@ func Test_magicFieldValue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
+
 	fmt.Fprint(f, "file contents")
-	f.Close()
 
 	io, _, _, _ := iostreams.Test()
 

--- a/pkg/githubtemplate/github_template_test.go
+++ b/pkg/githubtemplate/github_template_test.go
@@ -261,12 +261,11 @@ func TestFindLegacy(t *testing.T) {
 }
 
 func TestExtractName(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "gh-cli")
+	tmpfile, err := ioutil.TempFile(t.TempDir(), "gh-cli")
 	if err != nil {
 		t.Fatal(err)
 	}
 	tmpfile.Close()
-	defer os.Remove(tmpfile.Name())
 
 	type args struct {
 		filePath string
@@ -322,12 +321,11 @@ about: This is how you report bugs
 }
 
 func TestExtractContents(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "gh-cli")
+	tmpfile, err := ioutil.TempFile(t.TempDir(), "gh-cli")
 	if err != nil {
 		t.Fatal(err)
 	}
 	tmpfile.Close()
-	defer os.Remove(tmpfile.Name())
 
 	type args struct {
 		filePath string

--- a/pkg/githubtemplate/github_template_test.go
+++ b/pkg/githubtemplate/github_template_test.go
@@ -265,7 +265,7 @@ func TestExtractName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmpfile.Close()
+	defer tmpfile.Close()
 
 	type args struct {
 		filePath string
@@ -325,7 +325,7 @@ func TestExtractContents(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmpfile.Close()
+	defer tmpfile.Close()
 
 	type args struct {
 		filePath string


### PR DESCRIPTION
This PR removes the use of `os.TempDir` in tests in favor of `T.TempDir`.

Unlike `os.TempDir`, `T.TempDir` return temporary directories that are automatically cleaned up at the end of the test so there's no need to register cleanup functions.

Note that this method was [introduced in Go 1.15](https://golang.org/doc/go1.15#testing) which is the minimum required version for running the test suite.