### PR TITLE
feat: Advanced Issue Search support for `gh search issues`

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -610,7 +610,7 @@ var Options = []ConfigOption{
 	},
 	{
 		Key:           advancedIssueSearchKey,
-		Description:   "toggle advanced issue search API {enabled|disabled} (default disabled)",
+		Description:   "toggle advanced issue search API",
 		DefaultValue:  "disabled",
 		AllowedValues: []string{"enabled", "disabled"},
 		CurrentValue: func(c gh.Config, hostname string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,19 +15,20 @@ import (
 )
 
 const (
-	aliasesKey            = "aliases"
-	browserKey            = "browser"
-	editorKey             = "editor"
-	gitProtocolKey        = "git_protocol"
-	hostsKey              = "hosts"
-	httpUnixSocketKey     = "http_unix_socket"
-	oauthTokenKey         = "oauth_token"
-	pagerKey              = "pager"
-	promptKey             = "prompt"
-	preferEditorPromptKey = "prefer_editor_prompt"
-	userKey               = "user"
-	usersKey              = "users"
-	versionKey            = "version"
+	advancedIssueSearchKey = "advanced_issue_search"
+	aliasesKey             = "aliases"
+	browserKey             = "browser"
+	editorKey              = "editor"
+	gitProtocolKey         = "git_protocol"
+	hostsKey               = "hosts"
+	httpUnixSocketKey      = "http_unix_socket"
+	oauthTokenKey          = "oauth_token"
+	pagerKey               = "pager"
+	promptKey              = "prompt"
+	preferEditorPromptKey  = "prefer_editor_prompt"
+	userKey                = "user"
+	usersKey               = "users"
+	versionKey             = "version"
 )
 
 func NewConfig() (gh.Config, error) {
@@ -141,6 +142,11 @@ func (c *cfg) Prompt(hostname string) gh.ConfigEntry {
 func (c *cfg) PreferEditorPrompt(hostname string) gh.ConfigEntry {
 	// Intentionally panic if there is no user provided value or default value (which would be a programmer error)
 	return c.GetOrDefault(hostname, preferEditorPromptKey).Unwrap()
+}
+
+func (c *cfg) AdvancedIssueSearch(hostname string) gh.ConfigEntry {
+	// Intentionally panic if there is no user provided value or default value (which would be a programmer error)
+	return c.GetOrDefault(hostname, advancedIssueSearchKey).Unwrap()
 }
 
 func (c *cfg) Version() o.Option[string] {
@@ -600,6 +606,15 @@ var Options = []ConfigOption{
 		DefaultValue: "",
 		CurrentValue: func(c gh.Config, hostname string) string {
 			return c.Browser(hostname).Value
+		},
+	},
+	{
+		Key:           advancedIssueSearchKey,
+		Description:   "toggle advanced issue search API {enabled|disabled} (default disabled)",
+		DefaultValue:  "disabled",
+		AllowedValues: []string{"enabled", "disabled"},
+		CurrentValue: func(c gh.Config, hostname string) string {
+			return c.AdvancedIssueSearch(hostname).Value
 		},
 	},
 }

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -79,6 +79,9 @@ func NewFromString(cfgStr string) *ghmock.ConfigMock {
 	mock.CacheDirFunc = func() string {
 		return cfg.CacheDir()
 	}
+	mock.AdvancedIssueSearchFunc = func(hostname string) gh.ConfigEntry {
+		return cfg.AdvancedIssueSearch(hostname)
+	}
 	return mock
 }
 

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -35,6 +35,8 @@ type Config interface {
 	// Set provides primitive access for setting configuration values, optionally scoped by host.
 	Set(hostname string, key string, value string)
 
+	// AdvancedIssueSearch returns the configured advanced issue search, optionally scoped by host.
+	AdvancedIssueSearch(hostname string) ConfigEntry
 	// Browser returns the configured browser, optionally scoped by host.
 	Browser(hostname string) ConfigEntry
 	// Editor returns the configured editor, optionally scoped by host.

--- a/internal/gh/mock/config.go
+++ b/internal/gh/mock/config.go
@@ -19,6 +19,9 @@ var _ gh.Config = &ConfigMock{}
 //
 //		// make and configure a mocked gh.Config
 //		mockedConfig := &ConfigMock{
+//			AdvancedIssueSearchFunc: func(hostname string) gh.ConfigEntry {
+//				panic("mock out the AdvancedIssueSearch method")
+//			},
 //			AliasesFunc: func() gh.AliasConfig {
 //				panic("mock out the Aliases method")
 //			},
@@ -71,6 +74,9 @@ var _ gh.Config = &ConfigMock{}
 //
 //	}
 type ConfigMock struct {
+	// AdvancedIssueSearchFunc mocks the AdvancedIssueSearch method.
+	AdvancedIssueSearchFunc func(hostname string) gh.ConfigEntry
+
 	// AliasesFunc mocks the Aliases method.
 	AliasesFunc func() gh.AliasConfig
 
@@ -118,6 +124,11 @@ type ConfigMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// AdvancedIssueSearch holds details about calls to the AdvancedIssueSearch method.
+		AdvancedIssueSearch []struct {
+			// Hostname is the hostname argument value.
+			Hostname string
+		}
 		// Aliases holds details about calls to the Aliases method.
 		Aliases []struct {
 		}
@@ -190,21 +201,54 @@ type ConfigMock struct {
 		Write []struct {
 		}
 	}
-	lockAliases            sync.RWMutex
-	lockAuthentication     sync.RWMutex
-	lockBrowser            sync.RWMutex
-	lockCacheDir           sync.RWMutex
-	lockEditor             sync.RWMutex
-	lockGetOrDefault       sync.RWMutex
-	lockGitProtocol        sync.RWMutex
-	lockHTTPUnixSocket     sync.RWMutex
-	lockMigrate            sync.RWMutex
-	lockPager              sync.RWMutex
-	lockPreferEditorPrompt sync.RWMutex
-	lockPrompt             sync.RWMutex
-	lockSet                sync.RWMutex
-	lockVersion            sync.RWMutex
-	lockWrite              sync.RWMutex
+	lockAdvancedIssueSearch sync.RWMutex
+	lockAliases             sync.RWMutex
+	lockAuthentication      sync.RWMutex
+	lockBrowser             sync.RWMutex
+	lockCacheDir            sync.RWMutex
+	lockEditor              sync.RWMutex
+	lockGetOrDefault        sync.RWMutex
+	lockGitProtocol         sync.RWMutex
+	lockHTTPUnixSocket      sync.RWMutex
+	lockMigrate             sync.RWMutex
+	lockPager               sync.RWMutex
+	lockPreferEditorPrompt  sync.RWMutex
+	lockPrompt              sync.RWMutex
+	lockSet                 sync.RWMutex
+	lockVersion             sync.RWMutex
+	lockWrite               sync.RWMutex
+}
+
+// AdvancedIssueSearch calls AdvancedIssueSearchFunc.
+func (mock *ConfigMock) AdvancedIssueSearch(hostname string) gh.ConfigEntry {
+	if mock.AdvancedIssueSearchFunc == nil {
+		panic("ConfigMock.AdvancedIssueSearchFunc: method is nil but Config.AdvancedIssueSearch was just called")
+	}
+	callInfo := struct {
+		Hostname string
+	}{
+		Hostname: hostname,
+	}
+	mock.lockAdvancedIssueSearch.Lock()
+	mock.calls.AdvancedIssueSearch = append(mock.calls.AdvancedIssueSearch, callInfo)
+	mock.lockAdvancedIssueSearch.Unlock()
+	return mock.AdvancedIssueSearchFunc(hostname)
+}
+
+// AdvancedIssueSearchCalls gets all the calls that were made to AdvancedIssueSearch.
+// Check the length with:
+//
+//	len(mockedConfig.AdvancedIssueSearchCalls())
+func (mock *ConfigMock) AdvancedIssueSearchCalls() []struct {
+	Hostname string
+} {
+	var calls []struct {
+		Hostname string
+	}
+	mock.lockAdvancedIssueSearch.RLock()
+	calls = mock.calls.AdvancedIssueSearch
+	mock.lockAdvancedIssueSearch.RUnlock()
+	return calls
 }
 
 // Aliases calls AliasesFunc.

--- a/pkg/cmd/config/list/list_test.go
+++ b/pkg/cmd/config/list/list_test.go
@@ -88,6 +88,7 @@ func Test_listRun(t *testing.T) {
 				cfg.Set("HOST", "pager", "less")
 				cfg.Set("HOST", "http_unix_socket", "")
 				cfg.Set("HOST", "browser", "brave")
+				cfg.Set("HOST", "advanced_issue_search", "disabled")
 				return cfg
 			}(),
 			input: &ListOptions{Hostname: "HOST"},
@@ -98,6 +99,7 @@ prefer_editor_prompt=enabled
 pager=less
 http_unix_socket=
 browser=brave
+advanced_issue_search=disabled
 `,
 		},
 	}

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -65,9 +65,6 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 			if opts.Query.Limit < 1 || opts.Query.Limit > shared.SearchMaxResults {
 				return cmdutil.FlagErrorf("`--limit` must be between 1 and 1000")
 			}
-			if opts.AdvancedSearch {
-				opts.Query.AdvancedSearch = true
-			}
 			if c.Flags().Changed("author") && c.Flags().Changed("app") {
 				return cmdutil.FlagErrorf("specify only `--author` or `--app`")
 			}

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -16,9 +16,10 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 	var order, sort string
 	var appAuthor string
 	opts := &shared.IssuesOptions{
-		Browser: f.Browser,
-		Entity:  shared.Issues,
-		IO:      f.IOStreams,
+		AdvancedSearch: cmdutil.AdvancedIssueSearchEnabled(f),
+		Browser:        f.Browser,
+		Entity:         shared.Issues,
+		IO:             f.IOStreams,
 		Query: search.Query{Kind: search.KindIssues,
 			Qualifiers: search.Qualifiers{Type: "issue"}},
 	}
@@ -63,6 +64,9 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 			}
 			if opts.Query.Limit < 1 || opts.Query.Limit > shared.SearchMaxResults {
 				return cmdutil.FlagErrorf("`--limit` must be between 1 and 1000")
+			}
+			if opts.AdvancedSearch {
+				opts.Query.AdvancedSearch = true
 			}
 			if c.Flags().Changed("author") && c.Flags().Changed("app") {
 				return cmdutil.FlagErrorf("specify only `--author` or `--app`")

--- a/pkg/cmd/search/shared/shared.go
+++ b/pkg/cmd/search/shared/shared.go
@@ -60,6 +60,9 @@ func SearchIssues(opts *IssuesOptions) error {
 		}
 		return opts.Browser.Browse(url)
 	}
+	if opts.AdvancedSearch {
+		opts.Query.AdvancedSearch = true
+	}
 	io.StartProgressIndicator()
 	result, err := opts.Searcher.Issues(opts.Query)
 	io.StopProgressIndicator()

--- a/pkg/cmd/search/shared/shared.go
+++ b/pkg/cmd/search/shared/shared.go
@@ -27,14 +27,15 @@ const (
 )
 
 type IssuesOptions struct {
-	Browser  browser.Browser
-	Entity   EntityType
-	Exporter cmdutil.Exporter
-	IO       *iostreams.IOStreams
-	Now      time.Time
-	Query    search.Query
-	Searcher search.Searcher
-	WebMode  bool
+	AdvancedSearch bool
+	Browser        browser.Browser
+	Entity         EntityType
+	Exporter       cmdutil.Exporter
+	IO             *iostreams.IOStreams
+	Now            time.Time
+	Query          search.Query
+	Searcher       search.Searcher
+	WebMode        bool
 }
 
 func Searcher(f *cmdutil.Factory) (search.Searcher, error) {

--- a/pkg/cmdutil/features.go
+++ b/pkg/cmdutil/features.go
@@ -5,16 +5,23 @@ import (
 )
 
 func AdvancedIssueSearchEnabled(f *Factory) bool {
-	advancedSearch := os.Getenv("GH_ADVANCED_ISSUE_SEARCH")
-
-	if advancedSearch == "" {
-		config, err := f.Config()
-		if err != nil {
-			advancedSearch = "disabled"
-		} else {
-			advancedSearch = config.AdvancedIssueSearch("").Value
+	envVar, set := os.LookupEnv("GH_ADVANCED_ISSUE_SEARCH")
+	if set {
+		switch envVar {
+		case "", "0", "disabled", "false":
+			return false
+		default:
+			return true
 		}
 	}
 
-	return advancedSearch == "enabled"
+	var configValue string
+	config, err := f.Config()
+	if err != nil {
+		configValue = "disabled"
+	} else {
+		configValue = config.AdvancedIssueSearch("").Value
+	}
+
+	return configValue == "enabled"
 }

--- a/pkg/cmdutil/features.go
+++ b/pkg/cmdutil/features.go
@@ -1,0 +1,20 @@
+package cmdutil
+
+import (
+	"os"
+)
+
+func AdvancedIssueSearchEnabled(f *Factory) bool {
+	advancedSearch := os.Getenv("GH_ADVANCED_ISSUE_SEARCH")
+
+	if advancedSearch == "" {
+		config, err := f.Config()
+		if err != nil {
+			advancedSearch = "disabled"
+		} else {
+			advancedSearch = config.AdvancedIssueSearch("").Value
+		}
+	}
+
+	return advancedSearch == "enabled"
+}

--- a/pkg/cmdutil/features_test.go
+++ b/pkg/cmdutil/features_test.go
@@ -1,0 +1,112 @@
+package cmdutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/gh"
+	ghmock "github.com/cli/cli/v2/internal/gh/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdvancedIssueSearchEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		envVar      string
+		configValue string
+		configErr   error
+		wantEnabled bool
+	}{
+		{
+			name:        "environment variable set to enabled",
+			envVar:      "enabled",
+			wantEnabled: true,
+		},
+		{
+			name:        "environment variable set to something truthy",
+			envVar:      "yesplease",
+			wantEnabled: true,
+		},
+		{
+			name:        "environment variable set to disabled",
+			envVar:      "disabled",
+			wantEnabled: false,
+		},
+		{
+			name:        "environment variable set to false",
+			envVar:      "false",
+			wantEnabled: false,
+		},
+		{
+			name:        "environment variable set to ''",
+			envVar:      "",
+			wantEnabled: false,
+		},
+		{
+			name:        "config value enabled",
+			envVar:      "[unset]",
+			configValue: "enabled",
+			wantEnabled: true,
+		},
+		{
+			name:        "config value disabled",
+			envVar:      "[unset]",
+			configValue: "disabled",
+			wantEnabled: false,
+		},
+		// {
+		//     name:        "config value disabled",
+		//     envVar:      "",
+		//     configValue: "disabled",
+		//     wantEnabled: false,
+		// },
+		// {
+		//     name:        "config value other",
+		//     envVar:      "",
+		//     configValue: "other",
+		//     wantEnabled: false,
+		// },
+		// {
+		//     name:        "config error",
+		//     envVar:      "",
+		//     configErr:   errors.New("config error"),
+		//     wantEnabled: false,
+		// },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable for test
+			oldVal := os.Getenv("GH_ADVANCED_ISSUE_SEARCH")
+			if tt.envVar != "[unset]" {
+				t.Setenv("GH_ADVANCED_ISSUE_SEARCH", tt.envVar)
+			} else {
+				os.Unsetenv("GH_ADVANCED_ISSUE_SEARCH")
+			}
+			t.Cleanup(func() {
+				if oldVal != "" {
+					os.Setenv("GH_ADVANCED_ISSUE_SEARCH", oldVal)
+				} else {
+					os.Unsetenv("GH_ADVANCED_ISSUE_SEARCH")
+				}
+			})
+
+			mockConfig := &ghmock.ConfigMock{}
+			mockConfig.AdvancedIssueSearchFunc = func(host string) gh.ConfigEntry {
+				return gh.ConfigEntry{Value: tt.configValue}
+			}
+
+			factory := &Factory{}
+			factory.Config = func() (gh.Config, error) {
+				if tt.configErr != nil {
+					return nil, tt.configErr
+				}
+				return mockConfig, nil
+			}
+
+			result := AdvancedIssueSearchEnabled(factory)
+
+			assert.Equal(t, tt.wantEnabled, result)
+		})
+	}
+}

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -16,13 +16,14 @@ const (
 )
 
 type Query struct {
-	Keywords   []string
-	Kind       string
-	Limit      int
-	Order      string
-	Page       int
-	Qualifiers Qualifiers
-	Sort       string
+	AdvancedSearch bool
+	Keywords       []string
+	Kind           string
+	Limit          int
+	Order          string
+	Page           int
+	Qualifiers     Qualifiers
+	Sort           string
 }
 
 type Qualifiers struct {

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -88,7 +88,7 @@ type Qualifiers struct {
 
 func (q Query) String() string {
 	qualifiers := formatQualifiers(q.Qualifiers)
-	keywords := formatKeywords(q.Keywords)
+	keywords := formatKeywords(q.Keywords, q.AdvancedSearch)
 	all := append(keywords, qualifiers...)
 	return strings.TrimSpace(strings.Join(all, " "))
 }
@@ -149,10 +149,14 @@ func formatQualifiers(qs Qualifiers) []string {
 	return all
 }
 
-func formatKeywords(ks []string) []string {
+func formatKeywords(ks []string, advancedSearch bool) []string {
 	for i, k := range ks {
 		before, after, found := strings.Cut(k, ":")
-		if !found {
+		// Usage for advanced search is:
+		//    gh search issues -- "assignee:@me state:open"
+		//
+		// Rather than quoting each keyword, pass the query as provided
+		if advancedSearch || !found {
 			ks[i] = quote(k)
 		} else {
 			ks[i] = fmt.Sprintf("%s:%s", before, quote(after))

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -157,6 +157,9 @@ func (s searcher) Issues(query Query) (IssuesResult, error) {
 func (s searcher) search(query Query, result interface{}) (*http.Response, error) {
 	path := fmt.Sprintf("%ssearch/%s", ghinstance.RESTPrefix(s.host), query.Kind)
 	qs := url.Values{}
+	if query.AdvancedSearch {
+		qs.Set("advanced_search", "true")
+	}
 	qs.Set("page", strconv.Itoa(query.Page))
 	qs.Set("per_page", strconv.Itoa(query.Limit))
 	qs.Set("q", query.String())


### PR DESCRIPTION
Re https://github.com/cli/cli/issues/10577.

Add Advanced Search support for the `gh search issues` command.

To use advanced search syntax, set the `GH_ADVANCED_ISSUE_SEARCH` environment variable to `enabled`. Alternately, you may set the `advanced_issue_search` config option to `enabled`.

Usage:

```
> GH_ADVANCED_ISSUE_SEARCH=enabled gh search issues -- "assignee:@me state:open"
```

---

TODO:
* [ ] Fix failing test (`github.com/cli/cli/v2/pkg/cmd/search/issues`)