### PR TITLE
Improve errors when loading bundle locally fails

### DIFF
--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 )
 
-var ErrLocalAttestations = errors.New("failed to load local attestations")
+var ErrUnrecognisedBundleExtension = errors.New("bundle file extension not supported, must be json or jsonl")
 
 type FetchAttestationsConfig struct {
 	APIClient  api.Client
@@ -52,7 +52,7 @@ func GetLocalAttestations(path string) ([]*api.Attestation, error) {
 		}
 		return attestations, nil
 	}
-	return nil, ErrLocalAttestations
+	return nil, ErrUnrecognisedBundleExtension
 }
 
 func loadBundleFromJSONFile(path string) ([]*api.Attestation, error) {

--- a/pkg/cmd/attestation/verification/attestation_test.go
+++ b/pkg/cmd/attestation/verification/attestation_test.go
@@ -48,7 +48,7 @@ func TestGetLocalAttestations(t *testing.T) {
 		path := "../test/data/sigstore-js-2.1.0-bundles.tgz"
 		attestations, err := GetLocalAttestations(path)
 
-		require.ErrorIs(t, err, ErrLocalAttestations)
+		require.ErrorIs(t, err, ErrUnrecognisedBundleExtension)
 		require.Nil(t, attestations)
 	})
 }


### PR DESCRIPTION
### Description

This is the difference between:

```
➜  gh attestation verify ... --bundle attestation.jsonl
Verifying attestations for the artifact found at ...
Failed to verify the artifact: failed to fetch attestations for subject: sha256:5936c74c8999e9fd50ca0658f378a5d3f8492fb04bd77b952942fdbba4d038bb
```

and 

```
➜  gh attestation verify ... --bundle attestation.jsonl
Verifying attestations for the artifact found at ...
Failed to verify the artifact: failed to fetch attestations for subject: sha256:5936c74c8999e9fd50ca0658f378a5d3f8492fb04bd77b952942fdbba4d038bb: bundles could not be loaded from JSON lines file: failed to unmarshal bundle from JSON: proto: unexpected EOF
```

or 

```
➜  gh attestation verify ... --bundle bundle.jso
Verifying attestations for the artifact found at oci://ghcr.io/phillmv/arquivo
Failed to verify the artifact: failed to fetch attestations for subject: sha256:5936c74c8999e9fd50ca0658f378a5d3f8492fb04bd77b952942fdbba4d038b: bundle file extension not supported, must be json or jsonl
```
