### PR TITLE
mntly/extension not found

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -124,6 +124,9 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 						} else if errors.Is(err, commitNotFoundErr) {
 							return fmt.Errorf("%s %s does not exist in %s",
 								cs.FailureIcon(), cs.Cyan(pinFlag), args[0])
+						} else if errors.Is(err, repositoryNotFoundErr) {
+							return fmt.Errorf("%s Could not find extension '%s' on host %s",
+								cs.FailureIcon(), args[0], repo.RepoHost())
 						}
 						return err
 					}

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -88,6 +88,25 @@ func TestNewCmdExtension(t *testing.T) {
 			},
 		},
 		{
+			name: "error extension not found",
+			args: []string{"install", "owner/gh-some-ext"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.ListFunc = func() []extensions.Extension {
+					return []extensions.Extension{}
+				}
+				em.InstallFunc = func(_ ghrepo.Interface, _ string) error {
+					return repositoryNotFoundErr
+				}
+				return func(t *testing.T) {
+					installCalls := em.InstallCalls()
+					assert.Equal(t, 1, len(installCalls))
+					assert.Equal(t, "gh-some-ext", installCalls[0].InterfaceMoqParam.RepoName())
+				}
+			},
+			wantErr: true,
+			errMsg:  "X Could not find extension 'owner/gh-some-ext' on host github.com",
+		},
+		{
 			name:    "install local extension with pin",
 			args:    []string{"install", ".", "--pin", "v1.0.0"},
 			wantErr: true,

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -14,7 +14,7 @@ import (
 )
 
 func repoExists(httpClient *http.Client, repo ghrepo.Interface) (bool, error) {
-	url := fmt.Sprintf("%s%s/%s", ghinstance.HostPrefix(repo.RepoHost()), repo.RepoOwner(), repo.RepoName())
+	url := fmt.Sprintf("%s%s/%s", ghinstance.RESTPrefix(repo.RepoHost()), repo.RepoOwner(), repo.RepoName())
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return false, err

--- a/pkg/cmd/extension/http.go
+++ b/pkg/cmd/extension/http.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cli/cli/v2/internal/ghrepo"
 )
 
-func hasScript(httpClient *http.Client, repo ghrepo.Interface) (hs bool, err error) {
+func hasScript(httpClient *http.Client, repo ghrepo.Interface) (bool, error) {
 	path := fmt.Sprintf("repos/%s/%s/contents/%s",
 		repo.RepoOwner(), repo.RepoName(), repo.RepoName())
 	url := ghinstance.RESTPrefix(repo.RepoHost()) + path

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -337,6 +337,14 @@ type binManifest struct {
 
 // Install installs an extension from repo, and pins to commitish if provided
 func (m *Manager) Install(repo ghrepo.Interface, target string) error {
+	exists, err := repoExists(m.client, repo)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return repositoryNotFoundErr
+	}
+
 	isBin, err := isBinExtension(m.client, repo)
 	if err != nil {
 		return fmt.Errorf("could not check for binary extension: %w", err)

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -687,7 +687,7 @@ func TestManager_Install_binary_pinned(t *testing.T) {
 	defer reg.Verify(t)
 
 	reg.Register(
-		httpmock.REST("GET", "owner/gh-bin-ext"),
+		httpmock.REST("GET", "api/v3/owner/gh-bin-ext"),
 		httpmock.StringResponse(""),
 	)
 
@@ -759,7 +759,7 @@ func TestManager_Install_binary_unsupported(t *testing.T) {
 	client := http.Client{Transport: &reg}
 
 	reg.Register(
-		httpmock.REST("GET", "owner/gh-bin-ext"),
+		httpmock.REST("GET", "api/v3/owner/gh-bin-ext"),
 		httpmock.StringResponse(""),
 	)
 
@@ -806,7 +806,7 @@ func TestManager_Install_binary(t *testing.T) {
 	defer reg.Verify(t)
 
 	reg.Register(
-		httpmock.REST("GET", "owner/gh-bin-ext"),
+		httpmock.REST("GET", "api/v3/owner/gh-bin-ext"),
 		httpmock.StringResponse(""),
 	)
 

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -614,6 +614,10 @@ func TestManager_Install_git(t *testing.T) {
 	m := newTestManager(tempDir, &client, ios)
 
 	reg.Register(
+		httpmock.REST("GET", "owner/gh-some-ext"),
+		httpmock.StringResponse(""),
+	)
+	reg.Register(
 		httpmock.REST("GET", "repos/owner/gh-some-ext/releases/latest"),
 		httpmock.JSONResponse(
 			release{
@@ -647,6 +651,11 @@ func TestManager_Install_git_pinned(t *testing.T) {
 	m := newTestManager(tempDir, &client, ios)
 
 	reg.Register(
+		httpmock.REST("GET", "owner/gh-cool-ext"),
+		httpmock.StringResponse(""),
+	)
+
+	reg.Register(
 		httpmock.REST("GET", "repos/owner/gh-cool-ext/releases/latest"),
 		httpmock.JSONResponse(
 			release{
@@ -676,6 +685,11 @@ func TestManager_Install_binary_pinned(t *testing.T) {
 
 	reg := httpmock.Registry{}
 	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "owner/gh-bin-ext"),
+		httpmock.StringResponse(""),
+	)
 
 	reg.Register(
 		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
@@ -745,6 +759,11 @@ func TestManager_Install_binary_unsupported(t *testing.T) {
 	client := http.Client{Transport: &reg}
 
 	reg.Register(
+		httpmock.REST("GET", "owner/gh-bin-ext"),
+		httpmock.StringResponse(""),
+	)
+
+	reg.Register(
 		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
 		httpmock.JSONResponse(
 			release{
@@ -785,6 +804,11 @@ func TestManager_Install_binary(t *testing.T) {
 
 	reg := httpmock.Registry{}
 	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "owner/gh-bin-ext"),
+		httpmock.StringResponse(""),
+	)
 
 	reg.Register(
 		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),


### PR DESCRIPTION
fixes https://github.com/cli/cli/issues/6397

Changed the naked returns in `hasScript` to be explicit for readability.
