### PR TITLE
liveshare test: only sleep if conn is nil

### DIFF
--- a/pkg/liveshare/port_forwarder_test.go
+++ b/pkg/liveshare/port_forwarder_test.go
@@ -82,6 +82,8 @@ func TestPortForwarderStart(t *testing.T) {
 
 	go func() {
 		var conn net.Conn
+
+		// We retry DialTimeout in a loop to deal with a race in PortForwarder startup.
 		for tries := 0; conn == nil && tries < 2; tries++ {
 			conn, err = net.DialTimeout("tcp", ":8000", 2*time.Second)
 			if conn == nil {

--- a/pkg/liveshare/port_forwarder_test.go
+++ b/pkg/liveshare/port_forwarder_test.go
@@ -85,7 +85,9 @@ func TestPortForwarderStart(t *testing.T) {
 		retries := 0
 		for conn == nil && retries < 2 {
 			conn, err = net.DialTimeout("tcp", ":8000", 2*time.Second)
-			time.Sleep(1 * time.Second)
+			if conn == nil {
+				time.Sleep(1 * time.Second)
+			}
 		}
 		if conn == nil {
 			done <- errors.New("failed to connect to forwarded port")

--- a/pkg/liveshare/port_forwarder_test.go
+++ b/pkg/liveshare/port_forwarder_test.go
@@ -86,6 +86,7 @@ func TestPortForwarderStart(t *testing.T) {
 		for conn == nil && retries < 2 {
 			conn, err = net.DialTimeout("tcp", ":8000", 2*time.Second)
 			if conn == nil {
+				retries++
 				time.Sleep(1 * time.Second)
 			}
 		}

--- a/pkg/liveshare/port_forwarder_test.go
+++ b/pkg/liveshare/port_forwarder_test.go
@@ -82,11 +82,9 @@ func TestPortForwarderStart(t *testing.T) {
 
 	go func() {
 		var conn net.Conn
-		retries := 0
-		for conn == nil && retries < 2 {
+		for tries := 0; conn == nil && tries < 2; tries++ {
 			conn, err = net.DialTimeout("tcp", ":8000", 2*time.Second)
 			if conn == nil {
-				retries++
 				time.Sleep(1 * time.Second)
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/5338

- We only need to sleep if the `conn` is nil when attempting to connect, otherwise, we have a good connection and shouldn't take up execution time