### PR TITLE
Correct command to add gh-cli repo to dnf config

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -39,7 +39,7 @@ Install from our package repository for immediate access to latest releases:
 
 ```bash
 sudo dnf install dnf5-plugins
-sudo dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
+sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
 sudo dnf install gh --repo gh-cli
 ```
 


### PR DESCRIPTION
Noticed that the command was incorrect:

```
dnf config-manager: error: unrecognized arguments:
  --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
```