### PR TITLE
Upgrade to go 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up Go 1.16
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.18
 
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.16
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.18
 
       - name: Check out code
         uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
           go mod verify
           go mod download
 
-          LINT_VERSION=1.44.2
+          LINT_VERSION=1.45.2
           curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v${LINT_VERSION}/golangci-lint-${LINT_VERSION}-linux-amd64.tar.gz | \
             tar xz --strip-components 1 --wildcards \*/golangci-lint
           mkdir -p bin && mv golangci-lint bin/

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up Go 1.16
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.18
       - name: Generate changelog
         id: changelog
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 linters:
   enable:
   - gofmt
-  - nolintlint
 
 issues:
   max-issues-per-linter: 0

--- a/docs/source.md
+++ b/docs/source.md
@@ -1,6 +1,6 @@
 # Installation from source
 
-1. Verify that you have Go 1.16+ installed
+1. Verify that you have Go 1.18+ installed
 
    ```sh
    $ go version
@@ -21,12 +21,12 @@
    ```sh
    # installs to '/usr/local' by default; sudo may be required
    $ make install
-   
+
    # or, install to a different location
    $ make install prefix=/path/to/gh
    ```
 
-   #### Windows 
+   #### Windows
    ```pwsh
    # build the `bin\gh.exe` binary
    > go run script\build.go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cli/cli/v2
 
-go 1.16
+go 1.18
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.4
@@ -32,17 +32,42 @@ require (
 	github.com/muhammadmuzzammil1998/jsonc v0.0.0-20201229145248-615b0916ca38
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/shurcooL/githubv4 v0.0.0-20200928013246-d292edc3691b
-	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
-	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)
+
+require (
+	github.com/alecthomas/chroma v0.10.0 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dlclark/regexp2 v1.4.0 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/gorilla/css v1.0.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/itchyny/timefmt-go v0.1.3 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.17 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+	github.com/yuin/goldmark v1.4.4 // indirect
+	github.com/yuin/goldmark-emoji v1.0.1 // indirect
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
+	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
+	golang.org/x/text v0.3.7 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
 
 replace golang.org/x/crypto => github.com/cli/crypto v0.0.0-20210929142629-6be313f59b03


### PR DESCRIPTION
This PR updates the project to Go 1.18. 

As part of this PR I had to update our version of `golangci-lint` to support the new Go version. With this new version there are four linters that are currently disabled as being unsupported:

- gosimple
- staticcheck
- structcheck
- unused 

They are [currently being worked](https://github.com/golangci/golangci-lint/issues/2649) on to support Go 1.18. 

Additionally due to the fact that the `staticcheck` linter is not supported and we use `//nolint:staticcheck`  in a number of places to hide deprecation warnings from the linter I also had to disable the `nolintlint` linter so these annotations do not cause linter errors. 

In the near future we will want to update our version of `golangci-lint` to get these 5 linters re-enabled.