### PR TITLE
Add timeouts to keyring operations

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cli/cli/v2/internal/keyring"
 	ghAuth "github.com/cli/go-gh/v2/pkg/auth"
 	ghConfig "github.com/cli/go-gh/v2/pkg/config"
-	"github.com/zalando/go-keyring"
 )
 
 const (

--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -1,0 +1,80 @@
+// Package keyring is a simple wrapper that adds timeouts to the zalando/go-keyring package.
+package keyring
+
+import (
+	"context"
+	"time"
+
+	"github.com/zalando/go-keyring"
+)
+
+type TimeoutError struct {
+	message string
+}
+
+func (e *TimeoutError) Error() string {
+	return e.message
+}
+
+// Set secret in keyring for user.
+func Set(service, user, secret string) error {
+	duration := time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+	ch := make(chan error, 1)
+	go func() {
+		defer close(ch)
+		ch <- keyring.Set(service, user, secret)
+	}()
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		return &TimeoutError{"timeout while trying to set secret in keyring"}
+	}
+}
+
+// Get secret from keyring given service and user name.
+func Get(service, user string) (string, error) {
+	duration := time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+	resCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(resCh)
+		defer close(errCh)
+		val, err := keyring.Get(service, user)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		resCh <- val
+	}()
+	select {
+	case val := <-resCh:
+		return val, nil
+	case err := <-errCh:
+		return "", err
+	case <-ctx.Done():
+		return "", &TimeoutError{"timeout while trying to get secret from keyring"}
+	}
+}
+
+// Delete secret from keyring.
+func Delete(service, user string) error {
+	duration := time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+	ch := make(chan error, 1)
+	go func() {
+		defer close(ch)
+		ch <- keyring.Delete(service, user)
+	}()
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		return &TimeoutError{"timeout while trying to delete secret from keyring"}
+	}
+}

--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -2,7 +2,6 @@
 package keyring
 
 import (
-	"context"
 	"time"
 
 	"github.com/zalando/go-keyring"
@@ -18,9 +17,6 @@ func (e *TimeoutError) Error() string {
 
 // Set secret in keyring for user.
 func Set(service, user, secret string) error {
-	duration := time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
-	defer cancel()
 	ch := make(chan error, 1)
 	go func() {
 		defer close(ch)
@@ -29,16 +25,13 @@ func Set(service, user, secret string) error {
 	select {
 	case err := <-ch:
 		return err
-	case <-ctx.Done():
+	case <-time.After(3 * time.Second):
 		return &TimeoutError{"timeout while trying to set secret in keyring"}
 	}
 }
 
 // Get secret from keyring given service and user name.
 func Get(service, user string) (string, error) {
-	duration := time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
-	defer cancel()
 	ch := make(chan struct {
 		val string
 		err error
@@ -54,16 +47,13 @@ func Get(service, user string) (string, error) {
 	select {
 	case res := <-ch:
 		return res.val, res.err
-	case <-ctx.Done():
+	case <-time.After(3 * time.Second):
 		return "", &TimeoutError{"timeout while trying to get secret from keyring"}
 	}
 }
 
 // Delete secret from keyring.
 func Delete(service, user string) error {
-	duration := time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
-	defer cancel()
 	ch := make(chan error, 1)
 	go func() {
 		defer close(ch)
@@ -72,7 +62,7 @@ func Delete(service, user string) error {
 	select {
 	case err := <-ch:
 		return err
-	case <-ctx.Done():
+	case <-time.After(3 * time.Second):
 		return &TimeoutError{"timeout while trying to delete secret from keyring"}
 	}
 }


### PR DESCRIPTION
This PR adds some timeouts to keyring operations that have been reported as hanging in some WSL and Windows machines. The underlying issue stems from the `go-keyring` package that we use so until the bugs get fixed there we should properly handle the cases where it hangs. 

Fixes https://github.com/cli/cli/issues/7208