### PR TITLE
Fix colors of left and right parens of issue label are different

### DIFF
--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -33,7 +33,7 @@ func PrintIssues(io *iostreams.IOStreams, prefix string, totalCount int, issues 
 			table.AddField(issue.State, nil, nil)
 		}
 		table.AddField(text.ReplaceExcessiveWhitespace(issue.Title), nil, nil)
-		table.AddField(labels, truncateLabels, cs.Gray)
+		table.AddField(labels, truncateLabels, nil)
 		if table.IsTTY() {
 			table.AddField(utils.FuzzyAgo(ago), nil, cs.Gray)
 		} else {


### PR DESCRIPTION
This PR fixes small color issue on listing issues. Since the issue is very small, I made the fix and PR directly without making an issue.

Here are outputs of `gh issue list` before/after this fix.

### Before (gh 1.13.1)

<img width="723" alt="スクリーンショット 2021-07-31 2 14 33" src="https://user-images.githubusercontent.com/823277/127689062-11313330-cb25-45f5-8fef-26d842c29977.png">

Left paren of issue labels is gray but right paren of issue labels is white.

### After

<img width="723" alt="スクリーンショット 2021-07-31 2 15 17" src="https://user-images.githubusercontent.com/823277/127689097-4726bd77-8b44-4cf3-8c32-9daa0b46442a.png">

Both parens are white.

### Note

It is a bit difficult to make both parens gray because giving a color to right paren requires some hack. Issue labels are truncated when they are too long in `truncateLabels` function, but it truncates labels string without considering escape sequence.