### PR TITLE
codespace ssh: fix for nil logger on non-debugging scenarios

### DIFF
--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -62,17 +62,21 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		return fmt.Errorf("get or choose codespace: %w", err)
 	}
 
-	var debugLogger *fileLogger
+	var liveshareLogger *log.Logger
 	if opts.debug {
-		debugLogger, err = newFileLogger(opts.debugFile)
+		debugLogger, err := newFileLogger(opts.debugFile)
 		if err != nil {
 			return fmt.Errorf("error creating debug logger: %w", err)
 		}
 		defer safeClose(debugLogger, &err)
+
+		liveshareLogger = debugLogger.Logger
 		a.logger.Println("Debug file located at: " + debugLogger.Name())
+	} else {
+		liveshareLogger = noopLogger()
 	}
 
-	session, err := codespaces.ConnectToLiveshare(ctx, a.logger, debugLogger, a.apiClient, codespace)
+	session, err := codespaces.ConnectToLiveshare(ctx, a.logger, liveshareLogger, a.apiClient, codespace)
 	if err != nil {
 		return fmt.Errorf("error connecting to Live Share: %w", err)
 	}

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -62,7 +62,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		return fmt.Errorf("get or choose codespace: %w", err)
 	}
 
-	var liveshareLogger *log.Logger
+	liveshareLogger := noopLogger()
 	if opts.debug {
 		debugLogger, err := newFileLogger(opts.debugFile)
 		if err != nil {
@@ -72,8 +72,6 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 
 		liveshareLogger = debugLogger.Logger
 		a.logger.Println("Debug file located at: " + debugLogger.Name())
-	} else {
-		liveshareLogger = noopLogger()
 	}
 
 	session, err := codespaces.ConnectToLiveshare(ctx, a.logger, liveshareLogger, a.apiClient, codespace)

--- a/pkg/liveshare/client.go
+++ b/pkg/liveshare/client.go
@@ -75,10 +75,6 @@ func Connect(ctx context.Context, opts Options) (*Session, error) {
 		return nil, err
 	}
 
-	if opts.Logger == nil {
-		return nil, errors.New("Logger is required")
-	}
-
 	sock := newSocket(uri, opts.TLSConfig)
 	if err := sock.connect(ctx); err != nil {
 		return nil, fmt.Errorf("error connecting websocket: %w", err)


### PR DESCRIPTION
I introduced a "classic" Go bug as @adonovan called it 😄 

I tested this so much with the debug flag that I had a bug in the non-debugging case. If the user did not pass the `--debug` flag, I never create a logger and thus pass `nil` all the way down. It's also worst that you don't see the bug until the first tick of the heartbeat. The guard in the liveshare pkg does not catch this, so it is somewhat useless.

This fix creates a noop logger in the non-debug case.
