### PR TITLE
Fix login flow

### DIFF
--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -15,8 +15,6 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/utils"
-	"github.com/cli/go-gh"
-	ghAPI "github.com/cli/go-gh/pkg/api"
 	"github.com/cli/oauth"
 	"github.com/henvic/httpretty"
 )
@@ -139,9 +137,21 @@ func authFlow(oauthHost string, IO *iostreams.IOStreams, notice string, addition
 	return token.Token, userLogin, nil
 }
 
+type cfg struct {
+	authToken string
+}
+
+func (c cfg) Get(_, _ string) (string, error) {
+	return "", nil
+}
+
+func (c cfg) AuthToken(_ string) (string, string) {
+	return c.authToken, ""
+}
+
 func getViewer(hostname, token string) (string, error) {
-	opts := ghAPI.ClientOptions{Host: hostname, AuthToken: token}
-	client, err := gh.HTTPClient(&opts)
+	opts := api.HTTPClientOptions{Config: cfg{authToken: token}}
+	client, err := api.NewHTTPClient(opts)
 	if err != nil {
 		return "", err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,7 @@ func (c *cfg) GetOrDefault(hostname, key string) (string, error) {
 func (c *cfg) Set(hostname, key, value string) {
 	if hostname == "" {
 		c.cfg.Set([]string{key}, value)
+		return
 	}
 	c.cfg.Set([]string{hosts, hostname, key}, value)
 }


### PR DESCRIPTION
This PR fixes a bug where the authentication token was not properly being passed to the API client in the login flow causing users to not be able to log in.

Also fixes a small bug in `config set` where the value was also being set in the hosts file despite no hostname being supplied.

Closes https://github.com/cli/cli/issues/5927