### PR TITLE
Fix some typos raised by codespell

### DIFF
--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -109,7 +109,7 @@ if there are any remaining logged into the host:
 
 ## What is out of scope for this release?
 
-As mentioned above, we know that this only addreses some of the requests around supporting multiple accounts. While
+As mentioned above, we know that this only addresses some of the requests around supporting multiple accounts. While
 these are not out of scope forever, for this release some of the big things we have intentionally not included are:
  * Automatic account switching based on some context (e.g. `pwd`, `git remote`, etc)
  * Automatic configuration of git config such as `user.name` and `user.email` when switching
@@ -123,19 +123,19 @@ sharp edges in this release.
 ### Data Migration
 
 The trickiest piece of this work was that the `hosts.yml` file only supported a mapping of one-to-one in the host to
-account relationship. Having persistent data on disk that required a schema change presented a compatability challenge
+account relationship. Having persistent data on disk that required a schema change presented a compatibility challenge
 both backwards for those who use [`go-gh`](https://github.com/cli/go-gh/) outside of `gh`, and forward for `gh` itself
 where we try to ensure that it's possible to use older versions in case we accidentally make a breaking change for users.
 
 As such, from this release, running any command will attempt to migrate this data into a new format, and will
 additionally add a `version` field into the `config.yml` to aid in our future maintainability. While we have tried
-to maintain forward compatability (except in one edge case outlined below), and in the worst case you should be able
+to maintain forward compatibility (except in one edge case outlined below), and in the worst case you should be able
 to remove these files and start from scratch, if you are concerned about the data in these files, we advise you to take
 a backup.
 
-#### Forward Compatability Exclusion
+#### Forward Compatibility Exclusion
 
-There is one known case using `--insecure-storage` that we don't maintain complete forward and backward compatability.
+There is one known case using `--insecure-storage` that we don't maintain complete forward and backward compatibility.
 This occurs if you `auth login --insecure-storage`, upgrade to this release (which performs the data migration), run
 `auth login --insecure-storage` again on an older release, then at some time later use `auth switch` to make this
 account active. The symptom here would be usage of an older token (which may for example have different scopes).

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -20,7 +20,7 @@ func init() {
 
 	// Signal the tcell library to skip its expensive `init` block. This saves 30-40ms in startup
 	// time for the gh process. The downside is that some Unicode glyphs from user-generated
-	// content might cause mis-alignment in tcell-enabled views.
+	// content might cause misalignment in tcell-enabled views.
 	//
 	// https://github.com/gdamore/tcell/commit/2f889d79bd61b1fd2f43372529975a65b792a7ae
 	_ = os.Setenv("TCELL_MINIMIZE", "1")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,7 +47,7 @@ type Config interface {
 	Version() string
 }
 
-// Migration is the interace that config migrations must implement.
+// Migration is the interface that config migrations must implement.
 //
 // Migrations will receive a copy of the config, and should modify that copy
 // as necessary. After migration has completed, the modified config contents
@@ -167,7 +167,7 @@ func (c *cfg) Version() string {
 func (c *cfg) Migrate(m Migration) error {
 	version := c.Version()
 
-	// If migration has already occured then do not attempt to migrate again.
+	// If migration has already occurred then do not attempt to migrate again.
 	if m.PostVersion() == version {
 		return nil
 	}
@@ -241,7 +241,7 @@ func (c *AuthConfig) HasEnvToken() bool {
 			return true
 		}
 	}
-	// TODO: This is _extremely_ knowledgable about the implementation of TokenFromEnvOrConfig
+	// TODO: This is _extremely_ knowledgeable about the implementation of TokenFromEnvOrConfig
 	// It has to use a hostname that is not going to be found in the hosts so that it
 	// can guarantee that tokens will only be returned from a set env var.
 	// Discussed here, but maybe worth revisiting: https://github.com/cli/cli/pull/7169#discussion_r1136979033

--- a/internal/config/migration/multi_account.go
+++ b/internal/config/migration/multi_account.go
@@ -64,7 +64,7 @@ type tokenSource struct {
 // The reason for this is that we can then add new users under a host.
 // Note that we are only copying the config under a new users key, and
 // under a specific user. The original config is left alone. This is to
-// allow forward compatability for older versions of gh and also to avoid
+// allow forward compatibility for older versions of gh and also to avoid
 // breaking existing users of go-gh which looks at a specific location
 // in the config for oauth tokens that are stored insecurely.
 
@@ -195,7 +195,7 @@ func migrateToken(hostname, username string, tokenSource tokenSource) error {
 }
 
 func migrateConfig(c *config.Config, hostname, username string) error {
-	// Set the user key incase it was previously an anonymous user.
+	// Set the user key in case it was previously an anonymous user.
 	c.Set(append(hostsKey, hostname, "user"), username)
 	// Create the username key with an empty value so it will be
 	// written even if there are no keys set under it.

--- a/internal/tableprinter/table_printer.go
+++ b/internal/tableprinter/table_printer.go
@@ -16,7 +16,7 @@ type TablePrinter struct {
 	cs    *iostreams.ColorScheme
 }
 
-// IsTTY gets wether the TablePrinter will render to a terminal.
+// IsTTY gets whether the TablePrinter will render to a terminal.
 func (t *TablePrinter) IsTTY() bool {
 	return t.isTTY
 }

--- a/pkg/cmd/auth/switch/switch.go
+++ b/pkg/cmd/auth/switch/switch.go
@@ -122,7 +122,7 @@ func switchRun(opts *SwitchOptions) error {
 		username = candidates[0].user
 	} else if len(candidates) == 2 &&
 		candidates[0].host == candidates[1].host {
-		// If there is a single host with two users, automatically swith to the
+		// If there is a single host with two users, automatically switch to the
 		// inactive user without prompting.
 		hostname = candidates[0].host
 		username = candidates[0].user

--- a/pkg/cmd/issue/develop/develop_test.go
+++ b/pkg/cmd/issue/develop/develop_test.go
@@ -319,7 +319,7 @@ func TestDevelopRun(t *testing.T) {
 			expectedOut: "github.com/OWNER/REPO/tree/my-issue-1\n",
 		},
 		{
-			name: "develop new branch in diffferent repo than issue",
+			name: "develop new branch in different repo than issue",
 			opts: &DevelopOptions{
 				IssueSelector: "123",
 				BranchRepo:    "OWNER2/REPO",

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -113,10 +113,10 @@ type Project struct {
 	// We released gh v2.34.0 without realizing the Template field does not exist
 	// on GHES 3.8 and older. This broke all project commands for users targeting GHES 3.8
 	// and older. In order to fix this we will no longer query the Template field until
-	// GHES 3.8 gets deprecated on 2024-03-07. This solution was simplier and quicker
+	// GHES 3.8 gets deprecated on 2024-03-07. This solution was simpler and quicker
 	// than adding a feature detection measure to every place this query is used.
 	// It does have the negative consequence that we have had to remove the
-	// Template field when outputing projects to JSON using the --format flag supported
+	// Template field when outputting projects to JSON using the --format flag supported
 	// by a number of project commands. See `pkg/cmd/project/shared/format/json.go` for
 	// implementation.
 	// Template         bool
@@ -1001,7 +1001,7 @@ type Owner struct {
 // NewOwner creates a project Owner
 // If canPrompt is false, login is required as we cannot prompt for it.
 // If login is not empty, it is used to lookup the project owner.
-// If login is empty, interative mode is used to select an owner.
+// If login is empty, interactive mode is used to select an owner.
 // from the current viewer and their organizations
 func (c *Client) NewOwner(canPrompt bool, login string) (*Owner, error) {
 	if login != "" {

--- a/pkg/cmd/release/download/download_test.go
+++ b/pkg/cmd/release/download/download_test.go
@@ -280,7 +280,7 @@ func Test_downloadRun(t *testing.T) {
 			},
 		},
 		{
-			name:  "download single asset from matching patter into output option",
+			name:  "download single asset from matching pattern into output option",
 			isTTY: true,
 			opts: DownloadOptions{
 				OutputFile:   "./tmp/my-tarball.tgz",
@@ -296,7 +296,7 @@ func Test_downloadRun(t *testing.T) {
 			},
 		},
 		{
-			name:  "download single asset from matching patter into output 'stdout´",
+			name:  "download single asset from matching pattern into output 'stdout´",
 			isTTY: true,
 			opts: DownloadOptions{
 				OutputFile:   "-",

--- a/script/release
+++ b/script/release
@@ -102,7 +102,7 @@ if [ -n "$is_local" ]; then
 else
   if [ -n "$do_push" ]; then
     if ! git diff --quiet || ! git diff --cached --quiet; then
-      echo "refusing to continue due to uncomitted local changes" >&2
+      echo "refusing to continue due to uncommitted local changes" >&2
       exit 1
     fi
     announce git push


### PR DESCRIPTION
With `.codespellignore` containing:
```
aline
commitish
messag
noes
nwo
parth
prfiles
runn
timere
ue
welp
```

