### PR TITLE
update(project/item-edit): New clear flag to remove item field value

### DIFF
--- a/pkg/cmd/project/item-edit/item_edit.go
+++ b/pkg/cmd/project/item-edit/item_edit.go
@@ -70,6 +70,9 @@ func NewCmdEditItem(f *cmdutil.Factory, runF func(config editItemConfig) error) 
 		Example: heredoc.Doc(`
 			# edit an item's text field value
 			gh project item-edit --id <item-ID> --field-id <field-ID> --project-id <project-ID> --text "new text"
+
+			# clear an item's field value
+			gh project item-edit --id <item-ID> --field-id <field-ID> --project-id <project-ID> --clear
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmdutil.MutuallyExclusive(

--- a/pkg/cmd/project/item-edit/item_edit.go
+++ b/pkg/cmd/project/item-edit/item_edit.go
@@ -66,6 +66,8 @@ func NewCmdEditItem(f *cmdutil.Factory, runF func(config editItemConfig) error) 
 			Edit either a draft issue or a project item. Both usages require the ID of the item to edit.
 			
 			For non-draft issues, the ID of the project is also required, and only a single field value can be updated per invocation.
+
+			Remove project item field value using "--clear" flag.
 		`),
 		Example: heredoc.Doc(`
 			# edit an item's text field value

--- a/pkg/cmd/project/item-edit/item_edit.go
+++ b/pkg/cmd/project/item-edit/item_edit.go
@@ -173,6 +173,9 @@ func runEditItem(config editItemConfig) error {
 
 	// update item values
 	if config.opts.text != "" || config.opts.number != 0 || config.opts.date != "" || config.opts.singleSelectOptionID != "" || config.opts.iterationID != "" {
+		if config.opts.fieldID == "" && config.opts.projectID == "" {
+			return cmdutil.FlagErrorf("field-id and project-id must be provided")
+		}
 		if config.opts.fieldID == "" {
 			return cmdutil.FlagErrorf("field-id must be provided")
 		}

--- a/pkg/cmd/project/item-edit/item_edit.go
+++ b/pkg/cmd/project/item-edit/item_edit.go
@@ -83,6 +83,14 @@ func NewCmdEditItem(f *cmdutil.Factory, runF func(config editItemConfig) error) 
 				return err
 			}
 
+			if err := cmdutil.MutuallyExclusive(
+				"cannot use `--text`, `--number`, `--date`, `--single-select-option-id` or `--iteration-id` in conjunction with `--clear`",
+				opts.text != "" || opts.number != 0 || opts.date != "" || opts.singleSelectOptionID != "" || opts.iterationID != "",
+				opts.clear,
+			); err != nil {
+				return err
+			}
+
 			client, err := client.New(f)
 			if err != nil {
 				return err
@@ -134,9 +142,6 @@ func runEditItem(config editItemConfig) error {
 		if config.opts.projectID == "" {
 			// TODO: offer to fetch interactively
 			return cmdutil.FlagErrorf("project-id must be provided for use with the clear flag")
-		}
-		if config.opts.text != "" || config.opts.number != 0 || config.opts.date != "" || config.opts.singleSelectOptionID != "" || config.opts.iterationID != "" {
-			return cmdutil.FlagErrorf("cannot use this flag in conjunction with clear")
 		}
 		query, variables := buildClearItem(config)
 		err := config.client.Mutate("ClearItemFieldValue", query, variables)

--- a/pkg/cmd/project/item-edit/item_edit.go
+++ b/pkg/cmd/project/item-edit/item_edit.go
@@ -138,23 +138,17 @@ func NewCmdEditItem(f *cmdutil.Factory, runF func(config editItemConfig) error) 
 func runEditItem(config editItemConfig) error {
 	// when clear flag is used, remove value set to the corresponding field ID
 	if config.opts.clear {
-		if err := clearItemFieldValue(config); err != nil {
-			return err
-		}
+		return clearItemFieldValue(config)
 	}
 
 	// update draft issue
 	if config.opts.title != "" || config.opts.body != "" {
-		if err := updateDraftIssue(config); err != nil {
-			return err
-		}
+		return updateDraftIssue(config)
 	}
 
 	// update item values
 	if config.opts.text != "" || config.opts.number != 0 || config.opts.date != "" || config.opts.singleSelectOptionID != "" || config.opts.iterationID != "" {
-		if err := updateItemValues(config); err != nil {
-			return err
-		}
+		return updateItemValues(config)
 	}
 
 	if _, err := fmt.Fprintln(config.io.ErrOut, "error: no changes to make"); err != nil {


### PR DESCRIPTION
## Summary

This PR introduces a new clear flag for the `item-edit` command within `project` command, to clear a specific field's value. Fixes https://github.com/cli/cli/issues/7962

## Thought process

- [As discussed on that issue](https://github.com/cli/cli/issues/7962#issuecomment-1712714985), the clear flag maps to the [clearprojectv2itemfieldvalue mutation](https://docs.github.com/en/graphql/reference/mutations#clearprojectv2itemfieldvalue) to clear the field value. 
- The clear flag requires the `project-id` and `field-id` flags, in addition to the core requirement of `id` flag. 
- When one of these flags is used in conjunction with `clear`, the process errors out with an appropriate error message: text, date, single-select-option-id, number, iteration-id.
- `clear` flag can be used in conjunction with `json` format output.

## Screenshots

Here's a command that updates the date field value: `project item-edit --id PVTI_lAHOARuJY84AVcnszgJPkl4 --project-id PVT_kwHOARuJY84AVcns --field-id PVTF_lAHOARuJY84AVcnszgN11mU --date 2023-09-22` 

<img width="1656" alt="image" src="https://github.com/cli/cli/assets/18581859/66415d3d-1b7a-4d35-98e6-1148e3b15da8">

To clear the date value: `project item-edit --id PVTI_lAHOARuJY84AVcnszgJPkl4 --project-id PVT_kwHOARuJY84AVcns --field-id PVTF_lAHOARuJY84AVcnszgN11mU --clear`

<img width="1654" alt="image" src="https://github.com/cli/cli/assets/18581859/f3d2ebd7-e34a-42be-b858-22ce43feef8c">


<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
