### PR TITLE
Fix showing Checks information in `pr status`

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -396,7 +396,7 @@ func PullRequestStatus(client *Client, repo ghrepo.Interface, options StatusOpti
 		// these are always necessary to find the PR for the current branch
 		fields.AddValues([]string{"isCrossRepository", "headRepositoryOwner", "headRefName"})
 		gr := PullRequestGraphQL(fields.ToSlice())
-		fragments = fmt.Sprintf("fragment pr on PullRequest{%[1]s}fragment prWithReviews on PullRequest{%[1]s}", gr)
+		fragments = fmt.Sprintf("fragment pr on PullRequest{%s}fragment prWithReviews on PullRequest{...pr}", gr)
 	} else {
 		var err error
 		fragments, err = pullRequestFragment(client.http, repo.RepoHost())

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -533,7 +533,7 @@ func pullRequestFragment(httpClient *http.Client, hostname string) (string, erro
 
 	fields := []string{
 		"number", "title", "state", "url", "isDraft", "isCrossRepository",
-		"headRefName", "headRepositoryOwner", "mergeStateStatus",
+		"requiresStrictStatusChecks", "headRefName", "headRepositoryOwner", "mergeStateStatus",
 	}
 	if prFeatures.HasStatusCheckRollup {
 		fields = append(fields, "statusCheckRollup")

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -216,6 +216,8 @@ func PullRequestGraphQL(fields []string) string {
 			q = append(q, `commits(last:1){nodes{commit{oid}}}`)
 		case "commitsCount": // pseudo-field
 			q = append(q, `commits{totalCount}`)
+		case "requiresStrictStatusChecks": // pseudo-field
+			q = append(q, `baseRef{branchProtectionRule{requiresStrictStatusChecks}}`)
 		case "statusCheckRollup":
 			q = append(q, StatusCheckRollupGraphQL(""))
 		default:


### PR DESCRIPTION
An outdated GraphQL query was used in `pr status` to fetch Checks. It was technically valid, so it didn't error out on the server, but its results around Checks were not stored in a way that caused them to also be rendered.

This switches to `PullRequestGraphQL()` to build GraphQL queries, which is also used across the codebase, instead of manually rolling potentially error-prone queries by hand.

Fixes #3794
Followup to https://github.com/cli/cli/pull/3547