### PR TITLE
Enhance GitHub CLI Documentation with language around -- behavior

### DIFF
--- a/pkg/cmd/search/code/code.go
+++ b/pkg/cmd/search/code/code.go
@@ -39,6 +39,11 @@ func NewCmdCode(f *cmdutil.Factory, runF func(*CodeOptions) error) *cobra.Comman
 			The search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-code>
 
+			When your search query starts with a hyphen (-), you must use "--" to separate the search terms
+			from the command flags. This indicates that any following arguments starting with "-" are part
+			of the search query, not command flags. For example, to exclude test files:
+			  gh search code "func main" -- -path:test
+
 			Note that these search results are powered by what is now a legacy GitHub code search engine.
 			The results might not match what is seen on <github.com>, and new features like regex search
 			are not yet available via the GitHub API.

--- a/pkg/cmd/search/commits/commits.go
+++ b/pkg/cmd/search/commits/commits.go
@@ -45,6 +45,11 @@ func NewCmdCommits(f *cmdutil.Factory, runF func(*CommitsOptions) error) *cobra.
 
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-commits>
+
+			When your search query starts with a hyphen (-), you must use "--" to separate the search terms
+			from the command flags. This indicates that any following arguments starting with "-" are part
+			of the search query, not command flags. For example, to exclude commits from a specific author:
+			  gh search commits -- -author:hubot
 		`),
 		Example: heredoc.Doc(`
 			# Search commits matching set of keywords "readme" and "typo"

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -34,6 +34,11 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
+
+			When your search query starts with a hyphen (-), you must use "--" to separate the search terms
+			from the command flags. This indicates that any following arguments starting with "-" are part
+			of the search query, not command flags. For example, to find issues without any labels:
+			  gh search issues -- -label:*
 		`),
 		Example: heredoc.Doc(`
 			# Search issues matching set of keywords "readme" and "typo"

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -36,6 +36,11 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
+
+			When your search query starts with a hyphen (-), you must use "--" to separate the search terms
+			from the command flags. This indicates that any following arguments starting with "-" are part
+			of the search query, not command flags. For example, to search for PRs without the "bug" label:
+			  gh search prs -- -label:bug
 		`),
 		Example: heredoc.Doc(`
 			# Search pull requests matching set of keywords "fix" and "bug"

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -46,6 +46,11 @@ func NewCmdRepos(f *cmdutil.Factory, runF func(*ReposOptions) error) *cobra.Comm
 
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-for-repositories>
+
+			When your search query starts with a hyphen (-), you must use "--" to separate the search terms
+			from the command flags. This indicates that any following arguments starting with "-" are part
+			of the search query, not command flags. For example, to exclude repositories with topic "legacy":
+			  gh search repos -- -topic:legacy
 		`),
 		Example: heredoc.Doc(`
 			# Search repositories matching set of keywords "cli" and "shell"


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

This PR adds documentation around `--` in the following:
* gh search code
* gh search commits
* gh search issues
* gh search prs
* gh search repos

Fixes: #10480

Created with [Solver](https://solverai.com/)