### PR TITLE
Include auto-merge status info into gh pr status

### DIFF
--- a/pkg/cmd/pr/status/fixtures/prStatus.json
+++ b/pkg/cmd/pr/status/fixtures/prStatus.json
@@ -15,7 +15,8 @@
               "headRepositoryOwner": {
                 "login": "OWNER"
               },
-              "isCrossRepository": false
+              "isCrossRepository": false,
+              "autoMergeRequest": null
             }
           }
         ]
@@ -31,7 +32,8 @@
             "state": "OPEN",
             "url": "https://github.com/cli/cli/pull/8",
             "headRefName": "strawberries",
-            "isDraft": false
+            "isDraft": false,
+            "autoMergeRequest": null
           }
         }
       ]
@@ -46,7 +48,17 @@
             "state": "OPEN",
             "url": "https://github.com/cli/cli/pull/9",
             "headRefName": "apples",
-            "isDraft": false
+            "isDraft": false,
+            "autoMergeRequest": {
+              "authorEmail": null,
+              "commitBody": null,
+              "commitHeadline": null,
+              "mergeMethod": "SQUASH",
+              "enabledAt": "2020-08-27T19:00:12Z",
+              "enabledBy": {
+                "login": "hubot"
+              }
+            }
           } }, {
           "node": {
             "number": 11,
@@ -54,7 +66,8 @@
             "state": "OPEN",
             "url": "https://github.com/cli/cli/pull/1",
             "headRefName": "figs",
-            "isDraft": true
+            "isDraft": true,
+            "autoMergeRequest": null
           }
         }
       ]

--- a/pkg/cmd/pr/status/http.go
+++ b/pkg/cmd/pr/status/http.go
@@ -191,7 +191,7 @@ func pullRequestFragment(hostname string, conflictStatus bool) (string, error) {
 	fields := []string{
 		"number", "title", "state", "url", "isDraft", "isCrossRepository",
 		"headRefName", "headRepositoryOwner", "mergeStateStatus",
-		"statusCheckRollup", "requiresStrictStatusChecks",
+		"statusCheckRollup", "requiresStrictStatusChecks", "autoMergeRequest",
 	}
 
 	if conflictStatus {

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -284,6 +284,10 @@ func printPrs(io *iostreams.IOStreams, totalCount int, prs ...api.PullRequest) {
 				}
 			}
 
+			if pr.AutoMergeRequest != nil {
+				fmt.Fprintf(w, " %s", cs.Green("✓ Auto-merge enabled"))
+			}
+
 		} else {
 			fmt.Fprintf(w, " - %s", shared.StateTitleWithColor(cs, pr))
 		}

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -91,7 +91,7 @@ func TestPRStatus(t *testing.T) {
 
 	expectedPrs := []*regexp.Regexp{
 		regexp.MustCompile(`#8.*\[strawberries\]`),
-		regexp.MustCompile(`#9.*\[apples\]`),
+		regexp.MustCompile(`#9.*\[apples\].*✓ Auto-merge enabled`),
 		regexp.MustCompile(`#10.*\[blueberries\]`),
 		regexp.MustCompile(`#11.*\[figs\]`),
 	}


### PR DESCRIPTION
_This PR is part of a series for issue #7309, adding auto-merge status support to PR commands_

For any listed PR that has auto-merge enabled, a label is added:

```
✓ Auto-merge enabled 
```

in magenta:

<img width="388" alt="image" src="https://user-images.githubusercontent.com/46775/235355839-c574f89c-5ffd-4d76-95ad-d613a177f382.png">

Note: this PR includes the commit from #7384 as this is a direct dependency on the GraphQL query data being available.
