### PR TITLE
Fix potentially negative column widths in tables

### DIFF
--- a/utils/table_printer.go
+++ b/utils/table_printer.go
@@ -196,16 +196,17 @@ func (t *ttyTablePrinter) calculateColumnWidths(delimSize int) []int {
 	firstFlexCol := -1
 	// truncate long columns to the remaining available width
 	if numFlexColumns := numCols - numFixedCols(); numFlexColumns > 0 {
-		perColumn := availWidth() / numFlexColumns
-		for col := 0; col < numCols; col++ {
-			if colWidths[col] == 0 {
-				if firstFlexCol == -1 {
-					firstFlexCol = col
-				}
-				if max := maxColWidths[col]; max < perColumn {
-					colWidths[col] = max
-				} else {
-					colWidths[col] = perColumn
+		if perColumn := availWidth() / numFlexColumns; perColumn > 0 {
+			for col := 0; col < numCols; col++ {
+				if colWidths[col] == 0 {
+					if firstFlexCol == -1 {
+						firstFlexCol = col
+					}
+					if max := maxColWidths[col]; max < perColumn {
+						colWidths[col] = max
+					} else {
+						colWidths[col] = perColumn
+					}
 				}
 			}
 		}

--- a/utils/table_printer.go
+++ b/utils/table_printer.go
@@ -196,17 +196,16 @@ func (t *ttyTablePrinter) calculateColumnWidths(delimSize int) []int {
 	firstFlexCol := -1
 	// truncate long columns to the remaining available width
 	if numFlexColumns := numCols - numFixedCols(); numFlexColumns > 0 {
-		if perColumn := availWidth() / numFlexColumns; perColumn > 0 {
-			for col := 0; col < numCols; col++ {
-				if colWidths[col] == 0 {
-					if firstFlexCol == -1 {
-						firstFlexCol = col
-					}
-					if max := maxColWidths[col]; max < perColumn {
-						colWidths[col] = max
-					} else {
-						colWidths[col] = perColumn
-					}
+		perColumn := availWidth() / numFlexColumns
+		for col := 0; col < numCols; col++ {
+			if colWidths[col] == 0 {
+				if firstFlexCol == -1 {
+					firstFlexCol = col
+				}
+				if max := maxColWidths[col]; max < perColumn {
+					colWidths[col] = max
+				} else if perColumn > 0 {
+					colWidths[col] = perColumn
 				}
 			}
 		}


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
- Fixes #4950

Another teensy-tiny fix for something that was bothering me! Tables such as `gh gpg-key list` were running into problems because long flex columns were getting potentially negative widths calculated in `table_printer.go`'s `calculateColumnWidths()` function.

There was simply a missing if statement to guard against `availWidth()` returning a negative number. This led to the truncation function provided in `gh gpg-key list`'s implementation to error out when processing an ending index of `-5` or some other negative number when the terminal width was too small.

To reproduce the issue in trunk, simply resize your terminal to be really narrow (say, 5 characters wide), and run `gh gpg-key list`. As per the linked issue, it should error out. Then, try again on this branch -- things should be working!