### PR TITLE
Allow auto-completing the `--repo` values

### DIFF
--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -2,6 +2,8 @@ package cmdutil
 
 import (
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/cli/cli/internal/ghrepo"
 	"github.com/spf13/cobra"
@@ -19,6 +21,30 @@ func executeParentHooks(cmd *cobra.Command, args []string) error {
 
 func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
 	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `[HOST/]OWNER/REPO` format")
+	_ = cmd.RegisterFlagCompletionFunc("repo", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		var results []string
+		remotes, err := f.Remotes()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		config, err := f.Config()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		gh_host,err := config.DefaultHost()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		for _, remote := range remotes.FilterByHosts([]string{gh_host}) {
+			repo := remote.RepoOwner() + "/" + remote.RepoName()
+			if strings.HasPrefix(repo, toComplete) {
+				results = append(results, repo)
+			}
+		}
+		sort.Strings(results)
+		return results, cobra.ShellCompDirectiveNoFileComp
+	})
 
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		if err := executeParentHooks(cmd, args); err != nil {

--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -22,22 +22,26 @@ func executeParentHooks(cmd *cobra.Command, args []string) error {
 func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
 	cmd.PersistentFlags().StringP("repo", "R", "", "Select another repository using the `[HOST/]OWNER/REPO` format")
 	_ = cmd.RegisterFlagCompletionFunc("repo", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		var results []string
 		remotes, err := f.Remotes()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
+
 		config, err := f.Config()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
-		gh_host,err := config.DefaultHost()
+		defaultHost, err := config.DefaultHost()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
 
-		for _, remote := range remotes.FilterByHosts([]string{gh_host}) {
+		var results []string
+		for _, remote := range remotes {
 			repo := remote.RepoOwner() + "/" + remote.RepoName()
+			if !strings.EqualFold(remote.RepoHost(), defaultHost) {
+				repo = remote.RepoHost() + "/" + repo
+			}
 			if strings.HasPrefix(repo, toComplete) {
 				results = append(results, repo)
 			}


### PR DESCRIPTION
I have a local worktree with 28 different remotes, and `gh pr create` usually tries to pick one of the 27 I don't want to open a PR. So I thought it would be neat to have auto-completion for the `--repo` option. And here it is.

Please let me know if I made any mistake; This is the first Go code I wrote in at least two years.