### PR TITLE
make extension create binary aware

### DIFF
--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cli/cli/v2/pkg/extensions"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/pkg/prompt"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,6 +29,7 @@ func TestNewCmdExtension(t *testing.T) {
 		name         string
 		args         []string
 		managerStubs func(em *extensions.ExtensionManagerMock) func(*testing.T)
+		askStubs     func(as *prompt.AskStubber)
 		isTTY        bool
 		wantErr      bool
 		errMsg       string
@@ -263,10 +265,75 @@ func TestNewCmdExtension(t *testing.T) {
 			wantStdout: "gh test\tcli/gh-test\t\ngh test2\tcli/gh-test2\tUpgrade available\n",
 		},
 		{
-			name: "create extension tty",
-			args: []string{"create", "test"},
+			name: "create extension interactive",
+			args: []string{"create"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.CreateFunc = func(name string) error {
+				em.CreateFunc = func(name string, tmplType extensions.ExtTemplateType) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.CreateCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "gh-test", calls[0].Name)
+				}
+			},
+			isTTY: true,
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne("test")
+				as.StubOne(0)
+			},
+			wantStdout: heredoc.Doc(`
+				✓ Created directory gh-test
+				✓ Initialized git repository
+				✓ Set up extension scaffolding
+
+				gh-test is ready for development!
+
+				Next Steps
+				- run 'cd gh-test; gh extension install .; gh test' to see your new extension in action
+				- commit and use 'gh repo create' to share your extension with others
+
+				For more information on writing extensions:
+				https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions
+			`),
+		},
+		{
+			name: "create extension with arg, --precompiled=go",
+			args: []string{"create", "test", "--precompiled", "go"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.CreateFunc = func(name string, tmplType extensions.ExtTemplateType) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.CreateCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "gh-test", calls[0].Name)
+				}
+			},
+			isTTY: true,
+			wantStdout: heredoc.Doc(`
+				✓ Created directory gh-test
+				✓ Initialized git repository
+				✓ Set up extension scaffolding
+				✓ Downloaded Go dependencies
+				✓ Built gh-test binary
+
+				gh-test is ready for development!
+
+				Next Steps
+				- run 'cd gh-test; gh extension install .; gh test' to see your new extension in action
+				- use 'go build && gh test' to see changes in your code as you develop
+				- commit and use 'gh repo create' to share your extension with others
+
+				For more information on writing extensions:
+				https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions
+			`),
+		},
+		{
+			name: "create extension with arg, --precompiled=other",
+			args: []string{"create", "test", "--precompiled", "other"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.CreateFunc = func(name string, tmplType extensions.ExtTemplateType) error {
 					return nil
 				}
 				return func(t *testing.T) {
@@ -281,11 +348,42 @@ func TestNewCmdExtension(t *testing.T) {
 				✓ Initialized git repository
 				✓ Set up extension scaffolding
 
-				gh-test is ready for development
+				gh-test is ready for development!
 
-				Install locally with: cd gh-test && gh extension install .
+				Next Steps
+				- run 'cd gh-test; gh extension install .' to install your extension locally
+				- fill in script/build.sh with your compilation script for automated builds
+				- compile a gh-test binary locally and run 'gh test' to see changes
+				- commit and use 'gh repo create' to share your extension with others
 
-				Publish to GitHub with: gh repo create gh-test
+				For more information on writing extensions:
+				https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions
+			`),
+		},
+		{
+			name: "create extension tty with argument",
+			args: []string{"create", "test"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.CreateFunc = func(name string, tmplType extensions.ExtTemplateType) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					calls := em.CreateCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "gh-test", calls[0].Name)
+				}
+			},
+			isTTY: true,
+			wantStdout: heredoc.Doc(`
+				✓ Created directory gh-test
+				✓ Initialized git repository
+				✓ Set up extension scaffolding
+
+				gh-test is ready for development!
+
+				Next Steps
+				- run 'cd gh-test; gh extension install .; gh test' to see your new extension in action
+				- commit and use 'gh repo create' to share your extension with others
 
 				For more information on writing extensions:
 				https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions
@@ -295,7 +393,7 @@ func TestNewCmdExtension(t *testing.T) {
 			name: "create extension notty",
 			args: []string{"create", "gh-test"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.CreateFunc = func(name string) error {
+				em.CreateFunc = func(name string, tmplType extensions.ExtTemplateType) error {
 					return nil
 				}
 				return func(t *testing.T) {
@@ -319,6 +417,12 @@ func TestNewCmdExtension(t *testing.T) {
 			em := &extensions.ExtensionManagerMock{}
 			if tt.managerStubs != nil {
 				assertFunc = tt.managerStubs(em)
+			}
+
+			as, teardown := prompt.InitAskStubber()
+			defer teardown()
+			if tt.askStubs != nil {
+				tt.askStubs(as)
 			}
 
 			reg := httpmock.Registry{}

--- a/pkg/cmd/extension/ext_tmpls/buildScript.sh
+++ b/pkg/cmd/extension/ext_tmpls/buildScript.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "TODO implement this script."
+echo "It should build binaries in dist/<platform>-<arch>[.exe] as needed."
+exit 1

--- a/pkg/cmd/extension/ext_tmpls/goBinMain.go.txt
+++ b/pkg/cmd/extension/ext_tmpls/goBinMain.go.txt
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cli/go-gh"
+)
+
+func main() {
+	fmt.Println("hi world, this is the %s extension!")
+	client, err := gh.RESTClient(nil)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	response := struct {Login string}{}
+	err = client.Get("user", &response)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Printf("running as %%s\n", response.Login)
+}
+
+// For more examples of using go-gh, see:
+// https://github.com/cli/go-gh/blob/trunk/example_gh_test.go

--- a/pkg/cmd/extension/ext_tmpls/goBinWorkflow.yml
+++ b/pkg/cmd/extension/ext_tmpls/goBinWorkflow.yml
@@ -1,0 +1,14 @@
+name: release
+on:
+  push:
+    tags:
+      - "v*"
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cli/gh-extension-precompile@v1

--- a/pkg/cmd/extension/ext_tmpls/otherBinWorkflow.yml
+++ b/pkg/cmd/extension/ext_tmpls/otherBinWorkflow.yml
@@ -1,0 +1,16 @@
+name: release
+on:
+  push:
+    tags:
+      - "v*"
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cli/gh-extension-precompile@v1
+        with:
+          build_script_override: "script/build.sh"

--- a/pkg/cmd/extension/ext_tmpls/script.sh
+++ b/pkg/cmd/extension/ext_tmpls/script.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Hello %[1]s!"
+
+# Snippets to help get started:
+
+# Determine if an executable is in the PATH
+# if ! type -p ruby >/dev/null; then
+#   echo "Ruby not found on the system" >&2
+#   exit 1
+# fi
+
+# Pass arguments through to another command
+# gh issue list "$@" -R cli/cli
+
+# Using the gh api command to retrieve and format information
+# QUERY='
+#   query($endCursor: String) {
+#     viewer {
+#       repositories(first: 100, after: $endCursor) {
+#         nodes {
+#           nameWithOwner
+#           stargazerCount
+#         }
+#       }
+#     }
+#   }
+# '
+# TEMPLATE='
+#   {{- range $repo := .data.viewer.repositories.nodes -}}
+#     {{- printf "name: %[2]s - stargazers: %[3]s\n" $repo.nameWithOwner $repo.stargazerCount -}}
+#   {{- end -}}
+# '
+# exec gh api graphql -f query="${QUERY}" --paginate --template="${TEMPLATE}"

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -6,6 +6,14 @@ import (
 	"github.com/cli/cli/v2/internal/ghrepo"
 )
 
+type ExtTemplateType int
+
+const (
+	GitTemplateType      ExtTemplateType = 0
+	GoBinTemplateType    ExtTemplateType = 1
+	OtherBinTemplateType ExtTemplateType = 2
+)
+
 //go:generate moq -rm -out extension_mock.go . Extension
 type Extension interface {
 	Name() string // Extension Name without gh-
@@ -24,5 +32,5 @@ type ExtensionManager interface {
 	Upgrade(name string, force bool) error
 	Remove(name string) error
 	Dispatch(args []string, stdin io.Reader, stdout, stderr io.Writer) (bool, error)
-	Create(name string) error
+	Create(name string, tmplType ExtTemplateType) error
 }

--- a/pkg/extensions/manager_mock.go
+++ b/pkg/extensions/manager_mock.go
@@ -19,7 +19,7 @@ var _ ExtensionManager = &ExtensionManagerMock{}
 //
 // 		// make and configure a mocked ExtensionManager
 // 		mockedExtensionManager := &ExtensionManagerMock{
-// 			CreateFunc: func(name string) error {
+// 			CreateFunc: func(name string, tmplType ExtTemplateType) error {
 // 				panic("mock out the Create method")
 // 			},
 // 			DispatchFunc: func(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (bool, error) {
@@ -48,7 +48,7 @@ var _ ExtensionManager = &ExtensionManagerMock{}
 // 	}
 type ExtensionManagerMock struct {
 	// CreateFunc mocks the Create method.
-	CreateFunc func(name string) error
+	CreateFunc func(name string, tmplType ExtTemplateType) error
 
 	// DispatchFunc mocks the Dispatch method.
 	DispatchFunc func(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (bool, error)
@@ -74,6 +74,8 @@ type ExtensionManagerMock struct {
 		Create []struct {
 			// Name is the name argument value.
 			Name string
+			// TmplType is the tmplType argument value.
+			TmplType ExtTemplateType
 		}
 		// Dispatch holds details about calls to the Dispatch method.
 		Dispatch []struct {
@@ -124,29 +126,33 @@ type ExtensionManagerMock struct {
 }
 
 // Create calls CreateFunc.
-func (mock *ExtensionManagerMock) Create(name string) error {
+func (mock *ExtensionManagerMock) Create(name string, tmplType ExtTemplateType) error {
 	if mock.CreateFunc == nil {
 		panic("ExtensionManagerMock.CreateFunc: method is nil but ExtensionManager.Create was just called")
 	}
 	callInfo := struct {
-		Name string
+		Name     string
+		TmplType ExtTemplateType
 	}{
-		Name: name,
+		Name:     name,
+		TmplType: tmplType,
 	}
 	mock.lockCreate.Lock()
 	mock.calls.Create = append(mock.calls.Create, callInfo)
 	mock.lockCreate.Unlock()
-	return mock.CreateFunc(name)
+	return mock.CreateFunc(name, tmplType)
 }
 
 // CreateCalls gets all the calls that were made to Create.
 // Check the length with:
 //     len(mockedExtensionManager.CreateCalls())
 func (mock *ExtensionManagerMock) CreateCalls() []struct {
-	Name string
+	Name     string
+	TmplType ExtTemplateType
 } {
 	var calls []struct {
-		Name string
+		Name     string
+		TmplType ExtTemplateType
 	}
 	mock.lockCreate.RLock()
 	calls = mock.calls.Create


### PR DESCRIPTION
It's entirely possible I have overdone this and please tell me if so.

This PR adds a small wizard to `gh extension create` that collects a name and "type" of extension to create: script-based, go-based, or other compiled.

It also supposed `--precompiled=go` and `--precompiled=other` to avoid interactivity.

For Go extensions, it lays out a `main.go` with some helper functions pre-seeded as well as a workflow file that uses https://github.com/cli/gh-extension-precompile with default arguments.

For non-Go binary extensions, it lays out a stubbed `script/build.sh` script as well as a workflow file that uses https://github.com/cli/gh-extension-precompile with `build_override: script/build.sh` passed.

Part of #4194