### PR TITLE
feat: add comment selector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/henvic/httpretty v0.1.4
 	github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec
 	github.com/in-toto/attestation v1.1.1
+	github.com/itchyny/gojq v0.12.15
 	github.com/joho/godotenv v1.5.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-colorable v0.1.14
@@ -119,7 +120,6 @@ require (
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/in-toto/in-toto-golang v0.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/itchyny/gojq v0.12.15 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20211028175153-1c139d1cc84b // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -97,7 +97,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
 	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
 	cmd.Flags().BoolVar(&opts.EditLast, "edit-last", false, "Edit the last comment of the same author")
-	cmd.Flags().StringVar(&opts.EditSelector, "edit-selector", "", "Edit the comment based on the selector")
+	cmd.Flags().StringVar(&opts.EditSelector, "edit-selector", "", "Edit the comment based on the jq selector. Can be used only with --edit-last")
 	cmd.Flags().BoolVar(&opts.CreateIfNone, "create-if-none", false, "Create a new comment if no comments are found. Can be used only with --edit-last")
 
 	return cmd

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -97,6 +97,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*prShared.CommentableOptions) e
 	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
 	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
 	cmd.Flags().BoolVar(&opts.EditLast, "edit-last", false, "Edit the last comment of the same author")
+	cmd.Flags().StringVar(&opts.EditSelector, "edit-selector", "", "Edit the comment based on the selector")
 	cmd.Flags().BoolVar(&opts.CreateIfNone, "create-if-none", false, "Create a new comment if no comments are found. Can be used only with --edit-last")
 
 	return cmd

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -121,6 +121,18 @@ func TestNewCmdComment(t *testing.T) {
 			wantsErr: false,
 		},
 		{
+			name:  "edit last flag with selector",
+			input: "1 --edit-last --edit-selector='. | select(.body | contains \"test\")'",
+			output: shared.CommentableOptions{
+				Interactive:  true,
+				InputType:    shared.InputTypeEditor,
+				Body:         "",
+				EditLast:     true,
+				EditSelector: `. | select(.body | contains "test")`,
+			},
+			wantsErr: false,
+		},
+		{
 			name:  "edit last flag with create if none",
 			input: "1 --edit-last --create-if-none",
 			output: shared.CommentableOptions{

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -76,7 +76,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
 	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
 	cmd.Flags().BoolVar(&opts.EditLast, "edit-last", false, "Edit the last comment of the same author")
-	cmd.Flags().StringVar(&opts.EditSelector, "edit-selector", "", "Edit the comment based on the selector")
+	cmd.Flags().StringVar(&opts.EditSelector, "edit-selector", "", "Edit the comment based on the jq selector. Can be used only with --edit-last")
 	cmd.Flags().BoolVar(&opts.CreateIfNone, "create-if-none", false, "Create a new comment if no comments are found. Can be used only with --edit-last")
 
 	return cmd

--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -76,6 +76,7 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 	cmd.Flags().BoolP("editor", "e", false, "Skip prompts and open the text editor to write the body in")
 	cmd.Flags().BoolP("web", "w", false, "Open the web browser to write the comment")
 	cmd.Flags().BoolVar(&opts.EditLast, "edit-last", false, "Edit the last comment of the same author")
+	cmd.Flags().StringVar(&opts.EditSelector, "edit-selector", "", "Edit the comment based on the selector")
 	cmd.Flags().BoolVar(&opts.CreateIfNone, "create-if-none", false, "Create a new comment if no comments are found. Can be used only with --edit-last")
 
 	return cmd

--- a/pkg/cmd/pr/comment/comment_test.go
+++ b/pkg/cmd/pr/comment/comment_test.go
@@ -141,6 +141,18 @@ func TestNewCmdComment(t *testing.T) {
 			wantsErr: false,
 		},
 		{
+			name:  "edit last flag with selector",
+			input: "1 --edit-last --edit-selector='. | select(.body | contains \"test\")'",
+			output: shared.CommentableOptions{
+				Interactive:  true,
+				InputType:    shared.InputTypeEditor,
+				Body:         "",
+				EditLast:     true,
+				EditSelector: `. | select(.body | contains "test")`,
+			},
+			wantsErr: false,
+		},
+		{
 			name:  "edit last flag with create if none",
 			input: "1 --edit-last --create-if-none",
 			output: shared.CommentableOptions{

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
@@ -254,6 +255,9 @@ func selectComment(selector string, comments []api.Comment) (*api.Comment, error
 	if err != nil {
 		return nil, fmt.Errorf("invalid jq selector: %w", err)
 	}
+
+	// Reverse comments list, as we want to select last comment matchin expression.
+	slices.Reverse(comments)
 
 	for i, comment := range comments {
 		// Convert comment to map[string]interface{} using JSON round-trip

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -97,7 +97,7 @@ func CommentableRun(opts *CommentableOptions) error {
 	opts.Host = repo.RepoHost()
 
 	// Create new comment, bail before complexities of updating the last comment
-	if !opts.EditLast {
+	if !opts.EditLast || opts.EditSelector == "" {
 		return createComment(commentable, opts)
 	}
 

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -14,10 +14,12 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/surveyext"
+	"github.com/itchyny/gojq"
 	"github.com/spf13/cobra"
 )
 
 var errNoUserComments = errors.New("no comments found for current user")
+var errNoSelectorComments = errors.New("no comments found for given selector")
 
 type InputType int
 
@@ -46,6 +48,7 @@ type CommentableOptions struct {
 	InputType                 InputType
 	Body                      string
 	EditLast                  bool
+	EditSelector              string
 	CreateIfNone              bool
 	Quiet                     bool
 	Host                      string
@@ -183,11 +186,20 @@ func updateComment(commentable Commentable, opts *CommentableOptions) error {
 		return errNoUserComments
 	}
 
-	lastComment := &comments[len(comments)-1]
+	var editableComment *api.Comment
+	if opts.EditSelector != "" {
+		comment, err := selectComment(opts.EditSelector, comments)
+		if err != nil {
+			return err
+		}
+		editableComment = comment
+	} else {
+		editableComment = &comments[len(comments)-1]
+	}
 
 	switch opts.InputType {
 	case InputTypeWeb:
-		openURL := lastComment.Link()
+		openURL := editableComment.Link()
 		if opts.IO.IsStdoutTTY() && !opts.Quiet {
 			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", text.DisplayURL(openURL))
 		}
@@ -195,7 +207,7 @@ func updateComment(commentable Commentable, opts *CommentableOptions) error {
 	case InputTypeEditor:
 		var body string
 		var err error
-		initialValue := lastComment.Content()
+		initialValue := editableComment.Content()
 		if opts.Interactive {
 			body, err = opts.InteractiveEditSurvey(initialValue)
 		} else {
@@ -223,7 +235,7 @@ func updateComment(commentable Commentable, opts *CommentableOptions) error {
 	}
 
 	apiClient := api.NewClientFromHTTP(httpClient)
-	params := api.CommentUpdateInput{Body: opts.Body, CommentId: lastComment.Identifier()}
+	params := api.CommentUpdateInput{Body: opts.Body, CommentId: editableComment.Identifier()}
 	url, err := api.CommentUpdate(apiClient, opts.Host, params)
 	if err != nil {
 		return err
@@ -234,6 +246,28 @@ func updateComment(commentable Commentable, opts *CommentableOptions) error {
 	}
 
 	return nil
+}
+
+func selectComment(selector string, comments []api.Comment) (*api.Comment, error) {
+	query, err := gojq.Parse(selector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid jq selector: %w", err)
+	}
+
+	for i, comment := range comments {
+		iter := query.Run(comment)
+		v, ok := iter.Next()
+		if !ok || v == nil {
+			continue
+		}
+		if _, isErr := v.(error); isErr {
+			continue
+		}
+		// A match is any result that isn't false, null, or an error
+		return &comments[i], nil
+	}
+
+	return nil, fmt.Errorf("%w: %q", errNoSelectorComments, selector)
 }
 
 func CommentableConfirmSubmitSurvey(p Prompt) func() (bool, error) {

--- a/pkg/cmd/pr/shared/commentable.go
+++ b/pkg/cmd/pr/shared/commentable.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -97,7 +98,7 @@ func CommentableRun(opts *CommentableOptions) error {
 	opts.Host = repo.RepoHost()
 
 	// Create new comment, bail before complexities of updating the last comment
-	if !opts.EditLast || opts.EditSelector == "" {
+	if !opts.EditLast {
 		return createComment(commentable, opts)
 	}
 
@@ -255,19 +256,32 @@ func selectComment(selector string, comments []api.Comment) (*api.Comment, error
 	}
 
 	for i, comment := range comments {
-		iter := query.Run(comment)
-		v, ok := iter.Next()
-		if !ok || v == nil {
-			continue
+		// Convert comment to map[string]interface{} using JSON round-trip
+		raw, err := json.Marshal(comment)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal comment: %w", err)
 		}
-		if _, isErr := v.(error); isErr {
-			continue
+
+		var generic map[string]interface{}
+		if err := json.Unmarshal(raw, &generic); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal to generic map: %w", err)
 		}
-		// A match is any result that isn't false, null, or an error
-		return &comments[i], nil
+
+		iter := query.Run(generic)
+		for {
+			v, ok := iter.Next()
+			if !ok {
+				break
+			}
+			if err, isErr := v.(error); isErr {
+				return nil, fmt.Errorf("jq evaluation error: %w", err)
+			}
+			// Match found
+			return &comments[i], nil
+		}
 	}
 
-	return nil, fmt.Errorf("%w: %q", errNoSelectorComments, selector)
+	return nil, fmt.Errorf("%w: %s", errNoSelectorComments, selector)
 }
 
 func CommentableConfirmSubmitSurvey(p Prompt) func() (bool, error) {

--- a/pkg/cmd/pr/shared/commentable_test.go
+++ b/pkg/cmd/pr/shared/commentable_test.go
@@ -54,6 +54,19 @@ func Test_selectComment(t *testing.T) {
 			},
 			wantErr: errNoSelectorComments,
 		},
+		{
+			name: "multiple matches",
+			args: args{
+				selector: `. | select(.body | contains("test"))`,
+				comments: []api.Comment{
+					{ID: "test-0", Body: "It is a test. Thanks."},
+					{ID: "test-1", Body: "now thank you test"},
+					{ID: "test-2", Body: "thank test you"},
+					{ID: "test-3", Body: "this thank test you"},
+				},
+			},
+			want: &api.Comment{ID: "test-3"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/pr/shared/commentable_test.go
+++ b/pkg/cmd/pr/shared/commentable_test.go
@@ -21,7 +21,7 @@ func Test_selectComment(t *testing.T) {
 		{
 			name: "body contains expression",
 			args: args{
-				selector: `.body | contains("thank you")`,
+				selector: `. | select(.body | contains("thank you"))`,
 				comments: []api.Comment{
 					{ID: "test-0", Body: "It is a test. Thanks."},
 					{ID: "test-1", Body: "now thank you test"},
@@ -33,7 +33,7 @@ func Test_selectComment(t *testing.T) {
 		{
 			name: "author is known",
 			args: args{
-				selector: `.author.login == "alice"`,
+				selector: `. | select(.author.login == "alice")`,
 				comments: []api.Comment{
 					{ID: "test-0", Author: api.CommentAuthor{Login: "bobby"}},
 					{ID: "test-1", Author: api.CommentAuthor{Login: "alice"}},
@@ -45,7 +45,7 @@ func Test_selectComment(t *testing.T) {
 		{
 			name: "no comments matching expression",
 			args: args{
-				selector: `.author.login == "unknown"`,
+				selector: `. | select(.author.login == "unknown")`,
 				comments: []api.Comment{
 					{ID: "test-0", Author: api.CommentAuthor{Login: "bobby"}},
 					{ID: "test-1", Author: api.CommentAuthor{Login: "alice"}},
@@ -66,13 +66,11 @@ func Test_selectComment(t *testing.T) {
 					t.Errorf("selectComment() = _, %v, want _, %v", err, tt.wantErr)
 				}
 			} else {
-				if tt.wantErr != nil {
-					if got == nil || got.ID != tt.want.ID {
-						t.Errorf("selectComment() = %v, _, want %v, _", got, tt.want)
-					}
-					if !errors.Is(err, tt.wantErr) {
-						t.Errorf("selectComment() = _, %v, want _, %v", err, tt.wantErr)
-					}
+				if got == nil || got.ID != tt.want.ID {
+					t.Errorf("selectComment() = %v, _, want %v, _", got, tt.want)
+				}
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("selectComment() = _, %v, want _, %v", err, tt.wantErr)
 				}
 			}
 		})

--- a/pkg/cmd/pr/shared/commentable_test.go
+++ b/pkg/cmd/pr/shared/commentable_test.go
@@ -1,0 +1,80 @@
+package shared
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cli/cli/v2/api"
+)
+
+func Test_selectComment(t *testing.T) {
+	type args struct {
+		selector string
+		comments []api.Comment
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *api.Comment
+		wantErr error
+	}{
+		{
+			name: "body contains expression",
+			args: args{
+				selector: `.body | contains("thank you")`,
+				comments: []api.Comment{
+					{ID: "test-0", Body: "It is a test. Thanks."},
+					{ID: "test-1", Body: "now thank you test"},
+					{ID: "test-2", Body: "thank test you"},
+				},
+			},
+			want: &api.Comment{ID: "test-1"},
+		},
+		{
+			name: "author is known",
+			args: args{
+				selector: `.author.login == "alice"`,
+				comments: []api.Comment{
+					{ID: "test-0", Author: api.CommentAuthor{Login: "bobby"}},
+					{ID: "test-1", Author: api.CommentAuthor{Login: "alice"}},
+					{ID: "test-2", Author: api.CommentAuthor{Login: "github"}},
+				},
+			},
+			want: &api.Comment{ID: "test-1"},
+		},
+		{
+			name: "no comments matching expression",
+			args: args{
+				selector: `.author.login == "unknown"`,
+				comments: []api.Comment{
+					{ID: "test-0", Author: api.CommentAuthor{Login: "bobby"}},
+					{ID: "test-1", Author: api.CommentAuthor{Login: "alice"}},
+					{ID: "test-2", Author: api.CommentAuthor{Login: "github"}},
+				},
+			},
+			wantErr: errNoSelectorComments,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectComment(tt.args.selector, tt.args.comments)
+			if tt.wantErr != nil {
+				if got != nil {
+					t.Errorf("selectComment() = %v, _, want %v, _", got, tt.want)
+				}
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("selectComment() = _, %v, want _, %v", err, tt.wantErr)
+				}
+			} else {
+				if tt.wantErr != nil {
+					if got == nil || got.ID != tt.want.ID {
+						t.Errorf("selectComment() = %v, _, want %v, _", got, tt.want)
+					}
+					if !errors.Is(err, tt.wantErr) {
+						t.Errorf("selectComment() = _, %v, want _, %v", err, tt.wantErr)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/cmd/pr/shared/commentable_test.go
+++ b/pkg/cmd/pr/shared/commentable_test.go
@@ -31,13 +31,13 @@ func Test_selectComment(t *testing.T) {
 			want: &api.Comment{ID: "test-1"},
 		},
 		{
-			name: "author is known",
+			name: "id is known",
 			args: args{
-				selector: `. | select(.author.login == "alice")`,
+				selector: `. | select(.id == "test-1")`,
 				comments: []api.Comment{
-					{ID: "test-0", Author: api.CommentAuthor{Login: "bobby"}},
-					{ID: "test-1", Author: api.CommentAuthor{Login: "alice"}},
-					{ID: "test-2", Author: api.CommentAuthor{Login: "github"}},
+					{ID: "test-0"},
+					{ID: "test-1"},
+					{ID: "test-2"},
 				},
 			},
 			want: &api.Comment{ID: "test-1"},
@@ -45,11 +45,11 @@ func Test_selectComment(t *testing.T) {
 		{
 			name: "no comments matching expression",
 			args: args{
-				selector: `. | select(.author.login == "unknown")`,
+				selector: `. | select(.author.login == "not-alice")`,
 				comments: []api.Comment{
-					{ID: "test-0", Author: api.CommentAuthor{Login: "bobby"}},
+					{ID: "test-0", Author: api.CommentAuthor{Login: "alice"}},
 					{ID: "test-1", Author: api.CommentAuthor{Login: "alice"}},
-					{ID: "test-2", Author: api.CommentAuthor{Login: "github"}},
+					{ID: "test-2", Author: api.CommentAuthor{Login: "alice"}},
 				},
 			},
 			wantErr: errNoSelectorComments,


### PR DESCRIPTION
This PR introduces the ability to select and edit a specific comment using a `jq` selector when using the `--edit-last` flag in `issue comment` and `pr comment` commands.

The previous behavior always edited the last comment by the current user. This change provides more flexibility, enabling users to programmatically pick the right comment based on content or metadata, which is particularly useful in automated or scripted environments.

- **New flag:** `--edit-selector`  
  Allows users to specify a jq expression to select a specific comment (instead of defaulting to the latest one).  
  Example usage:  
  ```bash
  gh pr comment --edit-last --edit-selector '. | select(.body | contains("<!-- some arbitrary tag -->"))'
  gh pr comment --edit-last --edit-selector '. | select(.id == "2823981412")'
  ```

- **Updated logic in** `CommentableOptions` and `updateComment()`:
  - When `--edit-selector` is used, the code attempts to evaluate the selector against the list of comments.
  - If a match is found, that comment is edited.
  - If no match is found, an error is returned.

- **Dependency update:**
  - Moved `github.com/itchyny/gojq v0.12.15` from indirect to direct dependency in `go.mod`.

- **Tests:**
  - Added unit tests for `selectComment()` covering selector matches and failures.