### PR TITLE
Myriad fixes to provide clarity on determining tracking ref in PR create

### DIFF
--- a/git/objects.go
+++ b/git/objects.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 )
@@ -63,17 +62,6 @@ type TrackingRef struct {
 
 func (r TrackingRef) String() string {
 	return "refs/remotes/" + r.RemoteName + "/" + r.BranchName
-}
-
-func ParseTrackingRef(text string) (TrackingRef, error) {
-	parts := strings.SplitN(string(text), "/", 4)
-	if len(parts) != 4 {
-		return TrackingRef{}, fmt.Errorf("invalid tracking ref: %s", text)
-	}
-	return TrackingRef{
-		RemoteName: parts[2],
-		BranchName: parts[3],
-	}, nil
 }
 
 type Commit struct {

--- a/git/objects.go
+++ b/git/objects.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -62,6 +63,17 @@ type TrackingRef struct {
 
 func (r TrackingRef) String() string {
 	return "refs/remotes/" + r.RemoteName + "/" + r.BranchName
+}
+
+func ParseTrackingRef(text string) (TrackingRef, error) {
+	parts := strings.SplitN(string(text), "/", 4)
+	if len(parts) != 4 {
+		return TrackingRef{}, fmt.Errorf("invalid tracking ref: %s", text)
+	}
+	return TrackingRef{
+		RemoteName: parts[2],
+		BranchName: parts[3],
+	}, nil
 }
 
 type Commit struct {

--- a/git/objects.go
+++ b/git/objects.go
@@ -54,16 +54,6 @@ type Ref struct {
 	Name string
 }
 
-// TrackingRef represents a ref for a remote tracking branch.
-type TrackingRef struct {
-	RemoteName string
-	BranchName string
-}
-
-func (r TrackingRef) String() string {
-	return "refs/remotes/" + r.RemoteName + "/" + r.BranchName
-}
-
 type Commit struct {
 	Sha   string
 	Title string

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -519,7 +519,9 @@ func initDefaultTitleBody(ctx CreateContext, state *shared.IssueMetadataState, u
 }
 
 // tryDetermineTrackingRef is intended to try and find a remote branch on the same commit as the currently checked out
-// HEAD, i.e. the local branch.
+// HEAD, i.e. the local branch. If there are multiple branches that might match, the first remote is chosen, which in
+// practice is determined by the sorting algorithm applied much earlier in the process, roughly "upstream", "github", "origin",
+// and then everything else unstably sorted.
 func tryDetermineTrackingRef(gitClient *git.Client, remotes ghContext.Remotes, localBranchName string, headBranchConfig git.BranchConfig) (git.TrackingRef, bool) {
 	// To try and determine the tracking ref for a local branch, we first construct a collection of refs
 	// that might be tracking, given the current branch's config, and the list of known remotes.

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -518,6 +518,8 @@ func initDefaultTitleBody(ctx CreateContext, state *shared.IssueMetadataState, u
 	return nil
 }
 
+// determineTrackingBranch is intended to try and find a remote branch on the same commit as the currently checked out
+// HEAD, i.e. the local branch.
 func determineTrackingBranch(gitClient *git.Client, remotes ghContext.Remotes, localBranchName string, headBranchConfig git.BranchConfig) *git.TrackingRef {
 	// To try and determine the tracking ref for a local branch, we first construct a collection of refs
 	// that might be tracking, given the current branch's config, and the list of known remotes.

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -518,7 +518,7 @@ func initDefaultTitleBody(ctx CreateContext, state *shared.IssueMetadataState, u
 	return nil
 }
 
-func determineTrackingBranch(gitClient *git.Client, remotes ghContext.Remotes, localBranchName string, headBranchConfig *git.BranchConfig) *git.TrackingRef {
+func determineTrackingBranch(gitClient *git.Client, remotes ghContext.Remotes, localBranchName string, headBranchConfig git.BranchConfig) *git.TrackingRef {
 	// To try and determine the tracking ref for a local branch, we first construct a collection of refs
 	// that might be tracking, given the current branch's config, and the list of known remotes.
 	refsForLookup := []string{"HEAD"}
@@ -663,7 +663,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 	headBranchConfig := gitClient.ReadBranchConfig(context.Background(), headBranch)
 	if isPushEnabled {
 		// determine whether the head branch is already pushed to a remote
-		if pushedTo := determineTrackingBranch(gitClient, remotes, headBranch, &headBranchConfig); pushedTo != nil {
+		if pushedTo := determineTrackingBranch(gitClient, remotes, headBranch, headBranchConfig); pushedTo != nil {
 			isPushEnabled = false
 			if r, err := remotes.FindByName(pushedTo.RemoteName); err == nil {
 				headRepo = r

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -530,9 +530,16 @@ func (r trackingRef) String() string {
 
 func mustParseTrackingRef(text string) trackingRef {
 	parts := strings.SplitN(string(text), "/", 4)
+	// The only place this is called is tryDetermineTrackingRef, where we are reconstructing
+	// the same tracking ref we passed in. If it doesn't match the expected format, this is a
+	// programmer error we want to know about, so it's ok to panic.
 	if len(parts) != 4 {
-		panic(fmt.Errorf("invalid tracking ref: %s", text))
+		panic(fmt.Errorf("tracking ref should have four parts: %s", text))
 	}
+	if parts[0] != "refs" || parts[1] != "remotes" {
+		panic(fmt.Errorf("tracking ref should start with refs/remotes/: %s", text))
+	}
+
 	return trackingRef{
 		remoteName: parts[2],
 		branchName: parts[3],

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -555,15 +555,23 @@ func determineTrackingBranch(gitClient *git.Client, remotes ghContext.Remotes, l
 				continue
 			}
 			// Otherwise we can parse the returned ref into a tracking ref and return that
-			trackingRef, err := git.ParseTrackingRef(r.Name)
-			if err != nil {
-				return nil
-			}
+			trackingRef := mustParseTrackingRef(r.Name)
 			return &trackingRef
 		}
 	}
 
 	return nil
+}
+
+func mustParseTrackingRef(text string) git.TrackingRef {
+	parts := strings.SplitN(string(text), "/", 4)
+	if len(parts) != 4 {
+		panic(fmt.Errorf("invalid tracking ref: %s", text))
+	}
+	return git.TrackingRef{
+		RemoteName: parts[2],
+		BranchName: parts[3],
+	}
 }
 
 func NewIssueState(ctx CreateContext, opts CreateOptions) (*shared.IssueMetadataState, error) {

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1643,16 +1643,16 @@ func Test_tryDetermineTrackingRef(t *testing.T) {
 			name: "no match",
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
-				cs.Register("git show-ref --verify -- HEAD refs/remotes/origin/feature refs/remotes/upstream/feature", 0, "abc HEAD\nbca refs/remotes/origin/feature")
+				cs.Register("git show-ref --verify -- HEAD refs/remotes/upstream/feature refs/remotes/origin/feature", 0, "abc HEAD\nbca refs/remotes/upstream/feature")
 			},
 			remotes: context.Remotes{
 				&context.Remote{
-					Remote: &git.Remote{Name: "origin"},
-					Repo:   ghrepo.New("hubot", "Spoon-Knife"),
-				},
-				&context.Remote{
 					Remote: &git.Remote{Name: "upstream"},
 					Repo:   ghrepo.New("octocat", "Spoon-Knife"),
+				},
+				&context.Remote{
+					Remote: &git.Remote{Name: "origin"},
+					Repo:   ghrepo.New("hubot", "Spoon-Knife"),
 				},
 			},
 			expectedTrackingRef: git.TrackingRef{},
@@ -1662,24 +1662,24 @@ func Test_tryDetermineTrackingRef(t *testing.T) {
 			name: "match",
 			cmdStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
-				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature refs/remotes/upstream/feature$`, 0, heredoc.Doc(`
+				cs.Register(`git show-ref --verify -- HEAD refs/remotes/upstream/feature refs/remotes/origin/feature$`, 0, heredoc.Doc(`
 		deadbeef HEAD
-		deadb00f refs/remotes/origin/feature
-		deadbeef refs/remotes/upstream/feature
+		deadb00f refs/remotes/upstream/feature
+		deadbeef refs/remotes/origin/feature
 	`))
 			},
 			remotes: context.Remotes{
 				&context.Remote{
-					Remote: &git.Remote{Name: "origin"},
-					Repo:   ghrepo.New("hubot", "Spoon-Knife"),
-				},
-				&context.Remote{
 					Remote: &git.Remote{Name: "upstream"},
 					Repo:   ghrepo.New("octocat", "Spoon-Knife"),
 				},
+				&context.Remote{
+					Remote: &git.Remote{Name: "origin"},
+					Repo:   ghrepo.New("hubot", "Spoon-Knife"),
+				},
 			},
 			expectedTrackingRef: git.TrackingRef{
-				RemoteName: "upstream",
+				RemoteName: "origin",
 				BranchName: "feature",
 			},
 			expectedFound: true,

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1719,7 +1719,7 @@ func Test_determineTrackingBranch(t *testing.T) {
 				GitPath: "some/path/git",
 			}
 			headBranchConfig := gitClient.ReadBranchConfig(ctx.Background(), "feature")
-			ref := determineTrackingBranch(gitClient, tt.remotes, "feature", &headBranchConfig)
+			ref := determineTrackingBranch(gitClient, tt.remotes, "feature", headBranchConfig)
 			tt.assert(ref, t)
 		})
 	}

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1627,7 +1627,7 @@ func Test_tryDetermineTrackingRef(t *testing.T) {
 		name                string
 		cmdStubs            func(*run.CommandStubber)
 		remotes             context.Remotes
-		expectedTrackingRef git.TrackingRef
+		expectedTrackingRef trackingRef
 		expectedFound       bool
 	}{
 		{
@@ -1636,7 +1636,7 @@ func Test_tryDetermineTrackingRef(t *testing.T) {
 				cs.Register(`git config --get-regexp.+branch\\\.feature\\\.`, 0, "")
 				cs.Register(`git show-ref --verify -- HEAD`, 0, "abc HEAD")
 			},
-			expectedTrackingRef: git.TrackingRef{},
+			expectedTrackingRef: trackingRef{},
 			expectedFound:       false,
 		},
 		{
@@ -1655,7 +1655,7 @@ func Test_tryDetermineTrackingRef(t *testing.T) {
 					Repo:   ghrepo.New("hubot", "Spoon-Knife"),
 				},
 			},
-			expectedTrackingRef: git.TrackingRef{},
+			expectedTrackingRef: trackingRef{},
 			expectedFound:       false,
 		},
 		{
@@ -1678,9 +1678,9 @@ func Test_tryDetermineTrackingRef(t *testing.T) {
 					Repo:   ghrepo.New("hubot", "Spoon-Knife"),
 				},
 			},
-			expectedTrackingRef: git.TrackingRef{
-				RemoteName: "origin",
-				BranchName: "feature",
+			expectedTrackingRef: trackingRef{
+				remoteName: "origin",
+				branchName: "feature",
 			},
 			expectedFound: true,
 		},
@@ -1702,7 +1702,7 @@ func Test_tryDetermineTrackingRef(t *testing.T) {
 					Repo:   ghrepo.New("hubot", "Spoon-Knife"),
 				},
 			},
-			expectedTrackingRef: git.TrackingRef{},
+			expectedTrackingRef: trackingRef{},
 			expectedFound:       false,
 		},
 	}


### PR DESCRIPTION
## Description

Intended to be merged onto #10177

PR A/C tests pass:

```
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │                        TEST                        │             PACKAGE               │
│─────────┼─────────┼────────────────────────────────────────────────────┼───────────────────────────────────│
│  PASS   │   13.63 │ TestPullRequests/pr-checkout-with-url-from-fork    │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   12.09 │ TestPullRequests/pr-merge-merge-strategy           │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   11.92 │ TestPullRequests/pr-merge-rebase-strategy          │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   11.47 │ TestPullRequests/pr-view-same-org-fork             │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   11.44 │ TestPullRequests/pr-create-from-issue-develop-base │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   11.37 │ TestPullRequests/pr-comment                        │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   10.88 │ TestPullRequests/pr-view                           │ github.com/cli/cli/v2/acceptance  │
│  PASS   │   10.70 │ TestPullRequests/pr-create-with-metadata           │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    9.40 │ TestPullRequests/pr-create-from-manual-merge-base  │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    8.98 │ TestPullRequests/pr-checkout-by-number             │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    8.63 │ TestPullRequests/pr-list                           │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    8.02 │ TestPullRequests/pr-create-without-upstream-config │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    7.34 │ TestPullRequests/pr-checkout                       │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    7.02 │ TestPullRequests/pr-create-basic                   │ github.com/cli/cli/v2/acceptance  │
│  PASS   │    0.00 │ TestPullRequests                                   │ github.com/cli/cli/v2/acceptance  │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │             PACKAGE              │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼──────────────────────────────────┼───────┼──────┼──────┼───────│
│  PASS   │ 24.56s  │ github.com/cli/cli/v2/acceptance │ 15.6% │  15  │  0   │  0    │
└────────────────────────────────────────────────────────────────────────────────────┘
```