### PR TITLE
Consistent version format in version upgrade notice

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -279,8 +279,8 @@ func mainRun() exitCode {
 		}
 		fmt.Fprintf(stderr, "\n\n%s %s → %s\n",
 			ansi.Color("A new release of gh is available:", "yellow"),
-			ansi.Color(buildVersion, "cyan"),
-			ansi.Color(newRelease.Version, "cyan"))
+			ansi.Color(strings.TrimPrefix(buildVersion, "v"), "cyan"),
+			ansi.Color(strings.TrimPrefix(newRelease.Version, "v"), "cyan"))
 		if isHomebrew {
 			fmt.Fprintf(stderr, "To upgrade, run: %s\n", "brew update && brew upgrade gh")
 		}


### PR DESCRIPTION
We can strip the "v" prefix where it's unambiguous that we're talking about version numbers.

Before:

    A new release of gh is available: 2.8.0 => v2.9.0

After:

    A new release of gh is available: 2.8.0 => 2.9.0

Fixes #5528