### PR TITLE
Create stronger run log cache abstraction

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,8 @@ type Config interface {
 	Write() error
 	Migrate(Migration) error
 
+	CacheDir() string
+
 	Aliases() *AliasConfig
 	Authentication() *AuthConfig
 	Browser(string) string
@@ -189,6 +191,10 @@ func (c *cfg) Migrate(m Migration) error {
 	}
 
 	return nil
+}
+
+func (c *cfg) CacheDir() string {
+	return ghConfig.CacheDir()
 }
 
 func defaultFor(key string) (string, bool) {

--- a/internal/config/config_mock.go
+++ b/internal/config/config_mock.go
@@ -26,6 +26,9 @@ var _ Config = &ConfigMock{}
 //			BrowserFunc: func(s string) string {
 //				panic("mock out the Browser method")
 //			},
+//			CacheDirFunc: func() string {
+//				panic("mock out the CacheDir method")
+//			},
 //			EditorFunc: func(s string) string {
 //				panic("mock out the Editor method")
 //			},
@@ -72,6 +75,9 @@ type ConfigMock struct {
 	// BrowserFunc mocks the Browser method.
 	BrowserFunc func(s string) string
 
+	// CacheDirFunc mocks the CacheDir method.
+	CacheDirFunc func() string
+
 	// EditorFunc mocks the Editor method.
 	EditorFunc func(s string) string
 
@@ -114,6 +120,9 @@ type ConfigMock struct {
 		Browser []struct {
 			// S is the s argument value.
 			S string
+		}
+		// CacheDir holds details about calls to the CacheDir method.
+		CacheDir []struct {
 		}
 		// Editor holds details about calls to the Editor method.
 		Editor []struct {
@@ -171,6 +180,7 @@ type ConfigMock struct {
 	lockAliases        sync.RWMutex
 	lockAuthentication sync.RWMutex
 	lockBrowser        sync.RWMutex
+	lockCacheDir       sync.RWMutex
 	lockEditor         sync.RWMutex
 	lockGetOrDefault   sync.RWMutex
 	lockGitProtocol    sync.RWMutex
@@ -266,6 +276,33 @@ func (mock *ConfigMock) BrowserCalls() []struct {
 	mock.lockBrowser.RLock()
 	calls = mock.calls.Browser
 	mock.lockBrowser.RUnlock()
+	return calls
+}
+
+// CacheDir calls CacheDirFunc.
+func (mock *ConfigMock) CacheDir() string {
+	if mock.CacheDirFunc == nil {
+		panic("ConfigMock.CacheDirFunc: method is nil but Config.CacheDir was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockCacheDir.Lock()
+	mock.calls.CacheDir = append(mock.calls.CacheDir, callInfo)
+	mock.lockCacheDir.Unlock()
+	return mock.CacheDirFunc()
+}
+
+// CacheDirCalls gets all the calls that were made to CacheDir.
+// Check the length with:
+//
+//	len(mockedConfig.CacheDirCalls())
+func (mock *ConfigMock) CacheDirCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockCacheDir.RLock()
+	calls = mock.calls.CacheDir
+	mock.lockCacheDir.RUnlock()
 	return calls
 }
 

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -77,6 +77,9 @@ func NewFromString(cfgStr string) *ConfigMock {
 		val, _ := cfg.GetOrDefault("", versionKey)
 		return val
 	}
+	mock.CacheDirFunc = func() string {
+		return cfg.CacheDir()
+	}
 	return mock
 }
 

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -29,35 +29,48 @@ import (
 )
 
 type runLogCache interface {
-	Exists(string) bool
-	Create(string, io.Reader) error
-	Open(string) (*zip.ReadCloser, error)
+	Exists(key string) bool
+	Create(key string, r io.Reader) error
+	Open(key string) (*zip.ReadCloser, error)
 }
 
-type rlc struct{}
+type rlc struct {
+	cacheDir string
+}
 
-func (rlc) Exists(path string) bool {
-	if _, err := os.Stat(path); err != nil {
+func (c rlc) Exists(key string) bool {
+	if _, err := os.Stat(c.filepath(key)); err != nil {
 		return false
 	}
 	return true
 }
-func (rlc) Create(path string, content io.Reader) error {
-	err := os.MkdirAll(filepath.Dir(path), 0755)
-	if err != nil {
-		return fmt.Errorf("could not create cache: %w", err)
-	}
 
-	out, err := os.Create(path)
+func (c rlc) Create(key string, content io.Reader) error {
+	out, err := os.Create(c.filepath(key))
 	if err != nil {
-		return err
+		return fmt.Errorf("creating cache entry: %v", err)
 	}
 	defer out.Close()
-	_, err = io.Copy(out, content)
-	return err
+
+	if _, err := io.Copy(out, content); err != nil {
+		return fmt.Errorf("writing cache entry: %v", err)
+
+	}
+
+	return nil
 }
-func (rlc) Open(path string) (*zip.ReadCloser, error) {
-	return zip.OpenReader(path)
+
+func (c rlc) Open(key string) (*zip.ReadCloser, error) {
+	r, err := zip.OpenReader(c.filepath(key))
+	if err != nil {
+		return nil, fmt.Errorf("opening cache entry: %v", err)
+	}
+
+	return r, nil
+}
+
+func (c rlc) filepath(key string) string {
+	return filepath.Join(c.cacheDir, fmt.Sprintf("run-log-%s.zip", key))
 }
 
 type ViewOptions struct {
@@ -85,12 +98,11 @@ type ViewOptions struct {
 
 func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Command {
 	opts := &ViewOptions{
-		IO:          f.IOStreams,
-		HttpClient:  f.HttpClient,
-		Prompter:    f.Prompter,
-		Now:         time.Now,
-		Browser:     f.Browser,
-		RunLogCache: rlc{},
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Prompter:   f.Prompter,
+		Now:        time.Now,
+		Browser:    f.Browser,
 	}
 
 	cmd := &cobra.Command{
@@ -125,6 +137,15 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo
+
+			config, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			opts.RunLogCache = rlc{
+				cacheDir: config.CacheDir(),
+			}
 
 			if len(args) == 0 && opts.JobID == "" {
 				if !opts.IO.CanPrompt() {
@@ -431,9 +452,8 @@ func getLog(httpClient *http.Client, logURL string) (io.ReadCloser, error) {
 }
 
 func getRunLog(cache runLogCache, httpClient *http.Client, repo ghrepo.Interface, run *shared.Run, attempt uint64) (*zip.ReadCloser, error) {
-	filename := fmt.Sprintf("run-log-%d-%d.zip", run.ID, run.StartedTime().Unix())
-	filepath := filepath.Join(os.TempDir(), "gh-cli-cache", filename)
-	if !cache.Exists(filepath) {
+	cacheKey := fmt.Sprintf("%d-%d", run.ID, run.StartedTime().Unix())
+	if !cache.Exists(cacheKey) {
 		// Run log does not exist in cache so retrieve and store it
 		logURL := fmt.Sprintf("%srepos/%s/actions/runs/%d/logs",
 			ghinstance.RESTPrefix(repo.RepoHost()), ghrepo.FullName(repo), run.ID)
@@ -461,13 +481,13 @@ func getRunLog(cache runLogCache, httpClient *http.Client, repo ghrepo.Interface
 			return nil, err
 		}
 
-		err = cache.Create(filepath, respReader)
+		err = cache.Create(cacheKey, respReader)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return cache.Open(filepath)
+	return cache.Open(cacheKey)
 }
 
 func promptForJob(prompter shared.Prompter, cs *iostreams.ColorScheme, jobs []shared.Job) (*shared.Job, error) {

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -46,6 +46,10 @@ func (c RunLogCache) Exists(key string) (bool, error) {
 }
 
 func (c RunLogCache) Create(key string, content io.Reader) error {
+	if err := os.MkdirAll(filepath.Dir(c.cacheDir), 0755); err != nil {
+		return fmt.Errorf("creating cache directory: %v", err)
+	}
+
 	out, err := os.Create(c.filepath(key))
 	if err != nil {
 		return fmt.Errorf("creating cache entry: %v", err)

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/browser"
+	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmd/run/shared"
@@ -137,6 +138,9 @@ func TestNewCmdView(t *testing.T) {
 
 			f := &cmdutil.Factory{
 				IOStreams: ios,
+				Config: func() (config.Config, error) {
+					return config.NewBlankConfig(), nil
+				},
 			}
 
 			argv, err := shlex.Split(tt.cli)

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -1346,10 +1346,9 @@ func TestViewRun(t *testing.T) {
 
 		browser := &browser.Stub{}
 		tt.opts.Browser = browser
-		rlc := rlc{
+		tt.opts.RunLogCache = RunLogCache{
 			cacheDir: t.TempDir(),
 		}
-		tt.opts.RunLogCache = rlc
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := runView(tt.opts)

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -1495,8 +1495,8 @@ func Test_attachRunLog(t *testing.T) {
 
 type testRunLogCache struct{}
 
-func (testRunLogCache) Exists(path string) bool {
-	return false
+func (testRunLogCache) Exists(path string) (bool, error) {
+	return false, nil
 }
 func (testRunLogCache) Create(path string, content io.Reader) error {
 	return nil

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -1346,7 +1346,9 @@ func TestViewRun(t *testing.T) {
 
 		browser := &browser.Stub{}
 		tt.opts.Browser = browser
-		rlc := testRunLogCache{}
+		rlc := rlc{
+			cacheDir: t.TempDir(),
+		}
 		tt.opts.RunLogCache = rlc
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -1491,18 +1493,6 @@ func Test_attachRunLog(t *testing.T) {
 			}
 		})
 	}
-}
-
-type testRunLogCache struct{}
-
-func (testRunLogCache) Exists(path string) (bool, error) {
-	return false, nil
-}
-func (testRunLogCache) Create(path string, content io.Reader) error {
-	return nil
-}
-func (testRunLogCache) Open(path string) (*zip.ReadCloser, error) {
-	return zip.OpenReader("./fixtures/run_log.zip")
 }
 
 var barfTheFobLogOutput = heredoc.Doc(`


### PR DESCRIPTION
# Description

Since we made some changes to [`CacheDir` in `go-gh`](https://github.com/cli/go-gh/pull/153) there are some places in `gh` which hard coded assumptions about where the cache dir was location. For example `gh run view` attempted to write files directly to `os.TempDir() / gh-cli-cache`. To fix this we expose the `CacheDir` through the cli's own config (in future, we may want to expose other dirs in the same way) and then inject that into the `RunLogCache`.

In doing this, we also strengthen the abstraction because previously callers of `RunLogCache` needed to provide it with a full file path for every operation instead of a key (which makes a lot more sense when there is an interface that could be implemented e.g. in memory). However, I continued to construct the file paths in the same way so that cache entries aren't expired unnecessarily.

Previously, the `cache.Exists` method was hiding possible error states that would later crop up in `cache.Create` by assuming all errors mean the cache doesn't exist (when for example, it could be missing permissions). I made the error a first class part of the method signature that must be handled.

Finally, I removed the `testRunLogCache` in the tests because as a stub it was still deeply coupled to the test setup (i.e. tests that mocked the return of `./fixtures/run_log.zip`. It seemed better to remove this coupling and to get additional confidence in the `RunLogCache` (which was previously untested) by just using the real thing; the file system is fast and reliable. Since we don't have the test abstraction, we can remove the unused interface, it can always be returned later if at some point we feel we need it (unlikely?).