### PR TITLE
feat: Add cache key option to `gh cache list`

### DIFF
--- a/pkg/cmd/cache/list/list.go
+++ b/pkg/cmd/cache/list/list.go
@@ -49,7 +49,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		# List caches sorted by least recently accessed
 		$ gh cache list --sort last_accessed_at --order asc
 
-		# List caches with a prefix (or exact match)
+		# List caches that have keys matching a prefix (or that match exactly)
 		$ gh cache list --key key-prefix
 		`),
 		Aliases: []string{"ls"},

--- a/pkg/cmd/cache/list/list.go
+++ b/pkg/cmd/cache/list/list.go
@@ -27,6 +27,7 @@ type ListOptions struct {
 	Limit int
 	Order string
 	Sort  string
+	Key   string
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
@@ -69,6 +70,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum number of caches to fetch")
 	cmdutil.StringEnumFlag(cmd, &opts.Order, "order", "O", "desc", []string{"asc", "desc"}, "Order of caches returned")
 	cmdutil.StringEnumFlag(cmd, &opts.Sort, "sort", "S", "last_accessed_at", []string{"created_at", "last_accessed_at", "size_in_bytes"}, "Sort fetched caches")
+	cmd.Flags().StringVarP(&opts.Key, "key", "K", "", "Filter by cache key prefix")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, shared.CacheFields)
 
 	return cmd
@@ -87,7 +89,7 @@ func listRun(opts *ListOptions) error {
 	client := api.NewClientFromHTTP(httpClient)
 
 	opts.IO.StartProgressIndicator()
-	result, err := shared.GetCaches(client, repo, shared.GetCachesOptions{Limit: opts.Limit, Sort: opts.Sort, Order: opts.Order})
+	result, err := shared.GetCaches(client, repo, shared.GetCachesOptions{Limit: opts.Limit, Sort: opts.Sort, Order: opts.Order, Key: opts.Key})
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("%s Failed to get caches: %w", opts.IO.ColorScheme().FailureIcon(), err)

--- a/pkg/cmd/cache/list/list.go
+++ b/pkg/cmd/cache/list/list.go
@@ -70,7 +70,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum number of caches to fetch")
 	cmdutil.StringEnumFlag(cmd, &opts.Order, "order", "O", "desc", []string{"asc", "desc"}, "Order of caches returned")
 	cmdutil.StringEnumFlag(cmd, &opts.Sort, "sort", "S", "last_accessed_at", []string{"created_at", "last_accessed_at", "size_in_bytes"}, "Sort fetched caches")
-	cmd.Flags().StringVarP(&opts.Key, "key", "K", "", "Filter by cache key prefix")
+	cmd.Flags().StringVarP(&opts.Key, "key", "k", "", "Filter by cache key prefix")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, shared.CacheFields)
 
 	return cmd

--- a/pkg/cmd/cache/list/list.go
+++ b/pkg/cmd/cache/list/list.go
@@ -48,6 +48,9 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 		# List caches sorted by least recently accessed
 		$ gh cache list --sort last_accessed_at --order asc
+
+		# List caches with a prefix (or exact match)
+		$ gh cache list --key key-prefix
 		`),
 		Aliases: []string{"ls"},
 		Args:    cobra.NoArgs,

--- a/pkg/cmd/cache/list/list_test.go
+++ b/pkg/cmd/cache/list/list_test.go
@@ -187,6 +187,26 @@ ID  KEY  SIZE      CREATED            ACCESSED
 			wantStdout: "1\tfoo\t100 B\t2021-01-01T01:01:01Z\t2022-01-01T01:01:01Z\n2\tbar\t1.00 KiB\t2021-01-01T01:01:01Z\t2022-01-01T01:01:01Z\n",
 		},
 		{
+			name: "only requests caches with the provided key prefix",
+			opts: ListOptions{
+				Key: "test-key",
+			},
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					func(req *http.Request) bool {
+						return req.URL.Query().Get("key") == "test-key"
+					},
+					httpmock.JSONResponse(shared.CachePayload{
+						ActionsCaches: []shared.Cache{},
+						TotalCount:    0,
+					}))
+			},
+			// We could put anything here, we're really asserting that the key is passed
+			// to the API.
+			wantErr:    true,
+			wantErrMsg: "No caches found in OWNER/REPO",
+		},
+		{
 			name: "displays no results",
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(

--- a/pkg/cmd/cache/list/list_test.go
+++ b/pkg/cmd/cache/list/list_test.go
@@ -30,6 +30,7 @@ func TestNewCmdList(t *testing.T) {
 				Limit: 30,
 				Order: "desc",
 				Sort:  "last_accessed_at",
+				Key:   "",
 			},
 		},
 		{
@@ -39,6 +40,7 @@ func TestNewCmdList(t *testing.T) {
 				Limit: 100,
 				Order: "desc",
 				Sort:  "last_accessed_at",
+				Key:   "",
 			},
 		},
 		{
@@ -53,6 +55,7 @@ func TestNewCmdList(t *testing.T) {
 				Limit: 30,
 				Order: "desc",
 				Sort:  "created_at",
+				Key:   "",
 			},
 		},
 		{
@@ -62,6 +65,17 @@ func TestNewCmdList(t *testing.T) {
 				Limit: 30,
 				Order: "asc",
 				Sort:  "last_accessed_at",
+				Key:   "",
+			},
+		},
+		{
+			name:  "with key",
+			input: "--key cache-key-prefix-",
+			wants: ListOptions{
+				Limit: 30,
+				Order: "desc",
+				Sort:  "last_accessed_at",
+				Key:   "cache-key-prefix-",
 			},
 		},
 	}
@@ -90,6 +104,7 @@ func TestNewCmdList(t *testing.T) {
 			assert.Equal(t, tt.wants.Limit, gotOpts.Limit)
 			assert.Equal(t, tt.wants.Sort, gotOpts.Sort)
 			assert.Equal(t, tt.wants.Order, gotOpts.Order)
+			assert.Equal(t, tt.wants.Key, gotOpts.Key)
 		})
 	}
 }

--- a/pkg/cmd/cache/shared/shared.go
+++ b/pkg/cmd/cache/shared/shared.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/cli/cli/v2/api"
@@ -38,6 +39,7 @@ type GetCachesOptions struct {
 	Limit int
 	Order string
 	Sort  string
+	Key   string
 }
 
 // Return a list of caches for a repository. Pass a negative limit to request
@@ -56,6 +58,9 @@ func GetCaches(client *api.Client, repo ghrepo.Interface, opts GetCachesOptions)
 	}
 	if opts.Order != "" {
 		path += fmt.Sprintf("&direction=%s", opts.Order)
+	}
+	if opts.Key != "" {
+		path += fmt.Sprintf("&key=%s", url.QueryEscape(opts.Key))
 	}
 
 	var result *CachePayload


### PR DESCRIPTION
## Context

fixes #8674

We have many caches in the repository, so I'd like to filter the caches using the `key`.

![image](https://github.com/cli/cli/assets/803398/ab3ede3f-57ec-444c-b53b-72ab53cc2f9f)

## Description

This PR adds `key` option to `gh cache list` command.

```
-k, --key string        Filter by cache key prefix
```

## API Doc

> key string
> An explicit key or prefix for identifying the cache

ref. https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#list-github-actions-caches-for-a-repository

## Usage

```console
$ gh cache list --limit 5
45540	index-buildkit-1-f921bd05#428	8.68 KiB	2024-02-03T08:41:11Z	2024-02-03T08:41:11Z
45539	buildkit-blob-1-sha256:f83194c216fa4d2164b3a61b84de34c3f3dcde0486c7ac08f88f90fff94ece8f	14.52 MiB	2024-02-03T08:41:10Z	2024-02-03T08:41:10Z
45538	buildkit-blob-1-sha256:f5875d5436450a23f75f2aeae832b699edbe5e52bc1ff467f4fb87b333d34506	57.90 MiB	2024-02-03T08:41:07Z	2024-02-03T08:41:07Z
45537	buildkit-blob-1-sha256:e08e8703b2fb5e50153f792f3192087d26970d262806b397049d61b9a14b3af5	22.93 MiB	2024-02-03T08:41:05Z	2024-02-03T08:41:05Z
45536	buildkit-blob-1-sha256:dfaede8a3360e06afafa49705df836815b908dfc4c29223abd4d9b0926a4ebc7	33.04 MiB	2024-02-03T08:41:03Z	2024-02-03T08:41:03Z
$ gh cache list --key index-buildkit
45540	index-buildkit-1-f921bd05#428	8.68 KiB	2024-02-03T08:41:11Z	2024-02-03T08:41:11Z
45460	index-buildkit-1-f921bd05#427	8.69 KiB	2024-01-25T22:43:24Z	2024-02-03T08:38:14Z
45510	index-buildkit-1-61426cf1#1	8.69 KiB	2024-01-31T18:54:14Z	2024-01-31T18:54:14Z
```