### PR TITLE
Early exit repo sync if merge-upstream requires workflow scope

### DIFF
--- a/pkg/cmd/repo/sync/http.go
+++ b/pkg/cmd/repo/sync/http.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -33,6 +34,9 @@ type upstreamMergeErr struct{ error }
 
 var upstreamMergeUnavailableErr = upstreamMergeErr{errors.New("upstream merge API is unavailable")}
 
+var missingWorkflowScopeRE = regexp.MustCompile("refusing to allow.*without `workflow` scope")
+var missingWorkflowScopeErr = errors.New("Upstream commits contain workflow changes, which require the `workflow` scope to merge. To request it, run: gh auth refresh -s workflow")
+
 func triggerUpstreamMerge(client *api.Client, repo ghrepo.Interface, branch string) (string, error) {
 	var payload bytes.Buffer
 	if err := json.NewEncoder(&payload).Encode(map[string]interface{}{
@@ -52,6 +56,9 @@ func triggerUpstreamMerge(client *api.Client, repo ghrepo.Interface, branch stri
 		if errors.As(err, &httpErr) {
 			switch httpErr.StatusCode {
 			case http.StatusUnprocessableEntity, http.StatusConflict:
+				if missingWorkflowScopeRE.MatchString(httpErr.Message) {
+					return "", missingWorkflowScopeErr
+				}
 				return "", upstreamMergeErr{errors.New(httpErr.Message)}
 			case http.StatusNotFound:
 				return "", upstreamMergeUnavailableErr

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -457,6 +457,24 @@ func Test_SyncRun(t *testing.T) {
 			wantErr: true,
 			errMsg:  "trunk branch does not exist on OWNER/REPO-FORK repository",
 		},
+		{
+			name: "sync remote fork with missing workflow scope on token",
+			opts: &SyncOptions{
+				DestArg: "FORKOWNER/REPO-FORK",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryInfo\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"defaultBranchRef":{"name": "trunk"}}}}`))
+				reg.Register(
+					httpmock.REST("POST", "repos/FORKOWNER/REPO-FORK/merge-upstream"),
+					httpmock.StatusJSONResponse(422, struct {
+						Message string `json:"message"`
+					}{Message: "refusing to allow an OAuth App to create or update workflow `.github/workflows/unimportant.yml` without `workflow` scope"}))
+			},
+			wantErr: true,
+			errMsg:  "Upstream commits contain workflow changes, which require the `workflow` scope to merge. To request it, run: gh auth refresh -s workflow",
+		},
 	}
 	for _, tt := range tests {
 		reg := &httpmock.Registry{}

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -143,7 +143,20 @@ func StatusStringResponse(status int, body string) Responder {
 func JSONResponse(body interface{}) Responder {
 	return func(req *http.Request) (*http.Response, error) {
 		b, _ := json.Marshal(body)
-		return httpResponse(200, req, bytes.NewBuffer(b)), nil
+		header := http.Header{
+			"Content-Type": []string{"application/json"},
+		}
+		return httpResponseWithHeader(200, req, bytes.NewBuffer(b), header), nil
+	}
+}
+
+func StatusJSONResponse(status int, body interface{}) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		b, _ := json.Marshal(body)
+		header := http.Header{
+			"Content-Type": []string{"application/json"},
+		}
+		return httpResponseWithHeader(status, req, bytes.NewBuffer(b), header), nil
 	}
 }
 
@@ -215,10 +228,14 @@ func ScopesResponder(scopes string) func(*http.Request) (*http.Response, error) 
 }
 
 func httpResponse(status int, req *http.Request, body io.Reader) *http.Response {
+	return httpResponseWithHeader(status, req, body, http.Header{})
+}
+
+func httpResponseWithHeader(status int, req *http.Request, body io.Reader, header http.Header) *http.Response {
 	return &http.Response{
 		StatusCode: status,
 		Request:    req,
 		Body:       io.NopCloser(body),
-		Header:     http.Header{},
+		Header:     header,
 	}
 }


### PR DESCRIPTION
## Description

This is a step towards addressing https://github.com/cli/cli/issues/7574.

As a result of changes around repository APIs, if commits that are to be synced from upstream include workflow file changes, the API requires the token to have `workflow` scope. When that issue was raised this was failing as opaque errors on the `/merge-upstream` and `/repos/<OWNER>/<REPO>/git/refs/heads/<branch>` endpoints. The `/merge-upstream` endpoint has been updated to return a more transparent error of the form:

```
{
  "message": "refusing to allow an OAuth App to create or update workflow `.github/workflows/bench.yml` without `workflow` scope",
  "documentation_url": "https://docs.github.com/rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository"
}
```

This PR attempts to capture that and bubble an error to the user stating that they need to get these new scopes. Sadly, the API doe not report that it needs the `workflow` scope in the `X-Accepted-Oauth-Scopes` header and [even if it did we skip the scope suggestion on `422`](https://github.com/cli/cli/blob/bf7db84ca8b795a38ee47b5e54a8109a917a55bf/api/client.go#L208). I'm not sure what the reason for that is, so maybe someone can help me understand that.

### Demonstration

#### Before

```
➜  dune git:(main) gh repo sync williammartin-test-org/dune
HTTP 404: Not Found (https://api.github.com/repos/williammartin-test-org/dune/git/refs/heads/main)
```

#### After

```
➜  dune git:(main) ~/workspace/cli/bin/gh repo sync williammartin-test-org/dune
Upstream commits contain workflow changes, which require the `workflow` scope to merge. To request it, run: gh auth refresh -s workflow
```

### Reproduction

To reproduce this, you can:
 1. Create a repository `upstream`
 2. Create a fork `downstream`
 3. Push a workflow file change in `upstream`
 4. `gh repo sync <downstream>`

### Limitations

Since the `/upstream-merge` endpoint doesn't support `--force`, I think the following scenario is possible but I haven't confirmed it.

Given a repo that has diverged from upstream and that diverged history contains a workflow file change.
When I pass `--force` to the CLI
Then the `/merge-upstream` endpoint returns a `409` for conflict
And then we fall back to `/repos/<OWNER>/<REPO>/git/refs/heads/main` which still returns a `404` opaque error.

However, this seems a significant improvement either way and with `GH_DEBUG` the failure on the `/merge-upstream` is already much more apparent.