### PR TITLE
`--force` overrides pinned extensions

### DIFF
--- a/pkg/cmd/extension/extension.go
+++ b/pkg/cmd/extension/extension.go
@@ -49,8 +49,7 @@ func (e *Extension) IsPinned() bool {
 }
 
 func (e *Extension) UpdateAvailable() bool {
-	if e.isPinned ||
-		e.isLocal ||
+	if e.isLocal ||
 		e.currentVersion == "" ||
 		e.latestVersion == "" ||
 		e.currentVersion == e.latestVersion {

--- a/pkg/cmd/extension/extension_test.go
+++ b/pkg/cmd/extension/extension_test.go
@@ -1,0 +1,52 @@
+package extension
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateAvailable_IsLocal(t *testing.T) {
+	e := &Extension{
+		isLocal: true,
+	}
+
+	assert.False(t, e.UpdateAvailable())
+}
+
+func TestUpdateAvailable_NoCurrentVersion(t *testing.T) {
+	e := &Extension{
+		isLocal: false,
+	}
+
+	assert.False(t, e.UpdateAvailable())
+}
+
+func TestUpdateAvailable_NoLatestVersion(t *testing.T) {
+	e := &Extension{
+		isLocal:        false,
+		currentVersion: "1.0.0",
+	}
+
+	assert.False(t, e.UpdateAvailable())
+}
+
+func TestUpdateAvailable_CurrentVersionIsLatestVersion(t *testing.T) {
+	e := &Extension{
+		isLocal:        false,
+		currentVersion: "1.0.0",
+		latestVersion:  "1.0.0",
+	}
+
+	assert.False(t, e.UpdateAvailable())
+}
+
+func TestUpdateAvailable(t *testing.T) {
+	e := &Extension{
+		isLocal:        false,
+		currentVersion: "1.0.0",
+		latestVersion:  "1.1.0",
+	}
+
+	assert.True(t, e.UpdateAvailable())
+}

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -575,7 +575,7 @@ func (m *Manager) upgradeExtension(ext Extension, force bool) error {
 	if ext.isLocal {
 		return localExtensionUpgradeError
 	}
-	if ext.IsPinned() {
+	if !force && ext.IsPinned() {
 		return pinnedExtensionUpgradeError
 	}
 	if !ext.UpdateAvailable() {


### PR DESCRIPTION
fixes https://github.com/cli/cli/issues/6484

tested with a pinned extension:
- gh extension upgrade <name> --force
- gh extension upgrade --all --force
