### PR TITLE
fix repo create --confirm

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -221,21 +221,23 @@ func createRun(opts *CreateOptions) error {
 			return err
 		}
 
-		// GitIgnore and License templates not added when a template repository is passed.
-		if gitIgnoreTemplate == "" && opts.Template == "" && opts.IO.CanPrompt() {
-			gt, err := interactiveGitIgnore(api.NewClientFromHTTP(httpClient), host)
-			if err != nil {
-				return err
+		// GitIgnore and License templates not added when a template repository
+		// is passed, or when the confirm flag is set.
+		if opts.Template == "" && opts.IO.CanPrompt() && !opts.ConfirmSubmit {
+			if gitIgnoreTemplate == "" {
+				gt, err := interactiveGitIgnore(api.NewClientFromHTTP(httpClient), host)
+				if err != nil {
+					return err
+				}
+				gitIgnoreTemplate = gt
 			}
-			gitIgnoreTemplate = gt
-		}
-
-		if repoLicenseTemplate == "" && opts.Template == "" && opts.IO.CanPrompt() {
-			lt, err := interactiveLicense(api.NewClientFromHTTP(httpClient), host)
-			if err != nil {
-				return err
+			if repoLicenseTemplate == "" {
+				lt, err := interactiveLicense(api.NewClientFromHTTP(httpClient), host)
+				if err != nil {
+					return err
+				}
+				repoLicenseTemplate = lt
 			}
-			repoLicenseTemplate = lt
 		}
 	}
 


### PR DESCRIPTION
Respect the --confirm flag when deciding whether to prompt for gitignore
and license creation during `repo create`

Fixes #3989

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
