### PR TITLE
Skip trying to upgrade local extensions

### DIFF
--- a/pkg/cmd/extensions/extension.go
+++ b/pkg/cmd/extensions/extension.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -20,4 +21,21 @@ func (e *Extension) Path() string {
 
 func (e *Extension) URL() string {
 	return e.url
+}
+
+func (e *Extension) IsLocal() bool {
+	dir := filepath.Dir(e.path)
+	fileInfo, err := os.Lstat(dir)
+	if err != nil {
+		return false
+	}
+	// Check if extension is a symlink
+	if fileInfo.Mode()&os.ModeSymlink != 0 {
+		return true
+	}
+	// Check if extension does not have a git directory
+	if _, err = os.Stat(filepath.Join(dir, ".git")); err != nil {
+		return true
+	}
+	return false
 }

--- a/pkg/cmd/extensions/extension.go
+++ b/pkg/cmd/extensions/extension.go
@@ -1,6 +1,7 @@
 package extensions
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +35,7 @@ func (e *Extension) IsLocal() bool {
 		return true
 	}
 	// Check if extension does not have a git directory
-	if _, err = os.Stat(filepath.Join(dir, ".git")); err != nil {
+	if _, err = os.Stat(filepath.Join(dir, ".git")); errors.Is(err, os.ErrNotExist) {
 		return true
 	}
 	return false

--- a/pkg/cmd/extensions/manager.go
+++ b/pkg/cmd/extensions/manager.go
@@ -157,30 +157,16 @@ func (m *Manager) Upgrade(name string, stdout, stderr io.Writer) error {
 			continue
 		}
 
-		dir := filepath.Dir(f.Path())
-		fileInfo, e := os.Lstat(dir)
-		if e != nil {
-			err = e
+		if f.IsLocal() {
 			if name == "" {
-				fmt.Fprintf(stdout, "%s\n", err)
-			}
-			continue
-		}
-		if fileInfo.Mode()&os.ModeSymlink != 0 {
-			err = localExtensionUpgradeError
-			if name == "" {
-				fmt.Fprintf(stdout, "%s\n", err)
-			}
-			continue
-		}
-		if _, err = os.Stat(filepath.Join(dir, ".git")); err != nil {
-			err = localExtensionUpgradeError
-			if name == "" {
-				fmt.Fprintf(stdout, "%s\n", err)
+				fmt.Fprintf(stdout, "%s\n", localExtensionUpgradeError)
+			} else {
+				err = localExtensionUpgradeError
 			}
 			continue
 		}
 
+		dir := filepath.Dir(f.Path())
 		externalCmd := m.newCommand(exe, "-C", dir, "--git-dir="+filepath.Join(dir, ".git"), "pull", "--ff-only")
 		externalCmd.Stdout = stdout
 		externalCmd.Stderr = stderr

--- a/pkg/cmd/extensions/manager.go
+++ b/pkg/cmd/extensions/manager.go
@@ -166,7 +166,7 @@ func (m *Manager) Upgrade(name string, stdout, stderr io.Writer) error {
 			}
 			continue
 		}
-		if fileInfo.Mode().Type() == os.ModeSymlink {
+		if fileInfo.Mode()&os.ModeSymlink != 0 {
 			err = localExtensionUpgradeError
 			if name == "" {
 				fmt.Fprintf(stdout, "%s\n", err)

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -9,6 +9,7 @@ type Extension interface {
 	Name() string
 	Path() string
 	URL() string
+	IsLocal() bool
 }
 
 //go:generate moq -out manager_mock.go . ExtensionManager

--- a/pkg/extensions/extension_mock.go
+++ b/pkg/extensions/extension_mock.go
@@ -17,6 +17,9 @@ var _ Extension = &ExtensionMock{}
 //
 // 		// make and configure a mocked Extension
 // 		mockedExtension := &ExtensionMock{
+// 			IsLocalFunc: func() bool {
+// 				panic("mock out the IsLocal method")
+// 			},
 // 			NameFunc: func() string {
 // 				panic("mock out the Name method")
 // 			},
@@ -33,6 +36,9 @@ var _ Extension = &ExtensionMock{}
 //
 // 	}
 type ExtensionMock struct {
+	// IsLocalFunc mocks the IsLocal method.
+	IsLocalFunc func() bool
+
 	// NameFunc mocks the Name method.
 	NameFunc func() string
 
@@ -44,6 +50,9 @@ type ExtensionMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// IsLocal holds details about calls to the IsLocal method.
+		IsLocal []struct {
+		}
 		// Name holds details about calls to the Name method.
 		Name []struct {
 		}
@@ -54,9 +63,36 @@ type ExtensionMock struct {
 		URL []struct {
 		}
 	}
-	lockName sync.RWMutex
-	lockPath sync.RWMutex
-	lockURL  sync.RWMutex
+	lockIsLocal sync.RWMutex
+	lockName    sync.RWMutex
+	lockPath    sync.RWMutex
+	lockURL     sync.RWMutex
+}
+
+// IsLocal calls IsLocalFunc.
+func (mock *ExtensionMock) IsLocal() bool {
+	if mock.IsLocalFunc == nil {
+		panic("ExtensionMock.IsLocalFunc: method is nil but Extension.IsLocal was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockIsLocal.Lock()
+	mock.calls.IsLocal = append(mock.calls.IsLocal, callInfo)
+	mock.lockIsLocal.Unlock()
+	return mock.IsLocalFunc()
+}
+
+// IsLocalCalls gets all the calls that were made to IsLocal.
+// Check the length with:
+//     len(mockedExtension.IsLocalCalls())
+func (mock *ExtensionMock) IsLocalCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockIsLocal.RLock()
+	calls = mock.calls.IsLocal
+	mock.lockIsLocal.RUnlock()
+	return calls
 }
 
 // Name calls NameFunc.


### PR DESCRIPTION
This PR improves the experience when using the `extensions upgrade` command and have local extensions. Previous there would be error messages so this cleans up the experience a bunch to give useful output.

<img width="894" alt="Screen Shot 2021-07-01 at 9 47 31 AM" src="https://user-images.githubusercontent.com/7969779/124160735-6cf2f500-da51-11eb-82ad-ed31cbf27f0c.png"> 

https://github.com/cli/cli/issues/3895