### PR TITLE
Speed up gh start up time

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -18,6 +18,10 @@ func init() {
 		}
 	}
 
+	// Signal the tcell library to skip its expensive `init` block. This saves 30-40ms in startup
+	// time for the gh process. The downside is that some Unicode glyphs from user-generated
+	// content might cause mis-alignment in tcell-enabled views.
+	//
 	// https://github.com/gdamore/tcell/commit/2f889d79bd61b1fd2f43372529975a65b792a7ae
 	_ = os.Setenv("TCELL_MINIMIZE", "1")
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"os"
 	"runtime/debug"
 )
 
@@ -16,4 +17,7 @@ func init() {
 			Version = info.Main.Version
 		}
 	}
+
+	// https://github.com/gdamore/tcell/commit/2f889d79bd61b1fd2f43372529975a65b792a7ae
+	_ = os.Setenv("TCELL_MINIMIZE", "1")
 }


### PR DESCRIPTION
The tcell library used in `gh ext browse` has an `init()` block where it performs some very expensive indexing that takes 30-40 ms on my machine. This results in fixed overhead for every gh invocation, even for commands that don't use tcell at all.

```
~/p/gh-cli %  GODEBUG=inittrace=1 bin/gh version 1>/dev/null 2>&1 | awk '{print $5, $2}' | sort -rn | head -10
34 github.com/gdamore/tcell/v2
2.6 github.com/yuin/goldmark/util
0.86 github.com/alecthomas/chroma/styles
0.83 github.com/microcosm-cc/bluemonday/css
0.54 github.com/microcosm-cc/bluemonday
0.46 github.com/yuin/goldmark/extension
0.36 github.com/gorilla/css/scanner
0.34 github.com/AlecAivazis/survey/v2/terminal
0.32 unicode
0.27 gopkg.in/yaml%2ev3
```

This sets an environment variable that instructs tcell to avoid doing that. This works because the `internal/build` module will be initialized before the `github.com/gdamore/tcell/v2` module.

After:
```
~/p/gh-cli %  GODEBUG=inittrace=1 bin/gh version 1>/dev/null 2>&1 | awk '{print $5, $2}' | sort -rn | head -2
1.3 github.com/yuin/goldmark/util
0.42 github.com/alecthomas/chroma/styles
```