### PR TITLE
Remove idle timeout flag from gh cs edit

### DIFF
--- a/pkg/cmd/codespace/edit.go
+++ b/pkg/cmd/codespace/edit.go
@@ -3,7 +3,6 @@ package codespace
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/spf13/cobra"
@@ -12,7 +11,6 @@ import (
 type editOptions struct {
 	codespaceName string
 	displayName   string
-	idleTimeout   time.Duration
 	machine       string
 }
 
@@ -30,7 +28,6 @@ func newEditCmd(app *App) *cobra.Command {
 
 	editCmd.Flags().StringVarP(&opts.codespaceName, "codespace", "c", "", "Name of the codespace")
 	editCmd.Flags().StringVarP(&opts.displayName, "displayName", "d", "", "display name")
-	editCmd.Flags().DurationVar(&opts.idleTimeout, "idle-timeout", 0, "allowed inactivity before codespace is stopped, e.g. \"10m\", \"1h\"")
 	editCmd.Flags().StringVarP(&opts.machine, "machine", "m", "", "hardware specifications for the VM")
 
 	return editCmd
@@ -41,19 +38,16 @@ func (a *App) Edit(ctx context.Context, opts editOptions) error {
 	userInputs := struct {
 		CodespaceName string
 		DisplayName   string
-		IdleTimeout   time.Duration
 		SKU           string
 	}{
 		CodespaceName: opts.codespaceName,
 		DisplayName:   opts.displayName,
-		IdleTimeout:   opts.idleTimeout,
 		SKU:           opts.machine,
 	}
 	a.StartProgressIndicatorWithLabel("Editing codespace")
 	_, err := a.apiClient.EditCodespace(ctx, userInputs.CodespaceName, &api.EditCodespaceParams{
-		DisplayName:        userInputs.DisplayName,
-		IdleTimeoutMinutes: int(userInputs.IdleTimeout.Minutes()),
-		Machine:            userInputs.SKU,
+		DisplayName: userInputs.DisplayName,
+		Machine:     userInputs.SKU,
 	})
 	a.StopProgressIndicator()
 	if err != nil {


### PR DESCRIPTION
This flag isn't actually implemented to work so we should remove it 😄  It was cut for scope during https://github.com/github/codespaces/issues/4048. 

Should we want to add it back in later and flesh out the flow we would also need to consider [org policies](https://github.com/github/codespaces/issues/6854).

Do the [docs](https://cli.github.com/manual/gh_codespace_edit) auto update?