### PR TITLE
Fix HTTP 502 error reporting from GraphQL request

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -285,7 +285,10 @@ func HandleHTTPError(resp *http.Response) error {
 		return httpError
 	}
 
-	messages := []string{parsedBody.Message}
+	var messages []string
+	if parsedBody.Message != "" {
+		messages = append(messages, parsedBody.Message)
+	}
 	for _, raw := range parsedBody.Errors {
 		switch raw[0] {
 		case '"':
@@ -297,7 +300,7 @@ func HandleHTTPError(resp *http.Response) error {
 			var errInfo HTTPErrorItem
 			_ = json.Unmarshal(raw, &errInfo)
 			msg := errInfo.Message
-			if errInfo.Code != "custom" {
+			if errInfo.Code != "" && errInfo.Code != "custom" {
 				msg = fmt.Sprintf("%s.%s %s", errInfo.Resource, errInfo.Field, errorCodeToMessage(errInfo.Code))
 			}
 			if msg != "" {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -129,3 +129,20 @@ func TestRESTError(t *testing.T) {
 
 	}
 }
+
+func TestHandleHTTPError_GraphQL502(t *testing.T) {
+	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := &http.Response{
+		Request:    req,
+		StatusCode: 502,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(`{ "data": null, "errors": [{ "message": "Something went wrong" }] }`)),
+		Header:     map[string][]string{"Content-Type": {"application/json"}},
+	}
+	err = HandleHTTPError(resp)
+	if err == nil || err.Error() != "HTTP 502: Something went wrong (https://api.github.com/user)" {
+		t.Errorf("got error: %v", err)
+	}
+}


### PR DESCRIPTION
Now it makes sure that the message portion will be printed to stderr when the user encounters the error.

Before:
```
HTTP 502:  (https://api.github.com/graphql)
. 
```
After:
```
HTTP 502: Something went wrong while executing your query. This may be the result of a timeout, or it could be a GitHub bug. Please include `...` when reporting this issue. (https://api.github.com/graphql)
```
Ref. https://github.com/cli/cli/issues/4152