### PR TITLE
Add branch and actor filters to `run list`

### DIFF
--- a/pkg/cmd/run/cancel/cancel.go
+++ b/pkg/cmd/run/cancel/cancel.go
@@ -74,7 +74,7 @@ func runCancel(opts *CancelOptions) error {
 	var run *shared.Run
 
 	if opts.Prompt {
-		runs, err := shared.GetRunsWithFilter(client, repo, 10, func(run shared.Run) bool {
+		runs, err := shared.GetRunsWithFilter(client, repo, shared.EmptyFilters(), 10, func(run shared.Run) bool {
 			return run.Status != shared.Completed
 		})
 		if err != nil {

--- a/pkg/cmd/run/cancel/cancel.go
+++ b/pkg/cmd/run/cancel/cancel.go
@@ -74,7 +74,7 @@ func runCancel(opts *CancelOptions) error {
 	var run *shared.Run
 
 	if opts.Prompt {
-		runs, err := shared.GetRunsWithFilter(client, repo, shared.EmptyFilters(), 10, func(run shared.Run) bool {
+		runs, err := shared.GetRunsWithFilter(client, repo, nil, 10, func(run shared.Run) bool {
 			return run.Status != shared.Completed
 		})
 		if err != nil {

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -65,7 +65,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", defaultLimit, "Maximum number of runs to fetch")
 	cmd.Flags().StringVarP(&opts.WorkflowSelector, "workflow", "w", "", "Filter runs by workflow")
 	cmd.Flags().StringVarP(&opts.Branch, "branch", "b", "", "Filter runs by branch")
-	cmd.Flags().StringVarP(&opts.Actor, "actor", "a", "", "Filter runs by user who triggered the run")
+	cmd.Flags().StringVarP(&opts.Actor, "user", "u", "", "Filter runs by user who triggered the run")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, shared.RunFields)
 
 	return cmd

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -51,6 +51,22 @@ func TestNewCmdList(t *testing.T) {
 				WorkflowSelector: "foo.yml",
 			},
 		},
+		{
+			name: "branch",
+			cli:  "--branch new-cool-stuff",
+			wants: ListOptions{
+				Limit:  defaultLimit,
+				Branch: "new-cool-stuff",
+			},
+		},
+		{
+			name: "actor",
+			cli:  "--actor bak1an",
+			wants: ListOptions{
+				Limit: defaultLimit,
+				Actor: "bak1an",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -61,8 +61,8 @@ func TestNewCmdList(t *testing.T) {
 			},
 		},
 		{
-			name: "actor",
-			cli:  "--actor bak1an",
+			name: "user",
+			cli:  "--user bak1an",
 			wants: ListOptions{
 				Limit: defaultLimit,
 				Actor: "bak1an",

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -83,6 +83,9 @@ func TestNewCmdList(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.wants.Limit, gotOpts.Limit)
+			assert.Equal(t, tt.wants.WorkflowSelector, gotOpts.WorkflowSelector)
+			assert.Equal(t, tt.wants.Branch, gotOpts.Branch)
+			assert.Equal(t, tt.wants.Actor, gotOpts.Actor)
 		})
 	}
 }

--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -71,7 +71,7 @@ func runRerun(opts *RerunOptions) error {
 
 	if opts.Prompt {
 		cs := opts.IO.ColorScheme()
-		runs, err := shared.GetRunsWithFilter(client, repo, 10, func(run shared.Run) bool {
+		runs, err := shared.GetRunsWithFilter(client, repo, shared.EmptyFilters(), 10, func(run shared.Run) bool {
 			if run.Status != shared.Completed {
 				return false
 			}

--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -71,7 +71,7 @@ func runRerun(opts *RerunOptions) error {
 
 	if opts.Prompt {
 		cs := opts.IO.ColorScheme()
-		runs, err := shared.GetRunsWithFilter(client, repo, shared.EmptyFilters(), 10, func(run shared.Run) bool {
+		runs, err := shared.GetRunsWithFilter(client, repo, nil, 10, func(run shared.Run) bool {
 			if run.Status != shared.Completed {
 				return false
 			}

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -210,19 +210,6 @@ type FilterOptions struct {
 	Actor  string
 }
 
-func EmptyFilters() *FilterOptions {
-	return &FilterOptions{}
-}
-
-func (opts *FilterOptions) updateQuery(query *url.Values) {
-	if opts.Branch != "" {
-		query.Set("branch", opts.Branch)
-	}
-	if opts.Actor != "" {
-		query.Set("actor", opts.Actor)
-	}
-}
-
 func GetRunsWithFilter(client *api.Client, repo ghrepo.Interface, opts *FilterOptions, limit int, f func(Run) bool) ([]Run, error) {
 	path := fmt.Sprintf("repos/%s/actions/runs", ghrepo.FullName(repo))
 	runs, err := getRuns(client, repo, path, opts, 50)
@@ -271,7 +258,14 @@ func getRuns(client *api.Client, repo ghrepo.Interface, path string, opts *Filte
 		query := parsed.Query()
 		query.Set("per_page", fmt.Sprintf("%d", perPage))
 		query.Set("page", fmt.Sprintf("%d", page))
-		opts.updateQuery(&query)
+		if opts != nil {
+			if opts.Branch != "" {
+				query.Set("branch", opts.Branch)
+			}
+			if opts.Actor != "" {
+				query.Set("actor", opts.Actor)
+			}
+		}
 		parsed.RawQuery = query.Encode()
 		pagedPath := parsed.String()
 

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -205,9 +205,27 @@ type RunsPayload struct {
 	WorkflowRuns []Run `json:"workflow_runs"`
 }
 
-func GetRunsWithFilter(client *api.Client, repo ghrepo.Interface, limit int, f func(Run) bool) ([]Run, error) {
+type FilterOptions struct {
+	Branch string
+	Actor  string
+}
+
+func EmptyFilters() *FilterOptions {
+	return &FilterOptions{}
+}
+
+func (opts *FilterOptions) updateQuery(query *url.Values) {
+	if opts.Branch != "" {
+		query.Set("branch", opts.Branch)
+	}
+	if opts.Actor != "" {
+		query.Set("actor", opts.Actor)
+	}
+}
+
+func GetRunsWithFilter(client *api.Client, repo ghrepo.Interface, opts *FilterOptions, limit int, f func(Run) bool) ([]Run, error) {
 	path := fmt.Sprintf("repos/%s/actions/runs", ghrepo.FullName(repo))
-	runs, err := getRuns(client, repo, path, 50)
+	runs, err := getRuns(client, repo, path, opts, 50)
 	if err != nil {
 		return nil, err
 	}
@@ -224,17 +242,17 @@ func GetRunsWithFilter(client *api.Client, repo ghrepo.Interface, limit int, f f
 	return filtered, nil
 }
 
-func GetRunsByWorkflow(client *api.Client, repo ghrepo.Interface, limit int, workflowID int64) ([]Run, error) {
+func GetRunsByWorkflow(client *api.Client, repo ghrepo.Interface, opts *FilterOptions, limit int, workflowID int64) ([]Run, error) {
 	path := fmt.Sprintf("repos/%s/actions/workflows/%d/runs", ghrepo.FullName(repo), workflowID)
-	return getRuns(client, repo, path, limit)
+	return getRuns(client, repo, path, opts, limit)
 }
 
-func GetRuns(client *api.Client, repo ghrepo.Interface, limit int) ([]Run, error) {
+func GetRuns(client *api.Client, repo ghrepo.Interface, opts *FilterOptions, limit int) ([]Run, error) {
 	path := fmt.Sprintf("repos/%s/actions/runs", ghrepo.FullName(repo))
-	return getRuns(client, repo, path, limit)
+	return getRuns(client, repo, path, opts, limit)
 }
 
-func getRuns(client *api.Client, repo ghrepo.Interface, path string, limit int) ([]Run, error) {
+func getRuns(client *api.Client, repo ghrepo.Interface, path string, opts *FilterOptions, limit int) ([]Run, error) {
 	perPage := limit
 	page := 1
 	if limit > 100 {
@@ -253,6 +271,7 @@ func getRuns(client *api.Client, repo ghrepo.Interface, path string, limit int) 
 		query := parsed.Query()
 		query.Set("per_page", fmt.Sprintf("%d", perPage))
 		query.Set("page", fmt.Sprintf("%d", page))
+		opts.updateQuery(&query)
 		parsed.RawQuery = query.Encode()
 		pagedPath := parsed.String()
 

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -197,7 +197,7 @@ func runView(opts *ViewOptions) error {
 	if opts.Prompt {
 		// TODO arbitrary limit
 		opts.IO.StartProgressIndicator()
-		runs, err := shared.GetRuns(client, repo, 10)
+		runs, err := shared.GetRuns(client, repo, shared.EmptyFilters(), 10)
 		opts.IO.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to get runs: %w", err)

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -197,7 +197,7 @@ func runView(opts *ViewOptions) error {
 	if opts.Prompt {
 		// TODO arbitrary limit
 		opts.IO.StartProgressIndicator()
-		runs, err := shared.GetRuns(client, repo, shared.EmptyFilters(), 10)
+		runs, err := shared.GetRuns(client, repo, nil, 10)
 		opts.IO.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to get runs: %w", err)

--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -93,7 +93,7 @@ func watchRun(opts *WatchOptions) error {
 	var run *shared.Run
 
 	if opts.Prompt {
-		runs, err := shared.GetRunsWithFilter(client, repo, 10, func(run shared.Run) bool {
+		runs, err := shared.GetRunsWithFilter(client, repo, shared.EmptyFilters(), 10, func(run shared.Run) bool {
 			return run.Status != shared.Completed
 		})
 		if err != nil {

--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -93,7 +93,7 @@ func watchRun(opts *WatchOptions) error {
 	var run *shared.Run
 
 	if opts.Prompt {
-		runs, err := shared.GetRunsWithFilter(client, repo, shared.EmptyFilters(), 10, func(run shared.Run) bool {
+		runs, err := shared.GetRunsWithFilter(client, repo, nil, 10, func(run shared.Run) bool {
 			return run.Status != shared.Completed
 		})
 		if err != nil {


### PR DESCRIPTION
Both https://docs.github.com/en/rest/reference/actions#list-workflow-runs and https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository accept those query parameters and seems that it would be handy to have it in cli as well.

<hr/>

upd: Just noticed that there is a related issue #3686, have not seen it initially when opening the PR. Will pause adding tests until getting some initial feedback on the approach taken.