### PR TITLE
Improve error handling in apt setup script

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -16,7 +16,8 @@ Install:
 ```bash
 (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
 	&& sudo mkdir -p -m 755 /etc/apt/keyrings \
-	&& wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+        && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
 	&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
 	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
 	&& sudo apt update \


### PR DESCRIPTION
`wget -qO- ... | sudo tee` causes any errors from `wget` to be swallowed up, causing an empty keyring file to be configured.

For us, the local Ubuntu setup did not have `ca-certificates` installed, which caused `wget` to error out because of a authentication errors (untrusted certificate). However, the `-q` flag and the pipe into `tee` prevented the error from showing up or halting the script.

This PR turns on non-verbose output for `wget` and adds a proper short-circuit on the return code of it by storing the keyring in a temporary file first.

Fixes #10057.