### PR TITLE
Do not fall back to legacy template if template selector returns nil

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -318,8 +318,6 @@ func createRun(opts *CreateOptions) (err error) {
 
 			if template != nil {
 				templateContent = string(template.Body())
-			} else {
-				templateContent = string(tpl.LegacyBody())
 			}
 		}
 


### PR DESCRIPTION
`template, err = tpl.Choose()` properly handles legacy templates so this extra handling is no longer necessary and is actually causing a bug when choosing to create a blank pull request. 

Fixes https://github.com/cli/cli/issues/7419
