### PR TITLE
Replace spaces with tabs in mixed whitespace string

### DIFF
--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -182,7 +182,7 @@ func RequiredStatusCheckRollupGraphQL(prID, after string) string {
 								state,
 								targetUrl,
 								createdAt,
-                isRequired(pullRequestId: %[2]s)
+								isRequired(pullRequestId: %[2]s)
 							},
 							...on CheckRun {
 								name,
@@ -192,7 +192,7 @@ func RequiredStatusCheckRollupGraphQL(prID, after string) string {
 								startedAt,
 								completedAt,
 								detailsUrl,
-                isRequired(pullRequestId: %[2]s)
+								isRequired(pullRequestId: %[2]s)
 							}
 						},
 						pageInfo{hasNextPage,endCursor}


### PR DESCRIPTION
This makes the indentation of the query consistent no matter your local tab size rendering.

I was reading this query and was baffled until I realised the indentation was just rendered incorrectly. This is how it looks for me before this PR:

![image](https://user-images.githubusercontent.com/243995/196411927-d35aee1c-0a5e-4ba2-9132-1ec619162b0f.png)
