### PR TITLE
Allow user input for git fetch in repo sync

### DIFF
--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -134,7 +134,7 @@ func syncLocalRepo(opts *SyncOptions) error {
 		}
 	}
 
-	// Git fetch might require input from user, so do it before starting progess indicator.
+	// Git fetch might require input from user, so do it before starting progress indicator.
 	if err := opts.Git.Fetch(remote, fmt.Sprintf("refs/heads/%s", opts.Branch)); err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -34,7 +34,7 @@ func NewCmdSync(f *cmdutil.Factory, runF func(*SyncOptions) error) *cobra.Comman
 		IO:         f.IOStreams,
 		BaseRepo:   f.BaseRepo,
 		Remotes:    f.Remotes,
-		Git:        &gitExecuter{},
+		Git:        &gitExecuter{io: f.IOStreams},
 	}
 
 	cmd := &cobra.Command{
@@ -134,6 +134,11 @@ func syncLocalRepo(opts *SyncOptions) error {
 		}
 	}
 
+	// Git fetch might require input from user, so do it before starting progess indicator.
+	if err := opts.Git.Fetch(remote, fmt.Sprintf("refs/heads/%s", opts.Branch)); err != nil {
+		return err
+	}
+
 	opts.IO.StartProgressIndicator()
 	err = executeLocalRepoSync(srcRepo, remote, opts)
 	opts.IO.StopProgressIndicator()
@@ -231,10 +236,6 @@ func executeLocalRepoSync(srcRepo ghrepo.Interface, remote string, opts *SyncOpt
 	git := opts.Git
 	branch := opts.Branch
 	useForce := opts.Force
-
-	if err := git.Fetch(remote, fmt.Sprintf("refs/heads/%s", branch)); err != nil {
-		return err
-	}
 
 	hasLocalBranch := git.HasLocalBranch(branch)
 	if hasLocalBranch {


### PR DESCRIPTION
This PR modifies `repo sync` to forward IO streams to the `git fetch` command.  

Fixes https://github.com/cli/cli/issues/4295