### PR TITLE
Add support for XDG_STATE_HOME

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -264,7 +264,7 @@ func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {
 	}
 
 	repo := updaterEnabled
-	stateFilePath := filepath.Join(config.ConfigDir(), "state.yml")
+	stateFilePath := filepath.Join(config.StateDir(), "state.yml")
 	return update.CheckForUpdate(client, stateFilePath, repo, currentVersion)
 }
 

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -269,8 +269,7 @@ func Test_configFile_Write_toDisk(t *testing.T) {
 	}
 }
 
-func Test_autoMigrateConfigDir_noMigration(t *testing.T) {
-	// homeDir does not have any config files
+func Test_autoMigrateConfigDir_noMigration_notExist(t *testing.T) {
 	homeDir := t.TempDir()
 	migrateDir := t.TempDir()
 
@@ -282,7 +281,8 @@ func Test_autoMigrateConfigDir_noMigration(t *testing.T) {
 	os.Setenv(homeEnvVar, homeDir)
 	defer os.Setenv(homeEnvVar, old)
 
-	autoMigrateConfigDir(migrateDir)
+	err := autoMigrateConfigDir(migrateDir)
+	assert.Equal(t, errNotExist, err)
 
 	files, err := ioutil.ReadDir(migrateDir)
 	assert.NoError(t, err)
@@ -303,7 +303,8 @@ func Test_autoMigrateConfigDir_noMigration_samePath(t *testing.T) {
 	os.Setenv(homeEnvVar, homeDir)
 	defer os.Setenv(homeEnvVar, old)
 
-	autoMigrateConfigDir(migrateDir)
+	err = autoMigrateConfigDir(migrateDir)
+	assert.Equal(t, errSamePath, err)
 
 	files, err := ioutil.ReadDir(migrateDir)
 	assert.NoError(t, err)
@@ -330,7 +331,8 @@ func Test_autoMigrateConfigDir_migration(t *testing.T) {
 	assert.NoError(t, err)
 	f.Close()
 
-	autoMigrateConfigDir(migrateConfigDir)
+	err = autoMigrateConfigDir(migrateConfigDir)
+	assert.NoError(t, err)
 
 	_, err = ioutil.ReadDir(homeConfigDir)
 	assert.True(t, os.IsNotExist(err))
@@ -395,8 +397,7 @@ func Test_StateDir(t *testing.T) {
 	}
 }
 
-func Test_autoMigrateStateDir_noMigration(t *testing.T) {
-	// homeDir does not have any config files
+func Test_autoMigrateStateDir_noMigration_notExist(t *testing.T) {
 	homeDir := t.TempDir()
 	migrateDir := t.TempDir()
 
@@ -408,7 +409,8 @@ func Test_autoMigrateStateDir_noMigration(t *testing.T) {
 	os.Setenv(homeEnvVar, homeDir)
 	defer os.Setenv(homeEnvVar, old)
 
-	autoMigrateStateDir(migrateDir)
+	err := autoMigrateStateDir(migrateDir)
+	assert.Equal(t, errNotExist, err)
 
 	files, err := ioutil.ReadDir(migrateDir)
 	assert.NoError(t, err)
@@ -429,7 +431,8 @@ func Test_autoMigrateStateDir_noMigration_samePath(t *testing.T) {
 	os.Setenv(homeEnvVar, homeDir)
 	defer os.Setenv(homeEnvVar, old)
 
-	autoMigrateStateDir(migrateDir)
+	err = autoMigrateStateDir(migrateDir)
+	assert.Equal(t, errSamePath, err)
 
 	files, err := ioutil.ReadDir(migrateDir)
 	assert.NoError(t, err)
@@ -455,7 +458,8 @@ func Test_autoMigrateStateDir_migration(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(homeConfigDir, "state.yml"), nil, 0755)
 	assert.NoError(t, err)
 
-	autoMigrateStateDir(migrateConfigDir)
+	err = autoMigrateStateDir(migrateConfigDir)
+	assert.NoError(t, err)
 
 	files, err := ioutil.ReadDir(homeConfigDir)
 	assert.NoError(t, err)

--- a/internal/config/testing.go
+++ b/internal/config/testing.go
@@ -62,11 +62,3 @@ func stubConfig(main, hosts string) func() {
 		ReadConfigFile = orig
 	}
 }
-
-func stubMigrateConfigDir() func() {
-	orig := migrateConfigDir
-	migrateConfigDir = func(_, _ string) {}
-	return func() {
-		migrateConfigDir = orig
-	}
-}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -3,6 +3,8 @@ package update
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -83,9 +85,14 @@ func setStateEntry(stateFilePath string, t time.Time, r ReleaseInfo) error {
 	if err != nil {
 		return err
 	}
-	_ = ioutil.WriteFile(stateFilePath, content, 0600)
 
-	return nil
+	err = os.MkdirAll(filepath.Dir(stateFilePath), 0755)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(stateFilePath, content, 0600)
+	return err
 }
 
 func versionGreaterThan(v, w string) bool {


### PR DESCRIPTION
This PR adds support for the `XDG_STATE_HOME` environment variable. If present we will store the `state.yml` file at the path provided, if one already exists in the old config location we will try to migrate it to the new path. If the environment variable is not present then behavior will remain the same and the config directory will continue to be used to store `state.yml`. 

cc #2470
cc #554 