### PR TITLE
`gh extensions list`: Don't error if no extensions installed

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -47,7 +47,8 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 			RunE: func(cmd *cobra.Command, args []string) error {
 				cmds := m.List()
 				if len(cmds) == 0 {
-					fmt.Fprintf(io.Out, "no extensions installed\n")
+					cs := io.ColorScheme()
+					fmt.Fprintf(io.ErrOut, "%s No installed extensions found\n", cs.WarningIcon())
 					return nil
 				}
 				cs := io.ColorScheme()

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -47,7 +47,8 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 			RunE: func(cmd *cobra.Command, args []string) error {
 				cmds := m.List()
 				if len(cmds) == 0 {
-					return errors.New("no extensions installed")
+					fmt.Fprintf(io.Out, "no extensions installed\n")
+					return nil
 				}
 				cs := io.ColorScheme()
 				t := utils.NewTablePrinter(io)
@@ -80,10 +81,10 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 				Short: "Install a gh extension from a repository",
 				Long: heredoc.Doc(`
 				Install a GitHub repository locally as a GitHub CLI extension.
-				
+
 				The repository argument can be specified in "owner/repo" format as well as a full URL.
 				The URL format is useful when the repository is not hosted on github.com.
-				
+
 				To install an extension in development from the current directory, use "." as the
 				value of the repository argument.
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
- Fixes #5363

This is a really simple change, simply to fix the nonzero exit code when calling `gh extensions list` if the list is empty. We print the same message, but just exit gracefully.
