### PR TITLE
docs: improve docs for browse command as of #5352

### DIFF
--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -59,8 +59,8 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Long:  "Open the GitHub repository in the web browser.",
-		Short: "Open the repository in the browser",
+		Long:  "Open the GitHub repository, path inside it, commit, issue or pull request in the web browser.",
+		Short: "Open the repository, path inside it, issue or PR in the browser",
 		Use:   "browse [<number> | <path> | <commit-SHA>]",
 		Args:  cobra.MaximumNArgs(1),
 		Example: heredoc.Doc(`

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -66,7 +66,7 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 			- Issues
 			- Pull requests
 			- Repository content
-			- Repository profile
+			- Repository home page
 			- Repository settings
 		`),
 		Use:  "browse [<number> | <path> | <commit-SHA>]",

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -60,7 +60,7 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 
 	cmd := &cobra.Command{
 		Short: "Open repositories, issues, pull requests, and more in the browser",
-		Long:  heredoc.Doc(`
+		Long: heredoc.Doc(`
 			Transition from the terminal to the web browser to view and interact with:
 
 			- Issues
@@ -69,8 +69,8 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 			- Repository profile
 			- Repository settings
 		`),
-		Use:   "browse [<number> | <path> | <commit-SHA>]",
-		Args:  cobra.MaximumNArgs(1),
+		Use:  "browse [<number> | <path> | <commit-SHA>]",
+		Args: cobra.MaximumNArgs(1),
 		Example: heredoc.Doc(`
 			$ gh browse
 			#=> Open the home page of the current repository

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -59,8 +59,16 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Long:  "Open the GitHub repository, path inside it, commit, issue or pull request in the web browser.",
-		Short: "Open the repository, path inside it, issue or PR in the browser",
+		Short: "Open repositories, issues, pull requests, and more in the browser",
+		Long:  heredoc.Doc(`
+			Transition from the terminal to the web browser to view and interact with:
+
+			- issues
+			- pull requests
+			- repository content
+			- repository profile
+			- repository settings
+		`),
 		Use:   "browse [<number> | <path> | <commit-SHA>]",
 		Args:  cobra.MaximumNArgs(1),
 		Example: heredoc.Doc(`

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -63,11 +63,11 @@ func NewCmdBrowse(f *cmdutil.Factory, runF func(*BrowseOptions) error) *cobra.Co
 		Long:  heredoc.Doc(`
 			Transition from the terminal to the web browser to view and interact with:
 
-			- issues
-			- pull requests
-			- repository content
-			- repository profile
-			- repository settings
+			- Issues
+			- Pull requests
+			- Repository content
+			- Repository profile
+			- Repository settings
 		`),
 		Use:   "browse [<number> | <path> | <commit-SHA>]",
 		Args:  cobra.MaximumNArgs(1),


### PR DESCRIPTION
Fixes #5352.
# Description
In this PR I have improved docs for `gh browse` command to contain all capabilities of this command. I added capabilites to open path inside repository, issue, pull request and specific commit to command's description.
# Screenshots
## Long description
![image](https://github.com/user-attachments/assets/3f531043-af24-4117-937a-ea642bf3e2d0)
# Notes
*None*