### PR TITLE
Default to authenticated user on codespace delete

### DIFF
--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -80,6 +80,7 @@ func startLiveShareSession(ctx context.Context, codespace *api.Codespace, a *App
 
 //go:generate moq -fmt goimports -rm -skip-ensure -out mock_api.go . apiClient
 type apiClient interface {
+	GetUser(ctx context.Context) (*api.User, error)
 	GetCodespace(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error)
 	GetOrgMemberCodespace(ctx context.Context, orgName string, userName string, codespaceName string) (*api.Codespace, error)
 	ListCodespaces(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error)

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -85,7 +85,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 	if nameFilter == "" {
 		a.StartProgressIndicatorWithLabel("Fetching codespaces")
 		userName := opts.userName
-		if userName == "" {
+		if userName == "" && opts.orgName != "" {
 			currentUser, err := a.apiClient.GetUser(ctx)
 			if err != nil {
 				return err

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -84,7 +84,15 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 	nameFilter := opts.codespaceName
 	if nameFilter == "" {
 		a.StartProgressIndicatorWithLabel("Fetching codespaces")
-		codespaces, err = a.apiClient.ListCodespaces(ctx, api.ListCodespacesOptions{OrgName: opts.orgName, UserName: opts.userName})
+		userName := opts.userName
+		if userName == "" {
+			currentUser, err := a.apiClient.GetUser(ctx)
+			if err != nil {
+				return err
+			}
+			userName = currentUser.Login
+		}
+		codespaces, err = a.apiClient.ListCodespaces(ctx, api.ListCodespacesOptions{OrgName: opts.orgName, UserName: userName})
 		a.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("error getting codespaces: %w", err)

--- a/pkg/cmd/codespace/mock_api.go
+++ b/pkg/cmd/codespace/mock_api.go
@@ -46,6 +46,9 @@ import (
 //			GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
 //				panic("mock out the GetRepository method")
 //			},
+//			GetUserFunc: func(ctx context.Context) (*api.User, error) {
+//				panic("mock out the GetUser method")
+//			},
 //			ListCodespacesFunc: func(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error) {
 //				panic("mock out the ListCodespaces method")
 //			},
@@ -94,6 +97,9 @@ type apiClientMock struct {
 
 	// GetRepositoryFunc mocks the GetRepository method.
 	GetRepositoryFunc func(ctx context.Context, nwo string) (*api.Repository, error)
+
+	// GetUserFunc mocks the GetUser method.
+	GetUserFunc func(ctx context.Context) (*api.User, error)
 
 	// ListCodespacesFunc mocks the ListCodespaces method.
 	ListCodespacesFunc func(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error)
@@ -201,6 +207,11 @@ type apiClientMock struct {
 			// Nwo is the nwo argument value.
 			Nwo string
 		}
+		// GetUser holds details about calls to the GetUser method.
+		GetUser []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
 		// ListCodespaces holds details about calls to the ListCodespaces method.
 		ListCodespaces []struct {
 			// Ctx is the ctx argument value.
@@ -248,6 +259,7 @@ type apiClientMock struct {
 	lockGetCodespacesMachines          sync.RWMutex
 	lockGetOrgMemberCodespace          sync.RWMutex
 	lockGetRepository                  sync.RWMutex
+	lockGetUser                        sync.RWMutex
 	lockListCodespaces                 sync.RWMutex
 	lockListDevContainers              sync.RWMutex
 	lockStartCodespace                 sync.RWMutex
@@ -655,6 +667,38 @@ func (mock *apiClientMock) GetRepositoryCalls() []struct {
 	mock.lockGetRepository.RLock()
 	calls = mock.calls.GetRepository
 	mock.lockGetRepository.RUnlock()
+	return calls
+}
+
+// GetUser calls GetUserFunc.
+func (mock *apiClientMock) GetUser(ctx context.Context) (*api.User, error) {
+	if mock.GetUserFunc == nil {
+		panic("apiClientMock.GetUserFunc: method is nil but apiClient.GetUser was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockGetUser.Lock()
+	mock.calls.GetUser = append(mock.calls.GetUser, callInfo)
+	mock.lockGetUser.Unlock()
+	return mock.GetUserFunc(ctx)
+}
+
+// GetUserCalls gets all the calls that were made to GetUser.
+// Check the length with:
+//
+//	len(mockedapiClient.GetUserCalls())
+func (mock *apiClientMock) GetUserCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockGetUser.RLock()
+	calls = mock.calls.GetUser
+	mock.lockGetUser.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
Fixes #6188

When a username option is not provided for the `gh codespace delete` command, we will use the authenticated user's login as the default to avoid deleting anyone else's codespace by mistake.

Prior to this change, running `gh codespace delete --org MYORG --all` would fetch all of the codespaces associated with the org regardless of user and then only delete the ones associated with the authenticated user, which would lead to 404 errors when MYORG had codespaces owned by members other than the authenticated member.

**Before**
```
gh cs list --org my-fun-org
NAME                                             DISPLAY NAME            OWNER     REPOSITORY                           BRANCH  STATE         CREATED AT
monalisa-redesigned-cod-r4xpvj69qfj95            redesigned cod          monalisa  my-fun-org/codespaces-test           main    Shutdown      19d
luanzeba-obscure-space-carnival-r4j46766q9xcrr6  obscure space carnival  luanzeba  my-fun-org/codespaces-test           main    Provisioning  0m

gh cs delete --org my-fun-org --all
Deleting codespaces ⣽error deleting codespace "monalisa-redesigned-cod-r4xpvj69qfj95": HTTP 404: Not Found (https://api.github.com/user/codespaces/monalisa-redesigned-cod-r4xpvj69qfj95)
some codespaces failed to delete

gh cs list --org my-fun-org
NAME                                   DISPLAY NAME    OWNER     REPOSITORY                           BRANCH  STATE     CREATED AT
monalisa-redesigned-cod-r4xpvj69qfj95  redesigned cod  monalisa  my-fun-org/codespaces-test           main    Shutdown  19d
```

**After**
```
gh cs list --org my-fun-org
NAME                                             DISPLAY NAME            OWNER     REPOSITORY                           BRANCH  STATE         CREATED AT
monalisa-redesigned-cod-r4xpvj69qfj95            redesigned cod          monalisa  my-fun-org/codespaces-test           main    Shutdown      19d
luanzeba-obscure-space-carnival-r4j46766q9xcrr6  obscure space carnival  luanzeba  my-fun-org/codespaces-test           main    Provisioning  0m

gh cs delete --org my-fun-org --all

gh cs list --org my-fun-org
NAME                                   DISPLAY NAME    OWNER     REPOSITORY                           BRANCH  STATE     CREATED AT
monalisa-redesigned-cod-r4xpvj69qfj95  redesigned cod  monalisa  my-fun-org/codespaces-test           main    Shutdown  19d

```

## Notes

Due to the implementation relying on the `ListCodespaces` function to perform the work of filtering the codespaces by user, we had to basically reimplement the logic in the tests leveraging the mock functions. Coming from Ruby, that seems like a code smell, but we couldn't come up with a better alternative. Please let us know if you have any ideas to improve it and we'd be happy to implement it.
