### PR TITLE
Ignore EPIPE errors when writing to a closed pager

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -3,7 +3,6 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,7 +12,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
@@ -384,11 +382,7 @@ func processResponse(resp *http.Response, opts *ApiOptions, headersOutputStream 
 		_, err = io.Copy(opts.IO.Out, responseBody)
 	}
 	if err != nil {
-		if errors.Is(err, syscall.EPIPE) {
-			err = nil
-		} else {
-			return
-		}
+		return
 	}
 
 	if serverError == "" && resp.StatusCode > 299 {

--- a/pkg/cmd/pr/diff/diff.go
+++ b/pkg/cmd/pr/diff/diff.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"syscall"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
@@ -112,9 +111,6 @@ func diffRun(opts *DiffOptions) error {
 
 	if !opts.UseColor {
 		_, err = io.Copy(opts.IO.Out, diff)
-		if errors.Is(err, syscall.EPIPE) {
-			return nil
-		}
 		return err
 	}
 

--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"syscall"
 	"text/template"
 
 	"github.com/MakeNowJust/heredoc"
@@ -213,12 +212,7 @@ func viewRun(opts *ViewOptions) error {
 		View:        cs.Gray(fmt.Sprintf("View this repository on GitHub: %s", openURL)),
 	}
 
-	err = tmpl.Execute(stdout, repoData)
-	if err != nil && !errors.Is(err, syscall.EPIPE) {
-		return err
-	}
-
-	return nil
+	return tmpl.Execute(stdout, repoData)
 }
 
 func isMarkdownFile(filename string) bool {

--- a/pkg/iostreams/epipe_other.go
+++ b/pkg/iostreams/epipe_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+// +build !windows
+
+package iostreams
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isEpipeError(err error) bool {
+	return errors.Is(err, syscall.EPIPE)
+}

--- a/pkg/iostreams/epipe_windows.go
+++ b/pkg/iostreams/epipe_windows.go
@@ -1,0 +1,11 @@
+package iostreams
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isEpipeError(err error) bool {
+	// 232 is Windows error code ERROR_NO_DATA, "The pipe is being closed".
+	return errors.Is(err, syscall.Errno(232))
+}


### PR DESCRIPTION
While a gh command is writing stdout to a pager, the user may choose to close the pager program before the pager has read all the data on its standard input. In that case, the parent gh process will receive an EPIPE error, which would bubble up its error handling and cause it to print something like:

    write |1: broken pipe

Since this was caused by an explicit user action of closing the pager, and since the user probably doesn't want to see this uninformative error, this change informs our global error handling of this error and causes it to be ignored.

Followup to https://github.com/cli/cli/pull/5141
Fixes https://github.com/cli/cli/issues/2273