### PR TITLE
Fix nil pointer exception in codespace selection

### DIFF
--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -158,7 +158,7 @@ func chooseCodespaceFromList(ctx context.Context, codespaces []*api.Codespace) (
 				codespacesNames[seenCodespace.idx] = fullDisplayNameWithGitStatus
 
 				// Update the git status dirty map to reflect the new name.
-				if cs.hasUnsavedChanges() {
+				if seenCodespace.cs.hasUnsavedChanges() {
 					codespacesDirty[fullDisplayNameWithGitStatus] = true
 				}
 


### PR DESCRIPTION
`gh cs` can crash if the selected codespace has uncommitted changes and is the first of multiple ones for the same repo and branch in the list. This was introduced in https://github.com/cli/cli/pull/5577 .

```
> gh cs ssh
? Choose codespace: github/github: ubiquitous pancake (master*)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x160 pc=0x194d037]

goroutine 1 [running]:
github.com/cli/cli/v2/pkg/cmd/codespace.getOrChooseCodespace({0x2ace9e8?, 0xc000180640?}, {0x2ad0d80?, 0xc00059efa0?}, {0x0?, 0x0?})
	github.com/cli/cli/v2/pkg/cmd/codespace/common.go:249 +0x157
github.com/cli/cli/v2/pkg/cmd/codespace.(*App).SSH(0xc0002b3140, {0x2acea20?, 0xc0000d4008?}, {0xc0004864a0, 0x0, 0x2}, {{0x0, 0x0}, {0x0, 0x0}, ...})
	github.com/cli/cli/v2/pkg/cmd/codespace/ssh.go:118 +0xd8
github.com/cli/cli/v2/pkg/cmd/codespace.newSSHCmd.func2(0xc000175900?, {0xc0004864a0?, 0x2?, 0x2?})
	github.com/cli/cli/v2/pkg/cmd/codespace/ssh.go:92 +0xca
github.com/spf13/cobra.(*Command).execute(0xc000175900, {0xc000486480, 0x2, 0x2})
	github.com/spf13/cobra@v1.4.0/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc000366c80)
	github.com/spf13/cobra@v1.4.0/command.go:974 +0x3b4
main.mainRun()
	github.com/cli/cli/v2/cmd/gh/main.go:225 +0xcde
main.main()
	github.com/cli/cli/v2/cmd/gh/main.go:49 +0x19
```

cc @josebalius 