### PR TITLE
Suggest repos if `repo clone` fails due to typo

### DIFF
--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -343,36 +343,53 @@ func Test_RepoClone_RepoTypo(t *testing.T) {
 		{
 			"data": {
 				"repositoryOwner": {
-				"repositories": {
-					"totalCount": 3,
-					"nodes": [
-					{
-						"name": "hello-world",
-						"isFork": false,
-						"isPrivate": false,
-						"isArchived": false,
-						"visibility": "PUBLIC"
-					},
-					{
-						"name": "cli",
-						"isFork": true,
-						"isPrivate": false,
-						"isArchived": false,
-						"visibility": "PUBLIC"
-					},
-					{
-						"name": "REPO",
-						"isFork": false,
-						"isPrivate": true,
-						"isArchived": false,
-						"visibility": "PRIVATE"
-					}
-					],
-					"pageInfo": {
-					"hasNextPage": false,
-					"endCursor": ""
+					"repositories": {
+						"totalCount": 3,
+						"pageInfo": {
+							"hasNextPage": false,
+							"endCursor": ""
+						}
 					}
 				}
+			}
+	    }`))
+
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryList\b`),
+		httpmock.StringResponse(`
+		{
+			"data": {
+				"repositoryOwner": {
+					"repositories": {
+						"totalCount": 3,
+						"nodes": [
+							{
+								"name": "hello-world",
+								"isFork": false,
+								"isPrivate": false,
+								"isArchived": false,
+								"visibility": "PUBLIC"
+							},
+							{
+								"name": "cli",
+								"isFork": true,
+								"isPrivate": false,
+								"isArchived": false,
+								"visibility": "PUBLIC"
+							},
+							{
+								"name": "REPO",
+								"isFork": false,
+								"isPrivate": true,
+								"isArchived": false,
+								"visibility": "PRIVATE"
+							}
+						],
+						"pageInfo": {
+							"hasNextPage": false,
+							"endCursor": ""
+						}
+					}
 				}
 			}
 	}`))

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -321,3 +321,68 @@ func Test_RepoClone_withoutUsername(t *testing.T) {
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, "", output.Stderr())
 }
+
+func Test_RepoClone_RepoTypo(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StringResponse(`
+		{ "data": { "viewer": {
+			"login": "OWNER"
+		}}}`))
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.StringResponse(`
+				{ "data": {} }
+				`))
+
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryList\b`),
+		httpmock.StringResponse(`
+		{
+			"data": {
+				"repositoryOwner": {
+				"repositories": {
+					"totalCount": 3,
+					"nodes": [
+					{
+						"name": "hello-world",
+						"isFork": false,
+						"isPrivate": false,
+						"isArchived": false,
+						"visibility": "PUBLIC"
+					},
+					{
+						"name": "cli",
+						"isFork": true,
+						"isPrivate": false,
+						"isArchived": false,
+						"visibility": "PUBLIC"
+					},
+					{
+						"name": "REPO",
+						"isFork": false,
+						"isPrivate": true,
+						"isArchived": false,
+						"visibility": "PRIVATE"
+					}
+					],
+					"pageInfo": {
+					"hasNextPage": false,
+					"endCursor": ""
+					}
+				}
+				}
+			}
+	}`))
+	httpClient := &http.Client{Transport: reg}
+
+	_, err := runCloneCommand(httpClient, "REPOO") // typo
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	assert.ErrorContains(t, err, `Did you mean this?`)
+	assert.ErrorContains(t, err, "gh repo clone OWNER/REPO")
+}

--- a/pkg/cmd/repo/list/http_test.go
+++ b/pkg/cmd/repo/list/http_test.go
@@ -46,7 +46,7 @@ func Test_listReposWithLanguage(t *testing.T) {
 	)
 
 	client := http.Client{Transport: &reg}
-	res, err := listRepos(&client, "github.com", 10, "", FilterOptions{
+	res, err := ListRepos(&client, "github.com", 10, "", FilterOptions{
 		Language: "go",
 	})
 	require.NoError(t, err)

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -149,7 +149,7 @@ func listRun(opts *ListOptions) error {
 		filter.Fields = opts.Exporter.Fields()
 	}
 
-	listResult, err := listRepos(httpClient, host, opts.Limit, opts.Owner, filter)
+	listResult, err := ListRepos(httpClient, host, opts.Limit, opts.Owner, filter)
 	if err != nil {
 		return err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 )
@@ -113,4 +114,90 @@ func IsDebugEnabled() (bool, string) {
 	default:
 		return true, debugValue
 	}
+}
+
+func LevenshteinDistance(s, t string) int {
+	if len(s) == 0 {
+		return len(t)
+	}
+	if len(t) == 0 {
+		return len(s)
+	}
+	if s[0] == t[0] {
+		return LevenshteinDistance(s[1:], t[1:])
+	}
+
+	vals := []int{
+		LevenshteinDistance(s[1:], t[1:]),
+		LevenshteinDistance(s[1:], t),
+		LevenshteinDistance(s, t[1:]),
+	}
+
+	sort.Ints(vals)
+
+	min := vals[0]
+
+	return 1 + min
+}
+
+func LevenshteinDistanceIter(s, t string) int {
+	m := make([][]int, len(s)+1)
+	for i := 0; i <= len(s); i++ {
+		m[i] = make([]int, len(t)+1)
+	}
+
+	for i := 1; i <= len(s); i++ {
+		m[i][0] = i
+	}
+
+	for j := 1; j <= len(t); j++ {
+		m[0][j] = j
+	}
+
+	for j := 1; j <= len(t); j++ {
+		for i := 1; i <= len(s); i++ {
+
+			cost := 0
+			if s[i-1] != t[j-1] {
+				cost = 1
+			}
+
+			vals := []int{
+				m[i-1][j] + 1,      // deletion
+				m[i][j-1] + 1,      // insertion
+				m[i-1][j-1] + cost, // substitution
+			}
+
+			sort.Ints(vals)
+			m[i][j] = vals[0]
+		}
+	}
+	return m[len(s)][len(t)]
+}
+
+func LevenshteinDistanceIter2(s, t string) int {
+	v0 := make([]int, len(t)+1)
+	v1 := make([]int, len(t)+1)
+	for i := 0; i <= len(t); i++ {
+		v0[i] = i
+	}
+	for i := 0; i < len(s); i++ {
+		v1[0] = i + 1
+		for j := 0; j < len(t); j++ {
+			cost := 0
+			if s[i] != t[j] {
+				cost = 1
+			}
+			vals := []int{
+				v0[j+1] + 1,  // deletion
+				v1[j] + 1,    // insertion
+				v0[j] + cost, // substitution
+
+			}
+			sort.Ints(vals)
+			v1[j+1] = vals[0]
+		}
+		copy(v0, v1)
+	}
+	return v0[len(t)]
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"sort"
 	"strings"
 	"time"
 )
@@ -116,66 +115,17 @@ func IsDebugEnabled() (bool, string) {
 	}
 }
 
-func LevenshteinDistance(s, t string) int {
-	if len(s) == 0 {
-		return len(t)
-	}
-	if len(t) == 0 {
-		return len(s)
-	}
-	if s[0] == t[0] {
-		return LevenshteinDistance(s[1:], t[1:])
-	}
-
-	vals := []int{
-		LevenshteinDistance(s[1:], t[1:]),
-		LevenshteinDistance(s[1:], t),
-		LevenshteinDistance(s, t[1:]),
-	}
-
-	sort.Ints(vals)
-
-	min := vals[0]
-
-	return 1 + min
-}
-
-func LevenshteinDistanceIter(s, t string) int {
-	m := make([][]int, len(s)+1)
-	for i := 0; i <= len(s); i++ {
-		m[i] = make([]int, len(t)+1)
-	}
-
-	for i := 1; i <= len(s); i++ {
-		m[i][0] = i
-	}
-
-	for j := 1; j <= len(t); j++ {
-		m[0][j] = j
-	}
-
-	for j := 1; j <= len(t); j++ {
-		for i := 1; i <= len(s); i++ {
-
-			cost := 0
-			if s[i-1] != t[j-1] {
-				cost = 1
-			}
-
-			vals := []int{
-				m[i-1][j] + 1,      // deletion
-				m[i][j-1] + 1,      // insertion
-				m[i-1][j-1] + cost, // substitution
-			}
-
-			sort.Ints(vals)
-			m[i][j] = vals[0]
+func min(init int, rest ...int) int {
+	min := init
+	for _, v := range rest {
+		if min > v {
+			min = v
 		}
 	}
-	return m[len(s)][len(t)]
+	return min
 }
 
-func LevenshteinDistanceIter2(s, t string) int {
+func LevenshteinDistance(s, t string) int {
 	v0 := make([]int, len(t)+1)
 	v1 := make([]int, len(t)+1)
 	for i := 0; i <= len(t); i++ {
@@ -188,14 +138,12 @@ func LevenshteinDistanceIter2(s, t string) int {
 			if s[i] != t[j] {
 				cost = 1
 			}
-			vals := []int{
-				v0[j+1] + 1,  // deletion
-				v1[j] + 1,    // insertion
-				v0[j] + cost, // substitution
 
-			}
-			sort.Ints(vals)
-			v1[j+1] = vals[0]
+			v1[j+1] = min(
+				v0[j+1]+1,  // deletion
+				v1[j]+1,    // insertion
+				v0[j]+cost, // substitution
+			)
 		}
 		copy(v0, v1)
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -88,3 +88,113 @@ func TestLevenshteinDistance(t *testing.T) {
 		}
 	}
 }
+
+func TestFilterBySimilarity(t *testing.T) {
+	cases := []struct {
+		name     string
+		s        string
+		cands    []string
+		opt      FilterBySimilarityOpts
+		expected []string
+	}{
+		{
+			"test normal",
+			"cli/clii",
+			[]string{
+				"cli/cli",
+				"cli/go-gh",
+				"cli/scoop-gh",
+				"cli/browser",
+				"cli/gh-extension-precompile",
+				"cli/oauth",
+				"cli/safeexec",
+				"cli/crypto",
+				"cli/shurcooL-graphql",
+			},
+			DefaultFilterBySimilarityOpts,
+			[]string{
+				"cli/cli",
+			},
+		},
+		{
+			"test IgnoreCase: true(default)",
+			"cli/GO-GH",
+			[]string{
+				"cli/cli",
+				"cli/go-gh",
+				"cli/scoop-gh",
+				"cli/browser",
+				"cli/gh-extension-precompile",
+				"cli/oauth",
+				"cli/safeexec",
+				"cli/crypto",
+				"cli/shurcooL-graphql",
+			},
+			DefaultFilterBySimilarityOpts,
+			[]string{
+				"cli/go-gh",
+			},
+		},
+		{
+			"test IgnoreCase: false",
+			"cli/GO-GH",
+			[]string{
+				"cli/cli",
+				"cli/go-gh",
+				"cli/scoop-gh",
+				"cli/browser",
+				"cli/gh-extension-precompile",
+				"cli/oauth",
+				"cli/safeexec",
+				"cli/crypto",
+				"cli/shurcooL-graphql",
+			},
+			FilterBySimilarityOpts{
+				IgnoreCase: false,
+			},
+			[]string{},
+		},
+		{
+			"test Limit, DistanceLimit",
+			"cli/GO-GH",
+			[]string{
+				"cli/cli",
+				"cli/go-gh",
+				"cli/scoop-gh",
+				"cli/browser",
+				"cli/gh-extension-precompile",
+				"cli/oauth",
+				"cli/safeexec",
+				"cli/crypto",
+				"cli/shurcooL-graphql",
+			},
+			FilterBySimilarityOpts{
+				IgnoreCase:    true,
+				DistanceLimit: 4,
+				Limit:         2,
+			},
+			[]string{
+				"cli/go-gh",
+				"cli/scoop-gh",
+			},
+		},
+	}
+	for _, c := range cases {
+		got := FilterBySimilarity(c.s, c.cands, c.opt)
+		if len(got) != len(c.expected) {
+			t.Errorf(`unexpected result of "%s": length not equal`, c.name)
+		}
+		for i := 0; i < len(got); i++ {
+			g := got[i]
+			e := c.expected[i]
+			if g != e {
+				t.Errorf(`unexpected of "%s": expected %s, got %s`,
+					c.name,
+					e,
+					g,
+				)
+			}
+
+		}
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -61,3 +61,64 @@ func TestFuzzyAgoAbbr(t *testing.T) {
 		}
 	}
 }
+
+func TestLevenshteinDistance(t *testing.T) {
+	cases := []struct {
+		s        string
+		t        string
+		expected int
+	}{
+		{"k", "s", 1},
+		{"kitten", "kitten", 0},
+		{"kitten", "sitting", 3},
+	}
+	for _, c := range cases {
+		got := LevenshteinDistance(c.s, c.t)
+		if got != c.expected {
+			t.Errorf("unexpected LevenshteinDistance: expected %d, got %d, for %s, %s",
+				c.expected,
+				got,
+				c.s,
+				c.t,
+			)
+		}
+
+		got = LevenshteinDistanceIter(c.s, c.t)
+		if got != c.expected {
+			t.Errorf("unexpected LevenshteinDistanceIter: expected %d, got %d, for %s, %s",
+				c.expected,
+				got,
+				c.s,
+				c.t,
+			)
+		}
+
+		got = LevenshteinDistanceIter2(c.s, c.t)
+		if got != c.expected {
+			t.Errorf("unexpected LevenshteinDistanceIter2: expected %d, got %d, for %s, %s",
+				c.expected,
+				got,
+				c.s,
+				c.t,
+			)
+		}
+	}
+}
+
+func BenchmarkLevenshteinDistance(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		LevenshteinDistance("clifeaf/cli", "clijeaflj/cil")
+	}
+}
+
+func BenchmarkLevenshteinDistanceIter(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		LevenshteinDistanceIter("clifeaf/cli", "clijeaflj/cil")
+	}
+}
+
+func BenchmarkLevenshteinDistanceIter2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		LevenshteinDistanceIter2("clifeaf/cli", "clijeaflj/cil")
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -68,9 +68,13 @@ func TestLevenshteinDistance(t *testing.T) {
 		t        string
 		expected int
 	}{
+		{"", "", 0},
+		{"", "s", 1},
+		{"k", "", 1},
 		{"k", "s", 1},
 		{"kitten", "kitten", 0},
 		{"kitten", "sitting", 3},
+		{"cli/cli", "cli/cii", 1},
 	}
 	for _, c := range cases {
 		got := LevenshteinDistance(c.s, c.t)
@@ -82,43 +86,5 @@ func TestLevenshteinDistance(t *testing.T) {
 				c.t,
 			)
 		}
-
-		got = LevenshteinDistanceIter(c.s, c.t)
-		if got != c.expected {
-			t.Errorf("unexpected LevenshteinDistanceIter: expected %d, got %d, for %s, %s",
-				c.expected,
-				got,
-				c.s,
-				c.t,
-			)
-		}
-
-		got = LevenshteinDistanceIter2(c.s, c.t)
-		if got != c.expected {
-			t.Errorf("unexpected LevenshteinDistanceIter2: expected %d, got %d, for %s, %s",
-				c.expected,
-				got,
-				c.s,
-				c.t,
-			)
-		}
-	}
-}
-
-func BenchmarkLevenshteinDistance(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		LevenshteinDistance("clifeaf/cli", "clijeaflj/cil")
-	}
-}
-
-func BenchmarkLevenshteinDistanceIter(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		LevenshteinDistanceIter("clifeaf/cli", "clijeaflj/cil")
-	}
-}
-
-func BenchmarkLevenshteinDistanceIter2(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		LevenshteinDistanceIter2("clifeaf/cli", "clijeaflj/cil")
 	}
 }


### PR DESCRIPTION
Fixes #6134

* Add funcs for levenshtein distance
* If `repo clone` fails because of typo, suggest repos
  - Suggestions are based on
    - Repos which belongs to the owner
    - Levenshtein distance between input and candidate <= 2
* If owner has more than 1000 repos, suggestion is skipped
    - Add `CountRepos`
