### PR TITLE
Simplify brew upgrade instructions

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -244,7 +244,7 @@ func mainRun() exitCode {
 			ansi.Color(buildVersion, "cyan"),
 			ansi.Color(newRelease.Version, "cyan"))
 		if isHomebrew {
-			fmt.Fprintf(stderr, "To upgrade, run: %s\n", "brew update && brew upgrade gh")
+			fmt.Fprintf(stderr, "To upgrade, run: %s\n", "brew upgrade gh")
 		}
 		fmt.Fprintf(stderr, "%s\n\n",
 			ansi.Color(newRelease.URL, "yellow"))


### PR DESCRIPTION
I think the `brew update` instruction is unnecessary because `brew upgrade` automatically does this by default.

To disable auto update you need to use an environment flag `HOMEBREW_NO_AUTO_UPDATE=1`, and I think anybody using it should be aware of the implications of not updating brew and fetching new formulae.

Maybe I missed another reason for this instruction?