### PR TITLE
Notify user when codespace usage is covered by organization

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -94,6 +94,7 @@ func New(serverURL, apiURL, vscsURL string, httpClient httpClient) *API {
 // User represents a GitHub user.
 type User struct {
 	Login string `json:"login"`
+	Type  string `json:"type"`
 }
 
 // GetUser returns the user associated with the given token.

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -574,8 +574,8 @@ func (a *API) GetCodespacePreFlight(ctx context.Context, nwo string) (*User, err
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, nil
-	} else if resp.StatusCode != http.StatusForbidden {
-		return nil, fmt.Errorf("codespaces cannot be created from that repository")
+	} else if resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("you cannot create codespaces with that repository")
 	} else if resp.StatusCode != http.StatusOK {
 		return nil, api.HandleHTTPError(resp)
 	}
@@ -586,9 +586,9 @@ func (a *API) GetCodespacePreFlight(ctx context.Context, nwo string) (*User, err
 	}
 
 	var response struct {
-		BillableOwner User `json:"billableOwner"`
+		BillableOwner User `json:"billable_owner"`
 		Defaults      struct {
-			DevcontainerPath string `json:"devcontainerPath"`
+			DevcontainerPath string `json:"devcontainer_path"`
 			Location         string `json:"location"`
 		}
 	}

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -557,9 +557,9 @@ func (a *API) GetCodespaceRepoSuggestions(ctx context.Context, partialSearch str
 	return repoNames, nil
 }
 
-// GetCodespacePreFlight returns the billable owner and expected default values for
+// GetCodespaceBillableOwner returns the billable owner and expected default values for
 // codespaces created by the user for a given repository.
-func (a *API) GetCodespacePreFlight(ctx context.Context, nwo string) (*User, error) {
+func (a *API) GetCodespaceBillableOwner(ctx context.Context, nwo string) (*User, error) {
 	req, err := http.NewRequest(http.MethodGet, a.githubAPI+"/repos/"+nwo+"/codespaces/new", nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -120,7 +120,7 @@ type apiClient interface {
 	GetCodespaceRepositoryContents(ctx context.Context, codespace *api.Codespace, path string) ([]byte, error)
 	ListDevContainers(ctx context.Context, repoID int, branch string, limit int) (devcontainers []api.DevContainerEntry, err error)
 	GetCodespaceRepoSuggestions(ctx context.Context, partialSearch string, params api.RepoSearchParameters) ([]string, error)
-	GetCodespacePreFlight(ctx context.Context, nwo string) (*api.User, error)
+	GetCodespaceBillableOwner(ctx context.Context, nwo string) (*api.User, error)
 }
 
 var errNoCodespaces = errors.New("you have no codespaces")

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -120,6 +120,7 @@ type apiClient interface {
 	GetCodespaceRepositoryContents(ctx context.Context, codespace *api.Codespace, path string) ([]byte, error)
 	ListDevContainers(ctx context.Context, repoID int, branch string, limit int) (devcontainers []api.DevContainerEntry, err error)
 	GetCodespaceRepoSuggestions(ctx context.Context, partialSearch string, params api.RepoSearchParameters) ([]string, error)
+	GetCodespacePreFlight(ctx context.Context, nwo string) (*api.User, error)
 }
 
 var errNoCodespaces = errors.New("you have no codespaces")

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -143,7 +143,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 	}
 
 	a.StartProgressIndicatorWithLabel("Validating repository for codespaces")
-	billableOwner, err := a.apiClient.GetCodespacePreFlight(ctx, userInputs.Repository)
+	billableOwner, err := a.apiClient.GetCodespaceBillableOwner(ctx, userInputs.Repository)
 	a.StopProgressIndicator()
 
 	if billableOwner != nil && billableOwner.Type == "Organization" {

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -135,7 +135,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 
 		if billableOwner.Type == "Organization" {
 			cs := a.io.ColorScheme()
-			fmt.Fprintln(a.io.Out, cs.Blue("✓ Usage covered by "+billableOwner.Login))
+			fmt.Fprintln(a.io.Out, cs.Blue("✓ Codespaces usage for this repository is paid for by "+billableOwner.Login))
 		} else if err != nil {
 			return fmt.Errorf("error checking codespace ownership: %w", err)
 		}

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -146,11 +146,11 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 	billableOwner, err := a.apiClient.GetCodespaceBillableOwner(ctx, userInputs.Repository)
 	a.StopProgressIndicator()
 
-	if billableOwner != nil && billableOwner.Type == "Organization" {
+	if err != nil {
+		return fmt.Errorf("error checking codespace ownership: %w", err)
+	} else if billableOwner != nil && billableOwner.Type == "Organization" {
 		cs := a.io.ColorScheme()
 		fmt.Fprintln(a.io.Out, cs.Blue("✓ Codespaces usage for this repository is paid for by "+billableOwner.Login))
-	} else if err != nil {
-		return fmt.Errorf("error checking codespace ownership: %w", err)
 	}
 
 	if promptForRepoAndBranch {

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -133,7 +133,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		billableOwner, err := a.apiClient.GetCodespacePreFlight(ctx, userInputs.Repository)
 		a.StopProgressIndicator()
 
-		if billableOwner.Type == "Organization" {
+		if billableOwner != nil && billableOwner.Type == "Organization" {
 			cs := a.io.ColorScheme()
 			fmt.Fprintln(a.io.Out, cs.Blue("✓ Codespaces usage for this repository is paid for by "+billableOwner.Login))
 		} else if err != nil {

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -29,17 +29,17 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace with default branch and 30m idle timeout",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
-						return &api.User{
-							Login: "monalisa",
-							Type:  "User",
-						}, nil
-					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,
 							FullName:      nwo,
 							DefaultBranch: "main",
+						}, nil
+					},
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Login: "monalisa",
+							Type:  "User",
 						}, nil
 					},
 					ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
@@ -86,17 +86,17 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace with default branch shows idle timeout notice if present",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
-						return &api.User{
-							Login: "monalisa",
-							Type:  "User",
-						}, nil
-					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,
 							FullName:      nwo,
 							DefaultBranch: "main",
+						}, nil
+					},
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Login: "monalisa",
+							Type:  "User",
 						}, nil
 					},
 					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error) {
@@ -140,17 +140,17 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace with default branch with default devcontainer if no path provided and no devcontainer files exist in the repo",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
-						return &api.User{
-							Login: "monalisa",
-							Type:  "User",
-						}, nil
-					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,
 							FullName:      nwo,
 							DefaultBranch: "main",
+						}, nil
+					},
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Login: "monalisa",
+							Type:  "User",
 						}, nil
 					},
 					ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
@@ -199,17 +199,17 @@ func TestApp_Create(t *testing.T) {
 			name: "returns error when getting devcontainer paths fails",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
-						return &api.User{
-							Login: "monalisa",
-							Type:  "User",
-						}, nil
-					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,
 							FullName:      nwo,
 							DefaultBranch: "main",
+						}, nil
+					},
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Login: "monalisa",
+							Type:  "User",
 						}, nil
 					},
 					ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
@@ -230,17 +230,17 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace with default branch does not show idle timeout notice if not conntected to terminal",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
-						return &api.User{
-							Login: "monalisa",
-							Type:  "User",
-						}, nil
-					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,
 							FullName:      nwo,
 							DefaultBranch: "main",
+						}, nil
+					},
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Login: "monalisa",
+							Type:  "User",
 						}, nil
 					},
 					ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
@@ -338,6 +338,75 @@ func TestApp_Create(t *testing.T) {
 Open this URL in your browser to review and authorize additional permissions: example.com/permissions
 Alternatively, you can run "create" with the "--default-permissions" option to continue without authorizing additional permissions.
 `,
+		},
+		{
+			name: "returns error when user can't create codepaces for a repository",
+			fields: fields{
+				apiClient: &apiClientMock{
+					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
+						return &api.Repository{
+							ID:            1234,
+							FullName:      nwo,
+							DefaultBranch: "main",
+						}, nil
+					},
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return nil, fmt.Errorf("some error")
+					},
+				},
+			},
+			opts: createOptions{
+				repo:        "megacorp/private",
+				branch:      "",
+				machine:     "GIGA",
+				showStatus:  false,
+				idleTimeout: 30 * time.Minute,
+			},
+			wantErr: fmt.Errorf("error checking codespace ownership: some error"),
+		},
+		{
+			name: "mentions billable owner when org covers codepaces for a repository",
+			fields: fields{
+				apiClient: &apiClientMock{
+					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
+						return &api.Repository{
+							ID:            1234,
+							FullName:      nwo,
+							DefaultBranch: "main",
+						}, nil
+					},
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Type:  "Organization",
+							Login: "megacorp",
+						}, nil
+					},
+					ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
+						return []api.DevContainerEntry{{Path: ".devcontainer/devcontainer.json"}}, nil
+					},
+					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error) {
+						return []*api.Machine{
+							{
+								Name:        "GIGA",
+								DisplayName: "Gigabits of a machine",
+							},
+						}, nil
+					},
+					CreateCodespaceFunc: func(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error) {
+						return &api.Codespace{
+							Name: "megacorp-private-abcd1234",
+						}, nil
+					},
+				},
+			},
+			opts: createOptions{
+				repo:        "megacorp/private",
+				branch:      "",
+				machine:     "GIGA",
+				showStatus:  false,
+				idleTimeout: 30 * time.Minute,
+			},
+			wantStdout: "✓ Codespaces usage for this repository is paid for by megacorp\nmegacorp-private-abcd1234\n",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -36,7 +36,7 @@ func TestApp_Create(t *testing.T) {
 							DefaultBranch: "main",
 						}, nil
 					},
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+					GetCodespaceBillableOwnerFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Login: "monalisa",
 							Type:  "User",
@@ -93,7 +93,7 @@ func TestApp_Create(t *testing.T) {
 							DefaultBranch: "main",
 						}, nil
 					},
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+					GetCodespaceBillableOwnerFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Login: "monalisa",
 							Type:  "User",
@@ -147,7 +147,7 @@ func TestApp_Create(t *testing.T) {
 							DefaultBranch: "main",
 						}, nil
 					},
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+					GetCodespaceBillableOwnerFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Login: "monalisa",
 							Type:  "User",
@@ -206,7 +206,7 @@ func TestApp_Create(t *testing.T) {
 							DefaultBranch: "main",
 						}, nil
 					},
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+					GetCodespaceBillableOwnerFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Login: "monalisa",
 							Type:  "User",
@@ -237,7 +237,7 @@ func TestApp_Create(t *testing.T) {
 							DefaultBranch: "main",
 						}, nil
 					},
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+					GetCodespaceBillableOwnerFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Login: "monalisa",
 							Type:  "User",
@@ -286,7 +286,7 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace that requires accepting additional permissions",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+					GetCodespaceBillableOwnerFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Login: "monalisa",
 							Type:  "User",
@@ -350,7 +350,7 @@ Alternatively, you can run "create" with the "--default-permissions" option to c
 							DefaultBranch: "main",
 						}, nil
 					},
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+					GetCodespaceBillableOwnerFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return nil, fmt.Errorf("some error")
 					},
 				},
@@ -375,7 +375,7 @@ Alternatively, you can run "create" with the "--default-permissions" option to c
 							DefaultBranch: "main",
 						}, nil
 					},
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+					GetCodespaceBillableOwnerFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Type:  "Organization",
 							Login: "megacorp",
@@ -419,7 +419,7 @@ Alternatively, you can run "create" with the "--default-permissions" option to c
 							DefaultBranch: "main",
 						}, nil
 					},
-					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+					GetCodespaceBillableOwnerFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Type:  "User",
 							Login: "monalisa",

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -29,6 +29,12 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace with default branch and 30m idle timeout",
 			fields: fields{
 				apiClient: &apiClientMock{
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Login: "monalisa",
+							Type:  "User",
+						}, nil
+					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,
@@ -83,6 +89,12 @@ func TestApp_Create(t *testing.T) {
 					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
 						return "EUROPE", nil
 					},
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Login: "monalisa",
+							Type:  "User",
+						}, nil
+					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,
@@ -133,6 +145,12 @@ func TestApp_Create(t *testing.T) {
 				apiClient: &apiClientMock{
 					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
 						return "EUROPE", nil
+					},
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Login: "monalisa",
+							Type:  "User",
+						}, nil
 					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
@@ -190,6 +208,12 @@ func TestApp_Create(t *testing.T) {
 					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
 						return "EUROPE", nil
 					},
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Login: "monalisa",
+							Type:  "User",
+						}, nil
+					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,
@@ -217,6 +241,12 @@ func TestApp_Create(t *testing.T) {
 				apiClient: &apiClientMock{
 					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
 						return "EUROPE", nil
+					},
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Login: "monalisa",
+							Type:  "User",
+						}, nil
 					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
@@ -268,6 +298,12 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace that requires accepting additional permissions",
 			fields: fields{
 				apiClient: &apiClientMock{
+					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+						return &api.User{
+							Login: "monalisa",
+							Type:  "User",
+						}, nil
+					},
 					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 						return &api.Repository{
 							ID:            1234,

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -86,9 +86,6 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace with default branch shows idle timeout notice if present",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
-						return "EUROPE", nil
-					},
 					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Login: "monalisa",
@@ -143,9 +140,6 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace with default branch with default devcontainer if no path provided and no devcontainer files exist in the repo",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
-						return "EUROPE", nil
-					},
 					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Login: "monalisa",
@@ -205,9 +199,6 @@ func TestApp_Create(t *testing.T) {
 			name: "returns error when getting devcontainer paths fails",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
-						return "EUROPE", nil
-					},
 					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Login: "monalisa",
@@ -239,9 +230,6 @@ func TestApp_Create(t *testing.T) {
 			name: "create codespace with default branch does not show idle timeout notice if not conntected to terminal",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
-						return "EUROPE", nil
-					},
 					GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
 						return &api.User{
 							Login: "monalisa",

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -31,8 +31,8 @@ import (
 // 			GetCodespaceFunc: func(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error) {
 // 				panic("mock out the GetCodespace method")
 // 			},
-// 			GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
-// 				panic("mock out the GetCodespacePreFlight method")
+// 			GetCodespaceBillableOwnerFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+// 				panic("mock out the GetCodespaceBillableOwner method")
 // 			},
 // 			GetCodespaceRepoSuggestionsFunc: func(ctx context.Context, partialSearch string, params api.RepoSearchParameters) ([]string, error) {
 // 				panic("mock out the GetCodespaceRepoSuggestions method")
@@ -83,8 +83,8 @@ type apiClientMock struct {
 	// GetCodespaceFunc mocks the GetCodespace method.
 	GetCodespaceFunc func(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error)
 
-	// GetCodespacePreFlightFunc mocks the GetCodespacePreFlight method.
-	GetCodespacePreFlightFunc func(ctx context.Context, nwo string) (*api.User, error)
+	// GetCodespaceBillableOwnerFunc mocks the GetCodespaceBillableOwner method.
+	GetCodespaceBillableOwnerFunc func(ctx context.Context, nwo string) (*api.User, error)
 
 	// GetCodespaceRepoSuggestionsFunc mocks the GetCodespaceRepoSuggestions method.
 	GetCodespaceRepoSuggestionsFunc func(ctx context.Context, partialSearch string, params api.RepoSearchParameters) ([]string, error)
@@ -154,8 +154,8 @@ type apiClientMock struct {
 			// IncludeConnection is the includeConnection argument value.
 			IncludeConnection bool
 		}
-		// GetCodespacePreFlight holds details about calls to the GetCodespacePreFlight method.
-		GetCodespacePreFlight []struct {
+		// GetCodespaceBillableOwner holds details about calls to the GetCodespaceBillableOwner method.
+		GetCodespaceBillableOwner []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// Nwo is the nwo argument value.
@@ -240,7 +240,7 @@ type apiClientMock struct {
 	lockDeleteCodespace                sync.RWMutex
 	lockEditCodespace                  sync.RWMutex
 	lockGetCodespace                   sync.RWMutex
-	lockGetCodespacePreFlight          sync.RWMutex
+	lockGetCodespaceBillableOwner      sync.RWMutex
 	lockGetCodespaceRepoSuggestions    sync.RWMutex
 	lockGetCodespaceRepositoryContents sync.RWMutex
 	lockGetCodespacesMachines          sync.RWMutex
@@ -435,10 +435,10 @@ func (mock *apiClientMock) GetCodespaceCalls() []struct {
 	return calls
 }
 
-// GetCodespacePreFlight calls GetCodespacePreFlightFunc.
-func (mock *apiClientMock) GetCodespacePreFlight(ctx context.Context, nwo string) (*api.User, error) {
-	if mock.GetCodespacePreFlightFunc == nil {
-		panic("apiClientMock.GetCodespacePreFlightFunc: method is nil but apiClient.GetCodespacePreFlight was just called")
+// GetCodespaceBillableOwner calls GetCodespaceBillableOwnerFunc.
+func (mock *apiClientMock) GetCodespaceBillableOwner(ctx context.Context, nwo string) (*api.User, error) {
+	if mock.GetCodespaceBillableOwnerFunc == nil {
+		panic("apiClientMock.GetCodespaceBillableOwnerFunc: method is nil but apiClient.GetCodespaceBillableOwner was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
@@ -447,16 +447,16 @@ func (mock *apiClientMock) GetCodespacePreFlight(ctx context.Context, nwo string
 		Ctx: ctx,
 		Nwo: nwo,
 	}
-	mock.lockGetCodespacePreFlight.Lock()
-	mock.calls.GetCodespacePreFlight = append(mock.calls.GetCodespacePreFlight, callInfo)
-	mock.lockGetCodespacePreFlight.Unlock()
-	return mock.GetCodespacePreFlightFunc(ctx, nwo)
+	mock.lockGetCodespaceBillableOwner.Lock()
+	mock.calls.GetCodespaceBillableOwner = append(mock.calls.GetCodespaceBillableOwner, callInfo)
+	mock.lockGetCodespaceBillableOwner.Unlock()
+	return mock.GetCodespaceBillableOwnerFunc(ctx, nwo)
 }
 
-// GetCodespacePreFlightCalls gets all the calls that were made to GetCodespacePreFlight.
+// GetCodespaceBillableOwnerCalls gets all the calls that were made to GetCodespaceBillableOwner.
 // Check the length with:
-//     len(mockedapiClient.GetCodespacePreFlightCalls())
-func (mock *apiClientMock) GetCodespacePreFlightCalls() []struct {
+//     len(mockedapiClient.GetCodespaceBillableOwnerCalls())
+func (mock *apiClientMock) GetCodespaceBillableOwnerCalls() []struct {
 	Ctx context.Context
 	Nwo string
 } {
@@ -464,9 +464,9 @@ func (mock *apiClientMock) GetCodespacePreFlightCalls() []struct {
 		Ctx context.Context
 		Nwo string
 	}
-	mock.lockGetCodespacePreFlight.RLock()
-	calls = mock.calls.GetCodespacePreFlight
-	mock.lockGetCodespacePreFlight.RUnlock()
+	mock.lockGetCodespaceBillableOwner.RLock()
+	calls = mock.calls.GetCodespaceBillableOwner
+	mock.lockGetCodespaceBillableOwner.RUnlock()
 	return calls
 }
 

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -31,8 +31,8 @@ import (
 // 			GetCodespaceFunc: func(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error) {
 // 				panic("mock out the GetCodespace method")
 // 			},
-// 			GetCodespaceRegionLocationFunc: func(ctx context.Context) (string, error) {
-// 				panic("mock out the GetCodespaceRegionLocation method")
+// 			GetCodespacePreFlightFunc: func(ctx context.Context, nwo string) (*api.User, error) {
+// 				panic("mock out the GetCodespacePreFlight method")
 // 			},
 // 			GetCodespaceRepoSuggestionsFunc: func(ctx context.Context, partialSearch string, params api.RepoSearchParameters) ([]string, error) {
 // 				panic("mock out the GetCodespaceRepoSuggestions method")
@@ -83,8 +83,8 @@ type apiClientMock struct {
 	// GetCodespaceFunc mocks the GetCodespace method.
 	GetCodespaceFunc func(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error)
 
-	// GetCodespaceRegionLocationFunc mocks the GetCodespaceRegionLocation method.
-	GetCodespaceRegionLocationFunc func(ctx context.Context) (string, error)
+	// GetCodespacePreFlightFunc mocks the GetCodespacePreFlight method.
+	GetCodespacePreFlightFunc func(ctx context.Context, nwo string) (*api.User, error)
 
 	// GetCodespaceRepoSuggestionsFunc mocks the GetCodespaceRepoSuggestions method.
 	GetCodespaceRepoSuggestionsFunc func(ctx context.Context, partialSearch string, params api.RepoSearchParameters) ([]string, error)
@@ -154,10 +154,12 @@ type apiClientMock struct {
 			// IncludeConnection is the includeConnection argument value.
 			IncludeConnection bool
 		}
-		// GetCodespaceRegionLocation holds details about calls to the GetCodespaceRegionLocation method.
-		GetCodespaceRegionLocation []struct {
+		// GetCodespacePreFlight holds details about calls to the GetCodespacePreFlight method.
+		GetCodespacePreFlight []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+			// Nwo is the nwo argument value.
+			Nwo string
 		}
 		// GetCodespaceRepoSuggestions holds details about calls to the GetCodespaceRepoSuggestions method.
 		GetCodespaceRepoSuggestions []struct {
@@ -238,7 +240,7 @@ type apiClientMock struct {
 	lockDeleteCodespace                sync.RWMutex
 	lockEditCodespace                  sync.RWMutex
 	lockGetCodespace                   sync.RWMutex
-	lockGetCodespaceRegionLocation     sync.RWMutex
+	lockGetCodespacePreFlight          sync.RWMutex
 	lockGetCodespaceRepoSuggestions    sync.RWMutex
 	lockGetCodespaceRepositoryContents sync.RWMutex
 	lockGetCodespacesMachines          sync.RWMutex
@@ -433,34 +435,38 @@ func (mock *apiClientMock) GetCodespaceCalls() []struct {
 	return calls
 }
 
-// GetCodespaceRegionLocation calls GetCodespaceRegionLocationFunc.
-func (mock *apiClientMock) GetCodespaceRegionLocation(ctx context.Context) (string, error) {
-	if mock.GetCodespaceRegionLocationFunc == nil {
-		panic("apiClientMock.GetCodespaceRegionLocationFunc: method is nil but apiClient.GetCodespaceRegionLocation was just called")
+// GetCodespacePreFlight calls GetCodespacePreFlightFunc.
+func (mock *apiClientMock) GetCodespacePreFlight(ctx context.Context, nwo string) (*api.User, error) {
+	if mock.GetCodespacePreFlightFunc == nil {
+		panic("apiClientMock.GetCodespacePreFlightFunc: method is nil but apiClient.GetCodespacePreFlight was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
+		Nwo string
 	}{
 		Ctx: ctx,
+		Nwo: nwo,
 	}
-	mock.lockGetCodespaceRegionLocation.Lock()
-	mock.calls.GetCodespaceRegionLocation = append(mock.calls.GetCodespaceRegionLocation, callInfo)
-	mock.lockGetCodespaceRegionLocation.Unlock()
-	return mock.GetCodespaceRegionLocationFunc(ctx)
+	mock.lockGetCodespacePreFlight.Lock()
+	mock.calls.GetCodespacePreFlight = append(mock.calls.GetCodespacePreFlight, callInfo)
+	mock.lockGetCodespacePreFlight.Unlock()
+	return mock.GetCodespacePreFlightFunc(ctx, nwo)
 }
 
-// GetCodespaceRegionLocationCalls gets all the calls that were made to GetCodespaceRegionLocation.
+// GetCodespacePreFlightCalls gets all the calls that were made to GetCodespacePreFlight.
 // Check the length with:
-//     len(mockedapiClient.GetCodespaceRegionLocationCalls())
-func (mock *apiClientMock) GetCodespaceRegionLocationCalls() []struct {
+//     len(mockedapiClient.GetCodespacePreFlightCalls())
+func (mock *apiClientMock) GetCodespacePreFlightCalls() []struct {
 	Ctx context.Context
+	Nwo string
 } {
 	var calls []struct {
 		Ctx context.Context
+		Nwo string
 	}
-	mock.lockGetCodespaceRegionLocation.RLock()
-	calls = mock.calls.GetCodespaceRegionLocation
-	mock.lockGetCodespaceRegionLocation.RUnlock()
+	mock.lockGetCodespacePreFlight.RLock()
+	calls = mock.calls.GetCodespacePreFlight
+	mock.lockGetCodespacePreFlight.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
Adds support for a new codepaces API endpoint which surfaces the "billable owner" of a codespace. Consistent with the pattern we're implementing for github.com and the GitHub Codespaces extension in VS Code, we'll show when the billable owner is an organization, after the user supplies a repository.

https://user-images.githubusercontent.com/7283521/174496438-1671a237-5b06-467d-9340-1386ceb13039.mov

![Screen Shot 2022-06-17 at 3 30 19 PM](https://user-images.githubusercontent.com/7283521/174496120-0a170f92-41ee-4a2e-bc87-0ea62f7b2eae.png)

- A 403 is the expected response when a user cannot create a codespace with the repository, so an informative error message is used in this case.
- For safe rollout of the new endpoint and this feature, we don't stop the user on 404s, relying on the other erroring API calls that already stop the user from creating a codespace.

To surface this where desired, we make this request, and the existing request to fetch a repository, ahead of the branch prompt.

Implements internal codespaces issue #8227