### PR TITLE
Fix: 5501 - Added example to 'search prs' help output

### DIFF
--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -50,6 +50,9 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 
 			# search issues with numerous comments
 			$ gh search issues --comments=">100"
+
+			# search issues without label "bug"
+			$ gh search issues -- -label:bug
     `),
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 && c.Flags().NFlag() == 0 {

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -52,6 +52,9 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 
 			# search pull requests with numerous reactions
 			$ gh search prs --reactions=">100"
+
+			# search pull requests with excluded labels
+			$ gh search prs -- --label: labels to exclude
     `),
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 && c.Flags().NFlag() == 0 {

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -41,7 +41,7 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 			# search pull requests matching set of keywords "fix" and "bug"
 			$ gh search prs fix bug
 
-			# search draft pull requests in cli repository 
+			# search draft pull requests in cli repository
 			$ gh search prs --repo=cli/cli --draft
 
 			# search open pull requests requesting your review
@@ -53,8 +53,8 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 			# search pull requests with numerous reactions
 			$ gh search prs --reactions=">100"
 
-			# search pull requests with excluded labels
-			$ gh search prs -- --label: labels to exclude
+			# search pull requests without label "bug"
+			$ gh search prs -- -label:bug
     `),
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 && c.Flags().NFlag() == 0 {

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -60,6 +60,9 @@ func NewCmdRepos(f *cmdutil.Factory, runF func(*ReposOptions) error) *cobra.Comm
 
 			# search repositories by coding language and number of good first issues
 			$ gh search repos --language=go --good-first-issues=">=10"
+
+			# search repositories without topic "linux"
+			$ gh search repos -- -topic:linux
     `),
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 && c.Flags().NFlag() == 0 {


### PR DESCRIPTION
Fixes #5501 

As discussed in the issue, an example has been added for exluding labels when searching pull requests.

I still think it would be good to have a specific flag for this but I feel like this is something that requies some thought and that this pull request at least shows an example of how to achieve what the creator of issue 5501 was trying to do.
