### PR TITLE
Fix parsing base repo out of outdated git remotes

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -422,8 +423,8 @@ func RepoNetwork(client *Client, repos []ghrepo.Interface) (RepoNetworkResult, e
 		%s
 	}
 	`, strings.Join(queries, "")), nil, &graphqlResult)
-	graphqlError, isGraphQLError := err.(*GraphQLError)
-	if isGraphQLError {
+	var graphqlError GraphQLError
+	if errors.As(err, &graphqlError) {
 		// If the only errors are that certain repositories are not found,
 		// continue processing this response instead of returning an error
 		tolerated := true

--- a/pkg/cmd/status/status.go
+++ b/pkg/cmd/status/status.go
@@ -441,7 +441,7 @@ func (s *StatusGetter) LoadSearchResults() error {
 			if len(gqlErrors) == 0 {
 				err = nil
 			} else {
-				err = &api.GraphQLError{
+				err = api.GraphQLError{
 					GQLError: ghAPI.GQLError{
 						Errors: gqlErrors,
 					},


### PR DESCRIPTION
If any of the repositories named by git remotes could not be found via API lookup, a "could not resolve to a Repository" error would be thrown, but the goal of the base repo logic was to ignore NOT_FOUND errors.

Fixes https://github.com/cli/cli/issues/5993