### PR TITLE
Fix formatting in `git/client_test.go` comments for linter

### DIFF
--- a/git/client_test.go
+++ b/git/client_test.go
@@ -1655,7 +1655,7 @@ func createMockedCommandContext(t *testing.T, commands mockedCommands) commandCt
 	marshaledCommands, err := json.Marshal(commands)
 	require.NoError(t, err)
 
-	// invokes helper within current test binary, emulating desired behavior 
+	// invokes helper within current test binary, emulating desired behavior
 	return func(ctx context.Context, exe string, args ...string) *exec.Cmd {
 		cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestCommandMocking", "--")
 		cmd.Env = []string{


### PR DESCRIPTION
Fix formatting in `git/client_test.go` comments for linter