### PR TITLE
Improve docs around run rerun job flag

### DIFF
--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/run/shared"
@@ -39,8 +40,19 @@ func NewCmdRerun(f *cmdutil.Factory, runF func(*RerunOptions) error) *cobra.Comm
 
 	cmd := &cobra.Command{
 		Use:   "rerun [<run-id>]",
-		Short: "Rerun a failed run",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "Rerun a run",
+		Long: heredoc.Docf(`
+			Rerun an entire run, only failed jobs, or a specific job from a run.
+
+			Note that due for historical reasons, the %[1]s--job%[1]s flag may not take what you expect.
+			Specifically, when navigating to a job in the browser, the URL looks like this:
+			%[1]shttps://github.com/<org>/<repo>/actions/runs/<run-id>/jobs/<job-id>%[1]s.
+
+			However, this %[1]sjob-id%[1]s should not be used with the %[1]s--job%[1]s flag and will result in the
+			API returning %[1]s404 NOT FOUND%[1]s. Instead, you can get the correct job IDs using the following command:
+			%[1]sgh run view <run-id> --json jobs --jq '.jobs[] | {name, databaseId}'%[1]s.
+		`, "`"),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -46,9 +46,9 @@ func NewCmdRerun(f *cmdutil.Factory, runF func(*RerunOptions) error) *cobra.Comm
 
 			Note that due for historical reasons, the %[1]s--job%[1]s flag may not take what you expect.
 			Specifically, when navigating to a job in the browser, the URL looks like this:
-			%[1]shttps://github.com/<org>/<repo>/actions/runs/<run-id>/jobs/<job-id>%[1]s.
+			%[1]shttps://github.com/<org>/<repo>/actions/runs/<run-id>/jobs/<number>%[1]s.
 
-			However, this %[1]sjob-id%[1]s should not be used with the %[1]s--job%[1]s flag and will result in the
+			However, this %[1]snumber%[1]s should not be used with the %[1]s--job%[1]s flag and will result in the
 			API returning %[1]s404 NOT FOUND%[1]s. Instead, you can get the correct job IDs using the following command:
 			%[1]sgh run view <run-id> --json jobs --jq '.jobs[] | {name, databaseId}'%[1]s.
 		`, "`"),


### PR DESCRIPTION
### Description

This PR fixes https://github.com/cli/cli/issues/7507.

In the linked issue, there was confusion around which `id` to provide to `run rerun --job <job_id>`. Due to legacy reasons, this `job_id` is **not** the one you would expect simply by taking the suffix of the URL in the browser when navigating to a job.

This PR adds documentation to the `Long` description of the `rerun` command to draw attention to this, and how to find IDs for jobs in a run.

### Reviewer Notes

Here is a screenshot of the new text in `help` and in the `manual` (I'm not sure how to open manpages for a local build):

<img width="1010" alt="image" src="https://github.com/cli/cli/assets/1611510/8a15d197-766d-4a6b-8a21-9d2e03a9b48f">

<img width="1009" alt="image" src="https://github.com/cli/cli/assets/1611510/bdc87626-fb71-4931-a39c-557733053ca3">
