### PR TITLE
Fix `pr checkout` for cross-repository pull requests

### DIFF
--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -72,7 +72,7 @@ func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobr
 func checkoutRun(opts *CheckoutOptions) error {
 	findOptions := shared.FindOptions{
 		Selector: opts.SelectorArg,
-		Fields:   []string{"number", "headRefName", "headRepository", "headRepositoryOwner"},
+		Fields:   []string{"number", "headRefName", "headRepository", "headRepositoryOwner", "isCrossRepository"},
 	}
 	pr, baseRepo, err := opts.Finder.Find(findOptions)
 	if err != nil {

--- a/pkg/cmd/pr/checkout/checkout_test.go
+++ b/pkg/cmd/pr/checkout/checkout_test.go
@@ -110,7 +110,8 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 	defer http.Verify(t)
 
 	baseRepo, pr := stubPR("OWNER/REPO", "OWNER/REPO:feature")
-	shared.RunCommandFinder("123", pr, baseRepo)
+	finder := shared.RunCommandFinder("123", pr, baseRepo)
+	finder.ExpectFields([]string{"number", "headRefName", "headRepository", "headRepositoryOwner", "isCrossRepository"})
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
@@ -164,7 +165,8 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 	defer http.Verify(t)
 
 	baseRepo, pr := stubPR("OWNER/REPO", "hubot/REPO:feature")
-	shared.RunCommandFinder("123", pr, baseRepo)
+	finder := shared.RunCommandFinder("123", pr, baseRepo)
+	finder.ExpectFields([]string{"number", "headRefName", "headRepository", "headRepositoryOwner", "isCrossRepository"})
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
@@ -186,7 +188,8 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 	defer http.Verify(t)
 
 	baseRepo, pr := stubPR("OWNER/REPO:master", "hubot/REPO:feature")
-	shared.RunCommandFinder("123", pr, baseRepo)
+	finder := shared.RunCommandFinder("123", pr, baseRepo)
+	finder.ExpectFields([]string{"number", "headRefName", "headRepository", "headRepositoryOwner", "isCrossRepository"})
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)


### PR DESCRIPTION
Adds the missing `isCrossRepository` GraphQL field that wasn't requested from the server.

Followup to #3547 
Fixes #3661