### PR TITLE
fix: respect edit-last and create-if-none in non-interactive mode

### DIFF
--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -110,6 +110,8 @@ func CommentableRun(opts *CommentableOptions) error {
 					return errNoUserComments
 				}
 			}
+		} else if !opts.CreateIfNone {
+			return errNoUserComments
 		}
 	}
 	return createComment(commentable, opts)


### PR DESCRIPTION
Fixes #10580 

Previous changes made in #10427 created a behavioral change when using i.e. `gh pr comment --edit-last` in non-interactive mode, which was not properly accounted for. Ideally, using `--edit-last` should error out if the newer `--create-if-none` flag is not used, instead of creating a new comment anyway.

~~Assistance on updating tests would be appreciated, this is my first time editing Golang code. :)~~

Edit: tested locally, should be working now. And the changes are much smaller than originally pushed. 🙂 