### PR TITLE
Remove naked returns from git ParseURL

### DIFF
--- a/git/url.go
+++ b/git/url.go
@@ -40,12 +40,11 @@ func ParseURL(rawURL string) (*url.URL, error) {
 		return nil, err
 	}
 
-	if u.Scheme == "git+ssh" {
-		u.Scheme = "ssh"
-	}
-
-	if u.Scheme == "git+https" {
+	switch u.Scheme {
+	case "git+https":
 		u.Scheme = "https"
+	case "git+ssh":
+		u.Scheme = "ssh"
 	}
 
 	if u.Scheme != "ssh" {

--- a/git/url.go
+++ b/git/url.go
@@ -26,7 +26,7 @@ func isPossibleProtocol(u string) bool {
 }
 
 // ParseURL normalizes git remote urls
-func ParseURL(rawURL string) (u *url.URL, err error) {
+func ParseURL(rawURL string) (*url.URL, error) {
 	if !isPossibleProtocol(rawURL) &&
 		strings.ContainsRune(rawURL, ':') &&
 		// not a Windows path
@@ -35,9 +35,9 @@ func ParseURL(rawURL string) (u *url.URL, err error) {
 		rawURL = "ssh://" + strings.Replace(rawURL, ":", "/", 1)
 	}
 
-	u, err = url.Parse(rawURL)
+	u, err := url.Parse(rawURL)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	if u.Scheme == "git+ssh" {
@@ -49,7 +49,7 @@ func ParseURL(rawURL string) (u *url.URL, err error) {
 	}
 
 	if u.Scheme != "ssh" {
-		return
+		return u, nil
 	}
 
 	if strings.HasPrefix(u.Path, "//") {
@@ -60,5 +60,5 @@ func ParseURL(rawURL string) (u *url.URL, err error) {
 		u.Host = u.Host[0:idx]
 	}
 
-	return
+	return u, nil
 }

--- a/git/url_test.go
+++ b/git/url_test.go
@@ -196,13 +196,22 @@ func TestParseURL(t *testing.T) {
 				Path:   "",
 			},
 		},
+		{
+			name:    "fails to parse",
+			url:     "ssh://git@[/tmp/git-repo",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			u, err := ParseURL(tt.url)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("got error: %v", err)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
 			}
+
 			if u.Scheme != tt.want.Scheme {
 				t.Errorf("expected scheme %q, got %q", tt.want.Scheme, u.Scheme)
 			}

--- a/git/url_test.go
+++ b/git/url_test.go
@@ -1,6 +1,11 @@
 package git
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestIsURL(t *testing.T) {
 	tests := []struct {
@@ -56,9 +61,7 @@ func TestIsURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsURL(tt.url); got != tt.want {
-				t.Errorf("IsURL() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, IsURL(tt.url))
 		})
 	}
 }
@@ -206,24 +209,14 @@ func TestParseURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			u, err := ParseURL(tt.url)
 			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
+				require.Error(t, err)
 				return
 			}
 
-			if u.Scheme != tt.want.Scheme {
-				t.Errorf("expected scheme %q, got %q", tt.want.Scheme, u.Scheme)
-			}
-			if u.User.Username() != tt.want.User {
-				t.Errorf("expected user %q, got %q", tt.want.User, u.User.Username())
-			}
-			if u.Host != tt.want.Host {
-				t.Errorf("expected host %q, got %q", tt.want.Host, u.Host)
-			}
-			if u.Path != tt.want.Path {
-				t.Errorf("expected path %q, got %q", tt.want.Path, u.Path)
-			}
+			assert.Equal(t, u.Scheme, tt.want.Scheme)
+			assert.Equal(t, u.User.Username(), tt.want.User)
+			assert.Equal(t, u.Host, tt.want.Host)
+			assert.Equal(t, u.Path, tt.want.Path)
 		})
 	}
 }


### PR DESCRIPTION
# Description

As I was reviewing https://github.com/cli/cli/pull/8893, I noticed it was using naked returns. I can't see a good reason for this and it reduces clarity so I removed them. I also added a new test to ensure errors are bubbled from `ParseURL` and grouped some http scheme normalization together to make it clear that the `if` blocks were actually mutually exclusive.

CC: @babakks since you were just in this code, if you're feeling up for giving a quick review.