### PR TITLE
Always open new vscode window in `gh cs code`

### DIFF
--- a/pkg/cmd/codespace/code.go
+++ b/pkg/cmd/codespace/code.go
@@ -66,5 +66,5 @@ func vscodeProtocolURL(codespaceName string, useInsiders bool) string {
 	if useInsiders {
 		application = "vscode-insiders"
 	}
-	return fmt.Sprintf("%s://github.codespaces/connect?name=%s", application, url.QueryEscape(codespaceName))
+	return fmt.Sprintf("%s://github.codespaces/connect?name=%s&windowId=_blank", application, url.QueryEscape(codespaceName))
 }

--- a/pkg/cmd/codespace/code_test.go
+++ b/pkg/cmd/codespace/code_test.go
@@ -28,7 +28,7 @@ func TestApp_VSCode(t *testing.T) {
 				useInsiders:   false,
 			},
 			wantErr: false,
-			wantURL: "vscode://github.codespaces/connect?name=monalisa-cli-cli-abcdef",
+			wantURL: "vscode://github.codespaces/connect?name=monalisa-cli-cli-abcdef&windowId=_blank",
 		},
 		{
 			name: "open VS Code Insiders",
@@ -37,7 +37,7 @@ func TestApp_VSCode(t *testing.T) {
 				useInsiders:   true,
 			},
 			wantErr: false,
-			wantURL: "vscode-insiders://github.codespaces/connect?name=monalisa-cli-cli-abcdef",
+			wantURL: "vscode-insiders://github.codespaces/connect?name=monalisa-cli-cli-abcdef&windowId=_blank",
 		},
 		{
 			name: "open VS Code web",


### PR DESCRIPTION
fixes https://github.com/github/codespaces/issues/12633

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

There was a recent codespaces vscode extension release which better integrates with vscode's signals to reuse windows or not. Unfortunately, the CLI was sort of relying on the extension NOT integrating correctly for opening vscode and now `gh cs code` will take over any open vscode window. This change fixes that by always opening a new vscode window.