### PR TITLE
Docs: Clarify guidelines for `help wanted` issues and pull requests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,23 +4,25 @@ Hi! Thanks for your interest in contributing to the GitHub CLI!
 
 We accept pull requests for bug fixes and features where we've discussed the approach in an issue and given the go-ahead for a community member to work on it. We'd also love to hear about ideas for new features as issues.
 
-Please do:
+### Please do:
 
-* Check issues to verify that a [bug][bug issues] or [feature request][feature request issues] issue does not already exist for the same problem or feature.
-* Open an issue if things aren't working as expected.
-* Open an issue to propose a significant change.
-* Open an issue to propose a design for an issue labelled [`needs-design` and `help wanted`][needs design and help wanted], following the [proposing a design guidelines](#proposing-a-design) instructions below.
-* Open a pull request to fix a bug.
-* Open a pull request to fix documentation about a command.
-* Open a pull request for any issue labelled [`help wanted`][hw] or [`good first issue`][gfi].
+* Check issues to verify that a [bug][bug issues] or [feature request][feature request issues] issue does not already exist for the same problem or feature
+* Open an issue if things aren't working as expected
+* Open an issue to propose a significant change
+* Open an issue to propose a design for an issue labelled [`needs-design` and `help wanted`][needs design and help wanted], following the [proposing a design guidelines](#proposing-a-design) instructions below
+* Mention `@cli/code-reviewers` when an issue you want to work on does not have clear Acceptance Criteria
+* Open a pull request to fix a bug
+* Open a pull request to fix documentation about a command
+* Open a pull request for any issue labelled [`help wanted`][hw] or [`good first issue`][gfi]
 
-Please avoid:
+### Please _do not_:
 
-* Opening pull requests for issues marked `needs-design`, `needs-investigation`, or `blocked`.
-* Opening pull requests that haven't been approved for work in an issue
-* Adding installation instructions specifically for your OS/package manager.
-* Opening pull requests for any issue marked `core`. These issues require additional context from
-  the core CLI team at GitHub and any external pull requests will not be accepted.
+* Open pull requests for issues marked `needs-design`, `needs-investigation`, or `blocked`
+* Open pull requests that haven't been approved for work in an issue
+* Expand pull request scope to include changes that are not described in the issue's Acceptance Criteria
+* Add installation instructions specifically for your OS/package manager
+* Open pull requests for any issue marked `core`. These issues require additional context from
+  the core CLI team at GitHub and any external pull requests will not be accepted
 
 ## Building the project
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,8 +15,7 @@ We accept pull requests for bug fixes and features where we've discussed the app
 
 ### Please _do not_:
 
-* Open pull requests for issues marked `needs-design`, `needs-investigation`, or `blocked`
-* Open pull requests that haven't been approved for work in an issue
+* Open a pull request for issues without the `help wanted` label or explicit Acceptance Criteria
 * Expand pull request scope to include changes that are not described in the issue's Acceptance Criteria
 * Add installation instructions specifically for your OS/package manager
 * Open pull requests for any issue marked `core`. These issues require additional context from

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,8 +11,6 @@ We accept pull requests for bug fixes and features where we've discussed the app
 * Open an issue to propose a significant change
 * Open an issue to propose a design for an issue labelled [`needs-design` and `help wanted`][needs design and help wanted], following the [proposing a design guidelines](#proposing-a-design) instructions below
 * Mention `@cli/code-reviewers` when an issue you want to work on does not have clear Acceptance Criteria
-* Open a pull request to fix a bug
-* Open a pull request to fix documentation about a command
 * Open a pull request for any issue labelled [`help wanted`][hw] or [`good first issue`][gfi]
 
 ### Please _do not_:


### PR DESCRIPTION
This PR adds this note to the "please do" section:

> Mention `@cli/code-reviewers` when an issue you want to work on does not have clear Acceptance Criteria

and this note to the "please do not" section:

> Expand pull request scope to include changes that are not described in the issue's Acceptance Criteria

Also includes other misc formatting changes:

- Fix inconsistency with some bullet points ending with periods and some not
- Make "Please do" and "Please do not" level 3 headings for readability
- Match verb tense between "Please do" and "Please do not"  section lists
- Remove some redundant points and collapse some related points for conciseness 
 