### PR TITLE
Configure Dependabot to only consider patch version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - version-update:semver-minor
+        - version-update:semver-major
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
The rationale is that we don't want to consider automatic version upgrades for our dependencies unless they are only patch version bumps. Other types of upgrades are considered risky and we would rather initiate them manually & explicitly.

The [`ignore` directive](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore) doesn't apply to security updates, which will be suggested by Dependabot in any case.

Followup to #4473 