### PR TITLE
Update multi-account migration error msg

### DIFF
--- a/internal/config/migration/multi_account.go
+++ b/internal/config/migration/multi_account.go
@@ -120,7 +120,8 @@ func (m MultiAccount) Do(c *config.Config) error {
 
 		username, err := getUsername(c, hostname, tokenSource.token, m.Transport)
 		if err != nil {
-			return CowardlyRefusalError{fmt.Errorf("couldn't get user name for %q: %w", hostname, err)}
+			issueURL := "https://github.com/cli/cli/issues/8441"
+			return CowardlyRefusalError{fmt.Errorf("couldn't get user name for %q please visit %s for help: %w", hostname, issueURL, err)}
 		}
 
 		if err := migrateConfig(c, hostname, username); err != nil {

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -42,17 +42,16 @@ func Test_NewCmdLogin(t *testing.T) {
 		wantsErr    bool
 	}{
 		{
-			name:        "nontty, with-token",
-			stdin:       "abc123\n",
-			cli:         "--with-token",
-			defaultHost: "github.com",
+			name:  "nontty, with-token",
+			stdin: "abc123\n",
+			cli:   "--with-token",
 			wants: LoginOptions{
 				Hostname: "github.com",
 				Token:    "abc123",
 			},
 		},
 		{
-			name:        "nontty, Enterprise host",
+			name:        "nontty, with-token, enterprise default host",
 			stdin:       "abc123\n",
 			cli:         "--with-token",
 			defaultHost: "git.example.com",
@@ -209,6 +208,11 @@ func Test_NewCmdLogin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Make sure there is a default host set so that
+			// the local configuration file never read from.
+			if tt.defaultHost == "" {
+				tt.defaultHost = "github.com"
+			}
 			t.Setenv("GH_HOST", tt.defaultHost)
 
 			ios, stdin, _, _ := iostreams.Test()


### PR DESCRIPTION
This PR updates the multi-account migration error message when a username is unable to be retrieved to now include a link to an issue in the repo with remediation steps for that specific error. I did not feel this change warranted a new test, but happy to add one if others feel differently. 

Additionally, I fixed up some `auth login` tests that were reading the local config file causing failures if the user running the tests was only logged into a GHES instance.