### PR TITLE
WSL support for `codespace code` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Additional Conda installation options available on the [gh-feedstock page](https
 | ------------------ | ---------------------------------------- |
 | `spack install gh` | `spack uninstall gh && spack install gh` |
 
-### Linux & BSD
+### Linux, BSD & WSL2
 
 `gh` is available via [Homebrew](#homebrew), [Conda](#conda), [Spack](#spack), and as downloadable binaries from the [releases page][].
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -22,7 +22,7 @@ sudo apt install gh
 
 **Note**: If you get the error _"gpg: failed to start the dirmngr '/usr/bin/dirmngr': No such file or directory"_, try installing the `dirmngr` package: `sudo apt install dirmngr`.
 
-**On wsL2 systems**: `sudo apt-get install -y xdg-utils` is required to lauch codespaces in vscode | vscode-insiders
+**On wsl2 systems**: `sudo apt-get install -y xdg-utils` is required to lauch codespaces in vscode / vscode-insiders
 
 Upgrade:
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -9,7 +9,7 @@ our release schedule.
 
 ## Official sources
 
-### Debian, Ubuntu Linux (including wsl2), Raspberry Pi OS (apt)
+### Debian, Ubuntu Linux (including WSL2), Raspberry Pi OS (apt)
 
 Install:
 
@@ -22,7 +22,7 @@ sudo apt install gh
 
 **Note**: If you get the error _"gpg: failed to start the dirmngr '/usr/bin/dirmngr': No such file or directory"_, try installing the `dirmngr` package: `sudo apt install dirmngr`.
 
-**On wsl2 systems**: `sudo apt-get install -y xdg-utils` is required to lauch codespaces in vscode / vscode-insiders
+**On WSL2 systems**: `sudo apt-get install -y xdg-utils` is required to lauch codespaces in vscode / vscode-insiders
 
 Upgrade:
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -9,7 +9,7 @@ our release schedule.
 
 ## Official sources
 
-### Debian, Ubuntu Linux, Raspberry Pi OS (apt)
+### Debian, Ubuntu Linux (including wsl2), Raspberry Pi OS (apt)
 
 Install:
 
@@ -21,6 +21,8 @@ sudo apt install gh
 ```
 
 **Note**: If you get the error _"gpg: failed to start the dirmngr '/usr/bin/dirmngr': No such file or directory"_, try installing the `dirmngr` package: `sudo apt install dirmngr`.
+
+**On wsL2 systems**: `sudo apt-get install -y xdg-utils` is required to lauch codespaces in vscode | vscode-insiders
 
 Upgrade:
 


### PR DESCRIPTION
### what
provides small documentation update to help wsl2 users get past a cli error. tangentially related to https://github.com/cli/cli/issues/3526

### why
as a wsl2 user when i attempt to open a codespace in vscode, i get a path not found error. it wasn't obvious what the issue was... 'was xdg-open, not finding code? was it because i was running code insiders etc'. also it wasn't clear to me that `xdg-open` is not installed by default in wsl2. 

its worth mentioning that code itself, as well as regular windows programs open fine in wsl2 with out `xdg-open` which is why its not needed or missed before this.

![image](https://user-images.githubusercontent.com/1538695/139133832-6cbacd22-7e85-4be8-a401-72c2f2fc5821.png)

### follow on
https://wslutiliti.es/wslu/man/wslview.html is installed in wsl2 by default and https://github.com/4U6U57/wsl-open is a popular install as well. long term i'd like to see this transparent to the end user. that said given the backlog in #3526 I think a doc update is a sufficiently low hanging fruit.


### platform details
```
❯ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.3 LTS
Release:        20.04
Codename:       focal
```
![image](https://user-images.githubusercontent.com/1538695/139134647-08c1280f-1aef-451f-841e-2a4747e59f54.png)

```
PS C:\Users\makorwel> wsl -l
Windows Subsystem for Linux Distributions:
Ubuntu-20.04 (Default)
```