### PR TITLE
Fix panic when calling `gh pr view --json stateReason`

### DIFF
--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -249,7 +249,7 @@ func RequiredStatusCheckRollupGraphQL(prID, after string, includeEvent bool) str
 	}`), afterClause, prID, eventField)
 }
 
-var IssueFields = []string{
+var sharedIssuePRFields = []string{
 	"assignees",
 	"author",
 	"body",
@@ -268,10 +268,20 @@ var IssueFields = []string{
 	"title",
 	"updatedAt",
 	"url",
+}
+
+// Some fields are only valid in the context of issues.
+// They need to be enumerated separately in order to be filtered
+// from existing code that expects to be able to pass Issue fields
+// to PR queries, e.g. the PullRequestGraphql function.
+var issueOnlyFields = []string{
+	"isPinned",
 	"stateReason",
 }
 
-var PullRequestFields = append(IssueFields,
+var IssueFields = append(sharedIssuePRFields, issueOnlyFields...)
+
+var PullRequestFields = append(sharedIssuePRFields,
 	"additions",
 	"autoMergeRequest",
 	"baseRefName",
@@ -298,12 +308,6 @@ var PullRequestFields = append(IssueFields,
 	"reviews",
 	"statusCheckRollup",
 )
-
-// Some fields are only valid in the context of issues.
-var issueOnlyFields = []string{
-	"isPinned",
-	"stateReason",
-}
 
 // IssueGraphQL constructs a GraphQL query fragment for a set of issue fields.
 func IssueGraphQL(fields []string) string {

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -16,10 +16,36 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/pkg/jsonfieldstest"
 	"github.com/cli/cli/v2/test"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestJSONFields(t *testing.T) {
+	jsonfieldstest.ExpectCommandToSupportJSONFields(t, NewCmdView, []string{
+		"assignees",
+		"author",
+		"body",
+		"closed",
+		"comments",
+		"createdAt",
+		"closedAt",
+		"id",
+		"labels",
+		"milestone",
+		"number",
+		"projectCards",
+		"projectItems",
+		"reactionGroups",
+		"state",
+		"title",
+		"updatedAt",
+		"url",
+		"isPinned",
+		"stateReason",
+	})
+}
 
 func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
 	ios, _, stdout, stderr := iostreams.Test()

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -18,11 +18,60 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/pkg/jsonfieldstest"
 	"github.com/cli/cli/v2/test"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestJSONFields(t *testing.T) {
+	jsonfieldstest.ExpectCommandToSupportJSONFields(t, NewCmdView, []string{
+		"additions",
+		"assignees",
+		"author",
+		"autoMergeRequest",
+		"baseRefName",
+		"body",
+		"changedFiles",
+		"closed",
+		"closedAt",
+		"comments",
+		"commits",
+		"createdAt",
+		"deletions",
+		"files",
+		"headRefName",
+		"headRefOid",
+		"headRepository",
+		"headRepositoryOwner",
+		"id",
+		"isCrossRepository",
+		"isDraft",
+		"labels",
+		"latestReviews",
+		"maintainerCanModify",
+		"mergeCommit",
+		"mergeStateStatus",
+		"mergeable",
+		"mergedAt",
+		"mergedBy",
+		"milestone",
+		"number",
+		"potentialMergeCommit",
+		"projectCards",
+		"projectItems",
+		"reactionGroups",
+		"reviewDecision",
+		"reviewRequests",
+		"reviews",
+		"state",
+		"statusCheckRollup",
+		"title",
+		"updatedAt",
+		"url",
+	})
+}
 
 func Test_NewCmdView(t *testing.T) {
 	tests := []struct {

--- a/pkg/jsonfieldstest/jsonfieldstest.go
+++ b/pkg/jsonfieldstest/jsonfieldstest.go
@@ -1,0 +1,47 @@
+package jsonfieldstest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func jsonFieldsFor(cmd *cobra.Command) []string {
+	// This annotation is added by the `cmdutil.AddJSONFlags` function.
+	//
+	// This is an extremely janky way to get access to this information but due to the fact we pass
+	// around concrete cobra.Command structs, there's no viable way to have typed access to the fields.
+	//
+	// It's also kind of fragile because it's several hops away from the code that actually validates the usage
+	// of these flags, so it's possible for things to get out of sync.
+	stringFields, ok := cmd.Annotations["help:json-fields"]
+	if !ok {
+		return nil
+	}
+
+	return strings.Split(stringFields, ",")
+}
+
+// NewCmdFunc represents the typical function signature we use for creating commands e.g. `NewCmdView`.
+//
+// It is generic over `T` as each command construction has their own Options type e.g. `ViewOptions`
+type NewCmdFunc[T any] func(f *cmdutil.Factory, runF func(*T) error) *cobra.Command
+
+// ExpectCommandToSupportJSONFields asserts that the provided command supports exactly the provided fields.
+// Ordering of the expected fields is not important.
+//
+// Make sure you are not pointing to the same slice of fields in the test and the implementation.
+// It can be a little tedious to rewrite the fields inline in the test but it's significantly more useful because:
+//   - It forces the test author to think about and convey exactly the expected fields for a command
+//   - It avoids accidentally adding fields to a command, and the test passing unintentionally
+func ExpectCommandToSupportJSONFields[T any](t *testing.T, fn NewCmdFunc[T], expectedFields []string) {
+	t.Helper()
+
+	actualFields := jsonFieldsFor(fn(&cmdutil.Factory{}, nil))
+	assert.Equal(t, len(actualFields), len(expectedFields), "expected number of fields to match")
+	require.ElementsMatch(t, expectedFields, actualFields)
+}


### PR DESCRIPTION
## Description

Fixes #9160

This PR has two parts.

First, I fixed the panic itself by ensuring that `stateReason` is not included in the allowable json fields for `pr` commands. This is done by making a clearer separation between shared and Issue or PR only fields. It doesn't address some of the awkwardness on how `IssueOnlyFields` are used in say `PullRequestGraphql` function but that seemed to get out of hand quite quickly so I wanted to scope this PR down.

Second, I added a really suspicious testing idea that I had for getting some confidence in the allowable JSON fields. Up until now it has been easy to ensure fields **are** allowable by running a test that executes the command and providing flags that Cobra will parse. However, this issue is about a field that was unexpectedly included and that's a little harder to test. I've created a pretty horrible test harness that leans on the same annotations that we use to generate the help text for the `--json` flag. This allows us to assert **exactly** the allowable fields for a command. Ideally the commands themselves would expose this information in a type safe way but because it's all locked up inside Cobra's lifecycle hooks and concrete types, it's not so easy. One advantage of this approach is that if we later decide it sucks it should be very, very easy to address.

Additionally, this PR exposes `isPinned` for `issue` commands just because there's no reason not to, and because it makes maintenance a little easier.
