### PR TITLE
chore: make gh status link clickable

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -251,7 +251,7 @@ func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
 		if debug {
 			fmt.Fprintln(out, dnsError)
 		}
-		fmt.Fprintln(out, "check your internet connection or githubstatus.com")
+		fmt.Fprintln(out, "check your internet connection or https://githubstatus.com")
 		return
 	}
 

--- a/cmd/gh/main_test.go
+++ b/cmd/gh/main_test.go
@@ -43,7 +43,7 @@ func Test_printError(t *testing.T) {
 				debug: false,
 			},
 			wantOut: `error connecting to api.github.com
-check your internet connection or githubstatus.com
+check your internet connection or https://githubstatus.com
 `,
 		},
 		{


### PR DESCRIPTION
Adding `https://` to `githubstatus.com` to make it clickable on terminal emulators.

