### PR TITLE
[gh pr checkout] Add --no-tags option to git fetch commands in checko…

### DIFF
--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -172,7 +172,7 @@ func cmdsForExistingRemote(remote *cliContext.Remote, pr *api.PullRequest, opts 
 		refSpec += fmt.Sprintf(":refs/remotes/%s", remoteBranch)
 	}
 
-	cmds = append(cmds, []string{"fetch", remote.Name, refSpec})
+	cmds = append(cmds, []string{"fetch", remote.Name, refSpec, "--no-tags"})
 
 	localBranch := pr.HeadRefName
 	if opts.BranchName != "" {
@@ -202,7 +202,7 @@ func cmdsForMissingRemote(pr *api.PullRequest, baseURLOrName, repoHost, defaultB
 	ref := fmt.Sprintf("refs/pull/%d/head", pr.Number)
 
 	if opts.Detach {
-		cmds = append(cmds, []string{"fetch", baseURLOrName, ref})
+		cmds = append(cmds, []string{"fetch", baseURLOrName, ref, "--no-tags"})
 		cmds = append(cmds, []string{"checkout", "--detach", "FETCH_HEAD"})
 		return cmds
 	}
@@ -218,7 +218,7 @@ func cmdsForMissingRemote(pr *api.PullRequest, baseURLOrName, repoHost, defaultB
 	currentBranch, _ := opts.Branch()
 	if localBranch == currentBranch {
 		// PR head matches currently checked out branch
-		cmds = append(cmds, []string{"fetch", baseURLOrName, ref})
+		cmds = append(cmds, []string{"fetch", baseURLOrName, ref, "--no-tags"})
 		if opts.Force {
 			cmds = append(cmds, []string{"reset", "--hard", "FETCH_HEAD"})
 		} else {
@@ -227,10 +227,10 @@ func cmdsForMissingRemote(pr *api.PullRequest, baseURLOrName, repoHost, defaultB
 		}
 	} else {
 		if opts.Force {
-			cmds = append(cmds, []string{"fetch", baseURLOrName, fmt.Sprintf("%s:%s", ref, localBranch), "--force"})
+			cmds = append(cmds, []string{"fetch", baseURLOrName, fmt.Sprintf("%s:%s", ref, localBranch), "--force", "--no-tags"})
 		} else {
 			// TODO: check if non-fast-forward and suggest to use `--force`
-			cmds = append(cmds, []string{"fetch", baseURLOrName, fmt.Sprintf("%s:%s", ref, localBranch)})
+			cmds = append(cmds, []string{"fetch", baseURLOrName, fmt.Sprintf("%s:%s", ref, localBranch), "--no-tags"})
 		}
 
 		cmds = append(cmds, []string{"checkout", localBranch})

--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -226,13 +226,12 @@ func cmdsForMissingRemote(pr *api.PullRequest, baseURLOrName, repoHost, defaultB
 			cmds = append(cmds, []string{"merge", "--ff-only", "FETCH_HEAD"})
 		}
 	} else {
+		// TODO: check if non-fast-forward and suggest to use `--force`
+		fetchCmd := []string{"fetch", baseURLOrName, fmt.Sprintf("%s:%s", ref, localBranch), "--no-tags"}
 		if opts.Force {
-			cmds = append(cmds, []string{"fetch", baseURLOrName, fmt.Sprintf("%s:%s", ref, localBranch), "--force", "--no-tags"})
-		} else {
-			// TODO: check if non-fast-forward and suggest to use `--force`
-			cmds = append(cmds, []string{"fetch", baseURLOrName, fmt.Sprintf("%s:%s", ref, localBranch), "--no-tags"})
+			fetchCmd = append(fetchCmd, "--force")
 		}
-
+		cmds = append(cmds, fetchCmd)
 		cmds = append(cmds, []string{"checkout", localBranch})
 	}
 

--- a/pkg/cmd/pr/checkout/checkout_test.go
+++ b/pkg/cmd/pr/checkout/checkout_test.go
@@ -110,7 +110,7 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git show-ref --verify -- refs/heads/feature`, 1, "")
-				cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+				cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature --no-tags`, 0, "")
 				cs.Register(`git checkout -b feature --track origin/feature`, 0, "")
 			},
 		},
@@ -140,7 +140,7 @@ func Test_checkoutRun(t *testing.T) {
 				"origin": "OWNER/REPO",
 			},
 			runStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
+				cs.Register(`git fetch origin refs/pull/123/head:feature --no-tags`, 0, "")
 				cs.Register(`git config branch\.feature\.merge`, 1, "")
 				cs.Register(`git checkout feature`, 0, "")
 				cs.Register(`git config branch\.feature\.remote origin`, 0, "")
@@ -174,7 +174,7 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git show-ref --verify -- refs/heads/foobar`, 1, "")
-				cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+				cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature --no-tags`, 0, "")
 				cs.Register(`git checkout -b foobar --track origin/feature`, 0, "")
 			},
 		},
@@ -205,7 +205,7 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git config branch\.foobar\.merge`, 1, "")
-				cs.Register(`git fetch origin refs/pull/123/head:foobar`, 0, "")
+				cs.Register(`git fetch origin refs/pull/123/head:foobar --no-tags`, 0, "")
 				cs.Register(`git checkout foobar`, 0, "")
 				cs.Register(`git config branch\.foobar\.remote https://github.com/hubot/REPO.git`, 0, "")
 				cs.Register(`git config branch\.foobar\.pushRemote https://github.com/hubot/REPO.git`, 0, "")
@@ -260,7 +260,7 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git show-ref --verify -- refs/heads/feature`, 1, "")
-				cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+				cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature --no-tags`, 0, "")
 				cs.Register(`git checkout -b feature --track origin/feature`, 0, "")
 			},
 			remotes: map[string]string{
@@ -417,7 +417,7 @@ func TestPRCheckout_sameRepo(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature --no-tags`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 1, "")
 	cs.Register(`git checkout -b feature --track origin/feature`, 0, "")
 
@@ -436,7 +436,7 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature --no-tags`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 0, "")
 	cs.Register(`git checkout feature`, 0, "")
 	cs.Register(`git merge --ff-only refs/remotes/origin/feature`, 0, "")
@@ -468,7 +468,7 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch robot-fork \+refs/heads/feature:refs/remotes/robot-fork/feature`, 0, "")
+	cs.Register(`git fetch robot-fork \+refs/heads/feature:refs/remotes/robot-fork/feature --no-tags`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 1, "")
 	cs.Register(`git checkout -b feature --track robot-fork/feature`, 0, "")
 
@@ -488,7 +488,7 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:feature --no-tags`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 1, "")
 	cs.Register(`git checkout feature`, 0, "")
 	cs.Register(`git config branch\.feature\.remote origin`, 0, "")
@@ -510,7 +510,7 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:feature --no-tags`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
 	cs.Register(`git checkout feature`, 0, "")
 
@@ -529,7 +529,7 @@ func TestPRCheckout_detachedHead(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:feature --no-tags`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
 	cs.Register(`git checkout feature`, 0, "")
 
@@ -548,7 +548,7 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin refs/pull/123/head`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head --no-tags`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
 	cs.Register(`git merge --ff-only FETCH_HEAD`, 0, "")
 
@@ -585,7 +585,7 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin refs/pull/123/head:feature`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:feature --no-tags`, 0, "")
 	cs.Register(`git config branch\.feature\.merge`, 1, "")
 	cs.Register(`git checkout feature`, 0, "")
 	cs.Register(`git config branch\.feature\.remote https://github\.com/hubot/REPO\.git`, 0, "")
@@ -606,7 +606,7 @@ func TestPRCheckout_recurseSubmodules(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature --no-tags`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 0, "")
 	cs.Register(`git checkout feature`, 0, "")
 	cs.Register(`git merge --ff-only refs/remotes/origin/feature`, 0, "")
@@ -627,7 +627,7 @@ func TestPRCheckout_force(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature`, 0, "")
+	cs.Register(`git fetch origin \+refs/heads/feature:refs/remotes/origin/feature --no-tags`, 0, "")
 	cs.Register(`git show-ref --verify -- refs/heads/feature`, 0, "")
 	cs.Register(`git checkout feature`, 0, "")
 	cs.Register(`git reset --hard refs/remotes/origin/feature`, 0, "")
@@ -649,7 +649,7 @@ func TestPRCheckout_detach(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 	cs.Register(`git checkout --detach FETCH_HEAD`, 0, "")
-	cs.Register(`git fetch origin refs/pull/123/head`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head --no-tags`, 0, "")
 
 	output, err := runCommand(http, nil, "", `123 --detach`, baseRepo)
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/10254

Scenario: 
```
Given I have a repository with Git tags
When I run gh pr checkout
Then the branch is fetched with --no-tags
```

How to test:

1. Verify that there are no tags at all:
```
gqlc git:(main) GIT_TRACE=1 GIT_CURL_VERBOSE=1 git show-ref --tags -d
19:15:16.299293 git.c:455               trace: built-in: git show-ref --tags -d
```

2. Create test tags:
![image](https://github.com/user-attachments/assets/8f5341be-e0e9-4be4-8d35-3124ae9940eb)

3. Run `gh pr checkout XXX` and check if `--no-tag` appears in the fetch section.

```
 GH_DEBUG=1 gh pr checkout 1
[git remote -v]
[git config --get-regexp ^remote\..*\.gh-resolved$]
* Request at 2025-02-20 19:21:59.275807833 +0100 CET m=+0.073196802
* Request to https://api.github.com/graphql
* Request took 347.500805ms
[git remote -v]
[git config --get-regexp ^remote\..*\.gh-resolved$]
* Request at 2025-02-20 19:21:59.632861839 +0100 CET m=+0.430250808
* Request to https://api.github.com/graphql
* Request took 288.433004ms
* Request at 2025-02-20 19:21:59.921556543 +0100 CET m=+0.718945612
* Request to https://api.github.com/graphql
⣽* Request took 233.577603ms
[git remote -v]
[git config --get-regexp ^remote\..*\.gh-resolved$]
[git show-ref --verify -- refs/heads/testbranch]
[git -c credential.helper= -c credential.helper=!"/usr/bin/gh" auth git-credential fetch origin +refs/heads/testbranch:refs/remotes/origin/testbranch --no-tags]
[git checkout testbranch]
Switched to branch 'testbranch'
Your branch is up to date with 'origin/testbranch'.
[git merge --ff-only refs/remotes/origin/testbranch]
Already up to date.
```
4. Ensure there are still no tags:
```
GIT_TRACE=1 GIT_CURL_VERBOSE=1 git show-ref --tags -d
19:23:01.201215 git.c:455               trace: built-in: git show-ref --tags -d
```
5. Fetch tags to double-check: `git fetch --tags`.

```
From github.com:latzskim/gqlc
 * [new tag]         0.0.1-tag-main       -> 0.0.1-tag-main
 * [new tag]         0.0.1-tag-testbranch -> 0.0.1-tag-testbranch
 ```

```
 GIT_TRACE=1 GIT_CURL_VERBOSE=1 git show-ref --tags -d
19:26:22.878336 git.c:455               trace: built-in: git show-ref --tags -d
09547691e30013ec6626152e67ca736ba3ffd3af refs/tags/0.0.1-tag-main
237f2b896af7730953f95fcd87cf451f3b74a7b6 refs/tags/0.0.1-tag-testbranch
```
