### PR TITLE
Decouple from Cobra

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/itchyny/gojq v0.12.8 // indirect
 	github.com/itchyny/timefmt-go v0.1.3 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -74,3 +73,5 @@ require (
 )
 
 replace golang.org/x/crypto => github.com/cli/crypto v0.0.0-20210929142629-6be313f59b03
+
+replace github.com/spf13/cobra => ./internal/cobra

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,6 @@ github.com/henvic/httpretty v0.0.6/go.mod h1:X38wLjWXHkXT7r2+uK8LjCMne9rsuNaBLJ+
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
-github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/itchyny/gojq v0.12.8 h1:Zxcwq8w4IeR8JJYEtoG2MWJZUv0RGY6QqJcO1cqV8+A=
 github.com/itchyny/gojq v0.12.8/go.mod h1:gE2kZ9fVRU0+JAksaTzjIlgnCa2akU+a1V0WXgJQN5c=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=
@@ -229,8 +227,6 @@ github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 h1:B1PEwpArrNp4dk
 github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/sourcegraph/jsonrpc2 v0.1.0 h1:ohJHjZ+PcaLxDUjqk2NC3tIGsVa5bXThe1ZheSXOjuk=
 github.com/sourcegraph/jsonrpc2 v0.1.0/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
-github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
-github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -518,7 +514,6 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/h2non/gock.v1 v1.1.2 h1:jBbHXgGBK/AoPVfJh5x4r/WxIrElvbLel8TCZkkZJoY=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cobra/args.go
+++ b/internal/cobra/args.go
@@ -1,0 +1,39 @@
+package cobra
+
+import "fmt"
+
+type PositionalArgs func(cmd *Command, args []string) error
+
+func MinimumNArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) < n {
+			return fmt.Errorf("requires at least %d arguments, got %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+func MaximumNArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) > n {
+			return fmt.Errorf("accepts at most %d arguments, got %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+func ExactArgs(n int) PositionalArgs {
+	return func(cmd *Command, args []string) error {
+		if len(args) > n {
+			return fmt.Errorf("accepts exactly %d arguments, got %d", n, len(args))
+		}
+		return nil
+	}
+}
+
+var NoArgs PositionalArgs = func(cmd *Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("does not accept any arguments, got %v", args)
+	}
+	return nil
+}

--- a/internal/cobra/command.go
+++ b/internal/cobra/command.go
@@ -1,0 +1,79 @@
+package cobra
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+type Command struct {
+	Use     string
+	Short   string
+	Long    string
+	Example string
+
+	Hidden      bool
+	Deprecated  string
+	Annotations map[string]string
+	Aliases     []string
+	SuggestFor  []string
+
+	DisableFlagParsing         bool
+	DisableFlagsInUseLine      bool
+	SilenceErrors              bool
+	SilenceUsage               bool
+	SuggestionsMinimumDistance int
+
+	PreRun  func(cmd *Command, args []string)
+	Run     func(cmd *Command, args []string)
+	PreRunE func(cmd *Command, args []string) error
+	RunE    func(cmd *Command, args []string) error
+	Args    PositionalArgs
+
+	PersistentPreRunE func(cmd *Command, args []string) error
+	ValidArgsFunction func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective)
+
+	args          []string
+	outStream     io.Writer
+	errStream     io.Writer
+	localFlags    *pflag.FlagSet
+	parentCommand *Command
+	childCommands []*Command
+}
+
+func (c *Command) SetArgs(args []string) {
+	c.args = args
+}
+
+func (c *Command) SetIn(io.Reader) {}
+func (c *Command) SetOut(w io.Writer) {
+	c.outStream = w
+}
+func (c *Command) SetErr(w io.Writer) {
+	c.errStream = w
+}
+
+func (c *Command) ErrOrStderr() io.Writer {
+	if c.errStream != nil {
+		return c.errStream
+	}
+	return os.Stderr
+}
+
+func (c *Command) Context() context.Context {
+	return nil
+}
+
+func (c *Command) Name() string {
+	if idx := strings.IndexRune(c.Use, ' '); idx != -1 {
+		return c.Use[:idx]
+	}
+	return c.Use
+}
+
+func (c *Command) UseLine() string {
+	return c.Use
+}

--- a/internal/cobra/completion.go
+++ b/internal/cobra/completion.go
@@ -1,0 +1,55 @@
+package cobra
+
+import "io"
+
+type ShellCompDirective int
+
+const (
+	// ShellCompDirectiveError indicates an error occurred and completions should be ignored.
+	ShellCompDirectiveError ShellCompDirective = 1 << iota
+
+	// ShellCompDirectiveNoSpace indicates that the shell should not add a space
+	// after the completion even if there is a single completion provided.
+	ShellCompDirectiveNoSpace
+
+	// ShellCompDirectiveNoFileComp indicates that the shell should not provide
+	// file completion even when no completion is provided.
+	ShellCompDirectiveNoFileComp
+
+	// ShellCompDirectiveFilterFileExt indicates that the provided completions
+	// should be used as file extension filters.
+	// For flags, using Command.MarkFlagFilename() and Command.MarkPersistentFlagFilename()
+	// is a shortcut to using this directive explicitly.  The BashCompFilenameExt
+	// annotation can also be used to obtain the same behavior for flags.
+	ShellCompDirectiveFilterFileExt
+
+	// ShellCompDirectiveFilterDirs indicates that only directory names should
+	// be provided in file completion.  To request directory names within another
+	// directory, the returned completions should specify the directory within
+	// which to search.  The BashCompSubdirsInDir annotation can be used to
+	// obtain the same behavior but only for flags.
+	ShellCompDirectiveFilterDirs
+
+	// ShellCompDirectiveDefault indicates to let the shell perform its default
+	// behavior after completions have been provided.
+	// This one must be last to avoid messing up the iota count.
+	ShellCompDirectiveDefault ShellCompDirective = 0
+)
+
+const (
+	// ShellCompRequestCmd is the name of the hidden command that is used to request
+	// completion results from the program.  It is used by the shell completion scripts.
+	ShellCompRequestCmd = "__complete"
+	// ShellCompNoDescRequestCmd is the name of the hidden command that is used to request
+	// completion results without their description.  It is used by the shell completion scripts.
+	ShellCompNoDescRequestCmd = "__completeNoDesc"
+)
+
+func (c *Command) RegisterFlagCompletionFunc(flagName string, f func(cmd *Command, args []string, toComplete string) ([]string, ShellCompDirective)) error {
+	return nil
+}
+
+func (c *Command) GenBashCompletionV2(io.Writer, bool) error       { return nil }
+func (c *Command) GenZshCompletion(io.Writer) error                { return nil }
+func (c *Command) GenFishCompletion(io.Writer, bool) error         { return nil }
+func (c *Command) GenPowerShellCompletionWithDesc(io.Writer) error { return nil }

--- a/internal/cobra/dispatch.go
+++ b/internal/cobra/dispatch.go
@@ -1,0 +1,124 @@
+package cobra
+
+import (
+	"fmt"
+	"os"
+)
+
+func (c *Command) Traverse(args []string) (*Command, []string, error) {
+	foundCmd := c
+	for {
+		if len(args) == 0 {
+			return foundCmd, args, nil
+		}
+
+		cmdName := args[0]
+		if cmdName != "" && cmdName[0] == '-' {
+			return foundCmd, args, nil
+		}
+
+		isFound := false
+		for _, cmd := range foundCmd.childCommands {
+			if isNameMatch(cmd, cmdName) {
+				foundCmd = cmd
+				isFound = true
+				break
+			}
+		}
+		if !isFound {
+			if !foundCmd.Runnable() {
+				return foundCmd, args, fmt.Errorf("%s: could not find command %q", foundCmd.CommandPath(), cmdName)
+			}
+			return foundCmd, args, nil
+		}
+
+		args = args[1:]
+	}
+}
+
+func isNameMatch(c *Command, name string) bool {
+	if c.Name() == name {
+		return true
+	}
+	for _, alias := range c.Aliases {
+		if alias == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Command) ExecuteC() (*Command, error) {
+	cmd, args, err := c.Traverse(c.args)
+	if err != nil {
+		return cmd, err
+	}
+
+	flags := cmd.Flags()
+	if err := flags.Parse(args); err != nil {
+		return cmd, err
+	}
+	args = flags.Args()
+
+	if !cmd.Runnable() {
+		fmt.Fprint(os.Stdout, cmd.UsageString())
+		return cmd, nil
+	}
+
+	if cmd.Args != nil {
+		if err := cmd.Args(cmd, args); err != nil {
+			return cmd, err
+		}
+	}
+
+	if cmd.PreRunE != nil {
+		if err := cmd.PreRunE(cmd, args); err != nil {
+			return cmd, err
+		}
+	} else if cmd.PreRun != nil {
+		cmd.PreRun(cmd, args)
+	}
+
+	if cmd.RunE != nil {
+		return cmd, cmd.RunE(cmd, args)
+	}
+	cmd.Run(cmd, args)
+	return cmd, nil
+}
+
+func (c *Command) CommandPath() string {
+	if c.HasParent() {
+		return c.Parent().CommandPath() + " " + c.Name()
+	}
+	return c.Name()
+}
+
+func (c *Command) Runnable() bool {
+	return c.RunE != nil || c.Run != nil
+}
+
+func (c *Command) Commands() []*Command {
+	return c.childCommands
+}
+
+func (c *Command) AddCommand(cmds ...*Command) {
+	for _, child := range cmds {
+		child.parentCommand = c
+	}
+	c.childCommands = append(c.childCommands, cmds...)
+}
+
+func (c *Command) HasParent() bool {
+	return c.Parent() != nil
+}
+
+func (c *Command) Parent() *Command {
+	return nil
+}
+
+func (c *Command) Root() *Command {
+	if c.HasParent() {
+		return c.Parent().Root()
+	}
+	return c
+}

--- a/internal/cobra/flags.go
+++ b/internal/cobra/flags.go
@@ -1,0 +1,38 @@
+package cobra
+
+import "github.com/spf13/pflag"
+
+func (c *Command) ArgsLenAtDash() int {
+	return 0
+}
+
+func (c *Command) Flags() *pflag.FlagSet {
+	if c.localFlags == nil {
+		flags := pflag.NewFlagSet(c.CommandPath(), pflag.ContinueOnError)
+		flags.SetOutput(c.ErrOrStderr())
+		c.localFlags = flags
+	}
+	return c.localFlags
+}
+
+func (c *Command) LocalFlags() *pflag.FlagSet {
+	return c.Flags()
+}
+
+func (c *Command) PersistentFlags() *pflag.FlagSet {
+	return pflag.NewFlagSet("", pflag.ContinueOnError)
+}
+
+func (c *Command) InheritedFlags() *pflag.FlagSet {
+	return pflag.NewFlagSet("", pflag.ContinueOnError)
+}
+
+func (c *Command) NonInheritedFlags() *pflag.FlagSet {
+	return c.Flags()
+}
+
+func (c *Command) FlagErrorFunc() func(*Command, error) error {
+	return nil
+}
+
+func (c *Command) SetFlagErrorFunc(f func(*Command, error) error) {}

--- a/internal/cobra/go.mod
+++ b/internal/cobra/go.mod
@@ -1,0 +1,3 @@
+module github.com/spf13/cobra
+
+go 1.18

--- a/internal/cobra/help.go
+++ b/internal/cobra/help.go
@@ -1,0 +1,24 @@
+package cobra
+
+func (c *Command) UsageString() string {
+	return "Usage: " + c.UseLine() + "\n"
+}
+
+func (c *Command) InitDefaultHelpCmd()  {}
+func (c *Command) InitDefaultHelpFlag() {}
+
+func (c *Command) IsAvailableCommand() bool {
+	return true
+}
+
+func (c *Command) IsAdditionalHelpTopicCommand() bool {
+	return true
+}
+
+func (c *Command) SetHelpFunc(f func(*Command, []string)) {}
+
+func (c *Command) SetUsageFunc(f func(*Command) error) {}
+
+func (c *Command) SuggestionsFor(typedName string) []string {
+	return nil
+}

--- a/internal/cobra/legacy.go
+++ b/internal/cobra/legacy.go
@@ -1,0 +1,3 @@
+package cobra
+
+var MousetrapHelpText string


### PR DESCRIPTION
This code spike proposes a way to decouple from the Cobra codebase by making a minimal implementation of the Cobra APIs that we use.

In our experience, the Cobra codebase gave us more problems on the long term than it solved for us in the short term. I was tempted to make a command dispatcher that would give us more control and more granular error handling than Cobra does right now, and this is an experiment in doing just that (sans better error handling).

There is still a lot that is missing here: namely the auto-generated help system and completions support. The latter I would never try to re-implement, so if we decide to go forwards with this, in the future I would bring back the original Cobra as a dependency just to handle completion support.