### PR TITLE
Add acceptance tests for `org` and `ssh-key` commands

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -135,6 +135,15 @@ func TestSSHKeys(t *testing.T) {
 	testscript.Run(t, testScriptParamsFor(tsEnv, "ssh-key"))
 }
 
+func TestOrg(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "org"))
+}
+
 func testScriptParamsFor(tsEnv testScriptEnv, command string) testscript.Params {
 	var files []string
 	if tsEnv.script != "" {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -126,6 +126,15 @@ func TestLabels(t *testing.T) {
 	testscript.Run(t, testScriptParamsFor(tsEnv, "label"))
 }
 
+func TestSSHKeys(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "ssh-key"))
+}
+
 func testScriptParamsFor(tsEnv testScriptEnv, command string) testscript.Params {
 	var files []string
 	if tsEnv.script != "" {

--- a/acceptance/testdata/gpg-key/gpg-key.txtar
+++ b/acceptance/testdata/gpg-key/gpg-key.txtar
@@ -8,12 +8,16 @@ skip 'it modifies the user''s personal GitHub account GPG keys'
 # Add the gpg key to GH account
 exec gh gpg-key add gpg-key.pub
 
-# Defer deleting the gpg key from GH account
-defer gh gpg-key delete --yes 24C30F9C9115E747
-
 # Verify the gpg key was added to GH account
 exec gh gpg-key list
-stdout 24C30F9C9115E747
+stdout '24C30F9C9115E747'
+
+# Delete the gpg key from GH account
+exec gh gpg-key delete --yes '24C30F9C9115E747'
+
+# Check the key is deleted
+exec gh gpg-key list
+! stdout '24C30F9C9115E747'
 
 -- gpg-key.pub --
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/acceptance/testdata/org/org-list.txtar
+++ b/acceptance/testdata/org/org-list.txtar
@@ -1,0 +1,6 @@
+# This test could fail if the user is a member of more than 30 organizations because
+# the `gh org list` command only returns the first 30 organizations the user is a member of
+
+# List organizations the user is a member of
+exec gh org list
+stdout ${GH_ACCEPTANCE_ORG}

--- a/acceptance/testdata/ssh-key/ssh-key.txtar
+++ b/acceptance/testdata/ssh-key/ssh-key.txtar
@@ -1,0 +1,24 @@
+skip 'it modifies the user''s personal GitHub account SSH keys'
+
+# scopes admin:ssh_signing_key,admin:public_key
+
+# Add an SSH key to the account
+exec gh ssh-key add sshKey.pub --title 'acceptance-test-key'
+
+# List the SSH keys
+exec gh ssh-key list
+stdout 'acceptance-test-key'
+
+# Get the ID of the key we created
+exec gh api /user/keys --jq '.[] | select(.title == "acceptance-test-key") | .id'
+stdout2env SSH_KEY_ID
+
+# Delete the SSH key
+exec gh ssh-key delete --yes ${SSH_KEY_ID}
+
+# Check the key is deleted
+exec gh ssh-key list
+! stdout 'acceptance-test-key'
+
+-- sshKey.pub --
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAZmdeRNskfpvYL5YHB/YJaW8hTEXpnvPMkx5Ri+YwUr acceptance


### PR DESCRIPTION
This adds acceptance tests for `org` and `ssh-key` commands.

The `ssh-key` testscript is skipped by default because it modifies the test runner's personal SSH keys, so we'd rather people opted into that. In future perhaps we could add a `cond` so that people can toggle the running of this script programmatically, without modifying the script itself but that seems like a separate issue. (Same story as https://github.com/cli/cli/pull/9811)

Note that we also update the `gpg-key` tests here to align with a more direct testing of key deletion that we came up with in this PR for `ssh-key`.

## Test Results

**`ssh-key` tests:**

```
set -o pipefail && GH_ACCEPTANCE_TOKEN=$(gh auth token) GH_ACCEPTANCE_HOST=github.com GH_ACCEPTANCE_ORG=gh-acceptance-testing go test -tags acceptance -json -run ^TestSSHKeys$ github.com/cli/cli/v2/acceptance  | tparse --all go test
┌─────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │        TEST         │             PACKAGE               │
│─────────┼─────────┼─────────────────────┼───────────────────────────────────│
│  PASS   │    2.91 │ TestSSHKeys/ssh-key │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    0.00 │ TestSSHKeys         │ github.com/cli/cli/v2/acceptance  │
└─────────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │             PACKAGE              │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼──────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │  3.53s  │ github.com/cli/cli/v2/acceptance │  --   │  2   │  0   │  0    │
└────────────────────────────────────────────────────────────────────────────────────┘
```

**`org` tests:**

```
set -o pipefail && GH_ACCEPTANCE_TOKEN=$(gh auth token) GH_ACCEPTANCE_HOST=github.com GH_ACCEPTANCE_ORG=gh-acceptance-testing go test -tags acceptance -json -run ^TestOrg$ github.com/cli/cli/v2/acceptance  | tparse --all go test
┌──────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │       TEST       │             PACKAGE               │
│─────────┼─────────┼──────────────────┼───────────────────────────────────│
│  PASS   │    1.46 │ TestOrg/org-list │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    0.00 │ TestOrg          │ github.com/cli/cli/v2/acceptance  │
└──────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │             PACKAGE              │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼──────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │  2.06s  │ github.com/cli/cli/v2/acceptance │  --   │  2   │  0   │  0    │
└────────────────────────────────────────────────────────────────────────────────────┘
```


**`gpg-key` tests since we make an edit to those as well:**


```
set -o pipefail && GH_ACCEPTANCE_TOKEN=$(gh auth token) GH_ACCEPTANCE_HOST=github.com GH_ACCEPTANCE_ORG=gh-acceptance-testing go test -tags acceptance -json -run ^TestGPGKeys$ github.com/cli/cli/v2/acceptance  | tparse --all go test
┌─────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │        TEST         │             PACKAGE               │
│─────────┼─────────┼─────────────────────┼───────────────────────────────────│
│  PASS   │    2.07 │ TestGPGKeys/gpg-key │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    0.00 │ TestGPGKeys         │ github.com/cli/cli/v2/acceptance  │
└─────────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │             PACKAGE              │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼──────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │  2.67s  │ github.com/cli/cli/v2/acceptance │  --   │  2   │  0   │  0    │
└────────────────────────────────────────────────────────────────────────────────────┘
```