### PR TITLE
Add affected version heading to bug report issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,11 @@ assignees: ''
 
 ### Describe the bug
 
-A clear and concise description of what the bug is. Include version by typing `gh --version`.
+A clear and concise description of what the bug is. 
+
+### Affected version
+
+Please run `gh version` and paste the output below.
 
 ### Steps to reproduce the behavior
 


### PR DESCRIPTION
Many bug reports ignore providing the `gh` version, I'd prefer they didn't.

I think having the `gh` version as its own heading may help. Beyond that, I think it makes more sense for this to be a separate section for organizational and readability reasons. 
