### PR TITLE
test: Verify default repo setting

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -1086,3 +1086,4 @@ func requestableReviewersForCompletion(opts *CreateOptions) ([]string, error) {
 }
 
 var gitPushRegexp = regexp.MustCompile("^remote: (Create a pull request.*by visiting|[[:space:]]*https://.*/pull/new/).*\n?$")
+// Test change made on Sun Feb  9 18:29:08 +08 2025


### PR DESCRIPTION
This is a test PR to verify that the default repository is set correctly when creating PRs from forks.