### PR TITLE
proof of concept for flag-level disable auth check

### DIFF
--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -127,6 +127,7 @@ func NewVerifyCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command 
 
 	// general flags
 	verifyCmd.Flags().StringVarP(&opts.BundlePath, "bundle", "b", "", "Path to bundle on disk, either a single bundle in a JSON file or a JSON lines file with multiple bundles")
+	cmdutil.DisableAuthCheckFlag(verifyCmd.Flags().Lookup("bundle"))
 	cmdutil.StringEnumFlag(verifyCmd, &opts.DigestAlgorithm, "digest-alg", "d", "sha256", []string{"sha256", "sha512"}, "The algorithm used to compute a digest of the artifact")
 	verifyCmd.Flags().StringVarP(&opts.Owner, "owner", "o", "", "GitHub organization to scope attestation lookup by")
 	verifyCmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository name in the format <owner>/<repo>")


### PR DESCRIPTION
Relates #8995 

Building upon the existing command-level disable auth check logic, this commit adds flag-level disable auth check logic for any flag set with `-b,--bundle` flag of `gh attestation verify` being the first use case.

Subsequent commit to build out testing is needed as IsAuthCheckEnabled does not have tests.

### Testing

1. **Build changes and setup temporary working directory**
   
   ```shell
   andyfeller@Andys-MBP:cli/cli ‹andyfeller/flag-level-disableauth›$ make
   go build -trimpath -ldflags "-X github.com/cli/cli/v2/internal/build.Date=2024-04-25 -X github.com/cli/cli/v2/internal/build.Version=v2.48.0-9-g2d910406 " -o bin/gh ./cmd/gh
   
   andyfeller@Andys-MBP:cli/cli ‹andyfeller/flag-level-disableauth›$ mkdir tmp
   andyfeller@Andys-MBP:cli/cli ‹andyfeller/flag-level-disableauth›$ cd tmp 
   ```

1. **Download release artifact(s) built with attestation signatures captured**
   
   ```shell
   andyfeller@Andys-MBP:cli/tmp ‹andyfeller/flag-level-disableauth›$ ../bin/gh release download v0.0.10 --repo advanced-security/gh-sbom
   andyfeller@Andys-MBP:cli/tmp ‹andyfeller/flag-level-disableauth*›$ ll
   total 152360
   -rw-r--r--  1 andyfeller  staff   5.8M Apr 25 09:41 android-amd64
   -rw-r--r--  1 andyfeller  staff   5.6M Apr 25 09:41 android-arm64
   -rw-r--r--  1 andyfeller  staff   5.6M Apr 25 09:41 darwin-amd64
   -rw-r--r--  1 andyfeller  staff   5.5M Apr 25 09:41 darwin-arm64
   -rw-r--r--  1 andyfeller  staff   5.0M Apr 25 09:41 freebsd-386
   -rw-r--r--  1 andyfeller  staff   5.3M Apr 25 09:41 freebsd-amd64
   -rw-r--r--  1 andyfeller  staff   5.1M Apr 25 09:41 freebsd-arm64
   -rw-r--r--  1 andyfeller  staff   5.1M Apr 25 09:41 linux-386
   -rw-r--r--  1 andyfeller  staff   5.3M Apr 25 09:41 linux-amd64
   -rw-r--r--  1 andyfeller  staff   5.2M Apr 25 09:41 linux-arm
   -rw-r--r--  1 andyfeller  staff   5.1M Apr 25 09:41 linux-arm64
   -rw-r--r--  1 andyfeller  staff   5.3M Apr 25 09:41 windows-386.exe
   -rw-r--r--  1 andyfeller  staff   5.5M Apr 25 09:41 windows-amd64.exe
   -rw-r--r--  1 andyfeller  staff   5.2M Apr 25 09:41 windows-arm64.exe
   ```

1. **Download artifact attestation bundle for artifact and verify**
   
   ```shell
   andyfeller@Andys-MBP:cli/tmp ‹andyfeller/flag-level-disableauth*›$ ../bin/gh attestation download darwin-amd64 --repo advanced-security/gh-sbom
   Wrote attestations to file sha256:ab1bae8f19e92e1dce879373194627c1b322575618d13dd635572777d6df2437.jsonl.
   Any previous content has been overwritten
   
   The trusted metadata is now available at sha256:ab1bae8f19e92e1dce879373194627c1b322575618d13dd635572777d6df2437.jsonl


   andyfeller@Andys-MBP:cli/tmp ‹andyfeller/flag-level-disableauth*›$ ../bin/gh attestation verify darwin-amd64 --bundle sha256:ab1bae8f19e92e1dce879373194627c1b322575618d13dd635572777d6df2437.jsonl --repo advanced-security/gh-sbom
   Loaded digest sha256:ab1bae8f19e92e1dce879373194627c1b322575618d13dd635572777d6df2437 for file://darwin-amd64
   Loaded 2 attestations from sha256:ab1bae8f19e92e1dce879373194627c1b322575618d13dd635572777d6df2437.jsonl
   ✓ Verification succeeded!
   
   sha256:ab1bae8f19e92e1dce879373194627c1b322575618d13dd635572777d6df2437 was attested by:
   REPO                       PREDICATE_TYPE                  WORKFLOW                                        
   advanced-security/gh-sbom  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/v0.0.10
   advanced-security/gh-sbom  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/vtesting
   ```

1. **Logout of `github.com`**

   ```shell
   andyfeller@Andys-MBP:cli/tmp ‹andyfeller/flag-level-disableauth*›$ ../bin/gh auth status
   staffship-01.ghe.com
     ✓ Logged in to staffship-01.ghe.com account andyfeller (keyring)
     - Active account: true
     - Git operations protocol: https
     - Token: gho_************************************
     - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
   
   github.ghe.com
     ✓ Logged in to github.ghe.com account andyfeller (keyring)
     - Active account: true
     - Git operations protocol: https
     - Token: gho_************************************
     - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
   
   github.com
     ✓ Logged in to github.com account andyfeller (keyring)
     - Active account: true
     - Git operations protocol: ssh
     - Token: gho_************************************
     - Token scopes: 'admin:public_key', 'gist', 'read:org', 'repo'
   
   andyfeller@Andys-MBP:cli/tmp ‹andyfeller/flag-level-disableauth*›$ ../bin/gh auth logout
   ? What account do you want to log out of? andyfeller (github.com)
   ✓ Logged out of github.com account andyfeller
   
   andyfeller@Andys-MBP:cli/tmp ‹andyfeller/flag-level-disableauth*›$ ../bin/gh auth status
   staffship-01.ghe.com
     ✓ Logged in to staffship-01.ghe.com account andyfeller (keyring)
     - Active account: true
     - Git operations protocol: https
     - Token: gho_************************************
     - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
   
   github.ghe.com
     ✓ Logged in to github.ghe.com account andyfeller (keyring)
     - Active account: true
     - Git operations protocol: https
     - Token: gho_************************************
     - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
   ```

1. **Verify that `gh attestation verify -b` does not require auth with flag**
   
   ```shell
   andyfeller@Andys-MBP:cli/tmp ‹andyfeller/flag-level-disableauth*›$ ../bin/gh attestation verify darwin-amd64 --bundle sha256:ab1bae8f19e92e1dce879373194627c1b322575618d13dd635572777d6df2437.jsonl --repo advanced-security/gh-sbom
   Loaded digest sha256:ab1bae8f19e92e1dce879373194627c1b322575618d13dd635572777d6df2437 for file://darwin-amd64
   Loaded 2 attestations from sha256:ab1bae8f19e92e1dce879373194627c1b322575618d13dd635572777d6df2437.jsonl
   ✓ Verification succeeded!
   
   sha256:ab1bae8f19e92e1dce879373194627c1b322575618d13dd635572777d6df2437 was attested by:
   REPO                       PREDICATE_TYPE                  WORKFLOW                                        
   advanced-security/gh-sbom  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/v0.0.10
   advanced-security/gh-sbom  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/vtesting
   ```

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
