### PR TITLE
Fix the description of `gh release upload`

### DIFF
--- a/pkg/cmd/release/upload/upload.go
+++ b/pkg/cmd/release/upload/upload.go
@@ -41,7 +41,7 @@ func NewCmdUpload(f *cmdutil.Factory, runF func(*UploadOptions) error) *cobra.Co
 		Long: heredoc.Docf(`
 			Upload asset files to a GitHub Release.
 
-			To define a display label for an asset, append text starting with %[1]%#%[1]% after the
+			To define a display label for an asset, append text starting with %[1]s#%[1]s after the
 			file name.
 		`, "`"),
 		Args: cobra.MinimumNArgs(2),


### PR DESCRIPTION
The formatting verb is used incorrectly and produces a misleading help text for this command:

```
To define a display label for an asset, append text starting with %#% after the file name.
```

instead of the expected:

```
To define a display label for an asset, append text starting with `#` after the file name.
```