### PR TITLE
Add `gh config list`

### DIFF
--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/config"
 	cmdGet "github.com/cli/cli/v2/pkg/cmd/config/get"
+	cmdList "github.com/cli/cli/v2/pkg/cmd/config/list"
 	cmdSet "github.com/cli/cli/v2/pkg/cmd/config/set"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -33,6 +34,7 @@ func NewCmdConfig(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.AddCommand(cmdGet.NewCmdConfigGet(f, nil))
 	cmd.AddCommand(cmdSet.NewCmdConfigSet(f, nil))
+	cmd.AddCommand(cmdList.NewCmdConfigList(f, nil))
 
 	return cmd
 }

--- a/pkg/cmd/config/list/list.go
+++ b/pkg/cmd/config/list/list.go
@@ -60,7 +60,7 @@ func listRun(opts *ListOptions) error {
 	}
 
 	if isTTY {
-		fmt.Fprintf(opts.IO.Out, cs.Grayf("Settings configured for %s\n\n", host))
+		fmt.Fprint(opts.IO.Out, cs.Grayf("Settings configured for %s\n\n", host))
 	}
 
 	configOptions := config.ConfigOptions()
@@ -75,7 +75,7 @@ func listRun(opts *ListOptions) error {
 			configLine = cs.Bold(configLine)
 			configLine += fmt.Sprintf(" (default: %s)", key.DefaultValue)
 		}
-		fmt.Fprintln(opts.IO.Out, configLine)
+		fmt.Fprint(opts.IO.Out, configLine, "\n")
 	}
 
 	return nil

--- a/pkg/cmd/config/list/list.go
+++ b/pkg/cmd/config/list/list.go
@@ -1,0 +1,73 @@
+package list
+
+import (
+	"fmt"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type ListOptions struct {
+	IO     *iostreams.IOStreams
+	Config func() (config.Config, error)
+
+	Hostname string
+}
+
+func NewCmdConfigList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
+	opts := &ListOptions{
+		IO: f.IOStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Print a list of configuration keys and values",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Config = f.Config
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return listRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Hostname, "host", "h", "", "Get per-host setting")
+
+	return cmd
+}
+
+func listRun(opts *ListOptions) error {
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	//cs := opts.IO.ColorScheme()
+	isTTY := opts.IO.IsStdoutTTY()
+
+	host, err := cfg.DefaultHost()
+	if err != nil {
+		return err
+	}
+
+	if isTTY {
+		fmt.Printf("Settings configured for %s\n\n", host)
+	}
+
+	configOptions := config.ConfigOptions()
+
+	for _, key := range configOptions {
+		val, err := cfg.Get(opts.Hostname, key.Key)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s: %s\n", key.Key, val)
+	}
+
+	return nil
+}

--- a/pkg/cmd/config/list/list.go
+++ b/pkg/cmd/config/list/list.go
@@ -46,9 +46,6 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
-	cs := opts.IO.ColorScheme()
-	isTTY := opts.IO.IsStdoutTTY()
-
 	var host string
 	if opts.Hostname != "" {
 		host = opts.Hostname
@@ -59,23 +56,14 @@ func listRun(opts *ListOptions) error {
 		}
 	}
 
-	if isTTY {
-		fmt.Fprint(opts.IO.Out, cs.Grayf("Settings configured for %s\n\n", host))
-	}
-
 	configOptions := config.ConfigOptions()
 
 	for _, key := range configOptions {
-		val, err := cfg.Get(opts.Hostname, key.Key)
+		val, err := cfg.Get(host, key.Key)
 		if err != nil {
 			return err
 		}
-		configLine := fmt.Sprintf("%s: %s", key.Key, val)
-		if isTTY && key.DefaultValue != "" && val != key.DefaultValue {
-			configLine = cs.Bold(configLine)
-			configLine += fmt.Sprintf(" (default: %s)", key.DefaultValue)
-		}
-		fmt.Fprint(opts.IO.Out, configLine, "\n")
+		fmt.Fprint(opts.IO.Out, fmt.Sprintf("%s=%s\n", key.Key, val))
 	}
 
 	return nil

--- a/pkg/cmd/config/list/list.go
+++ b/pkg/cmd/config/list/list.go
@@ -63,7 +63,7 @@ func listRun(opts *ListOptions) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprint(opts.IO.Out, fmt.Sprintf("%s=%s\n", key.Key, val))
+		fmt.Fprintf(opts.IO.Out, "%s=%s\n", key.Key, val)
 	}
 
 	return nil

--- a/pkg/cmd/config/list/list_test.go
+++ b/pkg/cmd/config/list/list_test.go
@@ -72,13 +72,11 @@ func Test_listRun(t *testing.T) {
 		name    string
 		input   *ListOptions
 		config  config.ConfigStub
-		isTTY   bool
 		stdout  string
 		wantErr bool
 	}{
 		{
-			name:  "list",
-			isTTY: true,
+			name: "list",
 			config: config.ConfigStub{
 				"HOST:git_protocol":     "ssh",
 				"HOST:editor":           "/usr/bin/vim",
@@ -88,22 +86,18 @@ func Test_listRun(t *testing.T) {
 				"HOST:browser":          "brave",
 			},
 			input: &ListOptions{Hostname: "HOST"}, // ConfigStub gives empty DefaultHost
-			stdout: `Settings configured for HOST
-
-git_protocol: ssh (default: https)
-editor: /usr/bin/vim
-prompt: disabled (default: enabled)
-pager: less
-http_unix_socket: 
-browser: brave
+			stdout: `git_protocol=ssh
+editor=/usr/bin/vim
+prompt=disabled
+pager=less
+http_unix_socket=
+browser=brave
 `,
 		},
 	}
 
 	for _, tt := range tests {
 		io, _, stdout, _ := iostreams.Test()
-		io.SetStdoutTTY(tt.isTTY)
-		io.SetStdinTTY(tt.isTTY)
 		tt.input.IO = io
 		tt.input.Config = func() (config.Config, error) {
 			return tt.config, nil

--- a/pkg/cmd/config/list/list_test.go
+++ b/pkg/cmd/config/list/list_test.go
@@ -1,0 +1,119 @@
+package list
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdConfigList(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		output   ListOptions
+		wantsErr bool
+	}{
+		{
+			name:     "no arguments",
+			input:    "",
+			output:   ListOptions{},
+			wantsErr: false,
+		},
+		{
+			name:     "list with host",
+			input:    "--host HOST.com",
+			output:   ListOptions{Hostname: "HOST.com"},
+			wantsErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &cmdutil.Factory{
+				Config: func() (config.Config, error) {
+					return config.ConfigStub{}, nil
+				},
+			}
+
+			argv, err := shlex.Split(tt.input)
+			assert.NoError(t, err)
+
+			var gotOpts *ListOptions
+			cmd := NewCmdConfigList(f, func(opts *ListOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.Flags().BoolP("help", "x", false, "")
+
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.output.Hostname, gotOpts.Hostname)
+		})
+	}
+}
+
+func Test_listRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   *ListOptions
+		config  config.ConfigStub
+		isTTY   bool
+		stdout  string
+		wantErr bool
+	}{
+		{
+			name:  "list",
+			isTTY: true,
+			config: config.ConfigStub{
+				"HOST:git_protocol":     "ssh",
+				"HOST:editor":           "/usr/bin/vim",
+				"HOST:prompt":           "disabled",
+				"HOST:pager":            "less",
+				"HOST:http_unix_socket": "",
+				"HOST:browser":          "brave",
+			},
+			input: &ListOptions{Hostname: "HOST"}, // ConfigStub gives empty DefaultHost
+			stdout: `Settings configured for HOST
+
+git_protocol: ssh (default: https)
+editor: /usr/bin/vim
+prompt: disabled (default: enabled)
+pager: less
+http_unix_socket: 
+browser: brave
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		io, _, stdout, _ := iostreams.Test()
+		io.SetStdoutTTY(tt.isTTY)
+		io.SetStdinTTY(tt.isTTY)
+		tt.input.IO = io
+		tt.input.Config = func() (config.Config, error) {
+			return tt.config, nil
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := listRun(tt.input)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.stdout, stdout.String())
+			//assert.Equal(t, tt.stderr, stderr.String())
+		})
+	}
+}


### PR DESCRIPTION
Fixes #859

`gh config list` ~~pretty prints~~ plain prints key=value list of main config options 

- doesn't show custom config entries
- doesn't show aliases (use `gh alias list` instead)