### PR TITLE
Fix setting up git credential helper on Windows

### DIFF
--- a/pkg/cmd/auth/shared/git_credential.go
+++ b/pkg/cmd/auth/shared/git_credential.go
@@ -180,7 +180,7 @@ func isGitMissing(err error) bool {
 }
 
 func shellQuote(s string) string {
-	if strings.ContainsAny(s, " $") {
+	if strings.ContainsAny(s, " $\\") {
 		return "'" + s + "'"
 	}
 	return s


### PR DESCRIPTION
This fixes setting up the HTTPS git credential helper for `gh.exe` paths that contain backslashes (basically, any path on Windows).

Before:
```gitconfig
helper = !C:\\Path\to\gh.exe auth git-credential
```
The above looked correct to me but fails when git is trying to authenticate due to backslashes being interpreted as escapes (even though they are escaped themselves).

After:
```gitconfig
helper = !'C:\\Path\to\gh.exe' auth git-credential
```

If someone installed using the official GitHub CLI installer, this bug wouldn't affect them because the default installation path is under `C:\Program Files`, which contains a space and would thus get quoted anyway.