### PR TITLE
Continue projectsv2 support

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -192,6 +192,9 @@ func IssueCreate(client *Client, repo *Repository, params map[string]interface{}
 		switch key {
 		case "assigneeIds", "body", "issueTemplate", "labelIds", "milestoneId", "projectIds", "repositoryId", "title":
 			inputParams[key] = val
+		case "projectV2Ids":
+		default:
+			return nil, fmt.Errorf("invalid IssueCreate mutation parameter %s", key)
 		}
 	}
 	variables := map[string]interface{}{

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -37,6 +37,7 @@ type Issue struct {
 	Assignees      Assignees
 	Labels         Labels
 	ProjectCards   ProjectCards
+	ProjectItems   ProjectItems
 	Milestone      *Milestone
 	ReactionGroups ReactionGroups
 	IsPinned       bool
@@ -77,6 +78,10 @@ type ProjectCards struct {
 	TotalCount int
 }
 
+type ProjectItems struct {
+	Nodes []*ProjectV2Item
+}
+
 type ProjectInfo struct {
 	Project struct {
 		Name string `json:"name"`
@@ -84,6 +89,10 @@ type ProjectInfo struct {
 	Column struct {
 		Name string `json:"name"`
 	} `json:"column"`
+}
+
+type ProjectV2Item struct {
+	ID string `json:"id"`
 }
 
 func (p ProjectCards) ProjectNames() []string {

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -136,7 +136,9 @@ func IssueCreate(client *Client, repo *Repository, params map[string]interface{}
 		"repositoryId": repo.ID,
 	}
 	for key, val := range params {
-		inputParams[key] = val
+		if key != "projectV2Ids" {
+			inputParams[key] = val
+		}
 	}
 	variables := map[string]interface{}{
 		"input": inputParams,

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -92,7 +92,10 @@ type ProjectInfo struct {
 }
 
 type ProjectV2Item struct {
-	ID string `json:"id"`
+	ID      string `json:"id"`
+	Project struct {
+		Title string `json:"title"`
+	}
 }
 
 func (p ProjectCards) ProjectNames() []string {
@@ -101,6 +104,14 @@ func (p ProjectCards) ProjectNames() []string {
 		names[i] = c.Project.Name
 	}
 	return names
+}
+
+func (p ProjectItems) ProjectTitles() []string {
+	titles := make([]string, len(p.Nodes))
+	for i, c := range p.Nodes {
+		titles[i] = c.Project.Title
+	}
+	return titles
 }
 
 type Milestone struct {

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -127,6 +127,7 @@ func IssueCreate(client *Client, repo *Repository, params map[string]interface{}
 	mutation IssueCreate($input: CreateIssueInput!) {
 		createIssue(input: $input) {
 			issue {
+				id
 				url
 			}
 		}

--- a/api/queries_org.go
+++ b/api/queries_org.go
@@ -5,7 +5,7 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
-// OrganizationProjects fetches all open projects for an organization
+// OrganizationProjects fetches all open projects for an organization.
 func OrganizationProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, error) {
 	type responseData struct {
 		Organization struct {

--- a/api/queries_org.go
+++ b/api/queries_org.go
@@ -42,7 +42,7 @@ func OrganizationProjects(client *Client, repo ghrepo.Interface) ([]RepoProject,
 	return projects, nil
 }
 
-// OrganizationProjectsV2 fetches all open projectsV2 for an organization
+// OrganizationProjectsV2 fetches all open projectsV2 for an organization.
 func OrganizationProjectsV2(client *Client, repo ghrepo.Interface) ([]RepoProjectV2, error) {
 	type responseData struct {
 		Organization struct {
@@ -52,13 +52,14 @@ func OrganizationProjectsV2(client *Client, repo ghrepo.Interface) ([]RepoProjec
 					HasNextPage bool
 					EndCursor   string
 				}
-			} `graphql:"projectsV2(first: 100, orderBy: {field: TITLE, direction: ASC}, after: $endCursor)"`
+			} `graphql:"projectsV2(first: 100, orderBy: {field: TITLE, direction: ASC}, after: $endCursor, query: $query)"`
 		} `graphql:"organization(login: $owner)"`
 	}
 
 	variables := map[string]interface{}{
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"endCursor": (*githubv4.String)(nil),
+		"query":     githubv4.String("is:open"),
 	}
 
 	var projectsV2 []RepoProjectV2
@@ -69,11 +70,7 @@ func OrganizationProjectsV2(client *Client, repo ghrepo.Interface) ([]RepoProjec
 			return nil, err
 		}
 
-		for _, p := range query.Organization.ProjectsV2.Nodes {
-			if !p.Closed {
-				projectsV2 = append(projectsV2, p)
-			}
-		}
+		projectsV2 = append(projectsV2, query.Organization.ProjectsV2.Nodes...)
 
 		if !query.Organization.ProjectsV2.PageInfo.HasNextPage {
 			break

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -379,6 +379,19 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 		}
 	}
 
+	// projectsV2 are added in yet another mutation
+	projectV2Ids, ok := params["projectV2Ids"].([]string)
+	if ok {
+		projectItems := make(map[string]string, len(projectV2Ids))
+		for _, p := range projectV2Ids {
+			projectItems[p] = pr.ID
+		}
+		err = UpdateProjectV2Items(client, repo, projectItems, nil)
+		if err != nil {
+			return pr, err
+		}
+	}
+
 	return pr, nil
 }
 

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -74,6 +74,7 @@ type PullRequest struct {
 	Assignees      Assignees
 	Labels         Labels
 	ProjectCards   ProjectCards
+	ProjectItems   ProjectItems
 	Milestone      *Milestone
 	Comments       Comments
 	ReactionGroups ReactionGroups

--- a/api/queries_projects_v2.go
+++ b/api/queries_projects_v2.go
@@ -9,6 +9,11 @@ import (
 	"github.com/cli/cli/v2/internal/ghrepo"
 )
 
+const (
+	projectScope = "project"
+	scopesHeader = "X-Oauth-Scopes"
+)
+
 // UpdateProjectV2Items uses the addProjectV2ItemById and the deleteProjectV2Item mutations
 // to add and delete items from projects. The addProjectItems and deleteProjectItems arguments are
 // mappings between a project and an item. This function can be used across multiple projects
@@ -19,8 +24,8 @@ func UpdateProjectV2Items(client *Client, repo ghrepo.Interface, addProjectItems
 	if l == 0 {
 		return nil
 	}
-	inputs := make([]string, l)
-	mutations := make([]string, l)
+	inputs := make([]string, 0, l)
+	mutations := make([]string, 0, l)
 	variables := make(map[string]interface{}, l)
 	var i int
 
@@ -43,7 +48,7 @@ func UpdateProjectV2Items(client *Client, repo ghrepo.Interface, addProjectItems
 	return client.GraphQL(repo.RepoHost(), query, variables, nil)
 }
 
-// If auth token has "projects" scope that means that the host supports
+// If auth token has project scope that means that the host supports
 // projectsV2 and also that the auth token has correct permissions to
 // manipute them.
 func HasProjectsV2Scope(client *http.Client, host string) bool {
@@ -56,6 +61,6 @@ func HasProjectsV2Scope(client *http.Client, host string) bool {
 	if res.StatusCode != 200 {
 		return false
 	}
-	scopes := res.Header.Get("X-Oauth-Scopes")
-	return strings.Contains(scopes, "project")
+	scopes := res.Header.Get(scopesHeader)
+	return strings.Contains(scopes, projectScope)
 }

--- a/api/queries_projects_v2.go
+++ b/api/queries_projects_v2.go
@@ -37,3 +37,35 @@ func AddProjectV2ItemById(client *Client, repo *Repository, params map[string]in
 
 	return &result.AddItem.Item, nil
 }
+
+// DeleteProjectV2Item removes an item (e.g. issue or pull request) from a project V2
+func DeleteProjectV2Item(client *Client, repo *Repository, params map[string]interface{}) (*Item, error) {
+	query := `
+	mutation DeleteProjectV2Item($input: DeleteProjectV2ItemInput!) {
+		deleteProjectV2Item(input: $input) {
+			deletedItemId
+		}
+	}`
+
+	inputParams := map[string]interface{}{
+		"itemId":    params["itemId"],
+		"projectId": params["projectId"],
+	}
+
+	variables := map[string]interface{}{
+		"input": inputParams,
+	}
+
+	result := struct {
+		RemoveItem struct {
+			Item Item
+		}
+	}{}
+
+	err := client.GraphQL(repo.RepoHost(), query, variables, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result.RemoveItem.Item, nil
+}

--- a/api/queries_projects_v2.go
+++ b/api/queries_projects_v2.go
@@ -1,0 +1,39 @@
+package api
+
+type Item struct {
+	ID string
+}
+
+// AddProjectV2ItemById adds an item (e.g. issue or pull request) to a project V2
+func AddProjectV2ItemById(client *Client, repo *Repository, params map[string]interface{}) (*Item, error) {
+	query := `
+	mutation AddProjectV2ItemById($input: AddProjectV2ItemByIdInput!) {
+		addProjectV2ItemById(input: $input) {
+			item {
+				id
+			}
+		}
+	}`
+
+	inputParams := map[string]interface{}{
+		"contentId": params["contentId"],
+		"projectId": params["projectId"],
+	}
+
+	variables := map[string]interface{}{
+		"input": inputParams,
+	}
+
+	result := struct {
+		AddItem struct {
+			Item Item
+		}
+	}{}
+
+	err := client.GraphQL(repo.RepoHost(), query, variables, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result.AddItem.Item, nil
+}

--- a/api/queries_projects_v2_test.go
+++ b/api/queries_projects_v2_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateProjectV2Items(t *testing.T) {
+	var tests = []struct {
+		name        string
+		httpStubs   func(*httpmock.Registry)
+		expectError bool
+	}{
+		{
+			name: "updates project items",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateProjectV2Items\b`),
+					httpmock.GraphQLQuery(`{"data":{"add_000":{"item":{"id":"1"}},"delete_001":{"item":{"id":"2"}}}}`,
+						func(mutations string, inputs map[string]interface{}) {
+							expectedMutations := `
+                mutation UpdateProjectV2Items(
+                  $input_000: AddProjectV2ItemByIdInput!
+                  $input_001: AddProjectV2ItemByIdInput!
+                  $input_002: DeleteProjectV2ItemInput!
+                  $input_003: DeleteProjectV2ItemInput!
+                ) {
+                  add_000: addProjectV2ItemById(input: $input_000) { item { id } }
+                  add_001: addProjectV2ItemById(input: $input_001) { item { id } }
+                  delete_002: deleteProjectV2Item(input: $input_002) { deletedItemId }
+                  delete_003: deleteProjectV2Item(input: $input_003) { deletedItemId }
+                }`
+							expectedVariables := map[string]interface{}{
+								"input_000": map[string]interface{}{"contentId": "item1", "projectId": "project1"},
+								"input_001": map[string]interface{}{"contentId": "item2", "projectId": "project2"},
+								"input_002": map[string]interface{}{"itemId": "item3", "projectId": "project3"},
+								"input_003": map[string]interface{}{"itemId": "item4", "projectId": "project4"},
+							}
+							assert.Equal(t, stripSpace(expectedMutations), stripSpace(mutations))
+							assert.Equal(t, expectedVariables, inputs)
+						}))
+			},
+		},
+		{
+			name: "fails to update project items",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateProjectV2Items\b`),
+					httpmock.GraphQLMutation(`{"data":{}, "errors": [{"message": "some gql error"}]}`, func(inputs map[string]interface{}) {}),
+				)
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			if tt.httpStubs != nil {
+				tt.httpStubs(reg)
+			}
+			client := newTestClient(reg)
+			repo, _ := ghrepo.FromFullName("OWNER/REPO")
+			addProjectItems := map[string]string{"project1": "item1", "project2": "item2"}
+			deleteProjectItems := map[string]string{"project3": "item3", "project4": "item4"}
+			err := UpdateProjectV2Items(client, repo, addProjectItems, deleteProjectItems)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHasProjectsV2Scope(t *testing.T) {
+	var tests = []struct {
+		name      string
+		httpStubs func(*httpmock.Registry)
+		expect    bool
+	}{
+		{
+			name: "has project scope",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("HEAD", ""),
+					httpmock.ScopesResponder("repo, read:org, project"),
+				)
+			},
+			expect: true,
+		},
+		{
+			name: "has read:project scope",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("HEAD", ""),
+					httpmock.ScopesResponder("repo, read:org, read:project"),
+				)
+			},
+			expect: true,
+		},
+		{
+			name: "does not have project scope",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("HEAD", ""),
+					httpmock.ScopesResponder("repo, read:org"),
+				)
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			if tt.httpStubs != nil {
+				tt.httpStubs(reg)
+			}
+			client := &http.Client{Transport: reg}
+			actual := HasProjectsV2Scope(client, "github.com")
+			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func stripSpace(str string) string {
+	var b strings.Builder
+	b.Grow(len(str))
+	for _, ch := range str {
+		if !unicode.IsSpace(ch) {
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
+}

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1102,7 +1102,7 @@ func RepoProjectsV2(client *Client, repo ghrepo.Interface) ([]RepoProjectV2, err
 					HasNextPage bool
 					EndCursor   string
 				}
-			} `graphql:"projectsV2(first: 100, orderBy: {field: TITLE, direction: ASC}, after: $endCursor)"`
+			} `graphql:"projectsV2(first: 100, orderBy: {field: TITLE, direction: ASC}, after: $endCursor, query: $query)"`
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
@@ -1110,6 +1110,7 @@ func RepoProjectsV2(client *Client, repo ghrepo.Interface) ([]RepoProjectV2, err
 		"owner":     githubv4.String(repo.RepoOwner()),
 		"name":      githubv4.String(repo.RepoName()),
 		"endCursor": (*githubv4.String)(nil),
+		"query":     githubv4.String("is:open"),
 	}
 
 	var projectsV2 []RepoProjectV2
@@ -1120,11 +1121,7 @@ func RepoProjectsV2(client *Client, repo ghrepo.Interface) ([]RepoProjectV2, err
 			return nil, err
 		}
 
-		for _, p := range query.Repository.ProjectsV2.Nodes {
-			if !p.Closed {
-				projectsV2 = append(projectsV2, p)
-			}
-		}
+		projectsV2 = append(projectsV2, query.Repository.ProjectsV2.Nodes...)
 
 		if !query.Repository.ProjectsV2.PageInfo.HasNextPage {
 			break

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1156,8 +1156,7 @@ func RepoAndOrgProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, e
 func RepoAndOrgProjectsV2(client *Client, repo ghrepo.Interface) ([]RepoProjectV2, error) {
 	projectsV2, err := RepoProjectsV2(client, repo)
 	if err != nil {
-		if !strings.Contains(err.Error(), "Your token has not been granted the required scopes to execute this query") ||
-			!strings.Contains(err.Error(), "Field 'ProjectsV2' doesn't exist on type 'Repository'") {
+		if ProjectsV2IgnorableError(err) {
 			return nil, nil
 		}
 

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -985,6 +985,14 @@ type RepoProject struct {
 	ResourcePath string `json:"resourcePath"`
 }
 
+type RepoProjectV2 struct {
+	ID           string `json:"id"`
+	Title        string `json:"title"`
+	Number       int    `json:"number"`
+	ResourcePath string `json:"resourcePath"`
+	Closed       bool   `json:"closed"`
+}
+
 // RepoProjects fetches all open projects for a repository
 func RepoProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, error) {
 	type responseData struct {
@@ -1021,6 +1029,49 @@ func RepoProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, error) 
 	}
 
 	return projects, nil
+}
+
+// RepoProjectsV2 fetches all open projectsV2 for a repository
+func RepoProjectsV2(client *Client, repo ghrepo.Interface) ([]RepoProjectV2, error) {
+	type responseData struct {
+		Repository struct {
+			ProjectsV2 struct {
+				Nodes    []RepoProjectV2
+				PageInfo struct {
+					HasNextPage bool
+					EndCursor   string
+				}
+			} `graphql:"projectsV2(first: 100, orderBy: {field: TITLE, direction: ASC}, after: $endCursor)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	variables := map[string]interface{}{
+		"owner":     githubv4.String(repo.RepoOwner()),
+		"name":      githubv4.String(repo.RepoName()),
+		"endCursor": (*githubv4.String)(nil),
+	}
+
+	var projectsV2 []RepoProjectV2
+	for {
+		var query responseData
+		err := client.Query(repo.RepoHost(), "RepositoryProjectV2List", &query, variables)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, p := range query.Repository.ProjectsV2.Nodes {
+			if !p.Closed {
+				projectsV2 = append(projectsV2, p)
+			}
+		}
+
+		if !query.Repository.ProjectsV2.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Repository.ProjectsV2.PageInfo.EndCursor)
+	}
+
+	return projectsV2, nil
 }
 
 // RepoAndOrgProjects fetches all open projects for a repository and its org

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1299,7 +1299,6 @@ func RepoMilestones(client *Client, repo ghrepo.Interface, state string) ([]Repo
 
 func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []string) ([]string, error) {
 	var paths []string
-	// projectsV2 are ignored for now
 	projects, projectsV2, err := RepoAndOrgProjects(client, repo)
 	if err != nil {
 		return paths, err

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -198,16 +198,17 @@ func Test_RepoMetadata(t *testing.T) {
 }
 
 func Test_ProjectsToPaths(t *testing.T) {
-	expectedProjectPaths := []string{"OWNER/REPO/PROJECT_NUMBER", "ORG/PROJECT_NUMBER"}
+	expectedProjectPaths := []string{"OWNER/REPO/PROJECT_NUMBER", "ORG/PROJECT_NUMBER", "OWNER/REPO/PROJECT_NUMBER_2"}
 	projects := []RepoProject{
 		{ID: "id1", Name: "My Project", ResourcePath: "/OWNER/REPO/projects/PROJECT_NUMBER"},
 		{ID: "id2", Name: "Org Project", ResourcePath: "/orgs/ORG/projects/PROJECT_NUMBER"},
 		{ID: "id3", Name: "Project", ResourcePath: "/orgs/ORG/projects/PROJECT_NUMBER_2"},
 	}
 	projectsV2 := []RepoProjectV2{
-		{ID: "id4", Title: "My Project V2", ResourcePath: "/OWNER/REPO/projects/PROJECT_NUMBER_3"},
+		{ID: "id4", Title: "My Project V2", ResourcePath: "/OWNER/REPO/projects/PROJECT_NUMBER_2"},
+		{ID: "id5", Title: "Org Project V2", ResourcePath: "/orgs/ORG/projects/PROJECT_NUMBER_3"},
 	}
-	projectNames := []string{"My Project", "Org Project"}
+	projectNames := []string{"My Project", "Org Project", "My Project V2"}
 
 	projectPaths, err := ProjectsToPaths(projects, projectsV2, projectNames)
 	if err != nil {
@@ -272,7 +273,7 @@ func Test_ProjectNamesToPaths(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expectedProjectPaths := []string{"ORG/1", "OWNER/REPO/2"}
+	expectedProjectPaths := []string{"ORG/1", "OWNER/REPO/2", "ORG/2", "OWNER/REPO/4"}
 	if !sliceEqual(projectPaths, expectedProjectPaths) {
 		t.Errorf("expected projects paths %v, got %v", expectedProjectPaths, projectPaths)
 	}

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -204,9 +204,12 @@ func Test_ProjectsToPaths(t *testing.T) {
 		{ID: "id2", Name: "Org Project", ResourcePath: "/orgs/ORG/projects/PROJECT_NUMBER"},
 		{ID: "id3", Name: "Project", ResourcePath: "/orgs/ORG/projects/PROJECT_NUMBER_2"},
 	}
+	projectsV2 := []RepoProjectV2{
+		{ID: "id4", Title: "My Project V2", ResourcePath: "/OWNER/REPO/projects/PROJECT_NUMBER_3"},
+	}
 	projectNames := []string{"My Project", "Org Project"}
 
-	projectPaths, err := ProjectsToPaths(projects, projectNames)
+	projectPaths, err := ProjectsToPaths(projects, projectsV2, projectNames)
 	if err != nil {
 		t.Errorf("error resolving projects: %v", err)
 	}
@@ -264,7 +267,7 @@ func Test_ProjectNamesToPaths(t *testing.T) {
 		} } } }
 		`))
 
-	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap"})
+	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap", "TriageV2", "RoadmapV2"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -275,7 +275,7 @@ func IssueGraphQL(fields []string) string {
 		case "projectCards":
 			q = append(q, `projectCards(first:100){nodes{project{name}column{name}},totalCount}`)
 		case "projectItems":
-			q = append(q, `projectItems(first:100){nodes{id, project{title}}}`)
+			q = append(q, `projectItems(first:100){nodes{id, project{id,title}},totalCount}`)
 		case "milestone":
 			q = append(q, `milestone{number,title,description,dueOn}`)
 		case "reactionGroups":

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -274,6 +274,8 @@ func IssueGraphQL(fields []string) string {
 			q = append(q, `labels(first:100){nodes{id,name,description,color},totalCount}`)
 		case "projectCards":
 			q = append(q, `projectCards(first:100){nodes{project{name}column{name}},totalCount}`)
+		case "projectItems":
+			q = append(q, `projectItems(first:100){nodes{id}}`)
 		case "milestone":
 			q = append(q, `milestone{number,title,description,dueOn}`)
 		case "reactionGroups":

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -275,7 +275,7 @@ func IssueGraphQL(fields []string) string {
 		case "projectCards":
 			q = append(q, `projectCards(first:100){nodes{project{name}column{name}},totalCount}`)
 		case "projectItems":
-			q = append(q, `projectItems(first:100){nodes{id}}`)
+			q = append(q, `projectItems(first:100){nodes{id, project{title}}}`)
 		case "milestone":
 			q = append(q, `milestone{number,title,description,dueOn}`)
 		case "reactionGroups":

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -248,6 +248,8 @@ func createRun(opts *CreateOptions) (err error) {
 				Repo:      baseRepo,
 				State:     &tb,
 			}
+			//TODO: Add projects scope to default scopes and add good error messaging when scope is missing
+			//TODO: handle GHES versions that do not support projectsV2
 			err = prShared.MetadataSurvey(opts.IO, baseRepo, fetcher, &tb)
 			if err != nil {
 				return
@@ -285,6 +287,7 @@ func createRun(opts *CreateOptions) (err error) {
 			params["issueTemplate"] = templateNameForSubmit
 		}
 
+		//TODO: Add projects scope to default scopes and add good error messaging when scope is missing
 		err = prShared.AddMetadataToIssueParams(apiClient, baseRepo, params, &tb)
 		if err != nil {
 			return
@@ -296,37 +299,12 @@ func createRun(opts *CreateOptions) (err error) {
 			return
 		}
 
-		projectV2Ids, ok := params["projectV2Ids"].([]string)
-		if ok {
-			err = addIssueToProjectsV2(apiClient, repo, newIssue, projectV2Ids)
-			if err != nil {
-				fmt.Fprintln(opts.IO.ErrOut, "Failed to add issue with ID", newIssue.ID, "to projectsV2:", err)
-				return
-			}
-		}
-
 		fmt.Fprintln(opts.IO.Out, newIssue.URL)
 	} else {
 		panic("Unreachable state")
 	}
 
 	return
-}
-
-func addIssueToProjectsV2(client *api.Client, repo *api.Repository, issue *api.Issue, projectV2Ids []string) error {
-	for _, projectId := range projectV2Ids {
-		addItemParams := map[string]interface{}{
-			"contentId": issue.ID,
-			"projectId": projectId,
-		}
-
-		_, err := api.AddProjectV2ItemById(client, repo, addItemParams)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func generatePreviewURL(apiClient *api.Client, baseRepo ghrepo.Interface, tb shared.IssueMetadataState) (string, error) {

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -248,8 +248,6 @@ func createRun(opts *CreateOptions) (err error) {
 				Repo:      baseRepo,
 				State:     &tb,
 			}
-			//TODO: Add projects scope to default scopes and add good error messaging when scope is missing
-			//TODO: handle GHES versions that do not support projectsV2
 			err = prShared.MetadataSurvey(opts.IO, baseRepo, fetcher, &tb)
 			if err != nil {
 				return
@@ -287,7 +285,6 @@ func createRun(opts *CreateOptions) (err error) {
 			params["issueTemplate"] = templateNameForSubmit
 		}
 
-		//TODO: Add projects scope to default scopes and add good error messaging when scope is missing
 		err = prShared.AddMetadataToIssueParams(apiClient, baseRepo, params, &tb)
 		if err != nil {
 			return

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -296,12 +296,35 @@ func createRun(opts *CreateOptions) (err error) {
 			return
 		}
 
+		projectV2Ids, ok := params["projectV2Ids"].([]string)
+		if ok {
+			err = addIssueToProjectsV2(apiClient, repo, newIssue, projectV2Ids)
+			if err != nil {
+				fmt.Fprintln(opts.IO.ErrOut, "Failed to add issue with ID %w to projectsV2: %w", newIssue.ID, err)
+				return
+			}
+		}
+
 		fmt.Fprintln(opts.IO.Out, newIssue.URL)
 	} else {
 		panic("Unreachable state")
 	}
 
 	return
+}
+
+func addIssueToProjectsV2(client *api.Client, repo *api.Repository, issue *api.Issue, projectV2Ids []string) error {
+	for _, projectId := range projectV2Ids {
+		addItemParams := map[string]interface{}{
+			"contentId": issue.ID,
+			"projectId": projectId,
+		}
+
+		_, err := api.AddProjectV2ItemById(client, repo, addItemParams)
+		return err
+	}
+
+	return nil
 }
 
 func generatePreviewURL(apiClient *api.Client, baseRepo ghrepo.Interface, tb shared.IssueMetadataState) (string, error) {

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -300,7 +300,7 @@ func createRun(opts *CreateOptions) (err error) {
 		if ok {
 			err = addIssueToProjectsV2(apiClient, repo, newIssue, projectV2Ids)
 			if err != nil {
-				fmt.Fprintln(opts.IO.ErrOut, "Failed to add issue with ID %w to projectsV2: %w", newIssue.ID, err)
+				fmt.Fprintln(opts.IO.ErrOut, "Failed to add issue with ID", newIssue.ID, "to projectsV2:", err)
 				return
 			}
 		}

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -321,7 +321,9 @@ func addIssueToProjectsV2(client *api.Client, repo *api.Repository, issue *api.I
 		}
 
 		_, err := api.AddProjectV2ItemById(client, repo, addItemParams)
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -815,7 +815,7 @@ func TestIssueCreate_projectsV2(t *testing.T) {
 			assert.Equal(t, 2, len(inputs))
 		}))
 
-	output, err := runCommand(http, true, `-t TITLE -b BODY -p roadmapv2`)
+	output, err := runCommand(http, true, `-t TITLE -b BODY -p roadmapv2`, nil)
 	if err != nil {
 		t.Errorf("error running command `issue create`: %v", err)
 	}

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -217,6 +217,24 @@ func Test_createRun(t *testing.T) {
 						],
 						"pageInfo": { "hasNextPage": false }
 					} } } }`))
+				r.Register(
+					httpmock.GraphQL(`query RepositoryProjectV2List\b`),
+					httpmock.StringResponse(`
+					{ "data": { "repository": { "projectsV2": {
+						"nodes": [
+							{ "title": "CleanupV2", "id": "CLEANUPV2ID", "resourcePath": "/OWNER/REPO/projects/2" }
+						],
+						"pageInfo": { "hasNextPage": false }
+					} } } }`))
+				r.Register(
+					httpmock.GraphQL(`query OrganizationProjectV2List\b`),
+					httpmock.StringResponse(`
+					{ "data": { "organization": { "projectsV2": {
+						"nodes": [
+							{ "title": "Triage", "id": "TRIAGEID", "resourcePath": "/orgs/ORG/projects/2"  }
+						],
+						"pageInfo": { "hasNextPage": false }
+					} } } }`))
 			},
 			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?body=&projects=OWNER%2FREPO%2F1",
 			wantsStderr: "Opening github.com/OWNER/REPO/issues/new in your browser.\n",
@@ -613,6 +631,28 @@ func TestIssueCreate_metadata(t *testing.T) {
 		}
 		`))
 	http.Register(
+		httpmock.GraphQL(`query RepositoryProjectV2List\b`),
+		httpmock.StringResponse(`
+		{ "data": { "repository": { "projectsV2": {
+			"nodes": [
+				{ "title": "CleanupV2", "id": "CLEANUPV2ID" },
+				{ "title": "RoadmapV2", "id": "ROADMAPV2ID" }
+			],
+			"pageInfo": { "hasNextPage": false }
+		} } } }
+		`))
+	http.Register(
+		httpmock.GraphQL(`query OrganizationProjectV2List\b`),
+		httpmock.StringResponse(`
+		{	"data": { "organization": null },
+			"errors": [{
+				"type": "NOT_FOUND",
+				"path": [ "organization" ],
+				"message": "Could not resolve to an Organization with the login of 'OWNER'."
+			}]
+		}
+		`))
+	http.Register(
 		httpmock.GraphQL(`mutation IssueCreate\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "createIssue": { "issue": {
@@ -631,6 +671,7 @@ func TestIssueCreate_metadata(t *testing.T) {
 			if v, ok := inputs["teamIds"]; ok {
 				t.Errorf("did not expect teamIds: %v", v)
 			}
+			assert.NotContains(t, inputs, "projectV2Ids")
 		}))
 
 	output, err := runCommand(http, true, `-t TITLE -b BODY -a monalisa -l bug -l todo -p roadmap -m 'big one.oh'`, nil)

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -160,9 +160,12 @@ func editRun(opts *EditOptions) error {
 	editable.Body.Default = issue.Body
 	editable.Assignees.Default = issue.Assignees.Logins()
 	editable.Labels.Default = issue.Labels.Names()
-	defaultProjectNames := issue.ProjectCards.ProjectNames()
-	defaultProjectNames = append(defaultProjectNames, issue.ProjectItems.ProjectTitles()...)
-	editable.Projects.Default = defaultProjectNames
+	editable.Projects.Default = append(issue.ProjectCards.ProjectNames(), issue.ProjectItems.ProjectTitles()...)
+	projectItems := map[string]string{}
+	for _, n := range issue.ProjectItems.Nodes {
+		projectItems[n.Project.ID] = n.ID
+	}
+	editable.Projects.ProjectItems = projectItems
 	if issue.Milestone != nil {
 		editable.Milestone.Default = issue.Milestone.Title
 	}
@@ -194,7 +197,7 @@ func editRun(opts *EditOptions) error {
 	}
 
 	opts.IO.StartProgressIndicator()
-	err = prShared.UpdateIssue(httpClient, repo, issue.ID, issue.ProjectItems.Nodes, issue.IsPullRequest(), editable)
+	err = prShared.UpdateIssue(httpClient, repo, issue.ID, issue.IsPullRequest(), editable)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -160,7 +160,9 @@ func editRun(opts *EditOptions) error {
 	editable.Body.Default = issue.Body
 	editable.Assignees.Default = issue.Assignees.Logins()
 	editable.Labels.Default = issue.Labels.Names()
-	editable.Projects.Default = issue.ProjectCards.ProjectNames()
+	defaultProjectNames := issue.ProjectCards.ProjectNames()
+	defaultProjectNames = append(defaultProjectNames, issue.ProjectItems.ProjectTitles()...)
+	editable.Projects.Default = defaultProjectNames
 	if issue.Milestone != nil {
 		editable.Milestone.Default = issue.Milestone.Title
 	}

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -145,6 +145,7 @@ func editRun(opts *EditOptions) error {
 	}
 	if opts.Interactive || editable.Projects.Edited {
 		lookupFields = append(lookupFields, "projectCards")
+		lookupFields = append(lookupFields, "projectItems")
 	}
 	if opts.Interactive || editable.Milestone.Edited {
 		lookupFields = append(lookupFields, "milestone")
@@ -191,7 +192,7 @@ func editRun(opts *EditOptions) error {
 	}
 
 	opts.IO.StartProgressIndicator()
-	err = prShared.UpdateIssue(httpClient, repo, issue.ID, issue.IsPullRequest(), editable)
+	err = prShared.UpdateIssue(httpClient, repo, issue.ID, issue.ProjectItems.Nodes, issue.IsPullRequest(), editable)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -303,6 +303,7 @@ func Test_editRun(t *testing.T) {
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockIssueGet(t, reg)
+				mockIssueProjectItemsGet(t, reg)
 				mockRepoMetadata(t, reg)
 				mockIssueUpdate(t, reg)
 				mockIssueUpdateLabels(t, reg)
@@ -340,6 +341,7 @@ func Test_editRun(t *testing.T) {
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockIssueGet(t, reg)
+				mockIssueProjectItemsGet(t, reg)
 				mockRepoMetadata(t, reg)
 				mockIssueUpdate(t, reg)
 				mockIssueUpdateLabels(t, reg)
@@ -390,7 +392,16 @@ func mockIssueGet(_ *testing.T, reg *httpmock.Registry) {
 					"nodes": [
 						{ "project": { "name": "Roadmap" } }
 					], "totalCount": 1
-				},
+				}
+			} } } }`),
+	)
+}
+
+func mockIssueProjectItemsGet(_ *testing.T, reg *httpmock.Registry) {
+	reg.Register(
+		httpmock.GraphQL(`query IssueProjectItems\b`),
+		httpmock.StringResponse(`
+			{ "data": { "repository": { "issue": {
 				"projectItems": {
 					"nodes": [
 						{ "id": "ITEMID", "project": { "title": "CleanupV2" } }

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -280,7 +280,7 @@ func Test_editRun(t *testing.T) {
 					},
 					Projects: prShared.EditableSlice{
 						Add:    []string{"Cleanup", "RoadmapV2"},
-						Remove: []string{"Roadmap", "CleanupV2"},
+						Remove: []string{"Roadmap"},
 						Edited: true,
 					},
 					Milestone: prShared.EditableString{
@@ -297,7 +297,6 @@ func Test_editRun(t *testing.T) {
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockIssueGet(t, reg)
-				reg.StubRepoInfoResponse("OWNER", "REPO", "main")
 				mockRepoMetadata(t, reg)
 				mockIssueUpdate(t, reg)
 				mockIssueUpdateLabels(t, reg)
@@ -335,6 +334,7 @@ func Test_editRun(t *testing.T) {
 				mockIssueGet(t, reg)
 				mockRepoMetadata(t, reg)
 				mockIssueUpdate(t, reg)
+				mockProjectV2ItemUpdate(t, reg)
 			},
 			stdout: "https://github.com/OWNER/REPO/issue/123\n",
 		},
@@ -374,7 +374,7 @@ func mockIssueGet(_ *testing.T, reg *httpmock.Registry) {
 				"url": "https://github.com/OWNER/REPO/issue/123",
 				"projectItems": {
 					"nodes": [
-						{ "id": "1" }
+						{ "id": "1", "project": { "title": "CleanupV2" } }
 					]
 				}
 			} } } }`),
@@ -382,6 +382,7 @@ func mockIssueGet(_ *testing.T, reg *httpmock.Registry) {
 }
 
 func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry) {
+	reg.StubRepoInfoResponse("OWNER", "REPO", "main")
 	reg.Register(
 		httpmock.GraphQL(`query RepositoryAssignableUsers\b`),
 		httpmock.StringResponse(`

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -431,6 +431,27 @@ func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry) {
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryProjectV2List\b`),
+		httpmock.StringResponse(`
+		{ "data": { "repository": { "projectsV2": {
+			"nodes": [
+				{ "title": "CleanupV2", "id": "CLEANUPV2ID" },
+				{ "title": "RoadmapV2", "id": "ROADMAPV2ID" }
+			],
+			"pageInfo": { "hasNextPage": false }
+		} } } }
+		`))
+	reg.Register(
+		httpmock.GraphQL(`query OrganizationProjectV2List\b`),
+		httpmock.StringResponse(`
+		{ "data": { "organization": { "projectsV2": {
+			"nodes": [
+				{ "title": "TriageV2", "id": "TRIAGEV2ID" }
+			],
+			"pageInfo": { "hasNextPage": false }
+		} } } }
+		`))
 }
 
 func mockIssueUpdate(t *testing.T, reg *httpmock.Registry) {

--- a/pkg/cmd/issue/shared/lookup.go
+++ b/pkg/cmd/issue/shared/lookup.go
@@ -97,11 +97,13 @@ func findIssueOrPR(httpClient *http.Client, repo ghrepo.Interface, number int, f
 			fieldSet.Remove("stateReason")
 		}
 	}
+
+	var getProjectItems bool
 	if fieldSet.Contains("projectItems") {
-		if !api.HasProjectsV2Scope(httpClient, repo.RepoHost()) {
-			fieldSet.Remove("projectItems")
-		}
+		getProjectItems = true
+		fieldSet.Remove("projectItems")
 	}
+
 	fields = fieldSet.ToSlice()
 
 	type response struct {
@@ -154,6 +156,14 @@ func findIssueOrPR(httpClient *http.Client, repo ghrepo.Interface, number int, f
 
 	if resp.Repository.Issue == nil {
 		return nil, errors.New("issue was not found but GraphQL reported no error")
+	}
+
+	if getProjectItems {
+		apiClient := api.NewClientFromHTTP(httpClient)
+		err := api.ProjectsV2ItemsForIssue(apiClient, repo, resp.Repository.Issue)
+		if err != nil && !api.ProjectsV2IgnorableError(err) {
+			return nil, err
+		}
 	}
 
 	return resp.Repository.Issue, nil

--- a/pkg/cmd/issue/shared/lookup.go
+++ b/pkg/cmd/issue/shared/lookup.go
@@ -97,6 +97,11 @@ func findIssueOrPR(httpClient *http.Client, repo ghrepo.Interface, number int, f
 			fieldSet.Remove("stateReason")
 		}
 	}
+	if fieldSet.Contains("projectItems") {
+		if !api.HasProjectsV2Scope(httpClient, repo.RepoHost()) {
+			fieldSet.Remove("projectItems")
+		}
+	}
 	fields = fieldSet.ToSlice()
 
 	type response struct {

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -648,18 +648,6 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 
 	opts.IO.StartProgressIndicator()
 	pr, err := api.CreatePullRequest(client, ctx.BaseRepo, params)
-
-	if pr != nil {
-		projectV2Ids, ok := params["projectV2Ids"].([]string)
-		if ok {
-			err = addPullRequestToProjectsV2(client, ctx.BaseRepo, pr, projectV2Ids)
-			if err != nil {
-				fmt.Fprintln(opts.IO.ErrOut, "Failed to add pull request with ID", pr.ID, "to projectsV2:", err)
-				return err
-			}
-		}
-	}
-
 	opts.IO.StopProgressIndicator()
 	if pr != nil {
 		fmt.Fprintln(opts.IO.Out, pr.URL)
@@ -670,22 +658,6 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 		}
 		return fmt.Errorf("pull request create failed: %w", err)
 	}
-	return nil
-}
-
-func addPullRequestToProjectsV2(client *api.Client, repo *api.Repository, pullRequest *api.PullRequest, projectV2Ids []string) error {
-	for _, projectId := range projectV2Ids {
-		addItemParams := map[string]interface{}{
-			"contentId": pullRequest.ID,
-			"projectId": projectId,
-		}
-
-		_, err := api.AddProjectV2ItemById(client, repo, addItemParams)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -681,7 +681,9 @@ func addPullRequestToProjectsV2(client *api.Client, repo *api.Repository, pullRe
 		}
 
 		_, err := api.AddProjectV2ItemById(client, repo, addItemParams)
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -654,7 +654,7 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 		if ok {
 			err = addPullRequestToProjectsV2(client, ctx.BaseRepo, pr, projectV2Ids)
 			if err != nil {
-				fmt.Fprintln(opts.IO.ErrOut, "Failed to add pull request with ID %w to projectsV2: %w", pr.ID, err)
+				fmt.Fprintln(opts.IO.ErrOut, "Failed to add pull request with ID", pr.ID, "to projectsV2:", err)
 				return err
 			}
 		}

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -576,9 +576,28 @@ func Test_createRun(t *testing.T) {
 				} } } }
 				`))
 				reg.Register(
+					httpmock.GraphQL(`query RepositoryProjectV2List\b`),
+					httpmock.StringResponse(`
+				{ "data": { "repository": { "projectsV2": {
+					"nodes": [
+						{ "title": "CleanupV2", "id": "CLEANUPV2ID" },
+						{ "title": "RoadmapV2", "id": "ROADMAPV2ID" }
+					],
+					"pageInfo": { "hasNextPage": false }
+				} } } }			
+				`))
+				reg.Register(
 					httpmock.GraphQL(`query OrganizationProjectList\b`),
 					httpmock.StringResponse(`
 				{ "data": { "organization": { "projects": {
+					"nodes": [],
+					"pageInfo": { "hasNextPage": false }
+				} } } }
+				`))
+				reg.Register(
+					httpmock.GraphQL(`query OrganizationProjectV2List\b`),
+					httpmock.StringResponse(`
+				{ "data": { "organization": { "projectsV2": {
 					"nodes": [],
 					"pageInfo": { "hasNextPage": false }
 				} } } }
@@ -698,11 +717,41 @@ func Test_createRun(t *testing.T) {
 			} } } }
 			`))
 				reg.Register(
+					httpmock.GraphQL(`query RepositoryProjectList\b`),
+					httpmock.StringResponse(`
+			{ "data": { "repository": { "projects": {
+				"nodes": [
+					{ "name": "Cleanup", "id": "CLEANUPID", "resourcePath": "/OWNER/REPO/projects/1" }
+				],
+				"pageInfo": { "hasNextPage": false }
+			} } } }
+			`))
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryProjectV2List\b`),
+					httpmock.StringResponse(`
+			{ "data": { "repository": { "projectsV2": {
+				"nodes": [
+					{ "title": "CleanupV2", "id": "CLEANUPV2ID", "resourcePath": "/OWNER/REPO/projects/2" }
+				],
+				"pageInfo": { "hasNextPage": false }
+			} } } }
+			`))
+				reg.Register(
 					httpmock.GraphQL(`query OrganizationProjectList\b`),
 					httpmock.StringResponse(`
 			{ "data": { "organization": { "projects": {
 				"nodes": [
 					{ "name": "Triage", "id": "TRIAGEID", "resourcePath": "/orgs/ORG/projects/1"  }
+				],
+				"pageInfo": { "hasNextPage": false }
+			} } } }
+			`))
+				reg.Register(
+					httpmock.GraphQL(`query OrganizationProjectV2List\b`),
+					httpmock.StringResponse(`
+			{ "data": { "organization": { "projectsV2": {
+				"nodes": [
+					{ "title": "TriageV2", "id": "TRIAGEV2ID", "resourcePath": "/orgs/ORG/projects/2"  }
 				],
 				"pageInfo": { "hasNextPage": false }
 			} } } }

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -288,12 +288,15 @@ func Test_createRun(t *testing.T) {
 				opts.BodyProvided = true
 				opts.Title = "my title"
 				opts.Body = "my body"
-				opts.Projects = []string{"roadmap2"}
+				opts.Projects = []string{"RoadmapV2"}
 				return func() {}
 			},
 			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
-				reg.StubRepoInfoResponse("OWNER", "REPO", "master")
+				// reg.StubRepoInfoResponse("OWNER", "REPO", "master")
 				reg.StubRepoResponse("OWNER", "REPO")
+				reg.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StringResponse(`{"data": {"viewer": {"login": "OWNER"} } }`))
 				reg.Register(
 					httpmock.GraphQL(`query RepositoryProjectList\b`),
 					httpmock.StringResponse(`{ "data": { "repository": { "projects": { "nodes": [],	"pageInfo": { "hasNextPage": false } } } } }`))
@@ -301,11 +304,24 @@ func Test_createRun(t *testing.T) {
 					httpmock.GraphQL(`query OrganizationProjectList\b`),
 					httpmock.StringResponse(`{ "data": { "organization": { "projects": { "nodes": [], "pageInfo": { "hasNextPage": false } } } } }`))
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryProjectListV2\b`),
-					httpmock.StringResponse(`{ "data": { "repository": { "projectsV2": { "nodes": [],	"pageInfo": { "hasNextPage": false } } } } }`))
+					httpmock.GraphQL(`query RepositoryProjectV2List\b`),
+					httpmock.StringResponse(`
+				{ "data": { "repository": { "projectsV2": {
+					"nodes": [
+						{ "title": "CleanupV2", "id": "CLEANUPV2ID" },
+						{ "title": "RoadmapV2", "id": "ROADMAPV2ID" }
+					],
+					"pageInfo": { "hasNextPage": false }
+				} } } }
+				`))
 				reg.Register(
-					httpmock.GraphQL(`query OrganizationProjectListV2\b`),
-					httpmock.StringResponse(`{ "data": { "organization": { "projectsV2": { "nodes": [], "pageInfo": { "hasNextPage": false } } } } }`))
+					httpmock.GraphQL(`query OrganizationProjectV2List\b`),
+					httpmock.StringResponse(`
+				{ "data": { "organization": { "projectsV2": {
+					"nodes": [],
+					"pageInfo": { "hasNextPage": false }
+				} } } }
+				`))
 				reg.Register(
 					httpmock.GraphQL(`mutation PullRequestCreate\b`),
 					httpmock.GraphQLMutation(`
@@ -776,16 +792,6 @@ func Test_createRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query UserCurrent\b`),
 					httpmock.StringResponse(`{"data": {"viewer": {"login": "OWNER"} } }`))
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryProjectList\b`),
-					httpmock.StringResponse(`
-			{ "data": { "repository": { "projects": {
-				"nodes": [
-					{ "name": "Cleanup", "id": "CLEANUPID", "resourcePath": "/OWNER/REPO/projects/1" }
-				],
-				"pageInfo": { "hasNextPage": false }
-			} } } }
-			`))
 				reg.Register(
 					httpmock.GraphQL(`query RepositoryProjectList\b`),
 					httpmock.StringResponse(`

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -166,7 +166,9 @@ func editRun(opts *EditOptions) error {
 	editable.Reviewers.Default = pr.ReviewRequests.Logins()
 	editable.Assignees.Default = pr.Assignees.Logins()
 	editable.Labels.Default = pr.Labels.Names()
-	editable.Projects.Default = pr.ProjectCards.ProjectNames()
+	defaultProjectNames := pr.ProjectCards.ProjectNames()
+	defaultProjectNames = append(defaultProjectNames, pr.ProjectItems.ProjectTitles()...)
+	editable.Projects.Default = defaultProjectNames
 	if pr.Milestone != nil {
 		editable.Milestone.Default = pr.Milestone.Title
 	}

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -530,6 +530,27 @@ func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry, skipReviewers bool) 
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryProjectV2List\b`),
+		httpmock.StringResponse(`
+		{ "data": { "repository": { "projectsV2": {
+			"nodes": [
+				{ "title": "CleanupV2", "id": "CLEANUPV2ID" },
+				{ "title": "RoadmapV2", "id": "ROADMAPV2ID" }
+			],
+			"pageInfo": { "hasNextPage": false }
+		} } } }
+		`))
+	reg.Register(
+		httpmock.GraphQL(`query OrganizationProjectV2List\b`),
+		httpmock.StringResponse(`
+		{ "data": { "organization": { "projectsV2": {
+			"nodes": [
+				{ "title": "TriageV2", "id": "TRIAGEV2ID" }
+			],
+			"pageInfo": { "hasNextPage": false }
+		} } } }
+		`))
 	if !skipReviewers {
 		reg.Register(
 			httpmock.GraphQL(`query OrganizationTeamList\b`),

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -311,6 +311,11 @@ func Test_editRun(t *testing.T) {
 				SelectorArg: "123",
 				Finder: shared.NewMockFinder("123", &api.PullRequest{
 					URL: "https://github.com/OWNER/REPO/pull/123",
+					ProjectItems: api.ProjectItems{
+						Nodes: []*api.ProjectV2Item{
+							{ID: "1"},
+						},
+					},
 				}, ghrepo.New("OWNER", "REPO")),
 				Interactive: false,
 				Editable: shared.Editable{
@@ -342,8 +347,8 @@ func Test_editRun(t *testing.T) {
 						Edited: true,
 					},
 					Projects: shared.EditableSlice{
-						Add:    []string{"Cleanup", "Roadmap"},
-						Remove: []string{"Features"},
+						Add:    []string{"Cleanup", "RoadmapV2"},
+						Remove: []string{"Roadmap", "CleanupV2"},
 						Edited: true,
 					},
 					Milestone: shared.EditableString{
@@ -354,10 +359,12 @@ func Test_editRun(t *testing.T) {
 				Fetcher: testFetcher{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.StubRepoInfoResponse("OWNER", "REPO", "main")
 				mockRepoMetadata(t, reg, false)
 				mockPullRequestUpdate(t, reg)
 				mockPullRequestReviewersUpdate(t, reg)
 				mockPullRequestUpdateLabels(t, reg)
+				mockProjectV2ItemUpdate(t, reg)
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123\n",
 		},
@@ -367,6 +374,11 @@ func Test_editRun(t *testing.T) {
 				SelectorArg: "123",
 				Finder: shared.NewMockFinder("123", &api.PullRequest{
 					URL: "https://github.com/OWNER/REPO/pull/123",
+					ProjectItems: api.ProjectItems{
+						Nodes: []*api.ProjectV2Item{
+							{ID: "1"},
+						},
+					},
 				}, ghrepo.New("OWNER", "REPO")),
 				Interactive: false,
 				Editable: shared.Editable{
@@ -393,8 +405,9 @@ func Test_editRun(t *testing.T) {
 						Edited: true,
 					},
 					Projects: shared.EditableSlice{
-						Value:  []string{"Cleanup", "Roadmap"},
-						Remove: []string{"Features"},
+						Value:  []string{"Cleanup", "RoadmapV2"},
+						Remove: []string{"RoadmapV2"},
+						Add:    []string{"CleanupV2"},
 						Edited: true,
 					},
 					Milestone: shared.EditableString{
@@ -405,9 +418,11 @@ func Test_editRun(t *testing.T) {
 				Fetcher: testFetcher{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.StubRepoInfoResponse("OWNER", "REPO", "main")
 				mockRepoMetadata(t, reg, true)
 				mockPullRequestUpdate(t, reg)
 				mockPullRequestUpdateLabels(t, reg)
+				mockProjectV2ItemUpdate(t, reg)
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123\n",
 		},
@@ -594,6 +609,21 @@ func mockPullRequestUpdateLabels(t *testing.T, reg *httpmock.Registry) {
 		httpmock.GraphQL(`mutation LabelRemove\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "removeLabelsFromLabelable": { "__typename": "" } } }`,
+			func(inputs map[string]interface{}) {}),
+	)
+}
+
+func mockProjectV2ItemUpdate(t *testing.T, reg *httpmock.Registry) {
+	reg.Register(
+		httpmock.GraphQL(`mutation AddProjectV2ItemById\b`),
+		httpmock.GraphQLMutation(`
+		{ "data": { "addProjectV2ItemById": { "__typename": "" } } }`,
+			func(inputs map[string]interface{}) {}),
+	)
+	reg.Register(
+		httpmock.GraphQL(`mutation DeleteProjectV2Item\b`),
+		httpmock.GraphQLMutation(`
+		{ "data": { "deleteProjectV2Item": { "__typename": "" } } }`,
 			func(inputs map[string]interface{}) {}),
 	)
 }

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -313,7 +313,14 @@ func Test_editRun(t *testing.T) {
 					URL: "https://github.com/OWNER/REPO/pull/123",
 					ProjectItems: api.ProjectItems{
 						Nodes: []*api.ProjectV2Item{
-							{ID: "1"},
+							{
+								ID: "1",
+								Project: struct {
+									Title string "json:\"title\""
+								}{
+									Title: "CleanupV2",
+								},
+							},
 						},
 					},
 				}, ghrepo.New("OWNER", "REPO")),
@@ -348,7 +355,7 @@ func Test_editRun(t *testing.T) {
 					},
 					Projects: shared.EditableSlice{
 						Add:    []string{"Cleanup", "RoadmapV2"},
-						Remove: []string{"Roadmap", "CleanupV2"},
+						Remove: []string{"Roadmap"},
 						Edited: true,
 					},
 					Milestone: shared.EditableString{
@@ -359,7 +366,6 @@ func Test_editRun(t *testing.T) {
 				Fetcher: testFetcher{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.StubRepoInfoResponse("OWNER", "REPO", "main")
 				mockRepoMetadata(t, reg, false)
 				mockPullRequestUpdate(t, reg)
 				mockPullRequestReviewersUpdate(t, reg)
@@ -376,7 +382,14 @@ func Test_editRun(t *testing.T) {
 					URL: "https://github.com/OWNER/REPO/pull/123",
 					ProjectItems: api.ProjectItems{
 						Nodes: []*api.ProjectV2Item{
-							{ID: "1"},
+							{
+								ID: "1",
+								Project: struct {
+									Title string "json:\"title\""
+								}{
+									Title: "TriageV2",
+								},
+							},
 						},
 					},
 				}, ghrepo.New("OWNER", "REPO")),
@@ -418,7 +431,6 @@ func Test_editRun(t *testing.T) {
 				Fetcher: testFetcher{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.StubRepoInfoResponse("OWNER", "REPO", "main")
 				mockRepoMetadata(t, reg, true)
 				mockPullRequestUpdate(t, reg)
 				mockPullRequestUpdateLabels(t, reg)
@@ -489,6 +501,7 @@ func Test_editRun(t *testing.T) {
 }
 
 func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry, skipReviewers bool) {
+	reg.StubRepoInfoResponse("OWNER", "REPO", "main")
 	reg.Register(
 		httpmock.GraphQL(`query RepositoryAssignableUsers\b`),
 		httpmock.StringResponse(`

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -120,6 +120,7 @@ func (e Editable) AssigneeIds(client *api.Client, repo ghrepo.Interface) (*[]str
 	return &a, err
 }
 
+// ProjectIds returns a slice containing IDs of old projects (v1) that the issue or a PR has to be linked tos
 func (e Editable) ProjectIds() (*[]string, error) {
 	if !e.Projects.Edited {
 		return nil, nil
@@ -131,9 +132,36 @@ func (e Editable) ProjectIds() (*[]string, error) {
 		s.RemoveValues(e.Projects.Remove)
 		e.Projects.Value = s.ToSlice()
 	}
-	// ignore projectV2 IDs for now
 	p, _, err := e.Metadata.ProjectsToIDs(e.Projects.Value)
 	return &p, err
+}
+
+// ProjectV2Ids returns a pair of slices, where the first contains IDs of projectV2 the issue or a PR should be added to,
+// and the second contains IDs of projectV2 from which the issue or a PR should be removed
+func (e Editable) ProjectV2Ids() (*[]string, *[]string, error) {
+	if !e.Projects.Edited {
+		return nil, nil, nil
+	}
+
+	var addedProjectsV2 []string
+	var removedProjectsV2 []string
+	var err error
+
+	if len(e.Projects.Add) > 0 {
+		_, addedProjectsV2, err = e.Metadata.ProjectsToIDs(e.Projects.Add)
+		if err != nil {
+			return &addedProjectsV2, &removedProjectsV2, err
+		}
+	}
+
+	if len(e.Projects.Remove) > 0 {
+		_, removedProjectsV2, err = e.Metadata.ProjectsToIDs(e.Projects.Remove)
+		if err != nil {
+			return &addedProjectsV2, &removedProjectsV2, err
+		}
+	}
+
+	return &addedProjectsV2, &removedProjectsV2, nil
 }
 
 func (e Editable) MilestoneId() (*string, error) {

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -131,7 +131,7 @@ func (e Editable) ProjectIds() (*[]string, error) {
 		s.RemoveValues(e.Projects.Remove)
 		e.Projects.Value = s.ToSlice()
 	}
-	p, err := e.Metadata.ProjectsToIDs(e.Projects.Value)
+	p, _, err := e.Metadata.ProjectsToIDs(e.Projects.Value)
 	return &p, err
 }
 

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -131,6 +131,7 @@ func (e Editable) ProjectIds() (*[]string, error) {
 		s.RemoveValues(e.Projects.Remove)
 		e.Projects.Value = s.ToSlice()
 	}
+	// ignore projectV2 IDs for now
 	p, _, err := e.Metadata.ProjectsToIDs(e.Projects.Value)
 	return &p, err
 }

--- a/pkg/cmd/pr/shared/editable_http.go
+++ b/pkg/cmd/pr/shared/editable_http.go
@@ -41,7 +41,7 @@ func UpdateIssue(httpClient *http.Client, repo ghrepo.Interface, id string, proj
 		})
 	}
 
-	if len(options.Projects.Add) > 0 || len(options.Projects.Remove) > 0 {
+	if options.Projects.Edited {
 		wg.Go(func() error {
 			return linkIssueToProjectsV2(httpClient, repo, id, projectV2Items, options)
 		})

--- a/pkg/cmd/pr/shared/editable_http.go
+++ b/pkg/cmd/pr/shared/editable_http.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func UpdateIssue(httpClient *http.Client, repo ghrepo.Interface, id string, isPR bool, options Editable) error {
+func UpdateIssue(httpClient *http.Client, repo ghrepo.Interface, id string, projectV2Items []*api.ProjectV2Item, isPR bool, options Editable) error {
 	var wg errgroup.Group
 
 	// Labels are updated through discrete mutations to avoid having to replace the entire list of labels
@@ -38,6 +38,12 @@ func UpdateIssue(httpClient *http.Client, repo ghrepo.Interface, id string, isPR
 	if dirtyExcludingLabels(options) {
 		wg.Go(func() error {
 			return replaceIssueFields(httpClient, repo, id, isPR, options)
+		})
+	}
+
+	if len(options.Projects.Add) > 0 || len(options.Projects.Remove) > 0 {
+		wg.Go(func() error {
+			return linkIssueToProjectsV2(httpClient, repo, id, projectV2Items, options)
 		})
 	}
 
@@ -85,6 +91,45 @@ func replaceIssueFields(httpClient *http.Client, repo ghrepo.Interface, id strin
 		MilestoneID: ghId(milestoneId),
 	}
 	return updateIssue(httpClient, repo, params)
+}
+
+func linkIssueToProjectsV2(httpClient *http.Client, baseRepo ghrepo.Interface, id string, projectV2Items []*api.ProjectV2Item, options Editable) error {
+	apiClient := api.NewClientFromHTTP(httpClient)
+	repo, err := api.GitHubRepo(apiClient, baseRepo)
+	if err != nil {
+		return err
+	}
+
+	projectsV2ToAdd, projectsV2ToRemove, err := options.ProjectV2Ids()
+	if err != nil {
+		return err
+	}
+
+	for _, p := range *projectsV2ToAdd {
+		params := map[string]interface{}{
+			"contentId": id,
+			"projectId": p,
+		}
+		_, err := api.AddProjectV2ItemById(apiClient, repo, params)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, itemId := range projectV2Items {
+		for _, projectId := range *projectsV2ToRemove {
+			params := map[string]interface{}{
+				"itemId":    itemId.ID,
+				"projectId": projectId,
+			}
+			_, err := api.DeleteProjectV2Item(apiClient, repo, params)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func dirtyExcludingLabels(e Editable) bool {

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -155,9 +155,9 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 	}
 
 	if fields.Contains("projectItems") {
-    if !api.HasProjectsV2Scope(httpClient, f.repo.RepoHost()) {
-      fields.Remove("projectItems")
-    }
+		if !api.HasProjectsV2Scope(httpClient, f.repo.RepoHost()) {
+			fields.Remove("projectItems")
+		}
 	}
 
 	var pr *api.PullRequest

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -154,6 +154,12 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 		}
 	}
 
+	if fields.Contains("projectItems") {
+    if !api.HasProjectsV2Scope(httpClient, f.repo.RepoHost()) {
+      fields.Remove("projectItems")
+    }
+	}
+
 	var pr *api.PullRequest
 	if f.prNumber > 0 {
 		if numberFieldOnly {

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -109,11 +109,12 @@ func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, par
 	}
 	params["labelIds"] = labelIDs
 
-	projectIDs, err := tb.MetadataResult.ProjectsToIDs(tb.Projects)
+	projectIDs, projectV2IDs, err := tb.MetadataResult.ProjectsToIDs(tb.Projects)
 	if err != nil {
 		return fmt.Errorf("could not add to project: %w", err)
 	}
 	params["projectIds"] = projectIDs
+	params["projectV2Ids"] = projectV2IDs
 
 	if len(tb.Milestones) > 0 {
 		milestoneID, err := tb.MetadataResult.MilestoneToID(tb.Milestones[0])

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -203,8 +203,11 @@ func MetadataSurvey(io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher 
 		labels = append(labels, l.Name)
 	}
 	var projects []string
-	for _, l := range metadataResult.Projects {
-		projects = append(projects, l.Name)
+	for _, p := range metadataResult.Projects {
+		projects = append(projects, p.Name)
+	}
+	for _, p := range metadataResult.ProjectsV2 {
+		projects = append(projects, p.Title)
 	}
 	milestones := []string{noMilestone}
 	for _, m := range metadataResult.Milestones {


### PR DESCRIPTION
This PR continues PR #6043 from another contributor.
Original fork is currently unavailable and I restored changes in separate one.

Rebased and fixed tests as they were reworked since last PR change.

Note: Currently I had to manually run `gh auth refresh -s project` to make it work. Probably it makes sense to add project scope to default scopes.

Original PR description from #6043

> 
> Creating Issue/PR
> 
> Collect all IDs for repository's and organization's projects V2 and store them in the repo metadata to suport ID resolution.
> All extracted IDs for legacy/old/v1 projects are fed as an input for IssueCreate/PullRequestCreate mutation.
> All extracted IDs for new/v2 projects will are used to create AddProjectV2ItemById/DeleteProjectV2Item mutation.
> All collected projectV2 names are also used as hints in the interactive mode.
> Editing Issue/PR
> 
> Collect all IDs for repository's and organization's projects V2 and store them in the repo metadata to support ID resolution.
> Gather all item IDs corresponding to the edited entity to provide hints to which projects entity belongs and to support mapping of public ID to a project-specific item ID.
> Updating projects linked happens in two steps: 1) add item to all new projects and 2) remove item from all projects which are no longer needed.
> 3.1. all projects which are in the current selection, but to which the item does not belong, should be added.
> 3.2. all projects which are not in the current selection, but to which the item belongs, should be removed.
> Notes: I am a bit lost with regards to the expected level of testing and could use some guidance here. I ensured that existing tests pass with expected reasons. I ensured that correct APIs are called when project V2 items are impacted. I also did some manual testing of (non-)interactive modes on my own repo and projects. I would like to have more automated testing, but am a bit lost in the current setup.
> 

Fixes https://github.com/cli/cli/issues/4547