### PR TITLE
`gh repo rename` help text clarifies new repo name should not include owner

### DIFF
--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -49,9 +49,27 @@ func NewCmdRename(f *cmdutil.Factory, runf func(*RenameOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "rename [<new-name>]",
 		Short: "Rename a repository",
-		Long: heredoc.Doc(`Rename a GitHub repository.
+		Long: heredoc.Docf(`
+			Rename a GitHub repository.
+			
+			%[1]s<new-name>%[1]s is the desired repository name without the owner.
+			
+			By default, the current repository is renamed. Otherwise, the repository specified
+			with %[1]s--repo%[1]s is renamed.
+			
+			To transfer repository ownership to another user account or organization,
+			you must follow additional steps on GitHub.com
 
-		By default, this renames the current repository; otherwise renames the specified repository.`),
+			For more information on transferring repository ownership, see:
+			<https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository>
+			`, "`"),
+		Example: heredoc.Doc(`
+			# Rename the current repository (foo/bar -> foo/baz)
+			$ gh repo rename baz
+
+			# Rename the specified repository (qux/quux -> qux/baz)
+			$ gh repo rename -R qux/quux baz
+		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.BaseRepo = f.BaseRepo


### PR DESCRIPTION
## Description

- Update `gh repo rename` help doc.
    - Add `Example` doc to demo proper usage of the `<new-name>` arugment.
    - Add details to the `Long` doc about the intended value of the `<new-name>` argument.
    - Add details to the `Long` doc about transferring repository ownership.

**Relates to:**
- #10034
- #5292

## Demo

<details><summary>Current</summary>
<p>

```
❯ gh repo rename --help
Rename a GitHub repository.

By default, this renames the current repository; otherwise renames the specified repository.

USAGE
  gh repo rename [<new-name>] [flags]

FLAGS
  -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format
  -y, --yes                      Skip the confirmation prompt

INHERITED FLAGS
  --help   Show help for command

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`

```

</p>
</details> 


<details><summary>Proposed</summary>
<p>

```
❯ gh repo rename --help
Rename a GitHub repository.

`<new-name>` is the desired repository name without the owner.

By default, the current repository is renamed. Otherwise, the repository specified
with `--repo` is renamed.

To transfer repository ownership to another user account or organization,
you must follow additional steps on GitHub.com

For more information on transferring repository ownership, see:
<https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository>


USAGE
  gh repo rename [<new-name>] [flags]

FLAGS
  -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format
  -y, --yes                      Skip the confirmation prompt

INHERITED FLAGS
  --help   Show help for command

EXAMPLES
  # Rename the current repository (foo/bar -> foo/baz)
  $ gh repo rename baz
  
  # Rename the specified repository (qux/quux -> qux/baz)
  $ gh repo rename -R qux/quux baz

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
```

</p>
</details> 
