### PR TITLE
Publish codespace commands

### DIFF
--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -1,23 +1,14 @@
 package codespace
 
 import (
-	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 )
 
 func NewRootCmd(app *App) *cobra.Command {
 	root := &cobra.Command{
-		Use:           "codespace",
-		SilenceUsage:  true,  // don't print usage message after each error (see #80)
-		SilenceErrors: false, // print errors automatically so that main need not
-		Short:         "List, create, delete and SSH into codespaces",
-		Long:          `Work with GitHub codespaces`,
-		Example: heredoc.Doc(`
-			$ gh codespace list
-			$ gh codespace create
-			$ gh codespace delete
-			$ gh codespace ssh
-		`),
+		Use:   "codespace",
+		Short: "Manage and connect to your codespaces",
+		Long:  `Work with GitHub Codespaces`,
 	}
 
 	root.AddCommand(newCodeCmd(app))

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -7,8 +7,7 @@ import (
 func NewRootCmd(app *App) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "codespace",
-		Short: "Manage and connect to your codespaces",
-		Long:  `Work with GitHub Codespaces`,
+		Short: "Connect to and manage your codespaces",
 	}
 
 	root.AddCommand(newCodeCmd(app))

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -31,11 +31,12 @@ func newSSHCmd(app *App) *cobra.Command {
 	var opts sshOptions
 
 	sshCmd := &cobra.Command{
-		Use:   "ssh [flags] [--] [ssh-flags] [command]",
+		Use:   "ssh [<flags>...] [-- <ssh-flags>... [command]]",
 		Short: "SSH into a codespace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return app.SSH(cmd.Context(), args, opts)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	sshCmd.Flags().StringVarP(&opts.profile, "profile", "", "", "Name of the SSH profile to use")

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -31,7 +31,7 @@ func newSSHCmd(app *App) *cobra.Command {
 	var opts sshOptions
 
 	sshCmd := &cobra.Command{
-		Use:   "ssh [<flags>...] [<command>] [-- <ssh-flags>...]",
+		Use:   "ssh [<flags>...] [-- <ssh-flags>...] [<command>]",
 		Short: "SSH into a codespace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return app.SSH(cmd.Context(), args, opts)

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -31,7 +31,7 @@ func newSSHCmd(app *App) *cobra.Command {
 	var opts sshOptions
 
 	sshCmd := &cobra.Command{
-		Use:   "ssh [<flags>...] [-- <ssh-flags>... [command]]",
+		Use:   "ssh [<flags>...] [<command>] [-- <ssh-flags>...]",
 		Short: "SSH into a codespace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return app.SSH(cmd.Context(), args, opts)

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -136,7 +136,6 @@ func newCodespaceCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := codespaceCmd.NewRootCmd(app)
 	cmd.Use = "codespace"
 	cmd.Aliases = []string{"cs"}
-	cmd.Hidden = true
 	return cmd
 }
 


### PR DESCRIPTION
This publishes `gh codespace` commands, essentially just making them listed in the documentation.