### PR TITLE
Add gh repo clone command

### DIFF
--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -172,7 +172,7 @@ func cloneRun(opts *CloneOptions) error {
 
 	// If repo HasWikiEnabled and wantsWiki is true then create a new clone URL
 	if wantsWiki {
-		if !canonicalRepo.HasWikiEnabled {
+		if (!canonicalRepo.HasWikiEnabled) {
 			return fmt.Errorf("The '%s' repository does not have a wiki", ghrepo.FullName(canonicalRepo))
 		}
 		canonicalCloneURL = strings.TrimSuffix(canonicalCloneURL, ".git") + ".wiki.git"


### PR DESCRIPTION
Update the `pkg/cmd/repo/clone/clone.go` file to handle repository wiki cloning.

* Add parentheses around the condition in the `if` statement to check if the repository has wiki enabled.
* Modify the error message to include the repository's full name when the wiki is not enabled.
* Update the clone URL to point to the wiki repository if the `wantsWiki` flag is true.

