### PR TITLE
Added a section on manual verification of the relases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For more information, see [Linux & BSD installation](./docs/install_linux.md).
 | ------------------- | --------------------|
 | `winget install --id GitHub.cli` | `winget upgrade --id GitHub.cli` |
 
-> **Note**  
+> **Note**
 > The Windows installer modifies your PATH. When using Windows Terminal, you will need to **open a new window** for the changes to take effect. (Simply opening a new tab will _not_ be sufficient.)
 
 #### scoop
@@ -124,6 +124,36 @@ GitHub CLI comes pre-installed in all [GitHub-Hosted Runners](https://docs.githu
 ### Other platforms
 
 Download packaged binaries from the [releases page][].
+
+#### Verification of binaries
+
+Since version 2.50.0 `gh` has been producing [Build Provenance Attestation](https://github.blog/changelog/2024-06-25-artifact-attestations-is-generally-available/) enabling a cryptographically verifiable paper-trail back to the origin GitHub repository, git revision and build instructions used. The build provenance attestations are signed and relies on Public Good [Sigstore](https://www.sigstore.dev/) for PKI.
+
+There are two common ways to verify a downloaded release, depending if `gh` is aready installed or not. If `gh` is installed, it's trivial to verify a new release:
+
+```shell
+$ % gh at verify -R cli/cli gh_2.62.0_macOS_arm64.zip
+Loaded digest sha256:fdb77f31b8a6dd23c3fd858758d692a45f7fc76383e37d475bdcae038df92afc for file://gh_2.62.0_macOS_arm64.zip
+Loaded 1 attestation from GitHub API
+✓ Verification succeeded!
+
+sha256:fdb77f31b8a6dd23c3fd858758d692a45f7fc76383e37d475bdcae038df92afc was attested by:
+REPO     PREDICATE_TYPE                  WORKFLOW
+cli/cli  https://slsa.dev/provenance/v1  .github/workflows/deployment.yml@refs/heads/trunk
+```
+
+If `gh` is not installed, you can use the `cosign` [binary](https://github.com/sigstore/cosign) from Sigstore to verify a release. To perform this, you must first download the [attestation](https://github.com/cli/cli/attestations) for the downloaded release, then you can invoke cosign to verify the authenticity of the downloaded file:
+
+```shell
+$ cosign verify-blob-attestation --bundle cli-cli-attestation-3120304.sigstore.json \
+      --new-bundle-format \
+      --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+      --certificate-identity-regexp="^https://github.com/cli/cli/.github/workflows/deployment.yml@refs/heads/trunk$" \
+      gh_2.62.0_macOS_arm64.zip
+Verified OK
+```
+
+This will verify that the downloaded zip file is authentic, and it can be extracted to get the `gh` binary.
 
 ### Build from source
 

--- a/README.md
+++ b/README.md
@@ -133,29 +133,29 @@ There are two common ways to verify a downloaded release, depending if `gh` is a
 
 - **Option 1: Using `gh` if already installed:**
 
-```shell
-$ % gh at verify -R cli/cli gh_2.62.0_macOS_arm64.zip
-Loaded digest sha256:fdb77f31b8a6dd23c3fd858758d692a45f7fc76383e37d475bdcae038df92afc for file://gh_2.62.0_macOS_arm64.zip
-Loaded 1 attestation from GitHub API
-✓ Verification succeeded!
+  ```shell
+  $ % gh at verify -R cli/cli gh_2.62.0_macOS_arm64.zip
+  Loaded digest sha256:fdb77f31b8a6dd23c3fd858758d692a45f7fc76383e37d475bdcae038df92afc for file://gh_2.62.0_macOS_arm64.zip
+  Loaded 1 attestation from GitHub API
+  ✓ Verification succeeded!
 
-sha256:fdb77f31b8a6dd23c3fd858758d692a45f7fc76383e37d475bdcae038df92afc was attested by:
-REPO     PREDICATE_TYPE                  WORKFLOW
-cli/cli  https://slsa.dev/provenance/v1  .github/workflows/deployment.yml@refs/heads/trunk
-```
+  sha256:fdb77f31b8a6dd23c3fd858758d692a45f7fc76383e37d475bdcae038df92afc was attested by:
+  REPO     PREDICATE_TYPE                  WORKFLOW
+  cli/cli  https://slsa.dev/provenance/v1  .github/workflows/deployment.yml@refs/heads/trunk
+  ```
 
 - **Option 2: Using Sigstore [`cosign`](https://github.com/sigstore/cosign):**
 
-To perform this, download the [attestation](https://github.com/cli/cli/attestations) for the downloaded release and use cosign to verify the authenticity of the downloaded release:
+  To perform this, download the [attestation](https://github.com/cli/cli/attestations) for the downloaded release and use cosign to verify the authenticity of the downloaded release:
 
-```shell
-$ cosign verify-blob-attestation --bundle cli-cli-attestation-3120304.sigstore.json \
-      --new-bundle-format \
-      --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-      --certificate-identity-regexp="^https://github.com/cli/cli/.github/workflows/deployment.yml@refs/heads/trunk$" \
-      gh_2.62.0_macOS_arm64.zip
-Verified OK
-```
+  ```shell
+  $ cosign verify-blob-attestation --bundle cli-cli-attestation-3120304.sigstore.json \
+        --new-bundle-format \
+        --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+        --certificate-identity-regexp="^https://github.com/cli/cli/.github/workflows/deployment.yml@refs/heads/trunk$" \
+        gh_2.62.0_macOS_arm64.zip
+  Verified OK
+  ```
 
 ### Build from source
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Since version 2.50.0 `gh` has been producing [Build Provenance Attestation](http
 
 There are two common ways to verify a downloaded release, depending if `gh` is aready installed or not. If `gh` is installed, it's trivial to verify a new release:
 
-- **Option 1: Using `gh` if already installed:
+- **Option 1: Using `gh` if already installed:**
 
 ```shell
 $ % gh at verify -R cli/cli gh_2.62.0_macOS_arm64.zip
@@ -144,7 +144,7 @@ REPO     PREDICATE_TYPE                  WORKFLOW
 cli/cli  https://slsa.dev/provenance/v1  .github/workflows/deployment.yml@refs/heads/trunk
 ```
 
-- **Option 2: Using Sigstore [`cosign`](https://github.com/sigstore/cosign):
+- **Option 2: Using Sigstore [`cosign`](https://github.com/sigstore/cosign):**
 
 To perform this, download the [attestation](https://github.com/cli/cli/attestations) for the downloaded release and use cosign to verify the authenticity of the downloaded release:
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Since version 2.50.0 `gh` has been producing [Build Provenance Attestation](http
 
 There are two common ways to verify a downloaded release, depending if `gh` is aready installed or not. If `gh` is installed, it's trivial to verify a new release:
 
+- **Option 1: Using `gh` if already installed:
+
 ```shell
 $ % gh at verify -R cli/cli gh_2.62.0_macOS_arm64.zip
 Loaded digest sha256:fdb77f31b8a6dd23c3fd858758d692a45f7fc76383e37d475bdcae038df92afc for file://gh_2.62.0_macOS_arm64.zip
@@ -142,7 +144,9 @@ REPO     PREDICATE_TYPE                  WORKFLOW
 cli/cli  https://slsa.dev/provenance/v1  .github/workflows/deployment.yml@refs/heads/trunk
 ```
 
-If `gh` is not installed, you can use the `cosign` [binary](https://github.com/sigstore/cosign) from Sigstore to verify a release. To perform this, you must first download the [attestation](https://github.com/cli/cli/attestations) for the downloaded release, then you can invoke cosign to verify the authenticity of the downloaded file:
+- **Option 2: Using Sigstore [`cosign`](https://github.com/sigstore/cosign):
+
+To perform this, download the [attestation](https://github.com/cli/cli/attestations) for the downloaded release and use cosign to verify the authenticity of the downloaded release:
 
 ```shell
 $ cosign verify-blob-attestation --bundle cli-cli-attestation-3120304.sigstore.json \
@@ -152,8 +156,6 @@ $ cosign verify-blob-attestation --bundle cli-cli-attestation-3120304.sigstore.j
       gh_2.62.0_macOS_arm64.zip
 Verified OK
 ```
-
-This will verify that the downloaded zip file is authentic, and it can be extracted to get the `gh` binary.
 
 ### Build from source
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For more information, see [Linux & BSD installation](./docs/install_linux.md).
 | ------------------- | --------------------|
 | `winget install --id GitHub.cli` | `winget upgrade --id GitHub.cli` |
 
-> **Note**
+> [!NOTE]
 > The Windows installer modifies your PATH. When using Windows Terminal, you will need to **open a new window** for the changes to take effect. (Simply opening a new tab will _not_ be sufficient.)
 
 #### scoop


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Updated README to contain information on how to verify a release's build provenance attestation either using `gh` or `cosign`. Reason for adding a third party client (`cosign`) is that the first time it's downloaded, you can't really depend on the downloaded binary to verify itself. 