### PR TITLE
fix listing of PRs when merged ones are searched

### DIFF
--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -112,13 +112,14 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
-	if opts.State == "open" && shared.QueryHasStateClause(opts.Search) {
-		opts.State = ""
+	issueState := strings.ToLower(opts.State)
+	if issueState == "open" && shared.QueryHasStateClause(opts.Search) {
+		issueState = ""
 	}
 
 	filterOptions := prShared.FilterOptions{
 		Entity:    "issue",
-		State:     strings.ToLower(opts.State),
+		State:     issueState,
 		Assignee:  opts.Assignee,
 		Labels:    opts.Labels,
 		Author:    opts.Author,

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -112,6 +112,10 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
+	if opts.State == "open" && shared.QueryHasStateClause(opts.Search) {
+		opts.State = ""
+	}
+
 	filterOptions := prShared.FilterOptions{
 		Entity:    "issue",
 		State:     strings.ToLower(opts.State),

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -116,13 +116,14 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
-	if opts.State == "open" && shared.QueryHasStateClause(opts.Search) {
-		opts.State = ""
+	prState := strings.ToLower(opts.State)
+	if prState == "open" && shared.QueryHasStateClause(opts.Search) {
+		prState = ""
 	}
 
 	filters := shared.FilterOptions{
 		Entity:     "pr",
-		State:      strings.ToLower(opts.State),
+		State:      prState,
 		Author:     opts.Author,
 		Assignee:   opts.Assignee,
 		Labels:     opts.Labels,

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -2,9 +2,7 @@ package list
 
 import (
 	"fmt"
-	"github.com/google/shlex"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -118,17 +116,8 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
-	argv, err := shlex.Split(opts.Search)
-	if err != nil {
-		return err
-	}
-
-	re := regexp.MustCompile(`^merged:.*`)
-
-	for _, arg := range argv {
-		if opts.State == "open" && (arg == "is:closed" || arg == "is:merged" || re.MatchString(arg)) {
-			opts.State = ""
-		}
+	if opts.State == "open" && shared.QueryHasStateClause(opts.Search) {
+		opts.State = ""
 	}
 
 	filters := shared.FilterOptions{

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -119,6 +119,9 @@ func listRun(opts *ListOptions) error {
 	}
 
 	argv, err := shlex.Split(opts.Search)
+	if err != nil {
+		return err
+	}
 
 	re := regexp.MustCompile(`^merged:.*`)
 

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -2,7 +2,9 @@ package list
 
 import (
 	"fmt"
+	"github.com/google/shlex"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -114,6 +116,16 @@ func listRun(opts *ListOptions) error {
 	baseRepo, err := opts.BaseRepo()
 	if err != nil {
 		return err
+	}
+
+	argv, err := shlex.Split(opts.Search)
+
+	re := regexp.MustCompile(`^merged:.*`)
+
+	for _, arg := range argv {
+		if opts.State == "open" && (arg == "is:closed" || arg == "is:merged" || re.MatchString(arg)) {
+			opts.State = ""
+		}
 	}
 
 	filters := shared.FilterOptions{

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	"github.com/google/shlex"
 	"net/url"
 	"strings"
 
@@ -241,6 +242,21 @@ func SearchQueryBuild(options FilterOptions) string {
 	}
 
 	return q.String()
+}
+
+func QueryHasStateClause(searchQuery string) bool {
+	argv, err := shlex.Split(searchQuery)
+	if err != nil {
+		return false
+	}
+
+	for _, arg := range argv {
+		if arg == "is:closed" || arg == "is:merged" || arg == "state:closed" || arg == "state:merged" || strings.HasPrefix(arg, "merged:") || strings.HasPrefix(arg, "closed:") {
+			return true
+		}
+	}
+
+	return false
 }
 
 // MeReplacer resolves usages of `@me` to the handle of the currently logged in user.

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"reflect"
 	"testing"
@@ -149,5 +150,45 @@ func TestMeReplacer_Replace(t *testing.T) {
 				tt.verify(t)
 			}
 		})
+	}
+}
+
+func Test_QueryHasStateClause(t *testing.T) {
+	tests := []struct {
+		searchQuery string
+		hasState    bool
+	}{
+		{
+			searchQuery: "is:closed is:merged",
+			hasState:    true,
+		},
+		{
+			searchQuery: "author:mislav",
+			hasState:    false,
+		},
+		{
+			searchQuery: "assignee:g14a mentions:vilmibm",
+			hasState:    false,
+		},
+		{
+			searchQuery: "merged:>2021-05-20",
+			hasState:    true,
+		},
+		{
+			searchQuery: "state:merged state:open",
+			hasState:    true,
+		},
+		{
+			searchQuery: "assignee:g14a is:closed",
+			hasState:    true,
+		},
+		{
+			searchQuery: "state:closed label:bug",
+			hasState:    true,
+		},
+	}
+	for _, tt := range tests {
+		gotState := QueryHasStateClause(tt.searchQuery)
+		assert.Equal(t, tt.hasState, gotState)
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
This commit fixes the bug where empty list is being returned when merged PRs are searched.

Fixes https://github.com/cli/cli/issues/3702