### PR TITLE
Fix test that was deleting local config folder

### DIFF
--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -242,6 +242,7 @@ func Test_configFile_Write_toDisk(t *testing.T) {
 	configDir := filepath.Join(t.TempDir(), ".config", "gh")
 	os.Setenv(GH_CONFIG_DIR, configDir)
 	defer os.Unsetenv(GH_CONFIG_DIR)
+	defer stubMigrateConfigDir()()
 
 	cfg := NewFromString(`pager: less`)
 	err := cfg.Write()


### PR DESCRIPTION
Stub out auto config dir migration in test