### PR TITLE
Add more help message to browse command

### DIFF
--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -67,8 +67,8 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 			$ gh browse
 			#=> Open the home page of the current repository
 
-			$ gh browse script/createrepo.sh
-			#=> Open the repository in the path specified
+			$ gh browse script/
+			#=> Open the script directory of the current repository
 
 			$ gh browse 217
 			#=> Open issue or pull request 217

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -67,6 +67,9 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 			$ gh browse
 			#=> Open the home page of the current repository
 
+			$ gh browse script/createrepo.sh
+			#=> Open the repository in the path specified
+
 			$ gh browse 217
 			#=> Open issue or pull request 217
 


### PR DESCRIPTION
This pull request introduces an additional help command for the 'browse' command, providing guidance on navigating to a specific path within the repository.

fixes: https://github.com/cli/cli/issues/8524