### PR TITLE
Enhance gh repo create docs, fix random cmd link

### DIFF
--- a/pkg/cmd/auth/setupgit/setupgit.go
+++ b/pkg/cmd/auth/setupgit/setupgit.go
@@ -36,7 +36,7 @@ func NewCmdSetupGit(f *cmdutil.Factory, runF func(*SetupGitOptions) error) *cobr
 		Long: heredoc.Docf(`
 			This command configures %[1]sgit%[1]s to use GitHub CLI as a credential helper.
 			For more information on git credential helpers please reference:
-			https://git-scm.com/docs/gitcredentials.
+			<https://git-scm.com/docs/gitcredentials>.
 
 			By default, GitHub CLI will be set as the credential helper for all authenticated hosts.
 			If there is no authenticated hosts the command fails with an error.

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -93,7 +93,12 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			To create a remote repository from an existing local repository, specify the source directory with %[1]s--source%[1]s.
 			By default, the remote repository name will be the name of the source directory.
+
 			Pass %[1]s--push%[1]s to push any local commits to the new repository.
+
+			For language or platform .gitignore templates to use with %[1]s--gitignore%[1]s, <https://github.com/github/gitignore>.
+
+			For license keywords to use with %[1]s--license%[1]s, <https://choosealicense.com/>.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# create a repository interactively


### PR DESCRIPTION
Relates #8946

- updates the documentation within `gh repo create` to include links to lookup .gitignore templates and licenses
- fixes link markup within `gh auth setup-git` so link is formatted correctly on https://cli.github.com

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
