### PR TITLE
Add `dnf5` instructions to `docs/install_linux.md`

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -49,6 +49,9 @@ Alternatively, install from the [community repository](https://packages.fedorapr
 sudo dnf install gh
 ```
 
+> [!NOTE]
+> If errors regarding GPG signatures occur, see [cli/cli#9569](https://github.com/cli/cli/issues/9569) for steps to fix this.
+
 Upgrade:
 
 ```bash
@@ -90,6 +93,9 @@ Upgrade:
 sudo zypper ref
 sudo zypper update gh
 ```
+
+> [!NOTE]
+> If errors regarding GPG signatures occur, see [cli/cli#9569](https://github.com/cli/cli/issues/9569) for steps to fix this.
 
 ## Manual installation
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -43,6 +43,20 @@ sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.re
 sudo dnf install gh --repo gh-cli
 ```
 
+<details>
+<summary>Show dnf5 commands</summary>
+
+If you're using `dnf5`, commands will vary slightly:
+
+```bash
+sudo dnf5 install dnf5-plugins
+sudo dnf5 config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
+sudo dnf5 install gh --repo gh-cli
+```
+
+For more details, check out the [`dnf5 config-manager` documentation](https://dnf5.readthedocs.io/en/latest/dnf5_plugins/config-manager.8.html).
+</details>
+
 Alternatively, install from the [community repository](https://packages.fedoraproject.org/pkgs/gh/gh/):
 
 ```bash


### PR DESCRIPTION
- Add GPG key instructions to all appropriate sections
- Include `dnf5` commands
