### PR TITLE
Fix color output for non-256 color terminals

### DIFF
--- a/pkg/iostreams/console.go
+++ b/pkg/iostreams/console.go
@@ -3,6 +3,8 @@
 
 package iostreams
 
+import "errors"
+
 func enableVirtualTerminalProcessing(fd uintptr) error {
-	return nil
+	return errors.New("not implemented")
 }


### PR DESCRIPTION
The function enableVirtualTerminalProcessing must return an error if virtual terminal processing (only applicable on Windows) was not enabled, otherwise we assume that the terminal supports both 256-color and truecolor (since that is true of Windows terminals with virtual terminal processing enabled).

We have been erroneously assuming that all non-Windows terminals are 256-color and sending escape sequences to those that cannot interpret them. This led to some parts of Survey prompts being invisible on old terminals.

Regressed in https://github.com/cli/cli/pull/5681
