### PR TITLE
Avoid macOS prompt to allow incoming connections in liveshare tests

### DIFF
--- a/pkg/liveshare/port_forwarder_test.go
+++ b/pkg/liveshare/port_forwarder_test.go
@@ -46,7 +46,7 @@ func TestPortForwarderStart(t *testing.T) {
 	}
 	defer testServer.Close()
 
-	listen, err := net.Listen("tcp", ":8000")
+	listen, err := net.Listen("tcp", "127.0.0.1:8000")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Listening on the localhost interface disallows connections from the outside anyway, so the OS firewall doesn't have to prompt whether the user wants to allow incoming connections to the Go process.
