### PR TITLE
Expose commit SHA in PR reviews JSON export

### DIFF
--- a/api/queries_pr_review.go
+++ b/api/queries_pr_review.go
@@ -39,6 +39,7 @@ type PullRequestReview struct {
 	ReactionGroups      ReactionGroups `json:"reactionGroups"`
 	State               string         `json:"state"`
 	URL                 string         `json:"url,omitempty"`
+	Commit              Commit         `json:"commit"`
 }
 
 func AddReview(client *Client, repo ghrepo.Interface, pr *PullRequest, input *PullRequestReviewInput) error {

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -75,11 +75,13 @@ var prReviewRequests = shortenQuery(`
 var prReviews = shortenQuery(`
 	reviews(first: 100) {
 		nodes {
+			id,
 			author{login},
 			authorAssociation,
 			submittedAt,
 			body,
 			state,
+			commit{oid},
 			reactionGroups{content,users{totalCount}}
 		}
 		pageInfo{hasNextPage,endCursor}


### PR DESCRIPTION
This is to expose the exact commit that a PR review was left for: https://github.com/cli/cli/discussions/6615

Bonus fix: correctly reports the GraphQL `id` field for each PR review object in JSON.

```json
$ gh pr view 6603 --json reviews                       
{
  "reviews": [
    {
      "id": "PRR_kwDODKw3uc5GR6yX",
      "author": {
        "login": "mislav"
      },
      "authorAssociation": "MEMBER",
      "body": "Thanks for taking this on! Let's use YAML as it's more readable in its raw format than JSON.",
      "submittedAt": "2022-11-14T13:24:00Z",
      "includesCreatedEdit": false,
      "reactionGroups": [],
      "state": "CHANGES_REQUESTED",
      "commit": {
        "oid": "2e0e229d481b65c6302ec06225196a115b3fa5f4"
      }
    }
  ]
}
```