### PR TITLE
add gh cache to Actions explainer

### DIFF
--- a/pkg/cmd/actions/actions.go
+++ b/pkg/cmd/actions/actions.go
@@ -26,6 +26,7 @@ func actionsExplainer(cs *iostreams.ColorScheme) string {
 	header := cs.Bold("Welcome to GitHub Actions on the command line.")
 	runHeader := cs.Bold("Interacting with workflow runs")
 	workflowHeader := cs.Bold("Interacting with workflow files")
+	cacheHeader := cs.Bold("Interacting with the Actions cache")
 
 	return heredoc.Docf(`
 			%s
@@ -49,5 +50,12 @@ func actionsExplainer(cs *iostreams.ColorScheme) string {
 			gh workflow run:      Trigger a workflow_dispatch run for a workflow file
 
 			To see more help, run 'gh help workflow <subcommand>'
-		`, header, runHeader, workflowHeader)
+
+			%s
+			gh cache list:    List all the caches saved in Actions for a repository
+			gh cache delete:  Delete one or all saved caches in Actions for a repository
+
+			To see more help, run 'gh help cache <subcommand>'
+
+		`, header, runHeader, workflowHeader, cacheHeader)
 }


### PR DESCRIPTION
adds a stanza about `gh cache` to the output of `gh actions`
