### PR TITLE
Add GH_HOST to hosts list if it has corresponding auth token

### DIFF
--- a/internal/config/from_env.go
+++ b/internal/config/from_env.go
@@ -44,12 +44,9 @@ func (c *envConfig) Hosts() ([]string, error) {
 	hostSet := set.NewStringSet()
 	hostSet.AddValues(hosts)
 
-	// If GH_HOST is set and there is a valid environment variable
-	// token for the host then add it to list.
+	// If GH_HOST is set then add it to list.
 	if host := os.Getenv(GH_HOST); host != "" {
-		if token, _ := AuthTokenFromEnv(host); token != "" {
-			hostSet.Add(host)
-		}
+		hostSet.Add(host)
 	}
 
 	// If there is a valid environment variable token for the

--- a/internal/config/from_env.go
+++ b/internal/config/from_env.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 
 	"github.com/cli/cli/v2/internal/ghinstance"
@@ -57,7 +58,10 @@ func (c *envConfig) Hosts() ([]string, error) {
 		hostSet.Add(ghinstance.Default())
 	}
 
-	return hostSet.ToSlice(), nil
+	s := hostSet.ToSlice()
+	// If default host is in list then move it to the front.
+	sort.SliceStable(s, func(i, j int) bool { return s[i] == ghinstance.Default() })
+	return s, nil
 }
 
 func (c *envConfig) DefaultHost() (string, error) {

--- a/internal/config/from_env_test.go
+++ b/internal/config/from_env_test.go
@@ -264,7 +264,7 @@ func TestInheritEnv(t *testing.T) {
 			GITHUB_TOKEN: "ENVTOKEN",
 			hostname:     "github.com",
 			wants: wants{
-				hosts:     []string{"example.org", "github.com"},
+				hosts:     []string{"github.com", "example.org"},
 				token:     "ENVTOKEN",
 				source:    "GITHUB_TOKEN",
 				writeable: false,
@@ -280,7 +280,7 @@ func TestInheritEnv(t *testing.T) {
 			GH_TOKEN: "ENVTOKEN",
 			hostname: "github.com",
 			wants: wants{
-				hosts:     []string{"example.org", "github.com"},
+				hosts:     []string{"github.com", "example.org"},
 				token:     "ENVTOKEN",
 				source:    "GH_TOKEN",
 				writeable: false,

--- a/internal/config/from_env_test.go
+++ b/internal/config/from_env_test.go
@@ -44,6 +44,7 @@ func TestInheritEnv(t *testing.T) {
 	tests := []struct {
 		name                    string
 		baseConfig              string
+		GH_HOST                 string
 		GITHUB_TOKEN            string
 		GITHUB_ENTERPRISE_TOKEN string
 		GH_TOKEN                string
@@ -263,7 +264,7 @@ func TestInheritEnv(t *testing.T) {
 			GITHUB_TOKEN: "ENVTOKEN",
 			hostname:     "github.com",
 			wants: wants{
-				hosts:     []string{"github.com", "example.org"},
+				hosts:     []string{"example.org", "github.com"},
 				token:     "ENVTOKEN",
 				source:    "GITHUB_TOKEN",
 				writeable: false,
@@ -279,15 +280,29 @@ func TestInheritEnv(t *testing.T) {
 			GH_TOKEN: "ENVTOKEN",
 			hostname: "github.com",
 			wants: wants{
-				hosts:     []string{"github.com", "example.org"},
+				hosts:     []string{"example.org", "github.com"},
 				token:     "ENVTOKEN",
 				source:    "GH_TOKEN",
+				writeable: false,
+			},
+		},
+		{
+			name:                "GH_HOST adds host entry when paired with environment token",
+			baseConfig:          ``,
+			GH_HOST:             "example.org",
+			GH_ENTERPRISE_TOKEN: "GH_ENTERPRISE_TOKEN",
+			hostname:            "example.org",
+			wants: wants{
+				hosts:     []string{"example.org"},
+				token:     "GH_ENTERPRISE_TOKEN",
+				source:    "GH_ENTERPRISE_TOKEN",
 				writeable: false,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			setenv(t, "GH_HOST", tt.GH_HOST)
 			setenv(t, "GITHUB_TOKEN", tt.GITHUB_TOKEN)
 			setenv(t, "GITHUB_ENTERPRISE_TOKEN", tt.GITHUB_ENTERPRISE_TOKEN)
 			setenv(t, "GH_TOKEN", tt.GH_TOKEN)

--- a/pkg/set/string_set.go
+++ b/pkg/set/string_set.go
@@ -10,6 +10,7 @@ type stringSet struct {
 func NewStringSet() *stringSet {
 	s := &stringSet{}
 	s.m = make(map[string]struct{})
+	s.v = []string{}
 	return s
 }
 


### PR DESCRIPTION
This PR changes the behavior of `envConfig.Hosts()` to now include in the return set `GH_HOST` if it has a corresponding authentication token from one of the numerous environment variable token locations. This solves the case where `auth` commands were displaying that a user was not authenticated despite having both `GH_HOST` and a corresponding authentication token environment variable set. 

Closes https://github.com/cli/cli/issues/4576