### PR TITLE
Differentiate between non-git repository and other errors (#5603)

### DIFF
--- a/git/client_test.go
+++ b/git/client_test.go
@@ -784,7 +784,7 @@ func TestClientGitDir(t *testing.T) {
 				GitPath:        "path/to/git",
 				commandContext: cmdCtx,
 			}
-			dir, err := client.GitDir(context.Background())
+			dir, err := client.GitDir(context.Background(), false)
 			assert.Equal(t, tt.wantCmdArgs, strings.Join(cmd.Args[3:], " "))
 			if tt.wantErrorMsg == "" {
 				assert.NoError(t, err)

--- a/git/errors.go
+++ b/git/errors.go
@@ -8,6 +8,9 @@ import (
 // ErrNotOnAnyBranch indicates that the user is in detached HEAD state.
 var ErrNotOnAnyBranch = errors.New("git: not on any branch")
 
+// ErrNotAGitRepository indicates that the user is not inside a git repository
+var ErrNotAGitRepository = errors.New("fatal: not a git repository")
+
 type NotInstalled struct {
 	message string
 	err     error

--- a/pkg/cmd/repo/setdefault/setdefault.go
+++ b/pkg/cmd/repo/setdefault/setdefault.go
@@ -90,10 +90,12 @@ func NewCmdSetDefault(f *cmdutil.Factory, runF func(*SetDefaultOptions) error) *
 				return cmdutil.FlagErrorf("repository required when not running interactively")
 			}
 
-			if isLocal, err := opts.GitClient.IsLocalGitRepo(cmd.Context()); err != nil {
-				return err
-			} else if !isLocal {
+			isLocal, err := opts.GitClient.IsLocalGitRepo(cmd.Context())
+			if !isLocal {
 				return errors.New("must be run from inside a git repository")
+			}
+			if err != nil {
+				return err
 			}
 
 			if runF != nil {

--- a/pkg/cmd/repo/setdefault/setdefault_test.go
+++ b/pkg/cmd/repo/setdefault/setdefault_test.go
@@ -68,7 +68,7 @@ func TestNewCmdSetDefault(t *testing.T) {
 		{
 			name: "run from non-git directory",
 			gitStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git rev-parse --git-dir`, 128, "")
+				cs.Register(`git rev-parse --git-dir`, 0, "")
 			},
 			input:   "",
 			wantErr: true,


### PR DESCRIPTION
Fixes #5603 (hopefully)

As commented, if the error says "not a git repository" we wrap it in a own error type. However, if the error is anything else, we just forward to stderr, using the user's own locale.

Some things to clarify:

- Although commented in the code, I have used the `LANGUAGE` env variable, rather than `LANG`. This is because the `LANGUAGE` variable has the preference, so if an user has explicitly set up it, we wouldn't be able to ignore the user's locale. See [this](https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html) for more information.
- Using the "C" POSIX locale since it's the correct one to use to disable all localization. It should be present in all systems (for example, the en_US locale is not present in my current system). See [this](https://www.gnu.org/software/gettext/manual/html_node/Locale-Names.html) for more information.
- About tests: If we are running `gh` out of a git repository, we are using a custom `gitErr`, and so the exit code is not `128` anymore. Don't know if that's the correct way of doing so, but again, tell me and I will try to fix it. Also, I don't think any more tests are needed since we are not specifically handling the "unsafe repository" error, right?

Also, Since I don't get to work with Golang on a daily basis, my code may not be very idiomatic. Please, let me know if something looks wrong and needs to be changed.