### PR TITLE
[gh config][website manual] Escape pipe symbols in long description

### DIFF
--- a/internal/docs/markdown.go
+++ b/internal/docs/markdown.go
@@ -142,8 +142,16 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 		fmt.Fprintf(w, "```\n%s\n```\n\n", cmd.UseLine())
 	}
 	if hasLong {
-		longWithEscapedPipe := strings.ReplaceAll(cmd.Long, "|", "&#124;")
-		fmt.Fprintf(w, "%s\n\n", longWithEscapedPipe)
+		// For `gh config` command, escape pipe symbols in long description to prevent table formatting
+		// For more details, see https://github.com/cli/cli/issues/10348.
+		// This is a workaround until it's fixed in the kramdown.
+		// Related jekyll issue: https://github.com/jekyll/jekyll/issues/2818
+		if cmd.Use == "config <command>" {
+			longWithEscapedPipe := strings.ReplaceAll(cmd.Long, "|", "&#124;")
+			fmt.Fprintf(w, "%s\n\n", longWithEscapedPipe)
+		} else {
+			fmt.Fprintf(w, "%s\n\n", cmd.Long)
+		}
 	}
 
 	for _, g := range root.GroupedCommands(cmd) {


### PR DESCRIPTION
Fixes #10678.

This PR is an improvement on #10371.
This escapes the pipe symbols for the `gh config` command only.
The existing solution escapes pipe symbols for all the commands which has side effects in addition to what has been reported in #10678.


This is an issue with `kramdown` and others have been facing it too.
Here in this [SO thread](https://stackoverflow.com/questions/23751917/how-do-you-disable-tables-in-kramdown), replacing the kramdown parser has been suggested in this [answer](https://stackoverflow.com/a/45191564/7670262).
Not sure how much control `jekyll` provides and whether it's doable or not.
It would be good to look into to avoid such workarounds in the future given that some other parser works fine.