### PR TITLE
chore: Unify calling gh in examples

### DIFF
--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -188,7 +188,7 @@ var HelpTopics = []helpTopic{
 			cli-maintainer
 
 			# --jq can be used to implement more complex filtering and output changes:
-			$ bin/gh issue list --json number,title,labels --jq \
+			$ gh issue list --json number,title,labels --jq \
 			  'map(select((.labels | length) > 0))    # must have labels
 			  | map(.labels = (.labels | map(.name))) # show only the label names
 			  | .[:3]                                 # select the first 3 results'


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Calling `gh` is different in the [examples](https://cli.github.com/manual/gh_help_formatting).
There are two ways.

`$ gh pr`
`$ bin/gh issue`

This PR unifies, how is `gh` referenced in the docs to align with the style 

