### PR TITLE
codespace stop: new command to stop a running codespace

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -347,6 +347,30 @@ func (a *API) StartCodespace(ctx context.Context, codespaceName string) error {
 	return nil
 }
 
+func (a *API) StopCodespace(ctx context.Context, codespaceName string) error {
+	req, err := http.NewRequest(
+		http.MethodPost,
+		a.githubAPI+"/user/codespaces/"+codespaceName+"/stop",
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	a.setHeaders(req)
+	resp, err := a.do(ctx, req, "/user/codespaces/*/stop")
+	if err != nil {
+		return fmt.Errorf("error making request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return api.HandleHTTPError(resp)
+	}
+
+	return nil
+}
+
 type getCodespaceRegionLocationResponse struct {
 	Current string `json:"current"`
 }

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -253,6 +253,7 @@ func (c codespace) hasUnsavedChanges() bool {
 	return c.Environment.GitStatus.HasUncommitedChanges || c.Environment.GitStatus.HasUnpushedChanges
 }
 
-func (c codespace) isRunning() bool {
+// running returns whether the codespace environment is running.
+func (c codespace) running() bool {
 	return c.Environment.State == api.CodespaceEnvironmentStateAvailable
 }

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -38,6 +38,7 @@ type apiClient interface {
 	ListCodespaces(ctx context.Context, limit int) ([]*api.Codespace, error)
 	DeleteCodespace(ctx context.Context, name string) error
 	StartCodespace(ctx context.Context, name string) error
+	StopCodespace(ctx context.Context, name string) error
 	CreateCodespace(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error)
 	GetRepository(ctx context.Context, nwo string) (*api.Repository, error)
 	AuthorizedKeys(ctx context.Context, user string) ([]byte, error)
@@ -250,4 +251,8 @@ func (c codespace) branchWithGitStatus() string {
 // unsaved changes.
 func (c codespace) hasUnsavedChanges() bool {
 	return c.Environment.GitStatus.HasUncommitedChanges || c.Environment.GitStatus.HasUnpushedChanges
+}
+
+func (c codespace) isRunning() bool {
+	return c.Environment.State == api.CodespaceEnvironmentStateAvailable
 }

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -49,6 +49,9 @@ import (
 // 			StartCodespaceFunc: func(ctx context.Context, name string) error {
 // 				panic("mock out the StartCodespace method")
 // 			},
+// 			StopCodespaceFunc: func(ctx context.Context, name string) error {
+// 				panic("mock out the StopCodespace method")
+// 			},
 // 		}
 //
 // 		// use mockedapiClient in code that requires apiClient
@@ -88,6 +91,9 @@ type apiClientMock struct {
 
 	// StartCodespaceFunc mocks the StartCodespace method.
 	StartCodespaceFunc func(ctx context.Context, name string) error
+
+	// StopCodespaceFunc mocks the StopCodespace method.
+	StopCodespaceFunc func(ctx context.Context, name string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -172,6 +178,13 @@ type apiClientMock struct {
 			// Name is the name argument value.
 			Name string
 		}
+		// StopCodespace holds details about calls to the StopCodespace method.
+		StopCodespace []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Name is the name argument value.
+			Name string
+		}
 	}
 	lockAuthorizedKeys                 sync.RWMutex
 	lockCreateCodespace                sync.RWMutex
@@ -184,6 +197,7 @@ type apiClientMock struct {
 	lockGetUser                        sync.RWMutex
 	lockListCodespaces                 sync.RWMutex
 	lockStartCodespace                 sync.RWMutex
+	lockStopCodespace                  sync.RWMutex
 }
 
 // AuthorizedKeys calls AuthorizedKeysFunc.
@@ -576,5 +590,40 @@ func (mock *apiClientMock) StartCodespaceCalls() []struct {
 	mock.lockStartCodespace.RLock()
 	calls = mock.calls.StartCodespace
 	mock.lockStartCodespace.RUnlock()
+	return calls
+}
+
+// StopCodespace calls StopCodespaceFunc.
+func (mock *apiClientMock) StopCodespace(ctx context.Context, name string) error {
+	if mock.StopCodespaceFunc == nil {
+		panic("apiClientMock.StopCodespaceFunc: method is nil but apiClient.StopCodespace was just called")
+	}
+	callInfo := struct {
+		Ctx  context.Context
+		Name string
+	}{
+		Ctx:  ctx,
+		Name: name,
+	}
+	mock.lockStopCodespace.Lock()
+	mock.calls.StopCodespace = append(mock.calls.StopCodespace, callInfo)
+	mock.lockStopCodespace.Unlock()
+	return mock.StopCodespaceFunc(ctx, name)
+}
+
+// StopCodespaceCalls gets all the calls that were made to StopCodespace.
+// Check the length with:
+//     len(mockedapiClient.StopCodespaceCalls())
+func (mock *apiClientMock) StopCodespaceCalls() []struct {
+	Ctx  context.Context
+	Name string
+} {
+	var calls []struct {
+		Ctx  context.Context
+		Name string
+	}
+	mock.lockStopCodespace.RLock()
+	calls = mock.calls.StopCodespace
+	mock.lockStopCodespace.RUnlock()
 	return calls
 }

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -25,6 +25,7 @@ token to access the GitHub API with.`,
 	root.AddCommand(newLogsCmd(app))
 	root.AddCommand(newPortsCmd(app))
 	root.AddCommand(newSSHCmd(app))
+	root.AddCommand(newStopCmd(app))
 
 	return root
 }

--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -29,7 +29,7 @@ func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 	if codespaceName == "" {
 		codespaces, err := a.apiClient.ListCodespaces(ctx, -1)
 		if err != nil {
-			return fmt.Errorf("failed to list codespace: %w", err)
+			return fmt.Errorf("failed to list codespaces: %w", err)
 		}
 
 		var runningCodespaces []*api.Codespace
@@ -51,7 +51,7 @@ func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 	} else {
 		c, err := a.apiClient.GetCodespace(ctx, codespaceName, false)
 		if err != nil {
-			return fmt.Errorf("failed to get codespace: %w", err)
+			return fmt.Errorf("failed to get codespace: %q: %w", codespaceName, err)
 		}
 		cs := codespace{c}
 		if !cs.running() {

--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -35,7 +35,7 @@ func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 		var runningCodespaces []*api.Codespace
 		for _, c := range codespaces {
 			cs := codespace{c}
-			if cs.isRunning() {
+			if cs.running() {
 				runningCodespaces = append(runningCodespaces, c)
 			}
 		}
@@ -54,7 +54,7 @@ func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 			return fmt.Errorf("failed to get codespace: %w", err)
 		}
 		cs := codespace{c}
-		if !cs.isRunning() {
+		if !cs.running() {
 			return fmt.Errorf("codespace %q is not running", codespaceName)
 		}
 	}

--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -1,0 +1,68 @@
+package codespace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/spf13/cobra"
+)
+
+func newStopCmd(app *App) *cobra.Command {
+	var codespace string
+
+	stopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop a running codespace",
+		Args:  noArgsConstraint,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return app.StopCodespace(cmd.Context(), codespace)
+		},
+	}
+	stopCmd.Flags().StringVarP(&codespace, "codespace", "c", "", "Name of the codespace")
+
+	return stopCmd
+}
+
+func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
+	if codespaceName == "" {
+		codespaces, err := a.apiClient.ListCodespaces(ctx, -1)
+		if err != nil {
+			return fmt.Errorf("failed to list codespace: %w", err)
+		}
+
+		var runningCodespaces []*api.Codespace
+		for _, c := range codespaces {
+			cs := codespace{c}
+			if cs.isRunning() {
+				runningCodespaces = append(runningCodespaces, c)
+			}
+		}
+		if len(runningCodespaces) == 0 {
+			return errors.New("no running codespaces")
+		}
+
+		codespace, err := chooseCodespaceFromList(ctx, runningCodespaces)
+		if err != nil {
+			return fmt.Errorf("failed to choose codespace: %w", err)
+		}
+		codespaceName = codespace.Name
+	} else {
+		c, err := a.apiClient.GetCodespace(ctx, codespaceName, false)
+		if err != nil {
+			return fmt.Errorf("failed to get codespace: %w", err)
+		}
+		cs := codespace{c}
+		if !cs.isRunning() {
+			return fmt.Errorf("codespace %q is not running", codespaceName)
+		}
+	}
+
+	if err := a.apiClient.StopCodespace(ctx, codespaceName); err != nil {
+		return fmt.Errorf("failed to stop codespace: %w", err)
+	}
+	a.logger.Println("Codespace stopped")
+
+	return nil
+}


### PR DESCRIPTION
- Introduces new command `gh cs stop`
- If a codespace is passed via flag, it checks that is running before calling the API
- If no codespace is passed, it lists only the running codespaces available for shutdown