### PR TITLE
disable interactive prompting with GH_PROMPT_DISABLED

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,7 +176,7 @@ var configOptions = []ConfigOption{
 	},
 	{
 		Key:           "prompt",
-		Description:   "toggle interactive prompting in the terminal. Overridden if GH_PROMPT_DISABLED is set",
+		Description:   "toggle interactive prompting in the terminal",
 		DefaultValue:  "enabled",
 		AllowedValues: []string{"enabled", "disabled"},
 	},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,7 +176,7 @@ var configOptions = []ConfigOption{
 	},
 	{
 		Key:           "prompt",
-		Description:   "toggle interactive prompting in the terminal",
+		Description:   "toggle interactive prompting in the terminal. Overridden if GH_PROMPT_DISABLED is set",
 		DefaultValue:  "enabled",
 		AllowedValues: []string{"enabled", "disabled"},
 	},

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -183,7 +183,9 @@ func ioStreams(f *cmdutil.Factory) *iostreams.IOStreams {
 		return io
 	}
 
-	if prompt, _ := cfg.GetOrDefault("", "prompt"); prompt == "disabled" {
+	if _, ghPromptDisabled := os.LookupEnv("GH_PROMPT_DISABLED"); ghPromptDisabled {
+		io.SetNeverPrompt(true)
+	} else if prompt, _ := cfg.GetOrDefault("", "prompt"); prompt == "disabled" {
 		io.SetNeverPrompt(true)
 	}
 

--- a/pkg/cmd/factory/default_test.go
+++ b/pkg/cmd/factory/default_test.go
@@ -373,13 +373,7 @@ func Test_ioStreams_prompt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.env != nil {
 				for k, v := range tt.env {
-					old := os.Getenv(k)
-					os.Setenv(k, v)
-					if k == "GH_PROMPT_DISABLED" {
-						defer os.Unsetenv(k)
-					} else {
-						defer os.Setenv(k, old)
-					}
+					t.Setenv(k, v)
 				}
 			}
 			f := New("1")

--- a/pkg/cmd/factory/default_test.go
+++ b/pkg/cmd/factory/default_test.go
@@ -352,6 +352,7 @@ func Test_ioStreams_prompt(t *testing.T) {
 		name           string
 		config         config.Config
 		promptDisabled bool
+		env            map[string]string
 	}{
 		{
 			name:           "default config",
@@ -362,9 +363,25 @@ func Test_ioStreams_prompt(t *testing.T) {
 			config:         disablePromptConfig(),
 			promptDisabled: true,
 		},
+		{
+			name:           "prompt disabled via GH_PROMPT_DISABLED env var",
+			env:            map[string]string{"GH_PROMPT_DISABLED": "1"},
+			promptDisabled: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.env != nil {
+				for k, v := range tt.env {
+					old := os.Getenv(k)
+					os.Setenv(k, v)
+					if k == "GH_PROMPT_DISABLED" {
+						defer os.Unsetenv(k)
+					} else {
+						defer os.Setenv(k, old)
+					}
+				}
+			}
 			f := New("1")
 			f.Config = func() (config.Config, error) {
 				if tt.config == nil {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -82,7 +82,7 @@ var HelpTopics = map[string]map[string]string{
 			GH_CONFIG_DIR: the directory where gh will store configuration files. Default:
 			"$XDG_CONFIG_HOME/gh" or "$HOME/.config/gh".
 
-			GH_PROMPT_DISABLED: disable interactive prompting in the terminal.
+			GH_PROMPT_DISABLED: set to any value to disable interactive prompting in the terminal.
 		`),
 	},
 	"reference": {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -81,6 +81,9 @@ var HelpTopics = map[string]map[string]string{
 
 			GH_CONFIG_DIR: the directory where gh will store configuration files. Default:
 			"$XDG_CONFIG_HOME/gh" or "$HOME/.config/gh".
+
+			GH_PROMPT_DISABLED: disable interactive prompting in the terminal. This is the same as
+			setting the config for "prompt" to "disabled".
 		`),
 	},
 	"reference": {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -82,8 +82,7 @@ var HelpTopics = map[string]map[string]string{
 			GH_CONFIG_DIR: the directory where gh will store configuration files. Default:
 			"$XDG_CONFIG_HOME/gh" or "$HOME/.config/gh".
 
-			GH_PROMPT_DISABLED: disable interactive prompting in the terminal. This is the same as
-			setting the config for "prompt" to "disabled".
+			GH_PROMPT_DISABLED: disable interactive prompting in the terminal.
 		`),
 	},
 	"reference": {


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/6064

Disable interactive prompting and override config value of `prompt` with `GH_PROMPT_DISABLED` env var.

Update documentation for `config` and environment variables.

<img width="682" alt="Screen Shot 2022-08-15 at 5 58 51 PM" src="https://user-images.githubusercontent.com/1149246/184770308-5cc7e55b-2358-4660-905e-6fc31cd46a23.png">

I then ran `bin/gh pr create` without the env var to create this PR ❤️ 