### PR TITLE
[Issue:#5975] Added gist privacy type to terminal output

### DIFF
--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -115,6 +115,7 @@ func createRun(opts *CreateOptions) error {
 		return fmt.Errorf("failed to collect files for posting: %w", err)
 	}
 
+	cs := opts.IO.ColorScheme()
 	gistName := guessGistName(files)
 
 	processMessage := "Creating gist..."
@@ -125,10 +126,12 @@ func createRun(opts *CreateOptions) error {
 		} else {
 			processMessage = fmt.Sprintf("Creating gist %s", gistName)
 		}
-		completionMessage = fmt.Sprintf("Created gist %s", gistName)
+		if opts.Public {
+			completionMessage = fmt.Sprintf("Created %s gist %s", cs.Red("public"), gistName)
+		} else {
+			completionMessage = fmt.Sprintf("Created %s gist %s", cs.Green("secret"), gistName)
+		}
 	}
-
-	cs := opts.IO.ColorScheme()
 
 	errOut := opts.IO.ErrOut
 	fmt.Fprintf(errOut, "%s %s\n", cs.Gray("-"), processMessage)

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -187,7 +187,7 @@ func Test_createRun(t *testing.T) {
 				Filenames: []string{fixtureFile},
 			},
 			wantOut:    "https://gist.github.com/aa5a315d61ae9438b18d\n",
-			wantStderr: "- Creating gist fixture.txt\n✓ Created gist fixture.txt\n",
+			wantStderr: "- Creating gist fixture.txt\n✓ Created public gist fixture.txt\n",
 			wantErr:    false,
 			wantParams: map[string]interface{}{
 				"description": "",
@@ -208,7 +208,7 @@ func Test_createRun(t *testing.T) {
 				Filenames:   []string{fixtureFile},
 			},
 			wantOut:    "https://gist.github.com/aa5a315d61ae9438b18d\n",
-			wantStderr: "- Creating gist fixture.txt\n✓ Created gist fixture.txt\n",
+			wantStderr: "- Creating gist fixture.txt\n✓ Created secret gist fixture.txt\n",
 			wantErr:    false,
 			wantParams: map[string]interface{}{
 				"description": "an incredibly interesting gist",
@@ -229,7 +229,7 @@ func Test_createRun(t *testing.T) {
 			},
 			stdin:      "cool stdin content",
 			wantOut:    "https://gist.github.com/aa5a315d61ae9438b18d\n",
-			wantStderr: "- Creating gist with multiple files\n✓ Created gist fixture.txt\n",
+			wantStderr: "- Creating gist with multiple files\n✓ Created secret gist fixture.txt\n",
 			wantErr:    false,
 			wantParams: map[string]interface{}{
 				"description": "",
@@ -295,7 +295,7 @@ func Test_createRun(t *testing.T) {
 				Filenames: []string{fixtureFile},
 			},
 			wantOut:    "Opening gist.github.com/aa5a315d61ae9438b18d in your browser.\n",
-			wantStderr: "- Creating gist fixture.txt\n✓ Created gist fixture.txt\n",
+			wantStderr: "- Creating gist fixture.txt\n✓ Created secret gist fixture.txt\n",
 			wantErr:    false,
 			wantBrowse: "https://gist.github.com/aa5a315d61ae9438b18d",
 			wantParams: map[string]interface{}{


### PR DESCRIPTION
Changed the create.go part to add secret/public according to the flag `opts.Public`. I used the colour red for public and green for secret. Changed the tests accordingly. Please let me know if anything needs changing. Fixes #5975
![image](https://user-images.githubusercontent.com/29306674/180544903-ae480578-1635-4336-9f5f-38c57bb5cc59.png)

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #5975`
-->
