### PR TITLE
Revert "Update GoReleaser"

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.172.1 # pinning to prevent breaking on latest
+          version: v0.169.0 # pinning bc our config breaks on latest
           args: release --release-notes=CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,6 +64,5 @@ nfpms:
     formats:
       - deb
       - rpm
-    contents:
-      - src: "/share/man/man1/gh*.1"
-        dst: "/usr/share/man/man1"
+    files:
+      "./share/man/man1/gh*.1": "/usr/share/man/man1"


### PR DESCRIPTION
Reverts cli/cli#3926

Fixes #4023
Ref. https://github.com/goreleaser/goreleaser/issues/2325

According to [goreleaser documentation](https://goreleaser.com/customization/nfpm/), a potential fix for the latest goreleaser version could be to just do `bindir: /usr/bin` instead of `bindir: /usr`, but I thought it safer to revert to an older goreleaser version until we can more thoroughly test this.