### PR TITLE
Add `--profile` option to `gh cs cp`

### DIFF
--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -379,6 +379,7 @@ func newCpCmd(app *App) *cobra.Command {
 	cpCmd.Flags().BoolVarP(&opts.recursive, "recursive", "r", false, "Recursively copy directories")
 	cpCmd.Flags().BoolVarP(&opts.expand, "expand", "e", false, "Expand remote file names on remote shell")
 	cpCmd.Flags().StringVarP(&opts.codespace, "codespace", "c", "", "Name of the codespace")
+	cpCmd.Flags().StringVarP(&opts.profile, "profile", "p", "", "Name of the SSH profile to use")
 	return cpCmd
 }
 


### PR DESCRIPTION
closes https://github.com/github/codespaces/issues/6922

Simply exposes the `--profile` option which is already coded up for `gh cs ssh` for `gh cs cp`. This allows the use of custom profiles for `cp` the same way they are used for `ssh`.