### PR TITLE
Add extension create command

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -153,25 +153,26 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 				if err := m.Create(extName); err != nil {
 					return err
 				}
-				if io.IsStdoutTTY() {
-					link := "https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions"
-					cs := io.ColorScheme()
-					out := heredoc.Docf(`
-						%[1]s Created directory %[2]s
-						%[1]s Initialized git repository
-						%[1]s Set up extension scaffolding
-
-						%[2]s is ready for development
-
-						Install locally with: cd %[2]s && gh extension install .
-
-						Publish to GitHub with: gh repo create %[2]s
-
-						For more information on writing extensions:
-						%[3]s
-					`, cs.SuccessIcon(), extName, link)
-					fmt.Fprint(io.Out, out)
+				if !io.IsStdoutTTY() {
+					return nil
 				}
+				link := "https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions"
+				cs := io.ColorScheme()
+				out := heredoc.Docf(`
+					%[1]s Created directory %[2]s
+					%[1]s Initialized git repository
+					%[1]s Set up extension scaffolding
+
+					%[2]s is ready for development
+
+					Install locally with: cd %[2]s && gh extension install .
+
+					Publish to GitHub with: gh repo create %[2]s
+
+					For more information on writing extensions:
+					%[3]s
+				`, cs.SuccessIcon(), extName, link)
+				fmt.Fprint(io.Out, out)
 				return nil
 			},
 		},

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -141,6 +141,39 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 				return nil
 			},
 		},
+		&cobra.Command{
+			Use:   "create <name>",
+			Short: "Create a new extension",
+			Args:  cobra.ExactArgs(1),
+			RunE: func(cmd *cobra.Command, args []string) error {
+				extName := args[0]
+				if !strings.HasPrefix(extName, "gh-") {
+					extName = "gh-" + extName
+				}
+				if err := m.Create(extName); err != nil {
+					return err
+				}
+				if io.IsStdoutTTY() {
+					link := "https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions"
+					cs := io.ColorScheme()
+					out := heredoc.Docf(`
+						%[1]s Created directory %[2]s
+						%[1]s Initialized git repository
+						%[1]s Set up extension scaffolding
+
+						%[2]s is ready for development
+
+						Install locally with: cd %[2]s && gh extension install .
+
+						Publish to GitHub with: gh repo create %[2]s
+
+						For more information on writing extensions: %[3]s
+					`, cs.SuccessIcon(), extName, link)
+					fmt.Fprint(io.Out, out)
+				}
+				return nil
+			},
+		},
 	)
 
 	extCmd.Hidden = true

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -177,7 +177,6 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 		},
 	)
 
-	extCmd.Hidden = true
 	return &extCmd
 }
 

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -167,7 +167,8 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 
 						Publish to GitHub with: gh repo create %[2]s
 
-						For more information on writing extensions: %[3]s
+						For more information on writing extensions:
+						%[3]s
 					`, cs.SuccessIcon(), extName, link)
 					fmt.Fprint(io.Out, out)
 				}

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -144,7 +144,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 		&cobra.Command{
 			Use:   "create <name>",
 			Short: "Create a new extension",
-			Args:  cobra.ExactArgs(1),
+			Args:  cmdutil.ExactArgs(1, "must specify a name for the extension"),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				extName := args[0]
 				if !strings.HasPrefix(extName, "gh-") {

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -154,7 +154,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					return err
 				}
 				if io.IsStdoutTTY() {
-					link := "https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions"
+					link := "https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions"
 					cs := io.ColorScheme()
 					out := heredoc.Docf(`
 						%[1]s Created directory %[2]s

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -187,7 +187,7 @@ func TestNewCmdExtension(t *testing.T) {
 
 				Publish to GitHub with: gh repo create gh-test
 
-				For more information on writing extensions: https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions
+				For more information on writing extensions: https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions
 			`),
 		},
 		{

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/internal/config"
 	"github.com/cli/cli/pkg/cmdutil"
 	"github.com/cli/cli/pkg/extensions"
@@ -160,6 +161,50 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			wantStdout: "gh test\tcli/gh-test\t\ngh test2\tcli/gh-test2\tUpgrade available\n",
+		},
+		{
+			name: "create extension tty",
+			args: []string{"create", "test"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.CreateFunc = func(name string) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.CreateCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "gh-test", calls[0].Name)
+				}
+			},
+			isTTY: true,
+			wantStdout: heredoc.Doc(`
+				✓ Created directory gh-test
+				✓ Initialized git repository
+				✓ Set up extension scaffolding
+
+				gh-test is ready for development
+
+				Install locally with: cd gh-test && gh extension install .
+
+				Publish to GitHub with: gh repo create gh-test
+
+				For more information on writing extensions: https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions
+			`),
+		},
+		{
+			name: "create extension notty",
+			args: []string{"create", "gh-test"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.CreateFunc = func(name string) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.CreateCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "gh-test", calls[0].Name)
+				}
+			},
+			isTTY:      false,
+			wantStdout: "",
 		},
 	}
 

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -187,7 +187,8 @@ func TestNewCmdExtension(t *testing.T) {
 
 				Publish to GitHub with: gh repo create gh-test
 
-				For more information on writing extensions: https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions
+				For more information on writing extensions:
+				https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions
 			`),
 		},
 		{

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -269,8 +269,40 @@ func (m *Manager) Create(name string) error {
 
 	fileTmpl := heredoc.Docf(`
 		#!/bin/bash
+		set -e
 		echo "Hello %[1]s"
-	`, name)
+
+		# Examples to help get started:
+
+		# Determine if an executable is in the PATH
+		# if [ "$(which go)" = "" ]; then
+		#   echo "go not found in PATH"
+		#   exit 1
+		# fi
+
+		# Pass arguments through to a new process
+		# exec gh issue list "$@" -R cli/cli
+
+		# Using the gh api command to retrieve and format information
+		# QUERY='
+		#   query($endCursor: String) {
+		#     viewer {
+		#       repositories(first: 100, after: $endCursor) {
+		#         nodes {
+		#           nameWithOwner
+		#           stargazerCount
+		#         }
+		#       }
+		#     }
+		#   }
+		# '
+		# TEMPLATE='
+		#   {{- range $repo := .data.viewer.repositories.nodes -}}
+		#     {{- printf "name: %[2]s - stargazers: %[3]s\n" $repo.nameWithOwner $repo.stargazerCount -}}
+		#   {{- end -}}
+		# '
+		# exec gh api graphql --template="${TEMPLATE}" --paginate -f query="${QUERY}"
+	`, name, "%s", "%v")
 	filePath := filepath.Join(name, name)
 	err = ioutil.WriteFile(filePath, []byte(fileTmpl), 0755)
 	return err

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -306,6 +306,17 @@ func (m *Manager) Create(name string) error {
 	`, name, "%s", "%v")
 	filePath := filepath.Join(name, name)
 	err = ioutil.WriteFile(filePath, []byte(fileTmpl), 0755)
+	if err != nil {
+		return err
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Join(wd, name)
+	addCmd := m.newCommand(exe, "-C", dir, "--git-dir="+filepath.Join(dir, ".git"), "add", name, "--chmod=+x")
+	err = addCmd.Run()
 	return err
 }
 

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -261,7 +261,7 @@ func (m *Manager) Create(name string) error {
 		return err
 	}
 
-	initCmd := m.newCommand(exe, "init", "-b", "main", "--quiet", name)
+	initCmd := m.newCommand(exe, "init", "--quiet", name)
 	err = initCmd.Run()
 	if err != nil {
 		return err
@@ -270,18 +270,19 @@ func (m *Manager) Create(name string) error {
 	fileTmpl := heredoc.Docf(`
 		#!/bin/bash
 		set -e
-		echo "Hello %[1]s"
 
-		# Examples to help get started:
+		echo "Hello %[1]s!"
+
+		# Snippets to help get started:
 
 		# Determine if an executable is in the PATH
-		# if [ "$(which go)" = "" ]; then
-		#   echo "go not found in PATH"
+		# if ! type -p ruby >/dev/null; then
+		#   echo "Ruby not found on the system" >&2
 		#   exit 1
 		# fi
 
-		# Pass arguments through to a new process
-		# exec gh issue list "$@" -R cli/cli
+		# Pass arguments through to another command
+		# gh issue list "$@" -R cli/cli
 
 		# Using the gh api command to retrieve and format information
 		# QUERY='
@@ -301,7 +302,7 @@ func (m *Manager) Create(name string) error {
 		#     {{- printf "name: %[2]s - stargazers: %[3]s\n" $repo.nameWithOwner $repo.stargazerCount -}}
 		#   {{- end -}}
 		# '
-		# exec gh api graphql --template="${TEMPLATE}" --paginate -f query="${QUERY}"
+		# exec gh api graphql -f query="${QUERY}" --paginate --template="${TEMPLATE}"
 	`, name, "%s", "%v")
 	filePath := filepath.Join(name, name)
 	err = ioutil.WriteFile(filePath, []byte(fileTmpl), 0755)

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -202,6 +202,26 @@ func TestManager_Install(t *testing.T) {
 	assert.Equal(t, "", stderr.String())
 }
 
+func TestManager_Create(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	assert.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	m := newTestManager(tempDir)
+	err := m.Create("gh-test")
+	assert.NoError(t, err)
+	files, err := ioutil.ReadDir(filepath.Join(tempDir, "gh-test"))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(files))
+	extFile := files[0]
+	assert.Equal(t, "gh-test", extFile.Name())
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, os.FileMode(0666), extFile.Mode())
+	} else {
+		assert.Equal(t, os.FileMode(0755), extFile.Mode())
+	}
+}
+
 func stubExtension(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -21,4 +21,5 @@ type ExtensionManager interface {
 	Upgrade(name string, force bool, stdout, stderr io.Writer) error
 	Remove(name string) error
 	Dispatch(args []string, stdin io.Reader, stdout, stderr io.Writer) (bool, error)
+	Create(name string) error
 }


### PR DESCRIPTION
This PR adds the `extension create` command. It creates the local scaffolding for developing an extension and then outputs instructions on next steps for the user. Does not install the extension locally or publish the extension.

<img width="651" alt="Screen Shot 2021-08-19 at 4 08 39 PM" src="https://user-images.githubusercontent.com/7969779/130155559-8558884b-0417-4700-8227-d9f71c1d358e.png">

Fixes https://github.com/cli/cli/issues/4104
Supersedes https://github.com/cli/cli/pull/4157