### PR TITLE
`gh attestation verify` handles empty JSONL files

### DIFF
--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -17,7 +17,7 @@ import (
 )
 
 var ErrUnrecognisedBundleExtension = errors.New("bundle file extension not supported, must be json or jsonl")
-var ErrEmptyJSONLFile = errors.New("provided jsonl file is empty")
+var ErrEmptyBundleFile = errors.New("provided bundle file is empty")
 
 type FetchAttestationsConfig struct {
 	APIClient             api.Client
@@ -107,7 +107,7 @@ func loadBundlesFromJSONLinesFile(path string) ([]*api.Attestation, error) {
 	}
 
 	if len(attestations) == 0 {
-		return nil, ErrEmptyJSONLFile
+		return nil, ErrEmptyBundleFile
 	}
 
 	return attestations, nil

--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -17,6 +17,7 @@ import (
 )
 
 var ErrUnrecognisedBundleExtension = errors.New("bundle file extension not supported, must be json or jsonl")
+var ErrEmptyJSONLFile = errors.New("provided jsonl file is empty")
 
 type FetchAttestationsConfig struct {
 	APIClient             api.Client
@@ -81,6 +82,15 @@ func loadBundlesFromJSONLinesFile(path string) ([]*api.Attestation, error) {
 		return nil, fmt.Errorf("could not open file: %v", err)
 	}
 	defer file.Close()
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get file info: %v", err)
+	}
+
+	if fileInfo.Size() == 0 {
+		return nil, ErrEmptyJSONLFile
+	}
 
 	attestations := []*api.Attestation{}
 

--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -83,15 +83,6 @@ func loadBundlesFromJSONLinesFile(path string) ([]*api.Attestation, error) {
 	}
 	defer file.Close()
 
-	fileInfo, err := file.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get file info: %v", err)
-	}
-
-	if fileInfo.Size() == 0 {
-		return nil, ErrEmptyJSONLFile
-	}
-
 	attestations := []*api.Attestation{}
 
 	reader := bufio.NewReader(file)
@@ -113,6 +104,10 @@ func loadBundlesFromJSONLinesFile(path string) ([]*api.Attestation, error) {
 		attestations = append(attestations, &a)
 
 		line, err = reader.ReadBytes('\n')
+	}
+
+	if len(attestations) == 0 {
+		return nil, ErrEmptyJSONLFile
 	}
 
 	return attestations, nil

--- a/pkg/cmd/attestation/verification/attestation_test.go
+++ b/pkg/cmd/attestation/verification/attestation_test.go
@@ -1,6 +1,7 @@
 package verification
 
 import (
+	"os"
 	"testing"
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
@@ -17,6 +18,19 @@ func TestLoadBundlesFromJSONLinesFile(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, attestations, 2)
+}
+
+func TestLoadBundlesFromJSONLinesFile_RejectEmptyJSONLFile(t *testing.T) {
+	// Create a temporary file
+	emptyJSONL, err := os.CreateTemp("", "empty.jsonl")
+	require.NoError(t, err)
+	err = emptyJSONL.Close()
+	require.NoError(t, err)
+
+	attestations, err := loadBundlesFromJSONLinesFile(emptyJSONL.Name())
+
+	require.ErrorIs(t, err, ErrEmptyJSONLFile)
+	require.Nil(t, attestations)
 }
 
 func TestLoadBundleFromJSONFile(t *testing.T) {

--- a/pkg/cmd/attestation/verification/attestation_test.go
+++ b/pkg/cmd/attestation/verification/attestation_test.go
@@ -29,7 +29,7 @@ func TestLoadBundlesFromJSONLinesFile_RejectEmptyJSONLFile(t *testing.T) {
 
 	attestations, err := loadBundlesFromJSONLinesFile(emptyJSONL.Name())
 
-	require.ErrorIs(t, err, ErrEmptyJSONLFile)
+	require.ErrorIs(t, err, ErrEmptyBundleFile)
 	require.Nil(t, attestations)
 }
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes a bug in `gh attestation verify` that would cause the command to return a successful verification message when provided an empty JSONL file with the `--bundle` flag.