### PR TITLE
Misc. docs improvements

### DIFF
--- a/pkg/cmd/actions/actions.go
+++ b/pkg/cmd/actions/actions.go
@@ -11,12 +11,10 @@ func NewCmdActions(f *cmdutil.Factory) *cobra.Command {
 	cs := f.IOStreams.ColorScheme()
 
 	cmd := &cobra.Command{
-		Use:   "actions",
-		Short: "Learn about working with GitHub Actions",
-		Long:  actionsExplainer(cs),
-		Annotations: map[string]string{
-			"IsActions": "true",
-		},
+		Use:    "actions",
+		Short:  "Learn about working with GitHub Actions",
+		Long:   actionsExplainer(cs),
+		Hidden: true,
 	}
 
 	cmdutil.DisableAuthCheck(cmd)

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -214,7 +214,7 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 	cmd.Flags().StringArrayVarP(&opts.MagicFields, "field", "F", nil, "Add a typed parameter in `key=value` format")
 	cmd.Flags().StringArrayVarP(&opts.RawFields, "raw-field", "f", nil, "Add a string parameter in `key=value` format")
 	cmd.Flags().StringArrayVarP(&opts.RequestHeaders, "header", "H", nil, "Add a HTTP request header in `key:value` format")
-	cmd.Flags().StringSliceVarP(&opts.Previews, "preview", "p", nil, "Opt into GitHub API previews")
+	cmd.Flags().StringSliceVarP(&opts.Previews, "preview", "p", nil, "GitHub API preview `names` to request (without the \"-preview\" suffix)")
 	cmd.Flags().BoolVarP(&opts.ShowResponseHeaders, "include", "i", false, "Include HTTP response headers in the output")
 	cmd.Flags().BoolVar(&opts.Paginate, "paginate", false, "Make additional HTTP requests to fetch all pages of results")
 	cmd.Flags().StringVar(&opts.RequestInputFile, "input", "", "The `file` to use as body for the HTTP request (use \"-\" to read from standard input)")

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -14,8 +14,11 @@ import (
 func NewCmdAuth(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth <command>",
-		Short: "Login, logout, and refresh your authentication",
+		Short: "Authenticate gh with GitHub",
 		Long:  `Manage gh's authentication state.`,
+		Annotations: map[string]string{
+			"IsCore": "true",
+		},
 	}
 
 	cmdutil.DisableAuthCheck(cmd)

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -14,8 +14,7 @@ import (
 func NewCmdAuth(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth <command>",
-		Short: "Authenticate gh with GitHub",
-		Long:  `Manage gh's authentication state.`,
+		Short: "Authenticate gh and git with GitHub",
 		Annotations: map[string]string{
 			"IsCore": "true",
 		},

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -50,13 +50,17 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 		Long: heredoc.Docf(`
 			Authenticate with a GitHub host.
 
-			The default authentication mode is a web-based browser flow.
+			The default authentication mode is a web-based browser flow. After completion, an
+			authentication token will be stored internally.
 
-			Alternatively, pass in a token on standard input by using %[1]s--with-token%[1]s.
+			Alternatively, use %[1]s--with-token%[1]s to pass in a token on standard input.
 			The minimum required scopes for the token are: "repo", "read:org".
 
-			The %[1]s--scopes%[1]s flag accepts a comma separated list of scopes you want your gh credentials to
-			have. If absent, this command ensures that gh has access to a minimum set of scopes.
+			Alternatively, gh will use the authentication token found in environment variables.
+			This method is most suitable for "headless" use of gh such as in automation. See
+			%[1]sgh help environment%[1]s for more info.
+
+			To use gh in GitHub Actions, add %[1]sGH_TOKEN: ${{secrets.GITHUB_TOKEN}}%[1]s to "env".
 		`, "`"),
 		Example: heredoc.Doc(`
 			# start interactive setup
@@ -109,7 +113,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 	}
 
 	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "The hostname of the GitHub instance to authenticate with")
-	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", nil, "Additional authentication scopes for gh to have")
+	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", nil, "Additional authentication scopes to request")
 	cmd.Flags().BoolVar(&tokenStdin, "with-token", false, "Read token from standard input")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open a browser to authenticate")
 	cmdutil.StringEnumFlag(cmd, &opts.GitProtocol, "git-protocol", "p", "", []string{"ssh", "https"}, "The protocol to use for git operations")

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -23,9 +23,15 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 
 	cmd := &cobra.Command{
 		Use:   "comment {<number> | <url>}",
-		Short: "Create a new issue comment",
+		Short: "Add a comment to an issue",
+		Long: heredoc.Doc(`
+			Add a comment to a GitHub issue.
+
+			Without the body text supplied through flags, the command will interactively
+			prompt for the comment text.
+		`),
 		Example: heredoc.Doc(`
-			$ gh issue comment 22 --body "I was able to reproduce this issue, lets fix it."
+			$ gh issue comment 12 --body "Hi from GitHub CLI"
 		`),
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -54,10 +60,10 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Supply a body. Will prompt for one otherwise.")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "The comment body `text`")
 	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
-	cmd.Flags().BoolP("editor", "e", false, "Add body using editor")
-	cmd.Flags().BoolP("web", "w", false, "Add body in browser")
+	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
+	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
 
 	return cmd
 }

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -57,12 +57,17 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List and filter issues in this repository",
+		Short: "List issues in a repository",
+		Long: heredoc.Doc(`
+			List issues in a GitHub repository.
+
+			The search query syntax is documented here:
+			<https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests>
+		`),
 		Example: heredoc.Doc(`
-			$ gh issue list -l "bug" -l "help wanted"
-			$ gh issue list -A monalisa
-			$ gh issue list -a "@me"
-			$ gh issue list --web
+			$ gh issue list --label "bug" --label "help wanted"
+			$ gh issue list --author monalisa
+			$ gh issue list --assignee "@me"
 			$ gh issue list --milestone "The big 1.0"
 			$ gh issue list --search "error no:assignee sort:created-asc"
 		`),
@@ -83,9 +88,9 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open the browser to list the issue(s)")
+	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "List issues in the web browser")
 	cmd.Flags().StringVarP(&opts.Assignee, "assignee", "a", "", "Filter by assignee")
-	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Filter by labels")
+	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Filter by label")
 	cmd.Flags().StringVarP(&opts.State, "state", "s", "open", "Filter by state: {open|closed|all}")
 	_ = cmd.RegisterFlagCompletionFunc("state", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"open", "closed", "all"}, cobra.ShellCompDirectiveNoFileComp
@@ -93,7 +98,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().IntVarP(&opts.LimitResults, "limit", "L", 30, "Maximum number of issues to fetch")
 	cmd.Flags().StringVarP(&opts.Author, "author", "A", "", "Filter by author")
 	cmd.Flags().StringVar(&opts.Mention, "mention", "", "Filter by mention")
-	cmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter by milestone `number` or `title`")
+	cmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter by milestone number or title")
 	cmd.Flags().StringVarP(&opts.Search, "search", "S", "", "Search issues with `query`")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.IssueFields)
 

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -22,17 +22,15 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 
 	cmd := &cobra.Command{
 		Use:   "comment [<number> | <url> | <branch>]",
-		Short: "Create a new pr comment",
+		Short: "Add a comment to a pull request",
 		Long: heredoc.Doc(`
-			Create a new pr comment.
+			Add a comment to a GitHub pull request.
 
-			Without an argument, the pull request that belongs to the current branch
-			is selected.			
-
-			With '--web', comment on the pull request in a web browser instead.
+			Without the body text supplied through flags, the command will interactively
+			prompt for the comment text.
 		`),
 		Example: heredoc.Doc(`
-			$ gh pr comment 22 --body "This looks great, lets get it deployed."
+			$ gh pr comment 13 --body "Hi from GitHub CLI"
 		`),
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -68,10 +66,10 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Supply a body. Will prompt for one otherwise.")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "The comment body `text`")
 	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
-	cmd.Flags().BoolP("editor", "e", false, "Add body using editor")
-	cmd.Flags().BoolP("web", "w", false, "Add body in browser")
+	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
+	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
 
 	return cmd
 }

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -53,22 +53,25 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List and filter pull requests in this repository",
+		Short: "List pull requests in a repository",
+		Long: heredoc.Doc(`
+			List pull requests in a GitHub repository.
+
+			The search query syntax is documented here:
+			<https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests>
+		`),
 		Example: heredoc.Doc(`
 			List PRs authored by you
 			$ gh pr list --author "@me"
 
-			List PRs assigned to you
-			$ gh pr list --assignee "@me"
-
-			List PRs by label, combining multiple labels with AND
+			List only PRs with all of the given labels
 			$ gh pr list --label bug --label "priority 1"
 
-			List PRs using search syntax
+			Filter PRs using search syntax
 			$ gh pr list --search "status:success review:required"
 
-			Open the list of PRs in a web browser
-			$ gh pr list --web
+			Find a PR that introduced a given commit
+			$ gh pr list --search "<SHA>" --state merged
     	`),
 		Aliases: []string{"ls"},
 		Args:    cmdutil.NoArgsQuoteReminder,
@@ -99,7 +102,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open the browser to list the pull requests")
+	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "List pull requests in the web browser")
 	cmd.Flags().IntVarP(&opts.LimitResults, "limit", "L", 30, "Maximum number of items to fetch")
 	cmd.Flags().StringVarP(&opts.State, "state", "s", "open", "Filter by state: {open|closed|merged|all}")
 	_ = cmd.RegisterFlagCompletionFunc("state", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -107,7 +110,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	})
 	cmd.Flags().StringVarP(&opts.BaseBranch, "base", "B", "", "Filter by base branch")
 	cmd.Flags().StringVarP(&opts.HeadBranch, "head", "H", "", "Filter by head branch")
-	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Filter by labels")
+	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Filter by label")
 	cmd.Flags().StringVarP(&opts.Author, "author", "A", "", "Filter by author")
 	cmd.Flags().StringVar(&opts.AppAuthor, "app", "", "Filter by GitHub App author")
 	cmd.Flags().StringVarP(&opts.Assignee, "assignee", "a", "", "Filter by assignee")

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -65,7 +65,7 @@ func CommentablePreRun(cmd *cobra.Command, opts *CommentableOptions) error {
 
 	if inputFlags == 0 {
 		if !opts.IO.CanPrompt() {
-			return cmdutil.FlagErrorf("`--body`, `--body-file` or `--web` required when not running interactively")
+			return cmdutil.FlagErrorf("flags required when not running interactively")
 		}
 		opts.Interactive = true
 	} else if inputFlags == 1 {

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -68,10 +68,6 @@ func CommentablePreRun(cmd *cobra.Command, opts *CommentableOptions) error {
 			return cmdutil.FlagErrorf("flags required when not running interactively")
 		}
 		opts.Interactive = true
-	} else if inputFlags == 1 {
-		if !opts.IO.CanPrompt() && opts.InputType == InputTypeEditor {
-			return cmdutil.FlagErrorf("`--body`, `--body-file` or `--web` required when not running interactively")
-		}
 	} else if inputFlags > 1 {
 		return cmdutil.FlagErrorf("specify only one of `--body`, `--body-file`, `--editor`, or `--web`")
 	}

--- a/pkg/cmd/release/release.go
+++ b/pkg/cmd/release/release.go
@@ -15,7 +15,7 @@ import (
 func NewCmdRelease(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "release <command>",
-		Short: "Manage GitHub releases",
+		Short: "Manage releases",
 		Annotations: map[string]string{
 			"IsCore": "true",
 		},

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
@@ -61,21 +62,23 @@ func NewCmdFork(f *cmdutil.Factory, runF func(*ForkOptions) error) *cobra.Comman
 		Use: "fork [<repository>] [-- <gitflags>...]",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if cmd.ArgsLenAtDash() == 0 && len(args[1:]) > 0 {
-				return cmdutil.FlagErrorf("repository argument required when passing 'git clone' flags")
+				return cmdutil.FlagErrorf("repository argument required when passing git clone flags")
 			}
 			return nil
 		},
 		Short: "Create a fork of a repository",
-		Long: `Create a fork of a repository.
+		Long: heredoc.Docf(`
+			Create a fork of a repository.
 
-With no argument, creates a fork of the current repository. Otherwise, forks
-the specified repository.
+			With no argument, creates a fork of the current repository. Otherwise, forks
+			the specified repository.
 
-By default, the new fork is set to be your 'origin' remote and any existing
-origin remote is renamed to 'upstream'. To alter this behavior, you can set
-a name for the new fork's remote with --remote-name.
+			By default, the new fork is set to be your "origin" remote and any existing
+			origin remote is renamed to "upstream". To alter this behavior, you can set
+			a name for the new fork's remote with %[1]s--remote-name%[1]s.
 
-Additional 'git clone' flags can be passed in by listing them after '--'.`,
+			Additional git clone flags can be passed after %[1]s--%[1]s.
+		`, "`"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			promptOk := opts.IO.CanPrompt()
 			if len(args) > 0 {
@@ -109,14 +112,14 @@ Additional 'git clone' flags can be passed in by listing them after '--'.`,
 		if err == pflag.ErrHelp {
 			return err
 		}
-		return cmdutil.FlagErrorf("%w\nSeparate git clone flags with '--'.", err)
+		return cmdutil.FlagErrorf("%w\nSeparate git clone flags with `--`.", err)
 	})
 
-	cmd.Flags().BoolVar(&opts.Clone, "clone", false, "Clone the fork {true|false}")
-	cmd.Flags().BoolVar(&opts.Remote, "remote", false, "Add remote for fork {true|false}")
-	cmd.Flags().StringVar(&opts.RemoteName, "remote-name", defaultRemoteName, "Specify a name for a fork's new remote.")
+	cmd.Flags().BoolVar(&opts.Clone, "clone", false, "Clone the fork")
+	cmd.Flags().BoolVar(&opts.Remote, "remote", false, "Add a git remote for the fork")
+	cmd.Flags().StringVar(&opts.RemoteName, "remote-name", defaultRemoteName, "Specify the name for the new remote")
 	cmd.Flags().StringVar(&opts.Organization, "org", "", "Create the fork in an organization")
-	cmd.Flags().StringVar(&opts.ForkName, "fork-name", "", "Specify a name for the forked repo")
+	cmd.Flags().StringVar(&opts.ForkName, "fork-name", "", "Rename the forked repository")
 
 	return cmd
 }

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -45,7 +45,7 @@ func TestNewCmdFork(t *testing.T) {
 			name:    "git args without repo",
 			cli:     "-- --foo bar",
 			wantErr: true,
-			errMsg:  "repository argument required when passing 'git clone' flags",
+			errMsg:  "repository argument required when passing git clone flags",
 		},
 		{
 			name: "repo",
@@ -130,7 +130,7 @@ func TestNewCmdFork(t *testing.T) {
 			name:    "git flags in wrong place",
 			cli:     "--depth 1 OWNER/REPO",
 			wantErr: true,
-			errMsg:  "unknown flag: --depth\nSeparate git clone flags with '--'.",
+			errMsg:  "unknown flag: --depth\nSeparate git clone flags with `--`.",
 		},
 		{
 			name: "with fork name",

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -22,7 +22,7 @@ import (
 func NewCmdRepo(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "repo <command>",
-		Short: "Create, clone, fork, and view repositories",
+		Short: "Manage repositories",
 		Long:  `Work with GitHub repositories.`,
 		Example: heredoc.Doc(`
 			$ gh repo create

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -50,9 +50,6 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 			"help:feedback": heredoc.Doc(`
 				Open an issue using 'gh issue create -R github.com/cli/cli'
 			`),
-			"help:environment": heredoc.Doc(`
-				See 'gh help environment' for the list of supported environment variables.
-			`),
 		},
 	}
 


### PR DESCRIPTION
- list help topics in `gh` help output
- clean up `repo fork` docs
- allow `issue comment --editor` even if prompts are globally disabled
- fixes https://github.com/cli/cli/issues/2891
- fixes https://github.com/cli/cli/issues/3433
- fixes https://github.com/cli/cli/issues/4887
- fixes https://github.com/cli/cli/issues/1777
- fixes https://github.com/cli/cli/issues/2657
- fixes https://github.com/cli/cli/issues/4160
- fixes https://github.com/cli/cli/issues/1540