### PR TITLE
Correct openSUSE/zypper section

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -94,7 +94,7 @@ sudo yum update gh
 Install:
 
 ```bash
-sudo zypper addrepo https://cli.github.com/packages/rpm/gh-cli.repo
+sudo zypper addrepo -r https://cli.github.com/packages/rpm/gh-cli.repo
 sudo zypper ref
 sudo zypper install gh
 ```


### PR DESCRIPTION
If an URL points to the repo file, one needs to use `-r` option, otherwise they need to omit the `gh-cli.repo` fragment for the repo import to work.
