### PR TITLE
Print message after codespace deletion

### DIFF
--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -200,7 +200,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 
 	if a.io.IsStdoutTTY() && deletedCodespaces > 0 {
 		successMsg := fmt.Sprintf("%d codespace(s) deleted successfully\n", deletedCodespaces)
-		fmt.Fprint(a.io.Out, successMsg)
+		fmt.Fprint(a.io.ErrOut, successMsg)
 	}
 
 	return err

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -176,7 +177,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 		progressLabel = "Deleting codespaces"
 	}
 
-	var deletedCodespaces []string
+	var deletedCodespaces uint32
 	err = a.RunWithProgress(progressLabel, func() error {
 		var g errgroup.Group
 		for _, c := range codespacesToDelete {
@@ -186,7 +187,7 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 					a.errLogger.Printf("error deleting codespace %q: %v\n", codespaceName, err)
 					return err
 				}
-				deletedCodespaces = append(deletedCodespaces, codespaceName)
+				atomic.AddUint32(&deletedCodespaces, 1)
 				return nil
 			})
 		}
@@ -197,11 +198,11 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 		return nil
 	})
 
-	if a.io.IsStdoutTTY() && len(deletedCodespaces) > 0 {
+	if a.io.IsStdoutTTY() && deletedCodespaces > 0 {
 		cs := a.io.ColorScheme()
-		successMsg := fmt.Sprintf("%s Successfully deleted %d codespaces\n", cs.SuccessIcon(), len(deletedCodespaces))
+		successMsg := fmt.Sprintf("%s Successfully deleted %d codespaces\n", cs.SuccessIcon(), deletedCodespaces)
 		if len(codespacesToDelete) == 1 {
-			successMsg = fmt.Sprintf("%s Successfully deleted %s\n", cs.SuccessIcon(), deletedCodespaces[0])
+			successMsg = fmt.Sprintf("%s Successfully deleted %s\n", cs.SuccessIcon(), codespacesToDelete[0].Name)
 		}
 		fmt.Fprint(a.io.Out, successMsg)
 	}

--- a/pkg/cmd/codespace/delete.go
+++ b/pkg/cmd/codespace/delete.go
@@ -193,17 +193,13 @@ func (a *App) Delete(ctx context.Context, opts deleteOptions) (err error) {
 		}
 
 		if err := g.Wait(); err != nil {
-			return errors.New("some codespaces failed to delete")
+			return fmt.Errorf("%d codespace(s) failed to delete", len(codespacesToDelete)-int(deletedCodespaces))
 		}
 		return nil
 	})
 
 	if a.io.IsStdoutTTY() && deletedCodespaces > 0 {
-		cs := a.io.ColorScheme()
-		successMsg := fmt.Sprintf("%s Successfully deleted %d codespaces\n", cs.SuccessIcon(), deletedCodespaces)
-		if len(codespacesToDelete) == 1 {
-			successMsg = fmt.Sprintf("%s Successfully deleted %s\n", cs.SuccessIcon(), codespacesToDelete[0].Name)
-		}
+		successMsg := fmt.Sprintf("%d codespace(s) deleted successfully\n", deletedCodespaces)
 		fmt.Fprint(a.io.Out, successMsg)
 	}
 

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -42,7 +42,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc"},
-			wantStdout:  "1 codespace(s) deleted successfully\n",
+			wantStderr:  "1 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "by repo",
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "2 codespace(s) deleted successfully\n",
+			wantStderr:  "2 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "unused",
@@ -93,7 +93,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "2 codespace(s) deleted successfully\n",
+			wantStderr:  "2 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "deletion failed",
@@ -150,7 +150,7 @@ func TestDelete(t *testing.T) {
 				"Codespace hubot-robawt-abc has unsaved changes. OK to delete?":        true,
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "2 codespace(s) deleted successfully\n",
+			wantStderr:  "2 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "deletion for org codespace by admin succeeds",
@@ -175,7 +175,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123"},
-			wantStdout:  "1 codespace(s) deleted successfully\n",
+			wantStderr:  "1 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "deletion for org codespace by admin fails for codespace not found",
@@ -217,7 +217,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123"},
-			wantStdout:  "1 codespace(s) deleted successfully\n",
+			wantStderr:  "1 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "by repo owner",
@@ -255,6 +255,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"octocat-spoonknife-123", "octocat-spoonknife-c4f3"},
+			wantStderr:  "2 codespace(s) deleted successfully\n",
 			wantStdout:  "",
 		},
 	}

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -26,7 +26,7 @@ func TestDelete(t *testing.T) {
 		codespaces  []*api.Codespace
 		confirms    map[string]bool
 		deleteErr   error
-		wantErr     bool
+		wantErr     string
 		wantDeleted []string
 		wantStdout  string
 		wantStderr  string
@@ -42,7 +42,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc"},
-			wantStdout:  "✓ Successfully deleted hubot-robawt-abc\n",
+			wantStdout:  "1 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "by repo",
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "✓ Successfully deleted 2 codespaces\n",
+			wantStdout:  "2 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "unused",
@@ -93,7 +93,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "✓ Successfully deleted 2 codespaces\n",
+			wantStdout:  "2 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "deletion failed",
@@ -109,7 +109,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			deleteErr:   errors.New("aborted by test"),
-			wantErr:     true,
+			wantErr:     "2 codespace(s) failed to delete",
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-123"},
 			wantStderr: heredoc.Doc(`
 				error deleting codespace "hubot-robawt-abc": aborted by test
@@ -150,7 +150,7 @@ func TestDelete(t *testing.T) {
 				"Codespace hubot-robawt-abc has unsaved changes. OK to delete?":        true,
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "✓ Successfully deleted 2 codespaces\n",
+			wantStdout:  "2 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "deletion for org codespace by admin succeeds",
@@ -175,7 +175,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123"},
-			wantStdout:  "✓ Successfully deleted monalisa-spoonknife-123\n",
+			wantStdout:  "1 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "deletion for org codespace by admin fails for codespace not found",
@@ -201,7 +201,8 @@ func TestDelete(t *testing.T) {
 			},
 			wantDeleted: []string{},
 			wantStdout:  "",
-			wantErr:     true,
+			wantErr: "error fetching codespace information: " +
+				"codespace not found for user johnDoe with name monalisa-spoonknife-123",
 		},
 		{
 			name: "deletion for org codespace succeeds without username",
@@ -216,7 +217,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123"},
-			wantStdout:  "✓ Successfully deleted monalisa-spoonknife-123\n",
+			wantStdout:  "1 codespace(s) deleted successfully\n",
 		},
 		{
 			name: "by repo owner",
@@ -307,8 +308,8 @@ func TestDelete(t *testing.T) {
 			ios.SetStdoutTTY(true)
 			app := NewApp(ios, nil, apiMock, nil, nil)
 			err := app.Delete(context.Background(), opts)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("delete() error = %v, wantErr %v", err, tt.wantErr)
+			if (err != nil) && tt.wantErr != err.Error() {
+				t.Errorf("delete() error = %v, wantErr = %v", err, tt.wantErr)
 			}
 			for _, listArgs := range apiMock.ListCodespacesCalls() {
 				if listArgs.Opts.OrgName != "" && listArgs.Opts.UserName == "" {

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -42,7 +42,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc"},
-			wantStdout:  "",
+			wantStdout:  "✓ Successfully deleted hubot-robawt-abc\n",
 		},
 		{
 			name: "by repo",
@@ -70,7 +70,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "",
+			wantStdout:  "✓ Successfully deleted 2 codespaces\n",
 		},
 		{
 			name: "unused",
@@ -93,7 +93,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "",
+			wantStdout:  "✓ Successfully deleted 2 codespaces\n",
 		},
 		{
 			name: "deletion failed",
@@ -115,6 +115,7 @@ func TestDelete(t *testing.T) {
 				error deleting codespace "hubot-robawt-abc": aborted by test
 				error deleting codespace "monalisa-spoonknife-123": aborted by test
 			`),
+			wantStdout: "",
 		},
 		{
 			name: "with confirm",
@@ -149,7 +150,7 @@ func TestDelete(t *testing.T) {
 				"Codespace hubot-robawt-abc has unsaved changes. OK to delete?":        true,
 			},
 			wantDeleted: []string{"hubot-robawt-abc", "monalisa-spoonknife-c4f3"},
-			wantStdout:  "",
+			wantStdout:  "✓ Successfully deleted 2 codespaces\n",
 		},
 		{
 			name: "deletion for org codespace by admin succeeds",
@@ -174,7 +175,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123"},
-			wantStdout:  "",
+			wantStdout:  "✓ Successfully deleted monalisa-spoonknife-123\n",
 		},
 		{
 			name: "deletion for org codespace by admin fails for codespace not found",
@@ -215,7 +216,7 @@ func TestDelete(t *testing.T) {
 				},
 			},
 			wantDeleted: []string{"monalisa-spoonknife-123"},
-			wantStdout:  "",
+			wantStdout:  "✓ Successfully deleted monalisa-spoonknife-123\n",
 		},
 		{
 			name: "by repo owner",


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #7348 

Deleted one codepsace
```
❯❯ ./bin/gh cs delete                                                                                                     
? Choose codespace: kousikmitra/cli (trunk): legendary lamp
✓ Successfully deleted kousikmitra-legendary-lamp-wr5xpggpr442gvq
```
Note: Printing name of the codespace here as I think it would be more helpful for subsequent commands.

Deleted multiple codespace
```
❯❯ ./bin/gh cs delete --all                                                                                               
✓ Successfully deleted 2 codespaces
```

**Edit:**

partial success
```
❯❯ ./bin/gh cs delete --all                                                                            
Deleting codespaces ⡿error deleting codespace "kousikmitra-silver-bassoon-xyz": dummy error for testing
1 codespace(s) deleted successfully
1 codespace(s) failed to delete
```

all failed
```
❯❯ ./bin/gh cs delete --all                                                                            
Deleting codespaces ⡿error deleting codespace "kousikmitra-urban-sniffle-abc": dummy error for testing
error deleting codespace "kousikmitra-fluffy-spoon-xyz": dummy error for testing
2 codespace(s) failed to delete
```

all success
```
❯❯ ./bin/gh cs delete --all                                                                            
2 codespace(s) deleted successfully

❯❯ ./bin/gh cs delete --all                                                                            
1 codespace(s) deleted successfully
```
