### PR TITLE
Fix writing `gh api -i` response headers to terminal pager

### DIFF
--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -1299,7 +1299,7 @@ func Test_processResponse_template(t *testing.T) {
 		Template: `{{range .}}{{.title}} ({{.labels | pluck "name" | join ", " }}){{"\n"}}{{end}}`,
 	}
 	template := export.NewTemplate(ios, opts.Template)
-	_, err := processResponse(&resp, &opts, io.Discard, &template)
+	_, err := processResponse(&resp, &opts, ios.Out, io.Discard, &template)
 	require.NoError(t, err)
 
 	err = template.End()

--- a/pkg/export/template.go
+++ b/pkg/export/template.go
@@ -76,9 +76,7 @@ func (t *Template) parseTemplate(tpl string) (*template.Template, error) {
 	return template.New("").Funcs(templateFuncs).Parse(tpl)
 }
 
-func (t *Template) Execute(input io.Reader) error {
-	w := t.io.Out
-
+func (t *Template) Execute(w io.Writer, input io.Reader) error {
 	if t.template == nil {
 		template, err := t.parseTemplate(t.templateStr)
 		if err != nil {
@@ -103,7 +101,7 @@ func (t *Template) Execute(input io.Reader) error {
 
 func ExecuteTemplate(io *iostreams.IOStreams, input io.Reader, template string) error {
 	t := NewTemplate(io, template)
-	if err := t.Execute(input); err != nil {
+	if err := t.Execute(io.Out, input); err != nil {
 		return err
 	}
 	return t.End()


### PR DESCRIPTION
This ensures that `gh api` output streams are initialized _after_ the pager has been opened.

Fixes https://github.com/cli/cli/issues/6045