### PR TITLE
port repo edit prompts

### DIFF
--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -14,7 +14,7 @@ import (
 //go:generate moq -rm -out prompter_mock.go . Prompter
 type Prompter interface {
 	Select(string, string, []string) (int, error)
-	MultiSelect(string, []string, []string) ([]int, error)
+	MultiSelect(prompt string, defaults []string, options []string) ([]int, error)
 	Input(string, string) (string, error)
 	InputHostname() (string, error)
 	Password(string) (string, error)

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -441,14 +441,16 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 			if r.RebaseMergeAllowed {
 				defaultMergeOptions = append(defaultMergeOptions, allowRebaseMerge)
 			}
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.MultiSelect{
-				Message: "Allowed merge strategies",
-				Default: defaultMergeOptions,
-				Options: []string{allowMergeCommits, allowSquashMerge, allowRebaseMerge},
-			}, &selectedMergeOptions)
+			mergeOpts := []string{allowMergeCommits, allowSquashMerge, allowRebaseMerge}
+			selected, err := opts.Prompter.MultiSelect(
+				"Allowed merge strategies",
+				defaultMergeOptions,
+				mergeOpts)
 			if err != nil {
 				return err
+			}
+			for _, i := range selected {
+				selectedMergeOptions = append(selectedMergeOptions, mergeOpts[i])
 			}
 			enableMergeCommit := isIncluded(allowMergeCommits, selectedMergeOptions)
 			opts.Edits.EnableMergeCommit = &enableMergeCommit

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -319,6 +319,7 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 	}
 	for _, c := range choices {
 		switch c {
+		// TODO these initial assignments are no-ops; delete them
 		case optionDescription:
 			opts.Edits.Description = &r.Description
 			answer, err := opts.Prompter.Input("Description of the repository", r.Description)
@@ -328,14 +329,11 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 			opts.Edits.Description = &answer
 		case optionHomePageURL:
 			opts.Edits.Homepage = &r.HomepageURL
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.Input{
-				Message: "Repository home page URL",
-				Default: r.HomepageURL,
-			}, opts.Edits.Homepage)
+			a, err := opts.Prompter.Input("Repository home page URL", r.HomepageURL)
 			if err != nil {
 				return err
 			}
+			opts.Edits.Homepage = &a
 		case optionTopics:
 			addTopics, err := opts.Prompter.Input("Add topics?(csv format)", "")
 			if err != nil {
@@ -356,44 +354,32 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 			}
 		case optionDefaultBranchName:
 			opts.Edits.DefaultBranch = &r.DefaultBranchRef.Name
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.Input{
-				Message: "Default branch name",
-				Default: r.DefaultBranchRef.Name,
-			}, opts.Edits.DefaultBranch)
+			name, err := opts.Prompter.Input("Default branch name", r.DefaultBranchRef.Name)
 			if err != nil {
 				return err
 			}
+			opts.Edits.DefaultBranch = &name
 		case optionWikis:
 			opts.Edits.EnableWiki = &r.HasWikiEnabled
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.Confirm{
-				Message: "Enable Wikis?",
-				Default: r.HasWikiEnabled,
-			}, opts.Edits.EnableWiki)
+			c, err := opts.Prompter.Confirm("Enable Wikis?", r.HasWikiEnabled)
 			if err != nil {
 				return err
 			}
+			opts.Edits.EnableWiki = &c
 		case optionIssues:
 			opts.Edits.EnableIssues = &r.HasIssuesEnabled
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.Confirm{
-				Message: "Enable Issues?",
-				Default: r.HasIssuesEnabled,
-			}, opts.Edits.EnableIssues)
+			a, err := opts.Prompter.Confirm("Enable Issues?", r.HasIssuesEnabled)
 			if err != nil {
 				return err
 			}
+			opts.Edits.EnableIssues = &a
 		case optionProjects:
 			opts.Edits.EnableProjects = &r.HasProjectsEnabled
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.Confirm{
-				Message: "Enable Projects?",
-				Default: r.HasProjectsEnabled,
-			}, opts.Edits.EnableProjects)
+			a, err := opts.Prompter.Confirm("Enable Projects?", r.HasProjectsEnabled)
 			if err != nil {
 				return err
 			}
+			opts.Edits.EnableProjects = &a
 		case optionVisibility:
 			opts.Edits.Visibility = &r.Visibility
 			visibilityOptions := []string{"public", "private", "internal"}
@@ -463,14 +449,11 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 			opts.Edits.DeleteBranchOnMerge = &c
 		case optionTemplateRepo:
 			opts.Edits.IsTemplate = &r.IsTemplate
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.Confirm{
-				Message: "Convert into a template repository?",
-				Default: r.IsTemplate,
-			}, opts.Edits.IsTemplate)
+			c, err := opts.Prompter.Confirm("Convert into a template repository?", r.IsTemplate)
 			if err != nil {
 				return err
 			}
+			opts.Edits.IsTemplate = &c
 		case optionAllowForking:
 			opts.Edits.AllowForking = &r.ForkingAllowed
 			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -394,16 +394,6 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 			if err != nil {
 				return err
 			}
-		case optionDiscussions:
-			opts.Edits.EnableDiscussions = &r.HasDiscussionsEnabled
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.Confirm{
-				Message: "Enable Discussions?",
-				Default: r.HasDiscussionsEnabled,
-			}, opts.Edits.EnableDiscussions)
-			if err != nil {
-				return err
-			}
 		case optionVisibility:
 			opts.Edits.Visibility = &r.Visibility
 			visibilityOptions := []string{"public", "private", "internal"}

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -319,16 +319,13 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 	}
 	for _, c := range choices {
 		switch c {
-		// TODO these initial assignments are no-ops; delete them
 		case optionDescription:
-			opts.Edits.Description = &r.Description
 			answer, err := opts.Prompter.Input("Description of the repository", r.Description)
 			if err != nil {
 				return err
 			}
 			opts.Edits.Description = &answer
 		case optionHomePageURL:
-			opts.Edits.Homepage = &r.HomepageURL
 			a, err := opts.Prompter.Input("Repository home page URL", r.HomepageURL)
 			if err != nil {
 				return err
@@ -353,35 +350,30 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 				}
 			}
 		case optionDefaultBranchName:
-			opts.Edits.DefaultBranch = &r.DefaultBranchRef.Name
 			name, err := opts.Prompter.Input("Default branch name", r.DefaultBranchRef.Name)
 			if err != nil {
 				return err
 			}
 			opts.Edits.DefaultBranch = &name
 		case optionWikis:
-			opts.Edits.EnableWiki = &r.HasWikiEnabled
 			c, err := opts.Prompter.Confirm("Enable Wikis?", r.HasWikiEnabled)
 			if err != nil {
 				return err
 			}
 			opts.Edits.EnableWiki = &c
 		case optionIssues:
-			opts.Edits.EnableIssues = &r.HasIssuesEnabled
 			a, err := opts.Prompter.Confirm("Enable Issues?", r.HasIssuesEnabled)
 			if err != nil {
 				return err
 			}
 			opts.Edits.EnableIssues = &a
 		case optionProjects:
-			opts.Edits.EnableProjects = &r.HasProjectsEnabled
 			a, err := opts.Prompter.Confirm("Enable Projects?", r.HasProjectsEnabled)
 			if err != nil {
 				return err
 			}
 			opts.Edits.EnableProjects = &a
 		case optionVisibility:
-			opts.Edits.Visibility = &r.Visibility
 			visibilityOptions := []string{"public", "private", "internal"}
 			selected, err := opts.Prompter.Select("Visibility", strings.ToLower(r.Visibility), visibilityOptions)
 			if err != nil {
@@ -448,7 +440,6 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 			}
 			opts.Edits.DeleteBranchOnMerge = &c
 		case optionTemplateRepo:
-			opts.Edits.IsTemplate = &r.IsTemplate
 			c, err := opts.Prompter.Confirm("Convert into a template repository?", r.IsTemplate)
 			if err != nil {
 				return err

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
@@ -19,7 +18,6 @@ import (
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/cli/cli/v2/pkg/prompt"
 	"github.com/cli/cli/v2/pkg/set"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -446,15 +444,13 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 			}
 			opts.Edits.IsTemplate = &c
 		case optionAllowForking:
-			opts.Edits.AllowForking = &r.ForkingAllowed
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.Confirm{
-				Message: "Allow forking (of an organization repository)?",
-				Default: r.ForkingAllowed,
-			}, opts.Edits.AllowForking)
+			c, err := opts.Prompter.Confirm(
+				"Allow forking (of an organization repository)?",
+				r.ForkingAllowed)
 			if err != nil {
 				return err
 			}
+			opts.Edits.AllowForking = &c
 		}
 	}
 	return nil

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -458,24 +458,19 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 			}
 
 			opts.Edits.EnableAutoMerge = &r.AutoMergeAllowed
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.Confirm{
-				Message: "Enable Auto Merge?",
-				Default: r.AutoMergeAllowed,
-			}, opts.Edits.EnableAutoMerge)
+			c, err := opts.Prompter.Confirm("Enable Auto Merge?", r.AutoMergeAllowed)
 			if err != nil {
 				return err
 			}
+			opts.Edits.EnableAutoMerge = &c
 
 			opts.Edits.DeleteBranchOnMerge = &r.DeleteBranchOnMerge
-			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter
-			err = prompt.SurveyAskOne(&survey.Confirm{
-				Message: "Automatically delete head branches after merging?",
-				Default: r.DeleteBranchOnMerge,
-			}, opts.Edits.DeleteBranchOnMerge)
+			c, err = opts.Prompter.Confirm(
+				"Automatically delete head branches after merging?", r.DeleteBranchOnMerge)
 			if err != nil {
 				return err
 			}
+			opts.Edits.DeleteBranchOnMerge = &c
 		case optionTemplateRepo:
 			opts.Edits.IsTemplate = &r.IsTemplate
 			//nolint:staticcheck // SA1019: prompt.SurveyAskOne is deprecated: use Prompter


### PR DESCRIPTION
This PR ports `repo edit` to the new prompter. While doing this I noticed a severe lack of test coverage and some dead code so I dealt with that.

Part of #6255
