### PR TITLE
Make: Fix target name for Windows platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ endif
 ## The following tasks delegate to `script/build.go` so they can be run cross-platform.
 
 .PHONY: bin/gh$(EXE)
-bin/gh$(EXE): script/build
-	@script/build $@
+bin/gh$(EXE): script/build$(EXE)
+	@script/build$(EXE) $@
 
 script/build$(EXE): script/build.go
 ifeq ($(EXE),)


### PR DESCRIPTION

    This fixes the taget name by adding .exe extension for Windows platform.
    Otherwise, the following error is shown with `make bin/gh.exe' command.

    make: *** No rule to make target 'script/build', needed by 'bin/gh.exe'.  Stop.

