### PR TITLE
Remove old code paths and improve code comments for `repo sync`

### DIFF
--- a/pkg/cmd/repo/sync/http.go
+++ b/pkg/cmd/repo/sync/http.go
@@ -32,8 +32,6 @@ func latestCommit(client *api.Client, repo ghrepo.Interface, branch string) (com
 
 type upstreamMergeErr struct{ error }
 
-var upstreamMergeUnavailableErr = upstreamMergeErr{errors.New("upstream merge API is unavailable")}
-
 var missingWorkflowScopeRE = regexp.MustCompile("refusing to allow.*without `workflow` scope")
 var missingWorkflowScopeErr = errors.New("Upstream commits contain workflow changes, which require the `workflow` scope to merge. To request it, run: gh auth refresh -s workflow")
 
@@ -60,8 +58,6 @@ func triggerUpstreamMerge(client *api.Client, repo ghrepo.Interface, branch stri
 					return "", missingWorkflowScopeErr
 				}
 				return "", upstreamMergeErr{errors.New(httpErr.Message)}
-			case http.StatusNotFound:
-				return "", upstreamMergeUnavailableErr
 			}
 		}
 		return "", err

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -292,7 +292,7 @@ func Test_SyncRun(t *testing.T) {
 					httpmock.StringResponse(`{"data":{"repository":{"defaultBranchRef":{"name": "trunk"}}}}`))
 				reg.Register(
 					httpmock.REST("POST", "repos/FORKOWNER/REPO-FORK/merge-upstream"),
-					httpmock.StatusStringResponse(404, `{}`))
+					httpmock.StatusStringResponse(422, `{}`))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/git/refs/heads/trunk"),
 					httpmock.StringResponse(`{"object":{"sha":"0xDEADBEEF"}}`))


### PR DESCRIPTION
This PR removes a unused code path, and adds some documentation to the `repo sync` command in order to make it easier to debug in the future.

Closes https://github.com/cli/cli/issues/7574