### PR TITLE
Add `gh repo edit --enable-discussions`

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -45,6 +45,7 @@ type Repository struct {
 	IsSecurityPolicyEnabled bool
 	HasIssuesEnabled        bool
 	HasProjectsEnabled      bool
+	HasDiscussionsEnabled   bool
 	HasWikiEnabled          bool
 	MergeCommitAllowed      bool
 	SquashMergeAllowed      bool

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -348,6 +348,7 @@ var RepositoryFields = []string{
 	"hasIssuesEnabled",
 	"hasProjectsEnabled",
 	"hasWikiEnabled",
+	"hasDiscussionsEnabled",
 	"mergeCommitAllowed",
 	"squashMergeAllowed",
 	"rebaseMergeAllowed",

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -184,7 +184,8 @@ func editRun(ctx context.Context, opts *EditOptions) error {
 			"hasIssuesEnabled",
 			"hasProjectsEnabled",
 			"hasWikiEnabled",
-			"hasDiscussionsEnabled",
+			// TODO: GitHub Enterprise Server does not support has_discussions yet
+			// "hasDiscussionsEnabled",
 			"homepageUrl",
 			"isInOrganization",
 			"isTemplate",
@@ -279,7 +280,8 @@ func interactiveChoice(r *api.Repository) ([]string, error) {
 		optionIssues,
 		optionMergeOptions,
 		optionProjects,
-		optionDiscussions,
+		// TODO: GitHub Enterprise Server does not support has_discussions yet
+		// optionDiscussions,
 		optionTemplateRepo,
 		optionTopics,
 		optionVisibility,

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -36,6 +36,7 @@ const (
 	optionIssues            = "Issues"
 	optionMergeOptions      = "Merge Options"
 	optionProjects          = "Projects"
+	optionDiscussions       = "Discussions"
 	optionTemplateRepo      = "Template Repository"
 	optionTopics            = "Topics"
 	optionVisibility        = "Visibility"
@@ -66,6 +67,7 @@ type EditRepositoryInput struct {
 	EnableIssues        *bool   `json:"has_issues,omitempty"`
 	EnableMergeCommit   *bool   `json:"allow_merge_commit,omitempty"`
 	EnableProjects      *bool   `json:"has_projects,omitempty"`
+	EnableDiscussions   *bool   `json:"has_discussions,omitempty"`
 	EnableRebaseMerge   *bool   `json:"allow_rebase_merge,omitempty"`
 	EnableSquashMerge   *bool   `json:"allow_squash_merge,omitempty"`
 	EnableWiki          *bool   `json:"has_wiki,omitempty"`
@@ -146,6 +148,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(options *EditOptions) error) *cobr
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableIssues, "enable-issues", "", "Enable issues in the repository")
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableProjects, "enable-projects", "", "Enable projects in the repository")
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableWiki, "enable-wiki", "", "Enable wiki in the repository")
+	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableDiscussions, "enable-discussions", "", "Enable discussions in the repository")
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableMergeCommit, "enable-merge-commit", "", "Enable merging pull requests via merge commit")
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableSquashMerge, "enable-squash-merge", "", "Enable merging pull requests via squashed commit")
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableRebaseMerge, "enable-rebase-merge", "", "Enable merging pull requests via rebase")
@@ -181,6 +184,7 @@ func editRun(ctx context.Context, opts *EditOptions) error {
 			"hasIssuesEnabled",
 			"hasProjectsEnabled",
 			"hasWikiEnabled",
+			"hasDiscussionsEnabled",
 			"homepageUrl",
 			"isInOrganization",
 			"isTemplate",
@@ -275,6 +279,7 @@ func interactiveChoice(r *api.Repository) ([]string, error) {
 		optionIssues,
 		optionMergeOptions,
 		optionProjects,
+		optionDiscussions,
 		optionTemplateRepo,
 		optionTopics,
 		optionVisibility,
@@ -382,6 +387,16 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 				Message: "Enable Projects?",
 				Default: r.HasProjectsEnabled,
 			}, opts.Edits.EnableProjects)
+			if err != nil {
+				return err
+			}
+		case optionDiscussions:
+			opts.Edits.EnableDiscussions = &r.HasDiscussionsEnabled
+			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
+			err = prompt.SurveyAskOne(&survey.Confirm{
+				Message: "Enable Discussions?",
+				Default: r.HasDiscussionsEnabled,
+			}, opts.Edits.EnableDiscussions)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR add `--enable-discussions` flag to `gh repo edit` command.

## Test plan

```bash
$ make 
$ ./bin/gh repo edit --help
Edit repository settings.

To toggle a setting off, use the `--flag=false` syntax.


USAGE
  gh repo edit [<repository>] [flags]

FLAGS
      --add-topic strings        Add repository topic
      --allow-forking            Allow forking of an organization repository
      --allow-update-branch      Allow a pull request head branch that is behind its base branch to be updated
      --default-branch name      Set the default branch name for the repository
      --delete-branch-on-merge   Delete head branch when pull requests are merged
  -d, --description string       Description of the repository
      --enable-auto-merge        Enable auto-merge functionality
      --enable-discussions       Enable discussions in the repository
      --enable-issues            Enable issues in the repository
      --enable-merge-commit      Enable merging pull requests via merge commit
      --enable-projects          Enable projects in the repository
      --enable-rebase-merge      Enable merging pull requests via rebase
      --enable-squash-merge      Enable merging pull requests via squashed commit
      --enable-wiki              Enable wiki in the repository
  -h, --homepage URL             Repository home page URL
      --remove-topic strings     Remove repository topic
      --template                 Make the repository available as a template repository
      --visibility string        Change the visibility of the repository to {public,private,internal}

INHERITED FLAGS
  --help   Show help for command

ARGUMENTS
  A repository can be supplied as an argument in any of the following formats:
  - "OWNER/REPO"
  - by URL, e.g. "https://github.com/OWNER/REPO"

EXAMPLES
  # enable issues and wiki
  gh repo edit --enable-issues --enable-wiki

  # disable projects
  gh repo edit --enable-projects=false

LEARN MORE
  Use 'gh <command> <subcommand> --help' for more information about a command.
  Read the manual at https://cli.github.com/manual

# test some repositories
$ ./bin/gh repo edit azu/github-advisory-database-rss --enable-discussions
✓ Edited repository azu/github-advisory-database-rss
$ ./bin/gh repo edit azu/hubmemo --enable-discussions --enable-auto-merge --delete-branch-on-merge
✓ Edited repository azu/hubmemo
```


fix #6896 