### PR TITLE
Trim leading and trailing whitespace when setting secrets from stdin

### DIFF
--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -376,7 +376,7 @@ func getBody(opts *SetOptions) ([]byte, error) {
 		return nil, fmt.Errorf("failed to read from standard input: %w", err)
 	}
 
-	return bytes.TrimSpace(body), nil
+	return bytes.TrimRight(body, "\r\n"), nil
 }
 
 func mapRepoNamesToIDs(client *api.Client, host, defaultOwner string, repositoryNames []string) ([]int64, error) {

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -1,6 +1,7 @@
 package set
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -375,7 +376,7 @@ func getBody(opts *SetOptions) ([]byte, error) {
 		return nil, fmt.Errorf("failed to read from standard input: %w", err)
 	}
 
-	return body, nil
+	return bytes.TrimSpace(body), nil
 }
 
 func mapRepoNamesToIDs(client *api.Client, host, defaultOwner string, repositoryNames []string) ([]int64, error) {

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -459,6 +459,11 @@ func Test_getBody(t *testing.T) {
 			want:  "a secret",
 			stdin: "a secret",
 		},
+		{
+			name:  "from stdin with leading and trailing whitespace",
+			want:  "a secret",
+			stdin: "\ta secret\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -476,7 +481,7 @@ func Test_getBody(t *testing.T) {
 			})
 			assert.NoError(t, err)
 
-			assert.Equal(t, string(body), tt.want)
+			assert.Equal(t, tt.want, string(body))
 		})
 	}
 }

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -460,9 +460,9 @@ func Test_getBody(t *testing.T) {
 			stdin: "a secret",
 		},
 		{
-			name:  "from stdin with leading and trailing whitespace",
+			name:  "from stdin with trailing newline character",
 			want:  "a secret",
-			stdin: "\ta secret\n",
+			stdin: "a secret\n",
 		},
 	}
 


### PR DESCRIPTION
This PR changes the behavior of the `secret set` command to trim leading and trailing whitespace from secrets that are input from `stdin`. The issue this solves only mentions trailing whitespace but I could not think of a reason to not trim leading whitespace as well. 

closes https://github.com/cli/cli/issues/5031