### PR TITLE
Use new GitHub preview terms in `working-with-us.md`

### DIFF
--- a/docs/working-with-us.md
+++ b/docs/working-with-us.md
@@ -25,13 +25,13 @@ Describe how your new command would be used. Include mock-up examples, including
 
 We take this step seriously because we believe in keeping `gh`'s interface consistent and intuitive.
 
-## Step 2: Beta
+## Step 2: Public Preview
 
-Once we've signed off on the proposed UX on the issue opened in step 1, develop your extension to at least beta quality. It's up to you if you actually want to go through a beta release phase with real users or not.
+Once we've signed off on the proposed UX on the issue opened in step 1, develop your extension to at least public preview quality. It's up to you if you actually want to go through a public preview release phase with real users or not.
 
 ## Step 3: Merge or no merge
 
-With a beta in hand it's time to decide whether or not to mainline your extension into the `trunk` of `gh`. Some questions to consider:
+With a public preview in hand it's time to decide whether or not to mainline your extension into the `trunk` of `gh`. Some questions to consider:
 
 - How complex is the support burden for your feature?
 


### PR DESCRIPTION
Update the "working with us" doc to align with new GitHub previews terminology, replacing `beta` with `public preview`.

https://github.blog/changelog/2024-10-18-new-terminology-for-github-previews/
