### PR TITLE
[gh ext] Fix `GitKind` extension directory path

### DIFF
--- a/pkg/cmd/extension/extension.go
+++ b/pkg/cmd/extension/extension.go
@@ -163,7 +163,8 @@ func (e *Extension) IsPinned() bool {
 			isPinned = manifest.IsPinned
 		}
 	case GitKind:
-		pinPath := filepath.Join(e.Path(), fmt.Sprintf(".pin-%s", e.CurrentVersion()))
+		extDir := filepath.Dir(e.path)
+		pinPath := filepath.Join(extDir, fmt.Sprintf(".pin-%s", e.CurrentVersion()))
 		if _, err := os.Stat(pinPath); err == nil {
 			isPinned = true
 		} else {

--- a/pkg/cmd/extension/extension_test.go
+++ b/pkg/cmd/extension/extension_test.go
@@ -102,3 +102,82 @@ func TestOwnerCached(t *testing.T) {
 
 	assert.Equal(t, "cli", e.Owner())
 }
+
+func TestIsPinnedBinaryExtensionUnpinned(t *testing.T) {
+	tempDir := t.TempDir()
+	extName := "gh-bin-ext"
+	extDir := filepath.Join(tempDir, "extensions", extName)
+	extPath := filepath.Join(extDir, extName)
+	bm := binManifest{
+		Name: "gh-bin-ext",
+	}
+	assert.NoError(t, stubBinaryExtension(extDir, bm))
+	e := &Extension{
+		kind: BinaryKind,
+		path: extPath,
+	}
+
+	assert.False(t, e.IsPinned())
+}
+
+func TestIsPinnedBinaryExtensionPinned(t *testing.T) {
+	tempDir := t.TempDir()
+	extName := "gh-bin-ext"
+	extDir := filepath.Join(tempDir, "extensions", extName)
+	extPath := filepath.Join(extDir, extName)
+	bm := binManifest{
+		Name:     "gh-bin-ext",
+		IsPinned: true,
+	}
+	assert.NoError(t, stubBinaryExtension(extDir, bm))
+	e := &Extension{
+		kind: BinaryKind,
+		path: extPath,
+	}
+
+	assert.True(t, e.IsPinned())
+}
+
+func TestIsPinnedGitExtensionUnpinned(t *testing.T) {
+	tempDir := t.TempDir()
+	extPath := filepath.Join(tempDir, "extensions", "gh-local", "gh-local")
+	assert.NoError(t, stubExtension(extPath))
+
+	gc := &mockGitClient{}
+	gc.On("CommandOutput", []string{"rev-parse", "HEAD"}).Return("abcd1234", nil)
+	e := &Extension{
+		kind:      GitKind,
+		gitClient: gc,
+		path:      extPath,
+	}
+
+	assert.False(t, e.IsPinned())
+}
+
+func TestIsPinnedGitExtensionPinned(t *testing.T) {
+	tempDir := t.TempDir()
+	extPath := filepath.Join(tempDir, "extensions", "gh-local", "gh-local")
+	assert.NoError(t, stubPinnedExtension(extPath, "abcd1234"))
+
+	gc := &mockGitClient{}
+	gc.On("CommandOutput", []string{"rev-parse", "HEAD"}).Return("abcd1234", nil)
+	e := &Extension{
+		kind:      GitKind,
+		gitClient: gc,
+		path:      extPath,
+	}
+
+	assert.True(t, e.IsPinned())
+}
+
+func TestIsPinnedLocalExtension(t *testing.T) {
+	tempDir := t.TempDir()
+	extPath := filepath.Join(tempDir, "extensions", "gh-local", "gh-local")
+	assert.NoError(t, stubLocalExtension(tempDir, extPath))
+	e := &Extension{
+		kind: LocalKind,
+		path: extPath,
+	}
+
+	assert.False(t, e.IsPinned())
+}

--- a/pkg/cmd/extension/extension_test.go
+++ b/pkg/cmd/extension/extension_test.go
@@ -152,6 +152,7 @@ func TestIsPinnedGitExtensionUnpinned(t *testing.T) {
 	}
 
 	assert.False(t, e.IsPinned())
+	gc.AssertExpectations(t)
 }
 
 func TestIsPinnedGitExtensionPinned(t *testing.T) {
@@ -168,6 +169,7 @@ func TestIsPinnedGitExtensionPinned(t *testing.T) {
 	}
 
 	assert.True(t, e.IsPinned())
+	gc.AssertExpectations(t)
 }
 
 func TestIsPinnedLocalExtension(t *testing.T) {


### PR DESCRIPTION
Fixes #10228.

### Tests

```shell
$ bin/gh ext install --pin 81a4ce86e027f31d306883c25a71b5d05b007e2e andyfeller/gh-sonar
⡿Cloning into '/home/azeem/.local/share/gh/extensions/gh-sonar'...
⣾remote: Enumerating objects: 10, done.
remote: Counting objects: 100% (10/10), done.
remote: Compressing objects: 100% (8/8), done.
⣽remote: Total 10 (delta 1), reused 7 (delta 1), pack-reused 0 (from 0)
Receiving objects: 100% (10/10), 6.64 KiB | 6.64 MiB/s, done.
Resolving deltas: 100% (1/1), done.
✓ Installed extension andyfeller/gh-sonar
✓ Pinned extension at 81a4ce86e027f31d306883c25a71b5d05b007e2e


$ bin/gh ext list
NAME            REPO                 VERSION 
gh annotations  swfz/gh-annotations  v1.0.0
gh copilot      github/gh-copilot    v1.1.0
gh sonar        andyfeller/gh-sonar  81a4ce86


$ bin/gh ext upgrade gh-sonar --dry-run 
[sonar]: pinned extensions can not be upgraded
✓ Successfully checked extension upgrades

$ bin/gh ext upgrade gh-sonar
[sonar]: pinned extensions can not be upgraded
✓ Successfully checked extension upgrades
```

Screenshot:

![Screenshot from 2025-03-15 17-58-21](https://github.com/user-attachments/assets/9003ecac-13b6-4a81-990c-14de55b26be8)