### PR TITLE
Slightly clarify when CLI exits with code 4

### DIFF
--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -266,7 +266,7 @@ var HelpTopics = []helpTopic{
 
 			- If a command is running but gets cancelled, the exit code will be 2
 
-			- If a command encounters an authentication issue, the exit code will be 4
+			- If a command requires authentication, the exit code will be 4
 
 			NOTE: It is possible that a particular command may have more exit codes, so it is a good
 			practice to check documentation for the command if you are relying on exit codes to


### PR DESCRIPTION
## Description

In https://github.com/cli/cli/issues/9338 it was called out that the help text was unclear about when the CLI would exit with code `4`. Previously it indicated that _any_ authentication issue would result in `4`, which could include scope issues, permission issues, etc. This was not the original intention.

It's possible we will revisit our exit codes in the future but for the moment I just wanted to clarify that `4` is used _when the CLI needs to be authenticated at all_ i.e. there is no token available.