### PR TITLE
Include headRepositoryId when creating a new PR

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -516,7 +516,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 	}
 	for key, val := range params {
 		switch key {
-		case "title", "body", "draft", "baseRefName", "headRefName", "maintainerCanModify":
+		case "title", "body", "draft", "baseRefName", "headRefName", "maintainerCanModify", "headRepositoryId":
 			inputParams[key] = val
 		}
 	}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -804,6 +804,7 @@ func getRemotes(opts *CreateOptions) (ghContext.Remotes, error) {
 
 func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataState) error {
 	client := ctx.Client
+	headRepo := ctx.HeadRepo
 
 	params := map[string]interface{}{
 		"title":               state.Title,
@@ -812,6 +813,18 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 		"baseRefName":         ctx.BaseBranch,
 		"headRefName":         ctx.HeadBranchLabel,
 		"maintainerCanModify": opts.MaintainerCanModify,
+	}
+
+	if (headRepo != nil) {
+		if r, ok := headRepo.(*api.Repository); ok {
+			params["headRepositoryId"] = r.ID
+		} else {
+			r, err = api.GitHubRepo(client, headRepo)
+			if err != nil {
+				return fmt.Errorf("head repository ID lookup failed: %w", err)
+			}
+			params["headRepositoryId"] = r.ID
+		}
 	}
 
 	if params["title"] == "" {


### PR DESCRIPTION
gh pr create does not currently handle creating pull requests across
repositories in the same organization. If a user attempts to create such a
PR, they will see a confusing error message:

  pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be blank, No commits between innersource:main and sandbox:branch, Head ref must be a branch (createPullRequest)

According to the API documentation, to create such a pull request, the API
request must contain the headRepositoryId identifying where the PR branch
exists.

In the usual case where gh pr create is being called without arguments, the
head repository is already known. It is looked up in order to ensure the
local changes are pushed to the remote fork.

In submitPR, extract the repository ID from the headRepo. If the headRepo
is already a full repository object, just grab the ID from it. Otherwise
perform an additional API lookup to get the repository object and then grab
the ID from that.

Extend the CreatePullRequest API wrapper to pass the headRepositoryId if it
was given.

This partially fixes #10093, at least in cases where the head repository is
known. A different solution will be required for the general case where
--head is used.
