### PR TITLE
Update install_linux.md

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -32,6 +32,7 @@ sudo apt install gh
 Install from our package repository for immediate access to latest releases:
 
 ```bash
+sudo dnf install 'dnf-command(config-manager)'
 sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
 sudo dnf install gh
 ```


### PR DESCRIPTION
Added missing directive (bash) to ensure dnf has config-manager command correctly loaded prior to adding a repo.  Usually missing e.g., in a Docker container.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
