### PR TITLE
Fix minor auth login help typo

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -72,7 +72,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			The minimum required scopes for the token are: %[1]srepo%[1]s, %[1]sread:org%[1]s, and %[1]sgist%[1]s.
 			Take care when passing a fine-grained personal access token to %[1]s--with-token%[1]s
 			as the inherent scoping to certain resources may cause confusing behaviour when interacting with other
-			resources. Favour setting %[1]sGH_TOKEN$%[1]s for fine-grained personal access token usage.
+			resources. Favour setting %[1]sGH_TOKEN%[1]s for fine-grained personal access token usage.
 
 			Alternatively, gh will use the authentication token found in environment variables.
 			This method is most suitable for "headless" use of gh such as in automation. See


### PR DESCRIPTION
## Description

Removes a `$` sign I accidentally introduced in https://github.com/cli/cli/pull/10186