### PR TITLE
Pass current envs to SSH command to support alacritty terminal

### DIFF
--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -88,6 +88,7 @@ func newSSHCommand(ctx context.Context, port int, dst string, cmdArgs []string) 
 	}
 
 	cmd := exec.CommandContext(ctx, "ssh", cmdArgs...)
+	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Pass current envs to the SSH command. This makes `gh cs ssh` play nice with my setup where an environment variable is required.

I currently use `alacritty` for my terminal and this requires `TERM=xterm-256color` to be setup for SSH to play nice (there are other options to fix). See: https://github.com/alacritty/alacritty/issues/3932#issuecomment-702300361

Todo: 
- [ ] Test this fix locally