### PR TITLE
Refresh man pages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ release:
 before:
   hooks:
     - go mod tidy
-    - make manpages
+    - make manpages GH_VERSION={{.Version}}
 
 builds:
   - <<: &build_defaults

--- a/cmd/gen-docs/main.go
+++ b/cmd/gen-docs/main.go
@@ -58,13 +58,7 @@ func run(args []string) error {
 	}
 
 	if *manPage {
-		header := &docs.GenManHeader{
-			Title:   "gh",
-			Section: "1",
-			Source:  "",
-			Manual:  "",
-		}
-		if err := docs.GenManTree(rootCmd, header, *dir); err != nil {
+		if err := docs.GenManTree(rootCmd, *dir); err != nil {
 			return err
 		}
 	}

--- a/cmd/gen-docs/main_test.go
+++ b/cmd/gen-docs/main_test.go
@@ -18,7 +18,7 @@ func Test_run(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error reading `gh-issue-create.1`: %v", err)
 	}
-	if !strings.Contains(string(manPage), `\fBgh issue create`) {
+	if !strings.Contains(string(manPage), `\fB\fCgh issue create`) {
 		t.Fatal("man page corrupted")
 	}
 

--- a/internal/docs/docs_test.go
+++ b/internal/docs/docs_test.go
@@ -79,12 +79,14 @@ var dummyCmd = &cobra.Command{
 }
 
 func checkStringContains(t *testing.T, got, expected string) {
+	t.Helper()
 	if !strings.Contains(got, expected) {
 		t.Errorf("Expected to contain: \n %v\nGot:\n %v\n", expected, got)
 	}
 }
 
 func checkStringOmits(t *testing.T, got, expected string) {
+	t.Helper()
 	if strings.Contains(got, expected) {
 		t.Errorf("Expected to not contain: \n %v\nGot: %v", expected, got)
 	}

--- a/internal/docs/man_test.go
+++ b/internal/docs/man_test.go
@@ -20,7 +20,7 @@ func translate(in string) string {
 func TestGenManDoc(t *testing.T) {
 	header := &GenManHeader{
 		Title:   "Project",
-		Section: "2",
+		Section: "1",
 	}
 
 	// We generate on a subcommand so we have both subcommands and parents
@@ -49,7 +49,7 @@ func TestGenManDoc(t *testing.T) {
 func TestGenManNoHiddenParents(t *testing.T) {
 	header := &GenManHeader{
 		Title:   "Project",
-		Section: "2",
+		Section: "1",
 	}
 
 	// We generate on a subcommand so we have both subcommands and parents
@@ -94,15 +94,8 @@ func TestGenManSeeAlso(t *testing.T) {
 		t.Fatal(err)
 	}
 	scanner := bufio.NewScanner(buf)
-
-	if err := assertLineFound(scanner, ".SH SEE ALSO"); err != nil {
-		t.Fatalf("Couldn't find SEE ALSO section header: %v", err)
-	}
-	if err := assertNextLineEquals(scanner, ".PP"); err != nil {
-		t.Fatalf("First line after SEE ALSO wasn't break-indent: %v", err)
-	}
-	if err := assertNextLineEquals(scanner, `\fBroot-bbb(1)\fP, \fBroot-ccc(1)\fP`); err != nil {
-		t.Fatalf("Second line after SEE ALSO wasn't correct: %v", err)
+	if err := assertLineFound(scanner, ".SH SEE ALSO"); err == nil {
+		t.Fatalf("Did not expect SEE ALSO section header")
 	}
 }
 
@@ -115,31 +108,26 @@ func TestManPrintFlagsHidesShortDeprecated(t *testing.T) {
 	manPrintFlags(buf, c.Flags())
 
 	got := buf.String()
-	expected := "**--foo**=\"default\"\n\tFoo flag\n\n"
+	expected := "`--foo` `<string>`\n:   Foo flag\n\n"
 	if got != expected {
-		t.Errorf("Expected %v, got %v", expected, got)
+		t.Errorf("Expected %q, got %q", expected, got)
 	}
 }
 
 func TestGenManTree(t *testing.T) {
 	c := &cobra.Command{Use: "do [OPTIONS] arg1 arg2"}
-	header := &GenManHeader{Section: "2"}
 	tmpdir, err := ioutil.TempDir("", "test-gen-man-tree")
 	if err != nil {
 		t.Fatalf("Failed to create tmpdir: %s", err.Error())
 	}
 	defer os.RemoveAll(tmpdir)
 
-	if err := GenManTree(c, header, tmpdir); err != nil {
+	if err := GenManTree(c, tmpdir); err != nil {
 		t.Fatalf("GenManTree failed: %s", err.Error())
 	}
 
-	if _, err := os.Stat(filepath.Join(tmpdir, "do.2")); err != nil {
-		t.Fatalf("Expected file 'do.2' to exist")
-	}
-
-	if header.Title != "" {
-		t.Fatalf("Expected header.Title to be unmodified")
+	if _, err := os.Stat(filepath.Join(tmpdir, "do.1")); err != nil {
+		t.Fatalf("Expected file 'do.1' to exist")
 	}
 }
 
@@ -153,22 +141,6 @@ func assertLineFound(scanner *bufio.Scanner, expectedLine string) error {
 
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("scan failed: %s", err)
-	}
-
-	return fmt.Errorf("hit EOF before finding %v", expectedLine)
-}
-
-func assertNextLineEquals(scanner *bufio.Scanner, expectedLine string) error {
-	if scanner.Scan() {
-		line := scanner.Text()
-		if line == expectedLine {
-			return nil
-		}
-		return fmt.Errorf("got %v, not %v", line, expectedLine)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("scan failed: %v", err)
 	}
 
 	return fmt.Errorf("hit EOF before finding %v", expectedLine)


### PR DESCRIPTION
- Fix name of man pages for all subcommands
- Set title of all man pages to "GitHub CLI manual"
- Include gh version information in man pages
- Clean up rendering of flags section
- List subcommands for every command

<img width="1271" alt="Screen Shot 2021-12-20 at 17 56 41" src="https://user-images.githubusercontent.com/887/146803874-4968f6c4-404d-4e35-8269-3f21e96252a2.png">

Followup to https://github.com/cli/cli/pull/4752 https://github.com/cli/cli/pull/4675 /cc @meiji163 