### PR TITLE
feat(ghinstance): allow port in host

### DIFF
--- a/internal/ghinstance/host.go
+++ b/internal/ghinstance/host.go
@@ -23,7 +23,7 @@ func Default() string {
 // IsEnterprise reports whether a non-normalized host name looks like a GHE instance.
 func IsEnterprise(h string) bool {
 	normalizedHostName := NormalizeHostname(h)
-	return normalizedHostName != defaultHostname && normalizedHostName != localhost
+	return normalizedHostName != defaultHostname && !isLocal(normalizedHostName)
 }
 
 // IsTenancy reports whether a non-normalized host name looks like a tenancy instance.
@@ -76,10 +76,21 @@ func GraphQLEndpoint(hostname string) string {
 	if IsEnterprise(hostname) {
 		return fmt.Sprintf("https://%s/api/graphql", hostname)
 	}
-	if strings.EqualFold(hostname, localhost) {
+	if isLocal(hostname) {
 		return fmt.Sprintf("http://api.%s/graphql", hostname)
 	}
 	return fmt.Sprintf("https://api.%s/graphql", hostname)
+}
+
+func isLocal(h string) bool {
+	switch parts := strings.Split(h, ":"); len(parts) {
+	case 1, 2:
+		h = parts[0]
+	default:
+		return false
+	}
+
+	return strings.EqualFold(h, localhost)
 }
 
 func RESTPrefix(hostname string) string {
@@ -89,7 +100,7 @@ func RESTPrefix(hostname string) string {
 	if IsEnterprise(hostname) {
 		return fmt.Sprintf("https://%s/api/v3/", hostname)
 	}
-	if strings.EqualFold(hostname, localhost) {
+	if isLocal(hostname) {
 		return fmt.Sprintf("http://api.%s/", hostname)
 	}
 	return fmt.Sprintf("https://api.%s/", hostname)
@@ -97,7 +108,7 @@ func RESTPrefix(hostname string) string {
 
 func GistPrefix(hostname string) string {
 	prefix := "https://"
-	if strings.EqualFold(hostname, localhost) {
+	if isLocal(hostname) {
 		prefix = "http://"
 	}
 	return prefix + GistHost(hostname)
@@ -110,14 +121,14 @@ func GistHost(hostname string) string {
 	if IsEnterprise(hostname) {
 		return fmt.Sprintf("%s/gist/", hostname)
 	}
-	if strings.EqualFold(hostname, localhost) {
+	if isLocal(hostname) {
 		return fmt.Sprintf("%s/gist/", hostname)
 	}
 	return fmt.Sprintf("gist.%s/", hostname)
 }
 
 func HostPrefix(hostname string) string {
-	if strings.EqualFold(hostname, localhost) {
+	if isLocal(hostname) {
 		return fmt.Sprintf("http://%s/", hostname)
 	}
 	return fmt.Sprintf("https://%s/", hostname)

--- a/internal/ghinstance/host_test.go
+++ b/internal/ghinstance/host_test.go
@@ -24,6 +24,10 @@ func TestIsEnterprise(t *testing.T) {
 			want: false,
 		},
 		{
+			host: "github.localhost:8080",
+			want: false,
+		},
+		{
 			host: "api.github.localhost",
 			want: false,
 		},
@@ -60,6 +64,10 @@ func TestIsTenancy(t *testing.T) {
 		},
 		{
 			host: "github.localhost",
+			want: false,
+		},
+		{
+			host: "github.localhost:8080",
 			want: false,
 		},
 		{
@@ -103,6 +111,10 @@ func TestTenantName(t *testing.T) {
 			wantTenant: "github.localhost",
 		},
 		{
+			host:       "github.localhost:8080",
+			wantTenant: "github.localhost:8080",
+		},
+		{
 			host:       "garage.github.com",
 			wantTenant: "github.com",
 		},
@@ -125,6 +137,41 @@ func TestTenantName(t *testing.T) {
 		t.Run(tt.host, func(t *testing.T) {
 			if tenant, found := TenantName(tt.host); tenant != tt.wantTenant || found != tt.wantFound {
 				t.Errorf("TenantName(%v) = %v %v, want %v %v", tt.host, tenant, found, tt.wantTenant, tt.wantFound)
+			}
+		})
+	}
+}
+
+func TestIsLocal(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{
+			host: "github.com",
+			want: false,
+		},
+		{
+			host: "garage.github.com",
+			want: false,
+		},
+		{
+			host: "ghe.com",
+			want: false,
+		},
+		{
+			host: "github.localhost",
+			want: true,
+		},
+		{
+			host: "github.localhost:8080",
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			if got := IsLocal(tt.host); got != tt.want {
+				t.Errorf("IsLocal() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -158,6 +205,10 @@ func TestNormalizeHostname(t *testing.T) {
 		{
 			host: "api.github.localhost",
 			want: "github.localhost",
+		},
+		{
+			host: "gitHub.LocalHost:8080",
+			want: "github.localhost:8080",
 		},
 		{
 			host: "garage.github.com",
@@ -247,6 +298,10 @@ func TestGraphQLEndpoint(t *testing.T) {
 			want: "http://api.github.localhost/graphql",
 		},
 		{
+			host: "github.localhost:8080",
+			want: "http://api.github.localhost:8080/graphql",
+		},
+		{
 			host: "garage.github.com",
 			want: "https://garage.github.com/api/graphql",
 		},
@@ -276,6 +331,10 @@ func TestRESTPrefix(t *testing.T) {
 		{
 			host: "github.localhost",
 			want: "http://api.github.localhost/",
+		},
+		{
+			host: "github.localhost:8080",
+			want: "http://api.github.localhost:8080/",
 		},
 		{
 			host: "garage.github.com",


### PR DESCRIPTION
This PR proposes to allow setting port number in hosts.
It also updates existing tests and adds new one to cover the new cases.

> [!NOTE]
> Technically, a _port_ is not part of a _hostname_, but the current usage feels loose enough that it didn't seem out of place.

cc https://github.com/cli/cli/issues/6845
Fixes https://github.com/cli/cli/issues/8640

## Why

During local development, it's very useful to be able to use `github.localhost` to redirect traffic to a local webserver. However, it's not always listening on port `:80`. Having the ability to set port numbers would make local development much easier.

AFAIK this doesn't change any security consideration, as using local server is already possible.

## Examples

### `gh` upstream

Currently, it's possible to do this behavior with a specific API endpoint like:
```shell
$ GH_DEBUG=api gh api http://gihthub.localhost:8080/api/user
* Request at 2024-08-04 10:44:50.596839 +0200 CEST m=+0.042306376
* Request to http://github.localhost:8080/api/user
> GET /api/user HTTP/1.1
> Host: localhost:8080
> Accept: */*
> Content-Type: application/json; charset=utf-8
> Time-Zone: Europe/Berlin
> User-Agent: GitHub CLI 2.51.0
...
```

However, this doesn't work using `GH_HOST`:

```shell
GH_DEBUG=api GH_HOST=github.localhost:8080 gh api /user      
* Request at 2024-08-04 19:43:37.560564 +0200 CEST m=+0.042314584
* Request to https://github.localhost:8080/api/v3/user
> GET /api/v3/user HTTP/1.1
> Host: github.localhost:8080
> Accept: */*
> Content-Type: application/json; charset=utf-8
> Time-Zone: Europe/Berlin
> User-Agent: GitHub CLI 2.51.0
...
```

You could think "hey this is working!", except that `Request to https://localhost:8080/api/graphql` (note the `https` and `/api` instead of `api.github`) in fact isn't a "localhost" hostname, but an "enterprise" hostname.

<details><summary>Enterprise matching</summary>

As you can see in https://github.com/cli/cli/blob/89cbcfe7eb186ff4edbe10792d17bdc55b04f297/internal/ghinstance/host.go#L72-L96

- When `IsEnterprise` returns true, `https` is used (that's the case here).
- When the local hostname is found, `http` is used.

</details>


### `gh` on this branch

Compiled as `gh-port`:

```shell
$ GH_DEBUG=api ./gh-port api http://github.localhost:8080/api/user
* Request at 2024-08-04 19:44:02.902518 +0200 CEST m=+0.041669334
* Request to http://github.localhost:8080/api/user
> GET /api/user HTTP/1.1
> Host: github.localhost:8080
> Accept: */*
> Content-Type: application/json; charset=utf-8
> Time-Zone: Europe/Berlin
> User-Agent: GitHub CLI DEV
...

$ GH_DEBUG=api GH_HOST=github.localhost:8080 ./gh-port api /user
* Request at 2024-08-04 19:44:40.651391 +0200 CEST m=+0.042667001
* Request to http://api.github.localhost:8080/user
> GET /user HTTP/1.1
> Host: api.github.localhost:8080
> Accept: */*
> Content-Type: application/json; charset=utf-8
> Time-Zone: Europe/Berlin
> User-Agent: GitHub CLI DEV
...
```

## `go-gh`

`go-gh` also has its implementation logic for `localhost` verification: 
- https://github.com/cli/go-gh/blob/25db6b99518c88e03f71dbe9e58397c4cfb62caf/pkg/api/rest_client.go#L166
- https://github.com/cli/go-gh/blob/25db6b99518c88e03f71dbe9e58397c4cfb62caf/pkg/api/graphql_client.go#L178
- https://github.com/cli/go-gh/blob/25db6b99518c88e03f71dbe9e58397c4cfb62caf/pkg/auth/auth.go#L130-L194

With `localhost` defined here: 
- https://github.com/cli/go-gh/blob/25db6b99518c88e03f71dbe9e58397c4cfb62caf/pkg/api/http_client.go#L28
- https://github.com/cli/go-gh/blob/25db6b99518c88e03f71dbe9e58397c4cfb62caf/pkg/auth/auth.go#L27

It seems that those two codes are very similar and could probably be refactored into only the `go-gh` package:
- https://github.com/cli/go-gh/blob/25db6b99518c88e03f71dbe9e58397c4cfb62caf/pkg/auth/auth.go
- https://github.com/cli/cli/blob/89cbcfe7eb186ff4edbe10792d17bdc55b04f297/internal/ghinstance/host.go

<details><summary>Usage</summary>

For `cli/internal/ghinstance`:

file | `ghinstance.<method>`
--- | ---
api/client.go                                            | NormalizeHostname
api/http_client.go                                       | NormalizeHostname
api/queries_repo.go                                      | RESTPrefix
internal/authflow/flow.go                                | HostPrefix
internal/authflow/flow.go                                | IsEnterprise
internal/codespaces/api/api.go                           | HostPrefix
internal/codespaces/api/api.go                           | RESTPrefix
internal/featuredetection/feature_detection.go           | IsEnterprise
internal/ghrepo/repo.go                                  | Default
internal/ghrepo/repo.go                                  | HostPrefix
internal/ghrepo/repo.go                                  | TenantName
internal/prompter/prompter.go                            | HostnameValidator
pkg/cmd/api/api.go                                       | HostnameValidator
pkg/cmd/api/http.go                                      | GraphQLEndpoint
pkg/cmd/api/http.go                                      | RESTPrefix
pkg/cmd/attestation/auth/host.go                         | IsTenancy
pkg/cmd/auth/login/login.go                              | Default
pkg/cmd/auth/login/login.go                              | HostnameValidator
pkg/cmd/auth/shared/gitcredentials/fake_helper_config.go | GistHost
pkg/cmd/auth/shared/gitcredentials/helper_config.go      | GistHost
pkg/cmd/auth/shared/gitcredentials/helper_config.go      | HostPrefix
pkg/cmd/auth/shared/login_flow.go                        | GraphQLEndpoint
pkg/cmd/auth/shared/oauth_scopes.go                      | RESTPrefix
pkg/cmd/extension/http.go                                | RESTPrefix
pkg/cmd/factory/remote_resolver.go                       | Default
pkg/cmd/gist/clone/clone.go                              | IsEnterprise
pkg/cmd/gist/create/create.go                            | RESTPrefix
pkg/cmd/gist/view/view.go                                | GistPrefix
pkg/cmd/gpg-key/add/http.go                              | RESTPrefix
pkg/cmd/gpg-key/delete/http.go                           | RESTPrefix
pkg/cmd/gpg-key/list/http.go                             | RESTPrefix
pkg/cmd/pr/diff/diff.go                                  | RESTPrefix
pkg/cmd/pr/status/http.go                                | IsEnterprise
pkg/cmd/release/create/http.go                           | RESTPrefix
pkg/cmd/release/delete/delete.go                         | RESTPrefix
pkg/cmd/release/edit/http.go                             | RESTPrefix
pkg/cmd/release/shared/fetch.go                          | RESTPrefix
pkg/cmd/repo/delete/http.go                              | RESTPrefix
pkg/cmd/repo/deploy-key/add/http.go                      | RESTPrefix
pkg/cmd/repo/deploy-key/delete/http.go                   | RESTPrefix
pkg/cmd/repo/deploy-key/list/http.go                     | RESTPrefix
pkg/cmd/repo/edit/edit.go                                | RESTPrefix
pkg/cmd/repo/garden/http.go                              | RESTPrefix
pkg/cmd/ruleset/list/list.go                             | HostPrefix
pkg/cmd/run/shared/artifacts.go                          | RESTPrefix
pkg/cmd/run/view/view.go                                 | RESTPrefix
pkg/cmd/ssh-key/add/http.go                              | RESTPrefix
pkg/cmd/ssh-key/delete/http.go                           | RESTPrefix
pkg/cmd/ssh-key/shared/user_keys.go                      | RESTPrefix
pkg/search/searcher.go                                   | RESTPrefix

And for `go-gh/v2/pkg/auth`:

file                              | `auth.<method>`
---                               | ---
internal/ghrepo/repo.go           | DefaultHost
pkg/cmd/auth/login/login.go       | DefaultHost
internal/config/config.go         | TokenFromEnvOrConfig
internal/config/config.go         | KnownHosts
internal/config/config.go         | DefaultHost
pkg/cmd/ruleset/view/view.go      | DefaultHost
pkg/cmd/ruleset/list/list.go      | DefaultHost
pkg/cmd/attestation/api/client.go | DefaultHost
pkg/cmd/repo/delete/delete.go     | DefaultHost
pkg/cmd/attestation/auth/host.go  | DefaultHost

</details>

So if this change is deemed acceptable, there should be some adjustments made also to `go-gh`. Maybe it would be a good opportunity to merge the two into a single place?