### PR TITLE
Support remotes with slashes in pr create when guessing

### DIFF
--- a/acceptance/testdata/pr/pr-create-guesses-remote-from-sha-with-remote-and-branch-name-slashes.txtar
+++ b/acceptance/testdata/pr/pr-create-guesses-remote-from-sha-with-remote-and-branch-name-slashes.txtar
@@ -1,0 +1,53 @@
+skip 'it creates a fork owned by the user running the test'
+
+env REPO=${SCRIPT_NAME}-${RANDOM_STRING}
+env FORK=${REPO}-fork
+
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Get the current username for the fork owner
+exec gh api user --jq .login
+stdout2env USER
+
+# Create a repository with a file so it has a default branch
+exec gh repo create ${ORG}/${REPO} --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes ${ORG}/${REPO}
+
+# Create a user fork of repository. This will be owned by USER.
+exec gh repo fork ${ORG}/${REPO} --fork-name ${FORK}
+sleep 5
+
+# Defer repo cleanup of fork
+defer gh repo delete --yes ${USER}/${FORK}
+
+# Retrieve fork repository information
+exec gh repo view ${USER}/${FORK} --json id --jq '.id'
+stdout2env FORK_ID
+
+exec gh repo clone ${USER}/${FORK}
+cd ${FORK}
+
+# Rename the origin remote to have a slash
+exec git remote rename origin my/origin
+
+# Prepare a branch to commit
+exec git checkout -b feature/branch
+exec git commit --allow-empty -m 'Upstream Commit'
+# Push without setting an upstream (-u or config)
+exec git push upstream feature/branch
+
+# Prepare an additional commit
+exec git commit --allow-empty -m 'Fork Commit'
+# Push without setting an upstream (-u or config)
+exec git push my/origin feature/branch
+
+# Create the PR
+exec gh pr create --title 'Feature Title' --body 'Feature Body'
+stdout https://${GH_HOST}/${ORG}/${REPO}/pull/1
+
+# Check the PR is indeed created
+exec gh pr view ${USER}:feature/branch --json headRefName,headRepository,baseRefName,isCrossRepository
+stdout {"baseRefName":"main","headRefName":"feature/branch","headRepository":{"id":"${FORK_ID}","name":"${FORK}"},"isCrossRepository":true}

--- a/acceptance/testdata/pr/pr-create-guesses-remote-from-sha-with-remote-slash.txtar
+++ b/acceptance/testdata/pr/pr-create-guesses-remote-from-sha-with-remote-slash.txtar
@@ -1,0 +1,53 @@
+skip 'it creates a fork owned by the user running the test'
+
+env REPO=${SCRIPT_NAME}-${RANDOM_STRING}
+env FORK=${REPO}-fork
+
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Get the current username for the fork owner
+exec gh api user --jq .login
+stdout2env USER
+
+# Create a repository with a file so it has a default branch
+exec gh repo create ${ORG}/${REPO} --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes ${ORG}/${REPO}
+
+# Create a user fork of repository. This will be owned by USER.
+exec gh repo fork ${ORG}/${REPO} --fork-name ${FORK}
+sleep 5
+
+# Defer repo cleanup of fork
+defer gh repo delete --yes ${USER}/${FORK}
+
+# Retrieve fork repository information
+exec gh repo view ${USER}/${FORK} --json id --jq '.id'
+stdout2env FORK_ID
+
+exec gh repo clone ${USER}/${FORK}
+cd ${FORK}
+
+# Rename the origin remote to have a slash
+exec git remote rename origin my/origin
+
+# Prepare a branch to commit
+exec git checkout -b feature-branch
+exec git commit --allow-empty -m 'Upstream Commit'
+# Push without setting an upstream (-u or config)
+exec git push upstream feature-branch
+
+# Prepare an additional commit
+exec git commit --allow-empty -m 'Fork Commit'
+# Push without setting an upstream (-u or config)
+exec git push my/origin feature-branch
+
+# Create the PR
+exec gh pr create --title 'Feature Title' --body 'Feature Body'
+stdout https://${GH_HOST}/${ORG}/${REPO}/pull/1
+
+# Check the PR is indeed created
+exec gh pr view ${USER}:feature-branch --json headRefName,headRepository,baseRefName,isCrossRepository
+stdout {"baseRefName":"main","headRefName":"feature-branch","headRepository":{"id":"${FORK_ID}","name":"${FORK}"},"isCrossRepository":true}

--- a/acceptance/testdata/pr/pr-create-remote-ref-with-remote-slash.txtar
+++ b/acceptance/testdata/pr/pr-create-remote-ref-with-remote-slash.txtar
@@ -1,0 +1,49 @@
+#skip 'it creates a fork owned by the user running the test'
+
+# Setup environment variables used for testscript
+env REPO=${SCRIPT_NAME}-${RANDOM_STRING}
+env FORK=${REPO}-fork
+
+# Use gh as a credential helper
+exec gh auth setup-git
+
+# Get the current username for the fork owner
+exec gh api user --jq .login
+stdout2env USER
+
+# Create a repository to act as upstream with a file so it has a default branch
+exec gh repo create ${ORG}/${REPO} --add-readme --private
+
+# Defer repo cleanup of upstream
+defer gh repo delete --yes ${ORG}/${REPO}
+
+# Create a user fork of repository. This will be owned by USER.
+exec gh repo fork ${ORG}/${REPO} --fork-name ${FORK}
+sleep 5
+
+# Defer repo cleanup of fork
+defer gh repo delete --yes ${USER}/${FORK}
+
+# Retrieve fork repository information
+exec gh repo view ${USER}/${FORK} --json id --jq '.id'
+stdout2env FORK_ID
+
+# Clone the repo
+exec gh repo clone ${USER}/${FORK}
+cd ${FORK}
+
+# Rename the origin remote to have a slash
+exec git remote rename origin my/origin
+
+# Prepare a branch where changes are pulled from the upstream default branch but pushed to fork
+exec git checkout -b feature-branch
+exec git commit --allow-empty -m 'Empty Commit'
+exec git push -u my/origin feature-branch
+
+# Create the PR spanning upstream and fork repositories
+exec gh pr create --title 'Feature Title' --body 'Feature Body'
+stdout https://${GH_HOST}/${ORG}/${REPO}/pull/1
+
+# Assert that the PR was created with the correct head repository and refs
+exec gh pr view --json headRefName,headRepository,baseRefName,isCrossRepository
+stdout {"baseRefName":"main","headRefName":"feature-branch","headRepository":{"id":"${FORK_ID}","name":"${FORK}"},"isCrossRepository":true}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -839,24 +839,32 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 	//
 	// All that said, this has been the behaviour for a long, long time, and I do not want to make other behavioural changes
 	// in what is mostly a refactor.
-	refsToLookup := []string{"HEAD"}
+	refNamesToTrackingRefs := make(map[string]git.RemoteTrackingRef, len(remotes))
+	refNamesToLookup := []string{"HEAD"}
 	for _, remote := range remotes {
-		refsToLookup = append(refsToLookup, fmt.Sprintf("refs/remotes/%s/%s", remote.Name, currentBranch))
+		refName := fmt.Sprintf("refs/remotes/%s/%s", remote.Name, currentBranch)
+		refNamesToLookup = append(refNamesToLookup, refName)
+		refNamesToTrackingRefs[refName] = git.RemoteTrackingRef{
+			Remote: remote.Name,
+			Branch: currentBranch,
+		}
 	}
 
 	// Ignoring the error in this case is allowed because we may get refs and an error (see: --verify flag above).
 	// Ideally there would be a typed error to allow us to distinguish between an execution error and some refs
 	// not existing. However, this is too much to take on in an already large refactor.
-	refs, _ := opts.GitClient.ShowRefs(context.Background(), refsToLookup)
+	refs, _ := opts.GitClient.ShowRefs(context.Background(), refNamesToLookup)
 	if len(refs) > 1 {
 		headRef := refs[0]
 		var firstMatchingRef o.Option[git.RemoteTrackingRef]
 		// Loop over all the refs, trying to find one that matches the SHA of HEAD.
 		for _, r := range refs[1:] {
 			if r.Hash == headRef.Hash {
-				remoteTrackingRef, err := git.ParseRemoteTrackingRef(r.Name)
-				if err != nil {
-					return nil, err
+				remoteTrackingRef, ok := refNamesToTrackingRefs[r.Name]
+				if !ok {
+					// This should never happen because git should be returning the same remote ref name
+					// as we provided in the argument to ShowRefs.
+					return nil, fmt.Errorf("unexpected ref returned from show refs: %s", r.Name)
 				}
 
 				firstMatchingRef = o.Some(remoteTrackingRef)

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1773,6 +1773,93 @@ func TestRemoteGuessing(t *testing.T) {
 	// SHA that matches the HEAD ref in the `git show-ref` output.
 }
 
+func TestRemoteGuessingWithRemoteAndBranchContainingSlashes(t *testing.T) {
+	// Given git config does not provide the necessary info to determine a remote
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	cs.Register(`git status --porcelain`, 0, "")
+	cs.Register(`git config --get-regexp \^branch\\\..+\\\.\(remote\|merge\|pushremote\|gh-merge-base\)\$`, 0, "")
+	cs.Register(`git rev-parse --symbolic-full-name my/feature@{push}`, 0, "refs/remotes/my/origin/my/feature")
+	cs.Register("git config remote.pushDefault", 1, "")
+	cs.Register("git config push.default", 1, "")
+
+	// And Given there is a remote on a SHA that matches the current HEAD
+	cs.Register(`git show-ref --verify -- HEAD refs/remotes/my/upstream/my/feature refs/remotes/my/origin/my/feature`, 0, heredoc.Doc(`
+	deadbeef HEAD
+	deadb00f refs/remotes/my/upstream/my/feature
+	deadbeef refs/remotes/my/origin/my/feature`))
+
+	// When the command is run
+	reg := &httpmock.Registry{}
+	reg.StubRepoInfoResponse("OWNER", "REPO", "master")
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.GraphQL(`mutation PullRequestCreate\b`),
+		httpmock.GraphQLMutation(`
+				{ "data": { "createPullRequest": { "pullRequest": {
+					"URL": "https://github.com/OWNER/REPO/pull/12"
+				} } } }`, func(input map[string]interface{}) {
+			assert.Equal(t, "REPOID", input["repositoryId"].(string))
+			assert.Equal(t, "master", input["baseRefName"].(string))
+			assert.Equal(t, "OTHEROWNER:my/feature", input["headRefName"].(string))
+		}))
+
+	ios, _, _, _ := iostreams.Test()
+
+	opts := CreateOptions{
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		Config: func() (gh.Config, error) {
+			return config.NewBlankConfig(), nil
+		},
+		Browser:  &browser.Stub{},
+		IO:       ios,
+		Prompter: &prompter.PrompterMock{},
+		GitClient: &git.Client{
+			GhPath:  "some/path/gh",
+			GitPath: "some/path/git",
+		},
+		Finder: shared.NewMockFinder("my/feature", nil, nil),
+		Remotes: func() (context.Remotes, error) {
+			return context.Remotes{
+				{
+					Remote: &git.Remote{
+						Name:     "my/upstream",
+						Resolved: "base",
+					},
+					Repo: ghrepo.New("OWNER", "REPO"),
+				},
+				{
+					Remote: &git.Remote{
+						Name: "my/origin",
+					},
+					Repo: ghrepo.New("OTHEROWNER", "REPO-FORK"),
+				},
+			}, nil
+		},
+		Branch: func() (string, error) {
+			return "my/feature", nil
+		},
+
+		TitleProvided: true,
+		BodyProvided:  true,
+		Title:         "my title",
+		Body:          "my body",
+	}
+
+	require.NoError(t, createRun(&opts))
+
+	// Then guessed remote is used for the PR head,
+	// which annoyingly, is asserted above on the line:
+	// assert.Equal(t, "OTHEROWNER:feature", input["headRefName"].(string))
+	//
+	// This is because OTHEROWNER relates to the "origin" remote, which has a
+	// SHA that matches the HEAD ref in the `git show-ref` output.
+}
+
 func TestNoRepoCanBeDetermined(t *testing.T) {
 	// Given no head repo can be determined from git config
 	cs, cmdTeardown := run.Stub()


### PR DESCRIPTION
## Description

Builds on https://github.com/cli/cli/issues/10857

The previous PR handled slashes in branch names, this PR _mostly_ handles slashes in remotes. The `PushRevision` flow will not parse a remote `my/origin/branch` correctly, but the end result of that is that the create flow will try to guess, and this will correctly handle this case.