### PR TITLE
Add `nolint-insert` script to mark current lint violations as allowed

### DIFF
--- a/script/nolint-insert
+++ b/script/nolint-insert
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Usage: script/nolint-insert
+#        script/nolint-insert 'nolint:staticcheck // <explanation>'
+set -e
+
+insert-line() {
+  local n=$'\n'
+  sed -i.bak "${2}i\\${n}${3}${n}" "$1"
+  rm "$1.bak"
+}
+
+reverse() {
+  awk '{a[i++]=$0} END {for (j=i-1; j>=0;) print a[j--] }'
+}
+
+comment="${1}"
+
+golangci-lint run --out-format json | jq -r '.Issues[] | [.Pos.Filename, .Pos.Line, .FromLinter, .Text] | @tsv' | reverse | while IFS=$'\t' read -r filename line linter text; do
+  directive="nolint:${linter} // $text"
+  [ -z "$comment" ] || directive="$comment"
+  insert-line "$filename" "$line" "//${directive}"
+done
+
+go fmt ./...


### PR DESCRIPTION
The `nolint-insert` script runs `golangci-lint` and for every failure adds a code comment explicitly allowing that failure for that line of code. This is useful in scenarios where a new linter or function deprecation causes many violations, but the same PR that added the change cannot feasibly fix all outstanding violations. The solution is to comment current violations; effectively marking them for subsequent fixing and making it clear that the code that contains violations shouldn't be copied to new code.

Example use:

1. mark a function as deprecated;
2. run `script/nolint-insert`;
3. all callers of that function now have a `//nolint` directive.

From https://github.com/cli/cli/pull/5032
Ref. https://github.com/golangci/golangci-lint/issues/741