### PR TITLE
docs: fix typo in pr create

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -105,14 +105,11 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			to push the branch and offer an option to fork the base repository. Use %[1]s--head%[1]s to
 			explicitly skip any forking or pushing behavior.
 
-			A prompt will also ask for the title and the body of the pull request. Use %[0]s--title%[1]s and
+			A prompt will also ask for the title and the body of the pull request. Use %[1]s--title%[1]s and
 			%[1]s--body%[1]s to skip this, or use %[1]s--fill%[1]s to autofill these values from git commits.
 			It's important to notice that if the %[1]s--title%[1]s and/or %[1]s--body%[1]s are also provided
 			alongside %[1]s--fill%[1]s, the values specified by %[1]s--title%[1]s and/or %[1]s--body%[1]s will
 			take precedence and overwrite any autofilled content.
-
-			A prompt will also ask for the title and the body of the pull request. Use %[1]s--title%[1]s
-			and %[1]s--body%[1]s to skip this, or use %[1]s--fill%[1]s to autofill these values from git commits.
 
 			Link an issue to the pull request by referencing the issue in the body of the pull
 			request. If the body text mentions %[1]sFixes #123%[1]s or %[1]sCloses #123%[1]s, the referenced issue


### PR DESCRIPTION
https://cli.github.com/manual/gh_pr_create shows `BADINDEX` and broken markdown formatting right now.
Was very recently introduced in #8080.

(Maybe it would be worth adding some sort of validation/assertion/test to prevent BADINDEX in the future, but I'm not very familiar with golang!)