### PR TITLE
api: support array params in GET queries

### DIFF
--- a/pkg/cmd/api/http.go
+++ b/pkg/cmd/api/http.go
@@ -129,11 +129,15 @@ func addQueryParam(query url.Values, key string, value interface{}) error {
 	case map[string]interface{}:
 		for subkey, value := range v {
 			// support for nested subkeys can be added here if that is ever necessary
-			addQueryParam(query, subkey, value)
+			if err := addQueryParam(query, subkey, value); err != nil {
+				return err
+			}
 		}
 	case []interface{}:
 		for _, entry := range v {
-			addQueryParam(query, key+"[]", entry)
+			if err := addQueryParam(query, key+"[]", entry); err != nil {
+				return err
+			}
 		}
 	default:
 		return fmt.Errorf("unknown type %v", v)

--- a/pkg/cmd/api/http_test.go
+++ b/pkg/cmd/api/http_test.go
@@ -323,6 +323,14 @@ func Test_addQuery(t *testing.T) {
 			want: "?a=hello",
 		},
 		{
+			name: "array",
+			args: args{
+				path:   "",
+				params: map[string]interface{}{"a": []interface{}{"hello", "world"}},
+			},
+			want: "?a%5B%5D=hello&a%5B%5D=world",
+		},
+		{
 			name: "append",
 			args: args{
 				path:   "path",


### PR DESCRIPTION
GitHub API endpoints in theory support accepting array values in query parameters, e.g. `?a[]=one&a[]=two`

This allows array values to be serialized into GET query strings when `-f a[]=one -f a[]=two` is used in combination with `--method GET`.

Followup to https://github.com/cli/cli/pull/6614