### PR TITLE
Fix parsing IPv6 remote URLs

### DIFF
--- a/git/url.go
+++ b/git/url.go
@@ -56,9 +56,7 @@ func ParseURL(rawURL string) (u *url.URL, err error) {
 		u.Path = strings.TrimPrefix(u.Path, "/")
 	}
 
-	if idx := strings.Index(u.Host, ":"); idx >= 0 {
-		u.Host = u.Host[0:idx]
-	}
+	u.Host = strings.TrimSuffix(u.Host, ":"+u.Port())
 
 	return
 }

--- a/git/url_test.go
+++ b/git/url_test.go
@@ -127,6 +127,26 @@ func TestParseURL(t *testing.T) {
 			},
 		},
 		{
+			name: "ssh, ipv6",
+			url:  "ssh://git@[::1]/owner/repo.git",
+			want: url{
+				Scheme: "ssh",
+				User:   "git",
+				Host:   "[::1]",
+				Path:   "/owner/repo.git",
+			},
+		},
+		{
+			name: "ssh with port, ipv6",
+			url:  "ssh://git@[::1]:22/owner/repo.git",
+			want: url{
+				Scheme: "ssh",
+				User:   "git",
+				Host:   "[::1]",
+				Path:   "/owner/repo.git",
+			},
+		},
+		{
 			name: "git+ssh",
 			url:  "git+ssh://example.com/owner/repo.git",
 			want: url{


### PR DESCRIPTION
This PR fixes the panic raised when there's a remote with an IPv6 URL.

Fixes #8703

## Problem

I traced the problem, and as @williammartin suspected, the error ignored in the line [below](https://github.com/cli/go-gh/blob/d88d88f917cd4e0bcaa582bac2bb909bd79f9759/pkg/ssh/ssh.go#L42) was masking the actual problem:

```go
newURL, _ := url.Parse(u.String())
```

If we set the remotes as suggested by @jcgruenhage in #8703, the URL `u` (in the above code) will be `"ssh://git@[/tmp/git-repo"`, which obviously, is not a valid URL (note the open bracket and the missing IPv6 address). When `url.Parse` receives this it expects a closing bracket to be there as well, and since it's not, it'll then return an error saying `"missing ']' in host"`.

The malformed URL is created within the `ParseURL` function (in `git/url.go`) where the port number is removed from the host (by dropping everything after the first colon):

```go
// (git/url.go:59)
if idx := strings.Index(u.Host, ":"); idx >= 0 {
	u.Host = u.Host[0:idx]
}
```

This works fine with IPv4 addresses since there's only *one* colon, if any, in the host part just before the port number. But, IPv6 addresses could have more than one colon. In our example case, `u.Host` is `"[::1]:22"` and after (incorrectly) stripping the port number it gets changed to `"["`, which would later cause the mentioned error in `url.Parse`.

To fix this, we can trim the port number from the end of the host like this:

```go
// (git/url.go:59)
u.Host = strings.TrimSuffix(u.Host, ":"+u.Port())
```

This will also handle cases like `ssh://host:/`, where there's no port number after the colon. 

With this change, the panic is avoided and we get the following legitimate response:

```
none of the git remotes configured for this repository point to a known GitHub host. To tell gh about a new GitHub host, please use `gh auth login`
```
