### PR TITLE
`gh browse` subdirectory path problem with `repo` flag

### DIFF
--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -55,8 +55,7 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 		PathFromRepoRoot: func() string {
 			return f.GitClient.PathFromRoot(context.Background())
 		},
-		GitClient:       &localGitClient{client: f.GitClient},
-		HasRepoOverride: false,
+		GitClient: &localGitClient{client: f.GitClient},
 	}
 
 	cmd := &cobra.Command{
@@ -132,11 +131,8 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("%q is an invalid argument when using `--branch` or `--commit`", opts.SelectorArg)
 			}
 
-			if cmd.Flags().Changed("repo") {
-				opts.GitClient = &remoteGitClient{opts.BaseRepo, opts.HttpClient}
-			}
-
 			if cmd.Flags().Changed("repo") || os.Getenv("GH_REPO") != "" {
+				opts.GitClient = &remoteGitClient{opts.BaseRepo, opts.HttpClient}
 				opts.HasRepoOverride = true
 			}
 

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -275,7 +277,7 @@ func parseFile(opts BrowseOptions, f string) (p string, start int, end int, err 
 	}
 
 	p = filepath.ToSlash(parts[0])
-	if !path.IsAbs(p) {
+	if !path.IsAbs(p) && reflect.TypeOf(opts.GitClient) != reflect.TypeOf(&remoteGitClient{}) && os.Getenv("GH_REPO") == "" {
 		p = path.Join(opts.PathFromRepoRoot(), p)
 		if p == "." || strings.HasPrefix(p, "..") {
 			p = ""

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -512,6 +512,20 @@ func Test_runBrowse(t *testing.T) {
 			wantsErr:      false,
 		},
 		{
+			name: "does not use relative path when has repo override",
+			opts: BrowseOptions{
+				SelectorArg:     "README.md",
+				HasRepoOverride: true,
+				PathFromRepoRoot: func() string {
+					return "pkg/cmd/browse/"
+				},
+			},
+			baseRepo:      ghrepo.New("bchadwic", "gh-graph"),
+			defaultBranch: "trunk",
+			expectedURL:   "https://github.com/bchadwic/gh-graph/tree/trunk/README.md",
+			wantsErr:      false,
+		},
+		{
 			name: "use special characters in selector arg",
 			opts: BrowseOptions{
 				SelectorArg: "?=hello world/ *:23-44",


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #7674

Determine if the `--repo` is specified by checking if the `opts.GitClient` is an instance of `remoteGitClient` ([browse.go#L135](https://github.com/cli/cli/blob/be117db900af4602bd115313a880a47c31f7b38a/pkg/cmd/browse/browse.go#L135)) and check if environment variable `GH_REPO` is set.

If `--repo` is specified or `GH_REPO` is set, the current path will not be appended to the result.