### PR TITLE
feat: add `-a` flag to `gh run list`

### DIFF
--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -60,7 +60,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Long: heredoc.Docf(`
 		    List recent workflow runs.
 
-			Note that providing the %[1]sworkflow_name%[1]s to the %[1]s-w%[1]s flag will not fetch disabled workflows. 
+			Note that providing the %[1]sworkflow_name%[1]s to the %[1]s-w%[1]s flag will not fetch disabled workflows.
 			Also pass the %[1]s-a%[1]s flag to fetch disabled workflow runs using the %[1]sworkflow_name%[1]s and the %[1]s-w%[1]s flag.
 		`, "`"),
 		Aliases: []string{"ls"},
@@ -127,9 +127,7 @@ func listRun(opts *ListOptions) error {
 			// note: this will be incomplete if more workflow states are added to `workflowShared`
 			states = append(states, workflowShared.DisabledManually, workflowShared.DisabledInactivity)
 		}
-		if workflow, err := workflowShared.ResolveWorkflow(
-			opts.Prompter, opts.IO, client, baseRepo, false, opts.WorkflowSelector,
-			states); err == nil {
+		if workflow, err := workflowShared.ResolveWorkflow(opts.Prompter, opts.IO, client, baseRepo, false, opts.WorkflowSelector, states); err == nil {
 			filters.WorkflowID = workflow.ID
 			filters.WorkflowName = workflow.Name
 		} else {

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -120,8 +120,11 @@ func listRun(opts *ListOptions) error {
 
 	opts.IO.StartProgressIndicator()
 	if opts.WorkflowSelector != "" {
+		// initially the workflow state is limited to 'active'
 		states := []workflowShared.WorkflowState{workflowShared.Active}
 		if opts.All {
+			// the all flag tells us to add the remaining workflow states
+			// note: this will be incomplete if more workflow states are added to `workflowShared`
 			states = append(states, workflowShared.DisabledManually, workflowShared.DisabledInactivity)
 		}
 		if workflow, err := workflowShared.ResolveWorkflow(

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
+
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/tableprinter"
@@ -35,6 +37,7 @@ type ListOptions struct {
 	Event            string
 	Created          string
 	Commit           string
+	All              bool
 
 	now time.Time
 }
@@ -52,8 +55,14 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:     "list",
-		Short:   "List recent workflow runs",
+		Use:   "list",
+		Short: "List recent workflow runs",
+		Long: heredoc.Docf(`
+		    List recent workflow runs.
+
+			Note that providing the %[1]sworkflow_name%[1]s to the %[1]s-w%[1]s flag will not fetch disabled workflows. 
+			Also pass the %[1]s-a%[1]s flag to fetch disabled workflow runs using the %[1]sworkflow_name%[1]s and the %[1]s-w%[1]s flag.
+		`, "`"),
 		Aliases: []string{"ls"},
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -79,6 +88,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.Event, "event", "e", "", "Filter runs by which `event` triggered the run")
 	cmd.Flags().StringVarP(&opts.Created, "created", "", "", "Filter runs by the `date` it was created")
 	cmd.Flags().StringVarP(&opts.Commit, "commit", "c", "", "Filter runs by the `SHA` of the commit")
+	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "Include disabled workflows")
 	cmdutil.StringEnumFlag(cmd, &opts.Status, "status", "s", "", shared.AllStatuses, "Filter runs by status")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, shared.RunFields)
 
@@ -111,6 +121,9 @@ func listRun(opts *ListOptions) error {
 	opts.IO.StartProgressIndicator()
 	if opts.WorkflowSelector != "" {
 		states := []workflowShared.WorkflowState{workflowShared.Active}
+		if opts.All {
+			states = append(states, workflowShared.DisabledManually, workflowShared.DisabledInactivity)
+		}
 		if workflow, err := workflowShared.ResolveWorkflow(
 			opts.Prompter, opts.IO, client, baseRepo, false, opts.WorkflowSelector,
 			states); err == nil {

--- a/pkg/cmd/run/shared/test.go
+++ b/pkg/cmd/run/shared/test.go
@@ -15,21 +15,25 @@ func TestRun(id int64, s Status, c Conclusion) Run {
 }
 
 func TestRunWithCommit(id int64, s Status, c Conclusion, commit string) Run {
+	return TestRunWithWorkflowAndCommit(123, id, s, c, commit)
+}
+
+func TestRunWithWorkflowAndCommit(workflowId, runId int64, s Status, c Conclusion, commit string) Run {
 	return Run{
-		WorkflowID: 123,
-		ID:         id,
+		WorkflowID: workflowId,
+		ID:         runId,
 		CreatedAt:  TestRunStartTime,
 		UpdatedAt:  TestRunStartTime.Add(time.Minute*4 + time.Second*34),
 		Status:     s,
 		Conclusion: c,
 		Event:      "push",
 		HeadBranch: "trunk",
-		JobsURL:    fmt.Sprintf("https://api.github.com/runs/%d/jobs", id),
+		JobsURL:    fmt.Sprintf("https://api.github.com/runs/%d/jobs", runId),
 		HeadCommit: Commit{
 			Message: commit,
 		},
 		HeadSha: "1234567890",
-		URL:     fmt.Sprintf("https://github.com/runs/%d", id),
+		URL:     fmt.Sprintf("https://github.com/runs/%d", runId),
 		HeadRepository: Repo{
 			Owner: struct{ Login string }{Login: "OWNER"},
 			Name:  "REPO",


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #9038

This PR adds an `--all` (or `-a`) flag to `gh run list` so that users can get results for disabled workflows when searching for runs via the `workflow_name`. This mirrors the way the `gh workflow list -a` works. For more detail please see #9038