### PR TITLE
Disable gh update checker in our precompiled binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,6 @@ builds:
       main: ./cmd/gh
       ldflags:
         - -s -w -X github.com/cli/cli/v2/internal/build.Version={{.Version}} -X github.com/cli/cli/v2/internal/build.Date={{time "2006-01-02"}}
-        - -X main.updaterEnabled=cli/cli
     id: macos
     goos: [darwin]
     goarch: [amd64]


### PR DESCRIPTION
This is because most people install gh through a package manager, and people usually prefer for their package manager to check for updates instead of the gh process doing that at runtime.

After this, the only people still receiving update notifications would be Homebrew users, since the homebrew-core formula sets `main.updaterEnabled` explicitly.

Note that this also disables automatic update checking for Windows users who have installed the MSI. After this, MSI users will not learn about gh having new versions unless they perform the check themselves.

Fixes https://github.com/cli/cli/issues/6966, ref. https://github.com/cli/cli/issues/6867