### PR TITLE
Fix ignoring ProjectsV2-specific errors for GHES

### DIFF
--- a/api/queries_projects_v2.go
+++ b/api/queries_projects_v2.go
@@ -10,10 +10,10 @@ import (
 
 const (
 	errorProjectsV2ReadScope         = "field requires one of the following scopes: ['read:project']"
-	errorProjectsV2RepositoryField   = "Field 'ProjectsV2' doesn't exist on type 'Repository'"
-	errorProjectsV2OrganizationField = "Field 'ProjectsV2' doesn't exist on type 'Organization'"
-	errorProjectsV2IssueField        = "Field 'ProjectItems' doesn't exist on type 'Issue'"
-	errorProjectsV2PullRequestField  = "Field 'ProjectItems' doesn't exist on type 'PullRequest'"
+	errorProjectsV2RepositoryField   = "Field 'projectsV2' doesn't exist on type 'Repository'"
+	errorProjectsV2OrganizationField = "Field 'projectsV2' doesn't exist on type 'Organization'"
+	errorProjectsV2IssueField        = "Field 'projectItems' doesn't exist on type 'Issue'"
+	errorProjectsV2PullRequestField  = "Field 'projectItems' doesn't exist on type 'PullRequest'"
 )
 
 // UpdateProjectV2Items uses the addProjectV2ItemById and the deleteProjectV2Item mutations

--- a/api/queries_projects_v2_test.go
+++ b/api/queries_projects_v2_test.go
@@ -221,22 +221,22 @@ func TestProjectsV2IgnorableError(t *testing.T) {
 		},
 		{
 			name:      "repository projectsV2 field error",
-			errMsg:    "Field 'ProjectsV2' doesn't exist on type 'Repository'",
+			errMsg:    "Field 'projectsV2' doesn't exist on type 'Repository'",
 			expectOut: true,
 		},
 		{
 			name:      "organization projectsV2 field error",
-			errMsg:    "Field 'ProjectsV2' doesn't exist on type 'Organization'",
+			errMsg:    "Field 'projectsV2' doesn't exist on type 'Organization'",
 			expectOut: true,
 		},
 		{
 			name:      "issue projectItems field error",
-			errMsg:    "Field 'ProjectItems' doesn't exist on type 'Issue'",
+			errMsg:    "Field 'projectItems' doesn't exist on type 'Issue'",
 			expectOut: true,
 		},
 		{
 			name:      "pullRequest projectItems field error",
-			errMsg:    "Field 'ProjectItems' doesn't exist on type 'PullRequest'",
+			errMsg:    "Field 'projectItems' doesn't exist on type 'PullRequest'",
 			expectOut: true,
 		},
 		{


### PR DESCRIPTION
It was a capitalization issue when scanning error message text.

Fixes https://github.com/cli/cli/issues/6917
Followup to https://github.com/cli/cli/pull/6735