### PR TITLE
Remove need for uploaded SSH keys in `cs ssh` and `cs cp`

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -13,7 +13,6 @@ package api
 // - github.GetUser(github.Client)
 // - github.GetRepository(Client)
 // - github.ReadFile(Client, nwo, branch, path) // was GetCodespaceRepositoryContents
-// - github.AuthorizedKeys(Client, user)
 // - codespaces.Create(Client, user, repo, sku, branch, location)
 // - codespaces.Delete(Client, user, token, name)
 // - codespaces.Get(Client, token, owner, name)
@@ -1058,44 +1057,6 @@ func (a *API) GetCodespaceRepositoryContents(ctx context.Context, codespace *Cod
 	}
 
 	return decoded, nil
-}
-
-// AuthorizedKeys returns the public keys (in ~/.ssh/authorized_keys
-// format) registered by the specified GitHub user.
-func (a *API) AuthorizedKeys(ctx context.Context, user string) ([]string, error) {
-	url := fmt.Sprintf("%s/%s.keys", a.githubServer, user)
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := a.do(ctx, req, "/user.keys")
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returned %s", resp.Status)
-	}
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("error reading response body: %w", err)
-	}
-
-	allKeys := string(b)
-
-	var splitKeys []string
-	for _, key := range strings.Split(allKeys, "\n") {
-		key = strings.TrimSpace(key)
-		if key == "" {
-			continue
-		}
-
-		splitKeys = append(splitKeys, key)
-	}
-
-	return splitKeys, nil
 }
 
 // do executes the given request and returns the response. It creates an

--- a/pkg/cmd/codespace/code_test.go
+++ b/pkg/cmd/codespace/code_test.go
@@ -101,7 +101,6 @@ func testingCodeApp() *App {
 }
 
 func testCodeApiMock() *apiClientMock {
-	user := &api.User{Login: "monalisa"}
 	testingCodespace := &api.Codespace{
 		Name:   "monalisa-cli-cli-abcdef",
 		WebURL: "https://monalisa-cli-cli-abcdef.github.dev",
@@ -117,12 +116,6 @@ func testCodeApiMock() *apiClientMock {
 				return disabledCodespace, nil
 			}
 			return testingCodespace, nil
-		},
-		GetUserFunc: func(_ context.Context) (*api.User, error) {
-			return user, nil
-		},
-		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]string, error) {
-			return []string{}, nil
 		},
 	}
 }

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestDelete(t *testing.T) {
-	user := &api.User{Login: "hubot"}
 	now, _ := time.Parse(time.RFC3339, "2021-09-22T00:00:00Z")
 	daysAgo := func(n int) string {
 		return now.Add(time.Hour * -time.Duration(24*n)).Format(time.RFC3339)
@@ -207,9 +206,6 @@ func TestDelete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			apiMock := &apiClientMock{
-				GetUserFunc: func(_ context.Context) (*api.User, error) {
-					return user, nil
-				},
 				DeleteCodespaceFunc: func(_ context.Context, name string, orgName string, userName string) error {
 					if tt.deleteErr != nil {
 						return tt.deleteErr

--- a/pkg/cmd/codespace/logs_test.go
+++ b/pkg/cmd/codespace/logs_test.go
@@ -21,7 +21,6 @@ func TestPendingOperationDisallowsLogs(t *testing.T) {
 }
 
 func testingLogsApp() *App {
-	user := &api.User{Login: "monalisa"}
 	disabledCodespace := &api.Codespace{
 		Name:                           "disabledCodespace",
 		PendingOperation:               true,
@@ -33,12 +32,6 @@ func testingLogsApp() *App {
 				return disabledCodespace, nil
 			}
 			return nil, nil
-		},
-		GetUserFunc: func(_ context.Context) (*api.User, error) {
-			return user, nil
-		},
-		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]string, error) {
-			return []string{}, nil
 		},
 	}
 

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -16,9 +16,6 @@ import (
 //
 // 		// make and configure a mocked apiClient
 // 		mockedapiClient := &apiClientMock{
-// 			AuthorizedKeysFunc: func(ctx context.Context, user string) ([]string, error) {
-// 				panic("mock out the AuthorizedKeys method")
-// 			},
 // 			CreateCodespaceFunc: func(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error) {
 // 				panic("mock out the CreateCodespace method")
 // 			},
@@ -49,9 +46,6 @@ import (
 // 			GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 // 				panic("mock out the GetRepository method")
 // 			},
-// 			GetUserFunc: func(ctx context.Context) (*api.User, error) {
-// 				panic("mock out the GetUser method")
-// 			},
 // 			ListCodespacesFunc: func(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error) {
 // 				panic("mock out the ListCodespaces method")
 // 			},
@@ -71,9 +65,6 @@ import (
 //
 // 	}
 type apiClientMock struct {
-	// AuthorizedKeysFunc mocks the AuthorizedKeys method.
-	AuthorizedKeysFunc func(ctx context.Context, user string) ([]string, error)
-
 	// CreateCodespaceFunc mocks the CreateCodespace method.
 	CreateCodespaceFunc func(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error)
 
@@ -104,9 +95,6 @@ type apiClientMock struct {
 	// GetRepositoryFunc mocks the GetRepository method.
 	GetRepositoryFunc func(ctx context.Context, nwo string) (*api.Repository, error)
 
-	// GetUserFunc mocks the GetUser method.
-	GetUserFunc func(ctx context.Context) (*api.User, error)
-
 	// ListCodespacesFunc mocks the ListCodespaces method.
 	ListCodespacesFunc func(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error)
 
@@ -121,13 +109,6 @@ type apiClientMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// AuthorizedKeys holds details about calls to the AuthorizedKeys method.
-		AuthorizedKeys []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// User is the user argument value.
-			User string
-		}
 		// CreateCodespace holds details about calls to the CreateCodespace method.
 		CreateCodespace []struct {
 			// Ctx is the ctx argument value.
@@ -218,11 +199,6 @@ type apiClientMock struct {
 			// Nwo is the nwo argument value.
 			Nwo string
 		}
-		// GetUser holds details about calls to the GetUser method.
-		GetUser []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-		}
 		// ListCodespaces holds details about calls to the ListCodespaces method.
 		ListCodespaces []struct {
 			// Ctx is the ctx argument value.
@@ -260,7 +236,6 @@ type apiClientMock struct {
 			UserName string
 		}
 	}
-	lockAuthorizedKeys                 sync.RWMutex
 	lockCreateCodespace                sync.RWMutex
 	lockDeleteCodespace                sync.RWMutex
 	lockEditCodespace                  sync.RWMutex
@@ -271,46 +246,10 @@ type apiClientMock struct {
 	lockGetCodespacesMachines          sync.RWMutex
 	lockGetOrgMemberCodespace          sync.RWMutex
 	lockGetRepository                  sync.RWMutex
-	lockGetUser                        sync.RWMutex
 	lockListCodespaces                 sync.RWMutex
 	lockListDevContainers              sync.RWMutex
 	lockStartCodespace                 sync.RWMutex
 	lockStopCodespace                  sync.RWMutex
-}
-
-// AuthorizedKeys calls AuthorizedKeysFunc.
-func (mock *apiClientMock) AuthorizedKeys(ctx context.Context, user string) ([]string, error) {
-	if mock.AuthorizedKeysFunc == nil {
-		panic("apiClientMock.AuthorizedKeysFunc: method is nil but apiClient.AuthorizedKeys was just called")
-	}
-	callInfo := struct {
-		Ctx  context.Context
-		User string
-	}{
-		Ctx:  ctx,
-		User: user,
-	}
-	mock.lockAuthorizedKeys.Lock()
-	mock.calls.AuthorizedKeys = append(mock.calls.AuthorizedKeys, callInfo)
-	mock.lockAuthorizedKeys.Unlock()
-	return mock.AuthorizedKeysFunc(ctx, user)
-}
-
-// AuthorizedKeysCalls gets all the calls that were made to AuthorizedKeys.
-// Check the length with:
-//     len(mockedapiClient.AuthorizedKeysCalls())
-func (mock *apiClientMock) AuthorizedKeysCalls() []struct {
-	Ctx  context.Context
-	User string
-} {
-	var calls []struct {
-		Ctx  context.Context
-		User string
-	}
-	mock.lockAuthorizedKeys.RLock()
-	calls = mock.calls.AuthorizedKeys
-	mock.lockAuthorizedKeys.RUnlock()
-	return calls
 }
 
 // CreateCodespace calls CreateCodespaceFunc.
@@ -700,37 +639,6 @@ func (mock *apiClientMock) GetRepositoryCalls() []struct {
 	mock.lockGetRepository.RLock()
 	calls = mock.calls.GetRepository
 	mock.lockGetRepository.RUnlock()
-	return calls
-}
-
-// GetUser calls GetUserFunc.
-func (mock *apiClientMock) GetUser(ctx context.Context) (*api.User, error) {
-	if mock.GetUserFunc == nil {
-		panic("apiClientMock.GetUserFunc: method is nil but apiClient.GetUser was just called")
-	}
-	callInfo := struct {
-		Ctx context.Context
-	}{
-		Ctx: ctx,
-	}
-	mock.lockGetUser.Lock()
-	mock.calls.GetUser = append(mock.calls.GetUser, callInfo)
-	mock.lockGetUser.Unlock()
-	return mock.GetUserFunc(ctx)
-}
-
-// GetUserCalls gets all the calls that were made to GetUser.
-// Check the length with:
-//     len(mockedapiClient.GetUserCalls())
-func (mock *apiClientMock) GetUserCalls() []struct {
-	Ctx context.Context
-} {
-	var calls []struct {
-		Ctx context.Context
-	}
-	mock.lockGetUser.RLock()
-	calls = mock.calls.GetUser
-	mock.lockGetUser.RUnlock()
 	return calls
 }
 

--- a/pkg/cmd/codespace/ports_test.go
+++ b/pkg/cmd/codespace/ports_test.go
@@ -247,7 +247,6 @@ func TestPendingOperationDisallowsForwardPorts(t *testing.T) {
 }
 
 func testingPortsApp() *App {
-	user := &api.User{Login: "monalisa"}
 	disabledCodespace := &api.Codespace{
 		Name:                           "disabledCodespace",
 		PendingOperation:               true,
@@ -259,12 +258,6 @@ func testingPortsApp() *App {
 				return disabledCodespace, nil
 			}
 			return nil, nil
-		},
-		GetUserFunc: func(_ context.Context) (*api.User, error) {
-			return user, nil
-		},
-		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]string, error) {
-			return []string{}, nil
 		},
 	}
 

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -286,7 +286,7 @@ func selectSSHKeys(
 	}
 
 	// Finally, fall back to generating new automatic keys
-	autoKeyPair, err := setupAutomaticSSHKeys(sshContext)
+	autoKeyPair, err := generateAutomaticSSHKeys(sshContext)
 	if err != nil {
 		return nil, false, fmt.Errorf("generating automatic keypair: %v", err)
 	}
@@ -320,7 +320,7 @@ func automaticSSHKeyPair(sshContext ssh.Context) *ssh.KeyPair {
 	return nil
 }
 
-func setupAutomaticSSHKeys(sshContext ssh.Context) (*ssh.KeyPair, error) {
+func generateAutomaticSSHKeys(sshContext ssh.Context) (*ssh.KeyPair, error) {
 	keyPair := checkAndUpdateOldKeyPair(sshContext)
 	if keyPair != nil {
 		return keyPair, nil

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -277,23 +277,20 @@ func selectSSHKeys(
 		return autoKeyPair, true, nil
 	}
 
-	configKeyPair, err := firstConfiguredKeyPair(ctx, customConfigPath, opts.profile)
-	if err != nil && !errors.Is(err, errKeyFileNotFound) {
-		return nil, false, fmt.Errorf("checking configured keys: %w", err)
-	}
-
-	// Even if there was no error, there may simply be no configured keys, so still check for nil here
-	if configKeyPair != nil {
-		return configKeyPair, true, nil
-	}
-
-	// Finally, fall back to generating new automatic keys
-	autoKeyPair, err := generateAutomaticSSHKeys(sshContext)
+	keyPair, err := firstConfiguredKeyPair(ctx, customConfigPath, opts.profile)
 	if err != nil {
-		return nil, false, fmt.Errorf("generating automatic keypair: %w", err)
+		if !errors.Is(err, errKeyFileNotFound) {
+			return nil, false, fmt.Errorf("checking configured keys: %w", err)
+		}
+
+		// no valid key in ssh config, generate one
+		keyPair, err = generateAutomaticSSHKeys(sshContext)
+		if err != nil {
+			return nil, false, fmt.Errorf("generating automatic keypair: %w", err)
+		}
 	}
 
-	return autoKeyPair, true, nil
+	return keyPair, true, nil
 }
 
 // automaticSSHKeyPair returns the paths to the automatic key pair files, if they both exist

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -277,7 +277,7 @@ func selectSSHKeys(
 
 	configKeyPair, err := firstConfiguredKeyPair(ctx, customConfigPath, opts.profile)
 	if err != nil {
-		return nil, false, fmt.Errorf("checking configured keys: %v", err)
+		return nil, false, fmt.Errorf("checking configured keys: %w", err)
 	}
 
 	// Even if there was no error, there may simply be no configured keys, so still check for nil here
@@ -288,7 +288,7 @@ func selectSSHKeys(
 	// Finally, fall back to generating new automatic keys
 	autoKeyPair, err := setupAutomaticSSHKeys(sshContext)
 	if err != nil {
-		return nil, false, fmt.Errorf("generating automatic keypair: %v", err)
+		return nil, false, fmt.Errorf("generating automatic keypair: %w", err)
 	}
 
 	return autoKeyPair, true, nil

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -491,12 +491,6 @@ func (a *App) printOpenSSHConfig(ctx context.Context, opts sshOptions) (err erro
 		close(sshUsers)
 	}()
 
-	// While the above fetches are running, ensure that the user has keys installed.
-	// That lets us report a more useful error message if they don't.
-	if err = checkAuthorizedKeys(ctx, a.apiClient); err != nil {
-		return err
-	}
-
 	t, err := template.New("ssh_config").Parse(heredoc.Doc(`
 		Host cs.{{.Name}}.{{.EscapedRef}}
 			User {{.SSHUser}}

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -276,6 +276,7 @@ func selectSSHKeys(
 	return setupAutomaticSSHKeys(sshContext)
 }
 
+// automaticSSHKeyPair returns the paths to the automatic key pair files, if they both exist
 func automaticSSHKeyPair(sshContext ssh.Context) *ssh.KeyPair {
 	publicKeys, err := sshContext.LocalPublicKeys()
 	if err != nil {

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -206,7 +205,7 @@ func TestSelectSSHKeys(t *testing.T) {
 		sshContext := ssh.Context{ConfigDir: sshDir}
 
 		for _, file := range tt.sshDirFiles {
-			f, err := os.Create(path.Join(sshDir, file))
+			f, err := os.Create(filepath.Join(sshDir, file))
 			if err != nil {
 				t.Errorf("Failed to create test ssh dir file %q: %v", file, err)
 			}
@@ -214,11 +213,11 @@ func TestSelectSSHKeys(t *testing.T) {
 		}
 
 		if tt.sshConfigKeys != nil {
-			configPath := path.Join(sshDir, "test-config")
+			configPath := filepath.Join(sshDir, "test-config")
 
 			configContent := ""
 			for _, key := range tt.sshConfigKeys {
-				configContent += fmt.Sprintf("IdentityFile %s\n", path.Join(sshDir, key))
+				configContent += fmt.Sprintf("IdentityFile %s\n", filepath.Join(sshDir, key))
 			}
 
 			err := os.WriteFile(configPath, []byte(configContent), 0666)
@@ -255,8 +254,8 @@ func TestSelectSSHKeys(t *testing.T) {
 		}
 
 		// Strip the dir (sshDir) from the gotKeyPair paths so that they match wantKeyPair (which doesn't know the directory)
-		gotKeyPair.PrivateKeyPath = path.Base(gotKeyPair.PrivateKeyPath)
-		gotKeyPair.PublicKeyPath = path.Base(gotKeyPair.PublicKeyPath)
+		gotKeyPair.PrivateKeyPath = filepath.Base(gotKeyPair.PrivateKeyPath)
+		gotKeyPair.PublicKeyPath = filepath.Base(gotKeyPair.PublicKeyPath)
 
 		if fmt.Sprintf("%v", gotKeyPair) != fmt.Sprintf("%v", tt.wantKeyPair) {
 			t.Errorf("Want selectSSHKeys result to be %v, got %v", tt.wantKeyPair, gotKeyPair)

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -125,171 +125,132 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 	}
 }
 
-func TestUseAutomaticSSHKeysIdentityFileArg(t *testing.T) {
+func TestSelectSSHKeys(t *testing.T) {
 	tests := []struct {
-		identityFileArg string
-		wantResult      bool
+		sshDirFiles   []string
+		sshConfigKeys []string
+		sshArgs       []string
+		profileOpt    string
+		wantKeyPair   *ssh.KeyPair
 	}{
-		{"custom-private-key", false},
-		{automaticPrivateKeyName, true},
-		{"", false}, // Edge case check for missing arg value
-	}
-
-	for _, tt := range tests {
-		t.Logf("%v", tt.identityFileArg)
-
-		args := []string{"-i"}
-		if tt.identityFileArg != "" {
-			args = append(args, tt.identityFileArg)
-		}
-
-		result, err := useAutomaticSSHKeys(context.Background(), ssh.Context{}, nil, args, sshOptions{})
-
-		if err != nil {
-			t.Errorf("Unexpected error from useAutomaticSSHKeys: %v", err)
-		}
-
-		if result != tt.wantResult {
-			t.Errorf("Want useAutomaticSSHKeys to be %v, got %v", tt.wantResult, result)
-		}
-	}
-}
-
-func TestUseAutomaticSSHKeysWithAutoKeysExist(t *testing.T) {
-	dir := t.TempDir()
-
-	f, err := os.Create(path.Join(dir, automaticPrivateKeyName))
-	if err != nil {
-		t.Errorf("Failed to create test private key: %v", err)
-	}
-	f.Close()
-
-	f, err = os.Create(path.Join(dir, automaticPrivateKeyName+".pub"))
-	if err != nil {
-		t.Errorf("Failed to create test public key: %v", err)
-	}
-	f.Close()
-
-	sshContext := ssh.Context{
-		ConfigDir: dir,
-	}
-	result, err := useAutomaticSSHKeys(context.Background(), sshContext, nil, nil, sshOptions{})
-
-	if err != nil {
-		t.Errorf("Unexpected error from useAutomaticSSHKeys: %v", err)
-	}
-
-	if result != true {
-		t.Errorf("Want useAutomaticSSHKeys to be true, got false")
-	}
-}
-
-func TestHasUploadedPublicKeyForConfig(t *testing.T) {
-	type testLocalKeyPair struct {
-		privateKeyFile   string
-		publicKeyContent string
-	}
-
-	tests := []struct {
-		apiAuthorizedPublicKeys []string
-		localKeyPairs           []testLocalKeyPair
-		wantResult              bool
-	}{
-		// Failure tests
+		// -i tests
 		{
-			// No API keys and no local keys
-			wantResult: false,
+			sshArgs:     []string{"-i", "custom-private-key"},
+			wantKeyPair: &ssh.KeyPair{PrivateKeyPath: "custom-private-key", PublicKeyPath: "custom-private-key.pub"},
 		},
 		{
-			// Has API keys, but no local keys
-			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key"},
-			wantResult:              false,
+			sshArgs:     []string{"-i", automaticPrivateKeyName},
+			wantKeyPair: &ssh.KeyPair{PrivateKeyPath: automaticPrivateKeyName, PublicKeyPath: automaticPrivateKeyName + ".pub"},
 		},
 		{
-			// No API keys, but has local keys
-			localKeyPairs: []testLocalKeyPair{{"keyfile", "ssh-rsa test-key"}},
-			wantResult:    false,
-		},
-		{
-			// API keys and local keys, but not matching
-			apiAuthorizedPublicKeys: []string{"ssh-rsa test-api-key"},
-			localKeyPairs:           []testLocalKeyPair{{"keyfile", "ssh-rsa test-local-key"}},
-			wantResult:              false,
+			// Edge case check for missing arg value
+			sshArgs: []string{"-i"},
 		},
 
-		// Successful tests
+		// Auto key exists tests
 		{
-			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key"},
-			localKeyPairs:           []testLocalKeyPair{{"keyfile", "ssh-rsa test-key"}},
-			wantResult:              true,
+			sshDirFiles: []string{automaticPrivateKeyName, automaticPrivateKeyName + ".pub"},
+			wantKeyPair: &ssh.KeyPair{PrivateKeyPath: automaticPrivateKeyName, PublicKeyPath: automaticPrivateKeyName + ".pub"},
 		},
 		{
-			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key-1", "ssh-rsa test-key-2"},
-			localKeyPairs:           []testLocalKeyPair{{"keyfile1", "ssh-rsa test-key-1"}},
-			wantResult:              true,
-		},
-		{
-			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key-1"},
-			localKeyPairs:           []testLocalKeyPair{{"keyfile1", "ssh-rsa test-key-1"}, {"keyfile2", "ssh-rsa test-key-2"}},
-			wantResult:              true,
-		},
-		{
-			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key-1", "ssh-rsa test-key-2"},
-			localKeyPairs:           []testLocalKeyPair{{"keyfile3", "ssh-rsa test-key-3"}, {"keyfile2", "ssh-rsa test-key-2"}},
-			wantResult:              true,
+			sshDirFiles: []string{automaticPrivateKeyName, automaticPrivateKeyName + ".pub", "custom-private-key", "custom-private-key.pub"},
+			wantKeyPair: &ssh.KeyPair{PrivateKeyPath: automaticPrivateKeyName, PublicKeyPath: automaticPrivateKeyName + ".pub"},
 		},
 
-		// Extra case - local key contain comments
+		// SSH config tests
 		{
-			apiAuthorizedPublicKeys: []string{"ssh-rsa test-key-1", "ssh-rsa test-key"},
-			localKeyPairs:           []testLocalKeyPair{{"keyfile3", "ssh-rsa test-key a comment on the key"}},
-			wantResult:              true,
+			sshDirFiles:   []string{"custom-private-key", "custom-private-key.pub"},
+			sshConfigKeys: []string{"custom-private-key"},
+			wantKeyPair:   &ssh.KeyPair{PrivateKeyPath: "custom-private-key", PublicKeyPath: "custom-private-key.pub"},
+		},
+		{
+			// 2 pairs, but only 1 is configured
+			sshDirFiles:   []string{"custom-private-key", "custom-private-key.pub", "custom-private-key-2", "custom-private-key-2.pub"},
+			sshConfigKeys: []string{"custom-private-key-2"},
+			wantKeyPair:   &ssh.KeyPair{PrivateKeyPath: "custom-private-key-2", PublicKeyPath: "custom-private-key-2.pub"},
+		},
+		{
+			// 2 pairs, but only 1 has both public and private
+			sshDirFiles:   []string{"custom-private-key", "custom-private-key-2", "custom-private-key-2.pub"},
+			sshConfigKeys: []string{"custom-private-key", "custom-private-key-2"},
+			wantKeyPair:   &ssh.KeyPair{PrivateKeyPath: "custom-private-key-2", PublicKeyPath: "custom-private-key-2.pub"},
+		},
+
+		// Automatic key tests
+		{
+			wantKeyPair: &ssh.KeyPair{PrivateKeyPath: automaticPrivateKeyName, PublicKeyPath: automaticPrivateKeyName + ".pub"},
+		},
+		{
+			// Renames old key pair to new
+			sshDirFiles: []string{automaticPrivateKeyNameOld, automaticPrivateKeyNameOld + ".pub"},
+			wantKeyPair: &ssh.KeyPair{PrivateKeyPath: automaticPrivateKeyName, PublicKeyPath: automaticPrivateKeyName + ".pub"},
+		},
+		{
+			// Other key is configured, but doesn't exist
+			sshConfigKeys: []string{"custom-private-key"},
+			wantKeyPair:   &ssh.KeyPair{PrivateKeyPath: automaticPrivateKeyName, PublicKeyPath: automaticPrivateKeyName + ".pub"},
 		},
 	}
 
 	for _, tt := range tests {
-		t.Logf("%+v", tt)
+		sshDir := t.TempDir()
+		sshContext := ssh.Context{ConfigDir: sshDir}
 
-		mockApi := &apiClientMock{
-			GetUserFunc: func(ctx context.Context) (*api.User, error) {
-				return &api.User{Login: "test"}, nil
-			},
-			AuthorizedKeysFunc: func(_ context.Context, _ string) ([]string, error) {
-				return tt.apiAuthorizedPublicKeys, nil
-			},
-		}
-
-		dir := t.TempDir()
-		configPath := path.Join(dir, "test-config")
-
-		configContent := ""
-		for _, pair := range tt.localKeyPairs {
-			configContent += fmt.Sprintf("IdentityFile %s\n", path.Join(dir, pair.privateKeyFile))
-
-			err := os.WriteFile(path.Join(dir, pair.privateKeyFile+".pub"), []byte(pair.publicKeyContent), 0666)
+		for _, file := range tt.sshDirFiles {
+			f, err := os.Create(path.Join(sshDir, file))
 			if err != nil {
-				t.Fatalf("could not write test public key file %v", err)
+				t.Errorf("Failed to create test ssh dir file %q: %v", file, err)
 			}
+			f.Close()
 		}
 
-		err := os.WriteFile(configPath, []byte(configContent), 0666)
+		if tt.sshConfigKeys != nil {
+			configPath := path.Join(sshDir, "test-config")
+
+			configContent := ""
+			for _, key := range tt.sshConfigKeys {
+				configContent += fmt.Sprintf("IdentityFile %s\n", path.Join(sshDir, key))
+			}
+
+			err := os.WriteFile(configPath, []byte(configContent), 0666)
+			if err != nil {
+				t.Fatalf("could not write test config %v", err)
+			}
+
+			tt.sshArgs = append(tt.sshArgs, "-F", configPath)
+		}
+
+		gotKeyPair, err := selectSSHKeys(context.Background(), sshContext, tt.sshArgs, sshOptions{profile: tt.profileOpt})
+
+		if tt.wantKeyPair == nil {
+			if err == nil {
+				t.Errorf("Expected error from selectSSHKeys but got nil")
+			}
+
+			continue
+		}
+
 		if err != nil {
-			t.Fatalf("could not write test config %v", err)
+			t.Errorf("Unexpected error from selectSSHKeys: %v", err)
+			continue
 		}
 
-		result, err := hasUploadedPublicKeyForConfig(context.Background(), mockApi, configPath, "")
-		if err != nil {
-			t.Errorf("Unexpected error from hasUploadedPublicKeyForConfig: %v", err)
+		if gotKeyPair == nil {
+			t.Errorf("Expected non-nil result from selectSSHKeys but got nil")
+			continue
 		}
 
-		if result != tt.wantResult {
-			t.Errorf("Want hasUploadedPublicKeyForConfig to be %v, got %v", tt.wantResult, result)
+		// Strip the dir (sshDir) from the gotKeyPair paths so that they match wantKeyPair (which doesn't know the directory)
+		gotKeyPair.PrivateKeyPath = path.Base(gotKeyPair.PrivateKeyPath)
+		gotKeyPair.PublicKeyPath = path.Base(gotKeyPair.PublicKeyPath)
+
+		if fmt.Sprintf("%v", gotKeyPair) != fmt.Sprintf("%v", tt.wantKeyPair) {
+			t.Errorf("Want selectSSHKeys result to be %v, got %v", tt.wantKeyPair, gotKeyPair)
 		}
 	}
 }
 
 func testingSSHApp() *App {
-	user := &api.User{Login: "monalisa"}
 	disabledCodespace := &api.Codespace{
 		Name:                           "disabledCodespace",
 		PendingOperation:               true,
@@ -301,12 +262,6 @@ func testingSSHApp() *App {
 				return disabledCodespace, nil
 			}
 			return nil, nil
-		},
-		GetUserFunc: func(_ context.Context) (*api.User, error) {
-			return user, nil
-		},
-		AuthorizedKeysFunc: func(_ context.Context, _ string) ([]string, error) {
-			return []string{}, nil
 		},
 	}
 

--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -26,11 +26,11 @@ func TestPendingOperationDisallowsSSH(t *testing.T) {
 	}
 }
 
-func TestAutomaticSSHKeyPairs(t *testing.T) {
+func TestGenerateAutomaticSSHKeys(t *testing.T) {
 	tests := []struct {
-		// These files exist when calling setupAutomaticSSHKeys
+		// These files exist when calling generateAutomaticSSHKeys
 		existingFiles []string
-		// These files should exist after setupAutomaticSSHKeys finishes
+		// These files should exist after generateAutomaticSSHKeys finishes
 		wantFinalFiles []string
 	}{
 		// Basic case: no existing keys, they should be created
@@ -81,12 +81,12 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 			f.Close()
 		}
 
-		keyPair, err := setupAutomaticSSHKeys(sshContext)
+		keyPair, err := generateAutomaticSSHKeys(sshContext)
 		if err != nil {
-			t.Errorf("Unexpected error from setupAutomaticSSHKeys: %v", err)
+			t.Errorf("Unexpected error from generateAutomaticSSHKeys: %v", err)
 		}
 		if keyPair == nil {
-			t.Fatal("Unexpected nil KeyPair from setupAutomaticSSHKeys")
+			t.Fatal("Unexpected nil KeyPair from generateAutomaticSSHKeys")
 		}
 		if !strings.HasSuffix(keyPair.PrivateKeyPath, automaticPrivateKeyName) {
 			t.Errorf("Expected private key path %v, got %v", automaticPrivateKeyName, keyPair.PrivateKeyPath)
@@ -98,7 +98,7 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 		// Check that all the expected files are present
 		for _, file := range tt.wantFinalFiles {
 			if _, err := os.Stat(filepath.Join(dir, file)); err != nil {
-				t.Errorf("Want file %q to exist after setupAutomaticSSHKeys but it doesn't", file)
+				t.Errorf("Want file %q to exist after generateAutomaticSSHKeys but it doesn't", file)
 			}
 		}
 
@@ -118,7 +118,7 @@ func TestAutomaticSSHKeyPairs(t *testing.T) {
 			}
 
 			if !isWantedFile {
-				t.Errorf("Unexpected file %q exists after setupAutomaticSSHKeys", filename)
+				t.Errorf("Unexpected file %q exists after generateAutomaticSSHKeys", filename)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/cli/cli/issues/5601

For historic and back-compat reasons, `cs ssh` relies on the user to upload ssh keys to their GitHub profile in order for the ssh connection to work. More recently, we added support for an automatic key to be generated and the public key sent directly to the codespace at ssh start time. Due to some various user requests, we maintained support for having uploaded keys in order to bypass the automatic keys in https://github.com/cli/cli/pull/5958.

That change to maintain support for uploaded keys had a couple drawbacks. The first, which we knew at the time, was just key selection complexity. It required us to check local ssh config against uploaded keys and while it did work, it had significant code and understandability overhead. The second drawback, which we learned later, was that the API call to fetch public keys doesn't exist in some cases, namely EMU. For EMU users the `cs ssh` call could never work unless they specified the `-i` flag or manually created the automatic key.

So, finally, getting to what this change is: instead of checking for uploaded public keys, we will instead select a key pair at the time of running the command and send the public key to the codespace. This is the same behavior as we already have for automatic keys, but now it applies even to user created keys. 

This effectively removes both drawback above - we no longer need the complex logic of fetching and comparing uploaded keys, and by not needing the fetch anymore EMU users will be unblocked.

The precedence of selected key pair is this:
1. Key specified by `-i` argument
2. Automatic keypair, if it exists already
3. Key specified in ssh config (checked using existing `ssh -G` logic)
4. Automatic keypair, newly generated

From the selected keypair, the public key is sent to the codespace to be added to `authorized_keys`. The private key is appended to the ssh arguments with a `-i` parameter.