### PR TITLE
Allow cloning/tracking upstream

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -321,12 +321,20 @@ func RunClone(cloneURL string, args []string) (target string, err error) {
 	return
 }
 
+func AddOriginRemote(originURL, cloneDir string, branches []string) error {
+	return addRemote("origin", originURL, cloneDir, branches)
+}
+
 func AddUpstreamRemote(upstreamURL, cloneDir string, branches []string) error {
+	return addRemote("upstream", upstreamURL, cloneDir, branches)
+}
+
+func addRemote(remote, remoteURL, cloneDir string, branches []string) error {
 	args := []string{"-C", cloneDir, "remote", "add"}
 	for _, branch := range branches {
 		args = append(args, "-t", branch)
 	}
-	args = append(args, "-f", "upstream", upstreamURL)
+	args = append(args, "-f", remote, remoteURL)
 	cloneCmd, err := GitCommand(args...)
 	if err != nil {
 		return err

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -218,3 +218,15 @@ func TestAddUpstreamRemote(t *testing.T) {
 		})
 	}
 }
+
+func TestAddOriginRemote(t *testing.T) {
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	cs.Register(`git -C DIRECTORY remote add -f origin URL`, 0, "")
+
+	err := AddOriginRemote("URL", "DIRECTORY", []string{})
+	if err != nil {
+		t.Fatalf("error running command `git remote add -f`: %v", err)
+	}
+}


### PR DESCRIPTION
`gh repo clone --upstream foo` matches the common workflow:

- the default branch tracks upstream
- feature branches track fork

Fixes #2786

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
