### PR TITLE
Use `--visiblity` flag instead of `--private` and `--public`

### DIFF
--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -386,6 +386,8 @@ func RepositoryGraphQL(fields []string) string {
 			q = append(q, "pullRequests(states:OPEN){totalCount}")
 		case "defaultBranchRef":
 			q = append(q, "defaultBranchRef{name}")
+		case "visibility":
+			q = append(q, "visibility")
 		default:
 			q = append(q, field)
 		}

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -386,8 +386,6 @@ func RepositoryGraphQL(fields []string) string {
 			q = append(q, "pullRequests(states:OPEN){totalCount}")
 		case "defaultBranchRef":
 			q = append(q, "defaultBranchRef{name}")
-		case "visibility":
-			q = append(q, "visibility")
 		default:
 			q = append(q, field)
 		}

--- a/pkg/cmd/repo/list/fixtures/repoList.json
+++ b/pkg/cmd/repo/list/fixtures/repoList.json
@@ -11,7 +11,8 @@
             "isFork": false,
             "isPrivate": false,
             "isArchived": false,
-            "pushedAt": "2021-02-19T06:34:58Z"
+            "pushedAt": "2021-02-19T06:34:58Z",
+            "visibility": "PUBLIC"
           },
           {
             "nameWithOwner": "octocat/cli",
@@ -19,7 +20,8 @@
             "isFork": true,
             "isPrivate": false,
             "isArchived": false,
-            "pushedAt": "2021-02-19T06:06:06Z"
+            "pushedAt": "2021-02-19T06:06:06Z",
+            "visibility": "PUBLIC"
           },
           {
             "nameWithOwner": "octocat/testing",
@@ -27,7 +29,8 @@
             "isFork": false,
             "isPrivate": true,
             "isArchived": false,
-            "pushedAt": "2021-02-11T22:32:05Z"
+            "pushedAt": "2021-02-11T22:32:05Z",
+            "visibility": "PRIVATE"
           }
         ],
         "pageInfo": {

--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -5,9 +5,10 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/shurcooL/githubv4"
+
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/pkg/search"
-	"github.com/shurcooL/githubv4"
 )
 
 type RepositoryList struct {
@@ -18,7 +19,7 @@ type RepositoryList struct {
 }
 
 type FilterOptions struct {
-	Visibility  string // private, public
+	Visibility  string // private, public, internal
 	Fork        bool
 	Source      bool
 	Language    string

--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -30,7 +30,7 @@ type FilterOptions struct {
 }
 
 func listRepos(client *http.Client, hostname string, limit int, owner string, filter FilterOptions) (*RepositoryList, error) {
-	if filter.Language != "" || filter.Archived || filter.NonArchived || filter.Topic != "" {
+	if filter.Language != "" || filter.Archived || filter.NonArchived || filter.Topic != "" || filter.Visibility == "internal" {
 		return searchRepos(client, hostname, limit, owner, filter)
 	}
 

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -8,14 +8,15 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/test"
-	"github.com/google/shlex"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewCmdList(t *testing.T) {
@@ -72,7 +73,7 @@ func TestNewCmdList(t *testing.T) {
 		},
 		{
 			name: "only public",
-			cli:  "--public",
+			cli:  "--visibility=public",
 			wants: ListOptions{
 				Limit:       30,
 				Owner:       "",
@@ -87,7 +88,7 @@ func TestNewCmdList(t *testing.T) {
 		},
 		{
 			name: "only private",
-			cli:  "--private",
+			cli:  "--visibility=private",
 			wants: ListOptions{
 				Limit:       30,
 				Owner:       "",
@@ -191,9 +192,9 @@ func TestNewCmdList(t *testing.T) {
 			},
 		},
 		{
-			name:     "no public and private",
-			cli:      "--public --private",
-			wantsErr: "specify only one of `--public` or `--private`",
+			name:     "invalid visibility",
+			cli:      "--visibility=bad",
+			wantsErr: "`--visibility` only supports `public`, `private`, or `internal`",
 		},
 		{
 			name:     "no forks with sources",
@@ -385,7 +386,7 @@ func TestRepoList_filtering(t *testing.T) {
 		}),
 	)
 
-	output, err := runCommand(http, true, `--private --limit 2 `)
+	output, err := runCommand(http, true, `--visibility=private --limit 2 `)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -194,7 +194,7 @@ func TestNewCmdList(t *testing.T) {
 		{
 			name:     "invalid visibility",
 			cli:      "--visibility=bad",
-			wantsErr: "`--visibility` only supports `public`, `private`, or `internal`",
+			wantsErr: "invalid argument \"bad\" for \"--visibility\" flag: valid values are {public|private|internal}",
 		},
 		{
 			name:     "no forks with sources",


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #4151.

This pull request removes the `--private` and `--public` flags from `gh repo list`:

```bash
$  ./bin/gh repo list --public          
unknown flag: --public

Usage:  gh repo list [<owner>] [flags]

Flags:
      --archived            Show only archived rep
...
```

Instead, it used the `--visibility` flag, which can be `public`, `private`, or `internal`.

I can change the approach to introduce an `--internal` flag to maintain backward compatibility. I didn't go with that route because:

- [This](https://github.com/cli/cli/issues/4151#issuecomment-1010130213) comments.
- Even if we go with that route, to maintain consistency, `--private` would only show private repos which would alter the behavior for users who saw internal repositories with `--private`. 

Thanks in advance. 
