### PR TITLE
ssh.go: use setup example that should work with any ssh config

### DIFF
--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -59,7 +59,7 @@ func newSSHCmd(app *App) *cobra.Command {
 			$ gh codespace ssh
 
 			$ gh codespace ssh --config > ~/.ssh/codespaces
-			$ echo 'include ~/.ssh/codespaces' >> ~/.ssh/config
+			$ printf 'Match all\nInclude ~/.ssh/codespaces\n' >> ~/.ssh/config
 		`),
 		PreRunE: func(c *cobra.Command, args []string) error {
 			if opts.stdio {


### PR DESCRIPTION
The `gh cs ssh` command suggests an example recipe for setting up openssh integration. The last step appends an `Include` statement to the user's `~/.ssh/config`.

Unfortunately, this won't always work as intended. If the existing configuration ends with a `Host` block, the added `Include` statement will be conditional on whether that block matches.

By preceding the `Include` statement with `Match all`, we can ensure that it is always evaluated.

Fixes: https://github.com/github/codespaces/issues/7058
