### PR TITLE
Add `alias imports` command

### DIFF
--- a/pkg/cmd/alias/alias.go
+++ b/pkg/cmd/alias/alias.go
@@ -3,6 +3,7 @@ package alias
 import (
 	"github.com/MakeNowJust/heredoc"
 	deleteCmd "github.com/cli/cli/v2/pkg/cmd/alias/delete"
+	importsCmd "github.com/cli/cli/v2/pkg/cmd/alias/imports"
 	listCmd "github.com/cli/cli/v2/pkg/cmd/alias/list"
 	setCmd "github.com/cli/cli/v2/pkg/cmd/alias/set"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -23,6 +24,7 @@ func NewCmdAlias(f *cmdutil.Factory) *cobra.Command {
 	cmdutil.DisableAuthCheck(cmd)
 
 	cmd.AddCommand(deleteCmd.NewCmdDelete(f, nil))
+	cmd.AddCommand(importsCmd.NewCmdImports(f, nil))
 	cmd.AddCommand(listCmd.NewCmdList(f, nil))
 	cmd.AddCommand(setCmd.NewCmdSet(f, nil))
 

--- a/pkg/cmd/alias/imports/imports.go
+++ b/pkg/cmd/alias/imports/imports.go
@@ -1,0 +1,212 @@
+package imports
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+type ImportsOptions struct {
+	Config func() (config.Config, error)
+	IO     *iostreams.IOStreams
+
+	Filename          string
+	OverwriteExisting bool
+
+	validCommand func(string) bool
+}
+
+func NewCmdImports(f *cmdutil.Factory, runF func(*ImportsOptions) error) *cobra.Command {
+	opts := &ImportsOptions{
+		IO:     f.IOStreams,
+		Config: f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "imports [<filename> | -]",
+		Short: "Import aliases from a YAML file",
+		Long: heredoc.Doc(`
+            Import aliases from the contents of a YAML file.
+
+            Aliases should be defined as a map in YAML, where the keys represent aliases and
+            the values represent the corresponding expansions. An example file should look like
+            the following:
+
+                bugs: issue list --label=bug
+                igrep: '!gh issue list --label="$1" | grep "$2"'
+                features: |-
+                    issue list
+                    --label=enhancement
+
+            Use "-" to read aliases (in YAML format) from standard input.
+
+            The output from the gh command "alias list" can be used to produce a YAML file 
+            containing your aliases, which you can use to import them from one machine to
+            another. Run "gh help alias list" to learn more.
+        `),
+		Example: heredoc.Doc(`
+            # Import aliases from a file
+            $ gh alias imports aliases.yml
+
+            # Import aliases from standard input
+            $ gh alias imports -
+        `),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				return cmdutil.FlagErrorf("too many arguments")
+			}
+			if len(args) == 0 && opts.IO.IsStdinTTY() {
+				return cmdutil.FlagErrorf("no filename passed and nothing on STDIN")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Filename = "-"
+			if len(args) > 0 {
+				opts.Filename = args[0]
+			}
+
+			opts.validCommand = func(args string) bool {
+				split, err := shlex.Split(args)
+				if err != nil || len(split) == 0 {
+					return false
+				}
+
+				rootCmd := cmd.Root()
+				cmd, _, err := rootCmd.Traverse(split)
+				if err == nil && cmd != rootCmd {
+					return true
+				}
+
+				for _, ext := range f.ExtensionManager.List() {
+					if ext.Name() == split[0] {
+						return true
+					}
+				}
+				return false
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return importsRun(opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.OverwriteExisting, "clobber", false, "Overwrite existing aliases of the same name")
+
+	return cmd
+}
+
+func importsRun(opts *ImportsOptions) error {
+	cs := opts.IO.ColorScheme()
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	aliasCfg := cfg.Aliases()
+
+	b, err := cmdutil.ReadFile(opts.Filename, opts.IO.In)
+	if err != nil {
+		return err
+	}
+
+	aliasMap := map[string]string{}
+	if err = yaml.Unmarshal(b, &aliasMap); err != nil {
+		return err
+	}
+
+	isTerminal := opts.IO.IsStdoutTTY()
+	if isTerminal {
+		if opts.Filename == "-" {
+			fmt.Fprintf(opts.IO.ErrOut, "- Importing aliases from standard input\n")
+		} else {
+			fmt.Fprintf(opts.IO.ErrOut, "- Importing aliases from file %q\n", opts.Filename)
+		}
+	}
+
+	msg := strings.Builder{}
+
+	for _, alias := range getSortedKeys(aliasMap) {
+		if opts.validCommand(alias) {
+			msg.WriteString(
+				fmt.Sprintf("%s Could not import alias %s: already a gh command\n",
+					cs.FailureIcon(),
+					cs.Bold(alias),
+				),
+			)
+
+			continue
+		}
+
+		expansion := aliasMap[alias]
+
+		if !(strings.HasPrefix(expansion, "!") || opts.validCommand(expansion)) {
+			msg.WriteString(
+				fmt.Sprintf("%s Could not import alias %s: expansion does not correspond to a gh command\n",
+					cs.FailureIcon(),
+					cs.Bold(alias),
+				),
+			)
+
+			continue
+		}
+
+		if _, err := aliasCfg.Get(alias); err == nil {
+			if opts.OverwriteExisting {
+				aliasCfg.Add(alias, expansion)
+
+				msg.WriteString(
+					fmt.Sprintf("%s Changed alias %s\n",
+						cs.WarningIcon(),
+						cs.Bold(alias),
+					),
+				)
+			} else {
+				msg.WriteString(
+					fmt.Sprintf("%s Could not import alias %s: already taken\n",
+						cs.FailureIcon(),
+						cs.Bold(alias),
+					),
+				)
+			}
+		} else {
+			aliasCfg.Add(alias, expansion)
+
+			msg.WriteString(
+				fmt.Sprintf("%s Added alias %s\n",
+					cs.SuccessIcon(),
+					cs.Bold(alias),
+				),
+			)
+		}
+	}
+
+	if err := cfg.Write(); err != nil {
+		return err
+	}
+
+	if isTerminal {
+		fmt.Fprintln(opts.IO.ErrOut, msg.String())
+	}
+
+	return nil
+}
+
+func getSortedKeys(m map[string]string) []string {
+	keys := []string{}
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/cmd/alias/imports/imports.go
+++ b/pkg/cmd/alias/imports/imports.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/pkg/cmd/alias/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/google/shlex"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -74,25 +74,7 @@ func NewCmdImports(f *cmdutil.Factory, runF func(*ImportsOptions) error) *cobra.
 				opts.Filename = args[0]
 			}
 
-			opts.validCommand = func(args string) bool {
-				split, err := shlex.Split(args)
-				if err != nil || len(split) == 0 {
-					return false
-				}
-
-				rootCmd := cmd.Root()
-				cmd, _, err := rootCmd.Traverse(split)
-				if err == nil && cmd != rootCmd {
-					return true
-				}
-
-				for _, ext := range f.ExtensionManager.List() {
-					if ext.Name() == split[0] {
-						return true
-					}
-				}
-				return false
-			}
+			opts.validCommand = shared.ValidCommandFunc(f, cmd)
 
 			if runF != nil {
 				return runF(opts)

--- a/pkg/cmd/alias/imports/imports_test.go
+++ b/pkg/cmd/alias/imports/imports_test.go
@@ -1,0 +1,276 @@
+package imports
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/extensions"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/test"
+	"github.com/google/shlex"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAliasImports(t *testing.T) {
+	tmpFile := filepath.Join(os.TempDir(), "test.yml")
+	defer os.Remove(tmpFile)
+
+	tests := []struct {
+		name             string
+		isTTY            bool
+		input            string
+		stdin            string
+		fileContents     string
+		initialConfig    string
+		expectedConfig   string
+		expectedOutLines []string
+		expectedErrLines []string
+		wantErr          string
+	}{
+		{
+			name:    "no filename",
+			isTTY:   true,
+			wantErr: "no filename passed and nothing on STDIN",
+		},
+		{
+			name:    "more than one filename",
+			isTTY:   true,
+			input:   "aliases1.yml aliases2.yml",
+			wantErr: "too many arguments",
+		},
+		{
+			name:  "with no existing aliases",
+			isTTY: true,
+			input: tmpFile,
+			fileContents: heredoc.Doc(`
+                co: pr checkout
+                igrep: '!gh issue list --label="$1" | grep "$2"'
+            `),
+			expectedConfig: heredoc.Doc(`
+                aliases:
+                    co: pr checkout
+                    igrep: '!gh issue list --label="$1" | grep "$2"'
+            `),
+			expectedErrLines: []string{"Importing aliases from file", "Added alias (co|igrep)"},
+			expectedOutLines: []string{},
+		},
+		{
+			name:  "with existing aliases",
+			isTTY: true,
+			input: tmpFile,
+			fileContents: heredoc.Doc(`
+                users: |-
+                    api graphql -F name="$1" -f query='
+                        query ($name: String!) {
+                            user(login: $name) {
+                                name
+                            }
+                        }'
+                co: pr checkout
+            `),
+			initialConfig: heredoc.Doc(`
+                aliases:
+                    igrep: '!gh issue list --label="$1" | grep "$2"'
+                editor: vim
+            `),
+			expectedConfig: heredoc.Doc(`
+                aliases:
+                    igrep: '!gh issue list --label="$1" | grep "$2"'
+                    co: pr checkout
+                    users: |-
+                        api graphql -F name="$1" -f query='
+                            query ($name: String!) {
+                                user(login: $name) {
+                                    name
+                                }
+                            }'
+                editor: vim
+            `),
+			expectedErrLines: []string{"Importing aliases from file", "Added alias (co|users)"},
+			expectedOutLines: []string{},
+		},
+		{
+			name:  "from stdin",
+			isTTY: true,
+			input: "-",
+			stdin: heredoc.Doc(`
+                co: pr checkout
+                features: |-
+                    issue list
+                    --label=enhancement
+                igrep: '!gh issue list --label="$1" | grep "$2"'
+            `),
+			expectedConfig: heredoc.Doc(`
+                aliases:
+                    co: pr checkout
+                    features: |-
+                        issue list
+                        --label=enhancement
+                    igrep: '!gh issue list --label="$1" | grep "$2"'
+            `),
+			expectedErrLines: []string{"Importing aliases from standard input", "Added alias (co|igrep)"},
+			expectedOutLines: []string{},
+		},
+		{
+			name:  "already taken aliases",
+			isTTY: true,
+			input: tmpFile,
+			fileContents: heredoc.Doc(`
+                co: pr checkout -R cool/repo
+                igrep: '!gh issue list --label="$1" | grep "$2"'
+            `),
+			initialConfig: heredoc.Doc(`
+                aliases:
+                    co: pr checkout
+                editor: vim
+            `),
+			expectedConfig: heredoc.Doc(`
+                aliases:
+                    co: pr checkout
+                    igrep: '!gh issue list --label="$1" | grep "$2"'
+                editor: vim
+            `),
+			expectedErrLines: []string{
+				"Importing aliases from file",
+				"Could not import alias co: already taken",
+				"Added alias igrep",
+			},
+			expectedOutLines: []string{},
+		},
+		{
+			name:  "override aliases",
+			isTTY: true,
+			input: "--clobber " + tmpFile,
+			fileContents: heredoc.Doc(`
+                co: pr checkout -R cool/repo
+                igrep: '!gh issue list --label="$1" | grep "$2"'
+            `),
+			initialConfig: heredoc.Doc(`
+                aliases:
+                    co: pr checkout
+                editor: vim
+            `),
+			expectedConfig: heredoc.Doc(`
+                aliases:
+                    co: pr checkout -R cool/repo
+                    igrep: '!gh issue list --label="$1" | grep "$2"'
+                editor: vim
+            `),
+			expectedErrLines: []string{
+				"Importing aliases from file",
+				"Changed alias co",
+				"Added alias igrep",
+			},
+			expectedOutLines: []string{},
+		},
+		{
+			name:  "alias is a gh command",
+			isTTY: true,
+			input: tmpFile,
+			fileContents: heredoc.Doc(`
+                pr: pr checkout
+                issue: issue list
+                api: api graphql
+            `),
+			expectedErrLines: []string{"Could not import alias (pr|checkout|list): already a gh command"},
+			expectedOutLines: []string{},
+		},
+		{
+			name:  "invalid expansion",
+			isTTY: true,
+			input: tmpFile,
+			fileContents: heredoc.Doc(`
+                alias1:
+                alias2: ps checkout
+            `),
+			expectedErrLines: []string{"Could not import alias alias[0-9]: expansion does not correspond to a gh command"},
+			expectedOutLines: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, os.WriteFile(tmpFile, []byte(tt.fileContents), 0600))
+
+			readConfigs := config.StubWriteConfig(t)
+
+			cfg := config.NewFromString(tt.initialConfig)
+
+			output, err := runCommand(cfg, tt.isTTY, tt.input, tt.stdin)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			mainBuf := bytes.Buffer{}
+			readConfigs(&mainBuf, io.Discard)
+
+			//nolint:staticcheck // prefer exact matchers over ExpectLines
+			test.ExpectLines(t, output.Stderr(), tt.expectedErrLines...)
+			//nolint:staticcheck // prefer exact matchers over ExpectLines
+			test.ExpectLines(t, output.String(), tt.expectedOutLines...)
+
+			assert.Equal(t, tt.expectedConfig, mainBuf.String())
+		})
+	}
+}
+
+func runCommand(cfg config.Config, isTTY bool, cli, in string) (*test.CmdOut, error) {
+	ios, stdin, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
+	stdin.WriteString(in)
+
+	factory := &cmdutil.Factory{
+		IOStreams: ios,
+		Config: func() (config.Config, error) {
+			return cfg, nil
+		},
+		ExtensionManager: &extensions.ExtensionManagerMock{
+			ListFunc: func() []extensions.Extension {
+				return []extensions.Extension{}
+			},
+		},
+	}
+
+	cmd := NewCmdImports(factory, nil)
+
+	// fake command nesting structure needed for validCommand
+	rootCmd := &cobra.Command{}
+	rootCmd.AddCommand(cmd)
+	prCmd := &cobra.Command{Use: "pr"}
+	prCmd.AddCommand(&cobra.Command{Use: "checkout"})
+	prCmd.AddCommand(&cobra.Command{Use: "status"})
+	rootCmd.AddCommand(prCmd)
+	issueCmd := &cobra.Command{Use: "issue"}
+	issueCmd.AddCommand(&cobra.Command{Use: "list"})
+	rootCmd.AddCommand(issueCmd)
+	apiCmd := &cobra.Command{Use: "api"}
+	apiCmd.AddCommand(&cobra.Command{Use: "graphql"})
+	rootCmd.AddCommand(apiCmd)
+
+	argv, err := shlex.Split("imports " + cli)
+	if err != nil {
+		return nil, err
+	}
+	rootCmd.SetArgs(argv)
+	rootCmd.SetIn(stdin)
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+
+	err = rootCmd.Execute()
+	return &test.CmdOut{
+		OutBuf: stdout,
+		ErrBuf: stderr,
+	}, err
+}

--- a/pkg/cmd/alias/imports/imports_test.go
+++ b/pkg/cmd/alias/imports/imports_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestAliasImports(t *testing.T) {
-	tmpFile := filepath.Join(os.TempDir(), "test.yml")
+	tmpFile := filepath.Join(t.TempDir(), "test.yml")
 	defer os.Remove(tmpFile)
 
 	tests := []struct {

--- a/pkg/cmd/alias/set/set.go
+++ b/pkg/cmd/alias/set/set.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/pkg/cmd/alias/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/google/shlex"
 	"github.com/spf13/cobra"
 )
 
@@ -70,25 +70,7 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 			opts.Name = args[0]
 			opts.Expansion = args[1]
 
-			opts.validCommand = func(args string) bool {
-				split, err := shlex.Split(args)
-				if err != nil {
-					return false
-				}
-
-				rootCmd := cmd.Root()
-				cmd, _, err := rootCmd.Traverse(split)
-				if err == nil && cmd != rootCmd {
-					return true
-				}
-
-				for _, ext := range f.ExtensionManager.List() {
-					if ext.Name() == split[0] {
-						return true
-					}
-				}
-				return false
-			}
+			opts.validCommand = shared.ValidCommandFunc(f, cmd)
 
 			if runF != nil {
 				return runF(opts)

--- a/pkg/cmd/alias/shared/args.go
+++ b/pkg/cmd/alias/shared/args.go
@@ -1,0 +1,29 @@
+package shared
+
+import (
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/google/shlex"
+	"github.com/spf13/cobra"
+)
+
+func ValidCommandFunc(f *cmdutil.Factory, cmd *cobra.Command) func(string) bool {
+	return func(args string) bool {
+		split, err := shlex.Split(args)
+		if err != nil || len(split) == 0 {
+			return false
+		}
+
+		rootCmd := cmd.Root()
+		cmd, _, err = rootCmd.Traverse(split)
+		if err == nil && cmd != rootCmd {
+			return true
+		}
+
+		for _, ext := range f.ExtensionManager.List() {
+			if ext.Name() == split[0] {
+				return true
+			}
+		}
+		return false
+	}
+}


### PR DESCRIPTION
Fixes <https://github.com/cli/cli/issues/6475>

This pull request implements a new command for importing aliases (in YAML format). It can read aliases from a file or standard input. It logs each input alias that is added or discarded to standard error. The command also provides a `clobber` flag for overwriting already taken aliases. Note that I named the command `imports` and not `import` as `import` is a keyword in Go.

Let me know if I need to add/change/remove anything. 🙂

Here is a screenshot:

![screenshot](https://user-images.githubusercontent.com/21070577/222989951-3a608999-5433-456c-a623-8ff6de4186b9.png)