### PR TITLE
Fix `StatusJSONResponse` usage

### DIFF
--- a/pkg/cmd/gist/delete/delete_test.go
+++ b/pkg/cmd/gist/delete/delete_test.go
@@ -327,11 +327,12 @@ func Test_deleteRun(t *testing.T) {
 
 func Test_gistDelete(t *testing.T) {
 	tests := []struct {
-		name      string
-		httpStubs func(*httpmock.Registry)
-		hostname  string
-		gistID    string
-		wantErr   error
+		name          string
+		httpStubs     func(*httpmock.Registry)
+		hostname      string
+		gistID        string
+		wantErr       error
+		wantErrString string
 	}{
 		{
 			name: "successful delete",
@@ -343,7 +344,6 @@ func Test_gistDelete(t *testing.T) {
 			},
 			hostname: "github.com",
 			gistID:   "1234",
-			wantErr:  nil,
 		},
 		{
 			name: "when an gist is not found, it returns a NotFoundError",
@@ -362,17 +362,15 @@ func Test_gistDelete(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("DELETE", "gists/1234"),
-					httpmock.StatusJSONResponse(500, `{"message": "arbitrary error"}`),
+					httpmock.StatusJSONResponse(500, ghAPI.HTTPError{
+						StatusCode: 500,
+						Message:    "arbitrary error",
+					}),
 				)
 			},
-			hostname: "github.com",
-			gistID:   "1234",
-			wantErr: api.HTTPError{
-				HTTPError: &ghAPI.HTTPError{
-					StatusCode: 500,
-					Message:    "arbitrary error",
-				},
-			},
+			hostname:      "github.com",
+			gistID:        "1234",
+			wantErrString: "HTTP 500: arbitrary error (https://api.github.com/gists/1234)",
 		},
 	}
 
@@ -383,8 +381,10 @@ func Test_gistDelete(t *testing.T) {
 			client := api.NewClientFromHTTP(&http.Client{Transport: reg})
 
 			err := deleteGist(client, tt.hostname, tt.gistID)
-			if tt.wantErr != nil {
-				assert.ErrorAs(t, err, &tt.wantErr)
+			if tt.wantErrString != "" {
+				assert.EqualError(t, err, tt.wantErrString)
+			} else if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/cmd/gist/delete/delete_test.go
+++ b/pkg/cmd/gist/delete/delete_test.go
@@ -364,7 +364,7 @@ func Test_gistDelete(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("DELETE", "gists/1234"),
-					httpmock.StatusJSONResponse(500, ghAPI.HTTPError{
+					httpmock.JSONErrorResponse(500, ghAPI.HTTPError{
 						StatusCode: 500,
 						Message:    "arbitrary error",
 					}),

--- a/pkg/cmd/gist/delete/delete_test.go
+++ b/pkg/cmd/gist/delete/delete_test.go
@@ -347,16 +347,17 @@ func Test_gistDelete(t *testing.T) {
 			gistID:   "1234",
 		},
 		{
-			name: "when an gist is not found, it returns a NotFoundError",
+			name: "when a gist is not found, it returns a NotFoundError",
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("DELETE", "gists/1234"),
 					httpmock.StatusStringResponse(404, "{}"),
 				)
 			},
-			hostname: "github.com",
-			gistID:   "1234",
-			wantErr:  shared.NotFoundErr,
+			hostname:      "github.com",
+			gistID:        "1234",
+			wantErr:       shared.NotFoundErr, // To make sure we return the pre-defined error instance.
+			wantErrString: "not found",
 		},
 		{
 			name: "when there is a non-404 error deleting the gist, that error is returned",
@@ -382,14 +383,16 @@ func Test_gistDelete(t *testing.T) {
 			client := api.NewClientFromHTTP(&http.Client{Transport: reg})
 
 			err := deleteGist(client, tt.hostname, tt.gistID)
-			if tt.wantErrString != "" {
-				require.EqualError(t, err, tt.wantErrString)
-			} else if tt.wantErr != nil {
-				require.ErrorIs(t, err, tt.wantErr)
-			} else {
+			if tt.wantErrString == "" && tt.wantErr == nil {
 				require.NoError(t, err)
+			} else {
+				if tt.wantErrString != "" {
+					require.EqualError(t, err, tt.wantErrString)
+				}
+				if tt.wantErr != nil {
+					require.ErrorIs(t, err, tt.wantErr)
+				}
 			}
-
 		})
 	}
 }

--- a/pkg/cmd/gist/delete/delete_test.go
+++ b/pkg/cmd/gist/delete/delete_test.go
@@ -18,6 +18,7 @@ import (
 	ghAPI "github.com/cli/go-gh/v2/pkg/api"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewCmdDelete(t *testing.T) {
@@ -382,11 +383,11 @@ func Test_gistDelete(t *testing.T) {
 
 			err := deleteGist(client, tt.hostname, tt.gistID)
 			if tt.wantErrString != "" {
-				assert.EqualError(t, err, tt.wantErrString)
+				require.EqualError(t, err, tt.wantErrString)
 			} else if tt.wantErr != nil {
-				assert.ErrorIs(t, err, tt.wantErr)
+				require.ErrorIs(t, err, tt.wantErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 		})

--- a/pkg/cmd/gpg-key/delete/delete_test.go
+++ b/pkg/cmd/gpg-key/delete/delete_test.go
@@ -177,7 +177,7 @@ func Test_deleteRun(t *testing.T) {
 			opts: DeleteOptions{KeyID: "ABC123", Confirmed: true},
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(httpmock.REST("GET", "user/gpg_keys"), httpmock.StatusStringResponse(200, keysResp))
-				reg.Register(httpmock.REST("DELETE", "user/gpg_keys/123"), httpmock.StatusJSONResponse(404, api.HTTPError{
+				reg.Register(httpmock.REST("DELETE", "user/gpg_keys/123"), httpmock.JSONErrorResponse(404, api.HTTPError{
 					StatusCode: 404,
 					Message:    "GPG key 123 not found",
 				}))

--- a/pkg/cmd/run/watch/watch_test.go
+++ b/pkg/cmd/run/watch/watch_test.go
@@ -316,7 +316,7 @@ func TestWatchRun(t *testing.T) {
 				)
 				reg.Register(
 					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/1234"),
-					httpmock.StatusJSONResponse(404, api.HTTPError{
+					httpmock.JSONErrorResponse(404, api.HTTPError{
 						StatusCode: 404,
 						Message:    "run 1234 not found",
 					}),

--- a/pkg/httpmock/stub.go
+++ b/pkg/httpmock/stub.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/cli/go-gh/v2/pkg/api"
 )
 
 type Matcher func(req *http.Request) bool
@@ -160,6 +162,9 @@ func JSONResponse(body interface{}) Responder {
 	}
 }
 
+// StatusJSONResponse turns the given argument into a JSON response.
+//
+// The argument is not meant to be a JSON string, unless it's intentional.
 func StatusJSONResponse(status int, body interface{}) Responder {
 	return func(req *http.Request) (*http.Response, error) {
 		b, _ := json.Marshal(body)
@@ -168,6 +173,12 @@ func StatusJSONResponse(status int, body interface{}) Responder {
 		}
 		return httpResponseWithHeader(status, req, bytes.NewBuffer(b), header), nil
 	}
+}
+
+// JSONErrorResponse is a type-safe helper to avoid confusion around the
+// provided argument.
+func JSONErrorResponse(status int, err api.HTTPError) Responder {
+	return StatusJSONResponse(status, err)
 }
 
 func FileResponse(filename string) Responder {


### PR DESCRIPTION
While reviewing a PR I noticed a wrong usage of `StatusJSONResponse` and that led me to find another instance, which is now fixed in this PR.
