### PR TITLE
Improve documentation and error messaging for local extension installations without executables

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -315,11 +315,11 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					For the list of available extensions, see <https://github.com/topics/gh-extension>.
 				`, "`"),
 				Example: heredoc.Doc(`
-					# Install an extension from a remote repository hosted on GitHub.com
+					# Install an extension from a remote repository hosted on GitHub
 					$ gh extension install owner/gh-extension
 
-					# Install an extension from a remote repository on a different GitHub host
-					$ gh extension install https://git.example.com/owner/gh-extension
+					# Install an extension from a remote repository via full URL
+					$ gh extension install https://my.ghes.com/owner/gh-extension
 
 					# Install an extension from a local repository in the current working directory
 					$ gh extension install .

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -340,9 +340,11 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 						}
 
 						err = m.InstallLocal(wd)
-						if errors.Is(err, ErrExtensionExecutableNotFound) {
+						var ErrExtensionExecutableNotFound *ErrExtensionExecutableNotFound
+						if errors.As(err, &ErrExtensionExecutableNotFound) {
+							cs := io.ColorScheme()
 							if io.IsStdoutTTY() {
-								fmt.Fprintln(io.ErrOut, err.Error())
+								fmt.Fprintf(io.ErrOut, "%s %s", cs.WarningIcon(), ErrExtensionExecutableNotFound.Error())
 							}
 							return nil
 						}

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -293,12 +293,12 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 				Use:   "install <repository>",
 				Short: "Install a gh extension from a repository",
 				Long: heredoc.Docf(`
-					Install a GitHub CLI extension from a GitHub repository.
+					Install a GitHub CLI extension from a GitHub or local repository.
 
-					The repository argument can be specified in %[1]sOWNER/REPO%[1]s format or as a full repository URL.
+					For GitHub repositories, the repository argument can be specified in %[1]sOWNER/REPO%[1]s format or as a full repository URL.
 					The URL format is useful when the repository is not hosted on github.com.
 
-					To install an in-development extension from a locally cloned repository, use %[1]s.%[1]s as the
+					For local repositories, often used while developing extensions, use %[1]s.%[1]s as the
 					value of the repository argument. Note the following:
 
 					- After installing an extension from a locally cloned repository, the GitHub CLI will

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -302,10 +302,10 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					value of the repository argument. Note the following:
 
 					- After installing an extension from a locally cloned repository, the GitHub CLI will
-					manage this extension as a symbolic link (or equivalent mechanism on Windows) pointing to an executable file with the same
-					name as the repository in the repository's root.
-						- For example, if the repository is named %[1]sgh-foobar%[1]s, the symbolic link will
-						point to %[1]sgh-foobar%[1]s in the extension repository's root.
+					manage this extension as a symbolic link (or equivalent mechanism on Windows) pointing
+					to an executable file with the same name as the repository in the repository's root.
+					For example, if the repository is named %[1]sgh-foobar%[1]s, the symbolic link will point
+					to %[1]sgh-foobar%[1]s in the extension repository's root.
 					- When executing the extension, the GitHub CLI will run the executable file found
 					by following the symbolic link. If no executable file is found, the extension
 					will fail to execute.

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -293,19 +293,35 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 				Use:   "install <repository>",
 				Short: "Install a gh extension from a repository",
 				Long: heredoc.Docf(`
-					Install a GitHub repository locally as a GitHub CLI extension.
+					Install a GitHub CLI extension from a GitHub repository.
 
-					The repository argument can be specified in %[1]sOWNER/REPO%[1]s format as well as a full URL.
+					The repository argument can be specified in %[1]sOWNER/REPO%[1]s format or as a full repository URL.
 					The URL format is useful when the repository is not hosted on github.com.
 
-					To install an extension in development from the current directory, use %[1]s.%[1]s as the
-					value of the repository argument.
+					To install an in-development extension from a locally cloned repository, use %[1]s.%[1]s as the
+					value of the repository argument. Note the following:
+
+					- After installing an extension from a locally cloned repository, the GitHub CLI will
+					manage this extension as a symbolic link pointing to an executable file with the same
+					name as the repository in the repository's root.
+						- For example, if the repository is named %[1]sgh-foobar%[1]s, the symbolic link will
+						point to %[1]sgh-foobar%[1]s in the extension repository's root.
+					- When executing the extension, the GitHub CLI will run the executable file found
+					by following the symbolic link. If no executable file is found, the extension
+					will fail to execute.
+					- If the extension is precompiled, the executable file must be built manually and placed
+					in the repository's root.
 
 					For the list of available extensions, see <https://github.com/topics/gh-extension>.
 				`, "`"),
 				Example: heredoc.Doc(`
+					# Install an extension from a remote repository hosted on GitHub.com
 					$ gh extension install owner/gh-extension
+
+					# Install an extension from a remote repository on a different GitHub host
 					$ gh extension install https://git.example.com/owner/gh-extension
+
+					# Install an extension from a local repository in the current working directory
 					$ gh extension install .
 				`),
 				Args: cmdutil.MinimumArgs(1, "must specify a repository to install from"),

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -302,7 +302,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					value of the repository argument. Note the following:
 
 					- After installing an extension from a locally cloned repository, the GitHub CLI will
-					manage this extension as a symbolic link pointing to an executable file with the same
+					manage this extension as a symbolic link (or equivalent mechanism on Windows) pointing to an executable file with the same
 					name as the repository in the repository's root.
 						- For example, if the repository is named %[1]sgh-foobar%[1]s, the symbolic link will
 						point to %[1]sgh-foobar%[1]s in the extension repository's root.

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -338,7 +338,15 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 						if err != nil {
 							return err
 						}
-						return m.InstallLocal(wd)
+
+						err = m.InstallLocal(wd)
+						if errors.Is(err, ErrExtensionExecutableNotFound) {
+							if io.IsStdoutTTY() {
+								fmt.Fprintln(io.ErrOut, err.Error())
+							}
+							return nil
+						}
+						return err
 					}
 
 					repo, err := ghrepo.FromFullName(args[0])

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -287,6 +287,38 @@ func TestNewCmdExtension(t *testing.T) {
 			},
 		},
 		{
+			name: "install local extension without executable TTY",
+			args: []string{"install", "."},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.InstallLocalFunc = func(dir string) error {
+					return ErrExtensionExecutableNotFound
+				}
+				em.ListFunc = func() []extensions.Extension {
+					return []extensions.Extension{}
+				}
+				return nil
+			},
+			wantStderr: fmt.Sprintln(ErrExtensionExecutableNotFound.Error()),
+			wantErr:    false,
+			isTTY:      true,
+		},
+		{
+			name: "install local extension without executable no TTY",
+			args: []string{"install", "."},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.InstallLocalFunc = func(dir string) error {
+					return ErrExtensionExecutableNotFound
+				}
+				em.ListFunc = func() []extensions.Extension {
+					return []extensions.Extension{}
+				}
+				return nil
+			},
+			wantStderr: "",
+			wantErr:    false,
+			isTTY:      false,
+		},
+		{
 			name: "error extension not found",
 			args: []string{"install", "owner/gh-some-ext"},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -301,14 +301,9 @@ func TestNewCmdExtension(t *testing.T) {
 				}
 				return nil
 			},
-			wantStderr: fmt.Sprintf(
-				"! %s",
-				(&ErrExtensionExecutableNotFound{
-					Dir:  tempDir,
-					Name: "gh-test",
-				}).Error()),
-			wantErr: false,
-			isTTY:   true,
+			wantStderr: fmt.Sprintf("! an extension has been installed but there is no executable: executable file named \"%s\" in %s is required to run the extension after install. Perhaps you need to build it?\n", "gh-test", tempDir),
+			wantErr:    false,
+			isTTY:      true,
 		},
 		{
 			name: "install local extension without executable with no TTY shows no warning",

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -287,27 +287,38 @@ func TestNewCmdExtension(t *testing.T) {
 			},
 		},
 		{
-			name: "install local extension without executable TTY",
+			name: "installing local extension without executable with TTY shows warning",
 			args: []string{"install", "."},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
 				em.InstallLocalFunc = func(dir string) error {
-					return ErrExtensionExecutableNotFound
+					return &ErrExtensionExecutableNotFound{
+						Dir:  tempDir,
+						Name: "gh-test",
+					}
 				}
 				em.ListFunc = func() []extensions.Extension {
 					return []extensions.Extension{}
 				}
 				return nil
 			},
-			wantStderr: fmt.Sprintln(ErrExtensionExecutableNotFound.Error()),
-			wantErr:    false,
-			isTTY:      true,
+			wantStderr: fmt.Sprintf(
+				"! %s",
+				(&ErrExtensionExecutableNotFound{
+					Dir:  tempDir,
+					Name: "gh-test",
+				}).Error()),
+			wantErr: false,
+			isTTY:   true,
 		},
 		{
-			name: "install local extension without executable no TTY",
+			name: "install local extension without executable with no TTY shows no warning",
 			args: []string{"install", "."},
 			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
 				em.InstallLocalFunc = func(dir string) error {
-					return ErrExtensionExecutableNotFound
+					return &ErrExtensionExecutableNotFound{
+						Dir:  tempDir,
+						Name: "gh-test",
+					}
 				}
 				em.ListFunc = func() []extensions.Extension {
 					return []extensions.Extension{}

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -209,7 +209,7 @@ func (m *Manager) InstallLocal(dir string) error {
 	// it does indicate that the user will not be able to run the extension until
 	// the executable file is built or created manually somehow.
 	if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
-		errMsg := fmt.Errorf("%v %w: expected executable file named \"%s\" in %s, perhaps you need to build it?", cs.WarningIcon(), ErrExtensionExecutableNotFound, name, dir)
+		errMsg := fmt.Errorf("%v %w: executable file named \"%s\" in %s is required for the extension to run after install. Perhaps you need to build it?", cs.WarningIcon(), ErrExtensionExecutableNotFound, name, dir)
 		return errMsg
 	}
 	return nil

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -215,11 +215,14 @@ func (m *Manager) InstallLocal(dir string) error {
 	// An error here doesn't indicate a failed extension installation, but
 	// it does indicate that the user will not be able to run the extension until
 	// the executable file is built or created manually somehow.
-	if _, err := os.Stat(filepath.Join(dir, name)); os.IsNotExist(err) {
-		return &ErrExtensionExecutableNotFound{
-			Dir:  dir,
-			Name: name,
+	if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+		if os.IsNotExist(err) {
+			return &ErrExtensionExecutableNotFound{
+				Dir:  dir,
+				Name: name,
+			}
 		}
+		return err
 	}
 	return nil
 }

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -209,7 +209,7 @@ func (m *Manager) InstallLocal(dir string) error {
 	// it does indicate that the user will not be able to run the extension until
 	// the executable file is built or created manually somehow.
 	if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
-		errMsg := fmt.Errorf("%v %w: executable file named \"%s\" in %s is required for the extension to run after install. Perhaps you need to build it?", cs.WarningIcon(), ErrExtensionExecutableNotFound, name, dir)
+		errMsg := fmt.Errorf("%v %w: executable file named \"%s\" in %s is required to run the extension after install. Perhaps you need to build it?", cs.WarningIcon(), ErrExtensionExecutableNotFound, name, dir)
 		return errMsg
 	}
 	return nil

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -28,7 +28,15 @@ import (
 
 // ErrInitialCommitFailed indicates the initial commit when making a new extension failed.
 var ErrInitialCommitFailed = errors.New("initial commit failed")
-var ErrExtensionExecutableNotFound = errors.New("an extension has been installed but there is no executable")
+
+type ErrExtensionExecutableNotFound struct {
+	Dir  string
+	Name string
+}
+
+func (e *ErrExtensionExecutableNotFound) Error() string {
+	return fmt.Sprintf("an extension has been installed but there is no executable: executable file named \"%s\" in %s is required to run the extension after install. Perhaps you need to build it?\n", e.Name, e.Dir)
+}
 
 const darwinAmd64 = "darwin-amd64"
 
@@ -195,7 +203,6 @@ func (m *Manager) populateLatestVersions(exts []*Extension) {
 func (m *Manager) InstallLocal(dir string) error {
 	name := filepath.Base(dir)
 	targetLink := filepath.Join(m.installDir(), name)
-	cs := m.io.ColorScheme()
 
 	if err := os.MkdirAll(filepath.Dir(targetLink), 0755); err != nil {
 		return err
@@ -209,8 +216,10 @@ func (m *Manager) InstallLocal(dir string) error {
 	// it does indicate that the user will not be able to run the extension until
 	// the executable file is built or created manually somehow.
 	if _, err := os.Stat(filepath.Join(dir, name)); os.IsNotExist(err) {
-		errMsg := fmt.Errorf("%v %w: executable file named \"%s\" in %s is required to run the extension after install. Perhaps you need to build it?", cs.WarningIcon(), ErrExtensionExecutableNotFound, name, dir)
-		return errMsg
+		return &ErrExtensionExecutableNotFound{
+			Dir:  dir,
+			Name: name,
+		}
 	}
 	return nil
 }

--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -208,7 +208,7 @@ func (m *Manager) InstallLocal(dir string) error {
 	// An error here doesn't indicate a failed extension installation, but
 	// it does indicate that the user will not be able to run the extension until
 	// the executable file is built or created manually somehow.
-	if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+	if _, err := os.Stat(filepath.Join(dir, name)); os.IsNotExist(err) {
 		errMsg := fmt.Errorf("%v %w: executable file named \"%s\" in %s is required to run the extension after install. Perhaps you need to build it?", cs.WarningIcon(), ErrExtensionExecutableNotFound, name, dir)
 		return errMsg
 	}

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -759,7 +759,7 @@ func TestManager_Install_local(t *testing.T) {
 
 func TestManager_Install_local_no_executable_found(t *testing.T) {
 	tempDir := t.TempDir()
-	ios, _, stdout, _ := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 	m := newTestManager(tempDir, nil, nil, ios)
 	fakeExtensionName := "local-ext"
 
@@ -773,6 +773,7 @@ func TestManager_Install_local_no_executable_found(t *testing.T) {
 	err := m.InstallLocal(localDir)
 	require.ErrorIs(t, err, ErrExtensionExecutableNotFound)
 	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "", stderr.String())
 }
 
 func TestManager_Install_git(t *testing.T) {

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -771,7 +771,7 @@ func TestManager_Install_local_no_executable_found(t *testing.T) {
 	// to simulate an attempt to install a local extension without an executable
 
 	err := m.InstallLocal(localDir)
-	require.ErrorIs(t, err, ErrExtensionExecutableNotFound)
+	require.ErrorAs(t, err, new(*ErrExtensionExecutableNotFound))
 	assert.Equal(t, "", stdout.String())
 	assert.Equal(t, "", stderr.String())
 }

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -742,8 +742,8 @@ func TestManager_Install_local(t *testing.T) {
 	extensionLinkFile := filepath.Join(extManagerDir, "extensions", fakeExtensionName)
 
 	if runtime.GOOS == "windows" {
-		// We don't create symlinks on Windows, so check if we made a file
-		// with the correct contents
+		// We don't create true symlinks on Windows, so check if we made a
+		// file with the correct contents to produce the symlink-like behavior
 		b, err := os.ReadFile(extensionLinkFile)
 		require.NoError(t, err)
 		assert.Equal(t, extensionLocalPath, string(b))

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -719,6 +719,62 @@ func TestManager_UpgradeExtension_GitExtension_Pinned(t *testing.T) {
 	gcOne.AssertExpectations(t)
 }
 
+func TestManager_Install_local(t *testing.T) {
+	extManagerDir := t.TempDir()
+	ios, _, stdout, stderr := iostreams.Test()
+	m := newTestManager(extManagerDir, nil, nil, ios)
+	fakeExtensionName := "local-ext"
+
+	// Create a temporary directory to simulate the local extension repo
+	extensionLocalPath := filepath.Join(extManagerDir, fakeExtensionName)
+	require.NoError(t, os.MkdirAll(extensionLocalPath, 0755))
+
+	// Create a fake executable in the local extension directory
+	fakeExtensionExecutablePath := filepath.Join(extensionLocalPath, fakeExtensionName)
+	require.NoError(t, stubExtension(fakeExtensionExecutablePath))
+
+	err := m.InstallLocal(extensionLocalPath)
+	require.NoError(t, err)
+
+	// This is the path to a file:
+	// on windows this is a file whose contents is a string describing the path to the local extension dir.
+	// on other platforms this file is a real symlink to the local extension dir.
+	extensionLinkFile := filepath.Join(extManagerDir, "extensions", fakeExtensionName)
+
+	if runtime.GOOS == "windows" {
+		// We don't create symlinks on Windows, so check if we made a file
+		// with the correct contents
+		b, err := os.ReadFile(extensionLinkFile)
+		require.NoError(t, err)
+		assert.Equal(t, extensionLocalPath, string(b))
+	} else {
+		// Verify the created symlink points to the correct directory
+		linkTarget, err := os.Readlink(extensionLinkFile)
+		require.NoError(t, err)
+		assert.Equal(t, extensionLocalPath, linkTarget)
+	}
+	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "", stderr.String())
+}
+
+func TestManager_Install_local_no_executable_found(t *testing.T) {
+	tempDir := t.TempDir()
+	ios, _, stdout, _ := iostreams.Test()
+	m := newTestManager(tempDir, nil, nil, ios)
+	fakeExtensionName := "local-ext"
+
+	// Create a temporary directory to simulate the local extension repo
+	localDir := filepath.Join(tempDir, fakeExtensionName)
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+
+	// Intentionally not creating an executable in the local extension repo
+	// to simulate an attempt to install a local extension without an executable
+
+	err := m.InstallLocal(localDir)
+	require.ErrorIs(t, err, ErrExtensionExecutableNotFound)
+	assert.Equal(t, "", stdout.String())
+}
+
 func TestManager_Install_git(t *testing.T) {
 	tempDir := t.TempDir()
 


### PR DESCRIPTION
Fixes #9760 

## Requirements

> ### Acceptance Criteria
> 
> **Given** I am in a directory that doesn't have an executable for `gh` to call as an extension
> **When** I run `gh extension install .`
> **Then** I get an informative message on stderr saying "An extension has been installed but there is no executable found in this directory, perhaps you need to build it?"
> 
> This should be styled when there is a TTY and unstyled when there is not.
> 
> **When** I run `gh extension install --help`
> **Then** I see an explanation that `gh extension install .` creates a symlink to an executable in the local directory regardless of whether it exists or not, and it's necessary for the user to build executables out of band if need be.

## Demo

![image](https://github.com/user-attachments/assets/3c7e411a-d331-4959-9850-22e4dea78d6d)

## Reproduction

**Error message:**

```shell
# Setup path to `gh` binary built from this PR
bingh="<PATH_TO_GH_BINARY>"

$bingh ext create testing-9933
cd gh-testing-9933
rm gh-testing-9933
$bingh ext install .
```

**Cleanup/reset:**

```shell
# Assuming you're still in the testing extension dir...
cd ..
$bingh ext remove gh-testing-9933
rm -rf gh-testing-9933
```