### PR TITLE
add missing `ls` aliases to `list` subcommands

### DIFF
--- a/pkg/cmd/cache/list/list.go
+++ b/pkg/cmd/cache/list/list.go
@@ -47,7 +47,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		# List caches sorted by least recently accessed
 		$ gh cache list --sort last_accessed_at --order asc
 		`),
-		Args: cobra.NoArgs,
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/org/list/list.go
+++ b/pkg/cmd/org/list/list.go
@@ -39,6 +39,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			# List more organizations
 			$ gh org list --limit 100
 		`),
+		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.Limit < 1 {
 				return cmdutil.FlagErrorf("invalid limit: %v", opts.Limit)

--- a/pkg/cmd/project/list/list.go
+++ b/pkg/cmd/project/list/list.go
@@ -33,8 +33,8 @@ type listConfig struct {
 func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.Command {
 	opts := listOpts{}
 	listCmd := &cobra.Command{
-		Short: "List the projects for an owner",
 		Use:   "list",
+		Short: "List the projects for an owner",
 		Example: heredoc.Doc(`
 			# list the current user's projects
 			gh project list
@@ -42,6 +42,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 			# list the projects for org github including closed projects
 			gh project list --owner github --closed
 		`),
+		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := client.New(f)
 			if err != nil {

--- a/pkg/cmd/ruleset/list/list.go
+++ b/pkg/cmd/ruleset/list/list.go
@@ -62,7 +62,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			# List rulesets in an organization
 			$ gh ruleset list --org org-name
 		`),
-		Args: cobra.ExactArgs(0),
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if repoOverride, _ := cmd.Flags().GetString("repo"); repoOverride != "" && opts.Organization != "" {
 				return cmdutil.FlagErrorf("only one of --repo and --org may be specified")


### PR DESCRIPTION
following from prior work like #5214 and #5480
