### PR TITLE
Rename `--confirm` flag to `--yes` for various destructive commands

### DIFF
--- a/pkg/cmd/gpg-key/delete/delete.go
+++ b/pkg/cmd/gpg-key/delete/delete.go
@@ -38,7 +38,7 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 			opts.KeyID = args[0]
 
 			if !opts.IO.CanPrompt() && !opts.Confirmed {
-				return cmdutil.FlagErrorf("--confirm required when not running interactively")
+				return cmdutil.FlagErrorf("--yes required when not running interactively")
 			}
 
 			if runF != nil {
@@ -48,7 +48,9 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.Confirmed, "confirm", "y", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "Skip the confirmation prompt")
+    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+    cmd.Flags().BoolVarP(&opts.Confirmed, "yes", "y", false, "Skip the confirmation prompt")
 	return cmd
 }
 

--- a/pkg/cmd/gpg-key/delete/delete.go
+++ b/pkg/cmd/gpg-key/delete/delete.go
@@ -49,8 +49,8 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "Skip the confirmation prompt")
-    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
-    cmd.Flags().BoolVarP(&opts.Confirmed, "yes", "y", false, "Skip the confirmation prompt")
+	_ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+	cmd.Flags().BoolVarP(&opts.Confirmed, "yes", "y", false, "Skip the confirmation prompt")
 	return cmd
 }
 

--- a/pkg/cmd/gpg-key/delete/delete_test.go
+++ b/pkg/cmd/gpg-key/delete/delete_test.go
@@ -32,7 +32,7 @@ func TestNewCmdDelete(t *testing.T) {
 		{
 			name:   "confirm flag tty",
 			tty:    true,
-			input:  "ABC123 --confirm",
+			input:  "ABC123 --yes",
 			output: DeleteOptions{KeyID: "ABC123", Confirmed: true},
 		},
 		{
@@ -45,11 +45,11 @@ func TestNewCmdDelete(t *testing.T) {
 			name:       "no tty",
 			input:      "ABC123",
 			wantErr:    true,
-			wantErrMsg: "--confirm required when not running interactively",
+			wantErrMsg: "--yes required when not running interactively",
 		},
 		{
 			name:   "confirm flag no tty",
-			input:  "ABC123 --confirm",
+			input:  "ABC123 --yes",
 			output: DeleteOptions{KeyID: "ABC123", Confirmed: true},
 		},
 		{

--- a/pkg/cmd/issue/delete/delete.go
+++ b/pkg/cmd/issue/delete/delete.go
@@ -55,8 +55,8 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "confirm deletion without prompting")
-    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
-    cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "confirm deletion without prompting")
+	_ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+	cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "confirm deletion without prompting")
 	return cmd
 }
 

--- a/pkg/cmd/issue/delete/delete.go
+++ b/pkg/cmd/issue/delete/delete.go
@@ -49,11 +49,14 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 			if runF != nil {
 				return runF(opts)
 			}
+
 			return deleteRun(opts)
 		},
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "confirm deletion without prompting")
+    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+    cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "confirm deletion without prompting")
 	return cmd
 }
 

--- a/pkg/cmd/label/delete.go
+++ b/pkg/cmd/label/delete.go
@@ -53,8 +53,8 @@ func newCmdDelete(f *cmdutil.Factory, runF func(*deleteOptions) error) *cobra.Co
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "Confirm deletion without prompting")
-    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
-    cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "Confirm deletion without prompting")
+	_ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+	cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "Confirm deletion without prompting")
 
 	return cmd
 }

--- a/pkg/cmd/label/delete.go
+++ b/pkg/cmd/label/delete.go
@@ -42,7 +42,7 @@ func newCmdDelete(f *cmdutil.Factory, runF func(*deleteOptions) error) *cobra.Co
 			opts.Name = args[0]
 
 			if !opts.IO.CanPrompt() && !opts.Confirmed {
-				return cmdutil.FlagErrorf("--confirm required when not running interactively")
+				return cmdutil.FlagErrorf("--yes required when not running interactively")
 			}
 
 			if runF != nil {
@@ -53,6 +53,8 @@ func newCmdDelete(f *cmdutil.Factory, runF func(*deleteOptions) error) *cobra.Co
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "Confirm deletion without prompting")
+    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+    cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "Confirm deletion without prompting")
 
 	return cmd
 }

--- a/pkg/cmd/label/delete_test.go
+++ b/pkg/cmd/label/delete_test.go
@@ -37,14 +37,14 @@ func TestNewCmdDelete(t *testing.T) {
 		},
 		{
 			name:   "confirm argument",
-			input:  "test --confirm",
+			input:  "test --yes",
 			output: deleteOptions{Name: "test", Confirmed: true},
 		},
 		{
 			name:       "confirm no tty",
 			input:      "test",
 			wantErr:    true,
-			wantErrMsg: "--confirm required when not running interactively",
+			wantErrMsg: "--yes required when not running interactively",
 		},
 	}
 

--- a/pkg/cmd/repo/archive/archive.go
+++ b/pkg/cmd/repo/archive/archive.go
@@ -47,16 +47,21 @@ With no argument, archives the current repository.`),
 			}
 
 			if !opts.Confirmed && !opts.IO.CanPrompt() {
-				return cmdutil.FlagErrorf("--confirm required when not running interactively")
+				return cmdutil.FlagErrorf("--yes required when not running interactively")
 			}
+
 			if runF != nil {
 				return runF(opts)
 			}
-			return archiveRun(opts)
+
+            return archiveRun(opts)
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.Confirmed, "confirm", "y", false, "Skip the confirmation prompt")
+
+	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "Skip the confirmation prompt")
+    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+    cmd.Flags().BoolVarP(&opts.Confirmed, "yes", "y", false, "Skip the confirmation prompt")
 	return cmd
 }
 

--- a/pkg/cmd/repo/archive/archive.go
+++ b/pkg/cmd/repo/archive/archive.go
@@ -54,14 +54,13 @@ With no argument, archives the current repository.`),
 				return runF(opts)
 			}
 
-            return archiveRun(opts)
+			return archiveRun(opts)
 		},
 	}
 
-
 	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "Skip the confirmation prompt")
-    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
-    cmd.Flags().BoolVarP(&opts.Confirmed, "yes", "y", false, "Skip the confirmation prompt")
+	_ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+	cmd.Flags().BoolVarP(&opts.Confirmed, "yes", "y", false, "Skip the confirmation prompt")
 	return cmd
 }
 

--- a/pkg/cmd/repo/archive/archive_test.go
+++ b/pkg/cmd/repo/archive/archive_test.go
@@ -26,7 +26,7 @@ func TestNewCmdArchive(t *testing.T) {
 		{
 			name:    "no arguments no tty",
 			input:   "",
-			errMsg:  "--confirm required when not running interactively",
+			errMsg:  "--yes required when not running interactively",
 			wantErr: true,
 		},
 		{

--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -60,7 +60,7 @@ func NewCmdRename(f *cmdutil.Factory, runf func(*RenameOptions) error) *cobra.Co
 
 			if len(args) == 1 && !confirm && !opts.HasRepoOverride {
 				if !opts.IO.CanPrompt() {
-					return cmdutil.FlagErrorf("--confirm required when passing a single argument")
+					return cmdutil.FlagErrorf("--yes required when passing a single argument")
 				}
 				opts.DoConfirm = true
 			}
@@ -68,12 +68,15 @@ func NewCmdRename(f *cmdutil.Factory, runf func(*RenameOptions) error) *cobra.Co
 			if runf != nil {
 				return runf(opts)
 			}
+
 			return renameRun(opts)
 		},
 	}
 
 	cmdutil.EnableRepoOverride(cmd, f)
-	cmd.Flags().BoolVarP(&confirm, "confirm", "y", false, "skip confirmation prompt")
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "Skip confirmation prompt")
+    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+    cmd.Flags().BoolVarP(&confirm, "yes", "y", false, "Skip the confirmation prompt")
 
 	return cmd
 }

--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -75,8 +75,8 @@ func NewCmdRename(f *cmdutil.Factory, runf func(*RenameOptions) error) *cobra.Co
 
 	cmdutil.EnableRepoOverride(cmd, f)
 	cmd.Flags().BoolVar(&confirm, "confirm", false, "Skip confirmation prompt")
-    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
-    cmd.Flags().BoolVarP(&confirm, "yes", "y", false, "Skip the confirmation prompt")
+	_ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+	cmd.Flags().BoolVarP(&confirm, "yes", "y", false, "Skip the confirmation prompt")
 
 	return cmd
 }

--- a/pkg/cmd/repo/rename/rename_test.go
+++ b/pkg/cmd/repo/rename/rename_test.go
@@ -35,7 +35,7 @@ func TestNewCmdRename(t *testing.T) {
 		},
 		{
 			name:  "one argument no tty confirmed",
-			input: "REPO --confirm",
+			input: "REPO --yes",
 			output: RenameOptions{
 				newRepoSelector: "REPO",
 			},
@@ -43,12 +43,12 @@ func TestNewCmdRename(t *testing.T) {
 		{
 			name:    "one argument no tty",
 			input:   "REPO",
-			errMsg:  "--confirm required when passing a single argument",
+			errMsg:  "--yes required when passing a single argument",
 			wantErr: true,
 		},
 		{
 			name:  "one argument tty confirmed",
-			input: "REPO --confirm",
+			input: "REPO --yes",
 			tty:   true,
 			output: RenameOptions{
 				newRepoSelector: "REPO",

--- a/pkg/cmd/ssh-key/delete/delete.go
+++ b/pkg/cmd/ssh-key/delete/delete.go
@@ -48,9 +48,9 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 		},
 	}
 
-    cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "Skip the confirmation prompt")
-    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
-    cmd.Flags().BoolVarP(&opts.Confirmed, "yes", "y", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "Skip the confirmation prompt")
+	_ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+	cmd.Flags().BoolVarP(&opts.Confirmed, "yes", "y", false, "Skip the confirmation prompt")
 
 	return cmd
 }

--- a/pkg/cmd/ssh-key/delete/delete.go
+++ b/pkg/cmd/ssh-key/delete/delete.go
@@ -37,17 +37,21 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 			opts.KeyID = args[0]
 
 			if !opts.IO.CanPrompt() && !opts.Confirmed {
-				return cmdutil.FlagErrorf("--confirm required when not running interactively")
+				return cmdutil.FlagErrorf("--yes required when not running interactively")
 			}
 
 			if runF != nil {
 				return runF(opts)
 			}
+
 			return deleteRun(opts)
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.Confirmed, "confirm", "y", false, "Skip the confirmation prompt")
+    cmd.Flags().BoolVar(&opts.Confirmed, "confirm", false, "Skip the confirmation prompt")
+    _ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
+    cmd.Flags().BoolVarP(&opts.Confirmed, "yes", "y", false, "Skip the confirmation prompt")
+
 	return cmd
 }
 

--- a/pkg/cmd/ssh-key/delete/delete_test.go
+++ b/pkg/cmd/ssh-key/delete/delete_test.go
@@ -32,7 +32,7 @@ func TestNewCmdDelete(t *testing.T) {
 		{
 			name:   "confirm flag tty",
 			tty:    true,
-			input:  "123 --confirm",
+			input:  "123 --yes",
 			output: DeleteOptions{KeyID: "123", Confirmed: true},
 		},
 		{
@@ -45,11 +45,11 @@ func TestNewCmdDelete(t *testing.T) {
 			name:       "no tty",
 			input:      "123",
 			wantErr:    true,
-			wantErrMsg: "--confirm required when not running interactively",
+			wantErrMsg: "--yes required when not running interactively",
 		},
 		{
 			name:   "confirm flag no tty",
-			input:  "123 --confirm",
+			input:  "123 --yes",
 			output: DeleteOptions{KeyID: "123", Confirmed: true},
 		},
 		{


### PR DESCRIPTION
Fixes #6892 

As per the discussions in the issue. This PR addresses the additional commands that uses the `--confirm` flag and marks it as deprecated in favour of `--yes`
