### PR TITLE
Properly set stdout and stdin when running editor command

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -28,7 +28,7 @@ type CreateOptions struct {
 	Config     func() (config.Config, error)
 	HttpClient func() (*http.Client, error)
 	BaseRepo   func() (ghrepo.Interface, error)
-	Edit       func(string, string, string, io.Reader, io.Writer, io.Writer) (string, error)
+	Edit       func(string, string, string, surveyext.FileReader, surveyext.FileWriter, io.Writer) (string, error)
 
 	TagName      string
 	Target       string

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/prompt"
+	"github.com/cli/cli/v2/pkg/surveyext"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1046,7 +1047,7 @@ func Test_createRun_interactive(t *testing.T) {
 			return config.NewBlankConfig(), nil
 		}
 
-		tt.opts.Edit = func(_, _, val string, _ io.Reader, _, _ io.Writer) (string, error) {
+		tt.opts.Edit = func(_, _, val string, _ surveyext.FileReader, _ surveyext.FileWriter, _ io.Writer) (string, error) {
 			return val, nil
 		}
 


### PR DESCRIPTION
This was a regression stemming from https://github.com/cli/cli/pull/6200. Introducing the `fileReader` and `fileWriter` interfaces interestingly enough causes [`cmd.Run`](https://pkg.go.dev/os/exec#Cmd.Run) to behave differently. When the values for `stdin` and `stdout` are not of type `*os.File` they go down different code paths see: [stdin()](https://cs.opensource.google/go/go/+/refs/tags/go1.19.1:src/os/exec/exec.go;drc=c7a0b156592ca15612315fc71f4e287268643bfd;l=340), [stdout()](https://cs.opensource.google/go/go/+/refs/tags/go1.19.1:src/os/exec/exec.go;drc=c7a0b156592ca15612315fc71f4e287268643bfd;l=374). This alternative codepath uses [os.Pipe()](https://cs.opensource.google/go/go/+/refs/tags/go1.19.1:src/os/pipe2_unix.go;drc=c7a0b156592ca15612315fc71f4e287268643bfd;l=13) which causes issues for `neovim` because it no longer properly detects features, such as columns, of `stdout` resulting in weird state. 


Surprisingly this change didn't cause other invocations of editor to break. I have no idea why that is and was unable to determine the cause in my sleuthing.

Fixes https://github.com/cli/cli/issues/6231