### PR TITLE
Update triage documentation with link to unlabeled open issues

### DIFF
--- a/docs/triage.md
+++ b/docs/triage.md
@@ -6,7 +6,7 @@ triage role. The initial expectation is that the person in the role for the week
 
 ## Expectations for incoming issues
 
-All incoming issues need either an `enhancement`, `bug`, or `docs` label.
+Review and label [open issues missing either the `enhancement`, `bug`, or `docs` label](https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+-label%3Abug%2Cenhancement%2Cdocs+).
 
 To be considered triaged, `enhancement` issues require at least one of the following additional labels:
 


### PR DESCRIPTION
Adding link to triage document for ease of reviewing incoming / open issues.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
