### PR TITLE
fix: expose `run_attempt` field (as `attempt`) when getting a workflow run

### DIFF
--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -72,6 +72,7 @@ var RunFields = []string{
 	"createdAt",
 	"updatedAt",
 	"startedAt",
+	"attempt",
 	"status",
 	"conclusion",
 	"event",
@@ -97,7 +98,7 @@ type Run struct {
 	workflowName   string // cache column
 	WorkflowID     int64  `json:"workflow_id"`
 	Number         int64  `json:"run_number"`
-	Attempts       uint64 `json:"run_attempt"`
+	Attempt        uint64 `json:"run_attempt"`
 	HeadBranch     string `json:"head_branch"`
 	JobsURL        string `json:"jobs_url"`
 	HeadCommit     Commit `json:"head_commit"`


### PR DESCRIPTION
# Description 

the `run_attempt` field is not exposed in the `run view` and `run ls` commands, so the only why to get them via the cli is to use `gh api`

this change exposes it, but also renames the current field that wasn't being used as the data the field contains is not "how many attempts" rather "which attempt this info is for"