### PR TITLE
Fix Ubuntu installation instructions for curl

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -14,6 +14,7 @@ our release schedule.
 Install:
 
 ```bash
+type -p curl >/dev/null || sudo apt install curl -y
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
 && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
 && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \


### PR DESCRIPTION
Newer Ubuntu doesn't come with curl preinstalled anymore.

It does come with `wget` but I couldn't come up with a one-liner that switches between wget and curl based on which one is available. Maybe it's time that we start publishing an installer script?

Ref. https://github.com/cli/cli/issues/4634#issuecomment-1259330954