### PR TITLE
clear pr create multiselect on select

### DIFF
--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -327,7 +327,7 @@ func MetadataSurvey(io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher 
 		Milestone string
 	}{}
 
-	err = prompt.SurveyAsk(mqs, &values, survey.WithKeepFilter(true))
+	err = prompt.SurveyAsk(mqs, &values)
 	if err != nil {
 		return fmt.Errorf("could not prompt: %w", err)
 	}


### PR DESCRIPTION
This PR removes the survey `keepFilter` flag to make `pr create` consistent with `pr edit` which clears the search filter on multi-select item selection.

I chose to remove the flag here instead of adding it to the edit command because I believe clearing on selection is a more ergonomic user experience.