### PR TITLE
Fix GH_REPO usage with secret commands

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -212,7 +212,7 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 		},
 		Args: cobra.ExactArgs(1),
 		PreRun: func(c *cobra.Command, args []string) {
-			opts.BaseRepo = cmdutil.OverrideBaseRepoFunc(f, "")
+			opts.BaseRepo = cmdutil.PrioritiseEnvBaseRepoFunc(f.BaseRepo)
 		},
 		RunE: func(c *cobra.Command, args []string) error {
 			opts.RequestPath = args[0]

--- a/pkg/cmd/factory/default_test.go
+++ b/pkg/cmd/factory/default_test.go
@@ -254,7 +254,7 @@ func Test_SmartBaseRepo(t *testing.T) {
 }
 
 // Defined in pkg/cmdutil/repo_override.go but test it along with other BaseRepo functions
-func Test_OverrideBaseRepo(t *testing.T) {
+func Test_PrioritiseEnvBaseRepoFunc(t *testing.T) {
 	tests := []struct {
 		name        string
 		remotes     git.RemoteSet
@@ -267,14 +267,7 @@ func Test_OverrideBaseRepo(t *testing.T) {
 		wantsHost   string
 	}{
 		{
-			name:        "override from argument",
-			argOverride: "override/test",
-			wantsHost:   "github.com",
-			wantsOwner:  "override",
-			wantsName:   "test",
-		},
-		{
-			name:        "override from environment",
+			name:        "from environment",
 			envOverride: "somehost.com/override/test",
 			wantsHost:   "somehost.com",
 			wantsOwner:  "override",
@@ -307,7 +300,7 @@ func Test_OverrideBaseRepo(t *testing.T) {
 				},
 			}
 			f.Remotes = rr.Resolver()
-			f.BaseRepo = cmdutil.OverrideBaseRepoFunc(f, tt.argOverride)
+			f.BaseRepo = cmdutil.PrioritiseEnvBaseRepoFunc(f.BaseRepo)
 			repo, err := f.BaseRepo()
 			if tt.wantsErr {
 				assert.Error(t, err)

--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -59,7 +59,7 @@ func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
 			// If there was no flag set, then check the GH_REPO environment variable,
 			// which has lower precedence.
 			userProvidedRepo = os.Getenv("GH_REPO")
-			// If the envrionment variable was set, then set the value of the `repo` flag,
+			// If the environment variable was set, then set the value of the `repo` flag,
 			// this ensures that checks for `HasChanged` work correctly. It's a bit "spooky"
 			// action at a distance because the flag will not have been set by the user,
 			// but perhaps it makes sense?

--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -58,7 +58,7 @@ func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
 		if userProvidedRepo == "" {
 			// If there was no flag set, then check the GH_REPO environment variable,
 			// which has lower precedence.
-			repoOverride, ok := os.LookupEnv("GH_REPO")
+			userProvidedRepo = os.Getenv("GH_REPO")
 			// If the envrionment variable was set, then set the value of the `repo` flag,
 			// this ensures that checks for `HasChanged` work correctly. It's a bit "spooky"
 			// action at a distance because the flag will not have been set by the user,
@@ -68,9 +68,9 @@ func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
 			// the user set the repo, and the alternative is them having knowledge of the flag and env var,
 			// or by adjusting all our types so that the "source" of the BaseRepo is surfaced, which is a
 			// pretty big change.
-			if ok {
+			if userProvidedRepo != "" {
 				// TODO: comment why we ignore error
-				_ = cmd.Flags().Set("repo", repoOverride)
+				_ = cmd.Flags().Set("repo", userProvidedRepo)
 			}
 		}
 

--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -69,8 +70,9 @@ func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
 			// or by adjusting all our types so that the "source" of the BaseRepo is surfaced, which is a
 			// pretty big change.
 			if userProvidedRepo != "" {
-				// We can ignore errors here because the flag is guaranteed to exist and be a string.
-				_ = cmd.Flags().Set("repo", userProvidedRepo)
+				if err := cmd.Flags().Set("repo", userProvidedRepo); err != nil {
+					return fmt.Errorf("failed to set repo override flag: %v", err)
+				}
 			}
 		}
 

--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -69,7 +69,7 @@ func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
 			// or by adjusting all our types so that the "source" of the BaseRepo is surfaced, which is a
 			// pretty big change.
 			if userProvidedRepo != "" {
-				// TODO: comment why we ignore error
+				// We can ignore errors here because the flag is guaranteed to exist and be a string.
 				_ = cmd.Flags().Set("repo", userProvidedRepo)
 			}
 		}

--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -51,20 +51,49 @@ func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
 		if err := executeParentHooks(cmd, args); err != nil {
 			return err
 		}
-		repoOverride, _ := cmd.Flags().GetString("repo")
-		f.BaseRepo = OverrideBaseRepoFunc(f, repoOverride)
+
+		// First, get the value of the flag.
+		// We can ignore errors here because the flag is guaranteed to exist and be string.
+		userProvidedRepo, _ := cmd.Flags().GetString("repo")
+		if userProvidedRepo == "" {
+			// If there was no flag set, then check the GH_REPO environment variable,
+			// which has lower precedence.
+			repoOverride, ok := os.LookupEnv("GH_REPO")
+			// If the envrionment variable was set, then set the value of the `repo` flag,
+			// this ensures that checks for `HasChanged` work correctly. It's a bit "spooky"
+			// action at a distance because the flag will not have been set by the user,
+			// but perhaps it makes sense?
+			//
+			// The reason we need this is because there are `secret` commands that need to know whether
+			// the user set the repo, and the alternative is them having knowledge of the flag and env var,
+			// or by adjusting all our types so that the "source" of the BaseRepo is surfaced, which is a
+			// pretty big change.
+			if ok {
+				// TODO: comment why we ignore error
+				_ = cmd.Flags().Set("repo", repoOverride)
+			}
+		}
+
+		// If the user provided the repo from either source, then we can return that
+		// directly inside a new BaseRepo function.
+		if userProvidedRepo != "" {
+			f.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName(userProvidedRepo)
+			}
+		}
+
 		return nil
 	}
 }
 
-func OverrideBaseRepoFunc(f *Factory, override string) func() (ghrepo.Interface, error) {
-	if override == "" {
-		override = os.Getenv("GH_REPO")
-	}
-	if override != "" {
-		return func() (ghrepo.Interface, error) {
-			return ghrepo.FromFullName(override)
+type baseRepoFn func() (ghrepo.Interface, error)
+
+func PrioritiseEnvBaseRepoFunc(baseRepo baseRepoFn) func() (ghrepo.Interface, error) {
+	return func() (ghrepo.Interface, error) {
+		repo := os.Getenv("GH_REPO")
+		if repo == "" {
+			return baseRepo()
 		}
+		return ghrepo.FromFullName(repo)
 	}
-	return f.BaseRepo
 }


### PR DESCRIPTION
## Description

Fixes #10525 

Draft because I'm not convinced about the cost of the commented "spooky action at a distance" but wanted to put something out there.

I removed `OverrideBaseRepoFunc` because it was in my opinion, not a very good abstraction to have exported as seen in the call site of `gh api`: 

```
cmdutil.OverrideBaseRepoFunc(f, "")
```

Now replaced by:

```
cmdutil.PrioritiseEnvBaseRepoFunc(f.BaseRepo)
```

The code was then inlined into `EnableRepoOverride`.

## Acceptance

**Given** my cwd is not a git repo
**And** I have `GH_REPO` set to a repo I have permissions on
**When** I run any of the `gh secret` commands
**Then** I am able to interact with secrets on that repo

Before:

```
➜  workspace GH_REPO=williammartin-test-org/test-repo gh secret list
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

After:

```
➜  workspace GH_REPO=williammartin-test-org/test-repo ~/workspace/cli/bin/gh secret list | cat
FOO     2025-01-09T16:39:07Z
```