### PR TITLE
Convert `release view` to GraphQL

### DIFF
--- a/api/queries_release.go
+++ b/api/queries_release.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"time"
+)
+
+type Release struct {
+	DatabaseID   int64
+	ID           string
+	TagName      string
+	Name         string
+	Body         string
+	IsDraft      bool
+	IsPrerelease bool
+	CreatedAt    time.Time
+	PublishedAt  *time.Time
+	URL          string
+	ResourcePath string
+	Assets       []ReleaseAsset
+	Author       Author
+
+	Tag struct {
+		ID                 string
+		Name               string
+		Message            string
+		OID                string
+		CommitResourcePath string
+		CommitUrl          string
+		Tagger             Author
+	}
+
+	TagCommit struct {
+		ID         string
+		TarballURL string
+		ZipballURL string
+	}
+}
+
+type ReleaseAsset struct {
+	ID            string
+	Name          string
+	Size          int64
+	URL           string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	DownloadCount int
+	ContentType   string
+	DownloadURL   string
+	UploadedBy    Author
+}

--- a/api/queries_release.go
+++ b/api/queries_release.go
@@ -4,29 +4,50 @@ import (
 	"time"
 )
 
+var ReleaseFields = []string{
+	"url",
+	"tarballUrl",
+	"zipballUrl",
+	"id",
+	"tagName",
+	"name",
+	"description",
+	"isDraft",
+	"isLatest",
+	"isPrerelease",
+	"createdAt",
+	"publishedAt",
+	"author",
+	"releaseAssets",
+}
+
 type Release struct {
 	DatabaseID   int64
 	ID           string
 	TagName      string
 	Name         string
-	Body         string
+	Description  string
 	IsDraft      bool
 	IsPrerelease bool
 	CreatedAt    time.Time
 	PublishedAt  *time.Time
 	URL          string
 	ResourcePath string
-	Assets       []ReleaseAsset
 	Author       Author
 
+	ReleaseAssets struct {
+		TotalCount int
+		Nodes      []ReleaseAsset
+	} `graphql:"releaseAssets(first: 100)"`
+
 	Tag struct {
-		ID                 string
-		Name               string
-		Message            string
-		OID                string
-		CommitResourcePath string
-		CommitUrl          string
-		Tagger             Author
+		ID   string
+		Name string
+
+		Target struct {
+			OID string
+			// commitResourcePath string
+		}
 	}
 
 	TagCommit struct {

--- a/pkg/cmd/release/view/http.go
+++ b/pkg/cmd/release/view/http.go
@@ -1,0 +1,79 @@
+package view
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/shurcooL/githubv4"
+)
+
+func FetchRelease(ctx context.Context, httpClient *http.Client, repo ghrepo.Interface, tagName string) (*api.Release, error) {
+	variables := map[string]interface{}{
+		"owner":   githubv4.String(repo.RepoOwner()),
+		"name":    githubv4.String(repo.RepoName()),
+		"tagName": githubv4.String(tagName),
+	}
+
+	var query struct {
+		Repository struct {
+			Release *api.Release `graphql:"release(tagName: $tagName)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	gql := api.NewClientFromHTTP(httpClient)
+	if err := gql.QueryWithContext(ctx, repo.RepoHost(), "RepositoryReleaseByTag", &query, variables); err != nil {
+		return nil, err
+	}
+
+	return query.Repository.Release, nil
+}
+
+func FetchLatestRelease(ctx context.Context, httpClient *http.Client, repo ghrepo.Interface) (*api.Release, error) {
+	var listResponse struct {
+		Repository struct {
+			Releases struct {
+				Nodes []struct {
+					TagName  string
+					IsLatest bool
+				}
+				PageInfo struct {
+					HasNextPage bool
+					EndCursor   string
+				}
+			} `graphql:"releases(first: $perPage, orderBy: {field: CREATED_AT, direction: DESC}, after: $endCursor)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	variables := map[string]interface{}{
+		"owner":     githubv4.String(repo.RepoOwner()),
+		"name":      githubv4.String(repo.RepoName()),
+		"perPage":   githubv4.Int(100),
+		"endCursor": (*githubv4.String)(nil),
+	}
+
+	gql := api.NewClientFromHTTP(httpClient)
+
+	var tagName string
+loop:
+	for {
+		if err := gql.QueryWithContext(ctx, repo.RepoHost(), "RepositoryReleases", &listResponse, variables); err != nil {
+			return nil, err
+		}
+
+		for _, r := range listResponse.Repository.Releases.Nodes {
+			if r.IsLatest {
+				tagName = r.TagName
+				break loop
+			}
+		}
+
+		if !listResponse.Repository.Releases.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(listResponse.Repository.Releases.PageInfo.EndCursor)
+	}
+
+	return FetchRelease(ctx, httpClient, repo, tagName)
+}


### PR DESCRIPTION
Fixes #4572 (Part 1).

Before adding the `--json` support to `release list`, it was requested that `release view` be moved to GraphQL to begin standardizing the `release` command on a single API. This PR represents the first step to that effect. A follow up PR will add `--json` to the `list` command and move that to this shared model.

This PR is not yet in a ready state as I have to update tests and I have some questions about behavior.

- [ ] Address JSON filtering. Currently, all fields are returned, regardless of command input
- [ ] Determine why `Target.commitResourcePath` fails when executing the query, but the query works in the Explorer.
- [ ] Update tests and add any where necessary.

