### PR TITLE
Implement git project description (`.git/description`)

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"slices"
@@ -226,6 +228,55 @@ func (c *Client) Config(ctx context.Context, name string) (string, error) {
 		return "", err
 	}
 	return firstLine(out), nil
+}
+
+func (c *Client) Templates(ctx context.Context) (string, error) {
+	// https://git-scm.com/docs/git-init/2.2.3
+	// The template directory will be one of the following (in order):
+	// - the argument given with the --template option;
+	// (This can't be determined at this point)
+
+	// - the contents of the $GIT_TEMPLATE_DIR environment variable;
+	if envDir := os.Getenv("GIT_TEMPLATE_DIR"); envDir != "" {
+		return envDir, nil
+	}
+
+	// - the init.templatedir configuration variable; or
+	templateDir, err := c.Config(ctx, "init.templatedir")
+	if err == nil && templateDir != "" {
+		return templateDir, nil
+	}
+
+	// - the default template directory: /usr/share/git-core/templates.
+	command, err := c.Command(ctx, "--exec-path")
+	if err != nil {
+		return "", err
+	}
+	execPath, err := command.Output()
+	if err != nil {
+		return "", err
+	}
+	defaultTemplateDir := filepath.Join(strings.TrimSpace(string(execPath)), "templates")
+	if _, err := os.Stat(defaultTemplateDir); err == nil {
+		return defaultTemplateDir, nil
+	}
+
+	return "", fmt.Errorf("could not determine git template directory")
+}
+
+func (c *Client) Template(ctx context.Context, filename string) (string, error) {
+	templateDir, err := c.Templates(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	templatePath := filepath.Join(templateDir, filename)
+	content, err := os.ReadFile(templatePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read template file %s: %w", templatePath, err)
+	}
+
+	return string(content), nil
 }
 
 func (c *Client) UncommittedChangeCount(ctx context.Context) (int, error) {

--- a/git/objects.go
+++ b/git/objects.go
@@ -70,10 +70,10 @@ type ProjectDescription struct {
 }
 
 // input format: "<title>[\n[\n][<body>]"
-func NewProjectDescription(description string) ProjectDescription {
+func NewProjectDescription(description string) *ProjectDescription {
 	parts := strings.SplitN(description, "\n", 2)
 
-	result := ProjectDescription{
+	result := &ProjectDescription{
 		Title: parts[0],
 		Body:  "",
 	}

--- a/git/objects.go
+++ b/git/objects.go
@@ -70,7 +70,7 @@ type ProjectDescription struct {
 }
 
 // input format: "<title>[\n[\n][<body>]"
-func newProjectDescription(description string) ProjectDescription {
+func NewProjectDescription(description string) ProjectDescription {
 	parts := strings.SplitN(description, "\n", 2)
 
 	result := ProjectDescription{

--- a/git/objects.go
+++ b/git/objects.go
@@ -64,6 +64,34 @@ func (r TrackingRef) String() string {
 	return "refs/remotes/" + r.RemoteName + "/" + r.BranchName
 }
 
+type ProjectDescription struct {
+	Title string
+	Body  string
+}
+
+// input format: "<title>[\n[\n][<body>]"
+func newProjectDescription(description string) ProjectDescription {
+	parts := strings.SplitN(description, "\n", 2)
+
+	result := ProjectDescription{
+		Title: parts[0],
+		Body:  "",
+	}
+	if len(parts) > 1 {
+		result.Body = strings.TrimPrefix(parts[1], "\n") // remove optional leading newline
+	}
+
+	return result
+}
+
+// output format: "<title>[\n\n<body>]"
+func (p ProjectDescription) String() string {
+	if p.Body != "" {
+		return p.Title + "\n\n" + p.Body
+	}
+	return p.Title
+}
+
 type Commit struct {
 	Sha   string
 	Title string


### PR DESCRIPTION
## Purpose
There's a file for a project description, which is so far only properly implemented by gitweb, even tho GitHub Repositories feature a name and short description.
https://github.com/git/git/blob/04eaff62f286226f501dd21f069e0e257aee11a6/gitweb/gitweb.perl#L2951-L2954
More information/usages:
https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain
https://stackoverflow.com/questions/6866838/what-should-be-in-the-git-description-file
https://github.com/stephenh/git-central/blob/080aad76176bda0daef478cc1b6cd8fcbfc08112/server/post-receive-email#L453

https://lists.gnu.org/archive/html/savannah-hackers/2009-03/msg00051.html

## Tasks
- [x] `ProjectDescription` `struct` and related helpers
- [x] Git template retrieval
- [x] Project description retrieval, treating project description equal to template as empty
- [ ] Port constraints from GitHub repositories (such as description length)
- [ ] Read default values from description in `repo create`
- [ ] Write values to description wherever appropriate
- [ ] Tests