### PR TITLE
fix: list branches in square brackets in `gh run` and `gh codespace`

### DIFF
--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -198,7 +198,7 @@ func (c codespace) displayName(includeOwner bool) string {
 		displayName = c.Name
 	}
 
-	description := fmt.Sprintf("%s (%s): %s", c.Repository.FullName, branch, displayName)
+	description := fmt.Sprintf("%s [%s]: %s", c.Repository.FullName, branch, displayName)
 
 	if includeOwner {
 		description = fmt.Sprintf("%-15s %s", c.Owner.Login, description)

--- a/pkg/cmd/codespace/common_test.go
+++ b/pkg/cmd/codespace/common_test.go
@@ -34,7 +34,7 @@ func Test_codespace_displayName(t *testing.T) {
 					DisplayName: "scuba steve",
 				},
 			},
-			want: "cli/cli (trunk): scuba steve",
+			want: "cli/cli [trunk]: scuba steve",
 		},
 		{
 			name: "No included name - included gitstatus - no unsaved changes",
@@ -50,7 +50,7 @@ func Test_codespace_displayName(t *testing.T) {
 					DisplayName: "scuba steve",
 				},
 			},
-			want: "cli/cli (trunk): scuba steve",
+			want: "cli/cli [trunk]: scuba steve",
 		},
 		{
 			name: "No included name - included gitstatus - unsaved changes",
@@ -67,7 +67,7 @@ func Test_codespace_displayName(t *testing.T) {
 					DisplayName: "scuba steve",
 				},
 			},
-			want: "cli/cli (trunk*): scuba steve",
+			want: "cli/cli [trunk*]: scuba steve",
 		},
 		{
 			name: "Included name - included gitstatus - unsaved changes",
@@ -84,7 +84,7 @@ func Test_codespace_displayName(t *testing.T) {
 					DisplayName: "scuba steve",
 				},
 			},
-			want: "cli/cli (trunk*): scuba steve",
+			want: "cli/cli [trunk*]: scuba steve",
 		},
 		{
 			name: "Included name - included gitstatus - no unsaved changes",
@@ -101,7 +101,7 @@ func Test_codespace_displayName(t *testing.T) {
 					DisplayName: "scuba steve",
 				},
 			},
-			want: "cli/cli (trunk): scuba steve",
+			want: "cli/cli [trunk]: scuba steve",
 		},
 		{
 			name: "with includeOwner true, prefixes the codespace owner",
@@ -123,7 +123,7 @@ func Test_codespace_displayName(t *testing.T) {
 					DisplayName: "scuba steve",
 				},
 			},
-			want: "jimmy           cli/cli (trunk): scuba steve",
+			want: "jimmy           cli/cli [trunk]: scuba steve",
 		},
 	}
 	for _, tt := range tests {
@@ -163,7 +163,7 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 				},
 			},
 			wantCodespacesNames: []string{
-				"cli/cli (trunk): scuba steve",
+				"cli/cli [trunk]: scuba steve",
 			},
 		},
 		{
@@ -191,8 +191,8 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 				},
 			},
 			wantCodespacesNames: []string{
-				"cli/cli (trunk): scuba steve",
-				"cli/cli (trunk): flappy bird",
+				"cli/cli [trunk]: scuba steve",
+				"cli/cli [trunk]: flappy bird",
 			},
 		},
 		{
@@ -220,8 +220,8 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 				},
 			},
 			wantCodespacesNames: []string{
-				"cli/cli (trunk): scuba steve",
-				"cli/cli (feature): flappy bird",
+				"cli/cli [trunk]: scuba steve",
+				"cli/cli [feature]: flappy bird",
 			},
 		},
 		{
@@ -249,8 +249,8 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 				},
 			},
 			wantCodespacesNames: []string{
-				"github/cli (trunk): scuba steve",
-				"cli/cli (trunk): flappy bird",
+				"github/cli [trunk]: scuba steve",
+				"cli/cli [trunk]: flappy bird",
 			},
 		},
 		{
@@ -279,8 +279,8 @@ func Test_formatCodespacesForSelect(t *testing.T) {
 				},
 			},
 			wantCodespacesNames: []string{
-				"cli/cli (trunk): scuba steve",
-				"cli/cli (trunk*): flappy bird",
+				"cli/cli [trunk]: scuba steve",
+				"cli/cli [trunk*]: flappy bird",
 			},
 		},
 	}

--- a/pkg/cmd/run/cancel/cancel_test.go
+++ b/pkg/cmd/run/cancel/cancel_test.go
@@ -196,9 +196,9 @@ func TestRunCancel(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"* cool commit, CI (trunk) Feb 23, 2021"},
+					[]string{"* cool commit, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
-						return prompter.IndexFor(opts, "* cool commit, CI (trunk) Feb 23, 2021")
+						return prompter.IndexFor(opts, "* cool commit, CI [trunk] Feb 23, 2021")
 					})
 			},
 			wantOut: "✓ Request to cancel workflow 1234 submitted.\n",

--- a/pkg/cmd/run/delete/delete_test.go
+++ b/pkg/cmd/run/delete/delete_test.go
@@ -132,7 +132,7 @@ func TestRunDelete(t *testing.T) {
 			},
 			prompterStubs: func(pm *prompter.PrompterMock) {
 				pm.SelectFunc = func(_, _ string, opts []string) (int, error) {
-					return prompter.IndexFor(opts, "✓ cool commit, CI (trunk) Feb 23, 2021")
+					return prompter.IndexFor(opts, "✓ cool commit, CI [trunk] Feb 23, 2021")
 				}
 			},
 			httpStubs: func(reg *httpmock.Registry) {

--- a/pkg/cmd/run/rerun/rerun_test.go
+++ b/pkg/cmd/run/rerun/rerun_test.go
@@ -341,7 +341,7 @@ func TestRerun(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"X cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021"},
+					[]string{"X cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
 						return 2, nil
 					})

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -508,7 +508,7 @@ func SelectRun(p Prompter, cs *iostreams.ColorScheme, runs []Run) (string, error
 		symbol, _ := Symbol(cs, run.Status, run.Conclusion)
 		candidates = append(candidates,
 			// TODO truncate commit message, long ones look terrible
-			fmt.Sprintf("%s %s, %s (%s) %s", symbol, run.Title(), run.WorkflowName(), run.HeadBranch, preciseAgo(now, run.StartedTime())))
+			fmt.Sprintf("%s %s, %s [%s] %s", symbol, run.Title(), run.WorkflowName(), run.HeadBranch, preciseAgo(now, run.StartedTime())))
 	}
 
 	selected, err := p.Select("Select a workflow run", "", candidates)

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -543,9 +543,9 @@ func TestViewRun(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"X cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "✓ cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021"},
+					[]string{"X cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "✓ cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
-						return prompter.IndexFor(opts, "✓ cool commit, CI (trunk) Feb 23, 2021")
+						return prompter.IndexFor(opts, "✓ cool commit, CI [trunk] Feb 23, 2021")
 					})
 			},
 			opts: &ViewOptions{
@@ -593,9 +593,9 @@ func TestViewRun(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"X cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "✓ cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021"},
+					[]string{"X cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "✓ cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
-						return prompter.IndexFor(opts, "✓ cool commit, CI (trunk) Feb 23, 2021")
+						return prompter.IndexFor(opts, "✓ cool commit, CI [trunk] Feb 23, 2021")
 					})
 				pm.RegisterSelect("View a specific job in this run?",
 					[]string{"View all jobs in this run", "✓ cool job", "X sad job"},
@@ -646,9 +646,9 @@ func TestViewRun(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"X cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "✓ cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021"},
+					[]string{"X cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "✓ cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
-						return prompter.IndexFor(opts, "✓ cool commit, CI (trunk) Feb 23, 2021")
+						return prompter.IndexFor(opts, "✓ cool commit, CI [trunk] Feb 23, 2021")
 					})
 				pm.RegisterSelect("View a specific job in this run?",
 					[]string{"View all jobs in this run", "✓ cool job", "X sad job"},
@@ -743,9 +743,9 @@ func TestViewRun(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"X cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "✓ cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021"},
+					[]string{"X cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "✓ cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
-						return prompter.IndexFor(opts, "✓ cool commit, CI (trunk) Feb 23, 2021")
+						return prompter.IndexFor(opts, "✓ cool commit, CI [trunk] Feb 23, 2021")
 					})
 				pm.RegisterSelect("View a specific job in this run?",
 					[]string{"View all jobs in this run", "✓ cool job", "X sad job"},
@@ -823,7 +823,7 @@ func TestViewRun(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"X cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "✓ cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021"},
+					[]string{"X cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "✓ cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
 						return 4, nil
 					})
@@ -876,7 +876,7 @@ func TestViewRun(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"X cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "✓ cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021"},
+					[]string{"X cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "✓ cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
 						return 4, nil
 					})
@@ -950,7 +950,7 @@ func TestViewRun(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"X cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "✓ cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021"},
+					[]string{"X cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "✓ cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
 						return 4, nil
 					})
@@ -1104,9 +1104,9 @@ func TestViewRun(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"X cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "✓ cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021"},
+					[]string{"X cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "✓ cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
-						return prompter.IndexFor(opts, "✓ cool commit, CI (trunk) Feb 23, 2021")
+						return prompter.IndexFor(opts, "✓ cool commit, CI [trunk] Feb 23, 2021")
 					})
 				pm.RegisterSelect("View a specific job in this run?",
 					[]string{"View all jobs in this run", "✓ cool job", "X sad job"},
@@ -1155,9 +1155,9 @@ func TestViewRun(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"X cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "✓ cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "- cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "* cool commit, CI (trunk) Feb 23, 2021", "X cool commit, CI (trunk) Feb 23, 2021"},
+					[]string{"X cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "✓ cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "- cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "* cool commit, CI [trunk] Feb 23, 2021", "X cool commit, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
-						return prompter.IndexFor(opts, "✓ cool commit, CI (trunk) Feb 23, 2021")
+						return prompter.IndexFor(opts, "✓ cool commit, CI [trunk] Feb 23, 2021")
 					})
 				pm.RegisterSelect("View a specific job in this run?",
 					[]string{"View all jobs in this run", "✓ cool job", "X sad job"},

--- a/pkg/cmd/run/watch/watch_test.go
+++ b/pkg/cmd/run/watch/watch_test.go
@@ -272,9 +272,9 @@ func TestWatchRun(t *testing.T) {
 			httpStubs: successfulRunStubs,
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"* commit1, CI (trunk) Feb 23, 2021", "* commit2, CI (trunk) Feb 23, 2021"},
+					[]string{"* commit1, CI [trunk] Feb 23, 2021", "* commit2, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
-						return prompter.IndexFor(opts, "* commit2, CI (trunk) Feb 23, 2021")
+						return prompter.IndexFor(opts, "* commit2, CI [trunk] Feb 23, 2021")
 					})
 			},
 			wantOut: "\x1b[?1049h\x1b[0;0H\x1b[JRefreshing run status every 0 seconds. Press Ctrl+C to quit.\n\n* trunk CI · 2\nTriggered via push about 59 minutes ago\n\nJOBS\n✓ cool job in 4m34s (ID 10)\n  ✓ fob the barz\n  ✓ barz the fob\n\x1b[?1049l✓ trunk CI · 2\nTriggered via push about 59 minutes ago\n\nJOBS\n✓ cool job in 4m34s (ID 10)\n  ✓ fob the barz\n  ✓ barz the fob\n\n✓ Run CI (2) completed with 'success'\n",
@@ -290,9 +290,9 @@ func TestWatchRun(t *testing.T) {
 			httpStubs: failedRunStubs,
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect("Select a workflow run",
-					[]string{"* commit1, CI (trunk) Feb 23, 2021", "* commit2, CI (trunk) Feb 23, 2021"},
+					[]string{"* commit1, CI [trunk] Feb 23, 2021", "* commit2, CI [trunk] Feb 23, 2021"},
 					func(_, _ string, opts []string) (int, error) {
-						return prompter.IndexFor(opts, "* commit2, CI (trunk) Feb 23, 2021")
+						return prompter.IndexFor(opts, "* commit2, CI [trunk] Feb 23, 2021")
 					})
 			},
 			wantOut: "\x1b[?1049h\x1b[0;0H\x1b[JRefreshing run status every 0 seconds. Press Ctrl+C to quit.\n\n* trunk CI · 2\nTriggered via push about 59 minutes ago\n\n\x1b[?1049lX trunk CI · 2\nTriggered via push about 59 minutes ago\n\nJOBS\nX sad job in 4m34s (ID 20)\n  ✓ barf the quux\n  X quux the barf\n\nANNOTATIONS\nX the job is sad\nsad job: blaze.py#420\n\n\nX Run CI (2) completed with 'failure'\n",


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #10038 

## Changes

`pkg/cmd/run/shared`: Switched parentheses in `selectRun()` to square brackets.

### Before

```go
func selectRun() {
  ...
  fmt.Sprintf("%s %s, %s (%s) %s", ...)
  ...
}
```

### After

```go
func selectRun() {
  ...
  fmt.Sprintf("%s %s, %s [%s] %s", ...)
  ...
}
```