### PR TITLE
Diacritics substitution in prompt

### DIFF
--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/cli/cli/v2/internal/ghinstance"
+	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/surveyext"
 )
 
@@ -49,11 +50,20 @@ type surveyPrompter struct {
 	stderr    io.Writer
 }
 
+func Filter(filter, value string, index int) bool {
+	filter = text.RemoveDiacritics(strings.ToLower(filter))
+	value = text.RemoveDiacritics(strings.ToLower(value))
+
+	// include this option if it matches
+	return strings.Contains(value, filter)
+}
+
 func (p *surveyPrompter) Select(message, defaultValue string, options []string) (result int, err error) {
 	q := &survey.Select{
 		Message:  message,
 		Options:  options,
 		PageSize: 20,
+		Filter:   Filter,
 	}
 
 	if defaultValue != "" {
@@ -77,6 +87,7 @@ func (p *surveyPrompter) MultiSelect(message, defaultValue string, options []str
 		Message:  message,
 		Options:  options,
 		PageSize: 20,
+		Filter:   Filter,
 	}
 
 	if defaultValue != "" {

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -51,8 +51,8 @@ type surveyPrompter struct {
 }
 
 func Filter(filter, value string, index int) bool {
-	filter = text.RemoveDiacritics(strings.ToLower(filter))
-	value = text.RemoveDiacritics(strings.ToLower(value))
+	filter = strings.ToLower(text.RemoveDiacritics(filter))
+	value = strings.ToLower(text.RemoveDiacritics(value))
 
 	// include this option if it matches
 	return strings.Contains(value, filter)

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -50,7 +50,9 @@ type surveyPrompter struct {
 	stderr    io.Writer
 }
 
-func Filter(filter, value string, index int) bool {
+// LatinMatchingFilter returns whether the value matches the input filter.
+// The strings are compared normalized in case and diacritics.
+func LatinMatchingFilter(filter, value string, index int) bool {
 	filter = strings.ToLower(text.RemoveDiacritics(filter))
 	value = strings.ToLower(text.RemoveDiacritics(value))
 
@@ -63,7 +65,7 @@ func (p *surveyPrompter) Select(message, defaultValue string, options []string) 
 		Message:  message,
 		Options:  options,
 		PageSize: 20,
-		Filter:   Filter,
+		Filter:   LatinMatchingFilter,
 	}
 
 	if defaultValue != "" {
@@ -87,7 +89,7 @@ func (p *surveyPrompter) MultiSelect(message, defaultValue string, options []str
 		Message:  message,
 		Options:  options,
 		PageSize: 20,
-		Filter:   Filter,
+		Filter:   LatinMatchingFilter,
 	}
 
 	if defaultValue != "" {

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -51,13 +51,15 @@ type surveyPrompter struct {
 }
 
 // LatinMatchingFilter returns whether the value matches the input filter.
-// The strings are compared normalized in case and diacritics.
+// The strings are compared normalized in case.
+// The filter's diactritics are kept as-is, but the value's are normalized,
+// so that a missing diactritic in the filter still returns a result.
 func LatinMatchingFilter(filter, value string, index int) bool {
-	filter = strings.ToLower(text.RemoveDiacritics(filter))
-	value = strings.ToLower(text.RemoveDiacritics(value))
+	filter = strings.ToLower(filter)
+	value = strings.ToLower(value)
 
-	// include this option if it matches
-	return strings.Contains(value, filter)
+	// include this option if it matches.
+	return strings.Contains(value, filter) || strings.Contains(text.RemoveDiacritics(value), filter)
 }
 
 func (p *surveyPrompter) Select(message, defaultValue string, options []string) (result int, err error) {

--- a/internal/prompter/prompter_test.go
+++ b/internal/prompter/prompter_test.go
@@ -1,0 +1,84 @@
+package prompter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterDiacritics(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter string
+		value  string
+		want   bool
+	}{
+		{
+			name:   "exact match no diacritics",
+			filter: "Mikelis",
+			value:  "Mikelis",
+			want:   true,
+		},
+		{
+			name:   "exact match no diacritics",
+			filter: "Mikelis",
+			value:  "Mikelis",
+			want:   true,
+		},
+		{
+			name:   "exact match diacritics",
+			filter: "Miķelis",
+			value:  "Miķelis",
+			want:   true,
+		},
+		{
+			name:   "partial match diacritics",
+			filter: "Miķe",
+			value:  "Miķelis",
+			want:   true,
+		},
+		{
+			name:   "exact match diacritics in filter",
+			filter: "Mikelis",
+			value:  "Miķelis",
+			want:   true,
+		},
+		{
+			name:   "partial match diacritics in filter",
+			filter: "Miķe",
+			value:  "Mikelis",
+			want:   true,
+		},
+		{
+			name:   "exact match diacritics in value",
+			filter: "Miķelis",
+			value:  "Mikelis",
+			want:   true,
+		},
+		{
+			name:   "partial match diacritics in filter",
+			filter: "Mike",
+			value:  "Miķelis",
+			want:   true,
+		},
+		{
+			name:   "no match when removing diacritics in filter",
+			filter: "Mielis",
+			value:  "Mikelis",
+			want:   false,
+		},
+		{
+			name:   "no match when removing diacritics in value",
+			filter: "Mikelis",
+			value:  "Mielis",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, Filter(tt.filter, tt.value, 0), tt.want)
+		})
+	}
+
+}

--- a/internal/prompter/prompter_test.go
+++ b/internal/prompter/prompter_test.go
@@ -77,7 +77,7 @@ func TestFilterDiacritics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, Filter(tt.filter, tt.value, 0), tt.want)
+			assert.Equal(t, LatinMatchingFilter(tt.filter, tt.value, 0), tt.want)
 		})
 	}
 

--- a/internal/prompter/prompter_test.go
+++ b/internal/prompter/prompter_test.go
@@ -38,7 +38,7 @@ func TestFilterDiacritics(t *testing.T) {
 			want:   true,
 		},
 		{
-			name:   "exact match diacritics in filter",
+			name:   "exact match diacritics in value",
 			filter: "Mikelis",
 			value:  "Miķelis",
 			want:   true,
@@ -46,18 +46,6 @@ func TestFilterDiacritics(t *testing.T) {
 		{
 			name:   "partial match diacritics in filter",
 			filter: "Miķe",
-			value:  "Mikelis",
-			want:   true,
-		},
-		{
-			name:   "exact match diacritics in value",
-			filter: "Miķelis",
-			value:  "Mikelis",
-			want:   true,
-		},
-		{
-			name:   "partial match diacritics in filter",
-			filter: "Mike",
 			value:  "Miķelis",
 			want:   true,
 		},
@@ -71,6 +59,12 @@ func TestFilterDiacritics(t *testing.T) {
 			name:   "no match when removing diacritics in value",
 			filter: "Mikelis",
 			value:  "Mielis",
+			want:   false,
+		},
+		{
+			name:   "no match diacritics in filter",
+			filter: "Miķelis",
+			value:  "Mikelis",
 			want:   false,
 		},
 	}

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -6,10 +6,14 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/cli/go-gh/pkg/text"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 )
 
 var whitespaceRE = regexp.MustCompile(`\s+`)
@@ -71,4 +75,13 @@ func DisplayURL(urlStr string) string {
 		return urlStr
 	}
 	return u.Hostname() + u.Path
+}
+
+func RemoveDiacritics(val string) string {
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	normalized, _, err := transform.String(t, val)
+	if err != nil {
+		return val
+	}
+	return normalized
 }

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -77,11 +77,15 @@ func DisplayURL(urlStr string) string {
 	return u.Hostname() + u.Path
 }
 
-func RemoveDiacritics(val string) string {
+// RemoveDiacritics returns the input value without "diacritics", or accent marks
+func RemoveDiacritics(value string) string {
+	// 1/ Decompose the text into characters and diacritical marks,
+	// 2/ Remove the diacriticals marks (Mn = "Mark, nonspacing" unicode character category)
+	// 3/ Recompose the text
 	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
-	normalized, _, err := transform.String(t, val)
+	normalized, _, err := transform.String(t, value)
 	if err != nil {
-		return val
+		return value
 	}
 	return normalized
 }

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -79,10 +79,13 @@ func DisplayURL(urlStr string) string {
 
 // RemoveDiacritics returns the input value without "diacritics", or accent marks
 func RemoveDiacritics(value string) string {
+	// Mn = "Mark, nonspacing" unicode character category
+	removeMnTransfomer := runes.Remove(runes.In(unicode.Mn))
+
 	// 1/ Decompose the text into characters and diacritical marks,
-	// 2/ Remove the diacriticals marks (Mn = "Mark, nonspacing" unicode character category)
+	// 2/ Remove the diacriticals marks
 	// 3/ Recompose the text
-	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	t := transform.Chain(norm.NFD, removeMnTransfomer, norm.NFC)
 	normalized, _, err := transform.String(t, value)
 	if err != nil {
 		return value

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -93,6 +93,12 @@ func TestRemoveDiacritics(t *testing.T) {
 		{"ẁ", "w"},
 		{"ỳ", "y"},
 		{"ō", "o"},
+
+		// full words
+		{"Miķelis", "Mikelis"},
+		{"François", "Francois"},
+		{"žluťoučký", "zlutoucky"},
+		{"învățătorița", "invatatorita"},
 	}
 
 	for _, tt := range tests {

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -99,6 +99,7 @@ func TestRemoveDiacritics(t *testing.T) {
 		{"François", "Francois"},
 		{"žluťoučký", "zlutoucky"},
 		{"învățătorița", "invatatorita"},
+		{"Kękę przy łóżku", "Keke przy łozku"},
 	}
 
 	for _, tt := range tests {

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -59,12 +59,13 @@ func TestRemoveDiacritics(t *testing.T) {
 	tests := [][]string{
 		// no diacritics
 		{"e", "e"},
-
-		// unsupported characters remain untouched
-		{"ؤ", "و"},
+		{"و", "و"},
+		{"И", "И"},
+		{"ж", "ж"},
+		{"私", "私"},
+		{"万", "万"},
 
 		// diacritics test sets
-
 		{"à", "a"},
 		{"é", "e"},
 		{"è", "e"},
@@ -73,6 +74,8 @@ func TestRemoveDiacritics(t *testing.T) {
 		{"εͅ", "ε"},
 		{"ῃ", "η"},
 		{"ιͅ", "ι"},
+
+		{"ؤ", "و"},
 
 		{"ā", "a"},
 		{"č", "c"},

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -54,3 +54,47 @@ func TestFuzzyAgoAbbr(t *testing.T) {
 		assert.Equal(t, expected, fuzzy)
 	}
 }
+
+func TestRemoveDiacritics(t *testing.T) {
+	tests := [][]string{
+		// no diacritics
+		{"e", "e"},
+
+		// unsupported characters remain untouched
+		{"ؤ", "و"},
+
+		// diacritics test sets
+
+		{"à", "a"},
+		{"é", "e"},
+		{"è", "e"},
+		{"ô", "o"},
+		{"ᾳ", "α"},
+		{"εͅ", "ε"},
+		{"ῃ", "η"},
+		{"ιͅ", "ι"},
+
+		{"ā", "a"},
+		{"č", "c"},
+		{"ģ", "g"},
+		{"ķ", "k"},
+		{"ņ", "n"},
+		{"š", "s"},
+		{"ž", "z"},
+
+		{"ŵ", "w"},
+		{"ŷ", "y"},
+		{"ä", "a"},
+		{"ÿ", "y"},
+		{"á", "a"},
+		{"ẁ", "w"},
+		{"ỳ", "y"},
+		{"ō", "o"},
+	}
+
+	for _, tt := range tests {
+		t.Run(RemoveDiacritics(tt[0]), func(t *testing.T) {
+			assert.Equal(t, tt[1], RemoveDiacritics(tt[0]))
+		})
+	}
+}

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -396,7 +396,7 @@ func multiSelectSurvey(message string, defaults, options []string) ([]string, er
 		Message: message,
 		Options: options,
 		Default: defaults,
-		Filter:  prompter.Filter,
+		Filter:  prompter.LatinMatchingFilter,
 	}
 	err := survey.AskOne(q, &results)
 	return results, err

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -7,6 +7,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/set"
 	"github.com/cli/cli/v2/pkg/surveyext"
 )
@@ -395,6 +396,7 @@ func multiSelectSurvey(message string, defaults, options []string) ([]string, er
 		Message: message,
 		Options: options,
 		Default: defaults,
+		Filter:  prompter.Filter,
 	}
 	err := survey.AskOne(q, &results)
 	return results, err


### PR DESCRIPTION
Fixes #7142

I probably missed places to add the filter to, I would like to get some feedback before moving forward. 
@mislav thanks for your [tips](https://github.com/cli/cli/issues/7142#issuecomment-1465907659). The standard [transform](https://pkg.go.dev/golang.org/x/text/transform) library seems to do the trick...
