### PR TITLE
Add Acceptance tests for `issue` command

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -28,8 +28,16 @@ func TestMain(m *testing.M) {
 func TestPullRequests(t *testing.T) {
 	var tsEnv testScriptEnv
 	if err := tsEnv.fromEnv(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "pr"))
+}
+
+func TestIssues(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
 	}
 
 	testscript.Run(t, testScriptParamsFor(tsEnv, "pr"))
@@ -120,7 +128,7 @@ type missingEnvError struct {
 }
 
 func (e missingEnvError) Error() string {
-	return fmt.Sprintf("environment variables %s must be set and non-empty", strings.Join(e.missingEnvs, ", "))
+	return fmt.Sprintf("environment variable(s) %s must be set and non-empty", strings.Join(e.missingEnvs, ", "))
 }
 
 type testScriptEnv struct {

--- a/acceptance/testdata/issue/issue-comment.txtar
+++ b/acceptance/testdata/issue/issue-comment.txtar
@@ -1,0 +1,20 @@
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Create an issue in the repo
+cd $SCRIPT_NAME-$RANDOM_STRING
+exec gh issue create --title 'Feature Request' --body 'Feature Body'
+stdout2env ISSUE_URL
+
+# Comment on the issue
+exec gh issue comment $ISSUE_URL --body 'Looks like a great feature!'
+
+# View the issue
+exec gh issue view $ISSUE_URL --comments
+stdout 'Looks like a great feature!'

--- a/acceptance/testdata/issue/issue-create-basic.txtar
+++ b/acceptance/testdata/issue/issue-create-basic.txtar
@@ -1,0 +1,17 @@
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Create an issue in the repo
+cd $SCRIPT_NAME-$RANDOM_STRING
+exec gh issue create --title 'Feature Request' --body 'Feature Body'
+stdout2env ISSUE_URL
+
+# Check the issue was created
+exec gh issue view $ISSUE_URL
+stdout 'title:\tFeature Request$'

--- a/acceptance/testdata/issue/issue-create-with-metadata.txtar
+++ b/acceptance/testdata/issue/issue-create-with-metadata.txtar
@@ -15,5 +15,5 @@ stdout2env ISSUE_URL
 # Check the issue was create
 exec gh issue view $ISSUE_URL
 stdout 'title:\tFeature Request$'
-stdout 'assignees:\t.*$'
+stdout 'assignees:\t.+$'
 stdout 'labels:\tbug$'

--- a/acceptance/testdata/issue/issue-create-with-metadata.txtar
+++ b/acceptance/testdata/issue/issue-create-with-metadata.txtar
@@ -1,0 +1,19 @@
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Create an issue in the repo
+cd $SCRIPT_NAME-$RANDOM_STRING
+exec gh issue create --title 'Feature Request' --body 'Feature Body' --assignee '@me' --label 'bug'
+stdout2env ISSUE_URL
+
+# Check the issue was create
+exec gh issue view $ISSUE_URL
+stdout 'title:\tFeature Request$'
+stdout 'assignees:\t.*$'
+stdout 'labels:\tbug$'

--- a/acceptance/testdata/issue/issue-list.txtar
+++ b/acceptance/testdata/issue/issue-list.txtar
@@ -1,0 +1,16 @@
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Create an issue in the repo
+cd $SCRIPT_NAME-$RANDOM_STRING
+exec gh issue create --title 'Feature Request' --body 'Feature Body'
+
+# Check the issue is included in the list output
+exec gh issue list
+stdout 'OPEN\tFeature Request'

--- a/acceptance/testdata/issue/issue-view.txtar
+++ b/acceptance/testdata/issue/issue-view.txtar
@@ -1,0 +1,17 @@
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Create an issue in the repo
+cd $SCRIPT_NAME-$RANDOM_STRING
+exec gh issue create --title 'Feature Request' --body 'Feature Body'
+stdout2env ISSUE_URL
+
+# Check the issue was created
+exec gh issue view $ISSUE_URL
+stdout 'title:\tFeature Request$'


### PR DESCRIPTION
## Description

This adds a set of tests for the `gh issue` command.

```
➜  cli git:(wm/testscript-issues) set -o pipefail && GH_ACCEPTANCE_HOST=github.com GH_ACCEPTANCE_ORG=gh-acceptance-testing go test -tags acceptance -json -coverprofile=coverage.out -coverpkg=./... -run ^TestIssues$ github.com/cli/cli/v2/acceptance | tparse --all go test
┌───────────────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │                 TEST                  │             PACKAGE               │
│─────────┼─────────┼───────────────────────────────────────┼───────────────────────────────────│
│  PASS   │    6.26 │ TestIssues/issue-create-with-metadata │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    6.08 │ TestIssues/issue-comment              │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    5.64 │ TestIssues/issue-list                 │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    5.21 │ TestIssues/issue-create-basic         │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    5.19 │ TestIssues/issue-view                 │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    0.00 │ TestIssues                            │ github.com/cli/cli/v2/acceptance  │
└───────────────────────────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │             PACKAGE              │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼──────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │  7.24s  │ github.com/cli/cli/v2/acceptance │ 11.6% │  6   │  0   │  0    │
└────────────────────────────────────────────────────────────────────────────────────┘
```

You can run these with:

```
GH_ACCEPTANCE_TOKEN=<token> GH_ACCEPTANCE_HOST=<host> GH_ACCEPTANCE_ORG=<org> go test -tags acceptance -json -run ^TestIssues$ github.com/cli/cli/v2/acceptance
```