### PR TITLE
Add a test workflow for homebrew bump investigations

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,22 @@
+name: homebrewbump
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  homebrewbump:
+    environment: production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bump homebrew-core formula
+        uses: mislav/bump-homebrew-formula-action@v2
+        with:
+          formula-name: gh
+          formula-path: Formula/g/gh.rb
+          tag-name: v2.34.0
+          push-to: cli/homebrew-core
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_PR_PAT }}


### PR DESCRIPTION
### Description 

As part of investigating the [failures of our homebrew bump job](https://github.com/cli/cli/actions/runs/6096253415/job/16541661056), I'm adding a test workflow that we can run independently of the rest of the release steps to check things are working correctly.

When run, we would expect the job to succeed, but not open a new PR as the version v2.34.0 has already been accepted into homebrew-core.

Expect this to be removed after the investigation is complete.