### PR TITLE
Re-enable linters now that golangci-lint has been updated

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
           go mod verify
           go mod download
 
-          LINT_VERSION=1.45.2
+          LINT_VERSION=1.46.0
           curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v${LINT_VERSION}/golangci-lint-${LINT_VERSION}-linux-amd64.tar.gz | \
             tar xz --strip-components 1 --wildcards \*/golangci-lint
           mkdir -p bin && mv golangci-lint bin/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   enable:
   - gofmt
+  - nolintlint
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
When upgrading to Go 1.18 we disabled some linters because they were not supported yet. They are supported in the new version of `golangci-lint` so this PR upgrades to the newest version and re-enables the disabled linters. 

cc https://github.com/cli/cli/pull/5542