### PR TITLE
Get config for default host when -h is not given

### DIFF
--- a/pkg/cmd/config/get/get.go
+++ b/pkg/cmd/config/get/get.go
@@ -53,7 +53,14 @@ func NewCmdConfigGet(f *cmdutil.Factory, runF func(*GetOptions) error) *cobra.Co
 }
 
 func getRun(opts *GetOptions) error {
-	val, err := opts.Config.GetOrDefault(opts.Hostname, opts.Key)
+	var host string
+	if opts.Hostname != "" {
+		host = opts.Hostname
+	} else {
+		host, _ = opts.Config.DefaultHost()
+	}
+
+	val, err := opts.Config.GetOrDefault(host, opts.Key)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/config/get/get_test.go
+++ b/pkg/cmd/config/get/get_test.go
@@ -108,6 +108,20 @@ func Test_getRun(t *testing.T) {
 			},
 			stdout: "vim\n",
 		},
+		{
+			name: "get key scoped by default host",
+			input: &GetOptions{
+				Hostname: "",
+				Key:      "git_protocol",
+				Config: func() config.Config {
+					cfg := config.NewBlankConfig()
+					cfg.Set("", "git_protocol", "https")
+					cfg.Set("github.com", "git_protocol", "ssh")
+					return cfg
+				}(),
+			},
+			stdout: "ssh\n",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

# What

This aligns `config get`'s behaviour with `config list` [1].

[1] https://github.com/cli/cli/blob/1f488f4d5496e176300614b7bd9ded02c8572ec3/pkg/cmd/config/list/list.go#L50-L55

# Why

I have the following configs currently:

`~/.config/gh/config.yml`:

```yaml
git_protocol: https
```

`~/.config/gh/hosts.yml`:

```yaml
github.com:
    git_protocol: ssh
```

Now in a github.com repo,

```
$ gh config list
git_protocol=ssh
editor=
prompt=enabled
pager=
http_unix_socket=
browser=

$ gh config get git_protocol
https
```

I think the output should be consistent.

Fixes #6123