### PR TITLE
fix(api): do not interpret "branch" placeholder when `GH_REPO` is set

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -469,6 +470,11 @@ func fillPlaceholders(value string, opts *ApiOptions) (string, error) {
 				err = e
 			}
 		case "branch":
+			if os.Getenv("GH_REPO") != "" {
+				err = errors.New("unable to determine an appropriate value for the 'branch' placeholder")
+				return m
+			}
+
 			if branch, e := opts.Branch(); e == nil {
 				return branch
 			} else {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -1096,10 +1096,11 @@ func Test_fillPlaceholders(t *testing.T) {
 		opts  *ApiOptions
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
+		name      string
+		args      args
+		ghRepoSet bool
+		want      string
+		wantErr   bool
 	}{
 		{
 			name: "no changes",
@@ -1236,9 +1237,26 @@ func Test_fillPlaceholders(t *testing.T) {
 			want:    "{}{ownership}/{repository}",
 			wantErr: false,
 		},
+		{
+			name:      "branch can't be filled when GH_REPO is set",
+			ghRepoSet: true,
+			args: args{
+				value: "repos/:owner/:repo/branches/:branch",
+				opts: &ApiOptions{
+					BaseRepo: func() (ghrepo.Interface, error) {
+						return ghrepo.New("hubot", "robot-uprising"), nil
+					},
+				},
+			},
+			want:    "repos/hubot/robot-uprising/branches/:branch",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.ghRepoSet {
+				t.Setenv("GH_REPO", "hubot/robot-uprising")
+			}
 			got, err := fillPlaceholders(tt.args.value, tt.args.opts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("fillPlaceholders() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -1096,11 +1096,11 @@ func Test_fillPlaceholders(t *testing.T) {
 		opts  *ApiOptions
 	}
 	tests := []struct {
-		name      string
-		args      args
-		ghRepoSet bool
-		want      string
-		wantErr   bool
+		name         string
+		args         args
+		repoOverride bool
+		want         string
+		wantErr      bool
 	}{
 		{
 			name: "no changes",
@@ -1238,8 +1238,8 @@ func Test_fillPlaceholders(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "branch can't be filled when GH_REPO is set",
-			ghRepoSet: true,
+			name:         "branch can't be filled when GH_REPO is set",
+			repoOverride: true,
 			args: args{
 				value: "repos/:owner/:repo/branches/:branch",
 				opts: &ApiOptions{
@@ -1254,7 +1254,7 @@ func Test_fillPlaceholders(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.ghRepoSet {
+			if tt.repoOverride {
 				t.Setenv("GH_REPO", "hubot/robot-uprising")
 			}
 			got, err := fillPlaceholders(tt.args.value, tt.args.opts)


### PR DESCRIPTION
Before, we would always interpret the "branch" placeholder, typically setting
it to the currently checked-out branch in the repository in the current working
directory. It didn't make sense to do that when the `GH_REPO` environment
variable was specified because the repository would likely be different from
the one in the current working directory.

Now, we instead report an error if both `GH_REPO` environment variable and
`branch` placeholder are specified.

One concern is that this might break existing scripts in which `GH_REPO` just happens 
to be set to the currently checked out repository. I could maybe add a check to 
verify that the `GH_REPO` is set to a different repository from the currently
checked out repository? What do you think?

Fixes #7603
