### PR TITLE
codespace: Rename errors from Live Share to generic codespace

### DIFF
--- a/internal/codespaces/states.go
+++ b/internal/codespaces/states.go
@@ -43,7 +43,7 @@ func PollPostCreateStates(ctx context.Context, progress progressIndicator, apiCl
 
 	session, err := ConnectToLiveshare(ctx, progress, noopLogger, apiClient, codespace)
 	if err != nil {
-		return fmt.Errorf("connect to Live Share: %w", err)
+		return fmt.Errorf("connect to codespace: %w", err)
 	}
 	defer func() {
 		if closeErr := session.Close(); err == nil {

--- a/pkg/cmd/codespace/logs.go
+++ b/pkg/cmd/codespace/logs.go
@@ -53,7 +53,7 @@ func (a *App) Logs(ctx context.Context, codespaceName string, follow bool) (err 
 
 	session, err := codespaces.ConnectToLiveshare(ctx, a, noopLogger(), a.apiClient, codespace)
 	if err != nil {
-		return fmt.Errorf("connecting to Live Share: %w", err)
+		return fmt.Errorf("connecting to codespace: %w", err)
 	}
 	defer safeClose(session, &err)
 

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -59,7 +59,7 @@ func (a *App) ListPorts(ctx context.Context, codespaceName string, exporter cmdu
 
 	session, err := codespaces.ConnectToLiveshare(ctx, a, noopLogger(), a.apiClient, codespace)
 	if err != nil {
-		return fmt.Errorf("error connecting to Live Share: %w", err)
+		return fmt.Errorf("error connecting to codespace: %w", err)
 	}
 	defer safeClose(session, &err)
 
@@ -245,7 +245,7 @@ func (a *App) UpdatePortVisibility(ctx context.Context, codespaceName string, ar
 
 	session, err := codespaces.ConnectToLiveshare(ctx, a, noopLogger(), a.apiClient, codespace)
 	if err != nil {
-		return fmt.Errorf("error connecting to Live Share: %w", err)
+		return fmt.Errorf("error connecting to codespace: %w", err)
 	}
 	defer safeClose(session, &err)
 
@@ -321,7 +321,7 @@ func (a *App) ForwardPorts(ctx context.Context, codespaceName string, ports []st
 
 	session, err := codespaces.ConnectToLiveshare(ctx, a, noopLogger(), a.apiClient, codespace)
 	if err != nil {
-		return fmt.Errorf("error connecting to Live Share: %w", err)
+		return fmt.Errorf("error connecting to codespace: %w", err)
 	}
 	defer safeClose(session, &err)
 

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -85,7 +85,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 
 	session, err := codespaces.ConnectToLiveshare(ctx, a, liveshareLogger, a.apiClient, codespace)
 	if err != nil {
-		return fmt.Errorf("error connecting to Live Share: %w", err)
+		return fmt.Errorf("error connecting to codespace: %w", err)
 	}
 	defer safeClose(session, &err)
 


### PR DESCRIPTION
Closes internal issue codespaces#4496

Removes mention of Live Share in error messages shown to users. 
