### PR TITLE
Use AuthToken function to retrieve AuthToken instead of GetOrDefault

### DIFF
--- a/pkg/cmd/auth/token/token.go
+++ b/pkg/cmd/auth/token/token.go
@@ -52,9 +52,8 @@ func tokenRun(opts *TokenOptions) error {
 		return err
 	}
 
-	key := "oauth_token"
-	val, err := cfg.GetOrDefault(hostname, key)
-	if err != nil {
+	val, _ := cfg.AuthToken(hostname)
+	if val == "" {
 		return fmt.Errorf("no oauth token")
 	}
 


### PR DESCRIPTION
`AuthToken` properly handles auth token environment variables that may be set. I audited other places we are using `GetOrDefault` and this appears to be the only place this needed to be changed.

Fixes https://github.com/cli/cli/issues/6874