### PR TITLE
Print empty array for `gh cache list` when `--json` is provided

### DIFF
--- a/acceptance/testdata/workflow/cache-list-empty.txtar
+++ b/acceptance/testdata/workflow/cache-list-empty.txtar
@@ -1,0 +1,36 @@
+# It's unclear what we want to do with these acceptance tests beyond our GHEC discovery, so skip new ones by default
+skip
+
+# Set up env vars
+env REPO=${ORG}/${SCRIPT_NAME}-${RANDOM_STRING}
+
+# Create a repository with a file so it has a default branch
+exec gh repo create ${REPO} --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes ${REPO}
+
+# Set the repo to be targeted by all following commands
+env GH_REPO=${REPO}
+
+# Listing the cache non-interactively shows nothing
+exec gh cache list
+! stdout '.'
+
+# Listing the cache non-interactively with --json shows an empty array
+exec gh cache list --json id
+stdout '\[\]'
+
+# Now set an env var so the commands run interactively and without colour for stdout matching
+# Unfortunately testscript provides no way to turn them off again, and since this
+# script is for discovery, we're not adding a new command.
+env GH_FORCE_TTY=true
+env CLICOLOR=0
+
+# Listing the cache interactively shows an informative message on stderr
+exec gh cache list
+stderr 'No caches found in'
+
+# Listing the cache interactively with --json shows an empty array
+exec gh cache list --json id
+stdout '\[\]'

--- a/pkg/cmd/cache/list/list.go
+++ b/pkg/cmd/cache/list/list.go
@@ -106,7 +106,7 @@ func listRun(opts *ListOptions) error {
 		return fmt.Errorf("%s Failed to get caches: %w", opts.IO.ColorScheme().FailureIcon(), err)
 	}
 
-	if len(result.ActionsCaches) == 0 {
+	if len(result.ActionsCaches) == 0 && opts.Exporter == nil {
 		return cmdutil.NewNoResultsError(fmt.Sprintf("No caches found in %s", ghrepo.FullName(repo)))
 	}
 


### PR DESCRIPTION
## Description

Fixes https://github.com/cli/cli/issues/9882

### Acceptance

**Given** I have no actions cache entries
**When** I run `gh cache list --json ...`
**Then** I get an empty array

This should be true for both interactive and non-interactive invocations.

#### Before

```
➜ GH_FORCE_TTY=true gh cache list --repo williammartin-test-org/test-repo --json id | cat
No caches found in williammartin-test-org/test-repo
```

```
➜ gh cache list --repo williammartin-test-org/test-repo --json id | cat
```

#### After

```
➜ GH_FORCE_TTY=true ./bin/gh cache list --repo williammartin-test-org/test-repo --json id | cat
[]
```

```
➜ ./bin/gh cache list --repo williammartin-test-org/test-repo --json id | cat
[]
```
