### PR TITLE
Configuration variables for GitHub Actions impl: update

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -31,6 +31,7 @@ import (
 	secretCmd "github.com/cli/cli/v2/pkg/cmd/secret"
 	sshKeyCmd "github.com/cli/cli/v2/pkg/cmd/ssh-key"
 	statusCmd "github.com/cli/cli/v2/pkg/cmd/status"
+	variableCmd "github.com/cli/cli/v2/pkg/cmd/variable"
 	versionCmd "github.com/cli/cli/v2/pkg/cmd/version"
 	workflowCmd "github.com/cli/cli/v2/pkg/cmd/workflow"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -97,6 +98,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(extensionCmd.NewCmdExtension(f))
 	cmd.AddCommand(searchCmd.NewCmdSearch(f))
 	cmd.AddCommand(secretCmd.NewCmdSecret(f))
+	cmd.AddCommand(variableCmd.NewCmdVariable(f))
 	cmd.AddCommand(sshKeyCmd.NewCmdSSHKey(f))
 	cmd.AddCommand(statusCmd.NewCmdStatus(f, nil))
 	cmd.AddCommand(newCodespaceCmd(f))

--- a/pkg/cmd/variable/create/create.go
+++ b/pkg/cmd/variable/create/create.go
@@ -1,0 +1,223 @@
+package create
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdCreate(f *cmdutil.Factory, runF func(*shared.PostPatchOptions) error) *cobra.Command {
+	opts := &shared.PostPatchOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		HttpClient: f.HttpClient,
+		Prompter:   f.Prompter,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create <variable-name>",
+		Short: "Create variables",
+		Long: heredoc.Doc(`
+			Create a value for a variable on one of the following levels:
+			- repository (default): available to Actions runs in a repository
+			- environment: available to Actions runs for a deployment environment in a repository
+			- organization: available to Actions runs within an organization
+
+			Organization variable can optionally be restricted to only be available to
+			specific repositories.
+		`),
+		Example: heredoc.Doc(`
+			# Add variable value for the current repository in an interactive prompt
+			$ gh variable create MYVARIABLE
+
+			# Read variable value from an environment variable
+			$ gh variable create MYVARIABLE --body "$ENV_VALUE"
+
+			# Read variable value from a file
+			$ gh variable create MYVARIABLE < myfile.txt
+
+			# Create variable for a deployment environment in the current repository
+			$ gh variable create MYVARIABLE --env myenvironment
+
+			# Create organization-level variable visible to both public and private repositories
+			$ gh variable create MYVARIABLE --org myOrg --visibility all
+
+			# Create organization-level variable visible to specific repositories
+			$ gh variable create MYVARIABLE --org myOrg --repos repo1,repo2,repo3
+
+		`),
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			if err := cmdutil.MutuallyExclusive("specify only one of `--org` or `--env`", opts.OrgName != "", opts.EnvName != ""); err != nil {
+				return err
+			}
+
+			if err := cmdutil.MutuallyExclusive("specify only one of `--body`", opts.Body != ""); err != nil {
+				return err
+			}
+
+			if len(args) == 0 {
+				return cmdutil.FlagErrorf("must pass name argument")
+			} else {
+				opts.VariableName = args[0]
+			}
+
+			if cmd.Flags().Changed("visibility") {
+				if opts.OrgName == "" {
+					return cmdutil.FlagErrorf("`--visibility` is only supported with `--org`")
+				}
+
+				if opts.Visibility != shared.Selected && len(opts.RepositoryNames) > 0 {
+					return cmdutil.FlagErrorf("`--repos` is only supported with `--visibility=selected`")
+				}
+
+				if opts.Visibility == shared.Selected && len(opts.RepositoryNames) == 0 {
+					return cmdutil.FlagErrorf("`--repos` list required with `--visibility=selected`")
+				}
+			} else {
+				if len(opts.RepositoryNames) > 0 {
+					opts.Visibility = shared.Selected
+				}
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return createRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "Create `organization` variable")
+	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Create deployment `environment` variable")
+	cmdutil.StringEnumFlag(cmd, &opts.Visibility, "visibility", "v", shared.Private, []string{shared.All, shared.Private, shared.Selected}, "Create visibility for an organization variable")
+	cmd.Flags().StringSliceVarP(&opts.RepositoryNames, "repos", "r", []string{}, "List of `repositories` that can access an organization variable")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "The value for the variable (reads from standard input if not specified)")
+
+	return cmd
+}
+
+func createRun(opts *shared.PostPatchOptions) error {
+
+	c, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not create http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(c)
+	orgName := opts.OrgName
+	envName := opts.EnvName
+
+	var host string
+	var baseRepo ghrepo.Interface
+	if orgName == "" {
+		baseRepo, err = opts.BaseRepo()
+		if err != nil {
+			return err
+		}
+		host = baseRepo.RepoHost()
+	} else {
+		cfg, err := opts.Config()
+		if err != nil {
+			return err
+		}
+		host, _ = cfg.DefaultHost()
+	}
+	variables, err := shared.GetVariablesFromOptions(opts, client, host, false)
+	if err != nil {
+		return err
+	}
+
+	variableEntity, err := shared.GetVariableEntity(orgName, envName)
+	if err != nil {
+		return err
+	}
+
+	variableApp := shared.App(shared.Actions)
+	if err != nil || variableApp == shared.Unknown {
+		return err
+	}
+
+	if !shared.IsSupportedVariableEntity(variableApp, variableEntity) {
+		return fmt.Errorf("%s variables are not supported for %s", variableEntity, variableApp)
+	}
+
+	repoIdRes := shared.GetRepoIds(client, host, opts.OrgName, opts.RepositoryNames)
+	if repoIdRes.Err != nil {
+		return repoIdRes.Err
+	}
+
+	createc := make(chan createResult)
+	for variableKey, variable := range variables {
+		go func(variableKey string, variable shared.VariablePayload) {
+			var repoIds []int64
+			var visibility string
+			visibility = opts.Visibility
+			//cmd line opt overrides file
+			if len(repoIdRes.Ids) > 0 {
+				repoIds = repoIdRes.Ids
+			} else if variable.Visibility != "" {
+				visibility = variable.Visibility
+				repoIds = variable.Repositories
+			}
+			createc <- createVariable(opts, host, client, baseRepo, variableKey, variable.Value, visibility, repoIds, variableApp, variableEntity)
+		}(variableKey, variable)
+	}
+
+	err = nil
+	cs := opts.IO.ColorScheme()
+	for i := 0; i < len(variables); i++ {
+		result := <-createc
+		if result.err != nil {
+			err = multierror.Append(err, result.err)
+			continue
+		}
+		if result.value != "" {
+			fmt.Fprintln(opts.IO.Out, result.value)
+			continue
+		}
+		if !opts.IO.IsStdoutTTY() {
+			continue
+		}
+		target := orgName
+		if orgName == "" {
+			target = ghrepo.FullName(baseRepo)
+		}
+		fmt.Fprintf(opts.IO.Out, "%s Create %s variable %s for %s\n", cs.SuccessIcon(), variableApp.Title(), result.key, target)
+	}
+	return err
+}
+
+type createResult struct {
+	key   string
+	value string
+	err   error
+}
+
+func createVariable(opts *shared.PostPatchOptions, host string, client *api.Client, baseRepo ghrepo.Interface, variableKey, variableValue, visibility string, repositoryIDs []int64, app shared.App, entity shared.VariableEntity) (res createResult) {
+	orgName := opts.OrgName
+	envName := opts.EnvName
+	res.key = variableKey
+	var err error
+	switch entity {
+	case shared.Organization:
+		err = postOrgVariable(client, host, orgName, visibility, variableKey, variableValue, repositoryIDs, app)
+	case shared.Environment:
+		err = postEnvVariable(client, baseRepo, envName, variableKey, variableValue)
+	default:
+		err = postRepoVariable(client, baseRepo, variableKey, variableValue, app)
+	}
+	if err != nil {
+		res.err = fmt.Errorf("failed to create variable %q: %w", variableKey, err)
+		return
+	}
+	return
+}

--- a/pkg/cmd/variable/create/create_test.go
+++ b/pkg/cmd/variable/create/create_test.go
@@ -177,9 +177,8 @@ func Test_createRun_repo(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Actions",
-			opts: &shared.PostPatchOptions{
-			},
+			name:    "Actions",
+			opts:    &shared.PostPatchOptions{},
 			wantApp: "actions",
 			wantErr: false,
 		},
@@ -202,16 +201,16 @@ func Test_createRun_repo(t *testing.T) {
 				BaseRepo: func() (ghrepo.Interface, error) {
 					return ghrepo.FromFullName("owner/repo")
 				},
-				IO:             ios,
-				VariableName:   "cool_variable",
-				Body:           "a variable",
+				IO:           ios,
+				VariableName: "cool_variable",
+				Body:         "a variable",
 			}
 
 			err := createRun(opts)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
-			} else{
+			} else {
 				assert.NoError(t, err)
 			}
 
@@ -243,10 +242,10 @@ func Test_createRun_env(t *testing.T) {
 		BaseRepo: func() (ghrepo.Interface, error) {
 			return ghrepo.FromFullName("owner/repo")
 		},
-		EnvName:        "development",
-		IO:             ios,
-		VariableName:   "cool_variable",
-		Body:           "a variable",
+		EnvName:      "development",
+		IO:           ios,
+		VariableName: "cool_variable",
+		Body:         "a variable",
 	}
 
 	err := createRun(opts)

--- a/pkg/cmd/variable/create/create_test.go
+++ b/pkg/cmd/variable/create/create_test.go
@@ -1,0 +1,346 @@
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    shared.PostPatchOptions
+		stdinTTY bool
+		wantsErr bool
+	}{
+		{
+			name:     "invalid visibility",
+			cli:      "cool_variable --org coolOrg -v'mistyVeil'",
+			wantsErr: true,
+		},
+		{
+			name:     "invalid visibility",
+			cli:      "cool_variable --org coolOrg -v'selected'",
+			wantsErr: true,
+		},
+		{
+			name:     "repos with wrong vis",
+			cli:      "cool_variable --org coolOrg -v'private' -rcoolRepo",
+			wantsErr: true,
+		},
+		{
+			name:     "no name",
+			cli:      "",
+			wantsErr: true,
+		},
+		{
+			name:     "multiple names",
+			cli:      "cool_variable good_variable",
+			wantsErr: true,
+		},
+		{
+			name:     "visibility without org",
+			cli:      "cool_variable -vall",
+			wantsErr: true,
+		},
+		{
+			name: "repos without vis",
+			cli:  "cool_variable -bs --org coolOrg -rcoolRepo",
+			wants: shared.PostPatchOptions{
+				VariableName:    "cool_variable",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"coolRepo"},
+				Body:            "s",
+				OrgName:         "coolOrg",
+			},
+		},
+		{
+			name: "org with selected repo",
+			cli:  "-ocoolOrg -bs -vselected -rcoolRepo cool_variable",
+			wants: shared.PostPatchOptions{
+				VariableName:    "cool_variable",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"coolRepo"},
+				Body:            "s",
+				OrgName:         "coolOrg",
+			},
+		},
+		{
+			name: "org with selected repos",
+			cli:  `--org=coolOrg -bs -vselected -r="coolRepo,radRepo,goodRepo" cool_variable`,
+			wants: shared.PostPatchOptions{
+				VariableName:    "cool_variable",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"coolRepo", "goodRepo", "radRepo"},
+				Body:            "s",
+				OrgName:         "coolOrg",
+			},
+		},
+		{
+			name: "repo",
+			cli:  `cool_variable -b"a variable"`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.Private,
+				Body:         "a variable",
+				OrgName:      "",
+			},
+		},
+		{
+			name: "env",
+			cli:  `cool_variable -b"a variable" -eRelease`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.Private,
+				Body:         "a variable",
+				OrgName:      "",
+				EnvName:      "Release",
+			},
+		},
+		{
+			name: "vis all",
+			cli:  `cool_variable --org coolOrg -b"cool" -vall`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.All,
+				Body:         "cool",
+				OrgName:      "coolOrg",
+			},
+		},
+		{
+			name: "no store",
+			cli:  `cool_variable`,
+			wants: shared.PostPatchOptions{
+				VariableName: "cool_variable",
+				Visibility:   shared.Private,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			ios.SetStdinTTY(tt.stdinTTY)
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *shared.PostPatchOptions
+			cmd := NewCmdCreate(f, func(opts *shared.PostPatchOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.VariableName, gotOpts.VariableName)
+			assert.Equal(t, tt.wants.Body, gotOpts.Body)
+			assert.Equal(t, tt.wants.Visibility, gotOpts.Visibility)
+			assert.Equal(t, tt.wants.OrgName, gotOpts.OrgName)
+			assert.Equal(t, tt.wants.EnvName, gotOpts.EnvName)
+			assert.ElementsMatch(t, tt.wants.RepositoryNames, gotOpts.RepositoryNames)
+		})
+	}
+}
+
+func Test_createRun_repo(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *shared.PostPatchOptions
+		wantApp string
+		wantErr bool
+	}{
+		{
+			name: "Actions",
+			opts: &shared.PostPatchOptions{
+			},
+			wantApp: "actions",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+
+			reg.Register(httpmock.REST("POST", fmt.Sprintf("repositories/owner/repo/%s/variables", tt.wantApp)),
+				httpmock.StatusStringResponse(201, `{}`))
+
+			ios, _, _, _ := iostreams.Test()
+
+			opts := &shared.PostPatchOptions{
+				HttpClient: func() (*http.Client, error) {
+					return &http.Client{Transport: reg}, nil
+				},
+				Config: func() (config.Config, error) { return config.NewBlankConfig(), nil },
+				BaseRepo: func() (ghrepo.Interface, error) {
+					return ghrepo.FromFullName("owner/repo")
+				},
+				IO:             ios,
+				VariableName:   "cool_variable",
+				Body:           "a variable",
+				RandomOverride: fakeRandom,
+			}
+
+			err := createRun(opts)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			} else{
+				assert.NoError(t, err)
+			}
+
+			reg.Verify(t)
+
+			data, err := io.ReadAll(reg.Requests[0].Body)
+			assert.NoError(t, err)
+
+			var payload shared.VariablePayload
+			err = json.Unmarshal(data, &payload)
+			assert.NoError(t, err)
+			assert.Equal(t, payload.Value, "a variable")
+		})
+	}
+}
+
+func Test_createRun_env(t *testing.T) {
+	reg := &httpmock.Registry{}
+
+	reg.Register(httpmock.REST("POST", "repositories/owner/repo/environments/development/variables"), httpmock.StatusStringResponse(201, `{}`))
+
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &shared.PostPatchOptions{
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		Config: func() (config.Config, error) { return config.NewBlankConfig(), nil },
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.FromFullName("owner/repo")
+		},
+		EnvName:        "development",
+		IO:             ios,
+		VariableName:   "cool_variable",
+		Body:           "a variable",
+		RandomOverride: fakeRandom,
+	}
+
+	err := createRun(opts)
+	assert.NoError(t, err)
+
+	reg.Verify(t)
+
+	data, err := io.ReadAll(reg.Requests[0].Body)
+	assert.NoError(t, err)
+	var payload shared.VariablePayload
+	err = json.Unmarshal(data, &payload)
+	assert.NoError(t, err)
+	assert.Equal(t, payload.Value, "a variable")
+}
+
+func Test_createRun_org(t *testing.T) {
+	tests := []struct {
+		name             string
+		opts             *shared.PostPatchOptions
+		wantVisibility   shared.Visibility
+		wantRepositories []int64
+		wantApp          string
+	}{
+		{
+			name: "all vis",
+			opts: &shared.PostPatchOptions{
+				OrgName:    "UmbrellaCorporation",
+				Visibility: shared.All,
+			},
+			wantApp: "actions",
+		},
+		{
+			name: "selected visibility",
+			opts: &shared.PostPatchOptions{
+				OrgName:         "UmbrellaCorporation",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"birkin", "UmbrellaCorporation/wesker"},
+			},
+			wantRepositories: []int64{1, 2},
+			wantApp:          "actions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+
+			orgName := tt.opts.OrgName
+
+			reg.Register(httpmock.REST("POST",
+				fmt.Sprintf("orgs/%s/%s/variables", orgName, tt.wantApp)),
+				httpmock.StatusStringResponse(201, `{}`))
+
+			if len(tt.opts.RepositoryNames) > 0 {
+				reg.Register(httpmock.GraphQL(`query MapRepositoryNames\b`),
+					httpmock.StringResponse(`{"data":{"repo_0001":{"databaseId":1},"repo_0002":{"databaseId":2}}}`))
+			}
+
+			ios, _, _, _ := iostreams.Test()
+
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("owner/repo")
+			}
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.Config = func() (config.Config, error) {
+				return config.NewBlankConfig(), nil
+			}
+			tt.opts.IO = ios
+			tt.opts.VariableName = "org_variable"
+			tt.opts.Body = "a variable"
+			tt.opts.RandomOverride = fakeRandom
+
+			err := createRun(tt.opts)
+			assert.NoError(t, err)
+
+			reg.Verify(t)
+
+			data, err := io.ReadAll(reg.Requests[len(reg.Requests)-1].Body)
+			assert.NoError(t, err)
+			var payload shared.VariablePayload
+			err = json.Unmarshal(data, &payload)
+			assert.NoError(t, err)
+			assert.Equal(t, payload.Value, "a variable")
+			assert.Equal(t, payload.Name, tt.opts.VariableName)
+			assert.Equal(t, payload.Visibility, tt.opts.Visibility)
+			assert.ElementsMatch(t, payload.Repositories, tt.wantRepositories)
+		})
+	}
+}
+
+func fakeRandom() io.Reader {
+	return bytes.NewReader(bytes.Repeat([]byte{5}, 32))
+}

--- a/pkg/cmd/variable/create/create_test.go
+++ b/pkg/cmd/variable/create/create_test.go
@@ -205,7 +205,6 @@ func Test_createRun_repo(t *testing.T) {
 				IO:             ios,
 				VariableName:   "cool_variable",
 				Body:           "a variable",
-				RandomOverride: fakeRandom,
 			}
 
 			err := createRun(opts)
@@ -248,7 +247,6 @@ func Test_createRun_env(t *testing.T) {
 		IO:             ios,
 		VariableName:   "cool_variable",
 		Body:           "a variable",
-		RandomOverride: fakeRandom,
 	}
 
 	err := createRun(opts)
@@ -321,7 +319,6 @@ func Test_createRun_org(t *testing.T) {
 			tt.opts.IO = ios
 			tt.opts.VariableName = "org_variable"
 			tt.opts.Body = "a variable"
-			tt.opts.RandomOverride = fakeRandom
 
 			err := createRun(tt.opts)
 			assert.NoError(t, err)

--- a/pkg/cmd/variable/create/http.go
+++ b/pkg/cmd/variable/create/http.go
@@ -1,0 +1,51 @@
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+)
+
+func postVariable(client *api.Client, host, path string, payload interface{}) error {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to serialize: %w", err)
+	}
+	requestBody := bytes.NewReader(payloadBytes)
+
+	return client.REST(host, "POST", path, requestBody, nil)
+}
+
+func postOrgVariable(client *api.Client, host string, orgName, visibility, variableName, Value string, repositoryIDs []int64, app shared.App) error {
+	payload := shared.VariablePayload{
+		Name:         variableName,
+		Value:        Value,
+		Repositories: repositoryIDs,
+		Visibility:   visibility,
+	}
+	path := fmt.Sprintf(`orgs/%s/%s/variables`, orgName, app)
+
+	return postVariable(client, host, path, payload)
+}
+
+func postEnvVariable(client *api.Client, repo ghrepo.Interface, envName string, variableName, Value string) error {
+	payload := shared.VariablePayload{
+		Name:  variableName,
+		Value: Value,
+	}
+	path := fmt.Sprintf(`repositories/%s/environments/%s/variables`, ghrepo.FullName(repo), envName)
+	return postVariable(client, repo.RepoHost(), path, payload)
+}
+
+func postRepoVariable(client *api.Client, repo ghrepo.Interface, variableName, Value string, app shared.App) error {
+	payload := shared.VariablePayload{
+		Name:  variableName,
+		Value: Value,
+	}
+	path := fmt.Sprintf(`repositories/%s/%s/variables`, ghrepo.FullName(repo), app)
+	return postVariable(client, repo.RepoHost(), path, payload)
+}

--- a/pkg/cmd/variable/delete/delete.go
+++ b/pkg/cmd/variable/delete/delete.go
@@ -1,0 +1,144 @@
+package delete
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type DeleteOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	Config     func() (config.Config, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	VariableName string
+	OrgName      string
+	EnvName      string
+	Application  string
+}
+
+func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Command {
+	opts := &DeleteOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete <variable-name>",
+		Short: "Delete variables",
+		Long: heredoc.Doc(`
+			Delete a variable on one of the following levels:
+			- repository (default): available to Actions runs in a repository
+			- environment: available to Actions runs for a deployment environment in a repository
+			- organization: available to Actions runs within an organization
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			if err := cmdutil.MutuallyExclusive("specify only one of `--org` or `--env`", opts.OrgName != "", opts.EnvName != ""); err != nil {
+				return err
+			}
+
+			opts.VariableName = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return removeRun(opts)
+		},
+		Aliases: []string{
+			"remove",
+		},
+	}
+	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "Delete a variable for an organization")
+	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Delete a variable for an environment")
+
+	return cmd
+}
+
+func removeRun(opts *DeleteOptions) error {
+	c, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not create http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(c)
+
+	orgName := opts.OrgName
+	envName := opts.EnvName
+
+	variableEntity, err := shared.GetVariableEntity(orgName, envName)
+	if err != nil {
+		return err
+	}
+
+	variableApp := shared.App(shared.Actions)
+	if err != nil || variableApp == shared.Unknown {
+		return err
+	}
+
+	if !shared.IsSupportedVariableEntity(variableApp, variableEntity) {
+		return fmt.Errorf("%s variables are not supported for %s", variableEntity, variableApp)
+	}
+
+	var baseRepo ghrepo.Interface
+	if variableEntity == shared.Repository || variableEntity == shared.Environment {
+		baseRepo, err = opts.BaseRepo()
+		if err != nil {
+			return err
+		}
+	}
+
+	var path string
+	switch variableEntity {
+	case shared.Organization:
+		path = fmt.Sprintf(`orgs/%s/%s/variables/%s`, orgName, variableApp, opts.VariableName)
+	case shared.Environment:
+		path = fmt.Sprintf(`repos/%s/environments/%s/variables/%s`, ghrepo.FullName(baseRepo), envName, opts.VariableName)
+	case shared.Repository:
+		path = fmt.Sprintf(`repos/%s/%s/variables/%s`, ghrepo.FullName(baseRepo), variableApp, opts.VariableName)
+	}
+
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	host, _ := cfg.DefaultHost()
+
+	err = client.REST(host, "DELETE", path, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete variable %s: %w", opts.VariableName, err)
+	}
+
+	if opts.IO.IsStdoutTTY() {
+		var target string
+		switch variableEntity {
+		case shared.Organization:
+			target = orgName
+		case shared.Repository, shared.Environment:
+			target = ghrepo.FullName(baseRepo)
+		}
+
+		cs := opts.IO.ColorScheme()
+		if envName != "" {
+			fmt.Fprintf(opts.IO.Out, "%s Deleted variable %s from %s environment on %s\n", cs.SuccessIconWithColor(cs.Red), opts.VariableName, envName, target)
+		} else {
+			fmt.Fprintf(opts.IO.Out, "%s Deleted %s variable %s from %s\n", cs.SuccessIconWithColor(cs.Red), variableApp.Title(), opts.VariableName, target)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/variable/delete/delete_test.go
+++ b/pkg/cmd/variable/delete/delete_test.go
@@ -1,0 +1,213 @@
+package delete
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdDelete(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    DeleteOptions
+		wantsErr bool
+	}{
+		{
+			name:     "no args",
+			wantsErr: true,
+		},
+		{
+			name: "repo",
+			cli:  "cool",
+			wants: DeleteOptions{
+				VariableName: "cool",
+			},
+		},
+		{
+			name: "org",
+			cli:  "cool --org anOrg",
+			wants: DeleteOptions{
+				VariableName: "cool",
+				OrgName:    "anOrg",
+			},
+		},
+		{
+			name: "env",
+			cli:  "cool --env anEnv",
+			wants: DeleteOptions{
+				VariableName: "cool",
+				EnvName:    "anEnv",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *DeleteOptions
+			cmd := NewCmdDelete(f, func(opts *DeleteOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.VariableName, gotOpts.VariableName)
+			assert.Equal(t, tt.wants.OrgName, gotOpts.OrgName)
+			assert.Equal(t, tt.wants.EnvName, gotOpts.EnvName)
+		})
+	}
+
+}
+
+func Test_removeRun_repo(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     *DeleteOptions
+		wantPath string
+		wantErr bool
+	}{
+		{
+			name: "Actions",
+			opts: &DeleteOptions{
+				Application: "actions",
+				VariableName:  "cool_variable",
+			},
+			wantPath: "repos/owner/repo/actions/variables/cool_variable",
+		},
+	}
+
+	for _, tt := range tests {
+		reg := &httpmock.Registry{}
+
+		reg.Register(
+			httpmock.REST("DELETE", tt.wantPath),
+			httpmock.StatusStringResponse(204, "No Content"))
+
+		ios, _, _, _ := iostreams.Test()
+
+		tt.opts.IO = ios
+		tt.opts.HttpClient = func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		}
+		tt.opts.Config = func() (config.Config, error) {
+			return config.NewBlankConfig(), nil
+		}
+		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+			return ghrepo.FromFullName("owner/repo")
+		}
+
+		err := removeRun(tt.opts)
+		if tt.wantErr{
+			assert.Error(t, err)
+			return
+		} else {
+			assert.NoError(t, err)
+		}
+		reg.Verify(t)
+	}
+}
+
+func Test_removeRun_env(t *testing.T) {
+	reg := &httpmock.Registry{}
+
+	reg.Register(
+		httpmock.REST("DELETE", "repos/owner/repo/environments/development/variables/cool_variable"),
+		httpmock.StatusStringResponse(204, "No Content"))
+
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &DeleteOptions{
+		IO: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		Config: func() (config.Config, error) {
+			return config.NewBlankConfig(), nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.FromFullName("owner/repo")
+		},
+		VariableName: "cool_variable",
+		EnvName:    "development",
+		Application: "actions",
+	}
+
+	err := removeRun(opts)
+	assert.NoError(t, err)
+
+	reg.Verify(t)
+}
+
+func Test_removeRun_org(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     *DeleteOptions
+		wantPath string
+	}{
+		{
+			name: "org",
+			opts: &DeleteOptions{
+				OrgName: "UmbrellaCorporation",
+				Application: "actions",
+			},
+			wantPath: "orgs/UmbrellaCorporation/actions/variables/tVirus",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+
+			reg.Register(
+				httpmock.REST("DELETE", tt.wantPath),
+				httpmock.StatusStringResponse(204, "No Content"))
+
+			ios, _, _, _ := iostreams.Test()
+
+			tt.opts.Config = func() (config.Config, error) {
+				return config.NewBlankConfig(), nil
+			}
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("owner/repo")
+			}
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.IO = ios
+			tt.opts.VariableName = "tVirus"
+
+			err := removeRun(tt.opts)
+			assert.NoError(t, err)
+
+			reg.Verify(t)
+
+		})
+	}
+
+}

--- a/pkg/cmd/variable/list/list.go
+++ b/pkg/cmd/variable/list/list.go
@@ -1,0 +1,122 @@
+package list
+
+import (
+	"fmt"
+
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+	"github.com/cli/cli/v2/internal/tableprinter"
+)
+
+func NewCmdList(f *cmdutil.Factory, runF func(*shared.ListOptions) error) *cobra.Command {
+	opts := &shared.ListOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List variables",
+		Long: heredoc.Doc(`
+			List variables on one of the following levels:
+			- repository (default): available to Actions runs in a repository
+			- environment: available to Actions runs for a deployment environment in a repository
+			- organization: available to Actions runs within an organization
+		`),
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
+
+			if err := cmdutil.MutuallyExclusive("specify only one of `--org` or `--env`", opts.OrgName != "", opts.EnvName != ""); err != nil {
+				return err
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return listRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "List variables for an organization")
+	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "List variables for an environment")
+	cmd.Flags().IntVar(&opts.Page, "page", 1, "Page Number")
+	cmd.Flags().IntVar(&opts.PerPage, "perpage", 10, "Maximum variable count")
+	cmd.Flags().StringVarP(&opts.Name, "name", "n", "", "Name of a particular variable")
+
+	return cmd
+}
+
+func listRun(opts *shared.ListOptions) error {
+
+	showSelectedRepoInfo := opts.IO.IsStdoutTTY()
+	variables, err := shared.GetVariablesForList(opts, showSelectedRepoInfo)
+	if err != nil {
+		return err
+	}
+
+	if len(variables) == 0 {
+		return cmdutil.NewNoResultsError("no variables found")
+	}
+
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
+	}
+
+	table := tableprinter.New(opts.IO)
+	if opts.OrgName != "" {
+		table.HeaderRow("NAME", "VALUE", "UPDATED AT", "VISIBILITY")
+	} else {
+		table.HeaderRow("NAME", "VALUE", "UPDATED AT")
+	}
+	for _, variable := range variables {
+		table.AddField(variable.Name)
+		table.AddField(variable.Value)
+		updatedAt := variable.UpdatedAt.Format("2006-01-02")
+		if opts.IO.IsStdoutTTY() {
+			updatedAt = fmt.Sprintf("Updated %s", updatedAt)
+		}
+		table.AddField(updatedAt)
+		if variable.Visibility != "" {
+			if showSelectedRepoInfo {
+				table.AddField(fmtVisibility(*variable))
+			} else {
+				table.AddField(strings.ToUpper(string(variable.Visibility)), nil, nil)
+			}
+		}
+		table.EndRow()
+	}
+
+	err = table.Render()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fmtVisibility(s shared.Variable) string {
+	switch s.Visibility {
+	case shared.All:
+		return "Visible to all repositories"
+	case shared.Private:
+		return "Visible to private repositories"
+	case shared.Selected:
+		if s.NumSelectedRepos == 1 {
+			return "Visible to 1 selected repository"
+		} else {
+			return fmt.Sprintf("Visible to %d selected repositories", s.NumSelectedRepos)
+		}
+	}
+	return ""
+}

--- a/pkg/cmd/variable/list/list_test.go
+++ b/pkg/cmd/variable/list/list_test.go
@@ -1,0 +1,249 @@
+package list
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/test"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewCmdList(t *testing.T) {
+	tests := []struct {
+		name  string
+		cli   string
+		wants shared.ListOptions
+	}{
+		{
+			name: "repo",
+			cli:  "",
+			wants: shared.ListOptions{
+				OrgName: "",
+			},
+		},
+		{
+			name: "org",
+			cli:  "-oUmbrellaCorporation",
+			wants: shared.ListOptions{
+				OrgName: "UmbrellaCorporation",
+				Page: 1,
+				PerPage: 5,
+			},
+		},
+		{
+			name: "env",
+			cli:  "-eDevelopment",
+			wants: shared.ListOptions{
+				EnvName: "Development",
+				Page: 1,
+				PerPage: 2,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts *shared.ListOptions
+			cmd := NewCmdList(f, func(opts *shared.ListOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.OrgName, gotOpts.OrgName)
+			assert.Equal(t, tt.wants.EnvName, gotOpts.EnvName)
+		})
+	}
+}
+
+func Test_listRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		tty     bool
+		opts    *shared.ListOptions
+		wantOut []string
+	}{
+		{
+			name: "repo tty",
+			tty:  true,
+			opts: &shared.ListOptions{ },
+			wantOut: []string{
+				"VARIABLE_ONE.*Updated 1988-10-11",
+				"VARIABLE_TWO.*Updated 2020-12-04",
+				"VARIABLE_THREE.*Updated 1975-11-30",
+			},
+		},
+		{
+			name: "repo not tty",
+			tty:  false,
+			opts: &shared.ListOptions{ },
+			wantOut: []string{
+				"VARIABLE_ONE\tone\t1988-10-11",
+				"VARIABLE_TWO\ttwo\t2020-12-04",
+				"VARIABLE_THREE\tthree\t1975-11-30",
+			},
+		},
+		{
+			name: "org tty",
+			tty:  true,
+			opts: &shared.ListOptions{
+				OrgName: "UmbrellaCorporation",
+			},
+			wantOut: []string{
+				"VARIABLE_ONE.*Updated 1988-10-11.*Visible to all repositories",
+				"VARIABLE_TWO.*Updated 2020-12-04.*Visible to private repositories",
+				"VARIABLE_THREE.*Updated 1975-11-30.*Visible to 2 selected repositories",
+			},
+		},
+		{
+			name: "org not tty",
+			tty:  false,
+			opts: &shared.ListOptions{
+				OrgName: "UmbrellaCorporation",
+			},
+			wantOut: []string{
+				"VARIABLE_ONE\torg1\t1988-10-11\tALL",
+				"VARIABLE_TWO\torg2\t2020-12-04\tPRIVATE",
+				"VARIABLE_THREE\torg3\t1975-11-30\tSELECTED",
+			},
+		},
+		{
+			name: "env tty",
+			tty:  true,
+			opts: &shared.ListOptions{
+				EnvName: "Development",
+			},
+			wantOut: []string{
+				"VARIABLE_ONE.*Updated 1988-10-11",
+				"VARIABLE_TWO.*Updated 2020-12-04",
+				"VARIABLE_THREE.*Updated 1975-11-30",
+			},
+		},
+		{
+			name: "env not tty",
+			tty:  false,
+			opts: &shared.ListOptions{
+				EnvName: "Development",
+			},
+			wantOut: []string{
+				"VARIABLE_ONE\tone\t1988-10-11",
+				"VARIABLE_TWO\ttwo\t2020-12-04",
+				"VARIABLE_THREE\tthree\t1975-11-30",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+
+			path := "repositories/owner/repo/actions/variables"
+			if tt.opts.EnvName != "" {
+				path = fmt.Sprintf("repositories/owner/repo/environments/%s/variables", tt.opts.EnvName)
+			}
+
+			t0, _ := time.Parse("2006-01-02", "1988-10-11")
+			t1, _ := time.Parse("2006-01-02", "2020-12-04")
+			t2, _ := time.Parse("2006-01-02", "1975-11-30")
+			payload := shared.VariablesPayload{}
+			payload.Variables = []*shared.Variable{
+				{
+					Name:      "VARIABLE_ONE",
+					Value:     "one",
+					UpdatedAt: t0,
+				},
+				{
+					Name:      "VARIABLE_TWO",
+					Value:     "two",
+					UpdatedAt: t1,
+				},
+				{
+					Name:      "VARIABLE_THREE",
+					Value:     "three",
+					UpdatedAt: t2,
+				},
+			}
+			if tt.opts.OrgName != "" {
+				payload.Variables = []*shared.Variable{
+					{
+						Name:       "VARIABLE_ONE",
+						UpdatedAt:  t0,
+						Value:      "org1",
+						Visibility: shared.All,
+					},
+					{
+						Name:       "VARIABLE_TWO",
+						UpdatedAt:  t1,
+						Value:      "org2",
+						Visibility: shared.Private,
+					},
+					{
+						Name:             "VARIABLE_THREE",
+						UpdatedAt:        t2,
+						Value: 			  "org3",
+						Visibility:       shared.Selected,
+						SelectedReposURL: fmt.Sprintf("https://api.github.com/orgs/%s/actions/variables/VARIABLE_THREE/repositories", tt.opts.OrgName),
+					},
+				}
+				path = fmt.Sprintf("orgs/%s/actions/variables", tt.opts.OrgName)
+
+				if tt.tty {
+					reg.Register(
+						httpmock.REST("GET", fmt.Sprintf("orgs/%s/actions/variables/VARIABLE_THREE/repositories", tt.opts.OrgName)),
+						httpmock.JSONResponse(struct {
+							TotalCount int `json:"total_count"`
+						}{2}))
+				}
+			}
+
+			reg.Register(httpmock.REST("GET", path), httpmock.JSONResponse(payload))
+
+			ios, _, stdout, _ := iostreams.Test()
+
+			ios.SetStdoutTTY(tt.tty)
+
+			tt.opts.IO = ios
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("owner/repo")
+			}
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.Config = func() (config.Config, error) {
+				return config.NewBlankConfig(), nil
+			}
+
+		    err := listRun(tt.opts)
+			assert.NoError(t, err)
+
+			reg.Verify(t)
+
+			//nolint:staticcheck // prefer exact matchers over ExpectLines
+			test.ExpectLines(t, stdout.String(), tt.wantOut...)
+		})
+	}
+}

--- a/pkg/cmd/variable/shared/shared.go
+++ b/pkg/cmd/variable/shared/shared.go
@@ -69,8 +69,6 @@ type PostPatchOptions struct {
 	Config     func() (config.Config, error)
 	BaseRepo   func() (ghrepo.Interface, error)
 
-	RandomOverride func() io.Reader
-
 	VariableName    string
 	OrgName         string
 	EnvName         string

--- a/pkg/cmd/variable/shared/shared.go
+++ b/pkg/cmd/variable/shared/shared.go
@@ -56,7 +56,6 @@ type VariablePayload struct {
 	Repositories []int64 `json:"selected_repository_ids,omitempty"`
 }
 
-
 type repoNamesResult struct {
 	Ids []int64
 	Err error

--- a/pkg/cmd/variable/shared/shared.go
+++ b/pkg/cmd/variable/shared/shared.go
@@ -1,0 +1,380 @@
+package shared
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/text"
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+type Visibility string
+
+const (
+	All      = "all"
+	Private  = "private"
+	Selected = "selected"
+)
+
+type App string
+
+const (
+	Actions = "actions"
+	Unknown = "unknown"
+)
+
+func (app App) String() string {
+	return string(app)
+}
+
+func (app App) Title() string {
+	return text.Title(app.String())
+}
+
+type VariableEntity string
+
+const (
+	Repository   = "repository"
+	Organization = "organization"
+	Environment  = "environment"
+)
+
+type VariablePayload struct {
+	Name         string  `json:"name,omitempty"`
+	Value        string  `json:"value,omitempty"`
+	Visibility   string  `json:"visibility,omitempty"`
+	Repositories []int64 `json:"selected_repository_ids,omitempty"`
+}
+
+
+type repoNamesResult struct {
+	Ids []int64
+	Err error
+}
+
+type PostPatchOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	Config     func() (config.Config, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	RandomOverride func() io.Reader
+
+	VariableName    string
+	OrgName         string
+	EnvName         string
+	Body            string
+	Visibility      string
+	RepositoryNames []string
+	Prompter        iprompter
+}
+
+type ListOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	Config     func() (config.Config, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	OrgName string
+	EnvName string
+	Page    int
+	PerPage int
+	Name    string
+}
+
+type Variable struct {
+	Name             string     `json:"name"`
+	Value            string     `json:"value"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	Visibility       Visibility `json:"visibility"`
+	SelectedReposURL string     `json:"selected_repositories_url"`
+	NumSelectedRepos int
+}
+type VariablesPayload struct {
+	Variables []*Variable
+}
+
+type Repo struct {
+	Name string `json: "name"`
+}
+
+type SelectedRepos struct {
+	Repositories []*Repo
+}
+
+type httpClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type iprompter interface {
+	Input(string, string) (string, error)
+	Select(string, string, []string) (int, error)
+	Confirm(string, bool) (bool, error)
+}
+
+func GetVariableEntity(orgName, envName string) (VariableEntity, error) {
+	orgSet := orgName != ""
+	envSet := envName != ""
+
+	if orgSet && envSet {
+		return "", errors.New("cannot specify multiple variable entities")
+	}
+
+	if orgSet {
+		return Organization, nil
+	}
+	if envSet {
+		return Environment, nil
+	}
+	return Repository, nil
+}
+
+func IsSupportedVariableEntity(app App, entity VariableEntity) bool {
+	switch app {
+	case Actions:
+		return entity == Repository || entity == Organization || entity == Environment
+	default:
+		return false
+	}
+}
+
+// This does similar logic to `api.RepoNetwork`, but without the overfetching.
+func MapRepoToID(client *api.Client, host string, repositories []ghrepo.Interface) ([]int64, error) {
+	queries := make([]string, 0, len(repositories))
+	for i, repo := range repositories {
+		queries = append(queries, fmt.Sprintf(`
+			repo_%03d: repository(owner: %q, name: %q) {
+				databaseId
+			}
+		`, i, repo.RepoOwner(), repo.RepoName()))
+	}
+
+	query := fmt.Sprintf(`query MapRepositoryNames { %s }`, strings.Join(queries, ""))
+
+	graphqlResult := make(map[string]*struct {
+		DatabaseID int64 `json:"databaseId"`
+	})
+
+	if err := client.GraphQL(host, query, nil, &graphqlResult); err != nil {
+		return nil, fmt.Errorf("failed to look up repositories: %w", err)
+	}
+
+	repoKeys := make([]string, 0, len(repositories))
+	for k := range graphqlResult {
+		repoKeys = append(repoKeys, k)
+	}
+	sort.Strings(repoKeys)
+
+	result := make([]int64, len(repositories))
+	for i, k := range repoKeys {
+		result[i] = graphqlResult[k].DatabaseID
+	}
+	return result, nil
+}
+
+func getCurrentSelectedRepos(client httpClient, url string) string {
+	var selectedRepositories SelectedRepos
+	err := apiGet(client, url, &selectedRepositories)
+	if err != nil {
+		return ""
+	}
+	names := make([]string, 0)
+	for _, repo := range selectedRepositories.Repositories {
+		names = append(names, repo.Name)
+	}
+	return strings.Join(names, ",")
+}
+
+func MapRepoNamesToIDs(client *api.Client, host, defaultOwner string, repositoryNames []string) ([]int64, error) {
+	repos := make([]ghrepo.Interface, 0, len(repositoryNames))
+	for _, repositoryName := range repositoryNames {
+		var repo ghrepo.Interface
+		if strings.Contains(repositoryName, "/") || defaultOwner == "" {
+			var err error
+			repo, err = ghrepo.FromFullNameWithHost(repositoryName, host)
+			if err != nil {
+				return nil, fmt.Errorf("invalid repository name")
+			}
+		} else {
+			repo = ghrepo.NewWithHost(defaultOwner, repositoryName, host)
+		}
+		repos = append(repos, repo)
+	}
+	repositoryIDs, err := MapRepoToID(client, host, repos)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up IDs for repositories %v: %w", repositoryNames, err)
+	}
+	return repositoryIDs, nil
+}
+
+func GetRepoIds(client *api.Client, host, orgName string, repoNames []string) repoNamesResult {
+	if len(repoNames) == 0 {
+		return repoNamesResult{}
+	}
+	repositoryIDs, err := MapRepoNamesToIDs(client, host, orgName, repoNames)
+	return repoNamesResult{
+		Ids: repositoryIDs,
+		Err: err,
+	}
+}
+
+func GetVariablesFromOptions(opts *PostPatchOptions, client *api.Client, host string, isUpdate bool) (map[string]VariablePayload, error) {
+	variables := make(map[string]VariablePayload)
+	values, err := getBody(opts, client, host, isUpdate)
+	if err != nil {
+		return nil, fmt.Errorf("did not understand variable body: %w", err)
+	}
+	variables[opts.VariableName] = values
+	return variables, nil
+}
+
+func getVarFromRow(opts *PostPatchOptions, client *api.Client, host string, row []string, isUpdate bool) (VariablePayload, error) {
+	rowLength := len(row)
+	index := 1
+	if rowLength < 2 {
+		return VariablePayload{}, fmt.Errorf("less than 2 records in a row in file")
+	}
+	if rowLength > 3 && opts.OrgName == "" {
+		return VariablePayload{}, fmt.Errorf("more than 3 vals in a row in file for non org variable %s", row[0])
+	}
+
+	var variable VariablePayload
+	variable.Value = row[index]
+	index++
+	if isUpdate {
+		if rowLength >= 3 && len(row[index]) > 0 {
+			variable.Name = row[index]
+		} else {
+			variable.Name = row[0]
+		}
+		index++
+	} else {
+		variable.Name = row[0]
+	}
+	if opts.OrgName != "" {
+		if !isUpdate && rowLength >= 3 {
+			variable.Visibility = row[index]
+		} else if rowLength >= 4 {
+			variable.Visibility = row[index]
+		}
+		index++
+		if variable.Visibility == Selected {
+			if rowLength < 5 {
+				// do not exit here as repositoryNames in opts may have the info.
+				log.Printf("selected visibility with no repos mentioned for variable %s", row[0])
+			}
+			repoIdRes := GetRepoIds(client, host, opts.OrgName, row[index:])
+			if repoIdRes.Err != nil {
+				return VariablePayload{}, repoIdRes.Err
+			}
+			variable.Repositories = repoIdRes.Ids
+		}
+	}
+	return variable, nil
+}
+
+func getBody(opts *PostPatchOptions, client *api.Client, host string, isUpdate bool) (VariablePayload, error) {
+	if opts.Body != "" {
+		return getVarFromRow(opts, client, host, strings.Split(opts.VariableName+","+string(opts.Body), ","), isUpdate)
+	}
+
+	values := make([]string, 0)
+	if opts.IO.CanPrompt() {
+		var currentVar Variable
+		values = append(values, opts.VariableName)
+		data, err := opts.Prompter.Input("Value", currentVar.Value)
+		if err != nil {
+			return VariablePayload{}, err
+		}
+		values = append(values, data)
+		if isUpdate {
+			data, err = opts.Prompter.Input("New name", currentVar.Name)
+			if err != nil {
+				return VariablePayload{}, err
+			}
+			values = append(values, data)
+		}
+
+		if opts.OrgName != "" {
+			data, err = opts.Prompter.Input("Visibility", string(currentVar.Visibility))
+			if err != nil {
+				return VariablePayload{}, err
+			}
+			values = append(values, data)
+
+			if data == Selected {
+				data, err = opts.Prompter.Input("Repos(comma separated)", getCurrentSelectedRepos(client.HTTP(), currentVar.SelectedReposURL))
+				if err != nil {
+					return VariablePayload{}, err
+				}
+				values = append(values, strings.Split(data, ",")...)
+			}
+		}
+
+		fmt.Fprintln(opts.IO.Out)
+		return getVarFromRow(opts, client, host, values, isUpdate)
+	}
+
+	body, err := io.ReadAll(opts.IO.In)
+	if err != nil {
+		return VariablePayload{}, fmt.Errorf("failed to read from standard input: %w", err)
+	}
+
+	return getVarFromRow(opts, client, host, strings.Split(opts.VariableName+","+string(bytes.TrimRight(body, "\r\n")), ","), isUpdate)
+}
+
+
+func apiGet(client httpClient, url string, data interface{}) error {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 299 {
+		return api.HandleHTTPError(resp)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getSelectedRepositoryInformation(client httpClient, variables []*Variable) error {
+	type responseData struct {
+		TotalCount int `json:"total_count"`
+	}
+
+	for _, variable := range variables {
+		if variable.SelectedReposURL == "" {
+			continue
+		}
+		var result responseData
+		if err := apiGet(client, variable.SelectedReposURL, &result); err != nil {
+			return fmt.Errorf("failed determining selected repositories for %s: %w", variable.Name, err)
+		}
+		variable.NumSelectedRepos = result.TotalCount
+	}
+
+	return nil
+}

--- a/pkg/cmd/variable/shared/shared_test.go
+++ b/pkg/cmd/variable/shared/shared_test.go
@@ -35,7 +35,6 @@ func Test_getBodyPrompt(t *testing.T) {
 		},
 		IO:             ios,
 		Body:           "a variable",
-		RandomOverride: fakeRandom,
 	}
 	httpClient, _ := opts.HttpClient()
 	apiClient := api.NewClientFromHTTP(httpClient)
@@ -168,7 +167,6 @@ func Test_getBody(t *testing.T) {
 				IO:             ios,
 				VariableName:   "VARNAME",
 				Body:           "a variable",
-				RandomOverride: fakeRandom,
 			}
 			httpClient, _ := opts.HttpClient()
 			apiClient := api.NewClientFromHTTP(httpClient)

--- a/pkg/cmd/variable/shared/shared_test.go
+++ b/pkg/cmd/variable/shared/shared_test.go
@@ -33,8 +33,8 @@ func Test_getBodyPrompt(t *testing.T) {
 		BaseRepo: func() (ghrepo.Interface, error) {
 			return ghrepo.FromFullName("owner/repo")
 		},
-		IO:             ios,
-		Body:           "a variable",
+		IO:   ios,
+		Body: "a variable",
 	}
 	httpClient, _ := opts.HttpClient()
 	apiClient := api.NewClientFromHTTP(httpClient)
@@ -164,9 +164,9 @@ func Test_getBody(t *testing.T) {
 				BaseRepo: func() (ghrepo.Interface, error) {
 					return ghrepo.FromFullName("owner/repo")
 				},
-				IO:             ios,
-				VariableName:   "VARNAME",
-				Body:           "a variable",
+				IO:           ios,
+				VariableName: "VARNAME",
+				Body:         "a variable",
 			}
 			httpClient, _ := opts.HttpClient()
 			apiClient := api.NewClientFromHTTP(httpClient)
@@ -188,4 +188,3 @@ func (c testClient) Do(req *http.Request) (*http.Response, error) {
 func fakeRandom() io.Reader {
 	return bytes.NewReader(bytes.Repeat([]byte{5}, 32))
 }
-

--- a/pkg/cmd/variable/shared/shared_test.go
+++ b/pkg/cmd/variable/shared/shared_test.go
@@ -1,0 +1,193 @@
+package shared
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getBodyPrompt(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	ios.SetStdinTTY(true)
+	ios.SetStdoutTTY(true)
+
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	opts := &PostPatchOptions{
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		Config: func() (config.Config, error) {
+			return config.NewBlankConfig(), nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.FromFullName("owner/repo")
+		},
+		IO:             ios,
+		Body:           "a variable",
+		RandomOverride: fakeRandom,
+	}
+	httpClient, _ := opts.HttpClient()
+	apiClient := api.NewClientFromHTTP(httpClient)
+
+	body, err := getBody(opts, apiClient, "owner/repo", false)
+	assert.NoError(t, err)
+	assert.Equal(t, body.Value, "a variable")
+}
+
+func TestGetVariableEntity(t *testing.T) {
+	tests := []struct {
+		name    string
+		orgName string
+		envName string
+		want    VariableEntity
+		wantErr bool
+	}{
+		{
+			name:    "org",
+			orgName: "myOrg",
+			want:    Organization,
+		},
+		{
+			name:    "env",
+			envName: "myEnv",
+			want:    Environment,
+		},
+		{
+			name: "defaults to repo",
+			want: Repository,
+		},
+		{
+			name:    "Errors if both org and env are set",
+			orgName: "myOrg",
+			envName: "myEnv",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entity, err := GetVariableEntity(tt.orgName, tt.envName)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, entity)
+			}
+		})
+	}
+}
+
+func TestIsSupportedVariableEntity(t *testing.T) {
+	tests := []struct {
+		name                string
+		app                 App
+		supportedEntities   []VariableEntity
+		unsupportedEntities []VariableEntity
+	}{
+		{
+			name: "Actions",
+			app:  Actions,
+			supportedEntities: []VariableEntity{
+				Repository,
+				Organization,
+				Environment,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, entity := range tt.supportedEntities {
+				assert.True(t, IsSupportedVariableEntity(tt.app, entity))
+			}
+
+			for _, entity := range tt.unsupportedEntities {
+				assert.False(t, IsSupportedVariableEntity(tt.app, entity))
+			}
+		})
+	}
+}
+
+func Test_getBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		bodyArg string
+		want    string
+		stdin   string
+	}{
+		{
+			name:    "literal value",
+			bodyArg: "a variable",
+			want:    "a variable",
+		},
+		{
+			name:  "from stdin",
+			want:  "a variable",
+			stdin: "a variable",
+		},
+		{
+			name:  "from stdin with trailing newline character",
+			want:  "a variable",
+			stdin: "a variable\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, stdin, _, _ := iostreams.Test()
+
+			ios.SetStdinTTY(false)
+
+			_, err := stdin.WriteString(tt.stdin)
+			assert.NoError(t, err)
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			opts := &PostPatchOptions{
+				HttpClient: func() (*http.Client, error) {
+					return &http.Client{Transport: reg}, nil
+				},
+				Config: func() (config.Config, error) {
+					return config.NewBlankConfig(), nil
+				},
+				BaseRepo: func() (ghrepo.Interface, error) {
+					return ghrepo.FromFullName("owner/repo")
+				},
+				IO:             ios,
+				VariableName:   "VARNAME",
+				Body:           "a variable",
+				RandomOverride: fakeRandom,
+			}
+			httpClient, _ := opts.HttpClient()
+			apiClient := api.NewClientFromHTTP(httpClient)
+
+			body, err := getBody(opts, apiClient, "owner/repo", false)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.want, body.Value)
+		})
+	}
+}
+
+type testClient func(*http.Request) (*http.Response, error)
+
+func (c testClient) Do(req *http.Request) (*http.Response, error) {
+	return c(req)
+}
+
+func fakeRandom() io.Reader {
+	return bytes.NewReader(bytes.Repeat([]byte{5}, 32))
+}
+

--- a/pkg/cmd/variable/update/http.go
+++ b/pkg/cmd/variable/update/http.go
@@ -1,0 +1,51 @@
+package update
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
+)
+
+func patchVariable(client *api.Client, host, path string, payload interface{}) error {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to serialize: %w", err)
+	}
+	requestBody := bytes.NewReader(payloadBytes)
+
+	return client.REST(host, "PATCH", path, requestBody, nil)
+}
+
+func patchOrgVariable(client *api.Client, host string, orgName, visibility, variableName, updatedVariableName, value string, repositoryIDs []int64, app shared.App) error {
+	payload := shared.VariablePayload{
+		Name:         updatedVariableName,
+		Value:        value,
+		Repositories: repositoryIDs,
+		Visibility:   visibility,
+	}
+	path := fmt.Sprintf(`orgs/%s/%s/variables/%s`, orgName, app, variableName)
+
+	return patchVariable(client, host, path, payload)
+}
+
+func patchEnvVariable(client *api.Client, repo ghrepo.Interface, envName string, variableName, updatedVariableName, value string) error {
+	payload := shared.VariablePayload{
+		Name:  updatedVariableName,
+		Value: value,
+	}
+	path := fmt.Sprintf(`repos/%s/environments/%s/variables/%s`, ghrepo.FullName(repo), envName, variableName)
+	return patchVariable(client, repo.RepoHost(), path, payload)
+}
+
+func patchRepoVariable(client *api.Client, repo ghrepo.Interface, variableName, updatedVariableName, value string, app shared.App) error {
+	payload := shared.VariablePayload{
+		Name:  updatedVariableName,
+		Value: value,
+	}
+	path := fmt.Sprintf(`repos/%s/%s/variables/%s`, ghrepo.FullName(repo), app, variableName)
+	return patchVariable(client, repo.RepoHost(), path, payload)
+}

--- a/pkg/cmd/variable/variable.go
+++ b/pkg/cmd/variable/variable.go
@@ -5,6 +5,7 @@ import (
 	cmdCreate "github.com/cli/cli/v2/pkg/cmd/variable/create"
 	cmdList "github.com/cli/cli/v2/pkg/cmd/variable/list"
 	cmdDelete "github.com/cli/cli/v2/pkg/cmd/variable/delete"
+	cmdUpdate "github.com/cli/cli/v2/pkg/cmd/variable/update"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -24,5 +25,6 @@ func NewCmdVariable(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(cmdList.NewCmdList(f, nil))
 	cmd.AddCommand(cmdDelete.NewCmdDelete(f, nil))
 	cmd.AddCommand(cmdCreate.NewCmdCreate(f, nil)) 
+	cmd.AddCommand(cmdUpdate.NewCmdUpdate(f, nil)) 
 	return cmd
 }

--- a/pkg/cmd/variable/variable.go
+++ b/pkg/cmd/variable/variable.go
@@ -3,6 +3,7 @@ package variable
 import (
 	"github.com/MakeNowJust/heredoc"
 	cmdCreate "github.com/cli/cli/v2/pkg/cmd/variable/create"
+	cmdList "github.com/cli/cli/v2/pkg/cmd/variable/list"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +20,7 @@ func NewCmdVariable(f *cmdutil.Factory) *cobra.Command {
 
 	cmdutil.EnableRepoOverride(cmd, f)
 
+	cmd.AddCommand(cmdList.NewCmdList(f, nil))
 	cmd.AddCommand(cmdCreate.NewCmdCreate(f, nil))
 	return cmd
 }

--- a/pkg/cmd/variable/variable.go
+++ b/pkg/cmd/variable/variable.go
@@ -4,6 +4,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	cmdCreate "github.com/cli/cli/v2/pkg/cmd/variable/create"
 	cmdList "github.com/cli/cli/v2/pkg/cmd/variable/list"
+	cmdDelete "github.com/cli/cli/v2/pkg/cmd/variable/delete"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +22,7 @@ func NewCmdVariable(f *cmdutil.Factory) *cobra.Command {
 	cmdutil.EnableRepoOverride(cmd, f)
 
 	cmd.AddCommand(cmdList.NewCmdList(f, nil))
-	cmd.AddCommand(cmdCreate.NewCmdCreate(f, nil))
+	cmd.AddCommand(cmdDelete.NewCmdDelete(f, nil))
+	cmd.AddCommand(cmdCreate.NewCmdCreate(f, nil)) 
 	return cmd
 }

--- a/pkg/cmd/variable/variable.go
+++ b/pkg/cmd/variable/variable.go
@@ -1,0 +1,24 @@
+package variable
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	cmdCreate "github.com/cli/cli/v2/pkg/cmd/variable/create"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdVariable(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "variable <command>",
+		Short: "Manage GitHub Actions variables",
+		Long: heredoc.Doc(`
+		Variables can be set at the repository, environment or organization level for use in GitHub Actions.
+		Run "gh help variable create" to learn how to get started.
+`),
+	}
+
+	cmdutil.EnableRepoOverride(cmd, f)
+
+	cmd.AddCommand(cmdCreate.NewCmdCreate(f, nil))
+	return cmd
+}


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Update variables operation added through this PR. Modes supported: body, csv and prompt.
csv format is supported only for create and update :
create:
> name, value, vis(org), repos(org::selected)

update:
> name, value(optional), updated_name(optional), vis(org,optional), repos(org::selected)


![](https://user-images.githubusercontent.com/49831737/213978648-ea4d2897-87ea-49a6-b3af-613aed952da3.png)
![](https://user-images.githubusercontent.com/49831737/213978646-cb2ffc27-672b-495b-8c60-b9eea873ce34.png)


