### PR TITLE
Fake template field when exporting projects to json

### DIFF
--- a/pkg/cmd/project/shared/format/json.go
+++ b/pkg/cmd/project/shared/format/json.go
@@ -15,10 +15,13 @@ func JSONProject(project queries.Project) ([]byte, error) {
 		ShortDescription: project.ShortDescription,
 		Public:           project.Public,
 		Closed:           project.Closed,
-		Template:         project.Template,
-		Title:            project.Title,
-		ID:               project.ID,
-		Readme:           project.Readme,
+		// The Template field is hardcoded to be false due to https://github.com/cli/cli/issues/8103.
+		// The Template field does not exist on GHES 3.8 and older, once GHES 3.8 gets
+		// deprecated on 2024-03-07 we can start populating this field with actual data.
+		Template: false,
+		Title:    project.Title,
+		ID:       project.ID,
+		Readme:   project.Readme,
 		Items: struct {
 			TotalCount int `json:"totalCount"`
 		}{
@@ -50,10 +53,13 @@ func JSONProjects(projects []queries.Project, totalCount int) ([]byte, error) {
 			ShortDescription: p.ShortDescription,
 			Public:           p.Public,
 			Closed:           p.Closed,
-			Template:         p.Template,
-			Title:            p.Title,
-			ID:               p.ID,
-			Readme:           p.Readme,
+			// The Template field is hardcoded to be false due to https://github.com/cli/cli/issues/8103.
+			// The Template field does not exist on GHES 3.8 and older, once GHES 3.8 gets
+			// deprecated on 2024-03-07 we can start populating this field with actual data.
+			Template: false,
+			Title:    p.Title,
+			ID:       p.ID,
+			Readme:   p.Readme,
 			Items: struct {
 				TotalCount int `json:"totalCount"`
 			}{

--- a/pkg/cmd/project/shared/format/json.go
+++ b/pkg/cmd/project/shared/format/json.go
@@ -15,13 +15,13 @@ func JSONProject(project queries.Project) ([]byte, error) {
 		ShortDescription: project.ShortDescription,
 		Public:           project.Public,
 		Closed:           project.Closed,
-		// The Template field is hardcoded to be false due to https://github.com/cli/cli/issues/8103.
+		// The Template field is commented out due to https://github.com/cli/cli/issues/8103.
 		// The Template field does not exist on GHES 3.8 and older, once GHES 3.8 gets
-		// deprecated on 2024-03-07 we can start populating this field with actual data.
-		Template: false,
-		Title:    project.Title,
-		ID:       project.ID,
-		Readme:   project.Readme,
+		// deprecated on 2024-03-07 we can start populating this field again.
+		// Template: project.Template,
+		Title:  project.Title,
+		ID:     project.ID,
+		Readme: project.Readme,
 		Items: struct {
 			TotalCount int `json:"totalCount"`
 		}{
@@ -53,13 +53,13 @@ func JSONProjects(projects []queries.Project, totalCount int) ([]byte, error) {
 			ShortDescription: p.ShortDescription,
 			Public:           p.Public,
 			Closed:           p.Closed,
-			// The Template field is hardcoded to be false due to https://github.com/cli/cli/issues/8103.
+			// The Template field is commented out due to https://github.com/cli/cli/issues/8103.
 			// The Template field does not exist on GHES 3.8 and older, once GHES 3.8 gets
-			// deprecated on 2024-03-07 we can start populating this field with actual data.
-			Template: false,
-			Title:    p.Title,
-			ID:       p.ID,
-			Readme:   p.Readme,
+			// deprecated on 2024-03-07 we can start populating this field again.
+			// Template: p.Template,
+			Title:  p.Title,
+			ID:     p.ID,
+			Readme: p.Readme,
 			Items: struct {
 				TotalCount int `json:"totalCount"`
 			}{
@@ -95,11 +95,14 @@ type projectJSON struct {
 	ShortDescription string `json:"shortDescription"`
 	Public           bool   `json:"public"`
 	Closed           bool   `json:"closed"`
-	Template         bool   `json:"template"`
-	Title            string `json:"title"`
-	ID               string `json:"id"`
-	Readme           string `json:"readme"`
-	Items            struct {
+	// The Template field is commented out due to https://github.com/cli/cli/issues/8103.
+	// The Template field does not exist on GHES 3.8 and older, once GHES 3.8 gets
+	// deprecated on 2024-03-07 we can start populating this field again.
+	// Template         bool   `json:"template"`
+	Title  string `json:"title"`
+	ID     string `json:"id"`
+	Readme string `json:"readme"`
+	Items  struct {
 		TotalCount int `json:"totalCount"`
 	} `graphql:"items(first: 100)" json:"items"`
 	Fields struct {

--- a/pkg/cmd/project/shared/format/json_test.go
+++ b/pkg/cmd/project/shared/format/json_test.go
@@ -36,7 +36,6 @@ func TestJSONProject_Org(t *testing.T) {
 		ShortDescription: "short description",
 		Public:           true,
 		Readme:           "readme",
-		Template:         true,
 	}
 
 	project.Items.TotalCount = 1
@@ -46,7 +45,7 @@ func TestJSONProject_Org(t *testing.T) {
 	b, err := JSONProject(project)
 	assert.NoError(t, err)
 
-	assert.Equal(t, `{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"template":true,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"Organization","login":"github"}}`, string(b))
+	assert.Equal(t, `{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"template":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"Organization","login":"github"}}`, string(b))
 }
 
 func TestJSONProjects(t *testing.T) {
@@ -71,7 +70,6 @@ func TestJSONProjects(t *testing.T) {
 		ShortDescription: "short description",
 		Public:           true,
 		Readme:           "readme",
-		Template:         true,
 	}
 
 	orgProject.Items.TotalCount = 1
@@ -83,7 +81,7 @@ func TestJSONProjects(t *testing.T) {
 
 	assert.Equal(
 		t,
-		`{"projects":[{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"template":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"User","login":"monalisa"}},{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"template":true,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"Organization","login":"github"}}],"totalCount":2}`,
+		`{"projects":[{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"template":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"User","login":"monalisa"}},{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"template":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"Organization","login":"github"}}],"totalCount":2}`,
 		string(b))
 }
 

--- a/pkg/cmd/project/shared/format/json_test.go
+++ b/pkg/cmd/project/shared/format/json_test.go
@@ -25,7 +25,7 @@ func TestJSONProject_User(t *testing.T) {
 	b, err := JSONProject(project)
 	assert.NoError(t, err)
 
-	assert.Equal(t, `{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"template":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"User","login":"monalisa"}}`, string(b))
+	assert.Equal(t, `{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"User","login":"monalisa"}}`, string(b))
 }
 
 func TestJSONProject_Org(t *testing.T) {
@@ -45,7 +45,7 @@ func TestJSONProject_Org(t *testing.T) {
 	b, err := JSONProject(project)
 	assert.NoError(t, err)
 
-	assert.Equal(t, `{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"template":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"Organization","login":"github"}}`, string(b))
+	assert.Equal(t, `{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"Organization","login":"github"}}`, string(b))
 }
 
 func TestJSONProjects(t *testing.T) {
@@ -81,7 +81,7 @@ func TestJSONProjects(t *testing.T) {
 
 	assert.Equal(
 		t,
-		`{"projects":[{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"template":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"User","login":"monalisa"}},{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"template":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"Organization","login":"github"}}],"totalCount":2}`,
+		`{"projects":[{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"User","login":"monalisa"}},{"number":2,"url":"a url","shortDescription":"short description","public":true,"closed":false,"title":"","id":"123","readme":"readme","items":{"totalCount":1},"fields":{"totalCount":2},"owner":{"type":"Organization","login":"github"}}],"totalCount":2}`,
 		string(b))
 }
 

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -109,11 +109,21 @@ type Project struct {
 	ShortDescription string
 	Public           bool
 	Closed           bool
-	Template         bool
-	Title            string
-	ID               string
-	Readme           string
-	Items            struct {
+	// The Template field is commented out due to https://github.com/cli/cli/issues/8103.
+	// We released gh v2.34.0 without realizing the Template field does not exist
+	// on GHES 3.8 and older. This broke all project commands for users targeting GHES 3.8
+	// and older. In order to fix this we will no longer query the Template field until
+	// GHES 3.8 gets deprecated on 2024-03-07. This solution was simplier and quicker
+	// than adding a feature detection measure to every place this query is used.
+	// It does have the negative consequence that we have had to hardcode a false value for
+	// the Template field when outputing projects to JSON using the --format flag supported
+	// by a number of project commands. See `pkg/cmd/project/shared/format/json.go` for
+	// implementation.
+	// Template         bool
+	Title  string
+	ID     string
+	Readme string
+	Items  struct {
 		PageInfo   PageInfo
 		TotalCount int
 		Nodes      []ProjectItem

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -115,8 +115,8 @@ type Project struct {
 	// and older. In order to fix this we will no longer query the Template field until
 	// GHES 3.8 gets deprecated on 2024-03-07. This solution was simplier and quicker
 	// than adding a feature detection measure to every place this query is used.
-	// It does have the negative consequence that we have had to hardcode a false value for
-	// the Template field when outputing projects to JSON using the --format flag supported
+	// It does have the negative consequence that we have had to remove the
+	// Template field when outputing projects to JSON using the --format flag supported
 	// by a number of project commands. See `pkg/cmd/project/shared/format/json.go` for
 	// implementation.
 	// Template         bool


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/8103

This PR fixes the regression caused by https://github.com/cli/cli/pull/7916 and released in `gh` v2.34.0. In order to fix this regression we made the decision to fix the bigger issue by introducing a smaller bug. The smaller bug is that we are now hardcoding a value of `false` for the `template` field when using the `--format=json` flag for `project` commands. We felt this was a worthwhile tradeoff for expedited fixing of the regression and unblocking the `project` commands for users targeting GHES 3.8 and later.