### PR TITLE
Configuration variables for GitHub Actions impl 2/2

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -31,6 +31,7 @@ import (
 	secretCmd "github.com/cli/cli/v2/pkg/cmd/secret"
 	sshKeyCmd "github.com/cli/cli/v2/pkg/cmd/ssh-key"
 	statusCmd "github.com/cli/cli/v2/pkg/cmd/status"
+	variableCmd "github.com/cli/cli/v2/pkg/cmd/variable"
 	versionCmd "github.com/cli/cli/v2/pkg/cmd/version"
 	workflowCmd "github.com/cli/cli/v2/pkg/cmd/workflow"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -97,6 +98,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(extensionCmd.NewCmdExtension(f))
 	cmd.AddCommand(searchCmd.NewCmdSearch(f))
 	cmd.AddCommand(secretCmd.NewCmdSecret(f))
+	cmd.AddCommand(variableCmd.NewCmdVariable(f))
 	cmd.AddCommand(sshKeyCmd.NewCmdSSHKey(f))
 	cmd.AddCommand(statusCmd.NewCmdStatus(f, nil))
 	cmd.AddCommand(newCodespaceCmd(f))

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -31,7 +31,6 @@ import (
 	secretCmd "github.com/cli/cli/v2/pkg/cmd/secret"
 	sshKeyCmd "github.com/cli/cli/v2/pkg/cmd/ssh-key"
 	statusCmd "github.com/cli/cli/v2/pkg/cmd/status"
-	variableCmd "github.com/cli/cli/v2/pkg/cmd/variable"
 	versionCmd "github.com/cli/cli/v2/pkg/cmd/version"
 	workflowCmd "github.com/cli/cli/v2/pkg/cmd/workflow"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -98,7 +97,6 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(extensionCmd.NewCmdExtension(f))
 	cmd.AddCommand(searchCmd.NewCmdSearch(f))
 	cmd.AddCommand(secretCmd.NewCmdSecret(f))
-	cmd.AddCommand(variableCmd.NewCmdVariable(f))
 	cmd.AddCommand(sshKeyCmd.NewCmdSSHKey(f))
 	cmd.AddCommand(statusCmd.NewCmdStatus(f, nil))
 	cmd.AddCommand(newCodespaceCmd(f))

--- a/pkg/cmd/variable/create/create.go
+++ b/pkg/cmd/variable/create/create.go
@@ -29,10 +29,8 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*shared.PostPatchOptions) error)
 			- environment: available to Actions runs for a deployment environment in a repository
 			- organization: available to Actions runs within an organization
 
-			Organization can optionally be restricted to only be available to
+			Organization variable can optionally be restricted to only be available to
 			specific repositories.
-
-			Variable values are locally value before being sent to GitHub.
 		`),
 		Example: heredoc.Doc(`
 			# Add variable value for the current repository in an interactive prompt
@@ -107,10 +105,9 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*shared.PostPatchOptions) error)
 	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "Create `organization` variable")
 	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Create deployment `environment` variable")
 	cmdutil.StringEnumFlag(cmd, &opts.Visibility, "visibility", "v", shared.Private, []string{shared.All, shared.Private, shared.Selected}, "Create visibility for an organization variable")
-	cmd.Flags().StringSliceVarP(&opts.RepositoryNames, "repos", "r", []string{}, "List of `repositories` that can access an organization")
+	cmd.Flags().StringSliceVarP(&opts.RepositoryNames, "repos", "r", []string{}, "List of `repositories` that can access an organization variable")
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "The value for the variable (reads from standard input if not specified)")
 	cmd.Flags().StringVarP(&opts.CsvFile, "csv-file", "f", "", "Load variable names and values from a csv-formatted `file`")
-	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", shared.Actions, []string{shared.Actions}, "Create the application for a variable")
 
 	return cmd
 }
@@ -150,7 +147,7 @@ func createRun(opts *shared.PostPatchOptions) error {
 		return err
 	}
 
-	variableApp, err := shared.GetVariableApp(opts.Application, variableEntity)
+	variableApp := shared.App(shared.Actions)
 	if err != nil || variableApp == shared.Unknown {
 		return err
 	}

--- a/pkg/cmd/variable/create/create.go
+++ b/pkg/cmd/variable/create/create.go
@@ -1,0 +1,232 @@
+package create
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdCreate(f *cmdutil.Factory, runF func(*shared.PostPatchOptions) error) *cobra.Command {
+	opts := &shared.PostPatchOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		HttpClient: f.HttpClient,
+		Prompter:   f.Prompter,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create <variable-name>",
+		Short: "Create variables",
+		Long: heredoc.Doc(`
+			Create a value for a variable on one of the following levels:
+			- repository (default): available to Actions runs in a repository
+			- environment: available to Actions runs for a deployment environment in a repository
+			- organization: available to Actions runs within an organization
+
+			Organization can optionally be restricted to only be available to
+			specific repositories.
+
+			Variable values are locally value before being sent to GitHub.
+		`),
+		Example: heredoc.Doc(`
+			# Add variable value for the current repository in an interactive prompt
+			$ gh variable create MYVARIABLE
+
+			# Read variable value from an environment variable
+			$ gh variable create MYVARIABLE --body "$ENV_VALUE"
+
+			# Read variable value from a file
+			$ gh variable create MYVARIABLE < myfile.txt
+
+			# Create variable for a deployment environment in the current repository
+			$ gh variable create MYVARIABLE --env myenvironment
+
+			# Create organization-level variable visible to both public and private repositories
+			$ gh variable create MYVARIABLE --org myOrg --visibility all
+
+			# Create organization-level variable visible to specific repositories
+			$ gh variable create MYVARIABLE --org myOrg --repos repo1,repo2,repo3
+
+			# Create multiple variables from the csv in the prescribed format
+			$ gh variable create -f file.csv
+
+		`),
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			if err := cmdutil.MutuallyExclusive("specify only one of `--org` or `--env`", opts.OrgName != "", opts.EnvName != ""); err != nil {
+				return err
+			}
+
+			if err := cmdutil.MutuallyExclusive("specify only one of `--body` or `--csv-file`", opts.Body != "", opts.CsvFile != ""); err != nil {
+				return err
+			}
+
+			if len(args) == 0 {
+				if opts.CsvFile == "" {
+					return cmdutil.FlagErrorf("must pass name argument")
+				}
+			} else {
+				opts.VariableName = args[0]
+			}
+
+			if cmd.Flags().Changed("visibility") {
+				if opts.OrgName == "" {
+					return cmdutil.FlagErrorf("`--visibility` is only supported with `--org`")
+				}
+
+				if opts.Visibility != shared.Selected && len(opts.RepositoryNames) > 0 {
+					return cmdutil.FlagErrorf("`--repos` is only supported with `--visibility=selected`")
+				}
+
+				if opts.Visibility == shared.Selected && len(opts.RepositoryNames) == 0 {
+					return cmdutil.FlagErrorf("`--repos` list required with `--visibility=selected`")
+				}
+			} else {
+				if len(opts.RepositoryNames) > 0 {
+					opts.Visibility = shared.Selected
+				}
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return createRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "Create `organization` variable")
+	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Create deployment `environment` variable")
+	cmdutil.StringEnumFlag(cmd, &opts.Visibility, "visibility", "v", shared.Private, []string{shared.All, shared.Private, shared.Selected}, "Create visibility for an organization variable")
+	cmd.Flags().StringSliceVarP(&opts.RepositoryNames, "repos", "r", []string{}, "List of `repositories` that can access an organization")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "The value for the variable (reads from standard input if not specified)")
+	cmd.Flags().StringVarP(&opts.CsvFile, "csv-file", "f", "", "Load variable names and values from a csv-formatted `file`")
+	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", shared.Actions, []string{shared.Actions}, "Create the application for a variable")
+
+	return cmd
+}
+
+func createRun(opts *shared.PostPatchOptions) error {
+
+	c, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not create http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(c)
+	orgName := opts.OrgName
+	envName := opts.EnvName
+
+	var host string
+	var baseRepo ghrepo.Interface
+	if orgName == "" {
+		baseRepo, err = opts.BaseRepo()
+		if err != nil {
+			return err
+		}
+		host = baseRepo.RepoHost()
+	} else {
+		cfg, err := opts.Config()
+		if err != nil {
+			return err
+		}
+		host, _ = cfg.DefaultHost()
+	}
+	variables, err := shared.GetVariablesFromOptions(opts, client, host, false)
+	if err != nil {
+		return err
+	}
+
+	variableEntity, err := shared.GetVariableEntity(orgName, envName)
+	if err != nil {
+		return err
+	}
+
+	variableApp, err := shared.GetVariableApp(opts.Application, variableEntity)
+	if err != nil || variableApp == shared.Unknown {
+		return err
+	}
+
+	if !shared.IsSupportedVariableEntity(variableApp, variableEntity) {
+		return fmt.Errorf("%s variables are not supported for %s", variableEntity, variableApp)
+	}
+
+	repoIdRes := shared.GetRepoIds(client, host, opts.OrgName, opts.RepositoryNames)
+	if repoIdRes.Err != nil {
+		return repoIdRes.Err
+	}
+
+	createc := make(chan createResult)
+	for variableKey, variable := range variables {
+		go func(variableKey string, variable shared.VariablePayload) {
+			var repoIds []int64
+			var visibility string
+			visibility = opts.Visibility
+			//cmd line opt overrides file
+			if len(repoIdRes.Ids) > 0 {
+				repoIds = repoIdRes.Ids
+			} else if variable.Visibility != "" {
+				visibility = variable.Visibility
+				repoIds = variable.Repositories
+			}
+			createc <- createVariable(opts, host, client, baseRepo, variableKey, variable.Value, visibility, repoIds, variableApp, variableEntity)
+		}(variableKey, variable)
+	}
+
+	err = nil
+	cs := opts.IO.ColorScheme()
+	for i := 0; i < len(variables); i++ {
+		result := <-createc
+		if result.err != nil {
+			err = multierror.Append(err, result.err)
+			continue
+		}
+		if result.value != "" {
+			fmt.Fprintln(opts.IO.Out, result.value)
+			continue
+		}
+		if !opts.IO.IsStdoutTTY() {
+			continue
+		}
+		target := orgName
+		if orgName == "" {
+			target = ghrepo.FullName(baseRepo)
+		}
+		fmt.Fprintf(opts.IO.Out, "%s Create %s variable %s for %s\n", cs.SuccessIcon(), variableApp.Title(), result.key, target)
+	}
+	return err
+}
+
+type createResult struct {
+	key   string
+	value string
+	err   error
+}
+
+func createVariable(opts *shared.PostPatchOptions, host string, client *api.Client, baseRepo ghrepo.Interface, variableKey, variableValue, visibility string, repositoryIDs []int64, app shared.App, entity shared.VariableEntity) (res createResult) {
+	orgName := opts.OrgName
+	envName := opts.EnvName
+	res.key = variableKey
+	var err error
+	switch entity {
+	case shared.Organization:
+		err = postOrgVariable(client, host, orgName, visibility, variableKey, variableValue, repositoryIDs, app)
+	case shared.Environment:
+		err = postEnvVariable(client, baseRepo, envName, variableKey, variableValue)
+	default:
+		err = postRepoVariable(client, baseRepo, variableKey, variableValue, app)
+	}
+	if err != nil {
+		res.err = fmt.Errorf("failed to create variable %q: %w", variableKey, err)
+		return
+	}
+	return
+}

--- a/pkg/cmd/variable/create/create_test.go
+++ b/pkg/cmd/variable/create/create_test.go
@@ -1,0 +1,359 @@
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    shared.PostPatchOptions
+		stdinTTY bool
+		wantsErr bool
+	}{
+		{
+			name:     "invalid visibility",
+			cli:      "cool_variable --org coolOrg -v'mistyVeil'",
+			wantsErr: true,
+		},
+		{
+			name:     "invalid visibility",
+			cli:      "cool_variable --org coolOrg -v'selected'",
+			wantsErr: true,
+		},
+		{
+			name:     "repos with wrong vis",
+			cli:      "cool_variable --org coolOrg -v'private' -rcoolRepo",
+			wantsErr: true,
+		},
+		{
+			name:     "no name",
+			cli:      "",
+			wantsErr: true,
+		},
+		{
+			name:     "multiple names",
+			cli:      "cool_variable good_variable",
+			wantsErr: true,
+		},
+		{
+			name:     "visibility without org",
+			cli:      "cool_variable -vall",
+			wantsErr: true,
+		},
+		{
+			name: "repos without vis",
+			cli:  "cool_variable -bs --org coolOrg -rcoolRepo",
+			wants: shared.PostPatchOptions{
+				VariableName:    "cool_variable",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"coolRepo"},
+				Body:            "s",
+				OrgName:         "coolOrg",
+			},
+		},
+		{
+			name: "org with selected repo",
+			cli:  "-ocoolOrg -bs -vselected -rcoolRepo cool_variable",
+			wants: shared.PostPatchOptions{
+				VariableName:    "cool_variable",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"coolRepo"},
+				Body:            "s",
+				OrgName:         "coolOrg",
+			},
+		},
+		{
+			name: "org with selected repos",
+			cli:  `--org=coolOrg -bs -vselected -r="coolRepo,radRepo,goodRepo" cool_variable`,
+			wants: shared.PostPatchOptions{
+				VariableName:    "cool_variable",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"coolRepo", "goodRepo", "radRepo"},
+				Body:            "s",
+				OrgName:         "coolOrg",
+			},
+		},
+		{
+			name: "repo",
+			cli:  `cool_variable -b"a variable"`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.Private,
+				Body:         "a variable",
+				OrgName:      "",
+			},
+		},
+		{
+			name: "env",
+			cli:  `cool_variable -b"a variable" -eRelease`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.Private,
+				Body:         "a variable",
+				OrgName:      "",
+				EnvName:      "Release",
+			},
+		},
+		{
+			name: "vis all",
+			cli:  `cool_variable --org coolOrg -b"cool" -vall`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.All,
+				Body:         "cool",
+				OrgName:      "coolOrg",
+			},
+		},
+		{
+			name: "no store",
+			cli:  `cool_variable`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.Private,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			ios.SetStdinTTY(tt.stdinTTY)
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *shared.PostPatchOptions
+			cmd := NewCmdCreate(f, func(opts *shared.PostPatchOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.VariableName, gotOpts.VariableName)
+			assert.Equal(t, tt.wants.Body, gotOpts.Body)
+			assert.Equal(t, tt.wants.Visibility, gotOpts.Visibility)
+			assert.Equal(t, tt.wants.OrgName, gotOpts.OrgName)
+			assert.Equal(t, tt.wants.EnvName, gotOpts.EnvName)
+			assert.ElementsMatch(t, tt.wants.RepositoryNames, gotOpts.RepositoryNames)
+		})
+	}
+}
+
+func Test_createRun_repo(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *shared.PostPatchOptions
+		wantApp string
+		wantErr bool
+	}{
+		{
+			name: "Actions",
+			opts: &shared.PostPatchOptions{
+				Application: "actions",
+			},
+			wantApp: "actions",
+			wantErr: false,
+		},
+		{
+			name: "defaults to unknown",
+			opts: &shared.PostPatchOptions{
+				Application: "",
+			},
+			wantApp: "unknown",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+
+			reg.Register(httpmock.REST("POST", fmt.Sprintf("repos/owner/repo/%s/variables", tt.wantApp)),
+				httpmock.StatusStringResponse(201, `{}`))
+
+			ios, _, _, _ := iostreams.Test()
+
+			opts := &shared.PostPatchOptions{
+				HttpClient: func() (*http.Client, error) {
+					return &http.Client{Transport: reg}, nil
+				},
+				Config: func() (config.Config, error) { return config.NewBlankConfig(), nil },
+				BaseRepo: func() (ghrepo.Interface, error) {
+					return ghrepo.FromFullName("owner/repo")
+				},
+				IO:             ios,
+				VariableName:   "cool_variable",
+				Body:           "a variable",
+				RandomOverride: fakeRandom,
+				Application:    tt.opts.Application,
+			}
+
+			err := createRun(opts)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			} else{
+				assert.NoError(t, err)
+			}
+
+			reg.Verify(t)
+
+			data, err := io.ReadAll(reg.Requests[0].Body)
+			assert.NoError(t, err)
+
+			var payload shared.VariablePayload
+			err = json.Unmarshal(data, &payload)
+			assert.NoError(t, err)
+			assert.Equal(t, payload.Value, "a variable")
+		})
+	}
+}
+
+func Test_createRun_env(t *testing.T) {
+	reg := &httpmock.Registry{}
+
+	reg.Register(httpmock.REST("POST", "repos/owner/repo/environments/development/variables"), httpmock.StatusStringResponse(201, `{}`))
+
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &shared.PostPatchOptions{
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		Config: func() (config.Config, error) { return config.NewBlankConfig(), nil },
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.FromFullName("owner/repo")
+		},
+		EnvName:        "development",
+		IO:             ios,
+		VariableName:   "cool_variable",
+		Body:           "a variable",
+		Application:    "actions",
+		RandomOverride: fakeRandom,
+	}
+
+	err := createRun(opts)
+	assert.NoError(t, err)
+
+	reg.Verify(t)
+
+	data, err := io.ReadAll(reg.Requests[0].Body)
+	assert.NoError(t, err)
+	var payload shared.VariablePayload
+	err = json.Unmarshal(data, &payload)
+	assert.NoError(t, err)
+	assert.Equal(t, payload.Value, "a variable")
+}
+
+func Test_createRun_org(t *testing.T) {
+	tests := []struct {
+		name             string
+		opts             *shared.PostPatchOptions
+		wantVisibility   shared.Visibility
+		wantRepositories []int64
+		wantApp          string
+	}{
+		{
+			name: "all vis",
+			opts: &shared.PostPatchOptions{
+				OrgName:    "UmbrellaCorporation",
+				Visibility: shared.All,
+				Application: "actions",
+			},
+			wantApp: "actions",
+		},
+		{
+			name: "selected visibility",
+			opts: &shared.PostPatchOptions{
+				OrgName:         "UmbrellaCorporation",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"birkin", "UmbrellaCorporation/wesker"},
+				Application: "actions",
+			},
+			wantRepositories: []int64{1, 2},
+			wantApp:          "actions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+
+			orgName := tt.opts.OrgName
+
+			reg.Register(httpmock.REST("POST",
+				fmt.Sprintf("orgs/%s/%s/variables", orgName, tt.wantApp)),
+				httpmock.StatusStringResponse(201, `{}`))
+
+			if len(tt.opts.RepositoryNames) > 0 {
+				reg.Register(httpmock.GraphQL(`query MapRepositoryNames\b`),
+					httpmock.StringResponse(`{"data":{"repo_0001":{"databaseId":1},"repo_0002":{"databaseId":2}}}`))
+			}
+
+			ios, _, _, _ := iostreams.Test()
+
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("owner/repo")
+			}
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.Config = func() (config.Config, error) {
+				return config.NewBlankConfig(), nil
+			}
+			tt.opts.IO = ios
+			tt.opts.VariableName = "org_variable"
+			tt.opts.Body = "a variable"
+			tt.opts.RandomOverride = fakeRandom
+
+			err := createRun(tt.opts)
+			assert.NoError(t, err)
+
+			reg.Verify(t)
+
+			data, err := io.ReadAll(reg.Requests[len(reg.Requests)-1].Body)
+			assert.NoError(t, err)
+			var payload shared.VariablePayload
+			err = json.Unmarshal(data, &payload)
+			assert.NoError(t, err)
+			assert.Equal(t, payload.Value, "a variable")
+			assert.Equal(t, payload.Name, tt.opts.VariableName)
+			assert.Equal(t, payload.Visibility, tt.opts.Visibility)
+			assert.ElementsMatch(t, payload.Repositories, tt.wantRepositories)
+		})
+	}
+}
+
+func fakeRandom() io.Reader {
+	return bytes.NewReader(bytes.Repeat([]byte{5}, 32))
+}

--- a/pkg/cmd/variable/create/create_test.go
+++ b/pkg/cmd/variable/create/create_test.go
@@ -179,18 +179,9 @@ func Test_createRun_repo(t *testing.T) {
 		{
 			name: "Actions",
 			opts: &shared.PostPatchOptions{
-				Application: "actions",
 			},
 			wantApp: "actions",
 			wantErr: false,
-		},
-		{
-			name: "defaults to unknown",
-			opts: &shared.PostPatchOptions{
-				Application: "",
-			},
-			wantApp: "unknown",
-			wantErr: true,
 		},
 	}
 
@@ -215,7 +206,6 @@ func Test_createRun_repo(t *testing.T) {
 				VariableName:   "cool_variable",
 				Body:           "a variable",
 				RandomOverride: fakeRandom,
-				Application:    tt.opts.Application,
 			}
 
 			err := createRun(opts)
@@ -258,7 +248,6 @@ func Test_createRun_env(t *testing.T) {
 		IO:             ios,
 		VariableName:   "cool_variable",
 		Body:           "a variable",
-		Application:    "actions",
 		RandomOverride: fakeRandom,
 	}
 
@@ -288,7 +277,6 @@ func Test_createRun_org(t *testing.T) {
 			opts: &shared.PostPatchOptions{
 				OrgName:    "UmbrellaCorporation",
 				Visibility: shared.All,
-				Application: "actions",
 			},
 			wantApp: "actions",
 		},
@@ -298,7 +286,6 @@ func Test_createRun_org(t *testing.T) {
 				OrgName:         "UmbrellaCorporation",
 				Visibility:      shared.Selected,
 				RepositoryNames: []string{"birkin", "UmbrellaCorporation/wesker"},
-				Application: "actions",
 			},
 			wantRepositories: []int64{1, 2},
 			wantApp:          "actions",

--- a/pkg/cmd/variable/create/http.go
+++ b/pkg/cmd/variable/create/http.go
@@ -1,0 +1,51 @@
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+)
+
+func postVariable(client *api.Client, host, path string, payload interface{}) error {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to serialize: %w", err)
+	}
+	requestBody := bytes.NewReader(payloadBytes)
+
+	return client.REST(host, "POST", path, requestBody, nil)
+}
+
+func postOrgVariable(client *api.Client, host string, orgName, visibility, variableName, Value string, repositoryIDs []int64, app shared.App) error {
+	payload := shared.VariablePayload{
+		Name:         variableName,
+		Value:        Value,
+		Repositories: repositoryIDs,
+		Visibility:   visibility,
+	}
+	path := fmt.Sprintf(`orgs/%s/%s/variables`, orgName, app)
+
+	return postVariable(client, host, path, payload)
+}
+
+func postEnvVariable(client *api.Client, repo ghrepo.Interface, envName string, variableName, Value string) error {
+	payload := shared.VariablePayload{
+		Name:  variableName,
+		Value: Value,
+	}
+	path := fmt.Sprintf(`repos/%s/environments/%s/variables`, ghrepo.FullName(repo), envName)
+	return postVariable(client, repo.RepoHost(), path, payload)
+}
+
+func postRepoVariable(client *api.Client, repo ghrepo.Interface, variableName, Value string, app shared.App) error {
+	payload := shared.VariablePayload{
+		Name:  variableName,
+		Value: Value,
+	}
+	path := fmt.Sprintf(`repos/%s/%s/variables`, ghrepo.FullName(repo), app)
+	return postVariable(client, repo.RepoHost(), path, payload)
+}

--- a/pkg/cmd/variable/create/http.go
+++ b/pkg/cmd/variable/create/http.go
@@ -37,7 +37,7 @@ func postEnvVariable(client *api.Client, repo ghrepo.Interface, envName string, 
 		Name:  variableName,
 		Value: Value,
 	}
-	path := fmt.Sprintf(`repos/%s/environments/%s/variables`, ghrepo.FullName(repo), envName)
+	path := fmt.Sprintf(`repositories/%s/environments/%s/variables`, ghrepo.FullName(repo), envName)
 	return postVariable(client, repo.RepoHost(), path, payload)
 }
 
@@ -46,6 +46,6 @@ func postRepoVariable(client *api.Client, repo ghrepo.Interface, variableName, V
 		Name:  variableName,
 		Value: Value,
 	}
-	path := fmt.Sprintf(`repos/%s/%s/variables`, ghrepo.FullName(repo), app)
+	path := fmt.Sprintf(`repositories/%s/%s/variables`, ghrepo.FullName(repo), app)
 	return postVariable(client, repo.RepoHost(), path, payload)
 }

--- a/pkg/cmd/variable/delete/delete.go
+++ b/pkg/cmd/variable/delete/delete.go
@@ -65,7 +65,6 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	}
 	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "Delete a variable for an organization")
 	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Delete a variable for an environment")
-	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", shared.Actions, []string{shared.Actions}, "Delete a variable for a specific application")
 
 	return cmd
 }
@@ -85,7 +84,7 @@ func removeRun(opts *DeleteOptions) error {
 		return err
 	}
 
-	variableApp, err := shared.GetVariableApp(opts.Application, variableEntity)
+	variableApp := shared.App(shared.Actions)
 	if err != nil || variableApp == shared.Unknown {
 		return err
 	}

--- a/pkg/cmd/variable/delete/delete.go
+++ b/pkg/cmd/variable/delete/delete.go
@@ -1,0 +1,145 @@
+package delete
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type DeleteOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	Config     func() (config.Config, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	VariableName string
+	OrgName      string
+	EnvName      string
+	Application  string
+}
+
+func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Command {
+	opts := &DeleteOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete <variable-name>",
+		Short: "Delete variables",
+		Long: heredoc.Doc(`
+			Delete a variable on one of the following levels:
+			- repository (default): available to Actions runs in a repository
+			- environment: available to Actions runs for a deployment environment in a repository
+			- organization: available to Actions runs within an organization
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			if err := cmdutil.MutuallyExclusive("specify only one of `--org` or `--env`", opts.OrgName != "", opts.EnvName != ""); err != nil {
+				return err
+			}
+
+			opts.VariableName = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return removeRun(opts)
+		},
+		Aliases: []string{
+			"remove",
+		},
+	}
+	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "Delete a variable for an organization")
+	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Delete a variable for an environment")
+	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", shared.Actions, []string{shared.Actions}, "Delete a variable for a specific application")
+
+	return cmd
+}
+
+func removeRun(opts *DeleteOptions) error {
+	c, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not create http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(c)
+
+	orgName := opts.OrgName
+	envName := opts.EnvName
+
+	variableEntity, err := shared.GetVariableEntity(orgName, envName)
+	if err != nil {
+		return err
+	}
+
+	variableApp, err := shared.GetVariableApp(opts.Application, variableEntity)
+	if err != nil || variableApp == shared.Unknown {
+		return err
+	}
+
+	if !shared.IsSupportedVariableEntity(variableApp, variableEntity) {
+		return fmt.Errorf("%s variables are not supported for %s", variableEntity, variableApp)
+	}
+
+	var baseRepo ghrepo.Interface
+	if variableEntity == shared.Repository || variableEntity == shared.Environment {
+		baseRepo, err = opts.BaseRepo()
+		if err != nil {
+			return err
+		}
+	}
+
+	var path string
+	switch variableEntity {
+	case shared.Organization:
+		path = fmt.Sprintf(`orgs/%s/%s/variables/%s`, orgName, variableApp, opts.VariableName)
+	case shared.Environment:
+		path = fmt.Sprintf(`repos/%s/environments/%s/variables/%s`, ghrepo.FullName(baseRepo), envName, opts.VariableName)
+	case shared.Repository:
+		path = fmt.Sprintf(`repos/%s/%s/variables/%s`, ghrepo.FullName(baseRepo), variableApp, opts.VariableName)
+	}
+
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	host, _ := cfg.DefaultHost()
+
+	err = client.REST(host, "DELETE", path, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete variable %s: %w", opts.VariableName, err)
+	}
+
+	if opts.IO.IsStdoutTTY() {
+		var target string
+		switch variableEntity {
+		case shared.Organization:
+			target = orgName
+		case shared.Repository, shared.Environment:
+			target = ghrepo.FullName(baseRepo)
+		}
+
+		cs := opts.IO.ColorScheme()
+		if envName != "" {
+			fmt.Fprintf(opts.IO.Out, "%s Deleted variable %s from %s environment on %s\n", cs.SuccessIconWithColor(cs.Red), opts.VariableName, envName, target)
+		} else {
+			fmt.Fprintf(opts.IO.Out, "%s Deleted %s variable %s from %s\n", cs.SuccessIconWithColor(cs.Red), variableApp.Title(), opts.VariableName, target)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/variable/delete/delete_test.go
+++ b/pkg/cmd/variable/delete/delete_test.go
@@ -1,0 +1,221 @@
+package delete
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdDelete(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    DeleteOptions
+		wantsErr bool
+	}{
+		{
+			name:     "no args",
+			wantsErr: true,
+		},
+		{
+			name: "repo",
+			cli:  "cool",
+			wants: DeleteOptions{
+				VariableName: "cool",
+			},
+		},
+		{
+			name: "org",
+			cli:  "cool --org anOrg",
+			wants: DeleteOptions{
+				VariableName: "cool",
+				OrgName:    "anOrg",
+			},
+		},
+		{
+			name: "env",
+			cli:  "cool --env anEnv",
+			wants: DeleteOptions{
+				VariableName: "cool",
+				EnvName:    "anEnv",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *DeleteOptions
+			cmd := NewCmdDelete(f, func(opts *DeleteOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.VariableName, gotOpts.VariableName)
+			assert.Equal(t, tt.wants.OrgName, gotOpts.OrgName)
+			assert.Equal(t, tt.wants.EnvName, gotOpts.EnvName)
+		})
+	}
+
+}
+
+func Test_removeRun_repo(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     *DeleteOptions
+		wantPath string
+		wantErr bool
+	}{
+		{
+			name: "Actions",
+			opts: &DeleteOptions{
+				Application: "actions",
+				VariableName:  "cool_variable",
+			},
+			wantPath: "repos/owner/repo/actions/variables/cool_variable",
+		},
+		{
+			name: "defaults to error",
+			opts: &DeleteOptions{
+				VariableName: "cool_variable",
+			},
+			wantPath: "repos/owner/repo/actions/variables/cool_variable",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		reg := &httpmock.Registry{}
+
+		reg.Register(
+			httpmock.REST("DELETE", tt.wantPath),
+			httpmock.StatusStringResponse(204, "No Content"))
+
+		ios, _, _, _ := iostreams.Test()
+
+		tt.opts.IO = ios
+		tt.opts.HttpClient = func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		}
+		tt.opts.Config = func() (config.Config, error) {
+			return config.NewBlankConfig(), nil
+		}
+		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+			return ghrepo.FromFullName("owner/repo")
+		}
+
+		err := removeRun(tt.opts)
+		if tt.wantErr{
+			assert.Error(t, err)
+			return
+		} else {
+			assert.NoError(t, err)
+		}
+		reg.Verify(t)
+	}
+}
+
+func Test_removeRun_env(t *testing.T) {
+	reg := &httpmock.Registry{}
+
+	reg.Register(
+		httpmock.REST("DELETE", "repos/owner/repo/environments/development/variables/cool_variable"),
+		httpmock.StatusStringResponse(204, "No Content"))
+
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &DeleteOptions{
+		IO: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		Config: func() (config.Config, error) {
+			return config.NewBlankConfig(), nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.FromFullName("owner/repo")
+		},
+		VariableName: "cool_variable",
+		EnvName:    "development",
+		Application: "actions",
+	}
+
+	err := removeRun(opts)
+	assert.NoError(t, err)
+
+	reg.Verify(t)
+}
+
+func Test_removeRun_org(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     *DeleteOptions
+		wantPath string
+	}{
+		{
+			name: "org",
+			opts: &DeleteOptions{
+				OrgName: "UmbrellaCorporation",
+				Application: "actions",
+			},
+			wantPath: "orgs/UmbrellaCorporation/actions/variables/tVirus",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+
+			reg.Register(
+				httpmock.REST("DELETE", tt.wantPath),
+				httpmock.StatusStringResponse(204, "No Content"))
+
+			ios, _, _, _ := iostreams.Test()
+
+			tt.opts.Config = func() (config.Config, error) {
+				return config.NewBlankConfig(), nil
+			}
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("owner/repo")
+			}
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.IO = ios
+			tt.opts.VariableName = "tVirus"
+
+			err := removeRun(tt.opts)
+			assert.NoError(t, err)
+
+			reg.Verify(t)
+
+		})
+	}
+
+}

--- a/pkg/cmd/variable/list/list.go
+++ b/pkg/cmd/variable/list/list.go
@@ -51,7 +51,6 @@ func NewCmdList(f *cmdutil.Factory, runF func(*shared.ListOptions) error) *cobra
 	cmd.Flags().IntVar(&opts.Page, "page", 1, "Page Number")
 	cmd.Flags().IntVar(&opts.PerPage, "perpage", 10, "Maximum variable count")
 	cmd.Flags().StringVarP(&opts.Name, "name", "n", "", "Name of a particular variable")
-	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", shared.Actions, []string{shared.Actions}, "List variables for a specific application")
 
 	return cmd
 }

--- a/pkg/cmd/variable/list/list.go
+++ b/pkg/cmd/variable/list/list.go
@@ -1,0 +1,119 @@
+package list
+
+import (
+	"fmt"
+
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/utils"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdList(f *cmdutil.Factory, runF func(*shared.ListOptions) error) *cobra.Command {
+	opts := &shared.ListOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List variables",
+		Long: heredoc.Doc(`
+			List variables on one of the following levels:
+			- repository (default): available to Actions runs in a repository
+			- environment: available to Actions runs for a deployment environment in a repository
+			- organization: available to Actions runs within an organization
+		`),
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			if err := cmdutil.MutuallyExclusive("specify only one of `--org` or `--env`", opts.OrgName != "", opts.EnvName != ""); err != nil {
+				return err
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return listRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "List variables for an organization")
+	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "List variables for an environment")
+	cmd.Flags().IntVar(&opts.Page, "page", 1, "Page Number")
+	cmd.Flags().IntVar(&opts.PerPage, "perpage", 10, "Maximum variable count")
+	cmd.Flags().StringVarP(&opts.Name, "name", "n", "", "Name of a particular variable")
+	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", shared.Actions, []string{shared.Actions}, "List variables for a specific application")
+
+	return cmd
+}
+
+func listRun(opts *shared.ListOptions) error {
+
+	showSelectedRepoInfo := opts.IO.IsStdoutTTY()
+	variables, err := shared.GetVariablesForList(opts, showSelectedRepoInfo)
+	if err != nil {
+		return err
+	}
+
+	if len(variables) == 0 {
+		return cmdutil.NewNoResultsError("no variables found")
+	}
+
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
+	}
+
+	//nolint:staticcheck // SA1019: utils.NewTablePrinter is deprecated: use internal/tableprinter
+	tp := utils.NewTablePrinter(opts.IO)
+	for _, variable := range variables {
+		tp.AddField(variable.Name, nil, nil)
+		tp.AddField(variable.Value, nil, nil)
+		updatedAt := variable.UpdatedAt.Format("2006-01-02")
+		if opts.IO.IsStdoutTTY() {
+			updatedAt = fmt.Sprintf("Updated %s", updatedAt)
+		}
+		tp.AddField(updatedAt, nil, nil)
+		if variable.Visibility != "" {
+			if showSelectedRepoInfo {
+				tp.AddField(fmtVisibility(*variable), nil, nil)
+			} else {
+				tp.AddField(strings.ToUpper(string(variable.Visibility)), nil, nil)
+			}
+		}
+		tp.EndRow()
+	}
+
+	err = tp.Render()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fmtVisibility(s shared.Variable) string {
+	switch s.Visibility {
+	case shared.All:
+		return "Visible to all repositories"
+	case shared.Private:
+		return "Visible to private repositories"
+	case shared.Selected:
+		if s.NumSelectedRepos == 1 {
+			return "Visible to 1 selected repository"
+		} else {
+			return fmt.Sprintf("Visible to %d selected repositories", s.NumSelectedRepos)
+		}
+	}
+	return ""
+}

--- a/pkg/cmd/variable/list/list_test.go
+++ b/pkg/cmd/variable/list/list_test.go
@@ -1,0 +1,253 @@
+package list
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/test"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewCmdList(t *testing.T) {
+	tests := []struct {
+		name  string
+		cli   string
+		wants shared.ListOptions
+	}{
+		{
+			name: "repo",
+			cli:  "",
+			wants: shared.ListOptions{
+				OrgName: "",
+			},
+		},
+		{
+			name: "org",
+			cli:  "-oUmbrellaCorporation",
+			wants: shared.ListOptions{
+				OrgName: "UmbrellaCorporation",
+				Page: 1,
+				PerPage: 5,
+			},
+		},
+		{
+			name: "env",
+			cli:  "-eDevelopment",
+			wants: shared.ListOptions{
+				EnvName: "Development",
+				Page: 1,
+				PerPage: 2,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *shared.ListOptions
+			cmd := NewCmdList(f, func(opts *shared.ListOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.OrgName, gotOpts.OrgName)
+			assert.Equal(t, tt.wants.EnvName, gotOpts.EnvName)
+		})
+	}
+}
+
+func Test_listRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		tty     bool
+		opts    *shared.ListOptions
+		wantOut []string
+	}{
+		{
+			name: "repo tty",
+			tty:  true,
+			opts: &shared.ListOptions{ Application: "actions" },
+			wantOut: []string{
+				"VARIABLE_ONE.*Updated 1988-10-11",
+				"VARIABLE_TWO.*Updated 2020-12-04",
+				"VARIABLE_THREE.*Updated 1975-11-30",
+			},
+		},
+		{
+			name: "repo not tty",
+			tty:  false,
+			opts: &shared.ListOptions{ Application: "actions" },
+			wantOut: []string{
+				"VARIABLE_ONE\tone\t1988-10-11",
+				"VARIABLE_TWO\ttwo\t2020-12-04",
+				"VARIABLE_THREE\tthree\t1975-11-30",
+			},
+		},
+		{
+			name: "org tty",
+			tty:  true,
+			opts: &shared.ListOptions{
+				OrgName: "UmbrellaCorporation",
+				Application: "actions",
+			},
+			wantOut: []string{
+				"VARIABLE_ONE.*Updated 1988-10-11.*Visible to all repositories",
+				"VARIABLE_TWO.*Updated 2020-12-04.*Visible to private repositories",
+				"VARIABLE_THREE.*Updated 1975-11-30.*Visible to 2 selected repositories",
+			},
+		},
+		{
+			name: "org not tty",
+			tty:  false,
+			opts: &shared.ListOptions{
+				OrgName: "UmbrellaCorporation",
+				Application: "actions",
+			},
+			wantOut: []string{
+				"VARIABLE_ONE\torg1\t1988-10-11\tALL",
+				"VARIABLE_TWO\torg2\t2020-12-04\tPRIVATE",
+				"VARIABLE_THREE\torg3\t1975-11-30\tSELECTED",
+			},
+		},
+		{
+			name: "env tty",
+			tty:  true,
+			opts: &shared.ListOptions{
+				EnvName: "Development",
+				Application: "actions",
+			},
+			wantOut: []string{
+				"VARIABLE_ONE.*Updated 1988-10-11",
+				"VARIABLE_TWO.*Updated 2020-12-04",
+				"VARIABLE_THREE.*Updated 1975-11-30",
+			},
+		},
+		{
+			name: "env not tty",
+			tty:  false,
+			opts: &shared.ListOptions{
+				EnvName: "Development",
+				Application: "actions",
+			},
+			wantOut: []string{
+				"VARIABLE_ONE\tone\t1988-10-11",
+				"VARIABLE_TWO\ttwo\t2020-12-04",
+				"VARIABLE_THREE\tthree\t1975-11-30",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+
+			path := "repos/owner/repo/actions/variables"
+			if tt.opts.EnvName != "" {
+				path = fmt.Sprintf("repos/owner/repo/environments/%s/variables", tt.opts.EnvName)
+			}
+
+			t0, _ := time.Parse("2006-01-02", "1988-10-11")
+			t1, _ := time.Parse("2006-01-02", "2020-12-04")
+			t2, _ := time.Parse("2006-01-02", "1975-11-30")
+			payload := shared.VariablesPayload{}
+			payload.Variables = []*shared.Variable{
+				{
+					Name:      "VARIABLE_ONE",
+					Value:     "one",
+					UpdatedAt: t0,
+				},
+				{
+					Name:      "VARIABLE_TWO",
+					Value:     "two",
+					UpdatedAt: t1,
+				},
+				{
+					Name:      "VARIABLE_THREE",
+					Value:     "three",
+					UpdatedAt: t2,
+				},
+			}
+			if tt.opts.OrgName != "" {
+				payload.Variables = []*shared.Variable{
+					{
+						Name:       "VARIABLE_ONE",
+						UpdatedAt:  t0,
+						Value:      "org1",
+						Visibility: shared.All,
+					},
+					{
+						Name:       "VARIABLE_TWO",
+						UpdatedAt:  t1,
+						Value:      "org2",
+						Visibility: shared.Private,
+					},
+					{
+						Name:             "VARIABLE_THREE",
+						UpdatedAt:        t2,
+						Value: 			  "org3",
+						Visibility:       shared.Selected,
+						SelectedReposURL: fmt.Sprintf("https://api.github.com/orgs/%s/actions/variables/VARIABLE_THREE/repositories", tt.opts.OrgName),
+					},
+				}
+				path = fmt.Sprintf("orgs/%s/actions/variables", tt.opts.OrgName)
+
+				if tt.tty {
+					reg.Register(
+						httpmock.REST("GET", fmt.Sprintf("orgs/%s/actions/variables/VARIABLE_THREE/repositories", tt.opts.OrgName)),
+						httpmock.JSONResponse(struct {
+							TotalCount int `json:"total_count"`
+						}{2}))
+				}
+			}
+
+			reg.Register(httpmock.REST("GET", path), httpmock.JSONResponse(payload))
+
+			ios, _, stdout, _ := iostreams.Test()
+
+			ios.SetStdoutTTY(tt.tty)
+
+			tt.opts.IO = ios
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("owner/repo")
+			}
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.Config = func() (config.Config, error) {
+				return config.NewBlankConfig(), nil
+			}
+
+		    err := listRun(tt.opts)
+			assert.NoError(t, err)
+
+			reg.Verify(t)
+
+			//nolint:staticcheck // prefer exact matchers over ExpectLines
+			test.ExpectLines(t, stdout.String(), tt.wantOut...)
+		})
+	}
+}

--- a/pkg/cmd/variable/list/list_test.go
+++ b/pkg/cmd/variable/list/list_test.go
@@ -90,7 +90,7 @@ func Test_listRun(t *testing.T) {
 		{
 			name: "repo tty",
 			tty:  true,
-			opts: &shared.ListOptions{ Application: "actions" },
+			opts: &shared.ListOptions{ },
 			wantOut: []string{
 				"VARIABLE_ONE.*Updated 1988-10-11",
 				"VARIABLE_TWO.*Updated 2020-12-04",
@@ -100,7 +100,7 @@ func Test_listRun(t *testing.T) {
 		{
 			name: "repo not tty",
 			tty:  false,
-			opts: &shared.ListOptions{ Application: "actions" },
+			opts: &shared.ListOptions{ },
 			wantOut: []string{
 				"VARIABLE_ONE\tone\t1988-10-11",
 				"VARIABLE_TWO\ttwo\t2020-12-04",
@@ -112,7 +112,6 @@ func Test_listRun(t *testing.T) {
 			tty:  true,
 			opts: &shared.ListOptions{
 				OrgName: "UmbrellaCorporation",
-				Application: "actions",
 			},
 			wantOut: []string{
 				"VARIABLE_ONE.*Updated 1988-10-11.*Visible to all repositories",
@@ -125,7 +124,6 @@ func Test_listRun(t *testing.T) {
 			tty:  false,
 			opts: &shared.ListOptions{
 				OrgName: "UmbrellaCorporation",
-				Application: "actions",
 			},
 			wantOut: []string{
 				"VARIABLE_ONE\torg1\t1988-10-11\tALL",
@@ -138,7 +136,6 @@ func Test_listRun(t *testing.T) {
 			tty:  true,
 			opts: &shared.ListOptions{
 				EnvName: "Development",
-				Application: "actions",
 			},
 			wantOut: []string{
 				"VARIABLE_ONE.*Updated 1988-10-11",
@@ -151,7 +148,6 @@ func Test_listRun(t *testing.T) {
 			tty:  false,
 			opts: &shared.ListOptions{
 				EnvName: "Development",
-				Application: "actions",
 			},
 			wantOut: []string{
 				"VARIABLE_ONE\tone\t1988-10-11",

--- a/pkg/cmd/variable/shared/shared.go
+++ b/pkg/cmd/variable/shared/shared.go
@@ -86,7 +86,6 @@ type PostPatchOptions struct {
 	Visibility      string
 	RepositoryNames []string
 	CsvFile         string
-	Application     string
 	Prompter        iprompter
 }
 
@@ -98,7 +97,6 @@ type ListOptions struct {
 
 	OrgName     string
 	EnvName     string
-	Application string
 	Page        int
 	PerPage     int
 	Name        string
@@ -149,15 +147,6 @@ func GetVariableEntity(orgName, envName string) (VariableEntity, error) {
 		return Environment, nil
 	}
 	return Repository, nil
-}
-
-func GetVariableApp(app string, entity VariableEntity) (App, error) {
-	switch strings.ToLower(app) {
-	case Actions:
-		return Actions, nil
-	default:
-		return Unknown, fmt.Errorf("invalid application: %s", app)
-	}
 }
 
 func IsSupportedVariableEntity(app App, entity VariableEntity) bool {
@@ -357,7 +346,6 @@ func getBody(opts *PostPatchOptions, client *api.Client, host string, isUpdate b
 				BaseRepo:    opts.BaseRepo,
 				OrgName:     opts.OrgName,
 				EnvName:     opts.EnvName,
-				Application: opts.Application,
 				Page:        0,
 				PerPage:     0,
 				Name:        opts.VariableName,
@@ -430,7 +418,7 @@ func GetVariablesForList(opts *ListOptions, getSelectedRepoInfo bool) ([]*Variab
 		return nil, err
 	}
 
-	variableApp, err := GetVariableApp(opts.Application, variableEntity)
+	variableApp := App(Actions)
 	if err != nil || variableApp == Unknown {
 		return nil, err
 	}

--- a/pkg/cmd/variable/shared/shared.go
+++ b/pkg/cmd/variable/shared/shared.go
@@ -1,0 +1,555 @@
+package shared
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghinstance"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/text"
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+type Visibility string
+
+const (
+	All      = "all"
+	Private  = "private"
+	Selected = "selected"
+)
+
+type App string
+
+const (
+	Actions = "actions"
+	Unknown = "unknown"
+)
+
+func (app App) String() string {
+	return string(app)
+}
+
+func (app App) Title() string {
+	return text.Title(app.String())
+}
+
+type VariableEntity string
+
+const (
+	Repository   = "repository"
+	Organization = "organization"
+	Environment  = "environment"
+)
+
+type VariablePayload struct {
+	Name         string  `json:"name,omitempty"`
+	Value        string  `json:"value,omitempty"`
+	Visibility   string  `json:"visibility,omitempty"`
+	Repositories []int64 `json:"selected_repository_ids,omitempty"`
+	KeyID        string  `json:"key_id"`
+}
+
+type PubKey struct {
+	ID  string `json:"key_id"`
+	Key string
+}
+
+type repoNamesResult struct {
+	Ids []int64
+	Err error
+}
+
+type PostPatchOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	Config     func() (config.Config, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	RandomOverride func() io.Reader
+
+	VariableName    string
+	OrgName         string
+	EnvName         string
+	Body            string
+	Visibility      string
+	RepositoryNames []string
+	CsvFile         string
+	Application     string
+	Prompter        iprompter
+}
+
+type ListOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	Config     func() (config.Config, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	OrgName     string
+	EnvName     string
+	Application string
+	Page        int
+	PerPage     int
+	Name        string
+}
+
+type Variable struct {
+	Name             string     `json:"name"`
+	Value            string     `json:"value"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	Visibility       Visibility `json:"visibility"`
+	SelectedReposURL string     `json:"selected_repositories_url"`
+	NumSelectedRepos int
+}
+type VariablesPayload struct {
+	Variables []*Variable
+}
+
+type Repo struct {
+	Name string `json: "name"`
+}
+
+type SelectedRepos struct {
+	Repositories []*Repo
+}
+
+type httpClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type iprompter interface {
+	Input(string, string) (string, error)
+	Select(string, string, []string) (int, error)
+	Confirm(string, bool) (bool, error)
+}
+
+func GetVariableEntity(orgName, envName string) (VariableEntity, error) {
+	orgSet := orgName != ""
+	envSet := envName != ""
+
+	if orgSet && envSet {
+		return "", errors.New("cannot specify multiple variable entities")
+	}
+
+	if orgSet {
+		return Organization, nil
+	}
+	if envSet {
+		return Environment, nil
+	}
+	return Repository, nil
+}
+
+func GetVariableApp(app string, entity VariableEntity) (App, error) {
+	switch strings.ToLower(app) {
+	case Actions:
+		return Actions, nil
+	default:
+		return Unknown, fmt.Errorf("invalid application: %s", app)
+	}
+}
+
+func IsSupportedVariableEntity(app App, entity VariableEntity) bool {
+	switch app {
+	case Actions:
+		return entity == Repository || entity == Organization || entity == Environment
+	default:
+		return false
+	}
+}
+
+// This does similar logic to `api.RepoNetwork`, but without the overfetching.
+func MapRepoToID(client *api.Client, host string, repositories []ghrepo.Interface) ([]int64, error) {
+	queries := make([]string, 0, len(repositories))
+	for i, repo := range repositories {
+		queries = append(queries, fmt.Sprintf(`
+			repo_%03d: repository(owner: %q, name: %q) {
+				databaseId
+			}
+		`, i, repo.RepoOwner(), repo.RepoName()))
+	}
+
+	query := fmt.Sprintf(`query MapRepositoryNames { %s }`, strings.Join(queries, ""))
+
+	graphqlResult := make(map[string]*struct {
+		DatabaseID int64 `json:"databaseId"`
+	})
+
+	if err := client.GraphQL(host, query, nil, &graphqlResult); err != nil {
+		return nil, fmt.Errorf("failed to look up repositories: %w", err)
+	}
+
+	repoKeys := make([]string, 0, len(repositories))
+	for k := range graphqlResult {
+		repoKeys = append(repoKeys, k)
+	}
+	sort.Strings(repoKeys)
+
+	result := make([]int64, len(repositories))
+	for i, k := range repoKeys {
+		result[i] = graphqlResult[k].DatabaseID
+	}
+	return result, nil
+}
+
+func getCurrentSelectedRepos(client httpClient, url string) string {
+	var selectedRepositories SelectedRepos
+	err := apiGet(client, url, &selectedRepositories)
+	if err != nil {
+		return ""
+	}
+	names := make([]string, 0)
+	for _, repo := range selectedRepositories.Repositories {
+		names = append(names, repo.Name)
+	}
+	return strings.Join(names, ",")
+}
+
+func MapRepoNamesToIDs(client *api.Client, host, defaultOwner string, repositoryNames []string) ([]int64, error) {
+	repos := make([]ghrepo.Interface, 0, len(repositoryNames))
+	for _, repositoryName := range repositoryNames {
+		var repo ghrepo.Interface
+		if strings.Contains(repositoryName, "/") || defaultOwner == "" {
+			var err error
+			repo, err = ghrepo.FromFullNameWithHost(repositoryName, host)
+			if err != nil {
+				return nil, fmt.Errorf("invalid repository name")
+			}
+		} else {
+			repo = ghrepo.NewWithHost(defaultOwner, repositoryName, host)
+		}
+		repos = append(repos, repo)
+	}
+	repositoryIDs, err := MapRepoToID(client, host, repos)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up IDs for repositories %v: %w", repositoryNames, err)
+	}
+	return repositoryIDs, nil
+}
+
+func GetRepoIds(client *api.Client, host, orgName string, repoNames []string) repoNamesResult {
+	repoNamesC := make(chan repoNamesResult, 1)
+	go func() {
+		if len(repoNames) == 0 {
+			repoNamesC <- repoNamesResult{}
+			return
+		}
+		repositoryIDs, err := MapRepoNamesToIDs(client, host, orgName, repoNames)
+		repoNamesC <- repoNamesResult{
+			Ids: repositoryIDs,
+			Err: err,
+		}
+	}()
+	return <-repoNamesC
+}
+
+func GetVariablesFromOptions(opts *PostPatchOptions, client *api.Client, host string, isUpdate bool) (map[string]VariablePayload, error) {
+	variables := make(map[string]VariablePayload)
+	if opts.CsvFile != "" {
+		var r io.Reader
+		if opts.CsvFile == "-" {
+			defer opts.IO.In.Close()
+			r = opts.IO.In
+		} else {
+			f, err := os.Open(opts.CsvFile)
+			if err != nil {
+				return nil, fmt.Errorf("failed to open env file: %w", err)
+			}
+			defer f.Close()
+			r = f
+		}
+		csvReader := csv.NewReader(r)
+		csvReader.Comment = '#'
+		csvReader.FieldsPerRecord = -1
+		records, err := csvReader.ReadAll()
+		if err != nil {
+			return nil, fmt.Errorf("error parsing csv file: %w", err)
+		}
+		if len(records) == 0 {
+			return nil, fmt.Errorf("no variables found in file")
+		}
+		for _, row := range records {
+			variable, err := getVarFromRow(opts, client, host, row, isUpdate)
+			if err != nil {
+				return nil, err
+			}
+			variables[row[0]] = variable
+		}
+		return variables, nil
+	}
+
+	values, err := getBody(opts, client, host, isUpdate)
+	if err != nil {
+		return nil, fmt.Errorf("did not understand variable body: %w", err)
+	}
+	variables[opts.VariableName] = values
+	return variables, nil
+}
+
+func getVarFromRow(opts *PostPatchOptions, client *api.Client, host string, row []string, isUpdate bool) (VariablePayload, error) {
+	rowLength := len(row)
+	index := 1
+	if rowLength < 2 {
+		return VariablePayload{}, fmt.Errorf("less than 2 records in a row in file")
+	}
+	if rowLength > 3 && opts.OrgName == "" {
+		return VariablePayload{}, fmt.Errorf("more than 3 vals in a row in file for non org variable %s", row[0])
+	}
+
+	var variable VariablePayload
+	variable.Value = row[index]
+	index++
+	if isUpdate {
+		if rowLength >= 3 && len(row[index]) > 0 {
+			variable.Name = row[index]
+		} else {
+			variable.Name = row[0]
+		}
+		index++
+	} else {
+		variable.Name = row[0]
+	}
+	if opts.OrgName != "" {
+		if !isUpdate && rowLength >= 3 {
+			variable.Visibility = row[index]
+		} else if rowLength >= 4 {
+			variable.Visibility = row[index]
+		}
+		index++
+		if variable.Visibility == Selected {
+			if rowLength < 5 {
+				// do not exit here as repositoryNames in opts may have the info.
+				log.Printf("selected visibility with no repos mentioned for variable %s", row[0])
+			}
+			repoIdRes := GetRepoIds(client, host, opts.OrgName, row[index:])
+			if repoIdRes.Err != nil {
+				return VariablePayload{}, repoIdRes.Err
+			}
+			variable.Repositories = repoIdRes.Ids
+		}
+	}
+	return variable, nil
+}
+
+func getBody(opts *PostPatchOptions, client *api.Client, host string, isUpdate bool) (VariablePayload, error) {
+	if opts.Body != "" {
+		return getVarFromRow(opts, client, host, strings.Split(opts.VariableName+","+string(opts.Body), ","), isUpdate)
+	}
+
+	values := make([]string, 0)
+	if opts.IO.CanPrompt() {
+		var currentVar Variable
+		if isUpdate {
+			currentVariablePtr, err := GetVariablesForList(&ListOptions{HttpClient: opts.HttpClient,
+				IO:          opts.IO,
+				Config:      opts.Config,
+				BaseRepo:    opts.BaseRepo,
+				OrgName:     opts.OrgName,
+				EnvName:     opts.EnvName,
+				Application: opts.Application,
+				Page:        0,
+				PerPage:     0,
+				Name:        opts.VariableName,
+			}, true)
+			if err == nil && len(currentVariablePtr) > 0 {
+				currentVar = *currentVariablePtr[0]
+			}
+		}
+		values = append(values, opts.VariableName)
+		data, err := opts.Prompter.Input("Value", currentVar.Value)
+		if err != nil {
+			return VariablePayload{}, err
+		}
+		values = append(values, data)
+		if isUpdate {
+			data, err = opts.Prompter.Input("New name", currentVar.Name)
+			if err != nil {
+				return VariablePayload{}, err
+			}
+			values = append(values, data)
+		}
+
+		if opts.OrgName != "" {
+			data, err = opts.Prompter.Input("Visibility", string(currentVar.Visibility))
+			if err != nil {
+				return VariablePayload{}, err
+			}
+			values = append(values, data)
+
+			if data == Selected {
+				data, err = opts.Prompter.Input("Repos(comma separated)", getCurrentSelectedRepos(client.HTTP(), currentVar.SelectedReposURL))
+				if err != nil {
+					return VariablePayload{}, err
+				}
+				values = append(values, strings.Split(data, ",")...)
+			}
+		}
+
+		fmt.Fprintln(opts.IO.Out)
+		return getVarFromRow(opts, client, host, values, isUpdate)
+	}
+
+	body, err := io.ReadAll(opts.IO.In)
+	if err != nil {
+		return VariablePayload{}, fmt.Errorf("failed to read from standard input: %w", err)
+	}
+
+	return getVarFromRow(opts, client, host, strings.Split(opts.VariableName+","+string(bytes.TrimRight(body, "\r\n")), ","), isUpdate)
+}
+
+func GetVariablesForList(opts *ListOptions, getSelectedRepoInfo bool) ([]*Variable, error) {
+	client, err := opts.HttpClient()
+	if err != nil {
+		return nil, fmt.Errorf("could not create http client: %w", err)
+	}
+
+	orgName := opts.OrgName
+	envName := opts.EnvName
+
+	var baseRepo ghrepo.Interface
+	if orgName == "" {
+		baseRepo, err = opts.BaseRepo()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	variableEntity, err := GetVariableEntity(orgName, envName)
+	if err != nil {
+		return nil, err
+	}
+
+	variableApp, err := GetVariableApp(opts.Application, variableEntity)
+	if err != nil || variableApp == Unknown {
+		return nil, err
+	}
+
+	if !IsSupportedVariableEntity(variableApp, variableEntity) {
+		return nil, fmt.Errorf("%s variables are not supported for %s", variableEntity, variableApp)
+	}
+
+	var variables []*Variable
+
+	switch variableEntity {
+	case Repository:
+		variables, err = getRepoVariables(client, baseRepo, variableApp, opts.Page, opts.PerPage, opts.Name)
+	case Environment:
+		variables, err = getEnvVariables(client, baseRepo, envName, opts.Page, opts.PerPage, opts.Name)
+	case Organization:
+		var cfg config.Config
+		var host string
+
+		cfg, err = opts.Config()
+		if err != nil {
+			return nil, err
+		}
+
+		host, _ = cfg.DefaultHost()
+		variables, err = getOrgVariables(client, host, orgName, getSelectedRepoInfo, variableApp, opts.Page, opts.PerPage, opts.Name)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get variables: %w", err)
+	}
+	return variables, nil
+}
+
+func getOrgVariables(client httpClient, host, orgName string, getSelectedRepoInfo bool, app App, page, perPage int, name string) ([]*Variable, error) {
+	variables, err := getVariables(client, host, fmt.Sprintf(`orgs/%s/%s/variables`, orgName, app), page, perPage, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if getSelectedRepoInfo {
+		err = getSelectedRepositoryInformation(client, variables)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return variables, nil
+}
+
+func getEnvVariables(client httpClient, repo ghrepo.Interface, envName string, page, perPage int, name string) ([]*Variable, error) {
+	path := fmt.Sprintf(`repos/%s/environments/%s/variables`, ghrepo.FullName(repo), envName)
+	return getVariables(client, repo.RepoHost(), path, page, perPage, name)
+}
+
+func getRepoVariables(client httpClient, repo ghrepo.Interface, app App, page, perPage int, name string) ([]*Variable, error) {
+	return getVariables(client, repo.RepoHost(), fmt.Sprintf(`repos/%s/%s/variables`,
+		ghrepo.FullName(repo), app), page, perPage, name)
+}
+
+func getVariables(client httpClient, host, path string, page, perPage int, name string) ([]*Variable, error) {
+	var url string
+	if name != "" {
+		url = fmt.Sprintf("%s%s/%s", ghinstance.RESTPrefix(host), path, name)
+		var payload Variable
+		err := apiGet(client, url, &payload)
+		if err != nil {
+			return nil, err
+		}
+		return []*Variable{&payload}, nil
+	} else {
+		url = fmt.Sprintf("%s%s?page=%d&per_page=%d", ghinstance.RESTPrefix(host), path, page, perPage)
+		var payload VariablesPayload
+		err := apiGet(client, url, &payload)
+		if err != nil {
+			return nil, err
+		}
+		return payload.Variables, nil
+	}
+}
+
+func apiGet(client httpClient, url string, data interface{}) error {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 299 {
+		return api.HandleHTTPError(resp)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getSelectedRepositoryInformation(client httpClient, variables []*Variable) error {
+	type responseData struct {
+		TotalCount int `json:"total_count"`
+	}
+
+	for _, variable := range variables {
+		if variable.SelectedReposURL == "" {
+			continue
+		}
+		var result responseData
+		if err := apiGet(client, variable.SelectedReposURL, &result); err != nil {
+			return fmt.Errorf("failed determining selected repositories for %s: %w", variable.Name, err)
+		}
+		variable.NumSelectedRepos = result.TotalCount
+	}
+
+	return nil
+}

--- a/pkg/cmd/variable/shared/shared_test.go
+++ b/pkg/cmd/variable/shared/shared_test.go
@@ -93,64 +93,6 @@ func TestGetVariableEntity(t *testing.T) {
 	}
 }
 
-func TestGetVariableApp(t *testing.T) {
-	tests := []struct {
-		name    string
-		app     string
-		entity  VariableEntity
-		want    App
-		wantErr bool
-	}{
-		{
-			name: "Actions",
-			app:  "actions",
-			want: Actions,
-		},
-		{
-			name:   "Defaults to error for repository",
-			app:    "",
-			entity: Repository,
-			wantErr: true,
-		},
-		{
-			name:   "Defaults to error for organization",
-			app:    "",
-			entity: Organization,
-			wantErr: true,
-		},
-		{
-			name:   "Defaults to error for environment",
-			app:    "",
-			entity: Environment,
-			wantErr: true,
-		},
-		{
-			name:    "Unknown for invalid apps",
-			app:     "invalid",
-			want:    Unknown,
-			wantErr: true,
-		},
-		{
-			name: "case insensitive",
-			app:  "ACTIONS",
-			want: Actions,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			app, err := GetVariableApp(tt.app, tt.entity)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			} else {
-				assert.NoError(t, err)
-			}
-			assert.Equal(t, tt.want, app)
-		})
-	}
-}
-
 func TestIsSupportedVariableEntity(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/pkg/cmd/variable/shared/shared_test.go
+++ b/pkg/cmd/variable/shared/shared_test.go
@@ -1,0 +1,371 @@
+package shared
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getBodyPrompt(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	ios.SetStdinTTY(true)
+	ios.SetStdoutTTY(true)
+
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	opts := &PostPatchOptions{
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		Config: func() (config.Config, error) {
+			return config.NewBlankConfig(), nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.FromFullName("owner/repo")
+		},
+		IO:             ios,
+		Body:           "a variable",
+		RandomOverride: fakeRandom,
+	}
+	httpClient, _ := opts.HttpClient()
+	apiClient := api.NewClientFromHTTP(httpClient)
+
+	body, err := getBody(opts, apiClient, "owner/repo", false)
+	assert.NoError(t, err)
+	assert.Equal(t, body.Value, "a variable")
+}
+
+func TestGetVariableEntity(t *testing.T) {
+	tests := []struct {
+		name    string
+		orgName string
+		envName string
+		want    VariableEntity
+		wantErr bool
+	}{
+		{
+			name:    "org",
+			orgName: "myOrg",
+			want:    Organization,
+		},
+		{
+			name:    "env",
+			envName: "myEnv",
+			want:    Environment,
+		},
+		{
+			name: "defaults to repo",
+			want: Repository,
+		},
+		{
+			name:    "Errors if both org and env are set",
+			orgName: "myOrg",
+			envName: "myEnv",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entity, err := GetVariableEntity(tt.orgName, tt.envName)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, entity)
+			}
+		})
+	}
+}
+
+func TestGetVariableApp(t *testing.T) {
+	tests := []struct {
+		name    string
+		app     string
+		entity  VariableEntity
+		want    App
+		wantErr bool
+	}{
+		{
+			name: "Actions",
+			app:  "actions",
+			want: Actions,
+		},
+		{
+			name:   "Defaults to error for repository",
+			app:    "",
+			entity: Repository,
+			wantErr: true,
+		},
+		{
+			name:   "Defaults to error for organization",
+			app:    "",
+			entity: Organization,
+			wantErr: true,
+		},
+		{
+			name:   "Defaults to error for environment",
+			app:    "",
+			entity: Environment,
+			wantErr: true,
+		},
+		{
+			name:    "Unknown for invalid apps",
+			app:     "invalid",
+			want:    Unknown,
+			wantErr: true,
+		},
+		{
+			name: "case insensitive",
+			app:  "ACTIONS",
+			want: Actions,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app, err := GetVariableApp(tt.app, tt.entity)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, app)
+		})
+	}
+}
+
+func TestIsSupportedVariableEntity(t *testing.T) {
+	tests := []struct {
+		name                string
+		app                 App
+		supportedEntities   []VariableEntity
+		unsupportedEntities []VariableEntity
+	}{
+		{
+			name: "Actions",
+			app:  Actions,
+			supportedEntities: []VariableEntity{
+				Repository,
+				Organization,
+				Environment,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, entity := range tt.supportedEntities {
+				assert.True(t, IsSupportedVariableEntity(tt.app, entity))
+			}
+
+			for _, entity := range tt.unsupportedEntities {
+				assert.False(t, IsSupportedVariableEntity(tt.app, entity))
+			}
+		})
+	}
+}
+
+func Test_getBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		bodyArg string
+		want    string
+		stdin   string
+	}{
+		{
+			name:    "literal value",
+			bodyArg: "a variable",
+			want:    "a variable",
+		},
+		{
+			name:  "from stdin",
+			want:  "a variable",
+			stdin: "a variable",
+		},
+		{
+			name:  "from stdin with trailing newline character",
+			want:  "a variable",
+			stdin: "a variable\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, stdin, _, _ := iostreams.Test()
+
+			ios.SetStdinTTY(false)
+
+			_, err := stdin.WriteString(tt.stdin)
+			assert.NoError(t, err)
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			opts := &PostPatchOptions{
+				HttpClient: func() (*http.Client, error) {
+					return &http.Client{Transport: reg}, nil
+				},
+				Config: func() (config.Config, error) {
+					return config.NewBlankConfig(), nil
+				},
+				BaseRepo: func() (ghrepo.Interface, error) {
+					return ghrepo.FromFullName("owner/repo")
+				},
+				IO:             ios,
+				VariableName:   "VARNAME",
+				Body:           "a variable",
+				RandomOverride: fakeRandom,
+			}
+			httpClient, _ := opts.HttpClient()
+			apiClient := api.NewClientFromHTTP(httpClient)
+
+			body, err := getBody(opts, apiClient, "owner/repo", false)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.want, body.Value)
+		})
+	}
+}
+
+func Test_getVariablesFromOptions(t *testing.T) {
+	genFile := func(s string) string {
+		f, err := os.CreateTemp("", "gh-env.*")
+		if err != nil {
+			t.Fatal(err)
+			return ""
+		}
+		defer f.Close()
+		t.Cleanup(func() {
+			_ = os.Remove(f.Name())
+		})
+		_, err = f.WriteString(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return f.Name()
+	}
+
+	tests := []struct {
+		name    string
+		opts    PostPatchOptions
+		isTTY   bool
+		stdin   string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "variable from arg",
+			opts: PostPatchOptions{
+				VariableName: "FOO",
+				Body:         "bar",
+				CsvFile:      "",
+			},
+			want: map[string]string{"FOO": "bar"},
+		},
+		{
+			name: "variables from stdin",
+			opts: PostPatchOptions{
+				Body:    "",
+				CsvFile: "-",
+			},
+			stdin: `FOO,bar`,
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name: "variables from file",
+			opts: PostPatchOptions{
+				Body: "",
+				CsvFile: genFile(heredoc.Doc(`
+					FOO,bar
+					QUOTED,my value
+					#IGNORED, true
+				`)),
+			},
+			stdin: `FOO=bar`,
+			want: map[string]string{
+				"FOO":    "bar",
+				"QUOTED": "my value",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, stdin, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStdoutTTY(tt.isTTY)
+			stdin.WriteString(tt.stdin)
+			opts := tt.opts
+			opts.IO = ios
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			apiClient := api.NewClientFromHTTP(&http.Client{Transport: reg})
+
+			gotVariables, err := GetVariablesFromOptions(&opts, apiClient, "owner/repo", false)
+			if err != nil {
+				if !tt.wantErr {
+					t.Fatalf("getVariablesFromOptions() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			} else if tt.wantErr {
+				t.Fatalf("getVariablesFromOptions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if len(gotVariables) != len(tt.want) {
+				t.Fatalf("getVariablesFromOptions() = got %d variables, want %d", len(gotVariables), len(tt.want))
+			}
+			for k, v := range gotVariables {
+				if tt.want[k] != v.Value {
+					t.Errorf("getVariablesFromOptions() %s = got %q, want %q", k, v.Value, tt.want[k])
+				}
+			}
+		})
+	}
+}
+
+type testClient func(*http.Request) (*http.Response, error)
+
+func (c testClient) Do(req *http.Request) (*http.Response, error) {
+	return c(req)
+}
+
+func Test_getVariables_pagination(t *testing.T) {
+	var requests []*http.Request
+	var client testClient = func(req *http.Request) (*http.Response, error) {
+		header := make(map[string][]string)
+		if len(requests) == 0 {
+			header["Link"] = []string{}
+		}
+		requests = append(requests, req)
+		return &http.Response{
+			Request: req,
+			Body:    io.NopCloser(strings.NewReader(`{"variables":[{},{}]}`)),
+			Header:  header,
+		}, nil
+	}
+	page, perPage := 2, 25
+	variables, err := getVariables(client, "github.com", "path/to", page, perPage, "")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(requests))
+	assert.Equal(t, 2, len(variables))
+	assert.Equal(t, fmt.Sprintf("https://api.github.com/path/to?page=%d&per_page=%d", page, perPage), requests[0].URL.String())
+}
+
+func fakeRandom() io.Reader {
+	return bytes.NewReader(bytes.Repeat([]byte{5}, 32))
+}
+

--- a/pkg/cmd/variable/update/http.go
+++ b/pkg/cmd/variable/update/http.go
@@ -1,0 +1,51 @@
+package update
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+)
+
+func patchVariable(client *api.Client, host, path string, payload interface{}) error {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to serialize: %w", err)
+	}
+	requestBody := bytes.NewReader(payloadBytes)
+
+	return client.REST(host, "PATCH", path, requestBody, nil)
+}
+
+func patchOrgVariable(client *api.Client, host string, orgName, visibility, variableName, updatedVariableName, value string, repositoryIDs []int64, app shared.App) error {
+	payload := shared.VariablePayload{
+		Name:         updatedVariableName,
+		Value:        value,
+		Repositories: repositoryIDs,
+		Visibility:   visibility,
+	}
+	path := fmt.Sprintf(`orgs/%s/%s/variables/%s`, orgName, app, variableName)
+
+	return patchVariable(client, host, path, payload)
+}
+
+func patchEnvVariable(client *api.Client, repo ghrepo.Interface, envName string, variableName, updatedVariableName, value string) error {
+	payload := shared.VariablePayload{
+		Name:  updatedVariableName,
+		Value: value,
+	}
+	path := fmt.Sprintf(`repos/%s/environments/%s/variables/%s`, ghrepo.FullName(repo), envName, variableName)
+	return patchVariable(client, repo.RepoHost(), path, payload)
+}
+
+func patchRepoVariable(client *api.Client, repo ghrepo.Interface, variableName, updatedVariableName, value string, app shared.App) error {
+	payload := shared.VariablePayload{
+		Name:  updatedVariableName,
+		Value: value,
+	}
+	path := fmt.Sprintf(`repos/%s/%s/variables/%s`, ghrepo.FullName(repo), app, variableName)
+	return patchVariable(client, repo.RepoHost(), path, payload)
+}

--- a/pkg/cmd/variable/update/update.go
+++ b/pkg/cmd/variable/update/update.go
@@ -31,8 +31,6 @@ func NewCmdUpdate(f *cmdutil.Factory, runF func(*shared.PostPatchOptions) error)
 
 			Organization variables can optionally be restricted to only be available to
 			specific repositories.
-
-			Variable values are locally value before being sent to GitHub.
 		`),
 		Example: heredoc.Doc(`
 			# Add variable value for the current repository in an interactive prompt
@@ -110,7 +108,6 @@ func NewCmdUpdate(f *cmdutil.Factory, runF func(*shared.PostPatchOptions) error)
 	cmd.Flags().StringSliceVarP(&opts.RepositoryNames, "repos", "r", []string{}, "List of `repositories` that can access an organization variable")
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "The value for the variable (reads from standard input if not specified)")
 	cmd.Flags().StringVarP(&opts.CsvFile, "csv-file", "f", "", "Update names and values from a csv-formatted `file`")
-	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", shared.Actions, []string{shared.Actions}, "Update the application for a variable")
 
 	return cmd
 }
@@ -151,7 +148,7 @@ func updateRun(opts *shared.PostPatchOptions) error {
 		return err
 	}
 
-	variableApp, err := shared.GetVariableApp(opts.Application, variableEntity)
+	variableApp := shared.App(shared.Actions)
 	if err != nil || variableApp == shared.Unknown {
 		return err
 	}

--- a/pkg/cmd/variable/update/update.go
+++ b/pkg/cmd/variable/update/update.go
@@ -1,0 +1,234 @@
+package update
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdUpdate(f *cmdutil.Factory, runF func(*shared.PostPatchOptions) error) *cobra.Command {
+	opts := &shared.PostPatchOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		HttpClient: f.HttpClient,
+		Prompter:   f.Prompter,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update <variable-name>",
+		Short: "Update variables",
+		Long: heredoc.Doc(`
+			Update a value for a variable on one of the following levels:
+			- repository (default): available to Actions runs in a repository
+			- environment: available to Actions runs for a deployment environment in a repository
+			- organization: available to Actions runs within an organization
+
+			Organization variables can optionally be restricted to only be available to
+			specific repositories.
+
+			Variable values are locally value before being sent to GitHub.
+		`),
+		Example: heredoc.Doc(`
+			# Add variable value for the current repository in an interactive prompt
+			$ gh variable update MYVARIABLE
+
+			# Read variable value from an environment variable
+			$ gh variable update MYVARIABLE --body "$ENV_VALUE"
+
+			# Read variable value from a file
+			$ gh variable update MYVARIABLE < myfile.txt
+
+			# Update variable for a deployment environment in the current repository
+			$ gh variable update MYVARIABLE --env myenvironment
+
+			# Update organization-level variable visible to both public and private repositories
+			$ gh variable update MYVARIABLE --org myOrg --visibility all
+
+			# Update organization-level variable visible to specific repositories
+			$ gh variable update MYVARIABLE --org myOrg --repos repo1,repo2,repo3
+
+			# Update multiple variables from the csv in the prescribed format
+			$ gh variable update -f file.csv
+
+		`),
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			if err := cmdutil.MutuallyExclusive("specify only one of `--org` or `--env`", opts.OrgName != "", opts.EnvName != ""); err != nil {
+				return err
+			}
+
+			if err := cmdutil.MutuallyExclusive("specify only one of `--body` or `--csv-file`", opts.Body != "", opts.CsvFile != ""); err != nil {
+				return err
+			}
+
+			if len(args) == 0 {
+				if opts.CsvFile == "" {
+					return cmdutil.FlagErrorf("must pass name argument")
+				}
+			} else {
+				opts.VariableName = args[0]
+			}
+
+			if cmd.Flags().Changed("visibility") {
+				if opts.OrgName == "" {
+					return cmdutil.FlagErrorf("`--visibility` is only supported with `--org`")
+				}
+
+				if opts.Visibility != shared.Selected && len(opts.RepositoryNames) > 0 {
+					return cmdutil.FlagErrorf("`--repos` is only supported with `--visibility=selected`")
+				}
+
+				if opts.Visibility == shared.Selected && len(opts.RepositoryNames) == 0 {
+					return cmdutil.FlagErrorf("`--repos` list required with `--visibility=selected`")
+				}
+			} else {
+				if len(opts.RepositoryNames) > 0 {
+					opts.Visibility = shared.Selected
+				}
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return updateRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "Update `organization` variable")
+	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Update deployment `environment` variable")
+	cmdutil.StringEnumFlag(cmd, &opts.Visibility, "visibility", "v", shared.Private, []string{shared.All, shared.Private, shared.Selected}, "Update visibility for an organization variable")
+	cmd.Flags().StringSliceVarP(&opts.RepositoryNames, "repos", "r", []string{}, "List of `repositories` that can access an organization variable")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "The value for the variable (reads from standard input if not specified)")
+	cmd.Flags().StringVarP(&opts.CsvFile, "csv-file", "f", "", "Update names and values from a csv-formatted `file`")
+	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", shared.Actions, []string{shared.Actions}, "Update the application for a variable")
+
+	return cmd
+}
+
+func updateRun(opts *shared.PostPatchOptions) error {
+	c, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not update http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(c)
+
+	orgName := opts.OrgName
+	envName := opts.EnvName
+
+	var host string
+	var baseRepo ghrepo.Interface
+	if orgName == "" {
+		baseRepo, err = opts.BaseRepo()
+		if err != nil {
+			return err
+		}
+		host = baseRepo.RepoHost()
+	} else {
+		cfg, err := opts.Config()
+		if err != nil {
+			return err
+		}
+		host, _ = cfg.DefaultHost()
+	}
+
+	variables, err := shared.GetVariablesFromOptions(opts, client, host, true)
+	if err != nil {
+		return err
+	}
+
+	variableEntity, err := shared.GetVariableEntity(orgName, envName)
+	if err != nil {
+		return err
+	}
+
+	variableApp, err := shared.GetVariableApp(opts.Application, variableEntity)
+	if err != nil || variableApp == shared.Unknown {
+		return err
+	}
+
+	if !shared.IsSupportedVariableEntity(variableApp, variableEntity) {
+		return fmt.Errorf("%s variables are not supported for %s", variableEntity, variableApp)
+	}
+
+	repoIdRes := shared.GetRepoIds(client, host, opts.OrgName, opts.RepositoryNames)
+	if repoIdRes.Err != nil {
+		return repoIdRes.Err
+	}
+
+	updatec := make(chan updateResult)
+	for variableKey, variable := range variables {
+
+		go func(variableKey string, variable shared.VariablePayload) {
+			var repoIds []int64
+			var visibility string
+			visibility = opts.Visibility
+			//cmd line opt overrides file
+			if len(repoIdRes.Ids) > 0 {
+				repoIds = repoIdRes.Ids
+			} else if variable.Visibility != "" {
+				visibility = variable.Visibility
+				repoIds = variable.Repositories
+			}
+			updatec <- updateVariable(opts, host, client, baseRepo, variableKey, variable.Name, variable.Value, visibility, repoIds, variableApp, variableEntity)
+		}(variableKey, variable)
+	}
+
+	err = nil
+	cs := opts.IO.ColorScheme()
+	for i := 0; i < len(variables); i++ {
+		result := <-updatec
+		if result.err != nil {
+			err = multierror.Append(err, result.err)
+			continue
+		}
+		if result.value != "" {
+			fmt.Fprintln(opts.IO.Out, result.value)
+			continue
+		}
+		if !opts.IO.IsStdoutTTY() {
+			continue
+		}
+		target := orgName
+		if orgName == "" {
+			target = ghrepo.FullName(baseRepo)
+		}
+		fmt.Fprintf(opts.IO.Out, "%s Update %s variable %s for %s\n", cs.SuccessIcon(), variableApp.Title(), result.key, target)
+	}
+	return err
+}
+
+type updateResult struct {
+	key   string
+	value string
+	err   error
+}
+
+func updateVariable(opts *shared.PostPatchOptions, host string, client *api.Client, baseRepo ghrepo.Interface, variableKey, updatedVariableKey, variableValue, visibility string, repositoryIDs []int64, app shared.App, entity shared.VariableEntity) (res updateResult) {
+	orgName := opts.OrgName
+	envName := opts.EnvName
+	res.key = updatedVariableKey
+	var err error
+	switch entity {
+	case shared.Organization:
+		err = patchOrgVariable(client, host, orgName, visibility, variableKey, updatedVariableKey, variableValue, repositoryIDs, app)
+	case shared.Environment:
+		err = patchEnvVariable(client, baseRepo, envName, variableKey, updatedVariableKey, variableValue)
+	default:
+		err = patchRepoVariable(client, baseRepo, variableKey, updatedVariableKey, variableValue, app)
+	}
+	if err != nil {
+		res.err = fmt.Errorf("failed to update variable %q: %w", variableKey, err)
+		return
+	}
+	return
+}

--- a/pkg/cmd/variable/update/update_test.go
+++ b/pkg/cmd/variable/update/update_test.go
@@ -1,0 +1,358 @@
+package update
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdUpdate(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    shared.PostPatchOptions
+		stdinTTY bool
+		wantsErr bool
+	}{
+		{
+			name:     "invalid visibility",
+			cli:      "cool_variable --org coolOrg -v'mistyVeil'",
+			wantsErr: true,
+		},
+		{
+			name:     "invalid visibility",
+			cli:      "cool_variable --org coolOrg -v'selected'",
+			wantsErr: true,
+		},
+		{
+			name:     "repos with wrong vis",
+			cli:      "cool_variable --org coolOrg -v'private' -rcoolRepo",
+			wantsErr: true,
+		},
+		{
+			name:     "no name",
+			cli:      "",
+			wantsErr: true,
+		},
+		{
+			name:     "multiple names",
+			cli:      "cool_variable good_variable",
+			wantsErr: true,
+		},
+		{
+			name:     "visibility without org",
+			cli:      "cool_variable -vall",
+			wantsErr: true,
+		},
+		{
+			name: "repos without vis",
+			cli:  "cool_variable -bs --org coolOrg -rcoolRepo",
+			wants: shared.PostPatchOptions{
+				VariableName:    "cool_variable",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"coolRepo"},
+				Body:            "s",
+				OrgName:         "coolOrg",
+			},
+		},
+		{
+			name: "org with selected repo",
+			cli:  "-ocoolOrg -bs -vselected -rcoolRepo cool_variable",
+			wants: shared.PostPatchOptions{
+				VariableName:    "cool_variable",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"coolRepo"},
+				Body:            "s",
+				OrgName:         "coolOrg",
+			},
+		},
+		{
+			name: "org with selected repos",
+			cli:  `--org=coolOrg -bs -vselected -r="coolRepo,radRepo,goodRepo" cool_variable`,
+			wants: shared.PostPatchOptions{
+				VariableName:    "cool_variable",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"coolRepo", "goodRepo", "radRepo"},
+				Body:            "s",
+				OrgName:         "coolOrg",
+			},
+		},
+		{
+			name: "repo",
+			cli:  `cool_variable -b"a variable"`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.Private,
+				Body:         "a variable",
+				OrgName:      "",
+			},
+		},
+		{
+			name: "env",
+			cli:  `cool_variable -b"a variable" -eRelease`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.Private,
+				Body:         "a variable",
+				OrgName:      "",
+				EnvName:      "Release",
+			},
+		},
+		{
+			name: "vis all",
+			cli:  `cool_variable --org coolOrg -b"cool" -vall`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.All,
+				Body:         "cool",
+				OrgName:      "coolOrg",
+			},
+		},
+		{
+			name: "no store",
+			cli:  `cool_variable`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.Private,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			ios.SetStdinTTY(tt.stdinTTY)
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *shared.PostPatchOptions
+			cmd := NewCmdUpdate(f, func(opts *shared.PostPatchOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.VariableName, gotOpts.VariableName)
+			assert.Equal(t, tt.wants.Body, gotOpts.Body)
+			assert.Equal(t, tt.wants.Visibility, gotOpts.Visibility)
+			assert.Equal(t, tt.wants.OrgName, gotOpts.OrgName)
+			assert.Equal(t, tt.wants.EnvName, gotOpts.EnvName)
+			assert.ElementsMatch(t, tt.wants.RepositoryNames, gotOpts.RepositoryNames)
+		})
+	}
+}
+
+func Test_updateRun_repo(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *shared.PostPatchOptions
+		wantApp string
+		wantErr bool
+	}{
+		{
+			name: "Actions",
+			opts: &shared.PostPatchOptions{
+				Application: "actions",
+			},
+			wantApp: "actions",
+			wantErr: false,
+		},
+		{
+			name: "defaults to unknown",
+			opts: &shared.PostPatchOptions{
+				Application: "",
+			},
+			wantApp: "unknown",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+
+			reg.Register(httpmock.REST("PATCH", fmt.Sprintf("repos/owner/repo/%s/variables/cool_variable", tt.wantApp)),
+				httpmock.StatusStringResponse(201, `{}`))
+
+			ios, _, _, _ := iostreams.Test()
+
+			opts := &shared.PostPatchOptions{
+				HttpClient: func() (*http.Client, error) {
+					return &http.Client{Transport: reg}, nil
+				},
+				Config: func() (config.Config, error) { return config.NewBlankConfig(), nil },
+				BaseRepo: func() (ghrepo.Interface, error) {
+					return ghrepo.FromFullName("owner/repo")
+				},
+				IO:             ios,
+				VariableName:   "cool_variable",
+				Body:           "a variable",
+				RandomOverride: fakeRandom,
+				Application:    tt.opts.Application,
+			}
+
+			err := updateRun(opts)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			} else {
+				assert.NoError(t, err)
+			}
+
+			reg.Verify(t)
+
+			data, err := io.ReadAll(reg.Requests[0].Body)
+			assert.NoError(t, err)
+
+			var payload shared.VariablePayload
+			err = json.Unmarshal(data, &payload)
+			assert.NoError(t, err)
+			assert.Equal(t, payload.Value, "a variable")
+		})
+	}
+}
+
+func Test_updateRun_env(t *testing.T) {
+	reg := &httpmock.Registry{}
+
+	reg.Register(httpmock.REST("PATCH", "repos/owner/repo/environments/development/variables/cool_variable"), httpmock.StatusStringResponse(201, `{}`))
+
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &shared.PostPatchOptions{
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		Config: func() (config.Config, error) { return config.NewBlankConfig(), nil },
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.FromFullName("owner/repo")
+		},
+		EnvName:        "development",
+		IO:             ios,
+		VariableName:   "cool_variable",
+		Body:           "a variable",
+		RandomOverride: fakeRandom,
+		Application:    "actions",
+	}
+
+	err := updateRun(opts)
+	assert.NoError(t, err)
+
+	reg.Verify(t)
+
+	data, err := io.ReadAll(reg.Requests[0].Body)
+	assert.NoError(t, err)
+	var payload shared.VariablePayload
+	err = json.Unmarshal(data, &payload)
+	assert.NoError(t, err)
+	assert.Equal(t, payload.Value, "a variable")
+}
+
+func Test_updateRun_org(t *testing.T) {
+	tests := []struct {
+		name             string
+		opts             *shared.PostPatchOptions
+		wantVisibility   shared.Visibility
+		wantRepositories []int64
+		wantApp          string
+	}{
+		{
+			name: "all vis",
+			opts: &shared.PostPatchOptions{
+				OrgName:     "UmbrellaCorporation",
+				Visibility:  shared.All,
+				Application: "actions",
+			},
+			wantApp: "actions",
+		},
+		{
+			name: "selected visibility",
+			opts: &shared.PostPatchOptions{
+				OrgName:         "UmbrellaCorporation",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"birkin", "UmbrellaCorporation/wesker"},
+				Application:     "actions",
+			},
+			wantRepositories: []int64{1, 2},
+			wantApp:          "actions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+
+			orgName := tt.opts.OrgName
+
+			reg.Register(httpmock.REST("PATCH",
+				fmt.Sprintf("orgs/%s/%s/variables/cool_variable", orgName, tt.wantApp)),
+				httpmock.StatusStringResponse(201, `{}`))
+
+			if len(tt.opts.RepositoryNames) > 0 {
+				reg.Register(httpmock.GraphQL(`query MapRepositoryNames\b`),
+					httpmock.StringResponse(`{"data":{"repo_0001":{"databaseId":1},"repo_0002":{"databaseId":2}}}`))
+			}
+
+			ios, _, _, _ := iostreams.Test()
+
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("owner/repo")
+			}
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.Config = func() (config.Config, error) {
+				return config.NewBlankConfig(), nil
+			}
+			tt.opts.IO = ios
+			tt.opts.VariableName = "cool_variable"
+			tt.opts.Body = "a variable"
+			tt.opts.RandomOverride = fakeRandom
+
+			err := updateRun(tt.opts)
+			assert.NoError(t, err)
+
+			reg.Verify(t)
+
+			data, err := io.ReadAll(reg.Requests[len(reg.Requests)-1].Body)
+			assert.NoError(t, err)
+			var payload shared.VariablePayload
+			err = json.Unmarshal(data, &payload)
+			assert.NoError(t, err)
+			assert.Equal(t, payload.Value, "a variable")
+			assert.Equal(t, payload.Visibility, tt.opts.Visibility)
+			assert.ElementsMatch(t, payload.Repositories, tt.wantRepositories)
+		})
+	}
+}
+
+func fakeRandom() io.Reader {
+	return bytes.NewReader(bytes.Repeat([]byte{5}, 32))
+}

--- a/pkg/cmd/variable/update/update_test.go
+++ b/pkg/cmd/variable/update/update_test.go
@@ -179,18 +179,9 @@ func Test_updateRun_repo(t *testing.T) {
 		{
 			name: "Actions",
 			opts: &shared.PostPatchOptions{
-				Application: "actions",
 			},
 			wantApp: "actions",
 			wantErr: false,
-		},
-		{
-			name: "defaults to unknown",
-			opts: &shared.PostPatchOptions{
-				Application: "",
-			},
-			wantApp: "unknown",
-			wantErr: true,
 		},
 	}
 
@@ -215,7 +206,6 @@ func Test_updateRun_repo(t *testing.T) {
 				VariableName:   "cool_variable",
 				Body:           "a variable",
 				RandomOverride: fakeRandom,
-				Application:    tt.opts.Application,
 			}
 
 			err := updateRun(opts)
@@ -259,7 +249,6 @@ func Test_updateRun_env(t *testing.T) {
 		VariableName:   "cool_variable",
 		Body:           "a variable",
 		RandomOverride: fakeRandom,
-		Application:    "actions",
 	}
 
 	err := updateRun(opts)
@@ -288,7 +277,6 @@ func Test_updateRun_org(t *testing.T) {
 			opts: &shared.PostPatchOptions{
 				OrgName:     "UmbrellaCorporation",
 				Visibility:  shared.All,
-				Application: "actions",
 			},
 			wantApp: "actions",
 		},
@@ -298,7 +286,6 @@ func Test_updateRun_org(t *testing.T) {
 				OrgName:         "UmbrellaCorporation",
 				Visibility:      shared.Selected,
 				RepositoryNames: []string{"birkin", "UmbrellaCorporation/wesker"},
-				Application:     "actions",
 			},
 			wantRepositories: []int64{1, 2},
 			wantApp:          "actions",

--- a/pkg/cmd/variable/variable.go
+++ b/pkg/cmd/variable/variable.go
@@ -1,0 +1,32 @@
+package variable
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	cmdCreate "github.com/cli/cli/v2/pkg/cmd/variable/create"
+	cmdDelete "github.com/cli/cli/v2/pkg/cmd/variable/delete"
+	cmdList "github.com/cli/cli/v2/pkg/cmd/variable/list"
+	cmdUpdate "github.com/cli/cli/v2/pkg/cmd/variable/update"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdVariable(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "variable <command>",
+		Short: "Manage GitHub variables",
+		Long: heredoc.Doc(`
+			Variables can be set at the repository, or organization level for use in
+			GitHub Actions. Environment variables can be set for use in
+			GitHub Actions. Run "gh help variable create" to learn how to get started.
+`),
+	}
+
+	cmdutil.EnableRepoOverride(cmd, f)
+
+	cmd.AddCommand(cmdList.NewCmdList(f, nil))
+	cmd.AddCommand(cmdCreate.NewCmdCreate(f, nil))
+	cmd.AddCommand(cmdUpdate.NewCmdUpdate(f, nil))
+	cmd.AddCommand(cmdDelete.NewCmdDelete(f, nil))
+
+	return cmd
+}

--- a/pkg/cmd/variable/variable.go
+++ b/pkg/cmd/variable/variable.go
@@ -13,11 +13,10 @@ import (
 func NewCmdVariable(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "variable <command>",
-		Short: "Manage GitHub variables",
+		Short: "Manage GitHub Actions variables",
 		Long: heredoc.Doc(`
-			Variables can be set at the repository, or organization level for use in
-			GitHub Actions. Environment variables can be set for use in
-			GitHub Actions. Run "gh help variable create" to learn how to get started.
+		Variables can be set at the repository, environment or organization level for use in GitHub Actions.
+		Run "gh help variable create" to learn how to get started.
 `),
 	}
 


### PR DESCRIPTION
In continuation to https://github.com/cli/cli/pull/6876, this PR uses the common functionality and it supports `list`, `create`, `update` and `delete` functions for `org`, `repo` and `env` owner types. Input mechanisms include `csv`, `body` and `prompt`. 
csv format is supported only for create and update :
create:
> name, value, vis(org), repos(org::selected)

update:
> name, value(optional), updated_name(optional), vis(org,optional), repos(org::selected)

create:
<img width="787" alt="Screenshot 2023-01-23 at 11 59 00 AM" src="https://user-images.githubusercontent.com/49831737/213978626-30ed803a-318f-433f-a741-8cf000b16621.png">
<img width="950" alt="Screenshot 2023-01-23 at 11 59 06 AM" src="https://user-images.githubusercontent.com/49831737/213978620-6b46c0e7-cbbc-4fb7-b6ad-da1cfea51f36.png">

update:
<img width="784" alt="Screenshot 2023-01-23 at 12 01 15 PM" src="https://user-images.githubusercontent.com/49831737/213978648-ea4d2897-87ea-49a6-b3af-613aed952da3.png">
<img width="991" alt="Screenshot 2023-01-23 at 12 01 25 PM" src="https://user-images.githubusercontent.com/49831737/213978646-cb2ffc27-672b-495b-8c60-b9eea873ce34.png">

list:
<img width="938" alt="Screenshot 2023-01-23 at 12 02 36 PM" src="https://user-images.githubusercontent.com/49831737/213978693-3ce60ee7-d50d-4780-9244-d31039ade7f2.png">

delete:
<img width="801" alt="Screenshot 2023-01-23 at 12 03 04 PM" src="https://user-images.githubusercontent.com/49831737/213978734-44953aca-309d-4260-8043-8795c7d9ae59.png">
<img width="943" alt="Screenshot 2023-01-23 at 12 03 13 PM" src="https://user-images.githubusercontent.com/49831737/213978732-6d60937a-07e0-4d4e-aa15-8b0ef04ec544.png">
