### PR TITLE
Increase `GH_PAGER` precedence

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -96,8 +96,9 @@ func mainRun() exitCode {
 	if prompt, _ := cfg.Get("", "prompt"); prompt == "disabled" {
 		cmdFactory.IOStreams.SetNeverPrompt(true)
 	}
-
-	if pager, _ := cfg.Get("", "pager"); pager != "" {
+	if ghPager, ghPagerExists := os.LookupEnv("GH_PAGER"); ghPagerExists {
+		cmdFactory.IOStreams.SetPager(ghPager)
+	} else if pager, _ := cfg.Get("", "pager"); pager != "" {
 		cmdFactory.IOStreams.SetPager(pager)
 	}
 

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -281,12 +281,7 @@ func System() *IOStreams {
 	stdoutIsTTY := isTerminal(os.Stdout)
 	stderrIsTTY := isTerminal(os.Stderr)
 
-	var pagerCommand string
-	if ghPager, ghPagerExists := os.LookupEnv("GH_PAGER"); ghPagerExists {
-		pagerCommand = ghPager
-	} else {
-		pagerCommand = os.Getenv("PAGER")
-	}
+	pagerCommand := os.Getenv("PAGER")
 
 	io := &IOStreams{
 		In:           os.Stdin,


### PR DESCRIPTION
This PR makes `GH_PAGER` env var take higher precedence over local config.

When providing `GH_PAGER`, a user can change/disable the pager per single invocation, some examples:

```
gh config get pager
> less

GH_PAGER='delta' gh pr diff 3787
... format git diff output with delta instead of less
```


Ref. https://github.com/cli/cli/issues/3617#issuecomment-853216593

Closes #3617
