### PR TITLE
Fix disabled_inactivity workflow can be changed to enable

### DIFF
--- a/pkg/cmd/workflow/enable/enable.go
+++ b/pkg/cmd/workflow/enable/enable.go
@@ -67,7 +67,7 @@ func runEnable(opts *EnableOptions) error {
 		return fmt.Errorf("could not determine base repo: %w", err)
 	}
 
-	states := []shared.WorkflowState{shared.DisabledManually}
+	states := []shared.WorkflowState{shared.DisabledManually, shared.DisabledInactivity}
 	workflow, err := shared.ResolveWorkflow(
 		opts.IO, client, repo, opts.Prompt, opts.Selector, states)
 	if err != nil {

--- a/pkg/cmd/workflow/enable/enable_test.go
+++ b/pkg/cmd/workflow/enable/enable_test.go
@@ -181,6 +181,35 @@ func TestEnableRun(t *testing.T) {
 			wantOut: "✓ Enabled a disabled workflow\n",
 		},
 		{
+			name: "tty name arg inactivity workflow",
+			opts: &EnableOptions{
+				Selector: "a disabled inactivity workflow",
+			},
+			tty: true,
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a disabled inactivity workflow"),
+					httpmock.StatusStringResponse(404, "not found"))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
+					httpmock.JSONResponse(shared.WorkflowsPayload{
+						Workflows: []shared.Workflow{
+							shared.AWorkflow,
+							shared.DisabledInactivityWorkflow,
+							shared.UniqueDisabledWorkflow,
+							shared.AnotherWorkflow,
+						},
+					}))
+				reg.Register(
+					httpmock.REST("PUT", "repos/OWNER/REPO/actions/workflows/1206/enable"),
+					httpmock.StatusStringResponse(204, "{}"))
+			},
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne(1)
+			},
+			wantOut: "✓ Enabled a disabled inactivity workflow\n",
+		},
+		{
 			name: "tty ID arg",
 			opts: &EnableOptions{
 				Selector: "456",
@@ -235,6 +264,30 @@ func TestEnableRun(t *testing.T) {
 					}))
 				reg.Register(
 					httpmock.REST("PUT", "repos/OWNER/REPO/actions/workflows/1314/enable"),
+					httpmock.StatusStringResponse(204, "{}"))
+			},
+		},
+		{
+			name: "nontty name arg inactivity workflow",
+			opts: &EnableOptions{
+				Selector: "a disabled inactivity workflow",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a disabled inactivity workflow"),
+					httpmock.StatusStringResponse(404, "not found"))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
+					httpmock.JSONResponse(shared.WorkflowsPayload{
+						Workflows: []shared.Workflow{
+							shared.AWorkflow,
+							shared.DisabledInactivityWorkflow,
+							shared.UniqueDisabledWorkflow,
+							shared.AnotherWorkflow,
+						},
+					}))
+				reg.Register(
+					httpmock.REST("PUT", "repos/OWNER/REPO/actions/workflows/1206/enable"),
 					httpmock.StatusStringResponse(204, "{}"))
 			},
 		},

--- a/pkg/cmd/workflow/shared/shared.go
+++ b/pkg/cmd/workflow/shared/shared.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	Active           WorkflowState = "active"
-	DisabledManually WorkflowState = "disabled_manually"
+	Active             WorkflowState = "active"
+	DisabledManually   WorkflowState = "disabled_manually"
+	DisabledInactivity WorkflowState = "disabled_inactivity"
 )
 
 type WorkflowState string

--- a/pkg/cmd/workflow/shared/test.go
+++ b/pkg/cmd/workflow/shared/test.go
@@ -15,6 +15,13 @@ var DisabledWorkflow = Workflow{
 	State: DisabledManually,
 }
 
+var DisabledInactivityWorkflow = Workflow{
+	Name:  "a disabled inactivity workflow",
+	ID:    1206,
+	Path:  ".github/workflows/disabledInactivity.yml",
+	State: DisabledInactivity,
+}
+
 var AnotherDisabledWorkflow = Workflow{
 	Name:  "a disabled workflow",
 	ID:    1213,


### PR DESCRIPTION
Workflow in disabled_inactivity state could not be enabled, so it has been fixed.
Added state for disabled_inactivity to shared package.

Fixes #5025 