### PR TITLE
Check `GH_REPO` too in addition to `--repo` for disambiguation

### DIFF
--- a/acceptance/testdata/secret/secret-require-remote-disambiguation.txtar
+++ b/acceptance/testdata/secret/secret-require-remote-disambiguation.txtar
@@ -54,9 +54,9 @@ env GH_REPO=${ORG}/${REPO}-fork
 # Secret set using GH_REPO env var does not require disambiguation
 exec gh secret set 'TEST_SECRET_NAME2' --body 'TEST_SECRET_VALUE2'
 
-# Secret list using --repo flag does not require disambiguation
+# Secret list using GH_REPO env var does not require disambiguation
 exec gh secret list
 stdout 'TEST_SECRET_NAME2'
 
-# Secret delete using --repo flag does not require disambiguation
+# Secret delete using GH_REPO env var does not require disambiguation
 exec gh secret delete 'TEST_SECRET_NAME2'

--- a/acceptance/testdata/secret/secret-require-remote-disambiguation.txtar
+++ b/acceptance/testdata/secret/secret-require-remote-disambiguation.txtar
@@ -48,12 +48,15 @@ stdout 'TEST_SECRET_NAME'
 # Secret delete using --repo flag does not require disambiguation
 exec gh secret delete 'TEST_SECRET_NAME' --repo ${ORG}/${REPO}-fork
 
+# Setup GH_REPO for testing environment variable behavior
+env GH_REPO=${ORG}/${REPO}-fork
+
 # Secret set using GH_REPO env var does not require disambiguation
-exec gh secret set 'TEST_SECRET_NAME2' --body 'TEST_SECRET_VALUE2' --repo ${ORG}/${REPO}-fork
+exec gh secret set 'TEST_SECRET_NAME2' --body 'TEST_SECRET_VALUE2'
 
 # Secret list using --repo flag does not require disambiguation
-exec gh secret list --repo ${ORG}/${REPO}-fork
+exec gh secret list
 stdout 'TEST_SECRET_NAME2'
 
 # Secret delete using --repo flag does not require disambiguation
-exec gh secret delete 'TEST_SECRET_NAME2' --repo ${ORG}/${REPO}-fork
+exec gh secret delete 'TEST_SECRET_NAME2'

--- a/acceptance/testdata/secret/secret-require-remote-disambiguation.txtar
+++ b/acceptance/testdata/secret/secret-require-remote-disambiguation.txtar
@@ -34,3 +34,26 @@ stderr 'multiple remotes detected. please specify which repo to use by providing
 # Secret delete requires disambiguation
 ! exec gh secret delete 'TEST_SECRET_NAME'
 stderr 'multiple remotes detected. please specify which repo to use by providing the -R, --repo argument'
+
+# Move out of the fork repo to test whether secret commands work without local repository context
+cd ..
+
+# Secret set using --repo flag does not require disambiguation
+exec gh secret set 'TEST_SECRET_NAME' --body 'TEST_SECRET_VALUE' --repo ${ORG}/${REPO}-fork
+
+# Secret list using --repo flag does not require disambiguation
+exec gh secret list --repo ${ORG}/${REPO}-fork
+stdout 'TEST_SECRET_NAME'
+
+# Secret delete using --repo flag does not require disambiguation
+exec gh secret delete 'TEST_SECRET_NAME' --repo ${ORG}/${REPO}-fork
+
+# Secret set using GH_REPO env var does not require disambiguation
+exec gh secret set 'TEST_SECRET_NAME2' --body 'TEST_SECRET_VALUE2' --repo ${ORG}/${REPO}-fork
+
+# Secret list using --repo flag does not require disambiguation
+exec gh secret list --repo ${ORG}/${REPO}-fork
+stdout 'TEST_SECRET_NAME2'
+
+# Secret delete using --repo flag does not require disambiguation
+exec gh secret delete 'TEST_SECRET_NAME2' --repo ${ORG}/${REPO}-fork

--- a/pkg/cmd/secret/delete/delete.go
+++ b/pkg/cmd/secret/delete/delete.go
@@ -3,6 +3,7 @@ package delete
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
@@ -48,8 +49,9 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If the user specified a repo directly, then we're using the OverrideBaseRepoFunc set by EnableRepoOverride
 			// So there's no reason to use the specialised BaseRepoFunc that requires remote disambiguation.
-			opts.BaseRepo = f.BaseRepo
-			if !cmd.Flags().Changed("repo") {
+			if cmd.Flags().Changed("repo") || os.Getenv("GH_REPO") != "" {
+				opts.BaseRepo = f.BaseRepo
+			} else {
 				// If they haven't specified a repo directly, then we will wrap the BaseRepoFunc in one that errors if
 				// there might be multiple valid remotes.
 				opts.BaseRepo = shared.RequireNoAmbiguityBaseRepoFunc(opts.BaseRepo, f.Remotes)

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -3,6 +3,7 @@ package list
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -69,8 +70,9 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If the user specified a repo directly, then we're using the OverrideBaseRepoFunc set by EnableRepoOverride
 			// So there's no reason to use the specialised BaseRepoFunc that requires remote disambiguation.
-			opts.BaseRepo = f.BaseRepo
-			if !cmd.Flags().Changed("repo") {
+			if cmd.Flags().Changed("repo") || os.Getenv("GH_REPO") != "" {
+				opts.BaseRepo = f.BaseRepo
+			} else {
 				// If they haven't specified a repo directly, then we will wrap the BaseRepoFunc in one that errors if
 				// there might be multiple valid remotes.
 				opts.BaseRepo = shared.RequireNoAmbiguityBaseRepoFunc(opts.BaseRepo, f.Remotes)

--- a/pkg/cmd/secret/list/list_test.go
+++ b/pkg/cmd/secret/list/list_test.go
@@ -124,6 +124,7 @@ func TestNewCmdListBaseRepoFuncs(t *testing.T) {
 	tests := []struct {
 		name          string
 		args          string
+		env           map[string]string
 		prompterStubs func(*prompter.MockPrompter)
 		wantRepo      ghrepo.Interface
 		wantErr       error
@@ -134,14 +135,21 @@ func TestNewCmdListBaseRepoFuncs(t *testing.T) {
 			wantRepo: ghrepo.New("owner", "repo"),
 		},
 		{
-			name: "when there is no repo flag provided, and no prompting, the base func requiring no ambiguity is used",
+			name: "when GH_REPO env var is provided, the factory base repo func is used",
+			env: map[string]string{
+				"GH_REPO": "owner/repo",
+			},
+			wantRepo: ghrepo.New("owner", "repo"),
+		},
+		{
+			name: "when there is no repo flag or GH_REPO env var provided, and no prompting, the base func requiring no ambiguity is used",
 			args: "",
 			wantErr: shared.AmbiguousBaseRepoError{
 				Remotes: remotes,
 			},
 		},
 		{
-			name: "when there is no repo flag provided, and can prompt, the base func resolving ambiguity is used",
+			name: "when there is no repo flag or GH_REPO env var provided, and can prompt, the base func resolving ambiguity is used",
 			args: "",
 			prompterStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterSelect(
@@ -177,6 +185,10 @@ func TestNewCmdListBaseRepoFuncs(t *testing.T) {
 				Remotes: func() (ghContext.Remotes, error) {
 					return remotes, nil
 				},
+			}
+
+			for k, v := range tt.env {
+				t.Setenv(k, v)
 			}
 
 			argv, err := shlex.Split(tt.args)

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -106,8 +106,9 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If the user specified a repo directly, then we're using the OverrideBaseRepoFunc set by EnableRepoOverride
 			// So there's no reason to use the specialised BaseRepoFunc that requires remote disambiguation.
-			opts.BaseRepo = f.BaseRepo
-			if !cmd.Flags().Changed("repo") {
+			if cmd.Flags().Changed("repo") || os.Getenv("GH_REPO") != "" {
+				opts.BaseRepo = f.BaseRepo
+			} else {
 				// If they haven't specified a repo directly, then we will wrap the BaseRepoFunc in one that errors if
 				// there might be multiple valid remotes.
 				opts.BaseRepo = shared.RequireNoAmbiguityBaseRepoFunc(opts.BaseRepo, f.Remotes)


### PR DESCRIPTION
## Description

Fixes #10525

Commit pulled from @iamazeem's fork, with attribution maintained.

This is an alternative to https://github.com/cli/cli/pull/10535 because that one requires a bit more thought and I'd like this to go out in a release.

## Acceptance

**Given** my cwd is not a git repo
**And** I have `GH_REPO` set to a repo I have permissions on
**When** I run any of the `gh secret` commands
**Then** I am able to interact with secrets on that repo

Before:

```
➜  workspace GH_REPO=williammartin-test-org/test-repo gh secret list
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

After:

```
➜  workspace GH_REPO=williammartin-test-org/test-repo ~/workspace/cli/bin/gh secret list | cat
FOO     2025-01-09T16:39:07Z
```