### PR TITLE
Escape liquid tags in site docs

### DIFF
--- a/internal/docs/markdown.go
+++ b/internal/docs/markdown.go
@@ -85,6 +85,7 @@ func GenMarkdown(cmd *cobra.Command, w io.Writer) error {
 
 // GenMarkdownCustom creates custom markdown output.
 func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string) string) error {
+	fmt.Fprint(w, "{% raw %}")
 	fmt.Fprintf(w, "## %s\n\n", cmd.CommandPath())
 
 	hasLong := cmd.Long != ""
@@ -112,6 +113,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	if err := printOptions(w, cmd); err != nil {
 		return err
 	}
+	fmt.Fprint(w, "{% endraw %}\n")
 
 	if len(cmd.Example) > 0 {
 		fmt.Fprint(w, "### Examples\n\n{% highlight bash %}{% raw %}\n")


### PR DESCRIPTION
It is good practice to wrap all dynamic content in `{% raw %}..{% endraw %}` Liquid tags so that no syntax within can mistakenly get interpreted as Liquid tags. Fixes rendering of `gh auth login` help page.

Fixes https://github.com/cli/cli/issues/6149