### PR TITLE
Fix label create regression in v2.43.0

### DIFF
--- a/pkg/cmd/label/create.go
+++ b/pkg/cmd/label/create.go
@@ -137,8 +137,7 @@ func createLabel(client *http.Client, repo ghrepo.Interface, opts *createOptions
 		return err
 	}
 	requestBody := bytes.NewReader(requestByte)
-	result := label{}
-	err = apiClient.REST(repo.RepoHost(), "POST", path, requestBody, &result)
+	err = apiClient.REST(repo.RepoHost(), "POST", path, requestBody, nil)
 
 	if httpError, ok := err.(api.HTTPError); ok && isLabelAlreadyExistsError(httpError) {
 		err = errLabelAlreadyExists
@@ -173,8 +172,7 @@ func updateLabel(apiClient *api.Client, repo ghrepo.Interface, opts *editOptions
 		return err
 	}
 	requestBody := bytes.NewReader(requestByte)
-	result := label{}
-	err = apiClient.REST(repo.RepoHost(), "PATCH", path, requestBody, &result)
+	err = apiClient.REST(repo.RepoHost(), "PATCH", path, requestBody, nil)
 
 	if httpError, ok := err.(api.HTTPError); ok && isLabelAlreadyExistsError(httpError) {
 		err = errLabelAlreadyExists


### PR DESCRIPTION
## Description

This PR relates to https://github.com/cli/cli/issues/8652

It's mostly worth reading the comments there to understand most of the context.

The gist is that the `label` type was incorrectly being shared between GQL and REST response unmarshaling. I first thought that we should split the types but on closer inspection it doesn't look like the result of the REST requests is used at all, so why bother unmarshaling. It never seems to have been used at all: https://github.com/cli/cli/pull/5316/files#diff-acc8c020d84c08dfc3dce3c0c749ff98b80a8ff3f25d3258188142a30a5e5e00R133

This is also reflected in the tests which unfortunately never actually verified unmarshaling and would have broken on the change that introduced this regression: https://github.com/cli/cli/blob/e461c89b7dca8af35d10aeda3751d6d156992341/pkg/cmd/label/create_test.go#L101

Passing `nil` seems to be supported in other places (and is what I would expect from the way these functions normally work for unmarsahling): 

https://github.com/cli/cli/blob/e461c89b7dca8af35d10aeda3751d6d156992341/pkg/cmd/gist/delete/delete.go#L82

https://github.com/cli/cli/blob/e461c89b7dca8af35d10aeda3751d6d156992341/pkg/cmd/label/delete.go#L99

### Caveats

It's the end of a long day, after work hours, so my brain is definitely not running at full speed.

