### PR TITLE
fix repo create in org with license/ignore

### DIFF
--- a/pkg/cmd/factory/http.go
+++ b/pkg/cmd/factory/http.go
@@ -113,6 +113,7 @@ func NewHTTPClient(io *iostreams.IOStreams, cfg configGetter, appVersion string,
 		opts = append(opts,
 			api.AddHeaderFunc("Accept", func(req *http.Request) (string, error) {
 				accept := "application/vnd.github.merge-info-preview+json" // PullRequest.mergeStateStatus
+				accept += ", application/vnd.github.nebula-preview"        // visibility when RESTing repos into an org
 				if ghinstance.IsEnterprise(getHost(req)) {
 					accept += ", application/vnd.github.antiope-preview"    // Commit.statusCheckRollup
 					accept += ", application/vnd.github.shadow-cat-preview" // PullRequest.isDraft

--- a/pkg/cmd/factory/http_test.go
+++ b/pkg/cmd/factory/http_test.go
@@ -39,7 +39,7 @@ func TestNewHTTPClient(t *testing.T) {
 			wantHeader: map[string]string{
 				"authorization": "token MYTOKEN",
 				"user-agent":    "GitHub CLI v1.2.3",
-				"accept":        "application/vnd.github.merge-info-preview+json",
+				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
 			},
 			wantStderr: "",
 		},
@@ -69,7 +69,7 @@ func TestNewHTTPClient(t *testing.T) {
 			wantHeader: map[string]string{
 				"authorization": "",
 				"user-agent":    "GitHub CLI v1.2.3",
-				"accept":        "application/vnd.github.merge-info-preview+json",
+				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
 			},
 			wantStderr: "",
 		},
@@ -85,14 +85,14 @@ func TestNewHTTPClient(t *testing.T) {
 			wantHeader: map[string]string{
 				"authorization": "token MYTOKEN",
 				"user-agent":    "GitHub CLI v1.2.3",
-				"accept":        "application/vnd.github.merge-info-preview+json",
+				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
 			},
 			wantStderr: heredoc.Doc(`
 				* Request at <time>
 				* Request to http://<host>:<port>
 				> GET / HTTP/1.1
 				> Host: github.com
-				> Accept: application/vnd.github.merge-info-preview+json
+				> Accept: application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview
 				> Authorization: token ████████████████████
 				> User-Agent: GitHub CLI v1.2.3
 				
@@ -113,7 +113,7 @@ func TestNewHTTPClient(t *testing.T) {
 			wantHeader: map[string]string{
 				"authorization": "token GHETOKEN",
 				"user-agent":    "GitHub CLI v1.2.3",
-				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.antiope-preview, application/vnd.github.shadow-cat-preview",
+				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview, application/vnd.github.antiope-preview, application/vnd.github.shadow-cat-preview",
 			},
 			wantStderr: "",
 		},

--- a/pkg/cmd/repo/create/http.go
+++ b/pkg/cmd/repo/create/http.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/cli/cli/api"
 )
@@ -38,6 +39,9 @@ type repoTemplateInput struct {
 func repoCreate(client *http.Client, hostname string, input repoCreateInput, templateRepositoryID string) (*api.Repository, error) {
 	apiClient := api.NewClientFromHTTP(client)
 
+	ownerName := input.OwnerID
+	isOrg := false
+
 	if input.TeamID != "" {
 		orgID, teamID, err := resolveOrganizationTeam(apiClient, hostname, input.OwnerID, input.TeamID)
 		if err != nil {
@@ -46,7 +50,9 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput, tem
 		input.TeamID = teamID
 		input.OwnerID = orgID
 	} else if input.OwnerID != "" {
-		orgID, err := resolveOrganization(apiClient, hostname, input.OwnerID)
+		var orgID string
+		var err error
+		orgID, isOrg, err = resolveOrganization(apiClient, hostname, input.OwnerID)
 		if err != nil {
 			return nil, err
 		}
@@ -109,12 +115,19 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput, tem
 	}
 
 	if input.GitIgnoreTemplate != "" || input.LicenseTemplate != "" {
+		input.Visibility = strings.ToLower(input.Visibility)
 		body := &bytes.Buffer{}
 		enc := json.NewEncoder(body)
 		if err := enc.Encode(input); err != nil {
 			return nil, err
 		}
-		repo, err := api.CreateRepoTransformToV4(apiClient, hostname, "POST", "user/repos", body)
+
+		path := "user/repos"
+		if isOrg {
+			path = fmt.Sprintf("orgs/%s/repos", ownerName)
+		}
+
+		repo, err := api.CreateRepoTransformToV4(apiClient, hostname, "POST", path, body)
 		if err != nil {
 			return nil, err
 		}
@@ -141,12 +154,13 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput, tem
 }
 
 // using API v3 here because the equivalent in GraphQL needs `read:org` scope
-func resolveOrganization(client *api.Client, hostname, orgName string) (string, error) {
+func resolveOrganization(client *api.Client, hostname, orgName string) (string, bool, error) {
 	var response struct {
 		NodeID string `json:"node_id"`
+		Type   string
 	}
 	err := client.REST(hostname, "GET", fmt.Sprintf("users/%s", orgName), nil, &response)
-	return response.NodeID, err
+	return response.NodeID, response.Type == "Organization", err
 }
 
 // using API v3 here because the equivalent in GraphQL needs `read:org` scope


### PR DESCRIPTION
Fixes #3918

This PR detects when a `gh repo create foo/bar` invocation targets an org _and_ the user selects a .gitignore/license. In that case we switch to REST, but we have to either pick the user or org version of the REST endpoint.

In order to support passing `visibility` when using the create org repo endpoint, we need to opt into the `nebula` preview.
