### PR TITLE
gh auth login: added flags to partially automate flow

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -55,8 +55,8 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			Alternatively, pass in a token on standard input by using %[1]s--with-token%[1]s.
 			The minimum required scopes for the token are: "repo", "read:org".
 
-			The --scopes flag accepts a comma separated list of scopes you want your gh credentials to have. If
-			absent, this command ensures that gh has access to a minimum set of scopes.
+			The %[1]s--scopes%[1]s flag accepts a comma separated list of scopes you want your gh credentials to
+			have. If absent, this command ensures that gh has access to a minimum set of scopes.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# start interactive setup
@@ -65,11 +65,8 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			# authenticate against github.com by reading the token from a file
 			$ gh auth login --with-token < mytoken.txt
 
-			# authenticate with a specific GitHub Enterprise Server instance
+			# authenticate with a specific GitHub instance
 			$ gh auth login --hostname enterprise.internal
-
-			# authenticate with the public GitHub server instance
-			$ gh auth login --hostname github.com
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if tokenStdin && opts.Web {
@@ -115,8 +112,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", nil, "Additional authentication scopes for gh to have")
 	cmd.Flags().BoolVar(&tokenStdin, "with-token", false, "Read token from standard input")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open a browser to authenticate")
-	cmd.Flags().StringVarP(&opts.GitProtocol, "git-protocol", "p", "",
-		"Select the protocol git should use (options: ssh, https)")
+	cmdutil.StringEnumFlag(cmd, &opts.GitProtocol, "git-protocol", "p", "", []string{"ssh", "https"}, "The protocol to use for git operations")
 
 	return cmd
 }

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -31,6 +31,9 @@ type LoginOptions struct {
 	Scopes   []string
 	Token    string
 	Web      bool
+	UseGH    bool
+	UseHTTPS bool
+	UseSSH   bool
 }
 
 func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Command {
@@ -111,6 +114,9 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", nil, "Additional authentication scopes for gh to have")
 	cmd.Flags().BoolVar(&tokenStdin, "with-token", false, "Read token from standard input")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open a browser to authenticate")
+	cmd.Flags().BoolVar(&opts.UseGH, "use-gh", false, "Use GitHub.com (don't ask about GitHub Enterprise Server).")
+	cmd.Flags().BoolVar(&opts.UseHTTPS, "use-https", false, "Use HTTPS when connecting with git.")
+	cmd.Flags().BoolVar(&opts.UseSSH, "use-ssh", false, "Use SSH when connecting with git.")
 
 	return cmd
 }
@@ -122,7 +128,7 @@ func loginRun(opts *LoginOptions) error {
 	}
 
 	hostname := opts.Hostname
-	if opts.Interactive && hostname == "" {
+	if opts.Interactive && hostname == "" && !opts.UseGH {
 		var err error
 		hostname, err = promptForHostname()
 		if err != nil {
@@ -186,6 +192,8 @@ func loginRun(opts *LoginOptions) error {
 		Web:         opts.Web,
 		Scopes:      opts.Scopes,
 		Executable:  opts.MainExecutable,
+		UseHTTPS:    opts.UseHTTPS,
+		UseSSH:      opts.UseSSH,
 	})
 }
 

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -114,9 +114,9 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", nil, "Additional authentication scopes for gh to have")
 	cmd.Flags().BoolVar(&tokenStdin, "with-token", false, "Read token from standard input")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open a browser to authenticate")
-	cmd.Flags().BoolVar(&opts.UseGH, "use-gh", false, "Use GitHub.com (don't ask about GitHub Enterprise Server).")
-	cmd.Flags().BoolVar(&opts.UseHTTPS, "use-https", false, "Use HTTPS when connecting with git.")
-	cmd.Flags().BoolVar(&opts.UseSSH, "use-ssh", false, "Use SSH when connecting with git.")
+	cmd.Flags().BoolVar(&opts.UseGH, "use-gh", false, "Use GitHub.com (don't ask about GitHub Enterprise Server)")
+	cmd.Flags().BoolVar(&opts.UseHTTPS, "use-https", false, "Use HTTPS when connecting with git")
+	cmd.Flags().BoolVar(&opts.UseSSH, "use-ssh", false, "Use SSH when connecting with git")
 
 	return cmd
 }

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -27,13 +27,11 @@ type LoginOptions struct {
 
 	Interactive bool
 
-	Hostname string
-	Scopes   []string
-	Token    string
-	Web      bool
-	UseGH    bool
-	UseHTTPS bool
-	UseSSH   bool
+	Hostname    string
+	Scopes      []string
+	Token       string
+	Web         bool
+	GitProtocol string
 }
 
 func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Command {
@@ -69,6 +67,9 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 
 			# authenticate with a specific GitHub Enterprise Server instance
 			$ gh auth login --hostname enterprise.internal
+
+      # authenticate to the public github.com server
+      $ gh auth login --hostname github.com
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if tokenStdin && opts.Web {
@@ -114,9 +115,8 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", nil, "Additional authentication scopes for gh to have")
 	cmd.Flags().BoolVar(&tokenStdin, "with-token", false, "Read token from standard input")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open a browser to authenticate")
-	cmd.Flags().BoolVar(&opts.UseGH, "use-gh", false, "Use GitHub.com (don't ask about GitHub Enterprise Server)")
-	cmd.Flags().BoolVar(&opts.UseHTTPS, "use-https", false, "Use HTTPS when connecting with git")
-	cmd.Flags().BoolVar(&opts.UseSSH, "use-ssh", false, "Use SSH when connecting with git")
+	cmd.Flags().StringVarP(&opts.GitProtocol, "git-protocol", "p", "",
+		"Select the protocol git should use (options: ssh, https)")
 
 	return cmd
 }
@@ -128,7 +128,7 @@ func loginRun(opts *LoginOptions) error {
 	}
 
 	hostname := opts.Hostname
-	if opts.Interactive && hostname == "" && !opts.UseGH {
+	if opts.Interactive && hostname == "" {
 		var err error
 		hostname, err = promptForHostname()
 		if err != nil {
@@ -192,8 +192,7 @@ func loginRun(opts *LoginOptions) error {
 		Web:         opts.Web,
 		Scopes:      opts.Scopes,
 		Executable:  opts.MainExecutable,
-		UseHTTPS:    opts.UseHTTPS,
-		UseSSH:      opts.UseSSH,
+		GitProtocol: opts.GitProtocol,
 	})
 }
 

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -68,8 +68,8 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			# authenticate with a specific GitHub Enterprise Server instance
 			$ gh auth login --hostname enterprise.internal
 
-      # authenticate to the public github.com server
-      $ gh auth login --hostname github.com
+			# authenticate with the public GitHub server instance
+			$ gh auth login --hostname github.com
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if tokenStdin && opts.Web {

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -128,15 +128,11 @@ func Login(opts *LoginOptions) error {
 		var err error
 		authToken, err = authflow.AuthFlowWithConfig(cfg, opts.IO, hostname, "", append(opts.Scopes, additionalScopes...), opts.Interactive)
 		if err != nil {
-			fmt.Fprintf(opts.IO.ErrOut, "failed to authenticate via web browser: %s\n", err)
-			fmt.Fprintf(opts.IO.ErrOut, "Falling back to \"Paste an authentication token\".")
-			authMode = 1
-		} else {
-			fmt.Fprintf(opts.IO.ErrOut, "%s Authentication complete.\n", cs.SuccessIcon())
-			userValidated = true
-		}
-	}
-	if authMode == 1 {
+      return fmt.Errorf("failed to authenticate via web browser: %w", err)
+    }
+		fmt.Fprintf(opts.IO.ErrOut, "%s Authentication complete.\n", cs.SuccessIcon())
+		userValidated = true
+	} else {
 		minimumScopes := append([]string{"repo", "read:org"}, additionalScopes...)
 		fmt.Fprint(opts.IO.ErrOut, heredoc.Docf(`
 			Tip: you can generate a Personal Access Token here https://%s/settings/tokens

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -40,28 +40,20 @@ func Login(opts *LoginOptions) error {
 	httpClient := opts.HTTPClient
 	cs := opts.IO.ColorScheme()
 
-	var gitProtocol string
-	if opts.GitProtocol == "https" {
-		gitProtocol = "https"
-	} else if opts.GitProtocol == "ssh" {
-		gitProtocol = "ssh"
-	} else if opts.GitProtocol == "" {
-		if opts.Interactive {
-			var proto string
-			err := prompt.SurveyAskOne(&survey.Select{
-				Message: "What is your preferred protocol for Git operations?",
-				Options: []string{
-					"HTTPS",
-					"SSH",
-				},
-			}, &proto)
-			if err != nil {
-				return fmt.Errorf("could not prompt: %w", err)
-			}
-			gitProtocol = strings.ToLower(proto)
+	gitProtocol := strings.ToLower(opts.GitProtocol)
+	if opts.Interactive && gitProtocol == "" {
+		var proto string
+		err := prompt.SurveyAskOne(&survey.Select{
+			Message: "What is your preferred protocol for Git operations?",
+			Options: []string{
+				"HTTPS",
+				"SSH",
+			},
+		}, &proto)
+		if err != nil {
+			return fmt.Errorf("could not prompt: %w", err)
 		}
-	} else {
-		return fmt.Errorf("Unsupported --git-protocol option: %s", opts.GitProtocol)
+		gitProtocol = strings.ToLower(proto)
 	}
 
 	var additionalScopes []string
@@ -128,8 +120,8 @@ func Login(opts *LoginOptions) error {
 		var err error
 		authToken, err = authflow.AuthFlowWithConfig(cfg, opts.IO, hostname, "", append(opts.Scopes, additionalScopes...), opts.Interactive)
 		if err != nil {
-      return fmt.Errorf("failed to authenticate via web browser: %w", err)
-    }
+			return fmt.Errorf("failed to authenticate via web browser: %w", err)
+		}
 		fmt.Fprintf(opts.IO.ErrOut, "%s Authentication complete.\n", cs.SuccessIcon())
 		userValidated = true
 	} else {

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -29,8 +29,7 @@ type LoginOptions struct {
 	Web         bool
 	Scopes      []string
 	Executable  string
-	UseHTTPS    bool
-	UseSSH      bool
+	GitProtocol string
 
 	sshContext sshContext
 }
@@ -42,23 +41,27 @@ func Login(opts *LoginOptions) error {
 	cs := opts.IO.ColorScheme()
 
 	var gitProtocol string
-	if opts.UseHTTPS {
+	if opts.GitProtocol == "https" {
 		gitProtocol = "https"
-	} else if opts.UseSSH {
+	} else if opts.GitProtocol == "ssh" {
 		gitProtocol = "ssh"
-	} else if opts.Interactive {
-		var proto string
-		err := prompt.SurveyAskOne(&survey.Select{
-			Message: "What is your preferred protocol for Git operations?",
-			Options: []string{
-				"HTTPS",
-				"SSH",
-			},
-		}, &proto)
-		if err != nil {
-			return fmt.Errorf("could not prompt: %w", err)
+	} else if opts.GitProtocol == "" {
+		if opts.Interactive {
+			var proto string
+			err := prompt.SurveyAskOne(&survey.Select{
+				Message: "What is your preferred protocol for Git operations?",
+				Options: []string{
+					"HTTPS",
+					"SSH",
+				},
+			}, &proto)
+			if err != nil {
+				return fmt.Errorf("could not prompt: %w", err)
+			}
+			gitProtocol = strings.ToLower(proto)
 		}
-		gitProtocol = strings.ToLower(proto)
+	} else {
+		return fmt.Errorf("Unsupported --git-protocol option: %s", opts.GitProtocol)
 	}
 
 	var additionalScopes []string

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -42,7 +42,7 @@ func Login(opts *LoginOptions) error {
 	cs := opts.IO.ColorScheme()
 
 	var gitProtocol string
-	if opts.UseHTTS {
+	if opts.UseHTTPS {
 		gitProtocol = "https"
 	} else if opts.UseSSH {
 		gitProtocol = "ssh"
@@ -125,7 +125,7 @@ func Login(opts *LoginOptions) error {
 		var err error
 		authToken, err = authflow.AuthFlowWithConfig(cfg, opts.IO, hostname, "", append(opts.Scopes, additionalScopes...), opts.Interactive)
 		if err != nil {
-			fmt.Fprintf(opts.IO.ErrOut, "failed to authenticate via web browser: %w\n", err)
+			fmt.Fprintf(opts.IO.ErrOut, "failed to authenticate via web browser: %s\n", err)
 			fmt.Fprintf(opts.IO.ErrOut, "Falling back to \"Paste an authentication token\".")
 			authMode = 1
 		} else {

--- a/pkg/cmdutil/flags.go
+++ b/pkg/cmdutil/flags.go
@@ -1,7 +1,9 @@
 package cmdutil
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -19,6 +21,20 @@ func NilBoolFlag(cmd *cobra.Command, p **bool, name string, shorthand string, us
 	f := cmd.Flags().VarPF(newBoolValue(p), name, shorthand, usage)
 	f.NoOptDefVal = "true"
 	return f
+}
+
+// StringEnumFlag defines a new string flag that only allows values listed in options.
+func StringEnumFlag(cmd *cobra.Command, p *string, name, shorthand, defaultValue string, options []string, usage string) *pflag.Flag {
+	val := &enumValue{string: p, options: options}
+	f := cmd.Flags().VarPF(val, name, shorthand, fmt.Sprintf("%s: %s", usage, formatValuesForUsageDocs(options)))
+	_ = cmd.RegisterFlagCompletionFunc(name, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return options, cobra.ShellCompDirectiveNoFileComp
+	})
+	return f
+}
+
+func formatValuesForUsageDocs(values []string) string {
+	return fmt.Sprintf("{%s}", strings.Join(values, "|"))
 }
 
 type stringValue struct {
@@ -74,4 +90,32 @@ func (b *boolValue) Type() string {
 
 func (b *boolValue) IsBoolFlag() bool {
 	return true
+}
+
+type enumValue struct {
+	string  *string
+	options []string
+}
+
+func (e *enumValue) Set(value string) error {
+	found := false
+	for _, opt := range e.options {
+		if strings.EqualFold(opt, value) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("valid values are %s", formatValuesForUsageDocs(e.options))
+	}
+	*e.string = value
+	return nil
+}
+
+func (e *enumValue) String() string {
+	return *e.string
+}
+
+func (e *enumValue) Type() string {
+	return "string"
 }


### PR DESCRIPTION
Motivation: I maintain a tool that implements a specific workflow using git and gh.  A few of my users were
confused by the various options presented by the "gh auth login" flow, so I would like to add these command
line flags that can be optionally used to reduce the number of prompts the user is shown.

For example, if I know that I want all my users to not use GitHub Enterprise, and to use SSH to authenticate to
git, then my wrapper tool would run:

     gh auth login --use-gh --use-ssh

Then the users are only prompted for the remaining necessary items.

I also modified the flow so that if web-based authentication fails (ie if the user is trapped in text mode), `gh auth login` automatically falls over to prompting the user to paste a token.  This step, too, will reduce the number of support calls I have to respond to by one.

Tested by recompiling and manually retesting the gh tool.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
