### PR TITLE
fix binary extensions on windows

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -106,7 +106,15 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					return err
 				}
 
-				return m.Install(repo)
+				if err := m.Install(repo); err != nil {
+					return err
+				}
+
+				if io.IsStdoutTTY() {
+					cs := io.ColorScheme()
+					fmt.Fprintf(io.Out, "%s Installed extension %s\n", cs.SuccessIcon(), args[0])
+				}
+				return nil
 			},
 		},
 		func() *cobra.Command {

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -345,6 +345,9 @@ func (m *Manager) installBin(repo ghrepo.Interface) error {
 	}
 
 	suffix := m.platform()
+	if runtime.GOOS == "windows" {
+		suffix += ".exe"
+	}
 	var asset *releaseAsset
 	for _, a := range r.Assets {
 		if strings.HasSuffix(a.Name, suffix) {
@@ -354,9 +357,9 @@ func (m *Manager) installBin(repo ghrepo.Interface) error {
 	}
 
 	if asset == nil {
-		return fmt.Errorf("%s unsupported for %s. Open an issue: `gh issue create -R %s/%s -t'Support %s'`",
-			repo.RepoName(),
-			suffix, repo.RepoOwner(), repo.RepoName(), suffix)
+		return fmt.Errorf(
+			"%[1]s unsupported for %[2]s. Open an issue: `gh issue create -R %[3]s/%[1]s -t'Support %[2]s'`",
+			repo.RepoName(), m.platform(), repo.RepoOwner())
 	}
 
 	name := repo.RepoName()
@@ -368,6 +371,10 @@ func (m *Manager) installBin(repo ghrepo.Interface) error {
 	}
 
 	binPath := filepath.Join(targetDir, name)
+
+	if runtime.GOOS == "windows" {
+		binPath += ".exe"
+	}
 
 	err = downloadAsset(m.client, *asset, binPath)
 	if err != nil {
@@ -635,7 +642,11 @@ func isBinExtension(client *http.Client, repo ghrepo.Interface) (isBin bool, err
 	for _, a := range r.Assets {
 		dists := possibleDists()
 		for _, d := range dists {
-			if strings.HasSuffix(a.Name, d) {
+			suffix := d
+			if strings.HasPrefix(d, "windows") {
+				suffix += ".exe"
+			}
+			if strings.HasSuffix(a.Name, suffix) {
 				isBin = true
 				break
 			}

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -372,10 +372,7 @@ func (m *Manager) installBin(repo ghrepo.Interface) error {
 	}
 
 	binPath := filepath.Join(targetDir, name)
-
-	if runtime.GOOS == "windows" {
-		binPath += ".exe"
-	}
+	binPath += ext
 
 	err = downloadAsset(m.client, *asset, binPath)
 	if err != nil {

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -319,7 +319,7 @@ func TestManager_UpgradeExtension_BinaryExtension(t *testing.T) {
 				Tag: "v1.0.2",
 				Assets: []releaseAsset{
 					{
-						Name:   "gh-bin-ext-windows-amd64",
+						Name:   "gh-bin-ext-windows-amd64.exe",
 						APIURL: "https://example.com/release/cool2",
 					},
 				},
@@ -348,10 +348,10 @@ func TestManager_UpgradeExtension_BinaryExtension(t *testing.T) {
 		Owner: "owner",
 		Host:  "example.com",
 		Tag:   "v1.0.2",
-		Path:  filepath.Join(tempDir, "extensions/gh-bin-ext/gh-bin-ext"),
+		Path:  filepath.Join(tempDir, "extensions/gh-bin-ext/gh-bin-ext.exe"),
 	}, bm)
 
-	fakeBin, err := os.ReadFile(filepath.Join(tempDir, "extensions/gh-bin-ext/gh-bin-ext"))
+	fakeBin, err := os.ReadFile(filepath.Join(tempDir, "extensions/gh-bin-ext/gh-bin-ext.exe"))
 	assert.NoError(t, err)
 
 	assert.Equal(t, "FAKE UPGRADED BINARY", string(fakeBin))
@@ -448,7 +448,7 @@ func TestManager_Install_binary(t *testing.T) {
 			release{
 				Assets: []releaseAsset{
 					{
-						Name:   "gh-bin-ext-windows-amd64",
+						Name:   "gh-bin-ext-windows-amd64.exe",
 						APIURL: "https://example.com/release/cool",
 					},
 				},
@@ -460,7 +460,7 @@ func TestManager_Install_binary(t *testing.T) {
 				Tag: "v1.0.1",
 				Assets: []releaseAsset{
 					{
-						Name:   "gh-bin-ext-windows-amd64",
+						Name:   "gh-bin-ext-windows-amd64.exe",
 						APIURL: "https://example.com/release/cool",
 					},
 				},
@@ -489,10 +489,10 @@ func TestManager_Install_binary(t *testing.T) {
 		Owner: "owner",
 		Host:  "example.com",
 		Tag:   "v1.0.1",
-		Path:  filepath.Join(tempDir, "extensions/gh-bin-ext/gh-bin-ext"),
+		Path:  filepath.Join(tempDir, "extensions/gh-bin-ext/gh-bin-ext.exe"),
 	}, bm)
 
-	fakeBin, err := os.ReadFile(filepath.Join(tempDir, "extensions/gh-bin-ext/gh-bin-ext"))
+	fakeBin, err := os.ReadFile(filepath.Join(tempDir, "extensions/gh-bin-ext/gh-bin-ext.exe"))
 	assert.NoError(t, err)
 
 	assert.Equal(t, "FAKE BINARY", string(fakeBin))

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -52,8 +52,8 @@ func newTestManager(dir string, client *http.Client, io *iostreams.IOStreams) *M
 		config: config.NewBlankConfig(),
 		io:     io,
 		client: client,
-		platform: func() string {
-			return "windows-amd64"
+		platform: func() (string, string) {
+			return "windows-amd64", ".exe"
 		},
 	}
 }


### PR DESCRIPTION
sadly, executables on windows have to have a .exe suffix. this PR makes binary extension support account for that.