### PR TITLE
Use concurrency to check for extension updates

### DIFF
--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -214,8 +214,8 @@ func TestNewCmdExtension(t *testing.T) {
 			args: []string{"list"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
 				em.ListFunc = func(bool) []extensions.Extension {
-					ex1 := &Extension{path: "cli/gh-test", url: "https://github.com/cli/gh-test", updateAvailable: false}
-					ex2 := &Extension{path: "cli/gh-test2", url: "https://github.com/cli/gh-test2", updateAvailable: true}
+					ex1 := &Extension{path: "cli/gh-test", url: "https://github.com/cli/gh-test", currentVersion: "1", latestVersion: "1"}
+					ex2 := &Extension{path: "cli/gh-test2", url: "https://github.com/cli/gh-test2", currentVersion: "1", latestVersion: "2"}
 					return []extensions.Extension{ex1, ex2}
 				}
 				return func(t *testing.T) {

--- a/pkg/cmd/extension/extension.go
+++ b/pkg/cmd/extension/extension.go
@@ -7,11 +7,20 @@ import (
 
 const manifestName = "manifest.yml"
 
+type ExtensionKind int
+
+const (
+	GitKind ExtensionKind = iota
+	BinaryKind
+)
+
 type Extension struct {
-	path            string
-	url             string
-	isLocal         bool
-	updateAvailable bool
+	path           string
+	url            string
+	isLocal        bool
+	currentVersion string
+	latestVersion  string
+	kind           ExtensionKind
 }
 
 func (e *Extension) Name() string {
@@ -31,5 +40,11 @@ func (e *Extension) IsLocal() bool {
 }
 
 func (e *Extension) UpdateAvailable() bool {
-	return e.updateAvailable
+	if e.isLocal ||
+		e.currentVersion == "" ||
+		e.latestVersion == "" ||
+		e.currentVersion == e.latestVersion {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
This PR adds concurrency to the extension list command so that each extension update availability check is done in a separate Goroutine. As part of this I separated the parsing of the extensions directory from the actual checking for updates which I think makes the code easier to understand. Hopefully this makes the command fast enough.

Some other options that we can consider in the future are adding a flag to skip update availability checking, and also adding caching. I would have added caching to this PR but right now we only have a pattern for caching http requests and not git commands and I thought it would be a weird experience to have caching for only binary extensions and not git extensions.

Closes https://github.com/cli/cli/issues/4220