### PR TITLE
fix: `gh pr create -w`  ignore template flag

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -278,6 +278,9 @@ func createRun(opts *CreateOptions) (err error) {
 			state.Title = opts.Title
 			state.Body = opts.Body
 		}
+		if opts.Template != "" {
+			state.Template = opts.Template
+		}
 		err = handlePush(*opts, *ctx)
 		if err != nil {
 			return

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1714,6 +1714,19 @@ func Test_generateCompareURL(t *testing.T) {
 			want:    "https://github.com/OWNER/REPO/compare/main%2Ftrunk...owner:%21$&%27%28%29+%2C%3B=@?body=&expand=1",
 			wantErr: false,
 		},
+		{
+			name: "with template",
+			ctx: CreateContext{
+				BaseRepo:        api.InitRepoHostname(&api.Repository{Name: "REPO", Owner: api.RepositoryOwner{Login: "OWNER"}}, "github.com"),
+				BaseBranch:      "main",
+				HeadBranchLabel: "feature",
+			},
+			state: shared.IssueMetadataState{
+				Template: "story.md",
+			},
+			want:    "https://github.com/OWNER/REPO/compare/main...feature?body=&expand=1&template=story.md",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -27,6 +27,10 @@ func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, ba
 	if len(state.Assignees) > 0 {
 		q.Set("assignees", strings.Join(state.Assignees, ","))
 	}
+	// Embded a template only if the body is empty, which is useful for Web Mode, and avoid duplication in Editor Mode
+	if len(state.Template) > 0 && len(state.Body) == 0 {
+		q.Set("template", state.Template)
+	}
 	if len(state.Labels) > 0 {
 		q.Set("labels", strings.Join(state.Labels, ","))
 	}
@@ -40,6 +44,7 @@ func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, ba
 	if len(state.Milestones) > 0 {
 		q.Set("milestone", state.Milestones[0])
 	}
+
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -27,7 +27,7 @@ func WithPrAndIssueQueryParams(client *api.Client, baseRepo ghrepo.Interface, ba
 	if len(state.Assignees) > 0 {
 		q.Set("assignees", strings.Join(state.Assignees, ","))
 	}
-	// Embded a template only if the body is empty, which is useful for Web Mode, and avoid duplication in Editor Mode
+	// Set a template parameter if no body parameter is provided e.g. Web Mode
 	if len(state.Template) > 0 && len(state.Body) == 0 {
 		q.Set("template", state.Template)
 	}

--- a/pkg/cmd/pr/shared/state.go
+++ b/pkg/cmd/pr/shared/state.go
@@ -23,6 +23,8 @@ type IssueMetadataState struct {
 	Body  string
 	Title string
 
+	Template string
+
 	Metadata   []string
 	Reviewers  []string
 	Assignees  []string


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #7804 
Fixes #9325 

## Requirement
allow `gh pr create --web --template=[template file]` to create a PR using the specified template

## Solution
- add a new Template property to the `IssueMetadataState` given the query is allowed in both [Issue](https://docs.github.com/en/enterprise-cloud@latest/issues/tracking-your-work-with-issues/using-issues/creating-an-issue) and [Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) creation
