### PR TITLE
update(run): Use attempt input when fetching jobs

### DIFF
--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -429,7 +429,7 @@ type JobsPayload struct {
 	Jobs       []Job
 }
 
-func GetJobs(client *api.Client, repo ghrepo.Interface, run *Run) ([]Job, error) {
+func GetJobs(client *api.Client, repo ghrepo.Interface, run *Run, attempt uint64) ([]Job, error) {
 	if run.Jobs != nil {
 		return run.Jobs, nil
 	}
@@ -437,6 +437,10 @@ func GetJobs(client *api.Client, repo ghrepo.Interface, run *Run) ([]Job, error)
 	query := url.Values{}
 	query.Set("per_page", "100")
 	jobsPath := fmt.Sprintf("%s?%s", run.JobsURL, query.Encode())
+
+	if attempt > 0 {
+		jobsPath = fmt.Sprintf("repos/%s/actions/runs/%d/attempts/%d/jobs?%s", ghrepo.FullName(repo), run.ID, attempt, query.Encode())
+	}
 
 	for jobsPath != "" {
 		var resp JobsPayload

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -221,7 +221,7 @@ func runView(opts *ViewOptions) error {
 
 	if shouldFetchJobs(opts) {
 		opts.IO.StartProgressIndicator()
-		jobs, err = shared.GetJobs(client, repo, run)
+		jobs, err = shared.GetJobs(client, repo, run, attempt)
 		opts.IO.StopProgressIndicator()
 		if err != nil {
 			return err
@@ -259,7 +259,7 @@ func runView(opts *ViewOptions) error {
 
 	if selectedJob == nil && len(jobs) == 0 {
 		opts.IO.StartProgressIndicator()
-		jobs, err = shared.GetJobs(client, repo, run)
+		jobs, err = shared.GetJobs(client, repo, run, attempt)
 		opts.IO.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("failed to get jobs: %w", err)

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -256,7 +256,7 @@ func TestViewRun(t *testing.T) {
 												"name": "REPO"}}
 				]}}}}`))
 				reg.Register(
-					httpmock.REST("GET", "runs/3/jobs"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/3/attempts/3/jobs"),
 					httpmock.JSONResponse(shared.JobsPayload{
 						Jobs: []shared.Job{
 							shared.SuccessfulJob,
@@ -369,7 +369,7 @@ func TestViewRun(t *testing.T) {
 					httpmock.GraphQL(`query PullRequestForRun`),
 					httpmock.StringResponse(``))
 				reg.Register(
-					httpmock.REST("GET", "runs/3/jobs"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/3/attempts/3/jobs"),
 					httpmock.JSONResponse(shared.JobsPayload{}))
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/123"),
@@ -442,7 +442,7 @@ func TestViewRun(t *testing.T) {
 					httpmock.GraphQL(`query PullRequestForRun`),
 					httpmock.StringResponse(``))
 				reg.Register(
-					httpmock.REST("GET", "runs/3/jobs"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/3/attempts/3/jobs"),
 					httpmock.JSONResponse(shared.JobsPayload{
 						Jobs: []shared.Job{
 							shared.SuccessfulJob,
@@ -616,7 +616,7 @@ func TestViewRun(t *testing.T) {
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/3/attempts/3"),
 					httpmock.JSONResponse(shared.SuccessfulRun))
 				reg.Register(
-					httpmock.REST("GET", "runs/3/jobs"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/3/attempts/3/jobs"),
 					httpmock.JSONResponse(shared.JobsPayload{
 						Jobs: []shared.Job{
 							shared.SuccessfulJob,
@@ -846,7 +846,7 @@ func TestViewRun(t *testing.T) {
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/1234/attempts/3"),
 					httpmock.JSONResponse(shared.FailedRun))
 				reg.Register(
-					httpmock.REST("GET", "runs/1234/jobs"),
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/1234/attempts/3/jobs"),
 					httpmock.JSONResponse(shared.JobsPayload{
 						Jobs: []shared.Job{
 							shared.SuccessfulJob,

--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -28,6 +28,7 @@ type WatchOptions struct {
 	RunID      string
 	Interval   int
 	ExitStatus bool
+	Attempt    uint64
 
 	Prompt bool
 
@@ -73,6 +74,7 @@ func NewCmdWatch(f *cmdutil.Factory, runF func(*WatchOptions) error) *cobra.Comm
 	}
 	cmd.Flags().BoolVar(&opts.ExitStatus, "exit-status", false, "Exit with non-zero status if run fails")
 	cmd.Flags().IntVarP(&opts.Interval, "interval", "i", defaultInterval, "Refresh interval in seconds")
+	cmd.Flags().Uint64VarP(&opts.Attempt, "attempt", "a", 0, "The attempt number of the workflow run")
 
 	return cmd
 }
@@ -200,6 +202,7 @@ func watchRun(opts *WatchOptions) error {
 func renderRun(out io.Writer, opts WatchOptions, client *api.Client, repo ghrepo.Interface, run *shared.Run, prNumber string, annotationCache map[int64][]shared.Annotation) (*shared.Run, error) {
 	cs := opts.IO.ColorScheme()
 
+	attempt := opts.Attempt
 	var err error
 
 	run, err = shared.GetRun(client, repo, fmt.Sprintf("%d", run.ID), 0)
@@ -207,7 +210,7 @@ func renderRun(out io.Writer, opts WatchOptions, client *api.Client, repo ghrepo
 		return nil, fmt.Errorf("failed to get run: %w", err)
 	}
 
-	jobs, err := shared.GetJobs(client, repo, run)
+	jobs, err := shared.GetJobs(client, repo, run, attempt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get jobs: %w", err)
 	}

--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -86,6 +86,11 @@ func watchRun(opts *WatchOptions) error {
 	}
 	client := api.NewClientFromHTTP(c)
 
+	var attempt uint64 = 0
+	if opts.Attempt > 0 {
+		attempt = opts.Attempt
+	}
+
 	repo, err := opts.BaseRepo()
 	if err != nil {
 		return fmt.Errorf("failed to determine base repo: %w", err)
@@ -117,7 +122,7 @@ func watchRun(opts *WatchOptions) error {
 			}
 		}
 	} else {
-		run, err = shared.GetRun(client, repo, runID, 0)
+		run, err = shared.GetRun(client, repo, runID, attempt)
 		if err != nil {
 			return fmt.Errorf("failed to get run: %w", err)
 		}
@@ -202,10 +207,14 @@ func watchRun(opts *WatchOptions) error {
 func renderRun(out io.Writer, opts WatchOptions, client *api.Client, repo ghrepo.Interface, run *shared.Run, prNumber string, annotationCache map[int64][]shared.Annotation) (*shared.Run, error) {
 	cs := opts.IO.ColorScheme()
 
-	attempt := opts.Attempt
+	var attempt uint64 = 0
 	var err error
 
-	run, err = shared.GetRun(client, repo, fmt.Sprintf("%d", run.ID), 0)
+	if opts.Attempt > 0 {
+		attempt = opts.Attempt
+	}
+
+	run, err = shared.GetRun(client, repo, fmt.Sprintf("%d", run.ID), attempt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get run: %w", err)
 	}


### PR DESCRIPTION
- Introduce attempt flag for run watch and use attempt input when fetching jobs
- Remove exclude_pull_requests query param as it does not seem to be applicable to the jobs API path

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes https://github.com/cli/cli/issues/7823

This PR:

- Introduces a new `attempt` flag for `run watch`, matching that on `run view`
- Attempt flag in either command now properly outputs the jobs of the specified attempt

| Attempt 1 | Attempt 2 | Without attempt flag |
|--------|--------|--------|
| <img width="794" alt="image" src="https://github.com/cli/cli/assets/18581859/9e4d812c-41c5-4346-8204-02111d4bf84c"> | <img width="794" alt="image" src="https://github.com/cli/cli/assets/18581859/0867f429-2f21-4330-840b-c66e1bcf453c"> | <img width="794" alt="image" src="https://github.com/cli/cli/assets/18581859/dd8b350a-8a6e-4eac-83a3-42d2a86fc4b8"> | 