### PR TITLE
Add default configuration back from go-gh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/charmbracelet/lipgloss v0.5.0
-	github.com/cli/go-gh/v2 v2.4.1-0.20231019124728-ec1e1cd3e0cb
+	github.com/cli/go-gh/v2 v2.4.1-0.20231024095351-47a83eeb1778
 	github.com/cli/oauth v1.0.1
 	github.com/cli/safeexec v1.0.1
 	github.com/cpuguy83/go-md2man/v2 v2.0.3

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/charmbracelet/lipgloss v0.5.0/go.mod h1:EZLha/HbzEt7cYqdFPovlqy5FZPj0
 github.com/cli/browser v1.0.0/go.mod h1:IEWkHYbLjkhtjwwWlwTHW2lGxeS5gezEQBMLTwDHf5Q=
 github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
 github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
-github.com/cli/go-gh/v2 v2.4.1-0.20231019124728-ec1e1cd3e0cb h1:HeIpiv5Jf09GQA0AyABbjC7Zq55eyIxpv4/BU6ujHRk=
-github.com/cli/go-gh/v2 v2.4.1-0.20231019124728-ec1e1cd3e0cb/go.mod h1:h3salfqqooVpzKmHp6aUdeNx62UmxQRpLbagFSHTJGQ=
+github.com/cli/go-gh/v2 v2.4.1-0.20231024095351-47a83eeb1778 h1:2WcQtkNIafTIimwJJUTzFLqXO3BH4avCAcWQT22xiKc=
+github.com/cli/go-gh/v2 v2.4.1-0.20231024095351-47a83eeb1778/go.mod h1:h3salfqqooVpzKmHp6aUdeNx62UmxQRpLbagFSHTJGQ=
 github.com/cli/oauth v1.0.1 h1:pXnTFl/qUegXHK531Dv0LNjW4mLx626eS42gnzfXJPA=
 github.com/cli/oauth v1.0.1/go.mod h1:qd/FX8ZBD6n1sVNQO3aIdRxeu5LGw9WhKnYhIIoC2A4=
 github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -20,7 +20,7 @@ func newTestAuthConfig(t *testing.T) *AuthConfig {
 	//
 	// This means that tests can't be isolated from each other, so
 	// we swap out the function here to return a new config each time.
-	ghConfig.Read = func() (*ghConfig.Config, error) {
+	ghConfig.Read = func(_ *ghConfig.Config) (*ghConfig.Config, error) {
 		return authCfg.cfg, nil
 	}
 
@@ -29,7 +29,7 @@ func newTestAuthConfig(t *testing.T) *AuthConfig {
 	//
 	// We should consider whether it makes sense to change that but in the meantime
 	// we can use GH_CONFIG_DIR env var to ensure the tests remain isolated.
-	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	StubWriteConfig(t)
 
 	return &authCfg
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,7 @@ type Config interface {
 }
 
 func NewConfig() (Config, error) {
-	c, err := ghConfig.Read()
+	c, err := ghConfig.Read(fallbackConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (c *cfg) Authentication() *AuthConfig {
 }
 
 func defaultFor(key string) (string, bool) {
-	for _, co := range configOptions {
+	for _, co := range ConfigOptions() {
 		if co.Key == key {
 			return co.DefaultValue, true
 		}
@@ -276,6 +276,28 @@ func (a *AliasConfig) All() map[string]string {
 	return out
 }
 
+func fallbackConfig() *ghConfig.Config {
+	return ghConfig.ReadFromString(defaultConfigStr)
+}
+
+const defaultConfigStr = `
+# What protocol to use when performing git operations. Supported values: ssh, https
+git_protocol: https
+# What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.
+editor:
+# When to interactively prompt. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
+prompt: enabled
+# A pager program to send command output to, e.g. "less". Set the value to "cat" to disable the pager.
+pager:
+# Aliases allow you to create nicknames for gh commands
+aliases:
+  co: pr checkout
+# The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
+http_unix_socket:
+# What web browser gh should use when opening URLs. If blank, will refer to environment.
+browser:
+`
+
 type ConfigOption struct {
 	Key           string
 	Description   string
@@ -283,43 +305,41 @@ type ConfigOption struct {
 	AllowedValues []string
 }
 
-var configOptions = []ConfigOption{
-	{
-		Key:           "git_protocol",
-		Description:   "the protocol to use for git clone and push operations",
-		DefaultValue:  "https",
-		AllowedValues: []string{"https", "ssh"},
-	},
-	{
-		Key:          "editor",
-		Description:  "the text editor program to use for authoring text",
-		DefaultValue: "",
-	},
-	{
-		Key:           "prompt",
-		Description:   "toggle interactive prompting in the terminal",
-		DefaultValue:  "enabled",
-		AllowedValues: []string{"enabled", "disabled"},
-	},
-	{
-		Key:          "pager",
-		Description:  "the terminal pager program to send standard output to",
-		DefaultValue: "",
-	},
-	{
-		Key:          "http_unix_socket",
-		Description:  "the path to a Unix socket through which to make an HTTP connection",
-		DefaultValue: "",
-	},
-	{
-		Key:          "browser",
-		Description:  "the web browser to use for opening URLs",
-		DefaultValue: "",
-	},
-}
-
 func ConfigOptions() []ConfigOption {
-	return configOptions
+	return []ConfigOption{
+		{
+			Key:           "git_protocol",
+			Description:   "the protocol to use for git clone and push operations",
+			DefaultValue:  "https",
+			AllowedValues: []string{"https", "ssh"},
+		},
+		{
+			Key:          "editor",
+			Description:  "the text editor program to use for authoring text",
+			DefaultValue: "",
+		},
+		{
+			Key:           "prompt",
+			Description:   "toggle interactive prompting in the terminal",
+			DefaultValue:  "enabled",
+			AllowedValues: []string{"enabled", "disabled"},
+		},
+		{
+			Key:          "pager",
+			Description:  "the terminal pager program to send standard output to",
+			DefaultValue: "",
+		},
+		{
+			Key:          "http_unix_socket",
+			Description:  "the path to a Unix socket through which to make an HTTP connection",
+			DefaultValue: "",
+		},
+		{
+			Key:          "browser",
+			Description:  "the web browser to use for opening URLs",
+			DefaultValue: "",
+		},
+	}
 }
 
 func HomeDirPath(subdir string) (string, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -133,3 +133,35 @@ func TestGetOrDefaultNotFoundAndNoDefault(t *testing.T) {
 	require.ErrorAs(t, err, &keyNotFoundError)
 	require.Empty(t, val)
 }
+
+func TestFallbackConfig(t *testing.T) {
+	cfg := fallbackConfig()
+
+	protocol, err := cfg.Get([]string{"git_protocol"})
+	require.NoError(t, err)
+	require.Equal(t, "https", protocol)
+
+	editor, err := cfg.Get([]string{"editor"})
+	require.NoError(t, err)
+	require.Equal(t, "", editor)
+
+	prompt, err := cfg.Get([]string{"prompt"})
+	require.NoError(t, err)
+	require.Equal(t, "enabled", prompt)
+
+	pager, err := cfg.Get([]string{"pager"})
+	require.NoError(t, err)
+	require.Equal(t, "", pager)
+
+	socket, err := cfg.Get([]string{"http_unix_socket"})
+	require.NoError(t, err)
+	require.Equal(t, "", socket)
+
+	browser, err := cfg.Get([]string{"browser"})
+	require.NoError(t, err)
+	require.Equal(t, "", browser)
+
+	unknown, err := cfg.Get([]string{"unknown"})
+	require.EqualError(t, err, `could not find key "unknown"`)
+	require.Equal(t, "", unknown)
+}

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -10,24 +10,7 @@ import (
 )
 
 func NewBlankConfig() *ConfigMock {
-	defaultStr := `
-# What protocol to use when performing git operations. Supported values: ssh, https
-git_protocol: https
-# What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.
-editor:
-# When to interactively prompt. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
-prompt: enabled
-# A pager program to send command output to, e.g. "less". Set the value to "cat" to disable the pager.
-pager:
-# Aliases allow you to create nicknames for gh commands
-aliases:
-  co: pr checkout
-# The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
-http_unix_socket:
-# What web browser gh should use when opening URLs. If blank, will refer to environment.
-browser:
-`
-	return NewFromString(defaultStr)
+	return NewFromString(defaultConfigStr)
 }
 
 func NewFromString(cfgStr string) *ConfigMock {


### PR DESCRIPTION
Follow up to https://github.com/cli/go-gh/pull/142

This PR adds back in the default configuration knowledge that was previously held in `go-gh`. 

⚠️ Note that this can not be merged until https://github.com/cli/go-gh/pull/142 is merged and needs to pull in the latest `go-gh` version.