### PR TITLE
codespace: update cmd docs to match other commands

### DIFF
--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -1,21 +1,23 @@
 package codespace
 
 import (
+	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 )
-
-var version = "DEV" // Replaced in the release build process (by GoReleaser or Homebrew) by the git tag version number.
 
 func NewRootCmd(app *App) *cobra.Command {
 	root := &cobra.Command{
 		Use:           "codespace",
 		SilenceUsage:  true,  // don't print usage message after each error (see #80)
 		SilenceErrors: false, // print errors automatically so that main need not
-		Long: `Unofficial CLI tool to manage GitHub Codespaces.
-
-Running commands requires the GITHUB_TOKEN environment variable to be set to a
-token to access the GitHub API with.`,
-		Version: version,
+		Short:         "List, create, delete and SSH into codespaces",
+		Long:          `Work with GitHub codespaces`,
+		Example: heredoc.Doc(`
+			$ gh codespace list
+			$ gh codespace create
+			$ gh codespace delete
+			$ gh codespace ssh
+		`),
 	}
 
 	root.AddCommand(newCodeCmd(app))


### PR DESCRIPTION
- Updates the `pkg/cmd/codespace/root` command docs to adhere to the convention of other commands