### PR TITLE
Fix bug where branchProtectionRule doesn't exist in enterprise 2.22

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -533,10 +533,13 @@ func pullRequestFragment(httpClient *http.Client, hostname string) (string, erro
 
 	fields := []string{
 		"number", "title", "state", "url", "isDraft", "isCrossRepository",
-		"requiresStrictStatusChecks", "headRefName", "headRepositoryOwner", "mergeStateStatus",
+		"headRefName", "headRepositoryOwner", "mergeStateStatus",
 	}
 	if prFeatures.HasStatusCheckRollup {
 		fields = append(fields, "statusCheckRollup")
+	}
+	if prFeatures.HasBranchProtectionRule {
+		fields = append(fields, "requiresStrictStatusChecks")
 	}
 
 	var reviewFields []string


### PR DESCRIPTION
This makes adding the `branchProtectionRule` fragment to the PR graphQL queries conditional on the PR having the `HasBranchProtectionRule` feature. This used to be the behavior but was changed in #3804, so this PR just changes it back.

Fixes https://github.com/cli/cli/issues/3919