### PR TITLE
Suppress `attestation verify` output when no TTY present

### DIFF
--- a/pkg/cmd/attestation/io/handler.go
+++ b/pkg/cmd/attestation/io/handler.go
@@ -62,6 +62,10 @@ func (h *Handler) VerbosePrintf(f string, v ...interface{}) (int, error) {
 }
 
 func (h *Handler) PrintTable(headers []string, rows [][]string) error {
+	if !h.IO.IsStdoutTTY() {
+		return nil
+	}
+
 	t := tableprinter.New(h.IO, tableprinter.WithHeader(headers...))
 
 	for _, row := range rows {


### PR DESCRIPTION
Normally, the output of `gh attestation verify` looks something like the following:

```
Loaded digest sha256:d4b1e5cbc005e80684a73826a62ee81ea63a81f26c2df4d5a1a64d89cf386d06 for file:///Users/bdehamer/Downloads/artifact
Loaded 1 attestation from /Users/bdehamer/Downloads/actions-attest-build-provenance-attestation-2032782.sigstore.json
✓ Verification succeeded!

sha256:d4b1e5cbc005e80684a73826a62ee81ea63a81f26c2df4d5a1a64d89cf386d06 was attested by:
REPO                             PREDICATE_TYPE                  WORKFLOW                                    
actions/attest-build-provenance  https://slsa.dev/provenance/v1  .github/workflows/prober.yml@refs/heads/main
```

When running the command in GitHub Actions (an environment with no TTY), you'll see just the rows of the attestation table displayed. Something like:

```
actions/attest-build-provenance	https://slsa.dev/provenance/v1	.github/workflows/prober.yml@refs/heads/main
```

Without the rest of the information, this output doesn't make any sense. 

When running in an environment with no TTY, all of the output should be suppressed.

Fixes https://github.com/cli/cli/issues/9613