### PR TITLE
Added apt update command to linux install docs.

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -14,7 +14,7 @@ our release schedule.
 Install:
 
 ```bash
-type -p curl >/dev/null || sudo apt install curl -y
+type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
 && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
 && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \


### PR DESCRIPTION
Updating the install docs for Debian-based Linux systems to update apt first before attempting to install `curl`.