### PR TITLE
andyfeller/triage the final enhancements

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,10 @@
 name: Discussion Triage
-run-name: ${{ github.event.issue.title }}
+run-name: ${{ github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title }}
 on:
   issues:
+    types:
+      - labeled
+  pull_request:
     types:
       - labeled
 env:
@@ -27,6 +30,34 @@ jobs:
           cat << EOF | gh issue create --title "Triage issue \"$TITLE\"" --body-file - --repo "$TARGET_REPO" --label discuss
           **Title:** $TITLE
           **Issue:** $LINK
+          **Created:** $CREATED
+          **Triggered by:** @$TRIGGERED_BY
+
+          ---
+
+          > $BODY
+          EOF
+
+  pull_request:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'discuss'
+    steps:
+      - name: Create discuss issue based on source pull request
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+          CREATED: ${{ github.event.pull_request.created_at }}
+          GH_TOKEN: ${{ secrets.CLI_DISCUSSION_TRIAGE_TOKEN }}
+          LINK: ${{ github.repository }}#${{ github.event.pull_request.number }}
+          TITLE: ${{ github.event.pull_request.title }}
+          TRIGGERED_BY: ${{ github.triggering_actor }}
+        run: |
+          # Markdown quote source body by replacing newlines for newlines and markdown quoting
+          BODY="${BODY//$'\n'/$'\n'> }"
+
+          # Create discuss issue using dynamically constructed body within heredoc
+          cat << EOF | gh issue create --title "Triage PR \"$TITLE\"" --body-file - --repo "$TARGET_REPO" --label discuss
+          **Title:** $TITLE
+          **Pull request:** $LINK
           **Created:** $CREATED
           **Triggered by:** @$TRIGGERED_BY
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - labeled
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 env:
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'discuss'
     steps:
-      - name: Create discuss issue based on source issue
+      - name: Create issue based on source issue
         env:
           BODY: ${{ github.event.issue.body }}
           CREATED: ${{ github.event.issue.created_at }}
@@ -26,8 +26,8 @@ jobs:
           # Markdown quote source body by replacing newlines for newlines and markdown quoting
           BODY="${BODY//$'\n'/$'\n'> }"
 
-          # Create discuss issue using dynamically constructed body within heredoc
-          cat << EOF | gh issue create --title "Triage issue \"$TITLE\"" --body-file - --repo "$TARGET_REPO" --label discuss
+          # Create issue using dynamically constructed body within heredoc
+          cat << EOF | gh issue create --title "Triage issue \"$TITLE\"" --body-file - --repo "$TARGET_REPO" --label triage
           **Title:** $TITLE
           **Issue:** $LINK
           **Created:** $CREATED
@@ -40,9 +40,9 @@ jobs:
 
   pull_request:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'discuss'
+    if: github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'discuss'
     steps:
-      - name: Create discuss issue based on source pull request
+      - name: Create issue based on source pull request
         env:
           BODY: ${{ github.event.pull_request.body }}
           CREATED: ${{ github.event.pull_request.created_at }}
@@ -54,8 +54,8 @@ jobs:
           # Markdown quote source body by replacing newlines for newlines and markdown quoting
           BODY="${BODY//$'\n'/$'\n'> }"
 
-          # Create discuss issue using dynamically constructed body within heredoc
-          cat << EOF | gh issue create --title "Triage PR \"$TITLE\"" --body-file - --repo "$TARGET_REPO" --label discuss
+          # Create issue using dynamically constructed body within heredoc
+          cat << EOF | gh issue create --title "Triage PR \"$TITLE\"" --body-file - --repo "$TARGET_REPO" --label triage
           **Title:** $TITLE
           **Pull request:** $LINK
           **Created:** $CREATED


### PR DESCRIPTION
fixes https://github.com/github/cli/issues/261

This PR reverts the change from #8412 in preference for `pull_request_target`, which is a more secure method by ensuring that fork repositories cannot change the workflow in a pull request.

Additionally, this fixes a bug discovered after fixing the permissions behind the token as there are different labels between the 2 repositories: `cli/cli` uses `discuss` while `github/cli` uses `triage`.
