### PR TITLE
adding --json to pr create - backward compatibility concerns

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -292,6 +292,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 				pullRequest {
 					id
 					url
+					number
 				}
 			}
 	}`

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e // indirect
-	github.com/yuin/goldmark v1.4.4 // indirect
+	github.com/yuin/goldmark v1.5.2 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.4 h1:zNWRjYUW32G9KirMXYHQHVNFkXvMI7LpgNW2AgYAoIs=
 github.com/yuin/goldmark v1.4.4/go.mod h1:rmuwmfZ0+bvzB24eSC//bk1R1Zp3hM0OXYv/G2LIilg=
+github.com/yuin/goldmark v1.5.2 h1:ALmeCk/px5FSm1MAcFBAsVKZjDuMVj8Tm7FFIlMJnqU=
+github.com/yuin/goldmark v1.5.2/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark-emoji v1.0.1 h1:ctuWEyzGBwiucEqxzwe0SOYDXPAucOrE9NQC18Wa1os=
 github.com/yuin/goldmark-emoji v1.0.1/go.mod h1:2w1E6FEWLcDQkoTE+7HU6QF1F6SLlNGjRIBbIZQFqkQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -169,7 +169,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.PullRequestFields)
 	fl := cmd.Flags()
 	fl.BoolVarP(&opts.IsDraft, "draft", "d", false, "Mark pull request as a draft")
-	fl.StringVarP(&opts.Title, "title", "x", "", "Title for the pull request")
+	fl.StringVarP(&opts.Title, "title", "T", "", "Title for the pull request")
 	fl.StringVarP(&opts.Body, "body", "b", "", "Body for the pull request")
 	fl.StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
 	fl.StringVarP(&opts.BaseBranch, "base", "B", "", "The `branch` into which you want your code merged")


### PR DESCRIPTION
## Note, 

previously this PR was raised from my  personal account @devzer01, but i am closing that and open from my org account, so i can distribute the custom version to my git runners 

#6366 is the issue i created for this, I am open for discussion on how we can find some middle ground about the `-t` flag, I am open to creating a new json arg function without the json template ability. 

Hi gh is a great tool, i used it in many automation work, related to Devops pipelines workflows and so many. I was bit annoyed by the fact that pr create didn't provide a json output.

I went ahead and quickly added it so i can use this binary in my work, This PR is simply a draft, I haven''t added tests yet and I also in a rush renamed the short argument name for template which is t because it was being overwritten by the approach i brought in support for json.

Please provide some feedback, as I am not a daily go lang programmer. I hope you won't mind adding this feature into gh once i have completed the test and restore backward compatibility with the -t flag

> Hi! Thanks for the pull request. Please ensure that this change is linked to an issue by mentioning an issue number in the description of the pull request. If this pull request would close the issue, please put the word 'Fixes' before the issue number somewhere in the pull request body. If this is a tiny change like fixing a typo, feel free to ignore this message.

this is adding an essential feature, but has backward compatibility issues gh repo create has `-t` as short argument for title, for now i have renamed it to `-T` to avoid conflict with JSONArgs. 

its important for automation work to have the json output from this command for example 

# now 
there is no stable way to read the number of the pull request to be passed into the next auto merge command
```
gh pr create --head "hadata" --base master --body "automation" --title "automation" --json || jq '.number'
gh pr merge --auto --squash 40 <-- no way to get this value
```

# after
```
number=$(gh pr create --head "hadata" --base master --body "automation" --title "automation" --json || jq '.number')
 gh pr merge --auto --squash $number
```