### PR TITLE
Added colors to issue / pr labels in the terminal

### DIFF
--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -63,7 +63,7 @@ func IssueLabelList(issue api.Issue) string {
 
 	labelNames := make([]string, 0, len(issue.Labels.Nodes))
 	for _, label := range issue.Labels.Nodes {
-		labelNames = append(labelNames, label.Name)
+		labelNames = append(labelNames, iostreams.RGB(label.Color, label.Name))
 	}
 
 	return strings.Join(labelNames, ", ")

--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -63,7 +63,7 @@ func IssueLabelList(issue api.Issue) string {
 
 	labelNames := make([]string, 0, len(issue.Labels.Nodes))
 	for _, label := range issue.Labels.Nodes {
-		labelNames = append(labelNames, iostreams.RGB(label.Color, label.Name))
+		labelNames = append(labelNames, iostreams.HexToRGB(label.Color, label.Name))
 	}
 
 	return strings.Join(labelNames, ", ")

--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -22,7 +22,7 @@ func PrintIssues(io *iostreams.IOStreams, prefix string, totalCount int, issues 
 			issueNum = "#" + issueNum
 		}
 		issueNum = prefix + issueNum
-		labels := IssueLabelList(issue)
+		labels := IssueLabelList(issue, cs)
 		if labels != "" && table.IsTTY() {
 			labels = fmt.Sprintf("(%s)", labels)
 		}
@@ -56,14 +56,14 @@ func truncateLabels(w int, t string) string {
 	return fmt.Sprintf("(%s)", truncated)
 }
 
-func IssueLabelList(issue api.Issue) string {
+func IssueLabelList(issue api.Issue, cs *iostreams.ColorScheme) string {
 	if len(issue.Labels.Nodes) == 0 {
 		return ""
 	}
 
 	labelNames := make([]string, 0, len(issue.Labels.Nodes))
 	for _, label := range issue.Labels.Nodes {
-		labelNames = append(labelNames, iostreams.HexToRGB(label.Color, label.Name))
+		labelNames = append(labelNames, cs.HexToRGB(label.Color, label.Name))
 	}
 
 	return strings.Join(labelNames, ", ")

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -125,7 +125,7 @@ func viewRun(opts *ViewOptions) error {
 		return nil
 	}
 
-	return printRawIssuePreview(opts.IO.Out, issue)
+	return printRawIssuePreview(opts.IO.Out, issue, opts.IO.ColorScheme())
 }
 
 func findIssue(client *http.Client, baseRepoFn func() (ghrepo.Interface, error), selector string, loadComments bool) (*api.Issue, error) {
@@ -141,9 +141,9 @@ func findIssue(client *http.Client, baseRepoFn func() (ghrepo.Interface, error),
 	return issue, err
 }
 
-func printRawIssuePreview(out io.Writer, issue *api.Issue) error {
+func printRawIssuePreview(out io.Writer, issue *api.Issue, cs *iostreams.ColorScheme) error {
 	assignees := issueAssigneeList(*issue)
-	labels := shared.IssueLabelList(*issue)
+	labels := shared.IssueLabelList(*issue, cs)
 	projects := issueProjectList(*issue)
 
 	// Print empty strings for empty values so the number of metadata lines is consistent when
@@ -193,7 +193,7 @@ func printHumanIssuePreview(opts *ViewOptions, issue *api.Issue) error {
 		fmt.Fprint(out, cs.Bold("Assignees: "))
 		fmt.Fprintln(out, assignees)
 	}
-	if labels := shared.IssueLabelList(*issue); labels != "" {
+	if labels := shared.IssueLabelList(*issue, cs); labels != "" {
 		fmt.Fprint(out, cs.Bold("Labels: "))
 		fmt.Fprintln(out, labels)
 	}

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -374,7 +374,7 @@ func prLabelList(pr api.PullRequest) string {
 
 	labelNames := make([]string, 0, len(pr.Labels.Nodes))
 	for _, label := range pr.Labels.Nodes {
-		labelNames = append(labelNames, iostreams.RGB(label.Color, label.Name))
+		labelNames = append(labelNames, iostreams.HexToRGB(label.Color, label.Name))
 	}
 
 	list := strings.Join(labelNames, ", ")

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -139,7 +139,7 @@ func printRawPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 
 	reviewers := prReviewerList(*pr, cs)
 	assignees := prAssigneeList(*pr)
-	labels := prLabelList(*pr)
+	labels := prLabelList(*pr, cs)
 	projects := prProjectList(*pr)
 
 	fmt.Fprintf(out, "title:\t%s\n", pr.Title)
@@ -197,7 +197,7 @@ func printHumanPrPreview(opts *ViewOptions, pr *api.PullRequest) error {
 		fmt.Fprint(out, cs.Bold("Assignees: "))
 		fmt.Fprintln(out, assignees)
 	}
-	if labels := prLabelList(*pr); labels != "" {
+	if labels := prLabelList(*pr, cs); labels != "" {
 		fmt.Fprint(out, cs.Bold("Labels: "))
 		fmt.Fprintln(out, labels)
 	}
@@ -367,14 +367,14 @@ func prAssigneeList(pr api.PullRequest) string {
 	return list
 }
 
-func prLabelList(pr api.PullRequest) string {
+func prLabelList(pr api.PullRequest, cs *iostreams.ColorScheme) string {
 	if len(pr.Labels.Nodes) == 0 {
 		return ""
 	}
 
 	labelNames := make([]string, 0, len(pr.Labels.Nodes))
 	for _, label := range pr.Labels.Nodes {
-		labelNames = append(labelNames, iostreams.HexToRGB(label.Color, label.Name))
+		labelNames = append(labelNames, cs.HexToRGB(label.Color, label.Name))
 	}
 
 	list := strings.Join(labelNames, ", ")

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -374,7 +374,7 @@ func prLabelList(pr api.PullRequest) string {
 
 	labelNames := make([]string, 0, len(pr.Labels.Nodes))
 	for _, label := range pr.Labels.Nodes {
-		labelNames = append(labelNames, label.Name)
+		labelNames = append(labelNames, iostreams.RGB(label.Color, label.Name))
 	}
 
 	list := strings.Join(labelNames, ", ")

--- a/pkg/iostreams/color.go
+++ b/pkg/iostreams/color.go
@@ -3,6 +3,7 @@ package iostreams
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/mgutz/ansi"
@@ -201,4 +202,11 @@ func (c *ColorScheme) ColorFromString(s string) func(string) string {
 	}
 
 	return fn
+}
+
+func RGB(hex string, x string) string {
+	r, _ := strconv.ParseInt(hex[0:2], 16, 64)
+	g, _ := strconv.ParseInt(hex[2:4], 16, 64)
+	b, _ := strconv.ParseInt(hex[4:6], 16, 64)
+	return fmt.Sprintf("\033[38;2;%d;%d;%dm%s\033[0m", r, g, b, x)
 }

--- a/pkg/iostreams/color.go
+++ b/pkg/iostreams/color.go
@@ -204,7 +204,11 @@ func (c *ColorScheme) ColorFromString(s string) func(string) string {
 	return fn
 }
 
-func HexToRGB(hex string, x string) string {
+func (c *ColorScheme) HexToRGB(hex string, x string) string {
+	if !c.enabled || !c.is256enabled {
+		return x
+	}
+
 	r, _ := strconv.ParseInt(hex[0:2], 16, 64)
 	g, _ := strconv.ParseInt(hex[2:4], 16, 64)
 	b, _ := strconv.ParseInt(hex[4:6], 16, 64)

--- a/pkg/iostreams/color.go
+++ b/pkg/iostreams/color.go
@@ -204,7 +204,7 @@ func (c *ColorScheme) ColorFromString(s string) func(string) string {
 	return fn
 }
 
-func RGB(hex string, x string) string {
+func HexToRGB(hex string, x string) string {
 	r, _ := strconv.ParseInt(hex[0:2], 16, 64)
 	g, _ := strconv.ParseInt(hex[2:4], 16, 64)
 	b, _ := strconv.ParseInt(hex[4:6], 16, 64)

--- a/pkg/iostreams/color_test.go
+++ b/pkg/iostreams/color_test.go
@@ -3,6 +3,8 @@ package iostreams
 import (
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEnvColorDisabled(t *testing.T) {
@@ -141,5 +143,56 @@ func TestEnvColorForced(t *testing.T) {
 				t.Errorf("EnvColorForced(): want %v, got %v", tt.want, got)
 			}
 		})
+	}
+}
+
+func Test_HextoRGB(t *testing.T) {
+	tests := []struct {
+		name           string
+		hex            string
+		arg            string
+		expectedOutput string
+		expectedError  bool
+		cs             *ColorScheme
+	}{
+		{
+			name:           "Colored red enabled color",
+			hex:            "fc0303",
+			arg:            "red",
+			expectedOutput: "\033[38;2;252;3;3mred\033[0m",
+			cs:             NewColorScheme(true, true),
+		},
+		{
+			name:           "Failed colored red enabled color",
+			hex:            "fc0303",
+			arg:            "red",
+			expectedOutput: "\033[38;2;252;2;3mred\033[0m",
+			expectedError:  true,
+			cs:             NewColorScheme(true, true),
+		},
+		{
+			name:           "Colored red disabled color",
+			hex:            "fc0303",
+			arg:            "red",
+			expectedOutput: "red",
+			cs:             NewColorScheme(false, false),
+		},
+		{
+			name:           "Failed colored red disabled color",
+			hex:            "fc0303",
+			arg:            "red",
+			expectedOutput: "\033[38;2;252;3;3mred\033[0m",
+			expectedError:  true,
+			cs:             NewColorScheme(false, false),
+		},
+	}
+
+	for _, tt := range tests {
+		output := tt.cs.HexToRGB(tt.hex, tt.arg)
+		if tt.expectedError {
+			assert.NotEqual(t, tt.expectedOutput, output)
+		} else {
+			assert.Equal(t, tt.expectedOutput, output)
+		}
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
fixes #74

Allows for labels to be colored when viewing issues or pull requests in the terminal (limited to color enabled terminals only)

![issue_browser](https://user-images.githubusercontent.com/73488828/123907547-f22fba00-d92a-11eb-8472-9caf988224e1.jpg)
![issue_terminal](https://user-images.githubusercontent.com/73488828/123907542-f065f680-d92a-11eb-819f-04077fb55c2a.jpg)

