### PR TITLE
Don't de-alias configured hosts

### DIFF
--- a/context/remote_test.go
+++ b/context/remote_test.go
@@ -46,7 +46,7 @@ func Test_translateRemotes(t *testing.T) {
 	identityURL := func(u *url.URL) *url.URL {
 		return u
 	}
-	result := TranslateRemotes(gitRemotes, identityURL)
+	result := TranslateRemotes(gitRemotes, identityURL, nil)
 
 	if len(result) != 1 {
 		t.Errorf("got %d results", len(result))

--- a/pkg/cmd/factory/remote_resolver.go
+++ b/pkg/cmd/factory/remote_resolver.go
@@ -38,12 +38,6 @@ func (rr *remoteResolver) Resolver() func() (context.Remotes, error) {
 			return nil, remotesError
 		}
 
-		sshTranslate := rr.urlTranslator
-		if sshTranslate == nil {
-			sshTranslate = git.ParseSSHConfig().Translator()
-		}
-		resolvedRemotes := context.TranslateRemotes(gitRemotes, sshTranslate)
-
 		cfg, err := rr.getConfig()
 		if err != nil {
 			return nil, err
@@ -62,6 +56,12 @@ func (rr *remoteResolver) Resolver() func() (context.Remotes, error) {
 		hostsSet.AddValues(authedHosts)
 		hostsSet.AddValues([]string{defaultHost, ghinstance.Default()})
 		hosts := hostsSet.ToSlice()
+
+		sshTranslate := rr.urlTranslator
+		if sshTranslate == nil {
+			sshTranslate = git.ParseSSHConfig().Translator()
+		}
+		resolvedRemotes := context.TranslateRemotes(gitRemotes, sshTranslate, hosts)
 
 		// Sort remotes
 		sort.Sort(resolvedRemotes)


### PR DESCRIPTION
SSH aliases are used to translate Git remotes to configured domain
names. In certain GHE setups, the translation is counterproductive, as
the remote's domain name already matches the HTTPS name.

Check the remote against the list of configured hosts, skipping SSH
de-aliasing if a match is found.

Fixes #5168