### PR TITLE
Add support for XDG_DATA_HOME

### DIFF
--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -17,6 +17,7 @@ const (
 	GH_CONFIG_DIR   = "GH_CONFIG_DIR"
 	XDG_CONFIG_HOME = "XDG_CONFIG_HOME"
 	XDG_STATE_HOME  = "XDG_STATE_HOME"
+	XDG_DATA_HOME   = "XDG_DATA_HOME"
 	APP_DATA        = "AppData"
 	LOCAL_APP_DATA  = "LocalAppData"
 )
@@ -65,6 +66,24 @@ func StateDir() string {
 	// If the path does not exist try migrating state from default paths
 	if !dirExists(path) {
 		_ = autoMigrateStateDir(path)
+	}
+
+	return path
+}
+
+// Data path precedence
+// 1. XDG_DATA_HOME
+// 2. LocalAppData (windows only)
+// 3. HOME
+func DataDir() string {
+	var path string
+	if a := os.Getenv(XDG_DATA_HOME); a != "" {
+		path = filepath.Join(a, "gh")
+	} else if b := os.Getenv(LOCAL_APP_DATA); runtime.GOOS == "windows" && b != "" {
+		path = filepath.Join(b, "GitHub CLI")
+	} else {
+		c, _ := os.UserHomeDir()
+		path = filepath.Join(c, ".local", "share", "gh")
 	}
 
 	return path

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -64,6 +64,12 @@ var HelpTopics = map[string]map[string]string{
 			GH_NO_UPDATE_NOTIFIER: set to any value to disable update notifications. By default, gh
 			checks for new releases once every 24 hours and displays an upgrade notice on standard
 			error if a newer version was found.
+
+			GH_CONFIG_DIR, XDG_CONFIG_HOME (in order of precedence): the directory where gh will store configuration files.
+
+			XDG_STATE_HOME: the directory where gh will store state files.
+
+			XDG_DATA_HOME: the directory where gh will store data files.
 		`),
 	},
 	"reference": {


### PR DESCRIPTION
This PR introduces support for XDG_DATA_HOME to store data files. Since we don't currently have any data files stored there is no migration code. It also documents the new `XDG` environment variables in the environment help topic.

cc #2470
cc #554
closes https://github.com/cli/cli/issues/3712