### PR TITLE
Support `project view --web` with TTY

### DIFF
--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -29,16 +29,31 @@ func NewClient(httpClient *http.Client, hostname string, ios *iostreams.IOStream
 	}
 }
 
-func NewTestClient() *Client {
+// TestClientOpt is a test option for the test client.
+type TestClientOpt func(*Client)
+
+// WithPrompter is a test option to set the prompter for the test client.
+func WithPrompter(p iprompter) TestClientOpt {
+	return func(c *Client) {
+		c.prompter = p
+	}
+}
+
+func NewTestClient(opts ...TestClientOpt) *Client {
 	apiClient := &hostScopedClient{
 		hostname: "github.com",
 		Client:   api.NewClientFromHTTP(http.DefaultClient),
 	}
-	return &Client{
+	c := &Client{
 		apiClient: apiClient,
 		spinner:   false,
 		prompter:  nil,
 	}
+
+	for _, o := range opts {
+		o(c)
+	}
+	return c
 }
 
 type iprompter interface {

--- a/pkg/cmd/project/view/view.go
+++ b/pkg/cmd/project/view/view.go
@@ -82,6 +82,17 @@ func NewCmdView(f *cmdutil.Factory, runF func(config viewConfig) error) *cobra.C
 }
 
 func runView(config viewConfig) error {
+	canPrompt := config.io.CanPrompt()
+	owner, err := config.client.NewOwner(canPrompt, config.opts.owner)
+	if err != nil {
+		return err
+	}
+
+	project, err := config.client.NewProject(canPrompt, owner, config.opts.number, true)
+	if err != nil {
+		return err
+	}
+
 	if config.opts.web {
 		url, err := buildURL(config)
 		if err != nil {
@@ -92,17 +103,6 @@ func runView(config viewConfig) error {
 			return err
 		}
 		return nil
-	}
-
-	canPrompt := config.io.CanPrompt()
-	owner, err := config.client.NewOwner(canPrompt, config.opts.owner)
-	if err != nil {
-		return err
-	}
-
-	project, err := config.client.NewProject(canPrompt, owner, config.opts.number, true)
-	if err != nil {
-		return err
 	}
 
 	if config.opts.exporter != nil {

--- a/pkg/cmd/project/view/view.go
+++ b/pkg/cmd/project/view/view.go
@@ -94,12 +94,7 @@ func runView(config viewConfig) error {
 	}
 
 	if config.opts.web {
-		url, err := buildURL(config)
-		if err != nil {
-			return err
-		}
-
-		if err := config.URLOpener(url); err != nil {
+		if err := config.URLOpener(project.URL); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/cmd/project/view/view.go
+++ b/pkg/cmd/project/view/view.go
@@ -107,31 +107,6 @@ func runView(config viewConfig) error {
 	return printResults(config, project)
 }
 
-// TODO: support non-github.com hostnames
-func buildURL(config viewConfig) (string, error) {
-	var url string
-	if config.opts.owner == "@me" {
-		owner, err := config.client.ViewerLoginName()
-		if err != nil {
-			return "", err
-		}
-		url = fmt.Sprintf("https://github.com/users/%s/projects/%d", owner, config.opts.number)
-	} else {
-		_, ownerType, err := config.client.OwnerIDAndType(config.opts.owner)
-		if err != nil {
-			return "", err
-		}
-
-		if ownerType == queries.UserOwner {
-			url = fmt.Sprintf("https://github.com/users/%s/projects/%d", config.opts.owner, config.opts.number)
-		} else {
-			url = fmt.Sprintf("https://github.com/orgs/%s/projects/%d", config.opts.owner, config.opts.number)
-		}
-	}
-
-	return url, nil
-}
-
 func printResults(config viewConfig, project *queries.Project) error {
 	var sb strings.Builder
 	sb.WriteString("# Title\n")

--- a/pkg/cmd/project/view/view.go
+++ b/pkg/cmd/project/view/view.go
@@ -94,10 +94,7 @@ func runView(config viewConfig) error {
 	}
 
 	if config.opts.web {
-		if err := config.URLOpener(project.URL); err != nil {
-			return err
-		}
-		return nil
+		return config.URLOpener(project.URL)
 	}
 
 	if config.opts.exporter != nil {

--- a/pkg/cmd/project/view/view_test.go
+++ b/pkg/cmd/project/view/view_test.go
@@ -91,35 +91,6 @@ func TestNewCmdview(t *testing.T) {
 	}
 }
 
-func TestBuildURLViewer(t *testing.T) {
-	defer gock.Off()
-
-	gock.New("https://api.github.com").
-		Post("/graphql").
-		Reply(200).
-		JSON(`
-			{"data":
-				{"viewer":
-					{
-						"login":"theviewer"
-					}
-				}
-			}
-		`)
-
-	client := queries.NewTestClient()
-
-	url, err := buildURL(viewConfig{
-		opts: viewOpts{
-			number: 1,
-			owner:  "@me",
-		},
-		client: client,
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "https://github.com/users/theviewer/projects/1", url)
-}
-
 func TestRunView_User(t *testing.T) {
 	defer gock.Off()
 


### PR DESCRIPTION
Fixes #8721 

This PR fixes `gh project view --web` in TTY mode. The issue was that we were checking if `web` mode is enabled before prompting for the owner and project selections. This caused the prompt to be skipped and the resulting URL to be filled with empty values for `owner` and `project`.

Ex:
```
https://github.com/users//projects/0
```

The main fix was to move the prompt for owner and project selections to the top of the function, before checking if `web` mode is enabled.

I also removed the use of [`buildURL`](https://github.com/harveysanders/cli/blob/313b482e7a24beaeb82a77ad31e3996a5f6228e4/pkg/cmd/project/view/view.go#L111-L133) as all the GraphQL API responses already contain the URL for the project.

Let me know if `buildURL` is still needed for some reason and I'll refactor. I tested `project view` in both TTY and non-TTY modes and it's working as expected.

I add the `url` field in the GraphQL mocks in existing tests to mirror the real responses.

If you agree `buildURL` is not needed, I'll remove it and and it's associated test. It's only used in the test now.