### PR TITLE
Do not set default for survey prompt if empty string passed

### DIFF
--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -50,9 +50,12 @@ type surveyPrompter struct {
 func (p *surveyPrompter) Select(message, defaultValue string, options []string) (result int, err error) {
 	q := &survey.Select{
 		Message:  message,
-		Default:  defaultValue,
 		Options:  options,
 		PageSize: 20,
+	}
+
+	if defaultValue != "" {
+		q.Default = defaultValue
 	}
 
 	err = p.ask(q, &result)
@@ -63,9 +66,12 @@ func (p *surveyPrompter) Select(message, defaultValue string, options []string) 
 func (p *surveyPrompter) MultiSelect(message, defaultValue string, options []string) (result int, err error) {
 	q := &survey.MultiSelect{
 		Message:  message,
-		Default:  defaultValue,
 		Options:  options,
 		PageSize: 20,
+	}
+
+	if defaultValue != "" {
+		q.Default = defaultValue
 	}
 
 	err = p.ask(q, &result)


### PR DESCRIPTION
For survey's `Select` and `Multiselect` prompts, passing an empty string causes the surprising side effect of forcing survey to try and return the empty string as the user's chosen answer when the 0th choice is selected even though `""` is not in the choice list. In other survey prompts, a default of `""` is equivalent to there being no default.

While the correct course of action is likely a patch to survey to have it panic if a passed `Default` is not in a `Select`'s choices, this PR is a shorter term fix that just doesn't specify `Default` in our new Prompter interface if the empty string is passed.

Related to #6131
