### PR TITLE
Fix paginate with page bug for api sub command.

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -242,6 +242,7 @@ func apiRun(opts *ApiOptions) error {
 
 	if opts.Paginate && !isGraphQL {
 		requestPath = addPerPage(requestPath, 100, params)
+		requestPath = addPage(requestPath, 1, params)
 	}
 
 	if opts.RequestInputFile != "" {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -545,14 +545,14 @@ func Test_apiRun_paginationREST(t *testing.T) {
 			StatusCode: 200,
 			Body:       ioutil.NopCloser(bytes.NewBufferString(`{"page":1}`)),
 			Header: http.Header{
-				"Link": []string{`<https://api.github.com/repositories/1227/issues?page=2>; rel="next", <https://api.github.com/repositories/1227/issues?page=3>; rel="last"`},
+				"Link": []string{`<https://api.github.com/repositories/1227/issues?per_page=100&page=2>; rel="next", <https://api.github.com/repositories/1227/issues?per_page=100&page=3>; rel="last"`},
 			},
 		},
 		{
 			StatusCode: 200,
 			Body:       ioutil.NopCloser(bytes.NewBufferString(`{"page":2}`)),
 			Header: http.Header{
-				"Link": []string{`<https://api.github.com/repositories/1227/issues?page=3>; rel="next", <https://api.github.com/repositories/1227/issues?page=3>; rel="last"`},
+				"Link": []string{`<https://api.github.com/repositories/1227/issues?per_page=100&page=3>; rel="next", <https://api.github.com/repositories/1227/issues?per_page=100&page=3>; rel="last"`},
 			},
 		},
 		{
@@ -587,9 +587,9 @@ func Test_apiRun_paginationREST(t *testing.T) {
 	assert.Equal(t, `{"page":1}{"page":2}{"page":3}`, stdout.String(), "stdout")
 	assert.Equal(t, "", stderr.String(), "stderr")
 
-	assert.Equal(t, "https://api.github.com/issues?per_page=100", responses[0].Request.URL.String())
-	assert.Equal(t, "https://api.github.com/repositories/1227/issues?page=2", responses[1].Request.URL.String())
-	assert.Equal(t, "https://api.github.com/repositories/1227/issues?page=3", responses[2].Request.URL.String())
+	assert.Equal(t, "https://api.github.com/issues?per_page=100&page=1", responses[0].Request.URL.String())
+	assert.Equal(t, "https://api.github.com/repositories/1227/issues?per_page=100&page=2", responses[1].Request.URL.String())
+	assert.Equal(t, "https://api.github.com/repositories/1227/issues?per_page=100&page=3", responses[2].Request.URL.String())
 }
 
 func Test_apiRun_paginationGraphQL(t *testing.T) {

--- a/pkg/cmd/api/pagination.go
+++ b/pkg/cmd/api/pagination.go
@@ -89,9 +89,14 @@ loop:
 	return ""
 }
 
-func addPerPage(p string, perPage int, params map[string]interface{}) string {
-	if _, hasPerPage := params["per_page"]; hasPerPage {
-		return p
+func addPerPage(p string, defaultPerPage int, params map[string]interface{}) string {
+	perPage := defaultPerPage
+	if value, hasPerPage := params["per_page"]; hasPerPage {
+		switch v := value.(type) {
+		case int:
+			perPage = v
+		}
+		delete(params, "per_page")
 	}
 
 	idx := strings.IndexRune(p, '?')
@@ -105,4 +110,27 @@ func addPerPage(p string, perPage int, params map[string]interface{}) string {
 	}
 
 	return fmt.Sprintf("%s%sper_page=%d", p, sep, perPage)
+}
+
+func addPage(p string, defaultPage int, params map[string]interface{}) string {
+	page := defaultPage
+	if value, hasPage := params["page"]; hasPage {
+		switch v := value.(type) {
+		case int:
+			page = v
+		}
+		delete(params, "page")
+	}
+
+	idx := strings.IndexRune(p, '?')
+	sep := "?"
+
+	if idx >= 0 {
+		if qp, err := url.ParseQuery(p[idx+1:]); err == nil && qp.Get("page") != "" {
+			return p
+		}
+		sep = "&"
+	}
+
+	return fmt.Sprintf("%s%spage=%d", p, sep, page)
 }

--- a/pkg/cmd/api/pagination_test.go
+++ b/pkg/cmd/api/pagination_test.go
@@ -138,7 +138,7 @@ func Test_addPerPage(t *testing.T) {
 			want: "items?per_page=13",
 		},
 		{
-			name: "avoids adding per_page if already in params",
+			name: "use params per_page if already in params",
 			args: args{
 				p:       "items",
 				perPage: 13,
@@ -147,7 +147,7 @@ func Test_addPerPage(t *testing.T) {
 					"per_page": 99,
 				},
 			},
-			want: "items",
+			want: "items?per_page=99",
 		},
 		{
 			name: "avoids adding per_page if already in query",
@@ -163,6 +163,56 @@ func Test_addPerPage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := addPerPage(tt.args.p, tt.args.perPage, tt.args.params); got != tt.want {
 				t.Errorf("addPerPage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func Test_addPage(t *testing.T) {
+	type args struct {
+		p      string
+		page   int
+		params map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "adds page",
+			args: args{
+				p:      "items",
+				page:   3,
+				params: nil,
+			},
+			want: "items?page=3",
+		},
+		{
+			name: "use params page if already in params",
+			args: args{
+				p:    "items",
+				page: 3,
+				params: map[string]interface{}{
+					"state": "open",
+					"page":  4,
+				},
+			},
+			want: "items?page=4",
+		},
+		{
+			name: "avoids adding page if already in query",
+			args: args{
+				p:      "items?page=6&state=open",
+				page:   3,
+				params: nil,
+			},
+			want: "items?page=6&state=open",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := addPage(tt.args.p, tt.args.page, tt.args.params); got != tt.want {
+				t.Errorf("addPage() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #4540


- If the `page` option is specified, it overrides the `page` query parameter in the URL of the next page in the Link header.
- So, all request for same page that is specified by option.
