### PR TITLE
Fix `gh run download fails on large artifacts due to uint32 limitation`

### DIFF
--- a/pkg/cmd/run/shared/artifacts.go
+++ b/pkg/cmd/run/shared/artifacts.go
@@ -12,7 +12,7 @@ import (
 
 type Artifact struct {
 	Name        string `json:"name"`
-	Size        uint32 `json:"size_in_bytes"`
+	Size        uint64 `json:"size_in_bytes"`
 	DownloadURL string `json:"archive_download_url"`
 	Expired     bool   `json:"expired"`
 }


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes https://github.com/cli/cli/issues/3868

simply change `uint32` to 'uint64' for size