### PR TITLE
Document exit codes used by gh

### DIFF
--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -129,6 +129,20 @@ var HelpTopics = map[string]map[string]string{
 			  '
 		`),
 	},
+	"exit-codes": {
+		"short": "Exit codes used by gh",
+		"long": heredoc.Doc(`
+			gh follows normal conventions regarding exit codes.
+
+			- If a command completes successfully, the exit code will be 0
+			
+			- If a command fails for any reason, the exit code will be 1
+
+			NOTE: It is possible that a particular command may have more exit codes, so it is a good 
+			practice to check documentation for the command if you are relying on exit codes to 
+			control some behavior. 
+		`),
+	},
 }
 
 func NewHelpTopic(ios *iostreams.IOStreams, topic string) *cobra.Command {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -138,6 +138,10 @@ var HelpTopics = map[string]map[string]string{
 			
 			- If a command fails for any reason, the exit code will be 1
 
+			- If a command is running but gets cancelled, the exit code will be 2
+
+			- If a command encounters an authentication issue, the exit code will be 4
+
 			NOTE: It is possible that a particular command may have more exit codes, so it is a good 
 			practice to check documentation for the command if you are relying on exit codes to 
 			control some behavior. 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -111,6 +111,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(NewHelpTopic(f.IOStreams, "environment"))
 	cmd.AddCommand(NewHelpTopic(f.IOStreams, "formatting"))
 	cmd.AddCommand(NewHelpTopic(f.IOStreams, "mintty"))
+	cmd.AddCommand(NewHelpTopic(f.IOStreams, "exit-codes"))
 	referenceCmd := NewHelpTopic(f.IOStreams, "reference")
 	referenceCmd.SetHelpFunc(referenceHelpFn(f.IOStreams))
 	cmd.AddCommand(referenceCmd)


### PR DESCRIPTION
Adding documentation for exit codes used by 'gh'. Fixes #6024 

With this change, you can run `gh help exit-codes` and get:

```
gh follows normal conventions regarding exit codes.

- If a command completes successfully, the exit code will be 0

- If a command fails for any reason, the exit code will be 1

- If a command is running but gets cancelled, the exit code will be 2

- If a command encounters an authentication issue, the exit code will be 4

NOTE: It is possible that a particular command may have more exit codes, so it is a good 
practice to check documentation for the command if you are relying on exit codes to 
control some behavior. 
```

Running `gh help` outputs, amongst other things, a glossary that has "exit-codes" added to it: 

```
HELP TOPICS
  actions:     Learn about working with GitHub Actions
  environment: Environment variables that can be used with gh
  exit-codes:  Exit codes used by gh
  formatting:  Formatting options for JSON data exported from gh
  mintty:      Information about using gh with MinTTY
  reference:   A comprehensive reference of all gh commands
```

