### PR TITLE
Add `gh cs view` command

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -200,6 +200,7 @@ type Codespace struct {
 	RetentionExpiresAt             string              `json:"retention_expires_at"`
 	RecentFolders                  []string            `json:"recent_folders"`
 	BillableOwner                  User                `json:"billable_owner"`
+	EnvironmentId                  string              `json:"environment_id"`
 }
 
 type CodespaceGitStatus struct {
@@ -272,6 +273,8 @@ var ViewCodespaceFields = []string{
 	"retentionPeriodDays",
 	"retentionExpiresAt",
 	"recentFolders",
+	"vscsTarget",
+	"environmentId",
 }
 
 func (c *Codespace) ExportData(fields []string) map[string]interface{} {

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -192,6 +192,13 @@ type Codespace struct {
 	PendingOperationDisabledReason string              `json:"pending_operation_disabled_reason"`
 	IdleTimeoutNotice              string              `json:"idle_timeout_notice"`
 	WebURL                         string              `json:"web_url"`
+	DevContainerPath               string              `json:"devcontainer_path"`
+	Prebuild                       bool                `json:"prebuild"`
+	Location                       string              `json:"location"`
+	IdleTimeoutMinutes             int                 `json:"idle_timeout_minutes"`
+	RetentionExpiresAt             string              `json:"retention_expires_at"`
+	RecentFolders                  []string            `json:"recent_folders"`
+	BillableOwner                  User                `json:"billable_owner"`
 }
 
 type CodespaceGitStatus struct {
@@ -230,8 +237,8 @@ type CodespaceConnection struct {
 	HostPublicKeys []string `json:"hostPublicKeys"`
 }
 
-// CodespaceFields is the list of exportable fields for a codespace.
-var CodespaceFields = []string{
+// ListCodespaceFields is the list of exportable fields for a codespace when using the `gh cs list` command.
+var ListCodespaceFields = []string{
 	"displayName",
 	"name",
 	"owner",
@@ -242,6 +249,27 @@ var CodespaceFields = []string{
 	"lastUsedAt",
 	"machineName",
 	"vscsTarget",
+}
+
+// ViewCodespaceFields is the list of exportable fields for a codespace when using the `gh cs view` command.
+var ViewCodespaceFields = []string{
+	"name",
+	"displayName",
+	"state",
+	"owner",
+	"billableOwner",
+	"location",
+	"repository",
+	"gitStatus",
+	"devcontainerPath",
+	"machineName",
+	"machineDisplayName",
+	"prebuild",
+	"createdAt",
+	"lastUsedAt",
+	"idleTimeoutMinutes",
+	"retentionExpiresAt",
+	"recentFolders",
 }
 
 func (c *Codespace) ExportData(fields []string) map[string]interface{} {
@@ -256,11 +284,15 @@ func (c *Codespace) ExportData(fields []string) map[string]interface{} {
 			data[f] = c.Repository.FullName
 		case "machineName":
 			data[f] = c.Machine.Name
+		case "machineDisplayName":
+			data[f] = c.Machine.DisplayName
 		case "gitStatus":
 			data[f] = map[string]interface{}{
 				"ref":                   c.GitStatus.Ref,
 				"hasUnpushedChanges":    c.GitStatus.HasUnpushedChanges,
 				"hasUncommittedChanges": c.GitStatus.HasUncommittedChanges,
+				"ahead":                 c.GitStatus.Ahead,
+				"behind":                c.GitStatus.Behind,
 			}
 		case "vscsTarget":
 			if c.VSCSTarget != "" && c.VSCSTarget != VSCSTargetProduction {

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -269,6 +269,7 @@ var ViewCodespaceFields = []string{
 	"createdAt",
 	"lastUsedAt",
 	"idleTimeoutMinutes",
+	"retentionPeriodDays",
 	"retentionExpiresAt",
 	"recentFolders",
 }
@@ -287,6 +288,8 @@ func (c *Codespace) ExportData(fields []string) map[string]interface{} {
 			data[f] = c.Machine.Name
 		case "machineDisplayName":
 			data[f] = c.Machine.DisplayName
+		case "retentionPeriodDays":
+			data[f] = c.RetentionPeriodMinutes / 1440
 		case "gitStatus":
 			data[f] = map[string]interface{}{
 				"ref":                   c.GitStatus.Ref,

--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -196,6 +196,7 @@ type Codespace struct {
 	Prebuild                       bool                `json:"prebuild"`
 	Location                       string              `json:"location"`
 	IdleTimeoutMinutes             int                 `json:"idle_timeout_minutes"`
+	RetentionPeriodMinutes         int                 `json:"retention_period_minutes"`
 	RetentionExpiresAt             string              `json:"retention_expires_at"`
 	RecentFolders                  []string            `json:"recent_folders"`
 	BillableOwner                  User                `json:"billable_owner"`

--- a/pkg/cmd/codespace/list.go
+++ b/pkg/cmd/codespace/list.go
@@ -70,7 +70,7 @@ func newListCmd(app *App) *cobra.Command {
 
 	listCmd.Flags().StringVarP(&opts.orgName, "org", "o", "", "The `login` handle of the organization to list codespaces for (admin-only)")
 	listCmd.Flags().StringVarP(&opts.userName, "user", "u", "", "The `username` to list codespaces for (used with --org)")
-	cmdutil.AddJSONFlags(listCmd, &exporter, api.CodespaceFields)
+	cmdutil.AddJSONFlags(listCmd, &exporter, api.ListCodespaceFields)
 
 	listCmd.Flags().BoolVarP(&opts.useWeb, "web", "w", false, "List codespaces in the web browser, cannot be used with --user or --org")
 

--- a/pkg/cmd/codespace/root.go
+++ b/pkg/cmd/codespace/root.go
@@ -16,6 +16,7 @@ func NewRootCmd(app *App) *cobra.Command {
 	root.AddCommand(newDeleteCmd(app))
 	root.AddCommand(newJupyterCmd(app))
 	root.AddCommand(newListCmd(app))
+	root.AddCommand(newViewCmd(app))
 	root.AddCommand(newLogsCmd(app))
 	root.AddCommand(newPortsCmd(app))
 	root.AddCommand(newSSHCmd(app))

--- a/pkg/cmd/codespace/view.go
+++ b/pkg/cmd/codespace/view.go
@@ -19,8 +19,6 @@ const (
 type viewOptions struct {
 	selector *CodespaceSelector
 	exporter cmdutil.Exporter
-	orgName  string
-	userName string
 }
 
 func newViewCmd(app *App) *cobra.Command {

--- a/pkg/cmd/codespace/view.go
+++ b/pkg/cmd/codespace/view.go
@@ -1,0 +1,99 @@
+package codespace
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/utils"
+	"github.com/spf13/cobra"
+)
+
+type viewOptions struct {
+	selector *CodespaceSelector
+}
+
+func newViewCmd(app *App) *cobra.Command {
+	opts := &viewOptions{}
+	var exporter cmdutil.Exporter
+
+	viewCmd := &cobra.Command{
+		Use:   "view",
+		Short: "View details about a codespace",
+		Args:  noArgsConstraint,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return app.ViewCodespace(cmd.Context(), opts, exporter)
+		},
+	}
+	opts.selector = AddCodespaceSelector(viewCmd, app.apiClient)
+	cmdutil.AddJSONFlags(viewCmd, &exporter, api.ViewCodespaceFields)
+
+	return viewCmd
+}
+
+func (a *App) ViewCodespace(ctx context.Context, opts *viewOptions, exporter cmdutil.Exporter) error {
+	selectedCodespace, err := opts.selector.Select(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := a.io.StartPager(); err != nil {
+		a.errLogger.Printf("error starting pager: %v", err)
+	}
+	defer a.io.StopPager()
+
+	if exporter != nil {
+		return exporter.Write(a.io, selectedCodespace)
+	}
+
+	//nolint:staticcheck // SA1019: utils.NewTablePrinter is deprecated: use internal/tableprinter
+	tp := utils.NewTablePrinter(a.io)
+	c := codespace{selectedCodespace}
+	formattedName := formatNameForVSCSTarget(c.Name, c.VSCSTarget)
+
+	// Create an array of fields to display in the table with their values
+	fields := []struct {
+		name  string
+		value string
+	}{
+		{"Name", formattedName},
+		{"Display Name", c.DisplayName},
+		{"State", c.State},
+		{"Machine Name", c.Machine.Name},
+		{"Machine Display Name", c.Machine.DisplayName},
+		{"Prebuild", strconv.FormatBool(c.Prebuild)},
+		{"Owner", c.Owner.Login},
+		{"BillableOwner", c.BillableOwner.Login},
+		{"Location", c.Location},
+		{"Repository", c.Repository.FullName},
+		{"Branch", c.GitStatus.Ref},
+		{"Devcontainer Path", c.DevContainerPath},
+		{"Commits Ahead", strconv.Itoa(c.GitStatus.Ahead)},
+		{"Commits Behind", strconv.Itoa(c.GitStatus.Behind)},
+		{"Has Uncommitted Changes", strconv.FormatBool(c.GitStatus.HasUncommittedChanges)},
+		{"Has Unpushed Changes", strconv.FormatBool(c.GitStatus.HasUnpushedChanges)},
+		{"Created At", c.CreatedAt},
+		{"Last Used At", c.LastUsedAt},
+		{"Idle Timeout Minutes", strconv.Itoa(c.IdleTimeoutMinutes)},
+		{"Retention Expires At", c.RetentionExpiresAt},
+		{"Recent Folders", strings.Join(c.RecentFolders, ", ")},
+	}
+
+	for _, field := range fields {
+		// Only display the field if it has a value.
+		if field.value != "" {
+			tp.AddField(field.name, nil, nil)
+			tp.AddField(field.value, nil, nil)
+			tp.EndRow()
+		}
+	}
+
+	err = tp.Render()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/codespace/view.go
+++ b/pkg/cmd/codespace/view.go
@@ -134,7 +134,10 @@ func formatGitStatus(codespace codespace) string {
 
 func formatRetentionPeriodDays(codespace codespace) string {
 	days := codespace.RetentionPeriodMinutes / minutesInDay
-	if days == 1 {
+	// Don't display the retention period if it is 0 days
+	if days == 0 {
+		return ""
+	} else if days == 1 {
 		return "1 day"
 	}
 

--- a/pkg/cmd/codespace/view.go
+++ b/pkg/cmd/codespace/view.go
@@ -35,7 +35,8 @@ func newViewCmd(app *App) *cobra.Command {
 }
 
 func (a *App) ViewCodespace(ctx context.Context, opts *viewOptions, exporter cmdutil.Exporter) error {
-	if codespaceName := os.Getenv("CODESPACES_NAME"); os.Getenv("CODESPACES") == "true" && codespaceName != "" {
+	// If we are in a codespace, show the details for it
+	if codespaceName := os.Getenv("CODESPACE_NAME"); os.Getenv("CODESPACES") == "true" && codespaceName != "" {
 		opts.selector.codespaceName = codespaceName
 	}
 
@@ -66,21 +67,12 @@ func (a *App) ViewCodespace(ctx context.Context, opts *viewOptions, exporter cmd
 		{"Name", formattedName},
 		{"Display Name", c.DisplayName},
 		{"State", c.State},
-		{"Machine Name", c.Machine.Name},
-		{"Machine Display Name", c.Machine.DisplayName},
-		{"Prebuild", strconv.FormatBool(c.Prebuild)},
-		{"Owner", c.Owner.Login},
-		{"BillableOwner", c.BillableOwner.Login},
-		{"Location", c.Location},
-		{"Repository", c.Repository.FullName},
-		{"Branch", c.GitStatus.Ref},
-		{"Devcontainer Path", c.DevContainerPath},
 		{"Git Status", formatGitStatus(c)},
+		{"Devcontainer Path", c.DevContainerPath},
+		{"Machine Display Name", c.Machine.DisplayName},
 		{"Created At", c.CreatedAt},
-		{"Last Used At", c.LastUsedAt},
-		{"Idle Timeout Minutes", strconv.Itoa(c.IdleTimeoutMinutes)},
-		{"Retention Period Days", strconv.Itoa(c.RetentionPeriodMinutes / 1440)},
-		{"Retention Expires At", c.RetentionExpiresAt},
+		{"Idle Timeout", strconv.Itoa(c.IdleTimeoutMinutes) + " minutes"},
+		{"Retention Period", strconv.Itoa(c.RetentionPeriodMinutes/1440) + " days"},
 	}
 
 	for _, field := range fields {

--- a/pkg/cmd/codespace/view_test.go
+++ b/pkg/cmd/codespace/view_test.go
@@ -10,9 +10,6 @@ import (
 )
 
 func Test_NewCmdView(t *testing.T) {
-	type fields struct {
-		apiClient apiClient
-	}
 	tests := []struct {
 		tName         string
 		codespaceName string

--- a/pkg/cmd/codespace/view_test.go
+++ b/pkg/cmd/codespace/view_test.go
@@ -1,0 +1,128 @@
+package codespace
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/codespaces/api"
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+func Test_NewCmdView(t *testing.T) {
+	type fields struct {
+		apiClient apiClient
+	}
+	tests := []struct {
+		tName         string
+		codespaceName string
+		opts          *viewOptions
+		cliArgs       []string
+		wantErr       bool
+		wantStdout    string
+		errMsg        string
+	}{
+		{
+			tName:   "selector throws because no terminal found",
+			opts:    &viewOptions{},
+			wantErr: true,
+			errMsg:  "choosing codespace: error getting answers: no terminal",
+		},
+		{
+			tName:         "command fails because provided codespace doesn't exist",
+			codespaceName: "i-dont-exist",
+			opts:          &viewOptions{},
+			wantErr:       true,
+			errMsg:        "getting full codespace details: codespace not found",
+		},
+		{
+			tName:         "command succeeds because codespace exists (no details)",
+			codespaceName: "monalisa-cli-cli-abcdef",
+			opts:          &viewOptions{},
+			wantErr:       false,
+			wantStdout:    "Name\tmonalisa-cli-cli-abcdef\nGit Status\t - 0↓ 0↑\nIdle Timeout\t0 minutes\n",
+		},
+		{
+			tName:         "command succeeds because codespace exists (with details)",
+			codespaceName: "monalisa-cli-cli-hijklm",
+			opts:          &viewOptions{},
+			wantErr:       false,
+			wantStdout:    "Name\tmonalisa-cli-cli-hijklm\nGit Status\tmain* - 2↓ 1↑\nIdle Timeout\t30 minutes\nRetention Period\t1 day\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tName, func(t *testing.T) {
+			ios, _, stdout, _ := iostreams.Test()
+			a := &App{
+				apiClient: testViewApiMock(),
+				io:        ios,
+			}
+			selector := &CodespaceSelector{api: a.apiClient, codespaceName: tt.codespaceName}
+			tt.opts.selector = selector
+
+			var err error
+			if tt.cliArgs == nil {
+				if tt.opts.selector == nil {
+					t.Fatalf("selector must be set in opts if cliArgs are not provided")
+				}
+
+				err = a.ViewCodespace(context.Background(), tt.opts)
+			} else {
+				cmd := newViewCmd(a)
+				cmd.SilenceUsage = true
+				cmd.SilenceErrors = true
+				cmd.SetOut(ios.ErrOut)
+				cmd.SetErr(ios.ErrOut)
+				cmd.SetArgs(tt.cliArgs)
+				_, err = cmd.ExecuteC()
+			}
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("Edit() expected error, got nil")
+				} else if err.Error() != tt.errMsg {
+					t.Errorf("Edit() error = %q, want %q", err, tt.errMsg)
+				}
+			} else if err != nil {
+				t.Errorf("Edit() expected no error, got %v", err)
+			}
+
+			if out := stdout.String(); out != tt.wantStdout {
+				t.Errorf("stdout = %q, want %q", out, tt.wantStdout)
+			}
+		})
+	}
+}
+
+func testViewApiMock() *apiClientMock {
+	codespaceWithNoDetails := &api.Codespace{
+		Name: "monalisa-cli-cli-abcdef",
+	}
+	codespaceWithDetails := &api.Codespace{
+		Name: "monalisa-cli-cli-hijklm",
+		GitStatus: api.CodespaceGitStatus{
+			Ahead:                 1,
+			Behind:                2,
+			Ref:                   "main",
+			HasUnpushedChanges:    true,
+			HasUncommittedChanges: true,
+		},
+		IdleTimeoutMinutes:     30,
+		RetentionPeriodMinutes: 1440,
+	}
+	return &apiClientMock{
+		GetCodespaceFunc: func(_ context.Context, name string, _ bool) (*api.Codespace, error) {
+			if name == codespaceWithDetails.Name {
+				return codespaceWithDetails, nil
+			} else if name == codespaceWithNoDetails.Name {
+				return codespaceWithNoDetails, nil
+			}
+
+			return nil, fmt.Errorf("codespace not found")
+		},
+		ListCodespacesFunc: func(ctx context.Context, opts api.ListCodespacesOptions) ([]*api.Codespace, error) {
+			return []*api.Codespace{codespaceWithNoDetails, codespaceWithDetails}, nil
+		},
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/cli/cli/issues/7479

Adds the `gh cs view` command to give more details about a specific codespace. By default, we only show a few of the fields that most users will care about (similar to what VS Code does, shown below) but a wider array of options are available via the `--json` flag. Also, if the user is in a codespace and runs the command it will show details about that codespace.

What VS Code shows:
<img width="300" alt="image" src="https://github.com/cli/cli/assets/22037769/5bdd5f5e-f530-475c-ab02-0dc11ee85507">

`gh cs view` (no flags) shows the codespace picker:
<img width="418" alt="image" src="https://github.com/cli/cli/assets/22037769/eba906f9-c864-4e28-b969-4c8ec96c0153">

And once you select a codespace or provide the name using the `-c` flag, it will show this:
<img width="491" alt="image" src="https://github.com/cli/cli/assets/22037769/d0face2b-ccda-412a-8334-6de4077faa31">

All of the data available with the `--json` flag: 
<img width="500" alt="image" src="https://github.com/cli/cli/assets/22037769/7a110e73-3ef5-42a5-b32d-a24fcf04e9b7">


Tests are WIP pending some design review.