### PR TITLE
extend secure storage default to auth refresh

### DIFF
--- a/pkg/cmd/auth/refresh/refresh_test.go
+++ b/pkg/cmd/auth/refresh/refresh_test.go
@@ -86,11 +86,17 @@ func Test_NewCmdRefresh(t *testing.T) {
 			},
 		},
 		{
-			name: "secure storage",
+			name:  "secure storage",
+			tty:   true,
+			cli:   "--secure-storage",
+			wants: RefreshOptions{},
+		},
+		{
+			name: "insecure storage",
 			tty:  true,
-			cli:  "--secure-storage",
+			cli:  "--insecure-storage",
 			wants: RefreshOptions{
-				SecureStorage: true,
+				InsecureStorage: true,
 			},
 		},
 	}
@@ -178,8 +184,9 @@ func Test_refreshRun(t *testing.T) {
 				Hostname: "obed.morton",
 			},
 			wantAuthArgs: authArgs{
-				hostname: "obed.morton",
-				scopes:   nil,
+				hostname:      "obed.morton",
+				scopes:        nil,
+				secureStorage: true,
 			},
 		},
 		{
@@ -191,8 +198,9 @@ func Test_refreshRun(t *testing.T) {
 				Hostname: "",
 			},
 			wantAuthArgs: authArgs{
-				hostname: "github.com",
-				scopes:   nil,
+				hostname:      "github.com",
+				scopes:        nil,
+				secureStorage: true,
 			},
 		},
 		{
@@ -210,8 +218,9 @@ func Test_refreshRun(t *testing.T) {
 				}
 			},
 			wantAuthArgs: authArgs{
-				hostname: "github.com",
-				scopes:   nil,
+				hostname:      "github.com",
+				scopes:        nil,
+				secureStorage: true,
 			},
 		},
 		{
@@ -223,12 +232,13 @@ func Test_refreshRun(t *testing.T) {
 				Scopes: []string{"repo:invite", "public_key:read"},
 			},
 			wantAuthArgs: authArgs{
-				hostname: "github.com",
-				scopes:   []string{"repo:invite", "public_key:read"},
+				hostname:      "github.com",
+				scopes:        []string{"repo:invite", "public_key:read"},
+				secureStorage: true,
 			},
 		},
 		{
-			name: "scopes provided",
+			name: "more scopes provided",
 			cfgHosts: []string{
 				"github.com",
 			},
@@ -237,37 +247,16 @@ func Test_refreshRun(t *testing.T) {
 				Scopes: []string{"repo:invite", "public_key:read"},
 			},
 			wantAuthArgs: authArgs{
-				hostname: "github.com",
-				scopes:   []string{"repo:invite", "public_key:read", "delete_repo", "codespace"},
-			},
-		},
-		{
-			name: "explicit secure storage",
-			cfgHosts: []string{
-				"obed.morton",
-			},
-			opts: &RefreshOptions{
-				Hostname:      "obed.morton",
-				SecureStorage: true,
-			},
-			wantAuthArgs: authArgs{
-				hostname:      "obed.morton",
-				scopes:        nil,
+				hostname:      "github.com",
+				scopes:        []string{"repo:invite", "public_key:read", "delete_repo", "codespace"},
 				secureStorage: true,
 			},
 		},
 		{
-			name: "implicit secure storage",
-			config: func() config.Config {
-				cfg := config.NewFromString("")
-				authCfg := cfg.Authentication()
-				authCfg.SetHosts([]string{"obed.morton"})
-				authCfg.SetToken("abc123", "keyring")
-				cfg.AuthenticationFunc = func() *config.AuthConfig {
-					return authCfg
-				}
-				return cfg
-			}(),
+			name: "secure storage",
+			cfgHosts: []string{
+				"obed.morton",
+			},
 			opts: &RefreshOptions{
 				Hostname: "obed.morton",
 			},
@@ -275,6 +264,20 @@ func Test_refreshRun(t *testing.T) {
 				hostname:      "obed.morton",
 				scopes:        nil,
 				secureStorage: true,
+			},
+		},
+		{
+			name: "insecure storage",
+			cfgHosts: []string{
+				"obed.morton",
+			},
+			opts: &RefreshOptions{
+				Hostname:        "obed.morton",
+				InsecureStorage: true,
+			},
+			wantAuthArgs: authArgs{
+				hostname: "obed.morton",
+				scopes:   nil,
 			},
 		},
 	}


### PR DESCRIPTION
This PR makes `gh auth refresh` use secure storage by default, requiring `--insecure-storage` for old plaintext storage behavior.

Note that this means that if you've stored your creds in plaintext intentionally (perhaps because the OS keychain doesn't work for you) running `gh auth refresh` without `--insecure-storage` may lead to broken creds.
