### PR TITLE
Add label list/create command

### DIFF
--- a/pkg/cmd/label/create/create.go
+++ b/pkg/cmd/label/create/create.go
@@ -111,7 +111,7 @@ func createRun(opts *CreateOptions) error {
 	if opts.IO.IsStdoutTTY() {
 		cs := opts.IO.ColorScheme()
 		successMsg := fmt.Sprintf("\n%s Label %q created in %s\n", cs.SuccessIcon(), opts.Name, ghrepo.FullName(baseRepo))
-		fmt.Fprintf(opts.IO.Out, successMsg)
+		fmt.Fprint(opts.IO.Out, successMsg)
 	}
 
 	return nil

--- a/pkg/cmd/label/create/create.go
+++ b/pkg/cmd/label/create/create.go
@@ -110,7 +110,7 @@ func createRun(opts *CreateOptions) error {
 
 	if opts.IO.IsStdoutTTY() {
 		cs := opts.IO.ColorScheme()
-		successMsg := fmt.Sprintf("\n%s Label %q created\n", cs.SuccessIcon(), opts.Name)
+		successMsg := fmt.Sprintf("\n%s Label %q created in %s\n", cs.SuccessIcon(), opts.Name, ghrepo.FullName(baseRepo))
 		fmt.Fprintf(opts.IO.Out, successMsg)
 	}
 

--- a/pkg/cmd/label/create/create.go
+++ b/pkg/cmd/label/create/create.go
@@ -60,9 +60,14 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new label",
+		Long: heredoc.Docf(`
+		Create a new label on GitHub.
+
+		Must specify name for label, description and color is optional, if color isn't provided, a random color will be chosen.
+
+		Color needs to be 6 hex characters.
+		`),
 		Example: heredoc.Doc(`
-		$ gh label create --name bug
-		$ gh label create --name bug --description "Something isn't working"
 		$ gh label create --name bug --description "Something isn't working" --color "E99695"
 	`),
 		Args: cobra.NoArgs,
@@ -72,6 +77,8 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			if !nameProvided || strings.TrimSpace(opts.Name) == "" {
 				return cmdutil.FlagErrorf("must specify name for label.")
 			}
+
+			opts.Color = strings.TrimPrefix(opts.Color, "#")
 
 			if runF != nil {
 				return runF(&opts)
@@ -119,7 +126,7 @@ func createRun(opts *CreateOptions) error {
 
 	if isTerminal {
 		cs := opts.IO.ColorScheme()
-		successMsg := fmt.Sprintf("\n%s Label created.\n", cs.SuccessIcon())
+		successMsg := fmt.Sprintf("\n%s Label %s created.\n", cs.SuccessIcon(), opts.Name)
 
 		fmt.Fprintf(opts.IO.ErrOut, successMsg)
 	}

--- a/pkg/cmd/label/create/create.go
+++ b/pkg/cmd/label/create/create.go
@@ -47,7 +47,6 @@ type CreateOptions struct {
 	Name        string
 	Description string
 	Color       string
-	Interactive bool
 }
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {

--- a/pkg/cmd/label/create/create.go
+++ b/pkg/cmd/label/create/create.go
@@ -1,0 +1,222 @@
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/label/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/pkg/prompt"
+	"github.com/spf13/cobra"
+)
+
+var randomColor = []string{
+	"B60205",
+	"D93F0B",
+	"FBCA04",
+	"0E8A16",
+	"006B75",
+	"1D76DB",
+	"0052CC",
+	"5319E7",
+	"E99695",
+	"F9D0C4",
+	"FEF2C0",
+	"C2E0C6",
+	"BFDADC",
+	"C5DEF5",
+	"BFD4F2",
+	"D4C5F9",
+}
+
+type CreateOptions struct {
+	HttpClient func() (*http.Client, error)
+	Config     func() (config.Config, error)
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	Name        string
+	Description string
+	Color       string
+	Interactive bool
+}
+
+func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
+	opts := CreateOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		BaseRepo:   f.BaseRepo,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new label",
+		Example: heredoc.Doc(`
+		$ gh label create --name bug
+		$ gh label create --name bug --description "Something isn't working"
+		$ gh label create --name bug --description "Something isn't working" --color "E99695"
+	`),
+		Args: cobra.NoArgs,
+		RunE: func(c *cobra.Command, args []string) error {
+			nameProvided := c.Flags().Changed("name")
+			if !nameProvided {
+				opts.Interactive = true
+			}
+
+			if opts.Interactive && !opts.IO.CanPrompt() {
+				return cmdutil.FlagErrorf("must provide name when not running interactively")
+			}
+
+			opts.Name = strings.Trim(opts.Name, " ")
+
+			if runF != nil {
+				return runF(&opts)
+			}
+			return createRun(&opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Name, "name", "n", "", "Name of the label")
+	cmd.Flags().StringVarP(&opts.Description, "description", "d", "", "Description of the label")
+	cmd.Flags().StringVarP(&opts.Color, "color", "c", "", "Color of the label, if not specified will be random")
+
+	return cmd
+}
+
+func createRun(opts *CreateOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	if opts.Interactive {
+		err := interactiveLabelInfo(opts)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		if opts.Name == "" {
+			return fmt.Errorf("Name can't be blank")
+		}
+	}
+
+	if opts.Color == "" {
+		rand.Seed(time.Now().UnixNano())
+		opts.Color = randomColor[rand.Intn(len(randomColor)-1)]
+	}
+
+	client := api.NewClientFromHTTP(httpClient)
+
+	opts.IO.StartProgressIndicator()
+
+	err = createLabel(opts, client, baseRepo)
+
+	opts.IO.StopProgressIndicator()
+
+	if err != nil {
+		return err
+	}
+
+	isTerminal := opts.IO.IsStdoutTTY()
+
+	if isTerminal {
+		cs := opts.IO.ColorScheme()
+		successMsg := fmt.Sprintf("\n%s Label created.\n", cs.SuccessIcon())
+
+		fmt.Fprintf(opts.IO.ErrOut, successMsg)
+	}
+
+	return nil
+}
+
+func interactiveLabelInfo(opts *CreateOptions) error {
+	qs := []*survey.Question{}
+	if opts.Name == "" {
+		qs = append(qs, &survey.Question{
+			Name:   "labelName",
+			Prompt: &survey.Input{Message: "Label name"},
+		})
+	}
+	if opts.Description == "" {
+		qs = append(qs, &survey.Question{
+			Name:   "labelDescription",
+			Prompt: &survey.Input{Message: "Label description"},
+		})
+	}
+	if opts.Color == "" {
+		qs = append(qs, &survey.Question{
+			Name:   "labelColor",
+			Prompt: &survey.Input{Message: "Label color"},
+		})
+	}
+
+	answer := struct {
+		LabelName        string
+		LabelDescription string
+		LabelColor       string
+	}{}
+
+	err := prompt.SurveyAsk(qs, &answer)
+	if err != nil {
+		return err
+	}
+
+	if opts.Name == "" {
+		opts.Name = answer.LabelName
+	}
+	if opts.Description == "" {
+		opts.Description = answer.LabelDescription
+	}
+	if opts.Color == "" {
+		opts.Color = answer.LabelColor
+	}
+
+	return nil
+}
+
+type CreateLabelRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Color       string `json:"color,omitempty"`
+}
+
+func createLabel(opts *CreateOptions, client *api.Client, repo ghrepo.Interface) error {
+	path := fmt.Sprintf("repos/%s/%s/labels", repo.RepoOwner(), repo.RepoName())
+
+	body := CreateLabelRequest{
+		Name:        opts.Name,
+		Description: opts.Description,
+		Color:       opts.Color,
+	}
+
+	requestByte, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	requestBody := bytes.NewReader(requestByte)
+
+	result := shared.Label{}
+
+	err = client.REST(repo.RepoHost(), "POST", path, requestBody, &result)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/cmd/label/create/create_test.go
+++ b/pkg/cmd/label/create/create_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/cli/cli/v2/pkg/prompt"
 	"github.com/cli/cli/v2/test"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
@@ -57,7 +56,7 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	}, err
 }
 
-func TestLabelCreate_nontty_non_interactive(t *testing.T) {
+func TestLabelCreate_nontty(t *testing.T) {
 	http := &httpmock.Registry{}
 	defer http.Verify(t)
 
@@ -91,7 +90,7 @@ func TestLabelCreate_nontty_non_interactive(t *testing.T) {
 	assert.Equal(t, expectReqBody, reqBody)
 }
 
-func TestLabelCreate_tty_non_interactive(t *testing.T) {
+func TestLabelCreate_tty(t *testing.T) {
 	http := &httpmock.Registry{}
 	defer http.Verify(t)
 
@@ -123,79 +122,6 @@ func TestLabelCreate_tty_non_interactive(t *testing.T) {
 	}
 
 	assert.Equal(t, expectReqBody, reqBody)
-}
-
-func TestLabelCreate_tty_interactive(t *testing.T) {
-	tests := []struct {
-		Cli      string
-		AskStubs func(*prompt.AskStubber)
-	}{
-		{
-			Cli: "",
-			AskStubs: func(as *prompt.AskStubber) {
-				as.StubPrompt("Label name").AnswerWith("bugs")
-				as.StubPrompt("Label description").AnswerWith("Something isn't working")
-				as.StubPrompt("Label color").AnswerWith("0052cc")
-			},
-		},
-		{
-			Cli: "-d \"Something isn't working\"",
-			AskStubs: func(as *prompt.AskStubber) {
-				as.StubPrompt("Label name").AnswerWith("bugs")
-				as.StubPrompt("Label color").AnswerWith("0052cc")
-			},
-		},
-		{
-			Cli: "-c \"0052cc\"",
-			AskStubs: func(as *prompt.AskStubber) {
-				as.StubPrompt("Label name").AnswerWith("bugs")
-				as.StubPrompt("Label description").AnswerWith("Something isn't working")
-			},
-		},
-		{
-			Cli: "-d \"Something isn't working\" -c \"0052cc\"",
-			AskStubs: func(as *prompt.AskStubber) {
-				as.StubPrompt("Label name").AnswerWith("bugs")
-			},
-		},
-	}
-
-	for _, test := range tests {
-		http := &httpmock.Registry{}
-		defer http.Verify(t)
-
-		http.Register(
-			httpmock.REST("POST", "repos/OWNER/REPO/labels"),
-			httpmock.StatusStringResponse(201, "{}"),
-		)
-
-		as := prompt.NewAskStubber(t)
-		test.AskStubs(as)
-
-		output, err := runCommand(http, true, test.Cli)
-
-		if err != nil {
-			t.Errorf("error running command `label create`: %v", err)
-		}
-
-		assert.Equal(t, "\n✓ Label created.\n", output.Stderr())
-		assert.Equal(t, "", output.String())
-
-		bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
-		reqBody := CreateLabelRequest{}
-		err = json.Unmarshal(bodyBytes, &reqBody)
-		if err != nil {
-			t.Fatalf("error decoding JSON: %v", err)
-		}
-
-		expectReqBody := CreateLabelRequest{
-			Name:        "bugs",
-			Description: "Something isn't working",
-			Color:       "0052cc",
-		}
-
-		assert.Equal(t, expectReqBody, reqBody)
-	}
 }
 
 func TestLabelCreate_random_color(t *testing.T) {
@@ -236,5 +162,5 @@ func TestLabelCreate_failed_when_not_provide_name(t *testing.T) {
 	_, err := runCommand(http, false, "")
 
 	assert.NotNil(t, err)
-	assert.Equal(t, "must provide name when not running interactively", fmt.Sprintf("%v", err))
+	assert.Equal(t, "must specify name for label.", fmt.Sprintf("%v", err))
 }

--- a/pkg/cmd/label/create/create_test.go
+++ b/pkg/cmd/label/create/create_test.go
@@ -101,7 +101,7 @@ func TestCreateRun(t *testing.T) {
 					httpmock.StatusStringResponse(201, "{}"),
 				)
 			},
-			wantStdout: "\n✓ Label \"test\" created\n",
+			wantStdout: "\n✓ Label \"test\" created in OWNER/REPO\n",
 		},
 		{
 			name: "creates label notty",

--- a/pkg/cmd/label/create/create_test.go
+++ b/pkg/cmd/label/create/create_test.go
@@ -1,0 +1,240 @@
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/pkg/prompt"
+	"github.com/cli/cli/v2/test"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
+	io, _, stdout, stderr := iostreams.Test()
+	io.SetStdoutTTY(isTTY)
+	io.SetStdinTTY(isTTY)
+	io.SetStderrTTY(isTTY)
+
+	factory := &cmdutil.Factory{
+		IOStreams: io,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: rt}, nil
+		},
+		Config: func() (config.Config, error) {
+			return config.NewBlankConfig(), nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.New("OWNER", "REPO"), nil
+		},
+	}
+
+	cmd := NewCmdCreate(factory, nil)
+
+	argv, err := shlex.Split(cli)
+	if err != nil {
+		return nil, err
+	}
+	cmd.SetArgs(argv)
+
+	cmd.SetIn(&bytes.Buffer{})
+	cmd.SetOut(ioutil.Discard)
+	cmd.SetErr(ioutil.Discard)
+
+	_, err = cmd.ExecuteC()
+	return &test.CmdOut{
+		OutBuf: stdout,
+		ErrBuf: stderr,
+	}, err
+}
+
+func TestLabelCreate_nontty_non_interactive(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.REST("POST", "repos/OWNER/REPO/labels"),
+		httpmock.StatusStringResponse(201, "{}"),
+	)
+
+	output, err := runCommand(http, false, "-n bugs -d \"Something isn't working\" -c \"0052cc\"")
+
+	if err != nil {
+		t.Errorf("error running command `label create`: %v", err)
+	}
+
+	assert.Equal(t, "", output.Stderr())
+	assert.Equal(t, "", output.String())
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+	reqBody := CreateLabelRequest{}
+	err = json.Unmarshal(bodyBytes, &reqBody)
+	if err != nil {
+		t.Fatalf("error decoding JSON: %v", err)
+	}
+
+	expectReqBody := CreateLabelRequest{
+		Name:        "bugs",
+		Description: "Something isn't working",
+		Color:       "0052cc",
+	}
+
+	assert.Equal(t, expectReqBody, reqBody)
+}
+
+func TestLabelCreate_tty_non_interactive(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.REST("POST", "repos/OWNER/REPO/labels"),
+		httpmock.StatusStringResponse(201, "{}"),
+	)
+
+	output, err := runCommand(http, true, "-n bugs -d \"Something isn't working\" -c \"0052cc\"")
+
+	if err != nil {
+		t.Errorf("error running command `label create`: %v", err)
+	}
+
+	assert.Equal(t, "\n✓ Label created.\n", output.Stderr())
+	assert.Equal(t, "", output.String())
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+	reqBody := CreateLabelRequest{}
+	err = json.Unmarshal(bodyBytes, &reqBody)
+	if err != nil {
+		t.Fatalf("error decoding JSON: %v", err)
+	}
+
+	expectReqBody := CreateLabelRequest{
+		Name:        "bugs",
+		Description: "Something isn't working",
+		Color:       "0052cc",
+	}
+
+	assert.Equal(t, expectReqBody, reqBody)
+}
+
+func TestLabelCreate_tty_interactive(t *testing.T) {
+	tests := []struct {
+		Cli      string
+		AskStubs func(*prompt.AskStubber)
+	}{
+		{
+			Cli: "",
+			AskStubs: func(as *prompt.AskStubber) {
+				as.StubPrompt("Label name").AnswerWith("bugs")
+				as.StubPrompt("Label description").AnswerWith("Something isn't working")
+				as.StubPrompt("Label color").AnswerWith("0052cc")
+			},
+		},
+		{
+			Cli: "-d \"Something isn't working\"",
+			AskStubs: func(as *prompt.AskStubber) {
+				as.StubPrompt("Label name").AnswerWith("bugs")
+				as.StubPrompt("Label color").AnswerWith("0052cc")
+			},
+		},
+		{
+			Cli: "-c \"0052cc\"",
+			AskStubs: func(as *prompt.AskStubber) {
+				as.StubPrompt("Label name").AnswerWith("bugs")
+				as.StubPrompt("Label description").AnswerWith("Something isn't working")
+			},
+		},
+		{
+			Cli: "-d \"Something isn't working\" -c \"0052cc\"",
+			AskStubs: func(as *prompt.AskStubber) {
+				as.StubPrompt("Label name").AnswerWith("bugs")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		http := &httpmock.Registry{}
+		defer http.Verify(t)
+
+		http.Register(
+			httpmock.REST("POST", "repos/OWNER/REPO/labels"),
+			httpmock.StatusStringResponse(201, "{}"),
+		)
+
+		as := prompt.NewAskStubber(t)
+		test.AskStubs(as)
+
+		output, err := runCommand(http, true, test.Cli)
+
+		if err != nil {
+			t.Errorf("error running command `label create`: %v", err)
+		}
+
+		assert.Equal(t, "\n✓ Label created.\n", output.Stderr())
+		assert.Equal(t, "", output.String())
+
+		bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+		reqBody := CreateLabelRequest{}
+		err = json.Unmarshal(bodyBytes, &reqBody)
+		if err != nil {
+			t.Fatalf("error decoding JSON: %v", err)
+		}
+
+		expectReqBody := CreateLabelRequest{
+			Name:        "bugs",
+			Description: "Something isn't working",
+			Color:       "0052cc",
+		}
+
+		assert.Equal(t, expectReqBody, reqBody)
+	}
+}
+
+func TestLabelCreate_random_color(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.REST("POST", "repos/OWNER/REPO/labels"),
+		httpmock.StatusStringResponse(201, "{}"),
+	)
+
+	for i := 0; i < 2; i++ {
+
+	}
+	output, err := runCommand(http, false, "-n bugs")
+
+	if err != nil {
+		t.Errorf("error running command `label create`: %v", err)
+	}
+
+	assert.Equal(t, "", output.Stderr())
+	assert.Equal(t, "", output.String())
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+	reqBody := CreateLabelRequest{}
+	err = json.Unmarshal(bodyBytes, &reqBody)
+	if err != nil {
+		t.Fatalf("error decoding JSON: %v", err)
+	}
+
+	assert.Contains(t, randomColor, reqBody.Color)
+}
+
+func TestLabelCreate_failed_when_not_provide_name(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	_, err := runCommand(http, false, "")
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "must provide name when not running interactively", fmt.Sprintf("%v", err))
+}

--- a/pkg/cmd/label/create/create_test.go
+++ b/pkg/cmd/label/create/create_test.go
@@ -96,7 +96,15 @@ func TestLabelCreate_tty(t *testing.T) {
 
 	http.Register(
 		httpmock.REST("POST", "repos/OWNER/REPO/labels"),
-		httpmock.StatusStringResponse(201, "{}"),
+		httpmock.StatusStringResponse(201, `{
+			"id": 3973380732,
+			"node_id": "LA_kwDOHAVYr87s1Pp8",
+			"url": "https://api.github.com/repos/OWNER/REPO/labels/bugs",
+			"name": "bugs",
+			"color": "0052cc",
+			"default": false,
+			"description": "Something isn't working"
+		}`),
 	)
 
 	output, err := runCommand(http, true, "-n bugs -d \"Something isn't working\" -c \"0052cc\"")
@@ -130,7 +138,15 @@ func TestLabelCreate_when_color_with_prefix(t *testing.T) {
 
 	http.Register(
 		httpmock.REST("POST", "repos/OWNER/REPO/labels"),
-		httpmock.StatusStringResponse(201, "{}"),
+		httpmock.StatusStringResponse(201, `{
+			"id": 3973380732,
+			"node_id": "LA_kwDOHAVYr87s1Pp8",
+			"url": "https://api.github.com/repos/OWNER/REPO/labels/bugs",
+			"name": "bugs",
+			"color": "0052cc",
+			"default": false,
+			"description": "Something isn't working"
+		}`),
 	)
 
 	output, err := runCommand(http, false, "-n bugs -d \"Something isn't working\" -c \"#0052cc\"")

--- a/pkg/cmd/label/label.go
+++ b/pkg/cmd/label/label.go
@@ -1,0 +1,20 @@
+package label
+
+import (
+	labelListCmd "github.com/cli/cli/v2/pkg/cmd/label/list"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdLabel(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "label <command>",
+		Short: "Manage labels",
+		Long:  `Work with GitHub labels.`,
+	}
+	cmdutil.EnableRepoOverride(cmd, f)
+
+	cmd.AddCommand(labelListCmd.NewCmdList(f, nil))
+
+	return cmd
+}

--- a/pkg/cmd/label/label.go
+++ b/pkg/cmd/label/label.go
@@ -1,6 +1,7 @@
 package label
 
 import (
+	labelCreateCmd "github.com/cli/cli/v2/pkg/cmd/label/create"
 	labelListCmd "github.com/cli/cli/v2/pkg/cmd/label/list"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -15,6 +16,7 @@ func NewCmdLabel(f *cmdutil.Factory) *cobra.Command {
 	cmdutil.EnableRepoOverride(cmd, f)
 
 	cmd.AddCommand(labelListCmd.NewCmdList(f, nil))
+	cmd.AddCommand(labelCreateCmd.NewCmdCreate(f, nil))
 
 	return cmd
 }

--- a/pkg/cmd/label/list/http.go
+++ b/pkg/cmd/label/list/http.go
@@ -1,0 +1,85 @@
+package list
+
+import (
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/label/shared"
+)
+
+func listLabels(client *api.Client, repo ghrepo.Interface, limit int) ([]shared.Label, int, error) {
+	query := `
+	query LabelList($owner: String!,$repo: String!, $limit: Int!, $endCursor: String) {
+		repository(owner: $owner, name: $repo) {
+			labels(first: $limit, after: $endCursor) {
+				totalCount,
+				nodes {
+					name,
+					description,
+					color
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"owner": repo.RepoOwner(),
+		"repo":  repo.RepoName(),
+	}
+
+	type responseData struct {
+		Repository struct {
+			Labels struct {
+				TotalCount int
+				Nodes      []shared.Label
+				PageInfo   struct {
+					HasNextPage bool
+					EndCursor   string
+				}
+			}
+			HasIssuesEnabled bool
+		}
+	}
+
+	var labels []shared.Label
+	var totalCount int
+	pageLimit := min(limit, 100)
+
+loop:
+	for {
+		var response responseData
+		variables["limit"] = pageLimit
+		err := client.GraphQL(repo.RepoHost(), query, variables, &response)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		totalCount = response.Repository.Labels.TotalCount
+
+		for _, label := range response.Repository.Labels.Nodes {
+			labels = append(labels, label)
+			if len(labels) == limit {
+				break loop
+			}
+		}
+
+		if response.Repository.Labels.PageInfo.HasNextPage {
+			variables["endCursor"] = response.Repository.Labels.PageInfo.EndCursor
+			pageLimit = min(pageLimit, limit-len(labels))
+		} else {
+			break
+		}
+	}
+
+	return labels, totalCount, nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/cmd/label/list/http.go
+++ b/pkg/cmd/label/list/http.go
@@ -1,12 +1,15 @@
 package list
 
 import (
+	"net/http"
+
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/label/shared"
 )
 
-func listLabels(client *api.Client, repo ghrepo.Interface, limit int) ([]shared.Label, int, error) {
+func listLabels(client *http.Client, repo ghrepo.Interface, limit int) ([]shared.Label, int, error) {
+	apiClient := api.NewClientFromHTTP(client)
 	query := `
 	query LabelList($owner: String!,$repo: String!, $limit: Int!, $endCursor: String) {
 		repository(owner: $owner, name: $repo) {
@@ -52,7 +55,7 @@ loop:
 	for {
 		var response responseData
 		variables["limit"] = pageLimit
-		err := client.GraphQL(repo.RepoHost(), query, variables, &response)
+		err := apiClient.GraphQL(repo.RepoHost(), query, variables, &response)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/pkg/cmd/label/list/http_test.go
+++ b/pkg/cmd/label/list/http_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIssueList_pagination(t *testing.T) {
+func TestLabelList_pagination(t *testing.T) {
 	http := &httpmock.Registry{}
 	client := api.NewClient(api.ReplaceTripper(http))
 

--- a/pkg/cmd/label/list/http_test.go
+++ b/pkg/cmd/label/list/http_test.go
@@ -1,0 +1,99 @@
+package list
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIssueList_pagination(t *testing.T) {
+	http := &httpmock.Registry{}
+	client := api.NewClient(api.ReplaceTripper(http))
+
+	http.Register(
+		httpmock.GraphQL(`query LabelList\b`),
+		httpmock.StringResponse(`
+		{
+			"data": {
+				"repository": {
+					"labels": {
+						"totalCount": 2,
+						"nodes": [
+							{
+								"name": "bug",
+								"color": "d73a4a",
+								"description": "This is a bug label"
+							}
+						],
+						"pageInfo": {
+							"hasNextPage": true,
+							"endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0xMC0xMVQwMTozODowMyswODowMM5f3HZq"
+						}
+					}
+				}
+			}
+		}`),
+	)
+
+	http.Register(
+		httpmock.GraphQL(`query LabelList\b`),
+		httpmock.StringResponse(`
+		{
+			"data": {
+				"repository": {
+					"labels": {
+						"totalCount": 2,
+						"nodes": [
+							{
+								"name": "docs",
+								"color": "ffa8da",
+								"description": "This is a docs label"
+							}
+						],
+						"pageInfo": {
+							"hasNextPage": false,
+							"endCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wMS0zMVQxODo1NTo1MiswODowMM7hiAL3"
+						}
+					}
+				}
+			}
+		}`),
+	)
+
+	repo := ghrepo.New("OWNER", "REPO")
+	labels, totalCount, err := listLabels(client, repo, 10)
+	if err != nil {
+		t.Fatalf("LabelList() error = %v", err)
+	}
+
+	assert.Equal(t, 2, totalCount)
+	assert.Equal(t, 2, len(labels))
+
+	assert.Equal(t, "bug", labels[0].Name)
+	assert.Equal(t, "d73a4a", labels[0].Color)
+	assert.Equal(t, "This is a bug label", labels[0].Description)
+
+	assert.Equal(t, "docs", labels[1].Name)
+	assert.Equal(t, "ffa8da", labels[1].Color)
+	assert.Equal(t, "This is a docs label", labels[1].Description)
+
+	var reqBody struct {
+		Query     string
+		Variables map[string]interface{}
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+	_ = json.Unmarshal(bodyBytes, &reqBody)
+
+	assert.Nil(t, reqBody.Variables["endCursor"])
+
+	bodyBytes, _ = ioutil.ReadAll(http.Requests[1].Body)
+	_ = json.Unmarshal(bodyBytes, &reqBody)
+
+	assert.Equal(t, "Y3Vyc29yOnYyOpK5MjAxOS0xMC0xMVQwMTozODowMyswODowMM5f3HZq", reqBody.Variables["endCursor"].(string))
+}

--- a/pkg/cmd/label/list/list.go
+++ b/pkg/cmd/label/list/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/label/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/utils"
@@ -89,17 +90,8 @@ func listRun(opts *ListOptions) error {
 	return nil
 }
 
-type Label struct {
-	Id          int
-	Name        string
-	Color       string
-	Default     bool
-	Url         string
-	Description string
-}
-
-func getLabels(client *api.Client, repo ghrepo.Interface) ([]Label, error) {
-	labels := []Label{}
+func getLabels(client *api.Client, repo ghrepo.Interface) ([]shared.Label, error) {
+	labels := []shared.Label{}
 
 	path := fmt.Sprintf("repos/%s/%s/labels", repo.RepoOwner(), repo.RepoName())
 
@@ -110,7 +102,7 @@ func getLabels(client *api.Client, repo ghrepo.Interface) ([]Label, error) {
 	return labels, nil
 }
 
-func printLabels(labels []Label, io *iostreams.IOStreams) error {
+func printLabels(labels []shared.Label, io *iostreams.IOStreams) error {
 	cs := io.ColorScheme()
 	table := utils.NewTablePrinter(io)
 

--- a/pkg/cmd/label/list/list.go
+++ b/pkg/cmd/label/list/list.go
@@ -1,0 +1,132 @@
+package list
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/utils"
+	"github.com/spf13/cobra"
+)
+
+type browser interface {
+	Browse(string) error
+}
+
+type ListOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (ghrepo.Interface, error)
+	Browser    browser
+
+	WebMode bool
+}
+
+func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
+	opts := ListOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		BaseRepo:   f.BaseRepo,
+		Browser:    f.Browser,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "Show all labels",
+		Long:    "Display all labels of a GitHub repository.",
+		Args:    cobra.NoArgs,
+		Aliases: []string{"ls"},
+		RunE: func(c *cobra.Command, args []string) error {
+			if runF != nil {
+				return runF(&opts)
+			}
+			return listRun(&opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "List labels in the web browser")
+
+	return cmd
+}
+
+func listRun(opts *ListOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	if opts.WebMode {
+		labelListURL := ghrepo.GenerateRepoURL(baseRepo, "labels")
+
+		if opts.IO.IsStdoutTTY() {
+			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", utils.DisplayURL(labelListURL))
+		}
+
+		return opts.Browser.Browse(labelListURL)
+	}
+
+	client := api.NewClientFromHTTP(httpClient)
+
+	opts.IO.StartProgressIndicator()
+
+	labels, err := getLabels(client, baseRepo)
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StopProgressIndicator()
+
+	printLabels(labels, opts.IO)
+
+	return nil
+}
+
+type Label struct {
+	Id          int
+	Name        string
+	Color       string
+	Default     bool
+	Url         string
+	Description string
+}
+
+func getLabels(client *api.Client, repo ghrepo.Interface) ([]Label, error) {
+	labels := []Label{}
+
+	path := fmt.Sprintf("repos/%s/%s/labels", repo.RepoOwner(), repo.RepoName())
+
+	err := client.REST(repo.RepoHost(), "GET", path, nil, &labels)
+	if err != nil {
+		return nil, err
+	}
+	return labels, nil
+}
+
+func printLabels(labels []Label, io *iostreams.IOStreams) error {
+	cs := io.ColorScheme()
+	table := utils.NewTablePrinter(io)
+
+	for _, label := range labels {
+		labelName := ""
+		if table.IsTTY() {
+			labelName = cs.HexToRGB(label.Color, label.Name)
+		} else {
+			labelName = label.Name
+		}
+
+		table.AddField(labelName, nil, nil)
+		table.AddField(label.Description, nil, nil)
+
+		table.EndRow()
+	}
+
+	return table.Render()
+}

--- a/pkg/cmd/label/list/list_test.go
+++ b/pkg/cmd/label/list/list_test.go
@@ -1,0 +1,144 @@
+package list
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/test"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, *cmdutil.TestBrowser, error) {
+	io, _, stdout, stderr := iostreams.Test()
+	io.SetStdoutTTY(isTTY)
+	io.SetStdinTTY(isTTY)
+	io.SetStderrTTY(isTTY)
+
+	browser := &cmdutil.TestBrowser{}
+
+	factory := &cmdutil.Factory{
+		IOStreams: io,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: rt}, nil
+		},
+		Config: func() (config.Config, error) {
+			return config.NewBlankConfig(), nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.New("OWNER", "REPO"), nil
+		},
+		Browser: browser,
+	}
+
+	cmd := NewCmdList(factory, nil)
+
+	argv, err := shlex.Split(cli)
+	if err != nil {
+		return nil, nil, err
+	}
+	cmd.SetArgs(argv)
+
+	cmd.SetIn(&bytes.Buffer{})
+	cmd.SetOut(ioutil.Discard)
+	cmd.SetErr(ioutil.Discard)
+
+	_, err = cmd.ExecuteC()
+	return &test.CmdOut{
+		OutBuf: stdout,
+		ErrBuf: stderr,
+	}, browser, err
+}
+
+func TestLabelList_nontty(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.REST("GET", "repos/OWNER/REPO/labels"),
+		httpmock.JSONResponse([]Label{
+			{
+				Name:        "bug",
+				Color:       "#B60205",
+				Description: "This is a bug label",
+			},
+			{
+				Name:        "docs",
+				Color:       "#D93F0B",
+				Description: "This is a docs label",
+			},
+		}),
+	)
+
+	output, _, err := runCommand(http, false, "")
+	if err != nil {
+		t.Errorf("error running command `label list`: %v", err)
+	}
+
+	assert.Equal(t, "", output.Stderr())
+
+	outputLines := strings.Split(output.String(), "\n")
+
+	assert.Equal(t, 3, len(outputLines))
+	assert.Equal(t, "bug\tThis is a bug label", outputLines[0])
+	assert.Equal(t, "docs\tThis is a docs label", outputLines[1])
+	assert.Equal(t, "", outputLines[2])
+}
+
+func TestLabelList_tty(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.REST("GET", "repos/OWNER/REPO/labels"),
+		httpmock.JSONResponse([]Label{
+			{
+				Name:        "bug",
+				Color:       "#B60205",
+				Description: "This is a bug label",
+			},
+			{
+				Name:        "docs",
+				Color:       "#D93F0B",
+				Description: "This is a docs label",
+			},
+		}),
+	)
+
+	output, _, err := runCommand(http, true, "")
+	if err != nil {
+		t.Errorf("error running command `label list`: %v", err)
+	}
+
+	assert.Equal(t, "", output.Stderr())
+
+	outputLines := strings.Split(output.String(), "\n")
+
+	assert.Equal(t, 3, len(outputLines))
+	assert.Equal(t, "bug   This is a bug label", outputLines[0])
+	assert.Equal(t, "docs  This is a docs label", outputLines[1])
+	assert.Equal(t, "", outputLines[2])
+}
+
+func TestLabelList_web(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	output, browser, err := runCommand(http, true, "-w")
+	if err != nil {
+		t.Errorf("error running command `label list`: %v", err)
+	}
+
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, "Opening github.com/OWNER/REPO/labels in your browser.\n", output.ErrBuf.String())
+	browser.Verify(t, "https://github.com/OWNER/REPO/labels")
+
+}

--- a/pkg/cmd/label/list/list_test.go
+++ b/pkg/cmd/label/list/list_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/label/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -64,7 +65,7 @@ func TestLabelList_nontty(t *testing.T) {
 
 	http.Register(
 		httpmock.REST("GET", "repos/OWNER/REPO/labels"),
-		httpmock.JSONResponse([]Label{
+		httpmock.JSONResponse([]shared.Label{
 			{
 				Name:        "bug",
 				Color:       "#B60205",
@@ -99,7 +100,7 @@ func TestLabelList_tty(t *testing.T) {
 
 	http.Register(
 		httpmock.REST("GET", "repos/OWNER/REPO/labels"),
-		httpmock.JSONResponse([]Label{
+		httpmock.JSONResponse([]shared.Label{
 			{
 				Name:        "bug",
 				Color:       "#B60205",

--- a/pkg/cmd/label/list/list_test.go
+++ b/pkg/cmd/label/list/list_test.go
@@ -92,31 +92,32 @@ func TestListRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query LabelList\b`),
 					httpmock.StringResponse(`
-          {
-            "data": {
-              "repository": {
-                "labels": {
-                  "totalCount": 2,
-                  "nodes": [
-                    {
-                      "name": "bug",
-                      "color": "d73a4a",
-                      "description": "This is a bug label"
-                    },
-                    {
-                      "name": "docs",
-                      "color": "ffa8da",
-                      "description": "This is a docs label"
-                    }
-                  ],
-                  "pageInfo": {
-                    "hasNextPage": false,
-                    "endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0xMC0xMVQwMTozODowMyswODowMM5f3HZq"
-                  }
-                }
-              }
-            }
-          }`),
+						{
+							"data": {
+								"repository": {
+									"labels": {
+										"totalCount": 2,
+										"nodes": [
+											{
+												"name": "bug",
+												"color": "d73a4a",
+												"description": "This is a bug label"
+											},
+											{
+												"name": "docs",
+												"color": "ffa8da",
+												"description": "This is a docs label"
+											}
+										],
+										"pageInfo": {
+											"hasNextPage": false,
+											"endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0xMC0xMVQwMTozODowMyswODowMM5f3HZq"
+										}
+									}
+								}
+							}
+						}`,
+					),
 				)
 			},
 			wantStdout: "\nShowing 2 of 2 labels in OWNER/REPO\n\nbug   This is a bug label\ndocs  This is a docs label\n",
@@ -129,31 +130,32 @@ func TestListRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query LabelList\b`),
 					httpmock.StringResponse(`
-          {
-            "data": {
-              "repository": {
-                "labels": {
-                  "totalCount": 2,
-                  "nodes": [
-                    {
-                      "name": "bug",
-                      "color": "d73a4a",
-                      "description": "This is a bug label"
-                    },
-                    {
-                      "name": "docs",
-                      "color": "ffa8da",
-                      "description": "This is a docs label"
-                    }
-                  ],
-                  "pageInfo": {
-                    "hasNextPage": false,
-                    "endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0xMC0xMVQwMTozODowMyswODowMM5f3HZq"
-                  }
-                }
-              }
-            }
-          }`),
+						{
+							"data": {
+								"repository": {
+									"labels": {
+										"totalCount": 2,
+										"nodes": [
+											{
+												"name": "bug",
+												"color": "d73a4a",
+												"description": "This is a bug label"
+											},
+											{
+												"name": "docs",
+												"color": "ffa8da",
+												"description": "This is a docs label"
+											}
+										],
+										"pageInfo": {
+											"hasNextPage": false,
+											"endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0xMC0xMVQwMTozODowMyswODowMM5f3HZq"
+										}
+									}
+								}
+							}
+						}`,
+					),
 				)
 			},
 			wantStdout: "bug\tThis is a bug label\ndocs\tThis is a docs label\n",
@@ -166,20 +168,8 @@ func TestListRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query LabelList\b`),
 					httpmock.StringResponse(`
-          {
-            "data": {
-              "repository": {
-                "labels": {
-                  "totalCount": 0,
-                  "nodes": [],
-                  "pageInfo": {
-                    "hasNextPage": false,
-                    "endCursor": null
-                  }
-                }
-              }
-            }
-          }`),
+						{"data":{"repository":{"labels":{"totalCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}`,
+					),
 				)
 			},
 			wantStdout: "\nThere are no labels in OWNER/REPO\n\n",

--- a/pkg/cmd/label/shared/shared.go
+++ b/pkg/cmd/label/shared/shared.go
@@ -1,7 +1,6 @@
 package shared
 
 type Label struct {
-	Id          string
 	Name        string
 	Color       string
 	Description string

--- a/pkg/cmd/label/shared/shared.go
+++ b/pkg/cmd/label/shared/shared.go
@@ -1,0 +1,10 @@
+package shared
+
+type Label struct {
+	Id          int
+	Name        string
+	Color       string
+	Default     bool
+	Url         string
+	Description string
+}

--- a/pkg/cmd/label/shared/shared.go
+++ b/pkg/cmd/label/shared/shared.go
@@ -1,10 +1,8 @@
 package shared
 
 type Label struct {
-	Id          int
+	Id          string
 	Name        string
 	Color       string
-	Default     bool
-	Url         string
 	Description string
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -20,6 +20,7 @@ import (
 	gistCmd "github.com/cli/cli/v2/pkg/cmd/gist"
 	gpgKeyCmd "github.com/cli/cli/v2/pkg/cmd/gpg-key"
 	issueCmd "github.com/cli/cli/v2/pkg/cmd/issue"
+	labelCmd "github.com/cli/cli/v2/pkg/cmd/label"
 	prCmd "github.com/cli/cli/v2/pkg/cmd/pr"
 	releaseCmd "github.com/cli/cli/v2/pkg/cmd/release"
 	repoCmd "github.com/cli/cli/v2/pkg/cmd/repo"
@@ -102,6 +103,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(repoCmd.NewCmdRepo(&repoResolvingCmdFactory))
 	cmd.AddCommand(runCmd.NewCmdRun(&repoResolvingCmdFactory))
 	cmd.AddCommand(workflowCmd.NewCmdWorkflow(&repoResolvingCmdFactory))
+	cmd.AddCommand(labelCmd.NewCmdLabel(&repoResolvingCmdFactory))
 
 	// Help topics
 	cmd.AddCommand(NewHelpTopic("environment"))

--- a/pkg/cmdutil/args.go
+++ b/pkg/cmdutil/args.go
@@ -21,7 +21,6 @@ func MinimumArgs(n int, msg string) cobra.PositionalArgs {
 }
 
 func ExactArgs(n int, msg string) cobra.PositionalArgs {
-
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) > n {
 			return FlagErrorf("too many arguments")


### PR DESCRIPTION
The `label list` output will look like this, and could use `-w` flag to open on browser

![image](https://user-images.githubusercontent.com/27152144/158361067-c29f2611-05f6-422c-a3a8-b729212accb5.png)


Fixes #446