### PR TITLE
First pass with repo feature detection

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -39,7 +39,7 @@ type Issue struct {
 	Author           Author
 	Assignees        Assignees
 	Labels           Labels
-	ProjectCards     ProjectCards
+	ProjectCards     ProjectCards // TODO: This needs to be refactored because include/skip directives won't suffice for fields like this
 	ProjectItems     ProjectItems
 	Milestone        *Milestone
 	ReactionGroups   ReactionGroups

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -84,7 +84,7 @@ type PullRequest struct {
 
 	Assignees      Assignees
 	Labels         Labels
-	ProjectCards   ProjectCards
+	ProjectCards   ProjectCards // TODO: This needs to be refactored as unable to use skip/include directives when no longer available
 	ProjectItems   ProjectItems
 	Milestone      *Milestone
 	Comments       Comments

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -291,7 +291,7 @@ func Test_ProjectNamesToPaths(t *testing.T) {
 		} } } }
 		`))
 
-	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap", "TriageV2", "RoadmapV2", "MonalisaV2"})
+	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap", "TriageV2", "RoadmapV2", "MonalisaV2"}, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -351,7 +351,7 @@ t001: team(slug:"robots"){id,slug}
 			}
 		}))
 
-	result, err := RepoResolveMetadataIDs(client, repo, input)
+	result, err := RepoResolveMetadataIDs(client, repo, input, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/featuredetection/detector_mock.go
+++ b/internal/featuredetection/detector_mock.go
@@ -25,5 +25,10 @@ func (md *EnabledDetectorMock) PullRequestFeatures() (PullRequestFeatures, error
 }
 
 func (md *EnabledDetectorMock) RepositoryFeatures() (RepositoryFeatures, error) {
-	return allRepositoryFeatures, nil
+	return RepositoryFeatures{
+		PullRequestTemplateQuery: true,
+		VisibilityField:          true,
+		AutoMerge:                true,
+		ProjectsV1:               true,
+	}, nil
 }

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -41,12 +41,7 @@ type RepositoryFeatures struct {
 	PullRequestTemplateQuery bool
 	VisibilityField          bool
 	AutoMerge                bool
-}
-
-var allRepositoryFeatures = RepositoryFeatures{
-	PullRequestTemplateQuery: true,
-	VisibilityField:          true,
-	AutoMerge:                true,
+	ProjectsV1               bool
 }
 
 type detector struct {
@@ -163,10 +158,6 @@ func (d *detector) PullRequestFeatures() (PullRequestFeatures, error) {
 }
 
 func (d *detector) RepositoryFeatures() (RepositoryFeatures, error) {
-	if !ghinstance.IsEnterprise(d.host) {
-		return allRepositoryFeatures, nil
-	}
-
 	features := RepositoryFeatures{}
 
 	var featureDetection struct {
@@ -193,6 +184,10 @@ func (d *detector) RepositoryFeatures() (RepositoryFeatures, error) {
 		}
 		if field.Name == "autoMergeAllowed" {
 			features.AutoMerge = true
+		}
+		// v2 memex projects are accessed through `projectsV2` field and currently supported in all GitHub distributions
+		if field.Name == "projects" {
+			features.ProjectsV1 = true
 		}
 	}
 

--- a/internal/featuredetection/feature_detection_test.go
+++ b/internal/featuredetection/feature_detection_test.go
@@ -262,12 +262,43 @@ func TestRepositoryFeatures(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name:     "github.com",
+			name:     "github.com has v1 classic projects query",
 			hostname: "github.com",
+			queryResponse: map[string]string{
+				`query Repository_fields\b`: heredoc.Doc(`
+					{ "data": { "Repository": { "fields": [
+						{"name": "projects"},
+						{"name": "pullRequestTemplates"},
+						{"name": "visibility"},
+						{"name": "autoMergeAllowed"}
+					] } } }
+				`),
+			},
 			wantFeatures: RepositoryFeatures{
 				PullRequestTemplateQuery: true,
 				VisibilityField:          true,
 				AutoMerge:                true,
+				ProjectsV1:               true,
+			},
+			wantErr: false,
+		},
+		{
+			name:     "github.com without v1 classic projects",
+			hostname: "github.com",
+			queryResponse: map[string]string{
+				`query Repository_fields\b`: heredoc.Doc(`
+					{ "data": { "Repository": { "fields": [
+						{"name": "pullRequestTemplates"},
+						{"name": "visibility"},
+						{"name": "autoMergeAllowed"}
+					] } } }
+				`),
+			},
+			wantFeatures: RepositoryFeatures{
+				PullRequestTemplateQuery: true,
+				VisibilityField:          true,
+				AutoMerge:                true,
+				ProjectsV1:               false,
 			},
 			wantErr: false,
 		},

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
 	shared "github.com/cli/cli/v2/pkg/cmd/issue/shared"
@@ -22,11 +24,12 @@ type EditOptions struct {
 	IO         *iostreams.IOStreams
 	BaseRepo   func() (ghrepo.Interface, error)
 	Prompter   prShared.EditPrompter
+	Detector   fd.Detector
 
 	DetermineEditor    func() (string, error)
 	FieldsToEditSurvey func(prShared.EditPrompter, *prShared.Editable) error
 	EditFieldsSurvey   func(prShared.EditPrompter, *prShared.Editable, string) error
-	FetchOptions       func(*api.Client, ghrepo.Interface, *prShared.Editable) error
+	FetchOptions       func(*api.Client, ghrepo.Interface, *prShared.Editable, bool) error
 
 	SelectorArgs []string
 	Interactive  bool
@@ -167,6 +170,21 @@ func editRun(opts *EditOptions) error {
 		return err
 	}
 
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	if opts.Detector == nil {
+		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
+		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
+	}
+
+	repoFeatures, err := opts.Detector.RepositoryFeatures()
+	if err != nil {
+		return err
+	}
+
 	// Prompt the user which fields they'd like to edit.
 	editable := opts.Editable
 	if opts.Interactive {
@@ -200,7 +218,7 @@ func editRun(opts *EditOptions) error {
 	// Fetch editable shared fields once for all issues.
 	apiClient := api.NewClientFromHTTP(httpClient)
 	opts.IO.StartProgressIndicatorWithLabel("Fetching repository information")
-	err = opts.FetchOptions(apiClient, repo, &editable)
+	err = opts.FetchOptions(apiClient, repo, &editable, repoFeatures.ProjectsV1)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -345,6 +346,7 @@ func Test_editRun(t *testing.T) {
 					},
 				},
 				FetchOptions: prShared.FetchOptions,
+				Detector:     &fd.EnabledDetectorMock{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockIssueGet(t, reg)
@@ -385,6 +387,7 @@ func Test_editRun(t *testing.T) {
 					},
 				},
 				FetchOptions: prShared.FetchOptions,
+				Detector:     &fd.EnabledDetectorMock{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				// Should only be one fetch of metadata.
@@ -435,6 +438,7 @@ func Test_editRun(t *testing.T) {
 					},
 				},
 				FetchOptions: prShared.FetchOptions,
+				Detector:     &fd.EnabledDetectorMock{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockIssueNumberGet(t, reg, 123)
@@ -468,6 +472,7 @@ func Test_editRun(t *testing.T) {
 					},
 				},
 				FetchOptions: prShared.FetchOptions,
+				Detector:     &fd.EnabledDetectorMock{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				// Should only be one fetch of metadata.
@@ -548,6 +553,7 @@ func Test_editRun(t *testing.T) {
 				},
 				FetchOptions:    prShared.FetchOptions,
 				DetermineEditor: func() (string, error) { return "vim", nil },
+				Detector:        &fd.EnabledDetectorMock{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockIssueGet(t, reg)

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/config"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
@@ -1434,6 +1435,7 @@ func Test_createRun(t *testing.T) {
 				GhPath:  "some/path/gh",
 				GitPath: "some/path/git",
 			}
+			opts.Detector = &fd.EnabledDetectorMock{}
 			cleanSetup := func() {}
 			if tt.setup != nil {
 				cleanSetup = tt.setup(&opts, t)

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -3,9 +3,11 @@ package edit
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	shared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
@@ -25,6 +27,7 @@ type EditOptions struct {
 	Fetcher         EditableOptionsFetcher
 	EditorRetriever EditorRetriever
 	Prompter        shared.EditPrompter
+	Detector        fd.Detector
 
 	SelectorArg string
 	Interactive bool
@@ -230,8 +233,18 @@ func editRun(opts *EditOptions) error {
 	}
 	apiClient := api.NewClientFromHTTP(httpClient)
 
+	if opts.Detector == nil {
+		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
+		opts.Detector = fd.NewDetector(cachedClient, repo.RepoHost())
+	}
+
+	repoFeatures, err := opts.Detector.RepositoryFeatures()
+	if err != nil {
+		return err
+	}
+
 	opts.IO.StartProgressIndicator()
-	err = opts.Fetcher.EditableOptionsFetch(apiClient, repo, &editable)
+	err = opts.Fetcher.EditableOptionsFetch(apiClient, repo, &editable, repoFeatures.ProjectsV1)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
@@ -311,13 +324,13 @@ func (s surveyor) EditFields(editable *shared.Editable, editorCmd string) error 
 }
 
 type EditableOptionsFetcher interface {
-	EditableOptionsFetch(*api.Client, ghrepo.Interface, *shared.Editable) error
+	EditableOptionsFetch(*api.Client, ghrepo.Interface, *shared.Editable, bool) error
 }
 
 type fetcher struct{}
 
-func (f fetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable) error {
-	return shared.FetchOptions(client, repo, opts)
+func (f fetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable, includeProjects bool) error {
+	return shared.FetchOptions(client, repo, opts, includeProjects)
 }
 
 type EditorRetriever interface {

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	shared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -37,13 +38,16 @@ func TestNewCmdEdit(t *testing.T) {
 			output: EditOptions{
 				SelectorArg: "",
 				Interactive: true,
+				Detector:    &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
 		{
-			name:     "two arguments",
-			input:    "1 2",
-			output:   EditOptions{},
+			name:  "two arguments",
+			input: "1 2",
+			output: EditOptions{
+				Detector: &fd.EnabledDetectorMock{},
+			},
 			wantsErr: true,
 		},
 		{
@@ -52,6 +56,7 @@ func TestNewCmdEdit(t *testing.T) {
 			output: EditOptions{
 				SelectorArg: "23",
 				Interactive: true,
+				Detector:    &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -66,6 +71,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -80,6 +86,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -95,6 +102,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -109,6 +117,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -128,6 +137,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -142,6 +152,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -156,6 +167,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -170,6 +182,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -184,6 +197,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -198,6 +212,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -212,6 +227,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -228,6 +244,7 @@ func TestNewCmdEdit(t *testing.T) {
 						},
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -244,6 +261,7 @@ func TestNewCmdEdit(t *testing.T) {
 						},
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -258,6 +276,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -272,6 +291,7 @@ func TestNewCmdEdit(t *testing.T) {
 						Edited: true,
 					},
 				},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			wantsErr: false,
 		},
@@ -381,7 +401,8 @@ func Test_editRun(t *testing.T) {
 						Edited: true,
 					},
 				},
-				Fetcher: testFetcher{},
+				Fetcher:  testFetcher{},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				mockRepoMetadata(reg, false)
@@ -435,7 +456,8 @@ func Test_editRun(t *testing.T) {
 						Edited: true,
 					},
 				},
-				Fetcher: testFetcher{},
+				Fetcher:  testFetcher{},
+				Detector: &fd.EnabledDetectorMock{},
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				mockRepoMetadata(reg, true)
@@ -456,6 +478,7 @@ func Test_editRun(t *testing.T) {
 				Surveyor:        testSurveyor{},
 				Fetcher:         testFetcher{},
 				EditorRetriever: testEditorRetriever{},
+				Detector:        &fd.EnabledDetectorMock{},
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				mockRepoMetadata(reg, false)
@@ -477,6 +500,7 @@ func Test_editRun(t *testing.T) {
 				Surveyor:        testSurveyor{skipReviewers: true},
 				Fetcher:         testFetcher{},
 				EditorRetriever: testEditorRetriever{},
+				Detector:        &fd.EnabledDetectorMock{},
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				mockRepoMetadata(reg, true)
@@ -661,8 +685,8 @@ type testSurveyor struct {
 }
 type testEditorRetriever struct{}
 
-func (f testFetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable) error {
-	return shared.FetchOptions(client, repo, opts)
+func (f testFetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable, includeProjectsV1 bool) error {
+	return shared.FetchOptions(client, repo, opts, includeProjectsV1)
 }
 
 func (s testSurveyor) FieldsToEdit(e *shared.Editable) error {

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -376,12 +376,12 @@ func FieldsToEditSurvey(p EditPrompter, editable *Editable) error {
 	return nil
 }
 
-func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable) error {
+func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable, includeProjects bool) error {
 	input := api.RepoMetadataInput{
 		Reviewers:  editable.Reviewers.Edited,
 		Assignees:  editable.Assignees.Edited,
 		Labels:     editable.Labels.Edited,
-		Projects:   editable.Projects.Edited,
+		Projects:   editable.Projects.Edited && includeProjects, // TODO: This is a bit of a smell
 		Milestones: editable.Milestone.Edited,
 	}
 	metadata, err := api.RepoMetadata(client, repo, input)

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/shlex"
 )
 
-func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, baseURL string, state IssueMetadataState) (string, error) {
+func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, baseURL string, state IssueMetadataState, includeProjectsV1 bool) (string, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return "", err
@@ -31,7 +31,7 @@ func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, ba
 		q.Set("labels", strings.Join(state.Labels, ","))
 	}
 	if len(state.Projects) > 0 {
-		projectPaths, err := api.ProjectNamesToPaths(client, baseRepo, state.Projects)
+		projectPaths, err := api.ProjectNamesToPaths(client, baseRepo, state.Projects, includeProjectsV1)
 		if err != nil {
 			return "", fmt.Errorf("could not add to project: %w", err)
 		}
@@ -51,7 +51,7 @@ func ValidURL(urlStr string) bool {
 
 // Ensure that tb.MetadataResult object exists and contains enough pre-fetched API data to be able
 // to resolve all object listed in tb to GraphQL IDs.
-func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetadataState) error {
+func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetadataState, includeProjectsV1 bool) error {
 	resolveInput := api.RepoResolveInput{}
 
 	if len(tb.Assignees) > 0 && (tb.MetadataResult == nil || len(tb.MetadataResult.AssignableUsers) == 0) {
@@ -74,7 +74,7 @@ func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetada
 		resolveInput.Milestones = tb.Milestones
 	}
 
-	metadataResult, err := api.RepoResolveMetadataIDs(client, baseRepo, resolveInput)
+	metadataResult, err := api.RepoResolveMetadataIDs(client, baseRepo, resolveInput, includeProjectsV1)
 	if err != nil {
 		return err
 	}
@@ -88,12 +88,12 @@ func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetada
 	return nil
 }
 
-func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, params map[string]interface{}, tb *IssueMetadataState) error {
+func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, params map[string]interface{}, tb *IssueMetadataState, includeProjectsV1 bool) error {
 	if !tb.HasMetadata() {
 		return nil
 	}
 
-	if err := fillMetadata(client, baseRepo, tb); err != nil {
+	if err := fillMetadata(client, baseRepo, tb, includeProjectsV1); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -265,7 +265,7 @@ func Test_WithPrAndIssueQueryParams(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := WithPrAndIssueQueryParams(nil, nil, tt.args.baseURL, tt.args.state)
+			got, err := WithPrAndIssueQueryParams(nil, nil, tt.args.baseURL, tt.args.state, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("WithPrAndIssueQueryParams() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -173,7 +173,7 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 		Reviewers:  isChosen("Reviewers"),
 		Assignees:  isChosen("Assignees"),
 		Labels:     isChosen("Labels"),
-		Projects:   isChosen("Projects"),
+		Projects:   isChosen("Projects"), // TODO: This doesn't account for repo features, leaky abstraction
 		Milestones: isChosen("Milestone"),
 	}
 	metadataResult, err := fetcher.RepoMetadataFetch(metadataInput)

--- a/pkg/cmd/pr/shared/templates.go
+++ b/pkg/cmd/pr/shared/templates.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/git"
@@ -141,8 +140,7 @@ type templateManager struct {
 	fetchError error
 }
 
-func NewTemplateManager(httpClient *http.Client, repo ghrepo.Interface, p iprompter, dir string, allowFS bool, isPR bool) *templateManager {
-	cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
+func NewTemplateManager(httpClient *http.Client, repo ghrepo.Interface, p iprompter, dir string, allowFS bool, isPR bool, detector fd.Detector) *templateManager {
 	return &templateManager{
 		repo:       repo,
 		rootDir:    dir,
@@ -150,7 +148,7 @@ func NewTemplateManager(httpClient *http.Client, repo ghrepo.Interface, p ipromp
 		isPR:       isPR,
 		httpClient: httpClient,
 		prompter:   p,
-		detector:   fd.NewDetector(cachedClient, repo.RepoHost()),
+		detector:   detector,
 	}
 }
 

--- a/pkg/cmd/repo/edit/edit_test.go
+++ b/pkg/cmd/repo/edit/edit_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -199,6 +200,7 @@ func Test_editRun_interactive(t *testing.T) {
 			opts: EditOptions{
 				Repository:      ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				InteractiveMode: true,
+				Detector:        &fd.EnabledDetectorMock{},
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				el := append(editList, optionAllowForking)
@@ -246,6 +248,7 @@ func Test_editRun_interactive(t *testing.T) {
 			opts: EditOptions{
 				Repository:      ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				InteractiveMode: true,
+				Detector:        &fd.EnabledDetectorMock{},
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterMultiSelect("What do you want to edit?", nil, editList,
@@ -321,6 +324,7 @@ func Test_editRun_interactive(t *testing.T) {
 			opts: EditOptions{
 				Repository:      ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				InteractiveMode: true,
+				Detector:        &fd.EnabledDetectorMock{},
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterMultiSelect("What do you want to edit?", nil, editList,
@@ -367,6 +371,7 @@ func Test_editRun_interactive(t *testing.T) {
 			opts: EditOptions{
 				Repository:      ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				InteractiveMode: true,
+				Detector:        &fd.EnabledDetectorMock{},
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterMultiSelect("What do you want to edit?", nil, editList,
@@ -426,6 +431,7 @@ func Test_editRun_interactive(t *testing.T) {
 			opts: EditOptions{
 				Repository:      ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				InteractiveMode: true,
+				Detector:        &fd.EnabledDetectorMock{},
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterMultiSelect("What do you want to edit?", nil, editList,

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -333,7 +333,8 @@ func TestRepoList_nontty(t *testing.T) {
 			t, _ := time.Parse(time.RFC822, "19 Feb 21 15:00 UTC")
 			return t
 		},
-		Limit: 30,
+		Limit:    30,
+		Detector: &fd.EnabledDetectorMock{},
 	}
 
 	err := listRun(&opts)
@@ -374,7 +375,8 @@ func TestRepoList_tty(t *testing.T) {
 			t, _ := time.Parse(time.RFC822, "19 Feb 21 15:00 UTC")
 			return t
 		},
-		Limit: 30,
+		Limit:    30,
+		Detector: &fd.EnabledDetectorMock{},
 	}
 
 	err := listRun(&opts)
@@ -403,6 +405,16 @@ func TestRepoList_filtering(t *testing.T) {
 			assert.Equal(t, "PRIVATE", params["privacy"])
 			assert.Equal(t, float64(2), params["perPage"])
 		}),
+	)
+
+	http.Register(
+		httpmock.GraphQL(`query Repository_fields\b`),
+		httpmock.StringResponse(`{ "data": { "Repository": { "fields": [
+			{ "name": "autoMergeAllowed" },
+			{ "name": "projects" },
+			{ "name": "pullRequestTemplates" },
+			{ "name": "visibility" }
+		] } } }`),
 	)
 
 	output, err := runCommand(http, true, `--visibility=private --limit 2 `)


### PR DESCRIPTION
relates https://github.com/github/cli/issues/453
relates https://github.com/cli/cli/issues/9430

This commit is the first pass of having various commands to look at repo features to determine if v1 projects are available or not.

This doesn't delve into creating new tests as there are questions if this is the right approach or not as well as dealing with shurcool graphql query challenges that require refactoring.

### 🗒️ How you can help?

1. Is adding this new feature detection logic to repo features the right approach versus checking for v1 projects in issue, PR, and repo detection?

   There are some code paths that have feature detection logic for either issue or PR features, so putting this in repo detection requires a new type of detector to be used. 🤷 

2. Whether the feature detection variables should be moved into existing fields?

   There are some functions where I take a dirty approach of adding a new variable just to see what broke.  In some of these cases, there are other variables that might prove easier ways to shim in the new feature detection logic.

3. How to deal with shurcool `ProjectCards` logic refactoring?

   The `Issue` and `PullRequest` structs used for querying GraphQL have `ProjectCards` fields.  When these fields are dropped from the GraphQL schema, they will break requests, however there isn't a way to tell GraphQL client or server to silently ignore them.

### Thoughts and discoveries

1. **Changes to command behavior should be avoided as GHES 3.14 and older can use both v1 and v2 projects**

   We strive to ensure the GitHub CLI behavior is backward compatible as long as a capability is available aside from enhancements and bug fixes.  As such, I wanted to make as minimal changes to the code base to handle the sunset, avoiding significant refactoring of code where possible.

   The one area this is proving to be a challenge is `Issue` and `PullRequest` structs as their `ProjectCards` field is used to generate GraphQL queries and store the results to be used in code.  When the v1 project fields are removed, this will cause any GitHub.com usage to break because these fields are no longer in GraphQL schema.  **Note: the initial PR has not refactored this aspect, erring on the side of getting feedback before proceeding aside from leaving a comment to discuss.**

1. **Sunsetting v1 projects is no different than there being no v1 projects available**

   This prototype is designed to control whether v1 projects are retrieved for various commands; save that aforementioned note about `Issue` and `PullRequest`.

   Because these commands work with v1 and v2 projects, there is already an order of precedence such that v1 projects are checked before proceeding onto v2 projects.

1. **For GHES and GHEC users, the API calls needed to detect whether v1 projects availability should be cached to avoid excessive rate limit usage**

   This is already a trend in feature detection code instrumentation, but the additional queries to detect features need to be cached to minimize the impact to rate limits.  This works by taking the REST or GraphQL calls made and caching the results for 24 hours, assuming such information changes infrequently.