### PR TITLE
Add GH_DEBUG to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,5 +25,4 @@ A clear and concise description of what you expected to happen and what actually
 
 Paste the activity from your command line. Redact if needed.
 
-> [!NOTE]
-> Set `GH_DEBUG=true` for verbose logs or `GH_DEBUG=api` for verbose logs with HTTP traffic details.
+<!-- Note: Set `GH_DEBUG=true` for verbose logs or `GH_DEBUG=api` for verbose logs with HTTP traffic details. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,3 +24,4 @@ A clear and concise description of what you expected to happen and what actually
 ### Logs
 
 Paste the activity from your command line. Redact if needed.
+Tip: Set `GH_DEBUG=true` (verbose logs) or `GH_DEBUG=api` (verbose logs with HTTP traffic details)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,4 +24,6 @@ A clear and concise description of what you expected to happen and what actually
 ### Logs
 
 Paste the activity from your command line. Redact if needed.
-Tip: Set `GH_DEBUG=true` (verbose logs) or `GH_DEBUG=api` (verbose logs with HTTP traffic details)
+
+> [!NOTE]
+> Set `GH_DEBUG=true` for verbose logs or `GH_DEBUG=api` for verbose logs with HTTP traffic details.


### PR DESCRIPTION
Since reporting a few issues, many times the answer is "provide debug logs", adding to the template might help people to self-diagnose before reporting, and/or prevent a loop of communication between maintainers and issue author.