### PR TITLE
Replace ioutil with io and os

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -73,7 +72,7 @@ func CacheResponse(ttl time.Duration, dir string) ClientOption {
 func copyStream(r io.ReadCloser) (io.ReadCloser, io.ReadCloser) {
 	b := &bytes.Buffer{}
 	nr := io.TeeReader(r, b)
-	return ioutil.NopCloser(b), &readCloser{
+	return io.NopCloser(b), &readCloser{
 		Reader: nr,
 		Closer: r,
 	}

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"testing"
@@ -26,7 +25,7 @@ func Test_CacheResponse(t *testing.T) {
 			}
 			return &http.Response{
 				StatusCode: status,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+				Body:       io.NopCloser(bytes.NewBufferString(body)),
 			}, nil
 		},
 	}
@@ -44,7 +43,7 @@ func Test_CacheResponse(t *testing.T) {
 			return "", err
 		}
 		defer res.Body.Close()
-		resBody, err := ioutil.ReadAll(res.Body)
+		resBody, err := io.ReadAll(res.Body)
 		if err != nil {
 			err = fmt.Errorf("ReadAll: %w", err)
 		}

--- a/api/client.go
+++ b/api/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -343,7 +342,7 @@ func (c Client) RESTWithNext(hostname string, method string, p string, body io.R
 		return "", nil
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -379,7 +378,7 @@ func handleResponse(resp *http.Response, data interface{}) error {
 		return HandleHTTPError(resp)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -408,7 +407,7 @@ func HandleHTTPError(resp *http.Response) error {
 		return httpError
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		httpError.Message = err.Error()
 		return httpError

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -35,7 +35,7 @@ func TestGraphQL(t *testing.T) {
 	assert.Equal(t, "hubot", response.Viewer.Login)
 
 	req := http.Requests[0]
-	reqBody, _ := ioutil.ReadAll(req.Body)
+	reqBody, _ := io.ReadAll(req.Body)
 	assert.Equal(t, `{"query":"QUERY","variables":{"name":"Mona"}}`, string(reqBody))
 	assert.Equal(t, "token OTOKEN", req.Header.Get("Authorization"))
 }
@@ -116,7 +116,7 @@ func TestRESTError(t *testing.T) {
 		return &http.Response{
 			Request:    req,
 			StatusCode: 422,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(`{"message": "OH NO"}`)),
+			Body:       io.NopCloser(bytes.NewBufferString(`{"message": "OH NO"}`)),
 			Header: map[string][]string{
 				"Content-Type": {"application/json; charset=utf-8"},
 			},
@@ -146,7 +146,7 @@ func TestHandleHTTPError_GraphQL502(t *testing.T) {
 	resp := &http.Response{
 		Request:    req,
 		StatusCode: 502,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(`{ "data": null, "errors": [{ "message": "Something went wrong" }] }`)),
+		Body:       io.NopCloser(bytes.NewBufferString(`{ "data": null, "errors": [{ "message": "Something went wrong" }] }`)),
 		Header:     map[string][]string{"Content-Type": {"application/json"}},
 	}
 	err = HandleHTTPError(resp)
@@ -164,7 +164,7 @@ func TestHTTPError_ScopesSuggestion(t *testing.T) {
 		return &http.Response{
 			Request:    req,
 			StatusCode: s,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(`{}`)),
+			Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
 			Header: map[string][]string{
 				"Content-Type":            {"application/json"},
 				"X-Oauth-Scopes":          {haveScopes},

--- a/cmd/gen-docs/main.go
+++ b/cmd/gen-docs/main.go
@@ -40,9 +40,9 @@ func run(args []string) error {
 		return fmt.Errorf("error: --doc-path not set")
 	}
 
-	io, _, _, _ := iostreams.Test()
+	ios, _, _, _ := iostreams.Test()
 	rootCmd := root.NewCmdRoot(&cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		Browser:   &browser{},
 	}, "", "")
 	rootCmd.InitDefaultHelpCmd()

--- a/cmd/gen-docs/main_test.go
+++ b/cmd/gen-docs/main_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 )
@@ -14,7 +14,7 @@ func Test_run(t *testing.T) {
 		t.Fatalf("got error: %v", err)
 	}
 
-	manPage, err := ioutil.ReadFile(dir + "/gh-issue-create.1")
+	manPage, err := os.ReadFile(dir + "/gh-issue-create.1")
 	if err != nil {
 		t.Fatalf("error reading `gh-issue-create.1`: %v", err)
 	}
@@ -22,7 +22,7 @@ func Test_run(t *testing.T) {
 		t.Fatal("man page corrupted")
 	}
 
-	markdownPage, err := ioutil.ReadFile(dir + "/gh_issue_create.md")
+	markdownPage, err := os.ReadFile(dir + "/gh_issue_create.md")
 	if err != nil {
 		t.Fatalf("error reading `gh_issue_create.md`: %v", err)
 	}

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -33,7 +33,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -115,7 +114,7 @@ func (a *API) GetUser(ctx context.Context) (*User, error) {
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
@@ -153,7 +152,7 @@ func (a *API) GetRepository(ctx context.Context, nwo string) (*Repository, error
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
@@ -366,7 +365,7 @@ func (a *API) GetCodespace(ctx context.Context, codespaceName string, includeCon
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
@@ -464,7 +463,7 @@ func (a *API) GetCodespacesMachines(ctx context.Context, repoID int, branch, loc
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
@@ -676,7 +675,7 @@ func (a *API) startCreate(ctx context.Context, params *CreateCodespaceParams) (*
 			r        = io.TeeReader(resp.Body, bodyCopy)
 		)
 
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		if err != nil {
 			return nil, fmt.Errorf("error reading response body: %w", err)
 		}
@@ -688,7 +687,7 @@ func (a *API) startCreate(ctx context.Context, params *CreateCodespaceParams) (*
 			return nil, ue
 		}
 
-		resp.Body = ioutil.NopCloser(bodyCopy)
+		resp.Body = io.NopCloser(bodyCopy)
 
 		return nil, api.HandleHTTPError(resp)
 
@@ -696,7 +695,7 @@ func (a *API) startCreate(ctx context.Context, params *CreateCodespaceParams) (*
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
@@ -840,7 +839,7 @@ func (a *API) EditCodespace(ctx context.Context, codespaceName string, params *E
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
@@ -888,7 +887,7 @@ func (a *API) GetCodespaceRepositoryContents(ctx context.Context, codespace *Cod
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
@@ -924,7 +923,7 @@ func (a *API) AuthorizedKeys(ctx context.Context, user string) ([]byte, error) {
 		return nil, fmt.Errorf("server returned %s", resp.Status)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}

--- a/internal/codespaces/states.go
+++ b/internal/codespaces/states.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"strings"
@@ -39,7 +39,7 @@ type PostCreateState struct {
 // and calls the supplied poller for each batch of state changes.
 // It runs until it encounters an error, including cancellation of the context.
 func PollPostCreateStates(ctx context.Context, progress progressIndicator, apiClient apiClient, codespace *api.Codespace, poller func([]PostCreateState)) (err error) {
-	noopLogger := log.New(ioutil.Discard, "", 0)
+	noopLogger := log.New(io.Discard, "", 0)
 
 	session, err := ConnectToLiveshare(ctx, progress, noopLogger, apiClient, codespace)
 	if err != nil {

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -3,7 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -182,7 +182,7 @@ var ReadConfigFile = func(filename string) ([]byte, error) {
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -257,13 +256,13 @@ func Test_configFile_Write_toDisk(t *testing.T) {
 	}
 
 	expectedConfig := "pager: less\n"
-	if configBytes, err := ioutil.ReadFile(filepath.Join(configDir, "config.yml")); err != nil {
+	if configBytes, err := os.ReadFile(filepath.Join(configDir, "config.yml")); err != nil {
 		t.Error(err)
 	} else if string(configBytes) != expectedConfig {
 		t.Errorf("expected config.yml %q, got %q", expectedConfig, string(configBytes))
 	}
 
-	if configBytes, err := ioutil.ReadFile(filepath.Join(configDir, "hosts.yml")); err != nil {
+	if configBytes, err := os.ReadFile(filepath.Join(configDir, "hosts.yml")); err != nil {
 		t.Error(err)
 	} else if string(configBytes) != "" {
 		t.Errorf("unexpected hosts.yml: %q", string(configBytes))
@@ -288,7 +287,7 @@ func Test_configFile_WriteHosts_toDisk(t *testing.T) {
 	}
 
 	expectedConfig := "github.com:\n    user: monalisa\n    oauth_token: TOKEN\n"
-	actualConfig, err := ioutil.ReadFile(filepath.Join(configDir, "hosts.yml"))
+	actualConfig, err := os.ReadFile(filepath.Join(configDir, "hosts.yml"))
 	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, string(actualConfig))
 	_, nonExistErr := os.Stat(filepath.Join(configDir, "config.yml"))
@@ -310,7 +309,7 @@ func Test_autoMigrateConfigDir_noMigration_notExist(t *testing.T) {
 	err := autoMigrateConfigDir(migrateDir)
 	assert.Equal(t, errNotExist, err)
 
-	files, err := ioutil.ReadDir(migrateDir)
+	files, err := os.ReadDir(migrateDir)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(files))
 }
@@ -332,7 +331,7 @@ func Test_autoMigrateConfigDir_noMigration_samePath(t *testing.T) {
 	err = autoMigrateConfigDir(migrateDir)
 	assert.Equal(t, errSamePath, err)
 
-	files, err := ioutil.ReadDir(migrateDir)
+	files, err := os.ReadDir(migrateDir)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(files))
 }
@@ -353,17 +352,17 @@ func Test_autoMigrateConfigDir_migration(t *testing.T) {
 
 	err := os.MkdirAll(homeConfigDir, 0755)
 	assert.NoError(t, err)
-	f, err := ioutil.TempFile(homeConfigDir, "")
+	f, err := os.CreateTemp(homeConfigDir, "")
 	assert.NoError(t, err)
 	f.Close()
 
 	err = autoMigrateConfigDir(migrateConfigDir)
 	assert.NoError(t, err)
 
-	_, err = ioutil.ReadDir(homeConfigDir)
+	_, err = os.ReadDir(homeConfigDir)
 	assert.True(t, os.IsNotExist(err))
 
-	files, err := ioutil.ReadDir(migrateConfigDir)
+	files, err := os.ReadDir(migrateConfigDir)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(files))
 }
@@ -452,7 +451,7 @@ func Test_autoMigrateStateDir_noMigration_notExist(t *testing.T) {
 	err := autoMigrateStateDir(migrateDir)
 	assert.Equal(t, errNotExist, err)
 
-	files, err := ioutil.ReadDir(migrateDir)
+	files, err := os.ReadDir(migrateDir)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(files))
 }
@@ -474,7 +473,7 @@ func Test_autoMigrateStateDir_noMigration_samePath(t *testing.T) {
 	err = autoMigrateStateDir(migrateDir)
 	assert.Equal(t, errSamePath, err)
 
-	files, err := ioutil.ReadDir(migrateDir)
+	files, err := os.ReadDir(migrateDir)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(files))
 }
@@ -495,17 +494,17 @@ func Test_autoMigrateStateDir_migration(t *testing.T) {
 
 	err := os.MkdirAll(homeConfigDir, 0755)
 	assert.NoError(t, err)
-	err = ioutil.WriteFile(filepath.Join(homeConfigDir, "state.yml"), nil, 0755)
+	err = os.WriteFile(filepath.Join(homeConfigDir, "state.yml"), nil, 0755)
 	assert.NoError(t, err)
 
 	err = autoMigrateStateDir(migrateStateDir)
 	assert.NoError(t, err)
 
-	files, err := ioutil.ReadDir(homeConfigDir)
+	files, err := os.ReadDir(homeConfigDir)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(files))
 
-	files, err = ioutil.ReadDir(migrateStateDir)
+	files, err = os.ReadDir(migrateStateDir)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(files))
 	assert.Equal(t, "state.yml", files[0].Name())

--- a/internal/docs/man_test.go
+++ b/internal/docs/man_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -116,7 +115,7 @@ func TestManPrintFlagsHidesShortDeprecated(t *testing.T) {
 
 func TestGenManTree(t *testing.T) {
 	c := &cobra.Command{Use: "do [OPTIONS] arg1 arg2"}
-	tmpdir, err := ioutil.TempDir("", "test-gen-man-tree")
+	tmpdir, err := os.MkdirTemp("", "test-gen-man-tree")
 	if err != nil {
 		t.Fatalf("Failed to create tmpdir: %s", err.Error())
 	}
@@ -147,7 +146,7 @@ func assertLineFound(scanner *bufio.Scanner, expectedLine string) error {
 }
 
 func BenchmarkGenManToFile(b *testing.B) {
-	file, err := ioutil.TempFile(b.TempDir(), "")
+	file, err := os.CreateTemp(b.TempDir(), "")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/docs/markdown_test.go
+++ b/internal/docs/markdown_test.go
@@ -2,7 +2,6 @@ package docs
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -67,7 +66,7 @@ func TestGenMdNoHiddenParents(t *testing.T) {
 
 func TestGenMdTree(t *testing.T) {
 	c := &cobra.Command{Use: "do [OPTIONS] arg1 arg2"}
-	tmpdir, err := ioutil.TempDir("", "test-gen-md-tree")
+	tmpdir, err := os.MkdirTemp("", "test-gen-md-tree")
 	if err != nil {
 		t.Fatalf("Failed to create tmpdir: %v", err)
 	}
@@ -83,7 +82,7 @@ func TestGenMdTree(t *testing.T) {
 }
 
 func BenchmarkGenMarkdownToFile(b *testing.B) {
-	file, err := ioutil.TempFile(b.TempDir(), "")
+	file, err := os.CreateTemp(b.TempDir(), "")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -65,7 +64,7 @@ func getLatestReleaseInfo(client *api.Client, repo string) (*ReleaseInfo, error)
 }
 
 func getStateEntry(stateFilePath string) (*StateEntry, error) {
-	content, err := ioutil.ReadFile(stateFilePath)
+	content, err := os.ReadFile(stateFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +90,7 @@ func setStateEntry(stateFilePath string, t time.Time, r ReleaseInfo) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(stateFilePath, content, 0600)
+	err = os.WriteFile(stateFilePath, content, 0600)
 	return err
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -117,7 +116,7 @@ func TestCheckForUpdate(t *testing.T) {
 }
 
 func tempFilePath() string {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/cmd/alias/delete/delete_test.go
+++ b/pkg/cmd/alias/delete/delete_test.go
@@ -2,7 +2,7 @@ package delete
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
@@ -48,17 +48,17 @@ func TestAliasDelete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer config.StubWriteConfig(ioutil.Discard, ioutil.Discard)()
+			defer config.StubWriteConfig(io.Discard, io.Discard)()
 
 			cfg := config.NewFromString(tt.config)
 
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			factory := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 				Config: func() (config.Config, error) {
 					return cfg, nil
 				},
@@ -71,8 +71,8 @@ func TestAliasDelete(t *testing.T) {
 			cmd.SetArgs(argv)
 
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantErr != "" {

--- a/pkg/cmd/alias/list/list_test.go
+++ b/pkg/cmd/alias/list/list_test.go
@@ -2,7 +2,7 @@ package list
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
@@ -46,17 +46,17 @@ func TestAliasList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// TODO: change underlying config implementation so Write is not
 			// automatically called when editing aliases in-memory
-			defer config.StubWriteConfig(ioutil.Discard, ioutil.Discard)()
+			defer config.StubWriteConfig(io.Discard, io.Discard)()
 
 			cfg := config.NewFromString(tt.config)
 
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			factory := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 				Config: func() (config.Config, error) {
 					return cfg, nil
 				},
@@ -66,8 +66,8 @@ func TestAliasList(t *testing.T) {
 			cmd.SetArgs([]string{})
 
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err := cmd.ExecuteC()
 			if tt.wantErr {

--- a/pkg/cmd/alias/set/set.go
+++ b/pkg/cmd/alias/set/set.go
@@ -2,7 +2,7 @@ package set
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -162,7 +162,7 @@ func setRun(opts *SetOptions) error {
 
 func getExpansion(opts *SetOptions) (string, error) {
 	if opts.Expansion == "-" {
-		stdin, err := ioutil.ReadAll(opts.IO.In)
+		stdin, err := io.ReadAll(opts.IO.In)
 		if err != nil {
 			return "", fmt.Errorf("failed to read from STDIN: %w", err)
 		}

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
@@ -80,7 +79,7 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 			The default HTTP request method is "GET" normally and "POST" if any parameters
 			were added. Override the method with %[1]s--method%[1]s.
 
-			Pass one or more %[1]s-f/--raw-field%[1]s values in "key=value" format to add static string 
+			Pass one or more %[1]s-f/--raw-field%[1]s values in "key=value" format to add static string
 			parameters to the request payload. To add non-string or otherwise dynamic values, see
 			%[1]s--field%[1]s below. Note that adding request parameters will automatically switch the
 			request method to POST. To send the parameters as a GET query string instead, use
@@ -275,7 +274,7 @@ func apiRun(opts *ApiOptions) error {
 
 	headersOutputStream := opts.IO.Out
 	if opts.Silent {
-		opts.IO.Out = ioutil.Discard
+		opts.IO.Out = io.Discard
 	} else {
 		if err := opts.IO.StartPager(); err == nil {
 			defer opts.IO.StopPager()
@@ -536,7 +535,7 @@ func openUserFile(fn string, stdin io.ReadCloser) (io.ReadCloser, int64, error) 
 
 func parseErrorResponse(r io.Reader, statusCode int) (io.Reader, string, error) {
 	bodyCopy := &bytes.Buffer{}
-	b, err := ioutil.ReadAll(io.TeeReader(r, bodyCopy))
+	b, err := io.ReadAll(io.TeeReader(r, bodyCopy))
 	if err != nil {
 		return r, "", err
 	}

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -368,7 +368,7 @@ func Test_apiRun(t *testing.T) {
 			name: "success",
 			httpResponse: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`bam!`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`bam!`)),
 			},
 			err:    nil,
 			stdout: `bam!`,
@@ -383,7 +383,7 @@ func Test_apiRun(t *testing.T) {
 				Proto:      "HTTP/1.1",
 				Status:     "200 Okey-dokey",
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`body`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`body`)),
 				Header:     http.Header{"Content-Type": []string{"text/plain"}},
 			},
 			err:    nil,
@@ -404,7 +404,7 @@ func Test_apiRun(t *testing.T) {
 			name: "REST error",
 			httpResponse: &http.Response{
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"message": "THIS IS FINE"}`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`{"message": "THIS IS FINE"}`)),
 				Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
 			},
 			err:    cmdutil.SilentError,
@@ -415,7 +415,7 @@ func Test_apiRun(t *testing.T) {
 			name: "REST string errors",
 			httpResponse: &http.Response{
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"errors": ["ALSO", "FINE"]}`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`{"errors": ["ALSO", "FINE"]}`)),
 				Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
 			},
 			err:    cmdutil.SilentError,
@@ -429,7 +429,7 @@ func Test_apiRun(t *testing.T) {
 			},
 			httpResponse: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"errors": [{"message":"AGAIN"}, {"message":"FINE"}]}`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`{"errors": [{"message":"AGAIN"}, {"message":"FINE"}]}`)),
 				Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
 			},
 			err:    cmdutil.SilentError,
@@ -440,7 +440,7 @@ func Test_apiRun(t *testing.T) {
 			name: "failure",
 			httpResponse: &http.Response{
 				StatusCode: 502,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`gateway timeout`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`gateway timeout`)),
 			},
 			err:    cmdutil.SilentError,
 			stdout: `gateway timeout`,
@@ -453,7 +453,7 @@ func Test_apiRun(t *testing.T) {
 			},
 			httpResponse: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`body`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`body`)),
 			},
 			err:    nil,
 			stdout: ``,
@@ -469,7 +469,7 @@ func Test_apiRun(t *testing.T) {
 				Proto:      "HTTP/1.1",
 				Status:     "200 Okey-dokey",
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`body`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`body`)),
 				Header:     http.Header{"Content-Type": []string{"text/plain"}},
 			},
 			err:    nil,
@@ -483,7 +483,7 @@ func Test_apiRun(t *testing.T) {
 			},
 			httpResponse: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"status":"not a cat"}`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`{"status":"not a cat"}`)),
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 			},
 			err:    nil,
@@ -497,7 +497,7 @@ func Test_apiRun(t *testing.T) {
 			},
 			httpResponse: &http.Response{
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"message": "THIS IS FINE"}`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`{"message": "THIS IS FINE"}`)),
 				Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
 			},
 			err:    cmdutil.SilentError,
@@ -511,7 +511,7 @@ func Test_apiRun(t *testing.T) {
 			},
 			httpResponse: &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`[{"name":"Mona"},{"name":"Hubot"}]`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`[{"name":"Mona"},{"name":"Hubot"}]`)),
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
 			},
 			err:    nil,
@@ -525,7 +525,7 @@ func Test_apiRun(t *testing.T) {
 			},
 			httpResponse: &http.Response{
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(`{"message": "THIS IS FINE"}`)),
+				Body:       io.NopCloser(bytes.NewBufferString(`{"message": "THIS IS FINE"}`)),
 				Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
 			},
 			err:    cmdutil.SilentError,
@@ -536,9 +536,9 @@ func Test_apiRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
+			ios, _, stdout, stderr := iostreams.Test()
 
-			tt.options.IO = io
+			tt.options.IO = ios
 			tt.options.Config = func() (config.Config, error) { return config.NewBlankConfig(), nil }
 			tt.options.HttpClient = func() (*http.Client, error) {
 				var tr roundTripper = func(req *http.Request) (*http.Response, error) {
@@ -565,33 +565,33 @@ func Test_apiRun(t *testing.T) {
 }
 
 func Test_apiRun_paginationREST(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 
 	requestCount := 0
 	responses := []*http.Response{
 		{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(`{"page":1}`)),
+			Body:       io.NopCloser(bytes.NewBufferString(`{"page":1}`)),
 			Header: http.Header{
 				"Link": []string{`<https://api.github.com/repositories/1227/issues?page=2>; rel="next", <https://api.github.com/repositories/1227/issues?page=3>; rel="last"`},
 			},
 		},
 		{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(`{"page":2}`)),
+			Body:       io.NopCloser(bytes.NewBufferString(`{"page":2}`)),
 			Header: http.Header{
 				"Link": []string{`<https://api.github.com/repositories/1227/issues?page=3>; rel="next", <https://api.github.com/repositories/1227/issues?page=3>; rel="last"`},
 			},
 		},
 		{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(`{"page":3}`)),
+			Body:       io.NopCloser(bytes.NewBufferString(`{"page":3}`)),
 			Header:     http.Header{},
 		},
 	}
 
 	options := ApiOptions{
-		IO: io,
+		IO: ios,
 		HttpClient: func() (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				resp := responses[requestCount]
@@ -624,14 +624,14 @@ func Test_apiRun_paginationREST(t *testing.T) {
 }
 
 func Test_apiRun_paginationGraphQL(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 
 	requestCount := 0
 	responses := []*http.Response{
 		{
 			StatusCode: 200,
 			Header:     http.Header{"Content-Type": []string{`application/json`}},
-			Body: ioutil.NopCloser(bytes.NewBufferString(`{
+			Body: io.NopCloser(bytes.NewBufferString(`{
 				"data": {
 					"nodes": ["page one"],
 					"pageInfo": {
@@ -644,7 +644,7 @@ func Test_apiRun_paginationGraphQL(t *testing.T) {
 		{
 			StatusCode: 200,
 			Header:     http.Header{"Content-Type": []string{`application/json`}},
-			Body: ioutil.NopCloser(bytes.NewBufferString(`{
+			Body: io.NopCloser(bytes.NewBufferString(`{
 				"data": {
 					"nodes": ["page two"],
 					"pageInfo": {
@@ -657,7 +657,7 @@ func Test_apiRun_paginationGraphQL(t *testing.T) {
 	}
 
 	options := ApiOptions{
-		IO: io,
+		IO: ios,
 		HttpClient: func() (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				resp := responses[requestCount]
@@ -687,14 +687,14 @@ func Test_apiRun_paginationGraphQL(t *testing.T) {
 		Variables map[string]interface{}
 	}
 
-	bb, err := ioutil.ReadAll(responses[0].Request.Body)
+	bb, err := io.ReadAll(responses[0].Request.Body)
 	require.NoError(t, err)
 	err = json.Unmarshal(bb, &requestData)
 	require.NoError(t, err)
 	_, hasCursor := requestData.Variables["endCursor"].(string)
 	assert.Equal(t, false, hasCursor)
 
-	bb, err = ioutil.ReadAll(responses[1].Request.Body)
+	bb, err = io.ReadAll(responses[1].Request.Body)
 	require.NoError(t, err)
 	err = json.Unmarshal(bb, &requestData)
 	require.NoError(t, err)
@@ -704,15 +704,15 @@ func Test_apiRun_paginationGraphQL(t *testing.T) {
 }
 
 func Test_apiRun_paginated_template(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(true)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(true)
 
 	requestCount := 0
 	responses := []*http.Response{
 		{
 			StatusCode: 200,
 			Header:     http.Header{"Content-Type": []string{`application/json`}},
-			Body: ioutil.NopCloser(bytes.NewBufferString(`{
+			Body: io.NopCloser(bytes.NewBufferString(`{
 				"data": {
 					"nodes": [
 						{
@@ -730,7 +730,7 @@ func Test_apiRun_paginated_template(t *testing.T) {
 		{
 			StatusCode: 200,
 			Header:     http.Header{"Content-Type": []string{`application/json`}},
-			Body: ioutil.NopCloser(bytes.NewBufferString(`{
+			Body: io.NopCloser(bytes.NewBufferString(`{
 				"data": {
 					"nodes": [
 						{
@@ -748,7 +748,7 @@ func Test_apiRun_paginated_template(t *testing.T) {
 	}
 
 	options := ApiOptions{
-		IO: io,
+		IO: ios,
 		HttpClient: func() (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				resp := responses[requestCount]
@@ -782,14 +782,14 @@ func Test_apiRun_paginated_template(t *testing.T) {
 		Variables map[string]interface{}
 	}
 
-	bb, err := ioutil.ReadAll(responses[0].Request.Body)
+	bb, err := io.ReadAll(responses[0].Request.Body)
 	require.NoError(t, err)
 	err = json.Unmarshal(bb, &requestData)
 	require.NoError(t, err)
 	_, hasCursor := requestData.Variables["endCursor"].(string)
 	assert.Equal(t, false, hasCursor)
 
-	bb, err = ioutil.ReadAll(responses[1].Request.Body)
+	bb, err = io.ReadAll(responses[1].Request.Body)
 	require.NoError(t, err)
 	err = json.Unmarshal(bb, &requestData)
 	require.NoError(t, err)
@@ -825,14 +825,14 @@ func Test_apiRun_inputFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, stdin, _, _ := iostreams.Test()
+			ios, stdin, _, _ := iostreams.Test()
 			resp := &http.Response{StatusCode: 204}
 
 			inputFile := tt.inputFile
 			if tt.inputFile == "-" {
 				_, _ = stdin.Write(tt.inputContents)
 			} else {
-				f, err := ioutil.TempFile(tempDir, tt.inputFile)
+				f, err := os.CreateTemp(tempDir, tt.inputFile)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -847,11 +847,11 @@ func Test_apiRun_inputFile(t *testing.T) {
 				RequestInputFile: inputFile,
 				RawFields:        []string{"a=b", "c=d"},
 
-				IO: io,
+				IO: ios,
 				HttpClient: func() (*http.Client, error) {
 					var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 						var err error
-						if bodyBytes, err = ioutil.ReadAll(req.Body); err != nil {
+						if bodyBytes, err = io.ReadAll(req.Body); err != nil {
 							return nil, err
 						}
 						resp.Request = req
@@ -879,11 +879,11 @@ func Test_apiRun_inputFile(t *testing.T) {
 }
 
 func Test_apiRun_cache(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 
 	requestCount := 0
 	options := ApiOptions{
-		IO: io,
+		IO: ios,
 		HttpClient: func() (*http.Client, error) {
 			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
 				requestCount++
@@ -918,11 +918,11 @@ func Test_apiRun_cache(t *testing.T) {
 }
 
 func Test_parseFields(t *testing.T) {
-	io, stdin, _, _ := iostreams.Test()
+	ios, stdin, _, _ := iostreams.Test()
 	fmt.Fprint(stdin, "pasted contents")
 
 	opts := ApiOptions{
-		IO: io,
+		IO: ios,
 		RawFields: []string{
 			"robot=Hubot",
 			"destroyer=false",
@@ -954,7 +954,7 @@ func Test_parseFields(t *testing.T) {
 }
 
 func Test_magicFieldValue(t *testing.T) {
-	f, err := ioutil.TempFile(t.TempDir(), "gh-test")
+	f, err := os.CreateTemp(t.TempDir(), "gh-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -962,7 +962,7 @@ func Test_magicFieldValue(t *testing.T) {
 
 	fmt.Fprint(f, "file contents")
 
-	io, _, _, _ := iostreams.Test()
+	ios, _, _, _ := iostreams.Test()
 
 	type args struct {
 		v    string
@@ -1003,7 +1003,7 @@ func Test_magicFieldValue(t *testing.T) {
 			args: args{
 				v: ":owner",
 				opts: &ApiOptions{
-					IO: io,
+					IO: ios,
 					BaseRepo: func() (ghrepo.Interface, error) {
 						return ghrepo.New("hubot", "robot-uprising"), nil
 					},
@@ -1017,7 +1017,7 @@ func Test_magicFieldValue(t *testing.T) {
 			args: args{
 				v: "{owner}",
 				opts: &ApiOptions{
-					IO: io,
+					IO: ios,
 					BaseRepo: func() (ghrepo.Interface, error) {
 						return ghrepo.New("hubot", "robot-uprising"), nil
 					},
@@ -1030,7 +1030,7 @@ func Test_magicFieldValue(t *testing.T) {
 			name: "file",
 			args: args{
 				v:    "@" + f.Name(),
-				opts: &ApiOptions{IO: io},
+				opts: &ApiOptions{IO: ios},
 			},
 			want:    []byte("file contents"),
 			wantErr: false,
@@ -1039,7 +1039,7 @@ func Test_magicFieldValue(t *testing.T) {
 			name: "file error",
 			args: args{
 				v:    "@",
-				opts: &ApiOptions{IO: io},
+				opts: &ApiOptions{IO: ios},
 			},
 			want:    nil,
 			wantErr: true,
@@ -1061,7 +1061,7 @@ func Test_magicFieldValue(t *testing.T) {
 }
 
 func Test_openUserFile(t *testing.T) {
-	f, err := ioutil.TempFile(t.TempDir(), "gh-test")
+	f, err := os.CreateTemp(t.TempDir(), "gh-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1075,7 +1075,7 @@ func Test_openUserFile(t *testing.T) {
 	}
 	defer file.Close()
 
-	fb, err := ioutil.ReadAll(file)
+	fb, err := io.ReadAll(file)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1272,14 +1272,14 @@ func Test_previewNamesToMIMETypes(t *testing.T) {
 }
 
 func Test_processResponse_template(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 
 	resp := http.Response{
 		StatusCode: 200,
 		Header: map[string][]string{
 			"Content-Type": {"application/json"},
 		},
-		Body: ioutil.NopCloser(strings.NewReader(`[
+		Body: io.NopCloser(strings.NewReader(`[
 			{
 				"title": "First title",
 				"labels": [{"name":"bug"}, {"name":"help wanted"}]
@@ -1295,11 +1295,11 @@ func Test_processResponse_template(t *testing.T) {
 	}
 
 	opts := ApiOptions{
-		IO:       io,
+		IO:       ios,
 		Template: `{{range .}}{{.title}} ({{.labels | pluck "name" | join ", " }}){{"\n"}}{{end}}`,
 	}
-	template := export.NewTemplate(io, opts.Template)
-	_, err := processResponse(&resp, &opts, ioutil.Discard, &template)
+	template := export.NewTemplate(ios, opts.Template)
+	_, err := processResponse(&resp, &opts, io.Discard, &template)
 	require.NoError(t, err)
 
 	err = template.End()
@@ -1385,7 +1385,7 @@ func Test_parseErrorResponse(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseErrorResponse() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if gotString, _ := ioutil.ReadAll(got); tt.args.input != string(gotString) {
+			if gotString, _ := io.ReadAll(got); tt.args.input != string(gotString) {
 				t.Errorf("parseErrorResponse() got = %q, want %q", string(gotString), tt.args.input)
 			}
 			if got1 != tt.wantErrMsg {

--- a/pkg/cmd/api/http_test.go
+++ b/pkg/cmd/api/http_test.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -281,7 +281,7 @@ func Test_httpRequest(t *testing.T) {
 			}
 
 			if tt.want.body != "" {
-				bb, err := ioutil.ReadAll(req.Body)
+				bb, err := io.ReadAll(req.Body)
 				if err != nil {
 					t.Errorf("Request.Body ReadAll error = %v", err)
 					return

--- a/pkg/cmd/auth/gitcredential/helper_test.go
+++ b/pkg/cmd/auth/gitcredential/helper_test.go
@@ -217,10 +217,10 @@ func Test_helperRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, stdin, stdout, stderr := iostreams.Test()
+			ios, stdin, stdout, stderr := iostreams.Test()
 			fmt.Fprint(stdin, tt.input)
 			opts := &tt.opts
-			opts.IO = io
+			opts.IO = ios
 			if err := helperRun(opts); (err != nil) != tt.wantErr {
 				t.Fatalf("helperRun() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -3,7 +3,7 @@ package login
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -82,7 +82,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 
 			if tokenStdin {
 				defer opts.IO.In.Close()
-				token, err := ioutil.ReadAll(opts.IO.In)
+				token, err := io.ReadAll(opts.IO.In)
 				if err != nil {
 					return fmt.Errorf("failed to read token from standard input: %w", err)
 				}

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -168,13 +168,13 @@ func Test_NewCmdLogin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, stdin, _, _ := iostreams.Test()
+			ios, stdin, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
-			io.SetStdoutTTY(true)
-			io.SetStdinTTY(tt.stdinTTY)
+			ios.SetStdoutTTY(true)
+			ios.SetStdinTTY(tt.stdinTTY)
 			if tt.stdin != "" {
 				stdin.WriteString(tt.stdin)
 			}
@@ -309,17 +309,17 @@ func Test_loginRun_nontty(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		io, _, stdout, stderr := iostreams.Test()
+		ios, _, stdout, stderr := iostreams.Test()
 
-		io.SetStdinTTY(false)
-		io.SetStdoutTTY(false)
+		ios.SetStdinTTY(false)
+		ios.SetStdoutTTY(false)
 
 		tt.opts.Config = func() (config.Config, error) {
 			cfg := config.NewBlankConfig()
 			return config.InheritEnv(cfg), nil
 		}
 
-		tt.opts.IO = io
+		tt.opts.IO = ios
 		t.Run(tt.name, func(t *testing.T) {
 			reg := &httpmock.Registry{}
 			tt.opts.HttpClient = func() (*http.Client, error) {
@@ -513,13 +513,13 @@ func Test_loginRun_Survey(t *testing.T) {
 		if tt.opts == nil {
 			tt.opts = &LoginOptions{}
 		}
-		io, _, _, stderr := iostreams.Test()
+		ios, _, _, stderr := iostreams.Test()
 
-		io.SetStdinTTY(true)
-		io.SetStderrTTY(true)
-		io.SetStdoutTTY(true)
+		ios.SetStdinTTY(true)
+		ios.SetStderrTTY(true)
+		ios.SetStdoutTTY(true)
 
-		tt.opts.IO = io
+		tt.opts.IO = ios
 
 		cfg := config.NewBlankConfig()
 

--- a/pkg/cmd/auth/logout/logout_test.go
+++ b/pkg/cmd/auth/logout/logout_test.go
@@ -54,12 +54,12 @@ func Test_NewCmdLogout(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			argv, err := shlex.Split(tt.cli)
 			assert.NoError(t, err)
@@ -141,12 +141,12 @@ func Test_logoutRun_tty(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, stderr := iostreams.Test()
+			ios, _, _, stderr := iostreams.Test()
 
-			io.SetStdinTTY(true)
-			io.SetStdoutTTY(true)
+			ios.SetStdinTTY(true)
+			ios.SetStdoutTTY(true)
 
-			tt.opts.IO = io
+			tt.opts.IO = ios
 			cfg := config.NewBlankConfig()
 			tt.opts.Config = func() (config.Config, error) {
 				return cfg, nil
@@ -229,12 +229,12 @@ func Test_logoutRun_nontty(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, stderr := iostreams.Test()
+			ios, _, _, stderr := iostreams.Test()
 
-			io.SetStdinTTY(false)
-			io.SetStdoutTTY(false)
+			ios.SetStdinTTY(false)
+			ios.SetStdoutTTY(false)
 
-			tt.opts.IO = io
+			tt.opts.IO = ios
 			cfg := config.NewBlankConfig()
 			tt.opts.Config = func() (config.Config, error) {
 				return cfg, nil

--- a/pkg/cmd/auth/refresh/refresh_test.go
+++ b/pkg/cmd/auth/refresh/refresh_test.go
@@ -2,7 +2,7 @@ package refresh
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -89,13 +89,13 @@ func Test_NewCmdRefresh(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
-			io.SetNeverPrompt(tt.neverPrompt)
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
+			ios.SetNeverPrompt(tt.neverPrompt)
 
 			argv, err := shlex.Split(tt.cli)
 			assert.NoError(t, err)
@@ -238,12 +238,12 @@ func Test_refreshRun(t *testing.T) {
 				return nil
 			}
 
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 
-			io.SetStdinTTY(!tt.nontty)
-			io.SetStdoutTTY(!tt.nontty)
+			ios.SetStdinTTY(!tt.nontty)
+			ios.SetStdoutTTY(!tt.nontty)
 
-			tt.opts.IO = io
+			tt.opts.IO = ios
 			cfg := config.NewBlankConfig()
 			tt.opts.Config = func() (config.Config, error) {
 				return cfg, nil
@@ -263,7 +263,7 @@ func Test_refreshRun(t *testing.T) {
 					return &http.Response{
 						Request:    req,
 						StatusCode: statusCode,
-						Body:       ioutil.NopCloser(strings.NewReader(``)),
+						Body:       io.NopCloser(strings.NewReader(``)),
 						Header: http.Header{
 							"X-Oauth-Scopes": {tt.oldScopes},
 						},

--- a/pkg/cmd/auth/setupgit/setupgit_test.go
+++ b/pkg/cmd/auth/setupgit/setupgit_test.go
@@ -102,12 +102,12 @@ func Test_setupGitRun(t *testing.T) {
 				}
 			}
 
-			io, _, _, stderr := iostreams.Test()
+			ios, _, _, stderr := iostreams.Test()
 
-			io.SetStdinTTY(true)
-			io.SetStderrTTY(true)
-			io.SetStdoutTTY(true)
-			tt.opts.IO = io
+			ios.SetStdinTTY(true)
+			ios.SetStderrTTY(true)
+			ios.SetStdoutTTY(true)
+			tt.opts.IO = ios
 
 			err := setupGitRun(tt.opts)
 			if tt.expectedErr != "" {

--- a/pkg/cmd/auth/shared/login_flow_test.go
+++ b/pkg/cmd/auth/shared/login_flow_test.go
@@ -2,8 +2,8 @@ package shared
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -36,7 +36,7 @@ func (c tinyConfig) WriteHosts() error {
 
 func TestLogin_ssh(t *testing.T) {
 	dir := t.TempDir()
-	io, _, stdout, stderr := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 
 	tr := httpmock.Registry{}
 	defer tr.Verify(t)
@@ -72,13 +72,13 @@ func TestLogin_ssh(t *testing.T) {
 		}
 		assert.Equal(t, expected, args)
 		// simulate that the public key file has been generated
-		_ = ioutil.WriteFile(keyFile+".pub", []byte("PUBKEY"), 0600)
+		_ = os.WriteFile(keyFile+".pub", []byte("PUBKEY"), 0600)
 	})
 
 	cfg := tinyConfig{}
 
 	err := Login(&LoginOptions{
-		IO:          io,
+		IO:          ios,
 		Config:      &cfg,
 		HTTPClient:  &http.Client{Transport: &tr},
 		Hostname:    "example.com",

--- a/pkg/cmd/auth/shared/oauth_scopes.go
+++ b/pkg/cmd/auth/shared/oauth_scopes.go
@@ -3,7 +3,6 @@ package shared
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -50,7 +49,7 @@ func GetScopes(httpClient httpClient, hostname, authToken string) (string, error
 	defer func() {
 		// Ensure the response body is fully read and closed
 		// before we reconnect, so that we reuse the same TCPconnection.
-		_, _ = io.Copy(ioutil.Discard, res.Body)
+		_, _ = io.Copy(io.Discard, res.Body)
 		res.Body.Close()
 	}()
 

--- a/pkg/cmd/auth/shared/oauth_scopes_test.go
+++ b/pkg/cmd/auth/shared/oauth_scopes_test.go
@@ -2,7 +2,7 @@ package shared
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -58,7 +58,7 @@ func Test_HasMinimumScopes(t *testing.T) {
 				return &http.Response{
 					Request:    req,
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(&bytes.Buffer{}),
+					Body:       io.NopCloser(&bytes.Buffer{}),
 					Header: map[string][]string{
 						"X-Oauth-Scopes": {tt.header},
 					},

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -208,13 +208,13 @@ func Test_statusRun(t *testing.T) {
 				tt.opts = &StatusOptions{}
 			}
 
-			io, _, _, stderr := iostreams.Test()
+			ios, _, _, stderr := iostreams.Test()
 
-			io.SetStdinTTY(true)
-			io.SetStderrTTY(true)
-			io.SetStdoutTTY(true)
+			ios.SetStdinTTY(true)
+			ios.SetStderrTTY(true)
+			ios.SetStdoutTTY(true)
 
-			tt.opts.IO = io
+			tt.opts.IO = ios
 
 			cfg := config.NewBlankConfig()
 

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -2,7 +2,7 @@ package browse
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -126,8 +126,8 @@ func TestNewCmdBrowse(t *testing.T) {
 			argv, err := shlex.Split(tt.cli)
 			assert.NoError(t, err)
 			cmd.SetArgs(argv)
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			_, err = cmd.ExecuteC()
 
 			if tt.wantsErr {
@@ -418,7 +418,7 @@ func Test_runBrowse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
+			ios, _, stdout, stderr := iostreams.Test()
 			browser := cmdutil.TestBrowser{}
 
 			reg := httpmock.Registry{}
@@ -428,7 +428,7 @@ func Test_runBrowse(t *testing.T) {
 			}
 
 			opts := tt.opts
-			opts.IO = io
+			opts.IO = ios
 			opts.BaseRepo = func() (ghrepo.Interface, error) {
 				return tt.baseRepo, nil
 			}

--- a/pkg/cmd/codespace/code_test.go
+++ b/pkg/cmd/codespace/code_test.go
@@ -63,11 +63,11 @@ func TestApp_VSCode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &cmdutil.TestBrowser{}
-			io, _, stdout, stderr := iostreams.Test()
+			ios, _, stdout, stderr := iostreams.Test()
 			a := &App{
 				browser:   b,
 				apiClient: testCodeApiMock(),
-				io:        io,
+				io:        ios,
 			}
 			if err := a.VSCode(context.Background(), tt.args.codespaceName, tt.args.useInsiders, tt.args.useWeb); (err != nil) != tt.wantErr {
 				t.Errorf("App.VSCode() error = %v, wantErr %v", err, tt.wantErr)
@@ -96,8 +96,8 @@ func TestPendingOperationDisallowsCode(t *testing.T) {
 }
 
 func testingCodeApp() *App {
-	io, _, _, _ := iostreams.Test()
-	return NewApp(io, nil, testCodeApiMock(), nil)
+	ios, _, _, _ := iostreams.Test()
+	return NewApp(ios, nil, testCodeApiMock(), nil)
 }
 
 func testCodeApiMock() *apiClientMock {

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
@@ -256,7 +255,7 @@ func noArgsConstraint(cmd *cobra.Command, args []string) error {
 }
 
 func noopLogger() *log.Logger {
-	return log.New(ioutil.Discard, "", 0)
+	return log.New(io.Discard, "", 0)
 }
 
 type codespace struct {

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -311,13 +311,13 @@ Alternatively, you can run "create" with the "--default-permissions" option to c
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			a := &App{
-				io:        io,
+				io:        ios,
 				apiClient: tt.fields.apiClient,
 			}
 

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -187,10 +187,10 @@ func TestDelete(t *testing.T) {
 				},
 			}
 
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdinTTY(true)
-			io.SetStdoutTTY(true)
-			app := NewApp(io, nil, apiMock, nil)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdinTTY(true)
+			ios.SetStdoutTTY(true)
+			app := NewApp(ios, nil, apiMock, nil)
 			err := app.Delete(context.Background(), opts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("delete() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/cmd/codespace/logs_test.go
+++ b/pkg/cmd/codespace/logs_test.go
@@ -42,6 +42,6 @@ func testingLogsApp() *App {
 		},
 	}
 
-	io, _, _, _ := iostreams.Test()
-	return NewApp(io, nil, apiMock, nil)
+	ios, _, _, _ := iostreams.Test()
+	return NewApp(ios, nil, apiMock, nil)
 }

--- a/pkg/cmd/codespace/ports_test.go
+++ b/pkg/cmd/codespace/ports_test.go
@@ -191,10 +191,10 @@ func runUpdateVisibilityTest(t *testing.T, portVisibilities []portVisibility, ev
 		},
 	}
 
-	io, _, _, _ := iostreams.Test()
+	ios, _, _, _ := iostreams.Test()
 
 	a := &App{
-		io:        io,
+		io:        ios,
 		apiClient: mockApi,
 	}
 
@@ -264,7 +264,7 @@ func testingPortsApp() *App {
 		},
 	}
 
-	io, _, _, _ := iostreams.Test()
+	ios, _, _, _ := iostreams.Test()
 
-	return NewApp(io, nil, apiMock, nil)
+	return NewApp(ios, nil, apiMock, nil)
 }

--- a/pkg/cmd/codespace/select_test.go
+++ b/pkg/cmd/codespace/select_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -45,14 +44,14 @@ func TestApp_Select(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdinTTY(true)
-			io.SetStdoutTTY(true)
-			a := NewApp(io, nil, testSelectApiMock(), nil)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdinTTY(true)
+			ios.SetStdoutTTY(true)
+			a := NewApp(ios, nil, testSelectApiMock(), nil)
 
 			opts := selectOptions{}
 			if tt.outputToFile {
-				file, err := ioutil.TempFile("", "codespace-selection-test")
+				file, err := os.CreateTemp("", "codespace-selection-test")
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -441,7 +440,7 @@ type fileLogger struct {
 func newFileLogger(file string) (fl *fileLogger, err error) {
 	var f *os.File
 	if file == "" {
-		f, err = ioutil.TempFile("", "")
+		f, err = os.CreateTemp("", "")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tmp file: %w", err)
 		}

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -42,6 +42,6 @@ func testingSSHApp() *App {
 		},
 	}
 
-	io, _, _, _ := iostreams.Test()
-	return NewApp(io, nil, apiMock, nil)
+	ios, _, _, _ := iostreams.Test()
+	return NewApp(ios, nil, apiMock, nil)
 }

--- a/pkg/cmd/completion/completion_test.go
+++ b/pkg/cmd/completion/completion_test.go
@@ -44,8 +44,8 @@ func TestNewCmdCompletion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
-			completeCmd := NewCmdCompletion(io)
+			ios, _, stdout, stderr := iostreams.Test()
+			completeCmd := NewCmdCompletion(ios)
 			rootCmd := &cobra.Command{Use: "gh"}
 			rootCmd.AddCommand(completeCmd)
 

--- a/pkg/cmd/config/get/get_test.go
+++ b/pkg/cmd/config/get/get_test.go
@@ -107,8 +107,8 @@ func Test_getRun(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		io, _, stdout, stderr := iostreams.Test()
-		tt.input.IO = io
+		ios, _, stdout, stderr := iostreams.Test()
+		tt.input.IO = ios
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := getRun(tt.input)

--- a/pkg/cmd/config/list/list_test.go
+++ b/pkg/cmd/config/list/list_test.go
@@ -97,8 +97,8 @@ browser=brave
 	}
 
 	for _, tt := range tests {
-		io, _, stdout, _ := iostreams.Test()
-		tt.input.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		tt.input.IO = ios
 		tt.input.Config = func() (config.Config, error) {
 			return tt.config, nil
 		}

--- a/pkg/cmd/config/set/set_test.go
+++ b/pkg/cmd/config/set/set_test.go
@@ -132,8 +132,8 @@ func Test_setRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		io, _, stdout, stderr := iostreams.Test()
-		tt.input.IO = io
+		ios, _, stdout, stderr := iostreams.Test()
+		tt.input.IO = ios
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := setRun(tt.input)

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -2,7 +2,7 @@ package extension
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -551,8 +551,8 @@ func TestNewCmdExtension(t *testing.T) {
 
 			cmd := NewCmdExtension(&f)
 			cmd.SetArgs(tt.args)
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err := cmd.ExecuteC()
 			if tt.wantErr {

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -103,7 +102,7 @@ func fetchLatestRelease(httpClient *http.Client, baseRepo ghrepo.Interface) (*re
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +139,7 @@ func fetchReleaseFromTag(httpClient *http.Client, baseRepo ghrepo.Interface, tag
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +176,7 @@ func fetchCommitSHA(httpClient *http.Client, baseRepo ghrepo.Interface, targetRe
 		return "", api.HandleHTTPError(resp)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/factory/http_test.go
+++ b/pkg/cmd/factory/http_test.go
@@ -190,8 +190,8 @@ func TestNewHTTPClient(t *testing.T) {
 				os.Setenv("GH_DEBUG", oldGhDebug)
 			})
 
-			io, _, _, stderr := iostreams.Test()
-			client, err := NewHTTPClient(io, tt.args.config, tt.args.appVersion, tt.args.setAccept)
+			ios, _, _, stderr := iostreams.Test()
+			client, err := NewHTTPClient(ios, tt.args.config, tt.args.appVersion, tt.args.setAccept)
 			require.NoError(t, err)
 
 			req, err := http.NewRequest("GET", ts.URL, nil)

--- a/pkg/cmd/gist/clone/clone_test.go
+++ b/pkg/cmd/gist/clone/clone_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func runCloneCommand(httpClient *http.Client, cli string) (*test.CmdOut, error) {
-	io, stdin, stdout, stderr := iostreams.Test()
+	ios, stdin, stdout, stderr := iostreams.Test()
 	fac := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return httpClient, nil
 		},

--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -193,7 +193,7 @@ func processFiles(stdin io.ReadCloser, filenameOverride string, filenames []stri
 			} else {
 				filename = fmt.Sprintf("gistfile%d.txt", i)
 			}
-			content, err = ioutil.ReadAll(stdin)
+			content, err = io.ReadAll(stdin)
 			if err != nil {
 				return fs, fmt.Errorf("failed to read from stdin: %w", err)
 			}
@@ -211,7 +211,7 @@ func processFiles(stdin io.ReadCloser, filenameOverride string, filenames []stri
 				return nil, fmt.Errorf("failed to upload %s: binary file not supported", f)
 			}
 
-			content, err = ioutil.ReadFile(f)
+			content, err = os.ReadFile(f)
 			if err != nil {
 				return fs, fmt.Errorf("failed to read file %s: %w", f, err)
 			}

--- a/pkg/cmd/gist/edit/edit_test.go
+++ b/pkg/cmd/gist/edit/edit_test.go
@@ -3,8 +3,9 @@ package edit
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -110,7 +111,7 @@ func TestNewCmdEdit(t *testing.T) {
 
 func Test_editRun(t *testing.T) {
 	fileToAdd := filepath.Join(t.TempDir(), "gist-test.txt")
-	err := ioutil.WriteFile(fileToAdd, []byte("hello"), 0600)
+	err := os.WriteFile(fileToAdd, []byte("hello"), 0600)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -473,11 +474,11 @@ func Test_editRun(t *testing.T) {
 		tt.opts.HttpClient = func() (*http.Client, error) {
 			return &http.Client{Transport: reg}, nil
 		}
-		io, stdin, stdout, stderr := iostreams.Test()
+		ios, stdin, stdout, stderr := iostreams.Test()
 		stdin.WriteString(tt.stdin)
-		io.SetStdoutTTY(!tt.nontty)
-		io.SetStdinTTY(!tt.nontty)
-		tt.opts.IO = io
+		ios.SetStdoutTTY(!tt.nontty)
+		ios.SetStdinTTY(!tt.nontty)
+		tt.opts.IO = ios
 		tt.opts.Selector = "1234"
 
 		tt.opts.Config = func() (config.Config, error) {
@@ -499,7 +500,7 @@ func Test_editRun(t *testing.T) {
 			assert.NoError(t, err)
 
 			if tt.wantParams != nil {
-				bodyBytes, _ := ioutil.ReadAll(reg.Requests[2].Body)
+				bodyBytes, _ := io.ReadAll(reg.Requests[2].Body)
 				reqBody := make(map[string]interface{})
 				err = json.Unmarshal(bodyBytes, &reqBody)
 				if err != nil {

--- a/pkg/cmd/gist/list/list_test.go
+++ b/pkg/cmd/gist/list/list_test.go
@@ -365,9 +365,9 @@ func Test_listRun(t *testing.T) {
 			return config.NewBlankConfig(), nil
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdoutTTY(!tt.nontty)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdoutTTY(!tt.nontty)
+		tt.opts.IO = ios
 
 		if tt.opts.Limit == 0 {
 			tt.opts.Limit = 10

--- a/pkg/cmd/gist/view/view_test.go
+++ b/pkg/cmd/gist/view/view_test.go
@@ -78,11 +78,11 @@ func TestNewCmdView(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -371,9 +371,9 @@ func Test_viewRun(t *testing.T) {
 			return config.NewBlankConfig(), nil
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdoutTTY(true)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdoutTTY(true)
+		tt.opts.IO = ios
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := viewRun(tt.opts)
@@ -451,7 +451,7 @@ func Test_promptGists(t *testing.T) {
 		},
 	}
 
-	io, _, _, _ := iostreams.Test()
+	ios, _, _, _ := iostreams.Test()
 
 	for _, tt := range tests {
 		reg := &httpmock.Registry{}
@@ -474,7 +474,7 @@ func Test_promptGists(t *testing.T) {
 				tt.askStubs(as)
 			}
 
-			gistID, err := promptGists(client, "github.com", io.ColorScheme())
+			gistID, err := promptGists(client, "github.com", ios.ColorScheme())
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantOut, gistID)
 			reg.Verify(t)

--- a/pkg/cmd/gpg-key/add/add_test.go
+++ b/pkg/cmd/gpg-key/add/add_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func Test_runAdd(t *testing.T) {
-	io, stdin, stdout, stderr := iostreams.Test()
-	io.SetStdinTTY(false)
-	io.SetStdoutTTY(true)
-	io.SetStderrTTY(true)
+	ios, stdin, stdout, stderr := iostreams.Test()
+	ios.SetStdinTTY(false)
+	ios.SetStdoutTTY(true)
+	ios.SetStderrTTY(true)
 
 	stdin.WriteString("PUBKEY")
 
@@ -26,7 +26,7 @@ func Test_runAdd(t *testing.T) {
 		httpmock.StringResponse(`{}`))
 
 	err := runAdd(&AddOptions{
-		IO: io,
+		IO: ios,
 		Config: func() (config.Config, error) {
 			return config.NewBlankConfig(), nil
 		},

--- a/pkg/cmd/gpg-key/add/http.go
+++ b/pkg/cmd/gpg-key/add/http.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
@@ -17,7 +16,7 @@ var scopesError = errors.New("insufficient OAuth scopes")
 func gpgKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader) error {
 	url := ghinstance.RESTPrefix(hostname) + "user/gpg_keys"
 
-	keyBytes, err := ioutil.ReadAll(keyFile)
+	keyBytes, err := io.ReadAll(keyFile)
 	if err != nil {
 		return err
 	}
@@ -53,7 +52,7 @@ func gpgKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader) e
 		return err
 	}
 
-	_, err = io.Copy(ioutil.Discard, resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/gpg-key/list/http.go
+++ b/pkg/cmd/gpg-key/list/http.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -60,7 +60,7 @@ func userKeys(httpClient *http.Client, host, userHandle string) ([]gpgKey, error
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/gpg-key/list/list_test.go
+++ b/pkg/cmd/gpg-key/list/list_test.go
@@ -56,12 +56,12 @@ func TestListRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 			opts := tt.opts
-			opts.IO = io
+			opts.IO = ios
 			opts.Config = func() (config.Config, error) { return config.NewBlankConfig(), nil }
 			err := listRun(&opts)
 			if tt.wantErr {

--- a/pkg/cmd/issue/close/close_test.go
+++ b/pkg/cmd/issue/close/close_test.go
@@ -2,7 +2,7 @@ package close
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"testing"
@@ -18,13 +18,13 @@ import (
 )
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -45,8 +45,8 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -3,8 +3,8 @@ package comment
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -20,7 +20,7 @@ import (
 
 func TestNewCmdComment(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "my-body.md")
-	err := ioutil.WriteFile(tmpFile, []byte("a body from file"), 0600)
+	err := os.WriteFile(tmpFile, []byte("a body from file"), 0600)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -141,17 +141,17 @@ func TestNewCmdComment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, stdin, _, _ := iostreams.Test()
-			io.SetStdoutTTY(true)
-			io.SetStdinTTY(true)
-			io.SetStderrTTY(true)
+			ios, stdin, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(true)
+			ios.SetStdinTTY(true)
+			ios.SetStderrTTY(true)
 
 			if tt.stdin != "" {
 				_, _ = stdin.WriteString(tt.stdin)
 			}
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 				Browser:   &cmdutil.TestBrowser{},
 			}
 
@@ -246,10 +246,10 @@ func Test_commentRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		io, _, stdout, stderr := iostreams.Test()
-		io.SetStdoutTTY(true)
-		io.SetStdinTTY(true)
-		io.SetStderrTTY(true)
+		ios, _, stdout, stderr := iostreams.Test()
+		ios.SetStdoutTTY(true)
+		ios.SetStdinTTY(true)
+		ios.SetStderrTTY(true)
 
 		reg := &httpmock.Registry{}
 		defer reg.Verify(t)
@@ -257,7 +257,7 @@ func Test_commentRun(t *testing.T) {
 			tt.httpStubs(t, reg)
 		}
 
-		tt.input.IO = io
+		tt.input.IO = ios
 		tt.input.HttpClient = func() (*http.Client, error) {
 			return &http.Client{Transport: reg}, nil
 		}

--- a/pkg/cmd/issue/delete/delete_test.go
+++ b/pkg/cmd/issue/delete/delete_test.go
@@ -2,7 +2,7 @@ package delete
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"testing"
@@ -19,13 +19,13 @@ import (
 )
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -46,8 +46,8 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -3,8 +3,8 @@ package edit
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,7 +21,7 @@ import (
 
 func TestNewCmdEdit(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "my-body.md")
-	err := ioutil.WriteFile(tmpFile, []byte("a body from file"), 0600)
+	err := os.WriteFile(tmpFile, []byte("a body from file"), 0600)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -204,17 +204,17 @@ func TestNewCmdEdit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, stdin, _, _ := iostreams.Test()
-			io.SetStdoutTTY(true)
-			io.SetStdinTTY(true)
-			io.SetStderrTTY(true)
+			ios, stdin, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(true)
+			ios.SetStdinTTY(true)
+			ios.SetStderrTTY(true)
 
 			if tt.stdin != "" {
 				_, _ = stdin.WriteString(tt.stdin)
 			}
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.input)
@@ -338,10 +338,10 @@ func Test_editRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		io, _, stdout, stderr := iostreams.Test()
-		io.SetStdoutTTY(true)
-		io.SetStdinTTY(true)
-		io.SetStderrTTY(true)
+		ios, _, stdout, stderr := iostreams.Test()
+		ios.SetStdoutTTY(true)
+		ios.SetStdinTTY(true)
+		ios.SetStderrTTY(true)
 
 		reg := &httpmock.Registry{}
 		defer reg.Verify(t)
@@ -350,7 +350,7 @@ func Test_editRun(t *testing.T) {
 		httpClient := func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
 		baseRepo := func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil }
 
-		tt.input.IO = io
+		tt.input.IO = ios
 		tt.input.HttpClient = httpClient
 		tt.input.BaseRepo = baseRepo
 

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -2,7 +2,7 @@ package list
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/cli/cli/v2/api"
@@ -65,7 +65,7 @@ func TestIssueList(t *testing.T) {
 		Variables map[string]interface{}
 	}
 
-	bodyBytes, _ := ioutil.ReadAll(http.Requests[0].Body)
+	bodyBytes, _ := io.ReadAll(http.Requests[0].Body)
 	_ = json.Unmarshal(bodyBytes, &reqBody)
 	if reqLimit := reqBody.Variables["limit"].(float64); reqLimit != 100 {
 		t.Errorf("expected 100, got %v", reqLimit)
@@ -74,7 +74,7 @@ func TestIssueList(t *testing.T) {
 		t.Error("did not expect first request to pass 'endCursor'")
 	}
 
-	bodyBytes, _ = ioutil.ReadAll(http.Requests[1].Body)
+	bodyBytes, _ = io.ReadAll(http.Requests[1].Body)
 	_ = json.Unmarshal(bodyBytes, &reqBody)
 	if endCursor := reqBody.Variables["endCursor"].(string); endCursor != "ENDCURSOR" {
 		t.Errorf("expected %q, got %q", "ENDCURSOR", endCursor)

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -2,7 +2,7 @@ package list
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"testing"
@@ -21,13 +21,13 @@ import (
 )
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -48,8 +48,8 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{
@@ -182,9 +182,9 @@ func TestIssueList_disabledIssues(t *testing.T) {
 }
 
 func TestIssueList_web(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(true)
-	io.SetStderrTTY(true)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(true)
+	ios.SetStderrTTY(true)
 	browser := &cmdutil.TestBrowser{}
 
 	reg := &httpmock.Registry{}
@@ -194,7 +194,7 @@ func TestIssueList_web(t *testing.T) {
 	defer cmdTeardown(t)
 
 	err := listRun(&ListOptions{
-		IO:      io,
+		IO:      ios,
 		Browser: browser,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: reg}, nil

--- a/pkg/cmd/issue/reopen/reopen_test.go
+++ b/pkg/cmd/issue/reopen/reopen_test.go
@@ -2,7 +2,7 @@ package reopen
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"testing"
@@ -18,13 +18,13 @@ import (
 )
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -45,8 +45,8 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{

--- a/pkg/cmd/issue/status/status_test.go
+++ b/pkg/cmd/issue/status/status_test.go
@@ -2,7 +2,7 @@ package status
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"testing"
@@ -17,13 +17,13 @@ import (
 )
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -44,8 +44,8 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{

--- a/pkg/cmd/issue/transfer/transfer_test.go
+++ b/pkg/cmd/issue/transfer/transfer_test.go
@@ -2,7 +2,7 @@ package transfer
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -17,10 +17,10 @@ import (
 )
 
 func runCommand(rt http.RoundTripper, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -32,7 +32,7 @@ func runCommand(rt http.RoundTripper, cli string) (*test.CmdOut, error) {
 		},
 	}
 
-	io.SetStdoutTTY(true)
+	ios.SetStdoutTTY(true)
 
 	cmd := NewCmdTransfer(factory, nil)
 
@@ -43,8 +43,8 @@ func runCommand(rt http.RoundTripper, cli string) (*test.CmdOut, error) {
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 
@@ -124,9 +124,9 @@ func Test_transferRunSuccessfulIssueTransfer(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`query RepositoryInfo\b`),
 		httpmock.StringResponse(`
-				{ "data": { "repository": { 
+				{ "data": { "repository": {
 						"id": "dest-id",
-						"name": "REPO1", 
+						"name": "REPO1",
 						"owner": { "login": "OWNER1" },
 						"viewerPermission": "WRITE",
 						"hasIssuesEnabled": true

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -3,7 +3,7 @@ package view
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -20,13 +20,13 @@ import (
 )
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -47,8 +47,8 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{
@@ -58,9 +58,9 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 }
 
 func TestIssueView_web(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(true)
-	io.SetStderrTTY(true)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(true)
+	ios.SetStderrTTY(true)
 	browser := &cmdutil.TestBrowser{}
 
 	reg := &httpmock.Registry{}
@@ -79,7 +79,7 @@ func TestIssueView_web(t *testing.T) {
 	defer cmdTeardown(t)
 
 	err := viewRun(&ViewOptions{
-		IO:      io,
+		IO:      ios,
 		Browser: browser,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: reg}, nil
@@ -223,10 +223,10 @@ func TestIssueView_tty_Preview(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(true)
-			io.SetStdinTTY(true)
-			io.SetStderrTTY(true)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(true)
+			ios.SetStdinTTY(true)
+			ios.SetStderrTTY(true)
 
 			httpReg := &httpmock.Registry{}
 			defer httpReg.Verify(t)
@@ -234,7 +234,7 @@ func TestIssueView_tty_Preview(t *testing.T) {
 			httpReg.Register(httpmock.GraphQL(`query IssueByNumber\b`), httpmock.FileResponse(tc.fixture))
 
 			opts := ViewOptions{
-				IO: io,
+				IO: ios,
 				Now: func() time.Time {
 					t, _ := time.Parse(time.RFC822, "03 Nov 20 15:04 UTC")
 					return t

--- a/pkg/cmd/label/create_test.go
+++ b/pkg/cmd/label/create_test.go
@@ -3,7 +3,7 @@ package label
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -53,9 +53,9 @@ func TestNewCmdCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 			argv, err := shlex.Split(tt.input)
 			assert.NoError(t, err)
@@ -144,11 +144,11 @@ func TestCreateRun(t *testing.T) {
 			tt.opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: reg}, nil
 			}
-			io, _, stdout, _ := iostreams.Test()
-			io.SetStdoutTTY(tt.tty)
-			io.SetStdinTTY(tt.tty)
-			io.SetStderrTTY(tt.tty)
-			tt.opts.IO = io
+			ios, _, stdout, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.tty)
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStderrTTY(tt.tty)
+			tt.opts.IO = ios
 			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 				return ghrepo.New("OWNER", "REPO"), nil
 			}
@@ -157,7 +157,7 @@ func TestCreateRun(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantStdout, stdout.String())
 
-			bodyBytes, _ := ioutil.ReadAll(reg.Requests[0].Body)
+			bodyBytes, _ := io.ReadAll(reg.Requests[0].Body)
 			reqBody := map[string]string{}
 			err = json.Unmarshal(bodyBytes, &reqBody)
 			assert.NoError(t, err)

--- a/pkg/cmd/label/list_test.go
+++ b/pkg/cmd/label/list_test.go
@@ -46,9 +46,9 @@ func TestNewCmdList(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 			argv, err := shlex.Split(tt.input)
 			assert.NoError(t, err)
@@ -192,11 +192,11 @@ func TestListRun(t *testing.T) {
 			tt.opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: reg}, nil
 			}
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.tty)
-			io.SetStdinTTY(tt.tty)
-			io.SetStderrTTY(tt.tty)
-			tt.opts.IO = io
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.tty)
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStderrTTY(tt.tty)
+			tt.opts.IO = ios
 			tt.opts.Browser = &cmdutil.TestBrowser{}
 			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 				return ghrepo.New("OWNER", "REPO"), nil

--- a/pkg/cmd/pr/checkout/checkout_test.go
+++ b/pkg/cmd/pr/checkout/checkout_test.go
@@ -163,7 +163,7 @@ func Test_checkoutRun(t *testing.T) {
 			opts := tt.opts
 
 			ios, _, stdout, stderr := iostreams.Test()
-			ios.SetStdinTTY(true)
+			opts.IO = ios
 			httpReg := &httpmock.Registry{}
 			defer httpReg.Verify(t)
 			if tt.httpStubs != nil {

--- a/pkg/cmd/pr/checkout/checkout_test.go
+++ b/pkg/cmd/pr/checkout/checkout_test.go
@@ -3,7 +3,7 @@ package checkout
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -162,9 +162,8 @@ func Test_checkoutRun(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := tt.opts
 
-			io, _, stdout, stderr := iostreams.Test()
-			opts.IO = io
-
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdinTTY(true)
 			httpReg := &httpmock.Registry{}
 			defer httpReg.Verify(t)
 			if tt.httpStubs != nil {
@@ -211,10 +210,10 @@ func Test_checkoutRun(t *testing.T) {
 /** LEGACY TESTS **/
 
 func runCommand(rt http.RoundTripper, remotes context.Remotes, branch string, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -246,8 +245,8 @@ func runCommand(rt http.RoundTripper, remotes context.Remotes, branch string, cl
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{

--- a/pkg/cmd/pr/checks/checks_test.go
+++ b/pkg/cmd/pr/checks/checks_test.go
@@ -67,9 +67,9 @@ func TestNewCmdChecks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -249,16 +249,16 @@ func TestChecksRun_web(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			browser := &cmdutil.TestBrowser{}
 
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tc.isTTY)
-			io.SetStdinTTY(tc.isTTY)
-			io.SetStderrTTY(tc.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tc.isTTY)
+			ios.SetStdinTTY(tc.isTTY)
+			ios.SetStderrTTY(tc.isTTY)
 
 			_, teardown := run.Stub()
 			defer teardown(t)
 
 			err := checksRunWebMode(&ChecksOptions{
-				IO:          io,
+				IO:          ios,
 				Browser:     browser,
 				WebMode:     true,
 				SelectorArg: "123",

--- a/pkg/cmd/pr/close/close_test.go
+++ b/pkg/cmd/pr/close/close_test.go
@@ -2,7 +2,7 @@ package close
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -59,13 +59,13 @@ func stubPR(repo, prHead string) (ghrepo.Interface, *api.PullRequest) {
 }
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -83,8 +83,8 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -3,8 +3,8 @@ package comment
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,7 +21,7 @@ import (
 
 func TestNewCmdComment(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "my-body.md")
-	err := ioutil.WriteFile(tmpFile, []byte("a body from file"), 0600)
+	err := os.WriteFile(tmpFile, []byte("a body from file"), 0600)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -162,17 +162,17 @@ func TestNewCmdComment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, stdin, _, _ := iostreams.Test()
-			io.SetStdoutTTY(true)
-			io.SetStdinTTY(true)
-			io.SetStderrTTY(true)
+			ios, stdin, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(true)
+			ios.SetStdinTTY(true)
+			ios.SetStderrTTY(true)
 
 			if tt.stdin != "" {
 				_, _ = stdin.WriteString(tt.stdin)
 			}
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 				Browser:   &cmdutil.TestBrowser{},
 			}
 
@@ -267,10 +267,10 @@ func Test_commentRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		io, _, stdout, stderr := iostreams.Test()
-		io.SetStdoutTTY(true)
-		io.SetStdinTTY(true)
-		io.SetStderrTTY(true)
+		ios, _, stdout, stderr := iostreams.Test()
+		ios.SetStdoutTTY(true)
+		ios.SetStdinTTY(true)
+		ios.SetStderrTTY(true)
 
 		reg := &httpmock.Registry{}
 		defer reg.Verify(t)
@@ -280,7 +280,7 @@ func Test_commentRun(t *testing.T) {
 
 		httpClient := func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
 
-		tt.input.IO = io
+		tt.input.IO = ios
 		tt.input.HttpClient = httpClient
 		tt.input.RetrieveCommentable = func() (shared.Commentable, ghrepo.Interface, error) {
 			return &api.PullRequest{

--- a/pkg/cmd/pr/diff/diff_test.go
+++ b/pkg/cmd/pr/diff/diff_test.go
@@ -194,7 +194,7 @@ func Test_diffRun(t *testing.T) {
 			}
 
 			ios, _, stdout, stderr := iostreams.Test()
-			ios.SetStdinTTY(true)
+			opts.IO = ios
 			finder := shared.NewMockFinder("123", pr, ghrepo.New("OWNER", "REPO"))
 			finder.ExpectFields([]string{"number"})
 			opts.Finder = finder

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -3,8 +3,8 @@ package edit
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -21,7 +21,7 @@ import (
 
 func TestNewCmdEdit(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "my-body.md")
-	err := ioutil.WriteFile(tmpFile, []byte("a body from file"), 0600)
+	err := os.WriteFile(tmpFile, []byte("a body from file"), 0600)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -255,17 +255,17 @@ func TestNewCmdEdit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, stdin, _, _ := iostreams.Test()
-			io.SetStdoutTTY(true)
-			io.SetStdinTTY(true)
-			io.SetStderrTTY(true)
+			ios, stdin, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(true)
+			ios.SetStdinTTY(true)
+			ios.SetStderrTTY(true)
 
 			if tt.stdin != "" {
 				_, _ = stdin.WriteString(tt.stdin)
 			}
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.input)
@@ -450,10 +450,10 @@ func Test_editRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		io, _, stdout, stderr := iostreams.Test()
-		io.SetStdoutTTY(true)
-		io.SetStdinTTY(true)
-		io.SetStderrTTY(true)
+		ios, _, stdout, stderr := iostreams.Test()
+		ios.SetStdoutTTY(true)
+		ios.SetStdinTTY(true)
+		ios.SetStderrTTY(true)
 
 		reg := &httpmock.Registry{}
 		defer reg.Verify(t)
@@ -461,7 +461,7 @@ func Test_editRun(t *testing.T) {
 
 		httpClient := func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
 
-		tt.input.IO = io
+		tt.input.IO = ios
 		tt.input.HttpClient = httpClient
 
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -2,7 +2,7 @@ package list
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -19,14 +19,14 @@ import (
 )
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	browser := &cmdutil.TestBrowser{}
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		Browser:   browser,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
@@ -45,8 +45,8 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{

--- a/pkg/cmd/pr/ready/ready_test.go
+++ b/pkg/cmd/pr/ready/ready_test.go
@@ -2,7 +2,7 @@ package ready
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -51,13 +51,13 @@ func Test_NewCmdReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			var opts *ReadyOptions
@@ -72,8 +72,8 @@ func Test_NewCmdReady(t *testing.T) {
 			cmd.SetArgs(argv)
 
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantErr != "" {
@@ -89,13 +89,13 @@ func Test_NewCmdReady(t *testing.T) {
 }
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -110,8 +110,8 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{

--- a/pkg/cmd/pr/reopen/reopen_test.go
+++ b/pkg/cmd/pr/reopen/reopen_test.go
@@ -2,7 +2,7 @@ package reopen
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -18,13 +18,13 @@ import (
 )
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -39,8 +39,8 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{

--- a/pkg/cmd/pr/shared/preserve_test.go
+++ b/pkg/cmd/pr/shared/preserve_test.go
@@ -3,7 +3,8 @@ package shared
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -77,25 +78,25 @@ func Test_PreserveInput(t *testing.T) {
 				tt.state = &IssueMetadataState{}
 			}
 
-			io, _, _, errOut := iostreams.Test()
+			ios, _, _, errOut := iostreams.Test()
 
-			tf, tferr := ioutil.TempFile(tempDir, "testfile*")
+			tf, tferr := os.CreateTemp(tempDir, "testfile*")
 			assert.NoError(t, tferr)
 			defer tf.Close()
 
-			io.TempFileOverride = tf
+			ios.TempFileOverride = tf
 
 			var err error
 			if tt.err {
 				err = errors.New("error during creation")
 			}
 
-			PreserveInput(io, tt.state, &err)()
+			PreserveInput(ios, tt.state, &err)()
 
 			_, err = tf.Seek(0, 0)
 			assert.NoError(t, err)
 
-			data, err := ioutil.ReadAll(tf)
+			data, err := io.ReadAll(tf)
 			assert.NoError(t, err)
 
 			if tt.wantPreservation {

--- a/pkg/cmd/pr/shared/survey_test.go
+++ b/pkg/cmd/pr/shared/survey_test.go
@@ -19,7 +19,7 @@ func (mf *metadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput) (*api.
 }
 
 func TestMetadataSurvey_selectAll(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 
 	repo := ghrepo.New("OWNER", "REPO")
 
@@ -81,7 +81,7 @@ func TestMetadataSurvey_selectAll(t *testing.T) {
 	state := &IssueMetadataState{
 		Assignees: []string{"hubot"},
 	}
-	err := MetadataSurvey(io, repo, fetcher, state)
+	err := MetadataSurvey(ios, repo, fetcher, state)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())
@@ -95,7 +95,7 @@ func TestMetadataSurvey_selectAll(t *testing.T) {
 }
 
 func TestMetadataSurvey_keepExisting(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 
 	repo := ghrepo.New("OWNER", "REPO")
 
@@ -138,7 +138,7 @@ func TestMetadataSurvey_keepExisting(t *testing.T) {
 	state := &IssueMetadataState{
 		Assignees: []string{"hubot"},
 	}
-	err := MetadataSurvey(io, repo, fetcher, state)
+	err := MetadataSurvey(ios, repo, fetcher, state)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())

--- a/pkg/cmd/pr/shared/templates_test.go
+++ b/pkg/cmd/pr/shared/templates_test.go
@@ -1,7 +1,6 @@
 package shared
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,7 +16,7 @@ func TestTemplateManager_hasAPI(t *testing.T) {
 	rootDir := t.TempDir()
 	legacyTemplateFile := filepath.Join(rootDir, ".github", "ISSUE_TEMPLATE.md")
 	_ = os.MkdirAll(filepath.Dir(legacyTemplateFile), 0755)
-	_ = ioutil.WriteFile(legacyTemplateFile, []byte("LEGACY"), 0644)
+	_ = os.WriteFile(legacyTemplateFile, []byte("LEGACY"), 0644)
 
 	tr := httpmock.Registry{}
 	httpClient := &http.Client{Transport: &tr}
@@ -79,7 +78,7 @@ func TestTemplateManager_hasAPI_PullRequest(t *testing.T) {
 	rootDir := t.TempDir()
 	legacyTemplateFile := filepath.Join(rootDir, ".github", "PULL_REQUEST_TEMPLATE.md")
 	_ = os.MkdirAll(filepath.Dir(legacyTemplateFile), 0755)
-	_ = ioutil.WriteFile(legacyTemplateFile, []byte("LEGACY"), 0644)
+	_ = os.WriteFile(legacyTemplateFile, []byte("LEGACY"), 0644)
 
 	tr := httpmock.Registry{}
 	httpClient := &http.Client{Transport: &tr}

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -2,7 +2,7 @@ package status
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -20,13 +20,13 @@ import (
 )
 
 func runCommand(rt http.RoundTripper, branch string, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -62,8 +62,8 @@ func runCommand(rt http.RoundTripper, branch string, isTTY bool, cli string) (*t
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -75,13 +75,13 @@ func Test_NewCmdView(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			var opts *ViewOptions
@@ -96,8 +96,8 @@ func Test_NewCmdView(t *testing.T) {
 			cmd.SetArgs(argv)
 
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantErr != "" {
@@ -113,14 +113,14 @@ func Test_NewCmdView(t *testing.T) {
 }
 
 func runCommand(rt http.RoundTripper, branch string, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	browser := &cmdutil.TestBrowser{}
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		Browser:   browser,
 	}
 
@@ -133,8 +133,8 @@ func runCommand(rt http.RoundTripper, branch string, isTTY bool, cli string) (*t
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{

--- a/pkg/cmd/release/create/http.go
+++ b/pkg/cmd/release/create/http.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
@@ -109,7 +108,7 @@ func generateReleaseNotes(httpClient *http.Client, repo ghrepo.Interface, params
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +144,7 @@ func createRelease(httpClient *http.Client, repo ghrepo.Interface, params map[st
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +181,7 @@ func publishRelease(httpClient *http.Client, releaseURL string, discussionCatego
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/release/delete-asset/delete_asset_test.go
+++ b/pkg/cmd/release/delete-asset/delete_asset_test.go
@@ -2,7 +2,7 @@ package deleteasset
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -58,13 +58,13 @@ func Test_NewCmdDeleteAsset(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			var opts *DeleteAssetOptions
@@ -78,8 +78,8 @@ func Test_NewCmdDeleteAsset(t *testing.T) {
 			cmd.SetArgs(argv)
 
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantErr != "" {
@@ -130,10 +130,10 @@ func Test_deleteAssetRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			fakeHTTP := &httpmock.Registry{}
 			fakeHTTP.Register(httpmock.REST("GET", "repos/OWNER/REPO/releases/tags/v1.2.3"), httpmock.StringResponse(`{
@@ -150,7 +150,7 @@ func Test_deleteAssetRun(t *testing.T) {
 			}`))
 			fakeHTTP.Register(httpmock.REST("DELETE", "repos/OWNER/REPO/releases/assets/1"), httpmock.StatusStringResponse(204, ""))
 
-			tt.opts.IO = io
+			tt.opts.IO = ios
 			tt.opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: fakeHTTP}, nil
 			}

--- a/pkg/cmd/release/delete/delete_test.go
+++ b/pkg/cmd/release/delete/delete_test.go
@@ -2,7 +2,7 @@ package delete
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -51,13 +51,13 @@ func Test_NewCmdDelete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			var opts *DeleteOptions
@@ -72,8 +72,8 @@ func Test_NewCmdDelete(t *testing.T) {
 			cmd.SetArgs(argv)
 
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantErr != "" {
@@ -124,10 +124,10 @@ func Test_deleteRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			fakeHTTP := &httpmock.Registry{}
 			fakeHTTP.Register(httpmock.REST("GET", "repos/OWNER/REPO/releases/tags/v1.2.3"), httpmock.StringResponse(`{
@@ -137,7 +137,7 @@ func Test_deleteRun(t *testing.T) {
 			}`))
 			fakeHTTP.Register(httpmock.REST("DELETE", "repos/OWNER/REPO/releases/23456"), httpmock.StatusStringResponse(204, ""))
 
-			tt.opts.IO = io
+			tt.opts.IO = ios
 			tt.opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: fakeHTTP}, nil
 			}

--- a/pkg/cmd/release/download/download_test.go
+++ b/pkg/cmd/release/download/download_test.go
@@ -2,7 +2,7 @@ package download
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -113,13 +113,13 @@ func Test_NewCmdDownload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			var opts *DownloadOptions
@@ -134,8 +134,8 @@ func Test_NewCmdDownload(t *testing.T) {
 			cmd.SetArgs(argv)
 
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantErr != "" {
@@ -244,10 +244,10 @@ func Test_downloadRun(t *testing.T) {
 			tempDir := t.TempDir()
 			tt.opts.Destination = filepath.Join(tempDir, tt.opts.Destination)
 
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			fakeHTTP := &httpmock.Registry{}
 			fakeHTTP.Register(httpmock.REST("GET", "repos/OWNER/REPO/releases/tags/v1.2.3"), httpmock.StringResponse(`{
@@ -286,7 +286,7 @@ func Test_downloadRun(t *testing.T) {
 				),
 			)
 
-			tt.opts.IO = io
+			tt.opts.IO = ios
 			tt.opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: fakeHTTP}, nil
 			}

--- a/pkg/cmd/release/edit/http.go
+++ b/pkg/cmd/release/edit/http.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/release/shared"
-	"io/ioutil"
-	"net/http"
 )
 
 func editRelease(httpClient *http.Client, repo ghrepo.Interface, releaseID int64, params map[string]interface{}) (*shared.Release, error) {
@@ -38,7 +39,7 @@ func editRelease(httpClient *http.Client, repo ghrepo.Interface, releaseID int64
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -3,7 +3,7 @@ package list
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -37,13 +37,13 @@ func Test_NewCmdList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			var opts *ListOptions
@@ -58,8 +58,8 @@ func Test_NewCmdList(t *testing.T) {
 			cmd.SetArgs(argv)
 
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantErr != "" {
@@ -117,10 +117,10 @@ func Test_listRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			createdAt := frozenTime
 			if tt.isTTY {
@@ -170,7 +170,7 @@ func Test_listRun(t *testing.T) {
 				]
 			} } } }`, createdAt.Format(time.RFC3339))))
 
-			tt.opts.IO = io
+			tt.opts.IO = ios
 			tt.opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: fakeHTTP}, nil
 			}

--- a/pkg/cmd/release/shared/fetch.go
+++ b/pkg/cmd/release/shared/fetch.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -141,7 +141,7 @@ func FetchRelease(httpClient *http.Client, baseRepo ghrepo.Interface, tagName st
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func FetchLatestRelease(httpClient *http.Client, baseRepo ghrepo.Interface) (*Re
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func FindDraftRelease(httpClient *http.Client, baseRepo ghrepo.Interface, tagNam
 			return nil, api.HandleHTTPError(resp)
 		}
 
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/release/shared/upload.go
+++ b/pkg/cmd/release/shared/upload.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/url"
@@ -183,7 +182,7 @@ func uploadAsset(httpClient *http.Client, uploadURL string, asset AssetForUpload
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/release/view/view_test.go
+++ b/pkg/cmd/release/view/view_test.go
@@ -3,7 +3,7 @@ package view
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -56,13 +56,13 @@ func Test_NewCmdView(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			var opts *ViewOptions
@@ -77,8 +77,8 @@ func Test_NewCmdView(t *testing.T) {
 			cmd.SetArgs(argv)
 
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantErr != "" {
@@ -180,10 +180,10 @@ func Test_viewRun(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			path := "repos/OWNER/REPO/releases/tags/v1.2.3"
 			if tt.opts.TagName == "" {
@@ -205,7 +205,7 @@ func Test_viewRun(t *testing.T) {
 				]
 			}`, tt.releasedAt.Format(time.RFC3339))))
 
-			tt.opts.IO = io
+			tt.opts.IO = ios
 			tt.opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: fakeHTTP}, nil
 			}

--- a/pkg/cmd/repo/archive/archive_test.go
+++ b/pkg/cmd/repo/archive/archive_test.go
@@ -37,9 +37,9 @@ func TestNewCmdArchive(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 			argv, err := shlex.Split(tt.input)
 			assert.NoError(t, err)
@@ -137,8 +137,8 @@ func Test_ArchiveRun(t *testing.T) {
 		tt.opts.HttpClient = func() (*http.Client, error) {
 			return &http.Client{Transport: reg}, nil
 		}
-		io, _, stdout, stderr := iostreams.Test()
-		tt.opts.IO = io
+		ios, _, stdout, stderr := iostreams.Test()
+		tt.opts.IO = ios
 
 		//nolint:staticcheck // SA1019: prompt.InitAskStubber is deprecated: use NewAskStubber
 		q, teardown := prompt.InitAskStubber()
@@ -149,8 +149,8 @@ func Test_ArchiveRun(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			defer reg.Verify(t)
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			err := archiveRun(&tt.opts)
 			assert.NoError(t, err)

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -60,8 +60,8 @@ func TestNewCmdClone(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			io, stdin, stdout, stderr := iostreams.Test()
-			fac := &cmdutil.Factory{IOStreams: io}
+			ios, stdin, stdout, stderr := iostreams.Test()
+			fac := &cmdutil.Factory{IOStreams: ios}
 
 			var opts *CloneOptions
 			cmd := NewCmdClone(fac, func(co *CloneOptions) error {
@@ -95,9 +95,9 @@ func TestNewCmdClone(t *testing.T) {
 }
 
 func runCloneCommand(httpClient *http.Client, cli string) (*test.CmdOut, error) {
-	io, stdin, stdout, stderr := iostreams.Test()
+	ios, stdin, stdout, stderr := iostreams.Test()
 	fac := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return httpClient, nil
 		},

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -105,12 +105,12 @@ func TestNewCmdCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			var opts *CreateOptions
@@ -460,10 +460,10 @@ func Test_createRun(t *testing.T) {
 			tt.execStubs(cs)
 		}
 
-		io, _, stdout, stderr := iostreams.Test()
-		io.SetStdinTTY(tt.tty)
-		io.SetStdoutTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, stderr := iostreams.Test()
+		ios.SetStdinTTY(tt.tty)
+		ios.SetStdoutTTY(tt.tty)
+		tt.opts.IO = ios
 
 		t.Run(tt.name, func(t *testing.T) {
 			defer reg.Verify(t)

--- a/pkg/cmd/repo/delete/delete_test.go
+++ b/pkg/cmd/repo/delete/delete_test.go
@@ -45,11 +45,11 @@ func TestNewCmdDelete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 			argv, err := shlex.Split(tt.input)
 			assert.NoError(t, err)
@@ -169,10 +169,10 @@ func Test_deleteRun(t *testing.T) {
 			return &http.Client{Transport: reg}, nil
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdinTTY(tt.tty)
-		io.SetStdoutTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdinTTY(tt.tty)
+		ios.SetStdoutTTY(tt.tty)
+		tt.opts.IO = ios
 
 		t.Run(tt.name, func(t *testing.T) {
 			defer reg.Verify(t)

--- a/pkg/cmd/repo/deploy-key/add/add_test.go
+++ b/pkg/cmd/repo/deploy-key/add/add_test.go
@@ -52,11 +52,11 @@ func Test_addRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, stdin, stdout, stderr := iostreams.Test()
+			ios, stdin, stdout, stderr := iostreams.Test()
 			stdin.WriteString(tt.stdin)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			reg := &httpmock.Registry{}
 			if tt.httpStubs != nil {
@@ -64,7 +64,7 @@ func Test_addRun(t *testing.T) {
 			}
 
 			opts := tt.opts
-			opts.IO = io
+			opts.IO = ios
 			opts.BaseRepo = func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil }
 			opts.HTTPClient = func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
 

--- a/pkg/cmd/repo/deploy-key/add/http.go
+++ b/pkg/cmd/repo/deploy-key/add/http.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
@@ -17,7 +16,7 @@ func uploadDeployKey(httpClient *http.Client, repo ghrepo.Interface, keyFile io.
 	path := fmt.Sprintf("repos/%s/%s/keys", repo.RepoOwner(), repo.RepoName())
 	url := ghinstance.RESTPrefix(repo.RepoHost()) + path
 
-	keyBytes, err := ioutil.ReadAll(keyFile)
+	keyBytes, err := io.ReadAll(keyFile)
 	if err != nil {
 		return err
 	}
@@ -48,7 +47,7 @@ func uploadDeployKey(httpClient *http.Client, repo ghrepo.Interface, keyFile io.
 		return api.HandleHTTPError(resp)
 	}
 
-	_, err = io.Copy(ioutil.Discard, resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/deploy-key/delete/delete_test.go
+++ b/pkg/cmd/repo/deploy-key/delete/delete_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func Test_deleteRun(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdinTTY(false)
-	io.SetStdoutTTY(true)
-	io.SetStderrTTY(true)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdinTTY(false)
+	ios.SetStdoutTTY(true)
+	ios.SetStderrTTY(true)
 
 	tr := httpmock.Registry{}
 	defer tr.Verify(t)
@@ -24,7 +24,7 @@ func Test_deleteRun(t *testing.T) {
 		httpmock.StringResponse(`{}`))
 
 	err := deleteRun(&DeleteOptions{
-		IO: io,
+		IO: ios,
 		HTTPClient: func() (*http.Client, error) {
 			return &http.Client{Transport: &tr}, nil
 		},

--- a/pkg/cmd/repo/deploy-key/delete/http.go
+++ b/pkg/cmd/repo/deploy-key/delete/http.go
@@ -3,7 +3,6 @@ package delete
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
@@ -30,7 +29,7 @@ func deleteDeployKey(httpClient *http.Client, repo ghrepo.Interface, id string) 
 		return api.HandleHTTPError(resp)
 	}
 
-	_, err = io.Copy(ioutil.Discard, resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/deploy-key/list/http.go
+++ b/pkg/cmd/repo/deploy-key/list/http.go
@@ -3,7 +3,7 @@ package list
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -38,7 +38,7 @@ func repoKeys(httpClient *http.Client, repo ghrepo.Interface) ([]deployKey, erro
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/repo/deploy-key/list/list_test.go
+++ b/pkg/cmd/repo/deploy-key/list/list_test.go
@@ -100,10 +100,10 @@ func TestListRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			reg := &httpmock.Registry{}
 			if tt.httpStubs != nil {
@@ -111,7 +111,7 @@ func TestListRun(t *testing.T) {
 			}
 
 			opts := tt.opts
-			opts.IO = io
+			opts.IO = ios
 			opts.BaseRepo = func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil }
 			opts.HTTPClient = func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
 

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -493,7 +492,7 @@ func setTopics(ctx context.Context, httpClient *http.Client, repo ghrepo.Interfa
 	}
 
 	if res.Body != nil {
-		_, _ = io.Copy(ioutil.Discard, res.Body)
+		_, _ = io.Copy(io.Discard, res.Body)
 	}
 
 	return nil

--- a/pkg/cmd/repo/edit/edit_test.go
+++ b/pkg/cmd/repo/edit/edit_test.go
@@ -3,7 +3,7 @@ package edit
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -39,13 +39,13 @@ func TestNewCmdEdit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(true)
-			io.SetStdinTTY(true)
-			io.SetStderrTTY(true)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(true)
+			ios.SetStdinTTY(true)
+			ios.SetStderrTTY(true)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 				BaseRepo: func() (ghrepo.Interface, error) {
 					return ghrepo.New("OWNER", "REPO"), nil
 				},
@@ -66,8 +66,8 @@ func TestNewCmdEdit(t *testing.T) {
 
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantErr != "" {
@@ -132,10 +132,10 @@ func Test_editRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(true)
-			io.SetStdinTTY(true)
-			io.SetStderrTTY(true)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(true)
+			ios.SetStdinTTY(true)
+			ios.SetStderrTTY(true)
 
 			httpReg := &httpmock.Registry{}
 			defer httpReg.Verify(t)
@@ -145,8 +145,7 @@ func Test_editRun(t *testing.T) {
 
 			opts := &tt.opts
 			opts.HTTPClient = &http.Client{Transport: httpReg}
-			opts.IO = io
-
+			ios.SetStdinTTY(true)
 			err := editRun(context.Background(), opts)
 			if tt.wantsErr == "" {
 				require.NoError(t, err)
@@ -306,10 +305,10 @@ func Test_editRun_interactive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(true)
-			io.SetStdinTTY(true)
-			io.SetStderrTTY(true)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(true)
+			ios.SetStdinTTY(true)
+			ios.SetStderrTTY(true)
 
 			httpReg := &httpmock.Registry{}
 			defer httpReg.Verify(t)
@@ -319,8 +318,7 @@ func Test_editRun_interactive(t *testing.T) {
 
 			opts := &tt.opts
 			opts.HTTPClient = &http.Client{Transport: httpReg}
-			opts.IO = io
-
+			ios.SetStdinTTY(true)
 			as := prompt.NewAskStubber(t)
 			if tt.askStubs != nil {
 				tt.askStubs(as)

--- a/pkg/cmd/repo/edit/edit_test.go
+++ b/pkg/cmd/repo/edit/edit_test.go
@@ -145,7 +145,7 @@ func Test_editRun(t *testing.T) {
 
 			opts := &tt.opts
 			opts.HTTPClient = &http.Client{Transport: httpReg}
-			ios.SetStdinTTY(true)
+			opts.IO = ios
 			err := editRun(context.Background(), opts)
 			if tt.wantsErr == "" {
 				require.NoError(t, err)
@@ -318,7 +318,7 @@ func Test_editRun_interactive(t *testing.T) {
 
 			opts := &tt.opts
 			opts.HTTPClient = &http.Client{Transport: httpReg}
-			ios.SetStdinTTY(true)
+			opts.IO = ios
 			as := prompt.NewAskStubber(t)
 			if tt.askStubs != nil {
 				tt.askStubs(as)

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -2,7 +2,7 @@ package fork
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -146,14 +146,14 @@ func TestNewCmdFork(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
-			io.SetStdoutTTY(tt.tty)
-			io.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
+			ios.SetStdinTTY(tt.tty)
 
 			argv, err := shlex.Split(tt.cli)
 			assert.NoError(t, err)
@@ -438,7 +438,7 @@ func TestRepoFork(t *testing.T) {
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/forks"),
 					func(req *http.Request) (*http.Response, error) {
-						bb, err := ioutil.ReadAll(req.Body)
+						bb, err := io.ReadAll(req.Body)
 						if err != nil {
 							return nil, err
 						}
@@ -446,7 +446,7 @@ func TestRepoFork(t *testing.T) {
 						return &http.Response{
 							Request:    req,
 							StatusCode: 200,
-							Body:       ioutil.NopCloser(bytes.NewBufferString(`{"name":"REPO", "owner":{"login":"gamehendge"}}`)),
+							Body:       io.NopCloser(bytes.NewBufferString(`{"name":"REPO", "owner":{"login":"gamehendge"}}`)),
 						}, nil
 					})
 			},
@@ -644,11 +644,11 @@ func TestRepoFork(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		io, _, stdout, stderr := iostreams.Test()
-		io.SetStdinTTY(tt.tty)
-		io.SetStdoutTTY(tt.tty)
-		io.SetStderrTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, stderr := iostreams.Test()
+		ios.SetStdinTTY(tt.tty)
+		ios.SetStdoutTTY(tt.tty)
+		ios.SetStderrTTY(tt.tty)
+		tt.opts.IO = ios
 
 		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 			return ghrepo.New("OWNER", "REPO"), nil

--- a/pkg/cmd/repo/garden/http.go
+++ b/pkg/cmd/repo/garden/http.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -91,7 +91,7 @@ func getResponse(client *http.Client, host, path string, data interface{}) (*htt
 		return resp, nil
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/repo/list/http_test.go
+++ b/pkg/cmd/repo/list/http_test.go
@@ -2,7 +2,7 @@ package list
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -23,7 +23,7 @@ func Test_listReposWithLanguage(t *testing.T) {
 	reg.Register(
 		httpmock.GraphQL(`query RepositoryListSearch\b`),
 		func(req *http.Request) (*http.Response, error) {
-			jsonData, err := ioutil.ReadAll(req.Body)
+			jsonData, err := io.ReadAll(req.Body)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -2,7 +2,7 @@ package list
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -254,13 +254,13 @@ func TestNewCmdList(t *testing.T) {
 }
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(isTTY)
-	io.SetStdinTTY(isTTY)
-	io.SetStderrTTY(isTTY)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
 
 	factory := &cmdutil.Factory{
-		IOStreams: io,
+		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
@@ -278,8 +278,8 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	cmd.SetArgs(argv)
 
 	cmd.SetIn(&bytes.Buffer{})
-	cmd.SetOut(ioutil.Discard)
-	cmd.SetErr(ioutil.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 
 	_, err = cmd.ExecuteC()
 	return &test.CmdOut{
@@ -289,10 +289,10 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 }
 
 func TestRepoList_nontty(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(false)
-	io.SetStdinTTY(false)
-	io.SetStderrTTY(false)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(false)
+	ios.SetStdinTTY(false)
+	ios.SetStderrTTY(false)
 
 	httpReg := &httpmock.Registry{}
 	defer httpReg.Verify(t)
@@ -303,7 +303,7 @@ func TestRepoList_nontty(t *testing.T) {
 	)
 
 	opts := ListOptions{
-		IO: io,
+		IO: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: httpReg}, nil
 		},
@@ -330,10 +330,10 @@ func TestRepoList_nontty(t *testing.T) {
 }
 
 func TestRepoList_tty(t *testing.T) {
-	io, _, stdout, stderr := iostreams.Test()
-	io.SetStdoutTTY(true)
-	io.SetStdinTTY(true)
-	io.SetStderrTTY(true)
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(true)
+	ios.SetStdinTTY(true)
+	ios.SetStderrTTY(true)
 
 	httpReg := &httpmock.Registry{}
 	defer httpReg.Verify(t)
@@ -344,7 +344,7 @@ func TestRepoList_tty(t *testing.T) {
 	)
 
 	opts := ListOptions{
-		IO: io,
+		IO: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: httpReg}, nil
 		},

--- a/pkg/cmd/repo/rename/rename_test.go
+++ b/pkg/cmd/repo/rename/rename_test.go
@@ -73,11 +73,11 @@ func TestNewCmdRename(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.input)
@@ -254,10 +254,10 @@ func TestRenameRun(t *testing.T) {
 			return &http.Client{Transport: reg}, nil
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdinTTY(tt.tty)
-		io.SetStdoutTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdinTTY(tt.tty)
+		ios.SetStdoutTTY(tt.tty)
+		tt.opts.IO = ios
 
 		t.Run(tt.name, func(t *testing.T) {
 			defer reg.Verify(t)

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -2,7 +2,7 @@ package sync
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -66,11 +66,11 @@ func TestNewCmdSync(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 			argv, err := shlex.Split(tt.input)
 			assert.NoError(t, err)
@@ -417,7 +417,7 @@ func Test_SyncRun(t *testing.T) {
 							StatusCode: 422,
 							Request:    req,
 							Header:     map[string][]string{"Content-Type": {"application/json"}},
-							Body:       ioutil.NopCloser(bytes.NewBufferString(`{"message":"Update is not a fast forward"}`)),
+							Body:       io.NopCloser(bytes.NewBufferString(`{"message":"Update is not a fast forward"}`)),
 						}, nil
 					})
 			},
@@ -434,10 +434,10 @@ func Test_SyncRun(t *testing.T) {
 			return &http.Client{Transport: reg}, nil
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdinTTY(tt.tty)
-		io.SetStdoutTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdinTTY(tt.tty)
+		ios.SetStdoutTTY(tt.tty)
+		tt.opts.IO = ios
 
 		repo1, _ := ghrepo.FromFullName("OWNER/REPO")
 		repo2, _ := ghrepo.FromFullName("OWNER2/REPO2")

--- a/pkg/cmd/run/cancel/cancel_test.go
+++ b/pkg/cmd/run/cancel/cancel_test.go
@@ -2,7 +2,7 @@ package cancel
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -46,12 +46,12 @@ func TestNewCmdCancel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -65,8 +65,8 @@ func TestNewCmdCancel(t *testing.T) {
 
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
@@ -188,10 +188,10 @@ func TestRunCancel(t *testing.T) {
 			return &http.Client{Transport: reg}, nil
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdoutTTY(true)
-		io.SetStdinTTY(true)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdoutTTY(true)
+		ios.SetStdinTTY(true)
+		tt.opts.IO = ios
 		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 			return ghrepo.FromFullName("OWNER/REPO")
 		}

--- a/pkg/cmd/run/download/download_test.go
+++ b/pkg/cmd/run/download/download_test.go
@@ -2,7 +2,7 @@ package download
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"testing"
@@ -72,13 +72,13 @@ func Test_NewCmdDownload(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 				HttpClient: func() (*http.Client, error) {
 					return nil, nil
 				},
@@ -99,8 +99,8 @@ func Test_NewCmdDownload(t *testing.T) {
 			cmd.SetArgs(argv)
 
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantErr != "" {
@@ -247,8 +247,8 @@ func Test_runDownload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := &tt.opts
-			io, _, stdout, stderr := iostreams.Test()
-			opts.IO = io
+			ios, _, stdout, stderr := iostreams.Test()
+			opts.IO = ios
 			opts.Platform = newMockPlatform(t, tt.mockAPI)
 			opts.Prompter = newMockPrompter(t, tt.mockPrompt)
 

--- a/pkg/cmd/run/download/http.go
+++ b/pkg/cmd/run/download/http.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -44,7 +43,7 @@ func downloadArtifact(httpClient *http.Client, url, destDir string) error {
 		return api.HandleHTTPError(resp)
 	}
 
-	tmpfile, err := ioutil.TempFile("", "gh-artifact.*.zip")
+	tmpfile, err := os.CreateTemp("", "gh-artifact.*.zip")
 	if err != nil {
 		return fmt.Errorf("error initializing temporary file: %w", err)
 	}

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -3,7 +3,7 @@ package list
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -72,12 +72,12 @@ func TestNewCmdList(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -90,8 +90,8 @@ func TestNewCmdList(t *testing.T) {
 			})
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
@@ -248,9 +248,9 @@ func TestListRun(t *testing.T) {
 				return &http.Client{Transport: reg}, nil
 			}
 
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(!tt.nontty)
-			tt.opts.IO = io
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(!tt.nontty)
+			tt.opts.IO = ios
 			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 				return ghrepo.FromFullName("OWNER/REPO")
 			}

--- a/pkg/cmd/run/rerun/rerun_test.go
+++ b/pkg/cmd/run/rerun/rerun_test.go
@@ -2,7 +2,7 @@ package rerun
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -96,12 +96,12 @@ func TestNewCmdRerun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -114,8 +114,8 @@ func TestNewCmdRerun(t *testing.T) {
 			})
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
@@ -261,10 +261,10 @@ func TestRerun(t *testing.T) {
 			return &http.Client{Transport: reg}, nil
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdinTTY(tt.tty)
-		io.SetStdoutTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdinTTY(tt.tty)
+		ios.SetStdoutTTY(tt.tty)
+		tt.opts.IO = ios
 		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 			return ghrepo.FromFullName("OWNER/REPO")
 		}

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -120,12 +119,12 @@ func TestNewCmdView(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -138,8 +137,8 @@ func TestNewCmdView(t *testing.T) {
 			})
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
@@ -836,9 +835,9 @@ func TestViewRun(t *testing.T) {
 			return notnow
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdoutTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdoutTTY(tt.tty)
+		tt.opts.IO = ios
 		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 			return ghrepo.FromFullName("OWNER/REPO")
 		}

--- a/pkg/cmd/run/watch/watch_test.go
+++ b/pkg/cmd/run/watch/watch_test.go
@@ -2,7 +2,7 @@ package watch
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"runtime"
 	"testing"
@@ -60,12 +60,12 @@ func TestNewCmdWatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -78,8 +78,8 @@ func TestNewCmdWatch(t *testing.T) {
 			})
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
@@ -314,9 +314,9 @@ func TestWatchRun(t *testing.T) {
 			return notnow
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdoutTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdoutTTY(tt.tty)
+		tt.opts.IO = ios
 		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 			return ghrepo.FromFullName("OWNER/REPO")
 		}

--- a/pkg/cmd/search/issues/issues_test.go
+++ b/pkg/cmd/search/issues/issues_test.go
@@ -164,9 +164,9 @@ func TestNewCmdIssues(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 			argv, err := shlex.Split(tt.input)
 			assert.NoError(t, err)

--- a/pkg/cmd/search/prs/prs_test.go
+++ b/pkg/cmd/search/prs/prs_test.go
@@ -149,9 +149,9 @@ func TestNewCmdPrs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 			argv, err := shlex.Split(tt.input)
 			assert.NoError(t, err)

--- a/pkg/cmd/search/repos/repos_test.go
+++ b/pkg/cmd/search/repos/repos_test.go
@@ -118,9 +118,9 @@ func TestNewCmdRepos(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 			argv, err := shlex.Split(tt.input)
 			assert.NoError(t, err)
@@ -264,11 +264,11 @@ func TestReposRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		io, _, stdout, stderr := iostreams.Test()
-		io.SetStdinTTY(tt.tty)
-		io.SetStdoutTTY(tt.tty)
-		io.SetStderrTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, stderr := iostreams.Test()
+		ios.SetStdinTTY(tt.tty)
+		ios.SetStdoutTTY(tt.tty)
+		ios.SetStderrTTY(tt.tty)
+		tt.opts.IO = ios
 		t.Run(tt.name, func(t *testing.T) {
 			err := reposRun(tt.opts)
 			if tt.wantErr {

--- a/pkg/cmd/search/shared/shared_test.go
+++ b/pkg/cmd/search/shared/shared_test.go
@@ -188,11 +188,11 @@ func TestSearchIssues(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		io, _, stdout, stderr := iostreams.Test()
-		io.SetStdinTTY(tt.tty)
-		io.SetStdoutTTY(tt.tty)
-		io.SetStderrTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, stderr := iostreams.Test()
+		ios.SetStdinTTY(tt.tty)
+		ios.SetStdoutTTY(tt.tty)
+		ios.SetStderrTTY(tt.tty)
+		tt.opts.IO = ios
 		t.Run(tt.name, func(t *testing.T) {
 			err := SearchIssues(tt.opts)
 			if tt.wantErr {

--- a/pkg/cmd/secret/list/list_test.go
+++ b/pkg/cmd/secret/list/list_test.go
@@ -3,7 +3,7 @@ package list
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -73,9 +73,9 @@ func Test_NewCmdList(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -351,11 +351,11 @@ func Test_listRun(t *testing.T) {
 
 			reg.Register(httpmock.REST("GET", path), httpmock.JSONResponse(payload))
 
-			io, _, stdout, _ := iostreams.Test()
+			ios, _, stdout, _ := iostreams.Test()
 
-			io.SetStdoutTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
-			tt.opts.IO = io
+			tt.opts.IO = ios
 			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 				return ghrepo.FromFullName("owner/repo")
 			}
@@ -387,7 +387,7 @@ func Test_getSecrets_pagination(t *testing.T) {
 		requests = append(requests, req)
 		return &http.Response{
 			Request: req,
-			Body:    ioutil.NopCloser(strings.NewReader(`{"secrets":[{},{}]}`)),
+			Body:    io.NopCloser(strings.NewReader(`{"secrets":[{},{}]}`)),
 			Header:  header,
 		}, nil
 	}

--- a/pkg/cmd/secret/remove/remove_test.go
+++ b/pkg/cmd/secret/remove/remove_test.go
@@ -77,9 +77,9 @@ func TestNewCmdRemove(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -148,9 +148,9 @@ func Test_removeRun_repo(t *testing.T) {
 			httpmock.REST("DELETE", tt.wantPath),
 			httpmock.StatusStringResponse(204, "No Content"))
 
-		io, _, _, _ := iostreams.Test()
+		ios, _, _, _ := iostreams.Test()
 
-		tt.opts.IO = io
+		tt.opts.IO = ios
 		tt.opts.HttpClient = func() (*http.Client, error) {
 			return &http.Client{Transport: reg}, nil
 		}
@@ -175,10 +175,10 @@ func Test_removeRun_env(t *testing.T) {
 		httpmock.REST("DELETE", "repos/owner/repo/environments/development/secrets/cool_secret"),
 		httpmock.StatusStringResponse(204, "No Content"))
 
-	io, _, _, _ := iostreams.Test()
+	ios, _, _, _ := iostreams.Test()
 
 	opts := &RemoveOptions{
-		IO: io,
+		IO: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: reg}, nil
 		},
@@ -229,7 +229,7 @@ func Test_removeRun_org(t *testing.T) {
 				httpmock.REST("DELETE", tt.wantPath),
 				httpmock.StatusStringResponse(204, "No Content"))
 
-			io, _, _, _ := iostreams.Test()
+			ios, _, _, _ := iostreams.Test()
 
 			tt.opts.Config = func() (config.Config, error) {
 				return config.NewBlankConfig(), nil
@@ -240,7 +240,7 @@ func Test_removeRun_org(t *testing.T) {
 			tt.opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: reg}, nil
 			}
-			tt.opts.IO = io
+			tt.opts.IO = ios
 			tt.opts.SecretName = "tVirus"
 
 			err := removeRun(tt.opts)
@@ -260,10 +260,10 @@ func Test_removeRun_user(t *testing.T) {
 		httpmock.REST("DELETE", "user/codespaces/secrets/cool_secret"),
 		httpmock.StatusStringResponse(204, "No Content"))
 
-	io, _, _, _ := iostreams.Test()
+	ios, _, _, _ := iostreams.Test()
 
 	opts := &RemoveOptions{
-		IO: io,
+		IO: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: reg}, nil
 		},

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -388,7 +387,7 @@ func getBody(opts *SetOptions) ([]byte, error) {
 		return []byte(bodyInput), nil
 	}
 
-	body, err := ioutil.ReadAll(opts.IO.In)
+	body, err := io.ReadAll(opts.IO.In)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from standard input: %w", err)
 	}

--- a/pkg/cmd/ssh-key/add/add_test.go
+++ b/pkg/cmd/ssh-key/add/add_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func Test_runAdd(t *testing.T) {
-	io, stdin, stdout, stderr := iostreams.Test()
-	io.SetStdinTTY(false)
-	io.SetStdoutTTY(true)
-	io.SetStderrTTY(true)
+	ios, stdin, stdout, stderr := iostreams.Test()
+	ios.SetStdinTTY(false)
+	ios.SetStdoutTTY(true)
+	ios.SetStderrTTY(true)
 
 	stdin.WriteString("PUBKEY")
 
@@ -26,7 +26,7 @@ func Test_runAdd(t *testing.T) {
 		httpmock.StringResponse(`{}`))
 
 	err := runAdd(&AddOptions{
-		IO: io,
+		IO: ios,
 		Config: func() (config.Config, error) {
 			return config.NewBlankConfig(), nil
 		},

--- a/pkg/cmd/ssh-key/add/http.go
+++ b/pkg/cmd/ssh-key/add/http.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
@@ -14,7 +13,7 @@ import (
 func SSHKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader, title string) error {
 	url := ghinstance.RESTPrefix(hostname) + "user/keys"
 
-	keyBytes, err := ioutil.ReadAll(keyFile)
+	keyBytes, err := io.ReadAll(keyFile)
 	if err != nil {
 		return err
 	}
@@ -44,7 +43,7 @@ func SSHKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader, t
 		return api.HandleHTTPError(resp)
 	}
 
-	_, err = io.Copy(ioutil.Discard, resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/ssh-key/list/http.go
+++ b/pkg/cmd/ssh-key/list/http.go
@@ -3,7 +3,7 @@ package list
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -38,7 +38,7 @@ func userKeys(httpClient *http.Client, host, userHandle string) ([]sshKey, error
 		return nil, api.HandleHTTPError(resp)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/ssh-key/list/list_test.go
+++ b/pkg/cmd/ssh-key/list/list_test.go
@@ -125,13 +125,13 @@ func TestListRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.isTTY)
-			io.SetStdinTTY(tt.isTTY)
-			io.SetStderrTTY(tt.isTTY)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
 
 			opts := tt.opts
-			opts.IO = io
+			opts.IO = ios
 			opts.Config = func() (config.Config, error) { return config.NewBlankConfig(), nil }
 
 			err := listRun(&opts)

--- a/pkg/cmd/status/status_test.go
+++ b/pkg/cmd/status/status_test.go
@@ -46,16 +46,16 @@ func TestNewCmdStatus(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		io, _, _, _ := iostreams.Test()
-		io.SetStdinTTY(true)
-		io.SetStdoutTTY(true)
+		ios, _, _, _ := iostreams.Test()
+		ios.SetStdinTTY(true)
+		ios.SetStdoutTTY(true)
 
 		if tt.wants.Exclude == nil {
 			tt.wants.Exclude = []string{}
 		}
 
 		f := &cmdutil.Factory{
-			IOStreams: io,
+			IOStreams: ios,
 			Config: func() (config.Config, error) {
 				return config.NewBlankConfig(), nil
 			},
@@ -283,9 +283,9 @@ func TestStatusRun(t *testing.T) {
 			return c
 		}
 		tt.opts.HostConfig = testHostConfig("github.com")
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdoutTTY(true)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdoutTTY(true)
+		tt.opts.IO = ios
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := statusRun(tt.opts)

--- a/pkg/cmd/workflow/disable/disable_test.go
+++ b/pkg/cmd/workflow/disable/disable_test.go
@@ -2,7 +2,7 @@ package disable
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -54,12 +54,12 @@ func TestNewCmdDisable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -72,8 +72,8 @@ func TestNewCmdDisable(t *testing.T) {
 			})
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
@@ -269,10 +269,10 @@ func TestDisableRun(t *testing.T) {
 			return &http.Client{Transport: reg}, nil
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdoutTTY(tt.tty)
-		io.SetStdinTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdoutTTY(tt.tty)
+		ios.SetStdinTTY(tt.tty)
+		tt.opts.IO = ios
 		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 			return ghrepo.FromFullName("OWNER/REPO")
 		}

--- a/pkg/cmd/workflow/enable/enable_test.go
+++ b/pkg/cmd/workflow/enable/enable_test.go
@@ -2,7 +2,7 @@ package enable
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -54,12 +54,12 @@ func TestNewCmdEnable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -72,8 +72,8 @@ func TestNewCmdEnable(t *testing.T) {
 			})
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
@@ -318,10 +318,10 @@ func TestEnableRun(t *testing.T) {
 			return &http.Client{Transport: reg}, nil
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdoutTTY(tt.tty)
-		io.SetStdinTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdoutTTY(tt.tty)
+		ios.SetStdinTTY(tt.tty)
+		tt.opts.IO = ios
 		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 			return ghrepo.FromFullName("OWNER/REPO")
 		}

--- a/pkg/cmd/workflow/list/list_test.go
+++ b/pkg/cmd/workflow/list/list_test.go
@@ -3,7 +3,7 @@ package list
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -64,12 +64,12 @@ func Test_NewCmdList(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -82,8 +82,8 @@ func Test_NewCmdList(t *testing.T) {
 			})
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
@@ -221,9 +221,9 @@ func TestListRun(t *testing.T) {
 				return &http.Client{Transport: reg}, nil
 			}
 
-			io, _, stdout, stderr := iostreams.Test()
-			io.SetStdoutTTY(tt.tty)
-			tt.opts.IO = io
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.tty)
+			tt.opts.IO = ios
 			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 				return ghrepo.FromFullName("OWNER/REPO")
 			}

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"sort"
@@ -97,7 +97,7 @@ func NewCmdRun(f *cmdutil.Factory, runF func(*RunOptions) error) *cobra.Command 
 			}
 
 			if opts.JSON && !opts.IO.IsStdinTTY() {
-				jsonIn, err := ioutil.ReadAll(opts.IO.In)
+				jsonIn, err := io.ReadAll(opts.IO.In)
 				if err != nil {
 					return errors.New("failed to read from STDIN")
 				}

--- a/pkg/cmd/workflow/run/run_test.go
+++ b/pkg/cmd/workflow/run/run_test.go
@@ -5,8 +5,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/cli/cli/v2/api"
@@ -100,16 +101,16 @@ func TestNewCmdRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, stdin, _, _ := iostreams.Test()
+			ios, stdin, _, _ := iostreams.Test()
 			if tt.stdin == "" {
-				io.SetStdinTTY(tt.tty)
+				ios.SetStdinTTY(tt.tty)
 			} else {
 				stdin.WriteString(tt.stdin)
 			}
-			io.SetStdoutTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -122,8 +123,8 @@ func TestNewCmdRun(t *testing.T) {
 			})
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
@@ -148,7 +149,7 @@ func TestNewCmdRun(t *testing.T) {
 }
 
 func Test_magicFieldValue(t *testing.T) {
-	f, err := ioutil.TempFile(t.TempDir(), "gh-test")
+	f, err := os.CreateTemp(t.TempDir(), "gh-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +157,7 @@ func Test_magicFieldValue(t *testing.T) {
 
 	fmt.Fprint(f, "file contents")
 
-	io, _, _, _ := iostreams.Test()
+	ios, _, _, _ := iostreams.Test()
 
 	type args struct {
 		v    string
@@ -178,7 +179,7 @@ func Test_magicFieldValue(t *testing.T) {
 			name: "file",
 			args: args{
 				v:    "@" + f.Name(),
-				opts: RunOptions{IO: io},
+				opts: RunOptions{IO: ios},
 			},
 			want:    "file contents",
 			wantErr: false,
@@ -187,7 +188,7 @@ func Test_magicFieldValue(t *testing.T) {
 			name: "file error",
 			args: args{
 				v:    "@",
-				opts: RunOptions{IO: io},
+				opts: RunOptions{IO: ios},
 			},
 			want:    nil,
 			wantErr: true,
@@ -618,10 +619,10 @@ jobs:
 			return &http.Client{Transport: reg}, nil
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdinTTY(tt.tty)
-		io.SetStdoutTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdinTTY(tt.tty)
+		ios.SetStdoutTTY(tt.tty)
+		tt.opts.IO = ios
 		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 			return api.InitRepoHostname(&api.Repository{
 				Name:             "REPO",
@@ -649,7 +650,7 @@ jobs:
 			if len(reg.Requests) > 0 {
 				lastRequest := reg.Requests[len(reg.Requests)-1]
 				if lastRequest.Method == "POST" {
-					bodyBytes, _ := ioutil.ReadAll(lastRequest.Body)
+					bodyBytes, _ := io.ReadAll(lastRequest.Body)
 					reqBody := make(map[string]interface{})
 					err := json.Unmarshal(bodyBytes, &reqBody)
 					if err != nil {

--- a/pkg/cmd/workflow/view/view_test.go
+++ b/pkg/cmd/workflow/view/view_test.go
@@ -2,7 +2,7 @@ package view
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -123,12 +123,12 @@ func TestNewCmdView(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			io, _, _, _ := iostreams.Test()
-			io.SetStdinTTY(tt.tty)
-			io.SetStdoutTTY(tt.tty)
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
 
 			f := &cmdutil.Factory{
-				IOStreams: io,
+				IOStreams: ios,
 			}
 
 			argv, err := shlex.Split(tt.cli)
@@ -141,8 +141,8 @@ func TestNewCmdView(t *testing.T) {
 			})
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 
 			_, err = cmd.ExecuteC()
 			if tt.wantsErr {
@@ -403,10 +403,10 @@ func TestViewRun(t *testing.T) {
 			return &http.Client{Transport: reg}, nil
 		}
 
-		io, _, stdout, _ := iostreams.Test()
-		io.SetStdoutTTY(tt.tty)
-		io.SetStdinTTY(tt.tty)
-		tt.opts.IO = io
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdoutTTY(tt.tty)
+		ios.SetStdinTTY(tt.tty)
+		tt.opts.IO = ios
 
 		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 			return ghrepo.FromFullName("OWNER/REPO")

--- a/pkg/cmdutil/file_input.go
+++ b/pkg/cmdutil/file_input.go
@@ -2,15 +2,15 @@ package cmdutil
 
 import (
 	"io"
-	"io/ioutil"
+	"os"
 )
 
 func ReadFile(filename string, stdin io.ReadCloser) ([]byte, error) {
 	if filename == "-" {
-		b, err := ioutil.ReadAll(stdin)
+		b, err := io.ReadAll(stdin)
 		_ = stdin.Close()
 		return b, err
 	}
 
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }

--- a/pkg/cmdutil/json_flags_test.go
+++ b/pkg/cmdutil/json_flags_test.go
@@ -3,7 +3,7 @@ package cmdutil
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -99,8 +99,8 @@ func TestAddJSONFlags(t *testing.T) {
 			var exporter Exporter
 			AddJSONFlags(cmd, &exporter, tt.fields)
 			cmd.SetArgs(tt.args)
-			cmd.SetOut(ioutil.Discard)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			_, err := cmd.ExecuteC()
 			if tt.wantsError == "" {
 				require.NoError(t, err)

--- a/pkg/export/filter.go
+++ b/pkg/export/filter.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/itchyny/gojq"
 )
@@ -15,7 +14,7 @@ func FilterJSON(w io.Writer, input io.Reader, queryStr string) error {
 		return err
 	}
 
-	jsonData, err := ioutil.ReadAll(input)
+	jsonData, err := io.ReadAll(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/export/template.go
+++ b/pkg/export/template.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"strconv"
 	"strings"
@@ -81,7 +80,7 @@ func (t *Template) Execute(input io.Reader) error {
 		t.template = template
 	}
 
-	jsonData, err := ioutil.ReadAll(input)
+	jsonData, err := io.ReadAll(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/githubtemplate/github_template.go
+++ b/pkg/githubtemplate/github_template.go
@@ -2,7 +2,7 @@ package githubtemplate
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"regexp"
 	"sort"
@@ -24,7 +24,7 @@ func FindNonLegacy(rootDir string, name string) []string {
 
 mainLoop:
 	for _, dir := range candidateDirs {
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		if err != nil {
 			continue
 		}
@@ -32,7 +32,7 @@ mainLoop:
 		// detect multiple templates in a subdirectory
 		for _, file := range files {
 			if strings.EqualFold(file.Name(), name) && file.IsDir() {
-				templates, err := ioutil.ReadDir(path.Join(dir, file.Name()))
+				templates, err := os.ReadDir(path.Join(dir, file.Name()))
 				if err != nil {
 					break
 				}
@@ -63,7 +63,7 @@ func FindLegacy(rootDir string, name string) string {
 		path.Join(rootDir, "docs"),
 	}
 	for _, dir := range candidateDirs {
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		if err != nil {
 			continue
 		}
@@ -80,7 +80,7 @@ func FindLegacy(rootDir string, name string) string {
 
 // ExtractName returns the name of the template from YAML front-matter
 func ExtractName(filePath string) string {
-	contents, err := ioutil.ReadFile(filePath)
+	contents, err := os.ReadFile(filePath)
 	frontmatterBoundaries := detectFrontmatter(contents)
 	if err == nil && frontmatterBoundaries[0] == 0 {
 		templateData := struct {
@@ -95,7 +95,7 @@ func ExtractName(filePath string) string {
 
 // ExtractContents returns the template contents without the YAML front-matter
 func ExtractContents(filePath string) []byte {
-	contents, err := ioutil.ReadFile(filePath)
+	contents, err := os.ReadFile(filePath)
 	if err != nil {
 		return []byte{}
 	}

--- a/pkg/githubtemplate/github_template_test.go
+++ b/pkg/githubtemplate/github_template_test.go
@@ -1,7 +1,6 @@
 package githubtemplate
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -9,7 +8,7 @@ import (
 )
 
 func TestFindNonLegacy(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "gh-cli")
+	tmpdir, err := os.MkdirTemp("", "gh-cli")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +140,7 @@ func TestFindNonLegacy(t *testing.T) {
 }
 
 func TestFindLegacy(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "gh-cli")
+	tmpdir, err := os.MkdirTemp("", "gh-cli")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +260,7 @@ func TestFindLegacy(t *testing.T) {
 }
 
 func TestExtractName(t *testing.T) {
-	tmpfile, err := ioutil.TempFile(t.TempDir(), "gh-cli")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "gh-cli")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -312,7 +311,7 @@ about: This is how you report bugs
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = ioutil.WriteFile(tmpfile.Name(), []byte(tt.prepare), 0600)
+			_ = os.WriteFile(tmpfile.Name(), []byte(tt.prepare), 0600)
 			if got := ExtractName(tt.args.filePath); got != tt.want {
 				t.Errorf("ExtractName() = %v, want %v", got, tt.want)
 			}
@@ -321,7 +320,7 @@ about: This is how you report bugs
 }
 
 func TestExtractContents(t *testing.T) {
-	tmpfile, err := ioutil.TempFile(t.TempDir(), "gh-cli")
+	tmpfile, err := os.CreateTemp(t.TempDir(), "gh-cli")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +375,7 @@ Even more
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = ioutil.WriteFile(tmpfile.Name(), []byte(tt.prepare), 0600)
+			_ = os.WriteFile(tmpfile.Name(), []byte(tt.prepare), 0600)
 			if got := ExtractContents(tt.args.filePath); string(got) != tt.want {
 				t.Errorf("ExtractContents() = %v, want %v", string(got), tt.want)
 			}

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -75,8 +74,8 @@ func QueryMatcher(method string, path string, query url.Values) Matcher {
 func readBody(req *http.Request) ([]byte, error) {
 	bodyCopy := &bytes.Buffer{}
 	r := io.TeeReader(req.Body, bodyCopy)
-	req.Body = ioutil.NopCloser(bodyCopy)
-	return ioutil.ReadAll(r)
+	req.Body = io.NopCloser(bodyCopy)
+	return io.ReadAll(r)
 }
 
 func decodeJSONBody(req *http.Request, dest interface{}) error {
@@ -179,7 +178,7 @@ func ScopesResponder(scopes string) func(*http.Request) (*http.Response, error) 
 			Header: map[string][]string{
 				"X-Oauth-Scopes": {scopes},
 			},
-			Body: ioutil.NopCloser(bytes.NewBufferString("")),
+			Body: io.NopCloser(bytes.NewBufferString("")),
 		}, nil
 	}
 }
@@ -188,7 +187,7 @@ func httpResponse(status int, req *http.Request, body io.Reader) *http.Response 
 	return &http.Response{
 		StatusCode: status,
 		Request:    req,
-		Body:       ioutil.NopCloser(body),
+		Body:       io.NopCloser(body),
 		Header:     http.Header{},
 	}
 }

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -360,14 +359,14 @@ func (s *IOStreams) ReadUserFile(fn string) ([]byte, error) {
 		}
 	}
 	defer r.Close()
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func (s *IOStreams) TempFile(dir, pattern string) (*os.File, error) {
 	if s.TempFileOverride != nil {
 		return s.TempFileOverride, nil
 	}
-	return ioutil.TempFile(dir, pattern)
+	return os.CreateTemp(dir, pattern)
 }
 
 func System() *IOStreams {
@@ -408,7 +407,7 @@ func Test() (*IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
 	out := &bytes.Buffer{}
 	errOut := &bytes.Buffer{}
 	return &IOStreams{
-		In:     ioutil.NopCloser(in),
+		In:     io.NopCloser(in),
 		Out:    out,
 		ErrOut: errOut,
 		ttySize: func() (int, int, error) {

--- a/pkg/surveyext/editor_manual.go
+++ b/pkg/surveyext/editor_manual.go
@@ -3,7 +3,6 @@ package surveyext
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -47,7 +46,7 @@ func edit(editorCommand, fn, initialValue string, stdin io.Reader, stdout io.Wri
 	if pattern == "" {
 		pattern = "survey*.txt"
 	}
-	f, err := ioutil.TempFile("", pattern)
+	f, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return "", err
 	}
@@ -101,7 +100,7 @@ func edit(editorCommand, fn, initialValue string, stdin io.Reader, stdout io.Wri
 	}
 
 	// raw is a BOM-unstripped UTF8 byte slice
-	raw, err := ioutil.ReadFile(f.Name())
+	raw, err := os.ReadFile(f.Name())
 	if err != nil {
 		return "", err
 	}

--- a/script/build.go
+++ b/script/build.go
@@ -25,7 +25,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -215,7 +215,7 @@ func cmdOutput(args ...string) (string, error) {
 		return "", err
 	}
 	cmd := exec.Command(exe, args[1:]...)
-	cmd.Stderr = ioutil.Discard
+	cmd.Stderr = io.Discard
 	out, err := cmd.Output()
 	return strings.TrimSuffix(string(out), "\n"), err
 }


### PR DESCRIPTION
Fixes #5495

`iostreams` used the var `io` which is unfortunate since it collides with `io` from the standard library, so renamed it to `ios`