### PR TITLE
Remove misleading Codespaces ssh/copy password prompt

### DIFF
--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -56,7 +56,11 @@ func NewRemoteCommand(ctx context.Context, tunnelPort int, destination string, s
 // newSSHCommand populates an exec.Cmd to run a command (or if blank,
 // an interactive shell) over ssh.
 func newSSHCommand(ctx context.Context, port int, dst string, cmdArgs []string) (*exec.Cmd, []string, error) {
-	connArgs := []string{"-p", strconv.Itoa(port), "-o", "NoHostAuthenticationForLocalhost=yes"}
+	connArgs := []string{
+		"-p", strconv.Itoa(port),
+		"-o", "NoHostAuthenticationForLocalhost=yes",
+		"-o", "PasswordAuthentication=no",
+	}
 
 	// The ssh command syntax is: ssh [flags] user@host command [args...]
 	// There is no way to specify the user@host destination as a flag.
@@ -101,6 +105,7 @@ func newSCPCommand(ctx context.Context, port int, dst string, cmdArgs []string) 
 	connArgs := []string{
 		"-P", strconv.Itoa(port),
 		"-o", "NoHostAuthenticationForLocalhost=yes",
+		"-o", "PasswordAuthentication=no",
 		"-C", // compression
 	}
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Specifies the `PasswordAuthentication=no` option within `cs ssh` and `cs copy` to prevent misleading password prompts.

<img width="926" alt="codespace@localhost: Permission denied (publickev,password)" src="https://user-images.githubusercontent.com/19893438/179869435-b3a5fcfd-9baf-4a33-b54a-6f6509d50141.png">

#5752 generates SSH keys as needed (thanks @cmbrose!), but users can circumvent that new logic with the `-- -i <identityfile>` flag. This PR fully disables the misleading and impassable password prompt by adding the `-o PasswordAuthentication=no` flag to all `ssh` and `scp` commands.

**Users must use a public key when connecting to codespaces.** It is impossible to satisfy the password prompt that appears when public key authentication fails. Instead of hanging on a password prompt that users cannot satisfy, the `ssh`/`scp` command now fails quickly and mentions "publickey" in its error message.

This PR does not fix any scenarios where we cannot connect via SSH. Instead, it focuses on improving error messaging and prevents red herrings.