### PR TITLE
docs(install-linux): add instructions for Alpine Linux users

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -167,6 +167,19 @@ openSUSE Tumbleweed users can install from the [official distribution repo](http
 sudo zypper in gh
 ```
 
+### Alpine Linux
+
+Alpine Linux users can install from the `testing` repository, under `edge`:
+
+```bash
+# sudo might not even installed by default, so try to install as root
+sudo apk -X http://dl-cdn.alpinelinux.org/alpine/edge/testing add github-cli
+
+# manuals and shell completions are available as seperate packages
+# if not using bash, replace it with zsh or fish
+sudo apk -X http://dl-cdn.alpinelinux.org/alpine/edge/testing add github-cli-doc github-cli-bash-completion
+```
+
 [releases page]: https://github.com/cli/cli/releases/latest
 [arch linux repo]: https://www.archlinux.org/packages/community/x86_64/github-cli
 [arch linux aur]: https://aur.archlinux.org/packages/github-cli-git


### PR DESCRIPTION
This PR contains an addition of installing GitHub CLI on Alpine Linux, which is currently on the `testing` repository under the `edge` release line. (Actually, [I'm packaged GitHub CLI for v2.0.0 release](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/25158) on Alpine Linux weeks ago.)
