### PR TITLE
Codespaces: Use -R for --repo shorthand and deprecate -r

### DIFF
--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -289,7 +289,9 @@ func (c codespace) running() bool {
 // which instructs the user to use -R instead.
 func addDeprecatedRepoShorthand(cmd *cobra.Command, target *string) error {
 	cmd.Flags().StringVarP(target, "repo-deprecated", "r", "", "(Deprecated) Shorthand for --repo")
-	cmd.PersistentFlags().MarkHidden("repo-deprecated")
+	if err := cmd.PersistentFlags().MarkHidden("repo-deprecated"); err != nil {
+		return fmt.Errorf("error marking `-r` shorthand as hidden: %w", err)
+	}
 
 	if err := cmd.Flags().MarkShorthandDeprecated("repo-deprecated", "use `-R` instead"); err != nil {
 		return fmt.Errorf("error marking `-r` shorthand as deprecated: %w", err)

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -289,7 +289,8 @@ func (c codespace) running() bool {
 // which instructs the user to use -R instead.
 func addDeprecatedRepoShorthand(cmd *cobra.Command, target *string) error {
 	cmd.Flags().StringVarP(target, "repo-deprecated", "r", "", "(Deprecated) Shorthand for --repo")
-	if err := cmd.PersistentFlags().MarkHidden("repo-deprecated"); err != nil {
+
+	if err := cmd.Flags().MarkHidden("repo-deprecated"); err != nil {
 		return fmt.Errorf("error marking `-r` shorthand as hidden: %w", err)
 	}
 

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -284,3 +284,16 @@ func (c codespace) hasUnsavedChanges() bool {
 func (c codespace) running() bool {
 	return c.State == api.CodespaceStateAvailable
 }
+
+// addDeprecatedRepoShorthand adds a -r parameter (deprecated shorthand for --repo)
+// which instructs the user to use -R instead.
+func addDeprecatedRepoShorthand(cmd *cobra.Command, target *string) error {
+	cmd.Flags().StringVarP(target, "repo-deprecated", "r", "", "(Deprecated) Shorthand for --repo")
+	cmd.PersistentFlags().MarkHidden("repo-deprecated")
+
+	if err := cmd.Flags().MarkShorthandDeprecated("repo-deprecated", "use `-R` instead"); err != nil {
+		return fmt.Errorf("error marking `-r` shorthand as deprecated: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -83,7 +83,7 @@ func newCreateCmd(app *App) *cobra.Command {
 
 	createCmd.Flags().StringVarP(&opts.repo, "repo", "R", "", "repository name with owner: user/repo")
 	if err := addDeprecatedRepoShorthand(createCmd, &opts.repo); err != nil {
-		fmt.Fprint(app.io.ErrOut, "%v\n", err)
+		fmt.Fprintf(app.io.ErrOut, "%v\n", err)
 	}
 
 	createCmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "repository branch")

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -81,7 +81,11 @@ func newCreateCmd(app *App) *cobra.Command {
 		},
 	}
 
-	createCmd.Flags().StringVarP(&opts.repo, "repo", "r", "", "repository name with owner: user/repo")
+	createCmd.Flags().StringVarP(&opts.repo, "repo", "R", "", "repository name with owner: user/repo")
+	if err := addDeprecatedRepoShorthand(createCmd, &opts.repo); err != nil {
+		fmt.Fprint(app.io.ErrOut, "%v\n", err)
+	}
+
 	createCmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "repository branch")
 	createCmd.Flags().StringVarP(&opts.location, "location", "l", "", "location: {EastUs|SouthEastAsia|WestEurope|WestUs2} (determined automatically if not provided)")
 	createCmd.Flags().StringVarP(&opts.machine, "machine", "m", "", "hardware specifications for the VM")

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -68,7 +68,7 @@ func newDeleteCmd(app *App) *cobra.Command {
 	deleteCmd.Flags().BoolVar(&opts.deleteAll, "all", false, "Delete all codespaces")
 	deleteCmd.Flags().StringVarP(&opts.repoFilter, "repo", "R", "", "Delete codespaces for a `repository`")
 	if err := addDeprecatedRepoShorthand(deleteCmd, &opts.repoFilter); err != nil {
-		fmt.Fprint(app.io.ErrOut, "%v\n", err)
+		fmt.Fprintf(app.io.ErrOut, "%v\n", err)
 	}
 
 	deleteCmd.Flags().BoolVarP(&opts.skipConfirm, "force", "f", false, "Skip confirmation for codespaces that contain unsaved changes")

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -66,7 +66,11 @@ func newDeleteCmd(app *App) *cobra.Command {
 
 	deleteCmd.Flags().StringVarP(&opts.codespaceName, "codespace", "c", "", "Name of the codespace")
 	deleteCmd.Flags().BoolVar(&opts.deleteAll, "all", false, "Delete all codespaces")
-	deleteCmd.Flags().StringVarP(&opts.repoFilter, "repo", "r", "", "Delete codespaces for a `repository`")
+	deleteCmd.Flags().StringVarP(&opts.repoFilter, "repo", "R", "", "Delete codespaces for a `repository`")
+	if err := addDeprecatedRepoShorthand(deleteCmd, &opts.repoFilter); err != nil {
+		fmt.Fprint(app.io.ErrOut, "%v\n", err)
+	}
+
 	deleteCmd.Flags().BoolVarP(&opts.skipConfirm, "force", "f", false, "Skip confirmation for codespaces that contain unsaved changes")
 	deleteCmd.Flags().Uint16Var(&opts.keepDays, "days", 0, "Delete codespaces older than `N` days")
 	deleteCmd.Flags().StringVarP(&opts.orgName, "org", "o", "", "The `login` handle of the organization (admin-only)")

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -46,7 +46,7 @@ func newListCmd(app *App) *cobra.Command {
 	listCmd.Flags().IntVarP(&opts.limit, "limit", "L", 30, "Maximum number of codespaces to list")
 	listCmd.Flags().StringVarP(&opts.repo, "repo", "R", "", "Repository name with owner: user/repo")
 	if err := addDeprecatedRepoShorthand(listCmd, &opts.repo); err != nil {
-		fmt.Fprint(app.io.ErrOut, "%v\n", err)
+		fmt.Fprintf(app.io.ErrOut, "%v\n", err)
 	}
 
 	listCmd.Flags().StringVarP(&opts.orgName, "org", "o", "", "The `login` handle of the organization to list codespaces for (admin-only)")

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -44,7 +44,11 @@ func newListCmd(app *App) *cobra.Command {
 	}
 
 	listCmd.Flags().IntVarP(&opts.limit, "limit", "L", 30, "Maximum number of codespaces to list")
-	listCmd.Flags().StringVarP(&opts.repo, "repo", "r", "", "Repository name with owner: user/repo")
+	listCmd.Flags().StringVarP(&opts.repo, "repo", "R", "", "Repository name with owner: user/repo")
+	if err := addDeprecatedRepoShorthand(listCmd, &opts.repo); err != nil {
+		fmt.Fprint(app.io.ErrOut, "%v\n", err)
+	}
+
 	listCmd.Flags().StringVarP(&opts.orgName, "org", "o", "", "The `login` handle of the organization to list codespaces for (admin-only)")
 	listCmd.Flags().StringVarP(&opts.userName, "user", "u", "", "The `username` to list codespaces for (used with --org)")
 	cmdutil.AddJSONFlags(listCmd, &exporter, api.CodespaceFields)


### PR DESCRIPTION
Related: https://github.com/cli/cli/issues/6548

The `codespaces` commands use `-r` as shorthand for `--repo` which is inconsistent with other commands which use `-R` instead. This change updates existing usage of `-r` to be `-R` and marks usage of `-r` as hidden and deprecated.

Examples:

`-R` exists and `-r` is hidden:
<img width="699" alt="image" src="https://user-images.githubusercontent.com/5447118/207202918-a1bf73a4-e96e-4eac-87fb-7a8772e0b8ff.png">

`-R` works like `--repo`:
![image](https://user-images.githubusercontent.com/5447118/207140455-4c86cd21-e2a7-403f-8f0e-f31932e5c652.png)

`-r` still works, but warns about deprecation:
![image](https://user-images.githubusercontent.com/5447118/207140423-29613392-b6c0-4289-98c7-764995a4e6e9.png)

Note that part of the motivation to make this change is to make https://github.com/cli/cli/issues/6548 more friendly - it removes a collision of `-r` in `gh cs cp` for that change.