### PR TITLE
Refactor git client and add tests

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -148,8 +148,8 @@ func (c *Client) CurrentBranch(ctx context.Context) (string, error) {
 }
 
 // ShowRefs resolves fully-qualified refs to commit hashes.
-func (c *Client) ShowRefs(ctx context.Context, ref ...string) ([]Ref, error) {
-	args := append([]string{"show-ref", "--verify", "--"}, ref...)
+func (c *Client) ShowRefs(ctx context.Context, refs []string) ([]Ref, error) {
+	args := append([]string{"show-ref", "--verify", "--"}, refs...)
 	cmd, err := c.Command(ctx, args...)
 	if err != nil {
 		return nil, err
@@ -157,18 +157,18 @@ func (c *Client) ShowRefs(ctx context.Context, ref ...string) ([]Ref, error) {
 	// This functionality relies on parsing output from the git command despite
 	// an error status being returned from git.
 	out, err := cmd.Output()
-	var refs []Ref
+	var verified []Ref
 	for _, line := range outputLines(out) {
 		parts := strings.SplitN(line, " ", 2)
 		if len(parts) < 2 {
 			continue
 		}
-		refs = append(refs, Ref{
+		verified = append(verified, Ref{
 			Hash: parts[0],
 			Name: parts[1],
 		})
 	}
-	return refs, err
+	return verified, err
 }
 
 func (c *Client) Config(ctx context.Context, name string) (string, error) {

--- a/git/client.go
+++ b/git/client.go
@@ -15,121 +15,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/cli/cli/v2/internal/run"
 	"github.com/cli/safeexec"
 )
 
 var remoteRE = regexp.MustCompile(`(.+)\s+(.+)\s+\((push|fetch)\)`)
-
-// ErrNotOnAnyBranch indicates that the user is in detached HEAD state.
-var ErrNotOnAnyBranch = errors.New("git: not on any branch")
-
-type NotInstalled struct {
-	message string
-	err     error
-}
-
-func (e *NotInstalled) Error() string {
-	return e.message
-}
-
-func (e *NotInstalled) Unwrap() error {
-	return e.err
-}
-
-type GitError struct {
-	ExitCode int
-	Stderr   string
-	err      error
-}
-
-func (ge *GitError) Error() string {
-	if ge.Stderr == "" {
-		return fmt.Sprintf("failed to run git: %v", ge.err)
-	}
-	return fmt.Sprintf("failed to run git: %s", ge.Stderr)
-}
-
-func (ge *GitError) Unwrap() error {
-	return ge.err
-}
-
-type gitCommand struct {
-	*exec.Cmd
-}
-
-func (gc *gitCommand) Run() error {
-	// This is a hack in order to not break the hundreds of
-	// existing tests that rely on `run.PrepareCmd` to be invoked.
-	err := run.PrepareCmd(gc.Cmd).Run()
-	if err != nil {
-		ge := GitError{err: err}
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) {
-			ge.Stderr = string(exitError.Stderr)
-			ge.ExitCode = exitError.ExitCode()
-		}
-		return &ge
-	}
-	return nil
-}
-
-func (gc *gitCommand) Output() ([]byte, error) {
-	gc.Stdout = nil
-	gc.Stderr = nil
-	// This is a hack in order to not break the hundreds of
-	// existing tests that rely on `run.PrepareCmd` to be invoked.
-	out, err := run.PrepareCmd(gc.Cmd).Output()
-	if err != nil {
-		ge := GitError{err: err}
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) {
-			ge.Stderr = string(exitError.Stderr)
-			ge.ExitCode = exitError.ExitCode()
-		}
-		err = &ge
-	}
-	return out, err
-}
-
-func (gc *gitCommand) setRepoDir(repoDir string) {
-	for i, arg := range gc.Args {
-		if arg == "-C" {
-			gc.Args[i+1] = repoDir
-			return
-		}
-	}
-	gc.Args = append(gc.Args[:3], gc.Args[1:]...)
-	gc.Args[1] = "-C"
-	gc.Args[2] = repoDir
-}
-
-// Allow individual commands to be modified from the default client options.
-type CommandModifier func(*gitCommand)
-
-func WithStderr(stderr io.Writer) CommandModifier {
-	return func(gc *gitCommand) {
-		gc.Stderr = stderr
-	}
-}
-
-func WithStdout(stdout io.Writer) CommandModifier {
-	return func(gc *gitCommand) {
-		gc.Stdout = stdout
-	}
-}
-
-func WithStdin(stdin io.Reader) CommandModifier {
-	return func(gc *gitCommand) {
-		gc.Stdin = stdin
-	}
-}
-
-func WithRepoDir(repoDir string) CommandModifier {
-	return func(gc *gitCommand) {
-		gc.setRepoDir(repoDir)
-	}
-}
 
 type Client struct {
 	GhPath  string
@@ -139,7 +28,7 @@ type Client struct {
 	Stdin   io.Reader
 	Stdout  io.Writer
 
-	commandContext func(ctx context.Context, name string, args ...string) *exec.Cmd
+	commandContext commandCtx
 	mu             sync.Mutex
 }
 
@@ -165,24 +54,6 @@ func (c *Client) Command(ctx context.Context, args ...string) (*gitCommand, erro
 	cmd.Stdin = c.Stdin
 	cmd.Stdout = c.Stdout
 	return &gitCommand{cmd}, nil
-}
-
-func resolveGitPath() (string, error) {
-	path, err := safeexec.LookPath("git")
-	if err != nil {
-		if errors.Is(err, exec.ErrNotFound) {
-			programName := "git"
-			if runtime.GOOS == "windows" {
-				programName = "Git for Windows"
-			}
-			return "", &NotInstalled{
-				message: fmt.Sprintf("unable to find git executable in PATH; please install %s before retrying", programName),
-				err:     err,
-			}
-		}
-		return "", err
-	}
-	return path, nil
 }
 
 // AuthenticatedCommand is a wrapper around Command that included configuration to use gh
@@ -228,42 +99,6 @@ func (c *Client) Remotes(ctx context.Context) (RemoteSet, error) {
 	populateResolvedRemotes(remotes, outputLines(configOut))
 	sort.Sort(remotes)
 	return remotes, nil
-}
-
-func (c *Client) AddRemote(ctx context.Context, name, urlStr string, trackingBranches []string, mods ...CommandModifier) (*Remote, error) {
-	args := []string{"remote", "add"}
-	for _, branch := range trackingBranches {
-		args = append(args, "-t", branch)
-	}
-	args = append(args, "-f", name, urlStr)
-	cmd, err := c.Command(ctx, args...)
-	if err != nil {
-		return nil, err
-	}
-	for _, mod := range mods {
-		mod(cmd)
-	}
-	if _, err := cmd.Output(); err != nil {
-		return nil, err
-	}
-	var urlParsed *url.URL
-	if strings.HasPrefix(urlStr, "https") {
-		urlParsed, err = url.Parse(urlStr)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		urlParsed, err = ParseURL(urlStr)
-		if err != nil {
-			return nil, err
-		}
-	}
-	remote := &Remote{
-		Name:     name,
-		FetchURL: urlParsed,
-		PushURL:  urlParsed,
-	}
-	return remote, nil
 }
 
 func (c *Client) UpdateRemoteURL(ctx context.Context, name, url string) error {
@@ -403,19 +238,6 @@ func (c *Client) Commits(ctx context.Context, baseRef, headRef string) ([]*Commi
 	return commits, nil
 }
 
-func (c *Client) lookupCommit(ctx context.Context, sha, format string) ([]byte, error) {
-	args := []string{"-c", "log.ShowSignature=false", "show", "-s", "--pretty=format:" + format, sha}
-	cmd, err := c.Command(ctx, args...)
-	if err != nil {
-		return nil, err
-	}
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 func (c *Client) LastCommit(ctx context.Context) (*Commit, error) {
 	output, err := c.lookupCommit(ctx, "HEAD", "%H,%s")
 	if err != nil {
@@ -433,18 +255,17 @@ func (c *Client) CommitBody(ctx context.Context, sha string) (string, error) {
 	return string(output), err
 }
 
-// Push publishes a git ref to a remote and sets up upstream configuration.
-func (c *Client) Push(ctx context.Context, remote string, ref string, mods ...CommandModifier) error {
-	args := []string{"push", "--set-upstream", remote, ref}
-	//TODO: Use AuthenticatedCommand
+func (c *Client) lookupCommit(ctx context.Context, sha, format string) ([]byte, error) {
+	args := []string{"-c", "log.ShowSignature=false", "show", "-s", "--pretty=format:" + format, sha}
 	cmd, err := c.Command(ctx, args...)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	for _, mod := range mods {
-		mod(cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
 	}
-	return cmd.Run()
+	return out, nil
 }
 
 // ReadBranchConfig parses the `branch.BRANCH.(remote|merge)` part of git config.
@@ -533,39 +354,6 @@ func (c *Client) CheckoutNewBranch(ctx context.Context, remoteName, branch strin
 	return nil
 }
 
-func (c *Client) Pull(ctx context.Context, remote, branch string) error {
-	args := []string{"pull", "--ff-only", remote, branch}
-	//TODO: Use AuthenticatedCommand
-	cmd, err := c.Command(ctx, args...)
-	if err != nil {
-		return err
-	}
-	return cmd.Run()
-}
-
-func (c *Client) Clone(ctx context.Context, cloneURL string, args []string) (string, error) {
-	cloneArgs, target := parseCloneArgs(args)
-	cloneArgs = append(cloneArgs, cloneURL)
-	// If the args contain an explicit target, pass it to clone
-	// otherwise, parse the URL to determine where git cloned it to so we can return it
-	if target != "" {
-		cloneArgs = append(cloneArgs, target)
-	} else {
-		target = path.Base(strings.TrimSuffix(cloneURL, ".git"))
-	}
-	cloneArgs = append([]string{"clone"}, cloneArgs...)
-	//TODO: Use AuthenticatedCommand
-	cmd, err := c.Command(ctx, cloneArgs...)
-	if err != nil {
-		return "", err
-	}
-	err = cmd.Run()
-	if err != nil {
-		return "", err
-	}
-	return target, nil
-}
-
 // ToplevelDir returns the top-level directory path of the current repository.
 func (c *Client) ToplevelDir(ctx context.Context) (string, error) {
 	args := []string{"rev-parse", "--show-toplevel"}
@@ -608,6 +396,128 @@ func (c *Client) PathFromRoot(ctx context.Context) string {
 		return path[:len(path)-1]
 	}
 	return ""
+}
+
+// Below are commands that make network calls and need authentication credentials supplied from gh.
+
+func (c *Client) Fetch(ctx context.Context, remote string, refspec string, mods ...CommandModifier) error {
+	args := []string{"fetch", remote, refspec}
+	// TODO: Use AuthenticatedCommand
+	cmd, err := c.Command(ctx, args...)
+	if err != nil {
+		return err
+	}
+	for _, mod := range mods {
+		mod(cmd)
+	}
+	return cmd.Run()
+}
+
+func (c *Client) Pull(ctx context.Context, remote, branch string, mods ...CommandModifier) error {
+	args := []string{"pull", "--ff-only", remote, branch}
+	// TODO: Use AuthenticatedCommand
+	cmd, err := c.Command(ctx, args...)
+	if err != nil {
+		return err
+	}
+	for _, mod := range mods {
+		mod(cmd)
+	}
+	return cmd.Run()
+}
+
+func (c *Client) Push(ctx context.Context, remote string, ref string, mods ...CommandModifier) error {
+	args := []string{"push", "--set-upstream", remote, ref}
+	// TODO: Use AuthenticatedCommand
+	cmd, err := c.Command(ctx, args...)
+	if err != nil {
+		return err
+	}
+	for _, mod := range mods {
+		mod(cmd)
+	}
+	return cmd.Run()
+}
+
+func (c *Client) Clone(ctx context.Context, cloneURL string, args []string, mods ...CommandModifier) (string, error) {
+	cloneArgs, target := parseCloneArgs(args)
+	cloneArgs = append(cloneArgs, cloneURL)
+	// If the args contain an explicit target, pass it to clone otherwise,
+	// parse the URL to determine where git cloned it to so we can return it.
+	if target != "" {
+		cloneArgs = append(cloneArgs, target)
+	} else {
+		target = path.Base(strings.TrimSuffix(cloneURL, ".git"))
+	}
+	cloneArgs = append([]string{"clone"}, cloneArgs...)
+	// TODO: Use AuthenticatedCommand
+	cmd, err := c.Command(ctx, cloneArgs...)
+	if err != nil {
+		return "", err
+	}
+	for _, mod := range mods {
+		mod(cmd)
+	}
+	err = cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+func (c *Client) AddRemote(ctx context.Context, name, urlStr string, trackingBranches []string, mods ...CommandModifier) (*Remote, error) {
+	args := []string{"remote", "add"}
+	for _, branch := range trackingBranches {
+		args = append(args, "-t", branch)
+	}
+	args = append(args, "-f", name, urlStr)
+	// TODO: Use AuthenticatedCommand
+	cmd, err := c.Command(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	for _, mod := range mods {
+		mod(cmd)
+	}
+	if _, err := cmd.Output(); err != nil {
+		return nil, err
+	}
+	var urlParsed *url.URL
+	if strings.HasPrefix(urlStr, "https") {
+		urlParsed, err = url.Parse(urlStr)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		urlParsed, err = ParseURL(urlStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	remote := &Remote{
+		Name:     name,
+		FetchURL: urlParsed,
+		PushURL:  urlParsed,
+	}
+	return remote, nil
+}
+
+func resolveGitPath() (string, error) {
+	path, err := safeexec.LookPath("git")
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			programName := "git"
+			if runtime.GOOS == "windows" {
+				programName = "Git for Windows"
+			}
+			return "", &NotInstalled{
+				message: fmt.Sprintf("unable to find git executable in PATH; please install %s before retrying", programName),
+				err:     err,
+			}
+		}
+		return "", err
+	}
+	return path, nil
 }
 
 func isFilesystemPath(p string) bool {

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -3,12 +3,17 @@ package git
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
-	"github.com/cli/cli/v2/internal/run"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientCommand(t *testing.T) {
@@ -63,18 +68,18 @@ func TestClientAuthenticatedCommand(t *testing.T) {
 		{
 			name:     "adds credential helper config options",
 			path:     "path/to/gh",
-			wantArgs: []string{"git", "-c", "credential.helper=", "-c", "credential.helper=!\"path/to/gh\" auth git-credential", "fetch"},
+			wantArgs: []string{"path/to/git", "-c", "credential.helper=", "-c", "credential.helper=!\"path/to/gh\" auth git-credential", "fetch"},
 		},
 		{
 			name:     "fallback when GhPath is not set",
-			wantArgs: []string{"git", "-c", "credential.helper=", "-c", "credential.helper=!\"gh\" auth git-credential", "fetch"},
+			wantArgs: []string{"path/to/git", "-c", "credential.helper=", "-c", "credential.helper=!\"gh\" auth git-credential", "fetch"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := Client{
 				GhPath:  tt.path,
-				GitPath: "git",
+				GitPath: "path/to/git",
 			}
 			cmd, err := client.AuthenticatedCommand(context.Background(), "fetch")
 			assert.NoError(t, err)
@@ -122,7 +127,7 @@ func TestClientRemotes(t *testing.T) {
 	assert.Equal(t, "other", rs[3].Resolved)
 }
 
-func TestClientRemotesNoResolvedRemote(t *testing.T) {
+func TestClientRemotes_no_resolved_remote(t *testing.T) {
 	tempDir := t.TempDir()
 	initRepo(t, tempDir)
 	gitDir := filepath.Join(tempDir, ".git")
@@ -192,56 +197,66 @@ func TestParseRemotes(t *testing.T) {
 	assert.Equal(t, "/koke/grit.git", r[4].PushURL.Path)
 }
 
-func TestClientLastCommit(t *testing.T) {
-	client := Client{
-		RepoDir: "./fixtures/simple.git",
-	}
-	c, err := client.LastCommit(context.Background())
-	assert.NoError(t, err)
-	assert.Equal(t, "6f1a2405cace1633d89a79c74c65f22fe78f9659", c.Sha)
-	assert.Equal(t, "Second commit", c.Title)
-}
-
-func TestClientCommitBody(t *testing.T) {
-	client := Client{
-		RepoDir: "./fixtures/simple.git",
-	}
-	body, err := client.CommitBody(context.Background(), "6f1a2405cace1633d89a79c74c65f22fe78f9659")
-	assert.NoError(t, err)
-	assert.Equal(t, "I'm starting to get the hang of things\n", body)
-}
-
-func TestClientUncommittedChangeCount(t *testing.T) {
+func TestClientUpdateRemoteURL(t *testing.T) {
 	tests := []struct {
-		name     string
-		expected int
-		output   string
+		name         string
+		stub         commandCtx
+		wantErrorMsg string
 	}{
 		{
-			name:     "no changes",
-			expected: 0,
-			output:   "",
+			name: "update remote url",
+			stub: stubCommandContext(t, `git remote set-url test https://test.com`, 0, "", ""),
 		},
 		{
-			name:     "one change",
-			expected: 1,
-			output:   " M poem.txt",
-		},
-		{
-			name:     "untracked file",
-			expected: 2,
-			output:   " M poem.txt\n?? new.txt",
+			name:         "git error",
+			stub:         stubCommandContext(t, `git remote set-url test https://test.com`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cs, restore := run.Stub()
-			defer restore(t)
-			cs.Register(`git status --porcelain`, 0, tt.output)
-			client := Client{}
-			ucc, err := client.UncommittedChangeCount(context.Background())
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, ucc)
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			err := client.UpdateRemoteURL(context.Background(), "test", "https://test.com")
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestClientSetRemoteResolution(t *testing.T) {
+	tests := []struct {
+		name         string
+		stub         commandCtx
+		wantErrorMsg string
+	}{
+		{
+			name: "set remote resolution",
+			stub: stubCommandContext(t, `git config --add remote.origin.gh-resolved base`, 0, "", ""),
+		},
+		{
+			name:         "git error",
+			stub:         stubCommandContext(t, `git config --add remote.origin.gh-resolved base`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			err := client.SetRemoteResolution(context.Background(), "origin", "base")
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
 		})
 	}
 }
@@ -270,10 +285,10 @@ func TestClientCurrentBranch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cs, teardown := run.Stub()
-			defer teardown(t)
-			cs.Register(`git symbolic-ref --quiet HEAD`, 0, tt.stub)
-			client := Client{}
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: stubCommandContext(t, `git symbolic-ref --quiet HEAD`, 0, tt.stub, ""),
+			}
 			branch, err := client.CurrentBranch(context.Background())
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, branch)
@@ -281,13 +296,604 @@ func TestClientCurrentBranch(t *testing.T) {
 	}
 }
 
-func TestClientCurrentBranch_detached_head(t *testing.T) {
-	cs, teardown := run.Stub()
-	defer teardown(t)
-	cs.Register(`git symbolic-ref --quiet HEAD`, 1, "")
-	client := Client{}
+func TestClientCurrentBranch_detached_head_state(t *testing.T) {
+	client := Client{
+		GitPath:        "path/to/git",
+		commandContext: stubCommandContext(t, `git symbolic-ref --quiet HEAD`, 1, "", ""),
+	}
 	_, err := client.CurrentBranch(context.Background())
 	assert.EqualError(t, err, "failed to run git: not on any branch")
+}
+
+func TestClientShowRefs(t *testing.T) {
+	tests := []struct {
+		name         string
+		stub         commandCtx
+		wantRefs     []Ref
+		wantErrorMsg string
+	}{
+		{
+			name: "show refs with one vaid ref and one invalid ref",
+			stub: stubCommandContext(t,
+				`git show-ref --verify -- refs/heads/valid refs/heads/invalid`,
+				128,
+				"9ea76237a557015e73446d33268569a114c0649c refs/heads/valid",
+				"fatal: 'refs/heads/invalid' - not a valid ref"),
+			wantRefs: []Ref{{
+				Hash: "9ea76237a557015e73446d33268569a114c0649c",
+				Name: "refs/heads/valid",
+			}},
+			wantErrorMsg: "failed to run git: fatal: 'refs/heads/invalid' - not a valid ref",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			refs, err := client.ShowRefs(context.Background(), "refs/heads/valid", "refs/heads/invalid")
+			assert.EqualError(t, err, tt.wantErrorMsg)
+			assert.Equal(t, tt.wantRefs, refs)
+		})
+	}
+}
+
+func TestClientConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		stub         commandCtx
+		wantOut      string
+		wantErrorMsg string
+	}{
+		{
+			name:    "get config key",
+			stub:    stubCommandContext(t, `git config credential.helper`, 0, "test", ""),
+			wantOut: "test",
+		},
+		{
+			name:         "get unknown config key",
+			stub:         stubCommandContext(t, `git config credential.helper`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: unknown config key credential.helper",
+		},
+		{
+			name:         "git error",
+			stub:         stubCommandContext(t, `git config credential.helper`, 2, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			out, err := client.Config(context.Background(), "credential.helper")
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
+			assert.Equal(t, tt.wantOut, out)
+		})
+	}
+}
+
+func TestClientUncommittedChangeCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected int
+		output   string
+	}{
+		{
+			name:     "no changes",
+			expected: 0,
+			output:   "",
+		},
+		{
+			name:     "one change",
+			expected: 1,
+			output:   " M poem.txt",
+		},
+		{
+			name:     "untracked file",
+			expected: 2,
+			output:   " M poem.txt\n?? new.txt",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: stubCommandContext(t, `git status --porcelain`, 0, tt.output, ""),
+			}
+			ucc, err := client.UncommittedChangeCount(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, ucc)
+		})
+	}
+}
+
+func TestClientCommits(t *testing.T) {
+	tests := []struct {
+		name         string
+		stub         commandCtx
+		wantCommits  []*Commit
+		wantErrorMsg string
+	}{
+		{
+			name: "get commits",
+			stub: stubCommandContext(t,
+				`git -c log.ShowSignature=false log --pretty=format:%H,%s --cherry SHA1...SHA2`,
+				0,
+				"6a6872b918c601a0e730710ad8473938a7516d30,testing testability test",
+				""),
+			wantCommits: []*Commit{{
+				Sha:   "6a6872b918c601a0e730710ad8473938a7516d30",
+				Title: "testing testability test",
+			}},
+		},
+		{
+			name: "no commits between SHAs",
+			stub: stubCommandContext(t,
+				`git -c log.ShowSignature=false log --pretty=format:%H,%s --cherry SHA1...SHA2`,
+				0,
+				"",
+				""),
+			wantErrorMsg: "could not find any commits between SHA1 and SHA2",
+		},
+		{
+			name: "git error",
+			stub: stubCommandContext(t,
+				`git -c log.ShowSignature=false log --pretty=format:%H,%s --cherry SHA1...SHA2`,
+				1,
+				"",
+				"git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			commits, err := client.Commits(context.Background(), "SHA1", "SHA2")
+			if tt.wantErrorMsg != "" {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCommits, commits)
+		})
+	}
+}
+
+func TestClientLastCommit(t *testing.T) {
+	client := Client{
+		RepoDir: "./fixtures/simple.git",
+	}
+	c, err := client.LastCommit(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "6f1a2405cace1633d89a79c74c65f22fe78f9659", c.Sha)
+	assert.Equal(t, "Second commit", c.Title)
+}
+
+func TestClientCommitBody(t *testing.T) {
+	client := Client{
+		RepoDir: "./fixtures/simple.git",
+	}
+	body, err := client.CommitBody(context.Background(), "6f1a2405cace1633d89a79c74c65f22fe78f9659")
+	assert.NoError(t, err)
+	assert.Equal(t, "I'm starting to get the hang of things\n", body)
+}
+
+func TestClientReadBranchConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		stub             commandCtx
+		wantBranchConfig BranchConfig
+	}{
+		{
+			name: "read branch config",
+			stub: stubCommandContext(t,
+				`git config --get-regexp \^branch\\\.trunk\\\.\(remote\|merge\)\$`,
+				0,
+				"branch.trunk.remote origin\nbranch.trunk.merge refs/heads/trunk",
+				""),
+			wantBranchConfig: BranchConfig{RemoteName: "origin", MergeRef: "refs/heads/trunk"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			branchConfig := client.ReadBranchConfig(context.Background(), "trunk")
+			assert.Equal(t, tt.wantBranchConfig, branchConfig)
+		})
+	}
+}
+
+func TestClientDeleteLocalBranch(t *testing.T) {
+	tests := []struct {
+		name         string
+		stub         commandCtx
+		wantErrorMsg string
+	}{
+		{
+			name: "delete local branch",
+			stub: stubCommandContext(t, `git branch -D trunk`, 0, "", ""),
+		},
+		{
+			name:         "git error",
+			stub:         stubCommandContext(t, `git branch -D trunk`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			err := client.DeleteLocalBranch(context.Background(), "trunk")
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestClientHasLocalBranch(t *testing.T) {
+	tests := []struct {
+		name    string
+		stub    commandCtx
+		wantOut bool
+	}{
+		{
+			name:    "has local branch",
+			stub:    stubCommandContext(t, `git rev-parse --verify refs/heads/trunk`, 0, "", ""),
+			wantOut: true,
+		},
+		{
+			name:    "does not have local branch",
+			stub:    stubCommandContext(t, `git rev-parse --verify refs/heads/trunk`, 1, "", ""),
+			wantOut: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			out := client.HasLocalBranch(context.Background(), "trunk")
+			assert.Equal(t, out, tt.wantOut)
+		})
+	}
+}
+
+func TestClientCheckoutBranch(t *testing.T) {
+	tests := []struct {
+		name         string
+		stub         commandCtx
+		wantErrorMsg string
+	}{
+		{
+			name: "checkout branch",
+			stub: stubCommandContext(t, `git checkout trunk`, 0, "", ""),
+		},
+		{
+			name:         "git error",
+			stub:         stubCommandContext(t, `git checkout trunk`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			err := client.CheckoutBranch(context.Background(), "trunk")
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestClientCheckoutNewBranch(t *testing.T) {
+	tests := []struct {
+		name         string
+		stub         commandCtx
+		wantErrorMsg string
+	}{
+		{
+			name: "checkout new branch",
+			stub: stubCommandContext(t, `git checkout -b trunk --track origin`, 0, "", ""),
+		},
+		{
+			name:         "git error",
+			stub:         stubCommandContext(t, `git checkout -b trunk --track origin`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			err := client.CheckoutNewBranch(context.Background(), "origin", "trunk")
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestClientToplevelDir(t *testing.T) {
+	tests := []struct {
+		name         string
+		stub         commandCtx
+		wantDir      string
+		wantErrorMsg string
+	}{
+		{
+			name:    "top level dir",
+			stub:    stubCommandContext(t, `git rev-parse --show-toplevel`, 0, "/path/to/repo", ""),
+			wantDir: "/path/to/repo",
+		},
+		{
+			name:         "git error",
+			stub:         stubCommandContext(t, `git rev-parse --show-toplevel`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			dir, err := client.ToplevelDir(context.Background())
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
+			assert.Equal(t, tt.wantDir, dir)
+		})
+	}
+}
+
+func TestClientGitDir(t *testing.T) {
+	tests := []struct {
+		name         string
+		stub         commandCtx
+		wantDir      string
+		wantErrorMsg string
+	}{
+		{
+			name:    "git dir",
+			stub:    stubCommandContext(t, `git rev-parse --git-dir`, 0, "/path/to/repo/.git", ""),
+			wantDir: "/path/to/repo/.git",
+		},
+		{
+			name:         "git error",
+			stub:         stubCommandContext(t, `git rev-parse --git-dir`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			dir, err := client.GitDir(context.Background())
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
+			assert.Equal(t, tt.wantDir, dir)
+		})
+	}
+}
+
+func TestClientPathFromRoot(t *testing.T) {
+	tests := []struct {
+		name    string
+		stub    commandCtx
+		wantDir string
+	}{
+		{
+			name:    "current path from root",
+			stub:    stubCommandContext(t, `git rev-parse --show-prefix`, 0, "some/path/", ""),
+			wantDir: "some/path",
+		},
+		{
+			name:    "git error",
+			stub:    stubCommandContext(t, `git rev-parse --show-prefix`, 1, "", "git error message"),
+			wantDir: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			dir := client.PathFromRoot(context.Background())
+			assert.Equal(t, tt.wantDir, dir)
+		})
+	}
+}
+
+func TestClientFetch(t *testing.T) {
+	tests := []struct {
+		name         string
+		mods         []CommandModifier
+		stub         commandCtx
+		wantErrorMsg string
+	}{
+		{
+			name: "fetch",
+			stub: stubCommandContext(t, `git fetch origin trunk`, 0, "", ""),
+		},
+		{
+			name: "accepts command modifiers",
+			mods: []CommandModifier{WithRepoDir("/path/to/repo")},
+			stub: stubCommandContext(t, `git fetch origin trunk`, 0, "", ""),
+		},
+		{
+			name:         "git error",
+			stub:         stubCommandContext(t, `git fetch origin trunk`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			err := client.Fetch(context.Background(), "origin", "trunk", tt.mods...)
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestClientPull(t *testing.T) {
+	tests := []struct {
+		name         string
+		mods         []CommandModifier
+		stub         commandCtx
+		wantErrorMsg string
+	}{
+		{
+			name: "pull",
+			stub: stubCommandContext(t, `git pull --ff-only origin trunk`, 0, "", ""),
+		},
+		{
+			name: "accepts command modifiers",
+			mods: []CommandModifier{WithRepoDir("/path/to/repo")},
+			stub: stubCommandContext(t, `git pull --ff-only origin trunk`, 0, "", ""),
+		},
+		{
+			name:         "git error",
+			stub:         stubCommandContext(t, `git pull --ff-only origin trunk`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			err := client.Pull(context.Background(), "origin", "trunk", tt.mods...)
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestClientPush(t *testing.T) {
+	tests := []struct {
+		name         string
+		mods         []CommandModifier
+		stub         commandCtx
+		wantErrorMsg string
+	}{
+		{
+			name: "push",
+			stub: stubCommandContext(t, `git push --set-upstream origin trunk`, 0, "", ""),
+		},
+		{
+			name: "accepts command modifiers",
+			mods: []CommandModifier{WithRepoDir("/path/to/repo")},
+			stub: stubCommandContext(t, `git push --set-upstream origin trunk`, 0, "", ""),
+		},
+		{
+			name:         "git error",
+			stub:         stubCommandContext(t, `git push --set-upstream origin trunk`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			err := client.Push(context.Background(), "origin", "trunk", tt.mods...)
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
+		})
+	}
+}
+
+func TestClientClone(t *testing.T) {
+	tests := []struct {
+		name         string
+		mods         []CommandModifier
+		stub         commandCtx
+		wantTarget   string
+		wantErrorMsg string
+	}{
+		{
+			name:       "clone",
+			stub:       stubCommandContext(t, `git clone github.com/cli/cli`, 0, "", ""),
+			wantTarget: "cli",
+		},
+		{
+			name:       "accepts command modifiers",
+			mods:       []CommandModifier{WithRepoDir("/path/to/repo")},
+			stub:       stubCommandContext(t, `git clone github.com/cli/cli`, 0, "", ""),
+			wantTarget: "cli",
+		},
+		{
+			name:         "git error",
+			stub:         stubCommandContext(t, `git clone github.com/cli/cli`, 1, "", "git error message"),
+			wantErrorMsg: "failed to run git: git error message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{
+				GitPath:        "path/to/git",
+				commandContext: tt.stub,
+			}
+			target, err := client.Clone(context.Background(), "github.com/cli/cli", []string{}, tt.mods...)
+			if tt.wantErrorMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErrorMsg)
+			}
+			assert.Equal(t, tt.wantTarget, target)
+		})
+	}
 }
 
 func TestParseCloneArgs(t *testing.T) {
@@ -357,7 +963,7 @@ func TestClientAddRemote(t *testing.T) {
 			url:      "URL",
 			dir:      "DIRECTORY",
 			branches: []string{},
-			want:     "git -C DIRECTORY remote add -f test URL",
+			want:     `git -C DIRECTORY remote add -f test URL`,
 		},
 		{
 			title:    "fetch specific branches only",
@@ -365,16 +971,15 @@ func TestClientAddRemote(t *testing.T) {
 			url:      "URL",
 			dir:      "DIRECTORY",
 			branches: []string{"trunk", "dev"},
-			want:     "git -C DIRECTORY remote add -t trunk -t dev -f test URL",
+			want:     `git -C DIRECTORY remote add -t trunk -t dev -f test URL`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.title, func(t *testing.T) {
-			cs, cmdTeardown := run.Stub()
-			defer cmdTeardown(t)
-			cs.Register(tt.want, 0, "")
 			client := Client{
-				RepoDir: tt.dir,
+				GitPath:        "path/to/git",
+				RepoDir:        tt.dir,
+				commandContext: stubCommandContext(t, tt.want, 0, "", ""),
 			}
 			_, err := client.AddRemote(context.Background(), tt.name, tt.url, tt.branches)
 			assert.NoError(t, err)
@@ -396,4 +1001,46 @@ func initRepo(t *testing.T, dir string) {
 	assert.NoError(t, err)
 	_, err = cmd.Output()
 	assert.NoError(t, err)
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GH_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	if err := func(args []string) error {
+		fmt.Fprint(os.Stdout, os.Getenv("GH_HELPER_PROCESS_STDOUT"))
+		exitStatus := os.Getenv("GH_HELPER_PROCESS_EXIT_STATUS")
+		if exitStatus != "0" {
+			return errors.New("error")
+		}
+		return nil
+	}(os.Args[3:]); err != nil {
+		fmt.Fprint(os.Stderr, os.Getenv("GH_HELPER_PROCESS_STDERR"))
+		exitStatus := os.Getenv("GH_HELPER_PROCESS_EXIT_STATUS")
+		i, err := strconv.Atoi(exitStatus)
+		if err != nil {
+			os.Exit(1)
+		}
+		os.Exit(i)
+	}
+	os.Exit(0)
+}
+
+func stubCommandContext(t *testing.T, pattern string, exitStatus int, stdout, stderr string) commandCtx {
+	return func(ctx context.Context, exe string, args ...string) *exec.Cmd {
+		p := strings.Join(append([]string{exe}, args...), " ")
+		require.Regexp(t, pattern, p)
+		args = append([]string{os.Args[0], "-test.run=TestHelperProcess", "--", exe}, args...)
+		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+		stdoutEnv := fmt.Sprintf("GH_HELPER_PROCESS_STDOUT=%s", stdout)
+		stderrEnv := fmt.Sprintf("GH_HELPER_PROCESS_STDERR=%s", stderr)
+		exitStatusEnv := fmt.Sprintf("GH_HELPER_PROCESS_EXIT_STATUS=%v", exitStatus)
+		cmd.Env = []string{
+			"GH_WANT_HELPER_PROCESS=1",
+			stdoutEnv,
+			stderrEnv,
+			exitStatusEnv,
+		}
+		return cmd
+	}
 }

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -358,7 +358,7 @@ func TestClientShowRefs(t *testing.T) {
 				GitPath:        "path/to/git",
 				commandContext: cmdCtx,
 			}
-			refs, err := client.ShowRefs(context.Background(), "refs/heads/valid", "refs/heads/invalid")
+			refs, err := client.ShowRefs(context.Background(), []string{"refs/heads/valid", "refs/heads/invalid"})
 			assert.Equal(t, tt.wantCmdArgs, strings.Join(cmd.Args[3:], " "))
 			assert.EqualError(t, err, tt.wantErrorMsg)
 			assert.Equal(t, tt.wantRefs, refs)

--- a/git/command.go
+++ b/git/command.go
@@ -1,0 +1,100 @@
+package git
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+
+	"github.com/cli/cli/v2/internal/run"
+)
+
+type commandCtx = func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+type gitCommand struct {
+	*exec.Cmd
+}
+
+func (gc *gitCommand) Run() error {
+	stderr := &bytes.Buffer{}
+	if gc.Cmd.Stderr == nil {
+		gc.Cmd.Stderr = stderr
+	}
+	// This is a hack in order to not break the hundreds of
+	// existing tests that rely on `run.PrepareCmd` to be invoked.
+	err := run.PrepareCmd(gc.Cmd).Run()
+	if err != nil {
+		ge := GitError{err: err, Stderr: stderr.String()}
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			ge.ExitCode = exitError.ExitCode()
+		}
+		return &ge
+	}
+	return nil
+}
+
+func (gc *gitCommand) Output() ([]byte, error) {
+	gc.Stdout = nil
+	gc.Stderr = nil
+	// This is a hack in order to not break the hundreds of
+	// existing tests that rely on `run.PrepareCmd` to be invoked.
+	out, err := run.PrepareCmd(gc.Cmd).Output()
+	if err != nil {
+		ge := GitError{err: err}
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			ge.Stderr = string(exitError.Stderr)
+			ge.ExitCode = exitError.ExitCode()
+		}
+		err = &ge
+	}
+	return out, err
+}
+
+func (gc *gitCommand) setRepoDir(repoDir string) {
+	for i, arg := range gc.Args {
+		if arg == "-C" {
+			gc.Args[i+1] = repoDir
+			return
+		}
+	}
+	// Handle "--" invocations for testing purposes.
+	var index int
+	for i, arg := range gc.Args {
+		if arg == "--" {
+			index = i + 1
+		}
+	}
+	gc.Args = append(gc.Args[:index+3], gc.Args[index+1:]...)
+	gc.Args[index+1] = "-C"
+	gc.Args[index+2] = repoDir
+}
+
+// Allow individual commands to be modified from the default client options.
+type CommandModifier func(*gitCommand)
+
+func WithStderr(stderr io.Writer) CommandModifier {
+	return func(gc *gitCommand) {
+		gc.Stderr = stderr
+	}
+}
+
+func WithStdout(stdout io.Writer) CommandModifier {
+	return func(gc *gitCommand) {
+		gc.Stdout = stdout
+	}
+}
+
+func WithStdin(stdin io.Reader) CommandModifier {
+	return func(gc *gitCommand) {
+		gc.Stdin = stdin
+	}
+}
+
+func WithRepoDir(repoDir string) CommandModifier {
+	return func(gc *gitCommand) {
+		gc.setRepoDir(repoDir)
+	}
+}

--- a/git/errors.go
+++ b/git/errors.go
@@ -1,0 +1,39 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNotOnAnyBranch indicates that the user is in detached HEAD state.
+var ErrNotOnAnyBranch = errors.New("git: not on any branch")
+
+type NotInstalled struct {
+	message string
+	err     error
+}
+
+func (e *NotInstalled) Error() string {
+	return e.message
+}
+
+func (e *NotInstalled) Unwrap() error {
+	return e.err
+}
+
+type GitError struct {
+	ExitCode int
+	Stderr   string
+	err      error
+}
+
+func (ge *GitError) Error() string {
+	if ge.Stderr == "" {
+		return fmt.Sprintf("failed to run git: %v", ge.err)
+	}
+	return fmt.Sprintf("failed to run git: %s", ge.Stderr)
+}
+
+func (ge *GitError) Unwrap() error {
+	return ge.err
+}

--- a/pkg/cmd/issue/develop/develop.go
+++ b/pkg/cmd/issue/develop/develop.go
@@ -245,7 +245,6 @@ func developRunList(opts *DevelopOptions) (err error) {
 }
 
 func checkoutBranch(opts *DevelopOptions, baseRepo ghrepo.Interface, checkoutBranch string) (err error) {
-
 	remotes, err := opts.Remotes()
 	if err != nil {
 		return err
@@ -261,18 +260,11 @@ func checkoutBranch(opts *DevelopOptions, baseRepo ghrepo.Interface, checkoutBra
 			return err
 		}
 	} else {
-		gitFetch, err := opts.GitClient.Command(ctx.Background(), "fetch", "origin", fmt.Sprintf("+refs/heads/%[1]s:refs/remotes/origin/%[1]s", checkoutBranch))
-
+		err := opts.GitClient.Fetch(ctx.Background(), "origin", fmt.Sprintf("+refs/heads/%[1]s:refs/remotes/origin/%[1]s", checkoutBranch))
 		if err != nil {
 			return err
 		}
 
-		gitFetch.Stdout = opts.IO.Out
-		gitFetch.Stderr = opts.IO.ErrOut
-		err = gitFetch.Run()
-		if err != nil {
-			return err
-		}
 		if err := opts.GitClient.CheckoutNewBranch(ctx.Background(), baseRemote.Name, checkoutBranch); err != nil {
 			return err
 		}

--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -236,7 +236,7 @@ func missingMergeConfigForBranch(client *git.Client, b string) bool {
 }
 
 func localBranchExists(client *git.Client, b string) bool {
-	_, err := client.ShowRefs(context.Background(), "refs/heads/"+b)
+	_, err := client.ShowRefs(context.Background(), []string{"refs/heads/" + b})
 	return err == nil
 }
 

--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -242,7 +242,7 @@ func localBranchExists(client *git.Client, b string) bool {
 
 func executeCmds(client *git.Client, cmdQueue [][]string) error {
 	for _, args := range cmdQueue {
-		//TODO: Use AuthenticatedCommand
+		// TODO: Use AuthenticatedCommand
 		cmd, err := client.Command(context.Background(), args...)
 		if err != nil {
 			return err

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -423,7 +423,7 @@ func determineTrackingBranch(gitClient *git.Client, remotes ghContext.Remotes, h
 		refsForLookup = append(refsForLookup, tr.String())
 	}
 
-	resolvedRefs, _ := gitClient.ShowRefs(context.Background(), refsForLookup...)
+	resolvedRefs, _ := gitClient.ShowRefs(context.Background(), refsForLookup)
 	if len(resolvedRefs) > 1 {
 		for _, r := range resolvedRefs[1:] {
 			if r.Hash != resolvedRefs[0].Hash {

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -410,7 +410,7 @@ func Test_createRun(t *testing.T) {
 				cs.Register(`git -C . rev-parse --git-dir`, 0, ".git")
 				cs.Register(`git -C . rev-parse HEAD`, 0, "commithash")
 				cs.Register(`git -C . remote add origin https://github.com/OWNER/REPO`, 0, "")
-				cs.Register(`git -C . push -u origin HEAD`, 0, "")
+				cs.Register(`git -C . push --set-upstream origin HEAD`, 0, "")
 			},
 			wantStdout: "✓ Created repository OWNER/REPO on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n✓ Pushed commits to https://github.com/OWNER/REPO.git\n",
 		},

--- a/pkg/cmd/repo/sync/git.go
+++ b/pkg/cmd/repo/sync/git.go
@@ -70,7 +70,12 @@ func (g *gitExecuter) CurrentBranch() (string, error) {
 }
 
 func (g *gitExecuter) Fetch(remote, ref string) error {
-	return g.client.Fetch(context.Background(), remote, ref)
+	args := []string{"fetch", "-q", remote, ref}
+	cmd, err := g.client.Command(context.Background(), args...)
+	if err != nil {
+		return err
+	}
+	return cmd.Run()
 }
 
 func (g *gitExecuter) HasLocalBranch(branch string) bool {

--- a/pkg/cmd/repo/sync/git.go
+++ b/pkg/cmd/repo/sync/git.go
@@ -70,12 +70,7 @@ func (g *gitExecuter) CurrentBranch() (string, error) {
 }
 
 func (g *gitExecuter) Fetch(remote, ref string) error {
-	args := []string{"fetch", "-q", remote, ref}
-	cmd, err := g.client.Command(context.Background(), args...)
-	if err != nil {
-		return err
-	}
-	return cmd.Run()
+	return g.client.Fetch(context.Background(), remote, ref)
 }
 
 func (g *gitExecuter) HasLocalBranch(branch string) bool {
@@ -93,18 +88,11 @@ func (g *gitExecuter) IsAncestor(ancestor, progeny string) (bool, error) {
 }
 
 func (g *gitExecuter) IsDirty() (bool, error) {
-	cmd, err := g.client.Command(context.Background(), "status", "--untracked-files=no", "--porcelain")
+	changeCount, err := g.client.UncommittedChangeCount(context.Background())
 	if err != nil {
 		return false, err
 	}
-	output, err := cmd.Output()
-	if err != nil {
-		return true, err
-	}
-	if len(output) > 0 {
-		return true, nil
-	}
-	return false, nil
+	return changeCount != 0, nil
 }
 
 func (g *gitExecuter) MergeFastForward(ref string) error {


### PR DESCRIPTION
This PR does 3 things:

1. Separates out some code from `git/client.go` into separate files `git/command.go` and `git/errors.go`. This was done to reduce clutter of `git/client.go`.
2. Adds tests for the remaining methods of `git.Client`. Previously these were untested, or only covered by the commands that utilized them.
3. Replaces uses of `git.Client.Command()` with methods on `git.Client` that have the same functionality. Using predefined methods should be the preferred way to utilize the `git.Client` instead of writing manual command invocations.

Most of the line changes in the PR are for the new tests. Overall, this PR should not have any functional changes to it.