### PR TITLE
Introduce helpTopics type and reduce duplication across commands

### DIFF
--- a/pkg/cmd/root/help.go
+++ b/pkg/cmd/root/help.go
@@ -139,8 +139,8 @@ func rootHelpFunc(f *cmdutil.Factory, command *cobra.Command, args []string) {
 		if c := findCommand(command, "actions"); c != nil {
 			helpTopics = append(helpTopics, rpad(c.Name()+":", namePadding)+c.Short)
 		}
-		for topic, params := range HelpTopics {
-			helpTopics = append(helpTopics, rpad(topic+":", namePadding)+params["short"])
+		for _, helpTopic := range HelpTopics {
+			helpTopics = append(helpTopics, rpad(helpTopic.name+":", namePadding)+helpTopic.short)
 		}
 		sort.Strings(helpTopics)
 		helpEntries = append(helpEntries, helpEntry{"HELP TOPICS", strings.Join(helpTopics, "\n")})

--- a/pkg/cmd/root/help_reference.go
+++ b/pkg/cmd/root/help_reference.go
@@ -19,7 +19,11 @@ func referenceHelpFn(io *iostreams.IOStreams) func(*cobra.Command, []string) {
 			wrapWidth = io.TerminalWidth()
 		}
 
-		md, err := markdown.Render(cmd.Long,
+		// Assumes that we want to produce reference text for the entire tree of commands,
+		// starting from the root.
+		referenceText := stringifyCmdReference(cmd.Root())
+
+		md, err := markdown.Render(referenceText,
 			markdown.WithTheme(io.TerminalTheme()),
 			markdown.WithWrap(wrapWidth))
 		if err != nil {
@@ -38,7 +42,7 @@ func referenceHelpFn(io *iostreams.IOStreams) func(*cobra.Command, []string) {
 	}
 }
 
-func referenceLong(cmd *cobra.Command) string {
+func stringifyCmdReference(cmd *cobra.Command) string {
 	buf := bytes.NewBufferString("# gh reference\n\n")
 	for _, c := range cmd.Commands() {
 		if c.Hidden {

--- a/pkg/cmd/root/help_reference.go
+++ b/pkg/cmd/root/help_reference.go
@@ -11,7 +11,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func referenceHelpFn(io *iostreams.IOStreams) func(*cobra.Command, []string) {
+// longPager provides a pager over a commands Long message.
+// It is currently only used for the reference command
+func longPager(io *iostreams.IOStreams) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		wrapWidth := 0
 		if io.IsStdoutTTY() {
@@ -19,11 +21,7 @@ func referenceHelpFn(io *iostreams.IOStreams) func(*cobra.Command, []string) {
 			wrapWidth = io.TerminalWidth()
 		}
 
-		// Assumes that we want to produce reference text for the entire tree of commands,
-		// starting from the root.
-		referenceText := stringifyCmdReference(cmd.Root())
-
-		md, err := markdown.Render(referenceText,
+		md, err := markdown.Render(cmd.Long,
 			markdown.WithTheme(io.TerminalTheme()),
 			markdown.WithWrap(wrapWidth))
 		if err != nil {
@@ -42,7 +40,7 @@ func referenceHelpFn(io *iostreams.IOStreams) func(*cobra.Command, []string) {
 	}
 }
 
-func stringifyCmdReference(cmd *cobra.Command) string {
+func stringifyReference(cmd *cobra.Command) string {
 	buf := bytes.NewBufferString("# gh reference\n\n")
 	for _, c := range cmd.Commands() {
 		if c.Hidden {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -11,11 +11,10 @@ import (
 )
 
 type helpTopic struct {
-	name       string
-	short      string
-	long       string
-	example    string
-	helpFuncFn func(io *iostreams.IOStreams) func(*cobra.Command, []string)
+	name    string
+	short   string
+	long    string
+	example string
 }
 
 var HelpTopics = []helpTopic{
@@ -102,9 +101,8 @@ var HelpTopics = []helpTopic{
 		`),
 	},
 	{
-		name:       "reference",
-		short:      "A comprehensive reference of all gh commands",
-		helpFuncFn: referenceHelpFn,
+		name:  "reference",
+		short: "A comprehensive reference of all gh commands",
 	},
 	{
 		name:  "formatting",
@@ -293,17 +291,9 @@ func NewCmdHelpTopic(ios *iostreams.IOStreams, ht helpTopic) *cobra.Command {
 		return helpTopicUsageFunc(ios.ErrOut, c)
 	})
 
-	helpFunc := func() func(*cobra.Command, []string) {
-		if ht.helpFuncFn != nil {
-			return ht.helpFuncFn(ios)
-		}
-
-		return func(c *cobra.Command, _ []string) {
-			helpTopicHelpFunc(ios.Out, c)
-		}
-	}()
-
-	cmd.SetHelpFunc(helpFunc)
+	cmd.SetHelpFunc(func(c *cobra.Command, _ []string) {
+		helpTopicHelpFunc(ios.Out, c)
+	})
 
 	return cmd
 }

--- a/pkg/cmd/root/help_topic_test.go
+++ b/pkg/cmd/root/help_topic_test.go
@@ -4,76 +4,83 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestNewHelpTopic(t *testing.T) {
+func findHelpTopic(t *testing.T, name string) helpTopic {
+	t.Helper()
+
+	for _, ht := range HelpTopics {
+		if ht.name == name {
+			return ht
+		}
+	}
+
+	require.FailNowf(t, "", "expected to find a topic with name: %q in topics: %v", name, HelpTopics)
+	return helpTopic{}
+}
+
+func TestEnvironmentHelp(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
-		name     string
-		topic    string
-		args     []string
-		flags    []string
-		wantsErr bool
+		name      string
+		topic     string
+		args      []string
+		flags     []string
+		assertion require.ErrorAssertionFunc
 	}{
 		{
-			name:     "valid topic",
-			topic:    "environment",
-			args:     []string{},
-			flags:    []string{},
-			wantsErr: false,
+			name:      "valid topic",
+			topic:     "environment",
+			args:      []string{},
+			flags:     []string{},
+			assertion: require.NoError,
 		},
 		{
-			name:     "invalid topic",
-			topic:    "invalid",
-			args:     []string{},
-			flags:    []string{},
-			wantsErr: false,
+			name:      "more than zero args",
+			topic:     "environment",
+			args:      []string{"invalid"},
+			flags:     []string{},
+			assertion: require.NoError,
 		},
 		{
-			name:     "more than zero args",
-			topic:    "environment",
-			args:     []string{"invalid"},
-			flags:    []string{},
-			wantsErr: false,
+			name:      "more than zero flags",
+			topic:     "environment",
+			args:      []string{},
+			flags:     []string{"--invalid"},
+			assertion: require.Error,
 		},
 		{
-			name:     "more than zero flags",
-			topic:    "environment",
-			args:     []string{},
-			flags:    []string{"--invalid"},
-			wantsErr: true,
+			name:      "help arg",
+			topic:     "environment",
+			args:      []string{"help"},
+			flags:     []string{},
+			assertion: require.NoError,
 		},
 		{
-			name:     "help arg",
-			topic:    "environment",
-			args:     []string{"help"},
-			flags:    []string{},
-			wantsErr: false,
-		},
-		{
-			name:     "help flag",
-			topic:    "environment",
-			args:     []string{},
-			flags:    []string{"--help"},
-			wantsErr: false,
+			name:      "help flag",
+			topic:     "environment",
+			args:      []string{},
+			flags:     []string{"--help"},
+			assertion: require.NoError,
 		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ios, _, _, stderr := iostreams.Test()
 
-			cmd := NewHelpTopic(ios, tt.topic)
+			cmd := NewCmdHelpTopic(ios, findHelpTopic(t, tt.topic))
 			cmd.SetArgs(append(tt.args, tt.flags...))
 			cmd.SetOut(stderr)
 			cmd.SetErr(stderr)
 
 			_, err := cmd.ExecuteC()
-			if tt.wantsErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
+			tt.assertion(t, err)
 		})
 	}
 }

--- a/pkg/cmd/root/help_topic_test.go
+++ b/pkg/cmd/root/help_topic_test.go
@@ -7,63 +7,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func findHelpTopic(t *testing.T, name string) helpTopic {
-	t.Helper()
-
-	for _, ht := range HelpTopics {
-		if ht.name == name {
-			return ht
-		}
-	}
-
-	require.FailNowf(t, "", "expected to find a topic with name: %q in topics: %v", name, HelpTopics)
-	return helpTopic{}
-}
-
-func TestEnvironmentHelp(t *testing.T) {
+func TestCmdHelpTopic(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		topic     string
-		args      []string
-		flags     []string
-		assertion require.ErrorAssertionFunc
+		name                string
+		topic               helpTopic
+		args                []string
+		flags               []string
+		errorAssertion      require.ErrorAssertionFunc
+		expectedAnnotations map[string]string
 	}{
 		{
-			name:      "valid topic",
-			topic:     "environment",
-			args:      []string{},
-			flags:     []string{},
-			assertion: require.NoError,
+			name:           "when there are no args or flags, prints the long message to stdout",
+			topic:          helpTopic{name: "test-topic", long: "test-topic-long"},
+			args:           []string{},
+			flags:          []string{},
+			errorAssertion: require.NoError,
 		},
 		{
-			name:      "more than zero args",
-			topic:     "environment",
-			args:      []string{"invalid"},
-			flags:     []string{},
-			assertion: require.NoError,
+			name:           "when an arg is provided, it is ignored and help is printed",
+			topic:          helpTopic{name: "test-topic"},
+			args:           []string{"anything"},
+			flags:          []string{},
+			errorAssertion: require.NoError,
 		},
 		{
-			name:      "more than zero flags",
-			topic:     "environment",
-			args:      []string{},
-			flags:     []string{"--invalid"},
-			assertion: require.Error,
+			name:           "when a flag is provided, returns an error",
+			topic:          helpTopic{name: "test-topic"},
+			args:           []string{},
+			flags:          []string{"--anything"},
+			errorAssertion: require.Error,
 		},
 		{
-			name:      "help arg",
-			topic:     "environment",
-			args:      []string{"help"},
-			flags:     []string{},
-			assertion: require.NoError,
+			name:           "when there is an example, include it in the stdout",
+			topic:          helpTopic{name: "test-topic", example: "test-topic-example"},
+			args:           []string{},
+			flags:          []string{},
+			errorAssertion: require.NoError,
 		},
 		{
-			name:      "help flag",
-			topic:     "environment",
-			args:      []string{},
-			flags:     []string{"--help"},
-			assertion: require.NoError,
+			name:           "sets important markdown annotations on the command",
+			topic:          helpTopic{name: "test-topic"},
+			args:           []string{},
+			flags:          []string{},
+			errorAssertion: require.NoError,
+			expectedAnnotations: map[string]string{
+				"markdown:generate": "true",
+				"markdown:basename": "gh_help_test-topic",
+			},
 		},
 	}
 
@@ -72,15 +64,25 @@ func TestEnvironmentHelp(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ios, _, _, stderr := iostreams.Test()
+			ios, _, stdout, _ := iostreams.Test()
 
-			cmd := NewCmdHelpTopic(ios, findHelpTopic(t, tt.topic))
+			cmd := NewCmdHelpTopic(ios, tt.topic)
 			cmd.SetArgs(append(tt.args, tt.flags...))
-			cmd.SetOut(stderr)
-			cmd.SetErr(stderr)
 
 			_, err := cmd.ExecuteC()
-			tt.assertion(t, err)
+			tt.errorAssertion(t, err)
+
+			if tt.topic.long != "" {
+				require.Contains(t, stdout.String(), tt.topic.long)
+			}
+
+			if tt.topic.example != "" {
+				require.Contains(t, stdout.String(), tt.topic.example)
+			}
+
+			if len(tt.expectedAnnotations) > 0 {
+				require.Equal(t, cmd.Annotations, tt.expectedAnnotations)
+			}
 		})
 	}
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -125,18 +125,12 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(labelCmd.NewCmdLabel(&repoResolvingCmdFactory))
 
 	// Help topics
-	cmd.AddCommand(NewHelpTopic(f.IOStreams, "environment"))
-	cmd.AddCommand(NewHelpTopic(f.IOStreams, "formatting"))
-	cmd.AddCommand(NewHelpTopic(f.IOStreams, "mintty"))
-	cmd.AddCommand(NewHelpTopic(f.IOStreams, "exit-codes"))
-	referenceCmd := NewHelpTopic(f.IOStreams, "reference")
-	referenceCmd.SetHelpFunc(referenceHelpFn(f.IOStreams))
-	cmd.AddCommand(referenceCmd)
+	for _, ht := range HelpTopics {
+		cmd.AddCommand(NewCmdHelpTopic(f.IOStreams, ht))
+	}
 
 	cmdutil.DisableAuthCheck(cmd)
 
-	// this needs to appear last:
-	referenceCmd.Long = referenceLong(cmd)
 	return cmd
 }
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -125,12 +125,26 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd.AddCommand(labelCmd.NewCmdLabel(&repoResolvingCmdFactory))
 
 	// Help topics
+	var referenceCmd *cobra.Command
 	for _, ht := range HelpTopics {
-		cmd.AddCommand(NewCmdHelpTopic(f.IOStreams, ht))
+		helpTopicCmd := NewCmdHelpTopic(f.IOStreams, ht)
+		cmd.AddCommand(helpTopicCmd)
+
+		// See bottom of the function for why we explicitly care about the reference cmd
+		if ht.name == "reference" {
+			referenceCmd = helpTopicCmd
+		}
 	}
 
 	cmdutil.DisableAuthCheck(cmd)
 
+	// The reference command produces paged output that displays information on every other command.
+	// Therefore, we explicitly set the Long text and HelpFunc here after all other commands are registered.
+	// We experimented with producing the paged output dynamically when the HelpFunc is called but since
+	// doc generation makes use of the Long text, it is simpler to just be explicit here that this command
+	// is special.
+	referenceCmd.Long = stringifyReference(cmd)
+	referenceCmd.SetHelpFunc(longPager(f.IOStreams))
 	return cmd
 }
 


### PR DESCRIPTION
## Description

As I was investigating #5073 I noticed some temporal coupling between commands. Specifically, the `reference` help topic (introduced in #2223) has to have its `long` description [set after every other command is added to the root](https://github.com/cli/cli/blob/b01c27aba251c25353b570142d998cfa0ba2c00c/pkg/cmd/root/root.go#L138-L139). This is required because it needs to stringify data from all the commands to serve as the reference.

This is probably a **very minor** maintenance burden in practice. That said, I did have to go through the project history to understand the comment `"this needs to appear last"` because it didn't explain why.

Since I was looking at this code, and am in exploratory mode, it seemed like something I could try to resolve and get feedback on. Think of this more as a means for me to learn, and to start some conversations, rather than because I think this is a real pressing issue to fix!

There is no associated issue to fix but I can create one if that is useful.

## Update

I've updated the title and contents of this PR based on [this thread](https://github.com/cli/cli/pull/7414#discussion_r1187513378) highlighting some issues around the `Long` text being used for documentation.

This PR is now a general reworking to provide some types and comments that I would have found useful initially.