### PR TITLE
Allow `gh repo set-default --view` without repo argument

### DIFF
--- a/pkg/cmd/repo/setdefault/setdefault.go
+++ b/pkg/cmd/repo/setdefault/setdefault.go
@@ -86,7 +86,7 @@ func NewCmdSetDefault(f *cmdutil.Factory, runF func(*SetDefaultOptions) error) *
 				}
 			}
 
-			if !opts.IO.CanPrompt() && opts.Repo == nil {
+			if !opts.ViewMode && !opts.IO.CanPrompt() && opts.Repo == nil {
 				return cmdutil.FlagErrorf("repository required when not running interactively")
 			}
 
@@ -120,10 +120,9 @@ func setDefaultRun(opts *SetDefaultOptions) error {
 
 	if opts.ViewMode {
 		if currentDefaultRepo == nil {
-			fmt.Fprintln(opts.IO.Out, "no default repository has been set; use `gh repo set-default` to select one")
-		} else {
-			fmt.Fprintln(opts.IO.Out, displayRemoteRepoName(currentDefaultRepo))
+			return errors.New("no default repository has been set; use `gh repo set-default` to select one")
 		}
+		fmt.Fprintln(opts.IO.Out, displayRemoteRepoName(currentDefaultRepo))
 		return nil
 	}
 

--- a/pkg/cmd/repo/setdefault/setdefault.go
+++ b/pkg/cmd/repo/setdefault/setdefault.go
@@ -119,10 +119,11 @@ func setDefaultRun(opts *SetDefaultOptions) error {
 	currentDefaultRepo, _ := remotes.ResolvedRemote()
 
 	if opts.ViewMode {
-		if currentDefaultRepo == nil {
-			return errors.New("no default repository has been set; use `gh repo set-default` to select one")
+		if currentDefaultRepo != nil {
+			fmt.Fprintln(opts.IO.Out, displayRemoteRepoName(currentDefaultRepo))
+		} else if opts.IO.IsStdoutTTY() {
+			fmt.Fprintln(opts.IO.Out, "no default repository has been set; use `gh repo set-default` to select one")
 		}
-		fmt.Fprintln(opts.IO.Out, displayRemoteRepoName(currentDefaultRepo))
 		return nil
 	}
 

--- a/pkg/cmd/repo/setdefault/setdefault_test.go
+++ b/pkg/cmd/repo/setdefault/setdefault_test.go
@@ -175,7 +175,7 @@ func TestDefaultRun(t *testing.T) {
 					Repo:   repo1,
 				},
 			},
-			wantStdout: "no default repository has been set; use `gh repo set-default` to select one",
+			wantStdout: "no default repository has been set; use `gh repo set-default` to select one\n",
 		},
 		{
 			name: "view mode no current default",

--- a/pkg/cmd/repo/setdefault/setdefault_test.go
+++ b/pkg/cmd/repo/setdefault/setdefault_test.go
@@ -174,7 +174,8 @@ func TestDefaultRun(t *testing.T) {
 					Repo:   repo1,
 				},
 			},
-			wantStdout: "no default repository has been set; use `gh repo set-default` to select one\n",
+			wantErr: true,
+			errMsg:  "no default repository has been set; use `gh repo set-default` to select one",
 		},
 		{
 			name: "view mode with base resolved current default",

--- a/pkg/cmd/repo/setdefault/setdefault_test.go
+++ b/pkg/cmd/repo/setdefault/setdefault_test.go
@@ -166,6 +166,18 @@ func TestDefaultRun(t *testing.T) {
 			wantStdout: "no default repository has been set\n",
 		},
 		{
+			name: "tty view mode no current default",
+			tty:  true,
+			opts: SetDefaultOptions{ViewMode: true},
+			remotes: []*context.Remote{
+				{
+					Remote: &git.Remote{Name: "origin"},
+					Repo:   repo1,
+				},
+			},
+			wantStdout: "no default repository has been set; use `gh repo set-default` to select one",
+		},
+		{
 			name: "view mode no current default",
 			opts: SetDefaultOptions{ViewMode: true},
 			remotes: []*context.Remote{
@@ -174,8 +186,6 @@ func TestDefaultRun(t *testing.T) {
 					Repo:   repo1,
 				},
 			},
-			wantErr: true,
-			errMsg:  "no default repository has been set; use `gh repo set-default` to select one",
 		},
 		{
 			name: "view mode with base resolved current default",


### PR DESCRIPTION
This allows `gh repo set-default --view` to be called without a repository. On top of that, I updated the handling of this flag such that it returns an error if a default repository is not set which makes it easy to detect a problem from a script.

Fixes #7442