### PR TITLE
Allow explicitly empty body in issue/pr create

### DIFF
--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -234,10 +234,6 @@ func createRun(opts *CreateOptions) (err error) {
 			if err != nil {
 				return
 			}
-
-			if tb.Body == "" {
-				tb.Body = templateContent
-			}
 		}
 
 		openURL, err = generatePreviewURL(apiClient, baseRepo, tb)

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -114,6 +114,8 @@ func TestNewCmdCreate(t *testing.T) {
 			args, err := shlex.Split(tt.cli)
 			require.NoError(t, err)
 			cmd.SetArgs(args)
+			cmd.SetOut(ioutil.Discard)
+			cmd.SetErr(ioutil.Discard)
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
 				assert.Error(t, err)
@@ -168,7 +170,7 @@ func Test_createRun(t *testing.T) {
 				WebMode:   true,
 				Assignees: []string{"monalisa"},
 			},
-			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?assignees=monalisa",
+			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?assignees=monalisa&body=",
 			wantsStderr: "Opening github.com/OWNER/REPO/issues/new in your browser.\n",
 		},
 		{
@@ -185,7 +187,7 @@ func Test_createRun(t *testing.T) {
 						"viewer": { "login": "MonaLisa" }
 					} }`))
 			},
-			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?assignees=MonaLisa",
+			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?assignees=MonaLisa&body=",
 			wantsStderr: "Opening github.com/OWNER/REPO/issues/new in your browser.\n",
 		},
 		{
@@ -214,7 +216,7 @@ func Test_createRun(t *testing.T) {
 						"pageInfo": { "hasNextPage": false }
 					} } } }`))
 			},
-			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?projects=OWNER%2FREPO%2F1",
+			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?body=&projects=OWNER%2FREPO%2F1",
 			wantsStderr: "Opening github.com/OWNER/REPO/issues/new in your browser.\n",
 		},
 		{

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -302,10 +302,6 @@ func createRun(opts *CreateOptions) (err error) {
 		if err != nil {
 			return
 		}
-
-		if state.Body == "" {
-			state.Body = templateContent
-		}
 	}
 
 	openURL, err = generateCompareURL(*ctx, *state)

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -239,7 +239,7 @@ func TestPRCreate_nontty_web(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, "", output.Stderr())
-	assert.Equal(t, "https://github.com/OWNER/REPO/compare/master...feature?expand=1", output.BrowsedURL)
+	assert.Equal(t, "https://github.com/OWNER/REPO/compare/master...feature?body=&expand=1", output.BrowsedURL)
 }
 
 func TestPRCreate_recover(t *testing.T) {
@@ -780,7 +780,7 @@ func TestPRCreate_web(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, "Opening github.com/OWNER/REPO/compare/master...feature in your browser.\n", output.Stderr())
-	assert.Equal(t, "https://github.com/OWNER/REPO/compare/master...feature?expand=1", output.BrowsedURL)
+	assert.Equal(t, "https://github.com/OWNER/REPO/compare/master...feature?body=&expand=1", output.BrowsedURL)
 }
 
 func TestPRCreate_webLongURL(t *testing.T) {
@@ -851,7 +851,7 @@ func TestPRCreate_webProject(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, "Opening github.com/OWNER/REPO/compare/master...feature in your browser.\n", output.Stderr())
-	assert.Equal(t, "https://github.com/OWNER/REPO/compare/master...feature?expand=1&projects=ORG%2F1", output.BrowsedURL)
+	assert.Equal(t, "https://github.com/OWNER/REPO/compare/master...feature?body=&expand=1&projects=ORG%2F1", output.BrowsedURL)
 }
 
 func Test_determineTrackingBranch_empty(t *testing.T) {
@@ -965,7 +965,7 @@ func Test_generateCompareURL(t *testing.T) {
 				BaseBranch:      "main",
 				HeadBranchLabel: "feature",
 			},
-			want:    "https://github.com/OWNER/REPO/compare/main...feature?expand=1",
+			want:    "https://github.com/OWNER/REPO/compare/main...feature?body=&expand=1",
 			wantErr: false,
 		},
 		{
@@ -978,7 +978,7 @@ func Test_generateCompareURL(t *testing.T) {
 			state: prShared.IssueMetadataState{
 				Labels: []string{"one", "two three"},
 			},
-			want:    "https://github.com/OWNER/REPO/compare/a...b?expand=1&labels=one%2Ctwo+three",
+			want:    "https://github.com/OWNER/REPO/compare/a...b?body=&expand=1&labels=one%2Ctwo+three",
 			wantErr: false,
 		},
 		{
@@ -988,7 +988,7 @@ func Test_generateCompareURL(t *testing.T) {
 				BaseBranch:      "main/trunk",
 				HeadBranchLabel: "owner:feature",
 			},
-			want:    "https://github.com/OWNER/REPO/compare/main%2Ftrunk...owner%3Afeature?expand=1",
+			want:    "https://github.com/OWNER/REPO/compare/main%2Ftrunk...owner%3Afeature?body=&expand=1",
 			wantErr: false,
 		},
 	}

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -2,13 +2,13 @@ package shared
 
 import (
 	"fmt"
-	"github.com/google/shlex"
 	"net/url"
 	"strings"
 
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/githubsearch"
+	"github.com/google/shlex"
 )
 
 func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, baseURL string, state IssueMetadataState) (string, error) {
@@ -20,9 +20,10 @@ func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, ba
 	if state.Title != "" {
 		q.Set("title", state.Title)
 	}
-	if state.Body != "" {
-		q.Set("body", state.Body)
-	}
+	// We always want to set body, even if it's empty, to prevent the web interface to apply the default
+	// template. Since the user has the option to select a template in the terminal, assume that empty body
+	// here means that the user either skipped it or erased its contents.
+	q.Set("body", state.Body)
 	if len(state.Assignees) > 0 {
 		q.Set("assignees", strings.Join(state.Assignees, ","))
 	}

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -20,9 +20,9 @@ func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, ba
 	if state.Title != "" {
 		q.Set("title", state.Title)
 	}
-	// We always want to set body, even if it's empty, to prevent the web interface to apply the default
-	// template. Since the user has the option to select a template in the terminal, assume that empty body
-	// here means that the user either skipped it or erased its contents.
+	// We always want to send the body parameter, even if it's empty, to prevent the web interface from
+	// applying the default template. Since the user has the option to select a template in the terminal,
+	// assume that empty body here means that the user either skipped it or erased its contents.
 	q.Set("body", state.Body)
 	if len(state.Assignees) > 0 {
 		q.Set("assignees", strings.Join(state.Assignees, ","))

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -1,7 +1,6 @@
 package shared
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"reflect"
 	"testing"
@@ -9,6 +8,7 @@ import (
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/httpmock"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_listURLWithQuery(t *testing.T) {
@@ -190,5 +190,58 @@ func Test_QueryHasStateClause(t *testing.T) {
 	for _, tt := range tests {
 		gotState := QueryHasStateClause(tt.searchQuery)
 		assert.Equal(t, tt.hasState, gotState)
+	}
+}
+
+func Test_WithPrAndIssueQueryParams(t *testing.T) {
+	type args struct {
+		baseURL string
+		state   IssueMetadataState
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "blank",
+			args: args{
+				baseURL: "",
+				state:   IssueMetadataState{},
+			},
+			want: "?body=",
+		},
+		{
+			name: "no values",
+			args: args{
+				baseURL: "http://example.com/hey",
+				state:   IssueMetadataState{},
+			},
+			want: "http://example.com/hey?body=",
+		},
+		{
+			name: "title and body",
+			args: args{
+				baseURL: "http://example.com/hey",
+				state: IssueMetadataState{
+					Title: "my title",
+					Body:  "my bodeh",
+				},
+			},
+			want: "http://example.com/hey?body=my+bodeh&title=my+title",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := WithPrAndIssueQueryParams(nil, nil, tt.args.baseURL, tt.args.state)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WithPrAndIssueQueryParams() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("WithPrAndIssueQueryParams() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -110,7 +110,7 @@ func BodySurvey(state *IssueMetadataState, templateContent, editorCommand string
 		return err
 	}
 
-	if state.Body != "" && preBody != state.Body {
+	if preBody != state.Body {
 		state.MarkDirty()
 	}
 

--- a/pkg/surveyext/editor.go
+++ b/pkg/surveyext/editor.go
@@ -35,6 +35,8 @@ type GhEditor struct {
 	*survey.Editor
 	EditorCommand string
 	BlankAllowed  bool
+
+	lookPath func(string) ([]string, []string, error)
 }
 
 func (e *GhEditor) editorCommand() string {
@@ -136,7 +138,11 @@ func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (int
 	}
 
 	stdio := e.Stdio()
-	text, err := Edit(e.editorCommand(), e.FileName, initialValue, stdio.In, stdio.Out, stdio.Err, cursor)
+	lookPath := e.lookPath
+	if lookPath == nil {
+		lookPath = defaultLookPath
+	}
+	text, err := edit(e.editorCommand(), e.FileName, initialValue, stdio.In, stdio.Out, stdio.Err, cursor, lookPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/surveyext/editor_manual.go
+++ b/pkg/surveyext/editor_manual.go
@@ -16,6 +16,18 @@ type showable interface {
 }
 
 func Edit(editorCommand, fn, initialValue string, stdin io.Reader, stdout io.Writer, stderr io.Writer, cursor showable) (string, error) {
+	return edit(editorCommand, fn, initialValue, stdin, stdout, stderr, cursor, defaultLookPath)
+}
+
+func defaultLookPath(name string) ([]string, []string, error) {
+	exe, err := safeexec.LookPath(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	return []string{exe}, nil, nil
+}
+
+func edit(editorCommand, fn, initialValue string, stdin io.Reader, stdout io.Writer, stderr io.Writer, cursor showable, lookPath func(string) ([]string, []string, error)) (string, error) {
 	// prepare the temp file
 	pattern := fn
 	if pattern == "" {
@@ -56,12 +68,14 @@ func Edit(editorCommand, fn, initialValue string, stdin io.Reader, stdout io.Wri
 	}
 	args = append(args, f.Name())
 
-	editorExe, err := safeexec.LookPath(args[0])
+	editorExe, env, err := lookPath(args[0])
 	if err != nil {
 		return "", err
 	}
+	args = append(editorExe, args[1:]...)
 
-	cmd := exec.Command(editorExe, args[1:]...)
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Env = env
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/pkg/surveyext/editor_test.go
+++ b/pkg/surveyext/editor_test.go
@@ -74,7 +74,7 @@ func Test_GhEditor_Prompt_skip(t *testing.T) {
 	// wait until the prompt is rendered and send the Enter key
 	go func() {
 		pty.WaitForOutput("Body")
-		assert.Equal(t, "\x1b[0G\x1b[2K\x1b[0;1;92m? \x1b[0m\x1b[0;1;99mBody \x1b[0m\x1b[0;36m[(e) to launch vim, enter to skip] \x1b[0m\x1b[?25l", pty.Output())
+		assert.Equal(t, "\x1b[0G\x1b[2K\x1b[0;1;92m? \x1b[0m\x1b[0;1;99mBody \x1b[0m\x1b[0;36m[(e) to launch vim, enter to skip] \x1b[0m", normalizeANSI(pty.Output()))
 		pty.ResetOutput()
 		assert.NoError(t, pty.SendKey('\n'))
 	}()
@@ -82,7 +82,7 @@ func Test_GhEditor_Prompt_skip(t *testing.T) {
 	res, err := e.Prompt(defaultPromptConfig())
 	assert.NoError(t, err)
 	assert.Equal(t, "initial value", res)
-	assert.Equal(t, "\x1b[?25h", pty.Output())
+	assert.Equal(t, "", normalizeANSI(pty.Output()))
 }
 
 func Test_GhEditor_Prompt_editorAppend(t *testing.T) {
@@ -105,7 +105,7 @@ func Test_GhEditor_Prompt_editorAppend(t *testing.T) {
 	// wait until the prompt is rendered and send the 'e' key
 	go func() {
 		pty.WaitForOutput("Body")
-		assert.Equal(t, "\x1b[0G\x1b[2K\x1b[0;1;92m? \x1b[0m\x1b[0;1;99mBody \x1b[0m\x1b[0;36m[(e) to launch vim, enter to skip] \x1b[0m\x1b[?25l", pty.Output())
+		assert.Equal(t, "\x1b[0G\x1b[2K\x1b[0;1;92m? \x1b[0m\x1b[0;1;99mBody \x1b[0m\x1b[0;36m[(e) to launch vim, enter to skip] \x1b[0m", normalizeANSI(pty.Output()))
 		pty.ResetOutput()
 		assert.NoError(t, pty.SendKey('e'))
 	}()
@@ -113,7 +113,7 @@ func Test_GhEditor_Prompt_editorAppend(t *testing.T) {
 	res, err := e.Prompt(defaultPromptConfig())
 	assert.NoError(t, err)
 	assert.Equal(t, "initial value - added by vim", res)
-	assert.Equal(t, "\x1b[?25h\x1b[?25h", pty.Output())
+	assert.Equal(t, "", normalizeANSI(pty.Output()))
 }
 
 func Test_GhEditor_Prompt_editorTruncate(t *testing.T) {
@@ -136,7 +136,7 @@ func Test_GhEditor_Prompt_editorTruncate(t *testing.T) {
 	// wait until the prompt is rendered and send the 'e' key
 	go func() {
 		pty.WaitForOutput("Body")
-		assert.Equal(t, "\x1b[0G\x1b[2K\x1b[0;1;92m? \x1b[0m\x1b[0;1;99mBody \x1b[0m\x1b[0;36m[(e) to launch nano, enter to skip] \x1b[0m\x1b[?25l", pty.Output())
+		assert.Equal(t, "\x1b[0G\x1b[2K\x1b[0;1;92m? \x1b[0m\x1b[0;1;99mBody \x1b[0m\x1b[0;36m[(e) to launch nano, enter to skip] \x1b[0m", normalizeANSI(pty.Output()))
 		pty.ResetOutput()
 		assert.NoError(t, pty.SendKey('e'))
 	}()
@@ -144,7 +144,7 @@ func Test_GhEditor_Prompt_editorTruncate(t *testing.T) {
 	res, err := e.Prompt(defaultPromptConfig())
 	assert.NoError(t, err)
 	assert.Equal(t, "", res)
-	assert.Equal(t, "\x1b[?25h\x1b[?25h", pty.Output())
+	assert.Equal(t, "", normalizeANSI(pty.Output()))
 }
 
 // survey doesn't expose this
@@ -274,4 +274,11 @@ func (f *teeWriter) Reset() {
 	f.mu.Lock()
 	f.buf.Reset()
 	f.mu.Unlock()
+}
+
+// strips some ANSI escape sequences that we do not want tests to be concerned with
+func normalizeANSI(t string) string {
+	t = strings.ReplaceAll(t, "\x1b[?25h", "") // strip sequence that shows cursor
+	t = strings.ReplaceAll(t, "\x1b[?25l", "") // strip sequence that hides cursor
+	return t
 }

--- a/pkg/surveyext/editor_test.go
+++ b/pkg/surveyext/editor_test.go
@@ -59,8 +59,15 @@ func Test_GhEditor_Prompt(t *testing.T) {
 		errc <- err
 	}()
 
-	time.Sleep(5 * time.Millisecond)
+	for {
+		time.Sleep(time.Millisecond)
+		if strings.Contains(out.String(), "Body") {
+			break
+		}
+	}
+
 	assert.Equal(t, "\x1b[0G\x1b[2K\x1b[0;1;92m? \x1b[0m\x1b[0;1;99mBody \x1b[0m\x1b[0;36m[(e) to launch false, enter to skip] \x1b[0m\x1b[?25l", out.String())
+	out.Reset()
 	fmt.Fprint(pty, "\n") // send Enter key
 
 	err = <-errc
@@ -126,7 +133,12 @@ func (f *teeWriter) Write(p []byte) (n int, err error) {
 func (f *teeWriter) String() string {
 	f.mu.Lock()
 	s := f.buf.String()
-	f.buf.Reset()
 	f.mu.Unlock()
 	return s
+}
+
+func (f *teeWriter) Reset() {
+	f.mu.Lock()
+	f.buf.Reset()
+	f.mu.Unlock()
 }

--- a/pkg/surveyext/editor_test.go
+++ b/pkg/surveyext/editor_test.go
@@ -14,13 +14,50 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 	pseudotty "github.com/creack/pty"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func Test_GhEditor_Prompt(t *testing.T) {
+func testLookPath(s string) ([]string, []string, error) {
+	return []string{os.Args[0], "-test.run=TestHelperProcess", "--", s}, []string{"GH_WANT_HELPER_PROCESS=1"}, nil
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GH_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	if err := func(args []string) error {
+		switch args[0] {
+		// "vim" appends a message to the file
+		case "vim":
+			f, err := os.OpenFile(args[1], os.O_APPEND|os.O_WRONLY, 0)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			_, err = f.WriteString(" - added by vim")
+			return err
+		// "nano" truncates the contents of the file
+		case "nano":
+			f, err := os.OpenFile(args[1], os.O_TRUNC|os.O_WRONLY, 0)
+			if err != nil {
+				return err
+			}
+			return f.Close()
+		default:
+			return fmt.Errorf("unrecognized arguments: %#v\n", args)
+		}
+	}(os.Args[3:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func Test_GhEditor_Prompt_skip(t *testing.T) {
+	pty := newTerminal(t)
+
 	e := &GhEditor{
 		BlankAllowed:  true,
-		EditorCommand: "false",
+		EditorCommand: "vim",
 		Editor: &survey.Editor{
 			Message:       "Body",
 			FileName:      "*.md",
@@ -28,52 +65,86 @@ func Test_GhEditor_Prompt(t *testing.T) {
 			HideDefault:   true,
 			AppendDefault: true,
 		},
+		lookPath: func(s string) ([]string, []string, error) {
+			return nil, nil, errors.New("no editor allowed")
+		},
 	}
+	e.WithStdio(pty.Stdio())
 
-	pty, tty, err := pseudotty.Open()
-	if errors.Is(err, pseudotty.ErrUnsupported) {
-		return
-	}
-	require.NoError(t, err)
-	defer pty.Close()
-	defer tty.Close()
-
-	err = pseudotty.Setsize(tty, &pseudotty.Winsize{Cols: 72, Rows: 30})
-	require.NoError(t, err)
-
-	out := teeWriter{File: tty}
-	e.WithStdio(terminal.Stdio{
-		In:  tty,
-		Out: &out,
-		Err: tty,
-	})
-
-	var res string
-	errc := make(chan error)
-
+	// wait until the prompt is rendered and send the Enter key
 	go func() {
-		r, err := e.Prompt(defaultPromptConfig())
-		if r != nil {
-			res = r.(string)
-		}
-		errc <- err
+		pty.WaitForOutput("Body")
+		assert.Equal(t, "\x1b[0G\x1b[2K\x1b[0;1;92m? \x1b[0m\x1b[0;1;99mBody \x1b[0m\x1b[0;36m[(e) to launch vim, enter to skip] \x1b[0m\x1b[?25l", pty.Output())
+		pty.ResetOutput()
+		assert.NoError(t, pty.SendKey('\n'))
 	}()
 
-	for {
-		time.Sleep(time.Millisecond)
-		if strings.Contains(out.String(), "Body") {
-			break
-		}
-	}
-
-	assert.Equal(t, "\x1b[0G\x1b[2K\x1b[0;1;92m? \x1b[0m\x1b[0;1;99mBody \x1b[0m\x1b[0;36m[(e) to launch false, enter to skip] \x1b[0m\x1b[?25l", out.String())
-	out.Reset()
-	fmt.Fprint(pty, "\n") // send Enter key
-
-	err = <-errc
+	res, err := e.Prompt(defaultPromptConfig())
 	assert.NoError(t, err)
 	assert.Equal(t, "initial value", res)
-	assert.Equal(t, "\x1b[?25h", out.String())
+	assert.Equal(t, "\x1b[?25h", pty.Output())
+}
+
+func Test_GhEditor_Prompt_editorAppend(t *testing.T) {
+	pty := newTerminal(t)
+
+	e := &GhEditor{
+		BlankAllowed:  true,
+		EditorCommand: "vim",
+		Editor: &survey.Editor{
+			Message:       "Body",
+			FileName:      "*.md",
+			Default:       "initial value",
+			HideDefault:   true,
+			AppendDefault: true,
+		},
+		lookPath: testLookPath,
+	}
+	e.WithStdio(pty.Stdio())
+
+	// wait until the prompt is rendered and send the 'e' key
+	go func() {
+		pty.WaitForOutput("Body")
+		assert.Equal(t, "\x1b[0G\x1b[2K\x1b[0;1;92m? \x1b[0m\x1b[0;1;99mBody \x1b[0m\x1b[0;36m[(e) to launch vim, enter to skip] \x1b[0m\x1b[?25l", pty.Output())
+		pty.ResetOutput()
+		assert.NoError(t, pty.SendKey('e'))
+	}()
+
+	res, err := e.Prompt(defaultPromptConfig())
+	assert.NoError(t, err)
+	assert.Equal(t, "initial value - added by vim", res)
+	assert.Equal(t, "\x1b[?25h\x1b[?25h", pty.Output())
+}
+
+func Test_GhEditor_Prompt_editorTruncate(t *testing.T) {
+	pty := newTerminal(t)
+
+	e := &GhEditor{
+		BlankAllowed:  true,
+		EditorCommand: "nano",
+		Editor: &survey.Editor{
+			Message:       "Body",
+			FileName:      "*.md",
+			Default:       "initial value",
+			HideDefault:   true,
+			AppendDefault: true,
+		},
+		lookPath: testLookPath,
+	}
+	e.WithStdio(pty.Stdio())
+
+	// wait until the prompt is rendered and send the 'e' key
+	go func() {
+		pty.WaitForOutput("Body")
+		assert.Equal(t, "\x1b[0G\x1b[2K\x1b[0;1;92m? \x1b[0m\x1b[0;1;99mBody \x1b[0m\x1b[0;36m[(e) to launch nano, enter to skip] \x1b[0m\x1b[?25l", pty.Output())
+		pty.ResetOutput()
+		assert.NoError(t, pty.SendKey('e'))
+	}()
+
+	res, err := e.Prompt(defaultPromptConfig())
+	assert.NoError(t, err)
+	assert.Equal(t, "", res)
+	assert.Equal(t, "\x1b[?25h\x1b[?25h", pty.Output())
 }
 
 // survey doesn't expose this
@@ -113,6 +184,68 @@ func defaultPromptConfig() *survey.PromptConfig {
 			return strings.Contains(strings.ToLower(value), filter)
 		},
 		KeepFilter: false,
+	}
+}
+
+type testTerminal struct {
+	pty    *os.File
+	tty    *os.File
+	stdout *teeWriter
+	stderr *teeWriter
+}
+
+func newTerminal(t *testing.T) *testTerminal {
+	t.Helper()
+
+	pty, tty, err := pseudotty.Open()
+	if errors.Is(err, pseudotty.ErrUnsupported) {
+		t.SkipNow()
+		return nil
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		pty.Close()
+		tty.Close()
+	})
+
+	if err := pseudotty.Setsize(tty, &pseudotty.Winsize{Cols: 72, Rows: 30}); err != nil {
+		t.Fatal(err)
+	}
+
+	return &testTerminal{pty: pty, tty: tty}
+}
+
+func (t *testTerminal) SendKey(c rune) error {
+	_, err := t.pty.WriteString(string(c))
+	return err
+}
+
+func (t *testTerminal) WaitForOutput(s string) {
+	for {
+		time.Sleep(time.Millisecond)
+		if strings.Contains(t.stdout.String(), s) {
+			return
+		}
+	}
+}
+
+func (t *testTerminal) Output() string {
+	return t.stdout.String()
+}
+
+func (t *testTerminal) ResetOutput() {
+	t.stdout.Reset()
+}
+
+func (t *testTerminal) Stdio() terminal.Stdio {
+	t.stdout = &teeWriter{File: t.tty}
+	t.stderr = t.stdout
+	return terminal.Stdio{
+		In:  t.tty,
+		Out: t.stdout,
+		Err: t.stderr,
 	}
 }
 


### PR DESCRIPTION
In `issue/pr create`, choosing a template but then opening your editor and deleting all contents there should be submitting a blank body, in my opinion, since you've explicitly deleted all contents. But this wasn't happening for two reasons:

1. We used to treat `Body == ""` as a special case that meant "user has skipped editing". (We quit doing that in #3658, but the code that appended the template to a blank body still remained.) Fixes https://github.com/cli/cli/issues/1294
2. Even if the user tried to submit a blank body via browser, the `&body=` query parameter wasn't present, and thus the web interface would apply the template body again.

Bonus:
- Fixes flaky test https://github.com/cli/cli/pull/3784/checks?check_run_id=2746898164
- Add tests for opening the editor in Survey prompts. Our `surveyext` extension is now fully tested by spawning a pseudo-TTY and interacting with Survey there.

Manual testing note: to test saving a completely empty file in vim, I would have to do `:set noendofline nofixendofline`, since otherwise vim always includes a trailing newline (and thus the resulting string wouldn't be empty).

/cc @chemotaxis 