### PR TITLE
feat(cache): Add JSON exporting support for cache list

### DIFF
--- a/pkg/cmd/cache/list/list.go
+++ b/pkg/cmd/cache/list/list.go
@@ -21,6 +21,7 @@ type ListOptions struct {
 	BaseRepo   func() (ghrepo.Interface, error)
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
+	Exporter   cmdutil.Exporter
 	Now        time.Time
 
 	Limit int
@@ -68,6 +69,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum number of caches to fetch")
 	cmdutil.StringEnumFlag(cmd, &opts.Order, "order", "O", "desc", []string{"asc", "desc"}, "Order of caches returned")
 	cmdutil.StringEnumFlag(cmd, &opts.Sort, "sort", "S", "last_accessed_at", []string{"created_at", "last_accessed_at", "size_in_bytes"}, "Sort fetched caches")
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, shared.CacheFields)
 
 	return cmd
 }
@@ -99,6 +101,10 @@ func listRun(opts *ListOptions) error {
 		defer opts.IO.StopPager()
 	} else {
 		fmt.Fprintf(opts.IO.Out, "Failed to start pager: %v\n", err)
+	}
+
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, result.ActionsCaches)
 	}
 
 	if opts.IO.IsStdoutTTY() {

--- a/pkg/cmd/cache/shared/shared.go
+++ b/pkg/cmd/cache/shared/shared.go
@@ -2,11 +2,23 @@ package shared
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 )
+
+var CacheFields = []string{
+	"createdAt",
+	"id",
+	"key",
+	"lastAccessedAt",
+	"ref",
+	"sizeInBytes",
+	"version",
+}
 
 type Cache struct {
 	CreatedAt      time.Time `json:"created_at"`
@@ -70,4 +82,20 @@ pagination:
 	}
 
 	return result, nil
+}
+
+func (c *Cache) ExportData(fields []string) map[string]interface{} {
+	v := reflect.ValueOf(c).Elem()
+	fieldByName := func(v reflect.Value, field string) reflect.Value {
+		return v.FieldByNameFunc(func(s string) bool {
+			return strings.EqualFold(field, s)
+		})
+	}
+	data := map[string]interface{}{}
+
+	for _, f := range fields {
+		data[f] = fieldByName(v, f).Interface()
+	}
+
+	return data
 }

--- a/pkg/cmd/cache/shared/shared_test.go
+++ b/pkg/cmd/cache/shared/shared_test.go
@@ -1,13 +1,19 @@
 package shared
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetCaches(t *testing.T) {
@@ -63,6 +69,77 @@ func TestGetCaches(t *testing.T) {
 			result, err := GetCaches(client, repo, tt.opts)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantsCount, len(result.ActionsCaches))
+		})
+	}
+}
+
+func TestCache_ExportData(t *testing.T) {
+	src := heredoc.Doc(
+		`
+		{
+			"id": 505,
+			"ref": "refs/heads/main",
+			"key": "Linux-node-958aff96db2d75d67787d1e634ae70b659de937b",
+			"version": "73885106f58cc52a7df9ec4d4a5622a5614813162cb516c759a30af6bf56e6f0",
+			"last_accessed_at": "2019-01-24T22:45:36.000Z",
+			"created_at": "2019-01-24T22:45:36.000Z",
+			"size_in_bytes": 1024
+		}
+	`,
+	)
+
+	tests := []struct {
+		name       string
+		fields     []string
+		inputJSON  string
+		outputJSON string
+	}{
+		{
+			name:      "basic",
+			fields:    []string{"id", "key"},
+			inputJSON: src,
+			outputJSON: heredoc.Doc(
+				`
+				{
+					"id": 505,
+					"key": "Linux-node-958aff96db2d75d67787d1e634ae70b659de937b"
+				}
+			`,
+			),
+		},
+		{
+			name:      "full",
+			fields:    []string{"id", "ref", "key", "version", "lastAccessedAt", "createdAt", "sizeInBytes"},
+			inputJSON: src,
+			outputJSON: heredoc.Doc(
+				`
+				{
+					"createdAt": "2019-01-24T22:45:36Z",
+					"id": 505,
+					"key": "Linux-node-958aff96db2d75d67787d1e634ae70b659de937b",
+					"lastAccessedAt": "2019-01-24T22:45:36Z",
+					"ref": "refs/heads/main",
+					"sizeInBytes": 1024,
+					"version": "73885106f58cc52a7df9ec4d4a5622a5614813162cb516c759a30af6bf56e6f0"
+				}
+			`,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cache Cache
+			dec := json.NewDecoder(strings.NewReader(tt.inputJSON))
+			require.NoError(t, dec.Decode(&cache))
+
+			exported := cache.ExportData(tt.fields)
+
+			buf := bytes.Buffer{}
+			enc := json.NewEncoder(&buf)
+			enc.SetIndent("", "\t")
+			require.NoError(t, enc.Encode(exported))
+			assert.Equal(t, tt.outputJSON, buf.String())
 		})
 	}
 }


### PR DESCRIPTION
Closes #8032

This pull request proposes to add JSON exporting support for `gh cache list` command. This command was introduced in #7014. To extend the feature (e.g. Find caches that have some prefix), we want JSON exports so that we can interact with the cache list easily.

```
❯ go run ./cmd/gh cache list --json id,createdAt,key,lastAccessedAt,ref,sizeInBytes,version | jq '.[0]'
{
  "createdAt": "2023-08-31T19:26:13.0766667Z",
  "id": 1497,
  "key": "go-macOS-8610833a18cf890ecf488fae2b2c599ff728d9aa62abbd9f1e35b1bd4f9de6cd",
  "lastAccessedAt": "2023-09-06T14:53:14.8666667Z",
  "ref": "refs/heads/trunk",
  "sizeInBytes": 439063406,
  "version": "2a8d0f2be1a88abb057cd9fcea9832bd16e7ab71798dbf93cd890eb9add83cf6"
}
```
