### PR TITLE
Sigstore verifier logic updates

### DIFF
--- a/pkg/cmd/attestation/verification/sigstore.go
+++ b/pkg/cmd/attestation/verification/sigstore.go
@@ -84,15 +84,17 @@ func (v *LiveSigstoreVerifier) chooseVerifier(issuer string) (*verify.SignedEnti
 	// if no custom trusted root is set, attempt to create a Public Good or
 	// GitHub Sigstore verifier
 	if v.TrustedRoot == "" {
-		if issuer == PublicGoodIssuerOrg {
+		switch issuer {
+		case PublicGoodIssuerOrg:
 			if v.NoPublicGood {
 				return nil, fmt.Errorf("detected public good instance but requested verification without public good instance")
 			}
 			return newPublicGoodVerifier()
-		} else if issuer == GitHubIssuerOrg {
+		case GitHubIssuerOrg:
 			return newGitHubVerifier(v.TrustDomain)
+		default:
+			return nil, fmt.Errorf("leaf certificate issuer is not recognized")
 		}
-		return nil, fmt.Errorf("leaf certificate issuer is not recognized")
 	}
 
 	customTrustRoots, err := os.ReadFile(v.TrustedRoot)
@@ -128,14 +130,15 @@ func (v *LiveSigstoreVerifier) chooseVerifier(issuer string) (*verify.SignedEnti
 			//
 			// Note that we are *only* inferring the policy with the
 			// issuer. We *must* use the trusted root provided.
-			if issuer == PublicGoodIssuerOrg {
+			switch issuer {
+			case PublicGoodIssuerOrg:
 				if v.NoPublicGood {
 					return nil, fmt.Errorf("detected public good instance but requested verification without public good instance")
 				}
 				return newPublicGoodVerifierWithTrustedRoot(trustedRoot)
-			} else if issuer == GitHubIssuerOrg {
+			case GitHubIssuerOrg:
 				return newGitHubVerifierWithTrustedRoot(trustedRoot)
-			} else {
+			default:
 				// Make best guess at reasonable policy
 				return newCustomVerifier(trustedRoot)
 			}

--- a/pkg/cmd/attestation/verification/sigstore.go
+++ b/pkg/cmd/attestation/verification/sigstore.go
@@ -121,7 +121,7 @@ func (v *LiveSigstoreVerifier) chooseVerifier(issuer string) (*verify.SignedEnti
 				return nil, err
 			}
 
-			// if the custom trusted root issuer is not set or doesn't match the bundle's issuer, skip it
+			// if the custom trusted root issuer is not set or doesn't match the given issuer, skip it
 			if len(lowestCert.Issuer.Organization) == 0 || lowestCert.Issuer.Organization[0] != issuer {
 				continue
 			}

--- a/pkg/cmd/attestation/verification/sigstore.go
+++ b/pkg/cmd/attestation/verification/sigstore.go
@@ -88,22 +88,10 @@ func (v *LiveSigstoreVerifier) chooseVerifier(issuer string) (*verify.SignedEnti
 			if v.NoPublicGood {
 				return nil, fmt.Errorf("detected public good instance but requested verification without public good instance")
 			}
-
-			publicGoodVerifier, err := newPublicGoodVerifier()
-			if err != nil {
-				return nil, fmt.Errorf("failed to create Public Good Sigstore verifier: %v", err)
-			}
-
-			return publicGoodVerifier, nil
+			return newPublicGoodVerifier()
 		} else if issuer == GitHubIssuerOrg {
-			ghVerifier, err := newGitHubVerifier(v.TrustDomain)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create GitHub Sigstore verifier: %v", err)
-			}
-
-			return ghVerifier, nil
+			return newGitHubVerifier(v.TrustDomain)
 		}
-
 		return nil, fmt.Errorf("leaf certificate issuer is not recognized")
 	}
 
@@ -144,24 +132,12 @@ func (v *LiveSigstoreVerifier) chooseVerifier(issuer string) (*verify.SignedEnti
 				if v.NoPublicGood {
 					return nil, fmt.Errorf("detected public good instance but requested verification without public good instance")
 				}
-				verifier, err := newPublicGoodVerifierWithTrustedRoot(trustedRoot)
-				if err != nil {
-					return nil, err
-				}
-				return verifier, nil
+				return newPublicGoodVerifierWithTrustedRoot(trustedRoot)
 			} else if issuer == GitHubIssuerOrg {
-				verifier, err := newGitHubVerifierWithTrustedRoot(trustedRoot)
-				if err != nil {
-					return nil, err
-				}
-				return verifier, nil
+				return newGitHubVerifierWithTrustedRoot(trustedRoot)
 			} else {
 				// Make best guess at reasonable policy
-				customVerifier, err := newCustomVerifier(trustedRoot)
-				if err != nil {
-					return nil, fmt.Errorf("failed to create custom verifier: %v", err)
-				}
-				return customVerifier, nil
+				return newCustomVerifier(trustedRoot)
 			}
 		}
 		line, readError = reader.ReadBytes('\n')


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

This just rearranges some logic for the sigstore verifier used by the gh attestation command set.

cc https://github.com/cli/cli/issues/9850