### PR TITLE
fix pr create crash on interactive milestone selection

### DIFF
--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -281,6 +281,8 @@ func MetadataSurvey(io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher 
 			var milestoneDefault string
 			if len(state.Milestones) > 0 {
 				milestoneDefault = state.Milestones[0]
+			} else {
+				milestoneDefault = milestones[1]
 			}
 			mqs = append(mqs, &survey.Question{
 				Name: "milestone",


### PR DESCRIPTION
Fixes #7651

There are no test changes. This is bad. The pr create tests, especially ones around prompting, need to be rewritten and I didn't want to slow down getting this fix in.
