### PR TITLE
fix: do not throw an error when updgrading --all extensions if no extensions are installed

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -150,9 +150,12 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					}
 					cs := io.ColorScheme()
 					err := m.Upgrade(name, flagForce)
-					if err != nil && !errors.Is(err, upToDateError) && !errors.Is(err, noExtensionsInstalledError) {
+					if err != nil && !errors.Is(err, upToDateError) {
 						if name != "" {
 							fmt.Fprintf(io.ErrOut, "%s Failed upgrading extension %s: %s\n", cs.FailureIcon(), name, err)
+						} else if errors.Is(err, noExtensionsInstalledError) {
+							fmt.Fprintf(io.ErrOut, "%s No installed extensions found\n", cs.WarningIcon())
+							return nil
 						} else {
 							fmt.Fprintf(io.ErrOut, "%s Failed upgrading extensions\n", cs.FailureIcon())
 						}
@@ -161,8 +164,6 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					if io.IsStdoutTTY() {
 						if errors.Is(err, upToDateError) {
 							fmt.Fprintf(io.Out, "%s Extension already up to date\n", cs.SuccessIcon())
-						} else if errors.Is(err, noExtensionsInstalledError) {
-							fmt.Fprintf(io.Out, "%s No installed extensions found\n", cs.SuccessIcon())
 						} else if name != "" {
 							fmt.Fprintf(io.Out, "%s Successfully upgraded extension %s\n", cs.SuccessIcon(), name)
 						} else {

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -150,7 +150,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					}
 					cs := io.ColorScheme()
 					err := m.Upgrade(name, flagForce)
-					if err != nil && !errors.Is(err, upToDateError) {
+					if err != nil && !errors.Is(err, upToDateError) && !errors.Is(err, noExtensionsInstalledError) {
 						if name != "" {
 							fmt.Fprintf(io.ErrOut, "%s Failed upgrading extension %s: %s\n", cs.FailureIcon(), name, err)
 						} else {
@@ -161,6 +161,8 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					if io.IsStdoutTTY() {
 						if errors.Is(err, upToDateError) {
 							fmt.Fprintf(io.Out, "%s Extension already up to date\n", cs.SuccessIcon())
+						} else if errors.Is(err, noExtensionsInstalledError) {
+							fmt.Fprintf(io.Out, "%s No installed extensions found\n", cs.SuccessIcon())
 						} else if name != "" {
 							fmt.Fprintf(io.Out, "%s Successfully upgraded extension %s\n", cs.SuccessIcon(), name)
 						} else {

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -141,23 +141,6 @@ func TestNewCmdExtension(t *testing.T) {
 			wantStderr: "",
 		},
 		{
-			name: "upgrade all extension with none installed",
-			args: []string{"upgrade", "--all"},
-			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
-				em.UpgradeFunc = func(name string, force bool) error {
-					return noExtensionsInstalledError
-				}
-				return func(t *testing.T) {
-					calls := em.UpgradeCalls()
-					assert.Equal(t, 1, len(calls))
-					assert.Equal(t, "", calls[0].Name)
-				}
-			},
-			isTTY:      true,
-			wantStdout: "✓ No installed extensions found\n",
-			wantStderr: "",
-		},
-		{
 			name: "upgrade extension error",
 			args: []string{"upgrade", "hello"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
@@ -223,6 +206,22 @@ func TestNewCmdExtension(t *testing.T) {
 			},
 			isTTY:      true,
 			wantStdout: "✓ Successfully upgraded extensions\n",
+		},
+		{
+			name: "upgrade all none installed",
+			args: []string{"upgrade", "--all"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.UpgradeFunc = func(name string, force bool) error {
+					return noExtensionsInstalledError
+				}
+				return func(t *testing.T) {
+					calls := em.UpgradeCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "", calls[0].Name)
+				}
+			},
+			isTTY:      true,
+			wantStderr: "! No installed extensions found\n",
 		},
 		{
 			name: "upgrade all notty",

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -141,6 +141,23 @@ func TestNewCmdExtension(t *testing.T) {
 			wantStderr: "",
 		},
 		{
+			name: "upgrade all extension with none installed",
+			args: []string{"upgrade", "--all"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.UpgradeFunc = func(name string, force bool) error {
+					return noExtensionsInstalledError
+				}
+				return func(t *testing.T) {
+					calls := em.UpgradeCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "", calls[0].Name)
+				}
+			},
+			isTTY:      true,
+			wantStdout: "✓ No installed extensions found\n",
+			wantStderr: "",
+		},
+		{
 			name: "upgrade extension error",
 			args: []string{"upgrade", "hello"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {


### PR DESCRIPTION
If no extension name is provided, check to see if the error type is `noExtensionsInstalled`, in which case write to stderr "! No installed extensions found" and return nil so a non-zero exit code will not be returned.

resolves #5348

