### PR TITLE
Remove GHE handling for `workflow`

### DIFF
--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -162,7 +162,7 @@ func Login(opts *LoginOptions) error {
 		fmt.Fprint(opts.IO.ErrOut, heredoc.Docf(`
 			Tip: you can generate a Personal Access Token here https://%s/settings/tokens
 			The minimum required scopes are %s.
-		`, hostname, scopesSentence(minimumScopes, ghinstance.IsEnterprise(hostname))))
+		`, hostname, scopesSentence(minimumScopes)))
 
 		var err error
 		authToken, err = opts.Prompter.AuthToken()
@@ -216,14 +216,10 @@ func Login(opts *LoginOptions) error {
 	return nil
 }
 
-func scopesSentence(scopes []string, isEnterprise bool) string {
+func scopesSentence(scopes []string) string {
 	quoted := make([]string, len(scopes))
 	for i, s := range scopes {
 		quoted[i] = fmt.Sprintf("'%s'", s)
-		if s == "workflow" && isEnterprise {
-			// remove when GHE 2.x reaches EOL
-			quoted[i] += " (GHE 3.0+)"
-		}
 	}
 	return strings.Join(quoted, ", ")
 }

--- a/pkg/cmd/auth/shared/login_flow_test.go
+++ b/pkg/cmd/auth/shared/login_flow_test.go
@@ -117,8 +117,7 @@ func TestLogin_ssh(t *testing.T) {
 
 func Test_scopesSentence(t *testing.T) {
 	type args struct {
-		scopes       []string
-		isEnterprise bool
+		scopes []string
 	}
 	tests := []struct {
 		name string
@@ -128,39 +127,28 @@ func Test_scopesSentence(t *testing.T) {
 		{
 			name: "basic scopes",
 			args: args{
-				scopes:       []string{"repo", "read:org"},
-				isEnterprise: false,
+				scopes: []string{"repo", "read:org"},
 			},
 			want: "'repo', 'read:org'",
 		},
 		{
 			name: "empty",
 			args: args{
-				scopes:       []string(nil),
-				isEnterprise: false,
+				scopes: []string(nil),
 			},
 			want: "",
 		},
 		{
-			name: "workflow scope for dotcom",
+			name: "workflow scope",
 			args: args{
-				scopes:       []string{"repo", "workflow"},
-				isEnterprise: false,
+				scopes: []string{"repo", "workflow"},
 			},
 			want: "'repo', 'workflow'",
-		},
-		{
-			name: "workflow scope for GHE",
-			args: args{
-				scopes:       []string{"repo", "workflow"},
-				isEnterprise: true,
-			},
-			want: "'repo', 'workflow' (GHE 3.0+)",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := scopesSentence(tt.args.scopes, tt.args.isEnterprise); got != tt.want {
+			if got := scopesSentence(tt.args.scopes); got != tt.want {
 				t.Errorf("scopesSentence() = %q, want %q", got, tt.want)
 			}
 		})


### PR DESCRIPTION

According to [0] we appear to no longer support GHE 2.x, as the latest
release was deprecated in early 2022.

We can therefore remove this custom handling.

[0]: https://docs.github.com/en/enterprise-server@3.7/admin/all-releases

