### PR TITLE
Rename `gh extensions` → `gh extension`

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -1,4 +1,4 @@
-package extensions
+package extension
 
 import (
 	"errors"
@@ -15,12 +15,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmdExtensions(f *cmdutil.Factory) *cobra.Command {
+func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 	m := f.ExtensionManager
 	io := f.IOStreams
 
 	extCmd := cobra.Command{
-		Use:   "extensions",
+		Use:   "extension",
 		Short: "Manage gh extensions",
 		Long: heredoc.Docf(`
 			GitHub CLI extensions are repositories that provide additional gh commands.
@@ -31,6 +31,7 @@ func NewCmdExtensions(f *cmdutil.Factory) *cobra.Command {
 
 			An extension cannot override any of the core gh commands.
 		`, "`"),
+		Aliases: []string{"extensions"},
 	}
 
 	extCmd.AddCommand(

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -1,4 +1,4 @@
-package extensions
+package extension
 
 import (
 	"io"
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewCmdExtensions(t *testing.T) {
+func TestNewCmdExtension(t *testing.T) {
 	tempDir := t.TempDir()
 	oldWd, _ := os.Getwd()
 	assert.NoError(t, os.Chdir(tempDir))
@@ -183,7 +183,7 @@ func TestNewCmdExtensions(t *testing.T) {
 				ExtensionManager: em,
 			}
 
-			cmd := NewCmdExtensions(&f)
+			cmd := NewCmdExtension(&f)
 			cmd.SetArgs(tt.args)
 			cmd.SetOut(ioutil.Discard)
 			cmd.SetErr(ioutil.Discard)

--- a/pkg/cmd/extension/extension.go
+++ b/pkg/cmd/extension/extension.go
@@ -1,4 +1,4 @@
-package extensions
+package extension
 
 import (
 	"path/filepath"

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -1,4 +1,4 @@
-package extensions
+package extension
 
 import (
 	"bytes"

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -1,4 +1,4 @@
-package extensions
+package extension
 
 import (
 	"bytes"

--- a/pkg/cmd/extension/symlink_other.go
+++ b/pkg/cmd/extension/symlink_other.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package extensions
+package extension
 
 import "os"
 

--- a/pkg/cmd/extension/symlink_windows.go
+++ b/pkg/cmd/extension/symlink_windows.go
@@ -1,4 +1,4 @@
-package extensions
+package extension
 
 import "os"
 

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cli/cli/git"
 	"github.com/cli/cli/internal/config"
 	"github.com/cli/cli/internal/ghrepo"
-	"github.com/cli/cli/pkg/cmd/extensions"
+	"github.com/cli/cli/pkg/cmd/extension"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/iostreams"
 )
@@ -22,7 +22,7 @@ func New(appVersion string) *cmdutil.Factory {
 		Branch:     branchFunc(), // No factory dependencies
 		Executable: executable(), // No factory dependencies
 
-		ExtensionManager: extensions.NewManager(),
+		ExtensionManager: extension.NewManager(),
 	}
 
 	f.IOStreams = ioStreams(f)                   // Depends on Config

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -11,7 +11,7 @@ import (
 	browseCmd "github.com/cli/cli/pkg/cmd/browse"
 	completionCmd "github.com/cli/cli/pkg/cmd/completion"
 	configCmd "github.com/cli/cli/pkg/cmd/config"
-	extensionsCmd "github.com/cli/cli/pkg/cmd/extensions"
+	extensionCmd "github.com/cli/cli/pkg/cmd/extension"
 	"github.com/cli/cli/pkg/cmd/factory"
 	gistCmd "github.com/cli/cli/pkg/cmd/gist"
 	issueCmd "github.com/cli/cli/pkg/cmd/issue"
@@ -75,7 +75,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(creditsCmd.NewCmdCredits(f, nil))
 	cmd.AddCommand(gistCmd.NewCmdGist(f))
 	cmd.AddCommand(completionCmd.NewCmdCompletion(f.IOStreams))
-	cmd.AddCommand(extensionsCmd.NewCmdExtensions(f))
+	cmd.AddCommand(extensionCmd.NewCmdExtension(f))
 	cmd.AddCommand(secretCmd.NewCmdSecret(f))
 	cmd.AddCommand(sshKeyCmd.NewCmdSSHKey(f))
 


### PR DESCRIPTION
This is for compatibility with other core commands which are all singular.
