### PR TITLE
filter out internal ports from gh cs ports list

### DIFF
--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -22,6 +22,11 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	vscodeServerPortName       = "VSCodeServerInternal"
+	codespacesInternalPortName = "CodespacesInternal"
+)
+
 // newPortsCmd returns a Cobra "ports" command that displays a table of available ports,
 // according to the specified flags.
 func newPortsCmd(app *App) *cobra.Command {
@@ -74,13 +79,19 @@ func (a *App) ListPorts(ctx context.Context, codespaceName string, exporter cmdu
 		a.errLogger.Printf("Failed to get port names: %v", devContainerResult.err.Error())
 	}
 
-	portInfos := make([]*portInfo, len(ports))
-	for i, p := range ports {
-		portInfos[i] = &portInfo{
+	var portInfos []*portInfo
+
+	for _, p := range ports {
+		p := p
+		// filter out internal ports from list
+		if strings.HasPrefix(p.SessionName, vscodeServerPortName) || strings.HasPrefix(p.SessionName, codespacesInternalPortName) {
+			continue
+		}
+		portInfos = append(portInfos, &portInfo{
 			Port:         p,
 			codespace:    codespace,
 			devContainer: devContainerResult.devContainer,
-		}
+		})
 	}
 
 	if err := a.io.StartPager(); err != nil {

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -82,7 +82,6 @@ func (a *App) ListPorts(ctx context.Context, codespaceName string, exporter cmdu
 	var portInfos []*portInfo
 
 	for _, p := range ports {
-		p := p
 		// filter out internal ports from list
 		if strings.HasPrefix(p.SessionName, vscodeServerPortName) || strings.HasPrefix(p.SessionName, codespacesInternalPortName) {
 			continue


### PR DESCRIPTION
Fixes internal issue: https://github.com/github/codespaces/issues/8067

Filters out internal ports used by Codespaces that should not show up in the `ports` output list.

This matches the behavior that we have in the VSCode ports view. See above linked issue for more details.

## Before

```
✦ ➜ gh cs ports
? Choose codespace: cli/cli: trunk
LABEL  PORT   VISIBILITY  BROWSE URL
       16634  private     https://markphelps-cli-cli-gp776wcr7r-16634.githubpreview.dev
       16635  private     https://markphelps-cli-cli-gp776wcr7r-16635.githubpreview.dev
       42909  private     https://markphelps-cli-cli-gp776wcr7r-42909.githubpreview.dev
       2222   private     https://markphelps-cli-cli-gp776wcr7r-2222.githubpreview.dev
```

## After

```
✦ ➜ ./bin/gh cs ports
? Choose codespace: cli/cli: trunk
LABEL  PORT  VISIBILITY  BROWSE URL
       2222  private     https://markphelps-cli-cli-gp776wcr7r-2222.githubpreview.dev
```