### PR TITLE
Add support for disabling multiple workflows at once

### DIFF
--- a/pkg/cmd/workflow/disable/disable.go
+++ b/pkg/cmd/workflow/disable/disable.go
@@ -14,86 +14,203 @@ import (
 )
 
 type DisableOptions struct {
-	HttpClient func() (*http.Client, error)
-	IO         *iostreams.IOStreams
-	BaseRepo   func() (ghrepo.Interface, error)
-	Prompter   iprompter
+    HttpClient func() (*http.Client, error)
+    IO         *iostreams.IOStreams
+    BaseRepo   func() (ghrepo.Interface, error)
+    Prompter   iprompter
 
-	Selector string
-	Prompt   bool
+    Selector string
+    SelectorArgs []string
+    Prompt   bool
+    Multi    bool
 }
 
 type iprompter interface {
-	Select(string, string, []string) (int, error)
+    Select(string, string, []string) (int, error)
 }
 
 func NewCmdDisable(f *cmdutil.Factory, runF func(*DisableOptions) error) *cobra.Command {
-	opts := &DisableOptions{
-		IO:         f.IOStreams,
-		HttpClient: f.HttpClient,
-		Prompter:   f.Prompter,
-	}
+    opts := &DisableOptions{
+        IO:         f.IOStreams,
+        HttpClient: f.HttpClient,
+        Prompter:   f.Prompter,
+    }
 
-	cmd := &cobra.Command{
-		Use:   "disable [<workflow-id> | <workflow-name>]",
-		Short: "Disable a workflow",
-		Long:  "Disable a workflow, preventing it from running or showing up when listing workflows.",
-		Args:  cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// support `-R, --repo` override
-			opts.BaseRepo = f.BaseRepo
+    cmd := &cobra.Command{
+        Use:   "disable [<workflow-id> | <workflow-name>]",
+        Short: "Disable a workflow",
+        Long:  "Disable a workflow, preventing it from running or showing up when listing workflows.\n\nUse the --multi flag to disable multiple workflows at once.",
+        Example: "  # Disable a single workflow\n" +
+                 "  $ gh workflow disable 123\n" +
+                 "  $ gh workflow disable workflow-name\n\n" +
+                 "  # Disable multiple workflows\n" +
+                 "  $ gh workflow disable --multi workflow1 workflow2 123",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            // support `-R, --repo` override
+            opts.BaseRepo = f.BaseRepo
 
-			if len(args) > 0 {
-				opts.Selector = args[0]
-			} else if !opts.IO.CanPrompt() {
-				return cmdutil.FlagErrorf("workflow ID or name required when not running interactively")
-			} else {
-				opts.Prompt = true
-			}
+            // Validate arguments based on mode
+            if !opts.Multi && len(args) > 1 {
+                return fmt.Errorf("too many arguments, use --multi flag to disable multiple workflows")
+            }
 
-			if runF != nil {
-				return runF(opts)
-			}
-			return runDisable(opts)
-		},
-	}
+            // Process arguments
+            if len(args) > 0 {
+                if opts.Multi {
+                    opts.SelectorArgs = args
+                } else {
+                    opts.Selector = args[0]
+                }
+            } else if opts.Multi {
+                // Multi flag requires at least one argument
+                return cmdutil.FlagErrorf("at least one workflow ID or name required with --multi flag")
+            } else if !opts.IO.CanPrompt() {
+                return cmdutil.FlagErrorf("workflow ID or name required when not running interactively")
+            } else {
+                opts.Prompt = true
+            }
 
-	return cmd
+            if runF != nil {
+                return runF(opts)
+            }
+            return runDisable(opts)
+        },
+    }
+
+    // Add flags
+    cmd.Flags().BoolVar(&opts.Multi, "multi", false, "Disable multiple workflows at once")
+
+    return cmd
 }
 
+// runDisable handles the workflow disabling process
 func runDisable(opts *DisableOptions) error {
-	c, err := opts.HttpClient()
-	if err != nil {
-		return fmt.Errorf("could not build http client: %w", err)
-	}
-	client := api.NewClientFromHTTP(c)
+    c, err := opts.HttpClient()
+    if err != nil {
+        return fmt.Errorf("could not build http client: %w", err)
+    }
+    client := api.NewClientFromHTTP(c)
 
-	repo, err := opts.BaseRepo()
-	if err != nil {
-		return err
-	}
+    // Get repository
+    repo, err := opts.BaseRepo()
+    if err != nil {
+        return err
+    }
 
-	states := []shared.WorkflowState{shared.Active}
-	workflow, err := shared.ResolveWorkflow(
-		opts.Prompter, opts.IO, client, repo, opts.Prompt, opts.Selector, states)
-	if err != nil {
-		var fae shared.FilteredAllError
-		if errors.As(err, &fae) {
-			return errors.New("there are no enabled workflows to disable")
-		}
-		return err
-	}
+    // Handle multi-mode or single workflow mode
+    if opts.Multi {
+        return disableMultipleWorkflows(client, repo, opts)
+    }
 
-	path := fmt.Sprintf("repos/%s/actions/workflows/%d/disable", ghrepo.FullName(repo), workflow.ID)
-	err = client.REST(repo.RepoHost(), "PUT", path, nil, nil)
-	if err != nil {
-		return fmt.Errorf("failed to disable workflow: %w", err)
-	}
+    // Handle single workflow mode
+    workflow, err := resolveAndDisableWorkflow(client, repo, opts, opts.Selector, opts.Prompt)
+    if err != nil {
+        var fae shared.FilteredAllError
+        if errors.As(err, &fae) {
+            return errors.New("there are no enabled workflows to disable")
+        }
+        return err
+    }
 
-	if opts.IO.CanPrompt() {
-		cs := opts.IO.ColorScheme()
-		fmt.Fprintf(opts.IO.Out, "%s Disabled %s\n", cs.SuccessIconWithColor(cs.Red), cs.Bold(workflow.Name))
-	}
+    printDisabledMessage(opts.IO, workflow.Name)
+    return nil
+}
 
-	return nil
+// disableMultipleWorkflows handles disabling multiple workflows with error collection
+func disableMultipleWorkflows(client *api.Client, repo ghrepo.Interface, opts *DisableOptions) error {
+    var errs []error
+    var successCount int
+
+    resolvedSelectors := make(map[string]int64) // Maps selectors to workflow IDs
+    disabledWorkflowIDs := make(map[int64]bool) // Tracks already disabled workflow IDs
+    
+    for _, selector := range opts.SelectorArgs {
+        var workflow *shared.Workflow
+        var err error
+        
+        // Check if we've already resolved this selector
+        if workflowID, exists := resolvedSelectors[selector]; exists {
+            // Check if we've already disabled this workflow
+            if disabledWorkflowIDs[workflowID] {
+                // Workflow already disabled, skip silently
+                continue
+            }
+            
+            // Reuse the already resolved workflow ID to avoid prompting again
+            path := fmt.Sprintf("repos/%s/actions/workflows/%d/disable", ghrepo.FullName(repo), workflowID)
+            err = client.REST(repo.RepoHost(), "PUT", path, nil, nil)
+            if err != nil {
+                errs = append(errs, fmt.Errorf("workflow '%s': failed to disable workflow: %w", selector, err))
+                continue
+            }
+            
+            disabledWorkflowIDs[workflowID] = true
+            successCount++
+            continue
+        }
+
+        // Resolve and disable workflow normally
+        workflow, err = resolveAndDisableWorkflow(client, repo, opts, selector, false)
+        if err != nil {
+            var fae shared.FilteredAllError
+            if errors.As(err, &fae) {
+                errs = append(errs, fmt.Errorf("workflow '%s': there are no enabled workflows to disable", selector))
+            } else {
+                errs = append(errs, fmt.Errorf("workflow '%s': %w", selector, err))
+            }
+            continue
+        }
+
+        // Store the workflow ID for this selector to avoid prompting again
+        resolvedSelectors[selector] = workflow.ID
+        disabledWorkflowIDs[workflow.ID] = true
+        
+        successCount++
+        printDisabledMessage(opts.IO, workflow.Name)
+    }
+
+    if len(errs) > 0 {
+        if successCount > 0 {
+            // Some workflows were successfully disabled, others failed
+            fmt.Fprintf(opts.IO.Out, "%s: Successfully disabled %d out of %d workflows\n", 
+                opts.IO.ColorScheme().WarningIcon(), 
+                successCount, 
+                len(opts.SelectorArgs))
+        }
+        return errors.Join(errs...)
+    } else if opts.Multi && opts.IO.CanPrompt() {
+        // Add this block for complete success message
+        fmt.Fprintf(opts.IO.Out, "%s Successfully disabled all %d workflows\n",
+            opts.IO.ColorScheme().SuccessIcon(),
+            successCount)
+    }
+    
+
+    return nil
+}
+
+// resolveAndDisableWorkflow handles resolving and disabling a single workflow
+func resolveAndDisableWorkflow(client *api.Client, repo ghrepo.Interface, opts *DisableOptions, selector string, usePrompt bool) (*shared.Workflow, error) {
+    states := []shared.WorkflowState{shared.Active}
+    workflow, err := shared.ResolveWorkflow(
+        opts.Prompter, opts.IO, client, repo, usePrompt, selector, states)
+    if err != nil {
+        return nil, err
+    }
+
+    path := fmt.Sprintf("repos/%s/actions/workflows/%d/disable", ghrepo.FullName(repo), workflow.ID)
+    err = client.REST(repo.RepoHost(), "PUT", path, nil, nil)
+    if err != nil {
+        return nil, fmt.Errorf("failed to disable workflow: %w", err)
+    }
+
+    return workflow, nil
+}
+
+// printDisabledMessage prints a success message for a disabled workflow
+func printDisabledMessage(io *iostreams.IOStreams, workflowName string) {
+    if io.CanPrompt() {
+        cs := io.ColorScheme()
+        fmt.Fprintf(io.Out, "%s Disabled %s\n", cs.SuccessIconWithColor(cs.Red), cs.Bold(workflowName))
+    }
 }

--- a/pkg/cmd/workflow/disable/disable.go
+++ b/pkg/cmd/workflow/disable/disable.go
@@ -14,203 +14,202 @@ import (
 )
 
 type DisableOptions struct {
-    HttpClient func() (*http.Client, error)
-    IO         *iostreams.IOStreams
-    BaseRepo   func() (ghrepo.Interface, error)
-    Prompter   iprompter
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (ghrepo.Interface, error)
+	Prompter   iprompter
 
-    Selector string
-    SelectorArgs []string
-    Prompt   bool
-    Multi    bool
+	Selector     string
+	SelectorArgs []string
+	Prompt       bool
+	Multi        bool
 }
 
 type iprompter interface {
-    Select(string, string, []string) (int, error)
+	Select(string, string, []string) (int, error)
 }
 
 func NewCmdDisable(f *cmdutil.Factory, runF func(*DisableOptions) error) *cobra.Command {
-    opts := &DisableOptions{
-        IO:         f.IOStreams,
-        HttpClient: f.HttpClient,
-        Prompter:   f.Prompter,
-    }
+	opts := &DisableOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Prompter:   f.Prompter,
+	}
 
-    cmd := &cobra.Command{
-        Use:   "disable [<workflow-id> | <workflow-name>]",
-        Short: "Disable a workflow",
-        Long:  "Disable a workflow, preventing it from running or showing up when listing workflows.\n\nUse the --multi flag to disable multiple workflows at once.",
-        Example: "  # Disable a single workflow\n" +
-                 "  $ gh workflow disable 123\n" +
-                 "  $ gh workflow disable workflow-name\n\n" +
-                 "  # Disable multiple workflows\n" +
-                 "  $ gh workflow disable --multi workflow1 workflow2 123",
-        RunE: func(cmd *cobra.Command, args []string) error {
-            // support `-R, --repo` override
-            opts.BaseRepo = f.BaseRepo
+	cmd := &cobra.Command{
+		Use:   "disable [<workflow-id> | <workflow-name>]",
+		Short: "Disable a workflow",
+		Long:  "Disable a workflow, preventing it from running or showing up when listing workflows.\n\nUse the --multi flag to disable multiple workflows at once.",
+		Example: "  # Disable a single workflow\n" +
+			"  $ gh workflow disable 123\n" +
+			"  $ gh workflow disable workflow-name\n\n" +
+			"  # Disable multiple workflows\n" +
+			"  $ gh workflow disable --multi workflow1 workflow2 123",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// support `-R, --repo` override
+			opts.BaseRepo = f.BaseRepo
 
-            // Validate arguments based on mode
-            if !opts.Multi && len(args) > 1 {
-                return fmt.Errorf("too many arguments, use --multi flag to disable multiple workflows")
-            }
+			// Validate arguments based on mode
+			if !opts.Multi && len(args) > 1 {
+				return fmt.Errorf("too many arguments, use --multi flag to disable multiple workflows")
+			}
 
-            // Process arguments
-            if len(args) > 0 {
-                if opts.Multi {
-                    opts.SelectorArgs = args
-                } else {
-                    opts.Selector = args[0]
-                }
-            } else if opts.Multi {
-                // Multi flag requires at least one argument
-                return cmdutil.FlagErrorf("at least one workflow ID or name required with --multi flag")
-            } else if !opts.IO.CanPrompt() {
-                return cmdutil.FlagErrorf("workflow ID or name required when not running interactively")
-            } else {
-                opts.Prompt = true
-            }
+			// Process arguments
+			if len(args) > 0 {
+				if opts.Multi {
+					opts.SelectorArgs = args
+				} else {
+					opts.Selector = args[0]
+				}
+			} else if opts.Multi {
+				// Multi flag requires at least one argument
+				return cmdutil.FlagErrorf("at least one workflow ID or name required with --multi flag")
+			} else if !opts.IO.CanPrompt() {
+				return cmdutil.FlagErrorf("workflow ID or name required when not running interactively")
+			} else {
+				opts.Prompt = true
+			}
 
-            if runF != nil {
-                return runF(opts)
-            }
-            return runDisable(opts)
-        },
-    }
+			if runF != nil {
+				return runF(opts)
+			}
+			return runDisable(opts)
+		},
+	}
 
-    // Add flags
-    cmd.Flags().BoolVar(&opts.Multi, "multi", false, "Disable multiple workflows at once")
+	// Add flags
+	cmd.Flags().BoolVar(&opts.Multi, "multi", false, "Disable multiple workflows at once")
 
-    return cmd
+	return cmd
 }
 
 // runDisable handles the workflow disabling process
 func runDisable(opts *DisableOptions) error {
-    c, err := opts.HttpClient()
-    if err != nil {
-        return fmt.Errorf("could not build http client: %w", err)
-    }
-    client := api.NewClientFromHTTP(c)
+	c, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not build http client: %w", err)
+	}
+	client := api.NewClientFromHTTP(c)
 
-    // Get repository
-    repo, err := opts.BaseRepo()
-    if err != nil {
-        return err
-    }
+	// Get repository
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
 
-    // Handle multi-mode or single workflow mode
-    if opts.Multi {
-        return disableMultipleWorkflows(client, repo, opts)
-    }
+	// Handle multi-mode or single workflow mode
+	if opts.Multi {
+		return disableMultipleWorkflows(client, repo, opts)
+	}
 
-    // Handle single workflow mode
-    workflow, err := resolveAndDisableWorkflow(client, repo, opts, opts.Selector, opts.Prompt)
-    if err != nil {
-        var fae shared.FilteredAllError
-        if errors.As(err, &fae) {
-            return errors.New("there are no enabled workflows to disable")
-        }
-        return err
-    }
+	// Handle single workflow mode
+	workflow, err := resolveAndDisableWorkflow(client, repo, opts, opts.Selector, opts.Prompt)
+	if err != nil {
+		var fae shared.FilteredAllError
+		if errors.As(err, &fae) {
+			return errors.New("there are no enabled workflows to disable")
+		}
+		return err
+	}
 
-    printDisabledMessage(opts.IO, workflow.Name)
-    return nil
+	printDisabledMessage(opts.IO, workflow.Name)
+	return nil
 }
 
 // disableMultipleWorkflows handles disabling multiple workflows with error collection
 func disableMultipleWorkflows(client *api.Client, repo ghrepo.Interface, opts *DisableOptions) error {
-    var errs []error
-    var successCount int
+	var errs []error
+	var successCount int
 
-    resolvedSelectors := make(map[string]int64) // Maps selectors to workflow IDs
-    disabledWorkflowIDs := make(map[int64]bool) // Tracks already disabled workflow IDs
-    
-    for _, selector := range opts.SelectorArgs {
-        var workflow *shared.Workflow
-        var err error
-        
-        // Check if we've already resolved this selector
-        if workflowID, exists := resolvedSelectors[selector]; exists {
-            // Check if we've already disabled this workflow
-            if disabledWorkflowIDs[workflowID] {
-                // Workflow already disabled, skip silently
-                continue
-            }
-            
-            // Reuse the already resolved workflow ID to avoid prompting again
-            path := fmt.Sprintf("repos/%s/actions/workflows/%d/disable", ghrepo.FullName(repo), workflowID)
-            err = client.REST(repo.RepoHost(), "PUT", path, nil, nil)
-            if err != nil {
-                errs = append(errs, fmt.Errorf("workflow '%s': failed to disable workflow: %w", selector, err))
-                continue
-            }
-            
-            disabledWorkflowIDs[workflowID] = true
-            successCount++
-            continue
-        }
+	resolvedSelectors := make(map[string]int64) // Maps selectors to workflow IDs
+	disabledWorkflowIDs := make(map[int64]bool) // Tracks already disabled workflow IDs
 
-        // Resolve and disable workflow normally
-        workflow, err = resolveAndDisableWorkflow(client, repo, opts, selector, false)
-        if err != nil {
-            var fae shared.FilteredAllError
-            if errors.As(err, &fae) {
-                errs = append(errs, fmt.Errorf("workflow '%s': there are no enabled workflows to disable", selector))
-            } else {
-                errs = append(errs, fmt.Errorf("workflow '%s': %w", selector, err))
-            }
-            continue
-        }
+	for _, selector := range opts.SelectorArgs {
+		var workflow *shared.Workflow
+		var err error
 
-        // Store the workflow ID for this selector to avoid prompting again
-        resolvedSelectors[selector] = workflow.ID
-        disabledWorkflowIDs[workflow.ID] = true
-        
-        successCount++
-        printDisabledMessage(opts.IO, workflow.Name)
-    }
+		// Check if we've already resolved this selector
+		if workflowID, exists := resolvedSelectors[selector]; exists {
+			// Check if we've already disabled this workflow
+			if disabledWorkflowIDs[workflowID] {
+				// Workflow already disabled, skip silently
+				continue
+			}
 
-    if len(errs) > 0 {
-        if successCount > 0 {
-            // Some workflows were successfully disabled, others failed
-            fmt.Fprintf(opts.IO.Out, "%s: Successfully disabled %d out of %d workflows\n", 
-                opts.IO.ColorScheme().WarningIcon(), 
-                successCount, 
-                len(opts.SelectorArgs))
-        }
-        return errors.Join(errs...)
-    } else if opts.Multi && opts.IO.CanPrompt() {
-        // Add this block for complete success message
-        fmt.Fprintf(opts.IO.Out, "%s Successfully disabled all %d workflows\n",
-            opts.IO.ColorScheme().SuccessIcon(),
-            successCount)
-    }
-    
+			// Reuse the already resolved workflow ID to avoid prompting again
+			path := fmt.Sprintf("repos/%s/actions/workflows/%d/disable", ghrepo.FullName(repo), workflowID)
+			err = client.REST(repo.RepoHost(), "PUT", path, nil, nil)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("workflow '%s': failed to disable workflow: %w", selector, err))
+				continue
+			}
 
-    return nil
+			disabledWorkflowIDs[workflowID] = true
+			successCount++
+			continue
+		}
+
+		// Resolve and disable workflow normally
+		workflow, err = resolveAndDisableWorkflow(client, repo, opts, selector, false)
+		if err != nil {
+			var fae shared.FilteredAllError
+			if errors.As(err, &fae) {
+				errs = append(errs, fmt.Errorf("workflow '%s': there are no enabled workflows to disable", selector))
+			} else {
+				errs = append(errs, fmt.Errorf("workflow '%s': %w", selector, err))
+			}
+			continue
+		}
+
+		// Store the workflow ID for this selector to avoid prompting again
+		resolvedSelectors[selector] = workflow.ID
+		disabledWorkflowIDs[workflow.ID] = true
+
+		successCount++
+		printDisabledMessage(opts.IO, workflow.Name)
+	}
+
+	if len(errs) > 0 {
+		if successCount > 0 {
+			// Some workflows were successfully disabled, others failed
+			fmt.Fprintf(opts.IO.Out, "%s: Successfully disabled %d out of %d workflows\n",
+				opts.IO.ColorScheme().WarningIcon(),
+				successCount,
+				len(opts.SelectorArgs))
+		}
+		return errors.Join(errs...)
+	} else if opts.Multi && opts.IO.CanPrompt() {
+		// Add this block for complete success message
+		fmt.Fprintf(opts.IO.Out, "%s Successfully disabled all %d workflows\n",
+			opts.IO.ColorScheme().SuccessIcon(),
+			successCount)
+	}
+
+	return nil
 }
 
 // resolveAndDisableWorkflow handles resolving and disabling a single workflow
 func resolveAndDisableWorkflow(client *api.Client, repo ghrepo.Interface, opts *DisableOptions, selector string, usePrompt bool) (*shared.Workflow, error) {
-    states := []shared.WorkflowState{shared.Active}
-    workflow, err := shared.ResolveWorkflow(
-        opts.Prompter, opts.IO, client, repo, usePrompt, selector, states)
-    if err != nil {
-        return nil, err
-    }
+	states := []shared.WorkflowState{shared.Active}
+	workflow, err := shared.ResolveWorkflow(
+		opts.Prompter, opts.IO, client, repo, usePrompt, selector, states)
+	if err != nil {
+		return nil, err
+	}
 
-    path := fmt.Sprintf("repos/%s/actions/workflows/%d/disable", ghrepo.FullName(repo), workflow.ID)
-    err = client.REST(repo.RepoHost(), "PUT", path, nil, nil)
-    if err != nil {
-        return nil, fmt.Errorf("failed to disable workflow: %w", err)
-    }
+	path := fmt.Sprintf("repos/%s/actions/workflows/%d/disable", ghrepo.FullName(repo), workflow.ID)
+	err = client.REST(repo.RepoHost(), "PUT", path, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to disable workflow: %w", err)
+	}
 
-    return workflow, nil
+	return workflow, nil
 }
 
 // printDisabledMessage prints a success message for a disabled workflow
 func printDisabledMessage(io *iostreams.IOStreams, workflowName string) {
-    if io.CanPrompt() {
-        cs := io.ColorScheme()
-        fmt.Fprintf(io.Out, "%s Disabled %s\n", cs.SuccessIconWithColor(cs.Red), cs.Bold(workflowName))
-    }
+	if io.CanPrompt() {
+		cs := io.ColorScheme()
+		fmt.Fprintf(io.Out, "%s Disabled %s\n", cs.SuccessIconWithColor(cs.Red), cs.Bold(workflowName))
+	}
 }

--- a/pkg/cmd/workflow/disable/disable_test.go
+++ b/pkg/cmd/workflow/disable/disable_test.go
@@ -300,7 +300,7 @@ func TestDisableRun(t *testing.T) {
 				reg.Register(
 					httpmock.REST("PUT", "repos/OWNER/REPO/actions/workflows/123/disable"),
 					httpmock.StatusStringResponse(204, "{}"))
-				
+
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/789"),
 					httpmock.JSONResponse(shared.AnotherWorkflow))
@@ -354,7 +354,7 @@ func TestDisableRun(t *testing.T) {
 			err := runDisable(tt.opts)
 			if tt.wantErr {
 				assert.Error(t, err)
-					assert.Equal(t, tt.wantErrOut, err.Error())
+				assert.Equal(t, tt.wantErrOut, err.Error())
 				return
 			}
 			assert.NoError(t, err)

--- a/pkg/cmd/workflow/disable/disable_test.go
+++ b/pkg/cmd/workflow/disable/disable_test.go
@@ -50,6 +50,35 @@ func TestNewCmdDisable(t *testing.T) {
 				Selector: "123",
 			},
 		},
+		{
+			name:     "multiple args without multi flag",
+			cli:      "123 456",
+			tty:      true,
+			wantsErr: true,
+		},
+		{
+			name:     "multi flag with no args",
+			cli:      "--multi",
+			tty:      true,
+			wantsErr: true,
+		},
+		{
+			name: "multi flag with args",
+			cli:  "--multi 123 456",
+			tty:  true,
+			wants: DisableOptions{
+				Multi:        true,
+				SelectorArgs: []string{"123", "456"},
+			},
+		},
+		{
+			name: "multi flag with args nontty",
+			cli:  "--multi 123 456",
+			wants: DisableOptions{
+				Multi:        true,
+				SelectorArgs: []string{"123", "456"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -85,6 +114,8 @@ func TestNewCmdDisable(t *testing.T) {
 
 			assert.Equal(t, tt.wants.Selector, gotOpts.Selector)
 			assert.Equal(t, tt.wants.Prompt, gotOpts.Prompt)
+			assert.Equal(t, tt.wants.Multi, gotOpts.Multi)
+			assert.Equal(t, tt.wants.SelectorArgs, gotOpts.SelectorArgs)
 		})
 	}
 }
@@ -255,6 +286,47 @@ func TestDisableRun(t *testing.T) {
 			wantErr:    true,
 			wantErrOut: "could not resolve to a unique workflow; found: another.yml yetanother.yml",
 		},
+		{
+			name: "multi mode with multiple workflow IDs",
+			opts: &DisableOptions{
+				Multi:        true,
+				SelectorArgs: []string{"123", "789"},
+			},
+			tty: true,
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/123"),
+					httpmock.JSONResponse(shared.AWorkflow))
+				reg.Register(
+					httpmock.REST("PUT", "repos/OWNER/REPO/actions/workflows/123/disable"),
+					httpmock.StatusStringResponse(204, "{}"))
+				
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/789"),
+					httpmock.JSONResponse(shared.AnotherWorkflow))
+				reg.Register(
+					httpmock.REST("PUT", "repos/OWNER/REPO/actions/workflows/789/disable"),
+					httpmock.StatusStringResponse(204, "{}"))
+			},
+			wantOut: "✓ Disabled a workflow\n✓ Disabled another workflow\n✓ Successfully disabled all 2 workflows\n",
+		},
+		{
+			name: "multi mode with duplicate workflow",
+			opts: &DisableOptions{
+				Multi:        true,
+				SelectorArgs: []string{"123", "123"},
+			},
+			tty: true,
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/123"),
+					httpmock.JSONResponse(shared.AWorkflow))
+				reg.Register(
+					httpmock.REST("PUT", "repos/OWNER/REPO/actions/workflows/123/disable"),
+					httpmock.StatusStringResponse(204, "{}"))
+			},
+			wantOut: "✓ Disabled a workflow\n✓ Successfully disabled all 1 workflows\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -282,7 +354,7 @@ func TestDisableRun(t *testing.T) {
 			err := runDisable(tt.opts)
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.Equal(t, tt.wantErrOut, err.Error())
+					assert.Equal(t, tt.wantErrOut, err.Error())
 				return
 			}
 			assert.NoError(t, err)


### PR DESCRIPTION
# Add support for disabling multiple workflows with a single command

Fixes #10594 

This PR implements the feature requested to allow users to disable multiple GitHub Actions workflows with a single command invocation.

## Changes

- Added a new `--multi` flag to the `gh workflow disable` command
- Enhanced the command to accept multiple workflow IDs/names when the `--multi` flag is used
- Implemented error collection to report issues with individual workflows
- Added optimization to avoid redundant API calls for duplicate workflow references
- Added detailed success reporting for multi-workflow operations
- Updated command documentation with usage examples
- Added comprehensive test coverage for the new functionality

## Examples

Previously, users had to run multiple commands:
```bash
gh workflow disable workflow1
gh workflow disable workflow2
gh workflow disable workflow3
```

Now users can run:
```bash
gh workflow disable --multi workflow1 workflow2 workflow3
```

![Ekran görüntüsü 2025-03-16 222516](https://github.com/user-attachments/assets/58a7077d-0d8d-4f90-b1ed-58cf07387cd8)
![Ekran görüntüsü 2025-03-16 222611](https://github.com/user-attachments/assets/c8f446f8-727e-4ef3-9d32-6918919fd05e)
![Ekran görüntüsü 2025-03-16 222722](https://github.com/user-attachments/assets/3913b9e0-6280-4c2f-9ab2-7fb6c26be099)
![Ekran görüntüsü 2025-03-16 222830](https://github.com/user-attachments/assets/e5b32762-0b03-44c8-be5a-a8f36325d37e)
![Ekran görüntüsü 2025-03-16 223118](https://github.com/user-attachments/assets/922c2df8-4a26-4806-abe4-4ca4b1195943)


## Implementation Details

The implementation maintains backward compatibility while adding the new capability. The code reports how many workflows were successfully disabled, making it easier to manage large sets of workflows.


Fixes #10594