### PR TITLE
bug: fixed the msg returned for patching a repo variable

### DIFF
--- a/pkg/cmd/variable/set/http.go
+++ b/pkg/cmd/variable/set/http.go
@@ -72,7 +72,7 @@ func setVariable(client *api.Client, host string, opts setOptions) setResult {
 			return result
 		} else if errors.As(err, &postErr) && postErr.StatusCode == 409 {
 			// Server will return a 409 if variable already exists
-			result.Operation = createdOperation
+			result.Operation = updatedOperation
 			err = patchRepoVariable(client, opts.Repository, opts.Key, opts.Value)
 		}
 	}


### PR DESCRIPTION
Fixes #8712 

### Describe the bug
When updating an existing repo variable the return message is Created instead of Updated. This behaviour isn't observed for Environment or Organisation variables, only repo variables. 

### Change

Corrected the variable for result.Operation for the repo variable update to be updatedOperation instead of createdOperation. 