### PR TITLE
Update codespaces ssh doc

### DIFF
--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -65,8 +65,9 @@ func newSSHCmd(app *App) *cobra.Command {
 			if they were ordinary remote hosts (using 'ssh', not 'gh cs ssh').
 
 			Note that the codespace you are connecting to must have an SSH server pre-installed.
-			If the docker image being used for the codespace does not have an SSH server, you can
-			try adding the following snippet in your devcontainer.json:
+			If the docker image being used for the codespace does not have an SSH server,
+			install it in your Dockerfile or you can try adding the following snippet
+			in your devcontainer.json:
 			
 			"features": {
 				"sshd": "latest"


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Helps: https://github.com/cli/cli/issues/6025

Update the doc to indicate that the SSH needs to be pre-installed on the codespaces either in the dockerfile or via the `sshd` devcontainer feature (as the feature is only supported on selected distros)