### PR TITLE
Clear up --with-token fine grained PAT usage

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -69,9 +69,10 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			stored location.
 
 			Alternatively, use %[1]s--with-token%[1]s to pass in a personal access token (classic) on standard input.
-			The minimum required scopes for the token are: %[1]srepo%[1]s, %[1]sread:org%[1]s, and %[1]sgist%[1]s.
-
-			Fine-grained personal access tokens are not supported.
+			The minimum required scopes for the token are: %[1]srepo%[1]s, %[1]sread:org%[1]s, and %[1]sgist%[1]s. Although
+			it is possible to pass a fine-grained personal access token to %[1]s--with-token%[1]s, it should be done with
+			care, as the inherent scoping to certain resources may cause confusing behaviour when interacting with other
+			resources. Favour setting %[1]sGH_TOKEN$%[1]s for fine-grained personal access token usage. 
 
 			Alternatively, gh will use the authentication token found in environment variables.
 			This method is most suitable for "headless" use of gh such as in automation. See

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -69,9 +69,9 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			stored location.
 
 			Alternatively, use %[1]s--with-token%[1]s to pass in a personal access token (classic) on standard input.
-			The minimum required scopes for the token are: %[1]srepo%[1]s, %[1]sread:org%[1]s, and %[1]sgist%[1]s. Although
-			it is possible to pass a fine-grained personal access token to %[1]s--with-token%[1]s, it should be done with
-			care, as the inherent scoping to certain resources may cause confusing behaviour when interacting with other
+			The minimum required scopes for the token are: %[1]srepo%[1]s, %[1]sread:org%[1]s, and %[1]sgist%[1]s.
+			Take care when passing a fine-grained personal access token to %[1]s--with-token%[1]s
+			as the inherent scoping to certain resources may cause confusing behaviour when interacting with other
 			resources. Favour setting %[1]sGH_TOKEN$%[1]s for fine-grained personal access token usage. 
 
 			Alternatively, gh will use the authentication token found in environment variables.


### PR DESCRIPTION
## Description

Fixes #10131

Follow on from #10164

Clarify that Fine Grained PATs are usable but not advised when using `auth login --with-token`.