### PR TITLE
Fix doc typo for `repo sync`

### DIFF
--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -50,7 +50,7 @@ func NewCmdSync(f *cmdutil.Factory, runF func(*SyncOptions) error) *cobra.Comman
 			of the source repository to update the matching branch on the destination
 			repository so they are equal. A fast forward update will be used except when the
 			%[1]s--force%[1]s flag is specified, then the two branches will
-			by synced using a hard reset.
+			be synced using a hard reset.
 
 			Without an argument, the local repository is selected as the destination repository.
 


### PR DESCRIPTION
Sorry I didn't catch more.