### PR TITLE
change expected delete status to 202

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -521,7 +521,7 @@ func (a *API) DeleteCodespace(ctx context.Context, codespaceName string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		return api.HandleHTTPError(resp)
 	}
 


### PR DESCRIPTION
I'm getting errors when trying to delete codespaces, despite the operation succeeding.

I think success for this call is actually 202 rather than 200?

fixes https://github.com/cli/cli/issues/4530