### PR TITLE
Allow non-interactive gist file replacement

### DIFF
--- a/pkg/cmd/gist/edit/edit.go
+++ b/pkg/cmd/gist/edit/edit.go
@@ -244,11 +244,9 @@ func editRun(opts *EditOptions) error {
 			filesToUpdate[filename] = text
 		}
 
-		if !opts.IO.CanPrompt() {
-			break
-		}
-
-		if len(candidates) == 1 {
+		if !opts.IO.CanPrompt() ||
+			len(candidates) == 1 ||
+			opts.EditFilename != "" {
 			break
 		}
 


### PR DESCRIPTION
This small change allows the overwriting of a gist file with a local replacement without any interactivity. The behavior change is that if the user specifies the gist file to edit using the `--filename` flag then skip showing the continuation prompt of Submit/Cancel/Edit. It follows the same syntax as adding a file: 
```bash
# adding new file
gh gist edit <gist-id> -a <gist-filename> <local-filename>

# overwriting file
gh gist edit <gist-id> -f <gist-filename> <local-filename>
```

closes https://github.com/cli/cli/issues/5198
supersedes https://github.com/cli/cli/pull/5397