### PR TITLE
Allow PR create to create PRs with numerical branch names

### DIFF
--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -110,7 +110,13 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 			f.branchName = branch
 		}
 	} else if f.prNumber == 0 {
-		if prNumber, err := strconv.Atoi(strings.TrimPrefix(opts.Selector, "#")); err == nil {
+		// If opts.Selector is a valid number then assume it is the
+		// PR number unless opts.BaseBranch is specified. This is a
+		// special case for PR create command which will always want
+		// to assume that a numerical selector is a branch name rather
+		// than PR number.
+		prNumber, err := strconv.Atoi(strings.TrimPrefix(opts.Selector, "#"))
+		if opts.BaseBranch == "" && err == nil {
 			f.prNumber = prNumber
 		} else {
 			f.branchName = opts.Selector

--- a/pkg/cmd/pr/shared/finder_test.go
+++ b/pkg/cmd/pr/shared/finder_test.go
@@ -50,6 +50,35 @@ func TestFind(t *testing.T) {
 			wantRepo: "https://github.com/OWNER/REPO",
 		},
 		{
+			name: "number argument with base branch",
+			args: args{
+				selector:   "13",
+				baseBranch: "main",
+				fields:     []string{"id", "number"},
+				baseRepoFn: func() (ghrepo.Interface, error) {
+					return ghrepo.FromFullName("OWNER/REPO")
+				},
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query PullRequestForBranch\b`),
+					httpmock.StringResponse(`{"data":{"repository":{
+						"pullRequests":{"nodes":[
+							{
+								"number": 123,
+								"state": "OPEN",
+								"baseRefName": "main",
+								"headRefName": "13",
+								"isCrossRepository": false,
+								"headRepositoryOwner": {"login":"OWNER"}
+							}
+						]}
+					}}}`))
+			},
+			wantPR:   123,
+			wantRepo: "https://github.com/OWNER/REPO",
+		},
+		{
 			name: "baseRepo is error",
 			args: args{
 				selector: "13",


### PR DESCRIPTION
This PR adds a special case for the `pr create` command so that it can create PRs on branches that have numerical names. It adds a special case to the pull request finder where if the `BaseBranch` option is specified then always interpret the `Selector` option as a branch name rather than a potential PR number. The `pr create` command is the only command that uses the `BaseBranch` option functionality. 

Closes https://github.com/cli/cli/issues/3885