### PR TITLE
Document linux distribution updating 

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -99,7 +99,10 @@ jobs:
           popd
       - name: Run reprepro
         env:
-          RELEASES: "cosmic eoan disco groovy focal stable oldstable testing sid unstable buster bullseye stretch jessie bionic trusty precise xenial hirsute impish kali-rolling jammy"
+          # We are no longer adding to the distribution list.
+          # All apt distributions should use "stable" according to our install documentation.
+          # In the future we will remove legacy distributions listed here.
+          RELEASES: "cosmic eoan disco groovy focal stable oldstable testing sid unstable buster bullseye stretch jessie bionic trusty precise xenial hirsute impish kali-rolling"
         run: |
           mkdir -p upload
           for release in $RELEASES; do

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -99,7 +99,7 @@ jobs:
           popd
       - name: Run reprepro
         env:
-          RELEASES: "cosmic eoan disco groovy focal stable oldstable testing sid unstable buster bullseye stretch jessie bionic trusty precise xenial hirsute impish kali-rolling"
+          RELEASES: "cosmic eoan disco groovy focal stable oldstable testing sid unstable buster bullseye stretch jessie bionic trusty precise xenial hirsute impish kali-rolling jammy"
         run: |
           mkdir -p upload
           for release in $RELEASES; do

--- a/script/distributions
+++ b/script/distributions
@@ -176,12 +176,3 @@ Components: main
 Description: The GitHub CLI - ubuntu impish repo
 SignWith: C99B11DEB97541F0
 DebOverride: override.ubuntu
-
-Origin: gh
-Label: gh
-Codename: jammy
-Architectures: i386 amd64 armhf arm64
-Components: main
-Description: The GitHub CLI - ubuntu jammy repo
-SignWith: C99B11DEB97541F0
-DebOverride: override.ubuntu

--- a/script/distributions
+++ b/script/distributions
@@ -176,3 +176,12 @@ Components: main
 Description: The GitHub CLI - ubuntu impish repo
 SignWith: C99B11DEB97541F0
 DebOverride: override.ubuntu
+
+Origin: gh
+Label: gh
+Codename: jammy
+Architectures: i386 amd64 armhf arm64
+Components: main
+Description: The GitHub CLI - ubuntu jammy repo
+SignWith: C99B11DEB97541F0
+DebOverride: override.ubuntu


### PR DESCRIPTION
Document that we no longer are manually maintaining a list of apt linux distributions supported and moving forward they should all install the `stable` package.

cc https://github.com/cli/cli/issues/5523