### PR TITLE
binary extension migration

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -84,6 +84,15 @@ func CurrentBranch() (string, error) {
 	return "", fmt.Errorf("%sgit: %s", stderr.String(), err)
 }
 
+func listRemotesForPath(path string) ([]string, error) {
+	remoteCmd, err := GitCommand("-C", path, "remote", "-v")
+	if err != nil {
+		return nil, err
+	}
+	output, err := run.PrepareCmd(remoteCmd).Output()
+	return outputLines(output), err
+}
+
 func listRemotes() ([]string, error) {
 	remoteCmd, err := GitCommand("remote", "-v")
 	if err != nil {

--- a/git/remote.go
+++ b/git/remote.go
@@ -35,16 +35,11 @@ func (r *Remote) String() string {
 	return r.Name
 }
 
-// Remotes gets the git remotes set for the current repo
-func Remotes() (RemoteSet, error) {
-	list, err := listRemotes()
-	if err != nil {
-		return nil, err
-	}
-	remotes := parseRemotes(list)
+func remotes(path string, remoteList []string) (RemoteSet, error) {
+	remotes := parseRemotes(remoteList)
 
 	// this is affected by SetRemoteResolution
-	remoteCmd, err := GitCommand("config", "--get-regexp", `^remote\..*\.gh-resolved$`)
+	remoteCmd, err := GitCommand("-C", path, "config", "--get-regexp", `^remote\..*\.gh-resolved$`)
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +63,23 @@ func Remotes() (RemoteSet, error) {
 	}
 
 	return remotes, nil
+}
+
+func RemotesForPath(path string) (RemoteSet, error) {
+	list, err := listRemotesForPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return remotes(path, list)
+}
+
+// Remotes gets the git remotes set for the current repo
+func Remotes() (RemoteSet, error) {
+	list, err := listRemotes()
+	if err != nil {
+		return nil, err
+	}
+	return remotes(".", list)
 }
 
 func parseRemotes(gitRemotes []string) (remotes RemoteSet) {


### PR DESCRIPTION
Part of #4194 

This PR:

- adds ability to parse `ghrepo.Interface` and git remotes for a git repo at an arbitrary path (`ghrepo.FromPath`)
- Checks all non-binary extensions to see if they have switched to the releases-based precompiled extensions format during upgrade
- Removes and re-installs any migrated extensions
- does not worry about the possibility of a git-based extension becoming a binary extension; that is assumed to be a rare event (fixable through a remove/reinstall)

## considerations

- I'm only checking to see if the extension has changed formats when a git upgrade is available; my reasoning is that part of the new format is deleting the `gh-*` script from the repo's root which would show up as a git upgrade. Is this too hacky? Should we aggressively check for the new binary format even if there is not a git upgrade available?
- Is the loose error handling sufficient? I didn't want the bin format check to fail an upgrade that would otherwise work but I might be wrong.