### PR TITLE
Automatically open a codespace after creating it Fixes #7813

### DIFF
--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -70,6 +70,7 @@ type createOptions struct {
 	retentionPeriod   NullableDuration
 	displayName       string
 	useWeb            bool
+	connect           bool
 }
 
 func newCreateCmd(app *App) *cobra.Command {
@@ -107,6 +108,7 @@ func newCreateCmd(app *App) *cobra.Command {
 	createCmd.Flags().Var(&opts.retentionPeriod, "retention-period", "allowed time after shutting down before the codespace is automatically deleted (maximum 30 days), e.g. \"1h\", \"72h\"")
 	createCmd.Flags().StringVar(&opts.devContainerPath, "devcontainer-path", "", "path to the devcontainer.json file to use when creating codespace")
 	createCmd.Flags().StringVarP(&opts.displayName, "display-name", "d", "", "display name for the codespace")
+	createCmd.Flags().BoolVarP(&opts.connect, "connect", "c", false, "connect to the newly created codespace")
 
 	return createCmd
 }
@@ -327,6 +329,23 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 
 	if a.io.IsStderrTTY() && codespace.IdleTimeoutNotice != "" {
 		fmt.Fprintln(a.io.ErrOut, cs.Yellow("Notice:"), codespace.IdleTimeoutNotice)
+	}
+
+	// if the user provided a connect argument, we should ssh to the codespace after creating it
+	if opts.connect {
+		sshArgs := []string{}
+		sshOpts := sshOptions{
+			selector: &CodespaceSelector{
+				api: a.apiClient,
+
+				repoName:      userInputs.Repository,
+				codespaceName: codespace.Name,
+				repoOwner:     repository.Owner.Login,
+			},
+		}
+		if err := a.SSH(ctx, sshArgs, sshOpts); err != nil {
+			return fmt.Errorf("error connecting to codespace: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -335,31 +335,19 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		fmt.Fprintln(a.io.ErrOut, cs.Yellow("Notice:"), codespace.IdleTimeoutNotice)
 	}
 
-	// if the user provided a --open ssh argument, we should ssh to the codespace after creating it
-	if opts.open == "ssh" {
-		sshArgs := []string{}
-		sshOpts := sshOptions{
-			selector: &CodespaceSelector{
-				api: a.apiClient,
-
-				repoName:      userInputs.Repository,
-				codespaceName: codespace.Name,
-				repoOwner:     repository.Owner.Login,
-			},
-		}
-		if err := a.SSH(ctx, sshArgs, sshOpts); err != nil {
-			return fmt.Errorf("error connecting to codespace: %w", err)
-		}
-	}
-	// if the user provided a --open code argument, we should open in VS Code after creating it
 	selector := &CodespaceSelector{
-		api: a.apiClient,
-
+		api:           a.apiClient,
 		repoName:      userInputs.Repository,
 		codespaceName: codespace.Name,
 		repoOwner:     repository.Owner.Login,
 	}
-	if opts.open == "code" {
+
+	switch opts.open {
+	case "ssh":
+		if err := a.SSH(ctx, []string{}, sshOptions{selector: selector}); err != nil {
+			return fmt.Errorf("error connecting to codespace: %w", err)
+		}
+	case "code":
 		if err := a.VSCode(ctx, selector, false, false); err != nil {
 			return fmt.Errorf("error opening codespace in VS Code: %w", err)
 		}

--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -70,7 +70,7 @@ type createOptions struct {
 	retentionPeriod   NullableDuration
 	displayName       string
 	useWeb            bool
-	connect           bool
+	open              string
 }
 
 func newCreateCmd(app *App) *cobra.Command {
@@ -108,7 +108,7 @@ func newCreateCmd(app *App) *cobra.Command {
 	createCmd.Flags().Var(&opts.retentionPeriod, "retention-period", "allowed time after shutting down before the codespace is automatically deleted (maximum 30 days), e.g. \"1h\", \"72h\"")
 	createCmd.Flags().StringVar(&opts.devContainerPath, "devcontainer-path", "", "path to the devcontainer.json file to use when creating codespace")
 	createCmd.Flags().StringVarP(&opts.displayName, "display-name", "d", "", "display name for the codespace")
-	createCmd.Flags().BoolVarP(&opts.connect, "connect", "c", false, "connect to the newly created codespace")
+	createCmd.Flags().StringVarP(&opts.open, "open", "o", "", "open and connect to the newly created codespace through SSH or VS Code, can be one of {ssh, code}")
 
 	return createCmd
 }
@@ -132,6 +132,10 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 
 	if opts.useWeb && userInputs.Repository == "" {
 		return a.browser.Browse(fmt.Sprintf("%s/codespaces/new", a.apiClient.ServerURL()))
+	}
+
+	if opts.open != "" && opts.open != "ssh" && opts.open != "code" {
+		return fmt.Errorf("invalid value for --open: %q. Can be one of {ssh, code}", opts.open)
 	}
 
 	promptForRepoAndBranch := userInputs.Repository == "" && !opts.useWeb
@@ -331,8 +335,8 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		fmt.Fprintln(a.io.ErrOut, cs.Yellow("Notice:"), codespace.IdleTimeoutNotice)
 	}
 
-	// if the user provided a connect argument, we should ssh to the codespace after creating it
-	if opts.connect {
+	// if the user provided a --open ssh argument, we should ssh to the codespace after creating it
+	if opts.open == "ssh" {
 		sshArgs := []string{}
 		sshOpts := sshOptions{
 			selector: &CodespaceSelector{
@@ -345,6 +349,19 @@ func (a *App) Create(ctx context.Context, opts createOptions) error {
 		}
 		if err := a.SSH(ctx, sshArgs, sshOpts); err != nil {
 			return fmt.Errorf("error connecting to codespace: %w", err)
+		}
+	}
+	// if the user provided a --open code argument, we should open in VS Code after creating it
+	selector := &CodespaceSelector{
+		api: a.apiClient,
+
+		repoName:      userInputs.Repository,
+		codespaceName: codespace.Name,
+		repoOwner:     repository.Owner.Login,
+	}
+	if opts.open == "code" {
+		if err := a.VSCode(ctx, selector, false, false); err != nil {
+			return fmt.Errorf("error opening codespace in VS Code: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

This change is intended to add functionality to the `gh cs create` command whereby passing either the `--open` or `-o` flag to the create command will open and connect via SSH or VS Code to the newly created codespace #7813 

Ex. 
`gh cs create --open code` to open in VS Code
 `gh cs create --open ssh` to open SSH tunnel