### PR TITLE
Fix segfault in error handling of `gh repo rename`

### DIFF
--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -135,7 +135,11 @@ func renameRun(opts *RenameOptions) error {
 
 	remote, err := updateRemote(currRepo, newRepo, opts)
 	if err != nil {
-		fmt.Fprintf(opts.IO.ErrOut, "%s Warning: unable to update remote %q: %v\n", cs.WarningIcon(), remote.Name, err)
+		if remote != nil {
+			fmt.Fprintf(opts.IO.ErrOut, "%s Warning: unable to update remote %q: %v\n", cs.WarningIcon(), remote.Name, err)
+		} else {
+			fmt.Fprintf(opts.IO.ErrOut, "%s Warning: unable to update remote: %v\n", cs.WarningIcon(), err)
+		}
 	} else if opts.IO.IsStdoutTTY() {
 		fmt.Fprintf(opts.IO.Out, "%s Updated the %q remote\n", cs.SuccessIcon(), remote.Name)
 	}


### PR DESCRIPTION
Hi, the `updateRemote()` function used in the `gh repo rename` command does not always guarantee the `*ghcontext.Remote` return value to be `!= nil` as seen below:

https://github.com/cli/cli/blob/ec812a16f77df5f196189e9871722b9b601143bc/pkg/cmd/repo/rename/rename.go#L146-L168

However the caller of this function assumes this to be the case and always de-references `remote.Name` even if the function returns an error:

https://github.com/cli/cli/blob/ec812a16f77df5f196189e9871722b9b601143bc/pkg/cmd/repo/rename/rename.go#L136-L141

... which then leads to a segfault.

In my case, this edge case was triggered by renaming a repository that had previously been moved between organizations. My local remote was still outdated, which causes `remotes.FindByRepo()` to return `nil`.

This fix adds a new error message that handles this case which looks like below:

```sh
! Warning: unable to update remote: no matching remote found
```