### PR TITLE
[gh secret set] Support `--clear-repos` flag to clear selected repos for org secret

### DIFF
--- a/pkg/cmd/secret/set/http.go
+++ b/pkg/cmd/secret/set/http.go
@@ -96,6 +96,18 @@ func putOrgSecret(client *api.Client, host string, pk *PubKey, orgName, visibili
 	return putSecret(client, host, path, payload)
 }
 
+func clearOrgSecretSelectedRepositories(client *api.Client, host, orgName, secretName string, app shared.App) error {
+	path := fmt.Sprintf("orgs/%s/%s/secrets/%s/repositories", orgName, app, secretName)
+
+	payload := struct {
+		Repositories []int64 `json:"selected_repository_ids"`
+	}{
+		Repositories: []int64{},
+	}
+
+	return putSecret(client, host, path, payload)
+}
+
 func putUserSecret(client *api.Client, host string, pk *PubKey, key, eValue string, repositoryIDs []int64) error {
 	payload := SecretPayload{
 		EncryptedValue: eValue,

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -33,16 +33,17 @@ type SetOptions struct {
 
 	RandomOverride func() io.Reader
 
-	SecretName      string
-	OrgName         string
-	EnvName         string
-	UserSecrets     bool
-	Body            string
-	DoNotStore      bool
-	Visibility      string
-	RepositoryNames []string
-	EnvFile         string
-	Application     string
+	SecretName         string
+	OrgName            string
+	EnvName            string
+	UserSecrets        bool
+	Body               string
+	DoNotStore         bool
+	Visibility         string
+	RepositoryNames    []string
+	ClearSelectedRepos bool
+	EnvFile            string
+	Application        string
 }
 
 func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command {
@@ -56,7 +57,7 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 	cmd := &cobra.Command{
 		Use:   "set <secret-name>",
 		Short: "Create or update secrets",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Set a value for a secret on one of the following levels:
 			- repository (default): available to GitHub Actions runs or Dependabot in a repository
 			- environment: available to GitHub Actions runs for a deployment environment in a repository
@@ -66,8 +67,11 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 			Organization and user secrets can optionally be restricted to only be available to
 			specific repositories.
 
+			For an existing organization secret, set with %[1]s--repos%[1]s and %[1]s--visibility=selected%[1]s,
+			all its selected repositories can be cleared by using the %[1]s--clear-repos%[1]s flag.
+
 			Secret values are locally encrypted before being sent to GitHub.
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Paste secret value for the current repository in an interactive prompt
 			$ gh secret set MYSECRET
@@ -101,6 +105,9 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 
 			# Set multiple secrets from stdin
 			$ gh secret set -f - < myfile.txt
+
+			# Clear all selected repositories for an existing organization-level secret with visibility "selected"
+			$ gh secret set MYSECRET --org myorg --clear-repos
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -139,21 +146,34 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 				opts.SecretName = args[0]
 			}
 
-			if cmd.Flags().Changed("visibility") {
+			if opts.ClearSelectedRepos {
 				if opts.OrgName == "" {
-					return cmdutil.FlagErrorf("`--visibility` is only supported with `--org`")
+					return cmdutil.FlagErrorf("`--org` required with `--clear-repos`")
 				}
 
-				if opts.Visibility != shared.Selected && len(opts.RepositoryNames) > 0 {
-					return cmdutil.FlagErrorf("`--repos` is only supported with `--visibility=selected`")
-				}
+				nFlags := cmd.Flags().NFlag()
+				isAppUserProvided := cmd.Flags().Changed("app")
 
-				if opts.Visibility == shared.Selected && len(opts.RepositoryNames) == 0 {
-					return cmdutil.FlagErrorf("`--repos` list required with `--visibility=selected`")
+				if (!isAppUserProvided && nFlags > 2) || (isAppUserProvided && nFlags > 3) {
+					return cmdutil.FlagErrorf("`--clear-repos` is only supported with `--org` and `--app`")
 				}
 			} else {
-				if len(opts.RepositoryNames) > 0 {
-					opts.Visibility = shared.Selected
+				if cmd.Flags().Changed("visibility") {
+					if opts.OrgName == "" {
+						return cmdutil.FlagErrorf("`--visibility` is only supported with `--org`")
+					}
+
+					if opts.Visibility != shared.Selected && len(opts.RepositoryNames) > 0 {
+						return cmdutil.FlagErrorf("`--repos` is only supported with `--visibility=selected`")
+					}
+
+					if opts.Visibility == shared.Selected && len(opts.RepositoryNames) == 0 {
+						return cmdutil.FlagErrorf("`--repos` list required with `--visibility=selected`")
+					}
+				} else {
+					if len(opts.RepositoryNames) > 0 {
+						opts.Visibility = shared.Selected
+					}
 				}
 			}
 
@@ -170,6 +190,7 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 	cmd.Flags().BoolVarP(&opts.UserSecrets, "user", "u", false, "Set a secret for your user")
 	cmdutil.StringEnumFlag(cmd, &opts.Visibility, "visibility", "v", shared.Private, []string{shared.All, shared.Private, shared.Selected}, "Set visibility for an organization secret")
 	cmd.Flags().StringSliceVarP(&opts.RepositoryNames, "repos", "r", []string{}, "List of `repositories` that can access an organization or user secret")
+	cmd.Flags().BoolVar(&opts.ClearSelectedRepos, "clear-repos", false, "Clear all selected repositories for an existing organization secret")
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "The value for the secret (reads from standard input if not specified)")
 	cmd.Flags().BoolVar(&opts.DoNotStore, "no-store", false, "Print the encrypted, base64-encoded value instead of storing it on GitHub")
 	cmd.Flags().StringVarP(&opts.EnvFile, "env-file", "f", "", "Load secret names and values from a dotenv-formatted `file`")
@@ -200,16 +221,13 @@ func setRun(opts *SetOptions) error {
 		host, _ = cfg.Authentication().DefaultHost()
 	}
 
-	secrets, err := getSecretsFromOptions(opts)
-	if err != nil {
-		return err
-	}
-
 	c, err := opts.HttpClient()
 	if err != nil {
 		return fmt.Errorf("could not create http client: %w", err)
 	}
 	client := api.NewClientFromHTTP(c)
+
+	cs := opts.IO.ColorScheme()
 
 	secretEntity, err := shared.GetSecretEntity(orgName, envName, opts.UserSecrets)
 	if err != nil {
@@ -223,6 +241,34 @@ func setRun(opts *SetOptions) error {
 
 	if !shared.IsSupportedSecretEntity(secretApp, secretEntity) {
 		return fmt.Errorf("%s secrets are not supported for %s", secretEntity, secretApp)
+	}
+
+	if opts.ClearSelectedRepos {
+		err := clearOrgSecretSelectedRepositories(client, host, orgName, opts.SecretName, secretApp)
+		if err != nil {
+			if opts.IO.IsStdoutTTY() {
+				fmt.Fprintf(opts.IO.ErrOut, "%s Failed to clear all selected repositories for %s organization secret %s\n",
+					cs.FailureIcon(),
+					cs.Bold(orgName),
+					cs.Bold(opts.SecretName),
+				)
+			}
+			return err
+		} else {
+			if opts.IO.IsStdoutTTY() {
+				fmt.Fprintf(opts.IO.Out, "%s Cleared all selected repositories for %s organization secret %s\n",
+					cs.SuccessIcon(),
+					cs.Bold(orgName),
+					cs.Bold(opts.SecretName),
+				)
+			}
+			return nil
+		}
+	}
+
+	secrets, err := getSecretsFromOptions(opts)
+	if err != nil {
+		return err
 	}
 
 	var pk *PubKey
@@ -274,7 +320,6 @@ func setRun(opts *SetOptions) error {
 	}
 
 	err = nil
-	cs := opts.IO.ColorScheme()
 	for i := 0; i < len(secrets); i++ {
 		result := <-setc
 		if result.err != nil {

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -181,6 +181,30 @@ func TestNewCmdSet(t *testing.T) {
 				Application:     "Codespaces",
 			},
 		},
+		{
+			name: "clear repos with org",
+			cli:  `random_secret --org coolOrg --clear-repos`,
+			wants: SetOptions{
+				SecretName:         "random_secret",
+				OrgName:            "coolOrg",
+				ClearSelectedRepos: true,
+			},
+		},
+		{
+			name:     "clear repos without org",
+			cli:      `random_secret --clear-repos`,
+			wantsErr: true,
+		},
+		{
+			name:     "clear repos without org and repos",
+			cli:      `random_secret --clear-repos --repos r1,r2,r3`,
+			wantsErr: true,
+		},
+		{
+			name:     "clear repos with org and repos",
+			cli:      `random_secret --org coolOrg --clear-repos --repos r1,r2,r3`,
+			wantsErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -213,13 +237,16 @@ func TestNewCmdSet(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, tt.wants.SecretName, gotOpts.SecretName)
-			assert.Equal(t, tt.wants.Body, gotOpts.Body)
-			assert.Equal(t, tt.wants.Visibility, gotOpts.Visibility)
 			assert.Equal(t, tt.wants.OrgName, gotOpts.OrgName)
-			assert.Equal(t, tt.wants.EnvName, gotOpts.EnvName)
-			assert.Equal(t, tt.wants.DoNotStore, gotOpts.DoNotStore)
-			assert.ElementsMatch(t, tt.wants.RepositoryNames, gotOpts.RepositoryNames)
-			assert.Equal(t, tt.wants.Application, gotOpts.Application)
+
+			if !tt.wants.ClearSelectedRepos {
+				assert.Equal(t, tt.wants.Body, gotOpts.Body)
+				assert.Equal(t, tt.wants.Visibility, gotOpts.Visibility)
+				assert.Equal(t, tt.wants.EnvName, gotOpts.EnvName)
+				assert.Equal(t, tt.wants.DoNotStore, gotOpts.DoNotStore)
+				assert.ElementsMatch(t, tt.wants.RepositoryNames, gotOpts.RepositoryNames)
+				assert.Equal(t, tt.wants.Application, gotOpts.Application)
+			}
 		})
 	}
 }
@@ -579,6 +606,142 @@ func Test_setRun_org(t *testing.T) {
 				assert.Equal(t, payload.Visibility, tt.opts.Visibility)
 				assert.ElementsMatch(t, payload.Repositories, tt.wantRepositories)
 			}
+		})
+	}
+}
+
+func Test_setRun_org_secret_clear_repos(t *testing.T) {
+	tests := []struct {
+		name                       string
+		opts                       *SetOptions
+		wantVisibility             shared.Visibility
+		wantRepositories           []int64
+		wantDependabotRepositories []string
+		wantApp                    string
+		wantClearReposErr          error
+	}{
+		{
+			name: "actions selected repos",
+			opts: &SetOptions{
+				OrgName:         "ORG",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"ORG/REPO1", "ORG/REPO2"},
+			},
+			wantRepositories:  []int64{1, 2},
+			wantApp:           "actions",
+			wantClearReposErr: nil,
+		},
+		{
+			name: "dependabot selected repos",
+			opts: &SetOptions{
+				OrgName:         "ORG",
+				Visibility:      shared.Selected,
+				Application:     shared.Dependabot,
+				RepositoryNames: []string{"ORG/REPO1", "ORG/REPO2"},
+			},
+			wantDependabotRepositories: []string{"1", "2"},
+			wantApp:                    "dependabot",
+			wantClearReposErr:          nil,
+		},
+		{
+			name: "codespaces selected repos",
+			opts: &SetOptions{
+				OrgName:         "ORG",
+				Visibility:      shared.Selected,
+				Application:     shared.Codespaces,
+				RepositoryNames: []string{"ORG/REPO1", "ORG/REPO2"},
+			},
+			wantRepositories:  []int64{1, 2},
+			wantApp:           "codespaces",
+			wantClearReposErr: nil,
+		},
+		{
+			name: "actions selected repos",
+			opts: &SetOptions{
+				OrgName:         "ORG",
+				Visibility:      shared.Private,
+				RepositoryNames: []string{"ORG/REPO1", "ORG/REPO2"},
+			},
+			wantRepositories:  []int64{1, 2},
+			wantApp:           "actions",
+			wantClearReposErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+
+			orgName := tt.opts.OrgName
+
+			reg.Register(httpmock.REST("GET",
+				fmt.Sprintf("orgs/%s/%s/secrets/public-key", orgName, tt.wantApp)),
+				httpmock.JSONResponse(PubKey{ID: "123", Key: "CDjXqf7AJBXWhMczcy+Fs7JlACEptgceysutztHaFQI="}))
+
+			reg.Register(httpmock.REST("PUT",
+				fmt.Sprintf("orgs/%s/%s/secrets/cool_secret", orgName, tt.wantApp)),
+				httpmock.StatusStringResponse(201, `{}`))
+
+			if len(tt.opts.RepositoryNames) > 0 {
+				reg.Register(httpmock.GraphQL(`query MapRepositoryNames\b`),
+					httpmock.StringResponse(`{"data":{"REPO1":{"databaseId":1},"REPO2":{"databaseId":2}}}`))
+			}
+
+			ios, _, _, _ := iostreams.Test()
+
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.FromFullName("owner/repo")
+			}
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.Config = func() (gh.Config, error) {
+				return config.NewBlankConfig(), nil
+			}
+			tt.opts.IO = ios
+			tt.opts.SecretName = "cool_secret"
+			tt.opts.Body = "a secret"
+			tt.opts.RandomOverride = fakeRandom
+
+			err := setRun(tt.opts)
+			assert.NoError(t, err)
+
+			reg.Verify(t)
+
+			data, err := io.ReadAll(reg.Requests[len(reg.Requests)-1].Body)
+			assert.NoError(t, err)
+
+			if tt.opts.Application == shared.Dependabot {
+				var payload DependabotSecretPayload
+				err := json.Unmarshal(data, &payload)
+				assert.NoError(t, err)
+				assert.Equal(t, payload.KeyID, "123")
+				assert.Equal(t, payload.EncryptedValue, "UKYUCbHd0DJemxa3AOcZ6XcsBwALG9d4bpB8ZT0gSV39vl3BHiGSgj8zJapDxgB2BwqNqRhpjC4=")
+				assert.Equal(t, payload.Visibility, tt.opts.Visibility)
+				assert.ElementsMatch(t, payload.Repositories, tt.wantDependabotRepositories)
+			} else {
+				var payload SecretPayload
+				err := json.Unmarshal(data, &payload)
+				assert.NoError(t, err)
+				assert.Equal(t, payload.KeyID, "123")
+				assert.Equal(t, payload.EncryptedValue, "UKYUCbHd0DJemxa3AOcZ6XcsBwALG9d4bpB8ZT0gSV39vl3BHiGSgj8zJapDxgB2BwqNqRhpjC4=")
+				assert.Equal(t, payload.Visibility, tt.opts.Visibility)
+				assert.ElementsMatch(t, payload.Repositories, tt.wantRepositories)
+			}
+
+			// Clear selected repos
+
+			reg.Register(httpmock.REST("PUT",
+				fmt.Sprintf("orgs/%s/%s/secrets/cool_secret/repositories", orgName, tt.wantApp)),
+				httpmock.StatusStringResponse(204, ""))
+
+			tt.opts.ClearSelectedRepos = true
+			err = setRun(tt.opts)
+			assert.NoError(t, err)
+
+			reg.Verify(t)
+
+			assert.Equal(t, tt.wantClearReposErr, err)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #9808.

### APIs Used

- [Set selected repositories for an organization secret](https://docs.github.com/en/rest/actions/secrets?apiVersion=2022-11-28#set-selected-repositories-for-an-organization-secret)
  - `PUT /orgs/{org}/actions/secrets/{secret_name}/repositories`

### Tests

#### `bin/gh secret set --help`

<details>

<summary>Output</summary>

```shell
$ bin/gh secret set --help 
Set a value for a secret on one of the following levels:
- repository (default): available to GitHub Actions runs or Dependabot in a repository
- environment: available to GitHub Actions runs for a deployment environment in a repository
- organization: available to GitHub Actions runs, Dependabot, or Codespaces within an organization
- user: available to Codespaces for your user

Organization and user secrets can optionally be restricted to only be available to
specific repositories.

For an existing organization secret, set with `--repos` and `--visibility=selected`,
all its selected repositories can be cleared by using the `--clear-repos` flag.

Secret values are locally encrypted before being sent to GitHub.


USAGE
  gh secret set <secret-name> [flags]

FLAGS
  -a, --app string           Set the application for a secret: {actions|codespaces|dependabot}
  -b, --body string          The value for the secret (reads from standard input if not specified)
      --clear-repos          Clear all selected repositories for an existing organization secret
  -e, --env environment      Set deployment environment secret
  -f, --env-file file        Load secret names and values from a dotenv-formatted file
      --no-store             Print the encrypted, base64-encoded value instead of storing it on GitHub
  -o, --org organization     Set organization secret
  -r, --repos repositories   List of repositories that can access an organization or user secret
  -u, --user                 Set a secret for your user
  -v, --visibility string    Set visibility for an organization secret: {all|private|selected} (default "private")

INHERITED FLAGS
      --help                     Show help for command
  -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format

EXAMPLES
  # Paste secret value for the current repository in an interactive prompt
  $ gh secret set MYSECRET
  
  # Read secret value from an environment variable
  $ gh secret set MYSECRET --body "$ENV_VALUE"
  
  # Set secret for a specific remote repository
  $ gh secret set MYSECRET --repo origin/repo --body "$ENV_VALUE"
  
  # Read secret value from a file
  $ gh secret set MYSECRET < myfile.txt
  
  # Set secret for a deployment environment in the current repository
  $ gh secret set MYSECRET --env myenvironment
  
  # Set organization-level secret visible to both public and private repositories
  $ gh secret set MYSECRET --org myOrg --visibility all
  
  # Set organization-level secret visible to specific repositories
  $ gh secret set MYSECRET --org myOrg --repos repo1,repo2,repo3
  
  # Set user-level secret for Codespaces
  $ gh secret set MYSECRET --user
  
  # Set repository-level secret for Dependabot
  $ gh secret set MYSECRET --app dependabot
  
  # Set multiple secrets imported from the ".env" file
  $ gh secret set -f .env
  
  # Set multiple secrets from stdin
  $ gh secret set -f - < myfile.txt
  
  # Clear all selected repositories for an existing organization-level secret with visibility "selected"
  $ gh secret set MYSECRET --org myorg --clear-repos

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
```

</details>

#### `bin/gh secret set --org <ORG> --clear-repos <SECRET>` (SUCCESS = HTTP 204)

```shell
$ bin/gh secret set --org iamazeem-test-org1 S1 --body "123" --repos test
✓ Set Actions secret S1 for iamazeem-test-org1

$ bin/gh secret list --org iamazeem-test-org1
NAME  UPDATED                 VISIBILITY                      
S1    less than a minute ago  Visible to 1 selected repository

## TTY
$ bin/gh secret set --org iamazeem-test-org1 --clear-repos S1
✓ Cleared all selected repositories for iamazeem-test-org1 organization secret S1

## non-TTY
$ bin/gh secret set --org iamazeem-test-org1 --clear-repos S1 | cat

$ bin/gh secret list --org iamazeem-test-org1
NAME  UPDATED                 VISIBILITY                        
S1    less than a minute ago  Visible to 0 selected repositories
```

#### `bin/gh secret set --org <ORG> --clear-repos <SECRET>` (FAILURE = HTTP 404 Not Found)

```shell
## TTY
$ bin/gh secret set --org iamazeem-test-org1 --clear-repos S4
X Failed to clear all selected repositories for iamazeem-test-org1 organization secret S4
HTTP 404: Not Found (https://api.github.com/orgs/iamazeem-test-org1/actions/secrets/S4/repositories)
$ echo $?
1

## non-TTY
$ bin/gh secret set --org iamazeem-test-org1 --clear-repos S4 | cat
HTTP 404: Not Found (https://api.github.com/orgs/iamazeem-test-org1/actions/secrets/S4/repositories)
```

#### `bin/gh secret set --org <ORG> --clear-repos <SECRET>` (FAILURE = HTTP 409 Conflict)

```shell
## Create secret with private visibility
$ bin/gh secret set --org iamazeem-test-org1 S2 --body "123"
✓ Set Actions secret S2 for iamazeem-test-org1

$ bin/gh secret list --org iamazeem-test-org1
NAME  UPDATED                 VISIBILITY                     
S2    less than a minute ago  Visible to private repositories

## TTY
$ bin/gh secret set --org iamazeem-test-org1 --clear-repos S2
X Failed to clear all selected repositories for iamazeem-test-org1 organization secret S2
HTTP 409 (https://api.github.com/orgs/iamazeem-test-org1/actions/secrets/S2/repositories)
$ echo $?
1

## non-TTY
$ bin/gh secret set --org iamazeem-test-org1 --clear-repos S2 | cat
HTTP 409 (https://api.github.com/orgs/iamazeem-test-org1/actions/secrets/S2/repositories)
```