### PR TITLE
Show full permissions URL in `gh cs create`

### DIFF
--- a/pkg/cmd/codespace/create.go
+++ b/pkg/cmd/codespace/create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cli/cli/v2/internal/codespaces"
 	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
-	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -336,13 +335,12 @@ func (a *App) handleAdditionalPermissions(ctx context.Context, createParams *api
 	var (
 		isInteractive = a.io.CanPrompt()
 		cs            = a.io.ColorScheme()
-		displayURL    = text.DisplayURL(allowPermissionsURL)
 	)
 
 	fmt.Fprintf(a.io.ErrOut, "You must authorize or deny additional permissions requested by this codespace before continuing.\n")
 
 	if !isInteractive {
-		fmt.Fprintf(a.io.ErrOut, "%s in your browser to review and authorize additional permissions: %s\n", cs.Bold("Open this URL"), displayURL)
+		fmt.Fprintf(a.io.ErrOut, "%s in your browser to review and authorize additional permissions: %s\n", cs.Bold("Open this URL"), allowPermissionsURL)
 		fmt.Fprintf(a.io.ErrOut, "Alternatively, you can run %q with the %q option to continue without authorizing additional permissions.\n", a.io.ColorScheme().Bold("create"), cs.Bold("--default-permissions"))
 		return nil, cmdutil.SilentError
 	}


### PR DESCRIPTION
As described in https://github.com/cli/cli/issues/7982, the Codespaces create permissions URL can contain query parameters that are needed to ensure the correct devcontainer permissions are being authorized.

These were being stripped by `text.DisplayURL`, which resulted in directing the user to the wrong page to authorize permissions if they weren't using the default devcontainer on the default branch.

This PR removes that `text.DisplayURL` and displays the full permissions URL.

```shell
./bin/gh cs create --repo ORG/REPO --branch main --devcontainer-path=.devcontainer/actions/devcontainer.json | tail -n 1 
  ✓ Codespaces usage for this repository is paid for by ORG
You must authorize or deny additional permissions requested by this codespace before continuing.
Open this URL in your browser to review and authorize additional permissions: https://github.com/ORG/REPO/codespaces/allow_permissions?ref=main&devcontainer_path=.devcontainer/actions/devcontainer.json
Alternatively, you can run "create" with the "--default-permissions" option to continue without authorizing additional permissions.
```