### PR TITLE
`release create`: Trim spaces on tag name

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -223,6 +223,7 @@ func createRun(opts *CreateOptions) error {
 			if err != nil {
 				return fmt.Errorf("could not prompt: %w", err)
 			}
+			opts.TagName = strings.TrimSpace(opts.TagName)
 		}
 	}
 


### PR DESCRIPTION
Fixes #7737 
- Trim spaces on interactive tag name input
- Add test


<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
