### PR TITLE
chore: update codespaces Go version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/go:1.22",
+	"image": "mcr.microsoft.com/devcontainers/go:1.23",
 	"features": {
 		"ghcr.io/devcontainers/features/sshd:1": {}
 	},


### PR DESCRIPTION
Since `gh`  is currently built with Go 1.23, the devcontainer needs to be updated to allow building `gh` in a fresh codespace without additional manual steps.