### PR TITLE
add extra example of creating a repo in an organization

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -112,6 +112,9 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			# create a remote repository from the current directory
 			gh repo create my-project --private --source=. --remote=upstream
+
+			# create a remote repository in an organization
+			gh repo create org-name/repo-name
 		`),
 		Args:    cobra.MaximumNArgs(1),
 		Aliases: []string{"new"},


### PR DESCRIPTION
This PR adds an extra example of creating a repository inside an organization. 

Fixes [https://github.com/cli/cli/issues/8340](https://github.com/cli/cli/issues/8340)