### PR TITLE
Warn about missing OAuth scopes when reporting HTTP 4xx errors

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -241,12 +241,23 @@ func FetchRepository(client *Client, repo ghrepo.Interface, fields []string) (*R
 	}
 
 	var result struct {
-		Repository Repository
+		Repository *Repository
 	}
 	if err := client.GraphQL(repo.RepoHost(), query, variables, &result); err != nil {
 		return nil, err
 	}
-	return InitRepoHostname(&result.Repository, repo.RepoHost()), nil
+	// The GraphQL API should have returned an error in case of a missing repository, but this isn't
+	// guaranteed to happen when an authentication token with insufficient permissions is being used.
+	if result.Repository == nil {
+		return nil, GraphQLErrorResponse{
+			Errors: []GraphQLError{{
+				Type:    "NOT_FOUND",
+				Message: fmt.Sprintf("Could not resolve to a Repository with the name '%s/%s'.", repo.RepoOwner(), repo.RepoName()),
+			}},
+		}
+	}
+
+	return InitRepoHostname(result.Repository, repo.RepoHost()), nil
 }
 
 func GitHubRepo(client *Client, repo ghrepo.Interface) (*Repository, error) {
@@ -280,16 +291,24 @@ func GitHubRepo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 		"name":  repo.RepoName(),
 	}
 
-	result := struct {
-		Repository Repository
-	}{}
-	err := client.GraphQL(repo.RepoHost(), query, variables, &result)
-
-	if err != nil {
+	var result struct {
+		Repository *Repository
+	}
+	if err := client.GraphQL(repo.RepoHost(), query, variables, &result); err != nil {
 		return nil, err
 	}
+	// The GraphQL API should have returned an error in case of a missing repository, but this isn't
+	// guaranteed to happen when an authentication token with insufficient permissions is being used.
+	if result.Repository == nil {
+		return nil, GraphQLErrorResponse{
+			Errors: []GraphQLError{{
+				Type:    "NOT_FOUND",
+				Message: fmt.Sprintf("Could not resolve to a Repository with the name '%s/%s'.", repo.RepoOwner(), repo.RepoName()),
+			}},
+		}
+	}
 
-	return InitRepoHostname(&result.Repository, repo.RepoHost()), nil
+	return InitRepoHostname(result.Repository, repo.RepoHost()), nil
 }
 
 func RepoDefaultBranch(client *Client, repo ghrepo.Interface) (string, error) {

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -10,6 +10,27 @@ import (
 	"github.com/cli/cli/v2/pkg/httpmock"
 )
 
+func TestGitHubRepo_notFound(t *testing.T) {
+	httpReg := &httpmock.Registry{}
+	defer httpReg.Verify(t)
+
+	httpReg.Register(
+		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.StringResponse(`{ "data": { "repository": null } }`))
+
+	client := NewClient(ReplaceTripper(httpReg))
+	repo, err := GitHubRepo(client, ghrepo.New("OWNER", "REPO"))
+	if err == nil {
+		t.Fatal("GitHubRepo did not return an error")
+	}
+	if wants := "GraphQL error: Could not resolve to a Repository with the name 'OWNER/REPO'."; err.Error() != wants {
+		t.Errorf("GitHubRepo error: want %q, got %q", wants, err.Error())
+	}
+	if repo != nil {
+		t.Errorf("GitHubRepo: expected nil repo, got %v", repo)
+	}
+}
+
 func Test_RepoMetadata(t *testing.T) {
 	http := &httpmock.Registry{}
 	client := NewClient(ReplaceTripper(http))

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -226,6 +226,8 @@ func mainRun() exitCode {
 			fmt.Fprintln(stderr, "Try authenticating with:  gh auth login")
 		} else if strings.Contains(err.Error(), "Resource protected by organization SAML enforcement") {
 			fmt.Fprintln(stderr, "Try re-authenticating with:  gh auth refresh")
+		} else if msg := httpErr.ScopesSuggestion(); msg != "" {
+			fmt.Fprintln(stderr, msg)
 		}
 
 		return exitError

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -384,12 +384,14 @@ func processResponse(resp *http.Response, opts *ApiOptions, headersOutputStream 
 		}
 	}
 
+	if serverError == "" && resp.StatusCode > 299 {
+		serverError = fmt.Sprintf("HTTP %d", resp.StatusCode)
+	}
 	if serverError != "" {
 		fmt.Fprintf(opts.IO.ErrOut, "gh: %s\n", serverError)
-		err = cmdutil.SilentError
-		return
-	} else if resp.StatusCode > 299 {
-		fmt.Fprintf(opts.IO.ErrOut, "gh: HTTP %d\n", resp.StatusCode)
+		if msg := api.ScopesSuggestion(resp); msg != "" {
+			fmt.Fprintf(opts.IO.ErrOut, "gh: %s\n", msg)
+		}
 		err = cmdutil.SilentError
 		return
 	}

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -388,32 +388,3 @@ func Test_detectEmptyFiles(t *testing.T) {
 		assert.Equal(t, tt.isEmptyFile, isEmptyFile)
 	}
 }
-
-func Test_CreateRun_reauth(t *testing.T) {
-	reg := &httpmock.Registry{}
-	reg.Register(httpmock.REST("POST", "gists"), func(req *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: 404,
-			Request:    req,
-			Header: map[string][]string{
-				"X-Oauth-Scopes": {"repo, read:org"},
-			},
-			Body: ioutil.NopCloser(bytes.NewBufferString("oh no")),
-		}, nil
-	})
-
-	io, _, _, _ := iostreams.Test()
-
-	opts := &CreateOptions{
-		IO: io,
-		HttpClient: func() (*http.Client, error) {
-			return &http.Client{Transport: reg}, nil
-		},
-		Config: func() (config.Config, error) {
-			return config.NewBlankConfig(), nil
-		},
-	}
-
-	err := createRun(opts)
-	assert.EqualError(t, err, "This command requires the 'gist' OAuth scope.\nPlease re-authenticate with:  gh auth refresh -h github.com -s gist")
-}

--- a/pkg/cmd/ssh-key/add/add.go
+++ b/pkg/cmd/ssh-key/add/add.go
@@ -85,12 +85,6 @@ func runAdd(opts *AddOptions) error {
 
 	err = SSHKeyUpload(httpClient, hostname, keyReader, opts.Title)
 	if err != nil {
-		if errors.Is(err, scopesError) {
-			cs := opts.IO.ColorScheme()
-			fmt.Fprint(opts.IO.ErrOut, "Error: insufficient OAuth scopes to list SSH keys\n")
-			fmt.Fprintf(opts.IO.ErrOut, "Run the following to grant scopes: %s\n", cs.Bold("gh auth refresh -s write:public_key"))
-			return cmdutil.SilentError
-		}
 		return err
 	}
 

--- a/pkg/cmd/ssh-key/add/http.go
+++ b/pkg/cmd/ssh-key/add/http.go
@@ -12,8 +12,6 @@ import (
 	"github.com/cli/cli/v2/internal/ghinstance"
 )
 
-var scopesError = errors.New("insufficient OAuth scopes")
-
 func SSHKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader, title string) error {
 	url := ghinstance.RESTPrefix(hostname) + "user/keys"
 
@@ -43,9 +41,7 @@ func SSHKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader, t
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 404 {
-		return scopesError
-	} else if resp.StatusCode > 299 {
+	if resp.StatusCode > 299 {
 		var httpError api.HTTPError
 		err := api.HandleHTTPError(resp)
 		if errors.As(err, &httpError) && isDuplicateError(&httpError) {

--- a/pkg/cmd/ssh-key/list/http.go
+++ b/pkg/cmd/ssh-key/list/http.go
@@ -2,7 +2,6 @@ package list
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,8 +10,6 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghinstance"
 )
-
-var scopesError = errors.New("insufficient OAuth scopes")
 
 type sshKey struct {
 	Key       string
@@ -37,9 +34,7 @@ func userKeys(httpClient *http.Client, host, userHandle string) ([]sshKey, error
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 404 {
-		return nil, scopesError
-	} else if resp.StatusCode > 299 {
+	if resp.StatusCode > 299 {
 		return nil, api.HandleHTTPError(resp)
 	}
 

--- a/pkg/cmd/ssh-key/list/list.go
+++ b/pkg/cmd/ssh-key/list/list.go
@@ -1,7 +1,6 @@
 package list
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -59,12 +58,6 @@ func listRun(opts *ListOptions) error {
 
 	sshKeys, err := userKeys(apiClient, host, "")
 	if err != nil {
-		if errors.Is(err, scopesError) {
-			cs := opts.IO.ColorScheme()
-			fmt.Fprint(opts.IO.ErrOut, "Error: insufficient OAuth scopes to list SSH keys\n")
-			fmt.Fprintf(opts.IO.ErrOut, "Run the following to grant scopes: %s\n", cs.Bold("gh auth refresh -s read:public_key"))
-			return cmdutil.SilentError
-		}
 		return err
 	}
 

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -162,5 +162,6 @@ func httpResponse(status int, req *http.Request, body io.Reader) *http.Response 
 		StatusCode: status,
 		Request:    req,
 		Body:       ioutil.NopCloser(body),
+		Header:     http.Header{},
 	}
 }


### PR DESCRIPTION
If a 4xx server response lists scopes in the `X-Accepted-Oauth-Scopes` header that are not present in the `X-Oauth-Scopes` header, the final error messaging on stderr will now include a hint for the user that they might need to request the additional scope:

    $ gh codespace list
    error getting codespaces: HTTP 403: Must have admin rights to Repository. (https://api.github.com/user/codespaces?per_page=30)
    This API operation needs the "codespace" scope. To request it, run:  gh auth refresh -h github.com -s codespace

Fixes #4464, fixes #4518
Ref. https://github.com/cli/cli/pull/4451 https://github.com/cli/cli/issues/4415

Note that not all API endpoints consistently report the scopes they need. For example, the gist create endpoint doesn't report that it needs the `gist` scope, nor does the repo delete endpoint report that it needs `delete_repo`.