### PR TITLE
Fix: gh pr create --web does not respect title and body arguments

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -279,7 +279,7 @@ func createRun(opts *CreateOptions) error {
 	var openURL string
 
 	if opts.WebMode {
-		if (opts.Autofill || opts.FillFirst) {
+		if opts.Autofill || opts.FillFirst {
 			state.Title = opts.Title
 			state.Body = opts.Body
 		}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -279,10 +279,10 @@ func createRun(opts *CreateOptions) error {
 	var openURL string
 
 	if opts.WebMode {
-		if opts.Autofill || opts.FillFirst {
-			state.Title = opts.Title
-			state.Body = opts.Body
-		}
+
+		state.Title = opts.Title
+		state.Body = opts.Body
+
 		if opts.Template != "" {
 			state.Template = opts.Template
 		}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -280,8 +280,17 @@ func createRun(opts *CreateOptions) error {
 
 	if opts.WebMode {
 
-		state.Title = opts.Title
-		state.Body = opts.Body
+		if !(opts.Autofill || opts.FillFirst) {
+			state.Title = opts.Title
+			state.Body = opts.Body
+		}
+
+		if opts.TitleProvided {
+			state.Title = opts.Title
+		}
+		if opts.BodyProvided {
+			state.Body = opts.Body
+		}
 
 		if opts.Template != "" {
 			state.Template = opts.Template

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -279,7 +279,7 @@ func createRun(opts *CreateOptions) error {
 	var openURL string
 
 	if opts.WebMode {
-		if !(opts.Autofill || opts.FillFirst) {
+		if (opts.Autofill || opts.FillFirst) {
 			state.Title = opts.Title
 			state.Body = opts.Body
 		}


### PR DESCRIPTION
Fixes #10527 

### Solution

I added a condition if `opts.TitleProvided` and `opts.BodyProvided` then add the title and body.

I also noticed that using this command: `gh pr create --assignee @me --fill --title "test" --body "ticket number" --web` give the expected behaviour but when omitting the --assignee option it does not.