### PR TITLE
Add `--copy-url` flag to the `gh repo create` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 require (
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/cli/browser v1.2.0 // indirect
 	github.com/cli/shurcooL-graphql v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbf
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/briandowns/spinner v1.18.1 h1:yhQmQtM1zsqFsouh09Bk/jCjd50pC3EOGsh28gLVvwY=

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/atotto/clipboard"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/cli/cli/v2/api"
@@ -63,6 +64,7 @@ type CreateOptions struct {
 	Interactive        bool
 	IncludeAllBranches bool
 	AddReadme          bool
+	CopyUrl            bool
 }
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
@@ -196,6 +198,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmd.Flags().BoolVar(&opts.DisableWiki, "disable-wiki", false, "Disable wiki in the new repository")
 	cmd.Flags().BoolVar(&opts.IncludeAllBranches, "include-all-branches", false, "Include all branches from template repository")
 	cmd.Flags().BoolVar(&opts.AddReadme, "add-readme", false, "Add a README file to the new repository")
+	cmd.Flags().BoolVar(&opts.CopyUrl, "copy-url", false, "Copy the repository url to your clipboard")
 
 	// deprecated flags
 	cmd.Flags().BoolP("confirm", "y", false, "Skip the confirmation prompt")
@@ -406,6 +409,12 @@ func createFromScratch(opts *CreateOptions) error {
 		}
 	}
 
+	if opts.CopyUrl {
+		err := clipboard.WriteAll(repo.URL)
+		if err != nil {
+			fmt.Println("Cannot copy URL to clipboard.\n", err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/config"

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-
+	
 	"github.com/cenkalti/backoff/v4"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/config"


### PR DESCRIPTION
Adding `--copy-url` flag, if specified it let you automatically copy the repository url when it is done created to your clipboard.

I used this project to copy to clipboard: https://github.com/atotto/clipboard
