### PR TITLE
Adding an extra example of JSON output with field selection for gh issue list command

### DIFF
--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -71,6 +71,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			$ gh issue list --assignee "@me"
 			$ gh issue list --milestone "The big 1.0"
 			$ gh issue list --search "error no:assignee sort:created-asc"
+			$ gh issue list --json number --jq .[].number
 		`),
 		Aliases: []string{"ls"},
 		Args:    cmdutil.NoArgsQuoteReminder,


### PR DESCRIPTION
Note that the field name name repetition is required, as using `--jq` without `--json` raises an error:
```
$ gh issue list --jq .[].number
cannot use `--jq` without specifying `--json`
```