### PR TITLE
Create a Release Discussion on every new release

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -118,7 +118,7 @@ jobs:
         id: download_exe
         shell: bash
         run: |
-          gh release download "${GITHUB_REF#refs/tags/}" -p '*windows_amd64*.zip'
+          hub release download "${GITHUB_REF#refs/tags/}" -i '*windows_amd64*.zip'
           printf "::set-output name=zip::%s\n" *.zip
           unzip -o *.zip && rm -v *.zip
         env:
@@ -155,7 +155,7 @@ jobs:
         shell: bash
         run: |
           tag_name="${GITHUB_REF#refs/tags/}"
-          gh release upload "$tag_name" -- "$MSI_FILE"
+          hub release edit "$tag_name" -m "" -a "$MSI_FILE"
           release_url="$(gh api repos/:owner/:repo/releases -q ".[]|select(.tag_name==\"${tag_name}\")|.url")"
           publish_args=( -F draft=false )
           if [[ $GITHUB_REF != *-* ]]; then
@@ -183,7 +183,7 @@ jobs:
       - name: Bump scoop bucket
         shell: bash
         run: |
-          gh release download "${GITHUB_REF#refs/tags/}" -p '*_checksums.txt'
+          hub release download "${GITHUB_REF#refs/tags/}" -i '*_checksums.txt'
           script/scoop-gen "${GITHUB_REF#refs/tags/}" ./scoop-gh/gh.json < *_checksums.txt
           git -C ./scoop-gh commit -m "gh ${GITHUB_REF#refs/tags/}" gh.json
           if [[ $GITHUB_REF == *-* ]]; then

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -118,7 +118,7 @@ jobs:
         id: download_exe
         shell: bash
         run: |
-          hub release download "${GITHUB_REF#refs/tags/}" -i '*windows_amd64*.zip'
+          gh release download "${GITHUB_REF#refs/tags/}" -p '*windows_amd64*.zip'
           printf "::set-output name=zip::%s\n" *.zip
           unzip -o *.zip && rm -v *.zip
         env:
@@ -151,8 +151,14 @@ jobs:
             -Executable "${{ steps.buildmsi.outputs.msi }}"
       - name: Upload MSI
         shell: bash
-        run: hub release edit "${GITHUB_REF#refs/tags/}" -m "" --draft=false -a "${{ steps.buildmsi.outputs.msi }}"
+        run: |
+          tag_name="${GITHUB_REF#refs/tags/}"
+          gh release upload "$tag_name" -- "$MSI_FILE"
+          release_url="$(gh api repos/:owner/:repo/releases -q ".[]|select(.tag_name==\"${tag_name}\")|.url")"
+          gh api -X PATCH "$url" -F draft=false -f discussion_category_name="$DISCUSSION_CATEGORY"
         env:
+          MSI_FILE: ${{ steps.buildmsi.outputs.msi }}
+          DISCUSSION_CATEGORY: General
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Bump homebrew-core formula
         uses: mislav/bump-homebrew-formula-action@v1
@@ -171,7 +177,7 @@ jobs:
       - name: Bump scoop bucket
         shell: bash
         run: |
-          hub release download "${GITHUB_REF#refs/tags/}" -i '*_checksums.txt'
+          gh release download "${GITHUB_REF#refs/tags/}" -p '*_checksums.txt'
           script/scoop-gen "${GITHUB_REF#refs/tags/}" ./scoop-gh/gh.json < *_checksums.txt
           git -C ./scoop-gh commit -m "gh ${GITHUB_REF#refs/tags/}" gh.json
           if [[ $GITHUB_REF == *-* ]]; then

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -133,9 +133,11 @@ jobs:
       - name: Build MSI
         id: buildmsi
         shell: bash
+        env:
+          ZIP_FILE: ${{ steps.download_exe.outputs.zip }}
         run: |
           mkdir -p build
-          msi="$(basename "${{ steps.download_exe.outputs.zip }}" ".zip").msi"
+          msi="$(basename "$ZIP_FILE" ".zip").msi"
           printf "::set-output name=msi::%s\n" "$msi"
           go-msi make --msi "$PWD/$msi" --out "$PWD/build" --version "${GITHUB_REF#refs/tags/}"
       - name: Obtain signing cert
@@ -145,10 +147,10 @@ jobs:
         run: .\script\setup-windows-certificate.ps1
       - name: Sign MSI
         env:
+          CERT_FILE: ${{ steps.obtain_cert.outputs.cert-file }}
+          EXE_FILE: ${{ steps.buildmsi.outputs.msi }}
           GITHUB_CERT_PASSWORD: ${{ secrets.GITHUB_CERT_PASSWORD }}
-        run: |
-          .\script\sign.ps1 -Certificate "${{ steps.obtain_cert.outputs.cert-file }}" `
-            -Executable "${{ steps.buildmsi.outputs.msi }}"
+        run: .\script\sign.ps1 -Certificate $env:CERT_FILE -Executable $env:EXE_FILE
       - name: Upload MSI
         shell: bash
         run: |

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -161,7 +161,7 @@ jobs:
           if [[ $GITHUB_REF != *-* ]]; then
             publish_args+=( -f discussion_category_name="$DISCUSSION_CATEGORY" )
           fi
-          gh api -X PATCH "$url" "${publish_args[@]}"
+          gh api -X PATCH "$release_url" "${publish_args[@]}"
         env:
           MSI_FILE: ${{ steps.buildmsi.outputs.msi }}
           DISCUSSION_CATEGORY: General

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -157,7 +157,11 @@ jobs:
           tag_name="${GITHUB_REF#refs/tags/}"
           gh release upload "$tag_name" -- "$MSI_FILE"
           release_url="$(gh api repos/:owner/:repo/releases -q ".[]|select(.tag_name==\"${tag_name}\")|.url")"
-          gh api -X PATCH "$url" -F draft=false -f discussion_category_name="$DISCUSSION_CATEGORY"
+          publish_args=( -F draft=false )
+          if [[ $GITHUB_REF != *-* ]]; then
+            publish_args+=( -f discussion_category_name="$DISCUSSION_CATEGORY" )
+          fi
+          gh api -X PATCH "$url" "${publish_args[@]}"
         env:
           MSI_FILE: ${{ steps.buildmsi.outputs.msi }}
           DISCUSSION_CATEGORY: General


### PR DESCRIPTION
This uses the new Releases API to auto-generate a discussion in the "General" category linked to a release.

Questions:
- [x] Should we avoid generating a Discussion on patch releases, e.g. `1.2.x`? Since they only ever contain fixes, discussions around them might not be as interesting as discussions on releases that change behavior.

Bonus:
- switches from hub to gh in Actions
- guards script values against quoting issues/injection