### PR TITLE
feat: add json output for `gh pr checks`

### DIFF
--- a/pkg/cmd/pr/checks/aggregate.go
+++ b/pkg/cmd/pr/checks/aggregate.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/pkg/cmdutil"
 )
 
 type check struct {
@@ -26,6 +27,10 @@ type checkCounts struct {
 	Pending  int
 	Skipping int
 	Canceled int
+}
+
+func (ch *check) ExportData(fields []string) map[string]interface{} {
+	return cmdutil.StructExportData(ch, fields)
 }
 
 func aggregateChecks(checkContexts []api.CheckContext, requiredChecks bool) (checks []check, counts checkCounts) {

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -20,7 +20,7 @@ import (
 
 const defaultInterval time.Duration = 10 * time.Second
 
-var prChecksFields = []string{
+var prCheckFields = []string{
 	"name",
 	"state",
 	"startedAt",
@@ -110,7 +110,7 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 	cmd.Flags().IntVarP(&interval, "interval", "i", 10, "Refresh interval in seconds when using `--watch` flag")
 	cmd.Flags().BoolVar(&opts.Required, "required", false, "Only show checks that are required")
 
-	cmdutil.AddJSONFlags(cmd, &opts.Exporter, prChecksFields)
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, prCheckFields)
 
 	return cmd
 }

--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -20,10 +20,23 @@ import (
 
 const defaultInterval time.Duration = 10 * time.Second
 
+var prChecksFields = []string{
+	"name",
+	"state",
+	"startedAt",
+	"completedAt",
+	"link",
+	"bucket",
+	"event",
+	"workflow",
+	"description",
+}
+
 type ChecksOptions struct {
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
 	Browser    browser.Browser
+	Exporter   cmdutil.Exporter
 
 	Finder   shared.PRFinder
 	Detector fd.Detector
@@ -97,6 +110,8 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 	cmd.Flags().IntVarP(&interval, "interval", "i", 10, "Refresh interval in seconds when using `--watch` flag")
 	cmd.Flags().BoolVar(&opts.Required, "required", false, "Only show checks that are required")
 
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, prChecksFields)
+
 	return cmd
 }
 
@@ -159,6 +174,10 @@ func checksRun(opts *ChecksOptions) error {
 	checks, counts, err = populateStatusChecks(client, repo, pr, opts.Required, includeEvent)
 	if err != nil {
 		return err
+	}
+
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, checks)
 	}
 
 	if opts.Watch {


### PR DESCRIPTION
This PR proposes JSON ouptup support for the `gh pr checks` command.

Unlike the suggestion in https://github.com/cli/cli/issues/6056#issuecomment-1218390676, it doesn't do any aggregation, and rather returns the plain values.

The fields were extracted from https://github.com/cli/cli/blob/178fc2e51ead22bd0ef2904b4b5e3018d657914d/pkg/cmd/pr/checks/aggregate.go#L12-L20

The logic was inspired by https://github.com/cli/cli/blob/4b077daf7e74dbe6bf933f69e220066e3a12e8b4/pkg/cmd/repo/deploy-key/list/list.go upon suggestions from @andyfeller.

Fixes https://github.com/cli/cli/issues/6056