### PR TITLE
Authenticate network git commands

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -391,8 +391,7 @@ func (c *Client) revParse(ctx context.Context, args ...string) ([]byte, error) {
 
 func (c *Client) Fetch(ctx context.Context, remote string, refspec string, mods ...CommandModifier) error {
 	args := []string{"fetch", remote, refspec}
-	// TODO: Use AuthenticatedCommand
-	cmd, err := c.Command(ctx, args...)
+	cmd, err := c.AuthenticatedCommand(ctx, args...)
 	if err != nil {
 		return err
 	}
@@ -407,8 +406,7 @@ func (c *Client) Pull(ctx context.Context, remote, branch string, mods ...Comman
 	if remote != "" && branch != "" {
 		args = append(args, remote, branch)
 	}
-	// TODO: Use AuthenticatedCommand
-	cmd, err := c.Command(ctx, args...)
+	cmd, err := c.AuthenticatedCommand(ctx, args...)
 	if err != nil {
 		return err
 	}
@@ -420,8 +418,7 @@ func (c *Client) Pull(ctx context.Context, remote, branch string, mods ...Comman
 
 func (c *Client) Push(ctx context.Context, remote string, ref string, mods ...CommandModifier) error {
 	args := []string{"push", "--set-upstream", remote, ref}
-	// TODO: Use AuthenticatedCommand
-	cmd, err := c.Command(ctx, args...)
+	cmd, err := c.AuthenticatedCommand(ctx, args...)
 	if err != nil {
 		return err
 	}
@@ -442,8 +439,7 @@ func (c *Client) Clone(ctx context.Context, cloneURL string, args []string, mods
 		target = path.Base(strings.TrimSuffix(cloneURL, ".git"))
 	}
 	cloneArgs = append([]string{"clone"}, cloneArgs...)
-	// TODO: Use AuthenticatedCommand
-	cmd, err := c.Command(ctx, cloneArgs...)
+	cmd, err := c.AuthenticatedCommand(ctx, cloneArgs...)
 	if err != nil {
 		return "", err
 	}
@@ -463,8 +459,7 @@ func (c *Client) AddRemote(ctx context.Context, name, urlStr string, trackingBra
 		args = append(args, "-t", branch)
 	}
 	args = append(args, "-f", name, urlStr)
-	// TODO: Use AuthenticatedCommand
-	cmd, err := c.Command(ctx, args...)
+	cmd, err := c.AuthenticatedCommand(ctx, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -67,11 +67,11 @@ func TestClientAuthenticatedCommand(t *testing.T) {
 		{
 			name:     "adds credential helper config options",
 			path:     "path/to/gh",
-			wantArgs: []string{"path/to/git", "-c", "credential.helper=", "-c", "credential.helper=!\"path/to/gh\" auth git-credential", "fetch"},
+			wantArgs: []string{"path/to/git", "-c", "credential.helper=", "-c", `credential.helper=!"path/to/gh" auth git-credential`, "fetch"},
 		},
 		{
 			name:     "fallback when GhPath is not set",
-			wantArgs: []string{"path/to/git", "-c", "credential.helper=", "-c", "credential.helper=!\"gh\" auth git-credential", "fetch"},
+			wantArgs: []string{"path/to/git", "-c", "credential.helper=", "-c", `credential.helper=!"gh" auth git-credential`, "fetch"},
 		},
 	}
 	for _, tt := range tests {
@@ -846,18 +846,18 @@ func TestClientFetch(t *testing.T) {
 	}{
 		{
 			name:        "fetch",
-			wantCmdArgs: `path/to/git fetch origin trunk`,
+			wantCmdArgs: `path/to/git -c credential.helper= -c credential.helper=!"gh" auth git-credential fetch origin trunk`,
 		},
 		{
 			name:        "accepts command modifiers",
 			mods:        []CommandModifier{WithRepoDir("/path/to/repo")},
-			wantCmdArgs: `path/to/git -C /path/to/repo fetch origin trunk`,
+			wantCmdArgs: `path/to/git -C /path/to/repo -c credential.helper= -c credential.helper=!"gh" auth git-credential fetch origin trunk`,
 		},
 		{
 			name:          "git error",
 			cmdExitStatus: 1,
 			cmdStderr:     "git error message",
-			wantCmdArgs:   `path/to/git fetch origin trunk`,
+			wantCmdArgs:   `path/to/git -c credential.helper= -c credential.helper=!"gh" auth git-credential fetch origin trunk`,
 			wantErrorMsg:  "failed to run git: git error message",
 		},
 	}
@@ -891,18 +891,18 @@ func TestClientPull(t *testing.T) {
 	}{
 		{
 			name:        "pull",
-			wantCmdArgs: `path/to/git pull --ff-only origin trunk`,
+			wantCmdArgs: `path/to/git -c credential.helper= -c credential.helper=!"gh" auth git-credential pull --ff-only origin trunk`,
 		},
 		{
 			name:        "accepts command modifiers",
 			mods:        []CommandModifier{WithRepoDir("/path/to/repo")},
-			wantCmdArgs: `path/to/git -C /path/to/repo pull --ff-only origin trunk`,
+			wantCmdArgs: `path/to/git -C /path/to/repo -c credential.helper= -c credential.helper=!"gh" auth git-credential pull --ff-only origin trunk`,
 		},
 		{
 			name:          "git error",
 			cmdExitStatus: 1,
 			cmdStderr:     "git error message",
-			wantCmdArgs:   `path/to/git pull --ff-only origin trunk`,
+			wantCmdArgs:   `path/to/git -c credential.helper= -c credential.helper=!"gh" auth git-credential pull --ff-only origin trunk`,
 			wantErrorMsg:  "failed to run git: git error message",
 		},
 	}
@@ -936,18 +936,18 @@ func TestClientPush(t *testing.T) {
 	}{
 		{
 			name:        "push",
-			wantCmdArgs: `path/to/git push --set-upstream origin trunk`,
+			wantCmdArgs: `path/to/git -c credential.helper= -c credential.helper=!"gh" auth git-credential push --set-upstream origin trunk`,
 		},
 		{
 			name:        "accepts command modifiers",
 			mods:        []CommandModifier{WithRepoDir("/path/to/repo")},
-			wantCmdArgs: `path/to/git -C /path/to/repo push --set-upstream origin trunk`,
+			wantCmdArgs: `path/to/git -C /path/to/repo -c credential.helper= -c credential.helper=!"gh" auth git-credential push --set-upstream origin trunk`,
 		},
 		{
 			name:          "git error",
 			cmdExitStatus: 1,
 			cmdStderr:     "git error message",
-			wantCmdArgs:   `path/to/git push --set-upstream origin trunk`,
+			wantCmdArgs:   `path/to/git -c credential.helper= -c credential.helper=!"gh" auth git-credential push --set-upstream origin trunk`,
 			wantErrorMsg:  "failed to run git: git error message",
 		},
 	}
@@ -982,20 +982,20 @@ func TestClientClone(t *testing.T) {
 	}{
 		{
 			name:        "clone",
-			wantCmdArgs: `path/to/git clone github.com/cli/cli`,
+			wantCmdArgs: `path/to/git -c credential.helper= -c credential.helper=!"gh" auth git-credential clone github.com/cli/cli`,
 			wantTarget:  "cli",
 		},
 		{
 			name:        "accepts command modifiers",
 			mods:        []CommandModifier{WithRepoDir("/path/to/repo")},
-			wantCmdArgs: `path/to/git -C /path/to/repo clone github.com/cli/cli`,
+			wantCmdArgs: `path/to/git -C /path/to/repo -c credential.helper= -c credential.helper=!"gh" auth git-credential clone github.com/cli/cli`,
 			wantTarget:  "cli",
 		},
 		{
 			name:          "git error",
 			cmdExitStatus: 1,
 			cmdStderr:     "git error message",
-			wantCmdArgs:   `path/to/git clone github.com/cli/cli`,
+			wantCmdArgs:   `path/to/git -c credential.helper= -c credential.helper=!"gh" auth git-credential clone github.com/cli/cli`,
 			wantErrorMsg:  "failed to run git: git error message",
 		},
 	}
@@ -1089,7 +1089,7 @@ func TestClientAddRemote(t *testing.T) {
 			url:         "URL",
 			dir:         "DIRECTORY",
 			branches:    []string{},
-			wantCmdArgs: `path/to/git -C DIRECTORY remote add -f test URL`,
+			wantCmdArgs: `path/to/git -C DIRECTORY -c credential.helper= -c credential.helper=!"gh" auth git-credential remote add -f test URL`,
 		},
 		{
 			title:       "fetch specific branches only",
@@ -1097,7 +1097,7 @@ func TestClientAddRemote(t *testing.T) {
 			url:         "URL",
 			dir:         "DIRECTORY",
 			branches:    []string{"trunk", "dev"},
-			wantCmdArgs: `path/to/git -C DIRECTORY remote add -t trunk -t dev -f test URL`,
+			wantCmdArgs: `path/to/git -C DIRECTORY -c credential.helper= -c credential.helper=!"gh" auth git-credential remote add -t trunk -t dev -f test URL`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/run/stub.go
+++ b/internal/run/stub.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+const (
+	gitAuthRE = `-c credential.helper= -c credential.helper=!"[a-zA-Z/]*" auth git-credential `
+)
+
 type T interface {
 	Helper()
 	Errorf(string, ...interface{})
@@ -71,6 +75,9 @@ func (cs *CommandStubber) Register(pattern string, exitStatus int, output string
 	if len(pattern) < 1 {
 		panic("cannot use empty regexp pattern")
 	}
+	if strings.HasPrefix(pattern, "git") {
+		pattern = addGitAuthentication(pattern)
+	}
 	cs.stubs = append(cs.stubs, &commandStub{
 		pattern:    regexp.MustCompile(pattern),
 		exitStatus: exitStatus,
@@ -113,4 +120,14 @@ func (s *commandStub) Output() ([]byte, error) {
 		return []byte(nil), fmt.Errorf("%s exited with status %d", s.pattern, s.exitStatus)
 	}
 	return []byte(s.stdout), nil
+}
+
+// Inject git authentication string for specific git commands.
+func addGitAuthentication(s string) string {
+	pattern := regexp.MustCompile(`( fetch | pull | push | clone | remote add | submodule )`)
+	loc := pattern.FindStringIndex(s)
+	if loc == nil {
+		return s
+	}
+	return s[:loc[0]+1] + gitAuthRE + s[loc[0]+1:]
 }

--- a/internal/run/stub.go
+++ b/internal/run/stub.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	gitAuthRE = `-c credential.helper= -c credential.helper=!"[a-zA-Z/]*" auth git-credential `
+	gitAuthRE = `-c credential.helper= -c credential.helper=!"[^"]+" auth git-credential `
 )
 
 type T interface {
@@ -124,7 +124,7 @@ func (s *commandStub) Output() ([]byte, error) {
 
 // Inject git authentication string for specific git commands.
 func addGitAuthentication(s string) string {
-	pattern := regexp.MustCompile(`( fetch | pull | push | clone | remote add | submodule )`)
+	pattern := regexp.MustCompile(`( fetch | pull | push | clone | remote add.+-f | submodule )`)
 	loc := pattern.FindStringIndex(s)
 	if loc == nil {
 		return s

--- a/pkg/cmd/gist/clone/clone_test.go
+++ b/pkg/cmd/gist/clone/clone_test.go
@@ -26,7 +26,10 @@ func runCloneCommand(httpClient *http.Client, cli string) (*test.CmdOut, error) 
 		Config: func() (config.Config, error) {
 			return config.NewBlankConfig(), nil
 		},
-		GitClient: &git.Client{GitPath: "some/path/git"},
+		GitClient: &git.Client{
+			GhPath:  "some/path/gh",
+			GitPath: "some/path/git",
+		},
 	}
 
 	cmd := NewCmdClone(fac, nil)
@@ -60,32 +63,32 @@ func Test_GistClone(t *testing.T) {
 		{
 			name: "shorthand",
 			args: "GIST",
-			want: "git clone https://gist.github.com/GIST.git",
+			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://gist.github.com/GIST.git`,
 		},
 		{
 			name: "shorthand with directory",
 			args: "GIST target_directory",
-			want: "git clone https://gist.github.com/GIST.git target_directory",
+			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://gist.github.com/GIST.git target_directory`,
 		},
 		{
 			name: "clone arguments",
 			args: "GIST -- -o upstream --depth 1",
-			want: "git clone -o upstream --depth 1 https://gist.github.com/GIST.git",
+			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone -o upstream --depth 1 https://gist.github.com/GIST.git`,
 		},
 		{
 			name: "clone arguments with directory",
 			args: "GIST target_directory -- -o upstream --depth 1",
-			want: "git clone -o upstream --depth 1 https://gist.github.com/GIST.git target_directory",
+			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone -o upstream --depth 1 https://gist.github.com/GIST.git target_directory`,
 		},
 		{
 			name: "HTTPS URL",
 			args: "https://gist.github.com/OWNER/GIST",
-			want: "git clone https://gist.github.com/OWNER/GIST",
+			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://gist.github.com/OWNER/GIST`,
 		},
 		{
 			name: "SSH URL",
 			args: "git@gist.github.com:GIST.git",
-			want: "git clone git@gist.github.com:GIST.git",
+			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone git@gist.github.com:GIST.git`,
 		},
 	}
 	for _, tt := range tests {
@@ -97,7 +100,7 @@ func Test_GistClone(t *testing.T) {
 
 			cs, restore := run.Stub()
 			defer restore(t)
-			cs.Register(`git clone`, 0, "", func(s []string) {
+			cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone`, 0, "", func(s []string) {
 				assert.Equal(t, tt.want, strings.Join(s, " "))
 			})
 

--- a/pkg/cmd/gist/clone/clone_test.go
+++ b/pkg/cmd/gist/clone/clone_test.go
@@ -2,7 +2,6 @@ package clone
 
 import (
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/git"
@@ -63,32 +62,32 @@ func Test_GistClone(t *testing.T) {
 		{
 			name: "shorthand",
 			args: "GIST",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://gist.github.com/GIST.git`,
+			want: `git clone https://gist.github.com/GIST.git`,
 		},
 		{
 			name: "shorthand with directory",
 			args: "GIST target_directory",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://gist.github.com/GIST.git target_directory`,
+			want: `git clone https://gist.github.com/GIST.git target_directory`,
 		},
 		{
 			name: "clone arguments",
 			args: "GIST -- -o upstream --depth 1",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone -o upstream --depth 1 https://gist.github.com/GIST.git`,
+			want: `git clone -o upstream --depth 1 https://gist.github.com/GIST.git`,
 		},
 		{
 			name: "clone arguments with directory",
 			args: "GIST target_directory -- -o upstream --depth 1",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone -o upstream --depth 1 https://gist.github.com/GIST.git target_directory`,
+			want: `git clone -o upstream --depth 1 https://gist.github.com/GIST.git target_directory`,
 		},
 		{
 			name: "HTTPS URL",
 			args: "https://gist.github.com/OWNER/GIST",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://gist.github.com/OWNER/GIST`,
+			want: `git clone https://gist.github.com/OWNER/GIST`,
 		},
 		{
 			name: "SSH URL",
 			args: "git@gist.github.com:GIST.git",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone git@gist.github.com:GIST.git`,
+			want: `git clone git@gist.github.com:GIST.git`,
 		},
 	}
 	for _, tt := range tests {
@@ -100,9 +99,7 @@ func Test_GistClone(t *testing.T) {
 
 			cs, restore := run.Stub()
 			defer restore(t)
-			cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone`, 0, "", func(s []string) {
-				assert.Equal(t, tt.want, strings.Join(s, " "))
-			})
+			cs.Register(tt.want, 0, "")
 
 			output, err := runCloneCommand(httpClient, tt.args)
 			if err != nil {

--- a/pkg/cmd/gist/clone/clone_test.go
+++ b/pkg/cmd/gist/clone/clone_test.go
@@ -62,32 +62,32 @@ func Test_GistClone(t *testing.T) {
 		{
 			name: "shorthand",
 			args: "GIST",
-			want: `git clone https://gist.github.com/GIST.git`,
+			want: "git clone https://gist.github.com/GIST.git",
 		},
 		{
 			name: "shorthand with directory",
 			args: "GIST target_directory",
-			want: `git clone https://gist.github.com/GIST.git target_directory`,
+			want: "git clone https://gist.github.com/GIST.git target_directory",
 		},
 		{
 			name: "clone arguments",
 			args: "GIST -- -o upstream --depth 1",
-			want: `git clone -o upstream --depth 1 https://gist.github.com/GIST.git`,
+			want: "git clone -o upstream --depth 1 https://gist.github.com/GIST.git",
 		},
 		{
 			name: "clone arguments with directory",
 			args: "GIST target_directory -- -o upstream --depth 1",
-			want: `git clone -o upstream --depth 1 https://gist.github.com/GIST.git target_directory`,
+			want: "git clone -o upstream --depth 1 https://gist.github.com/GIST.git target_directory",
 		},
 		{
 			name: "HTTPS URL",
 			args: "https://gist.github.com/OWNER/GIST",
-			want: `git clone https://gist.github.com/OWNER/GIST`,
+			want: "git clone https://gist.github.com/OWNER/GIST",
 		},
 		{
 			name: "SSH URL",
 			args: "git@gist.github.com:GIST.git",
-			want: `git clone git@gist.github.com:GIST.git`,
+			want: "git clone git@gist.github.com:GIST.git",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/issue/develop/develop_test.go
+++ b/pkg/cmd/issue/develop/develop_test.go
@@ -469,7 +469,7 @@ func Test_developRun(t *testing.T) {
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git rev-parse --verify refs/heads/my-branch`, 0, "")
 				cs.Register(`git checkout my-branch`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only origin my-branch`, 0, "")
+				cs.Register(`git pull --ff-only origin my-branch`, 0, "")
 			},
 			expectedOut: "github.com/OWNER/REPO/tree/my-branch\n",
 		},
@@ -517,9 +517,9 @@ func Test_developRun(t *testing.T) {
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git rev-parse --verify refs/heads/my-branch`, 1, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/my-branch:refs/remotes/origin/my-branch`, 0, "")
+				cs.Register(`git fetch origin \+refs/heads/my-branch:refs/remotes/origin/my-branch`, 0, "")
 				cs.Register(`git checkout -b my-branch --track origin/my-branch`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only origin my-branch`, 0, "")
+				cs.Register(`git pull --ff-only origin my-branch`, 0, "")
 			},
 			expectedOut: "github.com/OWNER/REPO/tree/my-branch\n",
 		},

--- a/pkg/cmd/issue/develop/develop_test.go
+++ b/pkg/cmd/issue/develop/develop_test.go
@@ -469,7 +469,7 @@ func Test_developRun(t *testing.T) {
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git rev-parse --verify refs/heads/my-branch`, 0, "")
 				cs.Register(`git checkout my-branch`, 0, "")
-				cs.Register(`git pull --ff-only origin my-branch`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only origin my-branch`, 0, "")
 			},
 			expectedOut: "github.com/OWNER/REPO/tree/my-branch\n",
 		},
@@ -517,9 +517,9 @@ func Test_developRun(t *testing.T) {
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git rev-parse --verify refs/heads/my-branch`, 1, "")
-				cs.Register(`git fetch origin \+refs/heads/my-branch:refs/remotes/origin/my-branch`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/my-branch:refs/remotes/origin/my-branch`, 0, "")
 				cs.Register(`git checkout -b my-branch --track origin/my-branch`, 0, "")
-				cs.Register(`git pull --ff-only origin my-branch`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only origin my-branch`, 0, "")
 			},
 			expectedOut: "github.com/OWNER/REPO/tree/my-branch\n",
 		},
@@ -569,7 +569,10 @@ func Test_developRun(t *testing.T) {
 				return remotes, nil
 			}
 
-			opts.GitClient = &git.Client{GitPath: "some/path/git"}
+			opts.GitClient = &git.Client{
+				GhPath:  "some/path/gh",
+				GitPath: "some/path/git",
+			}
 
 			cmdStubs, cmdTeardown := run.Stub()
 			defer cmdTeardown(t)

--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -242,8 +242,7 @@ func localBranchExists(client *git.Client, b string) bool {
 
 func executeCmds(client *git.Client, cmdQueue [][]string) error {
 	for _, args := range cmdQueue {
-		// TODO: Use AuthenticatedCommand
-		cmd, err := client.Command(context.Background(), args...)
+		cmd, err := client.AuthenticatedCommand(context.Background(), args...)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -242,7 +242,13 @@ func localBranchExists(client *git.Client, b string) bool {
 
 func executeCmds(client *git.Client, cmdQueue [][]string) error {
 	for _, args := range cmdQueue {
-		cmd, err := client.AuthenticatedCommand(context.Background(), args...)
+		var err error
+		var cmd *git.Command
+		if args[0] == "fetch" || args[0] == "submodule" {
+			cmd, err = client.AuthenticatedCommand(context.Background(), args...)
+		} else {
+			cmd, err = client.Command(context.Background(), args...)
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pr/checkout/checkout_test.go
+++ b/pkg/cmd/pr/checkout/checkout_test.go
@@ -93,12 +93,12 @@ func Test_checkoutRun(t *testing.T) {
 				"origin": "OWNER/REPO",
 			},
 			runStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:feature`, 0, "")
+				cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
 				cs.Register(`git config branch\.feature\.merge`, 1, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.remote origin`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.pushRemote origin`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.merge refs/pull/123/head`, 0, "")
+				cs.Register(`git checkout feature`, 0, "")
+				cs.Register(`git config branch\.feature\.remote origin`, 0, "")
+				cs.Register(`git config branch\.feature\.pushRemote origin`, 0, "")
+				cs.Register(`git config branch\.feature\.merge refs/pull/123/head`, 0, "")
 			},
 		},
 		{
@@ -123,8 +123,8 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git show-ref --verify -- refs/heads/foobar`, 1, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout -b foobar --track origin/feature`, 0, "")
+				cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+				cs.Register(`git checkout -b foobar --track origin/feature`, 0, "")
 			},
 		},
 		{
@@ -150,11 +150,11 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config branch\.foobar\.merge`, 1, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:foobar`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout foobar`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.foobar\.remote https://github.com/hubot/REPO.git`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.foobar\.pushRemote https://github.com/hubot/REPO.git`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.foobar\.merge refs/heads/feature`, 0, "")
+				cs.Register(`git fetch origin refs/pull/123/head:foobar`, 0, "")
+				cs.Register(`git checkout foobar`, 0, "")
+				cs.Register(`git config branch\.foobar\.remote https://github.com/hubot/REPO.git`, 0, "")
+				cs.Register(`git config branch\.foobar\.pushRemote https://github.com/hubot/REPO.git`, 0, "")
+				cs.Register(`git config branch\.foobar\.merge refs/heads/feature`, 0, "")
 			},
 		},
 	}
@@ -275,9 +275,9 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 1, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout -b feature --track origin/feature`, 0, "")
+	cs.Register(`git checkout -b feature --track origin/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
 	assert.NoError(t, err)
@@ -295,10 +295,10 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential merge --ff-only refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git checkout feature`, 0, "")
+	cs.Register(`git merge --ff-only refs/remotes/origin/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
 	assert.NoError(t, err)
@@ -328,9 +328,9 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch robot-fork \+refs/heads/feature:refs/remotes/robot-fork/feature`, 0, "")
+	cs.Register(`git fetch robot-fork \+refs/heads/feature:refs/remotes/robot-fork/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 1, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout -b feature --track robot-fork/feature`, 0, "")
+	cs.Register(`git checkout -b feature --track robot-fork/feature`, 0, "")
 
 	output, err := runCommand(http, remotes, "master", `123`)
 	assert.NoError(t, err)
@@ -349,12 +349,12 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 1, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.remote origin`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.pushRemote origin`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.merge refs/pull/123/head`, 0, "")
+	cs.Register(`git checkout feature`, 0, "")
+	cs.Register(`git config branch\.feature\.remote origin`, 0, "")
+	cs.Register(`git config branch\.feature\.pushRemote origin`, 0, "")
+	cs.Register(`git config branch\.feature\.merge refs/pull/123/head`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
 	assert.NoError(t, err)
@@ -372,9 +372,9 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
+	cs.Register(`git checkout feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
 	assert.NoError(t, err)
@@ -392,9 +392,9 @@ func TestPRCheckout_detachedHead(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
+	cs.Register(`git checkout feature`, 0, "")
 
 	output, err := runCommand(http, nil, "", `123`)
 	assert.NoError(t, err)
@@ -412,9 +412,9 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential merge --ff-only FETCH_HEAD`, 0, "")
+	cs.Register(`git merge --ff-only FETCH_HEAD`, 0, "")
 
 	output, err := runCommand(http, nil, "feature", `123`)
 	assert.NoError(t, err)
@@ -449,12 +449,12 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 1, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.remote https://github\.com/hubot/REPO\.git`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.pushRemote https://github\.com/hubot/REPO\.git`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.merge refs/heads/feature`, 0, "")
+	cs.Register(`git checkout feature`, 0, "")
+	cs.Register(`git config branch\.feature\.remote https://github\.com/hubot/REPO\.git`, 0, "")
+	cs.Register(`git config branch\.feature\.pushRemote https://github\.com/hubot/REPO\.git`, 0, "")
+	cs.Register(`git config branch\.feature\.merge refs/heads/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
 	assert.NoError(t, err)
@@ -471,12 +471,12 @@ func TestPRCheckout_recurseSubmodules(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential merge --ff-only refs/remotes/origin/feature`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential submodule sync --recursive`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential submodule update --init --recursive`, 0, "")
+	cs.Register(`git checkout feature`, 0, "")
+	cs.Register(`git merge --ff-only refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git submodule sync --recursive`, 0, "")
+	cs.Register(`git submodule update --init --recursive`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123 --recurse-submodules`)
 	assert.NoError(t, err)
@@ -493,10 +493,10 @@ func TestPRCheckout_force(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential reset --hard refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git checkout feature`, 0, "")
+	cs.Register(`git reset --hard refs/remotes/origin/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123 --force`)
 
@@ -515,8 +515,8 @@ func TestPRCheckout_detach(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout --detach FETCH_HEAD`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head`, 0, "")
+	cs.Register(`git checkout --detach FETCH_HEAD`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head`, 0, "")
 
 	output, err := runCommand(http, nil, "", `123 --detach`)
 	assert.NoError(t, err)

--- a/pkg/cmd/pr/checkout/checkout_test.go
+++ b/pkg/cmd/pr/checkout/checkout_test.go
@@ -93,12 +93,12 @@ func Test_checkoutRun(t *testing.T) {
 				"origin": "OWNER/REPO",
 			},
 			runStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:feature`, 0, "")
 				cs.Register(`git config branch\.feature\.merge`, 1, "")
-				cs.Register(`git checkout feature`, 0, "")
-				cs.Register(`git config branch\.feature\.remote origin`, 0, "")
-				cs.Register(`git config branch\.feature\.pushRemote origin`, 0, "")
-				cs.Register(`git config branch\.feature\.merge refs/pull/123/head`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.remote origin`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.pushRemote origin`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.merge refs/pull/123/head`, 0, "")
 			},
 		},
 		{
@@ -123,8 +123,8 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git show-ref --verify -- refs/heads/foobar`, 1, "")
-				cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
-				cs.Register(`git checkout -b foobar --track origin/feature`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout -b foobar --track origin/feature`, 0, "")
 			},
 		},
 		{
@@ -150,11 +150,11 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config branch\.foobar\.merge`, 1, "")
-				cs.Register(`git fetch origin refs/pull/123/head:foobar`, 0, "")
-				cs.Register(`git checkout foobar`, 0, "")
-				cs.Register(`git config branch\.foobar\.remote https://github.com/hubot/REPO.git`, 0, "")
-				cs.Register(`git config branch\.foobar\.pushRemote https://github.com/hubot/REPO.git`, 0, "")
-				cs.Register(`git config branch\.foobar\.merge refs/heads/feature`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:foobar`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout foobar`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.foobar\.remote https://github.com/hubot/REPO.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.foobar\.pushRemote https://github.com/hubot/REPO.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.foobar\.merge refs/heads/feature`, 0, "")
 			},
 		},
 	}
@@ -197,7 +197,10 @@ func Test_checkoutRun(t *testing.T) {
 				return remotes, nil
 			}
 
-			opts.GitClient = &git.Client{GitPath: "some/path/git"}
+			opts.GitClient = &git.Client{
+				GhPath:  "some/path/gh",
+				GitPath: "some/path/git",
+			}
 
 			err := checkoutRun(opts)
 			if (err != nil) != tt.wantErr {
@@ -236,7 +239,10 @@ func runCommand(rt http.RoundTripper, remotes context.Remotes, branch string, cl
 		Branch: func() (string, error) {
 			return branch, nil
 		},
-		GitClient: &git.Client{GitPath: "some/path/git"},
+		GitClient: &git.Client{
+			GhPath:  "some/path/gh",
+			GitPath: "some/path/git",
+		},
 	}
 
 	cmd := NewCmdCheckout(factory, nil)
@@ -269,9 +275,9 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 1, "")
-	cs.Register(`git checkout -b feature --track origin/feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout -b feature --track origin/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
 	assert.NoError(t, err)
@@ -289,10 +295,10 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 0, "")
-	cs.Register(`git checkout feature`, 0, "")
-	cs.Register(`git merge --ff-only refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential merge --ff-only refs/remotes/origin/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
 	assert.NoError(t, err)
@@ -322,9 +328,9 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git fetch robot-fork \+refs/heads/feature:refs/remotes/robot-fork/feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch robot-fork \+refs/heads/feature:refs/remotes/robot-fork/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 1, "")
-	cs.Register(`git checkout -b feature --track robot-fork/feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout -b feature --track robot-fork/feature`, 0, "")
 
 	output, err := runCommand(http, remotes, "master", `123`)
 	assert.NoError(t, err)
@@ -343,12 +349,12 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:feature`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 1, "")
-	cs.Register(`git checkout feature`, 0, "")
-	cs.Register(`git config branch\.feature\.remote origin`, 0, "")
-	cs.Register(`git config branch\.feature\.pushRemote origin`, 0, "")
-	cs.Register(`git config branch\.feature\.merge refs/pull/123/head`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.remote origin`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.pushRemote origin`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.merge refs/pull/123/head`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
 	assert.NoError(t, err)
@@ -366,9 +372,9 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:feature`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
-	cs.Register(`git checkout feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
 	assert.NoError(t, err)
@@ -386,9 +392,9 @@ func TestPRCheckout_detachedHead(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:feature`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
-	cs.Register(`git checkout feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
 
 	output, err := runCommand(http, nil, "", `123`)
 	assert.NoError(t, err)
@@ -406,9 +412,9 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git fetch origin refs/pull/123/head`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
-	cs.Register(`git merge --ff-only FETCH_HEAD`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential merge --ff-only FETCH_HEAD`, 0, "")
 
 	output, err := runCommand(http, nil, "feature", `123`)
 	assert.NoError(t, err)
@@ -443,12 +449,12 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head:feature`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 1, "")
-	cs.Register(`git checkout feature`, 0, "")
-	cs.Register(`git config branch\.feature\.remote https://github\.com/hubot/REPO\.git`, 0, "")
-	cs.Register(`git config branch\.feature\.pushRemote https://github\.com/hubot/REPO\.git`, 0, "")
-	cs.Register(`git config branch\.feature\.merge refs/heads/feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.remote https://github\.com/hubot/REPO\.git`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.pushRemote https://github\.com/hubot/REPO\.git`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential config branch\.feature\.merge refs/heads/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
 	assert.NoError(t, err)
@@ -465,12 +471,12 @@ func TestPRCheckout_recurseSubmodules(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 0, "")
-	cs.Register(`git checkout feature`, 0, "")
-	cs.Register(`git merge --ff-only refs/remotes/origin/feature`, 0, "")
-	cs.Register(`git submodule sync --recursive`, 0, "")
-	cs.Register(`git submodule update --init --recursive`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential merge --ff-only refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential submodule sync --recursive`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential submodule update --init --recursive`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123 --recurse-submodules`)
 	assert.NoError(t, err)
@@ -487,10 +493,10 @@ func TestPRCheckout_force(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 0, "")
-	cs.Register(`git checkout feature`, 0, "")
-	cs.Register(`git reset --hard refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout feature`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential reset --hard refs/remotes/origin/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123 --force`)
 
@@ -509,8 +515,8 @@ func TestPRCheckout_detach(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git checkout --detach FETCH_HEAD`, 0, "")
-	cs.Register(`git fetch origin refs/pull/123/head`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential checkout --detach FETCH_HEAD`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential fetch origin refs/pull/123/head`, 0, "")
 
 	output, err := runCommand(http, nil, "", `123 --detach`)
 	assert.NoError(t, err)

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -266,7 +266,7 @@ func Test_createRun(t *testing.T) {
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream origin HEAD:feature`, 0, "")
+				cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
 			},
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubPrompt("Where should we push the 'feature' branch?").AnswerDefault()
@@ -307,7 +307,7 @@ func Test_createRun(t *testing.T) {
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream origin HEAD:feature`, 0, "")
+				cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
 			},
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubPrompt("Where should we push the 'feature' branch?").AnswerDefault()
@@ -351,8 +351,8 @@ func Test_createRun(t *testing.T) {
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f fork https://github.com/monalisa/REPO.git`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream fork HEAD:feature`, 0, "")
+				cs.Register(`git remote add -f fork https://github.com/monalisa/REPO.git`, 0, "")
+				cs.Register(`git push --set-upstream fork HEAD:feature`, 0, "")
 			},
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubPrompt("Where should we push the 'feature' branch?").
@@ -634,7 +634,7 @@ func Test_createRun(t *testing.T) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
 				cs.Register(`git( .+)? log( .+)? origin/master\.\.\.feature`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream origin HEAD:feature`, 0, "")
+				cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
 			},
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubPrompt("Where should we push the 'feature' branch?").
@@ -682,7 +682,7 @@ func Test_createRun(t *testing.T) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
 				cs.Register(`git( .+)? log( .+)? origin/master\.\.\.feature`, 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream origin HEAD:feature`, 0, "")
+				cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
 
 			},
 			askStubs: func(as *prompt.AskStubber) {

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -266,7 +266,7 @@ func Test_createRun(t *testing.T) {
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
-				cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream origin HEAD:feature`, 0, "")
 			},
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubPrompt("Where should we push the 'feature' branch?").AnswerDefault()
@@ -307,7 +307,7 @@ func Test_createRun(t *testing.T) {
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
-				cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream origin HEAD:feature`, 0, "")
 			},
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubPrompt("Where should we push the 'feature' branch?").AnswerDefault()
@@ -351,8 +351,8 @@ func Test_createRun(t *testing.T) {
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
-				cs.Register(`git remote add -f fork https://github.com/monalisa/REPO.git`, 0, "")
-				cs.Register(`git push --set-upstream fork HEAD:feature`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f fork https://github.com/monalisa/REPO.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream fork HEAD:feature`, 0, "")
 			},
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubPrompt("Where should we push the 'feature' branch?").
@@ -634,7 +634,7 @@ func Test_createRun(t *testing.T) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
 				cs.Register(`git( .+)? log( .+)? origin/master\.\.\.feature`, 0, "")
-				cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream origin HEAD:feature`, 0, "")
 			},
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubPrompt("Where should we push the 'feature' branch?").
@@ -682,7 +682,7 @@ func Test_createRun(t *testing.T) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
 				cs.Register(`git( .+)? log( .+)? origin/master\.\.\.feature`, 0, "")
-				cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream origin HEAD:feature`, 0, "")
 
 			},
 			askStubs: func(as *prompt.AskStubber) {
@@ -894,7 +894,10 @@ func Test_createRun(t *testing.T) {
 				return branch, nil
 			}
 			opts.Finder = shared.NewMockFinder(branch, nil, nil)
-			opts.GitClient = &git.Client{GitPath: "some/path/git"}
+			opts.GitClient = &git.Client{
+				GhPath:  "some/path/gh",
+				GitPath: "some/path/git",
+			}
 			cleanSetup := func() {}
 			if tt.setup != nil {
 				cleanSetup = tt.setup(&opts, t)
@@ -1011,7 +1014,10 @@ func Test_determineTrackingBranch(t *testing.T) {
 
 			tt.cmdStubs(cs)
 
-			gitClient := &git.Client{GitPath: "some/path/git"}
+			gitClient := &git.Client{
+				GhPath:  "some/path/gh",
+				GitPath: "some/path/git",
+			}
 			ref := determineTrackingBranch(gitClient, tt.remotes, "feature")
 			tt.assert(ref, t)
 		})

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -642,7 +642,7 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 	cs.Register(`git checkout main`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only`, 0, "")
+	cs.Register(`git pull --ff-only`, 0, "")
 
 	output, err := runCommand(http, "blueberries", true, `pr merge --merge --delete-branch`)
 	if err != nil {
@@ -692,7 +692,7 @@ func TestPrMerge_deleteBranch_nonDefault(t *testing.T) {
 	cs.Register(`git checkout fruit`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only`, 0, "")
+	cs.Register(`git pull --ff-only`, 0, "")
 
 	output, err := runCommand(http, "blueberries", true, `pr merge --merge --delete-branch`)
 	if err != nil {
@@ -742,7 +742,7 @@ func TestPrMerge_deleteBranch_checkoutNewBranch(t *testing.T) {
 	cs.Register(`git checkout -b fruit --track origin/fruit`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only`, 0, "")
+	cs.Register(`git pull --ff-only`, 0, "")
 
 	output, err := runCommand(http, "blueberries", true, `pr merge --merge --delete-branch`)
 	if err != nil {
@@ -1027,7 +1027,7 @@ func TestPrMerge_alreadyMerged(t *testing.T) {
 	cs.Register(`git checkout main`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only`, 0, "")
+	cs.Register(`git pull --ff-only`, 0, "")
 
 	//nolint:staticcheck // SA1019: prompt.NewAskStubber is deprecated: use PrompterMock
 	as := prompt.NewAskStubber(t)
@@ -1231,7 +1231,7 @@ func TestPRMergeTTY_withDeleteBranch(t *testing.T) {
 	cs.Register(`git checkout main`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only`, 0, "")
+	cs.Register(`git pull --ff-only`, 0, "")
 
 	//nolint:staticcheck // SA1019: prompt.NewAskStubber is deprecated: use PrompterMock
 	as := prompt.NewAskStubber(t)

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -270,7 +270,10 @@ func runCommand(rt http.RoundTripper, branch string, isTTY bool, cli string) (*t
 				},
 			}, nil
 		},
-		GitClient: &git.Client{GitPath: "some/path/git"},
+		GitClient: &git.Client{
+			GhPath:  "some/path/gh",
+			GitPath: "some/path/git",
+		},
 	}
 
 	cmd := NewCmdMerge(factory, nil)
@@ -639,7 +642,7 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 	cs.Register(`git checkout main`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
-	cs.Register(`git pull --ff-only`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only`, 0, "")
 
 	output, err := runCommand(http, "blueberries", true, `pr merge --merge --delete-branch`)
 	if err != nil {
@@ -689,7 +692,7 @@ func TestPrMerge_deleteBranch_nonDefault(t *testing.T) {
 	cs.Register(`git checkout fruit`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
-	cs.Register(`git pull --ff-only`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only`, 0, "")
 
 	output, err := runCommand(http, "blueberries", true, `pr merge --merge --delete-branch`)
 	if err != nil {
@@ -739,7 +742,7 @@ func TestPrMerge_deleteBranch_checkoutNewBranch(t *testing.T) {
 	cs.Register(`git checkout -b fruit --track origin/fruit`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
-	cs.Register(`git pull --ff-only`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only`, 0, "")
 
 	output, err := runCommand(http, "blueberries", true, `pr merge --merge --delete-branch`)
 	if err != nil {
@@ -1024,7 +1027,7 @@ func TestPrMerge_alreadyMerged(t *testing.T) {
 	cs.Register(`git checkout main`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
-	cs.Register(`git pull --ff-only`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only`, 0, "")
 
 	//nolint:staticcheck // SA1019: prompt.NewAskStubber is deprecated: use PrompterMock
 	as := prompt.NewAskStubber(t)
@@ -1228,7 +1231,7 @@ func TestPRMergeTTY_withDeleteBranch(t *testing.T) {
 	cs.Register(`git checkout main`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
 	cs.Register(`git branch -D blueberries`, 0, "")
-	cs.Register(`git pull --ff-only`, 0, "")
+	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential pull --ff-only`, 0, "")
 
 	//nolint:staticcheck // SA1019: prompt.NewAskStubber is deprecated: use PrompterMock
 	as := prompt.NewAskStubber(t)

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -2,7 +2,6 @@ package clone
 
 import (
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/git"
@@ -142,47 +141,47 @@ func Test_RepoClone(t *testing.T) {
 		{
 			name: "shorthand",
 			args: "OWNER/REPO",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/OWNER/REPO.git`,
+			want: `git clone https://github.com/OWNER/REPO.git`,
 		},
 		{
 			name: "shorthand with directory",
 			args: "OWNER/REPO target_directory",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/OWNER/REPO.git target_directory`,
+			want: `git clone https://github.com/OWNER/REPO.git target_directory`,
 		},
 		{
 			name: "clone arguments",
 			args: "OWNER/REPO -- -o upstream --depth 1",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone -o upstream --depth 1 https://github.com/OWNER/REPO.git`,
+			want: `git clone -o upstream --depth 1 https://github.com/OWNER/REPO.git`,
 		},
 		{
 			name: "clone arguments with directory",
 			args: "OWNER/REPO target_directory -- -o upstream --depth 1",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone -o upstream --depth 1 https://github.com/OWNER/REPO.git target_directory`,
+			want: `git clone -o upstream --depth 1 https://github.com/OWNER/REPO.git target_directory`,
 		},
 		{
 			name: "HTTPS URL",
 			args: "https://github.com/OWNER/REPO",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/OWNER/REPO.git`,
+			want: `git clone https://github.com/OWNER/REPO.git`,
 		},
 		{
 			name: "SSH URL",
 			args: "git@github.com:OWNER/REPO.git",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone git@github.com:OWNER/REPO.git`,
+			want: `git clone git@github.com:OWNER/REPO.git`,
 		},
 		{
 			name: "Non-canonical capitalization",
 			args: "Owner/Repo",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/OWNER/REPO.git`,
+			want: `git clone https://github.com/OWNER/REPO.git`,
 		},
 		{
 			name: "clone wiki",
 			args: "Owner/Repo.wiki",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/OWNER/REPO.wiki.git`,
+			want: `git clone https://github.com/OWNER/REPO.wiki.git`,
 		},
 		{
 			name: "wiki URL",
 			args: "https://github.com/owner/repo.wiki",
-			want: `git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/OWNER/REPO.wiki.git`,
+			want: `git clone https://github.com/OWNER/REPO.wiki.git`,
 		},
 	}
 	for _, tt := range tests {
@@ -205,9 +204,7 @@ func Test_RepoClone(t *testing.T) {
 
 			cs, restore := run.Stub()
 			defer restore(t)
-			cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone`, 0, "", func(s []string) {
-				assert.Equal(t, tt.want, strings.Join(s, " "))
-			})
+			cs.Register(tt.want, 0, "")
 
 			output, err := runCloneCommand(httpClient, tt.args)
 			if err != nil {
@@ -247,8 +244,8 @@ func Test_RepoClone_hasParent(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/OWNER/REPO.git`, 0, "")
-	cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -t trunk -f upstream https://github.com/hubot/ORIG.git`, 0, "")
+	cs.Register(`git clone https://github.com/OWNER/REPO.git`, 0, "")
+	cs.Register(`git -C REPO remote add -t trunk -f upstream https://github.com/hubot/ORIG.git`, 0, "")
 
 	_, err := runCloneCommand(httpClient, "OWNER/REPO")
 	if err != nil {
@@ -283,8 +280,8 @@ func Test_RepoClone_hasParent_upstreamRemoteName(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/OWNER/REPO.git`, 0, "")
-	cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -t trunk -f test https://github.com/hubot/ORIG.git`, 0, "")
+	cs.Register(`git clone https://github.com/OWNER/REPO.git`, 0, "")
+	cs.Register(`git -C REPO remote add -t trunk -f test https://github.com/hubot/ORIG.git`, 0, "")
 
 	_, err := runCloneCommand(httpClient, "OWNER/REPO --upstream-remote-name test")
 	if err != nil {
@@ -316,7 +313,7 @@ func Test_RepoClone_withoutUsername(t *testing.T) {
 
 	cs, restore := run.Stub()
 	defer restore(t)
-	cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github\.com/OWNER/REPO\.git`, 0, "")
+	cs.Register(`git clone https://github\.com/OWNER/REPO\.git`, 0, "")
 
 	output, err := runCloneCommand(httpClient, "REPO")
 	if err != nil {

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -141,47 +141,47 @@ func Test_RepoClone(t *testing.T) {
 		{
 			name: "shorthand",
 			args: "OWNER/REPO",
-			want: `git clone https://github.com/OWNER/REPO.git`,
+			want: "git clone https://github.com/OWNER/REPO.git",
 		},
 		{
 			name: "shorthand with directory",
 			args: "OWNER/REPO target_directory",
-			want: `git clone https://github.com/OWNER/REPO.git target_directory`,
+			want: "git clone https://github.com/OWNER/REPO.git target_directory",
 		},
 		{
 			name: "clone arguments",
 			args: "OWNER/REPO -- -o upstream --depth 1",
-			want: `git clone -o upstream --depth 1 https://github.com/OWNER/REPO.git`,
+			want: "git clone -o upstream --depth 1 https://github.com/OWNER/REPO.git",
 		},
 		{
 			name: "clone arguments with directory",
 			args: "OWNER/REPO target_directory -- -o upstream --depth 1",
-			want: `git clone -o upstream --depth 1 https://github.com/OWNER/REPO.git target_directory`,
+			want: "git clone -o upstream --depth 1 https://github.com/OWNER/REPO.git target_directory",
 		},
 		{
 			name: "HTTPS URL",
 			args: "https://github.com/OWNER/REPO",
-			want: `git clone https://github.com/OWNER/REPO.git`,
+			want: "git clone https://github.com/OWNER/REPO.git",
 		},
 		{
 			name: "SSH URL",
 			args: "git@github.com:OWNER/REPO.git",
-			want: `git clone git@github.com:OWNER/REPO.git`,
+			want: "git clone git@github.com:OWNER/REPO.git",
 		},
 		{
 			name: "Non-canonical capitalization",
 			args: "Owner/Repo",
-			want: `git clone https://github.com/OWNER/REPO.git`,
+			want: "git clone https://github.com/OWNER/REPO.git",
 		},
 		{
 			name: "clone wiki",
 			args: "Owner/Repo.wiki",
-			want: `git clone https://github.com/OWNER/REPO.wiki.git`,
+			want: "git clone https://github.com/OWNER/REPO.wiki.git",
 		},
 		{
 			name: "wiki URL",
 			args: "https://github.com/owner/repo.wiki",
-			want: `git clone https://github.com/OWNER/REPO.wiki.git`,
+			want: "git clone https://github.com/OWNER/REPO.wiki.git",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -564,7 +564,7 @@ func createFromLocal(opts *CreateOptions) error {
 
 func sourceInit(gitClient *git.Client, io *iostreams.IOStreams, remoteURL, baseRemote string) error {
 	cs := io.ColorScheme()
-	remoteAdd, err := gitClient.Command(context.Background(), "remote", "add", baseRemote, remoteURL)
+	remoteAdd, err := gitClient.AuthenticatedCommand(context.Background(), "remote", "add", baseRemote, remoteURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -564,7 +564,7 @@ func createFromLocal(opts *CreateOptions) error {
 
 func sourceInit(gitClient *git.Client, io *iostreams.IOStreams, remoteURL, baseRemote string) error {
 	cs := io.ColorScheme()
-	remoteAdd, err := gitClient.AuthenticatedCommand(context.Background(), "remote", "add", baseRemote, remoteURL)
+	remoteAdd, err := gitClient.Command(context.Background(), "remote", "add", baseRemote, remoteURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -243,7 +243,7 @@ func Test_createRun(t *testing.T) {
 
 			},
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git clone https://github.com/OWNER/REPO.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/OWNER/REPO.git`, 0, "")
 			},
 		},
 		{
@@ -410,7 +410,7 @@ func Test_createRun(t *testing.T) {
 				cs.Register(`git -C . rev-parse --git-dir`, 0, ".git")
 				cs.Register(`git -C . rev-parse HEAD`, 0, "commithash")
 				cs.Register(`git -C . remote add origin https://github.com/OWNER/REPO`, 0, "")
-				cs.Register(`git -C . push --set-upstream origin HEAD`, 0, "")
+				cs.Register(`git -C . -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream origin HEAD`, 0, "")
 			},
 			wantStdout: "✓ Created repository OWNER/REPO on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n✓ Pushed commits to https://github.com/OWNER/REPO.git\n",
 		},
@@ -493,7 +493,10 @@ func Test_createRun(t *testing.T) {
 			return config.NewBlankConfig(), nil
 		}
 
-		tt.opts.GitClient = &git.Client{GitPath: "some/path/git"}
+		tt.opts.GitClient = &git.Client{
+			GhPath:  "some/path/gh",
+			GitPath: "some/path/git",
+		}
 
 		ios, _, stdout, stderr := iostreams.Test()
 		ios.SetStdinTTY(tt.tty)

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -243,7 +243,7 @@ func Test_createRun(t *testing.T) {
 
 			},
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/OWNER/REPO.git`, 0, "")
+				cs.Register(`git clone https://github.com/OWNER/REPO.git`, 0, "")
 			},
 		},
 		{
@@ -410,7 +410,7 @@ func Test_createRun(t *testing.T) {
 				cs.Register(`git -C . rev-parse --git-dir`, 0, ".git")
 				cs.Register(`git -C . rev-parse HEAD`, 0, "commithash")
 				cs.Register(`git -C . remote add origin https://github.com/OWNER/REPO`, 0, "")
-				cs.Register(`git -C . -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential push --set-upstream origin HEAD`, 0, "")
+				cs.Register(`git -C . push --set-upstream origin HEAD`, 0, "")
 			},
 			wantStdout: "✓ Created repository OWNER/REPO on GitHub\n✓ Added remote https://github.com/OWNER/REPO.git\n✓ Pushed commits to https://github.com/OWNER/REPO.git\n",
 		},

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -234,7 +234,7 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git remote add -f fork https://github\.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f fork https://github\.com/someone/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n",
 		},
@@ -258,7 +258,7 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git remote add -f fork git@github\.com:someone/REPO\.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f fork git@github\.com:someone/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n",
 		},
@@ -288,7 +288,7 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
-				cs.Register(`git remote add -f origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f origin https://github.com/someone/REPO.git`, 0, "")
 			},
 			askStubs: func(as *prompt.AskStubber) {
 				//nolint:staticcheck // SA1019: as.StubOne is deprecated: use StubPrompt
@@ -364,7 +364,7 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
-				cs.Register(`git remote add -f origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f origin https://github.com/someone/REPO.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote origin\n",
 		},
@@ -418,7 +418,7 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
-				cs.Register(`git remote add -f origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f origin https://github.com/someone/REPO.git`, 0, "")
 			},
 		},
 		{
@@ -436,8 +436,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git clone --depth 1 https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone --depth 1 https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Cloned fork\n",
 		},
@@ -466,8 +466,8 @@ func TestRepoFork(t *testing.T) {
 					})
 			},
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git clone https://github.com/gamehendge/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/gamehendge/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork gamehendge/REPO\n✓ Cloned fork\n",
 		},
@@ -480,8 +480,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Cloned fork\n",
 		},
@@ -512,8 +512,8 @@ func TestRepoFork(t *testing.T) {
 				as.StubOne(true)
 			},
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Cloned fork\n",
 		},
@@ -533,8 +533,8 @@ func TestRepoFork(t *testing.T) {
 				as.StubOne(true)
 			},
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "! someone/REPO already exists\n✓ Cloned fork\n",
 		},
@@ -567,8 +567,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "someone/REPO already exists",
 		},
@@ -580,8 +580,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 		},
 		{
@@ -700,7 +700,10 @@ func TestRepoFork(t *testing.T) {
 			return tt.remotes, nil
 		}
 
-		tt.opts.GitClient = &git.Client{GitPath: "some/path/git"}
+		tt.opts.GitClient = &git.Client{
+			GhPath:  "some/path/gh",
+			GitPath: "some/path/git",
+		}
 
 		//nolint:staticcheck // SA1019: prompt.InitAskStubber is deprecated: use NewAskStubber
 		as, teardown := prompt.InitAskStubber()

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -234,7 +234,7 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f fork https://github\.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git remote add -f fork https://github\.com/someone/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n",
 		},
@@ -258,7 +258,7 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f fork git@github\.com:someone/REPO\.git`, 0, "")
+				cs.Register(`git remote add -f fork git@github\.com:someone/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n",
 		},
@@ -288,7 +288,7 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git remote add -f origin https://github.com/someone/REPO.git`, 0, "")
 			},
 			askStubs: func(as *prompt.AskStubber) {
 				//nolint:staticcheck // SA1019: as.StubOne is deprecated: use StubPrompt
@@ -364,7 +364,7 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git remote add -f origin https://github.com/someone/REPO.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote origin\n",
 		},
@@ -418,7 +418,7 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git remote add -f origin https://github.com/someone/REPO.git`, 0, "")
 			},
 		},
 		{
@@ -436,8 +436,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone --depth 1 https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git clone --depth 1 https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Cloned fork\n",
 		},
@@ -466,8 +466,8 @@ func TestRepoFork(t *testing.T) {
 					})
 			},
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/gamehendge/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git clone https://github.com/gamehendge/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork gamehendge/REPO\n✓ Cloned fork\n",
 		},
@@ -480,8 +480,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Cloned fork\n",
 		},
@@ -512,8 +512,8 @@ func TestRepoFork(t *testing.T) {
 				as.StubOne(true)
 			},
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Cloned fork\n",
 		},
@@ -533,8 +533,8 @@ func TestRepoFork(t *testing.T) {
 				as.StubOne(true)
 			},
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "! someone/REPO already exists\n✓ Cloned fork\n",
 		},
@@ -567,8 +567,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 			wantErrOut: "someone/REPO already exists",
 		},
@@ -580,8 +580,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO -c credential.helper= -c credential.helper=!"some/path/gh" auth git-credential remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 			},
 		},
 		{


### PR DESCRIPTION
The PR changes `git` client to now use `gh` as the default credential manager for authentication. For now, this is only applying to network `git` commands such as `Fetch`, `Pull`, `Pull`, `Clone`, `AddRemote`. The majority of the line changes in this PR are fixing up tests.

cc https://github.com/cli/cli/issues/2944