### PR TITLE
Do not generate docs for aliases

### DIFF
--- a/cmd/gen-docs/main.go
+++ b/cmd/gen-docs/main.go
@@ -49,7 +49,7 @@ func run(args []string) error {
 		IOStreams: ios,
 		Browser:   &browser{},
 		Config: func() (config.Config, error) {
-			return config.NewBlankConfig(), nil
+			return config.NewFromString(""), nil
 		},
 		ExtensionManager: &em{},
 	}, "", "")

--- a/pkg/cmd/root/help.go
+++ b/pkg/cmd/root/help.go
@@ -104,7 +104,7 @@ func rootHelpFunc(f *cmdutil.Factory, command *cobra.Command, args []string) {
 	cs := f.IOStreams.ColorScheme()
 
 	if help, _ := flags.GetBool("help"); !help && !command.Runnable() && len(flags.Args()) > 0 {
-		nestedSuggestFunc(f.IOStreams.ErrOut, command, strings.Join(flags.Args(), " "))
+		nestedSuggestFunc(f.IOStreams.ErrOut, command, flags.Args()[0])
 		hasFailed = true
 		return
 	}


### PR DESCRIPTION
Follow up to https://github.com/cli/cli/pull/7457 that fixes generating docs for the default `co` alias by using a blank config file instead of the default one. Also small UX improvement for suggesting nested commands. 