### PR TITLE
gh auth refresh command with --remove-scopes --reset-scope feature

### DIFF
--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -175,7 +175,7 @@ func refreshRun(opts *RefreshOptions) error {
 			}
 		}
 	} else {
-		tmpScopes = []string{"repo", "read:org", "admin:org"}
+		tmpScopes = []string{"repo", "read:org"}
 	}
 
 	for _, s := range opts.Scopes {

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -65,16 +65,24 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 			your gh credentials to have. If no scopes are provided, the command
 			maintains previously added scopes.
 
-			The command can only add additional scopes, but not remove previously
-			added ones. To reset scopes to the default minimum set of scopes, you
-			will need to create new credentials using the auth login command.
+			The --remove-scopes flag accepts a comma separated list of scopes you
+			want to remove from your gh credentials.
+
+			The --reset-scopes flag resets the scopes for your gh credentials to
+			the default minimum set of scopes, which are read:org and repo.
 		`),
 		Example: heredoc.Doc(`
+			$ gh auth refresh
+			# => open a browser to ensure your authentication credentials have the correct minimum scopes
+
 			$ gh auth refresh --scopes write:org,read:public_key
 			# => open a browser to add write:org and read:public_key scopes for use with gh api
 
-			$ gh auth refresh
-			# => open a browser to ensure your authentication credentials have the correct minimum scopes
+			$ gh auth refresh --remove-scopes delete_repo
+			# => open a browser to re-authenticate without the delete_repo scope(in case you previously added it)
+
+			$ gh auth refresh --reset-scopes
+			# => open a browser to re-authenticate with the default minimum scopes
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Interactive = opts.IO.CanPrompt()
@@ -92,7 +100,7 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 	}
 
 	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "The GitHub host to use for authentication")
-	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", nil, "Specify additional authentication scopes for gh to have (use comma to specify multiple scopes)")
+	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", nil, "Additional authentication scopes for gh to have")
 	// secure storage became the default on 2023/4/04; this flag is left as a no-op for backwards compatibility
 	var secureStorage bool
 	cmd.Flags().BoolVar(&secureStorage, "secure-storage", false, "Save authentication credentials in secure credential store")
@@ -100,7 +108,7 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 
 	cmd.Flags().BoolVarP(&opts.InsecureStorage, "insecure-storage", "", false, "Save authentication credentials in plain text instead of credential store")
 
-	cmd.Flags().StringSliceVarP(&opts.RemoveScopes, "remove-scopes", "r", nil, "Remove authentication scopes from gh (use comma to specify multiple scopes)")
+	cmd.Flags().StringSliceVarP(&opts.RemoveScopes, "remove-scopes", "r", nil, "Remove authentication scopes from gh to have")
 	cmd.Flags().BoolVarP(&opts.ResetScopes, "reset-scopes", "R", false, "Reset authentication scopes to the default minimum set of scopes")
 	return cmd
 }

--- a/pkg/cmd/auth/refresh/refresh_test.go
+++ b/pkg/cmd/auth/refresh/refresh_test.go
@@ -99,6 +99,38 @@ func Test_NewCmdRefresh(t *testing.T) {
 				InsecureStorage: true,
 			},
 		},
+		{
+			name: "remove scopes",
+			tty:  true,
+			cli:  "--remove-scopes repo:invite,delete_repo",
+			wants: RefreshOptions{
+				RemoveScopes: []string{"repo:invite", "delete_repo"},
+			},
+		},
+		{
+			name: "remove scopes shorthand",
+			tty:  true,
+			cli:  "-r repo:invite,delete_repo",
+			wants: RefreshOptions{
+				RemoveScopes: []string{"repo:invite", "delete_repo"},
+			},
+		},
+		{
+			name: "reset scopes",
+			tty:  true,
+			cli:  "--reset-scopes",
+			wants: RefreshOptions{
+				ResetScopes: true,
+			},
+		},
+		{
+			name: "reset scopes shorthand",
+			tty:  true,
+			cli:  "-R",
+			wants: RefreshOptions{
+				ResetScopes: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/auth/refresh/refresh_test.go
+++ b/pkg/cmd/auth/refresh/refresh_test.go
@@ -185,7 +185,7 @@ func Test_refreshRun(t *testing.T) {
 			},
 			wantAuthArgs: authArgs{
 				hostname:      "obed.morton",
-				scopes:        nil,
+				scopes:        []string{},
 				secureStorage: true,
 			},
 		},
@@ -199,7 +199,7 @@ func Test_refreshRun(t *testing.T) {
 			},
 			wantAuthArgs: authArgs{
 				hostname:      "github.com",
-				scopes:        nil,
+				scopes:        []string{},
 				secureStorage: true,
 			},
 		},
@@ -219,7 +219,7 @@ func Test_refreshRun(t *testing.T) {
 			},
 			wantAuthArgs: authArgs{
 				hostname:      "github.com",
-				scopes:        nil,
+				scopes:        []string{},
 				secureStorage: true,
 			},
 		},
@@ -248,7 +248,68 @@ func Test_refreshRun(t *testing.T) {
 			},
 			wantAuthArgs: authArgs{
 				hostname:      "github.com",
-				scopes:        []string{"repo:invite", "public_key:read", "delete_repo", "codespace"},
+				scopes:        []string{"delete_repo", "codespace", "repo:invite", "public_key:read"},
+				secureStorage: true,
+			},
+		},
+		{
+			name: "remove scopes",
+			cfgHosts: []string{
+				"github.com",
+			},
+			oldScopes: "delete_repo, codespace",
+			opts: &RefreshOptions{
+				RemoveScopes: []string{"codespace", "delete_repo", "repo:invite"},
+			},
+			wantAuthArgs: authArgs{
+				hostname:      "github.com",
+				scopes:        []string{},
+				secureStorage: true,
+			},
+		},
+		{
+			name: "remove all scopes",
+			cfgHosts: []string{
+				"github.com",
+			},
+			oldScopes: "repo:invite, delete_repo, codespace",
+			opts: &RefreshOptions{
+				RemoveScopes: []string{"codespace", "repo:invite", "delete_repo"},
+			},
+			wantAuthArgs: authArgs{
+				hostname:      "github.com",
+				scopes:        []string{},
+				secureStorage: true,
+			},
+		},
+		{
+			name: "remove scopes that don't exist",
+			cfgHosts: []string{
+				"github.com",
+			},
+			oldScopes: "repo:invite, delete_repo, codespace",
+			opts: &RefreshOptions{
+				RemoveScopes: []string{"codespace", "repo:invite", "public_key:read"},
+			},
+			wantAuthArgs: authArgs{
+				hostname:      "github.com",
+				scopes:        []string{"delete_repo"},
+				secureStorage: true,
+			},
+		},
+		{
+			name: "add and remove scopes",
+			cfgHosts: []string{
+				"github.com",
+			},
+			oldScopes: "repo:invite, delete_repo, codespace",
+			opts: &RefreshOptions{
+				Scopes:       []string{"repo:invite", "public_key:read", "workflow"},
+				RemoveScopes: []string{"codespace", "repo:invite", "workflow"},
+			},
+			wantAuthArgs: authArgs{
+				hostname:      "github.com",
+				scopes:        []string{"delete_repo", "public_key:read"},
 				secureStorage: true,
 			},
 		},
@@ -262,7 +323,7 @@ func Test_refreshRun(t *testing.T) {
 			},
 			wantAuthArgs: authArgs{
 				hostname:      "obed.morton",
-				scopes:        nil,
+				scopes:        []string{},
 				secureStorage: true,
 			},
 		},
@@ -277,7 +338,7 @@ func Test_refreshRun(t *testing.T) {
 			},
 			wantAuthArgs: authArgs{
 				hostname: "obed.morton",
-				scopes:   nil,
+				scopes:   []string{},
 			},
 		},
 	}


### PR DESCRIPTION
Solves: #6785

# Overview

This PR introduces new flags for `gh auth refresh` , --remove-scopes and --reset-scope, which had been discussed in #6785.
Unit tests are also created for this feature.

# Detail

## --remove-scopes
The --remove-scopes flag accepts a comma-separated list of scopes that users want to remove from gh command(in case you previously added it)

## --reset-scope
The --reset-scopes flag lets you re-authorize with the minimum set of scopes("repo", "read:org")


## Areas Requiring Confirmation
Due to modifications in the management of scopes, some parts of the tests, specifically those operations that do not involve scope manipulation, have been changed from expecting nil to an empty string array ([]string{}). I would like to request confirmation that these changes are appropriate and do not introduce any issues.