### PR TITLE
Fix obtained scope mapping to include implied scopes

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -236,7 +236,19 @@ func ScopesSuggestion(resp *http.Response) string {
 	for _, s := range strings.Split(tokenHasScopes, ",") {
 		s = strings.TrimSpace(s)
 		gotScopes[s] = struct{}{}
-		if strings.HasPrefix(s, "admin:") {
+		if s == "repo" {
+			gotScopes["repo:status"] = struct{}{}
+			gotScopes["repo_deployment"] = struct{}{}
+			gotScopes["public_repo"] = struct{}{}
+			gotScopes["repo:invite"] = struct{}{}
+			gotScopes["security_events"] = struct{}{}
+		} else if s == "user" {
+			gotScopes["read:user"] = struct{}{}
+			gotScopes["user:email"] = struct{}{}
+			gotScopes["user:follow"] = struct{}{}
+		} else if s == "codespace" {
+			gotScopes["codespace:secrets"] = struct{}{}
+		} else if strings.HasPrefix(s, "admin:") {
 			gotScopes["read:"+strings.TrimPrefix(s, "admin:")] = struct{}{}
 			gotScopes["write:"+strings.TrimPrefix(s, "admin:")] = struct{}{}
 		} else if strings.HasPrefix(s, "write:") {

--- a/api/client.go
+++ b/api/client.go
@@ -236,7 +236,7 @@ func ScopesSuggestion(resp *http.Response) string {
 	for _, s := range strings.Split(tokenHasScopes, ",") {
 		s = strings.TrimSpace(s)
 		gotScopes[s] = struct{}{}
-		
+
 		// Certain scopes may be grouped under a single "top-level" scope. The following branch
 		// statements include these grouped/implied scopes when the top-level scope is encountered.
 		// See https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps.

--- a/api/client.go
+++ b/api/client.go
@@ -236,6 +236,10 @@ func ScopesSuggestion(resp *http.Response) string {
 	for _, s := range strings.Split(tokenHasScopes, ",") {
 		s = strings.TrimSpace(s)
 		gotScopes[s] = struct{}{}
+		
+		// Certain scopes may be grouped under a single "top-level" scope. The following branch
+		// statements include these grouped/implied scopes when the top-level scope is encountered.
+		// See https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps.
 		if s == "repo" {
 			gotScopes["repo:status"] = struct{}{}
 			gotScopes["repo_deployment"] = struct{}{}


### PR DESCRIPTION
As is, `gotScopes` does not contain certain scopes because it doesn't check for the "special" scopes that imply other scopes. For example, the `repo` scope implies `repo:invite`.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
