### PR TITLE
codespace: progress indicator, stdlib logger

### DIFF
--- a/internal/codespaces/codespaces.go
+++ b/internal/codespaces/codespaces.go
@@ -35,7 +35,7 @@ func ConnectToLiveshare(ctx context.Context, logger logger, sessionLogger *log.L
 	var startedCodespace bool
 	if codespace.State != api.CodespaceStateAvailable {
 		startedCodespace = true
-		log.Print("Starting your codespace...")
+		logger.Print("Starting your codespace...")
 		if err := apiClient.StartCodespace(ctx, codespace.Name); err != nil {
 			return nil, fmt.Errorf("error starting codespace: %w", err)
 		}
@@ -44,7 +44,7 @@ func ConnectToLiveshare(ctx context.Context, logger logger, sessionLogger *log.L
 	for retries := 0; !connectionReady(codespace); retries++ {
 		if retries > 1 {
 			if retries%2 == 0 {
-				log.Print(".")
+				logger.Print(".")
 			}
 
 			time.Sleep(1 * time.Second)
@@ -62,10 +62,10 @@ func ConnectToLiveshare(ctx context.Context, logger logger, sessionLogger *log.L
 	}
 
 	if startedCodespace {
-		fmt.Print("\n")
+		logger.Print("\n")
 	}
 
-	log.Println("Connecting to your codespace...")
+	logger.Println("Connecting to your codespace...")
 
 	return liveshare.Connect(ctx, liveshare.Options{
 		ClientName:     "gh",

--- a/internal/codespaces/codespaces.go
+++ b/internal/codespaces/codespaces.go
@@ -11,6 +11,11 @@ import (
 	"github.com/cli/cli/v2/pkg/liveshare"
 )
 
+type logger interface {
+	Print(v ...interface{})
+	Println(v ...interface{})
+}
+
 func connectionReady(codespace *api.Codespace) bool {
 	return codespace.Connection.SessionID != "" &&
 		codespace.Connection.SessionToken != "" &&
@@ -26,7 +31,7 @@ type apiClient interface {
 
 // ConnectToLiveshare waits for a Codespace to become running,
 // and connects to it using a Live Share session.
-func ConnectToLiveshare(ctx context.Context, logger, sessionLogger *log.Logger, apiClient apiClient, codespace *api.Codespace) (*liveshare.Session, error) {
+func ConnectToLiveshare(ctx context.Context, logger logger, sessionLogger *log.Logger, apiClient apiClient, codespace *api.Codespace) (*liveshare.Session, error) {
 	var startedCodespace bool
 	if codespace.State != api.CodespaceStateAvailable {
 		startedCodespace = true

--- a/internal/codespaces/codespaces.go
+++ b/internal/codespaces/codespaces.go
@@ -4,23 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/pkg/liveshare"
 )
-
-type logger interface {
-	Print(v ...interface{}) (int, error)
-	Println(v ...interface{}) (int, error)
-}
-
-// TODO(josebalius): clean this up once we standardrize
-// logging for codespaces
-type liveshareLogger interface {
-	Println(v ...interface{})
-	Printf(f string, v ...interface{})
-}
 
 func connectionReady(codespace *api.Codespace) bool {
 	return codespace.Connection.SessionID != "" &&
@@ -37,7 +26,7 @@ type apiClient interface {
 
 // ConnectToLiveshare waits for a Codespace to become running,
 // and connects to it using a Live Share session.
-func ConnectToLiveshare(ctx context.Context, log logger, sessionLogger liveshareLogger, apiClient apiClient, codespace *api.Codespace) (*liveshare.Session, error) {
+func ConnectToLiveshare(ctx context.Context, logger, sessionLogger *log.Logger, apiClient apiClient, codespace *api.Codespace) (*liveshare.Session, error) {
 	var startedCodespace bool
 	if codespace.State != api.CodespaceStateAvailable {
 		startedCodespace = true

--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -10,7 +10,7 @@ import (
 )
 
 type printer interface {
-	Println(v ...interface{})
+	Printf(fmt string, v ...interface{})
 }
 
 // Shell runs an interactive secure shell over an existing
@@ -23,7 +23,7 @@ func Shell(ctx context.Context, p printer, sshArgs []string, port int, destinati
 	}
 
 	if usingCustomPort {
-		p.Println("Connection Details: ssh " + destination + " " + strings.Join(connArgs, " "))
+		p.Printf("Connection Details: ssh %s %s", destination, connArgs)
 	}
 
 	return cmd.Run()

--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -3,6 +3,7 @@ package codespaces
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"strconv"
@@ -12,14 +13,14 @@ import (
 // Shell runs an interactive secure shell over an existing
 // port-forwarding session. It runs until the shell is terminated
 // (including by cancellation of the context).
-func Shell(ctx context.Context, log logger, sshArgs []string, port int, destination string, usingCustomPort bool) error {
+func Shell(ctx context.Context, logger *log.Logger, sshArgs []string, port int, destination string, usingCustomPort bool) error {
 	cmd, connArgs, err := newSSHCommand(ctx, port, destination, sshArgs)
 	if err != nil {
 		return fmt.Errorf("failed to create ssh command: %w", err)
 	}
 
 	if usingCustomPort {
-		log.Println("Connection Details: ssh " + destination + " " + strings.Join(connArgs, " "))
+		logger.Println("Connection Details: ssh " + destination + " " + strings.Join(connArgs, " "))
 	}
 
 	return cmd.Run()

--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -3,7 +3,6 @@ package codespaces
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strconv"
@@ -13,7 +12,7 @@ import (
 // Shell runs an interactive secure shell over an existing
 // port-forwarding session. It runs until the shell is terminated
 // (including by cancellation of the context).
-func Shell(ctx context.Context, logger *log.Logger, sshArgs []string, port int, destination string, usingCustomPort bool) error {
+func Shell(ctx context.Context, logger logger, sshArgs []string, port int, destination string, usingCustomPort bool) error {
 	cmd, connArgs, err := newSSHCommand(ctx, port, destination, sshArgs)
 	if err != nil {
 		return fmt.Errorf("failed to create ssh command: %w", err)

--- a/internal/codespaces/states.go
+++ b/internal/codespaces/states.go
@@ -38,7 +38,7 @@ type PostCreateState struct {
 // PollPostCreateStates watches for state changes in a codespace,
 // and calls the supplied poller for each batch of state changes.
 // It runs until it encounters an error, including cancellation of the context.
-func PollPostCreateStates(ctx context.Context, logger logger, apiClient apiClient, codespace *api.Codespace, poller func([]PostCreateState)) (err error) {
+func PollPostCreateStates(ctx context.Context, logger *log.Logger, apiClient apiClient, codespace *api.Codespace, poller func([]PostCreateState)) (err error) {
 	noopLogger := log.New(ioutil.Discard, "", 0)
 
 	session, err := ConnectToLiveshare(ctx, logger, noopLogger, apiClient, codespace)

--- a/internal/codespaces/states.go
+++ b/internal/codespaces/states.go
@@ -58,14 +58,14 @@ func PollPostCreateStates(ctx context.Context, progress progressIndicator, apiCl
 	}
 	localPort := listen.Addr().(*net.TCPAddr).Port
 
-	progress.StartProgressIndicatorWithSuffix("Fetching SSH Details")
+	progress.StartProgressIndicatorWithLabel("Fetching SSH Details")
+	defer progress.StopProgressIndicator()
 	remoteSSHServerPort, sshUser, err := session.StartSSHServer(ctx)
-	progress.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting ssh server details: %w", err)
 	}
 
-	progress.StartProgressIndicatorWithSuffix("Fetching status")
+	progress.StartProgressIndicatorWithLabel("Fetching status")
 	tunnelClosed := make(chan error, 1) // buffered to avoid sender stuckness
 	go func() {
 		fwd := liveshare.NewPortForwarder(session, "sshd", remoteSSHServerPort, false)

--- a/internal/codespaces/states.go
+++ b/internal/codespaces/states.go
@@ -38,7 +38,7 @@ type PostCreateState struct {
 // PollPostCreateStates watches for state changes in a codespace,
 // and calls the supplied poller for each batch of state changes.
 // It runs until it encounters an error, including cancellation of the context.
-func PollPostCreateStates(ctx context.Context, logger *log.Logger, apiClient apiClient, codespace *api.Codespace, poller func([]PostCreateState)) (err error) {
+func PollPostCreateStates(ctx context.Context, logger logger, apiClient apiClient, codespace *api.Codespace, poller func([]PostCreateState)) (err error) {
 	noopLogger := log.New(ioutil.Discard, "", 0)
 
 	session, err := ConnectToLiveshare(ctx, logger, noopLogger, apiClient, codespace)

--- a/internal/codespaces/states.go
+++ b/internal/codespaces/states.go
@@ -38,10 +38,10 @@ type PostCreateState struct {
 // PollPostCreateStates watches for state changes in a codespace,
 // and calls the supplied poller for each batch of state changes.
 // It runs until it encounters an error, including cancellation of the context.
-func PollPostCreateStates(ctx context.Context, logger logger, apiClient apiClient, codespace *api.Codespace, poller func([]PostCreateState)) (err error) {
+func PollPostCreateStates(ctx context.Context, progress progressIndicator, apiClient apiClient, codespace *api.Codespace, poller func([]PostCreateState)) (err error) {
 	noopLogger := log.New(ioutil.Discard, "", 0)
 
-	session, err := ConnectToLiveshare(ctx, logger, noopLogger, apiClient, codespace)
+	session, err := ConnectToLiveshare(ctx, progress, noopLogger, apiClient, codespace)
 	if err != nil {
 		return fmt.Errorf("connect to Live Share: %w", err)
 	}
@@ -58,12 +58,14 @@ func PollPostCreateStates(ctx context.Context, logger logger, apiClient apiClien
 	}
 	localPort := listen.Addr().(*net.TCPAddr).Port
 
-	logger.Println("Fetching SSH Details...")
+	progress.StartProgressIndicatorWithSuffix("Fetching SSH Details")
 	remoteSSHServerPort, sshUser, err := session.StartSSHServer(ctx)
+	progress.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting ssh server details: %w", err)
 	}
 
+	progress.StartProgressIndicatorWithSuffix("Fetching status")
 	tunnelClosed := make(chan error, 1) // buffered to avoid sender stuckness
 	go func() {
 		fwd := liveshare.NewPortForwarder(session, "sshd", remoteSSHServerPort, false)
@@ -73,6 +75,7 @@ func PollPostCreateStates(ctx context.Context, logger logger, apiClient apiClien
 	t := time.NewTicker(1 * time.Second)
 	defer t.Stop()
 
+	var ticks int
 	for {
 		select {
 		case <-ctx.Done():
@@ -83,9 +86,13 @@ func PollPostCreateStates(ctx context.Context, logger logger, apiClient apiClien
 
 		case <-t.C:
 			states, err := getPostCreateOutput(ctx, localPort, sshUser)
+			if ticks == 0 {
+				progress.StopProgressIndicator()
+			}
 			if err != nil {
 				return fmt.Errorf("get post create output: %w", err)
 			}
+			ticks++
 
 			poller(states)
 		}

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -173,6 +173,7 @@ func chooseCodespaceFromList(ctx context.Context, codespaces []*api.Codespace) (
 
 // getOrChooseCodespace prompts the user to choose a codespace if the codespaceName is empty.
 // It then fetches the codespace record with full connection details.
+// TODO(josebalius): accept a progress indicator or *App and show progress when fetching.
 func getOrChooseCodespace(ctx context.Context, apiClient apiClient, codespaceName string) (codespace *api.Codespace, err error) {
 	if codespaceName == "" {
 		codespace, err = chooseCodespace(ctx, apiClient)

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -47,13 +47,13 @@ func NewApp(io *iostreams.IOStreams, apiClient apiClient) *App {
 }
 
 func (a *App) StartProgressIndicatorWithSuffix(s string) {
-	if a.isInteractive {
-		a.io.StartProgressIndicatorWithSuffix(s)
+	if !a.isInteractive {
+		// if we are not interactive, log the progress states
+		a.logger.Println(s)
 		return
 	}
 
-	// if we are not interactive, log the progress states
-	a.logger.Println(s)
+	a.io.StartProgressIndicatorWithSuffix(s)
 }
 
 func (a *App) StopProgressIndicator() {

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -24,57 +24,27 @@ import (
 type App struct {
 	io        *iostreams.IOStreams
 	apiClient apiClient
-
-	logger, errLogger *log.Logger
-	isInteractive     bool
+	errLogger *log.Logger
 }
 
 func NewApp(io *iostreams.IOStreams, apiClient apiClient) *App {
-	isInteractive := io.IsStdinTTY() && io.IsStdoutTTY()
-
-	logger := noopLogger()
-	// TODO(josebalius): Accept a debug parameter
-	if os.Getenv("DEBUG") != "" {
-		logger = log.New(io.Out, "* ", 0)
-	}
 	errLogger := log.New(io.ErrOut, "", 0)
 
 	return &App{
-		io:            io,
-		apiClient:     apiClient,
-		logger:        logger,
-		errLogger:     errLogger,
-		isInteractive: isInteractive,
+		io:        io,
+		apiClient: apiClient,
+		errLogger: errLogger,
 	}
 }
 
-// StartProgressIndicatorWithSuffix starts a progress indicator with a message.
-// If the app is non-interactive the message is logged.
-func (a *App) StartProgressIndicatorWithSuffix(s string) {
-	if !a.isInteractive {
-		// if we are not interactive, log the progress states
-		a.logger.Println(s)
-		return
-	}
-
-	a.io.StartProgressIndicatorWithSuffix(s)
+// StartProgressIndicatorWithLabel starts a progress indicator with a message.
+func (a *App) StartProgressIndicatorWithLabel(s string) {
+	a.io.StartProgressIndicatorWithLabel(s)
 }
 
 // StopProgressIndicator stops the progress indicator.
 func (a *App) StopProgressIndicator() {
 	a.io.StopProgressIndicator()
-}
-
-func (a *App) Print(v ...interface{}) {
-	fmt.Fprint(a.io.Out, v...)
-}
-
-func (a *App) Println(v ...interface{}) {
-	fmt.Fprintln(a.io.Out, v...)
-}
-
-func (a *App) Printf(f string, v ...interface{}) {
-	fmt.Fprintf(a.io.Out, f, v...)
 }
 
 //go:generate moq -fmt goimports -rm -skip-ensure -out mock_api.go . apiClient

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -31,9 +31,8 @@ type App struct {
 func NewApp(io *iostreams.IOStreams, apiClient apiClient) *App {
 	isInteractive := io.IsStdinTTY() && io.IsStdoutTTY()
 	logger := noopLogger()
-	// TODO(josebalius): pass this in
-	if os.Getenv("DEBUG") != "" {
-		logger = log.New(io.Out, "* ", 0)
+	if isInteractive {
+		logger = log.New(io.Out, "", 0)
 	}
 	errLogger := log.New(io.ErrOut, "", 0)
 
@@ -46,18 +45,15 @@ func NewApp(io *iostreams.IOStreams, apiClient apiClient) *App {
 	}
 }
 
-func (a *App) progress(msg string) {
+func (a *App) Print(v ...interface{}) {
 	if a.isInteractive {
-		a.io.StartProgressIndicatorWithMessage(msg)
-		return
+		fmt.Fprint(a.io.Out, v...)
 	}
-
-	a.logger.Println(msg)
 }
 
-func (a *App) progressStop() {
+func (a *App) Println(v ...interface{}) {
 	if a.isInteractive {
-		a.io.StopProgressIndicator()
+		fmt.Fprintln(a.io.Out, v...)
 	}
 }
 

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -22,24 +22,19 @@ import (
 )
 
 type App struct {
-	io                *iostreams.IOStreams
-	apiClient         apiClient
-	logger, errLogger *log.Logger
-	isInteractive     bool
+	io            *iostreams.IOStreams
+	apiClient     apiClient
+	errLogger     *log.Logger
+	isInteractive bool
 }
 
 func NewApp(io *iostreams.IOStreams, apiClient apiClient) *App {
 	isInteractive := io.IsStdinTTY() && io.IsStdoutTTY()
-	logger := noopLogger()
-	if isInteractive {
-		logger = log.New(io.Out, "", 0)
-	}
 	errLogger := log.New(io.ErrOut, "", 0)
 
 	return &App{
 		io:            io,
 		apiClient:     apiClient,
-		logger:        logger,
 		errLogger:     errLogger,
 		isInteractive: isInteractive,
 	}
@@ -54,6 +49,12 @@ func (a *App) Print(v ...interface{}) {
 func (a *App) Println(v ...interface{}) {
 	if a.isInteractive {
 		fmt.Fprintln(a.io.Out, v...)
+	}
+}
+
+func (a *App) Printf(f string, v ...interface{}) {
+	if a.isInteractive {
+		fmt.Fprintf(a.io.Out, f, v...)
 	}
 }
 

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -78,7 +78,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return errors.New("there are no available machine types for this repository")
 	}
 
-	a.logger.Println("Creating your codespace...")
+	a.Println("Creating your codespace...")
 	codespace, err := a.apiClient.CreateCodespace(ctx, &api.CreateCodespaceParams{
 		RepositoryID: repository.ID,
 		Branch:       branch,
@@ -95,7 +95,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		}
 	}
 
-	a.logger.Println("Codespace created: ")
+	a.Println("Codespace created: ")
 
 	fmt.Fprintln(os.Stdout, codespace.Name)
 

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/cli/cli/v2/internal/codespaces"
 	"github.com/cli/cli/v2/internal/codespaces/api"
-	"github.com/cli/cli/v2/pkg/cmd/codespace/output"
 	"github.com/fatih/camelcase"
 	"github.com/spf13/cobra"
 )
@@ -56,7 +55,9 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return fmt.Errorf("error getting branch name: %w", err)
 	}
 
+	a.progress("Fetching repository")
 	repository, err := a.apiClient.GetRepository(ctx, repo)
+	a.progressStop()
 	if err != nil {
 		return fmt.Errorf("error getting repository: %w", err)
 	}
@@ -79,20 +80,20 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return errors.New("there are no available machine types for this repository")
 	}
 
-	a.logger.Print("Creating your codespace...")
+	a.progress("Creating your codespace...")
 	codespace, err := a.apiClient.CreateCodespace(ctx, &api.CreateCodespaceParams{
 		RepositoryID: repository.ID,
 		Branch:       branch,
 		Machine:      machine,
 		Location:     locationResult.Location,
 	})
-	a.logger.Print("\n")
+	a.progressStop()
 	if err != nil {
 		return fmt.Errorf("error creating codespace: %w", err)
 	}
 
 	if opts.showStatus {
-		if err := showStatus(ctx, a.logger, a.apiClient, userResult.User, codespace); err != nil {
+		if err := a.showStatus(ctx, userResult.User, codespace); err != nil {
 			return fmt.Errorf("show status: %w", err)
 		}
 	}
@@ -107,9 +108,11 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 // showStatus polls the codespace for a list of post create states and their status. It will keep polling
 // until all states have finished. Once all states have finished, we poll once more to check if any new
 // states have been introduced and stop polling otherwise.
-func showStatus(ctx context.Context, log *output.Logger, apiClient apiClient, user *api.User, codespace *api.Codespace) error {
-	var lastState codespaces.PostCreateState
-	var breakNextState bool
+func (a *App) showStatus(ctx context.Context, user *api.User, codespace *api.Codespace) error {
+	var (
+		lastState      codespaces.PostCreateState
+		breakNextState bool
+	)
 
 	finishedStates := make(map[string]bool)
 	ctx, stopPolling := context.WithCancel(ctx)
@@ -123,26 +126,24 @@ func showStatus(ctx context.Context, log *output.Logger, apiClient apiClient, us
 			}
 
 			if state.Name != lastState.Name {
-				log.Print(state.Name)
+				a.progress(state.Name)
 
 				if state.Status == codespaces.PostCreateStateRunning {
 					inProgress = true
 					lastState = state
-					log.Print("...")
 					break
 				}
 
 				finishedStates[state.Name] = true
-				log.Println("..." + state.Status)
+				a.progressStop()
 			} else {
 				if state.Status == codespaces.PostCreateStateRunning {
 					inProgress = true
-					log.Print(".")
 					break
 				}
 
 				finishedStates[state.Name] = true
-				log.Println(state.Status)
+				a.progressStop()
 				lastState = codespaces.PostCreateState{} // reset the value
 			}
 		}
@@ -156,7 +157,7 @@ func showStatus(ctx context.Context, log *output.Logger, apiClient apiClient, us
 		}
 	}
 
-	err := codespaces.PollPostCreateStates(ctx, log, apiClient, codespace, poller)
+	err := codespaces.PollPostCreateStates(ctx, a.logger, a.apiClient, codespace, poller)
 	if err != nil {
 		if errors.Is(err, context.Canceled) && breakNextState {
 			return nil // we cancelled the context to stop polling, we can ignore the error

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -52,7 +52,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return fmt.Errorf("error getting branch name: %w", err)
 	}
 
-	a.StartProgressIndicatorWithSuffix("Fetching repository")
+	a.StartProgressIndicatorWithLabel("Fetching repository")
 	repository, err := a.apiClient.GetRepository(ctx, repo)
 	a.StopProgressIndicator()
 	if err != nil {
@@ -77,7 +77,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return errors.New("there are no available machine types for this repository")
 	}
 
-	a.StartProgressIndicatorWithSuffix("Creating codespace")
+	a.StartProgressIndicatorWithLabel("Creating codespace")
 	codespace, err := a.apiClient.CreateCodespace(ctx, &api.CreateCodespaceParams{
 		RepositoryID: repository.ID,
 		Branch:       branch,
@@ -95,9 +95,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		}
 	}
 
-	a.Println("Codespace created.")
 	fmt.Fprintln(a.io.Out, codespace.Name)
-
 	return nil
 }
 
@@ -122,7 +120,7 @@ func (a *App) showStatus(ctx context.Context, user *api.User, codespace *api.Cod
 			}
 
 			if state.Name != lastState.Name {
-				a.StartProgressIndicatorWithSuffix(state.Name)
+				a.StartProgressIndicatorWithLabel(state.Name)
 
 				if state.Status == codespaces.PostCreateStateRunning {
 					inProgress = true

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -55,7 +54,9 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return fmt.Errorf("error getting branch name: %w", err)
 	}
 
+	a.StartProgressIndicatorWithSuffix("Fetching repository")
 	repository, err := a.apiClient.GetRepository(ctx, repo)
+	a.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting repository: %w", err)
 	}
@@ -78,13 +79,14 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return errors.New("there are no available machine types for this repository")
 	}
 
-	a.logger.Println("Creating your codespace...")
+	a.StartProgressIndicatorWithSuffix("Creating codespace")
 	codespace, err := a.apiClient.CreateCodespace(ctx, &api.CreateCodespaceParams{
 		RepositoryID: repository.ID,
 		Branch:       branch,
 		Machine:      machine,
 		Location:     locationResult.Location,
 	})
+	a.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error creating codespace: %w", err)
 	}
@@ -95,9 +97,8 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		}
 	}
 
-	a.logger.Println("Codespace created: ")
-
-	fmt.Fprintln(os.Stdout, codespace.Name)
+	a.Println("Codespace created.")
+	fmt.Fprintln(a.io.Out, codespace.Name)
 
 	return nil
 }
@@ -123,26 +124,24 @@ func (a *App) showStatus(ctx context.Context, user *api.User, codespace *api.Cod
 			}
 
 			if state.Name != lastState.Name {
-				a.Print(state.Name)
+				a.StartProgressIndicatorWithSuffix(state.Name)
 
 				if state.Status == codespaces.PostCreateStateRunning {
 					inProgress = true
 					lastState = state
-					a.Print("...")
 					break
 				}
 
 				finishedStates[state.Name] = true
-				a.Println("..." + state.Status)
+				a.StopProgressIndicator()
 			} else {
 				if state.Status == codespaces.PostCreateStateRunning {
 					inProgress = true
-					a.Print(".")
 					break
 				}
 
 				finishedStates[state.Name] = true
-				a.Println(state.Status)
+				a.StopProgressIndicator()
 				lastState = codespaces.PostCreateState{} // reset the value
 			}
 		}

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -137,7 +137,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 	if len(codespacesToDelete) > 1 {
 		noun = noun + "s"
 	}
-	a.logger.Println(noun + " deleted.")
+	a.Println(noun + " deleted.")
 
 	return nil
 }

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -122,7 +122,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 		codespaceName := c.Name
 		g.Go(func() error {
 			if err := a.apiClient.DeleteCodespace(ctx, codespaceName); err != nil {
-				_, _ = a.logger.Errorf("error deleting codespace %q: %v\n", codespaceName, err)
+				a.errLogger.Printf("error deleting codespace %q: %v\n", codespaceName, err)
 				return err
 			}
 			return nil

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/utils"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -121,13 +122,11 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 		return errors.New("no codespaces to delete")
 	}
 
-	noun := "Codespace"
-	if len(codespacesToDelete) > 1 {
-		noun = noun + "s"
-	}
-
-	a.StartProgressIndicatorWithSuffix(fmt.Sprintf("Deleting %s", strings.ToLower(noun)))
-	g := errgroup.Group{}
+	a.StartProgressIndicatorWithSuffix("Deleting codespace(s)")
+	var (
+		deletedCodespaces int
+		g                 = errgroup.Group{}
+	)
 	for _, c := range codespacesToDelete {
 		codespaceName := c.Name
 		g.Go(func() error {
@@ -135,6 +134,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 				a.errLogger.Printf("error deleting codespace %q: %v\n", codespaceName, err)
 				return err
 			}
+			deletedCodespaces++
 			return nil
 		})
 	}
@@ -145,7 +145,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 	}
 	a.StopProgressIndicator()
 
-	a.Println(noun + " deleted.")
+	a.Printf("%s deleted.\n", utils.Pluralize(deletedCodespaces, "codespace"))
 
 	return nil
 }

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -125,7 +125,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 	a.StartProgressIndicatorWithSuffix("Deleting codespace(s)")
 	var (
 		deletedCodespaces int
-		g                 = errgroup.Group{}
+		g                 errgroup.Group
 	)
 	for _, c := range codespacesToDelete {
 		codespaceName := c.Name

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -1,7 +1,6 @@
 package codespace
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,7 +11,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/codespaces/api"
-	"github.com/cli/cli/v2/pkg/cmd/codespace/output"
+	"github.com/cli/cli/v2/pkg/iostreams"
 )
 
 func TestDelete(t *testing.T) {
@@ -188,12 +187,10 @@ func TestDelete(t *testing.T) {
 				},
 			}
 
-			stdout := &bytes.Buffer{}
-			stderr := &bytes.Buffer{}
-			app := &App{
-				apiClient: apiMock,
-				logger:    output.NewLogger(stdout, stderr, false),
-			}
+			io, _, stdout, stderr := iostreams.Test()
+			io.SetStdinTTY(true)
+			io.SetStdoutTTY(true)
+			app := NewApp(io, apiMock)
 			err := app.Delete(context.Background(), opts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("delete() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -1,7 +1,6 @@
 package codespace
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,7 +11,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/codespaces/api"
-	"github.com/cli/cli/v2/pkg/cmd/codespace/output"
+	"github.com/cli/cli/v2/pkg/iostreams"
 )
 
 func TestDelete(t *testing.T) {
@@ -188,12 +187,8 @@ func TestDelete(t *testing.T) {
 				},
 			}
 
-			stdout := &bytes.Buffer{}
-			stderr := &bytes.Buffer{}
-			app := &App{
-				apiClient: apiMock,
-				logger:    output.NewLogger(stdout, stderr, false),
-			}
+			io, _, stdout, stderr := iostreams.Test()
+			app := NewApp(io, apiMock)
 			err := app.Delete(context.Background(), opts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("delete() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -43,7 +43,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc"},
-			wantStdout:  "Codespace deleted.\n",
+			wantStdout:  "1 codespace deleted.\n",
 		},
 		{
 			name: "by repo",
@@ -71,7 +71,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "Codespaces deleted.\n",
+			wantStdout:  "2 codespaces deleted.\n",
 		},
 		{
 			name: "unused",
@@ -94,7 +94,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "Codespaces deleted.\n",
+			wantStdout:  "2 codespaces deleted.\n",
 		},
 		{
 			name: "deletion failed",
@@ -150,7 +150,7 @@ func TestDelete(t *testing.T) {
 				"Codespace hubot-robawt-abc has unsaved changes. OK to delete?":        true,
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "Codespaces deleted.\n",
+			wantStdout:  "2 codespaces deleted.\n",
 		},
 	}
 	for _, tt := range tests {
@@ -188,6 +188,8 @@ func TestDelete(t *testing.T) {
 			}
 
 			io, _, stdout, stderr := iostreams.Test()
+			io.SetStdinTTY(true)
+			io.SetStdoutTTY(true)
 			app := NewApp(io, apiMock)
 			err := app.Delete(context.Background(), opts)
 			if (err != nil) != tt.wantErr {

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -43,7 +43,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc"},
-			wantStdout:  "1 codespace deleted.\n",
+			wantStdout:  "",
 		},
 		{
 			name: "by repo",
@@ -71,7 +71,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "2 codespaces deleted.\n",
+			wantStdout:  "",
 		},
 		{
 			name: "unused",
@@ -94,7 +94,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "2 codespaces deleted.\n",
+			wantStdout:  "",
 		},
 		{
 			name: "deletion failed",
@@ -150,7 +150,7 @@ func TestDelete(t *testing.T) {
 				"Codespace hubot-robawt-abc has unsaved changes. OK to delete?":        true,
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "2 codespaces deleted.\n",
+			wantStdout:  "",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -3,7 +3,6 @@ package codespace
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/cli/cli/v2/pkg/cmd/codespace/output"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -34,12 +33,14 @@ func newListCmd(app *App) *cobra.Command {
 }
 
 func (a *App) List(ctx context.Context, asJSON bool, limit int) error {
+	a.StartProgressIndicatorWithSuffix("Fetching codespaces")
 	codespaces, err := a.apiClient.ListCodespaces(ctx, limit)
+	a.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting codespaces: %w", err)
 	}
 
-	table := output.NewTable(os.Stdout, asJSON)
+	table := output.NewTable(a.io.Out, asJSON)
 	table.SetHeader([]string{"Name", "Repository", "Branch", "State", "Created At"})
 	for _, apiCodespace := range codespaces {
 		cs := codespace{apiCodespace}

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -33,7 +33,7 @@ func newListCmd(app *App) *cobra.Command {
 }
 
 func (a *App) List(ctx context.Context, asJSON bool, limit int) error {
-	a.StartProgressIndicatorWithSuffix("Fetching codespaces")
+	a.StartProgressIndicatorWithLabel("Fetching codespaces")
 	codespaces, err := a.apiClient.ListCodespaces(ctx, limit)
 	a.StopProgressIndicator()
 	if err != nil {

--- a/pkg/cmd/codespace/logs.go
+++ b/pkg/cmd/codespace/logs.go
@@ -69,7 +69,7 @@ func (a *App) Logs(ctx context.Context, codespaceName string, follow bool) (err 
 	defer listen.Close()
 	localPort := listen.Addr().(*net.TCPAddr).Port
 
-	a.StartProgressIndicatorWithSuffix("Fetching SSH Details")
+	a.StartProgressIndicatorWithLabel("Fetching SSH Details")
 	remoteSSHServerPort, sshUser, err := session.StartSSHServer(ctx)
 	a.StopProgressIndicator()
 	if err != nil {

--- a/pkg/cmd/codespace/logs.go
+++ b/pkg/cmd/codespace/logs.go
@@ -69,7 +69,7 @@ func (a *App) Logs(ctx context.Context, codespaceName string, follow bool) (err 
 	defer listen.Close()
 	localPort := listen.Addr().(*net.TCPAddr).Port
 
-	a.logger.Println("Fetching SSH Details...")
+	a.Println("Fetching SSH Details...")
 	remoteSSHServerPort, sshUser, err := session.StartSSHServer(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting ssh server details: %w", err)

--- a/pkg/cmd/codespace/logs.go
+++ b/pkg/cmd/codespace/logs.go
@@ -51,7 +51,7 @@ func (a *App) Logs(ctx context.Context, codespaceName string, follow bool) (err 
 		return fmt.Errorf("get or choose codespace: %w", err)
 	}
 
-	session, err := codespaces.ConnectToLiveshare(ctx, a.logger, noopLogger(), a.apiClient, codespace)
+	session, err := codespaces.ConnectToLiveshare(ctx, a, noopLogger(), a.apiClient, codespace)
 	if err != nil {
 		return fmt.Errorf("connecting to Live Share: %w", err)
 	}

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -74,7 +74,7 @@ func (a *App) ListPorts(ctx context.Context, codespaceName string, asJSON bool) 
 	devContainerResult := <-devContainerCh
 	if devContainerResult.err != nil {
 		// Warn about failure to read the devcontainer file. Not a codespace command error.
-		_, _ = a.logger.Errorf("Failed to get port names: %v\n", devContainerResult.err.Error())
+		a.errLogger.Printf("Failed to get port names: %v\n", devContainerResult.err.Error())
 	}
 
 	table := output.NewTable(os.Stdout, asJSON)

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -64,7 +64,7 @@ func (a *App) ListPorts(ctx context.Context, codespaceName string, asJSON bool) 
 	}
 	defer safeClose(session, &err)
 
-	a.StartProgressIndicatorWithSuffix("Fetching ports")
+	a.StartProgressIndicatorWithLabel("Fetching ports")
 	ports, err := session.GetSharedServers(ctx)
 	a.StopProgressIndicator()
 	if err != nil {
@@ -183,15 +183,14 @@ func (a *App) UpdatePortVisibility(ctx context.Context, codespaceName string, ar
 	}
 	defer safeClose(session, &err)
 
+	// TODO: check if port visibility can be updated in parallel instead of sequentially
 	for _, port := range ports {
-		a.StartProgressIndicatorWithSuffix(fmt.Sprintf("Updating port %d visibility to: %s", port.number, port.visibility))
+		a.StartProgressIndicatorWithLabel(fmt.Sprintf("Updating port %d visibility to: %s", port.number, port.visibility))
 		err := session.UpdateSharedServerPrivacy(ctx, port.number, port.visibility)
 		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("error update port to public: %w", err)
 		}
-
-		a.Printf("Port %d is now %s scoped.\n", port.number, port.visibility)
 	}
 
 	return nil
@@ -272,7 +271,7 @@ func (a *App) ForwardPorts(ctx context.Context, codespaceName string, ports []st
 			}
 			defer listen.Close()
 
-			a.Printf("Forwarding ports: remote %d <=> local %d\n", pair.remote, pair.local)
+			a.errLogger.Printf("Forwarding ports: remote %d <=> local %d", pair.remote, pair.local)
 			name := fmt.Sprintf("share-%d", pair.remote)
 			fwd := liveshare.NewPortForwarder(session, name, pair.remote, false)
 			return fwd.ForwardToListener(ctx, listen) // error always non-nil

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -59,7 +59,7 @@ func (a *App) ListPorts(ctx context.Context, codespaceName string, asJSON bool) 
 
 	devContainerCh := getDevContainer(ctx, a.apiClient, codespace)
 
-	session, err := codespaces.ConnectToLiveshare(ctx, a.logger, noopLogger(), a.apiClient, codespace)
+	session, err := codespaces.ConnectToLiveshare(ctx, a, noopLogger(), a.apiClient, codespace)
 	if err != nil {
 		return fmt.Errorf("error connecting to Live Share: %w", err)
 	}
@@ -176,7 +176,7 @@ func (a *App) UpdatePortVisibility(ctx context.Context, codespaceName string, ar
 		return fmt.Errorf("error getting codespace: %w", err)
 	}
 
-	session, err := codespaces.ConnectToLiveshare(ctx, a.logger, noopLogger(), a.apiClient, codespace)
+	session, err := codespaces.ConnectToLiveshare(ctx, a, noopLogger(), a.apiClient, codespace)
 	if err != nil {
 		return fmt.Errorf("error connecting to Live Share: %w", err)
 	}
@@ -250,7 +250,7 @@ func (a *App) ForwardPorts(ctx context.Context, codespaceName string, ports []st
 		return fmt.Errorf("error getting codespace: %w", err)
 	}
 
-	session, err := codespaces.ConnectToLiveshare(ctx, a.logger, noopLogger(), a.apiClient, codespace)
+	session, err := codespaces.ConnectToLiveshare(ctx, a, noopLogger(), a.apiClient, codespace)
 	if err != nil {
 		return fmt.Errorf("error connecting to Live Share: %w", err)
 	}

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -65,7 +65,7 @@ func (a *App) ListPorts(ctx context.Context, codespaceName string, asJSON bool) 
 	}
 	defer safeClose(session, &err)
 
-	a.logger.Println("Loading ports...")
+	a.Println("Loading ports...")
 	ports, err := session.GetSharedServers(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting ports of shared servers: %w", err)
@@ -187,7 +187,7 @@ func (a *App) UpdatePortVisibility(ctx context.Context, codespaceName string, ar
 			return fmt.Errorf("error update port to public: %w", err)
 		}
 
-		a.logger.Printf("Port %d is now %s scoped.\n", port.number, port.visibility)
+		a.Printf("Port %d is now %s scoped.\n", port.number, port.visibility)
 	}
 
 	return nil
@@ -267,7 +267,7 @@ func (a *App) ForwardPorts(ctx context.Context, codespaceName string, ports []st
 				return err
 			}
 			defer listen.Close()
-			a.logger.Printf("Forwarding ports: remote %d <=> local %d\n", pair.remote, pair.local)
+			a.Printf("Forwarding ports: remote %d <=> local %d\n", pair.remote, pair.local)
 			name := fmt.Sprintf("share-%d", pair.remote)
 			fwd := liveshare.NewPortForwarder(session, name, pair.remote, false)
 			return fwd.ForwardToListener(ctx, listen) // error always non-nil

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -1,21 +1,22 @@
 package codespace
 
 import (
+	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 )
-
-var version = "DEV" // Replaced in the release build process (by GoReleaser or Homebrew) by the git tag version number.
 
 func NewRootCmd(app *App) *cobra.Command {
 	root := &cobra.Command{
 		Use:           "codespace",
 		SilenceUsage:  true,  // don't print usage message after each error (see #80)
 		SilenceErrors: false, // print errors automatically so that main need not
-		Long: `Unofficial CLI tool to manage GitHub Codespaces.
-
-Running commands requires the GITHUB_TOKEN environment variable to be set to a
-token to access the GitHub API with.`,
-		Version: version,
+		Short:         "List, create, and SSH into codespaces",
+		Long:          "Work with GitHub codespaces",
+		Example: heredoc.Doc(`
+			$ gh codespace list
+			$ gh codespace create
+			$ gh codespace ssh
+		`),
 	}
 
 	root.AddCommand(newCodeCmd(app))

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -52,6 +52,8 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		return fmt.Errorf("get or choose codespace: %w", err)
 	}
 
+	// TODO(josebalius): We can fetch the user in parallel to everything else
+	// we should convert this call and others to happen async
 	user, err := a.apiClient.GetUser(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting user: %w", err)

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -71,7 +71,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		defer safeClose(debugLogger, &err)
 
 		liveshareLogger = debugLogger.Logger
-		a.logger.Println("Debug file located at: " + debugLogger.Name())
+		a.Println("Debug file located at: " + debugLogger.Name())
 	}
 
 	session, err := codespaces.ConnectToLiveshare(ctx, a, liveshareLogger, a.apiClient, codespace)
@@ -84,7 +84,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		return err
 	}
 
-	a.logger.Println("Fetching SSH Details...")
+	a.Println("Fetching SSH Details...")
 	remoteSSHServerPort, sshUser, err := session.StartSSHServer(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting ssh server details: %w", err)
@@ -108,7 +108,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		connectDestination = fmt.Sprintf("%s@localhost", sshUser)
 	}
 
-	a.logger.Println("Ready...")
+	a.Println("Ready...")
 	tunnelClosed := make(chan error, 1)
 	go func() {
 		fwd := liveshare.NewPortForwarder(session, "sshd", remoteSSHServerPort, true)
@@ -117,7 +117,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 
 	shellClosed := make(chan error, 1)
 	go func() {
-		shellClosed <- codespaces.Shell(ctx, a.logger, sshArgs, localSSHServerPort, connectDestination, usingCustomPort)
+		shellClosed <- codespaces.Shell(ctx, a, sshArgs, localSSHServerPort, connectDestination, usingCustomPort)
 	}()
 
 	select {

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -111,7 +111,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		connectDestination = fmt.Sprintf("%s@localhost", sshUser)
 	}
 
-	a.Println("Ready...")
+	a.logger.Println("Ready")
 	tunnelClosed := make(chan error, 1)
 	go func() {
 		fwd := liveshare.NewPortForwarder(session, "sshd", remoteSSHServerPort, true)

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -74,7 +74,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		a.logger.Println("Debug file located at: " + debugLogger.Name())
 	}
 
-	session, err := codespaces.ConnectToLiveshare(ctx, a.logger, liveshareLogger, a.apiClient, codespace)
+	session, err := codespaces.ConnectToLiveshare(ctx, a, liveshareLogger, a.apiClient, codespace)
 	if err != nil {
 		return fmt.Errorf("error connecting to Live Share: %w", err)
 	}

--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -27,7 +27,9 @@ func newStopCmd(app *App) *cobra.Command {
 
 func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 	if codespaceName == "" {
+		a.StartProgressIndicatorWithSuffix("Fetching codespaces")
 		codespaces, err := a.apiClient.ListCodespaces(ctx, -1)
+		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to list codespaces: %w", err)
 		}
@@ -49,7 +51,9 @@ func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 		}
 		codespaceName = codespace.Name
 	} else {
+		a.StartProgressIndicatorWithSuffix("Fetching codespace")
 		c, err := a.apiClient.GetCodespace(ctx, codespaceName, false)
+		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to get codespace: %q: %w", codespaceName, err)
 		}
@@ -59,10 +63,12 @@ func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 		}
 	}
 
+	a.StartProgressIndicatorWithSuffix("Stopping codespace")
 	if err := a.apiClient.StopCodespace(ctx, codespaceName); err != nil {
 		return fmt.Errorf("failed to stop codespace: %w", err)
 	}
-	a.Println("Codespace stopped")
+	a.StopProgressIndicator()
 
+	a.Println("Codespace stopped.")
 	return nil
 }

--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -62,7 +62,7 @@ func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 	if err := a.apiClient.StopCodespace(ctx, codespaceName); err != nil {
 		return fmt.Errorf("failed to stop codespace: %w", err)
 	}
-	a.logger.Println("Codespace stopped")
+	a.Println("Codespace stopped")
 
 	return nil
 }

--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -27,7 +27,7 @@ func newStopCmd(app *App) *cobra.Command {
 
 func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 	if codespaceName == "" {
-		a.StartProgressIndicatorWithSuffix("Fetching codespaces")
+		a.StartProgressIndicatorWithLabel("Fetching codespaces")
 		codespaces, err := a.apiClient.ListCodespaces(ctx, -1)
 		a.StopProgressIndicator()
 		if err != nil {
@@ -51,7 +51,7 @@ func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 		}
 		codespaceName = codespace.Name
 	} else {
-		a.StartProgressIndicatorWithSuffix("Fetching codespace")
+		a.StartProgressIndicatorWithLabel("Fetching codespace")
 		c, err := a.apiClient.GetCodespace(ctx, codespaceName, false)
 		a.StopProgressIndicator()
 		if err != nil {
@@ -63,12 +63,11 @@ func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 		}
 	}
 
-	a.StartProgressIndicatorWithSuffix("Stopping codespace")
+	a.StartProgressIndicatorWithLabel("Stopping codespace")
+	defer a.StopProgressIndicator()
 	if err := a.apiClient.StopCodespace(ctx, codespaceName); err != nil {
 		return fmt.Errorf("failed to stop codespace: %w", err)
 	}
-	a.StopProgressIndicator()
 
-	a.Println("Codespace stopped.")
 	return nil
 }

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -122,6 +122,7 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 		return nil, nil, err
 	}
 
+	// TODO(josebalius): Should we be guarding here?
 	if f.progress != nil {
 		f.progress.StartProgressIndicator()
 		defer f.progress.StopProgressIndicator()

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -12,7 +12,6 @@ import (
 	authCmd "github.com/cli/cli/v2/pkg/cmd/auth"
 	browseCmd "github.com/cli/cli/v2/pkg/cmd/browse"
 	codespaceCmd "github.com/cli/cli/v2/pkg/cmd/codespace"
-	"github.com/cli/cli/v2/pkg/cmd/codespace/output"
 	completionCmd "github.com/cli/cli/v2/pkg/cmd/completion"
 	configCmd "github.com/cli/cli/v2/pkg/cmd/config"
 	extensionCmd "github.com/cli/cli/v2/pkg/cmd/extension"
@@ -128,10 +127,11 @@ func bareHTTPClient(f *cmdutil.Factory, version string) func() (*http.Client, er
 }
 
 func newCodespaceCmd(f *cmdutil.Factory) *cobra.Command {
-	cmd := codespaceCmd.NewRootCmd(codespaceCmd.NewApp(
-		output.NewLogger(f.IOStreams.Out, f.IOStreams.ErrOut, !f.IOStreams.IsStdoutTTY()),
+	app := codespaceCmd.NewApp(
+		f.IOStreams,
 		codespacesAPI.New("", &lazyLoadedHTTPClient{factory: f}),
-	))
+	)
+	cmd := codespaceCmd.NewRootCmd(app)
 	cmd.Use = "codespace"
 	cmd.Aliases = []string{"cs"}
 	cmd.Hidden = true

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -243,8 +243,10 @@ func (s *IOStreams) StartProgressIndicatorWithSuffix(suffix string) {
 	if suffix != "" {
 		opts = append(opts, spinner.WithSuffix(" "+suffix))
 	}
+
+	// 11 means Braille. See https://github.com/briandowns/spinner#available-character-sets
 	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, opts...)
-	sp.Color("black")
+	sp.Color("black") // TODO(josebalius): Find correct color depending on terminal bg
 	sp.Start()
 	s.progressIndicator = sp
 }

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -229,19 +229,21 @@ func (s *IOStreams) SetNeverPrompt(v bool) {
 }
 
 func (s *IOStreams) StartProgressIndicator() {
-	if !s.progressIndicatorEnabled {
-		return
-	}
-	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, spinner.WithWriter(s.ErrOut))
-	sp.Start()
-	s.progressIndicator = sp
+	s.StartProgressIndicatorWithSuffix("")
 }
 
-func (s *IOStreams) StartProgressIndicatorWithMessage(msg string) {
+func (s *IOStreams) StartProgressIndicatorWithSuffix(suffix string) {
 	if !s.progressIndicatorEnabled {
 		return
 	}
-	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, spinner.WithWriter(s.ErrOut), spinner.WithSuffix(" "+msg))
+
+	opts := []spinner.Option{
+		spinner.WithWriter(s.ErrOut),
+	}
+	if suffix != "" {
+		opts = append(opts, spinner.WithSuffix(" "+suffix))
+	}
+	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, opts...)
 	sp.Color("black")
 	sp.Start()
 	s.progressIndicator = sp

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -246,7 +246,7 @@ func (s *IOStreams) StartProgressIndicatorWithSuffix(suffix string) {
 
 	// 11 means Braille. See https://github.com/briandowns/spinner#available-character-sets
 	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, opts...)
-	sp.Color("black") // TODO(josebalius): Find correct color depending on terminal bg
+	_ = sp.Color("black") // TODO(josebalius): Find correct color depending on terminal bg
 	sp.Start()
 	s.progressIndicator = sp
 }

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -237,6 +237,16 @@ func (s *IOStreams) StartProgressIndicator() {
 	s.progressIndicator = sp
 }
 
+func (s *IOStreams) StartProgressIndicatorWithMessage(msg string) {
+	if !s.progressIndicatorEnabled {
+		return
+	}
+	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, spinner.WithWriter(s.ErrOut), spinner.WithSuffix(" "+msg))
+	sp.Color("black")
+	sp.Start()
+	s.progressIndicator = sp
+}
+
 func (s *IOStreams) StopProgressIndicator() {
 	if s.progressIndicator == nil {
 		return

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -246,7 +246,11 @@ func (s *IOStreams) StartProgressIndicatorWithSuffix(suffix string) {
 
 	// 11 means Braille. See https://github.com/briandowns/spinner#available-character-sets
 	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, opts...)
-	_ = sp.Color("black") // TODO(josebalius): Find correct color depending on terminal bg
+
+	if s.TerminalTheme() == "light" {
+		_ = sp.Color("fgBlack")
+	}
+
 	sp.Start()
 	s.progressIndicator = sp
 }

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -237,16 +237,6 @@ func (s *IOStreams) StartProgressIndicator() {
 	s.progressIndicator = sp
 }
 
-func (s *IOStreams) StartProgressIndicatorWithMessage(msg string) {
-	if !s.progressIndicatorEnabled {
-		return
-	}
-	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, spinner.WithWriter(s.ErrOut), spinner.WithSuffix(" "+msg))
-	sp.Color("black")
-	sp.Start()
-	s.progressIndicator = sp
-}
-
 func (s *IOStreams) StopProgressIndicator() {
 	if s.progressIndicator == nil {
 		return


### PR DESCRIPTION
I've merged the progress indicator into this PR. I think it is ready for review. The major TODO outstanding is figuring out the spinner color.

![progress-indicator](https://user-images.githubusercontent.com/339080/137821291-b2184287-6b01-4df6-80f9-213c9b7768d0.gif)


---
OP:

- Updates the `NewApp` to accept an `iostreams.IOStreams` pointer instead of an `output.Logger`
- `App` now creates an error logger, and checks for interactivity (TTY)
- The application still needs to Print UI-like behavior (for example `.` as a progress indicator) - Ideally this would be done with the spinner, I have another PR that does this but trying to keep the diffs reasonable. In order to support a dotter-like UI, we are using `*App.Print` and `*App.Println` to do so which noops in non-interactive environments, matching the existing behavior.
- I couldn't use a`*log.Logger` for app printing, because `*log.Logger` automatically appends a `\n` to all logs, so it is impossible to use the logger to print to the same line, once we switch to a progress indicator, we can switch to a logger like this since we don't need same-line printing.

This PR should essentially retain the exact same behavior we have today except without `*output.Logger`