### PR TITLE
Remove `Hidden` flag from `gh attestation` command

### DIFF
--- a/pkg/cmd/attestation/attestation.go
+++ b/pkg/cmd/attestation/attestation.go
@@ -15,7 +15,6 @@ func NewCmdAttestation(f *cmdutil.Factory) *cobra.Command {
 		Use:     "attestation [subcommand]",
 		Short:   "Work with artifact attestations",
 		Aliases: []string{"at"},
-		Hidden:  true,
 		Long:    "Download and verify artifact attestations.",
 	}
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

This removes the `Hidden` flag from the `attestation` commands. When a user types `gh --help`, `attestation` will be included in the help string's list of commands with some details.