### PR TITLE
Add `gh gpg-key delete <key-id>`

### DIFF
--- a/pkg/cmd/gpg-key/delete/delete.go
+++ b/pkg/cmd/gpg-key/delete/delete.go
@@ -64,7 +64,7 @@ func deleteRun(opts *DeleteOptions) error {
 	}
 
 	host, _ := cfg.DefaultHost()
-	gpgKeys, err := getGPGKeys(httpClient, host, "")
+	gpgKeys, err := getGPGKeys(httpClient, host)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func deleteRun(opts *DeleteOptions) error {
 	}
 
 	if id == "" {
-		return fmt.Errorf("unable to delete GPG key id %s: either the GPG key is not found or it is not owned by you", opts.KeyID)
+		return fmt.Errorf("unable to delete GPG key %s: either the GPG key is not found or it is not owned by you", opts.KeyID)
 	}
 
 	if !opts.Confirmed {
@@ -94,7 +94,8 @@ func deleteRun(opts *DeleteOptions) error {
 
 	if opts.IO.IsStdoutTTY() {
 		cs := opts.IO.ColorScheme()
-		fmt.Fprintf(opts.IO.Out, "%s GPG key id %s deleted from your account\n", cs.SuccessIcon(), opts.KeyID)
+		fmt.Fprintf(opts.IO.Out, "%s GPG key %s deleted from your account\n", cs.SuccessIcon(), opts.KeyID)
 	}
+
 	return nil
 }

--- a/pkg/cmd/gpg-key/delete/delete.go
+++ b/pkg/cmd/gpg-key/delete/delete.go
@@ -1,0 +1,100 @@
+package delete
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type DeleteOptions struct {
+	IO         *iostreams.IOStreams
+	Config     func() (config.Config, error)
+	HttpClient func() (*http.Client, error)
+
+	KeyID     string
+	Confirmed bool
+	Prompter  prompter.Prompter
+}
+
+func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Command {
+	opts := &DeleteOptions{
+		HttpClient: f.HttpClient,
+		Config:     f.Config,
+		IO:         f.IOStreams,
+		Prompter:   f.Prompter,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete <key-id>",
+		Short: "Delete a GPG key from your GitHub account",
+		Args:  cmdutil.ExactArgs(1, "cannot delete: key id required"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.KeyID = args[0]
+
+			if !opts.IO.CanPrompt() && !opts.Confirmed {
+				return cmdutil.FlagErrorf("--confirm required when not running interactively")
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return deleteRun(opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.Confirmed, "confirm", "y", false, "Skip the confirmation prompt")
+	return cmd
+}
+
+func deleteRun(opts *DeleteOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	host, _ := cfg.DefaultHost()
+	gpgKeys, err := getGPGKeys(httpClient, host, "")
+	if err != nil {
+		return err
+	}
+
+	id := ""
+	for _, gpgKey := range gpgKeys {
+		if gpgKey.KeyID == opts.KeyID {
+			id = strconv.Itoa(gpgKey.ID)
+			break
+		}
+	}
+
+	if id == "" {
+		return fmt.Errorf("unable to delete GPG key id %s: either the GPG key is not found or it is not owned by you", opts.KeyID)
+	}
+
+	if !opts.Confirmed {
+		if err := opts.Prompter.ConfirmDeletion(opts.KeyID); err != nil {
+			return err
+		}
+	}
+
+	err = deleteGPGKey(httpClient, host, id)
+	if err != nil {
+		return nil
+	}
+
+	if opts.IO.IsStdoutTTY() {
+		cs := opts.IO.ColorScheme()
+		fmt.Fprintf(opts.IO.Out, "%s GPG key id %s deleted from your account\n", cs.SuccessIcon(), opts.KeyID)
+	}
+	return nil
+}

--- a/pkg/cmd/gpg-key/delete/delete_test.go
+++ b/pkg/cmd/gpg-key/delete/delete_test.go
@@ -130,7 +130,7 @@ func Test_deleteRun(t *testing.T) {
 				reg.Register(httpmock.REST("GET", "user/gpg_keys"), httpmock.StatusStringResponse(200, keysResp))
 				reg.Register(httpmock.REST("DELETE", "user/gpg_keys/123"), httpmock.StatusStringResponse(204, ""))
 			},
-			wantStdout: "✓ GPG key id ABC123 deleted from your account\n",
+			wantStdout: "✓ GPG key ABC123 deleted from your account\n",
 		},
 		{
 			name: "delete with confirm flag tty",
@@ -140,7 +140,7 @@ func Test_deleteRun(t *testing.T) {
 				reg.Register(httpmock.REST("GET", "user/gpg_keys"), httpmock.StatusStringResponse(200, keysResp))
 				reg.Register(httpmock.REST("DELETE", "user/gpg_keys/123"), httpmock.StatusStringResponse(204, ""))
 			},
-			wantStdout: "✓ GPG key id ABC123 deleted from your account\n",
+			wantStdout: "✓ GPG key ABC123 deleted from your account\n",
 		},
 		{
 			name: "not found tty",
@@ -150,7 +150,7 @@ func Test_deleteRun(t *testing.T) {
 				reg.Register(httpmock.REST("GET", "user/gpg_keys"), httpmock.StatusStringResponse(200, "[]"))
 			},
 			wantErr:    true,
-			wantErrMsg: "unable to delete GPG key id ABC123: either the GPG key is not found or it is not owned by you",
+			wantErrMsg: "unable to delete GPG key ABC123: either the GPG key is not found or it is not owned by you",
 		},
 		{
 			name: "delete no tty",
@@ -168,7 +168,7 @@ func Test_deleteRun(t *testing.T) {
 				reg.Register(httpmock.REST("GET", "user/gpg_keys"), httpmock.StatusStringResponse(200, "[]"))
 			},
 			wantErr:    true,
-			wantErrMsg: "unable to delete GPG key id ABC123: either the GPG key is not found or it is not owned by you",
+			wantErrMsg: "unable to delete GPG key ABC123: either the GPG key is not found or it is not owned by you",
 		},
 	}
 

--- a/pkg/cmd/gpg-key/delete/delete_test.go
+++ b/pkg/cmd/gpg-key/delete/delete_test.go
@@ -1,0 +1,210 @@
+package delete
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdDelete(t *testing.T) {
+	tests := []struct {
+		name       string
+		tty        bool
+		input      string
+		output     DeleteOptions
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:   "tty",
+			tty:    true,
+			input:  "ABC123",
+			output: DeleteOptions{KeyID: "ABC123", Confirmed: false},
+		},
+		{
+			name:   "confirm flag tty",
+			tty:    true,
+			input:  "ABC123 --confirm",
+			output: DeleteOptions{KeyID: "ABC123", Confirmed: true},
+		},
+		{
+			name:   "shorthand confirm flag tty",
+			tty:    true,
+			input:  "ABC123 -y",
+			output: DeleteOptions{KeyID: "ABC123", Confirmed: true},
+		},
+		{
+			name:       "no tty",
+			input:      "ABC123",
+			wantErr:    true,
+			wantErrMsg: "--confirm required when not running interactively",
+		},
+		{
+			name:   "confirm flag no tty",
+			input:  "ABC123 --confirm",
+			output: DeleteOptions{KeyID: "ABC123", Confirmed: true},
+		},
+		{
+			name:   "shorthand confirm flag no tty",
+			input:  "ABC123 -y",
+			output: DeleteOptions{KeyID: "ABC123", Confirmed: true},
+		},
+		{
+			name:       "no args",
+			input:      "",
+			wantErr:    true,
+			wantErrMsg: "cannot delete: key id required",
+		},
+		{
+			name:       "too many args",
+			input:      "ABC123 XYZ",
+			wantErr:    true,
+			wantErrMsg: "too many arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStdoutTTY(tt.tty)
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+			argv, err := shlex.Split(tt.input)
+			assert.NoError(t, err)
+
+			var cmdOpts *DeleteOptions
+			cmd := NewCmdDelete(f, func(opts *DeleteOptions) error {
+				cmdOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.wantErrMsg)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.output.KeyID, cmdOpts.KeyID)
+			assert.Equal(t, tt.output.Confirmed, cmdOpts.Confirmed)
+		})
+	}
+}
+
+func Test_deleteRun(t *testing.T) {
+	keysResp := "[{\"id\":123,\"key_id\":\"ABC123\"}]"
+	tests := []struct {
+		name          string
+		tty           bool
+		opts          DeleteOptions
+		httpStubs     func(*httpmock.Registry)
+		prompterStubs func(*prompter.PrompterMock)
+		wantStdout    string
+		wantErr       bool
+		wantErrMsg    string
+	}{
+		{
+			name: "delete tty",
+			tty:  true,
+			opts: DeleteOptions{KeyID: "ABC123", Confirmed: false},
+			prompterStubs: func(pm *prompter.PrompterMock) {
+				pm.ConfirmDeletionFunc = func(_ string) error {
+					return nil
+				}
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/gpg_keys"), httpmock.StatusStringResponse(200, keysResp))
+				reg.Register(httpmock.REST("DELETE", "user/gpg_keys/123"), httpmock.StatusStringResponse(204, ""))
+			},
+			wantStdout: "✓ GPG key id ABC123 deleted from your account\n",
+		},
+		{
+			name: "delete with confirm flag tty",
+			tty:  true,
+			opts: DeleteOptions{KeyID: "ABC123", Confirmed: true},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/gpg_keys"), httpmock.StatusStringResponse(200, keysResp))
+				reg.Register(httpmock.REST("DELETE", "user/gpg_keys/123"), httpmock.StatusStringResponse(204, ""))
+			},
+			wantStdout: "✓ GPG key id ABC123 deleted from your account\n",
+		},
+		{
+			name: "not found tty",
+			tty:  true,
+			opts: DeleteOptions{KeyID: "ABC123", Confirmed: true},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/gpg_keys"), httpmock.StatusStringResponse(200, "[]"))
+			},
+			wantErr:    true,
+			wantErrMsg: "unable to delete GPG key id ABC123: either the GPG key is not found or it is not owned by you",
+		},
+		{
+			name: "delete no tty",
+			opts: DeleteOptions{KeyID: "ABC123", Confirmed: true},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/gpg_keys"), httpmock.StatusStringResponse(200, keysResp))
+				reg.Register(httpmock.REST("DELETE", "user/gpg_keys/123"), httpmock.StatusStringResponse(204, ""))
+			},
+			wantStdout: "",
+		},
+		{
+			name: "not found no tty",
+			opts: DeleteOptions{KeyID: "ABC123", Confirmed: true},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "user/gpg_keys"), httpmock.StatusStringResponse(200, "[]"))
+			},
+			wantErr:    true,
+			wantErrMsg: "unable to delete GPG key id ABC123: either the GPG key is not found or it is not owned by you",
+		},
+	}
+
+	for _, tt := range tests {
+		pm := &prompter.PrompterMock{}
+		if tt.prompterStubs != nil {
+			tt.prompterStubs(pm)
+		}
+		tt.opts.Prompter = pm
+
+		reg := &httpmock.Registry{}
+		if tt.httpStubs != nil {
+			tt.httpStubs(reg)
+		}
+
+		tt.opts.HttpClient = func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		}
+		tt.opts.Config = func() (config.Config, error) {
+			return config.NewBlankConfig(), nil
+		}
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdinTTY(tt.tty)
+		ios.SetStdoutTTY(tt.tty)
+		tt.opts.IO = ios
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := deleteRun(&tt.opts)
+			reg.Verify(t)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.wantErrMsg)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantStdout, stdout.String())
+		})
+	}
+}

--- a/pkg/cmd/gpg-key/delete/http.go
+++ b/pkg/cmd/gpg-key/delete/http.go
@@ -2,7 +2,6 @@ package delete
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,8 +9,6 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghinstance"
 )
-
-var errScopes = errors.New("insufficient OAuth scopes")
 
 type gpgKey struct {
 	ID    int
@@ -31,20 +28,15 @@ func deleteGPGKey(httpClient *http.Client, host, id string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 404 {
-		return errScopes
-	} else if resp.StatusCode > 299 {
+	if resp.StatusCode > 299 {
 		return api.HandleHTTPError(resp)
 	}
 
 	return nil
 }
 
-func getGPGKeys(httpClient *http.Client, host, userHandle string) ([]gpgKey, error) {
+func getGPGKeys(httpClient *http.Client, host string) ([]gpgKey, error) {
 	resource := "user/gpg_keys"
-	if userHandle != "" {
-		resource = fmt.Sprintf("users/%s/gpg_keys", userHandle)
-	}
 	url := fmt.Sprintf("%s%s?per_page=%d", ghinstance.RESTPrefix(host), resource, 100)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -57,9 +49,7 @@ func getGPGKeys(httpClient *http.Client, host, userHandle string) ([]gpgKey, err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 404 {
-		return nil, errScopes
-	} else if resp.StatusCode > 299 {
+	if resp.StatusCode > 299 {
 		return nil, api.HandleHTTPError(resp)
 	}
 

--- a/pkg/cmd/gpg-key/delete/http.go
+++ b/pkg/cmd/gpg-key/delete/http.go
@@ -1,0 +1,78 @@
+package delete
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghinstance"
+)
+
+var errScopes = errors.New("insufficient OAuth scopes")
+
+type gpgKey struct {
+	ID    int
+	KeyID string `json:"key_id"`
+}
+
+func deleteGPGKey(httpClient *http.Client, host, id string) error {
+	url := fmt.Sprintf("%suser/gpg_keys/%s", ghinstance.RESTPrefix(host), id)
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return errScopes
+	} else if resp.StatusCode > 299 {
+		return api.HandleHTTPError(resp)
+	}
+
+	return nil
+}
+
+func getGPGKeys(httpClient *http.Client, host, userHandle string) ([]gpgKey, error) {
+	resource := "user/gpg_keys"
+	if userHandle != "" {
+		resource = fmt.Sprintf("users/%s/gpg_keys", userHandle)
+	}
+	url := fmt.Sprintf("%s%s?per_page=%d", ghinstance.RESTPrefix(host), resource, 100)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return nil, errScopes
+	} else if resp.StatusCode > 299 {
+		return nil, api.HandleHTTPError(resp)
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var keys []gpgKey
+	err = json.Unmarshal(b, &keys)
+	if err != nil {
+		return nil, err
+	}
+
+	return keys, nil
+}

--- a/pkg/cmd/gpg-key/gpg_key.go
+++ b/pkg/cmd/gpg-key/gpg_key.go
@@ -2,6 +2,7 @@ package key
 
 import (
 	cmdAdd "github.com/cli/cli/v2/pkg/cmd/gpg-key/add"
+	cmdDelete "github.com/cli/cli/v2/pkg/cmd/gpg-key/delete"
 	cmdList "github.com/cli/cli/v2/pkg/cmd/gpg-key/list"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -14,8 +15,9 @@ func NewCmdGPGKey(f *cmdutil.Factory) *cobra.Command {
 		Long:  "Manage GPG keys registered with your GitHub account.",
 	}
 
-	cmd.AddCommand(cmdList.NewCmdList(f, nil))
 	cmd.AddCommand(cmdAdd.NewCmdAdd(f, nil))
+	cmd.AddCommand(cmdDelete.NewCmdDelete(f, nil))
+	cmd.AddCommand(cmdList.NewCmdList(f, nil))
 
 	return cmd
 }


### PR DESCRIPTION
Resolves #6332 
Add an ability to delete a GPG key `gh gpg-key delete <key-id>`.

```bash
$ gh gpg-key delete ABC123FOOBAR
? Type ABC123FOOBAR to confirm deletion: ABC123FOOBAR
✓ GPG key id ABC123FOOBAR deleted from your account
```