### PR TITLE
Change how gh-cli is installed on fedora

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -32,7 +32,8 @@ sudo apt install gh
 Install:
 
 ```bash
-sudo dnf install gh
+sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo 
+sudo dnf install gh #fedora can install gh-cli directly without adding a third-party repository
 ```
 
 Upgrade:

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -32,7 +32,6 @@ sudo apt install gh
 Install:
 
 ```bash
-sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
 sudo dnf install gh
 ```
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -29,11 +29,17 @@ sudo apt install gh
 
 ### Fedora, CentOS, Red Hat Enterprise Linux (dnf)
 
-Install:
+Install from our package repository for immediate access to latest releases:
 
 ```bash
-sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo 
-sudo dnf install gh #fedora can install gh-cli directly without adding a third-party repository
+sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+sudo dnf install gh
+```
+
+Alternatively, install from the [community repository](https://packages.fedoraproject.org/pkgs/gh/gh/):
+
+```bash
+sudo dnf install gh
 ```
 
 Upgrade:


### PR DESCRIPTION
gh-cli has entered fedora's official repository and can be installed directly through the '# dnf in gh' command without adding a third-party repository.
