### PR TITLE
Allow --org parameter in lieu of a repo context for rulesets, add current_user_can_bypass to rs view

### DIFF
--- a/pkg/cmd/ruleset/list/list.go
+++ b/pkg/cmd/ruleset/list/list.go
@@ -97,9 +97,15 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
-	repoI, err := opts.BaseRepo()
-	if err != nil {
-		return err
+	var repoI ghrepo.Interface
+
+	// only one of the repo or org context is necessary
+	if opts.Organization == "" {
+		var repoErr error
+		repoI, repoErr = opts.BaseRepo()
+		if repoErr != nil {
+			return repoErr
+		}
 	}
 
 	hostname, _ := ghAuth.DefaultHost()

--- a/pkg/cmd/ruleset/shared/shared.go
+++ b/pkg/cmd/ruleset/shared/shared.go
@@ -24,11 +24,12 @@ type RulesetGraphQL struct {
 }
 
 type RulesetREST struct {
-	Id           int
-	Name         string
-	Target       string
-	Enforcement  string
-	BypassActors []struct {
+	Id                   int
+	Name                 string
+	Target               string
+	Enforcement          string
+	CurrentUserCanBypass string `json:"current_user_can_bypass"`
+	BypassActors         []struct {
 		ActorId    int    `json:"actor_id"`
 		ActorType  string `json:"actor_type"`
 		BypassMode string `json:"bypass_mode"`

--- a/pkg/cmd/ruleset/view/fixtures/rulesetViewRepo.json
+++ b/pkg/cmd/ruleset/view/fixtures/rulesetViewRepo.json
@@ -5,6 +5,7 @@
 	"source_type": "Repository",
 	"source": "my-owner/repo-name",
 	"enforcement": "active",
+	"current_user_can_bypass": "pull_requests_only",
 	"conditions": {
 		"ref_name": {
 			"exclude": [],

--- a/pkg/cmd/ruleset/view/view.go
+++ b/pkg/cmd/ruleset/view/view.go
@@ -200,6 +200,10 @@ func viewRun(opts *ViewOptions) error {
 		fmt.Fprintf(w, "%s\n", rs.Enforcement)
 	}
 
+	if rs.CurrentUserCanBypass != "" {
+		fmt.Fprintf(w, "You can bypass: %s\n", strings.ReplaceAll(rs.CurrentUserCanBypass, "_", " "))
+	}
+
 	fmt.Fprintf(w, "\n%s\n", cs.Bold("Bypass List"))
 	if len(rs.BypassActors) == 0 {
 		fmt.Fprintf(w, "This ruleset cannot be bypassed\n")

--- a/pkg/cmd/ruleset/view/view.go
+++ b/pkg/cmd/ruleset/view/view.go
@@ -113,9 +113,15 @@ func viewRun(opts *ViewOptions) error {
 		return err
 	}
 
-	repoI, err := opts.BaseRepo()
-	if err != nil {
-		return err
+	var repoI ghrepo.Interface
+
+	// only one of the repo or org context is necessary
+	if opts.Organization == "" {
+		var repoErr error
+		repoI, repoErr = opts.BaseRepo()
+		if repoErr != nil {
+			return repoErr
+		}
 	}
 
 	hostname, _ := ghAuth.DefaultHost()

--- a/pkg/cmd/ruleset/view/view_test.go
+++ b/pkg/cmd/ruleset/view/view_test.go
@@ -157,6 +157,7 @@ func Test_viewRun(t *testing.T) {
 	ID: 42
 	Source: my-owner/repo-name (Repository)
 	Enforcement: Active
+	You can bypass: pull requests only
 	
 	Bypass List
 	- OrganizationAdmin (ID: 1), mode: always


### PR DESCRIPTION
Fixes #7699 and adds one more REST API field to the `view` subcommand.

#### Repo context/`--org` flag
A repo context is not necessary if the `--org` flag is used for ruleset subcommands, so this prevents the "repo not found" error from being thrown if the `--org` flag is provided outside of a repo. It also expands the tests to ensure nothing is being missed with `repoI` potentially being undefined. I don't really like this way of fixing this because it relies on `repoI` just not being touched when it shouldn't be, but I think refactoring to avoid that would make the code pretty difficult to read. Open to suggestions though if I'm missing something simple.

#### `current_user_can_bypass` REST API field
This PR also adds in the new `current_user_can_bypass` REST API field, which indicates whether the user making the request can bypass the ruleset. This is only returned by the REST API when queried with a repo context, so it will not be returned when using the `--org` flag, in which case I hide it completely. The three (current) possible display values will end up looking like:

```
You can bypass: never
You can bypass: pull requests only
You can bypass: always
```