### PR TITLE
Add progress indicator when installing an extension

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -347,7 +347,11 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 						return err
 					}
 
-					if err := m.Install(repo, pinFlag); err != nil {
+					io.StartProgressIndicator()
+					err = m.Install(repo, pinFlag)
+					io.StopProgressIndicator()
+
+					if err != nil {
 						if errors.Is(err, releaseNotFoundErr) {
 							return fmt.Errorf("%s Could not find a release of %s for %s",
 								cs.FailureIcon(), args[0], cs.Cyan(pinFlag))


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

When installing a ~28 MB extension on a ~15 Mbps internet connection, it took about 15 seconds to install the extension and I wasn't sure if my terminal was stuck or if it was in the process of downloading.

This adds the same progress indicator that `gh extension browse` uses to `gh extension install`. I thought about adding this to `gh extension upgrade` as well, but that's a bit trickier as that command outputs to stdout as it executes.