### PR TITLE
Remove `gh at verify` public beta note

### DIFF
--- a/pkg/cmd/attestation/attestation.go
+++ b/pkg/cmd/attestation/attestation.go
@@ -17,8 +17,6 @@ func NewCmdAttestation(f *cmdutil.Factory) *cobra.Command {
 		Short:   "Work with artifact attestations",
 		Aliases: []string{"at"},
 		Long: heredoc.Doc(`
-			### NOTE: This feature is currently in beta, and subject to change.
-
 			Download and verify artifact attestations.
 			`),
 	}

--- a/pkg/cmd/attestation/download/download.go
+++ b/pkg/cmd/attestation/download/download.go
@@ -23,7 +23,7 @@ func NewDownloadCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Comman
 		Args:  cmdutil.ExactArgs(1, "must specify file path or container image URI, as well as one of --owner or --repo"),
 		Short: "Download an artifact's attestations for offline use",
 		Long: heredoc.Docf(`
-   	  		### NOTE: This feature is currently in beta, and subject to change.
+			### NOTE: This feature is currently in beta, and subject to change.
 
 			Download attestations associated with an artifact for offline use.
 

--- a/pkg/cmd/attestation/download/download.go
+++ b/pkg/cmd/attestation/download/download.go
@@ -23,6 +23,8 @@ func NewDownloadCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Comman
 		Args:  cmdutil.ExactArgs(1, "must specify file path or container image URI, as well as one of --owner or --repo"),
 		Short: "Download an artifact's attestations for offline use",
 		Long: heredoc.Docf(`
+   	  		### NOTE: This feature is currently in beta, and subject to change.
+
 			Download attestations associated with an artifact for offline use.
 
 			The command requires either:

--- a/pkg/cmd/attestation/download/download.go
+++ b/pkg/cmd/attestation/download/download.go
@@ -23,8 +23,6 @@ func NewDownloadCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Comman
 		Args:  cmdutil.ExactArgs(1, "must specify file path or container image URI, as well as one of --owner or --repo"),
 		Short: "Download an artifact's attestations for offline use",
 		Long: heredoc.Docf(`
-			### NOTE: This feature is currently in beta, and subject to change.
-
 			Download attestations associated with an artifact for offline use.
 
 			The command requires either:

--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -60,11 +60,11 @@ func NewVerifyCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command 
 
 			The signer workflow's identity is validated against the attestation's
 			certificate's Subject Alternative Name (SAN). Often, the signer workflow is the
-			same workflow that originated the run and generated the attestation, and will
-			be located inside your repository. For this reason, by default this command uses
+			same workflow that started the run and generated the attestation, and will be
+			located inside your repository. For this reason, by default this command uses
 			either the %[1]s--repo%[1]s or the %[1]s--owner%[1]s flag value to validate the SAN.
 
-			However, sometimes the originating workflow is not be the same workflow that
+			However, sometimes the caller workflow is not be the same workflow that
 			performed the signing. If your attestation was generated via a reusable
 			workflow, then that reusable workflow is the signer whose identity needs to be
 			validated. In this situation, the signer workflow may or may not be located

--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -64,7 +64,7 @@ func NewVerifyCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command 
 			located inside your repository. For this reason, by default this command uses
 			either the %[1]s--repo%[1]s or the %[1]s--owner%[1]s flag value to validate the SAN.
 
-			However, sometimes the caller workflow is not be the same workflow that
+			However, sometimes the caller workflow is not the same workflow that
 			performed the signing. If your attestation was generated via a reusable
 			workflow, then that reusable workflow is the signer whose identity needs to be
 			validated. In this situation, the signer workflow may or may not be located

--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -58,8 +58,8 @@ func NewVerifyCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command 
 			To see the full results that are generated upon successful verification, i.e.
 			for use with a policy engine, provide the %[1]s--format=json%[1]s flag.
 
-			The signer workflow's identity is validated against the attestation's
-			certificate's Subject Alternative Name (SAN). Often, the signer workflow is the
+			The signer workflow's identity is validated against the Subject Alternative Name (SAN)
+			within the attestation certificate. Often, the signer workflow is the
 			same workflow that started the run and generated the attestation, and will be
 			located inside your repository. For this reason, by default this command uses
 			either the %[1]s--repo%[1]s or the %[1]s--owner%[1]s flag value to validate the SAN.


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

We're moving artifact attestations out of public beta (you've heard it here first, folks!), and consequently we don't need to warn folks that these commands are in beta.

Also, while reviewing the `--signer-repo` flag we realized we felt confused about its correct usage, even though we implemented it, and so I took the liberty to clarify which flags to use when using reusable workflows.

Finally, some reason that remains inscrutable to me I also ensured the docs didn't word wrap when printed on terminals 80chars wide.