### PR TITLE
Avoid sending empty JSON body when no params to api command

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -246,7 +246,10 @@ func apiRun(opts *ApiOptions) error {
 	}
 	method := opts.RequestMethod
 	requestHeaders := opts.RequestHeaders
-	var requestBody interface{} = params
+	var requestBody interface{}
+	if len(params) > 0 {
+		requestBody = params
+	}
 
 	if !opts.RequestMethodPassed && (len(params) > 0 || opts.RequestInputFile != "") {
 		method = "POST"

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -671,6 +671,7 @@ func Test_apiRun_paginationGraphQL(t *testing.T) {
 			return config.NewBlankConfig(), nil
 		},
 
+		RawFields:     []string{"foo=bar"},
 		RequestMethod: "POST",
 		RequestPath:   "graphql",
 		Paginate:      true,
@@ -796,6 +797,36 @@ func Test_apiRun_paginated_template(t *testing.T) {
 	endCursor, hasCursor := requestData.Variables["endCursor"].(string)
 	assert.Equal(t, true, hasCursor)
 	assert.Equal(t, "PAGE1_END", endCursor)
+}
+
+func Test_apiRun_DELETE(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+
+	var gotRequest *http.Request
+	err := apiRun(&ApiOptions{
+		IO: ios,
+		Config: func() (config.Config, error) {
+			return config.NewBlankConfig(), nil
+		},
+		HttpClient: func() (*http.Client, error) {
+			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
+				gotRequest = req
+				return &http.Response{StatusCode: 204, Request: req}, nil
+			}
+			return &http.Client{Transport: tr}, nil
+		},
+		MagicFields:         []string(nil),
+		RawFields:           []string(nil),
+		RequestMethod:       "DELETE",
+		RequestMethodPassed: true,
+	})
+	if err != nil {
+		t.Fatalf("got error %v", err)
+	}
+
+	if gotRequest.Body != nil {
+		t.Errorf("expected nil request body, got %T", gotRequest.Body)
+	}
 }
 
 func Test_apiRun_inputFile(t *testing.T) {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -765,6 +765,7 @@ func Test_apiRun_paginated_template(t *testing.T) {
 
 		RequestMethod: "POST",
 		RequestPath:   "graphql",
+		RawFields:     []string{"foo=bar"},
 		Paginate:      true,
 		// test that templates executed per page properly render a table.
 		Template: `{{range .data.nodes}}{{tablerow .page .caption}}{{end}}`,


### PR DESCRIPTION
Allows e.g. HTTP DELETE requests with an empty body instead of body being `{}` when no params were given.

This is a **backwards incompatible** change, but I am unaware of GitHub API endpoints that require an empty payload of `{}` and do not accept an empty request body instead.

Fixes https://github.com/cli/cli/issues/3937