### PR TITLE
make `gh pr create` behavior like `gh repo fork`

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -750,7 +750,26 @@ func handlePush(opts CreateOptions, ctx CreateContext) error {
 
 		// TODO: prevent clashes with another remote of a same name
 		gitClient := ctx.GitClient
-		gitRemote, err := gitClient.AddRemote(context.Background(), "fork", headRepoURL, []string{})
+
+		remoteName := "origin"
+		remotes, err := opts.Remotes()
+		if err != nil {
+			return err
+		}
+
+		if _, err := remotes.FindByName(remoteName); err == nil {
+			renameTarget := "upstream"
+			renameCmd, err := gitClient.Command(context.Background(), "remote", "rename", remoteName, renameTarget)
+			if err != nil {
+				return err
+			}
+			_, err = renameCmd.Output()
+			if err != nil {
+				return err
+			}
+		}
+
+		gitRemote, err := gitClient.AddRemote(context.Background(), remoteName, headRepoURL, []string{})
 		if err != nil {
 			return fmt.Errorf("error adding remote: %w", err)
 		}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -771,7 +771,7 @@ func handlePush(opts CreateOptions, ctx CreateContext) error {
 				return fmt.Errorf("error renaming origin remote: %w", err)
 			}
 			remoteName = "origin"
-			fmt.Fprintf(opts.IO.ErrOut, "Renamed 'origin' remote to 'upstream'\n")
+			fmt.Fprintf(opts.IO.ErrOut, "Changed %s remote to %q\n", ghrepo.FullName(ctx.BaseRepo), "upstream")
 		}
 
 		gitRemote, err := gitClient.AddRemote(context.Background(), remoteName, headRepoURL, []string{})
@@ -779,7 +779,7 @@ func handlePush(opts CreateOptions, ctx CreateContext) error {
 			return fmt.Errorf("error adding remote: %w", err)
 		}
 
-		fmt.Fprintf(opts.IO.ErrOut, "Added forked repository as remote %s\n", gitRemote.Name)
+		fmt.Fprintf(opts.IO.ErrOut, "Added %s as remote %q\n", ghrepo.FullName(headRepo), remoteName)
 
 		headRemote = &ghContext.Remote{
 			Remote: gitRemote,

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -736,49 +736,51 @@ func handlePush(opts CreateOptions, ctx CreateContext) error {
 	// missing:
 	// 1. the head repo was just created by auto-forking;
 	// 2. an existing fork was discovered by querying the API.
-	//
 	// In either case, we want to add the head repo as a new git remote so we
-	// can push to it.
+	// can push to it. We will try to add the head repo as the "origin" remote
+	// and fallback to the "fork" remote if it is unavailable. Also, if the
+	// base repo is the "origin" remote we will rename it "upstream".
 	if headRemote == nil && ctx.IsPushEnabled {
 		cfg, err := opts.Config()
 		if err != nil {
 			return err
 		}
-		cloneProtocol, _ := cfg.GetOrDefault(headRepo.RepoHost(), "git_protocol")
 
-		headRepoURL := ghrepo.FormatRemoteURL(headRepo, cloneProtocol)
-
-		// TODO: prevent clashes with another remote of a same name
-		gitClient := ctx.GitClient
-
-		remoteName := "origin"
 		remotes, err := opts.Remotes()
 		if err != nil {
 			return err
 		}
 
-		if origin, _ := remotes.FindByName(remoteName); origin != nil {
-			if ghrepo.IsSame(origin, ctx.BaseRepo) {
-				renameTarget := "upstream"
-				renameCmd, err := gitClient.Command(context.Background(), "remote", "rename", remoteName, renameTarget)
-				if err != nil {
-					return fmt.Errorf("failed to rename origin remote: %w", err)
-				}
-				_, err = renameCmd.Output()
-				if err != nil {
-					return err
-				}
-				fmt.Fprintf(opts.IO.ErrOut, "renamed '%s' remote to '%s' and add 'origin' remote for forked repo\n", remoteName, renameTarget)
-			} else {
-				remoteName = "fork"
+		cloneProtocol, _ := cfg.GetOrDefault(headRepo.RepoHost(), "git_protocol")
+		headRepoURL := ghrepo.FormatRemoteURL(headRepo, cloneProtocol)
+		gitClient := ctx.GitClient
+		origin, _ := remotes.FindByName("origin")
+		upstream, _ := remotes.FindByName("upstream")
+		remoteName := "origin"
+
+		if origin != nil {
+			remoteName = "fork"
+		}
+
+		if origin != nil && upstream == nil && ghrepo.IsSame(origin, ctx.BaseRepo) {
+			renameCmd, err := gitClient.Command(context.Background(), "remote", "rename", "origin", "upstream")
+			if err != nil {
+				return err
 			}
+			if _, err = renameCmd.Output(); err != nil {
+				return fmt.Errorf("error renaming origin remote: %w", err)
+			}
+			remoteName = "origin"
+			fmt.Fprintf(opts.IO.ErrOut, "Renamed 'origin' remote to 'upstream'\n")
 		}
 
 		gitRemote, err := gitClient.AddRemote(context.Background(), remoteName, headRepoURL, []string{})
 		if err != nil {
 			return fmt.Errorf("error adding remote: %w", err)
 		}
-		fmt.Fprintf(opts.IO.ErrOut, "added remote %s\n", gitRemote.Name)
+
+		fmt.Fprintf(opts.IO.ErrOut, "Added forked repository as remote %s\n", gitRemote.Name)
+
 		headRemote = &ghContext.Remote{
 			Remote: gitRemote,
 			Repo:   headRepo,

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -466,9 +466,9 @@ func Test_createRun(t *testing.T) {
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
+				cs.Register("git remote rename origin upstream", 0, "")
 				cs.Register(`git remote add origin https://github.com/monalisa/REPO.git`, 0, "")
 				cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
-				cs.Register("git remote rename origin upstream", 0, "")
 			},
 			promptStubs: func(pm *prompter.PrompterMock) {
 				pm.SelectFunc = func(p, _ string, opts []string) (int, error) {
@@ -480,7 +480,7 @@ func Test_createRun(t *testing.T) {
 				}
 			},
 			expectedOut:    "https://github.com/OWNER/REPO/pull/12\n",
-			expectedErrOut: "\nCreating pull request for monalisa:feature into master in OWNER/REPO\n\n",
+			expectedErrOut: "\nCreating pull request for monalisa:feature into master in OWNER/REPO\n\nRenamed 'origin' remote to 'upstream'\nAdded forked repository as remote origin\n",
 		},
 		{
 			name: "pushed to non base repo",

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -480,7 +480,7 @@ func Test_createRun(t *testing.T) {
 				}
 			},
 			expectedOut:    "https://github.com/OWNER/REPO/pull/12\n",
-			expectedErrOut: "\nCreating pull request for monalisa:feature into master in OWNER/REPO\n\nRenamed 'origin' remote to 'upstream'\nAdded forked repository as remote origin\n",
+			expectedErrOut: "\nCreating pull request for monalisa:feature into master in OWNER/REPO\n\nChanged OWNER/REPO remote to \"upstream\"\nAdded monalisa/REPO as remote \"origin\"\n",
 		},
 		{
 			name: "pushed to non base repo",

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -466,8 +466,9 @@ func Test_createRun(t *testing.T) {
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 0, "")
-				cs.Register(`git remote add fork https://github.com/monalisa/REPO.git`, 0, "")
-				cs.Register(`git push --set-upstream fork HEAD:feature`, 0, "")
+				cs.Register(`git remote add origin https://github.com/monalisa/REPO.git`, 0, "")
+				cs.Register(`git push --set-upstream origin HEAD:feature`, 0, "")
+				cs.Register("git remote rename origin upstream", 0, "")
 			},
 			promptStubs: func(pm *prompter.PrompterMock) {
 				pm.SelectFunc = func(p, _ string, opts []string) (int, error) {


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

this pr make `gh pr create` create `origin` remote not fork remote, and will rename old `origin` remote to `upstream`, so the `gh pr create` will have some behavior as `gh repo fork`.

The implementation in the code and the `gh repo fork` command are almost identical. I have read both sides of the code and find them good enough. 
I think the best approach to unify these two command would be to use the code from the fork command, as it ensures consistent behavior. However, I am not sure if calling another command is a good practice. Alternatively, we could consider extracting a common function. But I am not very familiar with the overall architecture, so I am unsure where the common code should be placed.


Fixes #4627 and #7320 