### PR TITLE
Avoid crash when deleting gist with no owner

### DIFF
--- a/pkg/cmd/gist/delete/delete.go
+++ b/pkg/cmd/gist/delete/delete.go
@@ -2,6 +2,7 @@ package delete
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -58,8 +59,6 @@ func deleteRun(opts *DeleteOptions) error {
 		return err
 	}
 
-	apiClient := api.NewClientFromHTTP(client)
-
 	cfg, err := opts.Config()
 	if err != nil {
 		return err
@@ -70,21 +69,11 @@ func deleteRun(opts *DeleteOptions) error {
 		return err
 	}
 
-	gist, err := shared.GetGist(client, host, gistID)
-	if err != nil {
-		return err
-	}
-	username, err := api.CurrentLoginName(apiClient, host)
-	if err != nil {
-		return err
-	}
-
-	if username != gist.Owner.Login {
-		return errors.New("you do not own this gist")
-	}
-
-	err = deleteGist(apiClient, host, gistID)
-	if err != nil {
+	apiClient := api.NewClientFromHTTP(client)
+	if err := deleteGist(apiClient, host, gistID); err != nil {
+		if errors.Is(err, shared.NotFoundErr) {
+			return fmt.Errorf("unable to delete gist %s: either the gist is not found or it is not owned by you", gistID)
+		}
 		return err
 	}
 
@@ -95,6 +84,10 @@ func deleteGist(apiClient *api.Client, hostname string, gistID string) error {
 	path := "gists/" + gistID
 	err := apiClient.REST(hostname, "DELETE", path, nil, nil)
 	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == 404 {
+			return shared.NotFoundErr
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
This removes the explicit check for the gist owner, speeding up the gist deletion due to fewer API requests, but resulting in a more vague error message in case the gist is "not found".

Fixes #5506