### PR TITLE
Enable `help` for extensions, accept full extension names as argument

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -116,7 +116,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 				RunE: func(cmd *cobra.Command, args []string) error {
 					var name string
 					if len(args) > 0 {
-						name = args[0]
+						name = normalizeExtensionSelector(args[0])
 					}
 					return m.Upgrade(name, flagForce, io.Out, io.ErrOut)
 				},
@@ -130,7 +130,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 			Short: "Remove an installed extension",
 			Args:  cobra.ExactArgs(1),
 			RunE: func(cmd *cobra.Command, args []string) error {
-				extName := args[0]
+				extName := normalizeExtensionSelector(args[0])
 				if err := m.Remove(extName); err != nil {
 					return err
 				}
@@ -166,4 +166,11 @@ func checkValidExtension(rootCmd *cobra.Command, m extensions.ExtensionManager, 
 	}
 
 	return nil
+}
+
+func normalizeExtensionSelector(n string) string {
+	if idx := strings.IndexRune(n, '/'); idx >= 0 {
+		n = n[idx+1:]
+	}
+	return strings.TrimPrefix(n, "gh-")
 }

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -101,6 +101,34 @@ func TestNewCmdExtension(t *testing.T) {
 			},
 		},
 		{
+			name: "upgrade an extension gh-prefix",
+			args: []string{"upgrade", "gh-hello"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.UpgradeFunc = func(name string, force bool, out, errOut io.Writer) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.UpgradeCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "hello", calls[0].Name)
+				}
+			},
+		},
+		{
+			name: "upgrade an extension full name",
+			args: []string{"upgrade", "monalisa/gh-hello"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.UpgradeFunc = func(name string, force bool, out, errOut io.Writer) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.UpgradeCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "hello", calls[0].Name)
+				}
+			},
+		},
+		{
 			name: "upgrade all",
 			args: []string{"upgrade", "--all"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
@@ -133,6 +161,38 @@ func TestNewCmdExtension(t *testing.T) {
 		{
 			name: "remove extension nontty",
 			args: []string{"remove", "hello"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.RemoveFunc = func(name string) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.RemoveCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "hello", calls[0].Name)
+				}
+			},
+			isTTY:      false,
+			wantStdout: "",
+		},
+		{
+			name: "remove extension gh-prefix",
+			args: []string{"remove", "gh-hello"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.RemoveFunc = func(name string) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.RemoveCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "hello", calls[0].Name)
+				}
+			},
+			isTTY:      false,
+			wantStdout: "",
+		},
+		{
+			name: "remove extension full name",
+			args: []string{"remove", "monalisa/gh-hello"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
 				em.RemoveFunc = func(name string) error {
 					return nil


### PR DESCRIPTION
Followup to https://github.com/cli/cli/pull/4116