### PR TITLE
Add `pr create --editor`

### DIFF
--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -122,7 +122,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmd.Flags().StringVarP(&opts.Title, "title", "t", "", "Supply a title. Will prompt for one otherwise.")
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Supply a body. Will prompt for one otherwise.")
 	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
-	cmd.Flags().BoolVarP(&opts.EditorMode, "editor", "e", false, "Skip prompts and open the text editor to write the title and body in. The first line is the title and the rest text is the body.")
+	cmd.Flags().BoolVarP(&opts.EditorMode, "editor", "e", false, "Skip prompts and open the text editor to write the title and body in. The first line is the title and the remaining text is the body.")
 	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open the browser to create an issue")
 	cmd.Flags().StringSliceVarP(&opts.Assignees, "assignee", "a", nil, "Assign people by their `login`. Use \"@me\" to self-assign.")
 	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Add labels by `name`")

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -30,15 +30,16 @@ import (
 
 type CreateOptions struct {
 	// This struct stores user input and factory functions
-	HttpClient func() (*http.Client, error)
-	GitClient  *git.Client
-	Config     func() (gh.Config, error)
-	IO         *iostreams.IOStreams
-	Remotes    func() (ghContext.Remotes, error)
-	Branch     func() (string, error)
-	Browser    browser.Browser
-	Prompter   shared.Prompt
-	Finder     shared.PRFinder
+	HttpClient       func() (*http.Client, error)
+	GitClient        *git.Client
+	Config           func() (gh.Config, error)
+	IO               *iostreams.IOStreams
+	Remotes          func() (ghContext.Remotes, error)
+	Branch           func() (string, error)
+	Browser          browser.Browser
+	Prompter         shared.Prompt
+	Finder           shared.PRFinder
+	TitledEditSurvey func(string, string) (string, string, error)
 
 	TitleProvided bool
 	BodyProvided  bool
@@ -49,6 +50,7 @@ type CreateOptions struct {
 	Autofill    bool
 	FillVerbose bool
 	FillFirst   bool
+	EditorMode  bool
 	WebMode     bool
 	RecoverFile string
 
@@ -88,14 +90,15 @@ type CreateContext struct {
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
 	opts := &CreateOptions{
-		IO:         f.IOStreams,
-		HttpClient: f.HttpClient,
-		GitClient:  f.GitClient,
-		Config:     f.Config,
-		Remotes:    f.Remotes,
-		Branch:     f.Branch,
-		Browser:    f.Browser,
-		Prompter:   f.Prompter,
+		IO:               f.IOStreams,
+		HttpClient:       f.HttpClient,
+		GitClient:        f.GitClient,
+		Config:           f.Config,
+		Remotes:          f.Remotes,
+		Branch:           f.Branch,
+		Browser:          f.Browser,
+		Prompter:         f.Prompter,
+		TitledEditSurvey: shared.TitledEditSurvey(&shared.UserEditor{Config: f.Config, IO: f.IOStreams}),
 	}
 
 	var bodyFile string
@@ -177,6 +180,20 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("`--fill-verbose` is not supported with `--fill`")
 			}
 
+			if err := cmdutil.MutuallyExclusive(
+				"specify only one of `--editor` or `--web`",
+				opts.EditorMode,
+				opts.WebMode,
+			); err != nil {
+				return err
+			}
+
+			config, err := f.Config()
+			if err != nil {
+				return err
+			}
+			opts.EditorMode = !opts.WebMode && (opts.EditorMode || config.PreferEditorPrompt("").Value == "enabled")
+
 			opts.BodyProvided = cmd.Flags().Changed("body")
 			if bodyFile != "" {
 				b, err := cmdutil.ReadFile(bodyFile, opts.IO.In)
@@ -193,6 +210,10 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			if !opts.IO.CanPrompt() && !opts.WebMode && !(opts.FillVerbose || opts.Autofill || opts.FillFirst) && (!opts.TitleProvided || !opts.BodyProvided) {
 				return cmdutil.FlagErrorf("must provide `--title` and `--body` (or `--fill` or `fill-first` or `--fillverbose`) when not running interactively")
+			}
+
+			if opts.EditorMode && !opts.IO.CanPrompt() {
+				return errors.New("--editor or enabled prefer_editor_prompt configuration are not supported in non-tty mode")
 			}
 
 			if opts.DryRun && opts.WebMode {
@@ -213,6 +234,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	fl.StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
 	fl.StringVarP(&opts.BaseBranch, "base", "B", "", "The `branch` into which you want your code merged")
 	fl.StringVarP(&opts.HeadBranch, "head", "H", "", "The `branch` that contains commits for your pull request (default [current branch])")
+	fl.BoolVarP(&opts.EditorMode, "editor", "e", false, "Skip prompts and open the text editor to write the title and body in. The first line is the title and the rest text is the body.")
 	fl.BoolVarP(&opts.WebMode, "web", "w", false, "Open the web browser to create a pull request")
 	fl.BoolVarP(&opts.FillVerbose, "fill-verbose", "", false, "Use commits msg+body for description")
 	fl.BoolVarP(&opts.Autofill, "fill", "f", false, "Use commit info for title and body")
@@ -315,7 +337,7 @@ func createRun(opts *CreateOptions) (err error) {
 			ghrepo.FullName(ctx.BaseRepo))
 	}
 
-	if opts.FillVerbose || opts.Autofill || opts.FillFirst || (opts.TitleProvided && opts.BodyProvided) {
+	if !opts.EditorMode && (opts.FillVerbose || opts.Autofill || opts.FillFirst || (opts.TitleProvided && opts.BodyProvided)) {
 		err = handlePush(*opts, *ctx)
 		if err != nil {
 			return
@@ -330,71 +352,101 @@ func createRun(opts *CreateOptions) (err error) {
 		}
 	}
 
-	if !opts.TitleProvided {
-		err = shared.TitleSurvey(opts.Prompter, state)
-		if err != nil {
-			return
-		}
+	action := shared.SubmitAction
+	if opts.IsDraft {
+		action = shared.SubmitDraftAction
 	}
 
-	defer shared.PreserveInput(opts.IO, state, &err)()
+	tpl := shared.NewTemplateManager(client.HTTP(), ctx.BaseRepo, opts.Prompter, opts.RootDirOverride, opts.RepoOverride == "", true)
 
-	if !opts.BodyProvided {
-		templateContent := ""
-		if opts.RecoverFile == "" {
-			tpl := shared.NewTemplateManager(client.HTTP(), ctx.BaseRepo, opts.Prompter, opts.RootDirOverride, opts.RepoOverride == "", true)
+	if opts.EditorMode {
+		if opts.Template != "" {
 			var template shared.Template
+			template, err = tpl.Select(opts.Template)
+			if err != nil {
+				return
+			}
+			if state.Title == "" {
+				state.Title = template.Title()
+			}
+			state.Body = string(template.Body())
+		}
 
-			if opts.Template != "" {
-				template, err = tpl.Select(opts.Template)
-				if err != nil {
-					return
+		state.Title, state.Body, err = opts.TitledEditSurvey(state.Title, state.Body)
+		if err != nil {
+			return
+		}
+		if state.Title == "" {
+			err = fmt.Errorf("title can't be blank")
+			return
+		}
+	} else {
+
+		if !opts.TitleProvided {
+			err = shared.TitleSurvey(opts.Prompter, state)
+			if err != nil {
+				return
+			}
+		}
+
+		defer shared.PreserveInput(opts.IO, state, &err)()
+
+		if !opts.BodyProvided {
+			templateContent := ""
+			if opts.RecoverFile == "" {
+				var template shared.Template
+
+				if opts.Template != "" {
+					template, err = tpl.Select(opts.Template)
+					if err != nil {
+						return
+					}
+				} else {
+					template, err = tpl.Choose()
+					if err != nil {
+						return
+					}
 				}
-			} else {
-				template, err = tpl.Choose()
-				if err != nil {
-					return
+
+				if template != nil {
+					templateContent = string(template.Body())
 				}
 			}
 
-			if template != nil {
-				templateContent = string(template.Body())
+			err = shared.BodySurvey(opts.Prompter, state, templateContent)
+			if err != nil {
+				return
 			}
 		}
 
-		err = shared.BodySurvey(opts.Prompter, state, templateContent)
-		if err != nil {
-			return
-		}
-	}
-
-	openURL, err = generateCompareURL(*ctx, *state)
-	if err != nil {
-		return
-	}
-
-	allowPreview := !state.HasMetadata() && shared.ValidURL(openURL) && !opts.DryRun
-	allowMetadata := ctx.BaseRepo.ViewerCanTriage()
-	action, err := shared.ConfirmPRSubmission(opts.Prompter, allowPreview, allowMetadata, state.Draft)
-	if err != nil {
-		return fmt.Errorf("unable to confirm: %w", err)
-	}
-
-	if action == shared.MetadataAction {
-		fetcher := &shared.MetadataFetcher{
-			IO:        opts.IO,
-			APIClient: client,
-			Repo:      ctx.BaseRepo,
-			State:     state,
-		}
-		err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.BaseRepo, fetcher, state)
+		openURL, err = generateCompareURL(*ctx, *state)
 		if err != nil {
 			return
 		}
 
-		action, err = shared.ConfirmPRSubmission(opts.Prompter, !state.HasMetadata() && !opts.DryRun, false, state.Draft)
+		allowPreview := !state.HasMetadata() && shared.ValidURL(openURL) && !opts.DryRun
+		allowMetadata := ctx.BaseRepo.ViewerCanTriage()
+		action, err = shared.ConfirmPRSubmission(opts.Prompter, allowPreview, allowMetadata, state.Draft)
 		if err != nil {
-			return
+			return fmt.Errorf("unable to confirm: %w", err)
+		}
+
+		if action == shared.MetadataAction {
+			fetcher := &shared.MetadataFetcher{
+				IO:        opts.IO,
+				APIClient: client,
+				Repo:      ctx.BaseRepo,
+				State:     state,
+			}
+			err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.BaseRepo, fetcher, state)
+			if err != nil {
+				return
+			}
+
+			action, err = shared.ConfirmPRSubmission(opts.Prompter, !state.HasMetadata() && !opts.DryRun, false, state.Draft)
+			if err != nil {
+				return
+			}
 		}
 	}
 

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -188,11 +188,11 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return err
 			}
 
-			config, err := f.Config()
+			var err error
+			opts.EditorMode, err = shared.InitEditorMode(f, opts.EditorMode, opts.WebMode, opts.IO.CanPrompt())
 			if err != nil {
 				return err
 			}
-			opts.EditorMode = !opts.WebMode && (opts.EditorMode || config.PreferEditorPrompt("").Value == "enabled")
 
 			opts.BodyProvided = cmd.Flags().Changed("body")
 			if bodyFile != "" {
@@ -210,10 +210,6 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			if !opts.IO.CanPrompt() && !opts.WebMode && !(opts.FillVerbose || opts.Autofill || opts.FillFirst) && (!opts.TitleProvided || !opts.BodyProvided) {
 				return cmdutil.FlagErrorf("must provide `--title` and `--body` (or `--fill` or `fill-first` or `--fillverbose`) when not running interactively")
-			}
-
-			if opts.EditorMode && !opts.IO.CanPrompt() {
-				return errors.New("--editor or enabled prefer_editor_prompt configuration are not supported in non-tty mode")
 			}
 
 			if opts.DryRun && opts.WebMode {

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -230,7 +230,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	fl.StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
 	fl.StringVarP(&opts.BaseBranch, "base", "B", "", "The `branch` into which you want your code merged")
 	fl.StringVarP(&opts.HeadBranch, "head", "H", "", "The `branch` that contains commits for your pull request (default [current branch])")
-	fl.BoolVarP(&opts.EditorMode, "editor", "e", false, "Skip prompts and open the text editor to write the title and body in. The first line is the title and the rest text is the body.")
+	fl.BoolVarP(&opts.EditorMode, "editor", "e", false, "Skip prompts and open the text editor to write the title and body in. The first line is the title and the remaining text is the body.")
 	fl.BoolVarP(&opts.WebMode, "web", "w", false, "Open the web browser to create a pull request")
 	fl.BoolVarP(&opts.FillVerbose, "fill-verbose", "", false, "Use commits msg+body for description")
 	fl.BoolVarP(&opts.Autofill, "fill", "f", false, "Use commit info for title and body")


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #9310 

There are 2 prompts during `pr create`. 
1. When commits are not fully pushed to remote, a prompt asks where to push. In editor mode, this prompt still appears because users can skip it by using the `--head` flag.
2. After filling in the title and body, there's usually a prompt asking "What's next?" In editor mode, this prompt is skipped. If `--draft` is specified, a draft pull request is submitted; otherwise, a regular pull request is submitted.
