### PR TITLE
Push data serialization concern into Exporter

### DIFF
--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -6,6 +6,7 @@ import (
 )
 
 func (issue *Issue) ExportData(fields []string) *map[string]interface{} {
+	v := reflect.ValueOf(issue).Elem()
 	data := map[string]interface{}{}
 
 	for _, f := range fields {
@@ -25,7 +26,6 @@ func (issue *Issue) ExportData(fields []string) *map[string]interface{} {
 		case "projectCards":
 			data[f] = issue.ProjectCards.Nodes
 		default:
-			v := reflect.ValueOf(issue).Elem()
 			sf := fieldByName(v, f)
 			data[f] = sf.Interface()
 		}
@@ -35,6 +35,7 @@ func (issue *Issue) ExportData(fields []string) *map[string]interface{} {
 }
 
 func (pr *PullRequest) ExportData(fields []string) *map[string]interface{} {
+	v := reflect.ValueOf(pr).Elem()
 	data := map[string]interface{}{}
 
 	for _, f := range fields {
@@ -75,28 +76,11 @@ func (pr *PullRequest) ExportData(fields []string) *map[string]interface{} {
 			}
 			data[f] = &requests
 		default:
-			v := reflect.ValueOf(pr).Elem()
 			sf := fieldByName(v, f)
 			data[f] = sf.Interface()
 		}
 	}
 
-	return &data
-}
-
-func ExportIssues(issues []Issue, fields []string) *[]interface{} {
-	data := make([]interface{}, len(issues))
-	for i := range issues {
-		data[i] = issues[i].ExportData(fields)
-	}
-	return &data
-}
-
-func ExportPRs(prs []PullRequest, fields []string) *[]interface{} {
-	data := make([]interface{}, len(prs))
-	for i := range prs {
-		data[i] = prs[i].ExportData(fields)
-	}
 	return &data
 }
 

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -90,31 +90,6 @@ func TestIssue_ExportData(t *testing.T) {
 	}
 }
 
-func TestExportIssues(t *testing.T) {
-	issues := []Issue{
-		{Milestone: Milestone{Title: "hi"}},
-		{},
-	}
-	exported := ExportIssues(issues, []string{"milestone"})
-
-	buf := bytes.Buffer{}
-	enc := json.NewEncoder(&buf)
-	enc.SetIndent("", "\t")
-	require.NoError(t, enc.Encode(exported))
-	assert.Equal(t, heredoc.Doc(`
-		[
-			{
-				"milestone": {
-					"title": "hi"
-				}
-			},
-			{
-				"milestone": null
-			}
-		]
-	`), buf.String())
-}
-
 func TestPullRequest_ExportData(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -155,8 +155,7 @@ func listRun(opts *ListOptions) error {
 	defer opts.IO.StopPager()
 
 	if opts.Exporter != nil {
-		data := api.ExportIssues(listResult.Issues, opts.Exporter.Fields())
-		return opts.Exporter.Write(opts.IO.Out, data, opts.IO.ColorEnabled())
+		return opts.Exporter.Write(opts.IO.Out, listResult.Issues, opts.IO.ColorEnabled())
 	}
 
 	if isTerminal {

--- a/pkg/cmd/issue/status/status.go
+++ b/pkg/cmd/issue/status/status.go
@@ -96,11 +96,11 @@ func statusRun(opts *StatusOptions) error {
 
 	if opts.Exporter != nil {
 		data := map[string]interface{}{
-			"createdBy": api.ExportIssues(issuePayload.Authored.Issues, opts.Exporter.Fields()),
-			"assigned":  api.ExportIssues(issuePayload.Assigned.Issues, opts.Exporter.Fields()),
-			"mentioned": api.ExportIssues(issuePayload.Mentioned.Issues, opts.Exporter.Fields()),
+			"createdBy": issuePayload.Authored.Issues,
+			"assigned":  issuePayload.Assigned.Issues,
+			"mentioned": issuePayload.Mentioned.Issues,
 		}
-		return opts.Exporter.Write(opts.IO.Out, &data, opts.IO.ColorEnabled())
+		return opts.Exporter.Write(opts.IO.Out, data, opts.IO.ColorEnabled())
 	}
 
 	out := opts.IO.Out

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -116,8 +116,7 @@ func viewRun(opts *ViewOptions) error {
 	defer opts.IO.StopPager()
 
 	if opts.Exporter != nil {
-		exportIssue := issue.ExportData(opts.Exporter.Fields())
-		return opts.Exporter.Write(opts.IO.Out, exportIssue, opts.IO.ColorEnabled())
+		return opts.Exporter.Write(opts.IO.Out, issue, opts.IO.ColorEnabled())
 	}
 
 	if opts.IO.IsStdoutTTY() {

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -155,8 +155,7 @@ func listRun(opts *ListOptions) error {
 	defer opts.IO.StopPager()
 
 	if opts.Exporter != nil {
-		data := api.ExportPRs(listResult.PullRequests, opts.Exporter.Fields())
-		return opts.Exporter.Write(opts.IO.Out, data, opts.IO.ColorEnabled())
+		return opts.Exporter.Write(opts.IO.Out, listResult.PullRequests, opts.IO.ColorEnabled())
 	}
 
 	if opts.IO.IsStdoutTTY() {

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -113,13 +113,13 @@ func statusRun(opts *StatusOptions) error {
 	if opts.Exporter != nil {
 		data := map[string]interface{}{
 			"currentBranch": nil,
-			"createdBy":     api.ExportPRs(prPayload.ViewerCreated.PullRequests, opts.Exporter.Fields()),
-			"needsReview":   api.ExportPRs(prPayload.ReviewRequested.PullRequests, opts.Exporter.Fields()),
+			"createdBy":     prPayload.ViewerCreated.PullRequests,
+			"needsReview":   prPayload.ReviewRequested.PullRequests,
 		}
 		if prPayload.CurrentPR != nil {
-			data["currentBranch"] = prPayload.CurrentPR.ExportData(opts.Exporter.Fields())
+			data["currentBranch"] = prPayload.CurrentPR
 		}
-		return opts.Exporter.Write(opts.IO.Out, &data, opts.IO.ColorEnabled())
+		return opts.Exporter.Write(opts.IO.Out, data, opts.IO.ColorEnabled())
 	}
 
 	out := opts.IO.Out

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -117,8 +117,7 @@ func viewRun(opts *ViewOptions) error {
 	defer opts.IO.StopPager()
 
 	if opts.Exporter != nil {
-		exportPR := pr.ExportData(opts.Exporter.Fields())
-		return opts.Exporter.Write(opts.IO.Out, exportPR, opts.IO.ColorEnabled())
+		return opts.Exporter.Write(opts.IO.Out, pr, opts.IO.ColorEnabled())
 	}
 
 	if connectedToTerminal {


### PR DESCRIPTION
The `Exporter.Write()` method can now be passed an unmodified data structure to convert to JSON. The Exporter will make sure that if the underlying objects implement `ExportData()`, that method will be called on each object individually. This retires old `ExportIssues`, `ExportPRs` methods.

Addressing @samcoe's concerns from https://github.com/cli/cli/pull/3414#discussion_r612808097