### PR TITLE
Disable automatic SSH keys when ssh command is used with --stdio flag

### DIFF
--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -226,6 +226,11 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 }
 
 func shouldUseAutomaticSSHKeys(args []string, opts sshOptions) bool {
+	if opts.stdio {
+		// The default or config-specified identity file should work.
+		return false
+	}
+
 	if opts.profile != "" {
 		// The profile may specify the identity file so cautiously don't override anything with that option
 		return false


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

In the case of `gh cs ssh --stdio` command, `gh` won't handle ssh args passed together or receive args from `ssh` command. Besides, SSH key is expected to be already set up when generating the config, and the generated key is not used in the generated config as well. So, it just doesn't make sense to generate key here.