### PR TITLE
Fixes #4084: Enable completion descriptions for powershell

### DIFF
--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -71,7 +71,7 @@ func NewCmdCompletion(io *iostreams.IOStreams) *cobra.Command {
 			case "zsh":
 				return rootCmd.GenZshCompletion(w)
 			case "powershell":
-				return rootCmd.GenPowerShellCompletion(w)
+				return rootCmd.GenPowerShellCompletionWithDesc(w)
 			case "fish":
 				return rootCmd.GenFishCompletion(w, true)
 			default:


### PR DESCRIPTION
Fixes #4084
Since completion descriptions are automatically enabled for all other shells, this PR simply calls the proper API to enable them for Powershell.  This yields:
```
PS /Users/marckhouzam/git/cli> bin/gh <TAB>
actions     (Learn about working with GitHub actions)         issue       (Manage issues)
alias       (Create command shortcuts)                        pr          (Manage pull requests)
api         (Make an authenticated GitHub API request)        release     (Manage GitHub releases)
auth        (Login, logout, and refresh your authentication)  repo        (Create, clone, fork, and view repositories)
browse      (Open the repository in the browser)              run         (View details about workflow runs)
completion  (Generate shell completion scripts)               secret      (Manage GitHub secrets)
config      (Manage configuration for gh)                     ssh-key     (Manage SSH keys)
gist        (Manage gists)                                    workflow    (View details about GitHub Actions workflows)
help        (Help about any command)                          co
```
See https://github.com/spf13/cobra/blob/master/shell_completions.md#powershell-completions