### PR TITLE
WIP: gh auth configure-docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 *.swp
 
 vendor/
+
+gh
+docker-credential-gh

--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -18,12 +18,14 @@ import (
 	"github.com/cli/cli/v2/internal/build"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/update"
+	credhelper "github.com/cli/cli/v2/pkg/cmd/auth/docker-cred-helper"
 	"github.com/cli/cli/v2/pkg/cmd/factory"
 	"github.com/cli/cli/v2/pkg/cmd/root"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/utils"
 	"github.com/cli/safeexec"
+	"github.com/docker/docker-credential-helpers/credentials"
 	"github.com/mattn/go-isatty"
 	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
@@ -85,6 +87,13 @@ func mainRun() exitCode {
 	// terminal. With this, a user can clone a repo (or take other actions) directly from explorer.
 	if len(os.Args) > 1 && os.Args[1] != "" {
 		cobra.MousetrapHelpText = ""
+	}
+
+	if filepath.Base(os.Args[0]) == "docker-credential-gh" {
+		// We're being invoked as the Docker credential helper.
+		// Run the credhelper command to print the token, and exit.
+		credentials.Serve(credhelper.CredHelper())
+		return exitOK
 	}
 
 	rootCmd, err := root.NewCmdRoot(cmdFactory, buildVersion, buildDate)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/cli/safeexec v1.0.1
 	github.com/cpuguy83/go-md2man/v2 v2.0.2
 	github.com/creack/pty v1.1.18
+	github.com/docker/cli v24.0.5+incompatible
 	github.com/docker/docker-credential-helpers v0.8.0
 	github.com/gabriel-vasile/mimetype v1.4.2
 	github.com/gdamore/tcell/v2 v2.5.4
@@ -56,6 +57,7 @@ require (
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
+	github.com/docker/docker v24.0.5+incompatible // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
@@ -73,10 +75,12 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.12.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e // indirect
 	github.com/yuin/goldmark v1.4.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/cli/safeexec v1.0.1
 	github.com/cpuguy83/go-md2man/v2 v2.0.2
 	github.com/creack/pty v1.1.18
+	github.com/docker/docker-credential-helpers v0.8.0
 	github.com/gabriel-vasile/mimetype v1.4.2
 	github.com/gdamore/tcell/v2 v2.5.4
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
+github.com/docker/cli v24.0.5+incompatible h1:WeBimjvS0eKdH4Ygx+ihVq1Q++xg36M/rMi4aXAvodc=
+github.com/docker/cli v24.0.5+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/docker v24.0.5+incompatible h1:WmgcE4fxyI6EEXxBRxsHnZXrO1pQ3smi0k/jho4HLeY=
+github.com/docker/docker v24.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.0 h1:YQFtbBQb4VrpoPxhFuzEBPQ9E16qz5SpHLS+uswaCp8=
 github.com/docker/docker-credential-helpers v0.8.0/go.mod h1:UGFXcuoQ5TxPiB54nHOZ32AWRqQdECoh/Mg0AlEYb40=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
@@ -132,6 +136,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/tview v0.0.0-20221029100920-c4a7e501810d h1:jKIUJdMcIVGOSHi6LSqJqw9RqblyblE2ZrHvFbWR3S0=
@@ -146,6 +152,8 @@ github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9 h1:nCBaIs5/R0HFP
 github.com/shurcooL/githubv4 v0.0.0-20230424031643-6cea62ecd5a9/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 h1:B1PEwpArrNp4dkQrfxh/abbBAOZBVp0ds+fBEOUOqOc=
 github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/jsonrpc2 v0.1.0 h1:ohJHjZ+PcaLxDUjqk2NC3tIGsVa5bXThe1ZheSXOjuk=
 github.com/sourcegraph/jsonrpc2 v0.1.0/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
@@ -200,6 +208,7 @@ golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
+github.com/docker/docker-credential-helpers v0.8.0 h1:YQFtbBQb4VrpoPxhFuzEBPQ9E16qz5SpHLS+uswaCp8=
+github.com/docker/docker-credential-helpers v0.8.0/go.mod h1:UGFXcuoQ5TxPiB54nHOZ32AWRqQdECoh/Mg0AlEYb40=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	authConfigureDockerCmd "github.com/cli/cli/v2/pkg/cmd/auth/configure-docker"
 	gitCredentialCmd "github.com/cli/cli/v2/pkg/cmd/auth/gitcredential"
 	authLoginCmd "github.com/cli/cli/v2/pkg/cmd/auth/login"
 	authLogoutCmd "github.com/cli/cli/v2/pkg/cmd/auth/logout"
@@ -28,6 +29,7 @@ func NewCmdAuth(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(gitCredentialCmd.NewCmdCredential(f, nil))
 	cmd.AddCommand(authSetupGitCmd.NewCmdSetupGit(f, nil))
 	cmd.AddCommand(authTokenCmd.NewCmdToken(f, nil))
+	cmd.AddCommand(authConfigureDockerCmd.NewCmdConfigureDocker(f, nil))
 
 	return cmd
 }

--- a/pkg/cmd/auth/configure-docker/configure_docker.go
+++ b/pkg/cmd/auth/configure-docker/configure_docker.go
@@ -1,0 +1,239 @@
+package configure_docker
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/git"
+	"github.com/cli/cli/v2/internal/browser"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghinstance"
+	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	ghAuth "github.com/cli/go-gh/v2/pkg/auth"
+	"github.com/spf13/cobra"
+)
+
+type ConfigureDockerOptions struct {
+	IO         *iostreams.IOStreams
+	Config     func() (config.Config, error)
+	HttpClient func() (*http.Client, error)
+	GitClient  *git.Client
+	Prompter   shared.Prompt
+	Browser    browser.Browser
+
+	MainExecutable string
+
+	Interactive bool
+
+	Hostname        string
+	Scopes          []string
+	Token           string
+	Web             bool
+	GitProtocol     string
+	InsecureStorage bool
+}
+
+func NewCmdConfigureDocker(f *cmdutil.Factory, runF func(*ConfigureDockerOptions) error) *cobra.Command {
+	opts := &ConfigureDockerOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		HttpClient: f.HttpClient,
+		GitClient:  f.GitClient,
+		Prompter:   f.Prompter,
+		Browser:    f.Browser,
+	}
+
+	var tokenStdin bool
+
+	cmd := &cobra.Command{
+		Use:   "configure-docker",
+		Args:  cobra.ExactArgs(0),
+		Short: "Configure a Docker credential helper.",
+		Long: heredoc.Docf(`
+			Configure a Docker credential helper.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# configure the Docker credential helper.
+			$ gh auth configure-docker
+
+			# authenticate against github.com by reading the token from a file
+			$ gh auth configure-docker --with-token < mytoken.txt
+
+			# authenticate with a specific GitHub instance
+			$ gh auth configure-docker --hostname enterprise.internal
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if tokenStdin && opts.Web {
+				return cmdutil.FlagErrorf("specify only one of `--web` or `--with-token`")
+			}
+			if tokenStdin && len(opts.Scopes) > 0 {
+				return cmdutil.FlagErrorf("specify only one of `--scopes` or `--with-token`")
+			}
+
+			if tokenStdin {
+				defer opts.IO.In.Close()
+				token, err := io.ReadAll(opts.IO.In)
+				if err != nil {
+					return fmt.Errorf("failed to read token from standard input: %w", err)
+				}
+				opts.Token = strings.TrimSpace(string(token))
+			}
+
+			if opts.IO.CanPrompt() && opts.Token == "" {
+				opts.Interactive = true
+			}
+
+			if cmd.Flags().Changed("hostname") {
+				if err := ghinstance.HostnameValidator(opts.Hostname); err != nil {
+					return cmdutil.FlagErrorf("error parsing hostname: %w", err)
+				}
+			}
+
+			if opts.Hostname == "" && (!opts.Interactive || opts.Web) {
+				opts.Hostname, _ = ghAuth.DefaultHost()
+			}
+
+			opts.MainExecutable = f.Executable()
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return configureDockerRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "The hostname of the GitHub instance to authenticate with")
+	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", []string{"write:packages"}, "Additional authentication scopes to request")
+	cmd.Flags().BoolVar(&tokenStdin, "with-token", false, "Read token from standard input")
+	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open a browser to authenticate")
+	cmd.Flags().BoolVar(&opts.InsecureStorage, "insecure-storage", false, "Save authentication credentials in plain text instead of credential store")
+	return cmd
+}
+
+func configureDockerRun(opts *ConfigureDockerOptions) error {
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+	authCfg := cfg.Authentication()
+
+	hostname := opts.Hostname
+	if opts.Interactive && hostname == "" {
+		var err error
+		hostname, err = promptForHostname(opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	// The go-gh Config object currently does not support case-insensitive lookups for host names,
+	// so normalize the host name case here before performing any lookups with it or persisting it.
+	// https://github.com/cli/go-gh/pull/105
+	hostname = strings.ToLower(hostname)
+
+	if src, writeable := shared.AuthTokenWriteable(authCfg, hostname); !writeable {
+		fmt.Fprintf(opts.IO.ErrOut, "The value of the %s environment variable is being used for authentication.\n", src)
+		fmt.Fprint(opts.IO.ErrOut, "To have GitHub CLI store credentials instead, first clear the value from the environment.\n")
+		return cmdutil.SilentError
+	}
+
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	if opts.Token != "" {
+		if err := shared.HasMinimumScopes(httpClient, hostname, opts.Token); err != nil {
+			return fmt.Errorf("error validating token: %w", err)
+		}
+		// Adding a user key ensures that a nonempty host section gets written to the config file.
+		if err := authCfg.Login(hostname, "x-access-token", opts.Token, opts.GitProtocol, !opts.InsecureStorage); err != nil {
+			return err
+		}
+	} else {
+		existingToken, _ := authCfg.Token(hostname)
+		if existingToken != "" && opts.Interactive {
+			if err := shared.HasMinimumScopes(httpClient, hostname, existingToken, opts.Scopes...); err == nil {
+				keepGoing, err := opts.Prompter.Confirm(fmt.Sprintf("You're already logged into %s. Do you want to re-authenticate?", hostname), false)
+				if err != nil {
+					return err
+				}
+				if !keepGoing {
+					return nil
+				}
+			}
+		}
+		if err := shared.Login(&shared.LoginOptions{
+			IO:            opts.IO,
+			Config:        authCfg,
+			HTTPClient:    httpClient,
+			Hostname:      hostname,
+			Interactive:   opts.Interactive,
+			Web:           opts.Web,
+			Scopes:        opts.Scopes,
+			Executable:    opts.MainExecutable,
+			GitProtocol:   opts.GitProtocol,
+			Prompter:      opts.Prompter,
+			GitClient:     opts.GitClient,
+			Browser:       opts.Browser,
+			SecureStorage: !opts.InsecureStorage,
+		}); err != nil {
+			return err
+		}
+	}
+
+	// With creds in place, we can now configure the Docker credential helper.
+
+	// Create a symlink at the executable's current path, which is assumed to be on $PATH.
+	ex, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("getting executable location: %w", err)
+	}
+	// If chainctl is not on PATH, then symlinking docker-credential-cgr
+	// won't work when docker tries to execute it, so fail instead.
+	onPath := false
+	for _, pathEl := range strings.Split(os.Getenv("PATH"), string(os.PathListSeparator)) {
+		if filepath.Dir(ex) == filepath.Clean(pathEl) {
+			onPath = true
+			break
+		}
+	}
+	if !onPath {
+		return errors.New("gh is not on PATH")
+	}
+	if err := os.Symlink(ex, filepath.Join(filepath.Dir(ex), "docker-credential-gh")); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("creating symlink: %w", err)
+	}
+
+	// TODO: update ~/.docker/config.json to add .credHelpers.[ghcr.io] = "gh"
+
+	return nil
+}
+
+func promptForHostname(opts *ConfigureDockerOptions) (string, error) {
+	options := []string{"GitHub.com", "GitHub Enterprise Server"}
+	hostType, err := opts.Prompter.Select(
+		"What account do you want to log into?",
+		options[0],
+		options)
+	if err != nil {
+		return "", err
+	}
+
+	isEnterprise := hostType == 1
+
+	hostname := ghinstance.Default()
+	if isEnterprise {
+		hostname, err = opts.Prompter.InputHostname()
+	}
+
+	return hostname, err
+}

--- a/pkg/cmd/auth/docker-cred-helper/credhelper.go
+++ b/pkg/cmd/auth/docker-cred-helper/credhelper.go
@@ -1,0 +1,34 @@
+package credhelper
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+var errNotImplemented = errors.New("not implemented")
+
+type helper struct{}
+
+func CredHelper() credentials.Helper { return helper{} }
+
+func (helper) Add(*credentials.Credentials) error { return errNotImplemented }
+func (helper) Delete(string) error                { return errNotImplemented }
+func (helper) List() (map[string]string, error)   { return nil, errNotImplemented }
+
+func (h helper) Get(serverURL string) (string, string, error) {
+	cfg, err := config.NewConfig() // TODO
+	if err != nil {
+		return "", "", err
+	}
+	authCfg := cfg.Authentication()
+
+	hostname, _ := authCfg.DefaultHost()
+	val, _ := authCfg.TokenFromKeyring(hostname)
+	if val == "" {
+		return "", "", fmt.Errorf("no oauth token")
+	}
+	return "_token", val, nil
+}


### PR DESCRIPTION
Opening this as a proof of concept, to keep the discussion going.

Fixes https://github.com/cli/cli/issues/5150

This assumes `gh` is on `PATH`, to be able to create a sibling symlink also on `PATH`. To test this, you need to:

```sh
go build ./cmd/gh
PATH=$(pwd):$PATH gh auth configure-docker
# see ./docker-credential-gh created as a symlink to ./gh
docker push ghcr.io/<me>/<whatever>
```

If the user doesn't have permission to write the symlink to `PATH`, `configure-docker` fails.

When installed in the normal way (e.g., `brew`), the flow is:

```sh
gh auth configure-docker  # pops up a browser asking for `write:packages` scope
docker push ghcr.io/<me>/<whatever>
```

Open questions / issues:
- this uses Docker's credhelper CLI scaffolding, which isn't strictly necessary but it removes some boilerplate; would you prefer to use `gh`'s CLI scaffolding here instead?
- we probably need a better error message when the symlink can't be created, or on Windows, or other cases where it can fail.
- need to write `~/.docker/config.json`, you can do it manually for now.
- we can have the credhelper detect a missing/insufficient/expired token and initiate the browser login flow, if you want.

Let me know if this is on the right track, and I can put some more work into it.

cc @mislav 