### PR TITLE
Fix grammar in `repo create` prompt

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -538,7 +538,7 @@ func createFromLocal(opts *CreateOptions) error {
 	// don't prompt for push if there are no commits
 	if opts.Interactive && committed {
 		pushQuestion := &survey.Confirm{
-			Message: fmt.Sprintf(`Would you like to push commits from the current branch to the %q?`, baseRemote),
+			Message: fmt.Sprintf(`Would you like to push commits from the current branch to %q?`, baseRemote),
 			Default: true,
 		}
 		err = prompt.SurveyAskOne(pushQuestion, &opts.Push)

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -535,7 +535,7 @@ func createFromLocal(opts *CreateOptions) error {
 		return err
 	}
 
-	// don't prompt for push if there's no commits
+	// don't prompt for push if there are no commits
 	if opts.Interactive && committed {
 		pushQuestion := &survey.Confirm{
 			Message: fmt.Sprintf(`Would you like to push commits from the current branch to the %q?`, baseRemote),


### PR DESCRIPTION
I have a more detailed explanation in the commit message, but there is a stray "the" in the prompt for creating a remote:

> Would you like to push commits from the current branch to the "github"?

This pull request omits "the":

> Would you like to push commits from the current branch to "github"?
