### PR TITLE
make prompt default values visible and also the color controllable in…

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -80,9 +80,6 @@ func mainRun() exitCode {
 		surveyCore.TemplateFuncsWithColor["color"] = func(style string) string {
 			switch style {
 			case "white":
-				if cmdFactory.IOStreams.ColorSupport256() {
-					return fmt.Sprintf("\x1b[%dm", 38)
-				}
 				return ansi.ColorCode("default")
 			default:
 				return ansi.ColorCode(style)

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -81,7 +81,7 @@ func mainRun() exitCode {
 			switch style {
 			case "white":
 				if cmdFactory.IOStreams.ColorSupport256() {
-					return fmt.Sprintf("\x1b[%d;5;%dm", 38, 242)
+					return fmt.Sprintf("\x1b[%dm", 38)
 				}
 				return ansi.ColorCode("default")
 			default:


### PR DESCRIPTION
Potential fix for #6545.  Change the default value in `gh pr edit` prompts to the ANSI white color (non-bright) instead of the dark grey that it is now.  Full disclosure, though, I haven't done testing to see if there are other commands for which this code is used.  But I would think that if there are, this change will have the same effect of making the text visible on dark terminals for these use cases as well.

To test, try running that command (gh pr edit) in a terminal with a dark background (which I think most devs prefer) using main and then again using this version.  For reference, here is a screenshot that shows what it looks like in main in my iTerm2 terminal.
<img width="451" alt="image" src="https://user-images.githubusercontent.com/4665096/233868937-88589711-9ea5-4331-88f8-89bf8f723132.png">

And here it is again with my change:
<img width="448" alt="image" src="https://user-images.githubusercontent.com/4665096/233868989-6524c8f1-4a93-455c-a952-7805073e6774.png">

Ref. https://github.com/cli/cli/pull/1631