### PR TITLE
chore: add title to iteration and milestone fields

### DIFF
--- a/pkg/cmd/project/shared/format/json.go
+++ b/pkg/cmd/project/shared/format/json.go
@@ -256,9 +256,11 @@ func projectFieldValueData(v queries.FieldValueNodes) any {
 		return v.ProjectV2ItemFieldDateValue.Date
 	case "ProjectV2ItemFieldIterationValue":
 		return struct {
+			Title     string `json:"title"`
 			StartDate string `json:"startDate"`
 			Duration  int    `json:"duration"`
 		}{
+			Title:     v.ProjectV2ItemFieldIterationValue.Title,
 			StartDate: v.ProjectV2ItemFieldIterationValue.StartDate,
 			Duration:  v.ProjectV2ItemFieldIterationValue.Duration,
 		}
@@ -270,9 +272,11 @@ func projectFieldValueData(v queries.FieldValueNodes) any {
 		return v.ProjectV2ItemFieldTextValue.Text
 	case "ProjectV2ItemFieldMilestoneValue":
 		return struct {
+			Title       string `json:"title"`
 			Description string `json:"description"`
 			DueOn       string `json:"dueOn"`
 		}{
+			Title:       v.ProjectV2ItemFieldMilestoneValue.Milestone.Title,
 			Description: v.ProjectV2ItemFieldMilestoneValue.Milestone.Description,
 			DueOn:       v.ProjectV2ItemFieldMilestoneValue.Milestone.DueOn,
 		}

--- a/pkg/cmd/project/shared/format/json_test.go
+++ b/pkg/cmd/project/shared/format/json_test.go
@@ -279,6 +279,82 @@ func TestJSONProjectDraftIssue(t *testing.T) {
 	assert.Equal(t, `{"id":"123","title":"title","body":"a body","type":"DraftIssue"}`, string(b))
 }
 
+func TestJSONProjectItem_DraftIssue_ProjectV2ItemFieldIterationValue(t *testing.T) {
+	iterationField := queries.ProjectField{TypeName: "ProjectV2IterationField"}
+	iterationField.IterationField.ID = "sprint"
+	iterationField.IterationField.Name = "Sprint"
+
+	iterationFieldValue := queries.FieldValueNodes{Type: "ProjectV2ItemFieldIterationValue"}
+	iterationFieldValue.ProjectV2ItemFieldIterationValue.Title = "Iteration Title"
+	iterationFieldValue.ProjectV2ItemFieldIterationValue.Field = iterationField
+
+	draftIssue := queries.ProjectItem{
+		Id: "draftIssueId",
+		Content: queries.ProjectItemContent{
+			TypeName: "DraftIssue",
+			DraftIssue: queries.DraftIssue{
+				Title: "Pull Request title",
+				Body:  "a body",
+			},
+		},
+	}
+	draftIssue.FieldValues.Nodes = []queries.FieldValueNodes{
+		iterationFieldValue,
+	}
+	p := &queries.Project{}
+	p.Fields.Nodes = []queries.ProjectField{iterationField}
+	p.Items.TotalCount = 5
+	p.Items.Nodes = []queries.ProjectItem{
+		draftIssue,
+	}
+
+	out, err := JSONProjectDetailedItems(p)
+	assert.NoError(t, err)
+	assert.JSONEq(
+		t,
+		`{"items":[{"sprint":{"title":"Iteration Title","startDate":"","duration":0},"content":{"type":"DraftIssue","body":"a body","title":"Pull Request title"},"id":"draftIssueId"}],"totalCount":5}`,
+		string(out))
+
+}
+
+func TestJSONProjectItem_DraftIssue_ProjectV2ItemFieldMilestoneValue(t *testing.T) {
+	milestoneField := queries.ProjectField{TypeName: "ProjectV2IterationField"}
+	milestoneField.IterationField.ID = "milestone"
+	milestoneField.IterationField.Name = "Milestone"
+
+	milestoneFieldValue := queries.FieldValueNodes{Type: "ProjectV2ItemFieldMilestoneValue"}
+	milestoneFieldValue.ProjectV2ItemFieldMilestoneValue.Milestone.Title = "Milestone Title"
+	milestoneFieldValue.ProjectV2ItemFieldMilestoneValue.Field = milestoneField
+
+	draftIssue := queries.ProjectItem{
+		Id: "draftIssueId",
+		Content: queries.ProjectItemContent{
+			TypeName: "DraftIssue",
+			DraftIssue: queries.DraftIssue{
+				Title: "Pull Request title",
+				Body:  "a body",
+			},
+		},
+	}
+	draftIssue.FieldValues.Nodes = []queries.FieldValueNodes{
+		milestoneFieldValue,
+	}
+	p := &queries.Project{}
+	p.Fields.Nodes = []queries.ProjectField{milestoneField}
+	p.Items.TotalCount = 5
+	p.Items.Nodes = []queries.ProjectItem{
+		draftIssue,
+	}
+
+	out, err := JSONProjectDetailedItems(p)
+	assert.NoError(t, err)
+	assert.JSONEq(
+		t,
+		`{"items":[{"milestone":{"title":"Milestone Title","dueOn":"","description":""},"content":{"type":"DraftIssue","body":"a body","title":"Pull Request title"},"id":"draftIssueId"}],"totalCount":5}`,
+		string(out))
+
+}
+
 func TestCamelCase(t *testing.T) {
 	assert.Equal(t, "camelCase", CamelCase("camelCase"))
 	assert.Equal(t, "camelCase", CamelCase("CamelCase"))

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -167,6 +167,7 @@ type FieldValueNodes struct {
 		Field ProjectField
 	} `graphql:"... on ProjectV2ItemFieldDateValue"`
 	ProjectV2ItemFieldIterationValue struct {
+		Title     string
 		StartDate string
 		Duration  int
 		Field     ProjectField
@@ -193,6 +194,7 @@ type FieldValueNodes struct {
 	} `graphql:"... on ProjectV2ItemFieldTextValue"`
 	ProjectV2ItemFieldMilestoneValue struct {
 		Milestone struct {
+			Title       string
 			Description string
 			DueOn       string
 		}


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Extends the `ProjectV2ItemFieldIterationValue` and `ProjectV2ItemFieldMilestoneValue` to add title property.

Fixes #7572