### PR TITLE
Fix PR create regression around title and body when there is only one commit

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -425,7 +425,7 @@ func initDefaultTitleBody(ctx CreateContext, state *shared.IssueMetadataState, u
 		return err
 	}
 
-	if useFirstCommit {
+	if len(commits) == 1 || useFirstCommit {
 		state.Title = commits[len(commits)-1].Title
 		state.Body = commits[len(commits)-1].Body
 	} else {

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1004,14 +1004,9 @@ func Test_createRun(t *testing.T) {
 			},
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(
-					"git -c log.ShowSignature=false log --pretty=format:%H,%s --cherry origin/master...feature",
+					"git -c log.ShowSignature=false log --pretty=format:%H,%s,%b --cherry origin/master...feature",
 					0,
-					"343jdfe47c9e3a30093cd17e48934ce354148e80,first commit of pr\n\nfirst commit description\n",
-				)
-				cs.Register(
-					"git -c log.ShowSignature=false show -s --pretty=format:%b 343jdfe47c9e3a30093cd17e48934ce354148e80",
-					0,
-					"first commit description",
+					"3a9b48085046d156c5acce8f3b3a0532cd706a4a,first commit of pr,first commit description\n",
 				)
 				cs.Register(`git rev-parse --show-toplevel`, 0, "")
 			},


### PR DESCRIPTION
## Description

Fixes https://github.com/cli/cli/issues/8706

Prior to #8423, when running `gh pr create` on a branch with a single commit, the `title` and `body` of the PR would be prefilled as if using `--fill-first`, using the commit summary for the `title` and the description for the `body`: https://github.com/cli/cli/blob/dd25f885dca8d9822e21da9274d5c2e98f76f73d/pkg/cmd/pr/create/create.go#L411-L423

In #8423 a [change was made](https://github.com/cli/cli/pull/8423/files#diff-cb9343080dd90f9b451c75e48ed4c460f12ab1e19fb27f21d0ce72bbacae42dcL415) such that this no longer applied for PRs with one commit. This meant that the prefilled `title` would be a sanitized form of the branch name, as happens when providing `--fill` or `--fill-verbose`.

This PR adds a test that validates that the commit information returned from `git -c log.ShowSignature=false log --pretty=format:%H,%s,%b --cherry origin/master...feature` is used in the pull request mutation when there is exactly one commit.

### Reviewer Notes

I've taken the simplest approach to fixing this regression by adding the conditional back. I will follow this with another PR that introduces a new `Filler` abstraction to tease apart some of this intertwined logic (for example, after #8423 the commit titles will be **bolded** in the PR body even if there is no description, which is a change from before).

Additionally, it's also worth noting that there is a strange interaction when running `gh pr create --fill` with just one commit on the git branch in that the code will fall into the `1 commit` branch as opposed to the expected `else`. However, this has always been the behaviour so I don't think we should "fix" it right now.

CC @allyjweir @guerinoni