### PR TITLE
Change int to uint64 for large fields

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -198,8 +198,8 @@ type CodespaceMachine struct {
 	Name            string `json:"name"`
 	DisplayName     string `json:"display_name"`
 	OperatingSystem string `json:"operating_system"`
-	StorageInBytes  int64  `json:"storage_in_bytes"`
-	MemoryInBytes   int64  `json:"memory_in_bytes"`
+	StorageInBytes  uint64 `json:"storage_in_bytes"`
+	MemoryInBytes   uint64 `json:"memory_in_bytes"`
 	CPUCount        int    `json:"cpus"`
 }
 

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -198,8 +198,8 @@ type CodespaceMachine struct {
 	Name            string `json:"name"`
 	DisplayName     string `json:"display_name"`
 	OperatingSystem string `json:"operating_system"`
-	StorageInBytes  int    `json:"storage_in_bytes"`
-	MemoryInBytes   int    `json:"memory_in_bytes"`
+	StorageInBytes  int64  `json:"storage_in_bytes"`
+	MemoryInBytes   int64  `json:"memory_in_bytes"`
 	CPUCount        int    `json:"cpus"`
 }
 


### PR DESCRIPTION
@cli/codespaces I went ahead and changed `StorageInBytes` and `MemoryInBytes` to `uint64` type to prevent the integer overflow described in https://github.com/cli/cli/issues/5645. Let me know if you think another approach is more appropriate.

Fixes https://github.com/cli/cli/issues/5645