### PR TITLE
Extensions UI tweaks

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -126,7 +126,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 			return cmd
 		}(),
 		&cobra.Command{
-			Use:   "remove",
+			Use:   "remove <name>",
 			Short: "Remove an installed extension",
 			Args:  cobra.ExactArgs(1),
 			RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -58,7 +58,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					t.AddField(repo, nil, nil)
 					var updateAvailable string
 					if c.UpdateAvailable() {
-						updateAvailable = "Update available"
+						updateAvailable = "Upgrade available"
 					}
 					t.AddField(updateAvailable, nil, cs.Green)
 					t.EndRow()

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -159,7 +159,7 @@ func TestNewCmdExtension(t *testing.T) {
 					assert.Equal(t, 1, len(em.ListCalls()))
 				}
 			},
-			wantStdout: "gh test\tcli/gh-test\t\ngh test2\tcli/gh-test2\tUpdate available\n",
+			wantStdout: "gh test\tcli/gh-test\t\ngh test2\tcli/gh-test2\tUpgrade available\n",
 		},
 	}
 


### PR DESCRIPTION
- Print `Upgrade available` instead of `Update available`
- Print `gh extension remove <name>` in usage synopsis
