### PR TITLE
Open PR against gh-merge-base

### DIFF
--- a/acceptance/testdata/pr/pr-create-from-issue-develop-base.txtar
+++ b/acceptance/testdata/pr/pr-create-from-issue-develop-base.txtar
@@ -1,0 +1,37 @@
+# Set up env vars
+env REPO=${SCRIPT_NAME}-${RANDOM_STRING}
+
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create ${ORG}/${REPO} --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes ${ORG}/${REPO}
+
+# Clone the repo
+exec gh repo clone ${ORG}/${REPO}
+
+# Create a branch to act as the merge base branch
+cd ${REPO}
+exec git checkout -b long-lived-feature-branch
+exec git push -u origin long-lived-feature-branch
+
+# Create an issue to develop against
+exec gh issue create --title 'Feature Request' --body 'Request Body'
+stdout2env ISSUE_URL
+
+# Create a new branch using issue develop with the long lived branch as the base
+exec gh issue develop --name 'feature-branch' --base 'long-lived-feature-branch' --checkout ${ISSUE_URL}
+
+# Prepare a PR on the develop branch
+exec git commit --allow-empty -m 'Empty Commit'
+exec git push -u origin feature-branch
+
+# Create the PR
+exec gh pr create --title 'Feature Title' --body 'Feature Body'
+
+# Check the PR is created against the base branch we specified
+exec gh pr view --json 'baseRefName' --jq '.baseRefName'
+stdout 'long-lived-feature-branch'

--- a/acceptance/testdata/pr/pr-create-from-manual-merge-base.txtar
+++ b/acceptance/testdata/pr/pr-create-from-manual-merge-base.txtar
@@ -1,0 +1,34 @@
+# Set up env vars
+env REPO=${SCRIPT_NAME}-${RANDOM_STRING}
+
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create ${ORG}/${REPO} --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes ${ORG}/${REPO}
+
+# Clone the repo
+exec gh repo clone ${ORG}/${REPO}
+
+# Create a branch to act as the merge base branch
+cd ${REPO}
+exec git checkout -b long-lived-feature-branch
+exec git push -u origin long-lived-feature-branch
+
+# Prepare a branch from the merge base to PR
+exec git checkout -b feature-branch
+exec git commit --allow-empty -m 'Empty Commit'
+exec git push -u origin feature-branch
+
+# Set the merge-base branch config
+exec git config 'branch.feature-branch.gh-merge-base' 'long-lived-feature-branch'
+
+# Create the PR
+exec gh pr create --title 'Feature Title' --body 'Feature Body'
+
+# Check the PR is created against the merge base branch
+exec gh pr view --json 'baseRefName' --jq '.baseRefName'
+stdout 'long-lived-feature-branch'

--- a/git/client.go
+++ b/git/client.go
@@ -20,6 +20,9 @@ import (
 	"github.com/cli/safeexec"
 )
 
+// MergeBaseConfig is the configuration setting to keep track of the PR target branch.
+const MergeBaseConfig = "gh-merge-base"
+
 var remoteRE = regexp.MustCompile(`(.+)\s+(.+)\s+\((push|fetch)\)`)
 
 // This regexp exists to match lines of the following form:
@@ -376,7 +379,7 @@ func (c *Client) lookupCommit(ctx context.Context, sha, format string) ([]byte, 
 // ReadBranchConfig parses the `branch.BRANCH.(remote|merge)` part of git config.
 func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (cfg BranchConfig) {
 	prefix := regexp.QuoteMeta(fmt.Sprintf("branch.%s.", branch))
-	args := []string{"config", "--get-regexp", fmt.Sprintf("^%s(remote|merge|gh-merge-base)$", prefix)}
+	args := []string{"config", "--get-regexp", fmt.Sprintf("^%s(remote|merge|%s)$", prefix, MergeBaseConfig)}
 	cmd, err := c.Command(ctx, args...)
 	if err != nil {
 		return
@@ -406,11 +409,24 @@ func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (cfg Branc
 			}
 		case "merge":
 			cfg.MergeRef = parts[1]
-		case "gh-merge-base":
+		case MergeBaseConfig:
 			cfg.MergeBase = parts[1]
 		}
 	}
 	return
+}
+
+// SetBranchConfig sets the named value on the given branch.
+func (c *Client) SetBranchConfig(ctx context.Context, branch, name, value string) error {
+	name = fmt.Sprintf("branch.%s.%s", branch, name)
+	args := []string{"config", name, value}
+	cmd, err := c.Command(ctx, args...)
+	if err != nil {
+		return err
+	}
+	// No output expected but check for any printed git error.
+	_, err = cmd.Output()
+	return err
 }
 
 func (c *Client) DeleteLocalTag(ctx context.Context, tag string) error {

--- a/git/client.go
+++ b/git/client.go
@@ -376,7 +376,7 @@ func (c *Client) lookupCommit(ctx context.Context, sha, format string) ([]byte, 
 	return out, nil
 }
 
-// ReadBranchConfig parses the `branch.BRANCH.(remote|merge)` part of git config.
+// ReadBranchConfig parses the `branch.BRANCH.(remote|merge|gh-merge-base)` part of git config.
 func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (cfg BranchConfig) {
 	prefix := regexp.QuoteMeta(fmt.Sprintf("branch.%s.", branch))
 	args := []string{"config", "--get-regexp", fmt.Sprintf("^%s(remote|merge|%s)$", prefix, MergeBaseConfig)}

--- a/git/client.go
+++ b/git/client.go
@@ -376,7 +376,7 @@ func (c *Client) lookupCommit(ctx context.Context, sha, format string) ([]byte, 
 // ReadBranchConfig parses the `branch.BRANCH.(remote|merge)` part of git config.
 func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (cfg BranchConfig) {
 	prefix := regexp.QuoteMeta(fmt.Sprintf("branch.%s.", branch))
-	args := []string{"config", "--get-regexp", fmt.Sprintf("^%s(remote|merge)$", prefix)}
+	args := []string{"config", "--get-regexp", fmt.Sprintf("^%s(remote|merge|gh-merge-base)$", prefix)}
 	cmd, err := c.Command(ctx, args...)
 	if err != nil {
 		return
@@ -385,6 +385,8 @@ func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (cfg Branc
 	if err != nil {
 		return
 	}
+
+	cfg.LocalName = branch
 	for _, line := range outputLines(out) {
 		parts := strings.SplitN(line, " ", 2)
 		if len(parts) < 2 {
@@ -404,6 +406,8 @@ func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (cfg Branc
 			}
 		case "merge":
 			cfg.MergeRef = parts[1]
+		case "gh-merge-base":
+			cfg.MergeBase = parts[1]
 		}
 	}
 	return

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -735,9 +735,9 @@ func TestClientReadBranchConfig(t *testing.T) {
 	}{
 		{
 			name:             "read branch config",
-			cmdStdout:        "branch.trunk.remote origin\nbranch.trunk.merge refs/heads/trunk",
-			wantCmdArgs:      `path/to/git config --get-regexp ^branch\.trunk\.(remote|merge)$`,
-			wantBranchConfig: BranchConfig{RemoteName: "origin", MergeRef: "refs/heads/trunk"},
+			cmdStdout:        "branch.trunk.remote origin\nbranch.trunk.merge refs/heads/trunk\nbranch.trunk.gh-merge-base trunk",
+			wantCmdArgs:      `path/to/git config --get-regexp ^branch\.trunk\.(remote|merge|gh-merge-base)$`,
+			wantBranchConfig: BranchConfig{LocalName: "trunk", RemoteName: "origin", MergeRef: "refs/heads/trunk", MergeBase: "trunk"},
 		},
 	}
 	for _, tt := range tests {

--- a/git/objects.go
+++ b/git/objects.go
@@ -71,7 +71,11 @@ type Commit struct {
 }
 
 type BranchConfig struct {
+	// LocalName of the branch.
+	LocalName  string
 	RemoteName string
 	RemoteURL  *url.URL
-	MergeRef   string
+	// MergeBase is the optional base branch to target in a new PR if `--base` is not specified.
+	MergeBase string
+	MergeRef  string
 }

--- a/pkg/cmd/issue/develop/develop.go
+++ b/pkg/cmd/issue/develop/develop.go
@@ -44,6 +44,13 @@ func NewCmdDevelop(f *cmdutil.Factory, runF func(*DevelopOptions) error) *cobra.
 	cmd := &cobra.Command{
 		Use:   "develop {<number> | <url>}",
 		Short: "Manage linked branches for an issue",
+		Long: heredoc.Docf(`
+			Manage linked branches for an issue.
+
+			When using the %[1]s--base%[1]s flag, the new development branch will be created from the specified
+			remote branch. The new branch will be configured as the base branch for pull requests created using
+			%[1]sgh pr create%[1]s.
+		`, "`"),
 		Example: heredoc.Doc(`
 			# List branches for issue 123
 			$ gh issue develop --list 123

--- a/pkg/cmd/issue/develop/develop.go
+++ b/pkg/cmd/issue/develop/develop.go
@@ -171,6 +171,14 @@ func developRunCreate(opts *DevelopOptions, apiClient *api.Client, issueRepo ghr
 		return err
 	}
 
+	// Remember which branch to target when creating a PR.
+	if opts.BaseBranch != "" {
+		err = opts.GitClient.SetBranchConfig(ctx.Background(), branchName, git.MergeBaseConfig, opts.BaseBranch)
+		if err != nil {
+			return err
+		}
+	}
+
 	fmt.Fprintf(opts.IO.Out, "%s/%s/tree/%s\n", branchRepo.RepoHost(), ghrepo.FullName(branchRepo), branchName)
 
 	return checkoutBranch(opts, branchRepo, branchName)

--- a/pkg/cmd/issue/develop/develop_test.go
+++ b/pkg/cmd/issue/develop/develop_test.go
@@ -399,6 +399,7 @@ func TestDevelopRun(t *testing.T) {
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git fetch origin \+refs/heads/my-branch:refs/remotes/origin/my-branch`, 0, "")
+				cs.Register(`git config branch\.my-branch\.gh-merge-base main`, 0, "")
 			},
 			expectedOut: "github.com/OWNER/REPO/tree/my-branch\n",
 		},

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -119,6 +119,10 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			alongside %[1]s--fill%[1]s, the values specified by %[1]s--title%[1]s and/or %[1]s--body%[1]s will
 			take precedence and overwrite any autofilled content.
 
+			The base branch for the created PR can be specified using the %[1]s--base%[1]s flag. If not provided,
+			the value of %[1]sgh-merge-base%[1]s git branch config will be used. If not configured, the repository's
+			default branch will be used.
+
 			Link an issue to the pull request by referencing the issue in the body of the pull
 			request. If the body text mentions %[1]sFixes #123%[1]s or %[1]sCloses #123%[1]s, the referenced issue
 			will automatically get closed when the pull request gets merged.

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -41,9 +41,8 @@ type CreateOptions struct {
 	Finder           shared.PRFinder
 	TitledEditSurvey func(string, string) (string, string, error)
 
-	TitleProvided      bool
-	BodyProvided       bool
-	BaseBranchProvided bool
+	TitleProvided bool
+	BodyProvided  bool
 
 	RootDirOverride string
 	RepoOverride    string
@@ -148,7 +147,6 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			opts.TitleProvided = cmd.Flags().Changed("title")
 			opts.RepoOverride, _ = cmd.Flags().GetString("repo")
-			opts.BaseBranchProvided = cmd.Flags().Changed("base")
 			// Workaround: Due to the way this command is implemented, we need to manually check GH_REPO.
 			// Commands should use the standard BaseRepoOverride functionality to handle this behavior instead.
 			if opts.RepoOverride == "" {
@@ -342,7 +340,7 @@ func createRun(opts *CreateOptions) (err error) {
 			ghrepo.FullName(ctx.BaseRepo))
 	}
 
-	if !opts.EditorMode && (opts.FillVerbose || opts.Autofill || opts.FillFirst || (opts.TitleProvided && opts.BodyProvided && ctx.BaseBranch != "")) {
+	if !opts.EditorMode && (opts.FillVerbose || opts.Autofill || opts.FillFirst || (opts.TitleProvided && opts.BodyProvided)) {
 		err = handlePush(*opts, *ctx)
 		if err != nil {
 			return
@@ -419,14 +417,6 @@ func createRun(opts *CreateOptions) (err error) {
 			}
 
 			err = shared.BodySurvey(opts.Prompter, state, templateContent)
-			if err != nil {
-				return
-			}
-		}
-
-		// Confirm the automatically-selected base branch.
-		if !opts.BaseBranchProvided {
-			err = confirmTrackingBranch(opts, ctx)
 			if err != nil {
 				return
 			}
@@ -564,14 +554,6 @@ func determineTrackingBranch(gitClient *git.Client, remotes ghContext.Remotes, h
 		}
 	}
 
-	return nil
-}
-
-func confirmTrackingBranch(opts *CreateOptions, ctx *CreateContext) (err error) {
-	ctx.BaseBranch, err = opts.Prompter.Input("Base branch", ctx.BaseBranch)
-	if err != nil {
-		return
-	}
 	return nil
 }
 

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1217,6 +1217,8 @@ func Test_createRun(t *testing.T) {
 				pm.InputFunc = func(p, d string) (string, error) {
 					if p == "Title (required)" {
 						return d, nil
+					} else if p == "Base branch" {
+						return d, nil
 					} else {
 						return "", prompter.NoSuchPromptErr(p)
 					}
@@ -1322,6 +1324,8 @@ func Test_createRun(t *testing.T) {
 
 				pm.InputFunc = func(p, d string) (string, error) {
 					if p == "Title (required)" {
+						return d, nil
+					} else if p == "Base branch" {
 						return d, nil
 					} else if p == "Body" {
 						return d, nil
@@ -1528,6 +1532,88 @@ func Test_createRun(t *testing.T) {
 			expectedOut:    "https://github.com/OWNER/REPO/pull/12\n",
 			expectedErrOut: "\nCreating pull request for monalisa:task1 into feature/feat2 in OWNER/REPO\n\n",
 		},
+		{
+			name: "non-default base branch prompt",
+			tty:  true,
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.BodyProvided = true
+				opts.Body = "my body"
+				opts.Branch = func() (string, error) {
+					return "task1", nil
+				}
+				opts.Remotes = func() (context.Remotes, error) {
+					return context.Remotes{
+						{
+							Remote: &git.Remote{
+								Name:     "upstream",
+								Resolved: "base",
+							},
+							Repo: ghrepo.New("OWNER", "REPO"),
+						},
+						{
+							Remote: &git.Remote{
+								Name: "origin",
+							},
+							Repo: ghrepo.New("monalisa", "REPO"),
+						},
+					}, nil
+				}
+				return func() {}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.GraphQLMutation(`
+							{ "data": { "createPullRequest": { "pullRequest": {
+								"URL": "https://github.com/OWNER/REPO/pull/12"
+							} } } }
+							`, func(input map[string]interface{}) {
+						assert.Equal(t, "REPOID", input["repositoryId"].(string))
+						assert.Equal(t, "my title", input["title"].(string))
+						assert.Equal(t, "my body", input["body"].(string))
+						assert.Equal(t, "feature/feat3", input["baseRefName"].(string))
+						assert.Equal(t, "monalisa:task1", input["headRefName"].(string))
+					}))
+			},
+			customBranchConfig: true,
+			cmdStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git config --get-regexp \^branch\\\.task1\\\.\(remote\|merge\|gh-merge-base\)\$`, 0, heredoc.Doc(`
+					branch.task1.remote origin
+					branch.task1.merge refs/heads/task1
+					branch.task1.gh-merge-base feature/feat2`)) // ReadBranchConfig
+				cs.Register(`git show-ref --verify`, 0, heredoc.Doc(`
+					deadbeef HEAD
+					deadb00f refs/remotes/upstream/feature/feat2
+					deadb01f refs/remotes/upstream/feature/feat3
+					deadbeef refs/remotes/origin/task1`)) // determineTrackingBranch
+				cs.Register(
+					"git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry upstream/feature/feat2...task1",
+					0,
+					"3a9b48085046d156c5acce8f3b3a0532cd706a4a\u0000my title\u0000my body\u0000\n") // initDefaultTitleBody from original base branch
+			},
+			promptStubs: func(pm *prompter.PrompterMock) {
+				pm.InputFunc = func(p, d string) (string, error) {
+					switch p {
+					case "Title (required)":
+						return "my title", nil
+					case "Base branch":
+						return "feature/feat3", nil
+					default:
+						return "", prompter.NoSuchPromptErr(p)
+					}
+				}
+				pm.SelectFunc = func(p, _ string, opts []string) (int, error) {
+					if p == "What's next?" {
+						return 0, nil
+					} else {
+						return -1, prompter.NoSuchPromptErr(p)
+					}
+				}
+			},
+			expectedOut: "https://github.com/OWNER/REPO/pull/12\n",
+			// Output message is created based on initial configuration; prompt will later override.
+			expectedErrOut: "\nCreating pull request for monalisa:task1 into feature/feat2 in OWNER/REPO\n\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1541,6 +1627,14 @@ func Test_createRun(t *testing.T) {
 			}
 
 			pm := &prompter.PrompterMock{}
+			pm.InputFunc = func(p, d string) (string, error) {
+				switch p {
+				case "Base branch":
+					return d, nil
+				default:
+					return "", prompter.NoSuchPromptErr(p)
+				}
+			}
 
 			if tt.promptStubs != nil {
 				tt.promptStubs(pm)


### PR DESCRIPTION
Partly resolves issue #8979 by checking for a `gh-merge-base` branch tag and using that as though it were passed to `gh pr create --base`.
