### PR TITLE
Fix multi pages search for gh search

### DIFF
--- a/pkg/search/result.go
+++ b/pkg/search/result.go
@@ -93,25 +93,29 @@ var PullRequestFields = append(IssueFields,
 type CodeResult struct {
 	IncompleteResults bool   `json:"incomplete_results"`
 	Items             []Code `json:"items"`
-	Total             int    `json:"total_count"`
+	// Number of code search results matching the query on the server. Ignoring limit.
+	Total int `json:"total_count"`
 }
 
 type CommitsResult struct {
 	IncompleteResults bool     `json:"incomplete_results"`
 	Items             []Commit `json:"items"`
-	Total             int      `json:"total_count"`
+	// Number of commits matching the query on the server. Ignoring limit.
+	Total int `json:"total_count"`
 }
 
 type RepositoriesResult struct {
 	IncompleteResults bool         `json:"incomplete_results"`
 	Items             []Repository `json:"items"`
-	Total             int          `json:"total_count"`
+	// Number of repositories matching the query on the server. Ignoring limit.
+	Total int `json:"total_count"`
 }
 
 type IssuesResult struct {
 	IncompleteResults bool    `json:"incomplete_results"`
 	Items             []Issue `json:"items"`
-	Total             int     `json:"total_count"`
+	// Number of isssues matching the query on the server. Ignoring limit.
+	Total int `json:"total_count"`
 }
 
 type Code struct {

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -152,7 +152,7 @@ func (s searcher) Repositories(query Query) (RepositoriesResult, error) {
 
 		itemsToAdd := min(len(page.Items), toRetrieve)
 		result.IncompleteResults = page.IncompleteResults
-		result.Total += itemsToAdd
+		result.Total = page.Total
 		result.Items = append(result.Items, page.Items[:itemsToAdd]...)
 		toRetrieve = toRetrieve - itemsToAdd
 	}
@@ -182,7 +182,7 @@ func (s searcher) Issues(query Query) (IssuesResult, error) {
 
 		itemsToAdd := min(len(page.Items), toRetrieve)
 		result.IncompleteResults = page.IncompleteResults
-		result.Total += itemsToAdd
+		result.Total = page.Total
 		result.Items = append(result.Items, page.Items[:itemsToAdd]...)
 		toRetrieve = toRetrieve - itemsToAdd
 	}

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -87,13 +87,11 @@ func (s searcher) Code(query Query) (CodeResult, error) {
 			return result, err
 		}
 
-		result.IncompleteResults = page.IncompleteResults
-
 		// If we're going to reach the requested limit, only add that many items,
 		// otherwise add all the results.
 		itemsToAdd := min(len(page.Items), toRetrieve)
-
-		result.Total += itemsToAdd
+		result.IncompleteResults = page.IncompleteResults
+		result.Total = page.Total
 		result.Items = append(result.Items, page.Items[:itemsToAdd]...)
 		toRetrieve = toRetrieve - itemsToAdd
 	}
@@ -122,11 +120,9 @@ func (s searcher) Commits(query Query) (CommitsResult, error) {
 			return result, err
 		}
 
-		result.IncompleteResults = page.IncompleteResults
-
 		itemsToAdd := min(len(page.Items), toRetrieve)
-
-		result.Total += itemsToAdd
+		result.IncompleteResults = page.IncompleteResults
+		result.Total = page.Total
 		result.Items = append(result.Items, page.Items[:itemsToAdd]...)
 		toRetrieve = toRetrieve - itemsToAdd
 	}
@@ -154,10 +150,8 @@ func (s searcher) Repositories(query Query) (RepositoriesResult, error) {
 			return result, err
 		}
 
-		result.IncompleteResults = page.IncompleteResults
-
 		itemsToAdd := min(len(page.Items), toRetrieve)
-
+		result.IncompleteResults = page.IncompleteResults
 		result.Total += itemsToAdd
 		result.Items = append(result.Items, page.Items[:itemsToAdd]...)
 		toRetrieve = toRetrieve - itemsToAdd
@@ -186,10 +180,8 @@ func (s searcher) Issues(query Query) (IssuesResult, error) {
 			return result, err
 		}
 
-		result.IncompleteResults = page.IncompleteResults
-
 		itemsToAdd := min(len(page.Items), toRetrieve)
-
+		result.IncompleteResults = page.IncompleteResults
 		result.Total += itemsToAdd
 		result.Items = append(result.Items, page.Items[:itemsToAdd]...)
 		toRetrieve = toRetrieve - itemsToAdd

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -91,6 +91,8 @@ func (s searcher) Code(query Query) (CodeResult, error) {
 		// otherwise add all the results.
 		numItemsToAdd := min(len(page.Items), numItemsToRetrieve)
 		result.IncompleteResults = page.IncompleteResults
+		// The API returns how many items match the query in every response.
+		// With the example above, this would be 500.
 		result.Total = page.Total
 		result.Items = append(result.Items, page.Items[:numItemsToAdd]...)
 		numItemsToRetrieve = numItemsToRetrieve - numItemsToAdd

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	// GitHub API has a limit of 100 per page
 	maxPerPage = 100
 	orderKey   = "order"
 	sortKey    = "sort"
@@ -60,96 +61,138 @@ func NewSearcher(client *http.Client, host string) Searcher {
 
 func (s searcher) Code(query Query) (CodeResult, error) {
 	result := CodeResult{}
-	toRetrieve := query.Limit
+
 	var resp *http.Response
 	var err error
+
+	toRetrieve := query.Limit
+	// We will request either the query limit if it's less than 1 page, or our max page size.
+	// This number doesn't change to keep a valid offset.
+	//
+	// For example, say we want 150 items out of 500.
+	// We request page #1 for 100 items and get items 0 to 99.
+	// Then we request page #2 for 100 items, we get items 100 to 199 and only keep 100 to 149.
+	// If we were to request page #2 for 50 items, we would instead get items 50 to 99.
+	query.Limit = min(toRetrieve, maxPerPage)
+
 	for toRetrieve > 0 {
-		query.Limit = min(toRetrieve, maxPerPage)
 		query.Page = nextPage(resp)
 		if query.Page == 0 {
 			break
 		}
+
 		page := CodeResult{}
 		resp, err = s.search(query, &page)
 		if err != nil {
 			return result, err
 		}
+
 		result.IncompleteResults = page.IncompleteResults
-		result.Total = page.Total
-		result.Items = append(result.Items, page.Items...)
-		toRetrieve = toRetrieve - len(page.Items)
+
+		// If we're going to reach the requested limit, only add that many items,
+		// otherwise add all the results.
+		itemsToAdd := min(len(page.Items), toRetrieve)
+
+		result.Total += itemsToAdd
+		result.Items = append(result.Items, page.Items[:itemsToAdd]...)
+		toRetrieve = toRetrieve - itemsToAdd
 	}
+
 	return result, nil
 }
 
 func (s searcher) Commits(query Query) (CommitsResult, error) {
 	result := CommitsResult{}
-	toRetrieve := query.Limit
+
 	var resp *http.Response
 	var err error
+
+	toRetrieve := query.Limit
+	query.Limit = min(toRetrieve, maxPerPage)
+
 	for toRetrieve > 0 {
-		query.Limit = min(toRetrieve, maxPerPage)
 		query.Page = nextPage(resp)
 		if query.Page == 0 {
 			break
 		}
+
 		page := CommitsResult{}
 		resp, err = s.search(query, &page)
 		if err != nil {
 			return result, err
 		}
+
 		result.IncompleteResults = page.IncompleteResults
-		result.Total = page.Total
-		result.Items = append(result.Items, page.Items...)
-		toRetrieve = toRetrieve - len(page.Items)
+
+		itemsToAdd := min(len(page.Items), toRetrieve)
+
+		result.Total += itemsToAdd
+		result.Items = append(result.Items, page.Items[:itemsToAdd]...)
+		toRetrieve = toRetrieve - itemsToAdd
 	}
 	return result, nil
 }
 
 func (s searcher) Repositories(query Query) (RepositoriesResult, error) {
 	result := RepositoriesResult{}
-	toRetrieve := query.Limit
+
 	var resp *http.Response
 	var err error
+
+	toRetrieve := query.Limit
+	query.Limit = min(toRetrieve, maxPerPage)
+
 	for toRetrieve > 0 {
-		query.Limit = min(toRetrieve, maxPerPage)
 		query.Page = nextPage(resp)
 		if query.Page == 0 {
 			break
 		}
+
 		page := RepositoriesResult{}
 		resp, err = s.search(query, &page)
 		if err != nil {
 			return result, err
 		}
+
 		result.IncompleteResults = page.IncompleteResults
-		result.Total = page.Total
-		result.Items = append(result.Items, page.Items...)
-		toRetrieve = toRetrieve - len(page.Items)
+
+		itemsToAdd := min(len(page.Items), toRetrieve)
+
+		result.Total += itemsToAdd
+		result.Items = append(result.Items, page.Items[:itemsToAdd]...)
+		toRetrieve = toRetrieve - itemsToAdd
 	}
 	return result, nil
 }
 
 func (s searcher) Issues(query Query) (IssuesResult, error) {
 	result := IssuesResult{}
-	toRetrieve := query.Limit
+
 	var resp *http.Response
 	var err error
+
+	toRetrieve := query.Limit
+	query.Limit = min(toRetrieve, maxPerPage)
+
 	for toRetrieve > 0 {
-		query.Limit = min(toRetrieve, maxPerPage)
 		query.Page = nextPage(resp)
 		if query.Page == 0 {
 			break
 		}
+
 		page := IssuesResult{}
 		resp, err = s.search(query, &page)
 		if err != nil {
 			return result, err
 		}
+
 		result.IncompleteResults = page.IncompleteResults
-		result.Total = page.Total
-		result.Items = append(result.Items, page.Items...)
-		toRetrieve = toRetrieve - len(page.Items)
+
+		itemsToAdd := min(len(page.Items), toRetrieve)
+
+		result.Total += itemsToAdd
+		result.Items = append(result.Items, page.Items[:itemsToAdd]...)
+		toRetrieve = toRetrieve - itemsToAdd
 	}
 	return result, nil
 }
@@ -236,10 +279,15 @@ func handleHTTPError(resp *http.Response) error {
 	return httpError
 }
 
+// https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api
 func nextPage(resp *http.Response) (page int) {
 	if resp == nil {
 		return 1
 	}
+
+	// When using pagination, responses get a "Link" field in their header.
+	// When a next page is available, "Link" contains a link to the next page
+	// tagged with rel="next".
 	for _, m := range linkRE.FindAllStringSubmatch(resp.Header.Get("Link"), -1) {
 		if !(len(m) > 2 && m[2] == "next") {
 			continue

--- a/pkg/search/searcher_test.go
+++ b/pkg/search/searcher_test.go
@@ -48,10 +48,14 @@ func TestSearcherCode(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.QueryMatcher("GET", "search/code", values),
-					httpmock.JSONResponse(CodeResult{
-						IncompleteResults: false,
-						Items:             []Code{{Name: "file.go"}},
-						Total:             1,
+					httpmock.JSONResponse(map[string]interface{}{
+						"incomplete_results": false,
+						"total_count":        1,
+						"items": []interface{}{
+							map[string]interface{}{
+								"name": "file.go",
+							},
+						},
 					}),
 				)
 			},
@@ -68,10 +72,14 @@ func TestSearcherCode(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.QueryMatcher("GET", "api/v3/search/code", values),
-					httpmock.JSONResponse(CodeResult{
-						IncompleteResults: false,
-						Items:             []Code{{Name: "file.go"}},
-						Total:             1,
+					httpmock.JSONResponse(map[string]interface{}{
+						"incomplete_results": false,
+						"total_count":        1,
+						"items": []interface{}{
+							map[string]interface{}{
+								"name": "file.go",
+							},
+						},
 					}),
 				)
 			},
@@ -89,7 +97,11 @@ func TestSearcherCode(t *testing.T) {
 				firstRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items":              []Code{{Name: "file.go"}},
+					"items": []interface{}{
+						map[string]interface{}{
+							"name": "file.go",
+						},
+					},
 				})
 				firstRes = httpmock.WithHeader(firstRes, "Link", `<https://api.github.com/search/code?page=2&per_page=30&q=org%3Agithub>; rel="next"`)
 				secondReq := httpmock.QueryMatcher("GET", "search/code", url.Values{
@@ -100,14 +112,18 @@ func TestSearcherCode(t *testing.T) {
 				secondRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items":              []Code{{Name: "file2.go"}},
+					"items": []interface{}{
+						map[string]interface{}{
+							"name": "file2.go",
+						},
+					},
 				})
 				reg.Register(firstReq, firstRes)
 				reg.Register(secondReq, secondRes)
 			},
 		},
 		{
-			name: "collects results for limit above one page",
+			name: "collect full and partial pages under total number of matching search results",
 			query: Query{
 				Keywords: []string{"keyword"},
 				Kind:     "code",
@@ -123,7 +139,7 @@ func TestSearcherCode(t *testing.T) {
 						Name: fmt.Sprintf("name%d.go", i),
 					}
 				}),
-				Total: 110,
+				Total: 287,
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				firstReq := httpmock.QueryMatcher("GET", "search/code", url.Values{
@@ -133,7 +149,7 @@ func TestSearcherCode(t *testing.T) {
 				})
 				firstRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
-					"total_count":        110,
+					"total_count":        287,
 					"items": initialize(0, 100, func(i int) interface{} {
 						return map[string]interface{}{
 							"name": fmt.Sprintf("name%d.go", i),
@@ -148,8 +164,8 @@ func TestSearcherCode(t *testing.T) {
 				})
 				secondRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
-					"total_count":        110,
-					"items": initialize(100, 110, func(i int) interface{} {
+					"total_count":        287,
+					"items": initialize(100, 200, func(i int) interface{} {
 						return map[string]interface{}{
 							"name": fmt.Sprintf("name%d.go", i),
 						}
@@ -253,10 +269,14 @@ func TestSearcherCommits(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.QueryMatcher("GET", "search/commits", values),
-					httpmock.JSONResponse(CommitsResult{
-						IncompleteResults: false,
-						Items:             []Commit{{Sha: "abc"}},
-						Total:             1,
+					httpmock.JSONResponse(map[string]interface{}{
+						"incomplete_results": false,
+						"total_count":        1,
+						"items": []interface{}{
+							map[string]interface{}{
+								"sha": "abc",
+							},
+						},
 					}),
 				)
 			},
@@ -276,7 +296,11 @@ func TestSearcherCommits(t *testing.T) {
 					httpmock.JSONResponse(map[string]interface{}{
 						"incomplete_results": false,
 						"total_count":        1,
-						"items":              []Commit{{Sha: "abc"}},
+						"items": []interface{}{
+							map[string]interface{}{
+								"sha": "abc",
+							},
+						},
 					}),
 				)
 			},
@@ -294,7 +318,11 @@ func TestSearcherCommits(t *testing.T) {
 				firstRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items":              []Commit{{Sha: "abc"}},
+					"items": []interface{}{
+						map[string]interface{}{
+							"sha": "abc",
+						},
+					},
 				})
 				firstRes = httpmock.WithHeader(firstRes, "Link", `<https://api.github.com/search/commits?page=2&per_page=30&q=org%3Agithub>; rel="next"`)
 				secondReq := httpmock.QueryMatcher("GET", "search/commits", url.Values{
@@ -307,14 +335,18 @@ func TestSearcherCommits(t *testing.T) {
 				secondRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
 					"total_count":        2,
-					"items":              []Commit{{Sha: "def"}},
+					"items": []interface{}{
+						map[string]interface{}{
+							"sha": "def",
+						},
+					},
 				})
 				reg.Register(firstReq, firstRes)
 				reg.Register(secondReq, secondRes)
 			},
 		},
 		{
-			name: "collects results for limit above one page",
+			name: "collect full and partial pages under total number of matching search results",
 			query: Query{
 				Keywords: []string{"keyword"},
 				Kind:     "commits",
@@ -333,7 +365,7 @@ func TestSearcherCommits(t *testing.T) {
 						Sha: strconv.Itoa(i),
 					}
 				}),
-				Total: 110,
+				Total: 287,
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				firstReq := httpmock.QueryMatcher("GET", "search/commits", url.Values{
@@ -345,10 +377,10 @@ func TestSearcherCommits(t *testing.T) {
 				})
 				firstRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
-					"total_count":        110,
-					"items": initialize(0, 100, func(i int) Commit {
-						return Commit{
-							Sha: strconv.Itoa(i),
+					"total_count":        287,
+					"items": initialize(0, 100, func(i int) map[string]interface{} {
+						return map[string]interface{}{
+							"sha": strconv.Itoa(i),
 						}
 					}),
 				})
@@ -362,10 +394,10 @@ func TestSearcherCommits(t *testing.T) {
 				})
 				secondRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
-					"total_count":        110,
-					"items": initialize(100, 110, func(i int) Commit {
-						return Commit{
-							Sha: strconv.Itoa(i),
+					"total_count":        287,
+					"items": initialize(100, 200, func(i int) map[string]interface{} {
+						return map[string]interface{}{
+							"sha": strconv.Itoa(i),
 						}
 					}),
 				})
@@ -544,7 +576,7 @@ func TestSearcherRepositories(t *testing.T) {
 			},
 		},
 		{
-			name: "collects results for limit above one page",
+			name: "collect full and partial pages under total number of matching search results",
 			query: Query{
 				Keywords: []string{"keyword"},
 				Kind:     "repositories",
@@ -563,7 +595,7 @@ func TestSearcherRepositories(t *testing.T) {
 						Name: fmt.Sprintf("name%d", i),
 					}
 				}),
-				Total: 110,
+				Total: 287,
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				firstReq := httpmock.QueryMatcher("GET", "search/repositories", url.Values{
@@ -575,7 +607,7 @@ func TestSearcherRepositories(t *testing.T) {
 				})
 				firstRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
-					"total_count":        110,
+					"total_count":        287,
 					"items": initialize(0, 100, func(i int) interface{} {
 						return map[string]interface{}{
 							"name": fmt.Sprintf("name%d", i),
@@ -592,8 +624,8 @@ func TestSearcherRepositories(t *testing.T) {
 				})
 				secondRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
-					"total_count":        110,
-					"items": initialize(100, 110, func(i int) interface{} {
+					"total_count":        287,
+					"items": initialize(100, 200, func(i int) interface{} {
 						return map[string]interface{}{
 							"name": fmt.Sprintf("name%d", i),
 						}
@@ -774,7 +806,7 @@ func TestSearcherIssues(t *testing.T) {
 			},
 		},
 		{
-			name: "collects results for limit above one page",
+			name: "collect full and partial pages under total number of matching search results",
 			query: Query{
 				Keywords: []string{"keyword"},
 				Kind:     "issues",
@@ -793,7 +825,7 @@ func TestSearcherIssues(t *testing.T) {
 						Number: i,
 					}
 				}),
-				Total: 110,
+				Total: 287,
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				firstReq := httpmock.QueryMatcher("GET", "search/issues", url.Values{
@@ -805,7 +837,7 @@ func TestSearcherIssues(t *testing.T) {
 				})
 				firstRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
-					"total_count":        110,
+					"total_count":        287,
 					"items": initialize(0, 100, func(i int) interface{} {
 						return map[string]interface{}{
 							"number": i,
@@ -822,8 +854,8 @@ func TestSearcherIssues(t *testing.T) {
 				})
 				secondRes := httpmock.JSONResponse(map[string]interface{}{
 					"incomplete_results": false,
-					"total_count":        110,
-					"items": initialize(100, 110, func(i int) interface{} {
+					"total_count":        287,
+					"items": initialize(100, 200, func(i int) interface{} {
 						return map[string]interface{}{
 							"number": i,
 						}


### PR DESCRIPTION
This fixes how `gh search` retrieves items when more than 100 items are requested and not a multiple of 100.

When using pagination, two variables are used: page and perPage. Pages can contain a maximum of 100 items.
The previous implementation tried to save the API some work by requesting less items for the last page.
But it didn't handle pagination correctly and ended up requesting some items a second time.

For example if 150 items are queried, the first page returns items 0->99.
Then it would try to query 50 items by asking for page 2 with 50 per page.
But this would return items 50->99 which isn't what we want.

This new version instead picks a fixed amount per page, in this case 100.
The first page returns items 0->99 and the second 100->199.
Then we discard items 150->199.

When less than 100 items are requested there is no change, we only request what we need.

----

In theory it's possible to both save the API some work and keep track of pagination but that would be more complex.

Fixes #9749