### PR TITLE
doc: clarify `gh auth refresh` command behavior

### DIFF
--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -58,8 +58,14 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 		Short: "Refresh stored authentication credentials",
 		Long: heredoc.Doc(`Expand or fix the permission scopes for stored credentials.
 
-			The --scopes flag accepts a comma separated list of scopes you want your gh credentials to have. If
-			absent, this command ensures that gh has access to a minimum set of scopes.
+			The --scopes flag accepts a comma separated list of scopes you want
+			your gh credentials to have. If no scopes are provided, the command
+			maintains previously added scopes.
+
+			Note: the "refresh" command can only add additional scopes, but not
+			remove previously added scopes. To reset scopes to the default
+			minimum set of scopes, de-authorize github CLI altogether and start
+			afresh.
 		`),
 		Example: heredoc.Doc(`
 			$ gh auth refresh --scopes write:org,read:public_key

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -62,10 +62,9 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 			your gh credentials to have. If no scopes are provided, the command
 			maintains previously added scopes.
 
-			Note: the "refresh" command can only add additional scopes, but not
-			remove previously added scopes. To reset scopes to the default
-			minimum set of scopes, de-authorize github CLI altogether and start
-			afresh.
+			The command can only add additional scopes, but not remove previously
+			added ones. To reset scopes to the default minimum set of scopes, you
+			will need to create new credentials using the auth login command.
 		`),
 		Example: heredoc.Doc(`
 			$ gh auth refresh --scopes write:org,read:public_key


### PR DESCRIPTION
Before, the command documentation was incorrectly stating that the `gh auth refresh` command resets the scope of the gh credentials.

This PR fixes and expands the documentation to better explain the current behavior of the `gh auth refresh` command which is:
- add new scopes if they are specified with the `--scope` flag
- maintain the previously added set of scopes otherwise

Closes #7126
