### PR TITLE
Require visibility confirmation in `gh repo edit`

### DIFF
--- a/pkg/cmd/repo/edit/edit_test.go
+++ b/pkg/cmd/repo/edit/edit_test.go
@@ -344,6 +344,7 @@ func Test_editRun_interactive(t *testing.T) {
 					}`))
 				reg.Exclude(t, httpmock.REST("PATCH", "repos/OWNER/REPO"))
 			},
+			wantsStderr: "Changing the repository visibility to private will cause permanent loss of 10 stars and 0 watchers.",
 		},
 		{
 			name: "changing visibility with confirmation",
@@ -378,6 +379,9 @@ func Test_editRun_interactive(t *testing.T) {
 									"name": "main"
 								},
 								"stargazerCount": 10,
+								"watchers": {
+									"totalCount": 15
+								},
 								"isInOrganization": false,
 								"repositoryTopics": {
 									"nodes": [{
@@ -395,6 +399,7 @@ func Test_editRun_interactive(t *testing.T) {
 						assert.Equal(t, "private", payload["visibility"])
 					}))
 			},
+			wantsStderr: "Changing the repository visibility to private will cause permanent loss of 10 stars and 15 watchers",
 		},
 		{
 			name: "the rest",
@@ -631,7 +636,7 @@ func Test_editRun_interactive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ios, _, _, _ := iostreams.Test()
+			ios, _, _, stderr := iostreams.Test()
 			ios.SetStdoutTTY(true)
 			ios.SetStdinTTY(true)
 			ios.SetStderrTTY(true)
@@ -656,9 +661,11 @@ func Test_editRun_interactive(t *testing.T) {
 			if tt.wantsErr == "" {
 				require.NoError(t, err)
 			} else {
-				assert.EqualError(t, err, tt.wantsErr)
+				require.EqualError(t, err, tt.wantsErr)
 				return
 			}
+
+			assert.Contains(t, stderr.String(), tt.wantsStderr)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #9807 

This commit modifies interactive and non-interactive behaviors around `gh repo edit` as well as providing greater information about the impact.

1. `--help` usage is expanded to highlight the most significant consequences of changing visibility
1. `--help` usage and interactive experience call out GitHub Docs content that act as source of truth about full consequences of various changes
1. `gh repo edit` interactive experience will require confirmation for any visibility change
1. `gh repo edit` interactive experience will output potential stars and watchers lose regardless of visibility transition
1. `gh repo edit` will require `--visibility` flag to include new `--accept-visibility-change-consequences` flag regardless of interactivity

### Changes to user experience

- `--help` explaining danger of visibility changes

  ```shell
  ./bin/gh repo edit --help
  Edit repository settings.
  
  To toggle a setting off, use the `--<flag>=false` syntax.
  
  Changing repository visibility can have unexpected consequences including but not limited to:
  
  - Losing stars and watchers, affecting repository ranking
  - Detaching public forks from the network
  - Disabling push rulesets
  - Allowing access to GitHub Actions history and logs
  
  When the `--visibility` flag is used, `--accept-visibility-change-consequences` flag is required.
  
  For information on all the potential consequences, see <https://gh.io/setting-repository-visibility>
  ```

- Initial disclaimer / warning in `gh repo edit` interactive mode
  ```shell
  $ ~/Documents/workspace/cli/cli/bin/gh repo edit
  ? What do you want to edit? Visibility
  ! Danger zone: changing repository visibility can have unexpected consequences; consult https://gh.io/setting-repository-visibility before continuing.
  ? Visibility  [Use arrows to move, type to filter]
  > public
    private
    internal
  ```

- Confirmation prompt when 0 stars and 0 watchers

  ```shell
  ~/Documents/workspace/cli/cli/bin/gh repo edit
  ? What do you want to edit? Visibility
  ! Danger zone: changing repository visibility can have unexpected consequences; consult https://gh.io/setting-repository-visibility before continuing.
  ? Visibility private
  ? Do you want to change visibility to private? (y/N) 
  ```

- Confirmation prompt when 1 star

  ```shell
  ~/Documents/workspace/cli/cli/bin/gh repo edit
  ? What do you want to edit? Visibility
  ! Danger zone: changing repository visibility can have unexpected consequences; consult https://gh.io/setting-repository-visibility before continuing.
  ? Visibility private
  ! Changing the repository visibility to private will cause permanent loss of 1 star and 0 watchers.
  ? Do you want to change visibility to private? (y/N) 
  ```

- Confirmation prompt when 1 watcher

  ```shell
  ~/Documents/workspace/cli/cli/bin/gh repo edit
  ? What do you want to edit? Visibility
  ! Danger zone: changing repository visibility can have unexpected consequences; consult https://gh.io/setting-repository-visibility before continuing.
  ? Visibility private
  ! Changing the repository visibility to private will cause permanent loss of 0 stars and 1 watcher.
  ? Do you want to change visibility to private? (y/N) 
  ```

- Confirmation prompt when 1 star and 1 watcher

  ```shell
  ~/Documents/workspace/cli/cli/bin/gh repo edit
  ? What do you want to edit? Visibility
  ! Danger zone: changing repository visibility can have unexpected consequences; consult https://gh.io/setting-repository-visibility before continuing.
  ? Visibility private
  ! Changing the repository visibility to private will cause permanent loss of 1 star and 1 watcher.
  ? Do you want to change visibility to private? (y/N) 
  ```

- Confirmation prompt when 2+ stars and 2+ watchers

  ```shell
  ~/Documents/workspace/cli/cli/bin/gh repo edit
  ? What do you want to edit? Visibility
  ! Danger zone: changing repository visibility can have unexpected consequences; consult https://gh.io/setting-repository-visibility before continuing.
  ? Visibility private
  ! Changing the repository visibility to private will cause permanent loss of 2 stars and 2 watchers.
  ? Do you want to change visibility to private? (y/N) 
  ```

