### PR TITLE
Command issue for Fedora and centos

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -39,7 +39,7 @@ Install from our package repository for immediate access to latest releases:
 
 ```bash
 sudo dnf install dnf5-plugins
-sudo dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
+sudo dnf config-manager --add-repo=https://cli.github.com/packages/rpm/gh-cli.repo
 sudo dnf install gh --repo gh-cli
 ```
 


### PR DESCRIPTION
Command change for fedora, centos where as its suppose to be `--add-repo` rather than `addrepo --from-repofile=`

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
