### PR TITLE
feat: add support to exclude pre-releases

### DIFF
--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -19,7 +19,7 @@ type Release struct {
 	PublishedAt  time.Time
 }
 
-func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, excludeDrafts bool) ([]Release, error) {
+func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, excludeDrafts bool, excludePreReleases bool) ([]Release, error) {
 	type responseData struct {
 		Repository struct {
 			Releases struct {
@@ -57,6 +57,9 @@ loop:
 
 		for _, r := range query.Repository.Releases.Nodes {
 			if excludeDrafts && r.IsDraft {
+				continue
+			}
+			if excludePreReleases && r.IsPrerelease {
 				continue
 			}
 			releases = append(releases, r)

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -17,8 +17,9 @@ type ListOptions struct {
 	IO         *iostreams.IOStreams
 	BaseRepo   func() (ghrepo.Interface, error)
 
-	LimitResults  int
-	ExcludeDrafts bool
+	LimitResults       int
+	ExcludeDrafts      bool
+	ExcludePreReleases bool
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
@@ -45,6 +46,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 	cmd.Flags().IntVarP(&opts.LimitResults, "limit", "L", 30, "Maximum number of items to fetch")
 	cmd.Flags().BoolVar(&opts.ExcludeDrafts, "exclude-drafts", false, "Exclude draft releases")
+	cmd.Flags().BoolVar(&opts.ExcludePreReleases, "exclude-pre-releases", false, "Exclude pre-releases")
 
 	return cmd
 }
@@ -60,7 +62,7 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
-	releases, err := fetchReleases(httpClient, baseRepo, opts.LimitResults, opts.ExcludeDrafts)
+	releases, err := fetchReleases(httpClient, baseRepo, opts.LimitResults, opts.ExcludeDrafts, opts.ExcludePreReleases)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -31,16 +31,27 @@ func Test_NewCmdList(t *testing.T) {
 			args:  "",
 			isTTY: true,
 			want: ListOptions{
-				LimitResults:  30,
-				ExcludeDrafts: false,
+				LimitResults:       30,
+				ExcludeDrafts:      false,
+				ExcludePreReleases: false,
 			},
 		},
 		{
 			name: "exclude drafts",
 			args: "--exclude-drafts",
 			want: ListOptions{
-				LimitResults:  30,
-				ExcludeDrafts: true,
+				LimitResults:       30,
+				ExcludeDrafts:      true,
+				ExcludePreReleases: false,
+			},
+		},
+		{
+			name: "exclude pre-releases",
+			args: "--exclude-pre-releases",
+			want: ListOptions{
+				LimitResults:       30,
+				ExcludeDrafts:      false,
+				ExcludePreReleases: true,
 			},
 		},
 	}
@@ -80,6 +91,7 @@ func Test_NewCmdList(t *testing.T) {
 
 			assert.Equal(t, tt.want.LimitResults, opts.LimitResults)
 			assert.Equal(t, tt.want.ExcludeDrafts, opts.ExcludeDrafts)
+			assert.Equal(t, tt.want.ExcludePreReleases, opts.ExcludePreReleases)
 		})
 	}
 }


### PR DESCRIPTION
This adds support to exclude pre-releases when using `gh release list`.

I've decided to go with `--exclude-pre-releases` for the flag, but happy to change this if it should be `prereleases` (all one word), or something else.

Closes #6581

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
