### PR TITLE
Fix pr create when branch name contains slashes

### DIFF
--- a/acceptance/testdata/pr/pr-create-guesses-remote-from-sha-with-branch-name-slash.txtar
+++ b/acceptance/testdata/pr/pr-create-guesses-remote-from-sha-with-branch-name-slash.txtar
@@ -31,18 +31,20 @@ exec gh repo clone ${USER}/${FORK}
 cd ${FORK}
 
 # Prepare a branch to commit
-exec git checkout -b feature-branch
+exec git checkout -b feature/branch
 exec git commit --allow-empty -m 'Upstream Commit'
-exec git push upstream feature-branch
+# Push without setting an upstream (-u or config)
+exec git push upstream feature/branch
 
 # Prepare an additional commit
 exec git commit --allow-empty -m 'Fork Commit'
-exec git push origin feature-branch
+# Push without setting an upstream (-u or config)
+exec git push origin feature/branch
 
 # Create the PR
 exec gh pr create --title 'Feature Title' --body 'Feature Body'
 stdout https://${GH_HOST}/${ORG}/${REPO}/pull/1
 
 # Check the PR is indeed created
-exec gh pr view ${USER}:feature-branch --json headRefName,headRepository,baseRefName,isCrossRepository
-stdout {"baseRefName":"main","headRefName":"feature-branch","headRepository":{"id":"${FORK_ID}","name":"${FORK}"},"isCrossRepository":true}
+exec gh pr view ${USER}:feature/branch --json headRefName,headRepository,baseRefName,isCrossRepository
+stdout {"baseRefName":"main","headRefName":"feature/branch","headRepository":{"id":"${FORK_ID}","name":"${FORK}"},"isCrossRepository":true}

--- a/acceptance/testdata/pr/pr-create-remote-ref-with-branch-name-slash.txtar
+++ b/acceptance/testdata/pr/pr-create-remote-ref-with-branch-name-slash.txtar
@@ -1,5 +1,6 @@
 skip 'it creates a fork owned by the user running the test'
 
+# Setup environment variables used for testscript
 env REPO=${SCRIPT_NAME}-${RANDOM_STRING}
 env FORK=${REPO}-fork
 
@@ -10,10 +11,10 @@ exec gh auth setup-git
 exec gh api user --jq .login
 stdout2env USER
 
-# Create a repository with a file so it has a default branch
+# Create a repository to act as upstream with a file so it has a default branch
 exec gh repo create ${ORG}/${REPO} --add-readme --private
 
-# Defer repo cleanup
+# Defer repo cleanup of upstream
 defer gh repo delete --yes ${ORG}/${REPO}
 
 # Create a user fork of repository. This will be owned by USER.
@@ -27,22 +28,19 @@ defer gh repo delete --yes ${USER}/${FORK}
 exec gh repo view ${USER}/${FORK} --json id --jq '.id'
 stdout2env FORK_ID
 
+# Clone the repo
 exec gh repo clone ${USER}/${FORK}
 cd ${FORK}
 
-# Prepare a branch to commit
-exec git checkout -b feature-branch
-exec git commit --allow-empty -m 'Upstream Commit'
-exec git push upstream feature-branch
+# Prepare a branch where changes are pulled from the upstream default branch but pushed to fork
+exec git checkout -b feature/branch
+exec git commit --allow-empty -m 'Empty Commit'
+exec git push -u origin feature/branch
 
-# Prepare an additional commit
-exec git commit --allow-empty -m 'Fork Commit'
-exec git push origin feature-branch
-
-# Create the PR
+# Create the PR spanning upstream and fork repositories
 exec gh pr create --title 'Feature Title' --body 'Feature Body'
 stdout https://${GH_HOST}/${ORG}/${REPO}/pull/1
 
-# Check the PR is indeed created
-exec gh pr view ${USER}:feature-branch --json headRefName,headRepository,baseRefName,isCrossRepository
-stdout {"baseRefName":"main","headRefName":"feature-branch","headRepository":{"id":"${FORK_ID}","name":"${FORK}"},"isCrossRepository":true}
+# Assert that the PR was created with the correct head repository and refs
+exec gh pr view --json headRefName,headRepository,baseRefName,isCrossRepository
+stdout {"baseRefName":"main","headRefName":"feature/branch","headRepository":{"id":"${FORK_ID}","name":"${FORK}"},"isCrossRepository":true}

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -1151,13 +1151,38 @@ func TestRemoteTrackingRef(t *testing.T) {
 			wantError             error
 		}{
 			{
-				name:              "valid remote tracking ref",
+				name:              "valid remote tracking ref without slash in branch name",
 				remoteTrackingRef: "refs/remotes/origin/branchName",
 				wantRemoteTrackingRef: RemoteTrackingRef{
 					Remote: "origin",
 					Branch: "branchName",
 				},
 			},
+			{
+				name:              "valid remote tracking ref with slash in branch name",
+				remoteTrackingRef: "refs/remotes/origin/branch/name",
+				wantRemoteTrackingRef: RemoteTrackingRef{
+					Remote: "origin",
+					Branch: "branch/name",
+				},
+			},
+			// TODO: Uncomment when we support slashes in remote names
+			// {
+			// 	name: "valid remote tracking ref with slash in remote name",
+			// 	remoteTrackingRef: "refs/remotes/my/origin/branchName",
+			// 	wantRemoteTrackingRef: RemoteTrackingRef{
+			// 		Remote: "my/origin",
+			// 		Branch: "branchName",
+			// 	},
+			// },
+			// {
+			// 	name: 			"valid remote tracking ref with slash in remote name and branch name",
+			// 	remoteTrackingRef: "refs/remotes/my/origin/branch/name",
+			// 	wantRemoteTrackingRef: RemoteTrackingRef{
+			// 		Remote: "my/origin",
+			// 		Branch: "branch/name",
+			// 	},
+			// },
 			{
 				name:                  "incorrect parts",
 				remoteTrackingRef:     "refs/remotes/origin",


### PR DESCRIPTION
## Description

Fixes https://github.com/cli/cli/issues/10857

In v2.71.0 we made [some large changes to begin respecting git configuration when determining the head ref of a PR in `pr create`](https://github.com/cli/cli/pull/10513). Part of this work involved parsing remote tracking refs returned by `git rev-parse` and `git show-ref`. Unfortunately, I made a silly assumption that remotes and branches wouldn't contain slashes (extra silly because I use slashes in my branches).

This PR modifies `ParseRemoteTrackingRef` to accept slashes under the assumption that they belong to the branch name, as opposed to the remote name. So `refs/remotes/foo/bar/baz` will be parsed as `{ Remote: "foo", Branch: "bar/baz"}`.

Further work will need to be done to address slashes in remote names, but branch names are likely by far the majority case here, so let's get this fixed. Evidence that remote names are less of an issue come from the fact they've been broken for several months because the previous code actually made the same assumptions around assuming remotes were only one path component long when there was ambiguity. That is because `SplitN` works left to right, so `refs/remotes/foo/bar/baz` would become `[refs remotes foo bar/baz]`

https://github.com/cli/cli/blob/408e21ebdddf9cd14289e49135389a6e5125eff4/pkg/cmd/pr/create/create.go#L532-L548

This code has been in for 3 and a half months (2.65.0) without complaint. However, the code **before** that handled the ambiguity correctly by holding onto a struct containing the remote and branch name separately, and referring back to it later:
https://github.com/cli/cli/blob/44ee17760709bedf1cad7e452e61751489b81a33/pkg/cmd/pr/create/create.go#L513-L552