### PR TITLE
feat(pr): Add cleanup subcommand to delete merged local branches

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -204,7 +204,7 @@ func (c *Client) UncommittedChangeCount(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	lines := strings.Split(string(out), "\n")
+	lines := outputLines(out)
 	count := 0
 	for _, l := range lines {
 		if l != "" {
@@ -274,6 +274,7 @@ func (c *Client) lookupCommit(ctx context.Context, sha, format string) ([]byte, 
 }
 
 // ReadBranchConfig parses the `branch.BRANCH.(remote|merge)` part of git config.
+// This is the upstream associated with a branch.
 func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (cfg BranchConfig) {
 	prefix := regexp.QuoteMeta(fmt.Sprintf("branch.%s.", branch))
 	args := []string{"config", "--get-regexp", fmt.Sprintf("^%s(remote|merge)$", prefix)}
@@ -354,6 +355,47 @@ func (c *Client) HasLocalBranch(ctx context.Context, branch string) bool {
 	return err == nil
 }
 
+// LocalBranches returns all local branches.
+func (c *Client) LocalBranches(ctx context.Context) []Branch {
+	args := []string{"branch", "--format", "%(objectname) %(refname) %(upstream)"}
+	cmd, err := c.Command(ctx, args...)
+	if err != nil {
+		return nil
+	}
+	output, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	lines := outputLines(output)
+
+	var branches []Branch
+	for _, line := range lines {
+		sections := strings.Split(line, " ")
+		objectname := sections[0]
+		refname := sections[1]
+		upstream := sections[2]
+		branch := Branch{
+			Local: Ref{
+				Hash: objectname,
+				Name: strings.TrimPrefix(refname, "refs/heads/"),
+			},
+		}
+		if upstream != "" {
+			trimmed := strings.TrimPrefix(sections[2], "refs/remotes/")
+			remoteSections := strings.SplitN(trimmed, "/", 2)
+			branch.Upstream = TrackingRef{
+				RemoteName: remoteSections[0],
+				BranchName: remoteSections[1],
+			}
+		}
+		branches = append(branches, branch)
+	}
+
+	return branches
+}
+
+// TrackingBranchNames returns the names of all remote branches of all remotes,
+// optionally filtered to branch names that match a prefix.
 func (c *Client) TrackingBranchNames(ctx context.Context, prefix string) []string {
 	args := []string{"branch", "-r", "--format", "%(refname:strip=3)"}
 	if prefix != "" {
@@ -367,7 +409,7 @@ func (c *Client) TrackingBranchNames(ctx context.Context, prefix string) []strin
 	if err != nil {
 		return nil
 	}
-	return strings.Split(string(output), "\n")
+	return outputLines(output)
 }
 
 // ToplevelDir returns the top-level directory path of the current repository.

--- a/git/objects.go
+++ b/git/objects.go
@@ -64,6 +64,14 @@ func (r TrackingRef) String() string {
 	return "refs/remotes/" + r.RemoteName + "/" + r.BranchName
 }
 
+// A Branch is a local git branch with a possible upstream remote tracking
+// branch. If the branch has no upstream, then TrackingRef will be its zero
+// value.
+type Branch struct {
+	Local    Ref
+	Upstream TrackingRef
+}
+
 type Commit struct {
 	Sha   string
 	Title string

--- a/pkg/cmd/pr/cleanup/cleanup.go
+++ b/pkg/cmd/pr/cleanup/cleanup.go
@@ -1,11 +1,19 @@
 package cleanup
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"sort"
+	"time"
 
+	"github.com/cli/cli/v2/api"
 	cliContext "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -19,11 +27,16 @@ type CleanupOptions struct {
 	IO         *iostreams.IOStreams
 	Remotes    func() (cliContext.Remotes, error)
 	Branch     func() (string, error)
+	Prompter   prompter.Prompter
 
 	Finder shared.PRFinder
 
-	SelectorArg string
-	All         bool
+	SelectorArg  string
+	All          bool
+	Strict       bool
+	MergedOnly   bool
+	UpToDateOnly bool
+	Yes          bool
 }
 
 func NewCmdCleanup(f *cmdutil.Factory, runF func(*CleanupOptions) error) *cobra.Command {
@@ -34,11 +47,12 @@ func NewCmdCleanup(f *cmdutil.Factory, runF func(*CleanupOptions) error) *cobra.
 		Config:     f.Config,
 		Remotes:    f.Remotes,
 		Branch:     f.Branch,
+		Prompter:   f.Prompter,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "cleanup {<number> | <url> | <branch> | --all}",
-		Short: "Clean up local branches of merged pull requests",
+		Short: "Clean up local branches of merged or closed pull requests",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Finder = shared.NewFinder(f)
@@ -55,10 +69,208 @@ func NewCmdCleanup(f *cmdutil.Factory, runF func(*CleanupOptions) error) *cobra.
 	}
 
 	cmd.Flags().BoolVarP(&opts.All, "all", "", false, "Clean up all merged pull requests")
+	cmd.Flags().BoolVarP(&opts.Strict, "strict", "", false, "Both --exclude-closed and --exclude-behind")
+	cmd.Flags().BoolVarP(&opts.MergedOnly, "exclude-closed", "", false, "Exclude branches of closed pull requests")
+	cmd.Flags().BoolVarP(&opts.UpToDateOnly, "exclude-behind", "", false, "Exclude branches that are behind their remote")
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "", false, "Skip deletion confirmation")
 
 	return cmd
 }
 
 func cleanupRun(opts *CleanupOptions) error {
+	// Validate input arguments: --all and PR selector are mutually exclusive, but
+	// at least one must be set.
+	if opts.All && opts.SelectorArg != "" {
+		return errors.New("Invalid arguments: cannot set both PR and --all")
+	} else if opts.SelectorArg == "" && !opts.All {
+		return errors.New("Invalid arguments: must set either PR or --all")
+	}
+
+	// Set flags.
+	if opts.Strict {
+		opts.MergedOnly = true
+		opts.UpToDateOnly = true
+	}
+
+	if opts.All {
+		// Get all local branches and their upstreams.
+		ctx := context.Background()
+		localBranches := opts.GitClient.LocalBranches(ctx)
+		var branchesWithUpstream []git.Branch
+		for _, localBranch := range localBranches {
+			if localBranch.Upstream.RemoteName == "" {
+				continue
+			}
+			branchesWithUpstream = append(branchesWithUpstream, localBranch)
+		}
+
+		timeWarning := ".."
+		if len(branchesWithUpstream) > 60 {
+			timeWarning = " This might take a few minutes..."
+		} else if len(branchesWithUpstream) > 30 {
+			timeWarning = " This might take a minute..."
+		} else if len(branchesWithUpstream) > 10 {
+			timeWarning = " This might take a few seconds..."
+		}
+		opts.IO.StartProgressIndicatorWithLabel(
+			fmt.Sprintf(
+				"Loading PRs for %d local branches with upstreams.%s\n",
+				len(branchesWithUpstream),
+				timeWarning,
+			),
+		)
+
+		// Get PRs associated with upstream branches.
+		var prs []*api.PullRequest
+		// TODO: Can these be loaded in parallel?
+		for _, branch := range branchesWithUpstream {
+			// TODO: This causes the progress indicator to "reset" very frequently.
+			// Should the Finder itself have a progress indicator? Perhaps we should
+			// invert that so consumers have control of the indicator instead.
+			pr, _, err := opts.Finder.Find(shared.FindOptions{
+				Selector: branch.Upstream.BranchName,
+				Fields:   []string{"commits", "headRefOid", "title"},
+				States:   []string{"MERGED", "CLOSED"},
+			})
+			if _, ok := err.(*shared.NotFoundError); ok {
+				continue
+			}
+			if err != nil {
+				return err
+			} else {
+				prs = append(prs, pr)
+
+				// Avoid rate limit. Since rate-limiting is based on count of nodes
+				// loaded, we only need to worry about it in the case where finding a PR
+				// succeeded (because no nodes are loaded in the not-found case).
+				//
+				// TODO: Intelligently retry on rate limiting instead.
+				time.Sleep(time.Second)
+			}
+		}
+		opts.IO.StopProgressIndicator()
+
+		// Reorganize branches by their HEAD commits for fast lookup.
+		branchesByCommit := make(map[string][]git.Branch)
+		for _, branch := range branchesWithUpstream {
+			branchesByCommit[branch.Local.Hash] = append(branchesByCommit[branch.Local.Hash], branch)
+		}
+
+		// Get the list of candidate branch deletions.
+		//
+		// Any local branch whose HEAD is a commit of a merged or closed PR is a
+		// candidate for deletion, because the local branch's history is a prefix of
+		// the remote branch's history (i.e. there are no local commits that the
+		// upstream does not have).
+		//
+		// This behavior is altered by:
+		// * --exclude-behind: the local branch's head ref must be the PR's head ref.
+		// * --exclude-closed: closed PRs are not considered.
+		deletionCandidates := make(map[git.Branch]*api.PullRequest)
+		for _, pr := range prs {
+			if opts.MergedOnly && pr.State == "CLOSED" {
+				continue
+			}
+
+			if opts.UpToDateOnly {
+				candidates := branchesByCommit[pr.HeadRefOid]
+				for _, candidate := range candidates {
+					deletionCandidates[candidate] = pr
+				}
+			} else {
+				for _, commit := range pr.Commits.Nodes {
+					candidates := branchesByCommit[commit.Commit.OID]
+					for _, candidate := range candidates {
+						deletionCandidates[candidate] = pr
+					}
+				}
+			}
+		}
+
+		// Interactively confirm branch deletion.
+		cs := opts.IO.ColorScheme()
+		if len(deletionCandidates) == 0 {
+			fmt.Fprintf(opts.IO.Out, "%s No branches to be cleaned up!\n", cs.SuccessIcon())
+			return nil
+		}
+
+		var branchesInAlphaOrder []git.Branch
+		for branch := range deletionCandidates {
+			branchesInAlphaOrder = append(branchesInAlphaOrder, branch)
+		}
+		sort.Slice(branchesInAlphaOrder, func(i, j int) bool {
+			return branchesInAlphaOrder[i].Local.Name < branchesInAlphaOrder[j].Local.Name
+		})
+
+		fmt.Fprintf(opts.IO.Out, "\nThe following branches can be cleaned up:\n\n")
+		table := tableprinter.New(opts.IO)
+		table.HeaderRow("Branch", "Status", "Pull Request")
+		for _, branch := range branchesInAlphaOrder {
+			pr := deletionCandidates[branch]
+
+			table.AddField(branch.Local.Name)
+
+			state := pr.State
+			if branch.Local.Hash != pr.HeadRefOid {
+				state = cs.WarningIcon() + " " + cs.Yellow(state)
+			}
+			if state == "MERGED" {
+				state = cs.SuccessIcon() + " " + cs.Green(state)
+			} else if state == "CLOSED" {
+				state = cs.SuccessIcon() + " " + cs.Red(state)
+			}
+			table.AddField(state)
+
+			table.AddField(
+				fmt.Sprintf(
+					"%s %s",
+					cs.Grayf("#%d", pr.Number),
+					pr.Title,
+				),
+			)
+
+			table.EndRow()
+		}
+		err := table.Render()
+		if err != nil {
+			return err
+		}
+
+		if !opts.UpToDateOnly {
+			fmt.Fprintf(opts.IO.Out, "\n%s indicates that a local branch is behind its remote.\n", cs.WarningIcon())
+		}
+		fmt.Fprintf(opts.IO.Out, "\n")
+
+		confirmed := false
+		if opts.Yes {
+			confirmed = true
+		} else if opts.IO.CanPrompt() {
+			branchTypeStr := "merged or closed"
+			if opts.MergedOnly {
+				branchTypeStr = "merged"
+			}
+			confirmed, err = opts.Prompter.Confirm(
+				fmt.Sprintf("Delete all %d %s branches?", len(deletionCandidates), branchTypeStr),
+				false,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Delete branches.
+		if confirmed {
+			for branch := range deletionCandidates {
+				err := opts.GitClient.DeleteLocalBranch(ctx, branch.Local.Name)
+				if err != nil {
+					return err
+				}
+			}
+			fmt.Fprintf(opts.IO.Out, "Deleted %d branches.\n", len(deletionCandidates))
+		} else {
+			fmt.Fprintf(opts.IO.Out, "Not deleting any branches.\n")
+		}
+	}
+
 	return nil
 }

--- a/pkg/cmd/pr/cleanup/cleanup.go
+++ b/pkg/cmd/pr/cleanup/cleanup.go
@@ -8,9 +8,7 @@ import (
 	"sort"
 
 	"github.com/cli/cli/v2/api"
-	cliContext "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
-	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/internal/tableprinter"
@@ -23,11 +21,8 @@ import (
 type CleanupOptions struct {
 	HttpClient func() (*http.Client, error)
 	GitClient  *git.Client
-	Config     func() (config.Config, error)
 	BaseRepo   func() (ghrepo.Interface, error)
 	IO         *iostreams.IOStreams
-	Remotes    func() (cliContext.Remotes, error)
-	Branch     func() (string, error)
 	Prompter   prompter.Prompter
 
 	Finder shared.PRFinder
@@ -45,10 +40,7 @@ func NewCmdCleanup(f *cmdutil.Factory, runF func(*CleanupOptions) error) *cobra.
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
 		GitClient:  f.GitClient,
-		Config:     f.Config,
 		BaseRepo:   f.BaseRepo,
-		Remotes:    f.Remotes,
-		Branch:     f.Branch,
 		Prompter:   f.Prompter,
 	}
 

--- a/pkg/cmd/pr/cleanup/cleanup.go
+++ b/pkg/cmd/pr/cleanup/cleanup.go
@@ -1,0 +1,64 @@
+package cleanup
+
+import (
+	"net/http"
+
+	cliContext "github.com/cli/cli/v2/context"
+	"github.com/cli/cli/v2/git"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type CleanupOptions struct {
+	HttpClient func() (*http.Client, error)
+	GitClient  *git.Client
+	Config     func() (config.Config, error)
+	IO         *iostreams.IOStreams
+	Remotes    func() (cliContext.Remotes, error)
+	Branch     func() (string, error)
+
+	Finder shared.PRFinder
+
+	SelectorArg string
+	All         bool
+}
+
+func NewCmdCleanup(f *cmdutil.Factory, runF func(*CleanupOptions) error) *cobra.Command {
+	opts := &CleanupOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		GitClient:  f.GitClient,
+		Config:     f.Config,
+		Remotes:    f.Remotes,
+		Branch:     f.Branch,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "cleanup {<number> | <url> | <branch> | --all}",
+		Short: "Clean up local branches of merged pull requests",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Finder = shared.NewFinder(f)
+
+			if len(args) > 0 {
+				opts.SelectorArg = args[0]
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return cleanupRun(opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.All, "all", "", false, "Clean up all merged pull requests")
+
+	return cmd
+}
+
+func cleanupRun(opts *CleanupOptions) error {
+	return nil
+}

--- a/pkg/cmd/pr/cleanup/cleanup_test.go
+++ b/pkg/cmd/pr/cleanup/cleanup_test.go
@@ -1,0 +1,1 @@
+package cleanup

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -5,6 +5,7 @@ import (
 	cmdLock "github.com/cli/cli/v2/pkg/cmd/issue/lock"
 	cmdCheckout "github.com/cli/cli/v2/pkg/cmd/pr/checkout"
 	cmdChecks "github.com/cli/cli/v2/pkg/cmd/pr/checks"
+	cmdCleanup "github.com/cli/cli/v2/pkg/cmd/pr/cleanup"
 	cmdClose "github.com/cli/cli/v2/pkg/cmd/pr/close"
 	cmdComment "github.com/cli/cli/v2/pkg/cmd/pr/comment"
 	cmdCreate "github.com/cli/cli/v2/pkg/cmd/pr/create"
@@ -48,6 +49,7 @@ func NewCmdPR(f *cmdutil.Factory) *cobra.Command {
 		cmdList.NewCmdList(f, nil),
 		cmdCreate.NewCmdCreate(f, nil),
 		cmdStatus.NewCmdStatus(f, nil),
+		cmdCleanup.NewCmdCleanup(f, nil),
 	)
 
 	cmdutil.AddGroup(cmd, "Targeted commands",

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -354,6 +354,9 @@ func findForBranch(httpClient *http.Client, repo ghrepo.Interface, baseBranch, h
 		return prs[a].State == "OPEN" && prs[b].State != "OPEN"
 	})
 
+	// There can be multiple PRs for each (base, head) combination, but only one
+	// open PR at a time. If an open PR exists for the combination, return that
+	// PR. Otherwise, return the latest one.
 	for _, pr := range prs {
 		if pr.HeadLabel() == headBranch && (baseBranch == "" || pr.BaseRefName == baseBranch) && (pr.State == "OPEN" || resp.Repository.DefaultBranchRef.Name != headBranch) {
 			return &pr, nil


### PR DESCRIPTION
I know your contributing guidelines say to avoid issues labelled `core`, but I hacked this together over the weekend after encountering #380 and it performs pretty well for me, so I thought I'd open a PR in case you folks want to take it over. Notably, this PR is still missing tests.

Here's an example of the UI for this subcommand on one of my repositories (note that actual output in TTY is colorized):

```
$ gh pr cleanup --all
Loading PRs for 90 local branches with upstreams. This can take a minute if you have many branches...

The following branches can be cleaned up:

BRANCH                                       STATUS    PULL REQUEST
PLAT-132-analysis-failures                   ✓ MERGED  #83 fix: Failed analyses should be reported as failed
PLAT-43-api-endpoints                        ✓ MERGED  #4 PLAT-43: Implement initial API endpoints
PLAT-44-worker-queuing                       ✓ MERGED  #6 PLAT-44: Set up worker queuing
jg/plat-156                                  ! MERGED  #79 [PLAT-156] Track caller metadata (e.g. build ID, task ID) for analyzeSource
jg/plat-330                                  ! MERGED  #111 [PLAT-330] include worker id in worker logs
jg/plat-61                                   ! MERGED  #14 PLAT-61 - Add credentials for git CLI download
jg/plat-74/cli-flags                         ! MERGED  #41 [PLAT-74] Unknown CLI flags should not cause an error 
jg/update/rel8                               ✓ MERGED  #60 update rel8 to 1.4.0.0
leo/refactor/analyze-job-exception-cleanup   ✓ CLOSED  #99 refactor: Avoid extra Either
leo/refactor/bugexception                    ! MERGED  #65 refactor: Migrate `error` to `bug`
plat-508-with-utf8                           ✓ MERGED  #156 fix: Handle UTF-8 input and output in handles
plat-509-worker-timeout-increase             ✓ MERGED  #155 fix: Increase license scanning timeouts one last time
// [... additional branches elided for brevity ...]

! indicates that a local branch is behind its remote.

? Delete all 79 merged or closed branches? No
Not deleting any branches.
```

Here is the implemented interface:

```
$ gh pr cleanup --help
Clean up local branches of merged or closed pull requests

USAGE
  gh pr cleanup {<number> | <url> | <branch> | --all} [flags]

FLAGS
  --all              Clean up all merged pull requests
  --exclude-behind   Exclude branches that are behind their remote
  --exclude-closed   Exclude branches of closed pull requests
  --strict           Both --exclude-closed and --exclude-behind
  --yes              Skip deletion confirmation

INHERITED FLAGS
      --help                     Show help for command
  -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format

LEARN MORE
  Use 'gh <command> <subcommand> --help' for more information about a command.
  Read the manual at https://cli.github.com/manual
```

Fixes #380.