### PR TITLE
Fix legacy prompt stub that is tripping up the linter

### DIFF
--- a/pkg/cmd/workflow/enable/enable_test.go
+++ b/pkg/cmd/workflow/enable/enable_test.go
@@ -204,9 +204,6 @@ func TestEnableRun(t *testing.T) {
 					httpmock.REST("PUT", "repos/OWNER/REPO/actions/workflows/1206/enable"),
 					httpmock.StatusStringResponse(204, "{}"))
 			},
-			askStubs: func(as *prompt.AskStubber) {
-				as.StubOne(1)
-			},
 			wantOut: "✓ Enabled a disabled inactivity workflow\n",
 		},
 		{


### PR DESCRIPTION
The CI failure [currently affecting trunk](https://github.com/cli/cli/actions/runs/1709008243) is the product of merging both https://github.com/cli/cli/pull/5047 and https://github.com/cli/cli/pull/5032.