### PR TITLE
repo fork: check that --org is not the empty string

### DIFF
--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -89,18 +89,14 @@ Additional 'git clone' flags can be passed in by listing them after '--'.`,
 
 			if opts.RemoteName == "" {
 				return &cmdutil.FlagError{Err: errors.New("--remote-name cannot be blank")}
+			} else if !cmd.Flags().Changed("remote-name") {
+				opts.Rename = true // Any existing 'origin' will be renamed to upstream
 			}
 
-			if promptOk && !cmd.Flags().Changed("clone") {
-				opts.PromptClone = true
-			}
-
-			if promptOk && !cmd.Flags().Changed("remote") {
-				opts.PromptRemote = true
-			}
-
-			if !cmd.Flags().Changed("remote-name") {
-				opts.Rename = true
+			if promptOk {
+				// We can prompt for these if they were not specified.
+				opts.PromptClone = !cmd.Flags().Changed("clone")
+				opts.PromptRemote = !cmd.Flags().Changed("remote")
 			}
 
 			if runF != nil {

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -83,6 +83,10 @@ Additional 'git clone' flags can be passed in by listing them after '--'.`,
 				opts.GitArgs = args[1:]
 			}
 
+			if cmd.Flags().Changed("org") && opts.Organization == "" {
+				return &cmdutil.FlagError{Err: errors.New("--org cannot be blank")}
+			}
+
 			if opts.RemoteName == "" {
 				return &cmdutil.FlagError{Err: errors.New("--remote-name cannot be blank")}
 			}

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -121,6 +121,12 @@ func TestNewCmdFork(t *testing.T) {
 			},
 		},
 		{
+			name:    "empty org",
+			cli:     " --org=''",
+			wantErr: true,
+			errMsg:  "--org cannot be blank",
+		},
+		{
 			name:    "git flags in wrong place",
 			cli:     "--depth 1 OWNER/REPO",
 			wantErr: true,


### PR DESCRIPTION
-----
I came across this while looking at #2722. I think that issue could keep its _help wanted_ tag, but—and forgive me—after staring at this code for so long, I'm not sure it is that of a ‘good first issue’ anymore! (Or perhaps it's just me.)

I also realize the second commit in this PR might get disputed (because “readability” is often, implicitly, “readability at which level/at which ability”)—I'm happy to see this merged with or without that commit. 🙂 

Thank you for your work on gh!