### PR TITLE
Updated to sanitize asset filename prior to uploading. Fixes #7024

### DIFF
--- a/pkg/cmd/release/upload/upload_test.go
+++ b/pkg/cmd/release/upload/upload_test.go
@@ -1,0 +1,52 @@
+package upload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SanitizeFileName(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "foo",
+			expected: "foo",
+		},
+		{
+			name:     "foo bar",
+			expected: "foo.bar",
+		},
+		{
+			name:     ".foo",
+			expected: "default.foo",
+		},
+		{
+			name:     "Foo bar",
+			expected: "Foo.bar",
+		},
+		{
+			name:     "Hello, दुनिया",
+			expected: "default.Hello",
+		},
+		{
+			name:     "this+has+plusses.jpg",
+			expected: "this+has+plusses.jpg",
+		},
+		{
+			name:     "this@has@at@signs.jpg",
+			expected: "this@has@at@signs.jpg",
+		},
+		{
+			name:     "façade.exposé",
+			expected: "facade.expose",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, sanitizeFileName(tt.name))
+		})
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #7024 

<img width="926" alt="image" src="https://user-images.githubusercontent.com/6889008/226353598-04855bfc-4be2-4c29-b931-87b57810edce.png">
