### PR TITLE
Correct benign mistake in off-by-one guard

### DIFF
--- a/pkg/cmd/api/pagination.go
+++ b/pkg/cmd/api/pagination.go
@@ -14,7 +14,7 @@ var linkRE = regexp.MustCompile(`<([^>]+)>;\s*rel="([^"]+)"`)
 
 func findNextPage(resp *http.Response) (string, bool) {
 	for _, m := range linkRE.FindAllStringSubmatch(resp.Header.Get("Link"), -1) {
-		if len(m) >= 2 && m[2] == "next" {
+		if len(m) > 2 && m[2] == "next" {
 			return m[1], true
 		}
 	}

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -250,7 +250,7 @@ var linkRE = regexp.MustCompile(`<([^>]+)>;\s*rel="([^"]+)"`)
 
 func findNextPage(link string) string {
 	for _, m := range linkRE.FindAllStringSubmatch(link, -1) {
-		if len(m) >= 2 && m[2] == "next" {
+		if len(m) > 2 && m[2] == "next" {
 			return m[1]
 		}
 	}


### PR DESCRIPTION
m[2] is the third element of m, rather than the second, so we have to
check instead that the len of m is at least 3.

Because the regular expression has two capture groups, the length of m
will always be 3, so currently the guard will always be true.

I noticed these while browsing the project on LGTM.com for another reason. Although these results weren't problematic, the rules are interesting. I could open a PR to add the `security-and-quality` suite for Code Scanning so that we'd see issues like this here. What do you think?