### PR TITLE
Fix: `gh pr create` prioritize `--title` and `--body` over `--fill` when `--web` is present

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -391,8 +391,10 @@ func createRun(opts *CreateOptions) error {
 	var openURL string
 
 	if opts.WebMode {
-		if !(opts.Autofill || opts.FillFirst) {
+		if opts.TitleProvided {
 			state.Title = opts.Title
+		}
+		if opts.BodyProvided {
 			state.Body = opts.Body
 		}
 		if opts.Template != "" {

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -388,15 +388,17 @@ func createRun(opts *CreateOptions) error {
 		return err
 	}
 
+	if opts.TitleProvided {
+		state.Title = opts.Title
+	}
+
+	if opts.BodyProvided {
+		state.Body = opts.Body
+	}
+
 	var openURL string
 
 	if opts.WebMode {
-		if opts.TitleProvided {
-			state.Title = opts.Title
-		}
-		if opts.BodyProvided {
-			state.Body = opts.Body
-		}
 		if opts.Template != "" {
 			state.Template = opts.Template
 		}
@@ -413,14 +415,6 @@ func createRun(opts *CreateOptions) error {
 			return err
 		}
 		return previewPR(*opts, openURL)
-	}
-
-	if opts.TitleProvided {
-		state.Title = opts.Title
-	}
-
-	if opts.BodyProvided {
-		state.Body = opts.Body
 	}
 
 	existingPR, _, err := opts.Finder.Find(shared.FindOptions{

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1590,6 +1590,28 @@ func Test_createRun(t *testing.T) {
 			},
 			expectedOut: "https://github.com/OWNER/REPO/pull/12\n",
 		},
+		{
+			name: "web prioritize title and body over fill",
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.WebMode = true
+				opts.HeadBranch = "feature"
+				opts.TitleProvided = true
+				opts.BodyProvided = true
+				opts.Title = "my title"
+				opts.Body = "my body"
+				opts.Autofill = true
+				return func() {}
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				cs.Register(
+					"git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry origin/master...feature",
+					0,
+					"56b6f8bb7c9e3a30093cd17e48934ce354148e80\u0000second commit of pr\u0000\u0000\n"+
+						"3a9b48085046d156c5acce8f3b3a0532cd706a4a\u0000first commit of pr\u0000first commit description\u0000\n",
+				)
+			},
+			expectedBrowse: "https://github.com/OWNER/REPO/compare/master...feature?body=my+body&expand=1&title=my+title",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #10527 

I had been working on this when I saw that another PR had come out to solve this issue. I didn't see any test cases on that PR so I figured I would throw mine out there to see which you prefer. 