### PR TITLE
Fix APT keyring location in Linux installation instructions

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -15,9 +15,9 @@ Install:
 
 ```bash
 type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
-curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-&& sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
-&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg \
+&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
 && sudo apt update \
 && sudo apt install gh -y
 ```


### PR DESCRIPTION
The current installation instructions mention `/usr/share/keyrings` as the location to copy the apt key files to, but according to the sources.list and apt-key manpages, the correct location for manually installed keys would be `/etc/apt/keyrings`.

This PR changes the instructions to point to that location instead.

From the sources.list manpage:
> The recommended locations for keyrings are /usr/share/keyrings for keyrings managed by packages, and /etc/apt/keyrings for keyrings managed by the system operator.

From the apt-key manpage:
> FILES
>    /etc/apt/trusted.gpg
>            Keyring of local trusted keys, new keys will be added here. Configuration Item: Dir::Etc::Trusted.
> 
>    /etc/apt/trusted.gpg.d/
>            File fragments for the trusted keys, additional keyrings can be stored here (by other packages or the administrator). Configuration Item Dir::Etc::TrustedParts.
> 
>    /etc/apt/keyrings/
>            Place to store additional keyrings to be used with Signed-By.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
