### PR TITLE
Fix: NO_COLOR setting not respected in gh upgrade notice

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -70,6 +70,7 @@ func mainRun() exitCode {
 	}
 	if !cmdFactory.IOStreams.ColorEnabled() {
 		surveyCore.DisableColor = true
+		ansi.DisableColors(true)
 	} else {
 		// override survey's poor choice of color
 		surveyCore.TemplateFuncsWithColor["color"] = func(style string) string {


### PR DESCRIPTION
Fixes: #6495 

Disabling colors in `ansi` is sufficient to fix the error.