### PR TITLE
Fix `repo list` when belonging to org with IP Allow list enabled

### DIFF
--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -80,7 +80,7 @@ func listRepos(client *http.Client, hostname string, limit int, owner string, fi
 	query := fmt.Sprintf(`query RepositoryList(%s) {
 		%s {
 			login
-			repositories(first: $perPage, after: $endCursor, privacy: $privacy, isFork: $fork, ownerAffiliations: OWNER, orderBy: { field: PUSHED_AT, direction: DESC }) {
+			repositories(first: $perPage, after: $endCursor, privacy: $privacy, isFork: $fork, affiliations: OWNER, orderBy: { field: PUSHED_AT, direction: DESC }) {
 				nodes{%s}
 				totalCount
 				pageInfo{hasNextPage,endCursor}


### PR DESCRIPTION
Using `ownerAffiliations` instead of `affiliations` seems more semantically correct to list all repos belonging to a user or an organization, but the latter has an added benefit of avoiding a problem when the API would return an error if the user happens to belong to an organization that has IP allow list enabled.

> GraphQL: Although you appear to have the correct authorization credentials, the \<ORG> organization has an IP allow list enabled, and \<IP> is not permitted to access this resource. (repositoryOwner.repositories.nodes.0)

From our GraphQL docs:

- `affiliations`: Array of viewer's affiliation options for repositories returned from the connection. For example, OWNER will include only repositories that the current viewer owns.

- `ownerAffiliations`: Array of owner's affiliation options for repositories returned from the connection. For example, OWNER will include only repositories that the organization or user being viewed owns.

Fixes https://github.com/github/repos/issues/3706