### PR TITLE
Mention possible need for sudo -E to run make install

### DIFF
--- a/docs/source.md
+++ b/docs/source.md
@@ -19,7 +19,7 @@
 
    #### Unix-like systems
    ```sh
-   # installs to '/usr/local' by default; sudo may be required
+   # installs to '/usr/local' by default; sudo may be required, or sudo -E for configured go environments
    $ make install
 
    # or, install to a different location


### PR DESCRIPTION
The documentation mentions that `make install` may require `sudo` to run. However, `sudo make install` will run Go commands with root's Go environment (e.g. /root/.config/go/env), which may not match the user's Go environment used to run `make` (e.g. ~/.config/go/env). This is a problem if the user's Go environment contains options such as `GOPROXY=direct` whose absence will cause build/install to fail. `sudo -E make install` will work around this issue in those sorts of situations, and I propose this warrants a bit more elaboration in the documentation comments.