### PR TITLE
List all secrets instead of being subject to the default limit of 30 results

### DIFF
--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -179,12 +179,24 @@ type secretsPayload struct {
 }
 
 func getSecrets(client *api.Client, host, path string) ([]*Secret, error) {
-	result := secretsPayload{}
+	results := secretsPayload{}
 
-	err := client.REST(host, "GET", path, nil, &result)
-	if err != nil {
-		return nil, err
+	perPage := 100
+	page := 1
+
+	for {
+		result := secretsPayload{}
+		err := client.REST(host, "GET", fmt.Sprintf("%s?per_page=%d&page=%d", path, perPage, page), nil, &result)
+		if err != nil {
+			return nil, err
+		}
+		results.Secrets = append(results.Secrets, result.Secrets...)
+		if len(result.Secrets) == 0 || len(result.Secrets) < 100 {
+			break
+		}
+
+		page++
 	}
 
-	return result.Secrets, nil
+	return results.Secrets, nil
 }


### PR DESCRIPTION
This commit adds an option to set a limit to the listing of secrets via the `--limit | -l` flag.

Screenshot for reference.

<img width="733" alt="image" src="https://user-images.githubusercontent.com/17702388/118944686-6a8d7d80-b972-11eb-99ac-e41f0b7ca847.png">

Fixes #3670 