### PR TITLE
Fix shell completion for extension commands

### DIFF
--- a/cmd/gh/main.go
+++ b/cmd/gh/main.go
@@ -108,10 +108,17 @@ func mainRun() exitCode {
 		expandedArgs = os.Args[1:]
 	}
 
-	// translate `gh help <command>` to `gh <command> --help` for extensions.
-	if len(expandedArgs) >= 2 && expandedArgs[0] == "help" && isExtensionCommand(rootCmd, expandedArgs[1:]) {
-		expandedArgs = expandedArgs[1:]
-		expandedArgs = append(expandedArgs, "--help")
+	if len(expandedArgs) >= 2 && isExtensionCommand(rootCmd, expandedArgs[1:]) {
+		switch expandedArgs[0] {
+		// translate `gh help <command>` to `gh <command> --help` for extensions.
+		case "help":
+			expandedArgs = expandedArgs[1:]
+			expandedArgs = append(expandedArgs, "--help")
+
+		// translate `gh __complete <command> $@` to `gh <command> __complete $@` for extensions.
+		case "__complete":
+			expandedArgs[0], expandedArgs[1] = expandedArgs[1], expandedArgs[0]
+		}
 	}
 
 	rootCmd.SetArgs(expandedArgs)


### PR DESCRIPTION
Given the precedent of how `gh help <command>` is translated to `gh <command> --help` if `gh` is given at least 2 arguments and `<command>` is an extension command -- this change introduces a similar translation from `gh __complete <command> ...` to the properly functioning `gh <command> __complete ...`.

Fixes: #5309 

