### PR TITLE
Add SigstoreVerifier unit tests with mocked `sigstore-go/SignedEntityVerifier`

### DIFF
--- a/pkg/cmd/attestation/verification/mock_verifier.go
+++ b/pkg/cmd/attestation/verification/mock_verifier.go
@@ -124,7 +124,7 @@ func (v *failAfterNCallsVerifier) Verify(entity verify.SignedEntity, pb verify.P
 	}
 	v.numCalls++
 	return &verify.VerificationResult{
-		MediaType: "dfsdfsd",
+		MediaType: "application/vnd.dev.sigstore.bundle+json;version=0.2",
 	}, nil
 }
 
@@ -166,22 +166,4 @@ func newVerifierWithFailAfterNCallsVerifier(failAfterNCalls int) *LiveSigstoreVe
 		return failVerifier, nil
 	}
 	return verifier
-}
-
-type VerifierWithMockSignedEntityVerifier struct {
-	LiveSigstoreVerifier
-	//Sev SignedEntityVerifier
-}
-
-func (v *VerifierWithMockSignedEntityVerifier) ChooseVerifier(issuer string) (SignedEntityVerifier, error) {
-	return &MockSignedEntityVerifier{}, nil
-}
-
-type VerifierWithFailSignedEntityVerifier struct {
-	LiveSigstoreVerifier
-	//Sev SignedEntityVerifier
-}
-
-func (v *VerifierWithFailSignedEntityVerifier) ChooseVerifier(issuer string) (SignedEntityVerifier, error) {
-	return &FailSignedEntityVerifier{}, nil
 }

--- a/pkg/cmd/attestation/verification/mock_verifier.go
+++ b/pkg/cmd/attestation/verification/mock_verifier.go
@@ -138,7 +138,7 @@ func newVerifierWithMockEntityVerifier() *LiveSigstoreVerifier {
 	verifier := NewLiveSigstoreVerifier(SigstoreConfig{
 		Logger: io.NewTestHandler(),
 	})
-	verifier.ChooseVerifier = func(issuer string) (SignedEntityVerifier, error) {
+	verifier.chooseVerifier = func(issuer string) (SignedEntityVerifier, error) {
 		return &MockSignedEntityVerifier{}, nil
 	}
 	return verifier
@@ -148,7 +148,7 @@ func newVerifierWithFailEntityVerifier() *LiveSigstoreVerifier {
 	verifier := NewLiveSigstoreVerifier(SigstoreConfig{
 		Logger: io.NewTestHandler(),
 	})
-	verifier.ChooseVerifier = func(issuer string) (SignedEntityVerifier, error) {
+	verifier.chooseVerifier = func(issuer string) (SignedEntityVerifier, error) {
 		return &FailSignedEntityVerifier{}, nil
 	}
 	return verifier
@@ -162,7 +162,7 @@ func newVerifierWithFailAfterNCallsVerifier(failAfterNCalls int) *LiveSigstoreVe
 	failVerifier := &failAfterNCallsVerifier{
 		failAfterNCalls: failAfterNCalls,
 	}
-	verifier.ChooseVerifier = func(issuer string) (SignedEntityVerifier, error) {
+	verifier.chooseVerifier = func(issuer string) (SignedEntityVerifier, error) {
 		return failVerifier, nil
 	}
 	return verifier

--- a/pkg/cmd/attestation/verification/sigstore.go
+++ b/pkg/cmd/attestation/verification/sigstore.go
@@ -36,6 +36,8 @@ type SigstoreConfig struct {
 	TrustDomain string
 }
 
+// SignedEntityVerifier is an interface for verifying individual attestations
+// against a trusted root
 type SignedEntityVerifier interface {
 	Verify(entity verify.SignedEntity, pb verify.PolicyBuilder) (*verify.VerificationResult, error)
 }

--- a/pkg/cmd/attestation/verification/sigstore.go
+++ b/pkg/cmd/attestation/verification/sigstore.go
@@ -47,9 +47,12 @@ type SigstoreVerifier interface {
 }
 
 type LiveSigstoreVerifier struct {
-	TrustedRoot    string
-	Logger         *io.Handler
-	NoPublicGood   bool
+	TrustedRoot  string
+	Logger       *io.Handler
+	NoPublicGood bool
+	// because the signed entity verifier is determined for individual
+	// attestations, we need to be able to switch out the verifier
+	// for testing every time an attestation is verified
 	chooseVerifier func(issuer string) (SignedEntityVerifier, error)
 	// If tenancy mode is not used, trust domain is empty
 	TrustDomain string

--- a/pkg/cmd/attestation/verification/sigstore.go
+++ b/pkg/cmd/attestation/verification/sigstore.go
@@ -50,7 +50,7 @@ type LiveSigstoreVerifier struct {
 	TrustedRoot    string
 	Logger         *io.Handler
 	NoPublicGood   bool
-	ChooseVerifier func(issuer string) (SignedEntityVerifier, error)
+	chooseVerifier func(issuer string) (SignedEntityVerifier, error)
 	// If tenancy mode is not used, trust domain is empty
 	TrustDomain string
 }
@@ -66,8 +66,8 @@ func NewLiveSigstoreVerifier(config SigstoreConfig) *LiveSigstoreVerifier {
 		Logger:       config.Logger,
 		NoPublicGood: config.NoPublicGood,
 		TrustDomain:  config.TrustDomain,
-		ChooseVerifier: func(issuer string) (SignedEntityVerifier, error) {
-			return ChooseLiveVerifier(config.NoPublicGood, issuer, config.TrustedRoot, config.TrustDomain)
+		chooseVerifier: func(issuer string) (SignedEntityVerifier, error) {
+			return chooseLiveVerifier(config.NoPublicGood, issuer, config.TrustedRoot, config.TrustDomain)
 		},
 	}
 }
@@ -90,7 +90,7 @@ func getBundleIssuer(b *bundle.Bundle) (string, error) {
 	return leafCert.Issuer.Organization[0], nil
 }
 
-func ChooseLiveVerifier(noPublicGood bool, issuer, trustedRoot, trustDomain string) (SignedEntityVerifier, error) {
+func chooseLiveVerifier(noPublicGood bool, issuer, trustedRoot, trustDomain string) (SignedEntityVerifier, error) {
 	// if no custom trusted root is set, attempt to create a Public Good or
 	// GitHub Sigstore verifier
 	if trustedRoot == "" {
@@ -180,7 +180,7 @@ func (v *LiveSigstoreVerifier) verify(attestation *api.Attestation, policy verif
 	}
 
 	// determine which verifier should attempt verification against the bundle
-	verifier, err := v.ChooseVerifier(issuer)
+	verifier, err := v.chooseVerifier(issuer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find recognized issuer from bundle content: %v", err)
 	}

--- a/pkg/cmd/attestation/verification/sigstore.go
+++ b/pkg/cmd/attestation/verification/sigstore.go
@@ -47,15 +47,11 @@ type SigstoreVerifier interface {
 }
 
 type LiveSigstoreVerifier struct {
-	TrustedRoot  string
-	Logger       *io.Handler
-	NoPublicGood bool
+	Logger *io.Handler
 	// because the signed entity verifier is determined for individual
 	// attestations, we need to be able to switch out the verifier
 	// for testing every time an attestation is verified
 	chooseVerifier func(issuer string) (SignedEntityVerifier, error)
-	// If tenancy mode is not used, trust domain is empty
-	TrustDomain string
 }
 
 var ErrNoAttestationsVerified = errors.New("no attestations were verified")
@@ -65,10 +61,7 @@ var ErrNoAttestationsVerified = errors.New("no attestations were verified")
 // Public Good, GitHub, or a custom trusted root.
 func NewLiveSigstoreVerifier(config SigstoreConfig) *LiveSigstoreVerifier {
 	return &LiveSigstoreVerifier{
-		TrustedRoot:  config.TrustedRoot,
-		Logger:       config.Logger,
-		NoPublicGood: config.NoPublicGood,
-		TrustDomain:  config.TrustDomain,
+		Logger: config.Logger,
 		chooseVerifier: func(issuer string) (SignedEntityVerifier, error) {
 			return chooseLiveVerifier(config.NoPublicGood, issuer, config.TrustedRoot, config.TrustDomain)
 		},

--- a/pkg/cmd/attestation/verification/sigstore_test.go
+++ b/pkg/cmd/attestation/verification/sigstore_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,8 +17,8 @@ func TestSigstoreVerifier(t *testing.T) {
 		require.Len(t, attestations, 3)
 
 		results, err := verifier.Verify(attestations, PublicGoodPolicy(t))
-		assert.NoError(t, err)
-		assert.Len(t, results, 2)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
 	})
 
 	t.Run("with 2/3 verified attestations - sigstore verification failed", func(t *testing.T) {
@@ -30,8 +29,8 @@ func TestSigstoreVerifier(t *testing.T) {
 		require.Len(t, attestations, 3)
 
 		results, err := verifier.Verify(attestations, PublicGoodPolicy(t))
-		assert.NoError(t, err)
-		assert.Len(t, results, 2)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
 	})
 
 	t.Run("fail with 0/2 verified attestations", func(t *testing.T) {
@@ -41,7 +40,7 @@ func TestSigstoreVerifier(t *testing.T) {
 		require.Len(t, attestations, 2)
 
 		results, err := verifier.Verify(attestations, PublicGoodPolicy(t))
-		assert.Error(t, err)
-		assert.Nil(t, results)
+		require.Error(t, err)
+		require.Nil(t, results)
 	})
 }

--- a/pkg/cmd/attestation/verification/sigstore_test.go
+++ b/pkg/cmd/attestation/verification/sigstore_test.go
@@ -1,89 +1,35 @@
-//go:build integration
-
 package verification
 
 import (
 	"testing"
 
-	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
-
 	"github.com/stretchr/testify/require"
 )
 
 func TestSigstoreVerifier(t *testing.T) {
-	type testcase struct {
-		name         string
-		attestations []*api.Attestation
-		expectErr    bool
-		errContains  string
-	}
-
-	testcases := []testcase{
-		{
-			name:         "with invalid signature",
-			attestations: getAttestationsFor(t, "../test/data/sigstoreBundle-invalid-signature.json"),
-			expectErr:    true,
-			errContains:  "verifying with issuer \"sigstore.dev\"",
-		},
-		{
-			name:         "with valid artifact and JSON lines file containing multiple Sigstore bundles",
-			attestations: getAttestationsFor(t, "../test/data/sigstore-js-2.1.0_with_2_bundles.jsonl"),
-		},
-		{
-			name:         "with invalid bundle version",
-			attestations: getAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json"),
-			expectErr:    true,
-			errContains:  "unsupported bundle version",
-		},
-		{
-			name:         "with no attestations",
-			attestations: []*api.Attestation{},
-			expectErr:    true,
-			errContains:  "no attestations were verified",
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			verifier := NewMockSigstoreVerifier(t)
-
-			results, err := verifier.Verify(tc.attestations, publicGoodPolicy(t))
-
-			if tc.expectErr {
-				require.Error(t, err)
-				require.ErrorContains(t, err, tc.errContains)
-				require.Nil(t, results)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, len(tc.attestations), len(results))
-			}
-		})
-	}
-
 	t.Run("with 2/3 verified attestations", func(t *testing.T) {
-		verifier := NewMockSigstoreVerifier(t)
+		verifier := newVerifierWithMockEntityVerifier()
 
-		invalidBundle := getAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json")
-		attestations := getAttestationsFor(t, "../test/data/sigstore-js-2.1.0_with_2_bundles.jsonl")
+		invalidBundle := GetAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json")
+		attestations := GetAttestationsFor(t, "../test/data/sigstore-js-2.1.0_with_2_bundles.jsonl")
 		attestations = append(attestations, invalidBundle[0])
 		require.Len(t, attestations, 3)
 
-		results, err := verifier.Verify(attestations, publicGoodPolicy(t))
-
-		require.Len(t, results, 2)
+		results, err := verifier.Verify(attestations, PublicGoodPolicy(t))
 		require.NoError(t, err)
+		require.Len(t, results, 2)
 	})
 
 	t.Run("fail with 0/2 verified attestations", func(t *testing.T) {
-		verifier := NewMockSigstoreVerifier(t)
+		verifier := newVerifierWithMockEntityVerifier()
 
-		invalidBundle := getAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json")
-		attestations := getAttestationsFor(t, "../test/data/sigstoreBundle-invalid-signature.json")
+		invalidBundle := GetAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json")
+		attestations := GetAttestationsFor(t, "../test/data/sigstoreBundle-invalid-signature.json")
 		attestations = append(attestations, invalidBundle[0])
 		require.Len(t, attestations, 2)
 
-		results, err := verifier.Verify(attestations, publicGoodPolicy(t))
-		require.Nil(t, results)
+		results, err := verifier.Verify(attestations, PublicGoodPolicy(t))
 		require.Error(t, err)
+		require.Nil(t, results)
 	})
 }

--- a/pkg/cmd/attestation/verification/sigstore_test.go
+++ b/pkg/cmd/attestation/verification/sigstore_test.go
@@ -3,6 +3,7 @@ package verification
 import (
 	"testing"
 
+	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,15 +22,16 @@ func TestSigstoreVerifier(t *testing.T) {
 		assert.Len(t, results, 2)
 	})
 
-	t.Run("with 1/2 verified attestations - sigstore verification failed", func(t *testing.T) {
-		verifier := newVerifierWithFailAfterNCallsVerifier(1)
+	t.Run("with 2/3 verified attestations - sigstore verification failed", func(t *testing.T) {
+		verifier := newVerifierWithFailAfterNCallsVerifier(2)
 
-		attestations := GetAttestationsFor(t, "../test/data/sigstore-js-2.1.0_with_2_bundles.jsonl")
-		require.Len(t, attestations, 2)
+		bundles := GetAttestationsFor(t, "../test/data/sigstore-js-2.1.0_with_2_bundles.jsonl")
+		attestations := []*api.Attestation{bundles[0], bundles[1], bundles[0]}
+		require.Len(t, attestations, 3)
 
 		results, err := verifier.Verify(attestations, PublicGoodPolicy(t))
 		assert.NoError(t, err)
-		assert.Len(t, results, 1)
+		assert.Len(t, results, 2)
 	})
 
 	t.Run("fail with 0/2 verified attestations", func(t *testing.T) {

--- a/pkg/cmd/attestation/verification/sigstore_test.go
+++ b/pkg/cmd/attestation/verification/sigstore_test.go
@@ -3,11 +3,12 @@ package verification
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSigstoreVerifier(t *testing.T) {
-	t.Run("with 2/3 verified attestations", func(t *testing.T) {
+	t.Run("with 2/3 verified attestations - unsupported bundle version", func(t *testing.T) {
 		verifier := newVerifierWithMockEntityVerifier()
 
 		invalidBundle := GetAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json")
@@ -16,20 +17,29 @@ func TestSigstoreVerifier(t *testing.T) {
 		require.Len(t, attestations, 3)
 
 		results, err := verifier.Verify(attestations, PublicGoodPolicy(t))
-		require.NoError(t, err)
-		require.Len(t, results, 2)
+		assert.NoError(t, err)
+		assert.Len(t, results, 2)
 	})
 
-	t.Run("fail with 0/2 verified attestations", func(t *testing.T) {
-		verifier := newVerifierWithMockEntityVerifier()
+	t.Run("with 1/2 verified attestations - sigstore verification failed", func(t *testing.T) {
+		verifier := newVerifierWithFailAfterNCallsVerifier(1)
 
-		invalidBundle := GetAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json")
-		attestations := GetAttestationsFor(t, "../test/data/sigstoreBundle-invalid-signature.json")
-		attestations = append(attestations, invalidBundle[0])
+		attestations := GetAttestationsFor(t, "../test/data/sigstore-js-2.1.0_with_2_bundles.jsonl")
 		require.Len(t, attestations, 2)
 
 		results, err := verifier.Verify(attestations, PublicGoodPolicy(t))
-		require.Error(t, err)
-		require.Nil(t, results)
+		assert.NoError(t, err)
+		assert.Len(t, results, 1)
+	})
+
+	t.Run("fail with 0/2 verified attestations", func(t *testing.T) {
+		verifier := newVerifierWithFailEntityVerifier()
+
+		attestations := GetAttestationsFor(t, "../test/data/sigstore-js-2.1.0_with_2_bundles.jsonl")
+		require.Len(t, attestations, 2)
+
+		results, err := verifier.Verify(attestations, PublicGoodPolicy(t))
+		assert.Error(t, err)
+		assert.Nil(t, results)
 	})
 }

--- a/pkg/cmd/attestation/verification/sigstore_test.go
+++ b/pkg/cmd/attestation/verification/sigstore_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package verification
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSigstoreVerifier(t *testing.T) {
+	type testcase struct {
+		name         string
+		attestations []*api.Attestation
+		expectErr    bool
+		errContains  string
+	}
+
+	testcases := []testcase{
+		{
+			name:         "with invalid signature",
+			attestations: getAttestationsFor(t, "../test/data/sigstoreBundle-invalid-signature.json"),
+			expectErr:    true,
+			errContains:  "verifying with issuer \"sigstore.dev\"",
+		},
+		{
+			name:         "with valid artifact and JSON lines file containing multiple Sigstore bundles",
+			attestations: getAttestationsFor(t, "../test/data/sigstore-js-2.1.0_with_2_bundles.jsonl"),
+		},
+		{
+			name:         "with invalid bundle version",
+			attestations: getAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json"),
+			expectErr:    true,
+			errContains:  "unsupported bundle version",
+		},
+		{
+			name:         "with no attestations",
+			attestations: []*api.Attestation{},
+			expectErr:    true,
+			errContains:  "no attestations were verified",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			verifier := NewMockSigstoreVerifier(t)
+
+			results, err := verifier.Verify(tc.attestations, publicGoodPolicy(t))
+
+			if tc.expectErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.errContains)
+				require.Nil(t, results)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, len(tc.attestations), len(results))
+			}
+		})
+	}
+
+	t.Run("with 2/3 verified attestations", func(t *testing.T) {
+		verifier := NewMockSigstoreVerifier(t)
+
+		invalidBundle := getAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json")
+		attestations := getAttestationsFor(t, "../test/data/sigstore-js-2.1.0_with_2_bundles.jsonl")
+		attestations = append(attestations, invalidBundle[0])
+		require.Len(t, attestations, 3)
+
+		results, err := verifier.Verify(attestations, publicGoodPolicy(t))
+
+		require.Len(t, results, 2)
+		require.NoError(t, err)
+	})
+
+	t.Run("fail with 0/2 verified attestations", func(t *testing.T) {
+		verifier := NewMockSigstoreVerifier(t)
+
+		invalidBundle := getAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json")
+		attestations := getAttestationsFor(t, "../test/data/sigstoreBundle-invalid-signature.json")
+		attestations = append(attestations, invalidBundle[0])
+		require.Len(t, attestations, 2)
+
+		results, err := verifier.Verify(attestations, publicGoodPolicy(t))
+		require.Nil(t, results)
+		require.Error(t, err)
+	})
+}

--- a/pkg/cmd/attestation/verification/test_helpers.go
+++ b/pkg/cmd/attestation/verification/test_helpers.go
@@ -1,0 +1,39 @@
+package verification
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
+	"github.com/cli/cli/v2/pkg/cmd/attestation/artifact"
+	"github.com/cli/cli/v2/pkg/cmd/attestation/test"
+	"github.com/sigstore/sigstore-go/pkg/verify"
+	"github.com/stretchr/testify/require"
+)
+
+func PublicGoodPolicy(t *testing.T) verify.PolicyBuilder {
+	t.Helper()
+
+	artifactPath := test.NormalizeRelativePath("../test/data/sigstore-js-2.1.0.tgz")
+	publicGoodArtifact, err := artifact.NewDigestedArtifact(nil, artifactPath, "sha512")
+	require.NoError(t, err)
+
+	return BuildPolicy(t, *publicGoodArtifact)
+}
+
+func BuildPolicy(t *testing.T, artifact artifact.DigestedArtifact) verify.PolicyBuilder {
+	t.Helper()
+
+	artifactDigestPolicyOption, err := BuildDigestPolicyOption(artifact)
+	require.NoError(t, err)
+
+	return verify.NewPolicy(artifactDigestPolicyOption, verify.WithoutIdentitiesUnsafe())
+}
+
+func GetAttestationsFor(t *testing.T, bundlePath string) []*api.Attestation {
+	t.Helper()
+
+	attestations, err := GetLocalAttestations(bundlePath)
+	require.NoError(t, err)
+
+	return attestations
+}


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

This adds unit tests for the `SigstoreVerfier` that mock the `sigstore-go/SignedEntityVerifier`, which is the actual struct required for integration tests. I am adding these unit tests because I would like to debug the root cause of the ongoing flaky SigstoreVerifier integration tests noted in https://github.com/cli/cli/issues/10390.

If these new unit tests consistently pass, then we know the root cause lies with how this code uses the `SignedEntityVerifier` instead of the surrounding Sigstore verification logic implemented in this package.