### PR TITLE
Add retries to Codespaces API client

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -693,7 +693,7 @@ func (a *API) setHeaders(req *http.Request) {
 // withRetry takes a generic function that sends an http request and retries
 // only when the returned response has a >=500 status code.
 func (a *API) withRetry(f func() (*http.Response, error)) (resp *http.Response, err error) {
-	for i := time.Duration(0); i < 5; i++ {
+	for i := 0; i < 5; i++ {
 		resp, err = f()
 		if err != nil {
 			return nil, err
@@ -701,7 +701,7 @@ func (a *API) withRetry(f func() (*http.Response, error)) (resp *http.Response, 
 		if resp.StatusCode < 500 {
 			break
 		}
-		time.Sleep(a.retryBackoff * (i + 1))
+		time.Sleep(a.retryBackoff * (time.Duration(i) + 1))
 	}
 	return resp, err
 }

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -698,10 +698,10 @@ func (a *API) withRetry(f func() (*http.Response, error)) (resp *http.Response, 
 		if err != nil {
 			return nil, err
 		}
-		if resp.StatusCode >= 500 {
-			time.Sleep(a.retryBackoff * (i + 1))
-			continue
+		if resp.StatusCode < 500 {
+			break
 		}
+		time.Sleep(a.retryBackoff * (i + 1))
 	}
 	return resp, err
 }

--- a/internal/codespaces/api/api_test.go
+++ b/internal/codespaces/api/api_test.go
@@ -116,10 +116,10 @@ func TestListCodespaces_unlimited(t *testing.T) {
 }
 
 func TestRetries(t *testing.T) {
-	var retryCount int
+	var callCount int
 	csName := "test_codespace"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if retryCount == 3 {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if callCount == 3 {
 			err := json.NewEncoder(w).Encode(Codespace{
 				Name: csName,
 			})
@@ -128,9 +128,10 @@ func TestRetries(t *testing.T) {
 			}
 			return
 		}
-		retryCount++
+		callCount++
 		w.WriteHeader(502)
-	}))
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handler(w, r) }))
 	t.Cleanup(srv.Close)
 	a := &API{
 		githubAPI: srv.URL,
@@ -140,8 +141,28 @@ func TestRetries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if retryCount != 3 {
-		t.Fatalf("expected at least 2 retries but got %d", retryCount)
+	if callCount != 3 {
+		t.Fatalf("expected at least 2 retries but got %d", callCount)
+	}
+	if cs.Name != csName {
+		t.Fatalf("expected codespace name to be %q but got %q", csName, cs.Name)
+	}
+	callCount = 0
+	handler = func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		err := json.NewEncoder(w).Encode(Codespace{
+			Name: csName,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	cs, err = a.GetCodespace(context.Background(), "test", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected no retries but got %d calls", callCount)
 	}
 	if cs.Name != csName {
 		t.Fatalf("expected codespace name to be %q but got %q", csName, cs.Name)

--- a/internal/codespaces/api/api_test.go
+++ b/internal/codespaces/api/api_test.go
@@ -120,9 +120,12 @@ func TestRetries(t *testing.T) {
 	csName := "test_codespace"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if retryCount == 3 {
-			json.NewEncoder(w).Encode(Codespace{
+			err := json.NewEncoder(w).Encode(Codespace{
 				Name: csName,
 			})
+			if err != nil {
+				t.Fatal(err)
+			}
 			return
 		}
 		retryCount++


### PR DESCRIPTION
This PR adds custom retries to a couple of our Codespaces API calls that may return a 502. Since we only need two calls to be retried for now, I did not introduce a new library that implements retries on the `*http.Client` but instead just write a small 10 line function. 

If more and more API calls need to be retried, then we can certainly add a more generic solution. 

Closes internal issue codespaces#5474