### PR TITLE
[gh repo clone] Add `--no-upstream` flag

### DIFF
--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -55,15 +55,11 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 			chosen from your configuration, which can be checked via %[1]sgh config get git_protocol%[1]s. If the protocol
 			scheme is provided, the repository will be cloned using the specified protocol.
 
-			If the repository is a fork, its parent repository will be added as an additional
-			git remote called %[1]supstream%[1]s. The remote name can be configured using %[1]s--upstream-remote-name%[1]s.
-			The %[1]s--upstream-remote-name%[1]s option supports an %[1]s@owner%[1]s value which will name
-			the remote after the owner of the parent repository.
+			If the repository is a fork, its parent repository will be added as an additional git remote named
+			%[1]supstream%[1]s and set as the default remote unless %[1]s--no-upstream%[1]s flag is specified.
 
-			If the repository is a fork, its parent repository will be set as the default remote repository.
-
-			To disable the addition of the %[1]supstream%[1]s remote for a forked repository,
-			use the %[1]s--no-upstream%[1]s flag. For a non-forked repository, this flag has no effect.
+			The remote name can be configured using the %[1]s--upstream-remote-name%[1]s flag, which supports
+			the %[1]s@owner%[1]s syntax to name it after the owner of the parent repository.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Clone a repository from a specific org
@@ -220,7 +216,6 @@ func cloneRun(opts *CloneOptions) error {
 
 		connectedToTerminal := opts.IO.IsStdoutTTY()
 		if connectedToTerminal {
-			cs := opts.IO.ColorScheme()
 			fmt.Fprintf(opts.IO.ErrOut, "Fetching %s as %s\n", upstreamName, ghrepo.FullName(canonicalRepo.Parent))
 		}
 

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -221,7 +221,7 @@ func cloneRun(opts *CloneOptions) error {
 		connectedToTerminal := opts.IO.IsStdoutTTY()
 		if connectedToTerminal {
 			cs := opts.IO.ColorScheme()
-			fmt.Fprintf(opts.IO.ErrOut, "%s Fetching %s of %s\n", cs.WarningIcon(), cs.Bold(upstreamName), cs.Bold(ghrepo.FullName(canonicalRepo.Parent)))
+			fmt.Fprintf(opts.IO.ErrOut, "Fetching %s as %s\n", upstreamName, ghrepo.FullName(canonicalRepo.Parent))
 		}
 
 		if err := gc.Fetch(ctx, upstreamName, ""); err != nil {

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -27,6 +27,7 @@ type CloneOptions struct {
 	GitArgs      []string
 	Repository   string
 	UpstreamName string
+	NoUpstream   bool
 }
 
 func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Command {
@@ -40,7 +41,7 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 	cmd := &cobra.Command{
 		DisableFlagsInUseLine: true,
 
-		Use:   "clone <repository> [<directory>] [-- <gitflags>...]",
+		Use:   "clone <repository> [<directory>] [flags] [-- <gitflags>...]",
 		Args:  cmdutil.MinimumArgs(1, "cannot clone: repository argument required"),
 		Short: "Clone a repository locally",
 		Long: heredoc.Docf(`
@@ -60,6 +61,9 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 			the remote after the owner of the parent repository.
 
 			If the repository is a fork, its parent repository will be set as the default remote repository.
+
+			To disable the addition of the %[1]supstream%[1]s remote for a forked repository,
+			use the %[1]s--no-upstream%[1]s flag. For a non-forked repository, this flag has no effect.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Clone a repository from a specific org
@@ -77,8 +81,19 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 
 			# Clone a repository with additional git clone flags
 			$ gh repo clone cli/cli -- --depth=1
+
+			# Clone a forked repository without the upstream remote
+			$ gh repo clone myuser/cli --no-upstream
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.MutuallyExclusive(
+				"specify only one of `--upstream-remote-name` or `--no-upstream`",
+				cmd.Flags().Changed("upstream-remote-name") && opts.UpstreamName != "",
+				opts.NoUpstream,
+			); err != nil {
+				return err
+			}
+
 			opts.Repository = args[0]
 			opts.GitArgs = args[1:]
 
@@ -91,6 +106,7 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 	}
 
 	cmd.Flags().StringVarP(&opts.UpstreamName, "upstream-remote-name", "u", "upstream", "Upstream remote name when cloning a fork")
+	cmd.Flags().BoolVar(&opts.NoUpstream, "no-upstream", false, "Do not set/fetch upstream remote when cloning a fork")
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		if err == pflag.ErrHelp {
 			return err
@@ -186,7 +202,7 @@ func cloneRun(opts *CloneOptions) error {
 	}
 
 	// If the repo is a fork, add the parent as an upstream remote and set the parent as the default repo.
-	if canonicalRepo.Parent != nil {
+	if !opts.NoUpstream && canonicalRepo.Parent != nil {
 		protocol := cfg.GitProtocol(canonicalRepo.Parent.RepoHost()).Value
 		upstreamURL := ghrepo.FormatRemoteURL(canonicalRepo.Parent, protocol)
 
@@ -202,6 +218,12 @@ func cloneRun(opts *CloneOptions) error {
 			return err
 		}
 
+		connectedToTerminal := opts.IO.IsStdoutTTY()
+		if connectedToTerminal {
+			cs := opts.IO.ColorScheme()
+			fmt.Fprintf(opts.IO.ErrOut, "%s Fetching %s of %s\n", cs.WarningIcon(), cs.Bold(upstreamName), cs.Bold(ghrepo.FullName(canonicalRepo.Parent)))
+		}
+
 		if err := gc.Fetch(ctx, upstreamName, ""); err != nil {
 			return err
 		}
@@ -214,7 +236,6 @@ func cloneRun(opts *CloneOptions) error {
 			return err
 		}
 
-		connectedToTerminal := opts.IO.IsStdoutTTY()
 		if connectedToTerminal {
 			cs := opts.IO.ColorScheme()
 			fmt.Fprintf(opts.IO.ErrOut, "%s Repository %s set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n", cs.WarningIcon(), cs.Bold(ghrepo.FullName(canonicalRepo.Parent)))

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -34,25 +34,56 @@ func TestNewCmdClone(t *testing.T) {
 			name: "repo argument",
 			args: "OWNER/REPO",
 			wantOpts: CloneOptions{
-				Repository: "OWNER/REPO",
-				GitArgs:    []string{},
+				Repository:   "OWNER/REPO",
+				GitArgs:      []string{},
+				UpstreamName: "upstream",
+				NoUpstream:   false,
 			},
 		},
 		{
 			name: "directory argument",
 			args: "OWNER/REPO mydir",
 			wantOpts: CloneOptions{
-				Repository: "OWNER/REPO",
-				GitArgs:    []string{"mydir"},
+				Repository:   "OWNER/REPO",
+				GitArgs:      []string{"mydir"},
+				UpstreamName: "upstream",
+				NoUpstream:   false,
 			},
 		},
 		{
 			name: "git clone arguments",
 			args: "OWNER/REPO -- --depth 1 --recurse-submodules",
 			wantOpts: CloneOptions{
-				Repository: "OWNER/REPO",
-				GitArgs:    []string{"--depth", "1", "--recurse-submodules"},
+				Repository:   "OWNER/REPO",
+				GitArgs:      []string{"--depth", "1", "--recurse-submodules"},
+				UpstreamName: "upstream",
+				NoUpstream:   false,
 			},
+		},
+		{
+			name: "upstream-remote-name argument",
+			args: "OWNER/REPO --upstream-remote-name test",
+			wantOpts: CloneOptions{
+				Repository:   "OWNER/REPO",
+				GitArgs:      []string{},
+				UpstreamName: "test",
+				NoUpstream:   false,
+			},
+		},
+		{
+			name: "no-upstream argument",
+			args: "OWNER/REPO --no-upstream",
+			wantOpts: CloneOptions{
+				Repository:   "OWNER/REPO",
+				GitArgs:      []string{},
+				UpstreamName: "upstream",
+				NoUpstream:   true,
+			},
+		},
+		{
+			name:    "upstream-remote-name and no-upstream arguments",
+			args:    "OWNER/REPO --upstream-remote-name test --no-upstream",
+			wantErr: "specify only one of `--upstream-remote-name` or `--no-upstream`",
 		},
 		{
 			name:    "unknown argument",
@@ -266,6 +297,42 @@ func Test_RepoClone_hasParent(t *testing.T) {
 	_, err := runCloneCommand(httpClient, "OWNER/REPO")
 	if err != nil {
 		t.Fatalf("error running command `repo clone`: %v", err)
+	}
+}
+
+func Test_RepoClone_hasParent_NoUpstream(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.StringResponse(`
+			{ "data": { "repository": {
+				"name": "REPO",
+				"owner": {
+					"login": "OWNER"
+				},
+				"parent": {
+					"name": "ORIG",
+					"owner": {
+						"login": "hubot"
+					},
+					"defaultBranchRef": {
+						"name": "trunk"
+					}
+				}
+			} } }
+		`))
+
+	httpClient := &http.Client{Transport: reg}
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	cs.Register(`git clone https://github.com/OWNER/REPO.git`, 0, "")
+
+	_, err := runCloneCommand(httpClient, "OWNER/REPO --no-upstream")
+	if err != nil {
+		t.Fatalf("error running command `repo clone` with `--no-upstream`: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #8274.

### Tests

#### `bin/gh repo clone --help`

<details>
<summary>Output</summary>

```shell
$ bin/gh repo clone --help 
Clone a GitHub repository locally. Pass additional `git clone` flags by listing
them after `--`.

If the `OWNER/` portion of the `OWNER/REPO` repository argument is omitted, it
defaults to the name of the authenticating user.

When a protocol scheme is not provided in the repository argument, the `git_protocol` will be
chosen from your configuration, which can be checked via `gh config get git_protocol`. If the protocol
scheme is provided, the repository will be cloned using the specified protocol.

If the repository is a fork, its parent repository will be added as an additional
git remote called `upstream`. The remote name can be configured using `--upstream-remote-name`.
The `--upstream-remote-name` option supports an `@owner` value which will name
the remote after the owner of the parent repository.

If the repository is a fork, its parent repository will be set as the default remote repository.

To disable the addition of the `upstream` remote for a forked repository,
use the `--no-upstream` flag. For a non-forked repository, this flag has no effect.


USAGE
  gh repo clone <repository> [<directory>] [flags] [-- <gitflags>...]

FLAGS
      --no-upstream                   Do not set/fetch upstream remote when cloning a fork
  -u, --upstream-remote-name string   Upstream remote name when cloning a fork (default "upstream")

INHERITED FLAGS
  --help   Show help for command

EXAMPLES
  # Clone a repository from a specific org
  $ gh repo clone cli/cli
  
  # Clone a repository from your own account
  $ gh repo clone myrepo
  
  # Clone a repo, overriding git protocol configuration
  $ gh repo clone https://github.com/cli/cli
  $ gh repo clone git@github.com:cli/cli.git
  
  # Clone a repository to a custom directory
  $ gh repo clone cli/cli workspace/cli
  
  # Clone a repository with additional git clone flags
  $ gh repo clone cli/cli -- --depth=1
  
  # Clone a forked repository without the upstream remote
  $ gh repo clone myuser/cli --no-upstream

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
```

</details>

#### `bin/gh repo clone iamazeem/cli --upstream-remote-name upstream --no-upstream`

```shell
$ bin/gh repo clone iamazeem/cli --upstream-remote-name upstream --no-upstream
specify only one of `--upstream-remote-name` or `--no-upstream`

Usage:  gh repo clone <repository> [<directory>] [flags] [-- <gitflags>...]

Flags:
      --no-upstream                   Do not set/fetch upstream remote when cloning a fork
  -u, --upstream-remote-name string   Upstream remote name when cloning a fork (default "upstream")

$ echo $?
1
```

#### `bin/gh repo clone iamazeem/cli cli1 -- --depth=1`

```shell
$ bin/gh repo clone iamazeem/cli cli1 -- --depth=1
Cloning into 'cli1'...
remote: Enumerating objects: 1306, done.
remote: Counting objects: 100% (1306/1306), done.
remote: Compressing objects: 100% (1150/1150), done.
remote: Total 1306 (delta 191), reused 609 (delta 105), pack-reused 0 (from 0)
Receiving objects: 100% (1306/1306), 12.67 MiB | 1.27 MiB/s, done.
Resolving deltas: 100% (191/191), done.
! Fetching upstream of cli/cli
From github.com:cli/cli
 * [new branch]      trunk      -> upstream/trunk
! Repository cli/cli set as the default repository. To learn more about the default repository, run: gh repo set-default --help

$ (cd cli1 && git remote)
origin
upstream
```

#### `bin/gh repo clone iamazeem/cli cli2 --no-upstream  -- --depth=1`

```shell
$ bin/gh repo clone iamazeem/cli cli2 --no-upstream  -- --depth=1
Cloning into 'cli2'...
remote: Enumerating objects: 1306, done.
remote: Counting objects: 100% (1306/1306), done.
remote: Compressing objects: 100% (1149/1149), done.
remote: Total 1306 (delta 191), reused 608 (delta 106), pack-reused 0 (from 0)
Receiving objects: 100% (1306/1306), 12.67 MiB | 822.00 KiB/s, done.
Resolving deltas: 100% (191/191), done.

$ (cd cli2 && git remote)
origin
```