### PR TITLE
Update Goreleaser, take 2

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.174.0
+          version: v0.174.1
           args: release --release-notes=CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.169.0 # pinning bc our config breaks on latest
+          version: v0.174.0
           args: release --release-notes=CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,12 +57,13 @@ nfpms:
   - license: MIT
     maintainer: GitHub
     homepage: https://github.com/cli/cli
-    bindir: /usr
+    bindir: /usr/bin
     dependencies:
       - git
     description: GitHub’s official command line tool.
     formats:
       - deb
       - rpm
-    files:
-      "./share/man/man1/gh*.1": "/usr/share/man/man1"
+    contents:
+      - src: "./share/man/man1/gh*.1"
+        dst: "/usr/share/man/man1"


### PR DESCRIPTION
Previously: #3926
Reverts commit 85d0447a6ea2263b0f2babbd44c1be1ccf3104d4.

Verified via:
```
$ goreleaser release --skip-publish --skip-validate --rm-dist
$ docker run --rm -ti -v "$PWD/dist:/dist" ubuntu:focal dpkg -c /dist/gh_1.13.1_linux_amd64.deb
drwxr-xr-x 0/0               0 2021-07-26 13:01 ./usr/
drwxr-xr-x 0/0               0 2021-07-26 13:01 ./usr/bin/
-rwxr-xr-x 0/0        28893184 2021-07-26 13:01 ./usr/bin/gh
```