### PR TITLE
Remove attestation test that requires being online

### DIFF
--- a/pkg/cmd/attestation/trustedroot/trustedroot_test.go
+++ b/pkg/cmd/attestation/trustedroot/trustedroot_test.go
@@ -85,11 +85,6 @@ func TestGetTrustedRoot(t *testing.T) {
 		TufRootPath: root,
 	}
 
-	t.Run("successfully verifies TUF root", func(t *testing.T) {
-		err := getTrustedRoot(tuf.New, opts)
-		require.NoError(t, err)
-	})
-
 	t.Run("failed to create TUF root", func(t *testing.T) {
 		err := getTrustedRoot(newTUFErrClient, opts)
 		require.Error(t, err)


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #8928

I didn't know that the tests should not rely on internet connectivity. Longer-term we could mock something out, but the way this is written today that would likely require some small changes to sigstore-go (to specify an interface).