### PR TITLE
Check for nil values to prevent nil dereference panic

### DIFF
--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -307,10 +307,18 @@ func buildTableVerifyContent(results []*verification.AttestationProcessingResult
 	content := make([][]string, len(results))
 
 	for i, res := range results {
+		if res.VerificationResult == nil ||
+			res.VerificationResult.Signature == nil ||
+			res.VerificationResult.Signature.Certificate == nil {
+			return nil, fmt.Errorf("bundle missing verification result fields")
+		}
 		builderSignerURI := res.VerificationResult.Signature.Certificate.Extensions.BuildSignerURI
 		repoAndOrg, workflow, err := extractAttestationDetail(builderSignerURI)
 		if err != nil {
 			return nil, err
+		}
+		if res.VerificationResult.Statement == nil {
+			return nil, fmt.Errorf("bundle missing attestation statement (bundle must originate from GitHub Artifact Attestations)")
 		}
 		predicateType := res.VerificationResult.Statement.PredicateType
 		content[i] = []string{repoAndOrg, predicateType, workflow}


### PR DESCRIPTION
Add validation checks for nil values to prevent panics when verifying attestation results. Note this patch does not tolerate bundles produced outside of GitHub Artifact Attestations, but it does prevent panics from occurring and introduces clear error messaging.

Fixes https://github.com/cli/cli/issues/9574