### PR TITLE
feat: add web flag for codespace list & create subcommand

### DIFF
--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -80,7 +80,7 @@ func newCreateCmd(app *App) *cobra.Command {
 		Short: "Create a codespace",
 		Args:  noArgsConstraint,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return cmdutil.MutuallyExclusive("using --web with --display-name, --idle-timeout, or --retention-period is not supported", opts.useWeb, opts.displayName != "", opts.idleTimeout != 0, opts.retentionPeriod.Duration != nil)
+			return cmdutil.MutuallyExclusive("using --web with --display-name, --idle-timeout, or --retention-period is not supported", opts.useWeb, opts.displayName != "" || opts.idleTimeout != 0 || opts.retentionPeriod.Duration != nil)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return app.Create(cmd.Context(), opts)

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -80,7 +80,7 @@ func newCreateCmd(app *App, runF func(*createOptions) error) *cobra.Command {
 		Short: "Create a codespace",
 		Args:  noArgsConstraint,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return cmdutil.MutuallyExclusive("using --web with --display-name, --idle-timeout, or --retention-period is not yet supported", opts.useWeb, opts.displayName != "", opts.idleTimeout != 0, opts.retentionPeriod.Duration != nil)
+			return cmdutil.MutuallyExclusive("using --web with --display-name, --idle-timeout, or --retention-period is not supported", opts.useWeb, opts.displayName != "", opts.idleTimeout != 0, opts.retentionPeriod.Duration != nil)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if runF != nil {

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -72,7 +72,7 @@ type createOptions struct {
 	useWeb            bool
 }
 
-func newCreateCmd(app *App, runF func(*createOptions) error) *cobra.Command {
+func newCreateCmd(app *App) *cobra.Command {
 	opts := createOptions{}
 
 	createCmd := &cobra.Command{
@@ -83,10 +83,6 @@ func newCreateCmd(app *App, runF func(*createOptions) error) *cobra.Command {
 			return cmdutil.MutuallyExclusive("using --web with --display-name, --idle-timeout, or --retention-period is not supported", opts.useWeb, opts.displayName != "", opts.idleTimeout != 0, opts.retentionPeriod.Duration != nil)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if runF != nil {
-				return runF(&opts)
-			}
-
 			return app.Create(cmd.Context(), opts)
 		},
 	}

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -265,7 +265,7 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 	// web UI also provide a way to select machine type
 	// therefore we let the user choose from the web UI instead of prompting from CLI
 	if !(opts.useWeb && opts.machine == "") {
-		machine, err = getMachineName(ctx, a.apiClient, repository.ID, opts.machine, branch, userInputs.Location, devContainerPath, opts.useWeb)
+		machine, err = getMachineName(ctx, a.apiClient, repository.ID, opts.machine, branch, userInputs.Location, devContainerPath)
 		if err != nil {
 			return fmt.Errorf("error getting machine type: %w", err)
 		}
@@ -461,7 +461,7 @@ func (a *App) showStatus(ctx context.Context, codespace *api.Codespace) error {
 }
 
 // getMachineName prompts the user to select the machine type, or validates the machine if non-empty.
-func getMachineName(ctx context.Context, apiClient apiClient, repoID int, machine, branch, location string, devcontainerPath string, useWeb bool) (string, error) {
+func getMachineName(ctx context.Context, apiClient apiClient, repoID int, machine, branch, location string, devcontainerPath string) (string, error) {
 	machines, err := apiClient.GetCodespacesMachines(ctx, repoID, branch, location, devcontainerPath)
 	if err != nil {
 		return "", fmt.Errorf("error requesting machine instance types: %w", err)
@@ -488,11 +488,6 @@ func getMachineName(ctx context.Context, apiClient apiClient, repoID int, machin
 
 	if len(machines) == 1 {
 		// VS Code does not prompt for machine if there is only one, this makes us consistent with that behavior
-		return machines[0].Name, nil
-	}
-
-	if useWeb {
-		// If we're using the web, we don't need to prompt for machine type
 		return machines[0].Name, nil
 	}
 

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -263,12 +263,19 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		}
 	}
 
-	machine, err := getMachineName(ctx, a.apiClient, repository.ID, opts.machine, branch, userInputs.Location, devContainerPath, opts.useWeb)
-	if err != nil {
-		return fmt.Errorf("error getting machine type: %w", err)
-	}
-	if machine == "" {
-		return errors.New("there are no available machine types for this repository")
+	machine := opts.machine
+	// skip this if we have useWeb and no machine name provided,
+	// because web UI will select default machine type if none is provided
+	// web UI also provide a way to select machine type
+	// therefore we let the user choose from the web UI instead of prompting from CLI
+	if !(opts.useWeb && opts.machine == "") {
+		machine, err = getMachineName(ctx, a.apiClient, repository.ID, opts.machine, branch, userInputs.Location, devContainerPath, opts.useWeb)
+		if err != nil {
+			return fmt.Errorf("error getting machine type: %w", err)
+		}
+		if machine == "" {
+			return errors.New("there are no available machine types for this repository")
+		}
 	}
 
 	createParams := &api.CreateCodespaceParams{

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -80,7 +80,11 @@ func newCreateCmd(app *App) *cobra.Command {
 		Short: "Create a codespace",
 		Args:  noArgsConstraint,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return cmdutil.MutuallyExclusive("using --web with --display-name, --idle-timeout, or --retention-period is not supported", opts.useWeb, opts.displayName != "" || opts.idleTimeout != 0 || opts.retentionPeriod.Duration != nil)
+			return cmdutil.MutuallyExclusive(
+				"using --web with --display-name, --idle-timeout, or --retention-period is not supported",
+				opts.useWeb,
+				opts.displayName != "" || opts.idleTimeout != 0 || opts.retentionPeriod.Duration != nil,
+			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return app.Create(cmd.Context(), opts)

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -160,6 +160,31 @@ func TestApp_Create(t *testing.T) {
 			wantStderr: "  ✓ Codespaces usage for this repository is paid for by monalisa\n",
 		},
 		{
+			name: "create codespace with nonexistent machine results in error",
+			fields: fields{
+				apiClient: apiCreateDefaults(&apiClientMock{
+					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string, devcontainerPath string) ([]*api.Machine, error) {
+						return []*api.Machine{
+							{
+								Name:        "GIGA",
+								DisplayName: "Gigabits of a machine",
+							},
+							{
+								Name:        "TERA",
+								DisplayName: "Terabits of a machine",
+							},
+						}, nil
+					},
+				}),
+			},
+			opts: createOptions{
+				repo:    "monalisa/dotfiles",
+				machine: "MEGA",
+			},
+			wantStderr: "  ✓ Codespaces usage for this repository is paid for by monalisa\n",
+			wantErr:    fmt.Errorf("error getting machine type: there is no such machine for the repository: %s\nAvailable machines: %v", "MEGA", []string{"GIGA", "TERA"}),
+		},
+		{
 			name: "create codespace with devcontainer path results in selecting the correct machine type",
 			fields: fields{
 				apiClient: apiCreateDefaults(&apiClientMock{

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -37,7 +37,7 @@ func TestCreateCmd(t *testing.T) {
 				displayName: "foo",
 				idleTimeout: 30 * time.Minute,
 			},
-			wantsErr: fmt.Errorf("using --web with --display-name, --idle-timeout, or --retention-period is not yet supported"),
+			wantsErr: fmt.Errorf("using --web with --display-name, --idle-timeout, or --retention-period is not supported"),
 		},
 	}
 

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -460,52 +460,6 @@ Alternatively, you can run "create" with the "--default-permissions" option to c
 			wantURL:    fmt.Sprintf("https://github.com/codespaces/new?repo=%d&ref=%s&machine=%s&location=%s", 123, "custom", "", "EastUS"),
 		},
 		{
-			name: "use first machine if theres more than 1 machine when using web flag and repo flag",
-			fields: fields{
-				apiClient: apiCreateDefaults(&apiClientMock{
-					GetCodespacesMachinesFunc: func(ctx context.Context, repoID int, branch, location string, devcontainerPath string) ([]*api.Machine, error) {
-						if devcontainerPath == "" {
-							return []*api.Machine{
-								{
-									Name:        "GIGA",
-									DisplayName: "Gigabits of a machine",
-								},
-							}, nil
-						} else {
-							return []*api.Machine{
-								{
-									Name:        "GIGA",
-									DisplayName: "Primary Gigabits of a machine",
-								},
-								{
-									Name:        "GIGA2",
-									DisplayName: "Secondary Gigabits of a machine",
-								},
-							}, nil
-						}
-					},
-					GetRepositoryFunc: func(ctx context.Context, nwo string) (*api.Repository, error) {
-						return &api.Repository{
-							ID:            123,
-							DefaultBranch: "main",
-						}, nil
-					},
-					CreateCodespaceFunc: func(ctx context.Context, params *api.CreateCodespaceParams) (*api.Codespace, error) {
-						return &api.Codespace{
-							Name: "monalisa-dotfiles-abcd1234",
-						}, nil
-					},
-				}),
-			},
-			opts: createOptions{
-				repo:    "monalisa/dotfiles",
-				useWeb:  true,
-				machine: "GIGA",
-			},
-			wantStderr: "  ✓ Codespaces usage for this repository is paid for by monalisa\n",
-			wantURL:    fmt.Sprintf("https://github.com/codespaces/new?repo=%d&ref=%s&machine=%s&location=%s", 123, "main", "GIGA", ""),
-		},
-		{
 			name: "return correct url with correct params when using web flag and repo flag",
 			fields: fields{
 				apiClient: apiCreateDefaults(&apiClientMock{

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -23,20 +23,8 @@ func TestCreateCmd(t *testing.T) {
 		wantsOpts createOptions
 	}{
 		{
-			name: "use web flag",
-			args: "--web",
-			wantsOpts: createOptions{
-				useWeb: true,
-			},
-		},
-		{
-			name: "return error when using web flag with display-name, idle-timeout, or retention-period flags",
-			args: "--web --display-name foo --idle-timeout 30m",
-			wantsOpts: createOptions{
-				useWeb:      true,
-				displayName: "foo",
-				idleTimeout: 30 * time.Minute,
-			},
+			name:     "return error when using web flag with display-name, idle-timeout, or retention-period flags",
+			args:     "--web --display-name foo --idle-timeout 30m",
 			wantsErr: fmt.Errorf("using --web with --display-name, --idle-timeout, or --retention-period is not supported"),
 		},
 	}
@@ -47,11 +35,7 @@ func TestCreateCmd(t *testing.T) {
 			a := &App{
 				io: ios,
 			}
-			var opts *createOptions
-			cmd := newCreateCmd(a, func(co *createOptions) error {
-				opts = co
-				return nil
-			})
+			cmd := newCreateCmd(a)
 
 			args, _ := shlex.Split(tt.args)
 			cmd.SetArgs(args)
@@ -66,14 +50,6 @@ func TestCreateCmd(t *testing.T) {
 				assert.EqualError(t, err, tt.wantsErr.Error())
 				return
 			}
-
-			assert.Equal(t, tt.wantsOpts.branch, opts.branch)
-			assert.Equal(t, tt.wantsOpts.displayName, opts.displayName)
-			assert.Equal(t, tt.wantsOpts.idleTimeout, opts.idleTimeout)
-			assert.Equal(t, tt.wantsOpts.machine, opts.machine)
-			assert.Equal(t, tt.wantsOpts.repo, opts.repo)
-			assert.Equal(t, tt.wantsOpts.retentionPeriod, opts.retentionPeriod)
-			assert.Equal(t, tt.wantsOpts.useWeb, opts.useWeb)
 		})
 	}
 }

--- a/pkg/cmd/codespace/create_test.go
+++ b/pkg/cmd/codespace/create_test.go
@@ -15,16 +15,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateCmd(t *testing.T) {
+func TestCreateCmdFlagError(t *testing.T) {
 	tests := []struct {
-		name      string
-		args      string
-		wantsErr  error
-		wantsOpts createOptions
+		name     string
+		args     string
+		wantsErr error
 	}{
 		{
 			name:     "return error when using web flag with display-name, idle-timeout, or retention-period flags",
 			args:     "--web --display-name foo --idle-timeout 30m",
+			wantsErr: fmt.Errorf("using --web with --display-name, --idle-timeout, or --retention-period is not supported"),
+		},
+		{
+			name:     "return error when using web flag with one of display-name, idle-timeout or retention-period flags",
+			args:     "--web --idle-timeout 30m",
 			wantsErr: fmt.Errorf("using --web with --display-name, --idle-timeout, or --retention-period is not supported"),
 		},
 	}
@@ -45,11 +49,8 @@ func TestCreateCmd(t *testing.T) {
 
 			_, err := cmd.ExecuteC()
 
-			if tt.wantsErr != nil {
-				assert.Error(t, err)
-				assert.EqualError(t, err, tt.wantsErr.Error())
-				return
-			}
+			assert.Error(t, err)
+			assert.EqualError(t, err, tt.wantsErr.Error())
 		})
 	}
 }

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -64,7 +64,7 @@ func newListCmd(app *App) *cobra.Command {
 	listCmd.Flags().StringVarP(&opts.userName, "user", "u", "", "The `username` to list codespaces for (used with --org)")
 	cmdutil.AddJSONFlags(listCmd, &exporter, api.CodespaceFields)
 
-	listCmd.Flags().BoolVarP(&opts.useWeb, "web", "w", false, "List codespaces in the web browser, can only be used with --repo flag")
+	listCmd.Flags().BoolVarP(&opts.useWeb, "web", "w", false, "List codespaces in the web browser, cannot be used with --user or --org")
 
 	return listCmd
 }

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -36,14 +36,22 @@ func newListCmd(app *App) *cobra.Command {
 		Aliases: []string{"ls"},
 		Args:    noArgsConstraint,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			err := cmdutil.MutuallyExclusive("using `--org` or `--user` with `--repo` is not allowed", opts.repo != "", opts.orgName != "" || opts.userName != "")
-			if err != nil {
+			if err := cmdutil.MutuallyExclusive(
+				"using `--org` or `--user` with `--repo` is not allowed",
+				opts.repo != "",
+				opts.orgName != "" || opts.userName != "",
+			); err != nil {
 				return err
 			}
-			err = cmdutil.MutuallyExclusive("using `--web` with `--org` or `--user` is not supported, please use with `--repo` instead", opts.useWeb, opts.orgName != "" || opts.userName != "")
-			if err != nil {
+
+			if err := cmdutil.MutuallyExclusive(
+				"using `--web` with `--org` or `--user` is not supported, please use with `--repo` instead",
+				opts.useWeb,
+				opts.orgName != "" || opts.userName != "",
+			); err != nil {
 				return err
 			}
+
 			if opts.limit < 1 {
 				return cmdutil.FlagErrorf("invalid limit: %v", opts.limit)
 			}

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -54,14 +54,14 @@ func newListCmd(app *App) *cobra.Command {
 	listCmd.Flags().StringVarP(&opts.userName, "user", "u", "", "The `username` to list codespaces for (used with --org)")
 	cmdutil.AddJSONFlags(listCmd, &exporter, api.CodespaceFields)
 
-	listCmd.Flags().BoolVarP(&opts.useWeb, "web", "w", false, "List codespaces in the web browser")
+	listCmd.Flags().BoolVarP(&opts.useWeb, "web", "w", false, "List codespaces in the web browser, can only be used with --repo flag")
 
 	return listCmd
 }
 
 func (a *App) List(ctx context.Context, opts *listOptions, exporter cmdutil.Exporter) error {
 	if opts.useWeb && (opts.orgName != "" || opts.userName != "") {
-		return cmdutil.FlagErrorf("using `--web` with `--org` or `--user` is not yet supported, please use with `--repo` instead")
+		return cmdutil.FlagErrorf("using `--web` with `--org` or `--user` is not supported, please use with `--repo` instead")
 	}
 
 	if opts.useWeb && opts.repo == "" {

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -21,7 +21,7 @@ type listOptions struct {
 	useWeb   bool
 }
 
-func newListCmd(app *App, runF func(*listOptions) error) *cobra.Command {
+func newListCmd(app *App) *cobra.Command {
 	opts := &listOptions{}
 	var exporter cmdutil.Exporter
 
@@ -49,10 +49,6 @@ func newListCmd(app *App, runF func(*listOptions) error) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if runF != nil {
-				return runF(opts)
-			}
-
 			return app.List(cmd.Context(), opts, exporter)
 		},
 	}

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -36,12 +36,13 @@ func newListCmd(app *App) *cobra.Command {
 		Aliases: []string{"ls"},
 		Args:    noArgsConstraint,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			// if repo is provided, we don't accept orgName or userName
-			if opts.repo != "" {
-				return cmdutil.MutuallyExclusive("using `--org` or `--user` with `--repo` is not allowed", opts.repo != "", opts.orgName != "" || opts.userName != "")
+			err := cmdutil.MutuallyExclusive("using `--org` or `--user` with `--repo` is not allowed", opts.repo != "", opts.orgName != "" || opts.userName != "")
+			if err != nil {
+				return err
 			}
-			if opts.useWeb {
-				return cmdutil.MutuallyExclusive("using `--web` with `--org` or `--user` is not supported, please use with `--repo` instead", opts.useWeb, opts.orgName != "" || opts.userName != "")
+			err = cmdutil.MutuallyExclusive("using `--web` with `--org` or `--user` is not supported, please use with `--repo` instead", opts.useWeb, opts.orgName != "" || opts.userName != "")
+			if err != nil {
+				return err
 			}
 			if opts.limit < 1 {
 				return cmdutil.FlagErrorf("invalid limit: %v", opts.limit)

--- a/pkg/cmd/codespace/list_test.go
+++ b/pkg/cmd/codespace/list_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListCmd(t *testing.T) {
+func TestListCmdFlagError(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     string

--- a/pkg/cmd/codespace/list_test.go
+++ b/pkg/cmd/codespace/list_test.go
@@ -132,7 +132,7 @@ func TestApp_List(t *testing.T) {
 				orgName:  "TestOrg",
 				userName: "jimmy",
 			},
-			wantError: fmt.Errorf("using `--web` with `--org` or `--user` is not yet supported, please use with `--repo` instead"),
+			wantError: fmt.Errorf("using `--web` with `--org` or `--user` is not supported, please use with `--repo` instead"),
 		},
 		{
 			name: "list codespaces,--web",

--- a/pkg/cmd/codespace/list_test.go
+++ b/pkg/cmd/codespace/list_test.go
@@ -16,10 +16,9 @@ import (
 
 func TestListCmd(t *testing.T) {
 	tests := []struct {
-		name      string
-		args      string
-		wantsErr  error
-		wantsOpts listOptions
+		name     string
+		args     string
+		wantsErr error
 	}{
 		{
 			name:     "list codespaces,--repo, --org and --user flag",
@@ -44,11 +43,8 @@ func TestListCmd(t *testing.T) {
 			a := &App{
 				io: ios,
 			}
-			var opts *listOptions
-			cmd := newListCmd(a, func(co *listOptions) error {
-				opts = co
-				return nil
-			})
+
+			cmd := newListCmd(a)
 
 			args, _ := shlex.Split(tt.args)
 			cmd.SetArgs(args)
@@ -63,12 +59,6 @@ func TestListCmd(t *testing.T) {
 				assert.EqualError(t, err, tt.wantsErr.Error())
 				return
 			}
-
-			assert.Equal(t, tt.wantsOpts.limit, opts.limit)
-			assert.Equal(t, tt.wantsOpts.repo, opts.repo)
-			assert.Equal(t, tt.wantsOpts.orgName, opts.orgName)
-			assert.Equal(t, tt.wantsOpts.userName, opts.userName)
-			assert.Equal(t, tt.wantsOpts.useWeb, opts.useWeb)
 		})
 	}
 }

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -15,7 +15,7 @@ func NewRootCmd(app *App) *cobra.Command {
 	root.AddCommand(newEditCmd(app))
 	root.AddCommand(newDeleteCmd(app))
 	root.AddCommand(newJupyterCmd(app))
-	root.AddCommand(newListCmd(app))
+	root.AddCommand(newListCmd(app, nil))
 	root.AddCommand(newLogsCmd(app))
 	root.AddCommand(newPortsCmd(app))
 	root.AddCommand(newSSHCmd(app))

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -11,7 +11,7 @@ func NewRootCmd(app *App) *cobra.Command {
 	}
 
 	root.AddCommand(newCodeCmd(app))
-	root.AddCommand(newCreateCmd(app))
+	root.AddCommand(newCreateCmd(app, nil))
 	root.AddCommand(newEditCmd(app))
 	root.AddCommand(newDeleteCmd(app))
 	root.AddCommand(newJupyterCmd(app))

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -11,11 +11,11 @@ func NewRootCmd(app *App) *cobra.Command {
 	}
 
 	root.AddCommand(newCodeCmd(app))
-	root.AddCommand(newCreateCmd(app, nil))
+	root.AddCommand(newCreateCmd(app))
 	root.AddCommand(newEditCmd(app))
 	root.AddCommand(newDeleteCmd(app))
 	root.AddCommand(newJupyterCmd(app))
-	root.AddCommand(newListCmd(app, nil))
+	root.AddCommand(newListCmd(app))
 	root.AddCommand(newLogsCmd(app))
 	root.AddCommand(newPortsCmd(app))
 	root.AddCommand(newSSHCmd(app))


### PR DESCRIPTION
This PR could fix #7261 

### Changes were made:
<br>

#### list subcommand

- adding web flag for opening list of codespace in browser with url: `https://github.com/codespaces`.
- `--web` flag can only be used with `--repo` flag, because in `https://github.com/codespaces` there only GET param for filtering with repository_id. (no params to filter with user or organizations). It will throws error if used with `--user` or `org` flag
- when user only specify `--web` flag without additional flags, it will open browser with default url: `https://github.com/codespaces`
- when user specify `--web` flag with `--repo` flag, it will first fetch repo_id from the api, and then open browser with url+repo_id param: `https://github.com/codespaces?repository_id={id}`
- add test case this newly added `--web` flag with above scenario
- modify the `t.Run` clause to add the `&browser.Stub{}` if `tt.opts.useWeb` is `true` (on `pkg/cmd/codespace/list_test.go`)

<br>

#### create subcommand

- adding web flag for creating codespace through browser with url: `https://github.com/codespaces`
- `--web` flag cannot be used with `--display-name`, `--idle-timeout`, or '--retention-period' flag because there's no option to set those in browser/Web UI. when used with those flags, it will throws error
- when user only specify `--web` flag without additional flags, it will open browser with default url: `https://github.com/codespaces/new`
- when user specify `--web` flag with `--repo` flag, it will first fetch repo_id from the api, and then open browser with url+repo_id param: `https://github.com/codespaces/new?repo={id}&ref={defaultBranch}&machine={firstMachineInList}&location={emptyString}`. 
- when no machine specified, it will automatically select the first machine instead of displaying machine chooser in terminal. (because already got machine chooser in web UI)
- when no branch specified, it will automatically select the default branch for the repository
- when no location specified, it will yield empty string to the location URL param, because the Web UI will automatically choose default location if none specified.
- when additional flags specified (repo, branch, machine, location) , it will plug the value to the respective params: `https://github.com/codespaces/new?repo={id}&ref={specifiedBranch}&machine={specifiedMachine}&location={specifiedLocation}`
- add test case this newly added `--web` flag with above scenario
- modify the `t.Run` clause to add the `&browser.Stub{}` if `tt.opts.useWeb` is `true` (on `pkg/cmd/codespace/create_test.go`)