### PR TITLE
Document bug reporting for unofficial packages

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,10 @@ assignees: ''
 
 ---
 
+<!--
+If you are reporting a bug in an unofficial package of the GitHub CLI, please ensure you have the latest version and check whether the bug is related to the package you have. The bug reporting methods for some unofficial packages are documented here: https://github.com/cli/cli/blob/trunk/docs/install_linux.md#unofficial-community-supported-methods
+-->
+
 ### Describe the bug
 
 A clear and concise description of what the bug is. Include version by typing `gh --version`.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Report an issue with an unofficial package of GitHub CLI
+    about: Please report through the packager's issue trackers.
+    url: https://github.com/cli/cli/blob/trunk/docs/install_linux.md#unofficial-community-supported-methods
   - name: Ask a question on how to use GitHub CLI
     about: For general-purpose questions and answers, see the Discussions section.
     url: https://github.com/cli/cli/discussions

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -54,6 +54,8 @@ Upgrade:
 sudo dnf update gh
 ```
 
+Bugs from the community repository's package can be reported [on RedHat's bug tracker](https://bugzilla.redhat.com/enter_bug.cgi?component=gh)
+
 ### Amazon Linux 2 (yum)
 
 Install using our package repository for immediate access to latest releases:
@@ -96,11 +98,13 @@ sudo zypper update gh
 
 ## Unofficial, community-supported methods
 
-The GitHub CLI team does not maintain the following packages or repositories and thus we are unable to provide support for those installation methods.
+The GitHub CLI team does not maintain the following packages or repositories and thus we are unable to provide support for those installation methods. When installing a third-party package, please keep the package version and potential changes in mind if you find issues.
 
 ### Snap (do not use)
 
 There are [so many issues with Snap](https://github.com/casperdcl/cli/issues/7) as a runtime mechanism for apps like GitHub CLI that our team suggests _never installing gh as a snap_.
+
+Snap-related bugs can be filed [through the snap package's issue tracker.](https://github.com/casperdcl/cli/issues/new/choose)
 
 ### Arch Linux
 


### PR DESCRIPTION
This attempts to redirect users filing reports for unofficial packages to those packages' issue trackers.

Spawned from the conversation at https://github.com/casperdcl/cli/issues/7#issuecomment-1367750799



<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
