### PR TITLE
cmd/api: Respect `GH_REPO` when substituting `{owner}/{repo}`

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -71,10 +71,12 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 			The endpoint argument should either be a path of a GitHub API v3 endpoint, or
 			"graphql" to access the GitHub API v4.
 
-			Placeholder values "{owner}", "{repo}", and "{branch}" in the endpoint argument will
-			get replaced with values from the repository of the current directory. Note that in
-			some shells, for example PowerShell, you may need to enclose any value that contains
-			"{...}" in quotes to prevent the shell from applying special meaning to curly braces.
+			Placeholder values "{owner}", "{repo}", and "{branch}" in the endpoint
+			argument will get replaced with values from the repository of the current
+			directory or the repository specified in the GH_REPO environment variable.
+			Note that in some shells, for example PowerShell, you may need to enclose
+			any value that contains "{...}" in quotes to prevent the shell from
+			applying special meaning to curly braces.
 
 			The default HTTP request method is "GET" normally and "POST" if any parameters
 			were added. Override the method with %[1]s--method%[1]s.
@@ -167,6 +169,9 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 			`),
 		},
 		Args: cobra.ExactArgs(1),
+		PreRun: func(c *cobra.Command, args []string) {
+			opts.BaseRepo = cmdutil.OverrideBaseRepoFunc(f, "")
+		},
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.RequestPath = args[0]
 			opts.RequestMethodPassed = c.Flags().Changed("method")


### PR DESCRIPTION
- Fixes #5061.
- Previously, a user could set `GH_REPO=TestOrg/repo` and run `gh api repos/{owner}/{repo}/releases` expecting to see the releases from `TestOrg/repo` but instead see releases from the current git repo they're in.
- Or, worse, if the user ran the command from outside of a git repo, they'd see a "not a git repo" error from git itself.
- This was different to `GH_REPO=TestOrg/repo gh release list` which successfully lists `TestOrg/repo`'s releases.

TODO and NOTES:

- [x] ~Test cases. Not sure how to do that tonight. For manual reproduction of the issue and testing my fix, I used a repo of mine that had releases, and one that did not (as you'll see from the before/after output below).~ Not necessary now we use `OverrideBaseRepoFunc` in the Cobra command definition. 
- [x] I found an `EnableRepoOverride` function, but I couldn't work out how to use it with only `GH_REPO`. It seemed to relate heavily to the `--repo` flag, and telling users to specify `--repo` in `gh api` seemed weird.
- [x] This might be overly clunky in terms of code style and Go conventions and abstractions for this specific codebase - it's been a while. Comments, instruction and improvements welcome!

(Also worth noting I'm doing this right now entirely in a personal capacity for fun - it's an open source repo after all!)

----

Before:

```shell
$ cd repos/issyl0/not-a-git-repo
$ GH_REPO=issyl0/terraform-provider-improvmx gh api repos/{owner}/{repo}/releases
unable to expand placeholder in path: fatal: not a git repository (or any of the parent directories): .git
/opt/homebrew/bin/git: exit status 128
```

```shell
$ cd repos/issyl0/a-git-repo-with-no-releases
$ GH_REPO=issyl0/terraform-provider-improvmx gh api repos/{owner}/{repo}/releases
[]
```

After:

```shell
$ cd repos/issyl0/not-a-git-repo
$ GH_REPO=issyl0/terraform-provider-improvmx ../../cli/cli/bin/gh api repos/{owner}/{repo}/releases
[lots of JSON about GH_REPO's releases - success]
```

```shell
$ cd repos/issyl0/a-git-repo-with-no-releases
$ GH_REPO=issyl0/terraform-provider-improvmx ../../cli/cli/bin/gh api repos/{owner}/{repo}/releases
[lots of JSON about GH_REPO's releases - success]
```