### PR TITLE
cmd/pr/checks: Describe bucket and state JSON fields

### DIFF
--- a/pkg/cmd/pr/checks/checks.go
+++ b/pkg/cmd/pr/checks/checks.go
@@ -61,15 +61,18 @@ func NewCmdChecks(f *cmdutil.Factory, runF func(*ChecksOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "checks [<number> | <url> | <branch>]",
 		Short: "Show CI status for a single pull request",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Show CI status for a single pull request.
 
 			Without an argument, the pull request that belongs to the current branch
 			is selected.
 
+			When the %[1]s--json%[1]s flag is used, it includes a %[1]sbucket%[1]s field, which categorizes
+			the %[1]sstate%[1]s field into %[1]spass%[1]s, %[1]sfail%[1]s, %[1]spending%[1]s, %[1]sskipping%[1]s, or %[1]scancel%[1]s.
+
 			Additional exit codes:
 				8: Checks pending
-		`),
+		`, "`"),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Finder = shared.NewFinder(f)


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Resolves https://github.com/cli/cli/issues/9205

This PR introduces a small help text command for PR checks where the `bucket` and `state` JSON fields are described. The original issue was only for the addition of `bucket` to the help text, but I feel that `state` needs to be described to differentiate between the two.

I am open to updating the help text to be a bit more descriptive, if needed. Right now I haven't described all the states either, because there are just way too many:

https://github.com/cli/cli/blob/dbcac5abc4ae8c20008ee25288f30a3aae0e0369/pkg/cmd/pr/checks/aggregate.go#L73-L87