### PR TITLE
codespace: implement new API payload

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -116,7 +116,8 @@ func jsonErrorResponse(b []byte) error {
 
 // Repository represents a GitHub repository.
 type Repository struct {
-	ID int `json:"id"`
+	ID       int    `json:"id"`
+	FullName string `json:"full_name"`
 }
 
 // GetRepository returns the repository associated with the given owner and name.
@@ -152,37 +153,27 @@ func (a *API) GetRepository(ctx context.Context, nwo string) (*Repository, error
 
 // Codespace represents a codespace.
 type Codespace struct {
-	Name           string               `json:"name"`
-	CreatedAt      string               `json:"created_at"`
-	LastUsedAt     string               `json:"last_used_at"`
-	State          string               `json:"state"`
-	Branch         string               `json:"branch"`
-	RepositoryName string               `json:"repository_name"`
-	RepositoryNWO  string               `json:"repository_nwo"`
-	OwnerLogin     string               `json:"owner_login"`
-	Environment    CodespaceEnvironment `json:"environment"`
-	Connection     CodespaceConnection  `json:"connection"`
+	Name       string              `json:"name"`
+	CreatedAt  string              `json:"created_at"`
+	LastUsedAt string              `json:"last_used_at"`
+	Owner      User                `json:"owner"`
+	Repository Repository          `json:"repository"`
+	State      string              `json:"state"`
+	GitStatus  CodespaceGitStatus  `json:"git_status"`
+	Connection CodespaceConnection `json:"connection"`
 }
 
-const CodespaceStateProvisioned = "provisioned"
-
-type CodespaceEnvironment struct {
-	State     string                        `json:"state"`
-	GitStatus CodespaceEnvironmentGitStatus `json:"gitStatus"`
-}
-
-type CodespaceEnvironmentGitStatus struct {
+type CodespaceGitStatus struct {
 	Ahead                int    `json:"ahead"`
 	Behind               int    `json:"behind"`
-	Branch               string `json:"branch"`
-	Commit               string `json:"commit"`
+	Ref                  string `json:"ref"`
 	HasUnpushedChanges   bool   `json:"hasUnpushedChanges"`
 	HasUncommitedChanges bool   `json:"hasUncommitedChanges"`
 }
 
 const (
-	// CodespaceEnvironmentStateAvailable is the state for a running codespace environment.
-	CodespaceEnvironmentStateAvailable = "Available"
+	// CodespaceStateAvailable is the state for a running codespace environment.
+	CodespaceStateAvailable = "Available"
 )
 
 type CodespaceConnection struct {
@@ -459,7 +450,7 @@ func (a *API) CreateCodespace(ctx context.Context, params *CreateCodespaceParams
 			}
 
 			// we continue to poll until the codespace shows as provisioned
-			if codespace.State != CodespaceStateProvisioned {
+			if codespace.State != CodespaceStateAvailable {
 				continue
 			}
 
@@ -549,13 +540,13 @@ type getCodespaceRepositoryContentsResponse struct {
 }
 
 func (a *API) GetCodespaceRepositoryContents(ctx context.Context, codespace *Codespace, path string) ([]byte, error) {
-	req, err := http.NewRequest(http.MethodGet, a.githubAPI+"/repos/"+codespace.RepositoryNWO+"/contents/"+path, nil)
+	req, err := http.NewRequest(http.MethodGet, a.githubAPI+"/repos/"+codespace.Repository.FullName+"/contents/"+path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
 	q := req.URL.Query()
-	q.Add("ref", codespace.Branch)
+	q.Add("ref", codespace.GitStatus.Ref)
 	req.URL.RawQuery = q.Encode()
 
 	a.setHeaders(req)

--- a/internal/codespaces/codespaces.go
+++ b/internal/codespaces/codespaces.go
@@ -27,7 +27,7 @@ func connectionReady(codespace *api.Codespace) bool {
 		codespace.Connection.SessionToken != "" &&
 		codespace.Connection.RelayEndpoint != "" &&
 		codespace.Connection.RelaySAS != "" &&
-		codespace.Environment.State == api.CodespaceEnvironmentStateAvailable
+		codespace.State == api.CodespaceStateAvailable
 }
 
 type apiClient interface {
@@ -39,7 +39,7 @@ type apiClient interface {
 // and connects to it using a Live Share session.
 func ConnectToLiveshare(ctx context.Context, log logger, sessionLogger liveshareLogger, apiClient apiClient, codespace *api.Codespace) (*liveshare.Session, error) {
 	var startedCodespace bool
-	if codespace.Environment.State != api.CodespaceEnvironmentStateAvailable {
+	if codespace.State != api.CodespaceStateAvailable {
 		startedCodespace = true
 		log.Print("Starting your codespace...")
 		if err := apiClient.StartCodespace(ctx, codespace.Name); err != nil {

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -226,17 +226,17 @@ type codespace struct {
 // If includeGitStatus is true, the branch will include a star if
 // the codespace has unsaved changes.
 func (c codespace) displayName(includeName, includeGitStatus bool) string {
-	branch := c.Branch
+	branch := c.GitStatus.Ref
 	if includeGitStatus {
 		branch = c.branchWithGitStatus()
 	}
 
 	if includeName {
 		return fmt.Sprintf(
-			"%s: %s [%s]", c.RepositoryNWO, branch, c.Name,
+			"%s: %s [%s]", c.Repository.FullName, branch, c.Name,
 		)
 	}
-	return c.RepositoryNWO + ": " + branch
+	return c.Repository.FullName + ": " + branch
 }
 
 // gitStatusDirty represents an unsaved changes status.
@@ -246,14 +246,14 @@ const gitStatusDirty = "*"
 // if the branch is currently being worked on.
 func (c codespace) branchWithGitStatus() string {
 	if c.hasUnsavedChanges() {
-		return c.Branch + gitStatusDirty
+		return c.GitStatus.Ref + gitStatusDirty
 	}
 
-	return c.Branch
+	return c.GitStatus.Ref
 }
 
 // hasUnsavedChanges returns whether the environment has
 // unsaved changes.
 func (c codespace) hasUnsavedChanges() bool {
-	return c.Environment.GitStatus.HasUncommitedChanges || c.Environment.GitStatus.HasUnpushedChanges
+	return c.GitStatus.HasUncommitedChanges || c.GitStatus.HasUnpushedChanges
 }

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -89,7 +89,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 		if nameFilter != "" && c.Name != nameFilter {
 			continue
 		}
-		if opts.repoFilter != "" && !strings.EqualFold(c.RepositoryNWO, opts.repoFilter) {
+		if opts.repoFilter != "" && !strings.EqualFold(c.Repository.FullName, opts.repoFilter) {
 			continue
 		}
 		if opts.keepDays > 0 {

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -53,16 +53,22 @@ func TestDelete(t *testing.T) {
 			},
 			codespaces: []*api.Codespace{
 				{
-					Name:          "monalisa-spoonknife-123",
-					RepositoryNWO: "monalisa/Spoon-Knife",
+					Name: "monalisa-spoonknife-123",
+					Repository: api.Repository{
+						FullName: "monalisa/Spoon-Knife",
+					},
 				},
 				{
-					Name:          "hubot-robawt-abc",
-					RepositoryNWO: "hubot/ROBAWT",
+					Name: "hubot-robawt-abc",
+					Repository: api.Repository{
+						FullName: "hubot/ROBAWT",
+					},
 				},
 				{
-					Name:          "monalisa-spoonknife-c4f3",
-					RepositoryNWO: "monalisa/Spoon-Knife",
+					Name: "monalisa-spoonknife-c4f3",
+					Repository: api.Repository{
+						FullName: "monalisa/Spoon-Knife",
+					},
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123", "monalisa-spoonknife-c4f3"},
@@ -122,27 +128,21 @@ func TestDelete(t *testing.T) {
 			codespaces: []*api.Codespace{
 				{
 					Name: "monalisa-spoonknife-123",
-					Environment: api.CodespaceEnvironment{
-						GitStatus: api.CodespaceEnvironmentGitStatus{
-							HasUnpushedChanges: true,
-						},
+					GitStatus: api.CodespaceGitStatus{
+						HasUnpushedChanges: true,
 					},
 				},
 				{
 					Name: "hubot-robawt-abc",
-					Environment: api.CodespaceEnvironment{
-						GitStatus: api.CodespaceEnvironmentGitStatus{
-							HasUncommitedChanges: true,
-						},
+					GitStatus: api.CodespaceGitStatus{
+						HasUncommitedChanges: true,
 					},
 				},
 				{
 					Name: "monalisa-spoonknife-c4f3",
-					Environment: api.CodespaceEnvironment{
-						GitStatus: api.CodespaceEnvironmentGitStatus{
-							HasUnpushedChanges:   false,
-							HasUncommitedChanges: false,
-						},
+					GitStatus: api.CodespaceGitStatus{
+						HasUnpushedChanges:   false,
+						HasUncommitedChanges: false,
 					},
 				},
 			},

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -45,9 +45,9 @@ func (a *App) List(ctx context.Context, asJSON bool, limit int) error {
 		cs := codespace{apiCodespace}
 		table.Append([]string{
 			cs.Name,
-			cs.RepositoryNWO,
+			cs.Repository.FullName,
 			cs.branchWithGitStatus(),
-			cs.Environment.State,
+			cs.State,
 			cs.CreatedAt,
 		})
 	}


### PR DESCRIPTION
This is a *breaking* change. Once this lands we must staff ship the feature flag that switches these endpoints to the new payloads. It means every internal user will need to update to the latest.