### PR TITLE
Add colon for `gh secret set`

### DIFF
--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -111,7 +111,7 @@ func Login(opts *LoginOptions) error {
 
 			if sshChoice {
 				passphrase, err := opts.Prompter.Password(
-					"Enter a passphrase for your new SSH key (Optional)")
+					"Enter a passphrase for your new SSH key (Optional):")
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -379,7 +379,7 @@ func getBody(opts *SetOptions) ([]byte, error) {
 	}
 
 	if opts.IO.CanPrompt() {
-		bodyInput, err := opts.Prompter.Password("Paste your secret")
+		bodyInput, err := opts.Prompter.Password("Paste your secret:")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -596,7 +596,7 @@ func Test_getBodyPrompt(t *testing.T) {
 	ios.SetStdoutTTY(true)
 
 	pm := prompter.NewMockPrompter(t)
-	pm.RegisterPassword("Paste your secret", func(_ string) (string, error) {
+	pm.RegisterPassword("Paste your secret:", func(_ string) (string, error) {
 		return "cool secret", nil
 	})
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

I understand that opening a PR directly violates the contribution guidelines, and I'm sorry for that, but I think this is an issue that can be fixed quickly.

I think the [paste secret prompt](https://github.com/cli/cli/blob/28c4d3075b5916acdb6974a7e4f5c49d2c274a86/pkg/cmd/secret/set/set.go#L382) in GitHub Cli is missing a colon, which is inconsistent with other [existing prompts](https://github.com/cli/cli/blob/28c4d3075b5916acdb6974a7e4f5c49d2c274a86/internal/prompter/prompter.go#L70) and creates ambiguity

Before change:

``` shell
? Paste your secret
```

(The missing colon may be interpreted as automatically pasting from the clipboard rather than typing after prompting)

After changes:

``` shell
? Paste your secret:
```