### PR TITLE
gh cs cp: disable remote shell expansion unless -e flag

### DIFF
--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -27,8 +27,10 @@ func Shell(ctx context.Context, log logger, sshArgs []string, port int, destinat
 
 // Copy runs an scp command over the specified port. The arguments may
 // include flags and non-flags, optionally separated by "--".
-// Remote files are indicated by a "remote:" prefix, and are resolved
-// relative to the remote user's home directory.
+//
+// Remote files indicated by a "remote:" prefix are resolved relative
+// to the remote user's home directory, and are subject to shell expansion
+// on the remote host; see https://lwn.net/Articles/835962/.
 func Copy(ctx context.Context, scpArgs []string, port int, destination string) error {
 	// Beware: invalid syntax causes scp to exit 1 with
 	// no error message, so don't let that happen.


### PR DESCRIPTION
https://github.com/cli/cli/issues/4486 added support for 'gh cs cp', a command to copy files between the local and remote file systems. It is implemented as a wrapper around scp. We recently learned that scp arguments are subject to all forms of shell expansion on the remote machine, which is useful but a [potential security risk](https://lwn.net/Articles/835962/).

This PR disables remote shell expansion by default. The expansion behavior must be explicitly enabled by passing the -e flag.

Example:
```text
$ gh cs cp -c ... 'remote:~/.bash*' dotfiles/
scp: ~/.bash*: No such file or directory
shell closed: exit status 1
$ gh cs cp -c ... -e 'remote:~/.bash*' dotfiles/
.bash_history                                                                              100% 5833   190.0KB/s   00:00    
.bashrc                                                                                    100% 1112    35.8KB/s   00:00    

$ gh cs cp -c ... -e 'remote:/workspaces/$RepositoryName/README.md' README
README.md                                                                                  100%  951    18.9KB/s   00:00    
```