### PR TITLE
Add FlagErrorf; encapsulate FlagError.error

### DIFF
--- a/cmd/gh/main_test.go
+++ b/cmd/gh/main_test.go
@@ -49,7 +49,7 @@ check your internet connection or https://githubstatus.com
 		{
 			name: "Cobra flag error",
 			args: args{
-				err:   &cmdutil.FlagError{Err: errors.New("unknown flag --foo")},
+				err:   cmdutil.FlagErrorf("unknown flag --foo"),
 				cmd:   cmd,
 				debug: false,
 			},

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -173,12 +173,12 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 
 			if c.Flags().Changed("hostname") {
 				if err := ghinstance.HostnameValidator(opts.Hostname); err != nil {
-					return &cmdutil.FlagError{Err: fmt.Errorf("error parsing `--hostname`: %w", err)}
+					return cmdutil.FlagErrorf("error parsing `--hostname`: %w", err)
 				}
 			}
 
 			if opts.Paginate && !strings.EqualFold(opts.RequestMethod, "GET") && opts.RequestPath != "graphql" {
-				return &cmdutil.FlagError{Err: errors.New("the `--paginate` option is not supported for non-GET requests")}
+				return cmdutil.FlagErrorf("the `--paginate` option is not supported for non-GET requests")
 			}
 
 			if err := cmdutil.MutuallyExclusive(

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -69,11 +69,11 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !opts.IO.CanPrompt() && !(tokenStdin || opts.Web) {
-				return &cmdutil.FlagError{Err: errors.New("--web or --with-token required when not running interactively")}
+				return cmdutil.FlagErrorf("--web or --with-token required when not running interactively")
 			}
 
 			if tokenStdin && opts.Web {
-				return &cmdutil.FlagError{Err: errors.New("specify only one of --web or --with-token")}
+				return cmdutil.FlagErrorf("specify only one of --web or --with-token")
 			}
 
 			if tokenStdin {
@@ -91,7 +91,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 
 			if cmd.Flags().Changed("hostname") {
 				if err := ghinstance.HostnameValidator(opts.Hostname); err != nil {
-					return &cmdutil.FlagError{Err: fmt.Errorf("error parsing --hostname: %w", err)}
+					return cmdutil.FlagErrorf("error parsing --hostname: %w", err)
 				}
 			}
 

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -48,7 +48,7 @@ func NewCmdLogout(f *cmdutil.Factory, runF func(*LogoutOptions) error) *cobra.Co
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.Hostname == "" && !opts.IO.CanPrompt() {
-				return &cmdutil.FlagError{Err: errors.New("--hostname required when not running interactively")}
+				return cmdutil.FlagErrorf("--hostname required when not running interactively")
 			}
 
 			if runF != nil {

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -62,7 +62,7 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 			opts.Interactive = opts.IO.CanPrompt()
 
 			if !opts.Interactive && opts.Hostname == "" {
-				return &cmdutil.FlagError{Err: errors.New("--hostname required when not running interactively")}
+				return cmdutil.FlagErrorf("--hostname required when not running interactively")
 			}
 
 			opts.MainExecutable = f.Executable()

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -20,7 +20,7 @@ func newListCmd(app *App) *cobra.Command {
 		Args:  noArgsConstraint,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if limit < 1 {
-				return &cmdutil.FlagError{Err: fmt.Errorf("invalid limit: %v", limit)}
+				return cmdutil.FlagErrorf("invalid limit: %v", limit)
 			}
 
 			return app.List(cmd.Context(), asJSON, limit)

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -229,7 +229,7 @@ func (a *App) Copy(ctx context.Context, args []string, opts cpOptions) error {
 		opts.scpArgs = append(opts.scpArgs, arg)
 	}
 	if !hasRemote {
-		return &cmdutil.FlagError{Err: fmt.Errorf("at least one argument must have a 'remote:' prefix")}
+		return cmdutil.FlagErrorf("at least one argument must have a 'remote:' prefix")
 	}
 	return a.SSH(ctx, nil, opts.sshOptions)
 }

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -1,7 +1,6 @@
 package completion
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -68,7 +67,7 @@ func NewCmdCompletion(io *iostreams.IOStreams) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if shellType == "" {
 				if io.IsStdoutTTY() {
-					return &cmdutil.FlagError{Err: errors.New("error: the value for `--shell` is required")}
+					return cmdutil.FlagErrorf("error: the value for `--shell` is required")
 				}
 				shellType = "bash"
 			}

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -117,13 +117,13 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 				Short: "Upgrade installed extensions",
 				Args: func(cmd *cobra.Command, args []string) error {
 					if len(args) == 0 && !flagAll {
-						return &cmdutil.FlagError{Err: errors.New("must specify an extension to upgrade")}
+						return cmdutil.FlagErrorf("must specify an extension to upgrade")
 					}
 					if len(args) > 0 && flagAll {
-						return &cmdutil.FlagError{Err: errors.New("cannot use `--all` with extension name")}
+						return cmdutil.FlagErrorf("cannot use `--all` with extension name")
 					}
 					if len(args) > 1 {
-						return &cmdutil.FlagError{Err: errors.New("too many arguments")}
+						return cmdutil.FlagErrorf("too many arguments")
 					}
 					return nil
 				},

--- a/pkg/cmd/gist/clone/clone.go
+++ b/pkg/cmd/gist/clone/clone.go
@@ -61,7 +61,7 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 		if err == pflag.ErrHelp {
 			return err
 		}
-		return &cmdutil.FlagError{Err: fmt.Errorf("%w\nSeparate git clone flags with '--'.", err)}
+		return cmdutil.FlagErrorf("%w\nSeparate git clone flags with '--'.", err)
 	})
 
 	return cmd

--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -82,7 +82,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return nil
 			}
 			if opts.IO.IsStdinTTY() {
-				return &cmdutil.FlagError{Err: errors.New("no filenames passed and nothing on STDIN")}
+				return cmdutil.FlagErrorf("no filenames passed and nothing on STDIN")
 			}
 			return nil
 		},

--- a/pkg/cmd/gist/list/list.go
+++ b/pkg/cmd/gist/list/list.go
@@ -1,7 +1,6 @@
 package list
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -40,7 +39,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.Limit < 1 {
-				return &cmdutil.FlagError{Err: fmt.Errorf("invalid limit: %v", opts.Limit)}
+				return cmdutil.FlagErrorf("invalid limit: %v", opts.Limit)
 			}
 
 			opts.Visibility = "all"

--- a/pkg/cmd/gpg-key/add/add.go
+++ b/pkg/cmd/gpg-key/add/add.go
@@ -35,7 +35,7 @@ func NewCmdAdd(f *cmdutil.Factory, runF func(*AddOptions) error) *cobra.Command 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				if opts.IO.IsStdoutTTY() && opts.IO.IsStdinTTY() {
-					return &cmdutil.FlagError{Err: errors.New("GPG key file missing")}
+					return cmdutil.FlagErrorf("GPG key file missing")
 				}
 				opts.KeyFile = "-"
 			} else {

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -1,7 +1,6 @@
 package create
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -83,13 +82,13 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			}
 
 			if !opts.IO.CanPrompt() && opts.RecoverFile != "" {
-				return &cmdutil.FlagError{Err: errors.New("`--recover` only supported when running interactively")}
+				return cmdutil.FlagErrorf("`--recover` only supported when running interactively")
 			}
 
 			opts.Interactive = !(titleProvided && bodyProvided)
 
 			if opts.Interactive && !opts.IO.CanPrompt() {
-				return &cmdutil.FlagError{Err: errors.New("must provide title and body when not running interactively")}
+				return cmdutil.FlagErrorf("must provide title and body when not running interactively")
 			}
 
 			if runF != nil {

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -1,7 +1,6 @@
 package edit
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -106,7 +105,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			}
 
 			if opts.Interactive && !opts.IO.CanPrompt() {
-				return &cmdutil.FlagError{Err: errors.New("field to edit flag required when not running interactively")}
+				return cmdutil.FlagErrorf("field to edit flag required when not running interactively")
 			}
 
 			if runF != nil {

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -68,7 +68,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			opts.BaseRepo = f.BaseRepo
 
 			if opts.LimitResults < 1 {
-				return &cmdutil.FlagError{Err: fmt.Errorf("invalid limit: %v", opts.LimitResults)}
+				return cmdutil.FlagErrorf("invalid limit: %v", opts.LimitResults)
 			}
 
 			if runF != nil {

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -1,7 +1,6 @@
 package checks
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -49,7 +48,7 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 			opts.Finder = shared.NewFinder(f)
 
 			if repoOverride, _ := cmd.Flags().GetString("repo"); repoOverride != "" && len(args) == 0 {
-				return &cmdutil.FlagError{Err: errors.New("argument required when using the --repo flag")}
+				return cmdutil.FlagErrorf("argument required when using the --repo flag")
 			}
 
 			if len(args) > 0 {

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -1,8 +1,6 @@
 package comment
 
 import (
-	"errors"
-
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
@@ -39,7 +37,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if repoOverride, _ := cmd.Flags().GetString("repo"); repoOverride != "" && len(args) == 0 {
-				return &cmdutil.FlagError{Err: errors.New("argument required when using the --repo flag")}
+				return cmdutil.FlagErrorf("argument required when using the --repo flag")
 			}
 			var selector string
 			if len(args) > 0 {

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -126,11 +126,11 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			opts.MaintainerCanModify = !noMaintainerEdit
 
 			if !opts.IO.CanPrompt() && opts.RecoverFile != "" {
-				return &cmdutil.FlagError{Err: errors.New("`--recover` only supported when running interactively")}
+				return cmdutil.FlagErrorf("`--recover` only supported when running interactively")
 			}
 
 			if !opts.IO.CanPrompt() && !opts.WebMode && !opts.TitleProvided && !opts.Autofill {
-				return &cmdutil.FlagError{Err: errors.New("`--title` or `--fill` required when not running interactively")}
+				return cmdutil.FlagErrorf("`--title` or `--fill` required when not running interactively")
 			}
 
 			if opts.IsDraft && opts.WebMode {

--- a/pkg/cmd/pr/diff/diff.go
+++ b/pkg/cmd/pr/diff/diff.go
@@ -50,7 +50,7 @@ func NewCmdDiff(f *cmdutil.Factory, runF func(*DiffOptions) error) *cobra.Comman
 			opts.Finder = shared.NewFinder(f)
 
 			if repoOverride, _ := cmd.Flags().GetString("repo"); repoOverride != "" && len(args) == 0 {
-				return &cmdutil.FlagError{Err: errors.New("argument required when using the --repo flag")}
+				return cmdutil.FlagErrorf("argument required when using the --repo flag")
 			}
 
 			if len(args) > 0 {
@@ -58,7 +58,7 @@ func NewCmdDiff(f *cmdutil.Factory, runF func(*DiffOptions) error) *cobra.Comman
 			}
 
 			if !validColorFlag(opts.UseColor) {
-				return &cmdutil.FlagError{Err: fmt.Errorf("did not understand color: %q. Expected one of always, never, or auto", opts.UseColor)}
+				return cmdutil.FlagErrorf("did not understand color: %q. Expected one of always, never, or auto", opts.UseColor)
 			}
 
 			if opts.UseColor == "auto" && !opts.IO.IsStdoutTTY() {

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -1,7 +1,6 @@
 package edit
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -120,7 +119,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			}
 
 			if opts.Interactive && !opts.IO.CanPrompt() {
-				return &cmdutil.FlagError{Err: errors.New("--tile, --body, --reviewer, --assignee, --label, --project, or --milestone required when not running interactively")}
+				return cmdutil.FlagErrorf("--tile, --body, --reviewer, --assignee, --label, --project, or --milestone required when not running interactively")
 			}
 
 			if runF != nil {

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -75,7 +75,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			opts.BaseRepo = f.BaseRepo
 
 			if opts.LimitResults < 1 {
-				return &cmdutil.FlagError{Err: fmt.Errorf("invalid value for --limit: %v", opts.LimitResults)}
+				return cmdutil.FlagErrorf("invalid value for --limit: %v", opts.LimitResults)
 			}
 
 			if cmd.Flags().Changed("draft") {

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -75,7 +75,7 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 			opts.Finder = shared.NewFinder(f)
 
 			if repoOverride, _ := cmd.Flags().GetString("repo"); repoOverride != "" && len(args) == 0 {
-				return &cmdutil.FlagError{Err: errors.New("argument required when using the --repo flag")}
+				return cmdutil.FlagErrorf("argument required when using the --repo flag")
 			}
 
 			if len(args) > 0 {
@@ -97,11 +97,11 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 			}
 			if methodFlags == 0 {
 				if !opts.IO.CanPrompt() {
-					return &cmdutil.FlagError{Err: errors.New("--merge, --rebase, or --squash required when not running interactively")}
+					return cmdutil.FlagErrorf("--merge, --rebase, or --squash required when not running interactively")
 				}
 				opts.InteractiveMode = true
 			} else if methodFlags > 1 {
-				return &cmdutil.FlagError{Err: errors.New("only one of --merge, --rebase, or --squash can be enabled")}
+				return cmdutil.FlagErrorf("only one of --merge, --rebase, or --squash can be enabled")
 			}
 
 			opts.IsDeleteBranchIndicated = cmd.Flags().Changed("delete-branch")

--- a/pkg/cmd/pr/ready/ready.go
+++ b/pkg/cmd/pr/ready/ready.go
@@ -1,7 +1,6 @@
 package ready
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -42,7 +41,7 @@ func NewCmdReady(f *cmdutil.Factory, runF func(*ReadyOptions) error) *cobra.Comm
 			opts.Finder = shared.NewFinder(f)
 
 			if repoOverride, _ := cmd.Flags().GetString("repo"); repoOverride != "" && len(args) == 0 {
-				return &cmdutil.FlagError{Err: errors.New("argument required when using the --repo flag")}
+				return cmdutil.FlagErrorf("argument required when using the --repo flag")
 			}
 
 			if len(args) > 0 {

--- a/pkg/cmd/pr/review/review.go
+++ b/pkg/cmd/pr/review/review.go
@@ -72,7 +72,7 @@ func NewCmdReview(f *cmdutil.Factory, runF func(*ReviewOptions) error) *cobra.Co
 			opts.Finder = shared.NewFinder(f)
 
 			if repoOverride, _ := cmd.Flags().GetString("repo"); repoOverride != "" && len(args) == 0 {
-				return &cmdutil.FlagError{Err: errors.New("argument required when using the --repo flag")}
+				return cmdutil.FlagErrorf("argument required when using the --repo flag")
 			}
 
 			if len(args) > 0 {
@@ -106,26 +106,26 @@ func NewCmdReview(f *cmdutil.Factory, runF func(*ReviewOptions) error) *cobra.Co
 				found++
 				opts.ReviewType = api.ReviewRequestChanges
 				if opts.Body == "" {
-					return &cmdutil.FlagError{Err: errors.New("body cannot be blank for request-changes review")}
+					return cmdutil.FlagErrorf("body cannot be blank for request-changes review")
 				}
 			}
 			if flagComment {
 				found++
 				opts.ReviewType = api.ReviewComment
 				if opts.Body == "" {
-					return &cmdutil.FlagError{Err: errors.New("body cannot be blank for comment review")}
+					return cmdutil.FlagErrorf("body cannot be blank for comment review")
 				}
 			}
 
 			if found == 0 && opts.Body == "" {
 				if !opts.IO.CanPrompt() {
-					return &cmdutil.FlagError{Err: errors.New("--approve, --request-changes, or --comment required when not running interactively")}
+					return cmdutil.FlagErrorf("--approve, --request-changes, or --comment required when not running interactively")
 				}
 				opts.InteractiveMode = true
 			} else if found == 0 && opts.Body != "" {
-				return &cmdutil.FlagError{Err: errors.New("--body unsupported without --approve, --request-changes, or --comment")}
+				return cmdutil.FlagErrorf("--body unsupported without --approve, --request-changes, or --comment")
 			} else if found > 1 {
-				return &cmdutil.FlagError{Err: errors.New("need exactly one of --approve, --request-changes, or --comment")}
+				return cmdutil.FlagErrorf("need exactly one of --approve, --request-changes, or --comment")
 			}
 
 			if runF != nil {

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -65,15 +65,15 @@ func CommentablePreRun(cmd *cobra.Command, opts *CommentableOptions) error {
 
 	if inputFlags == 0 {
 		if !opts.IO.CanPrompt() {
-			return &cmdutil.FlagError{Err: errors.New("`--body`, `--body-file` or `--web` required when not running interactively")}
+			return cmdutil.FlagErrorf("`--body`, `--body-file` or `--web` required when not running interactively")
 		}
 		opts.Interactive = true
 	} else if inputFlags == 1 {
 		if !opts.IO.CanPrompt() && opts.InputType == InputTypeEditor {
-			return &cmdutil.FlagError{Err: errors.New("`--body`, `--body-file` or `--web` required when not running interactively")}
+			return cmdutil.FlagErrorf("`--body`, `--body-file` or `--web` required when not running interactively")
 		}
 	} else if inputFlags > 1 {
-		return &cmdutil.FlagError{Err: fmt.Errorf("specify only one of `--body`, `--body-file`, `--editor`, or `--web`")}
+		return cmdutil.FlagErrorf("specify only one of `--body`, `--body-file`, `--editor`, or `--web`")
 	}
 
 	return nil

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -1,7 +1,6 @@
 package view
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -55,7 +54,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 			opts.Finder = shared.NewFinder(f)
 
 			if repoOverride, _ := cmd.Flags().GetString("repo"); repoOverride != "" && len(args) == 0 {
-				return &cmdutil.FlagError{Err: errors.New("argument required when using the --repo flag")}
+				return cmdutil.FlagErrorf("argument required when using the --repo flag")
 			}
 
 			if len(args) > 0 {

--- a/pkg/cmd/release/download/download.go
+++ b/pkg/cmd/release/download/download.go
@@ -61,7 +61,7 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 
 			if len(args) == 0 {
 				if len(opts.FilePatterns) == 0 {
-					return &cmdutil.FlagError{Err: errors.New("the '--pattern' flag is required when downloading the latest release")}
+					return cmdutil.FlagErrorf("the '--pattern' flag is required when downloading the latest release")
 				}
 			} else {
 				opts.TagName = args[0]

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -62,7 +62,7 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 		if err == pflag.ErrHelp {
 			return err
 		}
-		return &cmdutil.FlagError{Err: fmt.Errorf("%w\nSeparate git clone flags with '--'.", err)}
+		return cmdutil.FlagErrorf("%w\nSeparate git clone flags with '--'.", err)
 	})
 
 	return cmd

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -1,7 +1,6 @@
 package create
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"path"
@@ -94,25 +93,25 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			}
 
 			if len(args) == 0 && (opts.GitIgnoreTemplate != "" || opts.LicenseTemplate != "") {
-				return &cmdutil.FlagError{Err: errors.New(".gitignore and license templates are added only when a specific repository name is passed")}
+				return cmdutil.FlagErrorf(".gitignore and license templates are added only when a specific repository name is passed")
 			}
 
 			if opts.Template != "" && (opts.GitIgnoreTemplate != "" || opts.LicenseTemplate != "") {
-				return &cmdutil.FlagError{Err: errors.New(".gitignore and license templates are not added when template is provided")}
+				return cmdutil.FlagErrorf(".gitignore and license templates are not added when template is provided")
 			}
 
 			if !opts.IO.CanPrompt() {
 				if opts.Name == "" {
-					return &cmdutil.FlagError{Err: errors.New("name argument required when not running interactively")}
+					return cmdutil.FlagErrorf("name argument required when not running interactively")
 				}
 
 				if !opts.Internal && !opts.Private && !opts.Public {
-					return &cmdutil.FlagError{Err: errors.New("`--public`, `--private`, or `--internal` required when not running interactively")}
+					return cmdutil.FlagErrorf("`--public`, `--private`, or `--internal` required when not running interactively")
 				}
 			}
 
 			if opts.Template != "" && (opts.Homepage != "" || opts.Team != "" || cmd.Flags().Changed("enable-issues") || cmd.Flags().Changed("enable-wiki")) {
-				return &cmdutil.FlagError{Err: errors.New("The `--template` option is not supported with `--homepage`, `--team`, `--enable-issues`, or `--enable-wiki`")}
+				return cmdutil.FlagErrorf("The `--template` option is not supported with `--homepage`, `--team`, `--enable-issues`, or `--enable-wiki`")
 			}
 
 			if runF != nil {

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -1,7 +1,6 @@
 package delete
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -41,8 +40,7 @@ To authorize, run "gh auth refresh -s delete_repo"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.RepoArg = args[0]
 			if !opts.IO.CanPrompt() && !opts.Confirmed {
-				return &cmdutil.FlagError{
-					Err: errors.New("could not prompt: confirmation with prompt or --confirm flag required")}
+				return cmdutil.FlagErrorf("could not prompt: confirmation with prompt or --confirm flag required")
 			}
 			if runF != nil {
 				return runF(opts)

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -1,7 +1,6 @@
 package fork
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -61,7 +60,7 @@ func NewCmdFork(f *cmdutil.Factory, runF func(*ForkOptions) error) *cobra.Comman
 		Use: "fork [<repository>] [-- <gitflags>...]",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if cmd.ArgsLenAtDash() == 0 && len(args[1:]) > 0 {
-				return &cmdutil.FlagError{Err: fmt.Errorf("repository argument required when passing 'git clone' flags")}
+				return cmdutil.FlagErrorf("repository argument required when passing 'git clone' flags")
 			}
 			return nil
 		},
@@ -84,11 +83,11 @@ Additional 'git clone' flags can be passed in by listing them after '--'.`,
 			}
 
 			if cmd.Flags().Changed("org") && opts.Organization == "" {
-				return &cmdutil.FlagError{Err: errors.New("--org cannot be blank")}
+				return cmdutil.FlagErrorf("--org cannot be blank")
 			}
 
 			if opts.RemoteName == "" {
-				return &cmdutil.FlagError{Err: errors.New("--remote-name cannot be blank")}
+				return cmdutil.FlagErrorf("--remote-name cannot be blank")
 			} else if !cmd.Flags().Changed("remote-name") {
 				opts.Rename = true // Any existing 'origin' will be renamed to upstream
 			}
@@ -109,7 +108,7 @@ Additional 'git clone' flags can be passed in by listing them after '--'.`,
 		if err == pflag.ErrHelp {
 			return err
 		}
-		return &cmdutil.FlagError{Err: fmt.Errorf("%w\nSeparate git clone flags with '--'.", err)}
+		return cmdutil.FlagErrorf("%w\nSeparate git clone flags with '--'.", err)
 	})
 
 	cmd.Flags().BoolVar(&opts.Clone, "clone", false, "Clone the fork {true|false}")

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -54,17 +54,17 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Short: "List repositories owned by user or organization",
 		RunE: func(c *cobra.Command, args []string) error {
 			if opts.Limit < 1 {
-				return &cmdutil.FlagError{Err: fmt.Errorf("invalid limit: %v", opts.Limit)}
+				return cmdutil.FlagErrorf("invalid limit: %v", opts.Limit)
 			}
 
 			if flagPrivate && flagPublic {
-				return &cmdutil.FlagError{Err: fmt.Errorf("specify only one of `--public` or `--private`")}
+				return cmdutil.FlagErrorf("specify only one of `--public` or `--private`")
 			}
 			if opts.Source && opts.Fork {
-				return &cmdutil.FlagError{Err: fmt.Errorf("specify only one of `--source` or `--fork`")}
+				return cmdutil.FlagErrorf("specify only one of `--source` or `--fork`")
 			}
 			if opts.Archived && opts.NonArchived {
-				return &cmdutil.FlagError{Err: fmt.Errorf("specify only one of `--archived` or `--no-archived`")}
+				return cmdutil.FlagErrorf("specify only one of `--archived` or `--no-archived`")
 			}
 
 			if flagPrivate {

--- a/pkg/cmd/root/help.go
+++ b/pkg/cmd/root/help.go
@@ -38,7 +38,7 @@ func rootFlagErrorFunc(cmd *cobra.Command, err error) error {
 	if err == pflag.ErrHelp {
 		return err
 	}
-	return &cmdutil.FlagError{Err: err}
+	return cmdutil.FlagErrorWrap(err)
 }
 
 var hasFailed bool

--- a/pkg/cmd/run/cancel/cancel.go
+++ b/pkg/cmd/run/cancel/cancel.go
@@ -40,7 +40,7 @@ func NewCmdCancel(f *cmdutil.Factory, runF func(*CancelOptions) error) *cobra.Co
 			if len(args) > 0 {
 				opts.RunID = args[0]
 			} else if !opts.IO.CanPrompt() {
-				return &cmdutil.FlagError{Err: errors.New("run ID required when not running interactively")}
+				return cmdutil.FlagErrorf("run ID required when not running interactively")
 			} else {
 				opts.Prompt = true
 			}

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -48,7 +48,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			opts.PlainOutput = !terminal
 
 			if opts.Limit < 1 {
-				return &cmdutil.FlagError{Err: fmt.Errorf("invalid limit: %v", opts.Limit)}
+				return cmdutil.FlagErrorf("invalid limit: %v", opts.Limit)
 			}
 
 			if runF != nil {

--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -40,7 +40,7 @@ func NewCmdRerun(f *cmdutil.Factory, runF func(*RerunOptions) error) *cobra.Comm
 			if len(args) > 0 {
 				opts.RunID = args[0]
 			} else if !opts.IO.CanPrompt() {
-				return &cmdutil.FlagError{Err: errors.New("run ID required when not running interactively")}
+				return cmdutil.FlagErrorf("run ID required when not running interactively")
 			} else {
 				opts.Prompt = true
 			}

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -118,7 +118,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 
 			if len(args) == 0 && opts.JobID == "" {
 				if !opts.IO.CanPrompt() {
-					return &cmdutil.FlagError{Err: errors.New("run or job ID required when not running interactively")}
+					return cmdutil.FlagErrorf("run or job ID required when not running interactively")
 				} else {
 					opts.Prompt = true
 				}
@@ -135,11 +135,11 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 			}
 
 			if opts.Web && opts.Log {
-				return &cmdutil.FlagError{Err: errors.New("specify only one of --web or --log")}
+				return cmdutil.FlagErrorf("specify only one of --web or --log")
 			}
 
 			if opts.Log && opts.LogFailed {
-				return &cmdutil.FlagError{Err: errors.New("specify only one of --log or --log-failed")}
+				return cmdutil.FlagErrorf("specify only one of --log or --log-failed")
 			}
 
 			if runF != nil {

--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -1,7 +1,6 @@
 package watch
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"runtime"
@@ -57,7 +56,7 @@ func NewCmdWatch(f *cmdutil.Factory, runF func(*WatchOptions) error) *cobra.Comm
 			if len(args) > 0 {
 				opts.RunID = args[0]
 			} else if !opts.IO.CanPrompt() {
-				return &cmdutil.FlagError{Err: errors.New("run ID required when not running interactively")}
+				return cmdutil.FlagErrorf("run ID required when not running interactively")
 			} else {
 				opts.Prompt = true
 			}

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -71,7 +71,7 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 `),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return &cmdutil.FlagError{Err: errors.New("must pass single secret name")}
+				return cmdutil.FlagErrorf("must pass single secret name")
 			}
 			return nil
 		},
@@ -92,23 +92,19 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 
 			if cmd.Flags().Changed("visibility") {
 				if opts.OrgName == "" {
-					return &cmdutil.FlagError{Err: errors.New(
-						"--visibility not supported for repository secrets; did you mean to pass --org?")}
+					return cmdutil.FlagErrorf("--visibility not supported for repository secrets; did you mean to pass --org?")
 				}
 
 				if opts.Visibility != shared.All && opts.Visibility != shared.Private && opts.Visibility != shared.Selected {
-					return &cmdutil.FlagError{Err: errors.New(
-						"--visibility must be one of `all`, `private`, or `selected`")}
+					return cmdutil.FlagErrorf("--visibility must be one of `all`, `private`, or `selected`")
 				}
 
 				if opts.Visibility != shared.Selected && cmd.Flags().Changed("repos") {
-					return &cmdutil.FlagError{Err: errors.New(
-						"--repos only supported when --visibility='selected'")}
+					return cmdutil.FlagErrorf("--repos only supported when --visibility='selected'")
 				}
 
 				if opts.Visibility == shared.Selected && !cmd.Flags().Changed("repos") {
-					return &cmdutil.FlagError{Err: errors.New(
-						"--repos flag required when --visibility='selected'")}
+					return cmdutil.FlagErrorf("--repos flag required when --visibility='selected'")
 				}
 			} else {
 				if cmd.Flags().Changed("repos") {

--- a/pkg/cmd/ssh-key/add/add.go
+++ b/pkg/cmd/ssh-key/add/add.go
@@ -1,7 +1,6 @@
 package add
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -36,7 +35,7 @@ func NewCmdAdd(f *cmdutil.Factory, runF func(*AddOptions) error) *cobra.Command 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				if opts.IO.IsStdoutTTY() && opts.IO.IsStdinTTY() {
-					return &cmdutil.FlagError{Err: errors.New("public key file missing")}
+					return cmdutil.FlagErrorf("public key file missing")
 				}
 				opts.KeyFile = "-"
 			} else {

--- a/pkg/cmd/workflow/disable/disable.go
+++ b/pkg/cmd/workflow/disable/disable.go
@@ -40,7 +40,7 @@ func NewCmdDisable(f *cmdutil.Factory, runF func(*DisableOptions) error) *cobra.
 			if len(args) > 0 {
 				opts.Selector = args[0]
 			} else if !opts.IO.CanPrompt() {
-				return &cmdutil.FlagError{Err: errors.New("workflow ID or name required when not running interactively")}
+				return cmdutil.FlagErrorf("workflow ID or name required when not running interactively")
 			} else {
 				opts.Prompt = true
 			}

--- a/pkg/cmd/workflow/enable/enable.go
+++ b/pkg/cmd/workflow/enable/enable.go
@@ -40,7 +40,7 @@ func NewCmdEnable(f *cmdutil.Factory, runF func(*EnableOptions) error) *cobra.Co
 			if len(args) > 0 {
 				opts.Selector = args[0]
 			} else if !opts.IO.CanPrompt() {
-				return &cmdutil.FlagError{Err: errors.New("workflow ID or name required when not running interactively")}
+				return cmdutil.FlagErrorf("workflow ID or name required when not running interactively")
 			} else {
 				opts.Prompt = true
 			}

--- a/pkg/cmd/workflow/list/list.go
+++ b/pkg/cmd/workflow/list/list.go
@@ -45,7 +45,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			opts.PlainOutput = !terminal
 
 			if opts.Limit < 1 {
-				return &cmdutil.FlagError{Err: fmt.Errorf("invalid limit: %v", opts.Limit)}
+				return cmdutil.FlagErrorf("invalid limit: %v", opts.Limit)
 			}
 
 			if runF != nil {

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -78,7 +78,7 @@ func NewCmdRun(f *cmdutil.Factory, runF func(*RunOptions) error) *cobra.Command 
 		`),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(opts.MagicFields)+len(opts.RawFields) > 0 && len(args) == 0 {
-				return &cmdutil.FlagError{Err: fmt.Errorf("workflow argument required when passing -f or -F")}
+				return cmdutil.FlagErrorf("workflow argument required when passing -f or -F")
 			}
 			return nil
 		},
@@ -91,7 +91,7 @@ func NewCmdRun(f *cmdutil.Factory, runF func(*RunOptions) error) *cobra.Command 
 			if len(args) > 0 {
 				opts.Selector = args[0]
 			} else if !opts.IO.CanPrompt() {
-				return &cmdutil.FlagError{Err: errors.New("workflow ID, name, or filename required when not running interactively")}
+				return cmdutil.FlagErrorf("workflow ID, name, or filename required when not running interactively")
 			} else {
 				opts.Prompt = true
 			}
@@ -103,16 +103,16 @@ func NewCmdRun(f *cmdutil.Factory, runF func(*RunOptions) error) *cobra.Command 
 				}
 				opts.JSONInput = string(jsonIn)
 			} else if opts.JSON {
-				return &cmdutil.FlagError{Err: errors.New("--json specified but nothing on STDIN")}
+				return cmdutil.FlagErrorf("--json specified but nothing on STDIN")
 			}
 
 			if opts.Selector == "" {
 				if opts.JSONInput != "" {
-					return &cmdutil.FlagError{Err: errors.New("workflow argument required when passing JSON")}
+					return cmdutil.FlagErrorf("workflow argument required when passing JSON")
 				}
 			} else {
 				if opts.JSON && inputFieldsPassed {
-					return &cmdutil.FlagError{Err: errors.New("only one of STDIN or -f/-F can be passed")}
+					return cmdutil.FlagErrorf("only one of STDIN or -f/-F can be passed")
 				}
 			}
 

--- a/pkg/cmd/workflow/view/view.go
+++ b/pkg/cmd/workflow/view/view.go
@@ -1,7 +1,6 @@
 package view
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -59,13 +58,13 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 			if len(args) > 0 {
 				opts.Selector = args[0]
 			} else if !opts.IO.CanPrompt() {
-				return &cmdutil.FlagError{Err: errors.New("workflow argument required when not running interactively")}
+				return cmdutil.FlagErrorf("workflow argument required when not running interactively")
 			} else {
 				opts.Prompt = true
 			}
 
 			if !opts.YAML && opts.Ref != "" {
-				return &cmdutil.FlagError{Err: errors.New("`--yaml` required when specifying `--ref`")}
+				return cmdutil.FlagErrorf("`--yaml` required when specifying `--ref`")
 			}
 
 			if runF != nil {

--- a/pkg/cmdutil/args.go
+++ b/pkg/cmdutil/args.go
@@ -1,7 +1,6 @@
 package cmdutil
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -15,7 +14,7 @@ func MinimumArgs(n int, msg string) cobra.PositionalArgs {
 
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) < n {
-			return &FlagError{Err: errors.New(msg)}
+			return FlagErrorf("%s", msg)
 		}
 		return nil
 	}
@@ -25,11 +24,11 @@ func ExactArgs(n int, msg string) cobra.PositionalArgs {
 
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) > n {
-			return &FlagError{Err: errors.New("too many arguments")}
+			return FlagErrorf("too many arguments")
 		}
 
 		if len(args) < n {
-			return &FlagError{Err: errors.New(msg)}
+			return FlagErrorf("%s", msg)
 		}
 
 		return nil
@@ -57,5 +56,5 @@ func NoArgsQuoteReminder(cmd *cobra.Command, args []string) error {
 		errMsg += "; please quote all values that have spaces"
 	}
 
-	return &FlagError{Err: errors.New(errMsg)}
+	return FlagErrorf("%s", errMsg)
 }

--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -2,22 +2,33 @@ package cmdutil
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 )
 
+// FlagErrorf returns a new FlagError that wraps an error produced by
+// fmt.Errorf(format, args...).
+func FlagErrorf(format string, args ...interface{}) error {
+	return FlagErrorWrap(fmt.Errorf(format, args...))
+}
+
+// FlagError returns a new FlagError that wraps the specified error.
+func FlagErrorWrap(err error) error { return &FlagError{err} }
+
 // A *FlagError indicates an error processing command-line flags or other arguments.
 // Such errors cause the application to display the usage message.
 type FlagError struct {
-	Err error
+	// Note: not struct{error}: only *FlagError should satisfy error.
+	err error
 }
 
 func (fe *FlagError) Error() string {
-	return fe.Err.Error()
+	return fe.err.Error()
 }
 
 func (fe *FlagError) Unwrap() error {
-	return fe.Err
+	return fe.err
 }
 
 // SilentError is an error that triggers exit code 1 without any error messaging
@@ -38,7 +49,7 @@ func MutuallyExclusive(message string, conditions ...bool) error {
 		}
 	}
 	if numTrue > 1 {
-		return &FlagError{Err: errors.New(message)}
+		return FlagErrorf("%s", message)
 	}
 	return nil
 }


### PR DESCRIPTION
This change hides the representation of FlagError, exposing two constructors:
- FlagErrorf, which uses fmt.Errorf (and supports %w)
- FlagErrorWrap(error), which is used in exactly one place.

Do we need the second one? Note that calling it instead of FlagErrorf("%s", err) is a behavior change.