### PR TITLE
add and use ConfirmDeletion in {label,repo} delete

### DIFF
--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -3,6 +3,7 @@ package prompter
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/cli/cli/v2/internal/ghinstance"
@@ -18,6 +19,7 @@ type Prompter interface {
 	Password(string) (string, error)
 	AuthToken() (string, error)
 	Confirm(string, bool) (bool, error)
+	ConfirmDeletion(string) error
 	MarkdownEditor(string, string, bool) (string, error)
 }
 
@@ -95,6 +97,22 @@ func (p *surveyPrompter) Input(prompt, defaultValue string) (result string, err 
 	}, &result)
 
 	return
+}
+
+func (p *surveyPrompter) ConfirmDeletion(requiredValue string) error {
+	var result string
+	return p.ask(
+		&survey.Input{
+			Message: fmt.Sprintf("Type %s to confirm deletion:", requiredValue),
+		},
+		&result,
+		survey.WithValidator(
+			func(val interface{}) error {
+				if str := val.(string); !strings.EqualFold(str, requiredValue) {
+					return fmt.Errorf("You entered %s", str)
+				}
+				return nil
+			}))
 }
 
 func (p *surveyPrompter) InputHostname() (result string, err error) {

--- a/internal/prompter/prompter_mock.go
+++ b/internal/prompter/prompter_mock.go
@@ -23,6 +23,9 @@ var _ Prompter = &PrompterMock{}
 // 			ConfirmFunc: func(s string, b bool) (bool, error) {
 // 				panic("mock out the Confirm method")
 // 			},
+// 			ConfirmDeletionFunc: func(s string) error {
+// 				panic("mock out the ConfirmDeletion method")
+// 			},
 // 			InputFunc: func(s1 string, s2 string) (string, error) {
 // 				panic("mock out the Input method")
 // 			},
@@ -54,6 +57,9 @@ type PrompterMock struct {
 	// ConfirmFunc mocks the Confirm method.
 	ConfirmFunc func(s string, b bool) (bool, error)
 
+	// ConfirmDeletionFunc mocks the ConfirmDeletion method.
+	ConfirmDeletionFunc func(s string) error
+
 	// InputFunc mocks the Input method.
 	InputFunc func(s1 string, s2 string) (string, error)
 
@@ -83,6 +89,11 @@ type PrompterMock struct {
 			S string
 			// B is the b argument value.
 			B bool
+		}
+		// ConfirmDeletion holds details about calls to the ConfirmDeletion method.
+		ConfirmDeletion []struct {
+			// S is the s argument value.
+			S string
 		}
 		// Input holds details about calls to the Input method.
 		Input []struct {
@@ -127,14 +138,15 @@ type PrompterMock struct {
 			Strings []string
 		}
 	}
-	lockAuthToken      sync.RWMutex
-	lockConfirm        sync.RWMutex
-	lockInput          sync.RWMutex
-	lockInputHostname  sync.RWMutex
-	lockMarkdownEditor sync.RWMutex
-	lockMultiSelect    sync.RWMutex
-	lockPassword       sync.RWMutex
-	lockSelect         sync.RWMutex
+	lockAuthToken       sync.RWMutex
+	lockConfirm         sync.RWMutex
+	lockConfirmDeletion sync.RWMutex
+	lockInput           sync.RWMutex
+	lockInputHostname   sync.RWMutex
+	lockMarkdownEditor  sync.RWMutex
+	lockMultiSelect     sync.RWMutex
+	lockPassword        sync.RWMutex
+	lockSelect          sync.RWMutex
 }
 
 // AuthToken calls AuthTokenFunc.
@@ -195,6 +207,37 @@ func (mock *PrompterMock) ConfirmCalls() []struct {
 	mock.lockConfirm.RLock()
 	calls = mock.calls.Confirm
 	mock.lockConfirm.RUnlock()
+	return calls
+}
+
+// ConfirmDeletion calls ConfirmDeletionFunc.
+func (mock *PrompterMock) ConfirmDeletion(s string) error {
+	if mock.ConfirmDeletionFunc == nil {
+		panic("PrompterMock.ConfirmDeletionFunc: method is nil but Prompter.ConfirmDeletion was just called")
+	}
+	callInfo := struct {
+		S string
+	}{
+		S: s,
+	}
+	mock.lockConfirmDeletion.Lock()
+	mock.calls.ConfirmDeletion = append(mock.calls.ConfirmDeletion, callInfo)
+	mock.lockConfirmDeletion.Unlock()
+	return mock.ConfirmDeletionFunc(s)
+}
+
+// ConfirmDeletionCalls gets all the calls that were made to ConfirmDeletion.
+// Check the length with:
+//     len(mockedPrompter.ConfirmDeletionCalls())
+func (mock *PrompterMock) ConfirmDeletionCalls() []struct {
+	S string
+} {
+	var calls []struct {
+		S string
+	}
+	mock.lockConfirmDeletion.RLock()
+	calls = mock.calls.ConfirmDeletion
+	mock.lockConfirmDeletion.RUnlock()
 	return calls
 }
 

--- a/pkg/cmd/label/delete_test.go
+++ b/pkg/cmd/label/delete_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/cli/cli/v2/pkg/prompt"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
 )
@@ -83,14 +83,14 @@ func TestNewCmdDelete(t *testing.T) {
 
 func TestDeleteRun(t *testing.T) {
 	tests := []struct {
-		name       string
-		tty        bool
-		opts       *deleteOptions
-		httpStubs  func(*httpmock.Registry)
-		askStubs   func(*prompt.AskStubber)
-		wantStdout string
-		wantErr    bool
-		errMsg     string
+		name          string
+		tty           bool
+		opts          *deleteOptions
+		httpStubs     func(*httpmock.Registry)
+		prompterStubs func(*prompter.PrompterMock)
+		wantStdout    string
+		wantErr       bool
+		errMsg        string
 	}{
 		{
 			name: "deletes label",
@@ -102,10 +102,10 @@ func TestDeleteRun(t *testing.T) {
 					httpmock.StatusStringResponse(204, "{}"),
 				)
 			},
-			askStubs: func(as *prompt.AskStubber) {
-				// TODO: survey stubber doesn't have WithValidator support
-				// so this always passes regardless of prompt input
-				as.StubPrompt("Type test to confirm deletion:").AnswerWith("test")
+			prompterStubs: func(pm *prompter.PrompterMock) {
+				pm.ConfirmDeletionFunc = func(_ string) error {
+					return nil
+				}
 			},
 			wantStdout: "✓ Label \"test\" deleted from OWNER/REPO\n",
 		},
@@ -153,11 +153,11 @@ func TestDeleteRun(t *testing.T) {
 				return &http.Client{Transport: reg}, nil
 			}
 
-			//nolint:staticcheck // SA1019: prompt.NewAskStubber is deprecated: use PrompterMock
-			as := prompt.NewAskStubber(t)
-			if tt.askStubs != nil {
-				tt.askStubs(as)
+			pm := &prompter.PrompterMock{}
+			if tt.prompterStubs != nil {
+				tt.prompterStubs(pm)
 			}
+			tt.opts.Prompter = pm
 
 			io, _, stdout, _ := iostreams.Test()
 			io.SetStdoutTTY(tt.tty)

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -8,17 +8,20 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
-	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/spf13/cobra"
 )
 
+type iprompter interface {
+	ConfirmDeletion(string) error
+}
+
 type DeleteOptions struct {
 	HttpClient func() (*http.Client, error)
 	BaseRepo   func() (ghrepo.Interface, error)
-	Prompter   prompter.Prompter
+	Prompter   iprompter
 	IO         *iostreams.IOStreams
 	RepoArg    string
 	Confirmed  bool
@@ -92,13 +95,8 @@ func deleteRun(opts *DeleteOptions) error {
 	fullName := ghrepo.FullName(toDelete)
 
 	if !opts.Confirmed {
-		result, err := opts.Prompter.Input(
-			fmt.Sprintf("Type %s to confirm deletion:", fullName), "")
-		if err != nil {
+		if err := opts.Prompter.ConfirmDeletion(fullName); err != nil {
 			return err
-		}
-		if !strings.EqualFold(result, fullName) {
-			return fmt.Errorf("You entered %s", result)
 		}
 	}
 

--- a/pkg/cmd/repo/delete/delete_test.go
+++ b/pkg/cmd/repo/delete/delete_test.go
@@ -92,8 +92,8 @@ func Test_deleteRun(t *testing.T) {
 			opts:       &DeleteOptions{RepoArg: "OWNER/REPO"},
 			wantStdout: "✓ Deleted repository OWNER/REPO\n",
 			prompterStubs: func(p *prompter.PrompterMock) {
-				p.InputFunc = func(_, _ string) (string, error) {
-					return "OWNER/REPO", nil
+				p.ConfirmDeletionFunc = func(_ string) error {
+					return nil
 				}
 			},
 			httpStubs: func(reg *httpmock.Registry) {
@@ -108,8 +108,8 @@ func Test_deleteRun(t *testing.T) {
 			opts:       &DeleteOptions{},
 			wantStdout: "✓ Deleted repository OWNER/REPO\n",
 			prompterStubs: func(p *prompter.PrompterMock) {
-				p.InputFunc = func(_, _ string) (string, error) {
-					return "OWNER/REPO", nil
+				p.ConfirmDeletionFunc = func(_ string) error {
+					return nil
 				}
 			},
 			httpStubs: func(reg *httpmock.Registry) {
@@ -136,8 +136,8 @@ func Test_deleteRun(t *testing.T) {
 			wantStdout: "✓ Deleted repository OWNER/REPO\n",
 			tty:        true,
 			prompterStubs: func(p *prompter.PrompterMock) {
-				p.InputFunc = func(_, _ string) (string, error) {
-					return "OWNER/REPO", nil
+				p.ConfirmDeletionFunc = func(_ string) error {
+					return nil
 				}
 			},
 			httpStubs: func(reg *httpmock.Registry) {


### PR DESCRIPTION
This PR adds a new function to `surveyPrompter`, `ConfirmDeletion`. It requires the user to type in a specific value in order to confirm that something should be deleted.

I added it to `label delete` and `repo delete`, the two places we seem to use that pattern.
