### PR TITLE
docs: improve `repo edit` docs

### DIFF
--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -57,7 +57,21 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(options *EditOptions) error) *cobr
 				- by URL, e.g. "https://github.com/OWNER/REPO"
 			`),
 		},
+        Long: heredoc.Docf(`
+            Edit repository settings.
+
+            Use the %[1]s--enable-*%[1]s flags to enable a functionality in the repository.
+
+            To toggle off use the %[1]s--enable-issues=false%[1]s syntax.
+		`, "`"),
 		Args: cobra.MaximumNArgs(1),
+        Example: heredoc.Doc(`
+            # enable issues and wiki
+            gh repo edit --enable-issues --enable-wiki
+
+            # disable projects
+            gh repo edit --enable-projects=false
+        `),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().NFlag() == 0 {
 				return cmdutil.FlagErrorf("at least one flag is required")

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -57,21 +57,19 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(options *EditOptions) error) *cobr
 				- by URL, e.g. "https://github.com/OWNER/REPO"
 			`),
 		},
-        Long: heredoc.Docf(`
-            Edit repository settings.
+		Long: heredoc.Docf(`
+			Edit repository settings.
 
-            Use the %[1]s--enable-*%[1]s flags to enable a functionality in the repository.
-
-            To toggle off use the %[1]s--enable-issues=false%[1]s syntax.
+			To toggle a setting off, use the %[1]s--flag=false%[1]s syntax.
 		`, "`"),
 		Args: cobra.MaximumNArgs(1),
-        Example: heredoc.Doc(`
-            # enable issues and wiki
-            gh repo edit --enable-issues --enable-wiki
+		Example: heredoc.Doc(`
+			# enable issues and wiki
+			gh repo edit --enable-issues --enable-wiki
 
-            # disable projects
-            gh repo edit --enable-projects=false
-        `),
+			# disable projects
+			gh repo edit --enable-projects=false
+		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().NFlag() == 0 {
 				return cmdutil.FlagErrorf("at least one flag is required")


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Add examples to clarify how to disable functionalities with the `repo edit` command.
Demonstrate how to turn issues/wiki on and how to turn projects off.

Fixes #5100
