### PR TITLE
Address projects bugs

### DIFF
--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -19,6 +19,14 @@ func (issue *Issue) ExportData(fields []string) map[string]interface{} {
 			data[f] = issue.Labels.Nodes
 		case "projectCards":
 			data[f] = issue.ProjectCards.Nodes
+		case "projectItems":
+			items := make([]map[string]interface{}, 0, len(issue.ProjectItems.Nodes))
+			for _, n := range issue.ProjectItems.Nodes {
+				items = append(items, map[string]interface{}{
+					"title": n.Project.Title,
+				})
+			}
+			data[f] = items
 		default:
 			sf := fieldByName(v, f)
 			data[f] = sf.Interface()
@@ -96,6 +104,14 @@ func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
 			data[f] = pr.Labels.Nodes
 		case "projectCards":
 			data[f] = pr.ProjectCards.Nodes
+		case "projectItems":
+			items := make([]map[string]interface{}, 0, len(pr.ProjectItems.Nodes))
+			for _, n := range pr.ProjectItems.Nodes {
+				items = append(items, map[string]interface{}{
+					"title": n.Project.Title,
+				})
+			}
+			data[f] = items
 		case "reviews":
 			data[f] = pr.Reviews.Nodes
 		case "latestReviews":

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -75,6 +75,30 @@ func TestIssue_ExportData(t *testing.T) {
 				}
 			`),
 		},
+		{
+			name:   "project items",
+			fields: []string{"projectItems"},
+			inputJSON: heredoc.Doc(`
+				{ "projectItems": { "nodes": [
+					{
+						"id": "PVTI_id",
+						"project": {
+							"id": "PVT_id",
+							"title": "Some Project"
+						}
+					}
+				] } }
+			`),
+			outputJSON: heredoc.Doc(`
+				{
+					"projectItems": [
+						{
+							"title": "Some Project"
+						}
+					]
+				}
+			`),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/queries_org.go
+++ b/api/queries_org.go
@@ -42,45 +42,6 @@ func OrganizationProjects(client *Client, repo ghrepo.Interface) ([]RepoProject,
 	return projects, nil
 }
 
-// OrganizationProjectsV2 fetches all open projectsV2 for an organization.
-func OrganizationProjectsV2(client *Client, repo ghrepo.Interface) ([]RepoProjectV2, error) {
-	type responseData struct {
-		Organization struct {
-			ProjectsV2 struct {
-				Nodes    []RepoProjectV2
-				PageInfo struct {
-					HasNextPage bool
-					EndCursor   string
-				}
-			} `graphql:"projectsV2(first: 100, orderBy: {field: TITLE, direction: ASC}, after: $endCursor, query: $query)"`
-		} `graphql:"organization(login: $owner)"`
-	}
-
-	variables := map[string]interface{}{
-		"owner":     githubv4.String(repo.RepoOwner()),
-		"endCursor": (*githubv4.String)(nil),
-		"query":     githubv4.String("is:open"),
-	}
-
-	var projectsV2 []RepoProjectV2
-	for {
-		var query responseData
-		err := client.Query(repo.RepoHost(), "OrganizationProjectV2List", &query, variables)
-		if err != nil {
-			return nil, err
-		}
-
-		projectsV2 = append(projectsV2, query.Organization.ProjectsV2.Nodes...)
-
-		if !query.Organization.ProjectsV2.PageInfo.HasNextPage {
-			break
-		}
-		variables["endCursor"] = githubv4.String(query.Organization.ProjectsV2.PageInfo.EndCursor)
-	}
-
-	return projectsV2, nil
-}
-
 type OrgTeam struct {
 	ID   string
 	Slug string

--- a/api/queries_projects_v2.go
+++ b/api/queries_projects_v2.go
@@ -10,11 +10,20 @@ import (
 
 const (
 	errorProjectsV2ReadScope         = "field requires one of the following scopes: ['read:project']"
+	errorProjectsV2UserField         = "Field 'projectsV2' doesn't exist on type 'User'"
 	errorProjectsV2RepositoryField   = "Field 'projectsV2' doesn't exist on type 'Repository'"
 	errorProjectsV2OrganizationField = "Field 'projectsV2' doesn't exist on type 'Organization'"
 	errorProjectsV2IssueField        = "Field 'projectItems' doesn't exist on type 'Issue'"
 	errorProjectsV2PullRequestField  = "Field 'projectItems' doesn't exist on type 'PullRequest'"
 )
+
+type ProjectV2 struct {
+	ID           string `json:"id"`
+	Title        string `json:"title"`
+	Number       int    `json:"number"`
+	ResourcePath string `json:"resourcePath"`
+	Closed       bool   `json:"closed"`
+}
 
 // UpdateProjectV2Items uses the addProjectV2ItemById and the deleteProjectV2Item mutations
 // to add and delete items from projects. The addProjectItems and deleteProjectItems arguments are
@@ -126,6 +135,124 @@ func ProjectsV2ItemsForPullRequest(client *Client, repo ghrepo.Interface, pr *Pu
 	return nil
 }
 
+// OrganizationProjectsV2 fetches all open projectsV2 for an organization.
+func OrganizationProjectsV2(client *Client, repo ghrepo.Interface) ([]ProjectV2, error) {
+	type responseData struct {
+		Organization struct {
+			ProjectsV2 struct {
+				Nodes    []ProjectV2
+				PageInfo struct {
+					HasNextPage bool
+					EndCursor   string
+				}
+			} `graphql:"projectsV2(first: 100, orderBy: {field: TITLE, direction: ASC}, after: $endCursor, query: $query)"`
+		} `graphql:"organization(login: $owner)"`
+	}
+
+	variables := map[string]interface{}{
+		"owner":     githubv4.String(repo.RepoOwner()),
+		"endCursor": (*githubv4.String)(nil),
+		"query":     githubv4.String("is:open"),
+	}
+
+	var projectsV2 []ProjectV2
+	for {
+		var query responseData
+		err := client.Query(repo.RepoHost(), "OrganizationProjectV2List", &query, variables)
+		if err != nil {
+			return nil, err
+		}
+
+		projectsV2 = append(projectsV2, query.Organization.ProjectsV2.Nodes...)
+
+		if !query.Organization.ProjectsV2.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Organization.ProjectsV2.PageInfo.EndCursor)
+	}
+
+	return projectsV2, nil
+}
+
+// RepoProjectsV2 fetches all open projectsV2 for a repository.
+func RepoProjectsV2(client *Client, repo ghrepo.Interface) ([]ProjectV2, error) {
+	type responseData struct {
+		Repository struct {
+			ProjectsV2 struct {
+				Nodes    []ProjectV2
+				PageInfo struct {
+					HasNextPage bool
+					EndCursor   string
+				}
+			} `graphql:"projectsV2(first: 100, orderBy: {field: TITLE, direction: ASC}, after: $endCursor, query: $query)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	variables := map[string]interface{}{
+		"owner":     githubv4.String(repo.RepoOwner()),
+		"name":      githubv4.String(repo.RepoName()),
+		"endCursor": (*githubv4.String)(nil),
+		"query":     githubv4.String("is:open"),
+	}
+
+	var projectsV2 []ProjectV2
+	for {
+		var query responseData
+		err := client.Query(repo.RepoHost(), "RepositoryProjectV2List", &query, variables)
+		if err != nil {
+			return nil, err
+		}
+
+		projectsV2 = append(projectsV2, query.Repository.ProjectsV2.Nodes...)
+
+		if !query.Repository.ProjectsV2.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Repository.ProjectsV2.PageInfo.EndCursor)
+	}
+
+	return projectsV2, nil
+}
+
+// UserProjectsV2 fetches all open projectsV2 for a user.
+func UserProjectsV2(client *Client, hostname, login string) ([]ProjectV2, error) {
+	type responseData struct {
+		User struct {
+			ProjectsV2 struct {
+				Nodes    []ProjectV2
+				PageInfo struct {
+					HasNextPage bool
+					EndCursor   string
+				}
+			} `graphql:"projectsV2(first: 100, orderBy: {field: TITLE, direction: ASC}, after: $endCursor, query: $query)"`
+		} `graphql:"user(login: $login)"`
+	}
+
+	variables := map[string]interface{}{
+		"login":     githubv4.String(login),
+		"endCursor": (*githubv4.String)(nil),
+		"query":     githubv4.String("is:open"),
+	}
+
+	var projectsV2 []ProjectV2
+	for {
+		var query responseData
+		err := client.Query(hostname, "UserProjectV2List", &query, variables)
+		if err != nil {
+			return nil, err
+		}
+
+		projectsV2 = append(projectsV2, query.User.ProjectsV2.Nodes...)
+
+		if !query.User.ProjectsV2.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.User.ProjectsV2.PageInfo.EndCursor)
+	}
+
+	return projectsV2, nil
+}
+
 // When querying ProjectsV2 fields we generally dont want to show the user
 // scope errors and field does not exist errors. ProjectsV2IgnorableError
 // checks against known error strings to see if an error can be safely ignored.
@@ -134,6 +261,7 @@ func ProjectsV2ItemsForPullRequest(client *Client, repo ghrepo.Interface, pr *Pu
 func ProjectsV2IgnorableError(err error) bool {
 	msg := err.Error()
 	if strings.Contains(msg, errorProjectsV2ReadScope) ||
+		strings.Contains(msg, errorProjectsV2UserField) ||
 		strings.Contains(msg, errorProjectsV2RepositoryField) ||
 		strings.Contains(msg, errorProjectsV2OrganizationField) ||
 		strings.Contains(msg, errorProjectsV2IssueField) ||

--- a/api/queries_projects_v2.go
+++ b/api/queries_projects_v2.go
@@ -214,10 +214,10 @@ func RepoProjectsV2(client *Client, repo ghrepo.Interface) ([]ProjectV2, error) 
 	return projectsV2, nil
 }
 
-// UserProjectsV2 fetches all open projectsV2 for a user.
-func UserProjectsV2(client *Client, hostname, login string) ([]ProjectV2, error) {
+// CurrentUserProjectsV2 fetches all open projectsV2 for current user.
+func CurrentUserProjectsV2(client *Client, hostname string) ([]ProjectV2, error) {
 	type responseData struct {
-		User struct {
+		Viewer struct {
 			ProjectsV2 struct {
 				Nodes    []ProjectV2
 				PageInfo struct {
@@ -225,11 +225,10 @@ func UserProjectsV2(client *Client, hostname, login string) ([]ProjectV2, error)
 					EndCursor   string
 				}
 			} `graphql:"projectsV2(first: 100, orderBy: {field: TITLE, direction: ASC}, after: $endCursor, query: $query)"`
-		} `graphql:"user(login: $login)"`
+		} `graphql:"viewer"`
 	}
 
 	variables := map[string]interface{}{
-		"login":     githubv4.String(login),
 		"endCursor": (*githubv4.String)(nil),
 		"query":     githubv4.String("is:open"),
 	}
@@ -242,12 +241,12 @@ func UserProjectsV2(client *Client, hostname, login string) ([]ProjectV2, error)
 			return nil, err
 		}
 
-		projectsV2 = append(projectsV2, query.User.ProjectsV2.Nodes...)
+		projectsV2 = append(projectsV2, query.Viewer.ProjectsV2.Nodes...)
 
-		if !query.User.ProjectsV2.PageInfo.HasNextPage {
+		if !query.Viewer.ProjectsV2.PageInfo.HasNextPage {
 			break
 		}
-		variables["endCursor"] = githubv4.String(query.User.ProjectsV2.PageInfo.EndCursor)
+		variables["endCursor"] = githubv4.String(query.Viewer.ProjectsV2.PageInfo.EndCursor)
 	}
 
 	return projectsV2, nil

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -20,6 +20,10 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
+const (
+	errorResolvingOrganization = "Could not resolve to an Organization"
+)
+
 // Repository contains information about a GitHub repo
 type Repository struct {
 	ID                       string
@@ -653,7 +657,7 @@ type RepoMetadataResult struct {
 	AssignableUsers []RepoAssignee
 	Labels          []RepoLabel
 	Projects        []RepoProject
-	ProjectsV2      []RepoProjectV2
+	ProjectsV2      []ProjectV2
 	Milestones      []RepoMilestone
 	Teams           []OrgTeam
 }
@@ -758,17 +762,17 @@ func (m *RepoMetadataResult) projectV2TitleToID(projectTitle string) (string, bo
 	return "", false
 }
 
-func ProjectsToPaths(projects []RepoProject, projectsV2 []RepoProjectV2, names []string) ([]string, error) {
+func ProjectsToPaths(projects []RepoProject, projectsV2 []ProjectV2, names []string) ([]string, error) {
 	var paths []string
 	for _, projectName := range names {
 		found := false
 		for _, p := range projects {
 			if strings.EqualFold(projectName, p.Name) {
-				// format of ResourcePath: /OWNER/REPO/projects/PROJECT_NUMBER or /orgs/ORG/projects/PROJECT_NUMBER
-				// required format of path: OWNER/REPO/PROJECT_NUMBER or ORG/PROJECT_NUMBER
+				// format of ResourcePath: /OWNER/REPO/projects/PROJECT_NUMBER or /orgs/ORG/projects/PROJECT_NUMBER or /users/USER/projects/PROJECT_NUBER
+				// required format of path: OWNER/REPO/PROJECT_NUMBER or ORG/PROJECT_NUMBER or USER/PROJECT_NUMBER
 				var path string
 				pathParts := strings.Split(p.ResourcePath, "/")
-				if pathParts[1] == "orgs" {
+				if pathParts[1] == "orgs" || pathParts[1] == "users" {
 					path = fmt.Sprintf("%s/%s", pathParts[2], pathParts[4])
 				} else {
 					path = fmt.Sprintf("%s/%s/%s", pathParts[1], pathParts[2], pathParts[4])
@@ -783,11 +787,11 @@ func ProjectsToPaths(projects []RepoProject, projectsV2 []RepoProjectV2, names [
 		}
 		for _, p := range projectsV2 {
 			if strings.EqualFold(projectName, p.Title) {
-				// format of ResourcePath: /OWNER/REPO/projects/PROJECT_NUMBER or /orgs/ORG/projects/PROJECT_NUMBER
-				// required format of path: OWNER/REPO/PROJECT_NUMBER or ORG/PROJECT_NUMBER
+				// format of ResourcePath: /OWNER/REPO/projects/PROJECT_NUMBER or /orgs/ORG/projects/PROJECT_NUMBER or /users/USER/projects/PROJECT_NUBER
+				// required format of path: OWNER/REPO/PROJECT_NUMBER or ORG/PROJECT_NUMBER or USER/PROJECT_NUMBER
 				var path string
 				pathParts := strings.Split(p.ResourcePath, "/")
-				if pathParts[1] == "orgs" {
+				if pathParts[1] == "orgs" || pathParts[1] == "users" {
 					path = fmt.Sprintf("%s/%s", pathParts[2], pathParts[4])
 				} else {
 					path = fmt.Sprintf("%s/%s/%s", pathParts[1], pathParts[2], pathParts[4])
@@ -845,100 +849,86 @@ type RepoMetadataInput struct {
 
 // RepoMetadata pre-fetches the metadata for attaching to issues and pull requests
 func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput) (*RepoMetadataResult, error) {
-	result := RepoMetadataResult{}
-	errc := make(chan error)
-	count := 0
+	var result RepoMetadataResult
+	var repoProjects []RepoProject
+	var orgProjects []RepoProject
+	var userProjectsV2 []ProjectV2
+	var repoProjectsV2 []ProjectV2
+	var orgProjectsV2 []ProjectV2
+
+	g, _ := errgroup.WithContext(context.Background())
 
 	if input.Assignees || input.Reviewers {
-		count++
-		go func() {
+		g.Go(func() error {
 			users, err := RepoAssignableUsers(client, repo)
 			if err != nil {
 				err = fmt.Errorf("error fetching assignees: %w", err)
 			}
 			result.AssignableUsers = users
-			errc <- err
-		}()
+			return err
+		})
 	}
 	if input.Reviewers {
-		count++
-		go func() {
+		g.Go(func() error {
 			teams, err := OrganizationTeams(client, repo)
 			// TODO: better detection of non-org repos
-			if err != nil && !strings.Contains(err.Error(), "Could not resolve to an Organization") {
-				errc <- fmt.Errorf("error fetching organization teams: %w", err)
-				return
+			if err != nil && !strings.Contains(err.Error(), errorResolvingOrganization) {
+				err = fmt.Errorf("error fetching organization teams: %w", err)
+				return err
 			}
 			result.Teams = teams
-			errc <- nil
-		}()
+			return nil
+		})
 	}
 	if input.Reviewers {
-		count++
-		go func() {
+		g.Go(func() error {
 			login, err := CurrentLoginName(client, repo.RepoHost())
 			if err != nil {
 				err = fmt.Errorf("error fetching current login: %w", err)
 			}
 			result.CurrentLogin = login
-			errc <- err
-		}()
+			return err
+		})
 	}
 	if input.Labels {
-		count++
-		go func() {
+		g.Go(func() error {
 			labels, err := RepoLabels(client, repo)
 			if err != nil {
 				err = fmt.Errorf("error fetching labels: %w", err)
 			}
 			result.Labels = labels
-			errc <- err
-		}()
+			return err
+		})
 	}
 	if input.Projects {
-		count++
-		go func() {
-			projects, err := RepoAndOrgProjects(client, repo)
-			if err != nil {
-				errc <- err
-				return
-			}
-			result.Projects = projects
-			errc <- nil
-		}()
-	}
-	if input.Projects {
-		count++
-		go func() {
-			projectsV2, err := RepoAndOrgProjectsV2(client, repo)
-			if err != nil {
-				errc <- err
-				return
-			}
-			result.ProjectsV2 = projectsV2
-			errc <- nil
-		}()
+		g.Go(func() error {
+			var err error
+			result.Projects, result.ProjectsV2, err = relevantProjects(client, repo)
+			return err
+		})
 	}
 	if input.Milestones {
-		count++
-		go func() {
+		g.Go(func() error {
 			milestones, err := RepoMilestones(client, repo, "open")
 			if err != nil {
 				err = fmt.Errorf("error fetching milestones: %w", err)
 			}
 			result.Milestones = milestones
-			errc <- err
-		}()
+			return err
+		})
 	}
 
-	var err error
-	for i := 0; i < count; i++ {
-		if e := <-errc; e != nil {
-			err = e
-		}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
-	return &result, err
+	result.Projects = append(result.Projects, repoProjects...)
+	result.Projects = append(result.Projects, orgProjects...)
+	result.ProjectsV2 = append(result.ProjectsV2, userProjectsV2...)
+	result.ProjectsV2 = append(result.ProjectsV2, repoProjectsV2...)
+	result.ProjectsV2 = append(result.ProjectsV2, orgProjectsV2...)
+
+	return &result, nil
 }
 
 type RepoResolveInput struct {
@@ -1050,14 +1040,6 @@ type RepoProject struct {
 	ResourcePath string `json:"resourcePath"`
 }
 
-type RepoProjectV2 struct {
-	ID           string `json:"id"`
-	Title        string `json:"title"`
-	Number       int    `json:"number"`
-	ResourcePath string `json:"resourcePath"`
-	Closed       bool   `json:"closed"`
-}
-
 // RepoProjects fetches all open projects for a repository.
 func RepoProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, error) {
 	type responseData struct {
@@ -1094,87 +1076,6 @@ func RepoProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, error) 
 	}
 
 	return projects, nil
-}
-
-// RepoProjectsV2 fetches all open projectsV2 for a repository.
-func RepoProjectsV2(client *Client, repo ghrepo.Interface) ([]RepoProjectV2, error) {
-	type responseData struct {
-		Repository struct {
-			ProjectsV2 struct {
-				Nodes    []RepoProjectV2
-				PageInfo struct {
-					HasNextPage bool
-					EndCursor   string
-				}
-			} `graphql:"projectsV2(first: 100, orderBy: {field: TITLE, direction: ASC}, after: $endCursor, query: $query)"`
-		} `graphql:"repository(owner: $owner, name: $name)"`
-	}
-
-	variables := map[string]interface{}{
-		"owner":     githubv4.String(repo.RepoOwner()),
-		"name":      githubv4.String(repo.RepoName()),
-		"endCursor": (*githubv4.String)(nil),
-		"query":     githubv4.String("is:open"),
-	}
-
-	var projectsV2 []RepoProjectV2
-	for {
-		var query responseData
-		err := client.Query(repo.RepoHost(), "RepositoryProjectV2List", &query, variables)
-		if err != nil {
-			return nil, err
-		}
-
-		projectsV2 = append(projectsV2, query.Repository.ProjectsV2.Nodes...)
-
-		if !query.Repository.ProjectsV2.PageInfo.HasNextPage {
-			break
-		}
-		variables["endCursor"] = githubv4.String(query.Repository.ProjectsV2.PageInfo.EndCursor)
-	}
-
-	return projectsV2, nil
-}
-
-// RepoAndOrgProjects fetches all open projects for a repository and its organization.
-func RepoAndOrgProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, error) {
-	projects, err := RepoProjects(client, repo)
-	if err != nil {
-		return nil, fmt.Errorf("error fetching projects: %w", err)
-	}
-
-	orgProjects, err := OrganizationProjects(client, repo)
-	// TODO: Better detection of non-org repos.
-	if err != nil && !strings.Contains(err.Error(), "Could not resolve to an Organization") {
-		return nil, fmt.Errorf("error fetching organization projects: %w", err)
-	}
-
-	projects = append(projects, orgProjects...)
-
-	return projects, nil
-}
-
-// RepoAndOrgProjectsV2 fetches all open projectsV2 for a repository and its organization.
-// Note: If the auth token does not have sufficient scopes or projectsV2 is not supported
-// on the host then those errors are swallowed and nil is returned.
-func RepoAndOrgProjectsV2(client *Client, repo ghrepo.Interface) ([]RepoProjectV2, error) {
-	projectsV2, err := RepoProjectsV2(client, repo)
-	if err != nil {
-		if ProjectsV2IgnorableError(err) {
-			return nil, nil
-		}
-
-		return nil, fmt.Errorf("error fetching projectsV2: %w", err)
-	}
-
-	orgProjectsV2, err := OrganizationProjectsV2(client, repo)
-	if err != nil && !strings.Contains(err.Error(), "Could not resolve to an Organization") {
-		return nil, fmt.Errorf("error fetching organization projectsV2: %w", err)
-	}
-
-	projectsV2 = append(projectsV2, orgProjectsV2...)
-
-	return projectsV2, nil
 }
 
 type RepoAssignee struct {
@@ -1329,27 +1230,105 @@ func RepoMilestones(client *Client, repo ghrepo.Interface, state string) ([]Repo
 }
 
 func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []string) ([]string, error) {
+	projects, projectsV2, err := relevantProjects(client, repo)
+	if err != nil {
+		return nil, err
+	}
+	return ProjectsToPaths(projects, projectsV2, projectNames)
+}
+
+// RelevantProjects retrieves set of Projects and ProjectsV2 relevant to given repository:
+// - Projects for repository
+// - Projects for repository organization, if it belongs to one
+// - ProjectsV2 owned by current user
+// - ProjectsV2 linked to repository
+// - ProjectsV2 owned by repository organization, if it belongs to one
+func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []ProjectV2, error) {
+	var repoProjects []RepoProject
+	var orgProjects []RepoProject
+	var userProjectsV2 []ProjectV2
+	var repoProjectsV2 []ProjectV2
+	var orgProjectsV2 []ProjectV2
+
 	g, _ := errgroup.WithContext(context.Background())
-	var projects []RepoProject
-	var projectsV2 []RepoProjectV2
 
 	g.Go(func() error {
 		var err error
-		projects, err = RepoAndOrgProjects(client, repo)
+		repoProjects, err = RepoProjects(client, repo)
+		if err != nil {
+			err = fmt.Errorf("error fetching repo projects (classic): %w", err)
+		}
 		return err
 	})
-
 	g.Go(func() error {
 		var err error
-		projectsV2, err = RepoAndOrgProjectsV2(client, repo)
-		return err
+		orgProjects, err = OrganizationProjects(client, repo)
+		if err != nil && !strings.Contains(err.Error(), errorResolvingOrganization) {
+			err = fmt.Errorf("error fetching organization projects (classic): %w", err)
+			return err
+		}
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		login, err := CurrentLoginName(client, repo.RepoHost())
+		if err != nil {
+			err = fmt.Errorf("error fetching current login: %w", err)
+			return err
+		}
+		userProjectsV2, err = UserProjectsV2(client, repo.RepoHost(), login)
+		if err != nil && !ProjectsV2IgnorableError(err) {
+			err = fmt.Errorf("error fetching user projects: %w", err)
+			return err
+		}
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		repoProjectsV2, err = RepoProjectsV2(client, repo)
+		if err != nil && !ProjectsV2IgnorableError(err) {
+			err = fmt.Errorf("error fetching repo projects: %w", err)
+			return err
+		}
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		orgProjectsV2, err = OrganizationProjectsV2(client, repo)
+		if err != nil &&
+			!ProjectsV2IgnorableError(err) &&
+			!strings.Contains(err.Error(), errorResolvingOrganization) {
+			err = fmt.Errorf("error fetching organization projects: %w", err)
+			return err
+		}
+		return nil
 	})
 
 	if err := g.Wait(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return ProjectsToPaths(projects, projectsV2, projectNames)
+	projects := make([]RepoProject, 0, len(repoProjects)+len(orgProjects))
+	projects = append(projects, repoProjects...)
+	projects = append(projects, orgProjects...)
+
+	// ProjectV2 might appear across multiple queries so use a map to keep them deduplicated.
+	m := make(map[string]ProjectV2, len(userProjectsV2)+len(repoProjectsV2)+len(orgProjectsV2))
+	for _, p := range userProjectsV2 {
+		m[p.ID] = p
+	}
+	for _, p := range repoProjectsV2 {
+		m[p.ID] = p
+	}
+	for _, p := range orgProjectsV2 {
+		m[p.ID] = p
+	}
+	projectsV2 := make([]ProjectV2, 0, len(m))
+	for _, p := range m {
+		projectsV2 = append(projectsV2, p)
+	}
+
+	return projects, projectsV2, nil
 }
 
 func CreateRepoTransformToV4(apiClient *Client, hostname string, method string, path string, body io.Reader) (*Repository, error) {

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -850,11 +850,6 @@ type RepoMetadataInput struct {
 // RepoMetadata pre-fetches the metadata for attaching to issues and pull requests
 func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput) (*RepoMetadataResult, error) {
 	var result RepoMetadataResult
-	var repoProjects []RepoProject
-	var orgProjects []RepoProject
-	var userProjectsV2 []ProjectV2
-	var repoProjectsV2 []ProjectV2
-	var orgProjectsV2 []ProjectV2
 
 	g, _ := errgroup.WithContext(context.Background())
 
@@ -921,12 +916,6 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}
-
-	result.Projects = append(result.Projects, repoProjects...)
-	result.Projects = append(result.Projects, orgProjects...)
-	result.ProjectsV2 = append(result.ProjectsV2, userProjectsV2...)
-	result.ProjectsV2 = append(result.ProjectsV2, repoProjectsV2...)
-	result.ProjectsV2 = append(result.ProjectsV2, orgProjectsV2...)
 
 	return &result, nil
 }

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -850,8 +850,7 @@ type RepoMetadataInput struct {
 // RepoMetadata pre-fetches the metadata for attaching to issues and pull requests
 func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput) (*RepoMetadataResult, error) {
 	var result RepoMetadataResult
-
-	g, _ := errgroup.WithContext(context.Background())
+	var g errgroup.Group
 
 	if input.Assignees || input.Reviewers {
 		g.Go(func() error {

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1260,12 +1260,7 @@ func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []P
 	})
 	g.Go(func() error {
 		var err error
-		login, err := CurrentLoginName(client, repo.RepoHost())
-		if err != nil {
-			err = fmt.Errorf("error fetching current login: %w", err)
-			return err
-		}
-		userProjectsV2, err = UserProjectsV2(client, repo.RepoHost(), login)
+		userProjectsV2, err = CurrentUserProjectsV2(client, repo.RepoHost())
 		if err != nil && !ProjectsV2IgnorableError(err) {
 			err = fmt.Errorf("error fetching user projects: %w", err)
 			return err

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -121,14 +121,9 @@ func Test_RepoMetadata(t *testing.T) {
 		} } } }
 		`))
 	http.Register(
-		httpmock.GraphQL(`query UserCurrent\b`),
-		httpmock.StringResponse(`
-		  { "data": { "viewer": { "login": "monalisa" } } }
-		`))
-	http.Register(
 		httpmock.GraphQL(`query UserProjectV2List\b`),
 		httpmock.StringResponse(`
-		{ "data": { "user": { "projectsV2": {
+		{ "data": { "viewer": { "projectsV2": {
 			"nodes": [
 				{ "title": "MonalisaV2", "id": "MONALISAV2ID" }
 			],
@@ -283,14 +278,9 @@ func Test_ProjectNamesToPaths(t *testing.T) {
 		} } } }
 		`))
 	http.Register(
-		httpmock.GraphQL(`query UserCurrent\b`),
-		httpmock.StringResponse(`
-		  { "data": { "viewer": { "login": "monalisa" } } }
-		`))
-	http.Register(
 		httpmock.GraphQL(`query UserProjectV2List\b`),
 		httpmock.StringResponse(`
-		{ "data": { "user": { "projectsV2": {
+		{ "data": { "viewer": { "projectsV2": {
 			"nodes": [
 				{ "title": "MonalisaV2", "id": "MONALISAV2ID", "resourcePath": "/users/MONALISA/projects/5"  }
 			],

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -121,6 +121,21 @@ func Test_RepoMetadata(t *testing.T) {
 		} } } }
 		`))
 	http.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StringResponse(`
+		  { "data": { "viewer": { "login": "monalisa" } } }
+		`))
+	http.Register(
+		httpmock.GraphQL(`query UserProjectV2List\b`),
+		httpmock.StringResponse(`
+		{ "data": { "user": { "projectsV2": {
+			"nodes": [
+				{ "title": "MonalisaV2", "id": "MONALISAV2ID" }
+			],
+			"pageInfo": { "hasNextPage": false }
+		} } } }
+		`))
+	http.Register(
 		httpmock.GraphQL(`query OrganizationTeamList\b`),
 		httpmock.StringResponse(`
 		{ "data": { "organization": { "teams": {
@@ -170,8 +185,8 @@ func Test_RepoMetadata(t *testing.T) {
 	}
 
 	expectedProjectIDs := []string{"TRIAGEID", "ROADMAPID"}
-	expectedProjectV2IDs := []string{"TRIAGEV2ID", "ROADMAPV2ID"}
-	projectIDs, projectV2IDs, err := result.ProjectsToIDs([]string{"triage", "roadmap", "triagev2", "roadmapv2"})
+	expectedProjectV2IDs := []string{"TRIAGEV2ID", "ROADMAPV2ID", "MONALISAV2ID"}
+	projectIDs, projectV2IDs, err := result.ProjectsToIDs([]string{"triage", "roadmap", "triagev2", "roadmapv2", "monalisav2"})
 	if err != nil {
 		t.Errorf("error resolving projects: %v", err)
 	}
@@ -204,7 +219,7 @@ func Test_ProjectsToPaths(t *testing.T) {
 		{ID: "id2", Name: "Org Project", ResourcePath: "/orgs/ORG/projects/PROJECT_NUMBER"},
 		{ID: "id3", Name: "Project", ResourcePath: "/orgs/ORG/projects/PROJECT_NUMBER_2"},
 	}
-	projectsV2 := []RepoProjectV2{
+	projectsV2 := []ProjectV2{
 		{ID: "id4", Title: "My Project V2", ResourcePath: "/OWNER/REPO/projects/PROJECT_NUMBER_2"},
 		{ID: "id5", Title: "Org Project V2", ResourcePath: "/orgs/ORG/projects/PROJECT_NUMBER_3"},
 	}
@@ -267,13 +282,28 @@ func Test_ProjectNamesToPaths(t *testing.T) {
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
+	http.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StringResponse(`
+		  { "data": { "viewer": { "login": "monalisa" } } }
+		`))
+	http.Register(
+		httpmock.GraphQL(`query UserProjectV2List\b`),
+		httpmock.StringResponse(`
+		{ "data": { "user": { "projectsV2": {
+			"nodes": [
+				{ "title": "MonalisaV2", "id": "MONALISAV2ID", "resourcePath": "/users/MONALISA/projects/5"  }
+			],
+			"pageInfo": { "hasNextPage": false }
+		} } } }
+		`))
 
-	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap", "TriageV2", "RoadmapV2"})
+	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap", "TriageV2", "RoadmapV2", "MonalisaV2"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expectedProjectPaths := []string{"ORG/1", "OWNER/REPO/2", "ORG/2", "OWNER/REPO/4"}
+	expectedProjectPaths := []string{"ORG/1", "OWNER/REPO/2", "ORG/2", "OWNER/REPO/4", "MONALISA/5"}
 	if !sliceEqual(projectPaths, expectedProjectPaths) {
 		t.Errorf("expected projects paths %v, got %v", expectedProjectPaths, projectPaths)
 	}

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -221,6 +221,7 @@ var IssueFields = []string{
 	"milestone",
 	"number",
 	"projectCards",
+	"projectItems",
 	"reactionGroups",
 	"state",
 	"title",

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -235,6 +235,18 @@ func Test_createRun(t *testing.T) {
 						],
 						"pageInfo": { "hasNextPage": false }
 					} } } }`))
+				r.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StringResponse(`{"data": {"viewer": {"login": "monalisa"} } }`))
+				r.Register(
+					httpmock.GraphQL(`query UserProjectV2List\b`),
+					httpmock.StringResponse(`
+					{ "data": { "user": { "projectsV2": {
+						"nodes": [
+							{ "title": "Monalisa", "id": "MONALISAID", "resourcePath": "/users/MONALISA/projects/1"  }
+						],
+						"pageInfo": { "hasNextPage": false }
+					} } } }`))
 			},
 			wantsBrowse: "https://github.com/OWNER/REPO/issues/new?body=&projects=OWNER%2FREPO%2F1",
 			wantsStderr: "Opening github.com/OWNER/REPO/issues/new in your browser.\n",
@@ -647,6 +659,17 @@ func TestIssueCreate_metadata(t *testing.T) {
 		} } } }
 		`))
 	http.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StringResponse(`{"data": {"viewer": {"login": "monalisa"} } }`))
+	http.Register(
+		httpmock.GraphQL(`query UserProjectV2List\b`),
+		httpmock.StringResponse(`
+		{	"data": { "user": { "projectsV2": {
+			"nodes": [],
+			"pageInfo": { "hasNextPage": false }
+		} } } }
+		`))
+	http.Register(
 		httpmock.GraphQL(`mutation IssueCreate\b`),
 		httpmock.GraphQLMutation(`
 		{ "data": { "createIssue": { "issue": {
@@ -781,7 +804,20 @@ func TestIssueCreate_projectsV2(t *testing.T) {
 		httpmock.StringResponse(`
 		{ "data": { "organization": { "projectsV2": {
 			"nodes": [
-				{ "title": "TriageV2", "id": "TriageV2ID" }
+				{ "title": "TriageV2", "id": "TRIAGEV2ID" }
+			],
+			"pageInfo": { "hasNextPage": false }
+		} } } }
+		`))
+	http.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StringResponse(`{"data": {"viewer": {"login": "monalisa"} } }`))
+	http.Register(
+		httpmock.GraphQL(`query UserProjectV2List\b`),
+		httpmock.StringResponse(`
+		{ "data": { "user": { "projectsV2": {
+			"nodes": [
+				{ "title": "MonalisaV2", "id": "MONALISAV2ID" }
 			],
 			"pageInfo": { "hasNextPage": false }
 		} } } }

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -236,12 +236,9 @@ func Test_createRun(t *testing.T) {
 						"pageInfo": { "hasNextPage": false }
 					} } } }`))
 				r.Register(
-					httpmock.GraphQL(`query UserCurrent\b`),
-					httpmock.StringResponse(`{"data": {"viewer": {"login": "monalisa"} } }`))
-				r.Register(
 					httpmock.GraphQL(`query UserProjectV2List\b`),
 					httpmock.StringResponse(`
-					{ "data": { "user": { "projectsV2": {
+					{ "data": { "viewer": { "projectsV2": {
 						"nodes": [
 							{ "title": "Monalisa", "id": "MONALISAID", "resourcePath": "/users/MONALISA/projects/1"  }
 						],
@@ -659,12 +656,9 @@ func TestIssueCreate_metadata(t *testing.T) {
 		} } } }
 		`))
 	http.Register(
-		httpmock.GraphQL(`query UserCurrent\b`),
-		httpmock.StringResponse(`{"data": {"viewer": {"login": "monalisa"} } }`))
-	http.Register(
 		httpmock.GraphQL(`query UserProjectV2List\b`),
 		httpmock.StringResponse(`
-		{	"data": { "user": { "projectsV2": {
+		{	"data": { "viewer": { "projectsV2": {
 			"nodes": [],
 			"pageInfo": { "hasNextPage": false }
 		} } } }
@@ -810,12 +804,9 @@ func TestIssueCreate_projectsV2(t *testing.T) {
 		} } } }
 		`))
 	http.Register(
-		httpmock.GraphQL(`query UserCurrent\b`),
-		httpmock.StringResponse(`{"data": {"viewer": {"login": "monalisa"} } }`))
-	http.Register(
 		httpmock.GraphQL(`query UserProjectV2List\b`),
 		httpmock.StringResponse(`
-		{ "data": { "user": { "projectsV2": {
+		{ "data": { "viewer": { "projectsV2": {
 			"nodes": [
 				{ "title": "MonalisaV2", "id": "MONALISAV2ID" }
 			],

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -490,14 +490,9 @@ func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry) {
 		} } } }
 		`))
 	reg.Register(
-		httpmock.GraphQL(`query UserCurrent\b`),
-		httpmock.StringResponse(`
-		  { "data": { "viewer": { "login": "monalisa" } } }
-		`))
-	reg.Register(
 		httpmock.GraphQL(`query UserProjectV2List\b`),
 		httpmock.StringResponse(`
-		{ "data": { "user": { "projectsV2": {
+		{ "data": { "viewer": { "projectsV2": {
 			"nodes": [
 				{ "title": "MonalisaV2", "id": "MONALISAV2ID" }
 			],

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -489,6 +489,21 @@ func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry) {
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
+	reg.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StringResponse(`
+		  { "data": { "viewer": { "login": "monalisa" } } }
+		`))
+	reg.Register(
+		httpmock.GraphQL(`query UserProjectV2List\b`),
+		httpmock.StringResponse(`
+		{ "data": { "user": { "projectsV2": {
+			"nodes": [
+				{ "title": "MonalisaV2", "id": "MONALISAV2ID" }
+			],
+			"pageInfo": { "hasNextPage": false }
+		} } } }
+		`))
 }
 
 func mockIssueUpdate(t *testing.T, reg *httpmock.Registry) {

--- a/pkg/cmd/issue/shared/lookup.go
+++ b/pkg/cmd/issue/shared/lookup.go
@@ -102,6 +102,7 @@ func findIssueOrPR(httpClient *http.Client, repo ghrepo.Interface, number int, f
 	if fieldSet.Contains("projectItems") {
 		getProjectItems = true
 		fieldSet.Remove("projectItems")
+		fieldSet.Add("number")
 	}
 
 	fields = fieldSet.ToSlice()

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -296,31 +296,7 @@ func Test_createRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query UserCurrent\b`),
 					httpmock.StringResponse(`{"data": {"viewer": {"login": "OWNER"} } }`))
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryProjectList\b`),
-					httpmock.StringResponse(`{ "data": { "repository": { "projects": { "nodes": [],	"pageInfo": { "hasNextPage": false } } } } }`))
-				reg.Register(
-					httpmock.GraphQL(`query OrganizationProjectList\b`),
-					httpmock.StringResponse(`{ "data": { "organization": { "projects": { "nodes": [], "pageInfo": { "hasNextPage": false } } } } }`))
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryProjectV2List\b`),
-					httpmock.StringResponse(`
-				{ "data": { "repository": { "projectsV2": {
-					"nodes": [
-						{ "title": "CleanupV2", "id": "CLEANUPV2ID" },
-						{ "title": "RoadmapV2", "id": "ROADMAPV2ID" }
-					],
-					"pageInfo": { "hasNextPage": false }
-				} } } }
-				`))
-				reg.Register(
-					httpmock.GraphQL(`query OrganizationProjectV2List\b`),
-					httpmock.StringResponse(`
-				{ "data": { "organization": { "projectsV2": {
-					"nodes": [],
-					"pageInfo": { "hasNextPage": false }
-				} } } }
-				`))
+				mockRetrieveProjects(t, reg)
 				reg.Register(
 					httpmock.GraphQL(`mutation PullRequestCreate\b`),
 					httpmock.GraphQLMutation(`
@@ -652,44 +628,7 @@ func Test_createRun(t *testing.T) {
 					"pageInfo": { "hasNextPage": false }
 				} } } }
 				`))
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryProjectList\b`),
-					httpmock.StringResponse(`
-				{ "data": { "repository": { "projects": {
-					"nodes": [
-						{ "name": "Cleanup", "id": "CLEANUPID" },
-						{ "name": "Roadmap", "id": "ROADMAPID" }
-					],
-					"pageInfo": { "hasNextPage": false }
-				} } } }
-				`))
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryProjectV2List\b`),
-					httpmock.StringResponse(`
-				{ "data": { "repository": { "projectsV2": {
-					"nodes": [
-						{ "title": "CleanupV2", "id": "CLEANUPV2ID" },
-						{ "title": "RoadmapV2", "id": "ROADMAPV2ID" }
-					],
-					"pageInfo": { "hasNextPage": false }
-				} } } }			
-				`))
-				reg.Register(
-					httpmock.GraphQL(`query OrganizationProjectList\b`),
-					httpmock.StringResponse(`
-				{ "data": { "organization": { "projects": {
-					"nodes": [],
-					"pageInfo": { "hasNextPage": false }
-				} } } }
-				`))
-				reg.Register(
-					httpmock.GraphQL(`query OrganizationProjectV2List\b`),
-					httpmock.StringResponse(`
-				{ "data": { "organization": { "projectsV2": {
-					"nodes": [],
-					"pageInfo": { "hasNextPage": false }
-				} } } }
-				`))
+				mockRetrieveProjects(t, reg)
 				reg.Register(
 					httpmock.GraphQL(`mutation PullRequestCreate\b`),
 					httpmock.GraphQLMutation(`
@@ -794,46 +733,7 @@ func Test_createRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query UserCurrent\b`),
 					httpmock.StringResponse(`{"data": {"viewer": {"login": "OWNER"} } }`))
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryProjectList\b`),
-					httpmock.StringResponse(`
-			{ "data": { "repository": { "projects": {
-				"nodes": [
-					{ "name": "Cleanup", "id": "CLEANUPID", "resourcePath": "/OWNER/REPO/projects/1" }
-				],
-				"pageInfo": { "hasNextPage": false }
-			} } } }
-			`))
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryProjectV2List\b`),
-					httpmock.StringResponse(`
-			{ "data": { "repository": { "projectsV2": {
-				"nodes": [
-					{ "title": "CleanupV2", "id": "CLEANUPV2ID", "resourcePath": "/OWNER/REPO/projects/2" }
-				],
-				"pageInfo": { "hasNextPage": false }
-			} } } }
-			`))
-				reg.Register(
-					httpmock.GraphQL(`query OrganizationProjectList\b`),
-					httpmock.StringResponse(`
-			{ "data": { "organization": { "projects": {
-				"nodes": [
-					{ "name": "Triage", "id": "TRIAGEID", "resourcePath": "/orgs/ORG/projects/1"  }
-				],
-				"pageInfo": { "hasNextPage": false }
-			} } } }
-			`))
-				reg.Register(
-					httpmock.GraphQL(`query OrganizationProjectV2List\b`),
-					httpmock.StringResponse(`
-			{ "data": { "organization": { "projectsV2": {
-				"nodes": [
-					{ "title": "TriageV2", "id": "TRIAGEV2ID", "resourcePath": "/orgs/ORG/projects/2"  }
-				],
-				"pageInfo": { "hasNextPage": false }
-			} } } }
-			`))
+				mockRetrieveProjects(t, reg)
 			},
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
@@ -1287,6 +1187,64 @@ func Test_generateCompareURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mockRetrieveProjects(_ *testing.T, reg *httpmock.Registry) {
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryProjectList\b`),
+		httpmock.StringResponse(`
+				{ "data": { "repository": { "projects": {
+					"nodes": [
+						{ "name": "Cleanup", "id": "CLEANUPID", "resourcePath": "/OWNER/REPO/projects/1" },
+						{ "name": "Roadmap", "id": "ROADMAPID", "resourcePath": "/OWNER/REPO/projects/2" }
+					],
+					"pageInfo": { "hasNextPage": false }
+				} } } }
+				`))
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryProjectV2List\b`),
+		httpmock.StringResponse(`
+				{ "data": { "repository": { "projectsV2": {
+					"nodes": [
+						{ "title": "CleanupV2", "id": "CLEANUPV2ID", "resourcePath": "/OWNER/REPO/projects/3" },
+						{ "title": "RoadmapV2", "id": "ROADMAPV2ID", "resourcePath": "/OWNER/REPO/projects/4" }
+					],
+					"pageInfo": { "hasNextPage": false }
+				} } } }
+				`))
+	reg.Register(
+		httpmock.GraphQL(`query OrganizationProjectList\b`),
+		httpmock.StringResponse(`
+				{ "data": { "organization": { "projects": {
+					"nodes": [
+						{ "name": "Triage", "id": "TRIAGEID", "resourcePath": "/orgs/ORG/projects/1" }
+					],
+					"pageInfo": { "hasNextPage": false }
+				} } } }
+				`))
+	reg.Register(
+		httpmock.GraphQL(`query OrganizationProjectV2List\b`),
+		httpmock.StringResponse(`
+				{ "data": { "organization": { "projectsV2": {
+					"nodes": [
+						{ "title": "TriageV2", "id": "TRIAGEV2ID", "resourcePath": "/orgs/ORG/projects/2" }
+					],
+					"pageInfo": { "hasNextPage": false }
+				} } } }
+				`))
+	reg.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StringResponse(`{"data": {"viewer": {"login": "monalisa"} } }`))
+	reg.Register(
+		httpmock.GraphQL(`query UserProjectV2List\b`),
+		httpmock.StringResponse(`
+				{ "data": { "user": { "projectsV2": {
+					"nodes": [
+						{ "title": "MonalisaV2", "id": "MONALISAV2ID", "resourcePath": "/user/MONALISA/projects/2" }
+					],
+					"pageInfo": { "hasNextPage": false }
+				} } } }
+				`))
 }
 
 // TODO interactive metadata tests once: 1) we have test utils for Prompter and 2) metadata questions use Prompter

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1233,12 +1233,9 @@ func mockRetrieveProjects(_ *testing.T, reg *httpmock.Registry) {
 				} } } }
 				`))
 	reg.Register(
-		httpmock.GraphQL(`query UserCurrent\b`),
-		httpmock.StringResponse(`{"data": {"viewer": {"login": "monalisa"} } }`))
-	reg.Register(
 		httpmock.GraphQL(`query UserProjectV2List\b`),
 		httpmock.StringResponse(`
-				{ "data": { "user": { "projectsV2": {
+				{ "data": { "viewer": { "projectsV2": {
 					"nodes": [
 						{ "title": "MonalisaV2", "id": "MONALISAV2ID", "resourcePath": "/user/MONALISA/projects/2" }
 					],

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -566,14 +566,9 @@ func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry, skipReviewers bool) 
 		} } } }
 		`))
 	reg.Register(
-		httpmock.GraphQL(`query UserCurrent\b`),
-		httpmock.StringResponse(`
-		  { "data": { "viewer": { "login": "monalisa" } } }
-		`))
-	reg.Register(
 		httpmock.GraphQL(`query UserProjectV2List\b`),
 		httpmock.StringResponse(`
-		{ "data": { "user": { "projectsV2": {
+		{ "data": { "viewer": { "projectsV2": {
 			"nodes": [
 				{ "title": "MonalisaV2", "id": "MONALISAV2ID" }
 			],

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -464,22 +464,21 @@ func Test_editRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ios, _, stdout, stderr := iostreams.Test()
-		ios.SetStdoutTTY(true)
-		ios.SetStdinTTY(true)
-		ios.SetStderrTTY(true)
-
-		reg := &httpmock.Registry{}
-		defer reg.Verify(t)
-		tt.httpStubs(t, reg)
-
-		httpClient := func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
-
-		tt.input.IO = ios
-		tt.input.HttpClient = httpClient
-
 		t.Run(tt.name, func(t *testing.T) {
-			fmt.Println(tt.name)
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(true)
+			ios.SetStdinTTY(true)
+			ios.SetStderrTTY(true)
+
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			tt.httpStubs(t, reg)
+
+			httpClient := func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
+
+			tt.input.IO = ios
+			tt.input.HttpClient = httpClient
+
 			err := editRun(tt.input)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.stdout, stdout.String())
@@ -562,6 +561,21 @@ func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry, skipReviewers bool) 
 		{ "data": { "organization": { "projectsV2": {
 			"nodes": [
 				{ "title": "TriageV2", "id": "TRIAGEV2ID" }
+			],
+			"pageInfo": { "hasNextPage": false }
+		} } } }
+		`))
+	reg.Register(
+		httpmock.GraphQL(`query UserCurrent\b`),
+		httpmock.StringResponse(`
+		  { "data": { "viewer": { "login": "monalisa" } } }
+		`))
+	reg.Register(
+		httpmock.GraphQL(`query UserProjectV2List\b`),
+		httpmock.StringResponse(`
+		{ "data": { "user": { "projectsV2": {
+			"nodes": [
+				{ "title": "MonalisaV2", "id": "MONALISAV2ID" }
 			],
 			"pageInfo": { "hasNextPage": false }
 		} } } }


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/6989 - Allow retrieving `projectItems` from `--json` flag.
Fixes https://github.com/cli/cli/issues/6940 - Retrieve current user projectsV2 along with projectsV2 we were already retrieving.

Note that for now I did not address the behavior of projects with duplicate names. I think we should hold off on that for now as any behavior that I experimented with felt confusing. When there are duplicate named projects there is no way to know which project a user is referring to. I think our advice for users in this situation should be to rename the project to a unique name and/or manipulate the project on the web. This edge case seems highly unlikely as we have never (as far as I know) run into it with projects classic. If we have reports of this actually occurring we can revisit my decision.