### PR TITLE
Unconditionally resolve "ssh.github.com" to "github.com"

### DIFF
--- a/git/ssh_config.go
+++ b/git/ssh_config.go
@@ -30,9 +30,8 @@ func (m SSHAliasMap) Translator() func(*url.URL) *url.URL {
 		if !ok {
 			return u
 		}
-		// FIXME: cleanup domain logic
-		if strings.EqualFold(u.Hostname(), "github.com") && strings.EqualFold(resolvedHost, "ssh.github.com") {
-			return u
+		if strings.EqualFold(resolvedHost, "ssh.github.com") {
+			resolvedHost = "github.com"
 		}
 		newURL, _ := url.Parse(u.String())
 		newURL.Host = resolvedHost

--- a/git/ssh_config_test.go
+++ b/git/ssh_config_test.go
@@ -128,12 +128,14 @@ func Test_Translator(t *testing.T) {
 	m := SSHAliasMap{
 		"gh":         "github.com",
 		"github.com": "ssh.github.com",
+		"my.gh.com":  "ssh.github.com",
 	}
 	tr := m.Translator()
 
 	cases := [][]string{
 		{"ssh://gh/o/r", "ssh://github.com/o/r"},
 		{"ssh://github.com/o/r", "ssh://github.com/o/r"},
+		{"ssh://my.gh.com", "ssh://github.com"},
 		{"https://gh/o/r", "https://gh/o/r"},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
Previously, only `github.com` mapped to `ssh.github.com` via ssh config was treated as `github.com`. Now, every `ssh.github.com` host is treated as `github.com`, even if it was initially aliased as something else in the user's ssh hostname mappings.

Fixes https://github.com/cli/cli/issues/4217