### PR TITLE
pr merge: fix merge queue API access for PAT consumers

### DIFF
--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -72,9 +72,12 @@ func (d *detector) IssueFeatures() (IssueFeatures, error) {
 }
 
 func (d *detector) PullRequestFeatures() (PullRequestFeatures, error) {
-	if !ghinstance.IsEnterprise(d.host) {
-		return allPullRequestFeatures, nil
-	}
+	// TODO: reinstate the short-circuit once the APIs are fully available on github.com
+	// https://github.com/cli/cli/issues/5778
+	//
+	// if !ghinstance.IsEnterprise(d.host) {
+	// 	return allPullRequestFeatures, nil
+	// }
 
 	features := PullRequestFeatures{
 		ReviewDecision:       true,

--- a/internal/featuredetection/feature_detection_test.go
+++ b/internal/featuredetection/feature_detection_test.go
@@ -20,11 +20,36 @@ func TestPullRequestFeatures(t *testing.T) {
 		{
 			name:     "github.com",
 			hostname: "github.com",
+			queryResponse: map[string]string{
+				`query PullRequest_fields\b`: heredoc.Doc(`
+					{ "data": { "PullRequest": { "fields": [
+						{"name": "isInMergeQueue"},
+						{"name": "isMergeQueueEnabled"}
+					] } } }
+				`),
+			},
 			wantFeatures: PullRequestFeatures{
 				ReviewDecision:       true,
 				StatusCheckRollup:    true,
 				BranchProtectionRule: true,
 				MergeQueue:           true,
+			},
+			wantErr: false,
+		},
+		{
+			name:     "github.com with no merge queue",
+			hostname: "github.com",
+			queryResponse: map[string]string{
+				`query PullRequest_fields\b`: heredoc.Doc(`
+					{ "data": { "PullRequest": { "fields": [
+					] } } }
+				`),
+			},
+			wantFeatures: PullRequestFeatures{
+				ReviewDecision:       true,
+				StatusCheckRollup:    true,
+				BranchProtectionRule: true,
+				MergeQueue:           false,
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
The `github.com` API right now doesn't seem to make merge queue APIs available to people who use PAT to authenticate gh requests. This switches the conditional request strategy to also do feature-detection for dotcom (instead of just for Enterprise).

Fixes https://github.com/cli/cli/issues/5778