### PR TITLE
Simplify codespace picker

### DIFF
--- a/pkg/cmd/codespace/common_test.go
+++ b/pkg/cmd/codespace/common_test.go
@@ -1,6 +1,7 @@
 package codespace
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/cli/cli/v2/internal/codespaces/api"
@@ -126,6 +127,174 @@ func Test_codespace_displayName(t *testing.T) {
 			}
 			if got := c.displayName(tt.args.includeName, tt.args.includeGitStatus); got != tt.want {
 				t.Errorf("codespace.displayName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_formatCodespacesForSelect(t *testing.T) {
+	type args struct {
+		codespaces []*api.Codespace
+	}
+	tests := []struct {
+		name                string
+		args                args
+		wantCodespacesNames []string
+		wantCodespacesDirty map[string]bool
+	}{
+		{
+			name: "One codespace: Shows only repo and branch name",
+			args: args{
+				codespaces: []*api.Codespace{
+					{
+						GitStatus: api.CodespaceGitStatus{
+							Ref: "trunk",
+						},
+						Repository: api.Repository{
+							FullName: "cli/cli",
+						},
+						DisplayName: "scuba steve",
+					},
+				},
+			},
+			wantCodespacesNames: []string{
+				"cli/cli: trunk",
+			},
+			wantCodespacesDirty: map[string]bool{},
+		},
+		{
+			name: "Two codespaces on the same repo/branch: Adds the codespace's display name",
+			args: args{
+				codespaces: []*api.Codespace{
+					{
+						GitStatus: api.CodespaceGitStatus{
+							Ref: "trunk",
+						},
+						Repository: api.Repository{
+							FullName: "cli/cli",
+						},
+						DisplayName: "scuba steve",
+					},
+					{
+						GitStatus: api.CodespaceGitStatus{
+							Ref: "trunk",
+						},
+						Repository: api.Repository{
+							FullName: "cli/cli",
+						},
+						DisplayName: "flappy bird",
+					},
+				},
+			},
+			wantCodespacesNames: []string{
+				"cli/cli: scuba steve (trunk)",
+				"cli/cli: flappy bird (trunk)",
+			},
+			wantCodespacesDirty: map[string]bool{},
+		},
+		{
+			name: "Two codespaces on the different branches: Shows only repo and branch name",
+			args: args{
+				codespaces: []*api.Codespace{
+					{
+						GitStatus: api.CodespaceGitStatus{
+							Ref: "trunk",
+						},
+						Repository: api.Repository{
+							FullName: "cli/cli",
+						},
+						DisplayName: "scuba steve",
+					},
+					{
+						GitStatus: api.CodespaceGitStatus{
+							Ref: "feature",
+						},
+						Repository: api.Repository{
+							FullName: "cli/cli",
+						},
+						DisplayName: "flappy bird",
+					},
+				},
+			},
+			wantCodespacesNames: []string{
+				"cli/cli: trunk",
+				"cli/cli: feature",
+			},
+			wantCodespacesDirty: map[string]bool{},
+		},
+		{
+			name: "Two codespaces on the different repos: Shows only repo and branch name",
+			args: args{
+				codespaces: []*api.Codespace{
+					{
+						GitStatus: api.CodespaceGitStatus{
+							Ref: "trunk",
+						},
+						Repository: api.Repository{
+							FullName: "github/cli",
+						},
+						DisplayName: "scuba steve",
+					},
+					{
+						GitStatus: api.CodespaceGitStatus{
+							Ref: "trunk",
+						},
+						Repository: api.Repository{
+							FullName: "cli/cli",
+						},
+						DisplayName: "flappy bird",
+					},
+				},
+			},
+			wantCodespacesNames: []string{
+				"github/cli: trunk",
+				"cli/cli: trunk",
+			},
+			wantCodespacesDirty: map[string]bool{},
+		},
+		{
+			name: "Two codespaces on the same repo/branch, one dirty: Adds the codespace's display name and *",
+			args: args{
+				codespaces: []*api.Codespace{
+					{
+						GitStatus: api.CodespaceGitStatus{
+							Ref: "trunk",
+						},
+						Repository: api.Repository{
+							FullName: "cli/cli",
+						},
+						DisplayName: "scuba steve",
+					},
+					{
+						GitStatus: api.CodespaceGitStatus{
+							Ref:                  "trunk",
+							HasUncommitedChanges: true,
+						},
+						Repository: api.Repository{
+							FullName: "cli/cli",
+						},
+						DisplayName: "flappy bird",
+					},
+				},
+			},
+			wantCodespacesNames: []string{
+				"cli/cli: scuba steve (trunk)",
+				"cli/cli: flappy bird (trunk*)",
+			},
+			wantCodespacesDirty: map[string]bool{
+				"cli/cli: flappy bird (trunk*)": true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCodespacesNames, gotCodespacesDirty, _ := formatCodespacesForSelect(tt.args.codespaces)
+
+			if !reflect.DeepEqual(gotCodespacesNames, tt.wantCodespacesNames) {
+				t.Errorf("codespacesNames: got %v, want %v", gotCodespacesNames, tt.wantCodespacesNames)
+			}
+			if !reflect.DeepEqual(gotCodespacesDirty, tt.wantCodespacesDirty) {
+				t.Errorf("codespacesDirty: got %v, want %v", gotCodespacesDirty, tt.wantCodespacesDirty)
 			}
 		})
 	}

--- a/pkg/cmd/codespace/common_test.go
+++ b/pkg/cmd/codespace/common_test.go
@@ -11,14 +11,9 @@ func Test_codespace_displayName(t *testing.T) {
 	type fields struct {
 		Codespace *api.Codespace
 	}
-	type args struct {
-		includeName      bool
-		includeGitStatus bool
-	}
 	tests := []struct {
 		name   string
 		fields fields
-		args   args
 		want   string
 	}{
 		{
@@ -34,9 +29,6 @@ func Test_codespace_displayName(t *testing.T) {
 					DisplayName: "scuba steve",
 				},
 			},
-			args: args{
-				includeGitStatus: false,
-			},
 			want: "cli/cli (trunk): scuba steve",
 		},
 		{
@@ -51,9 +43,6 @@ func Test_codespace_displayName(t *testing.T) {
 					},
 					DisplayName: "scuba steve",
 				},
-			},
-			args: args{
-				includeGitStatus: true,
 			},
 			want: "cli/cli (trunk): scuba steve",
 		},
@@ -71,9 +60,6 @@ func Test_codespace_displayName(t *testing.T) {
 					DisplayName: "scuba steve",
 				},
 			},
-			args: args{
-				includeGitStatus: true,
-			},
 			want: "cli/cli (trunk*): scuba steve",
 		},
 		{
@@ -89,9 +75,6 @@ func Test_codespace_displayName(t *testing.T) {
 					},
 					DisplayName: "scuba steve",
 				},
-			},
-			args: args{
-				includeGitStatus: true,
 			},
 			want: "cli/cli (trunk*): scuba steve",
 		},
@@ -109,9 +92,6 @@ func Test_codespace_displayName(t *testing.T) {
 					DisplayName: "scuba steve",
 				},
 			},
-			args: args{
-				includeGitStatus: true,
-			},
 			want: "cli/cli (trunk): scuba steve",
 		},
 	}
@@ -120,7 +100,7 @@ func Test_codespace_displayName(t *testing.T) {
 			c := codespace{
 				Codespace: tt.fields.Codespace,
 			}
-			if got := c.displayName(tt.args.includeGitStatus); got != tt.want {
+			if got := c.displayName(); got != tt.want {
 				t.Errorf("codespace.displayName() = %v, want %v", got, tt.want)
 			}
 		})
@@ -275,7 +255,7 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCodespacesNames, _ := formatCodespacesForSelect(tt.args.codespaces)
+			gotCodespacesNames := formatCodespacesForSelect(tt.args.codespaces)
 
 			if !reflect.DeepEqual(gotCodespacesNames, tt.wantCodespacesNames) {
 				t.Errorf("codespacesNames: got %v, want %v", gotCodespacesNames, tt.wantCodespacesNames)

--- a/pkg/cmd/codespace/common_test.go
+++ b/pkg/cmd/codespace/common_test.go
@@ -35,10 +35,9 @@ func Test_codespace_displayName(t *testing.T) {
 				},
 			},
 			args: args{
-				includeName:      false,
 				includeGitStatus: false,
 			},
-			want: "cli/cli: trunk",
+			want: "cli/cli (trunk): scuba steve",
 		},
 		{
 			name: "No included name - included gitstatus - no unsaved changes",
@@ -54,10 +53,9 @@ func Test_codespace_displayName(t *testing.T) {
 				},
 			},
 			args: args{
-				includeName:      false,
 				includeGitStatus: true,
 			},
-			want: "cli/cli: trunk",
+			want: "cli/cli (trunk): scuba steve",
 		},
 		{
 			name: "No included name - included gitstatus - unsaved changes",
@@ -74,10 +72,9 @@ func Test_codespace_displayName(t *testing.T) {
 				},
 			},
 			args: args{
-				includeName:      false,
 				includeGitStatus: true,
 			},
-			want: "cli/cli: trunk*",
+			want: "cli/cli (trunk*): scuba steve",
 		},
 		{
 			name: "Included name - included gitstatus - unsaved changes",
@@ -94,10 +91,9 @@ func Test_codespace_displayName(t *testing.T) {
 				},
 			},
 			args: args{
-				includeName:      true,
 				includeGitStatus: true,
 			},
-			want: "cli/cli: scuba steve (trunk*)",
+			want: "cli/cli (trunk*): scuba steve",
 		},
 		{
 			name: "Included name - included gitstatus - no unsaved changes",
@@ -114,10 +110,9 @@ func Test_codespace_displayName(t *testing.T) {
 				},
 			},
 			args: args{
-				includeName:      true,
 				includeGitStatus: true,
 			},
-			want: "cli/cli: scuba steve (trunk)",
+			want: "cli/cli (trunk): scuba steve",
 		},
 	}
 	for _, tt := range tests {
@@ -125,7 +120,7 @@ func Test_codespace_displayName(t *testing.T) {
 			c := codespace{
 				Codespace: tt.fields.Codespace,
 			}
-			if got := c.displayName(tt.args.includeName, tt.args.includeGitStatus); got != tt.want {
+			if got := c.displayName(tt.args.includeGitStatus); got != tt.want {
 				t.Errorf("codespace.displayName() = %v, want %v", got, tt.want)
 			}
 		})
@@ -140,7 +135,6 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 		name                string
 		args                args
 		wantCodespacesNames []string
-		wantCodespacesDirty map[string]bool
 	}{
 		{
 			name: "One codespace: Shows only repo and branch name",
@@ -158,9 +152,8 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 				},
 			},
 			wantCodespacesNames: []string{
-				"cli/cli: trunk",
+				"cli/cli (trunk): scuba steve",
 			},
-			wantCodespacesDirty: map[string]bool{},
 		},
 		{
 			name: "Two codespaces on the same repo/branch: Adds the codespace's display name",
@@ -187,10 +180,9 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 				},
 			},
 			wantCodespacesNames: []string{
-				"cli/cli: scuba steve (trunk)",
-				"cli/cli: flappy bird (trunk)",
+				"cli/cli (trunk): scuba steve",
+				"cli/cli (trunk): flappy bird",
 			},
-			wantCodespacesDirty: map[string]bool{},
 		},
 		{
 			name: "Two codespaces on the different branches: Shows only repo and branch name",
@@ -217,10 +209,9 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 				},
 			},
 			wantCodespacesNames: []string{
-				"cli/cli: trunk",
-				"cli/cli: feature",
+				"cli/cli (trunk): scuba steve",
+				"cli/cli (feature): flappy bird",
 			},
-			wantCodespacesDirty: map[string]bool{},
 		},
 		{
 			name: "Two codespaces on the different repos: Shows only repo and branch name",
@@ -247,10 +238,9 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 				},
 			},
 			wantCodespacesNames: []string{
-				"github/cli: trunk",
-				"cli/cli: trunk",
+				"github/cli (trunk): scuba steve",
+				"cli/cli (trunk): flappy bird",
 			},
-			wantCodespacesDirty: map[string]bool{},
 		},
 		{
 			name: "Two codespaces on the same repo/branch, one dirty: Adds the codespace's display name and *",
@@ -278,23 +268,17 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 				},
 			},
 			wantCodespacesNames: []string{
-				"cli/cli: scuba steve (trunk)",
-				"cli/cli: flappy bird (trunk*)",
-			},
-			wantCodespacesDirty: map[string]bool{
-				"cli/cli: flappy bird (trunk*)": true,
+				"cli/cli (trunk): scuba steve",
+				"cli/cli (trunk*): flappy bird",
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCodespacesNames, gotCodespacesDirty, _ := formatCodespacesForSelect(tt.args.codespaces)
+			gotCodespacesNames, _ := formatCodespacesForSelect(tt.args.codespaces)
 
 			if !reflect.DeepEqual(gotCodespacesNames, tt.wantCodespacesNames) {
 				t.Errorf("codespacesNames: got %v, want %v", gotCodespacesNames, tt.wantCodespacesNames)
-			}
-			if !reflect.DeepEqual(gotCodespacesDirty, tt.wantCodespacesDirty) {
-				t.Errorf("codespacesDirty: got %v, want %v", gotCodespacesDirty, tt.wantCodespacesDirty)
 			}
 		})
 	}


### PR DESCRIPTION
Builds on https://github.com/cli/cli/pull/5811

Remove much of the complexity around creating and working with the codespace picker by always including the display name and git status of the codespace:

```
> cli/cli (trunk): scuba steve
  cli/cli (trunk*): flappy bird
  greggroth/cli (feature): kermit frog
```

See the tests for more examples.