### PR TITLE
Extension install check

### DIFF
--- a/pkg/cmd/extensions/command.go
+++ b/pkg/cmd/extensions/command.go
@@ -88,7 +88,12 @@ func NewCmdExtensions(f *cmdutil.Factory) *cobra.Command {
 					return err
 				}
 				if c != rootCmd {
-					return fmt.Errorf("could not install %s: %s is already a gh command", args[0], commandName)
+					return fmt.Errorf("could not install %s: %s is already a command", args[0], commandName)
+				}
+				for _, ext := range m.List() {
+					if ext.Name() == commandName {
+						return fmt.Errorf("could not install %s: %s is already an installed extension", args[0], commandName)
+					}
 				}
 
 				cfg, err := f.Config()

--- a/pkg/cmd/extensions/command.go
+++ b/pkg/cmd/extensions/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/cli/cli/pkg/cmdutil"
+	"github.com/cli/cli/pkg/extensions"
 	"github.com/cli/cli/utils"
 	"github.com/spf13/cobra"
 )
@@ -73,27 +74,13 @@ func NewCmdExtensions(f *cmdutil.Factory) *cobra.Command {
 					}
 					return m.InstallLocal(wd)
 				}
+
 				repo, err := ghrepo.FromFullName(args[0])
 				if err != nil {
 					return err
 				}
-				if !strings.HasPrefix(repo.RepoName(), "gh-") {
-					return errors.New("the repository name must start with `gh-`")
-				}
-
-				commandName := strings.TrimPrefix(repo.RepoName(), "gh-")
-				rootCmd := cmd.Root()
-				c, _, err := rootCmd.Traverse([]string{commandName})
-				if err != nil {
+				if err := checkValidExtension(cmd.Root(), m, repo.RepoName()); err != nil {
 					return err
-				}
-				if c != rootCmd {
-					return fmt.Errorf("could not install %s: %s is already a command", args[0], commandName)
-				}
-				for _, ext := range m.List() {
-					if ext.Name() == commandName {
-						return fmt.Errorf("could not install %s: %s is already an installed extension", args[0], commandName)
-					}
 				}
 
 				cfg, err := f.Config()
@@ -144,4 +131,25 @@ func NewCmdExtensions(f *cmdutil.Factory) *cobra.Command {
 
 	extCmd.Hidden = true
 	return &extCmd
+}
+
+func checkValidExtension(rootCmd *cobra.Command, m extensions.ExtensionManager, extName string) error {
+	if !strings.HasPrefix(extName, "gh-") {
+		return errors.New("extension repository name must start with `gh-`")
+	}
+
+	commandName := strings.TrimPrefix(extName, "gh-")
+	if c, _, err := rootCmd.Traverse([]string{commandName}); err != nil {
+		return err
+	} else if c != rootCmd {
+		return fmt.Errorf("%q matches the name of a built-in command", commandName)
+	}
+
+	for _, ext := range m.List() {
+		if ext.Name() == commandName {
+			return fmt.Errorf("there is already an installed extension that provides the %q command", commandName)
+		}
+	}
+
+	return nil
 }

--- a/pkg/cmd/extensions/command.go
+++ b/pkg/cmd/extensions/command.go
@@ -80,6 +80,17 @@ func NewCmdExtensions(f *cmdutil.Factory) *cobra.Command {
 				if !strings.HasPrefix(repo.RepoName(), "gh-") {
 					return errors.New("the repository name must start with `gh-`")
 				}
+
+				commandName := strings.TrimPrefix(repo.RepoName(), "gh-")
+				rootCmd := cmd.Root()
+				c, _, err := rootCmd.Traverse([]string{commandName})
+				if err != nil {
+					return err
+				}
+				if c != rootCmd {
+					return fmt.Errorf("could not install %s: %s is already a gh command", args[0], commandName)
+				}
+
 				cfg, err := f.Config()
 				if err != nil {
 					return err

--- a/pkg/cmd/extensions/command_test.go
+++ b/pkg/cmd/extensions/command_test.go
@@ -2,6 +2,7 @@ package extensions
 
 import (
 	"io"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -145,8 +146,8 @@ func TestNewCmdExtensions(t *testing.T) {
 
 			cmd := NewCmdExtensions(&f)
 			cmd.SetArgs(tt.args)
-			cmd.SetOut(io.Discard)
-			cmd.SetErr(io.Discard)
+			cmd.SetOut(ioutil.Discard)
+			cmd.SetErr(ioutil.Discard)
 
 			_, err := cmd.ExecuteC()
 			if tt.wantErr {


### PR DESCRIPTION
This PR disallows the installation of extensions that have the same name as another command or the same name as another installed extension. 

cc https://github.com/cli/cli/issues/3895