### PR TITLE
repo delete: change confirmation flag to `--yes`

### DIFF
--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -60,7 +60,7 @@ To authorize, run "gh auth refresh -s delete_repo"`,
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "confirm deletion without prompting")
-    cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "confirm deletion without prompting")
+	cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "confirm deletion without prompting")
 	return cmd
 }
 

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -62,7 +62,7 @@ To authorize, run "gh auth refresh -s delete_repo"`,
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "confirm deletion without prompting")
-	cmd.Flags().MarkDeprecated("confirm", "confirm deletion without prompting")
+	_ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
 	cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "confirm deletion without prompting")
 	return cmd
 }

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -50,7 +50,7 @@ To authorize, run "gh auth refresh -s delete_repo"`,
 			}
 
 			if !opts.IO.CanPrompt() && !opts.Confirmed {
-				return cmdutil.FlagErrorf("--yes or --confirm required when not running interactively")
+				return cmdutil.FlagErrorf("--yes required when not running interactively")
 			}
 
 			if runF != nil {
@@ -61,7 +61,8 @@ To authorize, run "gh auth refresh -s delete_repo"`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "[deprecated] confirm deletion without prompting")
+	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "confirm deletion without prompting")
+    cmd.Flags().MarkDeprecated("confirm", "confirm deletion without prompting")
 	cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "confirm deletion without prompting")
 	return cmd
 }

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -48,13 +48,15 @@ To authorize, run "gh auth refresh -s delete_repo"`,
 			if len(args) > 0 {
 				opts.RepoArg = args[0]
 			}
+
 			if !opts.IO.CanPrompt() && !opts.Confirmed {
-				return cmdutil.FlagErrorf("--confirm required when not running interactively")
+				return cmdutil.FlagErrorf("--yes or --confirm required when not running interactively, --confirm will be deprecated in the future")
 			}
 
 			if runF != nil {
 				return runF(opts)
 			}
+
 			return deleteRun(opts)
 		},
 	}

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -50,7 +50,7 @@ To authorize, run "gh auth refresh -s delete_repo"`,
 			}
 
 			if !opts.IO.CanPrompt() && !opts.Confirmed {
-				return cmdutil.FlagErrorf("--yes or --confirm required when not running interactively, --confirm will be deprecated in the future")
+				return cmdutil.FlagErrorf("--yes or --confirm required when not running interactively")
 			}
 
 			if runF != nil {
@@ -61,7 +61,7 @@ To authorize, run "gh auth refresh -s delete_repo"`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "confirm deletion without prompting")
+	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "[deprecated] confirm deletion without prompting")
 	cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "confirm deletion without prompting")
 	return cmd
 }

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -60,6 +60,7 @@ To authorize, run "gh auth refresh -s delete_repo"`,
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "confirm deletion without prompting")
+    cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "confirm deletion without prompting")
 	return cmd
 }
 

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -62,7 +62,7 @@ To authorize, run "gh auth refresh -s delete_repo"`,
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "confirm deletion without prompting")
-    cmd.Flags().MarkDeprecated("confirm", "confirm deletion without prompting")
+	cmd.Flags().MarkDeprecated("confirm", "confirm deletion without prompting")
 	cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "confirm deletion without prompting")
 	return cmd
 }

--- a/pkg/cmd/repo/delete/delete_test.go
+++ b/pkg/cmd/repo/delete/delete_test.go
@@ -29,12 +29,12 @@ func TestNewCmdDelete(t *testing.T) {
 			input:  "OWNER/REPO --confirm",
 			output: DeleteOptions{RepoArg: "OWNER/REPO", Confirmed: true},
 		},
-        {
-            name:   "yes flag",
-            tty:    true,
-            input:  "OWNER/REPO --yes",
-            output: DeleteOptions{RepoArg: "OWNER/REPO", Confirmed: true},
-        },
+		{
+			name:   "yes flag",
+			tty:    true,
+			input:  "OWNER/REPO --yes",
+			output: DeleteOptions{RepoArg: "OWNER/REPO", Confirmed: true},
+		},
 		{
 			name:    "no confirmation notty",
 			input:   "OWNER/REPO",

--- a/pkg/cmd/repo/delete/delete_test.go
+++ b/pkg/cmd/repo/delete/delete_test.go
@@ -40,7 +40,7 @@ func TestNewCmdDelete(t *testing.T) {
 			input:   "OWNER/REPO",
 			output:  DeleteOptions{RepoArg: "OWNER/REPO"},
 			wantErr: true,
-			errMsg:  "--confirm required when not running interactively",
+			errMsg:  "--yes required when not running interactively",
 		},
 		{
 			name:   "base repo resolution",

--- a/pkg/cmd/repo/delete/delete_test.go
+++ b/pkg/cmd/repo/delete/delete_test.go
@@ -29,6 +29,12 @@ func TestNewCmdDelete(t *testing.T) {
 			input:  "OWNER/REPO --confirm",
 			output: DeleteOptions{RepoArg: "OWNER/REPO", Confirmed: true},
 		},
+        {
+            name:   "yes flag",
+            tty:    true,
+            input:  "OWNER/REPO --yes",
+            output: DeleteOptions{RepoArg: "OWNER/REPO", Confirmed: true},
+        },
 		{
 			name:    "no confirmation notty",
 			input:   "OWNER/REPO",


### PR DESCRIPTION
Ref. #6892 

Passed an additional flag `--yes` to the delete command and marked `--confirm` as deprecated.