### PR TITLE
Added ppc64le support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
   - <<: *build_defaults
     id: linux
     goos: [linux]
-    goarch: [386, arm, amd64, arm64]
+    goarch: [386, arm, amd64, arm64, ppc64le]
     env:
       - CGO_ENABLED=0
 


### PR DESCRIPTION
Added ppc64le architecture support as it wasn't provided yet and shouldn't cause any problem during build due to GO's cross compilation.