### PR TITLE
Expose json databaseId field for release commands

### DIFF
--- a/pkg/cmd/release/shared/fetch.go
+++ b/pkg/cmd/release/shared/fetch.go
@@ -21,22 +21,22 @@ import (
 )
 
 var ReleaseFields = []string{
-	"url",
 	"apiUrl",
-	"uploadUrl",
-	"tarballUrl",
-	"zipballUrl",
-	"id",
-	"tagName",
-	"name",
-	"body",
-	"isDraft",
-	"isPrerelease",
-	"createdAt",
-	"publishedAt",
-	"targetCommitish",
 	"author",
 	"assets",
+	"body",
+	"createdAt",
+	"id",
+	"isDraft",
+	"isPrerelease",
+	"name",
+	"publishedAt",
+	"tagName",
+	"tarballUrl",
+	"targetCommitish",
+	"uploadUrl",
+	"url",
+	"zipballUrl",
 }
 
 type Release struct {

--- a/pkg/cmd/release/shared/fetch.go
+++ b/pkg/cmd/release/shared/fetch.go
@@ -26,6 +26,7 @@ var ReleaseFields = []string{
 	"assets",
 	"body",
 	"createdAt",
+	"databaseId",
 	"id",
 	"isDraft",
 	"isPrerelease",

--- a/pkg/cmd/release/view/view_test.go
+++ b/pkg/cmd/release/view/view_test.go
@@ -27,6 +27,7 @@ func TestJSONFields(t *testing.T) {
 		"assets",
 		"body",
 		"createdAt",
+		"databaseId",
 		"id",
 		"isDraft",
 		"isPrerelease",

--- a/pkg/cmd/release/view/view_test.go
+++ b/pkg/cmd/release/view/view_test.go
@@ -14,10 +14,32 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/pkg/jsonfieldstest"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestJSONFields(t *testing.T) {
+	jsonfieldstest.ExpectCommandToSupportJSONFields(t, NewCmdView, []string{
+		"apiUrl",
+		"author",
+		"assets",
+		"body",
+		"createdAt",
+		"id",
+		"isDraft",
+		"isPrerelease",
+		"name",
+		"publishedAt",
+		"tagName",
+		"tarballUrl",
+		"targetCommitish",
+		"uploadUrl",
+		"url",
+		"zipballUrl",
+	})
+}
 
 func Test_NewCmdView(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

Fixes https://github.com/cli/cli/issues/9278

### Acceptance Criteria

**Given** there is a release with <tag> on <repo>
**When** I run `gh release view --repo <repo> --json name,databaseId <tag>`
**Then** I see a JSON document containing an integer database Id for the release

```
➜ ./bin/gh release list --repo cli/cli | cat
GitHub CLI 2.53.0        Latest  v2.53.0 2024-07-17T18:51:32Z
...
```

```
➜ ./bin/gh release view --repo cli/cli --json name,databaseId v2.53.0 | cat
{"databaseId":165912183,"name":"GitHub CLI 2.53.0"}
```