### PR TITLE
Return empty error before starting a pager program

### DIFF
--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -185,6 +185,9 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return err
 	}
+	if len(listResult.Issues) == 0 {
+		return prShared.ListNoResults(ghrepo.FullName(baseRepo), "issue", !filterOptions.IsDefault())
+	}
 
 	if err := opts.IO.StartPager(); err == nil {
 		defer opts.IO.StopPager()
@@ -198,9 +201,6 @@ func listRun(opts *ListOptions) error {
 
 	if listResult.SearchCapped {
 		fmt.Fprintln(opts.IO.ErrOut, "warning: this query uses the Search API which is capped at 1000 results maximum")
-	}
-	if len(listResult.Issues) == 0 {
-		return prShared.ListNoResults(ghrepo.FullName(baseRepo), "issue", !filterOptions.IsDefault())
 	}
 	if isTerminal {
 		title := prShared.ListHeader(ghrepo.FullName(baseRepo), "issue", len(listResult.Issues), listResult.TotalCount, !filterOptions.IsDefault())

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -185,7 +185,7 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return err
 	}
-	if len(listResult.Issues) == 0 {
+	if len(listResult.Issues) == 0 && opts.Exporter == nil {
 		return prShared.ListNoResults(ghrepo.FullName(baseRepo), "issue", !filterOptions.IsDefault())
 	}
 

--- a/pkg/cmd/pr/checks/aggregate.go
+++ b/pkg/cmd/pr/checks/aggregate.go
@@ -24,20 +24,7 @@ type checkCounts struct {
 	Skipping int
 }
 
-func aggregateChecks(pr *api.PullRequest, requiredChecks bool) ([]check, checkCounts, error) {
-	checks := []check{}
-	counts := checkCounts{}
-
-	if len(pr.StatusCheckRollup.Nodes) == 0 {
-		return checks, counts, fmt.Errorf("no commit found on the pull request")
-	}
-
-	rollup := pr.StatusCheckRollup.Nodes[0].Commit.StatusCheckRollup.Contexts.Nodes
-	if len(rollup) == 0 {
-		return checks, counts, fmt.Errorf("no checks reported on the '%s' branch", pr.HeadRefName)
-	}
-
-	checkContexts := pr.StatusCheckRollup.Nodes[0].Commit.StatusCheckRollup.Contexts.Nodes
+func aggregateChecks(checkContexts []api.CheckContext, requiredChecks bool) (checks []check, counts checkCounts) {
 	for _, c := range eliminateDuplicates(checkContexts) {
 		if requiredChecks && !c.IsRequired {
 			continue
@@ -86,12 +73,7 @@ func aggregateChecks(pr *api.PullRequest, requiredChecks bool) ([]check, checkCo
 
 		checks = append(checks, item)
 	}
-
-	if len(checks) == 0 && requiredChecks {
-		return checks, counts, fmt.Errorf("no required checks reported on the '%s' branch", pr.HeadRefName)
-	}
-
-	return checks, counts, nil
+	return
 }
 
 // eliminateDuplicates filters a set of checks to only the most recent ones if the set includes repeated runs

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -1,6 +1,7 @@
 package checks
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -207,7 +208,7 @@ func populateStatusChecks(client *http.Client, repo ghrepo.Interface, pr *api.Pu
 	}
 
 	query := fmt.Sprintf(`
-	query PullRequestStatusChecks($id: ID!, $endCursor: String!) {
+	query PullRequestStatusChecks($id: ID!, $endCursor: String) {
 		node(id: $id) {
 			...on PullRequest {
 				%s
@@ -220,10 +221,8 @@ func populateStatusChecks(client *http.Client, repo ghrepo.Interface, pr *api.Pu
 	}
 
 	statusCheckRollup := api.CheckContexts{}
-	endCursor := ""
 
 	for {
-		variables["endCursor"] = endCursor
 		var resp response
 		err := apiClient.GraphQL(repo.RepoHost(), query, variables, &resp)
 		if err != nil {
@@ -231,7 +230,7 @@ func populateStatusChecks(client *http.Client, repo ghrepo.Interface, pr *api.Pu
 		}
 
 		if len(resp.Node.StatusCheckRollup.Nodes) == 0 {
-			return aggregateChecks(pr, requiredChecks)
+			return nil, checkCounts{}, errors.New("no commit found on the pull request")
 		}
 
 		result := resp.Node.StatusCheckRollup.Nodes[0].Commit.StatusCheckRollup.Contexts
@@ -243,18 +242,16 @@ func populateStatusChecks(client *http.Client, repo ghrepo.Interface, pr *api.Pu
 		if !result.PageInfo.HasNextPage {
 			break
 		}
-		endCursor = result.PageInfo.EndCursor
+		variables["endCursor"] = result.PageInfo.EndCursor
 	}
 
-	statusCheckRollup.PageInfo.HasNextPage = false
+	if len(statusCheckRollup.Nodes) == 0 {
+		return nil, checkCounts{}, fmt.Errorf("no checks reported on the '%s' branch", pr.HeadRefName)
+	}
 
-	pr.StatusCheckRollup.Nodes = []api.StatusCheckRollupNode{{
-		Commit: api.StatusCheckRollupCommit{
-			StatusCheckRollup: api.CommitStatusCheckRollup{
-				Contexts: statusCheckRollup,
-			},
-		},
-	}}
-
-	return aggregateChecks(pr, requiredChecks)
+	checks, counts := aggregateChecks(statusCheckRollup.Nodes, requiredChecks)
+	if len(checks) == 0 && requiredChecks {
+		return checks, counts, fmt.Errorf("no required checks reported on the '%s' branch", pr.HeadRefName)
+	}
+	return checks, counts, nil
 }

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -231,7 +231,7 @@ func populateStatusChecks(client *http.Client, repo ghrepo.Interface, pr *api.Pu
 		}
 
 		if len(resp.Node.StatusCheckRollup.Nodes) == 0 {
-			break
+			return aggregateChecks(pr, requiredChecks)
 		}
 
 		result := resp.Node.StatusCheckRollup.Nodes[0].Commit.StatusCheckRollup.Contexts

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -231,7 +231,7 @@ func populateStatusChecks(client *http.Client, repo ghrepo.Interface, pr *api.Pu
 		}
 
 		if len(resp.Node.StatusCheckRollup.Nodes) == 0 {
-			return aggregateChecks(pr, requiredChecks)
+			break
 		}
 
 		result := resp.Node.StatusCheckRollup.Nodes[0].Commit.StatusCheckRollup.Contexts

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -175,7 +175,7 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return err
 	}
-	if len(listResult.PullRequests) == 0 {
+	if len(listResult.PullRequests) == 0 && opts.Exporter == nil {
 		return shared.ListNoResults(ghrepo.FullName(baseRepo), "pull request", !filters.IsDefault())
 	}
 

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -175,6 +175,9 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return err
 	}
+	if len(listResult.PullRequests) == 0 {
+		return shared.ListNoResults(ghrepo.FullName(baseRepo), "pull request", !filters.IsDefault())
+	}
 
 	err = opts.IO.StartPager()
 	if err != nil {
@@ -188,9 +191,6 @@ func listRun(opts *ListOptions) error {
 
 	if listResult.SearchCapped {
 		fmt.Fprintln(opts.IO.ErrOut, "warning: this query uses the Search API which is capped at 1000 results maximum")
-	}
-	if len(listResult.PullRequests) == 0 {
-		return shared.ListNoResults(ghrepo.FullName(baseRepo), "pull request", !filters.IsDefault())
 	}
 	if opts.IO.IsStdoutTTY() {
 		title := shared.ListHeader(ghrepo.FullName(baseRepo), "pull request", len(listResult.PullRequests), listResult.TotalCount, !filters.IsDefault())

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -105,7 +105,7 @@ func listRun(opts *ListOptions) error {
 		return fmt.Errorf("failed to get runs: %w", err)
 	}
 	runs := runsResult.WorkflowRuns
-	if len(runs) == 0 {
+	if len(runs) == 0 && opts.Exporter == nil {
 		return cmdutil.NewNoResultsError("no runs found")
 	}
 

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -105,6 +105,9 @@ func listRun(opts *ListOptions) error {
 		return fmt.Errorf("failed to get runs: %w", err)
 	}
 	runs := runsResult.WorkflowRuns
+	if len(runs) == 0 {
+		return cmdutil.NewNoResultsError("no runs found")
+	}
 
 	if err := opts.IO.StartPager(); err == nil {
 		defer opts.IO.StopPager()
@@ -114,10 +117,6 @@ func listRun(opts *ListOptions) error {
 
 	if opts.Exporter != nil {
 		return opts.Exporter.Write(opts.IO, runs)
-	}
-
-	if len(runs) == 0 {
-		return cmdutil.NewNoResultsError("no runs found")
 	}
 
 	tp := utils.NewTablePrinter(opts.IO)

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -138,7 +138,7 @@ func reposRun(opts *ReposOptions) error {
 	if err != nil {
 		return err
 	}
-	if len(result.Items) == 0 {
+	if len(result.Items) == 0 && opts.Exporter == nil {
 		return cmdutil.NewNoResultsError("no repositories matched your search")
 	}
 	if err := io.StartPager(); err == nil {

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -138,6 +138,9 @@ func reposRun(opts *ReposOptions) error {
 	if err != nil {
 		return err
 	}
+	if len(result.Items) == 0 {
+		return cmdutil.NewNoResultsError("no repositories matched your search")
+	}
 	if err := io.StartPager(); err == nil {
 		defer io.StopPager()
 	} else {
@@ -145,9 +148,6 @@ func reposRun(opts *ReposOptions) error {
 	}
 	if opts.Exporter != nil {
 		return opts.Exporter.Write(io, result.Items)
-	}
-	if len(result.Items) == 0 {
-		return cmdutil.NewNoResultsError("no repositories matched your search")
 	}
 
 	return displayResults(io, opts.Now, result)

--- a/pkg/cmd/search/shared/shared.go
+++ b/pkg/cmd/search/shared/shared.go
@@ -65,7 +65,7 @@ func SearchIssues(opts *IssuesOptions) error {
 	if err != nil {
 		return err
 	}
-	if len(result.Items) == 0 {
+	if len(result.Items) == 0 && opts.Exporter == nil {
 		var msg string
 		switch opts.Entity {
 		case Both:

--- a/pkg/cmd/search/shared/shared.go
+++ b/pkg/cmd/search/shared/shared.go
@@ -65,17 +65,6 @@ func SearchIssues(opts *IssuesOptions) error {
 	if err != nil {
 		return err
 	}
-
-	if err := io.StartPager(); err == nil {
-		defer io.StopPager()
-	} else {
-		fmt.Fprintf(io.ErrOut, "failed to start pager: %v\n", err)
-	}
-
-	if opts.Exporter != nil {
-		return opts.Exporter.Write(io, result.Items)
-	}
-
 	if len(result.Items) == 0 {
 		var msg string
 		switch opts.Entity {
@@ -87,6 +76,16 @@ func SearchIssues(opts *IssuesOptions) error {
 			msg = "no pull requests matched your search"
 		}
 		return cmdutil.NewNoResultsError(msg)
+	}
+
+	if err := io.StartPager(); err == nil {
+		defer io.StopPager()
+	} else {
+		fmt.Fprintf(io.ErrOut, "failed to start pager: %v\n", err)
+	}
+
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(io, result.Items)
 	}
 
 	return displayIssueResults(io, opts.Now, opts.Entity, result)


### PR DESCRIPTION
Fixes #6400

Return empty error before starting a pager program.

Previously, these commands start `pager` even with empty results:
```
gh issue list
gh pr checks [<number> | <url> | <branch>]
gh pr list
gh run list
gh search issues [<query>]
gh search prs [<query>]
gh search repos [<query>]
```

For example, the output with `PAGER=less` shows
```
~
~
~
(END)
```
An error is printed after quitting a pager program.
```
no open issues in OWNER/REPO
```