### PR TITLE
Fix codespaces invoker immediately closing

### DIFF
--- a/pkg/cmd/codespace/jupyter.go
+++ b/pkg/cmd/codespace/jupyter.go
@@ -45,17 +45,23 @@ func (a *App) Jupyter(ctx context.Context, selector *CodespaceSelector) (err err
 	}
 	defer safeClose(session, &err)
 
-	serverPort, serverUrl := 0, ""
+	var (
+		invoker    rpc.Invoker
+		serverPort int
+		serverUrl  string
+	)
 	err = a.RunWithProgress("Starting JupyterLab on codespace", func() (err error) {
-		invoker, err := rpc.CreateInvoker(ctx, session)
+		invoker, err = rpc.CreateInvoker(ctx, session)
 		if err != nil {
 			return
 		}
-		defer safeClose(invoker, &err)
 
 		serverPort, serverUrl, err = invoker.StartJupyterServer(ctx)
 		return
 	})
+	if invoker != nil {
+		defer safeClose(invoker, &err)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes a regression from https://github.com/cli/cli/pull/6848

In that PR we wrap the invoker in a progress block, but kept the `defer` to close the invoker in that same block. This means that instead of the invoker living for the lifetime of the command, it closes immediately after it runs the RPC call. 

Since the RPC call finishes, the actual ssh or jupyter servers are still available, but since the invoker stops, no more keep-alive heartbeats are sent. This causes the codespace to prematurely suspend even while being actively used.

This change moves the `defer` out of the progress block so that the invoker continues running as long as the command does.

Note: the `cs logs` command also is impacted by this pattern, but since that is a short running command I didn't think it was worth fixing. If it is preferred to update `logs` as well for the sake of keep the pattern consistent then I can update that one too.