### PR TITLE
Respect GH_HOST in `auth login`, `repo delete`

### DIFF
--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -50,7 +50,7 @@ func FromFullName(nwo string) (Interface, error) {
 // FromFullNameWithHost is like FromFullName that defaults to a specific host for values that don't
 // explicitly include a hostname.
 func FromFullNameWithHost(nwo, fallbackHost string) (Interface, error) {
-	repo, err := repository.ParseWithHost(nwo, defaultHost())
+	repo, err := repository.ParseWithHost(nwo, fallbackHost)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	ghAuth "github.com/cli/go-gh/pkg/auth"
 	"github.com/spf13/cobra"
 )
 
@@ -99,7 +100,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			}
 
 			if opts.Hostname == "" && (!opts.Interactive || opts.Web) {
-				opts.Hostname = ghinstance.Default()
+				opts.Hostname, _ = ghAuth.DefaultHost()
 			}
 
 			opts.MainExecutable = f.Executable()

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -31,19 +31,31 @@ func stubHomeDir(t *testing.T, dir string) {
 
 func Test_NewCmdLogin(t *testing.T) {
 	tests := []struct {
-		name     string
-		cli      string
-		stdin    string
-		stdinTTY bool
-		wants    LoginOptions
-		wantsErr bool
+		name        string
+		cli         string
+		stdin       string
+		stdinTTY    bool
+		defaultHost string
+		wants       LoginOptions
+		wantsErr    bool
 	}{
 		{
-			name:  "nontty, with-token",
-			stdin: "abc123\n",
-			cli:   "--with-token",
+			name:        "nontty, with-token",
+			stdin:       "abc123\n",
+			cli:         "--with-token",
+			defaultHost: "github.com",
 			wants: LoginOptions{
 				Hostname: "github.com",
+				Token:    "abc123",
+			},
+		},
+		{
+			name:        "nontty, Enterprise host",
+			stdin:       "abc123\n",
+			cli:         "--with-token",
+			defaultHost: "git.example.com",
+			wants: LoginOptions{
+				Hostname: "git.example.com",
 				Token:    "abc123",
 			},
 		},
@@ -163,6 +175,8 @@ func Test_NewCmdLogin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GH_HOST", tt.defaultHost)
+
 			ios, stdin, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
 				IOStreams: ios,

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -6,12 +6,11 @@ import (
 	"strings"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
-
 	"github.com/cli/cli/v2/pkg/iostreams"
+	ghAuth "github.com/cli/go-gh/pkg/auth"
 	"github.com/spf13/cobra"
 )
 
@@ -78,7 +77,8 @@ func deleteRun(opts *DeleteOptions) error {
 	} else {
 		repoSelector := opts.RepoArg
 		if !strings.Contains(repoSelector, "/") {
-			currentUser, err := api.CurrentLoginName(apiClient, ghinstance.Default())
+			defaultHost, _ := ghAuth.DefaultHost()
+			currentUser, err := api.CurrentLoginName(apiClient, defaultHost)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Bonus fix: respect fallback host argument to `FromFullNameWithHost()`

Fixes https://github.com/cli/cli/issues/6335