### PR TITLE
Add flag to login command to set name and email in global git config

### DIFF
--- a/api/queries_user.go
+++ b/api/queries_user.go
@@ -19,3 +19,23 @@ func CurrentUserID(client *Client, hostname string) (string, error) {
 	err := client.Query(hostname, "UserCurrent", &query, nil)
 	return query.Viewer.ID, err
 }
+
+func CurrentUserEmail(client *Client, hostname string) (string, error) {
+	var query struct {
+		Viewer struct {
+			Email string
+		}
+	}
+	err := client.Query(hostname, "UserCurrent", &query, nil)
+	return query.Viewer.Email, err
+}
+
+func CurrentProfileName(client *Client, hostname string) (string, error) {
+	var query struct {
+		Viewer struct {
+			Name string
+		}
+	}
+	err := client.Query(hostname, "UserCurrent", &query, nil)
+	return query.Viewer.Name, err
+}

--- a/pkg/cmd/auth/setupgit/setupgit.go
+++ b/pkg/cmd/auth/setupgit/setupgit.go
@@ -1,13 +1,17 @@
 package setupgit
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	ghAuth "github.com/cli/go-gh/pkg/auth"
 	"github.com/spf13/cobra"
 )
 
@@ -16,26 +20,30 @@ type gitConfigurator interface {
 }
 
 type SetupGitOptions struct {
-	IO           *iostreams.IOStreams
-	Config       func() (config.Config, error)
-	Hostname     string
-	gitConfigure gitConfigurator
+	HttpClient     func() (*http.Client, error)
+	IO             *iostreams.IOStreams
+	Config         func() (config.Config, error)
+	Hostname       string
+	credentialFlow *shared.GitCredentialFlow
+	gitConfigure   gitConfigurator
 }
 
 func NewCmdSetupGit(f *cmdutil.Factory, runF func(*SetupGitOptions) error) *cobra.Command {
 	opts := &SetupGitOptions{
-		IO:     f.IOStreams,
-		Config: f.Config,
+		HttpClient: f.HttpClient,
+		IO:         f.IOStreams,
+		Config:     f.Config,
 	}
 
 	cmd := &cobra.Command{
 		Short: "Configure git to use GitHub CLI as a credential helper",
 		Use:   "setup-git",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.gitConfigure = &shared.GitCredentialFlow{
+			opts.credentialFlow = &shared.GitCredentialFlow{
 				Executable: f.Executable(),
 				GitClient:  f.GitClient,
 			}
+			opts.gitConfigure = opts.credentialFlow
 
 			if runF != nil {
 				return runF(opts)
@@ -71,17 +79,41 @@ func setupGitRun(opts *SetupGitOptions) error {
 	}
 
 	hostnamesToSetup := hostnames
+	defaultHostname, _ := ghAuth.DefaultHost()
 
 	if opts.Hostname != "" {
 		if !has(opts.Hostname, hostnames) {
 			return fmt.Errorf("You are not logged into the GitHub host %q\n", opts.Hostname)
 		}
 		hostnamesToSetup = []string{opts.Hostname}
+		defaultHostname = opts.Hostname
 	}
 
 	for _, hostname := range hostnamesToSetup {
 		if err := opts.gitConfigure.Setup(hostname, "", ""); err != nil {
 			return fmt.Errorf("failed to set up git credential helper: %w", err)
+		}
+
+		if hostname == defaultHostname {
+			ctx := context.Background()
+			httpClient, err := opts.HttpClient()
+			if err != nil {
+				return err
+			}
+			apiClient := api.NewClientFromHTTP(httpClient)
+
+			name, err := api.CurrentProfileName(apiClient, hostname)
+			if err != nil {
+				return fmt.Errorf("error using api: %w", err)
+			}
+
+			err = setGlobalGitConfig(ctx, opts.credentialFlow, "user.name", name)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(opts.IO.ErrOut, "%s Set global git config user.name as %s\n", cs.SuccessIcon(), name)
+
+			//TODO: repeat for email (token doesn't have required scope)
 		}
 	}
 
@@ -95,4 +127,12 @@ func has(needle string, haystack []string) bool {
 		}
 	}
 	return false
+}
+
+func setGlobalGitConfig(ctx context.Context, credentialFlow *shared.GitCredentialFlow, key, value string) error {
+	cmd, err := credentialFlow.GitClient.Command(ctx, "config", "--global", key, value)
+	if err != nil {
+		return err
+	}
+	return cmd.Run()
 }

--- a/pkg/cmd/auth/setupgit/setupgit_test.go
+++ b/pkg/cmd/auth/setupgit/setupgit_test.go
@@ -17,6 +17,8 @@ func (gf *mockGitConfigurer) Setup(hostname, username, authToken string) error {
 	return gf.setupErr
 }
 
+// TODO: add test cases for new feature with httpmock
+
 func Test_setupGitRun(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
Fixes #6096 

### What have I done
I added a  `--set-global-config` flag to `gh auth login` command which queries the GitHub API for the necessary values and then sets the global git config`user.name` and `user.email` keys using the retrieved values.

I believe that `gh auth login` was the more natural place to include this functionality rather than `gh auth setup-git` based on their descriptions.

Also, I set the default value of the flag to false so it won't unexpectedly change the behaviour of the command.

### Testing
I tested the code locally using my own GitHub account and didn't write any additional go tests. This can be easily done by enabling the flag when running the `gh auth login` command.

### Things I'm not sure about
According to the [docs](https://docs.github.com/en/graphql/reference/objects#user), the name can be nil and I'm not sure what to do in that case.
