### PR TITLE
Publish docs site using a deploy key instead of PAT

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -33,7 +33,7 @@ jobs:
           repository: github/cli.github.com
           path: site
           fetch-depth: 0
-          token: ${{secrets.SITE_GITHUB_TOKEN}}
+          ssh-key: ${{secrets.SITE_SSH_KEY}}
       - name: Update site man pages
         env:
           GIT_COMMITTER_NAME: cli automation


### PR DESCRIPTION
I'd like to decommission SITE_GITHUB_TOKEN as it's a PAT that has write access to all my `github/*` repositories. Instead, I've created a deploy key that only has access to `github/cli.github.com`.

    ssh-keygen -t ed25519 -C "gh docs push" -N "" -f ~/.ssh/gh-docs-publish
    gh repo -R github/cli.github.com deploy-key add ~/.ssh/gh-docs-publish.pub

    # testing:
    GIT_SSH_COMMAND='ssh -i $HOME/.ssh/gh-docs-publish' git push ...

Ref. https://github.com/cli/cli/pull/4302