### PR TITLE
allow users to open up the last commit of a repository while using repo override flag

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/shurcooL/githubv4"
 )
@@ -525,21 +524,12 @@ func ForkRepo(client *Client, repo ghrepo.Interface, org string) (*Repository, e
 	}, nil
 }
 
-func LastCommit(client *Client, repo ghrepo.Interface) (*git.Commit, error) {
+func LastCommit(client *Client, repo ghrepo.Interface) (*Commit, error) {
 	var responseData struct {
 		Repository struct {
 			DefaultBranchRef struct {
 				Target struct {
-					Commit struct {
-						History struct {
-							Edges []struct {
-								Node struct {
-									Sha   string `graphql:"oid"`
-									Title string `graphql:"messageHeadline"`
-								}
-							}
-						} `graphql:"history(first:1)"`
-					} `graphql:"... on Commit"`
+					Commit `graphql:"... on Commit"`
 				}
 			}
 		} `graphql:"repository(owner: $owner, name: $repo)"`
@@ -551,7 +541,7 @@ func LastCommit(client *Client, repo ghrepo.Interface) (*git.Commit, error) {
 	if err := gql.QueryNamed(context.Background(), "LastCommit", &responseData, variables); err != nil {
 		return nil, err
 	}
-	return (*git.Commit)(&responseData.Repository.DefaultBranchRef.Target.Commit.History.Edges[0].Node), nil
+	return &responseData.Repository.DefaultBranchRef.Target.Commit, nil
 }
 
 // RepoFindForks finds forks of the repo that are affiliated with the viewer

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -29,6 +29,7 @@ type BrowseOptions struct {
 	HttpClient       func() (*http.Client, error)
 	IO               *iostreams.IOStreams
 	PathFromRepoRoot func() string
+	LastCommit       func() (*git.Commit, error)
 
 	SelectorArg string
 
@@ -46,6 +47,7 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 		HttpClient:       f.HttpClient,
 		IO:               f.IOStreams,
 		PathFromRepoRoot: git.PathFromRepoRoot,
+		LastCommit:       git.LastCommit,
 	}
 
 	cmd := &cobra.Command{
@@ -98,6 +100,10 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 				return err
 			}
 
+			if opts.CommitFlag && cmd.Flags().Changed("repo") {
+				panic(fmt.Errorf("woah"))
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -123,7 +129,7 @@ func runBrowse(opts *BrowseOptions) error {
 	}
 
 	if opts.CommitFlag {
-		commit, err := git.LastCommit()
+		commit, err := opts.LastCommit()
 		if err == nil {
 			opts.Branch = commit.Sha
 		}

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -101,7 +101,7 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 			}
 
 			if opts.CommitFlag && cmd.Flags().Changed("repo") {
-				panic(fmt.Errorf("woah"))
+				opts.LastCommit = nil
 			}
 
 			if runF != nil {
@@ -129,6 +129,15 @@ func runBrowse(opts *BrowseOptions) error {
 	}
 
 	if opts.CommitFlag {
+		if opts.LastCommit == nil {
+			httpClient, err := opts.HttpClient()
+			if err != nil {
+				return err
+			}
+			opts.LastCommit = func() (*git.Commit, error) {
+				return api.LastCommit(api.NewClientFromHTTP(httpClient), baseRepo)
+			}
+		}
 		commit, err := opts.LastCommit()
 		if err == nil {
 			opts.Branch = commit.Sha

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -99,7 +99,6 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 			); err != nil {
 				return err
 			}
-
 			if opts.CommitFlag && cmd.Flags().Changed("repo") {
 				opts.LastCommit = nil
 			}
@@ -134,9 +133,7 @@ func runBrowse(opts *BrowseOptions) error {
 			if err != nil {
 				return err
 			}
-			opts.LastCommit = func() (*git.Commit, error) {
-				return api.LastCommit(api.NewClientFromHTTP(httpClient), baseRepo)
-			}
+			opts.LastCommit = func() (*git.Commit, error) { return api.LastCommit(api.NewClientFromHTTP(httpClient), baseRepo) }
 		}
 		commit, err := opts.LastCommit()
 		if err == nil {

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -129,7 +129,7 @@ func runBrowse(opts *BrowseOptions) error {
 
 	if opts.CommitFlag {
 		commit, err := opts.GitClient.LastCommit()
-		if err == nil && commit != nil {
+		if err == nil {
 			opts.Branch = commit.Sha
 		}
 	}
@@ -275,5 +275,8 @@ func (gc *remoteGitClient) LastCommit() (*git.Commit, error) {
 		return nil, err
 	}
 	commit, err := api.LastCommit(api.NewClientFromHTTP(httpClient), repo)
+	if err != nil {
+		return nil, err
+	}
 	return &git.Commit{Sha: commit.OID}, err
 }

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -129,9 +129,10 @@ func runBrowse(opts *BrowseOptions) error {
 
 	if opts.CommitFlag {
 		commit, err := opts.GitClient.LastCommit()
-		if err == nil {
-			opts.Branch = commit.Sha
+		if err != nil {
+			return err
 		}
+		opts.Branch = commit.Sha
 	}
 
 	section, err := parseSection(baseRepo, opts)
@@ -278,5 +279,5 @@ func (gc *remoteGitClient) LastCommit() (*git.Commit, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &git.Commit{Sha: commit.OID}, err
+	return &git.Commit{Sha: commit.OID}, nil
 }

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -420,6 +420,7 @@ func Test_runBrowse(t *testing.T) {
 			if tt.defaultBranch != "" {
 				reg.StubRepoInfoResponse(tt.baseRepo.RepoOwner(), tt.baseRepo.RepoName(), tt.defaultBranch)
 			}
+
 			opts := tt.opts
 			opts.IO = io
 			opts.BaseRepo = func() (ghrepo.Interface, error) {

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -352,10 +352,10 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL: "https://github.com/mislav/will_paginate/blob/3-0-stable/init.rb?plain=1#L6",
 		},
 		{
-			name: "open last commit",
+			name: "open last commit (local git client)",
 			opts: BrowseOptions{
 				CommitFlag: true,
-				LastCommit: git.LastCommit,
+				GitClient:  &localGitClient{},
 			},
 			baseRepo:    ghrepo.New("vilmibm", "gh-user-status"),
 			wantsErr:    false,
@@ -366,7 +366,7 @@ func Test_runBrowse(t *testing.T) {
 			opts: BrowseOptions{
 				CommitFlag:  true,
 				SelectorArg: "main.go",
-				LastCommit:  git.LastCommit,
+				GitClient:   &localGitClient{},
 			},
 			baseRepo:    ghrepo.New("vilmibm", "gh-user-status"),
 			wantsErr:    false,
@@ -420,7 +420,6 @@ func Test_runBrowse(t *testing.T) {
 			if tt.defaultBranch != "" {
 				reg.StubRepoInfoResponse(tt.baseRepo.RepoOwner(), tt.baseRepo.RepoName(), tt.defaultBranch)
 			}
-
 			opts := tt.opts
 			opts.IO = io
 			opts.BaseRepo = func() (ghrepo.Interface, error) {

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -157,6 +157,12 @@ func setGitDir(t *testing.T, dir string) {
 	})
 }
 
+type testGitClient struct{}
+
+func (gc *testGitClient) LastCommit() (*git.Commit, error) {
+	return &git.Commit{Sha: "6f1a2405cace1633d89a79c74c65f22fe78f9659"}, nil
+}
+
 func Test_runBrowse(t *testing.T) {
 	s := string(os.PathSeparator)
 	setGitDir(t, "../../../git/fixtures/simple.git")
@@ -352,10 +358,10 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL: "https://github.com/mislav/will_paginate/blob/3-0-stable/init.rb?plain=1#L6",
 		},
 		{
-			name: "open last commit (local git client)",
+			name: "open last commit",
 			opts: BrowseOptions{
 				CommitFlag: true,
-				GitClient:  &localGitClient{},
+				GitClient:  &testGitClient{},
 			},
 			baseRepo:    ghrepo.New("vilmibm", "gh-user-status"),
 			wantsErr:    false,
@@ -366,7 +372,7 @@ func Test_runBrowse(t *testing.T) {
 			opts: BrowseOptions{
 				CommitFlag:  true,
 				SelectorArg: "main.go",
-				GitClient:   &localGitClient{},
+				GitClient:   &testGitClient{},
 			},
 			baseRepo:    ghrepo.New("vilmibm", "gh-user-status"),
 			wantsErr:    false,

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -143,6 +143,7 @@ func TestNewCmdBrowse(t *testing.T) {
 			assert.Equal(t, tt.wants.WikiFlag, opts.WikiFlag)
 			assert.Equal(t, tt.wants.NoBrowserFlag, opts.NoBrowserFlag)
 			assert.Equal(t, tt.wants.SettingsFlag, opts.SettingsFlag)
+			assert.Equal(t, tt.wants.CommitFlag, opts.CommitFlag)
 		})
 	}
 }
@@ -354,6 +355,7 @@ func Test_runBrowse(t *testing.T) {
 			name: "open last commit",
 			opts: BrowseOptions{
 				CommitFlag: true,
+				LastCommit: git.LastCommit,
 			},
 			baseRepo:    ghrepo.New("vilmibm", "gh-user-status"),
 			wantsErr:    false,
@@ -364,6 +366,7 @@ func Test_runBrowse(t *testing.T) {
 			opts: BrowseOptions{
 				CommitFlag:  true,
 				SelectorArg: "main.go",
+				LastCommit:  git.LastCommit,
 			},
 			baseRepo:    ghrepo.New("vilmibm", "gh-user-status"),
 			wantsErr:    false,


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

fixes #4715 

Given the two options in the issue, I thought it would be best to allow this functionality rather than to produce an error. I tried to minimize the footprint of the solution while doing so.