### PR TITLE
Migrate to Cobra's built-in MutuallyExclusive flag helper

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -185,23 +185,6 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 				return cmdutil.FlagErrorf("the `--paginate` option is not supported for non-GET requests")
 			}
 
-			if err := cmdutil.MutuallyExclusive(
-				"the `--paginate` option is not supported with `--input`",
-				opts.Paginate,
-				opts.RequestInputFile != "",
-			); err != nil {
-				return err
-			}
-
-			if err := cmdutil.MutuallyExclusive(
-				"only one of `--template`, `--jq`, or `--silent` may be used",
-				opts.Silent,
-				opts.FilterOutput != "",
-				opts.Template != "",
-			); err != nil {
-				return err
-			}
-
 			if runF != nil {
 				return runF(&opts)
 			}
@@ -222,6 +205,10 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 	cmd.Flags().StringVarP(&opts.Template, "template", "t", "", "Format JSON output using a Go template; see \"gh help formatting\"")
 	cmd.Flags().StringVarP(&opts.FilterOutput, "jq", "q", "", "Query to select values from the response using jq syntax")
 	cmd.Flags().DurationVar(&opts.CacheTTL, "cache", 0, "Cache the response, e.g. \"3600s\", \"60m\", \"1h\"")
+
+	cmd.MarkFlagsMutuallyExclusive("paginate", "input")
+	cmd.MarkFlagsMutuallyExclusive("template", "jq", "silent")
+
 	return cmd
 }
 

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -76,13 +76,6 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			$ gh auth login --hostname enterprise.internal
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if tokenStdin && opts.Web {
-				return cmdutil.FlagErrorf("specify only one of `--web` or `--with-token`")
-			}
-			if tokenStdin && len(opts.Scopes) > 0 {
-				return cmdutil.FlagErrorf("specify only one of `--scopes` or `--with-token`")
-			}
-
 			if tokenStdin {
 				defer opts.IO.In.Close()
 				token, err := io.ReadAll(opts.IO.In)
@@ -120,6 +113,9 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 	cmd.Flags().BoolVar(&tokenStdin, "with-token", false, "Read token from standard input")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open a browser to authenticate")
 	cmdutil.StringEnumFlag(cmd, &opts.GitProtocol, "git-protocol", "p", "", []string{"ssh", "https"}, "The protocol to use for git operations")
+
+	cmd.MarkFlagsMutuallyExclusive("scopes", "with-token")
+	cmd.MarkFlagsMutuallyExclusive("web", "with-token")
 
 	return cmd
 }

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -93,16 +93,6 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 				opts.SelectorArg = args[0]
 			}
 
-			if err := cmdutil.MutuallyExclusive(
-				"specify only one of `--branch`, `--commit`, `--projects`, `--wiki`, or `--settings`",
-				opts.Branch != "",
-				opts.CommitFlag,
-				opts.WikiFlag,
-				opts.SettingsFlag,
-				opts.ProjectsFlag,
-			); err != nil {
-				return err
-			}
 			if cmd.Flags().Changed("repo") {
 				opts.GitClient = &remoteGitClient{opts.BaseRepo, opts.HttpClient}
 			}
@@ -121,6 +111,8 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 	cmd.Flags().BoolVarP(&opts.NoBrowserFlag, "no-browser", "n", false, "Print destination URL instead of opening the browser")
 	cmd.Flags().BoolVarP(&opts.CommitFlag, "commit", "c", false, "Open the last commit")
 	cmd.Flags().StringVarP(&opts.Branch, "branch", "b", "", "Select another branch by passing in the branch name")
+
+	cmd.MarkFlagsMutuallyExclusive("branch", "commit", "projects", "wiki", "settings")
 
 	return cmd
 }

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -54,9 +54,6 @@ func newDeleteCmd(app *App) *cobra.Command {
 		`),
 		Args: noArgsConstraint,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if opts.deleteAll && opts.repoFilter != "" {
-				return cmdutil.FlagErrorf("both `--all` and `--repo` is not supported")
-			}
 			if opts.orgName != "" && opts.codespaceName != "" && opts.userName == "" {
 				return cmdutil.FlagErrorf("using `--org` with `--codespace` requires `--user`")
 			}
@@ -71,6 +68,8 @@ func newDeleteCmd(app *App) *cobra.Command {
 	deleteCmd.Flags().Uint16Var(&opts.keepDays, "days", 0, "Delete codespaces older than `N` days")
 	deleteCmd.Flags().StringVarP(&opts.orgName, "org", "o", "", "The `login` handle of the organization (admin-only)")
 	deleteCmd.Flags().StringVarP(&opts.userName, "user", "u", "", "The `username` to delete codespaces for (used with --org)")
+
+	deleteCmd.MarkFlagsMutuallyExclusive("all", "repo")
 
 	return deleteCmd
 }

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -65,13 +65,6 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			bodyProvided := flags.Changed("body")
 			bodyFileProvided := bodyFile != ""
 
-			if err := cmdutil.MutuallyExclusive(
-				"specify only one of `--body` or `--body-file`",
-				bodyProvided,
-				bodyFileProvided,
-			); err != nil {
-				return err
-			}
 			if bodyProvided || bodyFileProvided {
 				opts.Editable.Body.Edited = true
 				if bodyFileProvided {
@@ -125,6 +118,8 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd.Flags().StringSliceVar(&opts.Editable.Projects.Add, "add-project", nil, "Add the issue to projects by `name`")
 	cmd.Flags().StringSliceVar(&opts.Editable.Projects.Remove, "remove-project", nil, "Remove the issue from projects by `name`")
 	cmd.Flags().StringVarP(&opts.Editable.Milestone.Value, "milestone", "m", "", "Edit the milestone the issue belongs to by `name`")
+
+	cmd.MarkFlagsMutuallyExclusive("body", "body-file")
 
 	return cmd
 }

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -82,10 +82,6 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 				return cmdutil.FlagErrorf("invalid limit: %v", opts.LimitResults)
 			}
 
-			if cmd.Flags().Changed("author") && cmd.Flags().Changed("app") {
-				return cmdutil.FlagErrorf("specify only `--author` or `--app`")
-			}
-
 			if cmd.Flags().Changed("app") {
 				opts.Author = fmt.Sprintf("app/%s", appAuthor)
 			}
@@ -108,6 +104,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter by milestone number or title")
 	cmd.Flags().StringVarP(&opts.Search, "search", "S", "", "Search issues with `query`")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.IssueFields)
+
+	cmd.MarkFlagsMutuallyExclusive("author", "app")
 
 	return cmd
 }

--- a/pkg/cmd/label/list.go
+++ b/pkg/cmd/label/list.go
@@ -58,11 +58,6 @@ func newCmdList(f *cmdutil.Factory, runF func(*listOptions) error) *cobra.Comman
 				return cmdutil.FlagErrorf("invalid limit: %v", opts.Query.Limit)
 			}
 
-			if opts.Query.Query != "" &&
-				(c.Flags().Changed("order") || c.Flags().Changed("sort")) {
-				return cmdutil.FlagErrorf("cannot specify `--order` or `--sort` with `--search`")
-			}
-
 			if runF != nil {
 				return runF(&opts)
 			}
@@ -75,6 +70,9 @@ func newCmdList(f *cmdutil.Factory, runF func(*listOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.Query.Query, "search", "S", "", "Search label names and descriptions")
 	cmdutil.StringEnumFlag(cmd, &opts.Query.Order, "order", "", defaultOrder, []string{"asc", "desc"}, "Order of labels returned")
 	cmdutil.StringEnumFlag(cmd, &opts.Query.Sort, "sort", "", defaultSort, []string{"created", "name"}, "Sort fetched labels")
+
+	cmd.MarkFlagsMutuallyExclusive("order", "search")
+	cmd.MarkFlagsMutuallyExclusive("sort", "search")
 
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, labelFields)
 

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -137,16 +137,6 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("`--recover` only supported when running interactively")
 			}
 
-			if opts.IsDraft && opts.WebMode {
-				return errors.New("the `--draft` flag is not supported with `--web`")
-			}
-			if len(opts.Reviewers) > 0 && opts.WebMode {
-				return errors.New("the `--reviewer` flag is not supported with `--web`")
-			}
-			if cmd.Flags().Changed("no-maintainer-edit") && opts.WebMode {
-				return errors.New("the `--no-maintainer-edit` flag is not supported with `--web`")
-			}
-
 			opts.BodyProvided = cmd.Flags().Changed("body")
 			if bodyFile != "" {
 				b, err := cmdutil.ReadFile(bodyFile, opts.IO.In)
@@ -184,6 +174,10 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	fl.StringVarP(&opts.Milestone, "milestone", "m", "", "Add the pull request to a milestone by `name`")
 	fl.Bool("no-maintainer-edit", false, "Disable maintainer's ability to modify pull request")
 	fl.StringVar(&opts.RecoverFile, "recover", "", "Recover input from a failed run of create")
+
+	cmd.MarkFlagsMutuallyExclusive("draft", "web")
+	cmd.MarkFlagsMutuallyExclusive("reviewer", "web")
+	cmd.MarkFlagsMutuallyExclusive("no-maintainer-edit", "web")
 
 	return cmd
 }

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -72,13 +72,6 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			bodyProvided := flags.Changed("body")
 			bodyFileProvided := bodyFile != ""
 
-			if err := cmdutil.MutuallyExclusive(
-				"specify only one of `--body` or `--body-file`",
-				bodyProvided,
-				bodyFileProvided,
-			); err != nil {
-				return err
-			}
 			if bodyProvided || bodyFileProvided {
 				opts.Editable.Body.Edited = true
 				if bodyFileProvided {
@@ -144,6 +137,8 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd.Flags().StringSliceVar(&opts.Editable.Projects.Add, "add-project", nil, "Add the pull request to projects by `name`")
 	cmd.Flags().StringSliceVar(&opts.Editable.Projects.Remove, "remove-project", nil, "Remove the pull request from projects by `name`")
 	cmd.Flags().StringVarP(&opts.Editable.Milestone.Value, "milestone", "m", "", "Edit the milestone the pull request belongs to by `name`")
+
+	cmd.MarkFlagsMutuallyExclusive("body", "body-file")
 
 	return cmd
 }

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -83,10 +83,6 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 				return cmdutil.FlagErrorf("invalid value for --limit: %v", opts.LimitResults)
 			}
 
-			if cmd.Flags().Changed("author") && cmd.Flags().Changed("app") {
-				return cmdutil.FlagErrorf("specify only `--author` or `--app`")
-			}
-
 			if cmd.Flags().Changed("app") {
 				opts.Author = fmt.Sprintf("app/%s", appAuthor)
 			}
@@ -111,6 +107,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmdutil.NilBoolFlag(cmd, &opts.Draft, "draft", "d", "Filter by draft state")
 
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.PullRequestFields)
+
+	cmd.MarkFlagsMutuallyExclusive("author", "app")
 
 	return cmd
 }

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -126,23 +126,6 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 			bodyProvided := cmd.Flags().Changed("body")
 			bodyFileProvided := bodyFile != ""
 
-			if err := cmdutil.MutuallyExclusive(
-				"specify only one of `--auto`, `--disable-auto`, or `--admin`",
-				opts.AutoMergeEnable,
-				opts.AutoMergeDisable,
-				opts.UseAdmin,
-			); err != nil {
-				return err
-			}
-
-			if err := cmdutil.MutuallyExclusive(
-				"specify only one of `--body` or `--body-file`",
-				bodyProvided,
-				bodyFileProvided,
-			); err != nil {
-				return err
-			}
-
 			if bodyProvided || bodyFileProvided {
 				opts.BodySet = true
 				if bodyFileProvided {
@@ -183,6 +166,10 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 	cmd.Flags().BoolVar(&opts.AutoMergeDisable, "disable-auto", false, "Disable auto-merge for this pull request")
 	cmd.Flags().StringVar(&opts.MatchHeadCommit, "match-head-commit", "", "Commit `SHA` that the pull request head must match to allow merge")
 	cmd.Flags().StringVarP(&opts.AuthorEmail, "author-email", "A", "", "Email `text` for merge commit author")
+
+	cmd.MarkFlagsMutuallyExclusive("auto", "disable-auto", "admin")
+	cmd.MarkFlagsMutuallyExclusive("body", "body-file")
+
 	return cmd
 }
 

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -44,9 +44,9 @@ func TestNewCmdCreate(t *testing.T) {
 			name: "new repo from remote",
 			cli:  "NEWREPO --public --clone",
 			wantsOpts: CreateOptions{
-				Name:   "NEWREPO",
-				Public: true,
-				Clone:  true},
+				Name:       "NEWREPO",
+				Visibility: "PUBLIC",
+				Clone:      true},
 		},
 		{
 			name:     "no visibility",
@@ -66,25 +66,25 @@ func TestNewCmdCreate(t *testing.T) {
 			name: "new remote from local",
 			cli:  "--source=/path/to/repo --private",
 			wantsOpts: CreateOptions{
-				Private: true,
-				Source:  "/path/to/repo"},
+				Visibility: "PRIVATE",
+				Source:     "/path/to/repo"},
 		},
 		{
 			name: "new remote from local with remote",
 			cli:  "--source=/path/to/repo --public --remote upstream",
 			wantsOpts: CreateOptions{
-				Public: true,
-				Source: "/path/to/repo",
-				Remote: "upstream",
+				Visibility: "PUBLIC",
+				Source:     "/path/to/repo",
+				Remote:     "upstream",
 			},
 		},
 		{
 			name: "new remote from local with push",
 			cli:  "--source=/path/to/repo --push --public",
 			wantsOpts: CreateOptions{
-				Public: true,
-				Source: "/path/to/repo",
-				Push:   true,
+				Visibility: "PUBLIC",
+				Source:     "/path/to/repo",
+				Push:       true,
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestNewCmdCreate(t *testing.T) {
 			cli:  "template-repo --template https://github.com/OWNER/REPO --public --include-all-branches",
 			wantsOpts: CreateOptions{
 				Name:               "template-repo",
-				Public:             true,
+				Visibility:         "PUBLIC",
 				Template:           "https://github.com/OWNER/REPO",
 				IncludeAllBranches: true,
 			},
@@ -163,9 +163,7 @@ func TestNewCmdCreate(t *testing.T) {
 			assert.Equal(t, tt.wantsOpts.Interactive, opts.Interactive)
 			assert.Equal(t, tt.wantsOpts.Source, opts.Source)
 			assert.Equal(t, tt.wantsOpts.Name, opts.Name)
-			assert.Equal(t, tt.wantsOpts.Public, opts.Public)
-			assert.Equal(t, tt.wantsOpts.Internal, opts.Internal)
-			assert.Equal(t, tt.wantsOpts.Private, opts.Private)
+			assert.Equal(t, tt.wantsOpts.Visibility, opts.Visibility)
 			assert.Equal(t, tt.wantsOpts.Clone, opts.Clone)
 		})
 	}

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -61,16 +61,6 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 				return cmdutil.FlagErrorf("invalid limit: %v", opts.Limit)
 			}
 
-			if err := cmdutil.MutuallyExclusive("specify only one of `--public`, `--private`, or `--visibility`", flagPublic, flagPrivate, opts.Visibility != ""); err != nil {
-				return err
-			}
-			if opts.Source && opts.Fork {
-				return cmdutil.FlagErrorf("specify only one of `--source` or `--fork`")
-			}
-			if opts.Archived && opts.NonArchived {
-				return cmdutil.FlagErrorf("specify only one of `--archived` or `--no-archived`")
-			}
-
 			if flagPrivate {
 				opts.Visibility = "private"
 			} else if flagPublic {
@@ -102,6 +92,10 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().BoolVar(&flagPublic, "public", false, "Show only public repositories")
 	_ = cmd.Flags().MarkDeprecated("public", "use `--visibility=public` instead")
 	_ = cmd.Flags().MarkDeprecated("private", "use `--visibility=private` instead")
+
+	cmd.MarkFlagsMutuallyExclusive("public", "private", "visibility")
+	cmd.MarkFlagsMutuallyExclusive("source", "fork")
+	cmd.MarkFlagsMutuallyExclusive("archived", "no-archived")
 
 	return cmd
 }

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -132,14 +132,6 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 				}
 			}
 
-			if opts.Web && opts.Log {
-				return cmdutil.FlagErrorf("specify only one of --web or --log")
-			}
-
-			if opts.Log && opts.LogFailed {
-				return cmdutil.FlagErrorf("specify only one of --log or --log-failed")
-			}
-
 			if runF != nil {
 				return runF(opts)
 			}
@@ -154,6 +146,8 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	cmd.Flags().BoolVar(&opts.LogFailed, "log-failed", false, "View the log for any failed steps in a run or specific job")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open run in the browser")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, shared.SingleRunFields)
+
+	cmd.MarkFlagsMutuallyExclusive("web", "log", "log-failed")
 
 	return cmd
 }

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -61,9 +61,6 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 			if opts.Query.Limit < 1 || opts.Query.Limit > shared.SearchMaxResults {
 				return cmdutil.FlagErrorf("`--limit` must be between 1 and 1000")
 			}
-			if c.Flags().Changed("author") && c.Flags().Changed("app") {
-				return cmdutil.FlagErrorf("specify only `--author` or `--app`")
-			}
 			if c.Flags().Changed("app") {
 				opts.Query.Qualifiers.Author = fmt.Sprintf("app/%s", appAuthor)
 			}
@@ -161,6 +158,8 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Team, "team-mentions", "", "Filter based on team mentions")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Updated, "updated", "", "Filter on last updated at `date`")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.User, "owner", "", "Filter on repository owner")
+
+	cmd.MarkFlagsMutuallyExclusive("author", "app")
 
 	return cmd
 }

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -63,9 +63,6 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 			if opts.Query.Limit < 1 || opts.Query.Limit > shared.SearchMaxResults {
 				return cmdutil.FlagErrorf("`--limit` must be between 1 and 1000")
 			}
-			if c.Flags().Changed("author") && c.Flags().Changed("app") {
-				return cmdutil.FlagErrorf("specify only `--author` or `--app`")
-			}
 			if c.Flags().Changed("app") {
 				opts.Query.Qualifiers.Author = fmt.Sprintf("app/%s", appAuthor)
 			}
@@ -183,6 +180,8 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 	cmd.Flags().StringVar(&requestedReviewer, "review-requested", "", "Filter on `user` or team requested to review")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.ReviewedBy, "reviewed-by", "", "Filter on `user` who reviewed")
 	cmdutil.StringEnumFlag(cmd, &opts.Query.Qualifiers.Status, "checks", "", "", []string{"pending", "success", "failure"}, "Filter based on status of the checks")
+
+	cmd.MarkFlagsMutuallyExclusive("author", "app")
 
 	return cmd
 }

--- a/pkg/cmd/secret/delete/delete.go
+++ b/pkg/cmd/secret/delete/delete.go
@@ -49,10 +49,6 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo
 
-			if err := cmdutil.MutuallyExclusive("specify only one of `--org`, `--env`, or `--user`", opts.OrgName != "", opts.EnvName != "", opts.UserSecrets); err != nil {
-				return err
-			}
-
 			opts.SecretName = args[0]
 
 			if runF != nil {
@@ -69,6 +65,8 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Delete a secret for an environment")
 	cmd.Flags().BoolVarP(&opts.UserSecrets, "user", "u", false, "Delete a secret for your user")
 	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", "", []string{shared.Actions, shared.Codespaces, shared.Dependabot}, "Delete a secret for a specific application")
+
+	cmd.MarkFlagsMutuallyExclusive("org", "env", "user")
 
 	return cmd
 }

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -55,10 +55,6 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo
 
-			if err := cmdutil.MutuallyExclusive("specify only one of `--org`, `--env`, or `--user`", opts.OrgName != "", opts.EnvName != "", opts.UserSecrets); err != nil {
-				return err
-			}
-
 			if runF != nil {
 				return runF(opts)
 			}
@@ -71,6 +67,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "List secrets for an environment")
 	cmd.Flags().BoolVarP(&opts.UserSecrets, "user", "u", false, "List a secret for your user")
 	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", "", []string{shared.Actions, shared.Codespaces, shared.Dependabot}, "List secrets for a specific application")
+
+	cmd.MarkFlagsMutuallyExclusive("org", "env", "user")
 
 	return cmd
 }

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -99,18 +99,6 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo
 
-			if err := cmdutil.MutuallyExclusive("specify only one of `--org`, `--env`, or `--user`", opts.OrgName != "", opts.EnvName != "", opts.UserSecrets); err != nil {
-				return err
-			}
-
-			if err := cmdutil.MutuallyExclusive("specify only one of `--body` or `--env-file`", opts.Body != "", opts.EnvFile != ""); err != nil {
-				return err
-			}
-
-			if err := cmdutil.MutuallyExclusive("specify only one of `--env-file` or `--no-store`", opts.EnvFile != "", opts.DoNotStore); err != nil {
-				return err
-			}
-
 			if len(args) == 0 {
 				if !opts.DoNotStore && opts.EnvFile == "" {
 					return cmdutil.FlagErrorf("must pass name argument")
@@ -154,6 +142,10 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 	cmd.Flags().BoolVar(&opts.DoNotStore, "no-store", false, "Print the encrypted, base64-encoded value instead of storing it on Github")
 	cmd.Flags().StringVarP(&opts.EnvFile, "env-file", "f", "", "Load secret names and values from a dotenv-formatted `file`")
 	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", "", []string{shared.Actions, shared.Codespaces, shared.Dependabot}, "Set the application for a secret")
+
+	cmd.MarkFlagsMutuallyExclusive("org", "env", "user")
+	cmd.MarkFlagsMutuallyExclusive("body", "env-file")
+	cmd.MarkFlagsMutuallyExclusive("env-file", "no-store")
 
 	return cmd
 }

--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -41,19 +41,6 @@ func IsUserCancellation(err error) bool {
 	return errors.Is(err, CancelError) || errors.Is(err, terminal.InterruptErr)
 }
 
-func MutuallyExclusive(message string, conditions ...bool) error {
-	numTrue := 0
-	for _, ok := range conditions {
-		if ok {
-			numTrue++
-		}
-	}
-	if numTrue > 1 {
-		return FlagErrorf("%s", message)
-	}
-	return nil
-}
-
 type NoResultsError struct {
 	message string
 }


### PR DESCRIPTION
This looks more declarative but the error message is abysmal:
```
%  gh repo create --public --private
if any flags in the group [public private internal] are set none of the others can be; [private public] were all set
```

TODO:
- [ ] figure out if we can transform Cobra's error message into something like before
- [ ] fix tests