### PR TITLE
Fix CODEOWNERS for codespaces

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 * @cli/code-reviewers
 
-pkg/cmd/codespace/* @cli/codespaces
-pkg/liveshare/* @cli/codespaces
-internal/codespaces/* @cli/codespaces
+pkg/cmd/codespace/ @cli/codespaces
+pkg/liveshare/ @cli/codespaces
+internal/codespaces/ @cli/codespaces


### PR DESCRIPTION
The expression `dir/*` only matches files directly under `dir/`.

https://github.com/cli/cli/pull/4723#issuecomment-968957898 /cc @josebalius 
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax