### PR TITLE
Publish to Windows Package Managar (WinGet)

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,12 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest # action can only be run on windows
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: GitHub.cli
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This action automatically generates manifests for WinGet Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

Before merging this:
1. Please add a GitHub token with `public_repo` scope as a repository secret and rename the secret name in the workflow.
2. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under @cli.

If it is not possible to fork winget-pkgs directly under the organization and will be forked under @cliAutomation, the following things need to be done additionally:
- Add `fork-user: cliAutomation` in the workflow after the `token:` line.
- Use Personal Access Token from @cliAutomation's account.

References:
* Ask for automated publishing: https://github.com/cli/cli/issues/1262
* PR which adds GitHub workflow: https://github.com/cli/cli/pull/3801
* Workflow was removed in https://github.com/cli/cli/pull/5699 since it wasn't working.