### PR TITLE
Fix `pr checkout`, cannot set up tracking info

### DIFF
--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -166,6 +166,9 @@ func cmdsForExistingRemote(remote *cliContext.Remote, pr *api.PullRequest, opts 
 			cmds = append(cmds, []string{"merge", "--ff-only", fmt.Sprintf("refs/remotes/%s", remoteBranch)})
 		}
 	default:
+		if !localBranchExists(opts.GitClient, remoteBranch) {
+			cmds = append(cmds, []string{"config", "--add", fmt.Sprintf("remote.%s.fetch", remote.Name), refSpec})
+		}
 		cmds = append(cmds, []string{"checkout", "-b", localBranch, "--track", remoteBranch})
 	}
 

--- a/pkg/cmd/pr/checkout/checkout_test.go
+++ b/pkg/cmd/pr/checkout/checkout_test.go
@@ -125,6 +125,7 @@ func Test_checkoutRun(t *testing.T) {
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git show-ref --verify -- refs/heads/foobar`, 1, "")
 				cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+				cs.Register(`git show-ref --verify -- refs/heads/origin/feature`, 0, "")
 				cs.Register(`git checkout -b foobar --track origin/feature`, 0, "")
 			},
 		},
@@ -278,6 +279,7 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 
 	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 1, "")
+	cs.Register(`git show-ref --verify -- refs/heads/origin/feature`, 0, "")
 	cs.Register(`git checkout -b feature --track origin/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`)
@@ -331,6 +333,7 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 
 	cs.Register(`git fetch robot-fork \+refs/heads/feature:refs/remotes/robot-fork/feature`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 1, "")
+	cs.Register(`git show-ref --verify -- refs/heads/robot-fork/feature`, 0, "")
 	cs.Register(`git checkout -b feature --track robot-fork/feature`, 0, "")
 
 	output, err := runCommand(http, remotes, "master", `123`)


### PR DESCRIPTION
Fixes #4287

Briefly, `gh pr checkout <pr> [--branch LOCAL_BRANCH]` works in two steps:
1. fetch the head branch of `<pr>` by running `git fetch REMOTE +refs/heads/BRANCH:refs/remotes/REMOTE/BRANCH`
2. checkout the fetched branch by running `git checkout -b LOCAL_BRANCH --track REMOTE/BRANCH`

What #4287 reported is that when the fetch `refs/remotes/REMOTE/BRANCH` is not covered in `remote.REMOTE.fetch` git config, then the second step failed with
```
fatal: cannot set up tracking information; starting point 'REMOTE/BRANCH' is not a branch
failed to run git: exit status 128
```

This PR solves this problem by running[^1]
```
git config --add remote.REMOTE.fetch +refs/heads/BRANCH:refs/remotes/REMOTE/BRANCH
```
if local branch `REMOTE/BRANCH` doesn't exist after the first step.

Note that [`remote.<name>.fetch`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-remoteltnamegtfetch) is a multi-valued Git config, though not clearly documented.

Note also that an old syntax `git config --add <name> <value>` is used to gain compatibility with old Git versions. Since Git 2.26.0, `git config` learnt some new subcommands and options, see the section _Deprecated modes_ in [`git config` doc](https://git-scm.com/docs/git-config#_deprecated_modes).

**TODO**

- [ ] add some code comment
- [ ] add new test; Need help mocking a restricted `remote.origin.fetch` config in test.

[^1]: Just realized that it does exactly the same as `git remote set-branches --add origin mybranch` mentioned by @mislav in https://github.com/cli/cli/issues/4287#issuecomment-915112505