### PR TITLE
issue comment: support quotes and arguments in EDITOR value

### DIFF
--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -144,11 +144,8 @@ func CommentableInteractiveEditSurvey(cf func() (config.Config, error), io *iost
 		if err != nil {
 			return "", err
 		}
-		if editorCommand == "" {
-			editorCommand = surveyext.DefaultEditorName()
-		}
 		cs := io.ColorScheme()
-		fmt.Fprintf(io.Out, "- %s to draft your comment in %s... ", cs.Bold("Press Enter"), cs.Bold(editorCommand))
+		fmt.Fprintf(io.Out, "- %s to draft your comment in %s... ", cs.Bold("Press Enter"), cs.Bold(surveyext.EditorName(editorCommand)))
 		_ = waitForEnter(io.In)
 		return surveyext.Edit(editorCommand, "*.md", "", io.In, io.Out, io.ErrOut)
 	}

--- a/pkg/surveyext/editor.go
+++ b/pkg/surveyext/editor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
+	shellquote "github.com/kballard/go-shellquote"
 )
 
 var (
@@ -37,14 +38,6 @@ type GhEditor struct {
 	BlankAllowed  bool
 
 	lookPath func(string) ([]string, []string, error)
-}
-
-func (e *GhEditor) editorCommand() string {
-	if e.EditorCommand == "" {
-		return defaultEditor
-	}
-
-	return e.EditorCommand
 }
 
 // EXTENDED to change prompt text
@@ -79,7 +72,7 @@ func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (int
 		EditorTemplateData{
 			Editor:        *e.Editor,
 			BlankAllowed:  e.BlankAllowed,
-			EditorCommand: filepath.Base(e.editorCommand()),
+			EditorCommand: EditorName(e.EditorCommand),
 			Config:        config,
 		},
 	)
@@ -127,7 +120,7 @@ func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (int
 					// EXTENDED to support printing editor in prompt, BlankAllowed
 					Editor:        *e.Editor,
 					BlankAllowed:  e.BlankAllowed,
-					EditorCommand: filepath.Base(e.editorCommand()),
+					EditorCommand: EditorName(e.EditorCommand),
 					ShowHelp:      true,
 					Config:        config,
 				},
@@ -144,7 +137,7 @@ func (e *GhEditor) prompt(initialValue string, config *survey.PromptConfig) (int
 	if lookPath == nil {
 		lookPath = defaultLookPath
 	}
-	text, err := edit(e.editorCommand(), e.FileName, initialValue, stdio.In, stdio.Out, stdio.Err, cursor, lookPath)
+	text, err := edit(e.EditorCommand, e.FileName, initialValue, stdio.In, stdio.Out, stdio.Err, cursor, lookPath)
 	if err != nil {
 		return "", err
 	}
@@ -166,6 +159,12 @@ func (e *GhEditor) Prompt(config *survey.PromptConfig) (interface{}, error) {
 	return e.prompt(initialValue, config)
 }
 
-func DefaultEditorName() string {
-	return filepath.Base(defaultEditor)
+func EditorName(editorCommand string) string {
+	if editorCommand == "" {
+		editorCommand = defaultEditor
+	}
+	if args, err := shellquote.Split(editorCommand); err == nil {
+		editorCommand = args[0]
+	}
+	return filepath.Base(editorCommand)
 }


### PR DESCRIPTION
The `issue comment` command would perform a `filepath.Base()` on the value of EDITOR and use the result for launching the editor, which is undesirable for both functional and display purposes:

- For functional purposes, always shellsplit the value of GH_EDITOR or EDITOR before we shell out to that process;
- For display purposes, extract the basename only after shellsplitting.

Fixes https://github.com/cli/cli/issues/5543