### PR TITLE
Make debugging httpmock easier

### DIFF
--- a/pkg/httpmock/registry.go
+++ b/pkg/httpmock/registry.go
@@ -29,16 +29,23 @@ type Testing interface {
 
 func (r *Registry) Verify(t Testing) {
 	var unmatched []string
+	var n int
 	for _, s := range r.stubs {
 		if !s.matched {
-			unmatched = append(unmatched, s.Label())
+			n++
+			if label := s.Label(); label != "" {
+				unmatched = append(unmatched, s.Label())
+			}
 		}
 	}
-	if len(unmatched) > 0 {
+	if n > 0 {
 		t.Helper()
 		// NOTE: stubs offer no useful reflection, so we can't print details
 		// about dead stubs and what they were trying to match
-		t.Errorf("%d unmatched HTTP stubs: %s", len(unmatched), strings.Join(unmatched, "\n"))
+		t.Errorf("%d unmatched HTTP stubs", n)
+		if len(unmatched) > 0 {
+			t.Errorf("unmatched stubs with labels:\n%s", strings.Join(unmatched, "\n"))
+		}
 	}
 }
 

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -18,6 +18,16 @@ type Stub struct {
 	matched   bool
 	Matcher   Matcher
 	Responder Responder
+	label     string
+}
+
+func (s *Stub) SetLabel(l string) *Stub {
+	s.label = l
+	return s
+}
+
+func (s *Stub) Label() string {
+	return s.label
 }
 
 func MatchAny(*http.Request) bool {


### PR DESCRIPTION
Debugging which stubs go unmatched during testing is kind of a pain.
This change adds an optional label field to httpmock.Stub that can be
used later during verification. If a stub is unmatched, the label is
included in the output.

This changes httpmock.Registry.Register to return a pointer to the stub that
was created. This allows for method chaining when creating a new
httpmock. That means the label is totally optional and doesn't break any
of the existing code.

e.g.
```
reg.Register(
        httpmock.GraphQL(`mutation LabelRemove\b`),
        httpmock.GraphQLMutation(`
        { "data": { "removeLabelsFromLabelable": { "__typename": "" } } }`,
                func(inputs map[string]interface{}) {}),
).SetLabel("label remove")
```
