### PR TITLE
handle attest case insensitivity

### DIFF
--- a/pkg/cmd/attestation/api/attestation.go
+++ b/pkg/cmd/attestation/api/attestation.go
@@ -9,6 +9,8 @@ import (
 const (
 	GetAttestationByRepoAndSubjectDigestPath  = "repos/%s/attestations/%s"
 	GetAttestationByOwnerAndSubjectDigestPath = "orgs/%s/attestations/%s"
+	GetUsernamePath                           = "users/%s"
+	GetRepoNamePath                           = "repos/%s"
 )
 
 type ErrNoAttestations struct {
@@ -30,4 +32,11 @@ type Attestation struct {
 
 type AttestationsResponse struct {
 	Attestations []*Attestation `json:"attestations"`
+}
+
+type UserResponse struct {
+	Login string `json:"login"`
+}
+type RepoResponse struct {
+	FullName string `json:"full_name"`
 }

--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -223,6 +223,27 @@ func runVerify(opts *Options) error {
 		attestations = filteredAttestations
 	}
 
+	// Normalize SAN Regex owner and repo values.
+	if opts.SANRegex != "" {
+		if opts.Owner != "" {
+			opts.Owner, err = c.APIClient.GetUsername(opts.Owner)
+			opts.SANRegex = expandToGitHubURL(opts.Owner)
+			if err != nil {
+				opts.Logger.Printf(opts.Logger.ColorScheme.Red("✗ Failed to get username for %s\n"), opts.Owner)
+				return err
+			}
+		}
+
+		if opts.Repo != "" {
+			opts.Repo, err = c.APIClient.GetRepoName(opts.Repo)
+			opts.SANRegex = expandToGitHubURL(opts.Repo)
+			if err != nil {
+				opts.Logger.Printf(opts.Logger.ColorScheme.Red("✗ Failed to get repository name for %s\n"), opts.Repo)
+				return err
+			}
+		}
+	}
+
 	policy, err := buildVerifyPolicy(opts, *artifact)
 	if err != nil {
 		opts.Logger.Println(opts.Logger.ColorScheme.Red("✗ Failed to build verification policy"))


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->


This change is to normalize owner, repo and SANRegex. 
-----------------

Without normalization, below cmd will cause error for SAN value and extension. 
```
/bin/gh attestation verify oci://ghcr.io/ejahngithub/test-generate-provenance@sha256:e10c4f0c7050fed92d5641d4fd87cce434a040a129731d52da86ad8234192017 --owner ejahngithub
Loaded digest sha256:e10c4f0c7050fed92d5641d4fd87cce434a040a129731d52da86ad8234192017 for oci://ghcr.io/ejahngithub/test-generate-provenance@sha256:e10c4f0c7050fed92d5641d4fd87cce434a040a129731d52da86ad8234192017
``` 
-----------------

If SANRegex is not normalize, will have this error. Due to this line https://github.com/cli/cli/blob/b05bddc210a1e45a25b76f9b320239e4c36f03ee/pkg/cmd/attestation/verify/policy.go#L24
```
Error: verifying with issuer "sigstore.dev": failed to verify certificate identity: no matching CertificateIdentity found, last error: expected SAN value to match regex "^https://github.com/ejahngithub/", got "https://github.com/ejahnGithub/test-generate-provenance/.github/workflows/publish_container.yaml@refs/tags/v0.1.8"
```

If repo or owner is not normalize, will have this error. Due to this line https://github.com/cli/cli/blob/b05bddc210a1e45a25b76f9b320239e4c36f03ee/pkg/cmd/attestation/verify/policy.go#L46-L54
```
Error: verifying with issuer "sigstore.dev": failed to verify certificate identity: no matching CertificateIdentity found, last error: expected SourceRepositoryOwnerURI to be "https://github.com/ejahngithub", got "https://github.com/ejahnGithub"
```



-----------------

With the new change, this will work. 

```
❯ ./bin/gh attestation verify oci://ghcr.io/ejahngithub/test-generate-provenance@sha256:e10c4f0c7050fed92d5641d4fd87cce434a040a129731d52da86ad8234192017 --owner ejahngithub
Loaded digest sha256:e10c4f0c7050fed92d5641d4fd87cce434a040a129731d52da86ad8234192017 for oci://ghcr.io/ejahngithub/test-generate-provenance@sha256:e10c4f0c7050fed92d5641d4fd87cce434a040a129731d52da86ad8234192017
Loaded 2 attestations from GitHub API
✓ Verification succeeded!

sha256:e10c4f0c7050fed92d5641d4fd87cce434a040a129731d52da86ad8234192017 was attested by:
REPO                                  PREDICATE_TYPE                  WORKFLOW                                                 
ejahnGithub/test-generate-provenance  https://slsa.dev/provenance/v1  .github/workflows/publish_container.yaml@refs/tags/v0.1.8
ejahnGithub/test-generate-provenance  https://spdx.dev/Document/v2.3  .github/workflows/publish_container.yaml@refs/tags/v0.1.8
```