### PR TITLE
Enhance Linux installation docs to redirect users to GPG renewal issue, better troubleshooting support

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -15,16 +15,13 @@ Install:
 
 ```bash
 (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-&& sudo mkdir -p -m 755 /etc/apt/keyrings \
-&& wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-&& sudo apt update \
-&& sudo apt install gh -y
+	&& sudo mkdir -p -m 755 /etc/apt/keyrings \
+	&& wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+	&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+	&& sudo apt update \
+	&& sudo apt install gh -y
 ```
-
-> **Note**
-> We were recently forced to change our GPG signing key. If you've previously downloaded the `githubcli-archive-keyring.gpg` file, you should re-download it again per above instructions. If you are using a keyserver to download the key, the ID of the new key is `23F3D4EA75716059`.
 
 Upgrade:
 
@@ -32,6 +29,9 @@ Upgrade:
 sudo apt update
 sudo apt install gh
 ```
+
+> [!NOTE]
+> If errors regarding GPG signatures occur, see [cli/cli#9569](https://github.com/cli/cli/issues/9569) for steps to fix this.
 
 ### Fedora, CentOS, Red Hat Enterprise Linux (dnf)
 
@@ -65,14 +65,14 @@ sudo yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.re
 sudo yum install gh
 ```
 
-> **Note**
-> We were recently forced to change our GPG signing key. If you've added the repository previously and now you're getting a GPG signing key error, disable the repository first with `sudo yum-config-manager --disable gh-cli` and add it again with `sudo yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo`.
-
 Upgrade:
 
 ```bash
 sudo yum update gh
 ```
+
+> [!NOTE]
+> If errors regarding GPG signatures occur, see [cli/cli#9569](https://github.com/cli/cli/issues/9569) for steps to fix this.
 
 ### openSUSE/SUSE Linux (zypper)
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -23,6 +23,9 @@ Install:
 && sudo apt install gh -y
 ```
 
+> **Note**
+> We were recently forced to change our GPG signing key. If you've previously downloaded the `githubcli-archive-keyring.gpg` file, you should re-download it again per above instructions. If you are using a keyserver to download the key, the ID of the new key is `23F3D4EA75716059`.
+
 Upgrade:
 
 ```bash
@@ -61,6 +64,9 @@ type -p yum-config-manager >/dev/null || sudo yum install yum-utils
 sudo yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
 sudo yum install gh
 ```
+
+> **Note**
+> We were recently forced to change our GPG signing key. If you've added the repository previously and now you're getting a GPG signing key error, disable the repository first with `sudo yum-config-manager --disable gh-cli` and add it again with `sudo yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo`.
 
 Upgrade:
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -23,9 +23,6 @@ Install:
 && sudo apt install gh -y
 ```
 
-> **Note**
-> We were recently forced to change our GPG signing key. If you've previously downloaded the `githubcli-archive-keyring.gpg` file, you should re-download it again per above instructions. If you are using a keyserver to download the key, the ID of the new key is `23F3D4EA75716059`.
-
 Upgrade:
 
 ```bash
@@ -64,9 +61,6 @@ type -p yum-config-manager >/dev/null || sudo yum install yum-utils
 sudo yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
 sudo yum install gh
 ```
-
-> **Note**
-> We were recently forced to change our GPG signing key. If you've added the repository previously and now you're getting a GPG signing key error, disable the repository first with `sudo yum-config-manager --disable gh-cli` and add it again with `sudo yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo`.
 
 Upgrade:
 


### PR DESCRIPTION
Relates #9569

Having been 2 years since the GitHub CLI changed GPG keys used to sign our releases, it no longer seems relevant to keep these notes in our installation docs as they are confusing to the uninitiated.

Instead, we want to redirect users to the relevant issue to get the most up to date help.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
