### PR TITLE
Add `--skip-ssh-key` option to `gh auth login` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
 	github.com/henvic/httpretty v0.1.3
+	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-colorable v0.1.13
@@ -96,7 +97,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.5 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/in-toto/in-toto-golang v0.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/gojq v0.12.15 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -30,12 +30,13 @@ type LoginOptions struct {
 
 	Interactive bool
 
-	Hostname        string
-	Scopes          []string
-	Token           string
-	Web             bool
-	GitProtocol     string
-	InsecureStorage bool
+	Hostname         string
+	Scopes           []string
+	Token            string
+	Web              bool
+	GitProtocol      string
+	InsecureStorage  bool
+	SkipSSHKeyPrompt bool
 }
 
 func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Command {
@@ -138,6 +139,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 	_ = cmd.Flags().MarkHidden("secure-storage")
 
 	cmd.Flags().BoolVar(&opts.InsecureStorage, "insecure-storage", false, "Save authentication credentials in plain text instead of credential store")
+	cmd.Flags().BoolVar(&opts.SkipSSHKeyPrompt, "skip-ssh-key", false, "Skip generate/upload SSH key prompt")
 
 	return cmd
 }
@@ -189,19 +191,20 @@ func loginRun(opts *LoginOptions) error {
 	}
 
 	return shared.Login(&shared.LoginOptions{
-		IO:            opts.IO,
-		Config:        authCfg,
-		HTTPClient:    httpClient,
-		Hostname:      hostname,
-		Interactive:   opts.Interactive,
-		Web:           opts.Web,
-		Scopes:        opts.Scopes,
-		Executable:    opts.MainExecutable,
-		GitProtocol:   opts.GitProtocol,
-		Prompter:      opts.Prompter,
-		GitClient:     opts.GitClient,
-		Browser:       opts.Browser,
-		SecureStorage: !opts.InsecureStorage,
+		IO:               opts.IO,
+		Config:           authCfg,
+		HTTPClient:       httpClient,
+		Hostname:         hostname,
+		Interactive:      opts.Interactive,
+		Web:              opts.Web,
+		Scopes:           opts.Scopes,
+		Executable:       opts.MainExecutable,
+		GitProtocol:      opts.GitProtocol,
+		Prompter:         opts.Prompter,
+		GitClient:        opts.GitClient,
+		Browser:          opts.Browser,
+		SecureStorage:    !opts.InsecureStorage,
+		SkipSSHKeyPrompt: opts.SkipSSHKeyPrompt,
 	})
 }
 

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -76,6 +76,10 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			The git protocol to use for git operations on this host can be set with %[1]s--git-protocol%[1]s,
 			or during the interactive prompting. Although login is for a single account on a host, setting
 			the git protocol will take effect for all users on the host.
+
+			Specifying %[1]sssh%[1]s for the git protocol will detect existing SSH keys to upload,
+			prompting to create and upload a new key if one is not found. This can be skipped with
+			%[1]s--skip-ssh-key%[1]s flag.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Start interactive setup

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -204,6 +204,23 @@ func Test_NewCmdLogin(t *testing.T) {
 				InsecureStorage: true,
 			},
 		},
+		{
+			name:     "tty skip-ssh-key",
+			stdinTTY: true,
+			cli:      "--skip-ssh-key",
+			wants: LoginOptions{
+				SkipSSHKeyPrompt: true,
+				Interactive:      true,
+			},
+		},
+		{
+			name: "nontty skip-ssh-key",
+			cli:  "--skip-ssh-key",
+			wants: LoginOptions{
+				Hostname:         "github.com",
+				SkipSSHKeyPrompt: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -28,19 +28,20 @@ type iconfig interface {
 }
 
 type LoginOptions struct {
-	IO            *iostreams.IOStreams
-	Config        iconfig
-	HTTPClient    *http.Client
-	GitClient     *git.Client
-	Hostname      string
-	Interactive   bool
-	Web           bool
-	Scopes        []string
-	Executable    string
-	GitProtocol   string
-	Prompter      Prompt
-	Browser       browser.Browser
-	SecureStorage bool
+	IO               *iostreams.IOStreams
+	Config           iconfig
+	HTTPClient       *http.Client
+	GitClient        *git.Client
+	Hostname         string
+	Interactive      bool
+	Web              bool
+	Scopes           []string
+	Executable       string
+	GitProtocol      string
+	Prompter         Prompt
+	Browser          browser.Browser
+	SecureStorage    bool
+	SkipSSHKeyPrompt bool
 
 	sshContext ssh.Context
 }
@@ -84,7 +85,7 @@ func Login(opts *LoginOptions) error {
 
 	var keyToUpload string
 	keyTitle := defaultSSHKeyTitle
-	if opts.Interactive && gitProtocol == "ssh" {
+	if opts.Interactive && !opts.SkipSSHKeyPrompt && gitProtocol == "ssh" {
 		pubKeys, err := opts.sshContext.LocalPublicKeys()
 		if err != nil {
 			return err

--- a/pkg/cmd/auth/shared/login_flow_test.go
+++ b/pkg/cmd/auth/shared/login_flow_test.go
@@ -29,160 +29,257 @@ func (c tinyConfig) UsersForHost(hostname string) []string {
 	return nil
 }
 
-func TestLogin_ssh(t *testing.T) {
-	dir := t.TempDir()
-	ios, _, stdout, stderr := iostreams.Test()
+func TestLogin(t *testing.T) {
+	tests := []struct {
+		name         string
+		opts         LoginOptions
+		httpStubs    func(*testing.T, *httpmock.Registry)
+		runStubs     func(*testing.T, *run.CommandStubber, *LoginOptions)
+		wantsConfig  map[string]string
+		wantsErr     string
+		stdout       string
+		stderr       string
+		stderrAssert func(*testing.T, *LoginOptions, string)
+	}{
+		{
+			name: "tty, prompt (protocol: ssh, create key: yes)",
+			opts: LoginOptions{
+				Prompter: &prompter.PrompterMock{
+					SelectFunc: func(prompt, _ string, opts []string) (int, error) {
+						switch prompt {
+						case "What is your preferred protocol for Git operations on this host?":
+							return prompter.IndexFor(opts, "SSH")
+						case "How would you like to authenticate GitHub CLI?":
+							return prompter.IndexFor(opts, "Paste an authentication token")
+						}
+						return -1, prompter.NoSuchPromptErr(prompt)
+					},
+					PasswordFunc: func(_ string) (string, error) {
+						return "monkey", nil
+					},
+					ConfirmFunc: func(prompt string, _ bool) (bool, error) {
+						return true, nil
+					},
+					AuthTokenFunc: func() (string, error) {
+						return "ATOKEN", nil
+					},
+					InputFunc: func(_, _ string) (string, error) {
+						return "Test Key", nil
+					},
+				},
 
-	tr := httpmock.Registry{}
-	defer tr.Verify(t)
-
-	tr.Register(
-		httpmock.REST("GET", "api/v3/"),
-		httpmock.ScopesResponder("repo,read:org"))
-	tr.Register(
-		httpmock.GraphQL(`query UserCurrent\b`),
-		httpmock.StringResponse(`{"data":{"viewer":{ "login": "monalisa" }}}`))
-	tr.Register(
-		httpmock.REST("GET", "api/v3/user/keys"),
-		httpmock.StringResponse(`[]`))
-	tr.Register(
-		httpmock.REST("POST", "api/v3/user/keys"),
-		httpmock.StringResponse(`{}`))
-
-	pm := &prompter.PrompterMock{}
-	pm.SelectFunc = func(prompt, _ string, opts []string) (int, error) {
-		switch prompt {
-		case "What is your preferred protocol for Git operations on this host?":
-			return prompter.IndexFor(opts, "SSH")
-		case "How would you like to authenticate GitHub CLI?":
-			return prompter.IndexFor(opts, "Paste an authentication token")
-		}
-		return -1, prompter.NoSuchPromptErr(prompt)
-	}
-	pm.PasswordFunc = func(_ string) (string, error) {
-		return "monkey", nil
-	}
-	pm.ConfirmFunc = func(prompt string, _ bool) (bool, error) {
-		return true, nil
-	}
-	pm.AuthTokenFunc = func() (string, error) {
-		return "ATOKEN", nil
-	}
-	pm.InputFunc = func(_, _ string) (string, error) {
-		return "Test Key", nil
-	}
-
-	rs, runRestore := run.Stub()
-	defer runRestore(t)
-
-	keyFile := filepath.Join(dir, "id_ed25519")
-	rs.Register(`ssh-keygen`, 0, "", func(args []string) {
-		expected := []string{
-			"ssh-keygen", "-t", "ed25519",
-			"-C", "",
-			"-N", "monkey",
-			"-f", keyFile,
-		}
-		assert.Equal(t, expected, args)
-		// simulate that the public key file has been generated
-		_ = os.WriteFile(keyFile+".pub", []byte("PUBKEY asdf"), 0600)
-	})
-
-	cfg := tinyConfig{}
-
-	err := Login(&LoginOptions{
-		IO:          ios,
-		Config:      &cfg,
-		Prompter:    pm,
-		HTTPClient:  &http.Client{Transport: &tr},
-		Hostname:    "example.com",
-		Interactive: true,
-		sshContext: ssh.Context{
-			ConfigDir: dir,
-			KeygenExe: "ssh-keygen",
+				Hostname:    "example.com",
+				Interactive: true,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "api/v3/"),
+					httpmock.ScopesResponder("repo,read:org"))
+				reg.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StringResponse(`{"data":{"viewer":{ "login": "monalisa" }}}`))
+				reg.Register(
+					httpmock.REST("GET", "api/v3/user/keys"),
+					httpmock.StringResponse(`[]`))
+				reg.Register(
+					httpmock.REST("POST", "api/v3/user/keys"),
+					httpmock.StringResponse(`{}`))
+			},
+			runStubs: func(t *testing.T, cs *run.CommandStubber, opts *LoginOptions) {
+				dir := t.TempDir()
+				keyFile := filepath.Join(dir, "id_ed25519")
+				cs.Register(`ssh-keygen`, 0, "", func(args []string) {
+					expected := []string{
+						"ssh-keygen", "-t", "ed25519",
+						"-C", "",
+						"-N", "monkey",
+						"-f", keyFile,
+					}
+					assert.Equal(t, expected, args)
+					// simulate that the public key file has been generated
+					_ = os.WriteFile(keyFile+".pub", []byte("PUBKEY asdf"), 0600)
+				})
+				opts.sshContext = ssh.Context{
+					ConfigDir: dir,
+					KeygenExe: "ssh-keygen",
+				}
+			},
+			wantsConfig: map[string]string{
+				"example.com:user":         "monalisa",
+				"example.com:oauth_token":  "ATOKEN",
+				"example.com:git_protocol": "ssh",
+			},
+			stderrAssert: func(t *testing.T, opts *LoginOptions, stderr string) {
+				assert.Equal(t, heredoc.Docf(`
+				Tip: you can generate a Personal Access Token here https://example.com/settings/tokens
+				The minimum required scopes are 'repo', 'read:org', 'admin:public_key'.
+				- gh config set -h example.com git_protocol ssh
+				✓ Configured git protocol
+				✓ Uploaded the SSH key to your GitHub account: %s/id_ed25519.pub
+				✓ Logged in as monalisa
+			`, opts.sshContext.ConfigDir), stderr)
+			},
 		},
-	})
-	assert.NoError(t, err)
+		{
+			name: "tty, --git-protocol ssh, prompt (create key: yes)",
+			opts: LoginOptions{
+				Prompter: &prompter.PrompterMock{
+					SelectFunc: func(prompt, _ string, opts []string) (int, error) {
+						switch prompt {
+						case "How would you like to authenticate GitHub CLI?":
+							return prompter.IndexFor(opts, "Paste an authentication token")
+						}
+						return -1, prompter.NoSuchPromptErr(prompt)
+					},
+					PasswordFunc: func(_ string) (string, error) {
+						return "monkey", nil
+					},
+					ConfirmFunc: func(prompt string, _ bool) (bool, error) {
+						return true, nil
+					},
+					AuthTokenFunc: func() (string, error) {
+						return "ATOKEN", nil
+					},
+					InputFunc: func(_, _ string) (string, error) {
+						return "Test Key", nil
+					},
+				},
 
-	assert.Equal(t, "", stdout.String())
-	assert.Equal(t, heredoc.Docf(`
-		Tip: you can generate a Personal Access Token here https://example.com/settings/tokens
-		The minimum required scopes are 'repo', 'read:org', 'admin:public_key'.
-		- gh config set -h example.com git_protocol ssh
-		✓ Configured git protocol
-		✓ Uploaded the SSH key to your GitHub account: %s.pub
-		✓ Logged in as monalisa
-	`, keyFile), stderr.String())
-
-	assert.Equal(t, "monalisa", cfg["example.com:user"])
-	assert.Equal(t, "ATOKEN", cfg["example.com:oauth_token"])
-	assert.Equal(t, "ssh", cfg["example.com:git_protocol"])
-}
-
-func TestLogin_noSSHPrompt(t *testing.T) {
-	dir := t.TempDir()
-	ios, _, stdout, stderr := iostreams.Test()
-
-	tr := httpmock.Registry{}
-	defer tr.Verify(t)
-
-	tr.Register(
-		httpmock.REST("GET", "api/v3/"),
-		httpmock.ScopesResponder("repo,read:org"))
-	tr.Register(
-		httpmock.GraphQL(`query UserCurrent\b`),
-		httpmock.StringResponse(`{"data":{"viewer":{ "login": "monalisa" }}}`))
-
-	pm := &prompter.PrompterMock{}
-	pm.SelectFunc = func(prompt, _ string, opts []string) (int, error) {
-		if prompt == "How would you like to authenticate GitHub CLI?" {
-			return prompter.IndexFor(opts, "Paste an authentication token")
-		}
-		return -1, prompter.NoSuchPromptErr(prompt)
-	}
-	pm.PasswordFunc = func(prompt string) (string, error) {
-		return "", prompter.NoSuchPromptErr(prompt)
-	}
-	pm.ConfirmFunc = func(prompt string, _ bool) (bool, error) {
-		return false, prompter.NoSuchPromptErr(prompt)
-	}
-	pm.AuthTokenFunc = func() (string, error) {
-		return "ATOKEN", nil
-	}
-	pm.InputFunc = func(prompt, _ string) (string, error) {
-		return "", prompter.NoSuchPromptErr(prompt)
-	}
-
-	cfg := tinyConfig{}
-
-	err := Login(&LoginOptions{
-		IO:               ios,
-		Config:           &cfg,
-		Prompter:         pm,
-		HTTPClient:       &http.Client{Transport: &tr},
-		Hostname:         "example.com",
-		Interactive:      true,
-		GitProtocol:      "SSH",
-		SkipSSHKeyPrompt: true,
-		sshContext: ssh.Context{
-			ConfigDir: dir,
-			KeygenExe: "ssh-keygen",
+				Hostname:    "example.com",
+				Interactive: true,
+				GitProtocol: "SSH",
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "api/v3/"),
+					httpmock.ScopesResponder("repo,read:org"))
+				reg.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StringResponse(`{"data":{"viewer":{ "login": "monalisa" }}}`))
+				reg.Register(
+					httpmock.REST("GET", "api/v3/user/keys"),
+					httpmock.StringResponse(`[]`))
+				reg.Register(
+					httpmock.REST("POST", "api/v3/user/keys"),
+					httpmock.StringResponse(`{}`))
+			},
+			runStubs: func(t *testing.T, cs *run.CommandStubber, opts *LoginOptions) {
+				dir := t.TempDir()
+				keyFile := filepath.Join(dir, "id_ed25519")
+				cs.Register(`ssh-keygen`, 0, "", func(args []string) {
+					expected := []string{
+						"ssh-keygen", "-t", "ed25519",
+						"-C", "",
+						"-N", "monkey",
+						"-f", keyFile,
+					}
+					assert.Equal(t, expected, args)
+					// simulate that the public key file has been generated
+					_ = os.WriteFile(keyFile+".pub", []byte("PUBKEY asdf"), 0600)
+				})
+				opts.sshContext = ssh.Context{
+					ConfigDir: dir,
+					KeygenExe: "ssh-keygen",
+				}
+			},
+			wantsConfig: map[string]string{
+				"example.com:user":         "monalisa",
+				"example.com:oauth_token":  "ATOKEN",
+				"example.com:git_protocol": "ssh",
+			},
+			stderrAssert: func(t *testing.T, opts *LoginOptions, stderr string) {
+				assert.Equal(t, heredoc.Docf(`
+				Tip: you can generate a Personal Access Token here https://example.com/settings/tokens
+				The minimum required scopes are 'repo', 'read:org', 'admin:public_key'.
+				- gh config set -h example.com git_protocol ssh
+				✓ Configured git protocol
+				✓ Uploaded the SSH key to your GitHub account: %s/id_ed25519.pub
+				✓ Logged in as monalisa
+			`, opts.sshContext.ConfigDir), stderr)
+			},
 		},
-	})
-	assert.NoError(t, err)
+		{
+			name: "tty, --git-protocol ssh, --skip-ssh-key",
+			opts: LoginOptions{
+				Prompter: &prompter.PrompterMock{
+					SelectFunc: func(prompt, _ string, opts []string) (int, error) {
+						if prompt == "How would you like to authenticate GitHub CLI?" {
+							return prompter.IndexFor(opts, "Paste an authentication token")
+						}
+						return -1, prompter.NoSuchPromptErr(prompt)
+					},
+					AuthTokenFunc: func() (string, error) {
+						return "ATOKEN", nil
+					},
+				},
 
-	assert.Equal(t, "", stdout.String())
-	assert.Equal(t, heredoc.Doc(`
-		Tip: you can generate a Personal Access Token here https://example.com/settings/tokens
-		The minimum required scopes are 'repo', 'read:org'.
-		- gh config set -h example.com git_protocol ssh
-		✓ Configured git protocol
-		✓ Logged in as monalisa
-	`), stderr.String())
+				Hostname:         "example.com",
+				Interactive:      true,
+				GitProtocol:      "SSH",
+				SkipSSHKeyPrompt: true,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "api/v3/"),
+					httpmock.ScopesResponder("repo,read:org"))
+				reg.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StringResponse(`{"data":{"viewer":{ "login": "monalisa" }}}`))
+			},
+			wantsConfig: map[string]string{
+				"example.com:user":         "monalisa",
+				"example.com:oauth_token":  "ATOKEN",
+				"example.com:git_protocol": "ssh",
+			},
+			stderr: heredoc.Doc(`
+				Tip: you can generate a Personal Access Token here https://example.com/settings/tokens
+				The minimum required scopes are 'repo', 'read:org'.
+				- gh config set -h example.com git_protocol ssh
+				✓ Configured git protocol
+				✓ Logged in as monalisa
+			`),
+		},
+	}
 
-	assert.Equal(t, "monalisa", cfg["example.com:user"])
-	assert.Equal(t, "ATOKEN", cfg["example.com:oauth_token"])
-	assert.Equal(t, "ssh", cfg["example.com:git_protocol"])
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, reg)
+			}
+
+			cfg := tinyConfig{}
+			ios, _, stdout, stderr := iostreams.Test()
+
+			tt.opts.IO = ios
+			tt.opts.Config = &cfg
+			tt.opts.HTTPClient = &http.Client{Transport: reg}
+
+			if tt.runStubs != nil {
+				rs, runRestore := run.Stub()
+				defer runRestore(t)
+				tt.runStubs(t, rs, &tt.opts)
+			}
+
+			err := Login(&tt.opts)
+
+			if tt.wantsErr != "" {
+				assert.EqualError(t, err, tt.wantsErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantsConfig, map[string]string(cfg))
+			}
+
+			assert.Equal(t, tt.stdout, stdout.String())
+
+			if tt.stderrAssert != nil {
+				tt.stderrAssert(t, &tt.opts, stderr.String())
+			} else {
+				assert.Equal(t, tt.stderr, stderr.String())
+			}
+		})
+	}
 }
 
 func Test_scopesSentence(t *testing.T) {

--- a/pkg/cmd/auth/shared/login_flow_test.go
+++ b/pkg/cmd/auth/shared/login_flow_test.go
@@ -115,9 +115,9 @@ func TestLogin(t *testing.T) {
 				The minimum required scopes are 'repo', 'read:org', 'admin:public_key'.
 				- gh config set -h example.com git_protocol ssh
 				✓ Configured git protocol
-				✓ Uploaded the SSH key to your GitHub account: %s/id_ed25519.pub
+				✓ Uploaded the SSH key to your GitHub account: %s
 				✓ Logged in as monalisa
-			`, opts.sshContext.ConfigDir), stderr)
+			`, filepath.Join(opts.sshContext.ConfigDir, "id_ed25519.pub")), stderr)
 			},
 		},
 		{
@@ -193,9 +193,9 @@ func TestLogin(t *testing.T) {
 				The minimum required scopes are 'repo', 'read:org', 'admin:public_key'.
 				- gh config set -h example.com git_protocol ssh
 				✓ Configured git protocol
-				✓ Uploaded the SSH key to your GitHub account: %s/id_ed25519.pub
+				✓ Uploaded the SSH key to your GitHub account: %s
 				✓ Logged in as monalisa
-			`, opts.sshContext.ConfigDir), stderr)
+			`, filepath.Join(opts.sshContext.ConfigDir, "id_ed25519.pub")), stderr)
 			},
 		},
 		{


### PR DESCRIPTION
This PR adds the new `--skip-ssh-key` option to the `auth login` command, which will disable further SSH key-related prompts.

Fixes #8508 