### PR TITLE
Add Alpine Linux install docs

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -187,7 +187,7 @@ Alpine Linux users can install from the [stable releases' community packaage rep
 apk add github-cli
 ```
 
-Users wanting the latest version of the CLI without waiting to be backported into their stable release they're using should use the edge release's
+Users wanting the latest version of the CLI without waiting to be backported into the stable release they're using should use the edge release's
 community repo through this method below, without mixing packages from stable and unstable repos.[^1]
 
 ```bash
@@ -195,7 +195,7 @@ echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/ap
 apk add github-cli@community
 ```
 
+[^1]: https://wiki.alpinelinux.org/wiki/Package_management#Repository_pinning
 [releases page]: https://github.com/cli/cli/releases/latest
 [arch linux repo]: https://www.archlinux.org/packages/community/x86_64/github-cli
 [arch linux aur]: https://aur.archlinux.org/packages/github-cli-git
-[^1]: https://wiki.alpinelinux.org/wiki/Package_management#Repository_pinning

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -179,6 +179,23 @@ openSUSE Tumbleweed users can install from the [official distribution repo](http
 sudo zypper in gh
 ```
 
+### Alpine Linux
+
+Alpine Linux users can install from the [stable releases' community packaage repository](https://pkgs.alpinelinux.org/packages?name=github-cli&branch=v3.15).
+
+```bash
+apk add github-cli
+```
+
+Users wanting the latest version of the CLI without waiting to be backported into their stable release they're using should use the edge release's
+community repo through this method below, without mixing packages from stable and unstable repos.[^1]
+
+```bash
+echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+apk add github-cli@community
+```
+
 [releases page]: https://github.com/cli/cli/releases/latest
 [arch linux repo]: https://www.archlinux.org/packages/community/x86_64/github-cli
 [arch linux aur]: https://aur.archlinux.org/packages/github-cli-git
+[^1]: https://wiki.alpinelinux.org/wiki/Package_management#Repository_pinning

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -195,7 +195,7 @@ echo "@community http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/ap
 apk add github-cli@community
 ```
 
-[^1]: https://wiki.alpinelinux.org/wiki/Package_management#Repository_pinning
 [releases page]: https://github.com/cli/cli/releases/latest
 [arch linux repo]: https://www.archlinux.org/packages/community/x86_64/github-cli
 [arch linux aur]: https://aur.archlinux.org/packages/github-cli-git
+[^1]: https://wiki.alpinelinux.org/wiki/Package_management#Repository_pinning


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

This PR continues the work of https://github.com/cli/cli/pull/4406 from scratch, [a month after the release of Alpine Linux v3.15](https://alpinelinux.org/posts/Alpine-3.15.0-released.html). There are some delays on back porting releases to stable versions from edge, so I provided instructions on how to install the latest CLI, though I'm [currently building a release tracker](https://github.com/ajhalili2006/github-cli-alpinelinux-tracker) to help to track which CLI releases are available on Alpine's official package repos.