### PR TITLE
Document run watch and view not supporting fine grained PATs

### DIFF
--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -96,7 +96,13 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "view [<run-id>]",
 		Short: "View a summary of a workflow run",
-		Args:  cobra.MaximumNArgs(1),
+		Long: heredoc.Docf(`
+			View a summary of a workflow run.
+
+			This command does not support authenticating via fine grained PATs
+			as it is not currently possible to create a PAT with the %[1]schecks:read%[1]s permission.
+		`, "`"),
+		Args: cobra.MaximumNArgs(1),
 		Example: heredoc.Doc(`
 			# Interactively select a run to view, optionally selecting a single job
 			$ gh run view

--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -45,6 +45,12 @@ func NewCmdWatch(f *cmdutil.Factory, runF func(*WatchOptions) error) *cobra.Comm
 	cmd := &cobra.Command{
 		Use:   "watch <run-id>",
 		Short: "Watch a run until it completes, showing its progress",
+		Long: heredoc.Docf(`
+			Watch a run until it completes, showing its progress.
+
+			This command does not support authenticating via fine grained PATs
+			as it is not currently possible to create a PAT with the %[1]schecks:read%[1]s permission.
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Watch a run until it's done
 			gh run watch


### PR DESCRIPTION
## Description

This relates to https://github.com/cli/cli/issues/8842

Currently it is not possible to create a fine grained PAT with the `checks:read` permission, which is required by the annotations endpoint.