### PR TITLE
Fix `gh cs ports` requiring `sudo` for privileged port numbers

### DIFF
--- a/internal/codespaces/codespaces.go
+++ b/internal/codespaces/codespaces.go
@@ -88,9 +88,9 @@ func ConnectToLiveshare(ctx context.Context, progress progressIndicator, session
 	})
 }
 
-// ListenTCP starts a localhost tcp listener and returns the listener and bound port
+// ListenTCP starts a localhost tcp listener on 127.0.0.1 and returns the listener and bound port
 func ListenTCP(port int) (*net.TCPListener, int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf(":%d", port))
+	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to build tcp address: %w", err)
 	}

--- a/internal/codespaces/codespaces.go
+++ b/internal/codespaces/codespaces.go
@@ -88,9 +88,14 @@ func ConnectToLiveshare(ctx context.Context, progress progressIndicator, session
 	})
 }
 
-// ListenTCP starts a localhost tcp listener on 127.0.0.1 and returns the listener and bound port
-func ListenTCP(port int) (*net.TCPListener, int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+// ListenTCP starts a localhost tcp listener on 127.0.0.1 (unless allInterfaces is true) and returns the listener and bound port
+func ListenTCP(port int, allInterfaces bool) (*net.TCPListener, int, error) {
+	host := "127.0.0.1"
+	if allInterfaces {
+		host = ""
+	}
+
+	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to build tcp address: %w", err)
 	}

--- a/internal/codespaces/codespaces.go
+++ b/internal/codespaces/codespaces.go
@@ -90,7 +90,7 @@ func ConnectToLiveshare(ctx context.Context, progress progressIndicator, session
 
 // ListenTCP starts a localhost tcp listener and returns the listener and bound port
 func ListenTCP(port int) (*net.TCPListener, int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to build tcp address: %w", err)
 	}

--- a/internal/codespaces/rpc/invoker.go
+++ b/internal/codespaces/rpc/invoker.go
@@ -239,6 +239,7 @@ func (i *invoker) StartSSHServerWithOptions(ctx context.Context, options StartSS
 }
 
 func listenTCP() (*net.TCPListener, error) {
+	// We will end up using this same address to connect, so specify the IP also or the connect will fail
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, fmt.Errorf("failed to build tcp address: %w", err)

--- a/internal/codespaces/states.go
+++ b/internal/codespaces/states.go
@@ -52,7 +52,7 @@ func PollPostCreateStates(ctx context.Context, progress progressIndicator, apiCl
 	}()
 
 	// Ensure local port is listening before client (getPostCreateOutput) connects.
-	listen, localPort, err := ListenTCP(0)
+	listen, localPort, err := ListenTCP(0, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/codespace/jupyter.go
+++ b/pkg/cmd/codespace/jupyter.go
@@ -67,7 +67,7 @@ func (a *App) Jupyter(ctx context.Context, selector *CodespaceSelector) (err err
 	}
 
 	// Pass 0 to pick a random port
-	listen, _, err := codespaces.ListenTCP(0)
+	listen, _, err := codespaces.ListenTCP(0, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/codespace/logs.go
+++ b/pkg/cmd/codespace/logs.go
@@ -49,7 +49,7 @@ func (a *App) Logs(ctx context.Context, selector *CodespaceSelector, follow bool
 	defer safeClose(session, &err)
 
 	// Ensure local port is listening before client (getPostCreateOutput) connects.
-	listen, localPort, err := codespaces.ListenTCP(0)
+	listen, localPort, err := codespaces.ListenTCP(0, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -379,7 +380,7 @@ func (a *App) ForwardPorts(ctx context.Context, selector *CodespaceSelector, por
 	for _, pair := range portPairs {
 		pair := pair
 		group.Go(func() error {
-			listen, _, err := codespaces.ListenTCP(pair.local)
+			listen, _, err := startPortForwardingTCPListener(pair.local)
 			if err != nil {
 				return err
 			}
@@ -427,4 +428,22 @@ func getPortPairs(ports []string) ([]portPair, error) {
 func normalizeJSON(j []byte) []byte {
 	// remove trailing commas
 	return bytes.ReplaceAll(j, []byte("},}"), []byte("}}"))
+}
+
+// startPortForwardingTCPListener starts a localhost tcp listener and returns the listener and bound port
+// Note: this is a re-implementation of `codespaces.ListenTCP` except that it allows all interfaces instead of just 127.0.0.1
+func startPortForwardingTCPListener(port int) (*net.TCPListener, int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to build tcp address: %w", err)
+	}
+
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to listen to local port over tcp: %w", err)
+	}
+
+	port = listener.Addr().(*net.TCPAddr).Port
+
+	return listener, port, nil
 }

--- a/pkg/cmd/codespace/ssh.go
+++ b/pkg/cmd/codespace/ssh.go
@@ -205,7 +205,7 @@ func (a *App) SSH(ctx context.Context, sshArgs []string, opts sshOptions) (err e
 	// Ensure local port is listening before client (Shell) connects.
 	// Unless the user specifies a server port, localSSHServerPort is 0
 	// and thus the client will pick a random port.
-	listen, localSSHServerPort, err := codespaces.ListenTCP(localSSHServerPort)
+	listen, localSSHServerPort, err := codespaces.ListenTCP(localSSHServerPort, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
From https://github.com/cli/cli/discussions/7313

Fixes a regression from https://github.com/cli/cli/pull/6888 where port fowarding used to start a listener just using `":<port>"` and is now using `"127.0.0.1:<port>"` which, for ports < 1024 requires `sudo` to run the command. The cli doesn't really care about binding to `127.0.0.1` specifically for these commands, so going back to the original behavior.