### PR TITLE
Add delete_branch_after_merge config option

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,8 +197,8 @@ var configOptions = []ConfigOption{
 		DefaultValue: "",
 	},
 	{
-		Key: "delete_branch_after_merge",
-		Description: "Delete the local branch after merging a PR",
+		Key:          "delete_branch_after_merge",
+		Description:  "Delete the local branch after merging a PR",
 		DefaultValue: "",
 	},
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,11 +17,11 @@ const (
 //
 //go:generate moq -rm -out config_mock.go . Config
 type Config interface {
-	AuthToken(string) (string, string)
-	Get(string, string) (string, error)
-	GetOrDefault(string, string) (string, error)
-	Set(string, string, string)
-	UnsetHost(string)
+	AuthToken(hostname string) (string, string)
+	Get(hostname string, key string) (string, error)
+	GetOrDefault(hostname string, key string) (string, error)
+	Set(hostname string, key string, value string)
+	UnsetHost(hostname string)
 	Hosts() []string
 	DefaultHost() (string, string)
 	Aliases() *AliasConfig
@@ -194,6 +194,11 @@ var configOptions = []ConfigOption{
 	{
 		Key:          "browser",
 		Description:  "the web browser to use for opening URLs",
+		DefaultValue: "",
+	},
+	{
+		Key: "delete_branch_after_merge",
+		Description: "Delete the local branch after merging a PR",
 		DefaultValue: "",
 	},
 }

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -26,6 +26,8 @@ aliases:
 http_unix_socket:
 # What web browser gh should use when opening URLs. If blank, will refer to environment.
 browser:
+# Delete the local branch after merging the PR
+delete_branch_after_merge:
 `
 	return NewFromString(defaultStr)
 }

--- a/pkg/cmd/config/list/list_test.go
+++ b/pkg/cmd/config/list/list_test.go
@@ -85,6 +85,7 @@ func Test_listRun(t *testing.T) {
 				cfg.Set("HOST", "pager", "less")
 				cfg.Set("HOST", "http_unix_socket", "")
 				cfg.Set("HOST", "browser", "brave")
+				cfg.Set("HOST", "delete_branch_after_merge", "true")
 				return cfg
 			}(),
 			input: &ListOptions{Hostname: "HOST"},
@@ -94,6 +95,7 @@ prompt=disabled
 pager=less
 http_unix_socket=
 browser=brave
+delete_branch_after_merge=true
 `,
 		},
 	}

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -1354,7 +1354,7 @@ func TestPRMergeTTY_withDeleteBranchConfigTrue(t *testing.T) {
 	}
 
 	mockCfgFunc := func() (config.Config, error) {
-		c := config.NewBlankConfig() 
+		c := config.NewBlankConfig()
 		c.SetFunc("", "delete_branch_after_merge", "true")
 		return c, nil
 	}
@@ -1426,7 +1426,7 @@ func TestPRMergeTTY_withDeleteBranchConfigFalse(t *testing.T) {
 	}
 
 	mockCfgFunc := func() (config.Config, error) {
-		c := config.NewBlankConfig() 
+		c := config.NewBlankConfig()
 		c.SetFunc("", "delete_branch_after_merge", "false")
 		return c, nil
 	}


### PR DESCRIPTION
New config option that, when true, will delete any local branch after a
PR merge during the `merge` command. The `--delete-branch (-d)` flag
will still override this new config option.

Added labels to the parameters for config.Config interface.

Fixes #6750
