### PR TITLE
Use filepath.Clean to sanitize path for archive downloads

### DIFF
--- a/pkg/cmd/release/download/download.go
+++ b/pkg/cmd/release/download/download.go
@@ -290,7 +290,7 @@ func downloadAsset(dest *destinationWriter, httpClient *http.Client, assetURL, f
 			return fmt.Errorf("unable to parse file name of archive: %w", err)
 		}
 		if serverFileName, ok := params["filename"]; ok {
-			fileName = serverFileName
+			fileName = filepath.Clean(serverFileName)
 		} else {
 			return errors.New("unable to determine file name of archive")
 		}


### PR DESCRIPTION
Fixes https://github.com/github/cli/issues/176