### PR TITLE
Update install_linux.md

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -14,7 +14,7 @@ our release schedule.
 Install:
 
 ```bash
-(type -p wget || (sudo apt update && sudo apt-get install wget -y)) \
+(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
 && sudo mkdir -p -m 755 /etc/apt/keyrings \
 && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
 && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -14,7 +14,9 @@ our release schedule.
 Install:
 
 ```bash
-sudo mkdir -p -m 755 /etc/apt/keyrings && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+(test -x /usr/bin/wget || which wget || sudo apt-get install wget -y) \
+&& sudo mkdir -p -m 755 /etc/apt/keyrings \
+&& wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
 && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
 && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
 && sudo apt update \

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -14,7 +14,7 @@ our release schedule.
 Install:
 
 ```bash
-(test -x /usr/bin/wget || which wget || sudo apt-get install wget -y) \
+(type -p wget || (sudo apt update && sudo apt-get install wget -y)) \
 && sudo mkdir -p -m 755 /etc/apt/keyrings \
 && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
 && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
Install `wget` if it is not found. `wget` is then used two lines later for installing `gh`.

Prior to this change, the instructions can fail if attempted on a Debian-based distro that does not include `wget`.

Fixes 8952