### PR TITLE
Fix auth refresh prompter initialization

### DIFF
--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -9,6 +9,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/authflow"
 	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -20,6 +21,7 @@ type RefreshOptions struct {
 	IO         *iostreams.IOStreams
 	Config     func() (config.Config, error)
 	httpClient *http.Client
+	Prompter   prompter.Prompter
 
 	MainExecutable string
 
@@ -39,6 +41,7 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 			return err
 		},
 		httpClient: &http.Client{},
+		Prompter:   f.Prompter,
 	}
 
 	cmd := &cobra.Command{
@@ -138,6 +141,7 @@ func refreshRun(opts *RefreshOptions) error {
 
 	credentialFlow := &shared.GitCredentialFlow{
 		Executable: opts.MainExecutable,
+		Prompter:   opts.Prompter,
 	}
 	gitProtocol, _ := cfg.GetOrDefault(hostname, "git_protocol")
 	if opts.Interactive && gitProtocol == "https" {

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -193,7 +193,7 @@ func listRun(opts *ListOptions) error {
 		fmt.Fprintf(opts.IO.Out, "\n%s\n\n", title)
 	}
 
-	issueShared.PrintIssues(opts.IO, "", len(listResult.Issues), listResult.Issues)
+	issueShared.PrintIssues(opts.IO, opts.Now(), "", len(listResult.Issues), listResult.Issues)
 
 	return nil
 }

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -41,7 +41,7 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 	}
 
 	fakeNow := func() time.Time {
-		return time.Date(2022, time.August, 24, 23, 50, 0, 0, time.UTC)
+		return time.Date(2022, time.August, 25, 23, 50, 0, 0, time.UTC)
 	}
 
 	cmd := NewCmdList(factory, func(opts *ListOptions) error {
@@ -104,7 +104,7 @@ func TestIssueList_tty(t *testing.T) {
 
 		Showing 3 of 3 open issues in OWNER/REPO
 
-		#1  number won   label  less than a minute ago
+		#1  number won   label  about 1 day ago
 		#2  number too   label  about 1 month ago
 		#4  number fore  label  about 2 years ago
 	`), output.String())

--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cli/cli/v2/utils"
 )
 
-func PrintIssues(io *iostreams.IOStreams, prefix string, totalCount int, issues []api.Issue) {
+func PrintIssues(io *iostreams.IOStreams, now time.Time, prefix string, totalCount int, issues []api.Issue) {
 	cs := io.ColorScheme()
 	table := utils.NewTablePrinter(io)
 	for _, issue := range issues {
@@ -22,7 +22,6 @@ func PrintIssues(io *iostreams.IOStreams, prefix string, totalCount int, issues 
 			issueNum = "#" + issueNum
 		}
 		issueNum = prefix + issueNum
-		now := time.Now()
 		ago := now.Sub(issue.UpdatedAt)
 		table.AddField(issueNum, nil, cs.ColorFromString(prShared.ColorForIssueState(issue)))
 		if !table.IsTTY() {

--- a/pkg/cmd/issue/status/status.go
+++ b/pkg/cmd/issue/status/status.go
@@ -3,6 +3,7 @@ package status
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
@@ -111,7 +112,7 @@ func statusRun(opts *StatusOptions) error {
 
 	prShared.PrintHeader(opts.IO, "Issues assigned to you")
 	if issuePayload.Assigned.TotalCount > 0 {
-		issueShared.PrintIssues(opts.IO, "  ", issuePayload.Assigned.TotalCount, issuePayload.Assigned.Issues)
+		issueShared.PrintIssues(opts.IO, time.Now(), "  ", issuePayload.Assigned.TotalCount, issuePayload.Assigned.Issues)
 	} else {
 		message := "  There are no issues assigned to you"
 		prShared.PrintMessage(opts.IO, message)
@@ -120,7 +121,7 @@ func statusRun(opts *StatusOptions) error {
 
 	prShared.PrintHeader(opts.IO, "Issues mentioning you")
 	if issuePayload.Mentioned.TotalCount > 0 {
-		issueShared.PrintIssues(opts.IO, "  ", issuePayload.Mentioned.TotalCount, issuePayload.Mentioned.Issues)
+		issueShared.PrintIssues(opts.IO, time.Now(), "  ", issuePayload.Mentioned.TotalCount, issuePayload.Mentioned.Issues)
 	} else {
 		prShared.PrintMessage(opts.IO, "  There are no issues mentioning you")
 	}
@@ -128,7 +129,7 @@ func statusRun(opts *StatusOptions) error {
 
 	prShared.PrintHeader(opts.IO, "Issues opened by you")
 	if issuePayload.Authored.TotalCount > 0 {
-		issueShared.PrintIssues(opts.IO, "  ", issuePayload.Authored.TotalCount, issuePayload.Authored.Issues)
+		issueShared.PrintIssues(opts.IO, time.Now(), "  ", issuePayload.Authored.TotalCount, issuePayload.Authored.Issues)
 	} else {
 		prShared.PrintMessage(opts.IO, "  There are no issues opened by you")
 	}


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/6139
Fixes https://github.com/cli/cli/pull/6135 bug here where `time.Now()` was not being properly propagated which caused the tests to fail