### PR TITLE
More discoverable help text to address #8918

### DIFF
--- a/pkg/cmd/pr/ready/ready.go
+++ b/pkg/cmd/pr/ready/ready.go
@@ -31,7 +31,7 @@ func NewCmdReady(f *cmdutil.Factory, runF func(*ReadyOptions) error) *cobra.Comm
 
 	cmd := &cobra.Command{
 		Use:   "ready [<number> | <url> | <branch>]",
-		Short: "Mark a pull request as ready for review",
+		Short: "Mark a pull request as ready for review (mark as draft with --undo)",
 		Long: heredoc.Docf(`
 			Mark a pull request as ready for review.
 


### PR DESCRIPTION
Partially addresses #8918 in lieu of adding a different CLI option in existing major versions

Signed-off-by: ksaleem <ksaleem@digitalocean.com>

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
