### PR TITLE
extension/manager: Treat symlinked bin with manifest.yml as Binary

### DIFF
--- a/pkg/cmd/extension/manager.go
+++ b/pkg/cmd/extension/manager.go
@@ -155,10 +155,17 @@ func (m *Manager) list(includeMetadata bool) ([]*Extension, error) {
 				})
 			}
 		} else if isSymlink(f.Type()) {
-			results = append(results, &Extension{
-				path: filepath.Join(dir, f.Name(), f.Name()),
-				kind: LocalKind,
-			})
+			if _, err := os.Stat(filepath.Join(dir, f.Name(), manifestName)); err == nil {
+				results = append(results, &Extension{
+					path: filepath.Join(dir, f.Name(), f.Name()),
+					kind: BinaryKind,
+				})
+			} else {
+				results = append(results, &Extension{
+					path: filepath.Join(dir, f.Name(), f.Name()),
+					kind: LocalKind,
+				})
+			}
 		} else {
 			// the contents of a regular file point to a local extension on disk
 			p, err := readPathFromFile(filepath.Join(dir, f.Name()))


### PR DESCRIPTION
Using nixos to install gh-extensions yields a symlink to a folder with the binary. Currently even if there is a manifest.yml in this directory, the extension manager will not read the manifest.yml file as it treats symlinks as `Local` type. This leads to a scenario where my `gh extension list` appears as such:

```
❯ gh extension list
NAME          REPO  VERSION
gh copilot
gh kustomize
gh not
gh notify
gh slack
```

With this proposed change, my `gh extension list` now shows information set in the manifest.yml (if present):

```
❯ bin/gh extension list
NAME          REPO               VERSION
gh copilot    github/gh-copilot  v1.1.0
gh kustomize
gh not        nobe4/gh-not       v0.6.4
gh notify
gh slack
```

I believe that the Local type is only for extensions being worked on locally and thus no manifest options are needed.

Because the files are in a symlinked directory, I excluded setting a git/http client on the Extension as this should indicate that the User is managing the extension and the gh cli should then not do so.

Fixes https://github.com/cli/cli/issues/10772