### PR TITLE
Fix Cobra completion output going to stdout

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -57,8 +57,8 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 		},
 	}
 
-	cmd.SetOut(f.IOStreams.ErrOut) // command usage summary and deprecation warnings
-	cmd.SetErr(f.IOStreams.ErrOut) // error messages
+	// cmd.SetOut(f.IOStreams.Out)    // can't use due to https://github.com/spf13/cobra/issues/1708
+	// cmd.SetErr(f.IOStreams.ErrOut) // just let it default to os.Stderr instead
 
 	cmd.Flags().Bool("version", false, "Show gh version")
 	cmd.PersistentFlags().Bool("help", false, "Show help for command")


### PR DESCRIPTION
If we don't ever call `cmd.SetOut()`, Cobra's default streams are actually okay and send things appropriately to stdout/stderr. It's only if we call this method that our problems start: https://github.com/spf13/cobra/issues/1708

Fixes https://github.com/cli/cli/issues/5709
Regression from https://github.com/cli/cli/pull/5698
Ref. https://github.com/cli/cli/issues/5674
Ref. https://github.com/cli/cli/pull/5703