### PR TITLE
Specify target to local tag SHA in release create

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1199,24 +1199,3 @@ func CreateRepoTransformToV4(apiClient *Client, hostname string, method string, 
 		IsPrivate: responsev3.Private,
 	}, nil
 }
-
-func RepoTagExists(httpClient *http.Client, repo ghrepo.Interface, tagName string) (bool, error) {
-	var query struct {
-		Repository struct {
-			Ref struct {
-				ID string
-			} `graphql:"ref(qualifiedName: $tagName)"`
-		} `graphql:"repository(owner: $owner, name: $name)"`
-	}
-
-	variables := map[string]interface{}{
-		"owner":   githubv4.String(repo.RepoOwner()),
-		"name":    githubv4.String(repo.RepoName()),
-		"tagName": githubv4.String(tagName),
-	}
-
-	gql := graphQLClient(httpClient, repo.RepoHost())
-	err := gql.QueryNamed(context.Background(), "RepositoryFindTag", &query, variables)
-
-	return query.Repository.Ref.ID != "", err
-}

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -241,6 +241,7 @@ func createRun(opts *CreateOptions) error {
 			var tagSha string
 			headRef := opts.TagName
 			tagSha, tagDescription, _ = gitTagInfo(opts.TagName)
+
 			if tagDescription == "" {
 				if opts.Target != "" {
 					// TODO: use the remote-tracking version of the branch ref
@@ -248,19 +249,20 @@ func createRun(opts *CreateOptions) error {
 				} else {
 					headRef = "HEAD"
 				}
-			} else {
-				// Local tag exists and target not specified so use tag
-				// SHA as target. This prevents the scenario where the
-				// user has a local unpushed tag and then when creating a
-				// release the API creates a new tag with the same name
-				// pointing to the repos default branch. This is confusing
-				// when the local unpushed tag was pointing to a different SHA.
-				// This will ensure that when the remote tag gets created
-				// it points to the correct commit.
-				if opts.Target == "" {
-					opts.Target = tagSha
-				}
 			}
+
+			// Local tag exists and target not specified so use tag
+			// SHA as target. This prevents the scenario where the
+			// user has a local unpushed tag and then when creating a
+			// release the API creates a new tag with the same name
+			// pointing to the repos default branch. This is confusing
+			// when the local unpushed tag was pointing to a different SHA.
+			// This will ensure that when the remote tag gets created
+			// it points to the correct commit.
+			if opts.Target == "" && tagSha != "" {
+				opts.Target = tagSha
+			}
+
 			if generatedNotes == nil {
 				if prevTag, err := detectPreviousTag(headRef); err == nil {
 					commits, _ := changelogForRange(fmt.Sprintf("%s..%s", prevTag, headRef))

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -179,14 +179,14 @@ func createRun(opts *CreateOptions) error {
 
 	var existingTag bool
 	if opts.TagName == "" {
-		remoteTags, err := getTags(httpClient, baseRepo, 5)
+		tags, err := getTags(httpClient, baseRepo, 5)
 		if err != nil {
 			return err
 		}
 
-		if len(remoteTags) != 0 {
-			options := make([]string, len(remoteTags))
-			for i, tag := range remoteTags {
+		if len(tags) != 0 {
+			options := make([]string, len(tags))
+			for i, tag := range tags {
 				options[i] = tag.Name
 			}
 			createNewTagOption := "Create a new tag"
@@ -218,13 +218,13 @@ func createRun(opts *CreateOptions) error {
 		}
 	}
 
-	var localTagDescription string
+	var tagDescription string
 	if opts.RepoOverride == "" {
-		var localTagSHA string
-		localTagSHA, localTagDescription, _ = gitTagInfo(opts.TagName)
+		var tagSHA string
+		tagSHA, tagDescription, _ = gitTagInfo(opts.TagName)
 		// existingTag is a short cut to knowing that a tag already exists on the remote
-		if localTagSHA != "" && !existingTag {
-			remoteExists, err := remoteTagExists(httpClient, baseRepo, localTagSHA)
+		if tagSHA != "" && !existingTag {
+			remoteExists, err := remoteTagExists(httpClient, baseRepo, tagSHA)
 			if err != nil {
 				return err
 			}
@@ -256,7 +256,7 @@ func createRun(opts *CreateOptions) error {
 
 		if opts.RepoOverride == "" {
 			headRef := opts.TagName
-			if localTagDescription == "" {
+			if tagDescription == "" {
 				if opts.Target != "" {
 					// TODO: use the remote-tracking version of the branch ref
 					headRef = opts.Target
@@ -279,7 +279,7 @@ func createRun(opts *CreateOptions) error {
 		if generatedChangelog != "" {
 			editorOptions = append(editorOptions, "Write using commit log as template")
 		}
-		if localTagDescription != "" {
+		if tagDescription != "" {
 			editorOptions = append(editorOptions, "Write using git tag message as template")
 		}
 		editorOptions = append(editorOptions, "Leave blank")
@@ -323,7 +323,7 @@ func createRun(opts *CreateOptions) error {
 			editorContents = generatedChangelog
 		case "Write using git tag message as template":
 			openEditor = true
-			editorContents = localTagDescription
+			editorContents = tagDescription
 		case "Leave blank":
 			openEditor = false
 		default:

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -671,6 +671,7 @@ func Test_createRun_interactive(t *testing.T) {
 			runStubs: func(rs *run.CommandStubber) {
 				rs.Register(`git tag --list`, 0, "hello from annotated tag")
 				rs.Register(`git describe --tags --abbrev=0 v1\.2\.3\^`, 1, "")
+				rs.Register(`git rev-list -n 1 v1.2.3`, 0, "tagsha123")
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("POST", "repos/OWNER/REPO/releases/generate-notes"),
@@ -683,10 +684,11 @@ func Test_createRun_interactive(t *testing.T) {
 					}`))
 			},
 			wantParams: map[string]interface{}{
-				"body":       "hello from annotated tag",
-				"draft":      false,
-				"prerelease": false,
-				"tag_name":   "v1.2.3",
+				"body":             "hello from annotated tag",
+				"draft":            false,
+				"prerelease":       false,
+				"tag_name":         "v1.2.3",
+				"target_commitish": "tagsha123",
 			},
 			wantOut: "https://github.com/OWNER/REPO/releases/tag/v1.2.3\n",
 		},

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -529,7 +529,7 @@ func Test_createRun_interactive(t *testing.T) {
 					AssertOptions([]string{"Publish release", "Save as draft", "Cancel"}).AnswerWith("Publish release")
 			},
 			runStubs: func(rs *run.CommandStubber) {
-				rs.Register(`git tag --list`, 0, "tagsha123\n")
+				rs.Register(`git tag --list`, 1, "")
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "repos/OWNER/REPO/tags"), httpmock.StatusStringResponse(200, `[

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -529,7 +529,7 @@ func Test_createRun_interactive(t *testing.T) {
 					AssertOptions([]string{"Publish release", "Save as draft", "Cancel"}).AnswerWith("Publish release")
 			},
 			runStubs: func(rs *run.CommandStubber) {
-				rs.Register(`git tag --list`, 1, "")
+				rs.Register(`git tag --list`, 0, "tagsha123\n")
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "repos/OWNER/REPO/tags"), httpmock.StatusStringResponse(200, `[
@@ -669,9 +669,8 @@ func Test_createRun_interactive(t *testing.T) {
 				as.StubPrompt("Submit?").AnswerWith("Publish release")
 			},
 			runStubs: func(rs *run.CommandStubber) {
-				rs.Register(`git tag --list`, 0, "hello from annotated tag")
+				rs.Register(`git tag --list`, 0, "tagsha123\nhello from annotated tag")
 				rs.Register(`git describe --tags --abbrev=0 v1\.2\.3\^`, 1, "")
-				rs.Register(`git rev-list -n 1 v1.2.3`, 0, "tagsha123")
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("POST", "repos/OWNER/REPO/releases/generate-notes"),

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -673,7 +673,7 @@ func Test_createRun_interactive(t *testing.T) {
 				rs.Register(`git describe --tags --abbrev=0 v1\.2\.3\^`, 1, "")
 			},
 			httpStubs: func(reg *httpmock.Registry) {
-				reg.Register(httpmock.GraphQL("RepositoryFindTag"),
+				reg.Register(httpmock.GraphQL("RepositoryFindRef"),
 					httpmock.StringResponse(`{"data":{"repository":{"ref": {"id": "tag id"}}}}`))
 				reg.Register(httpmock.REST("POST", "repos/OWNER/REPO/releases/generate-notes"),
 					httpmock.StatusStringResponse(404, `{}`))
@@ -701,7 +701,7 @@ func Test_createRun_interactive(t *testing.T) {
 				rs.Register(`git tag --list`, 0, "tag exists")
 			},
 			httpStubs: func(reg *httpmock.Registry) {
-				reg.Register(httpmock.GraphQL("RepositoryFindTag"),
+				reg.Register(httpmock.GraphQL("RepositoryFindRef"),
 					httpmock.StringResponse(`{"data":{"repository":{"ref": {"id": ""}}}}`))
 			},
 			wantErr: "tag v1.2.3 exists locally but has not been pushed to OWNER/REPO, please push it before continuing or specify the `--target` flag to create a new tag",

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -673,6 +673,8 @@ func Test_createRun_interactive(t *testing.T) {
 				rs.Register(`git describe --tags --abbrev=0 v1\.2\.3\^`, 1, "")
 			},
 			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "repos/OWNER/REPO/git/tags/tagsha123"),
+					httpmock.StatusStringResponse(200, `{}`))
 				reg.Register(httpmock.REST("POST", "repos/OWNER/REPO/releases/generate-notes"),
 					httpmock.StatusStringResponse(404, `{}`))
 				reg.Register(httpmock.REST("POST", "repos/OWNER/REPO/releases"),
@@ -683,11 +685,10 @@ func Test_createRun_interactive(t *testing.T) {
 					}`))
 			},
 			wantParams: map[string]interface{}{
-				"body":             "hello from annotated tag",
-				"draft":            false,
-				"prerelease":       false,
-				"tag_name":         "v1.2.3",
-				"target_commitish": "tagsha123",
+				"body":       "hello from annotated tag",
+				"draft":      false,
+				"prerelease": false,
+				"tag_name":   "v1.2.3",
 			},
 			wantOut: "https://github.com/OWNER/REPO/releases/tag/v1.2.3\n",
 		},

--- a/pkg/cmd/release/create/http.go
+++ b/pkg/cmd/release/create/http.go
@@ -43,6 +43,11 @@ func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tagSHA stri
 	}
 	defer resp.Body.Close()
 
+	_, err = io.Copy(io.Discard, resp.Body)
+	if err != nil {
+		return false, err
+	}
+
 	return resp.StatusCode == 200, nil
 }
 

--- a/pkg/cmd/release/create/http.go
+++ b/pkg/cmd/release/create/http.go
@@ -2,6 +2,7 @@ package create
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/release/shared"
+	graphql "github.com/cli/shurcooL-graphql"
 )
 
 type tag struct {
@@ -26,9 +28,23 @@ type releaseNotes struct {
 
 var notImplementedError = errors.New("not implemented")
 
-func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tag string) (bool, error) {
-	qualifiedTagName := fmt.Sprintf("refs/tags/%s", tag)
-	return api.RepoTagExists(httpClient, repo, qualifiedTagName)
+func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tagName string) (bool, error) {
+	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
+	qualifiedTagName := fmt.Sprintf("refs/tags/%s", tagName)
+	var query struct {
+		Repository struct {
+			Ref struct {
+				ID string
+			} `graphql:"ref(qualifiedName: $tagName)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+	variables := map[string]interface{}{
+		"owner":   graphql.String(repo.RepoOwner()),
+		"name":    graphql.String(repo.RepoName()),
+		"tagName": graphql.String(qualifiedTagName),
+	}
+	err := gql.QueryNamed(context.Background(), "RepositoryFindRef", &query, variables)
+	return query.Repository.Ref.ID != "", err
 }
 
 func getTags(httpClient *http.Client, repo ghrepo.Interface, limit int) ([]tag, error) {

--- a/pkg/cmd/release/create/http.go
+++ b/pkg/cmd/release/create/http.go
@@ -26,29 +26,9 @@ type releaseNotes struct {
 
 var notImplementedError = errors.New("not implemented")
 
-func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tagSHA string) (bool, error) {
-	path := fmt.Sprintf("repos/%s/%s/git/tags/%s", repo.RepoOwner(), repo.RepoName(), tagSHA)
-	url := ghinstance.RESTPrefix(repo.RepoHost()) + path
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return false, err
-	}
-
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return false, err
-	}
-	defer resp.Body.Close()
-
-	_, err = io.Copy(io.Discard, resp.Body)
-	if err != nil {
-		return false, err
-	}
-
-	return resp.StatusCode == 200, nil
+func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tag string) (bool, error) {
+	qualifiedTagName := fmt.Sprintf("refs/tags/%s", tag)
+	return api.RepoTagExists(httpClient, repo, qualifiedTagName)
 }
 
 func getTags(httpClient *http.Client, repo ghrepo.Interface, limit int) ([]tag, error) {

--- a/pkg/cmd/release/create/http.go
+++ b/pkg/cmd/release/create/http.go
@@ -26,6 +26,26 @@ type releaseNotes struct {
 
 var notImplementedError = errors.New("not implemented")
 
+func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tagSHA string) (bool, error) {
+	path := fmt.Sprintf("repos/%s/%s/git/tags/%s", repo.RepoOwner(), repo.RepoName(), tagSHA)
+	url := ghinstance.RESTPrefix(repo.RepoHost()) + path
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return false, err
+	}
+
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == 200, nil
+}
+
 func getTags(httpClient *http.Client, repo ghrepo.Interface, limit int) ([]tag, error) {
 	path := fmt.Sprintf("repos/%s/%s/tags?per_page=%d", repo.RepoOwner(), repo.RepoName(), limit)
 	url := ghinstance.RESTPrefix(repo.RepoHost()) + path


### PR DESCRIPTION
This PR sets the `target_commitish` parameter to the local tag SHA when present for the `release create` command. This prevents the API from creating a new tag pointed at the incorrect SHA if the local tag has not been pushed. 

cc https://github.com/cli/cli/pull/4571#pullrequestreview-855459329
Supersedes https://github.com/cli/cli/pull/4571
Closes https://github.com/cli/cli/issues/4357