### PR TITLE
Add topic filter to repository listing

### DIFF
--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -22,13 +22,14 @@ type FilterOptions struct {
 	Fork        bool
 	Source      bool
 	Language    string
+	Topic       string
 	Archived    bool
 	NonArchived bool
 	Fields      []string
 }
 
 func listRepos(client *http.Client, hostname string, limit int, owner string, filter FilterOptions) (*RepositoryList, error) {
-	if filter.Language != "" || filter.Archived || filter.NonArchived {
+	if filter.Language != "" || filter.Archived || filter.NonArchived || filter.Topic != "" {
 		return searchRepos(client, hostname, limit, owner, filter)
 	}
 
@@ -195,6 +196,10 @@ func searchQuery(owner string, filter FilterOptions) string {
 
 	if filter.Language != "" {
 		q.SetLanguage(filter.Language)
+	}
+
+	if filter.Topic != "" {
+		q.SetTopic(filter.Topic)
 	}
 
 	switch filter.Visibility {

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -28,6 +28,7 @@ type ListOptions struct {
 	Fork        bool
 	Source      bool
 	Language    string
+	Topic       string
 	Archived    bool
 	NonArchived bool
 
@@ -89,6 +90,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().BoolVar(&opts.Source, "source", false, "Show only non-forks")
 	cmd.Flags().BoolVar(&opts.Fork, "fork", false, "Show only forks")
 	cmd.Flags().StringVarP(&opts.Language, "language", "l", "", "Filter by primary coding language")
+	cmd.Flags().StringVar(&opts.Topic, "topic", "", "Filter by topic")
 	cmd.Flags().BoolVar(&opts.Archived, "archived", false, "Show only archived repositories")
 	cmd.Flags().BoolVar(&opts.NonArchived, "no-archived", false, "Omit archived repositories")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.RepositoryFields)
@@ -109,6 +111,7 @@ func listRun(opts *ListOptions) error {
 		Fork:        opts.Fork,
 		Source:      opts.Source,
 		Language:    opts.Language,
+		Topic:       opts.Topic,
 		Archived:    opts.Archived,
 		NonArchived: opts.NonArchived,
 		Fields:      defaultFields,
@@ -169,7 +172,7 @@ func listRun(opts *ListOptions) error {
 	}
 
 	if opts.IO.IsStdoutTTY() {
-		hasFilters := filter.Visibility != "" || filter.Fork || filter.Source || filter.Language != ""
+		hasFilters := filter.Visibility != "" || filter.Fork || filter.Source || filter.Language != "" || filter.Topic != ""
 		title := listHeader(listResult.Owner, len(listResult.Repositories), listResult.TotalCount, hasFilters)
 		fmt.Fprintf(opts.IO.Out, "\n%s\n\n", title)
 	}

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -35,6 +35,7 @@ func TestNewCmdList(t *testing.T) {
 				Fork:        false,
 				Source:      false,
 				Language:    "",
+				Topic:       "",
 				Archived:    false,
 				NonArchived: false,
 			},
@@ -49,6 +50,7 @@ func TestNewCmdList(t *testing.T) {
 				Fork:        false,
 				Source:      false,
 				Language:    "",
+				Topic:       "",
 				Archived:    false,
 				NonArchived: false,
 			},
@@ -63,6 +65,7 @@ func TestNewCmdList(t *testing.T) {
 				Fork:        false,
 				Source:      false,
 				Language:    "",
+				Topic:       "",
 				Archived:    false,
 				NonArchived: false,
 			},
@@ -77,6 +80,7 @@ func TestNewCmdList(t *testing.T) {
 				Fork:        false,
 				Source:      false,
 				Language:    "",
+				Topic:       "",
 				Archived:    false,
 				NonArchived: false,
 			},
@@ -91,6 +95,7 @@ func TestNewCmdList(t *testing.T) {
 				Fork:        false,
 				Source:      false,
 				Language:    "",
+				Topic:       "",
 				Archived:    false,
 				NonArchived: false,
 			},
@@ -105,6 +110,7 @@ func TestNewCmdList(t *testing.T) {
 				Fork:        true,
 				Source:      false,
 				Language:    "",
+				Topic:       "",
 				Archived:    false,
 				NonArchived: false,
 			},
@@ -119,6 +125,7 @@ func TestNewCmdList(t *testing.T) {
 				Fork:        false,
 				Source:      true,
 				Language:    "",
+				Topic:       "",
 				Archived:    false,
 				NonArchived: false,
 			},
@@ -133,6 +140,7 @@ func TestNewCmdList(t *testing.T) {
 				Fork:        false,
 				Source:      false,
 				Language:    "go",
+				Topic:       "",
 				Archived:    false,
 				NonArchived: false,
 			},
@@ -147,6 +155,7 @@ func TestNewCmdList(t *testing.T) {
 				Fork:        false,
 				Source:      false,
 				Language:    "",
+				Topic:       "",
 				Archived:    true,
 				NonArchived: false,
 			},
@@ -161,8 +170,24 @@ func TestNewCmdList(t *testing.T) {
 				Fork:        false,
 				Source:      false,
 				Language:    "",
+				Topic:       "",
 				Archived:    false,
 				NonArchived: true,
+			},
+		},
+		{
+			name: "with topic",
+			cli:  "--topic cli",
+			wants: ListOptions{
+				Limit:       30,
+				Owner:       "",
+				Visibility:  "",
+				Fork:        false,
+				Source:      false,
+				Language:    "",
+				Topic:       "cli",
+				Archived:    false,
+				NonArchived: false,
 			},
 		},
 		{
@@ -220,6 +245,7 @@ func TestNewCmdList(t *testing.T) {
 			assert.Equal(t, tt.wants.Owner, gotOpts.Owner)
 			assert.Equal(t, tt.wants.Visibility, gotOpts.Visibility)
 			assert.Equal(t, tt.wants.Fork, gotOpts.Fork)
+			assert.Equal(t, tt.wants.Topic, gotOpts.Topic)
 			assert.Equal(t, tt.wants.Source, gotOpts.Source)
 			assert.Equal(t, tt.wants.Archived, gotOpts.Archived)
 			assert.Equal(t, tt.wants.NonArchived, gotOpts.NonArchived)

--- a/pkg/githubsearch/query.go
+++ b/pkg/githubsearch/query.go
@@ -50,6 +50,7 @@ type Query struct {
 	milestone  string
 
 	language   string
+	topic      string
 	forkState  string
 	visibility string
 	isArchived *bool
@@ -118,6 +119,10 @@ func (q *Query) SetLanguage(name string) {
 	q.language = name
 }
 
+func (q *Query) SetTopic(name string) {
+	q.topic = name
+}
+
 func (q *Query) SetVisibility(visibility RepoVisibility) {
 	q.visibility = string(visibility)
 }
@@ -158,6 +163,9 @@ func (q *Query) String() string {
 	}
 	if q.language != "" {
 		qs += fmt.Sprintf("language:%s ", quote(q.language))
+	}
+	if q.topic != "" {
+		qs += fmt.Sprintf("topic:%s ", quote(q.topic))
 	}
 	if q.forkState != "" {
 		qs += fmt.Sprintf("fork:%s ", q.forkState)


### PR DESCRIPTION
Fixes #4046.  
Currently, it is only possible to filter by one topic. If it is desired, I will add the possibility to filter by multiple topics.

