### PR TITLE
Declare that the delete repo endpoint needs `delete_repo` scope

### DIFF
--- a/pkg/cmd/repo/delete/http.go
+++ b/pkg/cmd/repo/delete/http.go
@@ -26,7 +26,7 @@ func deleteRepo(client *http.Client, repo ghrepo.Interface) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode > 299 {
-		return api.HandleHTTPError(resp)
+		return api.HandleHTTPError(api.EndpointNeedsScopes(resp, "delete_repo"))
 	}
 
 	return nil


### PR DESCRIPTION
The API endpoint unfortunately doesn't declare this requirement in its `X-Accepted-Oauth-Scopes` response header.

Followup to https://github.com/cli/cli/pull/4451 