### PR TITLE
rename template to mark-template cmd

### DIFF
--- a/pkg/cmd/project/mark-template/mark_template_test.go
+++ b/pkg/cmd/project/mark-template/mark_template_test.go
@@ -1,4 +1,4 @@
-package template
+package marktemplate
 
 import (
 	"testing"
@@ -11,11 +11,11 @@ import (
 	"gopkg.in/h2non/gock.v1"
 )
 
-func TestNewCmdTemplate(t *testing.T) {
+func TestNewCmdMarkTemplate(t *testing.T) {
 	tests := []struct {
 		name        string
 		cli         string
-		wants       templateOpts
+		wants       markTemplateOpts
 		wantsErr    bool
 		wantsErrMsg string
 	}{
@@ -28,21 +28,21 @@ func TestNewCmdTemplate(t *testing.T) {
 		{
 			name: "number",
 			cli:  "123",
-			wants: templateOpts{
+			wants: markTemplateOpts{
 				number: 123,
 			},
 		},
 		{
 			name: "owner",
 			cli:  "--owner monalisa",
-			wants: templateOpts{
+			wants: markTemplateOpts{
 				owner: "monalisa",
 			},
 		},
 		{
 			name: "undo",
 			cli:  "--undo",
-			wants: templateOpts{
+			wants: markTemplateOpts{
 				undo: true,
 			},
 		},
@@ -50,7 +50,7 @@ func TestNewCmdTemplate(t *testing.T) {
 		{
 			name: "json",
 			cli:  "--format json",
-			wants: templateOpts{
+			wants: markTemplateOpts{
 				format: "json",
 			},
 		},
@@ -68,8 +68,8 @@ func TestNewCmdTemplate(t *testing.T) {
 			argv, err := shlex.Split(tt.cli)
 			assert.NoError(t, err)
 
-			var gotOpts templateOpts
-			cmd := NewCmdTemplate(f, func(config templateConfig) error {
+			var gotOpts markTemplateOpts
+			cmd := NewCmdMarkTemplate(f, func(config markTemplateConfig) error {
 				gotOpts = config.opts
 				return nil
 			})
@@ -164,8 +164,8 @@ func TestRunMarkTemplate_Org(t *testing.T) {
 
 	ios, _, stdout, _ := iostreams.Test()
 	ios.SetStdoutTTY(true)
-	config := templateConfig{
-		opts: templateOpts{
+	config := markTemplateConfig{
+		opts: markTemplateOpts{
 			owner:  "github",
 			number: 1,
 		},
@@ -173,7 +173,7 @@ func TestRunMarkTemplate_Org(t *testing.T) {
 		io:     ios,
 	}
 
-	err := runTemplate(config)
+	err := runMarkTemplate(config)
 	assert.NoError(t, err)
 	assert.Equal(
 		t,
@@ -256,8 +256,8 @@ func TestRunUnmarkTemplate_Org(t *testing.T) {
 
 	ios, _, stdout, _ := iostreams.Test()
 	ios.SetStdoutTTY(true)
-	config := templateConfig{
-		opts: templateOpts{
+	config := markTemplateConfig{
+		opts: markTemplateOpts{
 			owner:  "github",
 			number: 1,
 			undo:   true,
@@ -266,7 +266,7 @@ func TestRunUnmarkTemplate_Org(t *testing.T) {
 		io:     ios,
 	}
 
-	err := runTemplate(config)
+	err := runMarkTemplate(config)
 	assert.NoError(t, err)
 	assert.Equal(
 		t,

--- a/pkg/cmd/project/project.go
+++ b/pkg/cmd/project/project.go
@@ -17,7 +17,7 @@ import (
 	cmdItemEdit "github.com/cli/cli/v2/pkg/cmd/project/item-edit"
 	cmdItemList "github.com/cli/cli/v2/pkg/cmd/project/item-list"
 	cmdList "github.com/cli/cli/v2/pkg/cmd/project/list"
-	cmdTemplate "github.com/cli/cli/v2/pkg/cmd/project/template"
+	cmdTemplate "github.com/cli/cli/v2/pkg/cmd/project/mark-template"
 	cmdView "github.com/cli/cli/v2/pkg/cmd/project/view"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -44,7 +44,7 @@ func NewCmdProject(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(cmdDelete.NewCmdDelete(f, nil))
 	cmd.AddCommand(cmdEdit.NewCmdEdit(f, nil))
 	cmd.AddCommand(cmdView.NewCmdView(f, nil))
-	cmd.AddCommand(cmdTemplate.NewCmdTemplate(f, nil))
+	cmd.AddCommand(cmdTemplate.NewCmdMarkTemplate(f, nil))
 
 	// items
 	cmd.AddCommand(cmdItemList.NewCmdList(f, nil))


### PR DESCRIPTION
Follow up to https://github.com/cli/cli/pull/7916 it was decided that `mark-template` is a better name for that command. As this hasn't been included in a release yet, it's safe to update.

Command output
```
go run cmd/gh/main.go project -h

Work with GitHub Projects. Note that the token you are using must have 'project' scope, which is not set by default. You can verify your token scope by running 'gh auth status' and add the project scope by running 'gh auth refresh -s project'.

USAGE
  gh project <command> [flags]

AVAILABLE COMMANDS
  ...
  mark-template: Mark a project as a template
```

Tested:
```
go run cmd/gh/main.go project mark-template 1 --owner "github"
go run cmd/gh/main.go project mark-template 1 --owner "github" --undo
```

Note: this does not change the JSON field name, which remains `template` to match the returned API value.