### PR TITLE
feat(4248): add support for line range w/ browse

### DIFF
--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -169,12 +169,28 @@ func parseFileArg(fileArg string) (string, error) {
 	if len(arr) > 2 {
 		return "", fmt.Errorf("invalid use of colon\nUse 'gh browse --help' for more information about browse\n")
 	}
+
 	if len(arr) > 1 {
-		if !isNumber(arr[1]) {
-			return "", fmt.Errorf("invalid line number after colon\nUse 'gh browse --help' for more information about browse\n")
+		out := arr[0] + "#L"
+		lineRange := strings.Split(arr[1], "-")
+
+		if len(lineRange) > 0 {
+			if !isNumber(lineRange[0]) {
+				return "", fmt.Errorf("invalid line number after colon\nUse 'gh browse --help' for more information about browse\n")
+			}
+			out += lineRange[0]
 		}
-		return arr[0] + "#L" + arr[1], nil
+
+		if len(lineRange) > 1 {
+			if !isNumber(lineRange[1]) {
+				return "", fmt.Errorf("invalid line range after colon\nUse 'gh browse --help' for more information about browse\n")
+			}
+			out += "-L" + lineRange[1]
+		}
+
+		return out, nil
 	}
+
 	return arr[0], nil
 }
 

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -216,9 +216,26 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL:   "https://github.com/ravocean/angur/tree/trunk/path/to/file.txt#L32",
 		},
 		{
+			name: "file with line range",
+			opts: BrowseOptions{
+				SelectorArg: "path/to/file.txt:32-40",
+			},
+			baseRepo:      ghrepo.New("ravocean", "angur"),
+			defaultBranch: "trunk",
+			expectedURL:   "https://github.com/ravocean/angur/tree/trunk/path/to/file.txt#L32-L40",
+		},
+		{
 			name: "file with invalid line number",
 			opts: BrowseOptions{
 				SelectorArg: "path/to/file.txt:32:32",
+			},
+			baseRepo: ghrepo.New("ttran112", "ttrain211"),
+			wantsErr: true,
+		},
+		{
+			name: "file with invalid line range",
+			opts: BrowseOptions{
+				SelectorArg: "path/to/file.txt:32-abc",
 			},
 			baseRepo: ghrepo.New("ttran112", "ttrain211"),
 			wantsErr: true,


### PR DESCRIPTION
Allow using a range of lines when browsing files. For example:

`gh browse test.go:10-20`

Closes #4248

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
