### PR TITLE
Use api subdomains for tenant hosts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/glamour v0.7.0
 	github.com/charmbracelet/lipgloss v0.10.1-0.20240413172830-d0be07ea6b9c
-	github.com/cli/go-gh/v2 v2.9.0
+	github.com/cli/go-gh/v2 v2.10.0
 	github.com/cli/oauth v1.0.1
 	github.com/cli/safeexec v1.0.1
 	github.com/cpuguy83/go-md2man/v2 v2.0.4

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/charmbracelet/x/exp/term v0.0.0-20240425164147-ba2a9512b05f/go.mod h1
 github.com/cli/browser v1.0.0/go.mod h1:IEWkHYbLjkhtjwwWlwTHW2lGxeS5gezEQBMLTwDHf5Q=
 github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
 github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
-github.com/cli/go-gh/v2 v2.9.0 h1:D3lTjEneMYl54M+WjZ+kRPrR5CEJ5BHS05isBPOV3LI=
-github.com/cli/go-gh/v2 v2.9.0/go.mod h1:MeRoKzXff3ygHu7zP+NVTT+imcHW6p3tpuxHAzRM2xE=
+github.com/cli/go-gh/v2 v2.10.0 h1:GMflBKoErBXlLvN2euxzL+p7JaM8erlSmw0cT7uZr7M=
+github.com/cli/go-gh/v2 v2.10.0/go.mod h1:MeRoKzXff3ygHu7zP+NVTT+imcHW6p3tpuxHAzRM2xE=
 github.com/cli/oauth v1.0.1 h1:pXnTFl/qUegXHK531Dv0LNjW4mLx626eS42gnzfXJPA=
 github.com/cli/oauth v1.0.1/go.mod h1:qd/FX8ZBD6n1sVNQO3aIdRxeu5LGw9WhKnYhIIoC2A4=
 github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=

--- a/internal/ghinstance/host.go
+++ b/internal/ghinstance/host.go
@@ -73,6 +73,13 @@ func GraphQLEndpoint(hostname string) string {
 	if isGarage(hostname) {
 		return fmt.Sprintf("https://%s/api/graphql", hostname)
 	}
+	// Once we change Tenancy to no longer be treated as Enterprise, this
+	// conditional can be removed as the flow will fall through to the bottom.
+	// However, we can't do that until we've investigated all places in which
+	// Tenancy is currently treated as Enterprise.
+	if IsTenancy(hostname) {
+		return fmt.Sprintf("https://api.%s/graphql", hostname)
+	}
 	if IsEnterprise(hostname) {
 		return fmt.Sprintf("https://%s/api/graphql", hostname)
 	}
@@ -85,6 +92,13 @@ func GraphQLEndpoint(hostname string) string {
 func RESTPrefix(hostname string) string {
 	if isGarage(hostname) {
 		return fmt.Sprintf("https://%s/api/v3/", hostname)
+	}
+	// Once we change Tenancy to no longer be treated as Enterprise, this
+	// conditional can be removed as the flow will fall through to the bottom.
+	// However, we can't do that until we've investigated all places in which
+	// Tenancy is currently treated as Enterprise.
+	if IsTenancy(hostname) {
+		return fmt.Sprintf("https://api.%s/", hostname)
 	}
 	if IsEnterprise(hostname) {
 		return fmt.Sprintf("https://%s/api/v3/", hostname)

--- a/internal/ghinstance/host_test.go
+++ b/internal/ghinstance/host_test.go
@@ -254,6 +254,10 @@ func TestGraphQLEndpoint(t *testing.T) {
 			host: "ghe.io",
 			want: "https://ghe.io/api/graphql",
 		},
+		{
+			host: "tenant.ghe.com",
+			want: "https://api.tenant.ghe.com/graphql",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.host, func(t *testing.T) {
@@ -284,6 +288,10 @@ func TestRESTPrefix(t *testing.T) {
 		{
 			host: "ghe.io",
 			want: "https://ghe.io/api/v3/",
+		},
+		{
+			host: "tenant.ghe.com",
+			want: "https://api.tenant.ghe.com/",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/attestation/verify/verify_test.go
+++ b/pkg/cmd/attestation/verify/verify_test.go
@@ -43,7 +43,7 @@ func TestNewVerifyCmd(t *testing.T) {
 			},
 		},
 	}
-	testReg.Register(httpmock.REST(http.MethodGet, "api/v3/meta"),
+	testReg.Register(httpmock.REST(http.MethodGet, "meta"),
 		httpmock.StatusJSONResponse(200, &metaResp))
 
 	f := &cmdutil.Factory{


### PR DESCRIPTION
## WARNING: This should not be merged until `go-gh` is released to include https://github.com/cli/go-gh/pull/172 and the dependency is bumped here.

## Description

When targeting the API of tenants we should be using the subdomain rather than the path prefix.

### Reviewer Notes

The easiest way to black box test these changes is to build and run the CLI with commands that use the `go-gh` GQL and REST clients such as:

```
GH_DEBUG=api GH_HOST=tenant.ghe.com ./bin/gh secret list --repo whatever/whatever # REST
GH_DEBUG=api GH_HOST=tenant.ghe.com ./bin/gh repo list # GQL
```

And to call the `gh api` command directly which constructs a raw [`NewHTTPClient` from `go-gh`](https://github.com/cli/cli/blob/4430c40298c398a05efee728e5f9cfce3a1ff1d4/pkg/cmd/factory/default.go#L106) and [parses the hostname directly](https://github.com/cli/cli/blob/4430c40298c398a05efee728e5f9cfce3a1ff1d4/pkg/cmd/api/http.go#L22-L24).

```
GH_HOST=tenant.ghe.com ./bin/gh api --verbose /user
GH_HOST=tenant.ghe.com ./bin/gh api --verbose graphql
```

In all cases the HTTP requests should demonstrate the API subdomain being used instead of the path prefix.

There are other commands that go through each of these paths but I believe this covers the various options.