### PR TITLE
Feature detect v1 projects on non web-mode `issue create`

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -863,7 +863,8 @@ type RepoMetadataInput struct {
 	Assignees  bool
 	Reviewers  bool
 	Labels     bool
-	Projects   bool
+	ProjectsV1 bool
+	ProjectsV2 bool
 	Milestones bool
 }
 
@@ -882,6 +883,7 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 			return err
 		})
 	}
+
 	if input.Reviewers {
 		g.Go(func() error {
 			teams, err := OrganizationTeams(client, repo)
@@ -894,6 +896,7 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 			return nil
 		})
 	}
+
 	if input.Reviewers {
 		g.Go(func() error {
 			login, err := CurrentLoginName(client, repo.RepoHost())
@@ -904,6 +907,7 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 			return err
 		})
 	}
+
 	if input.Labels {
 		g.Go(func() error {
 			labels, err := RepoLabels(client, repo)
@@ -914,13 +918,23 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 			return err
 		})
 	}
-	if input.Projects {
+
+	if input.ProjectsV1 {
 		g.Go(func() error {
 			var err error
-			result.Projects, result.ProjectsV2, err = relevantProjects(client, repo)
+			result.Projects, err = v1Projects(client, repo)
 			return err
 		})
 	}
+
+	if input.ProjectsV2 {
+		g.Go(func() error {
+			var err error
+			result.ProjectsV2, err = v2Projects(client, repo)
+			return err
+		})
+	}
+
 	if input.Milestones {
 		g.Go(func() error {
 			milestones, err := RepoMilestones(client, repo, "open")
@@ -943,7 +957,8 @@ type RepoResolveInput struct {
 	Assignees  []string
 	Reviewers  []string
 	Labels     []string
-	Projects   []string
+	ProjectsV1 bool
+	ProjectsV2 bool
 	Milestones []string
 }
 
@@ -970,7 +985,8 @@ func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoRes
 
 	// there is no way to look up projects nor milestones by name, so preload them all
 	mi := RepoMetadataInput{
-		Projects:   len(input.Projects) > 0,
+		ProjectsV1: input.ProjectsV1,
+		ProjectsV2: input.ProjectsV2,
 		Milestones: len(input.Milestones) > 0,
 	}
 	result, err := RepoMetadata(client, repo, mi)
@@ -1245,18 +1261,12 @@ func ProjectNamesToPaths(client *Client, repo ghrepo.Interface, projectNames []s
 	return ProjectsToPaths(projects, projectsV2, projectNames)
 }
 
-// RelevantProjects retrieves set of Projects and ProjectsV2 relevant to given repository:
+// v1Projects retrieves set of RepoProjects relevant to given repository:
 // - Projects for repository
 // - Projects for repository organization, if it belongs to one
-// - ProjectsV2 owned by current user
-// - ProjectsV2 linked to repository
-// - ProjectsV2 owned by repository organization, if it belongs to one
-func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []ProjectV2, error) {
+func v1Projects(client *Client, repo ghrepo.Interface) ([]RepoProject, error) {
 	var repoProjects []RepoProject
 	var orgProjects []RepoProject
-	var userProjectsV2 []ProjectV2
-	var repoProjectsV2 []ProjectV2
-	var orgProjectsV2 []ProjectV2
 
 	g, _ := errgroup.WithContext(context.Background())
 
@@ -1268,6 +1278,7 @@ func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []P
 		}
 		return err
 	})
+
 	g.Go(func() error {
 		var err error
 		orgProjects, err = OrganizationProjects(client, repo)
@@ -1277,6 +1288,29 @@ func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []P
 		}
 		return nil
 	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	projects := make([]RepoProject, 0, len(repoProjects)+len(orgProjects))
+	projects = append(projects, repoProjects...)
+	projects = append(projects, orgProjects...)
+
+	return projects, nil
+}
+
+// v2Projects retrieves set of ProjectV2 relevant to given repository:
+// - ProjectsV2 owned by current user
+// - ProjectsV2 linked to repository
+// - ProjectsV2 owned by repository organization, if it belongs to one
+func v2Projects(client *Client, repo ghrepo.Interface) ([]ProjectV2, error) {
+	var userProjectsV2 []ProjectV2
+	var repoProjectsV2 []ProjectV2
+	var orgProjectsV2 []ProjectV2
+
+	g, _ := errgroup.WithContext(context.Background())
+
 	g.Go(func() error {
 		var err error
 		userProjectsV2, err = CurrentUserProjectsV2(client, repo.RepoHost())
@@ -1286,6 +1320,7 @@ func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []P
 		}
 		return nil
 	})
+
 	g.Go(func() error {
 		var err error
 		repoProjectsV2, err = RepoProjectsV2(client, repo)
@@ -1295,6 +1330,7 @@ func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []P
 		}
 		return nil
 	})
+
 	g.Go(func() error {
 		var err error
 		orgProjectsV2, err = OrganizationProjectsV2(client, repo)
@@ -1308,12 +1344,8 @@ func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []P
 	})
 
 	if err := g.Wait(); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
-	projects := make([]RepoProject, 0, len(repoProjects)+len(orgProjects))
-	projects = append(projects, repoProjects...)
-	projects = append(projects, orgProjects...)
 
 	// ProjectV2 might appear across multiple queries so use a map to keep them deduplicated.
 	m := make(map[string]ProjectV2, len(userProjectsV2)+len(repoProjectsV2)+len(orgProjectsV2))
@@ -1331,7 +1363,27 @@ func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []P
 		projectsV2 = append(projectsV2, p)
 	}
 
-	return projects, projectsV2, nil
+	return projectsV2, nil
+}
+
+// relevantProjects retrieves set of Project or ProjectV2 relevant to given repository:
+// - Projects for repository
+// - Projects for repository organization, if it belongs to one
+// - ProjectsV2 owned by current user
+// - ProjectsV2 linked to repository
+// - ProjectsV2 owned by repository organization, if it belongs to one
+func relevantProjects(client *Client, repo ghrepo.Interface) ([]RepoProject, []ProjectV2, error) {
+	v1Projects, err := v1Projects(client, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v2Projects, err := v2Projects(client, repo)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return v1Projects, v2Projects, nil
 }
 
 func CreateRepoTransformToV4(apiClient *Client, hostname string, method string, path string, body io.Reader) (*Repository, error) {

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -44,7 +44,8 @@ func Test_RepoMetadata(t *testing.T) {
 		Assignees:  true,
 		Reviewers:  true,
 		Labels:     true,
-		Projects:   true,
+		ProjectsV1: true,
+		ProjectsV2: true,
 		Milestones: true,
 	}
 

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -440,7 +440,8 @@ func createRun(opts *CreateOptions) error {
 		if err != nil {
 			return err
 		}
-		return submitPR(*opts, *ctx, *state)
+		// TODO wm: revisit project support
+		return submitPR(*opts, *ctx, *state, gh.ProjectsV1Supported)
 	}
 
 	if opts.RecoverFile != "" {
@@ -536,7 +537,8 @@ func createRun(opts *CreateOptions) error {
 				Repo:      ctx.PRRefs.BaseRepo(),
 				State:     state,
 			}
-			err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.PRRefs.BaseRepo(), fetcher, state)
+			// TODO wm: revisit project support
+			err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.PRRefs.BaseRepo(), fetcher, state, gh.ProjectsV1Supported)
 			if err != nil {
 				return err
 			}
@@ -565,11 +567,13 @@ func createRun(opts *CreateOptions) error {
 
 	if action == shared.SubmitDraftAction {
 		state.Draft = true
-		return submitPR(*opts, *ctx, *state)
+		// TODO wm: revisit project support
+		return submitPR(*opts, *ctx, *state, gh.ProjectsV1Supported)
 	}
 
 	if action == shared.SubmitAction {
-		return submitPR(*opts, *ctx, *state)
+		// TODO wm: revisit project support
+		return submitPR(*opts, *ctx, *state, gh.ProjectsV1Supported)
 	}
 
 	err = errors.New("expected to cancel, preview, or submit")
@@ -966,7 +970,7 @@ func getRemotes(opts *CreateOptions) (ghContext.Remotes, error) {
 	return remotes, nil
 }
 
-func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataState) error {
+func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataState, projectV1Support gh.ProjectsV1Support) error {
 	client := ctx.Client
 
 	params := map[string]interface{}{
@@ -982,7 +986,7 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 		return errors.New("pull request title must not be blank")
 	}
 
-	err := shared.AddMetadataToIssueParams(client, ctx.PRRefs.BaseRepo(), params, &state)
+	err := shared.AddMetadataToIssueParams(client, ctx.PRRefs.BaseRepo(), params, &state, projectV1Support)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -381,7 +381,8 @@ func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable)
 		Reviewers:  editable.Reviewers.Edited,
 		Assignees:  editable.Assignees.Edited,
 		Labels:     editable.Labels.Edited,
-		Projects:   editable.Projects.Edited,
+		ProjectsV1: editable.Projects.Edited,
+		ProjectsV2: editable.Projects.Edited,
 		Milestones: editable.Milestone.Edited,
 	}
 	metadata, err := api.RepoMetadata(client, repo, input)

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -151,7 +151,7 @@ type RepoMetadataFetcher interface {
 	RepoMetadataFetch(api.RepoMetadataInput) (*api.RepoMetadataResult, error)
 }
 
-func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher RepoMetadataFetcher, state *IssueMetadataState) error {
+func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface, fetcher RepoMetadataFetcher, state *IssueMetadataState, projectsV1Support gh.ProjectsV1Support) error {
 	isChosen := func(m string) bool {
 		for _, c := range state.Metadata {
 			if m == c {
@@ -181,7 +181,8 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 		Reviewers:  isChosen("Reviewers"),
 		Assignees:  isChosen("Assignees"),
 		Labels:     isChosen("Labels"),
-		Projects:   isChosen("Projects"),
+		ProjectsV1: isChosen("Projects") && projectsV1Support == gh.ProjectsV1Supported,
+		ProjectsV2: isChosen("Projects"),
 		Milestones: isChosen("Milestone"),
 	}
 	metadataResult, err := fetcher.RepoMetadataFetch(metadataInput)


### PR DESCRIPTION
## Description

Relates to: https://github.com/cli/cli/issues/10714
Builds on: https://github.com/cli/cli/pull/10813

This PR tackles projectv1 deprecation on issue creation that isn't `web mode` i.e. where:
 * The user has provided `--project`
 * The user has selected projects from the `Add Metadata > Projects` multiselect

### Reviewer Notes

**DO NOT MERGE** into base branch, wait for base branch to be merged into trunk.

You can verify the presence or absence of `projects` by running:

```
GH_DEBUG=api ./bin/gh issue create --title foo --body bar --project "fake project" 2>&1 | grep "projects("
```

This exists for queries `RepositoryProjectList` and `OrganizationProjectList`