### PR TITLE
Document auth switch behaviour for two or more accounts

### DIFF
--- a/pkg/cmd/auth/switch/switch.go
+++ b/pkg/cmd/auth/switch/switch.go
@@ -38,6 +38,10 @@ func NewCmdSwitch(f *cmdutil.Factory, runF func(*SwitchOptions) error) *cobra.Co
 			This command changes the authentication configuration that will
 			be used when running commands targeting the specified GitHub host.
 
+			If the specified host has two accounts, the active account will be switched
+			automatically. If there are more than two accounts, disambiguation will be
+			required either through the %[1]s--user%[1]s flag or an interactive prompt.
+
 			For a list of authenticated accounts you can run %[1]sgh auth status%[1]s.
 		`, "`"),
 		Example: heredoc.Doc(`


### PR DESCRIPTION
## Description

After reviewing https://github.com/cli/cli/pull/8838 it seemed like this could require a little more upfront documentation.