### PR TITLE
Remove defunct link from `gh actions`

### DIFF
--- a/pkg/cmd/actions/actions.go
+++ b/pkg/cmd/actions/actions.go
@@ -56,8 +56,5 @@ func actionsExplainer(cs *iostreams.ColorScheme) string {
 			gh workflow run:      Trigger a workflow_dispatch run for a workflow file
 
 			To see more help, run 'gh help workflow <subcommand>'
-
-			For more in depth help including examples, see online documentation at:
-			<https://docs.github.com/en/actions/guides/managing-github-actions-with-github-cli>
 		`, header, runHeader, workflowHeader)
 }


### PR DESCRIPTION
The online guide that was GitHub CLI-specific no longer exists. Instead, "GitHub CLI" sections were added to existing individual articles about managing workflow runs.

I've opted to drop the URL entirely since there is no single equivalent URL to link to anymore.

Fixes #4210