### PR TITLE
Warn against Windows absolute path when using `gh api`

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -186,7 +186,7 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 			opts.RequestMethodPassed = c.Flags().Changed("method")
 
 			if runtime.GOOS == "windows" && filepath.IsAbs(opts.RequestPath) {
-				return fmt.Errorf("invalid API endpoint: %q. Your shell might be rewriting URL paths as filesystem paths. To avoid this, omit the leading slash from the endpoint argument", opts.RequestPath)
+				return fmt.Errorf(`invalid API endpoint: "%s". Your shell might be rewriting URL paths as filesystem paths. To avoid this, omit the leading slash from the endpoint argument`, opts.RequestPath)
 			}
 
 			if c.Flags().Changed("hostname") {

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -182,6 +184,10 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.RequestPath = args[0]
 			opts.RequestMethodPassed = c.Flags().Changed("method")
+
+			if runtime.GOOS == "windows" && filepath.IsAbs(opts.RequestPath) {
+				return fmt.Errorf("a Windows-style absolute path was passed. drop the leading slash or escape it")
+			}
 
 			if c.Flags().Changed("hostname") {
 				if err := ghinstance.HostnameValidator(opts.Hostname); err != nil {

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -186,7 +186,7 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 			opts.RequestMethodPassed = c.Flags().Changed("method")
 
 			if runtime.GOOS == "windows" && filepath.IsAbs(opts.RequestPath) {
-				return fmt.Errorf("a Windows-style absolute path was passed. drop the leading slash or escape it")
+				return fmt.Errorf("invalid API endpoint: %q. Your shell might be rewriting URL paths as filesystem paths. To avoid this, omit the leading slash from the endpoint argument", opts.RequestPath)
 			}
 
 			if c.Flags().Changed("hostname") {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -367,7 +367,7 @@ func Test_NewCmdApi_WindowsAbsPath(t *testing.T) {
 
 	cmd.SetArgs([]string{`C:\users\repos`})
 	_, err := cmd.ExecuteC()
-	assert.EqualError(t, err, "a Windows-style absolute path was passed. drop the leading slash or escape it")
+	assert.EqualError(t, err, `invalid API endpoint: "C:\users\repos". Your shell might be rewriting URL paths as filesystem paths. To avoid this, omit the leading slash from the endpoint argument`)
 }
 
 func Test_apiRun(t *testing.T) {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -353,6 +354,20 @@ func Test_NewCmdApi(t *testing.T) {
 			assert.Equal(t, tt.wants.FilterOutput, opts.FilterOutput)
 		})
 	}
+}
+
+func Test_NewCmdApi_WindowsAbsPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.SkipNow()
+	}
+
+	cmd := NewCmdApi(&cmdutil.Factory{}, func(opts *ApiOptions) error {
+		return nil
+	})
+
+	cmd.SetArgs([]string{"/users/repos"})
+	_, err := cmd.ExecuteC()
+	assert.EqualError(t, err, "a Windows-style absolute path was passed. drop the leading slash or escape it")
 }
 
 func Test_apiRun(t *testing.T) {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -365,7 +365,7 @@ func Test_NewCmdApi_WindowsAbsPath(t *testing.T) {
 		return nil
 	})
 
-	cmd.SetArgs([]string{"C:\\users\\repos"})
+	cmd.SetArgs([]string{`C:\users\repos`})
 	_, err := cmd.ExecuteC()
 	assert.EqualError(t, err, "a Windows-style absolute path was passed. drop the leading slash or escape it")
 }

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -365,7 +365,7 @@ func Test_NewCmdApi_WindowsAbsPath(t *testing.T) {
 		return nil
 	})
 
-	cmd.SetArgs([]string{"/users/repos"})
+	cmd.SetArgs([]string{"C:\\users\\repos"})
 	_, err := cmd.ExecuteC()
 	assert.EqualError(t, err, "a Windows-style absolute path was passed. drop the leading slash or escape it")
 }


### PR DESCRIPTION
Fixes: <https://github.com/cli/cli/issues/6415>

This pull request allows the CLI to check against Windows-style absolute paths when providing an API endpoint to the `api` command, which is necessary for MinGW-based applications (e.g. Git Bash).

Let me know if I need to make any changes.