### PR TITLE
Consolidate GraphQL clients and make GraphQL headers uniform

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -67,6 +67,7 @@ func (c Client) GraphQL(hostname string, query string, variables map[string]inte
 // GraphQLError will be returned, but the data will also be parsed into the receiver.
 func (c Client) Mutate(hostname, name string, mutation interface{}, variables map[string]interface{}) error {
 	opts := clientOptions(hostname, c.http.Transport)
+	opts.Headers[graphqlFeatures] = mergeQueue
 	gqlClient, err := gh.GQLClient(&opts)
 	if err != nil {
 		return err
@@ -78,6 +79,7 @@ func (c Client) Mutate(hostname, name string, mutation interface{}, variables ma
 // GraphQLError will be returned, but the data will also be parsed into the receiver.
 func (c Client) Query(hostname, name string, query interface{}, variables map[string]interface{}) error {
 	opts := clientOptions(hostname, c.http.Transport)
+	opts.Headers[graphqlFeatures] = mergeQueue
 	gqlClient, err := gh.GQLClient(&opts)
 	if err != nil {
 		return err

--- a/api/queries_comments.go
+++ b/api/queries_comments.go
@@ -3,7 +3,6 @@ package api
 import (
 	"time"
 
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -46,7 +45,7 @@ func CommentCreate(client *Client, repoHost string, params CommentCreateInput) (
 	variables := map[string]interface{}{
 		"input": githubv4.AddCommentInput{
 			Body:      githubv4.String(params.Body),
-			SubjectID: graphql.ID(params.SubjectId),
+			SubjectID: githubv4.ID(params.SubjectId),
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/cli/go-gh v0.1.1-0.20220817122932-3630ab390fe7
 	github.com/cli/oauth v0.9.0
 	github.com/cli/safeexec v1.0.0
-	github.com/cli/shurcooL-graphql v0.0.1
 	github.com/cpuguy83/go-md2man/v2 v2.0.2
 	github.com/creack/pty v1.1.18
 	github.com/gabriel-vasile/mimetype v1.4.1
@@ -47,6 +46,7 @@ require (
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cli/browser v1.1.0 // indirect
+	github.com/cli/shurcooL-graphql v0.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/fatih/color v1.7.0 // indirect

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -1,11 +1,10 @@
 package featuredetection
 
 import (
-	"context"
 	"net/http"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghinstance"
-	graphql "github.com/cli/shurcooL-graphql"
 )
 
 type Detector interface {
@@ -90,9 +89,8 @@ func (d *detector) PullRequestFeatures() (PullRequestFeatures, error) {
 		} `graphql:"PullRequest: __type(name: \"PullRequest\")"`
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(d.host), d.httpClient)
-
-	err := gql.QueryNamed(context.Background(), "PullRequest_fields", &featureDetection, nil)
+	gql := api.NewClientFromHTTP(d.httpClient)
+	err := gql.Query(d.host, "PullRequest_fields", &featureDetection, nil)
 	if err != nil {
 		return features, err
 	}
@@ -124,9 +122,9 @@ func (d *detector) RepositoryFeatures() (RepositoryFeatures, error) {
 		} `graphql:"Repository: __type(name: \"Repository\")"`
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(d.host), d.httpClient)
+	gql := api.NewClientFromHTTP(d.httpClient)
 
-	err := gql.QueryNamed(context.Background(), "Repository_fields", &featureDetection, nil)
+	err := gql.Query(d.host, "Repository_fields", &featureDetection, nil)
 	if err != nil {
 		return features, err
 	}

--- a/pkg/cmd/gist/shared/shared.go
+++ b/pkg/cmd/gist/shared/shared.go
@@ -1,7 +1,6 @@
 package shared
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -10,8 +9,6 @@ import (
 	"time"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/shurcooL/githubv4"
 )
@@ -105,13 +102,13 @@ func ListGists(client *http.Client, hostname string, limit int, visibility strin
 		"visibility": githubv4.GistPrivacy(strings.ToUpper(visibility)),
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(hostname), client)
+	gql := api.NewClientFromHTTP(client)
 
 	gists := []Gist{}
 pagination:
 	for {
 		var result response
-		err := gql.QueryNamed(context.Background(), "GistList", &result, variables)
+		err := gql.Query(hostname, "GistList", &result, variables)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -1,19 +1,16 @@
 package close
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
 	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 	"github.com/spf13/cobra"
 )
@@ -122,6 +119,6 @@ func apiClose(httpClient *http.Client, repo ghrepo.Interface, issue *api.Issue) 
 		},
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
-	return gql.MutateNamed(context.Background(), "IssueClose", &mutation, variables)
+	gql := api.NewClientFromHTTP(httpClient)
+	return gql.Mutate(repo.RepoHost(), "IssueClose", &mutation, variables)
 }

--- a/pkg/cmd/issue/delete/delete.go
+++ b/pkg/cmd/issue/delete/delete.go
@@ -1,20 +1,18 @@
 package delete
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/prompt"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 	"github.com/spf13/cobra"
 )
@@ -122,6 +120,6 @@ func apiDelete(httpClient *http.Client, repo ghrepo.Interface, issueID string) e
 		},
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
-	return gql.MutateNamed(context.Background(), "IssueDelete", &mutation, variables)
+	gql := api.NewClientFromHTTP(httpClient)
+	return gql.Mutate(repo.RepoHost(), "IssueDelete", &mutation, variables)
 }

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -1,7 +1,6 @@
 package list
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,7 +10,6 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/config"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	issueShared "github.com/cli/cli/v2/pkg/cmd/issue/shared"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
@@ -19,7 +17,6 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/utils"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 	"github.com/spf13/cobra"
 )
@@ -243,8 +240,8 @@ func milestoneByNumber(client *http.Client, repo ghrepo.Interface, number int32)
 		"number": githubv4.Int(number),
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), client)
-	if err := gql.QueryNamed(context.Background(), "RepositoryMilestoneByNumber", &query, variables); err != nil {
+	gql := api.NewClientFromHTTP(client)
+	if err := gql.Query(repo.RepoHost(), "RepositoryMilestoneByNumber", &query, variables); err != nil {
 		return nil, err
 	}
 	if query.Repository.Milestone == nil {

--- a/pkg/cmd/issue/reopen/reopen.go
+++ b/pkg/cmd/issue/reopen/reopen.go
@@ -1,19 +1,16 @@
 package reopen
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
 	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 	"github.com/spf13/cobra"
 )
@@ -122,6 +119,6 @@ func apiReopen(httpClient *http.Client, repo ghrepo.Interface, issue *api.Issue)
 		},
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
-	return gql.MutateNamed(context.Background(), "IssueReopen", &mutation, variables)
+	gql := api.NewClientFromHTTP(httpClient)
+	return gql.Mutate(repo.RepoHost(), "IssueReopen", &mutation, variables)
 }

--- a/pkg/cmd/issue/transfer/transfer.go
+++ b/pkg/cmd/issue/transfer/transfer.go
@@ -1,18 +1,15 @@
 package transfer
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 	"github.com/spf13/cobra"
 )
@@ -110,7 +107,7 @@ func issueTransfer(httpClient *http.Client, issueID string, destRepo ghrepo.Inte
 		},
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(destRepo.RepoHost()), httpClient)
-	err := gql.MutateNamed(context.Background(), "IssueTransfer", &mutation, variables)
+	gql := api.NewClientFromHTTP(httpClient)
+	err := gql.Mutate(destRepo.RepoHost(), "IssueTransfer", &mutation, variables)
 	return mutation.TransferIssue.Issue.URL, err
 }

--- a/pkg/cmd/issue/view/http.go
+++ b/pkg/cmd/issue/view/http.go
@@ -1,13 +1,10 @@
 package view
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -33,10 +30,10 @@ func preloadIssueComments(client *http.Client, repo ghrepo.Interface, issue *api
 		issue.Comments.Nodes = issue.Comments.Nodes[0:0]
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), client)
+	gql := api.NewClientFromHTTP(client)
 	for {
 		var query response
-		err := gql.QueryNamed(context.Background(), "CommentsForIssue", &query, variables)
+		err := gql.Query(repo.RepoHost(), "CommentsForIssue", &query, variables)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pr/shared/editable_http.go
+++ b/pkg/cmd/pr/shared/editable_http.go
@@ -1,13 +1,10 @@
 package shared
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/sync/errgroup"
 )
@@ -113,8 +110,8 @@ func addLabels(httpClient *http.Client, id string, repo ghrepo.Interface, labels
 	}
 
 	variables := map[string]interface{}{"input": params}
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
-	return gql.MutateNamed(context.Background(), "LabelAdd", &mutation, variables)
+	gql := api.NewClientFromHTTP(httpClient)
+	return gql.Mutate(repo.RepoHost(), "LabelAdd", &mutation, variables)
 }
 
 func removeLabels(httpClient *http.Client, id string, repo ghrepo.Interface, labels []string) error {
@@ -130,8 +127,8 @@ func removeLabels(httpClient *http.Client, id string, repo ghrepo.Interface, lab
 	}
 
 	variables := map[string]interface{}{"input": params}
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
-	return gql.MutateNamed(context.Background(), "LabelRemove", &mutation, variables)
+	gql := api.NewClientFromHTTP(httpClient)
+	return gql.Mutate(repo.RepoHost(), "LabelRemove", &mutation, variables)
 }
 
 func updateIssue(httpClient *http.Client, repo ghrepo.Interface, params githubv4.UpdateIssueInput) error {
@@ -141,8 +138,8 @@ func updateIssue(httpClient *http.Client, repo ghrepo.Interface, params githubv4
 		} `graphql:"updateIssue(input: $input)"`
 	}
 	variables := map[string]interface{}{"input": params}
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
-	return gql.MutateNamed(context.Background(), "IssueUpdate", &mutation, variables)
+	gql := api.NewClientFromHTTP(httpClient)
+	return gql.Mutate(repo.RepoHost(), "IssueUpdate", &mutation, variables)
 }
 
 func updatePullRequest(httpClient *http.Client, repo ghrepo.Interface, params githubv4.UpdatePullRequestInput) error {
@@ -152,8 +149,8 @@ func updatePullRequest(httpClient *http.Client, repo ghrepo.Interface, params gi
 		} `graphql:"updatePullRequest(input: $input)"`
 	}
 	variables := map[string]interface{}{"input": params}
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
-	err := gql.MutateNamed(context.Background(), "PullRequestUpdate", &mutation, variables)
+	gql := api.NewClientFromHTTP(httpClient)
+	err := gql.Mutate(repo.RepoHost(), "PullRequestUpdate", &mutation, variables)
 	return err
 }
 

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -16,11 +16,9 @@ import (
 	remotes "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/set"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/sync/errgroup"
 )
@@ -365,11 +363,11 @@ func preloadPrReviews(httpClient *http.Client, repo ghrepo.Interface, pr *api.Pu
 		"endCursor": githubv4.String(pr.Reviews.PageInfo.EndCursor),
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
+	gql := api.NewClientFromHTTP(httpClient)
 
 	for {
 		var query response
-		err := gql.QueryNamed(context.Background(), "ReviewsForPullRequest", &query, variables)
+		err := gql.Query(repo.RepoHost(), "ReviewsForPullRequest", &query, variables)
 		if err != nil {
 			return err
 		}
@@ -405,11 +403,11 @@ func preloadPrComments(client *http.Client, repo ghrepo.Interface, pr *api.PullR
 		"endCursor": githubv4.String(pr.Comments.PageInfo.EndCursor),
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), client)
+	gql := api.NewClientFromHTTP(client)
 
 	for {
 		var query response
-		err := gql.QueryNamed(context.Background(), "CommentsForPullRequest", &query, variables)
+		err := gql.Query(repo.RepoHost(), "CommentsForPullRequest", &query, variables)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pr/shared/templates.go
+++ b/pkg/cmd/pr/shared/templates.go
@@ -1,7 +1,6 @@
 package shared
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -10,22 +9,18 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/git"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/githubtemplate"
 	"github.com/cli/cli/v2/pkg/prompt"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 )
 
 type issueTemplate struct {
-	// I would have un-exported these fields, except `cli/shurcool-graphql` then cannot unmarshal them :/
 	Gname string `graphql:"name"`
 	Gbody string `graphql:"body"`
 }
 
 type pullRequestTemplate struct {
-	// I would have un-exported these fields, except `cli/shurcool-graphql` then cannot unmarshal them :/
 	Gname string `graphql:"filename"`
 	Gbody string `graphql:"body"`
 }
@@ -66,9 +61,9 @@ func listIssueTemplates(httpClient *http.Client, repo ghrepo.Interface) ([]Templ
 		"name":  githubv4.String(repo.RepoName()),
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
+	gql := api.NewClientFromHTTP(httpClient)
 
-	err := gql.QueryNamed(context.Background(), "IssueTemplates", &query, variables)
+	err := gql.Query(repo.RepoHost(), "IssueTemplates", &query, variables)
 	if err != nil {
 		return nil, err
 	}
@@ -94,9 +89,9 @@ func listPullRequestTemplates(httpClient *http.Client, repo ghrepo.Interface) ([
 		"name":  githubv4.String(repo.RepoName()),
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
+	gql := api.NewClientFromHTTP(httpClient)
 
-	err := gql.QueryNamed(context.Background(), "PullRequestTemplates", &query, variables)
+	err := gql.Query(repo.RepoHost(), "PullRequestTemplates", &query, variables)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/release/create/http.go
+++ b/pkg/cmd/release/create/http.go
@@ -2,7 +2,6 @@ package create
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,7 +12,7 @@ import (
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/release/shared"
-	graphql "github.com/cli/shurcooL-graphql"
+	"github.com/shurcooL/githubv4"
 )
 
 type tag struct {
@@ -28,7 +27,7 @@ type releaseNotes struct {
 var notImplementedError = errors.New("not implemented")
 
 func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tagName string) (bool, error) {
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
+	gql := api.NewClientFromHTTP(httpClient)
 	qualifiedTagName := fmt.Sprintf("refs/tags/%s", tagName)
 	var query struct {
 		Repository struct {
@@ -38,11 +37,11 @@ func remoteTagExists(httpClient *http.Client, repo ghrepo.Interface, tagName str
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 	variables := map[string]interface{}{
-		"owner":   graphql.String(repo.RepoOwner()),
-		"name":    graphql.String(repo.RepoName()),
-		"tagName": graphql.String(qualifiedTagName),
+		"owner":   githubv4.String(repo.RepoOwner()),
+		"name":    githubv4.String(repo.RepoName()),
+		"tagName": githubv4.String(qualifiedTagName),
 	}
-	err := gql.QueryNamed(context.Background(), "RepositoryFindRef", &query, variables)
+	err := gql.Query(repo.RepoHost(), "RepositoryFindRef", &query, variables)
 	return query.Repository.Ref.ID != "", err
 }
 

--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -1,13 +1,11 @@
 package list
 
 import (
-	"context"
 	"net/http"
 	"time"
 
-	"github.com/cli/cli/v2/internal/ghinstance"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -46,13 +44,13 @@ func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, ex
 		"endCursor": (*githubv4.String)(nil),
 	}
 
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(repo.RepoHost()), httpClient)
+	gql := api.NewClientFromHTTP(httpClient)
 
 	var releases []Release
 loop:
 	for {
 		var query responseData
-		err := gql.QueryNamed(context.Background(), "RepositoryReleaseList", &query, variables)
+		err := gql.Query(repo.RepoHost(), "RepositoryReleaseList", &query, variables)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/repo/archive/http.go
+++ b/pkg/cmd/repo/archive/http.go
@@ -1,12 +1,9 @@
 package archive
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
-	graphql "github.com/cli/shurcooL-graphql"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -25,8 +22,7 @@ func archiveRepo(client *http.Client, repo *api.Repository) error {
 		},
 	}
 
-	host := repo.RepoHost()
-	gql := graphql.NewClient(ghinstance.GraphQLEndpoint(host), client)
-	err := gql.MutateNamed(context.Background(), "ArchiveRepository", &mutation, variables)
+	gql := api.NewClientFromHTTP(client)
+	err := gql.Mutate(repo.RepoHost(), "ArchiveRepository", &mutation, variables)
 	return err
 }


### PR DESCRIPTION
This PR fixes #6097 where we thought the `pr merge` codepath was sending the MergeQueue GraphQL feature header but it was not because it was using its own instance of `shurcooL-graphql` client rather than the standardized GraphQL client. I removed all instances of `shurcooL-graphql` so now all codepaths should be using the same GraphQL client from the API package. Additionally, I made updated the GraphQL client `Mutate` and `Query` functions to sending the MergeQueue features header.

Fixes https://github.com/cli/cli/issues/6097