### PR TITLE
Fix struct field tag

### DIFF
--- a/pkg/cmd/label/shared.go
+++ b/pkg/cmd/label/shared.go
@@ -21,7 +21,7 @@ type label struct {
 	Color       string    `json:"color"`
 	CreatedAt   time.Time `json:"createdAt"`
 	Description string    `json:"description"`
-	ID          string    `json:"id"`
+	ID          string    `json:"node_id"`
 	IsDefault   bool      `json:"isDefault"`
 	Name        string    `json:"name"`
 	URL         string    `json:"url"`


### PR DESCRIPTION
This tag should point to the `node_id` not the database `id`.
Fixes https://github.com/cli/cli/issues/5633