### PR TITLE
[gh repo sync] Make missing workflow regexp aware of GitHub App

### DIFF
--- a/pkg/cmd/repo/sync/http.go
+++ b/pkg/cmd/repo/sync/http.go
@@ -32,8 +32,8 @@ func latestCommit(client *api.Client, repo ghrepo.Interface, branch string) (com
 
 type upstreamMergeErr struct{ error }
 
-var missingWorkflowScopeRE = regexp.MustCompile("refusing to allow.*without `workflow` scope")
-var missingWorkflowScopeErr = errors.New("Upstream commits contain workflow changes, which require the `workflow` scope to merge. To request it, run: gh auth refresh -s workflow")
+var missingWorkflowScopeRE = regexp.MustCompile("refusing to allow.*without `workflow(s)?` (scope|permission)")
+var missingWorkflowScopeErr = errors.New("Upstream commits contain workflow changes, which require the `workflow` scope or permission to merge. To request it, run: gh auth refresh -s workflow")
 
 func triggerUpstreamMerge(client *api.Client, repo ghrepo.Interface, branch string) (string, error) {
 	var payload bytes.Buffer


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/10573
Follow up of https://github.com/cli/cli/pull/7612

The `missingWorkflowScopeRE` is defined to capture the error message when the `GH_TOKEN` does not have `workflow` scope in `gh repo sync <remote>`, but this is only intended for error messages for OAuth Apps and does not work with GitHub Apps.

In GitHub App, you will get the following error:

```
{
  "message": "refusing to allow a GitHub App to create or update workflow `.github/workflows/teamcity-pr-checks.yml` without `workflows` permission",
  "documentation_url": "https://docs.github.com/rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository",
  "status": "422"
}
```

As you can see above, the existing regexp does not match the "`workflows` permission".

This change modifies the regexp to return the user-friendly error message when the `workflow` permission is missing, even in the case of a GitHub App.
