### PR TITLE
Replace "GitHub Enterprise Server" option with "other" in gh auth login prompting

### DIFF
--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -92,7 +92,7 @@ func (p *surveyPrompter) InputHostname() (string, error) {
 	var result string
 	err := p.ask(
 		&survey.Input{
-			Message: "GHE hostname:",
+			Message: "Hostname:",
 		}, &result, survey.WithValidator(func(v interface{}) error {
 			return ghinstance.HostnameValidator(v.(string))
 		}))

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -59,7 +59,8 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 		Long: heredoc.Docf(`
 			Authenticate with a GitHub host.
 
-			The %[1]shostname%[1]s is where you log in to GitHub. The default hostname is %[1]sgithub.com%[1]s.
+			The default hostname is %[1]sgithub.com%[1]s. This can be overridden using the %[1]s--hostname%[1]s
+			flag.
 
 			The default authentication mode is a web-based browser flow. After completion, an
 			authentication token will be stored securely in the system credential store.

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -228,7 +228,7 @@ func loginRun(opts *LoginOptions) error {
 func promptForHostname(opts *LoginOptions) (string, error) {
 	options := []string{"GitHub.com", "Other"}
 	hostType, err := opts.Prompter.Select(
-		"What account do you want to log into?",
+		"Where do you use GitHub?",
 		options[0],
 		options)
 	if err != nil {

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -233,12 +233,10 @@ func promptForHostname(opts *LoginOptions) (string, error) {
 		return "", err
 	}
 
-	isEnterprise := hostType == 1
-
-	hostname := ghinstance.Default()
-	if isEnterprise {
-		hostname, err = opts.Prompter.InputHostname()
+	isGitHubDotCom := hostType == 0
+	if isGitHubDotCom {
+		return ghinstance.Default(), nil
 	}
 
-	return hostname, err
+	return opts.Prompter.InputHostname()
 }

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -226,7 +226,7 @@ func loginRun(opts *LoginOptions) error {
 }
 
 func promptForHostname(opts *LoginOptions) (string, error) {
-	options := []string{"GitHub.com", "other"}
+	options := []string{"GitHub.com", "Other"}
 	hostType, err := opts.Prompter.Select(
 		"What account do you want to log into?",
 		options[0],

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -59,6 +59,10 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 		Long: heredoc.Docf(`
 			Authenticate with a GitHub host.
 
+			Your %[1]shostname%[1]s is the domain where the GitHub instance you are logging into is hosted.
+			For example, "github.com" is the default hostname for GitHub.com. To authenticate with
+			a different hostname like github.enterprise.com, use that hostname instead.
+
 			The default authentication mode is a web-based browser flow. After completion, an
 			authentication token will be stored securely in the system credential store.
 			If a credential store is not found or there is an issue using it gh will fallback

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -59,9 +59,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 		Long: heredoc.Docf(`
 			Authenticate with a GitHub host.
 
-			The %[1]shostname%[1]s is the domain where the GitHub instance you are logging into is hosted.
-			For example, "github.com" is the hostname for GitHub.com. To authenticate with
-			a different hostname like github.enterprise.com, use that hostname instead.
+			The %[1]shostname%[1]s is where you log in to GitHub. The default hostname is %[1]sgithub.com%[1]s.
 
 			The default authentication mode is a web-based browser flow. After completion, an
 			authentication token will be stored securely in the system credential store.

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -59,8 +59,8 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 		Long: heredoc.Docf(`
 			Authenticate with a GitHub host.
 
-			Your %[1]shostname%[1]s is the domain where the GitHub instance you are logging into is hosted.
-			For example, "github.com" is the default hostname for GitHub.com. To authenticate with
+			The %[1]shostname%[1]s is the domain where the GitHub instance you are logging into is hosted.
+			For example, "github.com" is the hostname for GitHub.com. To authenticate with
 			a different hostname like github.enterprise.com, use that hostname instead.
 
 			The default authentication mode is a web-based browser flow. After completion, an

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -222,7 +222,7 @@ func loginRun(opts *LoginOptions) error {
 }
 
 func promptForHostname(opts *LoginOptions) (string, error) {
-	options := []string{"GitHub.com", "GitHub Enterprise Server"}
+	options := []string{"GitHub.com", "other"}
 	hostType, err := opts.Prompter.Select(
 		"What account do you want to log into?",
 		options[0],

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -547,7 +547,7 @@ func Test_loginRun_Survey(t *testing.T) {
 			wantErrOut: regexp.MustCompile("Tip: you can generate a Personal Access Token here https://rebecca.chambers/settings/tokens"),
 		},
 		{
-			name: "choose other",
+			name: "choose Other",
 			wantHosts: heredoc.Doc(`
                 brad.vickers:
                     users:
@@ -565,7 +565,7 @@ func Test_loginRun_Survey(t *testing.T) {
 				pm.SelectFunc = func(prompt, _ string, opts []string) (int, error) {
 					switch prompt {
 					case "What account do you want to log into?":
-						return prompter.IndexFor(opts, "other")
+						return prompter.IndexFor(opts, "Other")
 					case "What is your preferred protocol for Git operations on this host?":
 						return prompter.IndexFor(opts, "HTTPS")
 					case "How would you like to authenticate GitHub CLI?":
@@ -816,15 +816,15 @@ func Test_promptForHostname(t *testing.T) {
 		expect            string
 	}{
 		{
-			name:              "select GitHub.com",
+			name:              "select 'GitHub.com'",
 			selectedIndex:     0,
 			expectedSelection: "GitHub.com",
 			expect:            "github.com",
 		},
 		{
-			name:              "select other",
+			name:              "select 'Other'",
 			selectedIndex:     1,
-			expectedSelection: "other",
+			expectedSelection: "Other",
 			inputHostname:     "github.enterprise.com",
 			expect:            "github.enterprise.com",
 		},

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -564,7 +564,7 @@ func Test_loginRun_Survey(t *testing.T) {
 			prompterStubs: func(pm *prompter.PrompterMock) {
 				pm.SelectFunc = func(prompt, _ string, opts []string) (int, error) {
 					switch prompt {
-					case "What account do you want to log into?":
+					case "Where do you use GitHub?":
 						return prompter.IndexFor(opts, "Other")
 					case "What is your preferred protocol for Git operations on this host?":
 						return prompter.IndexFor(opts, "HTTPS")
@@ -607,7 +607,7 @@ func Test_loginRun_Survey(t *testing.T) {
 			prompterStubs: func(pm *prompter.PrompterMock) {
 				pm.SelectFunc = func(prompt, _ string, opts []string) (int, error) {
 					switch prompt {
-					case "What account do you want to log into?":
+					case "Where do you use GitHub?":
 						return prompter.IndexFor(opts, "GitHub.com")
 					case "What is your preferred protocol for Git operations on this host?":
 						return prompter.IndexFor(opts, "HTTPS")
@@ -641,7 +641,7 @@ func Test_loginRun_Survey(t *testing.T) {
 			prompterStubs: func(pm *prompter.PrompterMock) {
 				pm.SelectFunc = func(prompt, _ string, opts []string) (int, error) {
 					switch prompt {
-					case "What account do you want to log into?":
+					case "Where do you use GitHub?":
 						return prompter.IndexFor(opts, "GitHub.com")
 					case "What is your preferred protocol for Git operations on this host?":
 						return prompter.IndexFor(opts, "SSH")


### PR DESCRIPTION
Closes #9641

## Changes

- `gh auth login` prompting now provides an "other" option in place of "GitHub Enterprise Server"
- Tests were added/updated to cover this change
- Docs were updated for the `gh auth login` command to clarify how to use hostnames

## To test

1. Pull down the branch and build using `make`
2. Run `bin/gh auth login`
3. Notice the change in prompt

<img width="714" alt="Screenshot 2024-09-20 at 2 16 30 PM" src="https://github.com/user-attachments/assets/ea8905af-a66e-4866-b265-bc9e4a63831d">

4. Complete the flow to see that it is successful

<img width="810" alt="Screenshot 2024-09-20 at 2 20 42 PM" src="https://github.com/user-attachments/assets/d37c94a4-20a6-486c-9706-c209ab8c045f">

