### PR TITLE
Add `--no-pager` flag

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -66,6 +66,14 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.SetUsageFunc(rootUsageFunc)
 	cmd.SetFlagErrorFunc(rootFlagErrorFunc)
 
+	cmd.PersistentFlags().Bool("no-pager", false, "Disable pager")
+	_ = cmd.PersistentFlags().MarkHidden("no-pager")
+	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if cmd.Flags().Changed("no-pager") {
+			f.IOStreams.SetPager("")
+		}
+	}
+
 	formattedVersion := versionCmd.Format(version, buildDate)
 	cmd.SetVersionTemplate(formattedVersion)
 	cmd.Version = formattedVersion

--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -11,6 +11,11 @@ func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
 	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `[HOST/]OWNER/REPO` format")
 
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		// Execute rootCmd's PersistentPreRun hook
+		if rootPPreRun := cmd.Root().PersistentPreRun; rootPPreRun != nil {
+			rootPPreRun(cmd, args)
+		}
+
 		repoOverride, _ := cmd.Flags().GetString("repo")
 		if repoFromEnv := os.Getenv("GH_REPO"); repoOverride == "" && repoFromEnv != "" {
 			repoOverride = repoFromEnv


### PR DESCRIPTION
This PR adds a new (hidden) global flag `--no-pager` to allow disabling the pager in all sub-commands.

closes #3617
