### PR TITLE
Added `--active` flag to the `gh auth status` command

### DIFF
--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -129,6 +129,7 @@ type StatusOptions struct {
 
 	Hostname  string
 	ShowToken bool
+	Active    bool
 }
 
 func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Command {
@@ -163,6 +164,7 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 
 	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "Check only a specific hostname's auth status")
 	cmd.Flags().BoolVarP(&opts.ShowToken, "show-token", "t", false, "Display the auth token")
+	cmd.Flags().BoolVarP(&opts.Active, "active", "a", false, "Display the active account only")
 
 	return cmd
 }
@@ -222,6 +224,10 @@ func statusRun(opts *StatusOptions) error {
 
 		if err == nil && !isValidEntry(entry) {
 			err = cmdutil.SilentError
+		}
+
+		if opts.Active {
+			continue
 		}
 
 		users := authCfg.UsersForHost(hostname)

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -44,6 +44,13 @@ func Test_NewCmdStatus(t *testing.T) {
 				ShowToken: true,
 			},
 		},
+		{
+			name: "active",
+			cli:  "--active",
+			wants: StatusOptions{
+				Active: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -431,6 +438,27 @@ func Test_statusRun(t *testing.T) {
 				  - The token in GH_CONFIG_DIR/hosts.yml is invalid.
 				  - To re-authenticate, run: gh auth login -h ghe.io
 				  - To forget about this account, run: gh auth logout -h ghe.io -u monalisa-ghe
+			`),
+		},
+		{
+			name: "active",
+			opts: StatusOptions{
+				Active: true,
+			},
+			cfgStubs: func(t *testing.T, c gh.Config) {
+				login(t, c, "github.com", "monalisa", "gho_abc123", "https")
+				login(t, c, "github.com", "monalisa-2", "gho_abc123", "https")
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
+			},
+			wantOut: heredoc.Doc(`
+				github.com
+				  ✓ Logged in to github.com account monalisa-2 (GH_CONFIG_DIR/hosts.yml)
+				  - Active account: true
+				  - Git operations protocol: https
+				  - Token: gho_******
+				  - Token scopes: 'repo', 'read:org'
 			`),
 		},
 	}

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -389,14 +389,14 @@ func Test_statusRun(t *testing.T) {
 		{
 			name: "multiple hosts with multiple accounts with environment tokens and with errors",
 			opts: StatusOptions{},
-			env:  map[string]string{"GH_ENTERPRISE_TOKEN": "gho_abc123"},
+			env:  map[string]string{"GH_ENTERPRISE_TOKEN": "gho_abc123"}, // monalisa-ghe-2
 			cfgStubs: func(t *testing.T, c gh.Config) {
 				login(t, c, "github.com", "monalisa", "gho_def456", "https")
 				login(t, c, "github.com", "monalisa-2", "gho_ghi789", "https")
 				login(t, c, "ghe.io", "monalisa-ghe", "gho_xyz123", "ssh")
 			},
 			httpStubs: func(reg *httpmock.Registry) {
-				// Get scopes for monalia-2
+				// Get scopes for monalisa-2
 				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
 				// Get scopes for monalisa
 				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo"))
@@ -441,7 +441,7 @@ func Test_statusRun(t *testing.T) {
 			`),
 		},
 		{
-			name: "active",
+			name: "multiple accounts on a host, only active users",
 			opts: StatusOptions{
 				Active: true,
 			},
@@ -459,6 +459,73 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_******
 				  - Token scopes: 'repo', 'read:org'
+			`),
+		},
+		{
+			name: "multiple hosts with multiple accounts, only active users",
+			opts: StatusOptions{
+				Active: true,
+			},
+			cfgStubs: func(t *testing.T, c gh.Config) {
+				login(t, c, "github.com", "monalisa", "gho_abc123", "https")
+				login(t, c, "github.com", "monalisa-2", "gho_abc123", "https")
+				login(t, c, "ghe.io", "monalisa-ghe", "gho_abc123", "ssh")
+				login(t, c, "ghe.io", "monalisa-ghe-2", "gho_abc123", "ssh")
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				// Get scopes for monalisa-2
+				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
+				// Get scopes for monalisa-ghe-2
+				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.ScopesResponder("repo,read:org"))
+			},
+			wantOut: heredoc.Doc(`
+				github.com
+				  ✓ Logged in to github.com account monalisa-2 (GH_CONFIG_DIR/hosts.yml)
+				  - Active account: true
+				  - Git operations protocol: https
+				  - Token: gho_******
+				  - Token scopes: 'repo', 'read:org'
+
+				ghe.io
+				  ✓ Logged in to ghe.io account monalisa-ghe-2 (GH_CONFIG_DIR/hosts.yml)
+				  - Active account: true
+				  - Git operations protocol: ssh
+				  - Token: gho_******
+				  - Token scopes: 'repo', 'read:org'
+			`),
+		},
+		{
+			name: "multiple hosts with multiple accounts, only active users with errors",
+			opts: StatusOptions{
+				Active: true,
+			},
+			cfgStubs: func(t *testing.T, c gh.Config) {
+				login(t, c, "github.com", "monalisa", "gho_abc123", "https")
+				login(t, c, "github.com", "monalisa-2", "gho_abc123", "https")
+				login(t, c, "ghe.io", "monalisa-ghe", "gho_abc123", "ssh")
+				login(t, c, "ghe.io", "monalisa-ghe-2", "gho_abc123", "ssh")
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				// Get scopes for monalisa-2
+				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
+				// Error getting scopes for monalisa-ghe-2
+				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(404, "{}"))
+			},
+			wantErr: cmdutil.SilentError,
+			wantErrOut: heredoc.Doc(`
+				github.com
+				  ✓ Logged in to github.com account monalisa-2 (GH_CONFIG_DIR/hosts.yml)
+				  - Active account: true
+				  - Git operations protocol: https
+				  - Token: gho_******
+				  - Token scopes: 'repo', 'read:org'
+
+				ghe.io
+				  X Failed to log in to ghe.io account monalisa-ghe-2 (GH_CONFIG_DIR/hosts.yml)
+				  - Active account: true
+				  - The token in GH_CONFIG_DIR/hosts.yml is invalid.
+				  - To re-authenticate, run: gh auth login -h ghe.io
+				  - To forget about this account, run: gh auth logout -h ghe.io -u monalisa-ghe-2
 			`),
 		},
 	}


### PR DESCRIPTION
Fixes #9434

`--active` flag added to the `gh auth status` command, which outputs the currently active account only.

![image](https://github.com/user-attachments/assets/eafe0fcb-3234-41e7-b647-3bdf5ac0b3e6)