### PR TITLE
Add formula-path to homebrew-bump step

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -340,7 +340,7 @@ jobs:
         if: inputs.environment == 'production' && !contains(inputs.tag_name, '-')
         with:
           formula-name: gh
-          formula-path: "Formula/g/gh.rb"
+          formula-path: Formula/g/gh.rb
           tag-name: ${{ inputs.tag_name }}
           push-to: cli/homebrew-core
         env:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -340,6 +340,7 @@ jobs:
         if: inputs.environment == 'production' && !contains(inputs.tag_name, '-')
         with:
           formula-name: gh
+          formula-path: "Formula/g/gh.rb"
           tag-name: ${{ inputs.tag_name }}
           push-to: cli/homebrew-core
         env:


### PR DESCRIPTION
### Description

As described in https://github.com/cli/cli/issues/7718#issuecomment-1702877074, there has been a change to the structure of the `homebrew-core` repository such that formulas are now sharded by the first letter of their name e.g.

```
.../Formula/gh.rb -> .../Formula/g/gh.rb 
```

This means that when the action attempts to [get contents of a file it will fail](https://github.com/mislav/bump-homebrew-formula-action/blob/a1aa5acee0698beefeac8f69f2eb8a5f292bf8bb/src/edit-github-blob.ts#L103). This is also described in an [issue on the action repository](https://github.com/mislav/bump-homebrew-formula-action/issues/58).

Using the `formula-path` repo allows this to succeed as shown below comparing bad and good runs:

### Bad

```
➜  act -j release --input tag_name=v1 -s HOMEBREW_PR_PAT=<REDACTED>
WARN  ⚠ You are using Apple M-series chip and you have not specified container architecture, you might encounter issues while running act. If so, try running it with '--container-architecture linux/amd64'. ⚠
[Deployment/release] 🚀  Start image=catthehacker/ubuntu:act-latest
[Deployment/release]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
[Deployment/release]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[Deployment/release]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[Deployment/release]   ☁  git clone 'https://github.com/mislav/bump-homebrew-formula-action' # ref=v2
[Deployment/release] ⭐ Run Main Bump homebrew-core formula
[Deployment/release]   🐳  docker cp src=/Users/williammartin/.cache/act/mislav-bump-homebrew-formula-action@v2/ dst=/var/run/act/actions/mislav-bump-homebrew-formula-action@v2/
[Deployment/release]   🐳  docker exec cmd=[node /var/run/act/actions/mislav-bump-homebrew-formula-action@v2/lib/index.js] user= workdir=
| GET /repos/williammartin-test-org/homebrew-upgrade-test/tarball/v1 - 302 in 234ms
[Deployment/release]   💬  ::debug::GET https://codeload.github.com/williammartin-test-org/homebrew-upgrade-test/tar.gz/refs/tags/v1
| GET /repos/Homebrew/homebrew-core - 200 in 304ms
| GET /repos/Homebrew/homebrew-core/branches/master - 200 in 256ms
| POST /repos/cli/homebrew-core/merge-upstream - 200 in 706ms
| POST /repos/cli/homebrew-core/git/refs - 201 in 536ms
| GET /repos/cli/homebrew-core/contents/Formula%2Fgh.rb?ref=update-gh.rb-1693576800 - 404 in 295ms
[Deployment/release]   ❗  ::error::HttpError: Not Found
[Deployment/release]   ❌  Failure - Main Bump homebrew-core formula
[Deployment/release] exitcode '1': failure
[Deployment/release] 🏁  Job failed
Error: Job 'release' failed
```

#### Good

```
...
[Deployment/wmbump]   💬  ::debug::GET https://codeload.github.com/cli/cli/tar.gz/refs/tags/v2.33.0
| GET /repos/Homebrew/homebrew-core - 200 in 362ms
| GET /repos/Homebrew/homebrew-core/branches/master - 200 in 248ms
| POST /repos/cli/homebrew-core/merge-upstream - 200 in 452ms
| POST /repos/cli/homebrew-core/git/refs - 201 in 503ms
| GET /repos/cli/homebrew-core/contents/Formula%2Fg%2Fgh.rb?ref=update-gh.rb-1693579365 - 200 in 271ms
| Skipping: the formula is already at version 'v2.33.0'
[Deployment/wmbump]   ✅  Success - Main Bump homebrew-core formula
[Deployment/wmbump] 🏁  Job succeeded
```
