### PR TITLE
Add ability to filter issue and pr searches by app

### DIFF
--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -55,6 +55,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Browser:    f.Browser,
 	}
 
+	var appAuthor string
+
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List issues in a repository",
@@ -81,6 +83,14 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 				return cmdutil.FlagErrorf("invalid limit: %v", opts.LimitResults)
 			}
 
+			if cmd.Flags().Changed("author") && cmd.Flags().Changed("app") {
+				return cmdutil.FlagErrorf("specify only `--author` or `--app`")
+			}
+
+			if cmd.Flags().Changed("app") {
+				opts.Author = fmt.Sprintf("app/%s", appAuthor)
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -94,6 +104,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmdutil.StringEnumFlag(cmd, &opts.State, "state", "s", "open", []string{"open", "closed", "all"}, "Filter by state")
 	cmd.Flags().IntVarP(&opts.LimitResults, "limit", "L", 30, "Maximum number of issues to fetch")
 	cmd.Flags().StringVarP(&opts.Author, "author", "A", "", "Filter by author")
+	cmd.Flags().StringVar(&appAuthor, "app", "", "Filter by GitHub App author")
 	cmd.Flags().StringVar(&opts.Mention, "mention", "", "Filter by mention")
 	cmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter by milestone number or title")
 	cmd.Flags().StringVarP(&opts.Search, "search", "S", "", "Search issues with `query`")

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -136,6 +136,32 @@ No issues match your search in OWNER/REPO
 `, output.String())
 }
 
+func TestIssueList_tty_withAppFlag(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.GraphQL(`query IssueList\b`),
+		httpmock.GraphQLQuery(`
+		{ "data": {	"repository": {
+			"hasIssuesEnabled": true,
+			"issues": { "nodes": [] }
+		} } }`, func(_ string, params map[string]interface{}) {
+			assert.Equal(t, "app/dependabot", params["author"].(string))
+		}))
+
+	output, err := runCommand(http, true, "--app dependabot")
+	if err != nil {
+		t.Errorf("error running command `issue list`: %v", err)
+	}
+
+	assert.Equal(t, "", output.Stderr())
+	assert.Equal(t, `
+No issues match your search in OWNER/REPO
+
+`, output.String())
+}
+
 func TestIssueList_withInvalidLimitFlag(t *testing.T) {
 	http := &httpmock.Registry{}
 	defer http.Verify(t)

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -36,7 +36,6 @@ type ListOptions struct {
 	HeadBranch string
 	Labels     []string
 	Author     string
-	AppAuthor  string
 	Assignee   string
 	Search     string
 	Draft      string
@@ -50,6 +49,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	var draft bool
+	var appAuthor string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -87,12 +87,12 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 				opts.Draft = strconv.FormatBool(draft)
 			}
 
-			if err := cmdutil.MutuallyExclusive(
-				"specify only `--author` or `--app`",
-				opts.Author != "",
-				opts.AppAuthor != "",
-			); err != nil {
-				return err
+			if cmd.Flags().Changed("author") && cmd.Flags().Changed("app") {
+				return cmdutil.FlagErrorf("specify only `--author` or `--app`")
+			}
+
+			if cmd.Flags().Changed("app") {
+				opts.Author = fmt.Sprintf("app/%s", appAuthor)
 			}
 
 			if runF != nil {
@@ -109,7 +109,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.HeadBranch, "head", "H", "", "Filter by head branch")
 	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Filter by label")
 	cmd.Flags().StringVarP(&opts.Author, "author", "A", "", "Filter by author")
-	cmd.Flags().StringVar(&opts.AppAuthor, "app", "", "Filter by GitHub App author")
+	cmd.Flags().StringVar(&appAuthor, "app", "", "Filter by GitHub App author")
 	cmd.Flags().StringVarP(&opts.Assignee, "assignee", "a", "", "Filter by assignee")
 	cmd.Flags().StringVarP(&opts.Search, "search", "S", "", "Search pull requests with `query`")
 	cmd.Flags().BoolVarP(&draft, "draft", "d", false, "Filter by draft state")
@@ -172,10 +172,6 @@ func listRun(opts *ListOptions) error {
 			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", utils.DisplayURL(openURL))
 		}
 		return opts.Browser.Browse(openURL)
-	}
-
-	if opts.AppAuthor != "" {
-		filters.Author = fmt.Sprintf("app/%s", opts.AppAuthor)
 	}
 
 	listResult, err := listPullRequests(httpClient, baseRepo, filters, opts.LimitResults)

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -1,6 +1,8 @@
 package issues
 
 import (
+	"fmt"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/pkg/cmd/search/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -9,11 +11,10 @@ import (
 )
 
 func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobra.Command {
-	var includePrs bool
-	var locked bool
+	var locked, includePrs bool
 	var noAssignee, noLabel, noMilestone, noProject bool
-	var order string
-	var sort string
+	var order, sort string
+	var appAuthor string
 	opts := &shared.IssuesOptions{
 		Browser: f.Browser,
 		Entity:  shared.Issues,
@@ -56,6 +57,12 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 			}
 			if opts.Query.Limit < 1 || opts.Query.Limit > shared.SearchMaxResults {
 				return cmdutil.FlagErrorf("`--limit` must be between 1 and 1000")
+			}
+			if c.Flags().Changed("author") && c.Flags().Changed("app") {
+				return cmdutil.FlagErrorf("specify only `--author` or `--app`")
+			}
+			if c.Flags().Changed("app") {
+				opts.Query.Qualifiers.Author = fmt.Sprintf("app/%s", appAuthor)
 			}
 			if includePrs {
 				opts.Entity = shared.Both
@@ -123,6 +130,7 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 
 	// Query qualifier flags
 	cmd.Flags().BoolVar(&includePrs, "include-prs", false, "Include pull requests in results")
+	cmd.Flags().StringVar(&appAuthor, "app", "", "Filter by GitHub App author")
 	cmdutil.NilBoolFlag(cmd, &opts.Query.Qualifiers.Archived, "archived", "", "Restrict search to archived repositories")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Assignee, "assignee", "", "Filter by assignee")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Author, "author", "", "Filter by author")

--- a/pkg/cmd/search/issues/issues_test.go
+++ b/pkg/cmd/search/issues/issues_test.go
@@ -102,6 +102,24 @@ func TestNewCmdIssues(t *testing.T) {
 			},
 		},
 		{
+			name:  "app flag",
+			input: "--app dependabot",
+			output: shared.IssuesOptions{
+				Query: search.Query{
+					Keywords:   []string{},
+					Kind:       "issues",
+					Limit:      30,
+					Qualifiers: search.Qualifiers{Type: "issue", Author: "app/dependabot"},
+				},
+			},
+		},
+		{
+			name:    "invalid author and app flags",
+			input:   "--author test --app dependabot",
+			wantErr: true,
+			errMsg:  "specify only `--author` or `--app`",
+		},
+		{
 			name: "qualifier flags",
 			input: `
       --archived

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -1,6 +1,8 @@
 package prs
 
 import (
+	"fmt"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/pkg/cmd/search/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -9,11 +11,10 @@ import (
 )
 
 func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobra.Command {
-	var locked bool
-	var merged bool
+	var locked, merged bool
 	var noAssignee, noLabel, noMilestone, noProject bool
-	var order string
-	var sort string
+	var order, sort string
+	var appAuthor string
 	opts := &shared.IssuesOptions{
 		Browser: f.Browser,
 		Entity:  shared.Issues,
@@ -56,6 +57,12 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 			}
 			if opts.Query.Limit < 1 || opts.Query.Limit > shared.SearchMaxResults {
 				return cmdutil.FlagErrorf("`--limit` must be between 1 and 1000")
+			}
+			if c.Flags().Changed("author") && c.Flags().Changed("app") {
+				return cmdutil.FlagErrorf("specify only `--author` or `--app`")
+			}
+			if c.Flags().Changed("app") {
+				opts.Query.Qualifiers.Author = fmt.Sprintf("app/%s", appAuthor)
 			}
 			if c.Flags().Changed("order") {
 				opts.Query.Order = order
@@ -125,6 +132,7 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 		}, "Sort fetched results")
 
 	// Issue query qualifier flags
+	cmd.Flags().StringVar(&appAuthor, "app", "", "Filter by GitHub App author")
 	cmdutil.NilBoolFlag(cmd, &opts.Query.Qualifiers.Archived, "archived", "", "Restrict search to archived repositories")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Assignee, "assignee", "", "Filter by assignee")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Author, "author", "", "Filter by author")

--- a/pkg/cmd/search/prs/prs_test.go
+++ b/pkg/cmd/search/prs/prs_test.go
@@ -90,6 +90,24 @@ func TestNewCmdPrs(t *testing.T) {
 			errMsg:  "invalid argument \"invalid\" for \"--order\" flag: valid values are {asc|desc}",
 		},
 		{
+			name:  "app flag",
+			input: "--app dependabot",
+			output: shared.IssuesOptions{
+				Query: search.Query{
+					Keywords:   []string{},
+					Kind:       "issues",
+					Limit:      30,
+					Qualifiers: search.Qualifiers{Type: "pr", Author: "app/dependabot"},
+				},
+			},
+		},
+		{
+			name:    "invalid author and app flags",
+			input:   "--author test --app dependabot",
+			wantErr: true,
+			errMsg:  "specify only `--author` or `--app`",
+		},
+		{
 			name: "qualifier flags",
 			input: `
       --archived


### PR DESCRIPTION
This PR adds the `--app` filter flag to `issue list`, `search issues`, and `search prs` to bring them inline with `pr list`. Additionally, it fixes a bug in `pr list` where the `--app` flag was not being respected in web mode. 

cc https://github.com/cli/cli/issues/4045