### PR TITLE
Make auth refresh more convenient with secure storage

### DIFF
--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -134,7 +134,7 @@ func refreshRun(opts *RefreshOptions) error {
 	}
 
 	var additionalScopes []string
-	if oldToken, _ := authCfg.Token(hostname); oldToken != "" {
+	if oldToken, source := authCfg.Token(hostname); oldToken != "" {
 		if oldScopes, err := shared.GetScopes(opts.HttpClient, hostname, oldToken); err == nil {
 			for _, s := range strings.Split(oldScopes, ",") {
 				s = strings.TrimSpace(s)
@@ -142,6 +142,13 @@ func refreshRun(opts *RefreshOptions) error {
 					additionalScopes = append(additionalScopes, s)
 				}
 			}
+		}
+
+		// If previous token was stored in secure storage assume
+		// user wants to continue storing it there even if not
+		// explicitly stated with the secure storage flag.
+		if source == "keyring" {
+			opts.SecureStorage = true
 		}
 	}
 


### PR DESCRIPTION
This PR adds some convenience functionality to `auth refresh` command. Now if a user logged in with `auth login --secure-storage` or `auth refresh --secure-storage` next time they use `auth refresh` the `--secure-storage` flag will be implicitly set. Basically, if the token we want to refresh is coming from secure storage we assume that the user wants to continue to use secure storage even if they forgot to add the `--secure-storage` flag.