### PR TITLE
surface merge conflicts in pr status

### DIFF
--- a/pkg/cmd/pr/status/fixtures/prStatusChecks.json
+++ b/pkg/cmd/pr/status/fixtures/prStatusChecks.json
@@ -7,7 +7,7 @@
       }
     },
     "viewerCreated": {
-      "totalCount": 3,
+      "totalCount": 4,
       "edges": [
         {
           "node": {
@@ -116,6 +116,33 @@
                           {
                             "status": "COMPLETED",
                             "conclusion": "NEUTRAL"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "node": {
+            "number": 5,
+            "title": "Why can't berries get along?",
+            "state": "OPEN",
+            "url": "https://github.com/cli/cli/pull/5",
+            "headRefName": "strawberries",
+            "mergeable": "CONFLICTING",
+            "statusCheckRollup": {
+              "nodes": [
+                {
+                  "commit": {
+                    "statusCheckRollup": {
+                      "contexts": {
+                        "nodes": [
+                          {
+                            "state": "SUCCESS"
                           }
                         ]
                       }

--- a/pkg/cmd/pr/status/fixtures/prStatusChecks.json
+++ b/pkg/cmd/pr/status/fixtures/prStatusChecks.json
@@ -16,6 +16,7 @@
             "state": "OPEN",
             "url": "https://github.com/cli/cli/pull/8",
             "headRefName": "strawberries",
+            "mergeable": "UNKNOWN",
             "reviewDecision": "CHANGES_REQUESTED",
             "statusCheckRollup": {
               "nodes": [
@@ -98,6 +99,7 @@
             "state": "OPEN",
             "url": "https://github.com/cli/cli/pull/6",
             "headRefName": "avo",
+            "mergeable": "MERGEABLE",
             "reviewDecision": "REVIEW_REQUIRED",
             "statusCheckRollup": {
               "nodes": [

--- a/pkg/cmd/pr/status/http.go
+++ b/pkg/cmd/pr/status/http.go
@@ -187,14 +187,14 @@ func pullRequestStatus(httpClient *http.Client, repo ghrepo.Interface, options r
 	return &payload, nil
 }
 
-func pullRequestFragment(hostname string, showConflicts bool) (string, error) {
+func pullRequestFragment(hostname string, conflictStatus bool) (string, error) {
 	fields := []string{
 		"number", "title", "state", "url", "isDraft", "isCrossRepository",
 		"headRefName", "headRepositoryOwner", "mergeStateStatus",
 		"statusCheckRollup", "requiresStrictStatusChecks",
 	}
 
-	if showConflicts {
+	if conflictStatus {
 		fields = append(fields, "mergeable")
 	}
 	reviewFields := []string{"reviewDecision", "latestReviews"}

--- a/pkg/cmd/pr/status/http.go
+++ b/pkg/cmd/pr/status/http.go
@@ -12,11 +12,11 @@ import (
 )
 
 type requestOptions struct {
-	CurrentPR     int
-	HeadRef       string
-	Username      string
-	Fields        []string
-	ShowConflicts bool
+	CurrentPR      int
+	HeadRef        string
+	Username       string
+	Fields         []string
+	ConflictStatus bool
 }
 
 type pullRequestsPayload struct {
@@ -57,7 +57,7 @@ func pullRequestStatus(httpClient *http.Client, repo ghrepo.Interface, options r
 		fragments = fmt.Sprintf("fragment pr on PullRequest{%s}fragment prWithReviews on PullRequest{...pr}", gr)
 	} else {
 		var err error
-		fragments, err = pullRequestFragment(repo.RepoHost(), options.ShowConflicts)
+		fragments, err = pullRequestFragment(repo.RepoHost(), options.ConflictStatus)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pr/status/http.go
+++ b/pkg/cmd/pr/status/http.go
@@ -12,10 +12,11 @@ import (
 )
 
 type requestOptions struct {
-	CurrentPR int
-	HeadRef   string
-	Username  string
-	Fields    []string
+	CurrentPR     int
+	HeadRef       string
+	Username      string
+	Fields        []string
+	ShowConflicts bool
 }
 
 type pullRequestsPayload struct {
@@ -56,7 +57,7 @@ func pullRequestStatus(httpClient *http.Client, repo ghrepo.Interface, options r
 		fragments = fmt.Sprintf("fragment pr on PullRequest{%s}fragment prWithReviews on PullRequest{...pr}", gr)
 	} else {
 		var err error
-		fragments, err = pullRequestFragment(httpClient, repo.RepoHost())
+		fragments, err = pullRequestFragment(repo.RepoHost(), options.ShowConflicts)
 		if err != nil {
 			return nil, err
 		}
@@ -186,11 +187,15 @@ func pullRequestStatus(httpClient *http.Client, repo ghrepo.Interface, options r
 	return &payload, nil
 }
 
-func pullRequestFragment(httpClient *http.Client, hostname string) (string, error) {
+func pullRequestFragment(hostname string, showConflicts bool) (string, error) {
 	fields := []string{
 		"number", "title", "state", "url", "isDraft", "isCrossRepository",
 		"headRefName", "headRepositoryOwner", "mergeStateStatus",
 		"statusCheckRollup", "requiresStrictStatusChecks",
+	}
+
+	if showConflicts {
+		fields = append(fields, "mergeable")
 	}
 	reviewFields := []string{"reviewDecision", "latestReviews"}
 	fragments := fmt.Sprintf(`

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -275,7 +275,7 @@ func printPrs(io *iostreams.IOStreams, totalCount int, prs ...api.PullRequest) {
 				fmt.Fprintf(w, " %s", cs.Green("✓ No merge conflicts"))
 			} else if pr.Mergeable == "CONFLICTING" {
 				fmt.Fprintf(w, " %s", cs.Red("× Merge conflicts"))
-			} else if pr.Mergeable == "UNKNOWN" {
+			} else {
 				fmt.Fprintf(w, " %s", cs.Yellow("? Merge conflict status unknown"))
 			}
 

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -58,7 +58,7 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.ConflictStatus, "conflict-status", "c", false, "Display the conflict status of each pull request")
+	cmd.Flags().BoolVarP(&opts.ConflictStatus, "conflict-status", "c", false, "Display the merge conflict status of each pull request")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.PullRequestFields)
 
 	return cmd
@@ -275,8 +275,8 @@ func printPrs(io *iostreams.IOStreams, totalCount int, prs ...api.PullRequest) {
 				fmt.Fprintf(w, " %s", cs.Green("✓ No merge conflicts"))
 			} else if pr.Mergeable == "CONFLICTING" {
 				fmt.Fprintf(w, " %s", cs.Red("× Merge conflicts"))
-			} else {
-				fmt.Fprintf(w, " %s", cs.Yellow("? Merge conflict status unknown"))
+			} else if pr.Mergeable == "UNKNOWN" {
+				fmt.Fprintf(w, " %s", cs.Yellow("! Merge conflict status unknown"))
 			}
 
 			if pr.BaseRef.BranchProtectionRule.RequiresStrictStatusChecks {

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -58,7 +58,7 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.ShowConflicts, "show-conflicts", false, "Show merge conflicts on pull requests")
+	cmd.Flags().BoolVarP(&opts.ShowConflicts, "show-conflicts", "c", false, "Show merge conflicts on pull requests")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.PullRequestFields)
 
 	return cmd

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -116,6 +116,7 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 		"✓ Checks passing + Changes requested",
 		"- Checks pending ✓ 2 Approved",
 		"× 1/3 checks failing - Review required",
+		"✓ Checks passing × Merge conflicts",
 	}
 
 	for _, line := range expected {

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -113,7 +113,7 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 	}
 
 	expected := []string{
-		"✓ Checks passing + Changes requested ? Merge conflict status unknown",
+		"✓ Checks passing + Changes requested ! Merge conflict status unknown",
 		"- Checks pending ✓ 2 Approved",
 		"× 1/3 checks failing - Review required ✓ No merge conflicts",
 		"✓ Checks passing × Merge conflicts",

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -113,9 +113,9 @@ func TestPRStatus_reviewsAndChecks(t *testing.T) {
 	}
 
 	expected := []string{
-		"✓ Checks passing + Changes requested",
+		"✓ Checks passing + Changes requested ? Merge conflict status unknown",
 		"- Checks pending ✓ 2 Approved",
-		"× 1/3 checks failing - Review required",
+		"× 1/3 checks failing - Review required ✓ No merge conflicts",
 		"✓ Checks passing × Merge conflicts",
 	}
 


### PR DESCRIPTION
closes https://github.com/cli/cli/issues/872

The field [mergeStateStatus](https://docs.github.com/en/graphql/reference/enums#mergestatestatus) does not indicate if a merge is blocked due to a merge conflict. As an example, here is the response on a PR that has conflicts

```json
{
	"data": {
		"repository": {
			"pullRequest": {
				"id": "PR_XXX",
				"mergeStateStatus": "DIRTY",
				"mergeable": "CONFLICTING"
			}
		}
	}
}
```

It is also in a preview and subject to change. The field `mergeable` indicates if there a conflict with the pull request, and is already part of the `api.PullRequest` struct.

![Screen Shot 2022-09-29 at 8 15 24 AM](https://user-images.githubusercontent.com/1149246/193072754-a7e7835d-9573-4523-af8e-87fa4508b40d.png)


I'm not sure if the color, icon and text are the best to display this information, open to feedback!

### Update:
Following [this comment](https://github.com/cli/cli/pull/5999#issuecomment-1260425346) from @samcoe I've added a flag called `show-conflicts` with the intent that the additional field `mergeable` can be easily rolled into the default fields.

The flag will be effectively ignored if the user also passes `--json`, as that argument list will take precedence over the default fields, which is the current behavior without the flag.