### PR TITLE
Fix how teams are displayed in requested reviewers

### DIFF
--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -80,10 +80,20 @@ func (pr *PullRequest) ExportData(fields []string) *map[string]interface{} {
 		case "reviewRequests":
 			requests := make([]interface{}, 0, len(pr.ReviewRequests.Nodes))
 			for _, req := range pr.ReviewRequests.Nodes {
-				if req.RequestedReviewer.TypeName == "" {
-					continue
+				r := req.RequestedReviewer
+				switch r.TypeName {
+				case "User":
+					requests = append(requests, map[string]string{
+						"__typename": r.TypeName,
+						"login":      r.Login,
+					})
+				case "Team":
+					requests = append(requests, map[string]string{
+						"__typename": r.TypeName,
+						"name":       r.Name,
+						"slug":       r.LoginOrSlug(),
+					})
 				}
-				requests = append(requests, req.RequestedReviewer)
 			}
 			data[f] = &requests
 		default:

--- a/pkg/cmd/pr/view/fixtures/prViewPreviewWithReviewersByNumber.json
+++ b/pkg/cmd/pr/view/fixtures/prViewPreviewWithReviewersByNumber.json
@@ -21,10 +21,12 @@
               }
             },
             {
-                "requestedReviewer": {
-                    "__typename": "Team",
-                    "name": "Team 1"
-                }
+              "requestedReviewer": {
+                "__typename": "Team",
+                "name": "Team 1",
+                "slug": "team-1",
+                "organization": {"login": "my-org"}
+              }
             },
             {
               "requestedReviewer": {

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -294,8 +294,6 @@ func prReviewerList(pr api.PullRequest, cs *iostreams.ColorScheme) string {
 	return reviewerList
 }
 
-const teamTypeName = "Team"
-
 const ghostName = "ghost"
 
 // parseReviewers parses given Reviews and ReviewRequests
@@ -317,10 +315,7 @@ func parseReviewers(pr api.PullRequest) []*reviewerState {
 
 	// Overwrite reviewer's state if a review request for the same reviewer exists.
 	for _, reviewRequest := range pr.ReviewRequests.Nodes {
-		name := reviewRequest.RequestedReviewer.Login
-		if reviewRequest.RequestedReviewer.TypeName == teamTypeName {
-			name = reviewRequest.RequestedReviewer.Name
-		}
+		name := reviewRequest.RequestedReviewer.LoginOrSlug()
 		reviewerStates[name] = &reviewerState{
 			Name:  name,
 			State: requestedReviewState,

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -250,7 +250,7 @@ func TestPRView_Preview_nontty(t *testing.T) {
 				`milestone:\t\n`,
 				`additions:\t100\n`,
 				`deletions:\t10\n`,
-				`reviewers:\tDEF \(Commented\), def \(Changes requested\), ghost \(Approved\), hubot \(Commented\), xyz \(Approved\), 123 \(Requested\), Team 1 \(Requested\), abc \(Requested\)\n`,
+				`reviewers:\tDEF \(Commented\), def \(Changes requested\), ghost \(Approved\), hubot \(Commented\), xyz \(Approved\), 123 \(Requested\), abc \(Requested\), my-org\/team-1 \(Requested\)\n`,
 				`\*\*blueberries taste good\*\*`,
 			},
 		},
@@ -383,7 +383,7 @@ func TestPRView_Preview(t *testing.T) {
 			},
 			expectedOutputs: []string{
 				`Blueberries are from a fork`,
-				`Reviewers:.*DEF \(.*Commented.*\), def \(.*Changes requested.*\), ghost \(.*Approved.*\), hubot \(Commented\), xyz \(.*Approved.*\), 123 \(.*Requested.*\), Team 1 \(.*Requested.*\), abc \(.*Requested.*\)\n`,
+				`Reviewers: DEF \(Commented\), def \(Changes requested\), ghost \(Approved\), hubot \(Commented\), xyz \(Approved\), 123 \(Requested\), abc \(Requested\), my-org\/team-1 \(Requested\)`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`,
 			},


### PR DESCRIPTION
1. The `--json` export now only renders the `login` field for User types and `name` and `slug` fields for Team types.
2. The `pr view` command now renders team reviewers in the format of `ORG/SLUG` instead of the team name. This is so that the same value can be used in the `pr create -r` flag.

```
## BEFORE
$ gh pr view 123 --json reviewRequests
{
  "reviewRequests": [
    {
      "__typename": "User",
      "login": "monalisa",
      "name": "",
      "slug": "",
      "Organization": {
        "login": ""
      }
    },
    {
      "__typename": "Team",
      "login": "",
      "name": "Some team",
      "slug": "some-team",
      "Organization": {
        "login": "myorg"
      }
    }
  ]
}

## AFTER
$ gh pr view 123 --json reviewRequests
{
  "reviewRequests": [
    {
      "__typename": "User",
      "login": "monalisa"
    },
    {
      "__typename": "Team",
      "name": "Some team",
      "slug": "myorg/some-team"
    }
  ]
}
```

Followup to https://github.com/cli/cli/pull/3701