### PR TITLE
Use `codespaces.auto` instead for the automatic ssh keys

### DIFF
--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -273,14 +273,14 @@ func checkAndUpdateOldKeyPair(sshContext ssh.Context) *ssh.KeyPair {
 
 		// Both old public and private keys exist, rename them to the new name
 
-		privateKeyNew := strings.Replace(privateKey, automaticPrivateKeyNameOld, automaticPrivateKeyName, -1)
-		err = os.Rename(privateKey, privateKeyNew)
+		publicKeyNew := strings.Replace(publicKey, automaticPrivateKeyNameOld, automaticPrivateKeyName, -1)
+		err = os.Rename(publicKey, publicKeyNew)
 		if err != nil {
 			return nil
 		}
 
-		publicKeyNew := strings.Replace(publicKey, automaticPrivateKeyNameOld, automaticPrivateKeyName, -1)
-		err = os.Rename(publicKey, publicKeyNew)
+		privateKeyNew := strings.Replace(privateKey, automaticPrivateKeyNameOld, automaticPrivateKeyName, -1)
+		err = os.Rename(privateKey, privateKeyNew)
 		if err != nil {
 			return nil
 		}

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -261,7 +261,7 @@ func checkAndUpdateOldKeyPair(sshContext ssh.Context) *ssh.KeyPair {
 	}
 
 	for _, publicKey := range publicKeys {
-		if !strings.HasSuffix(publicKey, automaticPrivateKeyNameOld+".pub") {
+		if filepath.Base(publicKey) != automaticPrivateKeyNameOld+".pub" {
 			continue
 		}
 

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -24,6 +24,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const automaticPrivateKeyName = "codespaces.auto"
+
 type sshOptions struct {
 	codespace  string
 	profile    string
@@ -44,6 +46,11 @@ func newSSHCmd(app *App) *cobra.Command {
 		Long: heredoc.Doc(`
 			The 'ssh' command is used to SSH into a codespace. In its simplest form, you can
 			run 'gh cs ssh', select a codespace interactively, and connect.
+			
+			By default, the 'ssh' command will create a public/private ssh key pair to  
+			authenticate with the codespace (if they haven't already been created) inside the 
+			~/.ssh directory. Any private keys for which the public key has been uploaded to 
+			your GitHub profile may also be used instead, if desired.
 
 			The 'ssh' command also supports deeper integration with OpenSSH using a
 			'--config' option that generates per-codespace ssh configuration in OpenSSH
@@ -125,7 +132,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 	startSSHOptions := liveshare.StartSSHServerOptions{}
 
 	if shouldGenerateSSHKeys(args, opts) && sshContext.HasKeygen() {
-		keyPair, err := sshContext.GenerateSSHKey("codespaces", "")
+		keyPair, err := sshContext.GenerateSSHKey(automaticPrivateKeyName, "")
 		if err != nil && !errors.Is(err, ssh.ErrKeyAlreadyExists) {
 			return fmt.Errorf("failed to generate ssh keys: %w", err)
 		}
@@ -381,6 +388,11 @@ func newCpCmd(app *App) *cobra.Command {
 			be evaluated on the remote machine, subject to expansion of tildes, braces, globs,
 			environment variables, and backticks. For security, do not use this flag with arguments
 			provided by untrusted users; see <https://lwn.net/Articles/835962/> for discussion.
+			
+			By default, the 'cp' command will create a public/private ssh key pair to authenticate with 
+			the codespace (if they haven't already been created) inside the ~/.ssh directory. Any private 
+			keys for which the public key has been uploaded to your GitHub profile may also be used
+			instead, if desired.
 		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh codespace cp -e README.md 'remote:/workspaces/$RepositoryName/'

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -251,6 +251,9 @@ func setupAutomaticSSHKeys(sshContext ssh.Context) (*ssh.KeyPair, error) {
 	return keyPair, nil
 }
 
+// checkAndUpdateOldKeyPair handles backward compatibility with the old keypair names.
+// If the old public and private keys both exist they are renamed to the new name.
+// The return value is non-nil only if the rename happens.
 func checkAndUpdateOldKeyPair(sshContext ssh.Context) *ssh.KeyPair {
 	publicKeys, err := sshContext.LocalPublicKeys()
 	if err != nil {

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -273,13 +273,15 @@ func checkAndUpdateOldKeyPair(sshContext ssh.Context) *ssh.KeyPair {
 
 		// Both old public and private keys exist, rename them to the new name
 
-		publicKeyNew := strings.Replace(publicKey, automaticPrivateKeyNameOld, automaticPrivateKeyName, -1)
+		sshDir := filepath.Dir(publicKey)
+
+		publicKeyNew := filepath.Join(sshDir, automaticPrivateKeyName+".pub")
 		err = os.Rename(publicKey, publicKeyNew)
 		if err != nil {
 			return nil
 		}
 
-		privateKeyNew := strings.Replace(privateKey, automaticPrivateKeyNameOld, automaticPrivateKeyName, -1)
+		privateKeyNew := filepath.Join(sshDir, automaticPrivateKeyName)
 		err = os.Rename(privateKey, privateKeyNew)
 		if err != nil {
 			return nil

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -63,6 +63,11 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 			[]string{automaticPrivateKeyNameOld + ".pub"},
 			[]string{automaticPrivateKeyNameOld + ".pub", automaticPrivateKeyName, automaticPrivateKeyName + ".pub"},
 		},
+		// Backward compatibility (edge case): files exist which contains old key name as a substring, the new keys should be created
+		{
+			[]string{"foo" + automaticPrivateKeyNameOld + ".pub", "foo" + automaticPrivateKeyNameOld},
+			[]string{"foo" + automaticPrivateKeyNameOld + ".pub", "foo" + automaticPrivateKeyNameOld, automaticPrivateKeyName, automaticPrivateKeyName + ".pub"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/internal/codespaces/api"
@@ -86,6 +87,12 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 		}
 		if keyPair == nil {
 			t.Error("Unexpected nil KeyPair from setupAutomaticSSHKeys")
+		}
+		if !strings.HasSuffix(keyPair.PrivateKeyPath, automaticPrivateKeyName) {
+			t.Errorf("Expected private key path %v, got %v", automaticPrivateKeyName, keyPair.PrivateKeyPath)
+		}
+		if !strings.HasSuffix(keyPair.PublicKeyPath, automaticPrivateKeyName+".pub") {
+			t.Errorf("Expected public key path %v, got %v", automaticPrivateKeyName+".pub", keyPair.PublicKeyPath)
 		}
 
 		// Check that all the expected files are present

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -71,12 +71,13 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 			ConfigDir: dir,
 		}
 
-		defer os.RemoveAll(dir)
-
 		for _, file := range tt.existingFiles {
-			if _, err := os.Create(filepath.Join(dir, file)); err != nil {
+			f, err := os.Create(filepath.Join(dir, file))
+			if err != nil {
 				t.Errorf("Failed to setup test files: %v", err)
 			}
+			// If the file isn't closed here windows will have errors about file already in use
+			f.Close()
 		}
 
 		keyPair, err := setupAutomaticSSHKeys(sshContext)

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -70,7 +70,7 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to clean test directory: %v", err)
 		}
-		os.MkdirAll(dir, 0711)
+		err = os.MkdirAll(dir, 0711)
 		if err != nil {
 			t.Errorf("Failed to set up test directory: %v", err)
 		}

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -86,7 +86,7 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 			t.Errorf("Unexpected error from setupAutomaticSSHKeys: %v", err)
 		}
 		if keyPair == nil {
-			t.Error("Unexpected nil KeyPair from setupAutomaticSSHKeys")
+			t.Fatal("Unexpected nil KeyPair from setupAutomaticSSHKeys")
 		}
 		if !strings.HasSuffix(keyPair.PrivateKeyPath, automaticPrivateKeyName) {
 			t.Errorf("Expected private key path %v, got %v", automaticPrivateKeyName, keyPair.PrivateKeyPath)

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -26,12 +26,6 @@ func TestPendingOperationDisallowsSSH(t *testing.T) {
 }
 
 func TestAutomaticSSHKeyPairs(t *testing.T) {
-	dir := t.TempDir()
-
-	sshContext := ssh.Context{
-		ConfigDir: dir,
-	}
-
 	tests := []struct {
 		// These files exist when calling setupAutomaticSSHKeys
 		existingFiles []string
@@ -71,14 +65,13 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			t.Errorf("Failed to clean test directory: %v", err)
+		dir := t.TempDir()
+
+		sshContext := ssh.Context{
+			ConfigDir: dir,
 		}
-		err = os.MkdirAll(dir, 0711)
-		if err != nil {
-			t.Errorf("Failed to set up test directory: %v", err)
-		}
+
+		defer os.RemoveAll(dir)
 
 		for _, file := range tt.existingFiles {
 			if _, err := os.Create(filepath.Join(dir, file)); err != nil {


### PR DESCRIPTION
The [new `ssh` feature](https://github.com/cli/cli/pull/5752) to automatically create public/private keys will not create the keys if `~/.ssh/codespaces` (the name of the automatically created key) already exists. 

At the same time, the `--help` message and docs for the same command recommend running commands like `gh cs ssh --config > ~/.ssh/codespaces` to create `ssh` configs files. If someone has already created that file, the automatic keypair generation won't kick in. Which leads to some confusing messages.

This PR does 2 things:
1. Changes the name of the generated key to `codespaces.auto` to avoid the collision
2. Updates docs to explain that it will create the keys in the first place