### PR TITLE
Support bare repo creation

### DIFF
--- a/acceptance/testdata/repo/repo-create-bare.txtar
+++ b/acceptance/testdata/repo/repo-create-bare.txtar
@@ -1,0 +1,35 @@
+# It's unclear what we want to do with these acceptance tests beyond our GHEC discovery, so skip new ones by default
+skip
+
+# Set up env var
+env REPO=${SCRIPT_NAME}-${RANDOM_STRING}
+
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Initialise a local repository with two branches
+# We expect a bare repo to have all refs pushed with --mirror
+mkdir ${REPO}
+cd ${REPO}
+exec git init
+exec git checkout -b feature-1
+exec git commit --allow-empty -m 'Empty Commit 1'
+
+exec git checkout -b feature-2
+exec git commit --allow-empty -m 'Empty Commit 2'
+
+# Clone a bare repo from that local repo
+cd ..
+exec git clone --bare ${REPO} ${REPO}-bare
+cd ${REPO}-bare
+
+# Create a GitHub repository from that bare repo
+exec gh repo create ${ORG}/${REPO} --private --source . --push --remote bare
+
+# Defer repo cleanup
+defer gh repo delete --yes ${ORG}/${REPO}
+
+# Check the remote repo has both branches
+exec gh api /repos/${ORG}/${REPO}/branches
+stdout 'feature-1'
+stdout 'feature-2'

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -736,7 +736,11 @@ func hasCommits(gitClient *git.Client) (bool, error) {
 	return false, nil
 }
 
-// check if path is the top level directory of a git repo
+// Check if path is the top level directory of a git repo
+// This is subtly different from the git.Client IsLocalRepo method,
+// which returns true if we are _anywhere_ inside of a git repository.
+// I'm not sure whether this distinction really matters for repo create,
+// but I'm not confident enough right now to make that change.
 func isLocalRepo(gitClient *git.Client) (bool, error) {
 	projectDir, projectDirErr := gitClient.GitDir(context.Background())
 	if projectDirErr != nil {

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -740,7 +740,7 @@ func hasCommits(gitClient *git.Client) (bool, error) {
 func isLocalRepo(gitClient *git.Client) (bool, error) {
 	projectDir, projectDirErr := gitClient.GitDir(context.Background())
 	if projectDirErr != nil {
-		var execError *exec.ExitError
+		var execError errWithExitCode
 		if errors.As(projectDirErr, &execError) {
 			if exitCode := int(execError.ExitCode()); exitCode == 128 {
 				return false, nil

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -652,8 +652,13 @@ func createFromLocal(opts *CreateOptions) error {
 
 	// don't prompt for push if there are no commits
 	if opts.Interactive && committed {
+		msg := fmt.Sprintf("Would you like to push commits from the current branch to %q?", baseRemote)
+		if repoType == bare {
+			msg = fmt.Sprintf("Would you like to mirror all refs to %q?", baseRemote)
+		}
+
 		var err error
-		opts.Push, err = opts.Prompter.Confirm(fmt.Sprintf("Would you like to push commits from the current branch to %q?", baseRemote), true)
+		opts.Push, err = opts.Prompter.Confirm(msg, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -748,10 +748,12 @@ func isLocalRepo(gitClient *git.Client) (bool, error) {
 			return false, projectDirErr
 		}
 	}
-	if projectDir != ".git" {
-		return false, nil
+
+	if projectDir == ".git" || projectDir == "." {
+		return true, nil
 	}
-	return true, nil
+
+	return false, nil
 }
 
 // clone the checkout branch to specified path

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -94,7 +94,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			To create a remote repository from an existing local repository, specify the source directory with %[1]s--source%[1]s.
 			By default, the remote repository name will be the name of the source directory.
 
-			Pass %[1]s--push%[1]s to push any local commits to the new repository.
+			Pass %[1]s--push%[1]s to push any local commits to the new repository. If the repo is bare, this will mirror all refs.
 
 			For language or platform .gitignore templates to use with %[1]s--gitignore%[1]s, <https://github.com/github/gitignore>.
 

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -452,7 +452,7 @@ func Test_createRun(t *testing.T) {
 					switch message {
 					case "Add a remote?":
 						return true, nil
-					case `Would you like to push commits from the current branch to "origin"?`:
+					case `Would you like to mirror all refs to "origin"?`:
 						return true, nil
 					default:
 						return false, fmt.Errorf("unexpected confirm prompt: %s", message)


### PR DESCRIPTION
## Description

Fixes https://github.com/cli/cli/issues/9904

### Acceptance Criteria

**Given** My cwd is a bare git repository
**When** I run `gh repo create`, and I choose the option to push it to GitHub
**Then** It succeeds in creating and pushing the repo, mirroring all refs

```
➜  cli-triaging git:(main) ✗ cd non-bare

➜  non-bare git:(feature) git branch | cat
* feature
  main

➜  non-bare git:(feature) cd ..

➜  cli-triaging git:(main) ✗ git clone --bare non-bare bare
Cloning into bare repository 'bare'...
done.

➜  cli-triaging git:(main) ✗ cd bare

➜  bare git:(feature) ~/workspace/cli/bin/gh repo create
? What would you like to do? Push an existing local repository to GitHub
? Path to local repository .
? Repository name bare
? Repository owner williammartin-test-org
? Description
? Visibility Private
✓ Created repository williammartin-test-org/bare on GitHub
  https://github.com/williammartin-test-org/bare
? Add a remote? Yes
? What should the new remote be called? bare
✓ Added remote https://github.com/williammartin-test-org/bare.git
? Would you like to mirror all refs to "bare"? Yes
Enumerating objects: 3, done.
Counting objects: 100% (3/3), done.
Delta compression using up to 10 threads
Compressing objects: 100% (2/2), done.
Writing objects: 100% (3/3), 242 bytes | 242.00 KiB/s, done.
Total 3 (delta 1), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (1/1), done.
To https://github.com/williammartin-test-org/bare.git
 * [new branch]      feature -> feature
 * [new branch]      main -> main
✓ Mirrored all refs to https://github.com/williammartin-test-org/bare.git

➜  bare git:(feature) gh api /repos/williammartin-test-org/bare/branches | cat
[{"name":"feature","commit":{"sha":"fca77ed5e5be49ff42779f98061bcd0453f9649e","url":"https://api.github.com/repos/williammartin-test-org/bare/commits/fca77ed5e5be49ff42779f98061bcd0453f9649e"},"protected":false},{"name":"main","commit":{"sha":"fcf697da1ed589b88124193e59ca6ba3243a243c","url":"https://api.github.com/repos/williammartin-test-org/bare/commits/fcf697da1ed589b88124193e59ca6ba3243a243c"},"protected":false}]%
```

**Given** My cwd is a bare git repository
**When** I run `gh repo create --source . --push --private`
**Then** It succeeds in creating and pushing the repo, mirroring all refs

```
➜  cli-triaging git:(main) ✗ cd non-bare

➜  non-bare git:(feature) git branch | cat
* feature
  main

➜  non-bare git:(feature) cd ..

➜  cli-triaging git:(main) ✗ git clone --bare non-bare bare
Cloning into bare repository 'bare'...
done.

➜  bare git:(feature) ~/workspace/cli/bin/gh repo create williammartin-test-org/bare --source . --push --private --remote bare
✓ Created repository williammartin-test-org/bare on GitHub
  https://github.com/williammartin-test-org/bare
✓ Added remote https://github.com/williammartin-test-org/bare.git
Enumerating objects: 3, done.
Counting objects: 100% (3/3), done.
Delta compression using up to 10 threads
Compressing objects: 100% (2/2), done.
Writing objects: 100% (3/3), 242 bytes | 242.00 KiB/s, done.
Total 3 (delta 1), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (1/1), done.
To https://github.com/williammartin-test-org/bare.git
 * [new branch]      feature -> feature
 * [new branch]      main -> main
✓ Mirrored all refs to https://github.com/williammartin-test-org/bare.git

➜  bare git:(feature) gh api /repos/williammartin-test-org/bare/branches | cat
[{"name":"feature","commit":{"sha":"fca77ed5e5be49ff42779f98061bcd0453f9649e","url":"https://api.github.com/repos/williammartin-test-org/bare/commits/fca77ed5e5be49ff42779f98061bcd0453f9649e"},"protected":false},{"name":"main","commit":{"sha":"fcf697da1ed589b88124193e59ca6ba3243a243c","url":"https://api.github.com/repos/williammartin-test-org/bare/commits/fcf697da1ed589b88124193e59ca6ba3243a243c"},"protected":false}]%
```

### Acceptance Test

I also created an Acceptance Test:

```
➜ set -o pipefail | GH_ACCEPTANCE_SCRIPT=repo-create-bare.txtar GH_ACCEPTANCE_HOST=github.com GH_ACCEPTANCE_ORG=gh-acceptance-testing go test -tags acceptance -run '^TestRepo' -json github.com/cli/cli/v2/acceptance | tparse --all go test
┌───────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │           TEST            │             PACKAGE               │
│─────────┼─────────┼───────────────────────────┼───────────────────────────────────│
│  PASS   │    4.23 │ TestRepo/repo-create-bare │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    0.00 │ TestRepo                  │ github.com/cli/cli/v2/acceptance  │
└───────────────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │             PACKAGE              │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼──────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │  4.82s  │ github.com/cli/cli/v2/acceptance │  --   │  2   │  0   │  0    │
└────────────────────────────────────────────────────────────────────────────────────┘
```