### PR TITLE
Fix Codespace Creation Devcontainer bug

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -527,7 +527,7 @@ type Machine struct {
 }
 
 // GetCodespacesMachines returns the codespaces machines for the given repo, branch and location.
-func (a *API) GetCodespacesMachines(ctx context.Context, repoID int, branch, location string) ([]*Machine, error) {
+func (a *API) GetCodespacesMachines(ctx context.Context, repoID int, branch, location string, devcontainerPath string) ([]*Machine, error) {
 	reqURL := fmt.Sprintf("%s/repositories/%d/codespaces/machines", a.githubAPI, repoID)
 	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
@@ -537,6 +537,7 @@ func (a *API) GetCodespacesMachines(ctx context.Context, repoID int, branch, loc
 	q := req.URL.Query()
 	q.Add("location", location)
 	q.Add("ref", branch)
+	q.Add("devcontainer_path", devcontainerPath)
 	req.URL.RawQuery = q.Encode()
 
 	a.setHeaders(req)

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -101,7 +101,7 @@ type apiClient interface {
 	CreateCodespace(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error)
 	EditCodespace(ctx context.Context, codespaceName string, params *api.EditCodespaceParams) (*api.Codespace, error)
 	GetRepository(ctx context.Context, nwo string) (*api.Repository, error)
-	GetCodespacesMachines(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error)
+	GetCodespacesMachines(ctx context.Context, repoID int, branch, location string, devcontainerPath string) ([]*api.Machine, error)
 	GetCodespaceRepositoryContents(ctx context.Context, codespace *api.Codespace, path string) ([]byte, error)
 	ListDevContainers(ctx context.Context, repoID int, branch string, limit int) (devcontainers []api.DevContainerEntry, err error)
 	GetCodespaceRepoSuggestions(ctx context.Context, partialSearch string, params api.RepoSearchParameters) ([]string, error)

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -225,7 +225,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		}
 	}
 
-	machine, err := getMachineName(ctx, a.apiClient, repository.ID, opts.machine, branch, userInputs.Location)
+	machine, err := getMachineName(ctx, a.apiClient, repository.ID, opts.machine, branch, userInputs.Location, devContainerPath)
 	if err != nil {
 		return fmt.Errorf("error getting machine type: %w", err)
 	}
@@ -411,8 +411,8 @@ func (a *App) showStatus(ctx context.Context, codespace *api.Codespace) error {
 }
 
 // getMachineName prompts the user to select the machine type, or validates the machine if non-empty.
-func getMachineName(ctx context.Context, apiClient apiClient, repoID int, machine, branch, location string) (string, error) {
-	machines, err := apiClient.GetCodespacesMachines(ctx, repoID, branch, location)
+func getMachineName(ctx context.Context, apiClient apiClient, repoID int, machine, branch, location string, devcontainerPath string) (string, error) {
+	machines, err := apiClient.GetCodespacesMachines(ctx, repoID, branch, location, devcontainerPath)
 	if err != nil {
 		return "", fmt.Errorf("error requesting machine instance types: %w", err)
 	}

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -45,7 +45,7 @@ func TestApp_Create(t *testing.T) {
 					ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
 						return []api.DevContainerEntry{{Path: ".devcontainer/devcontainer.json"}}, nil
 					},
-					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error) {
+					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string, devcontainerPath string) ([]*api.Machine, error) {
 						return []*api.Machine{
 							{
 								Name:        "GIGA",
@@ -99,7 +99,7 @@ func TestApp_Create(t *testing.T) {
 							Type:  "User",
 						}, nil
 					},
-					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error) {
+					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string, devcontainerPath string) ([]*api.Machine, error) {
 						return []*api.Machine{
 							{
 								Name:        "GIGA",
@@ -156,7 +156,7 @@ func TestApp_Create(t *testing.T) {
 					ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
 						return []api.DevContainerEntry{}, nil
 					},
-					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error) {
+					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string, devcontainerPath string) ([]*api.Machine, error) {
 						return []*api.Machine{
 							{
 								Name:        "GIGA",
@@ -246,7 +246,7 @@ func TestApp_Create(t *testing.T) {
 					ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
 						return []api.DevContainerEntry{}, nil
 					},
-					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error) {
+					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string, devcontainerPath string) ([]*api.Machine, error) {
 						return []*api.Machine{
 							{
 								Name:        "GIGA",
@@ -302,7 +302,7 @@ func TestApp_Create(t *testing.T) {
 					ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
 						return []api.DevContainerEntry{{Path: ".devcontainer/devcontainer.json"}}, nil
 					},
-					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error) {
+					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string, devcontainerPath string) ([]*api.Machine, error) {
 						return []*api.Machine{
 							{
 								Name:        "GIGA",
@@ -384,7 +384,7 @@ Alternatively, you can run "create" with the "--default-permissions" option to c
 					ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
 						return []api.DevContainerEntry{{Path: ".devcontainer/devcontainer.json"}}, nil
 					},
-					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error) {
+					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string, devcontainerPath string) ([]*api.Machine, error) {
 						return []*api.Machine{
 							{
 								Name:        "GIGA",
@@ -429,7 +429,7 @@ Alternatively, you can run "create" with the "--default-permissions" option to c
 					ListDevContainersFunc: func(ctx context.Context, repoID int, branch string, limit int) ([]api.DevContainerEntry, error) {
 						return []api.DevContainerEntry{{Path: ".devcontainer/devcontainer.json"}}, nil
 					},
-					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string) ([]*api.Machine, error) {
+					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string, devcontainerPath string) ([]*api.Machine, error) {
 						return []*api.Machine{
 							{
 								Name:        "GIGA",

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -37,7 +37,7 @@ import (
 // 			GetCodespaceRepositoryContentsFunc: func(ctx context.Context, codespace *api.Codespace, path string) ([]byte, error) {
 // 				panic("mock out the GetCodespaceRepositoryContents method")
 // 			},
-// 			GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch string, location string) ([]*api.Machine, error) {
+// 			GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch string, location string, devcontainerPath string) ([]*api.Machine, error) {
 // 				panic("mock out the GetCodespacesMachines method")
 // 			},
 // 			GetOrgMemberCodespaceFunc: func(ctx context.Context, orgName string, userName string, codespaceName string) (*api.Codespace, error) {
@@ -87,7 +87,7 @@ type apiClientMock struct {
 	GetCodespaceRepositoryContentsFunc func(ctx context.Context, codespace *api.Codespace, path string) ([]byte, error)
 
 	// GetCodespacesMachinesFunc mocks the GetCodespacesMachines method.
-	GetCodespacesMachinesFunc func(ctx context.Context, repoID int, branch string, location string) ([]*api.Machine, error)
+	GetCodespacesMachinesFunc func(ctx context.Context, repoID int, branch string, location string, devcontainerPath string) ([]*api.Machine, error)
 
 	// GetOrgMemberCodespaceFunc mocks the GetOrgMemberCodespace method.
 	GetOrgMemberCodespaceFunc func(ctx context.Context, orgName string, userName string, codespaceName string) (*api.Codespace, error)
@@ -180,6 +180,8 @@ type apiClientMock struct {
 			Branch string
 			// Location is the location argument value.
 			Location string
+			// DevcontainerPath is the devcontainerPath argument value.
+			DevcontainerPath string
 		}
 		// GetOrgMemberCodespace holds details about calls to the GetOrgMemberCodespace method.
 		GetOrgMemberCodespace []struct {
@@ -522,41 +524,45 @@ func (mock *apiClientMock) GetCodespaceRepositoryContentsCalls() []struct {
 }
 
 // GetCodespacesMachines calls GetCodespacesMachinesFunc.
-func (mock *apiClientMock) GetCodespacesMachines(ctx context.Context, repoID int, branch string, location string) ([]*api.Machine, error) {
+func (mock *apiClientMock) GetCodespacesMachines(ctx context.Context, repoID int, branch string, location string, devcontainerPath string) ([]*api.Machine, error) {
 	if mock.GetCodespacesMachinesFunc == nil {
 		panic("apiClientMock.GetCodespacesMachinesFunc: method is nil but apiClient.GetCodespacesMachines was just called")
 	}
 	callInfo := struct {
-		Ctx      context.Context
-		RepoID   int
-		Branch   string
-		Location string
+		Ctx              context.Context
+		RepoID           int
+		Branch           string
+		Location         string
+		DevcontainerPath string
 	}{
-		Ctx:      ctx,
-		RepoID:   repoID,
-		Branch:   branch,
-		Location: location,
+		Ctx:              ctx,
+		RepoID:           repoID,
+		Branch:           branch,
+		Location:         location,
+		DevcontainerPath: devcontainerPath,
 	}
 	mock.lockGetCodespacesMachines.Lock()
 	mock.calls.GetCodespacesMachines = append(mock.calls.GetCodespacesMachines, callInfo)
 	mock.lockGetCodespacesMachines.Unlock()
-	return mock.GetCodespacesMachinesFunc(ctx, repoID, branch, location)
+	return mock.GetCodespacesMachinesFunc(ctx, repoID, branch, location, devcontainerPath)
 }
 
 // GetCodespacesMachinesCalls gets all the calls that were made to GetCodespacesMachines.
 // Check the length with:
 //     len(mockedapiClient.GetCodespacesMachinesCalls())
 func (mock *apiClientMock) GetCodespacesMachinesCalls() []struct {
-	Ctx      context.Context
-	RepoID   int
-	Branch   string
-	Location string
+	Ctx              context.Context
+	RepoID           int
+	Branch           string
+	Location         string
+	DevcontainerPath string
 } {
 	var calls []struct {
-		Ctx      context.Context
-		RepoID   int
-		Branch   string
-		Location string
+		Ctx              context.Context
+		RepoID           int
+		Branch           string
+		Location         string
+		DevcontainerPath string
 	}
 	mock.lockGetCodespacesMachines.RLock()
 	calls = mock.calls.GetCodespacesMachines


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes https://github.com/github/codespaces/issues/8916 by passing in the devcontainer_path into the API call to get a list of available machines.
