### PR TITLE
docs: Update installation instructions for WinGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For more information, see [Linux & BSD installation](./docs/install_linux.md).
 | ------------------- | --------------------|
 | `winget install --id GitHub.cli` | `winget upgrade --id GitHub.cli` |
 
-> **Note:**  
+> **Note**  
 > The Windows installer modifes your PATH. When using Windows Terminal, you will need to **open a new window** for the changes to take affect. (Simply opening a new tab will _not_ be sufficient.)
 
 #### scoop

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ For more information, see [Linux & BSD installation](./docs/install_linux.md).
 | ------------------- | --------------------|
 | `winget install --id GitHub.cli` | `winget upgrade --id GitHub.cli` |
 
+Note: The WinGet installer modifes your PATH.  If using Windows Terminal, you will need to **open a new _window_** for changes to take affect.  Opening a new tab will not be sufficient.
+
 #### scoop
 
 | Install:           | Upgrade:           |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ For more information, see [Linux & BSD installation](./docs/install_linux.md).
 | ------------------- | --------------------|
 | `winget install --id GitHub.cli` | `winget upgrade --id GitHub.cli` |
 
-Note: The WinGet installer modifes your PATH.  If using Windows Terminal, you will need to **open a new _window_** for changes to take affect.  Opening a new tab will not be sufficient.
+> **Note:**  
+> The Windows installer modifes your PATH. When using Windows Terminal, you will need to **open a new window** for the changes to take affect. (Simply opening a new tab will _not_ be sufficient.)
 
 #### scoop
 


### PR DESCRIPTION
After running `winget install --id GitHub.cli` I spent fifteen minutes trying to figure out why it didn't work.  My _first_ thought was something to do with the PATH, so I opened a new PowerShell tab.  When that didn't work, I spent 14 more minutes trying to figure out what went wrong.

I think giving specific instructions will help other developers like me.

Continuation from https://github.com/cli/cli/issues/4772#issuecomment-1345410075
