### PR TITLE
Apply UI polish around codespaces org-admin commands

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -380,18 +380,16 @@ func (a *API) GetOrgMemberCodespace(ctx context.Context, orgName string, userNam
 			return nil, fmt.Errorf("error unmarshaling response: %w", err)
 		}
 
-		nextURL := findNextPage(resp.Header.Get("Link"))
-
 		for _, cs := range response.Codespaces {
 			if cs.Name == codespaceName {
 				return cs, nil
 			}
 		}
 
+		nextURL := findNextPage(resp.Header.Get("Link"))
 		if nextURL == "" {
 			break
 		}
-
 		listURL = nextURL
 	}
 

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -50,7 +50,7 @@ func newDeleteCmd(app *App) *cobra.Command {
 			All codespaces for the authenticated user can be deleted, as well as codespaces for a
 			specific repository. Alternatively, only codespaces older than N days can be deleted.
 
-			Organization administrators may delete codespaces belonging to members of their organization.
+			Organization administrators may delete any codespace billed to the organization.
 		`),
 		Args: noArgsConstraint,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/utils"
@@ -22,8 +23,14 @@ func newListCmd(app *App) *cobra.Command {
 	var exporter cmdutil.Exporter
 
 	listCmd := &cobra.Command{
-		Use:     "list",
-		Short:   "List your codespaces",
+		Use:   "list",
+		Short: "List codespaces",
+		Long: heredoc.Doc(`
+			List codespaces of the authenticated user.
+
+			Alternatively, organization administrators may list codespaces belonging to members of
+			their organization.
+		`),
 		Aliases: []string{"ls"},
 		Args:    noArgsConstraint,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -36,8 +43,8 @@ func newListCmd(app *App) *cobra.Command {
 	}
 
 	listCmd.Flags().IntVarP(&opts.limit, "limit", "L", 30, "Maximum number of codespaces to list")
-	listCmd.Flags().StringVarP(&opts.orgName, "org", "o", "", "List codespaces for members of an organization (admin-only)")
-	listCmd.Flags().StringVarP(&opts.userName, "user", "u", "", "Used with --org to filter to a specific user")
+	listCmd.Flags().StringVarP(&opts.orgName, "org", "o", "", "The `login` handle of the organization to list codespaces for (admin-only)")
+	listCmd.Flags().StringVarP(&opts.userName, "user", "u", "", "The `username` to list codespaces for (used with --org)")
 	cmdutil.AddJSONFlags(listCmd, &exporter, api.CodespaceFields)
 
 	return listCmd

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -28,8 +28,7 @@ func newListCmd(app *App) *cobra.Command {
 		Long: heredoc.Doc(`
 			List codespaces of the authenticated user.
 
-			Alternatively, organization administrators may list codespaces belonging to members of
-			their organization.
+			Alternatively, organization administrators may list all codespaces billed to the organization.
 		`),
 		Aliases: []string{"ls"},
 		Args:    noArgsConstraint,

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -7,7 +7,7 @@ import (
 func NewRootCmd(app *App) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "codespace",
-		Short: "Connect to and manage your codespaces",
+		Short: "Connect to and manage codespaces",
 	}
 
 	root.AddCommand(newCodeCmd(app))

--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
 
@@ -22,22 +23,16 @@ func newStopCmd(app *App) *cobra.Command {
 		Use:   "stop",
 		Short: "Stop a running codespace",
 		Args:  noArgsConstraint,
-		PreRunE: func(c *cobra.Command, args []string) error {
-			if opts.orgName != "" {
-				if opts.codespaceName != "" && opts.userName == "" {
-					return errors.New("`--org` with `--codespace` requires `--username`")
-				}
-				return nil
-			}
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.orgName != "" && opts.codespaceName != "" && opts.userName == "" {
+				return cmdutil.FlagErrorf("using `--org` with `--codespace` requires `--user`")
+			}
 			return app.StopCodespace(cmd.Context(), opts)
 		},
 	}
 	stopCmd.Flags().StringVarP(&opts.codespaceName, "codespace", "c", "", "Name of the codespace")
-	stopCmd.Flags().StringVarP(&opts.orgName, "org", "o", "", "Stop codespace for an organization member (admin-only)")
-	stopCmd.Flags().StringVarP(&opts.userName, "username", "u", "", "Owner of the codespace. Required when using both -c and -o flags.")
+	stopCmd.Flags().StringVarP(&opts.orgName, "org", "o", "", "The `login` handle of the organization (admin-only)")
+	stopCmd.Flags().StringVarP(&opts.userName, "user", "u", "", "The `username` to stop codespace for (used with --org)")
 
 	return stopCmd
 }


### PR DESCRIPTION
This standardizes the `--user`/`--username` flag name to be just `--user` and improves related documentation.

Followup to https://github.com/cli/cli/pull/5827 https://github.com/cli/cli/pull/5812 https://github.com/cli/cli/pull/5807