### PR TITLE
use Prompter in auth commands

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -9,7 +9,6 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/ghinstance"
-	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -20,7 +19,7 @@ type LoginOptions struct {
 	IO         *iostreams.IOStreams
 	Config     func() (config.Config, error)
 	HttpClient func() (*http.Client, error)
-	Prompter   prompter.Prompter
+	Prompter   shared.Prompt
 
 	MainExecutable string
 

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -4,14 +4,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/cli/cli/v2/pkg/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -19,6 +17,7 @@ type LogoutOptions struct {
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
 	Config     func() (config.Config, error)
+	Prompter   shared.Prompt
 	Hostname   string
 }
 
@@ -27,6 +26,7 @@ func NewCmdLogout(f *cmdutil.Factory, runF func(*LogoutOptions) error) *cobra.Co
 		HttpClient: f.HttpClient,
 		IO:         f.IOStreams,
 		Config:     f.Config,
+		Prompter:   f.Prompter,
 	}
 
 	cmd := &cobra.Command{
@@ -79,15 +79,12 @@ func logoutRun(opts *LogoutOptions) error {
 		if len(candidates) == 1 {
 			hostname = candidates[0]
 		} else {
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.Select{
-				Message: "What account do you want to log out of?",
-				Options: candidates,
-			}, &hostname)
-
+			selected, err := opts.Prompter.Select(
+				"What account to you want to log out of?", "", candidates)
 			if err != nil {
 				return fmt.Errorf("could not prompt: %w", err)
 			}
+			hostname = candidates[selected]
 		}
 	} else {
 		var found bool

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -5,15 +5,12 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/authflow"
 	"github.com/cli/cli/v2/internal/config"
-	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/cli/cli/v2/pkg/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +18,7 @@ type RefreshOptions struct {
 	IO         *iostreams.IOStreams
 	Config     func() (config.Config, error)
 	httpClient *http.Client
-	Prompter   prompter.Prompter
+	Prompter   shared.Prompt
 
 	MainExecutable string
 
@@ -97,15 +94,11 @@ func refreshRun(opts *RefreshOptions) error {
 		if len(candidates) == 1 {
 			hostname = candidates[0]
 		} else {
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err := prompt.SurveyAskOne(&survey.Select{
-				Message: "What account do you want to refresh auth for?",
-				Options: candidates,
-			}, &hostname)
-
+			selected, err := opts.Prompter.Select("What account do you want to refresh auth for?", "", candidates)
 			if err != nil {
 				return fmt.Errorf("could not prompt: %w", err)
 			}
+			hostname = candidates[selected]
 		}
 	} else {
 		var found bool

--- a/pkg/cmd/auth/shared/git_credential.go
+++ b/pkg/cmd/auth/shared/git_credential.go
@@ -10,14 +10,13 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/ghinstance"
-	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/internal/run"
 	"github.com/google/shlex"
 )
 
 type GitCredentialFlow struct {
 	Executable string
-	Prompter   prompter.Prompter
+	Prompter   Prompt
 
 	shouldSetup bool
 	helper      string

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/authflow"
 	"github.com/cli/cli/v2/internal/ghinstance"
-	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmd/ssh-key/add"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/ssh"
@@ -34,7 +33,7 @@ type LoginOptions struct {
 	Scopes      []string
 	Executable  string
 	GitProtocol string
-	Prompter    prompter.Prompter
+	Prompter    Prompt
 
 	sshContext ssh.Context
 }

--- a/pkg/cmd/auth/shared/prompt.go
+++ b/pkg/cmd/auth/shared/prompt.go
@@ -1,0 +1,10 @@
+package shared
+
+type Prompt interface {
+	Select(string, string, []string) (int, error)
+	Confirm(string, bool) (bool, error)
+	InputHostname() (string, error)
+	AuthToken() (string, error)
+	Input(string, string) (string, error)
+	Password(string) (string, error)
+}


### PR DESCRIPTION
Part of #6255

Requires #6251

This PR finishes porting `gh auth` commands to use the new `Prompter`. I did extensive manual testing this time ^_^()
