### PR TITLE
Add type safety and readability to ProjectV1 support code

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"golang.org/x/sync/errgroup"
 
@@ -851,7 +852,7 @@ type RepoMetadataInput struct {
 }
 
 // RepoMetadata pre-fetches the metadata for attaching to issues and pull requests
-func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput, includeProjectV1 bool) (*RepoMetadataResult, error) {
+func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput, projectsV1Support gh.ProjectsV1Support) (*RepoMetadataResult, error) {
 	var result RepoMetadataResult
 	var g errgroup.Group
 
@@ -900,7 +901,7 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 	if input.Projects {
 		g.Go(func() error {
 			var err error
-			result.Projects, result.ProjectsV2, err = relevantProjects(client, repo, includeProjectV1)
+			result.Projects, result.ProjectsV2, err = relevantProjects(client, repo, projectsV1Support)
 			return err
 		})
 	}
@@ -931,7 +932,7 @@ type RepoResolveInput struct {
 }
 
 // RepoResolveMetadataIDs looks up GraphQL node IDs in bulk
-func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoResolveInput, includeProjectV1 bool) (*RepoMetadataResult, error) {
+func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoResolveInput, projectsV1Support gh.ProjectsV1Support) (*RepoMetadataResult, error) {
 	users := input.Assignees
 	hasUser := func(target string) bool {
 		for _, u := range users {
@@ -956,7 +957,7 @@ func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoRes
 		Projects:   len(input.Projects) > 0,
 		Milestones: len(input.Milestones) > 0,
 	}
-	result, err := RepoMetadata(client, repo, mi, includeProjectV1)
+	result, err := RepoMetadata(client, repo, mi, projectsV1Support)
 	if err != nil {
 		return result, err
 	}
@@ -1220,8 +1221,8 @@ func RepoMilestones(client *Client, repo ghrepo.Interface, state string) ([]Repo
 	return milestones, nil
 }
 
-func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []string, includeProjectV1 bool) ([]string, error) {
-	projects, projectsV2, err := relevantProjects(client, repo, includeProjectV1)
+func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []string, projectsV1Support gh.ProjectsV1Support) ([]string, error) {
+	projects, projectsV2, err := relevantProjects(client, repo, projectsV1Support)
 	if err != nil {
 		return nil, err
 	}
@@ -1234,7 +1235,7 @@ func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []s
 // - ProjectsV2 owned by current user
 // - ProjectsV2 linked to repository
 // - ProjectsV2 owned by repository organization, if it belongs to one
-func relevantProjects(client *Client, repo ghrepo.Interface, includeProjectV1 bool) ([]RepoProject, []ProjectV2, error) {
+func relevantProjects(client *Client, repo ghrepo.Interface, projectsV1Support gh.ProjectsV1Support) ([]RepoProject, []ProjectV2, error) {
 	var repoProjects []RepoProject
 	var orgProjects []RepoProject
 	var userProjectsV2 []ProjectV2
@@ -1243,7 +1244,7 @@ func relevantProjects(client *Client, repo ghrepo.Interface, includeProjectV1 bo
 
 	g, _ := errgroup.WithContext(context.Background())
 
-	if includeProjectV1 {
+	if projectsV1Support == gh.ProjectsV1Supported {
 		g.Go(func() error {
 			var err error
 			repoProjects, err = RepoProjects(client, repo)

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -150,7 +151,7 @@ func Test_RepoMetadata(t *testing.T) {
 		  { "data": { "viewer": { "login": "monalisa" } } }
 		`))
 
-	result, err := RepoMetadata(client, repo, input, true)
+	result, err := RepoMetadata(client, repo, input, gh.ProjectsV1Supported)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -291,7 +292,7 @@ func Test_ProjectNamesToPaths(t *testing.T) {
 		} } } }
 		`))
 
-	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap", "TriageV2", "RoadmapV2", "MonalisaV2"}, true)
+	projectPaths, err := ProjectNamesToPaths(client, repo, []string{"Triage", "Roadmap", "TriageV2", "RoadmapV2", "MonalisaV2"}, gh.ProjectsV1Supported)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -351,7 +352,7 @@ t001: team(slug:"robots"){id,slug}
 			}
 		}))
 
-	result, err := RepoResolveMetadataIDs(client, repo, input, false)
+	result, err := RepoResolveMetadataIDs(client, repo, input, gh.ProjectsV1Supported)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/featuredetection/detector_mock.go
+++ b/internal/featuredetection/detector_mock.go
@@ -1,5 +1,7 @@
 package featuredetection
 
+import "github.com/cli/cli/v2/internal/gh"
+
 type DisabledDetectorMock struct{}
 
 func (md *DisabledDetectorMock) IssueFeatures() (IssueFeatures, error) {
@@ -14,8 +16,8 @@ func (md *DisabledDetectorMock) RepositoryFeatures() (RepositoryFeatures, error)
 	return RepositoryFeatures{}, nil
 }
 
-func (md *DisabledDetectorMock) ProjectV1() (bool, error) {
-	return false, nil
+func (md *DisabledDetectorMock) ProjectsV1() (gh.ProjectsV1Support, error) {
+	return gh.ProjectsV1Unsupported, nil
 }
 
 type EnabledDetectorMock struct{}
@@ -32,6 +34,6 @@ func (md *EnabledDetectorMock) RepositoryFeatures() (RepositoryFeatures, error) 
 	return allRepositoryFeatures, nil
 }
 
-func (md *EnabledDetectorMock) ProjectV1() (bool, error) {
-	return true, nil
+func (md *EnabledDetectorMock) ProjectsV1() (gh.ProjectsV1Support, error) {
+	return gh.ProjectsV1Supported, nil
 }

--- a/internal/gh/projects.go
+++ b/internal/gh/projects.go
@@ -1,0 +1,30 @@
+package gh
+
+// ProjectsV1Support provides type safety and readability around whether or not Projects v1 is supported
+// by the targeted host.
+//
+// It is a sealed type to ensure that consumers must use the exported ProjectsV1Supported and ProjectsV1Unsupported
+// variables to get an instance of the type.
+type ProjectsV1Support interface {
+	sealed()
+}
+
+type projectsV1Supported struct{}
+
+func (projectsV1Supported) sealed() {}
+
+type projectsV1Unsupported struct{}
+
+func (projectsV1Unsupported) sealed() {}
+
+var (
+	ProjectsV1Supported   ProjectsV1Support = projectsV1Supported{}
+	ProjectsV1Unsupported ProjectsV1Support = projectsV1Unsupported{}
+)
+
+func ParseProjectsV1Support(b bool) ProjectsV1Support {
+	if b {
+		return ProjectsV1Supported
+	}
+	return ProjectsV1Unsupported
+}

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -154,7 +154,7 @@ func createRun(opts *CreateOptions) (err error) {
 		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
 	}
 
-	includeProjectV1, err := opts.Detector.ProjectV1()
+	projectsV1Support, err := opts.Detector.ProjectsV1()
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func createRun(opts *CreateOptions) (err error) {
 	if opts.WebMode {
 		var openURL string
 		if opts.Title != "" || opts.Body != "" || tb.HasMetadata() {
-			openURL, err = generatePreviewURL(apiClient, baseRepo, tb, includeProjectV1)
+			openURL, err = generatePreviewURL(apiClient, baseRepo, tb, projectsV1Support)
 			if err != nil {
 				return
 			}
@@ -273,7 +273,7 @@ func createRun(opts *CreateOptions) (err error) {
 			}
 		}
 
-		openURL, err = generatePreviewURL(apiClient, baseRepo, tb, includeProjectV1)
+		openURL, err = generatePreviewURL(apiClient, baseRepo, tb, projectsV1Support)
 		if err != nil {
 			return
 		}
@@ -292,7 +292,7 @@ func createRun(opts *CreateOptions) (err error) {
 				Repo:      baseRepo,
 				State:     &tb,
 			}
-			err = prShared.MetadataSurvey(opts.Prompter, opts.IO, baseRepo, fetcher, &tb, includeProjectV1)
+			err = prShared.MetadataSurvey(opts.Prompter, opts.IO, baseRepo, fetcher, &tb, projectsV1Support)
 			if err != nil {
 				return
 			}
@@ -348,7 +348,7 @@ func createRun(opts *CreateOptions) (err error) {
 			params["issueTemplate"] = templateNameForSubmit
 		}
 
-		err = prShared.AddMetadataToIssueParams(apiClient, baseRepo, params, &tb, includeProjectV1)
+		err = prShared.AddMetadataToIssueParams(apiClient, baseRepo, params, &tb, projectsV1Support)
 		if err != nil {
 			return
 		}
@@ -367,7 +367,7 @@ func createRun(opts *CreateOptions) (err error) {
 	return
 }
 
-func generatePreviewURL(apiClient *api.Client, baseRepo ghrepo.Interface, tb prShared.IssueMetadataState, includeProjectV1 bool) (string, error) {
+func generatePreviewURL(apiClient *api.Client, baseRepo ghrepo.Interface, tb prShared.IssueMetadataState, projectsV1Support gh.ProjectsV1Support) (string, error) {
 	openURL := ghrepo.GenerateRepoURL(baseRepo, "issues/new")
-	return prShared.WithPrAndIssueQueryParams(apiClient, baseRepo, openURL, tb, includeProjectV1)
+	return prShared.WithPrAndIssueQueryParams(apiClient, baseRepo, openURL, tb, projectsV1Support)
 }

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
 	shared "github.com/cli/cli/v2/pkg/cmd/issue/shared"
@@ -29,7 +30,7 @@ type EditOptions struct {
 	DetermineEditor    func() (string, error)
 	FieldsToEditSurvey func(prShared.EditPrompter, *prShared.Editable) error
 	EditFieldsSurvey   func(prShared.EditPrompter, *prShared.Editable, string) error
-	FetchOptions       func(*api.Client, ghrepo.Interface, *prShared.Editable, bool) error
+	FetchOptions       func(*api.Client, ghrepo.Interface, *prShared.Editable, gh.ProjectsV1Support) error
 
 	SelectorArgs []string
 	Interactive  bool
@@ -180,7 +181,7 @@ func editRun(opts *EditOptions) error {
 		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
 	}
 
-	includeProjectV1, err := opts.Detector.ProjectV1()
+	projectsV1Support, err := opts.Detector.ProjectsV1()
 	if err != nil {
 		return err
 	}
@@ -218,7 +219,7 @@ func editRun(opts *EditOptions) error {
 	// Fetch editable shared fields once for all issues.
 	apiClient := api.NewClientFromHTTP(httpClient)
 	opts.IO.StartProgressIndicatorWithLabel("Fetching repository information")
-	err = opts.FetchOptions(apiClient, repo, &editable, includeProjectV1)
+	err = opts.FetchOptions(apiClient, repo, &editable, projectsV1Support)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err

--- a/pkg/cmd/issue/shared/lookup.go
+++ b/pkg/cmd/issue/shared/lookup.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/set"
 	"golang.org/x/sync/errgroup"
@@ -167,11 +168,11 @@ func findIssueOrPR(httpClient *http.Client, repo ghrepo.Interface, number int, f
 		fieldSet.Add("number")
 	}
 	if fieldSet.Contains("projectCards") {
-		includeProjectV1, err := detector.ProjectV1()
+		projectsV1Support, err := detector.ProjectsV1()
 		if err != nil {
 			return nil, err
 		}
-		if !includeProjectV1 {
+		if projectsV1Support == gh.ProjectsV1Unsupported {
 			fieldSet.Remove("projectCards")
 		}
 	}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -88,7 +88,7 @@ type CreateContext struct {
 	IsPushEnabled      bool
 	Client             *api.Client
 	GitClient          *git.Client
-	IncludeProjectV1   bool
+	ProjectsV1Support  gh.ProjectsV1Support
 }
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
@@ -437,7 +437,7 @@ func createRun(opts *CreateOptions) (err error) {
 				Repo:      ctx.BaseRepo,
 				State:     state,
 			}
-			err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.BaseRepo, fetcher, state, ctx.IncludeProjectV1)
+			err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.BaseRepo, fetcher, state, ctx.ProjectsV1Support)
 			if err != nil {
 				return
 			}
@@ -731,7 +731,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
 		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
 	}
-	includeProjectV1, err := opts.Detector.ProjectV1()
+	projectsV1Support, err := opts.Detector.ProjectsV1()
 	if err != nil {
 		return nil, err
 	}
@@ -748,7 +748,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 		RepoContext:        repoContext,
 		Client:             client,
 		GitClient:          gitClient,
-		IncludeProjectV1:   includeProjectV1,
+		ProjectsV1Support:  projectsV1Support,
 	}, nil
 }
 
@@ -781,7 +781,7 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 		return errors.New("pull request title must not be blank")
 	}
 
-	err := shared.AddMetadataToIssueParams(client, ctx.BaseRepo, params, &state, ctx.IncludeProjectV1)
+	err := shared.AddMetadataToIssueParams(client, ctx.BaseRepo, params, &state, ctx.ProjectsV1Support)
 	if err != nil {
 		return err
 	}
@@ -1004,7 +1004,7 @@ func generateCompareURL(ctx CreateContext, state shared.IssueMetadataState) (str
 		ctx.BaseRepo,
 		"compare/%s...%s?expand=1",
 		url.PathEscape(ctx.BaseBranch), url.PathEscape(ctx.HeadBranchLabel))
-	url, err := shared.WithPrAndIssueQueryParams(ctx.Client, ctx.BaseRepo, u, state, ctx.IncludeProjectV1)
+	url, err := shared.WithPrAndIssueQueryParams(ctx.Client, ctx.BaseRepo, u, state, ctx.ProjectsV1Support)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -237,13 +237,13 @@ func editRun(opts *EditOptions) error {
 		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
 		opts.Detector = fd.NewDetector(cachedClient, repo.RepoHost())
 	}
-	includeProjectV1, err := opts.Detector.ProjectV1()
+	projectsV1Support, err := opts.Detector.ProjectsV1()
 	if err != nil {
 		return err
 	}
 
 	opts.IO.StartProgressIndicator()
-	err = opts.Fetcher.EditableOptionsFetch(apiClient, repo, &editable, includeProjectV1)
+	err = opts.Fetcher.EditableOptionsFetch(apiClient, repo, &editable, projectsV1Support)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
@@ -323,13 +323,13 @@ func (s surveyor) EditFields(editable *shared.Editable, editorCmd string) error 
 }
 
 type EditableOptionsFetcher interface {
-	EditableOptionsFetch(*api.Client, ghrepo.Interface, *shared.Editable, bool) error
+	EditableOptionsFetch(*api.Client, ghrepo.Interface, *shared.Editable, gh.ProjectsV1Support) error
 }
 
 type fetcher struct{}
 
-func (f fetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable, includeProjectV1 bool) error {
-	return shared.FetchOptions(client, repo, opts, includeProjectV1)
+func (f fetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable, projectsV1Support gh.ProjectsV1Support) error {
+	return shared.FetchOptions(client, repo, opts, projectsV1Support)
 }
 
 type EditorRetriever interface {

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/featuredetection"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	shared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -663,8 +664,8 @@ type testSurveyor struct {
 }
 type testEditorRetriever struct{}
 
-func (f testFetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable, includeProjectV1 bool) error {
-	return shared.FetchOptions(client, repo, opts, includeProjectV1)
+func (f testFetcher) EditableOptionsFetch(client *api.Client, repo ghrepo.Interface, opts *shared.Editable, projectsV1Support gh.ProjectsV1Support) error {
+	return shared.FetchOptions(client, repo, opts, projectsV1Support)
 }
 
 func (s testSurveyor) FieldsToEdit(e *shared.Editable) error {

--- a/pkg/cmd/pr/shared/completion.go
+++ b/pkg/cmd/pr/shared/completion.go
@@ -8,13 +8,14 @@ import (
 	"time"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 )
 
 func RequestableReviewersForCompletion(httpClient *http.Client, repo ghrepo.Interface) ([]string, error) {
 	client := api.NewClientFromHTTP(api.NewCachedHTTPClient(httpClient, time.Minute*2))
 
-	metadata, err := api.RepoMetadata(client, repo, api.RepoMetadataInput{Reviewers: true}, false)
+	metadata, err := api.RepoMetadata(client, repo, api.RepoMetadataInput{Reviewers: true}, gh.ProjectsV1Unsupported)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/set"
 )
@@ -376,7 +377,7 @@ func FieldsToEditSurvey(p EditPrompter, editable *Editable) error {
 	return nil
 }
 
-func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable, includeProjectV1 bool) error {
+func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable, projectsV1Support gh.ProjectsV1Support) error {
 	input := api.RepoMetadataInput{
 		Reviewers:  editable.Reviewers.Edited,
 		Assignees:  editable.Assignees.Edited,
@@ -384,7 +385,7 @@ func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable,
 		Projects:   editable.Projects.Edited,
 		Milestones: editable.Milestone.Edited,
 	}
-	metadata, err := api.RepoMetadata(client, repo, input, includeProjectV1)
+	metadata, err := api.RepoMetadata(client, repo, input, projectsV1Support)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -16,6 +16,7 @@ import (
 	remotes "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/set"
@@ -165,11 +166,11 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 		fields.Remove("projectItems")
 	}
 	if fields.Contains("projectCards") {
-		includeProjectV1, err := opts.Detector.ProjectV1()
+		projectsV1Support, err := opts.Detector.ProjectsV1()
 		if err != nil {
 			return nil, nil, err
 		}
-		if !includeProjectV1 {
+		if projectsV1Support == gh.ProjectsV1Unsupported {
 			fields.Remove("projectCards")
 		}
 	}

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/search"
 	"github.com/google/shlex"
 )
 
-func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, baseURL string, state IssueMetadataState, includeProjectV1 bool) (string, error) {
+func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, baseURL string, state IssueMetadataState, projectsV1Support gh.ProjectsV1Support) (string, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return "", err
@@ -31,7 +32,7 @@ func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, ba
 		q.Set("labels", strings.Join(state.Labels, ","))
 	}
 	if len(state.Projects) > 0 {
-		projectPaths, err := api.ProjectNamesToPaths(client, baseRepo, state.Projects, includeProjectV1)
+		projectPaths, err := api.ProjectNamesToPaths(client, baseRepo, state.Projects, projectsV1Support)
 		if err != nil {
 			return "", fmt.Errorf("could not add to project: %w", err)
 		}
@@ -51,7 +52,7 @@ func ValidURL(urlStr string) bool {
 
 // Ensure that tb.MetadataResult object exists and contains enough pre-fetched API data to be able
 // to resolve all object listed in tb to GraphQL IDs.
-func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetadataState, includeProjectV1 bool) error {
+func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetadataState, projectsV1Support gh.ProjectsV1Support) error {
 	resolveInput := api.RepoResolveInput{}
 
 	if len(tb.Assignees) > 0 && (tb.MetadataResult == nil || len(tb.MetadataResult.AssignableUsers) == 0) {
@@ -74,7 +75,7 @@ func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetada
 		resolveInput.Milestones = tb.Milestones
 	}
 
-	metadataResult, err := api.RepoResolveMetadataIDs(client, baseRepo, resolveInput, includeProjectV1)
+	metadataResult, err := api.RepoResolveMetadataIDs(client, baseRepo, resolveInput, projectsV1Support)
 	if err != nil {
 		return err
 	}
@@ -88,12 +89,12 @@ func fillMetadata(client *api.Client, baseRepo ghrepo.Interface, tb *IssueMetada
 	return nil
 }
 
-func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, params map[string]interface{}, tb *IssueMetadataState, includeProjectV1 bool) error {
+func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, params map[string]interface{}, tb *IssueMetadataState, projectsV1Support gh.ProjectsV1Support) error {
 	if !tb.HasMetadata() {
 		return nil
 	}
 
-	if err := fillMetadata(client, baseRepo, tb, includeProjectV1); err != nil {
+	if err := fillMetadata(client, baseRepo, tb, projectsV1Support); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
@@ -265,7 +266,7 @@ func Test_WithPrAndIssueQueryParams(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := WithPrAndIssueQueryParams(nil, nil, tt.args.baseURL, tt.args.state, false)
+			got, err := WithPrAndIssueQueryParams(nil, nil, tt.args.baseURL, tt.args.state, gh.ProjectsV1Unsupported)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("WithPrAndIssueQueryParams() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -132,19 +132,19 @@ type MetadataFetcher struct {
 	State     *IssueMetadataState
 }
 
-func (mf *MetadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput, includeProjectV1 bool) (*api.RepoMetadataResult, error) {
+func (mf *MetadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput, projectsV1Support gh.ProjectsV1Support) (*api.RepoMetadataResult, error) {
 	mf.IO.StartProgressIndicator()
-	metadataResult, err := api.RepoMetadata(mf.APIClient, mf.Repo, input, includeProjectV1)
+	metadataResult, err := api.RepoMetadata(mf.APIClient, mf.Repo, input, projectsV1Support)
 	mf.IO.StopProgressIndicator()
 	mf.State.MetadataResult = metadataResult
 	return metadataResult, err
 }
 
 type RepoMetadataFetcher interface {
-	RepoMetadataFetch(api.RepoMetadataInput, bool) (*api.RepoMetadataResult, error)
+	RepoMetadataFetch(api.RepoMetadataInput, gh.ProjectsV1Support) (*api.RepoMetadataResult, error)
 }
 
-func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher RepoMetadataFetcher, state *IssueMetadataState, includeProjectV1 bool) error {
+func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher RepoMetadataFetcher, state *IssueMetadataState, projectsV1Support gh.ProjectsV1Support) error {
 	isChosen := func(m string) bool {
 		for _, c := range state.Metadata {
 			if m == c {
@@ -177,7 +177,7 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 		Projects:   isChosen("Projects"),
 		Milestones: isChosen("Milestone"),
 	}
-	metadataResult, err := fetcher.RepoMetadataFetch(metadataInput, includeProjectV1)
+	metadataResult, err := fetcher.RepoMetadataFetch(metadataInput, projectsV1Support)
 	if err != nil {
 		return fmt.Errorf("error fetching metadata options: %w", err)
 	}

--- a/pkg/cmd/pr/shared/survey_test.go
+++ b/pkg/cmd/pr/shared/survey_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -14,7 +15,7 @@ type metadataFetcher struct {
 	metadataResult *api.RepoMetadataResult
 }
 
-func (mf *metadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput, includeProjectV1 bool) (*api.RepoMetadataResult, error) {
+func (mf *metadataFetcher) RepoMetadataFetch(input api.RepoMetadataInput, projectsV1Support gh.ProjectsV1Support) (*api.RepoMetadataResult, error) {
 	return mf.metadataResult, nil
 }
 
@@ -68,7 +69,7 @@ func TestMetadataSurvey_selectAll(t *testing.T) {
 		Assignees: []string{"hubot"},
 		Type:      PRMetadata,
 	}
-	err := MetadataSurvey(pm, ios, repo, fetcher, state, true)
+	err := MetadataSurvey(pm, ios, repo, fetcher, state, gh.ProjectsV1Supported)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())
@@ -113,7 +114,7 @@ func TestMetadataSurvey_keepExisting(t *testing.T) {
 	state := &IssueMetadataState{
 		Assignees: []string{"hubot"},
 	}
-	err := MetadataSurvey(pm, ios, repo, fetcher, state, true)
+	err := MetadataSurvey(pm, ios, repo, fetcher, state, gh.ProjectsV1Supported)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "", stdout.String())


### PR DESCRIPTION
## Description

In reviewing https://github.com/cli/cli/pull/9498, I didn't particularly like the naked booleans e.g.

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/2b0ed645-fd13-44d7-bbef-7c0abbc0309d">

So I decided to give them real names and a bit of type safety so that it reads like so:

<img width="1213" alt="image" src="https://github.com/user-attachments/assets/dd844dc1-5146-4a7a-94aa-d19f7f7c20cd">

I also added tests for the feature detection of ProjectsV1, which should be valuable even if you disagree with the rest of the PR.

### Nitty Gritty

#### Sealed Types?

You might be wondering why I didn't make a typed boolean like:

```go
type ProjectsV1Support bool

const (
    ProjectsV1Supported ProjectsV1Support = true
    ProjectsV1Unsupported ProjectsV1Support = false
)
```

The issue with this is that Go happily coerces unnamed values when the type def matches e.g.

```go
func Fn(projectsV1Supported ProjectsV1Support) {}
```

Can still be called like:

```go
Fn(true)
```

Which defeats the readability.

Ideally Go would support actual enumerations but 🤷 

#### Why `gh` package?

Initially I put a type into the `api` package but on further reflection I decided that the idea of whether projects v1 is supported is ubiquitous across the entire CLI, so it really does belong to the broader domain of `gh`.