### PR TITLE
Add `--head` filter to `gh pr list`

### DIFF
--- a/pkg/cmd/pr/list/http.go
+++ b/pkg/cmd/pr/list/http.go
@@ -36,12 +36,14 @@ func listPullRequests(httpClient *http.Client, repo ghrepo.Interface, filters pr
 			$limit: Int!,
 			$endCursor: String,
 			$baseBranch: String,
+			$headBranch: String,
 			$state: [PullRequestState!] = OPEN
 		) {
 			repository(owner: $owner, name: $repo) {
 				pullRequests(
 					states: $state,
 					baseRefName: $baseBranch,
+					headRefName: $headBranch,
 					first: $limit,
 					after: $endCursor,
 					orderBy: {field: CREATED_AT, direction: DESC}
@@ -79,6 +81,9 @@ func listPullRequests(httpClient *http.Client, repo ghrepo.Interface, filters pr
 
 	if filters.BaseBranch != "" {
 		variables["baseBranch"] = filters.BaseBranch
+	}
+	if filters.HeadBranch != "" {
+		variables["headBranch"] = filters.HeadBranch
 	}
 
 	res := api.PullRequestAndTotalCount{}

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -33,6 +33,7 @@ type ListOptions struct {
 
 	State      string
 	BaseBranch string
+	HeadBranch string
 	Labels     []string
 	Author     string
 	Assignee   string
@@ -88,6 +89,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		return []string{"open", "closed", "merged", "all"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	cmd.Flags().StringVarP(&opts.BaseBranch, "base", "B", "", "Filter by base branch")
+	cmd.Flags().StringVarP(&opts.HeadBranch, "head", "H", "", "Filter by head branch")
 	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Filter by labels")
 	cmd.Flags().StringVarP(&opts.Author, "author", "A", "", "Filter by author")
 	cmd.Flags().StringVarP(&opts.Assignee, "assignee", "a", "", "Filter by assignee")
@@ -131,6 +133,7 @@ func listRun(opts *ListOptions) error {
 		Assignee:   opts.Assignee,
 		Labels:     opts.Labels,
 		BaseBranch: opts.BaseBranch,
+		HeadBranch: opts.HeadBranch,
 		Search:     opts.Search,
 		Fields:     defaultFields,
 	}

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -160,6 +160,22 @@ func TestPRList_filteringClosed(t *testing.T) {
 	}
 }
 
+func TestPRList_filteringHeadBranch(t *testing.T) {
+	http := initFakeHTTP()
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.GraphQL(`query PullRequestList\b`),
+		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
+			assert.Equal(t, interface{}("bug-fix"), params["headBranch"])
+		}))
+
+	_, err := runCommand(http, true, `-H bug-fix`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPRList_filteringAssignee(t *testing.T) {
 	http := initFakeHTTP()
 	defer http.Verify(t)

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -154,6 +154,7 @@ type FilterOptions struct {
 	Labels     []string
 	Author     string
 	BaseBranch string
+	HeadBranch string
 	Mention    string
 	Milestone  string
 	Search     string
@@ -175,6 +176,9 @@ func (opts *FilterOptions) IsDefault() bool {
 		return false
 	}
 	if opts.BaseBranch != "" {
+		return false
+	}
+	if opts.HeadBranch != "" {
 		return false
 	}
 	if opts.Mention != "" {
@@ -231,6 +235,9 @@ func SearchQueryBuild(options FilterOptions) string {
 	}
 	if options.BaseBranch != "" {
 		q.SetBaseBranch(options.BaseBranch)
+	}
+	if options.HeadBranch != "" {
+		q.SetHeadBranch(options.HeadBranch)
 	}
 	if options.Mention != "" {
 		q.Mentions(options.Mention)

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -44,10 +44,11 @@ func Test_listURLWithQuery(t *testing.T) {
 					Assignee:   "bo",
 					Author:     "ka",
 					BaseBranch: "trunk",
+					HeadBranch: "bug-fix",
 					Mention:    "nu",
 				},
 			},
-			want:    "https://example.com/path?q=is%3Aissue+is%3Aopen+assignee%3Abo+author%3Aka+mentions%3Anu+base%3Atrunk",
+			want:    "https://example.com/path?q=is%3Aissue+is%3Aopen+assignee%3Abo+author%3Aka+mentions%3Anu+base%3Atrunk+head%3Abug-fix",
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
Adds `--head` filter to `gh pr list`.  I didn't create new issue for this, it was previously mentioned in https://github.com/cli/cli/issues/641 (the very last item in check list). 
I am not very familiar with Go and GitHub CLI internals, so this PR was hacked for 30 minutes using already implemented `--base` as a reference, so I hope I didn't make any mistakes :) 