### PR TITLE
feat: make the extension upgrade fancier

### DIFF
--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -469,9 +469,18 @@ func (m *Manager) Upgrade(name string, force bool) error {
 }
 
 func (m *Manager) upgradeExtensions(exts []*Extension, force bool) error {
+	var longestExtName = 0
+	for _, ext := range exts {
+		l := len(ext.Name())
+		if len(ext.Name()) > longestExtName {
+			longestExtName = l
+		}
+	}
+	format := fmt.Sprintf("[%%%ds]: ", longestExtName)
+
 	var failed bool
 	for _, f := range exts {
-		fmt.Fprintf(m.io.Out, "[%s]: ", f.Name())
+		fmt.Fprintf(m.io.Out, format, f.Name())
 		currentVersion := displayExtensionVersion(f, f.CurrentVersion())
 		err := m.upgradeExtension(f, force)
 		if err != nil {

--- a/pkg/cmd/extension/manager_test.go
+++ b/pkg/cmd/extension/manager_test.go
@@ -256,7 +256,7 @@ func TestManager_UpgradeExtensions(t *testing.T) {
 		`
 		[hello]: upgraded from old vers to new vers
 		[local]: local extensions can not be upgraded
-		[two]: upgraded from old vers to new vers
+		[  two]: upgraded from old vers to new vers
 		`,
 	), stdout.String())
 	assert.Equal(t, "", stderr.String())
@@ -293,7 +293,7 @@ func TestManager_UpgradeExtensions_DryRun(t *testing.T) {
 		`
  		[hello]: would have upgraded from 0 to 1
  		[local]: local extensions can not be upgraded
- 		[two]: would have upgraded from 2 to 3
+ 		[  two]: would have upgraded from 2 to 3
  		`,
 	), stdout.String())
 	assert.Equal(t, "", stderr.String())


### PR DESCRIPTION
This left-pad the extension names during upgrade so they all align nicely. It makes easier to see what is happening.

```bash
$ gh ext upgrade --all
[combine-prs]: already up to date
[copilot]: already up to date
[deflake]: already up to date
[edit]: already up to date
[exact]: already up to date
[not]: already up to date
[pr-repl]: already up to date
[shell]: already up to date
[slack]: already up to date
✓ Successfully checked extension upgrades

$ go run cmd/gh/main.go ext upgrade --all 
[combine-prs]: already up to date
[    copilot]: already up to date
[    deflake]: already up to date
[       edit]: already up to date
[      exact]: already up to date
[        not]: already up to date
[    pr-repl]: already up to date
[      shell]: already up to date
[      slack]: already up to date
✓ Successfully checked extension upgrades
```