### PR TITLE
detect commit hash in selector to open commit page

### DIFF
--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -61,6 +62,9 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 
 			$ gh browse 217
 			#=> Open issue or pull request 217
+
+			$ gh browse 77507cd94ccafcf568f8560cfecde965fcfa63
+			#=> Open commit page
 
 			$ gh browse --settings
 			#=> Open repository settings
@@ -169,6 +173,10 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 		return fmt.Sprintf("issues/%s", opts.SelectorArg), nil
 	}
 
+	if isCommit(opts.SelectorArg) {
+		return fmt.Sprintf("commit/%s", opts.SelectorArg), nil
+	}
+
 	filePath, rangeStart, rangeEnd, err := parseFile(*opts, opts.SelectorArg)
 	if err != nil {
 		return "", err
@@ -250,6 +258,13 @@ func parseFile(opts BrowseOptions, f string) (p string, start int, end int, err 
 func isNumber(arg string) bool {
 	_, err := strconv.Atoi(arg)
 	return err == nil
+}
+
+// sha1 and sha256 are supported
+var commitHash = regexp.MustCompile(`\A[a-f0-9]{7,64}\z`)
+
+func isCommit(arg string) bool {
+	return commitHash.MatchString(arg)
 }
 
 // gitClient is used to implement functions that can be performed on both local and remote git repositories

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -414,6 +414,35 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL: "https://github.com/bchadwic/test/blob/branch/with%20spaces%3F/%3F=hello%20world/%20%2A?plain=1#L23-L44",
 			wantsErr:    false,
 		},
+		{
+			name: "commit hash in selector arg",
+			opts: BrowseOptions{
+				SelectorArg: "77507cd94ccafcf568f8560cfecde965fcfa63e7",
+			},
+			baseRepo:    ghrepo.New("bchadwic", "test"),
+			expectedURL: "https://github.com/bchadwic/test/commit/77507cd94ccafcf568f8560cfecde965fcfa63e7",
+			wantsErr:    false,
+		},
+		{
+			name: "short commit hash in selector arg",
+			opts: BrowseOptions{
+				SelectorArg: "6e3689d5",
+			},
+			baseRepo:    ghrepo.New("bchadwic", "test"),
+			expectedURL: "https://github.com/bchadwic/test/commit/6e3689d5",
+			wantsErr:    false,
+		},
+
+		{
+			name: "commit hash with extension",
+			opts: BrowseOptions{
+				SelectorArg: "77507cd94ccafcf568f8560cfecde965fcfa63e7.txt",
+				Branch:      "trunk",
+			},
+			baseRepo:    ghrepo.New("bchadwic", "test"),
+			expectedURL: "https://github.com/bchadwic/test/tree/trunk/77507cd94ccafcf568f8560cfecde965fcfa63e7.txt",
+			wantsErr:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
I'd like to add a feature to open a commit page (e.g. https://github.com/cli/cli/commit/77507cd94ccafcf568f8560cfecde965fcfa63).
if you specify the path which starts with `commit/`, `gh browse` will open the commit page. WDYT?

I couldn't find a related issue, so please let me know if it exists(or should I create?)