### PR TITLE
Fix bug when fetching bundles from OCI registry

### DIFF
--- a/pkg/cmd/attestation/verification/attestation.go
+++ b/pkg/cmd/attestation/verification/attestation.go
@@ -118,7 +118,7 @@ func GetRemoteAttestations(client api.Client, params FetchRemoteAttestationsPara
 }
 
 func GetOCIAttestations(client oci.Client, artifact artifact.DigestedArtifact) ([]*api.Attestation, error) {
-	attestations, err := client.GetAttestations(artifact.NameRef(), artifact.Digest())
+	attestations, err := client.GetAttestations(artifact.NameRef(), artifact.DigestWithAlg())
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch OCI attestations: %w", err)
 	}


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes https://github.com/cli/cli/issues/10017

The algorithm should be included along with the digest when attempting to fetch bundles from an OCI registry. The algorithm was accidentally removed during a refactor, see the old code here: https://github.com/cli/cli/pull/9892/files#diff-84cf161d364effa25914785d22d193f33133a448d02e5f1559cd41ef6b48eff4L228