### PR TITLE
Codespaces create: Fix missing billable owner notice for individuals

### DIFF
--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -154,7 +154,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 
 	if err != nil {
 		return fmt.Errorf("error checking codespace ownership: %w", err)
-	} else if billableOwner != nil && billableOwner.Type == "Organization" {
+	} else if billableOwner != nil && (billableOwner.Type == "Organization" || billableOwner.Type == "User") {
 		cs := a.io.ColorScheme()
 		fmt.Fprintln(a.io.ErrOut, cs.Blue("  ✓ Codespaces usage for this repository is paid for by "+billableOwner.Login))
 	}


### PR DESCRIPTION
### Overview
This PR updates `gh cs create` to always output the billable owner when attempting to create a Codespace, not only when an Organization covers Codespaces usage for the repository.

![Screen Shot 2023-01-20 at 10 04 32 AM](https://user-images.githubusercontent.com/11203528/213755460-0a087601-e441-4938-a896-97a5e0b29c83.png)

Although all of the tests verify the expected STDERR output, I thought it'd be a good idea to include the appropriate User / Organization STDERR output tests for explicitness.

### Notes
Relates to internal Codespaces issue #11830