### PR TITLE
Fix "null" display in colored JSON output

### DIFF
--- a/pkg/jsoncolor/jsoncolor.go
+++ b/pkg/jsoncolor/jsoncolor.go
@@ -10,7 +10,7 @@ import (
 const (
 	colorDelim  = "1;38" // bright white
 	colorKey    = "1;34" // bright blue
-	colorNull   = "1;30" // gray
+	colorNull   = "36"   // cyan
 	colorString = "32"   // green
 	colorBool   = "33"   // yellow
 )


### PR DESCRIPTION
"null" was previously rendered in "bright black", an ANSI color that is not guaranteed to be visible at all depending on the terminal. Switch the color to cyan to ensure that "null" is visible.

Ref. https://github.com/cli/cli/pull/1631