### PR TITLE
[gh project item-edit] Fix number type

### DIFF
--- a/pkg/cmd/project/item-edit/item_edit.go
+++ b/pkg/cmd/project/item-edit/item_edit.go
@@ -23,7 +23,7 @@ type editItemOpts struct {
 	fieldID              string
 	projectID            string
 	text                 string
-	number               float32
+	number               float64
 	date                 string
 	singleSelectOptionID string
 	iterationID          string
@@ -123,7 +123,7 @@ func NewCmdEditItem(f *cmdutil.Factory, runF func(config editItemConfig) error) 
 	editItemCmd.Flags().StringVar(&opts.fieldID, "field-id", "", "ID of the field to update")
 	editItemCmd.Flags().StringVar(&opts.projectID, "project-id", "", "ID of the project to which the field belongs to")
 	editItemCmd.Flags().StringVar(&opts.text, "text", "", "Text value for the field")
-	editItemCmd.Flags().Float32Var(&opts.number, "number", 0, "Number value for the field")
+	editItemCmd.Flags().Float64Var(&opts.number, "number", 0, "Number value for the field")
 	editItemCmd.Flags().StringVar(&opts.date, "date", "", "Date value for the field (YYYY-MM-DD)")
 	editItemCmd.Flags().StringVar(&opts.singleSelectOptionID, "single-select-option-id", "", "ID of the single select option value to set on the field")
 	editItemCmd.Flags().StringVar(&opts.iterationID, "iteration-id", "", "ID of the iteration value to set on the field")

--- a/pkg/cmd/project/item-edit/item_edit_test.go
+++ b/pkg/cmd/project/item-edit/item_edit_test.go
@@ -48,6 +48,14 @@ func TestNewCmdeditItem(t *testing.T) {
 			},
 		},
 		{
+			name: "number with floating point value",
+			cli:  "--number 123.45 --id 123",
+			wants: editItemOpts{
+				number: 123.45,
+				itemID: "123",
+			},
+		},
+		{
 			name: "field-id",
 			cli:  "--field-id FIELD_ID --id 123",
 			wants: editItemOpts{
@@ -255,7 +263,7 @@ func TestRunItemEdit_Number(t *testing.T) {
 	// edit item
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"number":2}}}}`).
+		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"number":123.45}}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -284,7 +292,7 @@ func TestRunItemEdit_Number(t *testing.T) {
 	config := editItemConfig{
 		io: ios,
 		opts: editItemOpts{
-			number:    2,
+			number:    123.45,
 			itemID:    "item_id",
 			projectID: "project_id",
 			fieldID:   "field_id",

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -250,7 +250,7 @@ type FieldValueNodes struct {
 		Field ProjectField
 	} `graphql:"... on ProjectV2ItemFieldLabelValue"`
 	ProjectV2ItemFieldNumberValue struct {
-		Number float32
+		Number float64
 		Field  ProjectField
 	} `graphql:"... on ProjectV2ItemFieldNumberValue"`
 	ProjectV2ItemFieldSingleSelectValue struct {


### PR DESCRIPTION
Fixes #10342.

```shell
# number (float32)
$ gh project item-edit --project-id $projectId --id $itemId --field-id $fieldId --number 69.84
GraphQL: Number values cannot exceed 8 decimal places (updateProjectV2ItemFieldValue)

# number (float64)
$ bin/gh project item-edit --project-id $projectId --id $itemId --field-id $fieldId --number 69.84
Edited item "Test"
```