### PR TITLE
`gh extension install` not give an error if extension already installed and a clear message

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -32,7 +32,6 @@ github.com/cli/safeexec v1.0.1 h1:e/C79PbXF4yYTN/wauC4tviMxEV13BwljGj0N9j+N00=
 github.com/cli/safeexec v1.0.1/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/cli/shurcooL-graphql v0.0.3 h1:CtpPxyGDs136/+ZeyAfUKYmcQBjDlq5aqnrDCW5Ghh8=
 github.com/cli/shurcooL-graphql v0.0.3/go.mod h1:tlrLmw/n5Q/+4qSvosT+9/W5zc8ZMjnJeYBxSdb4nWA=
-github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var alreadyInstalledError = errors.New("the extension is already installed")
+var alreadyInstalledError = errors.New("alreadyInstalledError")
 
 func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 	m := f.ExtensionManager
@@ -335,24 +335,22 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 						return err
 					}
 
-					if ext, err := checkValidExtension(cmd.Root(), m, repo.RepoName()); err != nil {
+					cs := io.ColorScheme()
+
+					if ext, err := checkValidExtension(cmd.Root(), m, repo.RepoName(), repo.RepoOwner()); err != nil {
 						// If an existing extension was found and --force was specified, attempt to upgrade.
 						if forceFlag && ext != nil {
 							return upgradeFunc(ext.Name(), forceFlag, false)
 						}
 
 						if errors.Is(err, alreadyInstalledError) {
-							if io.IsStdoutTTY() {
-								cs := io.ColorScheme()
-								fmt.Fprintf(io.ErrOut, "%s Extension %s is already installed\n", cs.WarningIcon(), ext.Name())
-								return nil
-							}
+							fmt.Fprintf(io.ErrOut, "%s Extension %s is already installed\n", cs.WarningIcon(), ghrepo.FullName(repo))
+							return nil
 						}
 
 						return err
 					}
 
-					cs := io.ColorScheme()
 					if err := m.Install(repo, pinFlag); err != nil {
 						if errors.Is(err, releaseNotFoundErr) {
 							return fmt.Errorf("%s Could not find a release of %s for %s",
@@ -647,7 +645,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 	return &extCmd
 }
 
-func checkValidExtension(rootCmd *cobra.Command, m extensions.ExtensionManager, extName string) (extensions.Extension, error) {
+func checkValidExtension(rootCmd *cobra.Command, m extensions.ExtensionManager, extName, extOwner string) (extensions.Extension, error) {
 	if !strings.HasPrefix(extName, "gh-") {
 		return nil, errors.New("extension repository name must start with `gh-`")
 	}
@@ -659,7 +657,10 @@ func checkValidExtension(rootCmd *cobra.Command, m extensions.ExtensionManager, 
 
 	for _, ext := range m.List() {
 		if ext.Name() == commandName {
-			return ext, alreadyInstalledError
+			if ext.Owner() == extOwner {
+				return ext, alreadyInstalledError
+			}
+			return ext, fmt.Errorf("there is already an installed extension that provides the %q command", commandName)
 		}
 	}
 

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -239,7 +239,7 @@ func TestNewCmdExtension(t *testing.T) {
 			args: []string{"install", "owner/gh-existing-ext"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
 				em.ListFunc = func() []extensions.Extension {
-					e := &Extension{path: "owner2/gh-existing-ext"}
+					e := &Extension{path: "owner2/gh-existing-ext", owner: "owner2"}
 					return []extensions.Extension{e}
 				}
 				return func(t *testing.T) {
@@ -249,6 +249,21 @@ func TestNewCmdExtension(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "there is already an installed extension that provides the \"existing-ext\" command",
+		},
+		{
+			name: "install an already installed extension",
+			args: []string{"install", "owner/gh-existing-ext"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.ListFunc = func() []extensions.Extension {
+					e := &Extension{path: "owner/gh-existing-ext", owner: "owner"}
+					return []extensions.Extension{e}
+				}
+				return func(t *testing.T) {
+					calls := em.ListCalls()
+					assert.Equal(t, 1, len(calls))
+				}
+			},
+			wantStderr: "! Extension owner/gh-existing-ext is already installed\n",
 		},
 		{
 			name: "install local extension",
@@ -817,7 +832,7 @@ func TestNewCmdExtension(t *testing.T) {
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
 				em.ListFunc = func() []extensions.Extension {
 					return []extensions.Extension{
-						&Extension{path: "owner/gh-hello"},
+						&Extension{path: "owner/gh-hello", owner: "owner"},
 					}
 				}
 				em.InstallFunc = func(_ ghrepo.Interface, _ string) error {
@@ -924,19 +939,22 @@ func Test_checkValidExtension(t *testing.T) {
 		ListFunc: func() []extensions.Extension {
 			return []extensions.Extension{
 				&extensions.ExtensionMock{
-					NameFunc: func() string { return "screensaver" },
+					OwnerFunc: func() string { return "monalisa" },
+					NameFunc:  func() string { return "screensaver" },
 				},
 				&extensions.ExtensionMock{
-					NameFunc: func() string { return "triage" },
+					OwnerFunc: func() string { return "monalisa" },
+					NameFunc:  func() string { return "triage" },
 				},
 			}
 		},
 	}
 
 	type args struct {
-		rootCmd *cobra.Command
-		manager extensions.ExtensionManager
-		extName string
+		rootCmd  *cobra.Command
+		manager  extensions.ExtensionManager
+		extName  string
+		extOwner string
 	}
 	tests := []struct {
 		name      string
@@ -946,33 +964,56 @@ func Test_checkValidExtension(t *testing.T) {
 		{
 			name: "valid extension",
 			args: args{
-				rootCmd: rootCmd,
-				manager: m,
-				extName: "gh-hello",
+				rootCmd:  rootCmd,
+				manager:  m,
+				extOwner: "monalisa",
+				extName:  "gh-hello",
 			},
 		},
 		{
 			name: "invalid extension name",
 			args: args{
-				rootCmd: rootCmd,
-				manager: m,
-				extName: "gherkins",
+				rootCmd:  rootCmd,
+				manager:  m,
+				extOwner: "monalisa",
+				extName:  "gherkins",
 			},
 			wantError: "extension repository name must start with `gh-`",
 		},
 		{
 			name: "clashes with built-in command",
 			args: args{
-				rootCmd: rootCmd,
-				manager: m,
-				extName: "gh-auth",
+				rootCmd:  rootCmd,
+				manager:  m,
+				extOwner: "monalisa",
+				extName:  "gh-auth",
 			},
 			wantError: "\"auth\" matches the name of a built-in command or alias",
+		},
+		{
+			name: "clashes with an installed extension",
+			args: args{
+				rootCmd:  rootCmd,
+				manager:  m,
+				extOwner: "cli",
+				extName:  "gh-triage",
+			},
+			wantError: "there is already an installed extension that provides the \"triage\" command",
+		},
+		{
+			name: "clashes with same extension",
+			args: args{
+				rootCmd:  rootCmd,
+				manager:  m,
+				extOwner: "monalisa",
+				extName:  "gh-triage",
+			},
+			wantError: "alreadyInstalledError",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := checkValidExtension(tt.args.rootCmd, tt.args.manager, tt.args.extName)
+			_, err := checkValidExtension(tt.args.rootCmd, tt.args.manager, tt.args.extName, tt.args.extOwner)
 			if tt.wantError == "" {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -969,15 +969,6 @@ func Test_checkValidExtension(t *testing.T) {
 			},
 			wantError: "\"auth\" matches the name of a built-in command or alias",
 		},
-		{
-			name: "clashes with an installed extension",
-			args: args{
-				rootCmd: rootCmd,
-				manager: m,
-				extName: "gh-triage",
-			},
-			wantError: "there is already an installed extension that provides the \"triage\" command",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/extension/extension_test.go
+++ b/pkg/cmd/extension/extension_test.go
@@ -1,6 +1,7 @@
 package extension
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,4 +50,55 @@ func TestUpdateAvailable(t *testing.T) {
 	}
 
 	assert.True(t, e.UpdateAvailable())
+}
+
+func TestOwnerLocalExtension(t *testing.T) {
+	tempDir := t.TempDir()
+	extPath := filepath.Join(tempDir, "extensions", "gh-local", "gh-local")
+	assert.NoError(t, stubLocalExtension(tempDir, extPath))
+	e := &Extension{
+		kind: LocalKind,
+		path: extPath,
+	}
+
+	assert.Equal(t, "", e.Owner())
+}
+
+func TestOwnerBinaryExtension(t *testing.T) {
+	tempDir := t.TempDir()
+	extName := "gh-bin-ext"
+	extDir := filepath.Join(tempDir, "extensions", extName)
+	extPath := filepath.Join(extDir, extName)
+	bm := binManifest{
+		Owner: "owner",
+		Name:  "gh-bin-ext",
+		Host:  "example.com",
+		Tag:   "v1.0.1",
+	}
+	assert.NoError(t, stubBinaryExtension(extDir, bm))
+	e := &Extension{
+		kind: BinaryKind,
+		path: extPath,
+	}
+
+	assert.Equal(t, "owner", e.Owner())
+}
+
+func TestOwnerGitExtension(t *testing.T) {
+	gc := &mockGitClient{}
+	gc.On("Config", "remote.origin.url").Return("git@github.com:owner/repo.git", nil).Once()
+	e := &Extension{
+		kind:      GitKind,
+		gitClient: gc,
+	}
+
+	assert.Equal(t, "owner", e.Owner())
+}
+
+func TestOwnerCached(t *testing.T) {
+	e := &Extension{
+		owner: "cli",
+	}
+
+	assert.Equal(t, "cli", e.Owner())
 }

--- a/pkg/extensions/extension.go
+++ b/pkg/extensions/extension.go
@@ -25,6 +25,7 @@ type Extension interface {
 	UpdateAvailable() bool
 	IsBinary() bool
 	IsLocal() bool
+	Owner() string
 }
 
 //go:generate moq -rm -out manager_mock.go . ExtensionManager

--- a/pkg/extensions/extension_mock.go
+++ b/pkg/extensions/extension_mock.go
@@ -35,6 +35,9 @@ var _ Extension = &ExtensionMock{}
 //			NameFunc: func() string {
 //				panic("mock out the Name method")
 //			},
+//			OwnerFunc: func() string {
+//				panic("mock out the Owner method")
+//			},
 //			PathFunc: func() string {
 //				panic("mock out the Path method")
 //			},
@@ -69,6 +72,9 @@ type ExtensionMock struct {
 	// NameFunc mocks the Name method.
 	NameFunc func() string
 
+	// OwnerFunc mocks the Owner method.
+	OwnerFunc func() string
+
 	// PathFunc mocks the Path method.
 	PathFunc func() string
 
@@ -98,6 +104,9 @@ type ExtensionMock struct {
 		// Name holds details about calls to the Name method.
 		Name []struct {
 		}
+		// Owner holds details about calls to the Owner method.
+		Owner []struct {
+		}
 		// Path holds details about calls to the Path method.
 		Path []struct {
 		}
@@ -114,6 +123,7 @@ type ExtensionMock struct {
 	lockIsPinned        sync.RWMutex
 	lockLatestVersion   sync.RWMutex
 	lockName            sync.RWMutex
+	lockOwner           sync.RWMutex
 	lockPath            sync.RWMutex
 	lockURL             sync.RWMutex
 	lockUpdateAvailable sync.RWMutex
@@ -278,6 +288,33 @@ func (mock *ExtensionMock) NameCalls() []struct {
 	mock.lockName.RLock()
 	calls = mock.calls.Name
 	mock.lockName.RUnlock()
+	return calls
+}
+
+// Owner calls OwnerFunc.
+func (mock *ExtensionMock) Owner() string {
+	if mock.OwnerFunc == nil {
+		panic("ExtensionMock.OwnerFunc: method is nil but Extension.Owner was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockOwner.Lock()
+	mock.calls.Owner = append(mock.calls.Owner, callInfo)
+	mock.lockOwner.Unlock()
+	return mock.OwnerFunc()
+}
+
+// OwnerCalls gets all the calls that were made to Owner.
+// Check the length with:
+//
+//	len(mockedExtension.OwnerCalls())
+func (mock *ExtensionMock) OwnerCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockOwner.RLock()
+	calls = mock.calls.Owner
+	mock.lockOwner.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes https://github.com/cli/cli/issues/4463 and supercedes https://github.com/cli/cli/pull/4536