### PR TITLE
Hyperlink in terminal proof of concept.

### DIFF
--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -19,7 +19,7 @@ func PrintIssues(io *iostreams.IOStreams, prefix string, totalCount int, issues 
 	for _, issue := range issues {
 		issueNum := strconv.Itoa(issue.Number)
 		if table.IsTTY() {
-			issueNum = "#" + issueNum
+			issueNum = cs.HyperLink("#"+issueNum, issue.URL)
 		}
 		issueNum = prefix + issueNum
 		now := time.Now()

--- a/pkg/iostreams/color.go
+++ b/pkg/iostreams/color.go
@@ -220,3 +220,10 @@ func (c *ColorScheme) HexToRGB(hex string, x string) string {
 	b, _ := strconv.ParseInt(hex[4:6], 16, 64)
 	return fmt.Sprintf("\033[38;2;%d;%d;%dm%s\033[0m", r, g, b, x)
 }
+
+func (c *ColorScheme) HyperLink(title, href string) string {
+	if !c.enabled {
+		return title
+	}
+	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", href, title)
+}


### PR DESCRIPTION
This is a Proof of Concept of how hyperlinks can enhanced a bit the output of `gh` 

The hyperlinks works in about every terminal emulator (i think from 2017) 

https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda

and give a IMO a better experience when for example on a list to be able to click instead of copy and paste and add the repo url.

The screenshot is using gnome-terminal and i believe it works the same on iTerm2 (with ⌘+click)  and if i control+click here on the #4633 issue it will automatically get me to the issue url : 
 
![ScreenShot](https://user-images.githubusercontent.com/98980/139432797-954e4245-f4b4-489b-843c-56e46ff01cd0.png)

I will be happy to clean this up if you think that's a good idea for `gh` cli.
