### PR TITLE
Generate Go 1.17-style `go:build` directives

### DIFF
--- a/pkg/cmd/extension/symlink_other.go
+++ b/pkg/cmd/extension/symlink_other.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package extension

--- a/pkg/findsh/find.go
+++ b/pkg/findsh/find.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package findsh

--- a/pkg/iostreams/console.go
+++ b/pkg/iostreams/console.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package iostreams

--- a/pkg/iostreams/console_windows.go
+++ b/pkg/iostreams/console_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package iostreams

--- a/pkg/iostreams/tty_size.go
+++ b/pkg/iostreams/tty_size.go
@@ -1,4 +1,5 @@
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package iostreams
 


### PR DESCRIPTION
This is the result of running `go fmt` on our repository. This wasn't caught by CI since we use Go 1.16 there for the time being.