### PR TITLE
Add testscripts for gpg-key and label commands

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -86,7 +86,7 @@ func TestRepo(t *testing.T) {
 	if err := tsEnv.fromEnv(); err != nil {
 		t.Fatal(err)
 	}
-  
+
 	testscript.Run(t, testScriptParamsFor(tsEnv, "repo"))
 }
 
@@ -106,6 +106,15 @@ func TestVariables(t *testing.T) {
 	}
 
 	testscript.Run(t, testScriptParamsFor(tsEnv, "variable"))
+}
+
+func TestGPGKeys(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "gpg-key"))
 }
 
 func testScriptParamsFor(tsEnv testScriptEnv, command string) testscript.Params {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -117,6 +117,15 @@ func TestGPGKeys(t *testing.T) {
 	testscript.Run(t, testScriptParamsFor(tsEnv, "gpg-key"))
 }
 
+func TestLabels(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "label"))
+}
+
 func testScriptParamsFor(tsEnv testScriptEnv, command string) testscript.Params {
 	var files []string
 	if tsEnv.script != "" {

--- a/acceptance/testdata/gpg-key/gpg-key.txtar
+++ b/acceptance/testdata/gpg-key/gpg-key.txtar
@@ -1,0 +1,32 @@
+skip 'it modifies the user''s personal GitHub account GPG keys'
+
+# This test requires the admin:gpg_key scope to add and delete GPG keys to and
+# from the user's personal GitHub account. 
+# This test uses a GPG key that generated for this test only. The private key
+# has been deleted
+
+# Add the gpg key to GH account
+exec gh gpg-key add gpg-key.pub
+
+# Defer deleting the gpg key from GH account
+defer gh gpg-key delete --yes 24C30F9C9115E747
+
+# Verify the gpg key was added to GH account
+exec gh gpg-key list
+stdout 24C30F9C9115E747
+
+-- gpg-key.pub --
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mDMEZxpWhhYJKwYBBAHaRw8BAQdAmYiobR2ai/lVWOBtlAPRG1ZEMG5Effavpt5w
+n+wQ//W0R0dIIENMSSBhY2NlcHRhbmNlIHRlc3QgKGZvciBHSCBDTEkgYWNjZXB0
+YW5jZSB0ZXN0aW5nKSA8Y2xpQGdpdGh1Yi5jb20+iJkEExYKAEEWIQTEAQLLUl1x
+MDSmbL0kww+ckRXnRwUCZxpWhgIbAwUJAAFRgAULCQgHAgIiAgYVCgkICwIEFgID
+AQIeBwIXgAAKCRAkww+ckRXnRxkuAP9GiFi/etWxRjnkomdTaOU8Ccd6oHspuEzB
+PFxOJdYslQD+MXgY5UhM/q2iEVj0tiVsfRzDqB+g2weaF5EpqIwWcQ+4OARnGlaG
+EgorBgEEAZdVAQUBAQdA3D1vnVTc9URDQw/oAd1mG/zRX7vF4QrjFqFIt7uMf2gD
+AQgHiH4EGBYKACYWIQTEAQLLUl1xMDSmbL0kww+ckRXnRwUCZxpWhgIbDAUJAAFR
+gAAKCRAkww+ckRXnRxVuAQCngnR11jh2mob0FN0rPWce2juoJsh5gPB2d7LS4r5P
+VwEA6F2FeetcP51EyKyQGTp3GpmZgk0uCGJa1G5uqT+9mgc=
+=RLWi
+-----END PGP PUBLIC KEY BLOCK-----

--- a/acceptance/testdata/label/label.txtar
+++ b/acceptance/testdata/label/label.txtar
@@ -1,0 +1,25 @@
+# Setup useful env vars
+env REPO=${SCRIPT_NAME}-${RANDOM_STRING}
+
+# Create a repository
+exec gh repo create ${ORG}/${REPO} --private
+
+# Defer repo cleanup
+defer gh repo delete --yes ${ORG}/${REPO}
+
+# Set the GH_REPO env var to reduce redunant flags
+env GH_REPO=${ORG}/${REPO}
+
+# Create a custom label
+exec gh label create 'acceptance-test' --description 'First Description'
+
+# List the labels and check our custom label is there
+exec gh label list
+stdout 'acceptance-test\tFirst Description'
+
+# Edit the label
+exec gh label edit 'acceptance-test' --description 'Edited Description'
+
+# List the labels and check our custom label has been updated
+exec gh label list
+stdout 'acceptance-test\tEdited Description'


### PR DESCRIPTION
## Description

This PR adds a test script for the `gpg-key` and `label` commands. The `gpg-key` testscript is skipped by default because it modifies the test runner's personal gpg keys, so we'd rather people opted into that. In future perhaps we could add a `cond` so that people can toggle the running of this script programmatically, without modifying the script itself but that seems like a separate issue.