### PR TITLE
clone: Load "upstream" repo as https

### DIFF
--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -156,7 +156,7 @@ func cloneRun(opts *CloneOptions) error {
 
 	// If the repo is a fork, add the parent as an upstream
 	if canonicalRepo.Parent != nil {
-		protocol, err := cfg.Get(canonicalRepo.Parent.RepoHost(), "git_protocol")
+		protocol, err := cfg.Get(canonicalRepo.Parent.RepoHost(), "https_protocol")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Instead of loading the upstream repo as "git", let's load it as "https"
and avoid users mistakenly pushing to it without even noticing.

Having it as "https" will at least make the users wonder why they have
to add their username and password, giving them the chance to realise a
possible mistake that's about to happen. :-)

Related: #4762

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
