### PR TITLE
Support `GH_ACCEPTANCE_SCRIPT` env var to target a single script

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -32,6 +32,12 @@ A full example invocation can be found below:
 GH_ACCEPTANCE_HOST=<host> GH_ACCEPTANCE_ORG=<org> GH_ACCEPTANCE_TOKEN=<token> go test -tags=acceptance ./acceptance
 ```
 
+While writing a new test, it can be useful to target that specific script by providing the `GH_ACCEPTANCE_SCRIPT` env var in combination with the `-run` flag, for example:
+
+```
+GH_ACCEPTANCE_SCRIPT=pr-view.txtar GH_ACCEPTANCE_HOST=<host> GH_ACCEPTANCE_ORG=<org> GH_ACCEPTANCE_TOKEN=<token> go test -tags=acceptance -run ^TestPullRequests$ ./acceptance
+```
+
 #### Code Coverage
 
 To get code coverage, `go test` can be invoked with `coverpkg` and `coverprofile` like so:

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -35,10 +35,20 @@ func TestPullRequests(t *testing.T) {
 	testscript.Run(t, testScriptParamsFor(tsEnv, "pr"))
 }
 
-func testScriptParamsFor(tsEnv testScriptEnv, dir string) testscript.Params {
+func testScriptParamsFor(tsEnv testScriptEnv, command string) testscript.Params {
+	var files []string
+	if tsEnv.script != "" {
+		files = []string{path.Join("testdata", command, tsEnv.script)}
+	}
+
+	var dir string
+	if len(files) == 0 {
+		dir = path.Join("testdata", command)
+	}
+
 	return testscript.Params{
-		Dir:                 path.Join("testdata", dir),
-		Files:               []string{},
+		Dir:                 dir,
+		Files:               files,
 		Setup:               sharedSetup(tsEnv),
 		Cmds:                sharedCmds(tsEnv),
 		RequireExplicitExec: true,
@@ -128,6 +138,8 @@ type testScriptEnv struct {
 	org   string
 	token string
 
+	script string
+
 	skipDefer       bool
 	preserveWorkDir bool
 }
@@ -164,6 +176,7 @@ func (e *testScriptEnv) fromEnv() error {
 	e.org = envMap["GH_ACCEPTANCE_ORG"]
 	e.token = envMap["GH_ACCEPTANCE_TOKEN"]
 
+	e.script = os.Getenv("GH_ACCEPTANCE_SCRIPT")
 	e.preserveWorkDir = os.Getenv("GH_ACCEPTANCE_PRESERVE_WORK_DIR") == "true"
 	e.skipDefer = os.Getenv("GH_ACCEPTANCE_SKIP_DEFER") == "true"
 


### PR DESCRIPTION
## Description

This PR adds a `GH_ACCEPTANCE_SCRIPT` env var to allow running just a single script. It's a little janky since it needs to be provided with a `-run` flag but so far I've found a lot of value in it while developing each new script. See the README changes for more details.