### PR TITLE
adds display name for codespaces

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -158,14 +158,15 @@ func (a *API) GetRepository(ctx context.Context, nwo string) (*Repository, error
 
 // Codespace represents a codespace.
 type Codespace struct {
-	Name       string              `json:"name"`
-	CreatedAt  string              `json:"created_at"`
-	LastUsedAt string              `json:"last_used_at"`
-	Owner      User                `json:"owner"`
-	Repository Repository          `json:"repository"`
-	State      string              `json:"state"`
-	GitStatus  CodespaceGitStatus  `json:"git_status"`
-	Connection CodespaceConnection `json:"connection"`
+	Name        string              `json:"name"`
+	CreatedAt   string              `json:"created_at"`
+	DisplayName string              `json:"display_name"`
+	LastUsedAt  string              `json:"last_used_at"`
+	Owner       User                `json:"owner"`
+	Repository  Repository          `json:"repository"`
+	State       string              `json:"state"`
+	GitStatus   CodespaceGitStatus  `json:"git_status"`
+	Connection  CodespaceConnection `json:"connection"`
 }
 
 type CodespaceGitStatus struct {
@@ -195,6 +196,7 @@ type CodespaceConnection struct {
 
 // CodespaceFields is the list of exportable fields for a codespace.
 var CodespaceFields = []string{
+	"displayName",
 	"name",
 	"owner",
 	"repository",

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -259,11 +259,18 @@ func (c codespace) displayName(includeName, includeGitStatus bool) string {
 	}
 
 	if includeName {
+		var displayName = c.Name
+		if c.DisplayName != "" {
+			displayName = c.DisplayName
+		}
 		return fmt.Sprintf(
-			"%s: %s [%s]", c.Repository.FullName, branch, c.DisplayName,
+			"%s: %s (%s)", c.Repository.FullName, displayName, branch,
 		)
 	}
-	return c.Repository.FullName + ": " + branch
+	return fmt.Sprintf(
+		"%s: %s", c.Repository.FullName, branch,
+	)
+
 }
 
 // gitStatusDirty represents an unsaved changes status.

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -249,7 +249,7 @@ type codespace struct {
 }
 
 // displayName returns the repository nwo and branch.
-// If includeName is true, the name of the codespace is included.
+// If includeName is true, the name of the codespace (including displayName) is included.
 // If includeGitStatus is true, the branch will include a star if
 // the codespace has unsaved changes.
 func (c codespace) displayName(includeName, includeGitStatus bool) string {
@@ -260,7 +260,7 @@ func (c codespace) displayName(includeName, includeGitStatus bool) string {
 
 	if includeName {
 		return fmt.Sprintf(
-			"%s: %s [%s]", c.Repository.FullName, branch, c.Name,
+			"%s: %s [%s]", c.Repository.FullName, branch, c.DisplayName,
 		)
 	}
 	return c.Repository.FullName + ": " + branch

--- a/pkg/cmd/codespace/common_test.go
+++ b/pkg/cmd/codespace/common_test.go
@@ -1,0 +1,132 @@
+package codespace
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+)
+
+func Test_codespace_displayName(t *testing.T) {
+	type fields struct {
+		Codespace *api.Codespace
+	}
+	type args struct {
+		includeName      bool
+		includeGitStatus bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "No included name or gitstatus",
+			fields: fields{
+				Codespace: &api.Codespace{
+					GitStatus: api.CodespaceGitStatus{
+						Ref: "trunk",
+					},
+					Repository: api.Repository{
+						FullName: "cli/cli",
+					},
+					DisplayName: "scuba steve",
+				},
+			},
+			args: args{
+				includeName:      false,
+				includeGitStatus: false,
+			},
+			want: "cli/cli: trunk",
+		},
+		{
+			name: "No included name - included gitstatus - no unsaved changes",
+			fields: fields{
+				Codespace: &api.Codespace{
+					GitStatus: api.CodespaceGitStatus{
+						Ref: "trunk",
+					},
+					Repository: api.Repository{
+						FullName: "cli/cli",
+					},
+					DisplayName: "scuba steve",
+				},
+			},
+			args: args{
+				includeName:      false,
+				includeGitStatus: true,
+			},
+			want: "cli/cli: trunk",
+		},
+		{
+			name: "No included name - included gitstatus - unsaved changes",
+			fields: fields{
+				Codespace: &api.Codespace{
+					GitStatus: api.CodespaceGitStatus{
+						Ref:                  "trunk",
+						HasUncommitedChanges: true,
+					},
+					Repository: api.Repository{
+						FullName: "cli/cli",
+					},
+					DisplayName: "scuba steve",
+				},
+			},
+			args: args{
+				includeName:      false,
+				includeGitStatus: true,
+			},
+			want: "cli/cli: trunk*",
+		},
+		{
+			name: "Included name - included gitstatus - unsaved changes",
+			fields: fields{
+				Codespace: &api.Codespace{
+					GitStatus: api.CodespaceGitStatus{
+						Ref:                  "trunk",
+						HasUncommitedChanges: true,
+					},
+					Repository: api.Repository{
+						FullName: "cli/cli",
+					},
+					DisplayName: "scuba steve",
+				},
+			},
+			args: args{
+				includeName:      true,
+				includeGitStatus: true,
+			},
+			want: "cli/cli: scuba steve (trunk*)",
+		},
+		{
+			name: "Included name - included gitstatus - no unsaved changes",
+			fields: fields{
+				Codespace: &api.Codespace{
+					GitStatus: api.CodespaceGitStatus{
+						Ref:                  "trunk",
+						HasUncommitedChanges: false,
+					},
+					Repository: api.Repository{
+						FullName: "cli/cli",
+					},
+					DisplayName: "scuba steve",
+				},
+			},
+			args: args{
+				includeName:      true,
+				includeGitStatus: true,
+			},
+			want: "cli/cli: scuba steve (trunk)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := codespace{
+				Codespace: tt.fields.Codespace,
+			}
+			if got := c.displayName(tt.args.includeName, tt.args.includeGitStatus); got != tt.want {
+				t.Errorf("codespace.displayName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -54,6 +54,7 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 	tp := utils.NewTablePrinter(a.io)
 	if tp.IsTTY() {
 		tp.AddField("NAME", nil, nil)
+		tp.AddField("DISPLAY NAME", nil, nil)
 		tp.AddField("REPOSITORY", nil, nil)
 		tp.AddField("BRANCH", nil, nil)
 		tp.AddField("STATE", nil, nil)
@@ -74,6 +75,7 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 		}
 
 		tp.AddField(c.Name, nil, cs.Yellow)
+		tp.AddField(c.DisplayName, nil, cs.Blue)
 		tp.AddField(c.Repository.FullName, nil, nil)
 		tp.AddField(c.branchWithGitStatus(), nil, cs.Cyan)
 		tp.AddField(c.State, nil, stateColor)

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -54,7 +54,6 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 	tp := utils.NewTablePrinter(a.io)
 	if tp.IsTTY() {
 		tp.AddField("NAME", nil, nil)
-		tp.AddField("DISPLAY NAME", nil, nil)
 		tp.AddField("REPOSITORY", nil, nil)
 		tp.AddField("BRANCH", nil, nil)
 		tp.AddField("STATE", nil, nil)
@@ -74,8 +73,11 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 			stateColor = cs.Green
 		}
 
-		tp.AddField(c.Name, nil, cs.Yellow)
-		tp.AddField(c.DisplayName, nil, cs.Blue)
+		nameField := c.Name
+		if c.DisplayName != "" {
+			nameField = fmt.Sprintf("%s (%s)", nameField, c.DisplayName)
+		}
+		tp.AddField(nameField, nil, cs.Yellow)
 		tp.AddField(c.Repository.FullName, nil, nil)
 		tp.AddField(c.branchWithGitStatus(), nil, cs.Cyan)
 		tp.AddField(c.State, nil, stateColor)

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -73,11 +73,7 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 			stateColor = cs.Green
 		}
 
-		nameField := c.Name
-		if c.DisplayName != "" {
-			nameField = fmt.Sprintf("%s (%s)", nameField, c.DisplayName)
-		}
-		tp.AddField(nameField, nil, cs.Yellow)
+		tp.AddField(c.Name, nil, cs.Yellow)
 		tp.AddField(c.Repository.FullName, nil, nil)
 		tp.AddField(c.branchWithGitStatus(), nil, cs.Cyan)
 		tp.AddField(c.State, nil, stateColor)


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #5042 

The displayname is only available when using `list --json`

```bash
@veverkap ➜ /workspaces/cli (add_display_name) $ bin/gh cs list --json displayName
[
  {
    "displayName": "refactored chainsaw"
  }
]
@veverkap ➜ /workspaces/cli (add_display_name) $ bin/gh cs list
NAME                         REPOSITORY  BRANCH            STATE      CREATED AT
veverkap-cli-cli-qjv972x6xj  cli/cli     add_display_name  Available  3d
```