### PR TITLE
Support setting user Codespaces secrets

### DIFF
--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -53,6 +53,12 @@ func SetDefaultHost(host string) {
 // FromFullName extracts the GitHub repository information from the following
 // formats: "OWNER/REPO", "HOST/OWNER/REPO", and a full URL.
 func FromFullName(nwo string) (Interface, error) {
+	return FromFullNameWithHost(nwo, defaultHost())
+}
+
+// FromFullNameWithHost is like FromFullName that defaults to a specific host for values that don't
+// explicitly include a hostname.
+func FromFullNameWithHost(nwo, fallbackHost string) (Interface, error) {
 	if git.IsURL(nwo) {
 		u, err := git.ParseURL(nwo)
 		if err != nil {
@@ -71,7 +77,7 @@ func FromFullName(nwo string) (Interface, error) {
 	case 3:
 		return NewWithHost(parts[1], parts[2], parts[0]), nil
 	case 2:
-		return NewWithHost(parts[0], parts[1], defaultHost()), nil
+		return NewWithHost(parts[0], parts[1], fallbackHost), nil
 	default:
 		return nil, fmt.Errorf(`expected the "[HOST/]OWNER/REPO" format, got %q`, nwo)
 	}

--- a/pkg/cmd/secret/secret.go
+++ b/pkg/cmd/secret/secret.go
@@ -15,7 +15,8 @@ func NewCmdSecret(f *cmdutil.Factory) *cobra.Command {
 		Short: "Manage GitHub secrets",
 		Long: heredoc.Doc(`
 			Secrets can be set at the repository, environment, or organization level for use in
-			GitHub Actions. Run "gh help secret set" to learn how to get started.
+			GitHub Actions. User secrets can be set for use in GitHub Codespaces.
+			Run "gh help secret set" to learn how to get started.
 `),
 	}
 

--- a/pkg/cmd/secret/set/http.go
+++ b/pkg/cmd/secret/set/http.go
@@ -92,8 +92,17 @@ func putOrgSecret(client *api.Client, host string, pk *PubKey, opts SetOptions, 
 	var err error
 	if orgName != "" && visibility == shared.Selected {
 		repos := make([]ghrepo.Interface, 0, len(opts.RepositoryNames))
-		for _, repo := range opts.RepositoryNames {
-			repos = append(repos, ghrepo.New(opts.OrgName, repo))
+		for _, repositoryName := range opts.RepositoryNames {
+			var repo ghrepo.Interface
+			if strings.Contains(repositoryName, "/") {
+				repo, err = ghrepo.FromFullName(repositoryName)
+				if err != nil {
+					return fmt.Errorf("invalid repository name: %w", err)
+				}
+			} else {
+				repo = ghrepo.NewWithHost(opts.OrgName, repositoryName, host)
+			}
+			repos = append(repos, repo)
 		}
 		repositoryIDs, err = mapRepoToID(client, host, repos)
 		if err != nil {

--- a/pkg/cmd/secret/set/http.go
+++ b/pkg/cmd/secret/set/http.go
@@ -35,11 +35,6 @@ type PubKey struct {
 	Key string
 }
 
-type repositoryNWO struct {
-	owner string
-	name  string
-}
-
 func getPubKey(client *api.Client, host, path string) (*PubKey, error) {
 	pk := PubKey{}
 	err := client.REST(host, "GET", path, nil, &pk)

--- a/pkg/cmd/secret/set/http.go
+++ b/pkg/cmd/secret/set/http.go
@@ -94,7 +94,7 @@ func putOrgSecret(client *api.Client, host string, pk *PubKey, opts SetOptions, 
 		for _, repositoryName := range opts.RepositoryNames {
 			var repo ghrepo.Interface
 			if strings.Contains(repositoryName, "/") {
-				repo, err = ghrepo.FromFullName(repositoryName)
+				repo, err = ghrepo.FromFullNameWithHost(repositoryName, host)
 				if err != nil {
 					return fmt.Errorf("invalid repository name: %w", err)
 				}
@@ -130,7 +130,7 @@ func putUserSecret(client *api.Client, host string, pk *PubKey, opts SetOptions,
 		repos := make([]ghrepo.Interface, len(opts.RepositoryNames))
 		for i, repo := range opts.RepositoryNames {
 			// For user secrets, repository names should be fully qualifed (e.g. "owner/repo")
-			repoNWO, err := ghrepo.FromFullName(repo)
+			repoNWO, err := ghrepo.FromFullNameWithHost(repo, host)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -146,7 +146,7 @@ func setRun(opts *SetOptions) error {
 	envName := opts.EnvName
 
 	var baseRepo ghrepo.Interface
-	if orgName == "" {
+	if orgName == "" && !opts.UserSecrets {
 		baseRepo, err = opts.BaseRepo()
 		if err != nil {
 			return fmt.Errorf("could not determine base repo: %w", err)
@@ -199,7 +199,9 @@ func setRun(opts *SetOptions) error {
 
 	if opts.IO.IsStdoutTTY() {
 		target := orgName
-		if orgName == "" {
+		if opts.UserSecrets {
+			target = "your user"
+		} else if orgName == "" {
 			target = ghrepo.FullName(baseRepo)
 		}
 		cs := opts.IO.ColorScheme()

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -2,13 +2,10 @@ package set
 
 import (
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"regexp"
-	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
@@ -85,11 +82,6 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 			}
 
 			opts.SecretName = args[0]
-
-			err := validSecretName(opts.SecretName)
-			if err != nil {
-				return err
-			}
 
 			if cmd.Flags().Changed("visibility") {
 				if opts.OrgName == "" {
@@ -206,28 +198,6 @@ func setRun(opts *SetOptions) error {
 		}
 		cs := opts.IO.ColorScheme()
 		fmt.Fprintf(opts.IO.Out, "%s Set secret %s for %s\n", cs.SuccessIconWithColor(cs.Green), opts.SecretName, target)
-	}
-
-	return nil
-}
-
-func validSecretName(name string) error {
-	if name == "" {
-		return errors.New("secret name cannot be blank")
-	}
-
-	if strings.HasPrefix(name, "GITHUB_") {
-		return errors.New("secret name cannot begin with GITHUB_")
-	}
-
-	leadingNumber := regexp.MustCompile(`^[0-9]`)
-	if leadingNumber.MatchString(name) {
-		return errors.New("secret name cannot start with a number")
-	}
-
-	validChars := regexp.MustCompile(`^([0-9]|[a-z]|[A-Z]|_)+$`)
-	if !validChars.MatchString(name) {
-		return errors.New("secret name can only contain letters, numbers, and _")
 	}
 
 	return nil

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -92,8 +92,8 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 			}
 
 			if cmd.Flags().Changed("visibility") {
-				if opts.OrgName == "" && !opts.UserSecrets {
-					return cmdutil.FlagErrorf("--visibility not supported for repository secrets; did you mean to pass --org?")
+				if opts.OrgName == "" {
+					return cmdutil.FlagErrorf("`--visibility` is only supported with `--org`")
 				}
 
 				if opts.Visibility != shared.All && opts.Visibility != shared.Private && opts.Visibility != shared.Selected {

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -91,7 +91,7 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo
 
-			if err := cmdutil.MutuallyExclusive("specify only one of `--org` or `--env`", opts.OrgName != "", opts.EnvName != ""); err != nil {
+			if err := cmdutil.MutuallyExclusive("specify only one of `--org`, `--env`, or `--user`", opts.OrgName != "", opts.EnvName != "", opts.UserSecrets); err != nil {
 				return err
 			}
 
@@ -103,18 +103,18 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 				}
 
 				if opts.Visibility != shared.All && opts.Visibility != shared.Private && opts.Visibility != shared.Selected {
-					return cmdutil.FlagErrorf("--visibility must be one of `all`, `private`, or `selected`")
+					return cmdutil.FlagErrorf("`--visibility` must be one of \"all\", \"private\", or \"selected\"")
 				}
 
-				if opts.Visibility != shared.Selected && cmd.Flags().Changed("repos") {
-					return cmdutil.FlagErrorf("--repos only supported when --visibility='selected'")
+				if opts.Visibility != shared.Selected && len(opts.RepositoryNames) > 0 {
+					return cmdutil.FlagErrorf("`--repos` is only supported with `--visibility=selected`")
 				}
 
-				if opts.Visibility == shared.Selected && !cmd.Flags().Changed("repos") {
-					return cmdutil.FlagErrorf("--repos flag required when --visibility='selected'")
+				if opts.Visibility == shared.Selected && len(opts.RepositoryNames) == 0 {
+					return cmdutil.FlagErrorf("`--repos` list required with `--visibility=selected`")
 				}
 			} else {
-				if cmd.Flags().Changed("repos") {
+				if len(opts.RepositoryNames) > 0 {
 					opts.Visibility = shared.Selected
 				}
 			}

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -47,25 +47,39 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 	cmd := &cobra.Command{
 		Use:   "set <secret-name>",
 		Short: "Create or update secrets",
-		Long:  "Locally encrypt a new or updated secret at either the repository, environment, or organization level and send it to GitHub for storage.",
+		Long: heredoc.Doc(`
+			Set a value for a secret on one of the following levels:
+			- repository (default): available to Actions runs in a repository
+			- environment: available to Actions runs for a deployment environment in a repository
+			- organization: available to Actions runs within an organization
+			- user: available to Codespaces for your user
+
+			Organization and user secrets can optionally be restricted to only be available to
+			specific repositories.
+
+			Secret values are locally encrypted before being sent to GitHub.
+		`),
 		Example: heredoc.Doc(`
-			Paste secret in prompt
+			# Paste secret value for the current repository in an interactive prompt
 			$ gh secret set MYSECRET
 
-			Use environment variable as secret value
-			$ gh secret set MYSECRET  -b"${ENV_VALUE}"
+			# Read secret value from an environment variable
+			$ gh secret set MYSECRET --body "$ENV_VALUE"
 
-			Use file as secret value
-			$ gh secret set MYSECRET < file.json
+			# Read secret value from a file
+			$ gh secret set MYSECRET < myfile.txt
 
-			Set environment level secret
-			$ gh secret set MYSECRET -bval --env=anEnv
+			# Set secret for a deployment environment in the current repository
+			$ gh secret set MYSECRET --env myenvironment
 
-			Set organization level secret visible to entire organization
-			$ gh secret set MYSECRET -bval --org=anOrg --visibility=all
+			# Set organization-level secret visible to both public and private repositories
+			$ gh secret set MYSECRET --org myOrg --visibility all
 
-			Set organization level secret visible only to certain repositories
-			$ gh secret set MYSECRET -bval --org=anOrg --repos="repo1,repo2,repo3"
+			# Set organization-level secret visible to specific repositories
+			$ gh secret set MYSECRET --org myOrg --repos repo1,repo2,repo3
+
+			# Set user-level secret for Codespaces
+			$ gh secret set MYSECRET --user
 `),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -112,12 +126,13 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 			return setRun(opts)
 		},
 	}
-	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "Set a secret for an organization")
-	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Set a secret for an environment")
-	cmd.Flags().BoolVarP(&opts.UserSecrets, "user", "u", false, "Set a secret for the current user")
-	cmd.Flags().StringVarP(&opts.Visibility, "visibility", "v", "private", "Set visibility for an organization secret: `all`, `private`, or `selected`")
-	cmd.Flags().StringSliceVarP(&opts.RepositoryNames, "repos", "r", []string{}, "List of repository names for `selected` visibility")
-	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "A value for the secret. Reads from STDIN if not specified.")
+
+	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "Set `organization` secret")
+	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Set deployment `environment` secret")
+	cmd.Flags().BoolVarP(&opts.UserSecrets, "user", "u", false, "Set a secret for your user")
+	cmd.Flags().StringVarP(&opts.Visibility, "visibility", "v", "private", "Set visibility for an organization secret: `{all|private|selected}`")
+	cmd.Flags().StringSliceVarP(&opts.RepositoryNames, "repos", "r", []string{}, "List of `repositories` that can access an organization or user secret")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "The value for the secret (reads from standard input if not specified)")
 
 	return cmd
 }

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -397,9 +397,6 @@ func Test_setRun_user(t *testing.T) {
 
 			io, _, _, _ := iostreams.Test()
 
-			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
-				return ghrepo.FromFullName("owner/repo")
-			}
 			tt.opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: reg}, nil
 			}

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -91,18 +91,8 @@ func TestNewCmdSet(t *testing.T) {
 			},
 		},
 		{
-			name: "user with selected repo",
-			cli:  "-u -bs -vselected -rmonalisa/coolRepo cool_secret",
-			wants: SetOptions{
-				SecretName:      "cool_secret",
-				Visibility:      shared.Selected,
-				RepositoryNames: []string{"monalisa/coolRepo"},
-				Body:            "s",
-			},
-		},
-		{
 			name: "user with selected repos",
-			cli:  `-u -bs -vselected -r"monalisa/coolRepo,cli/cli,github/hub" cool_secret`,
+			cli:  `-u -bs -r"monalisa/coolRepo,cli/cli,github/hub" cool_secret`,
 			wants: SetOptions{
 				SecretName:      "cool_secret",
 				Visibility:      shared.Selected,
@@ -421,7 +411,6 @@ func Test_setRun_user(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, payload.KeyID, "123")
 			assert.Equal(t, payload.EncryptedValue, "UKYUCbHd0DJemxa3AOcZ6XcsBwALG9d4bpB8ZT0gSV39vl3BHiGSgj8zJapDxgB2BwqNqRhpjC4=")
-			assert.Equal(t, payload.Visibility, tt.opts.Visibility)
 			assert.ElementsMatch(t, payload.Repositories, tt.wantRepositories)
 		})
 	}

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -131,21 +131,6 @@ func TestNewCmdSet(t *testing.T) {
 				OrgName:    "coolOrg",
 			},
 		},
-		{
-			name:     "bad name prefix",
-			cli:      `GITHUB_SECRET -b"cool"`,
-			wantsErr: true,
-		},
-		{
-			name:     "leading numbers in name",
-			cli:      `123_SECRET -b"cool"`,
-			wantsErr: true,
-		},
-		{
-			name:     "invalid characters in name",
-			cli:      `BAD-SECRET -b"cool"`,
-			wantsErr: true,
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -295,7 +295,7 @@ func Test_setRun_org(t *testing.T) {
 			opts: &SetOptions{
 				OrgName:         "UmbrellaCorporation",
 				Visibility:      shared.Selected,
-				RepositoryNames: []string{"birkin", "wesker"},
+				RepositoryNames: []string{"birkin", "UmbrellaCorporation/wesker"},
 			},
 			wantRepositories: []int{1, 2},
 		},
@@ -317,7 +317,7 @@ func Test_setRun_org(t *testing.T) {
 
 			if len(tt.opts.RepositoryNames) > 0 {
 				reg.Register(httpmock.GraphQL(`query MapRepositoryNames\b`),
-					httpmock.StringResponse(`{"data":{"birkin":{"databaseId":1},"wesker":{"databaseId":2}}}`))
+					httpmock.StringResponse(`{"data":{"repo_0001":{"databaseId":1},"repo_0002":{"databaseId":2}}}`))
 			}
 
 			io, _, _, _ := iostreams.Test()

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -281,7 +281,7 @@ func Test_setRun_org(t *testing.T) {
 		name             string
 		opts             *SetOptions
 		wantVisibility   shared.Visibility
-		wantRepositories []string
+		wantRepositories []int
 	}{
 		{
 			name: "all vis",
@@ -297,7 +297,7 @@ func Test_setRun_org(t *testing.T) {
 				Visibility:      shared.Selected,
 				RepositoryNames: []string{"birkin", "wesker"},
 			},
-			wantRepositories: []string{"1", "2"},
+			wantRepositories: []int{1, 2},
 		},
 	}
 
@@ -419,7 +419,7 @@ func Test_setRun_user(t *testing.T) {
 
 			data, err := ioutil.ReadAll(reg.Requests[len(reg.Requests)-1].Body)
 			assert.NoError(t, err)
-			var payload SecretPayload
+			var payload CodespacesSecretPayload
 			err = json.Unmarshal(data, &payload)
 			assert.NoError(t, err)
 			assert.Equal(t, payload.KeyID, "123")


### PR DESCRIPTION
Supports #4698


This PR adds support for setting a Codespaces user secret via the CLI.

```bash
gh secret set -u -bs -vselected -r"cli/cli,github/hub" cool_secret
```

Codespaces user secrets follow a similar pattern to Actions organization secrets in that they can be shared with all repositories or a specific set of repositories.

To support this, this PR uses the public key and set secret APIs for user Codespaces secrets.

https://docs.github.com/en/rest/reference/codespaces#get-public-key-for-the-authenticated-user
https://docs.github.com/en/rest/reference/codespaces#create-or-update-a-secret-for-the-authenticated-user

### Repository selection

Unlike organization secrets, the repositories specified for a user secret do not have to belong to that owner of the secret.

When setting an organization secret via the CLI, the `--repos` option is used to specify a set of repository names.

For user secrets, I've reused that same `--repos` option but with the assumption that all repositories specified are fully qualified names with owners (NWOs). 

If this is confusing, we could either:
1. Use a different option for fully qualified repos rather than reusing `--repos`
2. Support both repository names and full NWOs. If an owner isn't specified, assume the owner is the current user.

I did not use the second option as I'm unsure how to retrieve the current user's login.

### Auth Issues

These APIs require the `user` or `read:user` scope, which is not currently requested by default.

Users will need to request the `user` scope to set a user secret
```bash
gh auth refresh -h github.com -s user
```

Since setting a secret first fetches the public key which requires `read:user` scopes and the set secret API requiring `user` scopes, users may hit auth issues twice before they are successful.

```bash

>gh secret set -u -bs -vselected -r"cli/cli,github/hub" cool_secret
failed to fetch public key: HTTP 403: This API requires the `read:user` scope. (https://api.github.com/user/codespaces/secrets/public-key)
This API operation needs the "read:user" scope. To request it, run:  gh auth refresh -h github.com -s read:user

>gh auth refresh -h github.com -s read:user 
...

>gh secret set -u -bs -vselected -r"cli/cli,github/hub" cool_secret
failed to set secret: HTTP 403: This API requires the `user` scope. (https://api.github.com/user/codespaces/secrets/cool_secret)
This API operation needs the "user" scope. To request it, run:  gh auth refresh -h github.com -s user

>gh auth refresh -h github.com -s user
...
```

### Testing

Validated that a secret was able to be added:
```bash
❯ bin/gh secret set -u -bs -vselected -r"joshmgross/clock,joshmgross/actions-testing" coolSecret
✓ Set secret coolSecret for cli/cli
```

![image](https://user-images.githubusercontent.com/16631042/141234644-e60f3278-65e8-4ac2-a2f9-7c38610bf906.png)

Fixes https://github.com/cli/cli/issues/4038