### PR TITLE
Added MPR installation instructions

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -152,6 +152,15 @@ Kiss Linux users can install from the [community repos](https://github.com/kissl
 kiss b github-cli && kiss i github-cli
 ```
 
+### makedeb Package Repository
+makedeb users can install from the [MPR](https://mpr.hunterwittenborn.com/packages/github-cli-bin):
+
+```bash
+git clone 'https://mpr.hunterwittenborn.com/github-cli-bin.git'
+cd github-cli-bin/
+makedeb -si
+```
+
 ### Nix/NixOS
 
 Nix/NixOS users can install from [nixpkgs](https://search.nixos.org/packages?show=gitAndTools.gh&query=gh&from=0&size=30&sort=relevance&channel=20.03#disabled):


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
The MPR is a centralized platform to pull and build Debian packages from. The built packages would function basically the same as the ones in the releases and APT repository, but the MPR gives the added benefit in that the user doesn't have to add an additional repository to their system.