### PR TITLE
Add capability to filter codespaces by repo owner

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -128,11 +128,18 @@ func (a *API) GetUser(ctx context.Context) (*User, error) {
 	return &response, nil
 }
 
+// RepositoryOwner represents owner of a repository
+type RepositoryOwner struct {
+	Type  string `json:"type"`
+	Login string `json:"login"`
+}
+
 // Repository represents a GitHub repository.
 type Repository struct {
-	ID            int    `json:"id"`
-	FullName      string `json:"full_name"`
-	DefaultBranch string `json:"default_branch"`
+	ID            int             `json:"id"`
+	FullName      string          `json:"full_name"`
+	DefaultBranch string          `json:"default_branch"`
+	Owner         RepositoryOwner `json:"owner"`
 }
 
 // GetRepository returns the repository associated with the given owner and name.

--- a/pkg/cmd/codespace/codespace_selector.go
+++ b/pkg/cmd/codespace/codespace_selector.go
@@ -15,6 +15,7 @@ type CodespaceSelector struct {
 
 	repoName      string
 	codespaceName string
+	repoOwner     string
 }
 
 var errNoFilteredCodespaces = errors.New("you have no codespaces meeting the filter criteria")
@@ -25,6 +26,7 @@ func AddCodespaceSelector(cmd *cobra.Command, api apiClient) *CodespaceSelector 
 
 	cmd.PersistentFlags().StringVarP(&cs.codespaceName, "codespace", "c", "", "Name of the codespace")
 	cmd.PersistentFlags().StringVarP(&cs.repoName, "repo", "R", "", "Filter codespace selection by repository name (user/repo)")
+	cmd.Flags().StringVar(&cs.repoOwner, "repo-owner", "", "To filter by the `username` of the repository owner")
 
 	cmd.MarkFlagsMutuallyExclusive("codespace", "repo")
 
@@ -100,6 +102,10 @@ func (cs *CodespaceSelector) fetchCodespaces(ctx context.Context) (codespaces []
 		}
 
 		codespaces = filteredCodespaces
+	}
+
+	if cs.repoOwner != "" {
+		codespaces = filterCodespacesByRepoOwner(codespaces, cs.repoOwner)
 	}
 
 	if len(codespaces) == 0 {

--- a/pkg/cmd/codespace/codespace_selector.go
+++ b/pkg/cmd/codespace/codespace_selector.go
@@ -29,6 +29,7 @@ func AddCodespaceSelector(cmd *cobra.Command, api apiClient) *CodespaceSelector 
 	cmd.PersistentFlags().StringVar(&cs.repoOwner, "repo-owner", "", "Filter codespace selection by repository owner (username or org)")
 
 	cmd.MarkFlagsMutuallyExclusive("codespace", "repo")
+	cmd.MarkFlagsMutuallyExclusive("codespace", "repo-owner")
 
 	return cs
 }

--- a/pkg/cmd/codespace/codespace_selector.go
+++ b/pkg/cmd/codespace/codespace_selector.go
@@ -26,7 +26,7 @@ func AddCodespaceSelector(cmd *cobra.Command, api apiClient) *CodespaceSelector 
 
 	cmd.PersistentFlags().StringVarP(&cs.codespaceName, "codespace", "c", "", "Name of the codespace")
 	cmd.PersistentFlags().StringVarP(&cs.repoName, "repo", "R", "", "Filter codespace selection by repository name (user/repo)")
-	cmd.Flags().StringVar(&cs.repoOwner, "repo-owner", "", "To filter by the `username` of the repository owner")
+	cmd.PersistentFlags().StringVar(&cs.repoOwner, "repo-owner", "", "To filter by the `username` of the repository owner")
 
 	cmd.MarkFlagsMutuallyExclusive("codespace", "repo")
 

--- a/pkg/cmd/codespace/codespace_selector.go
+++ b/pkg/cmd/codespace/codespace_selector.go
@@ -26,7 +26,7 @@ func AddCodespaceSelector(cmd *cobra.Command, api apiClient) *CodespaceSelector 
 
 	cmd.PersistentFlags().StringVarP(&cs.codespaceName, "codespace", "c", "", "Name of the codespace")
 	cmd.PersistentFlags().StringVarP(&cs.repoName, "repo", "R", "", "Filter codespace selection by repository name (user/repo)")
-	cmd.PersistentFlags().StringVar(&cs.repoOwner, "repo-owner", "", "To filter by the `username` of the repository owner")
+	cmd.PersistentFlags().StringVar(&cs.repoOwner, "repo-owner", "", "Filter codespace selection by repository owner (username or org)")
 
 	cmd.MarkFlagsMutuallyExclusive("codespace", "repo")
 

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
@@ -265,4 +266,15 @@ func addDeprecatedRepoShorthand(cmd *cobra.Command, target *string) error {
 	}
 
 	return nil
+}
+
+// filterCodespacesByRepoOwner filters a list of codespaces by the owner of the repository.
+func filterCodespacesByRepoOwner(codespaces []*api.Codespace, repoOwner string) []*api.Codespace {
+	filtered := make([]*api.Codespace, 0, len(codespaces))
+	for _, c := range codespaces {
+		if strings.EqualFold(c.Repository.Owner.Login, repoOwner) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
 }

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -217,6 +217,44 @@ func TestDelete(t *testing.T) {
 			wantDeleted: []string{"monalisa-spoonknife-123"},
 			wantStdout:  "",
 		},
+		{
+			name: "by repo owner",
+			opts: deleteOptions{
+				deleteAll: true,
+				repoOwner: "octocat",
+			},
+			codespaces: []*api.Codespace{
+				{
+					Name: "octocat-spoonknife-123",
+					Repository: api.Repository{
+						FullName: "octocat/Spoon-Knife",
+						Owner: api.RepositoryOwner{
+							Login: "octocat",
+						},
+					},
+				},
+				{
+					Name: "cli-robawt-abc",
+					Repository: api.Repository{
+						FullName: "cli/ROBAWT",
+						Owner: api.RepositoryOwner{
+							Login: "cli",
+						},
+					},
+				},
+				{
+					Name: "octocat-spoonknife-c4f3",
+					Repository: api.Repository{
+						FullName: "octocat/Spoon-Knife",
+						Owner: api.RepositoryOwner{
+							Login: "octocat",
+						},
+					},
+				},
+			},
+			wantDeleted: []string{"octocat-spoonknife-123", "octocat-spoonknife-c4f3"},
+			wantStdout:  "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #7315 

List all
```
❯❯ ./bin/gh cs list                                                                                                    took 513ms
NAME                                                DISPLAY NAME           REPOSITORY       BRANCH  STATE         CREATED AT
kousikmitra-laughing-space-disco-975wrjjr94whpg6w   laughing space disco   cli/cli          trunk   Shutdown      1h
kousikmitra-super-duper-palm-tree-wr5xpggq6xv2vvrq  super-duper palm-tree  kousikmitra/cli  trunk   Provisioning  0m
```

Filter by repo owner
```
❯❯ ./bin/gh cs delete --repo-owner cli                                                                                    took 2s
? Choose codespace:  [Use arrows to move, type to filter]
> cli/cli (trunk): laughing space disco

❯❯ ./bin/gh cs delete --repo-owner kousikmitra
? Choose codespace:  [Use arrows to move, type to filter]
> kousikmitra/cli (trunk): special waffle
```

Delete all with repo owner filter
```
❯❯ ./bin/gh cs delete --repo-owner kousikmitra --all
```

List after delete
```
❯❯ ./bin/gh cs list                                                                                                    took 932ms
NAME                                               DISPLAY NAME          REPOSITORY  BRANCH  STATE     CREATED AT
kousikmitra-laughing-space-disco-975wrjjr94whpg6w  laughing space disco  cli/cli     trunk   Shutdown  1h
```

Note: The PR has changes which will add the same filter to other cs subcommands which uses codespace.CodespaceSelector

