### PR TITLE
`run list`: do not fail on organization/enterprise ruleset imposed workflows

### DIFF
--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -62,6 +62,9 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 			Note that providing the %[1]sworkflow_name%[1]s to the %[1]s-w%[1]s flag will not fetch disabled workflows.
 			Also pass the %[1]s-a%[1]s flag to fetch disabled workflow runs using the %[1]sworkflow_name%[1]s and the %[1]s-w%[1]s flag.
+
+			A run with no workflow name indicates that the run likely belongs an organization ruleset required workflow,
+			and the authenticated user does not have access to the workflow definition.
 		`, "`"),
 		Aliases: []string{"ls"},
 		Args:    cobra.NoArgs,

--- a/pkg/cmd/run/list/list.go
+++ b/pkg/cmd/run/list/list.go
@@ -63,8 +63,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			Note that providing the %[1]sworkflow_name%[1]s to the %[1]s-w%[1]s flag will not fetch disabled workflows.
 			Also pass the %[1]s-a%[1]s flag to fetch disabled workflow runs using the %[1]sworkflow_name%[1]s and the %[1]s-w%[1]s flag.
 
-			A run with no workflow name indicates that the run likely belongs an organization ruleset required workflow,
-			and the authenticated user does not have access to the workflow definition.
+			Runs created by organization and enterprise ruleset workflows will not display a workflow name due to GitHub API limitations.
 		`, "`"),
 		Aliases: []string{"ls"},
 		Args:    cobra.NoArgs,

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -367,7 +367,7 @@ func TestListRun(t *testing.T) {
 			`),
 		},
 		{
-			name: "organization required workflow in run list (workflow GET returns 404)",
+			name: "org required workflow in runs list shows with empty workflow name",
 			opts: &ListOptions{
 				Limit: defaultLimit,
 				now:   shared.TestRunStartTime.Add(time.Minute*4 + time.Second*34),

--- a/pkg/cmd/run/list/list_test.go
+++ b/pkg/cmd/run/list/list_test.go
@@ -367,7 +367,7 @@ func TestListRun(t *testing.T) {
 			`),
 		},
 		{
-			name: "org required workflow in runs list shows with empty workflow name",
+			name: "org ruleset workflow in runs list shows with empty workflow name",
 			opts: &ListOptions{
 				Limit: defaultLimit,
 				now:   shared.TestRunStartTime.Add(time.Minute*4 + time.Second*34),

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -447,7 +447,7 @@ func preloadWorkflowNames(client *api.Client, repo ghrepo.Interface, runs []Run)
 			// Look up workflow by ID because it may have been deleted
 			workflow, err := workflowShared.GetWorkflow(client, repo, run.WorkflowID)
 			// If the error is an httpError and it is a 404, this is likely a
-			// organization-level "required workflow" ruleset. The user does not
+			// organization or enterprise ruleset workflow. The user does not
 			// have permissions to view the details of the workflow, so we cannot
 			// look it up directly without receiving a 404, but it is nonetheless
 			// in the workflow run list. To handle this, we set the workflow name

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -446,6 +446,16 @@ func preloadWorkflowNames(client *api.Client, repo ghrepo.Interface, runs []Run)
 		if _, ok := workflowMap[run.WorkflowID]; !ok {
 			// Look up workflow by ID because it may have been deleted
 			workflow, err := workflowShared.GetWorkflow(client, repo, run.WorkflowID)
+			// If the error is an httpError and it is a 404, this is likely a
+			// organization-level "required workflow" ruleset. The user does not
+			// have permissions to view the details of the workflow, so we cannot
+			// look it up directly without receiving a 404, but it is nonetheless
+			// in the workflow run list. To handle this, we set the workflow name
+			// to an empty string.
+			if httpErr, ok := err.(api.HTTPError); ok && httpErr.StatusCode == 404 {
+				workflowMap[run.WorkflowID] = ""
+				continue
+			}
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -452,6 +452,8 @@ func preloadWorkflowNames(client *api.Client, repo ghrepo.Interface, runs []Run)
 			// look it up directly without receiving a 404, but it is nonetheless
 			// in the workflow run list. To handle this, we set the workflow name
 			// to an empty string.
+			// Deciding to put this here instead of in GetWorkflow to allow
+			// the caller to decide what a 404 means.
 			if httpErr, ok := err.(api.HTTPError); ok && httpErr.StatusCode == 404 {
 				workflowMap[run.WorkflowID] = ""
 				continue

--- a/pkg/cmd/run/shared/test.go
+++ b/pkg/cmd/run/shared/test.go
@@ -18,6 +18,10 @@ func TestRunWithCommit(id int64, s Status, c Conclusion, commit string) Run {
 	return TestRunWithWorkflowAndCommit(123, id, s, c, commit)
 }
 
+func TestRunWithOrgRequiredWorkflow(id int64, s Status, c Conclusion, commit string) Run {
+	return TestRunWithWorkflowAndCommit(456, id, s, c, commit)
+}
+
 func TestRunWithWorkflowAndCommit(workflowId, runId int64, s Status, c Conclusion, commit string) Run {
 	return Run{
 		WorkflowID: workflowId,
@@ -55,6 +59,18 @@ var TestRuns []Run = []Run{
 	TestRun(8, Requested, ""),
 	TestRun(9, Queued, ""),
 	TestRun(10, Completed, Stale),
+}
+
+var TestRunsWithOrgRequiredWorkflows []Run = []Run{
+	TestRunWithOrgRequiredWorkflow(1, Completed, TimedOut, "cool commit"),
+	TestRunWithOrgRequiredWorkflow(2, InProgress, "", "cool commit"),
+	TestRunWithOrgRequiredWorkflow(3, Completed, Success, "cool commit"),
+	TestRunWithOrgRequiredWorkflow(4, Completed, Cancelled, "cool commit"),
+	TestRun(5, Completed, Failure),
+	TestRun(6, Completed, Neutral),
+	TestRun(7, Completed, Skipped),
+	TestRun(8, Requested, ""),
+	TestRun(9, Queued, ""),
 }
 
 var WorkflowRuns []Run = []Run{


### PR DESCRIPTION
Fixes #10076

> [!NOTE]
> There are slight differences between this and the acceptance criteria, see below and please provide feedback.

### Acceptance Criteria

> **Given** I there is a `run` whose workflow is required via an org ruleset
> **When** I run `gh run list`
> **Then** Under the `WORKFLOW` column I see no entry.

I was unsure of what "no entry" means here, but I interpreted it as meaning there should be whitespace in that column. I could also read this as wanting the words "no entry" to appear in the column.

Unit test output:

```
STATUS  TITLE        WORKFLOW  BRANCH  EVENT  ID  ELAPSED  AGE
X       cool commit            trunk   push   1   4m34s    about 4 minutes ago
*       cool commit            trunk   push   2   4m34s    about 4 minutes ago
✓       cool commit            trunk   push   3   4m34s    about 4 minutes ago
X       cool commit            trunk   push   4   4m34s    about 4 minutes ago
X       cool commit  CI        trunk   push   5   4m34s    about 4 minutes ago
-       cool commit  CI        trunk   push   6   4m34s    about 4 minutes ago
-       cool commit  CI        trunk   push   7   4m34s    about 4 minutes ago
*       cool commit  CI        trunk   push   8   4m34s    about 4 minutes ago
*       cool commit  CI        trunk   push   9   4m34s    about 4 minutes ago
```

> **When** I run `gh run list --help`
> **Then** I see an explanation of what no entry means.

```
 ./bin/gh run list --help
List recent workflow runs.

Note that providing the `workflow_name` to the `-w` flag will not fetch disabled workflows.
Also pass the `-a` flag to fetch disabled workflow runs using the `workflow_name` and the `-w` flag.

A run with no workflow name indicates that the run likely belongs an organization ruleset required workflow,
and the authenticated user does not have access to the workflow definition.

For more information about output formatting flags, see `gh help formatting`.
```

> **Given** I there is a `run` whose workflow is required via an org ruleset
> **When** I run `gh run list --json workflowName`
> **Then** I see `nil` for the value of `workflowName`
> I'm choosing `nil` because when programmatically interpreting this, it should not be confused with any other name.

I'm interested in knowing if we would be okay with simply having an empty string instead of `"nil"`:

example `gh run list --json workflowName`
```
<snip>
  {
    "workflowName": ""
  },
  {
    "workflowName": ""
  },
<snip>
```

If we do desire the string `"nil"` in the JSON output, then I'd be interested in hearing some ideas on implementation - how do we get blank whitespaces in the workflow name when running `gh run list` normally, but `"nil"` when exporting it as JSON? 

Seems to me that it would be easier to just keep both cases as an empty string 🤷 

> **When** I run `gh run list --help`
> **Then** I see an explanation that the `workflowName` field may be nil in this case
> 
> **Note**: Need to understand whether we have `workflowDatabaseId` json field. 
> 

Same comment as above.
