### PR TITLE
This pull request adds support for json output the to `gh pr checks` …

### DIFF
--- a/pkg/cmd/pr/checks/checks_test.go
+++ b/pkg/cmd/pr/checks/checks_test.go
@@ -183,7 +183,7 @@ func Test_checksRun(t *testing.T) {
 			wantOut:    "",
 			wantErr:    "",
 			jsonOutput: true,
-			wantJson:   "{\"cool tests\":{\"bucket\":\"pass\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"✓\",\"markColor\":\"✓\",\"name\":\"cool tests\",\"number\":123},\"rad tests\":{\"bucket\":\"skipping\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"-\",\"markColor\":\"-\",\"name\":\"rad tests\",\"number\":123},\"skip tests\":{\"bucket\":\"skipping\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"-\",\"markColor\":\"-\",\"name\":\"skip tests\",\"number\":123},\"summary\":\"All checks were successful\\n0 failing, 1 successful, 2 skipped, and 0 pending checks\"}",
+			wantJson:   "{\"cool tests\":{\"bucket\":\"pass\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"✓\",\"markColor\":\"✓\",\"name\":\"cool tests\",\"number\":123},\"failing\":0,\"passing\":1,\"pending\":0,\"rad tests\":{\"bucket\":\"skipping\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"-\",\"markColor\":\"-\",\"name\":\"rad tests\",\"number\":123},\"skip tests\":{\"bucket\":\"skipping\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"-\",\"markColor\":\"-\",\"name\":\"skip tests\",\"number\":123},\"skipping\":2,\"summary\":\"All checks were successful\\n0 failing, 1 successful, 2 skipped, and 0 pending checks\",\"tallies\":\"0 failing, 1 successful, 2 skipped, and 0 pending checks\"}",
 		},
 		{
 			name:       "no commits --json",
@@ -207,7 +207,7 @@ func Test_checksRun(t *testing.T) {
 			wantOut:    "",
 			wantErr:    "SilentError",
 			jsonOutput: true,
-			wantJson:   "{\"cool tests\":{\"bucket\":\"pass\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"✓\",\"markColor\":\"✓\",\"name\":\"cool tests\",\"number\":123},\"sad tests\":{\"bucket\":\"fail\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"X\",\"markColor\":\"X\",\"name\":\"sad tests\",\"number\":123},\"slow tests\":{\"bucket\":\"pending\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"*\",\"markColor\":\"*\",\"name\":\"slow tests\",\"number\":123},\"summary\":\"Some checks were not successful\\n1 failing, 1 successful, 0 skipped, and 1 pending checks\"}",
+			wantJson:   "{\"cool tests\":{\"bucket\":\"pass\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"✓\",\"markColor\":\"✓\",\"name\":\"cool tests\",\"number\":123},\"failing\":1,\"passing\":1,\"pending\":1,\"sad tests\":{\"bucket\":\"fail\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"X\",\"markColor\":\"X\",\"name\":\"sad tests\",\"number\":123},\"skipping\":0,\"slow tests\":{\"bucket\":\"pending\",\"elapsed\":\"1m26s\",\"link\":\"sweet link\",\"mark\":\"*\",\"markColor\":\"*\",\"name\":\"slow tests\",\"number\":123},\"summary\":\"Some checks were not successful\\n1 failing, 1 successful, 0 skipped, and 1 pending checks\",\"tallies\":\"1 failing, 1 successful, 0 skipped, and 1 pending checks\"}",
 		},
 	}
 

--- a/pkg/cmdutil/json_flags.go
+++ b/pkg/cmdutil/json_flags.go
@@ -59,6 +59,13 @@ func AddJSONFlags(cmd *cobra.Command, exportTarget *Exporter, fields []string) {
 				allowedFields := set.NewStringSet()
 				allowedFields.AddValues(fields)
 				for _, f := range export.fields {
+					// allow * to mean all fields.
+					if f == "*" {
+						// allow all fields.
+						export.fields = fields
+						break
+					}
+
 					if !allowedFields.Contains(f) {
 						sort.Strings(fields)
 						return JSONFlagError{fmt.Errorf("Unknown JSON field: %q\nAvailable fields:\n  %s", f, strings.Join(fields, "\n  "))}


### PR DESCRIPTION
…command.

It also adds support for a json format of `*` which is translated to all known fields.
Support for '*' json format affects all commands with a --json flag.

Add support for the --json and --jq flags to `gh pr checks`
Add support for '*' to be passed as fields for the --json flag to allow all fields to be returned

Fixes: #4671 

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
