### PR TITLE
Made it possible to do open num only commit hash with Browse Command

### DIFF
--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -174,7 +174,7 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 		}
 	}
 
-	if isNumber(opts.SelectorArg) {
+	if !opts.CommitFlag && isNumber(opts.SelectorArg) {
 		return fmt.Sprintf("issues/%s", strings.TrimPrefix(opts.SelectorArg, "#")), nil
 	}
 

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -123,6 +123,15 @@ func TestNewCmdBrowse(t *testing.T) {
 			},
 			wantsErr: false,
 		},
+		{
+			name: "commit hash flag",
+			cli:  "-c 123",
+			wants: BrowseOptions{
+				CommitFlag:  true,
+				SelectorArg: "123",
+			},
+			wantsErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -394,6 +403,17 @@ func Test_runBrowse(t *testing.T) {
 			baseRepo:    ghrepo.New("vilmibm", "gh-user-status"),
 			wantsErr:    false,
 			expectedURL: "https://github.com/vilmibm/gh-user-status/tree/6f1a2405cace1633d89a79c74c65f22fe78f9659/main.go",
+		},
+		{
+			name: "open number only commit hash",
+			opts: BrowseOptions{
+				CommitFlag:  true,
+				SelectorArg: "1234567890",
+				GitClient:   &testGitClient{},
+			},
+			baseRepo:    ghrepo.New("yanskun", "ILoveGitHub"),
+			wantsErr:    false,
+			expectedURL: "https://github.com/yanskun/ILoveGitHub/commit/1234567890",
 		},
 		{
 			name: "relative path from browse_test.go",


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

A short commit hash, such as `git log --oneline`.
This also has a numeric-only hash value.

If I use them as arguments to `gh browse` it tries to open an issue and fails.
so sad i fixed it.

I made it possible to use it by using it together with Option `--commit`.
It's a problem when you have filenames that consist only of numbers,
but that's okay😜