### PR TITLE
Add support to `attestation` command for more predicate types.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
 	github.com/henvic/httpretty v0.1.3
-	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-colorable v0.1.13
@@ -97,6 +96,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.5 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/in-toto/in-toto-golang v0.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/itchyny/gojq v0.12.15 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect

--- a/pkg/cmd/attestation/download/download.go
+++ b/pkg/cmd/attestation/download/download.go
@@ -20,7 +20,7 @@ func NewDownloadCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Comman
 	opts := &Options{}
 	downloadCmd := &cobra.Command{
 		Use:   "download [<file-path> | oci://<image-uri>] [--owner | --repo]",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.MinimumArgs(1, "must specify file path or container image URI, as well as one of --owner or --repo"),
 		Short: "Download an artifact's Sigstore bundle(s) for offline use",
 		Long: heredoc.Docf(`
 			Download an artifact's attestations, aka Sigstore bundle(s), for offline use.

--- a/pkg/cmd/attestation/download/options.go
+++ b/pkg/cmd/attestation/download/options.go
@@ -22,6 +22,7 @@ type Options struct {
 	Store           MetadataStore
 	OCIClient       oci.Client
 	Owner           string
+	PredicateType   string
 	Repo            string
 }
 

--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -2,6 +2,7 @@ package verification
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -112,4 +113,28 @@ func GetRemoteAttestations(c FetchAttestationsConfig) ([]*api.Attestation, error
 		return attestations, nil
 	}
 	return nil, fmt.Errorf("owner or repo must be provided")
+}
+
+type DssePayload struct {
+	PredicateType string `json:"predicateType"`
+}
+
+func FilterAttestations(predicateType string, attestations []*api.Attestation) []*api.Attestation {
+	filteredAttestations := []*api.Attestation{}
+
+	for _, each := range attestations {
+		dsseEnvelope := each.Bundle.GetDsseEnvelope()
+		if dsseEnvelope != nil {
+			var dssePayload DssePayload
+			if err := json.Unmarshal([]byte(dsseEnvelope.Payload), &dssePayload); err != nil {
+				// Don't fail just because a single entry can't be unmarshalled
+				continue
+			}
+			if dssePayload.PredicateType == predicateType {
+				filteredAttestations = append(filteredAttestations, each)
+			}
+		}
+	}
+
+	return filteredAttestations
 }

--- a/pkg/cmd/attestation/verification/attestation_test.go
+++ b/pkg/cmd/attestation/verification/attestation_test.go
@@ -3,7 +3,12 @@ package verification
 import (
 	"testing"
 
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	dsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
 )
 
 func TestLoadBundlesFromJSONLinesFile(t *testing.T) {
@@ -46,4 +51,52 @@ func TestGetLocalAttestations(t *testing.T) {
 		require.ErrorIs(t, err, ErrLocalAttestations)
 		require.Nil(t, attestations)
 	})
+}
+
+func TestFilterAttestations(t *testing.T) {
+	attestations := []*api.Attestation{
+		{
+			Bundle: &bundle.ProtobufBundle{
+				Bundle: &protobundle.Bundle{
+					Content: &protobundle.Bundle_DsseEnvelope{
+						DsseEnvelope: &dsse.Envelope{
+							PayloadType: "application/vnd.in-toto+json",
+							Payload:     []byte("{\"predicateType\": \"https://slsa.dev/provenance/v1\"}"),
+						},
+					},
+				},
+			},
+		},
+		{
+			Bundle: &bundle.ProtobufBundle{
+				Bundle: &protobundle.Bundle{
+					Content: &protobundle.Bundle_DsseEnvelope{
+						DsseEnvelope: &dsse.Envelope{
+							PayloadType: "application/vnd.something-other-than-in-toto+json",
+							Payload:     []byte("{\"predicateType\": \"https://slsa.dev/provenance/v1\"}"),
+						},
+					},
+				},
+			},
+		},
+		{
+			Bundle: &bundle.ProtobufBundle{
+				Bundle: &protobundle.Bundle{
+					Content: &protobundle.Bundle_DsseEnvelope{
+						DsseEnvelope: &dsse.Envelope{
+							PayloadType: "application/vnd.in-toto+json",
+							Payload:     []byte("{\"predicateType\": \"https://spdx.dev/Document/v2.3\"}"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	filtered := FilterAttestations("https://slsa.dev/provenance/v1", attestations)
+
+	require.Len(t, filtered, 1)
+
+	filtered = FilterAttestations("NonExistantPredicate", attestations)
+	require.Len(t, filtered, 0)
 }

--- a/pkg/cmd/attestation/verify/options.go
+++ b/pkg/cmd/attestation/verify/options.go
@@ -21,6 +21,7 @@ type Options struct {
 	NoPublicGood         bool
 	OIDCIssuer           string
 	Owner                string
+	PredicateType        string
 	Repo                 string
 	SAN                  string
 	SANRegex             string

--- a/pkg/cmd/attestation/verify/policy.go
+++ b/pkg/cmd/attestation/verify/policy.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	GitHubOIDCIssuer  = "https://token.actions.githubusercontent.com"
-	SLSAPredicateType = "https://slsa.dev/provenance/v1"
 	// represents the GitHub hosted runner in the certificate RunnerEnvironment extension
 	GitHubRunner = "github-hosted"
 )

--- a/pkg/cmd/attestation/verify/policy.go
+++ b/pkg/cmd/attestation/verify/policy.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	GitHubOIDCIssuer  = "https://token.actions.githubusercontent.com"
+	GitHubOIDCIssuer = "https://token.actions.githubusercontent.com"
 	// represents the GitHub hosted runner in the certificate RunnerEnvironment extension
 	GitHubRunner = "github-hosted"
 )

--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -20,7 +20,7 @@ func NewVerifyCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command 
 	opts := &Options{}
 	verifyCmd := &cobra.Command{
 		Use:   "verify [<file-path> | oci://<image-uri>] [--owner | --repo]",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.MinimumArgs(1, "must specify file path or container image URI, as well as one of --owner or --repo"),
 		Short: "Verify an artifact's integrity using attestations",
 		Long: heredoc.Docf(`
 			Verify the integrity and provenance of an artifact using its associated

--- a/pkg/cmd/attestation/verify/verify_test.go
+++ b/pkg/cmd/attestation/verify/verify_test.go
@@ -19,9 +19,6 @@ import (
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/in-toto/in-toto-golang/in_toto"
-	"github.com/sigstore/sigstore-go/pkg/verify"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -381,21 +378,4 @@ func TestRunVerify(t *testing.T) {
 		customOpts.BundlePath = ""
 		require.Error(t, runVerify(&customOpts))
 	})
-}
-
-func TestVerifySLSAPredicateType_InvalidPredicate(t *testing.T) {
-	statement := &in_toto.Statement{}
-	statement.PredicateType = "some-other-predicate-type"
-
-	apr := []*verification.AttestationProcessingResult{
-		{
-			VerificationResult: &verify.VerificationResult{
-				Statement: statement,
-			},
-		},
-	}
-
-	err := verifySLSAPredicateType(io.NewTestHandler(), apr)
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrNoMatchingSLSAPredicate)
 }


### PR DESCRIPTION
Before, we required all attestations have predicateType https://slsa.dev/provenance/v1. This allows you to use other predicate types, and adds the ability to filter responses from the API for a particular predicate type.
