### PR TITLE
Fix cache contention in Go CI jobs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,14 +21,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Restore Go modules cache
-        uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}-${{ hashFiles('go.mod') }}
-          restore-keys: |
-            go-${{ runner.os }}-
-
       - name: Download dependencies
         run: go mod download
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,14 +27,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Restore Go modules cache
-        uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: go-${{ runner.os }}-${{ hashFiles('go.mod') }}
-          restore-keys: |
-            go-${{ runner.os }}-
-
       - name: Verify dependencies
         run: |
           go mod verify


### PR DESCRIPTION
Fix the `Set up go` and `Restore Go modules cache` steps both trying to
read/write the same contents. Since the `setup-go` step runs first this
results in the "restore cache" step trying to write the same contents
under `~/go/pkg/mod` which results in errors like (e.g. random
example[1]):

    /usr/bin/tar -xf /home/runner/work/_temp/6d12957f-f226-455e-b99c-fa7ee8c962cb/cache.tzst -P -C /home/runner/work/cli/cli --use-compress-program unzstd
    /usr/bin/tar: ../../../go/pkg/mod/golang.org/x/net@v0.21.0/go.sum: Cannot open: File exists
    Error: /usr/bin/tar: ../../../go/pkg/mod/golang.org/x/net@v0.21.0/proxy/proxy.go: Cannot open: File exists
    Error: /usr/bin/tar: ../../../go/pkg/mod/golang.org/x/net@v0.21.0/proxy/socks5.go: Cannot open: File exists
    Error: /usr/bin/tar: ../../../go/pkg/mod/golang.org/x/net@v0.21.0/proxy/dial_test.go: Cannot open: File exists

Since restoring fails, the cache job thinks no cache hit was made and
proceeds to try and save, but since it may well have fetched a valid
cache this can also error (again, see[1]):

    Post job cleanup.
    /usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/cli/cli --files-from manifest.txt --use-compress-program zstdmt
    Failed to save: Unable to reserve cache with key go-Linux-1b4ae53bfd76c3b70f62d419e17f36544d0a1331f04b13d2a942e7752e3789c3, another job may be creating this cache. More details: Cache already exists. Scope: refs/heads/trunk, Key: go-Linux-1b4ae53bfd76c3b70f62d419e17f36544d0a1331f04b13d2a942e7752e3789c3, Version: 2a8d0f2be1a88abb057cd9fcea9832bd16e7ab71798dbf93cd890eb9add83cf6

To avoid this, just rely on the caching functionality of the `seutp-go`
action.

For some context, It appears this cache behaviour was added with
cb7315c85d3c0e010ba117ca7e692ed6f18f16c5 when these workflows were still
run with `setup-go@v2`:

    $ git show cb7315c85d3c0e010ba117ca7e692ed6f18f16c5:{.github/workflows/go.yml,.github/workflows/lint.yml} | grep 'actions/setup-go'
            uses: actions/setup-go@v2
            uses: actions/setup-go@v2

which is before caching behaviour was added (with `v3.2.0`[2]).

[1] https://github.com/cli/cli/actions/runs/8654869114/job/23732868571
[2] https://github.com/actions/setup-go/releases/tag/v3.2.0