### PR TITLE
Require Go 1.16+

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,8 +23,7 @@ Please avoid:
 ## Building the project
 
 Prerequisites:
-- Go 1.13+ for building the binary
-- Go 1.15+ for running the test suite
+- Go 1.16+
 
 Build with:
 * Unix-like systems: `make`

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -24,21 +24,4 @@ jobs:
         run: go test -race ./...
 
       - name: Build
-        run: go build -v ./cmd/gh
-
-  build-minimum:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.13
-
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Build
-        env:
-          CGO_ENABLED: '0'
         run: go build -v ./cmd/gh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Generate changelog
         run: |
           echo "GORELEASER_CURRENT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV

--- a/docs/source.md
+++ b/docs/source.md
@@ -1,6 +1,6 @@
 # Installation from source
 
-0. Verify that you have Go 1.13+ installed
+0. Verify that you have Go 1.16+ installed
 
    ```sh
    $ go version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cli/cli
 
-go 1.13
+go 1.16
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.14


### PR DESCRIPTION
Nothing in the codebase requires go 1.16, but this opens up a path to use new Go features going forward.

This also changes precompiled binaries to be built using Go 1.16 instead of Go 1.15.

There is no `build-minimum` CI job anymore, so I've removed it from merge requirements for the `trunk` branch.

Followup to #1596