### PR TITLE
Skip auto migrate of config when GH_CONFIG_DIR

### DIFF
--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -40,8 +40,9 @@ func ConfigDir() string {
 		path = filepath.Join(d, ".config", "gh")
 	}
 
-	// If the path does not exist try migrating config from default paths
-	if !dirExists(path) {
+	// If the path does not exist and the GH_CONFIG_DIR flag is not set try
+	// migrating config from default paths.
+	if !dirExists(path) && os.Getenv(GH_CONFIG_DIR) == "" {
 		_ = autoMigrateConfigDir(path)
 	}
 


### PR DESCRIPTION
If GH_CONFIG_DIR is set, don't auto migrate the config file. This fixes
the situation where the path given via GH_CONFIG_DIR does not exist and
the cli attempts to migrate an existing config to that location.

Fixes #3837

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
