### PR TITLE
Add flag to pr merge allowing the selection of the merge commit email

### DIFF
--- a/pkg/cmd/pr/merge/http.go
+++ b/pkg/cmd/pr/merge/http.go
@@ -36,6 +36,7 @@ type mergePayload struct {
 	commitBody      string
 	setCommitBody   bool
 	expectedHeadOid string
+	authorEmail     string
 }
 
 // TODO: drop after githubv4 gets updated
@@ -60,6 +61,10 @@ func mergePullRequest(client *http.Client, payload mergePayload) error {
 		input.MergeMethod = &m
 	}
 
+	if payload.authorEmail != "" {
+		authorEmail := githubv4.String(payload.authorEmail)
+		input.AuthorEmail = &authorEmail
+	}
 	if payload.commitSubject != "" {
 		commitHeadline := githubv4.String(payload.commitSubject)
 		input.CommitHeadline = &commitHeadline

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -39,6 +39,8 @@ type MergeOptions struct {
 	AutoMergeEnable  bool
 	AutoMergeDisable bool
 
+	AuthorEmail string
+
 	Body    string
 	BodySet bool
 	Subject string
@@ -177,6 +179,7 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 	cmd.Flags().BoolVar(&opts.AutoMergeEnable, "auto", false, "Automatically merge only after necessary requirements are met")
 	cmd.Flags().BoolVar(&opts.AutoMergeDisable, "disable-auto", false, "Disable auto-merge for this pull request")
 	cmd.Flags().StringVar(&opts.MatchHeadCommit, "match-head-commit", "", "Commit `SHA` that the pull request head must match to allow merge")
+	cmd.Flags().StringVarP(&opts.AuthorEmail, "author-email", "A", "", "Email `text` for merge commit author")
 	return cmd
 }
 
@@ -280,6 +283,7 @@ func (m *mergeContext) merge() error {
 		commitBody:      m.opts.Body,
 		setCommitBody:   m.opts.BodySet,
 		expectedHeadOid: m.opts.MatchHeadCommit,
+		authorEmail:     m.opts.AuthorEmail,
 	}
 
 	if m.shouldAddToMergeQueue() {


### PR DESCRIPTION
Fixes: #1450

`pr merge` lacked the ability to specify which email tied to your account is used to for merging commits. I added an `--author-email` flag to take in an email string to be used to populate the graphql field `authorEmail`. Otherwise the field is left blank and the merge commit uses your default email. 

I tested this on my own private repo to avoid leaking my personal emails to the public. It's worth noting that if you have settings configured to hide your personal email, Github will use your masked noreply email regardless of the email used here. 