### PR TITLE
Add basic `api` acceptance tests

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -55,6 +55,15 @@ func TestWorkflows(t *testing.T) {
 	testscript.Run(t, testScriptParamsFor(tsEnv, "workflow"))
 }
 
+func TestAPI(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "api"))
+}
+
 func testScriptParamsFor(tsEnv testScriptEnv, command string) testscript.Params {
 	var files []string
 	if tsEnv.script != "" {

--- a/acceptance/testdata/api/basic-graphql.txtar
+++ b/acceptance/testdata/api/basic-graphql.txtar
@@ -1,0 +1,3 @@
+# Basic graphql request
+exec gh api graphql -f query='query { viewer { login } }'
+stdout '"login":'

--- a/acceptance/testdata/api/basic-rest.txtar
+++ b/acceptance/testdata/api/basic-rest.txtar
@@ -1,0 +1,3 @@
+# Basic REST request
+exec gh api /user
+stdout '"login":'


### PR DESCRIPTION
This adds extremely basic acceptance tests for the `api` command:

```
❯ set -o pipefail && GH_ACCEPTANCE_HOST=github.com GH_ACCEPTANCE_ORG=gh-acceptance-testing GH_ACCEPTANCE_TOKEN=$(gh auth token) go test -tags acceptance -json -run ^TestAPI$ github.com/cli/cli/v2/acceptance | tparse --all go test
┌───────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │         TEST          │             PACKAGE               │
│─────────┼─────────┼───────────────────────┼───────────────────────────────────│
│  PASS   │    0.98 │ TestAPI/basic-graphql │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    0.97 │ TestAPI/basic-rest    │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    0.00 │ TestAPI               │ github.com/cli/cli/v2/acceptance  │
└───────────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │             PACKAGE              │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼──────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │  1.60s  │ github.com/cli/cli/v2/acceptance │  --   │  3   │  0   │  0    │
└────────────────────────────────────────────────────────────────────────────────────┘
``` 

You can run these with:

```
GH_ACCEPTANCE_TOKEN=<token> GH_ACCEPTANCE_HOST=<host> GH_ACCEPTANCE_ORG=<org> go test -tags acceptance -json -run ^TestAPI$ github.com/cli/cli/v2/acceptance
```

## Notes

I opted to not include any complex scenarios here - I think it would be challenging to find a balance between over testing the API itself and testing use-cases that are important to `gh api`. Open to feedback on additional test cases that are mindful of this balance.