### PR TITLE
feat: consistent issue and PR owner/repo#number in various prompt

### DIFF
--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -73,7 +73,7 @@ func closeRun(opts *CloseOptions) error {
 	}
 
 	if issue.State == "CLOSED" {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Issue #%d (%s) is already closed\n", cs.Yellow("!"), issue.Number, issue.Title)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Issue %s#%d (%s) is already closed\n", cs.Yellow("!"), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 		return nil
 	}
 
@@ -98,7 +98,7 @@ func closeRun(opts *CloseOptions) error {
 		return err
 	}
 
-	fmt.Fprintf(opts.IO.ErrOut, "%s Closed issue #%d (%s)\n", cs.SuccessIconWithColor(cs.Red), issue.Number, issue.Title)
+	fmt.Fprintf(opts.IO.ErrOut, "%s Closed issue %s#%d (%s)\n", cs.SuccessIconWithColor(cs.Red), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 
 	return nil
 }

--- a/pkg/cmd/issue/close/close_test.go
+++ b/pkg/cmd/issue/close/close_test.go
@@ -123,7 +123,7 @@ func TestCloseRun(t *testing.T) {
 						}),
 				)
 			},
-			wantStderr: "✓ Closed issue #13 (The title of the issue)\n",
+			wantStderr: "✓ Closed issue OWNER/REPO#13 (The title of the issue)\n",
 		},
 		{
 			name: "close issue with comment",
@@ -159,7 +159,7 @@ func TestCloseRun(t *testing.T) {
 						}),
 				)
 			},
-			wantStderr: "✓ Closed issue #13 (The title of the issue)\n",
+			wantStderr: "✓ Closed issue OWNER/REPO#13 (The title of the issue)\n",
 		},
 		{
 			name: "close issue with reason",
@@ -187,7 +187,7 @@ func TestCloseRun(t *testing.T) {
 						}),
 				)
 			},
-			wantStderr: "✓ Closed issue #13 (The title of the issue)\n",
+			wantStderr: "✓ Closed issue OWNER/REPO#13 (The title of the issue)\n",
 		},
 		{
 			name: "close issue with reason when reason is not supported",
@@ -214,7 +214,7 @@ func TestCloseRun(t *testing.T) {
 						}),
 				)
 			},
-			wantStderr: "✓ Closed issue #13 (The title of the issue)\n",
+			wantStderr: "✓ Closed issue OWNER/REPO#13 (The title of the issue)\n",
 		},
 		{
 			name: "issue already closed",
@@ -231,7 +231,7 @@ func TestCloseRun(t *testing.T) {
             } } }`),
 				)
 			},
-			wantStderr: "! Issue #13 (The title of the issue) is already closed\n",
+			wantStderr: "! Issue OWNER/REPO#13 (The title of the issue) is already closed\n",
 		},
 		{
 			name: "issues disabled",

--- a/pkg/cmd/issue/delete/delete.go
+++ b/pkg/cmd/issue/delete/delete.go
@@ -76,7 +76,7 @@ func deleteRun(opts *DeleteOptions) error {
 		return err
 	}
 	if issue.IsPullRequest() {
-		return fmt.Errorf("issue #%d is a pull request and cannot be deleted", issue.Number)
+		return fmt.Errorf("issue %s#%d is a pull request and cannot be deleted", ghrepo.FullName(baseRepo), issue.Number)
 	}
 
 	// When executed in an interactive shell, require confirmation, unless
@@ -95,7 +95,7 @@ func deleteRun(opts *DeleteOptions) error {
 	}
 
 	if opts.IO.IsStdoutTTY() {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Deleted issue #%d (%s).\n", cs.Red("✔"), issue.Number, issue.Title)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Deleted issue %s#%d (%s).\n", cs.Red("✔"), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 	}
 
 	return nil

--- a/pkg/cmd/issue/delete/delete_test.go
+++ b/pkg/cmd/issue/delete/delete_test.go
@@ -86,7 +86,7 @@ func TestIssueDelete(t *testing.T) {
 		t.Fatalf("error running command `issue delete`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Deleted issue #13 \(The title of the issue\)`)
+	r := regexp.MustCompile(`Deleted issue OWNER/REPO#13 \(The title of the issue\)`)
 
 	if !r.MatchString(output.Stderr()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
@@ -118,7 +118,7 @@ func TestIssueDelete_confirm(t *testing.T) {
 		t.Fatalf("error running command `issue delete`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Deleted issue #13 \(The title of the issue\)`)
+	r := regexp.MustCompile(`Deleted issue OWNER/REPO#13 \(The title of the issue\)`)
 
 	if !r.MatchString(output.Stderr()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())

--- a/pkg/cmd/issue/develop/develop.go
+++ b/pkg/cmd/issue/develop/develop.go
@@ -171,7 +171,7 @@ func developRunCreate(opts *DevelopOptions, apiClient *api.Client, issueRepo ghr
 		return err
 	}
 
-	fmt.Fprintf(opts.IO.Out, "%s/%s/%s/tree/%s\n", branchRepo.RepoHost(), branchRepo.RepoOwner(), branchRepo.RepoName(), branchName)
+	fmt.Fprintf(opts.IO.Out, "%s/%s/tree/%s\n", branchRepo.RepoHost(), ghrepo.FullName(branchRepo), branchName)
 
 	return checkoutBranch(opts, branchRepo, branchName)
 }
@@ -185,11 +185,11 @@ func developRunList(opts *DevelopOptions, apiClient *api.Client, issueRepo ghrep
 	}
 
 	if len(branches) == 0 {
-		return cmdutil.NewNoResultsError(fmt.Sprintf("no linked branches found for %s/%s#%d", issueRepo.RepoOwner(), issueRepo.RepoName(), issue.Number))
+		return cmdutil.NewNoResultsError(fmt.Sprintf("no linked branches found for %s#%d", ghrepo.FullName(issueRepo), issue.Number))
 	}
 
 	if opts.IO.IsStdoutTTY() {
-		fmt.Fprintf(opts.IO.Out, "\nShowing linked branches for %s/%s#%d\n\n", issueRepo.RepoOwner(), issueRepo.RepoName(), issue.Number)
+		fmt.Fprintf(opts.IO.Out, "\nShowing linked branches for %s#%d\n\n", ghrepo.FullName(issueRepo), issue.Number)
 	}
 
 	printLinkedBranches(opts.IO, branches)

--- a/pkg/cmd/issue/lock/lock_test.go
+++ b/pkg/cmd/issue/lock/lock_test.go
@@ -234,7 +234,7 @@ func Test_runLock(t *testing.T) {
 					return -1, prompter.NoSuchPromptErr(p)
 				}
 			},
-			wantOut: "✓ Locked as TOO_HEATED: Issue #451 (traverse the library)\n",
+			wantOut: "✓ Locked as TOO_HEATED: Issue OWNER/REPO#451 (traverse the library)\n",
 		},
 		{
 			name:  "lock issue with explicit reason tty",
@@ -261,7 +261,7 @@ func Test_runLock(t *testing.T) {
 						      "lockedRecord": {
 						        "locked": true }}}}`))
 			},
-			wantOut: "✓ Locked as OFF_TOPIC: Issue #451 (traverse the library)\n",
+			wantOut: "✓ Locked as OFF_TOPIC: Issue OWNER/REPO#451 (traverse the library)\n",
 		},
 		{
 			name:  "unlock issue tty",
@@ -288,7 +288,7 @@ func Test_runLock(t *testing.T) {
 						      "unlockedRecord": {
 						        "locked": false }}}}`))
 			},
-			wantOut: "✓ Unlocked: Issue #451 (traverse the library)\n",
+			wantOut: "✓ Unlocked: Issue OWNER/REPO#451 (traverse the library)\n",
 		},
 		{
 			name:  "unlock issue nontty",
@@ -375,14 +375,14 @@ func Test_runLock(t *testing.T) {
 			},
 			promptStubs: func(t *testing.T, pm *prompter.PrompterMock) {
 				pm.ConfirmFunc = func(p string, d bool) (bool, error) {
-					if p == "Issue #451 already locked. Unlock and lock again as OFF_TOPIC?" {
+					if p == "Issue OWNER/REPO#451 already locked. Unlock and lock again as OFF_TOPIC?" {
 						return true, nil
 					}
 
 					return false, prompter.NoSuchPromptErr(p)
 				}
 			},
-			wantOut: "✓ Locked as OFF_TOPIC: Issue #451 (traverse the library)\n",
+			wantOut: "✓ Locked as OFF_TOPIC: Issue OWNER/REPO#451 (traverse the library)\n",
 		},
 		{
 			name:  "relock issue nontty",
@@ -462,7 +462,7 @@ func Test_runLock(t *testing.T) {
 					return -1, prompter.NoSuchPromptErr(p)
 				}
 			},
-			wantOut: "✓ Locked as TOO_HEATED: Pull request #451 (traverse the library)\n",
+			wantOut: "✓ Locked as TOO_HEATED: Pull request OWNER/REPO#451 (traverse the library)\n",
 		},
 		{
 			name:  "lock pr with explicit reason tty",
@@ -489,7 +489,7 @@ func Test_runLock(t *testing.T) {
 						      "lockedRecord": {
 						        "locked": true }}}}`))
 			},
-			wantOut: "✓ Locked as OFF_TOPIC: Pull request #451 (traverse the library)\n",
+			wantOut: "✓ Locked as OFF_TOPIC: Pull request OWNER/REPO#451 (traverse the library)\n",
 		},
 		{
 			name:  "lock pr with explicit nontty",
@@ -566,7 +566,7 @@ func Test_runLock(t *testing.T) {
 						      "unlockedRecord": {
 						        "locked": false }}}}`))
 			},
-			wantOut: "✓ Unlocked: Pull request #451 (traverse the library)\n",
+			wantOut: "✓ Unlocked: Pull request OWNER/REPO#451 (traverse the library)\n",
 		},
 		{
 			name:  "relock pr tty",
@@ -603,14 +603,14 @@ func Test_runLock(t *testing.T) {
 			},
 			promptStubs: func(t *testing.T, pm *prompter.PrompterMock) {
 				pm.ConfirmFunc = func(p string, d bool) (bool, error) {
-					if p == "Pull request #451 already locked. Unlock and lock again as OFF_TOPIC?" {
+					if p == "Pull request OWNER/REPO#451 already locked. Unlock and lock again as OFF_TOPIC?" {
 						return true, nil
 					}
 
 					return false, prompter.NoSuchPromptErr(p)
 				}
 			},
-			wantOut: "✓ Locked as OFF_TOPIC: Pull request #451 (traverse the library)\n",
+			wantOut: "✓ Locked as OFF_TOPIC: Pull request OWNER/REPO#451 (traverse the library)\n",
 		},
 		{
 			name:  "relock pr nontty",

--- a/pkg/cmd/issue/pin/pin.go
+++ b/pkg/cmd/issue/pin/pin.go
@@ -79,7 +79,7 @@ func pinRun(opts *PinOptions) error {
 	}
 
 	if issue.IsPinned {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Issue #%d (%s) is already pinned to %s\n", cs.Yellow("!"), issue.Number, issue.Title, ghrepo.FullName(baseRepo))
+		fmt.Fprintf(opts.IO.ErrOut, "%s Issue %s#%d (%s) is already pinned\n", cs.Yellow("!"), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 		return nil
 	}
 
@@ -88,7 +88,7 @@ func pinRun(opts *PinOptions) error {
 		return err
 	}
 
-	fmt.Fprintf(opts.IO.ErrOut, "%s Pinned issue #%d (%s) to %s\n", cs.SuccessIcon(), issue.Number, issue.Title, ghrepo.FullName(baseRepo))
+	fmt.Fprintf(opts.IO.ErrOut, "%s Pinned issue %s#%d (%s)\n", cs.SuccessIcon(), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 
 	return nil
 }

--- a/pkg/cmd/issue/pin/pin_test.go
+++ b/pkg/cmd/issue/pin/pin_test.go
@@ -107,7 +107,7 @@ func TestPinRun(t *testing.T) {
 				)
 			},
 			wantStdout: "",
-			wantStderr: "✓ Pinned issue #20 (Issue Title) to OWNER/REPO\n",
+			wantStderr: "✓ Pinned issue OWNER/REPO#20 (Issue Title)\n",
 		},
 		{
 			name: "issue already pinned",
@@ -122,7 +122,7 @@ func TestPinRun(t *testing.T) {
             } } }`),
 				)
 			},
-			wantStderr: "! Issue #20 (Issue Title) is already pinned to OWNER/REPO\n",
+			wantStderr: "! Issue OWNER/REPO#20 (Issue Title) is already pinned\n",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/issue/reopen/reopen.go
+++ b/pkg/cmd/issue/reopen/reopen.go
@@ -70,7 +70,7 @@ func reopenRun(opts *ReopenOptions) error {
 	}
 
 	if issue.State == "OPEN" {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Issue #%d (%s) is already open\n", cs.Yellow("!"), issue.Number, issue.Title)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Issue %s#%d (%s) is already open\n", cs.Yellow("!"), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 		return nil
 	}
 
@@ -95,7 +95,7 @@ func reopenRun(opts *ReopenOptions) error {
 		return err
 	}
 
-	fmt.Fprintf(opts.IO.ErrOut, "%s Reopened issue #%d (%s)\n", cs.SuccessIconWithColor(cs.Green), issue.Number, issue.Title)
+	fmt.Fprintf(opts.IO.ErrOut, "%s Reopened issue %s#%d (%s)\n", cs.SuccessIconWithColor(cs.Green), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 
 	return nil
 }

--- a/pkg/cmd/issue/reopen/reopen_test.go
+++ b/pkg/cmd/issue/reopen/reopen_test.go
@@ -80,7 +80,7 @@ func TestIssueReopen(t *testing.T) {
 		t.Fatalf("error running command `issue reopen`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Reopened issue #2 \(The title of the issue\)`)
+	r := regexp.MustCompile(`Reopened issue OWNER/REPO#2 \(The title of the issue\)`)
 
 	if !r.MatchString(output.Stderr()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
@@ -105,7 +105,7 @@ func TestIssueReopen_alreadyOpen(t *testing.T) {
 		t.Fatalf("error running command `issue reopen`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Issue #2 \(The title of the issue\) is already open`)
+	r := regexp.MustCompile(`Issue OWNER/REPO#2 \(The title of the issue\) is already open`)
 
 	if !r.MatchString(output.Stderr()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
@@ -181,7 +181,7 @@ func TestIssueReopen_withComment(t *testing.T) {
 		t.Fatalf("error running command `issue reopen`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Reopened issue #2 \(The title of the issue\)`)
+	r := regexp.MustCompile(`Reopened issue OWNER/REPO#2 \(The title of the issue\)`)
 
 	if !r.MatchString(output.Stderr()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())

--- a/pkg/cmd/issue/transfer/transfer.go
+++ b/pkg/cmd/issue/transfer/transfer.go
@@ -62,7 +62,7 @@ func transferRun(opts *TransferOptions) error {
 		return err
 	}
 	if issue.IsPullRequest() {
-		return fmt.Errorf("issue #%d is a pull request and cannot be transferred", issue.Number)
+		return fmt.Errorf("issue %s#%d is a pull request and cannot be transferred", ghrepo.FullName(baseRepo), issue.Number)
 	}
 
 	destRepo, err := ghrepo.FromFullNameWithHost(opts.DestRepoSelector, baseRepo.RepoHost())

--- a/pkg/cmd/issue/unpin/unpin.go
+++ b/pkg/cmd/issue/unpin/unpin.go
@@ -79,7 +79,7 @@ func unpinRun(opts *UnpinOptions) error {
 	}
 
 	if !issue.IsPinned {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Issue #%d (%s) is not pinned to %s\n", cs.Yellow("!"), issue.Number, issue.Title, ghrepo.FullName(baseRepo))
+		fmt.Fprintf(opts.IO.ErrOut, "%s Issue %s#%d (%s) is not pinned\n", cs.Yellow("!"), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 		return nil
 	}
 
@@ -88,7 +88,7 @@ func unpinRun(opts *UnpinOptions) error {
 		return err
 	}
 
-	fmt.Fprintf(opts.IO.ErrOut, "%s Unpinned issue #%d (%s) from %s\n", cs.SuccessIconWithColor(cs.Red), issue.Number, issue.Title, ghrepo.FullName(baseRepo))
+	fmt.Fprintf(opts.IO.ErrOut, "%s Unpinned issue %s#%d (%s)\n", cs.SuccessIconWithColor(cs.Red), ghrepo.FullName(baseRepo), issue.Number, issue.Title)
 
 	return nil
 }

--- a/pkg/cmd/issue/unpin/unpin_test.go
+++ b/pkg/cmd/issue/unpin/unpin_test.go
@@ -107,7 +107,7 @@ func TestUnpinRun(t *testing.T) {
 				)
 			},
 			wantStdout: "",
-			wantStderr: "✓ Unpinned issue #20 (Issue Title) from OWNER/REPO\n",
+			wantStderr: "✓ Unpinned issue OWNER/REPO#20 (Issue Title)\n",
 		},
 		{
 			name: "issue not pinned",
@@ -122,7 +122,7 @@ func TestUnpinRun(t *testing.T) {
             } } }`),
 				)
 			},
-			wantStderr: "! Issue #20 (Issue Title) is not pinned to OWNER/REPO\n",
+			wantStderr: "! Issue OWNER/REPO#20 (Issue Title) is not pinned\n",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -183,7 +183,7 @@ func TestIssueView_tty_Preview(t *testing.T) {
 		"Open issue without metadata": {
 			fixture: "./fixtures/issueView_preview.json",
 			expectedOutputs: []string{
-				`ix of coins #123`,
+				`ix of coins OWNER/REPO#123`,
 				`Open.*marseilles opened about 9 years ago.*9 comments`,
 				`bold story`,
 				`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`,
@@ -192,7 +192,7 @@ func TestIssueView_tty_Preview(t *testing.T) {
 		"Open issue with metadata": {
 			fixture: "./fixtures/issueView_previewWithMetadata.json",
 			expectedOutputs: []string{
-				`ix of coins #123`,
+				`ix of coins OWNER/REPO#123`,
 				`Open.*marseilles opened about 9 years ago.*9 comments`,
 				`8 \x{1f615} • 7 \x{1f440} • 6 \x{2764}\x{fe0f} • 5 \x{1f389} • 4 \x{1f604} • 3 \x{1f680} • 2 \x{1f44e} • 1 \x{1f44d}`,
 				`Assignees:.*marseilles, monaco\n`,
@@ -206,7 +206,7 @@ func TestIssueView_tty_Preview(t *testing.T) {
 		"Open issue with empty body": {
 			fixture: "./fixtures/issueView_previewWithEmptyBody.json",
 			expectedOutputs: []string{
-				`ix of coins #123`,
+				`ix of coins OWNER/REPO#123`,
 				`Open.*marseilles opened about 9 years ago.*9 comments`,
 				`No description provided`,
 				`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`,
@@ -215,7 +215,7 @@ func TestIssueView_tty_Preview(t *testing.T) {
 		"Closed issue": {
 			fixture: "./fixtures/issueView_previewClosedState.json",
 			expectedOutputs: []string{
-				`ix of coins #123`,
+				`ix of coins OWNER/REPO#123`,
 				`Closed.*marseilles opened about 9 years ago.*9 comments`,
 				`bold story`,
 				`View this issue on GitHub: https://github.com/OWNER/REPO/issues/123`,
@@ -329,7 +329,7 @@ func TestIssueView_tty_Comments(t *testing.T) {
 				"IssueByNumber": "./fixtures/issueView_previewSingleComment.json",
 			},
 			expectedOutputs: []string{
-				`some title #123`,
+				`some title OWNER/REPO#123`,
 				`some body`,
 				`———————— Not showing 5 comments ————————`,
 				`marseilles \(Collaborator\) • Jan  1, 2020 • Newest comment`,
@@ -345,7 +345,7 @@ func TestIssueView_tty_Comments(t *testing.T) {
 				"CommentsForIssue": "./fixtures/issueView_previewFullComments.json",
 			},
 			expectedOutputs: []string{
-				`some title #123`,
+				`some title OWNER/REPO#123`,
 				`some body`,
 				`monalisa • Jan  1, 2020 • Edited`,
 				`1 \x{1f615} • 2 \x{1f440} • 3 \x{2764}\x{fe0f} • 4 \x{1f389} • 5 \x{1f604} • 6 \x{1f680} • 7 \x{1f44e} • 8 \x{1f44d}`,

--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -75,10 +75,10 @@ func closeRun(opts *CloseOptions) error {
 	}
 
 	if pr.State == "MERGED" {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d (%s) can't be closed because it was already merged\n", cs.FailureIcon(), pr.Number, pr.Title)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d (%s) can't be closed because it was already merged\n", cs.FailureIcon(), ghrepo.FullName(baseRepo), pr.Number, pr.Title)
 		return cmdutil.SilentError
 	} else if !pr.IsOpen() {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d (%s) is already closed\n", cs.WarningIcon(), pr.Number, pr.Title)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d (%s) is already closed\n", cs.WarningIcon(), ghrepo.FullName(baseRepo), pr.Number, pr.Title)
 		return nil
 	}
 
@@ -108,7 +108,7 @@ func closeRun(opts *CloseOptions) error {
 		return fmt.Errorf("API call failed: %w", err)
 	}
 
-	fmt.Fprintf(opts.IO.ErrOut, "%s Closed pull request #%d (%s)\n", cs.SuccessIconWithColor(cs.Red), pr.Number, pr.Title)
+	fmt.Fprintf(opts.IO.ErrOut, "%s Closed pull request %s#%d (%s)\n", cs.SuccessIconWithColor(cs.Red), ghrepo.FullName(baseRepo), pr.Number, pr.Title)
 
 	if opts.DeleteBranch {
 		ctx := context.Background()

--- a/pkg/cmd/pr/close/close_test.go
+++ b/pkg/cmd/pr/close/close_test.go
@@ -123,7 +123,7 @@ func TestPrClose(t *testing.T) {
 	output, err := runCommand(http, true, "96")
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Closed pull request #96 (The title of the PR)\n", output.Stderr())
+	assert.Equal(t, "✓ Closed pull request OWNER/REPO#96 (The title of the PR)\n", output.Stderr())
 }
 
 func TestPrClose_alreadyClosed(t *testing.T) {
@@ -138,7 +138,7 @@ func TestPrClose_alreadyClosed(t *testing.T) {
 	output, err := runCommand(http, true, "96")
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "! Pull request #96 (The title of the PR) is already closed\n", output.Stderr())
+	assert.Equal(t, "! Pull request OWNER/REPO#96 (The title of the PR) is already closed\n", output.Stderr())
 }
 
 func TestPrClose_deleteBranch_sameRepo(t *testing.T) {
@@ -170,7 +170,7 @@ func TestPrClose_deleteBranch_sameRepo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Doc(`
-		✓ Closed pull request #96 (The title of the PR)
+		✓ Closed pull request OWNER/REPO#96 (The title of the PR)
 		✓ Deleted branch blueberries
 	`), output.Stderr())
 }
@@ -201,7 +201,7 @@ func TestPrClose_deleteBranch_crossRepo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Doc(`
-		✓ Closed pull request #96 (The title of the PR)
+		✓ Closed pull request OWNER/REPO#96 (The title of the PR)
 		! Skipped deleting the remote branch of a pull request from fork
 		✓ Deleted branch blueberries
 	`), output.Stderr())
@@ -237,7 +237,7 @@ func TestPrClose_deleteBranch_sameBranch(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Doc(`
-		✓ Closed pull request #96 (The title of the PR)
+		✓ Closed pull request OWNER/REPO#96 (The title of the PR)
 		✓ Deleted branch trunk and switched to branch main
 	`), output.Stderr())
 }
@@ -270,7 +270,7 @@ func TestPrClose_deleteBranch_notInGitRepo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Doc(`
-		✓ Closed pull request #96 (The title of the PR)
+		✓ Closed pull request OWNER/REPO#96 (The title of the PR)
 		! Skipped deleting the local branch since current directory is not a git repository 
 		✓ Deleted branch trunk
 	`), output.Stderr())
@@ -306,5 +306,5 @@ func TestPrClose_withComment(t *testing.T) {
 	output, err := runCommand(http, true, "96 --comment 'closing comment'")
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Closed pull request #96 (The title of the PR)\n", output.Stderr())
+	assert.Equal(t, "✓ Closed pull request OWNER/REPO#96 (The title of the PR)\n", output.Stderr())
 }

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -207,14 +207,14 @@ func (m *mergeContext) disableAutoMerge() error {
 	if err := disableAutoMerge(m.httpClient, m.baseRepo, m.pr.ID); err != nil {
 		return err
 	}
-	return m.infof("%s Auto-merge disabled for pull request #%d\n", m.cs.SuccessIconWithColor(m.cs.Green), m.pr.Number)
+	return m.infof("%s Auto-merge disabled for pull request %s#%d\n", m.cs.SuccessIconWithColor(m.cs.Green), ghrepo.FullName(m.baseRepo), m.pr.Number)
 }
 
 // Check if this pull request is in a merge queue
 func (m *mergeContext) inMergeQueue() error {
 	// if the pull request is in a merge queue no further action is possible
 	if m.pr.IsInMergeQueue {
-		_ = m.warnf("%s Pull request #%d is already queued to merge\n", m.cs.WarningIcon(), m.pr.Number)
+		_ = m.warnf("%s Pull request %s#%d is already queued to merge\n", m.cs.WarningIcon(), ghrepo.FullName(m.baseRepo), m.pr.Number)
 		return ErrAlreadyInMergeQueue
 	}
 	return nil
@@ -251,7 +251,7 @@ func (m *mergeContext) canMerge() error {
 		return nil
 	}
 
-	_ = m.warnf("%s Pull request #%d is not mergeable: %s.\n", m.cs.FailureIcon(), m.pr.Number, reason)
+	_ = m.warnf("%s Pull request %s#%d is not mergeable: %s.\n", m.cs.FailureIcon(), ghrepo.FullName(m.baseRepo), m.pr.Number, reason)
 	_ = m.warnf("To have the pull request merged after all the requirements have been met, add the `--auto` flag.\n")
 	if remote := remoteForMergeConflictResolution(m.baseRepo, m.pr, m.opts); remote != nil {
 		mergeOrRebase := "merge"
@@ -344,7 +344,7 @@ func (m *mergeContext) merge() error {
 	}
 
 	if m.shouldAddToMergeQueue() {
-		_ = m.infof("%s Pull request #%d will be added to the merge queue for %s when ready\n", m.cs.SuccessIconWithColor(m.cs.Green), m.pr.Number, m.pr.BaseRefName)
+		_ = m.infof("%s Pull request %s#%d will be added to the merge queue for %s when ready\n", m.cs.SuccessIconWithColor(m.cs.Green), ghrepo.FullName(m.baseRepo), m.pr.Number, m.pr.BaseRefName)
 		return nil
 	}
 
@@ -356,7 +356,7 @@ func (m *mergeContext) merge() error {
 		case PullRequestMergeMethodSquash:
 			method = " via squash"
 		}
-		return m.infof("%s Pull request #%d will be automatically merged%s when all requirements are met\n", m.cs.SuccessIconWithColor(m.cs.Green), m.pr.Number, method)
+		return m.infof("%s Pull request %s#%d will be automatically merged%s when all requirements are met\n", m.cs.SuccessIconWithColor(m.cs.Green), ghrepo.FullName(m.baseRepo), m.pr.Number, method)
 	}
 
 	action := "Merged"
@@ -377,13 +377,13 @@ func (m *mergeContext) deleteLocalBranch() error {
 
 	if m.merged {
 		if m.opts.IO.CanPrompt() && !m.opts.IsDeleteBranchIndicated {
-			confirmed, err := m.opts.Prompter.Confirm(fmt.Sprintf("Pull request #%d was already merged. Delete the branch locally?", m.pr.Number), false)
+			confirmed, err := m.opts.Prompter.Confirm(fmt.Sprintf("Pull request %s#%d was already merged. Delete the branch locally?", ghrepo.FullName(m.baseRepo), m.pr.Number), false)
 			if err != nil {
 				return fmt.Errorf("could not prompt: %w", err)
 			}
 			m.deleteBranch = confirmed
 		} else {
-			_ = m.warnf(fmt.Sprintf("%s Pull request #%d was already merged\n", m.cs.WarningIcon(), m.pr.Number))
+			_ = m.warnf(fmt.Sprintf("%s Pull request %s#%d was already merged\n", m.cs.WarningIcon(), ghrepo.FullName(m.baseRepo), m.pr.Number))
 		}
 	}
 

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -235,7 +235,7 @@ func (m *mergeContext) warnIfDiverged() {
 		return
 	}
 
-	_ = m.warnf("%s Pull request #%d (%s) has diverged from local branch\n", m.cs.Yellow("!"), m.pr.Number, m.pr.Title)
+	_ = m.warnf("%s Pull request %s/%s#%d (%s) has diverged from local branch\n", m.cs.Yellow("!"), m.baseRepo.RepoOwner(), m.baseRepo.RepoName(), m.pr.Number, m.pr.Title)
 }
 
 // Check if the current state of the pull request allows for merging
@@ -302,7 +302,7 @@ func (m *mergeContext) merge() error {
 				return cmdutil.FlagErrorf("--merge, --rebase, or --squash required when not running interactively")
 			}
 
-			_ = m.infof("Merging pull request #%d (%s)\n", m.pr.Number, m.pr.Title)
+			_ = m.infof("Merging pull request %s/%s#%d (%s)\n", m.baseRepo.RepoOwner(), m.baseRepo.RepoName(), m.pr.Number, m.pr.Title)
 
 			apiClient := api.NewClientFromHTTP(m.httpClient)
 			r, err := api.GitHubRepo(apiClient, m.baseRepo)
@@ -366,7 +366,7 @@ func (m *mergeContext) merge() error {
 	case PullRequestMergeMethodSquash:
 		action = "Squashed and merged"
 	}
-	return m.infof("%s %s pull request #%d (%s)\n", m.cs.SuccessIconWithColor(m.cs.Magenta), action, m.pr.Number, m.pr.Title)
+	return m.infof("%s %s pull request %s/%s#%d (%s)\n", m.cs.SuccessIconWithColor(m.cs.Magenta), action, m.baseRepo.RepoOwner(), m.baseRepo.RepoName(), m.pr.Number, m.pr.Title)
 }
 
 // Delete local branch if requested and if allowed.

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -235,7 +235,7 @@ func (m *mergeContext) warnIfDiverged() {
 		return
 	}
 
-	_ = m.warnf("%s Pull request %s/%s#%d (%s) has diverged from local branch\n", m.cs.Yellow("!"), m.baseRepo.RepoOwner(), m.baseRepo.RepoName(), m.pr.Number, m.pr.Title)
+	_ = m.warnf("%s Pull request %s#%d (%s) has diverged from local branch\n", m.cs.Yellow("!"), ghrepo.FullName(m.baseRepo), m.pr.Number, m.pr.Title)
 }
 
 // Check if the current state of the pull request allows for merging
@@ -302,7 +302,7 @@ func (m *mergeContext) merge() error {
 				return cmdutil.FlagErrorf("--merge, --rebase, or --squash required when not running interactively")
 			}
 
-			_ = m.infof("Merging pull request %s/%s#%d (%s)\n", m.baseRepo.RepoOwner(), m.baseRepo.RepoName(), m.pr.Number, m.pr.Title)
+			_ = m.infof("Merging pull request %s#%d (%s)\n", ghrepo.FullName(m.baseRepo), m.pr.Number, m.pr.Title)
 
 			apiClient := api.NewClientFromHTTP(m.httpClient)
 			r, err := api.GitHubRepo(apiClient, m.baseRepo)
@@ -366,7 +366,7 @@ func (m *mergeContext) merge() error {
 	case PullRequestMergeMethodSquash:
 		action = "Squashed and merged"
 	}
-	return m.infof("%s %s pull request %s/%s#%d (%s)\n", m.cs.SuccessIconWithColor(m.cs.Magenta), action, m.baseRepo.RepoOwner(), m.baseRepo.RepoName(), m.pr.Number, m.pr.Title)
+	return m.infof("%s %s pull request %s#%d (%s)\n", m.cs.SuccessIconWithColor(m.cs.Magenta), action, ghrepo.FullName(m.baseRepo), m.pr.Number, m.pr.Title)
 }
 
 // Delete local branch if requested and if allowed.

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -337,7 +337,7 @@ func TestPrMerge(t *testing.T) {
 		t.Fatalf("error running command `pr merge`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Merged pull request #1 \(The title of the PR\)`)
+	r := regexp.MustCompile(`Merged pull request OWNER/REPO#1 \(The title of the PR\)`)
 
 	if !r.MatchString(output.Stderr()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
@@ -518,7 +518,7 @@ func TestPrMerge_withRepoFlag(t *testing.T) {
 		t.Fatalf("error running command `pr merge`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Merged pull request #1 \(The title of the PR\)`)
+	r := regexp.MustCompile(`Merged pull request OWNER/REPO#1 \(The title of the PR\)`)
 
 	if !r.MatchString(output.Stderr()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
@@ -559,7 +559,7 @@ func TestPrMerge_withMatchCommitHeadFlag(t *testing.T) {
 		t.Fatalf("error running command `pr merge`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Merged pull request #1 \(The title of the PR\)`)
+	r := regexp.MustCompile(`Merged pull request OWNER/REPO#1 \(The title of the PR\)`)
 
 	if !r.MatchString(output.Stderr()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
@@ -601,7 +601,7 @@ func TestPrMerge_withAuthorFlag(t *testing.T) {
 		t.Fatalf("error running command `pr merge`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Merged pull request #1 \(The title of the PR\)`)
+	r := regexp.MustCompile(`Merged pull request OWNER/REPO#1 \(The title of the PR\)`)
 
 	if !r.MatchString(output.Stderr()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
@@ -653,7 +653,7 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Doc(`
-		✓ Merged pull request #10 (Blueberries are a good fruit)
+		✓ Merged pull request OWNER/REPO#10 (Blueberries are a good fruit)
 		✓ Deleted local branch blueberries and switched to branch main
 		✓ Deleted remote branch blueberries
 	`), output.Stderr())
@@ -704,7 +704,7 @@ func TestPrMerge_deleteBranch_nonDefault(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Doc(`
-		✓ Merged pull request #10 (Blueberries are a good fruit)
+		✓ Merged pull request OWNER/REPO#10 (Blueberries are a good fruit)
 		✓ Deleted local branch blueberries and switched to branch fruit
 		✓ Deleted remote branch blueberries
 	`), output.Stderr())
@@ -753,7 +753,7 @@ func TestPrMerge_deleteBranch_onlyLocally(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Doc(`
-		✓ Merged pull request #10 (Blueberries are a good fruit)
+		✓ Merged pull request OWNER/REPO#10 (Blueberries are a good fruit)
 		✓ Deleted local branch blueberries and switched to branch main
 	`), output.Stderr())
 }
@@ -803,7 +803,7 @@ func TestPrMerge_deleteBranch_checkoutNewBranch(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Doc(`
-		✓ Merged pull request #10 (Blueberries are a good fruit)
+		✓ Merged pull request OWNER/REPO#10 (Blueberries are a good fruit)
 		✓ Deleted local branch blueberries and switched to branch fruit
 		✓ Deleted remote branch blueberries
 	`), output.Stderr())
@@ -850,7 +850,7 @@ func TestPrMerge_deleteNonCurrentBranch(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Doc(`
-		✓ Merged pull request #10 (Blueberries are a good fruit)
+		✓ Merged pull request OWNER/REPO#10 (Blueberries are a good fruit)
 		✓ Deleted local branch blueberries
 		✓ Deleted remote branch blueberries
 	`), output.Stderr())
@@ -892,7 +892,7 @@ func Test_nonDivergingPullRequest(t *testing.T) {
 	}
 
 	assert.Equal(t, heredoc.Doc(`
-		✓ Merged pull request #10 (Blueberries are a good fruit)
+		✓ Merged pull request OWNER/REPO#10 (Blueberries are a good fruit)
 	`), output.Stderr())
 }
 
@@ -932,8 +932,8 @@ func Test_divergingPullRequestWarning(t *testing.T) {
 	}
 
 	assert.Equal(t, heredoc.Doc(`
-		! Pull request #10 (Blueberries are a good fruit) has diverged from local branch
-		✓ Merged pull request #10 (Blueberries are a good fruit)
+		! Pull request OWNER/REPO#10 (Blueberries are a good fruit) has diverged from local branch
+		✓ Merged pull request OWNER/REPO#10 (Blueberries are a good fruit)
 	`), output.Stderr())
 }
 
@@ -972,7 +972,7 @@ func Test_pullRequestWithoutCommits(t *testing.T) {
 	}
 
 	assert.Equal(t, heredoc.Doc(`
-		✓ Merged pull request #10 (Blueberries are a good fruit)
+		✓ Merged pull request OWNER/REPO#10 (Blueberries are a good fruit)
 	`), output.Stderr())
 }
 
@@ -1010,7 +1010,7 @@ func TestPrMerge_rebase(t *testing.T) {
 		t.Fatalf("error running command `pr merge`: %v", err)
 	}
 
-	r := regexp.MustCompile(`Rebased and merged pull request #2 \(The title of the PR\)`)
+	r := regexp.MustCompile(`Rebased and merged pull request OWNER/REPO#2 \(The title of the PR\)`)
 
 	if !r.MatchString(output.Stderr()) {
 		t.Fatalf("output did not match regexp /%s/\n> output\n%q\n", r, output.Stderr())
@@ -1053,7 +1053,7 @@ func TestPrMerge_squash(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Doc(`
-		✓ Squashed and merged pull request #3 (The title of the PR)
+		✓ Squashed and merged pull request OWNER/REPO#3 (The title of the PR)
 	`), output.Stderr())
 }
 
@@ -1275,7 +1275,7 @@ func TestPRMergeTTY(t *testing.T) {
 		t.Fatalf("Got unexpected error running `pr merge` %s", err)
 	}
 
-	assert.Equal(t, "Merging pull request #3 (It was the best of times)\n✓ Merged pull request #3 (It was the best of times)\n", output.Stderr())
+	assert.Equal(t, "Merging pull request OWNER/REPO#3 (It was the best of times)\n✓ Merged pull request OWNER/REPO#3 (It was the best of times)\n", output.Stderr())
 }
 
 func TestPRMergeTTY_withDeleteBranch(t *testing.T) {
@@ -1346,8 +1346,8 @@ func TestPRMergeTTY_withDeleteBranch(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Doc(`
-		Merging pull request #3 (It was the best of times)
-		✓ Merged pull request #3 (It was the best of times)
+		Merging pull request OWNER/REPO#3 (It was the best of times)
+		✓ Merged pull request OWNER/REPO#3 (It was the best of times)
 		✓ Deleted local branch blueberries and switched to branch main
 		✓ Deleted remote branch blueberries
 	`), output.Stderr())
@@ -1438,7 +1438,7 @@ func TestPRMergeTTY_squashEditCommitMsgAndSubject(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())
-	assert.Equal(t, "Merging pull request #123 (title)\n✓ Squashed and merged pull request #123 (title)\n", stderr.String())
+	assert.Equal(t, "Merging pull request OWNER/REPO#123 (title)\n✓ Squashed and merged pull request OWNER/REPO#123 (title)\n", stderr.String())
 }
 
 func TestPRMergeEmptyStrategyNonTTY(t *testing.T) {
@@ -1517,7 +1517,7 @@ func TestPRTTY_cancelled(t *testing.T) {
 		t.Fatalf("got error %v", err)
 	}
 
-	assert.Equal(t, "Merging pull request #123 (title)\nCancelled.\n", output.Stderr())
+	assert.Equal(t, "Merging pull request OWNER/REPO#123 (title)\nCancelled.\n", output.Stderr())
 }
 
 func Test_mergeMethodSurvey(t *testing.T) {
@@ -1576,7 +1576,7 @@ func TestMergeRun_autoMerge(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())
-	assert.Equal(t, "✓ Pull request #123 will be automatically merged via squash when all requirements are met\n", stderr.String())
+    assert.Equal(t, "✓ Pull request #123 will be automatically merged via squash when all requirements are met\n", stderr.String())
 }
 
 func TestMergeRun_autoMerge_directMerge(t *testing.T) {
@@ -1614,7 +1614,7 @@ func TestMergeRun_autoMerge_directMerge(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())
-	assert.Equal(t, "✓ Merged pull request #123 ()\n", stderr.String())
+	assert.Equal(t, "✓ Merged pull request OWNER/REPO#123 ()\n", stderr.String())
 }
 
 func TestMergeRun_disableAutoMerge(t *testing.T) {
@@ -1867,7 +1867,7 @@ func TestPrAddToMergeQueueAdmin(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "Merging pull request #1 (The title of the PR)\n✓ Merged pull request #1 (The title of the PR)\n", output.Stderr())
+	assert.Equal(t, "Merging pull request OWNER/REPO#1 (The title of the PR)\n✓ Merged pull request OWNER/REPO#1 (The title of the PR)\n", output.Stderr())
 }
 
 func TestPrAddToMergeQueueAdminWithMergeStrategy(t *testing.T) {
@@ -1906,7 +1906,7 @@ func TestPrAddToMergeQueueAdminWithMergeStrategy(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Merged pull request #1 (The title of the PR)\n", output.Stderr())
+	assert.Equal(t, "✓ Merged pull request OWNER/REPO#1 (The title of the PR)\n", output.Stderr())
 }
 
 type testEditor struct{}

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -1576,7 +1576,7 @@ func TestMergeRun_autoMerge(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())
-    assert.Equal(t, "✓ Pull request #123 will be automatically merged via squash when all requirements are met\n", stderr.String())
+	assert.Equal(t, "✓ Pull request #123 will be automatically merged via squash when all requirements are met\n", stderr.String())
 }
 
 func TestMergeRun_autoMerge_directMerge(t *testing.T) {

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -369,7 +369,7 @@ func TestPrMerge_blocked(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Docf(`
-		X Pull request #1 is not mergeable: the base branch policy prohibits the merge.
+		X Pull request OWNER/REPO#1 is not mergeable: the base branch policy prohibits the merge.
 		To have the pull request merged after all the requirements have been met, add the %[1]s--auto%[1]s flag.
 		To use administrator privileges to immediately merge the pull request, add the %[1]s--admin%[1]s flag.
 		`, "`"), output.Stderr())
@@ -402,7 +402,7 @@ func TestPrMerge_dirty(t *testing.T) {
 
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, heredoc.Docf(`
-		X Pull request #123 is not mergeable: the merge commit cannot be cleanly created.
+		X Pull request OWNER/REPO#123 is not mergeable: the merge commit cannot be cleanly created.
 		To have the pull request merged after all the requirements have been met, add the %[1]s--auto%[1]s flag.
 		Run the following to resolve the merge conflicts locally:
 		  gh pr checkout 123 && git fetch origin trunk && git merge origin/trunk
@@ -1085,7 +1085,7 @@ func TestPrMerge_alreadyMerged(t *testing.T) {
 
 	pm := &prompter.PrompterMock{
 		ConfirmFunc: func(p string, d bool) (bool, error) {
-			if p == "Pull request #4 was already merged. Delete the branch locally?" {
+			if p == "Pull request OWNER/REPO#4 was already merged. Delete the branch locally?" {
 				return true, nil
 			} else {
 				return false, prompter.NoSuchPromptErr(p)
@@ -1129,7 +1129,7 @@ func TestPrMerge_alreadyMerged_withMergeStrategy(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "! Pull request #4 was already merged\n", output.Stderr())
+	assert.Equal(t, "! Pull request OWNER/REPO#4 was already merged\n", output.Stderr())
 }
 
 func TestPrMerge_alreadyMerged_withMergeStrategy_TTY(t *testing.T) {
@@ -1156,7 +1156,7 @@ func TestPrMerge_alreadyMerged_withMergeStrategy_TTY(t *testing.T) {
 
 	pm := &prompter.PrompterMock{
 		ConfirmFunc: func(p string, d bool) (bool, error) {
-			if p == "Pull request #4 was already merged. Delete the branch locally?" {
+			if p == "Pull request OWNER/REPO#4 was already merged. Delete the branch locally?" {
 				return true, nil
 			} else {
 				return false, prompter.NoSuchPromptErr(p)
@@ -1196,7 +1196,7 @@ func TestPrMerge_alreadyMerged_withMergeStrategy_crossRepo(t *testing.T) {
 
 	pm := &prompter.PrompterMock{
 		ConfirmFunc: func(p string, d bool) (bool, error) {
-			if p == "Pull request #4 was already merged. Delete the branch locally?" {
+			if p == "Pull request OWNER/REPO#4 was already merged. Delete the branch locally?" {
 				return d, nil
 			} else {
 				return false, prompter.NoSuchPromptErr(p)
@@ -1576,7 +1576,7 @@ func TestMergeRun_autoMerge(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())
-	assert.Equal(t, "✓ Pull request #123 will be automatically merged via squash when all requirements are met\n", stderr.String())
+	assert.Equal(t, "✓ Pull request OWNER/REPO#123 will be automatically merged via squash when all requirements are met\n", stderr.String())
 }
 
 func TestMergeRun_autoMerge_directMerge(t *testing.T) {
@@ -1649,7 +1649,7 @@ func TestMergeRun_disableAutoMerge(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())
-	assert.Equal(t, "✓ Auto-merge disabled for pull request #123\n", stderr.String())
+	assert.Equal(t, "✓ Auto-merge disabled for pull request OWNER/REPO#123\n", stderr.String())
 }
 
 func TestPrInMergeQueue(t *testing.T) {
@@ -1680,7 +1680,7 @@ func TestPrInMergeQueue(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "! Pull request #1 is already queued to merge\n", output.Stderr())
+	assert.Equal(t, "! Pull request OWNER/REPO#1 is already queued to merge\n", output.Stderr())
 }
 
 func TestPrAddToMergeQueueWithMergeMethod(t *testing.T) {
@@ -1718,7 +1718,7 @@ func TestPrAddToMergeQueueWithMergeMethod(t *testing.T) {
 		t.Fatalf("error running command `pr merge`: %v", err)
 	}
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "! The merge strategy for main is set by the merge queue\n✓ Pull request #1 will be added to the merge queue for main when ready\n", output.Stderr())
+	assert.Equal(t, "! The merge strategy for main is set by the merge queue\n✓ Pull request OWNER/REPO#1 will be added to the merge queue for main when ready\n", output.Stderr())
 }
 
 func TestPrAddToMergeQueueClean(t *testing.T) {
@@ -1758,7 +1758,7 @@ func TestPrAddToMergeQueueClean(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Pull request #1 will be added to the merge queue for main when ready\n", output.Stderr())
+	assert.Equal(t, "✓ Pull request OWNER/REPO#1 will be added to the merge queue for main when ready\n", output.Stderr())
 }
 
 func TestPrAddToMergeQueueBlocked(t *testing.T) {
@@ -1798,7 +1798,7 @@ func TestPrAddToMergeQueueBlocked(t *testing.T) {
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Pull request #1 will be added to the merge queue for main when ready\n", output.Stderr())
+	assert.Equal(t, "✓ Pull request OWNER/REPO#1 will be added to the merge queue for main when ready\n", output.Stderr())
 }
 
 func TestPrAddToMergeQueueAdmin(t *testing.T) {

--- a/pkg/cmd/pr/ready/ready.go
+++ b/pkg/cmd/pr/ready/ready.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -75,7 +76,7 @@ func readyRun(opts *ReadyOptions) error {
 	}
 
 	if !pr.IsOpen() {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d is closed. Only draft pull requests can be marked as \"ready for review\"\n", cs.FailureIcon(), pr.Number)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d is closed. Only draft pull requests can be marked as \"ready for review\"\n", cs.FailureIcon(), ghrepo.FullName(baseRepo), pr.Number)
 		return cmdutil.SilentError
 	}
 
@@ -87,7 +88,7 @@ func readyRun(opts *ReadyOptions) error {
 
 	if opts.Undo { // convert to draft
 		if pr.IsDraft {
-			fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d is already \"in draft\"\n", cs.WarningIcon(), pr.Number)
+			fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d is already \"in draft\"\n", cs.WarningIcon(), ghrepo.FullName(baseRepo), pr.Number)
 			return nil
 		}
 		err = api.ConvertPullRequestToDraft(apiClient, baseRepo, pr)
@@ -95,10 +96,10 @@ func readyRun(opts *ReadyOptions) error {
 			return fmt.Errorf("API call failed: %w", err)
 		}
 
-		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d is converted to \"draft\"\n", cs.SuccessIconWithColor(cs.Green), pr.Number)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d is converted to \"draft\"\n", cs.SuccessIconWithColor(cs.Green), ghrepo.FullName(baseRepo), pr.Number)
 	} else { // mark as ready for review
 		if !pr.IsDraft {
-			fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d is already \"ready for review\"\n", cs.WarningIcon(), pr.Number)
+			fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d is already \"ready for review\"\n", cs.WarningIcon(), ghrepo.FullName(baseRepo), pr.Number)
 			return nil
 		}
 
@@ -107,7 +108,7 @@ func readyRun(opts *ReadyOptions) error {
 			return fmt.Errorf("API call failed: %w", err)
 		}
 
-		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d is marked as \"ready for review\"\n", cs.SuccessIconWithColor(cs.Green), pr.Number)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d is marked as \"ready for review\"\n", cs.SuccessIconWithColor(cs.Green), ghrepo.FullName(baseRepo), pr.Number)
 	}
 
 	return nil

--- a/pkg/cmd/pr/ready/ready_test.go
+++ b/pkg/cmd/pr/ready/ready_test.go
@@ -142,7 +142,7 @@ func TestPRReady(t *testing.T) {
 	output, err := runCommand(http, true, "123")
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Pull request #123 is marked as \"ready for review\"\n", output.Stderr())
+	assert.Equal(t, "✓ Pull request OWNER/REPO#123 is marked as \"ready for review\"\n", output.Stderr())
 }
 
 func TestPRReady_alreadyReady(t *testing.T) {
@@ -159,7 +159,7 @@ func TestPRReady_alreadyReady(t *testing.T) {
 	output, err := runCommand(http, true, "123")
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "! Pull request #123 is already \"ready for review\"\n", output.Stderr())
+	assert.Equal(t, "! Pull request OWNER/REPO#123 is already \"ready for review\"\n", output.Stderr())
 }
 
 func TestPRReadyUndo(t *testing.T) {
@@ -184,7 +184,7 @@ func TestPRReadyUndo(t *testing.T) {
 	output, err := runCommand(http, true, "123 --undo")
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Pull request #123 is converted to \"draft\"\n", output.Stderr())
+	assert.Equal(t, "✓ Pull request OWNER/REPO#123 is converted to \"draft\"\n", output.Stderr())
 }
 
 func TestPRReadyUndo_alreadyDraft(t *testing.T) {
@@ -201,7 +201,7 @@ func TestPRReadyUndo_alreadyDraft(t *testing.T) {
 	output, err := runCommand(http, true, "123 --undo")
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "! Pull request #123 is already \"in draft\"\n", output.Stderr())
+	assert.Equal(t, "! Pull request OWNER/REPO#123 is already \"in draft\"\n", output.Stderr())
 }
 
 func TestPRReady_closed(t *testing.T) {
@@ -218,5 +218,5 @@ func TestPRReady_closed(t *testing.T) {
 	output, err := runCommand(http, true, "123")
 	assert.EqualError(t, err, "SilentError")
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "X Pull request #123 is closed. Only draft pull requests can be marked as \"ready for review\"\n", output.Stderr())
+	assert.Equal(t, "X Pull request OWNER/REPO#123 is closed. Only draft pull requests can be marked as \"ready for review\"\n", output.Stderr())
 }

--- a/pkg/cmd/pr/reopen/reopen.go
+++ b/pkg/cmd/pr/reopen/reopen.go
@@ -64,12 +64,12 @@ func reopenRun(opts *ReopenOptions) error {
 	}
 
 	if pr.State == "MERGED" {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d (%s) can't be reopened because it was already merged\n", cs.FailureIcon(), pr.Number, pr.Title)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d (%s) can't be reopened because it was already merged\n", cs.FailureIcon(), ghrepo.FullName(baseRepo), pr.Number, pr.Title)
 		return cmdutil.SilentError
 	}
 
 	if pr.IsOpen() {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request #%d (%s) is already open\n", cs.WarningIcon(), pr.Number, pr.Title)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Pull request %s#%d (%s) is already open\n", cs.WarningIcon(), ghrepo.FullName(baseRepo), pr.Number, pr.Title)
 		return nil
 	}
 
@@ -99,7 +99,7 @@ func reopenRun(opts *ReopenOptions) error {
 		return fmt.Errorf("API call failed: %w", err)
 	}
 
-	fmt.Fprintf(opts.IO.ErrOut, "%s Reopened pull request #%d (%s)\n", cs.SuccessIconWithColor(cs.Green), pr.Number, pr.Title)
+	fmt.Fprintf(opts.IO.ErrOut, "%s Reopened pull request %s#%d (%s)\n", cs.SuccessIconWithColor(cs.Green), ghrepo.FullName(baseRepo), pr.Number, pr.Title)
 
 	return nil
 }

--- a/pkg/cmd/pr/reopen/reopen_test.go
+++ b/pkg/cmd/pr/reopen/reopen_test.go
@@ -71,7 +71,7 @@ func TestPRReopen(t *testing.T) {
 	output, err := runCommand(http, true, "123")
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Reopened pull request #123 (The title of the PR)\n", output.Stderr())
+	assert.Equal(t, "✓ Reopened pull request OWNER/REPO#123 (The title of the PR)\n", output.Stderr())
 }
 
 func TestPRReopen_alreadyOpen(t *testing.T) {
@@ -88,7 +88,7 @@ func TestPRReopen_alreadyOpen(t *testing.T) {
 	output, err := runCommand(http, true, "123")
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "! Pull request #123 (The title of the PR) is already open\n", output.Stderr())
+	assert.Equal(t, "! Pull request OWNER/REPO#123 (The title of the PR) is already open\n", output.Stderr())
 }
 
 func TestPRReopen_alreadyMerged(t *testing.T) {
@@ -105,7 +105,7 @@ func TestPRReopen_alreadyMerged(t *testing.T) {
 	output, err := runCommand(http, true, "123")
 	assert.EqualError(t, err, "SilentError")
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "X Pull request #123 (The title of the PR) can't be reopened because it was already merged\n", output.Stderr())
+	assert.Equal(t, "X Pull request OWNER/REPO#123 (The title of the PR) can't be reopened because it was already merged\n", output.Stderr())
 }
 
 func TestPRReopen_withComment(t *testing.T) {
@@ -141,5 +141,5 @@ func TestPRReopen_withComment(t *testing.T) {
 	output, err := runCommand(http, true, "123 --comment 'reopening comment'")
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Reopened pull request #123 (The title of the PR)\n", output.Stderr())
+	assert.Equal(t, "✓ Reopened pull request OWNER/REPO#123 (The title of the PR)\n", output.Stderr())
 }

--- a/pkg/cmd/pr/review/review.go
+++ b/pkg/cmd/pr/review/review.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -194,11 +195,11 @@ func reviewRun(opts *ReviewOptions) error {
 
 	switch reviewData.State {
 	case api.ReviewComment:
-		fmt.Fprintf(opts.IO.ErrOut, "%s Reviewed pull request #%d\n", cs.Gray("-"), pr.Number)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Reviewed pull request %s#%d\n", cs.Gray("-"), ghrepo.FullName(baseRepo), pr.Number)
 	case api.ReviewApprove:
-		fmt.Fprintf(opts.IO.ErrOut, "%s Approved pull request #%d\n", cs.SuccessIcon(), pr.Number)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Approved pull request %s#%d\n", cs.SuccessIcon(), ghrepo.FullName(baseRepo), pr.Number)
 	case api.ReviewRequestChanges:
-		fmt.Fprintf(opts.IO.ErrOut, "%s Requested changes to pull request #%d\n", cs.Red("+"), pr.Number)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Requested changes to pull request %s#%d\n", cs.Red("+"), ghrepo.FullName(baseRepo), pr.Number)
 	}
 
 	return nil

--- a/pkg/cmd/pr/review/review_test.go
+++ b/pkg/cmd/pr/review/review_test.go
@@ -286,7 +286,7 @@ func TestPRReview_interactive(t *testing.T) {
 		  cool story                                                                  
 		
 	`), output.String())
-	assert.Equal(t, "✓ Approved pull request #123\n", output.Stderr())
+	assert.Equal(t, "✓ Approved pull request OWNER/REPO#123\n", output.Stderr())
 }
 
 func TestPRReview_interactive_no_body(t *testing.T) {
@@ -328,5 +328,5 @@ func TestPRReview_interactive_blank_approve(t *testing.T) {
 	output, err := runCommand(http, pm, nil, true, "")
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Approved pull request #123\n", output.Stderr())
+	assert.Equal(t, "✓ Approved pull request OWNER/REPO#123\n", output.Stderr())
 }

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -94,7 +95,7 @@ func viewRun(opts *ViewOptions) error {
 	} else if opts.Exporter != nil {
 		findOptions.Fields = opts.Exporter.Fields()
 	}
-	pr, _, err := opts.Finder.Find(findOptions)
+	pr, baseRepo, err := opts.Finder.Find(findOptions)
 	if err != nil {
 		return err
 	}
@@ -121,7 +122,7 @@ func viewRun(opts *ViewOptions) error {
 	}
 
 	if connectedToTerminal {
-		return printHumanPrPreview(opts, pr)
+		return printHumanPrPreview(opts, baseRepo, pr)
 	}
 
 	if opts.Comments {
@@ -173,12 +174,12 @@ func printRawPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 	return nil
 }
 
-func printHumanPrPreview(opts *ViewOptions, pr *api.PullRequest) error {
+func printHumanPrPreview(opts *ViewOptions, baseRepo ghrepo.Interface, pr *api.PullRequest) error {
 	out := opts.IO.Out
 	cs := opts.IO.ColorScheme()
 
 	// Header (Title and State)
-	fmt.Fprintf(out, "%s #%d\n", cs.Bold(pr.Title), pr.Number)
+	fmt.Fprintf(out, "%s %s#%d\n", cs.Bold(pr.Title), ghrepo.FullName(baseRepo), pr.Number)
 	fmt.Fprintf(out,
 		"%s • %s wants to merge %s into %s from %s • %s\n",
 		shared.StateTitleWithColor(cs, *pr),

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -381,7 +381,7 @@ func TestPRView_Preview(t *testing.T) {
 				"PullRequestByNumber": "./fixtures/prViewPreview.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12`,
+				`Blueberries are from a fork OWNER/REPO#12`,
 				`Open.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`.+100.-10`,
 				`blueberries taste good`,
@@ -395,7 +395,7 @@ func TestPRView_Preview(t *testing.T) {
 				"PullRequestByNumber": "./fixtures/prViewPreviewWithMetadataByNumber.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12`,
+				`Blueberries are from a fork OWNER/REPO#12`,
 				`Open.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`.+100.-10`,
 				`Reviewers:.*1 \(.*Requested.*\)\n`,
@@ -415,7 +415,7 @@ func TestPRView_Preview(t *testing.T) {
 				"ReviewsForPullRequest": "./fixtures/prViewPreviewManyReviews.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12`,
+				`Blueberries are from a fork OWNER/REPO#12`,
 				`Reviewers: DEF \(Commented\), def \(Changes requested\), ghost \(Approved\), hubot \(Commented\), xyz \(Approved\), 123 \(Requested\), abc \(Requested\), my-org\/team-1 \(Requested\)`,
 				`blueberries taste good`,
 				`View this pull request on GitHub: https://github.com/OWNER/REPO/pull/12`,
@@ -428,7 +428,7 @@ func TestPRView_Preview(t *testing.T) {
 				"PullRequestByNumber": "./fixtures/prViewPreviewClosedState.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12`,
+				`Blueberries are from a fork OWNER/REPO#12`,
 				`Closed.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`.+100.-10`,
 				`blueberries taste good`,
@@ -442,7 +442,7 @@ func TestPRView_Preview(t *testing.T) {
 				"PullRequestByNumber": "./fixtures/prViewPreviewMergedState.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12`,
+				`Blueberries are from a fork OWNER/REPO#12`,
 				`Merged.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`.+100.-10`,
 				`blueberries taste good`,
@@ -456,7 +456,7 @@ func TestPRView_Preview(t *testing.T) {
 				"PullRequestByNumber": "./fixtures/prViewPreviewDraftState.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12`,
+				`Blueberries are from a fork OWNER/REPO#12`,
 				`Draft.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`.+100.-10`,
 				`blueberries taste good`,
@@ -470,7 +470,7 @@ func TestPRView_Preview(t *testing.T) {
 				"PullRequestByNumber": "./fixtures/prViewPreviewWithAllChecksPassing.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12`,
+				`Blueberries are from a fork OWNER/REPO#12`,
 				`Open.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`.+100.-10 • ✓ Checks passing`,
 				`blueberries taste good`,
@@ -484,7 +484,7 @@ func TestPRView_Preview(t *testing.T) {
 				"PullRequestByNumber": "./fixtures/prViewPreviewWithAllChecksFailing.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12`,
+				`Blueberries are from a fork OWNER/REPO#12`,
 				`Open.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`.+100.-10 • × All checks failing`,
 				`blueberries taste good`,
@@ -498,7 +498,7 @@ func TestPRView_Preview(t *testing.T) {
 				"PullRequestByNumber": "./fixtures/prViewPreviewWithSomeChecksFailing.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12`,
+				`Blueberries are from a fork OWNER/REPO#12`,
 				`Open.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`.+100.-10 • × 1/2 checks failing`,
 				`blueberries taste good`,
@@ -512,7 +512,7 @@ func TestPRView_Preview(t *testing.T) {
 				"PullRequestByNumber": "./fixtures/prViewPreviewWithSomeChecksPending.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12`,
+				`Blueberries are from a fork OWNER/REPO#12`,
 				`Open.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`.+100.-10 • - Checks pending`,
 				`blueberries taste good`,
@@ -526,7 +526,7 @@ func TestPRView_Preview(t *testing.T) {
 				"PullRequestByNumber": "./fixtures/prViewPreviewWithNoChecks.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12`,
+				`Blueberries are from a fork OWNER/REPO#12`,
 				`Open.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`.+100.-10 • No checks`,
 				`blueberries taste good`,
@@ -540,7 +540,7 @@ func TestPRView_Preview(t *testing.T) {
 				"PullRequestByNumber": "./fixtures/prViewPreviewWithAutoMergeEnabled.json",
 			},
 			expectedOutputs: []string{
-				`Blueberries are from a fork #12\n`,
+				`Blueberries are from a fork OWNER/REPO#12\n`,
 				`Open.*nobody wants to merge 12 commits into master from blueberries . about X years ago`,
 				`Auto-merge:.*enabled.* by hubot, using squash and merge`,
 				`blueberries taste good`,
@@ -625,7 +625,7 @@ func TestPRView_tty_Comments(t *testing.T) {
 				"ReviewsForPullRequest": "./fixtures/prViewPreviewReviews.json",
 			},
 			expectedOutputs: []string{
-				`some title #12`,
+				`some title OWNER/REPO#12`,
 				`1 \x{1f615} • 2 \x{1f440} • 3 \x{2764}\x{fe0f}`,
 				`some body`,
 				`———————— Not showing 9 comments ————————`,
@@ -645,7 +645,7 @@ func TestPRView_tty_Comments(t *testing.T) {
 				"CommentsForPullRequest": "./fixtures/prViewPreviewFullComments.json",
 			},
 			expectedOutputs: []string{
-				`some title #12`,
+				`some title OWNER/REPO#12`,
 				`some body`,
 				`monalisa • Jan  1, 2020 • Edited`,
 				`1 \x{1f615} • 2 \x{1f440} • 3 \x{2764}\x{fe0f} • 4 \x{1f389} • 5 \x{1f604} • 6 \x{1f680} • 7 \x{1f44e} • 8 \x{1f44d}`,

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -294,7 +294,7 @@ func runView(opts *ViewOptions) error {
 	prNumber := ""
 	number, err := shared.PullRequestForRun(client, repo, *run)
 	if err == nil {
-		prNumber = fmt.Sprintf(" #%d", number)
+		prNumber = fmt.Sprintf(" %s#%d", ghrepo.FullName(repo), number)
 	}
 
 	var artifacts []shared.Artifact

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -222,7 +222,7 @@ func TestViewRun(t *testing.T) {
 					httpmock.REST("GET", "repos/OWNER/REPO/check-runs/10/annotations"),
 					httpmock.JSONResponse([]shared.Annotation{}))
 			},
-			wantOut: "\n✓ trunk CI #2898 · 3\nTriggered via push about 59 minutes ago\n\nJOBS\n✓ cool job in 4m34s (ID 10)\n\nFor more information about the job, try: gh run view --job=10\nView this run on GitHub: https://github.com/runs/3\n",
+			wantOut: "\n✓ trunk CI OWNER/REPO#2898 · 3\nTriggered via push about 59 minutes ago\n\nJOBS\n✓ cool job in 4m34s (ID 10)\n\nFor more information about the job, try: gh run view --job=10\nView this run on GitHub: https://github.com/runs/3\n",
 		},
 		{
 			name: "associate with PR with attempt",
@@ -266,7 +266,7 @@ func TestViewRun(t *testing.T) {
 					httpmock.REST("GET", "repos/OWNER/REPO/check-runs/10/annotations"),
 					httpmock.JSONResponse([]shared.Annotation{}))
 			},
-			wantOut: "\n✓ trunk CI #2898 · 3 (Attempt #3)\nTriggered via push about 59 minutes ago\n\nJOBS\n✓ cool job in 4m34s (ID 10)\n\nFor more information about the job, try: gh run view --job=10\nView this run on GitHub: https://github.com/runs/3/attempts/3\n",
+			wantOut: "\n✓ trunk CI OWNER/REPO#2898 · 3 (Attempt #3)\nTriggered via push about 59 minutes ago\n\nJOBS\n✓ cool job in 4m34s (ID 10)\n\nFor more information about the job, try: gh run view --job=10\nView this run on GitHub: https://github.com/runs/3/attempts/3\n",
 		},
 		{
 			name: "exit status, failed run",

--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -132,7 +132,7 @@ func watchRun(opts *WatchOptions) error {
 	prNumber := ""
 	number, err := shared.PullRequestForRun(client, repo, *run)
 	if err == nil {
-		prNumber = fmt.Sprintf(" #%d", number)
+		prNumber = fmt.Sprintf(" %s#%d", ghrepo.FullName(repo), number)
 	}
 
 	annotationCache := map[int64][]shared.Annotation{}


### PR DESCRIPTION
Various places show the PR number and title. Those places are updated to also show the owner/repo.

E.g. for `gh pr merge`
Before:

    Pull request #123 (title) is ready to be merged

After:

    Pull request owner/repo#123 (title) is ready to be merged

There are other places, where only the number is displayed. Those were intentionally left as is. It made sense to show the owner/repo only when the extra context of the title was present.

It also fixes the related tests.

Fixes #8777