### PR TITLE
use `gh browse` to open up gists

### DIFF
--- a/git/remote.go
+++ b/git/remote.go
@@ -93,7 +93,7 @@ func GistRemote() (string, error) {
 			return r.PushURL.String(), nil
 		}
 	}
-	return "", nil
+	return "", fmt.Errorf("unable to determine remote repo or gist")
 }
 
 func parseRemotes(gitRemotes []string) (remotes RemoteSet) {

--- a/git/remote.go
+++ b/git/remote.go
@@ -82,6 +82,20 @@ func Remotes() (RemoteSet, error) {
 	return remotes(".", list)
 }
 
+func GistRemote() (string, error) {
+	list, err := listRemotes()
+	if err != nil {
+		return "", err
+	}
+	remotes := parseRemotes(list)
+	for _, r := range remotes {
+		if strings.Contains(r.PushURL.Host, "gist") {
+			return r.PushURL.String(), nil
+		}
+	}
+	return "", nil
+}
+
 func parseRemotes(gitRemotes []string) (remotes RemoteSet) {
 	for _, r := range gitRemotes {
 		match := remoteRE.FindStringSubmatch(r)

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -126,12 +126,10 @@ func runBrowse(opts *BrowseOptions) error {
 
 func browseGist(opts *BrowseOptions) error {
 	url, err := git.GistRemote()
-	if url == "" {
-		return fmt.Errorf("unable to determine a remote github repo or gist")
-	}
 	if err != nil {
-		return fmt.Errorf("unable to determine base repository: %w", err)
+		return err
 	}
+	// TODO parse filename and line number
 	if opts.NoBrowserFlag {
 		_, err := fmt.Fprintln(opts.IO.Out, url)
 		return err


### PR DESCRIPTION
fixes #4746 

This is a **rough** pr, no review needed yet. I'm not sure if this is in the scope of `gh browse` but as mentioned in the issue above, an error seems to be unexpected when trying to open a gist using `gh browse`. 

If the team thinks this is in good alignment with the command I can keep working on it. Additionally I can make applicable args / flags work too (filename, line number, `--no-browser`).

Those are just some thoughts though!



