### PR TITLE
Fix typo in openSUSE installation instructions

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -170,7 +170,7 @@ nix-env -iA nixos.gitAndTools.gh
 
 ### openSUSE Tumbleweed
 
-openSUSE Tumbleweed users can install from the [offical distribution repo](https://software.opensuse.org/package/gh):
+openSUSE Tumbleweed users can install from the [official distribution repo](https://software.opensuse.org/package/gh):
 ```bash
 sudo zypper in gh
 ```


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
