### PR TITLE
Disallow update checker delaying the gh process

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -65,7 +65,7 @@ func mainRun() exitCode {
 	defer updateCancel()
 	updateMessageChan := make(chan *update.ReleaseInfo)
 	go func() {
-		rel, err := checkForUpdate(updateCtx, buildVersion)
+		rel, err := checkForUpdate(updateCtx, cmdFactory, buildVersion)
 		if err != nil && hasDebug {
 			fmt.Fprintf(stderr, "warning: checking for update failed: %v", err)
 		}
@@ -357,14 +357,11 @@ func isCI() bool {
 		os.Getenv("RUN_ID") != "" // TaskCluster, dsari
 }
 
-func checkForUpdate(ctx context.Context, currentVersion string) (*update.ReleaseInfo, error) {
+func checkForUpdate(ctx context.Context, f *cmdutil.Factory, currentVersion string) (*update.ReleaseInfo, error) {
 	if !shouldCheckForUpdate() {
 		return nil, nil
 	}
-	httpClient, err := api.NewHTTPClient(api.HTTPClientOptions{
-		AppVersion: currentVersion,
-		Log:        os.Stderr,
-	})
+	httpClient, err := f.HttpClient()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -53,17 +54,24 @@ func main() {
 func mainRun() exitCode {
 	buildDate := build.Date
 	buildVersion := build.Version
-
-	updateMessageChan := make(chan *update.ReleaseInfo)
-	go func() {
-		rel, _ := checkForUpdate(buildVersion)
-		updateMessageChan <- rel
-	}()
-
 	hasDebug, _ := utils.IsDebugEnabled()
 
 	cmdFactory := factory.New(buildVersion)
 	stderr := cmdFactory.IOStreams.ErrOut
+
+	ctx := context.Background()
+
+	updateCtx, updateCancel := context.WithCancel(ctx)
+	defer updateCancel()
+	updateMessageChan := make(chan *update.ReleaseInfo)
+	go func() {
+		rel, err := checkForUpdate(updateCtx, buildVersion)
+		if err != nil && hasDebug {
+			fmt.Fprintf(stderr, "warning: checking for update failed: %v", err)
+		}
+		updateMessageChan <- rel
+	}()
+
 	if !cmdFactory.IOStreams.ColorEnabled() {
 		surveyCore.DisableColor = true
 		ansi.DisableColors(true)
@@ -209,7 +217,7 @@ func mainRun() exitCode {
 
 	rootCmd.SetArgs(expandedArgs)
 
-	if cmd, err := rootCmd.ExecuteC(); err != nil {
+	if cmd, err := rootCmd.ExecuteContextC(ctx); err != nil {
 		var pagerPipeError *iostreams.ErrClosedPagerPipe
 		var noResultsError cmdutil.NoResultsError
 		if err == cmdutil.SilentError {
@@ -257,6 +265,7 @@ func mainRun() exitCode {
 		return exitError
 	}
 
+	updateCancel() // if the update checker hasn't completed by now, abort it
 	newRelease := <-updateMessageChan
 	if newRelease != nil {
 		isHomebrew := isUnderHomebrew(cmdFactory.Executable())
@@ -348,7 +357,7 @@ func isCI() bool {
 		os.Getenv("RUN_ID") != "" // TaskCluster, dsari
 }
 
-func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {
+func checkForUpdate(ctx context.Context, currentVersion string) (*update.ReleaseInfo, error) {
 	if !shouldCheckForUpdate() {
 		return nil, nil
 	}
@@ -359,10 +368,9 @@ func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	client := api.NewClientFromHTTP(httpClient)
 	repo := updaterEnabled
 	stateFilePath := filepath.Join(config.StateDir(), "state.yml")
-	return update.CheckForUpdate(client, stateFilePath, repo, currentVersion)
+	return update.CheckForUpdate(ctx, httpClient, stateFilePath, repo, currentVersion)
 }
 
 func isRecentRelease(publishedAt time.Time) bool {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,13 +1,13 @@
 package update
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"testing"
 
-	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/pkg/httpmock"
 )
 
@@ -75,7 +75,6 @@ func TestCheckForUpdate(t *testing.T) {
 			reg := &httpmock.Registry{}
 			httpClient := &http.Client{}
 			httpmock.ReplaceTripper(httpClient, reg)
-			client := api.NewClientFromHTTP(httpClient)
 
 			reg.Register(
 				httpmock.REST("GET", "repos/OWNER/REPO/releases/latest"),
@@ -85,7 +84,7 @@ func TestCheckForUpdate(t *testing.T) {
 				}`, s.LatestVersion, s.LatestURL)),
 			)
 
-			rel, err := CheckForUpdate(client, tempFilePath(), "OWNER/REPO", s.CurrentVersion)
+			rel, err := CheckForUpdate(context.TODO(), httpClient, tempFilePath(), "OWNER/REPO", s.CurrentVersion)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This ensures that checking for newer versions of gh happens in the background of the main operation that the user requested, and that when that operation is completed, the gh process should immediately exit without being delayed by the update checker goroutine.

Fixes https://github.com/cli/cli/issues/6867