### PR TITLE
Fix "missing method Fd" crash on Windows

### DIFF
--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/pkg/surveyext"
 )
@@ -22,19 +21,29 @@ type Prompter interface {
 	MarkdownEditor(string, string, bool) (string, error)
 }
 
-func New(editorCmd string, stdin io.Reader, stdout, stderr io.Writer) Prompter {
+type fileWriter interface {
+	io.Writer
+	Fd() uintptr
+}
+
+type fileReader interface {
+	io.Reader
+	Fd() uintptr
+}
+
+func New(editorCmd string, stdin fileReader, stdout fileWriter, stderr io.Writer) Prompter {
 	return &surveyPrompter{
 		editorCmd: editorCmd,
-		stdin:     stdin.(terminal.FileReader),
-		stdout:    stdout.(terminal.FileWriter),
+		stdin:     stdin,
+		stdout:    stdout,
 		stderr:    stderr,
 	}
 }
 
 type surveyPrompter struct {
 	editorCmd string
-	stdin     terminal.FileReader
-	stdout    terminal.FileWriter
+	stdin     fileReader
+	stdout    fileWriter
 	stderr    io.Writer
 }
 

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -281,8 +281,8 @@ func apiRun(opts *ApiOptions) error {
 		}
 	}
 
-	bodyWriter := opts.IO.Out
-	headersWriter := opts.IO.Out
+	var bodyWriter io.Writer = opts.IO.Out
+	var headersWriter io.Writer = opts.IO.Out
 	if opts.Silent {
 		bodyWriter = io.Discard
 	}

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -111,7 +111,7 @@ func checksRun(opts *ChecksOptions) error {
 		return checksRunWebMode(opts)
 	}
 
-	if !opts.Watch {
+	if opts.Watch {
 		opts.IO.StartAlternateScreenBuffer()
 	} else {
 		// Only start pager in non-watch mode

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -111,10 +111,8 @@ func checksRun(opts *ChecksOptions) error {
 		return checksRunWebMode(opts)
 	}
 
-	if opts.Watch {
-		if err := opts.IO.EnableVirtualTerminalProcessing(); err != nil {
-			return err
-		}
+	if !opts.Watch {
+		opts.IO.StartAlternateScreenBuffer()
 	} else {
 		// Only start pager in non-watch mode
 		if err := opts.IO.StartPager(); err == nil {
@@ -126,10 +124,6 @@ func checksRun(opts *ChecksOptions) error {
 
 	var checks []check
 	var counts checkCounts
-
-	if opts.Watch {
-		opts.IO.StartAlternateScreenBuffer()
-	}
 
 	// Do not return err until we can StopAlternateScreenBuffer()
 	var err error

--- a/pkg/cmdutil/json_flags_test.go
+++ b/pkg/cmdutil/json_flags_test.go
@@ -1,7 +1,6 @@
 package cmdutil
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"testing"
@@ -179,10 +178,7 @@ func Test_exportFormat_Write(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w := &bytes.Buffer{}
-			io := &iostreams.IOStreams{
-				Out: w,
-			}
+			io, _, w, _ := iostreams.Test()
 			if err := tt.exporter.Write(io, tt.args.data); (err != nil) != tt.wantErr {
 				t.Errorf("exportFormat.Write() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/iostreams/console.go
+++ b/pkg/iostreams/console.go
@@ -3,14 +3,10 @@
 
 package iostreams
 
-import (
-	"os"
-)
-
 func (s *IOStreams) EnableVirtualTerminalProcessing() error {
 	return nil
 }
 
-func enableVirtualTerminalProcessing(f *os.File) error {
+func enableVirtualTerminalProcessing(fd uintptr) error {
 	return nil
 }

--- a/pkg/iostreams/console.go
+++ b/pkg/iostreams/console.go
@@ -3,10 +3,6 @@
 
 package iostreams
 
-func (s *IOStreams) EnableVirtualTerminalProcessing() error {
-	return nil
-}
-
 func enableVirtualTerminalProcessing(fd uintptr) error {
 	return nil
 }

--- a/pkg/iostreams/console_windows.go
+++ b/pkg/iostreams/console_windows.go
@@ -4,18 +4,8 @@
 package iostreams
 
 import (
-	"os"
-
 	"golang.org/x/sys/windows"
 )
-
-func (s *IOStreams) EnableVirtualTerminalProcessing() error {
-	if !s.IsStdoutTTY() {
-		return nil
-	}
-
-	return enableVirtualTerminalProcessing(s.Out.Fd())
-}
 
 func enableVirtualTerminalProcessing(fd uintptr) error {
 	stdout := windows.Handle(fd)

--- a/pkg/iostreams/console_windows.go
+++ b/pkg/iostreams/console_windows.go
@@ -14,16 +14,11 @@ func (s *IOStreams) EnableVirtualTerminalProcessing() error {
 		return nil
 	}
 
-	f, ok := s.originalOut.(*os.File)
-	if !ok {
-		return nil
-	}
-
-	return enableVirtualTerminalProcessing(f)
+	return enableVirtualTerminalProcessing(s.Out.Fd())
 }
 
-func enableVirtualTerminalProcessing(f *os.File) error {
-	stdout := windows.Handle(f.Fd())
+func enableVirtualTerminalProcessing(fd uintptr) error {
+	stdout := windows.Handle(fd)
 
 	var originalMode uint32
 	windows.GetConsoleMode(stdout, &originalMode)

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -431,7 +431,7 @@ func System() *IOStreams {
 
 	isVirtualTerminal := false
 	if stdoutIsTTY {
-		if err := enableVirtualTerminalProcessing(os.Stdout); err == nil {
+		if err := enableVirtualTerminalProcessing(os.Stdout.Fd()); err == nil {
 			isVirtualTerminal = true
 		}
 	}

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -468,7 +468,7 @@ func Test() (*IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
 	in := &bytes.Buffer{}
 	out := &bytes.Buffer{}
 	errOut := &bytes.Buffer{}
-	return &IOStreams{
+	io := &IOStreams{
 		In: &fdReader{
 			fd:         0,
 			ReadCloser: io.NopCloser(in),
@@ -478,7 +478,11 @@ func Test() (*IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
 		ttySize: func() (int, int, error) {
 			return -1, -1, errors.New("ttySize not implemented in tests")
 		},
-	}, in, out, errOut
+	}
+	io.SetStdinTTY(false)
+	io.SetStdoutTTY(false)
+	io.SetStderrTTY(false)
+	return io, in, out, errOut
 }
 
 func isTerminal(f *os.File) bool {

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -29,13 +29,21 @@ type ErrClosedPagerPipe struct {
 	error
 }
 
+type fileWriter interface {
+	io.Writer
+	Fd() uintptr
+}
+
+type fileReader interface {
+	io.ReadCloser
+	Fd() uintptr
+}
+
 type IOStreams struct {
-	In     io.ReadCloser
-	Out    io.Writer
+	In     fileReader
+	Out    fileWriter
 	ErrOut io.Writer
 
-	// the original (non-colorable) output stream
-	originalOut   io.Writer
 	colorEnabled  bool
 	is256enabled  bool
 	hasTrueColor  bool
@@ -206,7 +214,10 @@ func (s *IOStreams) StartPager() error {
 	if err != nil {
 		return err
 	}
-	s.Out = &pagerWriter{pagedOut}
+	s.Out = &fdWriter{
+		fd:     s.Out.Fd(),
+		Writer: &pagerWriter{pagedOut},
+	}
 	err = pagerCmd.Start()
 	if err != nil {
 		return err
@@ -335,16 +346,12 @@ func (s *IOStreams) TerminalWidth() int {
 	}
 
 	defaultWidth := DefaultWidth
-	out := s.Out
-	if s.originalOut != nil {
-		out = s.originalOut
-	}
 
-	if w, _, err := terminalSize(out); err == nil {
+	if w, _, err := terminalSize(s.Out.Fd()); err == nil {
 		return w
 	}
 
-	if isCygwinTerminal(out) {
+	if isCygwinTerminal(s.Out.Fd()) {
 		tputExe, err := safeexec.LookPath("tput")
 		if err != nil {
 			return defaultWidth
@@ -430,9 +437,11 @@ func System() *IOStreams {
 	}
 
 	io := &IOStreams{
-		In:           os.Stdin,
-		originalOut:  os.Stdout,
-		Out:          colorable.NewColorable(os.Stdout),
+		In: os.Stdin,
+		Out: &fdWriter{
+			fd:     os.Stdout.Fd(),
+			Writer: colorable.NewColorable(os.Stdout),
+		},
 		ErrOut:       colorable.NewColorable(os.Stderr),
 		colorEnabled: EnvColorForced() || (!EnvColorDisabled() && stdoutIsTTY),
 		is256enabled: isVirtualTerminal || Is256ColorSupported(),
@@ -460,8 +469,11 @@ func Test() (*IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
 	out := &bytes.Buffer{}
 	errOut := &bytes.Buffer{}
 	return &IOStreams{
-		In:     io.NopCloser(in),
-		Out:    out,
+		In: &fdReader{
+			fd:         0,
+			ReadCloser: io.NopCloser(in),
+		},
+		Out:    &fdWriter{fd: 1, Writer: out},
 		ErrOut: errOut,
 		ttySize: func() (int, int, error) {
 			return -1, -1, errors.New("ttySize not implemented in tests")
@@ -473,19 +485,13 @@ func isTerminal(f *os.File) bool {
 	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
 }
 
-func isCygwinTerminal(w io.Writer) bool {
-	if f, isFile := w.(*os.File); isFile {
-		return isatty.IsCygwinTerminal(f.Fd())
-	}
-	return false
+func isCygwinTerminal(fd uintptr) bool {
+	return isatty.IsCygwinTerminal(fd)
 }
 
 // terminalSize measures the viewport of the terminal that the output stream is connected to
-func terminalSize(w io.Writer) (int, int, error) {
-	if f, isFile := w.(*os.File); isFile {
-		return term.GetSize(int(f.Fd()))
-	}
-	return 0, 0, fmt.Errorf("%v is not a file", w)
+func terminalSize(fd uintptr) (int, int, error) {
+	return term.GetSize(int(fd))
 }
 
 // pagerWriter implements a WriteCloser that wraps all EPIPE errors in an ErrClosedPagerPipe type.
@@ -499,4 +505,24 @@ func (w *pagerWriter) Write(d []byte) (int, error) {
 		return n, &ErrClosedPagerPipe{err}
 	}
 	return n, err
+}
+
+// fdWriter represents a wrapped stdout Writer that preserves the original file descriptor
+type fdWriter struct {
+	io.Writer
+	fd uintptr
+}
+
+func (w *fdWriter) Fd() uintptr {
+	return w.fd
+}
+
+// fdWriter represents a wrapped stdin ReadCloser that preserves the original file descriptor
+type fdReader struct {
+	io.ReadCloser
+	fd uintptr
+}
+
+func (r *fdReader) Fd() uintptr {
+	return r.fd
 }

--- a/pkg/iostreams/iostreams_test.go
+++ b/pkg/iostreams/iostreams_test.go
@@ -3,6 +3,7 @@ package iostreams
 import (
 	"errors"
 	"fmt"
+	"io"
 	"testing"
 )
 
@@ -35,6 +36,10 @@ func TestIOStreams_ForceTerminal(t *testing.T) {
 		{
 			name: "measure width fails",
 			iostreams: &IOStreams{
+				Out: &fdWriter{
+					Writer: io.Discard,
+					fd:     1,
+				},
 				ttySize: func() (int, int, error) {
 					return -1, -1, errors.New("ttySize sabotage!")
 				},


### PR DESCRIPTION
This ensures that `IOStreams.Out` always keeps the original `Fd()` value even if it's wrapped as a Colorable stream for Windows in cases when enabling virtual terminal processing has failed.

Fixes https://github.com/cli/cli/issues/6147