### PR TITLE
after merge, switch to base branch if available

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -307,6 +307,15 @@ func CheckoutBranch(branch string) error {
 	return run.PrepareCmd(configCmd).Run()
 }
 
+func CheckoutNewBranch(remoteName, branch string) error {
+	track := fmt.Sprintf("%s/%s", remoteName, branch)
+	configCmd, err := GitCommand("checkout", "-b", branch, "--track", track)
+	if err != nil {
+		return err
+	}
+	return run.PrepareCmd(configCmd).Run()
+}
+
 // pull changes from remote branch without version history
 func Pull(remote, branch string) error {
 	pullCmd, err := GitCommand("pull", "--ff-only", remote, branch)

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -322,9 +322,13 @@ func mergeRun(opts *MergeOptions) error {
 
 		var branchToSwitchTo string
 		if currentBranch == pr.HeadRefName {
-			branchToSwitchTo, err = api.RepoDefaultBranch(apiClient, baseRepo)
-			if err != nil {
-				return err
+			if pr.BaseRefName != "" && git.HasLocalBranch(pr.BaseRefName) {
+				branchToSwitchTo = pr.BaseRefName
+			} else {
+				branchToSwitchTo, err = api.RepoDefaultBranch(apiClient, baseRepo)
+				if err != nil {
+					return err
+				}
 			}
 
 			err = git.CheckoutBranch(branchToSwitchTo)

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -340,19 +340,16 @@ func mergeRun(opts *MergeOptions) error {
 			}
 
 			if git.HasLocalBranch(branchToSwitchTo) {
-				err = git.CheckoutBranch(branchToSwitchTo)
-				if err != nil {
+				if err := git.CheckoutBranch(branchToSwitchTo); err != nil {
 					return err
 				}
 			} else {
-				err = git.CheckoutNewBranch(baseRemote.Name, branchToSwitchTo)
-				if err != nil {
+				if err := git.CheckoutNewBranch(baseRemote.Name, branchToSwitchTo); err != nil {
 					return err
 				}
 			}
 
-			err = git.Pull(baseRemote.Name, branchToSwitchTo)
-			if err != nil {
+			if err := git.Pull(baseRemote.Name, branchToSwitchTo); err != nil {
 				fmt.Fprintf(opts.IO.ErrOut, "%s warning: not possible to fast-forward to: %q\n", cs.WarningIcon(), branchToSwitchTo)
 			}
 		}

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -497,6 +497,56 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 	`), output.Stderr())
 }
 
+func TestPrMerge_deleteBranch_nonDefault(t *testing.T) {
+	http := initFakeHTTP()
+	defer http.Verify(t)
+
+	shared.RunCommandFinder(
+		"",
+		&api.PullRequest{
+			ID:               "PR_10",
+			Number:           10,
+			State:            "OPEN",
+			Title:            "Blueberries are a good fruit",
+			HeadRefName:      "blueberries",
+			MergeStateStatus: "CLEAN",
+			BaseRefName:      "fruit",
+		},
+		baseRepo("OWNER", "REPO", "master"),
+	)
+
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestMerge\b`),
+		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+			assert.Equal(t, "PR_10", input["pullRequestId"].(string))
+			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
+			assert.NotContains(t, input, "commitHeadline")
+		}))
+	http.Register(
+		httpmock.REST("DELETE", "repos/OWNER/REPO/git/refs/heads/blueberries"),
+		httpmock.StringResponse(`{}`))
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	cs.Register(`git rev-parse --verify refs/heads/fruit`, 0, "")
+	cs.Register(`git checkout fruit`, 0, "")
+	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
+	cs.Register(`git branch -D blueberries`, 0, "")
+	cs.Register(`git pull --ff-only`, 0, "")
+
+	output, err := runCommand(http, "blueberries", true, `pr merge --merge --delete-branch`)
+	if err != nil {
+		t.Fatalf("Got unexpected error running `pr merge` %s", err)
+	}
+
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, heredoc.Doc(`
+		✓ Merged pull request #10 (Blueberries are a good fruit)
+		✓ Deleted branch blueberries and switched to branch fruit
+	`), output.Stderr())
+}
+
 func TestPrMerge_deleteNonCurrentBranch(t *testing.T) {
 	http := initFakeHTTP()
 	defer http.Verify(t)
@@ -764,6 +814,7 @@ func TestPrMerge_alreadyMerged(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
+	cs.Register(`git rev-parse --verify refs/heads/master`, 0, "")
 	cs.Register(`git checkout master`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -480,6 +480,7 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
+	cs.Register(`git rev-parse --verify refs/heads/master`, 0, "")
 	cs.Register(`git checkout master`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
@@ -531,6 +532,56 @@ func TestPrMerge_deleteBranch_nonDefault(t *testing.T) {
 
 	cs.Register(`git rev-parse --verify refs/heads/fruit`, 0, "")
 	cs.Register(`git checkout fruit`, 0, "")
+	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
+	cs.Register(`git branch -D blueberries`, 0, "")
+	cs.Register(`git pull --ff-only`, 0, "")
+
+	output, err := runCommand(http, "blueberries", true, `pr merge --merge --delete-branch`)
+	if err != nil {
+		t.Fatalf("Got unexpected error running `pr merge` %s", err)
+	}
+
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, heredoc.Doc(`
+		✓ Merged pull request #10 (Blueberries are a good fruit)
+		✓ Deleted branch blueberries and switched to branch fruit
+	`), output.Stderr())
+}
+
+func TestPrMerge_deleteBranch_checkoutNewBranch(t *testing.T) {
+	http := initFakeHTTP()
+	defer http.Verify(t)
+
+	shared.RunCommandFinder(
+		"",
+		&api.PullRequest{
+			ID:               "PR_10",
+			Number:           10,
+			State:            "OPEN",
+			Title:            "Blueberries are a good fruit",
+			HeadRefName:      "blueberries",
+			MergeStateStatus: "CLEAN",
+			BaseRefName:      "fruit",
+		},
+		baseRepo("OWNER", "REPO", "master"),
+	)
+
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestMerge\b`),
+		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+			assert.Equal(t, "PR_10", input["pullRequestId"].(string))
+			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
+			assert.NotContains(t, input, "commitHeadline")
+		}))
+	http.Register(
+		httpmock.REST("DELETE", "repos/OWNER/REPO/git/refs/heads/blueberries"),
+		httpmock.StringResponse(`{}`))
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	cs.Register(`git rev-parse --verify refs/heads/fruit`, 1, "")
+	cs.Register(`git checkout -b fruit --track origin/fruit`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
 	cs.Register(`git pull --ff-only`, 0, "")
@@ -957,6 +1008,7 @@ func TestPRMerge_interactiveWithDeleteBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
+	cs.Register(`git rev-parse --verify refs/heads/master`, 0, "")
 	cs.Register(`git checkout master`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")


### PR DESCRIPTION
Fixes #1096 

After merging, previously we would switch to the default branch in the repo. With this change, after merging we switch our branch to the base branch of the pull request. If that is not available, then we fall back to the same behavior as before.