### PR TITLE
Add support for last comment edit

### DIFF
--- a/api/queries_comments.go
+++ b/api/queries_comments.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"time"
 
 	"github.com/shurcooL/githubv4"
@@ -16,20 +15,14 @@ type Comments struct {
 	}
 }
 
-func (cs Comments) LastComment(username string) (*Comment, error) {
-	var lastComment Comment
-	found := false
+func (cs Comments) CommentsForUser(username string) []Comment {
+	var comments []Comment
 	for _, c := range cs.Nodes {
 		if c.Author.Login == username {
-			lastComment = c
-			found = true
+			comments = append(comments, c)
 		}
 	}
-	if found {
-		return &lastComment, nil
-	} else {
-		return nil, errors.New("not found")
-	}
+	return comments
 }
 
 type Comment struct {

--- a/api/queries_comments.go
+++ b/api/queries_comments.go
@@ -15,14 +15,14 @@ type Comments struct {
 	}
 }
 
-func (c Comments) LastCommentID(username string) string {
-	id := ""
-	for _, c := range c.Nodes {
+func (cs Comments) LastComment(username string) Comment {
+	var lastComment Comment
+	for _, c := range cs.Nodes {
 		if c.Author.Login == username {
-			id = c.ID
+			lastComment = c
 		}
 	}
-	return id
+	return lastComment
 }
 
 type Comment struct {
@@ -95,6 +95,10 @@ func CommentUpdate(client *Client, repoHost string, params CommentUpdateInput) (
 	}
 
 	return mutation.UpdateIssueComment.IssueComment.URL, nil
+}
+
+func (c Comment) Identifier() string {
+	return c.ID
 }
 
 func (c Comment) AuthorLogin() string {

--- a/api/queries_comments.go
+++ b/api/queries_comments.go
@@ -15,10 +15,10 @@ type Comments struct {
 	}
 }
 
-func (cs Comments) CommentsForUser(username string) []Comment {
+func (cs Comments) CurrentUserComments() []Comment {
 	var comments []Comment
 	for _, c := range cs.Nodes {
-		if c.Author.Login == username {
+		if c.ViewerDidAuthor {
 			comments = append(comments, c)
 		}
 	}
@@ -36,6 +36,7 @@ type Comment struct {
 	MinimizedReason     string         `json:"minimizedReason"`
 	ReactionGroups      ReactionGroups `json:"reactionGroups"`
 	URL                 string         `json:"url,omitempty"`
+	ViewerDidAuthor     bool           `json:"viewerDidAuthor"`
 }
 
 type CommentCreateInput struct {

--- a/api/queries_comments.go
+++ b/api/queries_comments.go
@@ -35,6 +35,7 @@ type Comment struct {
 	IsMinimized         bool           `json:"isMinimized"`
 	MinimizedReason     string         `json:"minimizedReason"`
 	ReactionGroups      ReactionGroups `json:"reactionGroups"`
+	URL                 string         `json:"url,omitempty"`
 }
 
 type CommentCreateInput struct {
@@ -130,7 +131,7 @@ func (c Comment) IsHidden() bool {
 }
 
 func (c Comment) Link() string {
-	return ""
+	return c.URL
 }
 
 func (c Comment) Reactions() ReactionGroups {

--- a/api/queries_comments.go
+++ b/api/queries_comments.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"time"
 
 	"github.com/shurcooL/githubv4"
@@ -15,14 +16,20 @@ type Comments struct {
 	}
 }
 
-func (cs Comments) LastComment(username string) Comment {
+func (cs Comments) LastComment(username string) (*Comment, error) {
 	var lastComment Comment
+	found := false
 	for _, c := range cs.Nodes {
 		if c.Author.Login == username {
 			lastComment = c
+			found = true
 		}
 	}
-	return lastComment
+	if found {
+		return &lastComment, nil
+	} else {
+		return nil, errors.New("not found")
+	}
 }
 
 type Comment struct {

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -245,6 +245,6 @@ func (i Issue) Identifier() string {
 	return i.ID
 }
 
-func (i Issue) LastComment(username string) Comment {
+func (i Issue) LastComment(username string) (*Comment, error) {
 	return i.Comments.LastComment(username)
 }

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -244,3 +244,7 @@ func (i Issue) Link() string {
 func (i Issue) Identifier() string {
 	return i.ID
 }
+
+func (i Issue) LastCommentIdentifier(username string) string {
+	return i.Comments.LastCommentID(username)
+}

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -245,6 +245,6 @@ func (i Issue) Identifier() string {
 	return i.ID
 }
 
-func (i Issue) LastComment(username string) (*Comment, error) {
-	return i.Comments.LastComment(username)
+func (i Issue) CommentsForUser(username string) []Comment {
+	return i.Comments.CommentsForUser(username)
 }

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -245,6 +245,6 @@ func (i Issue) Identifier() string {
 	return i.ID
 }
 
-func (i Issue) LastCommentIdentifier(username string) string {
-	return i.Comments.LastCommentID(username)
+func (i Issue) LastComment(username string) Comment {
+	return i.Comments.LastComment(username)
 }

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -245,6 +245,6 @@ func (i Issue) Identifier() string {
 	return i.ID
 }
 
-func (i Issue) CommentsForUser(username string) []Comment {
-	return i.Comments.CommentsForUser(username)
+func (i Issue) CurrentUserComments() []Comment {
+	return i.Comments.CurrentUserComments()
 }

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -214,8 +214,8 @@ func (pr PullRequest) Identifier() string {
 	return pr.ID
 }
 
-func (pr PullRequest) CommentsForUser(username string) []Comment {
-	return pr.Comments.CommentsForUser(username)
+func (pr PullRequest) CurrentUserComments() []Comment {
+	return pr.Comments.CurrentUserComments()
 }
 
 func (pr PullRequest) IsOpen() bool {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -214,8 +214,8 @@ func (pr PullRequest) Identifier() string {
 	return pr.ID
 }
 
-func (pr PullRequest) LastCommentIdentifier(username string) string {
-	return pr.Comments.LastCommentID(username)
+func (pr PullRequest) LastComment(username string) Comment {
+	return pr.Comments.LastComment(username)
 }
 
 func (pr PullRequest) IsOpen() bool {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -214,6 +214,10 @@ func (pr PullRequest) Identifier() string {
 	return pr.ID
 }
 
+func (pr PullRequest) LastCommentIdentifier(username string) string {
+	return pr.Comments.LastCommentID(username)
+}
+
 func (pr PullRequest) IsOpen() bool {
 	return pr.State == "OPEN"
 }

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -214,8 +214,8 @@ func (pr PullRequest) Identifier() string {
 	return pr.ID
 }
 
-func (pr PullRequest) LastComment(username string) (*Comment, error) {
-	return pr.Comments.LastComment(username)
+func (pr PullRequest) CommentsForUser(username string) []Comment {
+	return pr.Comments.CommentsForUser(username)
 }
 
 func (pr PullRequest) IsOpen() bool {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -214,7 +214,7 @@ func (pr PullRequest) Identifier() string {
 	return pr.ID
 }
 
-func (pr PullRequest) LastComment(username string) Comment {
+func (pr PullRequest) LastComment(username string) (*Comment, error) {
 	return pr.Comments.LastComment(username)
 }
 

--- a/api/queries_pr_review.go
+++ b/api/queries_pr_review.go
@@ -30,6 +30,7 @@ type PullRequestReviews struct {
 }
 
 type PullRequestReview struct {
+	ID                  string         `json:"id"`
 	Author              Author         `json:"author"`
 	AuthorAssociation   string         `json:"authorAssociation"`
 	Body                string         `json:"body"`
@@ -65,6 +66,10 @@ func AddReview(client *Client, repo ghrepo.Interface, pr *PullRequest, input *Pu
 	}
 
 	return client.Mutate(repo.RepoHost(), "PullRequestReviewAdd", &mutation, variables)
+}
+
+func (prr PullRequestReview) Identifier() string {
+	return prr.ID
 }
 
 func (prr PullRequestReview) AuthorLogin() string {

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -23,6 +23,7 @@ func shortenQuery(q string) string {
 var issueComments = shortenQuery(`
 	comments(first: 100) {
 		nodes {
+			id,
 			author{login},
 			authorAssociation,
 			body,

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -33,6 +33,7 @@ var issueComments = shortenQuery(`
 			minimizedReason,
 			reactionGroups{content,users{totalCount}},
 			url
+			viewerDidAuthor
 		},
 		pageInfo{hasNextPage,endCursor},
 		totalCount

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -32,7 +32,7 @@ var issueComments = shortenQuery(`
 			isMinimized,
 			minimizedReason,
 			reactionGroups{content,users{totalCount}},
-			url
+			url,
 			viewerDidAuthor
 		},
 		pageInfo{hasNextPage,endCursor},

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -31,7 +31,8 @@ var issueComments = shortenQuery(`
 			includesCreatedEdit,
 			isMinimized,
 			minimizedReason,
-			reactionGroups{content,users{totalCount}}
+			reactionGroups{content,users{totalCount}},
+			url
 		},
 		pageInfo{hasNextPage,endCursor},
 		totalCount

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -40,7 +40,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 				if err != nil {
 					return nil, nil, err
 				}
-				return issueShared.IssueFromArgWithFields(httpClient, f.BaseRepo, args[0], []string{"id", "url"})
+				return issueShared.IssueFromArgWithFields(httpClient, f.BaseRepo, args[0], []string{"id", "url", "comments"})
 			}
 			return prShared.CommentablePreRun(cmd, opts)
 		},
@@ -64,6 +64,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
 	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
 	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
+	cmd.Flags().BoolVar(&opts.EditLast, "edit-last", false, "Edit the last comment of the same author")
 
 	return cmd
 }

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -76,7 +76,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
 	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
 	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
-	cmd.Flags().BoolVar(&opts.Upsert, "edit-last", false, "Edit the last comment of the same author")
+	cmd.Flags().BoolVar(&opts.EditLast, "edit-last", false, "Edit the last comment of the same author")
 
 	return cmd
 }

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -2,7 +2,6 @@ package comment
 
 import (
 	"github.com/MakeNowJust/heredoc"
-	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	issueShared "github.com/cli/cli/v2/pkg/cmd/issue/shared"
 	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
@@ -41,18 +40,11 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 				if err != nil {
 					return nil, nil, err
 				}
-				return issueShared.IssueFromArgWithFields(httpClient, f.BaseRepo, args[0], []string{"id", "url", "comments"})
-			}
-			opts.RetrieveCurrentUser = func() (string, error) {
-				httpClient, err := f.HttpClient()
-				if err != nil {
-					return "", err
+				fields := []string{"id", "url"}
+				if opts.EditLast {
+					fields = append(fields, "comments")
 				}
-				baseRepo, err := f.BaseRepo()
-				if err != nil {
-					return "", err
-				}
-				return api.CurrentLoginName(api.NewClientFromHTTP(httpClient), baseRepo.RepoHost())
+				return issueShared.IssueFromArgWithFields(httpClient, f.BaseRepo, args[0], fields)
 			}
 			return prShared.CommentablePreRun(cmd, opts)
 		},

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -2,6 +2,7 @@ package comment
 
 import (
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	issueShared "github.com/cli/cli/v2/pkg/cmd/issue/shared"
 	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
@@ -41,6 +42,17 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 					return nil, nil, err
 				}
 				return issueShared.IssueFromArgWithFields(httpClient, f.BaseRepo, args[0], []string{"id", "url", "comments"})
+			}
+			opts.RetrieveCurrentUser = func() (string, error) {
+				httpClient, err := f.HttpClient()
+				if err != nil {
+					return "", err
+				}
+				baseRepo, err := f.BaseRepo()
+				if err != nil {
+					return "", err
+				}
+				return api.CurrentLoginName(api.NewClientFromHTTP(httpClient), baseRepo.RepoHost())
 			}
 			return prShared.CommentablePreRun(cmd, opts)
 		},

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -76,7 +76,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
 	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
 	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
-	cmd.Flags().BoolVar(&opts.EditLast, "edit-last", false, "Edit the last comment of the same author")
+	cmd.Flags().BoolVar(&opts.Upsert, "edit-last", false, "Edit the last comment of the same author")
 
 	return cmd
 }

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -237,6 +237,24 @@ func Test_commentRun(t *testing.T) {
 			stderr: "Opening github.com/OWNER/REPO/issues/123 in your browser.\n",
 		},
 		{
+			name: "non-interactive web with edit last",
+			input: &shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeWeb,
+				Body:        "",
+				EditLast:    true,
+
+				OpenInBrowser: func(string) error { return nil },
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StringResponse(`{"data":{"viewer":{"login":"octocat"}}}`),
+				)
+			},
+			stderr: "Opening github.com/OWNER/REPO/issues/123 in your browser.\n",
+		},
+		{
 			name: "non-interactive editor",
 			input: &shared.CommentableOptions{
 				Interactive: false,
@@ -312,8 +330,8 @@ func Test_commentRun(t *testing.T) {
 				ID:  "ISSUE-ID",
 				URL: "https://github.com/OWNER/REPO/issues/123",
 				Comments: api.Comments{Nodes: []api.Comment{
-					{ID: "id1", Author: api.Author{Login: "octocat"}},
-					{ID: "id2", Author: api.Author{Login: "monalisa"}},
+					{ID: "id1", Author: api.Author{Login: "octocat"}, URL: "https://github.com/OWNER/REPO/issues/123#issuecomment-111"},
+					{ID: "id2", Author: api.Author{Login: "monalisa"}, URL: "https://github.com/OWNER/REPO/issues/123#issuecomment-222"},
 				}},
 			}, ghrepo.New("OWNER", "REPO"), nil
 		}

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -215,7 +215,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: true,
 				InputType:   0,
 				Body:        "",
-				Upsert:      true,
+				EditLast:    true,
 
 				InteractiveEditSurvey: func(string) (string, error) { return "comment body", nil },
 				ConfirmSubmitSurvey:   func() (bool, error) { return true, nil },
@@ -242,7 +242,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeWeb,
 				Body:        "",
-				Upsert:      true,
+				EditLast:    true,
 
 				OpenInBrowser: func(string) error { return nil },
 			},
@@ -268,7 +268,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeEditor,
 				Body:        "",
-				Upsert:      true,
+				EditLast:    true,
 
 				EditSurvey: func(string) (string, error) { return "comment body", nil },
 			},
@@ -295,7 +295,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeInline,
 				Body:        "comment body",
-				Upsert:      true,
+				EditLast:    true,
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockCommentUpdate(t, reg)

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -283,6 +283,9 @@ func (c mockCommentable) Identifier() string {
 func (c mockCommentable) Link() string {
 	return "https://github.com/OWNER/REPO/issues/123"
 }
+func (c mockCommentable) LastCommentIdentifier(username string) string {
+	return "COMMENT-ID"
+}
 
 func mockCommentCreate(t *testing.T, reg *httpmock.Registry) {
 	reg.Register(

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
@@ -200,13 +201,29 @@ func Test_commentRun(t *testing.T) {
 				InputType:   0,
 				Body:        "",
 
-				InteractiveEditSurvey: func() (string, error) { return "comment body", nil },
+				InteractiveEditSurvey: func(string) (string, error) { return "comment body", nil },
 				ConfirmSubmitSurvey:   func() (bool, error) { return true, nil },
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockCommentCreate(t, reg)
 			},
 			stdout: "https://github.com/OWNER/REPO/issues/123#issuecomment-456\n",
+		},
+		{
+			name: "interactive editor with edit last",
+			input: &shared.CommentableOptions{
+				Interactive: true,
+				InputType:   0,
+				Body:        "",
+				EditLast:    true,
+
+				InteractiveEditSurvey: func(string) (string, error) { return "comment body", nil },
+				ConfirmSubmitSurvey:   func() (bool, error) { return true, nil },
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockCommentUpdate(t, reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/issues/123#issuecomment-111\n",
 		},
 		{
 			name: "non-interactive web",
@@ -226,12 +243,27 @@ func Test_commentRun(t *testing.T) {
 				InputType:   shared.InputTypeEditor,
 				Body:        "",
 
-				EditSurvey: func() (string, error) { return "comment body", nil },
+				EditSurvey: func(string) (string, error) { return "comment body", nil },
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockCommentCreate(t, reg)
 			},
 			stdout: "https://github.com/OWNER/REPO/issues/123#issuecomment-456\n",
+		},
+		{
+			name: "non-interactive editor with edit last",
+			input: &shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeEditor,
+				Body:        "",
+				EditLast:    true,
+
+				EditSurvey: func(string) (string, error) { return "comment body", nil },
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockCommentUpdate(t, reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/issues/123#issuecomment-111\n",
 		},
 		{
 			name: "non-interactive inline",
@@ -244,6 +276,19 @@ func Test_commentRun(t *testing.T) {
 				mockCommentCreate(t, reg)
 			},
 			stdout: "https://github.com/OWNER/REPO/issues/123#issuecomment-456\n",
+		},
+		{
+			name: "non-interactive inline with edit last",
+			input: &shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeInline,
+				Body:        "comment body",
+				EditLast:    true,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockCommentUpdate(t, reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/issues/123#issuecomment-111\n",
 		},
 	}
 	for _, tt := range tests {
@@ -263,7 +308,14 @@ func Test_commentRun(t *testing.T) {
 			return &http.Client{Transport: reg}, nil
 		}
 		tt.input.RetrieveCommentable = func() (shared.Commentable, ghrepo.Interface, error) {
-			return &mockCommentable{}, ghrepo.New("OWNER", "REPO"), nil
+			return &api.Issue{
+				ID:  "ISSUE-ID",
+				URL: "https://github.com/OWNER/REPO/issues/123",
+				Comments: api.Comments{Nodes: []api.Comment{
+					{ID: "id1", Author: api.Author{Login: "octocat"}},
+					{ID: "id2", Author: api.Author{Login: "monalisa"}},
+				}},
+			}, ghrepo.New("OWNER", "REPO"), nil
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -275,18 +327,6 @@ func Test_commentRun(t *testing.T) {
 	}
 }
 
-type mockCommentable struct{}
-
-func (c mockCommentable) Identifier() string {
-	return "ISSUE-ID"
-}
-func (c mockCommentable) Link() string {
-	return "https://github.com/OWNER/REPO/issues/123"
-}
-func (c mockCommentable) LastCommentIdentifier(username string) string {
-	return "COMMENT-ID"
-}
-
 func mockCommentCreate(t *testing.T, reg *httpmock.Registry) {
 	reg.Register(
 		httpmock.GraphQL(`mutation CommentCreate\b`),
@@ -296,6 +336,24 @@ func mockCommentCreate(t *testing.T, reg *httpmock.Registry) {
 		} } } } }`,
 			func(inputs map[string]interface{}) {
 				assert.Equal(t, "ISSUE-ID", inputs["subjectId"])
+				assert.Equal(t, "comment body", inputs["body"])
+			}),
+	)
+}
+
+func mockCommentUpdate(t *testing.T, reg *httpmock.Registry) {
+	reg.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StringResponse(`{"data":{"viewer":{"login":"octocat"}}}`),
+	)
+	reg.Register(
+		httpmock.GraphQL(`mutation CommentUpdate\b`),
+		httpmock.GraphQLMutation(`
+		{ "data": { "updateIssueComment": { "issueComment": {
+			"url": "https://github.com/OWNER/REPO/issues/123#issuecomment-111"
+		} } } }`,
+			func(inputs map[string]interface{}) {
+				assert.Equal(t, "id1", inputs["id"])
 				assert.Equal(t, "comment body", inputs["body"])
 			}),
 	)

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -329,9 +329,6 @@ func Test_commentRun(t *testing.T) {
 				}},
 			}, ghrepo.New("OWNER", "REPO"), nil
 		}
-		tt.input.RetrieveCurrentUser = func() (string, error) {
-			return "octocat", nil
-		}
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := shared.CommentableRun(tt.input)

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -215,7 +215,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: true,
 				InputType:   0,
 				Body:        "",
-				EditLast:    true,
+				Upsert:      true,
 
 				InteractiveEditSurvey: func(string) (string, error) { return "comment body", nil },
 				ConfirmSubmitSurvey:   func() (bool, error) { return true, nil },
@@ -242,7 +242,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeWeb,
 				Body:        "",
-				EditLast:    true,
+				Upsert:      true,
 
 				OpenInBrowser: func(string) error { return nil },
 			},
@@ -268,7 +268,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeEditor,
 				Body:        "",
-				EditLast:    true,
+				Upsert:      true,
 
 				EditSurvey: func(string) (string, error) { return "comment body", nil },
 			},
@@ -295,7 +295,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeInline,
 				Body:        "comment body",
-				EditLast:    true,
+				Upsert:      true,
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockCommentUpdate(t, reg)

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -324,7 +324,7 @@ func Test_commentRun(t *testing.T) {
 				ID:  "ISSUE-ID",
 				URL: "https://github.com/OWNER/REPO/issues/123",
 				Comments: api.Comments{Nodes: []api.Comment{
-					{ID: "id1", Author: api.Author{Login: "octocat"}, URL: "https://github.com/OWNER/REPO/issues/123#issuecomment-111"},
+					{ID: "id1", Author: api.Author{Login: "octocat"}, URL: "https://github.com/OWNER/REPO/issues/123#issuecomment-111", ViewerDidAuthor: true},
 					{ID: "id2", Author: api.Author{Login: "monalisa"}, URL: "https://github.com/OWNER/REPO/issues/123#issuecomment-222"},
 				}},
 			}, ghrepo.New("OWNER", "REPO"), nil

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -246,12 +246,6 @@ func Test_commentRun(t *testing.T) {
 
 				OpenInBrowser: func(string) error { return nil },
 			},
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query UserCurrent\b`),
-					httpmock.StringResponse(`{"data":{"viewer":{"login":"octocat"}}}`),
-				)
-			},
 			stderr: "Opening github.com/OWNER/REPO/issues/123 in your browser.\n",
 		},
 		{
@@ -335,6 +329,9 @@ func Test_commentRun(t *testing.T) {
 				}},
 			}, ghrepo.New("OWNER", "REPO"), nil
 		}
+		tt.input.RetrieveCurrentUser = func() (string, error) {
+			return "octocat", nil
+		}
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := shared.CommentableRun(tt.input)
@@ -360,10 +357,6 @@ func mockCommentCreate(t *testing.T, reg *httpmock.Registry) {
 }
 
 func mockCommentUpdate(t *testing.T, reg *httpmock.Registry) {
-	reg.Register(
-		httpmock.GraphQL(`query UserCurrent\b`),
-		httpmock.StringResponse(`{"data":{"viewer":{"login":"octocat"}}}`),
-	)
 	reg.Register(
 		httpmock.GraphQL(`mutation CommentUpdate\b`),
 		httpmock.GraphQLMutation(`

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -45,7 +45,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 			opts.RetrieveCommentable = func() (shared.Commentable, ghrepo.Interface, error) {
 				return finder.Find(shared.FindOptions{
 					Selector: selector,
-					Fields:   []string{"id", "url"},
+					Fields:   []string{"id", "url", "comments"},
 				})
 			}
 			return shared.CommentablePreRun(cmd, opts)
@@ -70,6 +70,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
 	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
 	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
+	cmd.Flags().BoolVar(&opts.EditLast, "edit-last", false, "Edit the last comment of the same author")
 
 	return cmd
 }

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -2,6 +2,7 @@ package comment
 
 import (
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -48,6 +49,17 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 					Fields:   []string{"id", "url", "comments"},
 				})
 			}
+			opts.RetrieveCurrentUser = func() (string, error) {
+				httpClient, err := f.HttpClient()
+				if err != nil {
+					return "", err
+				}
+				baseRepo, err := f.BaseRepo()
+				if err != nil {
+					return "", err
+				}
+				return api.CurrentLoginName(api.NewClientFromHTTP(httpClient), baseRepo.RepoHost())
+			}
 			return shared.CommentablePreRun(cmd, opts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -70,7 +82,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
 	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
 	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
-	cmd.Flags().BoolVar(&opts.EditLast, "edit-last", false, "Edit the last comment of the same author")
+	cmd.Flags().BoolVar(&opts.Upsert, "edit-last", false, "Edit the last comment of the same author")
 
 	return cmd
 }

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -2,7 +2,6 @@ package comment
 
 import (
 	"github.com/MakeNowJust/heredoc"
-	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -42,23 +41,16 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 			if len(args) > 0 {
 				selector = args[0]
 			}
+			fields := []string{"id", "url"}
+			if opts.EditLast {
+				fields = append(fields, "comments")
+			}
 			finder := shared.NewFinder(f)
 			opts.RetrieveCommentable = func() (shared.Commentable, ghrepo.Interface, error) {
 				return finder.Find(shared.FindOptions{
 					Selector: selector,
-					Fields:   []string{"id", "url", "comments"},
+					Fields:   fields,
 				})
-			}
-			opts.RetrieveCurrentUser = func() (string, error) {
-				httpClient, err := f.HttpClient()
-				if err != nil {
-					return "", err
-				}
-				baseRepo, err := f.BaseRepo()
-				if err != nil {
-					return "", err
-				}
-				return api.CurrentLoginName(api.NewClientFromHTTP(httpClient), baseRepo.RepoHost())
 			}
 			return shared.CommentablePreRun(cmd, opts)
 		},

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -82,7 +82,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
 	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
 	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
-	cmd.Flags().BoolVar(&opts.Upsert, "edit-last", false, "Edit the last comment of the same author")
+	cmd.Flags().BoolVar(&opts.EditLast, "edit-last", false, "Edit the last comment of the same author")
 
 	return cmd
 }

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -257,6 +257,24 @@ func Test_commentRun(t *testing.T) {
 			stderr: "Opening github.com/OWNER/REPO/pull/123 in your browser.\n",
 		},
 		{
+			name: "non-interactive web with edit last",
+			input: &shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeWeb,
+				Body:        "",
+				EditLast:    true,
+
+				OpenInBrowser: func(string) error { return nil },
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StringResponse(`{"data":{"viewer":{"login":"octocat"}}}`),
+				)
+			},
+			stderr: "Opening github.com/OWNER/REPO/pull/123 in your browser.\n",
+		},
+		{
 			name: "non-interactive editor",
 			input: &shared.CommentableOptions{
 				Interactive: false,
@@ -332,8 +350,8 @@ func Test_commentRun(t *testing.T) {
 				Number: 123,
 				URL:    "https://github.com/OWNER/REPO/pull/123",
 				Comments: api.Comments{Nodes: []api.Comment{
-					{ID: "id1", Author: api.Author{Login: "octocat"}},
-					{ID: "id2", Author: api.Author{Login: "monalisa"}},
+					{ID: "id1", Author: api.Author{Login: "octocat"}, URL: "https://github.com/OWNER/REPO/pull/123#issuecomment-111"},
+					{ID: "id2", Author: api.Author{Login: "monalisa"}, URL: "https://github.com/OWNER/REPO/pull/123#issuecomment-222"},
 				}},
 			}, ghrepo.New("OWNER", "REPO"), nil
 		}

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -235,7 +235,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: true,
 				InputType:   0,
 				Body:        "",
-				Upsert:      true,
+				EditLast:    true,
 
 				InteractiveEditSurvey: func(string) (string, error) { return "comment body", nil },
 				ConfirmSubmitSurvey:   func() (bool, error) { return true, nil },
@@ -262,7 +262,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeWeb,
 				Body:        "",
-				Upsert:      true,
+				EditLast:    true,
 
 				OpenInBrowser: func(string) error { return nil },
 			},
@@ -288,7 +288,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeEditor,
 				Body:        "",
-				Upsert:      true,
+				EditLast:    true,
 
 				EditSurvey: func(string) (string, error) { return "comment body", nil },
 			},
@@ -315,7 +315,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeInline,
 				Body:        "comment body",
-				Upsert:      true,
+				EditLast:    true,
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockCommentUpdate(t, reg)

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -349,9 +349,6 @@ func Test_commentRun(t *testing.T) {
 				}},
 			}, ghrepo.New("OWNER", "REPO"), nil
 		}
-		tt.input.RetrieveCurrentUser = func() (string, error) {
-			return "octocat", nil
-		}
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := shared.CommentableRun(tt.input)

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -266,12 +266,6 @@ func Test_commentRun(t *testing.T) {
 
 				OpenInBrowser: func(string) error { return nil },
 			},
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query UserCurrent\b`),
-					httpmock.StringResponse(`{"data":{"viewer":{"login":"octocat"}}}`),
-				)
-			},
 			stderr: "Opening github.com/OWNER/REPO/pull/123 in your browser.\n",
 		},
 		{
@@ -355,6 +349,9 @@ func Test_commentRun(t *testing.T) {
 				}},
 			}, ghrepo.New("OWNER", "REPO"), nil
 		}
+		tt.input.RetrieveCurrentUser = func() (string, error) {
+			return "octocat", nil
+		}
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := shared.CommentableRun(tt.input)
@@ -379,10 +376,6 @@ func mockCommentCreate(t *testing.T, reg *httpmock.Registry) {
 }
 
 func mockCommentUpdate(t *testing.T, reg *httpmock.Registry) {
-	reg.Register(
-		httpmock.GraphQL(`query UserCurrent\b`),
-		httpmock.StringResponse(`{"data":{"viewer":{"login":"octocat"}}}`),
-	)
 	reg.Register(
 		httpmock.GraphQL(`mutation CommentUpdate\b`),
 		httpmock.GraphQLMutation(`

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -344,7 +344,7 @@ func Test_commentRun(t *testing.T) {
 				Number: 123,
 				URL:    "https://github.com/OWNER/REPO/pull/123",
 				Comments: api.Comments{Nodes: []api.Comment{
-					{ID: "id1", Author: api.Author{Login: "octocat"}, URL: "https://github.com/OWNER/REPO/pull/123#issuecomment-111"},
+					{ID: "id1", Author: api.Author{Login: "octocat"}, URL: "https://github.com/OWNER/REPO/pull/123#issuecomment-111", ViewerDidAuthor: true},
 					{ID: "id2", Author: api.Author{Login: "monalisa"}, URL: "https://github.com/OWNER/REPO/pull/123#issuecomment-222"},
 				}},
 			}, ghrepo.New("OWNER", "REPO"), nil

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -235,7 +235,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: true,
 				InputType:   0,
 				Body:        "",
-				EditLast:    true,
+				Upsert:      true,
 
 				InteractiveEditSurvey: func(string) (string, error) { return "comment body", nil },
 				ConfirmSubmitSurvey:   func() (bool, error) { return true, nil },
@@ -262,7 +262,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeWeb,
 				Body:        "",
-				EditLast:    true,
+				Upsert:      true,
 
 				OpenInBrowser: func(string) error { return nil },
 			},
@@ -288,7 +288,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeEditor,
 				Body:        "",
-				EditLast:    true,
+				Upsert:      true,
 
 				EditSurvey: func(string) (string, error) { return "comment body", nil },
 			},
@@ -315,7 +315,7 @@ func Test_commentRun(t *testing.T) {
 				Interactive: false,
 				InputType:   shared.InputTypeInline,
 				Body:        "comment body",
-				EditLast:    true,
+				Upsert:      true,
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockCommentUpdate(t, reg)

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -221,13 +221,29 @@ func Test_commentRun(t *testing.T) {
 				InputType:   0,
 				Body:        "",
 
-				InteractiveEditSurvey: func() (string, error) { return "comment body", nil },
+				InteractiveEditSurvey: func(string) (string, error) { return "comment body", nil },
 				ConfirmSubmitSurvey:   func() (bool, error) { return true, nil },
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockCommentCreate(t, reg)
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
+		},
+		{
+			name: "interactive editor with edit last",
+			input: &shared.CommentableOptions{
+				Interactive: true,
+				InputType:   0,
+				Body:        "",
+				EditLast:    true,
+
+				InteractiveEditSurvey: func(string) (string, error) { return "comment body", nil },
+				ConfirmSubmitSurvey:   func() (bool, error) { return true, nil },
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockCommentUpdate(t, reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-111\n",
 		},
 		{
 			name: "non-interactive web",
@@ -247,12 +263,27 @@ func Test_commentRun(t *testing.T) {
 				InputType:   shared.InputTypeEditor,
 				Body:        "",
 
-				EditSurvey: func() (string, error) { return "comment body", nil },
+				EditSurvey: func(string) (string, error) { return "comment body", nil },
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockCommentCreate(t, reg)
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
+		},
+		{
+			name: "non-interactive editor with edit last",
+			input: &shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeEditor,
+				Body:        "",
+				EditLast:    true,
+
+				EditSurvey: func(string) (string, error) { return "comment body", nil },
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockCommentUpdate(t, reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-111\n",
 		},
 		{
 			name: "non-interactive inline",
@@ -265,6 +296,19 @@ func Test_commentRun(t *testing.T) {
 				mockCommentCreate(t, reg)
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-456\n",
+		},
+		{
+			name: "non-interactive inline with edit last",
+			input: &shared.CommentableOptions{
+				Interactive: false,
+				InputType:   shared.InputTypeInline,
+				Body:        "comment body",
+				EditLast:    true,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockCommentUpdate(t, reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123#issuecomment-111\n",
 		},
 	}
 	for _, tt := range tests {
@@ -287,6 +331,10 @@ func Test_commentRun(t *testing.T) {
 			return &api.PullRequest{
 				Number: 123,
 				URL:    "https://github.com/OWNER/REPO/pull/123",
+				Comments: api.Comments{Nodes: []api.Comment{
+					{ID: "id1", Author: api.Author{Login: "octocat"}},
+					{ID: "id2", Author: api.Author{Login: "monalisa"}},
+				}},
 			}, ghrepo.New("OWNER", "REPO"), nil
 		}
 
@@ -307,6 +355,24 @@ func mockCommentCreate(t *testing.T, reg *httpmock.Registry) {
 			"url": "https://github.com/OWNER/REPO/pull/123#issuecomment-456"
 		} } } } }`,
 			func(inputs map[string]interface{}) {
+				assert.Equal(t, "comment body", inputs["body"])
+			}),
+	)
+}
+
+func mockCommentUpdate(t *testing.T, reg *httpmock.Registry) {
+	reg.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StringResponse(`{"data":{"viewer":{"login":"octocat"}}}`),
+	)
+	reg.Register(
+		httpmock.GraphQL(`mutation CommentUpdate\b`),
+		httpmock.GraphQLMutation(`
+		{ "data": { "updateIssueComment": { "issueComment": {
+			"url": "https://github.com/OWNER/REPO/pull/123#issuecomment-111"
+		} } } }`,
+			func(inputs map[string]interface{}) {
+				assert.Equal(t, "id1", inputs["id"])
 				assert.Equal(t, "comment body", inputs["body"])
 			}),
 	)

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -125,14 +125,15 @@ func CommentableRun(opts *CommentableOptions) error {
 		if err != nil {
 			return err
 		}
-		if commentable.LastCommentIdentifier(username) == "" {
+		lastCommentId := commentable.LastCommentIdentifier(username)
+		if lastCommentId == "" {
 			params := api.CommentCreateInput{Body: opts.Body, SubjectId: commentable.Identifier()}
 			url, err = api.CommentCreate(apiClient, repo.RepoHost(), params)
 			if err != nil {
 				return err
 			}
 		} else {
-			params := api.CommentUpdateInput{Body: opts.Body, CommentId: commentable.LastCommentIdentifier(username)}
+			params := api.CommentUpdateInput{Body: opts.Body, CommentId: lastCommentId}
 			url, err = api.CommentUpdate(apiClient, repo.RepoHost(), params)
 			if err != nil {
 				return err

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -101,7 +101,12 @@ func CommentableRun(opts *CommentableOptions) error {
 
 	switch opts.InputType {
 	case InputTypeWeb:
-		openURL := commentable.Link() + "#issuecomment-new"
+		openURL := ""
+		if lastComment == nil {
+			openURL = commentable.Link() + "#issuecomment-new"
+		} else {
+			openURL = lastComment.Link()
+		}
 		if opts.IO.IsStdoutTTY() && !opts.Quiet {
 			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", text.DisplayURL(openURL))
 		}

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -44,7 +44,7 @@ type CommentableOptions struct {
 	Interactive           bool
 	InputType             InputType
 	Body                  string
-	EditLast              bool
+	Upsert                bool
 	Quiet                 bool
 }
 
@@ -86,7 +86,7 @@ func CommentableRun(opts *CommentableOptions) error {
 	}
 
 	var lastComment *api.Comment
-	if opts.EditLast {
+	if opts.Upsert {
 		username, err := opts.RetrieveCurrentUser()
 		if err != nil {
 			return err

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -29,7 +29,7 @@ const (
 type Commentable interface {
 	Link() string
 	Identifier() string
-	CommentsForUser(username string) []api.Comment
+	CurrentUserComments() []api.Comment
 }
 
 type CommentableOptions struct {
@@ -149,7 +149,7 @@ func updateComment(commentable Commentable, opts *CommentableOptions) error {
 		return err
 	}
 
-	comments := commentable.CommentsForUser(username)
+	comments := commentable.CurrentUserComments()
 	if len(comments) == 0 {
 		return fmt.Errorf("no comments created by %s found", username)
 	}

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -29,7 +29,7 @@ const (
 type Commentable interface {
 	Link() string
 	Identifier() string
-	LastComment(username string) (*api.Comment, error)
+	CommentsForUser(username string) []api.Comment
 }
 
 type CommentableOptions struct {
@@ -91,7 +91,10 @@ func CommentableRun(opts *CommentableOptions) error {
 		if err != nil {
 			return err
 		}
-		lastComment, _ = commentable.LastComment(username)
+		comments := commentable.CommentsForUser(username)
+		if len(comments) > 0 {
+			lastComment = &comments[len(comments)-1]
+		}
 	}
 
 	switch opts.InputType {

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -36,6 +36,7 @@ type CommentableOptions struct {
 	IO                    *iostreams.IOStreams
 	HttpClient            func() (*http.Client, error)
 	RetrieveCommentable   func() (Commentable, ghrepo.Interface, error)
+	RetrieveCurrentUser   func() (string, error)
 	EditSurvey            func(string) (string, error)
 	InteractiveEditSurvey func(string) (string, error)
 	ConfirmSubmitSurvey   func() (bool, error)
@@ -84,15 +85,9 @@ func CommentableRun(opts *CommentableOptions) error {
 		return err
 	}
 
-	httpClient, err := opts.HttpClient()
-	if err != nil {
-		return err
-	}
-	apiClient := api.NewClientFromHTTP(httpClient)
-
 	var lastComment *api.Comment
 	if opts.EditLast {
-		username, err := api.CurrentLoginName(apiClient, repo.RepoHost())
+		username, err := opts.RetrieveCurrentUser()
 		if err != nil {
 			return err
 		}
@@ -138,6 +133,11 @@ func CommentableRun(opts *CommentableOptions) error {
 		}
 	}
 
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+	apiClient := api.NewClientFromHTTP(httpClient)
 	url := ""
 	if lastComment == nil {
 		params := api.CommentCreateInput{Body: opts.Body, SubjectId: commentable.Identifier()}

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -36,7 +36,6 @@ type CommentableOptions struct {
 	IO                    *iostreams.IOStreams
 	HttpClient            func() (*http.Client, error)
 	RetrieveCommentable   func() (Commentable, ghrepo.Interface, error)
-	RetrieveCurrentUser   func() (string, error)
 	EditSurvey            func(string) (string, error)
 	InteractiveEditSurvey func(string) (string, error)
 	ConfirmSubmitSurvey   func() (bool, error)
@@ -144,14 +143,9 @@ func createComment(commentable Commentable, opts *CommentableOptions) error {
 }
 
 func updateComment(commentable Commentable, opts *CommentableOptions) error {
-	username, err := opts.RetrieveCurrentUser()
-	if err != nil {
-		return err
-	}
-
 	comments := commentable.CurrentUserComments()
 	if len(comments) == 0 {
-		return fmt.Errorf("no comments created by %s found", username)
+		return fmt.Errorf("no comments found for current user")
 	}
 
 	lastComment := &comments[len(comments)-1]

--- a/pkg/cmd/pr/shared/comments.go
+++ b/pkg/cmd/pr/shared/comments.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Comment interface {
+	Identifier() string
 	AuthorLogin() string
 	Association() string
 	Content() string


### PR DESCRIPTION
Fixes #3613 

Add `--edit-last` option to `issue/pr comment`.
This option edits the last comment that you are the author of. If the comment does not exist, a new one is added.
This is mainly useful when editing comments by the bot.