### PR TITLE
codespace: Handle HTTP request retry interruption

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -1159,6 +1159,6 @@ func (a *API) withRetry(f func() (*http.Response, error)) (*http.Response, error
 		if resp.StatusCode < 500 {
 			return resp, nil
 		}
-		return nil, errors.New("retry")
+		return nil, fmt.Errorf("received response with status code %d", resp.StatusCode)
 	}, backoff.WithMaxRetries(bo, 3))
 }


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

ref: https://github.com/cli/cli/issues/7819

## About

Fix the problem that the process of changing the error message depending on the cause of the HTTP request failure in `ConnectToLiveshare` did not work well.

## Problem

The current `ConnectToLiveshare` implementation always shows a timeout error message even if the GitHub API returns a 5XX error. This confuses users.

## Changes

The process of changing the error message depending on the cause of the HTTP request failure in `ConnectToLiveshare` was  implemented by determining if the error was wrapped with `backoff.PermanentError`. However, `backoff.Retry` unwraps it and returns the unwrapped error. Therefore, it cannot be determined by this method.
https://github.com/cenkalti/backoff/blob/a04a6fe64ffb0e3fd0816460529d300be5f252df/retry.go#L93-L96

In order to be able to determine it, define a new error type `TimeoutError` that represents a timeout, and use this type to determine the cause of the HTTP request failure.

## Behavior

With this change, the error message when a request in `ConnectToCodespace` function fails with a GitHub API's 5XX error will change as follows:
  - before: `failed to connect to Live Share: timed out while waiting for the codespace to start`
  - after: `failed to connect to Live Share: error getting codespace: error making request: retry`