### PR TITLE
fix(repo fork): add non-TTY output when fork is newly created

### DIFF
--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -221,6 +221,8 @@ func forkRun(opts *ForkOptions) error {
 	} else {
 		if connectedToTerminal {
 			fmt.Fprintf(stderr, "%s Created fork %s\n", cs.SuccessIconWithColor(cs.Green), cs.Bold(ghrepo.FullName(forkedRepo)))
+		} else {
+			fmt.Fprintf(stderr, "Created fork %s\n", ghrepo.FullName(forkedRepo))
 		}
 	}
 

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -222,7 +222,7 @@ func forkRun(opts *ForkOptions) error {
 		if connectedToTerminal {
 			fmt.Fprintf(stderr, "%s Created fork %s\n", cs.SuccessIconWithColor(cs.Green), cs.Bold(ghrepo.FullName(forkedRepo)))
 		} else {
-			fmt.Fprintf(stderr, "Created fork %s\n", ghrepo.FullName(forkedRepo))
+			fmt.Fprintln(opts.IO.Out, ghrepo.GenerateRepoURL(forkedRepo, ""))
 		}
 	}
 

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -390,6 +390,7 @@ func TestRepoFork(t *testing.T) {
 				},
 			},
 			httpStubs: forkPost,
+			wantOut:   "https://github.com/someone/REPO\n",
 		},
 		{
 			name: "implicit nontty remote exists",
@@ -424,11 +425,13 @@ func TestRepoFork(t *testing.T) {
 				cs.Register("git remote rename origin upstream", 0, "")
 				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
 			},
+			wantOut: "https://github.com/someone/REPO\n",
 		},
 		{
 			name:      "implicit nontty no args",
 			opts:      &ForkOptions{},
 			httpStubs: forkPost,
+			wantOut:   "https://github.com/someone/REPO\n",
 		},
 		{
 			name: "passes git flags",
@@ -561,6 +564,7 @@ func TestRepoFork(t *testing.T) {
 				Repository: "OWNER/REPO",
 			},
 			httpStubs: forkPost,
+			wantOut:   "https://github.com/someone/REPO\n",
 		},
 		{
 			name: "repo arg nontty repo already exists",
@@ -604,6 +608,7 @@ func TestRepoFork(t *testing.T) {
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
 			},
+			wantOut: "https://github.com/someone/REPO\n",
 		},
 		{
 			name: "non tty repo arg with fork-name",
@@ -640,6 +645,7 @@ func TestRepoFork(t *testing.T) {
 					httpmock.StringResponse(renameResult))
 			},
 			wantErrOut: "",
+			wantOut:    "https://github.com/OWNER/REPO\n",
 		},
 		{
 			name: "tty repo arg with fork-name",
@@ -694,6 +700,7 @@ func TestRepoFork(t *testing.T) {
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
 			},
+			wantOut: "https://github.com/someone/REPO\n",
 		},
 		{
 			name: "does not retry clone if error occurs and exit code is not 128",


### PR DESCRIPTION
Fixes #10079 

Previously, when running `gh repo fork` in a non-interactive environment (non-TTY) for a brand-new fork, there was no output—causing confusion for CI/CD scripts. This change adds an else block to ensure we print "Created fork <slug>" even in non-TTY mode, matching the behavior when a fork already exists.

