### PR TITLE
Suggest to re-authenticate to fix "SAML enforcement" error

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -217,13 +217,15 @@ func mainRun() exitCode {
 
 		if strings.Contains(err.Error(), "Incorrect function") {
 			fmt.Fprintln(stderr, "You appear to be running in MinTTY without pseudo terminal support.")
-			fmt.Fprintln(stderr, "To learn about workarounds for this error, run: gh help mintty")
+			fmt.Fprintln(stderr, "To learn about workarounds for this error, run:  gh help mintty")
 			return exitError
 		}
 
 		var httpErr api.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == 401 {
-			fmt.Fprintln(stderr, "hint: try authenticating with `gh auth login`")
+			fmt.Fprintln(stderr, "Try authenticating with:  gh auth login")
+		} else if strings.Contains(err.Error(), "Resource protected by organization SAML enforcement") {
+			fmt.Fprintln(stderr, "Try re-authenticating with:  gh auth refresh")
 		}
 
 		return exitError


### PR DESCRIPTION
As far as I can put together, this error appears when someone has authenticated GitHub CLI with a PAT that isn't authorized to access a certain org. It can also happen if someone has authorized GitHub CLI using the legacy "GitHub CLI (dev)" OAuth app instead of our production OAuth app.

Doing `gh auth refresh` will re-authenticate the user using our production "GitHub CLI" OAuth app which will not have problems accessing resources in different GitHub organizations.

Fixes #2661