### PR TITLE
Ensure local keys don't interfere with ssh_test

### DIFF
--- a/pkg/cmd/codespace/ssh_test.go
+++ b/pkg/cmd/codespace/ssh_test.go
@@ -212,21 +212,21 @@ func TestSelectSSHKeys(t *testing.T) {
 			f.Close()
 		}
 
-		if tt.sshConfigKeys != nil {
-			configPath := filepath.Join(sshDir, "test-config")
+		configPath := filepath.Join(sshDir, "test-config")
 
-			configContent := ""
-			for _, key := range tt.sshConfigKeys {
-				configContent += fmt.Sprintf("IdentityFile %s\n", filepath.Join(sshDir, key))
-			}
+		// Seed the config with a non-existent key so that the default config won't apply
+		configContent := "IdentityFile dummy\n"
 
-			err := os.WriteFile(configPath, []byte(configContent), 0666)
-			if err != nil {
-				t.Fatalf("could not write test config %v", err)
-			}
-
-			tt.sshArgs = append(tt.sshArgs, "-F", configPath)
+		for _, key := range tt.sshConfigKeys {
+			configContent += fmt.Sprintf("IdentityFile %s\n", filepath.Join(sshDir, key))
 		}
+
+		err := os.WriteFile(configPath, []byte(configContent), 0666)
+		if err != nil {
+			t.Fatalf("could not write test config %v", err)
+		}
+
+		tt.sshArgs = append([]string{"-F", configPath}, tt.sshArgs...)
 
 		gotKeyPair, gotShouldAddArg, err := selectSSHKeys(context.Background(), sshContext, tt.sshArgs, sshOptions{profile: tt.profileOpt})
 


### PR DESCRIPTION
Fixes: https://github.com/cli/cli/issues/6315

When running the ssh tests, some tests don't override the ssh config for custom `IdentityFile`s. These tests currently get the default ssh config, which includes a set of common private keys (e.g. `~/.ssh/id_rsa`). This means that if you run the tests locally and have one of these common keys, the test will pick up that key and get incorrect results.

To fix this, a dummy `IdentityFile` config is added to all tests. The existence of any custom `IdentityFile` value in the custom config is enough to make ssh not use the default keys.
