### PR TITLE
Include auto-merge information in gh pr view

### DIFF
--- a/pkg/cmd/pr/view/fixtures/prViewPreviewWithAutoMergeEnabled.json
+++ b/pkg/cmd/pr/view/fixtures/prViewPreviewWithAutoMergeEnabled.json
@@ -1,0 +1,55 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "number": 12,
+        "title": "Blueberries are from a fork",
+        "state": "OPEN",
+        "body": "**blueberries taste good**",
+        "url": "https://github.com/OWNER/REPO/pull/12",
+        "author": {
+          "login": "nobody"
+        },
+        "autoMergeRequest": {
+          "authorEmail": null,
+          "commitBody": null,
+          "commitHeadline": null,
+          "mergeMethod": "SQUASH",
+          "enabledAt": "2020-08-27T19:00:12Z",
+          "enabledBy": {
+            "login": "hubot"
+          }
+        },
+        "additions": 100,
+        "deletions": 10,
+        "reviewRequests": {
+            "nodes": [],
+            "totalcount": 0
+        },
+        "assignees": {
+          "nodes": [],
+          "totalcount": 0
+        },
+        "labels": {
+          "nodes": [],
+          "totalcount": 0
+        },
+        "projectcards": {
+          "nodes": [],
+          "totalcount": 0
+        },
+        "milestone": {},
+        "commits": {
+          "totalCount": 12
+        },
+        "baseRefName": "master",
+        "headRefName": "blueberries",
+        "headRepositoryOwner": {
+          "login": "hubot"
+        },
+        "isCrossRepository": true,
+        "isDraft": false
+      }
+    }
+  }
+}

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -314,6 +314,25 @@ func TestPRView_Preview_nontty(t *testing.T) {
 				`\*\*blueberries taste good\*\*`,
 			},
 		},
+		"PR with auto-merge enabled": {
+			branch: "master",
+			args:   "12",
+			fixtures: map[string]string{
+				"PullRequestByNumber": "./fixtures/prViewPreviewWithAutoMergeEnabled.json",
+			},
+			expectedOutputs: []string{
+				`title:\tBlueberries are from a fork\n`,
+				`state:\tOPEN\n`,
+				`author:\tnobody\n`,
+				`labels:\t\n`,
+				`assignees:\t\n`,
+				`projects:\t\n`,
+				`milestone:\t\n`,
+				`additions:\t100\n`,
+				`deletions:\t10\n`,
+				`auto-merge:\tenabled\thubot\tsquash\n`,
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -500,6 +519,20 @@ func TestPRView_Preview(t *testing.T) {
 				`Blueberries are from a fork #12`,
 				`Open.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`.+100.-10 • No checks`,
+				`blueberries taste good`,
+				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`,
+			},
+		},
+		"PR with auto-merge enabled": {
+			branch: "master",
+			args:   "12",
+			fixtures: map[string]string{
+				"PullRequestByNumber": "./fixtures/prViewPreviewWithAutoMergeEnabled.json",
+			},
+			expectedOutputs: []string{
+				`Blueberries are from a fork #12\n`,
+				`Open.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
+				`Auto-merge:.*enabled.* by hubot, using squash and merge`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`,
 			},


### PR DESCRIPTION
_This PR is part of a series for issue #7309, adding auto-merge status support to PR commands_

If a PR has auto-merge enabled, the human-readable output shows this in an additional line in the metadata section:

```
Auto-merge: enabled by [userid], using [merge method] • [when]
```

The line is not added when auto-merge is not enabled.

The raw version alawys includes a line; either

```
auto-merge: disabled
```

or

```
auto-merge: enabled ([userid], [merge method])
```

Note: this PR includes the commit from #7384 as this is a direct dependency on the GraphQL query data being available.