### PR TITLE
Remove naked return values from `ReadBranchConfig` and `prSelectorForCurrentBranch`

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -391,11 +391,13 @@ func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (BranchCon
 
 	out, err := cmd.Output()
 	if err != nil {
-		// This will error if no matches are found but the git command still ran successfully. We only
-		// want to return an error if the command failed to run, usually and ExitError, which will be
-		// indicated by output on Stderr.
-		if err.(*GitError).Stderr != "" {
-			return BranchConfig{}, err
+		// This is the error we expect if the git command does not run successfully.
+		// Note: err is non-nil if the command is successful but has no output
+		var gitError *GitError
+		if errors.As(err, &gitError) {
+			if gitError.Stderr != "" {
+				return BranchConfig{}, err
+			}
 		}
 		return BranchConfig{}, nil
 	}

--- a/git/client.go
+++ b/git/client.go
@@ -392,12 +392,10 @@ func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (BranchCon
 	out, err := cmd.Output()
 	if err != nil {
 		// This is the error we expect if the git command does not run successfully.
-		// Note: err is non-nil if the command is successful but has no output
+		// If the ExitCode is 1, then we just didn't find any config for the branch.
 		var gitError *GitError
-		if errors.As(err, &gitError) {
-			if gitError.Stderr != "" {
-				return BranchConfig{}, err
-			}
+		if ok := errors.As(err, &gitError); ok && gitError.ExitCode != 1 {
+			return BranchConfig{}, err
 		}
 		return BranchConfig{}, nil
 	}

--- a/git/client.go
+++ b/git/client.go
@@ -388,23 +388,23 @@ func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (BranchCon
 		return cfg, err
 	}
 
-	return c.createBranchConfig(outputLines(branchConfigOutput)), nil
+	return c.createBranchConfig(branchConfigOutput), nil
 }
 
-func (c *Client) readGitBranchConfig(ctx context.Context, branch string) ([]byte, error) {
+func (c *Client) readGitBranchConfig(ctx context.Context, branch string) ([]string, error) {
 	prefix := regexp.QuoteMeta(fmt.Sprintf("branch.%s.", branch))
 	args := []string{"config", "--get-regexp", fmt.Sprintf("^%s(remote|merge|%s)$", prefix, MergeBaseConfig)}
 	cmd, err := c.Command(ctx, args...)
 	if err != nil {
-		return []byte{}, err
+		return []string{}, err
 	}
 
 	out, err := cmd.Output()
 	if err != nil {
-		return []byte{}, err
+		return []string{}, err
 	}
 
-	return out, nil
+	return outputLines(out), nil
 }
 
 func (c *Client) createBranchConfig(gitBranchConfigOutput []string) BranchConfig {

--- a/git/client.go
+++ b/git/client.go
@@ -391,7 +391,13 @@ func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (BranchCon
 
 	out, err := cmd.Output()
 	if err != nil {
-		return BranchConfig{}, err
+		// This will error if no matches are found but the git command still ran successfully. We only
+		// want to return an error if the command failed to run, usually and ExitError, which will be
+		// indicated by output on Stderr.
+		if err.(*GitError).Stderr != "" {
+			return BranchConfig{}, err
+		}
+		return BranchConfig{}, nil
 	}
 
 	return parseBranchConfig(outputLines(out)), nil

--- a/git/client.go
+++ b/git/client.go
@@ -383,19 +383,33 @@ func (c *Client) lookupCommit(ctx context.Context, sha, format string) ([]byte, 
 func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (BranchConfig, error) {
 	var cfg BranchConfig
 
+	branchConfigOutput, err := c.readGitBranchConfig(ctx, branch)
+	if err != nil {
+		return cfg, err
+	}
+
+	return c.createBranchConfig(outputLines(branchConfigOutput)), nil
+}
+
+func (c *Client) readGitBranchConfig(ctx context.Context, branch string) ([]byte, error) {
 	prefix := regexp.QuoteMeta(fmt.Sprintf("branch.%s.", branch))
 	args := []string{"config", "--get-regexp", fmt.Sprintf("^%s(remote|merge|%s)$", prefix, MergeBaseConfig)}
 	cmd, err := c.Command(ctx, args...)
 	if err != nil {
-		return cfg, err
+		return []byte{}, err
 	}
 
 	out, err := cmd.Output()
 	if err != nil {
-		return cfg, err
+		return []byte{}, err
 	}
 
-	for _, line := range outputLines(out) {
+	return out, nil
+}
+
+func (c *Client) createBranchConfig(gitBranchConfigOutput []string) BranchConfig {
+	var cfg BranchConfig
+	for _, line := range gitBranchConfigOutput {
 		parts := strings.SplitN(line, " ", 2)
 		if len(parts) < 2 {
 			continue
@@ -418,7 +432,7 @@ func (c *Client) ReadBranchConfig(ctx context.Context, branch string) (BranchCon
 			cfg.MergeBase = parts[1]
 		}
 	}
-	return cfg, nil
+	return cfg
 }
 
 // SetBranchConfig sets the named value on the given branch.

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -744,22 +744,22 @@ func TestClientReadBranchConfig(t *testing.T) {
 			wantError:        nil,
 		},
 		{
-			name:             "output error",
-			cmdExitStatus:    1,
-			cmdStdout:        "",
-			cmdStderr:        "git error message",
-			branch:           "trunk",
-			wantBranchConfig: BranchConfig{},
-			wantError:        &GitError{},
-		},
-		{
-			name:             "git config runs successfully but returns no output",
+			name:             "git config runs successfully but returns no output (Exit Code 1)",
 			cmdExitStatus:    1,
 			cmdStdout:        "",
 			cmdStderr:        "",
 			branch:           "trunk",
 			wantBranchConfig: BranchConfig{},
 			wantError:        nil,
+		},
+		{
+			name:             "output error (Exit Code > 1)",
+			cmdExitStatus:    2,
+			cmdStdout:        "",
+			cmdStderr:        "git error message",
+			branch:           "trunk",
+			wantBranchConfig: BranchConfig{},
+			wantError:        &GitError{},
 		},
 	}
 	for _, tt := range tests {

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -747,7 +747,7 @@ func TestClientReadBranchConfig(t *testing.T) {
 				GitPath:        "path/to/git",
 				commandContext: cmdCtx,
 			}
-			branchConfig := client.ReadBranchConfig(context.Background(), "trunk")
+			branchConfig, _ := client.ReadBranchConfig(context.Background(), "trunk")
 			assert.Equal(t, tt.wantCmdArgs, strings.Join(cmd.Args[3:], " "))
 			assert.Equal(t, tt.wantBranchConfig, branchConfig)
 		})

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -756,43 +756,57 @@ func TestClientReadBranchConfig(t *testing.T) {
 
 func Test_readGitBranchConfig(t *testing.T) {
 	tests := []struct {
-		name        string
-		branch      string
-		cmdExitCode int
-		cmdStdout   string
-		cmdStderr   string
-		wantCmdArgs string
-		wantErr     *GitError
+		name           string
+		branch         string
+		cmdExitStatus  int
+		cmdStdout      string
+		cmdStderr      string
+		expectedOutput []string
+		expectedError  *GitError
 	}{
 		{
-			name:        "read branch config",
-			branch:      "trunk",
-			cmdStdout:   "branch.trunk.remote origin\nbranch.trunk.merge refs/heads/trunk\nbranch.trunk.gh-merge-base trunk",
-			wantCmdArgs: `path/to/git config --get-regexp ^branch\.trunk\.(remote|merge|gh-merge-base)$`,
+			name:          "read branch config",
+			branch:        "trunk",
+			cmdExitStatus: 0,
+			cmdStdout:     "branch.trunk.remote origin\nbranch.trunk.merge refs/heads/trunk\nbranch.trunk.gh-merge-base trunk",
+			expectedOutput: []string{
+				"branch.trunk.remote origin",
+				"branch.trunk.merge refs/heads/trunk",
+				"branch.trunk.gh-merge-base trunk"},
+			expectedError: nil,
 		},
 		{
-			name:        "command failure",
-			branch:      "trunk",
-			wantCmdArgs: `path/to/git config --get-regexp ^branch\.trunk\.(remote|merge|gh-merge-base)$`,
-			cmdExitCode: 1,
-			cmdStderr:   "error",
-			wantErr:     &GitError{ExitCode: 1, Stderr: "error"},
+			name:           "command failure",
+			branch:         "trunk",
+			cmdExitStatus:  1,
+			cmdStderr:      "git error message",
+			expectedOutput: []string{},
+			expectedError: &GitError{
+				ExitCode: 1,
+				Stderr:   "git error message",
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd, cmdCtx := createCommandContext(t, tt.cmdExitCode, tt.cmdStdout, tt.cmdStderr)
+			commandString := fmt.Sprintf("path/to/git config --get-regexp ^branch\\.%s\\.(remote|merge|gh-merge-base)$", tt.branch)
+			cmdCtx := createMockedCommandContext(t, map[args]commandResult{
+				args(commandString): {
+					ExitStatus: tt.cmdExitStatus,
+					Stdout:     tt.cmdStdout,
+					Stderr:     tt.cmdStderr,
+				},
+			})
 			client := Client{
 				GitPath:        "path/to/git",
 				commandContext: cmdCtx,
 			}
+
 			out, err := client.readGitBranchConfig(context.Background(), tt.branch)
-			if tt.wantErr != nil {
-				assert.Equal(t, tt.wantErr.ExitCode, err.(*GitError).ExitCode)
-				assert.Equal(t, tt.wantErr.Stderr, err.(*GitError).Stderr)
-			} else {
-				assert.Equal(t, tt.wantCmdArgs, strings.Join(cmd.Args[3:], " "))
-				assert.Equal(t, tt.cmdStdout, string(out))
+			assert.Equal(t, tt.expectedOutput, out)
+			if err != nil {
+				assert.Equal(t, tt.cmdStderr, err.(*GitError).Stderr)
+				assert.Equal(t, tt.cmdExitStatus, err.(*GitError).ExitCode)
 			}
 		})
 	}

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -750,7 +750,7 @@ func TestClientReadBranchConfig(t *testing.T) {
 			cmdStderr:        "git error message",
 			branch:           "trunk",
 			wantBranchConfig: BranchConfig{},
-			wantError:        &GitError{ExitCode: 1, Stderr: "git error message"},
+			wantError:        &GitError{},
 		},
 		{
 			name:             "git config runs successfully but returns no output",
@@ -773,12 +773,10 @@ func TestClientReadBranchConfig(t *testing.T) {
 			wantCmdArgs := fmt.Sprintf("path/to/git config --get-regexp ^branch\\.%s\\.(remote|merge|gh-merge-base)$", tt.branch)
 			assert.Equal(t, wantCmdArgs, strings.Join(cmd.Args[3:], " "))
 			assert.Equal(t, tt.wantBranchConfig, branchConfig)
-			if err != nil {
-				if tt.wantError == nil {
-					t.Fatalf("expected no error but got %v", err)
-				}
-				assert.Equal(t, tt.wantError.ExitCode, err.(*GitError).ExitCode)
-				assert.Equal(t, tt.wantError.Stderr, err.(*GitError).Stderr)
+			if tt.wantError != nil {
+				assert.ErrorAs(t, err, &tt.wantError)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -811,11 +812,32 @@ func Test_parseBranchConfig(t *testing.T) {
 				MergeBase:  "gh-merge-base",
 			},
 		},
+		{
+			name: "remote URL",
+			gitBranchConfigOutput: []string{
+				"branch.Frederick888/main.remote git@github.com:Frederick888/playground.git",
+				"branch.Frederick888/main.merge refs/heads/main",
+			},
+			wantBranchConfig: BranchConfig{
+				MergeRef: "refs/heads/main",
+				RemoteURL: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/Frederick888/playground.git",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			branchConfig := parseBranchConfig(tt.gitBranchConfigOutput)
-			assert.Equal(t, tt.wantBranchConfig, branchConfig)
+			assert.Equal(t, tt.wantBranchConfig.RemoteName, branchConfig.RemoteName)
+			assert.Equal(t, tt.wantBranchConfig.MergeRef, branchConfig.MergeRef)
+			assert.Equal(t, tt.wantBranchConfig.MergeBase, branchConfig.MergeBase)
+			if tt.wantBranchConfig.RemoteURL != nil {
+				assert.Equal(t, tt.wantBranchConfig.RemoteURL.String(), branchConfig.RemoteURL.String())
+			}
 		})
 	}
 }

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -680,7 +680,11 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 	var headRepo ghrepo.Interface
 	var headRemote *ghContext.Remote
 
-	headBranchConfig := gitClient.ReadBranchConfig(context.Background(), headBranch)
+	headBranchConfig, err := gitClient.ReadBranchConfig(context.Background(), headBranch)
+	if err != nil {
+		// We can still proceed without the branch config, so print to stderr but continue
+		fmt.Fprintf(opts.IO.ErrOut, "Error reading git branch config: %v\n", err)
+	}
 	if isPushEnabled {
 		// determine whether the head branch is already pushed to a remote
 		if trackingRef, found := tryDetermineTrackingRef(gitClient, remotes, headBranch, headBranchConfig); found {

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -683,7 +683,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 	headBranchConfig, err := gitClient.ReadBranchConfig(context.Background(), headBranch)
 	if err != nil {
 		// We can still proceed without the branch config, so print to stderr but continue
-		fmt.Fprintf(opts.IO.ErrOut, "Error reading git branch config: %v\n", err)
+		fmt.Fprintf(opts.IO.ErrOut, "Unable to read git branch config: %v\n", err)
 	}
 	if isPushEnabled {
 		// determine whether the head branch is already pushed to a remote

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1717,7 +1717,7 @@ func Test_tryDetermineTrackingRef(t *testing.T) {
 				GhPath:  "some/path/gh",
 				GitPath: "some/path/git",
 			}
-			headBranchConfig := gitClient.ReadBranchConfig(ctx.Background(), "feature")
+			headBranchConfig, _ := gitClient.ReadBranchConfig(ctx.Background(), "feature")
 			ref, found := tryDetermineTrackingRef(gitClient, tt.remotes, "feature", headBranchConfig)
 
 			assert.Equal(t, tt.expectedTrackingRef, ref)

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -37,7 +37,7 @@ type finder struct {
 	branchFn     func() (string, error)
 	remotesFn    func() (remotes.Remotes, error)
 	httpClient   func() (*http.Client, error)
-	branchConfig func(string) git.BranchConfig
+	branchConfig func(string) (git.BranchConfig, error)
 	progress     progressIndicator
 
 	repo       ghrepo.Interface
@@ -58,9 +58,8 @@ func NewFinder(factory *cmdutil.Factory) PRFinder {
 		remotesFn:  factory.Remotes,
 		httpClient: factory.HttpClient,
 		progress:   factory.IOStreams,
-		branchConfig: func(s string) git.BranchConfig {
-			branchConfig, _ := factory.GitClient.ReadBranchConfig(context.Background(), s)
-			return branchConfig
+		branchConfig: func(s string) (git.BranchConfig, error) {
+			return factory.GitClient.ReadBranchConfig(context.Background(), s)
 		},
 	}
 }
@@ -239,7 +238,10 @@ func (f *finder) parseCurrentBranch() (string, int, error) {
 		return "", 0, err
 	}
 
-	branchConfig := f.branchConfig(prHeadRef)
+	branchConfig, err := f.branchConfig(prHeadRef)
+	if err != nil {
+		return "", 0, err
+	}
 
 	// the branch is configured to merge a special PR head ref
 	if m := prHeadRE.FindStringSubmatch(branchConfig.MergeRef); m != nil {

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -59,7 +59,8 @@ func NewFinder(factory *cmdutil.Factory) PRFinder {
 		httpClient: factory.HttpClient,
 		progress:   factory.IOStreams,
 		branchConfig: func(s string) git.BranchConfig {
-			return factory.GitClient.ReadBranchConfig(context.Background(), s)
+			branchConfig, _ := factory.GitClient.ReadBranchConfig(context.Background(), s)
+			return branchConfig
 		},
 	}
 }

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -197,18 +197,21 @@ func prSelectorForCurrentBranch(branchConfig git.BranchConfig, baseRepo ghrepo.I
 		return prNumber, prHeadRef, nil
 	}
 
-	var err error
 	var branchOwner string
 	if branchConfig.RemoteURL != nil {
 		// the branch merges from a remote specified by URL
-		if r, err := ghrepo.FromURL(branchConfig.RemoteURL); err == nil {
-			branchOwner = r.RepoOwner()
+		r, err := ghrepo.FromURL(branchConfig.RemoteURL)
+		if err != nil {
+			return 0, prHeadRef, err
 		}
+		branchOwner = r.RepoOwner()
 	} else if branchConfig.RemoteName != "" {
 		// the branch merges from a remote specified by name
-		if r, err := rem.FindByName(branchConfig.RemoteName); err == nil {
-			branchOwner = r.RepoOwner()
+		r, err := rem.FindByName(branchConfig.RemoteName)
+		if err != nil {
+			return 0, prHeadRef, err
 		}
+		branchOwner = r.RepoOwner()
 	}
 
 	selector := prHeadRef
@@ -222,7 +225,7 @@ func prSelectorForCurrentBranch(branchConfig git.BranchConfig, baseRepo ghrepo.I
 		}
 	}
 
-	return 0, selector, err
+	return 0, selector, nil
 }
 
 func totalApprovals(pr *api.PullRequest) int {

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -186,7 +186,7 @@ func statusRun(opts *StatusOptions) error {
 
 func prSelectorForCurrentBranch(gitClient *git.Client, baseRepo ghrepo.Interface, prHeadRef string, rem ghContext.Remotes) (prNumber int, selector string, err error) {
 	selector = prHeadRef
-	branchConfig := gitClient.ReadBranchConfig(context.Background(), prHeadRef)
+	branchConfig, _ := gitClient.ReadBranchConfig(context.Background(), prHeadRef)
 
 	// the branch is configured to merge a special PR head ref
 	prHeadRE := regexp.MustCompile(`^refs/pull/(\d+)/head$`)

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -214,8 +214,8 @@ func prSelectorForCurrentBranch(branchConfig git.BranchConfig, baseRepo ghrepo.I
 		branchOwner = r.RepoOwner()
 	}
 
-	selector := prHeadRef
 	if branchOwner != "" {
+		selector := prHeadRef
 		if strings.HasPrefix(branchConfig.MergeRef, "refs/heads/") {
 			selector = strings.TrimPrefix(branchConfig.MergeRef, "refs/heads/")
 		}
@@ -223,9 +223,10 @@ func prSelectorForCurrentBranch(branchConfig git.BranchConfig, baseRepo ghrepo.I
 		if !strings.EqualFold(branchOwner, baseRepo.RepoOwner()) {
 			selector = fmt.Sprintf("%s:%s", branchOwner, selector)
 		}
+		return 0, selector, nil
 	}
 
-	return 0, selector, nil
+	return 0, prHeadRef, nil
 }
 
 func totalApprovals(pr *api.PullRequest) int {

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -94,7 +94,10 @@ func statusRun(opts *StatusOptions) error {
 		}
 
 		remotes, _ := opts.Remotes()
-		branchConfig, _ := opts.GitClient.ReadBranchConfig(ctx, currentBranch)
+		branchConfig, err := opts.GitClient.ReadBranchConfig(ctx, currentBranch)
+		if err != nil {
+			return err
+		}
 		currentPRNumber, currentPRHeadRef, err = prSelectorForCurrentBranch(branchConfig, baseRepo, currentBranch, remotes)
 		if err != nil {
 			return fmt.Errorf("could not query for pull request for current branch: %w", err)

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -205,14 +205,20 @@ func prSelectorForCurrentBranch(branchConfig git.BranchConfig, baseRepo ghrepo.I
 		// the branch merges from a remote specified by URL
 		r, err := ghrepo.FromURL(branchConfig.RemoteURL)
 		if err != nil {
-			return 0, prHeadRef, err
+			// TODO: We aren't returning the error because we discovered that it was shadowed
+			// before refactoring to its current return pattern. Thus, we aren't confident
+			// that returning the error won't break existing behavior.
+			return 0, prHeadRef, nil
 		}
 		branchOwner = r.RepoOwner()
 	} else if branchConfig.RemoteName != "" {
 		// the branch merges from a remote specified by name
 		r, err := rem.FindByName(branchConfig.RemoteName)
 		if err != nil {
-			return 0, prHeadRef, err
+			// TODO: We aren't returning the error because we discovered that it was shadowed
+			// before refactoring to its current return pattern. Thus, we aren't confident
+			// that returning the error won't break existing behavior.
+			return 0, prHeadRef, nil
 		}
 		branchOwner = r.RepoOwner()
 	}

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -387,6 +387,16 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 		wantError    error
 	}{
 		{
+			name: "The branch is configured to merge a special PR head ref",
+			branchConfig: git.BranchConfig{
+				MergeRef: "refs/pull/666/head",
+			},
+			prHeadRef:    "Frederick888/main",
+			wantPrNumber: 666,
+			wantSelector: "Frederick888/main",
+			wantError:    nil,
+		},
+		{
 			name: "Branch merges from a remote specified by URL",
 			branchConfig: git.BranchConfig{
 				RemoteURL: &url.URL{
@@ -395,18 +405,126 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 					Host:   "github.com",
 					Path:   "Frederick888/playground.git",
 				},
-				MergeRef: "refs/heads/main",
 			},
-			baseRepo:  ghrepo.NewWithHost("octocat", "playground", "github.com"),
+			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
 			prHeadRef: "Frederick888/main",
 			remotes: context.Remotes{
 				&context.Remote{
 					Remote: &git.Remote{Name: "origin"},
-					Repo:   ghrepo.NewWithHost("octocat", "playground", "github.com"),
+					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
 				},
 			},
 			wantPrNumber: 0,
-			wantSelector: "Frederick888:main",
+			wantSelector: "Frederick888/main",
+			wantError:    nil,
+		},
+		{
+			name: "Branch merges from a remote specified by name",
+			branchConfig: git.BranchConfig{
+				RemoteName: "upstream",
+			},
+			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+			prHeadRef: "Frederick888/main",
+			remotes: context.Remotes{
+				&context.Remote{
+					Remote: &git.Remote{Name: "origin"},
+					Repo:   ghrepo.NewWithHost("forkName", "playground", "github.com"),
+				},
+				&context.Remote{
+					Remote: &git.Remote{Name: "upstream"},
+					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+				},
+			},
+			wantPrNumber: 0,
+			wantSelector: "Frederick888/main",
+			wantError:    nil,
+		},
+		{
+			name: "Branch is a fork and merges from a remote specified by URL",
+			branchConfig: git.BranchConfig{
+				RemoteURL: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "forkName/playground.git",
+				},
+				MergeRef: "refs/heads/main",
+			},
+			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+			prHeadRef: "Frederick888/main",
+			remotes: context.Remotes{
+				&context.Remote{
+					Remote: &git.Remote{Name: "origin"},
+					Repo:   ghrepo.NewWithHost("forkName", "playground", "github.com"),
+				},
+			},
+			wantPrNumber: 0,
+			wantSelector: "forkName:main",
+			wantError:    nil,
+		},
+		{
+			name: "Branch is a fork and merges from a remote specified by name",
+			branchConfig: git.BranchConfig{
+				RemoteName: "origin",
+			},
+			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+			prHeadRef: "Frederick888/main",
+			remotes: context.Remotes{
+				&context.Remote{
+					Remote: &git.Remote{Name: "origin"},
+					Repo:   ghrepo.NewWithHost("forkName", "playground", "github.com"),
+				},
+				&context.Remote{
+					Remote: &git.Remote{Name: "upstream"},
+					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+				},
+			},
+			wantPrNumber: 0,
+			wantSelector: "forkName:Frederick888/main",
+			wantError:    nil,
+		},
+		{
+			name: "Branch specifies a mergeRef and merges from a remote specified by name",
+			branchConfig: git.BranchConfig{
+				RemoteName: "upstream",
+				MergeRef:   "refs/heads/main",
+			},
+			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+			prHeadRef: "Frederick888/main",
+			remotes: context.Remotes{
+				&context.Remote{
+					Remote: &git.Remote{Name: "origin"},
+					Repo:   ghrepo.NewWithHost("forkName", "playground", "github.com"),
+				},
+				&context.Remote{
+					Remote: &git.Remote{Name: "upstream"},
+					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+				},
+			},
+			wantPrNumber: 0,
+			wantSelector: "main",
+			wantError:    nil,
+		},
+		{
+			name: "Branch is a fork, specifies a mergeRef, and merges from a remote specified by name",
+			branchConfig: git.BranchConfig{
+				RemoteName: "origin",
+				MergeRef:   "refs/heads/main",
+			},
+			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+			prHeadRef: "Frederick888/main",
+			remotes: context.Remotes{
+				&context.Remote{
+					Remote: &git.Remote{Name: "origin"},
+					Repo:   ghrepo.NewWithHost("forkName", "playground", "github.com"),
+				},
+				&context.Remote{
+					Remote: &git.Remote{Name: "upstream"},
+					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+				},
+			},
+			wantPrNumber: 0,
+			wantSelector: "forkName:main",
 			wantError:    nil,
 		},
 	}

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -526,6 +527,41 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 			wantPrNumber: 0,
 			wantSelector: "forkName:main",
 			wantError:    nil,
+		},
+		{
+			name: "Remote URL error",
+			branchConfig: git.BranchConfig{
+				RemoteURL: &url.URL{
+					Scheme: "ssh",
+					User:   url.User("git"),
+					Host:   "github.com",
+					Path:   "/\\invalid?Path/",
+				},
+			},
+			prHeadRef:    "Frederick888/main",
+			wantPrNumber: 0,
+			wantSelector: "Frederick888/main",
+			wantError:    fmt.Errorf("invalid path: /\\invalid?Path/"),
+		},
+		{
+			name: "Remote Name error",
+			branchConfig: git.BranchConfig{
+				RemoteName: "nonexistentRemote",
+			},
+			prHeadRef: "Frederick888/main",
+			remotes: context.Remotes{
+				&context.Remote{
+					Remote: &git.Remote{Name: "origin"},
+					Repo:   ghrepo.NewWithHost("forkName", "playground", "github.com"),
+				},
+				&context.Remote{
+					Remote: &git.Remote{Name: "upstream"},
+					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+				},
+			},
+			wantPrNumber: 0,
+			wantSelector: "Frederick888/main",
+			wantError:    fmt.Errorf("no matching remote found"),
 		},
 	}
 

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -388,6 +388,14 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 		wantError    error
 	}{
 		{
+			name:         "Empty branch config",
+			branchConfig: git.BranchConfig{},
+			prHeadRef:    "Frederick888/main",
+			wantPrNumber: 0,
+			wantSelector: "Frederick888/main",
+			wantError:    nil,
+		},
+		{
 			name: "The branch is configured to merge a special PR head ref",
 			branchConfig: git.BranchConfig{
 				MergeRef: "refs/pull/666/head",

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -398,10 +398,10 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 		{
 			name: "The branch is configured to merge a special PR head ref",
 			branchConfig: git.BranchConfig{
-				MergeRef: "refs/pull/666/head",
+				MergeRef: "refs/pull/42/head",
 			},
 			prHeadRef:    "Frederick888/main",
-			wantPrNumber: 666,
+			wantPrNumber: 42,
 			wantSelector: "Frederick888/main",
 			wantError:    nil,
 		},

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -390,9 +390,9 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 		{
 			name:         "Empty branch config",
 			branchConfig: git.BranchConfig{},
-			prHeadRef:    "Frederick888/main",
+			prHeadRef:    "monalisa/main",
 			wantPrNumber: 0,
-			wantSelector: "Frederick888/main",
+			wantSelector: "monalisa/main",
 			wantError:    nil,
 		},
 		{
@@ -400,9 +400,9 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 			branchConfig: git.BranchConfig{
 				MergeRef: "refs/pull/42/head",
 			},
-			prHeadRef:    "Frederick888/main",
+			prHeadRef:    "monalisa/main",
 			wantPrNumber: 42,
-			wantSelector: "Frederick888/main",
+			wantSelector: "monalisa/main",
 			wantError:    nil,
 		},
 		{
@@ -412,19 +412,19 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 					Scheme: "ssh",
 					User:   url.User("git"),
 					Host:   "github.com",
-					Path:   "Frederick888/playground.git",
+					Path:   "monalisa/playground.git",
 				},
 			},
-			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
-			prHeadRef: "Frederick888/main",
+			baseRepo:  ghrepo.NewWithHost("monalisa", "playground", "github.com"),
+			prHeadRef: "monalisa/main",
 			remotes: context.Remotes{
 				&context.Remote{
 					Remote: &git.Remote{Name: "origin"},
-					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+					Repo:   ghrepo.NewWithHost("monalisa", "playground", "github.com"),
 				},
 			},
 			wantPrNumber: 0,
-			wantSelector: "Frederick888/main",
+			wantSelector: "monalisa/main",
 			wantError:    nil,
 		},
 		{
@@ -432,8 +432,8 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 			branchConfig: git.BranchConfig{
 				RemoteName: "upstream",
 			},
-			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
-			prHeadRef: "Frederick888/main",
+			baseRepo:  ghrepo.NewWithHost("monalisa", "playground", "github.com"),
+			prHeadRef: "monalisa/main",
 			remotes: context.Remotes{
 				&context.Remote{
 					Remote: &git.Remote{Name: "origin"},
@@ -441,11 +441,11 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 				},
 				&context.Remote{
 					Remote: &git.Remote{Name: "upstream"},
-					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+					Repo:   ghrepo.NewWithHost("monalisa", "playground", "github.com"),
 				},
 			},
 			wantPrNumber: 0,
-			wantSelector: "Frederick888/main",
+			wantSelector: "monalisa/main",
 			wantError:    nil,
 		},
 		{
@@ -459,8 +459,8 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 				},
 				MergeRef: "refs/heads/main",
 			},
-			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
-			prHeadRef: "Frederick888/main",
+			baseRepo:  ghrepo.NewWithHost("monalisa", "playground", "github.com"),
+			prHeadRef: "monalisa/main",
 			remotes: context.Remotes{
 				&context.Remote{
 					Remote: &git.Remote{Name: "origin"},
@@ -476,8 +476,8 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 			branchConfig: git.BranchConfig{
 				RemoteName: "origin",
 			},
-			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
-			prHeadRef: "Frederick888/main",
+			baseRepo:  ghrepo.NewWithHost("monalisa", "playground", "github.com"),
+			prHeadRef: "monalisa/main",
 			remotes: context.Remotes{
 				&context.Remote{
 					Remote: &git.Remote{Name: "origin"},
@@ -485,11 +485,11 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 				},
 				&context.Remote{
 					Remote: &git.Remote{Name: "upstream"},
-					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+					Repo:   ghrepo.NewWithHost("monalisa", "playground", "github.com"),
 				},
 			},
 			wantPrNumber: 0,
-			wantSelector: "forkName:Frederick888/main",
+			wantSelector: "forkName:monalisa/main",
 			wantError:    nil,
 		},
 		{
@@ -498,8 +498,8 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 				RemoteName: "upstream",
 				MergeRef:   "refs/heads/main",
 			},
-			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
-			prHeadRef: "Frederick888/main",
+			baseRepo:  ghrepo.NewWithHost("monalisa", "playground", "github.com"),
+			prHeadRef: "monalisa/main",
 			remotes: context.Remotes{
 				&context.Remote{
 					Remote: &git.Remote{Name: "origin"},
@@ -507,7 +507,7 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 				},
 				&context.Remote{
 					Remote: &git.Remote{Name: "upstream"},
-					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+					Repo:   ghrepo.NewWithHost("monalisa", "playground", "github.com"),
 				},
 			},
 			wantPrNumber: 0,
@@ -520,8 +520,8 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 				RemoteName: "origin",
 				MergeRef:   "refs/heads/main",
 			},
-			baseRepo:  ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
-			prHeadRef: "Frederick888/main",
+			baseRepo:  ghrepo.NewWithHost("monalisa", "playground", "github.com"),
+			prHeadRef: "monalisa/main",
 			remotes: context.Remotes{
 				&context.Remote{
 					Remote: &git.Remote{Name: "origin"},
@@ -529,7 +529,7 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 				},
 				&context.Remote{
 					Remote: &git.Remote{Name: "upstream"},
-					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+					Repo:   ghrepo.NewWithHost("monalisa", "playground", "github.com"),
 				},
 			},
 			wantPrNumber: 0,
@@ -546,9 +546,9 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 					Path:   "/\\invalid?Path/",
 				},
 			},
-			prHeadRef:    "Frederick888/main",
+			prHeadRef:    "monalisa/main",
 			wantPrNumber: 0,
-			wantSelector: "Frederick888/main",
+			wantSelector: "monalisa/main",
 			wantError:    fmt.Errorf("invalid path: /\\invalid?Path/"),
 		},
 		{
@@ -556,7 +556,7 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 			branchConfig: git.BranchConfig{
 				RemoteName: "nonexistentRemote",
 			},
-			prHeadRef: "Frederick888/main",
+			prHeadRef: "monalisa/main",
 			remotes: context.Remotes{
 				&context.Remote{
 					Remote: &git.Remote{Name: "origin"},
@@ -564,11 +564,11 @@ func Test_prSelectorForCurrentBranch(t *testing.T) {
 				},
 				&context.Remote{
 					Remote: &git.Remote{Name: "upstream"},
-					Repo:   ghrepo.NewWithHost("Frederick888", "playground", "github.com"),
+					Repo:   ghrepo.NewWithHost("monalisa", "playground", "github.com"),
 				},
 			},
 			wantPrNumber: 0,
-			wantSelector: "Frederick888/main",
+			wantSelector: "monalisa/main",
 			wantError:    fmt.Errorf("no matching remote found"),
 		},
 	}


### PR DESCRIPTION
## Motivation

After some discussion with @williammartin, we agreed that the naked return values pattern is something that we'd like to avoid in our codebase and that we should make an effort to remove them when we encounter them. This is the PR to remove the named return values from `ReadBranchConfig` that I encountered while working through #10188.

I also refactored `ReadBranchConfig` for two reasons: to surface the previously hidden errors it could produce and to allow for better test coverage of its core functionality. I did the latter by separating out the `git` call and the `BranchConfig` struct creation into their own functions to leverage dependency injection of the `git` call's return value into the `BranchConfig` creation.

While making this refactor work with the rest of the tool, I stumbled upon more named return values in `prSelectorForCurrentBranch` and decided to remove these as well. This resulted in a slight reorganization of the function in a way that I believe makes it easier to follow.

## Changes

- **Remove named returns from ReadBranchConfig and surface errors**
- **Refactor ReadBranchConfig for test coverage of newly returned erros**
- **Remove named return values from prSelectorForCurrentBranch**

## Testing

I haven't touched any of the original tests besides accommodating the new `ReadBranchConfig` api, and they are all passing, so I'm decently confident that this won't introduce any breaking changes. However, to exercise all the changes, follow these steps:

1. Pull down the branch `gh pr checkout 10197`
2. Build the branch
3. Execute the `gh pr status` command