### PR TITLE
Allow use of environmental variables in --jq expression

### DIFF
--- a/pkg/export/filter.go
+++ b/pkg/export/filter.go
@@ -4,12 +4,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/itchyny/gojq"
 )
 
 func FilterJSON(w io.Writer, input io.Reader, queryStr string) error {
 	query, err := gojq.Parse(queryStr)
+	if err != nil {
+		return err
+	}
+
+	code, err := gojq.Compile(
+		query,
+		gojq.WithEnvironLoader(func() []string {
+			return os.Environ()
+		}))
+
 	if err != nil {
 		return err
 	}
@@ -25,7 +36,7 @@ func FilterJSON(w io.Writer, input io.Reader, queryStr string) error {
 		return err
 	}
 
-	iter := query.Run(responseData)
+	iter := code.Run(responseData)
 	for {
 		v, ok := iter.Next()
 		if !ok {

--- a/pkg/export/filter_test.go
+++ b/pkg/export/filter_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func Test_filterJSON(t *testing.T) {
+	t.Setenv("CODE", "code_c")
+
 	type args struct {
 		json  io.Reader
 		query string
@@ -68,6 +70,27 @@ func Test_filterJSON(t *testing.T) {
 				Second but not last	
 				Alas, tis' the end	,feature
 			`),
+		},
+		{
+			name: "with env var",
+			args: args{
+				json: strings.NewReader(heredoc.Doc(`[
+					{
+						"title": "code_a",
+						"labels": [{"name":"bug"}, {"name":"help wanted"}]
+					},
+					{
+						"title": "code_b",
+						"labels": []
+					},
+					{
+						"title": "code_c",
+						"labels": [{}, {"name":"feature"}]
+					}
+				]`)),
+				query: `.[]| select(.title == env.CODE) | .labels`,
+			},
+			wantW: "[{},{\"name\":\"feature\"}]\n",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #5403

Passing `os.Environ` to **jq** compiler thus allowing the use of env vars in **jq** expressions.

