### PR TITLE
Enable MSI building for Windows arm64

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -203,10 +203,8 @@ jobs:
               platform="x64"
               ;;
             *_arm64 )
-              echo "skipping building MSI for arm64 because WiX 3.11 doesn't support it: https://github.com/wixtoolset/issues/issues/6141" >&2
-              continue
-              #source_dir="$PWD/dist/windows_windows_arm64"
-              #platform="arm64"
+              source_dir="$PWD/dist/windows_windows_arm64"
+              platform="arm64"
               ;;
             * )
               printf "unsupported architecture: %s\n" "$MSI_NAME" >&2


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #10199 

> [!NOTE]
> Although building on a x64 host will work best - given that WiX 3.14 [doesn't have a VS2022 extension for arm64](https://github.com/wixtoolset/issues/issues/6811#issuecomment-1781830500) - I managed to build the MSIs locally on my arm64 machine as well. [I tried to trigger a build](https://github.com/dennisameling/cli/actions/runs/12913698154/job/36011524428) on a x64 host in my fork, but it obviously fails due to missing code signing credentials.

I was able to build this successfully on my ARM64 device (Surface Pro X) by running these steps:

- Clone the repo locally
- Install `goreleaser` with `winget install goreleaser --version 1.26.2` (since this repo has not upgraded `goreleaser` to v2 yet)
- Open Git Bash (part of Git for Windows)
- Run `./script/release --local v2.65.0-dennis --platform windows` (this created the .exe and .zip files)
- Extract [this logic](https://github.com/cli/cli/blob/adc5f01d232adbe2cbe9bb638ab711fe916c508e/.github/workflows/deployment.yml#L192) into a dedicated `.sh` file and run it to create the MSIs

### `./script release` logs

<details>
  <summary>Click to expand</summary>
<pre>
$ ./script/release --local v2.65.0-dennis --platform windows
goreleaser release -f .goreleaser.generated.yml --clean --skip-validate --skip-publish --release-notes=$TMPDIR/tmp.jdHBsQiqqI
  • starting release...
  • loading                                          path=.goreleaser.generated.yml
  • DEPRECATED: --skip-publish was deprecated in favor of --skip=publish, check https://goreleaser.com/deprecations#-skip for more details
  • DEPRECATED: --skip-validate was deprecated in favor of --skip=validate, check https://goreleaser.com/deprecations#-skip for more details
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • couldn't find any tags before "v2.65.0-dennis"
    • git state                                      commit=c3342cc173a69e4c576c06d29f75b44a21e44ec6 branch=trunk current_tag=v2.65.0-dennis previous_tag=<unknown> dirty=true
    • pipe skipped                                   reason=validation is disabled
    • took: 1s
  • parsing tag
  • setting defaults
    • DEPRECATED:  archives.rlcp  should not be used anymore, check https://goreleaser.com/deprecations#archivesrlcp for more info
    • DEPRECATED:  archives.rlcp  should not be used anymore, check https://goreleaser.com/deprecations#archivesrlcp for more info
    • DEPRECATED:  archives.rlcp  should not be used anymore, check https://goreleaser.com/deprecations#archivesrlcp for more info
  • running before hooks
    • running                                        hook=echo make manpages GH_VERSION=2.65.0-dennis
    • running                                        hook=echo make completions
  • checking distribution directory
  • setting up metadata
  • storing release metadata
    • writing                                        file=dist\metadata.json
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist\config.yaml
  • building binaries
    • building                                       binary=dist\windows_windows_arm64\bin\gh.exe
    • building                                       binary=dist\windows_windows_amd64_v1\bin\gh.exe
    • building                                       binary=dist\windows_windows_386\bin\gh.exe
    • running hook                                   hook=pwsh .\script\sign.ps1 'C:\repos\cli\dist\windows_windows_arm64\bin\gh.exe'
Skipping Windows code signing; DLIB_PATH not set
    • running hook                                   hook=pwsh .\script\sign.ps1 'C:\repos\cli\dist\windows_windows_386\bin\gh.exe'
Skipping Windows code signing; DLIB_PATH not set
    • running hook                                   hook=pwsh .\script\sign.ps1 'C:\repos\cli\dist\windows_windows_amd64_v1\bin\gh.exe'
Skipping Windows code signing; DLIB_PATH not set
    • took: 1m51s
  • generating changelog
    • loaded "C:/Users/denni/AppData/Local/Temp/tmp.jdHBsQiqqI", but it is empty
  • archives
    • creating                                       archive=dist\gh_2.65.0-dennis_windows_386.zip
    • creating                                       archive=dist\gh_2.65.0-dennis_windows_arm64.zip
    • creating                                       archive=dist\gh_2.65.0-dennis_windows_amd64.zip
    • took: 5s
  • calculating checksums
  • storing artifacts metadata
    • writing                                        file=dist\artifacts.json
  • you are using deprecated options, check the output above for details
  • release succeeded after 1m57s
  • thanks for using goreleaser!
</pre>
</details>

### MSI logs

<details>
  <summary>Click to expand</summary>
<pre>
$ ./msbuild.sh
MSBuild version 17.10.4+10fbfbf2e for .NET Framework
Build started 22-1-2025 18:03:26.

Project "C:\repos\cli\build\windows\gh.wixproj" on node 1 (default targets).
PrepareForBuild:
  Creating directory "C:\repos\cli\bin\obj\x86\".
Compile:
  C:\Program Files (x86)\WiX Toolset v3.14\bin\candle.exe -dProductVersion=2.65.0 -dConfiguration=Release -dOutDir=C:/r
  epos/cli/dist\ -dPlatform=x86 -dProjectDir=C:\repos\cli\build\windows\ -dProjectExt=.wixproj -dProjectFileName=gh.wix
  proj -dProjectName=gh -dProjectPath=C:\repos\cli\build\windows\gh.wixproj -dTargetDir=C:\repos\cli\dist\ -dTargetExt=
  .msi -dTargetFileName=gh_2.65.0-dennis_windows_386.msi -dTargetName=gh_2.65.0-dennis_windows_386 -dTargetPath=C:\repo
  s\cli\dist\gh_2.65.0-dennis_windows_386.msi -out C:\repos\cli\bin\obj\x86\ -arch x86 -ext "C:\Program Files (x86)\WiX
   Toolset v3.14\bin\WixUIExtension.dll" -ext "C:\Program Files (x86)\WiX Toolset v3.14\bin\WixUtilExtension.dll" gh.wx
  s ui.wxs
Link:
  C:\Program Files (x86)\WiX Toolset v3.14\bin\Light.exe -out C:\repos\cli\dist\gh_2.65.0-dennis_windows_386.msi -pdbou
  t C:\repos\cli\dist\gh_2.65.0-dennis_windows_386.wixpdb -b C:\repos\cli\dist\windows_windows_386 -b C:\repos\cli\dist
  \windows_windows_386\bin -cultures:null -ext "C:\Program Files (x86)\WiX Toolset v3.14\bin\WixUIExtension.dll" -ext "
  C:\Program Files (x86)\WiX Toolset v3.14\bin\WixUtilExtension.dll" -contentsfile C:\repos\cli\bin\obj\x86\gh.wixproj.
  BindContentsFileListnull.txt -outputsfile C:\repos\cli\bin\obj\x86\gh.wixproj.BindOutputsFileListnull.txt -builtoutpu
  tsfile C:\repos\cli\bin\obj\x86\gh.wixproj.BindBuiltOutputsFileListnull.txt -wixprojectfile C:\repos\cli\build\window
  s\gh.wixproj C:\repos\cli\bin\obj\x86\gh.wixobj C:\repos\cli\bin\obj\x86\ui.wixobj
  gh -> C:\repos\cli\dist\gh_2.65.0-dennis_windows_386.msi
Done Building Project "C:\repos\cli\build\windows\gh.wixproj" (default targets).


Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:28.04
MSBuild version 17.10.4+10fbfbf2e for .NET Framework
Build started 22-1-2025 18:03:55.

Project "C:\repos\cli\build\windows\gh.wixproj" on node 1 (default targets).
PrepareForBuild:
  Creating directory "C:\repos\cli\bin\obj\x64\".
Compile:
  C:\Program Files (x86)\WiX Toolset v3.14\bin\candle.exe -dProductVersion=2.65.0 -dConfiguration=Release -dOutDir=C:/r
  epos/cli/dist\ -dPlatform=x64 -dProjectDir=C:\repos\cli\build\windows\ -dProjectExt=.wixproj -dProjectFileName=gh.wix
  proj -dProjectName=gh -dProjectPath=C:\repos\cli\build\windows\gh.wixproj -dTargetDir=C:\repos\cli\dist\ -dTargetExt=
  .msi -dTargetFileName=gh_2.65.0-dennis_windows_amd64.msi -dTargetName=gh_2.65.0-dennis_windows_amd64 -dTargetPath=C:\
  repos\cli\dist\gh_2.65.0-dennis_windows_amd64.msi -out C:\repos\cli\bin\obj\x64\ -arch x64 -ext "C:\Program Files (x8
  6)\WiX Toolset v3.14\bin\WixUIExtension.dll" -ext "C:\Program Files (x86)\WiX Toolset v3.14\bin\WixUtilExtension.dll"
   gh.wxs ui.wxs
Link:
  C:\Program Files (x86)\WiX Toolset v3.14\bin\Light.exe -out C:\repos\cli\dist\gh_2.65.0-dennis_windows_amd64.msi -pdb
  out C:\repos\cli\dist\gh_2.65.0-dennis_windows_amd64.wixpdb -b C:\repos\cli\dist\windows_windows_amd64_v1 -b C:\repos
  \cli\dist\windows_windows_amd64_v1\bin -cultures:null -ext "C:\Program Files (x86)\WiX Toolset v3.14\bin\WixUIExtensi
  on.dll" -ext "C:\Program Files (x86)\WiX Toolset v3.14\bin\WixUtilExtension.dll" -contentsfile C:\repos\cli\bin\obj\x
  64\gh.wixproj.BindContentsFileListnull.txt -outputsfile C:\repos\cli\bin\obj\x64\gh.wixproj.BindOutputsFileListnull.t
  xt -builtoutputsfile C:\repos\cli\bin\obj\x64\gh.wixproj.BindBuiltOutputsFileListnull.txt -wixprojectfile C:\repos\cl
  i\build\windows\gh.wixproj C:\repos\cli\bin\obj\x64\gh.wixobj C:\repos\cli\bin\obj\x64\ui.wixobj
  gh -> C:\repos\cli\dist\gh_2.65.0-dennis_windows_amd64.msi
Done Building Project "C:\repos\cli\build\windows\gh.wixproj" (default targets).


Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:28.48
MSBuild version 17.10.4+10fbfbf2e for .NET Framework
Build started 22-1-2025 18:04:24.

Project "C:\repos\cli\build\windows\gh.wixproj" on node 1 (default targets).
PrepareForBuild:
  Creating directory "C:\repos\cli\bin\obj\arm64\".
Compile:
  C:\Program Files (x86)\WiX Toolset v3.14\bin\candle.exe -dProductVersion=2.65.0 -dConfiguration=Release -dOutDir=C:/r
  epos/cli/dist\ -dPlatform=arm64 -dProjectDir=C:\repos\cli\build\windows\ -dProjectExt=.wixproj -dProjectFileName=gh.w
  ixproj -dProjectName=gh -dProjectPath=C:\repos\cli\build\windows\gh.wixproj -dTargetDir=C:\repos\cli\dist\ -dTargetEx
  t=.msi -dTargetFileName=gh_2.65.0-dennis_windows_arm64.msi -dTargetName=gh_2.65.0-dennis_windows_arm64 -dTargetPath=C
  :\repos\cli\dist\gh_2.65.0-dennis_windows_arm64.msi -out C:\repos\cli\bin\obj\arm64\ -arch arm64 -ext "C:\Program Fil
  es (x86)\WiX Toolset v3.14\bin\WixUIExtension.dll" -ext "C:\Program Files (x86)\WiX Toolset v3.14\bin\WixUtilExtensio
  n.dll" gh.wxs ui.wxs
Link:
  C:\Program Files (x86)\WiX Toolset v3.14\bin\Light.exe -out C:\repos\cli\dist\gh_2.65.0-dennis_windows_arm64.msi -pdb
  out C:\repos\cli\dist\gh_2.65.0-dennis_windows_arm64.wixpdb -b C:\repos\cli\dist\windows_windows_arm64 -b C:\repos\cl
  i\dist\windows_windows_arm64\bin -cultures:null -ext "C:\Program Files (x86)\WiX Toolset v3.14\bin\WixUIExtension.dll
  " -ext "C:\Program Files (x86)\WiX Toolset v3.14\bin\WixUtilExtension.dll" -sice:ICE39 -contentsfile C:\repos\cli\bin
  \obj\arm64\gh.wixproj.BindContentsFileListnull.txt -outputsfile C:\repos\cli\bin\obj\arm64\gh.wixproj.BindOutputsFile
  Listnull.txt -builtoutputsfile C:\repos\cli\bin\obj\arm64\gh.wixproj.BindBuiltOutputsFileListnull.txt -wixprojectfile
   C:\repos\cli\build\windows\gh.wixproj C:\repos\cli\bin\obj\arm64\gh.wixobj C:\repos\cli\bin\obj\arm64\ui.wixobj
  gh -> C:\repos\cli\dist\gh_2.65.0-dennis_windows_arm64.msi
Done Building Project "C:\repos\cli\build\windows\gh.wixproj" (default targets).


Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:26.48
</pre>
</details>

## Installation results

I was able to run the generated `gh_2.65.0-dennis_windows_arm64.msi` locally. The installation succeeded and the `gh` binary is available:

![image](https://github.com/user-attachments/assets/6acf2802-95cf-45d4-88a5-b8b9d1a7888c)

```
PS> gh --version
gh version 2.65.0-dennis (2025-01-22)
https://github.com/cli/cli/releases/tag/v2.65.0-dennis
```

Here's the MSI artifact in case anyone wants to test:

[gh_2.65.0-dennis_windows_arm64_msi.zip](https://github.com/user-attachments/files/18509230/gh_2.65.0-dennis_windows_arm64_msi.zip)