### PR TITLE
Add macOS-arm64 builds to release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ builds:
         - -X main.updaterEnabled=cli/cli
     id: macos
     goos: [darwin]
-    goarch: [amd64]
+    goarch: [amd64, arm64]
 
   - <<: *build_defaults
     id: linux


### PR DESCRIPTION
Currently GoReleaser only builds amd64 binaries for macOS. Adds arm64 to the architecture list.