### PR TITLE
Revert "Revert "Added functionality for org-level codespaces secrets""

### DIFF
--- a/pkg/cmd/secret/delete/delete.go
+++ b/pkg/cmd/secret/delete/delete.go
@@ -41,7 +41,7 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 			Delete a secret on one of the following levels:
 			- repository (default): available to Actions runs or Dependabot in a repository
 			- environment: available to Actions runs for a deployment environment in a repository
-			- organization: available to Actions runs or Dependabot within an organization
+			- organization: available to Actions runs, Dependabot, or Codespaces within an organization
 			- user: available to Codespaces for your user
 		`),
 		Args: cobra.ExactArgs(1),

--- a/pkg/cmd/secret/delete/delete_test.go
+++ b/pkg/cmd/secret/delete/delete_test.go
@@ -73,6 +73,15 @@ func TestNewCmdDelete(t *testing.T) {
 				Application: "Dependabot",
 			},
 		},
+		{
+			name: "Codespaces org",
+			cli:  "cool --app codespaces --org UmbrellaCorporation",
+			wants: DeleteOptions{
+				SecretName:  "cool",
+				OrgName:     "UmbrellaCorporation",
+				Application: "Codespaces",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -218,6 +227,14 @@ func Test_removeRun_org(t *testing.T) {
 				OrgName:     "UmbrellaCorporation",
 			},
 			wantPath: "orgs/UmbrellaCorporation/dependabot/secrets/tVirus",
+		},
+		{
+			name: "Codespaces org",
+			opts: &DeleteOptions{
+				Application: "codespaces",
+				OrgName:     "UmbrellaCorporation",
+			},
+			wantPath: "orgs/UmbrellaCorporation/codespaces/secrets/tVirus",
 		},
 	}
 

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -46,7 +46,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			List secrets on one of the following levels:
 			- repository (default): available to Actions runs or Dependabot in a repository
 			- environment: available to Actions runs for a deployment environment in a repository
-			- organization: available to Actions runs or Dependabot within an organization
+			- organization: available to Actions runs, Dependabot, or Codespaces within an organization
 			- user: available to Codespaces for your user
 		`),
 		Aliases: []string{"ls"},

--- a/pkg/cmd/secret/secret.go
+++ b/pkg/cmd/secret/secret.go
@@ -15,7 +15,7 @@ func NewCmdSecret(f *cmdutil.Factory) *cobra.Command {
 		Short: "Manage GitHub secrets",
 		Long: heredoc.Doc(`
 			Secrets can be set at the repository, or organization level for use in
-			GitHub Actions or Dependabot. User and repository secrets can be set for
+			GitHub Actions or Dependabot. User, organization, and repository secrets can be set for
 			use in GitHub Codespaces. Environment secrets can be set for use in
 			GitHub Actions. Run "gh help secret set" to learn how to get started.
 `),

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -58,7 +58,7 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 			Set a value for a secret on one of the following levels:
 			- repository (default): available to Actions runs or Dependabot in a repository
 			- environment: available to Actions runs for a deployment environment in a repository
-			- organization: available to Actions runs or Dependabot within an organization
+			- organization: available to Actions runs, Dependabot, or Codespaces within an organization
 			- user: available to Codespaces for your user
 
 			Organization and user secrets can optionally be restricted to only be available to

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -165,6 +165,18 @@ func TestNewCmdSet(t *testing.T) {
 				Application:     "Dependabot",
 			},
 		},
+		{
+			name: "Codespaces org",
+			cli:  `random_secret -ocoolOrg -b"random value" -vselected -r"coolRepo,cli/cli" -aCodespaces`,
+			wants: SetOptions{
+				SecretName:      "random_secret",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"coolRepo", "cli/cli"},
+				Body:            "random value",
+				OrgName:         "coolOrg",
+				Application:     "Codespaces",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/secret/shared/shared.go
+++ b/pkg/cmd/secret/shared/shared.go
@@ -85,7 +85,7 @@ func IsSupportedSecretEntity(app App, entity SecretEntity) bool {
 	case Actions:
 		return entity == Repository || entity == Organization || entity == Environment
 	case Codespaces:
-		return entity == User || entity == Repository
+		return entity == User || entity == Organization || entity == Repository
 	case Dependabot:
 		return entity == Repository || entity == Organization
 	default:

--- a/pkg/cmd/secret/shared/shared_test.go
+++ b/pkg/cmd/secret/shared/shared_test.go
@@ -167,9 +167,9 @@ func TestIsSupportedSecretEntity(t *testing.T) {
 			supportedEntities: []SecretEntity{
 				User,
 				Repository,
+				Organization,
 			},
 			unsupportedEntities: []SecretEntity{
-				Organization,
 				Environment,
 				Unknown,
 			},


### PR DESCRIPTION
Fixes https://github.com/github/codespaces/issues/9598

This PR provides support for listing, setting, and deleting org codespaces secrets. The API for this has already been implemented - https://github.com/github/codespaces/issues/7664.

Re-adds https://github.com/cli/cli/pull/6171 which has now been shipped.