### PR TITLE
Disable colorizing labels in `issue list` output

### DIFF
--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -22,7 +22,7 @@ func PrintIssues(io *iostreams.IOStreams, prefix string, totalCount int, issues 
 			issueNum = "#" + issueNum
 		}
 		issueNum = prefix + issueNum
-		labels := IssueLabelList(issue, cs)
+		labels := issueLabelList(&issue)
 		if labels != "" && table.IsTTY() {
 			labels = fmt.Sprintf("(%s)", labels)
 		}
@@ -56,14 +56,14 @@ func truncateLabels(w int, t string) string {
 	return fmt.Sprintf("(%s)", truncated)
 }
 
-func IssueLabelList(issue api.Issue, cs *iostreams.ColorScheme) string {
+func issueLabelList(issue *api.Issue) string {
 	if len(issue.Labels.Nodes) == 0 {
 		return ""
 	}
 
-	labelNames := make([]string, 0, len(issue.Labels.Nodes))
-	for _, label := range issue.Labels.Nodes {
-		labelNames = append(labelNames, cs.HexToRGB(label.Color, label.Name))
+	labelNames := make([]string, len(issue.Labels.Nodes))
+	for i, label := range issue.Labels.Nodes {
+		labelNames[i] = label.Name
 	}
 
 	return strings.Join(labelNames, ", ")

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -10,7 +10,6 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/api"
 	"github.com/cli/cli/internal/ghrepo"
-	"github.com/cli/cli/pkg/cmd/issue/shared"
 	issueShared "github.com/cli/cli/pkg/cmd/issue/shared"
 	prShared "github.com/cli/cli/pkg/cmd/pr/shared"
 	"github.com/cli/cli/pkg/cmdutil"
@@ -125,7 +124,7 @@ func viewRun(opts *ViewOptions) error {
 		return nil
 	}
 
-	return printRawIssuePreview(opts.IO.Out, issue, opts.IO.ColorScheme())
+	return printRawIssuePreview(opts.IO.Out, issue)
 }
 
 func findIssue(client *http.Client, baseRepoFn func() (ghrepo.Interface, error), selector string, loadComments bool) (*api.Issue, error) {
@@ -141,9 +140,9 @@ func findIssue(client *http.Client, baseRepoFn func() (ghrepo.Interface, error),
 	return issue, err
 }
 
-func printRawIssuePreview(out io.Writer, issue *api.Issue, cs *iostreams.ColorScheme) error {
+func printRawIssuePreview(out io.Writer, issue *api.Issue) error {
 	assignees := issueAssigneeList(*issue)
-	labels := shared.IssueLabelList(*issue, cs)
+	labels := issueLabelList(issue, nil)
 	projects := issueProjectList(*issue)
 
 	// Print empty strings for empty values so the number of metadata lines is consistent when
@@ -193,7 +192,7 @@ func printHumanIssuePreview(opts *ViewOptions, issue *api.Issue) error {
 		fmt.Fprint(out, cs.Bold("Assignees: "))
 		fmt.Fprintln(out, assignees)
 	}
-	if labels := shared.IssueLabelList(*issue, cs); labels != "" {
+	if labels := issueLabelList(issue, cs); labels != "" {
 		fmt.Fprint(out, cs.Bold("Labels: "))
 		fmt.Fprintln(out, labels)
 	}
@@ -277,4 +276,21 @@ func issueProjectList(issue api.Issue) string {
 		list += ", …"
 	}
 	return list
+}
+
+func issueLabelList(issue *api.Issue, cs *iostreams.ColorScheme) string {
+	if len(issue.Labels.Nodes) == 0 {
+		return ""
+	}
+
+	labelNames := make([]string, len(issue.Labels.Nodes))
+	for i, label := range issue.Labels.Nodes {
+		if cs == nil {
+			labelNames[i] = label.Name
+		} else {
+			labelNames[i] = cs.HexToRGB(label.Color, label.Name)
+		}
+	}
+
+	return strings.Join(labelNames, ", ")
 }


### PR DESCRIPTION
- Labels with dark color are not visible on a dark background (and vice versa on light backgrounds)
- "Raw" `issue view` output should never output colored labels, not even when CLICOLOR_FORCE is set

Fixes #4065, closes https://github.com/cli/cli/pull/4066, closes #4064
Partly reverts #3912 /cc @bchadwic 