### PR TITLE
Add Flox as an installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Additional Conda installation options available on the [gh-feedstock page](https
 
 For more information about the Webi installer see [its homepage](https://webinstall.dev/).
 
+#### Flox
+
+| Install:          | Upgrade:                |
+| ----------------- | ----------------------- |
+| `flox install gh` | `flox upgrade toplevel` |
+
+For more information about Flox, see [its homepage](https://flox.dev)
+
 ### Linux & BSD
 
 `gh` is available via:

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -204,6 +204,20 @@ Nix/NixOS users can install from [nixpkgs](https://search.nixos.org/packages?que
 nix-env -iA nixos.gh
 ```
 
+### Flox
+
+Flox users can install from the [official community nixpkgs](https://github.com/flox/nixpkgs).
+
+```bash
+# To install
+flox install gh
+
+# To upgrade
+flox upgrade toplevel
+```
+
+For more information about Flox, see [its homepage](https://flox.dev).
+
 ### openSUSE Tumbleweed
 
 openSUSE Tumbleweed users can install from the [official distribution repo](https://software.opensuse.org/package/gh):


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
`gh` is available and working in the Flox package manager today!
The `upgrade` command looks quite odd, since we're upgrading the `toplevel` "package group", which `gh` gets installed into by default, but the group isn't exclusive to `gh`.

Fixes #9397