### PR TITLE
codespace: fix for API response body change

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -161,14 +161,14 @@ type Codespace struct {
 	RepositoryNWO  string               `json:"repository_nwo"`
 	OwnerLogin     string               `json:"owner_login"`
 	Environment    CodespaceEnvironment `json:"environment"`
+	Connection     CodespaceConnection  `json:"connection"`
 }
 
 const CodespaceStateProvisioned = "provisioned"
 
 type CodespaceEnvironment struct {
-	State      string                         `json:"state"`
-	Connection CodespaceEnvironmentConnection `json:"connection"`
-	GitStatus  CodespaceEnvironmentGitStatus  `json:"gitStatus"`
+	State     string                        `json:"state"`
+	GitStatus CodespaceEnvironmentGitStatus `json:"gitStatus"`
 }
 
 type CodespaceEnvironmentGitStatus struct {
@@ -185,7 +185,7 @@ const (
 	CodespaceEnvironmentStateAvailable = "Available"
 )
 
-type CodespaceEnvironmentConnection struct {
+type CodespaceConnection struct {
 	SessionID      string   `json:"sessionId"`
 	SessionToken   string   `json:"sessionToken"`
 	RelayEndpoint  string   `json:"relayEndpoint"`

--- a/internal/codespaces/codespaces.go
+++ b/internal/codespaces/codespaces.go
@@ -16,10 +16,10 @@ type logger interface {
 }
 
 func connectionReady(codespace *api.Codespace) bool {
-	return codespace.Environment.Connection.SessionID != "" &&
-		codespace.Environment.Connection.SessionToken != "" &&
-		codespace.Environment.Connection.RelayEndpoint != "" &&
-		codespace.Environment.Connection.RelaySAS != "" &&
+	return codespace.Connection.SessionID != "" &&
+		codespace.Connection.SessionToken != "" &&
+		codespace.Connection.RelayEndpoint != "" &&
+		codespace.Connection.RelaySAS != "" &&
 		codespace.Environment.State == api.CodespaceEnvironmentStateAvailable
 }
 
@@ -67,10 +67,10 @@ func ConnectToLiveshare(ctx context.Context, log logger, apiClient apiClient, co
 	log.Println("Connecting to your codespace...")
 
 	return liveshare.Connect(ctx, liveshare.Options{
-		SessionID:      codespace.Environment.Connection.SessionID,
-		SessionToken:   codespace.Environment.Connection.SessionToken,
-		RelaySAS:       codespace.Environment.Connection.RelaySAS,
-		RelayEndpoint:  codespace.Environment.Connection.RelayEndpoint,
-		HostPublicKeys: codespace.Environment.Connection.HostPublicKeys,
+		SessionID:      codespace.Connection.SessionID,
+		SessionToken:   codespace.Connection.SessionToken,
+		RelaySAS:       codespace.Connection.RelaySAS,
+		RelayEndpoint:  codespace.Connection.RelayEndpoint,
+		HostPublicKeys: codespace.Connection.HostPublicKeys,
 	})
 }


### PR DESCRIPTION
- Connection is now embedded within the top level of the Codespace payload instead of inside the environment.
