### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/pkg/cmd/pr/update-branch/update_branch.go
+++ b/pkg/cmd/pr/update-branch/update_branch.go
@@ -43,7 +43,7 @@ func NewCmdUpdateBranch(f *cmdutil.Factory, runF func(*UpdateBranchOptions) erro
 			Without an argument, the pull request that belongs to the current branch is selected.
 
 			The default behavior is to update with a merge commit (i.e., merging the base branch
-			into the the PR's branch). To reconcile the changes with rebasing on top of the base
+			into the PR's branch). To reconcile the changes with rebasing on top of the base
 			branch, the %[1]s--rebase%[1]s option should be provided.
 		`, "`"),
 		Example: heredoc.Doc(`


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

remove redundant word in comment