### PR TITLE
Codespaces list by repo

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -269,16 +269,15 @@ func (c *Codespace) ExportData(fields []string) map[string]interface{} {
 }
 
 type ListCodespacesOptions struct {
-	OrgName    string
-	UserName   string
-	Repository *Repository
-	Limit      int
+	OrgName  string
+	UserName string
+	RepoName string
+	Limit    int
 }
 
 // ListCodespaces returns a list of codespaces for the user. Pass a negative limit to request all pages from
 // the API until all codespaces have been fetched.
 func (a *API) ListCodespaces(ctx context.Context, opts ListCodespacesOptions) (codespaces []*Codespace, err error) {
-
 	var (
 		perPage = 100
 		limit   = opts.Limit
@@ -288,11 +287,13 @@ func (a *API) ListCodespaces(ctx context.Context, opts ListCodespacesOptions) (c
 		perPage = limit
 	}
 
-	var listURL string
-	var spanName string
+	var (
+		listURL  string
+		spanName string
+	)
 
-	if opts.Repository != nil {
-		listURL = fmt.Sprintf("%s/repos/%s/codespaces?per_page=%d", a.githubAPI, opts.Repository.FullName, perPage)
+	if opts.RepoName != "" {
+		listURL = fmt.Sprintf("%s/repos/%s/codespaces?per_page=%d", a.githubAPI, opts.RepoName, perPage)
 		spanName = "/repos/*/codespaces"
 	} else if opts.OrgName != "" {
 		// the endpoints below can only be called by the organization admins

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -295,7 +295,7 @@ func (a *API) ListCodespaces(ctx context.Context, opts ListCodespacesOptions) (c
 		listURL = fmt.Sprintf("%s/repos/%s/codespaces?per_page=%d", a.githubAPI, opts.Repository.FullName, perPage)
 		spanName = "/repos/*/codespaces"
 	} else if opts.OrgName != "" {
-		// admin only
+		// the endpoints below can only be called by the organization admins
 		orgName := opts.OrgName
 		if opts.UserName != "" {
 			userName := opts.UserName

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -269,10 +269,10 @@ func (c *Codespace) ExportData(fields []string) map[string]interface{} {
 }
 
 type ListCodespacesOptions struct {
-	OrgName        string
-	UserName       string
-	RepositoryName string
-	Limit          int
+	OrgName    string
+	UserName   string
+	Repository *Repository
+	Limit      int
 }
 
 // ListCodespaces returns a list of codespaces for the user. Pass a negative limit (default) to request all pages from
@@ -290,7 +290,11 @@ func (a *API) ListCodespaces(ctx context.Context, opts ListCodespacesOptions) (c
 	var listURL string
 	var spanName string
 
-	if opts.OrgName != "" {
+	if opts.Repository != nil {
+		listURL = fmt.Sprintf("%s/repos/%s/codespaces?per_page=%d", a.githubAPI, opts.Repository.FullName, perPage)
+		spanName = "/repos/*/codespaces"
+	} else if opts.OrgName != "" {
+		// admin only
 		orgName := opts.OrgName
 		if opts.UserName != "" {
 			userName := opts.UserName

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -268,19 +268,32 @@ func (c *Codespace) ExportData(fields []string) map[string]interface{} {
 	return data
 }
 
-// ListCodespaces returns a list of codespaces for the user. Pass a negative limit to request all pages from
+type ListCodespacesOptions struct {
+	OrgName        string
+	UserName       string
+	RepositoryName string
+	Limit          int
+}
+
+// ListCodespaces returns a list of codespaces for the user. Pass a negative limit (default) to request all pages from
 // the API until all codespaces have been fetched.
-func (a *API) ListCodespaces(ctx context.Context, limit int, orgName string, userName string) (codespaces []*Codespace, err error) {
+func (a *API) ListCodespaces(ctx context.Context, opts ListCodespacesOptions) (codespaces []*Codespace, err error) {
 	perPage := 100
-	if limit > 0 && limit < 100 {
+	limit := opts.Limit
+
+	if limit == 0 {
+		limit = -1
+	} else if limit > 0 && limit < 100 {
 		perPage = limit
 	}
 
 	var listURL string
 	var spanName string
 
-	if orgName != "" {
-		if userName != "" {
+	if opts.OrgName != "" {
+		orgName := opts.OrgName
+		if opts.UserName != "" {
+			userName := opts.UserName
 			listURL = fmt.Sprintf("%s/orgs/%s/members/%s/codespaces?per_page=%d", a.githubAPI, orgName, userName, perPage)
 			spanName = "/orgs/*/members/*/codespaces"
 		} else {

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -275,15 +275,16 @@ type ListCodespacesOptions struct {
 	Limit      int
 }
 
-// ListCodespaces returns a list of codespaces for the user. Pass a negative limit (default) to request all pages from
+// ListCodespaces returns a list of codespaces for the user. Pass a negative limit to request all pages from
 // the API until all codespaces have been fetched.
 func (a *API) ListCodespaces(ctx context.Context, opts ListCodespacesOptions) (codespaces []*Codespace, err error) {
-	perPage := 100
-	limit := opts.Limit
 
-	if limit == 0 {
-		limit = -1
-	} else if limit > 0 && limit < 100 {
+	var (
+		perPage = 100
+		limit   = opts.Limit
+	)
+
+	if limit > 0 && limit < 100 {
 		perPage = limit
 	}
 

--- a/internal/codespaces/api/api_test.go
+++ b/internal/codespaces/api/api_test.go
@@ -140,7 +140,7 @@ func TestListCodespaces_limited(t *testing.T) {
 		client:    &http.Client{},
 	}
 	ctx := context.TODO()
-	codespaces, err := api.ListCodespaces(ctx, ListCodespacesOptions{Limit: 200, OrgName: "", UserName: ""})
+	codespaces, err := api.ListCodespaces(ctx, ListCodespacesOptions{Limit: 200})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestListCodespaces_unlimited(t *testing.T) {
 		client:    &http.Client{},
 	}
 	ctx := context.TODO()
-	codespaces, err := api.ListCodespaces(ctx, ListCodespacesOptions{OrgName: "", UserName: ""})
+	codespaces, err := api.ListCodespaces(ctx, ListCodespacesOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/codespaces/api/api_test.go
+++ b/internal/codespaces/api/api_test.go
@@ -140,7 +140,7 @@ func TestListCodespaces_limited(t *testing.T) {
 		client:    &http.Client{},
 	}
 	ctx := context.TODO()
-	codespaces, err := api.ListCodespaces(ctx, 200, "", "")
+	codespaces, err := api.ListCodespaces(ctx, ListCodespacesOptions{Limit: 200, OrgName: "", UserName: ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestListCodespaces_unlimited(t *testing.T) {
 		client:    &http.Client{},
 	}
 	ctx := context.TODO()
-	codespaces, err := api.ListCodespaces(ctx, -1, "", "")
+	codespaces, err := api.ListCodespaces(ctx, ListCodespacesOptions{OrgName: "", UserName: ""})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -108,7 +108,7 @@ type apiClient interface {
 	GetUser(ctx context.Context) (*api.User, error)
 	GetCodespace(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error)
 	GetOrgMemberCodespace(ctx context.Context, orgName string, userName string, codespaceName string) (*api.Codespace, error)
-	ListCodespaces(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error)
+	ListCodespaces(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error)
 	DeleteCodespace(ctx context.Context, name string, orgName string, userName string) error
 	StartCodespace(ctx context.Context, name string) error
 	StopCodespace(ctx context.Context, name string, orgName string, userName string) error
@@ -126,7 +126,7 @@ type apiClient interface {
 var errNoCodespaces = errors.New("you have no codespaces")
 
 func chooseCodespace(ctx context.Context, apiClient apiClient) (*api.Codespace, error) {
-	codespaces, err := apiClient.ListCodespaces(ctx, -1, "", "")
+	codespaces, err := apiClient.ListCodespaces(ctx, api.ListCodespacesOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting codespaces: %w", err)
 	}

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -80,7 +80,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 	nameFilter := opts.codespaceName
 	if nameFilter == "" {
 		a.StartProgressIndicatorWithLabel("Fetching codespaces")
-		codespaces, err = a.apiClient.ListCodespaces(ctx, -1, opts.orgName, opts.userName)
+		codespaces, err = a.apiClient.ListCodespaces(ctx, api.ListCodespacesOptions{OrgName: opts.orgName, UserName: opts.userName})
 		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("error getting codespaces: %w", err)

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -218,7 +218,7 @@ func TestDelete(t *testing.T) {
 				},
 			}
 			if tt.opts.codespaceName == "" {
-				apiMock.ListCodespacesFunc = func(_ context.Context, num int, orgName string, userName string) ([]*api.Codespace, error) {
+				apiMock.ListCodespacesFunc = func(_ context.Context, _ api.ListCodespacesOptions) ([]*api.Codespace, error) {
 					return tt.codespaces, nil
 				}
 			} else {

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -52,26 +52,13 @@ func newListCmd(app *App) *cobra.Command {
 }
 
 func (a *App) List(ctx context.Context, opts *listOptions, exporter cmdutil.Exporter) error {
-	if (opts.orgName != "" || opts.userName != "") && opts.repo != "" {
+	// if repo is provided, we don't accept orgName or userName
+	if opts.repo != "" && (opts.orgName != "" || opts.userName != "") {
 		return cmdutil.FlagErrorf("using `--org` or `--user` with `--repo` is not allowed")
 	}
 
-	var (
-		repository *api.Repository
-		err        error
-	)
-
-	if opts.repo != "" {
-		a.StartProgressIndicatorWithLabel("Fetching repository")
-		repository, err = a.apiClient.GetRepository(ctx, opts.repo)
-		a.StopProgressIndicator()
-		if err != nil {
-			return fmt.Errorf("error getting repository: %w", err)
-		}
-	}
-
 	a.StartProgressIndicatorWithLabel("Fetching codespaces")
-	codespaces, err := a.apiClient.ListCodespaces(ctx, api.ListCodespacesOptions{Limit: opts.limit, Repository: repository, OrgName: opts.orgName, UserName: opts.userName})
+	codespaces, err := a.apiClient.ListCodespaces(ctx, api.ListCodespacesOptions{Limit: opts.limit, RepoName: opts.repo, OrgName: opts.orgName, UserName: opts.userName})
 	a.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting codespaces: %w", err)

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -51,7 +51,7 @@ func newListCmd(app *App) *cobra.Command {
 
 func (a *App) List(ctx context.Context, opts *listOptions, exporter cmdutil.Exporter) error {
 	a.StartProgressIndicatorWithLabel("Fetching codespaces")
-	codespaces, err := a.apiClient.ListCodespaces(ctx, opts.limit, opts.orgName, opts.userName)
+	codespaces, err := a.apiClient.ListCodespaces(ctx, api.ListCodespacesOptions{Limit: opts.limit, OrgName: opts.orgName, UserName: opts.userName})
 	a.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("error getting codespaces: %w", err)

--- a/pkg/cmd/codespace/list_test.go
+++ b/pkg/cmd/codespace/list_test.go
@@ -89,20 +89,12 @@ func TestApp_List(t *testing.T) {
 			name: "list codespaces, --repo",
 			fields: fields{
 				apiClient: &apiClientMock{
-					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
-						if nwo != "cli/cli" {
-							return nil, fmt.Errorf("Expected nwo to be cli/cli. Got %s", nwo)
-						}
-						return &api.Repository{
-							FullName: "cli/cli",
-						}, nil
-					},
 					ListCodespacesFunc: func(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error) {
-						if opts.Repository == nil {
+						if opts.RepoName == "" {
 							return nil, fmt.Errorf("Expected repository to not be nil")
 						}
-						if opts.Repository.FullName != "cli/cli" {
-							return nil, fmt.Errorf("Expected repository name to be cli/cli. Got %s", opts.Repository.FullName)
+						if opts.RepoName != "cli/cli" {
+							return nil, fmt.Errorf("Expected repository name to be cli/cli. Got %s", opts.RepoName)
 						}
 						if opts.OrgName != "" {
 							return nil, fmt.Errorf("Expected orgName to be blank. Got %s", opts.OrgName)

--- a/pkg/cmd/codespace/list_test.go
+++ b/pkg/cmd/codespace/list_test.go
@@ -23,8 +23,8 @@ func TestApp_List(t *testing.T) {
 			name: "list codespaces, no flags",
 			fields: fields{
 				apiClient: &apiClientMock{
-					ListCodespacesFunc: func(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error) {
-						if orgName != "" {
+					ListCodespacesFunc: func(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error) {
+						if opts.OrgName != "" {
 							return nil, fmt.Errorf("should not be called with an orgName")
 						}
 						return []*api.Codespace{
@@ -41,12 +41,12 @@ func TestApp_List(t *testing.T) {
 			name: "list codespaces, --org flag",
 			fields: fields{
 				apiClient: &apiClientMock{
-					ListCodespacesFunc: func(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error) {
-						if orgName != "TestOrg" {
-							return nil, fmt.Errorf("Expected orgName to be TestOrg. Got %s", orgName)
+					ListCodespacesFunc: func(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error) {
+						if opts.OrgName != "TestOrg" {
+							return nil, fmt.Errorf("Expected orgName to be TestOrg. Got %s", opts.OrgName)
 						}
-						if userName != "" {
-							return nil, fmt.Errorf("Expected userName to be blank. Got %s", userName)
+						if opts.UserName != "" {
+							return nil, fmt.Errorf("Expected userName to be blank. Got %s", opts.UserName)
 						}
 						return []*api.Codespace{
 							{
@@ -64,12 +64,12 @@ func TestApp_List(t *testing.T) {
 			name: "list codespaces, --org and --user flag",
 			fields: fields{
 				apiClient: &apiClientMock{
-					ListCodespacesFunc: func(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error) {
-						if orgName != "TestOrg" {
-							return nil, fmt.Errorf("Expected orgName to be TestOrg. Got %s", orgName)
+					ListCodespacesFunc: func(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error) {
+						if opts.OrgName != "TestOrg" {
+							return nil, fmt.Errorf("Expected orgName to be TestOrg. Got %s", opts.OrgName)
 						}
-						if userName != "jimmy" {
-							return nil, fmt.Errorf("Expected userName to be jimmy. Got %s", userName)
+						if opts.UserName != "jimmy" {
+							return nil, fmt.Errorf("Expected userName to be jimmy. Got %s", opts.UserName)
 						}
 						return []*api.Codespace{
 							{

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -52,7 +52,7 @@ import (
 // 			GetUserFunc: func(ctx context.Context) (*api.User, error) {
 // 				panic("mock out the GetUser method")
 // 			},
-// 			ListCodespacesFunc: func(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error) {
+// 			ListCodespacesFunc: func(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error) {
 // 				panic("mock out the ListCodespaces method")
 // 			},
 // 			ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
@@ -108,7 +108,7 @@ type apiClientMock struct {
 	GetUserFunc func(ctx context.Context) (*api.User, error)
 
 	// ListCodespacesFunc mocks the ListCodespaces method.
-	ListCodespacesFunc func(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error)
+	ListCodespacesFunc func(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error)
 
 	// ListDevContainersFunc mocks the ListDevContainers method.
 	ListDevContainersFunc func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error)
@@ -227,12 +227,8 @@ type apiClientMock struct {
 		ListCodespaces []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Limit is the limit argument value.
-			Limit int
-			// OrgName is the orgName argument value.
-			OrgName string
-			// UserName is the userName argument value.
-			UserName string
+			// Opts is the opts argument value.
+			Opts api.ListCodespacesOptions
 		}
 		// ListDevContainers holds details about calls to the ListDevContainers method.
 		ListDevContainers []struct {
@@ -739,41 +735,33 @@ func (mock *apiClientMock) GetUserCalls() []struct {
 }
 
 // ListCodespaces calls ListCodespacesFunc.
-func (mock *apiClientMock) ListCodespaces(ctx context.Context, limit int, orgName string, userName string) ([]*api.Codespace, error) {
+func (mock *apiClientMock) ListCodespaces(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error) {
 	if mock.ListCodespacesFunc == nil {
 		panic("apiClientMock.ListCodespacesFunc: method is nil but apiClient.ListCodespaces was just called")
 	}
 	callInfo := struct {
-		Ctx      context.Context
-		Limit    int
-		OrgName  string
-		UserName string
+		Ctx  context.Context
+		Opts api.ListCodespacesOptions
 	}{
-		Ctx:      ctx,
-		Limit:    limit,
-		OrgName:  orgName,
-		UserName: userName,
+		Ctx:  ctx,
+		Opts: opts,
 	}
 	mock.lockListCodespaces.Lock()
 	mock.calls.ListCodespaces = append(mock.calls.ListCodespaces, callInfo)
 	mock.lockListCodespaces.Unlock()
-	return mock.ListCodespacesFunc(ctx, limit, orgName, userName)
+	return mock.ListCodespacesFunc(ctx, opts)
 }
 
 // ListCodespacesCalls gets all the calls that were made to ListCodespaces.
 // Check the length with:
 //     len(mockedapiClient.ListCodespacesCalls())
 func (mock *apiClientMock) ListCodespacesCalls() []struct {
-	Ctx      context.Context
-	Limit    int
-	OrgName  string
-	UserName string
+	Ctx  context.Context
+	Opts api.ListCodespacesOptions
 } {
 	var calls []struct {
-		Ctx      context.Context
-		Limit    int
-		OrgName  string
-		UserName string
+		Ctx  context.Context
+		Opts api.ListCodespacesOptions
 	}
 	mock.lockListCodespaces.RLock()
 	calls = mock.calls.ListCodespaces

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -235,7 +235,7 @@ func (a *App) printOpenSSHConfig(ctx context.Context, opts sshOptions) (err erro
 	var csList []*api.Codespace
 	if opts.codespace == "" {
 		a.StartProgressIndicatorWithLabel("Fetching codespaces")
-		csList, err = a.apiClient.ListCodespaces(ctx, -1, "", "")
+		csList, err = a.apiClient.ListCodespaces(ctx, api.ListCodespacesOptions{})
 		a.StopProgressIndicator()
 	} else {
 		var codespace *api.Codespace

--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -43,7 +43,7 @@ func (a *App) StopCodespace(ctx context.Context, opts *stopOptions) error {
 
 	if codespaceName == "" {
 		a.StartProgressIndicatorWithLabel("Fetching codespaces")
-		codespaces, err := a.apiClient.ListCodespaces(ctx, -1, opts.orgName, ownerName)
+		codespaces, err := a.apiClient.ListCodespaces(ctx, api.ListCodespacesOptions{OrgName: opts.orgName, UserName: ownerName})
 		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to list codespaces: %w", err)


### PR DESCRIPTION
This PR adds the ability to filter codespaces from the `cs list` command via a `--repo` or `-r` flag

Example:

### Normal List

```console
➜ ./bin/gh cs ls
NAME                                            DISPLAY NAME           REPOSITORY
markphelps-gp776wcpp66        studious space doodle  markphelps/repo-a
markphelps-rxppwvcpp67         super space system     markphelps/repo-b
markphelps-x4vvxqhx6j             super giggle           markphelps/repo-b
markphelps-x4vvxqhvw7v         friendly space robot   markphelps/repo-b
markphelps-4rww6937wqj        jubilant space eureka  markphelps/repo-c
```

### Specifying Repository

```console
➜ ./bin/gh cs ls -r markphelps/repo-c
NAME                                  DISPLAY NAME           REPOSITORY
markphelps-4rww6937wqj  jubilant space eureka  markphelps/repo-c
```

### Invalid Repository

```console
➜ ./bin/gh cs ls -r markphelps/foo
error getting repository: HTTP 404: Not Found (https://api.github.com/repos/markphelps/foo)
```


It also changes the internal `ListCodespaces` method signature from:

`func (a *API) ListCodespaces(ctx context.Context, limit int, orgName string, userName string)`

to:

`func (a *API) ListCodespaces(ctx context.Context, opts ListCodespacesOptions)`

introducing a new options struct:

```go
type ListCodespacesOptions struct {
	OrgName    string
	UserName   string
	Repository *Repository
	Limit      int
}
```