### PR TITLE
Cleanup extension upgrade command

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -132,7 +132,24 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					if len(args) > 0 {
 						name = normalizeExtensionSelector(args[0])
 					}
-					return m.Upgrade(name, flagForce)
+					cs := io.ColorScheme()
+					err := m.Upgrade(name, flagForce)
+					if err != nil {
+						if name != "" {
+							fmt.Fprintf(io.ErrOut, "%s Failed upgrading extension %s: %s", cs.FailureIcon(), name, err)
+						} else {
+							fmt.Fprintf(io.ErrOut, "%s Failed upgrading extensions", cs.FailureIcon())
+						}
+						return cmdutil.SilentError
+					}
+					if io.IsStdoutTTY() {
+						if name != "" {
+							fmt.Fprintf(io.Out, "%s Successfully upgraded extension %s\n", cs.SuccessIcon(), name)
+						} else {
+							fmt.Fprintf(io.Out, "%s Successfully upgraded extensions\n", cs.SuccessIcon())
+						}
+					}
+					return nil
 				},
 			}
 			cmd.Flags().BoolVar(&flagAll, "all", false, "Upgrade all extensions")

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -102,6 +102,23 @@ func TestNewCmdExtension(t *testing.T) {
 					assert.Equal(t, "hello", calls[0].Name)
 				}
 			},
+			isTTY:      true,
+			wantStdout: "✓ Successfully upgraded extension hello\n",
+		},
+		{
+			name: "upgrade an extension notty",
+			args: []string{"upgrade", "hello"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.UpgradeFunc = func(name string, force bool) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.UpgradeCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "hello", calls[0].Name)
+				}
+			},
+			isTTY: false,
 		},
 		{
 			name: "upgrade an extension gh-prefix",
@@ -116,6 +133,8 @@ func TestNewCmdExtension(t *testing.T) {
 					assert.Equal(t, "hello", calls[0].Name)
 				}
 			},
+			isTTY:      true,
+			wantStdout: "✓ Successfully upgraded extension hello\n",
 		},
 		{
 			name: "upgrade an extension full name",
@@ -130,6 +149,8 @@ func TestNewCmdExtension(t *testing.T) {
 					assert.Equal(t, "hello", calls[0].Name)
 				}
 			},
+			isTTY:      true,
+			wantStdout: "✓ Successfully upgraded extension hello\n",
 		},
 		{
 			name: "upgrade all",
@@ -144,6 +165,23 @@ func TestNewCmdExtension(t *testing.T) {
 					assert.Equal(t, "", calls[0].Name)
 				}
 			},
+			isTTY:      true,
+			wantStdout: "✓ Successfully upgraded extensions\n",
+		},
+		{
+			name: "upgrade all notty",
+			args: []string{"upgrade", "--all"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.UpgradeFunc = func(name string, force bool) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.UpgradeCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "", calls[0].Name)
+				}
+			},
+			isTTY: false,
 		},
 		{
 			name: "remove extension tty",


### PR DESCRIPTION
This PR does a couple things: 
* Cleans up the error handling of `extension upgrade`.
* Tightens up the UX of `extension upgrade` to include success/failure indicators.
* Adds concurrent checking for updates when using `extension upgrade --all`.

cc https://github.com/cli/cli/issues/4194