### PR TITLE
Don't allow the lazyLoadedHTTPClient mutex to wrap `Do()`

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -151,14 +151,14 @@ func (l *lazyLoadedHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	l.httpClientMu.RUnlock()
 
 	if httpClient == nil {
-		l.httpClientMu.Lock()
-		defer l.httpClientMu.Unlock()
-
 		var err error
+		l.httpClientMu.Lock()
 		l.httpClient, err = l.factory.HttpClient()
+		l.httpClientMu.Unlock()
 		if err != nil {
 			return nil, err
 		}
 	}
+
 	return l.httpClient.Do(req)
 }


### PR DESCRIPTION
We only need a mutex around accessing `l.httpClient`, but never around the actual HTTP request.

Followup to #4384 