### PR TITLE
Fix flaky liveshare session test

### DIFF
--- a/pkg/liveshare/port_forwarder_test.go
+++ b/pkg/liveshare/port_forwarder_test.go
@@ -105,7 +105,7 @@ func TestPortForwarderTrafficMonitor(t *testing.T) {
 	bb := make([]byte, l)
 	n, err := tm.Read(bb)
 	if err != nil {
-		t.Errorf("failed to read from traffic monitor: %w", err)
+		t.Errorf("failed to read from traffic monitor: %v", err)
 	}
 	if n != l {
 		t.Errorf("expected to read %d bytes, got %d", l, n)

--- a/pkg/liveshare/session.go
+++ b/pkg/liveshare/session.go
@@ -106,6 +106,8 @@ func (s *Session) StartSSHServer(ctx context.Context) (int, string, error) {
 
 // heartbeat runs until context cancellation, periodically checking whether there is a
 // reason to keep the connection alive, and if so, notifying the Live Share host to do so.
+// Heartbeat ensures it does not send more than one request every "interval" to ratelimit
+// how many keepAlives we send at a time.
 func (s *Session) heartbeat(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -274,7 +274,7 @@ func TestNotifyHostOfActivity(t *testing.T) {
 	)
 	testServer, session, err := makeMockSession(svc)
 	if err != nil {
-		t.Errorf("creating mock session: %v", err)
+		t.Fatalf("creating mock session: %v", err)
 	}
 	defer testServer.Close()
 	ctx := context.Background()
@@ -338,7 +338,7 @@ func TestSessionHeartbeat(t *testing.T) {
 	)
 	testServer, session, err := makeMockSession(svc)
 	if err != nil {
-		t.Errorf("creating mock session: %v", err)
+		t.Fatalf("creating mock session: %v", err)
 	}
 	defer testServer.Close()
 

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -375,7 +375,7 @@ func TestSessionHeartbeat(t *testing.T) {
 		requestsMu.Lock()
 		rc := requests
 		requestsMu.Unlock()
-		// though this could be also dropped, the sync.Waigroup above guarantees
+		// though this could be also dropped, the sync.WaitGroup above guarantees
 		// that it gets called a second time.
 		if rc != 2 {
 			t.Errorf("unexpected number of requests, expected: 2, got: %d", requests)


### PR DESCRIPTION
The session.keepAlive method by design drops requests if there's already one in flight. However, our tests send 2 requests and _assert_ that two requests were received and none were dropped. The way it was achieving that is by hoping to sleep long enough between the two requests. 

However, sleeping during tests for network requests to finish (even if by a local network) does not guarantee that said network requests will finish before the sleep is done and therefore we get rare but existing flakes where the session test below fails. 

This PR switches sleeping two having waitgroups to ensure that the serve request is finished (note that only guarantees the server request function is finished and not that the client side has moved on). 

internal issue: 6101