### PR TITLE
Design Draft for `gh repo edit`

### DIFF
--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -1,0 +1,109 @@
+package edit
+
+import (
+	"fmt"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/git"
+	"github.com/cli/cli/internal/config"
+	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/iostreams"
+	"github.com/spf13/cobra"
+	"net/http"
+	"path"
+)
+
+type EditOptions struct {
+	HttpClient func() (*http.Client, error)
+	Config     func() (config.Config, error)
+	IO         *iostreams.IOStreams
+
+	Name             string
+	Description      string
+	Homepage         string
+	IsTemplate       bool
+	EnableIssues     bool
+	EnableWiki       bool
+	EnableProjects   bool
+	Public           bool
+	Private          bool
+	Internal         bool
+	AllowMergeCommit bool
+	AllowSquashMerge bool
+	AllowRebaseMerge bool
+	Archive          bool
+	ConfirmSubmit    bool
+}
+
+func NewCmdEdit(f *cmdutil.Factory, runF func(options *EditOptions) error) *cobra.Command {
+	opts := &EditOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Config:     f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "edit [<name>]",
+		Short: "Edit repository settings",
+		Long: heredoc.Docf(`
+			Edit your Github Repo settings
+
+			If the current repository is a local git repository and the currently authenticated user has WRITE/ADMIN access to the repository, the command will let the user make changes to the repo settings.
+
+		`, "`"),
+		Args: cobra.MaximumNArgs(1),
+		Example: heredoc.Doc(`
+			 # update repo description, allow squash merge and delete merged branches automatically
+			  $ gh repo edit --description="awesome description" --allow-squash-merge --delete-merged-branch
+	  `),
+		Annotations: map[string]string{
+			"help:arguments": heredoc.Doc(`
+				A repository can be supplied as an argument in any of the following formats:
+				- "OWNER/REPO"
+				- by URL, e.g. "https://github.com/OWNER/REPO"
+			`),
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.Name = args[0]
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return editRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Description, "description", "d", "", "Description of the repository")
+	cmd.Flags().StringVarP(&opts.Homepage, "homepage", "h", "", "Repository home page `URL`")
+	cmd.Flags().BoolVar(&opts.IsTemplate, "is-template", false, "Make the repository available as a template `repository`")
+	cmd.Flags().BoolVar(&opts.EnableIssues, "enable-issues", true, "Enable issues in the repository")
+	cmd.Flags().BoolVar(&opts.EnableWiki, "enable-wiki", true, "Enable wiki in the repository")
+	cmd.Flags().BoolVar(&opts.Public, "public", false, "Make the repository public")
+	cmd.Flags().BoolVar(&opts.Private, "private", false, "Make the repository private")
+	cmd.Flags().BoolVar(&opts.Internal, "internal", false, "Make the repository internal")
+	cmd.Flags().BoolVar(&opts.AllowMergeCommit, "allow-merge-commit", true, "Enable merge commits")
+	cmd.Flags().BoolVar(&opts.AllowSquashMerge, "allow-squash-merge", true, "Enable squash merge")
+	cmd.Flags().BoolVar(&opts.AllowRebaseMerge, "allow-rebase-merge", true, "Enable rebase merge")
+
+	cmd.Flags().BoolVarP(&opts.ConfirmSubmit, "confirm", "y", false, "Skip the confirmation prompt")
+
+	return cmd
+}
+
+func editRun(opts *EditOptions) error {
+	projectDir, projectDirErr := git.ToplevelDir()
+	isNameAnArg := false
+
+	if opts.Name != "" {
+		isNameAnArg = true
+	} else {
+		if projectDirErr != nil {
+			return projectDirErr
+		}
+		opts.Name = path.Base(projectDir)
+	}
+
+	fmt.Println(isNameAnArg)
+	return nil
+}

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -32,6 +32,7 @@ type EditOptions struct {
 	AllowMergeCommit bool
 	AllowSquashMerge bool
 	AllowRebaseMerge bool
+	DeleteBranchOnMerge bool
 	Archive          bool
 	ConfirmSubmit    bool
 }
@@ -84,7 +85,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(options *EditOptions) error) *cobr
 	cmd.Flags().BoolVar(&opts.AllowMergeCommit, "allow-merge-commit", true, "Enable merge commits")
 	cmd.Flags().BoolVar(&opts.AllowSquashMerge, "allow-squash-merge", true, "Enable squash merge")
 	cmd.Flags().BoolVar(&opts.AllowRebaseMerge, "allow-rebase-merge", true, "Enable rebase merge")
-
+	cmd.Flags().BoolVar(&opts.DeleteBranchOnMerge, "delete-branch-on-merge", false, "Delete head branch where PRs are merged")
 	cmd.Flags().BoolVarP(&opts.ConfirmSubmit, "confirm", "y", false, "Skip the confirmation prompt")
 
 	return cmd
@@ -211,5 +212,22 @@ func interactiveRepoEdit() (*EditOptions, error) {
 		return nil, err
 	}
 
-	return nil, nil
+	return &EditOptions{
+		Name:             answers.RepoName,
+		Description:      answers.RepoDescription,
+		Homepage:         answers.RepoURL,
+		IsTemplate:       answers.IsTemplateRepo,
+		EnableIssues:     false,
+		EnableWiki:       false,
+		EnableProjects:   false,
+		Public:           false,
+		Private:          false,
+		Internal:         false,
+		AllowMergeCommit: true,
+		AllowSquashMerge: false,
+		AllowRebaseMerge: false,
+		DeleteBranchOnMerge: false,
+		Archive:          false,
+		ConfirmSubmit:    false,
+	}, nil
 }

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -5,6 +5,7 @@ import (
 	repoCloneCmd "github.com/cli/cli/pkg/cmd/repo/clone"
 	repoCreateCmd "github.com/cli/cli/pkg/cmd/repo/create"
 	creditsCmd "github.com/cli/cli/pkg/cmd/repo/credits"
+	repoEditCmd "github.com/cli/cli/pkg/cmd/repo/edit"
 	repoForkCmd "github.com/cli/cli/pkg/cmd/repo/fork"
 	gardenCmd "github.com/cli/cli/pkg/cmd/repo/garden"
 	repoListCmd "github.com/cli/cli/pkg/cmd/repo/list"
@@ -37,6 +38,7 @@ func NewCmdRepo(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(repoForkCmd.NewCmdFork(f, nil))
 	cmd.AddCommand(repoCloneCmd.NewCmdClone(f, nil))
 	cmd.AddCommand(repoCreateCmd.NewCmdCreate(f, nil))
+	cmd.AddCommand(repoEditCmd.NewCmdEdit(f, nil))
 	cmd.AddCommand(repoListCmd.NewCmdList(f, nil))
 	cmd.AddCommand(creditsCmd.NewCmdRepoCredits(f, nil))
 	cmd.AddCommand(gardenCmd.NewCmdGarden(f, nil))


### PR DESCRIPTION
This design draft and a dummy flow exposes more repository settings as discussed in https://github.com/cli/cli/issues/995

Attaching a google document for the design. And the head branch contains a dummy flow for `gh repo edit`

Might close #995 

Design doc - [Google doc](https://docs.google.com/document/d/1ot3GTPh7s44_7Fx26UjShfPvFhncWcf4lpCla4vmwbg/edit?usp=sharing)

Attaching screenshots for reference:

<img width="689" alt="image" src="https://user-images.githubusercontent.com/17702388/123090721-1b8da900-d446-11eb-939b-6ef8a21edb10.png">

<img width="710" alt="image" src="https://user-images.githubusercontent.com/17702388/123090910-555eaf80-d446-11eb-82ef-62fd8400237b.png">

<img width="710" alt="image" src="https://user-images.githubusercontent.com/17702388/123091639-3ad90600-d447-11eb-8be0-c2aac069c971.png">

