### PR TITLE
Update `--project <number>` flags in `gh search` to `owner/number`

### DIFF
--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -157,7 +157,7 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 	cmd.Flags().BoolVar(&noLabel, "no-label", false, "Filter on missing label")
 	cmd.Flags().BoolVar(&noMilestone, "no-milestone", false, "Filter on missing milestone")
 	cmd.Flags().BoolVar(&noProject, "no-project", false, "Filter on missing project")
-	cmd.Flags().StringVar(&opts.Query.Qualifiers.Project, "project", "", "Filter on project board `number`")
+	cmd.Flags().StringVar(&opts.Query.Qualifiers.Project, "project", "", "Filter on project board `owner/number`")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Reactions, "reactions", "", "Filter on `number` of reactions")
 	cmd.Flags().StringSliceVarP(&opts.Query.Qualifiers.Repo, "repo", "R", nil, "Filter on repository")
 	cmdutil.StringEnumFlag(cmd, &opts.Query.Qualifiers.State, "state", "", "", []string{"open", "closed"}, "Filter based on state")

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -168,7 +168,7 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 	cmd.Flags().BoolVar(&noLabel, "no-label", false, "Filter on missing label")
 	cmd.Flags().BoolVar(&noMilestone, "no-milestone", false, "Filter on missing milestone")
 	cmd.Flags().BoolVar(&noProject, "no-project", false, "Filter on missing project")
-	cmd.Flags().StringVar(&opts.Query.Qualifiers.Project, "project", "", "Filter on project board `number`")
+	cmd.Flags().StringVar(&opts.Query.Qualifiers.Project, "project", "", "Filter on project board `owner/number`")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Reactions, "reactions", "", "Filter on `number` of reactions")
 	cmd.Flags().StringSliceVarP(&opts.Query.Qualifiers.Repo, "repo", "R", nil, "Filter on repository")
 	cmdutil.StringEnumFlag(cmd, &opts.Query.Qualifiers.State, "state", "", "", []string{"open", "closed"}, "Filter based on state")


### PR DESCRIPTION
Fixes github/cli#452

### Changes

- **Update `gh search prs --project` flag doc to specify `owner/number` syntax**
- **Update `gh search issues --project` flag doc to specify `owner/number` syntax**

**Docs lines**
![Screenshot 2024-08-12 at 2 46 00 PM](https://github.com/user-attachments/assets/513c7ca3-4b64-4267-bf08-8204a262c919)

**Execution**
![Screenshot 2024-08-12 at 2 39 25 PM](https://github.com/user-attachments/assets/102365da-59a2-4357-8467-3bfc1463d829)

### Notes

The api provides an error if the syntax is incorrect (see above screenshot). That, combined with the documentation, should be enough for folks to troubleshoot any issues with these queries, so I don't think there's any need to add validation to the input for the `--project` flag.

Also, I added a test to each test file covering the `--project` flag and nothing failed, which makes me confident that there are no further updates required besides the docs. I subsequently removed the tests, as they weren't providing any value.