### PR TITLE
Add cs rebuild command

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -210,6 +210,8 @@ const (
 	CodespaceStateShutdown = "Shutdown"
 	// CodespaceStateStarting is the state for a starting codespace environment.
 	CodespaceStateStarting = "Starting"
+	// CodespaceStateRebuilding is the state for a rebuilding codespace environment.
+	CodespaceStateRebuilding = "Rebuilding"
 )
 
 type CodespaceConnection struct {

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -66,7 +66,7 @@ type liveshareSession interface {
 	StartSharing(context.Context, string, int) (liveshare.ChannelID, error)
 	StartSSHServer(context.Context) (int, string, error)
 	StartSSHServerWithOptions(context.Context, liveshare.StartSSHServerOptions) (int, string, error)
-	Rebuild(context.Context) error
+	RebuildContainer(context.Context) error
 }
 
 // Connects to a codespace using Live Share and returns that session

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -66,6 +66,7 @@ type liveshareSession interface {
 	StartSharing(context.Context, string, int) (liveshare.ChannelID, error)
 	StartSSHServer(context.Context) (int, string, error)
 	StartSSHServerWithOptions(context.Context, liveshare.StartSSHServerOptions) (int, string, error)
+	Rebuild(context.Context) error
 }
 
 // Connects to a codespace using Live Share and returns that session

--- a/pkg/cmd/codespace/rebuild.go
+++ b/pkg/cmd/codespace/rebuild.go
@@ -34,8 +34,7 @@ func (a *App) Rebuild(ctx context.Context, codespaceName string) (err error) {
 		return err
 	}
 
-	// Users can't change their codespace while it's rebuilding, so there's
-	// no need to execute this command.
+	// There's no need to rebuild again because users can't modify their codespace while it rebuilds
 	if codespace.State == api.CodespaceStateRebuilding {
 		fmt.Fprintf(a.io.Out, "%s is already rebuilding\n", codespace.Name)
 		return nil
@@ -43,13 +42,13 @@ func (a *App) Rebuild(ctx context.Context, codespaceName string) (err error) {
 
 	session, err := startLiveShareSession(ctx, codespace, a, false, "")
 	if err != nil {
-		return err
+		return fmt.Errorf("starting Live Share session: %w", err)
 	}
 	defer safeClose(session, &err)
 
 	err = session.Rebuild(ctx)
 	if err != nil {
-		return fmt.Errorf("couldn't rebuild codespace: %w", err)
+		return fmt.Errorf("rebuilding codespace via session: %w", err)
 	}
 
 	fmt.Fprintf(a.io.Out, "%s is rebuilding\n", codespace.Name)

--- a/pkg/cmd/codespace/rebuild.go
+++ b/pkg/cmd/codespace/rebuild.go
@@ -1,0 +1,57 @@
+package codespace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/spf13/cobra"
+)
+
+func newRebuildCmd(app *App) *cobra.Command {
+	var codespace string
+
+	rebuildCmd := &cobra.Command{
+		Use:   "rebuild",
+		Short: "Rebuild a codespace",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return app.Rebuild(cmd.Context(), codespace)
+		},
+	}
+
+	rebuildCmd.Flags().StringVarP(&codespace, "codespace", "c", "", "Name of the codespace")
+
+	return rebuildCmd
+}
+
+func (a *App) Rebuild(ctx context.Context, codespaceName string) (err error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	codespace, err := getOrChooseCodespace(ctx, a.apiClient, codespaceName)
+	if err != nil {
+		return err
+	}
+
+	// Users can't change their codespace while it's rebuilding, so there's
+	// no need to execute this command.
+	if codespace.State == api.CodespaceStateRebuilding {
+		fmt.Fprintf(a.io.Out, "%s is already rebuilding\n", codespace.Name)
+		return nil
+	}
+
+	session, err := startLiveShareSession(ctx, codespace, a, false, "")
+	if err != nil {
+		return err
+	}
+	defer safeClose(session, &err)
+
+	err = session.Rebuild(ctx)
+	if err != nil {
+		return fmt.Errorf("couldn't rebuild codespace: %w", err)
+	}
+
+	fmt.Fprintf(a.io.Out, "%s is rebuilding\n", codespace.Name)
+	return nil
+}

--- a/pkg/cmd/codespace/rebuild.go
+++ b/pkg/cmd/codespace/rebuild.go
@@ -46,7 +46,7 @@ func (a *App) Rebuild(ctx context.Context, codespaceName string) (err error) {
 	}
 	defer safeClose(session, &err)
 
-	err = session.Rebuild(ctx)
+	err = session.RebuildContainer(ctx)
 	if err != nil {
 		return fmt.Errorf("rebuilding codespace via session: %w", err)
 	}

--- a/pkg/cmd/codespace/rebuild_test.go
+++ b/pkg/cmd/codespace/rebuild_test.go
@@ -13,7 +13,7 @@ func TestAlreadyRebuildingCodespace(t *testing.T) {
 
 	err := app.Rebuild(context.Background(), "rebuildingCodespace")
 	if err != nil {
-		t.Errorf("error rebuilding a codespace that is already rebuilding: %v", err)
+		t.Errorf("rebuilding a codespace that was already rebuilding: %v", err)
 	}
 }
 

--- a/pkg/cmd/codespace/rebuild_test.go
+++ b/pkg/cmd/codespace/rebuild_test.go
@@ -1,0 +1,36 @@
+package codespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+func TestAlreadyRebuildingCodespace(t *testing.T) {
+	app := testingRebuildApp()
+
+	err := app.Rebuild(context.Background(), "rebuildingCodespace")
+	if err != nil {
+		t.Errorf("error rebuilding a codespace that is already rebuilding: %v", err)
+	}
+}
+
+func testingRebuildApp() *App {
+	rebuildingCodespace := &api.Codespace{
+		Name:  "rebuildingCodespace",
+		State: api.CodespaceStateRebuilding,
+	}
+	apiMock := &apiClientMock{
+		GetCodespaceFunc: func(_ context.Context, name string, _ bool) (*api.Codespace, error) {
+			if name == rebuildingCodespace.Name {
+				return rebuildingCodespace, nil
+			}
+			return nil, nil
+		},
+	}
+
+	ios, _, _, _ := iostreams.Test()
+	return NewApp(ios, nil, apiMock, nil)
+}

--- a/pkg/cmd/codespace/rebuild_test.go
+++ b/pkg/cmd/codespace/rebuild_test.go
@@ -9,7 +9,11 @@ import (
 )
 
 func TestAlreadyRebuildingCodespace(t *testing.T) {
-	app := testingRebuildApp()
+	rebuildingCodespace := &api.Codespace{
+		Name:  "rebuildingCodespace",
+		State: api.CodespaceStateRebuilding,
+	}
+	app := testingRebuildApp(*rebuildingCodespace)
 
 	err := app.Rebuild(context.Background(), "rebuildingCodespace")
 	if err != nil {
@@ -17,15 +21,11 @@ func TestAlreadyRebuildingCodespace(t *testing.T) {
 	}
 }
 
-func testingRebuildApp() *App {
-	rebuildingCodespace := &api.Codespace{
-		Name:  "rebuildingCodespace",
-		State: api.CodespaceStateRebuilding,
-	}
+func testingRebuildApp(mockCodespace api.Codespace) *App {
 	apiMock := &apiClientMock{
 		GetCodespaceFunc: func(_ context.Context, name string, _ bool) (*api.Codespace, error) {
-			if name == rebuildingCodespace.Name {
-				return rebuildingCodespace, nil
+			if name == mockCodespace.Name {
+				return &mockCodespace, nil
 			}
 			return nil, nil
 		},

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -22,6 +22,7 @@ func NewRootCmd(app *App) *cobra.Command {
 	root.AddCommand(newCpCmd(app))
 	root.AddCommand(newStopCmd(app))
 	root.AddCommand(newSelectCmd(app))
+	root.AddCommand(newRebuildCmd(app))
 
 	return root
 }

--- a/pkg/liveshare/session.go
+++ b/pkg/liveshare/session.go
@@ -124,13 +124,13 @@ func (s *Session) StartJupyterServer(ctx context.Context) (int, string, error) {
 }
 
 func (s *Session) Rebuild(ctx context.Context) error {
-	var success bool
-	err := s.rpc.do(ctx, "IEnvironmentConfigurationService.rebuildContainer", []string{}, &success)
+	var rebuildSuccess bool
+	err := s.rpc.do(ctx, "IEnvironmentConfigurationService.rebuildContainer", []string{}, &rebuildSuccess)
 	if err != nil {
 		return fmt.Errorf("invoking rebuild RPC: %w", err)
 	}
 
-	if !success {
+	if !rebuildSuccess {
 		return fmt.Errorf("couldn't rebuild codespace")
 	} else {
 		return nil

--- a/pkg/liveshare/session.go
+++ b/pkg/liveshare/session.go
@@ -123,6 +123,20 @@ func (s *Session) StartJupyterServer(ctx context.Context) (int, string, error) {
 	return port, response.ServerUrl, nil
 }
 
+func (s *Session) Rebuild(ctx context.Context) error {
+	var success bool
+	err := s.rpc.do(ctx, "IEnvironmentConfigurationService.rebuildContainer", []string{}, &success)
+	if err != nil {
+		return fmt.Errorf("invoking rebuild RPC: %w", err)
+	}
+
+	if !success {
+		return fmt.Errorf("couldn't rebuild codespace")
+	} else {
+		return nil
+	}
+}
+
 // heartbeat runs until context cancellation, periodically checking whether there is a
 // reason to keep the connection alive, and if so, notifying the Live Share host to do so.
 // Heartbeat ensures it does not send more than one request every "interval" to ratelimit

--- a/pkg/liveshare/session.go
+++ b/pkg/liveshare/session.go
@@ -132,9 +132,9 @@ func (s *Session) Rebuild(ctx context.Context) error {
 
 	if !rebuildSuccess {
 		return fmt.Errorf("couldn't rebuild codespace")
-	} else {
-		return nil
 	}
+
+	return nil
 }
 
 // heartbeat runs until context cancellation, periodically checking whether there is a

--- a/pkg/liveshare/session.go
+++ b/pkg/liveshare/session.go
@@ -125,7 +125,7 @@ func (s *Session) StartJupyterServer(ctx context.Context) (int, string, error) {
 
 func (s *Session) Rebuild(ctx context.Context) error {
 	var rebuildSuccess bool
-	err := s.rpc.do(ctx, "IEnvironmentConfigurationService.rebuildContainer", []string{}, &rebuildSuccess)
+	err := s.rpc.do(ctx, "IEnvironmentConfigurationService.rebuildContainer", nil, &rebuildSuccess)
 	if err != nil {
 		return fmt.Errorf("invoking rebuild RPC: %w", err)
 	}

--- a/pkg/liveshare/session.go
+++ b/pkg/liveshare/session.go
@@ -123,7 +123,7 @@ func (s *Session) StartJupyterServer(ctx context.Context) (int, string, error) {
 	return port, response.ServerUrl, nil
 }
 
-func (s *Session) Rebuild(ctx context.Context) error {
+func (s *Session) RebuildContainer(ctx context.Context) error {
 	var rebuildSuccess bool
 	err := s.rpc.do(ctx, "IEnvironmentConfigurationService.rebuildContainer", nil, &rebuildSuccess)
 	if err != nil {

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -399,6 +399,24 @@ func TestSessionHeartbeat(t *testing.T) {
 	}
 }
 
+func TestRebuild(t *testing.T) {
+	getSharedServers := func(conn *jsonrpc2.Conn, req *jsonrpc2.Request) (interface{}, error) {
+		return true, nil
+	}
+	testServer, session, err := makeMockSession(
+		livesharetest.WithService("IEnvironmentConfigurationService.rebuildContainer", getSharedServers),
+	)
+	if err != nil {
+		t.Fatalf("creating mock session: %v", err)
+	}
+	defer testServer.Close()
+
+	err = session.Rebuild(context.Background())
+	if err != nil {
+		t.Fatalf("rebuilding codespace over mock session: %v", err)
+	}
+}
+
 type mockLogger struct {
 	sync.Mutex
 	buf *bytes.Buffer

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -413,7 +413,7 @@ func TestRebuild(t *testing.T) {
 	}
 	defer testServer.Close()
 
-	err = session.Rebuild(context.Background())
+	err = session.RebuildContainer(context.Background())
 	if err != nil {
 		t.Fatalf("rebuilding codespace via mock session: %v", err)
 	}

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -400,7 +400,9 @@ func TestSessionHeartbeat(t *testing.T) {
 }
 
 func TestRebuild(t *testing.T) {
+	requestCount := 0
 	getSharedServers := func(conn *jsonrpc2.Conn, req *jsonrpc2.Request) (interface{}, error) {
+		requestCount++
 		return true, nil
 	}
 	testServer, session, err := makeMockSession(
@@ -414,6 +416,10 @@ func TestRebuild(t *testing.T) {
 	err = session.Rebuild(context.Background())
 	if err != nil {
 		t.Fatalf("rebuilding codespace via mock session: %v", err)
+	}
+
+	if requestCount == 0 {
+		t.Fatalf("no requests were made")
 	}
 }
 

--- a/pkg/liveshare/session_test.go
+++ b/pkg/liveshare/session_test.go
@@ -413,7 +413,7 @@ func TestRebuild(t *testing.T) {
 
 	err = session.Rebuild(context.Background())
 	if err != nil {
-		t.Fatalf("rebuilding codespace over mock session: %v", err)
+		t.Fatalf("rebuilding codespace via mock session: %v", err)
 	}
 }
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #6380

Adds a new `codespace rebuild` command that rebuilds a codespace. If the codespace is already rebuilding, then this command no-ops and exits successfully. The new command starts a Live Share session and orders a rebuild using RPC.

<img width="863" alt="Demo of gh codespace rebuild" src="https://user-images.githubusercontent.com/19893438/194692441-634088b6-4a92-4ea7-a5bf-5c464b63b2e6.png">

If #6358 lands before this PR merges, then this PR should adopt the new gRPC protocol.