### PR TITLE
Update GoReleaser to `v0.172.1`

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.169.0 # pinning bc our config breaks on latest
+          version: v0.172.1 # pinning to prevent breaking on latest
           args: release --release-notes=CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,5 +64,6 @@ nfpms:
     formats:
       - deb
       - rpm
-    files:
-      "./share/man/man1/gh*.1": "/usr/share/man/man1"
+    contents:
+      - src: "/share/man/man1/gh*.1"
+        dst: "/usr/share/man/man1"


### PR DESCRIPTION
Fixes #3909.

`nfpms.files` is deprecated: <https://goreleaser.com/deprecations/#nfpmsfiles>

Tested with this version:

```shell
goreleaser version 0.172.1
commit: 32a44ab928879bb32c1e266b80de32e07d5d6721
```

Before this pull request, `goreleaser check` printed this:

```shell
$goreleaser check
    • loading config file       file=.goreleaser.yml
    ⨯ command failed            error=yaml: unmarshal errors:
  line 67: field files not found in type config.NFPM
```
