### PR TITLE
Add prebuild availability status to create codespaces

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -415,8 +415,9 @@ func (a *API) GetCodespaceRegionLocation(ctx context.Context) (string, error) {
 }
 
 type Machine struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"display_name"`
+	Name                 string `json:"name"`
+	DisplayName          string `json:"display_name"`
+	PrebuildAvailability string `json:"prebuild_availability"`
 }
 
 // GetCodespacesMachines returns the codespaces machines for the given repo, branch and location.

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -2,8 +2,6 @@ package codespace
 
 import (
 	"testing"
-
-	"github.com/cli/cli/v2/pkg/iostreams"
 )
 
 func TestBuildDisplayName(t *testing.T) {
@@ -35,10 +33,7 @@ func TestBuildDisplayName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			makeGrayText := io.ColorScheme().Gray
-
-			displayName := buildDisplayName("4 cores, 8 GB RAM, 32 GB storage", tt.prebuildAvailability, makeGrayText)
+			displayName := buildDisplayName("4 cores, 8 GB RAM, 32 GB storage", tt.prebuildAvailability)
 
 			if displayName != tt.expectedDisplayName {
 				t.Errorf("displayName = %q, expectedDisplayName %q", displayName, tt.expectedDisplayName)

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -1,0 +1,66 @@
+package codespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+func TestGetMachineName(t *testing.T) {
+	tests := []struct {
+		name                 string
+		prebuildAvailability string
+		wantStdout           string
+	}{
+		{
+			name:                 "prebuild availability is pool",
+			prebuildAvailability: "pool",
+			wantStdout:           "something",
+		},
+		{
+			name:                 "prebuild availability is blob",
+			prebuildAvailability: "blob",
+			wantStdout:           "something",
+		},
+		{
+			name:                 "prebuild availability is none",
+			prebuildAvailability: "none",
+			wantStdout:           "something",
+		},
+		{
+			name:                 "prebuild availability is empty",
+			prebuildAvailability: "",
+			wantStdout:           "something",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiMock := &apiClientMock{
+				GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch string, location string) ([]*api.Machine, error) {
+					machines := []*api.Machine{
+						{
+							Name:                 "standardLinux32gb",
+							DisplayName:          "4 cores, 8 GB RAM, 32 GB storage",
+							PrebuildAvailability: tt.prebuildAvailability,
+						},
+					}
+					return machines, nil
+				},
+			}
+
+			io, _, stdout, _ := iostreams.Test()
+			io.SetStdinTTY(true)
+			io.SetStdoutTTY(true)
+			app := NewApp(io, apiMock)
+			ctx := context.TODO()
+
+			getMachineName(ctx, app.io, app.apiClient, 123, "", "main", "EastUs")
+
+			if out := stdout.String(); out != tt.wantStdout {
+				t.Errorf("stdout = %q, want %q", out, tt.wantStdout)
+			}
+		})
+	}
+}

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -1,65 +1,47 @@
 package codespace
 
 import (
-	"context"
 	"testing"
 
-	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/pkg/iostreams"
 )
 
-func TestGetMachineName(t *testing.T) {
+func TestBuildDisplayName(t *testing.T) {
 	tests := []struct {
 		name                 string
 		prebuildAvailability string
-		wantStdout           string
+		expectedDisplayName  string
 	}{
 		{
 			name:                 "prebuild availability is pool",
 			prebuildAvailability: "pool",
-			wantStdout:           "something",
+			expectedDisplayName:  "4 cores, 8 GB RAM, 32 GB storage (Prebuild ready)",
 		},
 		{
 			name:                 "prebuild availability is blob",
 			prebuildAvailability: "blob",
-			wantStdout:           "something",
+			expectedDisplayName:  "4 cores, 8 GB RAM, 32 GB storage (Prebuild ready)",
 		},
 		{
 			name:                 "prebuild availability is none",
 			prebuildAvailability: "none",
-			wantStdout:           "something",
+			expectedDisplayName:  "4 cores, 8 GB RAM, 32 GB storage",
 		},
 		{
 			name:                 "prebuild availability is empty",
 			prebuildAvailability: "",
-			wantStdout:           "something",
+			expectedDisplayName:  "4 cores, 8 GB RAM, 32 GB storage",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			apiMock := &apiClientMock{
-				GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch string, location string) ([]*api.Machine, error) {
-					machines := []*api.Machine{
-						{
-							Name:                 "standardLinux32gb",
-							DisplayName:          "4 cores, 8 GB RAM, 32 GB storage",
-							PrebuildAvailability: tt.prebuildAvailability,
-						},
-					}
-					return machines, nil
-				},
-			}
+			io, _, _, _ := iostreams.Test()
+			makeGrayText := io.ColorScheme().Gray
 
-			io, _, stdout, _ := iostreams.Test()
-			io.SetStdinTTY(true)
-			io.SetStdoutTTY(true)
-			app := NewApp(io, apiMock)
-			ctx := context.TODO()
+			displayName := buildDisplayName("4 cores, 8 GB RAM, 32 GB storage", tt.prebuildAvailability, makeGrayText)
 
-			getMachineName(ctx, app.io, app.apiClient, 123, "", "main", "EastUs")
-
-			if out := stdout.String(); out != tt.wantStdout {
-				t.Errorf("stdout = %q, want %q", out, tt.wantStdout)
+			if displayName != tt.expectedDisplayName {
+				t.Errorf("displayName = %q, expectedDisplayName %q", displayName, tt.expectedDisplayName)
 			}
 		})
 	}


### PR DESCRIPTION
## What Does This Do?
- Adds copy to the machine list when a prebuild is ready for a machine during the `gh cs create` command. A prebuild is ready when the API returns `pool` or `blob`. 
- I'm new to Go so extra 👀  much appreciated!
- Closes: internal codespaces#4702

## Screenshots 📷 

https://user-images.githubusercontent.com/17835681/142050289-acc8e1b5-8058-4391-9ceb-ddc7385e0da3.mov



