### PR TITLE
Fix release script to invoke HSM goreleaser config

### DIFF
--- a/script/release-hsm
+++ b/script/release-hsm
@@ -86,15 +86,15 @@ build_local() {
   local config="$goreleaser_config"
   case "$platform" in
   linux )
-    sed '/#build:windows/,/^$/d; /#build:macos/,/^$/d' .goreleaser.yml >.goreleaser.generated.yml
+    sed '/#build:windows/,/^$/d; /#build:macos/,/^$/d' "$config" >.goreleaser.generated.yml
     config=".goreleaser.generated.yml"
     ;;
   macos )
-    sed '/#build:windows/,/^$/d; /#build:linux/,/^$/d' .goreleaser.yml >.goreleaser.generated.yml
+    sed '/#build:windows/,/^$/d; /#build:linux/,/^$/d' "$config" >.goreleaser.generated.yml
     config=".goreleaser.generated.yml"
     ;;
   windows )
-    sed '/#build:linux/,/^$/d; /#build:macos/,/^$/d' .goreleaser.yml >.goreleaser.generated.yml
+    sed '/#build:linux/,/^$/d; /#build:macos/,/^$/d' "$config" >.goreleaser.generated.yml
     config=".goreleaser.generated.yml"
     ;;
   esac


### PR DESCRIPTION
relates https://github.com/github/cli/issues/213

This is a follow up to #8421, fixing an issue where the wrong GoReleaser configuration was used, bypassing the exe signing for the move to HSM