### PR TITLE
Add --verify-tag flag for release creation command

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -169,7 +169,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmd.Flags().BoolVarP(&opts.GenerateNotes, "generate-notes", "", false, "Automatically generate title and notes for the release")
 	cmd.Flags().StringVar(&opts.NotesStartTag, "notes-start-tag", "", "Tag to use as the starting point for generating release notes")
 	cmdutil.NilBoolFlag(cmd, &opts.IsLatest, "latest", "", "Mark this release as \"Latest\" (default: automatic based on date and version)")
-	cmd.Flags().BoolVarP(&opts.VerifyTag, "verify-tag", "", false, "Abort the release if the tag doesn't already exist")
+	cmd.Flags().BoolVarP(&opts.VerifyTag, "verify-tag", "", false, "Abort in case the git tag doesn't already exist in the remote repository")
 
 	return cmd
 }

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -228,9 +228,8 @@ func createRun(opts *CreateOptions) error {
 		}
 	}
 
-	var remoteTagPresent bool
 	if opts.VerifyTag && !existingTag {
-		remoteTagPresent, err = remoteTagExists(httpClient, baseRepo, opts.TagName)
+		remoteTagPresent, err := remoteTagExists(httpClient, baseRepo, opts.TagName)
 		if err != nil {
 			return err
 		}
@@ -251,7 +250,7 @@ func createRun(opts *CreateOptions) error {
 		// of local tag status.
 		// If a remote tag with the same name as specified exists already
 		// then a new tag will not be created so ignore local tag status.
-		if tagDescription != "" && !existingTag && opts.Target == "" && !remoteTagPresent {
+		if tagDescription != "" && !existingTag && opts.Target == "" && !opts.VerifyTag {
 			remoteExists, err := remoteTagExists(httpClient, baseRepo, opts.TagName)
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/6566

When running `gh release create <tag> --verify-tag`, we query <tag> among repository tags via the GitHub API before creating the release, and abort the command if the tag was not found.

### Things I'm not sure about
* Is the test coverage good? Should I cover more cases with different flag combinations?
* When checking for existence of remote tag in the "verify-tag" code path, we store the result in a variable to avoid the same API call later on. Is that reasonable?

### Disclaimer
I'm very new to Go and contributing to the cli project, so I welcome nit picky comments in the PR review as a learning opportunity.


