### PR TITLE
Keyring v2

### DIFF
--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"regexp"
 	"strings"
 
@@ -28,37 +27,7 @@ var (
 	jsonTypeRE = regexp.MustCompile(`[/+]json($|;)`)
 )
 
-type iconfig interface {
-	Get(string, string) (string, error)
-	Set(string, string, string)
-	Write() error
-}
-
-func AuthFlowWithConfig(cfg iconfig, IO *iostreams.IOStreams, hostname, notice string, additionalScopes []string, isInteractive bool) (string, error) {
-	// TODO this probably shouldn't live in this package. It should probably be in a new package that
-	// depends on both iostreams and config.
-
-	// FIXME: this duplicates `factory.browserLauncher()`
-	browserLauncher := os.Getenv("GH_BROWSER")
-	if browserLauncher == "" {
-		browserLauncher, _ = cfg.Get("", "browser")
-	}
-	if browserLauncher == "" {
-		browserLauncher = os.Getenv("BROWSER")
-	}
-
-	token, userLogin, err := authFlow(hostname, IO, notice, additionalScopes, isInteractive, browserLauncher)
-	if err != nil {
-		return "", err
-	}
-
-	cfg.Set(hostname, "user", userLogin)
-	cfg.Set(hostname, "oauth_token", token)
-
-	return token, cfg.Write()
-}
-
-func authFlow(oauthHost string, IO *iostreams.IOStreams, notice string, additionalScopes []string, isInteractive bool, browserLauncher string) (string, string, error) {
+func AuthFlow(oauthHost string, IO *iostreams.IOStreams, notice string, additionalScopes []string, isInteractive bool, b browser.Browser) (string, string, error) {
 	w := IO.ErrOut
 	cs := IO.ColorScheme()
 
@@ -106,7 +75,6 @@ func authFlow(oauthHost string, IO *iostreams.IOStreams, notice string, addition
 			fmt.Fprintf(w, "%s to open %s in your browser... ", cs.Bold("Press Enter"), oauthHost)
 			_ = waitForEnter(IO.In)
 
-			b := browser.New(browserLauncher, IO.Out, IO.ErrOut)
 			if err := b.Browse(authURL); err != nil {
 				fmt.Fprintf(w, "%s Failed opening a web browser at %s\n", cs.Red("!"), authURL)
 				fmt.Fprintf(w, "  %s\n", err)

--- a/internal/config/config_mock.go
+++ b/internal/config/config_mock.go
@@ -23,6 +23,9 @@ var _ Config = &ConfigMock{}
 //			AuthTokenFunc: func(s string) (string, string) {
 //				panic("mock out the AuthToken method")
 //			},
+//			AuthenticationFunc: func() *AuthConfig {
+//				panic("mock out the Authentication method")
+//			},
 //			DefaultHostFunc: func() (string, string) {
 //				panic("mock out the DefaultHost method")
 //			},
@@ -32,14 +35,8 @@ var _ Config = &ConfigMock{}
 //			GetOrDefaultFunc: func(s1 string, s2 string) (string, error) {
 //				panic("mock out the GetOrDefault method")
 //			},
-//			HostsFunc: func() []string {
-//				panic("mock out the Hosts method")
-//			},
 //			SetFunc: func(s1 string, s2 string, s3 string)  {
 //				panic("mock out the Set method")
-//			},
-//			UnsetHostFunc: func(s string)  {
-//				panic("mock out the UnsetHost method")
 //			},
 //			WriteFunc: func() error {
 //				panic("mock out the Write method")
@@ -57,6 +54,9 @@ type ConfigMock struct {
 	// AuthTokenFunc mocks the AuthToken method.
 	AuthTokenFunc func(s string) (string, string)
 
+	// AuthenticationFunc mocks the Authentication method.
+	AuthenticationFunc func() *AuthConfig
+
 	// DefaultHostFunc mocks the DefaultHost method.
 	DefaultHostFunc func() (string, string)
 
@@ -66,14 +66,8 @@ type ConfigMock struct {
 	// GetOrDefaultFunc mocks the GetOrDefault method.
 	GetOrDefaultFunc func(s1 string, s2 string) (string, error)
 
-	// HostsFunc mocks the Hosts method.
-	HostsFunc func() []string
-
 	// SetFunc mocks the Set method.
 	SetFunc func(s1 string, s2 string, s3 string)
-
-	// UnsetHostFunc mocks the UnsetHost method.
-	UnsetHostFunc func(s string)
 
 	// WriteFunc mocks the Write method.
 	WriteFunc func() error
@@ -87,6 +81,9 @@ type ConfigMock struct {
 		AuthToken []struct {
 			// S is the s argument value.
 			S string
+		}
+		// Authentication holds details about calls to the Authentication method.
+		Authentication []struct {
 		}
 		// DefaultHost holds details about calls to the DefaultHost method.
 		DefaultHost []struct {
@@ -105,9 +102,6 @@ type ConfigMock struct {
 			// S2 is the s2 argument value.
 			S2 string
 		}
-		// Hosts holds details about calls to the Hosts method.
-		Hosts []struct {
-		}
 		// Set holds details about calls to the Set method.
 		Set []struct {
 			// S1 is the s1 argument value.
@@ -117,24 +111,18 @@ type ConfigMock struct {
 			// S3 is the s3 argument value.
 			S3 string
 		}
-		// UnsetHost holds details about calls to the UnsetHost method.
-		UnsetHost []struct {
-			// S is the s argument value.
-			S string
-		}
 		// Write holds details about calls to the Write method.
 		Write []struct {
 		}
 	}
-	lockAliases      sync.RWMutex
-	lockAuthToken    sync.RWMutex
-	lockDefaultHost  sync.RWMutex
-	lockGet          sync.RWMutex
-	lockGetOrDefault sync.RWMutex
-	lockHosts        sync.RWMutex
-	lockSet          sync.RWMutex
-	lockUnsetHost    sync.RWMutex
-	lockWrite        sync.RWMutex
+	lockAliases        sync.RWMutex
+	lockAuthToken      sync.RWMutex
+	lockAuthentication sync.RWMutex
+	lockDefaultHost    sync.RWMutex
+	lockGet            sync.RWMutex
+	lockGetOrDefault   sync.RWMutex
+	lockSet            sync.RWMutex
+	lockWrite          sync.RWMutex
 }
 
 // Aliases calls AliasesFunc.
@@ -193,6 +181,33 @@ func (mock *ConfigMock) AuthTokenCalls() []struct {
 	mock.lockAuthToken.RLock()
 	calls = mock.calls.AuthToken
 	mock.lockAuthToken.RUnlock()
+	return calls
+}
+
+// Authentication calls AuthenticationFunc.
+func (mock *ConfigMock) Authentication() *AuthConfig {
+	if mock.AuthenticationFunc == nil {
+		panic("ConfigMock.AuthenticationFunc: method is nil but Config.Authentication was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockAuthentication.Lock()
+	mock.calls.Authentication = append(mock.calls.Authentication, callInfo)
+	mock.lockAuthentication.Unlock()
+	return mock.AuthenticationFunc()
+}
+
+// AuthenticationCalls gets all the calls that were made to Authentication.
+// Check the length with:
+//
+//	len(mockedConfig.AuthenticationCalls())
+func (mock *ConfigMock) AuthenticationCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockAuthentication.RLock()
+	calls = mock.calls.Authentication
+	mock.lockAuthentication.RUnlock()
 	return calls
 }
 
@@ -295,33 +310,6 @@ func (mock *ConfigMock) GetOrDefaultCalls() []struct {
 	return calls
 }
 
-// Hosts calls HostsFunc.
-func (mock *ConfigMock) Hosts() []string {
-	if mock.HostsFunc == nil {
-		panic("ConfigMock.HostsFunc: method is nil but Config.Hosts was just called")
-	}
-	callInfo := struct {
-	}{}
-	mock.lockHosts.Lock()
-	mock.calls.Hosts = append(mock.calls.Hosts, callInfo)
-	mock.lockHosts.Unlock()
-	return mock.HostsFunc()
-}
-
-// HostsCalls gets all the calls that were made to Hosts.
-// Check the length with:
-//
-//	len(mockedConfig.HostsCalls())
-func (mock *ConfigMock) HostsCalls() []struct {
-} {
-	var calls []struct {
-	}
-	mock.lockHosts.RLock()
-	calls = mock.calls.Hosts
-	mock.lockHosts.RUnlock()
-	return calls
-}
-
 // Set calls SetFunc.
 func (mock *ConfigMock) Set(s1 string, s2 string, s3 string) {
 	if mock.SetFunc == nil {
@@ -359,38 +347,6 @@ func (mock *ConfigMock) SetCalls() []struct {
 	mock.lockSet.RLock()
 	calls = mock.calls.Set
 	mock.lockSet.RUnlock()
-	return calls
-}
-
-// UnsetHost calls UnsetHostFunc.
-func (mock *ConfigMock) UnsetHost(s string) {
-	if mock.UnsetHostFunc == nil {
-		panic("ConfigMock.UnsetHostFunc: method is nil but Config.UnsetHost was just called")
-	}
-	callInfo := struct {
-		S string
-	}{
-		S: s,
-	}
-	mock.lockUnsetHost.Lock()
-	mock.calls.UnsetHost = append(mock.calls.UnsetHost, callInfo)
-	mock.lockUnsetHost.Unlock()
-	mock.UnsetHostFunc(s)
-}
-
-// UnsetHostCalls gets all the calls that were made to UnsetHost.
-// Check the length with:
-//
-//	len(mockedConfig.UnsetHostCalls())
-func (mock *ConfigMock) UnsetHostCalls() []struct {
-	S string
-} {
-	var calls []struct {
-		S string
-	}
-	mock.lockUnsetHost.RLock()
-	calls = mock.calls.UnsetHost
-	mock.lockUnsetHost.RUnlock()
 	return calls
 }
 

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -305,8 +305,10 @@ func Test_loginRun_nontty(t *testing.T) {
 				Token:    "abc456",
 			},
 			cfgStubs: func(c *config.ConfigMock) {
-				c.AuthTokenFunc = func(string) (string, string) {
-					return "value_from_env", "GH_TOKEN"
+				authCfg := c.Authentication()
+				authCfg.SetToken("value_from_env", "GH_TOKEN")
+				c.AuthenticationFunc = func() *config.AuthConfig {
+					return authCfg
 				}
 			},
 			wantErr: "SilentError",
@@ -322,8 +324,10 @@ func Test_loginRun_nontty(t *testing.T) {
 				Token:    "abc456",
 			},
 			cfgStubs: func(c *config.ConfigMock) {
-				c.AuthTokenFunc = func(string) (string, string) {
-					return "value_from_env", "GH_ENTERPRISE_TOKEN"
+				authCfg := c.Authentication()
+				authCfg.SetToken("value_from_env", "GH_ENTERPRISE_TOKEN")
+				c.AuthenticationFunc = func() *config.AuthConfig {
+					return authCfg
 				}
 			},
 			wantErr: "SilentError",
@@ -399,8 +403,10 @@ func Test_loginRun_Survey(t *testing.T) {
 				Interactive: true,
 			},
 			cfgStubs: func(c *config.ConfigMock) {
-				c.AuthTokenFunc = func(h string) (string, string) {
-					return "ghi789", "oauth_token"
+				authCfg := c.Authentication()
+				authCfg.SetToken("ghi789", "oauth_token")
+				c.AuthenticationFunc = func() *config.AuthConfig {
+					return authCfg
 				}
 			},
 			httpStubs: func(reg *httpmock.Registry) {

--- a/pkg/cmd/auth/refresh/refresh_test.go
+++ b/pkg/cmd/auth/refresh/refresh_test.go
@@ -234,7 +234,7 @@ func Test_refreshRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			aa := authArgs{}
-			tt.opts.AuthFlow = func(_ config.Config, _ *iostreams.IOStreams, hostname string, scopes []string, interactive bool) error {
+			tt.opts.AuthFlow = func(_ *config.AuthConfig, _ *iostreams.IOStreams, hostname string, scopes []string, interactive bool) error {
 				aa.hostname = hostname
 				aa.scopes = scopes
 				return nil

--- a/pkg/cmd/auth/setupgit/setupgit.go
+++ b/pkg/cmd/auth/setupgit/setupgit.go
@@ -54,8 +54,9 @@ func setupGitRun(opts *SetupGitOptions) error {
 	if err != nil {
 		return err
 	}
+	authCfg := cfg.Authentication()
 
-	hostnames := cfg.Hosts()
+	hostnames := authCfg.Hosts()
 
 	stderr := opts.IO.ErrOut
 	cs := opts.IO.ColorScheme()

--- a/pkg/cmd/auth/setupgit/setupgit_test.go
+++ b/pkg/cmd/auth/setupgit/setupgit_test.go
@@ -38,8 +38,10 @@ func Test_setupGitRun(t *testing.T) {
 			opts: &SetupGitOptions{
 				Config: func() (config.Config, error) {
 					cfg := &config.ConfigMock{}
-					cfg.HostsFunc = func() []string {
-						return []string{}
+					cfg.AuthenticationFunc = func() *config.AuthConfig {
+						authCfg := &config.AuthConfig{}
+						authCfg.SetHosts([]string{})
+						return authCfg
 					}
 					return cfg, nil
 				},
@@ -53,8 +55,10 @@ func Test_setupGitRun(t *testing.T) {
 				Hostname: "foo",
 				Config: func() (config.Config, error) {
 					cfg := &config.ConfigMock{}
-					cfg.HostsFunc = func() []string {
-						return []string{"bar"}
+					cfg.AuthenticationFunc = func() *config.AuthConfig {
+						authCfg := &config.AuthConfig{}
+						authCfg.SetHosts([]string{"bar"})
+						return authCfg
 					}
 					return cfg, nil
 				},
@@ -70,8 +74,10 @@ func Test_setupGitRun(t *testing.T) {
 				},
 				Config: func() (config.Config, error) {
 					cfg := &config.ConfigMock{}
-					cfg.HostsFunc = func() []string {
-						return []string{"bar"}
+					cfg.AuthenticationFunc = func() *config.AuthConfig {
+						authCfg := &config.AuthConfig{}
+						authCfg.SetHosts([]string{"bar"})
+						return authCfg
 					}
 					return cfg, nil
 				},
@@ -85,8 +91,10 @@ func Test_setupGitRun(t *testing.T) {
 				gitConfigure: &mockGitConfigurer{},
 				Config: func() (config.Config, error) {
 					cfg := &config.ConfigMock{}
-					cfg.HostsFunc = func() []string {
-						return []string{"bar"}
+					cfg.AuthenticationFunc = func() *config.AuthConfig {
+						authCfg := &config.AuthConfig{}
+						authCfg.SetHosts([]string{"bar"})
+						return authCfg
 					}
 					return cfg, nil
 				},
@@ -99,8 +107,10 @@ func Test_setupGitRun(t *testing.T) {
 				gitConfigure: &mockGitConfigurer{},
 				Config: func() (config.Config, error) {
 					cfg := &config.ConfigMock{}
-					cfg.HostsFunc = func() []string {
-						return []string{"bar", "yes"}
+					cfg.AuthenticationFunc = func() *config.AuthConfig {
+						authCfg := &config.AuthConfig{}
+						authCfg.SetHosts([]string{"bar", "yes"})
+						return authCfg
 					}
 					return cfg, nil
 				},

--- a/pkg/cmd/auth/shared/login_flow_test.go
+++ b/pkg/cmd/auth/shared/login_flow_test.go
@@ -18,15 +18,10 @@ import (
 
 type tinyConfig map[string]string
 
-func (c tinyConfig) Get(host, key string) (string, error) {
-	return c[fmt.Sprintf("%s:%s", host, key)], nil
-}
-
-func (c tinyConfig) Set(host string, key string, value string) {
-	c[fmt.Sprintf("%s:%s", host, key)] = value
-}
-
-func (c tinyConfig) Write() error {
+func (c tinyConfig) Login(host, username, token, gitProtocol string, encrypt bool) error {
+	c[fmt.Sprintf("%s:%s", host, "user")] = username
+	c[fmt.Sprintf("%s:%s", host, "oauth_token")] = token
+	c[fmt.Sprintf("%s:%s", host, "git_protocol")] = gitProtocol
 	return nil
 }
 

--- a/pkg/cmd/auth/shared/writeable.go
+++ b/pkg/cmd/auth/shared/writeable.go
@@ -8,7 +8,7 @@ const (
 	oauthToken = "oauth_token"
 )
 
-func AuthTokenWriteable(cfg config.Config, hostname string) (string, bool) {
-	token, src := cfg.AuthToken(hostname)
+func AuthTokenWriteable(authCfg *config.AuthConfig, hostname string) (string, bool) {
+	token, src := authCfg.Token(hostname)
 	return src, (token == "" || src == oauthToken)
 }

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -61,6 +61,7 @@ func statusRun(opts *StatusOptions) error {
 	if err != nil {
 		return err
 	}
+	authCfg := cfg.Authentication()
 
 	// TODO check tty
 
@@ -70,7 +71,7 @@ func statusRun(opts *StatusOptions) error {
 
 	statusInfo := map[string][]string{}
 
-	hostnames := cfg.Hosts()
+	hostnames := authCfg.Hosts()
 	if len(hostnames) == 0 {
 		fmt.Fprintf(stderr,
 			"You are not logged into any GitHub hosts. Run %s to authenticate.\n", cs.Bold("gh auth login"))
@@ -91,13 +92,13 @@ func statusRun(opts *StatusOptions) error {
 		}
 		isHostnameFound = true
 
-		token, tokenSource := cfg.AuthToken(hostname)
+		token, tokenSource := authCfg.Token(hostname)
 		if tokenSource == "oauth_token" {
 			// The go-gh function TokenForHost returns this value as source for tokens read from the
 			// config file, but we want the file path instead. This attempts to reconstruct it.
 			tokenSource = filepath.Join(config.ConfigDir(), "hosts.yml")
 		}
-		_, tokenIsWriteable := shared.AuthTokenWriteable(cfg, hostname)
+		_, tokenIsWriteable := shared.AuthTokenWriteable(authCfg, hostname)
 
 		statusInfo[hostname] = []string{}
 		addMsg := func(x string, ys ...interface{}) {
@@ -138,7 +139,7 @@ func statusRun(opts *StatusOptions) error {
 			}
 
 			addMsg("%s Logged in to %s as %s (%s)", cs.SuccessIcon(), hostname, cs.Bold(username), tokenSource)
-			proto, _ := cfg.GetOrDefault(hostname, "git_protocol")
+			proto, _ := authCfg.GitProtocol(hostname)
 			if proto != "" {
 				addMsg("%s Git operations for %s configured to use %s protocol.",
 					cs.SuccessIcon(), hostname, cs.Bold(proto))

--- a/pkg/cmd/factory/default_test.go
+++ b/pkg/cmd/factory/default_test.go
@@ -71,12 +71,14 @@ func Test_BaseRepo(t *testing.T) {
 				},
 				getConfig: func() (config.Config, error) {
 					cfg := &config.ConfigMock{}
-					cfg.HostsFunc = func() []string {
+					cfg.AuthenticationFunc = func() *config.AuthConfig {
+						authCfg := &config.AuthConfig{}
 						hosts := []string{"nonsense.com"}
 						if tt.override != "" {
 							hosts = append([]string{tt.override}, hosts...)
 						}
-						return hosts
+						authCfg.SetHosts(hosts)
+						return authCfg
 					}
 					cfg.DefaultHostFunc = func() (string, string) {
 						if tt.override != "" {
@@ -214,12 +216,14 @@ func Test_SmartBaseRepo(t *testing.T) {
 					cfg.AuthTokenFunc = func(_ string) (string, string) {
 						return "", ""
 					}
-					cfg.HostsFunc = func() []string {
+					cfg.AuthenticationFunc = func() *config.AuthConfig {
+						authCfg := &config.AuthConfig{}
 						hosts := []string{"nonsense.com"}
 						if tt.override != "" {
 							hosts = append([]string{tt.override}, hosts...)
 						}
-						return hosts
+						authCfg.SetHosts(hosts)
+						return authCfg
 					}
 					cfg.DefaultHostFunc = func() (string, string) {
 						if tt.override != "" {

--- a/pkg/cmd/factory/remote_resolver.go
+++ b/pkg/cmd/factory/remote_resolver.go
@@ -53,7 +53,7 @@ func (rr *remoteResolver) Resolver() func() (context.Remotes, error) {
 			return nil, err
 		}
 
-		authedHosts := cfg.Hosts()
+		authedHosts := cfg.Authentication().Hosts()
 		if len(authedHosts) == 0 {
 			return nil, errors.New("could not find any host configurations")
 		}

--- a/pkg/cmd/factory/remote_resolver_test.go
+++ b/pkg/cmd/factory/remote_resolver_test.go
@@ -32,8 +32,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "github.com", "default"
@@ -49,8 +51,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{"example.com"}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{"example.com"})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "example.com", "hosts"
@@ -68,8 +72,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{"example.com"}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{"example.com"})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "example.com", "hosts"
@@ -90,8 +96,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{"example.com"}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{"example.com"})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "example.com", "hosts"
@@ -109,8 +117,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{"example.com"}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{"example.com"})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "example.com", "default"
@@ -131,8 +141,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{"example.com"}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{"example.com"})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "example.com", "default"
@@ -150,8 +162,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{"example.com", "github.com"}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{"example.com", "github.com"})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "github.com", "default"
@@ -173,8 +187,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{"example.com", "github.com"}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{"example.com", "github.com"})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "github.com", "default"
@@ -196,8 +212,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{"example.com", "github.com"}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{"example.com", "github.com"})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "github.com", "default"
@@ -215,8 +233,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{"example.com"}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{"example.com"})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "test.com", "GH_HOST"
@@ -235,8 +255,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{"example.com"}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{"example.com"})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "test.com", "GH_HOST"
@@ -256,8 +278,10 @@ func Test_remoteResolver(t *testing.T) {
 			},
 			config: func() config.Config {
 				cfg := &config.ConfigMock{}
-				cfg.HostsFunc = func() []string {
-					return []string{"example.com", "test.com"}
+				cfg.AuthenticationFunc = func() *config.AuthConfig {
+					authCfg := &config.AuthConfig{}
+					authCfg.SetHosts([]string{"example.com", "test.com"})
+					return authCfg
 				}
 				cfg.DefaultHostFunc = func() (string, string) {
 					return "test.com", "GH_HOST"

--- a/pkg/cmdutil/auth_check.go
+++ b/pkg/cmdutil/auth_check.go
@@ -23,7 +23,7 @@ func CheckAuth(cfg config.Config) bool {
 		return true
 	}
 
-	if len(cfg.Hosts()) > 0 {
+	if len(cfg.Authentication().Hosts()) > 0 {
 		return true
 	}
 


### PR DESCRIPTION
This PR breaks up the `Config` interface and moves authentication methods into the new `AuthConfig`. This is done to make it easy to implement encrypted token storage. Essentially in any of the `auth` code we can now use `AuthConfig` instead of `Config`. There are no functional changes here and all test changes are done to now stub/mock out `AuthConfig` instead of `Config`. 

supersedes: https://github.com/cli/cli/pull/7023
follow up: https://github.com/cli/cli/pull/7043
cc: https://github.com/cli/cli/issues/449
