### PR TITLE
Refactor the `getAttestations` functions

### DIFF
--- a/pkg/cmd/attestation/download/download.go
+++ b/pkg/cmd/attestation/download/download.go
@@ -122,7 +122,7 @@ func runDownload(opts *Options) error {
 
 	opts.Logger.VerbosePrintf("Downloading trusted metadata for artifact %s\n\n", opts.ArtifactPath)
 
-	c := verification.FetchAttestationsConfig{
+	c := verification.FetchRemoteAttestations{
 		APIClient: opts.APIClient,
 		Digest:    artifact.DigestWithAlg(),
 		Limit:     opts.Limit,

--- a/pkg/cmd/attestation/download/download.go
+++ b/pkg/cmd/attestation/download/download.go
@@ -122,14 +122,13 @@ func runDownload(opts *Options) error {
 
 	opts.Logger.VerbosePrintf("Downloading trusted metadata for artifact %s\n\n", opts.ArtifactPath)
 
-	c := verification.FetchRemoteAttestationsParams{
-		APIClient: opts.APIClient,
-		Digest:    artifact.DigestWithAlg(),
-		Limit:     opts.Limit,
-		Owner:     opts.Owner,
-		Repo:      opts.Repo,
+	params := verification.FetchRemoteAttestationsParams{
+		Digest: artifact.DigestWithAlg(),
+		Limit:  opts.Limit,
+		Owner:  opts.Owner,
+		Repo:   opts.Repo,
 	}
-	attestations, err := verification.GetRemoteAttestations(c)
+	attestations, err := verification.GetRemoteAttestations(opts.APIClient, params)
 	if err != nil {
 		if errors.Is(err, api.ErrNoAttestations{}) {
 			fmt.Fprintf(opts.Logger.IO.Out, "No attestations found for %s\n", opts.ArtifactPath)

--- a/pkg/cmd/attestation/download/download.go
+++ b/pkg/cmd/attestation/download/download.go
@@ -122,7 +122,7 @@ func runDownload(opts *Options) error {
 
 	opts.Logger.VerbosePrintf("Downloading trusted metadata for artifact %s\n\n", opts.ArtifactPath)
 
-	c := verification.FetchRemoteAttestations{
+	c := verification.FetchRemoteAttestationsParams{
 		APIClient: opts.APIClient,
 		Digest:    artifact.DigestWithAlg(),
 		Limit:     opts.Limit,

--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -20,7 +20,7 @@ const SLSAPredicateV1 = "https://slsa.dev/provenance/v1"
 var ErrUnrecognisedBundleExtension = errors.New("bundle file extension not supported, must be json or jsonl")
 var ErrEmptyBundleFile = errors.New("provided bundle file is empty")
 
-type FetchAttestationsConfig struct {
+type FetchRemoteAttestations struct {
 	APIClient api.Client
 	Digest    string
 	Limit     int
@@ -96,7 +96,7 @@ func loadBundlesFromJSONLinesFile(path string) ([]*api.Attestation, error) {
 	return attestations, nil
 }
 
-func GetRemoteAttestations(c FetchAttestationsConfig) ([]*api.Attestation, error) {
+func GetRemoteAttestations(c FetchRemoteAttestations) ([]*api.Attestation, error) {
 	if c.APIClient == nil {
 		return nil, fmt.Errorf("api client must be provided")
 	}

--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -20,12 +20,11 @@ const SLSAPredicateV1 = "https://slsa.dev/provenance/v1"
 var ErrUnrecognisedBundleExtension = errors.New("bundle file extension not supported, must be json or jsonl")
 var ErrEmptyBundleFile = errors.New("provided bundle file is empty")
 
-type FetchRemoteAttestations struct {
-	APIClient api.Client
-	Digest    string
-	Limit     int
-	Owner     string
-	Repo      string
+type FetchRemoteAttestationsParams struct {
+	Digest string
+	Limit  int
+	Owner  string
+	Repo   string
 }
 
 // GetLocalAttestations returns a slice of attestations read from a local bundle file.
@@ -96,22 +95,22 @@ func loadBundlesFromJSONLinesFile(path string) ([]*api.Attestation, error) {
 	return attestations, nil
 }
 
-func GetRemoteAttestations(c FetchRemoteAttestations) ([]*api.Attestation, error) {
-	if c.APIClient == nil {
+func GetRemoteAttestations(client api.Client, params FetchRemoteAttestationsParams) ([]*api.Attestation, error) {
+	if client == nil {
 		return nil, fmt.Errorf("api client must be provided")
 	}
 	// check if Repo is set first because if Repo has been set, Owner will be set using the value of Repo.
 	// If Repo is not set, the field will remain empty. It will not be populated using the value of Owner.
-	if c.Repo != "" {
-		attestations, err := c.APIClient.GetByRepoAndDigest(c.Repo, c.Digest, c.Limit)
+	if params.Repo != "" {
+		attestations, err := client.GetByRepoAndDigest(params.Repo, params.Digest, params.Limit)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch attestations from %s: %w", c.Repo, err)
+			return nil, fmt.Errorf("failed to fetch attestations from %s: %w", params.Repo, err)
 		}
 		return attestations, nil
-	} else if c.Owner != "" {
-		attestations, err := c.APIClient.GetByOwnerAndDigest(c.Owner, c.Digest, c.Limit)
+	} else if params.Owner != "" {
+		attestations, err := client.GetByOwnerAndDigest(params.Owner, params.Digest, params.Limit)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch attestations from %s: %w", c.Owner, err)
+			return nil, fmt.Errorf("failed to fetch attestations from %s: %w", params.Owner, err)
 		}
 		return attestations, nil
 	}

--- a/pkg/cmd/attestation/verification/extensions.go
+++ b/pkg/cmd/attestation/verification/extensions.go
@@ -35,22 +35,22 @@ func VerifyCertExtensions(results []*AttestationProcessingResult, ec Enforcement
 }
 
 func verifyCertExtensions(given, expected certificate.Summary) error {
-	if !strings.EqualFold(expected.SourceRepositoryOwnerURI, verified.SourceRepositoryOwnerURI) {
-		return fmt.Errorf("expected SourceRepositoryOwnerURI to be %s, got %s", expected.SourceRepositoryOwnerURI, verified.SourceRepositoryOwnerURI)
+	if !strings.EqualFold(expected.SourceRepositoryOwnerURI, given.SourceRepositoryOwnerURI) {
+		return fmt.Errorf("expected SourceRepositoryOwnerURI to be %s, got %s", expected.SourceRepositoryOwnerURI, given.SourceRepositoryOwnerURI)
 	}
 
 	// if repo is set, compare the SourceRepositoryURI fields
-	if expected.SourceRepositoryURI != "" && !strings.EqualFold(expected.SourceRepositoryURI, verified.SourceRepositoryURI) {
-		return fmt.Errorf("expected SourceRepositoryURI to be %s, got %s", expected.SourceRepositoryURI, verified.SourceRepositoryURI)
+	if expected.SourceRepositoryURI != "" && !strings.EqualFold(expected.SourceRepositoryURI, given.SourceRepositoryURI) {
+		return fmt.Errorf("expected SourceRepositoryURI to be %s, got %s", expected.SourceRepositoryURI, given.SourceRepositoryURI)
 	}
 
 	// compare the OIDC issuers. If not equal, return an error depending
 	// on if there is a partial match
-	if !strings.EqualFold(expected.Issuer, verified.Issuer) {
-		if strings.Index(verified.Issuer, expected.Issuer+"/") == 0 {
-			return fmt.Errorf("expected Issuer to be %s, got %s -- if you have a custom OIDC issuer policy for your enterprise, use the --cert-oidc-issuer flag with your expected issuer", expected.Issuer, verified.Issuer)
+	if !strings.EqualFold(expected.Issuer, given.Issuer) {
+		if strings.Index(given.Issuer, expected.Issuer+"/") == 0 {
+			return fmt.Errorf("expected Issuer to be %s, got %s -- if you have a custom OIDC issuer policy for your enterprise, use the --cert-oidc-issuer flag with your expected issuer", expected.Issuer, given.Issuer)
 		}
-		return fmt.Errorf("expected Issuer to be %s, got %s", expected.Issuer, verified.Issuer)
+		return fmt.Errorf("expected Issuer to be %s, got %s", expected.Issuer, given.Issuer)
 	}
 
 	return nil

--- a/pkg/cmd/attestation/verification/extensions.go
+++ b/pkg/cmd/attestation/verification/extensions.go
@@ -34,7 +34,7 @@ func VerifyCertExtensions(results []*AttestationProcessingResult, ec Enforcement
 	return lastErr
 }
 
-func verifyCertExtensions(verified, expected certificate.Summary) error {
+func verifyCertExtensions(given, expected certificate.Summary) error {
 	if !strings.EqualFold(expected.SourceRepositoryOwnerURI, verified.SourceRepositoryOwnerURI) {
 		return fmt.Errorf("expected SourceRepositoryOwnerURI to be %s, got %s", expected.SourceRepositoryOwnerURI, verified.SourceRepositoryOwnerURI)
 	}

--- a/pkg/cmd/attestation/verify/attestation.go
+++ b/pkg/cmd/attestation/verify/attestation.go
@@ -32,7 +32,7 @@ func getAttestations(o *Options, a artifact.DigestedArtifact) ([]*api.Attestatio
 		return attestations, msg, nil
 	}
 
-	c := verification.FetchAttestationsConfig{
+	c := verification.FetchRemoteAttestations{
 		APIClient: o.APIClient,
 		Digest:    a.DigestWithAlg(),
 		Limit:     o.Limit,

--- a/pkg/cmd/attestation/verify/attestation.go
+++ b/pkg/cmd/attestation/verify/attestation.go
@@ -1,0 +1,51 @@
+package verify
+
+import (
+	"fmt"
+
+	"github.com/cli/cli/v2/internal/text"
+	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
+	"github.com/cli/cli/v2/pkg/cmd/attestation/artifact"
+	"github.com/cli/cli/v2/pkg/cmd/attestation/verification"
+)
+
+func getAttestations(o *Options, a artifact.DigestedArtifact) ([]*api.Attestation, string, error) {
+	if o.BundlePath != "" {
+		attestations, err := verification.GetLocalAttestations(o.BundlePath)
+		if err != nil {
+			msg := fmt.Sprintf("✗ Loading attestations from %s failed\n", a.URL)
+			return nil, msg, err
+		}
+		pluralAttestation := text.Pluralize(len(attestations), "attestation")
+		msg := fmt.Sprintf("Loaded %s from %s\n", pluralAttestation, o.BundlePath)
+		return attestations, msg, nil
+	}
+
+	if o.UseBundleFromRegistry {
+		attestations, err := verification.GetOCIAttestations(o.OCIClient, a)
+		if err != nil {
+			msg := "✗ Loading attestations from OCI registry failed\n"
+			return nil, msg, err
+		}
+		pluralAttestation := text.Pluralize(len(attestations), "attestation")
+		msg := fmt.Sprintf("Loaded %s from %s\n", pluralAttestation, o.ArtifactPath)
+		return attestations, msg, nil
+	}
+
+	c := verification.FetchAttestationsConfig{
+		APIClient: o.APIClient,
+		Digest:    a.DigestWithAlg(),
+		Limit:     o.Limit,
+		Owner:     o.Owner,
+		Repo:      o.Repo,
+	}
+
+	attestations, err := verification.GetRemoteAttestations(c)
+	if err != nil {
+		msg := "✗ Loading attestations from GitHub API failed\n"
+		return nil, msg, err
+	}
+	pluralAttestation := text.Pluralize(len(attestations), "attestation")
+	msg := fmt.Sprintf("Loaded %s from GitHub API\n", pluralAttestation)
+	return attestations, msg, nil
+}

--- a/pkg/cmd/attestation/verify/attestation.go
+++ b/pkg/cmd/attestation/verify/attestation.go
@@ -32,15 +32,14 @@ func getAttestations(o *Options, a artifact.DigestedArtifact) ([]*api.Attestatio
 		return attestations, msg, nil
 	}
 
-	c := verification.FetchRemoteAttestations{
-		APIClient: o.APIClient,
-		Digest:    a.DigestWithAlg(),
-		Limit:     o.Limit,
-		Owner:     o.Owner,
-		Repo:      o.Repo,
+	params := verification.FetchRemoteAttestationsParams{
+		Digest: a.DigestWithAlg(),
+		Limit:  o.Limit,
+		Owner:  o.Owner,
+		Repo:   o.Repo,
 	}
 
-	attestations, err := verification.GetRemoteAttestations(c)
+	attestations, err := verification.GetRemoteAttestations(o.APIClient, params)
 	if err != nil {
 		msg := "✗ Loading attestations from GitHub API failed"
 		return nil, msg, err

--- a/pkg/cmd/attestation/verify/attestation.go
+++ b/pkg/cmd/attestation/verify/attestation.go
@@ -13,22 +13,22 @@ func getAttestations(o *Options, a artifact.DigestedArtifact) ([]*api.Attestatio
 	if o.BundlePath != "" {
 		attestations, err := verification.GetLocalAttestations(o.BundlePath)
 		if err != nil {
-			msg := fmt.Sprintf("✗ Loading attestations from %s failed\n", a.URL)
+			msg := fmt.Sprintf("✗ Loading attestations from %s failed", a.URL)
 			return nil, msg, err
 		}
 		pluralAttestation := text.Pluralize(len(attestations), "attestation")
-		msg := fmt.Sprintf("Loaded %s from %s\n", pluralAttestation, o.BundlePath)
+		msg := fmt.Sprintf("Loaded %s from %s", pluralAttestation, o.BundlePath)
 		return attestations, msg, nil
 	}
 
 	if o.UseBundleFromRegistry {
 		attestations, err := verification.GetOCIAttestations(o.OCIClient, a)
 		if err != nil {
-			msg := "✗ Loading attestations from OCI registry failed\n"
+			msg := "✗ Loading attestations from OCI registry failed"
 			return nil, msg, err
 		}
 		pluralAttestation := text.Pluralize(len(attestations), "attestation")
-		msg := fmt.Sprintf("Loaded %s from %s\n", pluralAttestation, o.ArtifactPath)
+		msg := fmt.Sprintf("Loaded %s from %s", pluralAttestation, o.ArtifactPath)
 		return attestations, msg, nil
 	}
 
@@ -42,10 +42,10 @@ func getAttestations(o *Options, a artifact.DigestedArtifact) ([]*api.Attestatio
 
 	attestations, err := verification.GetRemoteAttestations(c)
 	if err != nil {
-		msg := "✗ Loading attestations from GitHub API failed\n"
+		msg := "✗ Loading attestations from GitHub API failed"
 		return nil, msg, err
 	}
 	pluralAttestation := text.Pluralize(len(attestations), "attestation")
-	msg := fmt.Sprintf("Loaded %s from GitHub API\n", pluralAttestation)
+	msg := fmt.Sprintf("Loaded %s from GitHub API", pluralAttestation)
 	return attestations, msg, nil
 }

--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -227,7 +227,7 @@ func runVerify(opts *Options) error {
 			opts.Logger.Printf(opts.Logger.ColorScheme.Red("✗ No attestations found for subject %s\n"), artifact.DigestWithAlg())
 			return err
 		}
-
+		// Print the message signifying failure fetching attestations
 		opts.Logger.Printf(opts.Logger.ColorScheme.Red(logMsg))
 		return err
 	}

--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -228,11 +228,11 @@ func runVerify(opts *Options) error {
 			return err
 		}
 		// Print the message signifying failure fetching attestations
-		opts.Logger.Printf(opts.Logger.ColorScheme.Red(logMsg))
+		opts.Logger.Println(opts.Logger.ColorScheme.Red(logMsg))
 		return err
 	}
 	// Print the message signifying success fetching attestations
-	opts.Logger.Printf(logMsg)
+	opts.Logger.Println(logMsg)
 
 	// Apply predicate type filter to returned attestations
 	filteredAttestations := verification.FilterAttestations(ec.PredicateType, attestations)


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

This refactors the various functions used for fetching attestations from different sources. It also adds a new `getAttestations` function for the `gh attestation verify` command. I also simplified the `verification.verifyCertExtensions` function.

cc https://github.com/cli/cli/issues/9850