### PR TITLE
Fix signing Windows exe on release

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,8 @@ builds:
     goarch: [386, amd64, arm64]
     hooks:
       post:
-        - ./script/sign-windows-executable.sh '{{ .Path }}'
+        - cmd: ./script/sign-windows-executable.sh '{{ .Path }}'
+          output: false
 
 archives:
   - id: nix


### PR DESCRIPTION
The `osslsigncode`-powered step would fail on Ubuntu 22 runners because osslsigncode would complain about the PFX certificate (or its password) being invalid. The downgrade to Ubuntu 20 fixes this for now.

```
Failed to parse PKCS#12 file: /tmp/cert.Ixj (Wrong password?)
006E50B99E7F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../crypto/evp/evp_fetch.c:349:Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()
```

https://github.com/cli/cli/actions/runs/3760731507/jobs/6391765553