### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Generate changelog
         id: changelog
         run: |
-          echo "::set-output name=tag-name::${GITHUB_REF#refs/tags/}"
+          echo "tag-name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           gh api repos/$GITHUB_REPOSITORY/releases/generate-notes \
             -f tag_name="${GITHUB_REF#refs/tags/}" \
             -f target_commitish=trunk \
@@ -143,7 +143,7 @@ jobs:
         shell: bash
         run: |
           hub release download "${GITHUB_REF#refs/tags/}" -i '*windows_amd64*.zip'
-          printf "::set-output name=zip::%s\n" *.zip
+          printf "zip=%s\n" *.zip >> $GITHUB_OUTPUT
           unzip -o *.zip && rm -v *.zip
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -165,7 +165,7 @@ jobs:
         shell: bash
         run: |
           base64 -d <<<"$CERT_CONTENTS" > ./cert.pfx
-          printf "::set-output name=cert-file::%s\n" ".\\cert.pfx"
+          printf "cert-file=%s\n" ".\\cert.pfx" >> $GITHUB_OUTPUT
         env:
           CERT_CONTENTS: ${{ secrets.WINDOWS_CERT_PFX }}
       - name: Sign MSI


### PR DESCRIPTION
### Description

Fixes #7194 

Update `.github/workflows/releases.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=tag-name::${GITHUB_REF#refs/tags/}"
```

```yml
printf "::set-output name=zip::%s\n" *.zip
```

**TO-BE**

```yml
echo "tag-name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
```

```yml
printf "zip=%s\n" *.zip >> $GITHUB_OUTPUT
```