### PR TITLE
Also set `pushRemote` on `gh pr checkout` from fork

### DIFF
--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -220,7 +220,11 @@ func cmdsForMissingRemote(pr *api.PullRequest, baseURLOrName, repoHost, defaultB
 		mergeRef = fmt.Sprintf("refs/heads/%s", pr.HeadRefName)
 	}
 	if missingMergeConfigForBranch(localBranch) {
+		// .remote is needed for `git pull` to work
+		// .pushRemote is needed for `git push` to work, if user has set `remote.pushDefault`.
+		// see https://git-scm.com/docs/git-config#Documentation/git-config.txt-branchltnamegtremote
 		cmds = append(cmds, []string{"git", "config", fmt.Sprintf("branch.%s.remote", localBranch), remote})
+		cmds = append(cmds, []string{"git", "config", fmt.Sprintf("branch.%s.pushRemote", localBranch), remote})
 		cmds = append(cmds, []string{"git", "config", fmt.Sprintf("branch.%s.merge", localBranch), mergeRef})
 	}
 

--- a/pkg/cmd/pr/checkout/checkout_test.go
+++ b/pkg/cmd/pr/checkout/checkout_test.go
@@ -97,6 +97,7 @@ func Test_checkoutRun(t *testing.T) {
 				cs.Register(`git config branch\.feature\.merge`, 1, "")
 				cs.Register(`git checkout feature`, 0, "")
 				cs.Register(`git config branch\.feature\.remote origin`, 0, "")
+				cs.Register(`git config branch\.feature\.pushRemote origin`, 0, "")
 				cs.Register(`git config branch\.feature\.merge refs/pull/123/head`, 0, "")
 			},
 		},
@@ -152,6 +153,7 @@ func Test_checkoutRun(t *testing.T) {
 				cs.Register(`git fetch origin refs/pull/123/head:foobar`, 0, "")
 				cs.Register(`git checkout foobar`, 0, "")
 				cs.Register(`git config branch\.foobar\.remote https://github.com/hubot/REPO.git`, 0, "")
+				cs.Register(`git config branch\.foobar\.pushRemote https://github.com/hubot/REPO.git`, 0, "")
 				cs.Register(`git config branch\.foobar\.merge refs/heads/feature`, 0, "")
 			},
 		},
@@ -343,6 +345,7 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 	cs.Register(`git config branch\.feature\.merge`, 1, "")
 	cs.Register(`git checkout feature`, 0, "")
 	cs.Register(`git config branch\.feature\.remote origin`, 0, "")
+	cs.Register(`git config branch\.feature\.pushRemote origin`, 0, "")
 	cs.Register(`git config branch\.feature\.merge refs/pull/123/head`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
@@ -442,6 +445,7 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 	cs.Register(`git config branch\.feature\.merge`, 1, "")
 	cs.Register(`git checkout feature`, 0, "")
 	cs.Register(`git config branch\.feature\.remote https://github\.com/hubot/REPO\.git`, 0, "")
+	cs.Register(`git config branch\.feature\.pushRemote https://github\.com/hubot/REPO\.git`, 0, "")
 	cs.Register(`git config branch\.feature\.merge refs/heads/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)


### PR DESCRIPTION
As explained in https://git-scm.com/docs/git-config#Documentation/git-config.txt-branchltnamegtremote if you have `remote.pushDefault` set in your global gitconfig (like I do), then _that_ setting will take precedence over `branch.<name>.remote` :disappointed: 

However, `branch.<name>.pushRemote` will take precedence over your `remote.pushDefault`  setting, such that `gh pr checkout 123 && make changes && git push` will just work, even if you have `remote.pushDefault` set :muscle:

EDIT: After some discussion, we found out we should keep setting `.remote` such that `git pull` will continue working.