### PR TITLE
Indent org billable owner notice for new codespaces

### DIFF
--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -150,7 +150,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		return fmt.Errorf("error checking codespace ownership: %w", err)
 	} else if billableOwner != nil && billableOwner.Type == "Organization" {
 		cs := a.io.ColorScheme()
-		fmt.Fprintln(a.io.Out, cs.Blue("✓ Codespaces usage for this repository is paid for by "+billableOwner.Login))
+		fmt.Fprintln(a.io.Out, cs.Blue("  ✓ Codespaces usage for this repository is paid for by "+billableOwner.Login))
 	}
 
 	if promptForRepoAndBranch {

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -406,7 +406,7 @@ Alternatively, you can run "create" with the "--default-permissions" option to c
 				showStatus:  false,
 				idleTimeout: 30 * time.Minute,
 			},
-			wantStdout: "✓ Codespaces usage for this repository is paid for by megacorp\nmegacorp-private-abcd1234\n",
+			wantStdout: "  ✓ Codespaces usage for this repository is paid for by megacorp\nmegacorp-private-abcd1234\n",
 		},
 		{
 			name: "doesn't mention billable owner when it's the individual",


### PR DESCRIPTION
Per design feedback on internal codespaces issue 8227, just adds 2 spaces of indentation below the repository prompt (please ignore my terminal's weird broken line height):

![Screen Shot 2022-06-20 at 9 53 34 PM](https://user-images.githubusercontent.com/7283521/174712916-c3950608-eca3-47a6-9d15-b03708d2c551.png)

