### PR TITLE
Update Go version to 1.23 in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ We accept pull requests for bug fixes and features where we've discussed the app
 ## Building the project
 
 Prerequisites:
-- Go 1.22+
+- Go 1.23+
 
 Build with:
 * Unix-like systems: `make`


### PR DESCRIPTION
## Description

[1.23 is actually required.](https://github.com/cli/cli/blob/c78f6e76182cde9f106df78c9e52269db3d42aa1/go.mod#L3)