### PR TITLE
Implement safeguard for `gh alias delete` test, prevent wiping out GitHub CLI configuration

### DIFF
--- a/pkg/cmd/alias/delete/delete_test.go
+++ b/pkg/cmd/alias/delete/delete_test.go
@@ -162,6 +162,9 @@ func TestDeleteRun(t *testing.T) {
 			tt.opts.IO = ios
 
 			cfg := config.NewFromString(tt.config)
+			cfg.WriteFunc = func() error {
+				return nil
+			}
 			tt.opts.Config = func() (gh.Config, error) {
 				return cfg, nil
 			}


### PR DESCRIPTION
Fixes #10590

Implement missing safeguard causing `gh alias delete` tests to wipe out tester's GitHub CLI configuration.

1. Confirm current GitHub CLI configuration

   ```shell
   cat ~/.config/gh/config.yml                
   ```
   
   resulting in:
   
   ```
   aliases: {unreleased: '!gh pr list --base trunk --limit 200 --search "merged:>$(gh release view --json createdAt --jq .createdAt)"', slackd: slack read -d}
   version: "1"
   prefer_editor_prompt: disabled
   advanced_issue_search: enabled
   ```

1. Clear cached GitHub CLI test runs

   ```shell
   go clean -testcache        
   ```

1. Successfully run `gh alias delete` tests

   ```shell
   go test -run "^TestDeleteRun$" github.com/cli/cli/v2/pkg/cmd/alias/delete
   ```

   resulting in:

   ```
   ok  	github.com/cli/cli/v2/pkg/cmd/alias/delete	0.215s
   ```


1. Confirm GitHub CLI configuration is unchanged

   ```shell
   cat ~/.config/gh/config.yml                                              
   ```

   resulting in:

   ```
   aliases: {unreleased: '!gh pr list --base trunk --limit 200 --search "merged:>$(gh release view --json createdAt --jq .createdAt)"', slackd: slack read -d}
   version: "1"
   prefer_editor_prompt: disabled
   advanced_issue_search: enabled
   ```
