### PR TITLE
binary extensions list & upgrade

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -132,7 +132,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					if len(args) > 0 {
 						name = normalizeExtensionSelector(args[0])
 					}
-					return m.Upgrade(name, flagForce, io.Out, io.ErrOut)
+					return m.Upgrade(name, flagForce)
 				},
 			}
 			cmd.Flags().BoolVar(&flagAll, "all", false, "Upgrade all extensions")

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -1,7 +1,6 @@
 package extension
 
 import (
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -94,7 +93,7 @@ func TestNewCmdExtension(t *testing.T) {
 			name: "upgrade an extension",
 			args: []string{"upgrade", "hello"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.UpgradeFunc = func(name string, force bool, out, errOut io.Writer) error {
+				em.UpgradeFunc = func(name string, force bool) error {
 					return nil
 				}
 				return func(t *testing.T) {
@@ -108,7 +107,7 @@ func TestNewCmdExtension(t *testing.T) {
 			name: "upgrade an extension gh-prefix",
 			args: []string{"upgrade", "gh-hello"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.UpgradeFunc = func(name string, force bool, out, errOut io.Writer) error {
+				em.UpgradeFunc = func(name string, force bool) error {
 					return nil
 				}
 				return func(t *testing.T) {
@@ -122,7 +121,7 @@ func TestNewCmdExtension(t *testing.T) {
 			name: "upgrade an extension full name",
 			args: []string{"upgrade", "monalisa/gh-hello"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.UpgradeFunc = func(name string, force bool, out, errOut io.Writer) error {
+				em.UpgradeFunc = func(name string, force bool) error {
 					return nil
 				}
 				return func(t *testing.T) {
@@ -136,7 +135,7 @@ func TestNewCmdExtension(t *testing.T) {
 			name: "upgrade all",
 			args: []string{"upgrade", "--all"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.UpgradeFunc = func(name string, force bool, out, errOut io.Writer) error {
+				em.UpgradeFunc = func(name string, force bool) error {
 					return nil
 				}
 				return func(t *testing.T) {

--- a/pkg/cmd/extension/extension.go
+++ b/pkg/cmd/extension/extension.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+const manifestName = "manifest.yml"
+
 type Extension struct {
 	path            string
 	url             string

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -70,12 +70,7 @@ func downloadAsset(httpClient *http.Client, asset releaseAsset, destPath string)
 		return api.HandleHTTPError(resp)
 	}
 
-	mode := os.O_WRONLY | os.O_CREATE | os.O_EXCL
-	if _, err := os.Stat(destPath); err == nil {
-		mode = os.O_WRONLY | os.O_EXCL
-	}
-
-	f, err := os.OpenFile(destPath, mode, 0755)
+	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -70,7 +70,12 @@ func downloadAsset(httpClient *http.Client, asset releaseAsset, destPath string)
 		return api.HandleHTTPError(resp)
 	}
 
-	f, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0755)
+	mode := os.O_WRONLY | os.O_CREATE | os.O_EXCL
+	if _, err := os.Stat(destPath); err == nil {
+		mode = os.O_WRONLY | os.O_EXCL
+	}
+
+	f, err := os.OpenFile(destPath, mode, 0755)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -306,7 +306,7 @@ func (m *Manager) installGit(cloneURL string, stdout, stderr io.Writer) error {
 
 var localExtensionUpgradeError = errors.New("local extensions can not be upgraded")
 
-func (m *Manager) Upgrade(name string, force bool, stdout, stderr io.Writer) error {
+func (m *Manager) Upgrade(name string, force bool) error {
 	exe, err := m.lookPath("git")
 	if err != nil {
 		return err
@@ -320,14 +320,14 @@ func (m *Manager) Upgrade(name string, force bool, stdout, stderr io.Writer) err
 	someUpgraded := false
 	for _, f := range exts {
 		if name == "" {
-			fmt.Fprintf(stdout, "[%s]: ", f.Name())
+			fmt.Fprintf(m.io.Out, "[%s]: ", f.Name())
 		} else if f.Name() != name {
 			continue
 		}
 
 		if f.IsLocal() {
 			if name == "" {
-				fmt.Fprintf(stdout, "%s\n", localExtensionUpgradeError)
+				fmt.Fprintf(m.io.Out, "%s\n", localExtensionUpgradeError)
 			} else {
 				err = localExtensionUpgradeError
 			}
@@ -344,7 +344,7 @@ func (m *Manager) Upgrade(name string, force bool, stdout, stderr io.Writer) err
 			pullCmd := m.newCommand(exe, "-C", dir, "--git-dir="+filepath.Join(dir, ".git"), "pull", "--ff-only")
 			cmds = []*exec.Cmd{pullCmd}
 		}
-		if e := runCmds(cmds, stdout, stderr); e != nil {
+		if e := runCmds(cmds, m.io.Out, m.io.ErrOut); e != nil {
 			err = e
 		}
 		someUpgraded = true

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -130,13 +130,13 @@ func (m *Manager) list(includeMetadata bool) ([]extensions.Extension, error) {
 func (m *Manager) parseExtensionDir(fi fs.FileInfo, includeMetadata bool) (*Extension, error) {
 	id := m.installDir()
 	if _, err := os.Stat(filepath.Join(id, fi.Name(), manifestName)); err == nil {
-		return m.parseBinaryExtension(fi, includeMetadata)
+		return m.parseBinaryExtensionDir(fi, includeMetadata)
 	}
 
-	return m.parseGitExtension(fi, includeMetadata)
+	return m.parseGitExtensionDir(fi, includeMetadata)
 }
 
-func (m *Manager) parseBinaryExtension(fi fs.FileInfo, includeMetadata bool) (*Extension, error) {
+func (m *Manager) parseBinaryExtensionDir(fi fs.FileInfo, includeMetadata bool) (*Extension, error) {
 	id := m.installDir()
 	exePath := filepath.Join(id, fi.Name(), fi.Name())
 	manifestPath := filepath.Join(id, fi.Name(), manifestName)
@@ -175,7 +175,7 @@ func (m *Manager) parseBinaryExtension(fi fs.FileInfo, includeMetadata bool) (*E
 	}, nil
 }
 
-func (m *Manager) parseGitExtension(fi fs.FileInfo, includeMetadata bool) (*Extension, error) {
+func (m *Manager) parseGitExtensionDir(fi fs.FileInfo, includeMetadata bool) (*Extension, error) {
 	// TODO untangle local from this since local might be binary or git
 	id := m.installDir()
 	var remoteUrl string

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -59,17 +59,21 @@ func TestManager_List(t *testing.T) {
 	assert.NoError(t, stubExtension(filepath.Join(tempDir, "extensions", "gh-hello", "gh-hello")))
 	assert.NoError(t, stubExtension(filepath.Join(tempDir, "extensions", "gh-two", "gh-two")))
 
+	assert.NoError(t, stubBinaryExtension(
+		filepath.Join(tempDir, "extensions", "gh-bin-ext"),
+		binManifest{
+			Owner: "owner",
+			Name:  "gh-bin-ext",
+			Host:  "example.com",
+			Tag:   "v1.0.1",
+		}))
+
 	m := newTestManager(tempDir, nil, nil)
 	exts := m.List(false)
-	assert.Equal(t, 2, len(exts))
-	assert.Equal(t, "hello", exts[0].Name())
-	assert.Equal(t, "two", exts[1].Name())
-}
-
-func TestManager_List_Binary(t *testing.T) {
-	//tempDir := t.TempDir()
-	// TODO
-
+	assert.Equal(t, 3, len(exts))
+	assert.Equal(t, "bin-ext", exts[0].Name())
+	assert.Equal(t, "hello", exts[1].Name())
+	assert.Equal(t, "two", exts[2].Name())
 }
 
 func TestManager_Dispatch(t *testing.T) {
@@ -212,13 +216,15 @@ func TestManager_Upgrade_BinaryExtension(t *testing.T) {
 	reg := httpmock.Registry{}
 	defer reg.Verify(t)
 	client := http.Client{Transport: &reg}
-	err := stubBinaryExtension(filepath.Join(tempDir, "extensions", "gh-bin-ext"), binManifest{
-		Owner: "owner",
-		Name:  "gh-bin-ext",
-		Host:  "example.com",
-		Tag:   "v1.0.1",
-	})
-	assert.NoError(t, err)
+
+	assert.NoError(t, stubBinaryExtension(
+		filepath.Join(tempDir, "extensions", "gh-bin-ext"),
+		binManifest{
+			Owner: "owner",
+			Name:  "gh-bin-ext",
+			Host:  "example.com",
+			Tag:   "v1.0.1",
+		}))
 
 	m := newTestManager(tempDir, &client, io)
 	reg.Register(
@@ -249,7 +255,7 @@ func TestManager_Upgrade_BinaryExtension(t *testing.T) {
 		httpmock.REST("GET", "release/cool2"),
 		httpmock.StringResponse("FAKE UPGRADED BINARY"))
 
-	err = m.Upgrade("bin-ext", false)
+	err := m.Upgrade("bin-ext", false)
 	assert.NoError(t, err)
 
 	manifest, err := os.ReadFile(filepath.Join(tempDir, "extensions/gh-bin-ext", manifestName))

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -66,6 +66,10 @@ func TestManager_List(t *testing.T) {
 	assert.Equal(t, "two", exts[1].Name())
 }
 
+func TestManager_List_Binary(t *testing.T) {
+	// TODO
+}
+
 func TestManager_Dispatch(t *testing.T) {
 	tempDir := t.TempDir()
 	extPath := filepath.Join(tempDir, "extensions", "gh-hello", "gh-hello")
@@ -197,6 +201,10 @@ func TestManager_Upgrade_NoExtensions(t *testing.T) {
 	assert.EqualError(t, err, "no extensions installed")
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
+}
+
+func TestManager_Upgrade_BinaryExtension(t *testing.T) {
+	// TODO
 }
 
 func TestManager_Install_git(t *testing.T) {

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -67,7 +67,9 @@ func TestManager_List(t *testing.T) {
 }
 
 func TestManager_List_Binary(t *testing.T) {
+	//tempDir := t.TempDir()
 	// TODO
+
 }
 
 func TestManager_Dispatch(t *testing.T) {
@@ -206,50 +208,19 @@ func TestManager_Upgrade_NoExtensions(t *testing.T) {
 func TestManager_Upgrade_BinaryExtension(t *testing.T) {
 	tempDir := t.TempDir()
 
-	installReg := httpmock.Registry{}
-	defer installReg.Verify(t)
-	installClient := http.Client{Transport: &installReg}
-
 	io, _, _, _ := iostreams.Test()
-	m := newTestManager(tempDir, &installClient, io)
-	repo := ghrepo.NewWithHost("owner", "gh-bin-ext", "example.com")
+	reg := httpmock.Registry{}
+	defer reg.Verify(t)
+	client := http.Client{Transport: &reg}
+	stubBinaryExtension(filepath.Join(tempDir, "extensions", "gh-bin-ext"), binManifest{
+		Owner: "owner",
+		Name:  "gh-bin-ext",
+		Host:  "example.com",
+		Tag:   "v1.0.1",
+	})
 
-	installReg.Register(
-		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
-		httpmock.JSONResponse(
-			release{
-				Assets: []releaseAsset{
-					{
-						Name:   "gh-bin-ext-windows-amd64",
-						APIURL: "https://example.com/release/cool",
-					},
-				},
-			}))
-	installReg.Register(
-		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
-		httpmock.JSONResponse(
-			release{
-				Tag: "v1.0.1",
-				Assets: []releaseAsset{
-					{
-						Name:   "gh-bin-ext-windows-amd64",
-						APIURL: "https://example.com/release/cool",
-					},
-				},
-			}))
-	installReg.Register(
-		httpmock.REST("GET", "release/cool"),
-		httpmock.StringResponse("FAKE BINARY"))
-
-	err := m.Install(repo)
-	assert.NoError(t, err)
-
-	upgradeReg := httpmock.Registry{}
-	defer upgradeReg.Verify(t)
-	upgradeClient := http.Client{Transport: &upgradeReg}
-
-	um := newTestManager(tempDir, &upgradeClient, io)
-	upgradeReg.Register(
+	m := newTestManager(tempDir, &client, io)
+	reg.Register(
 		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
 		httpmock.JSONResponse(
 			release{
@@ -261,7 +232,7 @@ func TestManager_Upgrade_BinaryExtension(t *testing.T) {
 					},
 				},
 			}))
-	upgradeReg.Register(
+	reg.Register(
 		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
 		httpmock.JSONResponse(
 			release{
@@ -273,11 +244,11 @@ func TestManager_Upgrade_BinaryExtension(t *testing.T) {
 					},
 				},
 			}))
-	upgradeReg.Register(
+	reg.Register(
 		httpmock.REST("GET", "release/cool2"),
 		httpmock.StringResponse("FAKE UPGRADED BINARY"))
 
-	err = um.Upgrade("bin-ext", false)
+	err := m.Upgrade("bin-ext", false)
 	assert.NoError(t, err)
 
 	manifest, err := os.ReadFile(filepath.Join(tempDir, "extensions/gh-bin-ext", manifestName))
@@ -499,4 +470,11 @@ func stubLocalExtension(tempDir, path string) error {
 		return err
 	}
 	return f.Close()
+}
+
+func stubBinaryExtension(path string, bm binManifest) error {
+	// TODO make directory
+	// TODO write manifest file
+	// TODO write fake binary file
+	return nil
 }

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -319,7 +319,7 @@ func TestManager_Install_binary(t *testing.T) {
 	err := m.Install(repo)
 	assert.NoError(t, err)
 
-	manifest, err := os.ReadFile(filepath.Join(tempDir, "extensions/gh-bin-ext/manifest.yml"))
+	manifest, err := os.ReadFile(filepath.Join(tempDir, "extensions/gh-bin-ext", manifestName))
 	assert.NoError(t, err)
 
 	var bm binManifest

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -108,11 +108,11 @@ func TestManager_Upgrade_AllExtensions(t *testing.T) {
 	assert.NoError(t, stubExtension(filepath.Join(tempDir, "extensions", "gh-two", "gh-two")))
 	assert.NoError(t, stubLocalExtension(tempDir, filepath.Join(tempDir, "extensions", "gh-local", "gh-local")))
 
-	m := newTestManager(tempDir, nil, nil)
+	io, _, stdout, stderr := iostreams.Test()
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	err := m.Upgrade("", false, stdout, stderr)
+	m := newTestManager(tempDir, nil, io)
+
+	err := m.Upgrade("", false)
 	assert.NoError(t, err)
 
 	assert.Equal(t, heredoc.Docf(
@@ -133,11 +133,11 @@ func TestManager_Upgrade_RemoteExtension(t *testing.T) {
 	tempDir := t.TempDir()
 	assert.NoError(t, stubExtension(filepath.Join(tempDir, "extensions", "gh-remote", "gh-remote")))
 
-	m := newTestManager(tempDir, nil, nil)
+	io, _, stdout, stderr := iostreams.Test()
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	err := m.Upgrade("remote", false, stdout, stderr)
+	m := newTestManager(tempDir, nil, io)
+
+	err := m.Upgrade("remote", false)
 	assert.NoError(t, err)
 	assert.Equal(t, heredoc.Docf(
 		`
@@ -153,11 +153,10 @@ func TestManager_Upgrade_LocalExtension(t *testing.T) {
 	tempDir := t.TempDir()
 	assert.NoError(t, stubLocalExtension(tempDir, filepath.Join(tempDir, "extensions", "gh-local", "gh-local")))
 
-	m := newTestManager(tempDir, nil, nil)
+	io, _, stdout, stderr := iostreams.Test()
+	m := newTestManager(tempDir, nil, io)
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	err := m.Upgrade("local", false, stdout, stderr)
+	err := m.Upgrade("local", false)
 	assert.EqualError(t, err, "local extensions can not be upgraded")
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
@@ -170,11 +169,10 @@ func TestManager_Upgrade_Force(t *testing.T) {
 
 	assert.NoError(t, stubExtension(filepath.Join(tempDir, "extensions", "gh-remote", "gh-remote")))
 
-	m := newTestManager(tempDir, nil, nil)
+	io, _, stdout, stderr := iostreams.Test()
+	m := newTestManager(tempDir, nil, io)
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	err := m.Upgrade("remote", true, stdout, stderr)
+	err := m.Upgrade("remote", true)
 	assert.NoError(t, err)
 	assert.Equal(t, heredoc.Docf(
 		`
@@ -192,11 +190,10 @@ func TestManager_Upgrade_Force(t *testing.T) {
 func TestManager_Upgrade_NoExtensions(t *testing.T) {
 	tempDir := t.TempDir()
 
-	m := newTestManager(tempDir, nil, nil)
+	io, _, stdout, stderr := iostreams.Test()
+	m := newTestManager(tempDir, nil, io)
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-	err := m.Upgrade("", false, stdout, stderr)
+	err := m.Upgrade("", false)
 	assert.EqualError(t, err, "no extensions installed")
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -20,7 +20,7 @@ type ExtensionManager interface {
 	List(includeMetadata bool) []Extension
 	Install(ghrepo.Interface) error
 	InstallLocal(dir string) error
-	Upgrade(name string, force bool, stdout, stderr io.Writer) error
+	Upgrade(name string, force bool) error
 	Remove(name string) error
 	Dispatch(args []string, stdin io.Reader, stdout, stderr io.Writer) (bool, error)
 	Create(name string) error

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -8,8 +8,8 @@ import (
 
 //go:generate moq -rm -out extension_mock.go . Extension
 type Extension interface {
-	Name() string
-	Path() string
+	Name() string // Extension Name without gh-
+	Path() string // Path to executable
 	URL() string
 	IsLocal() bool
 	UpdateAvailable() bool

--- a/pkg/extensions/manager_mock.go
+++ b/pkg/extensions/manager_mock.go
@@ -37,7 +37,7 @@ var _ ExtensionManager = &ExtensionManagerMock{}
 // 			RemoveFunc: func(name string) error {
 // 				panic("mock out the Remove method")
 // 			},
-// 			UpgradeFunc: func(name string, force bool, stdout io.Writer, stderr io.Writer) error {
+// 			UpgradeFunc: func(name string, force bool) error {
 // 				panic("mock out the Upgrade method")
 // 			},
 // 		}
@@ -66,7 +66,7 @@ type ExtensionManagerMock struct {
 	RemoveFunc func(name string) error
 
 	// UpgradeFunc mocks the Upgrade method.
-	UpgradeFunc func(name string, force bool, stdout io.Writer, stderr io.Writer) error
+	UpgradeFunc func(name string, force bool) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -112,10 +112,6 @@ type ExtensionManagerMock struct {
 			Name string
 			// Force is the force argument value.
 			Force bool
-			// Stdout is the stdout argument value.
-			Stdout io.Writer
-			// Stderr is the stderr argument value.
-			Stderr io.Writer
 		}
 	}
 	lockCreate       sync.RWMutex
@@ -326,41 +322,33 @@ func (mock *ExtensionManagerMock) RemoveCalls() []struct {
 }
 
 // Upgrade calls UpgradeFunc.
-func (mock *ExtensionManagerMock) Upgrade(name string, force bool, stdout io.Writer, stderr io.Writer) error {
+func (mock *ExtensionManagerMock) Upgrade(name string, force bool) error {
 	if mock.UpgradeFunc == nil {
 		panic("ExtensionManagerMock.UpgradeFunc: method is nil but ExtensionManager.Upgrade was just called")
 	}
 	callInfo := struct {
-		Name   string
-		Force  bool
-		Stdout io.Writer
-		Stderr io.Writer
+		Name  string
+		Force bool
 	}{
-		Name:   name,
-		Force:  force,
-		Stdout: stdout,
-		Stderr: stderr,
+		Name:  name,
+		Force: force,
 	}
 	mock.lockUpgrade.Lock()
 	mock.calls.Upgrade = append(mock.calls.Upgrade, callInfo)
 	mock.lockUpgrade.Unlock()
-	return mock.UpgradeFunc(name, force, stdout, stderr)
+	return mock.UpgradeFunc(name, force)
 }
 
 // UpgradeCalls gets all the calls that were made to Upgrade.
 // Check the length with:
 //     len(mockedExtensionManager.UpgradeCalls())
 func (mock *ExtensionManagerMock) UpgradeCalls() []struct {
-	Name   string
-	Force  bool
-	Stdout io.Writer
-	Stderr io.Writer
+	Name  string
+	Force bool
 } {
 	var calls []struct {
-		Name   string
-		Force  bool
-		Stdout io.Writer
-		Stderr io.Writer
+		Name  string
+		Force bool
 	}
 	mock.lockUpgrade.RLock()
 	calls = mock.calls.Upgrade


### PR DESCRIPTION
Part of #4194

This PR adds binary extension support to `gh extension upgrade` and `gh extension list`.

NB: I have yet to address the concept of a local binary extension (which may end up being a no-op, i'm not sure)

NB: there's some cleanup that could be done in `Upgrade()` (see discussion below) but I'm punting on it for now.

NB: For now I'm punting on the question of upgrading "old" binary extensions to new ones. A user is always able to remove+reinstall, but providing a nicer upgrade path might be nice.