### PR TITLE
Add `--json` option to `variable get` command

### DIFF
--- a/pkg/cmd/variable/get/get.go
+++ b/pkg/cmd/variable/get/get.go
@@ -119,15 +119,13 @@ func getRun(opts *GetOptions) error {
 		return fmt.Errorf("failed to get variable %s: %w", opts.VariableName, err)
 	}
 
-	if err := shared.PopulateSelectedRepositoryInformation(client, host, &variable); err != nil {
-		return err
-	}
-
 	if opts.Exporter != nil {
+		if err := shared.PopulateSelectedRepositoryInformation(client, host, &variable); err != nil {
+			return err
+		}
 		return opts.Exporter.Write(opts.IO, &variable)
 	}
 
 	fmt.Fprintf(opts.IO.Out, "%s\n", variable.Value)
-
 	return nil
 }

--- a/pkg/cmd/variable/get/get.go
+++ b/pkg/cmd/variable/get/get.go
@@ -21,19 +21,11 @@ type GetOptions struct {
 	Config     func() (gh.Config, error)
 	BaseRepo   func() (ghrepo.Interface, error)
 
+	Exporter cmdutil.Exporter
+
 	VariableName string
 	OrgName      string
 	EnvName      string
-}
-
-type getVariableResponse struct {
-	Value string `json:"value"`
-	// Other available but unused fields
-	// Name             string            `json:"name"`
-	// UpdatedAt        time.Time         `json:"updated_at"`
-	// Visibility       shared.Visibility `json:"visibility"`
-	// SelectedReposURL string            `json:"selected_repositories_url"`
-	// NumSelectedRepos int               `json:"num_selected_repos"`
 }
 
 func NewCmdGet(f *cmdutil.Factory, runF func(*GetOptions) error) *cobra.Command {
@@ -116,8 +108,8 @@ func getRun(opts *GetOptions) error {
 
 	host, _ := cfg.Authentication().DefaultHost()
 
-	var response getVariableResponse
-	if err = client.REST(host, "GET", path, nil, &response); err != nil {
+	var variable shared.Variable
+	if err = client.REST(host, "GET", path, nil, &variable); err != nil {
 		var httpErr api.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("variable %s was not found", opts.VariableName)
@@ -126,7 +118,7 @@ func getRun(opts *GetOptions) error {
 		return fmt.Errorf("failed to get variable %s: %w", opts.VariableName, err)
 	}
 
-	fmt.Fprintf(opts.IO.Out, "%s\n", response.Value)
+	fmt.Fprintf(opts.IO.Out, "%s\n", variable.Value)
 
 	return nil
 }

--- a/pkg/cmd/variable/get/get.go
+++ b/pkg/cmd/variable/get/get.go
@@ -64,6 +64,7 @@ func NewCmdGet(f *cmdutil.Factory, runF func(*GetOptions) error) *cobra.Command 
 	}
 	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "Get a variable for an organization")
 	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Get a variable for an environment")
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, shared.VariableJSONFields)
 
 	return cmd
 }
@@ -116,6 +117,14 @@ func getRun(opts *GetOptions) error {
 		}
 
 		return fmt.Errorf("failed to get variable %s: %w", opts.VariableName, err)
+	}
+
+	if err := shared.PopulateSelectedRepositoryInformation(client, host, &variable); err != nil {
+		return err
+	}
+
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, &variable)
 	}
 
 	fmt.Fprintf(opts.IO.Out, "%s\n", variable.Value)

--- a/pkg/cmd/variable/get/get_test.go
+++ b/pkg/cmd/variable/get/get_test.go
@@ -161,13 +161,14 @@ func Test_getRun(t *testing.T) {
 			opts: &GetOptions{
 				VariableName: "VARIABLE_ONE",
 			},
-			jsonFields: []string{"name", "value", "visibility", "updatedAt", "numSelectedRepos", "selectedReposURL"},
+			jsonFields: []string{"name", "value", "visibility", "updatedAt", "createdAt", "numSelectedRepos", "selectedReposURL"},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "repos/owner/repo/actions/variables/VARIABLE_ONE"),
 					httpmock.JSONResponse(shared.Variable{
 						Name:             "VARIABLE_ONE",
 						Value:            "repo_var",
 						UpdatedAt:        tf,
+						CreatedAt:        tf,
 						Visibility:       shared.Organization,
 						SelectedReposURL: "path/to/fetch/selected/repos",
 						NumSelectedRepos: 0, // This should be populated in a second API call.
@@ -181,6 +182,7 @@ func Test_getRun(t *testing.T) {
 				"name": "VARIABLE_ONE",
 				"value": "repo_var",
 				"updatedAt": "2024-01-01T00:00:00Z",
+				"createdAt": "2024-01-01T00:00:00Z",
 				"visibility": "organization",
 				"selectedReposURL": "path/to/fetch/selected/repos",
 				"numSelectedRepos": 99
@@ -266,6 +268,7 @@ func TestExportVariables(t *testing.T) {
 		Name:             "v1",
 		Value:            "test1",
 		UpdatedAt:        tf,
+		CreatedAt:        tf,
 		Visibility:       shared.All,
 		SelectedReposURL: "https://someurl.com",
 		NumSelectedRepos: 1,
@@ -274,6 +277,6 @@ func TestExportVariables(t *testing.T) {
 	exporter.SetFields(shared.VariableJSONFields)
 	require.NoError(t, exporter.Write(ios, vs))
 	require.JSONEq(t,
-		`{"name":"v1","numSelectedRepos":1,"selectedReposURL":"https://someurl.com","updatedAt":"2024-01-01T00:00:00Z","value":"test1","visibility":"all"}`,
+		`{"name":"v1","numSelectedRepos":1,"selectedReposURL":"https://someurl.com","updatedAt":"2024-01-01T00:00:00Z","createdAt":"2024-01-01T00:00:00Z","value":"test1","visibility":"all"}`,
 		stdout.String())
 }

--- a/pkg/cmd/variable/get/get_test.go
+++ b/pkg/cmd/variable/get/get_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/variable/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -104,7 +105,7 @@ func Test_getRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "repos/owner/repo/actions/variables/VARIABLE_ONE"),
-					httpmock.JSONResponse(getVariableResponse{
+					httpmock.JSONResponse(shared.Variable{
 						Value: "repo_var",
 					}))
 			},
@@ -118,7 +119,7 @@ func Test_getRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "orgs/TestOrg/actions/variables/VARIABLE_ONE"),
-					httpmock.JSONResponse(getVariableResponse{
+					httpmock.JSONResponse(shared.Variable{
 						Value: "org_var",
 					}))
 			},
@@ -132,7 +133,7 @@ func Test_getRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "repos/owner/repo/environments/Development/variables/VARIABLE_ONE"),
-					httpmock.JSONResponse(getVariableResponse{
+					httpmock.JSONResponse(shared.Variable{
 						Value: "env_var",
 					}))
 			},

--- a/pkg/cmd/variable/get/get_test.go
+++ b/pkg/cmd/variable/get/get_test.go
@@ -54,6 +54,18 @@ func TestNewCmdGet(t *testing.T) {
 			cli:     "-o TestOrg -e Development QUX",
 			wantErr: cmdutil.FlagErrorf("%s", "specify only one of `--org` or `--env`"),
 		},
+		{
+			name: "json",
+			cli:  "--json name,value FOO",
+			wants: GetOptions{
+				VariableName: "FOO",
+				Exporter: func() cmdutil.Exporter {
+					exporter := cmdutil.NewJSONExporter()
+					exporter.SetFields([]string{"name", "value"})
+					return exporter
+				}(),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -86,6 +98,7 @@ func TestNewCmdGet(t *testing.T) {
 			require.Equal(t, tt.wants.OrgName, gotOpts.OrgName)
 			require.Equal(t, tt.wants.EnvName, gotOpts.EnvName)
 			require.Equal(t, tt.wants.VariableName, gotOpts.VariableName)
+			require.Equal(t, tt.wants.Exporter, gotOpts.Exporter)
 		})
 	}
 }

--- a/pkg/cmd/variable/get/get_test.go
+++ b/pkg/cmd/variable/get/get_test.go
@@ -258,3 +258,22 @@ func Test_getRun(t *testing.T) {
 		t.Run(tt.name+" no-tty", runTest(false))
 	}
 }
+
+func TestExportVariables(t *testing.T) {
+	ios, _, stdout, _ := iostreams.Test()
+	tf, _ := time.Parse(time.RFC3339, "2024-01-01T00:00:00Z")
+	vs := &shared.Variable{
+		Name:             "v1",
+		Value:            "test1",
+		UpdatedAt:        tf,
+		Visibility:       shared.All,
+		SelectedReposURL: "https://someurl.com",
+		NumSelectedRepos: 1,
+	}
+	exporter := cmdutil.NewJSONExporter()
+	exporter.SetFields(shared.VariableJSONFields)
+	require.NoError(t, exporter.Write(ios, vs))
+	require.JSONEq(t,
+		`{"name":"v1","numSelectedRepos":1,"selectedReposURL":"https://someurl.com","updatedAt":"2024-01-01T00:00:00Z","value":"test1","visibility":"all"}`,
+		stdout.String())
+}

--- a/pkg/cmd/variable/list/list.go
+++ b/pkg/cmd/variable/list/list.go
@@ -30,15 +30,6 @@ type ListOptions struct {
 	EnvName string
 }
 
-var variableFields = []string{
-	"name",
-	"value",
-	"visibility",
-	"updatedAt",
-	"numSelectedRepos",
-	"selectedReposURL",
-}
-
 func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
 	opts := &ListOptions{
 		IO:         f.IOStreams,
@@ -76,7 +67,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "List variables for an organization")
 	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "List variables for an environment")
-	cmdutil.AddJSONFlags(cmd, &opts.Exporter, variableFields)
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, shared.VariableJSONFields)
 
 	return cmd
 }
@@ -103,7 +94,7 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
-	var variables []Variable
+	var variables []shared.Variable
 	showSelectedRepoInfo := opts.IO.IsStdoutTTY()
 
 	switch variableEntity {
@@ -170,20 +161,7 @@ func listRun(opts *ListOptions) error {
 	return nil
 }
 
-type Variable struct {
-	Name             string            `json:"name"`
-	Value            string            `json:"value"`
-	UpdatedAt        time.Time         `json:"updated_at"`
-	Visibility       shared.Visibility `json:"visibility"`
-	SelectedReposURL string            `json:"selected_repositories_url"`
-	NumSelectedRepos int               `json:"num_selected_repos"`
-}
-
-func (v *Variable) ExportData(fields []string) map[string]interface{} {
-	return cmdutil.StructExportData(v, fields)
-}
-
-func fmtVisibility(s Variable) string {
+func fmtVisibility(s shared.Variable) string {
 	switch s.Visibility {
 	case shared.All:
 		return "Visible to all repositories"
@@ -199,22 +177,23 @@ func fmtVisibility(s Variable) string {
 	return ""
 }
 
-func getRepoVariables(client *http.Client, repo ghrepo.Interface) ([]Variable, error) {
+func getRepoVariables(client *http.Client, repo ghrepo.Interface) ([]shared.Variable, error) {
 	return getVariables(client, repo.RepoHost(), fmt.Sprintf("repos/%s/actions/variables", ghrepo.FullName(repo)))
 }
 
-func getEnvVariables(client *http.Client, repo ghrepo.Interface, envName string) ([]Variable, error) {
+func getEnvVariables(client *http.Client, repo ghrepo.Interface, envName string) ([]shared.Variable, error) {
 	path := fmt.Sprintf("repos/%s/environments/%s/variables", ghrepo.FullName(repo), envName)
 	return getVariables(client, repo.RepoHost(), path)
 }
 
-func getOrgVariables(client *http.Client, host, orgName string, showSelectedRepoInfo bool) ([]Variable, error) {
+func getOrgVariables(client *http.Client, host, orgName string, showSelectedRepoInfo bool) ([]shared.Variable, error) {
 	variables, err := getVariables(client, host, fmt.Sprintf("orgs/%s/actions/variables", orgName))
 	if err != nil {
 		return nil, err
 	}
+	apiClient := api.NewClientFromHTTP(client)
 	if showSelectedRepoInfo {
-		err = populateSelectedRepositoryInformation(client, host, variables)
+		err = shared.PopulateMultipleSelectedRepositoryInformation(apiClient, host, variables)
 		if err != nil {
 			return nil, err
 		}
@@ -222,13 +201,13 @@ func getOrgVariables(client *http.Client, host, orgName string, showSelectedRepo
 	return variables, nil
 }
 
-func getVariables(client *http.Client, host, path string) ([]Variable, error) {
-	var results []Variable
+func getVariables(client *http.Client, host, path string) ([]shared.Variable, error) {
+	var results []shared.Variable
 	apiClient := api.NewClientFromHTTP(client)
 	path = fmt.Sprintf("%s?per_page=100", path)
 	for path != "" {
 		response := struct {
-			Variables []Variable
+			Variables []shared.Variable
 		}{}
 		var err error
 		path, err = apiClient.RESTWithNext(host, "GET", path, nil, &response)
@@ -238,21 +217,4 @@ func getVariables(client *http.Client, host, path string) ([]Variable, error) {
 		results = append(results, response.Variables...)
 	}
 	return results, nil
-}
-
-func populateSelectedRepositoryInformation(client *http.Client, host string, variables []Variable) error {
-	apiClient := api.NewClientFromHTTP(client)
-	for i, variable := range variables {
-		if variable.SelectedReposURL == "" {
-			continue
-		}
-		response := struct {
-			TotalCount int `json:"total_count"`
-		}{}
-		if err := apiClient.REST(host, "GET", variable.SelectedReposURL, nil, &response); err != nil {
-			return fmt.Errorf("failed determining selected repositories for %s: %w", variable.Name, err)
-		}
-		variables[i].NumSelectedRepos = response.TotalCount
-	}
-	return nil
 }

--- a/pkg/cmd/variable/list/list_test.go
+++ b/pkg/cmd/variable/list/list_test.go
@@ -175,9 +175,9 @@ func Test_listRun(t *testing.T) {
 			t1, _ := time.Parse("2006-01-02", "2020-12-04")
 			t2, _ := time.Parse("2006-01-02", "1975-11-30")
 			payload := struct {
-				Variables []Variable
+				Variables []shared.Variable
 			}{
-				Variables: []Variable{
+				Variables: []shared.Variable{
 					{
 						Name:      "VARIABLE_ONE",
 						Value:     "one",
@@ -196,7 +196,7 @@ func Test_listRun(t *testing.T) {
 				},
 			}
 			if tt.opts.OrgName != "" {
-				payload.Variables = []Variable{
+				payload.Variables = []shared.Variable{
 					{
 						Name:       "VARIABLE_ONE",
 						Value:      "org_one",
@@ -279,7 +279,7 @@ func Test_getVariables_pagination(t *testing.T) {
 func TestExportVariables(t *testing.T) {
 	ios, _, stdout, _ := iostreams.Test()
 	tf, _ := time.Parse(time.RFC3339, "2024-01-01T00:00:00Z")
-	vs := []Variable{{
+	vs := []shared.Variable{{
 		Name:             "v1",
 		Value:            "test1",
 		UpdatedAt:        tf,
@@ -288,7 +288,7 @@ func TestExportVariables(t *testing.T) {
 		NumSelectedRepos: 1,
 	}}
 	exporter := cmdutil.NewJSONExporter()
-	exporter.SetFields(variableFields)
+	exporter.SetFields(shared.VariableJSONFields)
 	require.NoError(t, exporter.Write(ios, vs))
 	require.JSONEq(t,
 		`[{"name":"v1","numSelectedRepos":1,"selectedReposURL":"https://someurl.com","updatedAt":"2024-01-01T00:00:00Z","value":"test1","visibility":"all"}]`,

--- a/pkg/cmd/variable/list/list_test.go
+++ b/pkg/cmd/variable/list/list_test.go
@@ -331,6 +331,7 @@ func TestExportVariables(t *testing.T) {
 		Name:             "v1",
 		Value:            "test1",
 		UpdatedAt:        tf,
+		CreatedAt:        tf,
 		Visibility:       shared.All,
 		SelectedReposURL: "https://someurl.com",
 		NumSelectedRepos: 1,
@@ -339,6 +340,6 @@ func TestExportVariables(t *testing.T) {
 	exporter.SetFields(shared.VariableJSONFields)
 	require.NoError(t, exporter.Write(ios, vs))
 	require.JSONEq(t,
-		`[{"name":"v1","numSelectedRepos":1,"selectedReposURL":"https://someurl.com","updatedAt":"2024-01-01T00:00:00Z","value":"test1","visibility":"all"}]`,
+		`[{"name":"v1","numSelectedRepos":1,"selectedReposURL":"https://someurl.com","updatedAt":"2024-01-01T00:00:00Z","createdAt":"2024-01-01T00:00:00Z","value":"test1","visibility":"all"}]`,
 		stdout.String())
 }

--- a/pkg/cmd/variable/shared/shared.go
+++ b/pkg/cmd/variable/shared/shared.go
@@ -2,6 +2,11 @@ package shared
 
 import (
 	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/pkg/cmdutil"
 )
 
 type Visibility string
@@ -20,6 +25,28 @@ const (
 	Environment  = "environment"
 )
 
+type Variable struct {
+	Name             string     `json:"name"`
+	Value            string     `json:"value"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	Visibility       Visibility `json:"visibility"`
+	SelectedReposURL string     `json:"selected_repositories_url"`
+	NumSelectedRepos int        `json:"num_selected_repos"`
+}
+
+var VariableJSONFields = []string{
+	"name",
+	"value",
+	"visibility",
+	"updatedAt",
+	"numSelectedRepos",
+	"selectedReposURL",
+}
+
+func (v *Variable) ExportData(fields []string) map[string]interface{} {
+	return cmdutil.StructExportData(v, fields)
+}
+
 func GetVariableEntity(orgName, envName string) (VariableEntity, error) {
 	orgSet := orgName != ""
 	envSet := envName != ""
@@ -35,4 +62,29 @@ func GetVariableEntity(orgName, envName string) (VariableEntity, error) {
 		return Environment, nil
 	}
 	return Repository, nil
+}
+
+func PopulateMultipleSelectedRepositoryInformation(apiClient *api.Client, host string, variables []Variable) error {
+	for i, variable := range variables {
+		if err := PopulateSelectedRepositoryInformation(apiClient, host, &variable); err != nil {
+			return err
+		}
+		variables[i] = variable
+	}
+	return nil
+}
+
+func PopulateSelectedRepositoryInformation(apiClient *api.Client, host string, variable *Variable) error {
+	if variable.SelectedReposURL == "" {
+		return nil
+	}
+
+	response := struct {
+		TotalCount int `json:"total_count"`
+	}{}
+	if err := apiClient.REST(host, "GET", variable.SelectedReposURL, nil, &response); err != nil {
+		return fmt.Errorf("failed determining selected repositories for %s: %w", variable.Name, err)
+	}
+	variable.NumSelectedRepos = response.TotalCount
+	return nil
 }

--- a/pkg/cmd/variable/shared/shared.go
+++ b/pkg/cmd/variable/shared/shared.go
@@ -29,6 +29,7 @@ type Variable struct {
 	Name             string     `json:"name"`
 	Value            string     `json:"value"`
 	UpdatedAt        time.Time  `json:"updated_at"`
+	CreatedAt        time.Time  `json:"created_at"`
 	Visibility       Visibility `json:"visibility"`
 	SelectedReposURL string     `json:"selected_repositories_url"`
 	NumSelectedRepos int        `json:"num_selected_repos"`
@@ -39,6 +40,7 @@ var VariableJSONFields = []string{
 	"value",
 	"visibility",
 	"updatedAt",
+	"createdAt",
 	"numSelectedRepos",
 	"selectedReposURL",
 }


### PR DESCRIPTION
This PR adds the `--json` option to the `variable get` command.

Notes regarding this PR:
- Some reusable parts from the `variable list` command are now extracted into the `shared` package.
- I had to change the `variable get` command implementation a bit, to also fetch the selected repositories information when the `--json` flag is used.
- I also added the `CreatedAt` field to the shared `Variable` type and it's now accessible through JSON fields, for both `get` and `list` commands.

Fixes #9118 