### PR TITLE
`gh pr create` duplicates targets if there are duplicate remotes

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -107,7 +107,7 @@ func (r *ResolvedRemotes) BaseRepo(io *iostreams.IOStreams) (ghrepo.Interface, e
 		"please run `gh repo set-default` to select a default remote repository.")
 }
 
-func (r *ResolvedRemotes) HeadRepos() ([]*api.Repository, error) {
+func (r *ResolvedRemotes) HeadRepos() ([]Remote, error) {
 	if r.network == nil {
 		err := resolveNetwork(r, defaultRemotesForLookup)
 		if err != nil {
@@ -115,10 +115,14 @@ func (r *ResolvedRemotes) HeadRepos() ([]*api.Repository, error) {
 		}
 	}
 
-	var results []*api.Repository
-	for _, repo := range r.network.Repositories {
+	var results []Remote
+	for i, repo := range r.network.Repositories {
 		if repo != nil && repo.ViewerCanPush() {
-			results = append(results, repo)
+			var remote = Remote{
+				Remote: r.remotes[i].Remote,
+				Repo:   repo,
+			}
+			results = append(results, remote)
 		}
 	}
 	return results, nil

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -576,17 +576,6 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 
 	// otherwise, ask the user for the head repository using info obtained from the API
 	if headRepo == nil && isPushEnabled && opts.IO.CanPrompt() {
-		pushableRepos, err := repoContext.HeadRepos()
-		if err != nil {
-			return nil, err
-		}
-
-		if len(pushableRepos) == 0 {
-			pushableRepos, err = api.RepoFindForks(client, baseRepo, 3)
-			if err != nil {
-				return nil, err
-			}
-		}
 
 		currentLogin, err := api.CurrentLoginName(client, baseRepo.RepoHost())
 		if err != nil {
@@ -595,10 +584,30 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 
 		hasOwnFork := false
 		var pushOptions []string
-		for _, r := range pushableRepos {
-			pushOptions = append(pushOptions, ghrepo.FullName(r))
-			if r.RepoOwner() == currentLogin {
+
+		pushableRepos, err := repoContext.HeadRepos()
+		if err != nil {
+			return nil, err
+		}
+
+		if len(pushableRepos) == 0 {
+			forkedPushableRepo, err := api.RepoFindForks(client, baseRepo, 3)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(forkedPushableRepo) != 0 {
 				hasOwnFork = true
+				for _, r := range forkedPushableRepo {
+					pushOptions = append(pushOptions, ghrepo.FullName(r))
+				}
+			}
+		} else {
+			for _, r := range pushableRepos {
+				pushOptions = append(pushOptions, fmt.Sprintf("%s (%s)", ghrepo.FullName(r), r.Remote.Name))
+				if r.RepoOwner() == currentLogin {
+					hasOwnFork = true
+				}
 			}
 		}
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #8158 

The return type of `HeadRepos` ([context.go#L110](https://github.com/cli/cli/blob/990149d8636b7bd6f211d1de0eb6f6545a45d12f/context/context.go#L110)) function is changed to `Remote` objects, which contains the name of remote. Then print it on terminal. 