### PR TITLE
Prevent repeating GET parameters when paginating with api command

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -319,6 +319,7 @@ func apiRun(opts *ApiOptions) error {
 			}
 		} else {
 			requestPath, hasNextPage = findNextPage(resp)
+			requestBody = nil // prevent repeating GET parameters
 		}
 
 		if hasNextPage && opts.ShowResponseHeaders {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -577,8 +577,11 @@ func Test_apiRun_paginationREST(t *testing.T) {
 			return config.NewBlankConfig(), nil
 		},
 
-		RequestPath: "issues",
-		Paginate:    true,
+		RequestMethod:       "GET",
+		RequestMethodPassed: true,
+		RequestPath:         "issues",
+		Paginate:            true,
+		RawFields:           []string{"per_page=50", "page=1"},
 	}
 
 	err := apiRun(&options)
@@ -587,7 +590,7 @@ func Test_apiRun_paginationREST(t *testing.T) {
 	assert.Equal(t, `{"page":1}{"page":2}{"page":3}`, stdout.String(), "stdout")
 	assert.Equal(t, "", stderr.String(), "stderr")
 
-	assert.Equal(t, "https://api.github.com/issues?per_page=100", responses[0].Request.URL.String())
+	assert.Equal(t, "https://api.github.com/issues?page=1&per_page=50", responses[0].Request.URL.String())
 	assert.Equal(t, "https://api.github.com/repositories/1227/issues?page=2", responses[1].Request.URL.String())
 	assert.Equal(t, "https://api.github.com/repositories/1227/issues?page=3", responses[2].Request.URL.String())
 }


### PR DESCRIPTION
Fixes #4540