### PR TITLE
feat(darwin): also release arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ builds:
         - -X main.updaterEnabled=cli/cli
     id: macos
     goos: [darwin]
-    goarch: [amd64]
+    goarch: [amd64, arm64]
 
   - <<: *build_defaults
     id: linux


### PR DESCRIPTION
Surprised to notice there are no binaries for Mac OS arm64 in this repo's releases.
I realize that most folks will probably be installing via the Homebrew bottle, but this seemed like an oversight.

Feel free to close this PR if said binary's absence is intentional.