### PR TITLE
Extract LiveshareSession interface

### DIFF
--- a/pkg/liveshare/client.go
+++ b/pkg/liveshare/client.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	"golang.org/x/crypto/ssh"
 )
 
 type logger interface {
@@ -135,42 +134,4 @@ type joinWorkspaceArgs struct {
 
 type joinWorkspaceResult struct {
 	SessionNumber int `json:"sessionNumber"`
-}
-
-// A channelID is an identifier for an exposed port on a remote
-// container that may be used to open an SSH channel to it.
-type channelID struct {
-	name, condition string
-}
-
-func (s *Session) openStreamingChannel(ctx context.Context, id channelID) (ssh.Channel, error) {
-	type getStreamArgs struct {
-		StreamName string `json:"streamName"`
-		Condition  string `json:"condition"`
-	}
-	args := getStreamArgs{
-		StreamName: id.name,
-		Condition:  id.condition,
-	}
-	var streamID string
-	if err := s.rpc.do(ctx, "streamManager.getStream", args, &streamID); err != nil {
-		return nil, fmt.Errorf("error getting stream id: %w", err)
-	}
-
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Session.OpenChannel+SendRequest")
-	defer span.Finish()
-	_ = ctx // ctx is not currently used
-
-	channel, reqs, err := s.ssh.conn.OpenChannel("session", nil)
-	if err != nil {
-		return nil, fmt.Errorf("error opening ssh channel for transport: %w", err)
-	}
-	go ssh.DiscardRequests(reqs)
-
-	requestType := fmt.Sprintf("stream-transport-%s", streamID)
-	if _, err = channel.SendRequest(requestType, true, nil); err != nil {
-		return nil, fmt.Errorf("error sending channel request: %w", err)
-	}
-
-	return channel, nil
 }

--- a/pkg/liveshare/client.go
+++ b/pkg/liveshare/client.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	"golang.org/x/crypto/ssh"
 )
 
 type logger interface {
@@ -72,7 +71,7 @@ func (opts *Options) uri(action string) (string, error) {
 // Connect connects to a Live Share workspace specified by the
 // options, and returns a session representing the connection.
 // The caller must call the session's Close method to end the session.
-func Connect(ctx context.Context, opts Options) (*Session, error) {
+func Connect(ctx context.Context, opts Options) (LiveshareSession, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "Connect")
 	defer span.Finish()
 
@@ -135,42 +134,4 @@ type joinWorkspaceArgs struct {
 
 type joinWorkspaceResult struct {
 	SessionNumber int `json:"sessionNumber"`
-}
-
-// A channelID is an identifier for an exposed port on a remote
-// container that may be used to open an SSH channel to it.
-type channelID struct {
-	name, condition string
-}
-
-func (s *Session) openStreamingChannel(ctx context.Context, id channelID) (ssh.Channel, error) {
-	type getStreamArgs struct {
-		StreamName string `json:"streamName"`
-		Condition  string `json:"condition"`
-	}
-	args := getStreamArgs{
-		StreamName: id.name,
-		Condition:  id.condition,
-	}
-	var streamID string
-	if err := s.rpc.do(ctx, "streamManager.getStream", args, &streamID); err != nil {
-		return nil, fmt.Errorf("error getting stream id: %w", err)
-	}
-
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Session.OpenChannel+SendRequest")
-	defer span.Finish()
-	_ = ctx // ctx is not currently used
-
-	channel, reqs, err := s.ssh.conn.OpenChannel("session", nil)
-	if err != nil {
-		return nil, fmt.Errorf("error opening ssh channel for transport: %w", err)
-	}
-	go ssh.DiscardRequests(reqs)
-
-	requestType := fmt.Sprintf("stream-transport-%s", streamID)
-	if _, err = channel.SendRequest(requestType, true, nil); err != nil {
-		return nil, fmt.Errorf("error sending channel request: %w", err)
-	}
-
-	return channel, nil
 }

--- a/pkg/liveshare/port_forwarder.go
+++ b/pkg/liveshare/port_forwarder.go
@@ -12,7 +12,7 @@ import (
 // A PortForwarder forwards TCP traffic over a Live Share session from a port on a remote
 // container to a local destination such as a network port or Go reader/writer.
 type PortForwarder struct {
-	session    LiveshareSession
+	session    *Session
 	name       string
 	remotePort int
 	keepAlive  bool
@@ -22,7 +22,7 @@ type PortForwarder struct {
 // remote port and Live Share session. The name describes the purpose
 // of the remote port or service. The keepAlive flag indicates whether
 // the session should be kept alive with port forwarding traffic.
-func NewPortForwarder(session LiveshareSession, name string, remotePort int, keepAlive bool) *PortForwarder {
+func NewPortForwarder(session *Session, name string, remotePort int, keepAlive bool) *PortForwarder {
 	return &PortForwarder{
 		session:    session,
 		name:       name,
@@ -115,14 +115,14 @@ func awaitError(ctx context.Context, errc <-chan error) error {
 type trafficMonitor struct {
 	reader io.Reader
 
-	session     LiveshareSession
+	session     *Session
 	trafficType string
 }
 
 // newTrafficMonitor returns a new trafficMonitor for the specified
 // session and traffic type. It wraps the provided io.Reader with its own
 // Read method.
-func newTrafficMonitor(reader io.Reader, session LiveshareSession, trafficType string) *trafficMonitor {
+func newTrafficMonitor(reader io.Reader, session *Session, trafficType string) *trafficMonitor {
 	return &trafficMonitor{reader, session, trafficType}
 }
 

--- a/pkg/liveshare/port_forwarder.go
+++ b/pkg/liveshare/port_forwarder.go
@@ -12,7 +12,7 @@ import (
 // A PortForwarder forwards TCP traffic over a Live Share session from a port on a remote
 // container to a local destination such as a network port or Go reader/writer.
 type PortForwarder struct {
-	session    *Session
+	session    LiveshareSession
 	name       string
 	remotePort int
 	keepAlive  bool
@@ -22,7 +22,7 @@ type PortForwarder struct {
 // remote port and Live Share session. The name describes the purpose
 // of the remote port or service. The keepAlive flag indicates whether
 // the session should be kept alive with port forwarding traffic.
-func NewPortForwarder(session *Session, name string, remotePort int, keepAlive bool) *PortForwarder {
+func NewPortForwarder(session LiveshareSession, name string, remotePort int, keepAlive bool) *PortForwarder {
 	return &PortForwarder{
 		session:    session,
 		name:       name,
@@ -115,14 +115,14 @@ func awaitError(ctx context.Context, errc <-chan error) error {
 type trafficMonitor struct {
 	reader io.Reader
 
-	session     *Session
+	session     LiveshareSession
 	trafficType string
 }
 
 // newTrafficMonitor returns a new trafficMonitor for the specified
 // session and traffic type. It wraps the provided io.Reader with its own
 // Read method.
-func newTrafficMonitor(reader io.Reader, session *Session, trafficType string) *trafficMonitor {
+func newTrafficMonitor(reader io.Reader, session LiveshareSession, trafficType string) *trafficMonitor {
 	return &trafficMonitor{reader, session, trafficType}
 }
 

--- a/pkg/liveshare/ports.go
+++ b/pkg/liveshare/ports.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/sourcegraph/jsonrpc2"
-	"golang.org/x/sync/errgroup"
 )
 
 // Port describes a port exposed by the container.
@@ -29,37 +28,6 @@ const (
 	PortChangeKindStart  PortChangeKind = "start"
 	PortChangeKindUpdate PortChangeKind = "update"
 )
-
-// startSharing tells the Live Share host to start sharing the specified port from the container.
-// The sessionName describes the purpose of the remote port or service.
-// It returns an identifier that can be used to open an SSH channel to the remote port.
-func (s *Session) startSharing(ctx context.Context, sessionName string, port int) (channelID, error) {
-	args := []interface{}{port, sessionName, fmt.Sprintf("http://localhost:%d", port)}
-	g, ctx := errgroup.WithContext(ctx)
-
-	g.Go(func() error {
-		startNotification, err := s.WaitForPortNotification(ctx, port, PortChangeKindStart)
-		if err != nil {
-			return fmt.Errorf("error while waiting for port notification: %w", err)
-
-		}
-		if !startNotification.Success {
-			return fmt.Errorf("error while starting port sharing: %s", startNotification.ErrorDetail)
-		}
-		return nil // success
-	})
-
-	var response Port
-	g.Go(func() error {
-		return s.rpc.do(ctx, "serverSharing.startSharing", args, &response)
-	})
-
-	if err := g.Wait(); err != nil {
-		return channelID{}, err
-	}
-
-	return channelID{response.StreamName, response.StreamCondition}, nil
-}
 
 type PortNotification struct {
 	Success bool // Helps us disambiguate between the SharingSucceeded/SharingFailed events
@@ -113,21 +81,4 @@ func (s *Session) WaitForPortNotification(ctx context.Context, port int, notifTy
 			return notification, nil
 		}
 	}
-}
-
-// GetSharedServers returns a description of each container port
-// shared by a prior call to StartSharing by some client.
-func (s *Session) GetSharedServers(ctx context.Context) ([]*Port, error) {
-	var response []*Port
-	if err := s.rpc.do(ctx, "serverSharing.getSharedServers", []string{}, &response); err != nil {
-		return nil, err
-	}
-
-	return response, nil
-}
-
-// UpdateSharedServerPrivacy controls port permissions and visibility scopes for who can access its URLs
-// in the browser.
-func (s *Session) UpdateSharedServerPrivacy(ctx context.Context, port int, visibility string) error {
-	return s.rpc.do(ctx, "serverSharing.updateSharedServerPrivacy", []interface{}{port, visibility}, nil)
 }

--- a/pkg/liveshare/session.go
+++ b/pkg/liveshare/session.go
@@ -5,7 +5,17 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
 )
+
+// A ChannelID is an identifier for an exposed port on a remote
+// container that may be used to open an SSH channel to it.
+type ChannelID struct {
+	name, condition string
+}
 
 // A Session represents the session between a connected Live Share client and server.
 type Session struct {
@@ -91,7 +101,7 @@ func (s *Session) StartJupyterServer(ctx context.Context) (int, string, error) {
 // heartbeat runs until context cancellation, periodically checking whether there is a
 // reason to keep the connection alive, and if so, notifying the Live Share host to do so.
 // Heartbeat ensures it does not send more than one request every "interval" to ratelimit
-// how many keepAlives we send at a time.
+// how many KeepAlives we send at a time.
 func (s *Session) heartbeat(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -118,13 +128,76 @@ func (s *Session) notifyHostOfActivity(ctx context.Context, activity string) err
 	return s.rpc.do(ctx, "ICodespaceHostService.notifyCodespaceOfClientActivity", params, nil)
 }
 
-// keepAlive accepts a reason that is retained if there is no active reason
+// KeepAlive accepts a reason that is retained if there is no active reason
 // to send to the server.
-func (s *Session) keepAlive(reason string) {
+func (s *Session) KeepAlive(reason string) {
 	select {
 	case s.keepAliveReason <- reason:
 	default:
 		// there is already an active keep alive reason
 		// so we can ignore this one
 	}
+}
+
+// StartSharing tells the Live Share host to start sharing the specified port from the container.
+// The sessionName describes the purpose of the remote port or service.
+// It returns an identifier that can be used to open an SSH channel to the remote port.
+func (s *Session) StartSharing(ctx context.Context, sessionName string, port int) (ChannelID, error) {
+	args := []interface{}{port, sessionName, fmt.Sprintf("http://localhost:%d", port)}
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		startNotification, err := s.WaitForPortNotification(ctx, port, PortChangeKindStart)
+		if err != nil {
+			return fmt.Errorf("error while waiting for port notification: %w", err)
+
+		}
+		if !startNotification.Success {
+			return fmt.Errorf("error while starting port sharing: %s", startNotification.ErrorDetail)
+		}
+		return nil // success
+	})
+
+	var response Port
+	g.Go(func() error {
+		return s.rpc.do(ctx, "serverSharing.startSharing", args, &response)
+	})
+
+	if err := g.Wait(); err != nil {
+		return ChannelID{}, err
+	}
+
+	return ChannelID{response.StreamName, response.StreamCondition}, nil
+}
+
+func (s *Session) OpenStreamingChannel(ctx context.Context, id ChannelID) (ssh.Channel, error) {
+	type getStreamArgs struct {
+		StreamName string `json:"streamName"`
+		Condition  string `json:"condition"`
+	}
+	args := getStreamArgs{
+		StreamName: id.name,
+		Condition:  id.condition,
+	}
+	var streamID string
+	if err := s.rpc.do(ctx, "streamManager.getStream", args, &streamID); err != nil {
+		return nil, fmt.Errorf("error getting stream id: %w", err)
+	}
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Session.OpenChannel+SendRequest")
+	defer span.Finish()
+	_ = ctx // ctx is not currently used
+
+	channel, reqs, err := s.ssh.conn.OpenChannel("session", nil)
+	if err != nil {
+		return nil, fmt.Errorf("error opening ssh channel for transport: %w", err)
+	}
+	go ssh.DiscardRequests(reqs)
+
+	requestType := fmt.Sprintf("stream-transport-%s", streamID)
+	if _, err = channel.SendRequest(requestType, true, nil); err != nil {
+		return nil, fmt.Errorf("error sending channel request: %w", err)
+	}
+
+	return channel, nil
 }

--- a/pkg/liveshare/session.go
+++ b/pkg/liveshare/session.go
@@ -5,30 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"time"
-
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/sync/errgroup"
-
-	"github.com/opentracing/opentracing-go"
 )
-
-// A channelID is an identifier for an exposed port on a remote
-// container that may be used to open an SSH channel to it.
-type channelID struct {
-	name, condition string
-}
-
-type LiveshareSession interface {
-	StartSSHServer(context.Context) (int, string, error)
-	StartJupyterServer(context.Context) (int, string, error)
-	GetSharedServers(context.Context) ([]*Port, error)
-	UpdateSharedServerPrivacy(context.Context, int, string) error
-	startSharing(context.Context, string, int) (channelID, error)
-	keepAlive(string)
-	heartbeat(context.Context, time.Duration)
-	openStreamingChannel(context.Context, channelID) (ssh.Channel, error)
-	notifyHostOfActivity(context.Context, string) error
-}
 
 // A Session represents the session between a connected Live Share client and server.
 type Session struct {
@@ -150,84 +127,4 @@ func (s *Session) keepAlive(reason string) {
 		// there is already an active keep alive reason
 		// so we can ignore this one
 	}
-}
-
-// startSharing tells the Live Share host to start sharing the specified port from the container.
-// The sessionName describes the purpose of the remote port or service.
-// It returns an identifier that can be used to open an SSH channel to the remote port.
-func (s *Session) startSharing(ctx context.Context, sessionName string, port int) (channelID, error) {
-	args := []interface{}{port, sessionName, fmt.Sprintf("http://localhost:%d", port)}
-	g, ctx := errgroup.WithContext(ctx)
-
-	g.Go(func() error {
-		startNotification, err := s.WaitForPortNotification(ctx, port, PortChangeKindStart)
-		if err != nil {
-			return fmt.Errorf("error while waiting for port notification: %w", err)
-
-		}
-		if !startNotification.Success {
-			return fmt.Errorf("error while starting port sharing: %s", startNotification.ErrorDetail)
-		}
-		return nil // success
-	})
-
-	var response Port
-	g.Go(func() error {
-		return s.rpc.do(ctx, "serverSharing.startSharing", args, &response)
-	})
-
-	if err := g.Wait(); err != nil {
-		return channelID{}, err
-	}
-
-	return channelID{response.StreamName, response.StreamCondition}, nil
-}
-
-// GetSharedServers returns a description of each container port
-// shared by a prior call to startSharing by some client.
-func (s *Session) GetSharedServers(ctx context.Context) ([]*Port, error) {
-	var response []*Port
-	if err := s.rpc.do(ctx, "serverSharing.getSharedServers", []string{}, &response); err != nil {
-		return nil, err
-	}
-
-	return response, nil
-}
-
-// UpdateSharedServerPrivacy controls port permissions and visibility scopes for who can access its URLs
-// in the browser.
-func (s *Session) UpdateSharedServerPrivacy(ctx context.Context, port int, visibility string) error {
-	return s.rpc.do(ctx, "serverSharing.updateSharedServerPrivacy", []interface{}{port, visibility}, nil)
-}
-
-func (s *Session) openStreamingChannel(ctx context.Context, id channelID) (ssh.Channel, error) {
-	type getStreamArgs struct {
-		StreamName string `json:"streamName"`
-		Condition  string `json:"condition"`
-	}
-	args := getStreamArgs{
-		StreamName: id.name,
-		Condition:  id.condition,
-	}
-	var streamID string
-	if err := s.rpc.do(ctx, "streamManager.getStream", args, &streamID); err != nil {
-		return nil, fmt.Errorf("error getting stream id: %w", err)
-	}
-
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Session.OpenChannel+SendRequest")
-	defer span.Finish()
-	_ = ctx // ctx is not currently used
-
-	channel, reqs, err := s.ssh.conn.OpenChannel("session", nil)
-	if err != nil {
-		return nil, fmt.Errorf("error opening ssh channel for transport: %w", err)
-	}
-	go ssh.DiscardRequests(reqs)
-
-	requestType := fmt.Sprintf("stream-transport-%s", streamID)
-	if _, err = channel.SendRequest(requestType, true, nil); err != nil {
-		return nil, fmt.Errorf("error sending channel request: %w", err)
-	}
-
-	return channel, nil
 }

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -103,7 +103,7 @@ func TestServerStartSharing(t *testing.T) {
 
 	done := make(chan error)
 	go func() {
-		streamID, err := session.startSharing(ctx, serverProtocol, serverPort)
+		streamID, err := session.StartSharing(ctx, serverProtocol, serverPort)
 		if err != nil {
 			done <- fmt.Errorf("error sharing server: %w", err)
 		}
@@ -247,10 +247,10 @@ func TestInvalidHostKey(t *testing.T) {
 func TestKeepAliveNonBlocking(t *testing.T) {
 	session := &Session{keepAliveReason: make(chan string, 1)}
 	for i := 0; i < 2; i++ {
-		session.keepAlive("io")
+		session.KeepAlive("io")
 	}
 
-	// if keepAlive blocks, we'll never reach this and timeout the test
+	// if KeepAlive blocks, we'll never reach this and timeout the test
 	// timing out
 }
 
@@ -367,10 +367,10 @@ func TestSessionHeartbeat(t *testing.T) {
 
 	go session.heartbeat(ctx, 50*time.Millisecond)
 	go func() {
-		session.keepAlive("input")
+		session.KeepAlive("input")
 		wg.Wait()
 		wg.Add(1)
-		session.keepAlive("input")
+		session.KeepAlive("input")
 		wg.Wait()
 		done <- struct{}{}
 	}()
@@ -380,7 +380,7 @@ func TestSessionHeartbeat(t *testing.T) {
 		t.Errorf("error from server: %v", err)
 	case <-done:
 		activityCount := strings.Count(logger.String(), "input")
-		// by design keepAlive can drop requests, and therefore there is zero guarantee
+		// by design KeepAlive can drop requests, and therefore there is zero guarantee
 		// that we actually get two requests if the network happened to be slow (rarely)
 		// during testing.
 		if activityCount != 1 && activityCount != 2 {

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -46,7 +46,9 @@ func makeMockSession(opts ...livesharetest.ServerOption) (*livesharetest.Server,
 	if err != nil {
 		return nil, nil, fmt.Errorf("error connecting to Live Share: %w", err)
 	}
-	return testServer, session, nil
+
+	testSession, _ := session.(*Session)
+	return testServer, testSession, nil
 }
 
 func TestServerStartSharing(t *testing.T) {

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -46,9 +46,7 @@ func makeMockSession(opts ...livesharetest.ServerOption) (*livesharetest.Server,
 	if err != nil {
 		return nil, nil, fmt.Errorf("error connecting to Live Share: %w", err)
 	}
-
-	testSession, _ := session.(*Session)
-	return testServer, testSession, nil
+	return testServer, session, nil
 }
 
 func TestServerStartSharing(t *testing.T) {


### PR DESCRIPTION
I'd like to [add support for a `--ssh` flag to the `gh cs create` command](https://github.com/cli/cli/pull/5722/files#r883143225), but testing it is a bit tricky because Liveshare is written with concrete types instead of interfaces and thus it's impossible to inject a mock. This refactor pulls out an interface that will permit a mock to be injected in future PRs.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
