### PR TITLE
Properly handle closing files that have been writen to

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -140,7 +140,8 @@ func (c *AuthConfig) Token(hostname string) (string, string) {
 	return token, source
 }
 
-// HasEnvToken checks whether the current env or config contains a token
+// HasEnvToken returns true when a token has been specified in an
+// environment variable, else returns false.
 func (c *AuthConfig) HasEnvToken() bool {
 	// This will check if there are any environment variable
 	// authentication tokens set for enterprise hosts.

--- a/pkg/cmd/run/download/zip.go
+++ b/pkg/cmd/run/download/zip.go
@@ -54,7 +54,7 @@ func extractZipFile(zf *zip.File, dest string) (extractErr error) {
 	}
 
 	defer func() {
-		if err := f.Close(); extractErr == nil && err != nil {
+		if err := df.Close(); extractErr == nil && err != nil {
 			extractErr = err
 		}
 	}()

--- a/pkg/cmd/run/download/zip.go
+++ b/pkg/cmd/run/download/zip.go
@@ -28,32 +28,39 @@ func extractZip(zr *zip.Reader, destDir string) error {
 	return nil
 }
 
-func extractZipFile(zf *zip.File, dest string) error {
+func extractZipFile(zf *zip.File, dest string) (extractErr error) {
 	zm := zf.Mode()
 	if zm.IsDir() {
-		return os.MkdirAll(dest, dirMode)
+		extractErr = os.MkdirAll(dest, dirMode)
+		return
 	}
 
-	f, err := zf.Open()
-	if err != nil {
-		return err
+	var f io.ReadCloser
+	f, extractErr = zf.Open()
+	if extractErr != nil {
+		return
 	}
 	defer f.Close()
 
 	if dir := filepath.Dir(dest); dir != "." {
-		if err := os.MkdirAll(dir, dirMode); err != nil {
-			return err
+		if extractErr = os.MkdirAll(dir, dirMode); extractErr != nil {
+			return
 		}
 	}
 
-	df, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, getPerm(zm))
-	if err != nil {
-		return err
+	var df *os.File
+	if df, extractErr = os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, getPerm(zm)); extractErr != nil {
+		return
 	}
-	defer df.Close()
 
-	_, err = io.Copy(df, f)
-	return err
+	defer func() {
+		if err := f.Close(); extractErr == nil && err != nil {
+			extractErr = err
+		}
+	}()
+
+	_, extractErr = io.Copy(df, f)
+	return
 }
 
 func getPerm(m os.FileMode) os.FileMode {

--- a/pkg/cmd/run/download/zip_test.go
+++ b/pkg/cmd/run/download/zip_test.go
@@ -11,23 +11,16 @@ import (
 
 func Test_extractZip(t *testing.T) {
 	tmpDir := t.TempDir()
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.Chdir(wd) })
+	extractPath := filepath.Join(tmpDir, "artifact")
 
 	zipFile, err := zip.OpenReader("./fixtures/myproject.zip")
 	require.NoError(t, err)
 	defer zipFile.Close()
 
-	extractPath := filepath.Join(tmpDir, "artifact")
-	err = os.MkdirAll(extractPath, 0700)
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(extractPath))
-
-	err = extractZip(&zipFile.Reader, ".")
+	err = extractZip(&zipFile.Reader, extractPath)
 	require.NoError(t, err)
 
-	_, err = os.Stat(filepath.Join("src", "main.go"))
+	_, err = os.Stat(filepath.Join(extractPath, "src", "main.go"))
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Addresses CodeQL warnings about properly handling the return value when closing a file that has been written to.

Fixes https://github.com/cli/cli/security/code-scanning/116
Fixes https://github.com/cli/cli/security/code-scanning/115
Fixes https://github.com/cli/cli/security/code-scanning/114
Fixes https://github.com/cli/cli/security/code-scanning/113