### PR TITLE
Fix git protocol and refactor Config interface

### DIFF
--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -158,17 +158,6 @@ func TestUserNotLoggedIn(t *testing.T) {
 	require.ErrorAs(t, err, &keyNotFoundError)
 }
 
-func TestGitProtocolNotLoggedInDefaults(t *testing.T) {
-	// Given we have not logged in
-	authCfg := newTestAuthConfig(t)
-
-	// When we get the git protocol
-	gitProtocol := authCfg.GitProtocol("github.com")
-
-	// Then it returns the default
-	require.Equal(t, "https", gitProtocol)
-}
-
 func TestHostsIncludesEnvVar(t *testing.T) {
 	// Given the GH_HOST env var is set
 	authCfg := newTestAuthConfig(t)
@@ -217,7 +206,7 @@ func TestDefaultHostLoggedInToOnlyOneHost(t *testing.T) {
 
 	// Then the returned host is that logged in host and the source is the hosts config
 	require.Equal(t, "ghe.io", defaultHost)
-	require.Equal(t, "hosts", source)
+	require.Equal(t, hosts, source)
 }
 
 func TestLoginSecureStorageUsesKeyring(t *testing.T) {
@@ -302,10 +291,11 @@ func TestLoginSetsGitProtocolForProvidedHost(t *testing.T) {
 	require.NoError(t, err)
 
 	// When we get the git protocol
-	gitProtocol := authCfg.GitProtocol("github.com")
+	protocol, err := authCfg.cfg.Get([]string{hosts, "github.com", gitProtocol})
+	require.NoError(t, err)
 
 	// Then it returns the git protocol we provided on login
-	require.Equal(t, "ssh", gitProtocol)
+	require.Equal(t, "ssh", protocol)
 }
 
 func TestLoginAddsHostIfNotAlreadyAdded(t *testing.T) {

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -206,7 +206,7 @@ func TestDefaultHostLoggedInToOnlyOneHost(t *testing.T) {
 
 	// Then the returned host is that logged in host and the source is the hosts config
 	require.Equal(t, "ghe.io", defaultHost)
-	require.Equal(t, hosts, source)
+	require.Equal(t, hostsKey, source)
 }
 
 func TestLoginSecureStorageUsesKeyring(t *testing.T) {
@@ -230,14 +230,14 @@ func TestLoginSecureStorageRemovesOldInsecureConfigToken(t *testing.T) {
 	// Given a usable keyring and an oauth token in the config
 	keyring.MockInit()
 	authCfg := newTestAuthConfig(t)
-	authCfg.cfg.Set([]string{hosts, "github.com", oauthToken}, "old-token")
+	authCfg.cfg.Set([]string{hostsKey, "github.com", oauthTokenKey}, "old-token")
 
 	// When we login with secure storage
 	_, err := authCfg.Login("github.com", "test-user", "test-token", "", true)
 
 	// Then it returns success, having also removed the old token from the config
 	require.NoError(t, err)
-	requireNoKey(t, authCfg.cfg, []string{hosts, "github.com", oauthToken})
+	requireNoKey(t, authCfg.cfg, []string{hostsKey, "github.com", oauthTokenKey})
 }
 
 func TestLoginSecureStorageWithErrorFallsbackAndReports(t *testing.T) {
@@ -252,7 +252,7 @@ func TestLoginSecureStorageWithErrorFallsbackAndReports(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, insecureStorageUsed, "expected to use insecure storage")
-	requireKeyWithValue(t, authCfg.cfg, []string{hosts, "github.com", oauthToken}, "test-token")
+	requireKeyWithValue(t, authCfg.cfg, []string{hostsKey, "github.com", oauthTokenKey}, "test-token")
 }
 
 func TestLoginInsecureStorage(t *testing.T) {
@@ -266,7 +266,7 @@ func TestLoginInsecureStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, insecureStorageUsed, "expected to use insecure storage")
-	requireKeyWithValue(t, authCfg.cfg, []string{hosts, "github.com", oauthToken}, "test-token")
+	requireKeyWithValue(t, authCfg.cfg, []string{hostsKey, "github.com", oauthTokenKey}, "test-token")
 }
 
 func TestLoginSetsUserForProvidedHost(t *testing.T) {
@@ -291,7 +291,7 @@ func TestLoginSetsGitProtocolForProvidedHost(t *testing.T) {
 	require.NoError(t, err)
 
 	// When we get the git protocol
-	protocol, err := authCfg.cfg.Get([]string{hosts, "github.com", gitProtocol})
+	protocol, err := authCfg.cfg.Get([]string{hostsKey, "github.com", gitProtocolKey})
 	require.NoError(t, err)
 
 	// Then it returns the git protocol we provided on login
@@ -324,7 +324,7 @@ func TestLogoutRemovesHostAndKeyringToken(t *testing.T) {
 	// Then we return success, and the host and token are removed from the config and keyring
 	require.NoError(t, err)
 
-	requireNoKey(t, authCfg.cfg, []string{hosts, "github.com"})
+	requireNoKey(t, authCfg.cfg, []string{hostsKey, "github.com"})
 	_, err = keyring.Get(keyringServiceName("github.com"), "")
 	require.ErrorIs(t, err, keyring.ErrNotFound)
 }

--- a/internal/config/config_mock.go
+++ b/internal/config/config_mock.go
@@ -23,11 +23,26 @@ var _ Config = &ConfigMock{}
 //			AuthenticationFunc: func() *AuthConfig {
 //				panic("mock out the Authentication method")
 //			},
-//			GetFunc: func(s1 string, s2 string) (string, error) {
-//				panic("mock out the Get method")
+//			BrowserFunc: func(s string) string {
+//				panic("mock out the Browser method")
+//			},
+//			EditorFunc: func(s string) string {
+//				panic("mock out the Editor method")
 //			},
 //			GetOrDefaultFunc: func(s1 string, s2 string) (string, error) {
 //				panic("mock out the GetOrDefault method")
+//			},
+//			GitProtocolFunc: func(s string) string {
+//				panic("mock out the GitProtocol method")
+//			},
+//			HTTPUnixSocketFunc: func(s string) string {
+//				panic("mock out the HTTPUnixSocket method")
+//			},
+//			PagerFunc: func(s string) string {
+//				panic("mock out the Pager method")
+//			},
+//			PromptFunc: func(s string) string {
+//				panic("mock out the Prompt method")
 //			},
 //			SetFunc: func(s1 string, s2 string, s3 string)  {
 //				panic("mock out the Set method")
@@ -48,11 +63,26 @@ type ConfigMock struct {
 	// AuthenticationFunc mocks the Authentication method.
 	AuthenticationFunc func() *AuthConfig
 
-	// GetFunc mocks the Get method.
-	GetFunc func(s1 string, s2 string) (string, error)
+	// BrowserFunc mocks the Browser method.
+	BrowserFunc func(s string) string
+
+	// EditorFunc mocks the Editor method.
+	EditorFunc func(s string) string
 
 	// GetOrDefaultFunc mocks the GetOrDefault method.
 	GetOrDefaultFunc func(s1 string, s2 string) (string, error)
+
+	// GitProtocolFunc mocks the GitProtocol method.
+	GitProtocolFunc func(s string) string
+
+	// HTTPUnixSocketFunc mocks the HTTPUnixSocket method.
+	HTTPUnixSocketFunc func(s string) string
+
+	// PagerFunc mocks the Pager method.
+	PagerFunc func(s string) string
+
+	// PromptFunc mocks the Prompt method.
+	PromptFunc func(s string) string
 
 	// SetFunc mocks the Set method.
 	SetFunc func(s1 string, s2 string, s3 string)
@@ -68,12 +98,15 @@ type ConfigMock struct {
 		// Authentication holds details about calls to the Authentication method.
 		Authentication []struct {
 		}
-		// Get holds details about calls to the Get method.
-		Get []struct {
-			// S1 is the s1 argument value.
-			S1 string
-			// S2 is the s2 argument value.
-			S2 string
+		// Browser holds details about calls to the Browser method.
+		Browser []struct {
+			// S is the s argument value.
+			S string
+		}
+		// Editor holds details about calls to the Editor method.
+		Editor []struct {
+			// S is the s argument value.
+			S string
 		}
 		// GetOrDefault holds details about calls to the GetOrDefault method.
 		GetOrDefault []struct {
@@ -81,6 +114,26 @@ type ConfigMock struct {
 			S1 string
 			// S2 is the s2 argument value.
 			S2 string
+		}
+		// GitProtocol holds details about calls to the GitProtocol method.
+		GitProtocol []struct {
+			// S is the s argument value.
+			S string
+		}
+		// HTTPUnixSocket holds details about calls to the HTTPUnixSocket method.
+		HTTPUnixSocket []struct {
+			// S is the s argument value.
+			S string
+		}
+		// Pager holds details about calls to the Pager method.
+		Pager []struct {
+			// S is the s argument value.
+			S string
+		}
+		// Prompt holds details about calls to the Prompt method.
+		Prompt []struct {
+			// S is the s argument value.
+			S string
 		}
 		// Set holds details about calls to the Set method.
 		Set []struct {
@@ -97,8 +150,13 @@ type ConfigMock struct {
 	}
 	lockAliases        sync.RWMutex
 	lockAuthentication sync.RWMutex
-	lockGet            sync.RWMutex
+	lockBrowser        sync.RWMutex
+	lockEditor         sync.RWMutex
 	lockGetOrDefault   sync.RWMutex
+	lockGitProtocol    sync.RWMutex
+	lockHTTPUnixSocket sync.RWMutex
+	lockPager          sync.RWMutex
+	lockPrompt         sync.RWMutex
 	lockSet            sync.RWMutex
 	lockWrite          sync.RWMutex
 }
@@ -157,39 +215,67 @@ func (mock *ConfigMock) AuthenticationCalls() []struct {
 	return calls
 }
 
-// Get calls GetFunc.
-func (mock *ConfigMock) Get(s1 string, s2 string) (string, error) {
-	if mock.GetFunc == nil {
-		panic("ConfigMock.GetFunc: method is nil but Config.Get was just called")
+// Browser calls BrowserFunc.
+func (mock *ConfigMock) Browser(s string) string {
+	if mock.BrowserFunc == nil {
+		panic("ConfigMock.BrowserFunc: method is nil but Config.Browser was just called")
 	}
 	callInfo := struct {
-		S1 string
-		S2 string
+		S string
 	}{
-		S1: s1,
-		S2: s2,
+		S: s,
 	}
-	mock.lockGet.Lock()
-	mock.calls.Get = append(mock.calls.Get, callInfo)
-	mock.lockGet.Unlock()
-	return mock.GetFunc(s1, s2)
+	mock.lockBrowser.Lock()
+	mock.calls.Browser = append(mock.calls.Browser, callInfo)
+	mock.lockBrowser.Unlock()
+	return mock.BrowserFunc(s)
 }
 
-// GetCalls gets all the calls that were made to Get.
+// BrowserCalls gets all the calls that were made to Browser.
 // Check the length with:
 //
-//	len(mockedConfig.GetCalls())
-func (mock *ConfigMock) GetCalls() []struct {
-	S1 string
-	S2 string
+//	len(mockedConfig.BrowserCalls())
+func (mock *ConfigMock) BrowserCalls() []struct {
+	S string
 } {
 	var calls []struct {
-		S1 string
-		S2 string
+		S string
 	}
-	mock.lockGet.RLock()
-	calls = mock.calls.Get
-	mock.lockGet.RUnlock()
+	mock.lockBrowser.RLock()
+	calls = mock.calls.Browser
+	mock.lockBrowser.RUnlock()
+	return calls
+}
+
+// Editor calls EditorFunc.
+func (mock *ConfigMock) Editor(s string) string {
+	if mock.EditorFunc == nil {
+		panic("ConfigMock.EditorFunc: method is nil but Config.Editor was just called")
+	}
+	callInfo := struct {
+		S string
+	}{
+		S: s,
+	}
+	mock.lockEditor.Lock()
+	mock.calls.Editor = append(mock.calls.Editor, callInfo)
+	mock.lockEditor.Unlock()
+	return mock.EditorFunc(s)
+}
+
+// EditorCalls gets all the calls that were made to Editor.
+// Check the length with:
+//
+//	len(mockedConfig.EditorCalls())
+func (mock *ConfigMock) EditorCalls() []struct {
+	S string
+} {
+	var calls []struct {
+		S string
+	}
+	mock.lockEditor.RLock()
+	calls = mock.calls.Editor
+	mock.lockEditor.RUnlock()
 	return calls
 }
 
@@ -226,6 +312,134 @@ func (mock *ConfigMock) GetOrDefaultCalls() []struct {
 	mock.lockGetOrDefault.RLock()
 	calls = mock.calls.GetOrDefault
 	mock.lockGetOrDefault.RUnlock()
+	return calls
+}
+
+// GitProtocol calls GitProtocolFunc.
+func (mock *ConfigMock) GitProtocol(s string) string {
+	if mock.GitProtocolFunc == nil {
+		panic("ConfigMock.GitProtocolFunc: method is nil but Config.GitProtocol was just called")
+	}
+	callInfo := struct {
+		S string
+	}{
+		S: s,
+	}
+	mock.lockGitProtocol.Lock()
+	mock.calls.GitProtocol = append(mock.calls.GitProtocol, callInfo)
+	mock.lockGitProtocol.Unlock()
+	return mock.GitProtocolFunc(s)
+}
+
+// GitProtocolCalls gets all the calls that were made to GitProtocol.
+// Check the length with:
+//
+//	len(mockedConfig.GitProtocolCalls())
+func (mock *ConfigMock) GitProtocolCalls() []struct {
+	S string
+} {
+	var calls []struct {
+		S string
+	}
+	mock.lockGitProtocol.RLock()
+	calls = mock.calls.GitProtocol
+	mock.lockGitProtocol.RUnlock()
+	return calls
+}
+
+// HTTPUnixSocket calls HTTPUnixSocketFunc.
+func (mock *ConfigMock) HTTPUnixSocket(s string) string {
+	if mock.HTTPUnixSocketFunc == nil {
+		panic("ConfigMock.HTTPUnixSocketFunc: method is nil but Config.HTTPUnixSocket was just called")
+	}
+	callInfo := struct {
+		S string
+	}{
+		S: s,
+	}
+	mock.lockHTTPUnixSocket.Lock()
+	mock.calls.HTTPUnixSocket = append(mock.calls.HTTPUnixSocket, callInfo)
+	mock.lockHTTPUnixSocket.Unlock()
+	return mock.HTTPUnixSocketFunc(s)
+}
+
+// HTTPUnixSocketCalls gets all the calls that were made to HTTPUnixSocket.
+// Check the length with:
+//
+//	len(mockedConfig.HTTPUnixSocketCalls())
+func (mock *ConfigMock) HTTPUnixSocketCalls() []struct {
+	S string
+} {
+	var calls []struct {
+		S string
+	}
+	mock.lockHTTPUnixSocket.RLock()
+	calls = mock.calls.HTTPUnixSocket
+	mock.lockHTTPUnixSocket.RUnlock()
+	return calls
+}
+
+// Pager calls PagerFunc.
+func (mock *ConfigMock) Pager(s string) string {
+	if mock.PagerFunc == nil {
+		panic("ConfigMock.PagerFunc: method is nil but Config.Pager was just called")
+	}
+	callInfo := struct {
+		S string
+	}{
+		S: s,
+	}
+	mock.lockPager.Lock()
+	mock.calls.Pager = append(mock.calls.Pager, callInfo)
+	mock.lockPager.Unlock()
+	return mock.PagerFunc(s)
+}
+
+// PagerCalls gets all the calls that were made to Pager.
+// Check the length with:
+//
+//	len(mockedConfig.PagerCalls())
+func (mock *ConfigMock) PagerCalls() []struct {
+	S string
+} {
+	var calls []struct {
+		S string
+	}
+	mock.lockPager.RLock()
+	calls = mock.calls.Pager
+	mock.lockPager.RUnlock()
+	return calls
+}
+
+// Prompt calls PromptFunc.
+func (mock *ConfigMock) Prompt(s string) string {
+	if mock.PromptFunc == nil {
+		panic("ConfigMock.PromptFunc: method is nil but Config.Prompt was just called")
+	}
+	callInfo := struct {
+		S string
+	}{
+		S: s,
+	}
+	mock.lockPrompt.Lock()
+	mock.calls.Prompt = append(mock.calls.Prompt, callInfo)
+	mock.lockPrompt.Unlock()
+	return mock.PromptFunc(s)
+}
+
+// PromptCalls gets all the calls that were made to Prompt.
+// Check the length with:
+//
+//	len(mockedConfig.PromptCalls())
+func (mock *ConfigMock) PromptCalls() []struct {
+	S string
+} {
+	var calls []struct {
+		S string
+	}
+	mock.lockPrompt.RLock()
+	calls = mock.calls.Prompt
+	mock.lockPrompt.RUnlock()
 	return calls
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,13 +22,13 @@ func TestNewConfigProvidesFallback(t *testing.T) {
 	}
 	_, err := NewConfig()
 	require.NoError(t, err)
-	requireKeyWithValue(t, spiedCfg, []string{"git_protocol"}, "https")
-	requireKeyWithValue(t, spiedCfg, []string{"editor"}, "")
-	requireKeyWithValue(t, spiedCfg, []string{"prompt"}, "enabled")
-	requireKeyWithValue(t, spiedCfg, []string{"pager"}, "")
-	requireKeyWithValue(t, spiedCfg, []string{"aliases", "co"}, "pr checkout")
-	requireKeyWithValue(t, spiedCfg, []string{"http_unix_socket"}, "")
-	requireKeyWithValue(t, spiedCfg, []string{"browser"}, "")
+	requireKeyWithValue(t, spiedCfg, []string{gitProtocol}, "https")
+	requireKeyWithValue(t, spiedCfg, []string{editor}, "")
+	requireKeyWithValue(t, spiedCfg, []string{prompt}, "enabled")
+	requireKeyWithValue(t, spiedCfg, []string{pager}, "")
+	requireKeyWithValue(t, spiedCfg, []string{aliases, "co"}, "pr checkout")
+	requireKeyWithValue(t, spiedCfg, []string{httpUnixSocket}, "")
+	requireKeyWithValue(t, spiedCfg, []string{browser}, "")
 }
 
 func TestGetNonExistentKey(t *testing.T) {
@@ -101,12 +101,12 @@ func TestGetOrDefaultApplicationDefaults(t *testing.T) {
 		key             string
 		expectedDefault string
 	}{
-		{"git_protocol", "https"},
-		{"editor", ""},
-		{"prompt", "enabled"},
-		{"pager", ""},
-		{"http_unix_socket", ""},
-		{"browser", ""},
+		{gitProtocol, "https"},
+		{editor, ""},
+		{prompt, "enabled"},
+		{pager, ""},
+		{httpUnixSocket, ""},
+		{browser, ""},
 	}
 
 	for _, tt := range tests {
@@ -127,10 +127,10 @@ func TestGetOrDefaultApplicationDefaults(t *testing.T) {
 func TestGetOrDefaultExistingKey(t *testing.T) {
 	// Given have a top level config entry
 	cfg := newTestConfig()
-	cfg.Set("", "git_protocol", "ssh")
+	cfg.Set("", gitProtocol, "ssh")
 
 	// When we get that key
-	val, err := cfg.GetOrDefault("", "git_protocol")
+	val, err := cfg.GetOrDefault("", gitProtocol)
 
 	// Then it returns successfully with the correct value, and doesn't fall back
 	// to the default
@@ -153,12 +153,12 @@ func TestGetOrDefaultNotFoundAndNoDefault(t *testing.T) {
 
 func TestFallbackConfig(t *testing.T) {
 	cfg := fallbackConfig()
-	requireKeyWithValue(t, cfg, []string{"git_protocol"}, "https")
-	requireKeyWithValue(t, cfg, []string{"editor"}, "")
-	requireKeyWithValue(t, cfg, []string{"prompt"}, "enabled")
-	requireKeyWithValue(t, cfg, []string{"pager"}, "")
-	requireKeyWithValue(t, cfg, []string{"aliases", "co"}, "pr checkout")
-	requireKeyWithValue(t, cfg, []string{"http_unix_socket"}, "")
-	requireKeyWithValue(t, cfg, []string{"browser"}, "")
+	requireKeyWithValue(t, cfg, []string{gitProtocol}, "https")
+	requireKeyWithValue(t, cfg, []string{editor}, "")
+	requireKeyWithValue(t, cfg, []string{prompt}, "enabled")
+	requireKeyWithValue(t, cfg, []string{pager}, "")
+	requireKeyWithValue(t, cfg, []string{aliases, "co"}, "pr checkout")
+	requireKeyWithValue(t, cfg, []string{httpUnixSocket}, "")
+	requireKeyWithValue(t, cfg, []string{browser}, "")
 	requireNoKey(t, cfg, []string{"unknown"})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,13 +22,13 @@ func TestNewConfigProvidesFallback(t *testing.T) {
 	}
 	_, err := NewConfig()
 	require.NoError(t, err)
-	requireKeyWithValue(t, spiedCfg, []string{gitProtocol}, "https")
-	requireKeyWithValue(t, spiedCfg, []string{editor}, "")
-	requireKeyWithValue(t, spiedCfg, []string{prompt}, "enabled")
-	requireKeyWithValue(t, spiedCfg, []string{pager}, "")
-	requireKeyWithValue(t, spiedCfg, []string{aliases, "co"}, "pr checkout")
-	requireKeyWithValue(t, spiedCfg, []string{httpUnixSocket}, "")
-	requireKeyWithValue(t, spiedCfg, []string{browser}, "")
+	requireKeyWithValue(t, spiedCfg, []string{gitProtocolKey}, "https")
+	requireKeyWithValue(t, spiedCfg, []string{editorKey}, "")
+	requireKeyWithValue(t, spiedCfg, []string{promptKey}, "enabled")
+	requireKeyWithValue(t, spiedCfg, []string{pagerKey}, "")
+	requireKeyWithValue(t, spiedCfg, []string{aliasesKey, "co"}, "pr checkout")
+	requireKeyWithValue(t, spiedCfg, []string{httpUnixSocketKey}, "")
+	requireKeyWithValue(t, spiedCfg, []string{browserKey}, "")
 }
 
 func TestGetNonExistentKey(t *testing.T) {
@@ -101,12 +101,12 @@ func TestGetOrDefaultApplicationDefaults(t *testing.T) {
 		key             string
 		expectedDefault string
 	}{
-		{gitProtocol, "https"},
-		{editor, ""},
-		{prompt, "enabled"},
-		{pager, ""},
-		{httpUnixSocket, ""},
-		{browser, ""},
+		{gitProtocolKey, "https"},
+		{editorKey, ""},
+		{promptKey, "enabled"},
+		{pagerKey, ""},
+		{httpUnixSocketKey, ""},
+		{browserKey, ""},
 	}
 
 	for _, tt := range tests {
@@ -127,10 +127,10 @@ func TestGetOrDefaultApplicationDefaults(t *testing.T) {
 func TestGetOrDefaultExistingKey(t *testing.T) {
 	// Given have a top level config entry
 	cfg := newTestConfig()
-	cfg.Set("", gitProtocol, "ssh")
+	cfg.Set("", gitProtocolKey, "ssh")
 
 	// When we get that key
-	val, err := cfg.GetOrDefault("", gitProtocol)
+	val, err := cfg.GetOrDefault("", gitProtocolKey)
 
 	// Then it returns successfully with the correct value, and doesn't fall back
 	// to the default
@@ -153,12 +153,12 @@ func TestGetOrDefaultNotFoundAndNoDefault(t *testing.T) {
 
 func TestFallbackConfig(t *testing.T) {
 	cfg := fallbackConfig()
-	requireKeyWithValue(t, cfg, []string{gitProtocol}, "https")
-	requireKeyWithValue(t, cfg, []string{editor}, "")
-	requireKeyWithValue(t, cfg, []string{prompt}, "enabled")
-	requireKeyWithValue(t, cfg, []string{pager}, "")
-	requireKeyWithValue(t, cfg, []string{aliases, "co"}, "pr checkout")
-	requireKeyWithValue(t, cfg, []string{httpUnixSocket}, "")
-	requireKeyWithValue(t, cfg, []string{browser}, "")
+	requireKeyWithValue(t, cfg, []string{gitProtocolKey}, "https")
+	requireKeyWithValue(t, cfg, []string{editorKey}, "")
+	requireKeyWithValue(t, cfg, []string{promptKey}, "enabled")
+	requireKeyWithValue(t, cfg, []string{pagerKey}, "")
+	requireKeyWithValue(t, cfg, []string{aliasesKey, "co"}, "pr checkout")
+	requireKeyWithValue(t, cfg, []string{httpUnixSocketKey}, "")
+	requireKeyWithValue(t, cfg, []string{browserKey}, "")
 	requireNoKey(t, cfg, []string{"unknown"})
 }

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -36,37 +36,37 @@ func NewFromString(cfgStr string) *ConfigMock {
 				return "github.com", "default"
 			},
 			hostsOverride: func() []string {
-				keys, _ := c.Keys([]string{hosts})
+				keys, _ := c.Keys([]string{hostsKey})
 				return keys
 			},
 			tokenOverride: func(hostname string) (string, string) {
-				token, _ := c.Get([]string{hosts, hostname, oauthToken})
-				return token, oauthToken
+				token, _ := c.Get([]string{hostsKey, hostname, oauthTokenKey})
+				return token, oauthTokenKey
 			},
 		}
 	}
 	mock.BrowserFunc = func(hostname string) string {
-		val, _ := cfg.GetOrDefault(hostname, browser)
+		val, _ := cfg.GetOrDefault(hostname, browserKey)
 		return val
 	}
 	mock.EditorFunc = func(hostname string) string {
-		val, _ := cfg.GetOrDefault(hostname, editor)
+		val, _ := cfg.GetOrDefault(hostname, editorKey)
 		return val
 	}
 	mock.GitProtocolFunc = func(hostname string) string {
-		val, _ := cfg.GetOrDefault(hostname, gitProtocol)
+		val, _ := cfg.GetOrDefault(hostname, gitProtocolKey)
 		return val
 	}
 	mock.HTTPUnixSocketFunc = func(hostname string) string {
-		val, _ := cfg.GetOrDefault(hostname, httpUnixSocket)
+		val, _ := cfg.GetOrDefault(hostname, httpUnixSocketKey)
 		return val
 	}
 	mock.PagerFunc = func(hostname string) string {
-		val, _ := cfg.GetOrDefault(hostname, pager)
+		val, _ := cfg.GetOrDefault(hostname, pagerKey)
 		return val
 	}
 	mock.PromptFunc = func(hostname string) string {
-		val, _ := cfg.GetOrDefault(hostname, prompt)
+		val, _ := cfg.GetOrDefault(hostname, promptKey)
 		return val
 	}
 	return mock

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -17,9 +17,6 @@ func NewFromString(cfgStr string) *ConfigMock {
 	c := ghConfig.ReadFromString(cfgStr)
 	cfg := cfg{c}
 	mock := &ConfigMock{}
-	mock.GetFunc = func(host, key string) (string, error) {
-		return cfg.Get(host, key)
-	}
 	mock.GetOrDefaultFunc = func(host, key string) (string, error) {
 		return cfg.GetOrDefault(host, key)
 	}
@@ -39,14 +36,38 @@ func NewFromString(cfgStr string) *ConfigMock {
 				return "github.com", "default"
 			},
 			hostsOverride: func() []string {
-				keys, _ := c.Keys([]string{"hosts"})
+				keys, _ := c.Keys([]string{hosts})
 				return keys
 			},
 			tokenOverride: func(hostname string) (string, string) {
 				token, _ := c.Get([]string{hosts, hostname, oauthToken})
-				return token, "oauth_token"
+				return token, oauthToken
 			},
 		}
+	}
+	mock.BrowserFunc = func(hostname string) string {
+		val, _ := cfg.GetOrDefault(hostname, browser)
+		return val
+	}
+	mock.EditorFunc = func(hostname string) string {
+		val, _ := cfg.GetOrDefault(hostname, editor)
+		return val
+	}
+	mock.GitProtocolFunc = func(hostname string) string {
+		val, _ := cfg.GetOrDefault(hostname, gitProtocol)
+		return val
+	}
+	mock.HTTPUnixSocketFunc = func(hostname string) string {
+		val, _ := cfg.GetOrDefault(hostname, httpUnixSocket)
+		return val
+	}
+	mock.PagerFunc = func(hostname string) string {
+		val, _ := cfg.GetOrDefault(hostname, pager)
+		return val
+	}
+	mock.PromptFunc = func(hostname string) string {
+		val, _ := cfg.GetOrDefault(hostname, prompt)
+		return val
 	}
 	return mock
 }

--- a/internal/prompter/prompter_mock.go
+++ b/internal/prompter/prompter_mock.go
@@ -35,7 +35,7 @@ var _ Prompter = &PrompterMock{}
 //			MarkdownEditorFunc: func(s1 string, s2 string, b bool) (string, error) {
 //				panic("mock out the MarkdownEditor method")
 //			},
-//			MultiSelectFunc: func(s string, strings1 []string, strings2 []string) ([]int, error) {
+//			MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
 //				panic("mock out the MultiSelect method")
 //			},
 //			PasswordFunc: func(s string) (string, error) {
@@ -70,7 +70,7 @@ type PrompterMock struct {
 	MarkdownEditorFunc func(s1 string, s2 string, b bool) (string, error)
 
 	// MultiSelectFunc mocks the MultiSelect method.
-	MultiSelectFunc func(s string, strings1 []string, strings2 []string) ([]int, error)
+	MultiSelectFunc func(prompt string, defaults []string, options []string) ([]int, error)
 
 	// PasswordFunc mocks the Password method.
 	PasswordFunc func(s string) (string, error)
@@ -116,12 +116,12 @@ type PrompterMock struct {
 		}
 		// MultiSelect holds details about calls to the MultiSelect method.
 		MultiSelect []struct {
-			// S is the s argument value.
-			S string
-			// Strings1 is the strings1 argument value.
-			Strings1 []string
-			// Strings2 is the strings2 argument value.
-			Strings2 []string
+			// Prompt is the prompt argument value.
+			Prompt string
+			// Defaults is the defaults argument value.
+			Defaults []string
+			// Options is the options argument value.
+			Options []string
 		}
 		// Password holds details about calls to the Password method.
 		Password []struct {
@@ -348,23 +348,23 @@ func (mock *PrompterMock) MarkdownEditorCalls() []struct {
 }
 
 // MultiSelect calls MultiSelectFunc.
-func (mock *PrompterMock) MultiSelect(s string, strings1 []string, strings2 []string) ([]int, error) {
+func (mock *PrompterMock) MultiSelect(prompt string, defaults []string, options []string) ([]int, error) {
 	if mock.MultiSelectFunc == nil {
 		panic("PrompterMock.MultiSelectFunc: method is nil but Prompter.MultiSelect was just called")
 	}
 	callInfo := struct {
-		S        string
-		Strings1 []string
-		Strings2 []string
+		Prompt   string
+		Defaults []string
+		Options  []string
 	}{
-		S:        s,
-		Strings1: strings1,
-		Strings2: strings2,
+		Prompt:   prompt,
+		Defaults: defaults,
+		Options:  options,
 	}
 	mock.lockMultiSelect.Lock()
 	mock.calls.MultiSelect = append(mock.calls.MultiSelect, callInfo)
 	mock.lockMultiSelect.Unlock()
-	return mock.MultiSelectFunc(s, strings1, strings2)
+	return mock.MultiSelectFunc(prompt, defaults, options)
 }
 
 // MultiSelectCalls gets all the calls that were made to MultiSelect.
@@ -372,14 +372,14 @@ func (mock *PrompterMock) MultiSelect(s string, strings1 []string, strings2 []st
 //
 //	len(mockedPrompter.MultiSelectCalls())
 func (mock *PrompterMock) MultiSelectCalls() []struct {
-	S        string
-	Strings1 []string
-	Strings2 []string
+	Prompt   string
+	Defaults []string
+	Options  []string
 } {
 	var calls []struct {
-		S        string
-		Strings1 []string
-		Strings2 []string
+		Prompt   string
+		Defaults []string
+		Options  []string
 	}
 	mock.lockMultiSelect.RLock()
 	calls = mock.calls.MultiSelect

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -178,7 +178,7 @@ func refreshRun(opts *RefreshOptions) error {
 		Prompter:   opts.Prompter,
 		GitClient:  opts.GitClient,
 	}
-	gitProtocol := authCfg.GitProtocol(hostname)
+	gitProtocol := cfg.GitProtocol(hostname)
 	if opts.Interactive && gitProtocol == "https" {
 		if err := credentialFlow.Prompt(hostname); err != nil {
 			return err

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -139,7 +139,7 @@ func statusRun(opts *StatusOptions) error {
 			}
 
 			addMsg("%s Logged in to %s as %s (%s)", cs.SuccessIcon(), hostname, cs.Bold(username), tokenSource)
-			proto := authCfg.GitProtocol(hostname)
+			proto := cfg.GitProtocol(hostname)
 			if proto != "" {
 				addMsg("%s Git operations for %s configured to use %s protocol.",
 					cs.SuccessIcon(), hostname, cs.Bold(proto))

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -346,7 +346,7 @@ func writeManifest(dir, name string, data []byte) (writeErr error) {
 }
 
 func (m *Manager) installGit(repo ghrepo.Interface, target string) error {
-	protocol, _ := m.config.GetOrDefault(repo.RepoHost(), "git_protocol")
+	protocol := m.config.GitProtocol(repo.RepoHost())
 	cloneURL := ghrepo.FormatRemoteURL(repo, protocol)
 
 	var commitSHA string

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -184,7 +184,7 @@ func ioStreams(f *cmdutil.Factory) *iostreams.IOStreams {
 
 	if _, ghPromptDisabled := os.LookupEnv("GH_PROMPT_DISABLED"); ghPromptDisabled {
 		io.SetNeverPrompt(true)
-	} else if prompt, _ := cfg.GetOrDefault("", "prompt"); prompt == "disabled" {
+	} else if prompt := cfg.Prompt(""); prompt == "disabled" {
 		io.SetNeverPrompt(true)
 	}
 
@@ -194,7 +194,7 @@ func ioStreams(f *cmdutil.Factory) *iostreams.IOStreams {
 	// 3. PAGER
 	if ghPager, ghPagerExists := os.LookupEnv("GH_PAGER"); ghPagerExists {
 		io.SetPager(ghPager)
-	} else if pager, _ := cfg.Get("", "pager"); pager != "" {
+	} else if pager := cfg.Pager(""); pager != "" {
 		io.SetPager(pager)
 	}
 

--- a/pkg/cmd/gist/clone/clone.go
+++ b/pkg/cmd/gist/clone/clone.go
@@ -80,7 +80,7 @@ func cloneRun(opts *CloneOptions) error {
 			return err
 		}
 		hostname, _ := cfg.Authentication().DefaultHost()
-		protocol := cfg.Authentication().GitProtocol(hostname)
+		protocol := cfg.GitProtocol(hostname)
 		gistURL = formatRemoteURL(hostname, gistURL, protocol)
 	}
 

--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -84,7 +84,7 @@ func checkoutRun(opts *CheckoutOptions) error {
 	if err != nil {
 		return err
 	}
-	protocol := cfg.Authentication().GitProtocol(baseRepo.RepoHost())
+	protocol := cfg.GitProtocol(baseRepo.RepoHost())
 
 	remotes, err := opts.Remotes()
 	if err != nil {

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -761,7 +761,7 @@ func handlePush(opts CreateOptions, ctx CreateContext) error {
 			return err
 		}
 
-		cloneProtocol := cfg.Authentication().GitProtocol(headRepo.RepoHost())
+		cloneProtocol := cfg.GitProtocol(headRepo.RepoHost())
 		headRepoURL := ghrepo.FormatRemoteURL(headRepo, cloneProtocol)
 		gitClient := ctx.GitClient
 		origin, _ := remotes.FindByName("origin")

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -129,7 +129,7 @@ func cloneRun(opts *CloneOptions) error {
 			return err
 		}
 
-		protocol = cfg.Authentication().GitProtocol(repo.RepoHost())
+		protocol = cfg.GitProtocol(repo.RepoHost())
 	}
 
 	wantsWiki := strings.HasSuffix(repo.RepoName(), ".wiki")
@@ -163,7 +163,7 @@ func cloneRun(opts *CloneOptions) error {
 
 	// If the repo is a fork, add the parent as an upstream remote and set the parent as the default repo.
 	if canonicalRepo.Parent != nil {
-		protocol := cfg.Authentication().GitProtocol(canonicalRepo.Parent.RepoHost())
+		protocol := cfg.GitProtocol(canonicalRepo.Parent.RepoHost())
 		upstreamURL := ghrepo.FormatRemoteURL(canonicalRepo.Parent, protocol)
 
 		upstreamName := opts.UpstreamName

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -395,7 +395,7 @@ func createFromScratch(opts *CreateOptions) error {
 	}
 
 	if opts.Clone {
-		protocol := cfg.Authentication().GitProtocol(repo.RepoHost())
+		protocol := cfg.GitProtocol(repo.RepoHost())
 		remoteURL := ghrepo.FormatRemoteURL(repo, protocol)
 
 		if !opts.AddReadme && opts.LicenseTemplate == "" && opts.GitIgnoreTemplate == "" && opts.Template == "" {
@@ -492,7 +492,7 @@ func createFromTemplate(opts *CreateOptions) error {
 	}
 
 	if opts.Clone {
-		protocol := cfg.Authentication().GitProtocol(repo.RepoHost())
+		protocol := cfg.GitProtocol(repo.RepoHost())
 		remoteURL := ghrepo.FormatRemoteURL(repo, protocol)
 
 		if err := cloneWithRetry(opts, remoteURL, templateRepoMainBranch); err != nil {
@@ -614,7 +614,7 @@ func createFromLocal(opts *CreateOptions) error {
 		fmt.Fprintln(stdout, repo.URL)
 	}
 
-	protocol := cfg.Authentication().GitProtocol(repo.RepoHost())
+	protocol := cfg.GitProtocol(repo.RepoHost())
 	remoteURL := ghrepo.FormatRemoteURL(repo, protocol)
 
 	if opts.Interactive {

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -243,7 +243,7 @@ func forkRun(opts *ForkOptions) error {
 	if err != nil {
 		return err
 	}
-	protocol, _ := cfg.Get(repoToFork.RepoHost(), "git_protocol")
+	protocol := cfg.GitProtocol(repoToFork.RepoHost())
 
 	gitClient := opts.GitClient
 	ctx := context.Background()

--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -149,7 +149,7 @@ func updateRemote(repo ghrepo.Interface, renamed ghrepo.Interface, opts *RenameO
 		return nil, err
 	}
 
-	protocol := cfg.Authentication().GitProtocol(repo.RepoHost())
+	protocol := cfg.GitProtocol(repo.RepoHost())
 
 	remotes, err := opts.Remotes()
 	if err != nil {

--- a/pkg/cmdutil/legacy.go
+++ b/pkg/cmdutil/legacy.go
@@ -16,7 +16,7 @@ func DetermineEditor(cf func() (config.Config, error)) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("could not read config: %w", err)
 		}
-		editorCommand, _ = cfg.Get("", "editor")
+		editorCommand = cfg.Editor("")
 	}
 
 	return editorCommand, nil


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/8250

This PR refactors the `Config` interface to now include direct accessor functions for the default configuration keys. This allows callers to not have to know about key names and hides that implementation detail from them. Outside of the `config` command and tests there should be no places aware of the configuration keys. As part of this work the `AuthConfig.GitProtocol` function got moved to now live on `Config`. I also added in more constants in the `config` package for the configuration keys so that we can stop writing them out without the compilers help. This PR is not as long as it looks as most of these changes are just updating call points. Lastly, there was a stale prompter mock that is included in the PR but is unrelated to the changes above. 