### PR TITLE
Use int64 repository IDs for Codespaces user secrets

### DIFF
--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -426,7 +426,7 @@ func Test_setRun_user(t *testing.T) {
 		name             string
 		opts             *SetOptions
 		wantVisibility   shared.Visibility
-		wantRepositories []string
+		wantRepositories []int64
 	}{
 		{
 			name: "all vis",
@@ -442,7 +442,7 @@ func Test_setRun_user(t *testing.T) {
 				Visibility:      shared.Selected,
 				RepositoryNames: []string{"cli/cli", "github/hub"},
 			},
-			wantRepositories: []string{"212613049", "401025"},
+			wantRepositories: []int64{212613049, 401025},
 		},
 	}
 
@@ -481,7 +481,7 @@ func Test_setRun_user(t *testing.T) {
 
 			data, err := io.ReadAll(reg.Requests[len(reg.Requests)-1].Body)
 			assert.NoError(t, err)
-			var payload CodespacesSecretPayload
+			var payload SecretPayload
 			err = json.Unmarshal(data, &payload)
 			assert.NoError(t, err)
 			assert.Equal(t, payload.KeyID, "123")


### PR DESCRIPTION
Follow-up to #4699

The API for creating Codespaces user secrets takes in a `selected_repository_ids` of repositories that have access to that secret.

https://docs.github.com/en/rest/codespaces/secrets?apiVersion=2022-11-28#create-or-update-a-secret-for-the-authenticated-user

This API originally only accepted string IDs for `selected_repository_ids` despite these being integer IDs, which required a separate `CodespacesSecretPayload` struct just for Codespaces user secrets.

This API now allows integer IDs, matching the other GitHub Secrets APIs and allowing us to remove some unnecessary string conversions.

### Testing

```
❯ bin/gh secret set -u -bSomeValue -r"joshmgross/clock,joshmgross/actions-testing" coolSecret
✓ Set Codespaces secret coolSecret for your user

❯ bin/gh secret list -u
COOLSECRET  Updated 2023-01-27  Visible to 2 selected repositories
```

![The user Codespaces settings page for "COOLSECRET" showing two selected repositories](https://user-images.githubusercontent.com/16631042/215181882-a724e0cf-c4df-4c91-8417-0ccf103f7d4e.png)
