### PR TITLE
Fix tenant-awareness for `trusted-root` command

### DIFF
--- a/pkg/cmd/attestation/trustedroot/trustedroot.go
+++ b/pkg/cmd/attestation/trustedroot/trustedroot.go
@@ -116,6 +116,12 @@ func getTrustedRoot(makeTUF tufClientInstantiator, opts *Options) error {
 	// Disable local caching, so we get up-to-date response from TUF repository
 	tufOpt.CacheValidity = 0
 
+	// Target will be either the default trusted root, or the trust domain-qualified one
+	ghTR := defaultTR
+	if opts.TrustDomain != "" {
+		ghTR = fmt.Sprintf("%s.%s", opts.TrustDomain, defaultTR)
+	}
+
 	if opts.TufUrl != "" && opts.TufRootPath != "" {
 		tufRoot, err := os.ReadFile(opts.TufRootPath)
 		if err != nil {
@@ -126,7 +132,7 @@ func getTrustedRoot(makeTUF tufClientInstantiator, opts *Options) error {
 		tufOpt.RepositoryBaseURL = opts.TufUrl
 		tufOptions = append(tufOptions, tufConfig{
 			tufOptions: tufOpt,
-			targets:    []string{defaultTR},
+			targets:    []string{ghTR},
 		})
 	} else {
 		// Get from both Sigstore public good and GitHub private instance
@@ -137,14 +143,9 @@ func getTrustedRoot(makeTUF tufClientInstantiator, opts *Options) error {
 
 		tufOpt = verification.GitHubTUFOptions()
 		tufOpt.CacheValidity = 0
-		targets := []string{defaultTR}
-		if opts.TrustDomain != "" {
-			targets = append(targets, fmt.Sprintf("%s.%s",
-				opts.TrustDomain, defaultTR))
-		}
 		tufOptions = append(tufOptions, tufConfig{
 			tufOptions: tufOpt,
-			targets:    targets,
+			targets:    []string{ghTR},
 		})
 	}
 


### PR DESCRIPTION
Addresses the issue in the `attestation trusted-root` command which prevents the `--tuf-url` and `--hostname` flags from being used together.

There is already logic which calculates the correct `trusted_root.json` prefix based on the supplied `--hostname` flag, but it was only being applied in the case where the `--tuf-url` was NOT supplied.

This change moves the logic to generate the tenant-aware `trusted_root.json` prefix and applies it to all cases.

Fixes #9637 