### PR TITLE
Simplify triage workflow given GitHub Actions limitations on OSS pull requests

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,10 +1,7 @@
 name: Discussion Triage
-run-name: ${{ github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title }}
+run-name: ${{ github.event.issue.title }}
 on:
   issues:
-    types:
-      - labeled
-  pull_request:
     types:
       - labeled
 env:
@@ -30,34 +27,6 @@ jobs:
           cat << EOF | gh issue create --title "Triage issue \"$TITLE\"" --body-file - --repo "$TARGET_REPO" --label discuss
           **Title:** $TITLE
           **Issue:** $LINK
-          **Created:** $CREATED
-          **Triggered by:** @$TRIGGERED_BY
-
-          ---
-
-          > $BODY
-          EOF
-
-  pull_request:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'discuss'
-    steps:
-      - name: Create discuss issue based on source pull request
-        env:
-          BODY: ${{ github.event.pull_request.body }}
-          CREATED: ${{ github.event.pull_request.created_at }}
-          GH_TOKEN: ${{ secrets.CLI_DISCUSSION_TRIAGE_TOKEN }}
-          LINK: ${{ github.repository }}#${{ github.event.pull_request.number }}
-          TITLE: ${{ github.event.pull_request.title }}
-          TRIGGERED_BY: ${{ github.triggering_actor }}
-        run: |
-          # Markdown quote source body by replacing newlines for newlines and markdown quoting
-          BODY="${BODY//$'\n'/$'\n'> }"
-
-          # Create discuss issue using dynamically constructed body within heredoc
-          cat << EOF | gh issue create --title "Triage PR \"$TITLE\"" --body-file - --repo "$TARGET_REPO" --label discuss
-          **Title:** $TITLE
-          **Pull request:** $LINK
           **Created:** $CREATED
           **Triggered by:** @$TRIGGERED_BY
 


### PR DESCRIPTION
fixes https://github.com/github/cli/issues/261

Since merging the initial PR, it appears there are specific limitations to GitHub Action workflows around OSS repos from forks that affects the workflow as well as create excessive queued up workflow runs when new PRs containing labels is kicked off.