### PR TITLE
Fix `pr merge` with GHE < 3.0

### DIFF
--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -208,6 +208,8 @@ func PullRequestGraphQL(fields []string) string {
 			q = append(q, prFiles)
 		case "commits":
 			q = append(q, prCommits)
+		case "lastCommit": // pseudo-field
+			q = append(q, `commits(last:1){nodes{commit{oid}}}`)
 		case "commitsCount": // pseudo-field
 			q = append(q, `commits{totalCount}`)
 		case "statusCheckRollup":

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -156,7 +156,7 @@ func mergeRun(opts *MergeOptions) error {
 
 	findOptions := shared.FindOptions{
 		Selector: opts.SelectorArg,
-		Fields:   []string{"id", "number", "state", "title", "commits", "mergeable", "headRepositoryOwner", "headRefName"},
+		Fields:   []string{"id", "number", "state", "title", "lastCommit", "mergeable", "headRepositoryOwner", "headRefName"},
 	}
 	pr, baseRepo, err := opts.Finder.Find(findOptions)
 	if err != nil {

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -464,11 +464,8 @@ func Test_nonDivergingPullRequest(t *testing.T) {
 	}
 	stubCommit(pr, "COMMITSHA1")
 
-	shared.RunCommandFinder(
-		"",
-		pr,
-		baseRepo("OWNER", "REPO", "master"),
-	)
+	prFinder := shared.RunCommandFinder("", pr, baseRepo("OWNER", "REPO", "master"))
+	prFinder.ExpectFields([]string{"id", "number", "state", "title", "lastCommit", "mergeable", "headRepositoryOwner", "headRefName"})
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),
@@ -505,11 +502,8 @@ func Test_divergingPullRequestWarning(t *testing.T) {
 	}
 	stubCommit(pr, "COMMITSHA1")
 
-	shared.RunCommandFinder(
-		"",
-		pr,
-		baseRepo("OWNER", "REPO", "master"),
-	)
+	prFinder := shared.RunCommandFinder("", pr, baseRepo("OWNER", "REPO", "master"))
+	prFinder.ExpectFields([]string{"id", "number", "state", "title", "lastCommit", "mergeable", "headRepositoryOwner", "headRefName"})
 
 	http.Register(
 		httpmock.GraphQL(`mutation PullRequestMerge\b`),

--- a/pkg/cmd/pr/status/fixtures/prStatusCurrentBranchClosed.json
+++ b/pkg/cmd/pr/status/fixtures/prStatusCurrentBranchClosed.json
@@ -12,24 +12,7 @@
               "state": "CLOSED",
               "url": "https://github.com/cli/cli/pull/8",
               "headRefName": "blueberries",
-              "reviewDecision": "CHANGES_REQUESTED",
-              "commits": {
-                "nodes": [
-                  {
-                    "commit": {
-                      "statusCheckRollup": {
-                        "contexts": {
-                          "nodes": [
-                            {
-                              "state": "SUCCESS"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
+              "reviewDecision": "CHANGES_REQUESTED"
             }
           }
         ]

--- a/pkg/cmd/pr/status/fixtures/prStatusCurrentBranchMerged.json
+++ b/pkg/cmd/pr/status/fixtures/prStatusCurrentBranchMerged.json
@@ -12,24 +12,7 @@
               "state": "MERGED",
               "url": "https://github.com/cli/cli/pull/8",
               "headRefName": "blueberries",
-              "reviewDecision": "CHANGES_REQUESTED",
-              "commits": {
-                "nodes": [
-                  {
-                    "commit": {
-                      "statusCheckRollup": {
-                        "contexts": {
-                          "nodes": [
-                            {
-                              "state": "SUCCESS"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
+              "reviewDecision": "CHANGES_REQUESTED"
             }
           }
         ]


### PR DESCRIPTION
This avoids loading authorship information for git commits, since it relies on a GraphQL API (the `Commit.authors` connection) that wasn't available before GHE v3.0. The full authorship information for commits wasn't necessary for the merge operation anyway; just loading the last commit OID was.

Fixes #3687
Followup from https://github.com/cli/cli/pull/3547