### PR TITLE
Set io when initializing extension manager

### DIFF
--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -46,6 +46,7 @@ func NewManager(io *iostreams.IOStreams) *Manager {
 		platform: func() string {
 			return fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 		},
+		io: io,
 	}
 }
 


### PR DESCRIPTION
Found a small bug when doing some extensions testing. We had forgotten to set `io` when initializing the extension manager.