### PR TITLE
Add beta designation on attestation command set

### DIFF
--- a/pkg/cmd/attestation/attestation.go
+++ b/pkg/cmd/attestation/attestation.go
@@ -1,6 +1,7 @@
 package attestation
 
 import (
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/download"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/inspect"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/tufrootverify"
@@ -13,9 +14,13 @@ import (
 func NewCmdAttestation(f *cmdutil.Factory) *cobra.Command {
 	root := &cobra.Command{
 		Use:     "attestation [subcommand]",
-		Short:   "Work with artifact attestations",
+		Short:   "(BETA) Work with artifact attestations",
 		Aliases: []string{"at"},
-		Long:    "Download and verify artifact attestations.",
+		Long: heredoc.Doc(`
+			# BETA: Feature subject to change
+
+			Download and verify artifact attestations.
+			`),
 	}
 
 	root.AddCommand(download.NewDownloadCmd(f, nil))

--- a/pkg/cmd/attestation/attestation.go
+++ b/pkg/cmd/attestation/attestation.go
@@ -14,10 +14,10 @@ import (
 func NewCmdAttestation(f *cmdutil.Factory) *cobra.Command {
 	root := &cobra.Command{
 		Use:     "attestation [subcommand]",
-		Short:   "(BETA) Work with artifact attestations",
+		Short:   "Work with artifact attestations",
 		Aliases: []string{"at"},
 		Long: heredoc.Doc(`
-			# BETA: Feature subject to change
+			# NOTE: This feature is currently in beta, and subject to change.
 
 			Download and verify artifact attestations.
 			`),

--- a/pkg/cmd/attestation/download/download.go
+++ b/pkg/cmd/attestation/download/download.go
@@ -21,9 +21,9 @@ func NewDownloadCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Comman
 	downloadCmd := &cobra.Command{
 		Use:   "download [<file-path> | oci://<image-uri>] [--owner | --repo]",
 		Args:  cmdutil.ExactArgs(1, "must specify file path or container image URI, as well as one of --owner or --repo"),
-		Short: "(BETA) Download an artifact's Sigstore bundle(s) for offline use",
+		Short: "Download an artifact's Sigstore bundle(s) for offline use",
 		Long: heredoc.Docf(`
-			# BETA: Feature subject to change
+			# NOTE: This feature is currently in beta, and subject to change.
 
 			Download an artifact's attestations, aka Sigstore bundle(s), for offline use.
 

--- a/pkg/cmd/attestation/download/download.go
+++ b/pkg/cmd/attestation/download/download.go
@@ -21,8 +21,10 @@ func NewDownloadCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Comman
 	downloadCmd := &cobra.Command{
 		Use:   "download [<file-path> | oci://<image-uri>] [--owner | --repo]",
 		Args:  cmdutil.ExactArgs(1, "must specify file path or container image URI, as well as one of --owner or --repo"),
-		Short: "Download an artifact's Sigstore bundle(s) for offline use",
+		Short: "(BETA) Download an artifact's Sigstore bundle(s) for offline use",
 		Long: heredoc.Docf(`
+			# BETA: Feature subject to change
+
 			Download an artifact's attestations, aka Sigstore bundle(s), for offline use.
 
 			The command requires either:

--- a/pkg/cmd/attestation/inspect/inspect.go
+++ b/pkg/cmd/attestation/inspect/inspect.go
@@ -21,9 +21,9 @@ func NewInspectCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command
 		Use:    "inspect [<file path> | oci://<OCI image URI>] --bundle <path-to-bundle>",
 		Args:   cmdutil.ExactArgs(1, "must specify file path or container image URI, as well --bundle"),
 		Hidden: true,
-		Short:  "(BETA) Inspect a sigstore bundle",
+		Short:  "Inspect a sigstore bundle",
 		Long: heredoc.Docf(`
-			# BETA: Feature subject to change
+			# NOTE: This feature is currently in beta, and subject to change.
 
 			Inspect a downloaded Sigstore bundle for a given artifact.
 

--- a/pkg/cmd/attestation/inspect/inspect.go
+++ b/pkg/cmd/attestation/inspect/inspect.go
@@ -21,10 +21,12 @@ func NewInspectCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command
 		Use:    "inspect [<file path> | oci://<OCI image URI>] --bundle <path-to-bundle>",
 		Args:   cmdutil.ExactArgs(1, "must specify file path or container image URI, as well --bundle"),
 		Hidden: true,
-		Short:  "Inspect a sigstore bundle",
+		Short:  "(BETA) Inspect a sigstore bundle",
 		Long: heredoc.Docf(`
+			# BETA: Feature subject to change
+
 			Inspect a downloaded Sigstore bundle for a given artifact.
-				
+
 			The command requires either:
 			* a relative path to a local artifact, or
 			* a container image URI (e.g. %[1]soci://<my-OCI-image-URI>%[1]s)
@@ -37,7 +39,7 @@ func NewInspectCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command
 			command).
 
 			By default, the command will print information about the bundle in a table format.
-			If the %[1]s--json-result%[1]s flag is provided, the command will print the 
+			If the %[1]s--json-result%[1]s flag is provided, the command will print the
 			information in JSON format.
 		`, "`"),
 		Example: heredoc.Doc(`

--- a/pkg/cmd/attestation/tufrootverify/tufrootverify.go
+++ b/pkg/cmd/attestation/tufrootverify/tufrootverify.go
@@ -21,10 +21,10 @@ func NewTUFRootVerifyCmd(f *cmdutil.Factory, runF func() error) *cobra.Command {
 	var cmd = cobra.Command{
 		Use:    "tuf-root-verify --mirror <mirror-url> --root <root.json>",
 		Args:   cobra.ExactArgs(0),
-		Short:  "(BETA) Verify the TUF repository from a provided TUF root",
+		Short:  "Verify the TUF repository from a provided TUF root",
 		Hidden: true,
 		Long: heredoc.Docf(`
-			# BETA: Feature subject to change
+			# NOTE: This feature is currently in beta, and subject to change.
 
 			Verify a TUF repository with a local TUF root.
 

--- a/pkg/cmd/attestation/tufrootverify/tufrootverify.go
+++ b/pkg/cmd/attestation/tufrootverify/tufrootverify.go
@@ -21,15 +21,17 @@ func NewTUFRootVerifyCmd(f *cmdutil.Factory, runF func() error) *cobra.Command {
 	var cmd = cobra.Command{
 		Use:    "tuf-root-verify --mirror <mirror-url> --root <root.json>",
 		Args:   cobra.ExactArgs(0),
-		Short:  "Verify the TUF repository from a provided TUF root",
+		Short:  "(BETA) Verify the TUF repository from a provided TUF root",
 		Hidden: true,
 		Long: heredoc.Docf(`
+			# BETA: Feature subject to change
+
 			Verify a TUF repository with a local TUF root.
 
-			The command requires you provide the %[1]s--mirror%[1]s flag, which should be the URL 
+			The command requires you provide the %[1]s--mirror%[1]s flag, which should be the URL
 			of the TUF repository mirror.
-			
-			The command also requires you provide the %[1]s--root%[1]s flag, which should be the 
+
+			The command also requires you provide the %[1]s--root%[1]s flag, which should be the
 			path to the TUF root file.
 
 			GitHub relies on TUF to securely deliver the trust root for our signing authority.

--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -23,9 +23,9 @@ func NewVerifyCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command 
 	verifyCmd := &cobra.Command{
 		Use:   "verify [<file-path> | oci://<image-uri>] [--owner | --repo]",
 		Args:  cmdutil.ExactArgs(1, "must specify file path or container image URI, as well as one of --owner or --repo"),
-		Short: "(BETA) Verify an artifact's integrity using attestations",
+		Short: "Verify an artifact's integrity using attestations",
 		Long: heredoc.Docf(`
-			# BETA: Feature subject to change
+			# NOTE: This feature is currently in beta, and subject to change.
 
 			Verify the integrity and provenance of an artifact using its associated
 			cryptographically signed attestations.

--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -23,8 +23,10 @@ func NewVerifyCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command 
 	verifyCmd := &cobra.Command{
 		Use:   "verify [<file-path> | oci://<image-uri>] [--owner | --repo]",
 		Args:  cmdutil.ExactArgs(1, "must specify file path or container image URI, as well as one of --owner or --repo"),
-		Short: "Verify an artifact's integrity using attestations",
+		Short: "(BETA) Verify an artifact's integrity using attestations",
 		Long: heredoc.Docf(`
+			# BETA: Feature subject to change
+
 			Verify the integrity and provenance of an artifact using its associated
 			cryptographically signed attestations.
 


### PR DESCRIPTION
With the `gh attestation` command set going into public beta, users should be reminded the feature is in beta and subject to change.

Both the short and long help usage are updated for individual command `--help` as well as `gh reference`.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

### Output

- **`gh reference`**

  By updating commands' `Short` field, the visible commands in `gh reference` reinforce the beta designation:

  ```shell
  andyfeller@Andys-MBP:cli/cli ‹andyfeller/attestation-beta-usage*›$ ./bin/gh reference | grep -A 5 "gh at"
  ## `gh attestation [subcommand]`
  
  (BETA) Work with artifact attestations
  
  ### `gh attestation download [<file-path> | oci://<image-uri>] [--owner | --repo] [flags]`
  
  (BETA) Download an artifact's Sigstore bundle(s) for offline use
  
    -d, --digest-alg string       The algorithm used to compute a digest of the artifact: {sha256|sha512} (default "sha256")
    -L, --limit int               Maximum number of attestations to fetch (default 30)
  --
  ### `gh attestation verify [<file-path> | oci://<image-uri>] [--owner | --repo] [flags]`
  
  (BETA) Verify an artifact's integrity using attestations
  
    -b, --bundle string                Path to bundle on disk, either a single bundle in a JSON file or a JSON lines file with multiple bundles
        --cert-identity string         Enforce that the certificate's subject alternative name matches the provided value exactly
  ```

- **`gh attestation --help`**

  ```shell
  andyfeller@Andys-MBP:cli/cli ‹andyfeller/attestation-beta-usage*›$ ./bin/gh at --help         
  # BETA: Feature subject to change
  
  Download and verify artifact attestations.
  
  
  USAGE
    gh attestation [subcommand] [flags]
  
  ALIASES
    at
  
  AVAILABLE COMMANDS
    download:    (BETA) Download an artifact's Sigstore bundle(s) for offline use
    verify:      (BETA) Verify an artifact's integrity using attestations
  
  INHERITED FLAGS
    --help   Show help for command
  
  LEARN MORE
    Use `gh <command> <subcommand> --help` for more information about a command.
    Read the manual at https://cli.github.com/manual
  ```

- **`gh attestation download --help`**

  ```shell
  andyfeller@Andys-MBP:cli/cli ‹andyfeller/attestation-beta-usage*›$ ./bin/gh at download --help
  # BETA: Feature subject to change
  
  Download an artifact's attestations, aka Sigstore bundle(s), for offline use.
  
  The command requires either:
  * a file path to an artifact, or
  * a container image URI (e.g. `oci://<image-uri>`)
  ```

- **`gh attestation inspect --help`**

  ```shell
  andyfeller@Andys-MBP:cli/cli ‹andyfeller/attestation-beta-usage*›$ ./bin/gh at inspect --help
  # BETA: Feature subject to change
  
  Inspect a downloaded Sigstore bundle for a given artifact.
  
  The command requires either:
  * a relative path to a local artifact, or
  * a container image URI (e.g. `oci://<my-OCI-image-URI>`)
  ```

- **`gh attestation tuf-root-verify --help`**

  ```shell
  andyfeller@Andys-MBP:cli/cli ‹andyfeller/attestation-beta-usage*›$ ./bin/gh at tuf-root-verify --help
  # BETA: Feature subject to change
  
  Verify a TUF repository with a local TUF root.
  
  The command requires you provide the `--mirror` flag, which should be the URL
  of the TUF repository mirror.
  ```

- **`gh attestation verify --help`**

  ```shell
  andyfeller@Andys-MBP:cli/cli ‹andyfeller/attestation-beta-usage*›$ ./bin/gh at verify --help 
  # BETA: Feature subject to change
  
  Verify the integrity and provenance of an artifact using its associated
  cryptographically signed attestations.
  
  The command requires either:
  * a file path to an artifact, or
  * a container image URI (e.g. `oci://<image-uri>`)
  ```
