### PR TITLE
Add org scoped port forwarding + fix test formatting

### DIFF
--- a/git/git_test.go
+++ b/git/git_test.go
@@ -100,7 +100,7 @@ func Test_CurrentBranch(t *testing.T) {
 
 		result, err := CurrentBranch()
 		if err != nil {
-			t.Errorf("got unexpected error: %w", err)
+			t.Errorf("got unexpected error: %v", err)
 		}
 		if result != v.Expected {
 			t.Errorf("unexpected branch name: %s instead of %s", result, v.Expected)

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -148,7 +148,7 @@ func newPortsPrivacyCmd(app *App) *cobra.Command {
 	return &cobra.Command{
 		Use:     "privacy <port:public|private|org>...",
 		Short:   "Change the privacy of the forwarded port",
-		Example: "gh cs ports privacy 80:org 3000:private 8000:public",
+		Example: "gh codespace ports privacy 80:org 3000:private 8000:public",
 		Args:    cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -146,7 +146,7 @@ func getDevContainer(ctx context.Context, apiClient apiClient, codespace *api.Co
 
 func newPortsVisibilityCmd(app *App) *cobra.Command {
 	return &cobra.Command{
-		Use:     "visibility <port:public|private|org>",
+		Use:     "visibility <port:public|private|org>...",
 		Short:   "Change the visibility of the forwarded port",
 		Example: "gh cs ports visibility 80:org 3000:private 8000:public",
 		Args:    cobra.ArbitraryArgs,

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -41,7 +41,7 @@ func newPortsCmd(app *App) *cobra.Command {
 	portsCmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
 
 	portsCmd.AddCommand(newPortsForwardCmd(app))
-	portsCmd.AddCommand(newPortsVisibilityCmd(app))
+	portsCmd.AddCommand(newPortsPrivacyCmd(app))
 
 	return portsCmd
 }
@@ -144,13 +144,16 @@ func getDevContainer(ctx context.Context, apiClient apiClient, codespace *api.Co
 	return ch
 }
 
-func newPortsVisibilityCmd(app *App) *cobra.Command {
+func newPortsPrivacyCmd(app *App) *cobra.Command {
 	return &cobra.Command{
-		Use:     "visibility <port:public|private|org>...",
-		Short:   "Change the visibility of the forwarded port",
-		Example: "gh cs ports visibility 80:org 3000:private 8000:public",
+		Use:     "privacy <port:public|private|org>...",
+		Short:   "Change the privacy of the forwarded port",
+		Example: "gh cs ports privacy 80:org 3000:private 8000:public",
 		Args:    cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("at least one port privacy argument is required")
+			}
 			codespace, err := cmd.Flags().GetString("codespace")
 			if err != nil {
 				// should only happen if flag is not defined
@@ -158,13 +161,13 @@ func newPortsVisibilityCmd(app *App) *cobra.Command {
 				// since it's a persistent flag that we control it should never happen
 				return fmt.Errorf("get codespace flag: %w", err)
 			}
-			return app.UpdatePortVisibility(cmd.Context(), codespace, args)
+			return app.UpdatePortPrivacy(cmd.Context(), codespace, args)
 		},
 	}
 }
 
-func (a *App) UpdatePortVisibility(ctx context.Context, codespaceName string, args []string) (err error) {
-	ports, err := a.parsePortVisibilities(args)
+func (a *App) UpdatePortPrivacy(ctx context.Context, codespaceName string, args []string) (err error) {
+	ports, err := a.parsePortPrivacies(args)
 	if err != nil {
 		return fmt.Errorf("error parsing port arguments: %w", err)
 	}
@@ -183,34 +186,34 @@ func (a *App) UpdatePortVisibility(ctx context.Context, codespaceName string, ar
 	defer safeClose(session, &err)
 
 	for _, port := range ports {
-		if err := session.UpdateSharedServerPrivacy(ctx, port.number, port.visibility); err != nil {
+		if err := session.UpdateSharedServerPrivacy(ctx, port.number, port.privacy); err != nil {
 			return fmt.Errorf("error update port to public: %w", err)
 		}
 
-		a.logger.Printf("Port %d is now %s.\n", port.number, port.visibility)
+		a.logger.Printf("Port %d is now %s scoped.\n", port.number, port.privacy)
 	}
 
 	return nil
 }
 
-type portVisibility struct {
-	number     int
-	visibility string
+type portPrivacy struct {
+	number  int
+	privacy string
 }
 
-func (a *App) parsePortVisibilities(args []string) ([]portVisibility, error) {
-	ports := make([]portVisibility, 0, len(args))
+func (a *App) parsePortPrivacies(args []string) ([]portPrivacy, error) {
+	ports := make([]portPrivacy, 0, len(args))
 	for _, a := range args {
 		fields := strings.Split(a, ":")
 		if len(fields) != 2 {
-			return nil, fmt.Errorf("invalid port visibility format for %q", a)
+			return nil, fmt.Errorf("invalid port privacy format for %q", a)
 		}
-		portStr, visibility := fields[0], fields[1]
+		portStr, privacy := fields[0], fields[1]
 		portNumber, err := strconv.Atoi(portStr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid port number: %w", err)
 		}
-		ports = append(ports, portVisibility{portNumber, visibility})
+		ports = append(ports, portPrivacy{portNumber, privacy})
 	}
 	return ports, nil
 }

--- a/pkg/liveshare/client_test.go
+++ b/pkg/liveshare/client_test.go
@@ -48,7 +48,7 @@ func TestConnect(t *testing.T) {
 		livesharetest.WithRelaySAS(opts.RelaySAS),
 	)
 	if err != nil {
-		t.Errorf("error creating Live Share server: %w", err)
+		t.Errorf("error creating Live Share server: %v", err)
 	}
 	defer server.Close()
 	opts.RelayEndpoint = "sb" + strings.TrimPrefix(server.URL(), "https")
@@ -65,10 +65,10 @@ func TestConnect(t *testing.T) {
 
 	select {
 	case err := <-server.Err():
-		t.Errorf("error from server: %w", err)
+		t.Errorf("error from server: %v", err)
 	case err := <-done:
 		if err != nil {
-			t.Errorf("error from client: %w", err)
+			t.Errorf("error from client: %v", err)
 		}
 	}
 }

--- a/pkg/liveshare/port_forwarder_test.go
+++ b/pkg/liveshare/port_forwarder_test.go
@@ -17,7 +17,7 @@ import (
 func TestNewPortForwarder(t *testing.T) {
 	testServer, session, err := makeMockSession()
 	if err != nil {
-		t.Errorf("create mock client: %w", err)
+		t.Errorf("create mock client: %v", err)
 	}
 	defer testServer.Close()
 	pf := NewPortForwarder(session, "ssh", 80, false)
@@ -42,7 +42,7 @@ func TestPortForwarderStart(t *testing.T) {
 		livesharetest.WithStream("stream-id", stream),
 	)
 	if err != nil {
-		t.Errorf("create mock session: %w", err)
+		t.Errorf("create mock session: %v", err)
 	}
 	defer testServer.Close()
 
@@ -86,10 +86,10 @@ func TestPortForwarderStart(t *testing.T) {
 
 	select {
 	case err := <-testServer.Err():
-		t.Errorf("error from server: %w", err)
+		t.Errorf("error from server: %v", err)
 	case err := <-done:
 		if err != nil {
-			t.Errorf("error from client: %w", err)
+			t.Errorf("error from client: %v", err)
 		}
 	}
 }

--- a/pkg/liveshare/session.go
+++ b/pkg/liveshare/session.go
@@ -41,6 +41,7 @@ type Port struct {
 	IsPublic                         bool   `json:"isPublic"`
 	IsTCPServerConnectionEstablished bool   `json:"isTCPServerConnectionEstablished"`
 	HasTLSHandshakePassed            bool   `json:"hasTLSHandshakePassed"`
+	Privacy                          string `json:"privacy"`
 }
 
 // startSharing tells the Live Share host to start sharing the specified port from the container.
@@ -67,10 +68,10 @@ func (s *Session) GetSharedServers(ctx context.Context) ([]*Port, error) {
 	return response, nil
 }
 
-// UpdateSharedVisibility controls port permissions and whether it can be accessed publicly
-// via the Browse URL
-func (s *Session) UpdateSharedVisibility(ctx context.Context, port int, public bool) error {
-	if err := s.rpc.do(ctx, "serverSharing.updateSharedServerVisibility", []interface{}{port, public}, nil); err != nil {
+// UpdateSharedServerPrivacy controls port permissions and visibility scopes for who can access its URLs
+// in the browser.
+func (s *Session) UpdateSharedServerPrivacy(ctx context.Context, port int, visibility string) error {
+	if err := s.rpc.do(ctx, "serverSharing.updateSharedServerPrivacy", []interface{}{port, visibility}, nil); err != nil {
 		return err
 	}
 

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -172,12 +172,12 @@ func TestServerUpdateSharedServerPrivacy(t *testing.T) {
 		} else {
 			return nil, errors.New("port param is not a float64")
 		}
-		if public, ok := req[1].(bool); ok {
-			if public != true {
-				return nil, errors.New("pulic param is not expected value")
+		if privacy, ok := req[1].(string); ok {
+			if privacy != "public" {
+				return nil, fmt.Errorf("expected privacy param to be public but got %q", privacy)
 			}
 		} else {
-			return nil, errors.New("public param is not a bool")
+			return nil, fmt.Errorf("expected privacy param to be a bool but go %T", req[1])
 		}
 		return nil, nil
 	}

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -182,7 +182,7 @@ func TestServerUpdateSharedServerPrivacy(t *testing.T) {
 		return nil, nil
 	}
 	testServer, session, err := makeMockSession(
-		livesharetest.WithService("serverSharing.updateSharedServerVisibility", updateSharedVisibility),
+		livesharetest.WithService("serverSharing.updateSharedServerPrivacy", updateSharedVisibility),
 	)
 	if err != nil {
 		t.Errorf("creating mock session: %v", err)

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -82,7 +82,7 @@ func TestServerStartSharing(t *testing.T) {
 	defer testServer.Close() //nolint:staticcheck // httptest.Server does not return errors on Close()
 
 	if err != nil {
-		t.Errorf("error creating mock session: %w", err)
+		t.Errorf("error creating mock session: %v", err)
 	}
 	ctx := context.Background()
 
@@ -100,10 +100,10 @@ func TestServerStartSharing(t *testing.T) {
 
 	select {
 	case err := <-testServer.Err():
-		t.Errorf("error from server: %w", err)
+		t.Errorf("error from server: %v", err)
 	case err := <-done:
 		if err != nil {
-			t.Errorf("error from client: %w", err)
+			t.Errorf("error from client: %v", err)
 		}
 	}
 }
@@ -121,7 +121,7 @@ func TestServerGetSharedServers(t *testing.T) {
 		livesharetest.WithService("serverSharing.getSharedServers", getSharedServers),
 	)
 	if err != nil {
-		t.Errorf("error creating mock session: %w", err)
+		t.Errorf("error creating mock session: %v", err)
 	}
 	defer testServer.Close()
 	ctx := context.Background()
@@ -148,15 +148,15 @@ func TestServerGetSharedServers(t *testing.T) {
 
 	select {
 	case err := <-testServer.Err():
-		t.Errorf("error from server: %w", err)
+		t.Errorf("error from server: %v", err)
 	case err := <-done:
 		if err != nil {
-			t.Errorf("error from client: %w", err)
+			t.Errorf("error from client: %v", err)
 		}
 	}
 }
 
-func TestServerUpdateSharedVisibility(t *testing.T) {
+func TestServerUpdateSharedServerPrivacy(t *testing.T) {
 	updateSharedVisibility := func(rpcReq *jsonrpc2.Request) (interface{}, error) {
 		var req []interface{}
 		if err := json.Unmarshal(*rpcReq.Params, &req); err != nil {
@@ -185,20 +185,20 @@ func TestServerUpdateSharedVisibility(t *testing.T) {
 		livesharetest.WithService("serverSharing.updateSharedServerVisibility", updateSharedVisibility),
 	)
 	if err != nil {
-		t.Errorf("creating mock session: %w", err)
+		t.Errorf("creating mock session: %v", err)
 	}
 	defer testServer.Close()
 	ctx := context.Background()
 	done := make(chan error)
 	go func() {
-		done <- session.UpdateSharedVisibility(ctx, 80, true)
+		done <- session.UpdateSharedServerPrivacy(ctx, 80, "public")
 	}()
 	select {
 	case err := <-testServer.Err():
-		t.Errorf("error from server: %w", err)
+		t.Errorf("error from server: %v", err)
 	case err := <-done:
 		if err != nil {
-			t.Errorf("error from client: %w", err)
+			t.Errorf("error from client: %v", err)
 		}
 	}
 }
@@ -214,7 +214,7 @@ func TestInvalidHostKey(t *testing.T) {
 	}
 	testServer, err := livesharetest.NewServer(opts...)
 	if err != nil {
-		t.Errorf("error creating server: %w", err)
+		t.Errorf("error creating server: %v", err)
 	}
 	_, err = Connect(context.Background(), Options{
 		SessionID:      "session-id",


### PR DESCRIPTION
This PR replaces the `gh cs ports <visibility> <port>` command with one that does not require sub commands for every visibility and adds the new "org scoped" visibility to them. 

The design as the PR stands is this: 

`gh cs ports privacy 80:org 3306:private 8000:public`

Other options: 

1. `gh cs ports visibility 80:org 3306:private 8000:public`
2. `gh cs ports privacy 80 --visibility org; gh cs ports visibility 3306 --visibility org; etc...`


This PR also fixes a formatting bug where `t.Errorf` was using `%w` which ends up spitting out a formatting error because it does not recognize the directive. 

Fixes https://github.com/cli/cli/issues/4498