### PR TITLE
Add tests for the existing config

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -32,7 +32,6 @@ github.com/cli/safeexec v1.0.1 h1:e/C79PbXF4yYTN/wauC4tviMxEV13BwljGj0N9j+N00=
 github.com/cli/safeexec v1.0.1/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/cli/shurcooL-graphql v0.0.3 h1:CtpPxyGDs136/+ZeyAfUKYmcQBjDlq5aqnrDCW5Ghh8=
 github.com/cli/shurcooL-graphql v0.0.3/go.mod h1:tlrLmw/n5Q/+4qSvosT+9/W5zc8ZMjnJeYBxSdb4nWA=
-github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -286,12 +286,11 @@ func TestLoginSetsUserForProvidedHost(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("GH_CONFIG_DIR", tempDir)
 
-	// Given a usable keyring and an empty config
-	keyring.MockInit()
+	// Given we are not logged in
 	authCfg := newTestAuthConfig()
 
 	// When we login
-	_, err := authCfg.Login("github.com", "test-user", "test-token", "ssh", true)
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "ssh", false)
 
 	// Then it returns success and the user is set
 	require.NoError(t, err)
@@ -301,16 +300,15 @@ func TestLoginSetsUserForProvidedHost(t *testing.T) {
 	require.Equal(t, "test-user", user)
 }
 
-func TestLoginSetsGitProtocolForProdivdedHost(t *testing.T) {
+func TestLoginSetsGitProtocolForProvidedHost(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("GH_CONFIG_DIR", tempDir)
 
-	// Given a usable keyring and an empty config
-	keyring.MockInit()
+	// Given we are not logged in
 	authCfg := newTestAuthConfig()
 
 	// When we login
-	_, err := authCfg.Login("github.com", "test-user", "test-token", "ssh", true)
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "ssh", false)
 
 	// Then it returns success and the git protocol is set
 	require.NoError(t, err)
@@ -324,12 +322,11 @@ func TestLoginAddsHostIfNotAlreadyAdded(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("GH_CONFIG_DIR", tempDir)
 
-	// Given a usable keyring and an empty config
-	keyring.MockInit()
+	// Given we are not logged in
 	authCfg := newTestAuthConfig()
 
 	// When we login
-	_, err := authCfg.Login("github.com", "test-user", "test-token", "ssh", true)
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "ssh", false)
 
 	// Then it returns success and a host is added
 	require.NoError(t, err)

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"testing"
 
 	ghConfig "github.com/cli/go-gh/v2/pkg/config"
@@ -17,7 +18,7 @@ func newTestAuthConfig() *AuthConfig {
 func TestTokenFromKeyring(t *testing.T) {
 	// Given a keyring that contains a token for a host
 	keyring.MockInit()
-	keyring.Set(keyringServiceName("github.com"), "", "test-token")
+	require.NoError(t, keyring.Set(keyringServiceName("github.com"), "", "test-token"))
 
 	// When we get the token from the auth config
 	authCfg := newTestAuthConfig()
@@ -88,4 +89,150 @@ func TestGitProtocolInAuthConfig(t *testing.T) {
 	// Then it returns success with the correct git protocol
 	require.NoError(t, err)
 	require.Equal(t, "ssh", gitProtocol)
+}
+
+func TestLoginSecureStorageUsesKeyring(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given a usable keyring
+	keyring.MockInit()
+	authCfg := newTestAuthConfig()
+
+	// When we login with secure storage
+	insecureStorageUsed, err := authCfg.Login("github.com", "test-user", "test-token", "", true)
+
+	// Then it returns success, notes that insecure storage was not used, and stores the token in the keyring
+	require.NoError(t, err)
+	require.False(t, insecureStorageUsed, "expected to use secure storage")
+
+	token, err := keyring.Get(keyringServiceName("github.com"), "")
+	require.NoError(t, err)
+	require.Equal(t, "test-token", token)
+}
+
+func TestLoginSecureStorageRemovesOldInsecureConfigToken(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given a usable keyring and an oauth token in the config
+	keyring.MockInit()
+	authCfg := newTestAuthConfig()
+	authCfg.cfg.Set([]string{hosts, "github.com", oauthToken}, "old-token")
+
+	// When we login with secure storage
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "", true)
+
+	// Then it returns success, having also removed the old token from the config
+	require.NoError(t, err)
+	requireNoKey(t, authCfg.cfg, []string{hosts, "github.com", oauthToken})
+}
+
+func TestLoginSecureStorageWithErrorFallsbackAndReports(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given a keyring that errors
+	keyring.MockInitWithError(errors.New("test-explosion"))
+	authCfg := newTestAuthConfig()
+
+	// When we login with secure storage
+	insecureStorageUsed, err := authCfg.Login("github.com", "test-user", "test-token", "", true)
+
+	// Then it returns success, reports that insecure storage was used, and stores the token in the config
+	require.NoError(t, err)
+
+	require.True(t, insecureStorageUsed, "expected to use insecure storage")
+	requireKeyWithValue(t, authCfg.cfg, []string{hosts, "github.com", oauthToken}, "test-token")
+}
+
+func TestLoginInsecureStorage(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	authCfg := newTestAuthConfig()
+
+	// When we login with insecure storage
+	insecureStorageUsed, err := authCfg.Login("github.com", "test-user", "test-token", "", false)
+
+	// Then it returns success, notes that insecure storage was used, and stores the token in the config
+	require.NoError(t, err)
+
+	require.True(t, insecureStorageUsed, "expected to use insecure storage")
+	requireKeyWithValue(t, authCfg.cfg, []string{hosts, "github.com", oauthToken}, "test-token")
+}
+
+func TestLoginSetsUserAndGitProtocolInConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given a usable keyring
+	keyring.MockInit()
+	authCfg := newTestAuthConfig()
+
+	// When we login with secure storage
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "ssh", true)
+
+	// Then it returns success, and stores the user and git protocol in the config
+	require.NoError(t, err)
+
+	requireKeyWithValue(t, authCfg.cfg, []string{hosts, "github.com", "user"}, "test-user")
+	requireKeyWithValue(t, authCfg.cfg, []string{hosts, "github.com", "git_protocol"}, "ssh")
+}
+
+func TestLogoutRemovesHostAndKeyringToken(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given we are logged into a host
+	keyring.MockInit()
+	authCfg := newTestAuthConfig()
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "ssh", true)
+	require.NoError(t, err)
+
+	// When we logout
+	err = authCfg.Logout("github.com")
+
+	// Then we return success, and the host and token are removed from the config and keyring
+	require.NoError(t, err)
+
+	requireNoKey(t, authCfg.cfg, []string{hosts, "github.com"})
+	_, err = keyring.Get(keyringServiceName("github.com"), "")
+	require.ErrorIs(t, err, keyring.ErrNotFound)
+}
+
+// Note that I'm not sure this test enforces particularly desirable behaviour
+// since it leads users to believe a token has been removed when really
+// that might have failed for some reason.
+func TestLogoutIgnoresErrorsFromConfigAndKeyring(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given we have keyring that errors, and a config that
+	// doesn't even have a hosts key (which would cause Remove to fail)
+	keyring.MockInitWithError(errors.New("test-explosion"))
+	authCfg := newTestAuthConfig()
+
+	// When we logout
+	err := authCfg.Logout("github.com")
+
+	// Then it returns success anyway, suppressing the errors
+	require.NoError(t, err)
+}
+
+func requireKeyWithValue(t *testing.T, cfg *ghConfig.Config, keys []string, value string) {
+	t.Helper()
+
+	actual, err := cfg.Get(keys)
+	require.NoError(t, err)
+
+	require.Equal(t, value, actual)
+}
+
+func requireNoKey(t *testing.T, cfg *ghConfig.Config, keys []string) {
+	t.Helper()
+
+	_, err := cfg.Get(keys)
+	var keyNotFoundError *ghConfig.KeyNotFoundError
+	require.ErrorAs(t, err, &keyNotFoundError)
 }

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -58,8 +58,8 @@ func TestTokenStoredInConfig(t *testing.T) {
 	token, source := authCfg.Token("github.com")
 
 	// Then the token is successfully fetched
-	// and the source is set to oauth_token but this isn't great
-	// but I can't find the issue # that references this.
+	// and the source is set to oauth_token but this isn't great:
+	// https://github.com/cli/go-gh/issues/94
 	require.Equal(t, "test-token", token)
 	require.Equal(t, "oauth_token", source)
 }

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"testing"
+
+	ghConfig "github.com/cli/go-gh/v2/pkg/config"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+)
+
+func newTestAuthConfig() *AuthConfig {
+	return &AuthConfig{
+		cfg: ghConfig.ReadFromString(""),
+	}
+}
+
+func TestTokenFromKeyring(t *testing.T) {
+	// Given a keyring that contains a token for a host
+	keyring.MockInit()
+	keyring.Set(keyringServiceName("github.com"), "", "test-token")
+
+	// When we get the token from the auth config
+	authCfg := newTestAuthConfig()
+	token, err := authCfg.TokenFromKeyring("github.com")
+
+	// Then it returns successfully with the correct token
+	require.NoError(t, err)
+	require.Equal(t, "test-token", token)
+}
+
+func TestTokenFromKeyringNonExistent(t *testing.T) {
+	// Given a keyring that doesn't contain any tokens
+	keyring.MockInit()
+
+	// When we try to get a token from the auth config
+	authCfg := newTestAuthConfig()
+	_, err := authCfg.TokenFromKeyring("github.com")
+
+	// Then it returns failure bubbling the ErrNotFound
+	require.ErrorIs(t, err, keyring.ErrNotFound)
+}
+
+func TestNoUserInAuthConfig(t *testing.T) {
+	// Given a host configuration without a user
+	authCfg := newTestAuthConfig()
+
+	// When we get the user
+	_, err := authCfg.User("github.com")
+
+	// Then it returns failure, bubbling the KeyNotFoundError
+	var keyNotFoundError *ghConfig.KeyNotFoundError
+	require.ErrorAs(t, err, &keyNotFoundError)
+}
+
+func TestUserInAuthConfig(t *testing.T) {
+	// Given an a host configuration with a user
+	authCfg := newTestAuthConfig()
+	authCfg.cfg.Set([]string{hosts, "github.com", "user"}, "test-user")
+
+	// When we get the user
+	user, err := authCfg.User("github.com")
+
+	// Then it returns success with the correct user
+	require.NoError(t, err)
+	require.Equal(t, "test-user", user)
+}
+
+func TestNoGitProtocolInAuthConfig(t *testing.T) {
+	// Given a host configuration without a git protocol
+	authCfg := newTestAuthConfig()
+
+	// When we get the git protocol
+	gitProtocol, err := authCfg.GitProtocol("github.com")
+
+	// Then it returns success, using the default
+	require.NoError(t, err)
+	require.Equal(t, "https", gitProtocol)
+}
+
+func TestGitProtocolInAuthConfig(t *testing.T) {
+	// Given an a host configuration with a git protocol
+	authCfg := newTestAuthConfig()
+	authCfg.cfg.Set([]string{hosts, "github.com", "git_protocol"}, "ssh")
+
+	// When we get the git protocol
+	gitProtocol, err := authCfg.GitProtocol("github.com")
+
+	// Then it returns success with the correct git protocol
+	require.NoError(t, err)
+	require.Equal(t, "ssh", gitProtocol)
+}

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -299,6 +299,27 @@ func TestLoginSetsGitProtocolForProdivdedHost(t *testing.T) {
 	require.Equal(t, "ssh", gitProtocol)
 }
 
+func TestLoginAddsHostIfNotAlreadyAdded(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given a usable keyring and an empty config
+	keyring.MockInit()
+	authCfg := newTestAuthConfig()
+	ghConfig.Read = func() (*ghConfig.Config, error) {
+		return authCfg.cfg, nil
+	}
+
+	// When we login
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "ssh", true)
+
+	// Then it returns success and a host is added
+	require.NoError(t, err)
+
+	hosts := authCfg.Hosts()
+	require.Contains(t, hosts, "github.com")
+}
+
 func TestLogoutRemovesHostAndKeyringToken(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("GH_CONFIG_DIR", tempDir)

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -323,6 +323,10 @@ func TestLogoutRemovesHostAndKeyringToken(t *testing.T) {
 // Note that I'm not sure this test enforces particularly desirable behaviour
 // since it leads users to believe a token has been removed when really
 // that might have failed for some reason.
+//
+// The original intention here is that if the logout fails, the user can't
+// really do anything to recover. On the other hand, a user might
+// want to rectify this manually, for example if there were on a shared machine.
 func TestLogoutIgnoresErrorsFromConfigAndKeyring(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("GH_CONFIG_DIR", tempDir)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -229,11 +229,9 @@ func (c *AuthConfig) Login(hostname, username, token, gitProtocol string, secure
 		c.cfg.Set([]string{hosts, hostname, oauthToken}, token)
 		insecureStorageUsed = true
 	}
-	// TODO: I can't find anywhere that calls this function without a username, so that would seem like
-	// something we might want to error on?
-	if username != "" {
-		c.cfg.Set([]string{hosts, hostname, "user"}, username)
-	}
+
+	c.cfg.Set([]string{hosts, hostname, "user"}, username)
+
 	if gitProtocol != "" {
 		c.cfg.Set([]string{hosts, hostname, "git_protocol"}, gitProtocol)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,7 +58,7 @@ func (c *cfg) GetOrDefault(hostname, key string) (string, error) {
 		return val, err
 	}
 
-	if val, ok := def(key); ok {
+	if val, ok := defaultFor(key); ok {
 		return val, nil
 	}
 
@@ -85,31 +85,13 @@ func (c *cfg) Authentication() *AuthConfig {
 	return &AuthConfig{cfg: c.cfg}
 }
 
-func def(key string) (string, bool) {
+func defaultFor(key string) (string, bool) {
 	for _, co := range configOptions {
 		if co.Key == key {
 			return co.DefaultValue, true
 		}
 	}
 	return "", false
-}
-
-func defaultFor(key string) string {
-	for _, co := range configOptions {
-		if co.Key == key {
-			return co.DefaultValue
-		}
-	}
-	return ""
-}
-
-func defaultExists(key string) bool {
-	for _, co := range configOptions {
-		if co.Key == key {
-			return true
-		}
-	}
-	return false
 }
 
 // AuthConfig is used for interacting with some persistent configuration for gh,
@@ -185,7 +167,12 @@ func (c *AuthConfig) GitProtocol(hostname string) (string, error) {
 	if err == nil {
 		return val, err
 	}
-	return defaultFor(key), nil
+
+	if val, ok := defaultFor(key); ok {
+		return val, nil
+	}
+
+	return "", nil
 }
 
 func (c *AuthConfig) Hosts() []string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,10 +139,6 @@ func (c *AuthConfig) HasEnvToken() bool {
 	// It has to use a hostname that is not going to be found in the hosts so that it
 	// can guarantee that tokens will only be returned from a set env var.
 	// Discussed here, but maybe worth revisiting: https://github.com/cli/cli/pull/7169#discussion_r1136979033
-	//
-	// By providing example.com. it's also _only_ looking for GH_ENTERPRISE_TOKEN or GITHUB_ENTERPRISE_TOKEN
-	// or the GITHUB_TOKEN if we happen to be in a codespace?? This doesn't seem to reflect the actual
-	// name of the function at all.
 	token, _ := ghAuth.TokenFromEnvOrConfig(hostname)
 	return token != ""
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -243,11 +243,6 @@ func (c *AuthConfig) Login(hostname, username, token, gitProtocol string, secure
 // Logout will remove user, git protocol, and auth token for the given hostname.
 // It will remove the auth token from the encrypted storage if it exists there.
 func (c *AuthConfig) Logout(hostname string) error {
-	// TODO: I can't find anywhere that expects to call this function without a hostname
-	// and that would seem like a programmer error?
-	if hostname == "" {
-		return nil
-	}
 	_ = c.cfg.Remove([]string{hosts, hostname})
 	_ = keyring.Delete(keyringServiceName(hostname), "")
 	return ghConfig.Write(c.cfg)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,7 @@ func (c *AuthConfig) User(hostname string) (string, error) {
 
 // GitProtocol will retrieve the git protocol for the logged in user at the given hostname.
 // If none is set it will return the default value.
+// TODO: although this returns an error, it actually has no path to error.
 func (c *AuthConfig) GitProtocol(hostname string) (string, error) {
 	key := "git_protocol"
 	val, err := c.cfg.Get([]string{hosts, hostname, key})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,6 +176,7 @@ func (c *AuthConfig) GitProtocol(hostname string) string {
 
 	// This should not happen, as we know there is a default value for this key.
 	// Perhaps it says something about our current default abstraction being not quite right?
+	// The defaults are also currently used to provide information about the config options.
 	return ""
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,14 @@ func (c *AuthConfig) HasEnvToken() bool {
 			return true
 		}
 	}
+	// TODO: This is _extremely_ knowledgable about the implementation of TokenFromEnvOrConfig
+	// It has to use a hostname that is not going to be found in the hosts so that it
+	// can guarantee that tokens will only be returned from a set env var.
+	// Discussed here, but maybe worth revisiting: https://github.com/cli/cli/pull/7169#discussion_r1136979033
+	//
+	// By providing example.com. it's also _only_ looking for GH_ENTERPRISE_TOKEN or GITHUB_ENTERPRISE_TOKEN
+	// or the GITHUB_TOKEN if we happen to be in a codespace?? This doesn't seem to reflect the actual
+	// name of the function at all.
 	token, _ := ghAuth.TokenFromEnvOrConfig(hostname)
 	return token != ""
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,19 +164,19 @@ func (c *AuthConfig) User(hostname string) (string, error) {
 
 // GitProtocol will retrieve the git protocol for the logged in user at the given hostname.
 // If none is set it will return the default value.
-// TODO: although this returns an error, it actually has no path to error.
-func (c *AuthConfig) GitProtocol(hostname string) (string, error) {
+func (c *AuthConfig) GitProtocol(hostname string) string {
 	key := "git_protocol"
-	val, err := c.cfg.Get([]string{hosts, hostname, key})
-	if err == nil {
-		return val, err
+	if val, err := c.cfg.Get([]string{hosts, hostname, key}); err == nil {
+		return val
 	}
 
 	if val, ok := defaultFor(key); ok {
-		return val, nil
+		return val
 	}
 
-	return "", nil
+	// This should not happen, as we know there is a default value for this key.
+	// Perhaps it says something about our current default abstraction being not quite right?
+	return ""
 }
 
 func (c *AuthConfig) Hosts() []string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,22 +53,13 @@ func (c *cfg) Get(hostname, key string) (string, error) {
 }
 
 func (c *cfg) GetOrDefault(hostname, key string) (string, error) {
-	var val string
-	var err error
-	if hostname != "" {
-		val, err = c.cfg.Get([]string{hosts, hostname, key})
-		if err == nil {
-			return val, err
-		}
-	}
-
-	val, err = c.cfg.Get([]string{key})
+	val, err := c.Get(hostname, key)
 	if err == nil {
 		return val, err
 	}
 
-	if defaultExists(key) {
-		return defaultFor(key), nil
+	if val, ok := def(key); ok {
+		return val, nil
 	}
 
 	return val, err
@@ -92,6 +83,15 @@ func (c *cfg) Aliases() *AliasConfig {
 
 func (c *cfg) Authentication() *AuthConfig {
 	return &AuthConfig{cfg: c.cfg}
+}
+
+func def(key string) (string, bool) {
+	for _, co := range configOptions {
+		if co.Key == key {
+			return co.DefaultValue, true
+		}
+	}
+	return "", false
 }
 
 func defaultFor(key string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,6 +234,8 @@ func (c *AuthConfig) Login(hostname, username, token, gitProtocol string, secure
 		c.cfg.Set([]string{hosts, hostname, oauthToken}, token)
 		insecureStorageUsed = true
 	}
+	// TODO: I can't find anywhere that calls this function without a username, so that would seem like
+	// something we might want to error on?
 	if username != "" {
 		c.cfg.Set([]string{hosts, hostname, "user"}, username)
 	}
@@ -246,6 +248,8 @@ func (c *AuthConfig) Login(hostname, username, token, gitProtocol string, secure
 // Logout will remove user, git protocol, and auth token for the given hostname.
 // It will remove the auth token from the encrypted storage if it exists there.
 func (c *AuthConfig) Logout(hostname string) error {
+	// TODO: I can't find anywhere that expects to call this function without a hostname
+	// and that would seem like a programmer error?
 	if hostname == "" {
 		return nil
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,95 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/stretchr/testify/require"
+
+	ghConfig "github.com/cli/go-gh/v2/pkg/config"
+)
+
+func TestGetNonExistentKey(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given we have no top level configuration
+	cfg, err := config.NewConfig()
+	require.NoError(t, err)
+
+	// When we get a key that has no value
+	val, err := cfg.Get("", "non-existent-key")
+
+	// Then it returns an error and the value is empty
+	var keyNotFoundError *ghConfig.KeyNotFoundError
+	require.ErrorAs(t, err, &keyNotFoundError)
+	require.Empty(t, val)
+}
+
+func TestGetNonExistentHostSpecificKey(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given have no top level configuration
+	cfg, err := config.NewConfig()
+	require.NoError(t, err)
+
+	// When we get a key for a host that has no value
+	val, err := cfg.Get("non-existent-host", "non-existent-key")
+
+	// Then it returns an error and the value is empty
+	var keyNotFoundError *ghConfig.KeyNotFoundError
+	require.ErrorAs(t, err, &keyNotFoundError)
+	require.Empty(t, val)
+}
+
+func TestGetExistingTopLevelKey(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given have a top level config entry
+	cfg, err := config.NewConfig()
+	require.NoError(t, err)
+	cfg.Set("", "top-level-key", "top-level-value")
+
+	// When we get that key
+	val, err := cfg.Get("non-existent-host", "top-level-key")
+
+	// Then it returns successfully with the correct value
+	require.NoError(t, err)
+	require.Equal(t, "top-level-value", val)
+}
+
+func TestGetExistingHostSpecificKey(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given have a host specific config entry
+	cfg, err := config.NewConfig()
+	require.NoError(t, err)
+	cfg.Set("github.com", "host-specific-key", "host-specific-value")
+
+	// When we get that key
+	val, err := cfg.Get("github.com", "host-specific-key")
+
+	// Then it returns successfully with the correct value
+	require.NoError(t, err)
+	require.Equal(t, "host-specific-value", val)
+}
+
+func TestGetHostnameSpecificKeyFallsBackToTopLevel(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+
+	// Given have a top level config entry
+	cfg, err := config.NewConfig()
+	require.NoError(t, err)
+	cfg.Set("", "key", "value")
+
+	// When we get that key on a specific host
+	val, err := cfg.Get("github.com", "key")
+
+	// Then it returns successfully, falling back to the top level config
+	require.NoError(t, err)
+	require.Equal(t, "value", val)
+}

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -178,7 +178,7 @@ func refreshRun(opts *RefreshOptions) error {
 		Prompter:   opts.Prompter,
 		GitClient:  opts.GitClient,
 	}
-	gitProtocol, _ := authCfg.GitProtocol(hostname)
+	gitProtocol := authCfg.GitProtocol(hostname)
 	if opts.Interactive && gitProtocol == "https" {
 		if err := credentialFlow.Prompt(hostname); err != nil {
 			return err

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -139,7 +139,7 @@ func statusRun(opts *StatusOptions) error {
 			}
 
 			addMsg("%s Logged in to %s as %s (%s)", cs.SuccessIcon(), hostname, cs.Bold(username), tokenSource)
-			proto, _ := authCfg.GitProtocol(hostname)
+			proto := authCfg.GitProtocol(hostname)
 			if proto != "" {
 				addMsg("%s Git operations for %s configured to use %s protocol.",
 					cs.SuccessIcon(), hostname, cs.Bold(proto))

--- a/pkg/cmd/gist/clone/clone.go
+++ b/pkg/cmd/gist/clone/clone.go
@@ -80,10 +80,7 @@ func cloneRun(opts *CloneOptions) error {
 			return err
 		}
 		hostname, _ := cfg.Authentication().DefaultHost()
-		protocol, err := cfg.GetOrDefault(hostname, "git_protocol")
-		if err != nil {
-			return err
-		}
+		protocol := cfg.Authentication().GitProtocol(hostname)
 		gistURL = formatRemoteURL(hostname, gistURL, protocol)
 	}
 

--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -84,7 +84,7 @@ func checkoutRun(opts *CheckoutOptions) error {
 	if err != nil {
 		return err
 	}
-	protocol, _ := cfg.GetOrDefault(baseRepo.RepoHost(), "git_protocol")
+	protocol := cfg.Authentication().GitProtocol(baseRepo.RepoHost())
 
 	remotes, err := opts.Remotes()
 	if err != nil {

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -761,7 +761,7 @@ func handlePush(opts CreateOptions, ctx CreateContext) error {
 			return err
 		}
 
-		cloneProtocol, _ := cfg.GetOrDefault(headRepo.RepoHost(), "git_protocol")
+		cloneProtocol := cfg.Authentication().GitProtocol(headRepo.RepoHost())
 		headRepoURL := ghrepo.FormatRemoteURL(headRepo, cloneProtocol)
 		gitClient := ctx.GitClient
 		origin, _ := remotes.FindByName("origin")

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -129,10 +129,7 @@ func cloneRun(opts *CloneOptions) error {
 			return err
 		}
 
-		protocol, err = cfg.GetOrDefault(repo.RepoHost(), "git_protocol")
-		if err != nil {
-			return err
-		}
+		protocol = cfg.Authentication().GitProtocol(repo.RepoHost())
 	}
 
 	wantsWiki := strings.HasSuffix(repo.RepoName(), ".wiki")
@@ -166,10 +163,7 @@ func cloneRun(opts *CloneOptions) error {
 
 	// If the repo is a fork, add the parent as an upstream remote and set the parent as the default repo.
 	if canonicalRepo.Parent != nil {
-		protocol, err := cfg.GetOrDefault(canonicalRepo.Parent.RepoHost(), "git_protocol")
-		if err != nil {
-			return err
-		}
+		protocol := cfg.Authentication().GitProtocol(canonicalRepo.Parent.RepoHost())
 		upstreamURL := ghrepo.FormatRemoteURL(canonicalRepo.Parent, protocol)
 
 		upstreamName := opts.UpstreamName

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -395,11 +395,7 @@ func createFromScratch(opts *CreateOptions) error {
 	}
 
 	if opts.Clone {
-		protocol, err := cfg.GetOrDefault(repo.RepoHost(), "git_protocol")
-		if err != nil {
-			return err
-		}
-
+		protocol := cfg.Authentication().GitProtocol(repo.RepoHost())
 		remoteURL := ghrepo.FormatRemoteURL(repo, protocol)
 
 		if !opts.AddReadme && opts.LicenseTemplate == "" && opts.GitIgnoreTemplate == "" && opts.Template == "" {
@@ -496,11 +492,7 @@ func createFromTemplate(opts *CreateOptions) error {
 	}
 
 	if opts.Clone {
-		protocol, err := cfg.GetOrDefault(repo.RepoHost(), "git_protocol")
-		if err != nil {
-			return err
-		}
-
+		protocol := cfg.Authentication().GitProtocol(repo.RepoHost())
 		remoteURL := ghrepo.FormatRemoteURL(repo, protocol)
 
 		if err := cloneWithRetry(opts, remoteURL, templateRepoMainBranch); err != nil {
@@ -622,11 +614,7 @@ func createFromLocal(opts *CreateOptions) error {
 		fmt.Fprintln(stdout, repo.URL)
 	}
 
-	protocol, err := cfg.GetOrDefault(repo.RepoHost(), "git_protocol")
-	if err != nil {
-		return err
-	}
-
+	protocol := cfg.Authentication().GitProtocol(repo.RepoHost())
 	remoteURL := ghrepo.FormatRemoteURL(repo, protocol)
 
 	if opts.Interactive {

--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -149,10 +149,7 @@ func updateRemote(repo ghrepo.Interface, renamed ghrepo.Interface, opts *RenameO
 		return nil, err
 	}
 
-	protocol, err := cfg.GetOrDefault(repo.RepoHost(), "git_protocol")
-	if err != nil {
-		return nil, err
-	}
+	protocol := cfg.Authentication().GitProtocol(repo.RepoHost())
 
 	remotes, err := opts.Remotes()
 	if err != nil {


### PR DESCRIPTION
### Description

In preparation for changing our configuration schema to support multiple accounts, I want gain confidence in our Config, particularly the pieces that relate to the `AuthConfig` structure and reach down into the config and keyring. I actually couldn't find any tests that provided coverage for this even as an integration.

There will need to also be some tests added to the `go-gh/auth` package which is called through here and reaches into the `config`.

I've left some comments on areas I want to call out.