### PR TITLE
Align devcontainer Go version with go.mod

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/go:1.19",
+	"image": "mcr.microsoft.com/devcontainers/go:1.21",
 	"features": {
 		"ghcr.io/devcontainers/features/sshd:1": {}
 	},


### PR DESCRIPTION
Update the devcontainer configuration to use the correct version of Go.

https://github.com/cli/cli/blob/72b6dc5d8c70525a6409abe6b1cbdf8d667f6193/go.mod#L3