### PR TITLE
Fix test debris from trustedroot integration tests

### DIFF
--- a/pkg/cmd/attestation/trustedroot/trustedroot_test.go
+++ b/pkg/cmd/attestation/trustedroot/trustedroot_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	ghmock "github.com/cli/cli/v2/internal/gh/mock"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/test"
+	"github.com/cli/cli/v2/pkg/cmd/attestation/verification"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -163,6 +165,13 @@ var newTUFErrClient tufClientInstantiator = func(o *tuf.Options) (*tuf.Client, e
 }
 
 func TestGetTrustedRoot(t *testing.T) {
+	// Set integration test flag to use temp directory
+	os.Setenv("GO_INTEGRATION_TEST", "1")
+	defer func() {
+		os.Unsetenv("GO_INTEGRATION_TEST")
+		verification.CleanupTestCache()
+	}()
+
 	mirror := "https://tuf-repo.github.com"
 	root := test.NormalizeRelativePath("../verification/embed/tuf-repo.github.com/root.json")
 
@@ -183,7 +192,6 @@ func TestGetTrustedRoot(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed to read root file")
 	})
-
 }
 
 type stubAuthConfig struct {

--- a/pkg/cmd/attestation/verification/tuf.go
+++ b/pkg/cmd/attestation/verification/tuf.go
@@ -15,6 +15,8 @@ var githubRoot []byte
 
 const GitHubTUFMirror = "https://tuf-repo.github.com"
 
+var testCacheDir string
+
 func DefaultOptionsWithCacheSetting(tufMetadataDir o.Option[string]) *tuf.Options {
 	opts := tuf.DefaultOptions()
 
@@ -26,13 +28,36 @@ func DefaultOptionsWithCacheSetting(tufMetadataDir o.Option[string]) *tuf.Option
 		opts.DisableLocalCache = true
 	}
 
-	// Set the cache path to the provided dir, or a directory owned by the CLI
-	opts.CachePath = tufMetadataDir.UnwrapOr(filepath.Join(config.CacheDir(), ".sigstore", "root"))
+	// During tests, use a temporary directory that will be cleaned up
+	if os.Getenv("GO_INTEGRATION_TEST") == "1" {
+		if testCacheDir == "" {
+			var err error
+			testCacheDir, err = os.MkdirTemp("", "gh-tuf-cache-*")
+			if err == nil {
+				opts.CachePath = testCacheDir
+			}
+		} else {
+			opts.CachePath = testCacheDir
+		}
+	} else {
+		// Set the cache path to the provided dir, or a directory owned by the CLI
+		opts.CachePath = tufMetadataDir.UnwrapOr(filepath.Join(config.CacheDir(), ".sigstore", "root"))
+	}
 
 	// Allow TUF cache for 1 day
 	opts.CacheValidity = 1
 
 	return opts
+}
+
+// CleanupTestCache removes the temporary test cache directory if it exists
+func CleanupTestCache() error {
+	if testCacheDir != "" {
+		err := os.RemoveAll(testCacheDir)
+		testCacheDir = ""
+		return err
+	}
+	return nil
 }
 
 func GitHubTUFOptions(tufMetadataDir o.Option[string]) *tuf.Options {


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

The trustedroot integration tests were leaving TUF repository cache files in the working directory. This PR fixes the issue by:

* Adding a temporary directory mechanism for TUF cache during tests
* Using a shared testCacheDir variable to manage the temp directory
* Creating temp directories only during test runs (when GO_INTEGRATION_TEST=1)
* Adding a CleanupTestCache function to properly remove the temp directory
* Updating tests to use proper cleanup through deferred functions
* The changes ensure that no debris files are left behind after running the tests.

Fixes: #10462

Created with [Solver](https://solverai.com/)