### PR TITLE
Add VSCS Target to `gh cs list`

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -171,7 +171,7 @@ type Codespace struct {
 	GitStatus   CodespaceGitStatus  `json:"git_status"`
 	Connection  CodespaceConnection `json:"connection"`
 	Machine     CodespaceMachine    `json:"machine"`
-	VSCSTarget  string              `json:"vscs_target,omitempty"`
+	VSCSTarget  string              `json:"vscs_target"`
 }
 
 type CodespaceGitStatus struct {

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -226,6 +226,7 @@ var CodespaceFields = []string{
 	"createdAt",
 	"lastUsedAt",
 	"machineName",
+	"vscsTarget",
 }
 
 func (c *Codespace) ExportData(fields []string) map[string]interface{} {
@@ -245,6 +246,10 @@ func (c *Codespace) ExportData(fields []string) map[string]interface{} {
 				"ref":                  c.GitStatus.Ref,
 				"hasUnpushedChanges":   c.GitStatus.HasUnpushedChanges,
 				"hasUncommitedChanges": c.GitStatus.HasUncommitedChanges,
+			}
+		case "vscsTarget":
+			if c.VSCSTarget != "" && c.VSCSTarget != VSCSTargetProduction {
+				data[f] = c.VSCSTarget
 			}
 		default:
 			sf := v.FieldByNameFunc(func(s string) bool {

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -171,6 +171,7 @@ type Codespace struct {
 	GitStatus   CodespaceGitStatus  `json:"git_status"`
 	Connection  CodespaceConnection `json:"connection"`
 	Machine     CodespaceMachine    `json:"machine"`
+	VSCSTarget  string              `json:"vscs_target,omitempty"`
 }
 
 type CodespaceGitStatus struct {

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -52,6 +52,13 @@ const (
 	vscsAPI      = "https://online.visualstudio.com"
 )
 
+const (
+	VSCSTargetLocal       = "local"
+	VSCSTargetDevelopment = "development"
+	VSCSTargetPPE         = "ppe"
+	VSCSTargetProduction  = "production"
+)
+
 // API is the interface to the codespace service.
 type API struct {
 	client       httpClient

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -43,6 +43,13 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 		return fmt.Errorf("error getting codespaces: %w", err)
 	}
 
+	hasNonDefaultVSCSTarget := false
+	for _, apiCodespace := range codespaces {
+		if apiCodespace.VSCSTarget != "prod" {
+			hasNonDefaultVSCSTarget = true
+		}
+	}
+
 	if err := a.io.StartPager(); err != nil {
 		a.errLogger.Printf("error starting pager: %v", err)
 	}
@@ -59,6 +66,11 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 		tp.AddField("BRANCH", nil, nil)
 		tp.AddField("STATE", nil, nil)
 		tp.AddField("CREATED AT", nil, nil)
+
+		if hasNonDefaultVSCSTarget {
+			tp.AddField("VSCS TARGET", nil, nil)
+		}
+
 		tp.EndRow()
 	}
 
@@ -88,6 +100,11 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 		} else {
 			tp.AddField(c.CreatedAt, nil, nil)
 		}
+
+		if hasNonDefaultVSCSTarget {
+			tp.AddField(c.VSCSTarget, nil, nil)
+		}
+
 		tp.EndRow()
 	}
 

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -43,10 +43,10 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 		return fmt.Errorf("error getting codespaces: %w", err)
 	}
 
-	hasNonDefaultVSCSTarget := false
+	hasNonProdVSCSTarget := false
 	for _, apiCodespace := range codespaces {
 		if apiCodespace.VSCSTarget != "prod" {
-			hasNonDefaultVSCSTarget = true
+			hasNonProdVSCSTarget = true
 		}
 	}
 
@@ -67,7 +67,7 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 		tp.AddField("STATE", nil, nil)
 		tp.AddField("CREATED AT", nil, nil)
 
-		if hasNonDefaultVSCSTarget {
+		if hasNonProdVSCSTarget {
 			tp.AddField("VSCS TARGET", nil, nil)
 		}
 
@@ -101,7 +101,7 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 			tp.AddField(c.CreatedAt, nil, nil)
 		}
 
-		if hasNonDefaultVSCSTarget {
+		if hasNonProdVSCSTarget {
 			tp.AddField(c.VSCSTarget, nil, nil)
 		}
 

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -45,8 +45,9 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 
 	hasNonProdVSCSTarget := false
 	for _, apiCodespace := range codespaces {
-		if apiCodespace.VSCSTarget != "prod" {
+		if apiCodespace.VSCSTarget != "" && apiCodespace.VSCSTarget != api.VSCSTargetProduction {
 			hasNonProdVSCSTarget = true
+			break
 		}
 	}
 
@@ -114,11 +115,11 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 }
 
 func formatNameForVSCSTarget(name, vscsTarget string) string {
-	if vscsTarget == "dev" || vscsTarget == "local" {
+	if vscsTarget == api.VSCSTargetDevelopment || vscsTarget == api.VSCSTargetLocal {
 		return fmt.Sprintf("%s 🚧", name)
 	}
 
-	if vscsTarget == "ppe" {
+	if vscsTarget == api.VSCSTargetPPE {
 		return fmt.Sprintf("%s ✨", name)
 	}
 

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -86,7 +86,9 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 			stateColor = cs.Green
 		}
 
-		tp.AddField(c.Name, nil, cs.Yellow)
+		formattedName := formatNameForVSCSTarget(c.Name, c.VSCSTarget)
+
+		tp.AddField(formattedName, nil, cs.Yellow)
 		tp.AddField(c.Repository.FullName, nil, nil)
 		tp.AddField(c.branchWithGitStatus(), nil, cs.Cyan)
 		tp.AddField(c.State, nil, stateColor)
@@ -109,4 +111,16 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 	}
 
 	return tp.Render()
+}
+
+func formatNameForVSCSTarget(name, vscsTarget string) string {
+	if vscsTarget == "dev" || vscsTarget == "local" {
+		return fmt.Sprintf("%s 🚧", name)
+	}
+
+	if vscsTarget == "ppe" {
+		return fmt.Sprintf("%s ✨", name)
+	}
+
+	return name
 }


### PR DESCRIPTION
closes https://github.com/github/codespaces/issues/6921

Adds `VSCS Target` column to the `gh cs list` if any non-prod codespaces exist. Also adds 🚧 and ✨ to names for dev and ppe.