### PR TITLE
Add ability to set title for ssh key in auth login

### DIFF
--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -94,7 +94,20 @@ func Login(opts *LoginOptions) error {
 			}
 		}
 	}
+
+	var keyTitle string
 	if keyToUpload != "" {
+		if opts.Interactive {
+			err := prompt.SurveyAskOne(&survey.Input{
+				Message: "SSH key title:",
+				Default: "GitHub CLI",
+			}, &keyTitle)
+			if err != nil {
+				return fmt.Errorf("could not prompt: %w", err)
+			}
+		} else {
+			keyTitle = "GitHub CLI"
+		}
 		additionalScopes = append(additionalScopes, "admin:public_key")
 	}
 
@@ -187,7 +200,7 @@ func Login(opts *LoginOptions) error {
 	}
 
 	if keyToUpload != "" {
-		err := sshKeyUpload(httpClient, hostname, keyToUpload)
+		err := sshKeyUpload(httpClient, hostname, keyToUpload, keyTitle)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -14,6 +14,8 @@ import (
 	"github.com/cli/cli/v2/pkg/prompt"
 )
 
+const defaultSSHKeyTitle = "GitHub CLI"
+
 type iconfig interface {
 	Get(string, string) (string, error)
 	Set(string, string, string) error
@@ -68,6 +70,7 @@ func Login(opts *LoginOptions) error {
 	}
 
 	var keyToUpload string
+	keyTitle := defaultSSHKeyTitle
 	if opts.Interactive && gitProtocol == "ssh" {
 		pubKeys, err := opts.sshContext.localPublicKeys()
 		if err != nil {
@@ -93,22 +96,18 @@ func Login(opts *LoginOptions) error {
 				return err
 			}
 		}
-	}
 
-	var keyTitle string
-	if keyToUpload != "" {
-		if opts.Interactive {
+		if keyToUpload != "" {
 			err := prompt.SurveyAskOne(&survey.Input{
-				Message: "SSH key title:",
-				Default: "GitHub CLI",
+				Message: "Title for your SSH key:",
+				Default: defaultSSHKeyTitle,
 			}, &keyTitle)
 			if err != nil {
 				return fmt.Errorf("could not prompt: %w", err)
 			}
-		} else {
-			keyTitle = "GitHub CLI"
+
+			additionalScopes = append(additionalScopes, "admin:public_key")
 		}
-		additionalScopes = append(additionalScopes, "admin:public_key")
 	}
 
 	var authMode int

--- a/pkg/cmd/auth/shared/login_flow_test.go
+++ b/pkg/cmd/auth/shared/login_flow_test.go
@@ -56,7 +56,7 @@ func TestLogin_ssh(t *testing.T) {
 	ask.StubPrompt("What is your preferred protocol for Git operations?").AnswerWith("SSH")
 	ask.StubPrompt("Generate a new SSH key to add to your GitHub account?").AnswerWith(true)
 	ask.StubPrompt("Enter a passphrase for your new SSH key (Optional)").AnswerWith("monkey")
-	ask.StubPrompt("SSH key title:").AnswerWith("Test Key")
+	ask.StubPrompt("Title for your SSH key:").AnswerWith("Test Key")
 	ask.StubPrompt("How would you like to authenticate GitHub CLI?").AnswerWith("Paste an authentication token")
 	ask.StubPrompt("Paste your authentication token:").AnswerWith("ATOKEN")
 

--- a/pkg/cmd/auth/shared/login_flow_test.go
+++ b/pkg/cmd/auth/shared/login_flow_test.go
@@ -56,6 +56,7 @@ func TestLogin_ssh(t *testing.T) {
 	ask.StubPrompt("What is your preferred protocol for Git operations?").AnswerWith("SSH")
 	ask.StubPrompt("Generate a new SSH key to add to your GitHub account?").AnswerWith(true)
 	ask.StubPrompt("Enter a passphrase for your new SSH key (Optional)").AnswerWith("monkey")
+	ask.StubPrompt("SSH key title:").AnswerWith("Test Key")
 	ask.StubPrompt("How would you like to authenticate GitHub CLI?").AnswerWith("Paste an authentication token")
 	ask.StubPrompt("Paste your authentication token:").AnswerWith("ATOKEN")
 

--- a/pkg/cmd/auth/shared/ssh_keys.go
+++ b/pkg/cmd/auth/shared/ssh_keys.go
@@ -108,12 +108,12 @@ func (c *sshContext) generateSSHKey() (string, error) {
 	return keyFile + ".pub", run.PrepareCmd(keygenCmd).Run()
 }
 
-func sshKeyUpload(httpClient *http.Client, hostname, keyFile string) error {
+func sshKeyUpload(httpClient *http.Client, hostname, keyFile string, title string) error {
 	f, err := os.Open(keyFile)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
-	return add.SSHKeyUpload(httpClient, hostname, f, "GitHub CLI")
+	return add.SSHKeyUpload(httpClient, hostname, f, title)
 }


### PR DESCRIPTION
Fixes #5502, adds the ability for the user to interatively set title for ssh key via prompt.  Uses the previous hardcoded value as default.