### PR TITLE
Clarify list repo behavior

### DIFF
--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -58,8 +58,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Long: heredoc.Docf(`
                   List and filter repositories owned by a user or organization.
 
-                  When listing repositories for an organization, this will not include repositories owned by members of the organization.
-		  This also applies when using the %[1]s--archived%[1]s, %[1]s--no-archived%[1]s, %[1]s--fork%[1]s, and %[1]s--source%[1]s options.
+                  Note that the list will only include repositories owned by the provided argument, and the %[1]s--fork%[1]s or %[1]s--source%[1]s flags will not traverse ownership boundaries.
+		  For example, when listing the forks in an organization, the output would not include those owned by individual users.
 		`, "`"),
 		Aliases: []string{"ls"},
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
 	"github.com/cli/cli/v2/api"
@@ -52,14 +53,15 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	)
 
 	cmd := &cobra.Command{
-		Use:     "list [<owner>]",
-		Args:    cobra.MaximumNArgs(1),
-		Short:   "List repositories owned by user or organization",
+		Use:   "list [<owner>]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "List repositories owned by user or organization",
 		Long: heredoc.Docf(`
-                  List and filter repositories owned by a user or organization.
+			List repositories owned by a user or organization.
 
-                  Note that the list will only include repositories owned by the provided argument, and the %[1]s--fork%[1]s or %[1]s--source%[1]s flags will not traverse ownership boundaries.
-		  For example, when listing the forks in an organization, the output would not include those owned by individual users.
+			Note that the list will only include repositories owned by the provided argument,
+			and the %[1]s--fork%[1]s or %[1]s--source%[1]s flags will not traverse ownership boundaries. For example,
+			when listing the forks in an organization, the output would not include those owned by individual users.
 		`, "`"),
 		Aliases: []string{"ls"},
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -55,6 +55,12 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Use:     "list [<owner>]",
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "List repositories owned by user or organization",
+		Long: heredoc.Docf(`
+                  List and filter repositories owned by a user or organization.
+
+                  When listing repositories for an organization, this will not include repositories owned by members of the organization.
+		  This also applies when using the %[1]s--archived%[1]s, %[1]s--no-archived%[1]s, %[1]s--fork%[1]s, and %[1]s--source%[1]s options.
+		`, "`"),
 		Aliases: []string{"ls"},
 		RunE: func(c *cobra.Command, args []string) error {
 			if opts.Limit < 1 {


### PR DESCRIPTION
This PR adds some clarification to the `gh repo list` command. Specifically, it addresses a possible point of confusion: when listing forks for an organization, it does not include forks owned by members of the organization.

**Edit by @williammartin**: This PR relates to https://github.com/cli/cli/issues/7975 and https://github.com/cli/cli/issues/7958