### PR TITLE
Add --clobber / --skip-existing to run download

### DIFF
--- a/pkg/cmd/run/download/download.go
+++ b/pkg/cmd/run/download/download.go
@@ -19,16 +19,18 @@ type DownloadOptions struct {
 	Platform platform
 	Prompter iprompter
 
-	DoPrompt       bool
-	RunID          string
-	DestinationDir string
-	Names          []string
-	FilePatterns   []string
+	DoPrompt          bool
+	RunID             string
+	DestinationDir    string
+	Names             []string
+	FilePatterns      []string
+	OverwriteExisting bool
+	SkipExisting      bool
 }
 
 type platform interface {
 	List(runID string) ([]shared.Artifact, error)
-	Download(url string, dir safepaths.Absolute) error
+	Download(url string, dir safepaths.Absolute, force bool, skip bool) error
 }
 
 type iprompter interface {
@@ -77,6 +79,9 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 				opts.IO.CanPrompt() {
 				opts.DoPrompt = true
 			}
+			if opts.OverwriteExisting && opts.SkipExisting {
+				return errors.New("specify either --clobber or --skip-existing. you cannot use both of them simultaneously")
+			}
 			// support `-R, --repo` override
 			baseRepo, err := f.BaseRepo()
 			if err != nil {
@@ -101,6 +106,8 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 	cmd.Flags().StringVarP(&opts.DestinationDir, "dir", "D", ".", "The directory to download artifacts into")
 	cmd.Flags().StringArrayVarP(&opts.Names, "name", "n", nil, "Download artifacts that match any of the given names")
 	cmd.Flags().StringArrayVarP(&opts.FilePatterns, "pattern", "p", nil, "Download artifacts that match a glob pattern")
+	cmd.Flags().BoolVar(&opts.OverwriteExisting, "clobber", false, "Overwrite existing files of the same name")
+	cmd.Flags().BoolVar(&opts.SkipExisting, "skip-existing", false, "Skip downloading when files of the same name exist")
 
 	return cmd
 }
@@ -187,7 +194,7 @@ func runDownload(opts *DownloadOptions) error {
 			}
 		}
 
-		err := opts.Platform.Download(a.DownloadURL, destDir)
+		err := opts.Platform.Download(a.DownloadURL, destDir, opts.OverwriteExisting, opts.SkipExisting)
 		if err != nil {
 			return fmt.Errorf("error downloading %s: %w", a.Name, err)
 		}

--- a/pkg/cmd/run/download/download_test.go
+++ b/pkg/cmd/run/download/download_test.go
@@ -186,7 +186,7 @@ func (f *fakePlatform) List(runID string) ([]shared.Artifact, error) {
 	return artifacts, nil
 }
 
-func (f *fakePlatform) Download(url string, dir safepaths.Absolute) error {
+func (f *fakePlatform) Download(url string, dir safepaths.Absolute, force bool, skip bool) error {
 	if err := os.MkdirAll(dir.String(), 0755); err != nil {
 		return err
 	}

--- a/pkg/cmd/run/download/http.go
+++ b/pkg/cmd/run/download/http.go
@@ -22,11 +22,11 @@ func (p *apiPlatform) List(runID string) ([]shared.Artifact, error) {
 	return shared.ListArtifacts(p.client, p.repo, runID)
 }
 
-func (p *apiPlatform) Download(url string, dir safepaths.Absolute) error {
-	return downloadArtifact(p.client, url, dir)
+func (p *apiPlatform) Download(url string, dir safepaths.Absolute, force bool, skip bool) error {
+	return downloadArtifact(p.client, url, dir, force, skip)
 }
 
-func downloadArtifact(httpClient *http.Client, url string, destDir safepaths.Absolute) error {
+func downloadArtifact(httpClient *http.Client, url string, destDir safepaths.Absolute, force bool, skip bool) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func downloadArtifact(httpClient *http.Client, url string, destDir safepaths.Abs
 	if err != nil {
 		return fmt.Errorf("error extracting zip archive: %w", err)
 	}
-	if err := extractZip(zipfile, destDir); err != nil {
+	if err := extractZip(zipfile, destDir, force, skip); err != nil {
 		return fmt.Errorf("error extracting zip archive: %w", err)
 	}
 

--- a/pkg/cmd/run/download/http_test.go
+++ b/pkg/cmd/run/download/http_test.go
@@ -65,14 +65,15 @@ func Test_Download(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)
 
-	reg.Register(
-		httpmock.REST("GET", "repos/OWNER/REPO/actions/artifacts/12345/zip"),
-		httpmock.FileResponse("./fixtures/myproject.zip"))
+	matcher := httpmock.REST("GET", "repos/OWNER/REPO/actions/artifacts/12345/zip")
+	responder := httpmock.FileResponse("./fixtures/myproject.zip")
+	url := "https://api.github.com/repos/OWNER/REPO/actions/artifacts/12345/zip"
+	reg.Register(matcher, responder)
 
 	api := &apiPlatform{
 		client: &http.Client{Transport: reg},
 	}
-	require.NoError(t, api.Download("https://api.github.com/repos/OWNER/REPO/actions/artifacts/12345/zip", destDir))
+	require.NoError(t, api.Download(url, destDir, false, false))
 
 	var paths []string
 	parentPrefix := tmpDir + string(filepath.Separator)
@@ -104,4 +105,39 @@ func Test_Download(t *testing.T) {
 		filepath.Join("artifact", "src", "main.go"),
 		filepath.Join("artifact", "src", "util.go"),
 	}, paths)
+	// test --clobber/--skip-existing option
+	readme := parentPrefix + filepath.Join("artifact", "readme.md")
+	stat, err := os.Stat(readme)
+	require.NoError(t, err)
+	mtimeFirst := stat.ModTime()
+
+	// test existing error
+	reg.Register(matcher, responder)
+	err = api.Download(url, destDir, false, false)
+	require.ErrorContains(t, err, "(use `--clobber` to override or `--skip-existing` to skip)")
+
+	stat, err = os.Stat(readme)
+	require.NoError(t, err)
+	mtimeError := stat.ModTime()
+	require.Equal(t, mtimeFirst, mtimeError)
+
+	// test --clobber
+	reg.Register(matcher, responder)
+	err = api.Download(url, destDir, true, false)
+	require.NoError(t, err)
+
+	stat, err = os.Stat(readme)
+	require.NoError(t, err)
+	mtimeClobber := stat.ModTime()
+	require.Less(t, mtimeFirst, mtimeClobber)
+
+	// test --skip-existing
+	reg.Register(matcher, responder)
+	err = api.Download(url, destDir, false, true)
+	require.NoError(t, err)
+
+	stat, err = os.Stat(readme)
+	require.NoError(t, err)
+	mtimeSkip := stat.ModTime()
+	require.Equal(t, mtimeClobber, mtimeSkip)
 }

--- a/pkg/cmd/run/download/zip.go
+++ b/pkg/cmd/run/download/zip.go
@@ -17,7 +17,7 @@ const (
 	execMode os.FileMode = 0755
 )
 
-func extractZip(zr *zip.Reader, destDir safepaths.Absolute) error {
+func extractZip(zr *zip.Reader, destDir safepaths.Absolute, force bool, skip bool) error {
 	for _, zf := range zr.File {
 		fpath, err := destDir.Join(zf.Name)
 		if err != nil {
@@ -28,14 +28,14 @@ func extractZip(zr *zip.Reader, destDir safepaths.Absolute) error {
 			return err
 		}
 
-		if err := extractZipFile(zf, fpath); err != nil {
+		if err := extractZipFile(zf, fpath, force, skip); err != nil {
 			return fmt.Errorf("error extracting %q: %w", zf.Name, err)
 		}
 	}
 	return nil
 }
 
-func extractZipFile(zf *zip.File, dest safepaths.Absolute) (extractErr error) {
+func extractZipFile(zf *zip.File, dest safepaths.Absolute, force bool, skip bool) (extractErr error) {
 	zm := zf.Mode()
 	if zm.IsDir() {
 		extractErr = os.MkdirAll(dest.String(), dirMode)
@@ -54,7 +54,22 @@ func extractZipFile(zf *zip.File, dest safepaths.Absolute) (extractErr error) {
 	}
 
 	var df *os.File
-	if df, extractErr = os.OpenFile(dest.String(), os.O_WRONLY|os.O_CREATE|os.O_EXCL, getPerm(zm)); extractErr != nil {
+	flag := os.O_WRONLY | os.O_CREATE
+	if !force {
+		flag = flag | os.O_EXCL
+	}
+
+	if df, extractErr = os.OpenFile(dest.String(), flag, getPerm(zm)); extractErr != nil {
+		errExist := errors.Is(extractErr, os.ErrExist)
+		if errExist && skip {
+			return nil
+		}
+		if errExist {
+			return fmt.Errorf(
+				"%s already exists ((use `--clobber` to override or `--skip-existing` to skip))",
+				dest,
+			)
+		}
 		return
 	}
 

--- a/pkg/cmd/run/download/zip_test.go
+++ b/pkg/cmd/run/download/zip_test.go
@@ -19,7 +19,7 @@ func Test_extractZip(t *testing.T) {
 	require.NoError(t, err)
 	defer zipFile.Close()
 
-	err = extractZip(&zipFile.Reader, extractPath)
+	err = extractZip(&zipFile.Reader, extractPath, false, false)
 	require.NoError(t, err)
 
 	_, err = os.Stat(filepath.Join(extractPath.String(), "src", "main.go"))


### PR DESCRIPTION
Fixes: https://github.com/cli/cli/issues/10336

This functionality already exists for `release download`. It was initally added in the same PR
https://github.com/cli/cli/pull/6053 but the changes were overwritten by a further commit.

Makes it possible to skip when the file already exists or overwriting existing files when required.

Before:
```
$ gh run download $latest_run_id --name assets --repo example/code

error downloading assets: error extracting zip archive: 
error extracting "code.zip": open code.zip: file exists
```

After:
```
$ gh run download $latest_run_id --name assets --repo example/code

error downloading assets: error extracting zip archive: 
error extracting "code.zip": open code.zip: already exists ((use `--clobber` to override or `--skip-existing` to skip))

$ gh run download $latest_run_id --name assets --repo example/code --clobber
# File overwritten

$ gh run download $latest_run_id --name assets --repo example/code --skip-existing
# File skipped
```


<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
