### PR TITLE
Add idle_timeout_minutes as possible cs create param

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -460,14 +460,14 @@ func (a *API) GetCodespacesMachines(ctx context.Context, repoID int, branch, loc
 
 // CreateCodespaceParams are the required parameters for provisioning a Codespace.
 type CreateCodespaceParams struct {
-	RepositoryID              int
-	Branch, Machine, Location string
+	RepositoryID, IdleTimeoutMinutes int
+	Branch, Machine, Location        string
 }
 
 // CreateCodespace creates a codespace with the given parameters and returns a non-nil error if it
 // fails to create.
 func (a *API) CreateCodespace(ctx context.Context, params *CreateCodespaceParams) (*Codespace, error) {
-	codespace, err := a.startCreate(ctx, params.RepositoryID, params.Machine, params.Branch, params.Location)
+	codespace, err := a.startCreate(ctx, params.RepositoryID, params.IdleTimeoutMinutes, params.Machine, params.Branch, params.Location)
 	if err != errProvisioningInProgress {
 		return codespace, err
 	}
@@ -502,10 +502,11 @@ func (a *API) CreateCodespace(ctx context.Context, params *CreateCodespaceParams
 }
 
 type startCreateRequest struct {
-	RepositoryID int    `json:"repository_id"`
-	Ref          string `json:"ref"`
-	Location     string `json:"location"`
-	Machine      string `json:"machine"`
+	RepositoryID       int    `json:"repository_id"`
+	IdleTimeoutMinutes int    `json:"idle_timeout_minutes"`
+	Ref                string `json:"ref"`
+	Location           string `json:"location"`
+	Machine            string `json:"machine"`
 }
 
 var errProvisioningInProgress = errors.New("provisioning in progress")
@@ -514,8 +515,8 @@ var errProvisioningInProgress = errors.New("provisioning in progress")
 // It may return success or an error, or errProvisioningInProgress indicating that the operation
 // did not complete before the GitHub API's time limit for RPCs (10s), in which case the caller
 // must poll the server to learn the outcome.
-func (a *API) startCreate(ctx context.Context, repoID int, machine, branch, location string) (*Codespace, error) {
-	requestBody, err := json.Marshal(startCreateRequest{repoID, branch, location, machine})
+func (a *API) startCreate(ctx context.Context, repoID, idleTimeoutMinutes int, machine, branch, location string) (*Codespace, error) {
+	requestBody, err := json.Marshal(startCreateRequest{repoID, idleTimeoutMinutes, branch, location, machine})
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request: %w", err)
 	}

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -460,14 +460,17 @@ func (a *API) GetCodespacesMachines(ctx context.Context, repoID int, branch, loc
 
 // CreateCodespaceParams are the required parameters for provisioning a Codespace.
 type CreateCodespaceParams struct {
-	RepositoryID, IdleTimeoutMinutes int
-	Branch, Machine, Location        string
+	RepositoryID       int
+	IdleTimeoutMinutes int
+	Branch             string
+	Machine            string
+	Location           string
 }
 
 // CreateCodespace creates a codespace with the given parameters and returns a non-nil error if it
 // fails to create.
 func (a *API) CreateCodespace(ctx context.Context, params *CreateCodespaceParams) (*Codespace, error) {
-	codespace, err := a.startCreate(ctx, params.RepositoryID, params.IdleTimeoutMinutes, params.Machine, params.Branch, params.Location)
+	codespace, err := a.startCreate(ctx, params)
 	if err != errProvisioningInProgress {
 		return codespace, err
 	}
@@ -515,8 +518,18 @@ var errProvisioningInProgress = errors.New("provisioning in progress")
 // It may return success or an error, or errProvisioningInProgress indicating that the operation
 // did not complete before the GitHub API's time limit for RPCs (10s), in which case the caller
 // must poll the server to learn the outcome.
-func (a *API) startCreate(ctx context.Context, repoID, idleTimeoutMinutes int, machine, branch, location string) (*Codespace, error) {
-	requestBody, err := json.Marshal(startCreateRequest{repoID, idleTimeoutMinutes, branch, location, machine})
+func (a *API) startCreate(ctx context.Context, params *CreateCodespaceParams) (*Codespace, error) {
+	if params == nil {
+		return nil, errors.New("startCreate missing parameters")
+	}
+
+	requestBody, err := json.Marshal(startCreateRequest{
+		RepositoryID:       params.RepositoryID,
+		IdleTimeoutMinutes: params.IdleTimeoutMinutes,
+		Ref:                params.Branch,
+		Location:           params.Location,
+		Machine:            params.Machine,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request: %w", err)
 	}

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -36,7 +36,7 @@ func newCreateCmd(app *App) *cobra.Command {
 	createCmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "repository branch")
 	createCmd.Flags().StringVarP(&opts.machine, "machine", "m", "", "hardware specifications for the VM")
 	createCmd.Flags().BoolVarP(&opts.showStatus, "status", "s", false, "show status of post-create command and dotfiles")
-	createCmd.Flags().DurationVarP(&opts.idleTimeout, "idle-timeout", "i", 30*time.Minute, "duration of inactivity before codespace is shutdown/stopped e.g. \"3600s\", \"60m\", \"1h\"")
+	createCmd.Flags().DurationVar(&opts.idleTimeout, "idle-timeout", 30*time.Minute, "allowed inactivity before codespace is stopped, e.g. \"10m\", \"1h\"")
 
 	return createCmd
 }
@@ -46,13 +46,11 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 	locationCh := getLocation(ctx, a.apiClient)
 
 	userInputs := struct {
-		Repository         string
-		Branch             string
-		IdleTimeoutMinutes int
+		Repository string
+		Branch     string
 	}{
-		Repository:         opts.repo,
-		Branch:             opts.branch,
-		IdleTimeoutMinutes: int(opts.idleTimeout.Minutes()), // necessary conversion for the API
+		Repository: opts.repo,
+		Branch:     opts.branch,
 	}
 
 	if userInputs.Repository == "" {
@@ -110,7 +108,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		Branch:             branch,
 		Machine:            machine,
 		Location:           locationResult.Location,
-		IdleTimeoutMinutes: userInputs.IdleTimeoutMinutes,
+		IdleTimeoutMinutes: int(opts.idleTimeout.Minutes()),
 	})
 	a.StopProgressIndicator()
 	if err != nil {

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/cli/cli/v2/internal/codespaces"
@@ -12,11 +13,11 @@ import (
 )
 
 type createOptions struct {
-	repo               string
-	branch             string
-	machine            string
-	showStatus         bool
-	idleTimeoutMinutes int
+	repo        string
+	branch      string
+	machine     string
+	showStatus  bool
+	idleTimeout time.Duration
 }
 
 func newCreateCmd(app *App) *cobra.Command {
@@ -35,7 +36,7 @@ func newCreateCmd(app *App) *cobra.Command {
 	createCmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "repository branch")
 	createCmd.Flags().StringVarP(&opts.machine, "machine", "m", "", "hardware specifications for the VM")
 	createCmd.Flags().BoolVarP(&opts.showStatus, "status", "s", false, "show status of post-create command and dotfiles")
-	createCmd.Flags().IntVarP(&opts.idleTimeoutMinutes, "idle-timeout-minutes", "i", 30, "idle timeout in minutes")
+	createCmd.Flags().DurationVarP(&opts.idleTimeout, "idle-timeout", "i", 30*time.Minute, "duration of inactivity before codespace is shutdown/stopped e.g. \"3600s\", \"60m\", \"1h\"")
 
 	return createCmd
 }
@@ -51,7 +52,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 	}{
 		Repository:         opts.repo,
 		Branch:             opts.branch,
-		IdleTimeoutMinutes: opts.idleTimeoutMinutes,
+		IdleTimeoutMinutes: int(opts.idleTimeout.Minutes()), // necessary conversion for the API
 	}
 
 	if userInputs.Repository == "" {

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -1,0 +1,88 @@
+package codespace
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+func TestApp_Create(t *testing.T) {
+	type fields struct {
+		apiClient apiClient
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		opts       createOptions
+		wantErr    bool
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name: "create codespace with default branch and 30m idle timeout",
+			fields: fields{
+				apiClient: &apiClientMock{
+					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
+						return "EUROPE", nil
+					},
+					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
+						return &api.Repository{
+							ID:            1234,
+							FullName:      nwo,
+							DefaultBranch: "main",
+						}, nil
+					},
+					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error) {
+						return []*api.Machine{
+							{
+								Name:        "GIGA",
+								DisplayName: "Gigabits of a machine",
+							},
+						}, nil
+					},
+					CreateCodespaceFunc: func(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error) {
+						if params.Branch != "main" {
+							return nil, fmt.Errorf("got branch %q, want %q", params.Branch, "main")
+						}
+						if params.IdleTimeoutMinutes != 30 {
+							return nil, fmt.Errorf("idle timeout minutes was %v", params.IdleTimeoutMinutes)
+						}
+						return &api.Codespace{
+							Name: "monalisa-dotfiles-abcd1234",
+						}, nil
+					},
+				},
+			},
+			opts: createOptions{
+				repo:        "monalisa/dotfiles",
+				branch:      "",
+				machine:     "GIGA",
+				showStatus:  false,
+				idleTimeout: 30 * time.Minute,
+			},
+			wantStdout: "monalisa-dotfiles-abcd1234\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, stdout, stderr := iostreams.Test()
+			a := &App{
+				io:        io,
+				apiClient: tt.fields.apiClient,
+			}
+			if err := a.Create(context.Background(), tt.opts); (err != nil) != tt.wantErr {
+				t.Errorf("App.Create() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got := stdout.String(); got != tt.wantStdout {
+				t.Errorf("stdout = %v, want %v", got, tt.wantStdout)
+			}
+			if got := stderr.String(); got != tt.wantStderr {
+				t.Errorf("stderr = %v, want %v", got, tt.wantStderr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We have a friction item for allowing users to specify idle timeout overrides for their codespaces. The plan is to roll out the feature allowing a permanent override via configuration in the UI, while the CLI can optionally specify overrides for each codespace created.

In practice it looks like:

```
» gh cs create -r monalisa/smile -b main --idle-timeout 129m                                                                                                                                                                                                             
monalisa-smile-6vc465g
```

And a few various error cases:

```bash
# setting timeout above maximum
» gh cs create -r monalisa/smile -b main --idle-timeout 1000m                                                                                                                                                                                                            
error creating codespace: HTTP 400: idle_timeout_minutes must be an integer between 5 and 720 minutes (http://api.github.localhost/user/codespaces)
exit status 1

# setting timeout below minimum
» gh cs create -r monalisa/smile -b main --idle-timeout 4m                                                                                                                                                                                                               
error creating codespace: HTTP 400: idle_timeout_minutes must be an integer between 5 and 720 minutes (http://api.github.localhost/user/codespaces)
exit status 1

# invalid input
» gh cs create -r github/registry-metadata -b master --idle-timeout foobar
invalid argument "foobar" for "-i, --idle-timeout" flag: time: invalid duration "foobar"

Usage:  gh codespace create [flags]

Flags:
  -b, --branch string           repository branch
  -i, --idle-timeout duration   duration of inactivity before codespace is shutdown/stopped e.g. "3600s", "60m", "1h" (default 30m0s)
  -m, --machine string          hardware specifications for the VM
  -r, --repo string             repository name with owner: user/repo
  -s, --status                  show status of post-create command and dotfiles

exit status 1
```

The parameter is bubbled up to the create command which sends this value along to VSCS as the `autoShutdownDelayMinutes` environment option.

To test this flag you must be enabled for https://admin.github.com/devtools/feature_flags/codespaces_custom_idle_timeout otherwise it drops the param and behaves as if it were never passed at all.

Fixes https://github.com/github/cli/issues/101