### PR TITLE
`gh pr merge --delete-branch` does not delete the remote branch when PR is merged via a merge queue

### DIFF
--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -449,6 +449,13 @@ func (m *mergeContext) deleteRemoteBranch() error {
 		return nil
 	}
 
+	// Don't delete the remote branch if there is a merge queue because doing so
+	// can cause the PR to close and be removed from the merge queue.
+	if m.shouldAddToMergeQueue() {
+		fmt.Fprintf(m.opts.IO.ErrOut, "%s Unable to delete remote branch %s: pull request is in merge queue\n", m.cs.WarningIcon(), m.cs.Cyan(m.pr.HeadRefName))
+		return nil
+	}
+
 	if !m.merged {
 		apiClient := api.NewClientFromHTTP(m.httpClient)
 		err := api.BranchDeleteRemote(apiClient, m.baseRepo, m.pr.HeadRefName)


### PR DESCRIPTION
## Description

When running `gh pr merge --delete-branch`, no longer delete the remote branch if the PR is merged via a merge queue.

Attempting to delete the remote branch with a PR that will be merged with a merge queue can cause the PR to be unexpectedly closed and the remote branch deleted before a successful merge.

Resolves #7011 

## Demo

<details><summary>Current Behavior...</summary>
<p>

```
test-general on  main took 3s 
❯ gh pr checkout 18
branch 'BagToad-patch-5' set up to track 'origin/BagToad-patch-5'.
Switched to a new branch 'BagToad-patch-5'

test-general on  BagToad-patch-5 
❯ gh pr merge -d   
✓ Pull request bagtoad-enterprise-cloud-testing/test-general#18 will be added to the merge queue for main when ready
From https://github.com/bagtoad-enterprise-cloud-testing/test-general
 * branch            main       -> FETCH_HEAD
Already up to date.
✓ Deleted local branch BagToad-patch-5 and switched to branch main
✓ Deleted remote branch BagToad-patch-5
```

![image](https://github.com/user-attachments/assets/98ed5ee4-b0e7-4e2e-a387-49041d5427e2)

</p>
</details> 

<details><summary>Proposed</summary>
<p>

```
test-general on  main took 2s 
❯ $ghbin pr checkout 18
branch 'BagToad-patch-5' set up to track 'origin/BagToad-patch-5'.
Switched to a new branch 'BagToad-patch-5'

test-general on  BagToad-patch-5 
❯ $ghbin pr merge -d                                           
✓ Pull request bagtoad-enterprise-cloud-testing/test-general#18 will be added to the merge queue for main when ready
From https://github.com/bagtoad-enterprise-cloud-testing/test-general
 * branch            main       -> FETCH_HEAD
Already up to date.
✓ Deleted local branch BagToad-patch-5 and switched to branch main
! Unable to delete remote branch BagToad-patch-5: pull request is in merge queue
```

![image](https://github.com/user-attachments/assets/54131666-f117-40ad-8c5b-f4de112377a3)

</p>
</details> 

## Notes

To reproduce this, you have to configure a repository with a ruleset that requires a merge queue. The merge queue must be configured in some way that allows a PR to wait in the merge queue for some amount of time. 

The following settings will work to accomplish that when one PR is in the merge queue:

<details><summary>merge queue settings image</summary>
<p>

![image](https://github.com/user-attachments/assets/1f4c7733-501a-4dc6-aa87-aa033b4a063e)


</p>
</details> 
