### PR TITLE
removing confusing user search text

### DIFF
--- a/pkg/cmd/search/search.go
+++ b/pkg/cmd/search/search.go
@@ -12,7 +12,7 @@ import (
 func NewCmdSearch(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search <command>",
-		Short: "Search for repositories, issues, pull requests and users",
+		Short: "Search for repositories, issues, and pull requests",
 		Long:  "Search across all of GitHub.",
 	}
 


### PR DESCRIPTION
the short text here claims that this command can search users, which doesn't exist. Was this removed, or is it maybe planned for future work? I'd personally love to have it added!

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
