### PR TITLE
issue-6910 clearer message with actionable hint for repo sync

### DIFF
--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -256,7 +256,7 @@ func executeLocalRepoSync(srcRepo ghrepo.Interface, remote string, opts *SyncOpt
 	}
 	if currentBranch == branch {
 		if isDirty, err := git.IsDirty(); err == nil && isDirty {
-			return fmt.Errorf("refusing to sync due to uncommitted or untracked local changes.\nCheck your local changes with `git status` and either commit them, or use `git stash --all` before retrying this `sync` and running `git stash pop` afterwards")
+			return fmt.Errorf("refusing to sync due to uncommitted/untracked local changes\ntip: use `git stash --all` before retrying the sync and run `git stash pop` afterwards")
 		} else if err != nil {
 			return err
 		}

--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -256,7 +256,7 @@ func executeLocalRepoSync(srcRepo ghrepo.Interface, remote string, opts *SyncOpt
 	}
 	if currentBranch == branch {
 		if isDirty, err := git.IsDirty(); err == nil && isDirty {
-			return fmt.Errorf("can't sync because there are local changes; please stash them before trying again")
+			return fmt.Errorf("refusing to sync due to uncommitted or untracked local changes.\nCheck your local changes with `git status` and either commit them, or use `git stash --all` before retrying this `sync` and running `git stash pop` afterwards")
 		} else if err != nil {
 			return err
 		}

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -229,7 +229,7 @@ func Test_SyncRun(t *testing.T) {
 				mgc.On("IsDirty").Return(true, nil).Once()
 			},
 			wantErr: true,
-			errMsg:  "refusing to sync due to uncommitted or untracked local changes.\nCheck your local changes with `git status` and either commit them, or use `git stash --all` before retrying this `sync` and running `git stash pop` afterwards",
+			errMsg:  "refusing to sync due to uncommitted/untracked local changes\ntip: use `git stash --all` before retrying the sync and run `git stash pop` afterwards",
 		},
 		{
 			name: "sync local repo with parent - existing branch, non-current",

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -229,7 +229,7 @@ func Test_SyncRun(t *testing.T) {
 				mgc.On("IsDirty").Return(true, nil).Once()
 			},
 			wantErr: true,
-			errMsg:  "can't sync because there are local changes; please stash them before trying again",
+			errMsg:  "refusing to sync due to uncommitted or untracked local changes.\nCheck your local changes with `git status` and either commit them, or use `git stash --all` before retrying this `sync` and running `git stash pop` afterwards",
 		},
 		{
 			name: "sync local repo with parent - existing branch, non-current",


### PR DESCRIPTION
issue-6910 clearer message with actionable hint
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Add hint to the gh repo sync error message for when there are untracked files.

Using git stash --all (or git stash --include-untracked) should help when people try to sync their local copy and 
the --force option fails due to untracked files.


--
Fixes #6910
