### PR TITLE
Clarify Mac OS Installer packages are unsigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ If you are a hubber and are interested in shipping new commands for the CLI, che
 
 `gh` is available via [Homebrew][], [MacPorts][], [Conda][], [Spack][], [Webi][], and as a downloadable binary including Mac OS installer `.pkg` from the [releases page][].
 
+> [!NOTE]
+> As of May 29th, Mac OS installer `.pkg` are unsigned with efforts prioritized in [`cli/cli#9139`](https://github.com/cli/cli/issues/9139) to support signing them.
+
 #### Homebrew
 
 | Install:          | Upgrade:          |


### PR DESCRIPTION
Relates #9139

This commit clarifies Mac OS Installer packages are unsigned due to additional work to obtain an Apple Developer ID Installer-signing identity.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
