### PR TITLE
fix: respect `GH_FORCE_TTY` when running `gh pr view`

### DIFF
--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -98,7 +98,7 @@ func viewRun(opts *ViewOptions) error {
 		return err
 	}
 
-	connectedToTerminal := opts.IO.IsStdoutTTY() && opts.IO.IsStderrTTY()
+	connectedToTerminal := opts.IO.IsStdoutTTY()
 
 	if opts.BrowserMode {
 		openURL := pr.URL


### PR DESCRIPTION
`GH_FORCE_TTY` only affects stdout, not stderr, so this check was
failing and the flag was being ignored.

I also checked for similar problem in other files but everything else
seemed stderr or stdin related.

Let me know if this needs tests or anything :)

Fixes #5354
