### PR TITLE
Allow injection of TUFMetadataDir in tests

### DIFF
--- a/pkg/cmd/attestation/trustedroot/trustedroot.go
+++ b/pkg/cmd/attestation/trustedroot/trustedroot.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cli/cli/v2/pkg/cmd/attestation/io"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/verification"
 	"github.com/cli/cli/v2/pkg/cmdutil"
+	o "github.com/cli/cli/v2/pkg/option"
 	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 
 	"github.com/MakeNowJust/heredoc"
@@ -121,7 +122,7 @@ func getTrustedRoot(makeTUF tufClientInstantiator, opts *Options) error {
 	var tufOptions []tufConfig
 	var defaultTR = "trusted_root.json"
 
-	tufOpt := verification.DefaultOptionsWithCacheSetting()
+	tufOpt := verification.DefaultOptionsWithCacheSetting(o.None[string]())
 	// Disable local caching, so we get up-to-date response from TUF repository
 	tufOpt.CacheValidity = 0
 
@@ -150,7 +151,7 @@ func getTrustedRoot(makeTUF tufClientInstantiator, opts *Options) error {
 			targets:    []string{defaultTR},
 		})
 
-		tufOpt = verification.GitHubTUFOptions()
+		tufOpt = verification.GitHubTUFOptions(o.None[string]())
 		tufOpt.CacheValidity = 0
 		tufOptions = append(tufOptions, tufConfig{
 			tufOptions: tufOpt,

--- a/pkg/cmd/attestation/verification/sigstore_integration_test.go
+++ b/pkg/cmd/attestation/verification/sigstore_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cli/cli/v2/pkg/cmd/attestation/artifact"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/io"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/test"
+	o "github.com/cli/cli/v2/pkg/option"
 
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/stretchr/testify/require"
@@ -50,7 +51,8 @@ func TestLiveSigstoreVerifier(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			verifier := NewLiveSigstoreVerifier(SigstoreConfig{
-				Logger: io.NewTestHandler(),
+				Logger:         io.NewTestHandler(),
+				TUFMetadataDir: o.Some(t.TempDir()),
 			})
 
 			results, err := verifier.Verify(tc.attestations, publicGoodPolicy(t))
@@ -68,7 +70,8 @@ func TestLiveSigstoreVerifier(t *testing.T) {
 
 	t.Run("with 2/3 verified attestations", func(t *testing.T) {
 		verifier := NewLiveSigstoreVerifier(SigstoreConfig{
-			Logger: io.NewTestHandler(),
+			Logger:         io.NewTestHandler(),
+			TUFMetadataDir: o.Some(t.TempDir()),
 		})
 
 		invalidBundle := getAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json")
@@ -84,7 +87,8 @@ func TestLiveSigstoreVerifier(t *testing.T) {
 
 	t.Run("fail with 0/2 verified attestations", func(t *testing.T) {
 		verifier := NewLiveSigstoreVerifier(SigstoreConfig{
-			Logger: io.NewTestHandler(),
+			Logger:         io.NewTestHandler(),
+			TUFMetadataDir: o.Some(t.TempDir()),
 		})
 
 		invalidBundle := getAttestationsFor(t, "../test/data/sigstore-js-2.1.0-bundle-v0.1.json")
@@ -107,7 +111,8 @@ func TestLiveSigstoreVerifier(t *testing.T) {
 		attestations := getAttestationsFor(t, "../test/data/github_provenance_demo-0.0.12-py3-none-any-bundle.jsonl")
 
 		verifier := NewLiveSigstoreVerifier(SigstoreConfig{
-			Logger: io.NewTestHandler(),
+			Logger:         io.NewTestHandler(),
+			TUFMetadataDir: o.Some(t.TempDir()),
 		})
 
 		results, err := verifier.Verify(attestations, githubPolicy)
@@ -119,8 +124,9 @@ func TestLiveSigstoreVerifier(t *testing.T) {
 		attestations := getAttestationsFor(t, "../test/data/sigstore-js-2.1.0_with_2_bundles.jsonl")
 
 		verifier := NewLiveSigstoreVerifier(SigstoreConfig{
-			Logger:      io.NewTestHandler(),
-			TrustedRoot: test.NormalizeRelativePath("../test/data/trusted_root.json"),
+			Logger:         io.NewTestHandler(),
+			TrustedRoot:    test.NormalizeRelativePath("../test/data/trusted_root.json"),
+			TUFMetadataDir: o.Some(t.TempDir()),
 		})
 
 		results, err := verifier.Verify(attestations, publicGoodPolicy(t))

--- a/pkg/cmd/attestation/verification/tuf.go
+++ b/pkg/cmd/attestation/verification/tuf.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	o "github.com/cli/cli/v2/pkg/option"
 	"github.com/cli/go-gh/v2/pkg/config"
 	"github.com/sigstore/sigstore-go/pkg/tuf"
 )
@@ -14,7 +15,7 @@ var githubRoot []byte
 
 const GitHubTUFMirror = "https://tuf-repo.github.com"
 
-func DefaultOptionsWithCacheSetting() *tuf.Options {
+func DefaultOptionsWithCacheSetting(tufMetadataDir o.Option[string]) *tuf.Options {
 	opts := tuf.DefaultOptions()
 
 	// The CODESPACES environment variable will be set to true in a Codespaces workspace
@@ -25,8 +26,8 @@ func DefaultOptionsWithCacheSetting() *tuf.Options {
 		opts.DisableLocalCache = true
 	}
 
-	// Set the cache path to a directory owned by the CLI
-	opts.CachePath = filepath.Join(config.CacheDir(), ".sigstore", "root")
+	// Set the cache path to the provided dir, or a directory owned by the CLI
+	opts.CachePath = tufMetadataDir.UnwrapOr(filepath.Join(config.CacheDir(), ".sigstore", "root"))
 
 	// Allow TUF cache for 1 day
 	opts.CacheValidity = 1
@@ -34,8 +35,8 @@ func DefaultOptionsWithCacheSetting() *tuf.Options {
 	return opts
 }
 
-func GitHubTUFOptions() *tuf.Options {
-	opts := DefaultOptionsWithCacheSetting()
+func GitHubTUFOptions(tufMetadataDir o.Option[string]) *tuf.Options {
+	opts := DefaultOptionsWithCacheSetting(tufMetadataDir)
 
 	opts.Root = githubRoot
 	opts.RepositoryBaseURL = GitHubTUFMirror

--- a/pkg/cmd/attestation/verification/tuf_test.go
+++ b/pkg/cmd/attestation/verification/tuf_test.go
@@ -5,16 +5,22 @@ import (
 	"path/filepath"
 	"testing"
 
+	o "github.com/cli/cli/v2/pkg/option"
 	"github.com/cli/go-gh/v2/pkg/config"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGitHubTUFOptions(t *testing.T) {
+func TestGitHubTUFOptionsNoMetadataDir(t *testing.T) {
 	os.Setenv("CODESPACES", "true")
-	opts := GitHubTUFOptions()
+	opts := GitHubTUFOptions(o.None[string]())
 
 	require.Equal(t, GitHubTUFMirror, opts.RepositoryBaseURL)
 	require.NotNil(t, opts.Root)
 	require.True(t, opts.DisableLocalCache)
 	require.Equal(t, filepath.Join(config.CacheDir(), ".sigstore", "root"), opts.CachePath)
+}
+
+func TestGitHubTUFOptionsWithMetadataDir(t *testing.T) {
+	opts := GitHubTUFOptions(o.Some("anything"))
+	require.Equal(t, "anything", opts.CachePath)
 }

--- a/pkg/cmd/attestation/verify/attestation_integration_test.go
+++ b/pkg/cmd/attestation/verify/attestation_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cli/cli/v2/pkg/cmd/attestation/io"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/test"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/verification"
+	o "github.com/cli/cli/v2/pkg/option"
 	"github.com/sigstore/sigstore-go/pkg/fulcio/certificate"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +26,8 @@ func getAttestationsFor(t *testing.T, bundlePath string) []*api.Attestation {
 
 func TestVerifyAttestations(t *testing.T) {
 	sgVerifier := verification.NewLiveSigstoreVerifier(verification.SigstoreConfig{
-		Logger: io.NewTestHandler(),
+		Logger:         io.NewTestHandler(),
+		TUFMetadataDir: o.Some(t.TempDir()),
 	})
 
 	certSummary := certificate.Summary{}

--- a/pkg/cmd/attestation/verify/verify_integration_test.go
+++ b/pkg/cmd/attestation/verify/verify_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cli/cli/v2/pkg/cmd/attestation/test"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/verification"
 	"github.com/cli/cli/v2/pkg/cmd/factory"
+	o "github.com/cli/cli/v2/pkg/option"
 	"github.com/cli/go-gh/v2/pkg/auth"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +20,8 @@ func TestVerifyIntegration(t *testing.T) {
 	logger := io.NewTestHandler()
 
 	sigstoreConfig := verification.SigstoreConfig{
-		Logger: logger,
+		Logger:         logger,
+		TUFMetadataDir: o.Some(t.TempDir()),
 	}
 
 	cmdFactory := factory.New("test")
@@ -130,7 +132,8 @@ func TestVerifyIntegrationCustomIssuer(t *testing.T) {
 	logger := io.NewTestHandler()
 
 	sigstoreConfig := verification.SigstoreConfig{
-		Logger: logger,
+		Logger:         logger,
+		TUFMetadataDir: o.Some(t.TempDir()),
 	}
 
 	cmdFactory := factory.New("test")
@@ -200,7 +203,8 @@ func TestVerifyIntegrationReusableWorkflow(t *testing.T) {
 	logger := io.NewTestHandler()
 
 	sigstoreConfig := verification.SigstoreConfig{
-		Logger: logger,
+		Logger:         logger,
+		TUFMetadataDir: o.Some(t.TempDir()),
 	}
 
 	cmdFactory := factory.New("test")
@@ -289,7 +293,8 @@ func TestVerifyIntegrationReusableWorkflowSignerWorkflow(t *testing.T) {
 	logger := io.NewTestHandler()
 
 	sigstoreConfig := verification.SigstoreConfig{
-		Logger: logger,
+		Logger:         logger,
+		TUFMetadataDir: o.Some(t.TempDir()),
 	}
 
 	cmdFactory := factory.New("test")


### PR DESCRIPTION
## Description

Fixes https://github.com/cli/cli/issues/10390 (hopefully)

As described in https://github.com/cli/cli/issues/10390#issuecomment-2671812894 the fundamental issue here is that there is a third party client (`TUF`) that is usually instantiated once on a `gh attestation` invocation but gets instantiated once per test. It downloads and stores json metadata in a shared location. It does this by writing a temp file and then using `os.Rename` to move it to the right place…godoc says:

> Even within the same directory, on non-Unix platforms Rename is not an atomic operation.

This PR allows for injection of this location.

### Reviewer Notes

I'm not really sure whether `TUF` is something that is supposed to leak out of the `verification` package, so this may be leaky. I chose to use an `Option` type to signify the possible absence of this because the alternative without larger refactoring is to pass around bare strings and rely on the zero value, which is pretty uninformative to the reader.

An alternative might be to have a struct that can be passed to the `DefaultOptionsWithCacheSetting` and `GitHubTUFOptions` functions but that seems overblown right now.

I'm not wedded to either of these things, just wanted to get something out that fixed the flaky tests, and it seems to have:

```
PS C:\Users\williammartin\workspace\cli> 1..10 | % { go test -tags=integration ./pkg/cmd/attestation/verification ./pkg/cmd/attestation/verify -count 2 -failfast }
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verification  4.849s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verify        22.185s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verification  4.424s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verify        20.310s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verification  4.837s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verify        20.663s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verification  4.917s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verify        21.998s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verification  5.919s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verify        20.572s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verification  4.875s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verify        22.144s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verification  5.236s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verify        21.297s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verification  4.907s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verify        21.929s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verification  4.854s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verify        20.692s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verification  4.439s
ok      github.com/cli/cli/v2/pkg/cmd/attestation/verify        21.337s
```
