### PR TITLE
Adjust environment help for host and tokens

### DIFF
--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -42,16 +42,17 @@ var HelpTopics = []helpTopic{
 		name:  "environment",
 		short: "Environment variables that can be used with gh",
 		long: heredoc.Docf(`
-			%[1]sGH_TOKEN%[1]s, %[1]sGITHUB_TOKEN%[1]s (in order of precedence): an authentication token for github.com
-			API requests. Setting this avoids being prompted to authenticate and takes precedence over
-			previously stored credentials.
+			%[1]sGH_TOKEN%[1]s, %[1]sGITHUB_TOKEN%[1]s (in order of precedence): an authentication token that will be
+			used when the host that is targeted by a command is either github.com or a subdomain of ghe.com.
+			Setting this avoids being prompted to authenticate and takes precedence over previously stored credentials.
 
-			%[1]sGH_ENTERPRISE_TOKEN%[1]s, %[1]sGITHUB_ENTERPRISE_TOKEN%[1]s (in order of precedence): an authentication
-			token for API requests to GitHub Enterprise. When setting this, also set %[1]sGH_HOST%[1]s.
+			%[1]sGH_ENTERPRISE_TOKEN%[1]s, %[1]sGITHUB_ENTERPRISE_TOKEN%[1]s (in order of precedence): an authentication 
+			token that will be used when the host that is targeted by a command is a GitHub Enterprise Server instance.
 
-			%[1]sGH_HOST%[1]s: specify the GitHub hostname for commands that would otherwise assume the
-			"github.com" host when not in a context of an existing repository. When setting this, 
-			also set %[1]sGH_ENTERPRISE_TOKEN%[1]s.
+			%[1]sGH_HOST%[1]s: specify the GitHub hostname for commands where a hostname has not been provided, or 
+			cannot be inferred from the context of a local git repository. If this host was previously authenticated
+			with, the stored credentials will be used. Otherwise, setting %[1]sGH_TOKEN%[1]s or
+			%[1]sGH_ENTERPRISE_TOKEN%[1]s is required, depending on the targeted host.
 
 			%[1]sGH_REPO%[1]s: specify the GitHub repository in the %[1]s[HOST/]OWNER/REPO%[1]s format for commands
 			that otherwise operate on a local repository.

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -50,7 +50,7 @@ var HelpTopics = []helpTopic{
 			token that will be used when a command targets a GitHub Enterprise Server host.
 
 			%[1]sGH_HOST%[1]s: specify the GitHub hostname for commands where a hostname has not been provided, or
-			cannot be inferred from the context of a local git repository. If this host was previously
+			cannot be inferred from the context of a local Git repository. If this host was previously
 			authenticated with, the stored credentials will be used. Otherwise, setting %[1]sGH_TOKEN%[1]s or
 			%[1]sGH_ENTERPRISE_TOKEN%[1]s is required, depending on the targeted host.
 

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -41,17 +41,17 @@ var HelpTopics = []helpTopic{
 	{
 		name:  "environment",
 		short: "Environment variables that can be used with gh",
-		long: heredoc.Docf(`
-			%[1]sGH_TOKEN%[1]s, %[1]sGITHUB_TOKEN%[1]s (in order of precedence): an authentication token that will be
-			used when the host that is targeted by a command is either github.com or a subdomain of ghe.com.
-			Setting this avoids being prompted to authenticate and takes precedence over previously stored credentials.
+		long: heredoc.Docf(`	
+			%[1]sGH_TOKEN%[1]s, %[1]sGITHUB_TOKEN%[1]s (in order of precedence): an authentication token that will be used when
+			a command targets either github.com or a subdomain of ghe.com. Setting this avoids being prompted to
+			authenticate and takes precedence over previously stored credentials.
 
 			%[1]sGH_ENTERPRISE_TOKEN%[1]s, %[1]sGITHUB_ENTERPRISE_TOKEN%[1]s (in order of precedence): an authentication 
-			token that will be used when the host that is targeted by a command is a GitHub Enterprise Server instance.
+			token that will be used when a command targets a GitHub Enterprise Server host.
 
-			%[1]sGH_HOST%[1]s: specify the GitHub hostname for commands where a hostname has not been provided, or 
-			cannot be inferred from the context of a local git repository. If this host was previously authenticated
-			with, the stored credentials will be used. Otherwise, setting %[1]sGH_TOKEN%[1]s or
+			%[1]sGH_HOST%[1]s: specify the GitHub hostname for commands where a hostname has not been provided, or
+			cannot be inferred from the context of a local git repository. If this host was previously
+			authenticated with, the stored credentials will be used. Otherwise, setting %[1]sGH_TOKEN%[1]s or
 			%[1]sGH_ENTERPRISE_TOKEN%[1]s is required, depending on the targeted host.
 
 			%[1]sGH_REPO%[1]s: specify the GitHub repository in the %[1]s[HOST/]OWNER/REPO%[1]s format for commands


### PR DESCRIPTION
## Description

With [GitHub Enterprise Cloud with data residency](https://github.com/newsroom/press-releases/data-residency-in-the-eu) becoming available, we've decided that `GH_TOKEN` will be used when targeting those hosts.

This PR clarifies that, and clarifies that `ENTERPRISE_TOKEN` is only used for GitHub Enterprise Server hosts.

We also adjusted `GH_HOST` because it wasn't quite accurate as there are more ways that a hostname can be provided or inferred than a local git repository. 