### PR TITLE
Add ability to trigger releases without pushing a git tag

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
-          version: v1.9.2
+          version: v1.11.2
           args: release --release-notes=CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tagname:
+        description: "The tag name to release"
+        required: true
 
 permissions:
   contents: write  # publishing releases
@@ -13,22 +18,34 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+      - name: Normalize tag name
+        id: normalize
+        run: |
+          tagname="${GITHUB_REF#refs/tags/}"
+          [ -z "$TAGNAME_INPUT" ] || tagname="$TAGNAME_INPUT"
+          prerelease=0
+          [[ $tagname != *-* ]] || prerelease=1
+          echo "::set-output name=tagname::$tagname"
+          echo "::set-output name=prerelease::$prerelease"
+        env:
+          TAGNAME_INPUT: ${{inputs.tagname}}
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: refs/tags/${{steps.normalize.outputs.tagname}}
       - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: Generate changelog
-        id: changelog
+        env:
+          TAGNAME: ${{steps.normalize.outputs.tagname}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
-          echo "::set-output name=tag-name::${GITHUB_REF#refs/tags/}"
           gh api repos/$GITHUB_REPOSITORY/releases/generate-notes \
-            -f tag_name="${GITHUB_REF#refs/tags/}" \
+            -f tag_name="$TAGNAME" \
             -f target_commitish=trunk \
             -q .body > CHANGELOG.md
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Install osslsigncode
         run: sudo apt-get install -y osslsigncode
       - name: Obtain signing cert
@@ -41,11 +58,11 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
-          version: v0.174.1
+          version: v1.9.2
           args: release --release-notes=CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          GORELEASER_CURRENT_TAG: ${{steps.changelog.outputs.tag-name}}
+          GORELEASER_CURRENT_TAG: ${{steps.normalize.outputs.tagname}}
           CERT_PASSWORD: ${{secrets.WINDOWS_CERT_PASSWORD}}
       - name: Checkout documentation site
         uses: actions/checkout@v3
@@ -60,16 +77,18 @@ jobs:
           GIT_AUTHOR_NAME: cli automation
           GIT_COMMITTER_EMAIL: noreply@github.com
           GIT_AUTHOR_EMAIL: noreply@github.com
-        run: make site-bump
+          TAGNAME: ${{steps.normalize.outputs.tagname}}
+        run: GITHUB_REF="refs/tags/$TAGNAME" make site-bump
       - name: Move project cards
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           PENDING_COLUMN: 8189733
           DONE_COLUMN: 7110130
+          PRERELEASE: ${{steps.normalize.outputs.prerelease}}
         run: |
           api() { gh api -H 'accept: application/vnd.github.inertia-preview+json' "$@"; }
-          api-write() { [[ $GITHUB_REF == *-* ]] && echo "skipping: api $*" || api "$@"; }
+          api-write() { [ "$PRERELEASE" -eq 1 ] && echo "skipping: api $*" || api "$@"; }
           cards=$(api --paginate projects/columns/$PENDING_COLUMN/cards | jq ".[].id")
           for card in $cards; do
             api-write --silent projects/columns/cards/$card/moves -f position=top -F column_id=$DONE_COLUMN
@@ -119,11 +138,13 @@ jobs:
           GIT_AUTHOR_NAME: cli automation
           GIT_COMMITTER_EMAIL: noreply@github.com
           GIT_AUTHOR_EMAIL: noreply@github.com
+          TAGNAME: ${{steps.normalize.outputs.tagname}}
+          PRERELEASE: ${{steps.normalize.outputs.prerelease}}
         working-directory: ./site
         run: |
           git add packages
-          git commit -m "Add rpm and deb packages for ${GITHUB_REF#refs/tags/}"
-          if [[ $GITHUB_REF == *-* ]]; then
+          git commit -m "Add rpm and deb packages for $TAGNAME"
+          if [ "$PRERELEASE" -eq 1 ]; then
             git log --oneline @{upstream}..
             git diff --name-status @{upstream}..
           else
@@ -134,17 +155,32 @@ jobs:
     needs: goreleaser
     runs-on: windows-latest
     steps:
+      - name: Normalize tag name
+        id: normalize
+        shell: bash
+        run: |
+          tagname="${GITHUB_REF#refs/tags/}"
+          [ -z "$TAGNAME_INPUT" ] || tagname="$TAGNAME_INPUT"
+          prerelease=0
+          [[ $tagname != *-* ]] || prerelease=1
+          echo "::set-output name=tagname::$tagname"
+          echo "::set-output name=prerelease::$prerelease"
+        env:
+          TAGNAME_INPUT: ${{inputs.tagname}}
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: refs/tags/${{steps.normalize.outputs.tagname}}
       - name: Download gh.exe
         id: download_exe
         shell: bash
         run: |
-          hub release download "${GITHUB_REF#refs/tags/}" -i '*windows_amd64*.zip'
+          gh release download "$TAGNAME" -p '*windows_amd64*.zip'
           printf "::set-output name=zip::%s\n" *.zip
           unzip -o *.zip && rm -v *.zip
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          TAGNAME: ${{steps.normalize.outputs.tagname}}
       - name: Prepare PATH
         id: setupmsbuild
         uses: microsoft/setup-msbuild@v1.0.3
@@ -154,9 +190,10 @@ jobs:
         env:
           ZIP_FILE: ${{ steps.download_exe.outputs.zip }}
           MSBUILD_PATH: ${{ steps.setupmsbuild.outputs.msbuildPath }}
+          TAGNAME: ${{steps.normalize.outputs.tagname}}
         run: |
           name="$(basename "$ZIP_FILE" ".zip")"
-          version="$(echo -e ${GITHUB_REF#refs/tags/v} | sed s/-.*$//)"
+          version="$(echo -e ${TAGNAME#v} | sed s/-.*$//)"
           "${MSBUILD_PATH}\MSBuild.exe" ./build/windows/gh.wixproj -p:SourceDir="$PWD" -p:OutputPath="$PWD" -p:OutputName="$name" -p:ProductVersion="$version"
       - name: Obtain signing cert
         id: obtain_cert
@@ -172,24 +209,24 @@ jobs:
           EXE_FILE: ${{ steps.buildmsi.outputs.msi }}
           CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
         run: .\script\signtool sign /d "GitHub CLI" /f $env:CERT_FILE /p $env:CERT_PASSWORD /fd sha256 /tr http://timestamp.digicert.com /v $env:EXE_FILE
-      - name: Upload MSI
+      - name: Upload MSI and publish release
         shell: bash
         run: |
-          tag_name="${GITHUB_REF#refs/tags/}"
-          hub release edit "$tag_name" -m "" -a "$MSI_FILE"
-          release_url="$(gh api repos/:owner/:repo/releases -q ".[]|select(.tag_name==\"${tag_name}\")|.url")"
-          publish_args=( -F draft=false )
-          if [[ $GITHUB_REF != *-* ]]; then
-            publish_args+=( -f discussion_category_name="$DISCUSSION_CATEGORY" )
+          gh release upload "$TAGNAME" "$MSI_FILE"
+          if [ "$PRERELEASE" -eq 0 ]; then
+            gh release edit "$TAGNAME" --draft=false --discussion-category="$DISCUSSION_CATEGORY"
+          else
+            gh release edit "$TAGNAME" --draft=false
           fi
-          gh api -X PATCH "$release_url" "${publish_args[@]}"
         env:
           MSI_FILE: ${{ steps.buildmsi.outputs.msi }}
           DISCUSSION_CATEGORY: General
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          TAGNAME: ${{steps.normalize.outputs.tagname}}
+          PRERELEASE: ${{steps.normalize.outputs.prerelease}}
       - name: Bump homebrew-core formula
         uses: mislav/bump-homebrew-formula-action@v1
-        if: "!contains(github.ref, '-')" # skip prereleases
+        if: steps.normalize.outputs.prerelease != "1" # skip prereleases
         with:
           formula-name: gh
         env:
@@ -204,10 +241,10 @@ jobs:
       - name: Bump scoop bucket
         shell: bash
         run: |
-          hub release download "${GITHUB_REF#refs/tags/}" -i '*_checksums.txt'
-          script/scoop-gen "${GITHUB_REF#refs/tags/}" ./scoop-gh/gh.json < *_checksums.txt
-          git -C ./scoop-gh commit -m "gh ${GITHUB_REF#refs/tags/}" gh.json
-          if [[ $GITHUB_REF == *-* ]]; then
+          gh release download "$TAGNAME" -p '*_checksums.txt'
+          script/scoop-gen "$TAGNAME" ./scoop-gh/gh.json < *_checksums.txt
+          git -C ./scoop-gh commit -m "gh $TAGNAME" gh.json
+          if [ "$PRERELEASE" -eq 1 ]; then
             git -C ./scoop-gh show -m
           else
             git -C ./scoop-gh push
@@ -218,3 +255,5 @@ jobs:
           GIT_AUTHOR_NAME: cli automation
           GIT_COMMITTER_EMAIL: noreply@github.com
           GIT_AUTHOR_EMAIL: noreply@github.com
+          TAGNAME: ${{steps.normalize.outputs.tagname}}
+          PRERELEASE: ${{steps.normalize.outputs.prerelease}}


### PR DESCRIPTION
This allows us to retry a failed release build without having to bump the git tag. Useful for regenerating release assets after changing secret values.

Example use:
```sh
gh workflow run releases.yml --ref workflow-dispatch -f tagname=v2.14.8-pre1
```