### PR TITLE
docs: Update documentation for `gh repo create` to clarify owner

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -88,6 +88,9 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			To create a remote repository non-interactively, supply the repository name and one of %[1]s--public%[1]s, %[1]s--private%[1]s, or %[1]s--internal%[1]s.
 			Pass %[1]s--clone%[1]s to clone the new repository locally.
 
+                        If the %[1]sOWNER/%[1]s portion of the %[1]sOWNER/REPO%[1]s name argument is omitted, it
+			defaults to the name of the authenticating user.
+
 			To create a remote repository from an existing local repository, specify the source directory with %[1]s--source%[1]s.
 			By default, the remote repository name will be the name of the source directory.
 			Pass %[1]s--push%[1]s to push any local commits to the new repository.
@@ -98,6 +101,9 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			# create a new remote repository and clone it locally
 			gh repo create my-project --public --clone
+
+                        # create a new remote repository in a different organization
+			gh repo create my-org/my-project --public
 
 			# create a remote repository from the current directory
 			gh repo create my-project --private --source=. --remote=upstream


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
The docs for gh repo create doesn't clarify how to create a repo in a different namespace nor does it clarify it defaults to the currently logged in user.