### PR TITLE
Make sure URLs are not truncated in tables

### DIFF
--- a/internal/tableprinter/table_printer.go
+++ b/internal/tableprinter/table_printer.go
@@ -33,6 +33,11 @@ func (tp *TablePrinter) AddTimeField(now, t time.Time, c func(string) string) {
 	tp.AddField(tf, WithColor(c))
 }
 
+// AddURLField displays the URL preventing it from being truncated.
+func (tp *TablePrinter) AddURLField(url string) {
+	tp.AddField(url, WithTruncate(nil))
+}
+
 var (
 	WithColor    = tableprinter.WithColor
 	WithPadding  = tableprinter.WithPadding

--- a/pkg/cmd/codespace/ports.go
+++ b/pkg/cmd/codespace/ports.go
@@ -116,7 +116,7 @@ func (a *App) ListPorts(ctx context.Context, selector *CodespaceSelector, export
 		tp.AddField(port.Label())
 		tp.AddField(cs.Yellow(fmt.Sprintf("%d", port.Port.PortNumber)))
 		tp.AddField(visibility)
-		tp.AddField(port.BrowseURL())
+		tp.AddURLField(port.BrowseURL())
 		tp.EndRow()
 	}
 	return tp.Render()

--- a/pkg/cmd/issue/develop/develop.go
+++ b/pkg/cmd/issue/develop/develop.go
@@ -202,7 +202,7 @@ func printLinkedBranches(io *iostreams.IOStreams, branches []api.LinkedBranch) {
 	table := tableprinter.New(io, tableprinter.WithHeader("BRANCH", "URL"))
 	for _, branch := range branches {
 		table.AddField(branch.BranchName, tableprinter.WithColor(cs.ColorFromString("cyan")))
-		table.AddField(branch.URL)
+		table.AddURLField(branch.URL)
 		table.EndRow()
 	}
 	_ = table.Render()

--- a/pkg/cmd/pr/checks/output.go
+++ b/pkg/cmd/pr/checks/output.go
@@ -46,7 +46,7 @@ func addRow(tp *tableprinter.TablePrinter, io *iostreams.IOStreams, o check) {
 		tp.AddField(name)
 		tp.AddField(o.Description)
 		tp.AddField(elapsed)
-		tp.AddField(o.Link)
+		tp.AddURLField(o.Link)
 	} else {
 		tp.AddField(o.Name)
 		if o.Bucket == "cancel" {
@@ -59,7 +59,7 @@ func addRow(tp *tableprinter.TablePrinter, io *iostreams.IOStreams, o check) {
 		} else {
 			tp.AddField(elapsed)
 		}
-		tp.AddField(o.Link)
+		tp.AddURLField(o.Link)
 		tp.AddField(o.Description)
 	}
 


### PR DESCRIPTION
In our old table printer URLs were automatically protected from being truncated, our new table printer does not have that feature so this PR explicitly adds that protection for URL fields. These are the three places I was able to find in the code that print URLs in tables but if we find more we should add the protection in those places as well.