### PR TITLE
add error message to `pr close` when missing args

### DIFF
--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -36,7 +36,7 @@ func NewCmdClose(f *cmdutil.Factory, runF func(*CloseOptions) error) *cobra.Comm
 	cmd := &cobra.Command{
 		Use:   "close {<number> | <url> | <branch>}",
 		Short: "Close a pull request",
-		Args:  cmdutil.ExactArgs(1, "cannot close: branch, url, or number of the pr required"),
+		Args:  cmdutil.ExactArgs(1, "cannot close pull request: number, url, or branch required"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Finder = shared.NewFinder(f)
 

--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -36,7 +36,7 @@ func NewCmdClose(f *cmdutil.Factory, runF func(*CloseOptions) error) *cobra.Comm
 	cmd := &cobra.Command{
 		Use:   "close {<number> | <url> | <branch>}",
 		Short: "Close a pull request",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.ExactArgs(1, "cannot close: branch, url, or number of the pr required"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Finder = shared.NewFinder(f)
 

--- a/pkg/cmd/pr/close/close_test.go
+++ b/pkg/cmd/pr/close/close_test.go
@@ -99,7 +99,7 @@ func TestNoArgs(t *testing.T) {
 
 	_, err := runCommand(http, true, "")
 
-	assert.ErrorContains(t, err, "cannot close: branch, url, or number of the pr required")
+	assert.EqualError(t, err, "cannot close pull request: number, url, or branch required")
 }
 
 func TestPrClose(t *testing.T) {

--- a/pkg/cmd/pr/close/close_test.go
+++ b/pkg/cmd/pr/close/close_test.go
@@ -93,6 +93,15 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	}, err
 }
 
+func TestNoArgs(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	_, err := runCommand(http, true, "")
+
+	assert.ErrorContains(t, err, "cannot close: branch, url, or number of the pr required")
+}
+
 func TestPrClose(t *testing.T) {
 	http := &httpmock.Registry{}
 	defer http.Verify(t)


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #5789 

Adds a custom error message when no arguments are passed to `gh pr close`. Error message is worded/formatted similar to other commands (`gist`, `issue`, `label`).

![image](https://user-images.githubusercontent.com/35144141/177230142-cfc6a3fc-8510-4000-964a-f0bbd4e57752.png)

