### PR TITLE
Normalize time-zone headers in tests

### DIFF
--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -182,6 +182,7 @@ func TestNewHTTPClient(t *testing.T) {
 			require.NoError(t, err)
 
 			req, err := http.NewRequest("GET", ts.URL, nil)
+			req.Header.Set("time-zone", "Europe/Amsterdam")
 			req.Host = tt.host
 			require.NoError(t, err)
 


### PR DESCRIPTION
Setting a static time zone guards from test failures when the local time zone could not be detected.

Fixes https://github.com/cli/cli/issues/6479