### PR TITLE
Add `isDraft` to `search prs` json options, matching `pr view`

### DIFF
--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -122,7 +122,7 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 	}
 
 	// Output flags
-	cmdutil.AddJSONFlags(cmd, &opts.Exporter, search.PRFields)
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, search.PullRequestFields)
 	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open the search query in the web browser")
 
 	// Query parameter flags

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -122,7 +122,7 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 	}
 
 	// Output flags
-	cmdutil.AddJSONFlags(cmd, &opts.Exporter, search.IssueFields)
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, search.PRFields)
 	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open the search query in the web browser")
 
 	// Query parameter flags

--- a/pkg/search/result.go
+++ b/pkg/search/result.go
@@ -57,7 +57,7 @@ var IssueFields = []string{
 	"url",
 }
 
-var PRFields = append(IssueFields,
+var PullRequestFields = append(IssueFields,
 	"isDraft",
 )
 
@@ -121,29 +121,28 @@ type User struct {
 }
 
 type Issue struct {
-	Assignees         []User      `json:"assignees"`
-	Author            User        `json:"user"`
-	AuthorAssociation string      `json:"author_association"`
-	Body              string      `json:"body"`
-	ClosedAt          time.Time   `json:"closed_at"`
-	CommentsCount     int         `json:"comments"`
-	CreatedAt         time.Time   `json:"created_at"`
-	ID                string      `json:"node_id"`
-	Labels            []Label     `json:"labels"`
-	IsLocked          bool        `json:"locked"`
-	Number            int         `json:"number"`
-	PullRequest       PullRequest `json:"pull_request"`
-	RepositoryURL     string      `json:"repository_url"`
+	Assignees         []User    `json:"assignees"`
+	Author            User      `json:"user"`
+	AuthorAssociation string    `json:"author_association"`
+	Body              string    `json:"body"`
+	ClosedAt          time.Time `json:"closed_at"`
+	CommentsCount     int       `json:"comments"`
+	CreatedAt         time.Time `json:"created_at"`
+	ID                string    `json:"node_id"`
+	Labels            []Label   `json:"labels"`
+	// This is a PullRequest field which does not appear in issue results,
+	// but lives outside the PullRequest object.
+	IsDraft       *bool       `json:"draft,omitempty"`
+	IsLocked      bool        `json:"locked"`
+	Number        int         `json:"number"`
+	PullRequest   PullRequest `json:"pull_request"`
+	RepositoryURL string      `json:"repository_url"`
 	// StateInternal should not be used directly. Use State() instead.
 	StateInternal string    `json:"state"`
 	StateReason   string    `json:"state_reason"`
 	Title         string    `json:"title"`
 	URL           string    `json:"html_url"`
 	UpdatedAt     time.Time `json:"updated_at"`
-
-	// this is really a PR field, and doesn't appear in issue results, but it's
-	// not inside the pull_request object
-	IsDraft *bool `json:"draft,omitempty"`
 }
 
 type PullRequest struct {

--- a/pkg/search/result.go
+++ b/pkg/search/result.go
@@ -57,6 +57,10 @@ var IssueFields = []string{
 	"url",
 }
 
+var PRFields = append(IssueFields,
+	"isDraft",
+)
+
 type RepositoriesResult struct {
 	IncompleteResults bool         `json:"incomplete_results"`
 	Items             []Repository `json:"items"`
@@ -136,6 +140,10 @@ type Issue struct {
 	Title         string    `json:"title"`
 	URL           string    `json:"html_url"`
 	UpdatedAt     time.Time `json:"updated_at"`
+
+	// this is really a PR field, and doesn't appear in issue results, but it's
+	// not inside the pull_request object
+	IsDraft *bool `json:"draft,omitempty"`
 }
 
 type PullRequest struct {

--- a/pkg/search/result_test.go
+++ b/pkg/search/result_test.go
@@ -47,6 +47,7 @@ func TestRepositoryExportData(t *testing.T) {
 
 func TestIssueExportData(t *testing.T) {
 	var updatedAt = time.Date(2021, 2, 28, 12, 30, 0, 0, time.UTC)
+	trueValue := true
 	tests := []struct {
 		name   string
 		fields []string
@@ -87,6 +88,18 @@ func TestIssueExportData(t *testing.T) {
 				StateInternal: "closed",
 			},
 			output: `{"isPullRequest":true,"state":"merged"}`,
+		},
+		{
+			name:   "isDraft when pull request",
+			fields: []string{"isDraft", "state"},
+			issue: Issue{
+				PullRequest: PullRequest{
+					URL: "a-url",
+				},
+				StateInternal: "open",
+				IsDraft:       &trueValue,
+			},
+			output: `{"isDraft":true,"state":"open"}`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
The `gh pr view --json ...` allows returning the `isDraft` field, but `gh search prs` does not. This adds that option to the search command to match the view command.
