### PR TITLE
Remove backwards compatibility with homedir library for config files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/mattn/go-isatty v0.0.13
 	github.com/mattn/go-runewidth v0.0.10
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/termenv v0.8.1
 	github.com/rivo/uniseg v0.2.0
 	github.com/shurcooL/githubv4 v0.0.0-20200928013246-d292edc3691b

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,6 @@ github.com/microcosm-cc/bluemonday v1.0.6/go.mod h1:HOT/6NaBlR0f9XlxD3zolN6Z3N8L
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"syscall"
 
-	"github.com/mitchellh/go-homedir"
 	"gopkg.in/yaml.v3"
 )
 
@@ -93,16 +92,10 @@ func DataDir() string {
 var errSamePath = errors.New("same path")
 var errNotExist = errors.New("not exist")
 
-// Check default paths (os.UserHomeDir, and homedir.Dir) for existing configs
+// Check default path, os.UserHomeDir, for existing configs
 // If configs exist then move them to newPath
-// TODO: Remove support for homedir.Dir location in v2
 func autoMigrateConfigDir(newPath string) error {
 	path, err := os.UserHomeDir()
-	if oldPath := filepath.Join(path, ".config", "gh"); err == nil && dirExists(oldPath) {
-		return migrateDir(oldPath, newPath)
-	}
-
-	path, err = homedir.Dir()
 	if oldPath := filepath.Join(path, ".config", "gh"); err == nil && dirExists(oldPath) {
 		return migrateDir(oldPath, newPath)
 	}
@@ -110,16 +103,10 @@ func autoMigrateConfigDir(newPath string) error {
 	return errNotExist
 }
 
-// Check default paths (os.UserHomeDir, and homedir.Dir) for existing state file (state.yml)
+// Check default path, os.UserHomeDir, for existing state file (state.yml)
 // If state file exist then move it to newPath
-// TODO: Remove support for homedir.Dir location in v2
 func autoMigrateStateDir(newPath string) error {
 	path, err := os.UserHomeDir()
-	if oldPath := filepath.Join(path, ".config", "gh"); err == nil && dirExists(oldPath) {
-		return migrateFile(oldPath, newPath, "state.yml")
-	}
-
-	path, err = homedir.Dir()
 	if oldPath := filepath.Join(path, ".config", "gh"); err == nil && dirExists(oldPath) {
 		return migrateFile(oldPath, newPath, "state.yml")
 	}
@@ -181,26 +168,10 @@ func ParseDefaultConfig() (Config, error) {
 func HomeDirPath(subdir string) (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		// TODO: remove go-homedir fallback in GitHub CLI v2
-		if legacyDir, err := homedir.Dir(); err == nil {
-			return filepath.Join(legacyDir, subdir), nil
-		}
 		return "", err
 	}
 
 	newPath := filepath.Join(homeDir, subdir)
-	if s, err := os.Stat(newPath); err == nil && s.IsDir() {
-		return newPath, nil
-	}
-
-	// TODO: remove go-homedir fallback in GitHub CLI v2
-	if legacyDir, err := homedir.Dir(); err == nil {
-		legacyPath := filepath.Join(legacyDir, subdir)
-		if s, err := os.Stat(legacyPath); err == nil && s.IsDir() {
-			return legacyPath, nil
-		}
-	}
-
 	return newPath, nil
 }
 


### PR DESCRIPTION
This PR removes the `homedir` library from `gh`. We will no longer use it to determine locations to check for older config files that need to be migrated.