### PR TITLE
Add --force flag for extensions upgrade

### DIFF
--- a/pkg/cmd/extensions/command.go
+++ b/pkg/cmd/extensions/command.go
@@ -96,6 +96,7 @@ func NewCmdExtensions(f *cmdutil.Factory) *cobra.Command {
 		},
 		func() *cobra.Command {
 			var flagAll bool
+			var flagForce bool
 			cmd := &cobra.Command{
 				Use:   "upgrade {<name> | --all}",
 				Short: "Upgrade installed extensions",
@@ -116,10 +117,11 @@ func NewCmdExtensions(f *cmdutil.Factory) *cobra.Command {
 					if len(args) > 0 {
 						name = args[0]
 					}
-					return m.Upgrade(name, io.Out, io.ErrOut)
+					return m.Upgrade(name, flagForce, io.Out, io.ErrOut)
 				},
 			}
 			cmd.Flags().BoolVar(&flagAll, "all", false, "Upgrade all extensions")
+			cmd.Flags().BoolVar(&flagForce, "force", false, "Force upgrade extension")
 			return cmd
 		}(),
 		&cobra.Command{

--- a/pkg/cmd/extensions/command_test.go
+++ b/pkg/cmd/extensions/command_test.go
@@ -90,7 +90,7 @@ func TestNewCmdExtensions(t *testing.T) {
 			name: "upgrade an extension",
 			args: []string{"upgrade", "hello"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.UpgradeFunc = func(name string, out, errOut io.Writer) error {
+				em.UpgradeFunc = func(name string, force bool, out, errOut io.Writer) error {
 					return nil
 				}
 				return func(t *testing.T) {
@@ -104,7 +104,7 @@ func TestNewCmdExtensions(t *testing.T) {
 			name: "upgrade all",
 			args: []string{"upgrade", "--all"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.UpgradeFunc = func(name string, out, errOut io.Writer) error {
+				em.UpgradeFunc = func(name string, force bool, out, errOut io.Writer) error {
 					return nil
 				}
 				return func(t *testing.T) {

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -18,7 +18,7 @@ type ExtensionManager interface {
 	List() []Extension
 	Install(url string, stdout, stderr io.Writer) error
 	InstallLocal(dir string) error
-	Upgrade(name string, stdout, stderr io.Writer) error
+	Upgrade(name string, force bool, stdout, stderr io.Writer) error
 	Remove(name string) error
 	Dispatch(args []string, stdin io.Reader, stdout, stderr io.Writer) (bool, error)
 }

--- a/pkg/extensions/manager_mock.go
+++ b/pkg/extensions/manager_mock.go
@@ -33,7 +33,7 @@ var _ ExtensionManager = &ExtensionManagerMock{}
 // 			RemoveFunc: func(name string) error {
 // 				panic("mock out the Remove method")
 // 			},
-// 			UpgradeFunc: func(name string, stdout io.Writer, stderr io.Writer) error {
+// 			UpgradeFunc: func(name string, force bool, stdout io.Writer, stderr io.Writer) error {
 // 				panic("mock out the Upgrade method")
 // 			},
 // 		}
@@ -59,7 +59,7 @@ type ExtensionManagerMock struct {
 	RemoveFunc func(name string) error
 
 	// UpgradeFunc mocks the Upgrade method.
-	UpgradeFunc func(name string, stdout io.Writer, stderr io.Writer) error
+	UpgradeFunc func(name string, force bool, stdout io.Writer, stderr io.Writer) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -100,6 +100,8 @@ type ExtensionManagerMock struct {
 		Upgrade []struct {
 			// Name is the name argument value.
 			Name string
+			// Force is the force argument value.
+			Force bool
 			// Stdout is the stdout argument value.
 			Stdout io.Writer
 			// Stderr is the stderr argument value.
@@ -285,23 +287,25 @@ func (mock *ExtensionManagerMock) RemoveCalls() []struct {
 }
 
 // Upgrade calls UpgradeFunc.
-func (mock *ExtensionManagerMock) Upgrade(name string, stdout io.Writer, stderr io.Writer) error {
+func (mock *ExtensionManagerMock) Upgrade(name string, force bool, stdout io.Writer, stderr io.Writer) error {
 	if mock.UpgradeFunc == nil {
 		panic("ExtensionManagerMock.UpgradeFunc: method is nil but ExtensionManager.Upgrade was just called")
 	}
 	callInfo := struct {
 		Name   string
+		Force  bool
 		Stdout io.Writer
 		Stderr io.Writer
 	}{
 		Name:   name,
+		Force:  force,
 		Stdout: stdout,
 		Stderr: stderr,
 	}
 	mock.lockUpgrade.Lock()
 	mock.calls.Upgrade = append(mock.calls.Upgrade, callInfo)
 	mock.lockUpgrade.Unlock()
-	return mock.UpgradeFunc(name, stdout, stderr)
+	return mock.UpgradeFunc(name, force, stdout, stderr)
 }
 
 // UpgradeCalls gets all the calls that were made to Upgrade.
@@ -309,11 +313,13 @@ func (mock *ExtensionManagerMock) Upgrade(name string, stdout io.Writer, stderr 
 //     len(mockedExtensionManager.UpgradeCalls())
 func (mock *ExtensionManagerMock) UpgradeCalls() []struct {
 	Name   string
+	Force  bool
 	Stdout io.Writer
 	Stderr io.Writer
 } {
 	var calls []struct {
 		Name   string
+		Force  bool
 		Stdout io.Writer
 		Stderr io.Writer
 	}


### PR DESCRIPTION
This PR adds a `--force` flag to the `extensions upgrade` command. The `--force` option uses `git reset --hard` to make the checked-out extension repo match the remote extension repo. It will discard any local changes or commits. 

cc https://github.com/cli/cli/issues/3895