### PR TITLE
Add handling of empty title for Issue and PR prompting alt

### DIFF
--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -111,7 +111,12 @@ func BodySurvey(p Prompt, state *IssueMetadataState, templateContent string) err
 }
 
 func TitleSurvey(p Prompt, state *IssueMetadataState) error {
-	result, err := p.Input("Title", state.Title)
+	result, err := p.Input("Title (required)", state.Title)
+
+	if result == "" {
+		return fmt.Errorf("Title cannot be blank")
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is the alternative approach from #9701 

<img width="360" alt="Screenshot 2024-10-04 at 10 34 23 AM" src="https://github.com/user-attachments/assets/1322796d-3112-46cb-95d5-6f98fffae76b">
