### PR TITLE
Add `projectsV2` to JSON fields of `gh repo` commands

### DIFF
--- a/api/queries_projects_v2.go
+++ b/api/queries_projects_v2.go
@@ -23,6 +23,7 @@ type ProjectV2 struct {
 	Number       int    `json:"number"`
 	ResourcePath string `json:"resourcePath"`
 	Closed       bool   `json:"closed"`
+	URL          string `json:"url"`
 }
 
 // UpdateProjectV2Items uses the addProjectV2ItemById and the deleteProjectV2Item mutations

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -124,6 +124,9 @@ type Repository struct {
 	Projects struct {
 		Nodes []RepoProject
 	}
+	ProjectsV2 struct {
+		Nodes []ProjectV2
+	}
 
 	// pseudo-field that keeps track of host name of this repo
 	hostname string

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -442,6 +442,7 @@ var RepositoryFields = []string{
 	"assignableUsers",
 	"mentionableUsers",
 	"projects",
+	"projectsV2",
 
 	// "branchProtectionRules", // too complex to expose
 	// "collaborators", // does it make sense to expose without affiliation filter?
@@ -487,6 +488,8 @@ func RepositoryGraphQL(fields []string) string {
 			q = append(q, "mentionableUsers(first:100){nodes{id,login,name}}")
 		case "projects":
 			q = append(q, "projects(first:100,states:OPEN){nodes{id,name,number,body,resourcePath}}")
+		case "projectsV2":
+			q = append(q, "projectsV2(first:100,query:\"is:open\"){nodes{id,number,title,readme,url}}")
 		case "watchers":
 			q = append(q, "watchers{totalCount}")
 		case "issues":

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -489,7 +489,7 @@ func RepositoryGraphQL(fields []string) string {
 		case "projects":
 			q = append(q, "projects(first:100,states:OPEN){nodes{id,name,number,body,resourcePath}}")
 		case "projectsV2":
-			q = append(q, "projectsV2(first:100,query:\"is:open\"){nodes{id,number,resourcePath,closed,url}}")
+			q = append(q, "projectsV2(first:100,query:\"is:open\"){nodes{id,number,title,resourcePath,closed,url}}")
 		case "watchers":
 			q = append(q, "watchers{totalCount}")
 		case "issues":

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -489,7 +489,7 @@ func RepositoryGraphQL(fields []string) string {
 		case "projects":
 			q = append(q, "projects(first:100,states:OPEN){nodes{id,name,number,body,resourcePath}}")
 		case "projectsV2":
-			q = append(q, "projectsV2(first:100,query:\"is:open\"){nodes{id,number,title,readme,url}}")
+			q = append(q, "projectsV2(first:100,query:\"is:open\"){nodes{id,number,resourcePath,closed,url}}")
 		case "watchers":
 			q = append(q, "watchers{totalCount}")
 		case "issues":


### PR DESCRIPTION
This PR adds `projectsV2` to JSON fields of `gh repo list` and `gh repo view` commands.

Fixes #8960 
