### PR TITLE
Adds internal codespace developer flags

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "extensions": [
+        "golang.go"
+    ]
+}

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -579,6 +579,8 @@ type CreateCodespaceParams struct {
 	Branch             string
 	Machine            string
 	Location           string
+	VscsTarget         string
+	VscsTargetUrl      string
 	PermissionsOptOut  bool
 }
 
@@ -625,6 +627,8 @@ type startCreateRequest struct {
 	Ref                string `json:"ref"`
 	Location           string `json:"location"`
 	Machine            string `json:"machine"`
+	VscsTarget         string `json:"vscs_target,omitempty"`
+	VscsTargetUrl      string `json:"vscs_target_url,omitempty"`
 	PermissionsOptOut  bool   `json:"devcontainer_permissions_opt_out"`
 }
 
@@ -654,8 +658,11 @@ func (a *API) startCreate(ctx context.Context, params *CreateCodespaceParams) (*
 		Ref:                params.Branch,
 		Location:           params.Location,
 		Machine:            params.Machine,
+		VscsTarget:         params.VscsTarget,
+		VscsTargetUrl:      params.VscsTargetUrl,
 		PermissionsOptOut:  params.PermissionsOptOut,
 	})
+
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling request: %w", err)
 	}

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -579,8 +579,8 @@ type CreateCodespaceParams struct {
 	Branch             string
 	Machine            string
 	Location           string
-	VscsTarget         string
-	VscsTargetUrl      string
+	VSCSTarget         string
+	VSCSTargetURL      string
 	PermissionsOptOut  bool
 }
 
@@ -627,8 +627,8 @@ type startCreateRequest struct {
 	Ref                string `json:"ref"`
 	Location           string `json:"location"`
 	Machine            string `json:"machine"`
-	VscsTarget         string `json:"vscs_target,omitempty"`
-	VscsTargetUrl      string `json:"vscs_target_url,omitempty"`
+	VSCSTarget         string `json:"vscs_target,omitempty"`
+	VSCSTargetURL      string `json:"vscs_target_url,omitempty"`
 	PermissionsOptOut  bool   `json:"devcontainer_permissions_opt_out"`
 }
 
@@ -658,8 +658,8 @@ func (a *API) startCreate(ctx context.Context, params *CreateCodespaceParams) (*
 		Ref:                params.Branch,
 		Location:           params.Location,
 		Machine:            params.Machine,
-		VscsTarget:         params.VscsTarget,
-		VscsTargetUrl:      params.VscsTargetUrl,
+		VSCSTarget:         params.VSCSTarget,
+		VSCSTargetURL:      params.VSCSTargetURL,
 		PermissionsOptOut:  params.PermissionsOptOut,
 	})
 

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -54,11 +54,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 	vscsTarget := os.Getenv("VSCS_TARGET")
 	vscsTargetUrl := os.Getenv("VSCS_TARGET_URL")
 
-	locationResult := locationResult{vscsLocation, nil}
-	if vscsLocation == "" {
-		// Automatic region detection
-		locationResult = <-getLocation(ctx, a.apiClient)
-	}
+	locationCh := getLocation(ctx, vscsLocation, a.apiClient)
 
 	userInputs := struct {
 		Repository string
@@ -110,6 +106,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		branch = repository.DefaultBranch
 	}
 
+	locationResult := <-locationCh
 	if locationResult.Err != nil {
 		return fmt.Errorf("error getting codespace region location: %w", locationResult.Err)
 	}
@@ -294,9 +291,18 @@ type locationResult struct {
 	Err      error
 }
 
-// getLocation fetches the closest Codespace datacenter region/location to the user.
-func getLocation(ctx context.Context, apiClient apiClient) <-chan locationResult {
+// getLocation fetches the closest Codespace datacenter
+// region/location to the user, unless the 'vscsLocationOverride' override is set
+func getLocation(ctx context.Context, vscsLocationOverride string, apiClient apiClient) <-chan locationResult {
 	ch := make(chan locationResult, 1)
+
+	// Developer override is set, return the override
+	if vscsLocationOverride != "" {
+		ch <- locationResult{vscsLocationOverride, nil}
+		return ch
+	}
+
+	// Dynamically fetch the region location
 	go func() {
 		location, err := apiClient.GetCodespaceRegionLocation(ctx)
 		ch <- locationResult{location, err}

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -291,6 +291,15 @@ type locationResult struct {
 // getLocation fetches the closest Codespace datacenter region/location to the user.
 func getLocation(ctx context.Context, apiClient apiClient) <-chan locationResult {
 	ch := make(chan locationResult, 1)
+
+	// Allow manually setting location string for testing with vscs_target
+	vscsLocation := os.Getenv("VSCS_LOCATION")
+	if vscsLocation != "" {
+		ch <- locationResult{vscsLocation, nil}
+		return ch
+	}
+
+	// Region detection
 	go func() {
 		location, err := apiClient.GetCodespaceRegionLocation(ctx)
 		ch <- locationResult{location, err}

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -112,11 +113,16 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return errors.New("there are no available machine types for this repository")
 	}
 
+	vscsTarget := os.Getenv("VSCS_TARGET")
+	vscsTargetUrl := os.Getenv("VSCS_TARGET_URL")
+
 	createParams := &api.CreateCodespaceParams{
 		RepositoryID:       repository.ID,
 		Branch:             branch,
 		Machine:            machine,
 		Location:           locationResult.Location,
+		VscsTarget:         vscsTarget,
+		VscsTargetUrl:      vscsTargetUrl,
 		IdleTimeoutMinutes: int(opts.idleTimeout.Minutes()),
 		PermissionsOptOut:  opts.permissionsOptOut,
 	}


### PR DESCRIPTION
closes https://github.com/github/codespaces/issues/6743

Adds internal developer flags to the Codespaces CLI client.

Also inits the repo's `devcontainer` for a better dev experience with Codespaces :) 