### PR TITLE
Improve queries in `issue` commands: no overfetching, support PR arguments

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -50,8 +50,16 @@ func TestGraphQLError(t *testing.T) {
 		httpmock.GraphQL(""),
 		httpmock.StringResponse(`
 			{ "errors": [
-				{"message":"OH NO"},
-				{"message":"this is fine"}
+				{
+					"type": "NOT_FOUND",
+					"message": "OH NO",
+					"path": ["repository", "issue"]
+				},
+				{
+					"type": "ACTUALLY_ITS_FINE",
+					"message": "this is fine",
+					"path": ["repository", "issues", 0, "comments"]
+				}
 			  ]
 			}
 		`),

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -342,27 +342,6 @@ func IssueByNumber(client *Client, repo ghrepo.Interface, number int) (*Issue, e
 	return &resp.Repository.Issue, nil
 }
 
-func IssueReopen(client *Client, repo ghrepo.Interface, issue Issue) error {
-	var mutation struct {
-		ReopenIssue struct {
-			Issue struct {
-				ID githubv4.ID
-			}
-		} `graphql:"reopenIssue(input: $input)"`
-	}
-
-	variables := map[string]interface{}{
-		"input": githubv4.ReopenIssueInput{
-			IssueID: issue.ID,
-		},
-	}
-
-	gql := graphQLClient(client.http, repo.RepoHost())
-	err := gql.MutateNamed(context.Background(), "IssueReopen", &mutation, variables)
-
-	return err
-}
-
 func IssueDelete(client *Client, repo ghrepo.Interface, issue Issue) error {
 	var mutation struct {
 		DeleteIssue struct {

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -342,27 +342,6 @@ func IssueByNumber(client *Client, repo ghrepo.Interface, number int) (*Issue, e
 	return &resp.Repository.Issue, nil
 }
 
-func IssueDelete(client *Client, repo ghrepo.Interface, issue Issue) error {
-	var mutation struct {
-		DeleteIssue struct {
-			Repository struct {
-				ID githubv4.ID
-			}
-		} `graphql:"deleteIssue(input: $input)"`
-	}
-
-	variables := map[string]interface{}{
-		"input": githubv4.DeleteIssueInput{
-			IssueID: issue.ID,
-		},
-	}
-
-	gql := graphQLClient(client.http, repo.RepoHost())
-	err := gql.MutateNamed(context.Background(), "IssueDelete", &mutation, variables)
-
-	return err
-}
-
 func IssueUpdate(client *Client, repo ghrepo.Interface, params githubv4.UpdateIssueInput) error {
 	var mutation struct {
 		UpdateIssue struct {

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -1,12 +1,10 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
-	"github.com/shurcooL/githubv4"
 )
 
 type IssuesPayload struct {
@@ -340,20 +338,6 @@ func IssueByNumber(client *Client, repo ghrepo.Interface, number int) (*Issue, e
 	}
 
 	return &resp.Repository.Issue, nil
-}
-
-func IssueUpdate(client *Client, repo ghrepo.Interface, params githubv4.UpdateIssueInput) error {
-	var mutation struct {
-		UpdateIssue struct {
-			Issue struct {
-				ID string
-			}
-		} `graphql:"updateIssue(input: $input)"`
-	}
-	variables := map[string]interface{}{"input": params}
-	gql := graphQLClient(client.http, repo.RepoHost())
-	err := gql.MutateNamed(context.Background(), "IssueUpdate", &mutation, variables)
-	return err
 }
 
 func (i Issue) Link() string {

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -22,6 +22,7 @@ type IssuesAndTotalCount struct {
 }
 
 type Issue struct {
+	Typename       string `json:"__typename"`
 	ID             string
 	Number         int
 	Title          string
@@ -39,6 +40,10 @@ type Issue struct {
 	ProjectCards   ProjectCards
 	Milestone      *Milestone
 	ReactionGroups ReactionGroups
+}
+
+func (i Issue) IsPullRequest() bool {
+	return i.Typename == "PullRequest"
 }
 
 type Assignees struct {
@@ -335,31 +340,6 @@ func IssueByNumber(client *Client, repo ghrepo.Interface, number int) (*Issue, e
 	}
 
 	return &resp.Repository.Issue, nil
-}
-
-func IssueClose(client *Client, repo ghrepo.Interface, issue Issue) error {
-	var mutation struct {
-		CloseIssue struct {
-			Issue struct {
-				ID githubv4.ID
-			}
-		} `graphql:"closeIssue(input: $input)"`
-	}
-
-	variables := map[string]interface{}{
-		"input": githubv4.CloseIssueInput{
-			IssueID: issue.ID,
-		},
-	}
-
-	gql := graphQLClient(client.http, repo.RepoHost())
-	err := gql.MutateNamed(context.Background(), "IssueClose", &mutation, variables)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func IssueReopen(client *Client, repo ghrepo.Interface, issue Issue) error {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -660,7 +660,7 @@ func isBlank(v interface{}) bool {
 	}
 }
 
-func PullRequestClose(client *Client, repo ghrepo.Interface, pr *PullRequest) error {
+func PullRequestClose(httpClient *http.Client, repo ghrepo.Interface, prID string) error {
 	var mutation struct {
 		ClosePullRequest struct {
 			PullRequest struct {
@@ -671,14 +671,12 @@ func PullRequestClose(client *Client, repo ghrepo.Interface, pr *PullRequest) er
 
 	variables := map[string]interface{}{
 		"input": githubv4.ClosePullRequestInput{
-			PullRequestID: pr.ID,
+			PullRequestID: prID,
 		},
 	}
 
-	gql := graphQLClient(client.http, repo.RepoHost())
-	err := gql.MutateNamed(context.Background(), "PullRequestClose", &mutation, variables)
-
-	return err
+	gql := graphQLClient(httpClient, repo.RepoHost())
+	return gql.MutateNamed(context.Background(), "PullRequestClose", &mutation, variables)
 }
 
 func PullRequestReopen(client *Client, repo ghrepo.Interface, pr *PullRequest) error {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -679,7 +679,7 @@ func PullRequestClose(httpClient *http.Client, repo ghrepo.Interface, prID strin
 	return gql.MutateNamed(context.Background(), "PullRequestClose", &mutation, variables)
 }
 
-func PullRequestReopen(client *Client, repo ghrepo.Interface, pr *PullRequest) error {
+func PullRequestReopen(httpClient *http.Client, repo ghrepo.Interface, prID string) error {
 	var mutation struct {
 		ReopenPullRequest struct {
 			PullRequest struct {
@@ -690,14 +690,12 @@ func PullRequestReopen(client *Client, repo ghrepo.Interface, pr *PullRequest) e
 
 	variables := map[string]interface{}{
 		"input": githubv4.ReopenPullRequestInput{
-			PullRequestID: pr.ID,
+			PullRequestID: prID,
 		},
 	}
 
-	gql := graphQLClient(client.http, repo.RepoHost())
-	err := gql.MutateNamed(context.Background(), "PullRequestReopen", &mutation, variables)
-
-	return err
+	gql := graphQLClient(httpClient, repo.RepoHost())
+	return gql.MutateNamed(context.Background(), "PullRequestReopen", &mutation, variables)
 }
 
 func PullRequestReady(client *Client, repo ghrepo.Interface, pr *PullRequest) error {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -621,20 +621,6 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 	return pr, nil
 }
 
-func UpdatePullRequest(client *Client, repo ghrepo.Interface, params githubv4.UpdatePullRequestInput) error {
-	var mutation struct {
-		UpdatePullRequest struct {
-			PullRequest struct {
-				ID string
-			}
-		} `graphql:"updatePullRequest(input: $input)"`
-	}
-	variables := map[string]interface{}{"input": params}
-	gql := graphQLClient(client.http, repo.RepoHost())
-	err := gql.MutateNamed(context.Background(), "PullRequestUpdate", &mutation, variables)
-	return err
-}
-
 func UpdatePullRequestReviews(client *Client, repo ghrepo.Interface, params githubv4.RequestReviewsInput) error {
 	var mutation struct {
 		RequestReviews struct {

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -176,6 +176,8 @@ var PullRequestFields = append(IssueFields,
 	"statusCheckRollup",
 )
 
+// PullRequestGraphQL constructs a GraphQL query fragment for a set of pull request fields. Since GitHub
+// pull requests are also technically issues, this function can be used to query issues as well.
 func PullRequestGraphQL(fields []string) string {
 	var q []string
 	for _, field := range fields {

--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -1,15 +1,19 @@
 package close
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	graphql "github.com/cli/shurcooL-graphql"
+	"github.com/shurcooL/githubv4"
 	"github.com/spf13/cobra"
 )
 
@@ -58,9 +62,8 @@ func closeRun(opts *CloseOptions) error {
 	if err != nil {
 		return err
 	}
-	apiClient := api.NewClientFromHTTP(httpClient)
 
-	issue, baseRepo, err := shared.IssueFromArg(apiClient, opts.BaseRepo, opts.SelectorArg)
+	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, []string{"id", "number", "title", "state"})
 	if err != nil {
 		return err
 	}
@@ -70,7 +73,7 @@ func closeRun(opts *CloseOptions) error {
 		return nil
 	}
 
-	err = api.IssueClose(apiClient, baseRepo, *issue)
+	err = apiClose(httpClient, baseRepo, issue)
 	if err != nil {
 		return err
 	}
@@ -78,4 +81,27 @@ func closeRun(opts *CloseOptions) error {
 	fmt.Fprintf(opts.IO.ErrOut, "%s Closed issue #%d (%s)\n", cs.SuccessIconWithColor(cs.Red), issue.Number, issue.Title)
 
 	return nil
+}
+
+func apiClose(httpClient *http.Client, repo ghrepo.Interface, issue *api.Issue) error {
+	if issue.IsPullRequest() {
+		return api.PullRequestClose(httpClient, repo, issue.ID)
+	}
+
+	var mutation struct {
+		CloseIssue struct {
+			Issue struct {
+				ID githubv4.ID
+			}
+		} `graphql:"closeIssue(input: $input)"`
+	}
+
+	variables := map[string]interface{}{
+		"input": githubv4.CloseIssueInput{
+			IssueID: issue.ID,
+		},
+	}
+
+	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
+	return gql.MutateNamed(context.Background(), "IssueClose", &mutation, variables)
 }

--- a/pkg/cmd/issue/close/close_test.go
+++ b/pkg/cmd/issue/close/close_test.go
@@ -119,9 +119,24 @@ func TestIssueClose_issuesDisabled(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`query IssueByNumber\b`),
 		httpmock.StringResponse(`
-			{ "data": { "repository": {
-				"hasIssuesEnabled": false
-			} } }`),
+			{
+				"data": {
+					"repository": {
+						"hasIssuesEnabled": false,
+						"issue": null
+					}
+				},
+				"errors": [
+					{
+						"type": "NOT_FOUND",
+						"path": [
+							"repository",
+							"issue"
+						],
+						"message": "Could not resolve to an issue or pull request with the number of 13."
+					}
+				]
+			}`),
 	)
 
 	_, err := runCommand(http, true, "13")

--- a/pkg/cmd/issue/delete/delete_test.go
+++ b/pkg/cmd/issue/delete/delete_test.go
@@ -145,9 +145,24 @@ func TestIssueDelete_issuesDisabled(t *testing.T) {
 	httpRegistry.Register(
 		httpmock.GraphQL(`query IssueByNumber\b`),
 		httpmock.StringResponse(`
-			{ "data": { "repository": {
-				"hasIssuesEnabled": false
-			} } }`),
+		{
+			"data": {
+				"repository": {
+					"hasIssuesEnabled": false,
+					"issue": null
+				}
+			},
+			"errors": [
+				{
+					"type": "NOT_FOUND",
+					"path": [
+						"repository",
+						"issue"
+					],
+					"message": "Could not resolve to an issue or pull request with the number of 13."
+				}
+			]
+		}`),
 	)
 
 	_, err := runCommand(httpRegistry, true, "13")

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -11,7 +11,6 @@ import (
 	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/shurcooL/githubv4"
 	"github.com/spf13/cobra"
 )
 
@@ -130,14 +129,15 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	return cmd
 }
 
+var lookupFields = []string{"id", "number", "title", "body", "assignees", "labels", "projectCards", "milestone", "url"}
+
 func editRun(opts *EditOptions) error {
 	httpClient, err := opts.HttpClient()
 	if err != nil {
 		return err
 	}
-	apiClient := api.NewClientFromHTTP(httpClient)
 
-	issue, repo, err := shared.IssueFromArg(apiClient, opts.BaseRepo, opts.SelectorArg)
+	issue, repo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, lookupFields)
 	if err != nil {
 		return err
 	}
@@ -159,6 +159,7 @@ func editRun(opts *EditOptions) error {
 		}
 	}
 
+	apiClient := api.NewClientFromHTTP(httpClient)
 	opts.IO.StartProgressIndicator()
 	err = opts.FetchOptions(apiClient, repo, &editable)
 	opts.IO.StopProgressIndicator()
@@ -178,7 +179,7 @@ func editRun(opts *EditOptions) error {
 	}
 
 	opts.IO.StartProgressIndicator()
-	err = updateIssue(apiClient, repo, issue.ID, editable)
+	err = prShared.UpdateIssue(httpClient, repo, issue.ID, issue.IsPullRequest(), editable)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
@@ -187,65 +188,4 @@ func editRun(opts *EditOptions) error {
 	fmt.Fprintln(opts.IO.Out, issue.URL)
 
 	return nil
-}
-
-func updateIssue(client *api.Client, repo ghrepo.Interface, id string, options prShared.Editable) error {
-	var err error
-	params := githubv4.UpdateIssueInput{
-		ID:    id,
-		Title: ghString(options.TitleValue()),
-		Body:  ghString(options.BodyValue()),
-	}
-	assigneeIds, err := options.AssigneeIds(client, repo)
-	if err != nil {
-		return err
-	}
-	params.AssigneeIDs = ghIds(assigneeIds)
-	labelIds, err := options.LabelIds()
-	if err != nil {
-		return err
-	}
-	params.LabelIDs = ghIds(labelIds)
-	projectIds, err := options.ProjectIds()
-	if err != nil {
-		return err
-	}
-	params.ProjectIDs = ghIds(projectIds)
-	milestoneId, err := options.MilestoneId()
-	if err != nil {
-		return err
-	}
-	params.MilestoneID = ghId(milestoneId)
-	return api.IssueUpdate(client, repo, params)
-}
-
-func ghIds(s *[]string) *[]githubv4.ID {
-	if s == nil {
-		return nil
-	}
-	ids := make([]githubv4.ID, len(*s))
-	for i, v := range *s {
-		ids[i] = v
-	}
-	return &ids
-}
-
-func ghId(s *string) *githubv4.ID {
-	if s == nil {
-		return nil
-	}
-	if *s == "" {
-		r := githubv4.ID(nil)
-		return &r
-	}
-	r := githubv4.ID(*s)
-	return &r
-}
-
-func ghString(s *string) *githubv4.String {
-	if s == nil {
-		return nil
-	}
-	r := githubv4.String(*s)
-	return &r
 }

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -129,12 +129,25 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	return cmd
 }
 
-var lookupFields = []string{"id", "number", "title", "body", "assignees", "labels", "projectCards", "milestone", "url"}
-
 func editRun(opts *EditOptions) error {
 	httpClient, err := opts.HttpClient()
 	if err != nil {
 		return err
+	}
+
+	editable := opts.Editable
+	lookupFields := []string{"id", "number", "title", "body", "url"}
+	if opts.Interactive || editable.Assignees.Edited {
+		lookupFields = append(lookupFields, "assignees")
+	}
+	if opts.Interactive || editable.Labels.Edited {
+		lookupFields = append(lookupFields, "labels")
+	}
+	if opts.Interactive || editable.Projects.Edited {
+		lookupFields = append(lookupFields, "projectCards")
+	}
+	if opts.Interactive || editable.Milestone.Edited {
+		lookupFields = append(lookupFields, "milestone")
 	}
 
 	issue, repo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, lookupFields)
@@ -142,7 +155,6 @@ func editRun(opts *EditOptions) error {
 		return err
 	}
 
-	editable := opts.Editable
 	editable.Title.Default = issue.Title
 	editable.Body.Default = issue.Body
 	editable.Assignees.Default = issue.Assignees.Logins()

--- a/pkg/cmd/issue/reopen/reopen_test.go
+++ b/pkg/cmd/issue/reopen/reopen_test.go
@@ -119,9 +119,24 @@ func TestIssueReopen_issuesDisabled(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`query IssueByNumber\b`),
 		httpmock.StringResponse(`
-			{ "data": { "repository": {
-				"hasIssuesEnabled": false
-			} } }`),
+		{
+			"data": {
+				"repository": {
+					"hasIssuesEnabled": false,
+					"issue": null
+				}
+			},
+			"errors": [
+				{
+					"type": "NOT_FOUND",
+					"path": [
+						"repository",
+						"issue"
+					],
+					"message": "Could not resolve to an issue or pull request with the number of 2."
+				}
+			]
+		}`),
 	)
 
 	_, err := runCommand(http, true, "2")

--- a/pkg/cmd/issue/shared/lookup.go
+++ b/pkg/cmd/issue/shared/lookup.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -11,6 +12,8 @@ import (
 	"github.com/cli/cli/v2/internal/ghrepo"
 )
 
+// IssueFromArg loads an issue with all its fields.
+// Deprecated: use IssueFromArgWithFields instead.
 func IssueFromArg(apiClient *api.Client, baseRepoFn func() (ghrepo.Interface, error), arg string) (*api.Issue, ghrepo.Interface, error) {
 	issueNumber, baseRepo := issueMetadataFromURL(arg)
 
@@ -30,7 +33,31 @@ func IssueFromArg(apiClient *api.Client, baseRepoFn func() (ghrepo.Interface, er
 		}
 	}
 
-	issue, err := issueFromNumber(apiClient, baseRepo, issueNumber)
+	issue, err := api.IssueByNumber(apiClient, baseRepo, issueNumber)
+	return issue, baseRepo, err
+}
+
+// IssueFromArgWithFields loads an issue or pull request with the specified fields.
+func IssueFromArgWithFields(httpClient *http.Client, baseRepoFn func() (ghrepo.Interface, error), arg string, fields []string) (*api.Issue, ghrepo.Interface, error) {
+	issueNumber, baseRepo := issueMetadataFromURL(arg)
+
+	if issueNumber == 0 {
+		var err error
+		issueNumber, err = strconv.Atoi(strings.TrimPrefix(arg, "#"))
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid issue format: %q", arg)
+		}
+	}
+
+	if baseRepo == nil {
+		var err error
+		baseRepo, err = baseRepoFn()
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not determine base repo: %w", err)
+		}
+	}
+
+	issue, err := findIssueOrPR(httpClient, baseRepo, issueNumber, fields)
 	return issue, baseRepo, err
 }
 
@@ -56,6 +83,34 @@ func issueMetadataFromURL(s string) (int, ghrepo.Interface) {
 	return issueNumber, repo
 }
 
-func issueFromNumber(apiClient *api.Client, repo ghrepo.Interface, issueNumber int) (*api.Issue, error) {
-	return api.IssueByNumber(apiClient, repo, issueNumber)
+func findIssueOrPR(httpClient *http.Client, repo ghrepo.Interface, number int, fields []string) (*api.Issue, error) {
+	type response struct {
+		Repository struct {
+			Issue *api.Issue
+		}
+	}
+
+	query := fmt.Sprintf(`
+	query IssueByNumber($owner: String!, $repo: String!, $number: Int!) {
+		repository(owner: $owner, name: $repo) {
+			issue: issueOrPullRequest(number: $number) {
+				...on Issue{%[1]s}
+				...on PullRequest{%[1]s}
+			}
+		}
+	}`, api.PullRequestGraphQL(fields))
+
+	variables := map[string]interface{}{
+		"owner":  repo.RepoOwner(),
+		"repo":   repo.RepoName(),
+		"number": number,
+	}
+
+	var resp response
+	client := api.NewClientFromHTTP(httpClient)
+	if err := client.GraphQL(repo.RepoHost(), query, variables, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Repository.Issue, nil
 }

--- a/pkg/cmd/issue/transfer/transfer.go
+++ b/pkg/cmd/issue/transfer/transfer.go
@@ -60,13 +60,15 @@ func transferRun(opts *TransferOptions) error {
 		return err
 	}
 
-	apiClient := api.NewClientFromHTTP(httpClient)
-	issue, _, err := shared.IssueFromArg(apiClient, opts.BaseRepo, opts.IssueSelector)
+	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.IssueSelector, []string{"id", "number"})
 	if err != nil {
 		return err
 	}
+	if issue.IsPullRequest() {
+		return fmt.Errorf("issue #%d is a pull request and cannot be transferred", issue.Number)
+	}
 
-	destRepo, err := ghrepo.FromFullName(opts.DestRepoSelector)
+	destRepo, err := ghrepo.FromFullNameWithHost(opts.DestRepoSelector, baseRepo.RepoHost())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -79,9 +79,8 @@ func closeRun(opts *CloseOptions) error {
 	if err != nil {
 		return err
 	}
-	apiClient := api.NewClientFromHTTP(httpClient)
 
-	err = api.PullRequestClose(apiClient, baseRepo, pr)
+	err = api.PullRequestClose(httpClient, baseRepo, pr.ID)
 	if err != nil {
 		return fmt.Errorf("API call failed: %w", err)
 	}
@@ -90,6 +89,7 @@ func closeRun(opts *CloseOptions) error {
 
 	if opts.DeleteBranch {
 		branchSwitchString := ""
+		apiClient := api.NewClientFromHTTP(httpClient)
 
 		if opts.DeleteLocalBranch {
 			currentBranch, err := opts.Branch()

--- a/pkg/cmd/pr/reopen/reopen.go
+++ b/pkg/cmd/pr/reopen/reopen.go
@@ -73,9 +73,8 @@ func reopenRun(opts *ReopenOptions) error {
 	if err != nil {
 		return err
 	}
-	apiClient := api.NewClientFromHTTP(httpClient)
 
-	err = api.PullRequestReopen(apiClient, baseRepo, pr)
+	err = api.PullRequestReopen(httpClient, baseRepo, pr.ID)
 	if err != nil {
 		return fmt.Errorf("API call failed: %w", err)
 	}

--- a/pkg/cmd/pr/shared/editable_http.go
+++ b/pkg/cmd/pr/shared/editable_http.go
@@ -1,0 +1,122 @@
+package shared
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghinstance"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	graphql "github.com/cli/shurcooL-graphql"
+	"github.com/shurcooL/githubv4"
+)
+
+func UpdateIssue(httpClient *http.Client, repo ghrepo.Interface, id string, isPR bool, options Editable) error {
+	title := ghString(options.TitleValue())
+	body := ghString(options.BodyValue())
+
+	apiClient := api.NewClientFromHTTP(httpClient)
+	assigneeIds, err := options.AssigneeIds(apiClient, repo)
+	if err != nil {
+		return err
+	}
+
+	labelIds, err := options.LabelIds()
+	if err != nil {
+		return err
+	}
+
+	projectIds, err := options.ProjectIds()
+	if err != nil {
+		return err
+	}
+
+	milestoneId, err := options.MilestoneId()
+	if err != nil {
+		return err
+	}
+
+	if isPR {
+		params := githubv4.UpdatePullRequestInput{
+			PullRequestID: id,
+			Title:         title,
+			Body:          body,
+			AssigneeIDs:   ghIds(assigneeIds),
+			LabelIDs:      ghIds(labelIds),
+			ProjectIDs:    ghIds(projectIds),
+			MilestoneID:   ghId(milestoneId),
+		}
+		if options.Base.Edited {
+			params.BaseRefName = ghString(&options.Base.Value)
+		}
+		return updatePullRequest(httpClient, repo, params)
+	}
+
+	return updateIssue(httpClient, repo, githubv4.UpdateIssueInput{
+		ID:          id,
+		Title:       title,
+		Body:        body,
+		AssigneeIDs: ghIds(assigneeIds),
+		LabelIDs:    ghIds(labelIds),
+		ProjectIDs:  ghIds(projectIds),
+		MilestoneID: ghId(milestoneId),
+	})
+}
+
+func updateIssue(httpClient *http.Client, repo ghrepo.Interface, params githubv4.UpdateIssueInput) error {
+	var mutation struct {
+		UpdateIssue struct {
+			Issue struct {
+				ID string
+			}
+		} `graphql:"updateIssue(input: $input)"`
+	}
+	variables := map[string]interface{}{"input": params}
+	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
+	return gql.MutateNamed(context.Background(), "IssueUpdate", &mutation, variables)
+}
+
+func updatePullRequest(httpClient *http.Client, repo ghrepo.Interface, params githubv4.UpdatePullRequestInput) error {
+	var mutation struct {
+		UpdatePullRequest struct {
+			PullRequest struct {
+				ID string
+			}
+		} `graphql:"updatePullRequest(input: $input)"`
+	}
+	variables := map[string]interface{}{"input": params}
+	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
+	err := gql.MutateNamed(context.Background(), "PullRequestUpdate", &mutation, variables)
+	return err
+}
+
+func ghIds(s *[]string) *[]githubv4.ID {
+	if s == nil {
+		return nil
+	}
+	ids := make([]githubv4.ID, len(*s))
+	for i, v := range *s {
+		ids[i] = v
+	}
+	return &ids
+}
+
+func ghId(s *string) *githubv4.ID {
+	if s == nil {
+		return nil
+	}
+	if *s == "" {
+		r := githubv4.ID(nil)
+		return &r
+	}
+	r := githubv4.ID(*s)
+	return &r
+}
+
+func ghString(s *string) *githubv4.String {
+	if s == nil {
+		return nil
+	}
+	r := githubv4.String(*s)
+	return &r
+}


### PR DESCRIPTION
Remove overfetching from the following commands, i.e. fetch only the GraphQL fields that are necessary for the operation (usually only `id` and `number`):
- `issue comment`
- `issue close`
- `issue reopen`
- `issue delete`
- `issue transfer`
- `issue edit` (non-interactive)

Have the following commands work with PR arguments as well as issues, since PRs are a kind of issues:
- `issue comment`
- `issue close`
- `issue reopen`
- `issue edit`

Fixes #4785, fixes https://github.com/cli/cli/issues/4202, fixes https://github.com/cli/cli/issues/4127
Partially addresses #3346
Followup to https://github.com/cli/cli/pull/3547

Commands to address in follow-up changes:
- `issue view` - great if this worked with PRs and also survived the error when project cards could not be fetched due to permissions