### PR TITLE
Add ability to comment on close/reopen of issues/pull requests

### DIFF
--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
+	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	graphql "github.com/cli/shurcooL-graphql"
@@ -24,6 +25,7 @@ type CloseOptions struct {
 	BaseRepo   func() (ghrepo.Interface, error)
 
 	SelectorArg string
+	Comment     string
 }
 
 func NewCmdClose(f *cmdutil.Factory, runF func(*CloseOptions) error) *cobra.Command {
@@ -52,6 +54,8 @@ func NewCmdClose(f *cmdutil.Factory, runF func(*CloseOptions) error) *cobra.Comm
 		},
 	}
 
+	cmd.Flags().StringVarP(&opts.Comment, "comment", "c", "", "Leave a closing comment")
+
 	return cmd
 }
 
@@ -71,6 +75,22 @@ func closeRun(opts *CloseOptions) error {
 	if issue.State == "CLOSED" {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Issue #%d (%s) is already closed\n", cs.Yellow("!"), issue.Number, issue.Title)
 		return nil
+	}
+
+	if opts.Comment != "" {
+		commentOpts := &prShared.CommentableOptions{
+			Body:       opts.Comment,
+			HttpClient: opts.HttpClient,
+			InputType:  prShared.InputTypeInline,
+			RetrieveCommentable: func() (prShared.Commentable, ghrepo.Interface, error) {
+				return issue, baseRepo, nil
+			},
+			Quiet: true,
+		}
+		err := prShared.CommentableRun(commentOpts)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = apiClose(httpClient, baseRepo, issue)

--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -82,10 +82,10 @@ func closeRun(opts *CloseOptions) error {
 			Body:       opts.Comment,
 			HttpClient: opts.HttpClient,
 			InputType:  prShared.InputTypeInline,
+			Quiet:      true,
 			RetrieveCommentable: func() (prShared.Commentable, ghrepo.Interface, error) {
 				return issue, baseRepo, nil
 			},
-			Quiet: true,
 		}
 		err := prShared.CommentableRun(commentOpts)
 		if err != nil {

--- a/pkg/cmd/issue/reopen/reopen.go
+++ b/pkg/cmd/issue/reopen/reopen.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
+	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	graphql "github.com/cli/shurcooL-graphql"
@@ -24,6 +25,7 @@ type ReopenOptions struct {
 	BaseRepo   func() (ghrepo.Interface, error)
 
 	SelectorArg string
+	Comment     string
 }
 
 func NewCmdReopen(f *cmdutil.Factory, runF func(*ReopenOptions) error) *cobra.Command {
@@ -52,6 +54,8 @@ func NewCmdReopen(f *cmdutil.Factory, runF func(*ReopenOptions) error) *cobra.Co
 		},
 	}
 
+	cmd.Flags().StringVarP(&opts.Comment, "comment", "c", "", "Add a reopening comment")
+
 	return cmd
 }
 
@@ -71,6 +75,22 @@ func reopenRun(opts *ReopenOptions) error {
 	if issue.State == "OPEN" {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Issue #%d (%s) is already open\n", cs.Yellow("!"), issue.Number, issue.Title)
 		return nil
+	}
+
+	if opts.Comment != "" {
+		commentOpts := &prShared.CommentableOptions{
+			Body:       opts.Comment,
+			HttpClient: opts.HttpClient,
+			InputType:  prShared.InputTypeInline,
+			RetrieveCommentable: func() (prShared.Commentable, ghrepo.Interface, error) {
+				return issue, baseRepo, nil
+			},
+			Quiet: true,
+		}
+		err := prShared.CommentableRun(commentOpts)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = apiReopen(httpClient, baseRepo, issue)

--- a/pkg/cmd/issue/reopen/reopen.go
+++ b/pkg/cmd/issue/reopen/reopen.go
@@ -82,10 +82,10 @@ func reopenRun(opts *ReopenOptions) error {
 			Body:       opts.Comment,
 			HttpClient: opts.HttpClient,
 			InputType:  prShared.InputTypeInline,
+			Quiet:      true,
 			RetrieveCommentable: func() (prShared.Commentable, ghrepo.Interface, error) {
 				return issue, baseRepo, nil
 			},
-			Quiet: true,
 		}
 		err := prShared.CommentableRun(commentOpts)
 		if err != nil {

--- a/pkg/cmd/issue/reopen/reopen_test.go
+++ b/pkg/cmd/issue/reopen/reopen_test.go
@@ -144,3 +144,46 @@ func TestIssueReopen_issuesDisabled(t *testing.T) {
 		t.Fatalf("got error: %v", err)
 	}
 }
+
+func TestIssueReopen_withComment(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.GraphQL(`query IssueByNumber\b`),
+		httpmock.StringResponse(`
+			{ "data": { "repository": {
+				"hasIssuesEnabled": true,
+				"issue": { "id": "THE-ID", "number": 2, "state": "CLOSED", "title": "The title of the issue"}
+			} } }`),
+	)
+	http.Register(
+		httpmock.GraphQL(`mutation CommentCreate\b`),
+		httpmock.GraphQLMutation(`
+		{ "data": { "addComment": { "commentEdge": { "node": {
+			"url": "https://github.com/OWNER/REPO/issues/123#issuecomment-456"
+		} } } } }`,
+			func(inputs map[string]interface{}) {
+				assert.Equal(t, "THE-ID", inputs["subjectId"])
+				assert.Equal(t, "reopening comment", inputs["body"])
+			}),
+	)
+	http.Register(
+		httpmock.GraphQL(`mutation IssueReopen\b`),
+		httpmock.GraphQLMutation(`{"id": "THE-ID"}`,
+			func(inputs map[string]interface{}) {
+				assert.Equal(t, inputs["issueId"], "THE-ID")
+			}),
+	)
+
+	output, err := runCommand(http, true, "2 --comment 'reopening comment'")
+	if err != nil {
+		t.Fatalf("error running command `issue reopen`: %v", err)
+	}
+
+	r := regexp.MustCompile(`Reopened issue #2 \(The title of the issue\)`)
+
+	if !r.MatchString(output.Stderr()) {
+		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
+	}
+}

--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -89,10 +89,10 @@ func closeRun(opts *CloseOptions) error {
 			Body:       opts.Comment,
 			HttpClient: opts.HttpClient,
 			InputType:  shared.InputTypeInline,
+			Quiet:      true,
 			RetrieveCommentable: func() (shared.Commentable, ghrepo.Interface, error) {
 				return pr, baseRepo, nil
 			},
-			Quiet: true,
 		}
 		err := shared.CommentableRun(commentOpts)
 		if err != nil {

--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/git"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -20,6 +21,7 @@ type CloseOptions struct {
 	Finder shared.PRFinder
 
 	SelectorArg       string
+	Comment           string
 	DeleteBranch      bool
 	DeleteLocalBranch bool
 }
@@ -50,6 +52,8 @@ func NewCmdClose(f *cmdutil.Factory, runF func(*CloseOptions) error) *cobra.Comm
 			return closeRun(opts)
 		},
 	}
+
+	cmd.Flags().StringVarP(&opts.Comment, "comment", "c", "", "Leave a closing comment")
 	cmd.Flags().BoolVarP(&opts.DeleteBranch, "delete-branch", "d", false, "Delete the local and remote branch after close")
 
 	return cmd
@@ -78,6 +82,22 @@ func closeRun(opts *CloseOptions) error {
 	httpClient, err := opts.HttpClient()
 	if err != nil {
 		return err
+	}
+
+	if opts.Comment != "" {
+		commentOpts := &shared.CommentableOptions{
+			Body:       opts.Comment,
+			HttpClient: opts.HttpClient,
+			InputType:  shared.InputTypeInline,
+			RetrieveCommentable: func() (shared.Commentable, ghrepo.Interface, error) {
+				return pr, baseRepo, nil
+			},
+			Quiet: true,
+		}
+		err := shared.CommentableRun(commentOpts)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = api.PullRequestClose(httpClient, baseRepo, pr.ID)

--- a/pkg/cmd/pr/reopen/reopen.go
+++ b/pkg/cmd/pr/reopen/reopen.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -18,6 +19,7 @@ type ReopenOptions struct {
 	Finder shared.PRFinder
 
 	SelectorArg string
+	Comment     string
 }
 
 func NewCmdReopen(f *cmdutil.Factory, runF func(*ReopenOptions) error) *cobra.Command {
@@ -43,6 +45,8 @@ func NewCmdReopen(f *cmdutil.Factory, runF func(*ReopenOptions) error) *cobra.Co
 			return reopenRun(opts)
 		},
 	}
+
+	cmd.Flags().StringVarP(&opts.Comment, "comment", "c", "", "Add a reopening comment")
 
 	return cmd
 }
@@ -72,6 +76,22 @@ func reopenRun(opts *ReopenOptions) error {
 	httpClient, err := opts.HttpClient()
 	if err != nil {
 		return err
+	}
+
+	if opts.Comment != "" {
+		commentOpts := &shared.CommentableOptions{
+			Body:       opts.Comment,
+			HttpClient: opts.HttpClient,
+			InputType:  shared.InputTypeInline,
+			RetrieveCommentable: func() (shared.Commentable, ghrepo.Interface, error) {
+				return pr, baseRepo, nil
+			},
+			Quiet: true,
+		}
+		err := shared.CommentableRun(commentOpts)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = api.PullRequestReopen(httpClient, baseRepo, pr.ID)

--- a/pkg/cmd/pr/reopen/reopen.go
+++ b/pkg/cmd/pr/reopen/reopen.go
@@ -83,10 +83,10 @@ func reopenRun(opts *ReopenOptions) error {
 			Body:       opts.Comment,
 			HttpClient: opts.HttpClient,
 			InputType:  shared.InputTypeInline,
+			Quiet:      true,
 			RetrieveCommentable: func() (shared.Commentable, ghrepo.Interface, error) {
 				return pr, baseRepo, nil
 			},
-			Quiet: true,
 		}
 		err := shared.CommentableRun(commentOpts)
 		if err != nil {

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -42,6 +42,7 @@ type CommentableOptions struct {
 	Interactive           bool
 	InputType             InputType
 	Body                  string
+	Quiet                 bool
 }
 
 func CommentablePreRun(cmd *cobra.Command, opts *CommentableOptions) error {
@@ -84,7 +85,7 @@ func CommentableRun(opts *CommentableOptions) error {
 	switch opts.InputType {
 	case InputTypeWeb:
 		openURL := commentable.Link() + "#issuecomment-new"
-		if opts.IO.IsStdoutTTY() {
+		if opts.IO.IsStdoutTTY() && !opts.Quiet {
 			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", utils.DisplayURL(openURL))
 		}
 		return opts.OpenInBrowser(openURL)
@@ -121,7 +122,9 @@ func CommentableRun(opts *CommentableOptions) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(opts.IO.Out, url)
+	if !opts.Quiet {
+		fmt.Fprintln(opts.IO.Out, url)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This PR adds the ability to leave a comment when closing/reopening issues and pull requests. We already have `issue comment` and `pr comment` so these new flags are meant to be shortcuts for the `issue comment && issue close` workflows. They purposefully do not support anything besides inline text input as I didn't want to add unnecessary complexity to these simple commands. For more advanced text input the `issue comment` and `pr comment` commands should still be used. 

Closes https://github.com/cli/cli/issues/1038