### PR TITLE
Update Go and other extension workflow templates to reflect recent enhancements to `cli/gh-extension-precompile`

### DIFF
--- a/pkg/cmd/extension/ext_tmpls/goBinWorkflow.yml
+++ b/pkg/cmd/extension/ext_tmpls/goBinWorkflow.yml
@@ -10,5 +10,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cli/gh-extension-precompile@v1
+        with:
+          generate_attestations: true
+          go_version_file: go.mod

--- a/pkg/cmd/extension/ext_tmpls/goBinWorkflow.yml
+++ b/pkg/cmd/extension/ext_tmpls/goBinWorkflow.yml
@@ -5,6 +5,8 @@ on:
       - "v*"
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:

--- a/pkg/cmd/extension/ext_tmpls/otherBinWorkflow.yml
+++ b/pkg/cmd/extension/ext_tmpls/otherBinWorkflow.yml
@@ -10,7 +10,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cli/gh-extension-precompile@v1
         with:
           build_script_override: "script/build.sh"
+          generate_attestations: true

--- a/pkg/cmd/extension/ext_tmpls/otherBinWorkflow.yml
+++ b/pkg/cmd/extension/ext_tmpls/otherBinWorkflow.yml
@@ -14,4 +14,3 @@ jobs:
       - uses: cli/gh-extension-precompile@v1
         with:
           build_script_override: "script/build.sh"
-          generate_attestations: true


### PR DESCRIPTION
Fixes #9394 