### PR TITLE
Fix flaky test

### DIFF
--- a/pkg/cmd/issue/shared/lookup_test.go
+++ b/pkg/cmd/issue/shared/lookup_test.go
@@ -285,10 +285,8 @@ func TestIssuesFromArgsWithFields(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-			for i, issue := range issues {
-				if issue.Number != tt.wantIssues[i] {
-					t.Errorf("want issue #%d, got #%d", tt.wantIssues[i], issue.Number)
-				}
+			for i := range issues {
+				assert.Contains(t, tt.wantIssues, issues[i].Number)
 			}
 			if repo != nil {
 				repoURL := ghrepo.GenerateRepoURL(repo, "")


### PR DESCRIPTION
`IssuesFromArgsWithFields` uses non-deterministic Go routines so this changes the assertion to `contains` rather than `equals` to avoid relying on ordering of returned issues.

Fixes https://github.com/cli/cli/issues/7511