### PR TITLE
Resolve go compiler regression

### DIFF
--- a/pkg/cmd/repo/garden/garden.go
+++ b/pkg/cmd/repo/garden/garden.go
@@ -236,16 +236,15 @@ func gardenRun(opts *GardenOptions) error {
 		}
 	}()
 
-mainLoop:
 	for {
 		oldX := player.X
 		oldY := player.Y
 
 		d := <-dirc
 		if d == Quit {
-			break mainLoop
+			break
 		} else if !player.move(d) {
-			continue mainLoop
+			continue
 		}
 
 		underPlayer := garden[player.Y][player.X]


### PR DESCRIPTION
## Description

Fixes #8700

With Go 1.22 a [compiler bug](https://github.com/golang/go/issues/65593) was introduced which causes the compiler to blow up. A full investigation hasn't been performed yet but it's generally in the space of `labels`.

The `gh repo garden` command makes use of a `mainLoop` label but it's only referenced from the first nested `for` loop, so there should be no functional difference between `break mainLoop / break` and `continue mainLoop / continue`.

