### PR TITLE
Enable owner flag to take multiple values for searching

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -253,7 +253,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 
 			// Qualifier flags
 			cmd.Flags().StringSliceVar(&qualifiers.License, "license", nil, "Filter based on license type")
-			cmd.Flags().StringVar(&qualifiers.User, "owner", "", "Filter on owner")
+			cmd.Flags().StringSliceVar(&qualifiers.User, "owner", nil, "Filter on owner")
 
 			return cmd
 		}(),

--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -209,7 +209,7 @@ func searchQuery(owner string, filter FilterOptions) string {
 			Is:       []string{filter.Visibility},
 			Language: filter.Language,
 			Topic:    filter.Topic,
-			User:     owner,
+			User:     []string{owner},
 		},
 	}
 

--- a/pkg/cmd/search/commits/commits.go
+++ b/pkg/cmd/search/commits/commits.go
@@ -114,7 +114,7 @@ func NewCmdCommits(f *cmdutil.Factory, runF func(*CommitsOptions) error) *cobra.
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Parent, "parent", "", "Filter by parent hash")
 	cmd.Flags().StringSliceVarP(&opts.Query.Qualifiers.Repo, "repo", "R", nil, "Filter on repository")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Tree, "tree", "", "Filter by tree hash")
-	cmd.Flags().StringVar(&opts.Query.Qualifiers.User, "owner", "", "Filter on repository owner")
+	cmd.Flags().StringSliceVar(&opts.Query.Qualifiers.User, "owner", nil, "Filter on repository owner")
 	cmdutil.StringSliceEnumFlag(cmd, &opts.Query.Qualifiers.Is, "visibility", "", nil, []string{"public", "private", "internal"}, "Filter based on repository visibility")
 
 	return cmd

--- a/pkg/cmd/search/commits/commits_test.go
+++ b/pkg/cmd/search/commits/commits_test.go
@@ -106,7 +106,7 @@ func TestNewCmdCommits(t *testing.T) {
 						Parent:         "bbb",
 						Repo:           []string{"owner/repo"},
 						Tree:           "ccc",
-						User:           "owner",
+						User:           []string{"owner"},
 						Is:             []string{"public"},
 					},
 				},

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -160,7 +160,7 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 	cmdutil.StringEnumFlag(cmd, &opts.Query.Qualifiers.State, "state", "", "", []string{"open", "closed"}, "Filter based on state")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Team, "team-mentions", "", "Filter based on team mentions")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Updated, "updated", "", "Filter on last updated at `date`")
-	cmd.Flags().StringVar(&opts.Query.Qualifiers.User, "owner", "", "Filter on repository owner")
+	cmd.Flags().StringSliceVar(&opts.Query.Qualifiers.User, "owner", nil, "Filter on repository owner")
 
 	return cmd
 }

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -171,7 +171,7 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 	cmdutil.StringEnumFlag(cmd, &opts.Query.Qualifiers.State, "state", "", "", []string{"open", "closed"}, "Filter based on state")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Team, "team-mentions", "", "Filter based on team mentions")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Updated, "updated", "", "Filter on last updated at `date`")
-	cmd.Flags().StringVar(&opts.Query.Qualifiers.User, "owner", "", "Filter on repository owner")
+	cmd.Flags().StringSliceVar(&opts.Query.Qualifiers.User, "owner", nil, "Filter on repository owner")
 
 	// Pull request query qualifier flags
 	cmd.Flags().StringVarP(&opts.Query.Qualifiers.Base, "base", "B", "", "Filter on base branch name")

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -118,7 +118,7 @@ func NewCmdRepos(f *cmdutil.Factory, runF func(*ReposOptions) error) *cobra.Comm
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Stars, "stars", "", "Filter on `number` of stars")
 	cmd.Flags().StringSliceVar(&opts.Query.Qualifiers.Topic, "topic", nil, "Filter on topic")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Topics, "number-topics", "", "Filter on `number` of topics")
-	cmd.Flags().StringVar(&opts.Query.Qualifiers.User, "owner", "", "Filter on owner")
+	cmd.Flags().StringSliceVar(&opts.Query.Qualifiers.User, "owner", nil, "Filter on owner")
 
 	return cmd
 }

--- a/pkg/cmd/search/repos/repos_test.go
+++ b/pkg/cmd/search/repos/repos_test.go
@@ -110,7 +110,7 @@ func TestNewCmdRepos(t *testing.T) {
 						Stars:            "6",
 						Topic:            []string{"topic"},
 						Topics:           "7",
-						User:             "owner",
+						User:             []string{"owner"},
 						Is:               []string{"public"},
 					},
 				},

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -79,7 +79,7 @@ type Qualifiers struct {
 	Tree                string
 	Type                string
 	Updated             string
-	User                string
+	User                []string
 }
 
 func (q Query) String() string {

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -36,11 +36,14 @@ func TestQueryString(t *testing.T) {
 					Stars:            "6",
 					Topic:            []string{"topic"},
 					Topics:           "7",
-					User:             "user",
+					User:             []string{"user1", "user2"},
 					Is:               []string{"public"},
 				},
 			},
-			out: "some keywords archived:true author-email:foo@example.com committer-date:2021-02-28 created:created followers:1 fork:true forks:2 good-first-issues:3 help-wanted-issues:4 in:description in:readme is:public language:language license:license pushed:updated size:5 stars:6 topic:topic topics:7 user:user",
+			out: "some keywords archived:true author-email:foo@example.com committer-date:2021-02-28 " +
+				"created:created followers:1 fork:true forks:2 good-first-issues:3 help-wanted-issues:4 " +
+				"in:description in:readme is:public language:language license:license pushed:updated size:5 " +
+				"stars:6 topic:topic topics:7 user:user1 user:user2",
 		},
 		{
 			name: "quotes keywords",
@@ -100,7 +103,7 @@ func TestQualifiersMap(t *testing.T) {
 				Stars:            "6",
 				Topic:            []string{"topic"},
 				Topics:           "7",
-				User:             "user",
+				User:             []string{"user1", "user2"},
 			},
 			out: map[string][]string{
 				"archived":           {"true"},
@@ -121,7 +124,7 @@ func TestQualifiersMap(t *testing.T) {
 				"stars":              {"6"},
 				"topic":              {"topic"},
 				"topics":             {"7"},
-				"user":               {"user"},
+				"user":               {"user1", "user2"},
 			},
 		},
 		{
@@ -130,7 +133,7 @@ func TestQualifiersMap(t *testing.T) {
 				Pushed: "updated",
 				Size:   "5",
 				Stars:  "6",
-				User:   "user",
+				User:   []string{"user"},
 			},
 			out: map[string][]string{
 				"pushed": {"updated"},


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixed #7296 

This PR will enhance `--owner` flag to take multiple values as well as csv values. This change will effect the following commands,

`gh extension search`
`gh search prs`
`gh search issues`
`gh search repos`
`gh search commits`


Ex: `gh search prs --owner user1 --owner user2 --owner user3,user4` will show all prs by user1, user2, user3 and user4