### PR TITLE
fix: correctly set `ErrNotOnAnyBranch` error in git client

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -142,6 +142,7 @@ func (c *Client) CurrentBranch(ctx context.Context) (string, error) {
 	if err != nil {
 		var gitErr *GitError
 		if ok := errors.As(err, &gitErr); ok && len(gitErr.Stderr) == 0 {
+			gitErr.err = ErrNotOnAnyBranch
 			gitErr.Stderr = "not on any branch"
 			return "", gitErr
 		}


### PR DESCRIPTION
Before, git client was not correctly reporting `ErrNotOnAnyBranch` error. Because of that, `gh pr status` was not functioning correctly when run from the detached HEAD. This PR fixes that.

Fixes #7051
