### PR TITLE
prefix urls with the scheme, improving discoverability

### DIFF
--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -293,7 +293,7 @@ func Test_createRun(t *testing.T) {
 				WebMode:   true,
 				Filenames: []string{fixtureFile},
 			},
-			wantOut:    "Opening gist.github.com/aa5a315d61ae9438b18d in your browser.\n",
+			wantOut:    "Opening https://gist.github.com/aa5a315d61ae9438b18d in your browser.\n",
 			wantStderr: "- Creating gist fixture.txt\n✓ Created gist fixture.txt\n",
 			wantErr:    false,
 			wantBrowse: "https://gist.github.com/aa5a315d61ae9438b18d",

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -220,7 +220,7 @@ func Test_commentRun(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockIssueFromNumber(t, reg)
 			},
-			stderr: "Opening github.com/OWNER/REPO/issues/123 in your browser.\n",
+			stderr: "Opening https://github.com/OWNER/REPO/issues/123 in your browser.\n",
 		},
 		{
 			name: "non-interactive editor",

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -152,7 +152,7 @@ func Test_createRun(t *testing.T) {
 				WebMode: true,
 			},
 			wantsBrowse: "https://github.com/OWNER/REPO/issues/new",
-			wantsStderr: "Opening github.com/OWNER/REPO/issues/new in your browser.\n",
+			wantsStderr: "Opening https://github.com/OWNER/REPO/issues/new in your browser.\n",
 		},
 		{
 			name: "title and body",
@@ -162,7 +162,7 @@ func Test_createRun(t *testing.T) {
 				Body:    "hello cli",
 			},
 			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?body=hello+cli&title=myissue",
-			wantsStderr: "Opening github.com/OWNER/REPO/issues/new in your browser.\n",
+			wantsStderr: "Opening https://github.com/OWNER/REPO/issues/new in your browser.\n",
 		},
 		{
 			name: "assignee",
@@ -171,7 +171,7 @@ func Test_createRun(t *testing.T) {
 				Assignees: []string{"monalisa"},
 			},
 			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?assignees=monalisa&body=",
-			wantsStderr: "Opening github.com/OWNER/REPO/issues/new in your browser.\n",
+			wantsStderr: "Opening https://github.com/OWNER/REPO/issues/new in your browser.\n",
 		},
 		{
 			name: "@me",
@@ -188,7 +188,7 @@ func Test_createRun(t *testing.T) {
 					} }`))
 			},
 			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?assignees=MonaLisa&body=",
-			wantsStderr: "Opening github.com/OWNER/REPO/issues/new in your browser.\n",
+			wantsStderr: "Opening https://github.com/OWNER/REPO/issues/new in your browser.\n",
 		},
 		{
 			name: "project",
@@ -217,7 +217,7 @@ func Test_createRun(t *testing.T) {
 					} } } }`))
 			},
 			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?body=&projects=OWNER%2FREPO%2F1",
-			wantsStderr: "Opening github.com/OWNER/REPO/issues/new in your browser.\n",
+			wantsStderr: "Opening https://github.com/OWNER/REPO/issues/new in your browser.\n",
 		},
 		{
 			name: "has templates",
@@ -237,7 +237,7 @@ func Test_createRun(t *testing.T) {
 				)
 			},
 			wantsBrowse: "https://github.com/OWNER/REPO/issues/new/choose",
-			wantsStderr: "Opening github.com/OWNER/REPO/issues/new/choose in your browser.\n",
+			wantsStderr: "Opening https://github.com/OWNER/REPO/issues/new/choose in your browser.\n",
 		},
 		{
 			name: "too long body",
@@ -557,7 +557,7 @@ func TestIssueCreate_continueInBrowser(t *testing.T) {
 
 		Creating issue in OWNER/REPO
 
-		Opening github.com/OWNER/REPO/issues/new in your browser.
+		Opening https://github.com/OWNER/REPO/issues/new in your browser.
 	`), output.Stderr())
 	assert.Equal(t, "https://github.com/OWNER/REPO/issues/new?body=body&title=hello", output.BrowsedURL)
 }

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -210,7 +210,7 @@ func TestIssueList_web(t *testing.T) {
 	}
 
 	assert.Equal(t, "", stdout.String())
-	assert.Equal(t, "Opening github.com/OWNER/REPO/issues in your browser.\n", stderr.String())
+	assert.Equal(t, "Opening https://github.com/OWNER/REPO/issues in your browser.\n", stderr.String())
 	browser.Verify(t, "https://github.com/OWNER/REPO/issues?q=is%3Aissue+assignee%3Apeter+label%3Abug+label%3Adocs+author%3Ajohn+mentions%3Afrank+milestone%3Av1.1")
 }
 

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -95,7 +95,7 @@ func TestIssueView_web(t *testing.T) {
 	}
 
 	assert.Equal(t, "", stdout.String())
-	assert.Equal(t, "Opening github.com/OWNER/REPO/issues/123 in your browser.\n", stderr.String())
+	assert.Equal(t, "Opening https://github.com/OWNER/REPO/issues/123 in your browser.\n", stderr.String())
 	browser.Verify(t, "https://github.com/OWNER/REPO/issues/123")
 }
 

--- a/pkg/cmd/pr/checks/checks_test.go
+++ b/pkg/cmd/pr/checks/checks_test.go
@@ -201,7 +201,7 @@ func TestChecksRun_web(t *testing.T) {
 		{
 			name:       "tty",
 			isTTY:      true,
-			wantStderr: "Opening github.com/OWNER/REPO/pull/123/checks in your browser.\n",
+			wantStderr: "Opening https://github.com/OWNER/REPO/pull/123/checks in your browser.\n",
 			wantStdout: "",
 			wantBrowse: "https://github.com/OWNER/REPO/pull/123/checks",
 		},

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -237,7 +237,7 @@ func Test_commentRun(t *testing.T) {
 
 				OpenInBrowser: func(string) error { return nil },
 			},
-			stderr: "Opening github.com/OWNER/REPO/pull/123 in your browser.\n",
+			stderr: "Opening https://github.com/OWNER/REPO/pull/123 in your browser.\n",
 		},
 		{
 			name: "non-interactive editor",

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -779,7 +779,7 @@ func TestPRCreate_web(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "Opening github.com/OWNER/REPO/compare/master...feature in your browser.\n", output.Stderr())
+	assert.Equal(t, "Opening https://github.com/OWNER/REPO/compare/master...feature in your browser.\n", output.Stderr())
 	assert.Equal(t, "https://github.com/OWNER/REPO/compare/master...feature?body=&expand=1", output.BrowsedURL)
 }
 
@@ -850,7 +850,7 @@ func TestPRCreate_webProject(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "Opening github.com/OWNER/REPO/compare/master...feature in your browser.\n", output.Stderr())
+	assert.Equal(t, "Opening https://github.com/OWNER/REPO/compare/master...feature in your browser.\n", output.Stderr())
 	assert.Equal(t, "https://github.com/OWNER/REPO/compare/master...feature?body=&expand=1&projects=ORG%2F1", output.BrowsedURL)
 }
 

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -273,7 +273,7 @@ func TestPRList_web(t *testing.T) {
 			}
 
 			assert.Equal(t, "", output.String())
-			assert.Equal(t, "Opening github.com/OWNER/REPO/pulls in your browser.\n", output.Stderr())
+			assert.Equal(t, "Opening https://github.com/OWNER/REPO/pulls in your browser.\n", output.Stderr())
 			assert.Equal(t, test.expectedBrowserURL, output.BrowsedURL)
 		})
 	}

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -466,7 +466,7 @@ func TestPRView_web_currentBranch(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "Opening github.com/OWNER/REPO/pull/10 in your browser.\n", output.Stderr())
+	assert.Equal(t, "Opening https://github.com/OWNER/REPO/pull/10 in your browser.\n", output.Stderr())
 	assert.Equal(t, "https://github.com/OWNER/REPO/pull/10", output.BrowsedURL)
 }
 

--- a/pkg/cmd/repo/view/view_test.go
+++ b/pkg/cmd/repo/view/view_test.go
@@ -106,7 +106,7 @@ func Test_RepoView_Web(t *testing.T) {
 		{
 			name:       "tty",
 			stdoutTTY:  true,
-			wantStderr: "Opening github.com/OWNER/REPO in your browser.\n",
+			wantStderr: "Opening https://github.com/OWNER/REPO in your browser.\n",
 			wantBrowse: "https://github.com/OWNER/REPO",
 		},
 		{

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -751,7 +751,7 @@ func TestViewRun(t *testing.T) {
 					httpmock.JSONResponse(shared.SuccessfulRun))
 			},
 			browsedURL: "https://github.com/runs/3",
-			wantOut:    "Opening github.com/runs/3 in your browser.\n",
+			wantOut:    "Opening https://github.com/runs/3 in your browser.\n",
 		},
 		{
 			name: "web job",
@@ -769,7 +769,7 @@ func TestViewRun(t *testing.T) {
 					httpmock.JSONResponse(shared.SuccessfulRun))
 			},
 			browsedURL: "https://github.com/jobs/10?check_suite_focus=true",
-			wantOut:    "Opening github.com/jobs/10 in your browser.\n",
+			wantOut:    "Opening https://github.com/jobs/10 in your browser.\n",
 		},
 		{
 			name: "hide job header, failure",

--- a/pkg/cmd/workflow/view/view_test.go
+++ b/pkg/cmd/workflow/view/view_test.go
@@ -222,7 +222,7 @@ func TestViewRun(t *testing.T) {
 					httpmock.JSONResponse(aWorkflow),
 				)
 			},
-			wantOut: "Opening github.com/OWNER/REPO/actions/workflows/flow.yml in your browser.\n",
+			wantOut: "Opening https://github.com/OWNER/REPO/actions/workflows/flow.yml in your browser.\n",
 		},
 		{
 			name: "web notty",
@@ -257,7 +257,7 @@ func TestViewRun(t *testing.T) {
 					httpmock.StringResponse(`{ "data": { "repository": { "defaultBranchRef": { "name": "trunk" } } } }`),
 				)
 			},
-			wantOut: "Opening github.com/OWNER/REPO/blob/trunk/.github/workflows/flow.yml in your browser.\n",
+			wantOut: "Opening https://github.com/OWNER/REPO/blob/trunk/.github/workflows/flow.yml in your browser.\n",
 		},
 		{
 			name: "web with yaml and ref",
@@ -274,7 +274,7 @@ func TestViewRun(t *testing.T) {
 					httpmock.JSONResponse(aWorkflow),
 				)
 			},
-			wantOut: "Opening github.com/OWNER/REPO/blob/base/.github/workflows/flow.yml in your browser.\n",
+			wantOut: "Opening https://github.com/OWNER/REPO/blob/base/.github/workflows/flow.yml in your browser.\n",
 		},
 		{
 			name: "workflow with yaml",

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -76,7 +76,7 @@ func DisplayURL(urlStr string) string {
 	if err != nil {
 		return urlStr
 	}
-	return u.Hostname() + u.Path
+	return fmt.Sprintf("%s://%s%s", u.Scheme, u.Hostname(), u.Path)
 }
 
 // Maximum length of a URL: 8192 bytes


### PR DESCRIPTION
Basically prefixing the URLs with their scheme. 

This improves readability in the CLI when trying to discover items that are interesting, both for humans and machines (CLI that allows clickable URLs).