### PR TITLE
simplify deb installation docs

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -80,7 +80,7 @@ jobs:
           popd
       - name: Run reprepro
         env:
-          RELEASES: "cosmic eoan disco groovy focal stable oldstable testing unstable buster bullseye stretch jessie bionic trusty precise xenial hirsute impish kali-rolling"
+          RELEASES: "cosmic eoan disco groovy focal stable oldstable testing sid unstable buster bullseye stretch jessie bionic trusty precise xenial hirsute impish kali-rolling"
         run: |
           mkdir -p upload
           for release in $RELEASES; do

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -13,13 +13,15 @@ If none of our official binaries, packages, repositories, nor community sources 
 
 ### Debian, Ubuntu Linux (apt)
 
-:warning: This will only work for the deb-based distributions we [explicitly support](/.github/workflows/releases.yml#L83) and the [architectures we officially support](/.goreleaser.yml#L27).
+:warning: This will only work for the [architectures we officially support](/.goreleaser.yml#L27).
+
+The below should work for any debian-based distribution. You can change `stable` to a specific codename [we support](/.github/workflows/releases.yml#L83) if that is your preference.
 
 Install:
 
 ```bash
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/github-cli2.list > /dev/null
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 sudo apt update
 sudo apt install gh
 ```

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -13,7 +13,9 @@ If none of our official binaries, packages, repositories, nor community sources 
 
 ### Debian, Ubuntu Linux (apt)
 
-This will only work for the deb-based distributions we [explicitly support](/.github/workflows/releases.yml#L83) and the [architectures we officially support](/.goreleaser.yml#L27).
+:warning: This will only work for the deb-based distributions we [explicitly support](/.github/workflows/releases.yml#L83) and the [architectures we officially support](/.goreleaser.yml#L27).
+
+Install:
 
 ```bash
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -2,7 +2,7 @@
 
 Packages downloaded from https://cli.github.com or from https://github.com/cli/cli/releases
 are considered official binaries. We focus on popular Linux distros and
-the following CPU architectures: `i386`, `amd64`, `arm64`.
+the following CPU architectures: `i386`, `amd64`, `arm64`, `armhf`.
 
 Other sources for installation are community-maintained and thus might lag behind
 our release schedule.
@@ -13,29 +13,16 @@ If none of our official binaries, packages, repositories, nor community sources 
 
 ### Debian, Ubuntu Linux (apt)
 
-Install (Using apt-key):
+This will only work for the deb-based distributions we [explicitly support](/.github/workflows/releases.yml#L83) and the [architectures we officially support](/.goreleaser.yml#L27).
 
 ```bash
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-sudo apt-add-repository https://cli.github.com/packages
-sudo apt update
-sudo apt install gh
-```
-
-**Note**: If you are behind a firewall, the connection to `keyserver.ubuntu.com` might fail. In that case, try running `sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C99B11DEB97541F0`.
-
-**Note**: If you get _"gpg: failed to start the dirmngr '/usr/bin/dirmngr': No such file or directory"_ error, try installing the `dirmngr` package. Run `sudo apt-get install dirmngr` and repeat the steps above.  
-
-**Note**: most systems will have `apt-add-repository` already. If you get a _command not found_
-error, try running `sudo apt install software-properties-common` and trying these steps again.
-
-Install (without add-apt-repository, with limited keyring scope):
-```bash
-sudo apt-key --keyring /usr/share/keyrings/githubcli-archive-keyring.gpg adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/github-cli2.list > /dev/null
 sudo apt update
 sudo apt install gh
 ```
+
+**Note**: If you get _"gpg: failed to start the dirmngr '/usr/bin/dirmngr': No such file or directory"_ error, try installing the `dirmngr` package. Run `sudo apt-get install dirmngr` and repeat the steps above.  
 
 Upgrade:
 

--- a/script/distributions
+++ b/script/distributions
@@ -32,6 +32,14 @@ SignWith: C99B11DEB97541F0
 
 Origin: gh
 Label: gh
+Codename: sid
+Architectures: i386 amd64 armhf arm64
+Components: main
+Description: The GitHub CLI - debian unstable repo
+SignWith: C99B11DEB97541F0
+
+Origin: gh
+Label: gh
 Codename: buster
 Architectures: i386 amd64 armhf arm64
 Components: main


### PR DESCRIPTION
Fixes #3513
Fixes #2893
Fixes #1827

This PR removes two tools from our .deb installation docs (apt-key, apt-add-repository). It also links to our GPG key on `cli.github.com` instead of on the ubuntu keyserver.

Hopefully this leads to a smoother installation experience across the various .deb distros.

Additionally, this PR adds explicit packaging for Debian Sid (the codename for `unstable`). We already packaged for sid, but only listed `unstable` and not `sid`. Typically, one could just symlink `unstable` to `sid` (as #1827 suggests) but unfortunately that doesn't work with GitHub Pages. It seems like we could allow symlinking with GitHub pages, but it wasn't immediately clear to me how to do so (or if we ought to). So for now, I've just added `sid` to our distributions file.

For reference: https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/troubleshooting-jekyll-build-errors-for-github-pages-sites#file-is-a-symlink

NB: if we are able to enable the symlinking, I could shorten our `distributions` file considerably and not require so many code names in the release workflow yaml.
