### PR TITLE
Drop surplus trailing space char in flag names in web

### DIFF
--- a/internal/docs/markdown.go
+++ b/internal/docs/markdown.go
@@ -103,7 +103,7 @@ type flagView struct {
 var flagsTemplate = `
 <dl class="flags">{{ range . }}
 	<dt>{{ if .Shorthand }}<code>-{{.Shorthand}}</code>, {{ end }}
-		<code>--{{.Name}}{{ if .Varname }} &lt;{{.Varname}}&gt;{{ end }}{{.DefValue}} </code></dt>
+		<code>--{{.Name}}{{ if .Varname }} &lt;{{.Varname}}&gt;{{ end }}{{.DefValue}}</code></dt>
 	<dd>{{.Usage}}</dd>
 {{ end }}</dl>
 `


### PR DESCRIPTION
Fixes #9513.

Introduced by 92cb2cc7 (more closely match cobra default val display, 2023-12-05).

cc @zsloane

------

The surplus trailing space can be observed in any web manual pages for `gh` commands and subcommands which contain an "Options" section. For example, on https://cli.github.com/manual/gh_codespace_create
![image](https://github.com/user-attachments/assets/56402790-65fc-40b4-a9dd-9d0c567e0192)

When the template `flagsTemplate` is parsed,

> By default, all text between actions is copied verbatim when the template is executed.
> <sub>_see https://pkg.go.dev/text/template#hdr-Text_and_spaces._<sub>