### PR TITLE
Replace uses of strings.Title

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
@@ -66,7 +67,6 @@ require (
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
-	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
 

--- a/internal/codespaces/states.go
+++ b/internal/codespaces/states.go
@@ -12,16 +12,14 @@ import (
 
 	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/pkg/liveshare"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
+	"github.com/cli/cli/v2/pkg/text"
 )
 
 // PostCreateStateStatus is a string value representing the different statuses a state can have.
 type PostCreateStateStatus string
 
 func (p PostCreateStateStatus) String() string {
-	c := cases.Title(language.English)
-	return c.String(string(p))
+	return text.Title(string(p))
 }
 
 const (

--- a/internal/codespaces/states.go
+++ b/internal/codespaces/states.go
@@ -8,18 +8,20 @@ import (
 	"io"
 	"log"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/pkg/liveshare"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // PostCreateStateStatus is a string value representing the different statuses a state can have.
 type PostCreateStateStatus string
 
 func (p PostCreateStateStatus) String() string {
-	return strings.Title(string(p))
+	c := cases.Title(language.English)
+	return c.String(string(p))
 }
 
 const (

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -19,6 +19,8 @@ import (
 	"github.com/cli/cli/v2/pkg/set"
 	"github.com/cli/cli/v2/utils"
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type browser interface {
@@ -256,7 +258,8 @@ func printHumanIssuePreview(opts *ViewOptions, issue *api.Issue) error {
 
 func issueStateTitleWithColor(cs *iostreams.ColorScheme, issue *api.Issue) string {
 	colorFunc := cs.ColorFromString(prShared.ColorForIssueState(*issue))
-	return colorFunc(strings.Title(strings.ToLower(issue.State)))
+	c := cases.Title(language.English)
+	return colorFunc(c.String(strings.ToLower(issue.State)))
 }
 
 func issueAssigneeList(issue api.Issue) string {

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -19,8 +19,6 @@ import (
 	"github.com/cli/cli/v2/pkg/set"
 	"github.com/cli/cli/v2/utils"
 	"github.com/spf13/cobra"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 type browser interface {
@@ -258,8 +256,11 @@ func printHumanIssuePreview(opts *ViewOptions, issue *api.Issue) error {
 
 func issueStateTitleWithColor(cs *iostreams.ColorScheme, issue *api.Issue) string {
 	colorFunc := cs.ColorFromString(prShared.ColorForIssueState(*issue))
-	c := cases.Title(language.English)
-	return colorFunc(c.String(strings.ToLower(issue.State)))
+	state := "Open"
+	if issue.State == "CLOSED" {
+		state = "Closed"
+	}
+	return colorFunc(state)
 }
 
 func issueAssigneeList(issue api.Issue) string {

--- a/pkg/cmd/pr/shared/comments.go
+++ b/pkg/cmd/pr/shared/comments.go
@@ -10,6 +10,8 @@ import (
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/markdown"
 	"github.com/cli/cli/v2/utils"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type Comment interface {
@@ -99,7 +101,8 @@ func formatComment(io *iostreams.IOStreams, comment Comment, newest bool) (strin
 		fmt.Fprint(&b, formatCommentStatus(cs, comment.Status()))
 	}
 	if comment.Association() != "NONE" {
-		fmt.Fprint(&b, cs.Boldf(" (%s)", strings.Title(strings.ToLower(comment.Association()))))
+		c := cases.Title(language.English)
+		fmt.Fprint(&b, cs.Boldf(" (%s)", c.String(strings.ToLower(comment.Association()))))
 	}
 	fmt.Fprint(&b, cs.Boldf(" • %s", utils.FuzzyAgoAbbr(time.Now(), comment.Created())))
 	if comment.IsEdited() {
@@ -195,7 +198,8 @@ func formatHiddenComment(comment Comment) string {
 	var b strings.Builder
 	fmt.Fprint(&b, comment.AuthorLogin())
 	if comment.Association() != "NONE" {
-		fmt.Fprintf(&b, " (%s)", strings.Title(strings.ToLower(comment.Association())))
+		c := cases.Title(language.English)
+		fmt.Fprintf(&b, " (%s)", c.String(strings.ToLower(comment.Association())))
 	}
 	fmt.Fprintf(&b, " • This comment has been marked as %s\n\n", comment.HiddenReason())
 	return b.String()

--- a/pkg/cmd/pr/shared/comments.go
+++ b/pkg/cmd/pr/shared/comments.go
@@ -9,9 +9,8 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/markdown"
+	"github.com/cli/cli/v2/pkg/text"
 	"github.com/cli/cli/v2/utils"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 type Comment interface {
@@ -101,8 +100,7 @@ func formatComment(io *iostreams.IOStreams, comment Comment, newest bool) (strin
 		fmt.Fprint(&b, formatCommentStatus(cs, comment.Status()))
 	}
 	if comment.Association() != "NONE" {
-		c := cases.Title(language.English)
-		fmt.Fprint(&b, cs.Boldf(" (%s)", c.String(strings.ToLower(comment.Association()))))
+		fmt.Fprint(&b, cs.Boldf(" (%s)", text.Title(comment.Association())))
 	}
 	fmt.Fprint(&b, cs.Boldf(" • %s", utils.FuzzyAgoAbbr(time.Now(), comment.Created())))
 	if comment.IsEdited() {
@@ -198,8 +196,7 @@ func formatHiddenComment(comment Comment) string {
 	var b strings.Builder
 	fmt.Fprint(&b, comment.AuthorLogin())
 	if comment.Association() != "NONE" {
-		c := cases.Title(language.English)
-		fmt.Fprintf(&b, " (%s)", c.String(strings.ToLower(comment.Association())))
+		fmt.Fprintf(&b, " (%s)", text.Title(comment.Association()))
 	}
 	fmt.Fprintf(&b, " • This comment has been marked as %s\n\n", comment.HiddenReason())
 	return b.String()

--- a/pkg/cmd/pr/shared/display.go
+++ b/pkg/cmd/pr/shared/display.go
@@ -8,15 +8,17 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/utils"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func StateTitleWithColor(cs *iostreams.ColorScheme, pr api.PullRequest) string {
 	prStateColorFunc := cs.ColorFromString(ColorForPRState(pr))
-
+	c := cases.Title(language.English)
 	if pr.State == "OPEN" && pr.IsDraft {
-		return prStateColorFunc(strings.Title(strings.ToLower("Draft")))
+		return prStateColorFunc(c.String(strings.ToLower("Draft")))
 	}
-	return prStateColorFunc(strings.Title(strings.ToLower(pr.State)))
+	return prStateColorFunc(c.String(strings.ToLower(pr.State)))
 }
 
 func ColorForPRState(pr api.PullRequest) string {

--- a/pkg/cmd/pr/shared/display.go
+++ b/pkg/cmd/pr/shared/display.go
@@ -2,23 +2,20 @@ package shared
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/pkg/text"
 	"github.com/cli/cli/v2/utils"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 func StateTitleWithColor(cs *iostreams.ColorScheme, pr api.PullRequest) string {
 	prStateColorFunc := cs.ColorFromString(ColorForPRState(pr))
-	c := cases.Title(language.English)
 	if pr.State == "OPEN" && pr.IsDraft {
-		return prStateColorFunc(c.String(strings.ToLower("Draft")))
+		return prStateColorFunc("Draft")
 	}
-	return prStateColorFunc(c.String(strings.ToLower(pr.State)))
+	return prStateColorFunc(text.Title(pr.State))
 }
 
 func ColorForPRState(pr api.PullRequest) string {

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -254,23 +254,20 @@ type reviewerState struct {
 
 // formattedReviewerState formats a reviewerState with state color
 func formattedReviewerState(cs *iostreams.ColorScheme, reviewer *reviewerState) string {
-	state := reviewer.State
-	if state == dismissedReviewState {
-		// Show "DISMISSED" review as "COMMENTED", since "dismissed" only makes
-		// sense when displayed in an events timeline but not in the final tally.
-		state = commentedReviewState
-	}
-
 	var displayState string
-	switch state {
+	switch reviewer.State {
 	case requestedReviewState:
 		displayState = cs.Yellow("Requested")
 	case approvedReviewState:
 		displayState = cs.Green("Approved")
 	case changesRequestedReviewState:
 		displayState = cs.Red("Changes requested")
+	case commentedReviewState, dismissedReviewState:
+		// Show "DISMISSED" review as "COMMENTED", since "dismissed" only makes
+		// sense when displayed in an events timeline but not in the final tally.
+		displayState = "Commented"
 	default:
-		displayState = text.Title(state)
+		displayState = text.Title(reviewer.State)
 	}
 
 	return fmt.Sprintf("%s (%s)", reviewer.Name, displayState)

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -12,10 +12,9 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/markdown"
+	"github.com/cli/cli/v2/pkg/text"
 	"github.com/cli/cli/v2/utils"
 	"github.com/spf13/cobra"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 type browser interface {
@@ -262,20 +261,19 @@ func formattedReviewerState(cs *iostreams.ColorScheme, reviewer *reviewerState) 
 		state = commentedReviewState
 	}
 
-	var colorFunc func(string) string
+	var displayState string
 	switch state {
 	case requestedReviewState:
-		colorFunc = cs.Yellow
+		displayState = cs.Yellow("Requested")
 	case approvedReviewState:
-		colorFunc = cs.Green
+		displayState = cs.Green("Approved")
 	case changesRequestedReviewState:
-		colorFunc = cs.Red
+		displayState = cs.Red("Changes requested")
 	default:
-		colorFunc = func(str string) string { return str } // Do nothing
+		displayState = text.Title(state)
 	}
 
-	c := cases.Title(language.English)
-	return fmt.Sprintf("%s (%s)", reviewer.Name, colorFunc(strings.ReplaceAll(c.String(strings.ToLower(state)), "_", " ")))
+	return fmt.Sprintf("%s (%s)", reviewer.Name, displayState)
 }
 
 // prReviewerList generates a reviewer list with their last state

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -14,6 +14,8 @@ import (
 	"github.com/cli/cli/v2/pkg/markdown"
 	"github.com/cli/cli/v2/utils"
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type browser interface {
@@ -272,7 +274,8 @@ func formattedReviewerState(cs *iostreams.ColorScheme, reviewer *reviewerState) 
 		colorFunc = func(str string) string { return str } // Do nothing
 	}
 
-	return fmt.Sprintf("%s (%s)", reviewer.Name, colorFunc(strings.ReplaceAll(strings.Title(strings.ToLower(state)), "_", " ")))
+	c := cases.Title(language.English)
+	return fmt.Sprintf("%s (%s)", reviewer.Name, colorFunc(strings.ReplaceAll(c.String(strings.ToLower(state)), "_", " ")))
 }
 
 // prReviewerList generates a reviewer list with their last state

--- a/pkg/cmd/secret/shared/shared.go
+++ b/pkg/cmd/secret/shared/shared.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
+	"github.com/cli/cli/v2/pkg/text"
 )
 
 type Visibility string
@@ -31,8 +30,7 @@ func (app App) String() string {
 }
 
 func (app App) Title() string {
-	c := cases.Title(language.English)
-	return c.String(app.String())
+	return text.Title(app.String())
 }
 
 type SecretEntity string

--- a/pkg/cmd/secret/shared/shared.go
+++ b/pkg/cmd/secret/shared/shared.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type Visibility string
@@ -28,7 +31,8 @@ func (app App) String() string {
 }
 
 func (app App) Title() string {
-	return strings.Title(app.String())
+	c := cases.Title(language.English)
+	return c.String(app.String())
 }
 
 type SecretEntity string

--- a/pkg/text/convert.go
+++ b/pkg/text/convert.go
@@ -1,6 +1,11 @@
 package text
 
-import "unicode"
+import (
+	"unicode"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
 
 // Copied from: https://github.com/asaskevich/govalidator
 func CamelToKebab(str string) string {
@@ -26,4 +31,9 @@ func addSegment(inrune, segment []rune) []rune {
 	}
 	inrune = append(inrune, segment...)
 	return inrune
+}
+
+func Title(str string) string {
+	c := cases.Title(language.English)
+	return c.String(str)
 }


### PR DESCRIPTION
After re-enabling linters in https://github.com/cli/cli/pull/5615, the re-enabled ones found some deprecation warnings around using `strings.Title` which is causing our lint CI job to fail. This replaces the uses of `strings.Title` and fixes the linter errors.