### PR TITLE
Handle erase operation in auth git-credential command

### DIFF
--- a/pkg/cmd/auth/gitcredential/helper.go
+++ b/pkg/cmd/auth/gitcredential/helper.go
@@ -54,7 +54,12 @@ func NewCmdCredential(f *cmdutil.Factory, runF func(*CredentialOptions) error) *
 func helperRun(opts *CredentialOptions) error {
 	if opts.Operation == "store" {
 		// We pretend to implement the "store" operation, but do nothing since we already have a cached token.
-		return cmdutil.SilentError
+		return nil
+	}
+
+	if opts.Operation == "erase" {
+		// We pretend to implement the "erase" operation, but do nothing since we don't want git to cause user to be logged out.
+		return nil
 	}
 
 	if opts.Operation != "get" {

--- a/pkg/cmd/auth/gitcredential/helper_test.go
+++ b/pkg/cmd/auth/gitcredential/helper_test.go
@@ -218,6 +218,25 @@ func Test_helperRun(t *testing.T) {
 			`),
 			wantStderr: "",
 		},
+		{
+			name: "noop store operation",
+			opts: CredentialOptions{
+				Operation: "store",
+			},
+		},
+		{
+			name: "noop erase operation",
+			opts: CredentialOptions{
+				Operation: "erase",
+			},
+		},
+		{
+			name: "unknown operation",
+			opts: CredentialOptions{
+				Operation: "unknown",
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds the handling of the `erase` operation to the `auth git-credential` command. The handling of `erase` is now a noop not an error. This PR also changes the handling of the `store` operation to be a noop that does not return an error.

I followed the guidelines from [here](https://git-scm.com/docs/gitcredentials) stating: 

> For a store or erase operation, the helper’s output is ignored.
> 
> If a helper fails to perform the requested operation or needs to notify the user of a potential issue, it may write to stderr.
> 
> If it does not support the requested operation (e.g., a read-only store or generator), it should silently ignore the request.
> 
> If a helper receives any other operation, it should silently ignore the request. This leaves room for future operations to be added (older helpers will just ignore the new requests).
> 

Closes https://github.com/cli/cli/issues/3891