### PR TITLE
Fix deleting remote branches with `#` in their name

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -447,6 +448,6 @@ func PullRequestReady(client *Client, repo ghrepo.Interface, pr *PullRequest) er
 }
 
 func BranchDeleteRemote(client *Client, repo ghrepo.Interface, branch string) error {
-	path := fmt.Sprintf("repos/%s/%s/git/refs/heads/%s", repo.RepoOwner(), repo.RepoName(), branch)
+	path := fmt.Sprintf("repos/%s/%s/git/refs/heads/%s", repo.RepoOwner(), repo.RepoName(), url.PathEscape(branch))
 	return client.REST(repo.RepoHost(), "DELETE", path, nil, nil)
 }

--- a/pkg/cmd/workflow/disable/disable_test.go
+++ b/pkg/cmd/workflow/disable/disable_test.go
@@ -133,7 +133,7 @@ func TestDisableRun(t *testing.T) {
 			tty: true,
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a workflow"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a%20workflow"),
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
@@ -158,7 +158,7 @@ func TestDisableRun(t *testing.T) {
 			tty: true,
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/another workflow"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/another%20workflow"),
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
@@ -217,7 +217,7 @@ func TestDisableRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a workflow"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a%20workflow"),
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
@@ -242,7 +242,7 @@ func TestDisableRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/another workflow"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/another%20workflow"),
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),

--- a/pkg/cmd/workflow/enable/enable_test.go
+++ b/pkg/cmd/workflow/enable/enable_test.go
@@ -133,7 +133,7 @@ func TestEnableRun(t *testing.T) {
 			tty: true,
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/terrible workflow"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/terrible%20workflow"),
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
@@ -159,7 +159,7 @@ func TestEnableRun(t *testing.T) {
 			tty: true,
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a disabled workflow"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a%20disabled%20workflow"),
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
@@ -188,7 +188,7 @@ func TestEnableRun(t *testing.T) {
 			tty: true,
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a disabled inactivity workflow"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a%20disabled%20inactivity%20workflow"),
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
@@ -243,7 +243,7 @@ func TestEnableRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/terrible workflow"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/terrible%20workflow"),
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
@@ -268,7 +268,7 @@ func TestEnableRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a disabled inactivity workflow"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a%20disabled%20inactivity%20workflow"),
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),
@@ -292,7 +292,7 @@ func TestEnableRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a disabled workflow"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/a%20disabled%20workflow"),
 					httpmock.StatusStringResponse(404, "not found"))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows"),

--- a/pkg/cmd/workflow/shared/shared.go
+++ b/pkg/cmd/workflow/shared/shared.go
@@ -139,7 +139,7 @@ func getWorkflowByID(client *api.Client, repo ghrepo.Interface, ID string) (*Wor
 	var workflow Workflow
 
 	err := client.REST(repo.RepoHost(), "GET",
-		fmt.Sprintf("repos/%s/actions/workflows/%s", ghrepo.FullName(repo), ID),
+		fmt.Sprintf("repos/%s/actions/workflows/%s", ghrepo.FullName(repo), url.PathEscape(ID)),
 		nil, &workflow)
 
 	if err != nil {

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -29,7 +29,7 @@ func REST(method, p string) Matcher {
 		if !strings.EqualFold(req.Method, method) {
 			return false
 		}
-		return req.URL.Path == "/"+p
+		return req.URL.EscapedPath() == "/"+p
 	}
 }
 


### PR DESCRIPTION
Path-escaping the branch parameter ensures that `#` isn't interpreted as a URL fragment.

Fixes https://github.com/cli/cli/issues/6215