### PR TITLE
repo set-default: support bare git repos

### DIFF
--- a/pkg/cmd/repo/setdefault/setdefault.go
+++ b/pkg/cmd/repo/setdefault/setdefault.go
@@ -90,9 +90,9 @@ func NewCmdSetDefault(f *cmdutil.Factory, runF func(*SetDefaultOptions) error) *
 				return cmdutil.FlagErrorf("repository required when not running interactively")
 			}
 
-			c := &git.Client{}
-
-			if !c.InGitDirectory(ctx.Background()) {
+			if isLocal, err := opts.GitClient.IsLocalGitRepo(cmd.Context()); err != nil {
+				return err
+			} else if !isLocal {
 				return errors.New("must be run from inside a git repository")
 			}
 

--- a/pkg/cmd/repo/setdefault/setdefault_test.go
+++ b/pkg/cmd/repo/setdefault/setdefault_test.go
@@ -29,7 +29,7 @@ func TestNewCmdSetDefault(t *testing.T) {
 		{
 			name: "no argument",
 			gitStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git rev-parse --is-inside-work-tree`, 0, "true")
+				cs.Register(`git rev-parse --git-dir`, 0, ".git")
 			},
 			input:  "",
 			output: SetDefaultOptions{},
@@ -37,7 +37,7 @@ func TestNewCmdSetDefault(t *testing.T) {
 		{
 			name: "repo argument",
 			gitStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git rev-parse --is-inside-work-tree`, 0, "true")
+				cs.Register(`git rev-parse --git-dir`, 0, ".git")
 			},
 			input:  "cli/cli",
 			output: SetDefaultOptions{Repo: ghrepo.New("cli", "cli")},
@@ -52,7 +52,7 @@ func TestNewCmdSetDefault(t *testing.T) {
 		{
 			name: "view flag",
 			gitStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git rev-parse --is-inside-work-tree`, 0, "true")
+				cs.Register(`git rev-parse --git-dir`, 0, ".git")
 			},
 			input:  "--view",
 			output: SetDefaultOptions{ViewMode: true},
@@ -60,7 +60,7 @@ func TestNewCmdSetDefault(t *testing.T) {
 		{
 			name: "unset flag",
 			gitStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git rev-parse --is-inside-work-tree`, 0, "true")
+				cs.Register(`git rev-parse --git-dir`, 0, ".git")
 			},
 			input:  "--unset",
 			output: SetDefaultOptions{UnsetMode: true},
@@ -68,7 +68,7 @@ func TestNewCmdSetDefault(t *testing.T) {
 		{
 			name: "run from non-git directory",
 			gitStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git rev-parse --is-inside-work-tree`, 1, "")
+				cs.Register(`git rev-parse --git-dir`, 128, "")
 			},
 			input:   "",
 			wantErr: true,
@@ -83,6 +83,7 @@ func TestNewCmdSetDefault(t *testing.T) {
 		io.SetStderrTTY(true)
 		f := &cmdutil.Factory{
 			IOStreams: io,
+			GitClient: &git.Client{GitPath: "/fake/path/to/git"},
 		}
 
 		var gotOpts *SetDefaultOptions


### PR DESCRIPTION
The command was using this to check for git repo context:

    git rev-parse --is-inside-work-tree

With this change, this is used instead:

    git rev-parse --git-dir

The latter approach works in the context of a bare git repository, which does not have a worktree, or in cases when the current directory is not a git repo but the GIT_DIR environment variable points to a git repository.

Fixes https://github.com/cli/cli/issues/6860