### PR TITLE
SSH help text to suggest the new features syntax

### DIFF
--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -66,11 +66,13 @@ func newSSHCmd(app *App) *cobra.Command {
 
 			Note that the codespace you are connecting to must have an SSH server pre-installed.
 			If the docker image being used for the codespace does not have an SSH server,
-			install it in your Dockerfile or you can try adding the following snippet
-			in your devcontainer.json:
-			
+			install it in your Dockerfile or, for codespaces that use Debian-based images,
+			you can add the following to your devcontainer.json:
+						
 			"features": {
-				"sshd": "latest"
+				"ghcr.io/devcontainers/features/sshd:1": {
+					"version": "latest"
+				}
 			}
 		`),
 		Example: heredoc.Doc(`

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -68,7 +68,7 @@ func newSSHCmd(app *App) *cobra.Command {
 			If the docker image being used for the codespace does not have an SSH server,
 			install it in your Dockerfile or, for codespaces that use Debian-based images,
 			you can add the following to your devcontainer.json:
-						
+
 			"features": {
 				"ghcr.io/devcontainers/features/sshd:1": {
 					"version": "latest"


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Related to https://github.com/github/codespaces/issues/9294

Now we have a new syntax for consuming devcontainer feature after open sourcing `devcontainers/features`. This PR update SSH help text with new feature syntax.
The help text now also makes it clear in what distros the sshd feature is supported