### PR TITLE
A minimal example of not requiring auth for some cases of gh attestation verify

### DIFF
--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -84,6 +84,20 @@ func NewVerifyCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command 
 			// set policy flags based on what has been provided
 			opts.SetPolicyFlags()
 
+			// check if we will be calling GitHub APIs
+			if opts.BundlePath == "" {
+				// If so, ensure user is authenticated
+				factoryConfig, err := f.Config()
+				if err != nil {
+					return err
+				}
+
+				authOk := cmdutil.CheckAuth(factoryConfig)
+				if !authOk {
+					return fmt.Errorf("Please supply a bundle or authenticate to gh")
+				}
+			}
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -122,6 +136,11 @@ func NewVerifyCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command 
 			return nil
 		},
 	}
+
+	// This command supports offline verification if the bundle is provided.
+	// So we disable the auth check here and manually check auth in the command,
+	// if needed.
+	cmdutil.DisableAuthCheck(verifyCmd)
 
 	// general flags
 	verifyCmd.Flags().StringVarP(&opts.BundlePath, "bundle", "b", "", "Path to bundle on disk, either a single bundle in a JSON file or a JSON lines file with multiple bundles")

--- a/pkg/cmd/attestation/verify/verify_test.go
+++ b/pkg/cmd/attestation/verify/verify_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/artifact/oci"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/io"
@@ -32,6 +33,12 @@ var (
 	bundlePath   = test.NormalizeRelativePath("../test/data/sigstore-js-2.1.0-bundle.json")
 )
 
+func MockAuthentication() *config.AuthConfig {
+	authConfig := config.AuthConfig{}
+	authConfig.SetActiveToken("asdf", "example.com")
+	return &authConfig
+}
+
 func TestNewVerifyCmd(t *testing.T) {
 	testIO, _, _, _ := iostreams.Test()
 	f := &cmdutil.Factory{
@@ -41,6 +48,12 @@ func TestNewVerifyCmd(t *testing.T) {
 			client := &http.Client{}
 			httpmock.ReplaceTripper(client, reg)
 			return client, nil
+		},
+		Config: func() (config.Config, error) {
+			configMock := config.ConfigMock{
+				AuthenticationFunc: MockAuthentication,
+			}
+			return &configMock, nil
 		},
 	}
 


### PR DESCRIPTION
If the user does **not** supply a bundle, then we call a GitHub REST API to fetch the bundle. However, if the user **does** supply a bundle, `gh attestation verify` doesn't make any GitHub REST API calls, and so the user does not need to be authenticated.