### PR TITLE
Ensure signed RPMs have attestations

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -277,11 +277,6 @@ jobs:
           rm -rf dist
           mkdir dist
           mv -v {linux,macos,windows}/gh_* dist/
-      - name: Attest release artifacts
-        if: inputs.environment == 'production'
-        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
-        with:
-          subject-path: "dist/gh_*"
       - name: Install packaging dependencies
         run: sudo apt-get install -y rpm reprepro
       - name: Set up GPG
@@ -302,6 +297,11 @@ jobs:
         run: |
           cp script/rpmmacros ~/.rpmmacros
           rpmsign --addsign dist/*.rpm
+      - name: Attest release artifacts
+        if: inputs.environment == 'production'
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-path: "dist/gh_*"
       - name: Run createrepo
         env:
           GPG_SIGN: ${{ inputs.environment == 'production' }}


### PR DESCRIPTION
Thanks to @malancas for highlighting issue ordering of RPM signing and attestations!  Now, all artifacts should have attestations appropriately generated

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
