### PR TITLE
Bump cpuguy83/go-md2man from 2.0.1 to 2.0.3

### DIFF
--- a/cmd/gen-docs/main_test.go
+++ b/cmd/gen-docs/main_test.go
@@ -18,7 +18,7 @@ func Test_run(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error reading `gh-issue-create.1`: %v", err)
 	}
-	if !strings.Contains(string(manPage), `\fB\fCgh issue create`) {
+	if !strings.Contains(string(manPage), `\fBgh issue create`) {
 		t.Fatal("man page corrupted")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cli/go-gh/v2 v2.3.0
 	github.com/cli/oauth v1.0.1
 	github.com/cli/safeexec v1.0.1
-	github.com/cpuguy83/go-md2man/v2 v2.0.2
+	github.com/cpuguy83/go-md2man/v2 v2.0.3
 	github.com/creack/pty v1.1.18
 	github.com/gabriel-vasile/mimetype v1.4.3
 	github.com/gdamore/tcell/v2 v2.5.4

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/cli/shurcooL-graphql v0.0.3 h1:CtpPxyGDs136/+ZeyAfUKYmcQBjDlq5aqnrDCW
 github.com/cli/shurcooL-graphql v0.0.3/go.mod h1:tlrLmw/n5Q/+4qSvosT+9/W5zc8ZMjnJeYBxSdb4nWA=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=


### PR DESCRIPTION
Version 2.0.3 introduces a fix in PR https://github.com/cpuguy83/go-md2man/pull/105 that breaks a test for gen-doc, thus requires a small change in the test.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
