### PR TITLE
add autocomplete descriptions for aliases and extensions

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -187,9 +187,9 @@ func mainRun() exitCode {
 		}
 		for _, ext := range cmdFactory.ExtensionManager.List() {
 			if strings.HasPrefix(ext.Name(), toComplete) {
+				var s string
 				if ext.IsLocal() {
-					s := fmt.Sprintf("%s\tLocal extension gh-%s", ext.Name(), ext.Name())
-					results = append(results, s)
+					s = fmt.Sprintf("%s\tLocal extension gh-%s", ext.Name(), ext.Name())
 				} else {
 					path := ext.URL()
 					if u, err := git.ParseURL(ext.URL()); err == nil {
@@ -197,9 +197,9 @@ func mainRun() exitCode {
 							path = ghrepo.FullName(r)
 						}
 					}
-					s := fmt.Sprintf("%s\tExtension %s", ext.Name(), path)
-					results = append(results, s)
+					s = fmt.Sprintf("%s\tExtension %s", ext.Name(), path)
 				}
+				results = append(results, s)
 			}
 		}
 		return results, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -179,7 +179,7 @@ func mainRun() exitCode {
 						s = fmt.Sprintf("%s\tShell alias", aliasName)
 					} else {
 						aliasValue = text.Truncate(80, aliasValue)
-						s = fmt.Sprintf("%s\tAlias for `%s`", aliasName, aliasValue)
+						s = fmt.Sprintf("%s\tAlias for %s", aliasName, aliasValue)
 					}
 					results = append(results, s)
 				}

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +14,7 @@ import (
 	surveyCore "github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/build"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/ghinstance"
@@ -26,6 +26,7 @@ import (
 	"github.com/cli/cli/v2/pkg/cmd/root"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/pkg/text"
 	"github.com/cli/cli/v2/utils"
 	"github.com/cli/safeexec"
 	"github.com/mattn/go-colorable"
@@ -173,7 +174,13 @@ func mainRun() exitCode {
 		if aliases, err := cfg.Aliases(); err == nil {
 			for aliasName, aliasValue := range aliases.All() {
 				if strings.HasPrefix(aliasName, toComplete) {
-					s := fmt.Sprintf("%s\tAlias for %q", aliasName, aliasValue)
+					var s string
+					if strings.HasPrefix(aliasValue, "!") {
+						s = fmt.Sprintf("%s\tShell alias", aliasName)
+					} else {
+						aliasValue = text.Truncate(80, aliasValue)
+						s = fmt.Sprintf("%s\tAlias for `%s`", aliasName, aliasValue)
+					}
 					results = append(results, s)
 				}
 			}
@@ -185,8 +192,10 @@ func mainRun() exitCode {
 					results = append(results, s)
 				} else {
 					path := ext.URL()
-					if u, err := url.Parse(ext.URL()); err == nil {
-						path = u.Path[1:]
+					if u, err := git.ParseURL(ext.URL()); err == nil {
+						if r, err := ghrepo.FromURL(u); err == nil {
+							path = ghrepo.FullName(r)
+						}
 					}
 					s := fmt.Sprintf("%s\tExtension %s", ext.Name(), path)
 					results = append(results, s)


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
- Fixes #4692

This is another tiny fix, but solves a headache I've been running into. Cobra [supports](https://github.com/spf13/cobra/blob/master/shell_completions.md#descriptions-for-completions) nice descriptions for shell completions, even if specified via a `ValidArgsFunction` -- simply append the description to the argument, separated by `\t`.

In this PR, I give aliases the description "Alias for CMD", and give extensions the description "Extension REPO/URL, version VERSION".

For example, my `zsh` autocompletion now contains the entries:
```text
...
clone        -- Alias for repo clone
co           -- Alias for pr checkout
...
repo-rename  -- Extension crguezl/gh-repo-rename, version 5a47360e8bfcf9047b
```

Obviously, we can tinker with/format these descriptions as needed -- I tried to match `git`'s alias autocompletion behavior for aliases and made this description up for extensions.

Additionally, once the descriptions are added, Cobra automatically sorts the commands into the full commands list!