### PR TITLE
fix: indentation in 'gh release create --help'

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -116,7 +116,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			Use release notes from a file
 			$ gh release create v1.2.3 -F changelog.md
    
-   			Don't mark the release as latest
+			Don't mark the release as latest
 			$ gh release create v1.2.3 --latest=false 
 
 			Upload all tarballs in a directory as release assets


### PR DESCRIPTION
This fixes the indentation of the `--latest=false` example in the output of `gh release create --help`. The current implementation uses 3 spaces followed by 3 tabs. The new implementation uses 3 tabs (like the other examples).

Currently, the output of `gh release create --help` looks like:
```
...
  Use release notes from a file
  $ gh release create v1.2.3 -F changelog.md
  
  			Don't mark the release as latest
  $ gh release create v1.2.3 --latest=false 
  
  Upload all tarballs in a directory as release assets
  $ gh release create v1.2.3 ./dist/*.tgz
...
```

This should make the ouput look like:
```
...
  Use release notes from a file
  $ gh release create v1.2.3 -F changelog.md
  
  Don't mark the release as latest
  $ gh release create v1.2.3 --latest=false 
  
  Upload all tarballs in a directory as release assets
  $ gh release create v1.2.3 ./dist/*.tgz
...
```

This issue was introduced in https://github.com/cli/cli/pull/8987.