### PR TITLE
[Codespaces] Disallow some operations on codespaces that have a pending operation

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -168,17 +168,19 @@ func (a *API) GetRepository(ctx context.Context, nwo string) (*Repository, error
 
 // Codespace represents a codespace.
 type Codespace struct {
-	Name        string              `json:"name"`
-	CreatedAt   string              `json:"created_at"`
-	DisplayName string              `json:"display_name"`
-	LastUsedAt  string              `json:"last_used_at"`
-	Owner       User                `json:"owner"`
-	Repository  Repository          `json:"repository"`
-	State       string              `json:"state"`
-	GitStatus   CodespaceGitStatus  `json:"git_status"`
-	Connection  CodespaceConnection `json:"connection"`
-	Machine     CodespaceMachine    `json:"machine"`
-	VSCSTarget  string              `json:"vscs_target"`
+	Name                           string              `json:"name"`
+	CreatedAt                      string              `json:"created_at"`
+	DisplayName                    string              `json:"display_name"`
+	LastUsedAt                     string              `json:"last_used_at"`
+	Owner                          User                `json:"owner"`
+	Repository                     Repository          `json:"repository"`
+	State                          string              `json:"state"`
+	GitStatus                      CodespaceGitStatus  `json:"git_status"`
+	Connection                     CodespaceConnection `json:"connection"`
+	Machine                        CodespaceMachine    `json:"machine"`
+	VSCSTarget                     string              `json:"vscs_target"`
+	PendingOperation               bool                `json:"pending_operation"`
+	PendingOperationDisabledReason string              `json:"pending_operation_disabled_reason"`
 }
 
 type CodespaceGitStatus struct {

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -167,6 +167,8 @@ func (a *API) GetRepository(ctx context.Context, nwo string) (*Repository, error
 }
 
 // Codespace represents a codespace.
+// You can see more about the fields in this type in the codespaces api docs:
+// https://docs.github.com/en/rest/reference/codespaces
 type Codespace struct {
 	Name                           string              `json:"name"`
 	CreatedAt                      string              `json:"created_at"`

--- a/pkg/cmd/codespace/code.go
+++ b/pkg/cmd/codespace/code.go
@@ -36,13 +36,6 @@ func (a *App) VSCode(ctx context.Context, codespaceName string, useInsiders bool
 		return fmt.Errorf("get or choose codespace: %w", err)
 	}
 
-	if codespace.PendingOperation {
-		return fmt.Errorf(
-			"codespace is disabled while it has a pending operation: %s",
-			codespace.PendingOperationDisabledReason,
-		)
-	}
-
 	url := vscodeProtocolURL(codespace.Name, useInsiders)
 	if err := a.browser.Browse(url); err != nil {
 		return fmt.Errorf("error opening Visual Studio Code: %w", err)

--- a/pkg/cmd/codespace/code.go
+++ b/pkg/cmd/codespace/code.go
@@ -33,7 +33,7 @@ func newCodeCmd(app *App) *cobra.Command {
 func (a *App) VSCode(ctx context.Context, codespaceName string, useInsiders bool) error {
 	codespace, err := getOrChooseCodespace(ctx, a.apiClient, codespaceName)
 	if err != nil {
-		return fmt.Errorf("get or choose codespace: %w", err)
+		return err
 	}
 
 	url := vscodeProtocolURL(codespace.Name, useInsiders)

--- a/pkg/cmd/codespace/code.go
+++ b/pkg/cmd/codespace/code.go
@@ -31,18 +31,19 @@ func newCodeCmd(app *App) *cobra.Command {
 
 // VSCode opens a codespace in the local VS VSCode application.
 func (a *App) VSCode(ctx context.Context, codespaceName string, useInsiders bool) error {
-	if codespaceName == "" {
-		codespace, err := chooseCodespace(ctx, a.apiClient)
-		if err != nil {
-			if err == errNoCodespaces {
-				return err
-			}
-			return fmt.Errorf("error choosing codespace: %w", err)
-		}
-		codespaceName = codespace.Name
+	codespace, err := getOrChooseCodespace(ctx, a.apiClient, codespaceName)
+	if err != nil {
+		return fmt.Errorf("get or choose codespace: %w", err)
 	}
 
-	url := vscodeProtocolURL(codespaceName, useInsiders)
+	if codespace.PendingOperation {
+		return fmt.Errorf(
+			"codespace is disabled while it has a pending operation: %s",
+			codespace.PendingOperationDisabledReason,
+		)
+	}
+
+	url := vscodeProtocolURL(codespace.Name, useInsiders)
 	if err := a.browser.Browse(url); err != nil {
 		return fmt.Errorf("error opening Visual Studio Code: %w", err)
 	}

--- a/pkg/cmd/codespace/code_test.go
+++ b/pkg/cmd/codespace/code_test.go
@@ -55,7 +55,7 @@ func TestApp_VSCode(t *testing.T) {
 }
 
 func TestPendingOperationDisallowsCode(t *testing.T) {
-	app := testingLogsApp()
+	app := testingCodeApp()
 
 	if err := app.VSCode(context.Background(), "disabledCodespace", false); err != nil {
 		if err.Error() != "get or choose codespace: codespace is disabled while it has a pending operation: Some pending operation" {

--- a/pkg/cmd/codespace/code_test.go
+++ b/pkg/cmd/codespace/code_test.go
@@ -58,7 +58,7 @@ func TestPendingOperationDisallowsCode(t *testing.T) {
 	app := testingCodeApp()
 
 	if err := app.VSCode(context.Background(), "disabledCodespace", false); err != nil {
-		if err.Error() != "get or choose codespace: codespace is disabled while it has a pending operation: Some pending operation" {
+		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
 			t.Errorf("expected pending operation error, but got: %v", err)
 		}
 	} else {

--- a/pkg/cmd/codespace/code_test.go
+++ b/pkg/cmd/codespace/code_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
 )
 
 func TestApp_VSCode(t *testing.T) {
@@ -41,12 +43,56 @@ func TestApp_VSCode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &cmdutil.TestBrowser{}
 			a := &App{
-				browser: b,
+				browser:   b,
+				apiClient: testCodeApiMock(),
 			}
 			if err := a.VSCode(context.Background(), tt.args.codespaceName, tt.args.useInsiders); (err != nil) != tt.wantErr {
 				t.Errorf("App.VSCode() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			b.Verify(t, tt.wantURL)
 		})
+	}
+}
+
+func TestPendingOperationDisallowsCode(t *testing.T) {
+	app := testingLogsApp()
+
+	if err := app.VSCode(context.Background(), "disabledCodespace", false); err != nil {
+		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
+			t.Errorf("expected pending operation error, but got: %v", err)
+		}
+	} else {
+		t.Error("expected pending operation error, but got nothing")
+	}
+}
+
+func testingCodeApp() *App {
+	io, _, _, _ := iostreams.Test()
+	return NewApp(io, nil, testCodeApiMock(), nil)
+}
+
+func testCodeApiMock() *apiClientMock {
+	user := &api.User{Login: "monalisa"}
+	testingCodespace := &api.Codespace{
+		Name: "monalisa-cli-cli-abcdef",
+	}
+	disabledCodespace := &api.Codespace{
+		Name:                           "disabledCodespace",
+		PendingOperation:               true,
+		PendingOperationDisabledReason: "Some pending operation",
+	}
+	return &apiClientMock{
+		GetCodespaceFunc: func(_ context.Context, name string, _ bool) (*api.Codespace, error) {
+			if name == "disabledCodespace" {
+				return disabledCodespace, nil
+			}
+			return testingCodespace, nil
+		},
+		GetUserFunc: func(_ context.Context) (*api.User, error) {
+			return user, nil
+		},
+		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]byte, error) {
+			return []byte{}, nil
+		},
 	}
 }

--- a/pkg/cmd/codespace/code_test.go
+++ b/pkg/cmd/codespace/code_test.go
@@ -58,7 +58,7 @@ func TestPendingOperationDisallowsCode(t *testing.T) {
 	app := testingLogsApp()
 
 	if err := app.VSCode(context.Background(), "disabledCodespace", false); err != nil {
-		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
+		if err.Error() != "get or choose codespace: codespace is disabled while it has a pending operation: Some pending operation" {
 			t.Errorf("expected pending operation error, but got: %v", err)
 		}
 	} else {

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -183,6 +183,13 @@ func getOrChooseCodespace(ctx context.Context, apiClient apiClient, codespaceNam
 		}
 	}
 
+	if codespace.PendingOperation {
+		return nil, fmt.Errorf(
+			"codespace is disabled while it has a pending operation: %s",
+			codespace.PendingOperationDisabledReason,
+		)
+	}
+
 	return codespace, nil
 }
 

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -101,7 +101,7 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 		tp.AddField(c.Repository.FullName, nil, nil)
 		tp.AddField(c.branchWithGitStatus(), nil, cs.Cyan)
 		if c.PendingOperation {
-			tp.AddField(c.PendingOperationDisabledReason, nil, cs.Gray)
+			tp.AddField(c.PendingOperationDisabledReason, nil, nameColor)
 		} else {
 			tp.AddField(c.State, nil, stateColor)
 		}

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -89,10 +89,22 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 
 		formattedName := formatNameForVSCSTarget(c.Name, c.VSCSTarget)
 
-		tp.AddField(formattedName, nil, cs.Yellow)
+		var nameColor func(string) string
+		switch c.PendingOperation {
+		case false:
+			nameColor = cs.Yellow
+		case true:
+			nameColor = cs.Gray
+		}
+
+		tp.AddField(formattedName, nil, nameColor)
 		tp.AddField(c.Repository.FullName, nil, nil)
 		tp.AddField(c.branchWithGitStatus(), nil, cs.Cyan)
-		tp.AddField(c.State, nil, stateColor)
+		if c.PendingOperation {
+			tp.AddField(c.PendingOperationDisabledReason, nil, cs.Gray)
+		} else {
+			tp.AddField(c.State, nil, stateColor)
+		}
 
 		if tp.IsTTY() {
 			ct, err := time.Parse(time.RFC3339, c.CreatedAt)

--- a/pkg/cmd/codespace/logs.go
+++ b/pkg/cmd/codespace/logs.go
@@ -41,6 +41,13 @@ func (a *App) Logs(ctx context.Context, codespaceName string, follow bool) (err 
 		return fmt.Errorf("get or choose codespace: %w", err)
 	}
 
+	if codespace.PendingOperation {
+		return fmt.Errorf(
+			"codespace is disabled while it has a pending operation: %s",
+			codespace.PendingOperationDisabledReason,
+		)
+	}
+
 	authkeys := make(chan error, 1)
 	go func() {
 		authkeys <- checkAuthorizedKeys(ctx, a.apiClient)

--- a/pkg/cmd/codespace/logs.go
+++ b/pkg/cmd/codespace/logs.go
@@ -41,13 +41,6 @@ func (a *App) Logs(ctx context.Context, codespaceName string, follow bool) (err 
 		return fmt.Errorf("get or choose codespace: %w", err)
 	}
 
-	if codespace.PendingOperation {
-		return fmt.Errorf(
-			"codespace is disabled while it has a pending operation: %s",
-			codespace.PendingOperationDisabledReason,
-		)
-	}
-
 	authkeys := make(chan error, 1)
 	go func() {
 		authkeys <- checkAuthorizedKeys(ctx, a.apiClient)

--- a/pkg/cmd/codespace/logs.go
+++ b/pkg/cmd/codespace/logs.go
@@ -38,7 +38,7 @@ func (a *App) Logs(ctx context.Context, codespaceName string, follow bool) (err 
 
 	codespace, err := getOrChooseCodespace(ctx, a.apiClient, codespaceName)
 	if err != nil {
-		return fmt.Errorf("get or choose codespace: %w", err)
+		return err
 	}
 
 	authkeys := make(chan error, 1)

--- a/pkg/cmd/codespace/logs_test.go
+++ b/pkg/cmd/codespace/logs_test.go
@@ -1,0 +1,47 @@
+package codespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+func TestPendingOperationDisallowsLogs(t *testing.T) {
+	app := testingLogsApp()
+
+	if err := app.Logs(context.Background(), "disabledCodespace", false); err != nil {
+		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
+			t.Errorf("expected pending operation error, but got: %v", err)
+		}
+	} else {
+		t.Error("expected pending operation error, but got nothing")
+	}
+}
+
+func testingLogsApp() *App {
+	user := &api.User{Login: "monalisa"}
+	disabledCodespace := &api.Codespace{
+		Name:                           "disabledCodespace",
+		PendingOperation:               true,
+		PendingOperationDisabledReason: "Some pending operation",
+	}
+	apiMock := &apiClientMock{
+		GetCodespaceFunc: func(_ context.Context, name string, _ bool) (*api.Codespace, error) {
+			if name == "disabledCodespace" {
+				return disabledCodespace, nil
+			}
+			return nil, nil
+		},
+		GetUserFunc: func(_ context.Context) (*api.User, error) {
+			return user, nil
+		},
+		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]byte, error) {
+			return []byte{}, nil
+		},
+	}
+
+	io, _, _, _ := iostreams.Test()
+	return NewApp(io, nil, apiMock, nil)
+}

--- a/pkg/cmd/codespace/logs_test.go
+++ b/pkg/cmd/codespace/logs_test.go
@@ -12,7 +12,7 @@ func TestPendingOperationDisallowsLogs(t *testing.T) {
 	app := testingLogsApp()
 
 	if err := app.Logs(context.Background(), "disabledCodespace", false); err != nil {
-		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
+		if err.Error() != "get or choose codespace: codespace is disabled while it has a pending operation: Some pending operation" {
 			t.Errorf("expected pending operation error, but got: %v", err)
 		}
 	} else {

--- a/pkg/cmd/codespace/logs_test.go
+++ b/pkg/cmd/codespace/logs_test.go
@@ -12,7 +12,7 @@ func TestPendingOperationDisallowsLogs(t *testing.T) {
 	app := testingLogsApp()
 
 	if err := app.Logs(context.Background(), "disabledCodespace", false); err != nil {
-		if err.Error() != "get or choose codespace: codespace is disabled while it has a pending operation: Some pending operation" {
+		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
 			t.Errorf("expected pending operation error, but got: %v", err)
 		}
 	} else {

--- a/pkg/cmd/codespace/ports_test.go
+++ b/pkg/cmd/codespace/ports_test.go
@@ -1,0 +1,71 @@
+package codespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+func TestPendingOperationDisallowsListPorts(t *testing.T) {
+	app := testingPortsApp()
+
+	if err := app.ListPorts(context.Background(), "disabledCodespace", nil); err != nil {
+		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
+			t.Errorf("expected pending operation error, but got: %v", err)
+		}
+	} else {
+		t.Error("expected pending operation error, but got nothing")
+	}
+}
+
+func TestPendingOperationDisallowsUpdatePortVisability(t *testing.T) {
+	app := testingPortsApp()
+
+	if err := app.UpdatePortVisibility(context.Background(), "disabledCodespace", nil); err != nil {
+		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
+			t.Errorf("expected pending operation error, but got: %v", err)
+		}
+	} else {
+		t.Error("expected pending operation error, but got nothing")
+	}
+}
+
+func TestPendingOperationDisallowsForwardPorts(t *testing.T) {
+	app := testingPortsApp()
+
+	if err := app.ForwardPorts(context.Background(), "disabledCodespace", nil); err != nil {
+		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
+			t.Errorf("expected pending operation error, but got: %v", err)
+		}
+	} else {
+		t.Error("expected pending operation error, but got nothing")
+	}
+}
+
+func testingPortsApp() *App {
+	user := &api.User{Login: "monalisa"}
+	disabledCodespace := &api.Codespace{
+		Name:                           "disabledCodespace",
+		PendingOperation:               true,
+		PendingOperationDisabledReason: "Some pending operation",
+	}
+	apiMock := &apiClientMock{
+		GetCodespaceFunc: func(_ context.Context, name string, _ bool) (*api.Codespace, error) {
+			if name == "disabledCodespace" {
+				return disabledCodespace, nil
+			}
+			return nil, nil
+		},
+		GetUserFunc: func(_ context.Context) (*api.User, error) {
+			return user, nil
+		},
+		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]byte, error) {
+			return []byte{}, nil
+		},
+	}
+
+	io, _, _, _ := iostreams.Test()
+	return NewApp(io, nil, apiMock, nil)
+}

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -125,7 +125,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 
 	codespace, err := getOrChooseCodespace(ctx, a.apiClient, opts.codespace)
 	if err != nil {
-		return fmt.Errorf("get or choose codespace: %w", err)
+		return err
 	}
 
 	liveshareLogger := noopLogger()

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -128,6 +128,13 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		return fmt.Errorf("get or choose codespace: %w", err)
 	}
 
+	if codespace.PendingOperation {
+		return fmt.Errorf(
+			"codespace is disabled while it has a pending operation: %s",
+			codespace.PendingOperationDisabledReason,
+		)
+	}
+
 	liveshareLogger := noopLogger()
 	if opts.debug {
 		debugLogger, err := newFileLogger(opts.debugFile)

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -128,13 +128,6 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 		return fmt.Errorf("get or choose codespace: %w", err)
 	}
 
-	if codespace.PendingOperation {
-		return fmt.Errorf(
-			"codespace is disabled while it has a pending operation: %s",
-			codespace.PendingOperationDisabledReason,
-		)
-	}
-
 	liveshareLogger := noopLogger()
 	if opts.debug {
 		debugLogger, err := newFileLogger(opts.debugFile)

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -1,0 +1,47 @@
+package codespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+func TestPendingOperationDisallowsSSH(t *testing.T) {
+	app := testingSSHApp()
+
+	if err := app.SSH(context.Background(), []string{}, sshOptions{codespace: "disabledCodespace"}); err != nil {
+		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
+			t.Errorf("expected pending operation error, but got: %v", err)
+		}
+	} else {
+		t.Error("expected pending operation error, but got nothing")
+	}
+}
+
+func testingSSHApp() *App {
+	user := &api.User{Login: "monalisa"}
+	disabledCodespace := &api.Codespace{
+		Name:                           "disabledCodespace",
+		PendingOperation:               true,
+		PendingOperationDisabledReason: "Some pending operation",
+	}
+	apiMock := &apiClientMock{
+		GetCodespaceFunc: func(_ context.Context, name string, _ bool) (*api.Codespace, error) {
+			if name == "disabledCodespace" {
+				return disabledCodespace, nil
+			}
+			return nil, nil
+		},
+		GetUserFunc: func(_ context.Context) (*api.User, error) {
+			return user, nil
+		},
+		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]byte, error) {
+			return []byte{}, nil
+		},
+	}
+
+	io, _, _, _ := iostreams.Test()
+	return NewApp(io, nil, apiMock, nil)
+}

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -12,7 +12,7 @@ func TestPendingOperationDisallowsSSH(t *testing.T) {
 	app := testingSSHApp()
 
 	if err := app.SSH(context.Background(), []string{}, sshOptions{codespace: "disabledCodespace"}); err != nil {
-		if err.Error() != "get or choose codespace: codespace is disabled while it has a pending operation: Some pending operation" {
+		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
 			t.Errorf("expected pending operation error, but got: %v", err)
 		}
 	} else {

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -12,7 +12,7 @@ func TestPendingOperationDisallowsSSH(t *testing.T) {
 	app := testingSSHApp()
 
 	if err := app.SSH(context.Background(), []string{}, sshOptions{codespace: "disabledCodespace"}); err != nil {
-		if err.Error() != "codespace is disabled while it has a pending operation: Some pending operation" {
+		if err.Error() != "get or choose codespace: codespace is disabled while it has a pending operation: Some pending operation" {
 			t.Errorf("expected pending operation error, but got: %v", err)
 		}
 	} else {


### PR DESCRIPTION
Closes https://github.com/github/codespaces/issues/6794

We (the Codespaces team) are in the process of introducing the concept of pending async operations to codespaces. When a codespace has a pending operation, it can't be started, stopped, updated or exported.

This PR handles this scenario for each operation that is not allowed during a pending operation. It will show an error message to the user that the requested action isn't allowed because the codespace has a pending operation and shows the user the pending operation reason. See the individual commit message for each operation to see the exact changes to error messages, but one example is: 

Old ssh error message:

```
$ gh cs ssh -c cwndrws-redacted
Starting codespace ⣽error connecting to codespace: error starting codespace: HTTP 422: your codespace has an operation pending: updating to a sku with a different amount of storage; please wait until this operation is complete (https://api.github.com/user/codespaces/cwndrws-redacted/start)
exit status 1

```

New ssh error message:

```
$ gh cs ssh -c cwndrws-redacted
codespace is disabled while it has a pending operation: Changing machine types...
exit status 1
```

It also changes the way codespaces look in the list (`gh cs list`) to look disabled (gray) with the pending operation reason replacing its state.

![Screen Shot 2022-03-15 at 5 36 11 PM](https://user-images.githubusercontent.com/1382553/158477324-4c46c9a7-4a09-494f-9953-31c7bf1f9454.png)
