### PR TITLE
Ensure that tests for command factory never read from user's config

### DIFF
--- a/pkg/cmd/factory/default_test.go
+++ b/pkg/cmd/factory/default_test.go
@@ -333,8 +333,10 @@ func Test_ioStreams_pager(t *testing.T) {
 				}
 			}
 			f := New("1")
-			if tt.config != nil {
-				f.Config = func() (config.Config, error) {
+			f.Config = func() (config.Config, error) {
+				if tt.config == nil {
+					return config.NewBlankConfig(), nil
+				} else {
 					return tt.config, nil
 				}
 			}
@@ -363,8 +365,10 @@ func Test_ioStreams_prompt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := New("1")
-			if tt.config != nil {
-				f.Config = func() (config.Config, error) {
+			f.Config = func() (config.Config, error) {
+				if tt.config == nil {
+					return config.NewBlankConfig(), nil
+				} else {
 					return tt.config, nil
 				}
 			}


### PR DESCRIPTION
If these tests are going to exerise `factory.New()`, the config getter should always be overriden since the default config getter reads from `~/.config/gh` and thus makes tests dependent on the user's environment.

Followup to https://github.com/cli/cli/pull/3841
Ref. https://github.com/cli/cli/pull/3044