### PR TITLE
Add per line review comments

### DIFF
--- a/pkg/cmd/pr/review/review.go
+++ b/pkg/cmd/pr/review/review.go
@@ -139,8 +139,8 @@ func NewCmdReview(f *cmdutil.Factory, runF func(*ReviewOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("cannot specify --approve, --request-changes, or --comment when commenting on a file")
 			}
 
-			if len(linesSlice) > 0 && opts.File == "" {
-				return cmdutil.FlagErrorf("must specify --file if --lines is given")
+			if (len(linesSlice) > 0) == (opts.File == "") {
+				return cmdutil.FlagErrorf("either both or neither of --file and --lines must be given")
 			}
 
 			if len(linesSlice) == 1 {

--- a/pkg/cmd/pr/review/review.go
+++ b/pkg/cmd/pr/review/review.go
@@ -135,7 +135,7 @@ func NewCmdReview(f *cmdutil.Factory, runF func(*ReviewOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("need exactly one of --approve, --request-changes, or --comment")
 			}
 
-			if opts.File != 0 && found > 0 {
+			if opts.File != "" && found > 0 {
 				return cmdutil.FlagErrorf("cannot specify --approve, --request-changes, or --comment when commenting on a file")
 			}
 
@@ -148,7 +148,7 @@ func NewCmdReview(f *cmdutil.Factory, runF func(*ReviewOptions) error) *cobra.Co
 			} else if len(linesSlice) == 2 {
 				opts.StartLine = &linesSlice[0]
 				opts.Line = linesSlice[1]
-			} else {
+			} else if len(linesSlice) > 2 {
 				return cmdutil.FlagErrorf("--lines must be either a single line, or a range")
 			}
 

--- a/pkg/cmd/pr/review/review_test.go
+++ b/pkg/cmd/pr/review/review_test.go
@@ -80,6 +80,21 @@ func Test_NewCmdReview(t *testing.T) {
 			},
 		},
 		{
+			name:  "single line comment",
+			args:  "--file test-file.txt --lines 5",
+			isTTY: true,
+			want: ReviewOptions{
+				File: "test-file.txt",
+				Line: 5,
+			},
+		},
+		{
+			name:    "lines parse error",
+			args:    "--file test-file.txt --lines 1,2,3",
+			isTTY:   true,
+			wantErr: "--lines must be either a single line, or a range",
+		},
+		{
 			name:    "no argument with --repo override",
 			args:    "-R owner/repo",
 			isTTY:   true,
@@ -120,6 +135,24 @@ func Test_NewCmdReview(t *testing.T) {
 			args:    "--body 'test' --body-file 'test-file.txt'",
 			isTTY:   true,
 			wantErr: "specify only one of `--body` or `--body-file`",
+		},
+		{
+			name:    "file with no lines",
+			args:    "--file test-file.txt",
+			isTTY:   true,
+			wantErr: "either both or neither of --file and --lines must be given",
+		},
+		{
+			name:    "lines with no file",
+			args:    "--lines 5,10",
+			isTTY:   true,
+			wantErr: "either both or neither of --file and --lines must be given",
+		},
+		{
+			name:    "file comment with approve",
+			args:    "--file test-file.txt --lines 5,10 --approve",
+			isTTY:   true,
+			wantErr: "cannot specify --approve, --request-changes, or --comment when commenting on a file",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds the ability to do the following:
```
$ gh pr review --file README.md --lines 5,6 --body "this is great"
```

This is a more modest PR than #7806. I'm hoping to generate discussion, and get
this merged before moving on to the more complicated user interface design
problems that suggusted changes pose. This also sidesteps the upstream bug in
diffparser.

Some open questions that I would like feedback on from the GitHub developers, or
other interested parties:
* I put this functionality under the `pr review` command because it is named
  that way in the API, but it could conceivably go under the `pr comment`
  subcommand as well.
* Currently, I believe that the line comment is created, but is pending the
  completion of the review. Should the success message indicate this to users?
  Perhaps a final interactive `gh pr review` should also list the number of
  pending line comments.
* Should there be a quicker way to add both a line comment, and then finish the
  review in one command?

See also #5904, #5905.
