### PR TITLE
Rename local repo by `gh repo rename`

### DIFF
--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -150,7 +150,7 @@ func renameRun(opts *RenameOptions) error {
 
 	if opts.RenameLocalDir {
 		if err = renameRepoDir(newRepoName, opts); err != nil {
-			return err
+			fmt.Fprintf(opts.IO.ErrOut, "Failed to rename local directory: %v", err)
 		}
 	}
 

--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -148,6 +148,15 @@ func renameRun(opts *RenameOptions) error {
 		fmt.Fprintf(opts.IO.Out, "%s Updated the %q remote\n", cs.SuccessIcon(), remote.Name)
 	}
 
+	if opts.DoConfirm && !opts.RenameLocalDir {
+		var confirmed bool
+		if confirmed, err = opts.Prompter.Confirm("Would you also like to rename the repo directory to ?", false); err != nil {
+			return err
+		}
+		if confirmed {
+			opts.RenameLocalDir = true
+		}
+	}
 	if opts.RenameLocalDir {
 		if err = renameRepoDir(newRepoName, opts); err != nil {
 			fmt.Fprintf(opts.IO.ErrOut, "Failed to rename local directory: %v", err)

--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -85,7 +85,7 @@ func NewCmdRename(f *cmdutil.Factory, runf func(*RenameOptions) error) *cobra.Co
 	cmd.Flags().BoolVar(&confirm, "confirm", false, "Skip confirmation prompt")
 	_ = cmd.Flags().MarkDeprecated("confirm", "use `--yes` instead")
 	cmd.Flags().BoolVarP(&confirm, "yes", "y", false, "Skip the confirmation prompt")
-	cmd.Flags().BoolVarP(&opts.RenameLocalDir, "rename-dir", "N", false, "Rename directory name of local repository")
+	cmd.Flags().BoolVarP(&opts.RenameLocalDir, "rename-dir", "N", false, "Rename the directory of the local repository to match the new repo name")
 
 	return cmd
 }


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #9695
An idea to address this issue, but it might run into the problem of not being able to rename the folder. Like I mentioned [here](https://github.com/cli/cli/issues/9695#issuecomment-2484791186), the issue happens because the gh process's working directory is the folder you’re trying to rename, which causes the error: "the process cannot access the folder because it is being used by another process." Any ideas about this?