### PR TITLE
Fix issue in FindEntry that causes extensions and alias crash

### DIFF
--- a/internal/config/config_map.go
+++ b/internal/config/config_map.go
@@ -68,13 +68,18 @@ func (cm *ConfigMap) FindEntry(key string) (ce *ConfigEntry, err error) {
 
 	ce = &ConfigEntry{}
 
-	topLevelKeys := cm.Root.Content
-	for i, v := range topLevelKeys {
+	// Content slice goes [key1, value1, key2, value2, ...]
+	topLevelPairs := cm.Root.Content
+	for i, v := range topLevelPairs {
+		// Skip every other slice item since we only want to check against keys
+		if i%2 != 0 {
+			continue
+		}
 		if v.Value == key {
 			ce.KeyNode = v
 			ce.Index = i
-			if i+1 < len(topLevelKeys) {
-				ce.ValueNode = topLevelKeys[i+1]
+			if i+1 < len(topLevelPairs) {
+				ce.ValueNode = topLevelPairs[i+1]
 			}
 			return
 		}

--- a/internal/config/config_map_test.go
+++ b/internal/config/config_map_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestFindEntry(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		output  string
+		wantErr bool
+	}{
+		{
+			name:   "find key",
+			key:    "valid",
+			output: "present",
+		},
+		{
+			name:    "find key that is not present",
+			key:     "invalid",
+			wantErr: true,
+		},
+		{
+			name:   "find key with blank value",
+			key:    "blank",
+			output: "",
+		},
+		{
+			name:   "find key that has same content as a value",
+			key:    "same",
+			output: "logical",
+		},
+	}
+
+	for _, tt := range tests {
+		cm := ConfigMap{Root: testYaml()}
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := cm.FindEntry(tt.key)
+			if tt.wantErr {
+				assert.EqualError(t, err, "not found")
+				return
+			}
+			assert.NoError(t, err)
+			fmt.Println(out)
+			assert.Equal(t, tt.output, out.ValueNode.Value)
+		})
+	}
+}
+
+func testYaml() *yaml.Node {
+	var root yaml.Node
+	var data = `
+valid: present
+erroneous: same
+blank:
+same: logical
+`
+	_ = yaml.Unmarshal([]byte(data), &root)
+	return root.Content[0]
+}


### PR DESCRIPTION
Fixes issue when finding entries in a config file. If there were any values in the file that matched the key name being searched for it would return the incorrect value. This was causing the segfault issue in https://github.com/cli/cli/issues/3895 and probably other places as well. 