### PR TITLE
Allow https scheme prefix for --hostname

### DIFF
--- a/internal/ghinstance/host.go
+++ b/internal/ghinstance/host.go
@@ -37,14 +37,14 @@ func NormalizeHostname(h string) string {
 		return localhost
 	}
 
-	return hostname
+	return strings.TrimPrefix(hostname, "https://")
 }
 
 func HostnameValidator(hostname string) error {
 	if len(strings.TrimSpace(hostname)) < 1 {
 		return errors.New("a value is required")
 	}
-	if strings.ContainsRune(hostname, '/') || strings.ContainsRune(hostname, ':') {
+	if (strings.ContainsRune(hostname, '/') || strings.ContainsRune(hostname, ':')) && !strings.HasPrefix(hostname, "https://") {
 		return errors.New("invalid hostname")
 	}
 	return nil

--- a/internal/ghinstance/host_test.go
+++ b/internal/ghinstance/host_test.go
@@ -90,6 +90,10 @@ func TestNormalizeHostname(t *testing.T) {
 			host: "git.my.org",
 			want: "git.my.org",
 		},
+		{
+			host: "https://git.my.org",
+			want: "git.my.org",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.host, func(t *testing.T) {
@@ -109,6 +113,11 @@ func TestHostnameValidator(t *testing.T) {
 		{
 			name:     "valid hostname",
 			input:    "internal.instance",
+			wantsErr: false,
+		},
+		{
+			name:     "hostname with https",
+			input:    "https://internal.instance",
 			wantsErr: false,
 		},
 		{

--- a/internal/ghrepo/repo.go
+++ b/internal/ghrepo/repo.go
@@ -72,7 +72,7 @@ func FromURL(u *url.URL) (Interface, error) {
 }
 
 func normalizeHostname(h string) string {
-	return strings.ToLower(strings.TrimPrefix(h, "www."))
+	return strings.ToLower(strings.TrimPrefix(strings.TrimPrefix(h, "https://"), "www."))
 }
 
 // IsSame compares two GitHub repositories
@@ -116,5 +116,5 @@ func (r ghRepo) RepoName() string {
 }
 
 func (r ghRepo) RepoHost() string {
-	return r.hostname
+	return strings.TrimPrefix(r.hostname, "https://")
 }

--- a/internal/ghrepo/repo_test.go
+++ b/internal/ghrepo/repo_test.go
@@ -190,6 +190,15 @@ func TestFromFullName(t *testing.T) {
 			wantName:     "REPO",
 			wantErr:      nil,
 		},
+		{
+			name:         "OWNER/REPO with default host override containing https scheme",
+			input:        "OWNER/REPO",
+			hostOverride: "https://override.com",
+			wantHost:     "override.com",
+			wantOwner:    "OWNER",
+			wantName:     "REPO",
+			wantErr:      nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -193,6 +193,7 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 				if err := ghinstance.HostnameValidator(opts.Hostname); err != nil {
 					return cmdutil.FlagErrorf("error parsing `--hostname`: %w", err)
 				}
+				opts.Hostname = strings.TrimPrefix(opts.Hostname, "https://")
 			}
 
 			if opts.Paginate && !strings.EqualFold(opts.RequestMethod, "GET") && opts.RequestPath != "graphql" {
@@ -314,6 +315,8 @@ func apiRun(opts *ApiOptions) error {
 	if opts.Hostname != "" {
 		host = opts.Hostname
 	}
+
+	host = strings.TrimPrefix(host, "https://")
 
 	tmpl := template.New(bodyWriter, opts.IO.TerminalWidth(), opts.IO.ColorEnabled())
 	err = tmpl.Parse(opts.Template)

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -239,6 +239,27 @@ func Test_NewCmdApi(t *testing.T) {
 			wantsErr: false,
 		},
 		{
+			name: "with hostname containing https scheme",
+			cli:  "graphql --hostname https://tom.petty",
+			wants: ApiOptions{
+				Hostname:            "tom.petty",
+				RequestMethod:       "GET",
+				RequestMethodPassed: false,
+				RequestPath:         "graphql",
+				RequestInputFile:    "",
+				RawFields:           []string(nil),
+				MagicFields:         []string(nil),
+				RequestHeaders:      []string(nil),
+				ShowResponseHeaders: false,
+				Paginate:            false,
+				Silent:              false,
+				CacheTTL:            0,
+				Template:            "",
+				FilterOutput:        "",
+			},
+			wantsErr: false,
+		},
+		{
 			name: "with cache",
 			cli:  "user --cache 5m",
 			wants: ApiOptions{


### PR DESCRIPTION
Allow the value of `--hostname` to be prefixed with `https://` to make usage of the tool within GitHub Enterprise Server easier without hardcoding a hostname by allowing use of `--hostname ${{ env.GITHUB_SERVER_URL }}` or `GH_HOST: ${{ env.GITHUB_SERVER_URL }}`.

Other schemes, such as `http`, are still rejected.

As [`GITHUB_SERVER_URL`](https://docs.github.com/en/actions/learn-github-actions/variables) is prefixed with `https://`, using it verbatim is rejected as an invalid hostname.

Before this change you'd need to do something like this and either hardcode the domain (or add some code to strip the hostname of the scheme first):

```yml
- name: gh
  shell: bash
  env:
    GH_ENTERPRISE_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
    GH_HOST: 'github.corp'
    run: |
      gh api \
        -H "Accept: application/vnd.github+json" \
        /user
```

With these changes you should be able to just do this:

```yml
- name: gh
  shell: bash
  env:
    GH_ENTERPRISE_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
    GH_HOST: ${{ env.GITHUB_SERVER_URL }}
    run: |
      gh api \
        -H "Accept: application/vnd.github+json" \
        /user
```

An alternative approach would be for `gh` to auto-detect when it's running in GitHub Actions for GHES and assume that the `GITHUB_SERVER_URL` should be used instead of `github.com` if the host isn't specified and `GH_ENTERPRISE_TOKEN` is set.

_Aside: this is basically my first ever foray into golang, so I imagine there's probably a better way to do this and/or a way to centralise this logic into one place instead of having to do it in a few places._
