### PR TITLE
Add 'git+https' to list of supported URL protocols

### DIFF
--- a/git/url.go
+++ b/git/url.go
@@ -14,6 +14,7 @@ func isSupportedProtocol(u string) bool {
 		strings.HasPrefix(u, "git+ssh:") ||
 		strings.HasPrefix(u, "git:") ||
 		strings.HasPrefix(u, "http:") ||
+		strings.HasPrefix(u, "git+https:") ||
 		strings.HasPrefix(u, "https:")
 }
 
@@ -41,6 +42,10 @@ func ParseURL(rawURL string) (u *url.URL, err error) {
 
 	if u.Scheme == "git+ssh" {
 		u.Scheme = "ssh"
+	}
+
+	if u.Scheme == "git+https" {
+		u.Scheme = "https"
 	}
 
 	if u.Scheme != "ssh" {

--- a/git/url_test.go
+++ b/git/url_test.go
@@ -29,8 +29,23 @@ func TestIsURL(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "git with extension",
+			url:  "git://example.com/owner/repo.git",
+			want: true,
+		},
+		{
+			name: "git+ssh",
+			url:  "git+ssh://git@example.com/owner/repo.git",
+			want: true,
+		},
+		{
 			name: "https",
 			url:  "https://example.com/owner/repo.git",
+			want: true,
+		},
+		{
+			name: "git+https",
+			url:  "git+https://example.com/owner/repo.git",
 			want: true,
 		},
 		{
@@ -116,6 +131,16 @@ func TestParseURL(t *testing.T) {
 			url:  "git+ssh://example.com/owner/repo.git",
 			want: url{
 				Scheme: "ssh",
+				User:   "",
+				Host:   "example.com",
+				Path:   "/owner/repo.git",
+			},
+		},
+		{
+			name: "git+https",
+			url:  "git+https://example.com/owner/repo.git",
+			want: url{
+				Scheme: "https",
 				User:   "",
 				Host:   "example.com",
 				Path:   "/owner/repo.git",


### PR DESCRIPTION
Fixes #4346, allowing commands such as `gh release --repo` to support most npm package git remotes as-is.
