### PR TITLE
Add mention of classic token in gh auth login docs

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -63,13 +63,15 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			flag.
 
 			The default authentication mode is a web-based browser flow. After completion, an
-			authentication token (classic) will be stored securely in the system credential store.
+			authentication token will be stored securely in the system credential store.
 			If a credential store is not found or there is an issue using it gh will fallback
 			to writing the token to a plain text file. See %[1]sgh auth status%[1]s for its
 			stored location.
 
-			Alternatively, use %[1]s--with-token%[1]s to pass in a token on standard input.
+			Alternatively, use %[1]s--with-token%[1]s to pass in a token (classic) on standard input.
 			The minimum required scopes for the token are: %[1]srepo%[1]s, %[1]sread:org%[1]s, and %[1]sgist%[1]s.
+
+			Fine-grained tokens are not supported.
 
 			Alternatively, gh will use the authentication token found in environment variables.
 			This method is most suitable for "headless" use of gh such as in automation. See

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -63,7 +63,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			flag.
 
 			The default authentication mode is a web-based browser flow. After completion, an
-			authentication token will be stored securely in the system credential store.
+			authentication token (classic) will be stored securely in the system credential store.
 			If a credential store is not found or there is an issue using it gh will fallback
 			to writing the token to a plain text file. See %[1]sgh auth status%[1]s for its
 			stored location.

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -68,10 +68,10 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			to writing the token to a plain text file. See %[1]sgh auth status%[1]s for its
 			stored location.
 
-			Alternatively, use %[1]s--with-token%[1]s to pass in a token (classic) on standard input.
+			Alternatively, use %[1]s--with-token%[1]s to pass in a personal access token (classic) on standard input.
 			The minimum required scopes for the token are: %[1]srepo%[1]s, %[1]sread:org%[1]s, and %[1]sgist%[1]s.
 
-			Fine-grained tokens are not supported.
+			Fine-grained personal access tokens are not supported.
 
 			Alternatively, gh will use the authentication token found in environment variables.
 			This method is most suitable for "headless" use of gh such as in automation. See


### PR DESCRIPTION
Closes #10131 

## Changes

Add mention of classic token to `gh auth login` docs. This copies the token labeling "Tokens (classic)" found in the UI so folks can visually match it to the cli docs

<img width="261" alt="Screenshot 2025-01-02 at 10 10 19 AM" src="https://github.com/user-attachments/assets/b1a9cf1f-02eb-49b1-9f72-911fd1ca370f" />
