### PR TITLE
Add --watch flag to pr checks command

### DIFF
--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -119,6 +119,13 @@ func checksRun(opts *ChecksOptions) error {
 		if err := opts.IO.EnableVirtualTerminalProcessing(); err != nil {
 			return err
 		}
+	} else {
+		// Only start pager in non-watch mode
+		if err := opts.IO.StartPager(); err == nil {
+			defer opts.IO.StopPager()
+		} else {
+			fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
+		}
 	}
 
 	var checks []check

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -67,7 +67,12 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 			}
 
 			if opts.Watch {
-				return checksRunWatchMode(opts)
+				duration, err := time.ParseDuration(fmt.Sprintf("%ds", opts.Interval))
+				if err != nil {
+					return fmt.Errorf("could not parse interval: %w", err)
+				}
+
+				return checksRunWatchMode(duration, opts)
 			}
 
 			return checksRun(opts)
@@ -100,12 +105,7 @@ func checksRunWebMode(opts *ChecksOptions) error {
 	return opts.Browser.Browse(openURL)
 }
 
-func checksRunWatchMode(opts *ChecksOptions) error {
-	duration, err := time.ParseDuration(fmt.Sprintf("%ds", opts.Interval))
-	if err != nil {
-		return fmt.Errorf("could not parse interval: %w", err)
-	}
-
+func checksRunWatchMode(duration time.Duration, opts *ChecksOptions) error {
 	checks, meta, err := collect(opts)
 	if err != nil {
 		return fmt.Errorf("cannot collect checks information: %w", err)

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -2,6 +2,9 @@ package checks
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -11,6 +14,8 @@ import (
 	"github.com/cli/cli/v2/utils"
 	"github.com/spf13/cobra"
 )
+
+const defaultInterval int = 30
 
 type browser interface {
 	Browse(string) error
@@ -24,6 +29,8 @@ type ChecksOptions struct {
 
 	SelectorArg string
 	WebMode     bool
+	Interval    int
+	Watch       bool
 }
 
 func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Command {
@@ -61,11 +68,17 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 				return checksRunWebMode(opts)
 			}
 
+			if opts.Watch {
+				return checksRunWatchMode(opts)
+			}
+
 			return checksRun(opts)
 		},
 	}
 
 	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open the web browser to show details about checks")
+	cmd.Flags().BoolVarP(&opts.Watch, "watch", "", false, "Watch checks and wait until are finished running")
+	cmd.Flags().IntVarP(&opts.Interval, "interval", "i", defaultInterval, "The number of seconds between each reprint When using --watch")
 
 	return cmd
 }
@@ -87,6 +100,61 @@ func checksRunWebMode(opts *ChecksOptions) error {
 		fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", utils.DisplayURL(openURL))
 	}
 	return opts.Browser.Browse(openURL)
+}
+
+func checksRunWatchMode(opts *ChecksOptions) error {
+	duration, err := time.ParseDuration(fmt.Sprintf("%ds", opts.Interval))
+	if err != nil {
+		return fmt.Errorf("could not parse interval: %w", err)
+	}
+
+	checks, meta, err := collect(opts)
+	if err != nil {
+		return fmt.Errorf("cannot collect checks information: %w", err)
+	}
+
+	isTerminal := opts.IO.IsStdoutTTY()
+	cs := opts.IO.ColorScheme()
+
+	err = printTable(isTerminal, cs, meta, checks, opts)
+	if err != nil {
+		return fmt.Errorf("cannot print table: %w", err)
+	}
+
+	// Intercept SIGINT to trap CTRL+C and exit appropriately
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		<-c
+		if meta.Failed+meta.Pending > 0 {
+			// NOTE: given is not possible to return an error from here
+			// exit with error as checksRun() does
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}()
+
+	for meta.Pending > 0 {
+		time.Sleep(duration)
+
+		if err := opts.IO.EnableVirtualTerminalProcessing(); err == nil {
+			// ANSI escape code to clean terminal window
+			// https://stackoverflow.com/a/22892171
+			fmt.Print(opts.IO.Out, "\033[H\033[2J")
+		}
+
+		checks, meta, err = collect(opts)
+		if err != nil {
+			return fmt.Errorf("cannot collect checks information: %w", err)
+		}
+
+		err = printTable(isTerminal, cs, meta, checks, opts)
+		if err != nil {
+			return fmt.Errorf("cannot print table: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func checksRun(opts *ChecksOptions) error {

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultInterval int = 10
+const defaultInterval time.Duration = 10 * time.Second
 
 type browser interface {
 	Browse(string) error
@@ -32,7 +32,6 @@ type ChecksOptions struct {
 }
 
 func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Command {
-	var interval int
 	opts := &ChecksOptions{
 		IO:      f.IOStreams,
 		Browser: f.Browser,
@@ -59,12 +58,6 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("cannot use `--interval` flag without `--watch` flag")
 			}
 
-			var err error
-			opts.Interval, err = time.ParseDuration(fmt.Sprintf("%ds", interval))
-			if err != nil {
-				return cmdutil.FlagErrorf("could not parse `--interval` flag: %w", err)
-			}
-
 			if len(args) > 0 {
 				opts.SelectorArg = args[0]
 			}
@@ -79,7 +72,7 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 
 	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open the web browser to show details about checks")
 	cmd.Flags().BoolVarP(&opts.Watch, "watch", "", false, "Watch checks until they finish")
-	cmd.Flags().IntVarP(&interval, "interval", "i", defaultInterval, "Refresh interval in seconds when using `--watch` flag")
+	cmd.Flags().DurationVarP(&opts.Interval, "interval", "i", defaultInterval, "Refresh interval in seconds when using `--watch` flag")
 
 	return cmd
 }

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultInterval int = 30
+const defaultInterval int = 10
 
 type browser interface {
 	Browse(string) error

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -75,8 +75,8 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 	}
 
 	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open the web browser to show details about checks")
-	cmd.Flags().BoolVarP(&opts.Watch, "watch", "", false, "Watch checks and wait until are finished running")
-	cmd.Flags().IntVarP(&opts.Interval, "interval", "i", defaultInterval, "The number of seconds between each reprint When using --watch")
+	cmd.Flags().BoolVarP(&opts.Watch, "watch", "", false, "Watch checks until they finish")
+	cmd.Flags().IntVarP(&opts.Interval, "interval", "i", defaultInterval, "Refresh interval in seconds when using watch flag")
 
 	return cmd
 }

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -2,8 +2,6 @@ package checks
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
@@ -120,19 +118,6 @@ func checksRunWatchMode(opts *ChecksOptions) error {
 	if err != nil {
 		return fmt.Errorf("cannot print table: %w", err)
 	}
-
-	// Intercept SIGINT to trap CTRL+C and exit appropriately
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	go func() {
-		<-c
-		if meta.Failed+meta.Pending > 0 {
-			// NOTE: given is not possible to return an error from here
-			// exit with error as checksRun() does
-			os.Exit(1)
-		}
-		os.Exit(0)
-	}()
 
 	for meta.Pending > 0 {
 		time.Sleep(duration)

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -55,15 +55,14 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("argument required when using the `--repo` flag")
 			}
 
-			if cmd.Flags().Changed("interval") {
-				if !opts.Watch {
-					return cmdutil.FlagErrorf("cannot use `--interval` flag without `--watch` flag")
-				}
-				var err error
-				opts.Interval, err = time.ParseDuration(fmt.Sprintf("%ds", interval))
-				if err != nil {
-					return cmdutil.FlagErrorf("could not parse `--interval` flag: %w", err)
-				}
+			if !opts.Watch && cmd.Flags().Changed("interval") {
+				return cmdutil.FlagErrorf("cannot use `--interval` flag without `--watch` flag")
+			}
+
+			var err error
+			opts.Interval, err = time.ParseDuration(fmt.Sprintf("%ds", interval))
+			if err != nil {
+				return cmdutil.FlagErrorf("could not parse `--interval` flag: %w", err)
 			}
 
 			if len(args) > 0 {

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -139,6 +139,11 @@ func checksRunWatchMode(opts *ChecksOptions) error {
 		}
 	}
 
+	// NOTE: all tasks have finished at this point, per the for loop above
+	if meta.Failed > 0 {
+		return cmdutil.SilentError
+	}
+
 	return nil
 }
 

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -55,14 +55,15 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("argument required when using the `--repo` flag")
 			}
 
-			if !opts.Watch && cmd.Flags().Changed("interval") {
-				return cmdutil.FlagErrorf("cannot use `--interval` flag without `--watch` flag")
-			}
-
-			var err error
-			opts.Interval, err = time.ParseDuration(fmt.Sprintf("%ds", interval))
-			if err != nil {
-				return cmdutil.FlagErrorf("could not parse `--interval` flag: %w", err)
+			if cmd.Flags().Changed("interval") {
+				if !opts.Watch {
+					return cmdutil.FlagErrorf("cannot use `--interval` flag without `--watch` flag")
+				}
+				var err error
+				opts.Interval, err = time.ParseDuration(fmt.Sprintf("%ds", interval))
+				if err != nil {
+					return cmdutil.FlagErrorf("could not parse `--interval` flag: %w", err)
+				}
 			}
 
 			if len(args) > 0 {

--- a/pkg/cmd/pr/checks/checks_test.go
+++ b/pkg/cmd/pr/checks/checks_test.go
@@ -227,7 +227,7 @@ func TestChecksRun_web(t *testing.T) {
 			_, teardown := run.Stub()
 			defer teardown(t)
 
-			err := checksRun(&ChecksOptions{
+			err := checksRunWebMode(&ChecksOptions{
 				IO:          io,
 				Browser:     browser,
 				WebMode:     true,

--- a/pkg/cmd/pr/checks/checks_test.go
+++ b/pkg/cmd/pr/checks/checks_test.go
@@ -28,22 +28,26 @@ func TestNewCmdChecks(t *testing.T) {
 		wantsError string
 	}{
 		{
-			name:  "no arguments",
-			cli:   "",
-			wants: ChecksOptions{},
+			name: "no arguments",
+			cli:  "",
+			wants: ChecksOptions{
+				Interval: time.Duration(10000000000),
+			},
 		},
 		{
 			name: "pr argument",
 			cli:  "1234",
 			wants: ChecksOptions{
 				SelectorArg: "1234",
+				Interval:    time.Duration(10000000000),
 			},
 		},
 		{
 			name: "watch flag",
 			cli:  "--watch",
 			wants: ChecksOptions{
-				Watch: true,
+				Watch:    true,
+				Interval: time.Duration(10000000000),
 			},
 		},
 		{

--- a/pkg/cmd/pr/checks/checks_test.go
+++ b/pkg/cmd/pr/checks/checks_test.go
@@ -81,13 +81,13 @@ func Test_checksRun(t *testing.T) {
 			name:    "no commits",
 			prJSON:  `{ "number": 123 }`,
 			wantOut: "",
-			wantErr: "cannot collect checks information: no commit found on the pull request",
+			wantErr: "no commit found on the pull request",
 		},
 		{
 			name:    "no checks",
-			prJSON:  `{ "number": 123, "statusCheckRollup": { "nodes": [{"commit": {"oid": "abc"}}]}, "baseRefName": "master" }`,
+			prJSON:  `{ "number": 123, "statusCheckRollup": { "nodes": [{"commit": {"oid": "abc"}}]}, "headRefName": "master" }`,
 			wantOut: "",
-			wantErr: "cannot collect checks information: no checks reported on the 'master' branch",
+			wantErr: "no checks reported on the 'master' branch",
 		},
 		{
 			name:    "some failing",
@@ -116,9 +116,9 @@ func Test_checksRun(t *testing.T) {
 		{
 			name:    "no checks",
 			nontty:  true,
-			prJSON:  `{ "number": 123, "statusCheckRollup": { "nodes": [{"commit": {"oid": "abc"}}]}, "baseRefName": "master" }`,
+			prJSON:  `{ "number": 123, "statusCheckRollup": { "nodes": [{"commit": {"oid": "abc"}}]}, "headRefName": "master" }`,
 			wantOut: "",
-			wantErr: "cannot collect checks information: no checks reported on the 'master' branch",
+			wantErr: "no checks reported on the 'master' branch",
 		},
 		{
 			name:    "some failing",

--- a/pkg/cmd/pr/checks/checks_test.go
+++ b/pkg/cmd/pr/checks/checks_test.go
@@ -81,13 +81,13 @@ func Test_checksRun(t *testing.T) {
 			name:    "no commits",
 			prJSON:  `{ "number": 123 }`,
 			wantOut: "",
-			wantErr: "no commit found on the pull request",
+			wantErr: "cannot collect checks information: no commit found on the pull request",
 		},
 		{
 			name:    "no checks",
 			prJSON:  `{ "number": 123, "statusCheckRollup": { "nodes": [{"commit": {"oid": "abc"}}]}, "baseRefName": "master" }`,
 			wantOut: "",
-			wantErr: "no checks reported on the 'master' branch",
+			wantErr: "cannot collect checks information: no checks reported on the 'master' branch",
 		},
 		{
 			name:    "some failing",
@@ -118,7 +118,7 @@ func Test_checksRun(t *testing.T) {
 			nontty:  true,
 			prJSON:  `{ "number": 123, "statusCheckRollup": { "nodes": [{"commit": {"oid": "abc"}}]}, "baseRefName": "master" }`,
 			wantOut: "",
-			wantErr: "no checks reported on the 'master' branch",
+			wantErr: "cannot collect checks information: no checks reported on the 'master' branch",
 		},
 		{
 			name:    "some failing",

--- a/pkg/cmd/pr/checks/collect.go
+++ b/pkg/cmd/pr/checks/collect.go
@@ -1,0 +1,120 @@
+package checks
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
+)
+
+type check struct {
+	Name        string    `json:"name"`
+	State       string    `json:"state"`
+	StartedAt   time.Time `json:"startedAt"`
+	CompletedAt time.Time `json:"completedAt"`
+	Link        string    `json:"link"`
+	Bucket      string    `json:"bucket"`
+}
+
+type checksMeta struct {
+	Failed   int
+	Passed   int
+	Pending  int
+	Skipping int
+}
+
+func collect(opts *ChecksOptions) ([]check, checksMeta, error) {
+	checks := []check{}
+	meta := checksMeta{}
+
+	findOptions := shared.FindOptions{
+		Selector: opts.SelectorArg,
+		Fields:   []string{"number", "baseRefName", "statusCheckRollup"},
+	}
+	pr, _, err := opts.Finder.Find(findOptions)
+	if err != nil {
+		return checks, meta, err
+	}
+
+	if len(pr.StatusCheckRollup.Nodes) == 0 {
+		return checks, meta, fmt.Errorf("no commit found on the pull request")
+	}
+
+	rollup := pr.StatusCheckRollup.Nodes[0].Commit.StatusCheckRollup.Contexts.Nodes
+	if len(rollup) == 0 {
+		return checks, meta, fmt.Errorf("no checks reported on the '%s' branch", pr.BaseRefName)
+	}
+
+	checkContexts := pr.StatusCheckRollup.Nodes[0].Commit.StatusCheckRollup.Contexts.Nodes
+	for _, c := range eliminateDuplicates(checkContexts) {
+		state := c.State
+		if state == "" {
+			if c.Status == "COMPLETED" {
+				state = c.Conclusion
+			} else {
+				state = c.Status
+			}
+		}
+
+		link := c.DetailsURL
+		if link == "" {
+			link = c.TargetURL
+		}
+
+		name := c.Name
+		if name == "" {
+			name = c.Context
+		}
+
+		item := check{
+			Name:        name,
+			State:       state,
+			StartedAt:   c.StartedAt,
+			CompletedAt: c.CompletedAt,
+			Link:        link,
+		}
+		switch state {
+		case "SUCCESS":
+			item.Bucket = "pass"
+			meta.Passed++
+		case "SKIPPED", "NEUTRAL":
+			item.Bucket = "skipping"
+			meta.Skipping++
+		case "ERROR", "FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED":
+			item.Bucket = "fail"
+			meta.Failed++
+		default: // "EXPECTED", "REQUESTED", "WAITING", "QUEUED", "PENDING", "IN_PROGRESS", "STALE"
+			item.Bucket = "pending"
+			meta.Pending++
+		}
+
+		checks = append(checks, item)
+	}
+
+	return checks, meta, nil
+}
+
+func eliminateDuplicates(checkContexts []api.CheckContext) []api.CheckContext {
+	// To return the most recent check, sort in descending order by StartedAt.
+	sort.Slice(checkContexts, func(i, j int) bool { return checkContexts[i].StartedAt.After(checkContexts[j].StartedAt) })
+
+	m := make(map[string]struct{})
+	unique := make([]api.CheckContext, 0, len(checkContexts))
+
+	// Eliminate duplicates using Name or Context.
+	for _, ctx := range checkContexts {
+		key := ctx.Name
+		if key == "" {
+			key = ctx.Context
+		}
+		if _, ok := m[key]; ok {
+			continue
+		}
+		unique = append(unique, ctx)
+		m[key] = struct{}{}
+	}
+
+	return unique
+}

--- a/pkg/cmd/pr/checks/output.go
+++ b/pkg/cmd/pr/checks/output.go
@@ -1,0 +1,108 @@
+package checks
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/utils"
+)
+
+func addRow(tp utils.TablePrinter, isTerminal bool, cs *iostreams.ColorScheme, o check) {
+	elapsed := ""
+	zeroTime := time.Time{}
+
+	if o.StartedAt != zeroTime && o.CompletedAt != zeroTime {
+		e := o.CompletedAt.Sub(o.StartedAt)
+		if e > 0 {
+			elapsed = e.String()
+		}
+	}
+
+	mark := "✓"
+	markColor := cs.Green
+	switch o.Bucket {
+	case "fail":
+		mark = "X"
+		markColor = cs.Red
+	case "pending":
+		mark = "*"
+		markColor = cs.Yellow
+	case "skipping":
+		mark = "-"
+		markColor = cs.Gray
+	}
+
+	if isTerminal {
+		tp.AddField(mark, nil, markColor)
+		tp.AddField(o.Name, nil, nil)
+		tp.AddField(elapsed, nil, nil)
+		tp.AddField(o.Link, nil, nil)
+	} else {
+		tp.AddField(o.Name, nil, nil)
+		tp.AddField(o.Bucket, nil, nil)
+		if elapsed == "" {
+			tp.AddField("0", nil, nil)
+		} else {
+			tp.AddField(elapsed, nil, nil)
+		}
+		tp.AddField(o.Link, nil, nil)
+	}
+
+	tp.EndRow()
+}
+
+func printTable(isTerminal bool, cs *iostreams.ColorScheme, meta checksMeta, checks []check, opts *ChecksOptions) error {
+	summary := ""
+	if meta.Failed+meta.Passed+meta.Skipping+meta.Pending > 0 {
+		if meta.Failed > 0 {
+			summary = "Some checks were not successful"
+		} else if meta.Pending > 0 {
+			summary = "Some checks are still pending"
+		} else {
+			summary = "All checks were successful"
+		}
+
+		tallies := fmt.Sprintf("%d failing, %d successful, %d skipped, and %d pending checks",
+			meta.Failed, meta.Passed, meta.Skipping, meta.Pending)
+
+		summary = fmt.Sprintf("%s\n%s", cs.Bold(summary), tallies)
+	}
+
+	if isTerminal {
+		fmt.Fprintln(opts.IO.Out, summary)
+		fmt.Fprintln(opts.IO.Out)
+	}
+
+	tp := utils.NewTablePrinter(opts.IO)
+
+	sort.Slice(checks, func(i, j int) bool {
+		b0 := checks[i].Bucket
+		n0 := checks[i].Name
+		l0 := checks[i].Link
+		b1 := checks[j].Bucket
+		n1 := checks[j].Name
+		l1 := checks[j].Link
+
+		if b0 == b1 {
+			if n0 == n1 {
+				return l0 < l1
+			}
+			return n0 < n1
+		}
+
+		return (b0 == "fail") || (b0 == "pending" && b1 == "success")
+	})
+
+	for _, o := range checks {
+		addRow(tp, isTerminal, cs, o)
+	}
+
+	err := tp.Render()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Hello maintainers! 

I'm using GitHub for a lot of projects, and found myself in the same situation as explained in https://github.com/cli/cli/issues/3669

CI checks takes a long time to run, and manually refreshing the GitHub web interface is suboptimal.

Following the discussion in the linked issue, I added a `--wait` flag to `pr checks` command. When this flag is used, the command does not exit immediately but report on current check statuses and wait until the number of pending checks is 0.

[![asciicast](https://asciinema.org/a/442125.svg)](https://asciinema.org/a/442125)

Fixes #3669

Implementation wise this PR refactor the current `pr checks` code to extract the data gathering logic and splits the 3 "modes" (web mode, wait mode, single execution mode) to reuse the current functionalities in multiple places. Existing functionalities have not been modified.  

I did not work on the `--watch` as I think it requires a bit more discussion around the desired UI, while the `--wait` is useful to everyone having to wait for a slow CI with a simpler UI.  
With this command is possible to execute use cases like "merge after all checks have been successful" from the GitHub CLI.

Happy to receive feedback about this, there are possible improvements but I wanted to keep this focused on a single change.  
Thank you!
