### PR TITLE
Add a long command description for secrets remove

### DIFF
--- a/pkg/cmd/secret/remove/remove.go
+++ b/pkg/cmd/secret/remove/remove.go
@@ -32,7 +32,8 @@ func NewCmdRemove(f *cmdutil.Factory, runF func(*RemoveOptions) error) *cobra.Co
 
 	cmd := &cobra.Command{
 		Use:   "remove <secret-name>",
-		Short: "Remove an organization, environment, or repository secret",
+		Short: "Remove secrets",
+		Long:  "Remove a secret for a repository, environment, or organization",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override


### PR DESCRIPTION
I noticed that the `set` and `list` commands have short and long description but remove has only a short one which is more like a long one. 

```
 ➜ gh secret --help
Secrets can be set at the repository, environment, or organization level for use in
GitHub Actions. Run "gh help secret set" to learn how to get started.


USAGE
  gh secret <command> [flags]

CORE COMMANDS
  list:       List secrets
  remove:     Remove an organization, environment, or repository secret
  set:        Create or update secrets
```

Would probably be better for consistency to have the current comamnd description be defined as long one.