### PR TITLE
Remove `Internal` from `gh repo create` prompt when owner is not an org

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -855,17 +855,22 @@ func interactiveRepoInfo(client *http.Client, hostname string, prompter iprompte
 		return "", "", "", err
 	}
 
-	visibilityOptions := []string{"Public", "Private"}
-	// orgs can also create internal repos
-	if owner != "" {
-		visibilityOptions = append(visibilityOptions, "Internal")
-	}
+	visibilityOptions := getRepoVisibilityOptions(owner)
 	selected, err := prompter.Select("Visibility", "Public", visibilityOptions)
 	if err != nil {
 		return "", "", "", err
 	}
 
 	return name, description, strings.ToUpper(visibilityOptions[selected]), nil
+}
+
+func getRepoVisibilityOptions(owner string) []string {
+	visibilityOptions := []string{"Public", "Private"}
+	// orgs can also create internal repos
+	if owner != "" {
+		visibilityOptions = append(visibilityOptions, "Internal")
+	}
+	return visibilityOptions
 }
 
 func interactiveRepoNameAndOwner(client *http.Client, hostname string, prompter iprompter, defaultName string) (string, string, error) {

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -855,7 +855,11 @@ func interactiveRepoInfo(client *http.Client, hostname string, prompter iprompte
 		return "", "", "", err
 	}
 
-	visibilityOptions := []string{"Public", "Private", "Internal"}
+	visibilityOptions := []string{"Public", "Private"}
+	// orgs can also create internal repos
+	if owner != "" {
+		visibilityOptions = append(visibilityOptions, "Internal")
+	}
 	selected, err := prompter.Select("Visibility", "Public", visibilityOptions)
 	if err != nil {
 		return "", "", "", err

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -866,3 +866,27 @@ func Test_createRun(t *testing.T) {
 		})
 	}
 }
+
+func Test_getRepoVisibilityOptions(t *testing.T) {
+	tests := []struct {
+		name  string
+		owner string
+		want  []string
+	}{
+		{
+			name:  "user repo",
+			owner: "",
+			want:  []string{"Public", "Private"},
+		},
+		{
+			name:  "org repo",
+			owner: "fooOrg",
+			want:  []string{"Public", "Private", "Internal"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, getRepoVisibilityOptions(tt.owner))
+		})
+	}
+}

--- a/pkg/cmd/repo/create/http.go
+++ b/pkg/cmd/repo/create/http.go
@@ -99,6 +99,11 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput) (*a
 		isOrg = owner.IsOrganization()
 	}
 
+	isInternal := strings.ToLower(input.Visibility) == "internal"
+	if isInternal && !isOrg {
+		return nil, fmt.Errorf("internal repositories can only be created within an organization")
+	}
+
 	if input.TemplateRepositoryID != "" {
 		var response struct {
 			CloneTemplateRepository struct {

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -728,13 +728,9 @@ func Test_repoCreate(t *testing.T) {
 				r.Register(
 					httpmock.REST("GET", "users/OWNER"),
 					httpmock.StringResponse(`{ "node_id": "1234", "type": "Not-Org" }`))
-				r.Register(
+				r.Exclude(
+					t,
 					httpmock.REST("POST", "user/repos"),
-					httpmock.RESTPayload(201, `{
-						"name":"winter-foods", 
-						"owner":{"login": "OWNER"}, 
-						"html_url":"the://URL"
-					}`, func(payload map[string]interface{}) {}),
 				)
 			},
 		},

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -696,19 +696,9 @@ func Test_repoCreate(t *testing.T) {
 				r.Register(
 					httpmock.REST("GET", "users/OWNER"),
 					httpmock.StringResponse(`{ "node_id": "1234", "type": "Not-Org" }`))
-				r.Register(
+				r.Exclude(
+					t,
 					httpmock.GraphQL(`mutation RepositoryCreate\b`),
-					httpmock.GraphQLMutation(
-						`{
-							"errors": [
-								{
-									"message": "Only organization-owned repositories can have internal visibility",
-								}
-							],
-							"data": null
-							}
-						}`,
-						func(map[string]interface{}) {}),
 				)
 			},
 		},

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -16,6 +16,7 @@ func Test_repoCreate(t *testing.T) {
 		input    repoCreateInput
 		stubs    func(t *testing.T, r *httpmock.Registry)
 		wantErr  bool
+		errMsg   string
 		wantRepo string
 	}{
 		{
@@ -692,6 +693,7 @@ func Test_repoCreate(t *testing.T) {
 				OwnerLogin:  "OWNER",
 			},
 			wantErr: true,
+			errMsg:  "internal repositories can only be created within an organization",
 			stubs: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.REST("GET", "users/OWNER"),
@@ -714,6 +716,7 @@ func Test_repoCreate(t *testing.T) {
 				InitReadme:  true,
 			},
 			wantErr: true,
+			errMsg:  "internal repositories can only be created within an organization",
 			stubs: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.REST("GET", "users/OWNER"),
@@ -734,6 +737,9 @@ func Test_repoCreate(t *testing.T) {
 			r, err := repoCreate(httpClient, tt.hostname, tt.input)
 			if tt.wantErr {
 				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.ErrorContains(t, err, tt.errMsg)
+				}
 				return
 			} else {
 				assert.NoError(t, err)

--- a/pkg/httpmock/registry.go
+++ b/pkg/httpmock/registry.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Replace http.Client transport layer with registry so all requests get
@@ -25,6 +28,18 @@ func (r *Registry) Register(m Matcher, resp Responder) {
 	})
 }
 
+func (r *Registry) Exclude(t *testing.T, m Matcher) {
+	excludedStub := &Stub{
+		Matcher: m,
+		Responder: func(req *http.Request) (*http.Response, error) {
+			assert.FailNowf(t, "Exclude error", "API called when excluded: %v", req.URL)
+			return nil, nil
+		},
+		exclude: true,
+	}
+	r.stubs = append(r.stubs, excludedStub)
+}
+
 type Testing interface {
 	Errorf(string, ...interface{})
 	Helper()
@@ -33,7 +48,7 @@ type Testing interface {
 func (r *Registry) Verify(t Testing) {
 	n := 0
 	for _, s := range r.stubs {
-		if !s.matched {
+		if !s.matched && !s.exclude {
 			n++
 		}
 	}
@@ -62,6 +77,7 @@ func (r *Registry) RoundTrip(req *http.Request) (*http.Response, error) {
 		stub = s
 		break // TODO: remove
 	}
+
 	if stub != nil {
 		stub.matched = true
 	}

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -18,6 +18,7 @@ type Stub struct {
 	matched   bool
 	Matcher   Matcher
 	Responder Responder
+	exclude   bool
 }
 
 func MatchAny(*http.Request) bool {


### PR DESCRIPTION
Fixes #9464

Internal repos only exist for organizations, so when a user selects their personal namespace to create a repo using `gh repo create`, `Internal` should not be an option in the `Visibility` prompt.

This should avoid the additional quirk where if the user selects `Internal` while creating a personal repo and then proceeds to add any of the README, .gitignore, or LICENSE files prompted for later, the repo will not error and instead get created as a `Public` repo. This has the potential for a user to unknowingly leak sensitive info intended to go into a non-public repo.

## Screenshots

### Visibility prompt when creating a personal repo

<img width="617" alt="Screenshot 2024-08-14 at 3 26 37 PM" src="https://github.com/user-attachments/assets/2a263826-e7e6-4721-8a11-f760a5f5f29a">

### Visibility prompt when creating an org repo

<img width="620" alt="Screenshot 2024-08-14 at 3 26 14 PM" src="https://github.com/user-attachments/assets/3e93dc7b-f058-46d2-8e45-9fc40d8cdebc">

## To test

1. Pull down branch `gh pr checkout 9465`
2. Build the tool in the root directory: `make`
3. Try the prompt, selecting your personal account: `bin/gh repo create`
