### PR TITLE
Build completions during release on macos

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,11 +7,10 @@ release:
 
 before:
   hooks:
-    - >-
+    - >- # The linux and windows archives package the manpages below
       {{ if eq .Runtime.Goos "windows" }}echo{{ end }} make manpages GH_VERSION={{.Version}}
-    - >-
-      {{ if ne .Runtime.Goos "linux" }}echo{{ end }} make completions
-
+    - >- # On linux the completions are used in nfpms below, but on macos they are used outside in the deployment build.
+      {{ if eq .Runtime.Goos "windows" }}echo{{ end }} make completions
 builds:
   - id: macos #build:macos
     goos: [darwin]


### PR DESCRIPTION
## Description

Follow on from #7555

It looks like there was a faulty assumption that on macos the `completions` would be available on the filesystem. However, when we tried to release it broke because they didn't exist: https://github.com/cli/cli/actions/runs/9272921562/job/25511828490

Looking at our `goreleaser` config, we previously only built `completions` on linux because they got packaged into the `.deb` and `.rpm` files. Although it's a little janky and we might want to revisit this approach, the easiest way to get to green is to update our goreleaser config to also build them on mac. The reason we might want to revisit it is because it creates a bit of a spooky action from a distance, where the completions are built here only to be used at some point in time in the future from a github action workflow.

Have created https://github.com/cli/cli/issues/9135 to keep track of that.