### PR TITLE
Exit with error if no matching predicate type exists

### DIFF
--- a/pkg/cmd/attestation/verify/verify.go
+++ b/pkg/cmd/attestation/verify/verify.go
@@ -236,7 +236,7 @@ func runVerify(opts *Options) error {
 	filteredAttestations := verification.FilterAttestations(ec.PredicateType, attestations)
 	if len(filteredAttestations) == 0 {
 		opts.Logger.Printf(opts.Logger.ColorScheme.Red("✗ No attestations found with predicate type: %s\n"), opts.PredicateType)
-		return err
+		return fmt.Errorf("no matching predicate found")
 	}
 	attestations = filteredAttestations
 

--- a/pkg/cmd/attestation/verify/verify_test.go
+++ b/pkg/cmd/attestation/verify/verify_test.go
@@ -501,6 +501,18 @@ func TestRunVerify(t *testing.T) {
 		require.Nil(t, runVerify(&customOpts))
 	})
 
+	t.Run("with valid OCI artifact with UseBundleFromRegistry flag and unknown predicate type", func(t *testing.T) {
+		customOpts := publicGoodOpts
+		customOpts.ArtifactPath = "oci://ghcr.io/github/test"
+		customOpts.BundlePath = ""
+		customOpts.UseBundleFromRegistry = true
+		customOpts.PredicateType = "https://predicate.type"
+
+		err := runVerify(&customOpts)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no matching predicate found")
+	})
+
 	t.Run("with valid OCI artifact with UseBundleFromRegistry flag but no bundle return from registry", func(t *testing.T) {
 		customOpts := publicGoodOpts
 		customOpts.ArtifactPath = "oci://ghcr.io/github/test"


### PR DESCRIPTION
The check for number of predicates found is correct, but if none was found, it returned `err` (uninitialized). Now the function returns a proper error, and I added a unit tests for this to prevent regressions.

closes https://github.com/cli/cli/issues/10418
