### PR TITLE
Support Fork with Default Branch Only

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -504,7 +504,7 @@ type repositoryV3 struct {
 }
 
 // ForkRepo forks the repository on GitHub and returns the new repository
-func ForkRepo(client *Client, repo ghrepo.Interface, org, newName string) (*Repository, error) {
+func ForkRepo(client *Client, repo ghrepo.Interface, org, newName string, defaultBranchOnly bool) (*Repository, error) {
 	path := fmt.Sprintf("repos/%s/forks", ghrepo.FullName(repo))
 
 	params := map[string]interface{}{}
@@ -513,6 +513,9 @@ func ForkRepo(client *Client, repo ghrepo.Interface, org, newName string) (*Repo
 	}
 	if newName != "" {
 		params["name"] = newName
+	}
+	if defaultBranchOnly {
+		params["default_branch_only"] = true
 	}
 
 	body := &bytes.Buffer{}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -698,7 +698,7 @@ func handlePush(opts CreateOptions, ctx CreateContext) error {
 	// one by forking the base repository
 	if headRepo == nil && ctx.IsPushEnabled {
 		opts.IO.StartProgressIndicator()
-		headRepo, err = api.ForkRepo(client, ctx.BaseRepo, "", "")
+		headRepo, err = api.ForkRepo(client, ctx.BaseRepo, "", "", false)
 		opts.IO.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("error forking repo: %w", err)

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -33,16 +33,17 @@ type ForkOptions struct {
 	Remotes    func() (ghContext.Remotes, error)
 	Since      func(time.Time) time.Duration
 
-	GitArgs      []string
-	Repository   string
-	Clone        bool
-	Remote       bool
-	PromptClone  bool
-	PromptRemote bool
-	RemoteName   string
-	Organization string
-	ForkName     string
-	Rename       bool
+	GitArgs           []string
+	Repository        string
+	Clone             bool
+	Remote            bool
+	PromptClone       bool
+	PromptRemote      bool
+	RemoteName        string
+	Organization      string
+	ForkName          string
+	Rename            bool
+	DefaultBranchOnly bool
 }
 
 // TODO warn about useless flags (--remote, --remote-name) when running from outside a repository
@@ -122,6 +123,7 @@ func NewCmdFork(f *cmdutil.Factory, runF func(*ForkOptions) error) *cobra.Comman
 	cmd.Flags().StringVar(&opts.RemoteName, "remote-name", defaultRemoteName, "Specify the name for the new remote")
 	cmd.Flags().StringVar(&opts.Organization, "org", "", "Create the fork in an organization")
 	cmd.Flags().StringVar(&opts.ForkName, "fork-name", "", "Rename the forked repository")
+	cmd.Flags().BoolVar(&opts.DefaultBranchOnly, "default-branch-only", false, "Only include the default branch in the fork")
 
 	return cmd
 }
@@ -181,7 +183,7 @@ func forkRun(opts *ForkOptions) error {
 	apiClient := api.NewClientFromHTTP(httpClient)
 
 	opts.IO.StartProgressIndicator()
-	forkedRepo, err := api.ForkRepo(apiClient, repoToFork, opts.Organization, opts.ForkName)
+	forkedRepo, err := api.ForkRepo(apiClient, repoToFork, opts.Organization, opts.ForkName, opts.DefaultBranchOnly)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("failed to fork: %w", err)


### PR DESCRIPTION
Fixes #6984

https://docs.github.com/en/rest/repos/forks?apiVersion=2022-11-28#create-a-fork includes a `default_branch_only` flag.
Introduced: https://github.blog/changelog/2022-07-27-you-can-now-fork-a-repo-and-copy-only-the-default-branch/

The web interface for this looks like this:
<img width="737" alt="image" src="https://user-images.githubusercontent.com/2119212/217278224-0a186e32-769b-4618-acd1-780b2914becc.png">

Note that the default behavior (at least for me?) in the web interface is to use this flag. That'd be way too much of an api change for me to introduce here, so we're going with the default legacy behavior of `default_branch_only=false` (well, technically unset, which lets GitHub change the fork behavior server-side in the future).