### PR TITLE
update default upstream when forking repo during PR creation

### DIFF
--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -798,6 +798,7 @@ func Test_createRun(t *testing.T) {
 				cs.Register("git remote rename origin upstream", 0, "")
 				cs.Register(`git remote add origin https://github.com/monalisa/REPO.git`, 0, "")
 				cs.Register(`git push --set-upstream origin HEAD:refs/heads/feature`, 0, "")
+				cs.Register(`git config --add remote.upstream.gh-resolved base`, 0, "")
 			},
 			promptStubs: func(pm *prompter.PrompterMock) {
 				pm.SelectFunc = func(p, _ string, opts []string) (int, error) {
@@ -809,7 +810,7 @@ func Test_createRun(t *testing.T) {
 				}
 			},
 			expectedOut:    "https://github.com/OWNER/REPO/pull/12\n",
-			expectedErrOut: "\nCreating pull request for monalisa:feature into master in OWNER/REPO\n\nChanged OWNER/REPO remote to \"upstream\"\nAdded monalisa/REPO as remote \"origin\"\n",
+			expectedErrOut: "\nCreating pull request for monalisa:feature into master in OWNER/REPO\n\nChanged OWNER/REPO remote to \"upstream\"\nAdded monalisa/REPO as remote \"origin\"\n! Repository monalisa/REPO set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n",
 		},
 		{
 			name: "pushed to non base repo",


### PR DESCRIPTION
This PR updates the behaviour to set the default upstream when forking a repo during PR creation. It ensures that the behaviour when performing a fork during PR creation remains consistent with `gh repo fork`.

Closes #10277

This bash script can be used to verify these changes: 
```bash
#!/bin/bash
set -e

# Configuration
UPSTREAM_REPO="BagToad/testing-public-1"
GITHUB_HOST="github.com"
GH_BIN="/Users/davidlivingston/Work/cli/bin/gh" # update with your own path

# Function to cleanup on exit or error
cleanup() {
    local exit_code=$?
    echo "Performing cleanup..."
    
    # Clean up local directory
    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
        echo "Removing local test directory..."
        rm -rf "$TEST_DIR"
    fi

    # Delete fork if it exists
    if [ -n "$FORK_EXISTS" ]; then
        echo "Deleting forked repository..."
        if "$GH_BIN" repo delete "$FORK_OWNER/$FORK_NAME" --confirm; then
            echo "Successfully deleted fork"
        else
            echo "Failed to delete fork"
            exit 1
        fi
    fi

    exit $exit_code
}

# Set up cleanup trap
trap cleanup EXIT

# Get the authenticated user
FORK_OWNER=$("$GH_BIN" api user -q .login)
FORK_NAME="testing-public-1"
echo "Authenticated as: $FORK_OWNER"

# Check if fork already exists
if "$GH_BIN" repo view "$FORK_OWNER/$FORK_NAME" &>/dev/null; then
    echo "Fork already exists at $FORK_OWNER/$FORK_NAME"
    echo "Please delete it first or use a different test account"
    exit 1
fi

# Test setup
echo "Setting up test environment..."

# Create a new directory for testing
TEST_DIR=$(mktemp -d)
cd "$TEST_DIR"
echo "Working in temporary directory: $TEST_DIR"

# Clone the CLI repository
echo "Cloning github.com/$UPSTREAM_REPO..."
git clone "https://$GITHUB_HOST/$UPSTREAM_REPO.git"
cd testing-public-1

# Create a test branch
TEST_BRANCH="test-default-repo-$(date +%s)"
git checkout -b "$TEST_BRANCH"

# Make a small change
echo "Making test changes..."
DATE_COMMENT="// Test change made on $(date)"
echo "$DATE_COMMENT" >> README.md

git add README.md
git commit -m "test: Add date comment for testing default repo setting"

# Create PR using gh CLI
echo "Creating pull request..."
GH_DEBUG=api "$GH_BIN" pr create \
    --title "test: Verify default repo setting" \
    --body "This is a test PR to verify that the default repository is set correctly when creating PRs from forks."

# Mark that fork exists for cleanup
FORK_EXISTS=1

TEST_BRANCH="test-default-repo-$(date +%s)-2"
git checkout -b "$TEST_BRANCH"

# Make a small change
echo "Making test changes..."
DATE_COMMENT="// Test change made on $(date)"
echo "$DATE_COMMENT" >> README.md

git add README.md
git commit -m "test: Add date comment for testing default repo setting"

# Create PR using ghCLI
echo "Creating pull request..."
GH_DEBUG=api "$GH_BIN" pr create \
    --title "test: Verify default repo setting 2" \
    --body "This is a test PR 2 to verify that the default repository is set correctly when creating PRs from forks."

echo "Verifying default repository setting..."

# First list all remotes and configs for debugging
echo "Current remotes:"
git remote -v

# Now check the gh-resolved setting
DEFAULT_REPO=$(git config --get remote.upstream.gh-resolved || echo "not set")
echo "Default repository setting: $DEFAULT_REPO"

if [ "$DEFAULT_REPO" = "base" ]; then
    echo "✅ Success: Default repository was set correctly"
else
    echo "❌ Error: Default repository was not set correctly. Upstream remote exists but gh-resolved setting is missing."
    exit 1
fi

echo "Test completed successfully"
```
