### PR TITLE
Fix up bug in RemoveEntry and add tests for config_map

### DIFF
--- a/internal/config/config_map_test.go
+++ b/internal/config/config_map_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,8 +45,131 @@ func TestFindEntry(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-			fmt.Println(out)
 			assert.Equal(t, tt.output, out.ValueNode.Value)
+		})
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	cm := ConfigMap{}
+	assert.Equal(t, true, cm.Empty())
+	cm.Root = &yaml.Node{
+		Content: []*yaml.Node{
+			{
+				Value: "test",
+			},
+		},
+	}
+	assert.Equal(t, false, cm.Empty())
+}
+
+func TestGetStringValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		wantValue string
+		wantErr   bool
+	}{
+		{
+			name:      "get key",
+			key:       "valid",
+			wantValue: "present",
+		},
+		{
+			name:    "get key that is not present",
+			key:     "invalid",
+			wantErr: true,
+		},
+		{
+			name:      "get key that has same content as a value",
+			key:       "same",
+			wantValue: "logical",
+		},
+	}
+
+	for _, tt := range tests {
+		cm := ConfigMap{Root: testYaml()}
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := cm.GetStringValue(tt.key)
+			if tt.wantErr {
+				assert.EqualError(t, err, "not found")
+				return
+			}
+			assert.Equal(t, tt.wantValue, val)
+		})
+	}
+}
+
+func TestSetStringValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{
+			name:  "set key that is not present",
+			key:   "notPresent",
+			value: "test1",
+		},
+		{
+			name:  "set key that is present",
+			key:   "erroneous",
+			value: "test2",
+		},
+		{
+			name:  "set key that is blank",
+			key:   "blank",
+			value: "test3",
+		},
+		{
+			name:  "set key that has same content as a value",
+			key:   "present",
+			value: "test4",
+		},
+	}
+
+	for _, tt := range tests {
+		cm := ConfigMap{Root: testYaml()}
+		t.Run(tt.name, func(t *testing.T) {
+			err := cm.SetStringValue(tt.key, tt.value)
+			assert.NoError(t, err)
+			val, err := cm.GetStringValue(tt.key)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.value, val)
+		})
+	}
+}
+
+func TestRemoveEntry(t *testing.T) {
+	tests := []struct {
+		name       string
+		key        string
+		wantLength int
+	}{
+		{
+			name:       "remove key",
+			key:        "erroneous",
+			wantLength: 6,
+		},
+		{
+			name:       "remove key that is not present",
+			key:        "invalid",
+			wantLength: 8,
+		},
+		{
+			name:       "remove key that has same content as a value",
+			key:        "same",
+			wantLength: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		cm := ConfigMap{Root: testYaml()}
+		t.Run(tt.name, func(t *testing.T) {
+			cm.RemoveEntry(tt.key)
+			assert.Equal(t, tt.wantLength, len(cm.Root.Content))
+			_, err := cm.FindEntry(tt.key)
+			assert.EqualError(t, err, "not found")
 		})
 	}
 }


### PR DESCRIPTION
While working on `go-gh` I ran into some issues with `ConfigMap` so this PR is back porting some of the fixes/changes I made. It fixes a bug in `config_map` where `RemoveEntry` didn't actually remove an entry from a `ConfigMap`. Outside of the bug fix there are no functional changes but it also cleans up some stylistic things and adds tests for `ConfigMap`.