### PR TITLE
Support editing gist description

### DIFF
--- a/pkg/cmd/gist/edit/edit_test.go
+++ b/pkg/cmd/gist/edit/edit_test.go
@@ -65,6 +65,14 @@ func TestNewCmdEdit(t *testing.T) {
 				AddFilename: "cool.md",
 			},
 		},
+		{
+			name: "description",
+			cli:  `123 --desc "my new description"`,
+			wants: EditOptions{
+				Selector:    "123",
+				Description: "my new description",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -260,6 +268,39 @@ func Test_editRun(t *testing.T) {
 			},
 			opts: &EditOptions{
 				AddFilename: fileToAdd,
+			},
+		},
+		{
+			name: "change description",
+			gist: &shared.Gist{
+				ID:          "1234",
+				Description: "my old description",
+				Files: map[string]*shared.GistFile{
+					"sample.txt": {
+						Filename: "sample.txt",
+						Type:     "text/plain",
+					},
+				},
+				Owner: &shared.GistOwner{Login: "octocat"},
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("POST", "gists/1234"),
+					httpmock.StatusStringResponse(201, "{}"))
+			},
+			wantParams: map[string]interface{}{
+				"description": "my new description",
+				"updated_at":  "0001-01-01T00:00:00Z",
+				"public":      false,
+				"files": map[string]interface{}{
+					"sample.txt": map[string]interface{}{
+						"content":  "new file content",
+						"filename": "sample.txt",
+						"type":     "text/plain",
+					},
+				},
+			},
+			opts: &EditOptions{
+				Description: "my new description",
 			},
 		},
 	}


### PR DESCRIPTION
Addresses one of the feature requests in https://github.com/cli/cli/issues/1260 

Add a --desc flag to gh gist edit to support editing gist descriptions. This flag can be used in combination with the other gist editing flags to edit the description whilst also adding/editing files.

Examples:

```
# Update description
gh gist edit 1234 --desc "a new description"

# Update description and add a new file
gh gist edit 1234 --desc "a new description" --add new_file.txt

# Update description and edit an existing file
gh gist edit 1234 --desc "a new description" --filename old_file.txt
```
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
