### PR TITLE
Improve gh run rerun docs

### DIFF
--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -52,6 +52,8 @@ func NewCmdRerun(f *cmdutil.Factory, runF func(*RerunOptions) error) *cobra.Comm
 			API returning %[1]s404 NOT FOUND%[1]s. Instead, you can get the correct job IDs using the following command:
 			
 				gh run view <run-id> --json jobs --jq '.jobs[] | {name, databaseId}'
+
+			You will need to use databaseId field for triggering job re-runs.
 		`, "`"),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -84,7 +86,7 @@ func NewCmdRerun(f *cmdutil.Factory, runF func(*RerunOptions) error) *cobra.Comm
 	}
 
 	cmd.Flags().BoolVar(&opts.OnlyFailed, "failed", false, "Rerun only failed jobs, including dependencies")
-	cmd.Flags().StringVarP(&opts.JobID, "job", "j", "", "Rerun a specific job from a run, including dependencies")
+	cmd.Flags().StringVarP(&opts.JobID, "job", "j", "", "Rerun a specific job ID from a run, including dependencies")
 	cmd.Flags().BoolVarP(&opts.Debug, "debug", "d", false, "Rerun with debug logging")
 
 	return cmd

--- a/pkg/cmd/run/rerun/rerun.go
+++ b/pkg/cmd/run/rerun/rerun.go
@@ -69,7 +69,11 @@ func NewCmdRerun(f *cmdutil.Factory, runF func(*RerunOptions) error) *cobra.Comm
 			}
 
 			if opts.RunID != "" && opts.JobID != "" {
-				return cmdutil.FlagErrorf("specify only one of `<run-id>` or `--job`")
+				opts.RunID = ""
+				if opts.IO.CanPrompt() {
+					cs := opts.IO.ColorScheme()
+					fmt.Fprintf(opts.IO.ErrOut, "%s both run and job IDs specified; ignoring run ID\n", cs.WarningIcon())
+				}
 			}
 
 			if runF != nil {

--- a/pkg/cmd/run/rerun/rerun_test.go
+++ b/pkg/cmd/run/rerun/rerun_test.go
@@ -78,10 +78,13 @@ func TestNewCmdRerun(t *testing.T) {
 			},
 		},
 		{
-			name:     "with args jobID and runID fails",
-			tty:      true,
-			cli:      "1234 --job 5678",
-			wantsErr: true,
+			name: "with args jobID and runID uses jobID",
+			tty:  true,
+			cli:  "1234 --job 5678",
+			wants: RerunOptions{
+				JobID: "5678",
+				RunID: "",
+			},
 		},
 		{
 			name:     "with arg job with no ID fails",


### PR DESCRIPTION
I have decided to not change the type of the argument since string is used in
several other places for jobID and I think it makes sense to keep that consistent.

If needed that would be better done as a separate PR

Fixes #8967

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->