### PR TITLE
Always show created gist privacy status.

### DIFF
--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -116,18 +116,22 @@ func createRun(opts *CreateOptions) error {
 	gistName := guessGistName(files)
 
 	processMessage := "Creating gist..."
-	completionMessage := "Created gist"
+
+	var completionMessage string
+	if opts.Public {
+		completionMessage = fmt.Sprintf("Created %s gist", cs.Red("public"))
+	} else {
+		completionMessage = fmt.Sprintf("Created %s gist", cs.Green("secret"))
+	}
+
 	if gistName != "" {
 		if len(files) > 1 {
 			processMessage = "Creating gist with multiple files"
 		} else {
 			processMessage = fmt.Sprintf("Creating gist %s", gistName)
 		}
-		if opts.Public {
-			completionMessage = fmt.Sprintf("Created %s gist %s", cs.Red("public"), gistName)
-		} else {
-			completionMessage = fmt.Sprintf("Created %s gist %s", cs.Green("secret"), gistName)
-		}
+
+		completionMessage += " " + gistName
 	}
 
 	errOut := opts.IO.ErrOut

--- a/pkg/cmd/gist/create/create.go
+++ b/pkg/cmd/gist/create/create.go
@@ -112,29 +112,18 @@ func createRun(opts *CreateOptions) error {
 		return fmt.Errorf("failed to collect files for posting: %w", err)
 	}
 
+	errOut := opts.IO.ErrOut
 	cs := opts.IO.ColorScheme()
 	gistName := guessGistName(files)
 
 	processMessage := "Creating gist..."
-
-	var completionMessage string
-	if opts.Public {
-		completionMessage = fmt.Sprintf("Created %s gist", cs.Red("public"))
-	} else {
-		completionMessage = fmt.Sprintf("Created %s gist", cs.Green("secret"))
-	}
-
 	if gistName != "" {
 		if len(files) > 1 {
 			processMessage = "Creating gist with multiple files"
 		} else {
 			processMessage = fmt.Sprintf("Creating gist %s", gistName)
 		}
-
-		completionMessage += " " + gistName
 	}
-
-	errOut := opts.IO.ErrOut
 	fmt.Fprintf(errOut, "%s %s\n", cs.Gray("-"), processMessage)
 
 	httpClient, err := opts.HttpClient()
@@ -165,6 +154,13 @@ func createRun(opts *CreateOptions) error {
 		return fmt.Errorf("%s Failed to create gist: %w", cs.Red("X"), err)
 	}
 
+	completionMessage := fmt.Sprintf("Created %s gist", cs.Green("secret"))
+	if opts.Public {
+		completionMessage = fmt.Sprintf("Created %s gist", cs.Red("public"))
+	}
+	if gistName != "" {
+		completionMessage += " " + gistName
+	}
 	fmt.Fprintf(errOut, "%s %s\n", cs.SuccessIconWithColor(cs.Green), completionMessage)
 
 	if opts.WebMode {

--- a/pkg/cmd/gist/create/create_test.go
+++ b/pkg/cmd/gist/create/create_test.go
@@ -275,7 +275,7 @@ func Test_createRun(t *testing.T) {
 			},
 			stdin:      "cool stdin content",
 			wantOut:    "https://gist.github.com/aa5a315d61ae9438b18d\n",
-			wantStderr: "- Creating gist...\n✓ Created gist\n",
+			wantStderr: "- Creating gist...\n✓ Created secret gist\n",
 			wantErr:    false,
 			wantParams: map[string]interface{}{
 				"description": "",


### PR DESCRIPTION
The output of `gh gist create` shows the privacy status of the gist only when a filename is provided. We now show it unconditionally.

Fixes #7644

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
