### PR TITLE
Better handling for waiting for codespaces to become ready

### DIFF
--- a/internal/codespaces/api/api.go
+++ b/internal/codespaces/api/api.go
@@ -240,6 +240,8 @@ const (
 	CodespaceStateAvailable = "Available"
 	// CodespaceStateShutdown is the state for a shutdown codespace environment.
 	CodespaceStateShutdown = "Shutdown"
+	// CodespaceStateShuttingDown is the state for a shutting down codespace environment.
+	CodespaceStateShuttingDown = "ShuttingDown"
 	// CodespaceStateStarting is the state for a starting codespace environment.
 	CodespaceStateStarting = "Starting"
 	// CodespaceStateRebuilding is the state for a rebuilding codespace environment.

--- a/internal/codespaces/codespaces.go
+++ b/internal/codespaces/codespaces.go
@@ -15,7 +15,12 @@ import (
 
 // codespaceStatePollingBackoff is the delay between state polls while waiting for codespaces to become
 // available. It's only exposed so that it can be shortened for testing, otherwise it should not be changed
-var codespaceStatePollingBackoff = backoff.NewConstantBackOff(10 * time.Second)
+var codespaceStatePollingBackoff backoff.BackOff = backoff.NewExponentialBackOff(
+	backoff.WithInitialInterval(1*time.Second),
+	backoff.WithMultiplier(1.02),
+	backoff.WithMaxInterval(10*time.Second),
+	backoff.WithMaxElapsedTime(5*time.Minute),
+)
 
 func connectionReady(codespace *api.Codespace) bool {
 	// If the codespace is not available, it is not ready

--- a/internal/codespaces/codespaces_test.go
+++ b/internal/codespaces/codespaces_test.go
@@ -34,7 +34,13 @@ func TestWaitUntilCodespaceConnectionReady_WhenAlreadyReady(t *testing.T) {
 	t.Parallel()
 
 	apiClient := &mockApiClient{}
-	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, readyCodespace)
+	result, err := waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, readyCodespace)
+	if err != nil {
+		t.Fatalf("Expected nil error, but was %v", err)
+	}
+	if result.State != api.CodespaceStateAvailable {
+		t.Fatalf("Expected final state to be %s, but was %s", api.CodespaceStateAvailable, result.State)
+	}
 }
 
 func TestWaitUntilCodespaceConnectionReady_PollsApi(t *testing.T) {
@@ -45,7 +51,14 @@ func TestWaitUntilCodespaceConnectionReady_PollsApi(t *testing.T) {
 			return readyCodespace, nil
 		},
 	}
-	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, &api.Codespace{State: api.CodespaceStateStarting})
+	result, err := waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, &api.Codespace{State: api.CodespaceStateStarting})
+
+	if err != nil {
+		t.Fatalf("Expected nil error, but was %v", err)
+	}
+	if result.State != api.CodespaceStateAvailable {
+		t.Fatalf("Expected final state to be %s, but was %s", api.CodespaceStateAvailable, result.State)
+	}
 }
 
 func TestWaitUntilCodespaceConnectionReady_StartsCodespace(t *testing.T) {
@@ -62,7 +75,13 @@ func TestWaitUntilCodespaceConnectionReady_StartsCodespace(t *testing.T) {
 			return nil
 		},
 	}
-	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+	result, err := waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+	if err != nil {
+		t.Fatalf("Expected nil error, but was %v", err)
+	}
+	if result.State != api.CodespaceStateAvailable {
+		t.Fatalf("Expected final state to be %s, but was %s", api.CodespaceStateAvailable, result.State)
+	}
 }
 
 func TestWaitUntilCodespaceConnectionReady_PollsCodespaceUntilReady(t *testing.T) {
@@ -86,7 +105,13 @@ func TestWaitUntilCodespaceConnectionReady_PollsCodespaceUntilReady(t *testing.T
 			return nil
 		},
 	}
-	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+	result, err := waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+	if err != nil {
+		t.Fatalf("Expected nil error, but was %v", err)
+	}
+	if result.State != api.CodespaceStateAvailable {
+		t.Fatalf("Expected final state to be %s, but was %s", api.CodespaceStateAvailable, result.State)
+	}
 }
 
 func TestWaitUntilCodespaceConnectionReady_WaitsForShutdownBeforeStarting(t *testing.T) {
@@ -110,10 +135,16 @@ func TestWaitUntilCodespaceConnectionReady_WaitsForShutdownBeforeStarting(t *tes
 			return nil
 		},
 	}
-	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+	result, err := waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+	if err != nil {
+		t.Fatalf("Expected nil error, but was %v", err)
+	}
+	if result.State != api.CodespaceStateAvailable {
+		t.Fatalf("Expected final state to be %s, but was %s", api.CodespaceStateAvailable, result.State)
+	}
 }
 
-func TestWaitUntilCodespaceConnectionReady_DoesntStartTwice(t *testing.T) {
+func TestUntilCodespaceConnectionReady_DoesntStartTwice(t *testing.T) {
 	t.Parallel()
 
 	codespace := &api.Codespace{State: api.CodespaceStateShutdown}
@@ -141,7 +172,13 @@ func TestWaitUntilCodespaceConnectionReady_DoesntStartTwice(t *testing.T) {
 			return nil
 		},
 	}
-	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+	result, err := waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+	if err != nil {
+		t.Fatalf("Expected nil error, but was %v", err)
+	}
+	if result.State != api.CodespaceStateAvailable {
+		t.Fatalf("Expected final state to be %s, but was %s", api.CodespaceStateAvailable, result.State)
+	}
 }
 
 type mockApiClient struct {

--- a/internal/codespaces/codespaces_test.go
+++ b/internal/codespaces/codespaces_test.go
@@ -1,0 +1,175 @@
+package codespaces
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/cli/cli/v2/internal/codespaces/api"
+)
+
+func init() {
+	// Set the backoff to 0 for testing so that they run quickly
+	codespaceStatePollingBackoff = backoff.NewConstantBackOff(time.Second * 0)
+}
+
+// This is just enough to trick `connectionReady`
+var readyCodespace = &api.Codespace{
+	State: api.CodespaceStateAvailable,
+	Connection: api.CodespaceConnection{
+		TunnelProperties: api.TunnelProperties{
+			ConnectAccessToken:     "test",
+			ManagePortsAccessToken: "test",
+			ServiceUri:             "test",
+			TunnelId:               "test",
+			ClusterId:              "test",
+			Domain:                 "test",
+		},
+	},
+}
+
+func TestWaitUntilCodespaceConnectionReady_WhenAlreadyReady(t *testing.T) {
+	t.Parallel()
+
+	apiClient := &mockApiClient{}
+	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, readyCodespace)
+}
+
+func TestWaitUntilCodespaceConnectionReady_PollsApi(t *testing.T) {
+	t.Parallel()
+
+	apiClient := &mockApiClient{
+		onGetCodespace: func() (*api.Codespace, error) {
+			return readyCodespace, nil
+		},
+	}
+	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, &api.Codespace{State: api.CodespaceStateStarting})
+}
+
+func TestWaitUntilCodespaceConnectionReady_StartsCodespace(t *testing.T) {
+	t.Parallel()
+
+	codespace := &api.Codespace{State: api.CodespaceStateShutdown}
+
+	apiClient := &mockApiClient{
+		onGetCodespace: func() (*api.Codespace, error) {
+			return codespace, nil
+		},
+		onStartCodespace: func() error {
+			*codespace = *readyCodespace
+			return nil
+		},
+	}
+	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+}
+
+func TestWaitUntilCodespaceConnectionReady_PollsCodespaceUntilReady(t *testing.T) {
+	t.Parallel()
+
+	codespace := &api.Codespace{State: api.CodespaceStateShutdown}
+	hasPolled := false
+
+	apiClient := &mockApiClient{
+		onGetCodespace: func() (*api.Codespace, error) {
+			if hasPolled {
+				*codespace = *readyCodespace
+			}
+
+			hasPolled = true
+
+			return codespace, nil
+		},
+		onStartCodespace: func() error {
+			codespace.State = api.CodespaceStateStarting
+			return nil
+		},
+	}
+	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+}
+
+func TestWaitUntilCodespaceConnectionReady_WaitsForShutdownBeforeStarting(t *testing.T) {
+	t.Parallel()
+
+	codespace := &api.Codespace{State: api.CodespaceStateShuttingDown}
+
+	apiClient := &mockApiClient{
+		onGetCodespace: func() (*api.Codespace, error) {
+			// Make sure that we poll at least once before going to shutdown
+			if codespace.State == api.CodespaceStateShuttingDown {
+				codespace.State = api.CodespaceStateShutdown
+			}
+			return codespace, nil
+		},
+		onStartCodespace: func() error {
+			if codespace.State != api.CodespaceStateShutdown {
+				t.Fatalf("Codespace started from non-shutdown state: %s", codespace.State)
+			}
+			*codespace = *readyCodespace
+			return nil
+		},
+	}
+	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+}
+
+func TestWaitUntilCodespaceConnectionReady_DoesntStartTwice(t *testing.T) {
+	t.Parallel()
+
+	codespace := &api.Codespace{State: api.CodespaceStateShutdown}
+	didStart := false
+	didPollAfterStart := false
+
+	apiClient := &mockApiClient{
+		onGetCodespace: func() (*api.Codespace, error) {
+			// Make sure that we are in shutdown state for one poll after starting to make sure we don't try to start again
+			if didPollAfterStart {
+				*codespace = *readyCodespace
+			}
+
+			if didStart {
+				didPollAfterStart = true
+			}
+
+			return codespace, nil
+		},
+		onStartCodespace: func() error {
+			if didStart {
+				t.Fatal("Should not start multiple times")
+			}
+			didStart = true
+			return nil
+		},
+	}
+	waitUntilCodespaceConnectionReady(context.Background(), &mockProgressIndicator{}, apiClient, codespace)
+}
+
+type mockApiClient struct {
+	onStartCodespace func() error
+	onGetCodespace   func() (*api.Codespace, error)
+}
+
+func (m *mockApiClient) StartCodespace(ctx context.Context, name string) error {
+	if m.onStartCodespace == nil {
+		panic("onStartCodespace not set and StartCodespace was called")
+	}
+
+	return m.onStartCodespace()
+}
+
+func (m *mockApiClient) GetCodespace(ctx context.Context, name string, includeConnection bool) (*api.Codespace, error) {
+	if m.onGetCodespace == nil {
+		panic("onGetCodespace not set and GetCodespace was called")
+	}
+
+	return m.onGetCodespace()
+}
+
+func (m *mockApiClient) HTTPClient() (*http.Client, error) {
+	panic("Not implemented")
+}
+
+type mockProgressIndicator struct{}
+
+func (m *mockProgressIndicator) StartProgressIndicatorWithLabel(s string) {}
+func (m *mockProgressIndicator) StopProgressIndicator()                   {}


### PR DESCRIPTION
Fixes: https://github.com/cli/cli/issues/10218

There's some faulty logic in `waitUntilCodespaceConnectionReady` where it initially checks if the codespace is not ready and attempts to start it once if it's not. 

The problem is: if the codespace is currently shutting down, rebuilding, or some other non-shutdown state, this start call will silently no-op and we won't try it again later - so the CLI will just poll until it eventually times out.

This change makes a better state machine of the polling logic so that we won't try to start the codespace until and unless it is actually shutdown.