### PR TITLE
Edit multiple issues, PRs in parallel

### DIFF
--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -41,8 +41,8 @@ func TestNewCmdEdit(t *testing.T) {
 			name:  "issue number argument",
 			input: "23",
 			output: EditOptions{
-				SelectorArg: "23",
-				Interactive: true,
+				SelectorArgs: []string{"23"},
+				Interactive:  true,
 			},
 			wantsErr: false,
 		},
@@ -50,7 +50,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:  "title flag",
 			input: "23 --title test",
 			output: EditOptions{
-				SelectorArg: "23",
+				SelectorArgs: []string{"23"},
 				Editable: prShared.Editable{
 					Title: prShared.EditableString{
 						Value:  "test",
@@ -64,7 +64,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:  "body flag",
 			input: "23 --body test",
 			output: EditOptions{
-				SelectorArg: "23",
+				SelectorArgs: []string{"23"},
 				Editable: prShared.Editable{
 					Body: prShared.EditableString{
 						Value:  "test",
@@ -79,7 +79,7 @@ func TestNewCmdEdit(t *testing.T) {
 			input: "23 --body-file -",
 			stdin: "this is on standard input",
 			output: EditOptions{
-				SelectorArg: "23",
+				SelectorArgs: []string{"23"},
 				Editable: prShared.Editable{
 					Body: prShared.EditableString{
 						Value:  "this is on standard input",
@@ -93,7 +93,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:  "body from file",
 			input: fmt.Sprintf("23 --body-file '%s'", tmpFile),
 			output: EditOptions{
-				SelectorArg: "23",
+				SelectorArgs: []string{"23"},
 				Editable: prShared.Editable{
 					Body: prShared.EditableString{
 						Value:  "a body from file",
@@ -107,7 +107,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:  "add-assignee flag",
 			input: "23 --add-assignee monalisa,hubot",
 			output: EditOptions{
-				SelectorArg: "23",
+				SelectorArgs: []string{"23"},
 				Editable: prShared.Editable{
 					Assignees: prShared.EditableSlice{
 						Add:    []string{"monalisa", "hubot"},
@@ -121,7 +121,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:  "remove-assignee flag",
 			input: "23 --remove-assignee monalisa,hubot",
 			output: EditOptions{
-				SelectorArg: "23",
+				SelectorArgs: []string{"23"},
 				Editable: prShared.Editable{
 					Assignees: prShared.EditableSlice{
 						Remove: []string{"monalisa", "hubot"},
@@ -135,7 +135,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:  "add-label flag",
 			input: "23 --add-label feature,TODO,bug",
 			output: EditOptions{
-				SelectorArg: "23",
+				SelectorArgs: []string{"23"},
 				Editable: prShared.Editable{
 					Labels: prShared.EditableSlice{
 						Add:    []string{"feature", "TODO", "bug"},
@@ -149,7 +149,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:  "remove-label flag",
 			input: "23 --remove-label feature,TODO,bug",
 			output: EditOptions{
-				SelectorArg: "23",
+				SelectorArgs: []string{"23"},
 				Editable: prShared.Editable{
 					Labels: prShared.EditableSlice{
 						Remove: []string{"feature", "TODO", "bug"},
@@ -163,7 +163,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:  "add-project flag",
 			input: "23 --add-project Cleanup,Roadmap",
 			output: EditOptions{
-				SelectorArg: "23",
+				SelectorArgs: []string{"23"},
 				Editable: prShared.Editable{
 					Projects: prShared.EditableProjects{
 						EditableSlice: prShared.EditableSlice{
@@ -179,7 +179,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:  "remove-project flag",
 			input: "23 --remove-project Cleanup,Roadmap",
 			output: EditOptions{
-				SelectorArg: "23",
+				SelectorArgs: []string{"23"},
 				Editable: prShared.Editable{
 					Projects: prShared.EditableProjects{
 						EditableSlice: prShared.EditableSlice{
@@ -195,7 +195,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:  "milestone flag",
 			input: "23 --milestone GA",
 			output: EditOptions{
-				SelectorArg: "23",
+				SelectorArgs: []string{"23"},
 				Editable: prShared.Editable{
 					Milestone: prShared.EditableString{
 						Value:  "GA",
@@ -243,7 +243,7 @@ func TestNewCmdEdit(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.output.SelectorArg, gotOpts.SelectorArg)
+			assert.Equal(t, tt.output.SelectorArgs, gotOpts.SelectorArgs)
 			assert.Equal(t, tt.output.Interactive, gotOpts.Interactive)
 			assert.Equal(t, tt.output.Editable, gotOpts.Editable)
 		})
@@ -261,8 +261,8 @@ func Test_editRun(t *testing.T) {
 		{
 			name: "non-interactive",
 			input: &EditOptions{
-				SelectorArg: "123",
-				Interactive: false,
+				SelectorArgs: []string{"123"},
+				Interactive:  false,
 				Editable: prShared.Editable{
 					Title: prShared.EditableString{
 						Value:  "new title",
@@ -314,8 +314,8 @@ func Test_editRun(t *testing.T) {
 		{
 			name: "interactive",
 			input: &EditOptions{
-				SelectorArg: "123",
-				Interactive: true,
+				SelectorArgs: []string{"123"},
+				Interactive:  true,
 				FieldsToEditSurvey: func(eo *prShared.Editable) error {
 					eo.Title.Edited = true
 					eo.Body.Edited = true

--- a/pkg/cmd/issue/shared/lookup.go
+++ b/pkg/cmd/issue/shared/lookup.go
@@ -19,26 +19,61 @@ import (
 // IssueFromArgWithFields loads an issue or pull request with the specified fields. If some of the fields
 // could not be fetched by GraphQL, this returns a non-nil issue and a *PartialLoadError.
 func IssueFromArgWithFields(httpClient *http.Client, baseRepoFn func() (ghrepo.Interface, error), arg string, fields []string) (*api.Issue, ghrepo.Interface, error) {
-	issueNumber, baseRepo := issueMetadataFromURL(arg)
-
-	if issueNumber == 0 {
-		var err error
-		issueNumber, err = strconv.Atoi(strings.TrimPrefix(arg, "#"))
-		if err != nil {
-			return nil, nil, fmt.Errorf("invalid issue format: %q", arg)
-		}
+	issues, baseRepo, err := IssuesFromArgsWithFields(httpClient, baseRepoFn, []string{arg}, fields)
+	var issue *api.Issue
+	if len(issues) == 1 {
+		issue = issues[0]
+	} else if len(issues) > 1 {
+		return nil, nil, fmt.Errorf("multiple issues not expected")
 	}
-
-	if baseRepo == nil {
-		var err error
-		baseRepo, err = baseRepoFn()
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
-	issue, err := findIssueOrPR(httpClient, baseRepo, issueNumber, fields)
 	return issue, baseRepo, err
+}
+
+// IssuesFromArgWithFields loads 1 oe more issues or pull requests with the specified fields. If some of the fields
+// could not be fetched by GraphQL, this returns non-nil issues and a *PartialLoadError.
+func IssuesFromArgsWithFields(httpClient *http.Client, baseRepoFn func() (ghrepo.Interface, error), args []string, fields []string) ([]*api.Issue, ghrepo.Interface, error) {
+	if len(args) == 0 {
+		return nil, nil, fmt.Errorf("missing required issue number")
+	}
+
+	issues := make([]*api.Issue, 0, len(args))
+	var issuesRepo ghrepo.Interface
+	var err error
+
+	for _, arg := range args {
+		issueNumber, baseRepo := issueMetadataFromURL(arg)
+
+		if issueNumber == 0 {
+			issueNumber, err = strconv.Atoi(strings.TrimPrefix(arg, "#"))
+			if err != nil {
+				return nil, nil, fmt.Errorf("invalid issue format: %q", arg)
+			}
+		}
+
+		if baseRepo == nil {
+			baseRepo, err = baseRepoFn()
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
+		// Make sure subsequent issues are all in the same repo as the first.
+		if issuesRepo == nil {
+			issuesRepo = baseRepo
+		} else if !ghrepo.IsSame(issuesRepo, baseRepo) {
+			return nil, nil, fmt.Errorf(
+				"multiple issues must be in same repo: found %q, expected %q",
+				ghrepo.FullName(baseRepo),
+				ghrepo.FullName(issuesRepo),
+			)
+		}
+
+		var issue *api.Issue
+		issue, err = findIssueOrPR(httpClient, baseRepo, issueNumber, fields)
+		issues = append(issues, issue)
+	}
+
+	return issues, issuesRepo, err
 }
 
 var issueURLRE = regexp.MustCompile(`^/([^/]+)/([^/]+)/issues/(\d+)`)

--- a/pkg/cmd/issue/shared/lookup_test.go
+++ b/pkg/cmd/issue/shared/lookup_test.go
@@ -239,7 +239,7 @@ func TestIssuesFromArgsWithFields(t *testing.T) {
 					}}}`))
 			},
 			wantErr:    true,
-			wantErrMsg: `multiple issues must be in same repo: found "OWNER/OTHERREPO", expected "OWNER/REPO"`,
+			wantErrMsg: "multiple issues must be in same repo",
 		},
 		{
 			name: "multiple issues",
@@ -286,7 +286,7 @@ func TestIssuesFromArgsWithFields(t *testing.T) {
 			}
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.EqualError(t, err, tt.wantErrMsg)
+				assert.ErrorContains(t, err, tt.wantErrMsg)
 				return
 			}
 			assert.NoError(t, err)

--- a/pkg/cmd/issue/shared/lookup_test.go
+++ b/pkg/cmd/issue/shared/lookup_test.go
@@ -212,11 +212,6 @@ func TestIssuesFromArgsWithFields(t *testing.T) {
 		wantErrMsg string
 	}{
 		{
-			name:       "no args",
-			wantErr:    true,
-			wantErrMsg: "missing required issue number",
-		},
-		{
 			name: "multiple repos",
 			args: args{
 				selectors: []string{"1", "https://github.com/OWNER/OTHERREPO/issues/2"},

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -203,7 +203,7 @@ func (e Editable) MilestoneId() (*string, error) {
 
 // Clone creates a mostly-shallow copy of Editable suitable for use in parallel
 // go routines. Fields that would be mutated will be copied.
-func (e Editable) Clone() Editable {
+func (e *Editable) Clone() Editable {
 	return Editable{
 		Title:     e.Title.clone(),
 		Body:      e.Body.clone(),
@@ -222,34 +222,36 @@ func (es *EditableString) clone() EditableString {
 	return EditableString{
 		Value:   es.Value,
 		Default: es.Default,
+		Edited:  es.Edited,
 		// Shallow copies since no mutation.
 		Options: es.Options,
-		Edited:  es.Edited,
 	}
 }
 
 func (es *EditableSlice) clone() EditableSlice {
 	cpy := EditableSlice{
-		// Shallow copies since no mutation.
-		Add:     es.Add,
-		Remove:  es.Remove,
-		Options: es.Options,
 		Edited:  es.Edited,
 		Allowed: es.Allowed,
+		// Shallow copies since no mutation.
+		Options: es.Options,
+		// Copy mutable string slices.
+		Add:     make([]string, len(es.Add)),
+		Remove:  make([]string, len(es.Remove)),
+		Value:   make([]string, len(es.Value)),
+		Default: make([]string, len(es.Default)),
 	}
+	copy(cpy.Add, es.Add)
+	copy(cpy.Remove, es.Remove)
 	copy(cpy.Value, es.Value)
 	copy(cpy.Default, es.Default)
 	return cpy
 }
 
 func (ep *EditableProjects) clone() EditableProjects {
-	cpy := EditableProjects{
+	return EditableProjects{
 		EditableSlice: ep.EditableSlice.clone(),
+		ProjectItems:  ep.ProjectItems,
 	}
-	for k, v := range ep.ProjectItems {
-		cpy.ProjectItems[k] = v
-	}
-	return cpy
 }
 
 func EditFieldsSurvey(editable *Editable, editorCommand string) error {

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -201,6 +201,57 @@ func (e Editable) MilestoneId() (*string, error) {
 	return &m, err
 }
 
+// Clone creates a mostly-shallow copy of Editable suitable for use in parallel
+// go routines. Fields that would be mutated will be copied.
+func (e Editable) Clone() Editable {
+	return Editable{
+		Title:     e.Title.clone(),
+		Body:      e.Body.clone(),
+		Base:      e.Base.clone(),
+		Reviewers: e.Reviewers.clone(),
+		Assignees: e.Assignees.clone(),
+		Labels:    e.Labels.clone(),
+		Projects:  e.Projects.clone(),
+		Milestone: e.Milestone.clone(),
+		// Shallow copy since no mutation.
+		Metadata: e.Metadata,
+	}
+}
+
+func (es *EditableString) clone() EditableString {
+	return EditableString{
+		Value:   es.Value,
+		Default: es.Default,
+		// Shallow copies since no mutation.
+		Options: es.Options,
+		Edited:  es.Edited,
+	}
+}
+
+func (es *EditableSlice) clone() EditableSlice {
+	cpy := EditableSlice{
+		// Shallow copies since no mutation.
+		Add:     es.Add,
+		Remove:  es.Remove,
+		Options: es.Options,
+		Edited:  es.Edited,
+		Allowed: es.Allowed,
+	}
+	copy(cpy.Value, es.Value)
+	copy(cpy.Default, es.Default)
+	return cpy
+}
+
+func (ep *EditableProjects) clone() EditableProjects {
+	cpy := EditableProjects{
+		EditableSlice: ep.EditableSlice.clone(),
+	}
+	for k, v := range ep.ProjectItems {
+		cpy.ProjectItems[k] = v
+	}
+	return cpy
+}
+
 func EditFieldsSurvey(editable *Editable, editorCommand string) error {
 	var err error
 	if editable.Title.Edited {

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -57,6 +57,33 @@ func GraphQL(q string) Matcher {
 	}
 }
 
+func MatchGraphQLMutation(q string, cb func(map[string]interface{}) bool) Matcher {
+	re := regexp.MustCompile(q)
+
+	return func(req *http.Request) bool {
+		if !strings.EqualFold(req.Method, "POST") {
+			return false
+		}
+		if req.URL.Path != "/graphql" && req.URL.Path != "/api/graphql" {
+			return false
+		}
+
+		var bodyData struct {
+			Query     string
+			Variables struct {
+				Input map[string]interface{}
+			}
+		}
+		_ = decodeJSONBody(req, &bodyData)
+
+		if re.MatchString(bodyData.Query) {
+			return cb(bodyData.Variables.Input)
+		}
+
+		return false
+	}
+}
+
 func QueryMatcher(method string, path string, query url.Values) Matcher {
 	return func(req *http.Request) bool {
 		if !REST(method, path)(req) {

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -57,7 +57,7 @@ func GraphQL(q string) Matcher {
 	}
 }
 
-func MatchGraphQLMutation(q string, cb func(map[string]interface{}) bool) Matcher {
+func GraphQLMutationMatcher(q string, cb func(map[string]interface{}) bool) Matcher {
 	re := regexp.MustCompile(q)
 
 	return func(req *http.Request) bool {


### PR DESCRIPTION
Resolves #5782 by allowing multiple issues or PRs to be edited in parallel, and querying for shared fields once to reduce network requests.
