### PR TITLE
Add support for custom SSH and SCP commands via environment variables

### DIFF
--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/cli/safeexec"
+	"github.com/google/shlex"
 )
 
 type printer interface {
@@ -77,9 +78,14 @@ func newSSHCommand(ctx context.Context, port int, dst string, cmdArgs []string, 
 		cmdArgs = append(cmdArgs, command...)
 	}
 
-	exe, err := safeexec.LookPath("ssh")
+	exe, args, err := getSSHCommand()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to execute ssh: %w", err)
+	}
+
+	// If we have custom args from the environment variable, insert them at the beginning
+	if len(args) > 0 {
+		cmdArgs = append(args, cmdArgs...)
 	}
 
 	cmd := exec.CommandContext(ctx, exe, cmdArgs...)
@@ -127,9 +133,14 @@ func newSCPCommand(ctx context.Context, port int, dst string, cmdArgs []string) 
 		cmdArgs = append(cmdArgs, arg)
 	}
 
-	exe, err := safeexec.LookPath("scp")
+	exe, args, err := getSCPCommand()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute scp: %w", err)
+	}
+
+	// If we have custom args from the environment variable, insert them at the beginning
+	if len(args) > 0 {
+		cmdArgs = append(args, cmdArgs...)
 	}
 
 	// Beware: invalid syntax causes scp to exit 1 with
@@ -171,4 +182,53 @@ func parseArgs(args []string, unaryFlags string) (cmdArgs, command []string, err
 	}
 
 	return cmdArgs, command, nil
+}
+
+// getCommandFromEnv returns the path to a command and any additional arguments based on an environment variable.
+// If the environment variable is set, its value is parsed to extract both the command path and any additional arguments.
+// Otherwise, it looks for the default command in the PATH.
+func getCommandFromEnv(envVar, defaultCmd string) (string, []string, error) {
+	if cmdLine := os.Getenv(envVar); cmdLine != "" {
+		// Parse the command line respecting quotes using shlex
+		args, err := shlex.Split(cmdLine)
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid %s: %w", envVar, err)
+		}
+		if len(args) == 0 {
+			return "", nil, fmt.Errorf("empty %s", envVar)
+		}
+
+		// If the command is a path, use it directly
+		// Otherwise, use safeexec.LookPath to find the executable
+		cmd := args[0]
+		if !strings.Contains(cmd, "/") {
+			cmd, err = safeexec.LookPath(cmd)
+			if err != nil {
+				return "", nil, fmt.Errorf("failed to find command '%s' specified in %s: %w", args[0], envVar, err)
+			}
+		}
+
+		return cmd, args[1:], nil
+	}
+
+	cmd, err := safeexec.LookPath(defaultCmd)
+	return cmd, nil, err
+}
+
+// getSSHCommand returns the path to the SSH command to use and any additional arguments.
+// If the GH_CS_SSH_COMMAND environment variable is set, its value is parsed to extract
+// both the command path and any additional arguments.
+// Otherwise, it looks for the "ssh" command in the PATH.
+// Similar to GIT_SSH_COMMAND, this supports specifying both the command path and additional arguments.
+func getSSHCommand() (string, []string, error) {
+	return getCommandFromEnv("GH_CS_SSH_COMMAND", "ssh")
+}
+
+// getSCPCommand returns the path to the SCP command to use and any additional arguments.
+// If the GH_CS_SCP_COMMAND environment variable is set, its value is parsed to extract
+// both the command path and any additional arguments.
+// Otherwise, it looks for the "scp" command in the PATH.
+// Similar to GIT_SSH_COMMAND, this supports specifying both the command path and additional arguments.
+func getSCPCommand() (string, []string, error) {
+	return getCommandFromEnv("GH_CS_SCP_COMMAND", "scp")
 }

--- a/internal/codespaces/ssh_env_test.go
+++ b/internal/codespaces/ssh_env_test.go
@@ -1,0 +1,362 @@
+package codespaces
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestGetSSHCommand(t *testing.T) {
+	// Save original env var to restore later
+	originalValue := os.Getenv("GH_CS_SSH_COMMAND")
+	defer os.Setenv("GH_CS_SSH_COMMAND", originalValue)
+
+	tests := []struct {
+		name           string
+		envValue       string
+		expectedCmd    string
+		expectedArgs   []string
+		expectedErrMsg string
+	}{
+		{
+			name:         "no env var set",
+			envValue:     "",
+			expectedCmd:  "ssh", // This assumes ssh is in PATH
+			expectedArgs: nil,
+		},
+		{
+			name:         "simple command",
+			envValue:     "/custom/path/to/ssh",
+			expectedCmd:  "/custom/path/to/ssh",
+			expectedArgs: []string{},
+		},
+		{
+			name:         "command with args",
+			envValue:     "/custom/path/to/ssh -o IdentityFile=/path/to/key",
+			expectedCmd:  "/custom/path/to/ssh",
+			expectedArgs: []string{"-o", "IdentityFile=/path/to/key"},
+		},
+		{
+			name:         "command with quoted args",
+			envValue:     "\"/path/with space/ssh\" -o \"Option=Value With Space\"",
+			expectedCmd:  "/path/with space/ssh",
+			expectedArgs: []string{"-o", "Option=Value With Space"},
+		},
+		{
+			name:         "command with single quotes",
+			envValue:     "'/path/with space/ssh' -o 'Option=Value With Space'",
+			expectedCmd:  "/path/with space/ssh",
+			expectedArgs: []string{"-o", "Option=Value With Space"},
+		},
+		{
+			name:           "empty command after parsing",
+			envValue:       "   ",
+			expectedErrMsg: "empty GH_CS_SSH_COMMAND",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the environment variable
+			os.Setenv("GH_CS_SSH_COMMAND", tt.envValue)
+
+			// Call the function
+			cmd, args, err := getSSHCommand()
+
+			// Check error
+			if tt.expectedErrMsg != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.expectedErrMsg)
+				}
+				if err.Error() != tt.expectedErrMsg {
+					t.Fatalf("expected error %q, got %q", tt.expectedErrMsg, err.Error())
+				}
+				return
+			}
+
+			// Check no error
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// For the "no env var" case, we just check that we got a non-empty command
+			if tt.envValue == "" {
+				if cmd == "" {
+					t.Fatal("expected non-empty command")
+				}
+				return
+			}
+
+			// Check command
+			if cmd != tt.expectedCmd {
+				t.Errorf("expected command %q, got %q", tt.expectedCmd, cmd)
+			}
+
+			// Check args
+			if !reflect.DeepEqual(args, tt.expectedArgs) {
+				t.Errorf("expected args %v, got %v", tt.expectedArgs, args)
+			}
+		})
+	}
+}
+
+func TestGetSCPCommand(t *testing.T) {
+	// Save original env var to restore later
+	originalValue := os.Getenv("GH_CS_SCP_COMMAND")
+	defer os.Setenv("GH_CS_SCP_COMMAND", originalValue)
+
+	tests := []struct {
+		name           string
+		envValue       string
+		expectedCmd    string
+		expectedArgs   []string
+		expectedErrMsg string
+	}{
+		{
+			name:         "no env var set",
+			envValue:     "",
+			expectedCmd:  "scp", // This assumes scp is in PATH
+			expectedArgs: nil,
+		},
+		{
+			name:         "simple command",
+			envValue:     "/custom/path/to/scp",
+			expectedCmd:  "/custom/path/to/scp",
+			expectedArgs: []string{},
+		},
+		{
+			name:         "command with args",
+			envValue:     "/custom/path/to/scp -F /path/to/config",
+			expectedCmd:  "/custom/path/to/scp",
+			expectedArgs: []string{"-F", "/path/to/config"},
+		},
+		{
+			name:         "command with quoted args",
+			envValue:     "\"/path/with space/scp\" -F \"/path/to/config with spaces\"",
+			expectedCmd:  "/path/with space/scp",
+			expectedArgs: []string{"-F", "/path/to/config with spaces"},
+		},
+		{
+			name:         "command with single quotes",
+			envValue:     "'/path/with space/scp' -F '/path/to/config with spaces'",
+			expectedCmd:  "/path/with space/scp",
+			expectedArgs: []string{"-F", "/path/to/config with spaces"},
+		},
+		{
+			name:           "empty command after parsing",
+			envValue:       "   ",
+			expectedErrMsg: "empty GH_CS_SCP_COMMAND",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the environment variable
+			os.Setenv("GH_CS_SCP_COMMAND", tt.envValue)
+
+			// Call the function
+			cmd, args, err := getSCPCommand()
+
+			// Check error
+			if tt.expectedErrMsg != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.expectedErrMsg)
+				}
+				if err.Error() != tt.expectedErrMsg {
+					t.Fatalf("expected error %q, got %q", tt.expectedErrMsg, err.Error())
+				}
+				return
+			}
+
+			// Check no error
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// For the "no env var" case, we just check that we got a non-empty command
+			if tt.envValue == "" {
+				if cmd == "" {
+					t.Fatal("expected non-empty command")
+				}
+				return
+			}
+
+			// Check command
+			if cmd != tt.expectedCmd {
+				t.Errorf("expected command %q, got %q", tt.expectedCmd, cmd)
+			}
+
+			// Check args
+			if !reflect.DeepEqual(args, tt.expectedArgs) {
+				t.Errorf("expected args %v, got %v", tt.expectedArgs, args)
+			}
+		})
+	}
+}
+
+func TestNewSSHCommandWithEnvVar(t *testing.T) {
+	// Save original env var to restore later
+	originalValue := os.Getenv("GH_CS_SSH_COMMAND")
+	defer os.Setenv("GH_CS_SSH_COMMAND", originalValue)
+
+	tests := []struct {
+		name         string
+		envValue     string
+		cmdArgs      []string
+		command      []string
+		expectedArgs []string
+	}{
+		{
+			name:     "no env var",
+			envValue: "",
+			cmdArgs:  []string{"-v"},
+			command:  []string{"ls", "-la"},
+			// We don't check the exact args here because they'll include connection args
+		},
+		{
+			name:     "env var with args",
+			envValue: "/custom/ssh -o CustomOption=Value",
+			cmdArgs:  []string{"-v"},
+			command:  []string{"ls", "-la"},
+			// We expect the env var args to be prepended to the command args
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the environment variable
+			os.Setenv("GH_CS_SSH_COMMAND", tt.envValue)
+
+			// Call the function
+			cmd, connArgs, err := newSSHCommand(context.Background(), 2222, "user@host", tt.cmdArgs, tt.command)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Check that we got a command
+			if cmd == nil {
+				t.Fatal("expected non-nil command")
+			}
+
+			// Check that connArgs is non-nil
+			if connArgs == nil {
+				t.Fatal("expected non-nil connArgs")
+			}
+
+			// Check command path and arguments from env var
+			if tt.envValue != "" {
+				// Get the command path
+				expectedPath := tt.envValue
+				if i := strings.Index(tt.envValue, " "); i != -1 {
+					expectedPath = tt.envValue[:i]
+
+					// Check that the arguments are included
+					parts := strings.Split(tt.envValue, " ")
+					for _, arg := range parts[1:] { // Skip the command path
+						found := slices.Contains(cmd.Args, arg)
+						if !found {
+							t.Errorf("env var arg %q not found in args: %v", arg, cmd.Args)
+						}
+					}
+				}
+
+				// Check the command path
+				if cmd.Path != expectedPath {
+					t.Errorf("expected command path %q, got %q", expectedPath, cmd.Path)
+				}
+			}
+
+			// Check that the command args include the user command
+			for _, cmdArg := range tt.command {
+				found := slices.Contains(cmd.Args, cmdArg)
+				if !found {
+					t.Errorf("command arg %q not found in args: %v", cmdArg, cmd.Args)
+				}
+			}
+		})
+	}
+}
+
+func TestNewSCPCommandWithEnvVar(t *testing.T) {
+	// Save original env var to restore later
+	originalValue := os.Getenv("GH_CS_SCP_COMMAND")
+	defer os.Setenv("GH_CS_SCP_COMMAND", originalValue)
+
+	tests := []struct {
+		name         string
+		envValue     string
+		cmdArgs      []string
+		expectedArgs []string
+	}{
+		{
+			name:     "no env var",
+			envValue: "",
+			cmdArgs:  []string{"-v", "local/file", "remote:file"},
+			// We don't check the exact args here because they'll include connection args
+		},
+		{
+			name:     "env var with args",
+			envValue: "/custom/scp -F /custom/config",
+			cmdArgs:  []string{"-v", "local/file", "remote:file"},
+			// We expect the env var args to be prepended to the command args
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the environment variable
+			os.Setenv("GH_CS_SCP_COMMAND", tt.envValue)
+
+			// Call the function
+			cmd, err := newSCPCommand(context.Background(), 2222, "user@host", tt.cmdArgs)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Check that we got a command
+			if cmd == nil {
+				t.Fatal("expected non-nil command")
+			}
+
+			// Check command path and arguments from env var
+			if tt.envValue != "" {
+				// Get the command path
+				expectedPath := tt.envValue
+				if i := strings.Index(tt.envValue, " "); i != -1 {
+					expectedPath = tt.envValue[:i]
+
+					// Check that the arguments are included
+					parts := strings.Split(tt.envValue, " ")
+					for _, arg := range parts[1:] { // Skip the command path
+						found := slices.Contains(cmd.Args, arg)
+						if !found {
+							t.Errorf("custom option %q not found in args: %v", arg, cmd.Args)
+						}
+					}
+				}
+
+				// Check the command path
+				if cmd.Path != expectedPath {
+					t.Errorf("expected command path %q, got %q", expectedPath, cmd.Path)
+				}
+			}
+
+			// Check that the command args include the file arguments
+			for _, cmdArg := range []string{"local/file", "user@host:file"} {
+				found := false
+				for _, arg := range cmd.Args {
+					if strings.Contains(arg, cmdArg) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("file arg containing %q not found in args: %v", cmdArg, cmd.Args)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/cli/cli/issues/9244

## Description

This PR adds support for customizing the SSH and SCP commands used by the GitHub CLI's codespace functionality through environment variables. Users can now specify alternative SSH/SCP commands with additional options, providing greater flexibility and control over their codespace connections.

## Features Added

- Added support for two new environment variables:
  - `GH_CS_SSH_COMMAND`: Allows customization of the SSH command used for `gh cs ssh`
  - `GH_CS_SCP_COMMAND`: Allows customization of the SCP command used for `gh cs cp`

- Implemented robust command-line parsing using the `github.com/google/shlex` library to handle quoted arguments and complex command structures

- Modified the newSSHCommand and newSCPCommand functions to incorporate arguments from the environment variables

## Implementation Details

- The implementation uses the `shlex` library to parse command lines with quoted arguments, ensuring proper handling of complex command structures
- Custom arguments from environment variables are inserted at the beginning of the command arguments list
- Comprehensive unit tests were added to verify the functionality with various command formats

## Example Usage

```bash
# Use SSH with verbose output
GH_CS_SSH_COMMAND="ssh -v" gh cs ssh -c my-codespace

# Use SSH with custom options
GH_CS_SSH_COMMAND="ssh -o LogLevel=DEBUG" gh cs ssh -c my-codespace

# Use a custom SSH binary with options
GH_CS_SSH_COMMAND="/path/to/custom/ssh -v -o IdentityFile=/custom/key" gh cs ssh -c my-codespace

# Similar usage for SCP commands
GH_CS_SCP_COMMAND="scp -v" gh cs cp -e README.md remote:/tmp/
```

## Testing

1. Unit tests that verify the parsing of environment variables with various command formats
2. Manual testing with real codespaces, confirming that both SSH and SCP commands work as expected

