### PR TITLE
Add option --json  for gh variable list

### DIFF
--- a/pkg/cmd/cache/shared/shared.go
+++ b/pkg/cmd/cache/shared/shared.go
@@ -2,12 +2,11 @@ package shared
 
 import (
 	"fmt"
-	"reflect"
-	"strings"
 	"time"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
 )
 
 var CacheFields = []string{
@@ -85,17 +84,5 @@ pagination:
 }
 
 func (c *Cache) ExportData(fields []string) map[string]interface{} {
-	v := reflect.ValueOf(c).Elem()
-	fieldByName := func(v reflect.Value, field string) reflect.Value {
-		return v.FieldByNameFunc(func(s string) bool {
-			return strings.EqualFold(field, s)
-		})
-	}
-	data := map[string]interface{}{}
-
-	for _, f := range fields {
-		data[f] = fieldByName(v, f).Interface()
-	}
-
-	return data
+	return cmdutil.StructExportData(c, fields)
 }

--- a/pkg/cmd/label/shared.go
+++ b/pkg/cmd/label/shared.go
@@ -1,9 +1,9 @@
 package label
 
 import (
-	"reflect"
-	"strings"
 	"time"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
 )
 
 var labelFields = []string{
@@ -21,31 +21,13 @@ type label struct {
 	Color       string    `json:"color"`
 	CreatedAt   time.Time `json:"createdAt"`
 	Description string    `json:"description"`
-	ID          string    `json:"node_id"`
+	ID          string    `json:"id"`
 	IsDefault   bool      `json:"isDefault"`
 	Name        string    `json:"name"`
 	URL         string    `json:"url"`
 	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
-// ExportData implements cmdutil.exportable
 func (l *label) ExportData(fields []string) map[string]interface{} {
-	v := reflect.ValueOf(l).Elem()
-	data := map[string]interface{}{}
-
-	for _, f := range fields {
-		switch f {
-		default:
-			sf := fieldByName(v, f)
-			data[f] = sf.Interface()
-		}
-	}
-
-	return data
-}
-
-func fieldByName(v reflect.Value, field string) reflect.Value {
-	return v.FieldByNameFunc(func(s string) bool {
-		return strings.EqualFold(field, s)
-	})
+	return cmdutil.StructExportData(l, fields)
 }

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -144,7 +144,7 @@ func listRun(opts *ListOptions) error {
 		return fmt.Errorf("failed to get secrets: %w", err)
 	}
 
-	if len(secrets) == 0 {
+	if len(secrets) == 0 && opts.Exporter == nil {
 		return cmdutil.NewNoResultsError("no secrets found")
 	}
 
@@ -193,6 +193,10 @@ type Secret struct {
 	Visibility       shared.Visibility `json:"visibility"`
 	SelectedReposURL string            `json:"selected_repositories_url"`
 	NumSelectedRepos int               `json:"num_selected_repos"`
+}
+
+func (s *Secret) ExportData(fields []string) map[string]interface{} {
+	return cmdutil.StructExportData(s, fields)
 }
 
 func fmtVisibility(s Secret) string {

--- a/pkg/cmd/secret/list/list_test.go
+++ b/pkg/cmd/secret/list/list_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_NewCmdList(t *testing.T) {
@@ -407,4 +408,22 @@ func Test_getSecrets_pagination(t *testing.T) {
 	secrets, err := getSecrets(client, "github.com", "path/to")
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(secrets))
+}
+
+func TestExportSecrets(t *testing.T) {
+	ios, _, stdout, _ := iostreams.Test()
+	tf, _ := time.Parse(time.RFC3339, "2024-01-01T00:00:00Z")
+	ss := []Secret{{
+		Name:             "s1",
+		UpdatedAt:        tf,
+		Visibility:       shared.All,
+		SelectedReposURL: "https://someurl.com",
+		NumSelectedRepos: 1,
+	}}
+	exporter := cmdutil.NewJSONExporter()
+	exporter.SetFields(secretFields)
+	require.NoError(t, exporter.Write(ios, ss))
+	require.JSONEq(t,
+		`[{"name":"s1","numSelectedRepos":1,"selectedReposURL":"https://someurl.com","updatedAt":"2024-01-01T00:00:00Z","visibility":"all"}]`,
+		stdout.String())
 }

--- a/pkg/cmd/variable/list/list.go
+++ b/pkg/cmd/variable/list/list.go
@@ -3,7 +3,6 @@ package list
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"time"
 
@@ -172,12 +171,16 @@ func listRun(opts *ListOptions) error {
 }
 
 type Variable struct {
-	Name             string
-	Value            string
-	UpdatedAt        time.Time `json:"updated_at"`
-	Visibility       shared.Visibility
-	SelectedReposURL string `json:"selected_repositories_url"`
-	NumSelectedRepos int
+	Name             string            `json:"name"`
+	Value            string            `json:"value"`
+	UpdatedAt        time.Time         `json:"updated_at"`
+	Visibility       shared.Visibility `json:"visibility"`
+	SelectedReposURL string            `json:"selected_repositories_url"`
+	NumSelectedRepos int               `json:"num_selected_repos"`
+}
+
+func (v *Variable) ExportData(fields []string) map[string]interface{} {
+	return cmdutil.StructExportData(v, fields)
 }
 
 func fmtVisibility(s Variable) string {
@@ -252,21 +255,4 @@ func populateSelectedRepositoryInformation(client *http.Client, host string, var
 		variables[i].NumSelectedRepos = response.TotalCount
 	}
 	return nil
-}
-
-func (v *Variable) ExportData(fields []string) map[string]interface{} {
-	e := reflect.ValueOf(v).Elem()
-	fieldByName := func(val reflect.Value, field string) reflect.Value {
-		return val.FieldByNameFunc(func(s string) bool {
-			return strings.EqualFold(field, s)
-		})
-	}
-	data := map[string]interface{}{}
-
-	for _, f := range fields {
-		sf := fieldByName(e, f)
-		data[f] = sf.Interface()
-	}
-
-	return data
 }

--- a/pkg/cmd/variable/list/list_test.go
+++ b/pkg/cmd/variable/list/list_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewCmdList(t *testing.T) {
@@ -272,4 +273,23 @@ func Test_getVariables_pagination(t *testing.T) {
 	variables, err := getVariables(client, "github.com", "path/to")
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(variables))
+}
+
+func TestExportVariables(t *testing.T) {
+	ios, _, stdout, _ := iostreams.Test()
+	tf, _ := time.Parse(time.RFC3339, "2024-01-01T00:00:00Z")
+	vs := []Variable{{
+		Name:             "v1",
+		Value:            "test1",
+		UpdatedAt:        tf,
+		Visibility:       shared.All,
+		SelectedReposURL: "https://someurl.com",
+		NumSelectedRepos: 1,
+	}}
+	exporter := cmdutil.NewJSONExporter()
+	exporter.SetFields(variableFields)
+	require.NoError(t, exporter.Write(ios, vs))
+	require.JSONEq(t,
+		`[{"name":"v1","numSelectedRepos":1,"selectedReposURL":"https://someurl.com","updatedAt":"2024-01-01T00:00:00Z","value":"test1","visibility":"all"}]`,
+		stdout.String())
 }

--- a/pkg/cmd/workflow/shared/shared.go
+++ b/pkg/cmd/workflow/shared/shared.go
@@ -8,12 +8,12 @@ import (
 	"io"
 	"net/url"
 	"path"
-	"reflect"
 	"strconv"
 	"strings"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/go-gh/v2/pkg/asciisanitizer"
 	"golang.org/x/text/transform"
@@ -51,21 +51,7 @@ func (w *Workflow) Base() string {
 }
 
 func (w *Workflow) ExportData(fields []string) map[string]interface{} {
-	fieldByName := func(v reflect.Value, field string) reflect.Value {
-		return v.FieldByNameFunc(func(s string) bool {
-			return strings.EqualFold(field, s)
-		})
-	}
-	v := reflect.ValueOf(w).Elem()
-	data := map[string]interface{}{}
-	for _, f := range fields {
-		switch f {
-		default:
-			sf := fieldByName(v, f)
-			data[f] = sf.Interface()
-		}
-	}
-	return data
+	return cmdutil.StructExportData(w, fields)
 }
 
 func GetWorkflows(client *api.Client, repo ghrepo.Interface, limit int) ([]Workflow, error) {

--- a/pkg/search/result.go
+++ b/pkg/search/result.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
 )
 
 var CodeFields = []string{
@@ -293,16 +295,7 @@ func (code Code) ExportData(fields []string) map[string]interface{} {
 }
 
 func (textMatch TextMatch) ExportData(fields []string) map[string]interface{} {
-	v := reflect.ValueOf(textMatch)
-	data := map[string]interface{}{}
-	for _, f := range fields {
-		switch f {
-		default:
-			sf := fieldByName(v, f)
-			data[f] = sf.Interface()
-		}
-	}
-	return data
+	return cmdutil.StructExportData(textMatch, fields)
 }
 
 func (commit Commit) ExportData(fields []string) map[string]interface{} {


### PR DESCRIPTION
Fixes #8492 

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

```shell
$ go run cmd/gh/main.go variable list --help
List variables on one of the following levels:
- repository (default): available to GitHub Actions runs or Dependabot in a repository
- environment: available to GitHub Actions runs for a deployment environment in a repository
- organization: available to GitHub Actions runs or Dependabot within an organization

For more information about output formatting flags, see `gh help formatting`.

USAGE
  gh variable list [flags]

FLAGS
  -e, --env string        List variables for an environment
  -q, --jq expression     Filter JSON output using a jq expression
      --json fields       Output JSON with the specified fields
  -o, --org string        List variables for an organization
  -t, --template string   Format JSON output using a Go template; see "gh help formatting"

INHERITED FLAGS
      --help                     Show help for command
  -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
```

```shell
# execute on my fork repo
$ go run cmd/gh/main.go variable list --json name (git)-[feat/variable-list-json-output]   [~/go/src/github.com/w1mvy/cli]
[]
```