### PR TITLE
config: introduce WriteHosts

### DIFF
--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -26,6 +26,7 @@ var (
 type iconfig interface {
 	Set(string, string, string) error
 	Write() error
+	WriteHosts() error
 }
 
 func AuthFlowWithConfig(cfg iconfig, IO *iostreams.IOStreams, hostname, notice string, additionalScopes []string, isInteractive bool) (string, error) {
@@ -46,7 +47,7 @@ func AuthFlowWithConfig(cfg iconfig, IO *iostreams.IOStreams, hostname, notice s
 		return "", err
 	}
 
-	return token, cfg.Write()
+	return token, cfg.WriteHosts()
 }
 
 func authFlow(oauthHost string, IO *iostreams.IOStreams, notice string, additionalScopes []string, isInteractive bool) (string, string, error) {

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -269,6 +269,28 @@ func Test_configFile_Write_toDisk(t *testing.T) {
 	}
 }
 
+func Test_configFile_WriteHosts_toDisk(t *testing.T) {
+	configDir := filepath.Join(t.TempDir(), ".config", "gh")
+	_ = os.MkdirAll(configDir, 0755)
+	err := ioutil.WriteFile(filepath.Join(configDir, "config.yml"), nil, 0444) // read-only
+	assert.NoError(t, err)
+	os.Setenv(GH_CONFIG_DIR, configDir)
+	defer os.Unsetenv(GH_CONFIG_DIR)
+
+	cfg := NewFromString(`hosts:\n github.com:\n  user: monalisa`)
+	err = cfg.WriteHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedConfig := "" // TODO why is this empty?
+	if configBytes, err := ioutil.ReadFile(filepath.Join(configDir, "hosts.yml")); err != nil {
+		t.Error(err)
+	} else if string(configBytes) != expectedConfig {
+		t.Errorf("expected hosts.yml %q, got %q", expectedConfig, string(configBytes))
+	}
+}
+
 func Test_autoMigrateConfigDir_noMigration_notExist(t *testing.T) {
 	homeDir := t.TempDir()
 	migrateDir := t.TempDir()

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -21,6 +21,7 @@ type Config interface {
 	Aliases() (*AliasConfig, error)
 	CheckWriteable(string, string) error
 	Write() error
+	WriteHosts() error
 }
 
 type ConfigOption struct {

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -67,6 +67,10 @@ func (c ConfigStub) Write() error {
 	return nil
 }
 
+func (c ConfigStub) WriteHosts() error {
+	return nil
+}
+
 func (c ConfigStub) DefaultHost() (string, error) {
 	return "", nil
 }

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -161,7 +161,7 @@ func loginRun(opts *LoginOptions) error {
 			return fmt.Errorf("error validating token: %w", err)
 		}
 
-		return cfg.Write()
+		return cfg.WriteHosts()
 	}
 
 	existingToken, _ := cfg.Get(hostname, "oauth_token")

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -151,7 +151,7 @@ func logoutRun(opts *LogoutOptions) error {
 	}
 
 	cfg.UnsetHost(hostname)
-	err = cfg.Write()
+	err = cfg.WriteHosts()
 	if err != nil {
 		return fmt.Errorf("failed to write config, authentication configuration not updated: %w", err)
 	}

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -18,6 +18,7 @@ type iconfig interface {
 	Get(string, string) (string, error)
 	Set(string, string, string) error
 	Write() error
+	WriteHosts() error
 }
 
 type LoginOptions struct {
@@ -173,7 +174,7 @@ func Login(opts *LoginOptions) error {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Configured git protocol\n", cs.SuccessIcon())
 	}
 
-	err := cfg.Write()
+	err := cfg.WriteHosts()
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/auth/shared/login_flow_test.go
+++ b/pkg/cmd/auth/shared/login_flow_test.go
@@ -30,6 +30,10 @@ func (c tinyConfig) Write() error {
 	return nil
 }
 
+func (c tinyConfig) WriteHosts() error {
+	return nil
+}
+
 func TestLogin_ssh(t *testing.T) {
 	dir := t.TempDir()
 	io, _, stdout, stderr := iostreams.Test()


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/4955

Allows writing only the `hosts.yml` config when there were no changes to the main config. This is useful to allow users to use `gh auth login` in scenarios where `config.yml` is read-only (e.g. managed with Nix/home-manager).

An alternative would be to check that the main config we're about to write is the same as what's in the file, but this seems messier to me.

I've confirmed that this works locally, but for some reason I could not make the test write the expected config, it writes an empty file.
