### PR TITLE
Clarify docs regarding what is listed when running gh workflow list

### DIFF
--- a/pkg/cmd/actions/actions.go
+++ b/pkg/cmd/actions/actions.go
@@ -42,7 +42,7 @@ func actionsExplainer(cs *iostreams.ColorScheme) string {
 			To see more help, run 'gh help run <subcommand>'
 
 			%s  
-			gh workflow list:     List all the workflow files in your repository  
+			gh workflow list:     List workflow files in your repository
 			gh workflow view:     View details for a workflow file  
 			gh workflow enable:   Enable a workflow file  
 			gh workflow disable:  Disable a workflow file  

--- a/pkg/cmd/workflow/list/list.go
+++ b/pkg/cmd/workflow/list/list.go
@@ -58,7 +58,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", defaultLimit, "Maximum number of workflows to fetch")
-	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "Show all workflows, including disabled workflows")
+	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "Also show disabled workflows")
 
 	return cmd
 }


### PR DESCRIPTION
Prevent confusion that `--all` actually list all workflows, `--limit` is what actually needs to be adjusted to list all workflows, if there are many.