### PR TITLE
Allow working with Codespaces repo secrets

### DIFF
--- a/pkg/cmd/secret/secret.go
+++ b/pkg/cmd/secret/secret.go
@@ -15,9 +15,9 @@ func NewCmdSecret(f *cmdutil.Factory) *cobra.Command {
 		Short: "Manage GitHub secrets",
 		Long: heredoc.Doc(`
 			Secrets can be set at the repository, or organization level for use in
-			GitHub Actions or Dependabot. User secrets can be set for use in GitHub Codespaces.
-			Environment secrets can be set for use in GitHub Actions.
-			Run "gh help secret set" to learn how to get started.
+			GitHub Actions or Dependabot. User and repository secrets can be set for
+			use in GitHub Codespaces. Environment secrets can be set for use in
+			GitHub Actions. Run "gh help secret set" to learn how to get started.
 `),
 	}
 

--- a/pkg/cmd/secret/shared/shared.go
+++ b/pkg/cmd/secret/shared/shared.go
@@ -85,7 +85,7 @@ func IsSupportedSecretEntity(app App, entity SecretEntity) bool {
 	case Actions:
 		return entity == Repository || entity == Organization || entity == Environment
 	case Codespaces:
-		return entity == User
+		return entity == User || entity == Repository
 	case Dependabot:
 		return entity == Repository || entity == Organization
 	default:

--- a/pkg/cmd/secret/shared/shared_test.go
+++ b/pkg/cmd/secret/shared/shared_test.go
@@ -166,9 +166,9 @@ func TestIsSupportedSecretEntity(t *testing.T) {
 			app:  Codespaces,
 			supportedEntities: []SecretEntity{
 				User,
+				Repository,
 			},
 			unsupportedEntities: []SecretEntity{
-				Repository,
 				Organization,
 				Environment,
 				Unknown,


### PR DESCRIPTION
Fixes https://github.com/github/codespaces/issues/8558

The API exists for this, so we can allow it through the CLI

https://docs.github.com/en/rest/codespaces/repository-secrets
