### PR TITLE
Fix listing repositories for a named GitHub user

### DIFF
--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -80,7 +80,7 @@ func listRepos(client *http.Client, hostname string, limit int, owner string, fi
 	query := fmt.Sprintf(`query RepositoryList(%s) {
 		%s {
 			login
-			repositories(first: $perPage, after: $endCursor, privacy: $privacy, isFork: $fork, affiliations: OWNER, orderBy: { field: PUSHED_AT, direction: DESC }) {
+			repositories(first: $perPage, after: $endCursor, privacy: $privacy, isFork: $fork, ownerAffiliations: OWNER, orderBy: { field: PUSHED_AT, direction: DESC }) {
 				nodes{%s}
 				totalCount
 				pageInfo{hasNextPage,endCursor}


### PR DESCRIPTION
Reverts cli/cli#6552
Fixes https://github.com/cli/cli/issues/6593

The change in the GraphQL query didn't actually fix the IP allow list problem for the affected customer, but it did cause a regression.