### PR TITLE
Add ARM64 to Darwin releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ builds:
         - -X main.updaterEnabled=cli/cli
     id: macos
     goos: [darwin]
-    goarch: [amd64]
+    goarch: [amd64, arm64]
 
   - <<: *build_defaults
     id: linux


### PR DESCRIPTION
Fixes #2426.

In the past, this was blocked by golang/go#42684, but that issue is now resolved and the Go toolchain is able to sign binaries by default.

I tested running goreleaser both on macOS directly and on Linux, and in both cases, the resulting gh binary runs on Apple Silicon without issue.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
