### PR TITLE
codespace create: fix regression returning nil codespace

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -425,7 +425,7 @@ type CreateCodespaceParams struct {
 func (a *API) CreateCodespace(ctx context.Context, params *CreateCodespaceParams) (*Codespace, error) {
 	codespace, err := a.startCreate(ctx, params.RepositoryID, params.Machine, params.Branch, params.Location)
 	if err != errProvisioningInProgress {
-		return nil, err
+		return codespace, err
 	}
 
 	// errProvisioningInProgress indicates that codespace creation did not complete


### PR DESCRIPTION
I noticed this while testing today. I regressed this yesterday landing another PR. I plan to tackle tests soon so this won't happen again but this unblocks users.
