### PR TITLE
"offline" verification using the bundle of attestations without any additional handling of the file

### DIFF
--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -3,6 +3,7 @@ package verification
 import (
 	"bufio"
 	"encoding/json"
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -88,6 +89,10 @@ func loadBundlesFromJSONLinesFile(path string) ([]*api.Attestation, error) {
 	var line []byte
 	line, err = reader.ReadBytes('\n')
 	for err == nil {
+		if len(bytes.TrimSpace(line)) == 0 {
+	            line, err = reader.ReadBytes('\n')
+	            continue
+	        }
 		var bundle bundle.ProtobufBundle
 		bundle.Bundle = new(protobundle.Bundle)
 		err = bundle.UnmarshalJSON(line)

--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -2,8 +2,8 @@ package verification
 
 import (
 	"bufio"
-	"encoding/json"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -90,9 +90,9 @@ func loadBundlesFromJSONLinesFile(path string) ([]*api.Attestation, error) {
 	line, err = reader.ReadBytes('\n')
 	for err == nil {
 		if len(bytes.TrimSpace(line)) == 0 {
-	            line, err = reader.ReadBytes('\n')
-	            continue
-	        }
+			line, err = reader.ReadBytes('\n')
+			continue
+		}
 		var bundle bundle.ProtobufBundle
 		bundle.Bundle = new(protobundle.Bundle)
 		err = bundle.UnmarshalJSON(line)


### PR DESCRIPTION
Fixes #9521 

this change will allow the gh attestation verify --bundle command to work correctly with JSONL files that have empty lines at the end, without requiring manual modification of the file