### PR TITLE
Add confirmation to extensions remove

### DIFF
--- a/pkg/cmd/extensions/command.go
+++ b/pkg/cmd/extensions/command.go
@@ -121,7 +121,12 @@ func NewCmdExtensions(f *cmdutil.Factory) *cobra.Command {
 			Short: "Remove an installed extension",
 			Args:  cobra.ExactArgs(1),
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return m.Remove(args[0])
+				if err := m.Remove(args[0]); err != nil {
+					return err
+				}
+				cs := io.ColorScheme()
+				fmt.Fprintf(io.Out, "%s Removed extension %s\n", cs.SuccessIcon(), args[0])
+				return nil
 			},
 		},
 	)

--- a/pkg/cmd/extensions/command.go
+++ b/pkg/cmd/extensions/command.go
@@ -121,11 +121,14 @@ func NewCmdExtensions(f *cmdutil.Factory) *cobra.Command {
 			Short: "Remove an installed extension",
 			Args:  cobra.ExactArgs(1),
 			RunE: func(cmd *cobra.Command, args []string) error {
-				if err := m.Remove(args[0]); err != nil {
+				extName := args[0]
+				if err := m.Remove(extName); err != nil {
 					return err
 				}
-				cs := io.ColorScheme()
-				fmt.Fprintf(io.Out, "%s Removed extension %s\n", cs.SuccessIcon(), args[0])
+				if io.IsStdoutTTY() {
+					cs := io.ColorScheme()
+					fmt.Fprintf(io.Out, "%s Removed extension %s\n", cs.SuccessIcon(), extName)
+				}
 				return nil
 			},
 		},

--- a/pkg/cmd/extensions/command_test.go
+++ b/pkg/cmd/extensions/command_test.go
@@ -102,6 +102,7 @@ func TestNewCmdExtensions(t *testing.T) {
 					assert.Equal(t, "hello", calls[0].Name)
 				}
 			},
+			wantStdout: "✓ Removed extension hello\n",
 		},
 	}
 

--- a/pkg/cmd/extensions/command_test.go
+++ b/pkg/cmd/extensions/command_test.go
@@ -24,6 +24,7 @@ func TestNewCmdExtensions(t *testing.T) {
 		name         string
 		args         []string
 		managerStubs func(em *extensions.ExtensionManagerMock) func(*testing.T)
+		isTTY        bool
 		wantErr      bool
 		wantStdout   string
 		wantStderr   string
@@ -90,7 +91,7 @@ func TestNewCmdExtensions(t *testing.T) {
 			},
 		},
 		{
-			name: "remove extension",
+			name: "remove extension tty",
 			args: []string{"remove", "hello"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
 				em.RemoveFunc = func(name string) error {
@@ -102,13 +103,32 @@ func TestNewCmdExtensions(t *testing.T) {
 					assert.Equal(t, "hello", calls[0].Name)
 				}
 			},
+			isTTY:      true,
 			wantStdout: "✓ Removed extension hello\n",
+		},
+		{
+			name: "remove extension nontty",
+			args: []string{"remove", "hello"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.RemoveFunc = func(name string) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.RemoveCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "hello", calls[0].Name)
+				}
+			},
+			isTTY:      false,
+			wantStdout: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			var assertFunc func(*testing.T)
 			em := &extensions.ExtensionManagerMock{}


### PR DESCRIPTION
This PR adds a success notice when removing an extension.

cc https://github.com/cli/cli/issues/3895