### PR TITLE
fix branch flag on browse within dir

### DIFF
--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -179,10 +179,6 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 		}
 	}
 
-	if opts.SelectorArg == "" {
-		return fmt.Sprintf("tree/%s/", branchName), nil
-	}
-
 	if rangeStart > 0 {
 		var rangeFragment string
 		if rangeEnd > 0 && rangeStart != rangeEnd {
@@ -196,6 +192,10 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 }
 
 func parseFile(opts BrowseOptions, f string) (p string, start int, end int, err error) {
+	if opts.SelectorArg == "" {
+		return
+	}
+
 	parts := strings.SplitN(f, ":", 3)
 	if len(parts) > 2 {
 		err = fmt.Errorf("invalid file argument: %q", f)

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -179,6 +179,10 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 		}
 	}
 
+	if opts.SelectorArg == "" {
+		return fmt.Sprintf("tree/%s/", branchName), nil
+	}
+
 	if rangeStart > 0 {
 		var rangeFragment string
 		if rangeEnd > 0 && rangeStart != rangeEnd {

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -192,7 +192,7 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 }
 
 func parseFile(opts BrowseOptions, f string) (p string, start int, end int, err error) {
-	if opts.SelectorArg == "" {
+	if f == "" {
 		return
 	}
 

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -503,7 +503,6 @@ func Test_parsePathFromFileArg(t *testing.T) {
 	}
 	for _, tt := range tests {
 		path, _, _, _ := parseFile(BrowseOptions{
-			SelectorArg: tt.fileArg,
 			PathFromRepoRoot: func() string {
 				return "pkg/cmd/browse/"
 			}}, tt.fileArg)

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -495,6 +495,11 @@ func Test_parsePathFromFileArg(t *testing.T) {
 			fileArg:      filepath.Join("..", "..", "..") + s + "",
 			expectedPath: "",
 		},
+		{
+			name:         "empty fileArg",
+			fileArg:      "",
+			expectedPath: "",
+		},
 	}
 	for _, tt := range tests {
 		path, _, _, _ := parseFile(BrowseOptions{

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -229,6 +229,35 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL: "https://github.com/bchadwic/LedZeppelinIV/tree/trunk/main.go",
 		},
 		{
+			name: "branch flag within dir",
+			opts: BrowseOptions{
+				Branch:           "feature-123",
+				PathFromRepoRoot: func() string { return "pkg/dir" },
+			},
+			baseRepo:    ghrepo.New("bstnc", "yeepers"),
+			expectedURL: "https://github.com/bstnc/yeepers/tree/feature-123/",
+		},
+		{
+			name: "branch flag within dir with .",
+			opts: BrowseOptions{
+				Branch:           "feature-123",
+				SelectorArg:      ".",
+				PathFromRepoRoot: func() string { return "pkg/dir" },
+			},
+			baseRepo:    ghrepo.New("bstnc", "yeepers"),
+			expectedURL: "https://github.com/bstnc/yeepers/tree/feature-123/pkg/dir",
+		},
+		{
+			name: "branch flag within dir with dir",
+			opts: BrowseOptions{
+				Branch:           "feature-123",
+				SelectorArg:      "inner/more",
+				PathFromRepoRoot: func() string { return "pkg/dir" },
+			},
+			baseRepo:    ghrepo.New("bstnc", "yeepers"),
+			expectedURL: "https://github.com/bstnc/yeepers/tree/feature-123/pkg/dir/inner/more",
+		},
+		{
 			name: "file with line number",
 			opts: BrowseOptions{
 				SelectorArg: "path/to/file.txt:32",

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -498,6 +498,7 @@ func Test_parsePathFromFileArg(t *testing.T) {
 	}
 	for _, tt := range tests {
 		path, _, _, _ := parseFile(BrowseOptions{
+			SelectorArg: tt.fileArg,
 			PathFromRepoRoot: func() string {
 				return "pkg/cmd/browse/"
 			}}, tt.fileArg)


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #4666 

If there is no selector provided in `gh browse --branch my-branch`, we should open to the repos home with that branch selected, not the directory they are in.
