### PR TITLE
Feat: Add `gh release checkout` command

### DIFF
--- a/pkg/cmd/release/checkout/checkout.go
+++ b/pkg/cmd/release/checkout/checkout.go
@@ -1,0 +1,88 @@
+package checkout
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	cliContext "github.com/cli/cli/v2/context"
+	"github.com/cli/cli/v2/git"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type CheckoutOptions struct {
+	HttpClient func() (*http.Client, error)
+	GitClient  *git.Client
+	IO         *iostreams.IOStreams
+	Remotes    func() (cliContext.Remotes, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+	Config     func() (gh.Config, error)
+
+	Force             bool
+	RecurseSubmodules bool
+	BranchName        string
+	TagName           string
+}
+
+func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobra.Command {
+	opts := &CheckoutOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		GitClient:  f.GitClient,
+		Remotes:    f.Remotes,
+		Config:     f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "checkout [<tag>]",
+		Short: "Check out a release tag in git",
+		Long: heredoc.Doc(`
+			Check out a GitHub release tag in your local repository.
+
+			Without a tag name, the latest release in the repository is checked out.
+			Use the --repo flag to specify a repository other than the current one.
+		`),
+		Example: heredoc.Doc(`
+			# Checkout the latest release
+			$ gh release checkout
+
+			# Checkout a specific release tag
+			$ gh release checkout v2.67.0
+
+			# Checkout a release from a non-local repo
+			$ gh release checkout v2.67.0 --repo cli/cli
+
+			# Checkout with a custom branch name
+			$ gh release checkout v2.67.0 -b my-release-branch
+		`),
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.BaseRepo = f.BaseRepo
+
+			if len(args) > 0 {
+				opts.TagName = args[0]
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return checkoutRun(opts)
+		},
+	}
+
+	// Flags
+	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Force checkout, resetting any local branch to the release tag")
+	cmd.Flags().BoolVarP(&opts.RecurseSubmodules, "recurse-submodules", "", false, "Update all submodules after checkout")
+	cmd.Flags().StringVarP(&opts.BranchName, "branch", "b", "", "Local branch name to use (default: tag name)")
+
+	return cmd
+}
+
+func checkoutRun(opts *CheckoutOptions) error {
+	fmt.Println("fetching release...")
+	return nil
+}

--- a/pkg/cmd/release/checkout/checkout.go
+++ b/pkg/cmd/release/checkout/checkout.go
@@ -2,9 +2,13 @@ package checkout
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -19,14 +23,16 @@ import (
 )
 
 type CheckoutOptions struct {
-	HttpClient func() (*http.Client, error)
-	GitClient  *git.Client
-	IO         *iostreams.IOStreams
-	Remotes    func() (cliContext.Remotes, error)
-	BaseRepo   func() (ghrepo.Interface, error)
-	Config     func() (gh.Config, error)
+	HttpClient     func() (*http.Client, error)
+	GitClient      *git.Client
+	IO             *iostreams.IOStreams
+	Remotes        func() (cliContext.Remotes, error)
+	BaseRepo       func() (ghrepo.Interface, error)
+	Config         func() (gh.Config, error)
+	IsLocalGitRepo bool
 
 	Force             bool
+	Yes               bool
 	RecurseSubmodules bool
 	BranchName        string
 	TagName           string
@@ -45,23 +51,24 @@ func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobr
 		Use:   "checkout [<tag>]",
 		Short: "Check out a release tag",
 		Long: heredoc.Doc(`
-			Check out a GitHub release tag in your local repository.
+			Check out a GitHub release tag.
 
-			Without a tag name, the latest release in the repository is checked out.
-			Use the --repo flag to specify a repository other than the current one.
+			In a local repository, checks out the specified release tag.
+			With --repo, clones the specified repository to a directory named '<reponame>-<releasetag>' if not in a matching Git repository.
+			Without a tag, checks out the latest release.
 		`),
 		Example: heredoc.Doc(`
-			# Checkout the latest release
+			# Checkout the latest release in the current repo
 			$ gh release checkout
 
-			# Checkout a specific release tag
+			# Checkout a specific tag in the current repo
 			$ gh release checkout v1.2.3
 
-			# Checkout a release from a non-local repo
+			# Clone and checkout a release from an external repo
 			$ gh release checkout v1.2.3 --repo owner/repo
 
-			# Checkout in a custom branch name
-			$ gh release checkout v1.2.3 -b my-release-branch
+			# Clone with a custom branch name
+			$ gh release checkout v1.2.3 -b my-branch --repo owner/repo
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -71,8 +78,14 @@ func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobr
 				opts.TagName = args[0]
 			}
 
-			if !opts.IO.IsStdoutTTY() && !opts.IO.IsStdinTTY() && opts.TagName == "" {
+			if !opts.IO.CanPrompt() && opts.TagName == "" {
 				return cmdutil.FlagErrorf("release tag argument required when not running interactively")
+			}
+
+			_, err := opts.Remotes()
+			opts.IsLocalGitRepo = err == nil
+			if !opts.IsLocalGitRepo && !cmd.Flags().Changed("repo") {
+				return fmt.Errorf("not in a Git repository and no --repo specified.\nPlease run from a Git repository or use --repo to specify a repository to checkout release")
 			}
 
 			if runF != nil {
@@ -82,8 +95,8 @@ func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobr
 		},
 	}
 
-	// Flags
 	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Force checkout, resetting any local branch to the release tag")
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Skip confirmation prompt when overwriting an existing directory or branch")
 	cmd.Flags().BoolVarP(&opts.RecurseSubmodules, "recurse-submodules", "", false, "Update all submodules after checkout")
 	cmd.Flags().StringVarP(&opts.BranchName, "branch", "b", "", "Local branch name to use (default: tag name)")
 
@@ -102,64 +115,130 @@ func checkoutRun(opts *CheckoutOptions) error {
 	}
 
 	ctx := context.Background()
-	var release *shared.Release
-
-	if opts.TagName == "" {
-		release, err = shared.FetchLatestRelease(ctx, httpClient, baseRepo)
-		if err != nil {
-			return cmdutil.FlagErrorf("failed to fetch latest release: %w", err)
-		}
-	} else {
-		release, err = shared.FetchRelease(ctx, httpClient, baseRepo, opts.TagName)
-		if err != nil {
-			return cmdutil.FlagErrorf("failed to fetch release %s: %w", opts.TagName, err)
-		}
-	}
-
-	// Validate tag name (simple check)
-	if strings.HasPrefix(release.TagName, "-") || strings.Contains(release.TagName, " ") {
-		return cmdutil.FlagErrorf("invalid tag name: %q", release.TagName)
-	}
 
 	cfg, err := opts.Config()
 	if err != nil {
 		return err
 	}
 	protocol := cfg.GitProtocol(baseRepo.RepoHost()).Value
+	remoteURL := ghrepo.FormatRemoteURL(baseRepo, protocol)
 
-	remotes, err := opts.Remotes()
+	var baseRemote *cliContext.Remote
+	var repoMatches bool
+	if opts.IsLocalGitRepo {
+		remotes, err := opts.Remotes()
+		if err != nil {
+			return fmt.Errorf("unexpected failure checking remotes: %w", err)
+		}
+		baseRemote, _ = remotes.FindByRepo(baseRepo.RepoOwner(), baseRepo.RepoName())
+		repoMatches = baseRemote != nil
+	}
+
+	if opts.IsLocalGitRepo && !repoMatches {
+		remotes, _ := opts.Remotes()
+		currentRepo := "unknown"
+		if len(remotes) > 0 {
+			currentRepo = fmt.Sprintf("%s/%s", remotes[0].RepoOwner(), remotes[0].RepoName())
+		}
+		return fmt.Errorf("--repo %s doesn't match the current repository (%s).\nRun outside a Git repo to checkout release, or omit --repo to use the current repo", ghrepo.FullName(baseRepo), currentRepo)
+	}
+
+	var release *shared.Release
+	fetchMessage := fmt.Sprintf("Fetching release info for %s...", ghrepo.FullName(baseRepo))
+	if opts.IO.IsStdoutTTY() {
+		opts.IO.StartProgressIndicatorWithLabel(fetchMessage)
+	}
+	if opts.TagName == "" {
+		release, err = shared.FetchLatestRelease(ctx, httpClient, baseRepo)
+	} else {
+		release, err = shared.FetchRelease(ctx, httpClient, baseRepo, opts.TagName)
+	}
+	if opts.IO.IsStdoutTTY() {
+		opts.IO.StopProgressIndicator()
+	}
 	if err != nil {
-		return err
-	}
-	baseRemote, _ := remotes.FindByRepo(baseRepo.RepoOwner(), baseRepo.RepoName())
-	baseURLOrName := ghrepo.FormatRemoteURL(baseRepo, protocol)
-	if baseRemote != nil {
-		baseURLOrName = baseRemote.Name
+		return fmt.Errorf("failed to fetch release %s: %w", opts.TagName, err)
 	}
 
-	var cmdQueue [][]string
 	localBranch := release.TagName
 	if opts.BranchName != "" {
 		localBranch = opts.BranchName
 	}
 
-	refSpec := fmt.Sprintf("refs/tags/%s", release.TagName)
-	cmdQueue = append(cmdQueue, []string{"fetch", baseURLOrName, refSpec, "--no-tags"})
-
 	cs := opts.IO.ColorScheme()
-	if localBranchExists(opts.GitClient, localBranch) {
-		if opts.IO.IsStdoutTTY() && opts.IO.IsStdinTTY() && !opts.Force {
-			fmt.Fprintf(opts.IO.Out, "A branch named '%s' already exists. Proceeding may overwrite local changes.\n", localBranch)
-			confirmed, err := confirm(opts.IO, "Do you want to proceed? [y/N] ")
-			if err != nil {
-				return fmt.Errorf("failed to get confirmation: %w", err)
-			}
-			if !confirmed {
-				fmt.Fprintf(opts.IO.Out, "%s Checkout aborted\n", cs.Yellow("!"))
-				return nil
+
+	if !opts.IsLocalGitRepo || !repoMatches {
+		targetDir := fmt.Sprintf("%s-%s", baseRepo.RepoName(), release.TagName)
+		if err := handleExistingDir(opts, targetDir, baseRepo, release.TagName, cs); err != nil {
+			return err
+		}
+
+		cloneArgs := []string{"--branch", release.TagName}
+		if opts.RecurseSubmodules {
+			cloneArgs = append(cloneArgs, "--recurse-submodules")
+		}
+		fetchMessage = fmt.Sprintf("Fetching %s@%s...", ghrepo.FullName(baseRepo), release.TagName)
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		if opts.IO.IsStdoutTTY() {
+			opts.IO.StartProgressIndicatorWithLabel(fetchMessage)
+		}
+		defaultTarget, err := opts.GitClient.Clone(ctx, remoteURL, cloneArgs, git.WithStdout(stdout), git.WithStderr(stderr))
+		if opts.IO.IsStdoutTTY() {
+			opts.IO.StopProgressIndicator()
+		}
+		if err != nil {
+			_, _ = io.Copy(opts.IO.ErrOut, stderr)
+			return fmt.Errorf("failed to clone repository: %w", err)
+		}
+		if defaultTarget != targetDir {
+			if err := os.Rename(defaultTarget, targetDir); err != nil {
+				return fmt.Errorf("failed to rename cloned directory from %s to %s: %w", defaultTarget, targetDir, err)
 			}
 		}
 
+		absTargetDir, err := filepath.Abs(targetDir)
+		if err != nil {
+			return fmt.Errorf("failed to get absolute path of cloned directory: %w", err)
+		}
+		cmd, err := opts.GitClient.Command(ctx, "checkout", "-b", localBranch)
+		if err != nil {
+			return fmt.Errorf("failed to prepare checkout command: %w", err)
+		}
+		cmd.Dir = absTargetDir
+		cmd.Stdout = nil
+		cmd.Stderr = opts.IO.ErrOut
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to create branch after clone: %w", err)
+		}
+
+		if opts.IO.IsStdoutTTY() {
+			fmt.Fprintf(opts.IO.Out, "%s Cloned %s@%s to %s\n", cs.SuccessIconWithColor(cs.Green), ghrepo.FullName(baseRepo), release.TagName, targetDir)
+		} else {
+			fmt.Fprintln(opts.IO.Out, targetDir)
+		}
+		return nil
+	}
+
+	baseURLOrName := baseRemote.Name
+	var cmdQueue [][]string
+	refSpec := fmt.Sprintf("refs/tags/%s", release.TagName)
+	fetchMessage = fmt.Sprintf("Fetching %s@%s...", ghrepo.FullName(baseRepo), release.TagName)
+	if opts.IO.IsStdoutTTY() {
+		opts.IO.StartProgressIndicatorWithLabel(fetchMessage)
+	}
+	err = executeCmds(opts.GitClient, git.CredentialPatternFromHost(baseRepo.RepoHost()), [][]string{{"fetch", baseURLOrName, refSpec, "--no-tags"}})
+	if opts.IO.IsStdoutTTY() {
+		opts.IO.StopProgressIndicator()
+	}
+	if err != nil {
+		return fmt.Errorf("failed to fetch release tag: %w", err)
+	}
+
+	if localBranchExists(opts.GitClient, localBranch) {
+		if err := handleExistingBranch(opts, localBranch, release.TagName, cs); err != nil {
+			return err
+		}
 		cmdQueue = append(cmdQueue, []string{"checkout", localBranch})
 		if opts.Force {
 			cmdQueue = append(cmdQueue, []string{"reset", "--hard", refSpec})
@@ -171,8 +250,7 @@ func checkoutRun(opts *CheckoutOptions) error {
 	}
 
 	if opts.RecurseSubmodules {
-		cmdQueue = append(cmdQueue, []string{"submodule", "sync", "--recursive"})
-		cmdQueue = append(cmdQueue, []string{"submodule", "update", "--init", "--recursive"})
+		cmdQueue = append(cmdQueue, []string{"submodule", "sync", "--recursive"}, []string{"submodule", "update", "--init", "--recursive"})
 	}
 
 	err = executeCmds(opts.GitClient, git.CredentialPatternFromHost(baseRepo.RepoHost()), cmdQueue)
@@ -183,11 +261,47 @@ func checkoutRun(opts *CheckoutOptions) error {
 	if opts.IO.IsStdoutTTY() {
 		fmt.Fprintf(opts.IO.Out, "%s Checked out %s to %s\n", cs.SuccessIconWithColor(cs.Green), release.TagName, localBranch)
 	}
-
 	return nil
 }
 
-// localBranchExists checks if a local branch already exists
+// handleExistingDir checks and handles an existing directory before cloning
+func handleExistingDir(opts *CheckoutOptions, targetDir string, baseRepo ghrepo.Interface, tagName string, cs *iostreams.ColorScheme) error {
+	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
+		return nil
+	}
+	if !opts.IO.CanPrompt() || opts.Yes {
+		return os.RemoveAll(targetDir)
+	}
+	prompt := fmt.Sprintf("Directory '%s' already exists. Overwrite by cloning %s@%s? [y/N] ", targetDir, ghrepo.FullName(baseRepo), tagName)
+	confirmed, err := confirm(opts.IO, prompt)
+	if err != nil {
+		return fmt.Errorf("failed to get confirmation: %w", err)
+	}
+	if !confirmed {
+		fmt.Fprintf(opts.IO.Out, "%s Checkout aborted\n", cs.Yellow("!"))
+		return cmdutil.SilentError
+	}
+	return os.RemoveAll(targetDir)
+}
+
+// handleExistingBranch checks and handles an existing branch before checkout
+func handleExistingBranch(opts *CheckoutOptions, branch, tagName string, cs *iostreams.ColorScheme) error {
+	if opts.Force || opts.Yes || !opts.IO.CanPrompt() {
+		return nil
+	}
+	prompt := fmt.Sprintf("Branch '%s' already exists. Overwrite with %s? [y/N] ", branch, tagName)
+	confirmed, err := confirm(opts.IO, prompt)
+	if err != nil {
+		return fmt.Errorf("failed to get confirmation: %w", err)
+	}
+	if !confirmed {
+		fmt.Fprintf(opts.IO.Out, "%s Checkout aborted\n", cs.Yellow("!"))
+		return cmdutil.SilentError
+	}
+	return nil
+}
+
+// localBranchExists checks if a local branch exists
 func localBranchExists(client *git.Client, branch string) bool {
 	_, err := client.ShowRefs(context.Background(), []string{"refs/heads/" + branch})
 	return err == nil
@@ -195,38 +309,40 @@ func localBranchExists(client *git.Client, branch string) bool {
 
 // confirm prompts the user for a yes/no response, defaulting to no
 func confirm(io *iostreams.IOStreams, prompt string) (bool, error) {
-	if !io.IsStdinTTY() || !io.IsStdoutTTY() {
+	if !io.CanPrompt() {
 		return false, nil
 	}
-
 	fmt.Fprint(io.Out, prompt)
 	reader := bufio.NewReader(io.In)
 	response, err := reader.ReadString('\n')
 	if err != nil {
 		return false, err
 	}
-
 	response = strings.TrimSpace(strings.ToLower(response))
 	return response == "y" || response == "yes", nil
 }
 
-// executeCmds runs a queue of Git commands with appropriate credential handling
+// executeCmds runs a queue of Git commands with output suppression
 func executeCmds(client *git.Client, credentialPattern git.CredentialPattern, cmdQueue [][]string) error {
+	ctx := context.Background()
 	for _, args := range cmdQueue {
-		var err error
 		var cmd *git.Command
+		var err error
 		switch args[0] {
 		case "submodule":
-			cmd, err = client.AuthenticatedCommand(context.Background(), credentialPattern, args...)
+			cmd, err = client.AuthenticatedCommand(ctx, credentialPattern, args...)
 		case "fetch":
-			cmd, err = client.AuthenticatedCommand(context.Background(), git.AllMatchingCredentialsPattern, args...)
+			cmd, err = client.AuthenticatedCommand(ctx, git.AllMatchingCredentialsPattern, args...)
 		default:
-			cmd, err = client.Command(context.Background(), args...)
+			cmd, err = client.Command(ctx, args...)
 		}
 		if err != nil {
 			return err
 		}
+		cmd.Stdout = nil
+		cmd.Stderr = &bytes.Buffer{}
 		if err := cmd.Run(); err != nil {
+			_, _ = io.Copy(os.Stderr, cmd.Stderr.(*bytes.Buffer))
 			return err
 		}
 	}

--- a/pkg/cmd/release/checkout/checkout.go
+++ b/pkg/cmd/release/checkout/checkout.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -49,11 +51,11 @@ func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobr
 
 	cmd := &cobra.Command{
 		Use:   "checkout [<tag>]",
-		Short: "Check out a release tag",
+		Short: "Check out a release",
 		Long: heredoc.Doc(`
-			Check out a GitHub release tag.
+			Check out a GitHub release.
 
-			In a local repository, checks out the specified release tag.
+			In a local repository, checks out the specified release.
 			With --repo, clones the specified repository to a directory named '<reponame>-<releasetag>' if not in a matching Git repository.
 			Without a tag, checks out the latest release.
 		`),
@@ -61,13 +63,13 @@ func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobr
 			# Checkout the latest release in the current repo
 			$ gh release checkout
 
-			# Checkout a specific tag in the current repo
+			# Checkout a specific release in the current repo
 			$ gh release checkout v1.2.3
 
-			# Clone and checkout a release from an external repo
+			# Checkout a release from an external repo
 			$ gh release checkout v1.2.3 --repo owner/repo
 
-			# Clone with a custom branch name
+			# Checkout in a custom branch name
 			$ gh release checkout v1.2.3 -b my-branch --repo owner/repo
 		`),
 		Args: cobra.MaximumNArgs(1),
@@ -125,6 +127,7 @@ func checkoutRun(opts *CheckoutOptions) error {
 
 	var baseRemote *cliContext.Remote
 	var repoMatches bool
+
 	if opts.IsLocalGitRepo {
 		remotes, err := opts.Remotes()
 		if err != nil {
@@ -140,11 +143,13 @@ func checkoutRun(opts *CheckoutOptions) error {
 		if len(remotes) > 0 {
 			currentRepo = fmt.Sprintf("%s/%s", remotes[0].RepoOwner(), remotes[0].RepoName())
 		}
-		return fmt.Errorf("--repo %s doesn't match the current repository (%s).\nRun outside a Git repo to checkout release, or omit --repo to use the current repo", ghrepo.FullName(baseRepo), currentRepo)
+		return fmt.Errorf("--repo %s doesn't match the current repository (%s).\nTry running out of a Git repo to checkout release, or omit --repo to checkout for current repo", ghrepo.FullName(baseRepo), currentRepo)
 	}
 
 	var release *shared.Release
+
 	fetchMessage := fmt.Sprintf("Fetching release info for %s...", ghrepo.FullName(baseRepo))
+
 	if opts.IO.IsStdoutTTY() {
 		opts.IO.StartProgressIndicatorWithLabel(fetchMessage)
 	}
@@ -167,7 +172,7 @@ func checkoutRun(opts *CheckoutOptions) error {
 
 	cs := opts.IO.ColorScheme()
 
-	if !opts.IsLocalGitRepo || !repoMatches {
+	if !opts.IsLocalGitRepo {
 		targetDir := fmt.Sprintf("%s-%s", baseRepo.RepoName(), release.TagName)
 		if err := handleExistingDir(opts, targetDir, baseRepo, release.TagName, cs); err != nil {
 			return err
@@ -209,7 +214,7 @@ func checkoutRun(opts *CheckoutOptions) error {
 		cmd.Stdout = nil
 		cmd.Stderr = opts.IO.ErrOut
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to create branch after clone: %w", err)
+			return fmt.Errorf("failed to create branch after checkout: %w", err)
 		}
 
 		if opts.IO.IsStdoutTTY() {
@@ -266,8 +271,12 @@ func checkoutRun(opts *CheckoutOptions) error {
 
 // handleExistingDir checks and handles an existing directory before cloning
 func handleExistingDir(opts *CheckoutOptions, targetDir string, baseRepo ghrepo.Interface, tagName string, cs *iostreams.ColorScheme) error {
-	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
+	_, err := os.Stat(targetDir)
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to stat directory %s: %w", targetDir, err)
 	}
 	if !opts.IO.CanPrompt() || opts.Yes {
 		return os.RemoveAll(targetDir)
@@ -278,7 +287,11 @@ func handleExistingDir(opts *CheckoutOptions, targetDir string, baseRepo ghrepo.
 		return fmt.Errorf("failed to get confirmation: %w", err)
 	}
 	if !confirmed {
-		fmt.Fprintf(opts.IO.Out, "%s Checkout aborted\n", cs.Yellow("!"))
+		msg := "! Checkout aborted\n"
+		if cs != nil {
+			msg = fmt.Sprintf("%s Checkout aborted\n", cs.Yellow("!"))
+		}
+		fmt.Fprint(opts.IO.Out, msg)
 		return cmdutil.SilentError
 	}
 	return os.RemoveAll(targetDir)

--- a/pkg/cmd/release/checkout/checkout.go
+++ b/pkg/cmd/release/checkout/checkout.go
@@ -1,14 +1,18 @@
 package checkout
 
 import (
+	"bufio"
+	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	cliContext "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/release/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/spf13/cobra"
@@ -83,6 +87,142 @@ func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobr
 }
 
 func checkoutRun(opts *CheckoutOptions) error {
-	fmt.Println("fetching release...")
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	var release *shared.Release
+
+	if opts.TagName == "" {
+		release, err = shared.FetchLatestRelease(ctx, httpClient, baseRepo)
+		if err != nil {
+			return fmt.Errorf("failed to fetch latest release: %w", err)
+		}
+	} else {
+		release, err = shared.FetchRelease(ctx, httpClient, baseRepo, opts.TagName)
+		if err != nil {
+			return fmt.Errorf("failed to fetch release %s: %w", opts.TagName, err)
+		}
+	}
+
+	if strings.HasPrefix(release.TagName, "-") {
+		return fmt.Errorf("invalid tag name: %q", release.TagName)
+	}
+
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+	protocol := cfg.GitProtocol(baseRepo.RepoHost()).Value
+
+	remotes, err := opts.Remotes()
+	if err != nil {
+		return err
+	}
+	baseRemote, _ := remotes.FindByRepo(baseRepo.RepoOwner(), baseRepo.RepoName())
+	baseURLOrName := ghrepo.FormatRemoteURL(baseRepo, protocol)
+	if baseRemote != nil {
+		baseURLOrName = baseRemote.Name
+	}
+
+	var cmdQueue [][]string
+	localBranch := release.TagName
+	if opts.BranchName != "" {
+		localBranch = opts.BranchName
+	}
+
+	refSpec := fmt.Sprintf("refs/tags/%s", release.TagName)
+	cmdQueue = append(cmdQueue, []string{"fetch", baseURLOrName, refSpec, "--no-tags"})
+
+	if localBranchExists(opts.GitClient, localBranch) {
+		if opts.IO.IsStdoutTTY() && !opts.Force {
+			fmt.Fprintf(opts.IO.Out, "A branch named '%s' already exists. Proceeding may overwrite local changes.\n", localBranch)
+			confirmed, err := confirm(opts.IO, "Do you want to proceed? [y/N] ")
+			if err != nil {
+				return fmt.Errorf("failed to get confirmation: %w", err)
+			}
+			if !confirmed {
+				fmt.Fprintf(opts.IO.Out, "Aborted.\n")
+				return nil
+			}
+		}
+
+		cmdQueue = append(cmdQueue, []string{"checkout", localBranch})
+		if opts.Force {
+			cmdQueue = append(cmdQueue, []string{"reset", "--hard", refSpec})
+		} else {
+			cmdQueue = append(cmdQueue, []string{"merge", "--ff-only", refSpec})
+		}
+	} else {
+		cmdQueue = append(cmdQueue, []string{"checkout", "-b", localBranch, refSpec})
+	}
+
+	if opts.RecurseSubmodules {
+		cmdQueue = append(cmdQueue, []string{"submodule", "sync", "--recursive"})
+		cmdQueue = append(cmdQueue, []string{"submodule", "update", "--init", "--recursive"})
+	}
+
+	err = executeCmds(opts.GitClient, git.CredentialPatternFromHost(baseRepo.RepoHost()), cmdQueue)
+	if err != nil {
+		return fmt.Errorf("failed to execute git commands: %w", err)
+	}
+
+	if opts.IO.IsStdoutTTY() {
+		fmt.Fprintf(opts.IO.Out, "Checked out %s to %s\n", release.TagName, localBranch)
+	}
+
+	return nil
+}
+
+// localBranchExists checks if a local branch already exists
+func localBranchExists(client *git.Client, branch string) bool {
+	_, err := client.ShowRefs(context.Background(), []string{"refs/heads/" + branch})
+	return err == nil
+}
+
+// confirm prompts the user for a yes/no response, defaulting to no
+func confirm(io *iostreams.IOStreams, prompt string) (bool, error) {
+	if !io.IsStdinTTY() || !io.IsStdoutTTY() {
+		return false, nil
+	}
+
+	fmt.Fprint(io.Out, prompt)
+	reader := bufio.NewReader(io.In)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	response = strings.TrimSpace(strings.ToLower(response))
+	return response == "y" || response == "yes", nil
+}
+
+// executeCmds runs a queue of Git commands with appropriate credential handling
+func executeCmds(client *git.Client, credentialPattern git.CredentialPattern, cmdQueue [][]string) error {
+	for _, args := range cmdQueue {
+		var err error
+		var cmd *git.Command
+		switch args[0] {
+		case "submodule":
+			cmd, err = client.AuthenticatedCommand(context.Background(), credentialPattern, args...)
+		case "fetch":
+			cmd, err = client.AuthenticatedCommand(context.Background(), git.AllMatchingCredentialsPattern, args...)
+		default:
+			cmd, err = client.Command(context.Background(), args...)
+		}
+		if err != nil {
+			return err
+		}
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/cmd/release/checkout/checkout.go
+++ b/pkg/cmd/release/checkout/checkout.go
@@ -43,7 +43,7 @@ func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobr
 
 	cmd := &cobra.Command{
 		Use:   "checkout [<tag>]",
-		Short: "Check out a release tag in git",
+		Short: "Check out a release tag",
 		Long: heredoc.Doc(`
 			Check out a GitHub release tag in your local repository.
 
@@ -55,13 +55,13 @@ func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobr
 			$ gh release checkout
 
 			# Checkout a specific release tag
-			$ gh release checkout v2.67.0
+			$ gh release checkout v1.2.3
 
 			# Checkout a release from a non-local repo
-			$ gh release checkout v2.67.0 --repo cli/cli
+			$ gh release checkout v1.2.3 --repo owner/repo
 
-			# Checkout with a custom branch name
-			$ gh release checkout v2.67.0 -b my-release-branch
+			# Checkout in a custom branch name
+			$ gh release checkout v1.2.3 -b my-release-branch
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -69,6 +69,10 @@ func NewCmdCheckout(f *cmdutil.Factory, runF func(*CheckoutOptions) error) *cobr
 
 			if len(args) > 0 {
 				opts.TagName = args[0]
+			}
+
+			if !opts.IO.IsStdoutTTY() && !opts.IO.IsStdinTTY() && opts.TagName == "" {
+				return cmdutil.FlagErrorf("release tag argument required when not running interactively")
 			}
 
 			if runF != nil {
@@ -103,17 +107,18 @@ func checkoutRun(opts *CheckoutOptions) error {
 	if opts.TagName == "" {
 		release, err = shared.FetchLatestRelease(ctx, httpClient, baseRepo)
 		if err != nil {
-			return fmt.Errorf("failed to fetch latest release: %w", err)
+			return cmdutil.FlagErrorf("failed to fetch latest release: %w", err)
 		}
 	} else {
 		release, err = shared.FetchRelease(ctx, httpClient, baseRepo, opts.TagName)
 		if err != nil {
-			return fmt.Errorf("failed to fetch release %s: %w", opts.TagName, err)
+			return cmdutil.FlagErrorf("failed to fetch release %s: %w", opts.TagName, err)
 		}
 	}
 
-	if strings.HasPrefix(release.TagName, "-") {
-		return fmt.Errorf("invalid tag name: %q", release.TagName)
+	// Validate tag name (simple check)
+	if strings.HasPrefix(release.TagName, "-") || strings.Contains(release.TagName, " ") {
+		return cmdutil.FlagErrorf("invalid tag name: %q", release.TagName)
 	}
 
 	cfg, err := opts.Config()
@@ -141,15 +146,16 @@ func checkoutRun(opts *CheckoutOptions) error {
 	refSpec := fmt.Sprintf("refs/tags/%s", release.TagName)
 	cmdQueue = append(cmdQueue, []string{"fetch", baseURLOrName, refSpec, "--no-tags"})
 
+	cs := opts.IO.ColorScheme()
 	if localBranchExists(opts.GitClient, localBranch) {
-		if opts.IO.IsStdoutTTY() && !opts.Force {
+		if opts.IO.IsStdoutTTY() && opts.IO.IsStdinTTY() && !opts.Force {
 			fmt.Fprintf(opts.IO.Out, "A branch named '%s' already exists. Proceeding may overwrite local changes.\n", localBranch)
 			confirmed, err := confirm(opts.IO, "Do you want to proceed? [y/N] ")
 			if err != nil {
 				return fmt.Errorf("failed to get confirmation: %w", err)
 			}
 			if !confirmed {
-				fmt.Fprintf(opts.IO.Out, "Aborted.\n")
+				fmt.Fprintf(opts.IO.Out, "%s Checkout aborted\n", cs.Yellow("!"))
 				return nil
 			}
 		}
@@ -175,7 +181,7 @@ func checkoutRun(opts *CheckoutOptions) error {
 	}
 
 	if opts.IO.IsStdoutTTY() {
-		fmt.Fprintf(opts.IO.Out, "Checked out %s to %s\n", release.TagName, localBranch)
+		fmt.Fprintf(opts.IO.Out, "%s Checked out %s to %s\n", cs.SuccessIconWithColor(cs.Green), release.TagName, localBranch)
 	}
 
 	return nil

--- a/pkg/cmd/release/checkout/checkout_test.go
+++ b/pkg/cmd/release/checkout/checkout_test.go
@@ -1,0 +1,295 @@
+package checkout
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	cliContext "github.com/cli/cli/v2/context"
+	"github.com/cli/cli/v2/git"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/run"
+	"github.com/cli/cli/v2/pkg/cmd/release/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdCheckout(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    string
+		isTTY   bool
+		want    CheckoutOptions
+		wantErr string
+	}{
+		{
+			name:  "no arguments",
+			args:  "",
+			isTTY: true,
+			want: CheckoutOptions{
+				TagName: "",
+			},
+		},
+		{
+			name:  "specific tag",
+			args:  "v1.2.3",
+			isTTY: true,
+			want: CheckoutOptions{
+				TagName: "v1.2.3",
+			},
+		},
+		{
+			name:  "force flag",
+			args:  "--force v1.2.3",
+			isTTY: true,
+			want: CheckoutOptions{
+				TagName: "v1.2.3",
+				Force:   true,
+			},
+		},
+		{
+			name:  "custom branch",
+			args:  "-b my-branch v1.2.3",
+			isTTY: true,
+			want: CheckoutOptions{
+				TagName:    "v1.2.3",
+				BranchName: "my-branch",
+			},
+		},
+		{
+			name:  "recurse submodules",
+			args:  "--recurse-submodules v1.2.3",
+			isTTY: true,
+			want: CheckoutOptions{
+				TagName:           "v1.2.3",
+				RecurseSubmodules: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+			var opts *CheckoutOptions
+			cmd := NewCmdCheckout(f, func(o *CheckoutOptions) error {
+				opts = o
+				return nil
+			})
+			argv, err := shlex.Split(tt.args)
+			require.NoError(t, err)
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			_, err = cmd.ExecuteC()
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.TagName, opts.TagName)
+			assert.Equal(t, tt.want.Force, opts.Force)
+			assert.Equal(t, tt.want.BranchName, opts.BranchName)
+			assert.Equal(t, tt.want.RecurseSubmodules, opts.RecurseSubmodules)
+		})
+	}
+}
+
+func Test_checkoutRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       *CheckoutOptions
+		runStubs   func(*run.CommandStubber)
+		stdin      string
+		isTTY      bool
+		wantStdout string
+		wantStderr string
+		wantErr    string
+	}{
+		{
+			name: "checkout latest release",
+			opts: &CheckoutOptions{
+				TagName: "",
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
+				cs.Register(`git show-ref --verify -- refs/heads/v1.2.3`, 1, "")
+				cs.Register(`git checkout -b v1.2.3 refs/tags/v1.2.3`, 0, "")
+			},
+			isTTY:      true,
+			wantStdout: "✓ Checked out v1.2.3 to v1.2.3\n",
+			wantStderr: "",
+		},
+		{
+			name: "checkout specific release",
+			opts: &CheckoutOptions{
+				TagName: "v1.2.3",
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
+				cs.Register(`git show-ref --verify -- refs/heads/v1.2.3`, 1, "")
+				cs.Register(`git checkout -b v1.2.3 refs/tags/v1.2.3`, 0, "")
+			},
+			isTTY:      true,
+			wantStdout: "✓ Checked out v1.2.3 to v1.2.3\n",
+			wantStderr: "",
+		},
+		{
+			name: "branch exists, TTY, confirm yes",
+			opts: &CheckoutOptions{
+				TagName: "v1.2.3",
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
+				cs.Register(`git show-ref --verify -- refs/heads/v1.2.3`, 0, "")
+				cs.Register(`git checkout v1.2.3`, 0, "")
+				cs.Register(`git merge --ff-only refs/tags/v1.2.3`, 0, "")
+			},
+			stdin:      "y\n",
+			isTTY:      true,
+			wantStdout: "A branch named 'v1.2.3' already exists. Proceeding may overwrite local changes.\nDo you want to proceed? [y/N] ✓ Checked out v1.2.3 to v1.2.3\n",
+			wantStderr: "",
+		},
+		{
+			name: "branch exists, TTY, confirm no",
+			opts: &CheckoutOptions{
+				TagName: "v1.2.3",
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git show-ref --verify -- refs/heads/v1.2.3`, 0, "")
+			},
+			stdin:      "n\n",
+			isTTY:      true,
+			wantStdout: "A branch named 'v1.2.3' already exists. Proceeding may overwrite local changes.\nDo you want to proceed? [y/N] ! Checkout aborted\n",
+			wantStderr: "",
+		},
+		{
+			name: "branch exists, non-TTY",
+			opts: &CheckoutOptions{
+				TagName: "v1.2.3",
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
+				cs.Register(`git show-ref --verify -- refs/heads/v1.2.3`, 0, "")
+				cs.Register(`git checkout v1.2.3`, 0, "")
+				cs.Register(`git merge --ff-only refs/tags/v1.2.3`, 0, "")
+			},
+			isTTY:      false,
+			wantStdout: "",
+			wantStderr: "",
+		},
+		{
+			name: "force flag",
+			opts: &CheckoutOptions{
+				TagName: "v1.2.3",
+				Force:   true,
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
+				cs.Register(`git show-ref --verify -- refs/heads/v1.2.3`, 0, "")
+				cs.Register(`git checkout v1.2.3`, 0, "")
+				cs.Register(`git reset --hard refs/tags/v1.2.3`, 0, "")
+			},
+			isTTY:      true,
+			wantStdout: "✓ Checked out v1.2.3 to v1.2.3\n",
+			wantStderr: "",
+		},
+		{
+			name: "custom branch name",
+			opts: &CheckoutOptions{
+				TagName:    "v1.2.3",
+				BranchName: "my-branch",
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
+				cs.Register(`git show-ref --verify -- refs/heads/my-branch`, 1, "")
+				cs.Register(`git checkout -b my-branch refs/tags/v1.2.3`, 0, "")
+			},
+			isTTY:      true,
+			wantStdout: "✓ Checked out v1.2.3 to my-branch\n",
+			wantStderr: "",
+		},
+		{
+			name: "recurse submodules",
+			opts: &CheckoutOptions{
+				TagName:           "v1.2.3",
+				RecurseSubmodules: true,
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
+				cs.Register(`git show-ref --verify -- refs/heads/v1.2.3`, 1, "")
+				cs.Register(`git checkout -b v1.2.3 refs/tags/v1.2.3`, 0, "")
+				cs.Register(`git submodule sync --recursive`, 0, "")
+				cs.Register(`git submodule update --init --recursive`, 0, "")
+			},
+			isTTY:      true,
+			wantStdout: "✓ Checked out v1.2.3 to v1.2.3\n",
+			wantStderr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, stdin, stdout, stderr := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+			if tt.stdin != "" {
+				stdin.WriteString(tt.stdin)
+			}
+
+			fakeHTTP := &httpmock.Registry{}
+			defer fakeHTTP.Verify(t)
+
+			shared.StubFetchRelease(t, fakeHTTP, "OWNER", "REPO", tt.opts.TagName, `{"tag_name": "v1.2.3"}`)
+
+			cs, cmdTeardown := run.Stub()
+			defer cmdTeardown(t)
+			if tt.runStubs != nil {
+				tt.runStubs(cs)
+			}
+
+			tt.opts.IO = ios
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: fakeHTTP}, nil
+			}
+			tt.opts.GitClient = &git.Client{GhPath: "gh", GitPath: "git"}
+			tt.opts.Remotes = func() (cliContext.Remotes, error) {
+				repo, err := ghrepo.FromFullName("OWNER/REPO")
+				if err != nil {
+					t.Fatal(err)
+				}
+				return cliContext.Remotes{
+					{Remote: &git.Remote{Name: "origin"}, Repo: repo},
+				}, nil
+			}
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("OWNER/REPO")
+			}
+			tt.opts.Config = func() (gh.Config, error) {
+				return config.NewBlankConfig(), nil
+			}
+
+			err := checkoutRun(tt.opts)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStdout, stdout.String())
+			assert.Equal(t, tt.wantStderr, stderr.String())
+		})
+	}
+}

--- a/pkg/cmd/release/checkout/checkout_test.go
+++ b/pkg/cmd/release/checkout/checkout_test.go
@@ -2,8 +2,11 @@ package checkout
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	cliContext "github.com/cli/cli/v2/context"
@@ -30,29 +33,29 @@ func TestNewCmdCheckout(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:  "no arguments",
-			args:  "",
-			isTTY: true,
-			want: CheckoutOptions{
-				TagName: "",
-			},
+			name:    "no arguments",
+			args:    "",
+			isTTY:   true,
+			wantErr: "not in a Git repository and no --repo specified.\nPlease run from a Git repository or use --repo to specify a repository to checkout release",
 		},
 		{
-			name:  "specific tag",
+			name:  "specific release",
 			args:  "v1.2.3",
 			isTTY: true,
 			want: CheckoutOptions{
 				TagName: "v1.2.3",
 			},
+			wantErr: "not in a Git repository and no --repo specified.\nPlease run from a Git repository or use --repo to specify a repository to checkout release",
 		},
 		{
-			name:  "force flag",
+			name:  "force",
 			args:  "--force v1.2.3",
 			isTTY: true,
 			want: CheckoutOptions{
 				TagName: "v1.2.3",
 				Force:   true,
 			},
+			wantErr: "not in a Git repository and no --repo specified.\nPlease run from a Git repository or use --repo to specify a repository to checkout release",
 		},
 		{
 			name:  "custom branch",
@@ -62,6 +65,7 @@ func TestNewCmdCheckout(t *testing.T) {
 				TagName:    "v1.2.3",
 				BranchName: "my-branch",
 			},
+			wantErr: "not in a Git repository and no --repo specified.\nPlease run from a Git repository or use --repo to specify a repository to checkout release",
 		},
 		{
 			name:  "recurse submodules",
@@ -71,6 +75,13 @@ func TestNewCmdCheckout(t *testing.T) {
 				TagName:           "v1.2.3",
 				RecurseSubmodules: true,
 			},
+			wantErr: "not in a Git repository and no --repo specified.\nPlease run from a Git repository or use --repo to specify a repository to checkout release",
+		},
+		{
+			name:    "no arguments, non-TTY",
+			args:    "",
+			isTTY:   false,
+			wantErr: "release tag argument required when not running interactively",
 		},
 	}
 
@@ -78,8 +89,12 @@ func TestNewCmdCheckout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ios, _, _, _ := iostreams.Test()
 			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
 			f := &cmdutil.Factory{
 				IOStreams: ios,
+				Remotes: func() (cliContext.Remotes, error) {
+					return nil, fmt.Errorf("not a git repo")
+				},
 			}
 			var opts *CheckoutOptions
 			cmd := NewCmdCheckout(f, func(o *CheckoutOptions) error {
@@ -99,10 +114,12 @@ func TestNewCmdCheckout(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			require.NotNil(t, opts, "opts should be initialized")
 			assert.Equal(t, tt.want.TagName, opts.TagName)
 			assert.Equal(t, tt.want.Force, opts.Force)
 			assert.Equal(t, tt.want.BranchName, opts.BranchName)
 			assert.Equal(t, tt.want.RecurseSubmodules, opts.RecurseSubmodules)
+			assert.False(t, opts.IsLocalGitRepo)
 		})
 	}
 }
@@ -112,6 +129,7 @@ func Test_checkoutRun(t *testing.T) {
 		name       string
 		opts       *CheckoutOptions
 		runStubs   func(*run.CommandStubber)
+		httpStubs  func(*httpmock.Registry)
 		stdin      string
 		isTTY      bool
 		wantStdout string
@@ -119,9 +137,13 @@ func Test_checkoutRun(t *testing.T) {
 		wantErr    string
 	}{
 		{
-			name: "checkout latest release",
+			name: "checkout latest release in local repo",
 			opts: &CheckoutOptions{
-				TagName: "",
+				TagName:        "",
+				IsLocalGitRepo: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "", `{"tag_name": "v1.2.3"}`)
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
@@ -130,12 +152,15 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			isTTY:      true,
 			wantStdout: "✓ Checked out v1.2.3 to v1.2.3\n",
-			wantStderr: "",
 		},
 		{
-			name: "checkout specific release",
+			name: "checkout specific release in local repo",
 			opts: &CheckoutOptions{
-				TagName: "v1.2.3",
+				TagName:        "v1.2.3",
+				IsLocalGitRepo: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{"tag_name": "v1.2.3"}`)
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
@@ -144,12 +169,15 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			isTTY:      true,
 			wantStdout: "✓ Checked out v1.2.3 to v1.2.3\n",
-			wantStderr: "",
 		},
 		{
 			name: "branch exists, TTY, confirm yes",
 			opts: &CheckoutOptions{
-				TagName: "v1.2.3",
+				TagName:        "v1.2.3",
+				IsLocalGitRepo: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{"tag_name": "v1.2.3"}`)
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
@@ -159,26 +187,34 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			stdin:      "y\n",
 			isTTY:      true,
-			wantStdout: "A branch named 'v1.2.3' already exists. Proceeding may overwrite local changes.\nDo you want to proceed? [y/N] ✓ Checked out v1.2.3 to v1.2.3\n",
-			wantStderr: "",
+			wantStdout: "Branch 'v1.2.3' already exists. Overwrite with v1.2.3? [y/N] ✓ Checked out v1.2.3 to v1.2.3\n",
 		},
 		{
 			name: "branch exists, TTY, confirm no",
 			opts: &CheckoutOptions{
-				TagName: "v1.2.3",
+				TagName:        "v1.2.3",
+				IsLocalGitRepo: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{"tag_name": "v1.2.3"}`)
 			},
 			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
 				cs.Register(`git show-ref --verify -- refs/heads/v1.2.3`, 0, "")
 			},
 			stdin:      "n\n",
 			isTTY:      true,
-			wantStdout: "A branch named 'v1.2.3' already exists. Proceeding may overwrite local changes.\nDo you want to proceed? [y/N] ! Checkout aborted\n",
-			wantStderr: "",
+			wantStdout: "Branch 'v1.2.3' already exists. Overwrite with v1.2.3? [y/N] ! Checkout aborted\n",
+			wantErr:    "SilentError",
 		},
 		{
 			name: "branch exists, non-TTY",
 			opts: &CheckoutOptions{
-				TagName: "v1.2.3",
+				TagName:        "v1.2.3",
+				IsLocalGitRepo: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{"tag_name": "v1.2.3"}`)
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
@@ -188,13 +224,16 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			isTTY:      false,
 			wantStdout: "",
-			wantStderr: "",
 		},
 		{
 			name: "force flag",
 			opts: &CheckoutOptions{
-				TagName: "v1.2.3",
-				Force:   true,
+				TagName:        "v1.2.3",
+				Force:          true,
+				IsLocalGitRepo: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{"tag_name": "v1.2.3"}`)
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
@@ -204,13 +243,16 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			isTTY:      true,
 			wantStdout: "✓ Checked out v1.2.3 to v1.2.3\n",
-			wantStderr: "",
 		},
 		{
 			name: "custom branch name",
 			opts: &CheckoutOptions{
-				TagName:    "v1.2.3",
-				BranchName: "my-branch",
+				TagName:        "v1.2.3",
+				BranchName:     "my-branch",
+				IsLocalGitRepo: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{"tag_name": "v1.2.3"}`)
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
@@ -219,13 +261,16 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			isTTY:      true,
 			wantStdout: "✓ Checked out v1.2.3 to my-branch\n",
-			wantStderr: "",
 		},
 		{
 			name: "recurse submodules",
 			opts: &CheckoutOptions{
 				TagName:           "v1.2.3",
 				RecurseSubmodules: true,
+				IsLocalGitRepo:    true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{"tag_name": "v1.2.3"}`)
 			},
 			runStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git fetch origin refs/tags/v1.2.3 --no-tags`, 0, "")
@@ -236,7 +281,49 @@ func Test_checkoutRun(t *testing.T) {
 			},
 			isTTY:      true,
 			wantStdout: "✓ Checked out v1.2.3 to v1.2.3\n",
-			wantStderr: "",
+		},
+		{
+			name: "clone when not in git repo",
+			opts: &CheckoutOptions{
+				TagName:        "v1.2.3",
+				IsLocalGitRepo: false,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{"tag_name": "v1.2.3"}`)
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git clone --branch v1.2.3 https://github.com/OWNER/REPO.git`, 0, "")
+				cs.Register(`git checkout -b v1.2.3`, 0, "")
+			},
+			isTTY:      true,
+			wantStdout: "✓ Cloned OWNER/REPO@v1.2.3 to REPO-v1.2.3\n",
+		},
+		{
+			name: "clone with mismatched repo",
+			opts: &CheckoutOptions{
+				TagName:        "v1.2.3",
+				IsLocalGitRepo: true,
+			},
+			isTTY:      true,
+			wantStdout: "",
+			wantErr:    "--repo OWNER/REPO doesn't match the current repository (OTHER/OTHER-REPO).\nTry running out of a Git repo to checkout release, or omit --repo to checkout for current repo",
+		},
+		{
+			name: "clone with existing dir, confirm yes",
+			opts: &CheckoutOptions{
+				TagName:        "v1.2.3",
+				IsLocalGitRepo: false,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{"tag_name": "v1.2.3"}`)
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git clone --branch v1.2.3 https://github.com/OWNER/REPO.git`, 0, "")
+				cs.Register(`git checkout -b v1.2.3`, 0, "")
+			},
+			stdin:      "y\n",
+			isTTY:      true,
+			wantStdout: "Directory 'REPO-v1.2.3' already exists. Overwrite by cloning OWNER/REPO@v1.2.3? [y/N] ✓ Cloned OWNER/REPO@v1.2.3 to REPO-v1.2.3\n",
 		},
 	}
 
@@ -251,8 +338,9 @@ func Test_checkoutRun(t *testing.T) {
 
 			fakeHTTP := &httpmock.Registry{}
 			defer fakeHTTP.Verify(t)
-
-			shared.StubFetchRelease(t, fakeHTTP, "OWNER", "REPO", tt.opts.TagName, `{"tag_name": "v1.2.3"}`)
+			if tt.httpStubs != nil {
+				tt.httpStubs(fakeHTTP)
+			}
 
 			cs, cmdTeardown := run.Stub()
 			defer cmdTeardown(t)
@@ -260,28 +348,59 @@ func Test_checkoutRun(t *testing.T) {
 				tt.runStubs(cs)
 			}
 
+			tempDir := t.TempDir()
+			if tt.name == "clone when not in git repo" || tt.name == "clone with existing dir, confirm yes" {
+				err := os.Mkdir(filepath.Join(tempDir, "REPO"), 0755)
+				if err != nil {
+					t.Fatalf("failed to create REPO dir: %v", err)
+				}
+				if tt.name == "clone with existing dir, confirm yes" {
+					err = os.Mkdir(filepath.Join(tempDir, "REPO-v1.2.3"), 0755)
+					if err != nil {
+						t.Fatalf("failed to create REPO-v1.2.3 dir: %v", err)
+					}
+				}
+			}
+
+			origDir, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("failed to get current dir: %v", err)
+			}
+			err = os.Chdir(tempDir)
+			if err != nil {
+				t.Fatalf("failed to change to temp dir: %v", err)
+			}
+			defer os.Chdir(origDir)
+
 			tt.opts.IO = ios
 			tt.opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: fakeHTTP}, nil
 			}
 			tt.opts.GitClient = &git.Client{GhPath: "gh", GitPath: "git"}
-			tt.opts.Remotes = func() (cliContext.Remotes, error) {
-				repo, err := ghrepo.FromFullName("OWNER/REPO")
-				if err != nil {
-					t.Fatal(err)
-				}
-				return cliContext.Remotes{
-					{Remote: &git.Remote{Name: "origin"}, Repo: repo},
-				}, nil
+			tt.opts.Config = func() (gh.Config, error) {
+				return config.NewBlankConfig(), nil
 			}
 			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
 				return ghrepo.FromFullName("OWNER/REPO")
 			}
-			tt.opts.Config = func() (gh.Config, error) {
-				return config.NewBlankConfig(), nil
+
+			if tt.name == "clone with mismatched repo" {
+				tt.opts.Remotes = func() (cliContext.Remotes, error) {
+					repo, _ := ghrepo.FromFullName("OTHER/OTHER-REPO")
+					return cliContext.Remotes{{Remote: &git.Remote{Name: "origin"}, Repo: repo}}, nil
+				}
+			} else if tt.opts.IsLocalGitRepo {
+				tt.opts.Remotes = func() (cliContext.Remotes, error) {
+					repo, _ := ghrepo.FromFullName("OWNER/REPO")
+					return cliContext.Remotes{{Remote: &git.Remote{Name: "origin"}, Repo: repo}}, nil
+				}
+			} else {
+				tt.opts.Remotes = func() (cliContext.Remotes, error) {
+					return nil, fmt.Errorf("not a git repo")
+				}
 			}
 
-			err := checkoutRun(tt.opts)
+			err = checkoutRun(tt.opts)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/pkg/cmd/release/release.go
+++ b/pkg/cmd/release/release.go
@@ -1,6 +1,7 @@
 package release
 
 import (
+	cmdCheckout "github.com/cli/cli/v2/pkg/cmd/release/checkout"
 	cmdCreate "github.com/cli/cli/v2/pkg/cmd/release/create"
 	cmdDelete "github.com/cli/cli/v2/pkg/cmd/release/delete"
 	cmdDeleteAsset "github.com/cli/cli/v2/pkg/cmd/release/delete-asset"
@@ -34,6 +35,7 @@ func NewCmdRelease(f *cmdutil.Factory) *cobra.Command {
 		cmdDownload.NewCmdDownload(f, nil),
 		cmdDelete.NewCmdDelete(f, nil),
 		cmdDeleteAsset.NewCmdDeleteAsset(f, nil),
+		cmdCheckout.NewCmdCheckout(f, nil),
 	)
 
 	return cmd


### PR DESCRIPTION
Fixes #6119

Adds `gh release checkout` command to check out the latest release or a specific  release if tag is provided.