### PR TITLE
Add PR auto-merge status info to PR queries

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -39,6 +39,8 @@ type PullRequest struct {
 	ClosedAt            *time.Time
 	MergedAt            *time.Time
 
+	AutoMergeRequest *AutoMergeRequest
+
 	MergeCommit          *Commit
 	PotentialMergeCommit *Commit
 
@@ -134,6 +136,16 @@ type CheckContext struct {
 type PRRepository struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+}
+
+type AutoMergeRequest struct {
+	AuthorEmail    *string `json:"authorEmail"`
+	CommitBody     *string `json:"commitBody"`
+	CommitHeadline *string `json:"commitHeadline"`
+	// MERGE, REBASE, SQUASH
+	MergeMethod string    `json:"mergeMethod"`
+	EnabledAt   time.Time `json:"enabledAt"`
+	EnabledBy   Author    `json:"enabledBy"`
 }
 
 // Commit loads just the commit SHA and nothing else

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -132,6 +132,17 @@ var prCommits = shortenQuery(`
 	}
 `)
 
+var autoMergeRequest = shortenQuery(`
+	autoMergeRequest {
+		authorEmail,
+		commitBody,
+		commitHeadline,
+		mergeMethod,
+		enabledAt,
+		enabledBy{login,...on User{id,name}}
+	}
+`)
+
 func StatusCheckRollupGraphQL(after string) string {
 	var afterClause string
 	if after != "" {
@@ -231,6 +242,7 @@ var IssueFields = []string{
 
 var PullRequestFields = append(IssueFields,
 	"additions",
+	"autoMergeRequest",
 	"baseRefName",
 	"changedFiles",
 	"commits",
@@ -285,6 +297,8 @@ func IssueGraphQL(fields []string) string {
 			q = append(q, `mergeCommit{oid}`)
 		case "potentialMergeCommit":
 			q = append(q, `potentialMergeCommit{oid}`)
+		case "autoMergeRequest":
+			q = append(q, autoMergeRequest)
 		case "comments":
 			q = append(q, issueComments)
 		case "lastComment": // pseudo-field


### PR DESCRIPTION
_This PR is part of a series for issue #7309, adding auto-merge status support to PR commands_

This PR adds the `autoMergeRequest` field to the list of JSON fields available to the `gh pr list`, `gh pr status` and `gh pr view` commands.

Once this information is available, each of these commands can be extended to make use of this; e.g. the `gh pr view` command could include that a PR will auto-merge once conditions are met in the output it generates.
