### PR TITLE
Show version diff when updating a single extension

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -380,9 +380,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 						}
 						if errors.Is(err, upToDateError) {
 							fmt.Fprintf(io.Out, "%s Extension already up to date\n", cs.SuccessIcon())
-						} else if name != "" {
-							fmt.Fprintf(io.Out, "%s %s upgraded extension %s\n", cs.SuccessIcon(), successStr, name)
-						} else {
+						} else if name == "" {
 							fmt.Fprintf(io.Out, "%s %s upgraded extensions\n", cs.SuccessIcon(), successStr)
 						}
 					}

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -363,7 +363,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					}
 					cs := io.ColorScheme()
 					err := m.Upgrade(name, flagForce)
-					if err != nil && !errors.Is(err, upToDateError) {
+					if err != nil {
 						if name != "" {
 							fmt.Fprintf(io.ErrOut, "%s Failed upgrading extension %s: %s\n", cs.FailureIcon(), name, err)
 						} else if errors.Is(err, noExtensionsInstalledError) {
@@ -378,11 +378,11 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 						if flagDryRun {
 							successStr = "Would have"
 						}
-						if errors.Is(err, upToDateError) {
-							fmt.Fprintf(io.Out, "%s Extension already up to date\n", cs.SuccessIcon())
-						} else if name == "" {
-							fmt.Fprintf(io.Out, "%s %s upgraded extensions\n", cs.SuccessIcon(), successStr)
+						extensionStr := "extension"
+						if name == "" {
+							extensionStr = "extensions"
 						}
+						fmt.Fprintf(io.Out, "%s %s upgraded %s\n", cs.SuccessIcon(), successStr, extensionStr)
 					}
 					return nil
 				},

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -323,7 +323,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Successfully upgraded extension hello\n",
+			wantStdout: "",
 		},
 		{
 			name: "upgrade an extension dry run",
@@ -343,7 +343,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Would have upgraded extension hello\n",
+			wantStdout: "",
 		},
 		{
 			name: "upgrade an extension notty",
@@ -410,7 +410,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Successfully upgraded extension hello\n",
+			wantStdout: "",
 		},
 		{
 			name: "upgrade an extension full name",
@@ -426,7 +426,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Successfully upgraded extension hello\n",
+			wantStdout: "",
 		},
 		{
 			name: "upgrade all",

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -323,7 +323,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Successfully upgraded extension\n",
 		},
 		{
 			name: "upgrade an extension dry run",
@@ -343,7 +343,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Would have upgraded extension\n",
 		},
 		{
 			name: "upgrade an extension notty",
@@ -365,7 +365,9 @@ func TestNewCmdExtension(t *testing.T) {
 			args: []string{"upgrade", "hello"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
 				em.UpgradeFunc = func(name string, force bool) error {
-					return upToDateError
+					// An already up to date extension returns the same response
+					// as an one that has been upgraded.
+					return nil
 				}
 				return func(t *testing.T) {
 					calls := em.UpgradeCalls()
@@ -374,8 +376,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Extension already up to date\n",
-			wantStderr: "",
+			wantStdout: "✓ Successfully upgraded extension\n",
 		},
 		{
 			name: "upgrade extension error",
@@ -410,7 +411,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Successfully upgraded extension\n",
 		},
 		{
 			name: "upgrade an extension full name",
@@ -426,7 +427,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Successfully upgraded extension\n",
 		},
 		{
 			name: "upgrade all",

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -516,7 +516,7 @@ func (m *Manager) Upgrade(name string, force bool) error {
 		if err != nil {
 			return err
 		}
-		return m.upgradeExtension(f, force)
+		return m.upgradeExtensions([]Extension{f}, force)
 	}
 	return fmt.Errorf("no extension matched %q", name)
 }
@@ -534,13 +534,6 @@ func (m *Manager) upgradeExtensions(exts []Extension, force bool) error {
 			}
 			fmt.Fprintf(m.io.Out, "%s\n", err)
 			continue
-		}
-		currentVersion := displayExtensionVersion(&f, f.currentVersion)
-		latestVersion := displayExtensionVersion(&f, f.latestVersion)
-		if m.dryRunMode {
-			fmt.Fprintf(m.io.Out, "would have upgraded from %s to %s\n", currentVersion, latestVersion)
-		} else {
-			fmt.Fprintf(m.io.Out, "upgraded from %s to %s\n", currentVersion, latestVersion)
 		}
 	}
 	if failed {
@@ -576,6 +569,15 @@ func (m *Manager) upgradeExtension(ext Extension, force bool) error {
 			return m.installBin(repo, "")
 		}
 		err = m.upgradeGitExtension(ext, force)
+	}
+	if err == nil {
+		currentVersion := displayExtensionVersion(&ext, ext.currentVersion)
+		latestVersion := displayExtensionVersion(&ext, ext.latestVersion)
+		var str string
+		if m.dryRunMode {
+			str = "would have "
+		}
+		fmt.Fprintf(m.io.Out, "%supgraded from %s to %s\n", str, currentVersion, latestVersion)
 	}
 	return err
 }

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -535,6 +535,13 @@ func (m *Manager) upgradeExtensions(exts []Extension, force bool) error {
 			fmt.Fprintf(m.io.Out, "%s\n", err)
 			continue
 		}
+		currentVersion := displayExtensionVersion(&f, f.currentVersion)
+		latestVersion := displayExtensionVersion(&f, f.latestVersion)
+		if m.dryRunMode {
+			fmt.Fprintf(m.io.Out, "would have upgraded from %s to %s\n", currentVersion, latestVersion)
+		} else {
+			fmt.Fprintf(m.io.Out, "upgraded from %s to %s\n", currentVersion, latestVersion)
+		}
 	}
 	if failed {
 		return errors.New("some extensions failed to upgrade")
@@ -569,15 +576,6 @@ func (m *Manager) upgradeExtension(ext Extension, force bool) error {
 			return m.installBin(repo, "")
 		}
 		err = m.upgradeGitExtension(ext, force)
-	}
-	if err == nil {
-		currentVersion := displayExtensionVersion(&ext, ext.currentVersion)
-		latestVersion := displayExtensionVersion(&ext, ext.latestVersion)
-		var str string
-		if m.dryRunMode {
-			str = "would have "
-		}
-		fmt.Fprintf(m.io.Out, "%supgraded from %s to %s\n", str, currentVersion, latestVersion)
 	}
 	return err
 }

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -369,7 +369,7 @@ func TestManager_UpgradeExtension_GitExtension(t *testing.T) {
 	ext.latestVersion = "new version"
 	err = m.upgradeExtension(ext, false)
 	assert.NoError(t, err)
-	assert.Equal(t, "upgraded from old vers to new vers\n", stdout.String())
+	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
 	gc.AssertExpectations(t)
 	gcOne.AssertExpectations(t)
@@ -395,7 +395,7 @@ func TestManager_UpgradeExtension_GitExtension_DryRun(t *testing.T) {
 	ext.latestVersion = "new version"
 	err = m.upgradeExtension(ext, false)
 	assert.NoError(t, err)
-	assert.Equal(t, "would have upgraded from old vers to new vers\n", stdout.String())
+	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
 	gc.AssertExpectations(t)
 	gcOne.AssertExpectations(t)
@@ -422,7 +422,7 @@ func TestManager_UpgradeExtension_GitExtension_Force(t *testing.T) {
 	ext.latestVersion = "new version"
 	err = m.upgradeExtension(ext, true)
 	assert.NoError(t, err)
-	assert.Equal(t, "upgraded from old vers to new vers\n", stdout.String())
+	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
 	gc.AssertExpectations(t)
 	gcOne.AssertExpectations(t)
@@ -566,7 +566,7 @@ func TestManager_UpgradeExtension_BinaryExtension(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "FAKE UPGRADED BINARY", string(fakeBin))
 
-	assert.Equal(t, "upgraded from v1.0.1 to v1.0.2\n", stdout.String())
+	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
 }
 
@@ -631,7 +631,7 @@ func TestManager_UpgradeExtension_BinaryExtension_Pinned_Force(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "FAKE UPGRADED BINARY", string(fakeBin))
 
-	assert.Equal(t, "upgraded from v1.0.1 to v1.0.2\n", stdout.String())
+	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
 }
 
@@ -684,7 +684,7 @@ func TestManager_UpgradeExtension_BinaryExtension_DryRun(t *testing.T) {
 		Host:  "example.com",
 		Tag:   "v1.0.1",
 	}, bm)
-	assert.Equal(t, "would have upgraded from v1.0.1 to v1.0.2\n", stdout.String())
+	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
 }
 

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -369,7 +369,7 @@ func TestManager_UpgradeExtension_GitExtension(t *testing.T) {
 	ext.latestVersion = "new version"
 	err = m.upgradeExtension(ext, false)
 	assert.NoError(t, err)
-	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "upgraded from old vers to new vers\n", stdout.String())
 	assert.Equal(t, "", stderr.String())
 	gc.AssertExpectations(t)
 	gcOne.AssertExpectations(t)
@@ -395,7 +395,7 @@ func TestManager_UpgradeExtension_GitExtension_DryRun(t *testing.T) {
 	ext.latestVersion = "new version"
 	err = m.upgradeExtension(ext, false)
 	assert.NoError(t, err)
-	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "would have upgraded from old vers to new vers\n", stdout.String())
 	assert.Equal(t, "", stderr.String())
 	gc.AssertExpectations(t)
 	gcOne.AssertExpectations(t)
@@ -422,7 +422,7 @@ func TestManager_UpgradeExtension_GitExtension_Force(t *testing.T) {
 	ext.latestVersion = "new version"
 	err = m.upgradeExtension(ext, true)
 	assert.NoError(t, err)
-	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "upgraded from old vers to new vers\n", stdout.String())
 	assert.Equal(t, "", stderr.String())
 	gc.AssertExpectations(t)
 	gcOne.AssertExpectations(t)
@@ -566,7 +566,7 @@ func TestManager_UpgradeExtension_BinaryExtension(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "FAKE UPGRADED BINARY", string(fakeBin))
 
-	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "upgraded from v1.0.1 to v1.0.2\n", stdout.String())
 	assert.Equal(t, "", stderr.String())
 }
 
@@ -631,7 +631,7 @@ func TestManager_UpgradeExtension_BinaryExtension_Pinned_Force(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "FAKE UPGRADED BINARY", string(fakeBin))
 
-	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "upgraded from v1.0.1 to v1.0.2\n", stdout.String())
 	assert.Equal(t, "", stderr.String())
 }
 
@@ -684,7 +684,7 @@ func TestManager_UpgradeExtension_BinaryExtension_DryRun(t *testing.T) {
 		Host:  "example.com",
 		Tag:   "v1.0.1",
 	}, bm)
-	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "would have upgraded from v1.0.1 to v1.0.2\n", stdout.String())
 	assert.Equal(t, "", stderr.String())
 }
 


### PR DESCRIPTION
This refactors the extension upgrade command to use `Manager.upgradeExtensions` when updating all extensions _and_ single extensions. With this approach, we get the versions included when updating a single extension.

Fixes #6483
