### PR TITLE
codespace: update running method

### DIFF
--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -261,5 +261,5 @@ func (c codespace) hasUnsavedChanges() bool {
 
 // running returns whether the codespace environment is running.
 func (c codespace) running() bool {
-	return c.Environment.State == api.CodespaceEnvironmentStateAvailable
+	return c.State == api.CodespaceStateAvailable
 }


### PR DESCRIPTION
This landed in `trunk` before the API that updates to the new payload and I did not catch it.
