### PR TITLE
Improve `gh release download` doc

### DIFF
--- a/pkg/cmd/release/download/download.go
+++ b/pkg/cmd/release/download/download.go
@@ -50,7 +50,8 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 			Download assets from a GitHub release.
 
 			Without an explicit tag name argument, assets are downloaded from the
-			latest release in the project. In this case, '--pattern' is required.
+			latest release in the project. In this case, "--pattern" or "--archive"
+                        is required, but not both.
 		`),
 		Example: heredoc.Doc(`
 			# download all assets from a specific release

--- a/pkg/cmd/release/download/download.go
+++ b/pkg/cmd/release/download/download.go
@@ -51,7 +51,7 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 
 			Without an explicit tag name argument, assets are downloaded from the
 			latest release in the project. In this case, "--pattern" or "--archive"
-                        is required, but not both.
+                        is required.
 		`),
 		Example: heredoc.Doc(`
 			# download all assets from a specific release


### PR DESCRIPTION
When downloading latest release assets,
`gh release download --archive=(zip|tar.gz)` works too.

Sync doc with no-arguments warning.
https://github.com/cli/cli/blob/f41f402a2098513344ac540439d775d1ad92d7ec/pkg/cmd/release/download/download.go#L73-L77
