### PR TITLE
[gh pr status] Mention `gh pr checks` in the `Long` section

### DIFF
--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	ghContext "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
@@ -51,7 +52,15 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show status of relevant pull requests",
-		Args:  cmdutil.NoArgsQuoteReminder,
+		Long: heredoc.Docf(`
+			Show status of relevant pull requests.
+
+			The status shows a summary of PRs that includes information such as
+			PR number, title, CI checks, reviews, etc.
+
+			For the details of CI checks, run %[1]sgh pr checks%[1]s.
+		`, "`"),
+		Args: cmdutil.NoArgsQuoteReminder,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -55,8 +55,8 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 		Long: heredoc.Docf(`
 			Show status of relevant pull requests.
 
-			The status shows a summary of PRs that includes information such as
-			PR number, title, CI checks, reviews, etc.
+			The status shows a summary of pull requests that includes information such as
+			pull request number, title, CI checks, reviews, etc.
 
 			To see more details of CI checks, run %[1]sgh pr checks%[1]s.
 		`, "`"),

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -58,7 +58,7 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 			The status shows a summary of PRs that includes information such as
 			PR number, title, CI checks, reviews, etc.
 
-			For the details of CI checks, run %[1]sgh pr checks%[1]s.
+			To see more details of CI checks, run %[1]sgh pr checks%[1]s.
 		`, "`"),
 		Args: cmdutil.NoArgsQuoteReminder,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Fixes #1807.

```shell
$ bin/gh pr status --help
Show status of relevant pull requests.

The status shows a summary of PRs that includes information such as
PR number, title, CI checks, reviews, etc.

To see more details of CI checks, run `gh pr checks`.

...
```