### PR TITLE
Use `/usr/bin/env bash` instead of `/bin/bash` in `gh extension create`

### DIFF
--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -268,7 +268,7 @@ func (m *Manager) Create(name string) error {
 	}
 
 	fileTmpl := heredoc.Docf(`
-		#!/bin/bash
+		#!/usr/bin/env bash
 		set -e
 
 		echo "Hello %[1]s!"


### PR DESCRIPTION
Not being too lazy to explain the reason, but this SO answer pretty much said it: https://stackoverflow.com/a/16365367

As for myself, the motivation is that NixOS doesn't have `/bin/bash` (only `/bin/sh`).

Some other places that may need to update:

- GitHub docs (https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions)
- Files under [`script`](https://github.com/cli/cli/tree/trunk/script) folder. They seems to be used by maintainers only but portability is always good.

P.S. I'm not sure when a new release will come out, but before this PR gets merged (if even) and everyone update to the new version, there will be a lot of new plugins using `/bin/sh` and *none* of them will work without modification. 

I probably won't bother to make a PR to change the shebang for every plugin out there, `gh` should set a good example, even if the current way works for most people.