### PR TITLE
docs: update codespace installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To add GitHub CLI to your codespace, add the following to your [devcontainer fil
 
 ```json
 "features": {
-  "github-cli": "latest"
+  "ghcr.io/devcontainers/features/github-cli:1": {}
 }
 ```
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Update Codespace installation instructions to use [recommended feature](https://github.com/devcontainers/features/tree/main/src/github-cli). Currently following warning is printed when building devcontainer:
```
WARNING: Using the deprecated 'github-cli' Feature. See https://github.com/devcontainers/features/tree/main/src/github-cli#example-usage for the updated Feature.
```