### PR TITLE
Fix typo in `cs stop` command: `Stoppping` -> `Stopping`

### DIFF
--- a/pkg/cmd/codespace/stop.go
+++ b/pkg/cmd/codespace/stop.go
@@ -97,7 +97,7 @@ func (a *App) StopCodespace(ctx context.Context, opts *stopOptions) error {
 		}
 	}
 
-	err := a.RunWithProgress("Stoppping codespace", func() (err error) {
+	err := a.RunWithProgress("Stopping codespace", func() (err error) {
 		err = a.apiClient.StopCodespace(ctx, codespaceName, opts.orgName, ownerName)
 		return
 	})


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
