### PR TITLE
Feat: Allow setting squash-merge-commit-title and message in gh repo …

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -46,16 +46,18 @@ type Repository struct {
 	UpdatedAt  time.Time
 	ArchivedAt *time.Time
 
-	IsBlankIssuesEnabled    bool
-	IsSecurityPolicyEnabled bool
-	HasIssuesEnabled        bool
-	HasProjectsEnabled      bool
-	HasDiscussionsEnabled   bool
-	HasWikiEnabled          bool
-	MergeCommitAllowed      bool
-	SquashMergeAllowed      bool
-	RebaseMergeAllowed      bool
-	AutoMergeAllowed        bool
+	IsBlankIssuesEnabled     bool
+	IsSecurityPolicyEnabled  bool
+	HasIssuesEnabled         bool
+	HasProjectsEnabled       bool
+	HasDiscussionsEnabled    bool
+	HasWikiEnabled           bool
+	MergeCommitAllowed       bool
+	SquashMergeAllowed       bool
+	RebaseMergeAllowed       bool
+	AutoMergeAllowed         bool
+	SquashMergeCommitTitle   string
+	SquashMergeCommitMessage string
 
 	ForkCount      int
 	StargazerCount int


### PR DESCRIPTION
Fixes #10092 

Started the changes to allow setting `squash-merge-commit-title` and `squash-merge-commit-message` in `gh repo edit`.

* From the original issue:
> Note: I'm not exactly sure what happens if allow_squash_merge is set to false. Do these settings take effect? Should they enable squash merge? (probably not). Update the A/C when this is discovered.

Looks like when allow_squash_merge is set to false and squash-merge-commit-title and message are set, no error is thrown from the API (suggesting the settings did take effect) but the squash merge setting does not change to enabled.

* When one of the invalid combinations is used the error that is returned looks like this:
```
HTTP 422: Validation Failed (https://api.github.com/repos/<repo-owner>/<repo-name>)
Repository.merge_commit_allowed is invalid
exit status 1
```
I return the error as is but let me know if we want to return the message from the server code mentioned in the original issue as a more helpful error message instead, i.e `"Sorry, invalid setting combination."`
