### PR TITLE
Add `label edit` command

### DIFF
--- a/pkg/cmd/label/edit.go
+++ b/pkg/cmd/label/edit.go
@@ -1,6 +1,7 @@
 package label
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -32,27 +33,31 @@ func newCmdEdit(f *cmdutil.Factory, runF func(*editOptions) error) *cobra.Comman
 
 	cmd := &cobra.Command{
 		Use:   "edit <name>",
-		Short: "Updates an existing label",
-		Long: heredoc.Doc(`
-			Updates an existing label on GitHub. You can also rename a label.
+		Short: "Edit a label",
+		Long: heredoc.Docf(`
+			Update a label on GitHub.
 
-			Must specify name for the label. The description or color is updated
-			to either of the values specified.
+			A label can be renamed using the %[1]s--name%[1]s flag.
 
-			Color needs to be 6 character hex value.
-		`),
+			The label color needs to be 6 character hex value.
+		`, "`"),
 		Example: heredoc.Doc(`
-			# update just the color for the bug label
+			# update the color of the bug label
 			$ gh label edit bug --color FF0000
 
-			# rename a label with a new description
-			$ gh label edit bug --rename issue --description "Bug or design issue"
+			# rename and edit the description of the bug label
+			$ gh label edit bug --name big-bug --description "Bigger than normal bug"
 	  `),
 		Args: cmdutil.ExactArgs(1, "cannot update label: name argument required"),
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.BaseRepo = f.BaseRepo
 			opts.Name = args[0]
 			opts.Color = strings.TrimPrefix(opts.Color, "#")
+			if opts.Description == "" &&
+				opts.Color == "" &&
+				opts.NewName == "" {
+				return cmdutil.FlagErrorf("specify at least one of `--color`, `--description`, or `--name`")
+			}
 			if runF != nil {
 				return runF(&opts)
 			}
@@ -60,9 +65,9 @@ func newCmdEdit(f *cmdutil.Factory, runF func(*editOptions) error) *cobra.Comman
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Description, "description", "d", "", "Description of the label.")
-	cmd.Flags().StringVarP(&opts.Color, "color", "c", "", "Color of the label. If not specified one will be selected at random.")
-	cmd.Flags().StringVarP(&opts.NewName, "rename", "", "", "Rename an existing label to the given name.")
+	cmd.Flags().StringVarP(&opts.Description, "description", "d", "", "Description of the label")
+	cmd.Flags().StringVarP(&opts.Color, "color", "c", "", "Color of the label")
+	cmd.Flags().StringVarP(&opts.NewName, "name", "n", "", "Name of the label")
 
 	return cmd
 }
@@ -83,6 +88,9 @@ func editRun(opts *editOptions) error {
 	err = updateLabel(apiClient, baseRepo, opts)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
+		if errors.Is(err, errLabelAlreadyExists) {
+			return fmt.Errorf("label with name %q already exists", opts.NewName)
+		}
 		return err
 	}
 

--- a/pkg/cmd/label/edit.go
+++ b/pkg/cmd/label/edit.go
@@ -1,0 +1,96 @@
+package label
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type editOptions struct {
+	BaseRepo   func() (ghrepo.Interface, error)
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+
+	Color       string
+	Description string
+	Name        string
+	NewName     string
+}
+
+func newCmdEdit(f *cmdutil.Factory, runF func(*editOptions) error) *cobra.Command {
+	opts := editOptions{
+		HttpClient: f.HttpClient,
+		IO:         f.IOStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "edit <name>",
+		Short: "Updates an existing label",
+		Long: heredoc.Doc(`
+			Updates an existing label on GitHub. You can also rename a label.
+
+			Must specify name for the label. The description or color is updated
+			to either of the values specified.
+
+			Color needs to be 6 character hex value.
+		`),
+		Example: heredoc.Doc(`
+			# update just the color for the bug label
+			$ gh label edit bug --color FF0000
+
+			# rename a label with a new description
+			$ gh label edit bug --rename issue --description "Bug or design issue"
+	  `),
+		Args: cmdutil.ExactArgs(1, "cannot update label: name argument required"),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts.BaseRepo = f.BaseRepo
+			opts.Name = args[0]
+			opts.Color = strings.TrimPrefix(opts.Color, "#")
+			if runF != nil {
+				return runF(&opts)
+			}
+			return editRun(&opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Description, "description", "d", "", "Description of the label.")
+	cmd.Flags().StringVarP(&opts.Color, "color", "c", "", "Color of the label. If not specified one will be selected at random.")
+	cmd.Flags().StringVarP(&opts.NewName, "rename", "", "", "Rename an existing label to the given name.")
+
+	return cmd
+}
+
+func editRun(opts *editOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+	apiClient := api.NewClientFromHTTP(httpClient)
+
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicator()
+	err = updateLabel(apiClient, baseRepo, opts)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return err
+	}
+
+	if opts.IO.IsStdoutTTY() {
+		cs := opts.IO.ColorScheme()
+		successMsg := fmt.Sprintf("%s Label %q updated in %s\n", cs.SuccessIcon(), opts.Name, ghrepo.FullName(baseRepo))
+		fmt.Fprint(opts.IO.Out, successMsg)
+	}
+
+	return nil
+}

--- a/pkg/cmd/label/edit_test.go
+++ b/pkg/cmd/label/edit_test.go
@@ -28,9 +28,10 @@ func TestNewCmdEdit(t *testing.T) {
 			errMsg:  "cannot update label: name argument required",
 		},
 		{
-			name:   "name argument",
-			input:  "test",
-			output: editOptions{Name: "test"},
+			name:    "name argument",
+			input:   "test",
+			wantErr: true,
+			errMsg:  "specify at least one of `--color`, `--description`, or `--name`",
 		},
 		{
 			name:   "description flag",
@@ -48,8 +49,8 @@ func TestNewCmdEdit(t *testing.T) {
 			output: editOptions{Name: "test", Color: "AAAAAA"},
 		},
 		{
-			name:   "rename flag",
-			input:  "test --rename test1",
+			name:   "name flag",
+			input:  "test --name test1",
 			output: editOptions{Name: "test", NewName: "test1"},
 		},
 	}

--- a/pkg/cmd/label/edit_test.go
+++ b/pkg/cmd/label/edit_test.go
@@ -1,0 +1,169 @@
+package label
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdEdit(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		output  editOptions
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "no argument",
+			input:   "",
+			wantErr: true,
+			errMsg:  "cannot update label: name argument required",
+		},
+		{
+			name:   "name argument",
+			input:  "test",
+			output: editOptions{Name: "test"},
+		},
+		{
+			name:   "description flag",
+			input:  "test --description 'some description'",
+			output: editOptions{Name: "test", Description: "some description"},
+		},
+		{
+			name:   "color flag",
+			input:  "test --color FFFFFF",
+			output: editOptions{Name: "test", Color: "FFFFFF"},
+		},
+		{
+			name:   "color flag with pound sign",
+			input:  "test --color '#AAAAAA'",
+			output: editOptions{Name: "test", Color: "AAAAAA"},
+		},
+		{
+			name:   "rename flag",
+			input:  "test --rename test1",
+			output: editOptions{Name: "test", NewName: "test1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: io,
+			}
+			argv, err := shlex.Split(tt.input)
+			assert.NoError(t, err)
+			var gotOpts *editOptions
+			cmd := newCmdEdit(f, func(opts *editOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantErr {
+				assert.EqualError(t, err, tt.errMsg)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.output.Color, gotOpts.Color)
+			assert.Equal(t, tt.output.Description, gotOpts.Description)
+			assert.Equal(t, tt.output.Name, gotOpts.Name)
+			assert.Equal(t, tt.output.NewName, gotOpts.NewName)
+		})
+	}
+}
+
+func TestEditRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		tty        bool
+		opts       *editOptions
+		httpStubs  func(*httpmock.Registry)
+		wantStdout string
+		wantErrMsg string
+	}{
+		{
+			name: "updates label",
+			tty:  true,
+			opts: &editOptions{Name: "test", Description: "some description"},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("PATCH", "repos/OWNER/REPO/labels/test"),
+					httpmock.StatusStringResponse(201, "{}"),
+				)
+			},
+			wantStdout: "✓ Label \"test\" updated in OWNER/REPO\n",
+		},
+		{
+			name: "updates label notty",
+			tty:  false,
+			opts: &editOptions{Name: "test", Description: "some description"},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("PATCH", "repos/OWNER/REPO/labels/test"),
+					httpmock.StatusStringResponse(201, "{}"),
+				)
+			},
+			wantStdout: "",
+		},
+		{
+			name: "updates missing label",
+			opts: &editOptions{Name: "invalid", Description: "some description"},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("PATCH", "repos/OWNER/REPO/labels/invalid"),
+					httpmock.WithHeader(
+						httpmock.StatusStringResponse(404, `{"message":"Not Found"}`),
+						"Content-Type",
+						"application/json",
+					),
+				)
+			},
+			wantErrMsg: "HTTP 404: Not Found (https://api.github.com/repos/OWNER/REPO/labels/invalid)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			if tt.httpStubs != nil {
+				tt.httpStubs(reg)
+			}
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			io, _, stdout, _ := iostreams.Test()
+			io.SetStdoutTTY(tt.tty)
+			io.SetStdinTTY(tt.tty)
+			io.SetStderrTTY(tt.tty)
+			tt.opts.IO = io
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.New("OWNER", "REPO"), nil
+			}
+			defer reg.Verify(t)
+			err := editRun(tt.opts)
+
+			if tt.wantErrMsg != "" {
+				assert.EqualError(t, err, tt.wantErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantStdout, stdout.String())
+		})
+	}
+}

--- a/pkg/cmd/label/label.go
+++ b/pkg/cmd/label/label.go
@@ -16,6 +16,7 @@ func NewCmdLabel(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(newCmdList(f, nil))
 	cmd.AddCommand(newCmdCreate(f, nil))
 	cmd.AddCommand(newCmdClone(f, nil))
+	cmd.AddCommand(newCmdEdit(f, nil))
 
 	return cmd
 }


### PR DESCRIPTION
Also fixes label update issue that would overwrite existing description or color with empty value if not explicitly specified. Related to #5489.