### PR TITLE
Mention setting GH_ENTERPRISE_TOKEN when GH_HOST is set

### DIFF
--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -50,7 +50,8 @@ var HelpTopics = []helpTopic{
 			token for API requests to GitHub Enterprise. When setting this, also set GH_HOST.
 
 			GH_HOST: specify the GitHub hostname for commands that would otherwise assume the
-			"github.com" host when not in a context of an existing repository.
+			"github.com" host when not in a context of an existing repository. When setting this, 
+			also set GH_ENTERPRISE_TOKEN.
 
 			GH_REPO: specify the GitHub repository in the "[HOST/]OWNER/REPO" format for commands
 			that otherwise operate on a local repository.


### PR DESCRIPTION
As an avid github.com Actions users, I spent several hours debugging 401 authentication failures that targeted a Github Enterprise Server (GHES) appliance. 

I 100% saw the note that IF I was setting `GH_ENTERPRISE_TOKEN` then I should set `GH_HOST`. When I saw the auth failure for `api.github.com` I immediately knew I needed to set `GH_HOST`.

I had no idea that `GH_TOKEN` and `GITHUB_TOKEN` [are disregarded](https://github.com/cli/go-gh/blob/ccb69a6ec9775c1d6efe8f0ab4ca404439e543a7/pkg/auth/auth.go#L64-L70) if `GH_HOST` [is not equal to either](https://github.com/cli/go-gh/blob/ccb69a6ec9775c1d6efe8f0ab4ca404439e543a7/pkg/auth/auth.go#L151-L153) `github` or `localhost`

Note: I don't know how to change the public docs, they need amending as well.