### PR TITLE
Add new line after error

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -157,7 +157,7 @@ func mainRun() exitCode {
 				if errors.As(err, &execError) {
 					return exitCode(execError.ExitCode())
 				}
-				fmt.Fprintf(stderr, "failed to run extension: %s", err, "\n")
+				fmt.Fprintf(stderr, "failed to run extension: %s\n", err)
 				return exitError
 			} else if found {
 				return exitOK

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -145,7 +145,7 @@ func mainRun() exitCode {
 				if errors.As(err, &execError) {
 					return exitCode(execError.ExitCode())
 				}
-				fmt.Fprintf(stderr, "failed to run external command: %s", err)
+				fmt.Fprintf(stderr, "failed to run external command: %s\n", err)
 				return exitError
 			}
 

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -157,7 +157,7 @@ func mainRun() exitCode {
 				if errors.As(err, &execError) {
 					return exitCode(execError.ExitCode())
 				}
-				fmt.Fprintf(stderr, "failed to run extension: %s", err)
+				fmt.Fprintf(stderr, "failed to run extension: %s", err, "\n")
 				return exitError
 			} else if found {
 				return exitOK


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #5123`
-->
Fixes #5123

This quick fix adds a new line character after "failed to run extension" errors