### PR TITLE
Support filtering PRs authored by GitHub Apps

### DIFF
--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -69,9 +69,6 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 			Open the list of PRs in a web browser
 			$ gh pr list --web
-
-			List PRs authored by a GitHub App
-			$ gh pr list --app "dependabot"
     	`),
 		Args: cmdutil.NoArgsQuoteReminder,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -36,7 +36,7 @@ type ListOptions struct {
 	HeadBranch string
 	Labels     []string
 	Author     string
-	App        string
+	AppAuthor  string
 	Assignee   string
 	Search     string
 	Draft      string
@@ -103,7 +103,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.HeadBranch, "head", "H", "", "Filter by head branch")
 	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Filter by labels")
 	cmd.Flags().StringVarP(&opts.Author, "author", "A", "", "Filter by author")
-	cmd.Flags().StringVar(&opts.App, "app", "", "Filter by GitHub App author")
+	cmd.Flags().StringVar(&opts.AppAuthor, "app", "", "Filter by GitHub App author")
 	cmd.Flags().StringVarP(&opts.Assignee, "assignee", "a", "", "Filter by assignee")
 	cmd.Flags().StringVarP(&opts.Search, "search", "S", "", "Search pull requests with `query`")
 	cmd.Flags().BoolVarP(&draft, "draft", "d", false, "Filter by draft state")
@@ -168,12 +168,12 @@ func listRun(opts *ListOptions) error {
 		return opts.Browser.Browse(openURL)
 	}
 
-	if opts.App != "" {
+	if opts.AppAuthor != "" {
 		if filters.Author != "" {
 			return fmt.Errorf("--app can't be specified when --author is specified")
 		}
 
-		filters.Author = fmt.Sprintf("app/%s", opts.App)
+		filters.Author = fmt.Sprintf("app/%s", opts.AppAuthor)
 	}
 
 	listResult, err := listPullRequests(httpClient, baseRepo, filters, opts.LimitResults)

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -83,6 +83,14 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 				opts.Draft = strconv.FormatBool(draft)
 			}
 
+			if err := cmdutil.MutuallyExclusive(
+				"specify only `--author` or `--app`",
+				opts.Author != "",
+				opts.AppAuthor != "",
+			); err != nil {
+				return err
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -166,10 +174,6 @@ func listRun(opts *ListOptions) error {
 	}
 
 	if opts.AppAuthor != "" {
-		if filters.Author != "" {
-			return fmt.Errorf("--app can't be specified when --author is specified")
-		}
-
 		filters.Author = fmt.Sprintf("app/%s", opts.AppAuthor)
 	}
 


### PR DESCRIPTION
Supports https://github.com/cli/cli/issues/4045

This pull request adds an `--app` option to `gh pr list` to allow filtering pull requests authored by GitHub Apps.

```
gh pr list --app dependabot
```

This is the same filter as `author`, but GitHub App bot users require the `app/` prefix.

```
gh pr list --author app/dependabot
```
>Equivalent command using `--author`

**Example output:**
```shell
❯ ./bin/gh pr list --repo cli/cli --state merged --limit 3 --app dependabot
Showing 3 of 14 pull requests in cli/cli that match your search

#5070  Bump github.com/google/go-cmp from 0.5.6 to 0.5.7         dependabot/go_modules/github.com/google/go-cmp-0.5.7
#4832  Bump github.com/itchyny/gojq from 0.12.5 to 0.12.6        dependabot/go_modules/github.com/itchyny/gojq-0.12.6
#4804  Bump github.com/mattn/go-colorable from 0.1.11 to 0.1.12  dependabot/go_modules/github.com/mattn/go-colorable-0.1.12
```