### PR TITLE
Support listing and removing user Codespaces secrets

### DIFF
--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/ghinstance"
@@ -25,8 +26,9 @@ type ListOptions struct {
 	Config     func() (config.Config, error)
 	BaseRepo   func() (ghrepo.Interface, error)
 
-	OrgName string
-	EnvName string
+	OrgName     string
+	EnvName     string
+	UserSecrets bool
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
@@ -39,13 +41,19 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List secrets",
-		Long:  "List secrets for a repository, environment, or organization",
-		Args:  cobra.NoArgs,
+		Long: heredoc.Doc(`
+			List secrets on one of the following levels:
+			- repository (default): available to Actions runs in a repository
+			- environment: available to Actions runs for a deployment environment in a repository
+			- organization: available to Actions runs within an organization
+			- user: available to Codespaces for your user
+		`),
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo
 
-			if err := cmdutil.MutuallyExclusive("specify only one of `--org` or `--env`", opts.OrgName != "", opts.EnvName != ""); err != nil {
+			if err := cmdutil.MutuallyExclusive("specify only one of `--org`, `--env`, or `--user`", opts.OrgName != "", opts.EnvName != "", opts.UserSecrets); err != nil {
 				return err
 			}
 
@@ -59,6 +67,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "List secrets for an organization")
 	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "List secrets for an environment")
+	cmd.Flags().BoolVarP(&opts.UserSecrets, "user", "u", false, "List a secret for your user")
 
 	return cmd
 }
@@ -73,7 +82,7 @@ func listRun(opts *ListOptions) error {
 	envName := opts.EnvName
 
 	var baseRepo ghrepo.Interface
-	if orgName == "" {
+	if orgName == "" && !opts.UserSecrets {
 		baseRepo, err = opts.BaseRepo()
 		if err != nil {
 			return fmt.Errorf("could not determine base repo: %w", err)
@@ -81,7 +90,7 @@ func listRun(opts *ListOptions) error {
 	}
 
 	var secrets []*Secret
-	if orgName == "" {
+	if orgName == "" && !opts.UserSecrets {
 		if envName == "" {
 			secrets, err = getRepoSecrets(client, baseRepo)
 		} else {
@@ -101,7 +110,11 @@ func listRun(opts *ListOptions) error {
 			return err
 		}
 
-		secrets, err = getOrgSecrets(client, host, orgName)
+		if opts.UserSecrets {
+			secrets, err = getUserSecrets(client, host)
+		} else {
+			secrets, err = getOrgSecrets(client, host, orgName)
+		}
 	}
 
 	if err != nil {
@@ -164,19 +177,23 @@ func getOrgSecrets(client httpClient, host, orgName string) ([]*Secret, error) {
 		return nil, err
 	}
 
-	type responseData struct {
-		TotalCount int `json:"total_count"`
+	err = getSelectedRepositoryInformation(client, secrets)
+	if err != nil {
+		return nil, err
 	}
 
-	for _, secret := range secrets {
-		if secret.SelectedReposURL == "" {
-			continue
-		}
-		var result responseData
-		if _, err := apiGet(client, secret.SelectedReposURL, &result); err != nil {
-			return nil, fmt.Errorf("failed determining selected repositories for %s: %w", secret.Name, err)
-		}
-		secret.NumSelectedRepos = result.TotalCount
+	return secrets, nil
+}
+
+func getUserSecrets(client httpClient, host string) ([]*Secret, error) {
+	secrets, err := getSecrets(client, host, "user/codespaces/secrets")
+	if err != nil {
+		return nil, err
+	}
+
+	err = getSelectedRepositoryInformation(client, secrets)
+	if err != nil {
+		return nil, err
 	}
 
 	return secrets, nil
@@ -255,4 +272,23 @@ func findNextPage(link string) string {
 		}
 	}
 	return ""
+}
+
+func getSelectedRepositoryInformation(client httpClient, secrets []*Secret) error {
+	type responseData struct {
+		TotalCount int `json:"total_count"`
+	}
+
+	for _, secret := range secrets {
+		if secret.SelectedReposURL == "" {
+			continue
+		}
+		var result responseData
+		if _, err := apiGet(client, secret.SelectedReposURL, &result); err != nil {
+			return fmt.Errorf("failed determining selected repositories for %s: %w", secret.Name, err)
+		}
+		secret.NumSelectedRepos = result.TotalCount
+	}
+
+	return nil
 }

--- a/pkg/cmd/secret/list/list_test.go
+++ b/pkg/cmd/secret/list/list_test.go
@@ -47,6 +47,13 @@ func Test_NewCmdList(t *testing.T) {
 				EnvName: "Development",
 			},
 		},
+		{
+			name: "user",
+			cli:  "-u",
+			wants: ListOptions{
+				UserSecrets: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -153,6 +160,30 @@ func Test_listRun(t *testing.T) {
 				"SECRET_THREE\t1975-11-30",
 			},
 		},
+		{
+			name: "user tty",
+			tty:  true,
+			opts: &ListOptions{
+				UserSecrets: true,
+			},
+			wantOut: []string{
+				"SECRET_ONE.*Updated 1988-10-11.*Visible to 1 selected repository",
+				"SECRET_TWO.*Updated 2020-12-04.*Visible to 2 selected repositories",
+				"SECRET_THREE.*Updated 1975-11-30.*Visible to 3 selected repositories",
+			},
+		},
+		{
+			name: "user not tty",
+			tty:  false,
+			opts: &ListOptions{
+				UserSecrets: true,
+			},
+			wantOut: []string{
+				"SECRET_ONE\t1988-10-11\t",
+				"SECRET_TWO\t2020-12-04\t",
+				"SECRET_THREE\t1975-11-30\t",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -208,6 +239,41 @@ func Test_listRun(t *testing.T) {
 					httpmock.JSONResponse(struct {
 						TotalCount int `json:"total_count"`
 					}{2}))
+			}
+
+			if tt.opts.UserSecrets {
+				payload.Secrets = []*Secret{
+					{
+						Name:             "SECRET_ONE",
+						UpdatedAt:        t0,
+						Visibility:       shared.Selected,
+						SelectedReposURL: "https://api.github.com/user/codespaces/secrets/SECRET_ONE/repositories",
+					},
+					{
+						Name:             "SECRET_TWO",
+						UpdatedAt:        t1,
+						Visibility:       shared.Selected,
+						SelectedReposURL: "https://api.github.com/user/codespaces/secrets/SECRET_TWO/repositories",
+					},
+					{
+						Name:             "SECRET_THREE",
+						UpdatedAt:        t2,
+						Visibility:       shared.Selected,
+						SelectedReposURL: "https://api.github.com/user/codespaces/secrets/SECRET_THREE/repositories",
+					},
+				}
+
+				path = "user/codespaces/secrets"
+				for i, secret := range payload.Secrets {
+					hostLen := len("https://api.github.com/")
+					path := secret.SelectedReposURL[hostLen:len(secret.SelectedReposURL)]
+					repositoryCount := i + 1
+					reg.Register(
+						httpmock.REST("GET", path),
+						httpmock.JSONResponse(struct {
+							TotalCount int `json:"total_count"`
+						}{repositoryCount}))
+				}
 			}
 
 			reg.Register(httpmock.REST("GET", path), httpmock.JSONResponse(payload))

--- a/pkg/cmd/secret/list/list_test.go
+++ b/pkg/cmd/secret/list/list_test.go
@@ -234,11 +234,13 @@ func Test_listRun(t *testing.T) {
 				}
 				path = fmt.Sprintf("orgs/%s/actions/secrets", tt.opts.OrgName)
 
-				reg.Register(
-					httpmock.REST("GET", fmt.Sprintf("orgs/%s/actions/secrets/SECRET_THREE/repositories", tt.opts.OrgName)),
-					httpmock.JSONResponse(struct {
-						TotalCount int `json:"total_count"`
-					}{2}))
+				if tt.tty {
+					reg.Register(
+						httpmock.REST("GET", fmt.Sprintf("orgs/%s/actions/secrets/SECRET_THREE/repositories", tt.opts.OrgName)),
+						httpmock.JSONResponse(struct {
+							TotalCount int `json:"total_count"`
+						}{2}))
+				}
 			}
 
 			if tt.opts.UserSecrets {
@@ -264,15 +266,17 @@ func Test_listRun(t *testing.T) {
 				}
 
 				path = "user/codespaces/secrets"
-				for i, secret := range payload.Secrets {
-					hostLen := len("https://api.github.com/")
-					path := secret.SelectedReposURL[hostLen:len(secret.SelectedReposURL)]
-					repositoryCount := i + 1
-					reg.Register(
-						httpmock.REST("GET", path),
-						httpmock.JSONResponse(struct {
-							TotalCount int `json:"total_count"`
-						}{repositoryCount}))
+				if tt.tty {
+					for i, secret := range payload.Secrets {
+						hostLen := len("https://api.github.com/")
+						path := secret.SelectedReposURL[hostLen:len(secret.SelectedReposURL)]
+						repositoryCount := i + 1
+						reg.Register(
+							httpmock.REST("GET", path),
+							httpmock.JSONResponse(struct {
+								TotalCount int `json:"total_count"`
+							}{repositoryCount}))
+					}
 				}
 			}
 


### PR DESCRIPTION
Supports #4698
Follow-up to #4699 which adds support for creating user secrets.

This PR adds support for listing and removing Codespaces user secrets. These APIs will require `read:user` and `user` scopes.
```
gh auth refresh -h github.com -s user
```

https://docs.github.com/en/rest/reference/codespaces#list-secrets-for-the-authenticated-user
https://docs.github.com/en/rest/reference/codespaces#delete-a-secret-for-the-authenticated-user

I've also updated the code that fetches the number of selected repositories for a secret to not run when outside the context of a TTY, since that information is only shown when in a TTY and requires extra API calls - https://github.com/cli/cli/commit/5b6827ac40911e4272fc70917982bc8b93bfd1a0
### Testing
I validated that secrets were able to be listed and removed:

```
❯ bin/gh secret list  --user               
MY_PAT         Updated 2021-10-26  Visible to 0 selected repositories
COOL_SECRET    Updated 2021-11-11  Visible to 1 selected repository
```

<details>

<summary>JSON API response for comparison</summary>

```json
{
  "total_count": 2,
  "secrets": [
    {
      "name": "MY_PAT",
      "created_at": "2021-10-26T19:17:07.000+00:00",
      "updated_at": "2021-10-26T19:17:07.000+00:00",
      "visibility": "selected",
      "selected_repositories_url": "https://api.github.com/user/codespaces/secrets/MY_PAT/repositories"
    },
    {
      "name": "COOL_SECRET",
      "created_at": "2021-11-07T20:55:53.000+00:00",
      "updated_at": "2021-11-11T03:34:15.000+00:00",
      "visibility": "selected",
      "selected_repositories_url": "https://api.github.com/user/codespaces/secrets/COOL_SECRET/repositories"
    }
  ]
}
```
</details>


```
❯ bin/gh secret remove cool_secret --user  
✓ Removed secret cool_secret from your user
```
