### PR TITLE
Include `numSelectedRepos` in JSON output of `gh secret list`

### DIFF
--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -40,7 +40,7 @@ var secretFields = []string{
 	"numSelectedRepos",
 }
 
-const secretFieldNumSelectedRepos = "numSelectedRepos"
+const fieldNumSelectedRepos = "numSelectedRepos"
 
 func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
 	opts := &ListOptions{
@@ -121,7 +121,7 @@ func listRun(opts *ListOptions) error {
 	if opts.Exporter != nil {
 		// Note that if there's an exporter set, then we don't mind the TTY mode
 		// because we just have to populate the requested fields.
-		showSelectedRepoInfo = slices.Contains(opts.Exporter.Fields(), secretFieldNumSelectedRepos)
+		showSelectedRepoInfo = slices.Contains(opts.Exporter.Fields(), fieldNumSelectedRepos)
 	}
 
 	var secrets []Secret

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -117,6 +117,13 @@ func listRun(opts *ListOptions) error {
 		return fmt.Errorf("%s secrets are not supported for %s", secretEntity, secretApp)
 	}
 
+	// Since populating the `NumSelectedRepos` field costs further API requests
+	// (one per secret), it's important to avoid extra calls when the output will
+	// not present the field's value. So, we should only populate this field in
+	// these cases:
+	//  1. The command is run in the TTY mode without the `--json <fields>` option.
+	//  2. The command is run with `--json <fields>` option, and `numSelectedRepos`
+	//     is among the selected fields. In this case, TTY mode is irrelevant.
 	showSelectedRepoInfo := opts.IO.IsStdoutTTY()
 	if opts.Exporter != nil {
 		// Note that if there's an exporter set, then we don't mind the TTY mode

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -3,6 +3,7 @@ package list
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -38,6 +39,8 @@ var secretFields = []string{
 	"updatedAt",
 	"numSelectedRepos",
 }
+
+const secretFieldNumSelectedRepos = "numSelectedRepos"
 
 func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
 	opts := &ListOptions{
@@ -114,9 +117,12 @@ func listRun(opts *ListOptions) error {
 		return fmt.Errorf("%s secrets are not supported for %s", secretEntity, secretApp)
 	}
 
-	var secrets []Secret
 	showSelectedRepoInfo := opts.IO.IsStdoutTTY()
+	if !showSelectedRepoInfo && opts.Exporter != nil {
+		showSelectedRepoInfo = slices.Contains(opts.Exporter.Fields(), secretFieldNumSelectedRepos)
+	}
 
+	var secrets []Secret
 	switch secretEntity {
 	case shared.Repository:
 		secrets, err = getRepoSecrets(client, baseRepo, secretApp)

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -118,7 +118,9 @@ func listRun(opts *ListOptions) error {
 	}
 
 	showSelectedRepoInfo := opts.IO.IsStdoutTTY()
-	if !showSelectedRepoInfo && opts.Exporter != nil {
+	if opts.Exporter != nil {
+		// Note that if there's an exporter set, then we don't mind the TTY mode
+		// because we just have to populate the requested fields.
 		showSelectedRepoInfo = slices.Contains(opts.Exporter.Fields(), secretFieldNumSelectedRepos)
 	}
 


### PR DESCRIPTION
This PR fixes unset/zero `numSelectedRepos` value within the JSON exported output of `gh secret list`, thanks to @andyfeller investigation and guidance.

Fixes #8679 

## Notes

In this PR, we explicitly check for the `numSelectedRepos` field in the `--json` argument, if any. The reason is to keep the current behavior as intact as possible, and also to avoid unnecessary API requests (which are per secret, to fetch selected repos).