### PR TITLE
Update winget installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For instructions on specific distributions and package managers, see [Linux & BS
 
 | Install:            | Upgrade:            |
 | ------------------- | --------------------|
-| `winget install gh` | `winget upgrade gh` |
+| `winget install --id GitHub.cli` | `winget upgrade --id GitHub.cli` |
 
 #### scoop
 


### PR DESCRIPTION
The current `winget` installation instructions are not working as there are collisions for the search term `gh` coming from the Windows Store


```
> winget install gh
Multiple packages found matching input criteria. Please refine the input.
Name       Id           Source
-------------------------------
AquaCheck  9WZDNCRDKSFZ msstore
GitHub CLI GitHub.cli   winget
```

As there are also collisions for other words e.g (`GitHub`, `GitHub.cli`) and more can be added in future, it seems like the best approach is to explicitly reference the package by id.