### PR TITLE
Fix set-default interactive not showing all remotes

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -13,7 +13,7 @@ import (
 
 // cap the number of git remotes looked up, since the user might have an
 // unusually large number of git remotes
-const maxRemotesForLookup = 5
+const defaultMaxRemotesForLookup = 5
 
 func ResolveRemotesToRepos(remotes Remotes, client *api.Client, base string) (*ResolvedRemotes, error) {
 	sort.Stable(remotes)
@@ -36,11 +36,11 @@ func ResolveRemotesToRepos(remotes Remotes, client *api.Client, base string) (*R
 	return result, nil
 }
 
-func resolveNetwork(result *ResolvedRemotes) error {
+func resolveNetwork(result *ResolvedRemotes, maxRemotesForLookup int) error {
 	var repos []ghrepo.Interface
 	for _, r := range result.remotes {
 		repos = append(repos, r)
-		if len(repos) == maxRemotesForLookup {
+		if len(repos) == maxRemotesForLookup || maxRemotesForLookup == 0 {
 			break
 		}
 	}
@@ -84,7 +84,7 @@ func (r *ResolvedRemotes) BaseRepo(io *iostreams.IOStreams) (ghrepo.Interface, e
 		return r.remotes[0], nil
 	}
 
-	repos, err := r.NetworkRepos()
+	repos, err := r.NetworkRepos(defaultMaxRemotesForLookup)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (r *ResolvedRemotes) BaseRepo(io *iostreams.IOStreams) (ghrepo.Interface, e
 
 func (r *ResolvedRemotes) HeadRepos() ([]*api.Repository, error) {
 	if r.network == nil {
-		err := resolveNetwork(r)
+		err := resolveNetwork(r, defaultMaxRemotesForLookup)
 		if err != nil {
 			return nil, err
 		}
@@ -124,9 +124,11 @@ func (r *ResolvedRemotes) HeadRepos() ([]*api.Repository, error) {
 	return results, nil
 }
 
-func (r *ResolvedRemotes) NetworkRepos() ([]*api.Repository, error) {
+// NetworkRepos fetches info about all remotes for the network of repos. Pass a value of 0 for
+// maxRemotesForLookup to signal no limit.
+func (r *ResolvedRemotes) NetworkRepos(maxRemotesForLookup int) ([]*api.Repository, error) {
 	if r.network == nil {
-		err := resolveNetwork(r)
+		err := resolveNetwork(r, defaultMaxRemotesForLookup)
 		if err != nil {
 			return nil, err
 		}

--- a/context/context.go
+++ b/context/context.go
@@ -11,9 +11,9 @@ import (
 	"github.com/cli/cli/v2/pkg/iostreams"
 )
 
-// cap the number of git remotes looked up, since the user might have an
-// unusually large number of git remotes
-const defaultMaxRemotesForLookup = 5
+// Cap the number of git remotes to look up, since the user might have an
+// unusually large number of git remotes.
+const defaultRemotesForLookup = 5
 
 func ResolveRemotesToRepos(remotes Remotes, client *api.Client, base string) (*ResolvedRemotes, error) {
 	sort.Stable(remotes)
@@ -36,11 +36,11 @@ func ResolveRemotesToRepos(remotes Remotes, client *api.Client, base string) (*R
 	return result, nil
 }
 
-func resolveNetwork(result *ResolvedRemotes, maxRemotesForLookup int) error {
+func resolveNetwork(result *ResolvedRemotes, remotesForLookup int) error {
 	var repos []ghrepo.Interface
 	for _, r := range result.remotes {
 		repos = append(repos, r)
-		if len(repos) == maxRemotesForLookup || maxRemotesForLookup == 0 {
+		if len(repos) == remotesForLookup {
 			break
 		}
 	}
@@ -84,7 +84,7 @@ func (r *ResolvedRemotes) BaseRepo(io *iostreams.IOStreams) (ghrepo.Interface, e
 		return r.remotes[0], nil
 	}
 
-	repos, err := r.NetworkRepos(defaultMaxRemotesForLookup)
+	repos, err := r.NetworkRepos(defaultRemotesForLookup)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (r *ResolvedRemotes) BaseRepo(io *iostreams.IOStreams) (ghrepo.Interface, e
 
 func (r *ResolvedRemotes) HeadRepos() ([]*api.Repository, error) {
 	if r.network == nil {
-		err := resolveNetwork(r, defaultMaxRemotesForLookup)
+		err := resolveNetwork(r, defaultRemotesForLookup)
 		if err != nil {
 			return nil, err
 		}
@@ -124,11 +124,11 @@ func (r *ResolvedRemotes) HeadRepos() ([]*api.Repository, error) {
 	return results, nil
 }
 
-// NetworkRepos fetches info about all remotes for the network of repos. Pass a value of 0 for
-// maxRemotesForLookup to signal no limit.
-func (r *ResolvedRemotes) NetworkRepos(maxRemotesForLookup int) ([]*api.Repository, error) {
+// NetworkRepos fetches info about remotes for the network of repos.
+// Pass a value of 0 to fetch info on all remotes.
+func (r *ResolvedRemotes) NetworkRepos(remotesForLookup int) ([]*api.Repository, error) {
 	if r.network == nil {
-		err := resolveNetwork(r, defaultMaxRemotesForLookup)
+		err := resolveNetwork(r, remotesForLookup)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/repo/setdefault/setdefault.go
+++ b/pkg/cmd/repo/setdefault/setdefault.go
@@ -160,7 +160,7 @@ func setDefaultRun(opts *SetDefaultOptions) error {
 		return err
 	}
 
-	knownRepos, err := resolvedRemotes.NetworkRepos()
+	knownRepos, err := resolvedRemotes.NetworkRepos(0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When running `gh repo set-default` in interactive mode only 5 remotes
were showing. This change refactors the methods that fetch the info for
those remotes. The methods now expect a limit to be provided. Passing
`0` allows running things with no limit.

Fixes #6854

## Note to reviewers
I was unsure if it made sense to start writing tests for context/context.go. Lots going on in that file and it would suck if someone else has a WIP branch to write those tests.

The description I'm leaving for the `ResolvedRemotes.NetworkRepos` method is questionable and I'd be surprised if someone can't come up with something better.
