### PR TITLE
Clean up GH_CONFIG_DIR docs

### DIFF
--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -49,7 +49,8 @@ var HelpTopics = map[string]map[string]string{
 			DEBUG: set to any value to enable verbose output to standard error. Include values "api"
 			or "oauth" to print detailed information about HTTP requests or authentication flow.
 
-			GH_PAGER, PAGER (in order of precedence): a terminal paging program to send standard output to, e.g. "less".
+			GH_PAGER, PAGER (in order of precedence): a terminal paging program to send standard output
+			to, e.g. "less".
 
 			GLAMOUR_STYLE: the style to use for rendering Markdown. See
 			https://github.com/charmbracelet/glamour#styles
@@ -65,11 +66,8 @@ var HelpTopics = map[string]map[string]string{
 			checks for new releases once every 24 hours and displays an upgrade notice on standard
 			error if a newer version was found.
 
-			GH_CONFIG_DIR, XDG_CONFIG_HOME (in order of precedence): the directory where gh will store configuration files.
-
-			XDG_STATE_HOME: the directory where gh will store state files.
-
-			XDG_DATA_HOME: the directory where gh will store data files.
+			GH_CONFIG_DIR: the directory where gh will store configuration files. Default:
+			"$XDG_CONFIG_HOME/gh" or "$HOME/.config/gh".
 		`),
 	},
 	"reference": {


### PR DESCRIPTION
This removes the false equivalence between GH_CONFIG_DIR and XDG_CONFIG_HOME. These settings do not have the same effect and should not be used for the same purposes.

Also remove the documentation about what `XDG_*` settings do. We simply conform to the XDG Base Directory Specification, but will not document it. It's likely that users of these environment variables already know what they do.

Followup to #3768
