### PR TITLE
fix adding/removing team reviewers with `gh pr edit`

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -168,7 +168,7 @@ func (r ReviewRequests) Logins() []string {
 	logins := make([]string, len(r.Nodes))
 	for i, a := range r.Nodes {
 		if a.RequestedReviewer.TypeName == teamTypeName {
-			logins[i] = a.RequestedReviewer.Organization.Login + "/" + a.RequestedReviewer.Slug
+			logins[i] = fmt.Sprintf("%s/%s", a.RequestedReviewer.Organization.Login, a.RequestedReviewer.Slug)
 		} else {
 			logins[i] = a.RequestedReviewer.Login
 		}
@@ -403,8 +403,8 @@ func PullRequestStatus(client *Client, repo ghrepo.Interface, options StatusOpti
 	queryPrefix := `
 	query PullRequestStatus($owner: String!, $repo: String!, $headRefName: String!, $viewerQuery: String!, $reviewerQuery: String!, $per_page: Int = 10) {
 		repository(owner: $owner, name: $repo) {
-			defaultBranchRef { 
-				name 
+			defaultBranchRef {
+				name
 			}
 			pullRequests(headRefName: $headRefName, first: $per_page, orderBy: { field: CREATED_AT, direction: DESC }) {
 				totalCount
@@ -420,8 +420,8 @@ func PullRequestStatus(client *Client, repo ghrepo.Interface, options StatusOpti
 		queryPrefix = `
 		query PullRequestStatus($owner: String!, $repo: String!, $number: Int!, $viewerQuery: String!, $reviewerQuery: String!, $per_page: Int = 10) {
 			repository(owner: $owner, name: $repo) {
-				defaultBranchRef { 
-					name 
+				defaultBranchRef {
+					name
 				}
 				pullRequest(number: $number) {
 					...prWithReviews

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -151,17 +151,27 @@ type PullRequestFile struct {
 type ReviewRequests struct {
 	Nodes []struct {
 		RequestedReviewer struct {
-			TypeName string `json:"__typename"`
-			Login    string `json:"login"`
-			Name     string `json:"name"`
+			TypeName     string `json:"__typename"`
+			Login        string `json:"login"`
+			Name         string `json:"name"`
+			Slug         string `json:"slug"`
+			Organization struct {
+				Login string `json:"login"`
+			}
 		}
 	}
 }
 
+const teamTypeName = "Team"
+
 func (r ReviewRequests) Logins() []string {
 	logins := make([]string, len(r.Nodes))
 	for i, a := range r.Nodes {
-		logins[i] = a.RequestedReviewer.Login
+		if a.RequestedReviewer.TypeName == teamTypeName {
+			logins[i] = a.RequestedReviewer.Organization.Login + "/" + a.RequestedReviewer.Slug
+		} else {
+			logins[i] = a.RequestedReviewer.Login
+		}
 	}
 	return logins
 }

--- a/api/queries_pr_test.go
+++ b/api/queries_pr_test.go
@@ -2,12 +2,12 @@ package api
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/httpmock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBranchDeleteRemote(t *testing.T) {
@@ -149,13 +149,13 @@ func Test_determinePullRequestFeatures(t *testing.T) {
 			}
 
 			gotPrFeatures, err := determinePullRequestFeatures(httpClient, tt.hostname)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("determinePullRequestFeatures() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				assert.Error(t, err)
 				return
+			} else {
+				assert.NoError(t, err)
 			}
-			if !reflect.DeepEqual(gotPrFeatures, tt.wantPrFeatures) {
-				t.Errorf("determinePullRequestFeatures() = %v, want %v", gotPrFeatures, tt.wantPrFeatures)
-			}
+			assert.Equal(t, tt.wantPrFeatures, gotPrFeatures)
 		})
 	}
 }
@@ -168,9 +168,9 @@ func Test_Logins(t *testing.T) {
 		want             []string
 	}{
 		{
-			name: "no requested reviewers",
+			name:             "no requested reviewers",
 			requestedReviews: `{"nodes": []}`,
-			want: []string{},
+			want:             []string{},
 		},
 		{
 			name: "user",
@@ -234,13 +234,9 @@ func Test_Logins(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := json.Unmarshal([]byte(tt.requestedReviews), &rr)
-			if err != nil {
-				t.Fatalf("Failed to unmarshal json string as ReviewRequests: %v", tt.requestedReviews)
-			}
-			got := rr.Logins()
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("Unexpected results: expected %v but got %v", tt.want, got)
-			}
+			assert.NoError(t, err, "Failed to unmarshal json string as ReviewRequests")
+			logins := rr.Logins()
+			assert.Equal(t, tt.want, logins)
 		})
 	}
 }

--- a/api/queries_pr_test.go
+++ b/api/queries_pr_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -154,6 +155,91 @@ func Test_determinePullRequestFeatures(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotPrFeatures, tt.wantPrFeatures) {
 				t.Errorf("determinePullRequestFeatures() = %v, want %v", gotPrFeatures, tt.wantPrFeatures)
+			}
+		})
+	}
+}
+
+func Test_Logins(t *testing.T) {
+	rr := ReviewRequests{}
+	var tests = []struct {
+		name             string
+		requestedReviews string
+		want             []string
+	}{
+		{
+			name: "no requested reviewers",
+			requestedReviews: `{"nodes": []}`,
+			want: []string{},
+		},
+		{
+			name: "user",
+			requestedReviews: `{"nodes": [
+				{
+					"requestedreviewer": {
+						"__typename": "User", "login": "testuser"
+					}
+				}
+			]}`,
+			want: []string{"testuser"},
+		},
+		{
+			name: "team",
+			requestedReviews: `{"nodes": [
+				{
+					"requestedreviewer": {
+						"__typename": "Team",
+						"name": "Test Team",
+						"slug": "test-team",
+						"organization": {"login": "myorg"}
+					}
+				}
+			]}`,
+			want: []string{"myorg/test-team"},
+		},
+		{
+			name: "multiple users and teams",
+			requestedReviews: `{"nodes": [
+				{
+					"requestedreviewer": {
+						"__typename": "User", "login": "user1"
+					}
+				},
+				{
+					"requestedreviewer": {
+						"__typename": "User", "login": "user2"
+					}
+				},
+				{
+					"requestedreviewer": {
+						"__typename": "Team",
+						"name": "Test Team",
+						"slug": "test-team",
+						"organization": {"login": "myorg"}
+					}
+				},
+				{
+					"requestedreviewer": {
+						"__typename": "Team",
+						"name": "Dev Team",
+						"slug": "dev-team",
+						"organization": {"login": "myorg"}
+					}
+				}
+			]}`,
+			want: []string{"user1", "user2", "myorg/test-team", "myorg/dev-team"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := json.Unmarshal([]byte(tt.requestedReviews), &rr)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal json string as ReviewRequests: %v", tt.requestedReviews)
+			}
+			got := rr.Logins()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Unexpected results: expected %v but got %v", tt.want, got)
 			}
 		})
 	}

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -41,7 +41,11 @@ var prReviewRequests = shortenQuery(`
 			requestedReviewer {
 				__typename,
 				...on User{login},
-				...on Team{name}
+				...on Team{
+					organization{login}
+					name,
+					slug
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #3705

### The issue:
According to the [documentation](https://cli.github.com/manual/gh_pr_edit) of `gh pr edit`, the `--add-reviewer` and `--remove-reviewer` flags accept team users with the following format: `myorg/team-slug`.
If the PR doesn't have any team user specified in the "reviewers" section, the existing code works.
But if the PR already has a team user specified in the "reviewers" section, the `gh pr edit 1 --add-reviewer myorg/other-team` command fails with the error message: `'' not found`.

### Identifying the root cause:
This error is returned by the TeamsToIDs function in `api/queries_repo.go`, because one element in `names` is an empty string.
Going further in debugging this, I found out that the empty string was generated by the Logins function in `api/queries_pr.go`.
The Logins function was using the RequestedReviewer.Login attribute for both normal users and team users. But teams don't have a Login field (see [Team graphql reference](https://docs.github.com/en/graphql/reference/objects#team)). So, when parsing an existing PR with a team as reviewer, the Logins function returns a list with an empty string element.

### Fix proposal:
This fix updates the graphql query to get the slug and the organization login in case of a team element, and it adds a check on the typename in Logins to build the login for a team concatenating the org login and the team slug. That way the team login can be compared to values in --add-reviewer, --remove-reviewer flags and in the metadata of the repo.

### Testing:
I added a simple unit test for the Logins function. I also built the gh command with the changes and manually tried the `gh pr edit` command with different combinations of the `--add-reviewer` and `--remove-reviewer` flags.

Thank you in advance for your inputs on this PR. Please let me know in case changes to the fix would be needed.