### PR TITLE
Make extension update check non-blocking

### DIFF
--- a/pkg/cmd/root/extension_test.go
+++ b/pkg/cmd/root/extension_test.go
@@ -123,6 +123,10 @@ func TestNewCmdExtension_Updates(t *testing.T) {
 		em := &extensions.ExtensionManagerMock{
 			DispatchFunc: func(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) (bool, error) {
 				// Assume extension executed / dispatched without problems as test is focused on upgrade checking.
+				// Sleep for 100 milliseconds to allow update checking logic to complete. This would be better
+				// served by making the behaviour controllable by channels, but it's a larger change than desired
+				// just to improve the test.
+				time.Sleep(100 * time.Millisecond)
 				return true, nil
 			},
 		}


### PR DESCRIPTION
Fixes #10235

This commit updates the Cobra command logic around extension upgrade checks to be non-blocking.

Previously, we were waiting for 1 second after the extension completed to allow the update checking logic complete, however users want the GitHub CLI to run as far as possible.

cc: @williammartin
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
