### PR TITLE
`gh at verify` retries fetching attestations if it receives a 5xx

### DIFF
--- a/pkg/cmd/attestation/api/client.go
+++ b/pkg/cmd/attestation/api/client.go
@@ -1,11 +1,14 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/cli/cli/v2/api"
 	ioconfig "github.com/cli/cli/v2/pkg/cmd/attestation/io"
 )
@@ -69,6 +72,9 @@ func (c *LiveClient) GetTrustDomain() (string, error) {
 	return c.getTrustDomain(MetaPath)
 }
 
+// Allow injecting backoff interval in tests.
+var getAttestationRetryInterval = time.Millisecond * 200
+
 func (c *LiveClient) getAttestations(url, name, digest string, limit int) ([]*Attestation, error) {
 	c.logger.VerbosePrintf("Fetching attestations for artifact digest %s\n\n", digest)
 
@@ -87,14 +93,31 @@ func (c *LiveClient) getAttestations(url, name, digest string, limit int) ([]*At
 	var attestations []*Attestation
 	var resp AttestationsResponse
 	var err error
+	bo := backoff.NewConstantBackOff(getAttestationRetryInterval)
+
 	// if no attestation or less than limit, then keep fetching
 	for url != "" && len(attestations) < limit {
-		url, err = c.api.RESTWithNext(c.host, http.MethodGet, url, nil, &resp)
+		err = backoff.Retry(func() error {
+			newURL, err := c.api.RESTWithNext(c.host, http.MethodGet, url, nil, &resp)
+
+			if err != nil {
+				if shouldRetry(err) {
+					return err
+				} else {
+					return backoff.Permanent(err)
+				}
+			}
+
+			url = newURL
+			attestations = append(attestations, resp.Attestations...)
+
+			return nil
+		}, backoff.WithMaxRetries(bo, 3))
+
+		// bail if RESTWithNext errored out
 		if err != nil {
 			return nil, err
 		}
-
-		attestations = append(attestations, resp.Attestations...)
 	}
 
 	if len(attestations) == 0 {
@@ -106,6 +129,17 @@ func (c *LiveClient) getAttestations(url, name, digest string, limit int) ([]*At
 	}
 
 	return attestations, nil
+}
+
+func shouldRetry(err error) bool {
+	var httpError api.HTTPError
+	if errors.As(err, &httpError) {
+		if httpError.StatusCode >= 500 && httpError.StatusCode <= 599 {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (c *LiveClient) getTrustDomain(url string) (string, error) {

--- a/pkg/cmd/attestation/api/client_test.go
+++ b/pkg/cmd/attestation/api/client_test.go
@@ -206,6 +206,9 @@ func TestGetTrustDomain(t *testing.T) {
 }
 
 func TestGetAttestationsRetries(t *testing.T) {
+	oldInterval := getAttestationRetryInterval
+	getAttestationRetryInterval = 0
+
 	fetcher := mockDataGenerator{
 		NumAttestations: 5,
 	}
@@ -229,4 +232,6 @@ func TestGetAttestationsRetries(t *testing.T) {
 	require.Equal(t, 10, len(attestations))
 	bundle := (attestations)[0].Bundle
 	require.Equal(t, bundle.GetMediaType(), "application/vnd.dev.sigstore.bundle.v0.3+json")
+
+	getAttestationRetryInterval = oldInterval
 }

--- a/pkg/cmd/attestation/api/client_test.go
+++ b/pkg/cmd/attestation/api/client_test.go
@@ -206,7 +206,6 @@ func TestGetTrustDomain(t *testing.T) {
 }
 
 func TestGetAttestationsRetries(t *testing.T) {
-	oldInterval := getAttestationRetryInterval
 	getAttestationRetryInterval = 0
 
 	fetcher := mockDataGenerator{
@@ -242,13 +241,10 @@ func TestGetAttestationsRetries(t *testing.T) {
 	require.Equal(t, len(attestations), 10)
 	bundle = (attestations)[0].Bundle
 	require.Equal(t, bundle.GetMediaType(), "application/vnd.dev.sigstore.bundle.v0.3+json")
-
-	getAttestationRetryInterval = oldInterval
 }
 
 // test total retries
 func TestGetAttestationsMaxRetries(t *testing.T) {
-	oldInterval := getAttestationRetryInterval
 	getAttestationRetryInterval = 0
 
 	fetcher := mockDataGenerator{
@@ -266,5 +262,4 @@ func TestGetAttestationsMaxRetries(t *testing.T) {
 	require.Error(t, err)
 
 	fetcher.AssertNumberOfCalls(t, "OnREST500Error", 4)
-	getAttestationRetryInterval = oldInterval
 }

--- a/pkg/cmd/attestation/api/mock_apiClient_test.go
+++ b/pkg/cmd/attestation/api/mock_apiClient_test.go
@@ -30,11 +30,11 @@ type mockDataGenerator struct {
 	NumAttestations int
 }
 
-func (m mockDataGenerator) OnRESTSuccess(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+func (m *mockDataGenerator) OnRESTSuccess(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
 	return m.OnRESTWithNextSuccessHelper(hostname, method, p, body, data, false)
 }
 
-func (m mockDataGenerator) OnRESTSuccessWithNextPage(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+func (m *mockDataGenerator) OnRESTSuccessWithNextPage(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
 	// if path doesn't contain after, it means first time hitting the mock server
 	// so return the first page and return the link header in the response
 	if !strings.Contains(p, "after") {
@@ -75,7 +75,7 @@ func (m *mockDataGenerator) OnREST500ErrorHandler() func(hostname, method, p str
 	}
 }
 
-func (m mockDataGenerator) OnRESTWithNextSuccessHelper(hostname, method, p string, body io.Reader, data interface{}, hasNext bool) (string, error) {
+func (m *mockDataGenerator) OnRESTWithNextSuccessHelper(hostname, method, p string, body io.Reader, data interface{}, hasNext bool) (string, error) {
 	atts := make([]*Attestation, m.NumAttestations)
 	for j := 0; j < m.NumAttestations; j++ {
 		att := makeTestAttestation()
@@ -105,7 +105,7 @@ func (m mockDataGenerator) OnRESTWithNextSuccessHelper(hostname, method, p strin
 	return "", nil
 }
 
-func (m mockDataGenerator) OnRESTWithNextNoAttestations(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+func (m *mockDataGenerator) OnRESTWithNextNoAttestations(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
 	resp := AttestationsResponse{
 		Attestations: make([]*Attestation, 0),
 	}
@@ -124,7 +124,7 @@ func (m mockDataGenerator) OnRESTWithNextNoAttestations(hostname, method, p stri
 	return "", nil
 }
 
-func (m mockDataGenerator) OnRESTWithNextError(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+func (m *mockDataGenerator) OnRESTWithNextError(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
 	return "", errors.New("failed to get attestations")
 }
 

--- a/pkg/cmd/attestation/api/mock_apiClient_test.go
+++ b/pkg/cmd/attestation/api/mock_apiClient_test.go
@@ -65,6 +65,16 @@ func (m *mockDataGenerator) FlakyOnRESTSuccessWithNextPageHandler() func(hostnam
 	}
 }
 
+// always returns a 500
+func (m *mockDataGenerator) OnREST500ErrorHandler() func(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+	m.On("OnREST500Error").Return()
+	return func(hostname, method, p string, body io.Reader, data interface{}) (string, error) {
+		m.MethodCalled("OnREST500Error")
+
+		return "", cliAPI.HTTPError{HTTPError: &ghAPI.HTTPError{StatusCode: 500}}
+	}
+}
+
 func (m mockDataGenerator) OnRESTWithNextSuccessHelper(hostname, method, p string, body io.Reader, data interface{}, hasNext bool) (string, error) {
 	atts := make([]*Attestation, m.NumAttestations)
 	for j := 0; j < m.NumAttestations; j++ {


### PR DESCRIPTION
Closes https://github.com/cli/cli/issues/9741

This PR:
- wraps the `api.RESTWithNext` and `api.REST` calls in `getAttestations` and `getTrustDomain` inside a `backoff.Retry` function
- adds a test that verifies that the backoff is being executed

Of note for reviewers:
- I arbitrarily selected a constant backoff, and a retry limit of 3. Feel free to suggest alternatives! cf https://pkg.go.dev/github.com/cenkalti/backoff/v4#ExponentialBackOff
- Mostly copied from https://github.com/cli/cli/blob/857854d1b3fa00aa5aa9f5a107191595ede08150/pkg/cmd/release/shared/upload.go#L140-L147