### PR TITLE
Shorten extension release checking from 3s to 1s

### DIFF
--- a/pkg/cmd/root/extension.go
+++ b/pkg/cmd/root/extension.go
@@ -72,7 +72,7 @@ func NewCmdExtension(io *iostreams.IOStreams, em extensions.ExtensionManager, ex
 					fmt.Fprintf(stderr, "%s\n\n",
 						cs.Yellow(releaseInfo.URL))
 				}
-			case <-time.After(3 * time.Second):
+			case <-time.After(1 * time.Second):
 				// Bail on checking for new extension update as its taking too long
 			}
 		},


### PR DESCRIPTION
Relates #8183

Addressing feedback from extension author demonstration about a noticable pause waiting for extension execution to complete due to amount of time waiting on channel.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
