### PR TITLE
Rely on go.mod go version in all workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,10 +29,10 @@ jobs:
           languages: go
           queries: security-and-quality
 
-      - name: Setup go
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,5 +1,5 @@
 name: Deployment
-run-name: ${{ inputs.tag_name }} / go ${{ inputs.go_version }} / ${{ inputs.environment }}
+run-name: ${{ inputs.tag_name }} / go / ${{ inputs.environment }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -17,9 +17,6 @@ on:
       environment:
         default: production
         type: environment
-      go_version:
-        default: "1.22"
-        type: string
       platforms:
         default: "linux,macos,windows"
         type: string
@@ -39,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ inputs.go_version }}
+          go-version-file: 'go.mod'
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -73,7 +70,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ inputs.go_version }}
+          go-version-file: 'go.mod'
       - name: Configure macOS signing
         if: inputs.environment == 'production'
         env:
@@ -130,7 +127,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ inputs.go_version }}
+          go-version-file: 'go.mod'
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,5 +1,5 @@
 name: Deployment
-run-name: ${{ inputs.tag_name }} / go / ${{ inputs.environment }}
+run-name: ${{ inputs.tag_name }} / ${{ inputs.environment }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.22
-
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
       - name: Restore Go modules cache
         uses: actions/cache@v4
@@ -48,13 +48,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.22
-
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
       - name: Build executable
         run: make

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.22
-
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
       - name: Restore Go modules cache
         uses: actions/cache@v4


### PR DESCRIPTION
# Description

Following on from the nice work of @yanskun bumping our [go version to 1.22](https://github.com/cli/cli/pull/8836), it seems like a bit of toil to go around finding all these places to bump the go version when it's really the version in the `go.mod` that we want to use.

This PR uses `setup-go`'s [`go-version-file`](https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file) feature to achieve that.