### PR TITLE
Consistent punctuation in command usages

### DIFF
--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -55,7 +55,7 @@ var configOptions = []ConfigOption{
 	},
 	{
 		Key:          "http_unix_socket",
-		Description:  "the path to a unix socket through which to make HTTP connection",
+		Description:  "the path to a Unix socket through which to make an HTTP connection",
 		DefaultValue: "",
 	},
 	{

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -46,7 +46,7 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 		Use:   "refresh",
 		Args:  cobra.ExactArgs(0),
 		Short: "Refresh stored authentication credentials",
-		Long: heredoc.Doc(`Expand or fix the permission scopes for stored credentials
+		Long: heredoc.Doc(`Expand or fix the permission scopes for stored credentials.
 
 			The --scopes flag accepts a comma separated list of scopes you want your gh credentials to have. If
 			absent, this command ensures that gh has access to a minimum set of scopes.

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -33,7 +33,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 
 			An extension cannot override any of the core gh commands.
 
-			See the list of available extensions at <https://github.com/topics/gh-extension>
+			See the list of available extensions at <https://github.com/topics/gh-extension>.
 		`, "`"),
 		Aliases: []string{"extensions"},
 	}
@@ -82,7 +82,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 				To install an extension in development from the current directory, use "." as the
 				value of the repository argument.
 
-				See the list of available extensions at <https://github.com/topics/gh-extension>
+				See the list of available extensions at <https://github.com/topics/gh-extension>.
 			`),
 			Example: heredoc.Doc(`
 				$ gh extension install owner/gh-extension

--- a/pkg/cmd/gpg-key/gpg_key.go
+++ b/pkg/cmd/gpg-key/gpg_key.go
@@ -11,7 +11,7 @@ func NewCmdGPGKey(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gpg-key <command>",
 		Short: "Manage GPG keys",
-		Long:  "Manage GPG keys registered with your GitHub account",
+		Long:  "Manage GPG keys registered with your GitHub account.",
 	}
 
 	cmd.AddCommand(cmdList.NewCmdList(f, nil))

--- a/pkg/cmd/issue/issue.go
+++ b/pkg/cmd/issue/issue.go
@@ -20,7 +20,7 @@ func NewCmdIssue(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "issue <command>",
 		Short: "Manage issues",
-		Long:  `Work with GitHub issues`,
+		Long:  `Work with GitHub issues.`,
 		Example: heredoc.Doc(`
 			$ gh issue list
 			$ gh issue create --label bug

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -24,7 +24,7 @@ func NewCmdPR(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pr <command>",
 		Short: "Manage pull requests",
-		Long:  "Work with GitHub pull requests",
+		Long:  "Work with GitHub pull requests.",
 		Example: heredoc.Doc(`
 			$ gh pr checkout 353
 			$ gh pr create --fill

--- a/pkg/cmd/pr/ready/ready.go
+++ b/pkg/cmd/pr/ready/ready.go
@@ -31,7 +31,7 @@ func NewCmdReady(f *cmdutil.Factory, runF func(*ReadyOptions) error) *cobra.Comm
 		Use:   "ready [<number> | <url> | <branch>]",
 		Short: "Mark a pull request as ready for review",
 		Long: heredoc.Doc(`
-			Mark a pull request as ready for review
+			Mark a pull request as ready for review.
 
 			Without an argument, the pull request that belongs to the current branch
 			is marked as ready.

--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -2,11 +2,11 @@ package rename
 
 import (
 	"fmt"
-	"github.com/cli/cli/v2/api"
 	"net/http"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/config"

--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -41,7 +41,7 @@ func NewCmdRename(f *cmdutil.Factory, runf func(*RenameOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "rename [<new-name>]",
 		Short: "Rename a repository",
-		Long: heredoc.Doc(`Rename a GitHub repository
+		Long: heredoc.Doc(`Rename a GitHub repository.
 
 		By default, this renames the current repository; otherwise renames the specified repository.`),
 		Args: cobra.MaximumNArgs(1),

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -23,7 +23,7 @@ func NewCmdRepo(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "repo <command>",
 		Short: "Create, clone, fork, and view repositories",
-		Long:  `Work with GitHub repositories`,
+		Long:  `Work with GitHub repositories.`,
 		Example: heredoc.Doc(`
 			$ gh repo create
 			$ gh repo clone cli/cli

--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -44,7 +44,7 @@ func NewCmdSync(f *cmdutil.Factory, runF func(*SyncOptions) error) *cobra.Comman
 		Long: heredoc.Docf(`
 			Sync destination repository from source repository. Syncing uses the main branch
 			of the source repository to update the matching branch on the destination
-			repository so they are equal. A fast forward update will be used execept when the
+			repository so they are equal. A fast forward update will be used except when the
 			%[1]s--force%[1]s flag is specified, then the two branches will
 			by synced using a hard reset.
 

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -11,7 +11,7 @@ var HelpTopics = map[string]map[string]string{
 		"short": "Information about using gh with MinTTY",
 		"long": heredoc.Doc(`
 			MinTTY is the terminal emulator that comes by default with Git
-			for Windows.  It has known issues with gh's ability to prompt a
+			for Windows. It has known issues with gh's ability to prompt a
 			user for input.
 
 			There are a few workarounds to make gh work with MinTTY:

--- a/pkg/cmd/ssh-key/ssh_key.go
+++ b/pkg/cmd/ssh-key/ssh_key.go
@@ -11,7 +11,7 @@ func NewCmdSSHKey(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ssh-key <command>",
 		Short: "Manage SSH keys",
-		Long:  "Manage SSH keys registered with your GitHub account",
+		Long:  "Manage SSH keys registered with your GitHub account.",
 	}
 
 	cmd.AddCommand(cmdList.NewCmdList(f, nil))

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -51,7 +51,7 @@ func NewCmdRun(f *cmdutil.Factory, runF func(*RunOptions) error) *cobra.Command 
 		Long: heredoc.Doc(`
 			Create a workflow_dispatch event for a given workflow.
 
-			This command will trigger GitHub Actions to run a given workflow file.  The given workflow file must
+			This command will trigger GitHub Actions to run a given workflow file. The given workflow file must
 			support a workflow_dispatch 'on' trigger in order to be run in this way.
 
 			If the workflow file supports inputs, they can be specified in a few ways:


### PR DESCRIPTION
Hello,

I made the punctuation more consistent across the different long command descriptions. Specifically, I made sure that the long descriptions utilize periods to distinguish them from short ones. I also made some minor spelling, grammatical, and spacing corrections.

I think the changes I'm making are harmless enough that I do not need to open up an issue, but let me know if that's not the case. Let me know if I need to make any adjustments.

Thanks,
Kevin