### PR TITLE
Print friendly error when `release create` fails due to missing `workflow` OAuth scope

### DIFF
--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -1102,10 +1102,12 @@ func Test_createRun(t *testing.T) {
 					httpmock.REST("POST", "repos/OWNER/REPO/releases"),
 					httpmock.StatusScopesResponder(404, `repo,read:org`))
 			},
-			wantErr: heredoc.Doc(`
-				HTTP 404: Failed to create release, "workflow" scope may be required
-				To request it, run gh auth refresh -h github.com -s workflow
+			wantStderr: heredoc.Doc(`
+				! Failed to create release, "workflow" scope may be required.
+				To request it, run:
+				gh auth refresh -h github.com -s workflow
 			`),
+			wantErr: cmdutil.SilentError.Error(),
 		},
 		{
 			name:  "API returns 404, OAuth token has workflow scope",
@@ -1182,7 +1184,6 @@ func Test_createRun(t *testing.T) {
 			err := createRun(&tt.opts)
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
-				return
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -238,6 +238,20 @@ func ScopesResponder(scopes string) func(*http.Request) (*http.Response, error) 
 	}
 }
 
+// StatusScopesResponder returns a response with the given status code and OAuth scopes.
+func StatusScopesResponder(status int, scopes string) func(*http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Request:    req,
+			Header: map[string][]string{
+				"X-Oauth-Scopes": {scopes},
+			},
+			Body: io.NopCloser(bytes.NewBufferString("")),
+		}, nil
+	}
+}
+
 func httpResponse(status int, req *http.Request, body io.Reader) *http.Response {
 	return httpResponseWithHeader(status, req, body, http.Header{})
 }

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -225,17 +225,9 @@ func GraphQLQuery(body string, cb func(string, map[string]interface{})) Responde
 	}
 }
 
+// ScopesResponder returns a response with a 200 status code and the given OAuth scopes.
 func ScopesResponder(scopes string) func(*http.Request) (*http.Response, error) {
-	return func(req *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: 200,
-			Request:    req,
-			Header: map[string][]string{
-				"X-Oauth-Scopes": {scopes},
-			},
-			Body: io.NopCloser(bytes.NewBufferString("")),
-		}, nil
-	}
+	return StatusScopesResponder(http.StatusOK, scopes)
 }
 
 // StatusScopesResponder returns a response with the given status code and OAuth scopes.


### PR DESCRIPTION
Resolves https://github.com/cli/cli/issues/9773 by adding a friendly error message when `gh release create` fails and it may be due to a missing `workflow` OAuth scope.

Example leveraging a fork of the repo in https://github.com/cli/cli/issues/9773:

```
gh release create v0.1.0 --target a602187ebae72cc0e8101cc46fc116a51c9e9e39 --title foo --notes bar -R bagtoad/bevy-yoetz
HTTP 404: Failed to create release, "workflow" scope may be required
To request it, run gh auth refresh -h github.com -s workflow
```