### PR TITLE
show pull request merged state on search

### DIFF
--- a/pkg/cmd/search/shared/shared.go
+++ b/pkg/cmd/search/shared/shared.go
@@ -114,12 +114,12 @@ func displayIssueResults(io *iostreams.IOStreams, now time.Time, et EntityType, 
 			issueNum = "#" + issueNum
 		}
 		if issue.IsPullRequest() {
-			tp.AddField(issueNum, nil, cs.ColorFromString(colorForPRState(issue.State)))
+			tp.AddField(issueNum, nil, cs.ColorFromString(colorForPRState(issue.State())))
 		} else {
-			tp.AddField(issueNum, nil, cs.ColorFromString(colorForIssueState(issue.State, issue.StateReason)))
+			tp.AddField(issueNum, nil, cs.ColorFromString(colorForIssueState(issue.State(), issue.StateReason)))
 		}
 		if !tp.IsTTY() {
-			tp.AddField(issue.State, nil, nil)
+			tp.AddField(issue.State(), nil, nil)
 		}
 		tp.AddField(text.RemoveExcessiveWhitespace(issue.Title), nil, nil)
 		tp.AddField(listIssueLabels(&issue, cs, tp.IsTTY()), nil, nil)

--- a/pkg/cmd/search/shared/shared_test.go
+++ b/pkg/cmd/search/shared/shared_test.go
@@ -77,7 +77,7 @@ func TestSearchIssues(t *testing.T) {
 							IncompleteResults: false,
 							Items: []search.Issue{
 								{RepositoryURL: "github.com/test/cli", Number: 123, State: "open", Title: "bug", Labels: []search.Label{{Name: "bug"}, {Name: "p1"}}, UpdatedAt: updatedAt},
-								{RepositoryURL: "github.com/what/what", Number: 456, State: "open", Title: "fix bug", Labels: []search.Label{{Name: "fix"}}, PullRequestLinks: search.PullRequestLinks{URL: "someurl"}, UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/what/what", Number: 456, State: "open", Title: "fix bug", Labels: []search.Label{{Name: "fix"}}, PullRequest: search.PullRequest{URL: "someurl"}, UpdatedAt: updatedAt},
 							},
 							Total: 300,
 						}, nil
@@ -119,7 +119,7 @@ func TestSearchIssues(t *testing.T) {
 							IncompleteResults: false,
 							Items: []search.Issue{
 								{RepositoryURL: "github.com/test/cli", Number: 123, State: "open", Title: "bug", Labels: []search.Label{{Name: "bug"}, {Name: "p1"}}, UpdatedAt: updatedAt},
-								{RepositoryURL: "github.com/what/what", Number: 456, State: "open", Title: "fix bug", Labels: []search.Label{{Name: "fix"}}, PullRequestLinks: search.PullRequestLinks{URL: "someurl"}, UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/what/what", Number: 456, State: "open", Title: "fix bug", Labels: []search.Label{{Name: "fix"}}, PullRequest: search.PullRequest{URL: "someurl"}, UpdatedAt: updatedAt},
 							},
 							Total: 300,
 						}, nil

--- a/pkg/cmd/search/shared/shared_test.go
+++ b/pkg/cmd/search/shared/shared_test.go
@@ -54,9 +54,9 @@ func TestSearchIssues(t *testing.T) {
 						return search.IssuesResult{
 							IncompleteResults: false,
 							Items: []search.Issue{
-								{RepositoryURL: "github.com/test/cli", Number: 123, State: "open", Title: "something broken", Labels: []search.Label{{Name: "bug"}, {Name: "p1"}}, UpdatedAt: updatedAt},
-								{RepositoryURL: "github.com/what/what", Number: 456, State: "closed", Title: "feature request", Labels: []search.Label{{Name: "enhancement"}}, UpdatedAt: updatedAt},
-								{RepositoryURL: "github.com/blah/test", Number: 789, State: "open", Title: "some title", UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/test/cli", Number: 123, StateInternal: "open", Title: "something broken", Labels: []search.Label{{Name: "bug"}, {Name: "p1"}}, UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/what/what", Number: 456, StateInternal: "closed", Title: "feature request", Labels: []search.Label{{Name: "enhancement"}}, UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/blah/test", Number: 789, StateInternal: "open", Title: "some title", UpdatedAt: updatedAt},
 							},
 							Total: 300,
 						}, nil
@@ -76,8 +76,8 @@ func TestSearchIssues(t *testing.T) {
 						return search.IssuesResult{
 							IncompleteResults: false,
 							Items: []search.Issue{
-								{RepositoryURL: "github.com/test/cli", Number: 123, State: "open", Title: "bug", Labels: []search.Label{{Name: "bug"}, {Name: "p1"}}, UpdatedAt: updatedAt},
-								{RepositoryURL: "github.com/what/what", Number: 456, State: "open", Title: "fix bug", Labels: []search.Label{{Name: "fix"}}, PullRequest: search.PullRequest{URL: "someurl"}, UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/test/cli", Number: 123, StateInternal: "open", Title: "bug", Labels: []search.Label{{Name: "bug"}, {Name: "p1"}}, UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/what/what", Number: 456, StateInternal: "open", Title: "fix bug", Labels: []search.Label{{Name: "fix"}}, PullRequest: search.PullRequest{URL: "someurl"}, UpdatedAt: updatedAt},
 							},
 							Total: 300,
 						}, nil
@@ -97,9 +97,9 @@ func TestSearchIssues(t *testing.T) {
 						return search.IssuesResult{
 							IncompleteResults: false,
 							Items: []search.Issue{
-								{RepositoryURL: "github.com/test/cli", Number: 123, State: "open", Title: "something broken", Labels: []search.Label{{Name: "bug"}, {Name: "p1"}}, UpdatedAt: updatedAt},
-								{RepositoryURL: "github.com/what/what", Number: 456, State: "closed", Title: "feature request", Labels: []search.Label{{Name: "enhancement"}}, UpdatedAt: updatedAt},
-								{RepositoryURL: "github.com/blah/test", Number: 789, State: "open", Title: "some title", UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/test/cli", Number: 123, StateInternal: "open", Title: "something broken", Labels: []search.Label{{Name: "bug"}, {Name: "p1"}}, UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/what/what", Number: 456, StateInternal: "closed", Title: "feature request", Labels: []search.Label{{Name: "enhancement"}}, UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/blah/test", Number: 789, StateInternal: "open", Title: "some title", UpdatedAt: updatedAt},
 							},
 							Total: 300,
 						}, nil
@@ -118,8 +118,8 @@ func TestSearchIssues(t *testing.T) {
 						return search.IssuesResult{
 							IncompleteResults: false,
 							Items: []search.Issue{
-								{RepositoryURL: "github.com/test/cli", Number: 123, State: "open", Title: "bug", Labels: []search.Label{{Name: "bug"}, {Name: "p1"}}, UpdatedAt: updatedAt},
-								{RepositoryURL: "github.com/what/what", Number: 456, State: "open", Title: "fix bug", Labels: []search.Label{{Name: "fix"}}, PullRequest: search.PullRequest{URL: "someurl"}, UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/test/cli", Number: 123, StateInternal: "open", Title: "bug", Labels: []search.Label{{Name: "bug"}, {Name: "p1"}}, UpdatedAt: updatedAt},
+								{RepositoryURL: "github.com/what/what", Number: 456, StateInternal: "open", Title: "fix bug", Labels: []search.Label{{Name: "fix"}}, PullRequest: search.PullRequest{URL: "someurl"}, UpdatedAt: updatedAt},
 							},
 							Total: 300,
 						}, nil

--- a/pkg/search/result.go
+++ b/pkg/search/result.go
@@ -117,28 +117,29 @@ type User struct {
 }
 
 type Issue struct {
-	Assignees         []User           `json:"assignees"`
-	Author            User             `json:"user"`
-	AuthorAssociation string           `json:"author_association"`
-	Body              string           `json:"body"`
-	ClosedAt          time.Time        `json:"closed_at"`
-	CommentsCount     int              `json:"comments"`
-	CreatedAt         time.Time        `json:"created_at"`
-	ID                string           `json:"node_id"`
-	Labels            []Label          `json:"labels"`
-	IsLocked          bool             `json:"locked"`
-	Number            int              `json:"number"`
-	PullRequestLinks  PullRequestLinks `json:"pull_request"`
-	RepositoryURL     string           `json:"repository_url"`
-	State             string           `json:"state"`
-	StateReason       string           `json:"state_reason"`
-	Title             string           `json:"title"`
-	URL               string           `json:"html_url"`
-	UpdatedAt         time.Time        `json:"updated_at"`
+	Assignees         []User      `json:"assignees"`
+	Author            User        `json:"user"`
+	AuthorAssociation string      `json:"author_association"`
+	Body              string      `json:"body"`
+	ClosedAt          time.Time   `json:"closed_at"`
+	CommentsCount     int         `json:"comments"`
+	CreatedAt         time.Time   `json:"created_at"`
+	ID                string      `json:"node_id"`
+	Labels            []Label     `json:"labels"`
+	IsLocked          bool        `json:"locked"`
+	Number            int         `json:"number"`
+	PullRequest       PullRequest `json:"pull_request"`
+	RepositoryURL     string      `json:"repository_url"`
+	State             string      `json:"state"`
+	StateReason       string      `json:"state_reason"`
+	Title             string      `json:"title"`
+	URL               string      `json:"html_url"`
+	UpdatedAt         time.Time   `json:"updated_at"`
 }
 
-type PullRequestLinks struct {
-	URL string `json:"html_url"`
+type PullRequest struct {
+	URL      string    `json:"html_url"`
+	MergedAt time.Time `json:"merged_at"`
 }
 
 type Label struct {
@@ -175,7 +176,7 @@ func (repo Repository) ExportData(fields []string) map[string]interface{} {
 }
 
 func (issue Issue) IsPullRequest() bool {
-	return issue.PullRequestLinks.URL != ""
+	return issue.PullRequest.URL != ""
 }
 
 func (issue Issue) ExportData(fields []string) map[string]interface{} {
@@ -219,6 +220,12 @@ func (issue Issue) ExportData(fields []string) map[string]interface{} {
 			data[f] = map[string]interface{}{
 				"name":          name,
 				"nameWithOwner": nameWithOwner,
+			}
+		case "state":
+			if !issue.PullRequest.MergedAt.IsZero() {
+				data[f] = "merged"
+			} else {
+				data[f] = issue.State
 			}
 		default:
 			sf := fieldByName(v, f)

--- a/pkg/search/result.go
+++ b/pkg/search/result.go
@@ -142,6 +142,10 @@ type PullRequest struct {
 	MergedAt time.Time `json:"merged_at"`
 }
 
+func (p PullRequest) Merged() bool {
+	return !p.MergedAt.IsZero()
+}
+
 type Label struct {
 	Color       string `json:"color"`
 	Description string `json:"description"`
@@ -222,9 +226,10 @@ func (issue Issue) ExportData(fields []string) map[string]interface{} {
 				"nameWithOwner": nameWithOwner,
 			}
 		case "state":
-			if !issue.PullRequest.MergedAt.IsZero() {
+			if issue.PullRequest.Merged() {
 				data[f] = "merged"
 			} else {
+				// either an issue or a pull request that is not merged
 				data[f] = issue.State
 			}
 		default:

--- a/pkg/search/result_test.go
+++ b/pkg/search/result_test.go
@@ -68,6 +68,26 @@ func TestIssueExportData(t *testing.T) {
 			},
 			output: `{"assignees":[{"id":"","login":"test","type":""}],"body":"body","commentsCount":1,"isLocked":true,"labels":[{"color":"","description":"","id":"","name":"label1"},{"color":"","description":"","id":"","name":"label2"}],"repository":{"name":"repo","nameWithOwner":"owner/repo"},"title":"title","updatedAt":"2021-02-28T12:30:00Z"}`,
 		},
+		{
+			name:   "state when issue",
+			fields: []string{"isPullRequest", "state"},
+			issue: Issue{
+				State: "closed",
+			},
+			output: `{"isPullRequest":false,"state":"closed"}`,
+		},
+		{
+			name:   "state when pull request",
+			fields: []string{"isPullRequest", "state"},
+			issue: Issue{
+				PullRequest: PullRequest{
+					MergedAt: time.Now(),
+					URL:      "a-url",
+				},
+				State: "closed",
+			},
+			output: `{"isPullRequest":true,"state":"merged"}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/search/result_test.go
+++ b/pkg/search/result_test.go
@@ -72,7 +72,7 @@ func TestIssueExportData(t *testing.T) {
 			name:   "state when issue",
 			fields: []string{"isPullRequest", "state"},
 			issue: Issue{
-				State: "closed",
+				StateInternal: "closed",
 			},
 			output: `{"isPullRequest":false,"state":"closed"}`,
 		},
@@ -84,7 +84,7 @@ func TestIssueExportData(t *testing.T) {
 					MergedAt: time.Now(),
 					URL:      "a-url",
 				},
-				State: "closed",
+				StateInternal: "closed",
 			},
 			output: `{"isPullRequest":true,"state":"merged"}`,
 		},


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/6290

@samcoe noted in the issue that the REST api https://docs.github.com/en/rest/search#search-issues-and-pull-requests which the `gh search prs` command uses returns issues with some fields related to a pull request, but not the pull request itself (unlike the GraphQL api).

The open api spec for the pull request object in the issue object is

```json
"pull_request": {
    "type": "object",
    "properties": {
      "merged_at": {
        "type": [
          "string",
          "null"
        ],
        "format": "date-time"
      },
      "diff_url": {
        "type": [
          "string",
          "null"
        ],
        "format": "uri"
      },
      "html_url": {
        "type": [
          "string",
          "null"
        ],
        "format": "uri"
      },
      "patch_url": {
        "type": [
          "string",
          "null"
        ],
        "format": "uri"
      },
      "url": {
        "type": [
          "string",
          "null"
        ],
        "format": "uri"
      }
    }
```

we can display  the merged state based on the presence of the `pull_request.merged_at` field and if it's not present we fall back to the state in the API body. 

I was concerned that this might be the state of the linked issue and not the PR, which could lead to a situation where the issue is closed with a linked PR which is open, and we would display the state as "closed". In testing against the api this isn't the case as we pass `type:pr` in the query string, which correctly returns a PR and not the linked issue.