### PR TITLE
Disable auth for cobra shell request completion hidden commands

### DIFF
--- a/pkg/cmdutil/auth_check.go
+++ b/pkg/cmdutil/auth_check.go
@@ -34,9 +34,11 @@ func CheckAuth(cfg config.Config) bool {
 }
 
 func IsAuthCheckEnabled(cmd *cobra.Command) bool {
-	if cmd.Name() == "help" {
+	switch cmd.Name() {
+	case "help", cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd:
 		return false
 	}
+
 	for c := cmd; c.Parent() != nil; c = c.Parent() {
 		if c.Annotations != nil && c.Annotations["skipAuthCheck"] == "true" {
 			return false


### PR DESCRIPTION
Those hidden command are used by the shell completion scripts, but they
are not disabled auth check. Thus, the shell completion does not work
even the completion setup was done properly.

Fixes #4188
