### PR TITLE
Fix bash completions for extensions and aliases

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -168,10 +168,8 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 	// Extensions
 	em := f.ExtensionManager
 	for _, e := range em.List() {
-		extension := e
 		extensionCmd := NewCmdExtension(io, em, e)
 		cmd.AddCommand(extensionCmd)
-		cmd.ValidArgs = append(cmd.ValidArgs, fmt.Sprintf("%s\t%s", extension.Name(), extensionCmd.Short))
 	}
 
 	// Aliases
@@ -193,7 +191,6 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 			if strings.HasPrefix(aliasValue, "!") {
 				shellAliasCmd := NewCmdShellAlias(io, parentArgs[0], aliasValue)
 				parentCmd.AddCommand(shellAliasCmd)
-				parentCmd.ValidArgs = append(parentCmd.ValidArgs, fmt.Sprintf("%s\tShell alias", aliasName))
 			} else {
 				aliasCmd := NewCmdAlias(io, parentArgs[0], aliasValue)
 				split, _ := shlex.Split(aliasValue)
@@ -205,7 +202,6 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 					rootHelpFunc(f, child, args)
 				})
 				parentCmd.AddCommand(aliasCmd)
-				parentCmd.ValidArgs = append(parentCmd.ValidArgs, fmt.Sprintf("%s\tAlias for %s", aliasName, aliasValue))
 			}
 		}
 	}


### PR DESCRIPTION
Now that extensions and alises are real Cobra Command instances, they will appear in completions automatically and don't need to be additionally inserted via ValidArgs. Their addition to ValidArgs have caused all extensions and aliases to be listed twice within completion results, which didn't seem to affect zsh completions at all, but in bash completions it had caused the completion description to be a part of the expansion.

```
bin/gh __complete merg
mergeconflict   Extension vilmibm/gh-mergeconflict
mergeconflict   Extension vilmibm/gh-mergeconflict
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

Fixes https://github.com/cli/cli/issues/7524