### PR TITLE
Rework local extensions for Windows

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -166,7 +166,7 @@ func mainRun() exitCode {
 				}
 			}
 		}
-		for _, ext := range cmdFactory.ExtensionManager.List() {
+		for _, ext := range cmdFactory.ExtensionManager.List(false) {
 			if strings.HasPrefix(ext.Name(), toComplete) {
 				results = append(results, ext.Name())
 			}

--- a/pkg/cmd/alias/set/set.go
+++ b/pkg/cmd/alias/set/set.go
@@ -82,7 +82,7 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 					return true
 				}
 
-				for _, ext := range f.ExtensionManager.List() {
+				for _, ext := range f.ExtensionManager.List(false) {
 					if ext.Name() == split[0] {
 						return true
 					}

--- a/pkg/cmd/alias/set/set_test.go
+++ b/pkg/cmd/alias/set/set_test.go
@@ -30,7 +30,7 @@ func runCommand(cfg config.Config, isTTY bool, cli string, in string) (*test.Cmd
 			return cfg, nil
 		},
 		ExtensionManager: &extensions.ExtensionManagerMock{
-			ListFunc: func() []extensions.Extension {
+			ListFunc: func(bool) []extensions.Extension {
 				return []extensions.Extension{}
 			},
 		},

--- a/pkg/cmd/extensions/command.go
+++ b/pkg/cmd/extensions/command.go
@@ -39,7 +39,7 @@ func NewCmdExtensions(f *cmdutil.Factory) *cobra.Command {
 			Short: "List installed extension commands",
 			Args:  cobra.NoArgs,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				cmds := m.List()
+				cmds := m.List(true)
 				if len(cmds) == 0 {
 					return errors.New("no extensions installed")
 				}
@@ -158,7 +158,7 @@ func checkValidExtension(rootCmd *cobra.Command, m extensions.ExtensionManager, 
 		return fmt.Errorf("%q matches the name of a built-in command", commandName)
 	}
 
-	for _, ext := range m.List() {
+	for _, ext := range m.List(false) {
 		if ext.Name() == commandName {
 			return fmt.Errorf("there is already an installed extension that provides the %q command", commandName)
 		}

--- a/pkg/cmd/extensions/command_test.go
+++ b/pkg/cmd/extensions/command_test.go
@@ -35,7 +35,7 @@ func TestNewCmdExtensions(t *testing.T) {
 			name: "install an extension",
 			args: []string{"install", "owner/gh-some-ext"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.ListFunc = func() []extensions.Extension {
+				em.ListFunc = func(bool) []extensions.Extension {
 					return []extensions.Extension{}
 				}
 				em.InstallFunc = func(s string, out, errOut io.Writer) error {
@@ -54,7 +54,7 @@ func TestNewCmdExtensions(t *testing.T) {
 			name: "install an extension with same name as existing extension",
 			args: []string{"install", "owner/gh-existing-ext"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.ListFunc = func() []extensions.Extension {
+				em.ListFunc = func(bool) []extensions.Extension {
 					e := &Extension{path: "owner2/gh-existing-ext"}
 					return []extensions.Extension{e}
 				}
@@ -150,7 +150,7 @@ func TestNewCmdExtensions(t *testing.T) {
 			name: "list extensions",
 			args: []string{"list"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.ListFunc = func() []extensions.Extension {
+				em.ListFunc = func(bool) []extensions.Extension {
 					ex1 := &Extension{path: "cli/gh-test", url: "https://github.com/cli/gh-test", updateAvailable: false}
 					ex2 := &Extension{path: "cli/gh-test2", url: "https://github.com/cli/gh-test2", updateAvailable: true}
 					return []extensions.Extension{ex1, ex2}
@@ -215,7 +215,7 @@ func Test_checkValidExtension(t *testing.T) {
 	rootCmd.AddCommand(&cobra.Command{Use: "auth"})
 
 	m := &extensions.ExtensionManagerMock{
-		ListFunc: func() []extensions.Extension {
+		ListFunc: func(bool) []extensions.Extension {
 			return []extensions.Extension{
 				&extensions.ExtensionMock{
 					NameFunc: func() string { return "screensaver" },

--- a/pkg/cmd/extensions/extension.go
+++ b/pkg/cmd/extensions/extension.go
@@ -1,8 +1,6 @@
 package extensions
 
 import (
-	"errors"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -10,6 +8,7 @@ import (
 type Extension struct {
 	path            string
 	url             string
+	isLocal         bool
 	updateAvailable bool
 }
 
@@ -26,20 +25,7 @@ func (e *Extension) URL() string {
 }
 
 func (e *Extension) IsLocal() bool {
-	dir := filepath.Dir(e.path)
-	fileInfo, err := os.Lstat(dir)
-	if err != nil {
-		return false
-	}
-	// Check if extension is a symlink
-	if fileInfo.Mode()&os.ModeSymlink != 0 {
-		return true
-	}
-	// Check if extension does not have a git directory
-	if _, err = os.Stat(filepath.Join(dir, ".git")); errors.Is(err, os.ErrNotExist) {
-		return true
-	}
-	return false
+	return e.isLocal
 }
 
 func (e *Extension) UpdateAvailable() bool {

--- a/pkg/cmd/extensions/manager.go
+++ b/pkg/cmd/extensions/manager.go
@@ -108,16 +108,11 @@ func (m *Manager) list(includeMetadata bool) ([]extensions.Extension, error) {
 			isLocal = true
 			if f.Mode()&os.ModeSymlink == 0 {
 				// if this is a regular file, its contents is the local directory of the extension
-				exeFile, err := os.Open(filepath.Join(dir, f.Name()))
+				p, err := readPathFromFile(filepath.Join(dir, f.Name()))
 				if err != nil {
 					return nil, err
 				}
-				b := make([]byte, 1024)
-				n, err := exeFile.Read(b)
-				if err != nil {
-					return nil, err
-				}
-				exePath = filepath.Join(strings.TrimSpace(string(b[:n])), f.Name())
+				exePath = filepath.Join(p, f.Name())
 			}
 		}
 		results = append(results, &Extension{
@@ -271,4 +266,15 @@ func runCmds(cmds []*exec.Cmd, stdout, stderr io.Writer) error {
 		}
 	}
 	return nil
+}
+
+func readPathFromFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	b := make([]byte, 1024)
+	n, err := f.Read(b)
+	return strings.TrimSpace(string(b[:n])), err
 }

--- a/pkg/cmd/extensions/manager_test.go
+++ b/pkg/cmd/extensions/manager_test.go
@@ -214,7 +214,7 @@ func stubExtension(path string) error {
 }
 
 func stubLocalExtension(tempDir, path string) error {
-	extDir, err := os.MkdirTemp(tempDir, "local-ext")
+	extDir, err := ioutil.TempDir(tempDir, "local-ext")
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/extensions/manager_test.go
+++ b/pkg/cmd/extensions/manager_test.go
@@ -48,7 +48,7 @@ func TestManager_List(t *testing.T) {
 	assert.NoError(t, stubExtension(filepath.Join(tempDir, "extensions", "gh-two", "gh-two")))
 
 	m := newTestManager(tempDir)
-	exts := m.List()
+	exts := m.List(false)
 	assert.Equal(t, 2, len(exts))
 	assert.Equal(t, "hello", exts[0].Name())
 	assert.Equal(t, "two", exts[1].Name())
@@ -94,7 +94,7 @@ func TestManager_Upgrade_AllExtensions(t *testing.T) {
 	tempDir := t.TempDir()
 	assert.NoError(t, stubExtension(filepath.Join(tempDir, "extensions", "gh-hello", "gh-hello")))
 	assert.NoError(t, stubExtension(filepath.Join(tempDir, "extensions", "gh-two", "gh-two")))
-	assert.NoError(t, stubLocalExtension(filepath.Join(tempDir, "extensions", "gh-local", "gh-local")))
+	assert.NoError(t, stubLocalExtension(tempDir, filepath.Join(tempDir, "extensions", "gh-local", "gh-local")))
 
 	m := newTestManager(tempDir)
 
@@ -139,7 +139,7 @@ func TestManager_Upgrade_RemoteExtension(t *testing.T) {
 
 func TestManager_Upgrade_LocalExtension(t *testing.T) {
 	tempDir := t.TempDir()
-	assert.NoError(t, stubLocalExtension(filepath.Join(tempDir, "extensions", "gh-local", "gh-local")))
+	assert.NoError(t, stubLocalExtension(tempDir, filepath.Join(tempDir, "extensions", "gh-local", "gh-local")))
 
 	m := newTestManager(tempDir)
 
@@ -203,12 +203,7 @@ func TestManager_Install(t *testing.T) {
 }
 
 func stubExtension(path string) error {
-	dir := filepath.Dir(path)
-	gitDir := filepath.Join(dir, ".git")
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return err
-	}
-	if err := os.Mkdir(gitDir, 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
 	f, err := os.OpenFile(path, os.O_CREATE, 0755)
@@ -218,11 +213,28 @@ func stubExtension(path string) error {
 	return f.Close()
 }
 
-func stubLocalExtension(path string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+func stubLocalExtension(tempDir, path string) error {
+	extDir, err := os.MkdirTemp(tempDir, "local-ext")
+	if err != nil {
 		return err
 	}
-	f, err := os.OpenFile(path, os.O_CREATE, 0755)
+	extFile, err := os.OpenFile(filepath.Join(extDir, filepath.Base(path)), os.O_CREATE, 0755)
+	if err != nil {
+		return err
+	}
+	if err := extFile.Close(); err != nil {
+		return err
+	}
+
+	linkPath := filepath.Dir(path)
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(linkPath, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(extDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/extensions/symlink_other.go
+++ b/pkg/cmd/extensions/symlink_other.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package extensions
+
+import "os"
+
+func makeSymlink(oldname, newname string) error {
+	return os.Symlink(oldname, newname)
+}

--- a/pkg/cmd/extensions/symlink_windows.go
+++ b/pkg/cmd/extensions/symlink_windows.go
@@ -1,0 +1,15 @@
+package extensions
+
+import "os"
+
+func makeSymlink(oldname, newname string) error {
+	// Create a regular file that contains the location of the directory where to find this extension. We
+	// avoid relying on symlinks because creating them on Windows requires administrator privileges.
+	f, err := os.OpenFile(newname, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(oldname)
+	return err
+}

--- a/pkg/cmd/root/help.go
+++ b/pkg/cmd/root/help.go
@@ -145,7 +145,7 @@ func rootHelpFunc(f *cmdutil.Factory, command *cobra.Command, args []string) {
 	}
 
 	if isRootCmd(command) {
-		if exts := f.ExtensionManager.List(); len(exts) > 0 {
+		if exts := f.ExtensionManager.List(false); len(exts) > 0 {
 			var names []string
 			for _, ext := range exts {
 				names = append(names, ext.Name())

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -4,7 +4,7 @@ import (
 	"io"
 )
 
-//go:generate moq -out extension_mock.go . Extension
+//go:generate moq -rm -out extension_mock.go . Extension
 type Extension interface {
 	Name() string
 	Path() string
@@ -13,9 +13,9 @@ type Extension interface {
 	UpdateAvailable() bool
 }
 
-//go:generate moq -out manager_mock.go . ExtensionManager
+//go:generate moq -rm -out manager_mock.go . ExtensionManager
 type ExtensionManager interface {
-	List() []Extension
+	List(includeMetadata bool) []Extension
 	Install(url string, stdout, stderr io.Writer) error
 	InstallLocal(dir string) error
 	Upgrade(name string, force bool, stdout, stderr io.Writer) error

--- a/pkg/extensions/manager_mock.go
+++ b/pkg/extensions/manager_mock.go
@@ -27,7 +27,7 @@ var _ ExtensionManager = &ExtensionManagerMock{}
 // 			InstallLocalFunc: func(dir string) error {
 // 				panic("mock out the InstallLocal method")
 // 			},
-// 			ListFunc: func() []Extension {
+// 			ListFunc: func(includeMetadata bool) []Extension {
 // 				panic("mock out the List method")
 // 			},
 // 			RemoveFunc: func(name string) error {
@@ -53,7 +53,7 @@ type ExtensionManagerMock struct {
 	InstallLocalFunc func(dir string) error
 
 	// ListFunc mocks the List method.
-	ListFunc func() []Extension
+	ListFunc func(includeMetadata bool) []Extension
 
 	// RemoveFunc mocks the Remove method.
 	RemoveFunc func(name string) error
@@ -90,6 +90,8 @@ type ExtensionManagerMock struct {
 		}
 		// List holds details about calls to the List method.
 		List []struct {
+			// IncludeMetadata is the includeMetadata argument value.
+			IncludeMetadata bool
 		}
 		// Remove holds details about calls to the Remove method.
 		Remove []struct {
@@ -230,24 +232,29 @@ func (mock *ExtensionManagerMock) InstallLocalCalls() []struct {
 }
 
 // List calls ListFunc.
-func (mock *ExtensionManagerMock) List() []Extension {
+func (mock *ExtensionManagerMock) List(includeMetadata bool) []Extension {
 	if mock.ListFunc == nil {
 		panic("ExtensionManagerMock.ListFunc: method is nil but ExtensionManager.List was just called")
 	}
 	callInfo := struct {
-	}{}
+		IncludeMetadata bool
+	}{
+		IncludeMetadata: includeMetadata,
+	}
 	mock.lockList.Lock()
 	mock.calls.List = append(mock.calls.List, callInfo)
 	mock.lockList.Unlock()
-	return mock.ListFunc()
+	return mock.ListFunc(includeMetadata)
 }
 
 // ListCalls gets all the calls that were made to List.
 // Check the length with:
 //     len(mockedExtensionManager.ListCalls())
 func (mock *ExtensionManagerMock) ListCalls() []struct {
+	IncludeMetadata bool
 } {
 	var calls []struct {
+		IncludeMetadata bool
 	}
 	mock.lockList.RLock()
 	calls = mock.calls.List


### PR DESCRIPTION
Replace the implementation that relied on symlinks with the one that create regular files that act like symlinks: they contain a reference to the local directory where to find the extension.

Bonus:
- Listing extensions is now faster in places where metadata is not needed (e.g. in `gh` help output) because checking for updates is skipped.
- Fixed error when the first installed extension happens to be a local one.