### PR TITLE
encode `gh browse` output url

### DIFF
--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -105,7 +105,9 @@ func IsSame(a, b Interface) bool {
 func GenerateRepoURL(repo Interface, p string, args ...interface{}) string {
 	baseURL := fmt.Sprintf("%s%s/%s", ghinstance.HostPrefix(repo.RepoHost()), repo.RepoOwner(), repo.RepoName())
 	if p != "" {
-		return baseURL + "/" + fmt.Sprintf(p, args...)
+		if path := fmt.Sprintf(p, args...); path != "" {
+			return baseURL + "/" + path
+		}
 	}
 	return baseURL
 }

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -2,6 +2,7 @@ package browse
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -125,6 +126,8 @@ func TestNewCmdBrowse(t *testing.T) {
 			argv, err := shlex.Split(tt.cli)
 			assert.NoError(t, err)
 			cmd.SetArgs(argv)
+			cmd.SetOut(ioutil.Discard)
+			cmd.SetErr(ioutil.Discard)
 			_, err = cmd.ExecuteC()
 
 			if tt.wantsErr {
@@ -235,7 +238,7 @@ func Test_runBrowse(t *testing.T) {
 				PathFromRepoRoot: func() string { return "pkg/dir" },
 			},
 			baseRepo:    ghrepo.New("bstnc", "yeepers"),
-			expectedURL: "https://github.com/bstnc/yeepers/tree/feature-123/",
+			expectedURL: "https://github.com/bstnc/yeepers/tree/feature-123",
 		},
 		{
 			name: "branch flag within dir with .",

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -170,7 +170,7 @@ func Test_runBrowse(t *testing.T) {
 				SelectorArg: "",
 			},
 			baseRepo:    ghrepo.New("jlsestak", "cli"),
-			expectedURL: "https://github.com/jlsestak/cli",
+			expectedURL: "https://github.com/jlsestak/cli/",
 		},
 		{
 			name: "settings flag",
@@ -366,11 +366,11 @@ func Test_runBrowse(t *testing.T) {
 		{
 			name: "use special characters in selector arg",
 			opts: BrowseOptions{
-				SelectorArg: "?=hello world *:23-44",
+				SelectorArg: "?=hello world/ *:23-44",
 			},
 			baseRepo:      ghrepo.New("bchadwic", "test"),
 			defaultBranch: "trunk",
-			expectedURL:   "https://github.com/bchadwic/test/blob/trunk/%3F=hello%20world%20%2A?plain=1#L23-L44",
+			expectedURL:   "https://github.com/bchadwic/test/blob/trunk/%3F=hello%20world/%20%2A?plain=1#L23-L44",
 			wantsErr:      false,
 		},
 	}
@@ -475,11 +475,6 @@ func Test_parsePathFromFileArg(t *testing.T) {
 			name:         "go to root of repository",
 			fileArg:      filepath.Join("..", "..", "..") + s + "",
 			expectedPath: "",
-		},
-		{
-			name:         "special character path",
-			fileArg:      "*bad path name*",
-			expectedPath: "pkg/cmd/browse/%2Abad%20path%20name%2A",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -363,6 +363,16 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL:   "https://github.com/bchadwic/gh-graph/tree/trunk/pkg/cmd/pr",
 			wantsErr:      false,
 		},
+		{
+			name: "use special characters in selector arg",
+			opts: BrowseOptions{
+				SelectorArg: "?=hello world *:23-44",
+			},
+			baseRepo:      ghrepo.New("bchadwic", "test"),
+			defaultBranch: "trunk",
+			expectedURL:   "https://github.com/bchadwic/test/blob/trunk/%3F=hello%20world%20%2A?plain=1#L23-L44",
+			wantsErr:      false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -465,6 +475,11 @@ func Test_parsePathFromFileArg(t *testing.T) {
 			name:         "go to root of repository",
 			fileArg:      filepath.Join("..", "..", "..") + s + "",
 			expectedPath: "",
+		},
+		{
+			name:         "special character path",
+			fileArg:      "*bad path name*",
+			expectedPath: "pkg/cmd/browse/%2Abad%20path%20name%2A",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
fixes #4647


1. User's before, and with this pr can't open up files with a `\` in the file's / folder's name
	- I can update the pr to allow for `\` to be escaped with another `\`? Not sure if this would be useful. `/` can't be in a path name so this isn't a problem.
2. I removed `utils.DisplayUrl()`, but this can be reinserted easily. 
	- I'm not sure if users would rather see the encoded or nonencoded url when opening up the url in the browser. Although I'm starting to see why that function was there in the first place.
