### PR TITLE
Remove ANSI color sequences when calculating width of display text

### DIFF
--- a/pkg/text/truncate.go
+++ b/pkg/text/truncate.go
@@ -1,6 +1,8 @@
 package text
 
 import (
+	"regexp"
+
 	runewidth "github.com/mattn/go-runewidth"
 	"github.com/rivo/uniseg"
 )
@@ -10,8 +12,11 @@ const (
 	minWidthForEllipsis = 5
 )
 
+var reColorSequence = regexp.MustCompile(`\x1B\[(:?\d+;)*\d+m`)
+
 // DisplayWidth calculates what the rendered width of a string may be
 func DisplayWidth(s string) int {
+	s = reColorSequence.ReplaceAllString(s, "")
 	g := uniseg.NewGraphemes(s)
 	w := 0
 	for g.Next() {

--- a/pkg/text/truncate_test.go
+++ b/pkg/text/truncate_test.go
@@ -149,6 +149,16 @@ func TestDisplayWidth(t *testing.T) {
 			text: `é́́`,
 			want: 1,
 		},
+		{
+			name: "256 bit color sequence",
+			text: "\x1b[38;2;215;58;74mbug\x1b[0m",
+			want: 3,
+		},
+		{
+			name: "4 bit color sequence",
+			text: "\x1b[31mbug\x1b[0m",
+			want: 3,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #4065 

This PR fixes the example shown in the issue as follows:

<img width="891" alt="スクリーンショット 2021-07-31 3 01 26" src="https://user-images.githubusercontent.com/823277/127693763-7c466513-4c9a-476b-87c4-75e04af16b17.png">

The start positions of issue date column are aligned correctly.
