### PR TITLE
Minor changes to `gh repo create`

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -855,17 +855,22 @@ func interactiveRepoInfo(client *http.Client, hostname string, prompter iprompte
 		return "", "", "", err
 	}
 
-	visibilityOptions := []string{"Public", "Private"}
-	// orgs can also create internal repos
-	if owner != "" {
-		visibilityOptions = append(visibilityOptions, "Internal")
-	}
+	visibilityOptions := getRepoVisibilityOptions(owner)
 	selected, err := prompter.Select("Visibility", "Public", visibilityOptions)
 	if err != nil {
 		return "", "", "", err
 	}
 
 	return name, description, strings.ToUpper(visibilityOptions[selected]), nil
+}
+
+func getRepoVisibilityOptions(owner string) []string {
+	visibilityOptions := []string{"Public", "Private"}
+	// orgs can also create internal repos
+	if owner != "" {
+		visibilityOptions = append(visibilityOptions, "Internal")
+	}
+	return visibilityOptions
 }
 
 func interactiveRepoNameAndOwner(client *http.Client, hostname string, prompter iprompter, defaultName string) (string, string, error) {

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -855,7 +855,11 @@ func interactiveRepoInfo(client *http.Client, hostname string, prompter iprompte
 		return "", "", "", err
 	}
 
-	visibilityOptions := []string{"Public", "Private", "Internal"}
+	visibilityOptions := []string{"Public", "Private"}
+	// orgs can also create internal repos
+	if owner != "" {
+		visibilityOptions = append(visibilityOptions, "Internal")
+	}
 	selected, err := prompter.Select("Visibility", "Public", visibilityOptions)
 	if err != nil {
 		return "", "", "", err

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -866,3 +866,27 @@ func Test_createRun(t *testing.T) {
 		})
 	}
 }
+
+func Test_getRepoVisibilityOptions(t *testing.T) {
+	tests := []struct {
+		name  string
+		owner string
+		want  []string
+	}{
+		{
+			name:  "user repo",
+			owner: "",
+			want:  []string{"Public", "Private"},
+		},
+		{
+			name:  "org repo",
+			owner: "fooOrg",
+			want:  []string{"Public", "Private", "Internal"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, getRepoVisibilityOptions(tt.owner))
+		})
+	}
+}

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -639,9 +639,9 @@ func Test_createRun(t *testing.T) {
 		{
 			name: "noninteractive create from scratch",
 			opts: &CreateOptions{
-				Interactive: false,
-				Name:        "REPO",
-				Visibility:  "PRIVATE",
+				Interactive:      false,
+				Name:             "REPO",
+				VisibilityOption: VisibilityOptionPrivate,
 			},
 			tty: false,
 			httpStubs: func(reg *httpmock.Registry) {
@@ -666,10 +666,10 @@ func Test_createRun(t *testing.T) {
 		{
 			name: "noninteractive create from source",
 			opts: &CreateOptions{
-				Interactive: false,
-				Source:      ".",
-				Name:        "REPO",
-				Visibility:  "PRIVATE",
+				Interactive:      false,
+				Source:           ".",
+				Name:             "REPO",
+				VisibilityOption: VisibilityOptionPrivate,
 			},
 			tty: false,
 			httpStubs: func(reg *httpmock.Registry) {
@@ -699,10 +699,10 @@ func Test_createRun(t *testing.T) {
 		{
 			name: "noninteractive clone from scratch",
 			opts: &CreateOptions{
-				Interactive: false,
-				Name:        "REPO",
-				Visibility:  "PRIVATE",
-				Clone:       true,
+				Interactive:      false,
+				Name:             "REPO",
+				VisibilityOption: VisibilityOptionPrivate,
+				Clone:            true,
 			},
 			tty: false,
 			httpStubs: func(reg *httpmock.Registry) {
@@ -731,11 +731,11 @@ func Test_createRun(t *testing.T) {
 		{
 			name: "noninteractive clone with readme",
 			opts: &CreateOptions{
-				Interactive: false,
-				Name:        "ElliotAlderson",
-				Visibility:  "PRIVATE",
-				Clone:       true,
-				AddReadme:   true,
+				Interactive:      false,
+				Name:             "ElliotAlderson",
+				VisibilityOption: VisibilityOptionPrivate,
+				Clone:            true,
+				AddReadme:        true,
 			},
 			tty: false,
 			httpStubs: func(reg *httpmock.Registry) {
@@ -760,12 +760,12 @@ func Test_createRun(t *testing.T) {
 		{
 			name: "noninteractive create from template with retry",
 			opts: &CreateOptions{
-				Interactive: false,
-				Name:        "REPO",
-				Visibility:  "PRIVATE",
-				Clone:       true,
-				Template:    "mytemplate",
-				BackOff:     &backoff.ZeroBackOff{},
+				Interactive:      false,
+				Name:             "REPO",
+				VisibilityOption: VisibilityOptionPrivate,
+				Clone:            true,
+				Template:         "mytemplate",
+				BackOff:          &backoff.ZeroBackOff{},
 			},
 			tty: false,
 			httpStubs: func(reg *httpmock.Registry) {
@@ -871,18 +871,23 @@ func Test_getRepoVisibilityOptions(t *testing.T) {
 	tests := []struct {
 		name  string
 		owner string
-		want  []string
+		want  visibilityOptions
 	}{
 		{
 			name:  "user repo",
 			owner: "",
-			want:  []string{"Public", "Private"},
+			want: visibilityOptions{
+				def:  VisibilityOptionPublic,
+				rest: []VisibilityOption{VisibilityOptionPrivate},
+			},
 		},
 		{
 			name:  "org repo",
 			owner: "fooOrg",
-			want:  []string{"Public", "Private", "Internal"},
-		},
+			want: visibilityOptions{
+				def:  VisibilityOptionPublic,
+				rest: []VisibilityOption{VisibilityOptionPrivate, VisibilityOptionInternal},
+			}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -856,11 +856,11 @@ func Test_createRun(t *testing.T) {
 			defer reg.Verify(t)
 			err := createRun(tt.opts)
 			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Equal(t, tt.errMsg, err.Error())
+				require.Error(t, err)
+				require.Equal(t, tt.errMsg, err.Error())
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantStdout, stdout.String())
 			assert.Equal(t, "", stderr.String())
 		})

--- a/pkg/cmd/repo/create/http.go
+++ b/pkg/cmd/repo/create/http.go
@@ -99,6 +99,11 @@ func repoCreate(client *http.Client, hostname string, input repoCreateInput) (*a
 		isOrg = owner.IsOrganization()
 	}
 
+	isInternal := strings.ToLower(input.Visibility) == "internal"
+	if isInternal && !isOrg {
+		return nil, fmt.Errorf("internal repositories can only be created within an organization")
+	}
+
 	if input.TemplateRepositoryID != "" {
 		var response struct {
 			CloneTemplateRepository struct {

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -728,13 +728,9 @@ func Test_repoCreate(t *testing.T) {
 				r.Register(
 					httpmock.REST("GET", "users/OWNER"),
 					httpmock.StringResponse(`{ "node_id": "1234", "type": "Not-Org" }`))
-				r.Register(
+				r.Exclude(
+					t,
 					httpmock.REST("POST", "user/repos"),
-					httpmock.RESTPayload(201, `{
-						"name":"winter-foods", 
-						"owner":{"login": "OWNER"}, 
-						"html_url":"the://URL"
-					}`, func(payload map[string]interface{}) {}),
 				)
 			},
 		},

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -696,19 +696,9 @@ func Test_repoCreate(t *testing.T) {
 				r.Register(
 					httpmock.REST("GET", "users/OWNER"),
 					httpmock.StringResponse(`{ "node_id": "1234", "type": "Not-Org" }`))
-				r.Register(
+				r.Exclude(
+					t,
 					httpmock.GraphQL(`mutation RepositoryCreate\b`),
-					httpmock.GraphQLMutation(
-						`{
-							"errors": [
-								{
-									"message": "Only organization-owned repositories can have internal visibility",
-								}
-							],
-							"data": null
-							}
-						}`,
-						func(map[string]interface{}) {}),
 				)
 			},
 		},

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -16,6 +16,7 @@ func Test_repoCreate(t *testing.T) {
 		input    repoCreateInput
 		stubs    func(t *testing.T, r *httpmock.Registry)
 		wantErr  bool
+		errMsg   string
 		wantRepo string
 	}{
 		{
@@ -692,6 +693,7 @@ func Test_repoCreate(t *testing.T) {
 				OwnerLogin:  "OWNER",
 			},
 			wantErr: true,
+			errMsg:  "internal repositories can only be created within an organization",
 			stubs: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.REST("GET", "users/OWNER"),
@@ -714,6 +716,7 @@ func Test_repoCreate(t *testing.T) {
 				InitReadme:  true,
 			},
 			wantErr: true,
+			errMsg:  "internal repositories can only be created within an organization",
 			stubs: func(t *testing.T, r *httpmock.Registry) {
 				r.Register(
 					httpmock.REST("GET", "users/OWNER"),
@@ -734,6 +737,9 @@ func Test_repoCreate(t *testing.T) {
 			r, err := repoCreate(httpClient, tt.hostname, tt.input)
 			if tt.wantErr {
 				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.ErrorContains(t, err, tt.errMsg)
+				}
 				return
 			} else {
 				assert.NoError(t, err)

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -27,7 +27,7 @@ func Test_repoCreate(t *testing.T) {
 				Name:             "winter-foods",
 				Description:      "roasted chestnuts",
 				HomepageURL:      "http://example.com",
-				Visibility:       "public",
+				Visibility:       visibilityPublic,
 				HasIssuesEnabled: true,
 				HasWikiEnabled:   true,
 			},
@@ -68,7 +68,7 @@ func Test_repoCreate(t *testing.T) {
 				Name:             "winter-foods",
 				Description:      "roasted chestnuts",
 				HomepageURL:      "http://example.com",
-				Visibility:       "public",
+				Visibility:       visibilityPublic,
 				HasIssuesEnabled: true,
 				HasWikiEnabled:   true,
 			},
@@ -107,7 +107,7 @@ func Test_repoCreate(t *testing.T) {
 			hostname: "github.com",
 			input: repoCreateInput{
 				Name:             "crisps",
-				Visibility:       "internal",
+				Visibility:       visibilityInternal,
 				OwnerLogin:       "snacks-inc",
 				HasIssuesEnabled: true,
 				HasWikiEnabled:   true,
@@ -149,7 +149,7 @@ func Test_repoCreate(t *testing.T) {
 			hostname: "github.com",
 			input: repoCreateInput{
 				Name:             "crisps",
-				Visibility:       "internal",
+				Visibility:       visibilityInternal,
 				OwnerLogin:       "snacks-inc",
 				TeamSlug:         "munchies",
 				HasIssuesEnabled: true,
@@ -194,7 +194,7 @@ func Test_repoCreate(t *testing.T) {
 			input: repoCreateInput{
 				Name:                 "gen-project",
 				Description:          "my generated project",
-				Visibility:           "private",
+				Visibility:           visibilityPrivate,
 				TemplateRepositoryID: "TPLID",
 				HasIssuesEnabled:     true,
 				HasWikiEnabled:       true,
@@ -239,7 +239,7 @@ func Test_repoCreate(t *testing.T) {
 			input: repoCreateInput{
 				Name:                 "gen-project",
 				Description:          "my generated project",
-				Visibility:           "private",
+				Visibility:           visibilityPrivate,
 				TemplateRepositoryID: "TPLID",
 				HasIssuesEnabled:     true,
 				HasWikiEnabled:       false,
@@ -304,7 +304,7 @@ func Test_repoCreate(t *testing.T) {
 			input: repoCreateInput{
 				Name:                 "gen-project",
 				Description:          "my generated project",
-				Visibility:           "private",
+				Visibility:           visibilityPrivate,
 				TemplateRepositoryID: "TPLID",
 				HasIssuesEnabled:     false,
 				HasWikiEnabled:       true,
@@ -369,7 +369,7 @@ func Test_repoCreate(t *testing.T) {
 			input: repoCreateInput{
 				Name:                 "gen-project",
 				Description:          "my generated project",
-				Visibility:           "private",
+				Visibility:           visibilityPrivate,
 				TemplateRepositoryID: "TPLID",
 				HasIssuesEnabled:     false,
 				HasWikiEnabled:       false,
@@ -434,7 +434,7 @@ func Test_repoCreate(t *testing.T) {
 			input: repoCreateInput{
 				Name:                 "gen-project",
 				Description:          "my generated project",
-				Visibility:           "private",
+				Visibility:           visibilityPrivate,
 				TemplateRepositoryID: "TPLID",
 				HasIssuesEnabled:     true,
 				HasWikiEnabled:       true,
@@ -546,7 +546,7 @@ func Test_repoCreate(t *testing.T) {
 			hostname: "github.com",
 			input: repoCreateInput{
 				Name:              "crisps",
-				Visibility:        "private",
+				Visibility:        visibilityPrivate,
 				LicenseTemplate:   "lgpl-3.0",
 				GitIgnoreTemplate: "Go",
 				HasIssuesEnabled:  true,
@@ -595,7 +595,7 @@ func Test_repoCreate(t *testing.T) {
 			hostname: "example.com",
 			input: repoCreateInput{
 				Name:              "crisps",
-				Visibility:        "private",
+				Visibility:        visibilityPrivate,
 				LicenseTemplate:   "lgpl-3.0",
 				GitIgnoreTemplate: "Go",
 				HasIssuesEnabled:  true,
@@ -622,7 +622,7 @@ func Test_repoCreate(t *testing.T) {
 			hostname: "github.com",
 			input: repoCreateInput{
 				Name:              "crisps",
-				Visibility:        "INTERNAL",
+				Visibility:        visibilityInternal,
 				OwnerLogin:        "snacks-inc",
 				LicenseTemplate:   "lgpl-3.0",
 				GitIgnoreTemplate: "Go",
@@ -654,7 +654,7 @@ func Test_repoCreate(t *testing.T) {
 			hostname: "github.com",
 			input: repoCreateInput{
 				Name:              "crisps",
-				Visibility:        "internal",
+				Visibility:        visibilityInternal,
 				OwnerLogin:        "snacks-inc",
 				TeamSlug:          "munchies",
 				LicenseTemplate:   "lgpl-3.0",

--- a/pkg/cmd/repo/create/http_test.go
+++ b/pkg/cmd/repo/create/http_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_repoCreate(t *testing.T) {
@@ -736,14 +737,14 @@ func Test_repoCreate(t *testing.T) {
 			httpClient := &http.Client{Transport: reg}
 			r, err := repoCreate(httpClient, tt.hostname, tt.input)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errMsg != "" {
 					assert.ErrorContains(t, err, tt.errMsg)
 				}
 				return
-			} else {
-				assert.NoError(t, err)
 			}
+
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantRepo, ghrepo.GenerateRepoURL(r, ""))
 		})
 	}

--- a/pkg/httpmock/registry.go
+++ b/pkg/httpmock/registry.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Replace http.Client transport layer with registry so all requests get
@@ -25,6 +28,18 @@ func (r *Registry) Register(m Matcher, resp Responder) {
 	})
 }
 
+func (r *Registry) Exclude(t *testing.T, m Matcher) {
+	excludedStub := &Stub{
+		Matcher: m,
+		Responder: func(req *http.Request) (*http.Response, error) {
+			assert.FailNowf(t, "Exclude error", "API called when excluded: %v", req.URL)
+			return nil, nil
+		},
+		exclude: true,
+	}
+	r.stubs = append(r.stubs, excludedStub)
+}
+
 type Testing interface {
 	Errorf(string, ...interface{})
 	Helper()
@@ -33,7 +48,7 @@ type Testing interface {
 func (r *Registry) Verify(t Testing) {
 	n := 0
 	for _, s := range r.stubs {
-		if !s.matched {
+		if !s.matched && !s.exclude {
 			n++
 		}
 	}
@@ -62,6 +77,7 @@ func (r *Registry) RoundTrip(req *http.Request) (*http.Response, error) {
 		stub = s
 		break // TODO: remove
 	}
+
 	if stub != nil {
 		stub.matched = true
 	}

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -18,6 +18,7 @@ type Stub struct {
 	matched   bool
 	Matcher   Matcher
 	Responder Responder
+	exclude   bool
 }
 
 func MatchAny(*http.Request) bool {


### PR DESCRIPTION
- **Exit repo create http tests under error conditions**
- **Exit in repo creation tests under error**
- **Provide typing for visibility in repo creation**

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
