### PR TITLE
Add support for XDG_CONFIG_HOME and AppData on Windows

### DIFF
--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"syscall"
 
 	"github.com/mitchellh/go-homedir"
@@ -13,16 +14,65 @@ import (
 )
 
 const (
-	GH_CONFIG_DIR = "GH_CONFIG_DIR"
+	GH_CONFIG_DIR   = "GH_CONFIG_DIR"
+	XDG_CONFIG_HOME = "XDG_CONFIG_HOME"
+	APP_DATA        = "AppData"
 )
 
+// Config path precedence
+// 1. GH_CONFIG_DIR
+// 2. XDG_CONFIG_HOME
+// 3. AppData (windows only)
+// 4. HOME
 func ConfigDir() string {
-	if v := os.Getenv(GH_CONFIG_DIR); v != "" {
-		return v
+	var path string
+	if a := os.Getenv(GH_CONFIG_DIR); a != "" {
+		path = a
+	} else if b := os.Getenv(XDG_CONFIG_HOME); b != "" {
+		path = filepath.Join(b, "gh")
+	} else if c := os.Getenv(APP_DATA); runtime.GOOS == "windows" && c != "" {
+		path = filepath.Join(c, "GitHub CLI")
+	} else {
+		d, _ := os.UserHomeDir()
+		path = filepath.Join(d, ".config", "gh")
 	}
 
-	homeDir, _ := homeDirAutoMigrate()
-	return homeDir
+	// If the path does not exist try migrating config from default paths
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		autoMigrateConfigDir(path)
+	}
+
+	return path
+}
+
+// Check default paths (os.UserHomeDir, and homedir.Dir) for existing configs
+// If configs exist then move them to newPath
+// TODO: Remove support for homedir.Dir location in v2
+func autoMigrateConfigDir(newPath string) {
+	path, err := os.UserHomeDir()
+	if oldPath := filepath.Join(path, ".config", "gh"); err == nil && dirExists(oldPath) {
+		migrateConfigDir(oldPath, newPath)
+		return
+	}
+
+	path, err = homedir.Dir()
+	if oldPath := filepath.Join(path, ".config", "gh"); err == nil && dirExists(oldPath) {
+		migrateConfigDir(oldPath, newPath)
+	}
+}
+
+func dirExists(path string) bool {
+	f, err := os.Stat(path)
+	return err == nil && f.IsDir()
+}
+
+var migrateConfigDir = func(oldPath, newPath string) {
+	if oldPath == newPath {
+		return
+	}
+
+	_ = os.MkdirAll(filepath.Dir(newPath), 0755)
+	_ = os.Rename(oldPath, newPath)
 }
 
 func ConfigFile() string {
@@ -57,36 +107,6 @@ func HomeDirPath(subdir string) (string, error) {
 		legacyPath := filepath.Join(legacyDir, subdir)
 		if s, err := os.Stat(legacyPath); err == nil && s.IsDir() {
 			return legacyPath, nil
-		}
-	}
-
-	return newPath, nil
-}
-
-// Looks up the `~/.config/gh` directory with backwards-compatibility with go-homedir and auto-migration
-// when an old homedir location was found.
-func homeDirAutoMigrate() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		// TODO: remove go-homedir fallback in GitHub CLI v2
-		if legacyDir, err := homedir.Dir(); err == nil {
-			return filepath.Join(legacyDir, ".config", "gh"), nil
-		}
-		return "", err
-	}
-
-	newPath := filepath.Join(homeDir, ".config", "gh")
-	_, newPathErr := os.Stat(newPath)
-	if newPathErr == nil || !os.IsNotExist(err) {
-		return newPath, newPathErr
-	}
-
-	// TODO: remove go-homedir fallback in GitHub CLI v2
-	if legacyDir, err := homedir.Dir(); err == nil {
-		legacyPath := filepath.Join(legacyDir, ".config", "gh")
-		if s, err := os.Stat(legacyPath); err == nil && s.IsDir() {
-			_ = os.MkdirAll(filepath.Dir(newPath), 0755)
-			return newPath, os.Rename(legacyPath, newPath)
 		}
 	}
 

--- a/internal/config/from_env_test.go
+++ b/internal/config/from_env_test.go
@@ -13,11 +13,13 @@ func TestInheritEnv(t *testing.T) {
 	orig_GITHUB_ENTERPRISE_TOKEN := os.Getenv("GITHUB_ENTERPRISE_TOKEN")
 	orig_GH_TOKEN := os.Getenv("GH_TOKEN")
 	orig_GH_ENTERPRISE_TOKEN := os.Getenv("GH_ENTERPRISE_TOKEN")
+	orig_AppData := os.Getenv("AppData")
 	t.Cleanup(func() {
 		os.Setenv("GITHUB_TOKEN", orig_GITHUB_TOKEN)
 		os.Setenv("GITHUB_ENTERPRISE_TOKEN", orig_GITHUB_ENTERPRISE_TOKEN)
 		os.Setenv("GH_TOKEN", orig_GH_TOKEN)
 		os.Setenv("GH_ENTERPRISE_TOKEN", orig_GH_ENTERPRISE_TOKEN)
+		os.Setenv("AppData", orig_AppData)
 	})
 
 	type wants struct {
@@ -264,6 +266,7 @@ func TestInheritEnv(t *testing.T) {
 			os.Setenv("GITHUB_ENTERPRISE_TOKEN", tt.GITHUB_ENTERPRISE_TOKEN)
 			os.Setenv("GH_TOKEN", tt.GH_TOKEN)
 			os.Setenv("GH_ENTERPRISE_TOKEN", tt.GH_ENTERPRISE_TOKEN)
+			os.Setenv("AppData", "")
 
 			baseCfg := NewFromString(tt.baseConfig)
 			cfg := InheritEnv(baseCfg)

--- a/internal/config/testing.go
+++ b/internal/config/testing.go
@@ -62,3 +62,11 @@ func stubConfig(main, hosts string) func() {
 		ReadConfigFile = orig
 	}
 }
+
+func stubMigrateConfigDir() func() {
+	orig := migrateConfigDir
+	migrateConfigDir = func(_, _ string) {}
+	return func() {
+		migrateConfigDir = orig
+	}
+}


### PR DESCRIPTION
This PR adds support for storing `gh` config files in `XDG_CONFIG_HOME` as well as `AppData` on Windows.

cc https://github.com/cli/cli/issues/2470
closes https://github.com/cli/cli/issues/1944
closes https://github.com/cli/cli/issues/554
supersedes https://github.com/cli/cli/pull/2080