### PR TITLE
config get: support getting oauth_token from keyring

### DIFF
--- a/pkg/cmd/config/get/get.go
+++ b/pkg/cmd/config/get/get.go
@@ -1,6 +1,7 @@
 package get
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
@@ -53,6 +54,16 @@ func NewCmdConfigGet(f *cmdutil.Factory, runF func(*GetOptions) error) *cobra.Co
 }
 
 func getRun(opts *GetOptions) error {
+	// search keyring storage when fetching the `oauth_token` value
+	if opts.Hostname != "" && opts.Key == "oauth_token" {
+		token, _ := opts.Config.Authentication().Token(opts.Hostname)
+		if token == "" {
+			return errors.New(`could not find key "oauth_token"`)
+		}
+		fmt.Fprintf(opts.IO.Out, "%s\n", token)
+		return nil
+	}
+
 	val, err := opts.Config.GetOrDefault(opts.Hostname, opts.Key)
 	if err != nil {
 		return err


### PR DESCRIPTION
Since we've advertised `gh config get -h HOST oauth_token` as an API for outside scripts and extensions to access the token, this should continue working even if the token was technically stored in keyring and not in the config file.

Followup to https://github.com/cli/cli/pull/7033, ref. https://github.com/cli/cli/pull/7023/files#diff-2ec875cc436fc5de2f3fa51bcef77080e23bbd84bb78d22d5f7ead9babd896cbR62