### PR TITLE
variable list: fix api path

### DIFF
--- a/pkg/cmd/variable/delete/delete.go
+++ b/pkg/cmd/variable/delete/delete.go
@@ -96,7 +96,7 @@ func removeRun(opts *DeleteOptions) error {
 	case shared.Organization:
 		path = fmt.Sprintf("orgs/%s/actions/variables/%s", orgName, opts.VariableName)
 	case shared.Environment:
-		path = fmt.Sprintf("repositories/%s/environments/%s/variables/%s", ghrepo.FullName(baseRepo), envName, opts.VariableName)
+		path = fmt.Sprintf("repos/%s/environments/%s/variables/%s", ghrepo.FullName(baseRepo), envName, opts.VariableName)
 	case shared.Repository:
 		path = fmt.Sprintf("repos/%s/actions/variables/%s", ghrepo.FullName(baseRepo), opts.VariableName)
 	}

--- a/pkg/cmd/variable/delete/delete_test.go
+++ b/pkg/cmd/variable/delete/delete_test.go
@@ -103,7 +103,7 @@ func TestRemoveRun(t *testing.T) {
 				VariableName: "cool_variable",
 				EnvName:      "development",
 			},
-			wantPath: "repositories/owner/repo/environments/development/variables/cool_variable",
+			wantPath: "repos/owner/repo/environments/development/variables/cool_variable",
 		},
 		{
 			name: "org",

--- a/pkg/cmd/variable/list/list.go
+++ b/pkg/cmd/variable/list/list.go
@@ -182,7 +182,7 @@ func getRepoVariables(client *http.Client, repo ghrepo.Interface) ([]Variable, e
 }
 
 func getEnvVariables(client *http.Client, repo ghrepo.Interface, envName string) ([]Variable, error) {
-	path := fmt.Sprintf("repositories/%s/environments/%s/variables", ghrepo.FullName(repo), envName)
+	path := fmt.Sprintf("repos/%s/environments/%s/variables", ghrepo.FullName(repo), envName)
 	return getVariables(client, repo.RepoHost(), path)
 }
 

--- a/pkg/cmd/variable/list/list_test.go
+++ b/pkg/cmd/variable/list/list_test.go
@@ -164,7 +164,7 @@ func Test_listRun(t *testing.T) {
 
 			path := "repos/owner/repo/actions/variables"
 			if tt.opts.EnvName != "" {
-				path = fmt.Sprintf("repositories/owner/repo/environments/%s/variables", tt.opts.EnvName)
+				path = fmt.Sprintf("repos/owner/repo/environments/%s/variables", tt.opts.EnvName)
 			} else if tt.opts.OrgName != "" {
 				path = fmt.Sprintf("orgs/%s/actions/variables", tt.opts.OrgName)
 			}


### PR DESCRIPTION
Getting a `404` trying to list variables for a specific environment because `repositories` is used instead of `repos`:

```elvish
esh ❯ gh variable list --env github-pages 
failed to get variables: HTTP 404: Not Found (https://api.github.com/repositories/rsteube/carapace-bin/environments/github-pages/variables?per_page=100)
Exception: gh exited with 1
[tty 6]:1:1: gh variable list --env github-pages 
```

related #6995
