### PR TITLE
Remove brew update instruction

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -271,7 +271,7 @@ func mainRun() exitCode {
 			ansi.Color(strings.TrimPrefix(buildVersion, "v"), "cyan"),
 			ansi.Color(strings.TrimPrefix(newRelease.Version, "v"), "cyan"))
 		if isHomebrew {
-			fmt.Fprintf(stderr, "To upgrade, run: %s\n", "brew update && brew upgrade gh")
+			fmt.Fprintf(stderr, "To upgrade, run: %s\n", "brew upgrade gh")
 		}
 		fmt.Fprintf(stderr, "%s\n\n",
 			ansi.Color(newRelease.URL, "yellow"))


### PR DESCRIPTION
Homebrew seems to auto-update by default now. I tried to dig up exactly when, but seem like it's been a thing since before 2019 or so.

No associated issue, I just noticed it when upgrading today and thought I'd try to help with UX a little.