### PR TITLE
Add Webi as an option for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you are a hubber and are interested in shipping new commands for the CLI, che
 
 ### macOS
 
-`gh` is available via [Homebrew][], [MacPorts][], [Conda][], [Spack][], and as a downloadable binary from the [releases page][].
+`gh` is available via [Homebrew][], [MacPorts][], [Conda][], [Spack][], [Webi][], and as a downloadable binary from the [releases page][].
 
 #### Homebrew
 
@@ -49,19 +49,27 @@ Additional Conda installation options available on the [gh-feedstock page](https
 | ------------------ | ---------------------------------------- |
 | `spack install gh` | `spack uninstall gh && spack install gh` |
 
+#### Webi
+
+| Install:                            | Upgrade:         |
+| ----------------------------------- | ---------------- |
+| `curl -sS https://webi.sh/gh \| sh` | `webi gh@stable` |
+
+For more information about the Webi installer see [it's homepage](https://webinstall.dev/).
+
 ### Linux & BSD
 
 `gh` is available via:
 - [our Debian and RPM repositories](./docs/install_linux.md);
 - community-maintained repositories in various Linux distros;
-- OS-agnostic package managers such as [Homebrew](#homebrew), [Conda](#conda), and [Spack](#spack); and
+- OS-agnostic package managers such as [Homebrew](#homebrew), [Conda](#conda), [Spack](#spack), [Webi](#webi); and
 - our [releases page][] as precompiled binaries.
 
 For more information, see [Linux & BSD installation](./docs/install_linux.md).
 
 ### Windows
 
-`gh` is available via [WinGet][], [scoop][], [Chocolatey][], [Conda](#conda), and as downloadable MSI.
+`gh` is available via [WinGet][], [scoop][], [Chocolatey][], [Conda](#conda), [Webi](#webi), and as downloadable MSI.
 
 #### WinGet
 
@@ -125,6 +133,7 @@ tool. Check out our [more detailed explanation][gh-vs-hub] to learn more.
 [Chocolatey]: https://chocolatey.org
 [Conda]: https://docs.conda.io/en/latest/
 [Spack]: https://spack.io
+[Webi]: https://webinstall.dev
 [releases page]: https://github.com/cli/cli/releases/latest
 [hub]: https://github.com/github/hub
 [contributing]: ./.github/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Additional Conda installation options available on the [gh-feedstock page](https
 | ----------------------------------- | ---------------- |
 | `curl -sS https://webi.sh/gh \| sh` | `webi gh@stable` |
 
-For more information about the Webi installer see [it's homepage](https://webinstall.dev/).
+For more information about the Webi installer see [its homepage](https://webinstall.dev/).
 
 ### Linux & BSD
 


### PR DESCRIPTION
The folks at @webinstall are doing a great job of curating and simplifying the installation of several dev tools.
Github cli is already supported (as I found out today webinstall/webi-installer-requests#81).

They asked nicely to open a PR to add their tool as an option in the docs and I definitely think it's worth, as it can save relevant time of figuring out how to install `gh` on different systems.

Webi is well documented and well maintained, I think it will be a good addition.

I'm open to feedbacks (let me know if linking their home/docs is ok here also.

Check them out  here https://webinstall.dev
Their installer is simple and can also be validated as it is open-source, [here](https://github.com/webinstall/webi-installers/tree/main/gh).