### PR TITLE
Always use same protocol for clone remotes

### DIFF
--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -159,10 +159,6 @@ func cloneRun(opts *CloneOptions) error {
 
 	// If the repo is a fork, add the parent as an upstream
 	if canonicalRepo.Parent != nil {
-		protocol, err := cfg.GetOrDefault(canonicalRepo.Parent.RepoHost(), "git_protocol")
-		if err != nil {
-			return err
-		}
 		upstreamURL := ghrepo.FormatRemoteURL(canonicalRepo.Parent, protocol)
 
 		upstreamName := opts.UpstreamName


### PR DESCRIPTION
This PR makes it so when we add an `upstream` remote during `repo clone` the URL uses the same protocol as the `origin` remote. If the clone URL does not include the protocol to use we only need to checks the users `git_protocol` preference once since a repo parent has to come from the same host as the fork.

In #5984 the user had `ssh` `git_protocol` configured for "github.com" and `https` `git_protocol` as the normal default, so in some odd circumstances when the `canonicalRepo.Parent.RepoHost()` did not return the same host as `repo.RepoHost()` it caused us to write different protocols for the `upstream` and `origin` remotes. 

Fixes https://github.com/cli/cli/issues/5984