### PR TITLE
`gh pr merge --delete-branch` exits with error when merge requested via merge queue

### DIFF
--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -241,7 +241,15 @@ func (m *mergeContext) warnIfDiverged() {
 // Check if the current state of the pull request allows for merging
 func (m *mergeContext) canMerge() error {
 	if m.mergeQueueRequired {
-		// a pull request can always be added to the merge queue
+		// Requesting branch deletion on a PR with a merge queue
+		// policy is not allowed. Doing so can unexpectedly
+		// delete branches before merging, close the PR, and remove
+		// the PR from the merge queue.
+		if m.opts.DeleteBranch {
+			fmt.Fprintf(m.opts.IO.ErrOut, "%s Cannot use `-d` or `--delete-branch` when merge queue enabled\n", m.cs.FailureIcon())
+			return cmdutil.SilentError
+		}
+		// Otherwise, a pull request can always be added to the merge queue
 		return nil
 	}
 

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -246,8 +246,7 @@ func (m *mergeContext) canMerge() error {
 		// delete branches before merging, close the PR, and remove
 		// the PR from the merge queue.
 		if m.opts.DeleteBranch {
-			fmt.Fprintf(m.opts.IO.ErrOut, "%s Cannot use `-d` or `--delete-branch` when merge queue enabled\n", m.cs.FailureIcon())
-			return cmdutil.SilentError
+			return fmt.Errorf("%s Cannot use `-d` or `--delete-branch` when merge queue enabled", m.cs.FailureIcon())
 		}
 		// Otherwise, a pull request can always be added to the merge queue
 		return nil

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -659,6 +659,34 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 	`), output.Stderr())
 }
 
+func TestPrMerge_deleteBranch_mergeQueue(t *testing.T) {
+	http := initFakeHTTP()
+	defer http.Verify(t)
+
+	shared.RunCommandFinder(
+		"",
+		&api.PullRequest{
+			ID:                  "PR_10",
+			Number:              10,
+			State:               "OPEN",
+			Title:               "Blueberries are a good fruit",
+			HeadRefName:         "blueberries",
+			BaseRefName:         "main",
+			MergeStateStatus:    "CLEAN",
+			IsMergeQueueEnabled: true,
+		},
+		baseRepo("OWNER", "REPO", "main"),
+	)
+
+	output, err := runCommand(http, nil, "blueberries", true, `pr merge --merge --delete-branch`)
+	assert.ErrorIs(t, err, cmdutil.SilentError)
+
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, heredoc.Docf(`
+		X Cannot use %[1]s-d%[1]s or %[1]s--delete-branch%[1]s when merge queue enabled
+	`, "`"), output.Stderr())
+}
+
 func TestPrMerge_deleteBranch_nonDefault(t *testing.T) {
 	http := initFakeHTTP()
 	defer http.Verify(t)

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -678,13 +678,8 @@ func TestPrMerge_deleteBranch_mergeQueue(t *testing.T) {
 		baseRepo("OWNER", "REPO", "main"),
 	)
 
-	output, err := runCommand(http, nil, "blueberries", true, `pr merge --merge --delete-branch`)
-	assert.ErrorIs(t, err, cmdutil.SilentError)
-
-	assert.Equal(t, "", output.String())
-	assert.Equal(t, heredoc.Docf(`
-		X Cannot use %[1]s-d%[1]s or %[1]s--delete-branch%[1]s when merge queue enabled
-	`, "`"), output.Stderr())
+	_, err := runCommand(http, nil, "blueberries", true, `pr merge --merge --delete-branch`)
+	assert.Contains(t, err.Error(), "X Cannot use `-d` or `--delete-branch` when merge queue enabled")
 }
 
 func TestPrMerge_deleteBranch_nonDefault(t *testing.T) {


### PR DESCRIPTION
## Description

When running `gh pr merge -d` on a repo with a merge queue policy, exit before attempting to merge.

Attempting to delete the remote branch with a PR that will be merged with a merge queue can cause the PR to be unexpectedly closed and the remote branch deleted before a successful merge.

Alternative fix #7011.

## Demo

<details><summary>Current Behavior...</summary>
<p>

```
test-general on  main took 3s 
❯ gh pr checkout 18
branch 'BagToad-patch-5' set up to track 'origin/BagToad-patch-5'.
Switched to a new branch 'BagToad-patch-5'

test-general on  BagToad-patch-5 
❯ gh pr merge -d   
✓ Pull request bagtoad-enterprise-cloud-testing/test-general#18 will be added to the merge queue for main when ready
From https://github.com/bagtoad-enterprise-cloud-testing/test-general
 * branch            main       -> FETCH_HEAD
Already up to date.
✓ Deleted local branch BagToad-patch-5 and switched to branch main
✓ Deleted remote branch BagToad-patch-5
```

![image](https://github.com/user-attachments/assets/98ed5ee4-b0e7-4e2e-a387-49041d5427e2)

</p>
</details> 

<details><summary>Proposed...</summary>
<p>

```
❯ $ghbin pr merge -d   
X Cannot use `-d` or `--delete-branch` when merge queue enabled
```
</p>
</details> 

## Notes

To reproduce this, you have to configure a repository with a ruleset that requires a merge queue. The merge queue must be configured in some way that allows a PR to wait in the merge queue for some amount of time. 

The following settings will work to accomplish that when one PR is in the merge queue:

<details><summary>merge queue settings image</summary>
<p>

![image](https://github.com/user-attachments/assets/1f4c7733-501a-4dc6-aa87-aa033b4a063e)


</p>
</details> 
