### PR TITLE
Added Arm64 compilation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,7 @@ builds:
   - <<: *build_defaults
     id: windows
     goos: [windows]
-    goarch: [386, amd64]
+    goarch: [386, amd64, arm64]
     hooks:
       post:
         - ./script/sign-windows-executable.sh '{{ .Path }}'

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -860,6 +860,7 @@ func possibleDists() []string {
 		"windows-386",
 		"windows-amd64",
 		"windows-arm",
+		"windows-arm64",
 	}
 }
 


### PR DESCRIPTION
Partially fixes #2545

There is still work needed for automating the release (sign, build msi, etc) into the releases.yml file, but this should at least build the exe into the artifacts, as well as allow users to use arm64 extensions.