### PR TITLE
Fix typo in has_uncommitted_changes for codespaces

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -187,11 +187,11 @@ type Codespace struct {
 }
 
 type CodespaceGitStatus struct {
-	Ahead                int    `json:"ahead"`
-	Behind               int    `json:"behind"`
-	Ref                  string `json:"ref"`
-	HasUnpushedChanges   bool   `json:"has_unpushed_changes"`
-	HasUncommitedChanges bool   `json:"has_uncommited_changes"`
+	Ahead                 int    `json:"ahead"`
+	Behind                int    `json:"behind"`
+	Ref                   string `json:"ref"`
+	HasUnpushedChanges    bool   `json:"has_unpushed_changes"`
+	HasUncommittedChanges bool   `json:"has_uncommitted_changes"`
 }
 
 type CodespaceMachine struct {
@@ -250,9 +250,9 @@ func (c *Codespace) ExportData(fields []string) map[string]interface{} {
 			data[f] = c.Machine.Name
 		case "gitStatus":
 			data[f] = map[string]interface{}{
-				"ref":                  c.GitStatus.Ref,
-				"hasUnpushedChanges":   c.GitStatus.HasUnpushedChanges,
-				"hasUncommitedChanges": c.GitStatus.HasUncommitedChanges,
+				"ref":                   c.GitStatus.Ref,
+				"hasUnpushedChanges":    c.GitStatus.HasUnpushedChanges,
+				"hasUncommittedChanges": c.GitStatus.HasUncommittedChanges,
 			}
 		case "vscsTarget":
 			if c.VSCSTarget != "" && c.VSCSTarget != VSCSTargetProduction {

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -277,7 +277,7 @@ func (c codespace) branchWithGitStatus() string {
 // hasUnsavedChanges returns whether the environment has
 // unsaved changes.
 func (c codespace) hasUnsavedChanges() bool {
-	return c.GitStatus.HasUncommitedChanges || c.GitStatus.HasUnpushedChanges
+	return c.GitStatus.HasUncommittedChanges || c.GitStatus.HasUnpushedChanges
 }
 
 // running returns whether the codespace environment is running.

--- a/pkg/cmd/codespace/common_test.go
+++ b/pkg/cmd/codespace/common_test.go
@@ -58,8 +58,8 @@ func Test_codespace_displayName(t *testing.T) {
 			fields: fields{
 				Codespace: &api.Codespace{
 					GitStatus: api.CodespaceGitStatus{
-						Ref:                  "trunk",
-						HasUncommitedChanges: true,
+						Ref:                   "trunk",
+						HasUncommittedChanges: true,
 					},
 					Repository: api.Repository{
 						FullName: "cli/cli",
@@ -75,8 +75,8 @@ func Test_codespace_displayName(t *testing.T) {
 			fields: fields{
 				Codespace: &api.Codespace{
 					GitStatus: api.CodespaceGitStatus{
-						Ref:                  "trunk",
-						HasUncommitedChanges: true,
+						Ref:                   "trunk",
+						HasUncommittedChanges: true,
 					},
 					Repository: api.Repository{
 						FullName: "cli/cli",
@@ -92,8 +92,8 @@ func Test_codespace_displayName(t *testing.T) {
 			fields: fields{
 				Codespace: &api.Codespace{
 					GitStatus: api.CodespaceGitStatus{
-						Ref:                  "trunk",
-						HasUncommitedChanges: false,
+						Ref:                   "trunk",
+						HasUncommittedChanges: false,
 					},
 					Repository: api.Repository{
 						FullName: "cli/cli",
@@ -114,8 +114,8 @@ func Test_codespace_displayName(t *testing.T) {
 						Login: "jimmy",
 					},
 					GitStatus: api.CodespaceGitStatus{
-						Ref:                  "trunk",
-						HasUncommitedChanges: false,
+						Ref:                   "trunk",
+						HasUncommittedChanges: false,
 					},
 					Repository: api.Repository{
 						FullName: "cli/cli",
@@ -268,8 +268,8 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 					},
 					{
 						GitStatus: api.CodespaceGitStatus{
-							Ref:                  "trunk",
-							HasUncommitedChanges: true,
+							Ref:                   "trunk",
+							HasUncommittedChanges: true,
 						},
 						Repository: api.Repository{
 							FullName: "cli/cli",

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -133,14 +133,14 @@ func TestDelete(t *testing.T) {
 				{
 					Name: "hubot-robawt-abc",
 					GitStatus: api.CodespaceGitStatus{
-						HasUncommitedChanges: true,
+						HasUncommittedChanges: true,
 					},
 				},
 				{
 					Name: "monalisa-spoonknife-c4f3",
 					GitStatus: api.CodespaceGitStatus{
-						HasUnpushedChanges:   false,
-						HasUncommitedChanges: false,
+						HasUnpushedChanges:    false,
+						HasUncommittedChanges: false,
 					},
 				},
 			},


### PR DESCRIPTION
The REST API for codespaces returns the following schema:
```
"git_status": {
    "ahead": 0,
    "behind": 0,
    "has_unpushed_changes": false,
    "has_uncommitted_changes": false,
    "ref": "main"
  },
  ```

The CLI was looking for `has_uncommited_changes` in the response instead of `has_uncommitted_changes`, leading to it always reporting a `false` value which could be different than the API response.

Note that this is a small breaking change in the CLI output when using `gh codespace list --json gitStatus` since it fixes the typo in the CLI output (`hasUncommittedChanges` compared to `hasUncommitedChanges` previously).

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
