### PR TITLE
Update StateDir comment to mention XDG_STATE_HOME.

### DIFF
--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -49,7 +49,7 @@ func ConfigDir() string {
 }
 
 // State path precedence
-// 1. XDG_CONFIG_HOME
+// 1. XDG_STATE_HOME
 // 2. LocalAppData (windows only)
 // 3. HOME
 func StateDir() string {


### PR DESCRIPTION
Actual XDG_STATE_HOME is used, but XDG_CONFIG_HOME is mentioned in comment.

_PS: originally opened as https://github.com/cli/cli/pull/4919, but there was no way for me to reopen :/._ 