### PR TITLE
Add acceptance test for `project` command

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -27,33 +27,6 @@ func TestMain(m *testing.M) {
 	}))
 }
 
-func TestPullRequests(t *testing.T) {
-	var tsEnv testScriptEnv
-	if err := tsEnv.fromEnv(); err != nil {
-		t.Fatal(err)
-	}
-
-	testscript.Run(t, testScriptParamsFor(tsEnv, "pr"))
-}
-
-func TestIssues(t *testing.T) {
-	var tsEnv testScriptEnv
-	if err := tsEnv.fromEnv(); err != nil {
-		t.Fatal(err)
-	}
-
-	testscript.Run(t, testScriptParamsFor(tsEnv, "pr"))
-}
-
-func TestWorkflows(t *testing.T) {
-	var tsEnv testScriptEnv
-	if err := tsEnv.fromEnv(); err != nil {
-		t.Fatal(err)
-	}
-
-	testscript.Run(t, testScriptParamsFor(tsEnv, "workflow"))
-}
-
 func TestAPI(t *testing.T) {
 	var tsEnv testScriptEnv
 	if err := tsEnv.fromEnv(); err != nil {
@@ -72,51 +45,6 @@ func TestAuth(t *testing.T) {
 	testscript.Run(t, testScriptParamsFor(tsEnv, "auth"))
 }
 
-func TestReleases(t *testing.T) {
-	var tsEnv testScriptEnv
-	if err := tsEnv.fromEnv(); err != nil {
-		t.Fatal(err)
-	}
-
-	testscript.Run(t, testScriptParamsFor(tsEnv, "release"))
-}
-
-func TestSearches(t *testing.T) {
-	var tsEnv testScriptEnv
-	if err := tsEnv.fromEnv(); err != nil {
-		t.Fatal(err)
-	}
-
-	testscript.Run(t, testScriptParamsFor(tsEnv, "search"))
-}
-
-func TestRepo(t *testing.T) {
-	var tsEnv testScriptEnv
-	if err := tsEnv.fromEnv(); err != nil {
-		t.Fatal(err)
-	}
-
-	testscript.Run(t, testScriptParamsFor(tsEnv, "repo"))
-}
-
-func TestSecrets(t *testing.T) {
-	var tsEnv testScriptEnv
-	if err := tsEnv.fromEnv(); err != nil {
-		t.Fatal(err)
-	}
-
-	testscript.Run(t, testScriptParamsFor(tsEnv, "secret"))
-}
-
-func TestVariables(t *testing.T) {
-	var tsEnv testScriptEnv
-	if err := tsEnv.fromEnv(); err != nil {
-		t.Fatal(err)
-	}
-
-	testscript.Run(t, testScriptParamsFor(tsEnv, "variable"))
-}
-
 func TestGPGKeys(t *testing.T) {
 	var tsEnv testScriptEnv
 	if err := tsEnv.fromEnv(); err != nil {
@@ -124,6 +52,15 @@ func TestGPGKeys(t *testing.T) {
 	}
 
 	testscript.Run(t, testScriptParamsFor(tsEnv, "gpg-key"))
+}
+
+func TestIssues(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "pr"))
 }
 
 func TestLabels(t *testing.T) {
@@ -135,6 +72,60 @@ func TestLabels(t *testing.T) {
 	testscript.Run(t, testScriptParamsFor(tsEnv, "label"))
 }
 
+func TestOrg(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "org"))
+}
+
+func TestPullRequests(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "pr"))
+}
+
+func TestReleases(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "release"))
+}
+
+func TestRepo(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "repo"))
+}
+
+func TestSearches(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "search"))
+}
+
+func TestSecrets(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "secret"))
+}
+
 func TestSSHKeys(t *testing.T) {
 	var tsEnv testScriptEnv
 	if err := tsEnv.fromEnv(); err != nil {
@@ -144,13 +135,22 @@ func TestSSHKeys(t *testing.T) {
 	testscript.Run(t, testScriptParamsFor(tsEnv, "ssh-key"))
 }
 
-func TestOrg(t *testing.T) {
+func TestVariables(t *testing.T) {
 	var tsEnv testScriptEnv
 	if err := tsEnv.fromEnv(); err != nil {
 		t.Fatal(err)
 	}
 
-	testscript.Run(t, testScriptParamsFor(tsEnv, "org"))
+	testscript.Run(t, testScriptParamsFor(tsEnv, "variable"))
+}
+
+func TestWorkflows(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "workflow"))
 }
 
 func testScriptParamsFor(tsEnv testScriptEnv, command string) testscript.Params {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -81,6 +81,15 @@ func TestOrg(t *testing.T) {
 	testscript.Run(t, testScriptParamsFor(tsEnv, "org"))
 }
 
+func TestProject(t *testing.T) {
+	var tsEnv testScriptEnv
+	if err := tsEnv.fromEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	testscript.Run(t, testScriptParamsFor(tsEnv, "project"))
+}
+
 func TestPullRequests(t *testing.T) {
 	var tsEnv testScriptEnv
 	if err := tsEnv.fromEnv(); err != nil {

--- a/acceptance/testdata/project/project-create-delete.txtar
+++ b/acceptance/testdata/project/project-create-delete.txtar
@@ -1,9 +1,10 @@
-# Create a project
-exec gh project create --owner=$ORG --title='acceptance-test-project-title'
-
-# Confirm the project has been created and get the project number
-exec gh project list --owner=$ORG --format=json --jq='.projects[] | select(.title == "acceptance-test-project-title") | .number'
+# Create a project and get the project number
+env PROJECT_TITLE=$SCRIPT_NAME-$RANDOM_STRING
+exec gh project create --owner=$ORG --title=$PROJECT_TITLE --format='json' --jq='.number'
 stdout2env PROJECT_NUMBER
+
+# Confirm the project has been created
+exec gh project view --owner=$ORG $PROJECT_NUMBER
 
 # Delete the project
 exec gh project delete --owner=$ORG $PROJECT_NUMBER

--- a/acceptance/testdata/project/project-create-delete.txtar
+++ b/acceptance/testdata/project/project-create-delete.txtar
@@ -1,0 +1,12 @@
+# Create a project
+exec gh project create --owner=$ORG --title='acceptance-test-project-title'
+
+# Confirm the project has been created and get the project number
+exec gh project list --owner=$ORG --format=json --jq='.projects[] | select(.title == "acceptance-test-project-title") | .number'
+stdout2env PROJECT_NUMBER
+
+# Delete the project
+exec gh project delete --owner=$ORG $PROJECT_NUMBER
+
+# Confirm the project has been deleted
+! exec gh project view --owner=$ORG $PROJECT_NUMBER


### PR DESCRIPTION
## Changes

- Alphabetize test functions, as these have been a steady source of merge conflicts. With alphabetization, the likelihood of merge conflicts arising from more tests being added is lower
- Add acceptance test for project-create and project-delete

## Notes

I've hardcoded the name of the project, copying the pattern used in the ssh-key test, so I could use the hard-coded name to retrieve the ID. There is the chance this can get in a broken state if another project is named the same as the one this test creates. It is probably not a huge deal for now.

## To Test

1. Pull down branch
2. Run
```shell
GH_ACCEPTANCE_SCRIPT=project-create-delete.txtar \
GH_ACCEPTANCE_TOKEN=<TOKEN> \
GH_ACCEPTANCE_ORG=<ORG> \
GH_ACCEPTANCE_HOST=<HOST> \
go test -tags=acceptance -run ^TestProject$ ./acceptance
```
