### PR TITLE
Linux installation: ensure GPG keyring is world-readable

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -15,6 +15,7 @@ Install:
 
 ```bash
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 sudo apt update
 sudo apt install gh


### PR DESCRIPTION
This alleviates problems with umask at the time of installation.

Fixes https://github.com/cli/cli/issues/5810