### PR TITLE
Add option to remove file from gist

### DIFF
--- a/pkg/cmd/gist/edit/edit.go
+++ b/pkg/cmd/gist/edit/edit.go
@@ -194,12 +194,11 @@ func editRun(opts *EditOptions) error {
 
 	// Remove a file from the gist
 	if opts.RemoveFilename != "" {
-		files, err := removeFile(gist.Files, opts.RemoveFilename)
+		err := removeFile(gist, opts.RemoveFilename)
 		if err != nil {
 			return err
 		}
 
-		gist.Files = files
 		return updateGist(apiClient, host, gist)
 	}
 
@@ -354,15 +353,12 @@ func getFilesToAdd(file string, content []byte) (map[string]*shared.GistFile, er
 	}, nil
 }
 
-func removeFile(files map[string]*shared.GistFile, filename string) (map[string]*shared.GistFile, error) {
-	if _, found := files[filename]; !found {
-		return nil, fmt.Errorf("gist has no file %q", filename)
+func removeFile(gist *shared.Gist, filename string) error {
+	if _, found := gist.Files[filename]; !found {
+		return fmt.Errorf("gist has no file %q", filename)
 	}
 
-	for name := range files {
-		if strings.Compare(name, filename) == 0 {
-			files[name] = nil
-		}
-	}
-	return files, nil
+	gist.Files[filename] = nil
+
+	return nil
 }

--- a/pkg/cmd/gist/edit/edit.go
+++ b/pkg/cmd/gist/edit/edit.go
@@ -83,10 +83,10 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.AddFilename, "add", "a", "", "Add a new file to the gist")
 	cmd.Flags().StringVarP(&opts.Description, "desc", "d", "", "New description for the gist")
 	cmd.Flags().StringVarP(&opts.EditFilename, "filename", "f", "", "Select a file to edit")
-	cmd.Flags().StringVarP(&opts.RemoveFilename, "remove-file", "r", "", "Remove a file from the gist")
+	cmd.Flags().StringVarP(&opts.RemoveFilename, "remove", "r", "", "Remove a file from the gist")
 
-	cmd.MarkFlagsMutuallyExclusive("add", "remove-file")
-	cmd.MarkFlagsMutuallyExclusive("remove-file", "filename")
+	cmd.MarkFlagsMutuallyExclusive("add", "remove")
+	cmd.MarkFlagsMutuallyExclusive("remove", "filename")
 
 	return cmd
 }

--- a/pkg/cmd/gist/edit/edit.go
+++ b/pkg/cmd/gist/edit/edit.go
@@ -85,6 +85,9 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.EditFilename, "filename", "f", "", "Select a file to edit")
 	cmd.Flags().StringVarP(&opts.RemoveFilename, "remove-file", "r", "", "Remove a file from the gist")
 
+	cmd.MarkFlagsMutuallyExclusive("add", "remove-file")
+	cmd.MarkFlagsMutuallyExclusive("remove-file", "filename")
+
 	return cmd
 }
 

--- a/pkg/cmd/gist/edit/edit_test.go
+++ b/pkg/cmd/gist/edit/edit_test.go
@@ -82,7 +82,7 @@ func TestNewCmdEdit(t *testing.T) {
 		},
 		{
 			name: "remove",
-			cli:  "123 --remove-file cool.md",
+			cli:  "123 --remove cool.md",
 			wants: EditOptions{
 				Selector:       "123",
 				RemoveFilename: "cool.md",

--- a/pkg/cmd/gist/edit/edit_test.go
+++ b/pkg/cmd/gist/edit/edit_test.go
@@ -36,9 +36,10 @@ func Test_getFilesToAdd(t *testing.T) {
 
 func TestNewCmdEdit(t *testing.T) {
 	tests := []struct {
-		name  string
-		cli   string
-		wants EditOptions
+		name     string
+		cli      string
+		wants    EditOptions
+		wantsErr bool
 	}{
 		{
 			name: "no flags",
@@ -88,6 +89,16 @@ func TestNewCmdEdit(t *testing.T) {
 				RemoveFilename: "cool.md",
 			},
 		},
+		{
+			name:     "add and remove are mutually exclusive",
+			cli:      "123 --add cool.md --remove great.md",
+			wantsErr: true,
+		},
+		{
+			name:     "filename and remove are mutually exclusive",
+			cli:      "123 --filename cool.md --remove great.md",
+			wantsErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -108,11 +119,17 @@ func TestNewCmdEdit(t *testing.T) {
 			cmd.SetErr(&bytes.Buffer{})
 
 			_, err = cmd.ExecuteC()
-			assert.NoError(t, err)
+			if tt.wantsErr {
+				require.Error(t, err)
+				return
+			}
 
-			assert.Equal(t, tt.wants.EditFilename, gotOpts.EditFilename)
-			assert.Equal(t, tt.wants.AddFilename, gotOpts.AddFilename)
-			assert.Equal(t, tt.wants.Selector, gotOpts.Selector)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.wants.EditFilename, gotOpts.EditFilename)
+			require.Equal(t, tt.wants.AddFilename, gotOpts.AddFilename)
+			require.Equal(t, tt.wants.Selector, gotOpts.Selector)
+			require.Equal(t, tt.wants.RemoveFilename, gotOpts.RemoveFilename)
 		})
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #7517 

* Add `--remove` flag in `gist edit`
    - to keep it consistent with add file flag
* will throw error if combined with `add` or `filename` flag
* does not support multiple file delete
