### PR TITLE
Add warning message for endpoint starting with `/` in `gh api <endpoint>`

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -175,6 +175,11 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 			opts.RequestPath = args[0]
 			opts.RequestMethodPassed = c.Flags().Changed("method")
 
+			if strings.HasPrefix(opts.RequestPath, "/") {
+				warningIcon := opts.IO.ColorScheme().WarningIcon()
+				fmt.Fprintf(opts.IO.ErrOut, "%s warning: '%s' An absolute window-styled path was passed which is likely to fail. Try dropping or escaping the starting slash in the endpoint if it fails. \n", warningIcon, opts.RequestPath)
+			}
+
 			if c.Flags().Changed("hostname") {
 				if err := ghinstance.HostnameValidator(opts.Hostname); err != nil {
 					return cmdutil.FlagErrorf("error parsing `--hostname`: %w", err)

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -177,7 +177,7 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 
 			if strings.HasPrefix(opts.RequestPath, "/") {
 				warningIcon := opts.IO.ColorScheme().WarningIcon()
-				fmt.Fprintf(opts.IO.ErrOut, "%s warning: '%s' An absolute window-styled path was passed which is likely to fail. Try dropping or escaping the starting slash in the endpoint if it fails. \n", warningIcon, opts.RequestPath)
+				fmt.Fprintf(opts.IO.ErrOut, "%s warning: '%s' An absolute window-styled path was passed which is likely to fail. Try dropping or escaping the leading slash in the endpoint if it fails. \n", warningIcon, opts.RequestPath)
 			}
 
 			if c.Flags().Changed("hostname") {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -319,7 +319,7 @@ func Test_NewCmdApi(t *testing.T) {
 				FilterOutput:        "",
 			},
 			wantsErr: false,
-			stderr:   "! warning: '/users/repos' An absolute window-styled path was passed which is likely to fail. Try dropping or escaping the starting slash in the endpoint if it fails. \n",
+			stderr:   "! warning: '/users/repos' An absolute window-styled path was passed which is likely to fail. Try dropping or escaping the leading slash in the endpoint if it fails. \n",
 		},
 		{
 			name:     "--silent with --jq",


### PR DESCRIPTION
Fixes #6415

**Description**
Added a warning message for the user whenever the endpoint is starting with a slash.

**Before**
```sh
❯ GH_DEBUG=true ./bin/gh api users/repos
* Request at 2022-10-21 01:16:33.038292 +0530 IST m=+0.030087293
* Request to https://api.github.com/users/repos

❯ GH_DEBUG=true ./bin/gh api /users/repos
* Request at 2022-10-21 01:16:49.221381 +0530 IST m=+0.023171918
* Request to https://api.github.com/users/repos
```

**After**
```sh
❯ GH_DEBUG=true ./bin/gh api users/repos
* Request at 2022-10-21 01:14:42.116196 +0530 IST m=+0.026859043
* Request to https://api.github.com/users/repos

❯ GH_DEBUG=true ./bin/gh api /users/repos
! warning: '/users/repos' An absolute window-styled path was passed which is likely to fail. Try dropping or escaping the starting slash in the endpoint if it fails.
* Request at 2022-10-21 01:15:06.412425 +0530 IST m=+0.026561084
* Request to https://api.github.com/users/repos
```