### PR TITLE
Remove redundant error on migration failure

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -60,7 +60,7 @@ func mainRun() exitCode {
 	if cfg, err := cmdFactory.Config(); err == nil {
 		var m migration.MultiAccount
 		if err := cfg.Migrate(m); err != nil {
-			fmt.Fprintf(stderr, "failed to migrate configuration: %s\n", err)
+			fmt.Fprintln(stderr, err)
 			return exitError
 		}
 	}


### PR DESCRIPTION
## Description

Error looked a bit redundant:

```
failed to migrate configuration: failed to migrate config: cowardly refusing to continue with multi account migration: couldn't get user name for "ghe.io" please visit https://github.com/cli/cli/issues/8441 for help: non-200 OK status code: 401 Unauthorized body: "{\"message\":\"Bad credentials\",\"documentation_url\":\"https://docs.github.com/enterprise-server@3.10/graphql\"}"
```

Removed the first part of the string.