### PR TITLE
Use SmartBaseRepoFunc for api command

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -179,9 +179,7 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 		},
 		Args: cobra.ExactArgs(1),
 		PreRun: func(c *cobra.Command, args []string) {
-			if repoOverride := os.Getenv("GH_REPO"); repoOverride != "" {
-				opts.BaseRepo = cmdutil.OverrideBaseRepoFunc(f, "")
-			}
+			opts.BaseRepo = cmdutil.OverrideBaseRepoFunc(f, "")
 		},
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.RequestPath = args[0]

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -179,7 +179,9 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 		},
 		Args: cobra.ExactArgs(1),
 		PreRun: func(c *cobra.Command, args []string) {
-			opts.BaseRepo = cmdutil.OverrideBaseRepoFunc(f, "")
+			if repoOverride := os.Getenv("GH_REPO"); repoOverride != "" {
+				opts.BaseRepo = cmdutil.OverrideBaseRepoFunc(f, "")
+			}
 		},
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.RequestPath = args[0]

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -133,13 +133,6 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 	cmd.AddCommand(sshKeyCmd.NewCmdSSHKey(f))
 	cmd.AddCommand(statusCmd.NewCmdStatus(f, nil))
 	cmd.AddCommand(newCodespaceCmd(f))
-
-	// the `api` command should not inherit any extra HTTP headers
-	bareHTTPCmdFactory := *f
-	bareHTTPCmdFactory.HttpClient = bareHTTPClient(f, version)
-
-	cmd.AddCommand(apiCmd.NewCmdApi(&bareHTTPCmdFactory, nil))
-
 	cmd.AddCommand(projectCmd.NewCmdProject(f))
 
 	// below here at the commands that require the "intelligent" BaseRepo resolver
@@ -155,6 +148,13 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 	cmd.AddCommand(runCmd.NewCmdRun(&repoResolvingCmdFactory))
 	cmd.AddCommand(workflowCmd.NewCmdWorkflow(&repoResolvingCmdFactory))
 	cmd.AddCommand(labelCmd.NewCmdLabel(&repoResolvingCmdFactory))
+
+	// the `api` command should not inherit any extra HTTP headers
+	bareHTTPCmdFactory := *f
+	bareHTTPCmdFactory.HttpClient = bareHTTPClient(f, version)
+	bareHTTPCmdFactory.BaseRepo = factory.SmartBaseRepoFunc(&bareHTTPCmdFactory)
+
+	cmd.AddCommand(apiCmd.NewCmdApi(&bareHTTPCmdFactory, nil))
 
 	// Help topics
 	var referenceCmd *cobra.Command


### PR DESCRIPTION
Fixes: #7595

The placeholder `{repo}` was previously substituted with whichever remote happened to be sorted first via `sort.Sort()`. Instead:

  - if `$GH_REPO` is not set, use `SmartBaseRepoFunc` to select the remote the user has configured via `repo set-default`.
  - if `$GH_REPO` is set, use `OverrideBaseRepoFunc` as before.