### PR TITLE
Fix up bindir for new version of goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,7 @@ nfpms:
   - license: MIT
     maintainer: GitHub
     homepage: https://github.com/cli/cli
-    bindir: /usr/bin
+    bindir: /usr
     dependencies:
       - git
     description: GitHub’s official command line tool.


### PR DESCRIPTION
Fixes regression caused by updating `goreleaser` where NFPM used to work differently https://github.com/goreleaser/goreleaser/issues/2476.

Closes https://github.com/cli/cli/issues/6619