### PR TITLE
add ls alias to gh repo list

### DIFF
--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -49,9 +49,10 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	)
 
 	cmd := &cobra.Command{
-		Use:   "list [<owner>]",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "List repositories owned by user or organization",
+		Use:     "list [<owner>]",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "List repositories owned by user or organization",
+		Aliases: []string{"ls"},
 		RunE: func(c *cobra.Command, args []string) error {
 			if opts.Limit < 1 {
 				return cmdutil.FlagErrorf("invalid limit: %v", opts.Limit)


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
This is just a small thing I noticed while using the cli earlier today! Looks like #5214 didn't add the `ls` alias to `gh repo list`. Now you can simply `gh repo ls`!
