### PR TITLE
Remove accidental caching from `repo list` and other commands

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -60,8 +60,9 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 }
 
 func NewCachedHTTPClient(httpClient *http.Client, ttl time.Duration) *http.Client {
-	httpClient.Transport = AddCacheTTLHeader(httpClient.Transport, ttl)
-	return httpClient
+	newClient := *httpClient
+	newClient.Transport = AddCacheTTLHeader(httpClient.Transport, ttl)
+	return &newClient
 }
 
 // AddCacheTTLHeader adds an header to the request telling the cache that the request


### PR DESCRIPTION
Any gh command that has invoked NewCachedHTTPClient has also inadvertently enabled caching for the original `http.Client` due to the nature that NewCachedHTTPClient mutates the original argument passed. As a consequence, running the same command repeatedly would produce the same stale result.

Commands that were accidentally cached:
- `repo list`/`repo edit`
- `pr checkout/close/comment/diff/edit/merge/ready/reopen/review/view`
- `issue create`/`pr create`
- `status`

Fixes https://github.com/cli/cli/issues/5940, fixes https://github.com/cli/cli/issues/5938
Followup to #5614