### PR TITLE
codespaces: handle star in display name

### DIFF
--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -205,8 +205,8 @@ func chooseCodespaceFromList(ctx context.Context, codespaces []*api.Codespace) (
 	// Codespaces are indexed without the git status included as compared
 	// to how it is displayed in the prompt, so the git status symbol needs
 	// cleaning up in case it is included.
-	isDirty := codespacesDirty[answers.Codespace]
 	selectedCodespace := answers.Codespace
+	isDirty := codespacesDirty[selectedCodespace]
 	if isDirty {
 		selectedCodespace = withoutGitStatus(answers.Codespace)
 	}


### PR DESCRIPTION
Fixes internal codespaces#7651

- Changes the parsing logic to remove the last * found in a codespace selector name, if the codespace is indeed dirty
