### PR TITLE
Avoid implicitly fetching when adding a new git remote

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -394,7 +394,10 @@ func (c *Client) revParse(ctx context.Context, args ...string) ([]byte, error) {
 // Below are commands that make network calls and need authentication credentials supplied from gh.
 
 func (c *Client) Fetch(ctx context.Context, remote string, refspec string, mods ...CommandModifier) error {
-	args := []string{"fetch", remote, refspec}
+	args := []string{"fetch", remote}
+	if refspec != "" {
+		args = append(args, refspec)
+	}
 	cmd, err := c.AuthenticatedCommand(ctx, args...)
 	if err != nil {
 		return err
@@ -462,8 +465,8 @@ func (c *Client) AddRemote(ctx context.Context, name, urlStr string, trackingBra
 	for _, branch := range trackingBranches {
 		args = append(args, "-t", branch)
 	}
-	args = append(args, "-f", name, urlStr)
-	cmd, err := c.AuthenticatedCommand(ctx, args...)
+	args = append(args, name, urlStr)
+	cmd, err := c.Command(ctx, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -1089,7 +1089,7 @@ func TestClientAddRemote(t *testing.T) {
 			url:         "URL",
 			dir:         "DIRECTORY",
 			branches:    []string{},
-			wantCmdArgs: `path/to/git -C DIRECTORY -c credential.helper= -c credential.helper=!"gh" auth git-credential remote add -f test URL`,
+			wantCmdArgs: `path/to/git -C DIRECTORY remote add test URL`,
 		},
 		{
 			title:       "fetch specific branches only",
@@ -1097,7 +1097,7 @@ func TestClientAddRemote(t *testing.T) {
 			url:         "URL",
 			dir:         "DIRECTORY",
 			branches:    []string{"trunk", "dev"},
-			wantCmdArgs: `path/to/git -C DIRECTORY -c credential.helper= -c credential.helper=!"gh" auth git-credential remote add -t trunk -t dev -f test URL`,
+			wantCmdArgs: `path/to/git -C DIRECTORY remote add -t trunk -t dev test URL`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -451,7 +451,7 @@ func Test_createRun(t *testing.T) {
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
-				cs.Register(`git remote add -f fork https://github.com/monalisa/REPO.git`, 0, "")
+				cs.Register(`git remote add fork https://github.com/monalisa/REPO.git`, 0, "")
 				cs.Register(`git push --set-upstream fork HEAD:feature`, 0, "")
 			},
 			promptStubs: func(pm *prompter.PrompterMock) {

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -179,6 +179,10 @@ func cloneRun(opts *CloneOptions) error {
 		if err != nil {
 			return err
 		}
+
+		if err := gitClient.Fetch(ctx, upstreamName, "", git.WithRepoDir(cloneDir)); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -245,7 +245,8 @@ func Test_RepoClone_hasParent(t *testing.T) {
 	defer cmdTeardown(t)
 
 	cs.Register(`git clone https://github.com/OWNER/REPO.git`, 0, "")
-	cs.Register(`git -C REPO remote add -t trunk -f upstream https://github.com/hubot/ORIG.git`, 0, "")
+	cs.Register(`git -C REPO remote add -t trunk upstream https://github.com/hubot/ORIG.git`, 0, "")
+	cs.Register(`git -C REPO fetch upstream`, 0, "")
 
 	_, err := runCloneCommand(httpClient, "OWNER/REPO")
 	if err != nil {
@@ -281,7 +282,8 @@ func Test_RepoClone_hasParent_upstreamRemoteName(t *testing.T) {
 	defer cmdTeardown(t)
 
 	cs.Register(`git clone https://github.com/OWNER/REPO.git`, 0, "")
-	cs.Register(`git -C REPO remote add -t trunk -f test https://github.com/hubot/ORIG.git`, 0, "")
+	cs.Register(`git -C REPO remote add -t trunk test https://github.com/hubot/ORIG.git`, 0, "")
+	cs.Register(`git -C REPO fetch test`, 0, "")
 
 	_, err := runCloneCommand(httpClient, "OWNER/REPO --upstream-remote-name test")
 	if err != nil {

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -329,6 +329,10 @@ func forkRun(opts *ForkOptions) error {
 				return err
 			}
 
+			if err := gitClient.Fetch(ctx, "upstream", "", git.WithRepoDir(cloneDir)); err != nil {
+				return err
+			}
+
 			if connectedToTerminal {
 				fmt.Fprintf(stderr, "%s Cloned fork\n", cs.SuccessIcon())
 			}

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -234,7 +234,7 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git remote add -f fork https://github\.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git remote add fork https://github\.com/someone/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n",
 		},
@@ -258,7 +258,7 @@ func TestRepoFork(t *testing.T) {
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git remote add -f fork git@github\.com:someone/REPO\.git`, 0, "")
+				cs.Register(`git remote add fork git@github\.com:someone/REPO\.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n",
 		},
@@ -288,7 +288,7 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
-				cs.Register(`git remote add -f origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
 			},
 			askStubs: func(as *prompt.AskStubber) {
 				//nolint:staticcheck // SA1019: as.StubOne is deprecated: use StubPrompt
@@ -364,7 +364,7 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
-				cs.Register(`git remote add -f origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote origin\n",
 		},
@@ -418,7 +418,7 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
-				cs.Register(`git remote add -f origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
 			},
 		},
 		{
@@ -437,7 +437,8 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone --depth 1 https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO fetch upstream`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Cloned fork\n",
 		},
@@ -467,7 +468,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/gamehendge/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO fetch upstream`, 0, "")
 			},
 			wantErrOut: "✓ Created fork gamehendge/REPO\n✓ Cloned fork\n",
 		},
@@ -481,7 +483,8 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO fetch upstream`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Cloned fork\n",
 		},
@@ -513,7 +516,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO fetch upstream`, 0, "")
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Cloned fork\n",
 		},
@@ -534,7 +538,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO fetch upstream`, 0, "")
 			},
 			wantErrOut: "! someone/REPO already exists\n✓ Cloned fork\n",
 		},
@@ -568,7 +573,8 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO fetch upstream`, 0, "")
 			},
 			wantErrOut: "someone/REPO already exists",
 		},
@@ -581,7 +587,8 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
-				cs.Register(`git -C REPO remote add -f upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO fetch upstream`, 0, "")
 			},
 		},
 		{


### PR DESCRIPTION
Auto-fetching is not always necessary and it can fail when adding a git remote for a just-created fork since the git objects might not yet be available on the platform.

Fixes https://github.com/cli/cli/issues/6975