### PR TITLE
Move non-integration tests to different test file

### DIFF
--- a/pkg/cmd/attestation/verification/attestation_test.go
+++ b/pkg/cmd/attestation/verification/attestation_test.go
@@ -87,6 +87,18 @@ func TestGetLocalAttestations(t *testing.T) {
 		require.ErrorIs(t, err, ErrUnrecognisedBundleExtension)
 		require.Nil(t, attestations)
 	})
+
+	t.Run("with missing verification material", func(t *testing.T) {
+		path := "../test/data/github_provenance_demo-0.0.12-py3-none-any-bundle-missing-verification-material.jsonl"
+		_, err := GetLocalAttestations(path)
+		require.ErrorContains(t, err, "missing verification material")
+	})
+
+	t.Run("with missing verification certificate", func(t *testing.T) {
+		path := "../test/data/github_provenance_demo-0.0.12-py3-none-any-bundle-missing-cert.jsonl"
+		_, err := GetLocalAttestations(path)
+		require.ErrorContains(t, err, "missing bundle content")
+	})
 }
 
 func TestFilterAttestations(t *testing.T) {

--- a/pkg/cmd/attestation/verification/sigstore_integration_test.go
+++ b/pkg/cmd/attestation/verification/sigstore_integration_test.go
@@ -42,16 +42,6 @@ func TestLiveSigstoreVerifier(t *testing.T) {
 		require.NoError(t, res.Error)
 	})
 
-	t.Run("with missing verification material", func(t *testing.T) {
-		_, err := GetLocalAttestations("../test/data/github_provenance_demo-0.0.12-py3-none-any-bundle-missing-verification-material.jsonl")
-		require.ErrorContains(t, err, "missing verification material")
-	})
-
-	t.Run("with missing verification certificate", func(t *testing.T) {
-		_, err := GetLocalAttestations("../test/data/github_provenance_demo-0.0.12-py3-none-any-bundle-missing-cert.jsonl")
-		require.ErrorContains(t, err, "missing bundle content")
-	})
-
 	t.Run("with GitHub Sigstore artifact", func(t *testing.T) {
 		githubArtifactPath := test.NormalizeRelativePath("../test/data/github_provenance_demo-0.0.12-py3-none-any.whl")
 		githubArtifact, err := artifact.NewDigestedArtifact(nil, githubArtifactPath, "sha256")


### PR DESCRIPTION
This moves a couple of non-integration tests related to the attestation subcommand to a different test file.

Fixes https://github.com/cli/cli/issues/9576