### PR TITLE
gh cs cp: copy files between local/remote file systems

### DIFF
--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -25,6 +25,24 @@ func Shell(ctx context.Context, log logger, sshArgs []string, port int, destinat
 	return cmd.Run()
 }
 
+// Copy runs an scp command over the specified port. The arguments may
+// include flags and non-flags, optionally separated by "--".
+// Remote files are indicated by a "user@host:" prefix.
+func Copy(ctx context.Context, scpArgs []string, port int) error {
+	// Beware: invalid syntax causes scp to exit 1 with
+	// no error message, so don't let that happen.
+	scpArgs = append([]string{
+		"-P", strconv.Itoa(port),
+		"-o", "NoHostAuthenticationForLocalhost=yes",
+		"-C", // compression
+	}, scpArgs...)
+	cmd := exec.CommandContext(ctx, "scp", scpArgs...)
+	cmd.Stdin = nil
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 // NewRemoteCommand returns an exec.Cmd that will securely run a shell
 // command on the remote machine.
 func NewRemoteCommand(ctx context.Context, tunnelPort int, destination string, sshArgs ...string) (*exec.Cmd, error) {

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -25,6 +25,7 @@ token to access the GitHub API with.`,
 	root.AddCommand(newLogsCmd(app))
 	root.AddCommand(newPortsCmd(app))
 	root.AddCommand(newSSHCmd(app))
+	root.AddCommand(newCpCmd(app))
 	root.AddCommand(newStopCmd(app))
 
 	return root


### PR DESCRIPTION
This PR adds a 'cs cp' subcommand that copies files between the local and remote file systems, using the "remote:" prefix to indicate the file system of the VM. Argument syntax follows cp and scp convention: one or more source files followed by a destination, which must be directory if there is more than one source. If any source is a directory, the -r (recursive) flag is required.

Fixes #4486