### PR TITLE
Fix doc bug for gh run watch

### DIFF
--- a/pkg/cmd/run/watch/watch.go
+++ b/pkg/cmd/run/watch/watch.go
@@ -56,7 +56,7 @@ func NewCmdWatch(f *cmdutil.Factory, runF func(*WatchOptions) error) *cobra.Comm
 			gh run watch
 
 			# Run some other command when the run is finished
-			gh run watch && notify-send "run is done!"
+			gh run watch && notify-send 'run is done!'
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override


### PR DESCRIPTION
The `gh run watch` help documentation has a small bug where the use of double quotes causes an error due to bash trying to expand `!`. Single quotes prevents this from happening.