### PR TITLE
Use `git config user.email` to determine the author email used when merging with `gh pr merge`

### DIFF
--- a/pkg/cmd/pr/merge/http.go
+++ b/pkg/cmd/pr/merge/http.go
@@ -20,13 +20,14 @@ const (
 )
 
 type mergePayload struct {
-	repo          ghrepo.Interface
-	pullRequestID string
-	method        PullRequestMergeMethod
-	auto          bool
-	commitSubject string
-	commitBody    string
-	setCommitBody bool
+	repo              ghrepo.Interface
+	pullRequestID     string
+	method            PullRequestMergeMethod
+	auto              bool
+	commitSubject     string
+	commitBody        string
+	commitAuthorEmail string
+	setCommitBody     bool
 }
 
 // TODO: drop after githubv4 gets updated
@@ -58,6 +59,10 @@ func mergePullRequest(client *http.Client, payload mergePayload) error {
 	if payload.setCommitBody {
 		commitBody := githubv4.String(payload.commitBody)
 		input.CommitBody = &commitBody
+	}
+	if payload.commitAuthorEmail != "" {
+		authorEmail := githubv4.String(payload.commitAuthorEmail)
+		input.AuthorEmail = &authorEmail
 	}
 
 	variables := map[string]interface{}{

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -228,10 +228,10 @@ func mergeRun(opts *MergeOptions) error {
 	}
 
 	if !isPRAlreadyMerged {
-		authorEmail, err := git.Config("user.email")
-		if err != nil {
-			// work out what to do if an error occurs
-		}
+
+		// ignore error, since git.Config will return "" for
+		// authorEmail if any error occurs
+		authorEmail, _ := git.Config("user.email")
 
 		payload := mergePayload{
 			repo:              baseRepo,

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -228,14 +228,20 @@ func mergeRun(opts *MergeOptions) error {
 	}
 
 	if !isPRAlreadyMerged {
+		authorEmail, err := git.Config("user.email")
+		if err != nil {
+			// work out what to do if an error occurs
+		}
+
 		payload := mergePayload{
-			repo:          baseRepo,
-			pullRequestID: pr.ID,
-			method:        opts.MergeMethod,
-			auto:          autoMerge,
-			commitSubject: opts.Subject,
-			commitBody:    opts.Body,
-			setCommitBody: opts.BodySet,
+			repo:              baseRepo,
+			pullRequestID:     pr.ID,
+			method:            opts.MergeMethod,
+			auto:              autoMerge,
+			commitSubject:     opts.Subject,
+			commitBody:        opts.Body,
+			commitAuthorEmail: authorEmail,
+			setCommitBody:     opts.BodySet,
 		}
 
 		if opts.InteractiveMode {


### PR DESCRIPTION
Fixes #1450

Tested on https://github.com/jtaylor100/test-repo

* https://github.com/jtaylor100/test-repo/commit/adebf80fed7a61f3f1d3e423b22f4b2b0bd76582 was made before the below changes, incorrectly using my GitHub default email as the author email.
* https://github.com/jtaylor100/test-repo/commit/5d1d23d236da3018fe1b06b9b019aa7897d19ff1 was made after the below changes, using the value of `git config user.email` from the repo as the author email.
* https://github.com/jtaylor100/test-repo/commit/0e2176b4463b2d187522d2562854bd06c6c132b3 was made after the below changes, where locally my value of `git config user.email` was empty, so the default GitHub email is used.