### PR TITLE
Actions: filter to workflow runs for a specific commit

### DIFF
--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -34,6 +34,7 @@ type ListOptions struct {
 	Status           string
 	Event            string
 	Created          string
+	Commit           string
 
 	now time.Time
 }
@@ -77,6 +78,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.Actor, "user", "u", "", "Filter runs by user who triggered the run")
 	cmd.Flags().StringVarP(&opts.Event, "event", "e", "", "Filter runs by which `event` triggered the run")
 	cmd.Flags().StringVarP(&opts.Created, "created", "", "", "Filter runs by the `date` it was created")
+	cmd.Flags().StringVarP(&opts.Commit, "commit", "c", "", "Filter runs by the `SHA` of the commit")
 	cmdutil.StringEnumFlag(cmd, &opts.Status, "status", "s", "", shared.AllStatuses, "Filter runs by status")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, shared.RunFields)
 
@@ -103,6 +105,7 @@ func listRun(opts *ListOptions) error {
 		Status:  opts.Status,
 		Event:   opts.Event,
 		Created: opts.Created,
+		Commit:  opts.Commit,
 	}
 
 	opts.IO.StartProgressIndicator()

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -479,6 +479,24 @@ func TestListRun(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "no runs found",
 		},
+		{
+			name: "commit filter applied",
+			opts: &ListOptions{
+				Limit:   defaultLimit,
+				Commit:  "1234567890123456789012345678901234567890",
+			},
+			isTTY: true,
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.QueryMatcher("GET", "repos/OWNER/REPO/actions/runs", url.Values{
+						"head_sha": []string{"1234567890123456789012345678901234567890"},
+					}),
+					httpmock.JSONResponse(shared.RunsPayload{}),
+				)
+			},
+			wantErr:    true,
+			wantErrMsg: "no runs found",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -482,8 +482,8 @@ func TestListRun(t *testing.T) {
 		{
 			name: "commit filter applied",
 			opts: &ListOptions{
-				Limit:   defaultLimit,
-				Commit:  "1234567890123456789012345678901234567890",
+				Limit:  defaultLimit,
+				Commit: "1234567890123456789012345678901234567890",
 			},
 			isTTY: true,
 			stubs: func(reg *httpmock.Registry) {

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -307,6 +307,7 @@ type FilterOptions struct {
 	Status       string
 	Event        string
 	Created      string
+	Commit       string
 }
 
 // GetRunsWithFilter fetches 50 runs from the API and filters them in-memory
@@ -357,6 +358,9 @@ func GetRuns(client *api.Client, repo ghrepo.Interface, opts *FilterOptions, lim
 		}
 		if opts.Created != "" {
 			path += fmt.Sprintf("&created=%s", url.QueryEscape(opts.Created))
+		}
+		if opts.Commit != "" {
+			path += fmt.Sprintf("&head_sha=%s", url.QueryEscape(opts.Commit))
 		}
 	}
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #8285 

Add `--commit/-c` flag to `gh run list`.
Now it should be able to list workflow runs for specific commit by `gh run list -c {SHA}`.

If further help is needed, please let me know, thank you!