### PR TITLE
Make branch input optional in codespace create

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -104,8 +104,9 @@ func (a *API) GetUser(ctx context.Context) (*User, error) {
 
 // Repository represents a GitHub repository.
 type Repository struct {
-	ID       int    `json:"id"`
-	FullName string `json:"full_name"`
+	ID            int    `json:"id"`
+	FullName      string `json:"full_name"`
+	DefaultBranch string `json:"default_branch"`
 }
 
 // GetRepository returns the repository associated with the given owner and name.


### PR DESCRIPTION
1. `gh codespace create -r owner/repo` will not prompt for the branch name anymore. It is no longer required to pass the `-b` flag. It will use the default branch for the repository.
2. The branch prompt during interactive `gh codespace create` now says that if left blank, the default branch of the repository will be used.

```
$ ghd cs create
? Repository: cli/cli
? Branch (leave blank for default branch):
```