### PR TITLE
Base64 decode GPG passphrase in deployment workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -301,7 +301,7 @@ jobs:
           base64 -d <<<"$GPG_KEY" | gpg --import --no-tty --batch --yes
           echo "allow-preset-passphrase" > ~/.gnupg/gpg-agent.conf
           gpg-connect-agent RELOADAGENT /bye
-          /usr/lib/gnupg2/gpg-preset-passphrase --preset "$GPG_KEYGRIP" <<<"$GPG_PASSPHRASE"
+          base64 -d <<<"$GPG_PASSPHRASE" | /usr/lib/gnupg2/gpg-preset-passphrase --preset "$GPG_KEYGRIP"
       - name: Sign RPMs
         if: inputs.environment == 'production'
         run: |


### PR DESCRIPTION
The core `gh` team discovered that the GPG passphrase secret is base64 encoded now, and so the deployment workflow needs to decode it.