### PR TITLE
Improve the suggested command for creating an issue when an extension doesn't have a binary for your platform

### DIFF
--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -285,8 +285,8 @@ func (m *Manager) installBin(repo ghrepo.Interface, target string) error {
 		issueCreateCommand := generateMissingBinaryIssueCreateCommand(repo.RepoOwner(), repo.RepoName(), platform)
 
 		return fmt.Errorf(
-			"%[1]s\n\nOpen an issue on the extension's repo by running the following command:\n\n	`%[2]s`",
-			errorMessageInRed, issueCreateCommand)
+			"%[1]s\n\nTo request support for %[2]s, open an issue on the extension's repo by running the following command:\n\n	`%[3]s`",
+			errorMessageInRed, platform, issueCreateCommand)
 	}
 
 	name := repo.RepoName()

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -280,9 +280,11 @@ func (m *Manager) installBin(repo ghrepo.Interface, target string) error {
 	}
 
 	if asset == nil {
+		issueCreateCommand := generateMissingBinaryIssueCreateCommand(repo.RepoOwner(), repo.RepoName(), platform)
+
 		return fmt.Errorf(
-			"%[1]s unsupported for %[2]s. Open an issue: `gh issue create -R %[3]s/%[1]s -t'Support %[2]s'`",
-			repo.RepoName(), platform, repo.RepoOwner())
+			"%[1]s unsupported for %[2]s. Open an issue: `%[3]s`",
+			repo.RepoName(), platform, issueCreateCommand)
 	}
 
 	name := repo.RepoName()
@@ -332,6 +334,15 @@ func (m *Manager) installBin(repo ghrepo.Interface, target string) error {
 	}
 
 	return nil
+}
+
+func generateMissingBinaryIssueCreateCommand(repoOwner string, repoName string, currentPlatform string) string {
+	issueBody := generateMissingBinaryIssueBody(currentPlatform)
+	return fmt.Sprintf("gh issue create -R %[1]s/%[2]s --title \"Add support for the %[3]s architecture\" --body \"%[4]s\"", repoOwner, repoName, currentPlatform, issueBody)
+}
+
+func generateMissingBinaryIssueBody(currentPlatform string) string {
+	return fmt.Sprintf("This extension does not support the %[1]s architecture. I tried to install it on a %[1]s machine, and it failed due to the lack of an available binary. Would you be able to update the extension's build and release process to include the relevant binary? For more details, see <https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions>.", currentPlatform)
 }
 
 func writeManifest(dir, name string, data []byte) (writeErr error) {

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -280,11 +280,13 @@ func (m *Manager) installBin(repo ghrepo.Interface, target string) error {
 	}
 
 	if asset == nil {
+		cs := m.io.ColorScheme()
+		errorMessageInRed := fmt.Sprintf(cs.Red("%[1]s unsupported for %[2]s."), repo.RepoName(), platform)
 		issueCreateCommand := generateMissingBinaryIssueCreateCommand(repo.RepoOwner(), repo.RepoName(), platform)
 
 		return fmt.Errorf(
-			"%[1]s unsupported for %[2]s. Open an issue: `%[3]s`",
-			repo.RepoName(), platform, issueCreateCommand)
+			"%[1]s\n\nOpen an issue on the extension's repo by running the following command:\n\n	`%[2]s`",
+			errorMessageInRed, issueCreateCommand)
 	}
 
 	name := repo.RepoName()

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -906,7 +906,7 @@ func TestManager_Install_binary_unsupported(t *testing.T) {
 	m := newTestManager(tempDir, &client, nil, ios)
 
 	err := m.Install(repo, "")
-	assert.EqualError(t, err, "gh-bin-ext unsupported for windows-amd64.\n\nOpen an issue on the extension's repo by running the following command:\n\n\t`gh issue create -R owner/gh-bin-ext --title \"Add support for the windows-amd64 architecture\" --body \"This extension does not support the windows-amd64 architecture. I tried to install it on a windows-amd64 machine, and it failed due to the lack of an available binary. Would you be able to update the extension's build and release process to include the relevant binary? For more details, see <https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions>.\"")
+	assert.EqualError(t, err, "gh-bin-ext unsupported for windows-amd64.\n\nTo request support for windows-amd64, open an issue on the extension's repo by running the following command:\n\n\t`gh issue create -R owner/gh-bin-ext --title \"Add support for the windows-amd64 architecture\" --body \"This extension does not support the windows-amd64 architecture. I tried to install it on a windows-amd64 machine, and it failed due to the lack of an available binary. Would you be able to update the extension's build and release process to include the relevant binary? For more details, see <https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions>.\"`")
 
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -906,7 +906,7 @@ func TestManager_Install_binary_unsupported(t *testing.T) {
 	m := newTestManager(tempDir, &client, nil, ios)
 
 	err := m.Install(repo, "")
-	assert.EqualError(t, err, "gh-bin-ext unsupported for windows-amd64. Open an issue: `gh issue create -R owner/gh-bin-ext -t'Support windows-amd64'`")
+	assert.EqualError(t, err, "gh-bin-ext unsupported for windows-amd64. Open an issue: `gh issue create -R owner/gh-bin-ext --title \"Add support for the windows-amd64 architecture\" --body \"This extension does not support the windows-amd64 architecture. I tried to install it on a windows-amd64 machine, and it failed due to the lack of an available binary. Would you be able to update the extension's build and release process to include the relevant binary? For more details, see <https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions>.\"`")
 
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -906,7 +906,7 @@ func TestManager_Install_binary_unsupported(t *testing.T) {
 	m := newTestManager(tempDir, &client, nil, ios)
 
 	err := m.Install(repo, "")
-	assert.EqualError(t, err, "gh-bin-ext unsupported for windows-amd64. Open an issue: `gh issue create -R owner/gh-bin-ext --title \"Add support for the windows-amd64 architecture\" --body \"This extension does not support the windows-amd64 architecture. I tried to install it on a windows-amd64 machine, and it failed due to the lack of an available binary. Would you be able to update the extension's build and release process to include the relevant binary? For more details, see <https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions>.\"`")
+	assert.EqualError(t, err, "gh-bin-ext unsupported for windows-amd64.\n\nOpen an issue on the extension's repo by running the following command:\n\n\t`gh issue create -R owner/gh-bin-ext --title \"Add support for the windows-amd64 architecture\" --body \"This extension does not support the windows-amd64 architecture. I tried to install it on a windows-amd64 machine, and it failed due to the lack of an available binary. Would you be able to update the extension's build and release process to include the relevant binary? For more details, see <https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions>.\"")
 
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())


### PR DESCRIPTION
When installing an extension, the CLI must to select the correct binary to download for the machine (see the [`installBin` function](https://github.com/cli/cli/blob/78c1d00eccac1b2ae82ac0bfeea3e2292c98056a/pkg/cmd/extension/manager.go#L240)).

By default, the CLI will download a binary matching the current machine's architecture.

If a suitable binary isn't available, the CLI [outputs an error](https://github.com/cli/cli/blob/78c1d00eccac1b2ae82ac0bfeea3e2292c98056a/pkg/cmd/extension/manager.go#L278), directing the user to create an issue on the extension's repository:

```go
if asset == nil {
	return fmt.Errorf(
		"%[1]s unsupported for %[2]s. Open an issue: `gh issue create -R %[3]s/%[1]s -t'Support %[2]s'`",
		repo.RepoName(), platform, repo.RepoOwner())
}
```

The issue this creates isn't very clear or helpful. It isn't obvious where it is coming from, or what you need to do.

This improves the suggested command, adding a better title to the issue and an explanatory body.

I have tested the resulting command on macOS and Windows, so I am confident that it has *at least reasonable* cross-platform support.

Fixes #9600.

## Testing instructions and sample output

To test this, try installing my `timrogers/gh-extension-without-binary` extension, which only has an esoteric `linux-ppc64` binary 😸:

```bash
gh extension install timrogers/gh-extension-without-binary
```

You'll get a nice (coloured) output like this:

![image](https://github.com/user-attachments/assets/4c1b86cc-a3ea-430e-8e93-26382423581f)

...which produces an issue like
https://github.com/timrogers/gh-extension-without-binary/issues/4.

<img width="983" alt="Screenshot 2024-09-12 at 12 31 36" src="https://github.com/user-attachments/assets/70464023-3835-4887-a8a4-86bd868e43a0">

