### PR TITLE
Improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GitHub CLI is available for repositories hosted on GitHub.com and GitHub Enterpr
 
 ## Documentation
 
-[See the manual][manual] for setup and usage instructions.
+[See the manual][manual] for usage instructions. Scroll down for [installation](## Installation).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GitHub CLI is available for repositories hosted on GitHub.com and GitHub Enterpr
 
 ## Documentation
 
-[See the manual][manual] for usage instructions. Scroll down for [installation](## Installation).
+[See the manual][manual] for usage instructions. Scroll down for [installation](#Installation).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GitHub CLI is available for repositories hosted on GitHub.com and GitHub Enterpr
 
 ## Documentation
 
-[See the manual][manual] for usage instructions. Scroll down for [installation](#Installation).
+For [installation options see below](#installation), for usage instructions [see the manual][manual].
 
 ## Contributing
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
I visited Google to find the cli install instructions, and ended up following these steps:

1. Link ends up on this repository (github.com/cli/cli)
2. Scroll down to usage and installation instructions
3. Click link to "see the manual" which visits https://cli.github.com/manual/
4. Click on the link to see installation instructions, which ends up back at the readme here.

This little change makes it clearer the installation instructions are below. Wording improvement welcome!