### PR TITLE
Add HasActiveToken method to AuthConfig to refactor auth check for `attestation trusted-root` command

### DIFF
--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -52,8 +52,32 @@ func TestTokenFromKeyringForUserErrorsIfUsernameIsBlank(t *testing.T) {
 	require.ErrorContains(t, err, "username cannot be blank")
 }
 
+func TestHasActiveToken(t *testing.T) {
+	// Given the user has logged in for a host
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "", false)
+	require.NoError(t, err)
+
+	// When we check if that host has an active token
+	hasActiveToken := authCfg.HasActiveToken("github.com")
+
+	// Then there is an active token
+	require.True(t, hasActiveToken, "expected there to be an active token")
+}
+
+func TestHasNoActiveToken(t *testing.T) {
+	// Given there are no users logged in for a host
+	authCfg := newTestAuthConfig(t)
+
+	// When we check if any host has an active token
+	hasActiveToken := authCfg.HasActiveToken("github.com")
+
+	// Then there is no active token
+	require.False(t, hasActiveToken, "expected there to be no active token")
+}
+
 func TestTokenStoredInConfig(t *testing.T) {
-	// When the user has logged in insecurely
+	// Given the user has logged in insecurely
 	authCfg := newTestAuthConfig(t)
 	_, err := authCfg.Login("github.com", "test-user", "test-token", "", false)
 	require.NoError(t, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -217,8 +217,7 @@ func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 	return token, source
 }
 
-// HasActiveToken returns true when a token for the hostname is
-// present.
+// HasActiveToken returns true when a token for the hostname is present.
 func (c *AuthConfig) HasActiveToken(hostname string) bool {
 	token, _ := c.ActiveToken(hostname)
 	return token != ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -217,6 +217,13 @@ func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 	return token, source
 }
 
+// HasActiveToken returns true when a token for the hostname is
+// present.
+func (c *AuthConfig) HasActiveToken(hostname string) bool {
+	token, _ := c.ActiveToken(hostname)
+	return token != ""
+}
+
 // HasEnvToken returns true when a token has been specified in an
 // environment variable, else returns false.
 func (c *AuthConfig) HasEnvToken() bool {

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -93,6 +93,9 @@ type Migration interface {
 // with knowledge on how to access encrypted storage when neccesarry.
 // Behavior is scoped to authentication specific tasks.
 type AuthConfig interface {
+	// HasActiveToken returns true when a token for the hostname is present.
+	HasActiveToken(hostname string) bool
+
 	// ActiveToken will retrieve the active auth token for the given hostname, searching environment variables,
 	// general configuration, and finally encrypted storage.
 	ActiveToken(hostname string) (token string, source string)

--- a/pkg/cmd/attestation/trustedroot/trustedroot.go
+++ b/pkg/cmd/attestation/trustedroot/trustedroot.go
@@ -74,7 +74,7 @@ func NewTrustedRootCmd(f *cmdutil.Factory, runF func(*Options) error) *cobra.Com
 					return err
 				}
 
-				if token, _ := c.Authentication().ActiveToken(opts.Hostname); token == "" {
+				if !c.Authentication().HasActiveToken(opts.Hostname) {
 					return fmt.Errorf("not authenticated with %s", opts.Hostname)
 				}
 

--- a/pkg/cmd/attestation/trustedroot/trustedroot_test.go
+++ b/pkg/cmd/attestation/trustedroot/trustedroot_test.go
@@ -109,7 +109,7 @@ func TestNewTrustedRootWithTenancy(t *testing.T) {
 			Config: func() (gh.Config, error) {
 				return &ghmock.ConfigMock{
 					AuthenticationFunc: func() gh.AuthConfig {
-						return &MockAuthConfig{Token: ""}
+						return &stubAuthConfig{hasActiveToken: false}
 					},
 				}, nil
 			},
@@ -136,7 +136,7 @@ func TestNewTrustedRootWithTenancy(t *testing.T) {
 			Config: func() (gh.Config, error) {
 				return &ghmock.ConfigMock{
 					AuthenticationFunc: func() gh.AuthConfig {
-						return &MockAuthConfig{Token: "TOKEN"}
+						return &stubAuthConfig{hasActiveToken: true}
 					},
 				}, nil
 			},
@@ -186,13 +186,13 @@ func TestGetTrustedRoot(t *testing.T) {
 
 }
 
-type MockAuthConfig struct {
+type stubAuthConfig struct {
 	config.AuthConfig
-	Token string
+	hasActiveToken bool
 }
 
-var _ gh.AuthConfig = (*MockAuthConfig)(nil)
+var _ gh.AuthConfig = (*stubAuthConfig)(nil)
 
-func (c *MockAuthConfig) ActiveToken(host string) (string, string) {
-	return c.Token, ""
+func (c *stubAuthConfig) HasActiveToken(host string) bool {
+	return c.hasActiveToken
 }


### PR DESCRIPTION
This PR proposes a new method to check if a hostname has an "active" token to slightly refactor the changes in https://github.com/cli/cli/pull/9610. Tests have also been updated accordingly.

Note this PR merges into `bdehamer/disable-attestation-trusted-root-auth-check`.

cc @bdehamer @williammartin 