### PR TITLE
Change issue close color from red to purple

### DIFF
--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -24,7 +24,7 @@ func PrintIssues(io *iostreams.IOStreams, prefix string, totalCount int, issues 
 		issueNum = prefix + issueNum
 		now := time.Now()
 		ago := now.Sub(issue.UpdatedAt)
-		table.AddField(issueNum, nil, cs.ColorFromString(prShared.ColorForState(issue.State)))
+		table.AddField(issueNum, nil, cs.ColorFromString(prShared.ColorForIssueState(issue)))
 		if !table.IsTTY() {
 			table.AddField(issue.State, nil, nil)
 		}

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -195,7 +195,7 @@ func printHumanIssuePreview(opts *ViewOptions, issue *api.Issue) error {
 	fmt.Fprintf(out, "%s #%d\n", cs.Bold(issue.Title), issue.Number)
 	fmt.Fprintf(out,
 		"%s • %s opened %s • %s\n",
-		issueStateTitleWithColor(cs, issue.State),
+		issueStateTitleWithColor(cs, issue),
 		issue.Author.Login,
 		utils.FuzzyAgo(ago),
 		utils.Pluralize(issue.Comments.TotalCount, "comment"),
@@ -254,9 +254,9 @@ func printHumanIssuePreview(opts *ViewOptions, issue *api.Issue) error {
 	return nil
 }
 
-func issueStateTitleWithColor(cs *iostreams.ColorScheme, state string) string {
-	colorFunc := cs.ColorFromString(prShared.ColorForState(state))
-	return colorFunc(strings.Title(strings.ToLower(state)))
+func issueStateTitleWithColor(cs *iostreams.ColorScheme, issue *api.Issue) string {
+	colorFunc := cs.ColorFromString(prShared.ColorForIssueState(*issue))
+	return colorFunc(strings.Title(strings.ToLower(issue.State)))
 }
 
 func issueAssigneeList(issue api.Issue) string {

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -199,7 +199,7 @@ func listRun(opts *ListOptions) error {
 		if table.IsTTY() {
 			prNum = "#" + prNum
 		}
-		table.AddField(prNum, nil, cs.ColorFromString(shared.ColorForPR(pr)))
+		table.AddField(prNum, nil, cs.ColorFromString(shared.ColorForPRState(pr)))
 		table.AddField(text.ReplaceExcessiveWhitespace(pr.Title), nil, nil)
 		table.AddField(pr.HeadLabel(), nil, cs.Cyan)
 		if !table.IsTTY() {

--- a/pkg/cmd/pr/shared/display.go
+++ b/pkg/cmd/pr/shared/display.go
@@ -10,7 +10,7 @@ import (
 )
 
 func StateTitleWithColor(cs *iostreams.ColorScheme, pr api.PullRequest) string {
-	prStateColorFunc := cs.ColorFromString(ColorForPR(pr))
+	prStateColorFunc := cs.ColorFromString(ColorForPRState(pr))
 
 	if pr.State == "OPEN" && pr.IsDraft {
 		return prStateColorFunc(strings.Title(strings.ToLower("Draft")))
@@ -18,21 +18,27 @@ func StateTitleWithColor(cs *iostreams.ColorScheme, pr api.PullRequest) string {
 	return prStateColorFunc(strings.Title(strings.ToLower(pr.State)))
 }
 
-func ColorForPR(pr api.PullRequest) string {
-	if pr.State == "OPEN" && pr.IsDraft {
-		return "gray"
-	}
-	return ColorForState(pr.State)
-}
-
-// ColorForState returns a color constant for a PR/Issue state
-func ColorForState(state string) string {
-	switch state {
+func ColorForPRState(pr api.PullRequest) string {
+	switch pr.State {
 	case "OPEN":
+		if pr.IsDraft {
+			return "gray"
+		}
 		return "green"
 	case "CLOSED":
 		return "red"
 	case "MERGED":
+		return "magenta"
+	default:
+		return ""
+	}
+}
+
+func ColorForIssueState(issue api.Issue) string {
+	switch issue.State {
+	case "OPEN":
+		return "green"
+	case "CLOSED":
 		return "magenta"
 	default:
 		return ""

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -216,7 +216,7 @@ func printPrs(io *iostreams.IOStreams, totalCount int, prs ...api.PullRequest) {
 	for _, pr := range prs {
 		prNumber := fmt.Sprintf("#%d", pr.Number)
 
-		prStateColorFunc := cs.ColorFromString(shared.ColorForPR(pr))
+		prStateColorFunc := cs.ColorFromString(shared.ColorForPRState(pr))
 
 		fmt.Fprintf(w, "  %s  %s %s", prStateColorFunc(prNumber), text.Truncate(50, text.ReplaceExcessiveWhitespace(pr.Title)), cs.Cyan("["+pr.HeadLabel()+"]"))
 

--- a/pkg/cmd/search/shared/shared.go
+++ b/pkg/cmd/search/shared/shared.go
@@ -95,7 +95,11 @@ func displayIssueResults(io *iostreams.IOStreams, et EntityType, results search.
 		if tp.IsTTY() {
 			issueNum = "#" + issueNum
 		}
-		tp.AddField(issueNum, nil, cs.ColorFromString(colorForIssueState(issue.State)))
+		if issue.IsPullRequest() {
+			tp.AddField(issueNum, nil, cs.ColorFromString(colorForPRState(issue.State)))
+		} else {
+			tp.AddField(issueNum, nil, cs.ColorFromString(colorForIssueState(issue.State)))
+		}
 		if !tp.IsTTY() {
 			tp.AddField(issue.State, nil, nil)
 		}
@@ -152,6 +156,17 @@ func listIssueLabels(issue *search.Issue, cs *iostreams.ColorScheme, colorize bo
 }
 
 func colorForIssueState(state string) string {
+	switch state {
+	case "open":
+		return "green"
+	case "closed":
+		return "magenta"
+	default:
+		return ""
+	}
+}
+
+func colorForPRState(state string) string {
 	switch state {
 	case "open":
 		return "green"


### PR DESCRIPTION
This PR changes the issue close color from red to purple, the new purple color has been standard across GitHub since late last year so this just brings the CLI inline with the other product offerings. 

Closes https://github.com/github/cli/issues/114