### PR TITLE
Add acceptance task to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,14 @@ completions: bin/gh$(EXE)
 	bin/gh$(EXE) completion -s fish > ./share/fish/vendor_completions.d/gh.fish
 	bin/gh$(EXE) completion -s zsh > ./share/zsh/site-functions/_gh
 
-# just a convenience task around `go test`
+# just convenience tasks around `go test`
 .PHONY: test
 test:
 	go test ./...
+
+.PHONY: acceptance
+acceptance:
+	go test -tags acceptance ./acceptance
 
 ## Site-related tasks are exclusively intended for use by the GitHub CLI team and for our release automation.
 

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ completions: bin/gh$(EXE)
 test:
 	go test ./...
 
+# For more information, see https://github.com/cli/cli/blob/trunk/acceptance/README.md
 .PHONY: acceptance
 acceptance:
 	go test -tags acceptance ./acceptance


### PR DESCRIPTION
## Description

With https://github.com/cli/cli/pull/9745 introducing an acceptance test suite that is only run with the `acceptance` build tag (and therefore not by `make test`) this adjusts the makefile have a target that runs them.

This is intentionally not part of `make test` because in my opinion standard test approaches (`make test` and `go test ./...`) should always pass without further configuration e.g env vars.

### Reviewer Notes

I've explicitly decided not to allow flags to be provided to `go test` via `make acceptance` because as far as I can see from reading around makefiles, it is a maintenance nightmare. It's low cost to run `go test -tags acceptance ./acceptance` directly if further configuration is required. Happy for someone to offer a different solution if it isn't arcane.