### PR TITLE
docs: better document auth scopes

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -85,7 +85,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			prompting to create and upload a new key if one is not found. This can be skipped with
 			%[1]s--skip-ssh-key%[1]s flag.
 
-			Run %[1]sgh help scopes%[1]s to see information about auth scopes.
+			For more information on OAuth scopes, <https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps/>.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Start interactive setup

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -84,6 +84,8 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			Specifying %[1]sssh%[1]s for the git protocol will detect existing SSH keys to upload,
 			prompting to create and upload a new key if one is not found. This can be skipped with
 			%[1]s--skip-ssh-key%[1]s flag.
+
+			Run %[1]sgh help scopes%[1]s to see information about auth scopes.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Start interactive setup

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -72,6 +72,8 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 			If you have multiple accounts in %[1]sgh auth status%[1]s and want to refresh the credentials for an
 			inactive account, you will have to use %[1]sgh auth switch%[1]s to that account first before using
 			this command, and then switch back when you are done.
+
+			Run %[1]sgh help scopes%[1]s to see information about auth scopes.
 		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh auth refresh --scopes write:org,read:public_key

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -56,7 +56,8 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 		Use:   "refresh",
 		Args:  cobra.ExactArgs(0),
 		Short: "Refresh stored authentication credentials",
-		Long: heredoc.Docf(`Expand or fix the permission scopes for stored credentials for active account.
+		Long: heredoc.Docf(`
+			Expand or fix the permission scopes for stored credentials for active account.
 
 			The %[1]s--scopes%[1]s flag accepts a comma separated list of scopes you want
 			your gh credentials to have. If no scopes are provided, the command
@@ -73,7 +74,7 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 			inactive account, you will have to use %[1]sgh auth switch%[1]s to that account first before using
 			this command, and then switch back when you are done.
 
-			Run %[1]sgh help scopes%[1]s to see information about auth scopes.
+			For more information on OAuth scopes, <https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps/>.
 		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh auth refresh --scopes write:org,read:public_key

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -277,6 +277,70 @@ var HelpTopics = []helpTopic{
 			control some behavior.
 		`),
 	},
+	{
+		name:  "scopes",
+		short: "Auth scopes for token used by gh",
+		long: heredoc.Docf(`
+			Scopes let you specify exactly what type of access you need. Scopes limit access for OAuth tokens.
+			They do not grant any additional permission beyond that which the user already has.
+			- %[1]s(no scope)%[1]s: grants read-only access to public information (including user profile info, repository 	info, and gists).
+			- %[1]srepo%[1]s: grants full access to public and private repositories including read and write access to code,
+			commit statuses, repository invitations, collaborators, deployment statuses, and repository webhooks.
+			  NOTE: In addition to repository related resources, the repo scope also grants access to manage organization-owned
+			  resources including projects, invitations, team memberships and webhooks.
+			  This scope also grants the ability to manage projects owned by users.
+			  - %[1]srepo:status%[1]s: grants read/write access to commit statuses in public and private repositories.
+			This scope is only necessary to grant other users or services access to private repository commit statuses without granting access to the code.
+			  - %[1]srepo_deployment%[1]s: grants access to deployment statuses for public and private repositories.
+			This scope is only necessary to grant other users or services access to deployment statuses, without granting access to the code.
+			  - %[1]spublic_repo%[1]s: limits access to public repositories. That includes read/write access to code,
+			commit statuses, repository projects, collaborators, and deployment statuses for public repositories and
+			organizations. Also required for starring public repositories.
+			  - %[1]srepo:invite%[1]s: grants accept/decline abilities for invitations to collaborate on a repository.
+			This scope is only necessary to grant other users or services access to invites without granting access to the code.
+			  - %[1]ssecurity_events%[1]s: grants read and write access to security events in the code scanning API.
+			This scope is only necessary to grant other users or services access to security events without granting access to the code.
+			- %[1]sadmin:repo_hook%[1]s: grants read, write, ping, and delete access to repository hooks in public or private repositories.
+			The %[1]srepo%[1]s and %[1]spublic_repo%[1]s scopes grant full access to repositories, including repository hooks. Use the %[1]sadmin:repo_hook%[1]s scope to limit access to only repository hooks.
+			  - %[1]swrite:repo_hook%[1]s: grants read, write, and ping access to hooks in public or private repositories.
+			  - %[1]sread:repo_hook%[1]s: grants read and ping access to hooks in public or private repositories.
+			- %[1]sadmin:org%[1]s: fully manage the organization and its teams, projects, and memberships.
+			  - %[1]swrite:org%[1]s: read and write access to organization membership and organization projects.
+			  - %[1]sread:org%[1]s: read-only access to organization membership, organization projects, and team membership.
+			- %[1]sadmin:public_key%[1]s: fully manage public keys.
+			  - %[1]swrite:public_key%[1]s: create, list, and view details for public keys.
+			  - %[1]sread:public_key%[1]s: list and view details for public keys.
+			- %[1]sadmin:org_hook%[1]s: grants read, write, ping, and delete access to organization hooks.
+			  NOTE: OAuth tokens will only be able to perform these actions on organization hooks which were created by the OAuth app.
+			  Personal access tokens will only be able to perform these actions on organization hooks created by a user.
+			- %[1]sgist%[1]s: grants write access to gists.
+			- %[1]snotifications%[1]s: grants:
+			  - read access to a user's notifications
+			  - mark as read access to threads
+			  - watch and unwatch access to a repository, and
+			  - read, write, and delete access to thread subscriptions.
+			- %[1]suser%[1]s: grants read/write access to profile info only. Note that this scope includes %[1]suser:email%[1]s and %[1]suser:follow%[1]s.
+			  - %[1]sread:user%[1]s: grants access to read a user's profile data.
+			  - %[1]suser:email%[1]s: grants read access to a user's email addresses.
+			  - %[1]suser:follow%[1]s: grants access to follow or unfollow other users.
+			- %[1]sproject%[1]s: grants read/write access to user and organization projects.
+			  - %[1]sread:project%[1]s: grants read only access to user and organization projects.
+			- %[1]sdelete_repo%[1]s: grants access to delete adminable repositories.
+			- %[1]swrite:packages%[1]s: grants access to upload or publish a package in GitHub Packages.
+			- %[1]sread:packages%[1]s: grants access to download or install packages from GitHub Packages.
+			- %[1]sdelete:packages%[1]s: grants access to delete packages from GitHub Packages.
+			- %[1]sadmin:gpg_key%[1]s: fully manage GPG keys.
+			  - %[1]swrite:gpg_key%[1]s: create, list, and view details for GPG keys.
+			  - %[1]sread:gpg_key%[1]s: list and view details for GPG keys.
+			- %[1]scodespace%[1]s: grants the ability to create and manage codespaces. Codespaces can expose a
+			%[1]sGITHUB_TOKEN%[1]s which may have a different set of scopes.
+			- %[1]sworkflow%[1]s: grants the ability to add and update GitHub Actions workflow files.
+			Workflow files can be committed without this scope if the same file (with both the same path and contents) exists
+			on another branch in the same repository. Workflow files can expose %[1]sGITHUB_TOKEN%[1]s which may have a
+			different set of scopes.
+			NOTE: You can always find up-to-date list of scopes at <https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps/#available-scopes>.
+		`, "`"),
+	},
 }
 
 func NewCmdHelpTopic(ios *iostreams.IOStreams, ht helpTopic) *cobra.Command {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -41,12 +41,12 @@ var HelpTopics = []helpTopic{
 	{
 		name:  "environment",
 		short: "Environment variables that can be used with gh",
-		long: heredoc.Docf(`	
+		long: heredoc.Docf(`
 			%[1]sGH_TOKEN%[1]s, %[1]sGITHUB_TOKEN%[1]s (in order of precedence): an authentication token that will be used when
 			a command targets either github.com or a subdomain of ghe.com. Setting this avoids being prompted to
 			authenticate and takes precedence over previously stored credentials.
 
-			%[1]sGH_ENTERPRISE_TOKEN%[1]s, %[1]sGITHUB_ENTERPRISE_TOKEN%[1]s (in order of precedence): an authentication 
+			%[1]sGH_ENTERPRISE_TOKEN%[1]s, %[1]sGITHUB_ENTERPRISE_TOKEN%[1]s (in order of precedence): an authentication
 			token that will be used when a command targets a GitHub Enterprise Server host.
 
 			%[1]sGH_HOST%[1]s: specify the GitHub hostname for commands where a hostname has not been provided, or
@@ -90,7 +90,7 @@ var HelpTopics = []helpTopic{
 			checks for new releases once every 24 hours and displays an upgrade notice on standard
 			error if a newer version was found.
 
-			%[1]sGH_CONFIG_DIR%[1]s: the directory where gh will store configuration files. If not specified, 
+			%[1]sGH_CONFIG_DIR%[1]s: the directory where gh will store configuration files. If not specified,
 			the default value will be one of the following paths (in order of precedence):
 			  - %[1]s$XDG_CONFIG_HOME/gh%[1]s (if %[1]s$XDG_CONFIG_HOME%[1]s is set),
 			  - %[1]s$AppData/GitHub CLI%[1]s (on Windows if %[1]s$AppData%[1]s is set), or
@@ -276,70 +276,6 @@ var HelpTopics = []helpTopic{
 			practice to check documentation for the command if you are relying on exit codes to
 			control some behavior.
 		`),
-	},
-	{
-		name:  "scopes",
-		short: "Auth scopes for token used by gh",
-		long: heredoc.Docf(`
-			Scopes let you specify exactly what type of access you need. Scopes limit access for OAuth tokens.
-			They do not grant any additional permission beyond that which the user already has.
-			- %[1]s(no scope)%[1]s: grants read-only access to public information (including user profile info, repository 	info, and gists).
-			- %[1]srepo%[1]s: grants full access to public and private repositories including read and write access to code,
-			commit statuses, repository invitations, collaborators, deployment statuses, and repository webhooks.
-			  NOTE: In addition to repository related resources, the repo scope also grants access to manage organization-owned
-			  resources including projects, invitations, team memberships and webhooks.
-			  This scope also grants the ability to manage projects owned by users.
-			  - %[1]srepo:status%[1]s: grants read/write access to commit statuses in public and private repositories.
-			This scope is only necessary to grant other users or services access to private repository commit statuses without granting access to the code.
-			  - %[1]srepo_deployment%[1]s: grants access to deployment statuses for public and private repositories.
-			This scope is only necessary to grant other users or services access to deployment statuses, without granting access to the code.
-			  - %[1]spublic_repo%[1]s: limits access to public repositories. That includes read/write access to code,
-			commit statuses, repository projects, collaborators, and deployment statuses for public repositories and
-			organizations. Also required for starring public repositories.
-			  - %[1]srepo:invite%[1]s: grants accept/decline abilities for invitations to collaborate on a repository.
-			This scope is only necessary to grant other users or services access to invites without granting access to the code.
-			  - %[1]ssecurity_events%[1]s: grants read and write access to security events in the code scanning API.
-			This scope is only necessary to grant other users or services access to security events without granting access to the code.
-			- %[1]sadmin:repo_hook%[1]s: grants read, write, ping, and delete access to repository hooks in public or private repositories.
-			The %[1]srepo%[1]s and %[1]spublic_repo%[1]s scopes grant full access to repositories, including repository hooks. Use the %[1]sadmin:repo_hook%[1]s scope to limit access to only repository hooks.
-			  - %[1]swrite:repo_hook%[1]s: grants read, write, and ping access to hooks in public or private repositories.
-			  - %[1]sread:repo_hook%[1]s: grants read and ping access to hooks in public or private repositories.
-			- %[1]sadmin:org%[1]s: fully manage the organization and its teams, projects, and memberships.
-			  - %[1]swrite:org%[1]s: read and write access to organization membership and organization projects.
-			  - %[1]sread:org%[1]s: read-only access to organization membership, organization projects, and team membership.
-			- %[1]sadmin:public_key%[1]s: fully manage public keys.
-			  - %[1]swrite:public_key%[1]s: create, list, and view details for public keys.
-			  - %[1]sread:public_key%[1]s: list and view details for public keys.
-			- %[1]sadmin:org_hook%[1]s: grants read, write, ping, and delete access to organization hooks.
-			  NOTE: OAuth tokens will only be able to perform these actions on organization hooks which were created by the OAuth app.
-			  Personal access tokens will only be able to perform these actions on organization hooks created by a user.
-			- %[1]sgist%[1]s: grants write access to gists.
-			- %[1]snotifications%[1]s: grants:
-			  - read access to a user's notifications
-			  - mark as read access to threads
-			  - watch and unwatch access to a repository, and
-			  - read, write, and delete access to thread subscriptions.
-			- %[1]suser%[1]s: grants read/write access to profile info only. Note that this scope includes %[1]suser:email%[1]s and %[1]suser:follow%[1]s.
-			  - %[1]sread:user%[1]s: grants access to read a user's profile data.
-			  - %[1]suser:email%[1]s: grants read access to a user's email addresses.
-			  - %[1]suser:follow%[1]s: grants access to follow or unfollow other users.
-			- %[1]sproject%[1]s: grants read/write access to user and organization projects.
-			  - %[1]sread:project%[1]s: grants read only access to user and organization projects.
-			- %[1]sdelete_repo%[1]s: grants access to delete adminable repositories.
-			- %[1]swrite:packages%[1]s: grants access to upload or publish a package in GitHub Packages.
-			- %[1]sread:packages%[1]s: grants access to download or install packages from GitHub Packages.
-			- %[1]sdelete:packages%[1]s: grants access to delete packages from GitHub Packages.
-			- %[1]sadmin:gpg_key%[1]s: fully manage GPG keys.
-			  - %[1]swrite:gpg_key%[1]s: create, list, and view details for GPG keys.
-			  - %[1]sread:gpg_key%[1]s: list and view details for GPG keys.
-			- %[1]scodespace%[1]s: grants the ability to create and manage codespaces. Codespaces can expose a
-			%[1]sGITHUB_TOKEN%[1]s which may have a different set of scopes.
-			- %[1]sworkflow%[1]s: grants the ability to add and update GitHub Actions workflow files.
-			Workflow files can be committed without this scope if the same file (with both the same path and contents) exists
-			on another branch in the same repository. Workflow files can expose %[1]sGITHUB_TOKEN%[1]s which may have a
-			different set of scopes.
-			NOTE: You can always find up-to-date list of scopes at <https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps/#available-scopes>.
-		`, "`"),
 	},
 }
 


### PR DESCRIPTION
Fixes #6092.
# Description
I have added new help topic `scopes`, which contains information [about auth scopes](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes). Also I have added mention of this help topic to `gh auth login` and `gh auth refresh`.
# Screenshots
## Help topic
![image](https://github.com/user-attachments/assets/d82b2ac3-d50f-4109-83a5-47bbb6317dfb)
## `gh auth login` command help
![image](https://github.com/user-attachments/assets/81e96cb3-7f04-41b2-87fd-5f57e06359be)
## `gh auth refresh` command help
![image](https://github.com/user-attachments/assets/4c38c192-e9b4-40dc-9184-e55a892b2163)
