### PR TITLE
Return SilentError if completed run failed

### DIFF
--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -123,6 +123,9 @@ func watchRun(opts *WatchOptions) error {
 
 	if run.Status == shared.Completed {
 		fmt.Fprintf(out, "Run %s (%s) has already completed with '%s'\n", cs.Bold(run.Name), cs.Cyanf("%d", run.ID), run.Conclusion)
+		if opts.ExitStatus && run.Conclusion != shared.Success {
+			return cmdutil.SilentError
+		}
 		return nil
 	}
 


### PR DESCRIPTION
If `gh run watch ${ID} --exit-status` is run and "ID" is the ID of a
completed job that failed, return a SilentError. This ensures that the
program returns a non-zero code.

Fixes #3962

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
