### PR TITLE
pr view: ensure that PR reviews are always rendered in `--comments` mode

### DIFF
--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -78,6 +78,7 @@ var prReviews = shortenQuery(`
 			reactionGroups{content,users{totalCount}}
 		}
 		pageInfo{hasNextPage,endCursor}
+		totalCount
 	}
 `)
 


### PR DESCRIPTION
The GraphQL query for review didn't use to request the `TotalCount` field, but that field was checked before rendering the conversation thread in `pr view --comments`. This fixes rendering the conversation thread when a PR only has reviews but no ordinary comments.

https://github.com/cli/cli/blob/a6380c8605bd6f47c92632f8f4a95b314bb96d75/pkg/cmd/pr/view/view.go#L227-L227

Fixes #4841