### PR TITLE
install binary extensions

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -247,12 +247,8 @@ func checkValidExtension(rootCmd *cobra.Command, m extensions.ExtensionManager, 
 }
 
 func isBinExtension(client *http.Client, repo ghrepo.Interface) (isBin bool, err error) {
-	hs, err := hasScript(client, repo)
-	if err != nil || hs {
-		return
-	}
-
-	_, err = fetchLatestRelease(client, repo)
+	var r *release
+	r, err = fetchLatestRelease(client, repo)
 	if err != nil {
 		httpErr, ok := err.(api.HTTPError)
 		if ok && httpErr.StatusCode == 404 {
@@ -262,7 +258,16 @@ func isBinExtension(client *http.Client, repo ghrepo.Interface) (isBin bool, err
 		return
 	}
 
-	isBin = true
+	for _, a := range r.Assets {
+		dists := possibleDists()
+		for _, d := range dists {
+			if strings.HasSuffix(a.Name, d) {
+				isBin = true
+				break
+			}
+		}
+	}
+
 	return
 }
 
@@ -271,4 +276,53 @@ func normalizeExtensionSelector(n string) string {
 		n = n[idx+1:]
 	}
 	return strings.TrimPrefix(n, "gh-")
+}
+
+func possibleDists() []string {
+	return []string{
+		"aix-ppc64",
+		"android-386",
+		"android-amd64",
+		"android-arm",
+		"android-arm64",
+		"darwin-amd64",
+		"darwin-arm64",
+		"dragonfly-amd64",
+		"freebsd-386",
+		"freebsd-amd64",
+		"freebsd-arm",
+		"freebsd-arm64",
+		"illumos-amd64",
+		"ios-amd64",
+		"ios-arm64",
+		"js-wasm",
+		"linux-386",
+		"linux-amd64",
+		"linux-arm",
+		"linux-arm64",
+		"linux-mips",
+		"linux-mips64",
+		"linux-mips64le",
+		"linux-mipsle",
+		"linux-ppc64",
+		"linux-ppc64le",
+		"linux-riscv64",
+		"linux-s390x",
+		"netbsd-386",
+		"netbsd-amd64",
+		"netbsd-arm",
+		"netbsd-arm64",
+		"openbsd-386",
+		"openbsd-amd64",
+		"openbsd-arm",
+		"openbsd-arm64",
+		"openbsd-mips64",
+		"plan9-386",
+		"plan9-amd64",
+		"plan9-arm",
+		"solaris-amd64",
+		"windows-386",
+		"windows-amd64",
+		"windows-arm",
+	}
 }

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -3,7 +3,6 @@ package extension
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -113,12 +112,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 				}
 				client = api.NewCachedClient(client, time.Second*30)
 
-				cfg, err := f.Config()
-				if err != nil {
-					return err
-				}
-
-				return m.Install(client, repo, io, cfg)
+				return m.Install(repo)
 			},
 		},
 		func() *cobra.Command {
@@ -228,83 +222,9 @@ func checkValidExtension(rootCmd *cobra.Command, m extensions.ExtensionManager, 
 	return nil
 }
 
-func isBinExtension(client *http.Client, repo ghrepo.Interface) (isBin bool, err error) {
-	var r *release
-	r, err = fetchLatestRelease(client, repo)
-	if err != nil {
-		httpErr, ok := err.(api.HTTPError)
-		if ok && httpErr.StatusCode == 404 {
-			err = nil
-			return
-		}
-		return
-	}
-
-	for _, a := range r.Assets {
-		dists := possibleDists()
-		for _, d := range dists {
-			if strings.HasSuffix(a.Name, d) {
-				isBin = true
-				break
-			}
-		}
-	}
-
-	return
-}
-
 func normalizeExtensionSelector(n string) string {
 	if idx := strings.IndexRune(n, '/'); idx >= 0 {
 		n = n[idx+1:]
 	}
 	return strings.TrimPrefix(n, "gh-")
-}
-
-func possibleDists() []string {
-	return []string{
-		"aix-ppc64",
-		"android-386",
-		"android-amd64",
-		"android-arm",
-		"android-arm64",
-		"darwin-amd64",
-		"darwin-arm64",
-		"dragonfly-amd64",
-		"freebsd-386",
-		"freebsd-amd64",
-		"freebsd-arm",
-		"freebsd-arm64",
-		"illumos-amd64",
-		"ios-amd64",
-		"ios-arm64",
-		"js-wasm",
-		"linux-386",
-		"linux-amd64",
-		"linux-arm",
-		"linux-arm64",
-		"linux-mips",
-		"linux-mips64",
-		"linux-mips64le",
-		"linux-mipsle",
-		"linux-ppc64",
-		"linux-ppc64le",
-		"linux-riscv64",
-		"linux-s390x",
-		"netbsd-386",
-		"netbsd-amd64",
-		"netbsd-arm",
-		"netbsd-arm64",
-		"openbsd-386",
-		"openbsd-amd64",
-		"openbsd-arm",
-		"openbsd-arm64",
-		"openbsd-mips64",
-		"plan9-386",
-		"plan9-amd64",
-		"plan9-arm",
-		"solaris-amd64",
-		"windows-386",
-		"windows-amd64",
-		"windows-arm",
-	}
 }

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -103,14 +101,10 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 				if err != nil {
 					return err
 				}
+
 				if err := checkValidExtension(cmd.Root(), m, repo.RepoName()); err != nil {
 					return err
 				}
-				client, err := f.HttpClient()
-				if err != nil {
-					return fmt.Errorf("could not make http client: %w", err)
-				}
-				client = api.NewCachedClient(client, time.Second*30)
 
 				return m.Install(repo)
 			},

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -105,38 +105,20 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					return err
 				}
 				if err := checkValidExtension(cmd.Root(), m, repo.RepoName()); err != nil {
-					// TODO i feel like this should check for a gh-foo script
 					return err
 				}
-
 				client, err := f.HttpClient()
 				if err != nil {
 					return fmt.Errorf("could not make http client: %w", err)
 				}
 				client = api.NewCachedClient(client, time.Second*30)
 
-				isBin, err := isBinExtension(client, repo)
-				if err != nil {
-					return fmt.Errorf("could not check for binary extension: %w", err)
-				}
-				if isBin {
-					return m.InstallBin(client, repo)
-				}
-
-				hs, err := hasScript(client, repo)
-				if err != nil {
-					return err
-				}
-				if !hs {
-					return errors.New("extension is uninstallable: missing executable")
-				}
-
 				cfg, err := f.Config()
 				if err != nil {
 					return err
 				}
-				protocol, _ := cfg.Get(repo.RepoHost(), "git_protocol")
-				return m.InstallGit(ghrepo.FormatRemoteURL(repo, protocol), io.Out, io.ErrOut)
+
+				return m.Install(client, repo, io, cfg)
 			},
 		},
 		func() *cobra.Command {

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -41,6 +41,9 @@ func TestNewCmdExtension(t *testing.T) {
 			args: []string{"install", "owner/gh-some-ext"},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
+					httpmock.REST("GET", "repos/owner/gh-some-ext/releases/latest"),
+					httpmock.StatusStringResponse(404, "nope"))
+				reg.Register(
 					httpmock.REST("GET", "repos/owner/gh-some-ext/contents/gh-some-ext"),
 					httpmock.StringResponse("a script"))
 			},
@@ -65,11 +68,10 @@ func TestNewCmdExtension(t *testing.T) {
 			args: []string{"install", "owner/gh-bin-ext"},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/owner/gh-bin-ext/contents/gh-bin-ext"),
-					httpmock.StatusStringResponse(404, "no"))
-				reg.Register(
 					httpmock.REST("GET", "repos/owner/gh-bin-ext/releases/latest"),
-					httpmock.StringResponse("{}"))
+					httpmock.JSONResponse(release{
+						Assets: []releaseAsset{
+							{Name: "gh-foo-windows-amd64"}}}))
 			},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
 				em.ListFunc = func(bool) []extensions.Extension {

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -42,7 +42,7 @@ func TestNewCmdExtension(t *testing.T) {
 				em.ListFunc = func(bool) []extensions.Extension {
 					return []extensions.Extension{}
 				}
-				em.InstallFunc = func(_ *http.Client, _ ghrepo.Interface, _ *iostreams.IOStreams, _ config.Config) error {
+				em.InstallFunc = func(_ ghrepo.Interface) error {
 					return nil
 				}
 				return func(t *testing.T) {

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -47,6 +47,7 @@ type releaseAsset struct {
 }
 
 type release struct {
+	Tag    string `json:"tag_name"`
 	Assets []releaseAsset
 }
 

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -1,0 +1,113 @@
+package extension
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghinstance"
+	"github.com/cli/cli/v2/internal/ghrepo"
+)
+
+func hasScript(httpClient *http.Client, repo ghrepo.Interface) (hs bool, err error) {
+	path := fmt.Sprintf("repos/%s/%s/contents/%s",
+		repo.RepoOwner(), repo.RepoName(), repo.RepoName())
+	url := ghinstance.RESTPrefix(repo.RepoHost()) + path
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return
+	}
+
+	if resp.StatusCode > 299 {
+		err = api.HandleHTTPError(resp)
+		return
+	}
+
+	hs = true
+	return
+}
+
+type releaseAsset struct {
+	Name   string
+	APIURL string `json:"url"`
+}
+
+type release struct {
+	Assets []releaseAsset
+}
+
+// downloadAsset downloads a single asset to the given file path.
+func downloadAsset(httpClient *http.Client, asset releaseAsset, destPath string) error {
+	req, err := http.NewRequest("GET", asset.APIURL, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Accept", "application/octet-stream")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 299 {
+		return api.HandleHTTPError(resp)
+	}
+
+	f, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0755)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+// fetchLatestRelease finds the latest published release for a repository.
+func fetchLatestRelease(httpClient *http.Client, baseRepo ghrepo.Interface) (*release, error) {
+	path := fmt.Sprintf("repos/%s/%s/releases/latest", baseRepo.RepoOwner(), baseRepo.RepoName())
+	url := ghinstance.RESTPrefix(baseRepo.RepoHost()) + path
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 299 {
+		return nil, api.HandleHTTPError(resp)
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var r release
+	err = json.Unmarshal(b, &r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -195,7 +195,7 @@ func (m *Manager) Install(client *http.Client, repo ghrepo.Interface, io *iostre
 		return fmt.Errorf("could not check for binary extension: %w", err)
 	}
 	if isBin {
-		return m.InstallBin(client, repo)
+		return m.installBin(client, repo)
 	}
 
 	hs, err := hasScript(client, repo)
@@ -208,10 +208,10 @@ func (m *Manager) Install(client *http.Client, repo ghrepo.Interface, io *iostre
 	}
 
 	protocol, _ := cfg.Get(repo.RepoHost(), "git_protocol")
-	return m.InstallGit(ghrepo.FormatRemoteURL(repo, protocol), io.Out, io.ErrOut)
+	return m.installGit(ghrepo.FormatRemoteURL(repo, protocol), io.Out, io.ErrOut)
 }
 
-func (m *Manager) InstallBin(client *http.Client, repo ghrepo.Interface) error {
+func (m *Manager) installBin(client *http.Client, repo ghrepo.Interface) error {
 	var r *release
 	r, err := fetchLatestRelease(client, repo)
 	if err != nil {
@@ -276,7 +276,7 @@ func (m *Manager) InstallBin(client *http.Client, repo ghrepo.Interface) error {
 	return nil
 }
 
-func (m *Manager) InstallGit(cloneURL string, stdout, stderr io.Writer) error {
+func (m *Manager) installGit(cloneURL string, stdout, stderr io.Writer) error {
 	exe, err := m.lookPath("git")
 	if err != nil {
 		return err

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -185,6 +185,7 @@ type BinManifest struct {
 	Name  string
 	Host  string
 	// TODO I may end up not using this; just thinking ahead to local installs
+	// TODO track version
 	Path string
 }
 

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -180,12 +180,12 @@ func (m *Manager) InstallLocal(dir string) error {
 	return makeSymlink(dir, targetLink)
 }
 
-type BinManifest struct {
+type binManifest struct {
 	Owner string
 	Name  string
 	Host  string
+	Tag   string
 	// TODO I may end up not using this; just thinking ahead to local installs
-	// TODO track version
 	Path string
 }
 
@@ -248,11 +248,12 @@ func (m *Manager) installBin(client *http.Client, repo ghrepo.Interface) error {
 		return fmt.Errorf("failed to download asset %s: %w", asset.Name, err)
 	}
 
-	manifest := BinManifest{
+	manifest := binManifest{
 		Name:  name,
 		Owner: repo.RepoOwner(),
 		Host:  repo.RepoHost(),
 		Path:  binPath,
+		Tag:   r.Tag,
 	}
 
 	bs, err := yaml.Marshal(manifest)

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -204,7 +204,7 @@ func (m *Manager) InstallBin(client *http.Client, repo ghrepo.Interface) error {
 	}
 
 	if asset == nil {
-		return fmt.Errorf("%s unsupported for %s. Open an issue: `gh issue create -R%s/%s -t'Support %s'`",
+		return fmt.Errorf("%s unsupported for %s. Open an issue: `gh issue create -R %s/%s -t'Support %s'`",
 			repo.RepoName(),
 			suffix, repo.RepoOwner(), repo.RepoName(), suffix)
 	}

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -254,6 +254,7 @@ func TestManager_Install_binary(t *testing.T) {
 		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
 		httpmock.JSONResponse(
 			release{
+				Tag: "v1.0.1",
 				Assets: []releaseAsset{
 					{
 						Name:   "gh-bin-ext-windows-amd64",
@@ -276,14 +277,15 @@ func TestManager_Install_binary(t *testing.T) {
 	manifest, err := os.ReadFile(filepath.Join(tempDir, "extensions/gh-bin-ext/manifest.yml"))
 	assert.NoError(t, err)
 
-	var bm BinManifest
+	var bm binManifest
 	err = yaml.Unmarshal(manifest, &bm)
 	assert.NoError(t, err)
 
-	assert.Equal(t, BinManifest{
+	assert.Equal(t, binManifest{
 		Name:  "gh-bin-ext",
 		Owner: "owner",
 		Host:  "example.com",
+		Tag:   "v1.0.1",
 		Path:  filepath.Join(tempDir, "extensions/gh-bin-ext/gh-bin-ext"),
 	}, bm)
 

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -44,7 +44,7 @@ func newTestManager(dir string) *Manager {
 			return cmd
 		},
 		platform: func() string {
-			return "amiga-arm64"
+			return "windows-amd64"
 		},
 	}
 }
@@ -222,7 +222,7 @@ func TestManager_InstallBin(t *testing.T) {
 			release{
 				Assets: []releaseAsset{
 					{
-						Name:   "gh-bin-ext-amiga-arm64",
+						Name:   "gh-bin-ext-windows-amd64",
 						APIURL: "https://example.com/release/cool",
 					},
 				},

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/context"
@@ -161,7 +162,8 @@ func extensionManager(f *cmdutil.Factory) *extension.Manager {
 	if err != nil {
 		return em
 	}
-	em.SetClient(client)
+
+	em.SetClient(api.NewCachedClient(client, time.Second*30))
 
 	return em
 }

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -2,6 +2,9 @@ package extensions
 
 import (
 	"io"
+	"net/http"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
 )
 
 //go:generate moq -rm -out extension_mock.go . Extension
@@ -16,7 +19,8 @@ type Extension interface {
 //go:generate moq -rm -out manager_mock.go . ExtensionManager
 type ExtensionManager interface {
 	List(includeMetadata bool) []Extension
-	Install(url string, stdout, stderr io.Writer) error
+	InstallGit(url string, stdout, stderr io.Writer) error
+	InstallBin(client *http.Client, repo ghrepo.Interface) error
 	InstallLocal(dir string) error
 	Upgrade(name string, force bool, stdout, stderr io.Writer) error
 	Remove(name string) error

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -2,11 +2,8 @@ package extensions
 
 import (
 	"io"
-	"net/http"
 
-	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/ghrepo"
-	"github.com/cli/cli/v2/pkg/iostreams"
 )
 
 //go:generate moq -rm -out extension_mock.go . Extension
@@ -21,7 +18,7 @@ type Extension interface {
 //go:generate moq -rm -out manager_mock.go . ExtensionManager
 type ExtensionManager interface {
 	List(includeMetadata bool) []Extension
-	Install(*http.Client, ghrepo.Interface, *iostreams.IOStreams, config.Config) error
+	Install(ghrepo.Interface) error
 	InstallLocal(dir string) error
 	Upgrade(name string, force bool, stdout, stderr io.Writer) error
 	Remove(name string) error

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -4,7 +4,9 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/iostreams"
 )
 
 //go:generate moq -rm -out extension_mock.go . Extension
@@ -19,8 +21,9 @@ type Extension interface {
 //go:generate moq -rm -out manager_mock.go . ExtensionManager
 type ExtensionManager interface {
 	List(includeMetadata bool) []Extension
-	InstallGit(url string, stdout, stderr io.Writer) error
-	InstallBin(client *http.Client, repo ghrepo.Interface) error
+	Install(*http.Client, ghrepo.Interface, *iostreams.IOStreams, config.Config) error
+	InstallBin(*http.Client, ghrepo.Interface) error
+	InstallGit(string, io.Writer, io.Writer) error
 	InstallLocal(dir string) error
 	Upgrade(name string, force bool, stdout, stderr io.Writer) error
 	Remove(name string) error

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -22,8 +22,6 @@ type Extension interface {
 type ExtensionManager interface {
 	List(includeMetadata bool) []Extension
 	Install(*http.Client, ghrepo.Interface, *iostreams.IOStreams, config.Config) error
-	InstallBin(*http.Client, ghrepo.Interface) error
-	InstallGit(string, io.Writer, io.Writer) error
 	InstallLocal(dir string) error
 	Upgrade(name string, force bool, stdout, stderr io.Writer) error
 	Remove(name string) error

--- a/pkg/extensions/manager_mock.go
+++ b/pkg/extensions/manager_mock.go
@@ -4,11 +4,8 @@
 package extensions
 
 import (
-	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/ghrepo"
-	"github.com/cli/cli/v2/pkg/iostreams"
 	"io"
-	"net/http"
 	"sync"
 )
 
@@ -28,7 +25,7 @@ var _ ExtensionManager = &ExtensionManagerMock{}
 // 			DispatchFunc: func(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (bool, error) {
 // 				panic("mock out the Dispatch method")
 // 			},
-// 			InstallFunc: func(client *http.Client, interfaceMoqParam ghrepo.Interface, iOStreams *iostreams.IOStreams, configMoqParam config.Config) error {
+// 			InstallFunc: func(interfaceMoqParam ghrepo.Interface) error {
 // 				panic("mock out the Install method")
 // 			},
 // 			InstallLocalFunc: func(dir string) error {
@@ -57,7 +54,7 @@ type ExtensionManagerMock struct {
 	DispatchFunc func(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (bool, error)
 
 	// InstallFunc mocks the Install method.
-	InstallFunc func(client *http.Client, interfaceMoqParam ghrepo.Interface, iOStreams *iostreams.IOStreams, configMoqParam config.Config) error
+	InstallFunc func(interfaceMoqParam ghrepo.Interface) error
 
 	// InstallLocalFunc mocks the InstallLocal method.
 	InstallLocalFunc func(dir string) error
@@ -91,14 +88,8 @@ type ExtensionManagerMock struct {
 		}
 		// Install holds details about calls to the Install method.
 		Install []struct {
-			// Client is the client argument value.
-			Client *http.Client
 			// InterfaceMoqParam is the interfaceMoqParam argument value.
 			InterfaceMoqParam ghrepo.Interface
-			// IOStreams is the iOStreams argument value.
-			IOStreams *iostreams.IOStreams
-			// ConfigMoqParam is the configMoqParam argument value.
-			ConfigMoqParam config.Config
 		}
 		// InstallLocal holds details about calls to the InstallLocal method.
 		InstallLocal []struct {
@@ -211,41 +202,29 @@ func (mock *ExtensionManagerMock) DispatchCalls() []struct {
 }
 
 // Install calls InstallFunc.
-func (mock *ExtensionManagerMock) Install(client *http.Client, interfaceMoqParam ghrepo.Interface, iOStreams *iostreams.IOStreams, configMoqParam config.Config) error {
+func (mock *ExtensionManagerMock) Install(interfaceMoqParam ghrepo.Interface) error {
 	if mock.InstallFunc == nil {
 		panic("ExtensionManagerMock.InstallFunc: method is nil but ExtensionManager.Install was just called")
 	}
 	callInfo := struct {
-		Client            *http.Client
 		InterfaceMoqParam ghrepo.Interface
-		IOStreams         *iostreams.IOStreams
-		ConfigMoqParam    config.Config
 	}{
-		Client:            client,
 		InterfaceMoqParam: interfaceMoqParam,
-		IOStreams:         iOStreams,
-		ConfigMoqParam:    configMoqParam,
 	}
 	mock.lockInstall.Lock()
 	mock.calls.Install = append(mock.calls.Install, callInfo)
 	mock.lockInstall.Unlock()
-	return mock.InstallFunc(client, interfaceMoqParam, iOStreams, configMoqParam)
+	return mock.InstallFunc(interfaceMoqParam)
 }
 
 // InstallCalls gets all the calls that were made to Install.
 // Check the length with:
 //     len(mockedExtensionManager.InstallCalls())
 func (mock *ExtensionManagerMock) InstallCalls() []struct {
-	Client            *http.Client
 	InterfaceMoqParam ghrepo.Interface
-	IOStreams         *iostreams.IOStreams
-	ConfigMoqParam    config.Config
 } {
 	var calls []struct {
-		Client            *http.Client
 		InterfaceMoqParam ghrepo.Interface
-		IOStreams         *iostreams.IOStreams
-		ConfigMoqParam    config.Config
 	}
 	mock.lockInstall.RLock()
 	calls = mock.calls.Install

--- a/pkg/extensions/manager_mock.go
+++ b/pkg/extensions/manager_mock.go
@@ -4,7 +4,9 @@
 package extensions
 
 import (
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"io"
+	"net/http"
 	"sync"
 )
 
@@ -24,8 +26,11 @@ var _ ExtensionManager = &ExtensionManagerMock{}
 // 			DispatchFunc: func(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (bool, error) {
 // 				panic("mock out the Dispatch method")
 // 			},
-// 			InstallFunc: func(url string, stdout io.Writer, stderr io.Writer) error {
-// 				panic("mock out the Install method")
+// 			InstallBinFunc: func(client *http.Client, repo ghrepo.Interface) error {
+// 				panic("mock out the InstallBin method")
+// 			},
+// 			InstallGitFunc: func(url string, stdout io.Writer, stderr io.Writer) error {
+// 				panic("mock out the InstallGit method")
 // 			},
 // 			InstallLocalFunc: func(dir string) error {
 // 				panic("mock out the InstallLocal method")
@@ -52,8 +57,11 @@ type ExtensionManagerMock struct {
 	// DispatchFunc mocks the Dispatch method.
 	DispatchFunc func(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (bool, error)
 
-	// InstallFunc mocks the Install method.
-	InstallFunc func(url string, stdout io.Writer, stderr io.Writer) error
+	// InstallBinFunc mocks the InstallBin method.
+	InstallBinFunc func(client *http.Client, repo ghrepo.Interface) error
+
+	// InstallGitFunc mocks the InstallGit method.
+	InstallGitFunc func(url string, stdout io.Writer, stderr io.Writer) error
 
 	// InstallLocalFunc mocks the InstallLocal method.
 	InstallLocalFunc func(dir string) error
@@ -85,8 +93,15 @@ type ExtensionManagerMock struct {
 			// Stderr is the stderr argument value.
 			Stderr io.Writer
 		}
-		// Install holds details about calls to the Install method.
-		Install []struct {
+		// InstallBin holds details about calls to the InstallBin method.
+		InstallBin []struct {
+			// Client is the client argument value.
+			Client *http.Client
+			// Repo is the repo argument value.
+			Repo ghrepo.Interface
+		}
+		// InstallGit holds details about calls to the InstallGit method.
+		InstallGit []struct {
 			// URL is the url argument value.
 			URL string
 			// Stdout is the stdout argument value.
@@ -123,7 +138,8 @@ type ExtensionManagerMock struct {
 	}
 	lockCreate       sync.RWMutex
 	lockDispatch     sync.RWMutex
-	lockInstall      sync.RWMutex
+	lockInstallBin   sync.RWMutex
+	lockInstallGit   sync.RWMutex
 	lockInstallLocal sync.RWMutex
 	lockList         sync.RWMutex
 	lockRemove       sync.RWMutex
@@ -204,10 +220,45 @@ func (mock *ExtensionManagerMock) DispatchCalls() []struct {
 	return calls
 }
 
-// Install calls InstallFunc.
-func (mock *ExtensionManagerMock) Install(url string, stdout io.Writer, stderr io.Writer) error {
-	if mock.InstallFunc == nil {
-		panic("ExtensionManagerMock.InstallFunc: method is nil but ExtensionManager.Install was just called")
+// InstallBin calls InstallBinFunc.
+func (mock *ExtensionManagerMock) InstallBin(client *http.Client, repo ghrepo.Interface) error {
+	if mock.InstallBinFunc == nil {
+		panic("ExtensionManagerMock.InstallBinFunc: method is nil but ExtensionManager.InstallBin was just called")
+	}
+	callInfo := struct {
+		Client *http.Client
+		Repo   ghrepo.Interface
+	}{
+		Client: client,
+		Repo:   repo,
+	}
+	mock.lockInstallBin.Lock()
+	mock.calls.InstallBin = append(mock.calls.InstallBin, callInfo)
+	mock.lockInstallBin.Unlock()
+	return mock.InstallBinFunc(client, repo)
+}
+
+// InstallBinCalls gets all the calls that were made to InstallBin.
+// Check the length with:
+//     len(mockedExtensionManager.InstallBinCalls())
+func (mock *ExtensionManagerMock) InstallBinCalls() []struct {
+	Client *http.Client
+	Repo   ghrepo.Interface
+} {
+	var calls []struct {
+		Client *http.Client
+		Repo   ghrepo.Interface
+	}
+	mock.lockInstallBin.RLock()
+	calls = mock.calls.InstallBin
+	mock.lockInstallBin.RUnlock()
+	return calls
+}
+
+// InstallGit calls InstallGitFunc.
+func (mock *ExtensionManagerMock) InstallGit(url string, stdout io.Writer, stderr io.Writer) error {
+	if mock.InstallGitFunc == nil {
+		panic("ExtensionManagerMock.InstallGitFunc: method is nil but ExtensionManager.InstallGit was just called")
 	}
 	callInfo := struct {
 		URL    string
@@ -218,16 +269,16 @@ func (mock *ExtensionManagerMock) Install(url string, stdout io.Writer, stderr i
 		Stdout: stdout,
 		Stderr: stderr,
 	}
-	mock.lockInstall.Lock()
-	mock.calls.Install = append(mock.calls.Install, callInfo)
-	mock.lockInstall.Unlock()
-	return mock.InstallFunc(url, stdout, stderr)
+	mock.lockInstallGit.Lock()
+	mock.calls.InstallGit = append(mock.calls.InstallGit, callInfo)
+	mock.lockInstallGit.Unlock()
+	return mock.InstallGitFunc(url, stdout, stderr)
 }
 
-// InstallCalls gets all the calls that were made to Install.
+// InstallGitCalls gets all the calls that were made to InstallGit.
 // Check the length with:
-//     len(mockedExtensionManager.InstallCalls())
-func (mock *ExtensionManagerMock) InstallCalls() []struct {
+//     len(mockedExtensionManager.InstallGitCalls())
+func (mock *ExtensionManagerMock) InstallGitCalls() []struct {
 	URL    string
 	Stdout io.Writer
 	Stderr io.Writer
@@ -237,9 +288,9 @@ func (mock *ExtensionManagerMock) InstallCalls() []struct {
 		Stdout io.Writer
 		Stderr io.Writer
 	}
-	mock.lockInstall.RLock()
-	calls = mock.calls.Install
-	mock.lockInstall.RUnlock()
+	mock.lockInstallGit.RLock()
+	calls = mock.calls.InstallGit
+	mock.lockInstallGit.RUnlock()
 	return calls
 }
 

--- a/pkg/extensions/manager_mock.go
+++ b/pkg/extensions/manager_mock.go
@@ -31,12 +31,6 @@ var _ ExtensionManager = &ExtensionManagerMock{}
 // 			InstallFunc: func(client *http.Client, interfaceMoqParam ghrepo.Interface, iOStreams *iostreams.IOStreams, configMoqParam config.Config) error {
 // 				panic("mock out the Install method")
 // 			},
-// 			InstallBinFunc: func(client *http.Client, interfaceMoqParam ghrepo.Interface) error {
-// 				panic("mock out the InstallBin method")
-// 			},
-// 			InstallGitFunc: func(s string, writer1 io.Writer, writer2 io.Writer) error {
-// 				panic("mock out the InstallGit method")
-// 			},
 // 			InstallLocalFunc: func(dir string) error {
 // 				panic("mock out the InstallLocal method")
 // 			},
@@ -64,12 +58,6 @@ type ExtensionManagerMock struct {
 
 	// InstallFunc mocks the Install method.
 	InstallFunc func(client *http.Client, interfaceMoqParam ghrepo.Interface, iOStreams *iostreams.IOStreams, configMoqParam config.Config) error
-
-	// InstallBinFunc mocks the InstallBin method.
-	InstallBinFunc func(client *http.Client, interfaceMoqParam ghrepo.Interface) error
-
-	// InstallGitFunc mocks the InstallGit method.
-	InstallGitFunc func(s string, writer1 io.Writer, writer2 io.Writer) error
 
 	// InstallLocalFunc mocks the InstallLocal method.
 	InstallLocalFunc func(dir string) error
@@ -112,22 +100,6 @@ type ExtensionManagerMock struct {
 			// ConfigMoqParam is the configMoqParam argument value.
 			ConfigMoqParam config.Config
 		}
-		// InstallBin holds details about calls to the InstallBin method.
-		InstallBin []struct {
-			// Client is the client argument value.
-			Client *http.Client
-			// InterfaceMoqParam is the interfaceMoqParam argument value.
-			InterfaceMoqParam ghrepo.Interface
-		}
-		// InstallGit holds details about calls to the InstallGit method.
-		InstallGit []struct {
-			// S is the s argument value.
-			S string
-			// Writer1 is the writer1 argument value.
-			Writer1 io.Writer
-			// Writer2 is the writer2 argument value.
-			Writer2 io.Writer
-		}
 		// InstallLocal holds details about calls to the InstallLocal method.
 		InstallLocal []struct {
 			// Dir is the dir argument value.
@@ -158,8 +130,6 @@ type ExtensionManagerMock struct {
 	lockCreate       sync.RWMutex
 	lockDispatch     sync.RWMutex
 	lockInstall      sync.RWMutex
-	lockInstallBin   sync.RWMutex
-	lockInstallGit   sync.RWMutex
 	lockInstallLocal sync.RWMutex
 	lockList         sync.RWMutex
 	lockRemove       sync.RWMutex
@@ -280,80 +250,6 @@ func (mock *ExtensionManagerMock) InstallCalls() []struct {
 	mock.lockInstall.RLock()
 	calls = mock.calls.Install
 	mock.lockInstall.RUnlock()
-	return calls
-}
-
-// InstallBin calls InstallBinFunc.
-func (mock *ExtensionManagerMock) InstallBin(client *http.Client, interfaceMoqParam ghrepo.Interface) error {
-	if mock.InstallBinFunc == nil {
-		panic("ExtensionManagerMock.InstallBinFunc: method is nil but ExtensionManager.InstallBin was just called")
-	}
-	callInfo := struct {
-		Client            *http.Client
-		InterfaceMoqParam ghrepo.Interface
-	}{
-		Client:            client,
-		InterfaceMoqParam: interfaceMoqParam,
-	}
-	mock.lockInstallBin.Lock()
-	mock.calls.InstallBin = append(mock.calls.InstallBin, callInfo)
-	mock.lockInstallBin.Unlock()
-	return mock.InstallBinFunc(client, interfaceMoqParam)
-}
-
-// InstallBinCalls gets all the calls that were made to InstallBin.
-// Check the length with:
-//     len(mockedExtensionManager.InstallBinCalls())
-func (mock *ExtensionManagerMock) InstallBinCalls() []struct {
-	Client            *http.Client
-	InterfaceMoqParam ghrepo.Interface
-} {
-	var calls []struct {
-		Client            *http.Client
-		InterfaceMoqParam ghrepo.Interface
-	}
-	mock.lockInstallBin.RLock()
-	calls = mock.calls.InstallBin
-	mock.lockInstallBin.RUnlock()
-	return calls
-}
-
-// InstallGit calls InstallGitFunc.
-func (mock *ExtensionManagerMock) InstallGit(s string, writer1 io.Writer, writer2 io.Writer) error {
-	if mock.InstallGitFunc == nil {
-		panic("ExtensionManagerMock.InstallGitFunc: method is nil but ExtensionManager.InstallGit was just called")
-	}
-	callInfo := struct {
-		S       string
-		Writer1 io.Writer
-		Writer2 io.Writer
-	}{
-		S:       s,
-		Writer1: writer1,
-		Writer2: writer2,
-	}
-	mock.lockInstallGit.Lock()
-	mock.calls.InstallGit = append(mock.calls.InstallGit, callInfo)
-	mock.lockInstallGit.Unlock()
-	return mock.InstallGitFunc(s, writer1, writer2)
-}
-
-// InstallGitCalls gets all the calls that were made to InstallGit.
-// Check the length with:
-//     len(mockedExtensionManager.InstallGitCalls())
-func (mock *ExtensionManagerMock) InstallGitCalls() []struct {
-	S       string
-	Writer1 io.Writer
-	Writer2 io.Writer
-} {
-	var calls []struct {
-		S       string
-		Writer1 io.Writer
-		Writer2 io.Writer
-	}
-	mock.lockInstallGit.RLock()
-	calls = mock.calls.InstallGit
-	mock.lockInstallGit.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
This pull request teaches `gh extension install` how to detect, download, and install a precompiled ("binary") extension.

This is not full support for binary extensions; see #4194 for the remaining TODOs. However, this PR can be merged without breaking any existing functionality or advertising any new functionality.

I included tests.
