### PR TITLE
codespace: fix Git status fields to snake case

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -155,8 +155,8 @@ type CodespaceGitStatus struct {
 	Ahead                int    `json:"ahead"`
 	Behind               int    `json:"behind"`
 	Ref                  string `json:"ref"`
-	HasUnpushedChanges   bool   `json:"hasUnpushedChanges"`
-	HasUncommitedChanges bool   `json:"hasUncommitedChanges"`
+	HasUnpushedChanges   bool   `json:"has_unpushed_changes"`
+	HasUncommitedChanges bool   `json:"has_uncommited_changes"`
 }
 
 const (


### PR DESCRIPTION
- Switch to snake case. This change was done in the public APIs only to adhere to the rest of the API
- Note: Connection details are still camel case given that this is a "hidden/internal" piece of data. I chatted with @bdmac about this and it'll stay as camelCase for now
