### PR TITLE
Stub out time.Now for search tests

### DIFF
--- a/pkg/cmd/search/repos/repos_test.go
+++ b/pkg/cmd/search/repos/repos_test.go
@@ -149,6 +149,8 @@ func TestNewCmdRepos(t *testing.T) {
 }
 
 func TestReposRun(t *testing.T) {
+	var now = time.Date(2022, 2, 28, 12, 30, 0, 0, time.UTC)
+	var updatedAt = time.Date(2021, 2, 28, 12, 30, 0, 0, time.UTC)
 	var query = search.Query{
 		Keywords: []string{"cli"},
 		Kind:     "repositories",
@@ -158,7 +160,6 @@ func TestReposRun(t *testing.T) {
 			Topic: []string{"golang"},
 		},
 	}
-	var updatedAt = time.Date(2021, 2, 28, 12, 30, 0, 0, time.UTC)
 	tests := []struct {
 		errMsg     string
 		name       string
@@ -270,6 +271,7 @@ func TestReposRun(t *testing.T) {
 		ios.SetStdoutTTY(tt.tty)
 		ios.SetStderrTTY(tt.tty)
 		tt.opts.IO = ios
+		tt.opts.Now = now
 		t.Run(tt.name, func(t *testing.T) {
 			err := reposRun(tt.opts)
 			if tt.wantErr {

--- a/pkg/cmd/search/shared/shared.go
+++ b/pkg/cmd/search/shared/shared.go
@@ -31,6 +31,7 @@ type IssuesOptions struct {
 	Entity   EntityType
 	Exporter cmdutil.Exporter
 	IO       *iostreams.IOStreams
+	Now      time.Time
 	Query    search.Query
 	Searcher search.Searcher
 	WebMode  bool
@@ -88,10 +89,13 @@ func SearchIssues(opts *IssuesOptions) error {
 		return cmdutil.NewNoResultsError(msg)
 	}
 
-	return displayIssueResults(io, opts.Entity, result)
+	return displayIssueResults(io, opts.Now, opts.Entity, result)
 }
 
-func displayIssueResults(io *iostreams.IOStreams, et EntityType, results search.IssuesResult) error {
+func displayIssueResults(io *iostreams.IOStreams, now time.Time, et EntityType, results search.IssuesResult) error {
+	if now.IsZero() {
+		now = time.Now()
+	}
 	cs := io.ColorScheme()
 	tp := utils.NewTablePrinter(io)
 	for _, issue := range results.Items {
@@ -120,7 +124,7 @@ func displayIssueResults(io *iostreams.IOStreams, et EntityType, results search.
 		tp.AddField(text.RemoveExcessiveWhitespace(issue.Title), nil, nil)
 		tp.AddField(listIssueLabels(&issue, cs, tp.IsTTY()), nil, nil)
 		if tp.IsTTY() {
-			tp.AddField(text.FuzzyAgo(time.Now(), issue.UpdatedAt), nil, cs.Gray)
+			tp.AddField(text.FuzzyAgo(now, issue.UpdatedAt), nil, cs.Gray)
 		} else {
 			tp.AddField(issue.UpdatedAt.String(), nil, nil)
 		}

--- a/pkg/cmd/search/shared/shared_test.go
+++ b/pkg/cmd/search/shared/shared_test.go
@@ -23,7 +23,9 @@ func TestSearcher(t *testing.T) {
 }
 
 func TestSearchIssues(t *testing.T) {
-	query := search.Query{
+	var now = time.Date(2022, 2, 28, 12, 30, 0, 0, time.UTC)
+	var updatedAt = time.Date(2021, 2, 28, 12, 30, 0, 0, time.UTC)
+	var query = search.Query{
 		Keywords: []string{"keyword"},
 		Kind:     "issues",
 		Limit:    30,
@@ -33,8 +35,6 @@ func TestSearchIssues(t *testing.T) {
 			Is:       []string{"public", "locked"},
 		},
 	}
-
-	var updatedAt = time.Date(2021, 2, 28, 12, 30, 0, 0, time.UTC)
 	tests := []struct {
 		errMsg     string
 		name       string
@@ -193,6 +193,7 @@ func TestSearchIssues(t *testing.T) {
 		ios.SetStdoutTTY(tt.tty)
 		ios.SetStderrTTY(tt.tty)
 		tt.opts.IO = ios
+		tt.opts.Now = now
 		t.Run(tt.name, func(t *testing.T) {
 			err := SearchIssues(tt.opts)
 			if tt.wantErr {


### PR DESCRIPTION
This PR adds the ability to inject a time into displaying search results so that they can be tested independent of the current time.

Fixes https://github.com/cli/cli/issues/6259