### PR TITLE
Fix `gh gpg-key add`  command when key is not armored

### DIFF
--- a/pkg/cmd/gpg-key/add/add.go
+++ b/pkg/cmd/gpg-key/add/add.go
@@ -78,7 +78,7 @@ func runAdd(opts *AddOptions) error {
 
 	hostname, _ := cfg.DefaultHost()
 
-	err = gpgKeyUpload(httpClient, hostname, keyReader)
+	err = gpgKeyUpload(httpClient, hostname, keyReader, opts.IO)
 	if err != nil {
 		if errors.Is(err, scopesError) {
 			cs := opts.IO.ColorScheme()
@@ -91,7 +91,7 @@ func runAdd(opts *AddOptions) error {
 
 	if opts.IO.IsStdoutTTY() {
 		cs := opts.IO.ColorScheme()
-		fmt.Fprintf(opts.IO.ErrOut, "%s GPG key added to your account\n", cs.SuccessIcon())
+		fmt.Fprintf(opts.IO.Out, "%s GPG key added to your account\n", cs.SuccessIcon())
 	}
 	return nil
 }

--- a/pkg/cmd/gpg-key/add/add.go
+++ b/pkg/cmd/gpg-key/add/add.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -78,12 +79,24 @@ func runAdd(opts *AddOptions) error {
 
 	hostname, _ := cfg.DefaultHost()
 
-	err = gpgKeyUpload(httpClient, hostname, keyReader, opts.IO)
+	err = gpgKeyUpload(httpClient, hostname, keyReader)
 	if err != nil {
-		if errors.Is(err, scopesError) {
-			cs := opts.IO.ColorScheme()
+		cs := opts.IO.ColorScheme()
+		if errors.Is(err, errScopesMissing) {
 			fmt.Fprint(opts.IO.ErrOut, "Error: insufficient OAuth scopes to list GPG keys\n")
 			fmt.Fprintf(opts.IO.ErrOut, "Run the following to grant scopes: %s\n", cs.Bold("gh auth refresh -s write:gpg_key"))
+			return cmdutil.SilentError
+		}
+		if errors.Is(err, errDuplicateKey) {
+			fmt.Fprintf(opts.IO.ErrOut, "%s Error: the key already exists in your account\n", cs.FailureIcon())
+			return cmdutil.SilentError
+		}
+		if errors.Is(err, errWrongFormat) {
+			fmt.Fprint(opts.IO.ErrOut, heredoc.Docf(`
+				%s Error: the GPG key you are trying to upload might not be in ASCII-armored format.
+				Find your GPG key ID with:    %s
+				Then add it to your account:  %s
+			`, cs.FailureIcon(), cs.Bold("gpg --list-keys"), cs.Bold("gpg --armor --export <ID> | gh gpg-key add -")))
 			return cmdutil.SilentError
 		}
 		return err

--- a/pkg/cmd/gpg-key/add/add_test.go
+++ b/pkg/cmd/gpg-key/add/add_test.go
@@ -11,32 +11,96 @@ import (
 )
 
 func Test_runAdd(t *testing.T) {
-	ios, stdin, stdout, stderr := iostreams.Test()
-	ios.SetStdinTTY(false)
-	ios.SetStdoutTTY(true)
-	ios.SetStderrTTY(true)
+	tests := []struct {
+		name       string
+		stdin      string
+		httpStubs  func(*httpmock.Registry)
+		wantsErr   bool
+		wantErrMsg string
+		wantsOpts  AddOptions
+	}{
+		{"armored_valid", "-----BEGIN PGP PUBLIC KEY BLOCK-----", func(reg *httpmock.Registry) {
+			reg.Register(
+				httpmock.REST("POST", "user/gpg_keys"),
+				httpmock.WithHeader(
+					httpmock.StatusStringResponse(200, `{}`),
+					"Content-Type",
+					"application/json",
+				),
+			)
+		}, false, "", AddOptions{}},
+		{"not_armored", "gCAAAAA7H7MHTZWFLJKD3vP4F7v", func(reg *httpmock.Registry) {
+			reg.Register(
+				httpmock.REST("POST", "user/gpg_keys"),
+				httpmock.WithHeader(
+					httpmock.StatusStringResponse(422, `{
+                                                "message": "Validation Failed",
+                                                "errors": [{
+                                                        "resource": "GpgKey",
+                                                        "code": "custom",
+                                                        "message": "We got an error doing that."
+                                                }],
+                                                "documentation_url": "https://docs.github.com/v3/users/gpg_keys"
+                                        }`),
+					"Content-Type",
+					"application/json",
+				),
+			)
+		}, true, "it seems that the GPG key is not armored.\nplease try to find your GPG key ID using:\n\tgpg --list-keys\n" +
+			"and use command below to add it to your accont:\n\tgpg --armor --export <GPG key ID> | gh gpg-key add -", AddOptions{}},
+		{"duplicate", "-----BEGIN PGP PUBLIC KEY BLOCK-----", func(reg *httpmock.Registry) {
+			reg.Register(
+				httpmock.REST("POST", "user/gpg_keys"),
+				httpmock.WithHeader(
+					httpmock.StatusStringResponse(422, `{
+                                                "message": "Validation Failed",
+                                                "errors": [{
+                                                        "resource": "GpgKey",
+                                                        "code": "custom",
+                                                        "field": "key_id",
+                                                        "message": "key_id already exists"
+                                                }, {
+                                                        "resource": "GpgKey",
+                                                        "code": "custom",
+                                                        "field": "public_key",
+                                                        "message": "public_key already exists"
+                                                }],
+                                                "documentation_url": "https://docs.github.com/v3/users/gpg_keys"
+                                        }`),
+					"Content-Type",
+					"application/json",
+				),
+			)
+		}, false, "", AddOptions{}},
+	}
 
-	stdin.WriteString("PUBKEY")
+	for _, tt := range tests {
+		ios, stdin, _, _ := iostreams.Test()
+		reg := &httpmock.Registry{}
+		defer reg.Verify(t)
 
-	tr := httpmock.Registry{}
-	defer tr.Verify(t)
-
-	tr.Register(
-		httpmock.REST("POST", "user/gpg_keys"),
-		httpmock.StringResponse(`{}`))
-
-	err := runAdd(&AddOptions{
-		IO: ios,
-		Config: func() (config.Config, error) {
+		tt.wantsOpts.IO = ios
+		tt.wantsOpts.HTTPClient = func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		}
+		if tt.httpStubs != nil {
+			tt.httpStubs(reg)
+		}
+		tt.wantsOpts.Config = func() (config.Config, error) {
 			return config.NewBlankConfig(), nil
-		},
-		HTTPClient: func() (*http.Client, error) {
-			return &http.Client{Transport: &tr}, nil
-		},
-		KeyFile: "-",
-	})
-	assert.NoError(t, err)
+		}
+		tt.wantsOpts.KeyFile = "-"
 
-	assert.Equal(t, "", stdout.String())
-	assert.Equal(t, "✓ GPG key added to your account\n", stderr.String())
+		stdin.WriteString(tt.stdin)
+		t.Run(tt.name, func(t *testing.T) {
+			err := runAdd(&tt.wantsOpts)
+			if tt.wantsErr {
+				if assert.Error(t, err) {
+					assert.Equal(t, tt.wantErrMsg, err.Error())
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/pkg/cmd/gpg-key/add/add_test.go
+++ b/pkg/cmd/gpg-key/add/add_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -18,64 +19,75 @@ func Test_runAdd(t *testing.T) {
 		wantStdout string
 		wantStderr string
 		wantErrMsg string
-		wantsOpts  AddOptions
+		opts       AddOptions
 	}{
-		{"armored_valid", "-----BEGIN PGP PUBLIC KEY BLOCK-----", func(reg *httpmock.Registry) {
-			reg.Register(
-				httpmock.REST("POST", "user/gpg_keys"),
-				httpmock.WithHeader(
-					httpmock.StatusStringResponse(200, `{}`),
-					"Content-Type",
-					"application/json",
-				),
-			)
-		}, "✓ GPG key added to your account\n", "", "", AddOptions{}},
-		{"not_armored", "gCAAAAA7H7MHTZWFLJKD3vP4F7v", func(reg *httpmock.Registry) {
-			reg.Register(
-				httpmock.REST("POST", "user/gpg_keys"),
-				httpmock.WithHeader(
+		{
+			name:  "valid key",
+			stdin: "-----BEGIN PGP PUBLIC KEY BLOCK-----",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("POST", "user/gpg_keys"),
+					httpmock.StatusStringResponse(200, ``))
+			},
+			wantStdout: "✓ GPG key added to your account\n",
+			wantStderr: "",
+			wantErrMsg: "",
+			opts:       AddOptions{KeyFile: "-"},
+		},
+		{
+			name:  "binary format fails",
+			stdin: "gCAAAAA7H7MHTZWFLJKD3vP4F7v",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("POST", "user/gpg_keys"),
 					httpmock.StatusStringResponse(422, `{
-                                                "message": "Validation Failed",
-                                                "errors": [{
-                                                        "resource": "GpgKey",
-                                                        "code": "custom",
-                                                        "message": "We got an error doing that."
-                                                }],
-                                                "documentation_url": "https://docs.github.com/v3/users/gpg_keys"
-                                        }`),
-					"Content-Type",
-					"application/json",
-				),
-			)
-		}, "", "X it seems that the GPG key is not armored.\n" +
-			"please try to find your GPG key ID using:\n" +
-			"\tgpg --list-keys\n" +
-			"and use command below to add it to your accont:\n" +
-			"\tgpg --armor --export <GPG key ID> | gh gpg-key add -\n", "SilentError", AddOptions{}},
-		{"duplicate", "-----BEGIN PGP PUBLIC KEY BLOCK-----", func(reg *httpmock.Registry) {
-			reg.Register(
-				httpmock.REST("POST", "user/gpg_keys"),
-				httpmock.WithHeader(
-					httpmock.StatusStringResponse(422, `{
-                                                "message": "Validation Failed",
-                                                "errors": [{
-                                                        "resource": "GpgKey",
-                                                        "code": "custom",
-                                                        "field": "key_id",
-                                                        "message": "key_id already exists"
-                                                }, {
-                                                        "resource": "GpgKey",
-                                                        "code": "custom",
-                                                        "field": "public_key",
-                                                        "message": "public_key already exists"
-                                                }],
-                                                "documentation_url": "https://docs.github.com/v3/users/gpg_keys"
-                                        }`),
-					"Content-Type",
-					"application/json",
-				),
-			)
-		}, "", "X Key already exists in your account\n", "SilentError", AddOptions{}},
+						"message": "Validation Failed",
+						"errors": [{
+							"resource": "GpgKey",
+							"code": "custom",
+							"message": "We got an error doing that."
+						}],
+						"documentation_url": "https://docs.github.com/v3/users/gpg_keys"
+					}`),
+				)
+			},
+			wantStdout: "",
+			wantStderr: heredoc.Doc(`
+				X Error: the GPG key you are trying to upload might not be in ASCII-armored format.
+				Find your GPG key ID with:    gpg --list-keys
+				Then add it to your account:  gpg --armor --export <ID> | gh gpg-key add -
+			`),
+			wantErrMsg: "SilentError",
+			opts:       AddOptions{KeyFile: "-"},
+		},
+		{
+			name:  "duplicate key",
+			stdin: "-----BEGIN PGP PUBLIC KEY BLOCK-----",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("POST", "user/gpg_keys"),
+					httpmock.WithHeader(httpmock.StatusStringResponse(422, `{
+						"message": "Validation Failed",
+						"errors": [{
+							"resource": "GpgKey",
+							"code": "custom",
+							"field": "key_id",
+							"message": "key_id already exists"
+						}, {
+							"resource": "GpgKey",
+							"code": "custom",
+							"field": "public_key",
+							"message": "public_key already exists"
+						}],
+						"documentation_url": "https://docs.github.com/v3/users/gpg_keys"
+					}`), "Content-type", "application/json"),
+				)
+			},
+			wantStdout: "",
+			wantStderr: "X Error: the key already exists in your account\n",
+			wantErrMsg: "SilentError",
+			opts:       AddOptions{KeyFile: "-"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -83,24 +95,24 @@ func Test_runAdd(t *testing.T) {
 		ios.SetStdinTTY(true)
 		ios.SetStdoutTTY(true)
 		ios.SetStderrTTY(true)
-		reg := &httpmock.Registry{}
-		defer reg.Verify(t)
+		stdin.WriteString(tt.stdin)
 
-		tt.wantsOpts.IO = ios
-		tt.wantsOpts.HTTPClient = func() (*http.Client, error) {
+		reg := &httpmock.Registry{}
+
+		tt.opts.IO = ios
+		tt.opts.HTTPClient = func() (*http.Client, error) {
 			return &http.Client{Transport: reg}, nil
 		}
 		if tt.httpStubs != nil {
 			tt.httpStubs(reg)
 		}
-		tt.wantsOpts.Config = func() (config.Config, error) {
+		tt.opts.Config = func() (config.Config, error) {
 			return config.NewBlankConfig(), nil
 		}
-		tt.wantsOpts.KeyFile = "-"
 
-		stdin.WriteString(tt.stdin)
 		t.Run(tt.name, func(t *testing.T) {
-			err := runAdd(&tt.wantsOpts)
+			defer reg.Verify(t)
+			err := runAdd(&tt.opts)
 			if tt.wantErrMsg != "" {
 				assert.Equal(t, tt.wantErrMsg, err.Error())
 			} else {

--- a/pkg/cmd/gpg-key/add/http.go
+++ b/pkg/cmd/gpg-key/add/http.go
@@ -61,6 +61,6 @@ func gpgKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader) e
 }
 
 func isDuplicateError(err *api.HTTPError) bool {
-	return err.StatusCode == 422 && len(err.Errors) == 1 &&
-		err.Errors[0].Field == "key" && err.Errors[0].Message == "key is already in use"
+	return err.StatusCode == 422 && len(err.Errors) == 2 &&
+		err.Errors[0].Field == "key_id" && err.Errors[0].Message == "key_id already exists"
 }

--- a/pkg/cmd/gpg-key/add/http.go
+++ b/pkg/cmd/gpg-key/add/http.go
@@ -49,6 +49,15 @@ func gpgKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader) e
 		if errors.As(err, &httpError) && isDuplicateError(&httpError) {
 			return nil
 		}
+		if errors.As(err, &httpError) && isKeyInvalidError(&httpError) {
+			if !isGpgKeyArmored(keyBytes) {
+				return errors.New("it seems that the GPG key is not armored.\n" +
+					"please try to find your GPG key ID using:\n" +
+					"\tgpg --list-keys\n" +
+					"and use command below to add it to your accont:\n" +
+					"\tgpg --armor --export <GPG key ID> | gh gpg-key add -")
+			}
+		}
 		return err
 	}
 
@@ -63,4 +72,15 @@ func gpgKeyUpload(httpClient *http.Client, hostname string, keyFile io.Reader) e
 func isDuplicateError(err *api.HTTPError) bool {
 	return err.StatusCode == 422 && len(err.Errors) == 2 &&
 		err.Errors[0].Field == "key_id" && err.Errors[0].Message == "key_id already exists"
+}
+
+func isKeyInvalidError(err *api.HTTPError) bool {
+	return err.StatusCode == 422 && len(err.Errors) == 1 &&
+		err.Errors[0].Field == "" && err.Errors[0].Message == "We got an error doing that."
+}
+
+func isGpgKeyArmored(keyBytes []byte) bool {
+	buf := make([]byte, 36)
+	copy(buf, keyBytes)
+	return bytes.Equal(buf, []byte("-----BEGIN PGP PUBLIC KEY BLOCK-----"))
 }


### PR DESCRIPTION
Fixes: #6466

The go community has marked `x/crypto/openpgp` as frozen&deprecated,  I guess it's not a good idea to import that package or implement a armor algorithm, which will be a maintenance burden. So a better error message is perfered.

When the gpg key is invalid(not armored or armored but correct ), Github will give a response like:

```json
{
	"message": "Validation Failed",
	"errors": [{
		"resource": "GpgKey",
		"code": "custom",
		"message": "We got an error doing that."
	}],
	"documentation_url": "https://docs.github.com/v3/users/gpg_keys"
}
```

I added a function `isKeyInvalidError()`  handle this error response.

Besides, I added a function `isGpgKeyArmored()` to judge if a gpg key is armored before uploading . Technically it's just checking if file is started with`-----BEGIN PGP PUBLIC KEY BLOCK-----`,  but this is enough to make sure the input file is an armored gpg key. After all, this function is to tell if a key is armored, not to tell if it's validated.

I found the `isDuplicateError()` is out-dated with the latest API response, so I fixed it btw.
