### PR TITLE
chore: typo hunting ft. codespell

### DIFF
--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -167,7 +167,7 @@ func (pi *portInfo) ExportData(fields []string) map[string]interface{} {
 		case "browseUrl":
 			data[f] = pi.BrowseURL()
 		default:
-			panic("unkown field: " + f)
+			panic("unknown field: " + f)
 		}
 	}
 

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -509,7 +509,7 @@ var noExtensionsInstalledError = errors.New("no extensions installed")
 func (m *Manager) Upgrade(name string, force bool) error {
 	// Fetch metadata during list only when upgrading all extensions.
 	// This is a performance improvement so that we don't make a
-	// bunch of unecessary network requests when trying to upgrade a single extension.
+	// bunch of unnecessary network requests when trying to upgrade a single extension.
 	fetchMetadata := name == ""
 	exts, _ := m.list(fetchMetadata)
 	if len(exts) == 0 {

--- a/pkg/cmd/factory/remote_resolver.go
+++ b/pkg/cmd/factory/remote_resolver.go
@@ -73,7 +73,7 @@ func (rr *remoteResolver) Resolver() func() (context.Remotes, error) {
 
 		// Filter again by default host if one is set
 		// For config file default host fallback to cachedRemotes if none match
-		// For enviornment default host (GH_HOST) do not fallback to cachedRemotes if none match
+		// For environment default host (GH_HOST) do not fallback to cachedRemotes if none match
 		if src != "default" {
 			filteredRemotes := cachedRemotes.FilterByHosts([]string{defaultHost})
 			if isHostEnv(src) || len(filteredRemotes) > 0 {

--- a/pkg/cmd/label/clone_test.go
+++ b/pkg/cmd/label/clone_test.go
@@ -139,7 +139,7 @@ func TestCloneRun(t *testing.T) {
 					{
 						"name": "bug",
 						"color": "d73a4a",
-						"description": "Someting isn't working"
+						"description": "Something isn't working"
 					}`),
 				)
 				reg.Register(
@@ -188,7 +188,7 @@ func TestCloneRun(t *testing.T) {
 					{
 						"name": "bug",
 						"color": "d73a4a",
-						"description": "Someting isn't working"
+						"description": "Something isn't working"
 					}`),
 				)
 			},
@@ -259,7 +259,7 @@ func TestCloneRun(t *testing.T) {
 					{
 						"name": "bug",
 						"color": "d73a4a",
-						"description": "Someting isn't working"
+						"description": "Something isn't working"
 					}`),
 				)
 				reg.Register(
@@ -371,7 +371,7 @@ func TestCloneRun(t *testing.T) {
 					httpmock.StatusStringResponse(201, `
 					{
 						"color": "d73a4a",
-						"description": "Someting isn't working"
+						"description": "Something isn't working"
 					}`),
 				)
 				reg.Register(
@@ -536,7 +536,7 @@ func TestCloneRun(t *testing.T) {
 					{
 						"name": "bug",
 						"color": "d73a4a",
-						"description": "Someting isn't working"
+						"description": "Something isn't working"
 					}`),
 				)
 				reg.Register(

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -222,7 +222,7 @@ func createRun(opts *CreateOptions) error {
 		// If there is a local tag with the same name as specified
 		// the user may not want to create a new tag on the remote
 		// as the local one might be annotated or signed.
-		// If the user specifies the target take that as explict instruction
+		// If the user specifies the target take that as explicit instruction
 		// to create the tag on the remote pointing to the target regardless
 		// of local tag status.
 		// If a remote tag with the same name as specified exists already

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -429,7 +429,7 @@ func createFromLocal(opts *CreateOptions) error {
 	}
 	if !isRepo {
 		if repoPath == "." {
-			return fmt.Errorf("current directory is not a git repository. Run `git init` to initalize it")
+			return fmt.Errorf("current directory is not a git repository. Run `git init` to initialize it")
 		}
 		return fmt.Errorf("%s is not a git repository. Run `git -C \"%s\" init` to initialize it", absPath, repoPath)
 	}
@@ -579,7 +579,7 @@ func sourceInit(io *iostreams.IOStreams, remoteURL, baseRemote, repoPath string)
 	return nil
 }
 
-// check if local repository has commited changes
+// check if local repository has committed changes
 func hasCommits(repoPath string) (bool, error) {
 	hasCommitsCmd, err := git.GitCommand("-C", repoPath, "rev-parse", "HEAD")
 	if err != nil {

--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -104,7 +104,7 @@ func runRerun(opts *RerunOptions) error {
 			if run.Status != shared.Completed {
 				return false
 			}
-			// TODO StartupFailure indiciates a bad yaml file; such runs can never be
+			// TODO StartupFailure indicates a bad yaml file; such runs can never be
 			// rerun. But hiding them from the prompt might confuse people?
 			return run.Conclusion != shared.Success && run.Conclusion != shared.StartupFailure
 		})

--- a/pkg/liveshare/client.go
+++ b/pkg/liveshare/client.go
@@ -1,5 +1,5 @@
 // Package liveshare is a Go client library for the Visual Studio Live Share
-// service, which provides collaborative, distibuted editing and debugging.
+// service, which provides collaborative, distributed editing and debugging.
 // See https://docs.microsoft.com/en-us/visualstudio/liveshare for an overview.
 //
 // It provides the ability for a Go program to connect to a Live Share


### PR DESCRIPTION
I like [codespell](https://github.com/codespell-project/codespell) I use it here
not a lot, a couple common typos
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
