### PR TITLE
Add flag to list codespaces under an organization

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -269,7 +269,7 @@ func (c *Codespace) ExportData(fields []string) map[string]interface{} {
 
 // ListCodespaces returns a list of codespaces for the user. Pass a negative limit to request all pages from
 // the API until all codespaces have been fetched.
-func (a *API) ListCodespaces(ctx context.Context, limit int, orgName string) (codespaces []*Codespace, err error) {
+func (a *API) ListCodespaces(ctx context.Context, limit int, orgName string, userName string) (codespaces []*Codespace, err error) {
 	perPage := 100
 	if limit > 0 && limit < 100 {
 		perPage = limit
@@ -279,8 +279,13 @@ func (a *API) ListCodespaces(ctx context.Context, limit int, orgName string) (co
 	var spanName string
 
 	if orgName != "" {
-		listURL = fmt.Sprintf("%s/orgs/%s/codespaces?per_page=%d", a.githubAPI, orgName, perPage)
-		spanName = "/orgs/*/codespaces"
+	    if userName != "" {
+		    listURL = fmt.Sprintf("%s/orgs/%s/members/%s/codespaces?per_page=%d", a.githubAPI, orgName, userName, perPage)
+		    spanName = "/orgs/*/members/*/codespaces"
+	    } else {
+		    listURL = fmt.Sprintf("%s/orgs/%s/codespaces?per_page=%d", a.githubAPI, orgName, perPage)
+		    spanName = "/orgs/*/codespaces"
+	    }
 	} else {
 		listURL = fmt.Sprintf("%s/user/codespaces?per_page=%d", a.githubAPI, perPage)
 		spanName = "/user/codespaces"

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -280,7 +280,7 @@ func (a *API) ListCodespaces(ctx context.Context, limit int, orgName string) (co
 
 	if orgName != "" {
 		listURL = fmt.Sprintf("%s/orgs/%s/codespaces?per_page=%d", a.githubAPI, orgName, perPage)
-		spanName = fmt.Sprintf("/orgs/%s/codespaces", orgName)
+		spanName = "/orgs/*/codespaces"
 	} else {
 		listURL = fmt.Sprintf("%s/user/codespaces?per_page=%d", a.githubAPI, perPage)
 		spanName = "/user/codespaces"

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -280,13 +280,13 @@ func (a *API) ListCodespaces(ctx context.Context, limit int, orgName string, use
 	var spanName string
 
 	if orgName != "" {
-	    if userName != "" {
-		    listURL = fmt.Sprintf("%s/orgs/%s/members/%s/codespaces?per_page=%d", a.githubAPI, orgName, userName, perPage)
-		    spanName = "/orgs/*/members/*/codespaces"
-	    } else {
-		    listURL = fmt.Sprintf("%s/orgs/%s/codespaces?per_page=%d", a.githubAPI, orgName, perPage)
-		    spanName = "/orgs/*/codespaces"
-	    }
+		if userName != "" {
+			listURL = fmt.Sprintf("%s/orgs/%s/members/%s/codespaces?per_page=%d", a.githubAPI, orgName, userName, perPage)
+			spanName = "/orgs/*/members/*/codespaces"
+		} else {
+			listURL = fmt.Sprintf("%s/orgs/%s/codespaces?per_page=%d", a.githubAPI, orgName, perPage)
+			spanName = "/orgs/*/codespaces"
+		}
 	} else {
 		listURL = fmt.Sprintf("%s/user/codespaces?per_page=%d", a.githubAPI, perPage)
 		spanName = "/user/codespaces"

--- a/internal/codespaces/api/api_test.go
+++ b/internal/codespaces/api/api_test.go
@@ -140,7 +140,7 @@ func TestListCodespaces_limited(t *testing.T) {
 		client:    &http.Client{},
 	}
 	ctx := context.TODO()
-	codespaces, err := api.ListCodespaces(ctx, 200, "")
+	codespaces, err := api.ListCodespaces(ctx, 200, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestListCodespaces_unlimited(t *testing.T) {
 		client:    &http.Client{},
 	}
 	ctx := context.TODO()
-	codespaces, err := api.ListCodespaces(ctx, -1, "")
+	codespaces, err := api.ListCodespaces(ctx, -1, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/codespaces/api/api_test.go
+++ b/internal/codespaces/api/api_test.go
@@ -140,7 +140,7 @@ func TestListCodespaces_limited(t *testing.T) {
 		client:    &http.Client{},
 	}
 	ctx := context.TODO()
-	codespaces, err := api.ListCodespaces(ctx, 200)
+	codespaces, err := api.ListCodespaces(ctx, 200, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestListCodespaces_unlimited(t *testing.T) {
 		client:    &http.Client{},
 	}
 	ctx := context.TODO()
-	codespaces, err := api.ListCodespaces(ctx, -1)
+	codespaces, err := api.ListCodespaces(ctx, -1, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -108,7 +108,7 @@ func startLiveShareSession(ctx context.Context, codespace *api.Codespace, a *App
 type apiClient interface {
 	GetUser(ctx context.Context) (*api.User, error)
 	GetCodespace(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error)
-	ListCodespaces(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error)
+	ListCodespaces(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error)
 	DeleteCodespace(ctx context.Context, name string) error
 	StartCodespace(ctx context.Context, name string) error
 	StopCodespace(ctx context.Context, name string) error
@@ -125,7 +125,7 @@ type apiClient interface {
 var errNoCodespaces = errors.New("you have no codespaces")
 
 func chooseCodespace(ctx context.Context, apiClient apiClient) (*api.Codespace, error) {
-	codespaces, err := apiClient.ListCodespaces(ctx, -1, "")
+	codespaces, err := apiClient.ListCodespaces(ctx, -1, "", "")
 	if err != nil {
 		return nil, fmt.Errorf("error getting codespaces: %w", err)
 	}

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -108,7 +108,7 @@ func startLiveShareSession(ctx context.Context, codespace *api.Codespace, a *App
 type apiClient interface {
 	GetUser(ctx context.Context) (*api.User, error)
 	GetCodespace(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error)
-	ListCodespaces(ctx context.Context, limit int) ([]*api.Codespace, error)
+	ListCodespaces(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error)
 	DeleteCodespace(ctx context.Context, name string) error
 	StartCodespace(ctx context.Context, name string) error
 	StopCodespace(ctx context.Context, name string) error
@@ -125,7 +125,7 @@ type apiClient interface {
 var errNoCodespaces = errors.New("you have no codespaces")
 
 func chooseCodespace(ctx context.Context, apiClient apiClient) (*api.Codespace, error) {
-	codespaces, err := apiClient.ListCodespaces(ctx, -1)
+	codespaces, err := apiClient.ListCodespaces(ctx, -1, "")
 	if err != nil {
 		return nil, fmt.Errorf("error getting codespaces: %w", err)
 	}

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -80,9 +80,6 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace with default branch shows idle timeout notice if present",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
-						return "EUROPE", nil
-					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,
@@ -131,9 +128,6 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace with default branch with default devcontainer if no path provided and no devcontainer files exist in the repo",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
-						return "EUROPE", nil
-					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,
@@ -187,9 +181,6 @@ func TestApp_Create(t *testing.T) {
 			name: "returns error when getting devcontainer paths fails",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
-						return "EUROPE", nil
-					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,
@@ -215,9 +206,6 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace with default branch does not show idle timeout notice if not conntected to terminal",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
-						return "EUROPE", nil
-					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -63,7 +63,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 	nameFilter := opts.codespaceName
 	if nameFilter == "" {
 		a.StartProgressIndicatorWithLabel("Fetching codespaces")
-		codespaces, err = a.apiClient.ListCodespaces(ctx, -1, "")
+		codespaces, err = a.apiClient.ListCodespaces(ctx, -1, "", "")
 		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("error getting codespaces: %w", err)

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -63,7 +63,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 	nameFilter := opts.codespaceName
 	if nameFilter == "" {
 		a.StartProgressIndicatorWithLabel("Fetching codespaces")
-		codespaces, err = a.apiClient.ListCodespaces(ctx, -1)
+		codespaces, err = a.apiClient.ListCodespaces(ctx, -1, "")
 		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("error getting codespaces: %w", err)

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -167,7 +167,7 @@ func TestDelete(t *testing.T) {
 				},
 			}
 			if tt.opts.codespaceName == "" {
-				apiMock.ListCodespacesFunc = func(_ context.Context, num int) ([]*api.Codespace, error) {
+				apiMock.ListCodespacesFunc = func(_ context.Context, num int, orgName string) ([]*api.Codespace, error) {
 					return tt.codespaces, nil
 				}
 			} else {

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -167,7 +167,7 @@ func TestDelete(t *testing.T) {
 				},
 			}
 			if tt.opts.codespaceName == "" {
-				apiMock.ListCodespacesFunc = func(_ context.Context, num int, orgName string) ([]*api.Codespace, error) {
+				apiMock.ListCodespacesFunc = func(_ context.Context, num int, orgName string, userName string) ([]*api.Codespace, error) {
 					return tt.codespaces, nil
 				}
 			} else {

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -12,7 +12,8 @@ import (
 )
 
 type listOptions struct {
-	limit int
+	limit   int
+	orgName string
 }
 
 func newListCmd(app *App) *cobra.Command {
@@ -34,6 +35,7 @@ func newListCmd(app *App) *cobra.Command {
 	}
 
 	listCmd.Flags().IntVarP(&opts.limit, "limit", "L", 30, "Maximum number of codespaces to list")
+	listCmd.Flags().StringVarP(&opts.orgName, "org", "o", "", "List codespaces for an organization")
 	cmdutil.AddJSONFlags(listCmd, &exporter, api.CodespaceFields)
 
 	return listCmd
@@ -41,7 +43,7 @@ func newListCmd(app *App) *cobra.Command {
 
 func (a *App) List(ctx context.Context, opts *listOptions, exporter cmdutil.Exporter) error {
 	a.StartProgressIndicatorWithLabel("Fetching codespaces")
-	codespaces, err := a.apiClient.ListCodespaces(ctx, opts.limit)
+	codespaces, err := a.apiClient.ListCodespaces(ctx, opts.limit, opts.orgName)
 	a.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting codespaces: %w", err)

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -14,6 +14,7 @@ import (
 type listOptions struct {
 	limit   int
 	orgName string
+	userName string
 }
 
 func newListCmd(app *App) *cobra.Command {
@@ -36,6 +37,7 @@ func newListCmd(app *App) *cobra.Command {
 
 	listCmd.Flags().IntVarP(&opts.limit, "limit", "L", 30, "Maximum number of codespaces to list")
 	listCmd.Flags().StringVarP(&opts.orgName, "org", "o", "", "List codespaces for an organization")
+	listCmd.Flags().StringVarP(&opts.userName, "user", "u", "", "Used with --org to filter to a specific user")
 	cmdutil.AddJSONFlags(listCmd, &exporter, api.CodespaceFields)
 
 	return listCmd
@@ -43,7 +45,7 @@ func newListCmd(app *App) *cobra.Command {
 
 func (a *App) List(ctx context.Context, opts *listOptions, exporter cmdutil.Exporter) error {
 	a.StartProgressIndicatorWithLabel("Fetching codespaces")
-	codespaces, err := a.apiClient.ListCodespaces(ctx, opts.limit, opts.orgName)
+	codespaces, err := a.apiClient.ListCodespaces(ctx, opts.limit, opts.orgName, opts.userName)
 	a.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting codespaces: %w", err)

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -74,6 +74,9 @@ func (a *App) List(ctx context.Context, opts *listOptions, exporter cmdutil.Expo
 	if tp.IsTTY() {
 		tp.AddField("NAME", nil, nil)
 		tp.AddField("DISPLAY NAME", nil, nil)
+		if opts.orgName != "" {
+			tp.AddField("OWNER", nil, nil)
+		}
 		tp.AddField("REPOSITORY", nil, nil)
 		tp.AddField("BRANCH", nil, nil)
 		tp.AddField("STATE", nil, nil)
@@ -110,6 +113,9 @@ func (a *App) List(ctx context.Context, opts *listOptions, exporter cmdutil.Expo
 
 		tp.AddField(formattedName, nil, nameColor)
 		tp.AddField(c.DisplayName, nil, nil)
+		if opts.orgName != "" {
+			tp.AddField(c.Owner.Login, nil, nil)
+		}
 		tp.AddField(c.Repository.FullName, nil, nil)
 		tp.AddField(c.branchWithGitStatus(), nil, cs.Cyan)
 		if c.PendingOperation {

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -12,8 +12,8 @@ import (
 )
 
 type listOptions struct {
-	limit   int
-	orgName string
+	limit    int
+	orgName  string
 	userName string
 }
 

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -11,8 +11,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type listOptions struct {
+	limit int
+}
+
 func newListCmd(app *App) *cobra.Command {
-	var limit int
+	opts := &listOptions{}
 	var exporter cmdutil.Exporter
 
 	listCmd := &cobra.Command{
@@ -21,23 +25,23 @@ func newListCmd(app *App) *cobra.Command {
 		Aliases: []string{"ls"},
 		Args:    noArgsConstraint,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if limit < 1 {
-				return cmdutil.FlagErrorf("invalid limit: %v", limit)
+			if opts.limit < 1 {
+				return cmdutil.FlagErrorf("invalid limit: %v", opts.limit)
 			}
 
-			return app.List(cmd.Context(), limit, exporter)
+			return app.List(cmd.Context(), opts, exporter)
 		},
 	}
 
-	listCmd.Flags().IntVarP(&limit, "limit", "L", 30, "Maximum number of codespaces to list")
+	listCmd.Flags().IntVarP(&opts.limit, "limit", "L", 30, "Maximum number of codespaces to list")
 	cmdutil.AddJSONFlags(listCmd, &exporter, api.CodespaceFields)
 
 	return listCmd
 }
 
-func (a *App) List(ctx context.Context, limit int, exporter cmdutil.Exporter) error {
+func (a *App) List(ctx context.Context, opts *listOptions, exporter cmdutil.Exporter) error {
 	a.StartProgressIndicatorWithLabel("Fetching codespaces")
-	codespaces, err := a.apiClient.ListCodespaces(ctx, limit)
+	codespaces, err := a.apiClient.ListCodespaces(ctx, opts.limit)
 	a.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting codespaces: %w", err)

--- a/pkg/cmd/codespace/list_test.go
+++ b/pkg/cmd/codespace/list_test.go
@@ -1,0 +1,76 @@
+package codespace
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+func TestApp_List(t *testing.T) {
+	type fields struct {
+		apiClient apiClient
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		opts   *listOptions
+	}{
+		{
+			name: "list codespaces, no flags",
+			fields: fields{
+				apiClient: &apiClientMock{
+					ListCodespacesFunc: func(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error) {
+						if orgName != "" {
+							return nil, fmt.Errorf("should not be called with an orgName")
+						}
+						return []*api.Codespace{
+							{
+								DisplayName: "CS1",
+							},
+						}, nil
+					},
+				},
+			},
+			opts: &listOptions{},
+		},
+		{
+			name: "list codespaces, --org flag",
+			fields: fields{
+				apiClient: &apiClientMock{
+					ListCodespacesFunc: func(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error) {
+						if orgName != "TestOrg" {
+							return nil, fmt.Errorf("Expected orgName to be TestOrg. Got %s", orgName)
+						}
+						return []*api.Codespace{
+							{
+								DisplayName: "CS1",
+							},
+						}, nil
+					},
+				},
+			},
+			opts: &listOptions{
+				orgName: "TestOrg",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			a := &App{
+				io:        ios,
+				apiClient: tt.fields.apiClient,
+			}
+			var exporter cmdutil.Exporter
+
+			err := a.List(context.Background(), tt.opts, exporter)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/cmd/codespace/list_test.go
+++ b/pkg/cmd/codespace/list_test.go
@@ -80,7 +80,7 @@ func TestApp_List(t *testing.T) {
 				},
 			},
 			opts: &listOptions{
-				orgName: "TestOrg",
+				orgName:  "TestOrg",
 				userName: "jimmy",
 			},
 		},

--- a/pkg/cmd/codespace/list_test.go
+++ b/pkg/cmd/codespace/list_test.go
@@ -23,7 +23,7 @@ func TestApp_List(t *testing.T) {
 			name: "list codespaces, no flags",
 			fields: fields{
 				apiClient: &apiClientMock{
-					ListCodespacesFunc: func(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error) {
+					ListCodespacesFunc: func(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error) {
 						if orgName != "" {
 							return nil, fmt.Errorf("should not be called with an orgName")
 						}
@@ -41,9 +41,12 @@ func TestApp_List(t *testing.T) {
 			name: "list codespaces, --org flag",
 			fields: fields{
 				apiClient: &apiClientMock{
-					ListCodespacesFunc: func(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error) {
+					ListCodespacesFunc: func(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error) {
 						if orgName != "TestOrg" {
 							return nil, fmt.Errorf("Expected orgName to be TestOrg. Got %s", orgName)
+						}
+						if userName != "" {
+							return nil, fmt.Errorf("Expected userName to be blank. Got %s", userName)
 						}
 						return []*api.Codespace{
 							{
@@ -55,6 +58,30 @@ func TestApp_List(t *testing.T) {
 			},
 			opts: &listOptions{
 				orgName: "TestOrg",
+			},
+		},
+		{
+			name: "list codespaces, --org and --user flag",
+			fields: fields{
+				apiClient: &apiClientMock{
+					ListCodespacesFunc: func(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error) {
+						if orgName != "TestOrg" {
+							return nil, fmt.Errorf("Expected orgName to be TestOrg. Got %s", orgName)
+						}
+						if userName != "jimmy" {
+							return nil, fmt.Errorf("Expected userName to be jimmy. Got %s", userName)
+						}
+						return []*api.Codespace{
+							{
+								DisplayName: "CS1",
+							},
+						}, nil
+					},
+				},
+			},
+			opts: &listOptions{
+				orgName: "TestOrg",
+				userName: "jimmy",
 			},
 		},
 	}

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -31,9 +31,6 @@ import (
 // 			GetCodespaceFunc: func(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error) {
 // 				panic("mock out the GetCodespace method")
 // 			},
-// 			GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
-// 				panic("mock out the GetCodespaceRegionLocation method")
-// 			},
 // 			GetCodespaceRepoSuggestionsFunc: func(ctx context.Context, partialSearch string, params api.RepoSearchParameters) ([]string, error) {
 // 				panic("mock out the GetCodespaceRepoSuggestions method")
 // 			},
@@ -49,7 +46,7 @@ import (
 // 			GetUserFunc: func(ctx context.Context) (*api.User, error) {
 // 				panic("mock out the GetUser method")
 // 			},
-// 			ListCodespacesFunc: func(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error) {
+// 			ListCodespacesFunc: func(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error) {
 // 				panic("mock out the ListCodespaces method")
 // 			},
 // 			ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
@@ -83,9 +80,6 @@ type apiClientMock struct {
 	// GetCodespaceFunc mocks the GetCodespace method.
 	GetCodespaceFunc func(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error)
 
-	// GetCodespaceRegionLocationFunc mocks the GetCodespaceRegionLocation method.
-	GetCodespaceRegionLocationFunc func(ctx context.Context) (string, error)
-
 	// GetCodespaceRepoSuggestionsFunc mocks the GetCodespaceRepoSuggestions method.
 	GetCodespaceRepoSuggestionsFunc func(ctx context.Context, partialSearch string, params api.RepoSearchParameters) ([]string, error)
 
@@ -102,7 +96,7 @@ type apiClientMock struct {
 	GetUserFunc func(ctx context.Context) (*api.User, error)
 
 	// ListCodespacesFunc mocks the ListCodespaces method.
-	ListCodespacesFunc func(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error)
+	ListCodespacesFunc func(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error)
 
 	// ListDevContainersFunc mocks the ListDevContainers method.
 	ListDevContainersFunc func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error)
@@ -154,11 +148,6 @@ type apiClientMock struct {
 			// IncludeConnection is the includeConnection argument value.
 			IncludeConnection bool
 		}
-		// GetCodespaceRegionLocation holds details about calls to the GetCodespaceRegionLocation method.
-		GetCodespaceRegionLocation []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-		}
 		// GetCodespaceRepoSuggestions holds details about calls to the GetCodespaceRepoSuggestions method.
 		GetCodespaceRepoSuggestions []struct {
 			// Ctx is the ctx argument value.
@@ -206,8 +195,10 @@ type apiClientMock struct {
 			Ctx context.Context
 			// Limit is the limit argument value.
 			Limit int
-			// OrgName is the orgName argument value
+			// OrgName is the orgName argument value.
 			OrgName string
+			// UserName is the userName argument value.
+			UserName string
 		}
 		// ListDevContainers holds details about calls to the ListDevContainers method.
 		ListDevContainers []struct {
@@ -240,7 +231,6 @@ type apiClientMock struct {
 	lockDeleteCodespace                sync.RWMutex
 	lockEditCodespace                  sync.RWMutex
 	lockGetCodespace                   sync.RWMutex
-	lockGetCodespaceRegionLocation     sync.RWMutex
 	lockGetCodespaceRepoSuggestions    sync.RWMutex
 	lockGetCodespaceRepositoryContents sync.RWMutex
 	lockGetCodespacesMachines          sync.RWMutex
@@ -435,37 +425,6 @@ func (mock *apiClientMock) GetCodespaceCalls() []struct {
 	return calls
 }
 
-// GetCodespaceRegionLocation calls GetCodespaceRegionLocationFunc.
-func (mock *apiClientMock) GetCodespaceRegionLocation(ctx context.Context) (string, error) {
-	if mock.GetCodespaceRegionLocationFunc == nil {
-		panic("apiClientMock.GetCodespaceRegionLocationFunc: method is nil but apiClient.GetCodespaceRegionLocation was just called")
-	}
-	callInfo := struct {
-		Ctx context.Context
-	}{
-		Ctx: ctx,
-	}
-	mock.lockGetCodespaceRegionLocation.Lock()
-	mock.calls.GetCodespaceRegionLocation = append(mock.calls.GetCodespaceRegionLocation, callInfo)
-	mock.lockGetCodespaceRegionLocation.Unlock()
-	return mock.GetCodespaceRegionLocationFunc(ctx)
-}
-
-// GetCodespaceRegionLocationCalls gets all the calls that were made to GetCodespaceRegionLocation.
-// Check the length with:
-//     len(mockedapiClient.GetCodespaceRegionLocationCalls())
-func (mock *apiClientMock) GetCodespaceRegionLocationCalls() []struct {
-	Ctx context.Context
-} {
-	var calls []struct {
-		Ctx context.Context
-	}
-	mock.lockGetCodespaceRegionLocation.RLock()
-	calls = mock.calls.GetCodespaceRegionLocation
-	mock.lockGetCodespaceRegionLocation.RUnlock()
-	return calls
-}
-
 // GetCodespaceRepoSuggestions calls GetCodespaceRepoSuggestionsFunc.
 func (mock *apiClientMock) GetCodespaceRepoSuggestions(ctx context.Context, partialSearch string, params api.RepoSearchParameters) ([]string, error) {
 	if mock.GetCodespaceRepoSuggestionsFunc == nil {
@@ -654,37 +613,41 @@ func (mock *apiClientMock) GetUserCalls() []struct {
 }
 
 // ListCodespaces calls ListCodespacesFunc.
-func (mock *apiClientMock) ListCodespaces(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error) {
+func (mock *apiClientMock) ListCodespaces(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error) {
 	if mock.ListCodespacesFunc == nil {
 		panic("apiClientMock.ListCodespacesFunc: method is nil but apiClient.ListCodespaces was just called")
 	}
 	callInfo := struct {
-		Ctx     context.Context
-		Limit   int
-		OrgName string
+		Ctx      context.Context
+		Limit    int
+		OrgName  string
+		UserName string
 	}{
-		Ctx:     ctx,
-		Limit:   limit,
-		OrgName: orgName,
+		Ctx:      ctx,
+		Limit:    limit,
+		OrgName:  orgName,
+		UserName: userName,
 	}
 	mock.lockListCodespaces.Lock()
 	mock.calls.ListCodespaces = append(mock.calls.ListCodespaces, callInfo)
 	mock.lockListCodespaces.Unlock()
-	return mock.ListCodespacesFunc(ctx, limit, orgName)
+	return mock.ListCodespacesFunc(ctx, limit, orgName, userName)
 }
 
 // ListCodespacesCalls gets all the calls that were made to ListCodespaces.
 // Check the length with:
 //     len(mockedapiClient.ListCodespacesCalls())
 func (mock *apiClientMock) ListCodespacesCalls() []struct {
-	Ctx     context.Context
-	Limit   int
-	OrgName string
+	Ctx      context.Context
+	Limit    int
+	OrgName  string
+	UserName string
 } {
 	var calls []struct {
-		Ctx     context.Context
-		Limit   int
-		OrgName string
+		Ctx      context.Context
+		Limit    int
+		OrgName  string
+		UserName string
 	}
 	mock.lockListCodespaces.RLock()
 	calls = mock.calls.ListCodespaces

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -49,7 +49,7 @@ import (
 // 			GetUserFunc: func(ctx context.Context) (*api.User, error) {
 // 				panic("mock out the GetUser method")
 // 			},
-// 			ListCodespacesFunc: func(ctx context.Context, limit int) ([]*api.Codespace, error) {
+// 			ListCodespacesFunc: func(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error) {
 // 				panic("mock out the ListCodespaces method")
 // 			},
 // 			ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
@@ -102,7 +102,7 @@ type apiClientMock struct {
 	GetUserFunc func(ctx context.Context) (*api.User, error)
 
 	// ListCodespacesFunc mocks the ListCodespaces method.
-	ListCodespacesFunc func(ctx context.Context, limit int) ([]*api.Codespace, error)
+	ListCodespacesFunc func(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error)
 
 	// ListDevContainersFunc mocks the ListDevContainers method.
 	ListDevContainersFunc func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error)
@@ -206,6 +206,8 @@ type apiClientMock struct {
 			Ctx context.Context
 			// Limit is the limit argument value.
 			Limit int
+			// OrgName is the orgName argument value
+			OrgName string
 		}
 		// ListDevContainers holds details about calls to the ListDevContainers method.
 		ListDevContainers []struct {
@@ -652,33 +654,37 @@ func (mock *apiClientMock) GetUserCalls() []struct {
 }
 
 // ListCodespaces calls ListCodespacesFunc.
-func (mock *apiClientMock) ListCodespaces(ctx context.Context, limit int) ([]*api.Codespace, error) {
+func (mock *apiClientMock) ListCodespaces(ctx context.Context, limit int, orgName string) ([]*api.Codespace, error) {
 	if mock.ListCodespacesFunc == nil {
 		panic("apiClientMock.ListCodespacesFunc: method is nil but apiClient.ListCodespaces was just called")
 	}
 	callInfo := struct {
-		Ctx   context.Context
-		Limit int
+		Ctx     context.Context
+		Limit   int
+		OrgName string
 	}{
-		Ctx:   ctx,
-		Limit: limit,
+		Ctx:     ctx,
+		Limit:   limit,
+		OrgName: orgName,
 	}
 	mock.lockListCodespaces.Lock()
 	mock.calls.ListCodespaces = append(mock.calls.ListCodespaces, callInfo)
 	mock.lockListCodespaces.Unlock()
-	return mock.ListCodespacesFunc(ctx, limit)
+	return mock.ListCodespacesFunc(ctx, limit, orgName)
 }
 
 // ListCodespacesCalls gets all the calls that were made to ListCodespaces.
 // Check the length with:
 //     len(mockedapiClient.ListCodespacesCalls())
 func (mock *apiClientMock) ListCodespacesCalls() []struct {
-	Ctx   context.Context
-	Limit int
+	Ctx     context.Context
+	Limit   int
+	OrgName string
 } {
 	var calls []struct {
-		Ctx   context.Context
-		Limit int
+		Ctx     context.Context
+		Limit   int
+		OrgName string
 	}
 	mock.lockListCodespaces.RLock()
 	calls = mock.calls.ListCodespaces

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -235,7 +235,7 @@ func (a *App) printOpenSSHConfig(ctx context.Context, opts sshOptions) (err erro
 	var csList []*api.Codespace
 	if opts.codespace == "" {
 		a.StartProgressIndicatorWithLabel("Fetching codespaces")
-		csList, err = a.apiClient.ListCodespaces(ctx, -1, "")
+		csList, err = a.apiClient.ListCodespaces(ctx, -1, "", "")
 		a.StopProgressIndicator()
 	} else {
 		var codespace *api.Codespace

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -235,7 +235,7 @@ func (a *App) printOpenSSHConfig(ctx context.Context, opts sshOptions) (err erro
 	var csList []*api.Codespace
 	if opts.codespace == "" {
 		a.StartProgressIndicatorWithLabel("Fetching codespaces")
-		csList, err = a.apiClient.ListCodespaces(ctx, -1)
+		csList, err = a.apiClient.ListCodespaces(ctx, -1, "")
 		a.StopProgressIndicator()
 	} else {
 		var codespace *api.Codespace

--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -28,7 +28,7 @@ func newStopCmd(app *App) *cobra.Command {
 func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 	if codespaceName == "" {
 		a.StartProgressIndicatorWithLabel("Fetching codespaces")
-		codespaces, err := a.apiClient.ListCodespaces(ctx, -1)
+		codespaces, err := a.apiClient.ListCodespaces(ctx, -1, "")
 		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to list codespaces: %w", err)

--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -28,7 +28,7 @@ func newStopCmd(app *App) *cobra.Command {
 func (a *App) StopCodespace(ctx context.Context, codespaceName string) error {
 	if codespaceName == "" {
 		a.StartProgressIndicatorWithLabel("Fetching codespaces")
-		codespaces, err := a.apiClient.ListCodespaces(ctx, -1, "")
+		codespaces, err := a.apiClient.ListCodespaces(ctx, -1, "", "")
 		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to list codespaces: %w", err)


### PR DESCRIPTION
https://github.com/github/codespaces/issues/8559

Add an `-o / --org` flag that will permit an organization admin to list codespaces that are billed to their organization.