### PR TITLE
Bugfix: Retention period is being sent to the API as 0

### DIFF
--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -88,7 +88,7 @@ func newCreateCmd(app *App) *cobra.Command {
 	createCmd.Flags().BoolVarP(&opts.permissionsOptOut, "default-permissions", "", false, "do not prompt to accept additional permissions requested by the codespace")
 	createCmd.Flags().BoolVarP(&opts.showStatus, "status", "s", false, "show status of post-create command and dotfiles")
 	createCmd.Flags().DurationVar(&opts.idleTimeout, "idle-timeout", 0, "allowed inactivity before codespace is stopped, e.g. \"10m\", \"1h\"")
-	// createCmd.Flags().Var(&opts.retentionPeriod, "retention-period", "allowed time after going idle before codespace is automatically deleted (maximum 30 days), e.g. \"1h\", \"72h\"")
+	// createCmd.Flags().Var(&opts.retentionPeriod, "retention-period", "allowed time after shutting down before the codespace is automatically deleted (maximum 30 days), e.g. \"1h\", \"72h\"")
 	createCmd.Flags().StringVar(&opts.devContainerPath, "devcontainer-path", "", "path to the devcontainer.json file to use when creating codespace")
 
 	return createCmd

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -32,7 +32,7 @@ type createOptions struct {
 	permissionsOptOut bool
 	devContainerPath  string
 	idleTimeout       time.Duration
-	retentionPeriod   time.Duration
+	retentionPeriod   string
 }
 
 func newCreateCmd(app *App) *cobra.Command {
@@ -54,7 +54,7 @@ func newCreateCmd(app *App) *cobra.Command {
 	createCmd.Flags().BoolVarP(&opts.permissionsOptOut, "default-permissions", "", false, "do not prompt to accept additional permissions requested by the codespace")
 	createCmd.Flags().BoolVarP(&opts.showStatus, "status", "s", false, "show status of post-create command and dotfiles")
 	createCmd.Flags().DurationVar(&opts.idleTimeout, "idle-timeout", 0, "allowed inactivity before codespace is stopped, e.g. \"10m\", \"1h\"")
-	// createCmd.Flags().DurationVar(&opts.retentionPeriod, "retention-period", 0, "allowed time after going idle before codespace is automatically deleted (maximum 30 days), e.g. \"1h\", \"72h\"")
+	// createCmd.Flags().StringVar(&opts.retentionPeriod, "retention-period", "", "allowed time after going idle before codespace is automatically deleted (maximum 30 days), e.g. \"1h\", \"72h\"")
 	createCmd.Flags().StringVar(&opts.devContainerPath, "devcontainer-path", "", "path to the devcontainer.json file to use when creating codespace")
 
 	return createCmd
@@ -178,7 +178,15 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return errors.New("there are no available machine types for this repository")
 	}
 
-	retentionPeriod := int(opts.retentionPeriod.Minutes())
+	var retentionPeriod *int
+	if opts.retentionPeriod != "" {
+		retentionMinutesf, err := time.ParseDuration(opts.retentionPeriod)
+		if err != nil {
+			return fmt.Errorf("error parsing retention period: %w", err)
+		}
+		retentionMinutei := int(retentionMinutesf.Minutes())
+		retentionPeriod = &retentionMinutei
+	}
 
 	createParams := &api.CreateCodespaceParams{
 		RepositoryID:           repository.ID,
@@ -188,7 +196,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		VSCSTarget:             vscsTarget,
 		VSCSTargetURL:          vscsTargetUrl,
 		IdleTimeoutMinutes:     int(opts.idleTimeout.Minutes()),
-		RetentionPeriodMinutes: &retentionPeriod,
+		RetentionPeriodMinutes: retentionPeriod,
 		DevContainerPath:       devContainerPath,
 		PermissionsOptOut:      opts.permissionsOptOut,
 	}

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -38,7 +38,7 @@ func (d *NullableDuration) String() string {
 func (d *NullableDuration) Set(str string) error {
 	duration, err := time.ParseDuration(str)
 	if err != nil {
-		return fmt.Errorf("error duration: %w", err)
+		return fmt.Errorf("error parsing duration: %w", err)
 	}
 	d.Duration = &duration
 	return nil

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -48,6 +48,15 @@ func (d *NullableDuration) Type() string {
 	return "duration"
 }
 
+func (d *NullableDuration) Minutes() *int {
+	if d.Duration != nil {
+		retentionMinutes := int(d.Duration.Minutes())
+		return &retentionMinutes
+	}
+
+	return nil
+}
+
 type createOptions struct {
 	repo              string
 	branch            string
@@ -204,19 +213,16 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 	}
 
 	createParams := &api.CreateCodespaceParams{
-		RepositoryID:       repository.ID,
-		Branch:             branch,
-		Machine:            machine,
-		Location:           userInputs.Location,
-		VSCSTarget:         vscsTarget,
-		VSCSTargetURL:      vscsTargetUrl,
-		IdleTimeoutMinutes: int(opts.idleTimeout.Minutes()),
-		DevContainerPath:   devContainerPath,
-		PermissionsOptOut:  opts.permissionsOptOut,
-	}
-	if opts.retentionPeriod.Duration != nil {
-		retentionMinutes := int(opts.retentionPeriod.Duration.Minutes())
-		createParams.RetentionPeriodMinutes = &retentionMinutes
+		RepositoryID:           repository.ID,
+		Branch:                 branch,
+		Machine:                machine,
+		Location:               userInputs.Location,
+		VSCSTarget:             vscsTarget,
+		VSCSTargetURL:          vscsTargetUrl,
+		IdleTimeoutMinutes:     int(opts.idleTimeout.Minutes()),
+		RetentionPeriodMinutes: opts.retentionPeriod.Minutes(),
+		DevContainerPath:       devContainerPath,
+		PermissionsOptOut:      opts.permissionsOptOut,
 	}
 
 	a.StartProgressIndicatorWithLabel("Creating codespace")

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -72,7 +72,7 @@ func TestApp_Create(t *testing.T) {
 				machine:         "GIGA",
 				showStatus:      false,
 				idleTimeout:     30 * time.Minute,
-				retentionPeriod: "48h",
+				retentionPeriod: NullableDuration{durationPtr(48 * time.Hour)},
 			},
 			wantStdout: "monalisa-dotfiles-abcd1234\n",
 		},
@@ -383,4 +383,8 @@ func TestBuildDisplayName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func durationPtr(d time.Duration) *time.Duration {
+	return &d
 }

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -72,7 +72,7 @@ func TestApp_Create(t *testing.T) {
 				machine:         "GIGA",
 				showStatus:      false,
 				idleTimeout:     30 * time.Minute,
-				retentionPeriod: 48 * time.Hour,
+				retentionPeriod: "48h",
 			},
 			wantStdout: "monalisa-dotfiles-abcd1234\n",
 		},

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -55,7 +55,7 @@ func TestApp_Create(t *testing.T) {
 							return nil, fmt.Errorf("idle timeout minutes was %v", params.IdleTimeoutMinutes)
 						}
 						if *params.RetentionPeriodMinutes != 2880 {
-							return nil, fmt.Errorf("retention period minutes was %v", params.RetentionPeriodMinutes)
+							return nil, fmt.Errorf("retention period minutes expected 2880, was %v", params.RetentionPeriodMinutes)
 						}
 						return &api.Codespace{
 							Name: "monalisa-dotfiles-abcd1234",
@@ -104,6 +104,9 @@ func TestApp_Create(t *testing.T) {
 						}
 						if params.IdleTimeoutMinutes != 30 {
 							return nil, fmt.Errorf("idle timeout minutes was %v", params.IdleTimeoutMinutes)
+						}
+						if params.RetentionPeriodMinutes != nil {
+							return nil, fmt.Errorf("retention period minutes expected nil, was %v", params.RetentionPeriodMinutes)
 						}
 						if params.DevContainerPath != ".devcontainer/foobar/devcontainer.json" {
 							return nil, fmt.Errorf("got dev container path %q, want %q", params.DevContainerPath, ".devcontainer/foobar/devcontainer.json")
@@ -325,14 +328,20 @@ Alternatively, you can run "create" with the "--default-permissions" option to c
 				apiClient: tt.fields.apiClient,
 			}
 
-			if err := a.Create(context.Background(), tt.opts); err != nil && tt.wantErr != nil {
+			err := a.Create(context.Background(), tt.opts)
+			if err != nil && tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			}
+			if err != nil && tt.wantErr == nil {
+				t.Logf(err.Error())
+			}
 			if got := stdout.String(); got != tt.wantStdout {
-				t.Errorf("stdout = %v, want %v", got, tt.wantStdout)
+				t.Logf(t.Name())
+				t.Errorf("  stdout = %v, want %v", got, tt.wantStdout)
 			}
 			if got := stderr.String(); got != tt.wantStderr {
-				t.Errorf("stderr = %v, want %v", got, tt.wantStderr)
+				t.Logf(t.Name())
+				t.Errorf("  stderr = %v, want %v", got, tt.wantStderr)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

The initialized value of `time.Duration` is 0. There is support for `nil` retention period at the API interface, but we missed support for this at the parameters. Thus, the API request is being made with `0` as the retention period.

This PR switches the argument type to a string and treats an empty string as a no-retention-period scenario and attempts to parse the string as a duration if the string is non-empty.