### PR TITLE
Support "all failed jobs" and individual job re-run for a github actions workflow run

### DIFF
--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -50,11 +50,7 @@ func NewCmdRerun(f *cmdutil.Factory, runF func(*RerunOptions) error) *cobra.Comm
 			}
 
 			if opts.RunID != "" && opts.JobID != "" {
-				opts.RunID = ""
-				if opts.IO.CanPrompt() {
-					cs := opts.IO.ColorScheme()
-					fmt.Fprintf(opts.IO.ErrOut, "%s both run and job IDs specified; ignoring run ID\n", cs.WarningIcon())
-				}
+				return cmdutil.FlagErrorf("specify only one of <run-id> or <job-id>")
 			}
 
 			if runF != nil {

--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -41,7 +41,7 @@ func NewCmdRerun(f *cmdutil.Factory, runF func(*RerunOptions) error) *cobra.Comm
 
 			if len(args) == 0 && opts.JobID == "" {
 				if !opts.IO.CanPrompt() {
-					return cmdutil.FlagErrorf("run or job ID required when not running interactively")
+					return cmdutil.FlagErrorf("`<run-id>` or `--job` required when not running interactively")
 				} else {
 					opts.Prompt = true
 				}
@@ -50,7 +50,7 @@ func NewCmdRerun(f *cmdutil.Factory, runF func(*RerunOptions) error) *cobra.Comm
 			}
 
 			if opts.RunID != "" && opts.JobID != "" {
-				return cmdutil.FlagErrorf("specify only one of <run-id> or <job-id>")
+				return cmdutil.FlagErrorf("specify only one of `<run-id>` or `--job`")
 			}
 
 			if runF != nil {
@@ -60,7 +60,7 @@ func NewCmdRerun(f *cmdutil.Factory, runF func(*RerunOptions) error) *cobra.Comm
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.OnlyFailed, "failed", false, "Rerun only failed jobs")
+	cmd.Flags().BoolVar(&opts.OnlyFailed, "failed", false, "Rerun only failed jobs, including dependencies")
 	cmd.Flags().StringVarP(&opts.JobID, "job", "j", "", "Rerun a specific job from a run, including dependencies")
 
 	return cmd
@@ -107,7 +107,7 @@ func runRerun(opts *RerunOptions) error {
 			return fmt.Errorf("failed to get runs: %w", err)
 		}
 		if len(runs) == 0 {
-			return errors.New("no recent runs have failed; please specify a specific run ID")
+			return errors.New("no recent runs have failed; please specify a specific `<run-id>`")
 		}
 		runID, err = shared.PromptForRun(cs, runs)
 		if err != nil {

--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -124,7 +124,7 @@ func runRerun(opts *RerunOptions) error {
 		if err != nil {
 			return err
 		}
-		if opts.IO.CanPrompt() {
+		if opts.IO.IsStdoutTTY() {
 			fmt.Fprintf(opts.IO.Out, "%s Requested rerun of job %s on run %s\n",
 				cs.SuccessIcon(),
 				cs.Cyanf("%d", selectedJob.ID),
@@ -142,7 +142,7 @@ func runRerun(opts *RerunOptions) error {
 		if err != nil {
 			return err
 		}
-		if opts.IO.CanPrompt() {
+		if opts.IO.IsStdoutTTY() {
 			onlyFailedMsg := ""
 			if opts.OnlyFailed {
 				onlyFailedMsg = "(failed jobs) "

--- a/pkg/cmd/run/rerun/rerun_test.go
+++ b/pkg/cmd/run/rerun/rerun_test.go
@@ -50,6 +50,23 @@ func TestNewCmdRerun(t *testing.T) {
 				RunID: "1234",
 			},
 		},
+		{
+			name: "failed arg nontty",
+			cli:  "4321 --failed",
+			wants: RerunOptions{
+				RunID:      "4321",
+				OnlyFailed: true,
+			},
+		},
+		{
+			name: "failed arg",
+			tty:  true,
+			cli:  "--failed",
+			wants: RerunOptions{
+				Prompt:     true,
+				OnlyFailed: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,6 +133,23 @@ func TestRerun(t *testing.T) {
 					httpmock.StringResponse("{}"))
 			},
 			wantOut: "✓ Requested rerun of run 1234\n",
+		},
+		{
+			name: "arg including onlyFailed",
+			tty:  true,
+			opts: &RerunOptions{
+				RunID:      "1234",
+				OnlyFailed: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/1234"),
+					httpmock.JSONResponse(shared.FailedRun))
+				reg.Register(
+					httpmock.REST("POST", "repos/OWNER/REPO/actions/runs/1234/rerun-failed-jobs"),
+					httpmock.StringResponse("{}"))
+			},
+			wantOut: "✓ Requested rerun (failed jobs) of run 1234\n",
 		},
 		{
 			name: "prompt",

--- a/pkg/cmd/run/rerun/rerun_test.go
+++ b/pkg/cmd/run/rerun/rerun_test.go
@@ -233,7 +233,7 @@ func TestRerun(t *testing.T) {
 						}}))
 			},
 			wantErr: true,
-			errOut:  "no recent runs have failed; please specify a specific run ID",
+			errOut:  "no recent runs have failed; please specify a specific `<run-id>`",
 		},
 		{
 			name: "unrerunnable",

--- a/pkg/cmd/run/rerun/rerun_test.go
+++ b/pkg/cmd/run/rerun/rerun_test.go
@@ -67,6 +67,33 @@ func TestNewCmdRerun(t *testing.T) {
 				OnlyFailed: true,
 			},
 		},
+		{
+			name: "with arg job",
+			tty:  true,
+			cli:  "--job 1234",
+			wants: RerunOptions{
+				JobID: "1234",
+			},
+		},
+		{
+			name: "with args job and runID ignores runID",
+			tty:  true,
+			cli:  "1234 --job 5678",
+			wants: RerunOptions{
+				JobID: "5678",
+			},
+		},
+		{
+			name:     "with arg job with no ID fails",
+			tty:      true,
+			cli:      "--job",
+			wantsErr: true,
+		},
+		{
+			name:     "with arg job with no ID no tty fails",
+			cli:      "--job",
+			wantsErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -152,6 +179,22 @@ func TestRerun(t *testing.T) {
 			wantOut: "✓ Requested rerun (failed jobs) of run 1234\n",
 		},
 		{
+			name: "arg including a specific job",
+			tty:  true,
+			opts: &RerunOptions{
+				JobID: "20", // 20 is shared.FailedJob.ID
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/jobs/20"),
+					httpmock.JSONResponse(shared.FailedJob))
+				reg.Register(
+					httpmock.REST("POST", "repos/OWNER/REPO/actions/jobs/20/rerun"),
+					httpmock.StringResponse("{}"))
+			},
+			wantOut: "✓ Requested rerun of job 20 on run 1234\n",
+		},
+		{
 			name: "prompt",
 			tty:  true,
 			opts: &RerunOptions{
@@ -209,7 +252,7 @@ func TestRerun(t *testing.T) {
 					httpmock.StatusStringResponse(403, "no"))
 			},
 			wantErr: true,
-			errOut:  "run 3 cannot be rerun; its workflow file may be broken.",
+			errOut:  "run 3 cannot be rerun; its workflow file may be broken",
 		},
 	}
 

--- a/pkg/cmd/run/rerun/rerun_test.go
+++ b/pkg/cmd/run/rerun/rerun_test.go
@@ -76,12 +76,10 @@ func TestNewCmdRerun(t *testing.T) {
 			},
 		},
 		{
-			name: "with args job and runID ignores runID",
-			tty:  true,
-			cli:  "1234 --job 5678",
-			wants: RerunOptions{
-				JobID: "5678",
-			},
+			name:     "with args jobID and runID fails",
+			tty:      true,
+			cli:      "1234 --job 5678",
+			wantsErr: true,
 		},
 		{
 			name:     "with arg job with no ID fails",

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -307,6 +307,18 @@ func GetJobs(client *api.Client, repo ghrepo.Interface, run Run) ([]Job, error) 
 	return result.Jobs, nil
 }
 
+func GetJob(client *api.Client, repo ghrepo.Interface, jobID string) (*Job, error) {
+	path := fmt.Sprintf("repos/%s/actions/jobs/%s", ghrepo.FullName(repo), jobID)
+
+	var result Job
+	err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
 func PromptForRun(cs *iostreams.ColorScheme, runs []Run) (string, error) {
 	var selected int
 	now := time.Now()

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -183,7 +183,7 @@ func runView(opts *ViewOptions) error {
 
 	if jobID != "" {
 		opts.IO.StartProgressIndicator()
-		selectedJob, err = getJob(client, repo, jobID)
+		selectedJob, err = shared.GetJob(client, repo, jobID)
 		opts.IO.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to get job: %w", err)
@@ -393,18 +393,6 @@ func runView(opts *ViewOptions) error {
 	}
 
 	return nil
-}
-
-func getJob(client *api.Client, repo ghrepo.Interface, jobID string) (*shared.Job, error) {
-	path := fmt.Sprintf("repos/%s/actions/jobs/%s", ghrepo.FullName(repo), jobID)
-
-	var result shared.Job
-	err := client.REST(repo.RepoHost(), "GET", path, nil, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	return &result, nil
 }
 
 func getLog(httpClient *http.Client, logURL string) (io.ReadCloser, error) {


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

This PR implements 2 new flags to the `gh run rerun` workflow, to support the upcoming work to allow running only the failed jobs from a GitHub Actions workflow run (`--failed`) and a specific job from a workflow (`--job <job-id>`).

The endpoints referenced here are NOT yet released publicly, so this PR should not be merged yet, but hopefully can merge shortly after we launch.

Our internal issue tracking this is https://github.com/github/cli/issues/110, let me know if I should create one in this repo as well. 

Also first time contributing here so open to any and all feedback, thanks in advance!! 🙇 