### PR TITLE
Fix panic when running `gh repo rename`

### DIFF
--- a/context/remote.go
+++ b/context/remote.go
@@ -31,7 +31,7 @@ func (r Remotes) FindByRepo(owner, name string) (*Remote, error) {
 			return rem, nil
 		}
 	}
-	return nil, fmt.Errorf("no matching remote found")
+	return nil, fmt.Errorf("no matching remote found; looking for %s/%s", owner, name)
 }
 
 // Filter remotes by given hostnames, maintains original order


### PR DESCRIPTION
This PR fixes the panic caused by calling `gh repo rename`. This happens when the remotes do not match the current name of a repo.

Fixes #8675 

## Problem

When we call `updateRemote` here:

https://github.com/cli/cli/blob/8948ee8c3beaf432676061aaaf481d2f41039483/pkg/cmd/repo/rename/rename.go#L136

it returns a `nil` remote and an error saying `no matching remote found`, which is actually returned from the `FindByRepo` method when it was looking for a remote pointing to the old name but couldn't find any.

The fix is to check `remote` against `nil` and format the warning message accordingly.

I also improved the underlying error message to reflect the expected values; it's now formatted like this:

```
no matching remote found; looking for <owner>/<name>
``` 
