### PR TITLE
Feature/create repo with gitignore license

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -220,7 +220,6 @@ func (c Client) REST(hostname string, method string, p string, body io.Reader, d
 	if err != nil {
 		return err
 	}
-
 	err = json.Unmarshal(b, &data)
 	if err != nil {
 		return err

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -20,7 +20,7 @@ type Repository struct {
 	ID                       string
 	Name                     string
 	NameWithOwner            string
-	Owner                    RepositoryOwner `json:"owner"`
+	Owner                    RepositoryOwner
 	Parent                   *Repository
 	TemplateRepository       *Repository
 	Description              string

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -442,11 +442,12 @@ func InitRepoHostname(repo *Repository, hostname string) *Repository {
 
 // RepositoryV3 is the repository result from GitHub API v3
 type repositoryV3 struct {
-	NodeID    string
+	NodeID    string `json:"node_id"`
 	Name      string
 	CreatedAt time.Time `json:"created_at"`
 	Owner     struct {
 		Login string
+		ID    string
 	}
 	Private  bool
 	HTMLUrl  string `json:"html_url"`
@@ -1133,8 +1134,10 @@ func CreateRepoTransformToV4(apiClient *Client, hostname string, method string, 
 		CreatedAt: responsev3.CreatedAt,
 		Owner: RepositoryOwner{
 			Login: responsev3.Owner.Login,
+			ID:    responsev3.Owner.ID,
 		},
-		hostname:  responsev3.hostname,
+		ID:        responsev3.NodeID,
+		hostname:  hostname,
 		URL:       responsev3.HTMLUrl,
 		IsPrivate: responsev3.Private,
 	}, nil

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -447,7 +447,6 @@ type repositoryV3 struct {
 	CreatedAt time.Time `json:"created_at"`
 	Owner     struct {
 		Login string
-		ID    string
 	}
 	Private  bool
 	HTMLUrl  string `json:"html_url"`
@@ -1133,7 +1132,6 @@ func CreateRepoTransformToV4(apiClient *Client, hostname string, method string, 
 		CreatedAt: responsev3.CreatedAt,
 		Owner: RepositoryOwner{
 			Login: responsev3.Owner.Login,
-			ID:    responsev3.Owner.ID,
 		},
 		ID:        responsev3.NodeID,
 		hostname:  hostname,

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -455,6 +455,8 @@ type RepositoryV3 struct {
 	Owner     struct {
 		Login string
 	}
+	Private  bool
+	HTMLUrl  string `json:"html_url"`
 	Parent   *RepositoryV3
 	hostname string
 }

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -448,9 +448,9 @@ type repositoryV3 struct {
 	Owner     struct {
 		Login string
 	}
-	Private  bool
-	HTMLUrl  string `json:"html_url"`
-	Parent   *repositoryV3
+	Private bool
+	HTMLUrl string `json:"html_url"`
+	Parent  *repositoryV3
 }
 
 // ForkRepo forks the repository on GitHub and returns the new repository

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -452,7 +452,6 @@ type repositoryV3 struct {
 	Private  bool
 	HTMLUrl  string `json:"html_url"`
 	Parent   *repositoryV3
-	hostname string
 }
 
 // ForkRepo forks the repository on GitHub and returns the new repository

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -98,6 +98,10 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return &cmdutil.FlagError{Err: errors.New(".gitignore and license templates are added only when a specific repository name is passed")}
 			}
 
+			if opts.Template != "" && (opts.GitIgnoreTemplate != "" || opts.LicenseTemplate != "") {
+				return &cmdutil.FlagError{Err: errors.New(".gitignore and license templates are not added when template is provided")}
+			}
+
 			if !opts.IO.CanPrompt() {
 				if opts.Name == "" {
 					return &cmdutil.FlagError{Err: errors.New("name argument required when not running interactively")}
@@ -217,7 +221,8 @@ func createRun(opts *CreateOptions) error {
 			return err
 		}
 
-		if gitIgnoreTemplate == "" {
+		// GitIgnore and License templates not added when a template repository is passed.
+		if gitIgnoreTemplate == "" && opts.Template == "" && opts.IO.CanPrompt() {
 			gt, err := interactiveGitIgnore(api.NewClientFromHTTP(httpClient), host)
 			if err != nil {
 				return err
@@ -225,7 +230,7 @@ func createRun(opts *CreateOptions) error {
 			gitIgnoreTemplate = gt
 		}
 
-		if repoLicenseTemplate == "" {
+		if repoLicenseTemplate == "" && opts.Template == "" && opts.IO.CanPrompt() {
 			lt, err := interactiveLicense(api.NewClientFromHTTP(httpClient), host)
 			if err != nil {
 				return err
@@ -243,6 +248,7 @@ func createRun(opts *CreateOptions) error {
 			return fmt.Errorf("argument error: %w", err)
 		}
 	} else {
+		fmt.Println("came inside")
 		host, err := cfg.DefaultHost()
 		if err != nil {
 			return err

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -248,7 +248,6 @@ func createRun(opts *CreateOptions) error {
 			return fmt.Errorf("argument error: %w", err)
 		}
 	} else {
-		fmt.Println("came inside")
 		host, err := cfg.DefaultHost()
 		if err != nil {
 			return err

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -455,6 +455,18 @@ func TestRepoCreate_withoutNameArg(t *testing.T) {
 			Name:  "repoVisibility",
 			Value: "PRIVATE",
 		},
+		{
+			Name: "optionToSkip",
+			Value: true,
+		},
+		{
+			Name: "gitIgnoreLicense",
+			Value: "license",
+		},
+		{
+			Name: "repoLicense",
+			Value: "Apache License 2.0",
+		},
 	})
 	as.Stub([]*prompt.QuestionStub{
 		{

--- a/pkg/cmd/repo/create/http.go
+++ b/pkg/cmd/repo/create/http.go
@@ -116,7 +116,7 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput, tem
 			return nil, err
 		}
 		var responseV3 api.RepositoryV3
-		err := apiClient.REST(hostname, "POST", fmt.Sprintf("user/repos"), body, &responseV3)
+		err := apiClient.REST(hostname, "POST", "user/repos", body, &responseV3)
 		if err != nil {
 			return nil, err
 		}
@@ -166,7 +166,7 @@ func resolveOrganizationTeam(client *api.Client, hostname, orgName, teamSlug str
 // ListGitIgnoreTemplates uses API v3 here because gitignore template isn't supported by GraphQL yet.
 func ListGitIgnoreTemplates(client *api.Client, hostname string) ([]string, error) {
 	var gitIgnoreTemplates []string
-	err := client.REST(hostname, "GET", fmt.Sprintf("gitignore/templates"), nil, &gitIgnoreTemplates)
+	err := client.REST(hostname, "GET", "gitignore/templates", nil, &gitIgnoreTemplates)
 	if err != nil {
 		return []string{}, err
 	}
@@ -176,7 +176,7 @@ func ListGitIgnoreTemplates(client *api.Client, hostname string) ([]string, erro
 // ListLicenseTemplates uses API v3 here because license template isn't supported by GraphQL yet.
 func ListLicenseTemplates(client *api.Client, hostname string) ([]api.License, error) {
 	var licenseTemplates []api.License
-	err := client.REST(hostname, "GET", fmt.Sprintf("licenses"), nil, &licenseTemplates)
+	err := client.REST(hostname, "GET", "licenses", nil, &licenseTemplates)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/repo/create/http.go
+++ b/pkg/cmd/repo/create/http.go
@@ -120,8 +120,7 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput, tem
 		if err != nil {
 			return nil, err
 		}
-		fmt.Println(&responseV3, "==========response v3===========")
-		return &responseV3, nil
+		return api.InitRepoV3Hostname(&responseV3, hostname), nil
 	}
 
 	err := apiClient.GraphQL(hostname, `


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

This commit adds a feature where you can initialize a repository with a `.gitignore` and/or a `license` template.

Fixes https://github.com/cli/cli/issues/1907

Attaching screenshots for reference:

- <img width="657" alt="image" src="https://user-images.githubusercontent.com/17702388/120097341-8a305d00-c14d-11eb-817b-eaae4eafbec4.png">

- <img width="657" alt="image" src="https://user-images.githubusercontent.com/17702388/120097347-99170f80-c14d-11eb-8557-2806af6a52e8.png">

- <img width="657" alt="image" src="https://user-images.githubusercontent.com/17702388/120097374-be0b8280-c14d-11eb-806a-0570d1bca9ba.png">

- <img width="657" alt="image" src="https://user-images.githubusercontent.com/17702388/120097398-daa7ba80-c14d-11eb-96d0-235e31a97c77.png">


