### PR TITLE
[gh api] Fix mutual exclusion messages of `--slurp` flag

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -239,17 +239,19 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 				return err
 			}
 
-			if opts.Slurp && !opts.Paginate {
-				return cmdutil.FlagErrorf("`--paginate` required when passing `--slurp`")
-			}
+			if opts.Slurp {
+				if err := cmdutil.MutuallyExclusive(
+					"the `--slurp` option is not supported with `--jq` or `--template`",
+					opts.Slurp,
+					opts.FilterOutput != "",
+					opts.Template != "",
+				); err != nil {
+					return err
+				}
 
-			if err := cmdutil.MutuallyExclusive(
-				"the `--slurp` option is not supported with `--jq` or `--template`",
-				opts.Slurp,
-				opts.FilterOutput != "",
-				opts.Template != "",
-			); err != nil {
-				return err
+				if !opts.Paginate {
+					return cmdutil.FlagErrorf("`--paginate` required when passing `--slurp`")
+				}
 			}
 
 			if err := cmdutil.MutuallyExclusive(


### PR DESCRIPTION
Fixes #10260.

```shell
$ bin/gh api notifications -F participating=true --jq '.' --template '{{range .}}{{tablerow .repository.full_name (truncate 100 .subject.title) .subject.type .reason (timeago .updated_at)}}{{end}}'
only one of `--template`, `--jq`, `--silent`, or `--verbose` may be used
...

$ bin/gh api notifications -F participating=true --slurp
`--paginate` required when passing `--slurp`
...
```