### PR TITLE
Avoid exiting with error when trying to install the same dep twice

### DIFF
--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -66,8 +66,7 @@ func TestNewCmdExtension(t *testing.T) {
 					assert.Equal(t, 1, len(calls))
 				}
 			},
-			wantErr: true,
-			errMsg:  "there is already an installed extension that provides the \"existing-ext\" command",
+			wantStderr: "there is already an installed extension that provides the \"existing-ext\" command\n",
 		},
 		{
 			name: "install local extension",
@@ -415,15 +414,6 @@ func Test_checkValidExtension(t *testing.T) {
 				extName: "gh-auth",
 			},
 			wantError: "\"auth\" matches the name of a built-in command",
-		},
-		{
-			name: "clashes with an installed extension",
-			args: args{
-				rootCmd: rootCmd,
-				manager: m,
-				extName: "gh-triage",
-			},
-			wantError: "there is already an installed extension that provides the \"triage\" command",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #4463 

Before if you ran `gh extension install <some-dep>` twice, on the second attempt it was exiting with the error code 1, now it just prints the error message but terminates the program successfully (code 0). 