### PR TITLE
Migrate search commands to new table printer and add headers

### DIFF
--- a/pkg/cmd/search/commits/commits.go
+++ b/pkg/cmd/search/commits/commits.go
@@ -156,6 +156,7 @@ func displayResults(io *iostreams.IOStreams, now time.Time, results search.Commi
 	}
 	cs := io.ColorScheme()
 	tp := tableprinter.New(io)
+	tp.HeaderRow("Repo", "SHA", "Message", "Author", "Created")
 	for _, commit := range results.Items {
 		tp.AddField(commit.Repo.FullName)
 		tp.AddField(commit.Sha)

--- a/pkg/cmd/search/commits/commits_test.go
+++ b/pkg/cmd/search/commits/commits_test.go
@@ -197,7 +197,7 @@ func TestCommitsRun(t *testing.T) {
 				},
 			},
 			tty:        true,
-			wantStdout: "\nShowing 3 of 300 commits\n\ntest/cli     aaaaaaaa  hello      monalisa    about 21 days ago\ntest/cliing  bbbbbbbb  hi         johnnytest  about 21 days ago\ncli/cli      cccccccc  greetings  hubot       about 21 days ago\n",
+			wantStdout: "\nShowing 3 of 300 commits\n\nREPO         SHA       MESSAGE    AUTHOR      CREATED\ntest/cli     aaaaaaaa  hello      monalisa    about 21 days ago\ntest/cliing  bbbbbbbb  hi         johnnytest  about 21 days ago\ncli/cli      cccccccc  greetings  hubot       about 21 days ago\n",
 		},
 		{
 			name: "displays results notty",

--- a/pkg/cmd/search/repos/repos_test.go
+++ b/pkg/cmd/search/repos/repos_test.go
@@ -188,7 +188,7 @@ func TestReposRun(t *testing.T) {
 				},
 			},
 			tty:        true,
-			wantStdout: "\nShowing 3 of 300 repositories\n\ntest/cli     of course  private, archived  Feb 28, 2021\ntest/cliing  wow        public, fork       Feb 28, 2021\ncli/cli      so much    internal           Feb 28, 2021\n",
+			wantStdout: "\nShowing 3 of 300 repositories\n\nNAME         DESCRIPTION  VISIBILITY         UPDATED\ntest/cli     of course    private, archived  about 1 year ago\ntest/cliing  wow          public, fork       about 1 year ago\ncli/cli      so much      internal           about 1 year ago\n",
 		},
 		{
 			name: "displays results notty",

--- a/pkg/cmd/search/shared/shared.go
+++ b/pkg/cmd/search/shared/shared.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/cli/cli/v2/internal/browser"
+	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/search"
-	"github.com/cli/cli/v2/utils"
 )
 
 type EntityType int
@@ -95,43 +95,46 @@ func displayIssueResults(io *iostreams.IOStreams, now time.Time, et EntityType, 
 	if now.IsZero() {
 		now = time.Now()
 	}
+	isTTY := io.IsStdoutTTY()
 	cs := io.ColorScheme()
-	//nolint:staticcheck // SA1019: utils.NewTablePrinter is deprecated: use internal/tableprinter
-	tp := utils.NewTablePrinter(io)
+	tp := tableprinter.New(io)
+	if et == Both {
+		tp.HeaderRow("Kind", "Repo", "ID", "Title", "Labels", "Updated")
+	} else {
+		tp.HeaderRow("Repo", "ID", "Title", "Labels", "Updated")
+	}
 	for _, issue := range results.Items {
 		if et == Both {
 			kind := "issue"
 			if issue.IsPullRequest() {
 				kind = "pr"
 			}
-			tp.AddField(kind, nil, nil)
+			tp.AddField(kind)
 		}
 		comp := strings.Split(issue.RepositoryURL, "/")
 		name := comp[len(comp)-2:]
-		tp.AddField(strings.Join(name, "/"), nil, nil)
+		tp.AddField(strings.Join(name, "/"))
 		issueNum := strconv.Itoa(issue.Number)
-		if tp.IsTTY() {
+		if isTTY {
 			issueNum = "#" + issueNum
 		}
 		if issue.IsPullRequest() {
-			tp.AddField(issueNum, nil, cs.ColorFromString(colorForPRState(issue.State())))
+			color := tableprinter.WithColor(cs.ColorFromString(colorForPRState(issue.State())))
+			tp.AddField(issueNum, color)
 		} else {
-			tp.AddField(issueNum, nil, cs.ColorFromString(colorForIssueState(issue.State(), issue.StateReason)))
+			color := tableprinter.WithColor(cs.ColorFromString(colorForIssueState(issue.State(), issue.StateReason)))
+			tp.AddField(issueNum, color)
 		}
-		if !tp.IsTTY() {
-			tp.AddField(issue.State(), nil, nil)
+		if !isTTY {
+			tp.AddField(issue.State())
 		}
-		tp.AddField(text.RemoveExcessiveWhitespace(issue.Title), nil, nil)
-		tp.AddField(listIssueLabels(&issue, cs, tp.IsTTY()), nil, nil)
-		if tp.IsTTY() {
-			tp.AddField(text.FuzzyAgo(now, issue.UpdatedAt), nil, cs.Gray)
-		} else {
-			tp.AddField(issue.UpdatedAt.String(), nil, nil)
-		}
+		tp.AddField(text.RemoveExcessiveWhitespace(issue.Title))
+		tp.AddField(listIssueLabels(&issue, cs, isTTY))
+		tp.AddTimeField(now, issue.UpdatedAt, cs.Gray)
 		tp.EndRow()
 	}
 
-	if io.IsStdoutTTY() {
+	if isTTY {
 		var header string
 		switch et {
 		case Both:

--- a/pkg/cmd/search/shared/shared_test.go
+++ b/pkg/cmd/search/shared/shared_test.go
@@ -64,7 +64,7 @@ func TestSearchIssues(t *testing.T) {
 				},
 			},
 			tty:        true,
-			wantStdout: "\nShowing 3 of 300 issues\n\ntest/cli   #123  something broken  bug, p1      about 1 year ago\nwhat/what  #456  feature request   enhancement  about 1 year ago\nblah/test  #789  some title                     about 1 year ago\n",
+			wantStdout: "\nShowing 3 of 300 issues\n\nREPO       ID    TITLE             LABELS       UPDATED\ntest/cli   #123  something broken  bug, p1      about 1 year ago\nwhat/what  #456  feature request   enhancement  about 1 year ago\nblah/test  #789  some title                     about 1 year ago\n",
 		},
 		{
 			name: "displays issues and pull requests tty",
@@ -85,7 +85,7 @@ func TestSearchIssues(t *testing.T) {
 				},
 			},
 			tty:        true,
-			wantStdout: "\nShowing 2 of 300 issues and pull requests\n\nissue  test/cli   #123  bug      bug, p1  about 1 year ago\npr     what/what  #456  fix bug  fix      about 1 year ago\n",
+			wantStdout: "\nShowing 2 of 300 issues and pull requests\n\nKIND   REPO       ID    TITLE    LABELS   UPDATED\nissue  test/cli   #123  bug      bug, p1  about 1 year ago\npr     what/what  #456  fix bug  fix      about 1 year ago\n",
 		},
 		{
 			name: "displays results notty",
@@ -106,7 +106,7 @@ func TestSearchIssues(t *testing.T) {
 					},
 				},
 			},
-			wantStdout: "test/cli\t123\topen\tsomething broken\tbug, p1\t2021-02-28 12:30:00 +0000 UTC\nwhat/what\t456\tclosed\tfeature request\tenhancement\t2021-02-28 12:30:00 +0000 UTC\nblah/test\t789\topen\tsome title\t\t2021-02-28 12:30:00 +0000 UTC\n",
+			wantStdout: "test/cli\t123\topen\tsomething broken\tbug, p1\t2021-02-28T12:30:00Z\nwhat/what\t456\tclosed\tfeature request\tenhancement\t2021-02-28T12:30:00Z\nblah/test\t789\topen\tsome title\t\t2021-02-28T12:30:00Z\n",
 		},
 		{
 			name: "displays issues and pull requests notty",
@@ -126,7 +126,7 @@ func TestSearchIssues(t *testing.T) {
 					},
 				},
 			},
-			wantStdout: "issue\ttest/cli\t123\topen\tbug\tbug, p1\t2021-02-28 12:30:00 +0000 UTC\npr\twhat/what\t456\topen\tfix bug\tfix\t2021-02-28 12:30:00 +0000 UTC\n",
+			wantStdout: "issue\ttest/cli\t123\topen\tbug\tbug, p1\t2021-02-28T12:30:00Z\npr\twhat/what\t456\topen\tfix bug\tfix\t2021-02-28T12:30:00Z\n",
 		},
 		{
 			name: "displays no results",


### PR DESCRIPTION
This PR migrates the search commands to use the new table printer and also adds headers to the TTY output of the search commands.