### PR TITLE
warn if PR is already merged

### DIFF
--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -72,7 +72,7 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 			Merge a pull request on GitHub.
 
 			Without an argument, the pull request that belongs to the current branch
-			is selected.			
+			is selected.
     	`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -303,7 +303,7 @@ func mergeRun(opts *MergeOptions) error {
 		if err != nil {
 			return fmt.Errorf("could not prompt: %w", err)
 		}
-	} else if crossRepoPR {
+	} else {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d was already merged\n", cs.WarningIcon(), pr.Number)
 	}
 


### PR DESCRIPTION
Fixes #5444

There is an existing [test](https://github.com/mntlty/cli/blob/bb9bf298353e62cc83a89d472ae4ca8b38c2ff28/pkg/cmd/pr/merge/merge_test.go#L886) for this condition 
but it is incorrectly testing (based on the test name `TestPrMerge_alreadyMerged_nonInteractive`) the `crossRepoPR` [case](https://github.com/mntlty/cli/blob/bb9bf298353e62cc83a89d472ae4ca8b38c2ff28/pkg/cmd/pr/merge/merge_test.go#L899) as the owner of the base repo is `OWNER` and the owner on the PR is `monalisa`.

I considered returning early [here](https://github.com/mntlty/cli/blob/e679bac799ed64f044820cc7889fb4f589636c52/pkg/cmd/pr/merge/merge.go#L210) with the following code

```go
if isPRAlreadyMerged && !opts.InteractiveMode {
	fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d was already merged\n", cs.WarningIcon(), pr.Number)
	return nil
}
```

but would have resulted in duplicate text with the cross repo check, which is pre-existing, and would not have checked local branch deletion. If that approach is preferable I can update this PR.

It seems to be correct to warn the user that the PR has been merged in all cases, not just when it is cross repo. If that is not the case I can modify the change in this PR to only cover the original issue:

```go
} else if crossRepoPR || !opts.InteractiveMode {
```