### PR TITLE
Allow Editing Codespaces

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -695,7 +695,7 @@ type EditCodespaceParams struct {
 type editRequest struct {
 	DisplayName        string `json:"display_name,omitempty"`
 	IdleTimeoutMinutes int    `json:"idle_timeout_minutes,omitempty"`
-	Machine            string `json:"machine"`
+	Machine            string `json:"machine,omitempty"`
 }
 
 func (a *API) EditCodespace(ctx context.Context, codespaceName string, params *EditCodespaceParams) (*Codespace, error) {

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -701,23 +701,13 @@ func (a *API) DeleteCodespace(ctx context.Context, codespaceName string) error {
 }
 
 type EditCodespaceParams struct {
-	DisplayName        string
-	IdleTimeoutMinutes int
-	Machine            string
-}
-
-type editRequest struct {
 	DisplayName        string `json:"display_name,omitempty"`
 	IdleTimeoutMinutes int    `json:"idle_timeout_minutes,omitempty"`
 	Machine            string `json:"machine,omitempty"`
 }
 
 func (a *API) EditCodespace(ctx context.Context, codespaceName string, params *EditCodespaceParams) (*Codespace, error) {
-	requestBody, err := json.Marshal(editRequest{
-		DisplayName:        params.DisplayName,
-		IdleTimeoutMinutes: params.IdleTimeoutMinutes,
-		Machine:            params.Machine,
-	})
+	requestBody, err := json.Marshal(params)
 
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request: %w", err)
@@ -735,7 +725,7 @@ func (a *API) EditCodespace(ctx context.Context, codespaceName string, params *E
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusOK {
 		return nil, api.HandleHTTPError(resp)
 	}
 

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -170,6 +170,7 @@ type Codespace struct {
 	State       string              `json:"state"`
 	GitStatus   CodespaceGitStatus  `json:"git_status"`
 	Connection  CodespaceConnection `json:"connection"`
+	Machine     CodespaceMachine    `json:"machine"`
 }
 
 type CodespaceGitStatus struct {
@@ -178,6 +179,15 @@ type CodespaceGitStatus struct {
 	Ref                  string `json:"ref"`
 	HasUnpushedChanges   bool   `json:"has_unpushed_changes"`
 	HasUncommitedChanges bool   `json:"has_uncommited_changes"`
+}
+
+type CodespaceMachine struct {
+	Name            string `json:"name"`
+	DisplayName     string `json:"display_name"`
+	OperatingSystem string `json:"operating_system"`
+	StorageInBytes  int    `json:"storage_in_bytes"`
+	MemoryInBytes   int    `json:"memory_in_bytes"`
+	CPUCount        int    `json:"cpus"`
 }
 
 const (
@@ -207,6 +217,7 @@ var CodespaceFields = []string{
 	"gitStatus",
 	"createdAt",
 	"lastUsedAt",
+	"machineName",
 }
 
 func (c *Codespace) ExportData(fields []string) map[string]interface{} {
@@ -219,6 +230,8 @@ func (c *Codespace) ExportData(fields []string) map[string]interface{} {
 			data[f] = c.Owner.Login
 		case "repository":
 			data[f] = c.Repository.FullName
+		case "machineName":
+			data[f] = c.Machine.Name
 		case "gitStatus":
 			data[f] = map[string]interface{}{
 				"ref":                  c.GitStatus.Ref,
@@ -265,6 +278,7 @@ func (a *API) ListCodespaces(ctx context.Context, limit int) (codespaces []*Code
 		var response struct {
 			Codespaces []*Codespace `json:"codespaces"`
 		}
+
 		dec := json.NewDecoder(resp.Body)
 		if err := dec.Decode(&response); err != nil {
 			return nil, fmt.Errorf("error unmarshaling response: %w", err)
@@ -704,7 +718,7 @@ func (a *API) EditCodespace(ctx context.Context, codespaceName string, params *E
 		IdleTimeoutMinutes: params.IdleTimeoutMinutes,
 		Machine:            params.Machine,
 	})
-	fmt.Printf("requestBody: %s\n", requestBody)
+
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request: %w", err)
 	}
@@ -721,9 +735,7 @@ func (a *API) EditCodespace(ctx context.Context, codespaceName string, params *E
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusAccepted {
-		return nil, errProvisioningInProgress // RPC finished before result of creation known
-	} else if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return nil, api.HandleHTTPError(resp)
 	}
 

--- a/internal/codespaces/api/api_test.go
+++ b/internal/codespaces/api/api_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"testing"
 )
@@ -263,5 +264,50 @@ func TestRetries(t *testing.T) {
 	}
 	if cs.Name != csName {
 		t.Fatalf("expected codespace name to be %q but got %q", csName, cs.Name)
+	}
+}
+
+func TestCodespace_ExportData(t *testing.T) {
+	type fields struct {
+		Name        string
+		CreatedAt   string
+		DisplayName string
+		LastUsedAt  string
+		Owner       User
+		Repository  Repository
+		State       string
+		GitStatus   CodespaceGitStatus
+		Connection  CodespaceConnection
+		Machine     CodespaceMachine
+	}
+	type args struct {
+		fields []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[string]interface{}
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Codespace{
+				Name:        tt.fields.Name,
+				CreatedAt:   tt.fields.CreatedAt,
+				DisplayName: tt.fields.DisplayName,
+				LastUsedAt:  tt.fields.LastUsedAt,
+				Owner:       tt.fields.Owner,
+				Repository:  tt.fields.Repository,
+				State:       tt.fields.State,
+				GitStatus:   tt.fields.GitStatus,
+				Connection:  tt.fields.Connection,
+				Machine:     tt.fields.Machine,
+			}
+			if got := c.ExportData(tt.args.fields); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Codespace.ExportData() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/codespaces/api/api_test.go
+++ b/internal/codespaces/api/api_test.go
@@ -301,6 +301,34 @@ func TestCodespace_ExportData(t *testing.T) {
 				"name": "test",
 			},
 		},
+		{
+			name: "just owner",
+			fields: fields{
+				Owner: User{
+					Login: "test",
+				},
+			},
+			args: args{
+				fields: []string{"owner"},
+			},
+			want: map[string]interface{}{
+				"owner": "test",
+			},
+		},
+		{
+			name: "just machine",
+			fields: fields{
+				Machine: CodespaceMachine{
+					Name: "test",
+				},
+			},
+			args: args{
+				fields: []string{"machineName"},
+			},
+			want: map[string]interface{}{
+				"machineName": "test",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -318,6 +346,90 @@ func TestCodespace_ExportData(t *testing.T) {
 			}
 			if got := c.ExportData(tt.args.fields); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Codespace.ExportData() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func createFakeEditServer(t *testing.T, codespaceName string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		checkPath := "/user/codespaces/" + codespaceName
+
+		if r.URL.Path != checkPath {
+			t.Fatal("Incorrect path")
+		}
+
+		if r.Method != http.MethodPatch {
+			t.Fatal("Incorrect method")
+		}
+
+		body := r.Body
+		if body == nil {
+			t.Fatal("No body")
+		}
+		defer body.Close()
+
+		var data map[string]interface{}
+		err := json.NewDecoder(body).Decode(&data)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if data["display_name"] != "changeTo" {
+			t.Fatal("Incorrect display name")
+		}
+
+		response := Codespace{
+			DisplayName: "changeTo",
+		}
+
+		responseData, _ := json.Marshal(response)
+		fmt.Fprint(w, string(responseData))
+	}))
+}
+func TestAPI_EditCodespace(t *testing.T) {
+	type args struct {
+		ctx           context.Context
+		codespaceName string
+		params        *EditCodespaceParams
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Codespace
+		wantErr bool
+	}{
+		{
+			name: "success",
+			args: args{
+				ctx:           context.Background(),
+				codespaceName: "test",
+				params: &EditCodespaceParams{
+					DisplayName: "changeTo",
+				},
+			},
+			want: &Codespace{
+				DisplayName: "changeTo",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svr := createFakeEditServer(t, tt.args.codespaceName)
+			defer svr.Close()
+
+			a := &API{
+				client:    &http.Client{},
+				githubAPI: svr.URL,
+			}
+			got, err := a.EditCodespace(tt.args.ctx, tt.args.codespaceName, tt.args.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("API.EditCodespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("API.EditCodespace() = %v, want %v", got.DisplayName, tt.want.DisplayName)
 			}
 		})
 	}

--- a/internal/codespaces/api/api_test.go
+++ b/internal/codespaces/api/api_test.go
@@ -289,7 +289,18 @@ func TestCodespace_ExportData(t *testing.T) {
 		args   args
 		want   map[string]interface{}
 	}{
-		// TODO: Add test cases.
+		{
+			name: "just name",
+			fields: fields{
+				Name: "test",
+			},
+			args: args{
+				fields: []string{"name"},
+			},
+			want: map[string]interface{}{
+				"name": "test",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -62,6 +62,7 @@ type apiClient interface {
 	StartCodespace(ctx context.Context, name string) error
 	StopCodespace(ctx context.Context, name string) error
 	CreateCodespace(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error)
+	EditCodespace(ctx context.Context, codespaceName string, params *api.EditCodespaceParams) (*api.Codespace, error)
 	GetRepository(ctx context.Context, nwo string) (*api.Repository, error)
 	AuthorizedKeys(ctx context.Context, user string) ([]byte, error)
 	GetCodespaceRegionLocation(ctx context.Context) (string, error)

--- a/pkg/cmd/codespace/edit.go
+++ b/pkg/cmd/codespace/edit.go
@@ -60,6 +60,6 @@ func (a *App) Edit(ctx context.Context, opts editOptions) error {
 		return fmt.Errorf("error editing codespace: %w", err)
 	}
 
-	fmt.Fprintln(a.io.Out, codespace.Name)
+	fmt.Fprintln(a.io.Out, codespace.DisplayName)
 	return nil
 }

--- a/pkg/cmd/codespace/edit.go
+++ b/pkg/cmd/codespace/edit.go
@@ -50,7 +50,7 @@ func (a *App) Edit(ctx context.Context, opts editOptions) error {
 		SKU:           opts.machine,
 	}
 	a.StartProgressIndicatorWithLabel("Editing codespace")
-	codespace, err := a.apiClient.EditCodespace(ctx, userInputs.CodespaceName, &api.EditCodespaceParams{
+	_, err := a.apiClient.EditCodespace(ctx, userInputs.CodespaceName, &api.EditCodespaceParams{
 		DisplayName:        userInputs.DisplayName,
 		IdleTimeoutMinutes: int(userInputs.IdleTimeout.Minutes()),
 		Machine:            userInputs.SKU,
@@ -60,6 +60,5 @@ func (a *App) Edit(ctx context.Context, opts editOptions) error {
 		return fmt.Errorf("error editing codespace: %w", err)
 	}
 
-	fmt.Fprintln(a.io.Out, codespace.DisplayName)
 	return nil
 }

--- a/pkg/cmd/codespace/edit.go
+++ b/pkg/cmd/codespace/edit.go
@@ -1,0 +1,65 @@
+package codespace
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/spf13/cobra"
+)
+
+type editOptions struct {
+	codespaceName string
+	displayName   string
+	idleTimeout   time.Duration
+	machine       string
+}
+
+func newEditCmd(app *App) *cobra.Command {
+	opts := editOptions{}
+
+	editCmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Edit a codespace",
+		Args:  noArgsConstraint,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return app.Edit(cmd.Context(), opts)
+		},
+	}
+
+	editCmd.Flags().StringVarP(&opts.codespaceName, "codespace", "c", "", "Name of the codespace")
+	editCmd.Flags().StringVarP(&opts.displayName, "displayName", "d", "", "display name")
+	editCmd.Flags().DurationVar(&opts.idleTimeout, "idle-timeout", 0, "allowed inactivity before codespace is stopped, e.g. \"10m\", \"1h\"")
+	editCmd.Flags().StringVarP(&opts.machine, "machine", "m", "", "hardware specifications for the VM")
+
+	return editCmd
+}
+
+// Edits a codespace
+func (a *App) Edit(ctx context.Context, opts editOptions) error {
+	userInputs := struct {
+		CodespaceName string
+		DisplayName   string
+		IdleTimeout   time.Duration
+		SKU           string
+	}{
+		CodespaceName: opts.codespaceName,
+		DisplayName:   opts.displayName,
+		IdleTimeout:   opts.idleTimeout,
+		SKU:           opts.machine,
+	}
+	a.StartProgressIndicatorWithLabel("Editing codespace")
+	codespace, err := a.apiClient.EditCodespace(ctx, userInputs.CodespaceName, &api.EditCodespaceParams{
+		DisplayName:        userInputs.DisplayName,
+		IdleTimeoutMinutes: int(userInputs.IdleTimeout.Minutes()),
+		Machine:            userInputs.SKU,
+	})
+	a.StopProgressIndicator()
+	if err != nil {
+		return fmt.Errorf("error editing codespace: %w", err)
+	}
+
+	fmt.Fprintln(a.io.Out, codespace.Name)
+	return nil
+}

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -25,6 +25,9 @@ import (
 // 			DeleteCodespaceFunc: func(ctx context.Context, name string) error {
 // 				panic("mock out the DeleteCodespace method")
 // 			},
+// 			EditCodespaceFunc: func(ctx context.Context, codespaceName string, params *api.EditCodespaceParams) (*api.Codespace, error) {
+// 				panic("mock out the EditCodespace method")
+// 			},
 // 			GetCodespaceFunc: func(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error) {
 // 				panic("mock out the GetCodespace method")
 // 			},
@@ -70,6 +73,9 @@ type apiClientMock struct {
 
 	// DeleteCodespaceFunc mocks the DeleteCodespace method.
 	DeleteCodespaceFunc func(ctx context.Context, name string) error
+
+	// EditCodespaceFunc mocks the EditCodespace method.
+	EditCodespaceFunc func(ctx context.Context, codespaceName string, params *api.EditCodespaceParams) (*api.Codespace, error)
 
 	// GetCodespaceFunc mocks the GetCodespace method.
 	GetCodespaceFunc func(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error)
@@ -123,6 +129,15 @@ type apiClientMock struct {
 			Ctx context.Context
 			// Name is the name argument value.
 			Name string
+		}
+		// EditCodespace holds details about calls to the EditCodespace method.
+		EditCodespace []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// CodespaceName is the codespaceName argument value.
+			CodespaceName string
+			// Params is the params argument value.
+			Params *api.EditCodespaceParams
 		}
 		// GetCodespace holds details about calls to the GetCodespace method.
 		GetCodespace []struct {
@@ -204,6 +219,7 @@ type apiClientMock struct {
 	lockAuthorizedKeys                 sync.RWMutex
 	lockCreateCodespace                sync.RWMutex
 	lockDeleteCodespace                sync.RWMutex
+	lockEditCodespace                  sync.RWMutex
 	lockGetCodespace                   sync.RWMutex
 	lockGetCodespaceRegionLocation     sync.RWMutex
 	lockGetCodespaceRepoSuggestions    sync.RWMutex
@@ -318,6 +334,45 @@ func (mock *apiClientMock) DeleteCodespaceCalls() []struct {
 	mock.lockDeleteCodespace.RLock()
 	calls = mock.calls.DeleteCodespace
 	mock.lockDeleteCodespace.RUnlock()
+	return calls
+}
+
+// EditCodespace calls EditCodespaceFunc.
+func (mock *apiClientMock) EditCodespace(ctx context.Context, codespaceName string, params *api.EditCodespaceParams) (*api.Codespace, error) {
+	if mock.EditCodespaceFunc == nil {
+		panic("apiClientMock.EditCodespaceFunc: method is nil but apiClient.EditCodespace was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		CodespaceName string
+		Params        *api.EditCodespaceParams
+	}{
+		Ctx:           ctx,
+		CodespaceName: codespaceName,
+		Params:        params,
+	}
+	mock.lockEditCodespace.Lock()
+	mock.calls.EditCodespace = append(mock.calls.EditCodespace, callInfo)
+	mock.lockEditCodespace.Unlock()
+	return mock.EditCodespaceFunc(ctx, codespaceName, params)
+}
+
+// EditCodespaceCalls gets all the calls that were made to EditCodespace.
+// Check the length with:
+//     len(mockedapiClient.EditCodespaceCalls())
+func (mock *apiClientMock) EditCodespaceCalls() []struct {
+	Ctx           context.Context
+	CodespaceName string
+	Params        *api.EditCodespaceParams
+} {
+	var calls []struct {
+		Ctx           context.Context
+		CodespaceName string
+		Params        *api.EditCodespaceParams
+	}
+	mock.lockEditCodespace.RLock()
+	calls = mock.calls.EditCodespace
+	mock.lockEditCodespace.RUnlock()
 	return calls
 }
 

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -12,6 +12,7 @@ func NewRootCmd(app *App) *cobra.Command {
 
 	root.AddCommand(newCodeCmd(app))
 	root.AddCommand(newCreateCmd(app))
+	root.AddCommand(newEditCmd(app))
 	root.AddCommand(newDeleteCmd(app))
 	root.AddCommand(newListCmd(app))
 	root.AddCommand(newLogsCmd(app))


### PR DESCRIPTION
Closes internal issue codespaces#6503

This gives the CLI user the ability to edit a Codespace:

```bash
@veverkap ➜ /workspaces/cli (edit_codspaces) $ bin/gh cs edit -h
Edit a codespace

USAGE
  gh codespace edit [flags]

FLAGS
  -c, --codespace string        Name of the codespace
  -d, --displayName string      display name
      --idle-timeout duration   allowed inactivity before codespace is stopped, e.g. "10m", "1h"
  -m, --machine string          hardware specifications for the VM

INHERITED FLAGS
  --help   Show help for command

LEARN MORE
  Use 'gh <command> <subcommand> --help' for more information about a command.
  Read the manual at https://cli.github.com/manual

```
An example:

```bash
@veverkap ➜ /workspaces/cli (edit_codspaces) $ bin/gh cs edit -c veverkap-cli-cli-x7r952v69g -d "fermion is the least"
```


It also adds the machineName to the `gh cs list --json` command.

```bash
@veverkap ➜ /workspaces/cli (edit_codspaces ✗) $ make && bin/gh cs list --json machineName,name,displayName
build.go: `bin/gh` is up to date.
[
  {
    "displayName": "fermion is the worst",
    "machineName": "standardLinux32gb",
    "name": "veverkap-cli-cli-wpv9rf9pp"
  },
  {
    "displayName": "fermion is the best",
    "machineName": "standardLinux32gb",
    "name": "veverkap-cli-cli-x7r952v69g"
  }
]
```

