### PR TITLE
Attestation Verification - Buffer Fix

### DIFF
--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -76,7 +76,7 @@ func loadBundlesFromJSONLinesFile(path string) ([]*api.Attestation, error) {
 	reader := bufio.NewReader(file)
 
 	var line []byte
-	line, err = readLine(reader)
+	line, err = reader.ReadBytes('\n')
 	for err == nil {
 		var bundle bundle.ProtobufBundle
 		bundle.Bundle = new(protobundle.Bundle)
@@ -87,27 +87,10 @@ func loadBundlesFromJSONLinesFile(path string) ([]*api.Attestation, error) {
 		a := api.Attestation{Bundle: &bundle}
 		attestations = append(attestations, &a)
 
-		line, err = readLine(reader)
+		line, err = reader.ReadBytes('\n')
 	}
 
 	return attestations, nil
-}
-
-func readLine(reader *bufio.Reader) ([]byte, error) {
-	var line []byte
-	for {
-		b, isPrefix, err := reader.ReadLine()
-		if err != nil {
-			return nil, err
-		}
-		line = append(line, b...)
-
-		if !isPrefix {
-			break
-		}
-	}
-
-	return line, nil
 }
 
 func GetRemoteAttestations(c FetchAttestationsConfig) ([]*api.Attestation, error) {

--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -73,24 +73,41 @@ func loadBundlesFromJSONLinesFile(path string) ([]*api.Attestation, error) {
 
 	attestations := []*api.Attestation{}
 
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		b := scanner.Bytes()
+	reader := bufio.NewReader(file)
+
+	var line []byte
+	line, err = readLine(reader)
+	for err == nil {
 		var bundle bundle.ProtobufBundle
 		bundle.Bundle = new(protobundle.Bundle)
-		err = bundle.UnmarshalJSON(b)
+		err = bundle.UnmarshalJSON(line)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal bundle from JSON: %v", err)
 		}
 		a := api.Attestation{Bundle: &bundle}
 		attestations = append(attestations, &a)
-	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, err
+		line, err = readLine(reader)
 	}
 
 	return attestations, nil
+}
+
+func readLine(reader *bufio.Reader) ([]byte, error) {
+	var line []byte
+	for {
+		b, isPrefix, err := reader.ReadLine()
+		if err != nil {
+			return nil, err
+		}
+		line = append(line, b...)
+
+		if !isPrefix {
+			break
+		}
+	}
+
+	return line, nil
 }
 
 func GetRemoteAttestations(c FetchAttestationsConfig) ([]*api.Attestation, error) {


### PR DESCRIPTION
Fixes #9199

Currently lines are read using scanner, however for very large attestations the buffer can be exceeded.

Golang documentation states;

> Programs that need more control over error handling or large tokens, or must run sequential scans on a reader, should use [bufio.Reader](https://pkg.go.dev/bufio#Reader) instead.

I encountered this error while running verification for a set of attestations:

> Error: bundles could not be loaded from JSON lines file: bufio.Scanner: token too long

This changes uses bufio reader and readlines instead to avoid buffer limits. An alternative would be to set a larger buffer, but the exact size would be dependent upon the size of a possible maximum attestation (which can be quite large).

This will resolve issue #9199