### PR TITLE
Fix some multiline command documentation to use `heredoc` strings

### DIFF
--- a/pkg/cmd/cache/delete/delete.go
+++ b/pkg/cmd/cache/delete/delete.go
@@ -35,23 +35,23 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "delete [<cache-id>| <cache-key> | --all]",
 		Short: "Delete GitHub Actions caches",
-		Long: `
-		Delete GitHub Actions caches.
+		Long: heredoc.Doc(`
+			Delete GitHub Actions caches.
 
-		Deletion requires authorization with the "repo" scope.
-`,
+			Deletion requires authorization with the "repo" scope.
+		`),
 		Example: heredoc.Doc(`
-		# Delete a cache by id
-		$ gh cache delete 1234
+			# Delete a cache by id
+			$ gh cache delete 1234
 
-		# Delete a cache by key
-		$ gh cache delete cache-key
+			# Delete a cache by key
+			$ gh cache delete cache-key
 
-		# Delete a cache by id in a specific repo
-		$ gh cache delete 1234 --repo cli/cli
+			# Delete a cache by id in a specific repo
+			$ gh cache delete 1234 --repo cli/cli
 
-		# Delete all caches
-		$ gh cache delete --all
+			# Delete all caches
+			$ gh cache delete --all
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/cache/delete/delete.go
+++ b/pkg/cmd/cache/delete/delete.go
@@ -35,11 +35,11 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "delete [<cache-id>| <cache-key> | --all]",
 		Short: "Delete GitHub Actions caches",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Delete GitHub Actions caches.
 
-			Deletion requires authorization with the "repo" scope.
-		`),
+			Deletion requires authorization with the %[1]srepo%[1]s scope.
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Delete a cache by id
 			$ gh cache delete 1234

--- a/pkg/cmd/codespace/rebuild.go
+++ b/pkg/cmd/codespace/rebuild.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/codespaces"
 	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/internal/codespaces/portforwarder"
@@ -20,9 +21,12 @@ func newRebuildCmd(app *App) *cobra.Command {
 	rebuildCmd := &cobra.Command{
 		Use:   "rebuild",
 		Short: "Rebuild a codespace",
-		Long: `Rebuilding recreates your codespace. Your code and any current changes will be
-preserved. Your codespace will be rebuilt using your working directory's
-dev container. A full rebuild also removes cached Docker images.`,
+		Long: heredoc.Doc(`
+			Rebuilding recreates your codespace.
+			
+			Your code and any current changes will be preserved. Your codespace will be rebuilt using
+			your working directory's dev container. A full rebuild also removes cached Docker images.
+		`),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return app.Rebuild(cmd.Context(), selector, fullRebuild)

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -38,12 +39,14 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "delete [<repository>]",
 		Short: "Delete a repository",
-		Long: `Delete a GitHub repository.
+		Long: heredoc.Doc(`
+			Delete a GitHub repository.
+			
+			With no argument, deletes the current repository. Otherwise, deletes the specified repository.
 
-With no argument, deletes the current repository. Otherwise, deletes the specified repository.
-
-Deletion requires authorization with the "delete_repo" scope. 
-To authorize, run "gh auth refresh -s delete_repo"`,
+			Deletion requires authorization with the "delete_repo" scope. 
+			To authorize, run "gh auth refresh -s delete_repo"
+		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -39,14 +39,14 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "delete [<repository>]",
 		Short: "Delete a repository",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Delete a GitHub repository.
 			
 			With no argument, deletes the current repository. Otherwise, deletes the specified repository.
 
-			Deletion requires authorization with the "delete_repo" scope. 
-			To authorize, run "gh auth refresh -s delete_repo"
-		`),
+			Deletion requires authorization with the %[1]sdelete_repo%[1]s scope. 
+			To authorize, run %[1]sgh auth refresh -s delete_repo%[1]s
+		`, "`"),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {


### PR DESCRIPTION
This is only a refactor to some existing multiline `Long:` command documentation to use `heredoc` strings  - no change to the actual wording.