### PR TITLE
Add integration tests for `gh attestation verify` when the `bundle-from-oci` flag is specified

### DIFF
--- a/pkg/cmd/attestation/verify/verify_integration_test.go
+++ b/pkg/cmd/attestation/verify/verify_integration_test.go
@@ -111,6 +111,25 @@ func TestVerifyIntegration(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "verifying with issuer \"sigstore.dev\"")
 	})
+
+	t.Run("with bundle from OCI registry", func(t *testing.T) {
+		opts := Options{
+			APIClient:             api.NewLiveClient(hc, host, logger),
+			ArtifactPath:          "oci://ghcr.io/malancas/attest-demo:latest",
+			UseBundleFromRegistry: true,
+			DigestAlgorithm:       "sha256",
+			Logger:                logger,
+			OCIClient:             oci.NewLiveClient(),
+			OIDCIssuer:            verification.GitHubOIDCIssuer,
+			Owner:                 "malancas",
+			PredicateType:         verification.SLSAPredicateV1,
+			SANRegex:              "^https://github.com/malancas/",
+			SigstoreVerifier:      verification.NewLiveSigstoreVerifier(sigstoreConfig),
+		}
+
+		err := runVerify(&opts)
+		require.NoError(t, err)
+	})
 }
 
 func TestVerifyIntegrationCustomIssuer(t *testing.T) {

--- a/pkg/cmd/attestation/verify/verify_integration_test.go
+++ b/pkg/cmd/attestation/verify/verify_integration_test.go
@@ -115,15 +115,15 @@ func TestVerifyIntegration(t *testing.T) {
 	t.Run("with bundle from OCI registry", func(t *testing.T) {
 		opts := Options{
 			APIClient:             api.NewLiveClient(hc, host, logger),
-			ArtifactPath:          "oci://ghcr.io/malancas/attest-demo:latest",
+			ArtifactPath:          "oci://ghcr.io/github/artifact-attestations-helm-charts/policy-controller:v0.10.0-github9",
 			UseBundleFromRegistry: true,
 			DigestAlgorithm:       "sha256",
 			Logger:                logger,
 			OCIClient:             oci.NewLiveClient(),
 			OIDCIssuer:            verification.GitHubOIDCIssuer,
-			Owner:                 "malancas",
+			Owner:                 "github",
 			PredicateType:         verification.SLSAPredicateV1,
-			SANRegex:              "^https://github.com/malancas/",
+			SANRegex:              "^https://github.com/github/",
 			SigstoreVerifier:      verification.NewLiveSigstoreVerifier(sigstoreConfig),
 		}
 

--- a/test/integration/attestation-cmd/verify-oci-bundle.sh
+++ b/test/integration/attestation-cmd/verify-oci-bundle.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the root directory of the repository
+rootDir="$(git rev-parse --show-toplevel)"
+
+ghBuildPath="$rootDir/bin/gh"
+
+# Verify an OCI artifact with bundles stored on the GHCR OCI registry
+echo "Testing with package $sigstore02PackageFile and attestation $sigstore02AttestationFile"
+if ! $ghBuildPath attestation verify oci://ghcr.io/malancas/attest-demo:latest --owner=malancas --bundle-from-oci; then
+    echo "Failed to verify oci://ghcr.io/malancas/attest-demo:latest with bundles from the GHCR OCI registry"
+    exit 1
+fi

--- a/test/integration/attestation-cmd/verify-oci-bundle.sh
+++ b/test/integration/attestation-cmd/verify-oci-bundle.sh
@@ -7,8 +7,8 @@ rootDir="$(git rev-parse --show-toplevel)"
 ghBuildPath="$rootDir/bin/gh"
 
 # Verify an OCI artifact with bundles stored on the GHCR OCI registry
-echo "Testing with OCI image ghcr.io/malancas/attest-demo:latest with the --bundle-from-oci flag"
-if ! $ghBuildPath attestation verify oci://ghcr.io/malancas/attest-demo:latest --owner=malancas --bundle-from-oci; then
-    echo "Failed to verify oci://ghcr.io/malancas/attest-demo:latest with bundles from the GHCR OCI registry"
+echo "Testing with OCI image ghcr.io/github/artifact-attestations-helm-charts/policy-controller:v0.10.0-github9 with the --bundle-from-oci flag"
+if ! $ghBuildPath attestation verify oci://ghcr.io/github/artifact-attestations-helm-charts/policy-controller:v0.10.0-github9 --owner=github --bundle-from-oci; then
+    echo "Failed to verify oci://ghcr.io/github/artifact-attestations-helm-charts/policy-controller:v0.10.0-github9 with bundles from the GHCR OCI registry"
     exit 1
 fi

--- a/test/integration/attestation-cmd/verify-oci-bundle.sh
+++ b/test/integration/attestation-cmd/verify-oci-bundle.sh
@@ -7,7 +7,7 @@ rootDir="$(git rev-parse --show-toplevel)"
 ghBuildPath="$rootDir/bin/gh"
 
 # Verify an OCI artifact with bundles stored on the GHCR OCI registry
-echo "Testing with package $sigstore02PackageFile and attestation $sigstore02AttestationFile"
+echo "Testing with OCI image ghcr.io/malancas/attest-demo:latest with the --bundle-from-oci flag"
 if ! $ghBuildPath attestation verify oci://ghcr.io/malancas/attest-demo:latest --owner=malancas --bundle-from-oci; then
     echo "Failed to verify oci://ghcr.io/malancas/attest-demo:latest with bundles from the GHCR OCI registry"
     exit 1


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Follow up to https://github.com/cli/cli/pull/10019

This adds integration tests for the `gh attestation verify --bundle-from-oci` configuration using a demo OCI image.