### PR TITLE
Add newline to body when viewing machine readable release

### DIFF
--- a/pkg/cmd/release/view/view.go
+++ b/pkg/cmd/release/view/view.go
@@ -182,6 +182,9 @@ func renderReleasePlain(w io.Writer, release *shared.Release) error {
 	}
 	fmt.Fprint(w, "--\n")
 	fmt.Fprint(w, release.Body)
+	if !strings.HasSuffix(release.Body, "\n") {
+		fmt.Fprintf(w, "\n")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Problem statement: 

If a release does not have a newline at the end of its body, that will affect the way the `gh` command prints its output in a machine-readable format and results in the next command's output being printed on the same line. This is undesirable even if the body has no trailing newline.

For example, given the following commands: 

```sh
gh release view
echo "Hello world"
```

...the output will be:

```
title:	test-release
tag:	test-release
draft:	false
prerelease:	false
author:	wheelerlaw
created:	2022-08-19T00:46:52Z
published:	2022-08-19T15:38:46Z
url:	https://github.com/wheelerlaw/example/releases/tag/test-release
--
testHello world!
```

...when it should be:

```
title:	test-release
tag:	test-release
draft:	false
prerelease:	false
author:	wheelerlaw
created:	2022-08-19T00:46:52Z
published:	2022-08-19T15:38:46Z
url:	https://github.com/wheelerlaw/example/releases/tag/test-release
--
test
Hello world!
```

No only is this behavior undesirable, it is inconsistent with the way the release is printed when viewed in the human readable format. For example, given the exact same commands (but run in a TTY), the output will print 2 new lines below the release body regardless if it has a trailing newline: 

```
test-release
wheelerlaw released this about 2 hours ago

  test                                                                        


View on GitHub: https://github.com/wheelerlaw/example/releases/tag/test-release
```

## Proposed change:

This fix prints a newline at the end of the release regardless if the release body has a newline or not, by checking to see if a newline is present at the end of the body and if not, printing one. 
