### PR TITLE
jtmcg/respect at push syntax

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -402,6 +402,25 @@ func (c *Client) ReadAtPushRef(ctx context.Context, branch string) (string, erro
 	return string(revParseOut), nil
 }
 
+// ReadBranchMergeRef gets the merge ref for the current branch.
+func (c *Client) ReadBranchMergeRef(ctx context.Context, branch string) (string, error) {
+	args := []string{"config", "--get", fmt.Sprintf("branch.%s.merge", branch)}
+	cmd, err := c.Command(ctx, args...)
+	if err != nil {
+		return "", err
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		var gitErr *GitError
+		if ok := errors.As(err, &gitErr); ok && gitErr.ExitCode == 1 {
+			gitErr.Stderr = fmt.Sprintf("unknown branch name '%s'", branch)
+			return "", gitErr
+		}
+		return "", err
+	}
+	return firstLine(out), nil
+}
+
 // ReadBranchConfig parses the `branch.BRANCH.(remote|merge|gh-merge-base)` part of git config.
 // If no branch config is found or there is an error in the command, it returns an empty BranchConfig.
 // Downstream consumers of ReadBranchConfig should consider the behavior they desire if this errors,

--- a/git/client.go
+++ b/git/client.go
@@ -376,6 +376,32 @@ func (c *Client) lookupCommit(ctx context.Context, sha, format string) ([]byte, 
 	return out, nil
 }
 
+// ReadAtPushRef gets the push ref for the current branch. This will fail
+// in non-centralized workflows if push.default = simple. In this case
+// we return a helpful error.
+//
+// As far as I can tell, the branch name of the push-ref will always be
+// the same as the current branch name, so rev-parse is about accessing
+// correct remote.
+func (c *Client) ReadAtPushRef(ctx context.Context, branch string) (string, error) {
+	revParseOut, err := c.revParse(ctx, "--abbrev-ref", branch+"@{push}")
+	if err != nil {
+		var gitError *GitError
+		if errors.As(err, &gitError) && gitError.ExitCode == 128 {
+			// TODO:: If the branch is configured to merge to a PR, we'll fall into this error conditional
+			// with the following error message: fatal: upstream branch 'refs/pull/<prNumber>/head'
+			// not stored as a remote-tracking branch. We can use this to determine the PR number for
+			// gh pr operations, as we can get the PR number from the ref. However, this feels out of scope
+			// for this function as it currently stands. I'm going to punt on this for now, but will revisit
+			// once more of the functionality around ReadAtPushRef takes shape.
+			return "", fmt.Errorf("%s. If you are trying to use a non-centralized workflow, set push.default to current: `git config push.default current`", gitError.Error())
+		}
+		return "", err
+	}
+
+	return string(revParseOut), nil
+}
+
 // ReadBranchConfig parses the `branch.BRANCH.(remote|merge|gh-merge-base)` part of git config.
 // If no branch config is found or there is an error in the command, it returns an empty BranchConfig.
 // Downstream consumers of ReadBranchConfig should consider the behavior they desire if this errors,

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -850,6 +850,75 @@ func TestClientReadAtPushRef(t *testing.T) {
 	}
 }
 
+func TestClientReadBranchMergeRef(t *testing.T) {
+	tests := []struct {
+		name          string
+		branch        string
+		gitConfigMock commandResult
+		wantMergeRef  string
+		wantErr       error
+	}{
+		{
+			name:   "when `git config --get branch.branchName.merge` resolves, it returns the correct MergeRef",
+			branch: "branchName",
+			gitConfigMock: commandResult{
+				Stdout: "refs/heads/branchName",
+			},
+			wantMergeRef: "refs/heads/branchName",
+			wantErr:      nil,
+		},
+		{
+			name:   "when `git config --get branch.branchName.merge` resolves with a special PR ref, it returns the correct MergeRef",
+			branch: "branchName",
+			gitConfigMock: commandResult{
+				Stdout: "refs/pull/42/head",
+			},
+			wantMergeRef: "refs/pull/42/head",
+			wantErr:      nil,
+		},
+		{
+			name:   "when the command returns no results, it provides the correct error",
+			branch: "branchName",
+			gitConfigMock: commandResult{
+				ExitStatus: 1,
+			},
+			wantMergeRef: "",
+			wantErr:      errors.New("failed to run git: unknown branch name 'branchName'"),
+		},
+		{
+			name:   "when the command errors, it returns the error",
+			branch: "branchName",
+			gitConfigMock: commandResult{
+				ExitStatus: 2,
+				Stderr:     "git-error",
+			},
+			wantMergeRef: "",
+			wantErr:      errors.New("failed to run git: git-error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pathToGit := "path/to/git"
+			gitConfigMergeRefCommand := fmt.Sprintf("%s config --get branch.%s.merge", pathToGit, tt.branch)
+			cmdCtx := createMockedCommandContext(t, mockedCommands{
+				args(gitConfigMergeRefCommand): tt.gitConfigMock,
+			})
+			client := Client{
+				GitPath:        pathToGit,
+				commandContext: cmdCtx,
+			}
+			mergeRef, err := client.ReadBranchMergeRef(context.Background(), tt.branch)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantMergeRef, mergeRef)
+		})
+	}
+}
+
 func Test_parseBranchConfig(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -782,6 +782,74 @@ func TestClientReadBranchConfig(t *testing.T) {
 	}
 }
 
+func TestClientReadAtPushRef(t *testing.T) {
+	tests := []struct {
+		name         string
+		branchName   string
+		revParseMock commandResult
+		wantRef      string
+		wantError    error
+	}{
+		{
+			name:       "when `git rev-parse --abbrev-ref branchName@{push}` resolves, it returns the correct RemoteRef",
+			branchName: "branchName",
+			revParseMock: commandResult{
+				Stdout: "remoteName/branchName",
+			},
+			wantRef: "remoteName/branchName",
+		},
+		{
+			name:       "when `git rev-parse --abbrev-ref otherBranch@{push}` resolves, it returns the correct RemoteRef",
+			branchName: "otherBranch",
+			revParseMock: commandResult{
+				Stdout: "otherRemote/otherBranch",
+			},
+			wantRef: "otherRemote/otherBranch",
+		},
+		{
+			name:       "when `git rev-parse --abbrev-ref branchName@{push}` does not resolve because push.default = simple, it should return the correct RemoteRef and Error",
+			branchName: "branchName",
+			revParseMock: commandResult{
+				ExitStatus: 128,
+				Stderr:     "fatal: cannot resolve 'simple' push to a single destination",
+			},
+			wantRef:   "",
+			wantError: errors.New("failed to run git: fatal: cannot resolve 'simple' push to a single destination. If you are trying to use a non-centralized workflow, set push.default to current: `git config push.default current`"),
+		},
+		{
+			name:       "when `git rev-parse --abbrev-ref branchName@{push}` does not resolve because of a git error, it should return the correct RemoteRef and Error",
+			branchName: "branchName",
+			revParseMock: commandResult{
+				ExitStatus: 2,
+				Stderr:     "git-error",
+			},
+			wantRef:   "",
+			wantError: errors.New("failed to run git: git-error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pathToGit := "path/to/git"
+			revParseCommand := fmt.Sprintf("%s rev-parse --abbrev-ref %s@{push}", pathToGit, tt.branchName)
+			cmdCtx := createMockedCommandContext(t, mockedCommands{
+				args(revParseCommand): tt.revParseMock,
+			})
+			client := Client{
+				GitPath:        pathToGit,
+				commandContext: cmdCtx,
+			}
+			ref, err := client.ReadAtPushRef(context.Background(), tt.branchName)
+			if tt.wantError != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.wantError.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantRef, ref)
+		})
+	}
+}
+
 func Test_parseBranchConfig(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -33,13 +33,14 @@ type progressIndicator interface {
 }
 
 type finder struct {
-	baseRepoFn   func() (ghrepo.Interface, error)
-	branchFn     func() (string, error)
-	remotesFn    func() (remotes.Remotes, error)
-	httpClient   func() (*http.Client, error)
-	branchConfig func(string) (git.BranchConfig, error)
-	atPushRef    func(string) (string, error)
-	progress     progressIndicator
+	baseRepoFn     func() (ghrepo.Interface, error)
+	branchFn       func() (string, error)
+	remotesFn      func() (remotes.Remotes, error)
+	httpClient     func() (*http.Client, error)
+	branchConfig   func(string) (git.BranchConfig, error)
+	branchMergeRef func(string) (string, error)
+	atPushRef      func(string) (string, error)
+	progress       progressIndicator
 
 	repo       ghrepo.Interface
 	prNumber   int
@@ -64,6 +65,9 @@ func NewFinder(factory *cmdutil.Factory) PRFinder {
 		},
 		atPushRef: func(branch string) (string, error) {
 			return factory.GitClient.ReadAtPushRef(context.Background(), branch)
+		},
+		branchMergeRef: func(branch string) (string, error) {
+			return factory.GitClient.ReadBranchMergeRef(context.Background(), branch)
 		},
 	}
 }
@@ -242,12 +246,12 @@ func (f *finder) parseCurrentBranchWithAtPushRef() (string, int, error) {
 	}
 
 	// Handle the case where the branch is configured to merge a special PR head ref
-	branchConfig, err := f.branchConfig(branch)
+	mergeRef, err := f.branchMergeRef(branch)
 	if err != nil {
 		return "", 0, err
 	}
 
-	if m := prHeadRE.FindStringSubmatch(branchConfig.MergeRef); m != nil {
+	if m := prHeadRE.FindStringSubmatch(mergeRef); m != nil {
 		prNumber, _ := strconv.Atoi(m[1])
 		return "", prNumber, nil
 	}

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -38,6 +38,7 @@ type finder struct {
 	remotesFn    func() (remotes.Remotes, error)
 	httpClient   func() (*http.Client, error)
 	branchConfig func(string) (git.BranchConfig, error)
+	atPushRef    func(string) (string, error)
 	progress     progressIndicator
 
 	repo       ghrepo.Interface
@@ -60,6 +61,9 @@ func NewFinder(factory *cmdutil.Factory) PRFinder {
 		progress:   factory.IOStreams,
 		branchConfig: func(s string) (git.BranchConfig, error) {
 			return factory.GitClient.ReadBranchConfig(context.Background(), s)
+		},
+		atPushRef: func(branch string) (string, error) {
+			return factory.GitClient.ReadAtPushRef(context.Background(), branch)
 		},
 	}
 }
@@ -228,6 +232,64 @@ func (f *finder) parseURL(prURL string) (ghrepo.Interface, int, error) {
 	repo := ghrepo.NewWithHost(m[1], m[2], u.Hostname())
 	prNumber, _ := strconv.Atoi(m[3])
 	return repo, prNumber, nil
+}
+
+func (f *finder) parseCurrentBranchWithAtPushRef() (string, int, error) {
+	// Get the current branch
+	branch, err := f.branchFn()
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Handle the case where the branch is configured to merge a special PR head ref
+	branchConfig, err := f.branchConfig(branch)
+	if err != nil {
+		return "", 0, err
+	}
+
+	if m := prHeadRE.FindStringSubmatch(branchConfig.MergeRef); m != nil {
+		prNumber, _ := strconv.Atoi(m[1])
+		return "", prNumber, nil
+	}
+
+	// Use @{push} ref to resolve the pr's head ref
+	atPushRef, err := f.atPushRef(branch)
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Find the @{push} remote
+	// This shouldn't fail because if there are no remotes then @{push} won't resolve
+	rem, err := f.remotesFn()
+	if err != nil {
+		panic(err)
+	}
+
+	var gitRemoteRepo ghrepo.Interface
+	for _, r := range rem {
+		if strings.Contains(atPushRef, r.Remote.Name) {
+			gitRemoteRepo = r
+			break
+		}
+	}
+
+	if gitRemoteRepo != nil {
+		// prepend `OWNER:` if this branch is pushed to a fork
+		// This is determined by:
+		//  - The repo having a different owner
+		//  - The repo having the same owner but a different name (private org fork)
+		// I suspect that the implementation of the second case may be broken in the face
+		// of a repo rename, where the remote hasn't been updated locally. This is a
+		// frequent issue in commands that use SmartBaseRepoFunc. It's not any worse than not
+		// supporting this case at all though.
+		sameOwner := strings.EqualFold(gitRemoteRepo.RepoOwner(), f.repo.RepoOwner())
+		sameOwnerDifferentRepoName := sameOwner && !strings.EqualFold(gitRemoteRepo.RepoName(), f.repo.RepoName())
+		if !sameOwner || sameOwnerDifferentRepoName {
+			return fmt.Sprintf("%s:%s", gitRemoteRepo.RepoOwner(), branch), 0, nil
+		}
+	}
+
+	return branch, 0, nil
 }
 
 var prHeadRE = regexp.MustCompile(`^refs/pull/(\d+)/head$`)

--- a/pkg/cmd/pr/shared/finder_test.go
+++ b/pkg/cmd/pr/shared/finder_test.go
@@ -16,14 +16,15 @@ import (
 )
 
 type args struct {
-	baseRepoFn   func() (ghrepo.Interface, error)
-	branchFn     func() (string, error)
-	atPushRefFn  func(string) (string, error)
-	branchConfig func(string) (git.BranchConfig, error)
-	remotesFn    func() (context.Remotes, error)
-	selector     string
-	fields       []string
-	baseBranch   string
+	baseRepoFn       func() (ghrepo.Interface, error)
+	branchFn         func() (string, error)
+	atPushRefFn      func(string) (string, error)
+	branchConfig     func(string) (git.BranchConfig, error)
+	branchMergeRefFn func(string) (string, error)
+	remotesFn        func() (context.Remotes, error)
+	selector         string
+	fields           []string
+	baseBranch       string
 }
 
 func TestFind(t *testing.T) {
@@ -586,8 +587,8 @@ func Test_parseCurrentBranchWithAtPushRef(t *testing.T) {
 				branchFn: func() (string, error) {
 					return "branchName", nil
 				},
-				branchConfig: stubBranchConfig(git.BranchConfig{}, nil),
-				atPushRefFn:  stubAtPushRef("", errors.New("atPushRefErr")),
+				branchMergeRefFn: stubBranchMergeRef("", nil),
+				atPushRefFn:      stubAtPushRef("", errors.New("atPushRefErr")),
 			},
 			wantSelector: "",
 			wantPR:       0,
@@ -599,27 +600,25 @@ func Test_parseCurrentBranchWithAtPushRef(t *testing.T) {
 				branchFn: func() (string, error) {
 					return "branchName", nil
 				},
-				branchConfig: stubBranchConfig(git.BranchConfig{
-					MergeRef: "refs/pull/13/head",
-				}, nil),
-				atPushRefFn: stubAtPushRef("", nil),
+				branchMergeRefFn: stubBranchMergeRef("refs/pull/13/head", nil),
+				atPushRefFn:      stubAtPushRef("", nil),
 			},
 			wantSelector: "",
 			wantPR:       13,
 			wantError:    nil,
 		},
 		{
-			name: "When the branch config fails",
+			name: "When the branch merge ref fails",
 			args: args{
 				branchFn: func() (string, error) {
 					return "branchName", nil
 				},
-				branchConfig: stubBranchConfig(git.BranchConfig{}, fmt.Errorf("branchConfigError")),
-				atPushRefFn:  stubAtPushRef("", nil),
+				branchMergeRefFn: stubBranchMergeRef("", fmt.Errorf("branchMergeRefError")),
+				atPushRefFn:      stubAtPushRef("", nil),
 			},
 			wantSelector: "",
 			wantPR:       0,
-			wantError:    errors.New("branchConfigError"),
+			wantError:    errors.New("branchMergeRefError"),
 		},
 		{
 			name: "When the merge ref is not a PR, it should return the branch name as the selector",
@@ -627,8 +626,8 @@ func Test_parseCurrentBranchWithAtPushRef(t *testing.T) {
 				branchFn: func() (string, error) {
 					return "branchName", nil
 				},
-				branchConfig: stubBranchConfig(git.BranchConfig{}, nil),
-				atPushRefFn:  stubAtPushRef("origin/branchName", nil),
+				branchMergeRefFn: stubBranchMergeRef("", nil),
+				atPushRefFn:      stubAtPushRef("origin/branchName", nil),
 			},
 			baseRepoRemote: context.Remote{
 				Remote: &git.Remote{Name: "origin"},
@@ -644,8 +643,8 @@ func Test_parseCurrentBranchWithAtPushRef(t *testing.T) {
 				branchFn: func() (string, error) {
 					return "branchName", nil
 				},
-				branchConfig: stubBranchConfig(git.BranchConfig{}, nil),
-				atPushRefFn:  stubAtPushRef("origin/branchName", nil),
+				branchMergeRefFn: stubBranchMergeRef("", nil),
+				atPushRefFn:      stubAtPushRef("origin/branchName", nil),
 			},
 			baseRepoRemote: context.Remote{
 				Remote: &git.Remote{Name: "upstream"},
@@ -665,8 +664,8 @@ func Test_parseCurrentBranchWithAtPushRef(t *testing.T) {
 				branchFn: func() (string, error) {
 					return "branchName", nil
 				},
-				branchConfig: stubBranchConfig(git.BranchConfig{}, nil),
-				atPushRefFn:  stubAtPushRef("origin/branchName", nil),
+				branchMergeRefFn: stubBranchMergeRef("", nil),
+				atPushRefFn:      stubAtPushRef("origin/branchName", nil),
 			},
 			baseRepoRemote: context.Remote{
 				Remote: &git.Remote{Name: "upstream"},
@@ -687,9 +686,9 @@ func Test_parseCurrentBranchWithAtPushRef(t *testing.T) {
 				httpClient: func() (*http.Client, error) {
 					return &http.Client{}, nil
 				},
-				baseRepoFn:   stubBaseRepo(tt.baseRepoRemote.Repo, nil),
-				branchFn:     tt.args.branchFn,
-				branchConfig: tt.args.branchConfig,
+				baseRepoFn:     stubBaseRepo(tt.baseRepoRemote.Repo, nil),
+				branchFn:       tt.args.branchFn,
+				branchMergeRef: tt.args.branchMergeRefFn,
 				remotesFn: stubRemotes(context.Remotes{
 					&tt.baseRepoRemote,
 					&tt.forkRepoRemote,
@@ -766,5 +765,11 @@ func stubRemotes(remotes context.Remotes, err error) func() (context.Remotes, er
 func stubBaseRepo(repo ghrepo.Interface, err error) func() (ghrepo.Interface, error) {
 	return func() (ghrepo.Interface, error) {
 		return repo, err
+	}
+}
+
+func stubBranchMergeRef(mergeRef string, err error) func(string) (string, error) {
+	return func(branch string) (string, error) {
+		return mergeRef, err
 	}
 }

--- a/pkg/cmd/pr/shared/finder_test.go
+++ b/pkg/cmd/pr/shared/finder_test.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -17,6 +18,7 @@ import (
 type args struct {
 	baseRepoFn   func() (ghrepo.Interface, error)
 	branchFn     func() (string, error)
+	atPushRefFn  func(string) (string, error)
 	branchConfig func(string) (git.BranchConfig, error)
 	remotesFn    func() (context.Remotes, error)
 	selector     string
@@ -557,6 +559,152 @@ func TestFind(t *testing.T) {
 	}
 }
 
+func Test_parseCurrentBranchWithAtPushRef(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           args
+		baseRepoRemote context.Remote
+		forkRepoRemote context.Remote
+		wantSelector   string
+		wantPR         int
+		wantError      error
+	}{
+		{
+			name: "When we fail to read the branch, it should return the error",
+			args: args{
+				branchFn: func() (string, error) {
+					return "", errors.New("branchErr")
+				},
+			},
+			wantSelector: "",
+			wantPR:       0,
+			wantError:    errors.New("branchErr"),
+		},
+		{
+			name: "When we fail to parse the @{push} ref, it should return the error",
+			args: args{
+				branchFn: func() (string, error) {
+					return "branchName", nil
+				},
+				branchConfig: stubBranchConfig(git.BranchConfig{}, nil),
+				atPushRefFn:  stubAtPushRef("", errors.New("atPushRefErr")),
+			},
+			wantSelector: "",
+			wantPR:       0,
+			wantError:    errors.New("atPushRefErr"),
+		},
+		{
+			name: "When the merge ref is a PR, it should return the PR number",
+			args: args{
+				branchFn: func() (string, error) {
+					return "branchName", nil
+				},
+				branchConfig: stubBranchConfig(git.BranchConfig{
+					MergeRef: "refs/pull/13/head",
+				}, nil),
+				atPushRefFn: stubAtPushRef("", nil),
+			},
+			wantSelector: "",
+			wantPR:       13,
+			wantError:    nil,
+		},
+		{
+			name: "When the branch config fails",
+			args: args{
+				branchFn: func() (string, error) {
+					return "branchName", nil
+				},
+				branchConfig: stubBranchConfig(git.BranchConfig{}, fmt.Errorf("branchConfigError")),
+				atPushRefFn:  stubAtPushRef("", nil),
+			},
+			wantSelector: "",
+			wantPR:       0,
+			wantError:    errors.New("branchConfigError"),
+		},
+		{
+			name: "When the merge ref is not a PR, it should return the branch name as the selector",
+			args: args{
+				branchFn: func() (string, error) {
+					return "branchName", nil
+				},
+				branchConfig: stubBranchConfig(git.BranchConfig{}, nil),
+				atPushRefFn:  stubAtPushRef("origin/branchName", nil),
+			},
+			baseRepoRemote: context.Remote{
+				Remote: &git.Remote{Name: "origin"},
+				Repo:   ghrepo.New("originOwner", "repo"),
+			},
+			wantSelector: "branchName",
+			wantPR:       0,
+			wantError:    nil,
+		},
+		{
+			name: "When the merge ref is not a PR, and the push remote is a fork, it should return the forkOwner:branchName as the selector",
+			args: args{
+				branchFn: func() (string, error) {
+					return "branchName", nil
+				},
+				branchConfig: stubBranchConfig(git.BranchConfig{}, nil),
+				atPushRefFn:  stubAtPushRef("origin/branchName", nil),
+			},
+			baseRepoRemote: context.Remote{
+				Remote: &git.Remote{Name: "upstream"},
+				Repo:   ghrepo.New("upstreamOwner", "repo"),
+			},
+			forkRepoRemote: context.Remote{
+				Remote: &git.Remote{Name: "origin"},
+				Repo:   ghrepo.New("originOwner", "repo"),
+			},
+			wantSelector: "originOwner:branchName",
+			wantPR:       0,
+			wantError:    nil,
+		},
+		{
+			name: "When the merge ref is not a PR, and the push remote is a fork with the same owner (indicating it is a private org fork), it should return the forkOwner:branchName as the selector",
+			args: args{
+				branchFn: func() (string, error) {
+					return "branchName", nil
+				},
+				branchConfig: stubBranchConfig(git.BranchConfig{}, nil),
+				atPushRefFn:  stubAtPushRef("origin/branchName", nil),
+			},
+			baseRepoRemote: context.Remote{
+				Remote: &git.Remote{Name: "upstream"},
+				Repo:   ghrepo.New("owner", "repo"),
+			},
+			forkRepoRemote: context.Remote{
+				Remote: &git.Remote{Name: "origin"},
+				Repo:   ghrepo.New("owner", "forked-repo"),
+			},
+			wantSelector: "owner:branchName",
+			wantPR:       0,
+			wantError:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := finder{
+				httpClient: func() (*http.Client, error) {
+					return &http.Client{}, nil
+				},
+				baseRepoFn:   stubBaseRepo(tt.baseRepoRemote.Repo, nil),
+				branchFn:     tt.args.branchFn,
+				branchConfig: tt.args.branchConfig,
+				remotesFn: stubRemotes(context.Remotes{
+					&tt.baseRepoRemote,
+					&tt.forkRepoRemote,
+				}, nil),
+				atPushRef: tt.args.atPushRefFn,
+				repo:      tt.baseRepoRemote.Repo,
+			}
+			selector, pr, err := f.parseCurrentBranchWithAtPushRef()
+			assert.Equal(t, tt.wantSelector, selector)
+			assert.Equal(t, tt.wantPR, pr)
+			assert.Equal(t, tt.wantError, err)
+		})
+	}
+}
+
 func Test_parseCurrentBranch(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -600,5 +748,23 @@ func Test_parseCurrentBranch(t *testing.T) {
 func stubBranchConfig(branchConfig git.BranchConfig, err error) func(string) (git.BranchConfig, error) {
 	return func(branch string) (git.BranchConfig, error) {
 		return branchConfig, err
+	}
+}
+
+func stubAtPushRef(refToReturn string, errToReturn error) func(string) (string, error) {
+	return func(branchName string) (string, error) {
+		return refToReturn, errToReturn
+	}
+}
+
+func stubRemotes(remotes context.Remotes, err error) func() (context.Remotes, error) {
+	return func() (context.Remotes, error) {
+		return remotes, err
+	}
+}
+
+func stubBaseRepo(repo ghrepo.Interface, err error) func() (ghrepo.Interface, error) {
+	return func() (ghrepo.Interface, error) {
+		return repo, err
 	}
 }


### PR DESCRIPTION
- **Add ReadAtPushRef method to git client**
- **Add parseCurrentBranchWithAtPushRef method to pr finder**
- **Add BranchMergeRef method to git client**
