### PR TITLE
When renaming an existing remote as part of remote creation in `gh repo fork`, log the change

### DIFF
--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -306,6 +306,10 @@ func forkRun(opts *ForkOptions) error {
 					if err != nil {
 						return err
 					}
+
+					if connectedToTerminal {
+						fmt.Fprintf(stderr, "%s Renamed remote %s to %s\n", cs.SuccessIcon(), cs.Bold(remoteName), cs.Bold(renameTarget))
+					}
 				} else {
 					return fmt.Errorf("a git remote named '%s' already exists", remoteName)
 				}

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -298,7 +298,7 @@ func TestRepoFork(t *testing.T) {
 					return true, nil
 				})
 			},
-			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote origin\n",
+			wantErrOut: "✓ Created fork someone/REPO\n✓ Renamed remote origin to upstream\n✓ Added remote origin\n",
 		},
 		{
 			name: "implicit tty reuse existing remote",
@@ -370,7 +370,7 @@ func TestRepoFork(t *testing.T) {
 				cs.Register("git remote rename origin upstream", 0, "")
 				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
 			},
-			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote origin\n",
+			wantErrOut: "✓ Created fork someone/REPO\n✓ Renamed remote origin to upstream\n✓ Added remote origin\n",
 		},
 		{
 			name: "implicit nontty reuse existing remote",


### PR DESCRIPTION
When running `gh repo fork` in the context of an existing repo, the CLI offers to create a remote for the fork:

```
? Would you like to add a remote for the fork? Yes
```

If you accept, it prints a log stating that the `origin` remote has been created:

```
✓ Added remote origin
```

Where there is an existing `origin` remote, this is renamed to `upstream`, but this is done silently without any notification to the user.

```bash
$ git remote -v
origin	https://github.com/timrogers/badger.github.io.git (fetch)
origin	https://github.com/timrogers/badger.github.io.git (push)
upstream	https://github.com/badger/badger.github.io.git (fetch)
upstream	https://github.com/badger/badger.github.io.git (push)
```

It seems kinda fine to rename the remote without explicitly confirming since this is not a truly destructive action, but it should make it clear what it is doing.

This updates the logging to explicitly log about the renaming of the existing remote:

```
✓ Renamed remote origin to upstream
```

Fixes #9982.