### PR TITLE
Fix missing text in "man gh-codespace-ssh"

### DIFF
--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -60,12 +60,11 @@ func newSSHCmd(app *App) *cobra.Command {
 			By default, the 'ssh' command will create a public/private ssh key pair to  
 			authenticate with the codespace inside the ~/.ssh directory.
 
-			The 'ssh' command also supports deeper integration with OpenSSH using a
-			'--config' option that generates per-codespace ssh configuration in OpenSSH
-			format. Including this configuration in your ~/.ssh/config improves the user
-			experience of tools that integrate with OpenSSH, such as bash/zsh completion of
-			ssh hostnames, remote path completion for scp/rsync/sshfs, git ssh remotes, and
-			so on.
+			The 'ssh' command also supports deeper integration with OpenSSH using a '--config'
+			option that generates per-codespace ssh configuration in OpenSSH format.
+			Including this configuration in your ~/.ssh/config improves the user experience
+			of tools that integrate with OpenSSH, such as bash/zsh completion of ssh hostnames,
+			remote path completion for scp/rsync/sshfs, git ssh remotes, and so on.
 
 			Once that is set up (see the second example below), you can ssh to codespaces as
 			if they were ordinary remote hosts (using 'ssh', not 'gh cs ssh').


### PR DESCRIPTION
Rearrange the long help text so that '--config' does not appear at the start of a line which groff interprets as an undefined macro and skips (i.e. not renders) the content of that whole line:

```groff
'--config' option that generates per-codespace ssh configuration in OpenSSH
```

To reproduce:

```console
$ go run cmd/gen-docs/main.go --man-page --doc-path /tmp/gh-manpages
$ man --warnings -E UTF-8 -l -Tutf8 -Z /tmp/gh-manpages/gh-codespace-ssh.1 >/dev/null
troff: <standard input>:26: warning: macro '--config'' not defined
```
Discovered by the Debian Lintian tool.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
