### PR TITLE
configurable maxwidth for markdown WithWrap()

### DIFF
--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -99,6 +99,10 @@ var HelpTopics = []helpTopic{
 
 			%[1]sGH_PATH%[1]s: set the path to the gh executable, useful for when gh can not properly determine
 			its own path such as in the cygwin terminal.
+
+			%[1]sGH_MDWIDTH%[1]s: default maximum width for markdown render wrapping.  The max width of lines
+			wrapped on the terminal will be taken as the lesser of the terminal width, this value, or 120 if
+			not specified.  This value is used, for example, with %[1]spr view%[1]s subcommand.
 		`, "`"),
 	},
 	{

--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -1,6 +1,9 @@
 package markdown
 
 import (
+	"os"
+	"strconv"
+
 	"github.com/charmbracelet/glamour"
 	ghMarkdown "github.com/cli/go-gh/v2/pkg/markdown"
 )
@@ -10,11 +13,16 @@ func WithoutIndentation() glamour.TermRendererOption {
 }
 
 // WithWrap is a rendering option that set the character limit for soft
-// wrapping the markdown rendering. There is a max limit of 120 characters.
+// wrapping the markdown rendering. There is a max limit of 120 characters,
+// unless the user overrides with an environment variable.
 // If 0 is passed then wrapping is disabled.
 func WithWrap(w int) glamour.TermRendererOption {
-	if w > 120 {
-		w = 120
+	width, err := strconv.Atoi(os.Getenv("GH_MDWIDTH"))
+	if err != nil {
+		width = 120
+	}
+	if w > width {
+		w = width
 	}
 	return ghMarkdown.WithWrap(w)
 }


### PR DESCRIPTION
The markdown output width seems too wide.  For example for `gh pr view`, it would be desirable to limit to 80 columns.  This makes it more readable for some users that have a preference for narrower paragraphs.

In #6016 the maxwidth was changed from 80 to 120.  The current code appears to use `TerminalWidth()` (pkg/iostreams/iostreams.go) which populates from termios (ie `TIOCGWINSZ`), but won't exceed the hardcoded value of 120 as set in `WithWrap()` (pkg/markdown/markdown.go).

This patch adds an environment variable override, `$GH_MDWIDTH`, similar to how `$MANWIDTH` is used to set the display width of man pages.  The default remains at 120.

Without the patch, my workaround is like so:
```
script -qc "sh -c 'stty columns 80; gh pr view 1234'" /dev/null
```

It seems like the tool should have its own setting rather than hardcode it.  The other option would be to use a `gh config` setting, but the env var is really simple and obvious, and has precedent with other tools (like `man`).

Please apply, thanks.

Fixes #9627