### PR TITLE
Add ability to use negated qualifiers

### DIFF
--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -105,6 +105,9 @@ func formatQualifiers(qs Qualifiers) []string {
 
 func formatKeywords(ks []string) []string {
 	for i, k := range ks {
+		if strings.Contains(k, ":") {
+			k = strings.TrimPrefix(k, "not")
+		}
 		ks[i] = quote(k)
 	}
 	return ks

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -56,6 +56,13 @@ func TestQueryString(t *testing.T) {
 			},
 			out: "topic:\"quote qualifier\"",
 		},
+		{
+			name: "negates keywords",
+			query: Query{
+				Keywords: []string{"not-org:cli"},
+			},
+			out: "-org:cli",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
On GitHub there is at the ability to negate all search qualifiers by adding a `-` in front of the qualifier name. Doing this using the search commands results in an error due to our flag parsing library inadvertently thinking it is a shorthand flag. 
```shell
$ gh search repos test -org:cli
$ unknown shorthand flag: 'o' in -org:cli
```
To overcome this limitation this PR introduces the syntax of `not-` for negating search qualifiers. This syntax gets translated to the standard `-` when being sent to GitHub.
```shell
$ gh search repos test not-org:cli
$ Showing 30 of 4971327 repositories
```