### PR TITLE
Fix non-working `gh issue view` usage example

### DIFF
--- a/pkg/cmd/issue/issue.go
+++ b/pkg/cmd/issue/issue.go
@@ -24,7 +24,7 @@ func NewCmdIssue(f *cmdutil.Factory) *cobra.Command {
 		Example: heredoc.Doc(`
 			$ gh issue list
 			$ gh issue create --label bug
-			$ gh issue view --web
+			$ gh issue view 353 --web
 		`),
 		Annotations: map[string]string{
 			"IsCore": "true",

--- a/pkg/cmd/issue/issue.go
+++ b/pkg/cmd/issue/issue.go
@@ -24,7 +24,7 @@ func NewCmdIssue(f *cmdutil.Factory) *cobra.Command {
 		Example: heredoc.Doc(`
 			$ gh issue list
 			$ gh issue create --label bug
-			$ gh issue view 353 --web
+			$ gh issue view 123 --web
 		`),
 		Annotations: map[string]string{
 			"IsCore": "true",


### PR DESCRIPTION
`gh issue view` always requires an argument to be passed.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
