### PR TITLE
Use git client in extension manager

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -414,7 +414,10 @@ func (c *Client) Fetch(ctx context.Context, remote string, refspec string, mods 
 }
 
 func (c *Client) Pull(ctx context.Context, remote, branch string, mods ...CommandModifier) error {
-	args := []string{"pull", "--ff-only", remote, branch}
+	args := []string{"pull", "--ff-only"}
+	if remote != "" && branch != "" {
+		args = append(args, remote, branch)
+	}
 	// TODO: Use AuthenticatedCommand
 	cmd, err := c.Command(ctx, args...)
 	if err != nil {

--- a/git/client.go
+++ b/git/client.go
@@ -32,7 +32,7 @@ type Client struct {
 	mu             sync.Mutex
 }
 
-func (c *Client) Command(ctx context.Context, args ...string) (*gitCommand, error) {
+func (c *Client) Command(ctx context.Context, args ...string) (*Command, error) {
 	if c.RepoDir != "" {
 		args = append([]string{"-C", c.RepoDir}, args...)
 	}
@@ -53,12 +53,12 @@ func (c *Client) Command(ctx context.Context, args ...string) (*gitCommand, erro
 	cmd.Stderr = c.Stderr
 	cmd.Stdin = c.Stdin
 	cmd.Stdout = c.Stdout
-	return &gitCommand{cmd}, nil
+	return &Command{cmd}, nil
 }
 
 // AuthenticatedCommand is a wrapper around Command that included configuration to use gh
 // as the credential helper for git.
-func (c *Client) AuthenticatedCommand(ctx context.Context, args ...string) (*gitCommand, error) {
+func (c *Client) AuthenticatedCommand(ctx context.Context, args ...string) (*Command, error) {
 	preArgs := []string{"-c", "credential.helper="}
 	if c.GhPath == "" {
 		// Assumes that gh is in PATH.

--- a/git/client.go
+++ b/git/client.go
@@ -70,11 +70,14 @@ func (c *Client) AuthenticatedCommand(ctx context.Context, args ...string) (*git
 	return c.Command(ctx, args...)
 }
 
-func (c *Client) Remotes(ctx context.Context) (RemoteSet, error) {
+func (c *Client) Remotes(ctx context.Context, mods ...CommandModifier) (RemoteSet, error) {
 	remoteArgs := []string{"remote", "-v"}
 	remoteCmd, err := c.Command(ctx, remoteArgs...)
 	if err != nil {
 		return nil, err
+	}
+	for _, mod := range mods {
+		mod(remoteCmd)
 	}
 	remoteOut, remoteErr := remoteCmd.Output()
 	if remoteErr != nil {
@@ -85,6 +88,9 @@ func (c *Client) Remotes(ctx context.Context) (RemoteSet, error) {
 	configCmd, err := c.Command(ctx, configArgs...)
 	if err != nil {
 		return nil, err
+	}
+	for _, mod := range mods {
+		mod(configCmd)
 	}
 	configOut, configErr := configCmd.Output()
 	if configErr != nil {
@@ -171,11 +177,14 @@ func (c *Client) ShowRefs(ctx context.Context, refs []string) ([]Ref, error) {
 	return verified, err
 }
 
-func (c *Client) Config(ctx context.Context, name string) (string, error) {
+func (c *Client) Config(ctx context.Context, name string, mods ...CommandModifier) (string, error) {
 	args := []string{"config", name}
 	cmd, err := c.Command(ctx, args...)
 	if err != nil {
 		return "", err
+	}
+	for _, mod := range mods {
+		mod(cmd)
 	}
 	out, err := cmd.Output()
 	if err != nil {
@@ -327,11 +336,14 @@ func (c *Client) HasLocalBranch(ctx context.Context, branch string) bool {
 	return err == nil
 }
 
-func (c *Client) CheckoutBranch(ctx context.Context, branch string) error {
+func (c *Client) CheckoutBranch(ctx context.Context, branch string, mods ...CommandModifier) error {
 	args := []string{"checkout", branch}
 	cmd, err := c.Command(ctx, args...)
 	if err != nil {
 		return err
+	}
+	for _, mod := range mods {
+		mod(cmd)
 	}
 	_, err = cmd.Output()
 	if err != nil {

--- a/git/client.go
+++ b/git/client.go
@@ -70,14 +70,11 @@ func (c *Client) AuthenticatedCommand(ctx context.Context, args ...string) (*Com
 	return c.Command(ctx, args...)
 }
 
-func (c *Client) Remotes(ctx context.Context, mods ...CommandModifier) (RemoteSet, error) {
+func (c *Client) Remotes(ctx context.Context) (RemoteSet, error) {
 	remoteArgs := []string{"remote", "-v"}
 	remoteCmd, err := c.Command(ctx, remoteArgs...)
 	if err != nil {
 		return nil, err
-	}
-	for _, mod := range mods {
-		mod(remoteCmd)
 	}
 	remoteOut, remoteErr := remoteCmd.Output()
 	if remoteErr != nil {
@@ -88,9 +85,6 @@ func (c *Client) Remotes(ctx context.Context, mods ...CommandModifier) (RemoteSe
 	configCmd, err := c.Command(ctx, configArgs...)
 	if err != nil {
 		return nil, err
-	}
-	for _, mod := range mods {
-		mod(configCmd)
 	}
 	configOut, configErr := configCmd.Output()
 	if configErr != nil {
@@ -177,14 +171,11 @@ func (c *Client) ShowRefs(ctx context.Context, refs []string) ([]Ref, error) {
 	return verified, err
 }
 
-func (c *Client) Config(ctx context.Context, name string, mods ...CommandModifier) (string, error) {
+func (c *Client) Config(ctx context.Context, name string) (string, error) {
 	args := []string{"config", name}
 	cmd, err := c.Command(ctx, args...)
 	if err != nil {
 		return "", err
-	}
-	for _, mod := range mods {
-		mod(cmd)
 	}
 	out, err := cmd.Output()
 	if err != nil {
@@ -336,14 +327,11 @@ func (c *Client) HasLocalBranch(ctx context.Context, branch string) bool {
 	return err == nil
 }
 
-func (c *Client) CheckoutBranch(ctx context.Context, branch string, mods ...CommandModifier) error {
+func (c *Client) CheckoutBranch(ctx context.Context, branch string) error {
 	args := []string{"checkout", branch}
 	cmd, err := c.Command(ctx, args...)
 	if err != nil {
 		return err
-	}
-	for _, mod := range mods {
-		mod(cmd)
 	}
 	_, err = cmd.Output()
 	if err != nil {

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -369,7 +369,6 @@ func TestClientShowRefs(t *testing.T) {
 func TestClientConfig(t *testing.T) {
 	tests := []struct {
 		name          string
-		mods          []CommandModifier
 		cmdExitStatus int
 		cmdStdout     string
 		cmdStderr     string
@@ -381,13 +380,6 @@ func TestClientConfig(t *testing.T) {
 			name:        "get config key",
 			cmdStdout:   "test",
 			wantCmdArgs: `path/to/git config credential.helper`,
-			wantOut:     "test",
-		},
-		{
-			name:        "accepts command modifiers",
-			mods:        []CommandModifier{WithRepoDir("/path/to/repo")},
-			cmdStdout:   "test",
-			wantCmdArgs: `path/to/git -C /path/to/repo config credential.helper`,
 			wantOut:     "test",
 		},
 		{
@@ -412,7 +404,7 @@ func TestClientConfig(t *testing.T) {
 				GitPath:        "path/to/git",
 				commandContext: cmdCtx,
 			}
-			out, err := client.Config(context.Background(), "credential.helper", tt.mods...)
+			out, err := client.Config(context.Background(), "credential.helper")
 			assert.Equal(t, tt.wantCmdArgs, strings.Join(cmd.Args[3:], " "))
 			if tt.wantErrorMsg == "" {
 				assert.NoError(t, err)
@@ -643,7 +635,6 @@ func TestClientHasLocalBranch(t *testing.T) {
 func TestClientCheckoutBranch(t *testing.T) {
 	tests := []struct {
 		name          string
-		mods          []CommandModifier
 		cmdExitStatus int
 		cmdStdout     string
 		cmdStderr     string
@@ -653,11 +644,6 @@ func TestClientCheckoutBranch(t *testing.T) {
 		{
 			name:        "checkout branch",
 			wantCmdArgs: `path/to/git checkout trunk`,
-		},
-		{
-			name:        "accepts command modifiers",
-			mods:        []CommandModifier{WithRepoDir("/path/to/repo")},
-			wantCmdArgs: `path/to/git -C /path/to/repo checkout trunk`,
 		},
 		{
 			name:          "git error",
@@ -674,7 +660,7 @@ func TestClientCheckoutBranch(t *testing.T) {
 				GitPath:        "path/to/git",
 				commandContext: cmdCtx,
 			}
-			err := client.CheckoutBranch(context.Background(), "trunk", tt.mods...)
+			err := client.CheckoutBranch(context.Background(), "trunk")
 			assert.Equal(t, tt.wantCmdArgs, strings.Join(cmd.Args[3:], " "))
 			if tt.wantErrorMsg == "" {
 				assert.NoError(t, err)

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -369,6 +369,7 @@ func TestClientShowRefs(t *testing.T) {
 func TestClientConfig(t *testing.T) {
 	tests := []struct {
 		name          string
+		mods          []CommandModifier
 		cmdExitStatus int
 		cmdStdout     string
 		cmdStderr     string
@@ -380,6 +381,13 @@ func TestClientConfig(t *testing.T) {
 			name:        "get config key",
 			cmdStdout:   "test",
 			wantCmdArgs: `path/to/git config credential.helper`,
+			wantOut:     "test",
+		},
+		{
+			name:        "accepts command modifiers",
+			mods:        []CommandModifier{WithRepoDir("/path/to/repo")},
+			cmdStdout:   "test",
+			wantCmdArgs: `path/to/git -C /path/to/repo config credential.helper`,
 			wantOut:     "test",
 		},
 		{
@@ -404,7 +412,7 @@ func TestClientConfig(t *testing.T) {
 				GitPath:        "path/to/git",
 				commandContext: cmdCtx,
 			}
-			out, err := client.Config(context.Background(), "credential.helper")
+			out, err := client.Config(context.Background(), "credential.helper", tt.mods...)
 			assert.Equal(t, tt.wantCmdArgs, strings.Join(cmd.Args[3:], " "))
 			if tt.wantErrorMsg == "" {
 				assert.NoError(t, err)
@@ -635,6 +643,7 @@ func TestClientHasLocalBranch(t *testing.T) {
 func TestClientCheckoutBranch(t *testing.T) {
 	tests := []struct {
 		name          string
+		mods          []CommandModifier
 		cmdExitStatus int
 		cmdStdout     string
 		cmdStderr     string
@@ -644,6 +653,11 @@ func TestClientCheckoutBranch(t *testing.T) {
 		{
 			name:        "checkout branch",
 			wantCmdArgs: `path/to/git checkout trunk`,
+		},
+		{
+			name:        "accepts command modifiers",
+			mods:        []CommandModifier{WithRepoDir("/path/to/repo")},
+			wantCmdArgs: `path/to/git -C /path/to/repo checkout trunk`,
 		},
 		{
 			name:          "git error",
@@ -660,7 +674,7 @@ func TestClientCheckoutBranch(t *testing.T) {
 				GitPath:        "path/to/git",
 				commandContext: cmdCtx,
 			}
-			err := client.CheckoutBranch(context.Background(), "trunk")
+			err := client.CheckoutBranch(context.Background(), "trunk", tt.mods...)
 			assert.Equal(t, tt.wantCmdArgs, strings.Join(cmd.Args[3:], " "))
 			if tt.wantErrorMsg == "" {
 				assert.NoError(t, err)

--- a/git/command.go
+++ b/git/command.go
@@ -12,11 +12,11 @@ import (
 
 type commandCtx = func(ctx context.Context, name string, args ...string) *exec.Cmd
 
-type gitCommand struct {
+type Command struct {
 	*exec.Cmd
 }
 
-func (gc *gitCommand) Run() error {
+func (gc *Command) Run() error {
 	stderr := &bytes.Buffer{}
 	if gc.Cmd.Stderr == nil {
 		gc.Cmd.Stderr = stderr
@@ -35,7 +35,7 @@ func (gc *gitCommand) Run() error {
 	return nil
 }
 
-func (gc *gitCommand) Output() ([]byte, error) {
+func (gc *Command) Output() ([]byte, error) {
 	gc.Stdout = nil
 	gc.Stderr = nil
 	// This is a hack in order to not break the hundreds of
@@ -53,7 +53,7 @@ func (gc *gitCommand) Output() ([]byte, error) {
 	return out, err
 }
 
-func (gc *gitCommand) SetRepoDir(repoDir string) {
+func (gc *Command) setRepoDir(repoDir string) {
 	for i, arg := range gc.Args {
 		if arg == "-C" {
 			gc.Args[i+1] = repoDir
@@ -73,28 +73,28 @@ func (gc *gitCommand) SetRepoDir(repoDir string) {
 }
 
 // Allow individual commands to be modified from the default client options.
-type CommandModifier func(*gitCommand)
+type CommandModifier func(*Command)
 
 func WithStderr(stderr io.Writer) CommandModifier {
-	return func(gc *gitCommand) {
+	return func(gc *Command) {
 		gc.Stderr = stderr
 	}
 }
 
 func WithStdout(stdout io.Writer) CommandModifier {
-	return func(gc *gitCommand) {
+	return func(gc *Command) {
 		gc.Stdout = stdout
 	}
 }
 
 func WithStdin(stdin io.Reader) CommandModifier {
-	return func(gc *gitCommand) {
+	return func(gc *Command) {
 		gc.Stdin = stdin
 	}
 }
 
 func WithRepoDir(repoDir string) CommandModifier {
-	return func(gc *gitCommand) {
-		gc.SetRepoDir(repoDir)
+	return func(gc *Command) {
+		gc.setRepoDir(repoDir)
 	}
 }

--- a/git/command.go
+++ b/git/command.go
@@ -53,7 +53,7 @@ func (gc *gitCommand) Output() ([]byte, error) {
 	return out, err
 }
 
-func (gc *gitCommand) setRepoDir(repoDir string) {
+func (gc *gitCommand) SetRepoDir(repoDir string) {
 	for i, arg := range gc.Args {
 		if arg == "-C" {
 			gc.Args[i+1] = repoDir
@@ -95,6 +95,6 @@ func WithStdin(stdin io.Reader) CommandModifier {
 
 func WithRepoDir(repoDir string) CommandModifier {
 	return func(gc *gitCommand) {
-		gc.setRepoDir(repoDir)
+		gc.SetRepoDir(repoDir)
 	}
 }

--- a/pkg/cmd/extension/git.go
+++ b/pkg/cmd/extension/git.go
@@ -1,0 +1,56 @@
+package extension
+
+import (
+	"context"
+
+	"github.com/cli/cli/v2/git"
+)
+
+type gitClient interface {
+	CheckoutBranch(branch string, mods ...git.CommandModifier) error
+	Clone(cloneURL string, args []string, mods ...git.CommandModifier) (string, error)
+	CommandOutput(args []string, mods ...git.CommandModifier) ([]byte, error)
+	Config(name string, mods ...git.CommandModifier) (string, error)
+	Fetch(remote string, refspec string, mods ...git.CommandModifier) error
+	Pull(remote, branch string, mods ...git.CommandModifier) error
+	Remotes(mods ...git.CommandModifier) (git.RemoteSet, error)
+}
+
+type gitExecuter struct {
+	client *git.Client
+}
+
+func (g *gitExecuter) CheckoutBranch(branch string, mods ...git.CommandModifier) error {
+	return g.client.CheckoutBranch(context.Background(), branch, mods...)
+}
+
+func (g *gitExecuter) Clone(cloneURL string, cloneArgs []string, mods ...git.CommandModifier) (string, error) {
+	return g.client.Clone(context.Background(), cloneURL, cloneArgs, mods...)
+}
+
+func (g *gitExecuter) CommandOutput(args []string, mods ...git.CommandModifier) ([]byte, error) {
+	cmd, err := g.client.Command(context.Background(), args...)
+	if err != nil {
+		return nil, err
+	}
+	for _, mod := range mods {
+		mod(cmd)
+	}
+	return cmd.Output()
+}
+
+func (g *gitExecuter) Config(name string, mods ...git.CommandModifier) (string, error) {
+	return g.client.Config(context.Background(), name, mods...)
+}
+
+func (g *gitExecuter) Fetch(remote string, refspec string, mods ...git.CommandModifier) error {
+	return g.client.Fetch(context.Background(), remote, refspec, mods...)
+}
+
+func (g *gitExecuter) Pull(remote, branch string, mods ...git.CommandModifier) error {
+	return g.client.Pull(context.Background(), remote, branch, mods...)
+}
+
+func (g *gitExecuter) Remotes(mods ...git.CommandModifier) (git.RemoteSet, error) {
+	return g.client.Remotes(context.Background(), mods...)
+}

--- a/pkg/cmd/extension/git.go
+++ b/pkg/cmd/extension/git.go
@@ -7,50 +7,61 @@ import (
 )
 
 type gitClient interface {
-	CheckoutBranch(branch string, mods ...git.CommandModifier) error
-	Clone(cloneURL string, args []string, mods ...git.CommandModifier) (string, error)
-	CommandOutput(args []string, mods ...git.CommandModifier) ([]byte, error)
-	Config(name string, mods ...git.CommandModifier) (string, error)
-	Fetch(remote string, refspec string, mods ...git.CommandModifier) error
-	Pull(remote, branch string, mods ...git.CommandModifier) error
-	Remotes(mods ...git.CommandModifier) (git.RemoteSet, error)
+	CheckoutBranch(branch string) error
+	Clone(cloneURL string, args []string) (string, error)
+	CommandOutput(args []string) ([]byte, error)
+	Config(name string) (string, error)
+	Fetch(remote string, refspec string) error
+	ForRepo(repoDir string) gitClient
+	Pull(remote, branch string) error
+	Remotes() (git.RemoteSet, error)
 }
 
 type gitExecuter struct {
 	client *git.Client
 }
 
-func (g *gitExecuter) CheckoutBranch(branch string, mods ...git.CommandModifier) error {
-	return g.client.CheckoutBranch(context.Background(), branch, mods...)
+func (g *gitExecuter) CheckoutBranch(branch string) error {
+	return g.client.CheckoutBranch(context.Background(), branch)
 }
 
-func (g *gitExecuter) Clone(cloneURL string, cloneArgs []string, mods ...git.CommandModifier) (string, error) {
-	return g.client.Clone(context.Background(), cloneURL, cloneArgs, mods...)
+func (g *gitExecuter) Clone(cloneURL string, cloneArgs []string) (string, error) {
+	return g.client.Clone(context.Background(), cloneURL, cloneArgs)
 }
 
-func (g *gitExecuter) CommandOutput(args []string, mods ...git.CommandModifier) ([]byte, error) {
+func (g *gitExecuter) CommandOutput(args []string) ([]byte, error) {
 	cmd, err := g.client.Command(context.Background(), args...)
 	if err != nil {
 		return nil, err
 	}
-	for _, mod := range mods {
-		mod(cmd)
-	}
 	return cmd.Output()
 }
 
-func (g *gitExecuter) Config(name string, mods ...git.CommandModifier) (string, error) {
-	return g.client.Config(context.Background(), name, mods...)
+func (g *gitExecuter) Config(name string) (string, error) {
+	return g.client.Config(context.Background(), name)
 }
 
-func (g *gitExecuter) Fetch(remote string, refspec string, mods ...git.CommandModifier) error {
-	return g.client.Fetch(context.Background(), remote, refspec, mods...)
+func (g *gitExecuter) Fetch(remote string, refspec string) error {
+	return g.client.Fetch(context.Background(), remote, refspec)
 }
 
-func (g *gitExecuter) Pull(remote, branch string, mods ...git.CommandModifier) error {
-	return g.client.Pull(context.Background(), remote, branch, mods...)
+func (g *gitExecuter) ForRepo(repoDir string) gitClient {
+	return &gitExecuter{
+		client: &git.Client{
+			GhPath:  g.client.GhPath,
+			RepoDir: repoDir,
+			GitPath: g.client.GitPath,
+			Stderr:  g.client.Stderr,
+			Stdin:   g.client.Stdin,
+			Stdout:  g.client.Stdout,
+		},
+	}
 }
 
-func (g *gitExecuter) Remotes(mods ...git.CommandModifier) (git.RemoteSet, error) {
-	return g.client.Remotes(context.Background(), mods...)
+func (g *gitExecuter) Pull(remote, branch string) error {
+	return g.client.Pull(context.Background(), remote, branch)
+}
+
+func (g *gitExecuter) Remotes() (git.RemoteSet, error) {
+	return g.client.Remotes(context.Background())
 }

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -40,7 +40,7 @@ type Manager struct {
 	dryRunMode bool
 }
 
-func NewManager(ios *iostreams.IOStreams) *Manager {
+func NewManager(ios *iostreams.IOStreams, gc *git.Client) *Manager {
 	return &Manager{
 		dataDir:    config.DataDir,
 		lookPath:   safeexec.LookPath,
@@ -53,7 +53,8 @@ func NewManager(ios *iostreams.IOStreams) *Manager {
 			}
 			return fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH), ext
 		},
-		io: ios,
+		io:        ios,
+		gitClient: &gitExecuter{client: gc},
 	}
 }
 
@@ -63,10 +64,6 @@ func (m *Manager) SetConfig(cfg config.Config) {
 
 func (m *Manager) SetClient(client *http.Client) {
 	m.client = client
-}
-
-func (m *Manager) SetGitClient(gitClient *git.Client) {
-	m.gitClient = &gitExecuter{client: gitClient}
 }
 
 func (m *Manager) EnableDryRunMode() {

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -565,7 +565,7 @@ func TestManager_UpgradeExtension_BinaryExtension_Pinned_Force(t *testing.T) {
 		}))
 
 	ios, _, stdout, stderr := iostreams.Test()
-	m := newTestManager(tempDir, &http.Client{Transport: &reg}, ios)
+	m := newTestManager(tempDir, &http.Client{Transport: &reg}, nil, ios)
 	reg.Register(
 		httpmock.REST("GET", "api/v3/repos/owner/gh-bin-ext/releases/latest"),
 		httpmock.JSONResponse(

--- a/pkg/cmd/extension/mocks.go
+++ b/pkg/cmd/extension/mocks.go
@@ -1,8 +1,6 @@
 package extension
 
 import (
-	"os/exec"
-
 	"github.com/cli/cli/v2/git"
 	"github.com/stretchr/testify/mock"
 )
@@ -11,47 +9,45 @@ type mockGitClient struct {
 	mock.Mock
 }
 
-func (g *mockGitClient) CheckoutBranch(branch string, mods ...git.CommandModifier) error {
-	args := g.Called(branch, extractRepoDir(mods))
+func (g *mockGitClient) CheckoutBranch(branch string) error {
+	args := g.Called(branch)
 	return args.Error(0)
 }
 
-func (g *mockGitClient) Clone(cloneURL string, cloneArgs []string, mods ...git.CommandModifier) (string, error) {
-	args := g.Called(cloneURL, cloneArgs, extractRepoDir(mods))
+func (g *mockGitClient) Clone(cloneURL string, cloneArgs []string) (string, error) {
+	args := g.Called(cloneURL, cloneArgs)
 	return args.String(0), args.Error(1)
 }
 
-func (g *mockGitClient) CommandOutput(commandArgs []string, mods ...git.CommandModifier) ([]byte, error) {
-	args := g.Called(commandArgs, extractRepoDir(mods))
+func (g *mockGitClient) CommandOutput(commandArgs []string) ([]byte, error) {
+	args := g.Called(commandArgs)
 	return []byte(args.String(0)), args.Error(1)
 }
 
-func (g *mockGitClient) Config(name string, mods ...git.CommandModifier) (string, error) {
-	args := g.Called(name, extractRepoDir(mods))
+func (g *mockGitClient) Config(name string) (string, error) {
+	args := g.Called(name)
 	return args.String(0), args.Error(1)
 }
 
-func (g *mockGitClient) Fetch(remote string, refspec string, mods ...git.CommandModifier) error {
-	args := g.Called(remote, refspec, extractRepoDir(mods))
+func (g *mockGitClient) Fetch(remote string, refspec string) error {
+	args := g.Called(remote, refspec)
 	return args.Error(0)
 }
 
-func (g *mockGitClient) Pull(remote, branch string, mods ...git.CommandModifier) error {
-	args := g.Called(remote, branch, extractRepoDir(mods))
-	return args.Error(0)
-}
-
-func (g *mockGitClient) Remotes(mods ...git.CommandModifier) (git.RemoteSet, error) {
-	args := g.Called(extractRepoDir(mods))
-	return nil, args.Error(1)
-}
-
-func extractRepoDir(mods []git.CommandModifier) string {
-	if len(mods) == 0 || len(mods) > 1 {
-		return ""
+func (g *mockGitClient) ForRepo(repoDir string) gitClient {
+	args := g.Called(repoDir)
+	if v, ok := args.Get(0).(*mockGitClient); ok {
+		return v
 	}
-	mod := mods[0]
-	gitCmd := &git.Command{Cmd: &exec.Cmd{Args: []string{"-C", ""}}}
-	mod(gitCmd)
-	return gitCmd.Args[1]
+	return nil
+}
+
+func (g *mockGitClient) Pull(remote, branch string) error {
+	args := g.Called(remote, branch)
+	return args.Error(0)
+}
+
+func (g *mockGitClient) Remotes() (git.RemoteSet, error) {
+	args := g.Called()
+	return nil, args.Error(1)
 }

--- a/pkg/cmd/extension/mocks.go
+++ b/pkg/cmd/extension/mocks.go
@@ -1,0 +1,57 @@
+package extension
+
+import (
+	"os/exec"
+
+	"github.com/cli/cli/v2/git"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockGitClient struct {
+	mock.Mock
+}
+
+func (g *mockGitClient) CheckoutBranch(branch string, mods ...git.CommandModifier) error {
+	args := g.Called(branch, extractRepoDir(mods))
+	return args.Error(0)
+}
+
+func (g *mockGitClient) Clone(cloneURL string, cloneArgs []string, mods ...git.CommandModifier) (string, error) {
+	args := g.Called(cloneURL, cloneArgs, extractRepoDir(mods))
+	return args.String(0), args.Error(1)
+}
+
+func (g *mockGitClient) CommandOutput(commandArgs []string, mods ...git.CommandModifier) ([]byte, error) {
+	args := g.Called(commandArgs, extractRepoDir(mods))
+	return []byte(args.String(0)), args.Error(1)
+}
+
+func (g *mockGitClient) Config(name string, mods ...git.CommandModifier) (string, error) {
+	args := g.Called(name, extractRepoDir(mods))
+	return args.String(0), args.Error(1)
+}
+
+func (g *mockGitClient) Fetch(remote string, refspec string, mods ...git.CommandModifier) error {
+	args := g.Called(remote, refspec, extractRepoDir(mods))
+	return args.Error(0)
+}
+
+func (g *mockGitClient) Pull(remote, branch string, mods ...git.CommandModifier) error {
+	args := g.Called(remote, branch, extractRepoDir(mods))
+	return args.Error(0)
+}
+
+func (g *mockGitClient) Remotes(mods ...git.CommandModifier) (git.RemoteSet, error) {
+	args := g.Called(extractRepoDir(mods))
+	return nil, args.Error(1)
+}
+
+func extractRepoDir(mods []git.CommandModifier) string {
+	if len(mods) == 0 || len(mods) > 1 {
+		return ""
+	}
+	mod := mods[0]
+	gitCmd := &git.Command{Cmd: &exec.Cmd{Args: []string{"-C", ""}}}
+	mod(gitCmd)
+	return gitCmd.Args[1]
+}

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -158,6 +158,8 @@ func branchFunc(f *cmdutil.Factory) func() (string, error) {
 func extensionManager(f *cmdutil.Factory) *extension.Manager {
 	em := extension.NewManager(f.IOStreams)
 
+	em.SetGitClient(f.GitClient)
+
 	cfg, err := f.Config()
 	if err != nil {
 		return em

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -156,9 +156,7 @@ func branchFunc(f *cmdutil.Factory) func() (string, error) {
 }
 
 func extensionManager(f *cmdutil.Factory) *extension.Manager {
-	em := extension.NewManager(f.IOStreams)
-
-	em.SetGitClient(f.GitClient)
+	em := extension.NewManager(f.IOStreams, f.GitClient)
 
 	cfg, err := f.Config()
 	if err != nil {


### PR DESCRIPTION
This PR changes the `ExtensionManager` to utilize the new `git.Client`. It required a bit of refactoring, mostly creating a `gitClient` interface for just the `ExtensionManager` to use, in order to make everything testable. Overall functionality of `ExtensionManager` should not change at all.