### PR TITLE
Alias `list` as `ls` for all commands 

### DIFF
--- a/pkg/cmd/alias/list/list.go
+++ b/pkg/cmd/alias/list/list.go
@@ -24,8 +24,9 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List your aliases",
+		Use:     "list",
+		Short:   "List your aliases",
+		Aliases: []string{"ls"},
 		Long: heredoc.Doc(`
 			This command prints out all of the aliases gh is configured to use.
 		`),

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -16,9 +16,10 @@ func newListCmd(app *App) *cobra.Command {
 	var exporter cmdutil.Exporter
 
 	listCmd := &cobra.Command{
-		Use:   "list",
-		Short: "List your codespaces",
-		Args:  noArgsConstraint,
+		Use:     "list",
+		Short:   "List your codespaces",
+		Aliases: []string{"ls"},
+		Args:    noArgsConstraint,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if limit < 1 {
 				return cmdutil.FlagErrorf("invalid limit: %v", limit)

--- a/pkg/cmd/config/list/list.go
+++ b/pkg/cmd/config/list/list.go
@@ -23,9 +23,10 @@ func NewCmdConfigList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "Print a list of configuration keys and values",
-		Args:  cobra.ExactArgs(0),
+		Use:     "list",
+		Short:   "Print a list of configuration keys and values",
+		Aliases: []string{"list"},
+		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runF != nil {
 				return runF(opts)

--- a/pkg/cmd/config/list/list.go
+++ b/pkg/cmd/config/list/list.go
@@ -25,7 +25,7 @@ func NewCmdConfigList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Print a list of configuration keys and values",
-		Aliases: []string{"list"},
+		Aliases: []string{"ls"},
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runF != nil {

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -40,9 +40,10 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 
 	extCmd.AddCommand(
 		&cobra.Command{
-			Use:   "list",
-			Short: "List installed extension commands",
-			Args:  cobra.NoArgs,
+			Use:     "list",
+			Short:   "List installed extension commands",
+			Aliases: []string{"list"},
+			Args:    cobra.NoArgs,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				cmds := m.List(true)
 				if len(cmds) == 0 {

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -42,7 +42,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 		&cobra.Command{
 			Use:     "list",
 			Short:   "List installed extension commands",
-			Aliases: []string{"list"},
+			Aliases: []string{"ls"},
 			Args:    cobra.NoArgs,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				cmds := m.List(true)

--- a/pkg/cmd/gist/list/list.go
+++ b/pkg/cmd/gist/list/list.go
@@ -35,9 +35,10 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	var flagSecret bool
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List your gists",
-		Args:  cobra.NoArgs,
+		Use:     "list",
+		Short:   "List your gists",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.Limit < 1 {
 				return cmdutil.FlagErrorf("invalid limit: %v", opts.Limit)

--- a/pkg/cmd/gpg-key/list/list.go
+++ b/pkg/cmd/gpg-key/list/list.go
@@ -27,9 +27,10 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "Lists GPG keys in your GitHub account",
-		Args:  cobra.ExactArgs(0),
+		Use:     "list",
+		Short:   "Lists GPG keys in your GitHub account",
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runF != nil {
 				return runF(opts)

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -66,7 +66,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			$ gh issue list --milestone "The big 1.0"
 			$ gh issue list --search "error no:assignee sort:created-asc"
 		`),
-		Args: cmdutil.NoArgsQuoteReminder,
+		Aliases: []string{"list"},
+		Args:    cmdutil.NoArgsQuoteReminder,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -66,7 +66,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			$ gh issue list --milestone "The big 1.0"
 			$ gh issue list --search "error no:assignee sort:created-asc"
 		`),
-		Aliases: []string{"list"},
+		Aliases: []string{"ls"},
 		Args:    cmdutil.NoArgsQuoteReminder,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -70,7 +70,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			Open the list of PRs in a web browser
 			$ gh pr list --web
     	`),
-		Args: cmdutil.NoArgsQuoteReminder,
+		Aliases: []string{"ls"},
+		Args:    cmdutil.NoArgsQuoteReminder,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -28,9 +28,10 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List releases in a repository",
-		Args:  cobra.NoArgs,
+		Use:     "list",
+		Short:   "List releases in a repository",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/repo/deploy-key/list/list.go
+++ b/pkg/cmd/repo/deploy-key/list/list.go
@@ -26,9 +26,10 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List deploy keys in a GitHub repository",
-		Args:  cobra.ExactArgs(0),
+		Use:     "list",
+		Short:   "List deploy keys in a GitHub repository",
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.BaseRepo = f.BaseRepo
 

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -40,9 +40,10 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List recent workflow runs",
-		Args:  cobra.NoArgs,
+		Use:     "list",
+		Short:   "List recent workflow runs",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -48,7 +48,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			- organization: available to Actions runs within an organization
 			- user: available to Codespaces for your user
 		`),
-		Args: cobra.NoArgs,
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/ssh-key/list/list.go
+++ b/pkg/cmd/ssh-key/list/list.go
@@ -26,9 +26,10 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "Lists SSH keys in your GitHub account",
-		Args:  cobra.ExactArgs(0),
+		Use:     "list",
+		Short:   "Lists SSH keys in your GitHub account",
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runF != nil {
 				return runF(opts)

--- a/pkg/cmd/workflow/list/list.go
+++ b/pkg/cmd/workflow/list/list.go
@@ -33,10 +33,11 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List workflows",
-		Long:  "List workflow files, hiding disabled workflows by default.",
-		Args:  cobra.NoArgs,
+		Use:     "list",
+		Short:   "List workflows",
+		Long:    "List workflow files, hiding disabled workflows by default.",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo


### PR DESCRIPTION
I always get tripped up whenever trying to list my Codespaces, adding
`ls` as an alias for `list` feels natural enough!

Closes: #2602