### PR TITLE
2nd attempt to feature detect v1 project support

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -851,7 +851,7 @@ type RepoMetadataInput struct {
 }
 
 // RepoMetadata pre-fetches the metadata for attaching to issues and pull requests
-func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput) (*RepoMetadataResult, error) {
+func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput, includeProjectV1 bool) (*RepoMetadataResult, error) {
 	var result RepoMetadataResult
 	var g errgroup.Group
 
@@ -900,7 +900,7 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 	if input.Projects {
 		g.Go(func() error {
 			var err error
-			result.Projects, result.ProjectsV2, err = relevantProjects(client, repo)
+			result.Projects, result.ProjectsV2, err = relevantProjects(client, repo, includeProjectV1)
 			return err
 		})
 	}
@@ -931,7 +931,7 @@ type RepoResolveInput struct {
 }
 
 // RepoResolveMetadataIDs looks up GraphQL node IDs in bulk
-func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoResolveInput) (*RepoMetadataResult, error) {
+func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoResolveInput, includeProjectV1 bool) (*RepoMetadataResult, error) {
 	users := input.Assignees
 	hasUser := func(target string) bool {
 		for _, u := range users {
@@ -956,7 +956,7 @@ func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoRes
 		Projects:   len(input.Projects) > 0,
 		Milestones: len(input.Milestones) > 0,
 	}
-	result, err := RepoMetadata(client, repo, mi)
+	result, err := RepoMetadata(client, repo, mi, includeProjectV1)
 	if err != nil {
 		return result, err
 	}
@@ -1220,8 +1220,8 @@ func RepoMilestones(client *Client, repo ghrepo.Interface, state string) ([]Repo
 	return milestones, nil
 }
 
-func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []string) ([]string, error) {
-	projects, projectsV2, err := relevantProjects(client, repo)
+func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []string, includeProjectV1 bool) ([]string, error) {
+	projects, projectsV2, err := relevantProjects(client, repo, includeProjectV1)
 	if err != nil {
 		return nil, err
 	}
@@ -1234,7 +1234,7 @@ func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []s
 // - ProjectsV2 owned by current user
 // - ProjectsV2 linked to repository
 // - ProjectsV2 owned by repository organization, if it belongs to one
-func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []ProjectV2, error) {
+func relevantProjects(client *Client, repo ghrepo.Interface, includeProjectV1 bool) ([]RepoProject, []ProjectV2, error) {
 	var repoProjects []RepoProject
 	var orgProjects []RepoProject
 	var userProjectsV2 []ProjectV2
@@ -1243,23 +1243,26 @@ func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []P
 
 	g, _ := errgroup.WithContext(context.Background())
 
-	g.Go(func() error {
-		var err error
-		repoProjects, err = RepoProjects(client, repo)
-		if err != nil {
-			err = fmt.Errorf("error fetching repo projects (classic): %w", err)
-		}
-		return err
-	})
-	g.Go(func() error {
-		var err error
-		orgProjects, err = OrganizationProjects(client, repo)
-		if err != nil && !strings.Contains(err.Error(), errorResolvingOrganization) {
-			err = fmt.Errorf("error fetching organization projects (classic): %w", err)
+	if includeProjectV1 {
+		g.Go(func() error {
+			var err error
+			repoProjects, err = RepoProjects(client, repo)
+			if err != nil {
+				err = fmt.Errorf("error fetching repo projects (classic): %w", err)
+			}
 			return err
-		}
-		return nil
-	})
+		})
+		g.Go(func() error {
+			var err error
+			orgProjects, err = OrganizationProjects(client, repo)
+			if err != nil && !strings.Contains(err.Error(), errorResolvingOrganization) {
+				err = fmt.Errorf("error fetching organization projects (classic): %w", err)
+				return err
+			}
+			return nil
+		})
+	}
+
 	g.Go(func() error {
 		var err error
 		userProjectsV2, err = CurrentUserProjectsV2(client, repo.RepoHost())

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"golang.org/x/sync/errgroup"
 
@@ -851,7 +852,7 @@ type RepoMetadataInput struct {
 }
 
 // RepoMetadata pre-fetches the metadata for attaching to issues and pull requests
-func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput, includeProjectV1 bool) (*RepoMetadataResult, error) {
+func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput, projectsV1Support gh.ProjectsV1Support) (*RepoMetadataResult, error) {
 	var result RepoMetadataResult
 	var g errgroup.Group
 
@@ -900,7 +901,7 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 	if input.Projects {
 		g.Go(func() error {
 			var err error
-			result.Projects, result.ProjectsV2, err = relevantProjects(client, repo, includeProjectV1)
+			result.Projects, result.ProjectsV2, err = relevantProjects(client, repo, projectsV1Support)
 			return err
 		})
 	}
@@ -931,7 +932,7 @@ type RepoResolveInput struct {
 }
 
 // RepoResolveMetadataIDs looks up GraphQL node IDs in bulk
-func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoResolveInput, includeProjectV1 bool) (*RepoMetadataResult, error) {
+func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoResolveInput, projectsV1Support gh.ProjectsV1Support) (*RepoMetadataResult, error) {
 	users := input.Assignees
 	hasUser := func(target string) bool {
 		for _, u := range users {
@@ -956,7 +957,7 @@ func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoRes
 		Projects:   len(input.Projects) > 0,
 		Milestones: len(input.Milestones) > 0,
 	}
-	result, err := RepoMetadata(client, repo, mi, includeProjectV1)
+	result, err := RepoMetadata(client, repo, mi, projectsV1Support)
 	if err != nil {
 		return result, err
 	}
@@ -1220,8 +1221,8 @@ func RepoMilestones(client *Client, repo ghrepo.Interface, state string) ([]Repo
 	return milestones, nil
 }
 
-func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []string, includeProjectV1 bool) ([]string, error) {
-	projects, projectsV2, err := relevantProjects(client, repo, includeProjectV1)
+func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []string, projectsV1Support gh.ProjectsV1Support) ([]string, error) {
+	projects, projectsV2, err := relevantProjects(client, repo, projectsV1Support)
 	if err != nil {
 		return nil, err
 	}
@@ -1234,7 +1235,7 @@ func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []s
 // - ProjectsV2 owned by current user
 // - ProjectsV2 linked to repository
 // - ProjectsV2 owned by repository organization, if it belongs to one
-func relevantProjects(client *Client, repo ghrepo.Interface, includeProjectV1 bool) ([]RepoProject, []ProjectV2, error) {
+func relevantProjects(client *Client, repo ghrepo.Interface, projectsV1Support gh.ProjectsV1Support) ([]RepoProject, []ProjectV2, error) {
 	var repoProjects []RepoProject
 	var orgProjects []RepoProject
 	var userProjectsV2 []ProjectV2
@@ -1243,7 +1244,7 @@ func relevantProjects(client *Client, repo ghrepo.Interface, includeProjectV1 bo
 
 	g, _ := errgroup.WithContext(context.Background())
 
-	if includeProjectV1 {
+	if projectsV1Support == gh.ProjectsV1Supported {
 		g.Go(func() error {
 			var err error
 			repoProjects, err = RepoProjects(client, repo)

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -150,7 +150,7 @@ func Test_RepoMetadata(t *testing.T) {
 		  { "data": { "viewer": { "login": "monalisa" } } }
 		`))
 
-	result, err := RepoMetadata(client, repo, input)
+	result, err := RepoMetadata(client, repo, input, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -291,7 +291,7 @@ func Test_ProjectNamesToPaths(t *testing.T) {
 		} } } }
 		`))
 
-	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap", "TriageV2", "RoadmapV2", "MonalisaV2"})
+	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap", "TriageV2", "RoadmapV2", "MonalisaV2"}, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -351,7 +351,7 @@ t001: team(slug:"robots"){id,slug}
 			}
 		}))
 
-	result, err := RepoResolveMetadataIDs(client, repo, input)
+	result, err := RepoResolveMetadataIDs(client, repo, input, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -150,7 +151,7 @@ func Test_RepoMetadata(t *testing.T) {
 		  { "data": { "viewer": { "login": "monalisa" } } }
 		`))
 
-	result, err := RepoMetadata(client, repo, input, true)
+	result, err := RepoMetadata(client, repo, input, gh.ProjectsV1Supported)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -291,7 +292,7 @@ func Test_ProjectNamesToPaths(t *testing.T) {
 		} } } }
 		`))
 
-	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap", "TriageV2", "RoadmapV2", "MonalisaV2"}, true)
+	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap", "TriageV2", "RoadmapV2", "MonalisaV2"}, gh.ProjectsV1Supported)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -351,7 +352,7 @@ t001: team(slug:"robots"){id,slug}
 			}
 		}))
 
-	result, err := RepoResolveMetadataIDs(client, repo, input, false)
+	result, err := RepoResolveMetadataIDs(client, repo, input, gh.ProjectsV1Supported)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/featuredetection/detector_mock.go
+++ b/internal/featuredetection/detector_mock.go
@@ -14,6 +14,10 @@ func (md *DisabledDetectorMock) RepositoryFeatures() (RepositoryFeatures, error)
 	return RepositoryFeatures{}, nil
 }
 
+func (md *DisabledDetectorMock) ProjectV1() (bool, error) {
+	return false, nil
+}
+
 type EnabledDetectorMock struct{}
 
 func (md *EnabledDetectorMock) IssueFeatures() (IssueFeatures, error) {
@@ -26,4 +30,8 @@ func (md *EnabledDetectorMock) PullRequestFeatures() (PullRequestFeatures, error
 
 func (md *EnabledDetectorMock) RepositoryFeatures() (RepositoryFeatures, error) {
 	return allRepositoryFeatures, nil
+}
+
+func (md *EnabledDetectorMock) ProjectV1() (bool, error) {
+	return true, nil
 }

--- a/internal/featuredetection/detector_mock.go
+++ b/internal/featuredetection/detector_mock.go
@@ -1,5 +1,7 @@
 package featuredetection
 
+import "github.com/cli/cli/v2/internal/gh"
+
 type DisabledDetectorMock struct{}
 
 func (md *DisabledDetectorMock) IssueFeatures() (IssueFeatures, error) {
@@ -14,8 +16,8 @@ func (md *DisabledDetectorMock) RepositoryFeatures() (RepositoryFeatures, error)
 	return RepositoryFeatures{}, nil
 }
 
-func (md *DisabledDetectorMock) ProjectV1() (bool, error) {
-	return false, nil
+func (md *DisabledDetectorMock) ProjectsV1() (gh.ProjectsV1Support, error) {
+	return gh.ProjectsV1Unsupported, nil
 }
 
 type EnabledDetectorMock struct{}
@@ -32,6 +34,6 @@ func (md *EnabledDetectorMock) RepositoryFeatures() (RepositoryFeatures, error) 
 	return allRepositoryFeatures, nil
 }
 
-func (md *EnabledDetectorMock) ProjectV1() (bool, error) {
-	return true, nil
+func (md *EnabledDetectorMock) ProjectsV1() (gh.ProjectsV1Support, error) {
+	return gh.ProjectsV1Supported, nil
 }

--- a/internal/gh/projects.go
+++ b/internal/gh/projects.go
@@ -1,0 +1,30 @@
+package gh
+
+// ProjectsV1Support provides type safety and readability around whether or not Projects v1 is supported
+// by the targeted host.
+//
+// It is a sealed type to ensure that consumers must use the exported ProjectsV1Supported and ProjectsV1Unsupported
+// variables to get an instance of the type.
+type ProjectsV1Support interface {
+	sealed()
+}
+
+type projectsV1Supported struct{}
+
+func (projectsV1Supported) sealed() {}
+
+type projectsV1Unsupported struct{}
+
+func (projectsV1Unsupported) sealed() {}
+
+var (
+	ProjectsV1Supported   ProjectsV1Support = projectsV1Supported{}
+	ProjectsV1Unsupported ProjectsV1Support = projectsV1Unsupported{}
+)
+
+func ParseProjectsV1Support(b bool) ProjectsV1Support {
+	if b {
+		return ProjectsV1Supported
+	}
+	return ProjectsV1Unsupported
+}

--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -67,7 +67,7 @@ func closeRun(opts *CloseOptions) error {
 		return err
 	}
 
-	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, []string{"id", "number", "title", "state"})
+	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, []string{"id", "number", "title", "state"}, opts.Detector)
 	if err != nil {
 		return err
 	}
@@ -109,6 +109,7 @@ func apiClose(httpClient *http.Client, repo ghrepo.Interface, issue *api.Issue, 
 	}
 
 	if reason != "" {
+		// Should this be moved up into closeRun()?
 		if detector == nil {
 			cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
 			detector = fd.NewDetector(cachedClient, repo.RepoHost())

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -44,7 +44,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 				if opts.EditLast {
 					fields = append(fields, "comments")
 				}
-				return issueShared.IssueFromArgWithFields(httpClient, f.BaseRepo, args[0], fields)
+				return issueShared.IssueFromArgWithFields(httpClient, f.BaseRepo, args[0], fields, opts.Detector)
 			}
 			return prShared.CommentablePreRun(cmd, opts)
 		},

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
@@ -25,6 +27,7 @@ type CreateOptions struct {
 	Browser          browser.Browser
 	Prompter         prShared.Prompt
 	TitledEditSurvey func(string, string) (string, string, error)
+	Detector         fd.Detector
 
 	RootDirOverride string
 
@@ -146,6 +149,16 @@ func createRun(opts *CreateOptions) (err error) {
 		return
 	}
 
+	if opts.Detector == nil {
+		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
+		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
+	}
+
+	includeProjectV1, err := opts.Detector.ProjectV1()
+	if err != nil {
+		return err
+	}
+
 	isTerminal := opts.IO.IsStdoutTTY()
 
 	var milestones []string
@@ -182,7 +195,7 @@ func createRun(opts *CreateOptions) (err error) {
 	if opts.WebMode {
 		var openURL string
 		if opts.Title != "" || opts.Body != "" || tb.HasMetadata() {
-			openURL, err = generatePreviewURL(apiClient, baseRepo, tb)
+			openURL, err = generatePreviewURL(apiClient, baseRepo, tb, includeProjectV1)
 			if err != nil {
 				return
 			}
@@ -260,7 +273,7 @@ func createRun(opts *CreateOptions) (err error) {
 			}
 		}
 
-		openURL, err = generatePreviewURL(apiClient, baseRepo, tb)
+		openURL, err = generatePreviewURL(apiClient, baseRepo, tb, includeProjectV1)
 		if err != nil {
 			return
 		}
@@ -279,7 +292,7 @@ func createRun(opts *CreateOptions) (err error) {
 				Repo:      baseRepo,
 				State:     &tb,
 			}
-			err = prShared.MetadataSurvey(opts.Prompter, opts.IO, baseRepo, fetcher, &tb)
+			err = prShared.MetadataSurvey(opts.Prompter, opts.IO, baseRepo, fetcher, &tb, includeProjectV1)
 			if err != nil {
 				return
 			}
@@ -335,7 +348,7 @@ func createRun(opts *CreateOptions) (err error) {
 			params["issueTemplate"] = templateNameForSubmit
 		}
 
-		err = prShared.AddMetadataToIssueParams(apiClient, baseRepo, params, &tb)
+		err = prShared.AddMetadataToIssueParams(apiClient, baseRepo, params, &tb, includeProjectV1)
 		if err != nil {
 			return
 		}
@@ -354,7 +367,7 @@ func createRun(opts *CreateOptions) (err error) {
 	return
 }
 
-func generatePreviewURL(apiClient *api.Client, baseRepo ghrepo.Interface, tb prShared.IssueMetadataState) (string, error) {
+func generatePreviewURL(apiClient *api.Client, baseRepo ghrepo.Interface, tb prShared.IssueMetadataState, includeProjectV1 bool) (string, error) {
 	openURL := ghrepo.GenerateRepoURL(baseRepo, "issues/new")
-	return prShared.WithPrAndIssueQueryParams(apiClient, baseRepo, openURL, tb)
+	return prShared.WithPrAndIssueQueryParams(apiClient, baseRepo, openURL, tb, includeProjectV1)
 }

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -154,7 +154,7 @@ func createRun(opts *CreateOptions) (err error) {
 		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
 	}
 
-	includeProjectV1, err := opts.Detector.ProjectV1()
+	projectsV1Support, err := opts.Detector.ProjectsV1()
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func createRun(opts *CreateOptions) (err error) {
 	if opts.WebMode {
 		var openURL string
 		if opts.Title != "" || opts.Body != "" || tb.HasMetadata() {
-			openURL, err = generatePreviewURL(apiClient, baseRepo, tb, includeProjectV1)
+			openURL, err = generatePreviewURL(apiClient, baseRepo, tb, projectsV1Support)
 			if err != nil {
 				return
 			}
@@ -273,7 +273,7 @@ func createRun(opts *CreateOptions) (err error) {
 			}
 		}
 
-		openURL, err = generatePreviewURL(apiClient, baseRepo, tb, includeProjectV1)
+		openURL, err = generatePreviewURL(apiClient, baseRepo, tb, projectsV1Support)
 		if err != nil {
 			return
 		}
@@ -292,7 +292,7 @@ func createRun(opts *CreateOptions) (err error) {
 				Repo:      baseRepo,
 				State:     &tb,
 			}
-			err = prShared.MetadataSurvey(opts.Prompter, opts.IO, baseRepo, fetcher, &tb, includeProjectV1)
+			err = prShared.MetadataSurvey(opts.Prompter, opts.IO, baseRepo, fetcher, &tb, projectsV1Support)
 			if err != nil {
 				return
 			}
@@ -348,7 +348,7 @@ func createRun(opts *CreateOptions) (err error) {
 			params["issueTemplate"] = templateNameForSubmit
 		}
 
-		err = prShared.AddMetadataToIssueParams(apiClient, baseRepo, params, &tb, includeProjectV1)
+		err = prShared.AddMetadataToIssueParams(apiClient, baseRepo, params, &tb, projectsV1Support)
 		if err != nil {
 			return
 		}
@@ -367,7 +367,7 @@ func createRun(opts *CreateOptions) (err error) {
 	return
 }
 
-func generatePreviewURL(apiClient *api.Client, baseRepo ghrepo.Interface, tb prShared.IssueMetadataState, includeProjectV1 bool) (string, error) {
+func generatePreviewURL(apiClient *api.Client, baseRepo ghrepo.Interface, tb prShared.IssueMetadataState, projectsV1Support gh.ProjectsV1Support) (string, error) {
 	openURL := ghrepo.GenerateRepoURL(baseRepo, "issues/new")
-	return prShared.WithPrAndIssueQueryParams(apiClient, baseRepo, openURL, tb, includeProjectV1)
+	return prShared.WithPrAndIssueQueryParams(apiClient, baseRepo, openURL, tb, projectsV1Support)
 }

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
@@ -475,6 +476,7 @@ func Test_createRun(t *testing.T) {
 			}
 			browser := &browser.Stub{}
 			opts.Browser = browser
+			opts.Detector = &featuredetection.EnabledDetectorMock{}
 
 			err := createRun(opts)
 			if tt.wantsErr == "" {
@@ -521,6 +523,7 @@ func runCommandWithRootDirOverridden(rt http.RoundTripper, isTTY bool, cli strin
 
 	cmd := NewCmdCreate(factory, func(opts *CreateOptions) error {
 		opts.RootDirOverride = rootDir
+		opts.Detector = &featuredetection.EnabledDetectorMock{}
 		return createRun(opts)
 	})
 

--- a/pkg/cmd/issue/delete/delete.go
+++ b/pkg/cmd/issue/delete/delete.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
@@ -20,6 +21,7 @@ type DeleteOptions struct {
 	IO         *iostreams.IOStreams
 	BaseRepo   func() (ghrepo.Interface, error)
 	Prompter   iprompter
+	Detector   fd.Detector
 
 	SelectorArg string
 	Confirmed   bool
@@ -71,7 +73,7 @@ func deleteRun(opts *DeleteOptions) error {
 		return err
 	}
 
-	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, []string{"id", "number", "title"})
+	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, []string{"id", "number", "title"}, opts.Detector)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/issue/develop/develop.go
+++ b/pkg/cmd/issue/develop/develop.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
@@ -23,6 +24,7 @@ type DevelopOptions struct {
 	IO         *iostreams.IOStreams
 	BaseRepo   func() (ghrepo.Interface, error)
 	Remotes    func() (context.Remotes, error)
+	Detector   fd.Detector
 
 	IssueSelector string
 	Name          string
@@ -125,7 +127,7 @@ func developRun(opts *DevelopOptions) error {
 	}
 
 	opts.IO.StartProgressIndicator()
-	issue, issueRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.IssueSelector, []string{"id", "number"})
+	issue, issueRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.IssueSelector, []string{"id", "number"}, opts.Detector)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
 	shared "github.com/cli/cli/v2/pkg/cmd/issue/shared"
@@ -29,7 +30,7 @@ type EditOptions struct {
 	DetermineEditor    func() (string, error)
 	FieldsToEditSurvey func(prShared.EditPrompter, *prShared.Editable) error
 	EditFieldsSurvey   func(prShared.EditPrompter, *prShared.Editable, string) error
-	FetchOptions       func(*api.Client, ghrepo.Interface, *prShared.Editable, bool) error
+	FetchOptions       func(*api.Client, ghrepo.Interface, *prShared.Editable, gh.ProjectsV1Support) error
 
 	SelectorArgs []string
 	Interactive  bool
@@ -180,7 +181,7 @@ func editRun(opts *EditOptions) error {
 		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
 	}
 
-	includeProjectV1, err := opts.Detector.ProjectV1()
+	projectsV1Support, err := opts.Detector.ProjectsV1()
 	if err != nil {
 		return err
 	}
@@ -218,7 +219,7 @@ func editRun(opts *EditOptions) error {
 	// Fetch editable shared fields once for all issues.
 	apiClient := api.NewClientFromHTTP(httpClient)
 	opts.IO.StartProgressIndicatorWithLabel("Fetching repository information")
-	err = opts.FetchOptions(apiClient, repo, &editable, includeProjectV1)
+	err = opts.FetchOptions(apiClient, repo, &editable, projectsV1Support)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
 	shared "github.com/cli/cli/v2/pkg/cmd/issue/shared"
@@ -22,11 +24,12 @@ type EditOptions struct {
 	IO         *iostreams.IOStreams
 	BaseRepo   func() (ghrepo.Interface, error)
 	Prompter   prShared.EditPrompter
+	Detector   fd.Detector
 
 	DetermineEditor    func() (string, error)
 	FieldsToEditSurvey func(prShared.EditPrompter, *prShared.Editable) error
 	EditFieldsSurvey   func(prShared.EditPrompter, *prShared.Editable, string) error
-	FetchOptions       func(*api.Client, ghrepo.Interface, *prShared.Editable) error
+	FetchOptions       func(*api.Client, ghrepo.Interface, *prShared.Editable, bool) error
 
 	SelectorArgs []string
 	Interactive  bool
@@ -167,6 +170,21 @@ func editRun(opts *EditOptions) error {
 		return err
 	}
 
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	if opts.Detector == nil {
+		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
+		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
+	}
+
+	includeProjectV1, err := opts.Detector.ProjectV1()
+	if err != nil {
+		return err
+	}
+
 	// Prompt the user which fields they'd like to edit.
 	editable := opts.Editable
 	if opts.Interactive {
@@ -192,7 +210,7 @@ func editRun(opts *EditOptions) error {
 	}
 
 	// Get all specified issues and make sure they are within the same repo.
-	issues, repo, err := shared.IssuesFromArgsWithFields(httpClient, opts.BaseRepo, opts.SelectorArgs, lookupFields)
+	issues, repo, err := shared.IssuesFromArgsWithFields(httpClient, opts.BaseRepo, opts.SelectorArgs, lookupFields, opts.Detector)
 	if err != nil {
 		return err
 	}
@@ -200,7 +218,7 @@ func editRun(opts *EditOptions) error {
 	// Fetch editable shared fields once for all issues.
 	apiClient := api.NewClientFromHTTP(httpClient)
 	opts.IO.StartProgressIndicatorWithLabel("Fetching repository information")
-	err = opts.FetchOptions(apiClient, repo, &editable)
+	err = opts.FetchOptions(apiClient, repo, &editable, includeProjectV1)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -577,6 +578,7 @@ func Test_editRun(t *testing.T) {
 			tt.input.IO = ios
 			tt.input.HttpClient = httpClient
 			tt.input.BaseRepo = baseRepo
+			tt.input.Detector = &featuredetection.EnabledDetectorMock{}
 
 			err := editRun(tt.input)
 			if tt.wantErr {

--- a/pkg/cmd/issue/lock/lock.go
+++ b/pkg/cmd/issue/lock/lock.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	issueShared "github.com/cli/cli/v2/pkg/cmd/issue/shared"
@@ -96,6 +97,7 @@ type LockOptions struct {
 	IO         *iostreams.IOStreams
 	BaseRepo   func() (ghrepo.Interface, error)
 	Prompter   iprompter
+	Detector   fd.Detector
 
 	ParentCmd   string
 	Reason      string
@@ -214,7 +216,7 @@ func lockRun(state string, opts *LockOptions) error {
 		return err
 	}
 
-	issuePr, baseRepo, err := issueShared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, fields())
+	issuePr, baseRepo, err := issueShared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, fields(), opts.Detector)
 
 	parent := alias[opts.ParentCmd]
 

--- a/pkg/cmd/issue/pin/pin.go
+++ b/pkg/cmd/issue/pin/pin.go
@@ -73,7 +73,7 @@ func pinRun(opts *PinOptions) error {
 		return err
 	}
 
-	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, []string{"id", "number", "title", "isPinned"})
+	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, []string{"id", "number", "title", "isPinned"}, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/issue/reopen/reopen.go
+++ b/pkg/cmd/issue/reopen/reopen.go
@@ -64,7 +64,7 @@ func reopenRun(opts *ReopenOptions) error {
 		return err
 	}
 
-	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, []string{"id", "number", "title", "state"})
+	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, []string{"id", "number", "title", "state"}, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/issue/shared/lookup.go
+++ b/pkg/cmd/issue/shared/lookup.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/set"
 	"golang.org/x/sync/errgroup"
@@ -167,11 +168,11 @@ func findIssueOrPR(httpClient *http.Client, repo ghrepo.Interface, number int, f
 		fieldSet.Add("number")
 	}
 	if fieldSet.Contains("projectCards") {
-		includeProjectV1, err := detector.ProjectV1()
+		projectsV1Support, err := detector.ProjectsV1()
 		if err != nil {
 			return nil, err
 		}
-		if !includeProjectV1 {
+		if projectsV1Support == gh.ProjectsV1Unsupported {
 			fieldSet.Remove("projectCards")
 		}
 	}

--- a/pkg/cmd/issue/shared/lookup_test.go
+++ b/pkg/cmd/issue/shared/lookup_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -193,7 +194,7 @@ func TestIssueFromArgWithFields(t *testing.T) {
 				tt.httpStub(reg)
 			}
 			httpClient := &http.Client{Transport: reg}
-			issue, repo, err := IssueFromArgWithFields(httpClient, tt.args.baseRepoFn, tt.args.selector, []string{"number"})
+			issue, repo, err := IssueFromArgWithFields(httpClient, tt.args.baseRepoFn, tt.args.selector, []string{"number"}, &fd.EnabledDetectorMock{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IssueFromArgWithFields() error = %v, wantErr %v", err, tt.wantErr)
 				if issue == nil {
@@ -289,7 +290,7 @@ func TestIssuesFromArgsWithFields(t *testing.T) {
 				tt.httpStub(reg)
 			}
 			httpClient := &http.Client{Transport: reg}
-			issues, repo, err := IssuesFromArgsWithFields(httpClient, tt.args.baseRepoFn, tt.args.selectors, []string{"number"})
+			issues, repo, err := IssuesFromArgsWithFields(httpClient, tt.args.baseRepoFn, tt.args.selectors, []string{"number"}, &fd.EnabledDetectorMock{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IssuesFromArgsWithFields() error = %v, wantErr %v", err, tt.wantErr)
 				if issues == nil {

--- a/pkg/cmd/issue/transfer/transfer.go
+++ b/pkg/cmd/issue/transfer/transfer.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
@@ -19,6 +20,7 @@ type TransferOptions struct {
 	Config     func() (gh.Config, error)
 	IO         *iostreams.IOStreams
 	BaseRepo   func() (ghrepo.Interface, error)
+	Detector   fd.Detector
 
 	IssueSelector    string
 	DestRepoSelector string
@@ -57,7 +59,7 @@ func transferRun(opts *TransferOptions) error {
 		return err
 	}
 
-	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.IssueSelector, []string{"id", "number"})
+	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.IssueSelector, []string{"id", "number"}, opts.Detector)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/issue/unpin/unpin.go
+++ b/pkg/cmd/issue/unpin/unpin.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
@@ -21,6 +22,7 @@ type UnpinOptions struct {
 	IO          *iostreams.IOStreams
 	BaseRepo    func() (ghrepo.Interface, error)
 	SelectorArg string
+	Detector    fd.Detector
 }
 
 func NewCmdUnpin(f *cmdutil.Factory, runF func(*UnpinOptions) error) *cobra.Command {
@@ -73,7 +75,7 @@ func unpinRun(opts *UnpinOptions) error {
 		return err
 	}
 
-	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, []string{"id", "number", "title", "isPinned"})
+	issue, baseRepo, err := shared.IssueFromArgWithFields(httpClient, opts.BaseRepo, opts.SelectorArg, []string{"id", "number", "title", "isPinned"}, opts.Detector)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/run"
@@ -66,7 +67,10 @@ func runCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, err
 		},
 	}
 
-	cmd := NewCmdView(factory, nil)
+	cmd := NewCmdView(factory, func(opts *ViewOptions) error {
+		opts.Detector = &featuredetection.EnabledDetectorMock{}
+		return viewRun(opts)
+	})
 
 	argv, err := shlex.Split(cli)
 	if err != nil {
@@ -274,6 +278,7 @@ func TestIssueView_tty_Preview(t *testing.T) {
 					return ghrepo.New("OWNER", "REPO"), nil
 				},
 				SelectorArg: "123",
+				Detector:    &featuredetection.EnabledDetectorMock{},
 			}
 
 			err := viewRun(&opts)

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -88,7 +88,7 @@ type CreateContext struct {
 	IsPushEnabled      bool
 	Client             *api.Client
 	GitClient          *git.Client
-	IncludeProjectV1   bool
+	ProjectsV1Support  gh.ProjectsV1Support
 }
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
@@ -437,7 +437,7 @@ func createRun(opts *CreateOptions) (err error) {
 				Repo:      ctx.BaseRepo,
 				State:     state,
 			}
-			err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.BaseRepo, fetcher, state, ctx.IncludeProjectV1)
+			err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.BaseRepo, fetcher, state, ctx.ProjectsV1Support)
 			if err != nil {
 				return
 			}
@@ -731,7 +731,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
 		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
 	}
-	includeProjectV1, err := opts.Detector.ProjectV1()
+	projectsV1Support, err := opts.Detector.ProjectsV1()
 	if err != nil {
 		return nil, err
 	}
@@ -748,7 +748,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 		RepoContext:        repoContext,
 		Client:             client,
 		GitClient:          gitClient,
-		IncludeProjectV1:   includeProjectV1,
+		ProjectsV1Support:  projectsV1Support,
 	}, nil
 }
 
@@ -781,7 +781,7 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 		return errors.New("pull request title must not be blank")
 	}
 
-	err := shared.AddMetadataToIssueParams(client, ctx.BaseRepo, params, &state, ctx.IncludeProjectV1)
+	err := shared.AddMetadataToIssueParams(client, ctx.BaseRepo, params, &state, ctx.ProjectsV1Support)
 	if err != nil {
 		return err
 	}
@@ -1004,7 +1004,7 @@ func generateCompareURL(ctx CreateContext, state shared.IssueMetadataState) (str
 		ctx.BaseRepo,
 		"compare/%s...%s?expand=1",
 		url.PathEscape(ctx.BaseBranch), url.PathEscape(ctx.HeadBranchLabel))
-	url, err := shared.WithPrAndIssueQueryParams(ctx.Client, ctx.BaseRepo, u, state, ctx.IncludeProjectV1)
+	url, err := shared.WithPrAndIssueQueryParams(ctx.Client, ctx.BaseRepo, u, state, ctx.ProjectsV1Support)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -18,6 +18,7 @@ import (
 	ghContext "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/browser"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
@@ -40,6 +41,7 @@ type CreateOptions struct {
 	Prompter         shared.Prompt
 	Finder           shared.PRFinder
 	TitledEditSurvey func(string, string) (string, string, error)
+	Detector         fd.Detector
 
 	TitleProvided bool
 	BodyProvided  bool
@@ -86,6 +88,7 @@ type CreateContext struct {
 	IsPushEnabled      bool
 	Client             *api.Client
 	GitClient          *git.Client
+	IncludeProjectV1   bool
 }
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
@@ -434,7 +437,7 @@ func createRun(opts *CreateOptions) (err error) {
 				Repo:      ctx.BaseRepo,
 				State:     state,
 			}
-			err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.BaseRepo, fetcher, state)
+			err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.BaseRepo, fetcher, state, ctx.IncludeProjectV1)
 			if err != nil {
 				return
 			}
@@ -724,6 +727,15 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 		baseTrackingBranch = fmt.Sprintf("%s/%s", baseRemote.Name, baseBranch)
 	}
 
+	if opts.Detector == nil {
+		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
+		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
+	}
+	includeProjectV1, err := opts.Detector.ProjectV1()
+	if err != nil {
+		return nil, err
+	}
+
 	return &CreateContext{
 		BaseRepo:           baseRepo,
 		HeadRepo:           headRepo,
@@ -736,6 +748,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 		RepoContext:        repoContext,
 		Client:             client,
 		GitClient:          gitClient,
+		IncludeProjectV1:   includeProjectV1,
 	}, nil
 }
 
@@ -768,7 +781,7 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 		return errors.New("pull request title must not be blank")
 	}
 
-	err := shared.AddMetadataToIssueParams(client, ctx.BaseRepo, params, &state)
+	err := shared.AddMetadataToIssueParams(client, ctx.BaseRepo, params, &state, ctx.IncludeProjectV1)
 	if err != nil {
 		return err
 	}
@@ -991,7 +1004,7 @@ func generateCompareURL(ctx CreateContext, state shared.IssueMetadataState) (str
 		ctx.BaseRepo,
 		"compare/%s...%s?expand=1",
 		url.PathEscape(ctx.BaseBranch), url.PathEscape(ctx.HeadBranchLabel))
-	url, err := shared.WithPrAndIssueQueryParams(ctx.Client, ctx.BaseRepo, u, state)
+	url, err := shared.WithPrAndIssueQueryParams(ctx.Client, ctx.BaseRepo, u, state, ctx.IncludeProjectV1)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
@@ -1526,6 +1527,7 @@ func Test_createRun(t *testing.T) {
 				GhPath:  "some/path/gh",
 				GitPath: "some/path/git",
 			}
+			opts.Detector = &featuredetection.EnabledDetectorMock{}
 			cleanSetup := func() {}
 			if tt.setup != nil {
 				cleanSetup = tt.setup(&opts, t)

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -237,13 +237,13 @@ func editRun(opts *EditOptions) error {
 		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
 		opts.Detector = fd.NewDetector(cachedClient, repo.RepoHost())
 	}
-	includeProjectV1, err := opts.Detector.ProjectV1()
+	projectsV1Support, err := opts.Detector.ProjectsV1()
 	if err != nil {
 		return err
 	}
 
 	opts.IO.StartProgressIndicator()
-	err = opts.Fetcher.EditableOptionsFetch(apiClient, repo, &editable, includeProjectV1)
+	err = opts.Fetcher.EditableOptionsFetch(apiClient, repo, &editable, projectsV1Support)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
@@ -323,13 +323,13 @@ func (s surveyor) EditFields(editable *shared.Editable, editorCmd string) error 
 }
 
 type EditableOptionsFetcher interface {
-	EditableOptionsFetch(*api.Client, ghrepo.Interface, *shared.Editable, bool) error
+	EditableOptionsFetch(*api.Client, ghrepo.Interface, *shared.Editable, gh.ProjectsV1Support) error
 }
 
 type fetcher struct{}
 
-func (f fetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable, includeProjectV1 bool) error {
-	return shared.FetchOptions(client, repo, opts, includeProjectV1)
+func (f fetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable, projectsV1Support gh.ProjectsV1Support) error {
+	return shared.FetchOptions(client, repo, opts, projectsV1Support)
 }
 
 type EditorRetriever interface {

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/featuredetection"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	shared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -663,8 +664,8 @@ type testSurveyor struct {
 }
 type testEditorRetriever struct{}
 
-func (f testFetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable, includeProjectV1 bool) error {
-	return shared.FetchOptions(client, repo, opts, includeProjectV1)
+func (f testFetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable, projectsV1Support gh.ProjectsV1Support) error {
+	return shared.FetchOptions(client, repo, opts, projectsV1Support)
 }
 
 func (s testSurveyor) FieldsToEdit(e *shared.Editable) error {

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	shared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -502,6 +503,7 @@ func Test_editRun(t *testing.T) {
 
 			tt.input.IO = ios
 			tt.input.HttpClient = httpClient
+			tt.input.Detector = &featuredetection.EnabledDetectorMock{}
 
 			err := editRun(tt.input)
 			assert.NoError(t, err)
@@ -661,8 +663,8 @@ type testSurveyor struct {
 }
 type testEditorRetriever struct{}
 
-func (f testFetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable) error {
-	return shared.FetchOptions(client, repo, opts)
+func (f testFetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable, includeProjectV1 bool) error {
+	return shared.FetchOptions(client, repo, opts, includeProjectV1)
 }
 
 func (s testSurveyor) FieldsToEdit(e *shared.Editable) error {

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
@@ -45,6 +46,7 @@ type CommentableOptions struct {
 	EditLast              bool
 	Quiet                 bool
 	Host                  string
+	Detector              fd.Detector
 }
 
 func CommentablePreRun(cmd *cobra.Command, opts *CommentableOptions) error {

--- a/pkg/cmd/pr/shared/completion.go
+++ b/pkg/cmd/pr/shared/completion.go
@@ -14,7 +14,7 @@ import (
 func RequestableReviewersForCompletion(httpClient *http.Client, repo ghrepo.Interface) ([]string, error) {
 	client := api.NewClientFromHTTP(api.NewCachedHTTPClient(httpClient, time.Minute*2))
 
-	metadata, err := api.RepoMetadata(client, repo, api.RepoMetadataInput{Reviewers: true})
+	metadata, err := api.RepoMetadata(client, repo, api.RepoMetadataInput{Reviewers: true}, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pr/shared/completion.go
+++ b/pkg/cmd/pr/shared/completion.go
@@ -8,13 +8,14 @@ import (
 	"time"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 )
 
 func RequestableReviewersForCompletion(httpClient *http.Client, repo ghrepo.Interface) ([]string, error) {
 	client := api.NewClientFromHTTP(api.NewCachedHTTPClient(httpClient, time.Minute*2))
 
-	metadata, err := api.RepoMetadata(client, repo, api.RepoMetadataInput{Reviewers: true}, false)
+	metadata, err := api.RepoMetadata(client, repo, api.RepoMetadataInput{Reviewers: true}, gh.ProjectsV1Unsupported)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -376,7 +376,7 @@ func FieldsToEditSurvey(p EditPrompter, editable *Editable) error {
 	return nil
 }
 
-func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable) error {
+func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable, includeProjectV1 bool) error {
 	input := api.RepoMetadataInput{
 		Reviewers:  editable.Reviewers.Edited,
 		Assignees:  editable.Assignees.Edited,
@@ -384,7 +384,7 @@ func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable)
 		Projects:   editable.Projects.Edited,
 		Milestones: editable.Milestone.Edited,
 	}
-	metadata, err := api.RepoMetadata(client, repo, input)
+	metadata, err := api.RepoMetadata(client, repo, input, includeProjectV1)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/set"
 )
@@ -376,7 +377,7 @@ func FieldsToEditSurvey(p EditPrompter, editable *Editable) error {
 	return nil
 }
 
-func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable, includeProjectV1 bool) error {
+func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable, projectsV1Support gh.ProjectsV1Support) error {
 	input := api.RepoMetadataInput{
 		Reviewers:  editable.Reviewers.Edited,
 		Assignees:  editable.Assignees.Edited,
@@ -384,7 +385,7 @@ func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable,
 		Projects:   editable.Projects.Edited,
 		Milestones: editable.Milestone.Edited,
 	}
-	metadata, err := api.RepoMetadata(client, repo, input, includeProjectV1)
+	metadata, err := api.RepoMetadata(client, repo, input, projectsV1Support)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -16,6 +16,7 @@ import (
 	remotes "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/set"
@@ -165,11 +166,11 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 		fields.Remove("projectItems")
 	}
 	if fields.Contains("projectCards") {
-		includeProjectV1, err := opts.Detector.ProjectV1()
+		projectsV1Support, err := opts.Detector.ProjectsV1()
 		if err != nil {
 			return nil, nil, err
 		}
-		if !includeProjectV1 {
+		if projectsV1Support == gh.ProjectsV1Unsupported {
 			fields.Remove("projectCards")
 		}
 	}

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/search"
 	"github.com/google/shlex"
 )
 
-func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, baseURL string, state IssueMetadataState, includeProjectV1 bool) (string, error) {
+func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, baseURL string, state IssueMetadataState, projectsV1Support gh.ProjectsV1Support) (string, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return "", err
@@ -31,7 +32,7 @@ func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, ba
 		q.Set("labels", strings.Join(state.Labels, ","))
 	}
 	if len(state.Projects) > 0 {
-		projectPaths, err := api.ProjectNamesToPaths(client, baseRepo, state.Projects, includeProjectV1)
+		projectPaths, err := api.ProjectNamesToPaths(client, baseRepo, state.Projects, projectsV1Support)
 		if err != nil {
 			return "", fmt.Errorf("could not add to project: %w", err)
 		}
@@ -51,7 +52,7 @@ func ValidURL(urlStr string) bool {
 
 // Ensure that tb.MetadataResult object exists and contains enough pre-fetched API data to be able
 // to resolve all object listed in tb to GraphQL IDs.
-func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetadataState, includeProjectV1 bool) error {
+func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetadataState, projectsV1Support gh.ProjectsV1Support) error {
 	resolveInput := api.RepoResolveInput{}
 
 	if len(tb.Assignees) > 0 && (tb.MetadataResult == nil || len(tb.MetadataResult.AssignableUsers) == 0) {
@@ -74,7 +75,7 @@ func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetada
 		resolveInput.Milestones = tb.Milestones
 	}
 
-	metadataResult, err := api.RepoResolveMetadataIDs(client, baseRepo, resolveInput, includeProjectV1)
+	metadataResult, err := api.RepoResolveMetadataIDs(client, baseRepo, resolveInput, projectsV1Support)
 	if err != nil {
 		return err
 	}
@@ -88,12 +89,12 @@ func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetada
 	return nil
 }
 
-func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, params map[string]interface{}, tb *IssueMetadataState, includeProjectV1 bool) error {
+func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, params map[string]interface{}, tb *IssueMetadataState, projectsV1Support gh.ProjectsV1Support) error {
 	if !tb.HasMetadata() {
 		return nil
 	}
 
-	if err := fillMetadata(client, baseRepo, tb, includeProjectV1); err != nil {
+	if err := fillMetadata(client, baseRepo, tb, projectsV1Support); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -265,7 +265,7 @@ func Test_WithPrAndIssueQueryParams(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := WithPrAndIssueQueryParams(nil, nil, tt.args.baseURL, tt.args.state)
+			got, err := WithPrAndIssueQueryParams(nil, nil, tt.args.baseURL, tt.args.state, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("WithPrAndIssueQueryParams() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -265,7 +266,7 @@ func Test_WithPrAndIssueQueryParams(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := WithPrAndIssueQueryParams(nil, nil, tt.args.baseURL, tt.args.state, false)
+			got, err := WithPrAndIssueQueryParams(nil, nil, tt.args.baseURL, tt.args.state, gh.ProjectsV1Unsupported)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("WithPrAndIssueQueryParams() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -132,19 +132,19 @@ type MetadataFetcher struct {
 	State     *IssueMetadataState
 }
 
-func (mf *MetadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput) (*api.RepoMetadataResult, error) {
+func (mf *MetadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput, includeProjectV1 bool) (*api.RepoMetadataResult, error) {
 	mf.IO.StartProgressIndicator()
-	metadataResult, err := api.RepoMetadata(mf.APIClient, mf.Repo, input)
+	metadataResult, err := api.RepoMetadata(mf.APIClient, mf.Repo, input, includeProjectV1)
 	mf.IO.StopProgressIndicator()
 	mf.State.MetadataResult = metadataResult
 	return metadataResult, err
 }
 
 type RepoMetadataFetcher interface {
-	RepoMetadataFetch(api.RepoMetadataInput) (*api.RepoMetadataResult, error)
+	RepoMetadataFetch(api.RepoMetadataInput, bool) (*api.RepoMetadataResult, error)
 }
 
-func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher RepoMetadataFetcher, state *IssueMetadataState) error {
+func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher RepoMetadataFetcher, state *IssueMetadataState, includeProjectV1 bool) error {
 	isChosen := func(m string) bool {
 		for _, c := range state.Metadata {
 			if m == c {
@@ -177,7 +177,7 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 		Projects:   isChosen("Projects"),
 		Milestones: isChosen("Milestone"),
 	}
-	metadataResult, err := fetcher.RepoMetadataFetch(metadataInput)
+	metadataResult, err := fetcher.RepoMetadataFetch(metadataInput, includeProjectV1)
 	if err != nil {
 		return fmt.Errorf("error fetching metadata options: %w", err)
 	}

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -132,19 +132,19 @@ type MetadataFetcher struct {
 	State     *IssueMetadataState
 }
 
-func (mf *MetadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput, includeProjectV1 bool) (*api.RepoMetadataResult, error) {
+func (mf *MetadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput, projectsV1Support gh.ProjectsV1Support) (*api.RepoMetadataResult, error) {
 	mf.IO.StartProgressIndicator()
-	metadataResult, err := api.RepoMetadata(mf.APIClient, mf.Repo, input, includeProjectV1)
+	metadataResult, err := api.RepoMetadata(mf.APIClient, mf.Repo, input, projectsV1Support)
 	mf.IO.StopProgressIndicator()
 	mf.State.MetadataResult = metadataResult
 	return metadataResult, err
 }
 
 type RepoMetadataFetcher interface {
-	RepoMetadataFetch(api.RepoMetadataInput, bool) (*api.RepoMetadataResult, error)
+	RepoMetadataFetch(api.RepoMetadataInput, gh.ProjectsV1Support) (*api.RepoMetadataResult, error)
 }
 
-func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher RepoMetadataFetcher, state *IssueMetadataState, includeProjectV1 bool) error {
+func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher RepoMetadataFetcher, state *IssueMetadataState, projectsV1Support gh.ProjectsV1Support) error {
 	isChosen := func(m string) bool {
 		for _, c := range state.Metadata {
 			if m == c {
@@ -177,7 +177,7 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 		Projects:   isChosen("Projects"),
 		Milestones: isChosen("Milestone"),
 	}
-	metadataResult, err := fetcher.RepoMetadataFetch(metadataInput, includeProjectV1)
+	metadataResult, err := fetcher.RepoMetadataFetch(metadataInput, projectsV1Support)
 	if err != nil {
 		return fmt.Errorf("error fetching metadata options: %w", err)
 	}

--- a/pkg/cmd/pr/shared/survey_test.go
+++ b/pkg/cmd/pr/shared/survey_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -14,7 +15,7 @@ type metadataFetcher struct {
 	metadataResult *api.RepoMetadataResult
 }
 
-func (mf *metadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput, includeProjectV1 bool) (*api.RepoMetadataResult, error) {
+func (mf *metadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput, projectsV1Support gh.ProjectsV1Support) (*api.RepoMetadataResult, error) {
 	return mf.metadataResult, nil
 }
 
@@ -68,7 +69,7 @@ func TestMetadataSurvey_selectAll(t *testing.T) {
 		Assignees: []string{"hubot"},
 		Type:      PRMetadata,
 	}
-	err := MetadataSurvey(pm, ios, repo, fetcher, state, true)
+	err := MetadataSurvey(pm, ios, repo, fetcher, state, gh.ProjectsV1Supported)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())
@@ -113,7 +114,7 @@ func TestMetadataSurvey_keepExisting(t *testing.T) {
 	state := &IssueMetadataState{
 		Assignees: []string{"hubot"},
 	}
-	err := MetadataSurvey(pm, ios, repo, fetcher, state, true)
+	err := MetadataSurvey(pm, ios, repo, fetcher, state, gh.ProjectsV1Supported)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())

--- a/pkg/cmd/pr/shared/survey_test.go
+++ b/pkg/cmd/pr/shared/survey_test.go
@@ -14,7 +14,7 @@ type metadataFetcher struct {
 	metadataResult *api.RepoMetadataResult
 }
 
-func (mf *metadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput) (*api.RepoMetadataResult, error) {
+func (mf *metadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput, includeProjectV1 bool) (*api.RepoMetadataResult, error) {
 	return mf.metadataResult, nil
 }
 
@@ -68,7 +68,7 @@ func TestMetadataSurvey_selectAll(t *testing.T) {
 		Assignees: []string{"hubot"},
 		Type:      PRMetadata,
 	}
-	err := MetadataSurvey(pm, ios, repo, fetcher, state)
+	err := MetadataSurvey(pm, ios, repo, fetcher, state, true)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())
@@ -113,7 +113,7 @@ func TestMetadataSurvey_keepExisting(t *testing.T) {
 	state := &IssueMetadataState{
 		Assignees: []string{"hubot"},
 	}
-	err := MetadataSurvey(pm, ios, repo, fetcher, state)
+	err := MetadataSurvey(pm, ios, repo, fetcher, state, true)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())


### PR DESCRIPTION
Relates #9430 

This commit is an alternative approach from #9454 in several regards:

1. Using a separate feature detection method, avoiding the need to modify repository feature detection
2. Adding feature detector to other commands, avoiding the need to mock GraphQL calls in tests
3. Conditionally including `ProjectCards` field in `Issue` and `PullRequest`
4. Temporarily including `INCLUDE_PROJECT_V1` environment variable, allowing maintainers to manually test with v1 project support on or off while automated tests can be written

I want to emphasize that this PR is being merged into `cli-9430` rather than `trunk` because the scope of #9430 should include automated testing and likely other enhancements.  This is an attempt to get a basis that @jtmcg and myself can use to build upon.

## Demonstration

The following primitives are being used for testing:

- **Project V1:** https://github.com/cli/cli/projects/1
- **Issue:** https://github.com/cli/cli/issues/9430
- **PR:** https://github.com/cli/cli/pull/9497

<details>
<summary>
  <b>Building local <code>gh</code> for testing</b>
</summary>
<p>

```shell
$ make
go build -trimpath -ldflags "-X github.com/cli/cli/v2/internal/build.Date=2024-08-21 -X github.com/cli/cli/v2/internal/build.Version=v2.54.0-53-g1a61d868 " -o bin/gh ./cmd/gh
```

</p>
</details>


### `gh issue view`

<details>
<summary>
  <b><code>gh issue view</code> with v1 project included</b>
</summary>
<p>

```shell
$ ./bin/gh issue view https://github.com/cli/cli/issues/9430
V1 (Classic) Projects sunsetting migration plans cli/cli#9430
Open • jtmcg opened about 14 days ago • 1 comment
2 ❤️
Assignees: andyfeller, jtmcg
Labels: core, gh-issue, gh-pr, gh-search
Projects: The GitHub CLI (Backlog 🗒)


  ## Introduction                                                                                                     
                                                                                                                      
  Hello y'all 👋 GitHub CLI team here to add some transparency to some upcoming work we have planned around making the
  CLI ready for the upcoming v1 projects migration https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/.
                                                                                                                      
  The good news: there's not a lot to do and it probably won't impact you 🎉                                          
                                                                                                                      
  The  gh projects  commands were designed only for v2 projects, so nothing changes here.                             
                                                                                                                      
  The other commands that do touch both v1 and v2 projects currently work for both, so there's not much to do to make 
  this migration seamless. I'll outline our plans below.                                                              
                                                                                                                      
  ## What we're doing to prepare                                                                                      
                                                                                                                      
  The following commands will be impacted:                                                                            
                                                                                                                      
  • gh issue create --project https://github.com/cli/cli/blob/trunk/pkg/cmd/issue/create/create.go                    
  • gh issue edit --add-project https://github.com/cli/cli/blob/trunk/pkg/cmd/issue/edit/edit.go                      
  • gh issue edit --remove-project https://github.com/cli/cli/blob/trunk/pkg/cmd/issue/edit/edit.go                   
  • gh pr create --project https://github.com/cli/cli/blob/trunk/pkg/cmd/pr/create/create.go                          
  • gh pr edit --add-project https://github.com/cli/cli/blob/trunk/pkg/cmd/pr/edit/edit.go                            
  • gh pr edit --remove-project https://github.com/cli/cli/blob/trunk/pkg/cmd/pr/edit/edit.go                         
                                                                                                                      
  However, there's only a handful of things we need to do to each:                                                    
                                                                                                                      
  ### Change the  --project <name>  flag to  --project <title>                                                        
                                                                                                                      
  This is entirely cosmetic.  name  was how we referred to projects in v1, while  title  is how we refer to projects  
  in v2. We expect this docs update will help those transitioning from v1 to v2. Here's an example of the code that   
  will be changed for gh issue create --project                                                                       
  https://github.com/cli/cli/blob/86964d8809bed7bfbd798d444d5923b8a2bbd4d6/pkg/cmd/issue/create/create.go#L140.       
                                                                                                                      
  ### Update  --project <number>  flags in  gh search  to  --project <owner>/<number>                                 
                                                                                                                      
  Once again, entirely cosmetic. GitHub search requires the  <owner>/<number>  to be provided for searching projects  
  in the UI and CLI alike for v2 projects, so we're updating the docs to reflect this with the same motivation as     
  above. Here's an example of the code that will be changed for gh search issue --project                             
  https://github.com/cli/cli/blob/86964d8809bed7bfbd798d444d5923b8a2bbd4d6/pkg/cmd/search/issues/issues.go#L160       
                                                                                                                      
  ### Prepare for the REST API sunset on November 19, 2024                                                            
                                                                                                                      
  We're doing some feature detection                                                                                  
  https://github.com/cli/cli/blob/trunk/internal/featuredetection/feature_detection.go work to determine whether or   
  not the API contains the concept of v1 projects so we can gracefully handle GitHub Enterprise Server (GHES) and our 
  cloud product side-by-side. We support older versions of our GHES offering for a year after they are released, so GHES
  customers will still have access to their local v1 api version for a full year after it gets turned off for cloud.  
  The work we're doing here will both ensure a smooth transition when the API is sunset on November 19th, 2024, as    
  well as allow us to support GHES customers for the following year.                                                  
                                                                                                                      
  ## How to get involved                                                                                              
                                                                                                                      
  We've got these updates ourselves, but we'd appreciate any and all feedback around the CLI in regards to the        
  migration. If you encounter anything, create an issue https://github.com/cli/cli/issues/new and let us know what's  
  going on.                                                                                                           


Danysharma00 • This comment has been marked as SPAM


View this issue on GitHub: https://github.com/cli/cli/issues/9430
```

</p>
</details> 
<details>
<summary>
  <b><code>gh issue view</code> without v1 project included</b>
</summary>
<p>

```shell
$ INCLUDE_PROJECT_V1=false ./bin/gh issue view https://github.com/cli/cli/issues/9430
V1 (Classic) Projects sunsetting migration plans cli/cli#9430
Open • jtmcg opened about 14 days ago • 1 comment
2 ❤️
Assignees: andyfeller, jtmcg
Labels: core, gh-issue, gh-pr, gh-search


  ## Introduction                                                                                                     
                                                                                                                      
  Hello y'all 👋 GitHub CLI team here to add some transparency to some upcoming work we have planned around making the
  CLI ready for the upcoming v1 projects migration https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/.
                                                                                                                      
  The good news: there's not a lot to do and it probably won't impact you 🎉                                          
                                                                                                                      
  The  gh projects  commands were designed only for v2 projects, so nothing changes here.                             
                                                                                                                      
  The other commands that do touch both v1 and v2 projects currently work for both, so there's not much to do to make 
  this migration seamless. I'll outline our plans below.                                                              
                                                                                                                      
  ## What we're doing to prepare                                                                                      
                                                                                                                      
  The following commands will be impacted:                                                                            
                                                                                                                      
  • gh issue create --project https://github.com/cli/cli/blob/trunk/pkg/cmd/issue/create/create.go                    
  • gh issue edit --add-project https://github.com/cli/cli/blob/trunk/pkg/cmd/issue/edit/edit.go                      
  • gh issue edit --remove-project https://github.com/cli/cli/blob/trunk/pkg/cmd/issue/edit/edit.go                   
  • gh pr create --project https://github.com/cli/cli/blob/trunk/pkg/cmd/pr/create/create.go                          
  • gh pr edit --add-project https://github.com/cli/cli/blob/trunk/pkg/cmd/pr/edit/edit.go                            
  • gh pr edit --remove-project https://github.com/cli/cli/blob/trunk/pkg/cmd/pr/edit/edit.go                         
                                                                                                                      
  However, there's only a handful of things we need to do to each:                                                    
                                                                                                                      
  ### Change the  --project <name>  flag to  --project <title>                                                        
                                                                                                                      
  This is entirely cosmetic.  name  was how we referred to projects in v1, while  title  is how we refer to projects  
  in v2. We expect this docs update will help those transitioning from v1 to v2. Here's an example of the code that   
  will be changed for gh issue create --project                                                                       
  https://github.com/cli/cli/blob/86964d8809bed7bfbd798d444d5923b8a2bbd4d6/pkg/cmd/issue/create/create.go#L140.       
                                                                                                                      
  ### Update  --project <number>  flags in  gh search  to  --project <owner>/<number>                                 
                                                                                                                      
  Once again, entirely cosmetic. GitHub search requires the  <owner>/<number>  to be provided for searching projects  
  in the UI and CLI alike for v2 projects, so we're updating the docs to reflect this with the same motivation as     
  above. Here's an example of the code that will be changed for gh search issue --project                             
  https://github.com/cli/cli/blob/86964d8809bed7bfbd798d444d5923b8a2bbd4d6/pkg/cmd/search/issues/issues.go#L160       
                                                                                                                      
  ### Prepare for the REST API sunset on November 19, 2024                                                            
                                                                                                                      
  We're doing some feature detection                                                                                  
  https://github.com/cli/cli/blob/trunk/internal/featuredetection/feature_detection.go work to determine whether or   
  not the API contains the concept of v1 projects so we can gracefully handle GitHub Enterprise Server (GHES) and our 
  cloud product side-by-side. We support older versions of our GHES offering for a year after they are released, so GHES
  customers will still have access to their local v1 api version for a full year after it gets turned off for cloud.  
  The work we're doing here will both ensure a smooth transition when the API is sunset on November 19th, 2024, as    
  well as allow us to support GHES customers for the following year.                                                  
                                                                                                                      
  ## How to get involved                                                                                              
                                                                                                                      
  We've got these updates ourselves, but we'd appreciate any and all feedback around the CLI in regards to the        
  migration. If you encounter anything, create an issue https://github.com/cli/cli/issues/new and let us know what's  
  going on.                                                                                                           


Danysharma00 • This comment has been marked as SPAM


View this issue on GitHub: https://github.com/cli/cli/issues/9430
```

</p>
</details> 


<details>
<summary>
  <b><code>gh issue view --json projectCards</code> with v1 project included</b>
</summary>
<p>

```shell
$ ./bin/gh issue view https://github.com/cli/cli/issues/9430 --json projectCards
{
  "projectCards": [
    {
      "project": {
        "name": "The GitHub CLI"
      },
      "column": {
        "name": "Backlog 🗒"
      }
    }
  ]
}
```

</p>
</details> 

<details>
<summary>
  <b><code>gh issue view --json projectCards</code> without v1 project included</b>
</summary>
<p>

```shell
$ INCLUDE_PROJECT_V1=false ./bin/gh issue view https://github.com/cli/cli/issues/9430 --json projectCards
{
  "projectCards": null
}
```

</p>
</details> 


### `gh pr view`

<details>
<summary>
  <b><code>gh pr view</code> with v1 project included</b>
</summary>
<p>

```shell
$ ./bin/gh pr view https://github.com/cli/cli/pull/9497
Fix `pr checkout`, non-branch starting point cli/cli#9497
Open • muzimuzhi wants to merge 1 commit into trunk from fix/pr-checkout-with-restricted-remote-fetch • about 3 hours ago
+6 -0 • ✓ Checks passing
Reviewers: cli/code-reviewers (Requested), williammartin (Requested)
Labels: external
Projects: The GitHub CLI (Needs review 🤔)


  Fixes #4287                                                                                                         
                                                                                                                      
  Need help mocking a restricted  remote.origin.fetch  config in test.                                                


View this pull request on GitHub: https://github.com/cli/cli/pull/9497
andyfeller@Andys-MBP:cli/cli ‹cli-9430-fd›$ INCLUDE_V1_PROJECTS=false ./bin/
```

</p>
</details> 

<details>
<summary>
  <b><code>gh pr view</code> without v1 project included</b>
</summary>
<p>

```shell
$ INCLUDE_PROJECT_V1=false ./bin/gh pr view https://github.com/cli/cli/pull/9497
Fix `pr checkout`, non-branch starting point cli/cli#9497
Open • muzimuzhi wants to merge 1 commit into trunk from fix/pr-checkout-with-restricted-remote-fetch • about 3 hours ago
+6 -0 • ✓ Checks passing
Reviewers: cli/code-reviewers (Requested), williammartin (Requested)
Labels: external


  Fixes #4287                                                                                                         
                                                                                                                      
  Need help mocking a restricted  remote.origin.fetch  config in test.                                                


View this pull request on GitHub: https://github.com/cli/cli/pull/9497
```

</p>
</details> 




<details>
<summary>
  <b><code>gh pr view --json projectCards</code> with v1 project included</b>
</summary>
<p>

```shell
$ ./bin/gh pr view https://github.com/cli/cli/pull/9497 --json projectCards      
{
  "projectCards": [
    {
      "project": {
        "name": "The GitHub CLI"
      },
      "column": {
        "name": "Needs review 🤔"
      }
    }
  ]
}
```

</p>
</details> 

<details>
<summary>
  <b><code>gh pr view --json projectCards</code> without v1 project included</b>
</summary>
<p>

```shell
$ INCLUDE_PROJECT_V1=false ./bin/gh pr view https://github.com/cli/cli/pull/9497 --json projectCards
{
  "projectCards": null
}
```

</p>
</details> 