### PR TITLE
feat: add `gh deployment` commands

### DIFF
--- a/pkg/cmd/deployment/create/create.go
+++ b/pkg/cmd/deployment/create/create.go
@@ -110,8 +110,12 @@ func createRun(opts *createOptions) error {
 
 	body := bytes.NewReader(requestByte)
 
+	var deployment = struct {
+		ID int `json:"id"`
+	}{}
+
 	opts.IO.StartProgressIndicator()
-	err = client.REST(repo.RepoHost(), "POST", path, body, nil)
+	err = client.REST(repo.RepoHost(), "POST", path, body, &deployment)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("could not create deployment: %w", err)
@@ -122,6 +126,8 @@ func createRun(opts *createOptions) error {
 		cs := opts.IO.ColorScheme()
 		fmt.Fprintf(out, "%s Created deployment for %s in %s\n",
 			cs.SuccessIcon(), cs.Bold(ref), ghrepo.FullName(repo))
+	} else {
+		fmt.Fprintf(opts.IO.Out, "%d\n", deployment.ID)
 	}
 
 	return nil

--- a/pkg/cmd/deployment/create/create.go
+++ b/pkg/cmd/deployment/create/create.go
@@ -1,0 +1,121 @@
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type createOptions struct {
+	BaseRepo   func() (ghrepo.Interface, error)
+	Branch     func() (string, error)
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+
+	Ref         string
+	Environment string
+}
+
+func NewCmdCreate(f *cmdutil.Factory, runF func(*createOptions) error) *cobra.Command {
+	opts := createOptions{
+		HttpClient: f.HttpClient,
+		IO:         f.IOStreams,
+		Branch:     f.Branch,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new deployment",
+		Long: heredoc.Docf(`
+			Create a new deployment.
+
+			This will dispatch a %[1]sdeployment%[1]s event that external services can listen for and act on.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# Create a deployment on the current branch
+			$ gh deployment create
+
+			# Create a deployment at a specified ref
+			$ gh deployment create --ref main
+
+			# Create a deployment for a specific environment
+			$ gh deployment create --environment test
+		`),
+		Args: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			opts.BaseRepo = f.BaseRepo
+			if runF != nil {
+				return runF(&opts)
+			}
+			return createRun(&opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Ref, "ref", "r", "", "The `branch`, `tag` or `SHA` to deploy (default [current branch])")
+	cmd.Flags().StringVarP(&opts.Environment, "environment", "e", "", "The `environment` that the deployment is for")
+
+	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "ref")
+
+	return cmd
+}
+
+func createRun(opts *createOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not build http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(httpClient)
+
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	ref := opts.Ref
+
+	if ref == "" {
+		ref, err = opts.Branch()
+		if err != nil {
+			return fmt.Errorf("could not determine the current branch: %w", err)
+		}
+	}
+
+	path := fmt.Sprintf("repos/%s/%s/deployments",
+		repo.RepoOwner(), repo.RepoName())
+
+	requestByte, err := json.Marshal(map[string]string{
+		"ref":         ref,
+		"environment": opts.Environment,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to serialize deployment inputs: %w", err)
+	}
+
+	body := bytes.NewReader(requestByte)
+
+	opts.IO.StartProgressIndicator()
+	err = client.REST(repo.RepoHost(), "POST", path, body, nil)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return fmt.Errorf("could not create deployment: %w", err)
+	}
+
+	if opts.IO.IsStdoutTTY() {
+		out := opts.IO.Out
+		cs := opts.IO.ColorScheme()
+		fmt.Fprintf(out, "%s Deployment created for %s\n",
+			cs.SuccessIcon(), cs.Bold(ref))
+	}
+
+	return nil
+}

--- a/pkg/cmd/deployment/create/create.go
+++ b/pkg/cmd/deployment/create/create.go
@@ -24,6 +24,11 @@ type createOptions struct {
 	Environment string
 }
 
+type deploymentRequest struct {
+	Ref         string `json:"ref,omitempty"`
+	Environment string `json:"environment,omitempty"`
+}
+
 func NewCmdCreate(f *cmdutil.Factory, runF func(*createOptions) error) *cobra.Command {
 	opts := createOptions{
 		HttpClient: f.HttpClient,
@@ -93,10 +98,12 @@ func createRun(opts *createOptions) error {
 	path := fmt.Sprintf("repos/%s/%s/deployments",
 		repo.RepoOwner(), repo.RepoName())
 
-	requestByte, err := json.Marshal(map[string]string{
-		"ref":         ref,
-		"environment": opts.Environment,
-	})
+	deploymentRequest := deploymentRequest{
+		Ref:         ref,
+		Environment: opts.Environment,
+	}
+
+	requestByte, err := json.Marshal(deploymentRequest)
 	if err != nil {
 		return fmt.Errorf("failed to serialize deployment inputs: %w", err)
 	}
@@ -113,8 +120,8 @@ func createRun(opts *createOptions) error {
 	if opts.IO.IsStdoutTTY() {
 		out := opts.IO.Out
 		cs := opts.IO.ColorScheme()
-		fmt.Fprintf(out, "%s Deployment created for %s\n",
-			cs.SuccessIcon(), cs.Bold(ref))
+		fmt.Fprintf(out, "%s Created deployment for %s in %s\n",
+			cs.SuccessIcon(), cs.Bold(ref), ghrepo.FullName(repo))
 	}
 
 	return nil

--- a/pkg/cmd/deployment/create/create_test.go
+++ b/pkg/cmd/deployment/create/create_test.go
@@ -94,7 +94,7 @@ func Test_createRun(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/deployments"),
-					httpmock.RESTPayload(201, `{"id": 1}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(201, `{}`, func(payload map[string]interface{}) {
 						assert.Equal(t, map[string]interface{}{
 							"ref": "main",
 						}, payload)
@@ -112,7 +112,7 @@ func Test_createRun(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/deployments"),
-					httpmock.RESTPayload(201, `{"id": 1}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(201, `{}`, func(payload map[string]interface{}) {
 						assert.Equal(t, map[string]interface{}{
 							"ref": "trunk",
 						}, payload)
@@ -130,7 +130,7 @@ func Test_createRun(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/deployments"),
-					httpmock.RESTPayload(201, `{"id": 1}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(201, `{}`, func(payload map[string]interface{}) {
 						assert.Equal(t, map[string]interface{}{
 							"ref":         "main",
 							"environment": "production",
@@ -150,7 +150,7 @@ func Test_createRun(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/deployments"),
-					httpmock.RESTPayload(201, `{"id": 1}`, func(payload map[string]interface{}) {
+					httpmock.RESTPayload(201, `{}`, func(payload map[string]interface{}) {
 						assert.Equal(t, map[string]interface{}{
 							"ref":         "trunk",
 							"environment": "production",
@@ -159,6 +159,22 @@ func Test_createRun(t *testing.T) {
 				)
 			},
 			wantStdout: "✓ Created deployment for trunk in OWNER/REPO\n",
+		},
+		{
+			name:  "no TTY",
+			opts:  &createOptions{},
+			isTTY: false,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("POST", "repos/OWNER/REPO/deployments"),
+					httpmock.RESTPayload(201, `{}`, func(payload map[string]interface{}) {
+						assert.Equal(t, map[string]interface{}{
+							"ref": "main",
+						}, payload)
+					}),
+				)
+			},
+			wantStdout: "",
 		},
 	}
 

--- a/pkg/cmd/deployment/create/create_test.go
+++ b/pkg/cmd/deployment/create/create_test.go
@@ -1,0 +1,77 @@
+package create
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdCreate(t *testing.T) {
+	tests := []struct {
+		name  string
+		cli   string
+		wants createOptions
+	}{
+		{
+			name: "no flags",
+			cli:  "",
+			wants: createOptions{
+				Ref:         "",
+				Environment: "",
+			},
+		},
+		{
+			name: "ref flag",
+			cli:  "--ref main",
+			wants: createOptions{
+				Ref:         "main",
+				Environment: "",
+			},
+		},
+		{
+			name: "environment flag",
+			cli:  "--environment production",
+			wants: createOptions{
+				Ref:         "",
+				Environment: "production",
+			},
+		},
+		{
+			name: "ref and environment flags",
+			cli:  "--ref main --environment production",
+			wants: createOptions{
+				Ref:         "main",
+				Environment: "production",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts createOptions
+			cmd := NewCmdCreate(f, func(opts *createOptions) error {
+				gotOpts = *opts
+				return nil
+			})
+
+			cmd.SetArgs(argv)
+			_, err = cmd.ExecuteC()
+
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.Ref, gotOpts.Ref)
+			assert.Equal(t, tt.wants.Environment, gotOpts.Environment)
+		})
+	}
+}

--- a/pkg/cmd/deployment/delete/delete.go
+++ b/pkg/cmd/deployment/delete/delete.go
@@ -1,0 +1,92 @@
+package delete
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type deleteOptions struct {
+	BaseRepo   func() (ghrepo.Interface, error)
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+
+	Deployment string
+}
+
+func NewCmdDelete(f *cmdutil.Factory, runF func(*deleteOptions) error) *cobra.Command {
+	opts := deleteOptions{
+		HttpClient: f.HttpClient,
+		IO:         f.IOStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete <deployment>",
+		Short: "Delete a deployment",
+		Long: heredoc.Docf(`
+			Delete a deployment.
+
+			If the repository only has one deployment, you can delete the
+			deployment regardless of its status. If the repository has more
+			than one deployment, you can only delete inactive deployments.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# Delete a deployment in the current repository
+			$ gh deployment delete 1234
+
+			# Delete a deployment in a specific repository
+			$ gh deployment delete --repo owner/repo 1234
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts.BaseRepo = f.BaseRepo
+
+			opts.Deployment = args[0]
+
+			if runF != nil {
+				return runF(&opts)
+			}
+			return deleteRun(&opts)
+		},
+	}
+
+	return cmd
+}
+
+func deleteRun(opts *deleteOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not build http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(httpClient)
+
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("repos/%s/%s/deployments/%s",
+		repo.RepoOwner(), repo.RepoName(), opts.Deployment)
+
+	opts.IO.StartProgressIndicator()
+	err = client.REST(repo.RepoHost(), "DELETE", path, nil, nil)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return fmt.Errorf("could not delete deployment: %w", err)
+	}
+
+	if opts.IO.IsStdoutTTY() {
+		out := opts.IO.Out
+		cs := opts.IO.ColorScheme()
+		fmt.Fprintf(out, "%s Deleted deployment %s from %s\n",
+			cs.SuccessIcon(), cs.Bold(opts.Deployment), ghrepo.FullName(repo))
+	}
+
+	return nil
+}

--- a/pkg/cmd/deployment/delete/delete_test.go
+++ b/pkg/cmd/deployment/delete/delete_test.go
@@ -1,0 +1,171 @@
+package delete
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdDelete(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    deleteOptions
+		wantsErr bool
+	}{
+		{
+			name:     "no arguments",
+			cli:      "",
+			wantsErr: true,
+		},
+		{
+			name:  "id argument",
+			cli:   "123",
+			wants: deleteOptions{Deployment: "123"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts deleteOptions
+			cmd := NewCmdDelete(f, func(opts *deleteOptions) error {
+				gotOpts = *opts
+				return nil
+			})
+
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.Deployment, gotOpts.Deployment)
+		})
+	}
+}
+
+func Test_deleteRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       *deleteOptions
+		isTTY      bool
+		httpStubs  func(t *testing.T, reg *httpmock.Registry)
+		wantStdout string
+		wantStderr string
+		wantErr    string
+	}{
+		{
+			name: "delete deployment",
+			opts: &deleteOptions{
+				Deployment: "123456789",
+			},
+			isTTY: true,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("DELETE", "repos/OWNER/REPO/deployments/123456789"),
+					httpmock.StatusStringResponse(204, ""),
+				)
+			},
+			wantStdout: "✓ Deleted deployment 123456789 from OWNER/REPO\n",
+		},
+		{
+			name: "no TTY",
+			opts: &deleteOptions{
+				Deployment: "123456789",
+			},
+			isTTY: false,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("DELETE", "repos/OWNER/REPO/deployments/123456789"),
+					httpmock.StatusStringResponse(204, ""),
+				)
+			},
+			wantStdout: "",
+		},
+		{
+			name: "missing deployment",
+			opts: &deleteOptions{
+				Deployment: "123456789",
+			},
+			isTTY: true,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("DELETE", "repos/OWNER/REPO/deployments/123456789"),
+					httpmock.StatusStringResponse(404, ""),
+				)
+			},
+			wantErr:    "could not delete deployment: HTTP 404 (https://api.github.com/repos/OWNER/REPO/deployments/123456789)",
+			wantStdout: "",
+		},
+		{
+			name: "validation failed",
+			opts: &deleteOptions{
+				Deployment: "123456789",
+			},
+			isTTY: true,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("DELETE", "repos/OWNER/REPO/deployments/123456789"),
+					httpmock.StatusStringResponse(422, ""),
+				)
+			},
+			wantErr:    "could not delete deployment: HTTP 422 (https://api.github.com/repos/OWNER/REPO/deployments/123456789)",
+			wantStdout: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, stdout, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
+
+			fakeHTTP := &httpmock.Registry{}
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, fakeHTTP)
+			}
+			defer fakeHTTP.Verify(t)
+
+			tt.opts.IO = ios
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: fakeHTTP}, nil
+			}
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("OWNER/REPO")
+			}
+
+			err := deleteRun(tt.opts)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantStdout, stdout.String())
+		})
+	}
+}

--- a/pkg/cmd/deployment/deployment.go
+++ b/pkg/cmd/deployment/deployment.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	cmdCreate "github.com/cli/cli/v2/pkg/cmd/deployment/create"
+	cmdDelete "github.com/cli/cli/v2/pkg/cmd/deployment/delete"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -15,6 +16,7 @@ func NewCmdDeployment(f *cmdutil.Factory) *cobra.Command {
 	cmdutil.EnableRepoOverride(cmd, f)
 
 	cmd.AddCommand(cmdCreate.NewCmdCreate(f, nil))
+	cmd.AddCommand(cmdDelete.NewCmdDelete(f, nil))
 
 	return cmd
 }

--- a/pkg/cmd/deployment/deployment.go
+++ b/pkg/cmd/deployment/deployment.go
@@ -1,0 +1,20 @@
+package deployment
+
+import (
+	cmdCreate "github.com/cli/cli/v2/pkg/cmd/deployment/create"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdDeployment(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deployment <command>",
+		Short: "Manage GitHub deployments",
+		Long:  `Work with GitHub deployments.`,
+	}
+	cmdutil.EnableRepoOverride(cmd, f)
+
+	cmd.AddCommand(cmdCreate.NewCmdCreate(f, nil))
+
+	return cmd
+}

--- a/pkg/cmd/deployment/deployment.go
+++ b/pkg/cmd/deployment/deployment.go
@@ -4,6 +4,7 @@ import (
 	cmdCreate "github.com/cli/cli/v2/pkg/cmd/deployment/create"
 	cmdDelete "github.com/cli/cli/v2/pkg/cmd/deployment/delete"
 	cmdList "github.com/cli/cli/v2/pkg/cmd/deployment/list"
+	cmdUpdate "github.com/cli/cli/v2/pkg/cmd/deployment/update"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -17,6 +18,7 @@ func NewCmdDeployment(f *cmdutil.Factory) *cobra.Command {
 	cmdutil.EnableRepoOverride(cmd, f)
 
 	cmd.AddCommand(cmdCreate.NewCmdCreate(f, nil))
+	cmd.AddCommand(cmdUpdate.NewCmdUpdate(f, nil))
 	cmd.AddCommand(cmdList.NewCmdList(f, nil))
 	cmd.AddCommand(cmdDelete.NewCmdDelete(f, nil))
 

--- a/pkg/cmd/deployment/deployment.go
+++ b/pkg/cmd/deployment/deployment.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	cmdCreate "github.com/cli/cli/v2/pkg/cmd/deployment/create"
 	cmdDelete "github.com/cli/cli/v2/pkg/cmd/deployment/delete"
+	cmdList "github.com/cli/cli/v2/pkg/cmd/deployment/list"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -16,6 +17,7 @@ func NewCmdDeployment(f *cmdutil.Factory) *cobra.Command {
 	cmdutil.EnableRepoOverride(cmd, f)
 
 	cmd.AddCommand(cmdCreate.NewCmdCreate(f, nil))
+	cmd.AddCommand(cmdList.NewCmdList(f, nil))
 	cmd.AddCommand(cmdDelete.NewCmdDelete(f, nil))
 
 	return cmd

--- a/pkg/cmd/deployment/list/list.go
+++ b/pkg/cmd/deployment/list/list.go
@@ -1,0 +1,223 @@
+package list
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/tableprinter"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/shurcooL/githubv4"
+	"github.com/spf13/cobra"
+)
+
+type listOptions struct {
+	BaseRepo   func() (ghrepo.Interface, error)
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	Now        time.Time
+
+	Limit int
+}
+
+type deployment struct {
+	ID  int
+	Ref *struct {
+		Name string
+	}
+	Environment  string
+	LatestStatus *struct {
+		State     string
+		CreatedAt time.Time
+	}
+	CreatedAt time.Time
+}
+
+type listDeploymentsQuery struct {
+	Repository struct {
+		Deployments struct {
+			Nodes []struct {
+				DatabaseID int
+				Ref        *struct {
+					Name string
+				}
+				Environment  string
+				LatestStatus *struct {
+					State     string
+					CreatedAt time.Time
+				}
+				CreatedAt time.Time
+			}
+			PageInfo struct {
+				HasNextPage bool
+				EndCursor   string
+			}
+		} `graphql:"deployments(first: $per_page, after: $endCursor, orderBy: {field: CREATED_AT, direction: DESC})"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+func NewCmdList(f *cmdutil.Factory, runF func(*listOptions) error) *cobra.Command {
+	opts := listOptions{
+		HttpClient: f.HttpClient,
+		IO:         f.IOStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List deployments",
+		Long: heredoc.Docf(`
+			List deployments.
+
+			If the repository only has one deployment, you can delete the
+			deployment regardless of its status. If the repository has more
+			than one deployment, you can only delete inactive deployments.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# List deployments in the current repository
+			$ gh deployment list
+
+			# List deployments in a specific repository
+			$ gh deployment list --repo owner/repo
+
+			# List more than 10 deployments
+			$ gh deployment list --limit 100
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(c *cobra.Command, args []string) error {
+			opts.BaseRepo = f.BaseRepo
+
+			if runF != nil {
+				return runF(&opts)
+			}
+			return listRun(&opts)
+		},
+	}
+
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 10, "Maximum number of deployments to fetch")
+
+	return cmd
+}
+
+func listDeployments(client *api.Client, repo ghrepo.Interface, limit int) ([]deployment, error) {
+	perPage := limit
+	if perPage > 100 {
+		perPage = 100
+	}
+
+	variables := map[string]interface{}{
+		"owner":     githubv4.String(repo.RepoOwner()),
+		"name":      githubv4.String(repo.RepoName()),
+		"per_page":  githubv4.Int(perPage),
+		"endCursor": (*githubv4.String)(nil),
+	}
+
+	deployments := []deployment{}
+
+pagination:
+	for {
+		var result listDeploymentsQuery
+		err := client.Query(repo.RepoHost(), "RepositoryDeployments", &result, variables)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, node := range result.Repository.Deployments.Nodes {
+			deployment := deployment{
+				ID:           node.DatabaseID,
+				Ref:          node.Ref,
+				Environment:  node.Environment,
+				LatestStatus: node.LatestStatus,
+				CreatedAt:    node.CreatedAt,
+			}
+			deployments = append(deployments, deployment)
+
+			if len(deployments) == limit {
+				break pagination
+			}
+		}
+
+		if !result.Repository.Deployments.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(result.Repository.Deployments.PageInfo.EndCursor)
+	}
+
+	return deployments, nil
+}
+
+func listRun(opts *listOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not build http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(httpClient)
+
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicator()
+	deployments, err := listDeployments(client, repo, opts.Limit)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return fmt.Errorf("could not list deployments: %w", err)
+	}
+
+	if len(deployments) == 0 {
+		return cmdutil.NewNoResultsError("no deployments found")
+	}
+
+	if err := opts.IO.StartPager(); err == nil {
+		defer opts.IO.StopPager()
+	} else {
+		fmt.Fprintf(opts.IO.ErrOut, "failed to start pager: %v\n", err)
+	}
+
+	cs := opts.IO.ColorScheme()
+	tp := tableprinter.New(opts.IO, tableprinter.WithHeader("ID", "ENVIRONMENT", "STATUS", "REF", "CREATED"))
+
+	if opts.Now.IsZero() {
+		opts.Now = time.Now()
+	}
+
+	for _, deployment := range deployments {
+		tp.AddField(strconv.Itoa(deployment.ID))
+		tp.AddField(deployment.Environment, tableprinter.WithColor(cs.Bold))
+
+		status := "none"
+		if deployment.LatestStatus != nil {
+			status = strings.ToLower(deployment.LatestStatus.State)
+		}
+		switch status {
+		case "error", "failure":
+			tp.AddField(status, tableprinter.WithColor(cs.Red))
+		case "queued", "pending":
+			tp.AddField(status, tableprinter.WithColor(cs.Yellow))
+		case "in_progress":
+			tp.AddField(status, tableprinter.WithColor(cs.Blue))
+		case "success":
+			tp.AddField(status, tableprinter.WithColor(cs.Green))
+		case "inactive":
+		default:
+			tp.AddField(status, tableprinter.WithColor(cs.Gray))
+		}
+
+		ref := "none"
+		if deployment.Ref != nil {
+			ref = deployment.Ref.Name
+		}
+		tp.AddField(ref)
+
+		tp.AddTimeField(opts.Now, deployment.CreatedAt, cs.Gray)
+		tp.EndRow()
+	}
+
+	return tp.Render()
+}

--- a/pkg/cmd/deployment/list/list_test.go
+++ b/pkg/cmd/deployment/list/list_test.go
@@ -36,6 +36,14 @@ func TestNewCmdList(t *testing.T) {
 				Limit: 1000,
 			},
 		},
+		{
+			name: "filter by environment",
+			cli:  "--environment test",
+			wants: listOptions{
+				Limit:       10,
+				Environment: "test",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -217,7 +225,6 @@ func TestListRun(t *testing.T) {
 				)
 			},
 			wantStdout: heredoc.Doc(`
-				ID	ENVIRONMENT	STATUS	REF	CREATED
 				1	production	in_progress	main	2020-10-11T20:38:03Z
 				2	test	success	test	2020-10-11T20:38:03Z
 			`),

--- a/pkg/cmd/deployment/list/list_test.go
+++ b/pkg/cmd/deployment/list/list_test.go
@@ -1,0 +1,260 @@
+package list
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdList(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    listOptions
+		wantsErr bool
+	}{
+		{
+			name: "no arguments",
+			cli:  "",
+			wants: listOptions{
+				Limit: 10,
+			},
+		},
+		{
+			name: "limit flag",
+			cli:  "--limit 1000",
+			wants: listOptions{
+				Limit: 1000,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts listOptions
+			cmd := NewCmdList(f, func(opts *listOptions) error {
+				gotOpts = *opts
+				return nil
+			})
+
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.Limit, gotOpts.Limit)
+		})
+	}
+}
+
+func TestListRun(t *testing.T) {
+	var now = time.Date(2023, 1, 1, 1, 1, 1, 1, time.UTC)
+	tests := []struct {
+		name       string
+		tty        bool
+		opts       *listOptions
+		httpStubs  func(*httpmock.Registry)
+		wantErr    bool
+		wantErrMsg string
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name: "no deployments",
+			tty:  true,
+			opts: &listOptions{},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryDeployments\b`),
+					httpmock.StringResponse(`
+						{
+							"data": {
+								"repository": {
+									"deployments": {
+										"nodes": [],
+										"pageInfo": {
+											"hasNextPage": false,
+											"endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0xMC0xMVQwMTozODowMyswODowMM5f3HZq"
+										}
+									}
+								}
+							}
+						}`,
+					),
+				)
+			},
+			wantErr:    true,
+			wantErrMsg: "no deployments found",
+		},
+		{
+			name: "list of deployments",
+			tty:  true,
+			opts: &listOptions{},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryDeployments\b`),
+					httpmock.StringResponse(`
+						{
+							"data": {
+								"repository": {
+									"deployments": {
+										"nodes": [
+											{
+												"databaseId": 1,
+												"environment": "production",
+												"latestStatus": {
+													"state": "in_progress",
+													"createdAt": "2020-10-11T20:38:03Z"
+												},
+												"ref": {
+													"name": "main"
+												},
+												"createdAt": "2020-10-11T20:38:03Z"
+											},
+											{
+												"databaseId": 2,
+												"environment": "test",
+												"latestStatus": {
+													"state": "success",
+													"createdAt": "2020-10-11T20:38:03Z"
+												},
+												"ref": {
+													"name": "test"
+												},
+												"createdAt": "2020-10-11T20:38:03Z"
+											}
+										],
+										"pageInfo": {
+											"hasNextPage": false,
+											"endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0xMC0xMVQwMTozODowMyswODowMM5f3HZq"
+										}
+									}
+								}
+							}
+						}`,
+					),
+				)
+			},
+			wantStdout: heredoc.Doc(`
+				ID  ENVIRONMENT  STATUS       REF   CREATED
+				1   production   in_progress  main  about 2 years ago
+				2   test         success      test  about 2 years ago
+			`),
+		},
+		{
+			name: "not tty",
+			tty:  false,
+			opts: &listOptions{},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryDeployments\b`),
+					httpmock.StringResponse(`
+						{
+							"data": {
+								"repository": {
+									"deployments": {
+										"nodes": [
+											{
+												"databaseId": 1,
+												"environment": "production",
+												"latestStatus": {
+													"state": "in_progress",
+													"createdAt": "2020-10-11T20:38:03Z"
+												},
+												"ref": {
+													"name": "main"
+												},
+												"createdAt": "2020-10-11T20:38:03Z"
+											},
+											{
+												"databaseId": 2,
+												"environment": "test",
+												"latestStatus": {
+													"state": "success",
+													"createdAt": "2020-10-11T20:38:03Z"
+												},
+												"ref": {
+													"name": "test"
+												},
+												"createdAt": "2020-10-11T20:38:03Z"
+											}
+										],
+										"pageInfo": {
+											"hasNextPage": false,
+											"endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0xMC0xMVQwMTozODowMyswODowMM5f3HZq"
+										}
+									}
+								}
+							}
+						}`,
+					),
+				)
+			},
+			wantStdout: heredoc.Doc(`
+				ID	ENVIRONMENT	STATUS	REF	CREATED
+				1	production	in_progress	main	2020-10-11T20:38:03Z
+				2	test	success	test	2020-10-11T20:38:03Z
+			`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			if tt.httpStubs != nil {
+				tt.httpStubs(reg)
+			}
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			ios, _, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.tty)
+			ios.SetStdinTTY(tt.tty)
+			ios.SetStderrTTY(tt.tty)
+			tt.opts.IO = ios
+			tt.opts.Now = now
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.New("OWNER", "REPO"), nil
+			}
+			defer reg.Verify(t)
+			err := listRun(tt.opts)
+			if tt.wantErr {
+				if tt.wantErrMsg != "" {
+					assert.EqualError(t, err, tt.wantErrMsg)
+				} else {
+					assert.Error(t, err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantStdout, stdout.String())
+			assert.Equal(t, tt.wantStderr, stderr.String())
+		})
+	}
+}

--- a/pkg/cmd/deployment/list/list_test.go
+++ b/pkg/cmd/deployment/list/list_test.go
@@ -192,7 +192,7 @@ func TestListRun(t *testing.T) {
 												"databaseId": 1,
 												"environment": "production",
 												"latestStatus": {
-													"state": "in_progress",
+													"state": "IN_PROGRESS",
 													"createdAt": "2020-10-11T20:38:03Z"
 												},
 												"ref": {
@@ -204,7 +204,7 @@ func TestListRun(t *testing.T) {
 												"databaseId": 2,
 												"environment": "test",
 												"latestStatus": {
-													"state": "success",
+													"state": "SUCCESS",
 													"createdAt": "2020-10-11T20:38:03Z"
 												},
 												"ref": {
@@ -227,6 +227,104 @@ func TestListRun(t *testing.T) {
 			wantStdout: heredoc.Doc(`
 				1	production	in_progress	main	2020-10-11T20:38:03Z
 				2	test	success	test	2020-10-11T20:38:03Z
+			`),
+		},
+		{
+			name: "no status deployments",
+			tty:  false,
+			opts: &listOptions{},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryDeployments\b`),
+					httpmock.StringResponse(`
+						{
+							"data": {
+								"repository": {
+									"deployments": {
+										"nodes": [
+											{
+												"databaseId": 1,
+												"environment": "production",
+												"latestStatus": null,
+												"ref": {
+													"name": "main"
+												},
+												"createdAt": "2020-10-11T20:38:03Z"
+											},
+											{
+												"databaseId": 2,
+												"environment": "test",
+												"latestStatus": {
+													"state": "SUCCESS",
+													"createdAt": "2020-10-11T20:38:03Z"
+												},
+												"ref": {
+													"name": "test"
+												},
+												"createdAt": "2020-10-11T20:38:03Z"
+											}
+										],
+										"pageInfo": {
+											"hasNextPage": false,
+											"endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0xMC0xMVQwMTozODowMyswODowMM5f3HZq"
+										}
+									}
+								}
+							}
+						}`,
+					),
+				)
+			},
+			wantStdout: heredoc.Doc(`
+				1	production	none	main	2020-10-11T20:38:03Z
+				2	test	success	test	2020-10-11T20:38:03Z
+			`),
+		},
+		{
+			name: "no ref deployments",
+			tty:  false,
+			opts: &listOptions{},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryDeployments\b`),
+					httpmock.StringResponse(`
+						{
+							"data": {
+								"repository": {
+									"deployments": {
+										"nodes": [
+											{
+												"databaseId": 1,
+												"environment": "production",
+												"latestStatus": null,
+												"ref": null,
+												"createdAt": "2020-10-11T20:38:03Z"
+											},
+											{
+												"databaseId": 2,
+												"environment": "test",
+												"latestStatus": {
+													"state": "SUCCESS",
+													"createdAt": "2020-10-11T20:38:03Z"
+												},
+												"ref": null,
+												"createdAt": "2020-10-11T20:38:03Z"
+											}
+										],
+										"pageInfo": {
+											"hasNextPage": false,
+											"endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0xMC0xMVQwMTozODowMyswODowMM5f3HZq"
+										}
+									}
+								}
+							}
+						}`,
+					),
+				)
+			},
+			wantStdout: heredoc.Doc(`
+				1	production	none	none	2020-10-11T20:38:03Z
+				2	test	success	none	2020-10-11T20:38:03Z
 			`),
 		},
 	}

--- a/pkg/cmd/deployment/list/list_test.go
+++ b/pkg/cmd/deployment/list/list_test.go
@@ -81,7 +81,7 @@ func TestNewCmdList(t *testing.T) {
 	}
 }
 
-func TestListRun(t *testing.T) {
+func Test_listRun(t *testing.T) {
 	var now = time.Date(2023, 1, 1, 1, 1, 1, 1, time.UTC)
 	tests := []struct {
 		name       string

--- a/pkg/cmd/deployment/update/update.go
+++ b/pkg/cmd/deployment/update/update.go
@@ -1,0 +1,154 @@
+package update
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type updateOptions struct {
+	BaseRepo   func() (ghrepo.Interface, error)
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+
+	Deployment     string
+	Status         string
+	LogURL         string
+	Description    string
+	Environment    string
+	EnvironmentURL string
+	AutoInactive   bool
+}
+
+func NewCmdUpdate(f *cmdutil.Factory, runF func(*updateOptions) error) *cobra.Command {
+	opts := updateOptions{
+		HttpClient: f.HttpClient,
+		IO:         f.IOStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update [flags] <deployment>",
+		Short: "Update a deployment",
+		Long: heredoc.Docf(`
+			Update a deployment.
+
+			To update a deployment, you must specify a %[1]sstatus%[1]s and can include details such as a %[1]slog-url%[1]s.
+
+			This command will update the deployment by creating a new deployment status.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# Update a deployment to in_progress
+			$ gh deployment update --status in_progress 1234
+
+			# Update a deployment to add a log_url
+			$ gh deployment update --log-url https://example.com 1234
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts.BaseRepo = f.BaseRepo
+
+			opts.Deployment = args[0]
+
+			if opts.Status == "" {
+				return fmt.Errorf("status flag is required")
+			}
+
+			switch opts.Status {
+			case "queued", "in_progress", "inactive", "in_review", "approved", "rejected", "pending", "error", "failure", "success":
+			default:
+				return fmt.Errorf("invalid status: %s", opts.Status)
+			}
+
+			if len(opts.Description) > 140 {
+				return fmt.Errorf("description must be less than 140 characters")
+			}
+
+			if runF != nil {
+				return runF(&opts)
+			}
+			return updateRun(&opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Status, "status", "s", "", "The `status` of the deployment")
+	cmd.Flags().StringVarP(&opts.LogURL, "log-url", "l", "", "The full URL of the deployment output")
+	cmd.Flags().StringVarP(&opts.Description, "description", "d", "", "A short description of the status")
+	cmd.Flags().StringVarP(&opts.Environment, "environment", "e", "", "Name for the target deployment environment")
+	cmd.Flags().StringVarP(&opts.EnvironmentURL, "environment-url", "u", "", "The URL for accessing your environment")
+	cmd.Flags().BoolVar(&opts.AutoInactive, "auto-inactive", true, "Add a new inactive status to all prior non-transient, non-production environment deployments with the same repository and environment")
+
+	return cmd
+}
+
+func updateRun(opts *updateOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not build http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(httpClient)
+
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	err = createDeploymentStatus(client, opts, repo)
+	if err != nil {
+		return err
+	}
+
+	if opts.IO.IsStdoutTTY() {
+		out := opts.IO.Out
+		cs := opts.IO.ColorScheme()
+		fmt.Fprintf(out, "%s Created deployment status in %s\n",
+			cs.SuccessIcon(), ghrepo.FullName(repo))
+	}
+
+	return nil
+}
+
+func createDeploymentStatus(client *api.Client, opts *updateOptions, repo ghrepo.Interface) error {
+	path := fmt.Sprintf("repos/%s/%s/deployments/%s/statuses",
+		repo.RepoOwner(), repo.RepoName(), opts.Deployment)
+
+	request := struct {
+		State          string `json:"state"`
+		LogURL         string `json:"log_url,omitempty"`
+		Description    string `json:"description,omitempty"`
+		Environment    string `json:"environment,omitempty"`
+		EnvironmentURL string `json:"environment_url,omitempty"`
+		AutoInactive   bool   `json:"auto_inactive"`
+	}{
+		State:          opts.Status,
+		LogURL:         opts.LogURL,
+		Description:    opts.Description,
+		Environment:    opts.Environment,
+		EnvironmentURL: opts.EnvironmentURL,
+		AutoInactive:   opts.AutoInactive,
+	}
+
+	requestByte, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("failed to serialize deployment status inputs: %w", err)
+	}
+
+	body := bytes.NewReader(requestByte)
+
+	opts.IO.StartProgressIndicator()
+	err = client.REST(repo.RepoHost(), "POST", path, body, nil)
+	opts.IO.StopProgressIndicator()
+
+	if err != nil {
+		return fmt.Errorf("failed to create deployment status: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/deployment/update/update_test.go
+++ b/pkg/cmd/deployment/update/update_test.go
@@ -1,0 +1,273 @@
+package update
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdList(t *testing.T) {
+	tests := []struct {
+		name     string
+		cli      string
+		wants    updateOptions
+		wantsErr bool
+	}{
+		{
+			name:     "no arguments",
+			cli:      "",
+			wantsErr: true,
+		},
+		{
+			name: "status flag",
+			cli:  "--status in_progress 1234",
+			wants: updateOptions{
+				Status:       "in_progress",
+				Deployment:   "1234",
+				AutoInactive: true,
+			},
+		},
+		{
+			name: "log-url flag",
+			cli:  "--status in_progress --log-url https://example.com 1234",
+			wants: updateOptions{
+				Status:       "in_progress",
+				LogURL:       "https://example.com",
+				Deployment:   "1234",
+				AutoInactive: true,
+			},
+		},
+		{
+			name: "description flag",
+			cli:  "--status in_progress --description 'deploying a thing' 1234",
+			wants: updateOptions{
+				Status:       "in_progress",
+				Description:  "deploying a thing",
+				Deployment:   "1234",
+				AutoInactive: true,
+			},
+		},
+		{
+			name: "environment flag",
+			cli:  "--status in_progress --environment production 1234",
+			wants: updateOptions{
+				Status:       "in_progress",
+				Environment:  "production",
+				Deployment:   "1234",
+				AutoInactive: true,
+			},
+		},
+		{
+			name: "environment-url flag",
+			cli:  "--status in_progress --environment-url https://example.com 1234",
+			wants: updateOptions{
+				Status:         "in_progress",
+				EnvironmentURL: "https://example.com",
+				Deployment:     "1234",
+				AutoInactive:   true,
+			},
+		},
+		{
+			name: "auto-inactive flag",
+			cli:  "--status in_progress --auto-inactive=false 1234",
+			wants: updateOptions{
+				Status:       "in_progress",
+				Deployment:   "1234",
+				AutoInactive: false,
+			},
+		},
+		{
+			name:     "invalid status flag",
+			cli:      "--status invalid 1234",
+			wantsErr: true,
+		},
+		{
+			name:     "invalid auto-inactive flag",
+			cli:      "--status in_progress --auto-inactive=invalid 1234",
+			wantsErr: true,
+		},
+		{
+			name:     "invalid description flag",
+			cli:      "--status in_progress --description 'this is a really long description that exceeds 140 characters in length this is a really long description that exceeds 140 characters in length' 1234",
+			wantsErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var gotOpts updateOptions
+			cmd := NewCmdUpdate(f, func(opts *updateOptions) error {
+				gotOpts = *opts
+				return nil
+			})
+
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wants.Deployment, gotOpts.Deployment)
+			assert.Equal(t, tt.wants.Status, gotOpts.Status)
+			assert.Equal(t, tt.wants.LogURL, gotOpts.LogURL)
+			assert.Equal(t, tt.wants.Description, gotOpts.Description)
+			assert.Equal(t, tt.wants.Environment, gotOpts.Environment)
+			assert.Equal(t, tt.wants.EnvironmentURL, gotOpts.EnvironmentURL)
+			assert.Equal(t, tt.wants.AutoInactive, gotOpts.AutoInactive)
+		})
+	}
+}
+
+func Test_updateRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       *updateOptions
+		isTTY      bool
+		httpStubs  func(t *testing.T, reg *httpmock.Registry)
+		wantStdout string
+		wantStderr string
+		wantErr    string
+	}{
+		{
+			name: "update deployment",
+			opts: &updateOptions{
+				Deployment:   "1234",
+				Status:       "in_progress",
+				AutoInactive: true,
+			},
+			isTTY: true,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("POST", "repos/OWNER/REPO/deployments/1234/statuses"),
+					httpmock.RESTPayload(201, `{}`, func(payload map[string]interface{}) {
+						assert.Equal(t, map[string]interface{}{
+							"state":         "in_progress",
+							"auto_inactive": true,
+						}, payload)
+					}),
+				)
+			},
+			wantStdout: "✓ Created deployment status in OWNER/REPO\n",
+		},
+		{
+			name: "update deployment with details",
+			opts: &updateOptions{
+				Deployment:     "1234",
+				Status:         "success",
+				LogURL:         "https://example.com/logs",
+				Description:    "deploying a thing",
+				Environment:    "production",
+				EnvironmentURL: "https://example.com",
+				AutoInactive:   false,
+			},
+			isTTY: true,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("POST", "repos/OWNER/REPO/deployments/1234/statuses"),
+					httpmock.RESTPayload(201, `{}`, func(payload map[string]interface{}) {
+						assert.Equal(t, map[string]interface{}{
+							"state":           "success",
+							"log_url":         "https://example.com/logs",
+							"description":     "deploying a thing",
+							"environment":     "production",
+							"environment_url": "https://example.com",
+							"auto_inactive":   false,
+						}, payload)
+					}),
+				)
+			},
+			wantStdout: "✓ Created deployment status in OWNER/REPO\n",
+		},
+		{
+			name: "no TTY",
+			opts: &updateOptions{
+				Deployment:   "12346",
+				Status:       "in_progress",
+				AutoInactive: true,
+			},
+			isTTY: false,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("POST", "repos/OWNER/REPO/deployments/12346/statuses"),
+					httpmock.RESTPayload(201, `{}`, func(payload map[string]interface{}) {
+						assert.Equal(t, map[string]interface{}{
+							"state":         "in_progress",
+							"auto_inactive": true,
+						}, payload)
+					}),
+				)
+			},
+		},
+		{
+			name: "validation failed",
+			opts: &updateOptions{
+				Deployment:   "1234",
+				Status:       "in_progress",
+				AutoInactive: true,
+			},
+			isTTY: true,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("POST", "repos/OWNER/REPO/deployments/1234/statuses"),
+					httpmock.StatusStringResponse(422, ""),
+				)
+			},
+			wantErr: "failed to create deployment status: HTTP 422 (https://api.github.com/repos/OWNER/REPO/deployments/1234/statuses)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, stdout, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStderrTTY(tt.isTTY)
+
+			fakeHTTP := &httpmock.Registry{}
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, fakeHTTP)
+			}
+			defer fakeHTTP.Verify(t)
+
+			tt.opts.IO = ios
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: fakeHTTP}, nil
+			}
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("OWNER/REPO")
+			}
+
+			err := updateRun(tt.opts)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantStdout, stdout.String())
+		})
+	}
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -16,6 +16,7 @@ import (
 	codespaceCmd "github.com/cli/cli/v2/pkg/cmd/codespace"
 	completionCmd "github.com/cli/cli/v2/pkg/cmd/completion"
 	configCmd "github.com/cli/cli/v2/pkg/cmd/config"
+	deploymentCmd "github.com/cli/cli/v2/pkg/cmd/deployment"
 	extensionCmd "github.com/cli/cli/v2/pkg/cmd/extension"
 	"github.com/cli/cli/v2/pkg/cmd/factory"
 	gistCmd "github.com/cli/cli/v2/pkg/cmd/gist"
@@ -153,6 +154,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 	cmd.AddCommand(workflowCmd.NewCmdWorkflow(&repoResolvingCmdFactory))
 	cmd.AddCommand(labelCmd.NewCmdLabel(&repoResolvingCmdFactory))
 	cmd.AddCommand(cacheCmd.NewCmdCache(&repoResolvingCmdFactory))
+	cmd.AddCommand(deploymentCmd.NewCmdDeployment(&repoResolvingCmdFactory))
 	cmd.AddCommand(apiCmd.NewCmdApi(&repoResolvingCmdFactory, nil))
 
 	// Help topics


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/5541.

Manage GitHub deployments using `gh deployment` commands.

https://docs.github.com/en/rest/deployments/deployments

This is my first serious bit of Go and I made good use of Copilot to get though some of this so feedback very welcome!

### Usage

Basic overview of the four commands, further detail is included as examples in each command.

```bash
# Create a deployment on the current branch
$ gh deployment create --status in_progress

# Update a deployment to success
$ gh deployment update --status success 1234

# List deployments in the current repo
$ gh deployment list

# Delete a deployment
$ gh deployment delete 1234
```