### PR TITLE
gh release download: add specific release ID parameter

### DIFF
--- a/pkg/cmd/release/download/download.go
+++ b/pkg/cmd/release/download/download.go
@@ -157,9 +157,16 @@ func downloadRun(opts *DownloadOptions) error {
 
 	var release *shared.Release
 	if opts.TagName == "" {
-		release, err = shared.FetchLatestRelease(httpClient, baseRepo)
-		if err != nil {
-			return err
+		if opts.ReleaseId == "" {
+			release, err = shared.FetchLatestRelease(httpClient, baseRepo)
+			if err != nil {
+				return err
+			}
+		} else {
+			release, err = shared.FetchReleaseById(httpClient, baseRepo, opts.ReleaseId)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		release, err = shared.FetchRelease(httpClient, baseRepo, opts.TagName)

--- a/pkg/cmd/release/download/download.go
+++ b/pkg/cmd/release/download/download.go
@@ -72,7 +72,7 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 			opts.BaseRepo = f.BaseRepo
 
 			if len(args) == 0 {
-				if len(opts.FilePatterns) == 0 && opts.ArchiveType == "" {
+				if len(opts.ReleaseId) == 0 && len(opts.FilePatterns) == 0 && opts.ArchiveType == "" {
 					return cmdutil.FlagErrorf("`--pattern` or `--archive` is required when downloading the latest release")
 				}
 			} else {

--- a/pkg/cmd/release/download/download_test.go
+++ b/pkg/cmd/release/download/download_test.go
@@ -110,6 +110,12 @@ func Test_NewCmdDownload(t *testing.T) {
 			isTTY:   true,
 			wantErr: "the value for `--archive` must be one of \"zip\" or \"tar.gz\"",
 		},
+		{
+			name:    "simultaneous tag and release-id arguments",
+			args:    "v1.2.3 --release-id 1234",
+			isTTY:   true,
+			wantErr: "specify only one of '<tag>' or '--release-id'",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### What

Download assets from a specific release ID

### Why

This approach will allow to download any assets from draft releases too in addition to  formal releases.

### Use case

Given a draft release I'd like to download all the assets to run some validations before transitioning the release from draft to ready

https://stackoverflow.com/questions/60792587/how-do-i-download-a-file-from-a-github-draft is the reference I've found about doing something similar.


### Examples

```
Download all the artifacts for a specific release-id
$ gh release download --release-id 63259499
```

### Issues

Fixes https://github.com/cli/cli/issues/5443