### PR TITLE
Add note for external contributors to `working-with-us.md`

### DIFF
--- a/docs/working-with-us.md
+++ b/docs/working-with-us.md
@@ -4,6 +4,9 @@ POV: your team at GitHub is interested in shipping a new command in `gh`.
 
 This document outlines the process the CLI team prefers for helping ensure success both for your new feature and the CLI project as a whole.
 
+> [!NOTE]
+> External contributors, please see [CONTRIBUTING.md](/.github/CONTRIBUTING.md).
+
 ## Step 0: Create an extension
 
 Even if you want to see your code merged into `gh`, you should start with [an extension](https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions) written in Go and leveraging [go-gh](https://github.com/cli/go-gh). Though `gh` extensions can be written in any language, we treat Go as a first class experience and ship a library of helpers for extensions written in Go.


### PR DESCRIPTION
I felt that there should be slightly more indication that this is a document for hubbers and not external contributors. This PR adds a note box indicating where an external contributor should go instead. 

![image](https://github.com/user-attachments/assets/a766c4b0-650a-4fa6-a7a9-d5bad08007e0)
