### PR TITLE
Suggest installing Rosetta when extension installation fails due to missing `darwin-arm64` binary, but a `darwin-amd64` binary is available

### DIFF
--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -267,14 +267,14 @@ func (m *Manager) installBin(repo ghrepo.Interface, target string) error {
 	if asset == nil && isMacARM {
 		for _, a := range r.Assets {
 			if strings.HasSuffix(a.Name, "darwin-amd64") {
-				if hasRosetta() {
-					asset = &a
-					break
-				} else {
+				if !hasRosetta() {
 					return fmt.Errorf(
 						"%[1]s unsupported for %[2]s. Install Rosetta with `softwareupdate --install-rosetta` to use the available darwin-amd64 binary, or open an issue: `gh issue create -R %[3]s/%[1]s -t'Support %[2]s'`",
 						repo.RepoName(), platform, repo.RepoOwner())
 				}
+
+				asset = &a
+				break
 			}
 		}
 	}

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -263,12 +263,18 @@ func (m *Manager) installBin(repo ghrepo.Interface, target string) error {
 		}
 	}
 
-	// if an arm64 binary is unavailable, fall back to amd64 if it can be executed through Rosetta 2
-	if asset == nil && isMacARM && hasRosetta() {
+	// if using an ARM-based Mac and an arm64 binary is unavailable, fall back to amd64 if a relevant binary is available and Rosetta 2 is installed
+	if asset == nil && isMacARM {
 		for _, a := range r.Assets {
 			if strings.HasSuffix(a.Name, "darwin-amd64") {
-				asset = &a
-				break
+				if hasRosetta() {
+					asset = &a
+					break
+				} else {
+					return fmt.Errorf(
+						"%[1]s unsupported for %[2]s. Install Rosetta with `softwareupdate --install-rosetta` to use the available darwin-amd64 binary, or open an issue: `gh issue create -R %[3]s/%[1]s -t'Support %[2]s'`",
+						repo.RepoName(), platform, repo.RepoOwner())
+				}
 			}
 		}
 	}

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -771,7 +771,7 @@ func possibleDists() []string {
 	}
 }
 
-func hasRosetta() bool {
+var hasRosetta = func() bool {
 	_, err := os.Stat("/Library/Apple/usr/libexec/oah/libRosettaRuntime")
 	return err == nil
 }


### PR DESCRIPTION
When installing an extension, the CLI must to select the correct binary to download for the machine (see the [`installBin` function](https://github.com/cli/cli/blob/78c1d00eccac1b2ae82ac0bfeea3e2292c98056a/pkg/cmd/extension/manager.go#L240)).

By default, the CLI will download a binary matching the current machine's architecture.

However, to provide better support for Macs running on Apple Silicon, it will [fall back](https://github.com/cli/cli/blob/78c1d00eccac1b2ae82ac0bfeea3e2292c98056a/pkg/cmd/extension/manager.go#L267-L274) from `darwin-arm64` to `darwin-amd64` if [Rosetta](https://support.apple.com/en-gb/102527) (Apple's compatibility layer) is installed.

If Rosetta isn't installed, this fallback doesn't happen, which can lead to surprising and confusing results when one Mac has Rosetta and another doesn't, because the extension will install on one machine but not another.

In the situation where a `darwin-arm64` binary isn't available but the CLI can't fall back to `amd64` because Rosetta isn't installed, this updates our error message to suggest installing Rosetta.

Fixes https://github.com/cli/cli/issues/9592.