### PR TITLE
Remove the default value from idle-timeout 

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -507,7 +507,7 @@ func (a *API) CreateCodespace(ctx context.Context, params *CreateCodespaceParams
 
 type startCreateRequest struct {
 	RepositoryID       int    `json:"repository_id"`
-	IdleTimeoutMinutes int    `json:"idle_timeout_minutes"`
+	IdleTimeoutMinutes int    `json:"idle_timeout_minutes,omitempty"`
 	Ref                string `json:"ref"`
 	Location           string `json:"location"`
 	Machine            string `json:"machine"`

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -36,7 +36,7 @@ func newCreateCmd(app *App) *cobra.Command {
 	createCmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "repository branch")
 	createCmd.Flags().StringVarP(&opts.machine, "machine", "m", "", "hardware specifications for the VM")
 	createCmd.Flags().BoolVarP(&opts.showStatus, "status", "s", false, "show status of post-create command and dotfiles")
-	createCmd.Flags().DurationVar(&opts.idleTimeout, "idle-timeout", 30*time.Minute, "allowed inactivity before codespace is stopped, e.g. \"10m\", \"1h\"")
+	createCmd.Flags().DurationVar(&opts.idleTimeout, "idle-timeout", 0, "allowed inactivity before codespace is stopped, e.g. \"10m\", \"1h\"")
 
 	return createCmd
 }


### PR DESCRIPTION
https://github.com/cli/cli/pull/4741 added `idle-timeout` as a param that could be specified on codespace creation. This works well for those overrides, but users can also set a default timeout in the UI in their codespace settings. This user setting should take precedence over the default 30 minute timeout that happens when the user has no specific value set.

With the way it works now, the default value on the new param means that not specifying any idle timeout will always use 30 minutes, which could be very different to the value the user has saved.

The order of precendence is `GH CLI override > codespace settings UI override > VSCS default (30 mins)`.

This change removes the default and omits the value entirely from the API call when not set, which properly falls back to the user's saved setting if available and the 30 min default if the setting is not saved for the user.
