### PR TITLE
Amend location of GPG key file

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -14,8 +14,8 @@ our release schedule.
 Install:
 
 ```bash
-curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/etc/apt/trusted.gpg.d/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/trusted.gpg.d/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 sudo apt update
 sudo apt install gh
 ```


### PR DESCRIPTION
Following the Debian documentation for [SecureApt](https://wiki.debian.org/SecureApt) the keyring files should be stored in `/etc/apt/trusted.gpg.d/`.

> In more recent Debian GNU/Linux versions (Wheezy, for example), the keyrings are stored in specific files all located in the `/etc/apt/trusted.gpg.d` directory.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
