### PR TITLE
feat(cli): alias gh pr open with gh pr create

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -125,7 +125,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			$ gh pr create --base develop --head monalisa:feature
 		`),
 		Args:    cmdutil.NoArgsQuoteReminder,
-		Aliases: []string{"new"},
+		Aliases: []string{"new", "open"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Finder = shared.NewFinder(f)
 


### PR DESCRIPTION
Open is common terminology in the context of github pull requests, however the gh pr create cmd only supports `new` alias. 

Example of open wording from github docs
`To open a pull request in a public repository...`
`Once a pull request is opened...`
