### PR TITLE
Add acceptance tests for `workflow`, `run`, and `cache` commands

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"math/rand"
 
@@ -33,6 +35,16 @@ func TestPullRequests(t *testing.T) {
 	}
 
 	testscript.Run(t, testScriptParamsFor(tsEnv, "pr"))
+}
+
+func TestWorkflows(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "workflow"))
 }
 
 func testScriptParamsFor(tsEnv testScriptEnv, command string) testscript.Params {
@@ -118,6 +130,23 @@ func sharedCmds(tsEnv testScriptEnv) map[string]func(ts *testscript.TestScript, 
 			}
 
 			ts.Setenv(args[0], strings.TrimRight(ts.ReadFile("stdout"), "\n"))
+		},
+		"sleep": func(ts *testscript.TestScript, neg bool, args []string) {
+			if neg {
+				ts.Fatalf("unsupported: ! sleep")
+			}
+			if len(args) != 1 {
+				ts.Fatalf("usage: sleep seconds")
+			}
+
+			// sleep for the given number of seconds
+			seconds, err := strconv.Atoi(args[0])
+			if err != nil {
+				ts.Fatalf("invalid number of seconds: %v", err)
+			}
+
+			d := time.Duration(seconds) * time.Second
+			time.Sleep(d)
 		},
 	}
 }

--- a/acceptance/testdata/workflow/cache-list-delete.txtar
+++ b/acceptance/testdata/workflow/cache-list-delete.txtar
@@ -29,7 +29,7 @@ stdout 'Test Workflow Name'
 exec gh workflow run 'Test Workflow Name'
 
 # It takes some time for a workflow run to register
-sleep 5
+sleep 10
 
 # Get the run ID we want to watch
 exec gh run list --json databaseId --jq '.[0].databaseId'

--- a/acceptance/testdata/workflow/cache-list-delete.txtar
+++ b/acceptance/testdata/workflow/cache-list-delete.txtar
@@ -44,7 +44,6 @@ stdout 'Linux-values'
 
 # Delete the cache
 exec gh cache delete 'Linux-values'
-stdout ''
 
 -- workflow.yml --
 name: Test Workflow Name

--- a/acceptance/testdata/workflow/cache-list-delete.txtar
+++ b/acceptance/testdata/workflow/cache-list-delete.txtar
@@ -1,0 +1,70 @@
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# commit the workflow file
+cd $SCRIPT_NAME-$RANDOM_STRING
+mkdir .github/workflows
+mv ../workflow.yml .github/workflows/workflow.yml
+exec git add .github/workflows/workflow.yml
+exec git commit -m 'Create workflow file'
+exec git push -u origin main
+
+# Sleep because it takes a second for the workflow to register
+sleep 1
+
+# Check the workflow is indeed created
+exec gh workflow list
+stdout 'Test Workflow Name'
+
+# Run the workflow
+exec gh workflow run 'Test Workflow Name'
+
+# It takes some time for a workflow run to register
+sleep 5
+
+# Get the run ID we want to watch
+exec gh run list --json databaseId --jq '.[0].databaseId'
+stdout2env RUN_ID
+
+# Wait for workflow to complete
+exec gh run watch $RUN_ID --exit-status
+
+# List the cache
+exec gh cache list
+stdout 'Linux-values'
+
+# Delete the cache
+exec gh cache delete 'Linux-values'
+stdout ''
+
+-- workflow.yml --
+name: Test Workflow Name
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache values
+      id: cache-values
+      uses: actions/cache@v4
+      with:
+        path: values.txt
+        key: ${{ runner.os }}-values
+
+    - name: Generate values file
+      if: steps.cache-values.outputs.cache-hit != 'true'
+      run: echo "values" > values.txt

--- a/acceptance/testdata/workflow/run-cancel.txtar
+++ b/acceptance/testdata/workflow/run-cancel.txtar
@@ -1,0 +1,73 @@
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# commit the workflow file
+cd $SCRIPT_NAME-$RANDOM_STRING
+mkdir .github/workflows
+mv ../workflow.yml .github/workflows/workflow.yml
+exec git add .github/workflows/workflow.yml
+exec git commit -m 'Create workflow file'
+exec git push -u origin main
+
+# Sleep because it takes a second for the workflow to register
+sleep 1
+
+# Check the workflow is indeed created
+exec gh workflow list
+stdout 'Test Workflow Name'
+
+# Run the workflow
+exec gh workflow run 'Test Workflow Name'
+
+# It takes some time for a workflow run to register
+sleep 5
+
+# Get the run ID we want to cancel
+exec gh run list --json databaseId --jq '.[0].databaseId'
+stdout2env RUN_ID
+
+# cancel the workflow run
+exec gh run cancel $RUN_ID
+stdout '✓ Request to cancel workflow [0-9]+ submitted.'
+
+# It takes some time for a workflow run to be cancelled
+sleep 5
+
+# Check the workflow run is cancelled
+exec gh run list --json conclusion --jq '.[0].conclusion'
+stdout 'cancelled'
+
+-- workflow.yml --
+# This is a basic workflow to help you get started with Actions
+
+name: Test Workflow Name
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: sleep 30

--- a/acceptance/testdata/workflow/run-cancel.txtar
+++ b/acceptance/testdata/workflow/run-cancel.txtar
@@ -29,7 +29,7 @@ stdout 'Test Workflow Name'
 exec gh workflow run 'Test Workflow Name'
 
 # It takes some time for a workflow run to register
-sleep 5
+sleep 10
 
 # Get the run ID we want to cancel
 exec gh run list --json databaseId --jq '.[0].databaseId'

--- a/acceptance/testdata/workflow/run-cancel.txtar
+++ b/acceptance/testdata/workflow/run-cancel.txtar
@@ -39,8 +39,8 @@ stdout2env RUN_ID
 exec gh run cancel $RUN_ID
 stdout '✓ Request to cancel workflow [0-9]+ submitted.'
 
-# It takes some time for a workflow run to be cancelled
-sleep 5
+# Wait for workflow to complete
+exec gh run watch $RUN_ID
 
 # Check the workflow run is cancelled
 exec gh run list --json conclusion --jq '.[0].conclusion'

--- a/acceptance/testdata/workflow/run-delete.txtar
+++ b/acceptance/testdata/workflow/run-delete.txtar
@@ -1,0 +1,74 @@
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# commit the workflow file
+cd $SCRIPT_NAME-$RANDOM_STRING
+mkdir .github/workflows
+mv ../workflow.yml .github/workflows/workflow.yml
+exec git add .github/workflows/workflow.yml
+exec git commit -m 'Create workflow file'
+exec git push -u origin main
+
+# Sleep because it takes a second for the workflow to register
+sleep 1
+
+# Check the workflow is indeed created
+exec gh workflow list
+stdout 'Test Workflow Name'
+
+# Run the workflow
+exec gh workflow run 'Test Workflow Name'
+
+# It takes some time for a workflow run to register
+sleep 5
+
+# Get the run ID we want to watch & delete
+exec gh run list --json databaseId --jq '.[0].databaseId'
+stdout2env RUN_ID
+
+# Wait for workflow to complete
+exec gh run watch $RUN_ID --exit-status
+
+# Delete the workflow run
+exec gh run delete $RUN_ID
+stdout '✓ Request to delete workflow submitted.'
+
+# It takes some time for a workflow run to be deleted
+sleep 5
+
+# Check the workflow run is cancelled
+exec gh run list
+stdout ''
+
+-- workflow.yml --
+# This is a basic workflow to help you get started with Actions
+
+name: Test Workflow Name
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!

--- a/acceptance/testdata/workflow/run-delete.txtar
+++ b/acceptance/testdata/workflow/run-delete.txtar
@@ -45,7 +45,7 @@ stdout '✓ Request to delete workflow submitted.'
 # It takes some time for a workflow run to be deleted
 sleep 5
 
-# Check the workflow run is cancelled
+# Check the workflow run is cancelled, which is implied by an empty list
 exec gh run list
 stdout ''
 

--- a/acceptance/testdata/workflow/run-delete.txtar
+++ b/acceptance/testdata/workflow/run-delete.txtar
@@ -29,7 +29,7 @@ stdout 'Test Workflow Name'
 exec gh workflow run 'Test Workflow Name'
 
 # It takes some time for a workflow run to register
-sleep 5
+sleep 10
 
 # Get the run ID we want to watch & delete
 exec gh run list --json databaseId --jq '.[0].databaseId'

--- a/acceptance/testdata/workflow/run-download.txtar
+++ b/acceptance/testdata/workflow/run-download.txtar
@@ -40,7 +40,6 @@ exec gh run watch $RUN_ID --exit-status
 
 # Download the artifact
 exec gh run download $RUN_ID
-stdout '' 
 
 # Check if we downloaded the artifact
 exists ./my-artifact/world.txt

--- a/acceptance/testdata/workflow/run-download.txtar
+++ b/acceptance/testdata/workflow/run-download.txtar
@@ -29,7 +29,7 @@ stdout 'Test Workflow Name'
 exec gh workflow run 'Test Workflow Name'
 
 # It takes some time for a workflow run to register
-sleep 5
+sleep 10
 
 # Get the run ID we want to watch
 exec gh run list --json databaseId --jq '.[0].databaseId'

--- a/acceptance/testdata/workflow/run-download.txtar
+++ b/acceptance/testdata/workflow/run-download.txtar
@@ -63,7 +63,6 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - run: mkdir -p path/to/artifact
       - run: echo hello > world.txt
       - uses: actions/upload-artifact@v4
         with:

--- a/acceptance/testdata/workflow/run-download.txtar
+++ b/acceptance/testdata/workflow/run-download.txtar
@@ -1,0 +1,72 @@
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# commit the workflow file
+cd $SCRIPT_NAME-$RANDOM_STRING
+mkdir .github/workflows
+mv ../workflow.yml .github/workflows/workflow.yml
+exec git add .github/workflows/workflow.yml
+exec git commit -m 'Create workflow file'
+exec git push -u origin main
+
+# Sleep because it takes a second for the workflow to register
+sleep 1
+
+# Check the workflow is indeed created
+exec gh workflow list
+stdout 'Test Workflow Name'
+
+# Run the workflow
+exec gh workflow run 'Test Workflow Name'
+
+# It takes some time for a workflow run to register
+sleep 5
+
+# Get the run ID we want to watch
+exec gh run list --json databaseId --jq '.[0].databaseId'
+stdout2env RUN_ID
+
+# Wait for workflow to complete
+exec gh run watch $RUN_ID --exit-status
+
+# Download the artifact
+exec gh run download $RUN_ID
+stdout '' 
+
+# Check if we downloaded the artifact
+exists ./my-artifact/world.txt
+
+-- workflow.yml --
+# This is a basic workflow to help you get started with Actions
+
+name: Test Workflow Name
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - run: mkdir -p path/to/artifact
+      - run: echo hello > world.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: my-artifact
+          path: world.txt

--- a/acceptance/testdata/workflow/run-rerun.txtar
+++ b/acceptance/testdata/workflow/run-rerun.txtar
@@ -29,7 +29,7 @@ stdout 'Test Workflow Name'
 exec gh workflow run 'Test Workflow Name'
 
 # It takes some time for a workflow run to register
-sleep 5
+sleep 10
 
 # Get the run ID we want to rerun
 exec gh run list --json databaseId --jq '.[0].databaseId'
@@ -38,16 +38,12 @@ stdout2env RUN_ID
 # Wait for workflow to complete
 exec gh run watch $RUN_ID --exit-status
 
-# Get the run ID we want to rerun
-exec gh run list --json databaseId --jq '.[0].databaseId'
-stdout2env RUN_ID
-
 # Rerun the workflow run
 exec gh run rerun $RUN_ID
 stdout ''
 
 # It takes some time for a workflow run to register
-sleep 5
+sleep 10
 
 # Wait for workflow to complete
 exec gh run watch $RUN_ID --exit-status

--- a/acceptance/testdata/workflow/run-rerun.txtar
+++ b/acceptance/testdata/workflow/run-rerun.txtar
@@ -1,0 +1,79 @@
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# commit the workflow file
+cd $SCRIPT_NAME-$RANDOM_STRING
+mkdir .github/workflows
+mv ../workflow.yml .github/workflows/workflow.yml
+exec git add .github/workflows/workflow.yml
+exec git commit -m 'Create workflow file'
+exec git push -u origin main
+
+# Sleep because it takes a second for the workflow to register
+sleep 1
+
+# Check the workflow is indeed created
+exec gh workflow list
+stdout 'Test Workflow Name'
+
+# Run the workflow
+exec gh workflow run 'Test Workflow Name'
+
+# It takes some time for a workflow run to register
+sleep 5
+
+# Get the run ID we want to rerun
+exec gh run list --json databaseId --jq '.[0].databaseId'
+stdout2env RUN_ID
+
+# Wait for workflow to complete
+exec gh run watch $RUN_ID --exit-status
+
+# Get the run ID we want to rerun
+exec gh run list --json databaseId --jq '.[0].databaseId'
+stdout2env RUN_ID
+
+# Rerun the workflow run
+# There's some inconsistency here compared to `run delete` and other `run`
+# commands because run rerun doesn't return output in non-tty.
+exec gh run rerun $RUN_ID
+stdout ''
+
+# It takes some time for a workflow run to register
+sleep 5
+
+# Wait for workflow to complete
+exec gh run watch $RUN_ID --exit-status
+
+-- workflow.yml --
+# This is a basic workflow to help you get started with Actions
+
+name: Test Workflow Name
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!

--- a/acceptance/testdata/workflow/run-rerun.txtar
+++ b/acceptance/testdata/workflow/run-rerun.txtar
@@ -43,8 +43,6 @@ exec gh run list --json databaseId --jq '.[0].databaseId'
 stdout2env RUN_ID
 
 # Rerun the workflow run
-# There's some inconsistency here compared to `run delete` and other `run`
-# commands because run rerun doesn't return output in non-tty.
 exec gh run rerun $RUN_ID
 stdout ''
 

--- a/acceptance/testdata/workflow/run-rerun.txtar
+++ b/acceptance/testdata/workflow/run-rerun.txtar
@@ -40,7 +40,6 @@ exec gh run watch $RUN_ID --exit-status
 
 # Rerun the workflow run
 exec gh run rerun $RUN_ID
-stdout ''
 
 # It takes some time for a workflow run to register
 sleep 10

--- a/acceptance/testdata/workflow/run-view.txtar
+++ b/acceptance/testdata/workflow/run-view.txtar
@@ -1,0 +1,66 @@
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# commit the workflow file
+cd $SCRIPT_NAME-$RANDOM_STRING
+mkdir .github/workflows
+mv ../workflow.yml .github/workflows/workflow.yml
+exec git add .github/workflows/workflow.yml
+exec git commit -m 'Create workflow file'
+exec git push -u origin main
+
+# Sleep because it takes a second for the workflow to register
+sleep 1
+
+# Check the workflow is indeed created
+exec gh workflow list
+stdout 'Test Workflow Name'
+
+# Run the workflow
+exec gh workflow run 'Test Workflow Name'
+
+# It takes some time for a workflow run to register
+sleep 5
+
+# Get the run ID we want to view
+exec gh run list --json databaseId --jq '.[0].databaseId'
+stdout2env RUN_ID
+
+# Wait for workflow to complete
+exec gh run watch $RUN_ID --exit-status
+
+# View the workflow run
+exec gh run view $RUN_ID
+
+-- workflow.yml --
+# This is a basic workflow to help you get started with Actions
+
+name: Test Workflow Name
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: sleep 10

--- a/acceptance/testdata/workflow/run-view.txtar
+++ b/acceptance/testdata/workflow/run-view.txtar
@@ -63,4 +63,4 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Run a one-line script
-        run: sleep 10
+        run: echo Hello, world!

--- a/acceptance/testdata/workflow/run-view.txtar
+++ b/acceptance/testdata/workflow/run-view.txtar
@@ -29,7 +29,7 @@ stdout 'Test Workflow Name'
 exec gh workflow run 'Test Workflow Name'
 
 # It takes some time for a workflow run to register
-sleep 5
+sleep 10
 
 # Get the run ID we want to view
 exec gh run list --json databaseId --jq '.[0].databaseId'

--- a/acceptance/testdata/workflow/workflow-enable-disable.txtar
+++ b/acceptance/testdata/workflow/workflow-enable-disable.txtar
@@ -1,0 +1,71 @@
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# commit the workflow file
+cd $SCRIPT_NAME-$RANDOM_STRING
+mkdir .github/workflows
+mv ../workflow.yml .github/workflows/workflow.yml
+exec git add .github/workflows/workflow.yml
+exec git commit -m 'Create workflow file'
+exec git push -u origin main
+
+# Sleep because it takes a second for the workflow to register
+sleep 1
+
+# Check the workflow is indeed created
+exec gh workflow list
+stdout 'Test Workflow Name'
+
+# disable the workflow
+exec gh workflow disable 'Test Workflow Name'
+
+# Check the workflow is indeed disabled
+# Disabled workflows are hidden by default.
+exec gh workflow list
+stdout ''
+
+# Check that the listing shows it is disabled
+exec gh workflow list --all
+stdout 'Test\s+Workflow\s+Name\s+disabled_manually\s+\d+'
+
+# enable the workflow
+exec gh workflow enable 'Test Workflow Name'
+
+# Check the workflow is indeed enabled
+exec gh workflow list
+stdout 'Test Workflow Name'
+
+-- workflow.yml --
+# This is a basic workflow to help you get started with Actions
+
+name: Test Workflow Name
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: sleep 10

--- a/acceptance/testdata/workflow/workflow-enable-disable.txtar
+++ b/acceptance/testdata/workflow/workflow-enable-disable.txtar
@@ -63,4 +63,4 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Run a one-line script
-        run: sleep 10
+        run: echo Hello, world!

--- a/acceptance/testdata/workflow/workflow-enable-disable.txtar
+++ b/acceptance/testdata/workflow/workflow-enable-disable.txtar
@@ -28,11 +28,6 @@ stdout 'Test Workflow Name'
 # disable the workflow
 exec gh workflow disable 'Test Workflow Name'
 
-# Check the workflow is indeed disabled
-# Disabled workflows are hidden by default.
-exec gh workflow list
-stdout ''
-
 # Check that the listing shows it is disabled
 exec gh workflow list --all
 stdout 'Test\s+Workflow\s+Name\s+disabled_manually\s+\d+'
@@ -42,7 +37,7 @@ exec gh workflow enable 'Test Workflow Name'
 
 # Check the workflow is indeed enabled
 exec gh workflow list
-stdout 'Test Workflow Name'
+stdout 'Test\s+Workflow\s+Name\s+active\s+\d+'
 
 -- workflow.yml --
 # This is a basic workflow to help you get started with Actions

--- a/acceptance/testdata/workflow/workflow-list.txtar
+++ b/acceptance/testdata/workflow/workflow-list.txtar
@@ -1,0 +1,52 @@
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# commit the workflow file
+cd $SCRIPT_NAME-$RANDOM_STRING
+mkdir .github/workflows
+mv ../workflow.yml .github/workflows/workflow.yml
+exec git add .github/workflows/workflow.yml
+exec git commit -m 'Create workflow file'
+exec git push -u origin main
+
+# Sleep because it takes a second for the workflow to register
+sleep 1
+
+# Check the workflow is indeed created
+exec gh workflow list
+stdout 'Test Workflow Name'
+
+-- workflow.yml --
+# This is a basic workflow to help you get started with Actions
+
+name: Test Workflow Name
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: sleep 10

--- a/acceptance/testdata/workflow/workflow-list.txtar
+++ b/acceptance/testdata/workflow/workflow-list.txtar
@@ -49,4 +49,4 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Run a one-line script
-        run: sleep 10
+        run: echo Hello, world!

--- a/acceptance/testdata/workflow/workflow-run.txtar
+++ b/acceptance/testdata/workflow/workflow-run.txtar
@@ -1,0 +1,62 @@
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# commit the workflow file
+cd $SCRIPT_NAME-$RANDOM_STRING
+mkdir .github/workflows
+mv ../workflow.yml .github/workflows/workflow.yml
+exec git add .github/workflows/workflow.yml
+exec git commit -m 'Create workflow file'
+exec git push -u origin main
+
+# Sleep because it takes a second for the workflow to register
+sleep 1
+
+# Check the workflow is indeed created
+exec gh workflow list
+stdout 'Test Workflow Name'
+
+# Run the workflow
+exec gh workflow run 'Test Workflow Name'
+
+# It takes some time for a workflow run to register
+sleep 5
+
+# Check the workflow run exists
+exec gh run list
+stdout 'Test Workflow Name' 
+
+-- workflow.yml --
+# This is a basic workflow to help you get started with Actions
+
+name: Test Workflow Name
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!

--- a/acceptance/testdata/workflow/workflow-run.txtar
+++ b/acceptance/testdata/workflow/workflow-run.txtar
@@ -29,7 +29,7 @@ stdout 'Test Workflow Name'
 exec gh workflow run 'Test Workflow Name'
 
 # It takes some time for a workflow run to register
-sleep 5
+sleep 10
 
 # Check the workflow run exists
 exec gh run list

--- a/acceptance/testdata/workflow/workflow-view.txtar
+++ b/acceptance/testdata/workflow/workflow-view.txtar
@@ -49,4 +49,4 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Run a one-line script
-        run: sleep 10
+        run: echo Hello, world!

--- a/acceptance/testdata/workflow/workflow-view.txtar
+++ b/acceptance/testdata/workflow/workflow-view.txtar
@@ -1,0 +1,52 @@
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# commit the workflow file
+cd $SCRIPT_NAME-$RANDOM_STRING
+mkdir .github/workflows
+mv ../workflow.yml .github/workflows/workflow.yml
+exec git add .github/workflows/workflow.yml
+exec git commit -m 'Create workflow file'
+exec git push -u origin main
+
+# Sleep because it takes a second for the workflow to register
+sleep 1
+
+# Check the workflow is indeed created
+exec gh workflow view 'Test Workflow Name'
+stdout 'Test Workflow Name - workflow.yml'
+
+-- workflow.yml --
+# This is a basic workflow to help you get started with Actions
+
+name: Test Workflow Name
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: sleep 10


### PR DESCRIPTION
This adds a set of tests for the `gh workflow`, `gh run`, and `gh cache` commands:

```
❯ set -o pipefail && GH_ACCEPTANCE_HOST=github.com GH_ACCEPTANCE_ORG=gh-acceptance-testing go test -tags acceptance -json -run ^TestWorkflows$ github.com/cli/cli/v2/acceptance | tparse --all go test
┌───────────────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │                 TEST                  │             PACKAGE               │
│─────────┼─────────┼───────────────────────────────────────┼───────────────────────────────────│
│  PASS   │   46.22 │ TestWorkflows/run-rerun               │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   38.29 │ TestWorkflows/run-view                │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   34.86 │ TestWorkflows/cache-list-delete       │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   32.85 │ TestWorkflows/run-delete              │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   28.11 │ TestWorkflows/run-download            │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   24.68 │ TestWorkflows/run-cancel              │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   18.31 │ TestWorkflows/workflow-run            │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    9.75 │ TestWorkflows/workflow-enable-disable │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    7.35 │ TestWorkflows/workflow-view           │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    6.25 │ TestWorkflows/workflow-list           │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    0.00 │ TestWorkflows                         │ github.com/cli/cli/v2/acceptance  │
└───────────────────────────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │             PACKAGE              │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼──────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │ 46.85s  │ github.com/cli/cli/v2/acceptance │  --   │  11  │  0   │  0    │
└────────────────────────────────────────────────────────────────────────────────────┘
```

You can run these with:

```
GH_ACCEPTANCE_TOKEN=<token> GH_ACCEPTANCE_HOST=<host> GH_ACCEPTANCE_ORG=<org> go test -tags acceptance -json -run ^TestWorkflows$ github.com/cli/cli/v2/acceptance
```


## Notes

This PR implements a `sleep` command because we need to wait between operations for the actions backend to wake-up before the API will start returning data. I don't particularly like the approach, but to avoid spending more time on it I've left it as-is pending feedback.