### PR TITLE
Credential rotations, renames and decouplings from Mislav

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -341,5 +341,6 @@ jobs:
         with:
           formula-name: gh
           tag-name: ${{ inputs.tag_name }}
+          push-to: cli/homebrew-core
         env:
-          COMMITTER_TOKEN: ${{ secrets.UPLOAD_GITHUB_TOKEN }}
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_PR_PAT }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -218,7 +218,7 @@ jobs:
           repository: github/cli.github.com
           path: site
           fetch-depth: 0
-          ssh-key: ${{ secrets.SITE_SSH_KEY }}
+          token: ${{ secrets.SITE_DEPLOY_PAT }}
       - name: Update site man pages
         env:
           GIT_COMMITTER_NAME: cli automation


### PR DESCRIPTION
### Description

We can use a scoped PAT instead of an ssh key for deployment. This has been partially tested (read-only) as part of https://github.com/cli/cli/actions/runs/5199215231/jobs/9376480393

We can use a legacy PAT and our own fork of homebrew for opening PRs on new CLI releases.

