### PR TITLE
Repo sync optimizations

### DIFF
--- a/pkg/cmd/repo/sync/mocks.go
+++ b/pkg/cmd/repo/sync/mocks.go
@@ -13,13 +13,13 @@ func (g *mockGitClient) BranchRemote(a string) (string, error) {
 	return args.String(0), args.Error(1)
 }
 
-func (g *mockGitClient) CheckoutLocal(a string) error {
-	args := g.Called(a)
+func (g *mockGitClient) UpdateBranch(b, r string) error {
+	args := g.Called(b, r)
 	return args.Error(0)
 }
 
-func (g *mockGitClient) CheckoutRemote(a, b string) error {
-	args := g.Called(a, b)
+func (g *mockGitClient) CreateBranch(b, r, u string) error {
+	args := g.Called(b, r, u)
 	return args.Error(0)
 }
 

--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -114,14 +114,9 @@ func syncLocalRepo(opts *SyncOptions) error {
 	if err != nil {
 		return err
 	}
-	for _, r := range remotes {
-		if r.RepoName() == srcRepo.RepoName() &&
-			r.RepoOwner() == srcRepo.RepoOwner() &&
-			r.RepoHost() == srcRepo.RepoHost() {
-			remote = r.Name
-		}
-	}
-	if remote == "" {
+	if r, err := remotes.FindByRepo(srcRepo.RepoOwner(), srcRepo.RepoName()); err == nil {
+		remote = r.Name
+	} else {
 		return fmt.Errorf("can't find corresponding remote for %s", ghrepo.FullName(srcRepo))
 	}
 

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -192,7 +192,6 @@ func Test_SyncRun(t *testing.T) {
 				Branch: "trunk",
 			},
 			gitStubs: func(mgc *mockGitClient) {
-				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
@@ -208,7 +207,6 @@ func Test_SyncRun(t *testing.T) {
 				Branch: "trunk",
 			},
 			gitStubs: func(mgc *mockGitClient) {
-				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("BranchRemote", "trunk").Return("upstream", nil).Once()
@@ -219,12 +217,19 @@ func Test_SyncRun(t *testing.T) {
 		{
 			name: "sync local repo with parent and local changes",
 			tty:  true,
-			opts: &SyncOptions{},
+			opts: &SyncOptions{
+				Branch: "trunk",
+			},
 			gitStubs: func(mgc *mockGitClient) {
+				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
+				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
+				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
+				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
+				mgc.On("CurrentBranch").Return("trunk", nil).Once()
 				mgc.On("IsDirty").Return(true, nil).Once()
 			},
 			wantErr: true,
-			errMsg:  "can't sync because there are local changes, please commit or stash them",
+			errMsg:  "can't sync because there are local changes; please stash them before trying again",
 		},
 		{
 			name: "sync local repo with parent - existing branch, non-current",
@@ -233,7 +238,6 @@ func Test_SyncRun(t *testing.T) {
 				Branch: "trunk",
 			},
 			gitStubs: func(mgc *mockGitClient) {
-				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
@@ -250,7 +254,6 @@ func Test_SyncRun(t *testing.T) {
 				Branch: "trunk",
 			},
 			gitStubs: func(mgc *mockGitClient) {
-				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(false).Once()
 				mgc.On("CurrentBranch").Return("test", nil).Once()

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -465,9 +465,11 @@ func Test_SyncRun(t *testing.T) {
 }
 
 func newMockGitClient(t *testing.T, config func(*mockGitClient)) *mockGitClient {
+	t.Helper()
 	m := &mockGitClient{}
 	m.Test(t)
 	t.Cleanup(func() {
+		t.Helper()
 		m.AssertExpectations(t)
 	})
 	if config != nil {

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -126,29 +126,26 @@ func Test_SyncRun(t *testing.T) {
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
-				mgc.On("IsAncestor", "trunk", "origin/trunk").Return(true, nil).Once()
+				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
-				mgc.On("MergeFastForward", "refs/remotes/origin/trunk").Return(nil).Once()
+				mgc.On("MergeFastForward", "FETCH_HEAD").Return(nil).Once()
 			},
 			wantStdout: "✓ Synced the \"trunk\" branch from OWNER/REPO to local repository\n",
 		},
 		{
 			name: "sync local repo with parent - notty",
 			tty:  false,
-			opts: &SyncOptions{},
-			httpStubs: func(reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryInfo\b`),
-					httpmock.StringResponse(`{"data":{"repository":{"defaultBranchRef":{"name": "trunk"}}}}`))
+			opts: &SyncOptions{
+				Branch: "trunk",
 			},
 			gitStubs: func(mgc *mockGitClient) {
 				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
-				mgc.On("IsAncestor", "trunk", "origin/trunk").Return(true, nil).Once()
+				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
-				mgc.On("MergeFastForward", "refs/remotes/origin/trunk").Return(nil).Once()
+				mgc.On("MergeFastForward", "FETCH_HEAD").Return(nil).Once()
 			},
 			wantStdout: "",
 		},
@@ -156,78 +153,50 @@ func Test_SyncRun(t *testing.T) {
 			name: "sync local repo with specified source repo",
 			tty:  true,
 			opts: &SyncOptions{
+				Branch: "trunk",
 				SrcArg: "OWNER2/REPO2",
-			},
-			httpStubs: func(reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryInfo\b`),
-					httpmock.StringResponse(`{"data":{"repository":{"defaultBranchRef":{"name": "trunk"}}}}`))
 			},
 			gitStubs: func(mgc *mockGitClient) {
 				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "upstream", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("BranchRemote", "trunk").Return("upstream", nil).Once()
-				mgc.On("IsAncestor", "trunk", "upstream/trunk").Return(true, nil).Once()
+				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
-				mgc.On("MergeFastForward", "refs/remotes/upstream/trunk").Return(nil).Once()
+				mgc.On("MergeFastForward", "FETCH_HEAD").Return(nil).Once()
 			},
 			wantStdout: "✓ Synced the \"trunk\" branch from OWNER2/REPO2 to local repository\n",
-		},
-		{
-			name: "sync local repo with parent and specified branch",
-			tty:  true,
-			opts: &SyncOptions{
-				Branch: "test",
-			},
-			gitStubs: func(mgc *mockGitClient) {
-				mgc.On("IsDirty").Return(false, nil).Once()
-				mgc.On("Fetch", "origin", "refs/heads/test").Return(nil).Once()
-				mgc.On("HasLocalBranch", "test").Return(true).Once()
-				mgc.On("BranchRemote", "test").Return("origin", nil).Once()
-				mgc.On("IsAncestor", "test", "origin/test").Return(true, nil).Once()
-				mgc.On("CurrentBranch").Return("test", nil).Once()
-				mgc.On("MergeFastForward", "refs/remotes/origin/test").Return(nil).Once()
-			},
-			wantStdout: "✓ Synced the \"test\" branch from OWNER/REPO to local repository\n",
 		},
 		{
 			name: "sync local repo with parent and force specified",
 			tty:  true,
 			opts: &SyncOptions{
-				Force: true,
-			},
-			httpStubs: func(reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryInfo\b`),
-					httpmock.StringResponse(`{"data":{"repository":{"defaultBranchRef":{"name": "trunk"}}}}`))
+				Branch: "trunk",
+				Force:  true,
 			},
 			gitStubs: func(mgc *mockGitClient) {
 				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
-				mgc.On("IsAncestor", "trunk", "origin/trunk").Return(false, nil).Once()
+				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(false, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
-				mgc.On("ResetHard", "refs/remotes/origin/trunk").Return(nil).Once()
+				mgc.On("ResetHard", "FETCH_HEAD").Return(nil).Once()
 			},
 			wantStdout: "✓ Synced the \"trunk\" branch from OWNER/REPO to local repository\n",
 		},
 		{
 			name: "sync local repo with parent and not fast forward merge",
 			tty:  true,
-			opts: &SyncOptions{},
-			httpStubs: func(reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryInfo\b`),
-					httpmock.StringResponse(`{"data":{"repository":{"defaultBranchRef":{"name": "trunk"}}}}`))
+			opts: &SyncOptions{
+				Branch: "trunk",
 			},
 			gitStubs: func(mgc *mockGitClient) {
 				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
-				mgc.On("IsAncestor", "trunk", "origin/trunk").Return(false, nil).Once()
+				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(false, nil).Once()
 			},
 			wantErr: true,
 			errMsg:  "can't sync because there are diverging changes; use `--force` to overwrite the destination branch",
@@ -235,11 +204,8 @@ func Test_SyncRun(t *testing.T) {
 		{
 			name: "sync local repo with parent and mismatching branch remotes",
 			tty:  true,
-			opts: &SyncOptions{},
-			httpStubs: func(reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryInfo\b`),
-					httpmock.StringResponse(`{"data":{"repository":{"defaultBranchRef":{"name": "trunk"}}}}`))
+			opts: &SyncOptions{
+				Branch: "trunk",
 			},
 			gitStubs: func(mgc *mockGitClient) {
 				mgc.On("IsDirty").Return(false, nil).Once()
@@ -261,24 +227,34 @@ func Test_SyncRun(t *testing.T) {
 			errMsg:  "can't sync because there are local changes, please commit or stash them",
 		},
 		{
-			name: "sync local repo with parent not on default branch",
+			name: "sync local repo with parent - existing branch, non-current",
 			tty:  true,
-			opts: &SyncOptions{},
-			httpStubs: func(reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryInfo\b`),
-					httpmock.StringResponse(`{"data":{"repository":{"defaultBranchRef":{"name": "trunk"}}}}`))
+			opts: &SyncOptions{
+				Branch: "trunk",
 			},
 			gitStubs: func(mgc *mockGitClient) {
 				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
-				mgc.On("IsAncestor", "trunk", "origin/trunk").Return(true, nil).Once()
+				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("test", nil).Once()
-				mgc.On("CheckoutLocal", "trunk").Return(nil).Once()
-				mgc.On("MergeFastForward", "refs/remotes/origin/trunk").Return(nil).Once()
-				mgc.On("CheckoutLocal", "test").Return(nil).Once()
+				mgc.On("UpdateBranch", "trunk", "FETCH_HEAD").Return(nil).Once()
+			},
+			wantStdout: "✓ Synced the \"trunk\" branch from OWNER/REPO to local repository\n",
+		},
+		{
+			name: "sync local repo with parent - create new branch",
+			tty:  true,
+			opts: &SyncOptions{
+				Branch: "trunk",
+			},
+			gitStubs: func(mgc *mockGitClient) {
+				mgc.On("IsDirty").Return(false, nil).Once()
+				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
+				mgc.On("HasLocalBranch", "trunk").Return(false).Once()
+				mgc.On("CurrentBranch").Return("test", nil).Once()
+				mgc.On("CreateBranch", "trunk", "FETCH_HEAD", "origin/trunk").Return(nil).Once()
 			},
 			wantStdout: "✓ Synced the \"trunk\" branch from OWNER/REPO to local repository\n",
 		},
@@ -470,9 +446,8 @@ func Test_SyncRun(t *testing.T) {
 			return tt.remotes, nil
 		}
 
-		tt.opts.Git = newMockGitClient(t, tt.gitStubs)
-
 		t.Run(tt.name, func(t *testing.T) {
+			tt.opts.Git = newMockGitClient(t, tt.gitStubs)
 			defer reg.Verify(t)
 			err := syncRun(tt.opts)
 			if tt.wantErr {


### PR DESCRIPTION
- Avoid `git checkout` since it's not needed to either sync the current branch nor non-current branches
- Only check `git status` when syncing the current branch; for others it doesn't matter
- Enable `repo sync` on detached HEAD
- Enable `repo sync` for git remotes that don't necessarily track all the branches (i.e. those that don't have `+refs/heads/*:refs/remotes/origin/*` as their fetch refspec)

Followup to https://github.com/cli/cli/pull/3813#discussion_r685163369