### PR TITLE
Fix unmarshalling GraphQL error type

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -123,8 +123,8 @@ type graphQLResponse struct {
 // GraphQLError is a single error returned in a GraphQL response
 type GraphQLError struct {
 	Type    string
-	Path    []string
 	Message string
+	// Path []interface // mixed strings and numbers
 }
 
 // GraphQLErrorResponse contains errors returned in a GraphQL response

--- a/pkg/cmd/secret/set/http.go
+++ b/pkg/cmd/secret/set/http.go
@@ -130,17 +130,7 @@ func mapRepoNameToID(client *api.Client, host, orgName string, repositoryNames [
 		DatabaseID int `json:"databaseId"`
 	})
 
-	err := client.GraphQL(host, query, nil, &graphqlResult)
-
-	gqlErr, isGqlErr := err.(*api.GraphQLErrorResponse)
-	if isGqlErr {
-		for _, ge := range gqlErr.Errors {
-			if ge.Type == "NOT_FOUND" {
-				return nil, fmt.Errorf("could not find %s/%s", orgName, ge.Path[0])
-			}
-		}
-	}
-	if err != nil {
+	if err := client.GraphQL(host, query, nil, &graphqlResult); err != nil {
 		return nil, fmt.Errorf("failed to look up repositories: %w", err)
 	}
 


### PR DESCRIPTION
The "path" field of a GraphQL error object contains a mix of strings and numbers and cannot be deserialized into `[]string`. Fortunately, we don't need to rely on the "path" field and instead have the final error message be constructed by aggregating human-readable "message" fields.

Fixes #4086, followup to #2529