### PR TITLE
Disable issue with template

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -164,8 +164,8 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			if cmd.Flags().Changed("enable-wiki") {
 				opts.DisableWiki = !enableWiki
 			}
-			if opts.Template != "" && (opts.Homepage != "" || opts.Team != "" || opts.DisableIssues) {
-				return cmdutil.FlagErrorf("the `--template` option is not supported with `--homepage`, `--team`, or `--disable-issues`")
+			if opts.Template != "" && (opts.Homepage != "" || opts.Team != "") {
+				return cmdutil.FlagErrorf("the `--template` option is not supported with `--homepage`, or `--team`")
 			}
 
 			if opts.Template == "" && opts.IncludeAllBranches {

--- a/pkg/cmd/repo/create/http.go
+++ b/pkg/cmd/repo/create/http.go
@@ -65,8 +65,9 @@ type cloneTemplateRepositoryInput struct {
 }
 
 type updateRepositoryInput struct {
-	RepositoryID   string `json:"repositoryId"`
-	HasWikiEnabled bool   `json:"hasWikiEnabled"`
+	RepositoryID     string `json:"repositoryId"`
+	HasWikiEnabled   bool   `json:"hasWikiEnabled"`
+	HasIssuesEnabled bool   `json:"hasIssuesEnabled"`
 }
 
 // repoCreate creates a new GitHub repository
@@ -138,11 +139,12 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput) (*a
 			return nil, err
 		}
 
-		if !input.HasWikiEnabled {
+		if !input.HasWikiEnabled || !input.HasIssuesEnabled {
 			updateVariables := map[string]interface{}{
 				"input": updateRepositoryInput{
-					RepositoryID:   response.CloneTemplateRepository.Repository.ID,
-					HasWikiEnabled: input.HasWikiEnabled,
+					RepositoryID:     response.CloneTemplateRepository.Repository.ID,
+					HasWikiEnabled:   input.HasWikiEnabled,
+					HasIssuesEnabled: input.HasIssuesEnabled,
 				},
 			}
 

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -297,6 +297,71 @@ func Test_repoCreate(t *testing.T) {
 			wantRepo: "https://github.com/OWNER/REPO",
 		},
 		{
+			name:     "create personal repo from template repo, and disable issues",
+			hostname: "github.com",
+			input: repoCreateInput{
+				Name:                 "gen-project",
+				Description:          "my generated project",
+				Visibility:           "private",
+				TemplateRepositoryID: "TPLID",
+				HasIssuesEnabled:     false,
+				HasWikiEnabled:       true,
+				IncludeAllBranches:   false,
+			},
+			stubs: func(t *testing.T, r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StringResponse(`{"data": {"viewer": {"id":"USERID"} } }`))
+				r.Register(
+					httpmock.GraphQL(`mutation CloneTemplateRepository\b`),
+					httpmock.GraphQLMutation(
+						`{
+							"data": {
+								"cloneTemplateRepository": {
+									"repository": {
+										"id": "REPOID",
+										"name": "REPO",
+										"owner": {"login":"OWNER"},
+										"url": "the://URL"
+									}
+								}
+							}
+						}`,
+						func(inputs map[string]interface{}) {
+							assert.Equal(t, map[string]interface{}{
+								"name":               "gen-project",
+								"description":        "my generated project",
+								"visibility":         "PRIVATE",
+								"ownerId":            "USERID",
+								"repositoryId":       "TPLID",
+								"includeAllBranches": false,
+							}, inputs)
+						}),
+				)
+				r.Register(
+					httpmock.GraphQL(`mutation UpdateRepository\b`),
+					httpmock.GraphQLMutation(
+						`{
+							"data": {
+								"updateRepository": {
+									"repository": {
+										"id": "REPOID"
+									}
+								}
+							}
+						}`,
+						func(inputs map[string]interface{}) {
+							assert.Equal(t, map[string]interface{}{
+								"repositoryId":     "REPOID",
+								"hasWikiEnabled":   true,
+								"hasIssuesEnabled": false,
+							}, inputs)
+						}),
+				)
+			},
+			wantRepo: "https://github.com/OWNER/REPO",
+		},
+		{
 			name:     "create org repo from template repo",
 			hostname: "github.com",
 			input: repoCreateInput{

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -287,8 +287,9 @@ func Test_repoCreate(t *testing.T) {
 						}`,
 						func(inputs map[string]interface{}) {
 							assert.Equal(t, map[string]interface{}{
-								"repositoryId":   "REPOID",
-								"hasWikiEnabled": false,
+								"repositoryId":     "REPOID",
+								"hasWikiEnabled":   false,
+								"hasIssuesEnabled": true,
 							}, inputs)
 						}),
 				)


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Similar to #7886 

In this PR, I have made it possible to use --disable-issues option with --template option.

fyi: https://docs.github.com/en/graphql/reference/mutations#updaterepository