### PR TITLE
codespace: switches port binding to 127.0.0.1 where possible

### DIFF
--- a/internal/codespaces/states.go
+++ b/internal/codespaces/states.go
@@ -52,7 +52,7 @@ func PollPostCreateStates(ctx context.Context, logger logger, apiClient apiClien
 	}()
 
 	// Ensure local port is listening before client (getPostCreateOutput) connects.
-	listen, err := net.Listen("tcp", ":0") // arbitrary port
+	listen, err := net.Listen("tcp", "127.0.0.1:0") // arbitrary port
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/codespace/logs.go
+++ b/pkg/cmd/codespace/logs.go
@@ -62,7 +62,7 @@ func (a *App) Logs(ctx context.Context, codespaceName string, follow bool) (err 
 	}
 
 	// Ensure local port is listening before client (getPostCreateOutput) connects.
-	listen, err := net.Listen("tcp", ":0") // arbitrary port
+	listen, err := net.Listen("tcp", "127.0.0.1:0") // arbitrary port
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -94,7 +94,9 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 	usingCustomPort := localSSHServerPort != 0 // suppress log of command line in Shell
 
 	// Ensure local port is listening before client (Shell) connects.
-	listen, err := net.Listen("tcp", fmt.Sprintf(":%d", localSSHServerPort))
+	// Unless the user specifies a server port, localSSHServerPort is 0
+	// and thus the client will pick a random port.
+	listen, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", localSSHServerPort))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Avoids the accept connections prompt (to be verified by @mislav )
- Port forwarding still uses an empty interface to avoid sudo prompts