### PR TITLE
Add job to deployment workflow to validate the tag name for a given release

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Validate tag name format
         run: |
-          if [[ ! "${{ inputs.tag_name }}" =~ ^v[0-9]+.[0-9]+.[0-9]+$]]; then
+          if [[ ! "${{ inputs.tag_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$]]; then
             echo "Invalid tag name format. Must be in the form v1.2.3"
             exit 1
           fi

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -28,7 +28,17 @@ on:
         default: true
 
 jobs:
+  validate-tag-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag name format
+        run: |
+          if [[ ! "${{ inputs.tag_name }}" =~ ^v[0-9]+.[0-9]+.[0-9]+$]]; then
+            echo "Invalid tag name format. Must be in the form v1.2.3"
+            exit 1
+          fi
   linux:
+    needs: validate-tag-name
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     if: contains(inputs.platforms, 'linux')
@@ -63,6 +73,7 @@ jobs:
             dist/*.deb
 
   macos:
+    needs: validate-tag-name
     runs-on: macos-latest
     environment: ${{ inputs.environment }}
     if: contains(inputs.platforms, 'macos')
@@ -134,6 +145,7 @@ jobs:
             dist/*.pkg
  
   windows:
+    needs: validate-tag-name
     runs-on: windows-latest
     environment: ${{ inputs.environment }}
     if: contains(inputs.platforms, 'windows')


### PR DESCRIPTION
## Changes

This adds a `validate-tag-name` job to our deployment workflow that will halt the deployment if the tag name doesn't follow the format `v1.2.3`. It is agnostic to the size of the numbers, so `v123.456.78901234` is also a valid tag.

## Testing

Not sure how to test this without running the workflow 😅 I did test the regex this runs on and it seemed to work fine. I think this is probably low risk enough to `#shiptolearn`