### PR TITLE
rename gh auth status -h flag to -H

### DIFF
--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -48,7 +48,7 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "Check a specific hostname's auth status")
+	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "H", "", "Check a specific hostname's auth status")
 	cmd.Flags().BoolVarP(&opts.ShowToken, "show-token", "t", false, "Display the auth token")
 
 	return cmd

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -16,9 +16,10 @@ import (
 
 func Test_NewCmdStatus(t *testing.T) {
 	tests := []struct {
-		name  string
-		cli   string
-		wants StatusOptions
+		name    string
+		cli     string
+		wants   StatusOptions
+		wantErr bool
 	}{
 		{
 			name:  "no arguments",
@@ -33,6 +34,19 @@ func Test_NewCmdStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "hostname set",
+			cli:  "-H bella.ramsey",
+			wants: StatusOptions{
+				Hostname: "bella.ramsey",
+			},
+		},
+		{
+			name:    "hostname not found",
+			cli:     "-H joel.miller",
+			wantErr: true,
+		},
+
+		{
 			name: "show token",
 			cli:  "--show-token",
 			wants: StatusOptions{
@@ -46,6 +60,11 @@ func Test_NewCmdStatus(t *testing.T) {
 			f := &cmdutil.Factory{}
 
 			argv, err := shlex.Split(tt.cli)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
 			assert.NoError(t, err)
 
 			var gotOpts *StatusOptions
@@ -188,7 +207,8 @@ func Test_statusRun(t *testing.T) {
 					httpmock.StringResponse(`{"data":{"viewer":{"login":"tess"}}}`))
 			},
 			wantErrOut: regexp.MustCompile(`(?s)Token: xyz456.*Token: abc123`),
-		}, {
+		},
+		{
 			name: "missing hostname",
 			opts: &StatusOptions{
 				Hostname: "github.example.com",


### PR DESCRIPTION
`gh auth status -h` prints the help and not set the hostname as documented,
since `-h` is assigned to help via the global flag let's rename it to `-H`