### PR TITLE
Add ability to force terminal-style output even when redirected

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -61,6 +61,10 @@ func mainRun() exitCode {
 
 	cmdFactory := factory.New(buildVersion)
 	stderr := cmdFactory.IOStreams.ErrOut
+
+	if spec := os.Getenv("GH_FORCE_TTY"); spec != "" {
+		cmdFactory.IOStreams.ForceTerminal(spec)
+	}
 	if !cmdFactory.IOStreams.ColorEnabled() {
 		surveyCore.DisableColor = true
 	} else {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -62,6 +62,11 @@ var HelpTopics = map[string]map[string]string{
 			CLICOLOR_FORCE: set to a value other than "0" to keep ANSI colors in output
 			even when the output is piped.
 
+			GH_FORCE_TTY: set to any value to force terminal-style output even when the output is
+			redirected. When the value is a number, it is interpreted as the number of columns
+			available in the viewport. When the value is a percentage, it will be applied against
+			the number of columns available in the current viewport.
+
 			GH_NO_UPDATE_NOTIFIER: set to any value to disable update notifications. By default, gh
 			checks for new releases once every 24 hours and displays an upgrade notice on standard
 			error if a newer version was found.

--- a/pkg/iostreams/iostreams_test.go
+++ b/pkg/iostreams/iostreams_test.go
@@ -1,0 +1,68 @@
+package iostreams
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIOStreams_ForceTerminal(t *testing.T) {
+	tests := []struct {
+		name      string
+		iostreams *IOStreams
+		arg       string
+		wantTTY   bool
+		wantWidth int
+	}{
+		{
+			name:      "explicit width",
+			iostreams: &IOStreams{},
+			arg:       "72",
+			wantTTY:   true,
+			wantWidth: 72,
+		},
+		{
+			name: "measure width",
+			iostreams: &IOStreams{
+				ttySize: func() (int, int, error) {
+					return 72, 0, nil
+				},
+			},
+			arg:       "true",
+			wantTTY:   true,
+			wantWidth: 72,
+		},
+		{
+			name: "measure width fails",
+			iostreams: &IOStreams{
+				ttySize: func() (int, int, error) {
+					return -1, -1, errors.New("ttySize sabotage!")
+				},
+			},
+			arg:       "true",
+			wantTTY:   true,
+			wantWidth: 80,
+		},
+		{
+			name: "apply percentage",
+			iostreams: &IOStreams{
+				ttySize: func() (int, int, error) {
+					return 72, 0, nil
+				},
+			},
+			arg:       "50%",
+			wantTTY:   true,
+			wantWidth: 36,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.iostreams.ForceTerminal(tt.arg)
+			if isTTY := tt.iostreams.IsStdoutTTY(); isTTY != tt.wantTTY {
+				t.Errorf("IOStreams.IsStdoutTTY() = %v, want %v", isTTY, tt.wantTTY)
+			}
+			if tw := tt.iostreams.TerminalWidth(); tw != tt.wantWidth {
+				t.Errorf("IOStreams.TerminalWidth() = %v, want %v", tw, tt.wantWidth)
+			}
+		})
+	}
+}

--- a/pkg/iostreams/tty_size.go
+++ b/pkg/iostreams/tty_size.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/term"
 )
 
+// ttySize measures the size of the controlling terminal for the current process
 func ttySize() (int, int, error) {
 	f, err := os.Open("/dev/tty")
 	if err != nil {

--- a/pkg/iostreams/tty_size.go
+++ b/pkg/iostreams/tty_size.go
@@ -1,0 +1,18 @@
+//+build !windows
+
+package iostreams
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+func ttySize() (int, int, error) {
+	f, err := os.Open("/dev/tty")
+	if err != nil {
+		return -1, -1, err
+	}
+	defer f.Close()
+	return term.GetSize(int(f.Fd()))
+}

--- a/pkg/iostreams/tty_size_windows.go
+++ b/pkg/iostreams/tty_size_windows.go
@@ -1,0 +1,16 @@
+package iostreams
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+func ttySize() (int, int, error) {
+	f, err := os.Open("CONOUT$")
+	if err != nil {
+		return -1, -1, err
+	}
+	defer f.Close()
+	return term.GetSize(int(f.Fd()))
+}


### PR DESCRIPTION
Allows terminal-style output to be piped to a file or a script. Color will be enabled unless explicitly disabled with one of the color-controlling environment variables.

Optionally allows to specify the number of available columns as an absolute number or as a percentage of the current viewport.

Fixes #4035 

Example:
```sh
GH_FORCE_TTY=49% gh issue list | fzf --ansi --preview 'GH_FORCE_TTY=$FZF_PREVIEW_COLUMNS gh issue view {1}'
```

Questions:
- How does the "GH_FORCE_TTY" name sound? 