### PR TITLE
make a commit on extension create

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -564,9 +564,18 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					} else {
 						fullName = "gh-" + extName
 					}
+
+					cs := io.ColorScheme()
+
+					commitIcon := cs.SuccessIcon()
 					if err := m.Create(fullName, tmplType); err != nil {
-						return err
+						if errors.Is(err, ErrInitialCommitFailed) {
+							commitIcon = cs.FailureIcon()
+						} else {
+							return err
+						}
 					}
+
 					if !io.IsStdoutTTY() {
 						return nil
 					}
@@ -577,7 +586,6 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 						"- run 'cd %[1]s; gh extension install .; gh %[2]s' to see your new extension in action",
 						fullName, extName)
 
-					cs := io.ColorScheme()
 					if tmplType == extensions.GoBinTemplateType {
 						goBinChecks = heredoc.Docf(`
 						%[1]s Downloaded Go dependencies
@@ -596,7 +604,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					out := heredoc.Docf(`
 						%[1]s Created directory %[2]s
 						%[1]s Initialized git repository
-						%[1]s Made initial commit
+						%[7]s Made initial commit
 						%[1]s Set up extension scaffolding
 						%[6]s
 						%[2]s is ready for development!
@@ -607,7 +615,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 
 						For more information on writing extensions:
 						%[3]s
-					`, cs.SuccessIcon(), fullName, link, cs.Bold("Next Steps"), steps, goBinChecks)
+					`, cs.SuccessIcon(), fullName, link, cs.Bold("Next Steps"), steps, goBinChecks, commitIcon)
 					fmt.Fprint(io.Out, out)
 					return nil
 				},

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -585,7 +585,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 						`, cs.SuccessIcon(), fullName)
 						steps = heredoc.Docf(`
 						- run 'cd %[1]s; gh extension install .; gh %[2]s' to see your new extension in action
-						- use 'go build && gh %[2]s' to see changes in your code as you develop`, fullName, extName)
+						- run 'go build && gh %[2]s' to see changes in your code as you develop`, fullName, extName)
 					} else if tmplType == extensions.OtherBinTemplateType {
 						steps = heredoc.Docf(`
 						- run 'cd %[1]s; gh extension install .' to install your extension locally
@@ -596,13 +596,14 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					out := heredoc.Docf(`
 						%[1]s Created directory %[2]s
 						%[1]s Initialized git repository
+						%[1]s Made initial commit
 						%[1]s Set up extension scaffolding
 						%[6]s
 						%[2]s is ready for development!
 
 						%[4]s
 						%[5]s
-						- commit and use 'gh repo create' to share your extension with others
+						- run 'gh repo create' to share your extension with others
 
 						For more information on writing extensions:
 						%[3]s

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -714,6 +714,36 @@ func TestNewCmdExtension(t *testing.T) {
 			`),
 		},
 		{
+			name: "create extension tty with argument commit fails",
+			args: []string{"create", "test"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.CreateFunc = func(name string, tmplType extensions.ExtTemplateType) error {
+					return ErrInitialCommitFailed
+				}
+				return func(t *testing.T) {
+					calls := em.CreateCalls()
+					assert.Equal(t, 1, len(calls))
+					assert.Equal(t, "gh-test", calls[0].Name)
+				}
+			},
+			isTTY: true,
+			wantStdout: heredoc.Doc(`
+				✓ Created directory gh-test
+				✓ Initialized git repository
+				X Made initial commit
+				✓ Set up extension scaffolding
+
+				gh-test is ready for development!
+
+				Next Steps
+				- run 'cd gh-test; gh extension install .; gh test' to see your new extension in action
+				- run 'gh repo create' to share your extension with others
+
+				For more information on writing extensions:
+				https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions
+			`),
+		},
+		{
 			name: "create extension notty",
 			args: []string{"create", "gh-test"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -605,13 +605,14 @@ func TestNewCmdExtension(t *testing.T) {
 			wantStdout: heredoc.Doc(`
 				✓ Created directory gh-test
 				✓ Initialized git repository
+				✓ Made initial commit
 				✓ Set up extension scaffolding
 
 				gh-test is ready for development!
 
 				Next Steps
 				- run 'cd gh-test; gh extension install .; gh test' to see your new extension in action
-				- commit and use 'gh repo create' to share your extension with others
+				- run 'gh repo create' to share your extension with others
 
 				For more information on writing extensions:
 				https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions
@@ -634,6 +635,7 @@ func TestNewCmdExtension(t *testing.T) {
 			wantStdout: heredoc.Doc(`
 				✓ Created directory gh-test
 				✓ Initialized git repository
+				✓ Made initial commit
 				✓ Set up extension scaffolding
 				✓ Downloaded Go dependencies
 				✓ Built gh-test binary
@@ -642,8 +644,8 @@ func TestNewCmdExtension(t *testing.T) {
 
 				Next Steps
 				- run 'cd gh-test; gh extension install .; gh test' to see your new extension in action
-				- use 'go build && gh test' to see changes in your code as you develop
-				- commit and use 'gh repo create' to share your extension with others
+				- run 'go build && gh test' to see changes in your code as you develop
+				- run 'gh repo create' to share your extension with others
 
 				For more information on writing extensions:
 				https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions
@@ -666,6 +668,7 @@ func TestNewCmdExtension(t *testing.T) {
 			wantStdout: heredoc.Doc(`
 				✓ Created directory gh-test
 				✓ Initialized git repository
+				✓ Made initial commit
 				✓ Set up extension scaffolding
 
 				gh-test is ready for development!
@@ -674,7 +677,7 @@ func TestNewCmdExtension(t *testing.T) {
 				- run 'cd gh-test; gh extension install .' to install your extension locally
 				- fill in script/build.sh with your compilation script for automated builds
 				- compile a gh-test binary locally and run 'gh test' to see changes
-				- commit and use 'gh repo create' to share your extension with others
+				- run 'gh repo create' to share your extension with others
 
 				For more information on writing extensions:
 				https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions
@@ -697,13 +700,14 @@ func TestNewCmdExtension(t *testing.T) {
 			wantStdout: heredoc.Doc(`
 				✓ Created directory gh-test
 				✓ Initialized git repository
+				✓ Made initial commit
 				✓ Set up extension scaffolding
 
 				gh-test is ready for development!
 
 				Next Steps
 				- run 'cd gh-test; gh extension install .; gh test' to see your new extension in action
-				- commit and use 'gh repo create' to share your extension with others
+				- run 'gh repo create' to share your extension with others
 
 				For more information on writing extensions:
 				https://docs.github.com/github-cli/github-cli/creating-github-cli-extensions

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -654,8 +654,13 @@ func (m *Manager) Create(name string, tmplType extensions.ExtTemplateType) error
 	}
 
 	scopedClient := m.gitClient.ForRepo(name)
-	_, err := scopedClient.CommandOutput([]string{"add", name, "--chmod=+x"})
-	return err
+	if _, err := scopedClient.CommandOutput([]string{"add", name, "--chmod=+x"}); err != nil {
+		return err
+	}
+
+	scopedClient.CommandOutput([]string{"commit", "-m", "initial commit"})
+
+	return nil
 }
 
 func (m *Manager) otherBinScaffolding(name string) error {
@@ -672,8 +677,11 @@ func (m *Manager) otherBinScaffolding(name string) error {
 		return err
 	}
 
-	_, err := scopedClient.CommandOutput([]string{"add", "."})
-	return err
+	if _, err := scopedClient.CommandOutput([]string{"add", "."}); err != nil {
+		return err
+	}
+	scopedClient.CommandOutput([]string{"commit", "-m", "initial commit"})
+	return nil
 }
 
 func (m *Manager) goBinScaffolding(name string) error {
@@ -718,8 +726,11 @@ func (m *Manager) goBinScaffolding(name string) error {
 	}
 
 	scopedClient := m.gitClient.ForRepo(name)
-	_, err = scopedClient.CommandOutput([]string{"add", "."})
-	return err
+	if _, err := scopedClient.CommandOutput([]string{"add", "."}); err != nil {
+		return err
+	}
+	scopedClient.CommandOutput([]string{"commit", "-m", "initial commit"})
+	return nil
 }
 
 func isSymlink(m os.FileMode) bool {

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -27,6 +27,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// ErrInitialCommitFailed indicates the initial commit when making a new extension failed.
+var ErrInitialCommitFailed = errors.New("initial commit failed")
+
 type Manager struct {
 	dataDir    func() string
 	lookPath   func(string) (string, error)
@@ -658,7 +661,9 @@ func (m *Manager) Create(name string, tmplType extensions.ExtTemplateType) error
 		return err
 	}
 
-	scopedClient.CommandOutput([]string{"commit", "-m", "initial commit"})
+	if _, err := scopedClient.CommandOutput([]string{"commit", "-m", "initial commit"}); err != nil {
+		return ErrInitialCommitFailed
+	}
 
 	return nil
 }
@@ -680,7 +685,11 @@ func (m *Manager) otherBinScaffolding(name string) error {
 	if _, err := scopedClient.CommandOutput([]string{"add", "."}); err != nil {
 		return err
 	}
-	scopedClient.CommandOutput([]string{"commit", "-m", "initial commit"})
+
+	if _, err := scopedClient.CommandOutput([]string{"commit", "-m", "initial commit"}); err != nil {
+		return ErrInitialCommitFailed
+	}
+
 	return nil
 }
 
@@ -729,7 +738,11 @@ func (m *Manager) goBinScaffolding(name string) error {
 	if _, err := scopedClient.CommandOutput([]string{"add", "."}); err != nil {
 		return err
 	}
-	scopedClient.CommandOutput([]string{"commit", "-m", "initial commit"})
+
+	if _, err := scopedClient.CommandOutput([]string{"commit", "-m", "initial commit"}); err != nil {
+		return ErrInitialCommitFailed
+	}
+
 	return nil
 }
 

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -1036,6 +1036,7 @@ func TestManager_Create(t *testing.T) {
 	gc.On("ForRepo", "gh-test").Return(gcOne).Once()
 	gc.On("CommandOutput", []string{"init", "--quiet", "gh-test"}).Return("", nil).Once()
 	gcOne.On("CommandOutput", []string{"add", "gh-test", "--chmod=+x"}).Return("", nil).Once()
+	gcOne.On("CommandOutput", []string{"commit", "-m", "initial commit"}).Return("", nil).Once()
 
 	m := newTestManager(".", nil, gc, ios)
 
@@ -1068,6 +1069,7 @@ func TestManager_Create_go_binary(t *testing.T) {
 	gc.On("ForRepo", "gh-test").Return(gcOne).Once()
 	gc.On("CommandOutput", []string{"init", "--quiet", "gh-test"}).Return("", nil).Once()
 	gcOne.On("CommandOutput", []string{"add", "."}).Return("", nil).Once()
+	gcOne.On("CommandOutput", []string{"commit", "-m", "initial commit"}).Return("", nil).Once()
 
 	m := newTestManager(".", &http.Client{Transport: &reg}, gc, ios)
 
@@ -1111,6 +1113,7 @@ func TestManager_Create_other_binary(t *testing.T) {
 	gc.On("CommandOutput", []string{"init", "--quiet", "gh-test"}).Return("", nil).Once()
 	gcOne.On("CommandOutput", []string{"add", filepath.Join("script", "build.sh"), "--chmod=+x"}).Return("", nil).Once()
 	gcOne.On("CommandOutput", []string{"add", "."}).Return("", nil).Once()
+	gcOne.On("CommandOutput", []string{"commit", "-m", "initial commit"}).Return("", nil).Once()
 
 	m := newTestManager(".", nil, gc, ios)
 


### PR DESCRIPTION
Closes https://github.com/cli/cli/issues/6795

1. Makes a commit with the message "initial commit" for each of
- go binary
- other binary
- script
type extensions.
2. Adds an extra message to the output indicating that a commit was made
3. Changes the command output to say "run" instead of "use" for consistency

Note that the issue states that

> The commit operation should be non-fatal in case something in the user's git config makes the commit fail.

I understood this to mean that if an error occurs making the commit, we should not fail extension creation.

