### PR TITLE
Reinforce not opening PRs without approval on an issue

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Please do:
 Please avoid:
 
 * Opening pull requests for issues marked `needs-design`, `needs-investigation`, or `blocked`.
+* Opening pull requests that haven't been approved for work in an issue
 * Adding installation instructions specifically for your OS/package manager.
 * Opening pull requests for any issue marked `core`. These issues require additional context from
   the core CLI team at GitHub and any external pull requests will not be accepted.


### PR DESCRIPTION
### Description

To be honest, the first time I read the `CONTRIBUTING` guide I jumped to the bullet points and didn't really give a lot of weight to the sentence:

> We accept pull requests for bug fixes and features where we've discussed the approach in an issue and given the go-ahead for a community member to work on it.

This just adds to the please avoid section to reinforce this idea.