### PR TITLE
Correctly determine run started/elapsed timestamps

### DIFF
--- a/pkg/cmd/pr/checks/output.go
+++ b/pkg/cmd/pr/checks/output.go
@@ -3,7 +3,6 @@ package checks
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/utils"
@@ -12,9 +11,8 @@ import (
 func addRow(tp utils.TablePrinter, io *iostreams.IOStreams, o check) {
 	cs := io.ColorScheme()
 	elapsed := ""
-	zeroTime := time.Time{}
 
-	if o.StartedAt != zeroTime && o.CompletedAt != zeroTime {
+	if !o.StartedAt.IsZero() && !o.CompletedAt.IsZero() {
 		e := o.CompletedAt.Sub(o.StartedAt)
 		if e > 0 {
 			elapsed = e.String()

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -24,19 +24,21 @@ type ListOptions struct {
 	HttpClient func() (*http.Client, error)
 	BaseRepo   func() (ghrepo.Interface, error)
 
-	PlainOutput bool
-	Exporter    cmdutil.Exporter
+	Exporter cmdutil.Exporter
 
 	Limit            int
 	WorkflowSelector string
 	Branch           string
 	Actor            string
+
+	now time.Time
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
 	opts := &ListOptions{
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
+		now:        time.Now(),
 	}
 
 	cmd := &cobra.Command{
@@ -47,9 +49,6 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo
-
-			terminal := opts.IO.IsStdoutTTY() && opts.IO.IsStdinTTY()
-			opts.PlainOutput = !terminal
 
 			if opts.Limit < 1 {
 				return cmdutil.FlagErrorf("invalid limit: %v", opts.Limit)
@@ -126,7 +125,7 @@ func listRun(opts *ListOptions) error {
 
 	cs := opts.IO.ColorScheme()
 
-	if !opts.PlainOutput {
+	if tp.IsTTY() {
 		tp.AddField("STATUS", nil, nil)
 		tp.AddField("NAME", nil, nil)
 		tp.AddField("WORKFLOW", nil, nil)
@@ -139,12 +138,12 @@ func listRun(opts *ListOptions) error {
 	}
 
 	for _, run := range runs {
-		if opts.PlainOutput {
-			tp.AddField(string(run.Status), nil, nil)
-			tp.AddField(string(run.Conclusion), nil, nil)
-		} else {
+		if tp.IsTTY() {
 			symbol, symbolColor := shared.Symbol(cs, run.Status, run.Conclusion)
 			tp.AddField(symbol, nil, symbolColor)
+		} else {
+			tp.AddField(string(run.Status), nil, nil)
+			tp.AddField(string(run.Conclusion), nil, nil)
 		}
 
 		tp.AddField(run.CommitMsg(), nil, cs.Bold)
@@ -154,7 +153,7 @@ func listRun(opts *ListOptions) error {
 		tp.AddField(string(run.Event), nil, nil)
 		tp.AddField(fmt.Sprintf("%d", run.ID), nil, cs.Cyan)
 
-		tp.AddField(run.Duration().String(), nil, nil)
+		tp.AddField(run.Duration(opts.now).String(), nil, nil)
 		tp.AddField(utils.FuzzyAgoAbbr(time.Now(), run.StartedTime()), nil, nil)
 		tp.EndRow()
 	}

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -154,12 +154,12 @@ func listRun(opts *ListOptions) error {
 		tp.AddField(string(run.Event), nil, nil)
 		tp.AddField(fmt.Sprintf("%d", run.ID), nil, cs.Cyan)
 
-		elapsed := run.UpdatedAt.Sub(run.CreatedAt)
+		elapsed := run.UpdatedAt.Sub(run.StartedAt)
 		if elapsed < 0 {
 			elapsed = 0
 		}
 		tp.AddField(elapsed.String(), nil, nil)
-		tp.AddField(utils.FuzzyAgoAbbr(time.Now(), run.CreatedAt), nil, nil)
+		tp.AddField(utils.FuzzyAgoAbbr(time.Now(), run.StartedAt), nil, nil)
 		tp.EndRow()
 	}
 

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -154,12 +154,8 @@ func listRun(opts *ListOptions) error {
 		tp.AddField(string(run.Event), nil, nil)
 		tp.AddField(fmt.Sprintf("%d", run.ID), nil, cs.Cyan)
 
-		elapsed := run.UpdatedAt.Sub(run.StartedAt)
-		if elapsed < 0 {
-			elapsed = 0
-		}
-		tp.AddField(elapsed.String(), nil, nil)
-		tp.AddField(utils.FuzzyAgoAbbr(time.Now(), run.StartedAt), nil, nil)
+		tp.AddField(run.Duration().String(), nil, nil)
+		tp.AddField(utils.FuzzyAgoAbbr(time.Now(), run.StartedTime()), nil, nil)
 		tp.EndRow()
 	}
 

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -84,10 +84,10 @@ func (r *Run) StartedTime() time.Time {
 	return r.StartedAt
 }
 
-func (r *Run) Duration() time.Duration {
+func (r *Run) Duration(now time.Time) time.Duration {
 	endTime := r.UpdatedAt
 	if r.Status != Completed {
-		endTime = time.Now()
+		endTime = now
 	}
 	d := endTime.Sub(r.StartedTime())
 	if d < 0 {

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -61,11 +61,13 @@ type Run struct {
 	Name           string
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
+	StartedAt      time.Time `json:"run_started_at"`
 	Status         Status
 	Conclusion     Conclusion
 	Event          string
 	ID             int64
 	WorkflowID     int64  `json:"workflow_id"`
+	Attempts       uint8  `json:"run_attempt"`
 	HeadBranch     string `json:"head_branch"`
 	JobsURL        string `json:"jobs_url"`
 	HeadCommit     Commit `json:"head_commit"`
@@ -329,7 +331,7 @@ func PromptForRun(cs *iostreams.ColorScheme, runs []Run) (string, error) {
 		symbol, _ := Symbol(cs, run.Status, run.Conclusion)
 		candidates = append(candidates,
 			// TODO truncate commit message, long ones look terrible
-			fmt.Sprintf("%s %s, %s (%s) %s", symbol, run.CommitMsg(), run.Name, run.HeadBranch, preciseAgo(now, run.CreatedAt)))
+			fmt.Sprintf("%s %s, %s (%s) %s", symbol, run.CommitMsg(), run.Name, run.HeadBranch, preciseAgo(now, run.StartedAt)))
 	}
 
 	// TODO consider custom filter so it's fuzzier. right now matches start anywhere in string but

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -85,11 +85,15 @@ func (r *Run) StartedTime() time.Time {
 }
 
 func (r *Run) Duration() time.Duration {
-	d := r.UpdatedAt.Sub(r.StartedTime())
+	endTime := r.UpdatedAt
+	if r.Status != Completed {
+		endTime = time.Now()
+	}
+	d := endTime.Sub(r.StartedTime())
 	if d < 0 {
 		return 0
 	}
-	return d
+	return d.Round(time.Second)
 }
 
 type Repo struct {

--- a/pkg/cmd/run/shared/shared_test.go
+++ b/pkg/cmd/run/shared/shared_test.go
@@ -56,6 +56,8 @@ func TestGetAnnotations404(t *testing.T) {
 }
 
 func TestRun_Duration(t *testing.T) {
+	now, _ := time.Parse(time.RFC3339, "2022-07-20T11:22:58Z")
+
 	tests := []struct {
 		name  string
 		json  string
@@ -84,13 +86,13 @@ func TestRun_Duration(t *testing.T) {
 		},
 		{
 			name: "in_progress",
-			json: heredoc.Docf(`
+			json: heredoc.Doc(`
 				{
 					"created_at": "2022-07-20T11:20:13Z",
-					"run_started_at": "%s",
+					"run_started_at": "2022-07-20T11:20:55Z",
 					"updated_at": "2022-07-20T11:21:16Z",
 					"status": "in_progress"
-				}`, time.Now().Add(-time.Second*123).Format(time.RFC3339)),
+				}`),
 			wants: "2m3s",
 		},
 	}
@@ -98,7 +100,7 @@ func TestRun_Duration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var r Run
 			assert.NoError(t, json.Unmarshal([]byte(tt.json), &r))
-			assert.Equal(t, tt.wants, r.Duration().String())
+			assert.Equal(t, tt.wants, r.Duration(now).String())
 		})
 	}
 }

--- a/pkg/cmd/run/shared/test.go
+++ b/pkg/cmd/run/shared/test.go
@@ -5,23 +5,14 @@ import (
 	"time"
 )
 
-// Test data for use in the various run and job tests
-func created() time.Time {
-	created, _ := time.Parse("2006-01-02 15:04:05", "2021-02-23 04:51:00")
-	return created
-}
-
-func updated() time.Time {
-	updated, _ := time.Parse("2006-01-02 15:04:05", "2021-02-23 04:55:34")
-	return updated
-}
+var TestRunStartTime, _ = time.Parse("2006-01-02 15:04:05", "2021-02-23 04:51:00")
 
 func TestRun(name string, id int64, s Status, c Conclusion) Run {
 	return Run{
 		Name:       name,
 		ID:         id,
-		CreatedAt:  created(),
-		UpdatedAt:  updated(),
+		CreatedAt:  TestRunStartTime,
+		UpdatedAt:  TestRunStartTime.Add(time.Minute*4 + time.Second*34),
 		Status:     s,
 		Conclusion: c,
 		Event:      "push",
@@ -66,8 +57,8 @@ var SuccessfulJob Job = Job{
 	Status:      Completed,
 	Conclusion:  Success,
 	Name:        "cool job",
-	StartedAt:   created(),
-	CompletedAt: updated(),
+	StartedAt:   TestRunStartTime,
+	CompletedAt: TestRunStartTime.Add(time.Minute*4 + time.Second*34),
 	URL:         "https://github.com/jobs/10",
 	RunID:       3,
 	Steps: []Step{
@@ -91,8 +82,8 @@ var FailedJob Job = Job{
 	Status:      Completed,
 	Conclusion:  Failure,
 	Name:        "sad job",
-	StartedAt:   created(),
-	CompletedAt: updated(),
+	StartedAt:   TestRunStartTime,
+	CompletedAt: TestRunStartTime.Add(time.Minute*4 + time.Second*34),
 	URL:         "https://github.com/jobs/20",
 	RunID:       1234,
 	Steps: []Step{

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -319,7 +319,7 @@ func runView(opts *ViewOptions) error {
 
 	out := opts.IO.Out
 
-	ago := opts.Now().Sub(run.StartedAt)
+	ago := opts.Now().Sub(run.StartedTime())
 
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, shared.RenderRunHeader(cs, *run, utils.FuzzyAgo(ago), prNumber))
@@ -416,7 +416,7 @@ func getLog(httpClient *http.Client, logURL string) (io.ReadCloser, error) {
 }
 
 func getRunLog(cache runLogCache, httpClient *http.Client, repo ghrepo.Interface, run *shared.Run) (*zip.ReadCloser, error) {
-	filename := fmt.Sprintf("run-log-%d-%d.zip", run.ID, run.CreatedAt.Unix())
+	filename := fmt.Sprintf("run-log-%d-%d.zip", run.ID, run.StartedTime().Unix())
 	filepath := filepath.Join(os.TempDir(), "gh-cli-cache", filename)
 	if !cache.Exists(filepath) {
 		// Run log does not exist in cache so retrieve and store it

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -319,7 +319,7 @@ func runView(opts *ViewOptions) error {
 
 	out := opts.IO.Out
 
-	ago := opts.Now().Sub(run.CreatedAt)
+	ago := opts.Now().Sub(run.StartedAt)
 
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, shared.RenderRunHeader(cs, *run, utils.FuzzyAgo(ago), prNumber))

--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -180,7 +180,7 @@ func renderRun(opts WatchOptions, client *api.Client, repo ghrepo.Interface, run
 		return nil, fmt.Errorf("failed to get run: %w", err)
 	}
 
-	ago := opts.Now().Sub(run.CreatedAt)
+	ago := opts.Now().Sub(run.StartedTime())
 
 	jobs, err := shared.GetJobs(client, repo, *run)
 	if err != nil {

--- a/pkg/cmd/run/watch/watch_test.go
+++ b/pkg/cmd/run/watch/watch_test.go
@@ -333,7 +333,10 @@ func TestWatchRun(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, tt.wantOut, stdout.String())
+			// avoiding using `assert.Equal` here because it would print raw escape sequences to stdout
+			if got := stdout.String(); got != tt.wantOut {
+				t.Errorf("got stdout:\n%q\nwant:\n%q", got, tt.wantOut)
+			}
 			reg.Verify(t)
 		})
 	}

--- a/pkg/cmd/workflow/view/view.go
+++ b/pkg/cmd/workflow/view/view.go
@@ -223,11 +223,7 @@ func viewWorkflowInfo(opts *ViewOptions, client *api.Client, repo ghrepo.Interfa
 		tp.AddField(string(run.Event), nil, nil)
 
 		if opts.Raw {
-			elapsed := run.UpdatedAt.Sub(run.CreatedAt)
-			if elapsed < 0 {
-				elapsed = 0
-			}
-			tp.AddField(elapsed.String(), nil, nil)
+			tp.AddField(run.Duration().String(), nil, nil)
 		}
 
 		tp.AddField(fmt.Sprintf("%d", run.ID), nil, cs.Cyan)

--- a/pkg/cmd/workflow/view/view.go
+++ b/pkg/cmd/workflow/view/view.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
@@ -30,6 +31,8 @@ type ViewOptions struct {
 	Prompt   bool
 	Raw      bool
 	YAML     bool
+
+	now time.Time
 }
 
 func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Command {
@@ -37,6 +40,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
 		Browser:    f.Browser,
+		now:        time.Now(),
 	}
 
 	cmd := &cobra.Command{
@@ -223,7 +227,7 @@ func viewWorkflowInfo(opts *ViewOptions, client *api.Client, repo ghrepo.Interfa
 		tp.AddField(string(run.Event), nil, nil)
 
 		if opts.Raw {
-			tp.AddField(run.Duration().String(), nil, nil)
+			tp.AddField(run.Duration(opts.now).String(), nil, nil)
 		}
 
 		tp.AddField(fmt.Sprintf("%d", run.ID), nil, cs.Cyan)


### PR DESCRIPTION
This switches `run list` and `run view` commands to measure how long ago did the run happen by using `run_started_at`, which is the timestamp of the latest run in a series, instead of `created_at`, which is the timestamp of the first run.

Fixes https://github.com/cli/cli/issues/5931
Most likely fixes https://github.com/cli/cli/issues/5629