### PR TITLE
#2720 | Add patch flag to pull-request diff command

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -267,7 +267,7 @@ func (pr *PullRequest) DisplayableReviews() PullRequestReviews {
 	return PullRequestReviews{Nodes: published, TotalCount: len(published)}
 }
 
-func (c Client) PullRequestDiff(baseRepo ghrepo.Interface, prNumber int) (io.ReadCloser, error) {
+func (c Client) PullRequestDiff(baseRepo ghrepo.Interface, prNumber int, patch bool) (io.ReadCloser, error) {
 	url := fmt.Sprintf("%srepos/%s/pulls/%d",
 		ghinstance.RESTPrefix(baseRepo.RepoHost()), ghrepo.FullName(baseRepo), prNumber)
 	req, err := http.NewRequest("GET", url, nil)
@@ -275,7 +275,11 @@ func (c Client) PullRequestDiff(baseRepo ghrepo.Interface, prNumber int) (io.Rea
 		return nil, err
 	}
 
-	req.Header.Set("Accept", "application/vnd.github.v3.diff; charset=utf-8")
+	if patch {
+		req.Header.Set("Accept", "application/vnd.github.v3.patch")
+	} else {
+		req.Header.Set("Accept", "application/vnd.github.v3.diff; charset=utf-8")
+	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/pkg/cmd/pr/diff/diff.go
+++ b/pkg/cmd/pr/diff/diff.go
@@ -25,6 +25,7 @@ type DiffOptions struct {
 
 	SelectorArg string
 	UseColor    string
+	Patch       bool
 }
 
 func NewCmdDiff(f *cmdutil.Factory, runF func(*DiffOptions) error) *cobra.Command {
@@ -70,6 +71,7 @@ func NewCmdDiff(f *cmdutil.Factory, runF func(*DiffOptions) error) *cobra.Comman
 	}
 
 	cmd.Flags().StringVar(&opts.UseColor, "color", "auto", "Use color in diff output: {always|never|auto}")
+	cmd.Flags().BoolVar(&opts.Patch, "patch", false, "Display diff in patch format")
 
 	return cmd
 }
@@ -90,7 +92,7 @@ func diffRun(opts *DiffOptions) error {
 	}
 	apiClient := api.NewClientFromHTTP(httpClient)
 
-	diff, err := apiClient.PullRequestDiff(baseRepo, pr.Number)
+	diff, err := apiClient.PullRequestDiff(baseRepo, pr.Number, opts.Patch)
 	if err != nil {
 		return fmt.Errorf("could not find pull request diff: %w", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/2720 
Added a flag to display pull-request diff in patch format.