### PR TITLE
Fix issue sourcing signtool for Windows signing

### DIFF
--- a/script/sign.ps1
+++ b/script/sign.ps1
@@ -8,4 +8,7 @@ if ($null -ne $env:METADATA_PATH) {
 	exit
 }
 
-& (Resolve-Path "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe") sign /d "GitHub CLI" /fd sha256 /td sha256 /tr http://timestamp.acs.microsoft.com /v /dlib "$Env:DLIB_PATH" /dmdf "$Env:METADATA_PATH" "$args[0]"
+$signtool = Resolve-Path "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe" | Select-Object -Last 1
+Write-Host "Using signtool from $signtool"
+
+& $signtool sign /d "GitHub CLI" /fd sha256 /td sha256 /tr http://timestamp.acs.microsoft.com /v /dlib "$Env:DLIB_PATH" /dmdf "$Env:METADATA_PATH" "$args[0]"


### PR DESCRIPTION
relates https://github.com/github/cli/issues/213

Workflow is currently breaking because there are multiple versions of signtool installed on runners.  We face a challenge where we either hardcode this to a specific version on the runner or always choose the latest version; this change does the latter.