### PR TITLE
Adding support for -L/--limit parameter to the gh cs list command

### DIFF
--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -5,34 +5,47 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/pkg/cmd/codespace/output"
+	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
 
+type ListOptions struct {
+	AsJSON       bool
+	LimitResults int
+}
+
 func newListCmd(app *App) *cobra.Command {
-	var asJSON bool
+	opts := &ListOptions{}
 
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List your codespaces",
 		Args:  noArgsConstraint,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return app.List(cmd.Context(), asJSON)
+			if opts.LimitResults < 1 {
+				return &cmdutil.FlagError{Err: fmt.Errorf("invalid limit: %v", opts.LimitResults)}
+			}
+
+			return app.List(cmd.Context(), opts)
 		},
 	}
 
-	listCmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
+	listCmd.Flags().BoolVar(&opts.AsJSON, "json", false, "Output as JSON")
+	listCmd.Flags().IntVarP(&opts.LimitResults, "limit", "L", 30, "Maximum number of codespaces to fetch")
 
 	return listCmd
 }
 
-func (a *App) List(ctx context.Context, asJSON bool) error {
-	codespaces, err := a.apiClient.ListCodespaces(ctx)
+func (a *App) List(ctx context.Context, opts *ListOptions) error {
+	ctxWithLimits := context.WithValue(ctx, &api.ListDefaultLimitKey{}, opts.LimitResults)
+	codespaces, err := a.apiClient.ListCodespaces(ctxWithLimits)
 	if err != nil {
 		return fmt.Errorf("error getting codespaces: %w", err)
 	}
 
-	table := output.NewTable(os.Stdout, asJSON)
+	table := output.NewTable(os.Stdout, opts.AsJSON)
 	table.SetHeader([]string{"Name", "Repository", "Branch", "State", "Created At"})
 	for _, apiCodespace := range codespaces {
 		cs := codespace{apiCodespace}


### PR DESCRIPTION
Fixes #4452 Add list limit support to codespaces' listing command.
Follows the same approach by using cobra to fetch the value from a command line option.

The value is passed to the underlying API methods using the context parameter.

```go
ctxWithLimits := context.WithValue(ctx, &api.ListDefaultLimitKey{}, opts.LimitResults)
codespaces, err := a.apiClient.ListCodespaces(ctxWithLimits)
```

The implementation also does not break previous functionality implemented by the current ```API.ListCodespaces``` used by other codespace operations.

#### TODO
- [X] Implement limit option
- [ ] Add specific tests