### PR TITLE
Update prebuild availability status display at codespace creation

### DIFF
--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -469,12 +469,12 @@ func getRepoSuggestions(ctx context.Context, apiClient apiClient, partialSearch 
 // prebuildAvailability will be migrated to use enum values: "none", "ready", "in_progress" before Prebuild GA
 // Enum values "blob" and "pool" will be deprecated soon.
 func buildDisplayName(displayName string, prebuildAvailability string) string {
-	switch prebuildAvailability { 
-		case "blob", "pool", "ready": 
-			return displayName + " (Prebuild ready)" 
-		case "in_progress": 
-			return displayName + " (Prebuild in progress)" 
-		default: 
-			return displayName 
+	switch prebuildAvailability {
+	case "blob", "pool", "ready":
+		return displayName + " (Prebuild ready)"
+	case "in_progress":
+		return displayName + " (Prebuild in progress)"
+	default:
+		return displayName
 	}
 }

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -466,18 +466,14 @@ func getRepoSuggestions(ctx context.Context, apiClient apiClient, partialSearch 
 }
 
 // buildDisplayName returns display name to be used in the machine survey prompt.
-// prebuildAvailability will be migrated to use enum values: "none", "ready", "in_progress"
+// prebuildAvailability will be migrated to use enum values: "none", "ready", "in_progress" before Prebuild GA
 // Enum values "blob" and "pool" will be deprecated soon.
 func buildDisplayName(displayName string, prebuildAvailability string) string {
-	prebuildText := ""
-
-	if prebuildAvailability == "blob" || prebuildAvailability == "pool" || prebuildAvailability == "ready" {
-		prebuildText = " (Prebuild ready)"
+	switch prebuildAvailability { 
+		case "blob", "pool", "ready": 
+			return displayName + " (Prebuild ready)" 
+		case "in_progress": 
+			return displayName + " (Prebuild in progress)" 
+		default: return displayName 
 	}
-
-	if prebuildAvailability == "in_progress" {
-		prebuildText = " (Prebuild in progress)"
-	}
-
-	return fmt.Sprintf("%s%s", displayName, prebuildText)
 }

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -466,11 +466,17 @@ func getRepoSuggestions(ctx context.Context, apiClient apiClient, partialSearch 
 }
 
 // buildDisplayName returns display name to be used in the machine survey prompt.
+// prebuildAvailability will be migrated to use enum values: "none", "ready", "in_progress"
+// Enum values "blob" and "pool" will be deprecated soon.
 func buildDisplayName(displayName string, prebuildAvailability string) string {
 	prebuildText := ""
 
-	if prebuildAvailability == "blob" || prebuildAvailability == "pool" {
+	if prebuildAvailability == "blob" || prebuildAvailability == "pool" || prebuildAvailability == "ready" {
 		prebuildText = " (Prebuild ready)"
+	}
+
+	if prebuildAvailability == "in_progress" {
+		prebuildText = " (Prebuild in progress)"
 	}
 
 	return fmt.Sprintf("%s%s", displayName, prebuildText)

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -474,6 +474,7 @@ func buildDisplayName(displayName string, prebuildAvailability string) string {
 			return displayName + " (Prebuild ready)" 
 		case "in_progress": 
 			return displayName + " (Prebuild in progress)" 
-		default: return displayName 
+		default: 
+			return displayName 
 	}
 }

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -373,6 +373,16 @@ func TestBuildDisplayName(t *testing.T) {
 			prebuildAvailability: "",
 			expectedDisplayName:  "4 cores, 8 GB RAM, 32 GB storage",
 		},
+		{
+			name:                 "prebuild availability is ready",
+			prebuildAvailability: "ready",
+			expectedDisplayName:  "4 cores, 8 GB RAM, 32 GB storage (Prebuild ready)",
+		},
+		{
+			name:                 "prebuild availability is in_progress",
+			prebuildAvailability: "in_progress",
+			expectedDisplayName:  "4 cores, 8 GB RAM, 32 GB storage (Prebuild in progress)",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
### What Does This Do?
Adds copy to the machine list when a prebuilt image is ready or in_progress for a machine during the gh cs create command. 
We plan to deprecate "pool" or "blob" enums in the API response and replace them with more explicit values "ready" or "in_progress".
Update the Cli logic to accept new enum values.

This is my first Cli PR, please feel free to give any feedback.
New enum values are behind a FF, so this change may not affect current flows until feature flag is on.
Demo:
![image](https://user-images.githubusercontent.com/68875335/171502483-b0c20233-8a6d-4712-ab9b-970b70e0c466.png)


Reference PR: https://github.com/cli/cli/pull/4737
Closes: Internal issues https://github.com/github/codespaces/issues/5861 and https://github.com/github/codespaces/issues/4776