### PR TITLE
Allow repo list to work with GHES earlier than 3.3

### DIFF
--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -36,12 +36,14 @@ type RepositoryFeatures struct {
 	IssueTemplateMutation    bool
 	IssueTemplateQuery       bool
 	PullRequestTemplateQuery bool
+	VisibilityField          bool
 }
 
 var allRepositoryFeatures = RepositoryFeatures{
 	IssueTemplateMutation:    true,
 	IssueTemplateQuery:       true,
 	PullRequestTemplateQuery: true,
+	VisibilityField:          true,
 }
 
 type detector struct {
@@ -101,6 +103,9 @@ func (d *detector) RepositoryFeatures() (RepositoryFeatures, error) {
 	for _, field := range featureDetection.Repository.Fields {
 		if field.Name == "pullRequestTemplates" {
 			features.PullRequestTemplateQuery = true
+		}
+		if field.Name == "visibility" {
+			features.VisibilityField = true
 		}
 	}
 

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -37,6 +37,7 @@ type RepositoryFeatures struct {
 	IssueTemplateQuery       bool
 	PullRequestTemplateQuery bool
 	VisibilityField          bool
+	AutoMerge                bool
 }
 
 var allRepositoryFeatures = RepositoryFeatures{
@@ -44,6 +45,7 @@ var allRepositoryFeatures = RepositoryFeatures{
 	IssueTemplateQuery:       true,
 	PullRequestTemplateQuery: true,
 	VisibilityField:          true,
+	AutoMerge:                true,
 }
 
 type detector struct {
@@ -106,6 +108,9 @@ func (d *detector) RepositoryFeatures() (RepositoryFeatures, error) {
 		}
 		if field.Name == "visibility" {
 			features.VisibilityField = true
+		}
+		if field.Name == "autoMergeAllowed" {
+			features.AutoMerge = true
 		}
 	}
 

--- a/internal/featuredetection/feature_detection_test.go
+++ b/internal/featuredetection/feature_detection_test.go
@@ -73,6 +73,7 @@ func TestRepositoryFeatures(t *testing.T) {
 				IssueTemplateQuery:       true,
 				PullRequestTemplateQuery: true,
 				VisibilityField:          true,
+				AutoMerge:                true,
 			},
 			wantErr: false,
 		},
@@ -120,6 +121,23 @@ func TestRepositoryFeatures(t *testing.T) {
 				IssueTemplateMutation: true,
 				IssueTemplateQuery:    true,
 				VisibilityField:       true,
+			},
+			wantErr: false,
+		},
+		{
+			name:     "GHE has automerge field",
+			hostname: "git.my.org",
+			queryResponse: map[string]string{
+				`query Repository_fields\b`: heredoc.Doc(`
+					{ "data": { "Repository": { "fields": [
+						{"name": "autoMergeAllowed"}
+					] } } }
+				`),
+			},
+			wantFeatures: RepositoryFeatures{
+				IssueTemplateMutation: true,
+				IssueTemplateQuery:    true,
+				AutoMerge:             true,
 			},
 			wantErr: false,
 		},

--- a/internal/featuredetection/feature_detection_test.go
+++ b/internal/featuredetection/feature_detection_test.go
@@ -72,6 +72,7 @@ func TestRepositoryFeatures(t *testing.T) {
 				IssueTemplateMutation:    true,
 				IssueTemplateQuery:       true,
 				PullRequestTemplateQuery: true,
+				VisibilityField:          true,
 			},
 			wantErr: false,
 		},
@@ -102,6 +103,23 @@ func TestRepositoryFeatures(t *testing.T) {
 				IssueTemplateMutation:    true,
 				IssueTemplateQuery:       true,
 				PullRequestTemplateQuery: true,
+			},
+			wantErr: false,
+		},
+		{
+			name:     "GHE has visibility field",
+			hostname: "git.my.org",
+			queryResponse: map[string]string{
+				`query Repository_fields\b`: heredoc.Doc(`
+					{ "data": { "Repository": { "fields": [
+						{"name": "visibility"}
+					] } } }
+				`),
+			},
+			wantFeatures: RepositoryFeatures{
+				IssueTemplateMutation: true,
+				IssueTemplateQuery:    true,
+				VisibilityField:       true,
 			},
 			wantErr: false,
 		},

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -588,9 +588,6 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 			return nil, cmdutil.CancelError
 		} else {
 			// "Create a fork of ..."
-			if baseRepo.IsPrivate {
-				return nil, fmt.Errorf("cannot fork private repository %s", ghrepo.FullName(baseRepo))
-			}
 			headBranchLabel = fmt.Sprintf("%s:%s", currentLogin, headBranch)
 		}
 	}

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -48,6 +49,7 @@ type EditOptions struct {
 	AddTopics       []string
 	RemoveTopics    []string
 	InteractiveMode bool
+	Detector        fd.Detector
 	// Cache of current repo topics to avoid retrieving them
 	// in multiple flows.
 	topicsCache []string
@@ -158,9 +160,17 @@ func editRun(ctx context.Context, opts *EditOptions) error {
 	repo := opts.Repository
 
 	if opts.InteractiveMode {
+		detector := opts.Detector
+		if detector == nil {
+			detector = fd.NewDetector(opts.HTTPClient, repo.RepoHost())
+		}
+		repoFeatures, err := detector.RepositoryFeatures()
+		if err != nil {
+			return err
+		}
+
 		apiClient := api.NewClientFromHTTP(opts.HTTPClient)
 		fieldsToRetrieve := []string{
-			"autoMergeAllowed",
 			"defaultBranchRef",
 			"deleteBranchOnMerge",
 			"description",
@@ -174,8 +184,14 @@ func editRun(ctx context.Context, opts *EditOptions) error {
 			"rebaseMergeAllowed",
 			"repositoryTopics",
 			"squashMergeAllowed",
-			"visibility",
 		}
+		if repoFeatures.VisibilityField {
+			fieldsToRetrieve = append(fieldsToRetrieve, "visibility")
+		}
+		if repoFeatures.AutoMerge {
+			fieldsToRetrieve = append(fieldsToRetrieve, "autoMergeAllowed")
+		}
+
 		opts.IO.StartProgressIndicator()
 		fetchedRepo, err := api.FetchRepository(apiClient, opts.Repository, fieldsToRetrieve)
 		opts.IO.StopProgressIndicator()

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -225,16 +225,7 @@ func listHeader(owner string, matchCount, totalMatchCount int, hasFilters bool) 
 }
 
 func repoInfo(r api.Repository) string {
-	tags := []string{}
-	if r.Visibility != "" {
-		tags = append(tags, strings.ToLower(r.Visibility))
-	} else {
-		if r.IsPrivate {
-			tags = append(tags, "private")
-		} else {
-			tags = append(tags, "public")
-		}
-	}
+	tags := []string{visibilityLabel(r)}
 
 	if r.IsFork {
 		tags = append(tags, "fork")
@@ -244,4 +235,13 @@ func repoInfo(r api.Repository) string {
 	}
 
 	return strings.Join(tags, ", ")
+}
+
+func visibilityLabel(repo api.Repository) string {
+	if repo.Visibility != "" {
+		return strings.ToLower(repo.Visibility)
+	} else if repo.IsPrivate {
+		return "private"
+	}
+	return "public"
 }

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -173,9 +173,7 @@ func listRun(opts *ListOptions) error {
 		info := repoInfo(repo)
 		infoColor := cs.Gray
 
-		if (repo.Visibility != "" &&
-			repo.Visibility != "PUBLIC") ||
-			repo.IsPrivate {
+		if repo.IsPrivate {
 			infoColor = cs.Yellow
 		}
 

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/text"
@@ -21,6 +22,7 @@ type ListOptions struct {
 	Config     func() (config.Config, error)
 	IO         *iostreams.IOStreams
 	Exporter   cmdutil.Exporter
+	Detector   fd.Detector
 
 	Limit int
 	Owner string
@@ -104,26 +106,12 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	return cmd
 }
 
-var defaultFields = []string{"nameWithOwner", "description", "isPrivate", "isFork", "isArchived", "createdAt", "pushedAt", "visibility"}
+var defaultFields = []string{"nameWithOwner", "description", "isPrivate", "isFork", "isArchived", "createdAt", "pushedAt"}
 
 func listRun(opts *ListOptions) error {
 	httpClient, err := opts.HttpClient()
 	if err != nil {
 		return err
-	}
-
-	filter := FilterOptions{
-		Visibility:  opts.Visibility,
-		Fork:        opts.Fork,
-		Source:      opts.Source,
-		Language:    opts.Language,
-		Topic:       opts.Topic,
-		Archived:    opts.Archived,
-		NonArchived: opts.NonArchived,
-		Fields:      defaultFields,
-	}
-	if opts.Exporter != nil {
-		filter.Fields = opts.Exporter.Fields()
 	}
 
 	cfg, err := opts.Config()
@@ -134,6 +122,33 @@ func listRun(opts *ListOptions) error {
 	host, err := cfg.DefaultHost()
 	if err != nil {
 		return err
+	}
+
+	if opts.Detector == nil {
+		opts.Detector = fd.NewDetector(httpClient, host)
+	}
+	features, err := opts.Detector.RepositoryFeatures()
+	if err != nil {
+		return err
+	}
+
+	fields := defaultFields
+	if features.VisibilityField {
+		fields = append(defaultFields, "visibility")
+	}
+
+	filter := FilterOptions{
+		Visibility:  opts.Visibility,
+		Fork:        opts.Fork,
+		Source:      opts.Source,
+		Language:    opts.Language,
+		Topic:       opts.Topic,
+		Archived:    opts.Archived,
+		NonArchived: opts.NonArchived,
+		Fields:      fields,
+	}
+	if opts.Exporter != nil {
+		filter.Fields = opts.Exporter.Fields()
 	}
 
 	listResult, err := listRepos(httpClient, host, opts.Limit, opts.Owner, filter)
@@ -158,7 +173,9 @@ func listRun(opts *ListOptions) error {
 		info := repoInfo(repo)
 		infoColor := cs.Gray
 
-		if repo.Visibility != "PUBLIC" {
+		if (repo.Visibility != "" &&
+			repo.Visibility != "PUBLIC") ||
+			repo.IsPrivate {
 			infoColor = cs.Yellow
 		}
 
@@ -208,8 +225,15 @@ func listHeader(owner string, matchCount, totalMatchCount int, hasFilters bool) 
 }
 
 func repoInfo(r api.Repository) string {
-	tags := []string{
-		strings.ToLower(r.Visibility),
+	tags := []string{}
+	if r.Visibility != "" {
+		tags = append(tags, strings.ToLower(r.Visibility))
+	} else {
+		if r.IsPrivate {
+			tags = append(tags, "private")
+		} else {
+			tags = append(tags, "public")
+		}
 	}
 
 	if r.IsFork {

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -154,7 +154,7 @@ func displayResults(io *iostreams.IOStreams, results search.RepositoriesResult) 
 	cs := io.ColorScheme()
 	tp := utils.NewTablePrinter(io)
 	for _, repo := range results.Items {
-		tags := []string{repo.Visibility}
+		tags := []string{visibilityLabel(repo)}
 		if repo.IsFork {
 			tags = append(tags, "fork")
 		}
@@ -183,4 +183,13 @@ func displayResults(io *iostreams.IOStreams, results search.RepositoriesResult) 
 		fmt.Fprintf(io.Out, "\n%s", header)
 	}
 	return tp.Render()
+}
+
+func visibilityLabel(repo search.Repository) string {
+	if repo.Visibility != "" {
+		return repo.Visibility
+	} else if repo.IsPrivate {
+		return "private"
+	}
+	return "public"
 }


### PR DESCRIPTION
This PR adds conditional logic to only retrieve the `Repository.visibility` graphql field if the enterprise host actually supports it. If not, use old logic for displaying `public` and `private` repo visibility. 
 
Fixes https://github.com/cli/cli/issues/5714