### PR TITLE
[codespaces]: add hidden select command

### DIFF
--- a/pkg/cmd/codespace/.gitignore
+++ b/pkg/cmd/codespace/.gitignore
@@ -1,1 +1,0 @@
-codespace-selection-test.log

--- a/pkg/cmd/codespace/.gitignore
+++ b/pkg/cmd/codespace/.gitignore
@@ -1,0 +1,1 @@
+codespace-selection-test.log

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -20,6 +20,7 @@ func NewRootCmd(app *App) *cobra.Command {
 	root.AddCommand(newSSHCmd(app))
 	root.AddCommand(newCpCmd(app))
 	root.AddCommand(newStopCmd(app))
+	root.AddCommand(newSelectCmd(app))
 
 	return root
 }

--- a/pkg/cmd/codespace/select.go
+++ b/pkg/cmd/codespace/select.go
@@ -47,7 +47,7 @@ func newSelectCmd(app *App) *cobra.Command {
 // ```shell
 // 		gh codespace select --file /tmp/selected_codespace.txt
 // ```
-func (a *App) Select(ctx context.Context, name string, opts selectOptions) error {
+func (a *App) Select(ctx context.Context, name string, opts selectOptions) (err error) {
 	codespace, err := getOrChooseCodespace(ctx, a.apiClient, name)
 	if err != nil {
 		return err
@@ -56,13 +56,17 @@ func (a *App) Select(ctx context.Context, name string, opts selectOptions) error
 	if opts.filePath != "" {
 		f, err := os.Create(opts.filePath)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create output file: %w", err)
 		}
 
 		f.WriteString(codespace.Name);
+		
+		defer safeClose(f, &err)
+
 		return nil
 	}
 
-	a.io.Out.Write([]byte(fmt.Sprintf("%s\n", codespace.Name)));
+	fmt.Fprintln(a.io.Out, codespace.Name)
+
 	return nil
 }

--- a/pkg/cmd/codespace/select.go
+++ b/pkg/cmd/codespace/select.go
@@ -1,0 +1,33 @@
+package codespace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newSelectCmd(app *App) *cobra.Command {
+	codeCmd := &cobra.Command{
+		Use:   "select",
+		Short: "Select a codespace",
+		Hidden: true,
+		Args:  noArgsConstraint,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return app.Select(cmd.Context(), "")
+		},
+	}
+
+	return codeCmd
+}
+
+func (a *App) Select(ctx context.Context, name string) error {
+	codespace, err := getOrChooseCodespace(ctx, a.apiClient, name)
+	if err != nil {
+		return err
+	}
+
+	a.io.Out.Write([]byte(fmt.Sprintf("%s\n", codespace.Name)));
+
+	return nil
+}

--- a/pkg/cmd/codespace/select.go
+++ b/pkg/cmd/codespace/select.go
@@ -17,7 +17,7 @@ func newSelectCmd(app *App) *cobra.Command {
 
 	selectCmd := &cobra.Command{
 		Use:   "select",
-		Short: "Select a codespace",
+		Short: "Select a Codespace",
 		Hidden: true,
 		Args:  noArgsConstraint,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/codespace/select.go
+++ b/pkg/cmd/codespace/select.go
@@ -16,10 +16,10 @@ func newSelectCmd(app *App) *cobra.Command {
 	opts := selectOptions{}
 
 	selectCmd := &cobra.Command{
-		Use:   "select",
-		Short: "Select a Codespace",
+		Use:    "select",
+		Short:  "Select a Codespace",
 		Hidden: true,
-		Args:  noArgsConstraint,
+		Args:   noArgsConstraint,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return app.Select(cmd.Context(), "", opts)
 		},
@@ -33,7 +33,7 @@ func newSelectCmd(app *App) *cobra.Command {
 // dialog by external GH CLI extensions. By default output selected codespace name
 // into `stdout`. Pass `--file`(`-f`) flag along with a file path to output selected
 // codespace name into a file instead.
-// 
+//
 // ## Examples
 //
 // With `stdout` output:
@@ -61,11 +61,11 @@ func (a *App) Select(ctx context.Context, name string, opts selectOptions) (err 
 
 		defer safeClose(f, &err)
 
-		_, err = f.WriteString(codespace.Name);
+		_, err = f.WriteString(codespace.Name)
 		if err != nil {
 			return fmt.Errorf("failed to write codespace name to output file: %w", err)
 		}
-		
+
 		return nil
 	}
 

--- a/pkg/cmd/codespace/select.go
+++ b/pkg/cmd/codespace/select.go
@@ -29,10 +29,10 @@ func newSelectCmd(app *App) *cobra.Command {
 	return selectCmd
 }
 
-// Hidden codespace `select` command allows to reuse the common codespace selection
+// Hidden codespace `select` command allows to reuse existing codespace selection
 // dialog by external GH CLI extensions. By default output selected codespace name
 // into `stdout`. Pass `--file`(`-f`) flag along with a file path to output selected
-// codespace into a file instead.
+// codespace name into a file instead.
 // 
 // ## Examples
 //
@@ -42,7 +42,7 @@ func newSelectCmd(app *App) *cobra.Command {
 // 		gh codespace select
 // ```
 //
-// With `into-a-file`` output:
+// With `into-a-file` output:
 //
 // ```shell
 // 		gh codespace select --file /tmp/selected_codespace.txt

--- a/pkg/cmd/codespace/select.go
+++ b/pkg/cmd/codespace/select.go
@@ -59,10 +59,13 @@ func (a *App) Select(ctx context.Context, name string, opts selectOptions) (err 
 			return fmt.Errorf("failed to create output file: %w", err)
 		}
 
-		f.WriteString(codespace.Name);
-		
 		defer safeClose(f, &err)
 
+		_, err = f.WriteString(codespace.Name);
+		if err != nil {
+			return fmt.Errorf("failed to write codespace name to output file: %w", err)
+		}
+		
 		return nil
 	}
 

--- a/pkg/cmd/codespace/select_test.go
+++ b/pkg/cmd/codespace/select_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const CODESPACE_NAME = "monalisa-cli-cli-abcdef"
-const OUTPUT_FILE_PATH = "../../../bin/codespace-selection-test.log"
+const OUTPUT_FILE_PATH = "codespace-selection-test.log"
 
 func TestApp_Select(t *testing.T) {
 	tests := []struct {
@@ -68,7 +68,7 @@ func TestApp_Select(t *testing.T) {
 
 				dat, err := os.ReadFile(tt.opts.filePath)
 				if err != nil {
-					panic(err)
+					t.Fatal(err)
 				}
 
 				if string(dat) != tt.wantFileContents {
@@ -89,7 +89,7 @@ func testSelectApiMock() *apiClientMock {
 				return testingCodespace, nil
 			}
 
-			return nil, errors.New("Cannot find codespace.")
+			return nil, errors.New("cannot find codespace")
 		},
 	}
 }

--- a/pkg/cmd/codespace/select_test.go
+++ b/pkg/cmd/codespace/select_test.go
@@ -1,0 +1,69 @@
+package codespace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+const CODESPACE_NAME = "monalisa-cli-cli-abcdef"
+
+func TestApp_Select(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		wantErr bool
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name: "Select a codespace",
+			arg: CODESPACE_NAME,
+			wantErr: false,
+			wantStdout: fmt.Sprintf("%s\n", CODESPACE_NAME),
+		},
+		{
+			name: "Select a codespace error",
+			arg: "non-existent-codespace-name",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, stdout, stderr := iostreams.Test()
+			io.SetStdinTTY(true)
+			io.SetStdoutTTY(true)
+			a := NewApp(io, nil, testSelectApiMock(), nil)
+
+			if err := a.Select(context.Background(), tt.arg); (err != nil) != tt.wantErr {
+				t.Errorf("App.Select() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if out := stdout.String(); out != tt.wantStdout {
+				t.Errorf("stdout = %q, want %q", out, tt.wantStdout)
+			}
+			if out := sortLines(stderr.String()); out != tt.wantStderr {
+				t.Errorf("stderr = %q, want %q", out, tt.wantStderr)
+			}
+		})
+	}
+}
+
+func testSelectApiMock() *apiClientMock {
+	testingCodespace := &api.Codespace{
+		Name: CODESPACE_NAME,
+	}
+	return &apiClientMock{
+		GetCodespaceFunc: func(_ context.Context, name string, includeConnection bool) (*api.Codespace, error) {
+			if name == CODESPACE_NAME {
+				return testingCodespace, nil
+			}
+
+			return nil, errors.New("Cannot find codespace.")
+		},
+	}
+}

--- a/pkg/cmd/codespace/select_test.go
+++ b/pkg/cmd/codespace/select_test.go
@@ -3,11 +3,11 @@ package codespace
 import (
 	"context"
 	"errors"
-	"os"
 	"fmt"
-	"testing"
 	"io/ioutil"
-	
+	"os"
+	"testing"
+
 	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/pkg/iostreams"
 )
@@ -16,31 +16,31 @@ const CODESPACE_NAME = "monalisa-cli-cli-abcdef"
 
 func TestApp_Select(t *testing.T) {
 	tests := []struct {
-		name    string
-		arg     string
-		wantErr bool
-		outputToFile bool
-		wantStdout string
-		wantStderr string
+		name             string
+		arg              string
+		wantErr          bool
+		outputToFile     bool
+		wantStdout       string
+		wantStderr       string
 		wantFileContents string
 	}{
 		{
-			name: "Select a codespace",
-			arg: CODESPACE_NAME,
-			wantErr: false,
+			name:       "Select a codespace",
+			arg:        CODESPACE_NAME,
+			wantErr:    false,
 			wantStdout: fmt.Sprintf("%s\n", CODESPACE_NAME),
 		},
 		{
-			name: "Select a codespace error",
-			arg: "non-existent-codespace-name",
+			name:    "Select a codespace error",
+			arg:     "non-existent-codespace-name",
 			wantErr: true,
 		},
 		{
-			name: "Select a codespace",
-			arg: CODESPACE_NAME,
-			wantErr: false,
+			name:             "Select a codespace",
+			arg:              CODESPACE_NAME,
+			wantErr:          false,
 			wantFileContents: CODESPACE_NAME,
-			outputToFile: true,
+			outputToFile:     true,
 		},
 	}
 	for _, tt := range tests {
@@ -59,7 +59,7 @@ func TestApp_Select(t *testing.T) {
 
 				defer os.Remove(file.Name())
 
-				opts = selectOptions { filePath: file.Name() }
+				opts = selectOptions{filePath: file.Name()}
 			}
 
 			if err := a.Select(context.Background(), tt.arg, opts); (err != nil) != tt.wantErr {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1478800/161322869-d0f3e014-7e94-4ff7-b1c8-d8b3eb6f4b11.png)

Adds hidden `codespace select` command so external GH CLI extensions can reuse existing codespace selection dialog. By default outputs selected codespace to `stdout`. Pass `--file`(`-f`) flag along with a file path to output selected codespace name to a file instead.

## Use cases

Currently used by [gh net](https://github.com/legomushroom/gh-net) (docs and naming still in progress) extension that implements network bridging between a codespace and developers machine:

1. User runs `gh net start` command.
2. The extension invokes the select command in background as a child process: `gh codespace select --file /tmp/selected-codespace`.
3. If user selects a codespace, the extension grabs its name from file and SSH-es into the codespace to create data stream for network forwarding: `gh codespace -c ${NAME} ssh ${COMMAND}`


https://user-images.githubusercontent.com/1478800/161329407-a2ee3947-38a6-4543-ab7c-955df7657a91.mp4

## Examples

With `stdout` output:

```shell
    gh codespace select
```

With `into-a-file` output:

```shell
    gh codespace select --file /tmp/selected_codespace.txt
```
