### PR TITLE
Support listing and removing Dependabot secrets

### DIFF
--- a/pkg/cmd/secret/list/list_test.go
+++ b/pkg/cmd/secret/list/list_test.go
@@ -54,6 +54,21 @@ func Test_NewCmdList(t *testing.T) {
 				UserSecrets: true,
 			},
 		},
+		{
+			name: "Dependabot repo",
+			cli:  "--app Dependabot",
+			wants: ListOptions{
+				Application: "Dependabot",
+			},
+		},
+		{
+			name: "Dependabot org",
+			cli:  "--app Dependabot --org UmbrellaCorporation",
+			wants: ListOptions{
+				Application: "Dependabot",
+				OrgName:     "UmbrellaCorporation",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -184,6 +199,56 @@ func Test_listRun(t *testing.T) {
 				"SECRET_THREE\t1975-11-30\t",
 			},
 		},
+		{
+			name: "Dependabot repo tty",
+			tty:  true,
+			opts: &ListOptions{
+				Application: "Dependabot",
+			},
+			wantOut: []string{
+				"SECRET_ONE.*Updated 1988-10-11",
+				"SECRET_TWO.*Updated 2020-12-04",
+				"SECRET_THREE.*Updated 1975-11-30",
+			},
+		},
+		{
+			name: "Dependabot repo not tty",
+			tty:  false,
+			opts: &ListOptions{
+				Application: "Dependabot",
+			},
+			wantOut: []string{
+				"SECRET_ONE\t1988-10-11",
+				"SECRET_TWO\t2020-12-04",
+				"SECRET_THREE\t1975-11-30",
+			},
+		},
+		{
+			name: "Dependabot org tty",
+			tty:  true,
+			opts: &ListOptions{
+				Application: "Dependabot",
+				OrgName:     "UmbrellaCorporation",
+			},
+			wantOut: []string{
+				"SECRET_ONE.*Updated 1988-10-11.*Visible to all repositories",
+				"SECRET_TWO.*Updated 2020-12-04.*Visible to private repositories",
+				"SECRET_THREE.*Updated 1975-11-30.*Visible to 2 selected repositories",
+			},
+		},
+		{
+			name: "Dependabot org not tty",
+			tty:  false,
+			opts: &ListOptions{
+				Application: "Dependabot",
+				OrgName:     "UmbrellaCorporation",
+			},
+			wantOut: []string{
+				"SECRET_ONE\t1988-10-11\tALL",
+				"SECRET_TWO\t2020-12-04\tPRIVATE",
+				"SECRET_THREE\t1975-11-30\tSELECTED",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -278,6 +343,10 @@ func Test_listRun(t *testing.T) {
 							}{repositoryCount}))
 					}
 				}
+			}
+
+			if tt.opts.Application == "Dependabot" {
+				path = strings.Replace(path, "actions", "dependabot", 1)
 			}
 
 			reg.Register(httpmock.REST("GET", path), httpmock.JSONResponse(payload))

--- a/pkg/cmd/secret/remove/remove_test.go
+++ b/pkg/cmd/secret/remove/remove_test.go
@@ -2,7 +2,6 @@ package remove
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -57,6 +56,23 @@ func TestNewCmdRemove(t *testing.T) {
 				UserSecrets: true,
 			},
 		},
+		{
+			name: "Dependabot repo",
+			cli:  "cool --app Dependabot",
+			wants: RemoveOptions{
+				SecretName:  "cool",
+				Application: "Dependabot",
+			},
+		},
+		{
+			name: "Dependabot org",
+			cli:  "cool --app Dependabot --org UmbrellaCorporation",
+			wants: RemoveOptions{
+				SecretName:  "cool",
+				OrgName:     "UmbrellaCorporation",
+				Application: "Dependabot",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -95,32 +111,61 @@ func TestNewCmdRemove(t *testing.T) {
 }
 
 func Test_removeRun_repo(t *testing.T) {
-	reg := &httpmock.Registry{}
-
-	reg.Register(
-		httpmock.REST("DELETE", "repos/owner/repo/actions/secrets/cool_secret"),
-		httpmock.StatusStringResponse(204, "No Content"))
-
-	io, _, _, _ := iostreams.Test()
-
-	opts := &RemoveOptions{
-		IO: io,
-		HttpClient: func() (*http.Client, error) {
-			return &http.Client{Transport: reg}, nil
+	tests := []struct {
+		name     string
+		opts     *RemoveOptions
+		wantPath string
+	}{
+		{
+			name: "Actions",
+			opts: &RemoveOptions{
+				Application: "actions",
+				SecretName:  "cool_secret",
+			},
+			wantPath: "repos/owner/repo/actions/secrets/cool_secret",
 		},
-		Config: func() (config.Config, error) {
-			return config.NewBlankConfig(), nil
+		{
+			name: "Dependabot",
+			opts: &RemoveOptions{
+				Application: "dependabot",
+				SecretName:  "cool_dependabot_secret",
+			},
+			wantPath: "repos/owner/repo/dependabot/secrets/cool_dependabot_secret",
 		},
-		BaseRepo: func() (ghrepo.Interface, error) {
-			return ghrepo.FromFullName("owner/repo")
+		{
+			name: "defaults to Actions",
+			opts: &RemoveOptions{
+				SecretName: "cool_secret",
+			},
+			wantPath: "repos/owner/repo/actions/secrets/cool_secret",
 		},
-		SecretName: "cool_secret",
 	}
 
-	err := removeRun(opts)
-	assert.NoError(t, err)
+	for _, tt := range tests {
+		reg := &httpmock.Registry{}
 
-	reg.Verify(t)
+		reg.Register(
+			httpmock.REST("DELETE", tt.wantPath),
+			httpmock.StatusStringResponse(204, "No Content"))
+
+		io, _, _, _ := iostreams.Test()
+
+		tt.opts.IO = io
+		tt.opts.HttpClient = func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		}
+		tt.opts.Config = func() (config.Config, error) {
+			return config.NewBlankConfig(), nil
+		}
+		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+			return ghrepo.FromFullName("owner/repo")
+		}
+
+		err := removeRun(tt.opts)
+		assert.NoError(t, err)
+
+		reg.Verify(t)
+	}
 }
 
 func Test_removeRun_env(t *testing.T) {
@@ -155,18 +200,36 @@ func Test_removeRun_env(t *testing.T) {
 
 func Test_removeRun_org(t *testing.T) {
 	tests := []struct {
-		name string
-		opts *RemoveOptions
+		name     string
+		opts     *RemoveOptions
+		wantPath string
 	}{
 		{
-			name: "repo",
-			opts: &RemoveOptions{},
+			name:     "repo",
+			opts:     &RemoveOptions{},
+			wantPath: "repos/owner/repo/actions/secrets/tVirus",
 		},
 		{
 			name: "org",
 			opts: &RemoveOptions{
 				OrgName: "UmbrellaCorporation",
 			},
+			wantPath: "orgs/UmbrellaCorporation/actions/secrets/tVirus",
+		},
+		{
+			name: "Dependabot repo",
+			opts: &RemoveOptions{
+				Application: "dependabot",
+			},
+			wantPath: "repos/owner/repo/dependabot/secrets/tVirus",
+		},
+		{
+			name: "Dependabot org",
+			opts: &RemoveOptions{
+				Application: "dependabot",
+				OrgName:     "UmbrellaCorporation",
+			},
+			wantPath: "orgs/UmbrellaCorporation/dependabot/secrets/tVirus",
 		},
 	}
 
@@ -174,17 +237,9 @@ func Test_removeRun_org(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			reg := &httpmock.Registry{}
 
-			orgName := tt.opts.OrgName
-
-			if orgName == "" {
-				reg.Register(
-					httpmock.REST("DELETE", "repos/owner/repo/actions/secrets/tVirus"),
-					httpmock.StatusStringResponse(204, "No Content"))
-			} else {
-				reg.Register(
-					httpmock.REST("DELETE", fmt.Sprintf("orgs/%s/actions/secrets/tVirus", orgName)),
-					httpmock.StatusStringResponse(204, "No Content"))
-			}
+			reg.Register(
+				httpmock.REST("DELETE", tt.wantPath),
+				httpmock.StatusStringResponse(204, "No Content"))
 
 			io, _, _, _ := iostreams.Test()
 

--- a/pkg/cmd/secret/remove/remove_test.go
+++ b/pkg/cmd/secret/remove/remove_test.go
@@ -205,23 +205,11 @@ func Test_removeRun_org(t *testing.T) {
 		wantPath string
 	}{
 		{
-			name:     "repo",
-			opts:     &RemoveOptions{},
-			wantPath: "repos/owner/repo/actions/secrets/tVirus",
-		},
-		{
 			name: "org",
 			opts: &RemoveOptions{
 				OrgName: "UmbrellaCorporation",
 			},
 			wantPath: "orgs/UmbrellaCorporation/actions/secrets/tVirus",
-		},
-		{
-			name: "Dependabot repo",
-			opts: &RemoveOptions{
-				Application: "dependabot",
-			},
-			wantPath: "repos/owner/repo/dependabot/secrets/tVirus",
 		},
 		{
 			name: "Dependabot org",


### PR DESCRIPTION
Closes #3851

Follow-up to #5134

This PR adds support for listing and removing Dependabot repository and organization secrets.

```
gh secret list --app dependabot
COOL_SECRET  Updated 2022-01-30
```

```
gh secret remove COOL_SECRET --app dependabot
✓ Removed Dependabot secret COOL_SECRET from joshmgross/cli
```

This PR follows the same pattern as #5134 with an `--app` parameter to specify which application secrets should be listed or removed.