### PR TITLE
Fix pr checks command for GHES versions older than 3.9

### DIFF
--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -205,10 +205,14 @@ func StatusCheckRollupGraphQLWithoutCountByState(after string) string {
 	}`), afterClause)
 }
 
-func RequiredStatusCheckRollupGraphQL(prID, after string) string {
+func RequiredStatusCheckRollupGraphQL(prID, after string, includeEvent bool) string {
 	var afterClause string
 	if after != "" {
 		afterClause = ",after:" + after
+	}
+	eventField := "event,"
+	if !includeEvent {
+		eventField = ""
 	}
 	return fmt.Sprintf(shortenQuery(`
 	statusCheckRollup: commits(last: 1) {
@@ -228,7 +232,7 @@ func RequiredStatusCheckRollupGraphQL(prID, after string) string {
 							},
 							...on CheckRun {
 								name,
-								checkSuite{workflowRun{event,workflow{name}}},
+								checkSuite{workflowRun{%[3]sworkflow{name}}},
 								status,
 								conclusion,
 								startedAt,
@@ -242,7 +246,7 @@ func RequiredStatusCheckRollupGraphQL(prID, after string) string {
 				}
 			}
 		}
-	}`), afterClause, prID)
+	}`), afterClause, prID, eventField)
 }
 
 var IssueFields = []string{

--- a/internal/featuredetection/feature_detection_test.go
+++ b/internal/featuredetection/feature_detection_test.go
@@ -82,7 +82,7 @@ func TestPullRequestFeatures(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name:     "github.com with merge queue and status check counts by state",
+			name:     "github.com with all features",
 			hostname: "github.com",
 			queryResponse: map[string]string{
 				`query PullRequest_fields\b`: heredoc.Doc(`
@@ -104,10 +104,21 @@ func TestPullRequestFeatures(t *testing.T) {
 						}
 					}
 				}`),
+				`query PullRequest_fields2\b`: heredoc.Doc(`
+				{
+					"data": {
+						"WorkflowRun": {
+							"fields": [
+								{"name": "event"}
+							]
+						}
+					}
+				}`),
 			},
 			wantFeatures: PullRequestFeatures{
 				MergeQueue:                     true,
 				CheckRunAndStatusContextCounts: true,
+				CheckRunEvent:                  true,
 			},
 			wantErr: false,
 		},
@@ -131,15 +142,26 @@ func TestPullRequestFeatures(t *testing.T) {
 						}
 					}
 				}`),
+				`query PullRequest_fields2\b`: heredoc.Doc(`
+				{
+					"data": {
+						"WorkflowRun": {
+							"fields": [
+								{"name": "event"}
+							]
+						}
+					}
+				}`),
 			},
 			wantFeatures: PullRequestFeatures{
 				MergeQueue:                     false,
 				CheckRunAndStatusContextCounts: true,
+				CheckRunEvent:                  true,
 			},
 			wantErr: false,
 		},
 		{
-			name:     "GHE with merge queue and status check counts by state",
+			name:     "GHE with all features",
 			hostname: "git.my.org",
 			queryResponse: map[string]string{
 				`query PullRequest_fields\b`: heredoc.Doc(`
@@ -161,15 +183,26 @@ func TestPullRequestFeatures(t *testing.T) {
 						}
 					}
 				}`),
+				`query PullRequest_fields2\b`: heredoc.Doc(`
+				{
+					"data": {
+						"WorkflowRun": {
+							"fields": [
+								{"name": "event"}
+							]
+						}
+					}
+				}`),
 			},
 			wantFeatures: PullRequestFeatures{
 				MergeQueue:                     true,
 				CheckRunAndStatusContextCounts: true,
+				CheckRunEvent:                  true,
 			},
 			wantErr: false,
 		},
 		{
-			name:     "GHE without merge queue and status check counts by state",
+			name:     "GHE with no features",
 			hostname: "git.my.org",
 			queryResponse: map[string]string{
 				`query PullRequest_fields\b`: heredoc.Doc(`
@@ -183,10 +216,19 @@ func TestPullRequestFeatures(t *testing.T) {
 						}
 					}
 				}`),
+				`query PullRequest_fields2\b`: heredoc.Doc(`
+				{
+					"data": {
+						"WorkflowRun": {
+							"fields": []
+						}
+					}
+				}`),
 			},
 			wantFeatures: PullRequestFeatures{
 				MergeQueue:                     false,
 				CheckRunAndStatusContextCounts: false,
+				CheckRunEvent:                  false,
 			},
 			wantErr: false,
 		},

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
@@ -24,7 +25,8 @@ type ChecksOptions struct {
 	IO         *iostreams.IOStreams
 	Browser    browser.Browser
 
-	Finder shared.PRFinder
+	Finder   shared.PRFinder
+	Detector fd.Detector
 
 	SelectorArg string
 	WebMode     bool
@@ -142,8 +144,19 @@ func checksRun(opts *ChecksOptions) error {
 	var checks []check
 	var counts checkCounts
 	var err error
+	var includeEvent bool
 
-	checks, counts, err = populateStatusChecks(client, repo, pr, opts.Required)
+	if opts.Detector == nil {
+		cachedClient := api.NewCachedHTTPClient(client, time.Hour*24)
+		opts.Detector = fd.NewDetector(cachedClient, repo.RepoHost())
+	}
+	if features, featuresErr := opts.Detector.PullRequestFeatures(); featuresErr != nil {
+		return featuresErr
+	} else {
+		includeEvent = features.CheckRunEvent
+	}
+
+	checks, counts, err = populateStatusChecks(client, repo, pr, opts.Required, includeEvent)
 	if err != nil {
 		return err
 	}
@@ -183,7 +196,7 @@ func checksRun(opts *ChecksOptions) error {
 
 		time.Sleep(opts.Interval)
 
-		checks, counts, err = populateStatusChecks(client, repo, pr, opts.Required)
+		checks, counts, err = populateStatusChecks(client, repo, pr, opts.Required, includeEvent)
 		if err != nil {
 			break
 		}
@@ -210,7 +223,7 @@ func checksRun(opts *ChecksOptions) error {
 	return nil
 }
 
-func populateStatusChecks(client *http.Client, repo ghrepo.Interface, pr *api.PullRequest, requiredChecks bool) ([]check, checkCounts, error) {
+func populateStatusChecks(client *http.Client, repo ghrepo.Interface, pr *api.PullRequest, requiredChecks bool, includeEvent bool) ([]check, checkCounts, error) {
 	apiClient := api.NewClientFromHTTP(client)
 
 	type response struct {
@@ -224,7 +237,7 @@ func populateStatusChecks(client *http.Client, repo ghrepo.Interface, pr *api.Pu
 				%s
 			}
 		}
-	}`, api.RequiredStatusCheckRollupGraphQL("$id", "$endCursor"))
+	}`, api.RequiredStatusCheckRollupGraphQL("$id", "$endCursor", includeEvent))
 
 	variables := map[string]interface{}{
 		"id": pr.ID,

--- a/pkg/cmd/pr/checks/fixtures/withEvents.json
+++ b/pkg/cmd/pr/checks/fixtures/withEvents.json
@@ -1,0 +1,55 @@
+{
+  "data": {
+    "node": {
+      "statusCheckRollup": {
+        "nodes": [
+          {
+            "commit": {
+              "oid": "abc",
+              "statusCheckRollup": {
+                "contexts": {
+                  "nodes": [
+                    {
+                      "conclusion": "SUCCESS",
+                      "status": "COMPLETED",
+                      "name": "cool tests",
+                      "description": "cool description",
+                      "completedAt": "2020-08-27T19:00:12Z",
+                      "startedAt": "2020-08-27T18:58:46Z",
+                      "detailsUrl": "sweet link",
+                      "checkSuite": {
+                        "workflowRun": {
+                          "event": "pull_request",
+                          "workflow": {
+                            "name": "tests"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "conclusion": "SUCCESS",
+                      "status": "COMPLETED",
+                      "name": "cool tests",
+                      "description": "cool description",
+                      "completedAt": "2020-08-27T19:00:12Z",
+                      "startedAt": "2020-08-27T18:58:46Z",
+                      "detailsUrl": "sweet link",
+                      "checkSuite": {
+                        "workflowRun": {
+                          "event": "push",
+                          "workflow": {
+                            "name": "tests"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/pkg/cmd/pr/checks/fixtures/withoutEvents.json
+++ b/pkg/cmd/pr/checks/fixtures/withoutEvents.json
@@ -1,0 +1,53 @@
+{
+  "data": {
+    "node": {
+      "statusCheckRollup": {
+        "nodes": [
+          {
+            "commit": {
+              "oid": "abc",
+              "statusCheckRollup": {
+                "contexts": {
+                  "nodes": [
+                    {
+                      "conclusion": "SUCCESS",
+                      "status": "COMPLETED",
+                      "name": "cool tests",
+                      "description": "cool description",
+                      "completedAt": "2020-08-27T19:00:12Z",
+                      "startedAt": "2020-08-27T18:58:46Z",
+                      "detailsUrl": "sweet link",
+                      "checkSuite": {
+                        "workflowRun": {
+                          "workflow": {
+                            "name": "tests"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "conclusion": "SUCCESS",
+                      "status": "COMPLETED",
+                      "name": "cool tests",
+                      "description": "cool description",
+                      "completedAt": "2020-08-27T19:00:12Z",
+                      "startedAt": "2020-08-27T18:58:46Z",
+                      "detailsUrl": "sweet link",
+                      "checkSuite": {
+                        "workflowRun": {
+                          "workflow": {
+                            "name": "tests"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
My previous change https://github.com/cli/cli/pull/7618 did not take into account that the `event` field does not exist in GHES older than 3.9 and thus broke the `pr checks` command for older GHES instances. This PR fixes that by using feature detection to see if the `event` field exists before requesting it.

Fixes https://github.com/cli/cli/issues/7716