### PR TITLE
Use default host for auth token command if a hostname is not provided

### DIFF
--- a/pkg/cmd/auth/token/token.go
+++ b/pkg/cmd/auth/token/token.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/cli/cli/v2/internal/config"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/spf13/cobra"
@@ -45,16 +44,16 @@ func NewCmdToken(f *cmdutil.Factory, runF func(*TokenOptions) error) *cobra.Comm
 }
 
 func tokenRun(opts *TokenOptions) error {
-	hostname := opts.Hostname
-	if hostname == "" {
-		hostname = ghinstance.Default()
-	}
-
 	cfg, err := opts.Config()
 	if err != nil {
 		return err
 	}
 	authCfg := cfg.Authentication()
+
+	hostname := opts.Hostname
+	if hostname == "" {
+		hostname, _ = authCfg.DefaultHost()
+	}
 
 	var val string
 	if opts.SecureStorage {

--- a/pkg/cmd/auth/token/token_test.go
+++ b/pkg/cmd/auth/token/token_test.go
@@ -125,6 +125,22 @@ func TestTokenRun(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "no oauth token",
 		},
+		{
+			name: "uses default host when one is not provided",
+			opts: TokenOptions{
+				Config: func() (config.Config, error) {
+					cfg := config.NewBlankConfig()
+					cfg.AuthenticationFunc = func() *config.AuthConfig {
+						authCfg := &config.AuthConfig{}
+						authCfg.SetDefaultHost("github.mycompany.com", "GH_HOST")
+						authCfg.SetToken("gho_1234567", "default")
+						return authCfg
+					}
+					return cfg, nil
+				},
+			},
+			wantStdout: "gho_1234567\n",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/7090