### PR TITLE
Add timeout error in `gh auth status`

### DIFF
--- a/pkg/cmd/auth/shared/oauth_scopes.go
+++ b/pkg/cmd/auth/shared/oauth_scopes.go
@@ -3,7 +3,6 @@ package shared
 import (
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"strings"
 
@@ -44,9 +43,6 @@ func GetScopes(httpClient httpClient, hostname, authToken string) (string, error
 	req.Header.Set("Authorization", "token "+authToken)
 
 	res, err := httpClient.Do(req)
-	if err, ok := err.(net.Error); ok && err.Timeout() {
-		return "", err
-	}
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/auth/shared/oauth_scopes.go
+++ b/pkg/cmd/auth/shared/oauth_scopes.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 
@@ -43,6 +44,9 @@ func GetScopes(httpClient httpClient, hostname, authToken string) (string, error
 	req.Header.Set("Authorization", "token "+authToken)
 
 	res, err := httpClient.Do(req)
+	if err, ok := err.(net.Error); ok && err.Timeout() {
+		return "", err
+	}
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -108,7 +108,8 @@ func statusRun(opts *StatusOptions) error {
 
 		scopesHeader, err := shared.GetScopes(httpClient, hostname, token)
 		if err != nil {
-			if err, ok := err.(net.Error); ok && err.Timeout() {
+			var networkError net.Error
+			if errors.As(err, &networkError) && networkError.Timeout() {
 				addMsg("%s %s: timeout trying to connect to host", cs.Red("X"), hostname)
 			} else {
 				addMsg("%s %s: authentication failed", cs.Red("X"), hostname)

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -109,7 +109,7 @@ func statusRun(opts *StatusOptions) error {
 		scopesHeader, err := shared.GetScopes(httpClient, hostname, token)
 		if err != nil {
 			if err, ok := err.(net.Error); ok && err.Timeout() {
-				addMsg("%s %s: timeout exceeded", cs.Red("X"), hostname)
+				addMsg("%s %s: timeout trying to connect to host", cs.Red("X"), hostname)
 			} else {
 				addMsg("%s %s: authentication failed", cs.Red("X"), hostname)
 				addMsg("- The %s token in %s is invalid.", cs.Bold(hostname), tokenSource)

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -84,6 +85,26 @@ func Test_statusRun(t *testing.T) {
 		wantOut    string
 		wantErrOut string
 	}{
+		{
+			name: "timeout error",
+			opts: &StatusOptions{
+				Hostname: "joel.miller",
+			},
+			cfgStubs: func(c *config.ConfigMock) {
+				c.Set("joel.miller", "oauth_token", "abc123")
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "api/v3/"), func(req *http.Request) (*http.Response, error) {
+					// timeout error
+					return nil, context.DeadlineExceeded
+				})
+			},
+			wantErr: "SilentError",
+			wantErrOut: heredoc.Doc(`
+			joel.miller
+			  X joel.miller: timeout exceeded
+			`),
+		},
 		{
 			name: "hostname set",
 			opts: &StatusOptions{

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -102,7 +102,7 @@ func Test_statusRun(t *testing.T) {
 			wantErr: "SilentError",
 			wantErrOut: heredoc.Doc(`
 			joel.miller
-			  X joel.miller: timeout exceeded
+			  X joel.miller: timeout trying to connect to host
 			`),
 		},
 		{


### PR DESCRIPTION
hi, this should fix #8293.
tried it by temporarily setting the http client timeout to 1nanosecond, and it showed the new error ("timeout exceeded"), instead of "authentication failed".

