### PR TITLE
Fix `go` directive in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cli/cli/v2
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/cli/cli/v2
 
-go 1.22.0
+go 1.22
+
+toolchain go1.22.2
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
The docs[1] say:

> The version must be a valid Go version, such as 1.9, 1.14, or 1.21rc1.

A 'Go version' is a go release[2], but there's no release of Go `1.22` (compare with Go `1.20` that _does_ have a release) the first release of Go `1.22` was Go `1.22.0` so use that here.

This will cause issue in any environment where parsing this module triggers a toolchain download (i.e. something running Go `1.21`, since before then the directive was only advisory, and with the `GOTOOLCHAIN` env var not set to `none`), for example:

    $ docker run --rm --interactive --volume "$PWD:/work" --workdir /work golang:1.21.0 go mod tidy
    go: downloading go1.22 (linux/amd64)
    go: download go1.22 for linux/amd64: toolchain not available

This change should have no impact on any setup that works with the current directive.

There's more detail and discussions around this at[4]

[1] https://go.dev/ref/mod#go-mod-file-go
[2] https://go.dev/doc/toolchain#version
[3] https://go.dev/doc/devel/release
[4] https://github.com/golang/go/issues/62278

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
