### PR TITLE
[Codespaces] Support random `--server-port=0` and printing connection details

### DIFF
--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -18,13 +18,15 @@ type printer interface {
 // Shell runs an interactive secure shell over an existing
 // port-forwarding session. It runs until the shell is terminated
 // (including by cancellation of the context).
-func Shell(ctx context.Context, p printer, sshArgs []string, port int, destination string, usingCustomPort bool) error {
+func Shell(
+	ctx context.Context, p printer, sshArgs []string, port int, destination string, printConnDetails bool,
+) error {
 	cmd, connArgs, err := newSSHCommand(ctx, port, destination, sshArgs)
 	if err != nil {
 		return fmt.Errorf("failed to create ssh command: %w", err)
 	}
 
-	if usingCustomPort {
+	if printConnDetails {
 		p.Printf("Connection Details: ssh %s %s", destination, connArgs)
 	}
 


### PR DESCRIPTION
This PR introduces slightly modified behavior for the `--server-port` flag that should only make it more useable to CLI users.

Before:
If you passed `--server-port=1234` to the `gh cs ssh` command, it would create the local SSH server on port  `1234` and (very important) print the connection details that CLI users can use to connect aka `ssh codespace@localhost -p 1234 ...`

This approach works well when the CLI user can guarantee that port `1234` is available on the OS. This is hard to do and can't be guaranteed. 

The solution that the CLI currently exposes is to pass `--server-port=0` which allows the OS to find a random open port and give it to CLI to create the SSH server with. Only problem is that the current logic would then keep the CLI from printing connection details. Hence CLI users would never know which random port was picked or see the connection details.

The default for `--server-port` is `0`, so even if we don't pass it it's being "used"

After:
With this change, we use a feature of cobra that tells us when a flag has been "changed" (or set) even if it matches the default value. This is important, because there is a difference in behavior that we want.

With the `--server-port=0` explicitly passed, the CLI will now capture a random port AND print connection details 🎉 
Without the `--server-port` flag being explicitly passed, the CLI will continue to capture a random port but it will NOT print the connection details.

This unblocks some personal OSS work I am doing for an extension that uses the SSH command to connect to the codespace.
