### PR TITLE
[gh pr view] Support `closingIssuesReferences` JSON field

### DIFF
--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -139,6 +139,12 @@ func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
 				}
 			}
 			data[f] = &requests
+		case "closingIssuesReferences":
+			items := make([]int, 0, len(pr.ClosingIssuesReferences.Nodes))
+			for _, n := range pr.ClosingIssuesReferences.Nodes {
+				items = append(items, n.Number)
+			}
+			data[f] = items
 		default:
 			sf := fieldByName(v, f)
 			data[f] = sf.Interface()

--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -140,9 +140,22 @@ func (pr *PullRequest) ExportData(fields []string) map[string]interface{} {
 			}
 			data[f] = &requests
 		case "closingIssuesReferences":
-			items := make([]int, 0, len(pr.ClosingIssuesReferences.Nodes))
+			items := make([]map[string]interface{}, 0, len(pr.ClosingIssuesReferences.Nodes))
 			for _, n := range pr.ClosingIssuesReferences.Nodes {
-				items = append(items, n.Number)
+				items = append(items, map[string]interface{}{
+
+					"id":     n.ID,
+					"number": n.Number,
+					"url":    n.URL,
+					"repository": map[string]interface{}{
+						"id":   n.Repository.ID,
+						"name": n.Repository.Name,
+						"owner": map[string]interface{}{
+							"id":    n.Repository.Owner.ID,
+							"login": n.Repository.Owner.Login,
+						},
+					},
+				})
 			}
 			data[f] = items
 		default:

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -250,18 +250,62 @@ func TestPullRequest_ExportData(t *testing.T) {
 			fields: []string{"closingIssuesReferences"},
 			inputJSON: heredoc.Doc(`
 				{ "closingIssuesReferences": { "nodes": [
-						{
-							"number": 123
-						},
-						{
-							"number": 456
+					{
+						"id": "I_123",
+						"number": 123,
+						"url": "https://github.com/cli/cli/issues/123",
+						"repository": {
+							"id": "R_123",
+							"name": "cli",
+							"owner": {
+								"id": "O_123",
+								"login": "cli"
+							}
 						}
+					},
+					{
+						"id": "I_456",
+						"number": 456,
+						"url": "https://github.com/cli/cli/issues/456",
+						"repository": {
+							"id": "R_456",
+							"name": "cli",
+							"owner": {
+								"id": "O_456",
+								"login": "cli"
+							}
+						}
+					}
 				] } }
 			`),
 			outputJSON: heredoc.Doc(`
 				{ "closingIssuesReferences": [
-					123,
-					456
+					{
+						"id": "I_123",
+						"number": 123,
+						"repository": {
+							"id": "R_123",
+							"name": "cli",
+							"owner": {
+							"id": "O_123",
+							"login": "cli"
+							}
+						},
+						"url": "https://github.com/cli/cli/issues/123"
+					},
+					{
+						"id": "I_456",
+						"number": 456,
+						"repository": {
+							"id": "R_456",
+							"name": "cli",
+							"owner": {
+							"id": "O_456",
+							"login": "cli"
+							}
+						},
+						"url": "https://github.com/cli/cli/issues/456"
+					}
 				] }
 			`),
 		},

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -245,6 +245,31 @@ func TestPullRequest_ExportData(t *testing.T) {
 				}
 			`),
 		},
+		{
+			name:   "linked issues",
+			fields: []string{"closingIssuesReferences"},
+			inputJSON: heredoc.Doc(`
+				{ "closingIssuesReferences":
+				 	{ "nodes": [
+							{
+								"number": 123
+							},
+							{
+								"number": 456
+							}
+						]
+					}
+				}
+			`),
+			outputJSON: heredoc.Doc(`
+				{
+					"closingIssuesReferences": [
+						123,
+						456
+					]
+				}
+			`),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -249,25 +249,20 @@ func TestPullRequest_ExportData(t *testing.T) {
 			name:   "linked issues",
 			fields: []string{"closingIssuesReferences"},
 			inputJSON: heredoc.Doc(`
-				{ "closingIssuesReferences":
-				 	{ "nodes": [
-							{
-								"number": 123
-							},
-							{
-								"number": 456
-							}
-						]
-					}
-				}
+				{ "closingIssuesReferences": { "nodes": [
+						{
+							"number": 123
+						},
+						{
+							"number": 456
+						}
+				] } }
 			`),
 			outputJSON: heredoc.Doc(`
-				{
-					"closingIssuesReferences": [
-						123,
-						456
-					]
-				}
+				{ "closingIssuesReferences": [
+					123,
+					456
+				] }
 			`),
 		},
 	}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -93,6 +93,12 @@ type PullRequest struct {
 	Reviews        PullRequestReviews
 	LatestReviews  PullRequestReviews
 	ReviewRequests ReviewRequests
+
+	ClosingIssuesReferences struct {
+		Nodes []struct {
+			Number int
+		}
+	}
 }
 
 type StatusCheckRollupNode struct {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -94,11 +94,7 @@ type PullRequest struct {
 	LatestReviews  PullRequestReviews
 	ReviewRequests ReviewRequests
 
-	ClosingIssuesReferences struct {
-		Nodes []struct {
-			Number int
-		}
-	}
+	ClosingIssuesReferences ClosingIssuesReferences
 }
 
 type StatusCheckRollupNode struct {
@@ -111,6 +107,16 @@ type StatusCheckRollupCommit struct {
 
 type CommitStatusCheckRollup struct {
 	Contexts CheckContexts
+}
+
+type ClosingIssuesReferences struct {
+	Nodes []struct {
+		Number int
+	}
+	PageInfo struct {
+		HasNextPage bool
+		EndCursor   string
+	}
 }
 
 // https://docs.github.com/en/graphql/reference/enums#checkrunstate

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -111,7 +111,17 @@ type CommitStatusCheckRollup struct {
 
 type ClosingIssuesReferences struct {
 	Nodes []struct {
-		Number int
+		ID         string
+		Number     int
+		URL        string
+		Repository struct {
+			ID    string
+			Name  string
+			Owner struct {
+				ID    string
+				Login string
+			}
+		}
 	}
 	PageInfo struct {
 		HasNextPage bool

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -135,7 +135,17 @@ var prCommits = shortenQuery(`
 var prClosingIssuesReferences = shortenQuery(`
 	closingIssuesReferences(first: 100) {
 		nodes {
-			number
+			id,
+			number,
+			url,
+			repository {
+				id,
+				name,
+				owner {
+					id,
+					login
+				}
+			}
 		}
 		pageInfo{hasNextPage,endCursor}
 	}

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -132,6 +132,15 @@ var prCommits = shortenQuery(`
 	}
 `)
 
+var prClosingIssuesReferences = shortenQuery(`
+	closingIssuesReferences(first: 100) {
+		nodes {
+			number
+		}
+		pageInfo{hasNextPage,endCursor}
+	}
+`)
+
 var autoMergeRequest = shortenQuery(`
 	autoMergeRequest {
 		authorEmail,
@@ -368,7 +377,7 @@ func IssueGraphQL(fields []string) string {
 		case "statusCheckRollupWithCountByState": // pseudo-field
 			q = append(q, StatusCheckRollupGraphQLWithCountByState())
 		case "closingIssuesReferences":
-			q = append(q, `closingIssuesReferences(first:100){nodes{number}}`)
+			q = append(q, prClosingIssuesReferences)
 		default:
 			q = append(q, field)
 		}

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -287,6 +287,7 @@ var PullRequestFields = append(sharedIssuePRFields,
 	"baseRefName",
 	"baseRefOid",
 	"changedFiles",
+	"closingIssuesReferences",
 	"commits",
 	"deletions",
 	"files",
@@ -366,6 +367,8 @@ func IssueGraphQL(fields []string) string {
 			q = append(q, StatusCheckRollupGraphQLWithoutCountByState(""))
 		case "statusCheckRollupWithCountByState": // pseudo-field
 			q = append(q, StatusCheckRollupGraphQLWithCountByState())
+		case "closingIssuesReferences":
+			q = append(q, `closingIssuesReferences(first:100){nodes{number}}`)
 		default:
 			q = append(q, field)
 		}

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -598,7 +598,7 @@ func preloadPrClosingIssuesReferences(client *http.Client, repo ghrepo.Interface
 		variables["endCursor"] = githubv4.String(query.Node.PullRequest.ClosingIssuesReferences.PageInfo.EndCursor)
 	}
 
-	pr.Comments.PageInfo.HasNextPage = false
+	pr.ClosingIssuesReferences.PageInfo.HasNextPage = false
 	return nil
 }
 

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -272,6 +272,11 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 			return preloadPrComments(httpClient, f.baseRefRepo, pr)
 		})
 	}
+	if fields.Contains("closingIssuesReferences") {
+		g.Go(func() error {
+			return preloadPrClosingIssuesReferences(httpClient, f.baseRefRepo, pr)
+		})
+	}
 	if fields.Contains("statusCheckRollup") {
 		g.Go(func() error {
 			return preloadPrChecks(httpClient, f.baseRefRepo, pr)
@@ -552,6 +557,45 @@ func preloadPrComments(client *http.Client, repo ghrepo.Interface, pr *api.PullR
 			break
 		}
 		variables["endCursor"] = githubv4.String(query.Node.PullRequest.Comments.PageInfo.EndCursor)
+	}
+
+	pr.Comments.PageInfo.HasNextPage = false
+	return nil
+}
+
+func preloadPrClosingIssuesReferences(client *http.Client, repo ghrepo.Interface, pr *api.PullRequest) error {
+	if !pr.ClosingIssuesReferences.PageInfo.HasNextPage {
+		return nil
+	}
+
+	type response struct {
+		Node struct {
+			PullRequest struct {
+				ClosingIssuesReferences api.ClosingIssuesReferences `graphql:"closingIssuesReferences(first: 100, after: $endCursor)"`
+			} `graphql:"...on PullRequest"`
+		} `graphql:"node(id: $id)"`
+	}
+
+	variables := map[string]interface{}{
+		"id":        githubv4.ID(pr.ID),
+		"endCursor": githubv4.String(pr.ClosingIssuesReferences.PageInfo.EndCursor),
+	}
+
+	gql := api.NewClientFromHTTP(client)
+
+	for {
+		var query response
+		err := gql.Query(repo.RepoHost(), "closingIssuesReferences", &query, variables)
+		if err != nil {
+			return err
+		}
+
+		pr.ClosingIssuesReferences.Nodes = append(pr.ClosingIssuesReferences.Nodes, query.Node.PullRequest.ClosingIssuesReferences.Nodes...)
+
+		if !query.Node.PullRequest.ClosingIssuesReferences.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Node.PullRequest.ClosingIssuesReferences.PageInfo.EndCursor)
 	}
 
 	pr.Comments.PageInfo.HasNextPage = false

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -37,6 +37,7 @@ func TestJSONFields(t *testing.T) {
 		"changedFiles",
 		"closed",
 		"closedAt",
+		"closingIssuesReferences",
 		"comments",
 		"commits",
 		"createdAt",


### PR DESCRIPTION
Fixes #10529.

### Acceptance Tests

#### One (1) Linked Issue

```shell
$ bin/gh pr view 10544 --repo cli/cli --json title,number,closingIssuesReferences
{
  "closingIssuesReferences": [
    10529
  ],
  "number": 10544,
  "title": "[gh pr view] Support `closingIssuesReferences` JSON field"
}
```

#### Two (2) Linked Issues

```shell
$ bin/gh pr view 74 --json closingIssuesReferences --repo iamazeem/test
{
  "closingIssuesReferences": [
    73,
    75
  ]
}
```

#### Two (2) Linked Issues with `GH_DEBUG=api` showing pagination (using `first: 1` for testing only)

```shell
$ GH_DEBUG=api bin/gh pr view 74 --json closingIssuesReferences --repo iamazeem/test
⣾* Request at 2025-03-05 23:38:17.10776039 +0500 PKT m=+0.056023724
* Request to https://api.github.com/graphql
> POST /graphql HTTP/1.1
> Host: api.github.com
> Accept: application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview
> Authorization: token ████████████████████
> Content-Length: 347
> Content-Type: application/json; charset=utf-8
> Graphql-Features: merge_queue
> Time-Zone: Asia/Karachi
> User-Agent: GitHub CLI v2.66.1-233-g988476f1

GraphQL query:
query PullRequestByNumber($owner: String!, $repo: String!, $pr_number: Int!) {
    repository(owner: $owner, name: $repo) {
      pullRequest(number: $pr_number) {closingIssuesReferences(first: 1) {nodes {number}pageInfo{hasNextPage,endCursor}},id,number}
    }
  }
GraphQL variables: {"owner":"iamazeem","pr_number":74,"repo":"test"}

⢿< HTTP/2.0 200 OK
< Access-Control-Allow-Origin: *
< Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset
< Content-Security-Policy: default-src 'none'
< Content-Type: application/json; charset=utf-8
< Date: Wed, 05 Mar 2025 18:38:18 GMT
< Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
< Server: github.com
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< Vary: Accept-Encoding, Accept, X-Requested-With
< X-Accepted-Oauth-Scopes: repo
< X-Content-Type-Options: nosniff
< X-Frame-Options: deny
< X-Github-Media-Type: github.v4; param=merge-info-preview.nebula-preview; format=json
< X-Github-Request-Id: E22C:2D6425:A4AF1F:D09216:67C89A19
< X-Oauth-Client-Id: 178c6fc778ccc68e1d6a
< X-Oauth-Scopes: admin:public_key, codespace, gist, project, read:org, read:packages, repo
< X-Ratelimit-Limit: 5000
< X-Ratelimit-Remaining: 4592
< X-Ratelimit-Reset: 1741200039
< X-Ratelimit-Resource: graphql
< X-Ratelimit-Used: 408
< X-Xss-Protection: 0

{
  "data": {
    "repository": {
      "pullRequest": {
        "closingIssuesReferences": {
          "nodes": [
            {
              "number": 73
            }
          ],
          "pageInfo": {
            "hasNextPage": true,
            "endCursor": "MQ"
          }
        },
        "id": "PR_kwDOFWDJUc6Kx39M",
        "number": 74
      }
    }
  }
}

* Request took 1.376562811s
* Request at 2025-03-05 23:38:18.487958536 +0500 PKT m=+1.436221876
* Request to https://api.github.com/graphql
> POST /graphql HTTP/1.1
> Host: api.github.com
> Accept: application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview
> Authorization: token ████████████████████
> Content-Length: 262
> Content-Type: application/json
> Graphql-Features: merge_queue
> Time-Zone: Asia/Karachi
> User-Agent: GitHub CLI v2.66.1-233-g988476f1

GraphQL query:
query closingIssuesReferences($endCursor:String!$id:ID!){node(id: $id){...on PullRequest{closingIssuesReferences(first: 1, after: $endCursor){nodes{number},pageInfo{hasNextPage,endCursor}}}}}
GraphQL variables: {"endCursor":"MQ","id":"PR_kwDOFWDJUc6Kx39M"}

⣷< HTTP/2.0 200 OK
< Access-Control-Allow-Origin: *
< Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset
< Content-Security-Policy: default-src 'none'
< Content-Type: application/json; charset=utf-8
< Date: Wed, 05 Mar 2025 18:38:18 GMT
< Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
< Server: github.com
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< Vary: Accept-Encoding, Accept, X-Requested-With
< X-Accepted-Oauth-Scopes: repo
< X-Content-Type-Options: nosniff
< X-Frame-Options: deny
< X-Github-Media-Type: github.v4; param=merge-info-preview.nebula-preview; format=json
< X-Github-Request-Id: E22C:2D6425:A4AF41:D09248:67C89A1A
< X-Oauth-Client-Id: 178c6fc778ccc68e1d6a
< X-Oauth-Scopes: admin:public_key, codespace, gist, project, read:org, read:packages, repo
< X-Ratelimit-Limit: 5000
< X-Ratelimit-Remaining: 4591
< X-Ratelimit-Reset: 1741200039
< X-Ratelimit-Resource: graphql
< X-Ratelimit-Used: 409
< X-Xss-Protection: 0

{
  "data": {
    "node": {
      "closingIssuesReferences": {
        "nodes": [
          {
            "number": 75
          }
        ],
        "pageInfo": {
          "hasNextPage": false,
          "endCursor": "Mg"
        }
      }
    }
  }
}

* Request took 498.52847ms
{
  "closingIssuesReferences": [
    73,
    75
  ]
}
```