### PR TITLE
Recognize `.yaml` in addition to `.yml` suffix as workflow file name

### DIFF
--- a/pkg/cmd/workflow/run/run_test.go
+++ b/pkg/cmd/workflow/run/run_test.go
@@ -471,6 +471,26 @@ jobs:
 			errOut:  "could not create workflow dispatch event: HTTP 422 (https://api.github.com/repos/OWNER/REPO/actions/workflows/12345/dispatches)",
 		},
 		{
+			name: "yaml file extension",
+			tty:  false,
+			opts: &RunOptions{
+				Selector: "workflow.yaml",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/workflow.yaml"),
+					httpmock.StatusStringResponse(200, `{"id": 12345}`))
+				reg.Register(
+					httpmock.REST("POST", "repos/OWNER/REPO/actions/workflows/12345/dispatches"),
+					httpmock.StatusStringResponse(204, ""))
+			},
+			wantBody: map[string]interface{}{
+				"inputs": map[string]interface{}{},
+				"ref":    "trunk",
+			},
+			wantErr: false,
+		},
+		{
 			// TODO this test is somewhat silly; it's more of a placeholder in case I decide to handle the API error more elegantly
 			name: "input fields, missing required",
 			opts: &RunOptions{

--- a/pkg/cmd/workflow/shared/shared.go
+++ b/pkg/cmd/workflow/shared/shared.go
@@ -124,7 +124,7 @@ func FindWorkflow(client *api.Client, repo ghrepo.Interface, workflowSelector st
 		return nil, errors.New("empty workflow selector")
 	}
 
-	if _, err := strconv.Atoi(workflowSelector); err == nil || strings.HasSuffix(workflowSelector, ".yml") {
+	if _, err := strconv.Atoi(workflowSelector); err == nil || isWorkflowFile(workflowSelector) {
 		workflow, err := getWorkflowByID(client, repo, workflowSelector)
 		if err != nil {
 			return nil, err
@@ -137,6 +137,11 @@ func FindWorkflow(client *api.Client, repo ghrepo.Interface, workflowSelector st
 
 func GetWorkflow(client *api.Client, repo ghrepo.Interface, workflowID int64) (*Workflow, error) {
 	return getWorkflowByID(client, repo, strconv.FormatInt(workflowID, 10))
+}
+
+func isWorkflowFile(f string) bool {
+	name := strings.ToLower(f)
+	return strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml")
 }
 
 // ID can be either a numeric database ID or the workflow file name


### PR DESCRIPTION
This fixes dispatching and looking up workflows which have the `.yaml` file extension.

Fixes https://github.com/cli/cli/issues/6328
Followup to https://github.com/cli/cli/pull/6266