### PR TITLE
Simplify run view annotation fetch error handling

### DIFF
--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -305,21 +305,12 @@ func runView(opts *ViewOptions) error {
 	}
 
 	var annotations []shared.Annotation
-
-	var annotationErr error
-	var as []shared.Annotation
 	for _, job := range jobs {
-		as, annotationErr = shared.GetAnnotations(client, repo, job)
-		if annotationErr != nil {
-			break
+		as, err := shared.GetAnnotations(client, repo, job)
+		if err != nil {
+			return fmt.Errorf("failed to get annotations: %w", err)
 		}
 		annotations = append(annotations, as...)
-	}
-
-	opts.IO.StopProgressIndicator()
-
-	if annotationErr != nil {
-		return fmt.Errorf("failed to get annotations: %w", annotationErr)
 	}
 
 	out := opts.IO.Out

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -1279,6 +1279,40 @@ func TestViewRun(t *testing.T) {
 			},
 			wantOut: "fetched 5 jobs\n",
 		},
+		{
+			name: "Returns error when failing to get annotations",
+			opts: &ViewOptions{
+				RunID:      "1234",
+				ExitStatus: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/1234"),
+					httpmock.JSONResponse(shared.FailedRun))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/123"),
+					httpmock.JSONResponse(shared.TestWorkflow))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/1234/artifacts"),
+					httpmock.StringResponse(`{}`))
+				reg.Register(
+					httpmock.GraphQL(`query PullRequestForRun`),
+					httpmock.StringResponse(``))
+				reg.Register(
+					httpmock.REST("GET", "runs/1234/jobs"),
+					httpmock.JSONResponse(shared.JobsPayload{
+						Jobs: []shared.Job{
+							shared.FailedJob,
+						},
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/check-runs/20/annotations"),
+					httpmock.StatusStringResponse(500, "internal server error"),
+				)
+			},
+			errMsg:  "failed to get annotations: HTTP 500 (https://api.github.com/repos/OWNER/REPO/check-runs/20/annotations)",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

While I was looking up some other issue relating to annotations I spotted this bit of implementation that took me a moment to understand because it made it look like the `annotationErr` was special in some way. I wondered if this pattern existed to ensure `opts.IO.StopProgressIndicator()` was called but it actually doesn't seem to be started. Maybe it was some debris and the indicator should be running, but it doesn't seem to happening for the blocks above.

Either way, I added a test because this error case was not covered. Don't necessarily love that I the `errMsg` in the test includes the `HTTP` error but we only set the test up for exact matching.