### PR TITLE
Include Project Item Status for Issues and Pull Requests

### DIFF
--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -109,7 +109,8 @@ func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
 			items := make([]map[string]interface{}, 0, len(pr.ProjectItems.Nodes))
 			for _, n := range pr.ProjectItems.Nodes {
 				items = append(items, map[string]interface{}{
-					"title": n.Project.Title,
+					"status": n.Status,
+					"title":  n.Project.Title,
 				})
 			}
 			data[f] = items

--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -23,7 +23,8 @@ func (issue *Issue) ExportData(fields []string) map[string]interface{} {
 			items := make([]map[string]interface{}, 0, len(issue.ProjectItems.Nodes))
 			for _, n := range issue.ProjectItems.Nodes {
 				items = append(items, map[string]interface{}{
-					"title": n.Project.Title,
+					"status": n.Status,
+					"title":  n.Project.Title,
 				})
 			}
 			data[f] = items

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -213,6 +213,38 @@ func TestPullRequest_ExportData(t *testing.T) {
 				}
 			`),
 		},
+		{
+			name:   "project items",
+			fields: []string{"projectItems"},
+			inputJSON: heredoc.Doc(`
+				{ "projectItems": { "nodes": [
+					{
+						"id": "PVTPR_id",
+						"project": {
+							"id": "PVT_id",
+							"title": "Some Project"
+						},
+						"status": {
+							"name": "Todo",
+							"optionId": "abc123"
+						}
+					}
+				] } }
+			`),
+			outputJSON: heredoc.Doc(`
+				{
+					"projectItems": [
+						{
+							"status": {
+								"optionId": "abc123",
+								"name": "Todo"
+							},
+							"title": "Some Project"
+						}
+					]
+				}
+			`),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -85,6 +85,10 @@ func TestIssue_ExportData(t *testing.T) {
 						"project": {
 							"id": "PVT_id",
 							"title": "Some Project"
+						},
+						"status": {
+							"name": "Todo",
+							"optionId": "abc123"
 						}
 					}
 				] } }
@@ -93,6 +97,10 @@ func TestIssue_ExportData(t *testing.T) {
 				{
 					"projectItems": [
 						{
+							"status": {
+								"optionId": "abc123",
+								"name": "Todo"
+							},
 							"title": "Some Project"
 						}
 					]

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -106,6 +106,10 @@ type ProjectV2Item struct {
 		ID    string `json:"id"`
 		Title string `json:"title"`
 	}
+	Status struct {
+		OptionID string `json:"optionId"`
+		Name     string `json:"name"`
+	}
 }
 
 func (p ProjectCards) ProjectNames() []string {

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -318,7 +318,7 @@ func IssueGraphQL(fields []string) string {
 		case "projectCards":
 			q = append(q, `projectCards(first:100){nodes{project{name}column{name}},totalCount}`)
 		case "projectItems":
-			q = append(q, `projectItems(first:100){nodes{id, project{id,title}},totalCount}`)
+			q = append(q, `projectItems(first:100){nodes{id, project{id,title}, status:fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue{optionId,name}}},totalCount}`)
 		case "milestone":
 			q = append(q, `milestone{number,title,description,dueOn}`)
 		case "reactionGroups":

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -33,6 +33,11 @@ func TestPullRequestGraphQL(t *testing.T) {
 			fields: []string{"isPinned", "stateReason", "number"},
 			want:   "number",
 		},
+		{
+			name:   "projectItems",
+			fields: []string{"projectItems"},
+			want:   `projectItems(first:100){nodes{id, project{id,title}, status:fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue{optionId,name}}},totalCount}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -68,6 +73,11 @@ func TestIssueGraphQL(t *testing.T) {
 			name:   "compressed query",
 			fields: []string{"files"},
 			want:   "files(first: 100) {nodes {additions,deletions,path}}",
+		},
+		{
+			name:   "projectItems",
+			fields: []string{"projectItems"},
+			want:   `projectItems(first:100){nodes{id, project{id,title}, status:fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue{optionId,name}}},totalCount}`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #7796

Projects (classic) offered a very basic way of organizing a project board by status (called column). This column value would be included in the following CLI commands when an issue and/or PR was added to a projects classic:

```zsh
./bin/gh issue list --repo <owner/name> --json projectCards
./bin/gh pr list --repo <owner/name> --json projectCards
```

The new Projects experience is much more configurable but still has the concept of status in the form of a project field. This PR seeks to expose this `projectItems.status` value to provide some reasonable parity with `projectCards.column`

Here are two example commands using this PR's build:

```zsh
./bin/gh issue list --repo mattruggio/kitkat --json projectItems
```

Resulting output:

```json
[
  {
    "projectItems": [
      {
        "status": {
          "optionId": "47fc9ee4",
          "name": "In Progress"
        },
        "title": "Test Public Project"
      }
    ]
  },
  {
    "projectItems": [
      {
        "status": {
          "optionId": "",
          "name": ""
        },
        "title": "Test Public Project"
      }
    ]
  }
]
```

```zsh
./bin/gh pr list --repo mattruggio/kitkat --json projectItems
```

Resulting output:


```json
[
  {
    "projectItems": [
      {
        "status": {
          "optionId": "47fc9ee4",
          "name": "In Progress"
        },
        "title": "Test Public Project"
      }
    ]
  },
  {
    "projectItems": [
      {
        "status": {
          "optionId": "",
          "name": ""
        },
        "title": "Test Public Project"
      }
    ]
  }
]
```

Notes:

* `projectItems.status` is the closest mechanic we have in projects equivalent to `projectCards.column`. So much so that when classic projects are migrated to new projects, their column values are converted to status field values.
* It is not 100% a perfect 1:1 though. For example: projects offers a much more configurable way to organize and group a project items. In some scenarios project views can be vertically grouped by other columns other than `status`. In those cases `status` may not be the exact desired projectItems value. That should be acceptable though, since project item `status` is still a standard and useful field to include.
* This pattern is not extendable to all fields given the configurable nature of projects: fields can be added, edited, and removed. Even with the additional configurability, the status column in projects is fixed and is included in every project. IMO, it makes sense to make an exception for a few standardized project fields, with Status potentially providing the paved path in the new projects experience.