### PR TITLE
Dont follow redirects on repo delete

### DIFF
--- a/pkg/cmd/repo/delete/http.go
+++ b/pkg/cmd/repo/delete/http.go
@@ -10,8 +10,11 @@ import (
 )
 
 func deleteRepo(client *http.Client, repo ghrepo.Interface) error {
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
+	noRedirectClient := &http.Client{
+		Transport: client.Transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	url := fmt.Sprintf("%srepos/%s",
@@ -23,7 +26,7 @@ func deleteRepo(client *http.Client, repo ghrepo.Interface) error {
 		return err
 	}
 
-	resp, err := client.Do(request)
+	resp, err := noRedirectClient.Do(request)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/delete/http.go
+++ b/pkg/cmd/repo/delete/http.go
@@ -10,11 +10,10 @@ import (
 )
 
 func deleteRepo(client *http.Client, repo ghrepo.Interface) error {
-	noRedirectClient := &http.Client{
-		Transport: client.Transport,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+	oldClient := *client
+	client = &oldClient
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
 	}
 
 	url := fmt.Sprintf("%srepos/%s",
@@ -26,7 +25,7 @@ func deleteRepo(client *http.Client, repo ghrepo.Interface) error {
 		return err
 	}
 
-	resp, err := noRedirectClient.Do(request)
+	resp, err := client.Do(request)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/delete/http.go
+++ b/pkg/cmd/repo/delete/http.go
@@ -10,6 +10,10 @@ import (
 )
 
 func deleteRepo(client *http.Client, repo ghrepo.Interface) error {
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
 	url := fmt.Sprintf("%srepos/%s",
 		ghinstance.RESTPrefix(repo.RepoHost()),
 		ghrepo.FullName(repo))


### PR DESCRIPTION
Don't follow redirects when trying to do repo deletion. This prevents accidentally deleting repos that have transferred ownership.  