### PR TITLE
Prompt for username in `sponsors list` command

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -33,6 +33,7 @@ import (
 	runCmd "github.com/cli/cli/v2/pkg/cmd/run"
 	searchCmd "github.com/cli/cli/v2/pkg/cmd/search"
 	secretCmd "github.com/cli/cli/v2/pkg/cmd/secret"
+	sponsorsCmd "github.com/cli/cli/v2/pkg/cmd/sponsors"
 	sshKeyCmd "github.com/cli/cli/v2/pkg/cmd/ssh-key"
 	statusCmd "github.com/cli/cli/v2/pkg/cmd/status"
 	variableCmd "github.com/cli/cli/v2/pkg/cmd/variable"
@@ -134,6 +135,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 	cmd.AddCommand(extensionCmd.NewCmdExtension(f))
 	cmd.AddCommand(searchCmd.NewCmdSearch(f))
 	cmd.AddCommand(secretCmd.NewCmdSecret(f))
+	cmd.AddCommand(sponsorsCmd.NewCmdSponsors(f))
 	cmd.AddCommand(variableCmd.NewCmdVariable(f))
 	cmd.AddCommand(sshKeyCmd.NewCmdSSHKey(f))
 	cmd.AddCommand(statusCmd.NewCmdStatus(f, nil))

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -78,10 +78,7 @@ func listRun(opts *ListOptions) error {
 	}
 
 	if len(sponsors) == 0 {
-		if opts.IO.IsStdoutTTY() {
-			fmt.Fprintln(opts.IO.Out, "no sponsor found")
-		}
-		return nil
+		return cmdutil.NewNoResultsError("no sponsor found")
 	}
 
 	headers := []string{"Sponsor"}

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/shurcooL/graphql"
+	"github.com/shurcooL/githubv4"
 	"github.com/spf13/cobra"
 
 	"github.com/cli/cli/v2/api"
@@ -106,10 +106,10 @@ func listSponsors(httpClient *http.Client, hostname string, username string, lim
 				Edges []struct {
 					Node struct {
 						User struct {
-							Login graphql.String
+							Login githubv4.String
 						} `graphql:"... on User"`
 						Org struct {
-							Login graphql.String
+							Login githubv4.String
 						} `graphql:"... on Organization"`
 					}
 				}
@@ -120,8 +120,8 @@ func listSponsors(httpClient *http.Client, hostname string, username string, lim
 	client := api.NewClientFromHTTP(httpClient)
 
 	variables := map[string]any{
-		"login": graphql.String(username),
-		"limit": graphql.Int(limit),
+		"login": githubv4.String(username),
+		"limit": githubv4.Int(limit),
 	}
 
 	err := client.Query(hostname, "UserSponsorList", &query, variables)

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -78,8 +78,7 @@ func listRun(opts *ListOptions) error {
 	}
 
 	if len(sponsors) == 0 {
-		fmt.Fprintf(opts.IO.ErrOut, "no sponsor found\n")
-		return nil
+		return cmdutil.NewNoResultsError("no sponsor found")
 	}
 
 	headers := []string{"Sponsor"}

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/shurcooL/graphql"
+	"github.com/spf13/cobra"
+
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/spf13/cobra"
 )
 
 const defaultListLimit = 30
@@ -96,51 +98,42 @@ func listRun(opts *ListOptions) error {
 }
 
 func listSponsors(httpClient *http.Client, hostname string, username string, limit uint) ([]string, error) {
-	type response struct {
+	var query struct {
 		User struct {
 			Sponsors struct {
 				Edges []struct {
 					Node struct {
-						Login string
+						User struct {
+							Login graphql.String
+						} `graphql:"... on User"`
+						Org struct {
+							Login graphql.String
+						} `graphql:"... on Organization"`
 					}
 				}
-			}
-		}
+			} `graphql:"sponsors(first: $limit, orderBy: { direction: ASC, field: LOGIN })"`
+		} `graphql:"user(login: $login)"`
 	}
-
-	query := `query UserSponsorList($login: String!, $limit: Int!) {
-		user(login: $login) {
-			sponsors(first: $limit, orderBy: { direction: ASC, field: LOGIN } ) {
-				edges {
-					node {
-						... on User {
-							login
-						}
-						... on Organization {
-							login
-						}
-					}
-				}
-			}
-		}
-	}`
 
 	client := api.NewClientFromHTTP(httpClient)
 
 	variables := map[string]any{
-		"login": username,
-		"limit": limit,
+		"login": graphql.String(username),
+		"limit": graphql.Int(limit),
 	}
 
-	var data response
-	err := client.GraphQL(hostname, query, variables, &data)
+	err := client.Query(hostname, "UserSponsorList", &query, variables)
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]string, 0, len(data.User.Sponsors.Edges))
-	for _, edge := range data.User.Sponsors.Edges {
-		result = append(result, edge.Node.Login)
+	result := make([]string, 0, len(query.User.Sponsors.Edges))
+	for _, edge := range query.User.Sponsors.Edges {
+		if edge.Node.User.Login != "" {
+			result = append(result, string(edge.Node.User.Login))
+		} else if edge.Node.Org.Login != "" {
+			result = append(result, string(edge.Node.Org.Login))
+		}
 	}
 	return result, nil
 }

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -10,6 +11,7 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -21,6 +23,7 @@ type ListOptions struct {
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
 	Config     func() (gh.Config, error)
+	Prompter   prompter.Prompter
 
 	Username string
 }
@@ -30,20 +33,20 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		IO:         f.IOStreams,
 		Config:     f.Config,
 		HttpClient: f.HttpClient,
+		Prompter:   f.Prompter,
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list <user>",
+		Use:   "list [<user>]",
 		Short: "List sponsors",
 		Long: heredoc.Doc(`
 			List sponsors of a given user.
 		`),
 		Aliases: []string{"ls"},
-		Args:    cmdutil.ExactArgs(1, "must specify username"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// This is for consistency with the other commands, but the check seems
-			// irrelevant since we have already used the cobra.ExactArgs.
-			if len(args) > 0 {
+			if len(args) > 1 {
+				return cmdutil.FlagErrorf("too many arguments")
+			} else if len(args) == 1 {
 				opts.Username = args[0]
 			}
 
@@ -70,6 +73,17 @@ func listRun(opts *ListOptions) error {
 	}
 
 	username := opts.Username
+
+	if username == "" {
+		if !opts.IO.CanPrompt() {
+			return errors.New("username not provided")
+		}
+		value, err := opts.Prompter.Input("Which user do you want to target?", "")
+		if err != nil {
+			return err
+		}
+		username = value
+	}
 
 	hostname, _ := cfg.Authentication().DefaultHost()
 	sponsors, err := listSponsors(client, hostname, username, defaultListLimit)

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -78,7 +78,8 @@ func listRun(opts *ListOptions) error {
 	}
 
 	if len(sponsors) == 0 {
-		return cmdutil.NewNoResultsError("no sponsor found")
+		fmt.Fprintln(opts.IO.Out, "no sponsor found")
+		return nil
 	}
 
 	headers := []string{"Sponsor"}

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -78,7 +78,9 @@ func listRun(opts *ListOptions) error {
 	}
 
 	if len(sponsors) == 0 {
-		fmt.Fprintln(opts.IO.Out, "no sponsor found")
+		if opts.IO.IsStdoutTTY() {
+			fmt.Fprintln(opts.IO.Out, "no sponsor found")
+		}
 		return nil
 	}
 

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -1,0 +1,146 @@
+package list
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/tableprinter"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+const defaultListLimit = 30
+
+type ListOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	Config     func() (gh.Config, error)
+
+	Username string
+}
+
+func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
+	opts := &ListOptions{
+		IO:         f.IOStreams,
+		Config:     f.Config,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list <user>",
+		Short: "List sponsors",
+		Long: heredoc.Doc(`
+			List sponsors of a given user.
+		`),
+		Aliases: []string{"ls"},
+		Args:    cmdutil.ExactArgs(1, "must specify username"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// This is for consistency with the other commands, but the check seems
+			// irrelevant since we have already used the cobra.ExactArgs.
+			if len(args) > 0 {
+				opts.Username = args[0]
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return listRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+func listRun(opts *ListOptions) error {
+	client, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not create http client: %w", err)
+	}
+
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	username := opts.Username
+
+	hostname, _ := cfg.Authentication().DefaultHost()
+	sponsors, err := listSponsors(client, hostname, username, defaultListLimit)
+	if err != nil {
+		return err
+	}
+
+	if len(sponsors) == 0 {
+		fmt.Fprintf(opts.IO.ErrOut, "no sponsor found\n")
+		return nil
+	}
+
+	headers := []string{"Sponsor"}
+	table := tableprinter.New(opts.IO, tableprinter.WithHeader(headers...))
+	for _, sponsor := range sponsors {
+		table.AddField(sponsor)
+		table.EndRow()
+	}
+
+	err = table.Render()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func listSponsors(httpClient *http.Client, hostname string, username string, limit uint) ([]string, error) {
+	type response struct {
+		User struct {
+			Sponsors struct {
+				Edges []struct {
+					Node struct {
+						Login string
+					}
+				}
+			}
+		}
+	}
+
+	query := `query UserSponsorList($login: String!, $limit: Int!) {
+		user(login: $login) {
+			sponsors(first: $limit, orderBy: { direction: ASC, field: LOGIN } ) {
+				edges {
+					node {
+						... on User {
+							login
+						}
+						... on Organization {
+							login
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	client := api.NewClientFromHTTP(httpClient)
+
+	variables := map[string]any{
+		"login": username,
+		"limit": limit,
+	}
+
+	var data response
+	err := client.GraphQL(hostname, query, variables, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]string, 0, len(data.User.Sponsors.Edges))
+	for _, edge := range data.User.Sponsors.Edges {
+		result = append(result, edge.Node.Login)
+	}
+	return result, nil
+}

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -192,7 +192,7 @@ func Test_listRun(t *testing.T) {
 				require.EqualError(t, err, tt.wantErr)
 				return
 			}
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			expectedStdout := ""
 			if len(tt.wantStdout) > 0 {

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -1,0 +1,205 @@
+package list
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdList(t *testing.T) {
+	tests := []struct {
+		name    string
+		cli     string
+		wants   ListOptions
+		wantErr string
+	}{
+		{
+			name:    "no arg",
+			cli:     "",
+			wantErr: "must specify username",
+		},
+		{
+			name: "normal",
+			cli:  "johndoe",
+			wants: ListOptions{
+				Username: "johndoe",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			assert.NoError(t, err)
+
+			var listOpts *ListOptions
+			cmd := NewCmdList(f, func(opts *ListOptions) error {
+				listOpts = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+			if tt.wantErr != "" {
+				require.Equal(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			require.Equal(t, tt.wants.Username, listOpts.Username)
+		})
+	}
+}
+
+func Test_listRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		tty        bool
+		opts       *ListOptions
+		httpStubs  func(*httpmock.Registry)
+		wantStdout []string
+		wantStderr string
+		wantErr    string
+	}{
+		{
+			name: "normal tty",
+			tty:  true,
+			opts: &ListOptions{
+				Username: "johndoe",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserSponsorList\b`),
+					httpmock.GraphQLQuery(`
+						{
+							"data": {
+								"user": {
+									"sponsors": {
+										"edges": [
+											{
+												"node": {
+													"login": "foo"
+												}
+											},
+											{
+												"node": {
+													"login": "bar"
+												}
+											}
+										]
+									}
+								}
+							}
+						}`,
+						func(_ string, inputs map[string]interface{}) {
+							assert.Equal(t, "johndoe", inputs["login"])
+							assert.Equal(t, float64(30), inputs["limit"])
+						},
+					),
+				)
+			},
+			wantStdout: []string{
+				"SPONSOR",
+				"foo",
+				"bar",
+			},
+		}, {
+			name: "normal tty, no sponsor",
+			tty:  true,
+			opts: &ListOptions{
+				Username: "johndoe",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserSponsorList\b`),
+					httpmock.GraphQLQuery(`
+						{
+							"data": {
+								"user": {
+									"sponsors": {
+										"edges": []
+									}
+								}
+							}
+						}`,
+						func(_ string, inputs map[string]interface{}) {
+							assert.Equal(t, "johndoe", inputs["login"])
+							assert.Equal(t, float64(30), inputs["limit"])
+						},
+					),
+				)
+			},
+			wantStderr: "no sponsor found\n",
+		}, {
+			name: "api error",
+			tty:  true,
+			opts: &ListOptions{
+				Username: "johndoe",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserSponsorList\b`),
+					httpmock.GraphQLQuery(
+						`{"data":{}, "errors": [{"message": "some gql error"}]}`,
+						func(query string, inputs map[string]interface{}) {},
+					),
+				)
+			},
+			wantErr: "GraphQL: some gql error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			ios, _, stdout, stderr := iostreams.Test()
+
+			ios.SetStdoutTTY(tt.tty)
+
+			tt.opts.IO = ios
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.Config = func() (gh.Config, error) {
+				return config.NewBlankConfig(), nil
+			}
+
+			tt.httpStubs(reg)
+
+			err := listRun(tt.opts)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.Nil(t, err)
+
+			expectedStdout := ""
+			if len(tt.wantStdout) > 0 {
+				expectedStdout = fmt.Sprintf("%s\n", strings.Join(tt.wantStdout, "\n"))
+			}
+			assert.Equal(t, expectedStdout, stdout.String())
+			assert.Equal(t, tt.wantStderr, stderr.String())
+		})
+	}
+}

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -25,9 +27,11 @@ func TestNewCmdList(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "no arg",
-			cli:     "",
-			wantErr: "must specify username",
+			name: "no arg",
+			cli:  "",
+			wants: ListOptions{
+				Username: "",
+			},
 		},
 		{
 			name: "normal",
@@ -72,12 +76,13 @@ func TestNewCmdList(t *testing.T) {
 
 func Test_listRun(t *testing.T) {
 	tests := []struct {
-		name       string
-		tty        bool
-		opts       *ListOptions
-		httpStubs  func(*testing.T, *httpmock.Registry)
-		wantStdout []string
-		wantErr    string
+		name          string
+		tty           bool
+		opts          *ListOptions
+		httpStubs     func(*testing.T, *httpmock.Registry)
+		prompterStubs func(*testing.T, *prompter.PrompterMock)
+		wantStdout    []string
+		wantErr       string
 	}{
 		{
 			name: "normal tty",
@@ -115,6 +120,53 @@ func Test_listRun(t *testing.T) {
 						},
 					),
 				)
+			},
+			wantStdout: []string{
+				"SPONSOR",
+				"foo",
+				"bar",
+			},
+		}, {
+			name: "normal tty, no-username",
+			tty:  true,
+			opts: &ListOptions{},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserSponsorList\b`),
+					httpmock.GraphQLQuery(`
+						{
+							"data": {
+								"user": {
+									"sponsors": {
+										"edges": [
+											{
+												"node": {
+													"login": "foo"
+												}
+											},
+											{
+												"node": {
+													"login": "bar"
+												}
+											}
+										]
+									}
+								}
+							}
+						}`,
+						func(_ string, inputs map[string]interface{}) {
+							assert.Equal(t, "johndoe", inputs["login"])
+							assert.Equal(t, float64(30), inputs["limit"])
+						},
+					),
+				)
+			},
+			prompterStubs: func(t *testing.T, pm *prompter.PrompterMock) {
+				pm.InputFunc = func(message, def string) (string, error) {
+					assert.Equal(t, "Which user do you want to target?", message)
+					assert.Empty(t, def)
+					return "johndoe", nil
+				}
 			},
 			wantStdout: []string{
 				"SPONSOR",
@@ -162,6 +214,21 @@ func Test_listRun(t *testing.T) {
 				"foo",
 				"bar",
 			},
+		}, {
+			name: "failure tty, prompt error",
+			tty:  true,
+			opts: &ListOptions{},
+			prompterStubs: func(t *testing.T, pm *prompter.PrompterMock) {
+				pm.InputFunc = func(message, def string) (string, error) {
+					return "", errors.New("prompt error")
+				}
+			},
+			wantErr: "prompt error",
+		}, {
+			name:    "failure no-tty, no-username",
+			tty:     false,
+			opts:    &ListOptions{},
+			wantErr: "username not provided",
 		}, {
 			name: "normal tty, no sponsor",
 			tty:  true,
@@ -240,8 +307,15 @@ func Test_listRun(t *testing.T) {
 			reg := &httpmock.Registry{}
 			defer reg.Verify(t)
 
+			pm := &prompter.PrompterMock{}
+			if tt.prompterStubs != nil {
+				tt.prompterStubs(t, pm)
+			}
+			tt.opts.Prompter = pm
+
 			ios, _, stdout, _ := iostreams.Test()
 
+			ios.SetStdinTTY(tt.tty)
 			ios.SetStdoutTTY(tt.tty)
 
 			tt.opts.IO = ios
@@ -252,7 +326,9 @@ func Test_listRun(t *testing.T) {
 				return config.NewBlankConfig(), nil
 			}
 
-			tt.httpStubs(t, reg)
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, reg)
+			}
 
 			err := listRun(tt.opts)
 			if tt.wantErr != "" {

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -123,6 +123,47 @@ func Test_listRun(t *testing.T) {
 				"bar",
 			},
 		}, {
+			name: "normal no-tty",
+			tty:  false,
+			opts: &ListOptions{
+				Username: "johndoe",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserSponsorList\b`),
+					httpmock.GraphQLQuery(`
+						{
+							"data": {
+								"user": {
+									"sponsors": {
+										"edges": [
+											{
+												"node": {
+													"login": "foo"
+												}
+											},
+											{
+												"node": {
+													"login": "bar"
+												}
+											}
+										]
+									}
+								}
+							}
+						}`,
+						func(_ string, inputs map[string]interface{}) {
+							assert.Equal(t, "johndoe", inputs["login"])
+							assert.Equal(t, float64(30), inputs["limit"])
+						},
+					),
+				)
+			},
+			wantStdout: []string{
+				"foo",
+				"bar",
+			},
+		}, {
 			name: "normal tty, no sponsor",
 			tty:  true,
 			opts: &ListOptions{
@@ -149,6 +190,32 @@ func Test_listRun(t *testing.T) {
 				)
 			},
 			wantStdout: []string{"no sponsor found"},
+		}, {
+			name: "normal no-tty, no sponsor",
+			tty:  false,
+			opts: &ListOptions{
+				Username: "johndoe",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserSponsorList\b`),
+					httpmock.GraphQLQuery(`
+						{
+							"data": {
+								"user": {
+									"sponsors": {
+										"edges": []
+									}
+								}
+							}
+						}`,
+						func(_ string, inputs map[string]interface{}) {
+							assert.Equal(t, "johndoe", inputs["login"])
+							assert.Equal(t, float64(30), inputs["limit"])
+						},
+					),
+				)
+			},
 		}, {
 			name: "api error",
 			tty:  true,

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -148,7 +148,7 @@ func Test_listRun(t *testing.T) {
 					),
 				)
 			},
-			wantStderr: "no sponsor found\n",
+			wantStdout: []string{"no sponsor found"},
 		}, {
 			name: "api error",
 			tty:  true,

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -77,7 +77,6 @@ func Test_listRun(t *testing.T) {
 		opts       *ListOptions
 		httpStubs  func(*httpmock.Registry)
 		wantStdout []string
-		wantStderr string
 		wantErr    string
 	}{
 		{
@@ -240,7 +239,7 @@ func Test_listRun(t *testing.T) {
 			reg := &httpmock.Registry{}
 			defer reg.Verify(t)
 
-			ios, _, stdout, stderr := iostreams.Test()
+			ios, _, stdout, _ := iostreams.Test()
 
 			ios.SetStdoutTTY(tt.tty)
 
@@ -266,7 +265,6 @@ func Test_listRun(t *testing.T) {
 				expectedStdout = fmt.Sprintf("%s\n", strings.Join(tt.wantStdout, "\n"))
 			}
 			assert.Equal(t, expectedStdout, stdout.String())
-			assert.Equal(t, tt.wantStderr, stderr.String())
 		})
 	}
 }

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -75,7 +75,7 @@ func Test_listRun(t *testing.T) {
 		name       string
 		tty        bool
 		opts       *ListOptions
-		httpStubs  func(*httpmock.Registry)
+		httpStubs  func(*testing.T, *httpmock.Registry)
 		wantStdout []string
 		wantErr    string
 	}{
@@ -85,7 +85,7 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query UserSponsorList\b`),
 					httpmock.GraphQLQuery(`
@@ -127,7 +127,7 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query UserSponsorList\b`),
 					httpmock.GraphQLQuery(`
@@ -168,7 +168,7 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query UserSponsorList\b`),
 					httpmock.GraphQLQuery(`
@@ -195,7 +195,7 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query UserSponsorList\b`),
 					httpmock.GraphQLQuery(`
@@ -222,7 +222,7 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(_ *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query UserSponsorList\b`),
 					httpmock.GraphQLQuery(
@@ -252,7 +252,7 @@ func Test_listRun(t *testing.T) {
 				return config.NewBlankConfig(), nil
 			}
 
-			tt.httpStubs(reg)
+			tt.httpStubs(t, reg)
 
 			err := listRun(tt.opts)
 			if tt.wantErr != "" {

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -188,7 +188,7 @@ func Test_listRun(t *testing.T) {
 					),
 				)
 			},
-			wantStdout: []string{"no sponsor found"},
+			wantErr: "no sponsor found",
 		}, {
 			name: "normal no-tty, no sponsor",
 			tty:  false,
@@ -215,6 +215,7 @@ func Test_listRun(t *testing.T) {
 					),
 				)
 			},
+			wantErr: "no sponsor found",
 		}, {
 			name: "api error",
 			tty:  true,

--- a/pkg/cmd/sponsors/sponsors.go
+++ b/pkg/cmd/sponsors/sponsors.go
@@ -1,0 +1,18 @@
+package sponsorsß
+
+import (
+	cmdList "github.com/cli/cli/v2/pkg/cmd/sponsors/list"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdSponsors(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sponsors <command>",
+		Short: "Manage sponsors",
+	}
+
+	cmd.AddCommand(cmdList.NewCmdList(f, nil))
+
+	return cmd
+}

--- a/pkg/cmd/sponsors/sponsors.go
+++ b/pkg/cmd/sponsors/sponsors.go
@@ -1,4 +1,4 @@
-package sponsorsß
+package sponsors
 
 import (
 	cmdList "github.com/cli/cli/v2/pkg/cmd/sponsors/list"


### PR DESCRIPTION
This PR improves the `sponsors list` command by prompting for the username, if it was not provided. If it's a non-TTY stream, then an error will be returned.

## Acceptance criteria

### 1. Prompt for username (TTY)

**Given** I have the name of a Sponsorable user that has less than 30 sponsors
**When** I run gh sponsors list
**Then** I am prompted for a user e.g

```sh
➜  gh sponsors list
? Which user do you want to target? ...
```

**And** When I enter the name of the sponsorable user and press enter
**Then** I see a list of usernames in a single column table with a header

Implementation result:

```sh
$ gh sponsors list
? Which user do you want to target? onsi
SPONSOR      
austince
authzed
belden
erdnas
ibrasho
mercedes-benz
mrkmcknz
ppeble
srevinsaju
williammartin
```

### 2. Fail if username is not provided (non-TTY)

**When** I run GH_PROMPT_DISABLED=true gh sponsors list
**Then** I receive an error that no user was provided

Implementation result:

```sh
% GH_PROMPT_DISABLED=true gh sponsors list
username not provided
exit status 1
```

