### PR TITLE
Add non-local PR template support

### DIFF
--- a/pkg/cmd/pr/shared/templates.go
+++ b/pkg/cmd/pr/shared/templates.go
@@ -128,7 +128,7 @@ func hasTemplateSupport(httpClient *http.Client, hostname string, isPR bool) (bo
 	}
 
 	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(hostname), httpClient)
-	err := gql.QueryNamed(context.Background(), "Templates_fields", &featureDetection, nil)
+	err := gql.QueryNamed(context.Background(), "IssueTemplates_fields", &featureDetection, nil)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cmd/pr/shared/templates_test.go
+++ b/pkg/cmd/pr/shared/templates_test.go
@@ -24,7 +24,7 @@ func TestTemplateManager_hasAPI(t *testing.T) {
 	defer tr.Verify(t)
 
 	tr.Register(
-		httpmock.GraphQL(`query Templates_fields\b`),
+		httpmock.GraphQL(`query IssueTemplates_fields\b`),
 		httpmock.StringResponse(`{"data":{
 			"Repository": {
 				"fields": [
@@ -86,7 +86,7 @@ func TestTemplateManager_hasAPI_PullRequest(t *testing.T) {
 	defer tr.Verify(t)
 
 	tr.Register(
-		httpmock.GraphQL(`query Templates_fields\b`),
+		httpmock.GraphQL(`query IssueTemplates_fields\b`),
 		httpmock.StringResponse(`{"data":{
 			"Repository": {
 				"fields": [

--- a/pkg/cmd/pr/shared/templates_test.go
+++ b/pkg/cmd/pr/shared/templates_test.go
@@ -24,7 +24,7 @@ func TestTemplateManager_hasAPI(t *testing.T) {
 	defer tr.Verify(t)
 
 	tr.Register(
-		httpmock.GraphQL(`query IssueTemplates_fields\b`),
+		httpmock.GraphQL(`query Templates_fields\b`),
 		httpmock.StringResponse(`{"data":{
 			"Repository": {
 				"fields": [
@@ -86,7 +86,7 @@ func TestTemplateManager_hasAPI_PullRequest(t *testing.T) {
 	defer tr.Verify(t)
 
 	tr.Register(
-		httpmock.GraphQL(`query PullRequestTemplates_fields\b`),
+		httpmock.GraphQL(`query Templates_fields\b`),
 		httpmock.StringResponse(`{"data":{
 			"Repository": {
 				"fields": [
@@ -127,6 +127,6 @@ func TestTemplateManager_hasAPI_PullRequest(t *testing.T) {
 	tpl, err := m.Choose()
 
 	assert.NoError(t, err)
-	assert.Equal(t, "bug_pr.md", tpl.NameForSubmit())
+	assert.Equal(t, "", tpl.NameForSubmit())
 	assert.Equal(t, "I fixed a problem", string(tpl.Body()))
 }

--- a/pkg/cmd/pr/shared/templates_test.go
+++ b/pkg/cmd/pr/shared/templates_test.go
@@ -63,14 +63,70 @@ func TestTemplateManager_hasAPI(t *testing.T) {
 
 	assert.Equal(t, "LEGACY", string(m.LegacyBody()))
 
-	//nolint:staticcheck // SA1019: prompt.InitAskStubber is deprecated: use NewAskStubber
-	as, askRestore := prompt.InitAskStubber()
-	defer askRestore()
+	as := prompt.NewAskStubber(t)
+	as.StubPrompt("Choose a template").
+		AssertOptions([]string{"Bug report", "Feature request", "Open a blank issue"}).
+		AnswerWith("Feature request")
 
-	//nolint:staticcheck // SA1019: as.StubOne is deprecated: use StubPrompt
-	as.StubOne(1) // choose "Feature Request"
 	tpl, err := m.Choose()
+
 	assert.NoError(t, err)
 	assert.Equal(t, "Feature request", tpl.NameForSubmit())
 	assert.Equal(t, "I need a feature", string(tpl.Body()))
+}
+
+func TestTemplateManager_hasAPI_PullRequest(t *testing.T) {
+	rootDir := t.TempDir()
+	legacyTemplateFile := filepath.Join(rootDir, ".github", "PULL_REQUEST_TEMPLATE.md")
+	_ = os.MkdirAll(filepath.Dir(legacyTemplateFile), 0755)
+	_ = ioutil.WriteFile(legacyTemplateFile, []byte("LEGACY"), 0644)
+
+	tr := httpmock.Registry{}
+	httpClient := &http.Client{Transport: &tr}
+	defer tr.Verify(t)
+
+	tr.Register(
+		httpmock.GraphQL(`query PullRequestTemplates_fields\b`),
+		httpmock.StringResponse(`{"data":{
+			"Repository": {
+				"fields": [
+					{"name": "foo"},
+					{"name": "pullRequestTemplates"}
+				]
+			}
+		}}`))
+	tr.Register(
+		httpmock.GraphQL(`query PullRequestTemplates\b`),
+		httpmock.StringResponse(`{"data":{"repository":{
+			"pullRequestTemplates": [
+				{"filename": "bug_pr.md", "body": "I fixed a problem"},
+				{"filename": "feature_pr.md", "body": "I added a feature"}
+			]
+		}}}`))
+
+	m := templateManager{
+		repo:         ghrepo.NewWithHost("OWNER", "REPO", "example.com"),
+		rootDir:      rootDir,
+		allowFS:      true,
+		isPR:         true,
+		httpClient:   httpClient,
+		cachedClient: httpClient,
+	}
+
+	hasTemplates, err := m.HasTemplates()
+	assert.NoError(t, err)
+	assert.True(t, hasTemplates)
+
+	assert.Equal(t, "LEGACY", string(m.LegacyBody()))
+
+	as := prompt.NewAskStubber(t)
+	as.StubPrompt("Choose a template").
+		AssertOptions([]string{"bug_pr.md", "feature_pr.md", "Open a blank pull request"}).
+		AnswerWith("bug_pr.md")
+
+	tpl, err := m.Choose()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "bug_pr.md", tpl.NameForSubmit())
+	assert.Equal(t, "I fixed a problem", string(tpl.Body()))
 }


### PR DESCRIPTION
This PR adds the ability to use non-local templates when opening a PR. It is mostly a copy of the work done for issue create templates.

Closes https://github.com/cli/cli/issues/838