### PR TITLE
Correct the help message for -F

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -114,7 +114,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			$ gh release create v1.2.3 --generate-notes
 
 			Use release notes from a file
-			$ gh release create v1.2.3 -F changelog.md
+			$ gh release create v1.2.3 -F release-notes.md
 
 			Use annotated tag notes
 			$ gh release create v1.2.3 --notes-from-tag


### PR DESCRIPTION
It should be a release notes file instead of a changelog file, this might be confusing for users to input the wrong file here.

Refs #9276.
