### PR TITLE
Add `--json` export flag for release list

### DIFF
--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -2,16 +2,15 @@ package list
 
 import (
 	"net/http"
-	"reflect"
-	"strings"
 	"time"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/shurcooL/githubv4"
 )
 
-var ReleaseFields = []string{
+var releaseFields = []string{
 	"name",
 	"tagName",
 	"isDraft",
@@ -29,6 +28,10 @@ type Release struct {
 	IsPrerelease bool
 	CreatedAt    time.Time
 	PublishedAt  time.Time
+}
+
+func (r *Release) ExportData(fields []string) map[string]interface{} {
+	return cmdutil.StructExportData(r, fields)
 }
 
 func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, excludeDrafts bool, excludePreReleases bool) ([]Release, error) {
@@ -87,21 +90,4 @@ loop:
 	}
 
 	return releases, nil
-}
-
-func (r *Release) ExportData(fields []string) map[string]interface{} {
-	v := reflect.ValueOf(r).Elem()
-	fieldByName := func(v reflect.Value, field string) reflect.Value {
-		return v.FieldByNameFunc(func(s string) bool {
-			return strings.EqualFold(field, s)
-		})
-	}
-	data := map[string]interface{}{}
-
-	for _, f := range fields {
-		sf := fieldByName(v, f)
-		data[f] = sf.Interface()
-	}
-
-	return data
 }

--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -2,12 +2,24 @@ package list
 
 import (
 	"net/http"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/shurcooL/githubv4"
 )
+
+var ReleaseFields = []string{
+	"name",
+	"tagName",
+	"isDraft",
+	"isLatest",
+	"isPrerelease",
+	"createdAt",
+	"publishedAt",
+}
 
 type Release struct {
 	Name         string
@@ -75,4 +87,21 @@ loop:
 	}
 
 	return releases, nil
+}
+
+func (r *Release) ExportData(fields []string) map[string]interface{} {
+	v := reflect.ValueOf(r).Elem()
+	fieldByName := func(v reflect.Value, field string) reflect.Value {
+		return v.FieldByNameFunc(func(s string) bool {
+			return strings.EqualFold(field, s)
+		})
+	}
+	data := map[string]interface{}{}
+
+	for _, f := range fields {
+		sf := fieldByName(v, f)
+		data[f] = sf.Interface()
+	}
+
+	return data
 }

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -50,7 +50,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().IntVarP(&opts.LimitResults, "limit", "L", 30, "Maximum number of items to fetch")
 	cmd.Flags().BoolVar(&opts.ExcludeDrafts, "exclude-drafts", false, "Exclude draft releases")
 	cmd.Flags().BoolVar(&opts.ExcludePreReleases, "exclude-pre-releases", false, "Exclude pre-releases")
-	cmdutil.AddJSONFlags(cmd, &opts.Exporter, ReleaseFields)
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, releaseFields)
 
 	return cmd
 }

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -18,6 +18,8 @@ type ListOptions struct {
 	IO         *iostreams.IOStreams
 	BaseRepo   func() (ghrepo.Interface, error)
 
+	Exporter cmdutil.Exporter
+
 	LimitResults       int
 	ExcludeDrafts      bool
 	ExcludePreReleases bool
@@ -48,6 +50,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().IntVarP(&opts.LimitResults, "limit", "L", 30, "Maximum number of items to fetch")
 	cmd.Flags().BoolVar(&opts.ExcludeDrafts, "exclude-drafts", false, "Exclude draft releases")
 	cmd.Flags().BoolVar(&opts.ExcludePreReleases, "exclude-pre-releases", false, "Exclude pre-releases")
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, ReleaseFields)
 
 	return cmd
 }
@@ -68,7 +71,7 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
-	if len(releases) == 0 {
+	if len(releases) == 0 && opts.Exporter == nil {
 		return cmdutil.NewNoResultsError("no releases found")
 	}
 
@@ -76,6 +79,10 @@ func listRun(opts *ListOptions) error {
 		defer opts.IO.StopPager()
 	} else {
 		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
+	}
+
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, releases)
 	}
 
 	table := tableprinter.New(opts.IO, tableprinter.WithHeader("Title", "Type", "Tag name", "Published"))

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -214,3 +214,24 @@ func Test_listRun(t *testing.T) {
 		})
 	}
 }
+
+func TestExportReleases(t *testing.T) {
+	ios, _, stdout, _ := iostreams.Test()
+	createdAt, _ := time.Parse(time.RFC3339, "2024-01-01T00:00:00Z")
+	publishedAt, _ := time.Parse(time.RFC3339, "2024-02-01T00:00:00Z")
+	rs := []Release{{
+		Name:         "v1",
+		TagName:      "tag",
+		IsDraft:      true,
+		IsLatest:     false,
+		IsPrerelease: true,
+		CreatedAt:    createdAt,
+		PublishedAt:  publishedAt,
+	}}
+	exporter := cmdutil.NewJSONExporter()
+	exporter.SetFields(releaseFields)
+	require.NoError(t, exporter.Write(ios, rs))
+	require.JSONEq(t,
+		`[{"createdAt":"2024-01-01T00:00:00Z","isDraft":true,"isLatest":false,"isPrerelease":true,"name":"v1","publishedAt":"2024-02-01T00:00:00Z","tagName":"tag"}]`,
+		stdout.String())
+}


### PR DESCRIPTION
It was similarly solved in https://github.com/cli/cli/pull/3869 but for the `release list` command.

In addition, I added the same logic for empty results as explained in https://github.com/cli/cli/pull/6419.


```bash
$ go run cmd/gh/main.go \
  release list \
  --limit 1 \
  --json name,tagName \
  --jq '.[]' --repo cli/cli
{"name":"GitHub CLI 2.40.1","tagName":"v2.40.1"}
```

```bash
$ go run cmd/gh/main.go \
  release list --help
List releases in a repository

For more information about output formatting flags, see `gh help formatting`.

USAGE
  gh release list [flags]

FLAGS
      --exclude-drafts         Exclude draft releases
      --exclude-pre-releases   Exclude pre-releases
  -q, --jq expression          Filter JSON output using a jq expression
      --json fields            Output JSON with the specified fields
  -L, --limit int              Maximum number of items to fetch (default 30)
  -t, --template string        Format JSON output using a Go template; see "gh help formatting"
```

Closes https://github.com/cli/cli/issues/4572