### PR TITLE
Remove redundant MSI signing environment variables typo

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -215,9 +215,6 @@ jobs:
           Get-ChildItem -Path .\dist -Filter *.msi | ForEach-Object {
             .\script\sign.ps1 $_.FullName
           }
-        env:
-          CERT_FILE: ${{ steps.obtain_cert.outputs.cert-file }}
-          CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
       - uses: actions/upload-artifact@v3
         with:
           name: windows


### PR DESCRIPTION
relates https://github.com/github/cli/issues/213

This fixes an issue missed in #8465 where the MSI signing step previously had environment variables defined beneath the run portion.