### PR TITLE
cs create: include HTTP status code in error from /user/codespaces/*/start

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -341,7 +341,7 @@ func (a *API) StartCodespace(ctx context.Context, codespaceName string) error {
 		if len(b) > 100 {
 			b = append(b[:97], "..."...)
 		}
-		return fmt.Errorf("failed to start codespace: %s", b)
+		return fmt.Errorf("failed to start codespace: %s (%s)", b, resp.Status)
 	}
 
 	return nil


### PR DESCRIPTION
The error message is often empty in this case, so the HTTP status code is all we have.

Context: https://github.com/github/codespaces/issues/4398#issuecomment-942176851