### PR TITLE
Fix multiword keyword quoting for search commands

### DIFF
--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -147,7 +147,12 @@ func formatQualifiers(qs Qualifiers) []string {
 
 func formatKeywords(ks []string) []string {
 	for i, k := range ks {
-		ks[i] = quote(k)
+		before, after, found := strings.Cut(k, ":")
+		if !found {
+			ks[i] = quote(k)
+		} else {
+			ks[i] = fmt.Sprintf("%s:%s", before, quote(after))
+		}
 	}
 	return ks
 }

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -47,7 +47,14 @@ func TestQueryString(t *testing.T) {
 			query: Query{
 				Keywords: []string{"quote keywords"},
 			},
-			out: "\"quote keywords\"",
+			out: `"quote keywords"`,
+		},
+		{
+			name: "quotes keywords that are qualifiers",
+			query: Query{
+				Keywords: []string{"quote:keywords", "quote:multiword keywords"},
+			},
+			out: `quote:keywords quote:"multiword keywords"`,
 		},
 		{
 			name: "quotes qualifiers",
@@ -56,7 +63,7 @@ func TestQueryString(t *testing.T) {
 					Topic: []string{"quote qualifier"},
 				},
 			},
-			out: "topic:\"quote qualifier\"",
+			out: `topic:"quote qualifier"`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Previously when searching using multiword keywords that were also qualifiers, mainly used when wanting to negate qualifiers e.g. `gh issue search -- -label:"help wanted"`, we would be improperly quoting leading to no search results. This fixes the quoting so that they are properly sent to the API.

Fixes https://github.com/cli/cli/issues/7154