### PR TITLE
Fix displayed header for search prs command

### DIFF
--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -17,7 +17,7 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 	var appAuthor string
 	opts := &shared.IssuesOptions{
 		Browser: f.Browser,
-		Entity:  shared.Issues,
+		Entity:  shared.PullRequests,
 		IO:      f.IOStreams,
 		Query: search.Query{Kind: search.KindIssues,
 			Qualifiers: search.Qualifiers{Type: "pr"}},


### PR DESCRIPTION
Small change to fix `search prs` as it was displaying "issues" in the header instead of "pull requests".

cc https://github.com/cli/cli/issues/5482#issuecomment-1102984151
closes https://github.com/cli/cli/issues/5486