### PR TITLE
Add --auto-merge filtering to gh pr list

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -11,9 +11,10 @@ import (
 )
 
 type PullRequestAndTotalCount struct {
-	TotalCount   int
-	PullRequests []PullRequest
-	SearchCapped bool
+	TotalCount             int
+	TotalCountIsUpperBound bool
+	PullRequests           []PullRequest
+	SearchCapped           bool
 }
 
 type PullRequest struct {

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -203,7 +203,7 @@ func listRun(opts *ListOptions) error {
 		fmt.Fprintln(opts.IO.ErrOut, "warning: this query uses the Search API which is capped at 1000 results maximum")
 	}
 	if isTerminal {
-		title := prShared.ListHeader(ghrepo.FullName(baseRepo), "issue", len(listResult.Issues), listResult.TotalCount, !filterOptions.IsDefault())
+		title := prShared.ListHeader(ghrepo.FullName(baseRepo), "issue", len(listResult.Issues), listResult.TotalCount, false, !filterOptions.IsDefault())
 		fmt.Fprintf(opts.IO.Out, "\n%s\n\n", title)
 	}
 

--- a/pkg/cmd/pr/list/fixtures/prList.json
+++ b/pkg/cmd/pr/list/fixtures/prList.json
@@ -11,7 +11,8 @@
             "createdAt": "2022-08-24T20:01:12Z",
             "headRefName": "feature",
             "state": "OPEN",
-            "isDraft": true
+            "isDraft": true,
+            "autoMergeRequest": null
           },
           {
             "number": 29,
@@ -24,7 +25,8 @@
             "isCrossRepository": true,
             "headRepositoryOwner": {
               "login": "hubot"
-            }
+            },
+            "autoMergeRequest": {}
           },
           {
             "number": 28,
@@ -33,7 +35,8 @@
             "title": "Improve documentation",
             "createdAt": "2020-01-26T19:01:12Z",
             "url": "https://github.com/monalisa/hello/pull/28",
-            "headRefName": "docs"
+            "headRefName": "docs",
+            "autoMergeRequest": {}
           }
         ],
         "pageInfo": {

--- a/pkg/cmd/pr/list/http_test.go
+++ b/pkg/cmd/pr/list/http_test.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
@@ -157,6 +158,456 @@ func Test_listPullRequests(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("listPullRequests() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+		})
+	}
+}
+
+func Test_ListPRsPaged(t *testing.T) {
+	// to create references to
+	trueVar := true
+	falseVar := false
+
+	type args struct {
+		filters prShared.FilterOptions
+		limit   int
+	}
+	type expected struct {
+		prCount      int
+		totalCount   int
+		isUpperBound bool
+	}
+	tests := []struct {
+		name      string
+		args      args
+		queryType string
+		responses []string
+		expected  expected
+	}{
+		{
+			name: "default",
+			args: args{
+				filters: prShared.FilterOptions{
+					State: "open",
+				},
+				limit: 8,
+			},
+			queryType: "PullRequestList",
+			responses: []string{
+				`{"data": {"repository": {"pullRequests": {
+                    "totalCount": 20,
+                    "nodes": [
+                        {"title": "P1PR1"},
+                        {"title": "P1PR2"},
+                        {"title": "P1PR3"},
+                        {"title": "P1PR4"},
+                        {"title": "P1PR5"}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE2"}
+                }}}}`,
+				`{"data": {"repository": {"pullRequests": {
+                    "totalCount": 20,
+                    "nodes": [
+                        {"title": "P2PR1"},
+                        {"title": "P2PR2"},
+                        {"title": "P2PR3"}
+                    ],
+                    "pageInfo": {"hasNextPage": false}
+                }}}}`,
+			},
+			expected: expected{
+				prCount:      8,
+				totalCount:   20,
+				isUpperBound: false,
+			},
+		},
+		{
+			name: "with search",
+			args: args{
+				filters: prShared.FilterOptions{
+					State:  "open",
+					Search: "one world in:title",
+				},
+				limit: 30,
+			},
+			queryType: "PullRequestSearch",
+			responses: []string{
+				`{"data": {"search": {
+                    "issueCount": 20,
+                    "nodes": [
+                        {"title": "P1PR1"},
+                        {"title": "P1PR2"},
+                        {"title": "P1PR3"},
+                        {"title": "P1PR4"},
+                        {"title": "P1PR5"}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE2"}
+                }}}`,
+				`{"data": {"search": {
+                    "issueCount": 20,
+                    "nodes": [
+                        {"title": "P2PR1"},
+                        {"title": "P2PR2"},
+                        {"title": "P2PR3"}
+                    ],
+                    "pageInfo": {"hasNextPage": false}
+                }}}`,
+			},
+			expected: expected{
+				prCount:      8,
+				totalCount:   20,
+				isUpperBound: false,
+			},
+		},
+		{
+			name: "with auto-merge enabled, more pages",
+			args: args{
+				filters: prShared.FilterOptions{
+					State:           "open",
+					AutoMergeStatus: &trueVar,
+				},
+				limit: 5,
+			},
+			queryType: "PullRequestList",
+			responses: []string{
+				`{"data": {"repository": {"pullRequests": {
+                    "totalCount": 20,
+                    "nodes": [
+                        {"title": "P1PR1 disabled", "autoMergeRequest": null},
+                        {"title": "P1PR2 -- 1 / 5", "autoMergeRequest": {}},
+                        {"title": "P1PR3 -- 2 / 5", "autoMergeRequest": {}},
+                        {"title": "P1PR4 disabled", "autoMergeRequest": null},
+                        {"title": "P1PR5 -- 3 / 5", "autoMergeRequest": {}}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE2"}
+                }}}}`,
+				`{"data": {"repository": {"pullRequests": {
+                    "totalCount": 20,
+                    "nodes": [
+                        {"title": "P2PR1 -- 1 / 5", "autoMergeRequest": {}},
+                        {"title": "P2PR2 disabled", "autoMergeRequest": null},
+                        {"title": "P2PR3 -- 2 / 5", "autoMergeRequest": {}},
+                        {"title": "P2PR4 -- 3 / 5", "autoMergeRequest": {}},
+                        {"title": "P2PR5 disabled", "autoMergeRequest": null}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE3"}
+                }}}}`,
+			},
+			expected: expected{
+				prCount:      5,
+				totalCount:   16,
+				isUpperBound: true,
+			},
+		},
+		{
+			name: "with auto-merge enabled, no more pages",
+			args: args{
+				filters: prShared.FilterOptions{
+					State:           "open",
+					AutoMergeStatus: &trueVar,
+				},
+				limit: 5,
+			},
+			queryType: "PullRequestList",
+			responses: []string{
+				`{"data": {"repository": {"pullRequests": {
+                    "totalCount": 10,
+                    "nodes": [
+                        {"title": "P1PR1 disabled", "autoMergeRequest": null},
+                        {"title": "P1PR2 -- 1 / 5", "autoMergeRequest": {}},
+                        {"title": "P1PR3 -- 2 / 5", "autoMergeRequest": {}},
+                        {"title": "P1PR4 disabled", "autoMergeRequest": null},
+                        {"title": "P1PR5 -- 3 / 5", "autoMergeRequest": {}}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE2"}
+                }}}}`,
+				`{"data": {"repository": {"pullRequests": {
+                    "totalCount": 10,
+                    "nodes": [
+                        {"title": "P2PR1 -- 4 / 5", "autoMergeRequest": {}},
+                        {"title": "P2PR2 disabled", "autoMergeRequest": null},
+                        {"title": "P2PR3 -- 5 / 5", "autoMergeRequest": {}},
+                        {"title": "P2PR4 -- extra", "autoMergeRequest": {}},
+                        {"title": "P2PR5 disabled", "autoMergeRequest": null}
+                    ],
+                    "pageInfo": {"hasNextPage": false}
+                }}}}`,
+			},
+			expected: expected{
+				prCount:      5,
+				totalCount:   6,
+				isUpperBound: false,
+			},
+		},
+		{
+			name: "with auto-merge disabled, more pages",
+			args: args{
+				filters: prShared.FilterOptions{
+					State:           "open",
+					AutoMergeStatus: &falseVar,
+				},
+				limit: 5,
+			},
+			queryType: "PullRequestList",
+			responses: []string{
+				`{"data": {"repository": {"pullRequests": {
+                    "totalCount": 20,
+                    "nodes": [
+                        {"title": "P1PR1 - 1 / 5", "autoMergeRequest": null},
+                        {"title": "P1PR2 enabled", "autoMergeRequest": {}},
+                        {"title": "P1PR3 enabled", "autoMergeRequest": {}},
+                        {"title": "P1PR4 - 2 / 5", "autoMergeRequest": null},
+                        {"title": "P1PR5 enabled", "autoMergeRequest": {}}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE2"}
+                }}}}`,
+				`{"data": {"repository": {"pullRequests": {
+                    "totalCount": 20,
+                    "nodes": [
+                        {"title": "P2PR1 enabled", "autoMergeRequest": {}},
+                        {"title": "P2PR2 - 3 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR3 - 4 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR4 - 5 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR5 - extra", "autoMergeRequest": null}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE3"}
+                }}}}`,
+			},
+			expected: expected{
+				prCount:      5,
+				totalCount:   16,
+				isUpperBound: true,
+			},
+		},
+		{
+			name: "with auto-merge disabled, no more pages",
+			args: args{
+				filters: prShared.FilterOptions{
+					State:           "open",
+					AutoMergeStatus: &falseVar,
+				},
+				limit: 5,
+			},
+			queryType: "PullRequestList",
+			responses: []string{
+				`{"data": {"repository": {"pullRequests": {
+                    "totalCount": 10,
+                    "nodes": [
+                        {"title": "P1PR1 - 1 / 5", "autoMergeRequest": null},
+                        {"title": "P1PR2 enabled", "autoMergeRequest": {}},
+                        {"title": "P1PR3 enabled", "autoMergeRequest": {}},
+                        {"title": "P1PR4 - 2 / 5", "autoMergeRequest": null},
+                        {"title": "P1PR5 enabled", "autoMergeRequest": {}}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE2"}
+                }}}}`,
+				`{"data": {"repository": {"pullRequests": {
+                    "totalCount": 10,
+                    "nodes": [
+                        {"title": "P2PR1 enabled", "autoMergeRequest": {}},
+                        {"title": "P2PR2 - 3 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR3 - 4 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR4 - 5 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR5 - extra", "autoMergeRequest": null}
+                    ],
+                    "pageInfo": {"hasNextPage": false}
+                }}}}`,
+			},
+			expected: expected{
+				prCount:      5,
+				totalCount:   6,
+				isUpperBound: false,
+			},
+		},
+		{
+			name: "with search and auto-merge enabled, more pages",
+			args: args{
+				filters: prShared.FilterOptions{
+					State:           "open",
+					AutoMergeStatus: &trueVar,
+					Search:          "one world in:title",
+				},
+				limit: 5,
+			},
+			queryType: "PullRequestSearch",
+			responses: []string{
+				`{"data": {"search": {
+                    "issueCount": 20,
+                    "nodes": [
+                        {"title": "P1PR1 disabled", "autoMergeRequest": null},
+                        {"title": "P1PR2 -- 1 / 5", "autoMergeRequest": {}},
+                        {"title": "P1PR3 -- 2 / 5", "autoMergeRequest": {}},
+                        {"title": "P1PR4 disabled", "autoMergeRequest": null},
+                        {"title": "P1PR5 -- 3 / 5", "autoMergeRequest": {}}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE2"}
+                }}}`,
+				`{"data": {"search": {
+                    "issueCount": 20,
+                    "nodes": [
+                        {"title": "P2PR1 -- 1 / 5", "autoMergeRequest": {}},
+                        {"title": "P2PR2 disabled", "autoMergeRequest": null},
+                        {"title": "P2PR3 -- 2 / 5", "autoMergeRequest": {}},
+                        {"title": "P2PR4 -- 3 / 5", "autoMergeRequest": {}},
+                        {"title": "P2PR5 disabled", "autoMergeRequest": null}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE3"}
+                }}}`,
+			},
+			expected: expected{
+				prCount:      5,
+				totalCount:   16,
+				isUpperBound: true,
+			},
+		},
+		{
+			name: "with search and auto-merge enabled, no more pages",
+			args: args{
+				filters: prShared.FilterOptions{
+					State:           "open",
+					AutoMergeStatus: &trueVar,
+					Search:          "one world in:title",
+				},
+				limit: 5,
+			},
+			queryType: "PullRequestSearch",
+			responses: []string{
+				`{"data": {"search": {
+                    "issueCount": 10,
+                    "nodes": [
+                        {"title": "P1PR1 disabled", "autoMergeRequest": null},
+                        {"title": "P1PR2 -- 1 / 5", "autoMergeRequest": {}},
+                        {"title": "P1PR3 -- 2 / 5", "autoMergeRequest": {}},
+                        {"title": "P1PR4 disabled", "autoMergeRequest": null},
+                        {"title": "P1PR5 -- 3 / 5", "autoMergeRequest": {}}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE2"}
+                }}}`,
+				`{"data": {"search": {
+                    "issueCount": 10,
+                    "nodes": [
+                        {"title": "P2PR1 -- 4 / 5", "autoMergeRequest": {}},
+                        {"title": "P2PR2 disabled", "autoMergeRequest": null},
+                        {"title": "P2PR3 -- 5 / 5", "autoMergeRequest": {}},
+                        {"title": "P2PR4 -- extra", "autoMergeRequest": {}},
+                        {"title": "P2PR5 disabled", "autoMergeRequest": null}
+                    ],
+                    "pageInfo": {"hasNextPage": false}
+                }}}`,
+			},
+			expected: expected{
+				prCount:      5,
+				totalCount:   6,
+				isUpperBound: false,
+			},
+		},
+		{
+			name: "with search and auto-merge disabled, more pages",
+			args: args{
+				filters: prShared.FilterOptions{
+					State:           "open",
+					AutoMergeStatus: &falseVar,
+					Search:          "one world in:title",
+				},
+				limit: 5,
+			},
+			queryType: "PullRequestSearch",
+			responses: []string{
+				`{"data": {"search": {
+                    "issueCount": 20,
+                    "nodes": [
+                        {"title": "P1PR1 - 1 / 5", "autoMergeRequest": null},
+                        {"title": "P1PR2 enabled", "autoMergeRequest": {}},
+                        {"title": "P1PR3 enabled", "autoMergeRequest": {}},
+                        {"title": "P1PR4 - 2 / 5", "autoMergeRequest": null},
+                        {"title": "P1PR5 enabled", "autoMergeRequest": {}}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE2"}
+                }}}`,
+				`{"data": {"search": {
+                    "issueCount": 20,
+                    "nodes": [
+                        {"title": "P2PR1 enabled", "autoMergeRequest": {}},
+                        {"title": "P2PR2 - 3 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR3 - 4 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR4 - 5 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR5 - extra", "autoMergeRequest": null}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE3"}
+                }}}`,
+			},
+			expected: expected{
+				prCount:      5,
+				totalCount:   16,
+				isUpperBound: true,
+			},
+		},
+		{
+			name: "with search and auto-merge disabled, no more pages",
+			args: args{
+				filters: prShared.FilterOptions{
+					State:           "open",
+					AutoMergeStatus: &falseVar,
+					Search:          "one world in:title",
+				},
+				limit: 5,
+			},
+			queryType: "PullRequestSearch",
+			responses: []string{
+				`{"data": {"search": {
+                    "issueCount": 10,
+                    "nodes": [
+                        {"title": "P1PR1 - 1 / 5", "autoMergeRequest": null},
+                        {"title": "P1PR2 enabled", "autoMergeRequest": {}},
+                        {"title": "P1PR3 enabled", "autoMergeRequest": {}},
+                        {"title": "P1PR4 - 2 / 5", "autoMergeRequest": null},
+                        {"title": "P1PR5 enabled", "autoMergeRequest": {}}
+                    ],
+                    "pageInfo": {"hasNextPage": true, "endCursor": "PAGE2"}
+                }}}`,
+				`{"data": {"search": {
+                    "issueCount": 10,
+                    "nodes": [
+                        {"title": "P2PR1 enabled", "autoMergeRequest": {}},
+                        {"title": "P2PR2 - 3 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR3 - 4 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR4 - 5 / 5", "autoMergeRequest": null},
+                        {"title": "P2PR5 - extra", "autoMergeRequest": null}
+                    ],
+                    "pageInfo": {"hasNextPage": false}
+                }}}`,
+			},
+			expected: expected{
+				prCount:      5,
+				totalCount:   6,
+				isUpperBound: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			for _, response := range tt.responses {
+				reg.Register(
+					httpmock.GraphQL(fmt.Sprintf(`query %s\b`, tt.queryType)),
+					httpmock.StringResponse(response),
+				)
+			}
+			httpClient := &http.Client{Transport: reg}
+
+			res, err := listPullRequests(httpClient, ghrepo.New("OWNER", "REPO"), tt.args.filters, tt.args.limit)
+			if err != nil {
+				t.Errorf("listPullRequests() error = %v", err)
+				return
+			}
+			if len(res.PullRequests) != tt.expected.prCount {
+				t.Errorf("listPullRequests() returned %d PRs, want %d", len(res.PullRequests), tt.expected.prCount)
+			}
+			if res.TotalCount != tt.expected.totalCount {
+				t.Errorf("listPullRequests() returned total count %d, want %d", res.TotalCount, tt.expected.totalCount)
+			}
+			if res.TotalCountIsUpperBound != tt.expected.isUpperBound {
+				t.Errorf("listPullRequests() returned total count is upper bound %t, want %t", res.TotalCountIsUpperBound, tt.expected.isUpperBound)
 			}
 		})
 	}

--- a/pkg/cmd/pr/shared/display.go
+++ b/pkg/cmd/pr/shared/display.go
@@ -62,13 +62,17 @@ func ListNoResults(repoName string, itemName string, hasFilters bool) error {
 	return cmdutil.NewNoResultsError(fmt.Sprintf("no open %ss in %s", itemName, repoName))
 }
 
-func ListHeader(repoName string, itemName string, matchCount int, totalMatchCount int, hasFilters bool) string {
+func ListHeader(repoName string, itemName string, matchCount int, totalMatchCount int, totalIsUpperBound bool, hasFilters bool) string {
 	if hasFilters {
 		matchVerb := "match"
 		if totalMatchCount == 1 {
 			matchVerb = "matches"
 		}
-		return fmt.Sprintf("Showing %d of %s in %s that %s your search", matchCount, text.Pluralize(totalMatchCount, itemName), repoName, matchVerb)
+		total := text.Pluralize(totalMatchCount, itemName)
+		if totalIsUpperBound {
+			total = "up to " + total
+		}
+		return fmt.Sprintf("Showing %d of %s in %s that %s your search", matchCount, total, repoName, matchVerb)
 	}
 
 	return fmt.Sprintf("Showing %d of %s in %s", matchCount, text.Pluralize(totalMatchCount, fmt.Sprintf("open %s", itemName)), repoName)

--- a/pkg/cmd/pr/shared/display_test.go
+++ b/pkg/cmd/pr/shared/display_test.go
@@ -10,11 +10,12 @@ import (
 
 func Test_listHeader(t *testing.T) {
 	type args struct {
-		repoName        string
-		itemName        string
-		matchCount      int
-		totalMatchCount int
-		hasFilters      bool
+		repoName          string
+		itemName          string
+		matchCount        int
+		totalMatchCount   int
+		totalIsUpperBound bool
+		hasFilters        bool
 	}
 	tests := []struct {
 		name string
@@ -24,73 +25,91 @@ func Test_listHeader(t *testing.T) {
 		{
 			name: "one result",
 			args: args{
-				repoName:        "REPO",
-				itemName:        "genie",
-				matchCount:      1,
-				totalMatchCount: 23,
-				hasFilters:      false,
+				repoName:          "REPO",
+				itemName:          "genie",
+				matchCount:        1,
+				totalMatchCount:   23,
+				totalIsUpperBound: false,
+				hasFilters:        false,
 			},
 			want: "Showing 1 of 23 open genies in REPO",
 		},
 		{
 			name: "one result after filters",
 			args: args{
-				repoName:        "REPO",
-				itemName:        "tiny cup",
-				matchCount:      1,
-				totalMatchCount: 23,
-				hasFilters:      true,
+				repoName:          "REPO",
+				itemName:          "tiny cup",
+				matchCount:        1,
+				totalMatchCount:   23,
+				totalIsUpperBound: false,
+				hasFilters:        true,
 			},
 			want: "Showing 1 of 23 tiny cups in REPO that match your search",
 		},
 		{
 			name: "one result in total",
 			args: args{
-				repoName:        "REPO",
-				itemName:        "chip",
-				matchCount:      1,
-				totalMatchCount: 1,
-				hasFilters:      false,
+				repoName:          "REPO",
+				itemName:          "chip",
+				matchCount:        1,
+				totalMatchCount:   1,
+				totalIsUpperBound: false,
+				hasFilters:        false,
 			},
 			want: "Showing 1 of 1 open chip in REPO",
 		},
 		{
 			name: "one result in total after filters",
 			args: args{
-				repoName:        "REPO",
-				itemName:        "spicy noodle",
-				matchCount:      1,
-				totalMatchCount: 1,
-				hasFilters:      true,
+				repoName:          "REPO",
+				itemName:          "spicy noodle",
+				matchCount:        1,
+				totalMatchCount:   1,
+				totalIsUpperBound: false,
+				hasFilters:        true,
 			},
 			want: "Showing 1 of 1 spicy noodle in REPO that matches your search",
 		},
 		{
 			name: "multiple results",
 			args: args{
-				repoName:        "REPO",
-				itemName:        "plant",
-				matchCount:      4,
-				totalMatchCount: 23,
-				hasFilters:      false,
+				repoName:          "REPO",
+				itemName:          "plant",
+				matchCount:        4,
+				totalMatchCount:   23,
+				totalIsUpperBound: false,
+				hasFilters:        false,
 			},
 			want: "Showing 4 of 23 open plants in REPO",
 		},
 		{
 			name: "multiple results after filters",
 			args: args{
-				repoName:        "REPO",
-				itemName:        "boomerang",
-				matchCount:      4,
-				totalMatchCount: 23,
-				hasFilters:      true,
+				repoName:          "REPO",
+				itemName:          "boomerang",
+				matchCount:        4,
+				totalMatchCount:   23,
+				totalIsUpperBound: false,
+				hasFilters:        true,
 			},
 			want: "Showing 4 of 23 boomerangs in REPO that match your search",
+		},
+		{
+			name: "multiple results after filters with upper bound",
+			args: args{
+				repoName:          "REPO",
+				itemName:          "boomerang",
+				matchCount:        4,
+				totalMatchCount:   23,
+				totalIsUpperBound: true,
+				hasFilters:        true,
+			},
+			want: "Showing 4 of up to 23 boomerangs in REPO that match your search",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ListHeader(tt.args.repoName, tt.args.itemName, tt.args.matchCount, tt.args.totalMatchCount, tt.args.hasFilters); got != tt.want {
+			if got := ListHeader(tt.args.repoName, tt.args.itemName, tt.args.matchCount, tt.args.totalMatchCount, tt.args.totalIsUpperBound, tt.args.hasFilters); got != tt.want {
 				t.Errorf("listHeader() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -154,19 +154,20 @@ func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, par
 }
 
 type FilterOptions struct {
-	Assignee   string
-	Author     string
-	BaseBranch string
-	Draft      *bool
-	Entity     string
-	Fields     []string
-	HeadBranch string
-	Labels     []string
-	Mention    string
-	Milestone  string
-	Repo       string
-	Search     string
-	State      string
+	Assignee        string
+	Author          string
+	BaseBranch      string
+	Draft           *bool
+	AutoMergeStatus *bool
+	Entity          string
+	Fields          []string
+	HeadBranch      string
+	Labels          []string
+	Mention         string
+	Milestone       string
+	Repo            string
+	Search          string
+	State           string
 }
 
 func (opts *FilterOptions) IsDefault() bool {
@@ -195,6 +196,9 @@ func (opts *FilterOptions) IsDefault() bool {
 		return false
 	}
 	if opts.Search != "" {
+		return false
+	}
+	if opts.AutoMergeStatus != nil {
 		return false
 	}
 	return true


### PR DESCRIPTION
_This PR is part of a series for issue #7309, adding auto-merge status support to PR commands_

Add the ability to filter the `gh pr list` PRs on their auto-merge status.  There is no _server-side_ support for this, so entries are filtered when retrieving the list of PRs from GraphQL.

Because the list now is (further) filtered on the client side, the total number of PRs after filtering can't be known exactly until you fetch _all_ pages, which would be inefficient and wasteful, so instead the total is marked as an _upper bound_ and the text changes from *Showing MATCHED of TOTAL* to *Showing MATCHED of up to TOTAL* unless the last page was reached during local filtering.

```bash
$ gh pr list --auto-merge disabled

Showing 30 of 35 pull requests in cli/cli that match your search

...
```

There are two commits here; the first commit refactors the `pr/list/http.go` code to consolidate the GraphQL paged-result handling for the two `PullRequestList` and `PullRequestSearch` functions into a single `fetchPullRequests()` function that can handle GraphQL paging for either. This makes it then far easier to add client-side filtering to this single function rather that having to duplicate the effort.

