### PR TITLE
Update `gh attestation` bundle fetching logic

### DIFF
--- a/pkg/cmd/attestation/api/client.go
+++ b/pkg/cmd/attestation/api/client.go
@@ -178,6 +178,7 @@ func (c *LiveClient) fetchBundleFromAttestations(attestations []*Attestation) ([
 
 			// If the bundle field is nil, try to fetch the bundle with the provided URL
 			if a.Bundle == nil {
+				c.logger.VerbosePrintf("Bundle field is empty. Trying to fetch with bundle URL\n\n")
 				b, err := c.GetBundle(a.BundleURL)
 				if err != nil {
 					return fmt.Errorf("failed to fetch bundle with URL: %w", err)
@@ -185,10 +186,11 @@ func (c *LiveClient) fetchBundleFromAttestations(attestations []*Attestation) ([
 				fetched[i] = &Attestation{
 					Bundle: b,
 				}
+				return nil
 			}
 
 			// otherwise fall back to the bundle field
-			c.logger.VerbosePrintf("Bundle URL is empty. Falling back to bundle field\n\n")
+			c.logger.VerbosePrintf("Fetching bundle from Bundle field\n\n")
 			fetched[i] = &Attestation{
 				Bundle: a.Bundle,
 			}

--- a/pkg/cmd/attestation/api/client.go
+++ b/pkg/cmd/attestation/api/client.go
@@ -176,23 +176,23 @@ func (c *LiveClient) fetchBundleFromAttestations(attestations []*Attestation) ([
 				return fmt.Errorf("attestation has no bundle or bundle URL")
 			}
 
-			// for now, we fallback to the bundle field if the bundle URL is empty
-			if a.BundleURL == "" {
-				c.logger.VerbosePrintf("Bundle URL is empty. Falling back to bundle field\n\n")
-				fetched[i] = &Attestation{
-					Bundle: a.Bundle,
+			// If the bundle field is nil, try to fetch the bundle with the provided URL
+			if a.Bundle == nil {
+				b, err := c.GetBundle(a.BundleURL)
+				if err != nil {
+					return fmt.Errorf("failed to fetch bundle with URL: %w", err)
 				}
-				return nil
+				fetched[i] = &Attestation{
+					Bundle: b,
+				}
 			}
 
-			// otherwise fetch the bundle with the provided URL
-			b, err := c.GetBundle(a.BundleURL)
-			if err != nil {
-				return fmt.Errorf("failed to fetch bundle with URL: %w", err)
-			}
+			// otherwise fall back to the bundle field
+			c.logger.VerbosePrintf("Bundle URL is empty. Falling back to bundle field\n\n")
 			fetched[i] = &Attestation{
-				Bundle: b,
+				Bundle: a.Bundle,
 			}
+
 			return nil
 		})
 	}

--- a/pkg/cmd/attestation/api/client_test.go
+++ b/pkg/cmd/attestation/api/client_test.go
@@ -180,7 +180,7 @@ func TestGetByDigest_Error(t *testing.T) {
 	require.Nil(t, attestations)
 }
 
-func TestFetchBundleFromAttestations(t *testing.T) {
+func TestFetchBundleFromAttestations_Fallback_Bundle_Field(t *testing.T) {
 	httpClient := &mockHttpClient{}
 	client := LiveClient{
 		httpClient: httpClient,
@@ -194,7 +194,7 @@ func TestFetchBundleFromAttestations(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, fetched, 2)
 	require.Equal(t, "application/vnd.dev.sigstore.bundle.v0.3+json", fetched[0].Bundle.GetMediaType())
-	httpClient.AssertNumberOfCalls(t, "OnGetSuccess", 2)
+	httpClient.AssertNumberOfCalls(t, "OnGetSuccess", 0)
 }
 
 func TestFetchBundleFromAttestations_InvalidAttestation(t *testing.T) {
@@ -220,7 +220,10 @@ func TestFetchBundleFromAttestations_Fail(t *testing.T) {
 	}
 
 	att1 := makeTestAttestation()
+	att1.Bundle = nil
 	att2 := makeTestAttestation()
+	att2.Bundle = nil
+	// zero out the bundle field so it tries fetching by URL
 	attestations := []*Attestation{&att1, &att2}
 	fetched, err := c.fetchBundleFromAttestations(attestations)
 	require.Error(t, err)
@@ -237,6 +240,7 @@ func TestFetchBundleFromAttestations_FetchByURLFail(t *testing.T) {
 	}
 
 	a := makeTestAttestation()
+	a.Bundle = nil
 	attestations := []*Attestation{&a}
 	bundle, err := c.fetchBundleFromAttestations(attestations)
 	require.Error(t, err)

--- a/pkg/cmd/attestation/api/client_test.go
+++ b/pkg/cmd/attestation/api/client_test.go
@@ -180,7 +180,7 @@ func TestGetByDigest_Error(t *testing.T) {
 	require.Nil(t, attestations)
 }
 
-func TestFetchBundleFromAttestations_Fallback_Bundle_Field(t *testing.T) {
+func TestFetchBundleFromAttestations_BundleURL(t *testing.T) {
 	httpClient := &mockHttpClient{}
 	client := LiveClient{
 		httpClient: httpClient,
@@ -188,13 +188,16 @@ func TestFetchBundleFromAttestations_Fallback_Bundle_Field(t *testing.T) {
 	}
 
 	att1 := makeTestAttestation()
+	att1.Bundle = nil
 	att2 := makeTestAttestation()
+	att2.Bundle = nil
+	// zero out the bundle field so it tries fetching by URL
 	attestations := []*Attestation{&att1, &att2}
 	fetched, err := client.fetchBundleFromAttestations(attestations)
 	require.NoError(t, err)
 	require.Len(t, fetched, 2)
-	require.Equal(t, "application/vnd.dev.sigstore.bundle.v0.3+json", fetched[0].Bundle.GetMediaType())
-	httpClient.AssertNumberOfCalls(t, "OnGetSuccess", 0)
+	require.NotNil(t, "application/vnd.dev.sigstore.bundle.v0.3+json", fetched[0].Bundle.GetMediaType())
+	httpClient.AssertNumberOfCalls(t, "OnGetSuccess", 2)
 }
 
 func TestFetchBundleFromAttestations_InvalidAttestation(t *testing.T) {
@@ -211,7 +214,7 @@ func TestFetchBundleFromAttestations_InvalidAttestation(t *testing.T) {
 	require.Nil(t, fetched, 2)
 }
 
-func TestFetchBundleFromAttestations_Fail(t *testing.T) {
+func TestFetchBundleFromAttestations_Fail_BundleURL(t *testing.T) {
 	httpClient := &failAfterOneCallHttpClient{}
 
 	c := &LiveClient{


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Update the bundle fetching logic used by `gh attestation` so the code only tries fetching a bundle with the URL from the `BundleURL` field if the `Bundle` field is empty.