### PR TITLE
Add header to the `gpg-key list` output

### DIFF
--- a/pkg/cmd/gpg-key/list/http.go
+++ b/pkg/cmd/gpg-key/list/http.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cli/cli/v2/internal/ghinstance"
 )
 
-var scopesError = errors.New("insufficient OAuth scopes")
+var errScopes = errors.New("insufficient OAuth scopes")
 
 type emails []email
 
@@ -30,7 +30,7 @@ func (es emails) String() string {
 }
 
 type gpgKey struct {
-	KeyId     string    `json:"key_id"`
+	KeyID     string    `json:"key_id"`
 	PublicKey string    `json:"public_key"`
 	Emails    emails    `json:"emails"`
 	CreatedAt time.Time `json:"created_at"`
@@ -55,7 +55,7 @@ func userKeys(httpClient *http.Client, host, userHandle string) ([]gpgKey, error
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 404 {
-		return nil, scopesError
+		return nil, errScopes
 	} else if resp.StatusCode > 299 {
 		return nil, api.HandleHTTPError(resp)
 	}

--- a/pkg/cmd/gpg-key/list/list_test.go
+++ b/pkg/cmd/gpg-key/list/list_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListRun(t *testing.T) {
+func Test_listRun(t *testing.T) {
 	tests := []struct {
 		name       string
 		opts       ListOptions
@@ -22,17 +23,84 @@ func TestListRun(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "list tty",
-			opts:       ListOptions{HTTPClient: mockGPGResponse},
-			isTTY:      true,
-			wantStdout: "johnny@test.com      ABCDEF12345...  xJMEW...oofoo  Created Ju...  Expires 20...\nmonalisa@github.com  1234567890A...  xJMEW...arbar  Created Ja...  Never expires\n",
+			name: "list tty",
+			opts: ListOptions{HTTPClient: func() (*http.Client, error) {
+				createdAt := time.Now().Add(time.Duration(-24) * time.Hour)
+				expiresAt, _ := time.Parse(time.RFC3339, "2099-01-01T15:44:24+01:00")
+				noExpires := time.Time{}
+				reg := &httpmock.Registry{}
+				reg.Register(
+					httpmock.REST("GET", "user/gpg_keys"),
+					httpmock.StringResponse(fmt.Sprintf(`[
+						{
+							"id": 1234,
+							"key_id": "ABCDEF1234567890",
+							"public_key": "xJMEWfoofoofoo",
+							"emails": [{"email": "johnny@test.com"}],
+							"created_at": "%[1]s",
+							"expires_at": "%[2]s"
+						},
+						{
+							"id": 5678,
+							"key_id": "1234567890ABCDEF",
+							"public_key": "xJMEWbarbarbar",
+							"emails": [{"email": "monalisa@github.com"}],
+							"created_at": "%[1]s",
+							"expires_at": "%[3]s"
+						}
+					]`, createdAt.Format(time.RFC3339),
+						expiresAt.Format(time.RFC3339),
+						noExpires.Format(time.RFC3339))),
+				)
+				return &http.Client{Transport: reg}, nil
+			}},
+			isTTY: true,
+			wantStdout: heredoc.Doc(`
+				EMAIL                KEY ID            PUBLIC KEY      ADDED  EXPIRES
+				johnny@test.com      ABCDEF1234567890  xJMEWfoofoofoo  1d     2099-01-01
+				monalisa@github.com  1234567890ABCDEF  xJMEWbarbarbar  1d     Never
+			`),
 			wantStderr: "",
 		},
 		{
-			name:       "list non-tty",
-			opts:       ListOptions{HTTPClient: mockGPGResponse},
-			isTTY:      false,
-			wantStdout: "johnny@test.com\tABCDEF1234567890\txJMEWfoofoofoo\t2020-06-11T15:44:24+01:00\t2099-01-01T15:44:24+01:00\nmonalisa@github.com\t1234567890ABCDEF\txJMEWbarbarbar\t2021-01-11T15:44:24+01:00\t0001-01-01T00:00:00Z\n",
+			name: "list non-tty",
+			opts: ListOptions{HTTPClient: func() (*http.Client, error) {
+				createdAt1, _ := time.Parse(time.RFC3339, "2020-06-11T15:44:24+01:00")
+				expiresAt, _ := time.Parse(time.RFC3339, "2099-01-01T15:44:24+01:00")
+				createdAt2, _ := time.Parse(time.RFC3339, "2021-01-11T15:44:24+01:00")
+				noExpires := time.Time{}
+				reg := &httpmock.Registry{}
+				reg.Register(
+					httpmock.REST("GET", "user/gpg_keys"),
+					httpmock.StringResponse(fmt.Sprintf(`[
+						{
+							"id": 1234,
+							"key_id": "ABCDEF1234567890",
+							"public_key": "xJMEWfoofoofoo",
+							"emails": [{"email": "johnny@test.com"}],
+							"created_at": "%[1]s",
+							"expires_at": "%[2]s"
+						},
+						{
+							"id": 5678,
+							"key_id": "1234567890ABCDEF",
+							"public_key": "xJMEWbarbarbar",
+							"emails": [{"email": "monalisa@github.com"}],
+							"created_at": "%[3]s",
+							"expires_at": "%[4]s"
+						}
+					]`, createdAt1.Format(time.RFC3339),
+						expiresAt.Format(time.RFC3339),
+						createdAt2.Format(time.RFC3339),
+						noExpires.Format(time.RFC3339))),
+				)
+				return &http.Client{Transport: reg}, nil
+			}},
+			isTTY: false,
+			wantStdout: heredoc.Doc(`
+				johnny@test.com	ABCDEF1234567890	xJMEWfoofoofoo	2020-06-11T15:44:24+01:00	2099-01-01T15:44:24+01:00
+				monalisa@github.com	1234567890ABCDEF	xJMEWbarbarbar	2021-01-11T15:44:24+01:00	0001-01-01T00:00:00Z
+			`),
 			wantStderr: "",
 		},
 		{
@@ -73,37 +141,4 @@ func TestListRun(t *testing.T) {
 			assert.Equal(t, tt.wantStderr, stderr.String())
 		})
 	}
-}
-
-func mockGPGResponse() (*http.Client, error) {
-	ca1, _ := time.Parse(time.RFC3339, "2020-06-11T15:44:24+01:00")
-	ea1, _ := time.Parse(time.RFC3339, "2099-01-01T15:44:24+01:00")
-	ca2, _ := time.Parse(time.RFC3339, "2021-01-11T15:44:24+01:00")
-	ea2 := time.Time{}
-	reg := &httpmock.Registry{}
-	reg.Register(
-		httpmock.REST("GET", "user/gpg_keys"),
-		httpmock.StringResponse(fmt.Sprintf(`[
-			{
-				"id": 1234,
-				"key_id": "ABCDEF1234567890",
-				"public_key": "xJMEWfoofoofoo",
-				"emails": [{"email": "johnny@test.com"}],
-				"created_at": "%[1]s",
-				"expires_at": "%[2]s"
-			},
-			{
-				"id": 5678,
-				"key_id": "1234567890ABCDEF",
-				"public_key": "xJMEWbarbarbar",
-				"emails": [{"email": "monalisa@github.com"}],
-				"created_at": "%[3]s",
-				"expires_at": "%[4]s"
-			}
-		]`, ca1.Format(time.RFC3339),
-			ea1.Format(time.RFC3339),
-			ca2.Format(time.RFC3339),
-			ea2.Format(time.RFC3339))),
-	)
-	return &http.Client{Transport: reg}, nil
 }


### PR DESCRIPTION
As discussed in #6332.

Add header to the `gpg-key list` output:

```
$ gh gpg-key list
EMAIL                               KEY ID            PUBLIC KEY     ADDED  EXPIRES
name@domain.com                     3AA5C34371567FOO  xxxxx...xxxxx  1d     Never
name1@domain.com, name2@domain.com  3AA5C34371567BAR  xxxxx...xxxxx  1d     2023-01-01
```

There's no changes in non interactive mode.