### PR TITLE
Fix authenticating git operations after `auth login --with-token`

### DIFF
--- a/pkg/cmd/auth/gitcredential/helper.go
+++ b/pkg/cmd/auth/gitcredential/helper.go
@@ -112,6 +112,9 @@ func helperRun(opts *CredentialOptions) error {
 		gotUser = tokenUser
 	} else {
 		gotUser, _, _ = cfg.GetWithSource(lookupHost, "user")
+		if gotUser == "" {
+			gotUser = tokenUser
+		}
 	}
 
 	if gotUser == "" || gotToken == "" {

--- a/pkg/cmd/auth/gitcredential/helper_test.go
+++ b/pkg/cmd/auth/gitcredential/helper_test.go
@@ -15,11 +15,6 @@ func (c tinyConfig) GetWithSource(host, key string) (string, string, error) {
 	return c[fmt.Sprintf("%s:%s", host, key)], c["_source"], nil
 }
 
-func (c tinyConfig) Get(host, key string) (val string, err error) {
-	val, _, err = c.GetWithSource(host, key)
-	return
-}
-
 func Test_helperRun(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -168,6 +163,30 @@ func Test_helperRun(t *testing.T) {
 			`),
 			wantErr:    true,
 			wantStdout: "",
+			wantStderr: "",
+		},
+		{
+			name: "no username configured",
+			opts: CredentialOptions{
+				Operation: "get",
+				Config: func() (config, error) {
+					return tinyConfig{
+						"_source":                 "/Users/monalisa/.config/gh/hosts.yml",
+						"example.com:oauth_token": "OTOKEN",
+					}, nil
+				},
+			},
+			input: heredoc.Doc(`
+				protocol=https
+				host=example.com
+			`),
+			wantErr: false,
+			wantStdout: heredoc.Doc(`
+				protocol=https
+				host=example.com
+				username=x-access-token
+				password=OTOKEN
+			`),
 			wantStderr: "",
 		},
 		{


### PR DESCRIPTION
After completing the interactive `gh auth login` flow, the `hosts.yml` config file will have been populated with both `oauth_token` and `user` properties for the GitHub host. However, after `auth login --with-token` only the `oauth_token` is persisted but no username.

This fixes `auth git-credential` behavior so it allows authentication even if the `user` property is missing. It's entirely optional to send a proper username for git authentication, since GitHub seems to ignore the actual value sent and just focuses on the token itself.

Fixes https://github.com/cli/cli/issues/5183