### PR TITLE
Remove unused method from `httpmock` package

### DIFF
--- a/pkg/httpmock/legacy.go
+++ b/pkg/httpmock/legacy.go
@@ -2,26 +2,9 @@ package httpmock
 
 import (
 	"fmt"
-	"net/http"
-	"os"
 )
 
 // TODO: clean up methods in this file when there are no more callers
-
-func (r *Registry) StubWithFixturePath(status int, fixturePath string) func() {
-	fixtureFile, err := os.Open(fixturePath)
-	r.Register(MatchAny, func(req *http.Request) (*http.Response, error) {
-		if err != nil {
-			return nil, err
-		}
-		return httpResponse(200, req, fixtureFile), nil
-	})
-	return func() {
-		if err == nil {
-			fixtureFile.Close()
-		}
-	}
-}
 
 func (r *Registry) StubRepoInfoResponse(owner, repo, branch string) {
 	r.Register(


### PR DESCRIPTION
`repo fork`'s tests where the last ones using this method, so now that #3809 is merged `StubWithFixturePath` it's not needed anymore.
