### PR TITLE
Support explicitly marking a Release as "Latest"

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -38,6 +38,7 @@ type CreateOptions struct {
 	BodyProvided bool
 	Draft        bool
 	Prerelease   bool
+	IsLatest     *bool
 
 	Assets []*shared.AssetForUpload
 
@@ -164,6 +165,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmd.Flags().StringVarP(&opts.DiscussionCategory, "discussion-category", "", "", "Start a discussion in the specified category")
 	cmd.Flags().BoolVarP(&opts.GenerateNotes, "generate-notes", "", false, "Automatically generate title and notes for the release")
 	cmd.Flags().StringVar(&opts.NotesStartTag, "notes-start-tag", "", "Tag to use as the starting point for generating release notes")
+	cmdutil.NilBoolFlag(cmd, &opts.IsLatest, "latest", "", "Mark this release as \"Latest\" (default: automatic based on date and version)")
 
 	return cmd
 }
@@ -408,6 +410,10 @@ func createRun(opts *CreateOptions) error {
 	}
 	if opts.Target != "" {
 		params["target_commitish"] = opts.Target
+	}
+	if opts.IsLatest != nil {
+		// valid values: true/false/legacy
+		params["make_latest"] = fmt.Sprintf("%v", *opts.IsLatest)
 	}
 	if opts.DiscussionCategory != "" {
 		params["discussion_category_name"] = opts.DiscussionCategory

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -260,6 +260,46 @@ func Test_NewCmdCreate(t *testing.T) {
 				NotesStartTag: "v1.1.0",
 			},
 		},
+		{
+			name:  "latest",
+			args:  "--latest v1.1.0",
+			isTTY: false,
+			want: CreateOptions{
+				TagName:       "v1.1.0",
+				Target:        "",
+				Name:          "",
+				Body:          "",
+				BodyProvided:  false,
+				Draft:         false,
+				Prerelease:    false,
+				IsLatest:      boolPtr(true),
+				RepoOverride:  "",
+				Concurrency:   5,
+				Assets:        []*shared.AssetForUpload(nil),
+				GenerateNotes: false,
+				NotesStartTag: "",
+			},
+		},
+		{
+			name:  "not latest",
+			args:  "--latest=false v1.1.0",
+			isTTY: false,
+			want: CreateOptions{
+				TagName:       "v1.1.0",
+				Target:        "",
+				Name:          "",
+				Body:          "",
+				BodyProvided:  false,
+				Draft:         false,
+				Prerelease:    false,
+				IsLatest:      boolPtr(false),
+				RepoOverride:  "",
+				Concurrency:   5,
+				Assets:        []*shared.AssetForUpload(nil),
+				GenerateNotes: false,
+				NotesStartTag: "",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -312,6 +352,7 @@ func Test_NewCmdCreate(t *testing.T) {
 			assert.Equal(t, tt.want.DiscussionCategory, opts.DiscussionCategory)
 			assert.Equal(t, tt.want.GenerateNotes, opts.GenerateNotes)
 			assert.Equal(t, tt.want.NotesStartTag, opts.NotesStartTag)
+			assert.Equal(t, tt.want.IsLatest, opts.IsLatest)
 
 			require.Equal(t, len(tt.want.Assets), len(opts.Assets))
 			for i := range tt.want.Assets {
@@ -443,6 +484,35 @@ func Test_createRun(t *testing.T) {
 			},
 			wantStdout: "https://github.com/OWNER/REPO/releases/tag/v1.2.3\n",
 			wantStderr: ``,
+		},
+		{
+			name:  "with latest",
+			isTTY: false,
+			opts: CreateOptions{
+				TagName:       "v1.2.3",
+				Name:          "",
+				Body:          "",
+				Target:        "",
+				IsLatest:      boolPtr(true),
+				BodyProvided:  true,
+				GenerateNotes: false,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("POST", "repos/OWNER/REPO/releases"), httpmock.RESTPayload(201, `{
+					"url": "https://api.github.com/releases/123",
+					"upload_url": "https://api.github.com/assets/upload",
+					"html_url": "https://github.com/OWNER/REPO/releases/tag/v1.2.3"
+				}`, func(params map[string]interface{}) {
+					assert.Equal(t, map[string]interface{}{
+						"tag_name":    "v1.2.3",
+						"draft":       false,
+						"prerelease":  false,
+						"make_latest": "true",
+					}, params)
+				}))
+			},
+			wantStdout: "https://github.com/OWNER/REPO/releases/tag/v1.2.3\n",
+			wantErr:    "",
 		},
 		{
 			name:  "with generate notes",
@@ -1100,4 +1170,8 @@ func Test_createRun_interactive(t *testing.T) {
 			assert.Equal(t, "", stderr.String())
 		})
 	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/pkg/cmd/release/edit/edit.go
+++ b/pkg/cmd/release/edit/edit.go
@@ -24,6 +24,7 @@ type EditOptions struct {
 	DiscussionCategory *string
 	Draft              *bool
 	Prerelease         *bool
+	IsLatest           *bool
 }
 
 func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Command {
@@ -72,6 +73,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 
 	cmdutil.NilBoolFlag(cmd, &opts.Draft, "draft", "", "Save the release as a draft instead of publishing it")
 	cmdutil.NilBoolFlag(cmd, &opts.Prerelease, "prerelease", "", "Mark the release as a prerelease")
+	cmdutil.NilBoolFlag(cmd, &opts.IsLatest, "latest", "", "Explicitly mark the release as \"Latest\"")
 	cmdutil.NilStringFlag(cmd, &opts.Body, "notes", "n", "Release notes")
 	cmdutil.NilStringFlag(cmd, &opts.Name, "title", "t", "Release title")
 	cmdutil.NilStringFlag(cmd, &opts.DiscussionCategory, "discussion-category", "", "Start a discussion in the specified category when publishing a draft")
@@ -144,6 +146,11 @@ func getParams(opts *EditOptions) map[string]interface{} {
 
 	if opts.Target != "" {
 		params["target_commitish"] = opts.Target
+	}
+
+	if opts.IsLatest != nil {
+		// valid values: true/false/legacy
+		params["make_latest"] = fmt.Sprintf("%v", *opts.IsLatest)
 	}
 
 	return params

--- a/pkg/cmd/release/edit/edit_test.go
+++ b/pkg/cmd/release/edit/edit_test.go
@@ -103,6 +103,24 @@ func Test_NewCmdEdit(t *testing.T) {
 			},
 		},
 		{
+			name:  "latest",
+			args:  "v1.2.3 --latest",
+			isTTY: false,
+			want: EditOptions{
+				TagName:  "",
+				IsLatest: boolPtr(true),
+			},
+		},
+		{
+			name:  "not latest",
+			args:  "v1.2.3 --latest=false",
+			isTTY: false,
+			want: EditOptions{
+				TagName:  "",
+				IsLatest: boolPtr(false),
+			},
+		},
+		{
 			name:  "provide notes from file",
 			args:  fmt.Sprintf(`v1.2.3 -F '%s'`, tf.Name()),
 			isTTY: false,
@@ -169,6 +187,7 @@ func Test_NewCmdEdit(t *testing.T) {
 			assert.Equal(t, tt.want.DiscussionCategory, opts.DiscussionCategory)
 			assert.Equal(t, tt.want.Draft, opts.Draft)
 			assert.Equal(t, tt.want.Prerelease, opts.Prerelease)
+			assert.Equal(t, tt.want.IsLatest, opts.IsLatest)
 		})
 	}
 }
@@ -244,6 +263,23 @@ func Test_editRun(t *testing.T) {
 					assert.Equal(t, map[string]interface{}{
 						"tag_name":                 "v1.2.3",
 						"discussion_category_name": "some-category",
+					}, params)
+				})
+			},
+			wantStdout: "https://github.com/OWNER/REPO/releases/tag/v1.2.3\n",
+			wantStderr: "",
+		},
+		{
+			name:  "edit the latest marker",
+			isTTY: false,
+			opts: EditOptions{
+				IsLatest: boolPtr(true),
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				mockSuccessfulEditResponse(reg, func(params map[string]interface{}) {
+					assert.Equal(t, map[string]interface{}{
+						"tag_name":    "v1.2.3",
+						"make_latest": "true",
 					}, params)
 				})
 			},


### PR DESCRIPTION
https://github.blog/changelog/2022-10-21-explicitly-set-the-latest-release/

Fixes https://github.com/cli/cli/issues/2678