### PR TITLE
Support template, jq flags with standard format flag

### DIFF
--- a/pkg/cmd/project/close/close.go
+++ b/pkg/cmd/project/close/close.go
@@ -19,7 +19,7 @@ type closeOpts struct {
 	owner     string
 	reopen    bool
 	projectID string
-	format    string
+	exporter  cmdutil.Exporter
 }
 
 type closeConfig struct {
@@ -78,7 +78,7 @@ func NewCmdClose(f *cmdutil.Factory, runF func(config closeConfig) error) *cobra
 
 	closeCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the owner. Use \"@me\" for the current user.")
 	closeCmd.Flags().BoolVar(&opts.reopen, "undo", false, "Reopen a closed project")
-	closeCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be 'json'")
+	cmdutil.AddFormatFlags(closeCmd, &opts.exporter)
 
 	return closeCmd
 }
@@ -103,7 +103,7 @@ func runClose(config closeConfig) error {
 		return err
 	}
 
-	if config.opts.format == "json" {
+	if config.opts.exporter != nil {
 		return printJSON(config, *project)
 	}
 
@@ -134,10 +134,6 @@ func printResults(config closeConfig, project queries.Project) error {
 }
 
 func printJSON(config closeConfig, project queries.Project) error {
-	b, err := format.JSONProject(project)
-	if err != nil {
-		return err
-	}
-	_, err = config.io.Out.Write(b)
-	return err
+	projectJSON := format.JSONProject(project)
+	return config.opts.exporter.Write(config.io, projectJSON)
 }

--- a/pkg/cmd/project/close/close.go
+++ b/pkg/cmd/project/close/close.go
@@ -104,7 +104,7 @@ func runClose(config closeConfig) error {
 	}
 
 	if config.opts.exporter != nil {
-		return printJSON(config, *project)
+		return printJSON(config, query.UpdateProjectV2.ProjectV2)
 	}
 
 	return printResults(config, query.UpdateProjectV2.ProjectV2)

--- a/pkg/cmd/project/close/close_test.go
+++ b/pkg/cmd/project/close/close_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdClose(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       closeOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         closeOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "not-a-number",
@@ -47,11 +48,9 @@ func TestNewCmdClose(t *testing.T) {
 			},
 		},
 		{
-			name: "json",
-			cli:  "--format json",
-			wants: closeOpts{
-				format: "json",
-			},
+			name:          "json",
+			cli:           "--format json",
+			wantsExporter: true,
 		},
 	}
 
@@ -84,7 +83,7 @@ func TestNewCmdClose(t *testing.T) {
 
 			assert.Equal(t, tt.wants.number, gotOpts.number)
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/close/close_test.go
+++ b/pkg/cmd/project/close/close_test.go
@@ -452,3 +452,100 @@ func TestRunClose_Reopen(t *testing.T) {
 		"http://a-url.com\n",
 		stdout.String())
 }
+
+func TestRunClose_JSON(t *testing.T) {
+	defer gock.Off()
+	// gock.Observe(gock.DumpRequest)
+
+	// get user ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserOrgOwner.*",
+			"variables": map[string]interface{}{
+				"login": "monalisa",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"id": "an ID",
+				},
+			},
+			"errors": []interface{}{
+				map[string]interface{}{
+					"type": "NOT_FOUND",
+					"path": []string{"organization"},
+				},
+			},
+		})
+
+	// get user project ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  0,
+				"afterItems":  nil,
+				"firstFields": 0,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]string{
+						"id": "an ID",
+					},
+				},
+			},
+		})
+
+	// close project
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","closed":true}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"updateProjectV2": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"number": 1,
+						"title":  "a title",
+						"url":    "http://a-url.com",
+						"owner": map[string]interface{}{
+							"__typename": "User",
+							"login":      "monalisa",
+						},
+					},
+				},
+			},
+		})
+
+	client := queries.NewTestClient()
+
+	ios, _, stdout, _ := iostreams.Test()
+	config := closeConfig{
+		io: ios,
+		opts: closeOpts{
+			number:   1,
+			owner:    "monalisa",
+			exporter: cmdutil.NewJSONExporter(),
+		},
+		client: client,
+	}
+
+	err := runClose(config)
+	assert.NoError(t, err)
+	assert.JSONEq(
+		t,
+		`{"number":1,"url":"http://a-url.com","shortDescription":"","public":false,"closed":false,"title":"a title","id":"","readme":"","items":{"totalCount":0},"fields":{"totalCount":0},"owner":{"type":"User","login":"monalisa"}}`,
+		stdout.String())
+}

--- a/pkg/cmd/project/copy/copy.go
+++ b/pkg/cmd/project/copy/copy.go
@@ -22,7 +22,7 @@ type copyOpts struct {
 	sourceOwner        string
 	targetOwner        string
 	title              string
-	format             string
+	exporter           cmdutil.Exporter
 }
 
 type copyConfig struct {
@@ -79,7 +79,7 @@ func NewCmdCopy(f *cmdutil.Factory, runF func(config copyConfig) error) *cobra.C
 	copyCmd.Flags().StringVar(&opts.targetOwner, "target-owner", "", "Login of the target owner. Use \"@me\" for the current user.")
 	copyCmd.Flags().StringVar(&opts.title, "title", "", "Title for the new project")
 	copyCmd.Flags().BoolVar(&opts.includeDraftIssues, "drafts", false, "Include draft issues when copying")
-	cmdutil.StringEnumFlag(copyCmd, &opts.format, "format", "", "", []string{"json"}, "Output format")
+	cmdutil.AddFormatFlags(copyCmd, &opts.exporter)
 
 	_ = copyCmd.MarkFlagRequired("title")
 
@@ -113,7 +113,7 @@ func runCopy(config copyConfig) error {
 		return err
 	}
 
-	if config.opts.format == "json" {
+	if config.opts.exporter != nil {
 		return printJSON(config, query.CopyProjectV2.ProjectV2)
 	}
 
@@ -144,10 +144,6 @@ func printResults(config copyConfig, project queries.Project) error {
 }
 
 func printJSON(config copyConfig, project queries.Project) error {
-	b, err := format.JSONProject(project)
-	if err != nil {
-		return err
-	}
-	_, err = config.io.Out.Write(b)
-	return err
+	projectJSON := format.JSONProject(project)
+	return config.opts.exporter.Write(config.io, projectJSON)
 }

--- a/pkg/cmd/project/copy/copy_test.go
+++ b/pkg/cmd/project/copy/copy_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdCopy(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       copyOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         copyOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "not-a-number",
@@ -68,9 +69,9 @@ func TestNewCmdCopy(t *testing.T) {
 			name: "json",
 			cli:  "--format json --title t",
 			wants: copyOpts{
-				format: "json",
-				title:  "t",
+				title: "t",
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -106,7 +107,7 @@ func TestNewCmdCopy(t *testing.T) {
 			assert.Equal(t, tt.wants.targetOwner, gotOpts.targetOwner)
 			assert.Equal(t, tt.wants.title, gotOpts.title)
 			assert.Equal(t, tt.wants.includeDraftIssues, gotOpts.includeDraftIssues)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/copy/copy_test.go
+++ b/pkg/cmd/project/copy/copy_test.go
@@ -459,3 +459,128 @@ func TestRunCopy_Me(t *testing.T) {
 		"http://a-url.com\n",
 		stdout.String())
 }
+
+func TestRunCopy_JSON(t *testing.T) {
+	defer gock.Off()
+	// gock.Observe(gock.DumpRequest)
+
+	// get user project ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  0,
+				"afterItems":  nil,
+				"firstFields": 0,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]string{
+						"id": "an ID",
+					},
+				},
+			},
+		})
+
+	// get source user ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserOrgOwner.*",
+			"variables": map[string]string{
+				"login": "monalisa",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"id":    "an ID",
+					"login": "monalisa",
+				},
+			},
+			"errors": []interface{}{
+				map[string]interface{}{
+					"type": "NOT_FOUND",
+					"path": []string{"organization"},
+				},
+			},
+		})
+
+	// get target user ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserOrgOwner.*",
+			"variables": map[string]string{
+				"login": "monalisa",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"id":    "an ID",
+					"login": "monalisa",
+				},
+			},
+			"errors": []interface{}{
+				map[string]interface{}{
+					"type": "NOT_FOUND",
+					"path": []string{"organization"},
+				},
+			},
+		})
+
+	// Copy project
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"copyProjectV2": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"number": 1,
+						"title":  "a title",
+						"url":    "http://a-url.com",
+						"owner": map[string]string{
+							"login": "monalisa",
+						},
+					},
+				},
+			},
+		})
+
+	client := queries.NewTestClient()
+
+	ios, _, stdout, _ := iostreams.Test()
+	config := copyConfig{
+		io: ios,
+		opts: copyOpts{
+			title:       "a title",
+			sourceOwner: "monalisa",
+			targetOwner: "monalisa",
+			number:      1,
+			exporter:    cmdutil.NewJSONExporter(),
+		},
+		client: client,
+	}
+
+	err := runCopy(config)
+	assert.NoError(t, err)
+	assert.JSONEq(
+		t,
+		`{"number":1,"url":"http://a-url.com","shortDescription":"","public":false,"closed":false,"title":"a title","id":"","readme":"","items":{"totalCount":0},"fields":{"totalCount":0},"owner":{"type":"","login":"monalisa"}}`,
+		stdout.String())
+}

--- a/pkg/cmd/project/create/create_test.go
+++ b/pkg/cmd/project/create/create_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdCreate(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       createOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         createOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name: "title",
@@ -38,9 +39,9 @@ func TestNewCmdCreate(t *testing.T) {
 			name: "json",
 			cli:  "--title t --format json",
 			wants: createOpts{
-				format: "json",
-				title:  "t",
+				title: "t",
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -73,7 +74,7 @@ func TestNewCmdCreate(t *testing.T) {
 
 			assert.Equal(t, tt.wants.title, gotOpts.title)
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/delete/delete.go
+++ b/pkg/cmd/project/delete/delete.go
@@ -97,7 +97,7 @@ func runDelete(config deleteConfig) error {
 	}
 
 	if config.opts.exporter != nil {
-		return printJSON(config, *project)
+		return printJSON(config, query.DeleteProject.Project)
 	}
 
 	return printResults(config, query.DeleteProject.Project)

--- a/pkg/cmd/project/delete/delete.go
+++ b/pkg/cmd/project/delete/delete.go
@@ -18,7 +18,7 @@ type deleteOpts struct {
 	owner     string
 	number    int32
 	projectID string
-	format    string
+	exporter  cmdutil.Exporter
 }
 
 type deleteConfig struct {
@@ -72,7 +72,7 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(config deleteConfig) error) *cob
 	}
 
 	deleteCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the owner. Use \"@me\" for the current user.")
-	cmdutil.StringEnumFlag(deleteCmd, &opts.format, "format", "", "", []string{"json"}, "Output format")
+	cmdutil.AddFormatFlags(deleteCmd, &opts.exporter)
 
 	return deleteCmd
 }
@@ -96,7 +96,7 @@ func runDelete(config deleteConfig) error {
 		return err
 	}
 
-	if config.opts.format == "json" {
+	if config.opts.exporter != nil {
 		return printJSON(config, *project)
 	}
 
@@ -126,11 +126,6 @@ func printResults(config deleteConfig, project queries.Project) error {
 }
 
 func printJSON(config deleteConfig, project queries.Project) error {
-	b, err := format.JSONProject(project)
-	if err != nil {
-		return err
-	}
-
-	_, err = config.io.Out.Write(b)
-	return err
+	projectJSON := format.JSONProject(project)
+	return config.opts.exporter.Write(config.io, projectJSON)
 }

--- a/pkg/cmd/project/delete/delete_test.go
+++ b/pkg/cmd/project/delete/delete_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdDelete(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       deleteOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         deleteOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "not-a-number",
@@ -40,11 +41,9 @@ func TestNewCmdDelete(t *testing.T) {
 			},
 		},
 		{
-			name: "json",
-			cli:  "--format json",
-			wants: deleteOpts{
-				format: "json",
-			},
+			name:          "json",
+			cli:           "--format json",
+			wantsExporter: true,
 		},
 	}
 
@@ -77,7 +76,7 @@ func TestNewCmdDelete(t *testing.T) {
 
 			assert.Equal(t, tt.wants.number, gotOpts.number)
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/edit/edit.go
+++ b/pkg/cmd/project/edit/edit.go
@@ -22,7 +22,7 @@ type editOpts struct {
 	visibility       string
 	shortDescription string
 	projectID        string
-	format           string
+	exporter         cmdutil.Exporter
 }
 
 type editConfig struct {
@@ -86,7 +86,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(config editConfig) error) *cobra.C
 	editCmd.Flags().StringVar(&opts.title, "title", "", "New title for the project")
 	editCmd.Flags().StringVar(&opts.readme, "readme", "", "New readme for the project")
 	editCmd.Flags().StringVarP(&opts.shortDescription, "description", "d", "", "New description of the project")
-	cmdutil.StringEnumFlag(editCmd, &opts.format, "format", "", "", []string{"json"}, "Output format")
+	cmdutil.AddFormatFlags(editCmd, &opts.exporter)
 
 	return editCmd
 }
@@ -110,7 +110,7 @@ func runEdit(config editConfig) error {
 		return err
 	}
 
-	if config.opts.format == "json" {
+	if config.opts.exporter != nil {
 		return printJSON(config, *project)
 	}
 
@@ -155,11 +155,6 @@ func printResults(config editConfig, project queries.Project) error {
 }
 
 func printJSON(config editConfig, project queries.Project) error {
-	b, err := format.JSONProject(project)
-	if err != nil {
-		return err
-	}
-
-	_, err = config.io.Out.Write(b)
-	return err
+	projectJSON := format.JSONProject(project)
+	return config.opts.exporter.Write(config.io, projectJSON)
 }

--- a/pkg/cmd/project/edit/edit.go
+++ b/pkg/cmd/project/edit/edit.go
@@ -111,7 +111,7 @@ func runEdit(config editConfig) error {
 	}
 
 	if config.opts.exporter != nil {
-		return printJSON(config, *project)
+		return printJSON(config, query.UpdateProjectV2.ProjectV2)
 	}
 
 	return printResults(config, query.UpdateProjectV2.ProjectV2)

--- a/pkg/cmd/project/edit/edit_test.go
+++ b/pkg/cmd/project/edit/edit_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdEdit(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       editOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         editOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "not-a-number",
@@ -85,9 +86,9 @@ func TestNewCmdEdit(t *testing.T) {
 			name: "json",
 			cli:  "--format json --title t",
 			wants: editOpts{
-				format: "json",
-				title:  "t",
+				title: "t",
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -124,7 +125,7 @@ func TestNewCmdEdit(t *testing.T) {
 			assert.Equal(t, tt.wants.title, gotOpts.title)
 			assert.Equal(t, tt.wants.readme, gotOpts.readme)
 			assert.Equal(t, tt.wants.shortDescription, gotOpts.shortDescription)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/field-create/field_create_test.go
+++ b/pkg/cmd/project/field-create/field_create_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdCreateField(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       createFieldOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         createFieldOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "missing-name-and-data-type",
@@ -70,11 +71,11 @@ func TestNewCmdCreateField(t *testing.T) {
 			name: "json",
 			cli:  "--format json --name n --data-type TEXT ",
 			wants: createFieldOpts{
-				format:              "json",
 				name:                "n",
 				dataType:            "TEXT",
 				singleSelectOptions: []string{},
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -110,7 +111,7 @@ func TestNewCmdCreateField(t *testing.T) {
 			assert.Equal(t, tt.wants.name, gotOpts.name)
 			assert.Equal(t, tt.wants.dataType, gotOpts.dataType)
 			assert.Equal(t, tt.wants.singleSelectOptions, gotOpts.singleSelectOptions)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/field-delete/field_delete.go
+++ b/pkg/cmd/project/field-delete/field_delete.go
@@ -13,8 +13,8 @@ import (
 )
 
 type deleteFieldOpts struct {
-	fieldID string
-	format  string
+	fieldID  string
+	exporter cmdutil.Exporter
 }
 
 type deleteFieldConfig struct {
@@ -55,7 +55,7 @@ func NewCmdDeleteField(f *cmdutil.Factory, runF func(config deleteFieldConfig) e
 	}
 
 	deleteFieldCmd.Flags().StringVar(&opts.fieldID, "id", "", "ID of the field to delete")
-	cmdutil.StringEnumFlag(deleteFieldCmd, &opts.format, "format", "", "", []string{"json"}, "Output format")
+	cmdutil.AddFormatFlags(deleteFieldCmd, &opts.exporter)
 
 	_ = deleteFieldCmd.MarkFlagRequired("id")
 
@@ -70,7 +70,7 @@ func runDeleteField(config deleteFieldConfig) error {
 		return err
 	}
 
-	if config.opts.format == "json" {
+	if config.opts.exporter != nil {
 		return printJSON(config, query.DeleteProjectV2Field.Field)
 	}
 
@@ -95,11 +95,6 @@ func printResults(config deleteFieldConfig, field queries.ProjectField) error {
 }
 
 func printJSON(config deleteFieldConfig, field queries.ProjectField) error {
-	b, err := format.JSONProjectField(field)
-	if err != nil {
-		return err
-	}
-
-	_, err = config.io.Out.Write(b)
-	return err
+	projectFieldJSON := format.JSONProjectField(field)
+	return config.opts.exporter.Write(config.io, projectFieldJSON)
 }

--- a/pkg/cmd/project/field-delete/field_delete_test.go
+++ b/pkg/cmd/project/field-delete/field_delete_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdDeleteField(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       deleteFieldOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         deleteFieldOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "no id",
@@ -36,9 +37,9 @@ func TestNewCmdDeleteField(t *testing.T) {
 			name: "json",
 			cli:  "--id 123 --format json",
 			wants: deleteFieldOpts{
-				format:  "json",
 				fieldID: "123",
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -70,7 +71,7 @@ func TestNewCmdDeleteField(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, tt.wants.fieldID, gotOpts.fieldID)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/field-list/field_list_test.go
+++ b/pkg/cmd/project/field-list/field_list_test.go
@@ -14,11 +14,12 @@ import (
 
 func TestNewCmdList(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       listOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         listOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "not-a-number",
@@ -46,9 +47,9 @@ func TestNewCmdList(t *testing.T) {
 			name: "json",
 			cli:  "--format json",
 			wants: listOpts{
-				format: "json",
-				limit:  30,
+				limit: 30,
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -82,7 +83,7 @@ func TestNewCmdList(t *testing.T) {
 			assert.Equal(t, tt.wants.number, gotOpts.number)
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
 			assert.Equal(t, tt.wants.limit, gotOpts.limit)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/item-add/item_add_test.go
+++ b/pkg/cmd/project/item-add/item_add_test.go
@@ -423,3 +423,119 @@ func TestRunAddItem_Me(t *testing.T) {
 		"Added item\n",
 		stdout.String())
 }
+
+func TestRunAddItem_JSON(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// get user ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserOrgOwner.*",
+			"variables": map[string]interface{}{
+				"login": "monalisa",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"id": "an ID",
+				},
+			},
+			"errors": []interface{}{
+				map[string]interface{}{
+					"type": "NOT_FOUND",
+					"path": []string{"organization"},
+				},
+			},
+		})
+
+	// get project ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  0,
+				"afterItems":  nil,
+				"firstFields": 0,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"id": "an ID",
+					},
+				},
+			},
+		})
+
+	// get item ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query GetIssueOrPullRequest.*",
+			"variables": map[string]interface{}{
+				"url": "https://github.com/cli/go-gh/issues/1",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"resource": map[string]interface{}{
+					"id":         "item ID",
+					"__typename": "Issue",
+				},
+			},
+		})
+
+	// create item
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation AddItem.*","variables":{"input":{"projectId":"an ID","contentId":"item ID"}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"addProjectV2ItemById": map[string]interface{}{
+					"item": map[string]interface{}{
+						"id": "item ID",
+						"content": map[string]interface{}{
+							"__typename": "Issue",
+							"title":      "a title",
+						},
+					},
+				},
+			},
+		})
+
+	client := queries.NewTestClient()
+
+	ios, _, stdout, _ := iostreams.Test()
+	config := addItemConfig{
+		opts: addItemOpts{
+			owner:    "monalisa",
+			number:   1,
+			itemURL:  "https://github.com/cli/go-gh/issues/1",
+			exporter: cmdutil.NewJSONExporter(),
+		},
+		client: client,
+		io:     ios,
+	}
+
+	err := runAddItem(config)
+	assert.NoError(t, err)
+	assert.JSONEq(
+		t,
+		`{"id":"item ID","title":"a title","body":"","type":"Issue"}`,
+		stdout.String())
+}

--- a/pkg/cmd/project/item-add/item_add_test.go
+++ b/pkg/cmd/project/item-add/item_add_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdaddItem(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       addItemOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         addItemOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "missing-url",
@@ -58,9 +59,9 @@ func TestNewCmdaddItem(t *testing.T) {
 			name: "json",
 			cli:  "--format json --url github.com/cli/cli",
 			wants: addItemOpts{
-				format:  "json",
 				itemURL: "github.com/cli/cli",
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -94,7 +95,7 @@ func TestNewCmdaddItem(t *testing.T) {
 			assert.Equal(t, tt.wants.number, gotOpts.number)
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
 			assert.Equal(t, tt.wants.itemURL, gotOpts.itemURL)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/item-archive/item_archive_test.go
+++ b/pkg/cmd/project/item-archive/item_archive_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdarchiveItem(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       archiveItemOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         archiveItemOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "missing-id",
@@ -66,9 +67,9 @@ func TestNewCmdarchiveItem(t *testing.T) {
 			name: "json",
 			cli:  "--format json --id 123",
 			wants: archiveItemOpts{
-				format: "json",
 				itemID: "123",
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -103,7 +104,7 @@ func TestNewCmdarchiveItem(t *testing.T) {
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
 			assert.Equal(t, tt.wants.itemID, gotOpts.itemID)
 			assert.Equal(t, tt.wants.undo, gotOpts.undo)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/item-archive/item_archive_test.go
+++ b/pkg/cmd/project/item-archive/item_archive_test.go
@@ -636,3 +636,99 @@ func TestRunArchive_Me_Undo(t *testing.T) {
 		"Unarchived item\n",
 		stdout.String())
 }
+
+func TestRunArchive_JSON(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// get user ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserOrgOwner.*",
+			"variables": map[string]interface{}{
+				"login": "monalisa",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"id": "an ID",
+				},
+			},
+			"errors": []interface{}{
+				map[string]interface{}{
+					"type": "NOT_FOUND",
+					"path": []string{"organization"},
+				},
+			},
+		})
+
+	// get project ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  0,
+				"afterItems":  nil,
+				"firstFields": 0,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"id": "an ID",
+					},
+				},
+			},
+		})
+
+	// archive item
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation ArchiveProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"archiveProjectV2Item": map[string]interface{}{
+					"item": map[string]interface{}{
+						"id": "item ID",
+						"content": map[string]interface{}{
+							"__typename": "Issue",
+							"title":      "a title",
+						},
+					},
+				},
+			},
+		})
+
+	client := queries.NewTestClient()
+
+	ios, _, stdout, _ := iostreams.Test()
+	config := archiveItemConfig{
+		opts: archiveItemOpts{
+			owner:    "monalisa",
+			number:   1,
+			itemID:   "item ID",
+			exporter: cmdutil.NewJSONExporter(),
+		},
+		client: client,
+		io:     ios,
+	}
+
+	err := runArchiveItem(config)
+	assert.NoError(t, err)
+	assert.JSONEq(
+		t,
+		`{"id":"item ID","title":"a title","body":"","type":"Issue"}`,
+		stdout.String())
+}

--- a/pkg/cmd/project/item-create/item_create_test.go
+++ b/pkg/cmd/project/item-create/item_create_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdCreateItem(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       createItemOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         createItemOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "missing-title",
@@ -66,9 +67,9 @@ func TestNewCmdCreateItem(t *testing.T) {
 			name: "json",
 			cli:  "--format json --title t",
 			wants: createItemOpts{
-				format: "json",
-				title:  "t",
+				title: "t",
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -102,7 +103,7 @@ func TestNewCmdCreateItem(t *testing.T) {
 			assert.Equal(t, tt.wants.number, gotOpts.number)
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
 			assert.Equal(t, tt.wants.title, gotOpts.title)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/item-delete/item_delete.go
+++ b/pkg/cmd/project/item-delete/item_delete.go
@@ -18,7 +18,7 @@ type deleteItemOpts struct {
 	number    int32
 	itemID    string
 	projectID string
-	format    string
+	exporter  cmdutil.Exporter
 }
 
 type deleteItemConfig struct {
@@ -73,7 +73,7 @@ func NewCmdDeleteItem(f *cmdutil.Factory, runF func(config deleteItemConfig) err
 
 	deleteItemCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the owner. Use \"@me\" for the current user.")
 	deleteItemCmd.Flags().StringVar(&opts.itemID, "id", "", "ID of the item to delete")
-	cmdutil.StringEnumFlag(deleteItemCmd, &opts.format, "format", "", "", []string{"json"}, "Output format")
+	cmdutil.AddFormatFlags(deleteItemCmd, &opts.exporter)
 
 	_ = deleteItemCmd.MarkFlagRequired("id")
 
@@ -99,7 +99,7 @@ func runDeleteItem(config deleteItemConfig) error {
 		return err
 	}
 
-	if config.opts.format == "json" {
+	if config.opts.exporter != nil {
 		return printJSON(config, query.DeleteProjectItem.DeletedItemId)
 	}
 
@@ -126,6 +126,8 @@ func printResults(config deleteItemConfig) error {
 }
 
 func printJSON(config deleteItemConfig, ID githubv4.ID) error {
-	_, err := config.io.Out.Write([]byte(fmt.Sprintf(`{"id": "%s"}`, ID)))
-	return err
+	m := map[string]interface{}{
+		"id": ID,
+	}
+	return config.opts.exporter.Write(config.io, m)
 }

--- a/pkg/cmd/project/item-delete/item_delete.go
+++ b/pkg/cmd/project/item-delete/item_delete.go
@@ -125,9 +125,9 @@ func printResults(config deleteItemConfig) error {
 	return err
 }
 
-func printJSON(config deleteItemConfig, ID githubv4.ID) error {
+func printJSON(config deleteItemConfig, id githubv4.ID) error {
 	m := map[string]interface{}{
-		"id": ID,
+		"id": id,
 	}
 	return config.opts.exporter.Write(config.io, m)
 }

--- a/pkg/cmd/project/item-delete/item_delete_test.go
+++ b/pkg/cmd/project/item-delete/item_delete_test.go
@@ -356,3 +356,92 @@ func TestRunDelete_Me(t *testing.T) {
 		"Deleted item\n",
 		stdout.String())
 }
+
+func TestRunDelete_JSON(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+	// get user ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserOrgOwner.*",
+			"variables": map[string]interface{}{
+				"login": "monalisa",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"id": "an ID",
+				},
+			},
+			"errors": []interface{}{
+				map[string]interface{}{
+					"type": "NOT_FOUND",
+					"path": []string{"organization"},
+				},
+			},
+		})
+
+	// get project ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  0,
+				"afterItems":  nil,
+				"firstFields": 0,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"id": "an ID",
+					},
+				},
+			},
+		})
+
+	// delete item
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation DeleteProjectItem.*","variables":{"input":{"projectId":"an ID","itemId":"item ID"}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"deleteProjectV2Item": map[string]interface{}{
+					"deletedItemId": "item ID",
+				},
+			},
+		})
+
+	client := queries.NewTestClient()
+
+	ios, _, stdout, _ := iostreams.Test()
+	config := deleteItemConfig{
+		opts: deleteItemOpts{
+			owner:    "monalisa",
+			number:   1,
+			itemID:   "item ID",
+			exporter: cmdutil.NewJSONExporter(),
+		},
+		client: client,
+		io:     ios,
+	}
+
+	err := runDeleteItem(config)
+	assert.NoError(t, err)
+	assert.JSONEq(
+		t,
+		`{"id":"item ID"}`,
+		stdout.String())
+}

--- a/pkg/cmd/project/item-delete/item_delete_test.go
+++ b/pkg/cmd/project/item-delete/item_delete_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdDeleteItem(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       deleteItemOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         deleteItemOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "missing-id",
@@ -58,9 +59,9 @@ func TestNewCmdDeleteItem(t *testing.T) {
 			name: "json",
 			cli:  "--format json --id 123",
 			wants: deleteItemOpts{
-				format: "json",
 				itemID: "123",
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -94,7 +95,7 @@ func TestNewCmdDeleteItem(t *testing.T) {
 			assert.Equal(t, tt.wants.number, gotOpts.number)
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
 			assert.Equal(t, tt.wants.itemID, gotOpts.itemID)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/item-edit/item_edit_test.go
+++ b/pkg/cmd/project/item-edit/item_edit_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdeditItem(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       editItemOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         editItemOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "missing-id",
@@ -108,9 +109,9 @@ func TestNewCmdeditItem(t *testing.T) {
 			name: "json",
 			cli:  "--format json --id 123",
 			wants: editItemOpts{
-				format: "json",
 				itemID: "123",
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -143,7 +144,7 @@ func TestNewCmdeditItem(t *testing.T) {
 
 			assert.Equal(t, tt.wants.number, gotOpts.number)
 			assert.Equal(t, tt.wants.itemID, gotOpts.itemID)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 			assert.Equal(t, tt.wants.title, gotOpts.title)
 			assert.Equal(t, tt.wants.fieldID, gotOpts.fieldID)
 			assert.Equal(t, tt.wants.projectID, gotOpts.projectID)

--- a/pkg/cmd/project/item-list/item_list.go
+++ b/pkg/cmd/project/item-list/item_list.go
@@ -15,10 +15,10 @@ import (
 )
 
 type listOpts struct {
-	limit  int
-	owner  string
-	number int32
-	format string
+	limit    int
+	owner    string
+	number   int32
+	exporter cmdutil.Exporter
 }
 
 type listConfig struct {
@@ -66,7 +66,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 	}
 
 	listCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the owner. Use \"@me\" for the current user.")
-	cmdutil.StringEnumFlag(listCmd, &opts.format, "format", "", "", []string{"json"}, "Output format")
+	cmdutil.AddFormatFlags(listCmd, &opts.exporter)
 	listCmd.Flags().IntVarP(&opts.limit, "limit", "L", queries.LimitDefault, "Maximum number of items to fetch")
 
 	return listCmd
@@ -93,7 +93,7 @@ func runList(config listConfig) error {
 		return err
 	}
 
-	if config.opts.format == "json" {
+	if config.opts.exporter != nil {
 		return printJSON(config, project)
 	}
 
@@ -124,10 +124,6 @@ func printResults(config listConfig, items []queries.ProjectItem, login string) 
 }
 
 func printJSON(config listConfig, project *queries.Project) error {
-	b, err := format.JSONProjectDetailedItems(project)
-	if err != nil {
-		return err
-	}
-	_, err = config.io.Out.Write(b)
-	return err
+	projectDetailedItemsJSON := format.JSONProjectDetailedItems(project)
+	return config.opts.exporter.Write(config.io, projectDetailedItemsJSON)
 }

--- a/pkg/cmd/project/item-list/item_list_test.go
+++ b/pkg/cmd/project/item-list/item_list_test.go
@@ -15,11 +15,12 @@ import (
 
 func TestNewCmdList(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       listOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         listOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "not-a-number",
@@ -47,9 +48,9 @@ func TestNewCmdList(t *testing.T) {
 			name: "json",
 			cli:  "--format json",
 			wants: listOpts{
-				format: "json",
-				limit:  30,
+				limit: 30,
 			},
+			wantsExporter: true,
 		},
 	}
 
@@ -82,7 +83,7 @@ func TestNewCmdList(t *testing.T) {
 
 			assert.Equal(t, tt.wants.number, gotOpts.number)
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 			assert.Equal(t, tt.wants.limit, gotOpts.limit)
 		})
 	}

--- a/pkg/cmd/project/list/list.go
+++ b/pkg/cmd/project/list/list.go
@@ -69,7 +69,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 	listCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the owner")
 	listCmd.Flags().BoolVarP(&opts.closed, "closed", "", false, "Include closed projects")
 	listCmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open projects list in the browser")
-	cmdutil.AddFormatFlags(listCmd, &opts.exporter, format.ProjectFields)
+	cmdutil.AddFormatFlags(listCmd, &opts.exporter)
 	listCmd.Flags().IntVarP(&opts.limit, "limit", "L", queries.LimitDefault, "Maximum number of projects to fetch")
 
 	return listCmd
@@ -161,7 +161,6 @@ func printResults(config listConfig, projects []queries.Project, owner string) e
 		tp.AddField(
 			strconv.Itoa(int(p.Number)),
 			tableprinter.WithTruncate(nil),
-			tableprinter.WithColor(cs.ColorFromString(format.ColorForProjectState(p))),
 		)
 		tp.AddField(p.Title)
 		tp.AddField(

--- a/pkg/cmd/project/mark-template/mark_template.go
+++ b/pkg/cmd/project/mark-template/mark_template.go
@@ -121,7 +121,7 @@ func runMarkTemplate(config markTemplateConfig) error {
 	}
 
 	if config.opts.exporter != nil {
-		return printJSON(config, *project)
+		return printJSON(config, query.TemplateProject.Project)
 	}
 
 	return printResults(config, query.TemplateProject.Project)

--- a/pkg/cmd/project/mark-template/mark_template.go
+++ b/pkg/cmd/project/mark-template/mark_template.go
@@ -19,7 +19,7 @@ type markTemplateOpts struct {
 	undo      bool
 	number    int32
 	projectID string
-	format    string
+	exporter  cmdutil.Exporter
 }
 
 type markTemplateConfig struct {
@@ -82,7 +82,7 @@ func NewCmdMarkTemplate(f *cmdutil.Factory, runF func(config markTemplateConfig)
 
 	markTemplateCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the org owner.")
 	markTemplateCmd.Flags().BoolVar(&opts.undo, "undo", false, "Unmark the project as a template.")
-	cmdutil.StringEnumFlag(markTemplateCmd, &opts.format, "format", "", "", []string{"json"}, "Output format")
+	cmdutil.AddFormatFlags(markTemplateCmd, &opts.exporter)
 
 	return markTemplateCmd
 }
@@ -107,7 +107,7 @@ func runMarkTemplate(config markTemplateConfig) error {
 			return err
 		}
 
-		if config.opts.format == "json" {
+		if config.opts.exporter != nil {
 			return printJSON(config, *project)
 		}
 
@@ -120,7 +120,7 @@ func runMarkTemplate(config markTemplateConfig) error {
 		return err
 	}
 
-	if config.opts.format == "json" {
+	if config.opts.exporter != nil {
 		return printJSON(config, *project)
 	}
 
@@ -166,11 +166,6 @@ func printResults(config markTemplateConfig, project queries.Project) error {
 }
 
 func printJSON(config markTemplateConfig, project queries.Project) error {
-	b, err := format.JSONProject(project)
-	if err != nil {
-		return err
-	}
-
-	_, err = config.io.Out.Write(b)
-	return err
+	projectJSON := format.JSONProject(project)
+	return config.opts.exporter.Write(config.io, projectJSON)
 }

--- a/pkg/cmd/project/mark-template/mark_template_test.go
+++ b/pkg/cmd/project/mark-template/mark_template_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestNewCmdMarkTemplate(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       markTemplateOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         markTemplateOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "not-a-number",
@@ -48,11 +49,9 @@ func TestNewCmdMarkTemplate(t *testing.T) {
 		},
 
 		{
-			name: "json",
-			cli:  "--format json",
-			wants: markTemplateOpts{
-				format: "json",
-			},
+			name:          "json",
+			cli:           "--format json",
+			wantsExporter: true,
 		},
 	}
 
@@ -85,7 +84,7 @@ func TestNewCmdMarkTemplate(t *testing.T) {
 
 			assert.Equal(t, tt.wants.number, gotOpts.number)
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 		})
 	}
 }

--- a/pkg/cmd/project/shared/format/display.go
+++ b/pkg/cmd/project/shared/format/display.go
@@ -1,0 +1,19 @@
+package format
+
+import (
+	"github.com/cli/cli/v2/pkg/cmd/project/shared/queries"
+)
+
+func ProjectState(project queries.Project) string {
+	if project.Closed {
+		return "closed"
+	}
+	return "open"
+}
+
+func ColorForProjectState(project queries.Project) string {
+	if project.Closed {
+		return "gray"
+	}
+	return "green"
+}

--- a/pkg/cmd/project/shared/format/display_test.go
+++ b/pkg/cmd/project/shared/format/display_test.go
@@ -1,0 +1,18 @@
+package format
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/cmd/project/shared/queries"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectState(t *testing.T) {
+	assert.Equal(t, "open", ProjectState(queries.Project{}))
+	assert.Equal(t, "closed", ProjectState(queries.Project{Closed: true}))
+}
+
+func TestColorForProjectState(t *testing.T) {
+	assert.Equal(t, "green", ColorForProjectState(queries.Project{}))
+	assert.Equal(t, "gray", ColorForProjectState(queries.Project{Closed: true}))
+}

--- a/pkg/cmd/project/shared/format/json.go
+++ b/pkg/cmd/project/shared/format/json.go
@@ -86,20 +86,6 @@ func JSONProjects(projects []queries.Project, totalCount int) ProjectsJSON {
 	}
 }
 
-var ProjectFields = []string{
-	"number",
-	"url",
-	"shortDescription",
-	"public",
-	"closed",
-	"title",
-	"id",
-	"readme",
-	"items",
-	"fields",
-	"owner",
-}
-
 type ProjectJSON struct {
 	Number           int32  `json:"number"`
 	URL              string `json:"url"`
@@ -132,13 +118,13 @@ type ProjectsJSON struct {
 
 // JSONProjectField serializes a ProjectField to JSON.
 func JSONProjectField(field queries.ProjectField) ([]byte, error) {
-	val := projectFieldJSON{
+	val := ProjectFieldJSON{
 		ID:   field.ID(),
 		Name: field.Name(),
 		Type: field.Type(),
 	}
 	for _, o := range field.Options() {
-		val.Options = append(val.Options, singleSelectOptionJSON{
+		val.Options = append(val.Options, SingleSelectOptionJSON{
 			Name: o.Name,
 			ID:   o.ID,
 		})
@@ -149,16 +135,16 @@ func JSONProjectField(field queries.ProjectField) ([]byte, error) {
 
 // JSONProjectFields serializes a slice of ProjectFields to JSON.
 // JSON fields are `totalCount` and `fields`.
-func JSONProjectFields(project *queries.Project) ([]byte, error) {
-	var result []projectFieldJSON
+func JSONProjectFields(project *queries.Project) ProjectFieldsJSON {
+	var result []ProjectFieldJSON
 	for _, f := range project.Fields.Nodes {
-		val := projectFieldJSON{
+		val := ProjectFieldJSON{
 			ID:   f.ID(),
 			Name: f.Name(),
 			Type: f.Type(),
 		}
 		for _, o := range f.Options() {
-			val.Options = append(val.Options, singleSelectOptionJSON{
+			val.Options = append(val.Options, SingleSelectOptionJSON{
 				Name: o.Name,
 				ID:   o.ID,
 			})
@@ -167,23 +153,25 @@ func JSONProjectFields(project *queries.Project) ([]byte, error) {
 		result = append(result, val)
 	}
 
-	return json.Marshal(struct {
-		Fields     []projectFieldJSON `json:"fields"`
-		TotalCount int                `json:"totalCount"`
-	}{
+	return ProjectFieldsJSON{
 		Fields:     result,
 		TotalCount: project.Fields.TotalCount,
-	})
+	}
 }
 
-type projectFieldJSON struct {
+type ProjectFieldJSON struct {
 	ID      string                   `json:"id"`
 	Name    string                   `json:"name"`
 	Type    string                   `json:"type"`
-	Options []singleSelectOptionJSON `json:"options,omitempty"`
+	Options []SingleSelectOptionJSON `json:"options,omitempty"`
 }
 
-type singleSelectOptionJSON struct {
+type ProjectFieldsJSON struct {
+	Fields     []ProjectFieldJSON `json:"fields"`
+	TotalCount int                `json:"totalCount"`
+}
+
+type SingleSelectOptionJSON struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }

--- a/pkg/cmd/project/shared/format/json.go
+++ b/pkg/cmd/project/shared/format/json.go
@@ -337,7 +337,7 @@ func serializeProjectWithItems(project *queries.Project) []map[string]any {
 
 	// make a map of fields by ID
 	for _, f := range project.Fields.Nodes {
-		fields[f.ID()] = CamelCase(f.Name())
+		fields[f.ID()] = camelCase(f.Name())
 	}
 	itemsSlice := make([]map[string]any, 0)
 
@@ -373,8 +373,8 @@ type ProjectDetailedItems struct {
 	TotalCount int              `json:"totalCount"`
 }
 
-// CamelCase converts a string to camelCase, which is useful for turning Go field names to JSON keys.
-func CamelCase(s string) string {
+// camelCase converts a string to camelCase, which is useful for turning Go field names to JSON keys.
+func camelCase(s string) string {
 	if len(s) == 0 {
 		return ""
 	}

--- a/pkg/cmd/project/shared/format/json.go
+++ b/pkg/cmd/project/shared/format/json.go
@@ -5,46 +5,7 @@ import (
 	"strings"
 
 	"github.com/cli/cli/v2/pkg/cmd/project/shared/queries"
-	"github.com/cli/cli/v2/pkg/cmdutil"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
-
-func AddJSONFlags(cmd *cobra.Command, format *string, exportTarget *cmdutil.Exporter, fields []string) {
-	oldPreRun := cmd.PreRunE
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		if oldPreRun != nil {
-			if err := oldPreRun(cmd, args); err != nil {
-				return err
-			}
-		}
-
-		jsonFlag := cmd.Flags().Lookup("json")
-		if err := cmdutil.MutuallyExclusive(
-			"specify only one of `--format` or `--json`",
-			format != nil,
-			jsonFlag.Changed,
-		); err != nil {
-			return err
-		}
-
-		// Check legacy "format" and use consistent "json" flag instead
-		if *format == "json" {
-			jv := jsonFlag.Value.(pflag.SliceValue)
-			if err := jv.Replace(fields); err != nil {
-				return err
-			}
-			jsonFlag.Changed = true
-		}
-
-		return nil
-	}
-
-	_ = cmd.Flags().MarkDeprecated("format", "use `--json` instead")
-
-	// TODO: Implement filtering on specified fields; likely requires rewrite to use string queries instead of graphql tags.
-	cmdutil.AddJSONFlags(cmd, exportTarget, fields)
-}
 
 // JSONProject serializes a Project to JSON.
 func JSONProject(project queries.Project) ([]byte, error) {

--- a/pkg/cmd/project/shared/format/json.go
+++ b/pkg/cmd/project/shared/format/json.go
@@ -1,15 +1,14 @@
 package format
 
 import (
-	"encoding/json"
 	"strings"
 
 	"github.com/cli/cli/v2/pkg/cmd/project/shared/queries"
 )
 
 // JSONProject serializes a Project to JSON.
-func JSONProject(project queries.Project) ([]byte, error) {
-	return json.Marshal(ProjectJSON{
+func JSONProject(project queries.Project) ProjectJSON {
+	return ProjectJSON{
 		Number:           project.Number,
 		URL:              project.URL,
 		ShortDescription: project.ShortDescription,
@@ -39,7 +38,7 @@ func JSONProject(project queries.Project) ([]byte, error) {
 			Type:  project.OwnerType(),
 			Login: project.OwnerLogin(),
 		},
-	})
+	}
 }
 
 // JSONProjects serializes a slice of Projects to JSON.
@@ -117,7 +116,7 @@ type ProjectsJSON struct {
 }
 
 // JSONProjectField serializes a ProjectField to JSON.
-func JSONProjectField(field queries.ProjectField) ([]byte, error) {
+func JSONProjectField(field queries.ProjectField) ProjectFieldJSON {
 	val := ProjectFieldJSON{
 		ID:   field.ID(),
 		Name: field.Name(),
@@ -130,7 +129,7 @@ func JSONProjectField(field queries.ProjectField) ([]byte, error) {
 		})
 	}
 
-	return json.Marshal(val)
+	return val
 }
 
 // JSONProjectFields serializes a slice of ProjectFields to JSON.
@@ -177,17 +176,17 @@ type SingleSelectOptionJSON struct {
 }
 
 // JSONProjectItem serializes a ProjectItem to JSON.
-func JSONProjectItem(item queries.ProjectItem) ([]byte, error) {
-	return json.Marshal(projectItemJSON{
+func JSONProjectItem(item queries.ProjectItem) ProjectItemJSON {
+	return ProjectItemJSON{
 		ID:    item.ID(),
 		Title: item.Title(),
 		Body:  item.Body(),
 		Type:  item.Type(),
 		URL:   item.URL(),
-	})
+	}
 }
 
-type projectItemJSON struct {
+type ProjectItemJSON struct {
 	ID    string `json:"id"`
 	Title string `json:"title"`
 	Body  string `json:"body"`
@@ -200,17 +199,17 @@ type projectItemJSON struct {
 // https://docs.github.com/en/graphql/reference/mutations#updateprojectv2draftissue
 // is a DraftIssue https://docs.github.com/en/graphql/reference/objects#draftissue
 // and not a ProjectV2Item https://docs.github.com/en/graphql/reference/objects#projectv2item
-func JSONProjectDraftIssue(item queries.DraftIssue) ([]byte, error) {
+func JSONProjectDraftIssue(item queries.DraftIssue) DraftIssueJSON {
 
-	return json.Marshal(draftIssueJSON{
+	return DraftIssueJSON{
 		ID:    item.ID,
 		Title: item.Title,
 		Body:  item.Body,
 		Type:  "DraftIssue",
-	})
+	}
 }
 
-type draftIssueJSON struct {
+type DraftIssueJSON struct {
 	ID    string `json:"id"`
 	Title string `json:"title"`
 	Body  string `json:"body"`
@@ -361,15 +360,17 @@ func serializeProjectWithItems(project *queries.Project) []map[string]any {
 
 // JSONProjectWithItems returns a detailed JSON representation of project items.
 // JSON fields are `totalCount` and `items`.
-func JSONProjectDetailedItems(project *queries.Project) ([]byte, error) {
+func JSONProjectDetailedItems(project *queries.Project) ProjectDetailedItems {
 	items := serializeProjectWithItems(project)
-	return json.Marshal(struct {
-		Items      []map[string]any `json:"items"`
-		TotalCount int              `json:"totalCount"`
-	}{
+	return ProjectDetailedItems{
 		Items:      items,
 		TotalCount: project.Items.TotalCount,
-	})
+	}
+}
+
+type ProjectDetailedItems struct {
+	Items      []map[string]any `json:"items"`
+	TotalCount int              `json:"totalCount"`
 }
 
 // CamelCase converts a string to camelCase, which is useful for turning Go field names to JSON keys.

--- a/pkg/cmd/project/shared/format/json_test.go
+++ b/pkg/cmd/project/shared/format/json_test.go
@@ -359,8 +359,8 @@ func TestJSONProjectItem_DraftIssue_ProjectV2ItemFieldMilestoneValue(t *testing.
 }
 
 func TestCamelCase(t *testing.T) {
-	assert.Equal(t, "camelCase", CamelCase("camelCase"))
-	assert.Equal(t, "camelCase", CamelCase("CamelCase"))
-	assert.Equal(t, "c", CamelCase("C"))
-	assert.Equal(t, "", CamelCase(""))
+	assert.Equal(t, "camelCase", camelCase("camelCase"))
+	assert.Equal(t, "camelCase", camelCase("CamelCase"))
+	assert.Equal(t, "c", camelCase("C"))
+	assert.Equal(t, "", camelCase(""))
 }

--- a/pkg/cmd/project/shared/format/json_test.go
+++ b/pkg/cmd/project/shared/format/json_test.go
@@ -23,7 +23,7 @@ func TestJSONProject_User(t *testing.T) {
 	project.Fields.TotalCount = 2
 	project.Owner.TypeName = "User"
 	project.Owner.User.Login = "monalisa"
-	b, err := JSONProject(project)
+	b, err := json.Marshal(JSONProject(project))
 	assert.NoError(t, err)
 
 	assert.Equal(t, `{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"User","login":"monalisa"}}`, string(b))
@@ -43,7 +43,7 @@ func TestJSONProject_Org(t *testing.T) {
 	project.Fields.TotalCount = 2
 	project.Owner.TypeName = "Organization"
 	project.Owner.Organization.Login = "github"
-	b, err := JSONProject(project)
+	b, err := json.Marshal(JSONProject(project))
 	assert.NoError(t, err)
 
 	assert.Equal(t, `{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"Organization","login":"github"}}`, string(b))
@@ -93,7 +93,7 @@ func TestJSONProjectField_FieldType(t *testing.T) {
 	field.Field.ID = "123"
 	field.Field.Name = "name"
 
-	b, err := JSONProjectField(field)
+	b, err := json.Marshal(JSONProjectField(field))
 	assert.NoError(t, err)
 
 	assert.Equal(t, `{"id":"123","name":"name","type":"ProjectV2Field"}`, string(b))
@@ -115,7 +115,7 @@ func TestJSONProjectField_SingleSelectType(t *testing.T) {
 		},
 	}
 
-	b, err := JSONProjectField(field)
+	b, err := json.Marshal(JSONProjectField(field))
 	assert.NoError(t, err)
 
 	assert.Equal(t, `{"id":"123","name":"name","type":"ProjectV2SingleSelectField","options":[{"id":"123","name":"name"},{"id":"456","name":"name2"}]}`, string(b))
@@ -127,7 +127,7 @@ func TestJSONProjectField_ProjectV2IterationField(t *testing.T) {
 	field.IterationField.ID = "123"
 	field.IterationField.Name = "name"
 
-	b, err := JSONProjectField(field)
+	b, err := json.Marshal(JSONProjectField(field))
 	assert.NoError(t, err)
 
 	assert.Equal(t, `{"id":"123","name":"name","type":"ProjectV2IterationField"}`, string(b))
@@ -178,7 +178,7 @@ func TestJSONProjectItem_DraftIssue(t *testing.T) {
 	item.Content.DraftIssue.Title = "title"
 	item.Content.DraftIssue.Body = "a body"
 
-	b, err := JSONProjectItem(item)
+	b, err := json.Marshal(JSONProjectItem(item))
 	assert.NoError(t, err)
 
 	assert.Equal(t, `{"id":"123","title":"title","body":"a body","type":"DraftIssue"}`, string(b))
@@ -192,7 +192,7 @@ func TestJSONProjectItem_Issue(t *testing.T) {
 	item.Content.Issue.Body = "a body"
 	item.Content.Issue.URL = "a-url"
 
-	b, err := JSONProjectItem(item)
+	b, err := json.Marshal(JSONProjectItem(item))
 	assert.NoError(t, err)
 
 	assert.Equal(t, `{"id":"123","title":"title","body":"a body","type":"Issue","url":"a-url"}`, string(b))
@@ -206,7 +206,7 @@ func TestJSONProjectItem_PullRequest(t *testing.T) {
 	item.Content.PullRequest.Body = "a body"
 	item.Content.PullRequest.URL = "a-url"
 
-	b, err := JSONProjectItem(item)
+	b, err := json.Marshal(JSONProjectItem(item))
 	assert.NoError(t, err)
 
 	assert.Equal(t, `{"id":"123","title":"title","body":"a body","type":"PullRequest","url":"a-url"}`, string(b))
@@ -262,7 +262,7 @@ func TestJSONProjectDetailedItems(t *testing.T) {
 		},
 	}
 
-	out, err := JSONProjectDetailedItems(p)
+	out, err := json.Marshal(JSONProjectDetailedItems(p))
 	assert.NoError(t, err)
 	assert.Equal(
 		t,
@@ -276,7 +276,7 @@ func TestJSONProjectDraftIssue(t *testing.T) {
 	item.Title = "title"
 	item.Body = "a body"
 
-	b, err := JSONProjectDraftIssue(item)
+	b, err := json.Marshal(JSONProjectDraftIssue(item))
 	assert.NoError(t, err)
 
 	assert.Equal(t, `{"id":"123","title":"title","body":"a body","type":"DraftIssue"}`, string(b))
@@ -311,7 +311,7 @@ func TestJSONProjectItem_DraftIssue_ProjectV2ItemFieldIterationValue(t *testing.
 		draftIssue,
 	}
 
-	out, err := JSONProjectDetailedItems(p)
+	out, err := json.Marshal(JSONProjectDetailedItems(p))
 	assert.NoError(t, err)
 	assert.JSONEq(
 		t,
@@ -349,7 +349,7 @@ func TestJSONProjectItem_DraftIssue_ProjectV2ItemFieldMilestoneValue(t *testing.
 		draftIssue,
 	}
 
-	out, err := JSONProjectDetailedItems(p)
+	out, err := json.Marshal(JSONProjectDetailedItems(p))
 	assert.NoError(t, err)
 	assert.JSONEq(
 		t,

--- a/pkg/cmd/project/shared/format/json_test.go
+++ b/pkg/cmd/project/shared/format/json_test.go
@@ -164,7 +164,8 @@ func TestJSONProjectFields(t *testing.T) {
 			TotalCount: 5,
 		},
 	}
-	b, err := JSONProjectFields(p)
+	projectFieldsJSON := JSONProjectFields(p)
+	b, err := json.Marshal(projectFieldsJSON)
 	assert.NoError(t, err)
 
 	assert.Equal(t, `{"fields":[{"id":"123","name":"name","type":"ProjectV2Field"},{"id":"123","name":"name","type":"ProjectV2SingleSelectField","options":[{"id":"123","name":"name"},{"id":"456","name":"name2"}]}],"totalCount":5}`, string(b))

--- a/pkg/cmd/project/shared/format/json_test.go
+++ b/pkg/cmd/project/shared/format/json_test.go
@@ -1,6 +1,7 @@
 package format
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/cli/cli/v2/pkg/cmd/project/shared/queries"
@@ -76,7 +77,8 @@ func TestJSONProjects(t *testing.T) {
 	orgProject.Fields.TotalCount = 2
 	orgProject.Owner.TypeName = "Organization"
 	orgProject.Owner.Organization.Login = "github"
-	b, err := JSONProjects([]queries.Project{userProject, orgProject}, 2)
+	projectsJSON := JSONProjects([]queries.Project{userProject, orgProject}, 2)
+	b, err := json.Marshal(projectsJSON)
 	assert.NoError(t, err)
 
 	assert.Equal(

--- a/pkg/cmd/project/view/view.go
+++ b/pkg/cmd/project/view/view.go
@@ -16,10 +16,10 @@ import (
 )
 
 type viewOpts struct {
-	web    bool
-	owner  string
-	number int32
-	format string
+	web      bool
+	owner    string
+	number   int32
+	exporter cmdutil.Exporter
 }
 
 type viewConfig struct {
@@ -77,7 +77,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(config viewConfig) error) *cobra.C
 
 	viewCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the owner. Use \"@me\" for the current user.")
 	viewCmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open a project in the browser")
-	cmdutil.StringEnumFlag(viewCmd, &opts.format, "format", "", "", []string{"json"}, "Output format")
+	cmdutil.AddFormatFlags(viewCmd, &opts.exporter)
 
 	return viewCmd
 }
@@ -106,7 +106,7 @@ func runView(config viewConfig) error {
 		return err
 	}
 
-	if config.opts.format == "json" {
+	if config.opts.exporter != nil {
 		return printJSON(config, *project)
 	}
 
@@ -193,11 +193,6 @@ func printResults(config viewConfig, project *queries.Project) error {
 }
 
 func printJSON(config viewConfig, project queries.Project) error {
-	b, err := format.JSONProject(project)
-	if err != nil {
-		return err
-	}
-
-	_, err = config.io.Out.Write(b)
-	return err
+	projectJSON := format.JSONProject(project)
+	return config.opts.exporter.Write(config.io, projectJSON)
 }

--- a/pkg/cmd/project/view/view_test.go
+++ b/pkg/cmd/project/view/view_test.go
@@ -14,11 +14,12 @@ import (
 
 func TestNewCmdview(t *testing.T) {
 	tests := []struct {
-		name        string
-		cli         string
-		wants       viewOpts
-		wantsErr    bool
-		wantsErrMsg string
+		name          string
+		cli           string
+		wants         viewOpts
+		wantsErr      bool
+		wantsErrMsg   string
+		wantsExporter bool
 	}{
 		{
 			name:        "not-a-number",
@@ -48,11 +49,9 @@ func TestNewCmdview(t *testing.T) {
 			},
 		},
 		{
-			name: "json",
-			cli:  "--format json",
-			wants: viewOpts{
-				format: "json",
-			},
+			name:          "json",
+			cli:           "--format json",
+			wantsExporter: true,
 		},
 	}
 
@@ -85,7 +84,7 @@ func TestNewCmdview(t *testing.T) {
 
 			assert.Equal(t, tt.wants.number, gotOpts.number)
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
-			assert.Equal(t, tt.wants.format, gotOpts.format)
+			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 			assert.Equal(t, tt.wants.web, gotOpts.web)
 		})
 	}

--- a/pkg/cmdutil/json_flags.go
+++ b/pkg/cmdutil/json_flags.go
@@ -110,7 +110,7 @@ func checkJSONFlags(cmd *cobra.Command) (*exportFormat, error) {
 	return nil, nil
 }
 
-func AddFormatFlags(cmd *cobra.Command, exportTarget *Exporter, fields []string) {
+func AddFormatFlags(cmd *cobra.Command, exportTarget *Exporter) {
 	var format string
 	StringEnumFlag(cmd, &format, "format", "", "", []string{"json"}, "Output format")
 	f := cmd.Flags()
@@ -125,7 +125,7 @@ func AddFormatFlags(cmd *cobra.Command, exportTarget *Exporter, fields []string)
 			}
 		}
 
-		if export, err := checkFormatFlags(c, fields); err == nil {
+		if export, err := checkFormatFlags(c); err == nil {
 			if export == nil {
 				*exportTarget = nil
 			} else {
@@ -136,20 +136,9 @@ func AddFormatFlags(cmd *cobra.Command, exportTarget *Exporter, fields []string)
 		}
 		return nil
 	}
-
-	cmd.SetFlagErrorFunc(func(c *cobra.Command, e error) error {
-		if c == cmd && e.Error() == "flag needs an argument: --json" {
-			sort.Strings(fields)
-			return JSONFlagError{fmt.Errorf("Specify one or more comma-separated fields for `--json`:\n  %s", strings.Join(fields, "\n  "))}
-		}
-		if cmd.HasParent() {
-			return cmd.Parent().FlagErrorFunc()(c, e)
-		}
-		return e
-	})
 }
 
-func checkFormatFlags(cmd *cobra.Command, fields []string) (*exportFormat, error) {
+func checkFormatFlags(cmd *cobra.Command) (*exportFormat, error) {
 	f := cmd.Flags()
 	formatFlag := f.Lookup("format")
 	formatValue := formatFlag.Value.String()
@@ -162,7 +151,6 @@ func checkFormatFlags(cmd *cobra.Command, fields []string) (*exportFormat, error
 			return nil, errors.New("cannot use `--web` with `--format`")
 		}
 		return &exportFormat{
-			fields:   fields,
 			filter:   jqFlag.Value.String(),
 			template: tplFlag.Value.String(),
 		}, nil

--- a/pkg/cmdutil/json_flags.go
+++ b/pkg/cmdutil/json_flags.go
@@ -173,6 +173,18 @@ type exportFormat struct {
 	template string
 }
 
+// NewJSONExporter returns an Exporter to emit JSON.
+func NewJSONExporter(opts ...JSONExporterOption) Exporter {
+	e := &exportFormat{}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// JSONExporterOption customizes a JSON Exporter for NewJSONExporter.
+type JSONExporterOption func(e *exportFormat)
+
 func (e *exportFormat) Fields() []string {
 	return e.fields
 }

--- a/pkg/cmdutil/json_flags_test.go
+++ b/pkg/cmdutil/json_flags_test.go
@@ -117,7 +117,6 @@ func TestAddJSONFlags(t *testing.T) {
 }
 
 func TestAddFormatFlags(t *testing.T) {
-	fields := []string{"id", "number"}
 	tests := []struct {
 		name        string
 		args        []string
@@ -163,7 +162,6 @@ func TestAddFormatFlags(t *testing.T) {
 			name: "with json format",
 			args: []string{"--format", "json"},
 			wantsExport: &exportFormat{
-				fields:   fields,
 				filter:   "",
 				template: "",
 			},
@@ -172,7 +170,6 @@ func TestAddFormatFlags(t *testing.T) {
 			name: "with jq filter",
 			args: []string{"--format", "json", "-q.number"},
 			wantsExport: &exportFormat{
-				fields:   fields,
 				filter:   ".number",
 				template: "",
 			},
@@ -181,7 +178,6 @@ func TestAddFormatFlags(t *testing.T) {
 			name: "with Go template",
 			args: []string{"--format", "json", "-t", "{{.number}}"},
 			wantsExport: &exportFormat{
-				fields:   fields,
 				filter:   "",
 				template: "{{.number}}",
 			},
@@ -192,7 +188,7 @@ func TestAddFormatFlags(t *testing.T) {
 			cmd := &cobra.Command{Run: func(*cobra.Command, []string) {}}
 			cmd.Flags().Bool("web", false, "")
 			var exporter Exporter
-			AddFormatFlags(cmd, &exporter, fields)
+			AddFormatFlags(cmd, &exporter)
 			cmd.SetArgs(tt.args)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)

--- a/pkg/cmdutil/json_flags_test.go
+++ b/pkg/cmdutil/json_flags_test.go
@@ -16,7 +16,7 @@ func TestAddJSONFlags(t *testing.T) {
 		name        string
 		fields      []string
 		args        []string
-		wantsExport *exportFormat
+		wantsExport *jsonExporter
 		wantsError  string
 	}{
 		{
@@ -64,7 +64,7 @@ func TestAddJSONFlags(t *testing.T) {
 			name:   "with JSON fields",
 			fields: []string{"id", "number", "title"},
 			args:   []string{"--json", "number,title"},
-			wantsExport: &exportFormat{
+			wantsExport: &jsonExporter{
 				fields:   []string{"number", "title"},
 				filter:   "",
 				template: "",
@@ -74,7 +74,7 @@ func TestAddJSONFlags(t *testing.T) {
 			name:   "with jq filter",
 			fields: []string{"id", "number", "title"},
 			args:   []string{"--json", "number", "-q.number"},
-			wantsExport: &exportFormat{
+			wantsExport: &jsonExporter{
 				fields:   []string{"number"},
 				filter:   ".number",
 				template: "",
@@ -84,7 +84,7 @@ func TestAddJSONFlags(t *testing.T) {
 			name:   "with Go template",
 			fields: []string{"id", "number", "title"},
 			args:   []string{"--json", "number", "-t", "{{.number}}"},
-			wantsExport: &exportFormat{
+			wantsExport: &jsonExporter{
 				fields:   []string{"number"},
 				filter:   "",
 				template: "{{.number}}",
@@ -120,7 +120,7 @@ func TestAddFormatFlags(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
-		wantsExport *exportFormat
+		wantsExport *jsonExporter
 		wantsError  string
 	}{
 		{
@@ -161,7 +161,7 @@ func TestAddFormatFlags(t *testing.T) {
 		{
 			name: "with json format",
 			args: []string{"--format", "json"},
-			wantsExport: &exportFormat{
+			wantsExport: &jsonExporter{
 				filter:   "",
 				template: "",
 			},
@@ -169,7 +169,7 @@ func TestAddFormatFlags(t *testing.T) {
 		{
 			name: "with jq filter",
 			args: []string{"--format", "json", "-q.number"},
-			wantsExport: &exportFormat{
+			wantsExport: &jsonExporter{
 				filter:   ".number",
 				template: "",
 			},
@@ -177,7 +177,7 @@ func TestAddFormatFlags(t *testing.T) {
 		{
 			name: "with Go template",
 			args: []string{"--format", "json", "-t", "{{.number}}"},
-			wantsExport: &exportFormat{
+			wantsExport: &jsonExporter{
 				filter:   "",
 				template: "{{.number}}",
 			},
@@ -214,7 +214,7 @@ func Test_exportFormat_Write(t *testing.T) {
 	}
 	tests := []struct {
 		name     string
-		exporter exportFormat
+		exporter jsonExporter
 		args     args
 		wantW    string
 		wantErr  bool
@@ -222,7 +222,7 @@ func Test_exportFormat_Write(t *testing.T) {
 	}{
 		{
 			name:     "regular JSON output",
-			exporter: exportFormat{},
+			exporter: jsonExporter{},
 			args: args{
 				data: map[string]string{"name": "hubot"},
 			},
@@ -232,7 +232,7 @@ func Test_exportFormat_Write(t *testing.T) {
 		},
 		{
 			name:     "call ExportData",
-			exporter: exportFormat{fields: []string{"field1", "field2"}},
+			exporter: jsonExporter{fields: []string{"field1", "field2"}},
 			args: args{
 				data: &exportableItem{"item1"},
 			},
@@ -242,7 +242,7 @@ func Test_exportFormat_Write(t *testing.T) {
 		},
 		{
 			name:     "recursively call ExportData",
-			exporter: exportFormat{fields: []string{"f1", "f2"}},
+			exporter: jsonExporter{fields: []string{"f1", "f2"}},
 			args: args{
 				data: map[string]interface{}{
 					"s1": []exportableItem{{"i1"}, {"i2"}},
@@ -255,7 +255,7 @@ func Test_exportFormat_Write(t *testing.T) {
 		},
 		{
 			name:     "with jq filter",
-			exporter: exportFormat{filter: ".name"},
+			exporter: jsonExporter{filter: ".name"},
 			args: args{
 				data: map[string]string{"name": "hubot"},
 			},
@@ -265,7 +265,7 @@ func Test_exportFormat_Write(t *testing.T) {
 		},
 		{
 			name:     "with jq filter pretty printing",
-			exporter: exportFormat{filter: "."},
+			exporter: jsonExporter{filter: "."},
 			args: args{
 				data: map[string]string{"name": "hubot"},
 			},
@@ -275,7 +275,7 @@ func Test_exportFormat_Write(t *testing.T) {
 		},
 		{
 			name:     "with Go template",
-			exporter: exportFormat{template: "{{.name}}"},
+			exporter: jsonExporter{template: "{{.name}}"},
 			args: args{
 				data: map[string]string{"name": "hubot"},
 			},


### PR DESCRIPTION
Defines a new `cmdutil` package function that adds support for `--format` along with `--template` and `--jq`. This can be used instead of the `--json` flags which requires a field list and will filter the GraphQL query when filtering is unnecessary.