### PR TITLE
Fix setting environment secrets

### DIFF
--- a/pkg/cmd/secret/set/http.go
+++ b/pkg/cmd/secret/set/http.go
@@ -55,6 +55,11 @@ func getRepoPubKey(client *api.Client, repo ghrepo.Interface) (*PubKey, error) {
 		ghrepo.FullName(repo)))
 }
 
+func getEnvPubKey(client *api.Client, repo ghrepo.Interface, envName string) (*PubKey, error) {
+	return getPubKey(client, repo.RepoHost(), fmt.Sprintf("repos/%s/environments/%s/secrets/public-key",
+		ghrepo.FullName(repo), envName))
+}
+
 func putSecret(client *api.Client, host, path string, payload SecretPayload) error {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -168,6 +168,8 @@ func setRun(opts *SetOptions) error {
 	var pk *PubKey
 	if orgName != "" {
 		pk, err = getOrgPublicKey(client, host, orgName)
+	} else if envName != "" {
+		pk, err = getEnvPubKey(client, baseRepo, envName)
 	} else {
 		pk, err = getRepoPubKey(client, baseRepo)
 	}

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -219,7 +219,7 @@ func Test_setRun_repo(t *testing.T) {
 func Test_setRun_env(t *testing.T) {
 	reg := &httpmock.Registry{}
 
-	reg.Register(httpmock.REST("GET", "repos/owner/repo/actions/secrets/public-key"),
+	reg.Register(httpmock.REST("GET", "repos/owner/repo/environments/development/secrets/public-key"),
 		httpmock.JSONResponse(PubKey{ID: "123", Key: "CDjXqf7AJBXWhMczcy+Fs7JlACEptgceysutztHaFQI="}))
 
 	reg.Register(httpmock.REST("PUT", "repos/owner/repo/environments/development/secrets/cool_secret"), httpmock.StatusStringResponse(201, `{}`))


### PR DESCRIPTION
This uses the correct public key when setting environment secrets.
https://docs.github.com/en/rest/reference/actions#get-an-environment-public-key

Fixes #3831