### PR TITLE
Post go-gh integration cleanup

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -12,15 +12,14 @@ import (
 	ghAPI "github.com/cli/go-gh/pkg/api"
 )
 
-type configGetter interface {
-	Get(string, string) (string, error)
+type tokenGetter interface {
 	AuthToken(string) (string, string)
 }
 
 type HTTPClientOptions struct {
 	AppVersion        string
 	CacheTTL          time.Duration
-	Config            configGetter
+	Config            tokenGetter
 	EnableCache       bool
 	Log               io.Writer
 	SkipAcceptHeaders bool
@@ -75,7 +74,7 @@ func AddCacheTTLHeader(rt http.RoundTripper, ttl time.Duration) http.RoundTrippe
 }
 
 // AddAuthToken adds an authentication token header for the host specified by the request.
-func AddAuthTokenHeader(rt http.RoundTripper, cfg configGetter) http.RoundTripper {
+func AddAuthTokenHeader(rt http.RoundTripper, cfg tokenGetter) http.RoundTripper {
 	return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
 		hostname := ghinstance.NormalizeHostname(getHost(req))
 		if token, _ := cfg.AuthToken(hostname); token != "" {

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestNewHTTPClient(t *testing.T) {
 	type args struct {
-		config     configGetter
+		config     tokenGetter
 		appVersion string
 		setAccept  bool
 	}
@@ -206,10 +206,6 @@ func TestNewHTTPClient(t *testing.T) {
 }
 
 type tinyConfig map[string]string
-
-func (c tinyConfig) Get(host, key string) (string, error) {
-	return c[fmt.Sprintf("%s:%s", host, key)], nil
-}
 
 func (c tinyConfig) AuthToken(host string) (string, string) {
 	return c[fmt.Sprintf("%s:%s", host, "oauth_token")], "oauth_token"

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -98,9 +98,6 @@ func mainRun() exitCode {
 		return exitError
 	}
 
-	host, _ := cfg.DefaultHost()
-	ghrepo.SetDefaultHost(host)
-
 	expandedArgs := []string{}
 	if len(os.Args) > 0 {
 		expandedArgs = os.Args[1:]

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -141,12 +141,8 @@ type cfg struct {
 	authToken string
 }
 
-func (c cfg) Get(_, _ string) (string, error) {
-	return "", nil
-}
-
-func (c cfg) AuthToken(_ string) (string, string) {
-	return c.authToken, ""
+func (c cfg) AuthToken(hostname string) (string, string) {
+	return c.authToken, "oauth_token"
 }
 
 func getViewer(hostname, token string) (string, error) {

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cli/cli/v2/internal/ghinstance"
+	ghAuth "github.com/cli/go-gh/pkg/auth"
 	"github.com/cli/go-gh/pkg/repository"
 )
 
@@ -35,19 +36,9 @@ func FullName(r Interface) string {
 	return fmt.Sprintf("%s/%s", r.RepoOwner(), r.RepoName())
 }
 
-var defaultHostOverride string
-
 func defaultHost() string {
-	if defaultHostOverride != "" {
-		return defaultHostOverride
-	}
-	return ghinstance.Default()
-}
-
-// SetDefaultHost overrides the default GitHub hostname for FromFullName.
-// TODO: remove after FromFullName approach is revisited
-func SetDefaultHost(host string) {
-	defaultHostOverride = host
+	host, _ := ghAuth.DefaultHost()
+	return host
 }
 
 // FromFullName extracts the GitHub repository information from the following

--- a/internal/ghrepo/repo_test.go
+++ b/internal/ghrepo/repo_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"testing"
 )
 
@@ -194,7 +195,9 @@ func TestFromFullName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.hostOverride != "" {
-				SetDefaultHost(tt.hostOverride)
+				old := os.Getenv("GH_HOST")
+				os.Setenv("GH_HOST", tt.hostOverride)
+				defer os.Setenv("GH_HOST", old)
 			}
 			r, err := FromFullName(tt.input)
 			if tt.wantErr != nil {


### PR DESCRIPTION
This is a small refactoring PR now that the `go-gh` integration has been shipped. It does two things:

1. Remove the now unused `Get` function from the `configGetter` interface and rename it to `tokenGetter`.
2. Remove `ghrepo.SetDefaultHost` and refactor implementation of `ghrepo.defaultHost` to use `ghAuth.DefaultHost` instead. Functionally this is equivalent but it removes `defaultHostOverride`, global state, from the `ghrepo` package.

cc https://github.com/cli/cli/issues/5560