### PR TITLE
Removed tty message when checking for extension upgrades

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -50,7 +50,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"extensions", "ext"},
 	}
 
-	upgradeFunc := func(name string, flagForce, flagDryRun bool) error {
+	upgradeFunc := func(name string, flagForce bool) error {
 		cs := io.ColorScheme()
 		err := m.Upgrade(name, flagForce)
 		if err != nil {
@@ -330,7 +330,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					if ext, err := checkValidExtension(cmd.Root(), m, repo.RepoName(), repo.RepoOwner()); err != nil {
 						// If an existing extension was found and --force was specified, attempt to upgrade.
 						if forceFlag && ext != nil {
-							return upgradeFunc(ext.Name(), forceFlag, false)
+							return upgradeFunc(ext.Name(), forceFlag)
 						}
 
 						if errors.Is(err, alreadyInstalledError) {
@@ -399,7 +399,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					if flagDryRun {
 						m.EnableDryRunMode()
 					}
-					return upgradeFunc(name, flagForce, flagDryRun)
+					return upgradeFunc(name, flagForce)
 				},
 			}
 			cmd.Flags().BoolVar(&flagAll, "all", false, "Upgrade all extensions")

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -64,6 +64,10 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 			return cmdutil.SilentError
 		}
 
+		if io.IsStdoutTTY() {
+			fmt.Fprintf(io.Out, "%s Successfully checked extension upgrades\n", cs.SuccessIcon())
+		}
+
 		return nil
 	}
 

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -63,17 +63,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 			}
 			return cmdutil.SilentError
 		}
-		if io.IsStdoutTTY() {
-			successStr := "Successfully"
-			if flagDryRun {
-				successStr = "Would have"
-			}
-			extensionStr := "extension"
-			if name == "" {
-				extensionStr = "extensions"
-			}
-			fmt.Fprintf(io.Out, "%s %s upgraded %s\n", cs.SuccessIcon(), successStr, extensionStr)
-		}
+
 		return nil
 	}
 

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -332,7 +332,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Successfully upgraded extension\n",
+			wantStdout: "",
 		},
 		{
 			name: "upgrade an extension dry run",
@@ -352,7 +352,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Would have upgraded extension\n",
+			wantStdout: "",
 		},
 		{
 			name: "upgrade an extension notty",
@@ -385,7 +385,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Successfully upgraded extension\n",
+			wantStdout: "",
 		},
 		{
 			name: "upgrade extension error",
@@ -420,7 +420,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Successfully upgraded extension\n",
+			wantStdout: "",
 		},
 		{
 			name: "upgrade an extension full name",
@@ -436,7 +436,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Successfully upgraded extension\n",
+			wantStdout: "",
 		},
 		{
 			name: "upgrade all",
@@ -452,7 +452,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Successfully upgraded extensions\n",
+			wantStdout: "",
 		},
 		{
 			name: "upgrade all dry run",
@@ -472,7 +472,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Would have upgraded extensions\n",
+			wantStdout: "",
 		},
 		{
 			name: "upgrade all none installed",
@@ -853,7 +853,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "✓ Successfully upgraded extension\n",
+			wantStdout: "",
 		},
 	}
 

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -332,7 +332,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Successfully checked extension upgrades\n",
 		},
 		{
 			name: "upgrade an extension dry run",
@@ -352,7 +352,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Successfully checked extension upgrades\n",
 		},
 		{
 			name: "upgrade an extension notty",
@@ -385,7 +385,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Successfully checked extension upgrades\n",
 		},
 		{
 			name: "upgrade extension error",
@@ -420,7 +420,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Successfully checked extension upgrades\n",
 		},
 		{
 			name: "upgrade an extension full name",
@@ -436,7 +436,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Successfully checked extension upgrades\n",
 		},
 		{
 			name: "upgrade all",
@@ -452,7 +452,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Successfully checked extension upgrades\n",
 		},
 		{
 			name: "upgrade all dry run",
@@ -472,7 +472,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Successfully checked extension upgrades\n",
 		},
 		{
 			name: "upgrade all none installed",
@@ -853,7 +853,7 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 			},
 			isTTY:      true,
-			wantStdout: "",
+			wantStdout: "✓ Successfully checked extension upgrades\n",
 		},
 	}
 


### PR DESCRIPTION
Fixes #8535 

TTY messages are no longer displayed when checking for extension upgrades. These messages were removed because they were confusing users.

Thank you @williammartin for providing insight on this issue from my old [PR](https://github.com/cli/cli/pull/8584). I was having issues with my old branch so I decided to create a new one for this PR.
