### PR TITLE
codespace: use progress indicator

### DIFF
--- a/internal/codespaces/states.go
+++ b/internal/codespaces/states.go
@@ -38,10 +38,10 @@ type PostCreateState struct {
 // PollPostCreateStates watches for state changes in a codespace,
 // and calls the supplied poller for each batch of state changes.
 // It runs until it encounters an error, including cancellation of the context.
-func PollPostCreateStates(ctx context.Context, logger logger, apiClient apiClient, codespace *api.Codespace, poller func([]PostCreateState)) (err error) {
+func PollPostCreateStates(ctx context.Context, progress progressIndicator, apiClient apiClient, codespace *api.Codespace, poller func([]PostCreateState)) (err error) {
 	noopLogger := log.New(ioutil.Discard, "", 0)
 
-	session, err := ConnectToLiveshare(ctx, logger, noopLogger, apiClient, codespace)
+	session, err := ConnectToLiveshare(ctx, progress, noopLogger, apiClient, codespace)
 	if err != nil {
 		return fmt.Errorf("connect to Live Share: %w", err)
 	}
@@ -58,12 +58,14 @@ func PollPostCreateStates(ctx context.Context, logger logger, apiClient apiClien
 	}
 	localPort := listen.Addr().(*net.TCPAddr).Port
 
-	logger.Println("Fetching SSH Details...")
+	progress.StartProgressIndicatorWithSuffix("Fetching SSH Details")
 	remoteSSHServerPort, sshUser, err := session.StartSSHServer(ctx)
+	progress.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting ssh server details: %w", err)
 	}
 
+	progress.StartProgressIndicatorWithSuffix("Fetching status")
 	tunnelClosed := make(chan error, 1) // buffered to avoid sender stuckness
 	go func() {
 		fwd := liveshare.NewPortForwarder(session, "sshd", remoteSSHServerPort, false)
@@ -73,6 +75,7 @@ func PollPostCreateStates(ctx context.Context, logger logger, apiClient apiClien
 	t := time.NewTicker(1 * time.Second)
 	defer t.Stop()
 
+	var ticks int
 	for {
 		select {
 		case <-ctx.Done():
@@ -83,9 +86,13 @@ func PollPostCreateStates(ctx context.Context, logger logger, apiClient apiClien
 
 		case <-t.C:
 			states, err := getPostCreateOutput(ctx, localPort, sshUser)
+			if ticks == 0 {
+				progress.StopProgressIndicator()
+			}
 			if err != nil {
 				return fmt.Errorf("get post create output: %w", err)
 			}
+			ticks++
 
 			poller(states)
 		}

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -173,6 +173,7 @@ func chooseCodespaceFromList(ctx context.Context, codespaces []*api.Codespace) (
 
 // getOrChooseCodespace prompts the user to choose a codespace if the codespaceName is empty.
 // It then fetches the codespace record with full connection details.
+// TODO(josebalius): accept a progress indicator or *App and show progress when fetching.
 func getOrChooseCodespace(ctx context.Context, apiClient apiClient, codespaceName string) (codespace *api.Codespace, err error) {
 	if codespaceName == "" {
 		codespace, err = chooseCodespace(ctx, apiClient)

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -47,13 +47,13 @@ func NewApp(io *iostreams.IOStreams, apiClient apiClient) *App {
 }
 
 func (a *App) StartProgressIndicatorWithSuffix(s string) {
-	if a.isInteractive {
-		a.io.StartProgressIndicatorWithSuffix(s)
+	if !a.isInteractive {
+		// if we are not interactive, log the progress states
+		a.logger.Println(s)
 		return
 	}
 
-	// if we are not interactive, log the progress states
-	a.logger.Println(s)
+	a.io.StartProgressIndicatorWithSuffix(s)
 }
 
 func (a *App) StopProgressIndicator() {

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -55,7 +54,9 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return fmt.Errorf("error getting branch name: %w", err)
 	}
 
+	a.StartProgressIndicatorWithSuffix("Fetching repository")
 	repository, err := a.apiClient.GetRepository(ctx, repo)
+	a.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting repository: %w", err)
 	}
@@ -78,13 +79,14 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return errors.New("there are no available machine types for this repository")
 	}
 
-	a.logger.Println("Creating your codespace...")
+	a.StartProgressIndicatorWithSuffix("Creating codespace")
 	codespace, err := a.apiClient.CreateCodespace(ctx, &api.CreateCodespaceParams{
 		RepositoryID: repository.ID,
 		Branch:       branch,
 		Machine:      machine,
 		Location:     locationResult.Location,
 	})
+	a.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error creating codespace: %w", err)
 	}
@@ -95,9 +97,8 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		}
 	}
 
-	a.logger.Println("Codespace created: ")
-
-	fmt.Fprintln(os.Stdout, codespace.Name)
+	a.Println("Codespace created.")
+	fmt.Fprintln(a.io.Out, codespace.Name)
 
 	return nil
 }
@@ -123,26 +124,24 @@ func (a *App) showStatus(ctx context.Context, user *api.User, codespace *api.Cod
 			}
 
 			if state.Name != lastState.Name {
-				a.Print(state.Name)
+				a.StartProgressIndicatorWithSuffix(state.Name)
 
 				if state.Status == codespaces.PostCreateStateRunning {
 					inProgress = true
 					lastState = state
-					a.Print("...")
 					break
 				}
 
 				finishedStates[state.Name] = true
-				a.Println("..." + state.Status)
+				a.StopProgressIndicator()
 			} else {
 				if state.Status == codespaces.PostCreateStateRunning {
 					inProgress = true
-					a.Print(".")
 					break
 				}
 
 				finishedStates[state.Name] = true
-				a.Println(state.Status)
+				a.StopProgressIndicator()
 				lastState = codespaces.PostCreateState{} // reset the value
 			}
 		}

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/utils"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -121,13 +122,11 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 		return errors.New("no codespaces to delete")
 	}
 
-	noun := "Codespace"
-	if len(codespacesToDelete) > 1 {
-		noun = noun + "s"
-	}
-
-	a.StartProgressIndicatorWithSuffix(fmt.Sprintf("Deleting %s", strings.ToLower(noun)))
-	g := errgroup.Group{}
+	a.StartProgressIndicatorWithSuffix("Deleting codespace(s)")
+	var (
+		deletedCodespaces int
+		g                 = errgroup.Group{}
+	)
 	for _, c := range codespacesToDelete {
 		codespaceName := c.Name
 		g.Go(func() error {
@@ -135,6 +134,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 				a.errLogger.Printf("error deleting codespace %q: %v\n", codespaceName, err)
 				return err
 			}
+			deletedCodespaces++
 			return nil
 		})
 	}
@@ -145,7 +145,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 	}
 	a.StopProgressIndicator()
 
-	a.Println(noun + " deleted.")
+	a.Printf("%s deleted.\n", utils.Pluralize(deletedCodespaces, "codespace"))
 
 	return nil
 }

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -125,7 +125,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 	a.StartProgressIndicatorWithSuffix("Deleting codespace(s)")
 	var (
 		deletedCodespaces int
-		g                 = errgroup.Group{}
+		g                 errgroup.Group
 	)
 	for _, c := range codespacesToDelete {
 		codespaceName := c.Name

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -1,7 +1,6 @@
 package codespace
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,7 +11,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/codespaces/api"
-	"github.com/cli/cli/v2/pkg/cmd/codespace/output"
+	"github.com/cli/cli/v2/pkg/iostreams"
 )
 
 func TestDelete(t *testing.T) {
@@ -188,12 +187,8 @@ func TestDelete(t *testing.T) {
 				},
 			}
 
-			stdout := &bytes.Buffer{}
-			stderr := &bytes.Buffer{}
-			app := &App{
-				apiClient: apiMock,
-				logger:    output.NewLogger(stdout, stderr, false),
-			}
+			io, _, stdout, stderr := iostreams.Test()
+			app := NewApp(io, apiMock)
 			err := app.Delete(context.Background(), opts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("delete() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -43,7 +43,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc"},
-			wantStdout:  "Codespace deleted.\n",
+			wantStdout:  "1 codespace deleted.\n",
 		},
 		{
 			name: "by repo",
@@ -71,7 +71,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "Codespaces deleted.\n",
+			wantStdout:  "2 codespaces deleted.\n",
 		},
 		{
 			name: "unused",
@@ -94,7 +94,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "Codespaces deleted.\n",
+			wantStdout:  "2 codespaces deleted.\n",
 		},
 		{
 			name: "deletion failed",
@@ -150,7 +150,7 @@ func TestDelete(t *testing.T) {
 				"Codespace hubot-robawt-abc has unsaved changes. OK to delete?":        true,
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "Codespaces deleted.\n",
+			wantStdout:  "2 codespaces deleted.\n",
 		},
 	}
 	for _, tt := range tests {
@@ -188,6 +188,8 @@ func TestDelete(t *testing.T) {
 			}
 
 			io, _, stdout, stderr := iostreams.Test()
+			io.SetStdinTTY(true)
+			io.SetStdoutTTY(true)
 			app := NewApp(io, apiMock)
 			err := app.Delete(context.Background(), opts)
 			if (err != nil) != tt.wantErr {

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -3,7 +3,6 @@ package codespace
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/cli/cli/v2/pkg/cmd/codespace/output"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -34,12 +33,14 @@ func newListCmd(app *App) *cobra.Command {
 }
 
 func (a *App) List(ctx context.Context, asJSON bool, limit int) error {
+	a.StartProgressIndicatorWithSuffix("Fetching codespaces")
 	codespaces, err := a.apiClient.ListCodespaces(ctx, limit)
+	a.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting codespaces: %w", err)
 	}
 
-	table := output.NewTable(os.Stdout, asJSON)
+	table := output.NewTable(a.io.Out, asJSON)
 	table.SetHeader([]string{"Name", "Repository", "Branch", "State", "Created At"})
 	for _, apiCodespace := range codespaces {
 		cs := codespace{apiCodespace}

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -52,6 +52,8 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		return fmt.Errorf("get or choose codespace: %w", err)
 	}
 
+	// TODO(josebalius): We can fetch the user in parallel to everything else
+	// we should convert this call and others to happen async
 	user, err := a.apiClient.GetUser(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting user: %w", err)

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -111,7 +111,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		connectDestination = fmt.Sprintf("%s@localhost", sshUser)
 	}
 
-	a.Println("Ready...")
+	a.logger.Println("Ready")
 	tunnelClosed := make(chan error, 1)
 	go func() {
 		fwd := liveshare.NewPortForwarder(session, "sshd", remoteSSHServerPort, true)

--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -27,7 +27,9 @@ func newStopCmd(app *App) *cobra.Command {
 
 func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 	if codespaceName == "" {
+		a.StartProgressIndicatorWithSuffix("Fetching codespaces")
 		codespaces, err := a.apiClient.ListCodespaces(ctx, -1)
+		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to list codespaces: %w", err)
 		}
@@ -49,7 +51,9 @@ func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 		}
 		codespaceName = codespace.Name
 	} else {
+		a.StartProgressIndicatorWithSuffix("Fetching codespace")
 		c, err := a.apiClient.GetCodespace(ctx, codespaceName, false)
+		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to get codespace: %q: %w", codespaceName, err)
 		}
@@ -59,10 +63,12 @@ func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 		}
 	}
 
+	a.StartProgressIndicatorWithSuffix("Stopping codespace")
 	if err := a.apiClient.StopCodespace(ctx, codespaceName); err != nil {
 		return fmt.Errorf("failed to stop codespace: %w", err)
 	}
-	a.Println("Codespace stopped")
+	a.StopProgressIndicator()
 
+	a.Println("Codespace stopped.")
 	return nil
 }

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -122,6 +122,7 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 		return nil, nil, err
 	}
 
+	// TODO(josebalius): Should we be guarding here?
 	if f.progress != nil {
 		f.progress.StartProgressIndicator()
 		defer f.progress.StopProgressIndicator()

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -243,8 +243,10 @@ func (s *IOStreams) StartProgressIndicatorWithSuffix(suffix string) {
 	if suffix != "" {
 		opts = append(opts, spinner.WithSuffix(" "+suffix))
 	}
+
+	// 11 means Braille. See https://github.com/briandowns/spinner#available-character-sets
 	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, opts...)
-	sp.Color("black")
+	sp.Color("black") // TODO(josebalius): Find correct color depending on terminal bg
 	sp.Start()
 	s.progressIndicator = sp
 }

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -229,19 +229,21 @@ func (s *IOStreams) SetNeverPrompt(v bool) {
 }
 
 func (s *IOStreams) StartProgressIndicator() {
-	if !s.progressIndicatorEnabled {
-		return
-	}
-	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, spinner.WithWriter(s.ErrOut))
-	sp.Start()
-	s.progressIndicator = sp
+	s.StartProgressIndicatorWithSuffix("")
 }
 
-func (s *IOStreams) StartProgressIndicatorWithMessage(msg string) {
+func (s *IOStreams) StartProgressIndicatorWithSuffix(suffix string) {
 	if !s.progressIndicatorEnabled {
 		return
 	}
-	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, spinner.WithWriter(s.ErrOut), spinner.WithSuffix(" "+msg))
+
+	opts := []spinner.Option{
+		spinner.WithWriter(s.ErrOut),
+	}
+	if suffix != "" {
+		opts = append(opts, spinner.WithSuffix(" "+suffix))
+	}
+	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, opts...)
 	sp.Color("black")
 	sp.Start()
 	s.progressIndicator = sp

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -246,7 +246,7 @@ func (s *IOStreams) StartProgressIndicatorWithSuffix(suffix string) {
 
 	// 11 means Braille. See https://github.com/briandowns/spinner#available-character-sets
 	sp := spinner.New(spinner.CharSets[11], 400*time.Millisecond, opts...)
-	sp.Color("black") // TODO(josebalius): Find correct color depending on terminal bg
+	_ = sp.Color("black") // TODO(josebalius): Find correct color depending on terminal bg
 	sp.Start()
 	s.progressIndicator = sp
 }


### PR DESCRIPTION
This PR builds on top of https://github.com/cli/cli/pull/4555 and it changes the code to use IOStreams' progress indicator.

- Most of the logged states turn into progress indicators
- There are a few TODOs that need to be resolved (working on this but happy to get feedback)
- The spinner color is hardcoded to black at the moment. I use a light terminal and the default spinner is very light and barely visible. We need to resolve how to set the spinner color?
- If we are non-interactive, loading states are instead logged. If `DEBUG=1` has been set, then they are logged out to the `io.Out`
- There are functions like `getOrChooseCodespace` that should probably also take a progressIndicator or an `*App`. I really wanted to move everything out of `pkg/cmd/codespace` and `internal/codespaces/app.go` and other files. It feels like we need to this at some point. I actually did in another branch but the diff is huge 😬 
