### PR TITLE
generateCompareURL uses url.PathEscape instead of url.QueryEscape

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -755,7 +755,7 @@ func generateCompareURL(ctx CreateContext, state shared.IssueMetadataState) (str
 	u := ghrepo.GenerateRepoURL(
 		ctx.BaseRepo,
 		"compare/%s...%s?expand=1",
-		url.QueryEscape(ctx.BaseBranch), url.QueryEscape(ctx.HeadBranchLabel))
+		url.PathEscape(ctx.BaseBranch), url.PathEscape(ctx.HeadBranchLabel))
 	url, err := shared.WithPrAndIssueQueryParams(ctx.Client, ctx.BaseRepo, u, state)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
For ctx.{BaseBranch,HeadBranchLabel}.

- Using the web interface: `https://github.com/cli/cli/compare/trunk...GreenRecycleBin:!$&'()+,;=@?expand=1`
- `$ gh pr create --web`—Before: `https://github.com/cli/cli/compare/trunk...GreenRecycleBin%3A%21%24%26%27%28%29%2B%2C%3B%3D%40?body=&expand=1`
- `$ gh pr create --web`—After: `https://github.com/cli/cli/compare/trunk...GreenRecycleBin:%21$&%27%28%29+%2C%3B=@?body=&expand=1`

(Pardon the branch name, I wanted to identify a valid Git branch name that contains as many characters in sub-delims and gen-delims that are also valid in URL path segments.)
