### PR TITLE
fix: Prevent nil dereference in `pr view`.

### DIFF
--- a/pkg/cmd/pr/view/fixtures/prViewPreviewWithNilProject.json
+++ b/pkg/cmd/pr/view/fixtures/prViewPreviewWithNilProject.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "number": 12,
+        "title": "Blueberries are from a fork",
+        "state": "MERGED",
+        "body": "**blueberries taste good**",
+        "url": "https://github.com/OWNER/REPO/pull/12",
+        "author": {
+          "login": "nobody"
+        },
+        "commits": {
+          "totalCount": 12
+        },
+        "additions": 100,
+        "deletions": 10,
+        "baseRefName": "master",
+        "headRefName": "blueberries",
+        "headRepositoryOwner": {
+          "login": "hubot"
+        },
+        "projectCards": {
+          "nodes": [
+            null
+          ],
+          "totalCount": 1
+        },
+        "isCrossRepository": true
+      }
+    }
+  }
+}

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -439,6 +439,9 @@ func prProjectList(pr api.PullRequest) string {
 
 	projectNames := make([]string, 0, len(pr.ProjectCards.Nodes))
 	for _, project := range pr.ProjectCards.Nodes {
+		if project == nil {
+			continue
+		}
 		colName := project.Column.Name
 		if colName == "" {
 			colName = "Awaiting triage"

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -333,6 +333,16 @@ func TestPRView_Preview_nontty(t *testing.T) {
 				`auto-merge:\tenabled\thubot\tsquash\n`,
 			},
 		},
+		"PR with nil project": {
+			branch: "master",
+			args:   "12",
+			fixtures: map[string]string{
+				"PullRequestByNumber": "./fixtures/prViewPreviewWithNilProject.json",
+			},
+			expectedOutputs: []string{
+				`projects:\t\n`,
+			},
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
The API may return a `null` project, maybe related to "legacy projects". This is translated to a nil pointer in Go. When accessing `project.Column`, the nil pointer was dereferenced, causing a segmentation fault.

To reproduce, run the following command:

```sh
$ gh pr view 3481 -R collectd/collectd
```