### PR TITLE
Use subtests in attestation verification integration tests

### DIFF
--- a/pkg/cmd/attestation/verification/sigstore_integration_test.go
+++ b/pkg/cmd/attestation/verification/sigstore_integration_test.go
@@ -48,20 +48,22 @@ func TestLiveSigstoreVerifier(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		verifier := NewLiveSigstoreVerifier(SigstoreConfig{
-			Logger: io.NewTestHandler(),
+		t.Run(tc.name, func(t *testing.T) {
+			verifier := NewLiveSigstoreVerifier(SigstoreConfig{
+				Logger: io.NewTestHandler(),
+			})
+
+			results, err := verifier.Verify(tc.attestations, publicGoodPolicy(t))
+
+			if tc.expectErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.errContains)
+				require.Nil(t, results)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, len(tc.attestations), len(results))
+			}
 		})
-
-		results, err := verifier.Verify(tc.attestations, publicGoodPolicy(t))
-
-		if tc.expectErr {
-			require.Error(t, err, "test case: %s", tc.name)
-			require.ErrorContains(t, err, tc.errContains, "test case: %s", tc.name)
-			require.Nil(t, results, "test case: %s", tc.name)
-		} else {
-			require.Equal(t, len(tc.attestations), len(results), "test case: %s", tc.name)
-			require.NoError(t, err, "test case: %s", tc.name)
-		}
 	}
 
 	t.Run("with 2/3 verified attestations", func(t *testing.T) {


### PR DESCRIPTION
## Description

These tests look like they should be subtests, avoiding the need for manual instrumentation of test names.

No associated issue because this should be a minor change with no UX impact.

```
➜  go test -v -tags=integration ./pkg/cmd/attestation/verification -count 1

=== RUN   TestLoadBundlesFromJSONLinesFile
=== RUN   TestLoadBundlesFromJSONLinesFile/with_original_file
=== RUN   TestLoadBundlesFromJSONLinesFile/with_extra_lines
--- PASS: TestLoadBundlesFromJSONLinesFile (0.01s)
    --- PASS: TestLoadBundlesFromJSONLinesFile/with_original_file (0.01s)
    --- PASS: TestLoadBundlesFromJSONLinesFile/with_extra_lines (0.01s)
=== RUN   TestLoadBundlesFromJSONLinesFile_RejectEmptyJSONLFile
--- PASS: TestLoadBundlesFromJSONLinesFile_RejectEmptyJSONLFile (0.00s)
=== RUN   TestLoadBundleFromJSONFile
--- PASS: TestLoadBundleFromJSONFile (0.00s)
=== RUN   TestGetLocalAttestations
=== RUN   TestGetLocalAttestations/with_JSON_file_containing_one_bundle
=== RUN   TestGetLocalAttestations/with_JSON_lines_file_containing_multiple_bundles
=== RUN   TestGetLocalAttestations/with_file_with_unrecognized_extension
=== RUN   TestGetLocalAttestations/with_non-existent_bundle_file_and_JSON_file
=== RUN   TestGetLocalAttestations/with_non-existent_bundle_file_and_JSON_lines_file
=== RUN   TestGetLocalAttestations/with_missing_verification_material
=== RUN   TestGetLocalAttestations/with_missing_verification_certificate
--- PASS: TestGetLocalAttestations (0.01s)
    --- PASS: TestGetLocalAttestations/with_JSON_file_containing_one_bundle (0.00s)
    --- PASS: TestGetLocalAttestations/with_JSON_lines_file_containing_multiple_bundles (0.00s)
    --- PASS: TestGetLocalAttestations/with_file_with_unrecognized_extension (0.00s)
    --- PASS: TestGetLocalAttestations/with_non-existent_bundle_file_and_JSON_file (0.00s)
    --- PASS: TestGetLocalAttestations/with_non-existent_bundle_file_and_JSON_lines_file (0.00s)
    --- PASS: TestGetLocalAttestations/with_missing_verification_material (0.00s)
    --- PASS: TestGetLocalAttestations/with_missing_verification_certificate (0.00s)
=== RUN   TestFilterAttestations
--- PASS: TestFilterAttestations (0.00s)
=== RUN   TestVerifyCertExtensions
=== RUN   TestVerifyCertExtensions/passes_with_one_result
=== RUN   TestVerifyCertExtensions/passes_with_1/2_valid_results
=== RUN   TestVerifyCertExtensions/fails_when_all_results_fail_verification
=== RUN   TestVerifyCertExtensions/with_wrong_SourceRepositoryOwnerURI
=== RUN   TestVerifyCertExtensions/with_wrong_SourceRepositoryURI
=== RUN   TestVerifyCertExtensions/with_wrong_OIDCIssuer
=== RUN   TestVerifyCertExtensions/with_partial_OIDCIssuer_match
--- PASS: TestVerifyCertExtensions (0.00s)
    --- PASS: TestVerifyCertExtensions/passes_with_one_result (0.00s)
    --- PASS: TestVerifyCertExtensions/passes_with_1/2_valid_results (0.00s)
    --- PASS: TestVerifyCertExtensions/fails_when_all_results_fail_verification (0.00s)
    --- PASS: TestVerifyCertExtensions/with_wrong_SourceRepositoryOwnerURI (0.00s)
    --- PASS: TestVerifyCertExtensions/with_wrong_SourceRepositoryURI (0.00s)
    --- PASS: TestVerifyCertExtensions/with_wrong_OIDCIssuer (0.00s)
    --- PASS: TestVerifyCertExtensions/with_partial_OIDCIssuer_match (0.00s)
=== RUN   TestLiveSigstoreVerifier
=== RUN   TestLiveSigstoreVerifier/with_invalid_signature
=== RUN   TestLiveSigstoreVerifier/with_valid_artifact_and_JSON_lines_file_containing_multiple_Sigstore_bundles
=== RUN   TestLiveSigstoreVerifier/with_invalid_bundle_version
=== RUN   TestLiveSigstoreVerifier/with_no_attestations
=== RUN   TestLiveSigstoreVerifier/with_2/3_verified_attestations
=== RUN   TestLiveSigstoreVerifier/fail_with_0/2_verified_attestations
=== RUN   TestLiveSigstoreVerifier/with_GitHub_Sigstore_artifact
=== RUN   TestLiveSigstoreVerifier/with_custom_trusted_root
--- PASS: TestLiveSigstoreVerifier (2.21s)
    --- PASS: TestLiveSigstoreVerifier/with_invalid_signature (0.46s)
    --- PASS: TestLiveSigstoreVerifier/with_valid_artifact_and_JSON_lines_file_containing_multiple_Sigstore_bundles (0.69s)
    --- PASS: TestLiveSigstoreVerifier/with_invalid_bundle_version (0.00s)
    --- PASS: TestLiveSigstoreVerifier/with_no_attestations (0.00s)
    --- PASS: TestLiveSigstoreVerifier/with_2/3_verified_attestations (0.68s)
    --- PASS: TestLiveSigstoreVerifier/fail_with_0/2_verified_attestations (0.32s)
    --- PASS: TestLiveSigstoreVerifier/with_GitHub_Sigstore_artifact (0.03s)
    --- PASS: TestLiveSigstoreVerifier/with_custom_trusted_root (0.02s)
=== RUN   TestGitHubTUFOptions
--- PASS: TestGitHubTUFOptions (0.00s)
PASS
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verification  2.536s
```