### PR TITLE
Use transform.Transformer interface for ascii sanitization

### DIFF
--- a/api/sanitize_ascii_test.go
+++ b/api/sanitize_ascii_test.go
@@ -87,11 +87,7 @@ func TestHTTPClientSanitizeASCIIControlCharactersC1(t *testing.T) {
 }
 
 func TestSanitizedReadCloser(t *testing.T) {
-	data := []byte(`"Assign},"L`)
-	var r io.Reader = bytes.NewReader(data)
-	r = sanitizedReadCloser(io.NopCloser(r))
-	r = iotest.OneByteReader(r)
-	out, err := io.ReadAll(r)
-	require.NoError(t, err)
-	assert.Equal(t, data, out)
+	data := []byte(`the quick brown fox\njumped over the lazy dog\t`)
+	rc := sanitizedReadCloser(io.NopCloser(bytes.NewReader(data)))
+	assert.NoError(t, iotest.TestReader(rc, data))
 }

--- a/api/sanitize_ascii_test.go
+++ b/api/sanitize_ascii_test.go
@@ -86,10 +86,10 @@ func TestHTTPClientSanitizeASCIIControlCharactersC1(t *testing.T) {
 	assert.Equal(t, "monalisa¡", issue.Author.Login)
 }
 
-func TestSanitizeASCIIReadCloser(t *testing.T) {
+func TestSanitizedReadCloser(t *testing.T) {
 	data := []byte(`"Assign},"L`)
 	var r io.Reader = bytes.NewReader(data)
-	r = &sanitizeASCIIReadCloser{ReadCloser: io.NopCloser(r)}
+	r = sanitizedReadCloser(io.NopCloser(r))
 	r = iotest.OneByteReader(r)
 	out, err := io.ReadAll(r)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR simplifies the ascii sanitization algorithm by utilizing the `transform.Transformer` interface and the `transform.Reader`. Now the algorithm doesn't have to manually keep track of the remainder and can follow the very explicit implementation instructions for `transform.Transformer`. There are no functional changes here, it should operate the same as before. 