### PR TITLE
Add Acceptance Criteria requirement to triage.md for accepted issues

### DIFF
--- a/docs/triage.md
+++ b/docs/triage.md
@@ -8,6 +8,8 @@ triage role. The initial expectation is that the person in the role for the week
 
 Review and label [open issues missing either the `enhancement`, `bug`, or `docs` label](https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+-label%3Abug%2Cenhancement%2Cdocs+).
 
+Any issue that is accepted to be done as either an `enhancement`, `bug`, or `docs` requires explicit Acceptance Criteria in a comment on the issue before it is triaged.
+
 To be considered triaged, `enhancement` issues require at least one of the following additional labels:
 
 - `core`: reserved for the core CLI team

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -8,7 +8,7 @@ triage role. The initial expectation is that the person in the role for the week
 
 Review and label [open issues missing either the `enhancement`, `bug`, or `docs` label](https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+-label%3Abug%2Cenhancement%2Cdocs+).
 
-Any issue that is accepted to be done as either an `enhancement`, `bug`, or `docs` requires explicit Acceptance Criteria in a comment on the issue before it is triaged.
+Any issue that is accepted to be done as either an `enhancement`, `bug`, or `docs` requires explicit Acceptance Criteria in a comment on the issue before `needs-triage` label is removed.
 
 To be considered triaged, `enhancement` issues require at least one of the following additional labels:
 


### PR DESCRIPTION
To better facilitate community collaboration and to help reduce the amount of information any collaborator needs to peruse in a given issue, clear Acceptance Criteria on accepted issues should be included. This will reduce the amount of back and forth on PRs submitted by ensuring expectations for a given issue are clear.

I'll note that this was something that was apparent to me after [reviewing](https://github.com/cli/cli/pull/9431#issuecomment-2274006771) #9431. I updated the linked issue, #9398 with the AC to better support the collaborator.
