### PR TITLE
Properly handle issue and pr state options when building search queries

### DIFF
--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -227,7 +227,7 @@ func TestIssueList_web(t *testing.T) {
 
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "Opening github.com/OWNER/REPO/issues in your browser.\n", stderr.String())
-	browser.Verify(t, "https://github.com/OWNER/REPO/issues?q=assignee%3Apeter+author%3Ajohn+label%3Abug+label%3Adocs+mentions%3Afrank+milestone%3Av1.1+state%3Aall+type%3Aissue")
+	browser.Verify(t, "https://github.com/OWNER/REPO/issues?q=assignee%3Apeter+author%3Ajohn+label%3Abug+label%3Adocs+mentions%3Afrank+milestone%3Av1.1+type%3Aissue")
 }
 
 func Test_issueList(t *testing.T) {

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -183,7 +183,7 @@ func TestPRList_filteringAssignee(t *testing.T) {
 	http.Register(
 		httpmock.GraphQL(`query PullRequestSearch\b`),
 		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
-			assert.Equal(t, `assignee:hubot base:develop label:"needs tests" repo:OWNER/REPO state:merged type:pr`, params["q"].(string))
+			assert.Equal(t, `assignee:hubot base:develop is:merged label:"needs tests" repo:OWNER/REPO type:pr`, params["q"].(string))
 		}))
 
 	_, err := runCommand(http, true, `-s merged -l "needs tests" -a hubot -B develop`)
@@ -292,7 +292,7 @@ func TestPRList_web(t *testing.T) {
 		{
 			name:               "filters",
 			cli:                "-a peter -l bug -l docs -L 10 -s merged -B trunk",
-			expectedBrowserURL: "https://github.com/OWNER/REPO/pulls?q=assignee%3Apeter+base%3Atrunk+label%3Abug+label%3Adocs+state%3Amerged+type%3Apr",
+			expectedBrowserURL: "https://github.com/OWNER/REPO/pulls?q=assignee%3Apeter+base%3Atrunk+is%3Amerged+label%3Abug+label%3Adocs+type%3Apr",
 		},
 		{
 			name:               "draft",

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -212,8 +212,6 @@ func SearchQueryBuild(options FilterOptions) string {
 	switch options.State {
 	case "open", "closed":
 		state = options.State
-	case "all":
-		// do nothing
 	case "merged":
 		is = "merged"
 	}

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -208,6 +208,15 @@ func ListURLWithQuery(listURL string, options FilterOptions) (string, error) {
 }
 
 func SearchQueryBuild(options FilterOptions) string {
+	var is, state string
+	switch options.State {
+	case "open", "closed":
+		state = options.State
+	case "all":
+		// do nothing
+	case "merged":
+		is = "merged"
+	}
 	q := search.Query{
 		Qualifiers: search.Qualifiers{
 			Assignee:  options.Assignee,
@@ -219,7 +228,8 @@ func SearchQueryBuild(options FilterOptions) string {
 			Mentions:  options.Mention,
 			Milestone: options.Milestone,
 			Repo:      []string{options.Repo},
-			State:     options.State,
+			State:     state,
+			Is:        []string{is},
 			Type:      options.Entity,
 		},
 	}


### PR DESCRIPTION
The PR slightly changes how we build search queries for the `issue list` and `pr list` commands to properly handle the `--state all` and `--state merged` flag inputs.

Fixes https://github.com/cli/cli/issues/5508