### PR TITLE
Don't deduplicate checks that stem from different events

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -183,16 +183,10 @@ type CheckContexts struct {
 }
 
 type CheckContext struct {
-	TypeName   string `json:"__typename"`
-	Name       string `json:"name"`
-	IsRequired bool   `json:"isRequired"`
-	CheckSuite struct {
-		WorkflowRun struct {
-			Workflow struct {
-				Name string `json:"name"`
-			} `json:"workflow"`
-		} `json:"workflowRun"`
-	} `json:"checkSuite"`
+	TypeName   string     `json:"__typename"`
+	Name       string     `json:"name"`
+	IsRequired bool       `json:"isRequired"`
+	CheckSuite CheckSuite `json:"checkSuite"`
 	// QUEUED IN_PROGRESS COMPLETED WAITING PENDING REQUESTED
 	Status string `json:"status"`
 	// ACTION_REQUIRED TIMED_OUT CANCELLED FAILURE SUCCESS NEUTRAL SKIPPED STARTUP_FAILURE STALE
@@ -208,6 +202,19 @@ type CheckContext struct {
 	State     StatusState `json:"state"`
 	TargetURL string      `json:"targetUrl"`
 	CreatedAt time.Time   `json:"createdAt"`
+}
+
+type CheckSuite struct {
+	WorkflowRun WorkflowRun `json:"workflowRun"`
+}
+
+type WorkflowRun struct {
+	Event    string   `json:"event"`
+	Workflow Workflow `json:"workflow"`
+}
+
+type Workflow struct {
+	Name string `json:"name"`
 }
 
 type PRRepository struct {

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -226,7 +226,7 @@ func RequiredStatusCheckRollupGraphQL(prID, after string) string {
 							},
 							...on CheckRun {
 								name,
-								checkSuite{workflowRun{workflow{name}}},
+								checkSuite{workflowRun{event,workflow{name}}},
 								status,
 								conclusion,
 								startedAt,

--- a/pkg/cmd/pr/checks/aggregate.go
+++ b/pkg/cmd/pr/checks/aggregate.go
@@ -15,6 +15,8 @@ type check struct {
 	CompletedAt time.Time `json:"completedAt"`
 	Link        string    `json:"link"`
 	Bucket      string    `json:"bucket"`
+	Event       string    `json:"event"`
+	Workflow    string    `json:"workflow"`
 }
 
 type checkCounts struct {
@@ -55,7 +57,10 @@ func aggregateChecks(checkContexts []api.CheckContext, requiredChecks bool) (che
 			StartedAt:   c.StartedAt,
 			CompletedAt: c.CompletedAt,
 			Link:        link,
+			Event:       c.CheckSuite.WorkflowRun.Event,
+			Workflow:    c.CheckSuite.WorkflowRun.Workflow.Name,
 		}
+
 		switch state {
 		case "SUCCESS":
 			item.Bucket = "pass"
@@ -91,7 +96,7 @@ func eliminateDuplicates(checkContexts []api.CheckContext) []api.CheckContext {
 			}
 			mapContexts[ctx.Context] = struct{}{}
 		} else {
-			key := fmt.Sprintf("%s/%s", ctx.Name, ctx.CheckSuite.WorkflowRun.Workflow.Name)
+			key := fmt.Sprintf("%s/%s/%s", ctx.Name, ctx.CheckSuite.WorkflowRun.Workflow.Name, ctx.CheckSuite.WorkflowRun.Event)
 			if _, exists := mapChecks[key]; exists {
 				continue
 			}

--- a/pkg/cmd/pr/checks/checks_test.go
+++ b/pkg/cmd/pr/checks/checks_test.go
@@ -610,6 +610,156 @@ func TestEliminateDuplicates(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "unique workflow name",
+			checkContexts: []api.CheckContext{
+				{
+					TypeName:    "CheckRun",
+					Name:        "build (ubuntu-latest)",
+					Status:      "COMPLETED",
+					Conclusion:  "SUCCESS",
+					StartedAt:   time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					CompletedAt: time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					DetailsURL:  "https://github.com/cli/cli/runs/1",
+					CheckSuite: api.CheckSuite{
+						WorkflowRun: api.WorkflowRun{
+							Event: "push",
+							Workflow: api.Workflow{
+								Name: "some builds",
+							},
+						},
+					},
+				},
+				{
+					TypeName:    "CheckRun",
+					Name:        "build (ubuntu-latest)",
+					Status:      "COMPLETED",
+					Conclusion:  "SUCCESS",
+					StartedAt:   time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					CompletedAt: time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					DetailsURL:  "https://github.com/cli/cli/runs/2",
+					CheckSuite: api.CheckSuite{
+						WorkflowRun: api.WorkflowRun{
+							Event: "push",
+							Workflow: api.Workflow{
+								Name: "some other builds",
+							},
+						},
+					},
+				},
+			},
+			want: []api.CheckContext{
+				{
+					TypeName:    "CheckRun",
+					Name:        "build (ubuntu-latest)",
+					Status:      "COMPLETED",
+					Conclusion:  "SUCCESS",
+					StartedAt:   time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					CompletedAt: time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					DetailsURL:  "https://github.com/cli/cli/runs/1",
+					CheckSuite: api.CheckSuite{
+						WorkflowRun: api.WorkflowRun{
+							Event: "push",
+							Workflow: api.Workflow{
+								Name: "some builds",
+							},
+						},
+					},
+				},
+				{
+					TypeName:    "CheckRun",
+					Name:        "build (ubuntu-latest)",
+					Status:      "COMPLETED",
+					Conclusion:  "SUCCESS",
+					StartedAt:   time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					CompletedAt: time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					DetailsURL:  "https://github.com/cli/cli/runs/2",
+					CheckSuite: api.CheckSuite{
+						WorkflowRun: api.WorkflowRun{
+							Event: "push",
+							Workflow: api.Workflow{
+								Name: "some other builds",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unique workflow run event",
+			checkContexts: []api.CheckContext{
+				{
+					TypeName:    "CheckRun",
+					Name:        "build (ubuntu-latest)",
+					Status:      "COMPLETED",
+					Conclusion:  "SUCCESS",
+					StartedAt:   time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					CompletedAt: time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					DetailsURL:  "https://github.com/cli/cli/runs/1",
+					CheckSuite: api.CheckSuite{
+						WorkflowRun: api.WorkflowRun{
+							Event: "push",
+							Workflow: api.Workflow{
+								Name: "builds",
+							},
+						},
+					},
+				},
+				{
+					TypeName:    "CheckRun",
+					Name:        "build (ubuntu-latest)",
+					Status:      "COMPLETED",
+					Conclusion:  "SUCCESS",
+					StartedAt:   time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					CompletedAt: time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					DetailsURL:  "https://github.com/cli/cli/runs/2",
+					CheckSuite: api.CheckSuite{
+						WorkflowRun: api.WorkflowRun{
+							Event: "pull_request",
+							Workflow: api.Workflow{
+								Name: "builds",
+							},
+						},
+					},
+				},
+			},
+			want: []api.CheckContext{
+				{
+					TypeName:    "CheckRun",
+					Name:        "build (ubuntu-latest)",
+					Status:      "COMPLETED",
+					Conclusion:  "SUCCESS",
+					StartedAt:   time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					CompletedAt: time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					DetailsURL:  "https://github.com/cli/cli/runs/1",
+					CheckSuite: api.CheckSuite{
+						WorkflowRun: api.WorkflowRun{
+							Event: "push",
+							Workflow: api.Workflow{
+								Name: "builds",
+							},
+						},
+					},
+				},
+				{
+					TypeName:    "CheckRun",
+					Name:        "build (ubuntu-latest)",
+					Status:      "COMPLETED",
+					Conclusion:  "SUCCESS",
+					StartedAt:   time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					CompletedAt: time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC),
+					DetailsURL:  "https://github.com/cli/cli/runs/2",
+					CheckSuite: api.CheckSuite{
+						WorkflowRun: api.WorkflowRun{
+							Event: "pull_request",
+							Workflow: api.Workflow{
+								Name: "builds",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/pr/checks/output.go
+++ b/pkg/cmd/pr/checks/output.go
@@ -34,8 +34,16 @@ func addRow(tp utils.TablePrinter, io *iostreams.IOStreams, o check) {
 	}
 
 	if io.IsStdoutTTY() {
+		var name string
+		if o.Workflow != "" {
+			name += fmt.Sprintf("%s/", o.Workflow)
+		}
+		name += o.Name
+		if o.Event != "" {
+			name += fmt.Sprintf(" (%s)", o.Event)
+		}
 		tp.AddField(mark, nil, markColor)
-		tp.AddField(o.Name, nil, nil)
+		tp.AddField(name, nil, nil)
 		tp.AddField(elapsed, nil, nil)
 		tp.AddField(o.Link, nil, nil)
 	} else {


### PR DESCRIPTION
This PR changes `pr checks` to take into account the workflow run event when deciding if a check is duplicated. Additionally, I updated the output of `pr checks` to match what is shown on the web. I did not change the non-tty output as I was unsure if that was necessary or helpful even.

Before:

<img width="826" alt="Screenshot 2023-06-26 at 10 13 16 AM" src="https://github.com/cli/cli/assets/7969779/5f4f5947-c5d8-47c6-891c-14dfa4acd407">

After:

<img width="987" alt="Screenshot 2023-06-26 at 10 13 26 AM" src="https://github.com/cli/cli/assets/7969779/ddaee922-0f18-46f4-ae28-78fa41a34c9b">

Web:

<img width="857" alt="Screenshot 2023-06-26 at 10 13 41 AM" src="https://github.com/cli/cli/assets/7969779/3ae77ba9-542d-4cae-86dc-5cb25e0b1332">


Closes https://github.com/cli/cli/issues/7604