### PR TITLE
Adds a timeout context to the ssh waiter to prevent indefinite hanging

### DIFF
--- a/pkg/liveshare/rpc.go
+++ b/pkg/liveshare/rpc.go
@@ -34,7 +34,7 @@ func (r *rpcClient) do(ctx context.Context, method string, args, result interfac
 	}
 
 	// timeout for waiter in case a connection cannot be made
-	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
 	return waiter.Wait(waitCtx, result)

--- a/pkg/liveshare/rpc.go
+++ b/pkg/liveshare/rpc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/sourcegraph/jsonrpc2"
@@ -32,7 +33,11 @@ func (r *rpcClient) do(ctx context.Context, method string, args, result interfac
 		return fmt.Errorf("error dispatching %q call: %w", method, err)
 	}
 
-	return waiter.Wait(ctx, result)
+	// timeout for waiter in case a connection cannot be made
+	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	return waiter.Wait(waitCtx, result)
 }
 
 type nullHandler struct{}


### PR DESCRIPTION
This patch adds a timeout to the ssh call waiter in the liveshare client. While the hope is to never have issues that would cause the liveshare client call to hang in the first place, we have now seen cases of it happening so this prevents users from having requests stall for more than a couple of minutes.

I was able to test this works by having my local build ssh into a codespace that I had changed the sshd_config port on without restarting sshd itself. `gh cs ssh` then tries to ssh using the incorrect port and hangs for the correct 2 mins before giving:

```
» go run cmd/gh/main.go cs ssh                                                                                                                                                                                                                                                                                          1 ↵
? Choose codespace: github/github: fix-pkg-permission-expiry
kex_exchange_identification: read: Connection reset by peer
tunnel closed: error opening streaming channel for new connection: error getting stream id: context deadline exceeded
exit status 1
```

Without the new context the request hangs for much longer (reportedly 8-9 minutes at times) before aborting.

Closes: https://github.com/github/cli/issues/100
