### PR TITLE
add deb-get installation instructions

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -44,13 +44,13 @@ sudo apt install curl
 curl -sL https://raw.githubusercontent.com/wimpysworld/deb-get/main/deb-get | sudo -E bash -s install deb-get
 ```
 
-Then install Github CLI using the following command in terminal:
+Then install gh using the following command in terminal:
 
 ```bash
 deb-get install gh
 ```
 
-Once Github CLI is installed it can be kept upto date using:
+Once gh is installed it can be kept up to date using:
 
 ```bash
 deb-get update

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -32,6 +32,31 @@ sudo apt update
 sudo apt install gh
 ```
 
+### Debian, Ubuntu Linux, Raspberry Pi OS (deb-get)
+
+For users of Debian and Ubuntu based distributions, you can also install and
+update the official `.deb` packages we publish in our GitHub releases page using [deb-get](https://github.com/wimpysworld/deb-get).
+
+First install `deb-get` using these commands in a terminal:
+
+```bash
+sudo apt install curl
+curl -sL https://raw.githubusercontent.com/wimpysworld/deb-get/main/deb-get | sudo -E bash -s install deb-get
+```
+
+Then install Github CLI using the following command in terminal:
+
+```bash
+deb-get install gh
+```
+
+Once Github CLI is installed it can be kept upto date using:
+
+```bash
+deb-get update
+deb-get upgrade
+```
+
 ### Fedora, CentOS, Red Hat Enterprise Linux (dnf)
 
 Install from our package repository for immediate access to latest releases:


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
deb-get is a way for users to install and update software on Ubuntu and other Debian based Linux distributions. It uses the official download from Github releases, and installs/ updates it using native Linux tooling. It is similar to winget on Windows.

This PR is part of a mini-hacktoberfest event put on by the deb-get team https://github.com/wimpysworld/deb-get/issues/579.