### PR TITLE
Added tenancy aware attestation commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,7 @@
 # vim
 *.swp
 
+# Emacs
+*~
+
 vendor/

--- a/pkg/cmd/attestation/api/client_test.go
+++ b/pkg/cmd/attestation/api/client_test.go
@@ -172,3 +172,35 @@ func TestGetByDigest_Error(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, attestations)
 }
+
+func TestGetTrustDomain(t *testing.T) {
+	fetcher := mockMetaGenerator{
+		TrustDomain: "foo",
+	}
+
+	t.Run("with returned trust domain", func(t *testing.T) {
+		c := LiveClient{
+			api: mockAPIClient{
+				OnREST: fetcher.OnREST,
+			},
+			logger: io.NewTestHandler(),
+		}
+		td, err := c.GetTrustDomain()
+		require.Nil(t, err)
+		require.Equal(t, "foo", td)
+
+	})
+
+	t.Run("with error", func(t *testing.T) {
+		c := LiveClient{
+			api: mockAPIClient{
+				OnREST: fetcher.OnRESTError,
+			},
+			logger: io.NewTestHandler(),
+		}
+		td, err := c.GetTrustDomain()
+		require.Equal(t, "", td)
+		require.ErrorContains(t, err, "test error")
+	})
+
+}

--- a/pkg/cmd/attestation/api/mock_client.go
+++ b/pkg/cmd/attestation/api/mock_client.go
@@ -9,6 +9,7 @@ import (
 type MockClient struct {
 	OnGetByRepoAndDigest  func(repo, digest string, limit int) ([]*Attestation, error)
 	OnGetByOwnerAndDigest func(owner, digest string, limit int) ([]*Attestation, error)
+	OnGetTrustDomain      func() (string, error)
 }
 
 func (m MockClient) GetByRepoAndDigest(repo, digest string, limit int) ([]*Attestation, error) {
@@ -17,6 +18,10 @@ func (m MockClient) GetByRepoAndDigest(repo, digest string, limit int) ([]*Attes
 
 func (m MockClient) GetByOwnerAndDigest(owner, digest string, limit int) ([]*Attestation, error) {
 	return m.OnGetByOwnerAndDigest(owner, digest, limit)
+}
+
+func (m MockClient) GetTrustDomain() (string, error) {
+	return m.OnGetTrustDomain()
 }
 
 func makeTestAttestation() Attestation {

--- a/pkg/cmd/attestation/api/trust_domain.go
+++ b/pkg/cmd/attestation/api/trust_domain.go
@@ -1,0 +1,15 @@
+package api
+
+const MetaPath = "meta"
+
+type ArtifactAttestations struct {
+	TrustDomain string `json:"trust_domain"`
+}
+
+type Domain struct {
+	ArtifactAttestations ArtifactAttestations `json:"artifact_attestations"`
+}
+
+type MetaResponse struct {
+	Domains Domain `json:"domains"`
+}

--- a/pkg/cmd/attestation/auth/host.go
+++ b/pkg/cmd/attestation/auth/host.go
@@ -4,14 +4,11 @@ import (
 	"errors"
 
 	"github.com/cli/cli/v2/internal/ghinstance"
-	"github.com/cli/go-gh/v2/pkg/auth"
 )
 
 var ErrUnsupportedHost = errors.New("An unsupported host was detected. Note that gh attestation does not currently support GHES")
 
-func IsHostSupported() error {
-	host, _ := auth.DefaultHost()
-
+func IsHostSupported(host string) error {
 	// Note that this check is slightly redundant as Tenancy should not be considered Enterprise
 	// but the ghinstance package has not been updated to reflect this yet.
 	if ghinstance.IsEnterprise(host) && !ghinstance.IsTenancy(host) {

--- a/pkg/cmd/attestation/auth/host_test.go
+++ b/pkg/cmd/attestation/auth/host_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"testing"
 
+	ghauth "github.com/cli/go-gh/v2/pkg/auth"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,7 +40,8 @@ func TestIsHostSupported(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("GH_HOST", tc.host)
 
-			err := IsHostSupported()
+			host, _ := ghauth.DefaultHost()
+			err := IsHostSupported(host)
 			if tc.expectedErr {
 				require.ErrorIs(t, err, ErrUnsupportedHost)
 			} else {

--- a/pkg/cmd/attestation/download/options.go
+++ b/pkg/cmd/attestation/download/options.go
@@ -24,6 +24,7 @@ type Options struct {
 	Owner           string
 	PredicateType   string
 	Repo            string
+	Hostname        string
 }
 
 func (opts *Options) AreFlagsValid() error {

--- a/pkg/cmd/attestation/inspect/bundle_test.go
+++ b/pkg/cmd/attestation/inspect/bundle_test.go
@@ -12,7 +12,7 @@ import (
 func TestGetOrgAndRepo(t *testing.T) {
 	t.Run("with valid source URL", func(t *testing.T) {
 		sourceURL := "https://github.com/github/gh-attestation"
-		org, repo, err := getOrgAndRepo(sourceURL)
+		org, repo, err := getOrgAndRepo("", sourceURL)
 		require.Nil(t, err)
 		require.Equal(t, "github", org)
 		require.Equal(t, "gh-attestation", repo)
@@ -20,10 +20,18 @@ func TestGetOrgAndRepo(t *testing.T) {
 
 	t.Run("with invalid source URL", func(t *testing.T) {
 		sourceURL := "hub.com/github/gh-attestation"
-		org, repo, err := getOrgAndRepo(sourceURL)
+		org, repo, err := getOrgAndRepo("", sourceURL)
 		require.Error(t, err)
 		require.Zero(t, org)
 		require.Zero(t, repo)
+	})
+
+	t.Run("with valid source tenant URL", func(t *testing.T) {
+		sourceURL := "https://foo.ghe.com/github/gh-attestation"
+		org, repo, err := getOrgAndRepo("foo", sourceURL)
+		require.Nil(t, err)
+		require.Equal(t, "github", org)
+		require.Equal(t, "gh-attestation", repo)
 	})
 }
 
@@ -35,7 +43,7 @@ func TestGetAttestationDetail(t *testing.T) {
 	require.NoError(t, err)
 
 	attestation := attestations[0]
-	detail, err := getAttestationDetail(*attestation)
+	detail, err := getAttestationDetail("", *attestation)
 	require.NoError(t, err)
 
 	require.Equal(t, "sigstore", detail.OrgName)

--- a/pkg/cmd/attestation/inspect/options.go
+++ b/pkg/cmd/attestation/inspect/options.go
@@ -18,6 +18,8 @@ type Options struct {
 	OCIClient        oci.Client
 	SigstoreVerifier verification.SigstoreVerifier
 	exporter         cmdutil.Exporter
+	Hostname         string
+	Tenant           string
 }
 
 // Clean cleans the file path option values

--- a/pkg/cmd/attestation/trustedroot/trustedroot.go
+++ b/pkg/cmd/attestation/trustedroot/trustedroot.go
@@ -6,9 +6,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cli/cli/v2/internal/ghinstance"
+	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/auth"
+	"github.com/cli/cli/v2/pkg/cmd/attestation/io"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/verification"
 	"github.com/cli/cli/v2/pkg/cmdutil"
+	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/sigstore/sigstore-go/pkg/tuf"
@@ -19,6 +23,8 @@ type Options struct {
 	TufUrl      string
 	TufRootPath string
 	VerifyOnly  bool
+	Hostname    string
+	TrustDomain string
 }
 
 type tufClientInstantiator func(o *tuf.Options) (*tuf.Client, error)
@@ -54,8 +60,26 @@ func NewTrustedRootCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Com
 			gh attestation trusted-root
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := auth.IsHostSupported(); err != nil {
+			if opts.Hostname == "" {
+				opts.Hostname, _ = ghauth.DefaultHost()
+			}
+
+			if err := auth.IsHostSupported(opts.Hostname); err != nil {
 				return err
+			}
+
+			if ghinstance.IsTenancy(opts.Hostname) {
+				hc, err := f.HttpClient()
+				if err != nil {
+					return err
+				}
+				logger := io.NewHandler(f.IOStreams)
+				apiClient := api.NewLiveClient(hc, opts.Hostname, logger)
+				td, err := apiClient.GetTrustDomain()
+				if err != nil {
+					return err
+				}
+				opts.TrustDomain = td
 			}
 
 			if runF != nil {
@@ -74,12 +98,19 @@ func NewTrustedRootCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Com
 	trustedRootCmd.Flags().StringVarP(&opts.TufRootPath, "tuf-root", "", "", "Path to the TUF root.json file on disk")
 	trustedRootCmd.MarkFlagsRequiredTogether("tuf-url", "tuf-root")
 	trustedRootCmd.Flags().BoolVarP(&opts.VerifyOnly, "verify-only", "", false, "Don't output trusted_root.jsonl contents")
+	trustedRootCmd.Flags().StringVarP(&opts.Hostname, "hostname", "", "", "Configure host to use")
 
 	return &trustedRootCmd
 }
 
+type tufConfig struct {
+	tufOptions *tuf.Options
+	targets    []string
+}
+
 func getTrustedRoot(makeTUF tufClientInstantiator, opts *Options) error {
-	var tufOptions []*tuf.Options
+	var tufOptions []tufConfig
+	var defaultTR = "trusted_root.json"
 
 	tufOpt := verification.DefaultOptionsWithCacheSetting()
 	// Disable local caching, so we get up-to-date response from TUF repository
@@ -93,37 +124,54 @@ func getTrustedRoot(makeTUF tufClientInstantiator, opts *Options) error {
 
 		tufOpt.Root = tufRoot
 		tufOpt.RepositoryBaseURL = opts.TufUrl
-		tufOptions = append(tufOptions, tufOpt)
+		tufOptions = append(tufOptions, tufConfig{
+			tufOptions: tufOpt,
+			targets:    []string{defaultTR},
+		})
 	} else {
 		// Get from both Sigstore public good and GitHub private instance
-		tufOptions = append(tufOptions, tufOpt)
+		tufOptions = append(tufOptions, tufConfig{
+			tufOptions: tufOpt,
+			targets:    []string{defaultTR},
+		})
 
 		tufOpt = verification.GitHubTUFOptions()
 		tufOpt.CacheValidity = 0
-		tufOptions = append(tufOptions, tufOpt)
+		targets := []string{defaultTR}
+		if opts.TrustDomain != "" {
+			targets = append(targets, fmt.Sprintf("%s.%s",
+				opts.TrustDomain, defaultTR))
+		}
+		tufOptions = append(tufOptions, tufConfig{
+			tufOptions: tufOpt,
+			targets:    targets,
+		})
 	}
 
-	for _, tufOpt = range tufOptions {
-		tufClient, err := makeTUF(tufOpt)
+	for _, tufOpt := range tufOptions {
+		tufClient, err := makeTUF(tufOpt.tufOptions)
 		if err != nil {
 			return fmt.Errorf("failed to create TUF client: %v", err)
 		}
 
-		t, err := tufClient.GetTarget("trusted_root.json")
-		if err != nil {
-			return err
-		}
+		for _, target := range tufOpt.targets {
+			t, err := tufClient.GetTarget(target)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve trusted root %s via TUF: %w",
+					target, err)
+			}
 
-		output := new(bytes.Buffer)
-		err = json.Compact(output, t)
-		if err != nil {
-			return err
-		}
+			output := new(bytes.Buffer)
+			err = json.Compact(output, t)
+			if err != nil {
+				return err
+			}
 
-		if !opts.VerifyOnly {
-			fmt.Println(output)
-		} else {
-			fmt.Printf("Local TUF repository for %s updated and verified\n", tufOpt.RepositoryBaseURL)
+			if !opts.VerifyOnly {
+				fmt.Println(output)
+			} else {
+				fmt.Printf("Local TUF repository for %s updated and verified\n", tufOpt.tufOptions.RepositoryBaseURL)
+			}
 		}
 	}
 

--- a/pkg/cmd/attestation/verification/extensions_test.go
+++ b/pkg/cmd/attestation/verification/extensions_test.go
@@ -25,22 +25,74 @@ func TestVerifyCertExtensions(t *testing.T) {
 	}
 
 	t.Run("VerifyCertExtensions with owner and repo", func(t *testing.T) {
-		err := VerifyCertExtensions(results, "owner", "owner/repo")
+		err := VerifyCertExtensions(results, "", "owner", "owner/repo")
 		require.NoError(t, err)
 	})
 
+	t.Run("VerifyCertExtensions with owner and repo, but wrong tenant", func(t *testing.T) {
+		err := VerifyCertExtensions(results, "foo", "owner", "owner/repo")
+		require.ErrorContains(t, err, "expected SourceRepositoryOwnerURI to be https://foo.ghe.com/owner, got https://github.com/owner")
+	})
+
 	t.Run("VerifyCertExtensions with owner", func(t *testing.T) {
-		err := VerifyCertExtensions(results, "owner", "")
+		err := VerifyCertExtensions(results, "", "owner", "")
 		require.NoError(t, err)
 	})
 
 	t.Run("VerifyCertExtensions with wrong owner", func(t *testing.T) {
-		err := VerifyCertExtensions(results, "wrong", "")
+		err := VerifyCertExtensions(results, "", "wrong", "")
 		require.ErrorContains(t, err, "expected SourceRepositoryOwnerURI to be https://github.com/wrong, got https://github.com/owner")
 	})
 
 	t.Run("VerifyCertExtensions with wrong repo", func(t *testing.T) {
-		err := VerifyCertExtensions(results, "owner", "wrong")
+		err := VerifyCertExtensions(results, "", "owner", "wrong")
 		require.ErrorContains(t, err, "expected SourceRepositoryURI to be https://github.com/wrong, got https://github.com/owner/repo")
+	})
+}
+
+func TestVerifyTenancyCertExtensions(t *testing.T) {
+	results := []*AttestationProcessingResult{
+		{
+			VerificationResult: &verify.VerificationResult{
+				Signature: &verify.SignatureVerificationResult{
+					Certificate: &certificate.Summary{
+						Extensions: certificate.Extensions{
+							SourceRepositoryOwnerURI: "https://foo.ghe.com/owner",
+							SourceRepositoryURI:      "https://foo.ghe.com/owner/repo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("VerifyCertExtensions with owner and repo", func(t *testing.T) {
+		err := VerifyCertExtensions(results, "foo", "owner", "owner/repo")
+		require.NoError(t, err)
+	})
+
+	t.Run("VerifyCertExtensions with owner and repo, no tenant", func(t *testing.T) {
+		err := VerifyCertExtensions(results, "", "owner", "owner/repo")
+		require.ErrorContains(t, err, "expected SourceRepositoryOwnerURI to be https://github.com/owner, got https://foo.ghe.com/owner")
+	})
+
+	t.Run("VerifyCertExtensions with owner and repo, wrong tenant", func(t *testing.T) {
+		err := VerifyCertExtensions(results, "bar", "owner", "owner/repo")
+		require.ErrorContains(t, err, "expected SourceRepositoryOwnerURI to be https://bar.ghe.com/owner, got https://foo.ghe.com/owner")
+	})
+
+	t.Run("VerifyCertExtensions with owner", func(t *testing.T) {
+		err := VerifyCertExtensions(results, "foo", "owner", "")
+		require.NoError(t, err)
+	})
+
+	t.Run("VerifyCertExtensions with wrong owner", func(t *testing.T) {
+		err := VerifyCertExtensions(results, "foo", "wrong", "")
+		require.ErrorContains(t, err, "expected SourceRepositoryOwnerURI to be https://foo.ghe.com/wrong, got https://foo.ghe.com/owner")
+	})
+
+	t.Run("VerifyCertExtensions with wrong repo", func(t *testing.T) {
+		err := VerifyCertExtensions(results, "foo", "owner", "wrong")
+		require.ErrorContains(t, err, "expected SourceRepositoryURI to be https://foo.ghe.com/wrong, got https://foo.ghe.com/owner/repo")
 	})
 }

--- a/pkg/cmd/attestation/verify/options.go
+++ b/pkg/cmd/attestation/verify/options.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/artifact/oci"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/io"
@@ -37,6 +38,9 @@ type Options struct {
 	OCIClient             oci.Client
 	SigstoreVerifier      verification.SigstoreVerifier
 	exporter              cmdutil.Exporter
+	Hostname              string
+	// Tenant is only set when tenancy is used
+	Tenant string
 }
 
 // Clean cleans the file path option values
@@ -57,12 +61,12 @@ func (opts *Options) SetPolicyFlags() {
 		opts.Owner = splitRepo[0]
 
 		if !isSignerIdentityProvided(opts) {
-			opts.SANRegex = expandToGitHubURL(opts.Repo)
+			opts.SANRegex = expandToGitHubURL(opts.Tenant, opts.Repo)
 		}
 		return
 	}
 	if !isSignerIdentityProvided(opts) {
-		opts.SANRegex = expandToGitHubURL(opts.Owner)
+		opts.SANRegex = expandToGitHubURL(opts.Tenant, opts.Owner)
 	}
 }
 
@@ -92,6 +96,13 @@ func (opts *Options) AreFlagsValid() error {
 	// Check that both the bundle-from-oci and bundle-path flags are not used together
 	if opts.UseBundleFromRegistry && opts.BundlePath != "" {
 		return fmt.Errorf("bundle-from-oci flag cannot be used with bundle-path flag")
+	}
+
+	// Verify provided hostname
+	if opts.Hostname != "" {
+		if err := ghinstance.HostnameValidator(opts.Hostname); err != nil {
+			return fmt.Errorf("error parsing hostname: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/cmd/attestation/verify/verify_integration_test.go
+++ b/pkg/cmd/attestation/verify/verify_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cli/cli/v2/pkg/cmd/attestation/test"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/verification"
 	"github.com/cli/cli/v2/pkg/cmd/factory"
+	"github.com/cli/go-gh/v2/pkg/auth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,8 +29,10 @@ func TestVerifyIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	host, _ := auth.DefaultHost()
+
 	publicGoodOpts := Options{
-		APIClient:        api.NewLiveClient(hc, logger),
+		APIClient:        api.NewLiveClient(hc, host, logger),
 		ArtifactPath:     artifactPath,
 		BundlePath:       bundlePath,
 		DigestAlgorithm:  "sha512",
@@ -99,8 +102,10 @@ func TestVerifyIntegrationReusableWorkflow(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	host, _ := auth.DefaultHost()
+
 	baseOpts := Options{
-		APIClient:        api.NewLiveClient(hc, logger),
+		APIClient:        api.NewLiveClient(hc, host, logger),
 		ArtifactPath:     artifactPath,
 		BundlePath:       bundlePath,
 		DigestAlgorithm:  "sha256",
@@ -185,8 +190,10 @@ func TestVerifyIntegrationReusableWorkflowSignerWorkflow(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	host, _ := auth.DefaultHost()
+
 	baseOpts := Options{
-		APIClient:        api.NewLiveClient(hc, logger),
+		APIClient:        api.NewLiveClient(hc, host, logger),
 		ArtifactPath:     artifactPath,
 		BundlePath:       bundlePath,
 		Config:           cmdFactory.Config,
@@ -203,6 +210,7 @@ func TestVerifyIntegrationReusableWorkflowSignerWorkflow(t *testing.T) {
 		name           string
 		signerWorkflow string
 		expectErr      bool
+		host           string
 	}
 
 	testcases := []testcase{
@@ -220,12 +228,14 @@ func TestVerifyIntegrationReusableWorkflowSignerWorkflow(t *testing.T) {
 			name:           "valid signer workflow without host (defaults to github.com)",
 			signerWorkflow: "github/artifact-attestations-workflows/.github/workflows/attest.yml",
 			expectErr:      false,
+			host:           "github.com",
 		},
 	}
 
 	for _, tc := range testcases {
 		opts := baseOpts
 		opts.SignerWorkflow = tc.signerWorkflow
+		opts.Hostname = tc.host
 
 		err := runVerify(&opts)
 		if tc.expectErr {


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
This PR introduces a functionality to configure the host using --hostname flag instead of using GH_HOST environment variable.

It also updates the attestation commands (verify, download, inspect and trusted-root) to support tenancy mode.