### PR TITLE
Add commit `message` to `pr view` JSON commits export

### DIFF
--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -89,6 +89,7 @@ func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
 				}
 				commits = append(commits, map[string]interface{}{
 					"oid":             commit.OID,
+					"message":         commit.Message,
 					"messageHeadline": commit.MessageHeadline,
 					"messageBody":     commit.MessageBody,
 					"committedDate":   commit.CommittedDate,

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -260,6 +260,7 @@ type PullRequestCommitCommit struct {
 			User  GitHubUser
 		}
 	}
+	Message         string
 	MessageHeadline string
 	MessageBody     string
 	CommittedDate   time.Time

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -122,6 +122,7 @@ var prCommits = shortenQuery(`
 						user{id,login}
 					}
 				},
+				message,
 				messageHeadline,
 				messageBody,
 				oid,

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -38,6 +38,11 @@ func TestPullRequestGraphQL(t *testing.T) {
 			fields: []string{"projectItems"},
 			want:   `projectItems(first:100){nodes{id, project{id,title}, status:fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue{optionId,name}}},totalCount}`,
 		},
+		{
+			name:   "commits",
+			fields: []string{"commits"},
+			want:   "commits(first: 100) {nodes {commit {authors(first:100) {nodes {name,email,user{id,login}}},message,messageHeadline,messageBody,oid,committedDate,authoredDate}}}",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Add the full commit message to the output of `gh pr view <num> --json commits`. Also, add tests for commits to the query builder.

Fixes https://github.com/cli/cli/issues/9680