### PR TITLE
Added Support for GH_DEBUG

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -327,9 +327,10 @@ func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {
 // does not depend on user configuration
 func basicClient(currentVersion string) (*api.Client, error) {
 	var opts []api.ClientOption
-	verbose, _ := utils.IsDebugEnabled()
-	if verbose {
-		opts = append(opts, apiVerboseLog())
+	if isVerbose, debugValue := utils.IsDebugEnabled(); isVerbose {
+		colorize := utils.IsTerminal(os.Stderr)
+		logTraffic := strings.Contains(debugValue, "api")
+		opts = append(opts, api.VerboseLog(colorable.NewColorable(os.Stderr), logTraffic, colorize))
 	}
 	opts = append(opts, api.AddHeader("User-Agent", fmt.Sprintf("GitHub CLI %s", currentVersion)))
 
@@ -343,13 +344,6 @@ func basicClient(currentVersion string) (*api.Client, error) {
 		opts = append(opts, api.AddHeader("Authorization", fmt.Sprintf("token %s", token)))
 	}
 	return api.NewClient(opts...), nil
-}
-
-func apiVerboseLog() api.ClientOption {
-	debugEnabled, debugValue := utils.IsDebugEnabled()
-	logTraffic := debugEnabled && strings.Contains(debugValue, "api")
-	colorize := utils.IsTerminal(os.Stderr)
-	return api.VerboseLog(colorable.NewColorable(os.Stderr), logTraffic, colorize)
 }
 
 func isRecentRelease(publishedAt time.Time) bool {

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -58,7 +58,7 @@ func mainRun() exitCode {
 		updateMessageChan <- rel
 	}()
 
-	hasDebug := os.Getenv("DEBUG") != ""
+	hasDebug, _ := utils.IsDebugEnabled()
 
 	cmdFactory := factory.New(buildVersion)
 	stderr := cmdFactory.IOStreams.ErrOut
@@ -327,7 +327,8 @@ func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {
 // does not depend on user configuration
 func basicClient(currentVersion string) (*api.Client, error) {
 	var opts []api.ClientOption
-	if verbose := os.Getenv("DEBUG"); verbose != "" {
+	verbose, _ := utils.IsDebugEnabled()
+	if verbose {
 		opts = append(opts, apiVerboseLog())
 	}
 	opts = append(opts, api.AddHeader("User-Agent", fmt.Sprintf("GitHub CLI %s", currentVersion)))
@@ -345,7 +346,8 @@ func basicClient(currentVersion string) (*api.Client, error) {
 }
 
 func apiVerboseLog() api.ClientOption {
-	logTraffic := strings.Contains(os.Getenv("DEBUG"), "api")
+	debugEnabled, debugValue := utils.IsDebugEnabled()
+	logTraffic := debugEnabled && strings.Contains(debugValue, "api")
 	colorize := utils.IsTerminal(os.Stderr)
 	return api.VerboseLog(colorable.NewColorable(os.Stderr), logTraffic, colorize)
 }

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -12,8 +12,8 @@ import (
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/cli/oauth"
 	"github.com/cli/cli/v2/utils"
+	"github.com/cli/oauth"
 )
 
 var (
@@ -54,9 +54,9 @@ func authFlow(oauthHost string, IO *iostreams.IOStreams, notice string, addition
 	cs := IO.ColorScheme()
 
 	httpClient := http.DefaultClient
-	debugEnabled, envDebug := utils.IsDebugEnabled()
+	debugEnabled, debugValue := utils.IsDebugEnabled()
 	if debugEnabled {
-		logTraffic := strings.Contains(envDebug, "api") || strings.Contains(envDebug, "oauth")
+		logTraffic := strings.Contains(debugValue, "api")
 		httpClient.Transport = api.VerboseLog(IO.ErrOut, logTraffic, IO.ColorEnabled())(httpClient.Transport)
 	}
 

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/oauth"
+	"github.com/cli/cli/v2/utils"
 )
 
 var (
@@ -53,7 +54,8 @@ func authFlow(oauthHost string, IO *iostreams.IOStreams, notice string, addition
 	cs := IO.ColorScheme()
 
 	httpClient := http.DefaultClient
-	if envDebug := os.Getenv("DEBUG"); envDebug != "" {
+	debugEnabled, envDebug := utils.IsDebugEnabled()
+	if debugEnabled {
 		logTraffic := strings.Contains(envDebug, "api") || strings.Contains(envDebug, "oauth")
 		httpClient.Transport = api.VerboseLog(IO.ErrOut, logTraffic, IO.ColorEnabled())(httpClient.Transport)
 	}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
 	"github.com/cli/cli/v2/utils"
 )
 
@@ -29,8 +30,7 @@ type cmdWithStderr struct {
 }
 
 func (c cmdWithStderr) Output() ([]byte, error) {
-	debugEnabled, _ := utils.IsDebugEnabled()
-	if debugEnabled {
+	if isVerbose, _ := utils.IsDebugEnabled(); isVerbose {
 		_ = printArgs(os.Stderr, c.Cmd.Args)
 	}
 	if c.Cmd.Stderr != nil {
@@ -46,8 +46,7 @@ func (c cmdWithStderr) Output() ([]byte, error) {
 }
 
 func (c cmdWithStderr) Run() error {
-	debugEnabled, _ := utils.IsDebugEnabled()
-	if debugEnabled {
+	if isVerbose, _ := utils.IsDebugEnabled(); isVerbose {
 		_ = printArgs(os.Stderr, c.Cmd.Args)
 	}
 	if c.Cmd.Stderr != nil {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"github.com/cli/cli/v2/utils"
 )
 
 // Runnable is typically an exec.Cmd or its stub in tests
@@ -28,7 +29,8 @@ type cmdWithStderr struct {
 }
 
 func (c cmdWithStderr) Output() ([]byte, error) {
-	if os.Getenv("DEBUG") != "" {
+	debugEnabled, _ := utils.IsDebugEnabled()
+	if debugEnabled {
 		_ = printArgs(os.Stderr, c.Cmd.Args)
 	}
 	if c.Cmd.Stderr != nil {
@@ -44,7 +46,8 @@ func (c cmdWithStderr) Output() ([]byte, error) {
 }
 
 func (c cmdWithStderr) Run() error {
-	if os.Getenv("DEBUG") != "" {
+	debugEnabled, _ := utils.IsDebugEnabled()
+	if debugEnabled {
 		_ = printArgs(os.Stderr, c.Cmd.Args)
 	}
 	if c.Cmd.Stderr != nil {

--- a/pkg/cmd/factory/http.go
+++ b/pkg/cmd/factory/http.go
@@ -83,8 +83,8 @@ func NewHTTPClient(io *iostreams.IOStreams, cfg configGetter, appVersion string,
 			return httpunix.NewRoundTripper(unixSocket)
 		}))
 	}
-	debugEnabled, debugValue := utils.IsDebugEnabled()
-	if debugEnabled {
+
+	if isVerbose, debugValue := utils.IsDebugEnabled(); isVerbose {
 		logTraffic := strings.Contains(debugValue, "api")
 		opts = append(opts, api.VerboseLog(io.ErrOut, logTraffic, io.IsStderrTTY()))
 	}

--- a/pkg/cmd/factory/http.go
+++ b/pkg/cmd/factory/http.go
@@ -3,7 +3,6 @@ package factory
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/httpunix"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/utils"
 )
 
 var timezoneNames = map[int]string{
@@ -83,9 +83,9 @@ func NewHTTPClient(io *iostreams.IOStreams, cfg configGetter, appVersion string,
 			return httpunix.NewRoundTripper(unixSocket)
 		}))
 	}
-
-	if verbose := os.Getenv("DEBUG"); verbose != "" {
-		logTraffic := strings.Contains(verbose, "api")
+	debugEnabled, debugValue := utils.IsDebugEnabled()
+	if debugEnabled {
+		logTraffic := strings.Contains(debugValue, "api")
 		opts = append(opts, api.VerboseLog(io.ErrOut, logTraffic, io.IsStderrTTY()))
 	}
 

--- a/pkg/cmd/factory/http_test.go
+++ b/pkg/cmd/factory/http_test.go
@@ -84,8 +84,8 @@ func TestNewHTTPClient(t *testing.T) {
 				appVersion: "v1.2.3",
 				setAccept:  true,
 			},
-			host:     "github.com",
-			envDebug: "api",
+			host:       "github.com",
+			envDebug:   "api",
 			setGhDebug: false,
 			wantHeader: map[string]string{
 				"authorization": "token MYTOKEN",
@@ -114,7 +114,7 @@ func TestNewHTTPClient(t *testing.T) {
 				appVersion: "v1.2.3",
 				setAccept:  true,
 			},
-			host:     "github.com",
+			host:       "github.com",
 			envGhDebug: "api",
 			setGhDebug: true,
 			wantHeader: map[string]string{

--- a/pkg/cmd/factory/http_test.go
+++ b/pkg/cmd/factory/http_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/cli/cli/v2/utils"
 )
 
 func TestNewHTTPClient(t *testing.T) {
@@ -25,6 +24,7 @@ func TestNewHTTPClient(t *testing.T) {
 		name       string
 		args       args
 		envDebug   string
+		setGhDebug bool
 		envGhDebug string
 		host       string
 		sso        string
@@ -86,6 +86,7 @@ func TestNewHTTPClient(t *testing.T) {
 			},
 			host:     "github.com",
 			envDebug: "api",
+			setGhDebug: false,
 			wantHeader: map[string]string{
 				"authorization": "token MYTOKEN",
 				"user-agent":    "GitHub CLI v1.2.3",
@@ -115,6 +116,7 @@ func TestNewHTTPClient(t *testing.T) {
 			},
 			host:     "github.com",
 			envGhDebug: "api",
+			setGhDebug: true,
 			wantHeader: map[string]string{
 				"authorization": "token MYTOKEN",
 				"user-agent":    "GitHub CLI v1.2.3",
@@ -176,9 +178,13 @@ func TestNewHTTPClient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			oldDebug := os.Getenv("DEBUG")
-			oldGhDeub := os.Getenv("GH_DEBUG")
+			oldGhDebug := os.Getenv("GH_DEBUG")
 			os.Setenv("DEBUG", tt.envDebug)
-			os.Setenv("GH_DEBUG", tt.envGhDebug)
+			if tt.setGhDebug {
+				os.Setenv("GH_DEBUG", tt.envGhDebug)
+			} else {
+				os.Unsetenv("GH_DEBUG")
+			}
 			t.Cleanup(func() {
 				os.Setenv("DEBUG", oldDebug)
 				os.Setenv("GH_DEBUG", oldGhDebug)

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -47,8 +47,11 @@ var HelpTopics = map[string]map[string]string{
 
 			GH_BROWSER, BROWSER (in order of precedence): the web browser to use for opening links.
 
-			DEBUG: set to any value to enable verbose output to standard error. Include values "api"
-			or "oauth" to print detailed information about HTTP requests or authentication flow.
+			GH_DEBUG: Set to 0, false or the empty string to disable verbose output to standard error. Set to
+			any other value to enable. If not set, then DEBUG is used.
+
+			DEBUG: Deprecated, see GH_DEBUG - set to any value to enable verbose output to standard error. 
+			Include values "api" or "oauth" to print detailed information about HTTP requests or authentication flow.
 
 			GH_PAGER, PAGER (in order of precedence): a terminal paging program to send standard output
 			to, e.g. "less".

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -47,11 +47,11 @@ var HelpTopics = map[string]map[string]string{
 
 			GH_BROWSER, BROWSER (in order of precedence): the web browser to use for opening links.
 
-			GH_DEBUG: Set to 0, false or the empty string to disable verbose output to standard error. Set to
-			any other value to enable. If not set, then DEBUG is used.
+			GH_DEBUG: set to a truthy value to enable verbose output on standard error. Set to "api"
+			to additionally log details of HTTP traffic.
 
-			DEBUG: Deprecated, see GH_DEBUG - set to any value to enable verbose output to standard error. 
-			Include values "api" or "oauth" to print detailed information about HTTP requests or authentication flow.
+			DEBUG (deprecated): set to "1", "true", or "yes" to enable verbose output on standard
+			error.
 
 			GH_PAGER, PAGER (in order of precedence): a terminal paging program to send standard output
 			to, e.g. "less".

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,9 +3,9 @@ package utils
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
-	"os"
 )
 
 func Pluralize(num int, thing string) string {
@@ -86,15 +86,22 @@ func ValidURL(urlStr string) bool {
 }
 
 func IsDebugEnabled() (bool, string) {
-	gh_val, gh_present := os.LookupEnv("GH_DEBUG")
-	legacy_val, legacy_present := os.LookupEnv("DEBUG")
-	if gh_present && (gh_val == "0" || gh_val == "false" || gh_val == "") {
-		return false, gh_val
-	} else if gh_present {
-		return true, gh_val
-	} else if !legacy_present || legacy_val == "0" || legacy_val == "false" || legacy_val == "" {
-		return false, legacy_val
-	} else {
-		return true, legacy_val
+	debugValue, isDebugSet := os.LookupEnv("GH_DEBUG")
+	legacyDebugValue := os.Getenv("DEBUG")
+
+	if !isDebugSet {
+		switch legacyDebugValue {
+		case "true", "1", "yes", "api":
+			return true, legacyDebugValue
+		default:
+			return false, legacyDebugValue
+		}
+	}
+
+	switch debugValue {
+	case "false", "0", "no", "":
+		return false, debugValue
+	default:
+		return true, debugValue
 	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"os"
 )
 
 func Pluralize(num int, thing string) string {
@@ -82,4 +83,18 @@ func DisplayURL(urlStr string) string {
 // Maximum length of a URL: 8192 bytes
 func ValidURL(urlStr string) bool {
 	return len(urlStr) < 8192
+}
+
+func IsDebugEnabled() (bool, string) {
+	gh_val, gh_present := os.LookupEnv("GH_DEBUG")
+	legacy_val, legacy_present := os.LookupEnv("DEBUG")
+	if gh_present && (gh_val == "0" || gh_val == "false" || gh_val == "") {
+		return false, gh_val
+	} else if gh_present {
+		return true, gh_val
+	} else if !legacy_present || legacy_val == "0" || legacy_val == "false" || legacy_val == "" {
+		return false, legacy_val
+	} else {
+		return true, legacy_val
+	}
 }


### PR DESCRIPTION
Fixes #5289

**Description of fix**:
It used to be that if you wanted to enable `DEBUG` you gave `DEBUG` a value. Now the debug output can be  disabled via setting `GH_DEBUG` to `0`, `false` or the empty string and can be enabled via `GH_DEBUG` to any other value.
  
The original behaviour is also supported, as a fallback where the `GH_DEBUG` does not exist, then the program checks for `DEBUG` as per existing behaviour.

**Description of testing**:
Run the tests as per contributing guidelines.
Manually tested different combinations of `DEBUG` & `GH_DEBUG` as below:
```
$ GH_DEBUG="0" DEBUG=999 bin/gh auth login
? What account do you want to log into? GitHub.com
? What is your preferred protocol for Git operations? HTTPS
? Authenticate Git with your GitHub credentials? Yes
? How would you like to authenticate GitHub CLI? Login with a web browser

$ GH_DEBUG="1" DEBUG=999 bin/gh auth login
? What account do you want to log into? GitHub.com
? What is your preferred protocol for Git operations? HTTPS
[git config credential.https://github.com.helper]
[git config credential.helper]
? Authenticate Git with your GitHub credentials? (Y/n) 

$ GH_DEBUG="cake" DEBUG=999 bin/gh auth login
? What account do you want to log into? GitHub.com
? What is your preferred protocol for Git operations? HTTPS
[git config credential.https://github.com.helper]
[git config credential.helper]
? Authenticate Git with your GitHub credentials? (Y/n) 

$ GH_DEBUG="cake" bin/gh auth login
? What account do you want to log into? GitHub.com
? What is your preferred protocol for Git operations? HTTPS
[git config credential.https://github.com.helper]
[git config credential.helper]
? Authenticate Git with your GitHub credentials? (Y/n) 

$ GH_DEBUG="cake" bin/gh auth login
? What account do you want to log into? GitHub.com
? What is your preferred protocol for Git operations? HTTPS
[git config credential.https://github.com.helper]
[git config credential.helper]
? Authenticate Git with your GitHub credentials? (Y/n) 

$ GH_DEBUG="" bin/gh auth login
? What account do you want to log into? GitHub.com
? What is your preferred protocol for Git operations? HTTPS
? Authenticate Git with your GitHub credentials? Yes
? How would you like to authenticate GitHub CLI? Login with a web browser

! First copy your one-time code: 2EF5-DDCC
Press Enter to open github.com in your browser... ^C
$ GH_DEBUG="0" bin/gh auth login
? What account do you want to log into? GitHub.com
? What is your preferred protocol for Git operations? HTTPS
? Authenticate Git with your GitHub credentials? Yes
? How would you like to authenticate GitHub CLI? Login with a web browser

! First copy your one-time code: E122-73FE
Press Enter to open github.com in your browser... ^C
$ GH_DEBUG="false" bin/gh auth login
? What account do you want to log into? GitHub.com
? What is your preferred protocol for Git operations? HTTPS
? Authenticate Git with your GitHub credentials? Yes
? How would you like to authenticate GitHub CLI? Login with a web browser

! First copy your one-time code: F57B-620B
Press Enter to open github.com in your browser... ^C
$ GH_DEBUG="t" bin/gh auth login
? What account do you want to log into? GitHub.com
? What is your preferred protocol for Git operations? HTTPS
[git config credential.https://github.com.helper]
[git config credential.helper]
? Authenticate Git with your GitHub credentials? (Y/n) 
```