### PR TITLE
Codespaces ssh helptext to indicate how to install ssh

### DIFF
--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -63,6 +63,14 @@ func newSSHCmd(app *App) *cobra.Command {
 
 			Once that is set up (see the second example below), you can ssh to codespaces as
 			if they were ordinary remote hosts (using 'ssh', not 'gh cs ssh').
+
+			Please note that you might need to explicitly install 'sshd' when using a
+			custom container image. You can install it by adding following snippet to the 
+			'devcontainer.json'
+			
+			"features": {
+				"sshd": "latest"
+			}
 		`),
 		Example: heredoc.Doc(`
 			$ gh codespace ssh

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -64,9 +64,9 @@ func newSSHCmd(app *App) *cobra.Command {
 			Once that is set up (see the second example below), you can ssh to codespaces as
 			if they were ordinary remote hosts (using 'ssh', not 'gh cs ssh').
 
-			Please note that you might need to explicitly install 'sshd' when using a
-			custom container image. You can install it by adding following snippet to the 
-			'devcontainer.json'
+			Note that the codespace you are connecting to must have an SSH server pre-installed.
+			If the docker image being used for the codespace does not have an SSH server, you can
+			try adding the following snippet in your devcontainer.json:
 			
 			"features": {
 				"sshd": "latest"


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Requested: https://github.com/cli/cli/issues/5739#issuecomment-1199780829

`gh cs ssh --help`

SSH is no longer auto-installed on connect, on codespace container. Users will need to ensure their container has sshd pre-installed, before they can connect to it.
This PR updates the docs to reflect the same.
