### PR TITLE
Add instructions for MidnightBSD installation

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -165,7 +165,7 @@ pkg install gh
 
 ### MidnightBSD
 
-MidnightBSD users can install from mports
+MidnightBSD users can install from [mports](https://www.midnightbsd.org/documentation/mports/index.html)
 
 ```bash
 cd /usr/mports/devel/gh/ && make install clean

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -163,6 +163,20 @@ Or via [pkg(8)](https://www.freebsd.org/cgi/man.cgi?pkg(8)):
 pkg install gh
 ```
 
+### MidnightBSD
+
+MidnightBSD users can install from mports
+
+```bash
+cd /usr/mports/devel/gh/ && make install clean
+```
+
+Or via [mport(1)](http://man.midnightbsd.org/cgi-bin/man.cgi/mport):
+
+```bash
+mport install gh
+```
+
 ### NetBSD/pkgsrc
 
 NetBSD users and those on [platforms supported by pkgsrc](https://pkgsrc.org/#index4h1) can install the [gh package](https://pkgsrc.se/net/gh):


### PR DESCRIPTION
The gh cli tool was recently added to the MidnightBSD mports collection.  

https://github.com/MidnightBSD/mports/commit/7869f70cefe39d018805d6cd4ef08f611e6efbf1
