### PR TITLE
Add --upstream-remote-name flag to gh replo clone

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -382,6 +382,21 @@ func AddUpstreamRemote(upstreamURL, cloneDir string, branches []string) error {
 	return run.PrepareCmd(cloneCmd).Run()
 }
 
+func AddCustomUpstreamRemote(upstreamURL, upstreamName, cloneDir string, branches []string) error {
+	args := []string{"-C", cloneDir, "remote", "add"}
+	for _, branch := range branches {
+		args = append(args, "-t", branch)
+	}
+	args = append(args, "-f", upstreamName, upstreamURL)
+	cloneCmd, err := GitCommand(args...)
+	if err != nil {
+		return err
+	}
+	cloneCmd.Stdout = os.Stdout
+	cloneCmd.Stderr = os.Stderr
+	return run.PrepareCmd(cloneCmd).Run()
+}
+
 func isFilesystemPath(p string) bool {
 	return p == "." || strings.HasPrefix(p, "./") || strings.HasPrefix(p, "/")
 }

--- a/git/git.go
+++ b/git/git.go
@@ -367,27 +367,12 @@ func RunClone(cloneURL string, args []string) (target string, err error) {
 	return
 }
 
-func AddUpstreamRemote(upstreamURL, cloneDir string, branches []string) error {
-	args := []string{"-C", cloneDir, "remote", "add"}
+func AddNamedRemote(url, name, dir string, branches []string) error {
+	args := []string{"-C", dir, "remote", "add"}
 	for _, branch := range branches {
 		args = append(args, "-t", branch)
 	}
-	args = append(args, "-f", "upstream", upstreamURL)
-	cloneCmd, err := GitCommand(args...)
-	if err != nil {
-		return err
-	}
-	cloneCmd.Stdout = os.Stdout
-	cloneCmd.Stderr = os.Stderr
-	return run.PrepareCmd(cloneCmd).Run()
-}
-
-func AddCustomUpstreamRemote(upstreamURL, upstreamName, cloneDir string, branches []string) error {
-	args := []string{"-C", cloneDir, "remote", "add"}
-	for _, branch := range branches {
-		args = append(args, "-t", branch)
-	}
-	args = append(args, "-f", upstreamName, upstreamURL)
+	args = append(args, "-f", name, url)
 	cloneCmd, err := GitCommand(args...)
 	if err != nil {
 		return err

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -181,37 +181,40 @@ func TestParseExtraCloneArgs(t *testing.T) {
 	}
 }
 
-func TestAddUpstreamRemote(t *testing.T) {
+func TestAddNamedRemote(t *testing.T) {
 	tests := []struct {
-		name        string
-		upstreamURL string
-		cloneDir    string
-		branches    []string
-		want        string
+		title    string
+		name     string
+		url      string
+		dir      string
+		branches []string
+		want     string
 	}{
 		{
-			name:        "fetch all",
-			upstreamURL: "URL",
-			cloneDir:    "DIRECTORY",
-			branches:    []string{},
-			want:        "git -C DIRECTORY remote add -f upstream URL",
+			title:    "fetch all",
+			name:     "test",
+			url:      "URL",
+			dir:      "DIRECTORY",
+			branches: []string{},
+			want:     "git -C DIRECTORY remote add -f test URL",
 		},
 		{
-			name:        "fetch specific branches only",
-			upstreamURL: "URL",
-			cloneDir:    "DIRECTORY",
-			branches:    []string{"master", "dev"},
-			want:        "git -C DIRECTORY remote add -t master -t dev -f upstream URL",
+			title:    "fetch specific branches only",
+			name:     "test",
+			url:      "URL",
+			dir:      "DIRECTORY",
+			branches: []string{"trunk", "dev"},
+			want:     "git -C DIRECTORY remote add -t trunk -t dev -f test URL",
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.title, func(t *testing.T) {
 			cs, cmdTeardown := run.Stub()
 			defer cmdTeardown(t)
 
 			cs.Register(tt.want, 0, "")
 
-			err := AddUpstreamRemote(tt.upstreamURL, tt.cloneDir, tt.branches)
+			err := AddNamedRemote(tt.url, tt.name, tt.dir, tt.branches)
 			if err != nil {
 				t.Fatalf("error running command `git remote add -f`: %v", err)
 			}

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -20,10 +20,8 @@ type CloneOptions struct {
 	HttpClient func() (*http.Client, error)
 	Config     func() (config.Config, error)
 	IO         *iostreams.IOStreams
-	Exporter   cmdutil.Exporter
 
 	GitArgs      []string
-	MagicFields  []string
 	Repository   string
 	UpstreamName string
 }
@@ -66,7 +64,6 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 	}
 
 	cmd.Flags().StringVarP(&opts.UpstreamName, "upstream-remote-name", "u", "upstream", "Upstream remote name when cloning a fork")
-	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.RepositoryFields)
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		if err == pflag.ErrHelp {
 			return err

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -317,7 +317,7 @@ func forkRun(opts *ForkOptions) error {
 			}
 
 			upstreamURL := ghrepo.FormatRemoteURL(repoToFork, protocol)
-			err = git.AddUpstreamRemote(upstreamURL, cloneDir, []string{})
+			err = git.AddNamedRemote(upstreamURL, "upstream", cloneDir, []string{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #5467 

First take on the issue here, also newer to Go and the project so any guidance would be greatly appreciated.

- [x] Added `--upstream-remote-name` flag
- [x] Added `@owner` decorator

![image](https://user-images.githubusercontent.com/1892225/169634066-353045ce-d1a5-42f1-a29a-42682c2cb2ed.png)

![image](https://user-images.githubusercontent.com/1892225/169634011-8a16c2f4-5bed-44ac-b5ff-55b6e8ecf7a5.png)

