### PR TITLE
Renames permissions out param to multi_repo_permissions_opt_out

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -646,7 +646,7 @@ type startCreateRequest struct {
 	Machine            string `json:"machine"`
 	VSCSTarget         string `json:"vscs_target,omitempty"`
 	VSCSTargetURL      string `json:"vscs_target_url,omitempty"`
-	PermissionsOptOut  bool   `json:"devcontainer_permissions_opt_out"`
+	PermissionsOptOut  bool   `json:"multi_repo_permissions_opt_out"`
 }
 
 var errProvisioningInProgress = errors.New("provisioning in progress")


### PR DESCRIPTION
Renames `devcontainer_permissions_opt_out` to `multi_repo_permissions_opt_out` to be consistent with the param in the public API. 
Fixes https://github.com/github/codespaces/issues/7021
