### PR TITLE
codespaces: add Display Name to the list command

### DIFF
--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -67,6 +67,7 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 	tp := utils.NewTablePrinter(a.io)
 	if tp.IsTTY() {
 		tp.AddField("NAME", nil, nil)
+		tp.AddField("DISPLAY NAME", nil, nil)
 		tp.AddField("REPOSITORY", nil, nil)
 		tp.AddField("BRANCH", nil, nil)
 		tp.AddField("STATE", nil, nil)
@@ -102,6 +103,7 @@ func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) er
 		}
 
 		tp.AddField(formattedName, nil, nameColor)
+		tp.AddField(c.DisplayName, nil, nil)
 		tp.AddField(c.Repository.FullName, nil, nil)
 		tp.AddField(c.branchWithGitStatus(), nil, cs.Cyan)
 		if c.PendingOperation {


### PR DESCRIPTION
Closes internal issue codespaces#6607
Closes #5426 

Adds Display Name as a column of the list command.
- Not fancy but solves a key UX friction point that we've heard multiple times
- It does not break existing contract for those that scripting around the Name column