### PR TITLE
Fix commands that use iostreams RefreshScreen

### DIFF
--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -406,14 +406,14 @@ func System() *IOStreams {
 		term:         &terminal,
 	}
 
-	io.stdoutIsTTY = io.IsStdoutTTY()
-	io.stderrIsTTY = io.IsStderrTTY()
+	stdoutIsTTY := io.IsStdoutTTY()
+	stderrIsTTY := io.IsStderrTTY()
 
-	if io.stdoutIsTTY && io.stderrIsTTY {
+	if stdoutIsTTY && stderrIsTTY {
 		io.progressIndicatorEnabled = true
 	}
 
-	if io.stdoutIsTTY && hasAlternateScreenBuffer(terminal.IsTrueColorSupported()) {
+	if stdoutIsTTY && hasAlternateScreenBuffer(terminal.IsTrueColorSupported()) {
 		io.alternateScreenBufferEnabled = true
 	}
 

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -341,7 +341,7 @@ func (s *IOStreams) SetAlternateScreenBufferEnabled(enabled bool) {
 }
 
 func (s *IOStreams) RefreshScreen() {
-	if s.stdoutIsTTY {
+	if s.IsStdoutTTY() {
 		// Move cursor to 0,0
 		fmt.Fprint(s.Out, "\x1b[0;0H")
 		// Clear from cursor to bottom of screen
@@ -406,13 +406,16 @@ func System() *IOStreams {
 		term:         &terminal,
 	}
 
-	stdoutIsTTY := io.IsStdoutTTY()
+	io.stdoutIsTTY = io.IsStdoutTTY()
+	io.stderrIsTTY = io.IsStderrTTY()
+	io.stdoutTTYOverride = true
+	io.stderrTTYOverride = true
 
-	if stdoutIsTTY && io.IsStderrTTY() {
+	if io.stdoutIsTTY && io.stderrIsTTY {
 		io.progressIndicatorEnabled = true
 	}
 
-	if stdoutIsTTY && hasAlternateScreenBuffer(terminal.IsTrueColorSupported()) {
+	if io.stdoutIsTTY && hasAlternateScreenBuffer(terminal.IsTrueColorSupported()) {
 		io.alternateScreenBufferEnabled = true
 	}
 

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -408,8 +408,6 @@ func System() *IOStreams {
 
 	io.stdoutIsTTY = io.IsStdoutTTY()
 	io.stderrIsTTY = io.IsStderrTTY()
-	io.stdoutTTYOverride = true
-	io.stderrTTYOverride = true
 
 	if io.stdoutIsTTY && io.stderrIsTTY {
 		io.progressIndicatorEnabled = true


### PR DESCRIPTION
Fixes small regression from https://github.com/cli/cli/commit/9ec2107cc6194d9145ff7bd905b6c73bba968648 where `RefreshScreen` was checking if `stdout` was a TTY incorrectly resulting in the watch command not refreshing the screen properly. 

Fixes https://github.com/cli/cli/issues/6601