### PR TITLE
Enable linux riscv64 builds in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ builds:
 
   - id: linux #build:linux
     goos: [linux]
-    goarch: [386, arm, amd64, arm64]
+    goarch: [386, arm, amd64, arm64, riscv64]
     env:
       - CGO_ENABLED=0
     binary: bin/gh


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
