### PR TITLE
`gh repo sync` should be able to sync a local branch with an upstream remote

### DIFF
--- a/pkg/cmd/repo/sync/git.go
+++ b/pkg/cmd/repo/sync/git.go
@@ -3,13 +3,11 @@ package sync
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/cli/cli/v2/git"
 )
 
 type gitClient interface {
-	BranchRemote(string) (string, error)
 	CurrentBranch() (string, error)
 	UpdateBranch(string, string) error
 	CreateBranch(string, string, string) error
@@ -23,20 +21,6 @@ type gitClient interface {
 
 type gitExecuter struct {
 	client *git.Client
-}
-
-func (g *gitExecuter) BranchRemote(branch string) (string, error) {
-	args := []string{"rev-parse", "--symbolic-full-name", "--abbrev-ref", fmt.Sprintf("%s@{u}", branch)}
-	cmd, err := g.client.Command(context.Background(), args...)
-	if err != nil {
-		return "", err
-	}
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	parts := strings.SplitN(string(out), "/", 2)
-	return parts[0], nil
 }
 
 func (g *gitExecuter) UpdateBranch(branch, ref string) error {

--- a/pkg/cmd/repo/sync/git.go
+++ b/pkg/cmd/repo/sync/git.go
@@ -14,7 +14,6 @@ type gitClient interface {
 	UpdateBranch(string, string) error
 	CreateBranch(string, string, string) error
 	Fetch(string, string) error
-	HasCommonAncestor(string, string) (bool, error)
 	HasLocalBranch(string) bool
 	IsAncestor(string, string) (bool, error)
 	IsDirty() (bool, error)
@@ -77,16 +76,6 @@ func (g *gitExecuter) Fetch(remote, ref string) error {
 		return err
 	}
 	return cmd.Run()
-}
-
-func (g *gitExecuter) HasCommonAncestor(commit1, commit2 string) (bool, error) {
-	args := []string{"merge-base", commit1, commit2}
-	cmd, err := g.client.Command(context.Background(), args...)
-	if err != nil {
-		return false, err
-	}
-	_, err = cmd.Output()
-	return err == nil, nil
 }
 
 func (g *gitExecuter) HasLocalBranch(branch string) bool {

--- a/pkg/cmd/repo/sync/git.go
+++ b/pkg/cmd/repo/sync/git.go
@@ -14,6 +14,7 @@ type gitClient interface {
 	UpdateBranch(string, string) error
 	CreateBranch(string, string, string) error
 	Fetch(string, string) error
+	HasCommonAncestor(string, string) (bool, error)
 	HasLocalBranch(string) bool
 	IsAncestor(string, string) (bool, error)
 	IsDirty() (bool, error)
@@ -76,6 +77,16 @@ func (g *gitExecuter) Fetch(remote, ref string) error {
 		return err
 	}
 	return cmd.Run()
+}
+
+func (g *gitExecuter) HasCommonAncestor(commit1, commit2 string) (bool, error) {
+	args := []string{"merge-base", commit1, commit2}
+	cmd, err := g.client.Command(context.Background(), args...)
+	if err != nil {
+		return false, err
+	}
+	_, err = cmd.Output()
+	return err == nil, nil
 }
 
 func (g *gitExecuter) HasLocalBranch(branch string) bool {

--- a/pkg/cmd/repo/sync/mocks.go
+++ b/pkg/cmd/repo/sync/mocks.go
@@ -8,11 +8,6 @@ type mockGitClient struct {
 	mock.Mock
 }
 
-func (g *mockGitClient) BranchRemote(a string) (string, error) {
-	args := g.Called(a)
-	return args.String(0), args.Error(1)
-}
-
 func (g *mockGitClient) UpdateBranch(b, r string) error {
 	args := g.Called(b, r)
 	return args.Error(0)

--- a/pkg/cmd/repo/sync/mocks.go
+++ b/pkg/cmd/repo/sync/mocks.go
@@ -33,11 +33,6 @@ func (g *mockGitClient) Fetch(a, b string) error {
 	return args.Error(0)
 }
 
-func (g *mockGitClient) HasCommonAncestor(a, b string) (bool, error) {
-	args := g.Called(a, b)
-	return args.Bool(0), args.Error(1)
-}
-
 func (g *mockGitClient) HasLocalBranch(a string) bool {
 	args := g.Called(a)
 	return args.Bool(0)

--- a/pkg/cmd/repo/sync/mocks.go
+++ b/pkg/cmd/repo/sync/mocks.go
@@ -33,6 +33,11 @@ func (g *mockGitClient) Fetch(a, b string) error {
 	return args.Error(0)
 }
 
+func (g *mockGitClient) HasCommonAncestor(a, b string) (bool, error) {
+	args := g.Called(a, b)
+	return args.Bool(0), args.Error(1)
+}
+
 func (g *mockGitClient) HasLocalBranch(a string) bool {
 	args := g.Called(a)
 	return args.Bool(0)

--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -229,7 +229,6 @@ func executeLocalRepoSync(srcRepo ghrepo.Interface, remote string, opts *SyncOpt
 		if err != nil {
 			return err
 		}
-
 		if !fastForward && !useForce {
 			return divergingError
 		}

--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -151,9 +151,6 @@ func syncLocalRepo(opts *SyncOptions) error {
 		if errors.Is(err, divergingError) {
 			return fmt.Errorf("can't sync because there are diverging changes; use `--force` to overwrite the destination branch")
 		}
-		if errors.Is(err, mismatchRemotesError) {
-			return fmt.Errorf("can't sync because %s is not tracking %s", opts.Branch, ghrepo.FullName(srcRepo))
-		}
 		return err
 	}
 
@@ -220,7 +217,6 @@ func syncRemoteRepo(opts *SyncOptions) error {
 }
 
 var divergingError = errors.New("diverging changes")
-var mismatchRemotesError = errors.New("branch remote does not match specified source")
 
 func executeLocalRepoSync(srcRepo ghrepo.Interface, remote string, opts *SyncOptions) error {
 	git := opts.Git
@@ -229,19 +225,6 @@ func executeLocalRepoSync(srcRepo ghrepo.Interface, remote string, opts *SyncOpt
 
 	hasLocalBranch := git.HasLocalBranch(branch)
 	if hasLocalBranch {
-		branchRemote, err := git.BranchRemote(branch)
-		if err != nil {
-			return err
-		}
-		if branchRemote != remote {
-			hasCommonAncestor, err := git.HasCommonAncestor(branch, "FETCH_HEAD")
-			if err != nil {
-				return err
-			}
-			if !hasCommonAncestor {
-				return mismatchRemotesError
-			}
-		}
 		fastForward, err := git.IsAncestor(branch, "FETCH_HEAD")
 		if err != nil {
 			return err

--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -234,9 +234,14 @@ func executeLocalRepoSync(srcRepo ghrepo.Interface, remote string, opts *SyncOpt
 			return err
 		}
 		if branchRemote != remote {
-			return mismatchRemotesError
+			hasCommonAncestor, err := git.HasCommonAncestor(branch, "FETCH_HEAD")
+			if err != nil {
+				return err
+			}
+			if !hasCommonAncestor {
+				return mismatchRemotesError
+			}
 		}
-
 		fastForward, err := git.IsAncestor(branch, "FETCH_HEAD")
 		if err != nil {
 			return err

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -122,11 +122,11 @@ func Test_SyncRun(t *testing.T) {
 					httpmock.StringResponse(`{"data":{"repository":{"defaultBranchRef":{"name": "trunk"}}}}`))
 			},
 			gitStubs: func(mgc *mockGitClient) {
-				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
+				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("MergeFastForward", "FETCH_HEAD").Return(nil).Once()
 			},
 			wantStdout: "✓ Synced the \"trunk\" branch from OWNER/REPO to local repository\n",
@@ -138,11 +138,11 @@ func Test_SyncRun(t *testing.T) {
 				Branch: "trunk",
 			},
 			gitStubs: func(mgc *mockGitClient) {
-				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
+				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("MergeFastForward", "FETCH_HEAD").Return(nil).Once()
 			},
 			wantStdout: "",
@@ -155,11 +155,11 @@ func Test_SyncRun(t *testing.T) {
 				SrcArg: "OWNER2/REPO2",
 			},
 			gitStubs: func(mgc *mockGitClient) {
-				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "upstream", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
+				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("MergeFastForward", "FETCH_HEAD").Return(nil).Once()
 			},
 			wantStdout: "✓ Synced the \"trunk\" branch from OWNER2/REPO2 to local repository\n",
@@ -172,14 +172,32 @@ func Test_SyncRun(t *testing.T) {
 				Force:  true,
 			},
 			gitStubs: func(mgc *mockGitClient) {
-				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(false, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
+				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("ResetHard", "FETCH_HEAD").Return(nil).Once()
 			},
 			wantStdout: "✓ Synced the \"trunk\" branch from OWNER/REPO to local repository\n",
+		},
+		{
+			name: "sync local repo with specified source repo and force specified",
+			tty:  true,
+			opts: &SyncOptions{
+				Branch: "trunk",
+				SrcArg: "OWNER2/REPO2",
+				Force:  true,
+			},
+			gitStubs: func(mgc *mockGitClient) {
+				mgc.On("Fetch", "upstream", "refs/heads/trunk").Return(nil).Once()
+				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
+				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(false, nil).Once()
+				mgc.On("CurrentBranch").Return("trunk", nil).Once()
+				mgc.On("IsDirty").Return(false, nil).Once()
+				mgc.On("ResetHard", "FETCH_HEAD").Return(nil).Once()
+			},
+			wantStdout: "✓ Synced the \"trunk\" branch from OWNER2/REPO2 to local repository\n",
 		},
 		{
 			name: "sync local repo with parent and not fast forward merge",
@@ -196,29 +214,14 @@ func Test_SyncRun(t *testing.T) {
 			errMsg:  "can't sync because there are diverging changes; use `--force` to overwrite the destination branch",
 		},
 		{
-			name: "sync local repo with upstream remote",
+			name: "sync local repo with specified source repo and not fast forward merge",
 			tty:  true,
 			opts: &SyncOptions{
 				Branch: "trunk",
+				SrcArg: "OWNER2/REPO2",
 			},
 			gitStubs: func(mgc *mockGitClient) {
-				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
-				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
-				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
-				mgc.On("CurrentBranch").Return("trunk", nil).Once()
-				mgc.On("IsDirty").Return(false, nil).Once()
-				mgc.On("MergeFastForward", "FETCH_HEAD").Return(nil).Once()
-			},
-			wantStdout: "✓ Synced the \"trunk\" branch from OWNER/REPO to local repository\n",
-		},
-		{
-			name: "sync local repo with parent and mismatching branch remotes",
-			tty:  true,
-			opts: &SyncOptions{
-				Branch: "trunk",
-			},
-			gitStubs: func(mgc *mockGitClient) {
-				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
+				mgc.On("Fetch", "upstream", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(false, nil).Once()
 			},

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -125,7 +125,6 @@ func Test_SyncRun(t *testing.T) {
 				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
-				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
 				mgc.On("MergeFastForward", "FETCH_HEAD").Return(nil).Once()
@@ -142,7 +141,6 @@ func Test_SyncRun(t *testing.T) {
 				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
-				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
 				mgc.On("MergeFastForward", "FETCH_HEAD").Return(nil).Once()
@@ -160,7 +158,6 @@ func Test_SyncRun(t *testing.T) {
 				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "upstream", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
-				mgc.On("BranchRemote", "trunk").Return("upstream", nil).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
 				mgc.On("MergeFastForward", "FETCH_HEAD").Return(nil).Once()
@@ -178,7 +175,6 @@ func Test_SyncRun(t *testing.T) {
 				mgc.On("IsDirty").Return(false, nil).Once()
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
-				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(false, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
 				mgc.On("ResetHard", "FETCH_HEAD").Return(nil).Once()
@@ -194,7 +190,6 @@ func Test_SyncRun(t *testing.T) {
 			gitStubs: func(mgc *mockGitClient) {
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
-				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(false, nil).Once()
 			},
 			wantErr: true,
@@ -209,8 +204,6 @@ func Test_SyncRun(t *testing.T) {
 			gitStubs: func(mgc *mockGitClient) {
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
-				mgc.On("BranchRemote", "trunk").Return("upstream", nil).Once()
-				mgc.On("HasCommonAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
 				mgc.On("IsDirty").Return(false, nil).Once()
@@ -227,11 +220,10 @@ func Test_SyncRun(t *testing.T) {
 			gitStubs: func(mgc *mockGitClient) {
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
-				mgc.On("BranchRemote", "trunk").Return("upstream", nil).Once()
-				mgc.On("HasCommonAncestor", "trunk", "FETCH_HEAD").Return(false, nil).Once()
+				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(false, nil).Once()
 			},
 			wantErr: true,
-			errMsg:  "can't sync because trunk is not tracking OWNER/REPO",
+			errMsg:  "can't sync because there are diverging changes; use `--force` to overwrite the destination branch",
 		},
 		{
 			name: "sync local repo with parent and local changes",
@@ -242,7 +234,6 @@ func Test_SyncRun(t *testing.T) {
 			gitStubs: func(mgc *mockGitClient) {
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
-				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("trunk", nil).Once()
 				mgc.On("IsDirty").Return(true, nil).Once()
@@ -259,7 +250,6 @@ func Test_SyncRun(t *testing.T) {
 			gitStubs: func(mgc *mockGitClient) {
 				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
 				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
-				mgc.On("BranchRemote", "trunk").Return("origin", nil).Once()
 				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
 				mgc.On("CurrentBranch").Return("test", nil).Once()
 				mgc.On("UpdateBranch", "trunk", "FETCH_HEAD").Return(nil).Once()


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #8100

Suppose there are 3 remotes
```shell
$ git remote -v
origin     git@github.com:me/project.git (fetch)
origin     git@github.com:me/project.git (push)
upstream   git@github.com:owner/project.git (fetch)
upstream   git@github.com:owner/project.git (push)
stranger   git@github.com:strangers/strangers.git (fetch)
stranger   git@github.com:strangers/strangers.git (push)
```

The `orgin` is `upstream`'s fork, and local repo is cloned from `origin`. Besides, the `stranger` has nothing to do with the `origin`, `upstream`, and `local` ones.

If you are trying `gh repo sync --source owner/project`, the program will enter [sync.go#236](https://github.com/cli/cli/compare/trunk...benebsiny:cli-8100?expand=1#diff-ee523f622ebcb46a15e716b85cededf15fa0a198a5a2f9a54fe47fa33077ec30R236) block. Next, check if this remote has the same ancestor as local repo, and this is done by func `HasCommonAncestor` ([sync.go#237](https://github.com/cli/cli/compare/trunk...benebsiny:cli-8100?expand=1#diff-ee523f622ebcb46a15e716b85cededf15fa0a198a5a2f9a54fe47fa33077ec30R237)), which runs `git merge-base branch_name FETCH_HEAD` ([Git Doc](https://git-scm.com/docs/git-merge-base)). Since the local repo is a fork of `upstream`, func `HasCommonAncestor` should return true. Then the program continues.

If you are trying `gh repo sync --source strangers/strangers`, func `HasCommonAncestor` should return false. Therefore, an error message is shown: `can't sync because master is not tracking strangers/strangers`

---

Assume that the `upstream` is removed by `git remote remove upstream`, then run `gh repo sync --source owner/project`, an error message is shown: `can't sync because master is not tracking owner/project`.
So, should this PR also handle (try to sync) the remotes which are not listed in `git remote`? Or just show the aforementioned error message?

If there's something unclarity, please let me know, thank you!