### PR TITLE
Add `--reviewer` flag completion

### DIFF
--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -145,6 +145,24 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd.Flags().StringSliceVar(&opts.Editable.Projects.Remove, "remove-project", nil, "Remove the pull request from projects by `name`")
 	cmd.Flags().StringVarP(&opts.Editable.Milestone.Value, "milestone", "m", "", "Edit the milestone the pull request belongs to by `name`")
 
+	for _, flagName := range []string{"add-reviewer", "remove-reviewer"} {
+		_ = cmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			baseRepo, err := f.BaseRepo()
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+			httpClient, err := f.HttpClient()
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+			results, err := shared.RequestableReviewersForCompletion(httpClient, baseRepo)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+			return results, cobra.ShellCompDirectiveNoFileComp
+		})
+	}
+
 	return cmd
 }
 

--- a/pkg/cmd/pr/shared/completion.go
+++ b/pkg/cmd/pr/shared/completion.go
@@ -1,0 +1,39 @@
+package shared
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+)
+
+func RequestableReviewersForCompletion(httpClient *http.Client, repo ghrepo.Interface) ([]string, error) {
+	client := api.NewClientFromHTTP(api.NewCachedHTTPClient(httpClient, time.Minute*2))
+
+	metadata, err := api.RepoMetadata(client, repo, api.RepoMetadataInput{Reviewers: true})
+	if err != nil {
+		return nil, err
+	}
+
+	results := []string{}
+	for _, user := range metadata.AssignableUsers {
+		if strings.EqualFold(user.Login, metadata.CurrentLogin) {
+			continue
+		}
+		if user.Name != "" {
+			results = append(results, fmt.Sprintf("%s\t%s", user.Login, user.Name))
+		} else {
+			results = append(results, user.Login)
+		}
+	}
+	for _, team := range metadata.Teams {
+		results = append(results, fmt.Sprintf("%s/%s", repo.RepoOwner(), team.Slug))
+	}
+
+	sort.Strings(results)
+	return results, nil
+}


### PR DESCRIPTION
Fixes #6872


This PR suggests a completion method for the `--reviewer`  flag. 

Improvement ideas:
- apply on other commands, such as edit reviewers
- filter out reviewers based on previous flag values

Question for reviewers: is there a better place for the completion utility?