### PR TITLE
[gh config] Escape pipe symbol in Long desc for website manual

### DIFF
--- a/internal/docs/markdown.go
+++ b/internal/docs/markdown.go
@@ -142,7 +142,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 		fmt.Fprintf(w, "```\n%s\n```\n\n", cmd.UseLine())
 	}
 	if hasLong {
-		longWithEscapedPipe := strings.ReplaceAll(cmd.Long, "|", "\\|")
+		longWithEscapedPipe := strings.ReplaceAll(cmd.Long, "|", "&#124;")
 		fmt.Fprintf(w, "%s\n\n", longWithEscapedPipe)
 	}
 

--- a/internal/docs/markdown.go
+++ b/internal/docs/markdown.go
@@ -142,7 +142,8 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 		fmt.Fprintf(w, "```\n%s\n```\n\n", cmd.UseLine())
 	}
 	if hasLong {
-		fmt.Fprintf(w, "%s\n\n", cmd.Long)
+		longWithEscapedPipe := strings.ReplaceAll(cmd.Long, "|", "\\|")
+		fmt.Fprintf(w, "%s\n\n", longWithEscapedPipe)
 	}
 
 	for _, g := range root.GroupedCommands(cmd) {

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -16,7 +16,7 @@ import (
 func NewCmdConfig(f *cmdutil.Factory) *cobra.Command {
 	longDoc := strings.Builder{}
 	longDoc.WriteString("Display or change configuration settings for gh.\n\n")
-	longDoc.WriteString("Current respected settings:\n")
+	longDoc.WriteString("Current respected settings:\n\n")
 	for _, co := range config.Options {
 		longDoc.WriteString(fmt.Sprintf("- `%s`: %s", co.Key, co.Description))
 		if len(co.AllowedValues) > 0 {


### PR DESCRIPTION
Fixes #10348.

- Replace pipe `|` symbol its respective HTML numeric code i.e. [`&#124;`](https://en.wikipedia.org/wiki/Numeric_character_reference)
- Add newline before an unordered list
  - Otherwise, the unordered list is treated as a paragraph i.e. `<p>...</p>`
  - See the `irb` example below with `kramdown`

Generated website manual with:

```shell
go run ./cmd/gen-docs --website --doc-path dist/manual
```

Verified with `irb` and `kramdown v2.5.1`.

**Issue without a newline before a list (conversion to a paragraph)**:

```shell
$ irb
2.6.3 :001 > require 'kramdown'
 => true 
2.6.3 :002 > text = <<-EOF
2.6.3 :003"> Current respected settings:
- `git_protocol`: the protocol to use for git clone and push operations {https&#124;ssh} (default https)
- `editor`: the text editor program to use for authoring text
- `prompt`: toggle interactive prompting in the terminal {enabled&#124;disabled} (default enabled)
- `prefer_editor_prompt`: toggle preference for editor-based interactive prompting in the terminal {enabled&#124;disabled} (default disabled)
- `pager`: the terminal pager program to send standard output to
- `http_unix_socket`: the path to a Unix socket through which to make an HTTP connection
- `browser`: the web browser to use for opening URLs
2.6.3 :011"> EOF
 => "Current respected settings:\n- `git_protocol`: the protocol to use for git clone and push operations {https&#124;ssh} (default https)\n- `editor`: the text editor program to use for authoring text\n- `prompt`: toggle interactive prompting in the terminal {enabled&#124;disabled} (default enabled)\n- `prefer_editor_prompt`: toggle preference for editor-based interactive prompting in the terminal {enabled&#124;disabled} (default disabled)\n- `pager`: the terminal pager program to send standard output to\n- `http_unix_socket`: the path to a Unix socket through which to make an HTTP connection\n- `browser`: the web browser to use for opening URLs\n" 
2.6.3 :012 > print Kramdown::Document.new(text).to_html
<p>Current respected settings:
- <code>git_protocol</code>: the protocol to use for git clone and push operations {https|ssh} (default https)
- <code>editor</code>: the text editor program to use for authoring text
- <code>prompt</code>: toggle interactive prompting in the terminal {enabled|disabled} (default enabled)
- <code>prefer_editor_prompt</code>: toggle preference for editor-based interactive prompting in the terminal {enabled|disabled} (default disabled)
- <code>pager</code>: the terminal pager program to send standard output to
- <code>http_unix_socket</code>: the path to a Unix socket through which to make an HTTP connection
- <code>browser</code>: the web browser to use for opening URLs</p>
 => nil 
```

**Correct conversion to an unordered list with a newline before the list**:

```shell
$ irb
2.6.3 :001 > require 'kramdown'
 => true 
2.6.3 :002 > text = <<-EOF
2.6.3 :003"> Current respected settings:

- `git_protocol`: the protocol to use for git clone and push operations {https&#124;ssh} (default https)
- `editor`: the text editor program to use for authoring text
- `prompt`: toggle interactive prompting in the terminal {enabled&#124;disabled} (default enabled)
- `prefer_editor_prompt`: toggle preference for editor-based interactive prompting in the terminal {enabled&#124;disabled} (default disabled)
- `pager`: the terminal pager program to send standard output to
- `http_unix_socket`: the path to a Unix socket through which to make an HTTP connection
- `browser`: the web browser to use for opening URLs
2.6.3 :012"> EOF
 => "Current respected settings:\n\n- `git_protocol`: the protocol to use for git clone and push operations {https&#124;ssh} (default https)\n- `editor`: the text editor program to use for authoring text\n- `prompt`: toggle interactive prompting in the terminal {enabled&#124;disabled} (default enabled)\n- `prefer_editor_prompt`: toggle preference for editor-based interactive prompting in the terminal {enabled&#124;disabled} (default disabled)\n- `pager`: the terminal pager program to send standard output to\n- `http_unix_socket`: the path to a Unix socket through which to make an HTTP connection\n- `browser`: the web browser to use for opening URLs\n" 
2.6.3 :013 > 
2.6.3 :014 > print Kramdown::Document.new(text).to_html
<p>Current respected settings:</p>

<ul>
  <li><code>git_protocol</code>: the protocol to use for git clone and push operations {https|ssh} (default https)</li>
  <li><code>editor</code>: the text editor program to use for authoring text</li>
  <li><code>prompt</code>: toggle interactive prompting in the terminal {enabled|disabled} (default enabled)</li>
  <li><code>prefer_editor_prompt</code>: toggle preference for editor-based interactive prompting in the terminal {enabled|disabled} (default disabled)</li>
  <li><code>pager</code>: the terminal pager program to send standard output to</li>
  <li><code>http_unix_socket</code>: the path to a Unix socket through which to make an HTTP connection</li>
  <li><code>browser</code>: the web browser to use for opening URLs</li>
</ul>
 => nil 
```

Compared the above conversion to paragraph scenario with existing lists and their generated HTML source of manual.
Apparently, there the conversion is being done correctly without a newline before the list.