### PR TITLE
Correctly handle Windows paths when creating gists

### DIFF
--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -215,7 +215,7 @@ func processFiles(stdin io.ReadCloser, filenameOverride string, filenames []stri
 				return fs, fmt.Errorf("failed to read file %s: %w", f, err)
 			}
 
-			filename = path.Base(f)
+			filename = filepath.Base(f)
 		}
 
 		fs[filename] = &shared.GistFile{

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -163,9 +163,9 @@ func TestNewCmdCreate(t *testing.T) {
 
 func Test_createRun(t *testing.T) {
 	tempDir := t.TempDir()
-	fixtureFile := path.Join(tempDir, "fixture.txt")
+	fixtureFile := filepath.Join(tempDir, "fixture.txt")
 	assert.NoError(t, ioutil.WriteFile(fixtureFile, []byte("{}"), 0644))
-	emptyFile := path.Join(tempDir, "empty.txt")
+	emptyFile := filepath.Join(tempDir, "empty.txt")
 	assert.NoError(t, ioutil.WriteFile(emptyFile, []byte(" \t\n"), 0644))
 
 	tests := []struct {


### PR DESCRIPTION
Supports https://github.com/cli/cli/issues/5113

When creating gists on Windows, the filename is not correctly parsed when the file path contains `\` path separators, resulting in gists being created with the full file path as the name.

This is due to using `path`, which doesn't handle OS-specific file separators. Switching to `filepath` resolves the issue - https://pkg.go.dev/path/filepath

I've validated that the existing code fails the tests fail on a Windows machine when the file paths are created using OS-specific file separators (`filePath.Join`).

This is the recommended solution to https://github.com/cli/cli/issues/5113#issuecomment-1027777083, but does not resolve the original request to allow defining a file name when creating gists.