### PR TITLE
Use alternate screen buffer unconditionally

### DIFF
--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -464,7 +464,7 @@ func System() *IOStreams {
 		io.progressIndicatorEnabled = true
 	}
 
-	if stdoutIsTTY && isVirtualTerminal {
+	if stdoutIsTTY {
 		io.alternateScreenBufferEnabled = true
 	}
 


### PR DESCRIPTION
Fixes regression from #6356. Previous assumption before #5681 was that VT cursor movement and screen clearing was supported, so this effectively restores that assumption while remaining separate from color support and virtual terminal processing support.
