### PR TITLE
Check for already configured ssh keys before using automatic key

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -1062,7 +1062,7 @@ func (a *API) GetCodespaceRepositoryContents(ctx context.Context, codespace *Cod
 
 // AuthorizedKeys returns the public keys (in ~/.ssh/authorized_keys
 // format) registered by the specified GitHub user.
-func (a *API) AuthorizedKeys(ctx context.Context, user string) ([]byte, error) {
+func (a *API) AuthorizedKeys(ctx context.Context, user string) ([]string, error) {
 	url := fmt.Sprintf("%s/%s.keys", a.githubServer, user)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -1082,7 +1082,19 @@ func (a *API) AuthorizedKeys(ctx context.Context, user string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
-	return b, nil
+
+	allKeys := string(b)
+
+	splitKeys := []string{}
+	for _, key := range strings.Split(allKeys, "\n") {
+		if key == "" {
+			continue
+		}
+
+		splitKeys = append(splitKeys, strings.TrimSpace(key))
+	}
+
+	return splitKeys, nil
 }
 
 // do executes the given request and returns the response. It creates an

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -1087,11 +1087,12 @@ func (a *API) AuthorizedKeys(ctx context.Context, user string) ([]string, error)
 
 	splitKeys := []string{}
 	for _, key := range strings.Split(allKeys, "\n") {
+		key = strings.TrimSpace(key)
 		if key == "" {
 			continue
 		}
 
-		splitKeys = append(splitKeys, strings.TrimSpace(key))
+		splitKeys = append(splitKeys, key)
 	}
 
 	return splitKeys, nil

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -1085,7 +1085,7 @@ func (a *API) AuthorizedKeys(ctx context.Context, user string) ([]string, error)
 
 	allKeys := string(b)
 
-	splitKeys := []string{}
+	var splitKeys []string
 	for _, key := range strings.Split(allKeys, "\n") {
 		key = strings.TrimSpace(key)
 		if key == "" {

--- a/pkg/cmd/codespace/code_test.go
+++ b/pkg/cmd/codespace/code_test.go
@@ -121,8 +121,8 @@ func testCodeApiMock() *apiClientMock {
 		GetUserFunc: func(_ context.Context) (*api.User, error) {
 			return user, nil
 		},
-		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]byte, error) {
-			return []byte{}, nil
+		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]string, error) {
+			return []string{}, nil
 		},
 	}
 }

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -115,7 +115,7 @@ type apiClient interface {
 	CreateCodespace(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error)
 	EditCodespace(ctx context.Context, codespaceName string, params *api.EditCodespaceParams) (*api.Codespace, error)
 	GetRepository(ctx context.Context, nwo string) (*api.Repository, error)
-	AuthorizedKeys(ctx context.Context, user string) ([]byte, error)
+	AuthorizedKeys(ctx context.Context, user string) ([]string, error)
 	GetCodespacesMachines(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error)
 	GetCodespaceRepositoryContents(ctx context.Context, codespace *api.Codespace, path string) ([]byte, error)
 	ListDevContainers(ctx context.Context, repoID int, branch string, limit int) (devcontainers []api.DevContainerEntry, err error)

--- a/pkg/cmd/codespace/logs_test.go
+++ b/pkg/cmd/codespace/logs_test.go
@@ -37,8 +37,8 @@ func testingLogsApp() *App {
 		GetUserFunc: func(_ context.Context) (*api.User, error) {
 			return user, nil
 		},
-		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]byte, error) {
-			return []byte{}, nil
+		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]string, error) {
+			return []string{}, nil
 		},
 	}
 

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -279,7 +279,7 @@ type apiClientMock struct {
 }
 
 // AuthorizedKeys calls AuthorizedKeysFunc.
-func (mock *apiClientMock) AuthorizedKeys(ctx context.Context, user string) ([]byte, error) {
+func (mock *apiClientMock) AuthorizedKeys(ctx context.Context, user string) ([]string, error) {
 	if mock.AuthorizedKeysFunc == nil {
 		panic("apiClientMock.AuthorizedKeysFunc: method is nil but apiClient.AuthorizedKeys was just called")
 	}

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -16,7 +16,7 @@ import (
 //
 // 		// make and configure a mocked apiClient
 // 		mockedapiClient := &apiClientMock{
-// 			AuthorizedKeysFunc: func(ctx context.Context, user string) ([]byte, error) {
+// 			AuthorizedKeysFunc: func(ctx context.Context, user string) ([]string, error) {
 // 				panic("mock out the AuthorizedKeys method")
 // 			},
 // 			CreateCodespaceFunc: func(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error) {
@@ -72,7 +72,7 @@ import (
 // 	}
 type apiClientMock struct {
 	// AuthorizedKeysFunc mocks the AuthorizedKeys method.
-	AuthorizedKeysFunc func(ctx context.Context, user string) ([]byte, error)
+	AuthorizedKeysFunc func(ctx context.Context, user string) ([]string, error)
 
 	// CreateCodespaceFunc mocks the CreateCodespace method.
 	CreateCodespaceFunc func(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error)

--- a/pkg/cmd/codespace/ports_test.go
+++ b/pkg/cmd/codespace/ports_test.go
@@ -259,8 +259,8 @@ func testingPortsApp() *App {
 		GetUserFunc: func(_ context.Context) (*api.User, error) {
 			return user, nil
 		},
-		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]byte, error) {
-			return []byte{}, nil
+		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]string, error) {
+			return []string{}, nil
 		},
 	}
 

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -244,7 +244,7 @@ func shouldUseAutomaticSSHKeys(
 
 	// If there is a public key uploaded which matches a configured
 	// private key, there is no need for automatic key generation
-	return hasUploadedPublicKeyForConfig(ctx, sshContext, apiClient, customConfigPath, opts.profile)
+	return !hasUploadedPublicKeyForConfig(ctx, sshContext, apiClient, customConfigPath, opts.profile)
 }
 
 func setupAutomaticSSHKeys(sshContext ssh.Context) (*ssh.KeyPair, error) {

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -366,7 +366,7 @@ func hasUploadedPublicKeyForConfig(
 	}
 
 	for _, uploadedPublicKey := range uploadedPublicKeys {
-		if ok, _ := publicKeyMap[uploadedPublicKey]; ok {
+		if publicKeyMap[uploadedPublicKey] {
 			return true, nil
 		}
 	}

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -141,11 +141,9 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 			return fmt.Errorf("failed to generate ssh keys: %w", err)
 		}
 
-		if keyPair != nil {
-			startSSHOptions.UserPublicKeyFile = keyPair.PublicKeyPath
-			// For both cp and ssh, flags need to come first in the args (before a command in ssh and files in cp), so prepend this flag
-			args = append([]string{"-i", keyPair.PrivateKeyPath}, args...)
-		}
+		startSSHOptions.UserPublicKeyFile = keyPair.PublicKeyPath
+		// For both cp and ssh, flags need to come first in the args (before a command in ssh and files in cp), so prepend this flag
+		args = append([]string{"-i", keyPair.PrivateKeyPath}, args...)
 	}
 
 	codespace, err := getOrChooseCodespace(ctx, a.apiClient, opts.codespace)

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -261,7 +261,7 @@ func useAutomaticSSHKeys(
 
 	// If there is a public key uploaded which matches a configured
 	// private key, there is no need for automatic key generation
-	hasPublicKey, err := hasUploadedPublicKeyForConfig(ctx, sshContext, apiClient, customConfigPath, opts.profile)
+	hasPublicKey, err := hasUploadedPublicKeyForConfig(ctx, apiClient, customConfigPath, opts.profile)
 
 	return !hasPublicKey, err
 }
@@ -351,7 +351,6 @@ func checkAndUpdateOldKeyPair(sshContext ssh.Context) *ssh.KeyPair {
 // compares them to uploaded public keys to see if there is a match
 func hasUploadedPublicKeyForConfig(
 	ctx context.Context,
-	sshContext ssh.Context,
 	apiClient apiClient,
 	customConfigFile string,
 	customHost string,
@@ -361,7 +360,7 @@ func hasUploadedPublicKeyForConfig(
 		return false, fmt.Errorf("getting local ssh keys: %w", err)
 	}
 
-	configuredPublicKeys := []string{}
+	var configuredPublicKeys []string
 	for _, privateKeyPath := range configuredPrivateKeyPaths {
 		publicKeyPath := privateKeyPath + ".pub"
 
@@ -439,7 +438,7 @@ func getConfiguredPrivateKeys(
 		return nil, fmt.Errorf("could not load ssh configuration: %w", err)
 	}
 
-	privateKeyPaths := []string{}
+	var privateKeyPaths []string
 
 	userHomeDir, _ := os.UserHomeDir()
 

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -536,7 +536,7 @@ func (a *App) printOpenSSHConfig(ctx context.Context, opts sshOptions) (err erro
 	t, err := template.New("ssh_config").Parse(heredoc.Doc(`
 		Host cs.{{.Name}}.{{.EscapedRef}}
 			User {{.SSHUser}}
-			ProxyCommand {{.GHExec}} cs ssh -c {{.Name}} --stdio
+			ProxyCommand {{.GHExec}} cs ssh -c {{.Name}} --stdio -- -i ~/.ssh/{{.AutomaticIdentityFile}}
 			UserKnownHostsFile=/dev/null
 			StrictHostKeyChecking no
 			LogLevel quiet

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -123,7 +123,48 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 			}
 		}
 	}
+}
 
+func TestDontUseAutomaticSSHKeysWithCustomPrivateKey(t *testing.T) {
+	args := []string{"-i", "private-key"}
+	result, err := useAutomaticSSHKeys(context.Background(), ssh.Context{}, nil, args, sshOptions{})
+
+	if err != nil {
+		t.Errorf("Unexpected error from useAutomaticSSHKeys: %v", err)
+	}
+
+	if result != false {
+		t.Errorf("Want useAutomaticSSHKeys to be false, got true")
+	}
+}
+
+func TestUseAutomaticSSHKeysWithAutoKeysExist(t *testing.T) {
+	dir := t.TempDir()
+
+	f, err := os.Create(path.Join(dir, automaticPrivateKeyName))
+	if err != nil {
+		t.Errorf("Failed to create test private key: %v", err)
+	}
+	f.Close()
+
+	f, err = os.Create(path.Join(dir, automaticPrivateKeyName+".pub"))
+	if err != nil {
+		t.Errorf("Failed to create test public key: %v", err)
+	}
+	f.Close()
+
+	sshContext := ssh.Context{
+		ConfigDir: dir,
+	}
+	result, err := useAutomaticSSHKeys(context.Background(), sshContext, nil, nil, sshOptions{})
+
+	if err != nil {
+		t.Errorf("Unexpected error from useAutomaticSSHKeys: %v", err)
+	}
+
+	if result != true {
+		t.Errorf("Want useAutomaticSSHKeys to be true, got false")
+	}
 }
 
 func TestHasUploadedPublicKeyForConfig(t *testing.T) {

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -125,16 +125,33 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 	}
 }
 
-func TestDontUseAutomaticSSHKeysWithCustomPrivateKey(t *testing.T) {
-	args := []string{"-i", "private-key"}
-	result, err := useAutomaticSSHKeys(context.Background(), ssh.Context{}, nil, args, sshOptions{})
-
-	if err != nil {
-		t.Errorf("Unexpected error from useAutomaticSSHKeys: %v", err)
+func TestUseAutomaticSSHKeysIdentityFileArg(t *testing.T) {
+	tests := []struct {
+		identityFileArg string
+		wantResult      bool
+	}{
+		{"custom-private-key", false},
+		{automaticPrivateKeyName, true},
+		{"", false}, // Edge case check for missing arg value
 	}
 
-	if result != false {
-		t.Errorf("Want useAutomaticSSHKeys to be false, got true")
+	for _, tt := range tests {
+		t.Logf("%v", tt.identityFileArg)
+
+		args := []string{"-i"}
+		if tt.identityFileArg != "" {
+			args = append(args, tt.identityFileArg)
+		}
+
+		result, err := useAutomaticSSHKeys(context.Background(), ssh.Context{}, nil, args, sshOptions{})
+
+		if err != nil {
+			t.Errorf("Unexpected error from useAutomaticSSHKeys: %v", err)
+		}
+
+		if result != tt.wantResult {
+			t.Errorf("Want useAutomaticSSHKeys to be %v, got %v", tt.wantResult, result)
+		}
 	}
 }
 

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -253,9 +253,7 @@ func TestHasUploadedPublicKeyForConfig(t *testing.T) {
 			t.Fatalf("could not write test config %v", err)
 		}
 
-		sshContext := ssh.Context{}
-
-		result, err := hasUploadedPublicKeyForConfig(context.Background(), sshContext, mockApi, configPath, "")
+		result, err := hasUploadedPublicKeyForConfig(context.Background(), mockApi, configPath, "")
 		if err != nil {
 			t.Errorf("Unexpected error from hasUploadedPublicKeyForConfig: %v", err)
 		}

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -201,7 +201,10 @@ func TestHasUploadedPublicKeyForConfig(t *testing.T) {
 		for _, pair := range tt.localKeyPairs {
 			configContent += fmt.Sprintf("IdentityFile %s\n", path.Join(dir, pair.privateKeyFile))
 
-			os.WriteFile(path.Join(dir, pair.privateKeyFile+".pub"), []byte(pair.publicKeyContent), 0666)
+			err := os.WriteFile(path.Join(dir, pair.privateKeyFile+".pub"), []byte(pair.publicKeyContent), 0666)
+			if err != nil {
+				t.Fatalf("could not write test public key file %v", err)
+			}
 		}
 
 		err := os.WriteFile(configPath, []byte(configContent), 0666)

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -214,7 +214,10 @@ func TestHasUploadedPublicKeyForConfig(t *testing.T) {
 
 		sshContext := ssh.Context{}
 
-		result := hasUploadedPublicKeyForConfig(context.Background(), sshContext, mockApi, configPath, "")
+		result, err := hasUploadedPublicKeyForConfig(context.Background(), sshContext, mockApi, configPath, "")
+		if err != nil {
+			t.Errorf("Unexpected error from hasUploadedPublicKeyForConfig: %v", err)
+		}
 
 		if result != tt.wantResult {
 			t.Errorf("Want hasUploadedPublicKeyForConfig to be %v, got %v", tt.wantResult, result)

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -137,6 +137,7 @@ func TestHasUploadedPublicKeyForConfig(t *testing.T) {
 		localKeyPairs           []testLocalKeyPair
 		wantResult              bool
 	}{
+		// Failure tests
 		{
 			// No API keys and no local keys
 			wantResult: false,
@@ -158,10 +159,25 @@ func TestHasUploadedPublicKeyForConfig(t *testing.T) {
 			wantResult:              false,
 		},
 
+		// Successful tests
 		{
-			// API keys and local keys and matching
 			apiAuthorizedPublicKeys: []string{"test-key"},
 			localKeyPairs:           []testLocalKeyPair{{"keyfile", "test-key"}},
+			wantResult:              true,
+		},
+		{
+			apiAuthorizedPublicKeys: []string{"test-key-1", "test-key-2"},
+			localKeyPairs:           []testLocalKeyPair{{"keyfile1", "test-key-1"}},
+			wantResult:              true,
+		},
+		{
+			apiAuthorizedPublicKeys: []string{"test-key-1"},
+			localKeyPairs:           []testLocalKeyPair{{"keyfile1", "test-key-1"}, {"keyfile2", "test-key-2"}},
+			wantResult:              true,
+		},
+		{
+			apiAuthorizedPublicKeys: []string{"test-key-1", "test-key-2"},
+			localKeyPairs:           []testLocalKeyPair{{"keyfile3", "test-key-3"}, {"keyfile2", "test-key-2"}},
 			wantResult:              true,
 		},
 	}

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -185,40 +185,47 @@ func TestHasUploadedPublicKeyForConfig(t *testing.T) {
 		},
 		{
 			// Has API keys, but no local keys
-			apiAuthorizedPublicKeys: []string{"test-key"},
+			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key"},
 			wantResult:              false,
 		},
 		{
 			// No API keys, but has local keys
-			localKeyPairs: []testLocalKeyPair{{"keyfile", "test-key"}},
+			localKeyPairs: []testLocalKeyPair{{"keyfile", "ssh-rsa test-key"}},
 			wantResult:    false,
 		},
 		{
 			// API keys and local keys, but not matching
-			apiAuthorizedPublicKeys: []string{"test-api-key"},
-			localKeyPairs:           []testLocalKeyPair{{"keyfile", "test-local-key"}},
+			apiAuthorizedPublicKeys: []string{"ssh-rsa test-api-key"},
+			localKeyPairs:           []testLocalKeyPair{{"keyfile", "ssh-rsa test-local-key"}},
 			wantResult:              false,
 		},
 
 		// Successful tests
 		{
-			apiAuthorizedPublicKeys: []string{"test-key"},
-			localKeyPairs:           []testLocalKeyPair{{"keyfile", "test-key"}},
+			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key"},
+			localKeyPairs:           []testLocalKeyPair{{"keyfile", "ssh-rsa test-key"}},
 			wantResult:              true,
 		},
 		{
-			apiAuthorizedPublicKeys: []string{"test-key-1", "test-key-2"},
-			localKeyPairs:           []testLocalKeyPair{{"keyfile1", "test-key-1"}},
+			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key-1", "ssh-rsa test-key-2"},
+			localKeyPairs:           []testLocalKeyPair{{"keyfile1", "ssh-rsa test-key-1"}},
 			wantResult:              true,
 		},
 		{
-			apiAuthorizedPublicKeys: []string{"test-key-1"},
-			localKeyPairs:           []testLocalKeyPair{{"keyfile1", "test-key-1"}, {"keyfile2", "test-key-2"}},
+			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key-1"},
+			localKeyPairs:           []testLocalKeyPair{{"keyfile1", "ssh-rsa test-key-1"}, {"keyfile2", "ssh-rsa test-key-2"}},
 			wantResult:              true,
 		},
 		{
-			apiAuthorizedPublicKeys: []string{"test-key-1", "test-key-2"},
-			localKeyPairs:           []testLocalKeyPair{{"keyfile3", "test-key-3"}, {"keyfile2", "test-key-2"}},
+			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key-1", "ssh-rsa test-key-2"},
+			localKeyPairs:           []testLocalKeyPair{{"keyfile3", "ssh-rsa test-key-3"}, {"keyfile2", "ssh-rsa test-key-2"}},
+			wantResult:              true,
+		},
+
+		// Extra case - local key contain comments
+		{
+			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key-1", "ssh-rsa test-key"},
+			localKeyPairs:           []testLocalKeyPair{{"keyfile3", "ssh-rsa test-key a comment on the key"}},
 			wantResult:              true,
 		},
 	}

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -141,8 +141,8 @@ func testingSSHApp() *App {
 		GetUserFunc: func(_ context.Context) (*api.User, error) {
 			return user, nil
 		},
-		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]byte, error) {
-			return []byte{}, nil
+		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]string, error) {
+			return []string{}, nil
 		},
 	}
 

--- a/pkg/ssh/ssh_keys.go
+++ b/pkg/ssh/ssh_keys.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/run"
@@ -78,29 +77,6 @@ func (c *Context) GenerateSSHKey(keyName string, passphrase string) (*KeyPair, e
 	}
 
 	return &keyPair, nil
-}
-
-func (c *Context) GetPublicKeyFromPrivateKey(privateKeyPath string) (string, error) {
-	keygenExe, err := c.findKeygen()
-	if err != nil {
-		return "", err
-	}
-
-	keygenCmd := exec.Command(keygenExe, "-y", "-f", privateKeyPath)
-	keygenRunnable := run.PrepareCmd(keygenCmd)
-
-	fullPublicKeyBytes, err := keygenRunnable.Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to generate public key: %w", err)
-	}
-
-	fullPublicKey := string(fullPublicKeyBytes)
-
-	// The public key format is "<type> <key>[ <comment>]" - remove the comment if it exists
-	publicKeyParts := strings.SplitN(fullPublicKey, " ", 3)
-	publicKeyWithoutComment := strings.Join(publicKeyParts[:2], " ")
-
-	return publicKeyWithoutComment, nil
 }
 
 func (c *Context) sshDir() (string, error) {


### PR DESCRIPTION
Fixes: https://github.com/github/codespaces/issues/8154 (again)

An additional follow up to https://github.com/cli/cli/pull/5752 where users had issues with the password-less `codespaces.auto` key being generated for `gh cs ssh`, even though they already had valid ssh keys configured.

This PR will now check the ssh configuration to see which private keys ssh (or scp) will use and check if the user has a matching public key uploaded to GitHub. If so, it will skip creating the automatic key.

The configuration check is done using `ssh -G localhost` which gives the effective configuration for the real `localhost` connection the command will attempt to make later. It parses this configuration for `identityfile` lines and uses these as the target private keys to search for in the public key set.

Additionally, the PR improves the handling of `--profile` and `-- -F` parameters, where before we cautiously bailed out and did not generate keys, we now can use those parameters in the `ssh -G` call to check if we should still generate auto keys with those parameters. This is useful for users of `gh ssh cs --config` to ensure that they still get proper automatic keys. If the `-- -i` flag is provided, the command will continue to not generate automatic keys, this provides an escape hatch from the behavior if needed.

Note: the `-G` flag is added in `OpenSSH 6.8` which [released in 2015](https://www.openssh.com/txt/release-6.8), so hopefully that is long enough ago to rely on 😄 

Verified cases:

- Results in using `codespaces.auto`:
   - [x] No uploaded ssh keys
   - [x] No matching uploaded ssh keys
   - [x] `codespaces.auto` already exists
   - [x] `codespaces.auto` already exists and has a passphrase
   - [x] Using the `--config` flow as documented in `--help`
   - [x] Has a matching custom key, but `codespaces.auto` exists
- Results in a custom key:
   - [x] Using `-- -i <key>` for key with/without passphrase
   - [x] Using `--profile` which specifies a custom key
   - [x] Has a matching uploaded public key with/without a passphrase 
