### PR TITLE
Fix issue with closing pager stream

### DIFF
--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -1761,20 +1761,3 @@ func Test_apiRun_acceptHeader(t *testing.T) {
 		})
 	}
 }
-
-func TestQueue_Close(t *testing.T) {
-	sut := queue{}
-	actual := make([]int, 0, 2)
-
-	func() {
-		defer sut.Close()
-		sut.Enqueue(func() {
-			actual = append(actual, 0)
-		})
-		sut.Enqueue(func() {
-			actual = append(actual, 1)
-		})
-	}()
-
-	assert.Equal(t, []int{0, 1}, actual)
-}


### PR DESCRIPTION
This PR fixes the issue reported in #9017. The problem was due to using old references to IO streams, which were to change when the `StartPager` method was called in a later stage. The fix is to start the pager before grabbing references to the IO streams.

With this change, the `queue` type is no longer needed. Ordinary `defer` statements were used instead (like in v2.47.0).

Fixes #9017 
