### PR TITLE
Cache Go modules between CI runs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,6 +17,15 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Cache Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go
+          key: ${{ runner.os }}-build-${{ hashFiles('go.mod') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
       - name: Download dependencies
         run: go mod download
 


### PR DESCRIPTION
Downloading 3rd-party dependencies for running our test suite and building gh [can take up to 6 minutes](https://github.com/cli/cli/runs/4803053141?check_suite_focus=true). This aims to speed that up by caching downloaded modules between runs.