### PR TITLE
update latest release logic

### DIFF
--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -15,6 +15,7 @@ type Release struct {
 	Name         string
 	TagName      string
 	IsDraft      bool
+	IsLatest     bool
 	IsPrerelease bool
 	CreatedAt    time.Time
 	PublishedAt  time.Time

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -66,7 +66,6 @@ func listRun(opts *ListOptions) error {
 	now := time.Now()
 	table := utils.NewTablePrinter(opts.IO)
 	iofmt := opts.IO.ColorScheme()
-	seenLatest := false
 	for _, rel := range releases {
 		title := text.ReplaceExcessiveWhitespace(rel.Name)
 		if title == "" {
@@ -76,10 +75,9 @@ func listRun(opts *ListOptions) error {
 
 		badge := ""
 		var badgeColor func(string) string
-		if !rel.IsDraft && !rel.IsPrerelease && !seenLatest {
+		if rel.IsLatest {
 			badge = "Latest"
 			badgeColor = iofmt.Green
-			seenLatest = true
 		} else if rel.IsDraft {
 			badge = "Draft"
 			badgeColor = iofmt.Red

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -134,6 +134,7 @@ func Test_listRun(t *testing.T) {
 					{
 						"name": "",
 						"tagName": "v1.1.0",
+						"isLatest": false,
 						"isDraft": true,
 						"isPrerelease": false,
 						"createdAt": "%[1]s",
@@ -142,6 +143,7 @@ func Test_listRun(t *testing.T) {
 					{
 						"name": "The big 1.0",
 						"tagName": "v1.0.0",
+						"isLatest": true,
 						"isDraft": false,
 						"isPrerelease": false,
 						"createdAt": "%[1]s",
@@ -150,6 +152,7 @@ func Test_listRun(t *testing.T) {
 					{
 						"name": "1.0 release candidate",
 						"tagName": "v1.0.0-pre.2",
+						"isLatest": false,
 						"isDraft": false,
 						"isPrerelease": true,
 						"createdAt": "%[1]s",
@@ -158,6 +161,7 @@ func Test_listRun(t *testing.T) {
 					{
 						"name": "New features",
 						"tagName": "v0.9.2",
+						"isLatest": false,
 						"isDraft": false,
 						"isPrerelease": false,
 						"createdAt": "%[1]s",


### PR DESCRIPTION
Based on the history for this utility `IsLatest` didn't exist when it was written as it was added in https://docs.github.com/en/graphql/overview/changelog#schema-changes-for-2021-01-19.

Fixes #4922

<img width="639" alt="image" src="https://user-images.githubusercontent.com/83483/146447876-44678a90-6bfe-41d7-834f-f22e2f43ea7d.png">

to match what is displayed on https://github.com/elastic/elasticsearch/releases
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/83483/146448008-b104981b-db60-4b35-85cd-966fadc1df58.png">


