### PR TITLE
Use secret public key instead of file

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -79,7 +79,7 @@ jobs:
         run: sudo apt-get install -y rpm reprepro
       - name: Set up GPG
         run: |
-          gpg --import --no-tty --batch --yes < script/pubkey.asc
+          echo "${{secrets.GPG_PUBKEY}}" | base64 -d | gpg --import --no-tty --batch --yes
           echo "${{secrets.GPG_KEY}}" | base64 -d | gpg --import --no-tty --batch --yes
           echo "allow-preset-passphrase" > ~/.gnupg/gpg-agent.conf
           gpg-connect-agent RELOADAGENT /bye


### PR DESCRIPTION
Use secret public GPG key instead of file in release workflow.