### PR TITLE
Add confirmation prompt when changing visibility to private

### DIFF
--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -30,6 +30,7 @@ type MergeOptions struct {
 	Branch     func() (string, error)
 	Remotes    func() (ghContext.Remotes, error)
 	Prompter   shared.Prompt
+	Config     func() (config.Config, error)
 
 	Finder shared.PRFinder
 
@@ -65,6 +66,7 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 		Branch:     f.Branch,
 		Remotes:    f.Remotes,
 		Prompter:   f.Prompter,
+		Config:     f.Config,
 	}
 
 	var (

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -30,7 +30,6 @@ type MergeOptions struct {
 	Branch     func() (string, error)
 	Remotes    func() (ghContext.Remotes, error)
 	Prompter   shared.Prompt
-	Config     func() (config.Config, error)
 
 	Finder shared.PRFinder
 
@@ -66,7 +65,6 @@ func NewCmdMerge(f *cmdutil.Factory, runF func(*MergeOptions) error) *cobra.Comm
 		Branch:     f.Branch,
 		Remotes:    f.Remotes,
 		Prompter:   f.Prompter,
-		Config:     f.Config,
 	}
 
 	var (

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -578,5 +578,7 @@ func isIncluded(value string, opts []string) bool {
 }
 
 func confirmChangeVisibilityPrivate(opts *EditOptions) (bool, error) {
-	return opts.Prompter.Confirm("Are you sure you want to make this repository private? You will lose all the stars.", false)
+	return opts.Prompter.Confirm("This is a potentially destructive action. " +
+	"You will permanently lost all stars and watchers of this repository. " +
+	"Are you sure you want to change this repository to private?", false)
 }

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -578,7 +578,11 @@ func isIncluded(value string, opts []string) bool {
 }
 
 func confirmChangeVisibilityPrivate(opts *EditOptions) (bool, error) {
-	return opts.Prompter.Confirm("This is a potentially destructive action. " +
-	"You will permanently lost all stars and watchers of this repository. " +
-	"Are you sure you want to change this repository to private?", false)
+	_, err := fmt.Fprintf(opts.IO.ErrOut, "WARNING: This is a potentially destructive action.\n" +
+"You will permanently lost all stars and watchers of this repository.\n")
+	if err != nil {
+		return false, err
+	}
+
+	return opts.Prompter.Confirm("Are you sure you want to change this repository to private?", false)
 }

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -52,7 +52,7 @@ type EditOptions struct {
 	RemoveTopics    []string
 	InteractiveMode bool
 	Detector        fd.Detector
-	Prompter prompter.Prompter
+	Prompter        prompter.Prompter
 	// Cache of current repo topics to avoid retrieving them
 	// in multiple flows.
 	topicsCache []string
@@ -78,7 +78,7 @@ type EditRepositoryInput struct {
 
 func NewCmdEdit(f *cmdutil.Factory, runF func(options *EditOptions) error) *cobra.Command {
 	opts := &EditOptions{
-		IO: f.IOStreams,
+		IO:       f.IOStreams,
 		Prompter: f.Prompter,
 	}
 
@@ -577,9 +577,12 @@ func isIncluded(value string, opts []string) bool {
 	return false
 }
 
+// confirmChangeVisibilityPrivate displays warning message and
+// show confirmation prompt when user chose to change repository's
+// visibility to private.
 func confirmChangeVisibilityPrivate(opts *EditOptions) (bool, error) {
-	_, err := fmt.Fprintf(opts.IO.ErrOut, "WARNING: This is a potentially destructive action.\n" +
-"You will permanently lost all stars and watchers of this repository.\n")
+	_, err := fmt.Fprintf(opts.IO.ErrOut, "WARNING: This is a potentially destructive action.\n"+
+		"You will permanently lost all stars and watchers of this repository.\n")
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -402,7 +402,9 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 				return err
 			}
 		case optionVisibility:
-			opts.Edits.Visibility = &r.Visibility
+			opts.Edits.Visibility = new(string)
+			*opts.Edits.Visibility = r.Visibility
+
 			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
 			err = prompt.SurveyAskOne(&survey.Select{
 				Message: "Visibility",


### PR DESCRIPTION
Fixes #6598 

- Add confirmation prompts when user tries to change a repository's visibility to `private` using the interactive mode or `visibility` option. 

1. When `visibility` option is defined explicitly
```sh
vscode ➜ /workspaces/cli (feature/add-warning-change-visibility-private) $ go run cmd/gh/main.go repo edit --visibility=private
WARNING: This is a potentially destructive action.
You will permanently lost all stars and watchers of this repository.
? Are you sure you want to change this repository to private? (y/N) 
```

2. In interactive mode

```sh
vscode ➜ /workspaces/cli (feature/add-warning-change-visibility-private) $ go run cmd/gh/main.go repo edit
? What do you want to edit? Visibility
? Visibility private
WARNING: This is a potentially destructive action.
You will permanently lost all stars and watchers of this repository.
? Are you sure you want to change this repository to private? (y/N) 
```
💠