### PR TITLE
Print auth help message based on environment

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -325,7 +325,7 @@ func printNoAuthHelp(out io.Writer, cs *iostreams.ColorScheme) {
 	var helpMessage string
 	if os.Getenv("CI") == "true" {
 		helpMessage = "Either `GH_TOKEN` or `GITHUB_TOKEN` must be set to use `gh`"
-		if _, ok := os.LookupEnv("GITHUB_ACTION"); ok {
+		if os.Getenv("GITHUB_ACTION") != "" {
 			helpMessage += heredoc.Doc(`
 				 in a GitHub Action.
 

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -325,7 +325,7 @@ func printNoAuthHelp(out io.Writer, cs *iostreams.ColorScheme) {
 	var helpMessage string
 	if os.Getenv("CI") == "true" {
 		helpMessage = "Either `GH_TOKEN` or `GITHUB_TOKEN` must be set to use `gh`"
-		if os.Getenv("GITHUB_ACTION") != "" {
+		if os.Getenv("GITHUB_ACTIONS") == "true" {
 			helpMessage += heredoc.Doc(`
 				 in a GitHub Action.
 

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -324,7 +324,7 @@ func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
 func printNoAuthHelp(out io.Writer, cs *iostreams.ColorScheme) {
 	var helpMessage string
 	if os.Getenv("CI") == "true" {
-		helpMessage = "Either `GH_TOKEN` or `GITHUB_TOKEN` must be set to use `gh`"
+		helpMessage = "`GH_TOKEN` must be set to use `gh`"
 		if os.Getenv("GITHUB_ACTIONS") == "true" {
 			helpMessage += heredoc.Doc(`
 				 in a GitHub Action.

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -348,7 +348,7 @@ func printNoAuthHelp(out io.Writer, cs *iostreams.ColorScheme) {
 			To authenticate, please run %s.
 		`, cs.Bold("Welcome to GitHub CLI!"), "`gh auth login`")
 	}
-	fmt.Fprintf(out, helpMessage)
+	fmt.Fprint(out, helpMessage)
 }
 
 func shouldCheckForUpdate() bool {

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -324,22 +324,21 @@ func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
 func printNoAuthHelp(out io.Writer, cs *iostreams.ColorScheme) {
 	var helpMessage string
 	if os.Getenv("CI") == "true" {
-		helpMessage = "`GH_TOKEN` must be set to use `gh`"
 		if os.Getenv("GITHUB_ACTIONS") == "true" {
-			helpMessage += heredoc.Doc(`
-				 in a GitHub Action.
+			helpMessage = heredoc.Docf(`
+				%s must be set to use %s in a GitHub Action.
 
 				Example:
 
 				env:
 				  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-			`)
+			`, "`GH_TOKEN`", "`gh`")
 		} else {
-			helpMessage += heredoc.Doc(`
-				 in this CI environment.
+			helpMessage = heredoc.Docf(`
+				%s must be set to use %s in this CI environment.
 
 				Please consult the relevant documentation for setting these environment variables.
-			`)
+			`, "`GH_TOKEN`", "`gh`")
 		}
 	} else {
 		helpMessage = heredoc.Docf(`

--- a/cmd/gh/main_test.go
+++ b/cmd/gh/main_test.go
@@ -5,11 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
 	"testing"
 
 	"github.com/cli/cli/v2/pkg/cmdutil"
-	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/spf13/cobra"
 )
 
@@ -74,64 +72,6 @@ check your internet connection or https://githubstatus.com
 			printError(out, tt.args.err, tt.args.cmd, tt.args.debug)
 			if gotOut := out.String(); gotOut != tt.wantOut {
 				t.Errorf("printError() = %q, want %q", gotOut, tt.wantOut)
-			}
-		})
-	}
-}
-
-func Test_printNoAuthHelp(t *testing.T) {
-	orig_CI := os.Getenv("CI")
-	orig_GITHUB_ACTIONS := os.Getenv("GITHUB_ACTIONS")
-	t.Cleanup(func() {
-		os.Setenv("CI", orig_CI)
-		os.Setenv("GITHUB_ACTIONS", orig_GITHUB_ACTIONS)
-	})
-	tests := []struct {
-		name           string
-		CI             string
-		GITHUB_ACTIONS string
-		wantOut        string
-	}{
-		{
-			name:           "Interactive",
-			CI:             "",
-			GITHUB_ACTIONS: "",
-			wantOut: `Welcome to GitHub CLI!
-
-To authenticate, please run ` + "`gh auth login`.\n",
-		},
-		{
-			name:           "Non-Interactive, not a GitHub Action",
-			CI:             "true",
-			GITHUB_ACTIONS: "",
-			wantOut: "`GH_TOKEN` must be set to use `gh` in this CI environment." + `
-
-Please consult the relevant documentation for setting these environment variables.
-`,
-		},
-		{
-			name:           "GitHub Action",
-			CI:             "true",
-			GITHUB_ACTIONS: "true",
-			wantOut: "`GH_TOKEN` must be set to use `gh` in a GitHub Action." + `
-
-Example:
-
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			out := &bytes.Buffer{}
-			cs := &iostreams.ColorScheme{}
-			os.Setenv("CI", tt.CI)
-			os.Setenv("GITHUB_ACTIONS", tt.GITHUB_ACTIONS)
-			printNoAuthHelp(out, cs)
-			if gotOut := out.String(); gotOut != tt.wantOut {
-				t.Errorf("printNoAuthHelp() = %q, want %q", gotOut, tt.wantOut)
 			}
 		})
 	}

--- a/cmd/gh/main_test.go
+++ b/cmd/gh/main_test.go
@@ -104,7 +104,7 @@ To authenticate, please run ` + "`gh auth login`.\n",
 			name:           "Non-Interactive, not a GitHub Action",
 			CI:             "true",
 			GITHUB_ACTIONS: "",
-			wantOut: "Either `GH_TOKEN` or `GITHUB_TOKEN` must be set to use `gh` in this CI environment." + `
+			wantOut: "`GH_TOKEN` must be set to use `gh` in this CI environment." + `
 
 Please consult the relevant documentation for setting these environment variables.
 `,
@@ -113,7 +113,7 @@ Please consult the relevant documentation for setting these environment variable
 			name:           "GitHub Action",
 			CI:             "true",
 			GITHUB_ACTIONS: "true",
-			wantOut: "Either `GH_TOKEN` or `GITHUB_TOKEN` must be set to use `gh` in a GitHub Action." + `
+			wantOut: "`GH_TOKEN` must be set to use `gh` in a GitHub Action." + `
 
 Example:
 

--- a/cmd/gh/main_test.go
+++ b/cmd/gh/main_test.go
@@ -81,38 +81,38 @@ check your internet connection or https://githubstatus.com
 
 func Test_printNoAuthHelp(t *testing.T) {
 	orig_CI := os.Getenv("CI")
-	orig_GITHUB_ACTION := os.Getenv("GITHUB_ACTION")
+	orig_GITHUB_ACTIONS := os.Getenv("GITHUB_ACTIONS")
 	t.Cleanup(func() {
 		os.Setenv("CI", orig_CI)
-		os.Setenv("GITHUB_ACTION", orig_GITHUB_ACTION)
+		os.Setenv("GITHUB_ACTIONS", orig_GITHUB_ACTIONS)
 	})
 	tests := []struct {
-		name          string
-		CI            string
-		GITHUB_ACTION string
-		wantOut       string
+		name           string
+		CI             string
+		GITHUB_ACTIONS string
+		wantOut        string
 	}{
 		{
-			name:          "Interactive",
-			CI:            "",
-			GITHUB_ACTION: "",
+			name:           "Interactive",
+			CI:             "",
+			GITHUB_ACTIONS: "",
 			wantOut: `Welcome to GitHub CLI!
 
 To authenticate, please run ` + "`gh auth login`.\n",
 		},
 		{
-			name:          "Non-Interactive, not a GitHub Action",
-			CI:            "true",
-			GITHUB_ACTION: "",
+			name:           "Non-Interactive, not a GitHub Action",
+			CI:             "true",
+			GITHUB_ACTIONS: "",
 			wantOut: "Either `GH_TOKEN` or `GITHUB_TOKEN` must be set to use `gh` in this CI environment." + `
 
 Please consult the relevant documentation for setting these environment variables.
 `,
 		},
 		{
-			name:          "GitHub Action",
-			CI:            "true",
-			GITHUB_ACTION: "__run",
+			name:           "GitHub Action",
+			CI:             "true",
+			GITHUB_ACTIONS: "true",
 			wantOut: "Either `GH_TOKEN` or `GITHUB_TOKEN` must be set to use `gh` in a GitHub Action." + `
 
 Example:
@@ -128,7 +128,7 @@ env:
 			out := &bytes.Buffer{}
 			cs := &iostreams.ColorScheme{}
 			os.Setenv("CI", tt.CI)
-			os.Setenv("GITHUB_ACTION", tt.GITHUB_ACTION)
+			os.Setenv("GITHUB_ACTIONS", tt.GITHUB_ACTIONS)
 			printNoAuthHelp(out, cs)
 			if gotOut := out.String(); gotOut != tt.wantOut {
 				t.Errorf("printNoAuthHelp() = %q, want %q", gotOut, tt.wantOut)


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
This will check if `gh` is running in a CI environment by checking the `CI` environment variable. If so, it will suggest using environment variables to set the auth token. Additionally, if the CI environment is detected to be GitHub Actions (`GITHUB_ACTION!=""`), it will provide some example code (https://github.com/cli/cli/issues/5387#issuecomment-1150994598).

If it is not a CI environment, it will print the standard help message.

Fixes #5387
