### PR TITLE
Feature: added Order flag for release list command

### DIFF
--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/cli/cli/v2/api"
@@ -34,7 +35,7 @@ func (r *Release) ExportData(fields []string) map[string]interface{} {
 	return cmdutil.StructExportData(r, fields)
 }
 
-func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, excludeDrafts bool, excludePreReleases bool) ([]Release, error) {
+func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, excludeDrafts bool, excludePreReleases bool, order string) ([]Release, error) {
 	type responseData struct {
 		Repository struct {
 			Releases struct {
@@ -43,7 +44,7 @@ func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, ex
 					HasNextPage bool
 					EndCursor   string
 				}
-			} `graphql:"releases(first: $perPage, orderBy: {field: CREATED_AT, direction: DESC}, after: $endCursor)"`
+			} `graphql:"releases(first: $perPage, orderBy: {field: CREATED_AT, direction: $direction}, after: $endCursor)"`
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
@@ -57,6 +58,7 @@ func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, ex
 		"name":      githubv4.String(repo.RepoName()),
 		"perPage":   githubv4.Int(perPage),
 		"endCursor": (*githubv4.String)(nil),
+		"direction": githubv4.OrderDirection(strings.ToUpper(order)),
 	}
 
 	gql := api.NewClientFromHTTP(httpClient)

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -23,6 +23,7 @@ type ListOptions struct {
 	LimitResults       int
 	ExcludeDrafts      bool
 	ExcludePreReleases bool
+	Order string
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
@@ -50,6 +51,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().IntVarP(&opts.LimitResults, "limit", "L", 30, "Maximum number of items to fetch")
 	cmd.Flags().BoolVar(&opts.ExcludeDrafts, "exclude-drafts", false, "Exclude draft releases")
 	cmd.Flags().BoolVar(&opts.ExcludePreReleases, "exclude-pre-releases", false, "Exclude pre-releases")
+	cmdutil.StringEnumFlag(cmd, &opts.Order, "order", "O", "desc", []string{"asc", "desc"}, "Order of releases returned")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, releaseFields)
 
 	return cmd
@@ -66,7 +68,7 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
-	releases, err := fetchReleases(httpClient, baseRepo, opts.LimitResults, opts.ExcludeDrafts, opts.ExcludePreReleases)
+	releases, err := fetchReleases(httpClient, baseRepo, opts.LimitResults, opts.ExcludeDrafts, opts.ExcludePreReleases, opts.Order)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -23,7 +23,7 @@ type ListOptions struct {
 	LimitResults       int
 	ExcludeDrafts      bool
 	ExcludePreReleases bool
-	Order string
+	Order              string
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -34,7 +34,7 @@ func Test_NewCmdList(t *testing.T) {
 				LimitResults:       30,
 				ExcludeDrafts:      false,
 				ExcludePreReleases: false,
-				Order: "desc",
+				Order:              "desc",
 			},
 		},
 		{
@@ -44,7 +44,7 @@ func Test_NewCmdList(t *testing.T) {
 				LimitResults:       30,
 				ExcludeDrafts:      true,
 				ExcludePreReleases: false,
-				Order: "desc",
+				Order:              "desc",
 			},
 		},
 		{
@@ -54,17 +54,17 @@ func Test_NewCmdList(t *testing.T) {
 				LimitResults:       30,
 				ExcludeDrafts:      false,
 				ExcludePreReleases: true,
-				Order: "desc",
+				Order:              "desc",
 			},
 		},
 		{
 			name: "with order",
 			args: "--order asc",
 			want: ListOptions{
-				LimitResults: 30,
-				ExcludeDrafts: false,
+				LimitResults:       30,
+				ExcludeDrafts:      false,
 				ExcludePreReleases: false,
-				Order: "asc",
+				Order:              "asc",
 			},
 		},
 	}

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -34,6 +34,7 @@ func Test_NewCmdList(t *testing.T) {
 				LimitResults:       30,
 				ExcludeDrafts:      false,
 				ExcludePreReleases: false,
+				Order: "desc",
 			},
 		},
 		{
@@ -43,6 +44,7 @@ func Test_NewCmdList(t *testing.T) {
 				LimitResults:       30,
 				ExcludeDrafts:      true,
 				ExcludePreReleases: false,
+				Order: "desc",
 			},
 		},
 		{
@@ -52,6 +54,17 @@ func Test_NewCmdList(t *testing.T) {
 				LimitResults:       30,
 				ExcludeDrafts:      false,
 				ExcludePreReleases: true,
+				Order: "desc",
+			},
+		},
+		{
+			name: "with order",
+			args: "--order asc",
+			want: ListOptions{
+				LimitResults: 30,
+				ExcludeDrafts: false,
+				ExcludePreReleases: false,
+				Order: "asc",
 			},
 		},
 	}
@@ -92,6 +105,7 @@ func Test_NewCmdList(t *testing.T) {
 			assert.Equal(t, tt.want.LimitResults, opts.LimitResults)
 			assert.Equal(t, tt.want.ExcludeDrafts, opts.ExcludeDrafts)
 			assert.Equal(t, tt.want.ExcludePreReleases, opts.ExcludePreReleases)
+			assert.Equal(t, tt.want.Order, opts.Order)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #8579 

Release lists can now be ordered by `created_at`.

`bin/gh release list --order asc` orders the Releases by oldest first

`bin/gh release list --order desc` orders the Releases by newest first

Notes: 
- this PR addresses the 1st issue mentioned in #8579 
- #8474 addresses the 2nd issue mentioned in #8579