### PR TITLE
Standardize pager output across commands

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -279,11 +279,11 @@ func apiRun(opts *ApiOptions) error {
 	if opts.Silent {
 		opts.IO.Out = ioutil.Discard
 	} else {
-		err := opts.IO.StartPager()
-		if err != nil {
-			return err
+		if err := opts.IO.StartPager(); err == nil {
+			defer opts.IO.StopPager()
+		} else {
+			fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
 		}
-		defer opts.IO.StopPager()
 	}
 
 	cfg, err := opts.Config()

--- a/pkg/cmd/gist/list/list.go
+++ b/pkg/cmd/gist/list/list.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -82,6 +83,12 @@ func listRun(opts *ListOptions) error {
 	gists, err := shared.ListGists(client, host, opts.Limit, opts.Visibility)
 	if err != nil {
 		return err
+	}
+
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
 	}
 
 	cs := opts.IO.ColorScheme()

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -160,11 +160,11 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
-	err = opts.IO.StartPager()
-	if err != nil {
-		return err
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
 	}
-	defer opts.IO.StopPager()
 
 	if opts.Exporter != nil {
 		return opts.Exporter.Write(opts.IO, listResult.Issues)

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -193,6 +193,12 @@ func checksRun(opts *ChecksOptions) error {
 		return (b0 == "fail") || (b0 == "pending" && b1 == "success")
 	})
 
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
+	}
+
 	tp := utils.NewTablePrinter(opts.IO)
 
 	for _, o := range outputs {

--- a/pkg/cmd/pr/diff/diff.go
+++ b/pkg/cmd/pr/diff/diff.go
@@ -104,11 +104,11 @@ func diffRun(opts *DiffOptions) error {
 	}
 	defer diff.Close()
 
-	err = opts.IO.StartPager()
-	if err != nil {
-		return err
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
 	}
-	defer opts.IO.StopPager()
 
 	if !opts.UseColor {
 		_, err = io.Copy(opts.IO.Out, diff)

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -109,12 +109,11 @@ func viewRun(opts *ViewOptions) error {
 	}
 
 	opts.IO.DetectTerminalTheme()
-
-	err = opts.IO.StartPager()
-	if err != nil {
-		return err
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
 	}
-	defer opts.IO.StopPager()
 
 	if opts.Exporter != nil {
 		return opts.Exporter.Write(opts.IO, pr)

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -63,6 +63,12 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
+	}
+
 	now := time.Now()
 	table := utils.NewTablePrinter(opts.IO)
 	iofmt := opts.IO.ColorScheme()

--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -142,10 +142,11 @@ func viewRun(opts *ViewOptions) error {
 	}
 
 	opts.IO.DetectTerminalTheme()
-	if err := opts.IO.StartPager(); err != nil {
-		return err
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
 	}
-	defer opts.IO.StopPager()
 
 	if opts.Exporter != nil {
 		return opts.Exporter.Write(opts.IO, repo)

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -107,6 +107,12 @@ func listRun(opts *ListOptions) error {
 		return fmt.Errorf("failed to get runs: %w", err)
 	}
 
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
+	}
+
 	if opts.Exporter != nil {
 		return opts.Exporter.Write(opts.IO, runs)
 	}

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -122,6 +122,12 @@ func listRun(opts *ListOptions) error {
 		return fmt.Errorf("failed to get secrets: %w", err)
 	}
 
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
+	}
+
 	tp := utils.NewTablePrinter(opts.IO)
 	for _, secret := range secrets {
 		tp.AddField(secret.Name, nil, nil)

--- a/pkg/cmd/workflow/list/list.go
+++ b/pkg/cmd/workflow/list/list.go
@@ -88,6 +88,12 @@ func listRun(opts *ListOptions) error {
 		return nil
 	}
 
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
+	}
+
 	tp := utils.NewTablePrinter(opts.IO)
 	cs := opts.IO.ColorScheme()
 

--- a/pkg/cmd/workflow/view/view.go
+++ b/pkg/cmd/workflow/view/view.go
@@ -123,10 +123,17 @@ func runView(opts *ViewOptions) error {
 		return opts.Browser.Browse(address)
 	}
 
-	if opts.YAML {
-		err = viewWorkflowContent(opts, client, workflow)
+	opts.IO.DetectTerminalTheme()
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
 	} else {
-		err = viewWorkflowInfo(opts, client, workflow)
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
+	}
+
+	if opts.YAML {
+		err = viewWorkflowContent(opts, client, repo, workflow, opts.Ref)
+	} else {
+		err = viewWorkflowInfo(opts, client, repo, workflow)
 	}
 	if err != nil {
 		return err
@@ -135,19 +142,12 @@ func runView(opts *ViewOptions) error {
 	return nil
 }
 
-func viewWorkflowContent(opts *ViewOptions, client *api.Client, workflow *shared.Workflow) error {
-	repo, err := opts.BaseRepo()
-	if err != nil {
-		return fmt.Errorf("could not determine base repo: %w", err)
-	}
-
-	opts.IO.StartProgressIndicator()
-	yamlBytes, err := shared.GetWorkflowContent(client, repo, *workflow, opts.Ref)
-	opts.IO.StopProgressIndicator()
+func viewWorkflowContent(opts *ViewOptions, client *api.Client, repo ghrepo.Interface, workflow *shared.Workflow, ref string) error {
+	yamlBytes, err := shared.GetWorkflowContent(client, repo, *workflow, ref)
 	if err != nil {
 		if s, ok := err.(api.HTTPError); ok && s.StatusCode == 404 {
-			if opts.Ref != "" {
-				return fmt.Errorf("could not find workflow file %s on %s, try specifying a different ref", workflow.Base(), opts.Ref)
+			if ref != "" {
+				return fmt.Errorf("could not find workflow file %s on %s, try specifying a different ref", workflow.Base(), ref)
 			}
 			return fmt.Errorf("could not find workflow file %s, try specifying a branch or tag using `--ref`", workflow.Base())
 		}
@@ -155,12 +155,6 @@ func viewWorkflowContent(opts *ViewOptions, client *api.Client, workflow *shared
 	}
 
 	yaml := string(yamlBytes)
-
-	opts.IO.DetectTerminalTheme()
-	if err := opts.IO.StartPager(); err != nil {
-		fmt.Fprintf(opts.IO.ErrOut, "starting pager failed: %v\n", err)
-	}
-	defer opts.IO.StopPager()
 
 	if !opts.Raw {
 		cs := opts.IO.ColorScheme()
@@ -191,15 +185,8 @@ func viewWorkflowContent(opts *ViewOptions, client *api.Client, workflow *shared
 	return nil
 }
 
-func viewWorkflowInfo(opts *ViewOptions, client *api.Client, workflow *shared.Workflow) error {
-	repo, err := opts.BaseRepo()
-	if err != nil {
-		return fmt.Errorf("could not determine base repo: %w", err)
-	}
-
-	opts.IO.StartProgressIndicator()
+func viewWorkflowInfo(opts *ViewOptions, client *api.Client, repo ghrepo.Interface, workflow *shared.Workflow) error {
 	wr, err := getWorkflowRuns(client, repo, workflow)
-	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("failed to get runs: %w", err)
 	}


### PR DESCRIPTION
Add pager functionality to the following commands:
- gist list
- pr checks
- release list
- run list
- run view
- secret list
- workflow list
- workflow view

Additionally, normalize error handling when starting the pager has failed: only print a non-fatal notice to stderr instead of aborting the whole command.

Fixes https://github.com/cli/cli/issues/5102