### PR TITLE
Fix expected error output of `TestRepo/repo-set-default`

### DIFF
--- a/acceptance/testdata/repo/repo-set-default.txtar
+++ b/acceptance/testdata/repo/repo-set-default.txtar
@@ -7,7 +7,7 @@ defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
 # Ensure that no default is set
 cd $SCRIPT_NAME-$RANDOM_STRING
 exec gh repo set-default --view
-stderr 'no default repository has been set; use `gh repo set-default` to select one'
+stderr 'No default remote repository has been set. To learn more about the default repository, run: gh repo set-default --help'
 
 # Set the default
 exec gh repo set-default $ORG/$SCRIPT_NAME-$RANDOM_STRING


### PR DESCRIPTION
Fixes #10883 

First time contributor here, so please let me know if I'm doing something wrong. 

I imagine the output for `gh repo set-default` changed recently and we didn't update this acceptance test, is this possible? After making this change, I was able to run the test successfully.

### Before

```bash
GH_ACCEPTANCE_HOST=*** GH_ACCEPTANCE_ORG=*** GH_ACCEPTANCE_TOKEN=ghp_*** GOMAXPROCS=1 go test -run ^TestRepo/repo-set-default$ -v -tags=acceptance ./acceptance
=== RUN   TestRepo
=== RUN   TestRepo/repo-set-default
=== PAUSE TestRepo/repo-set-default
=== CONT  TestRepo/repo-set-default
    testscript.go:584: WORK=$WORK
        PATH=***
        GOTRACEBACK=system
        HOME=$WORK
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SCRIPT_NAME=repo_set_default
        GH_CONFIG_DIR=$WORK
        GH_HOST=test-prodcus01.ghe.com
        ORG=aconsuegra-test
        GH_TOKEN=ghp_************************************
        RANDOM_STRING=oaJIlaRWss

        # Create and clone a repository with a file so it has a default branch (9.278s)
        > exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private --clone
        [stdout]
        https://test-prodcus01.ghe.com/aconsuegra-test/repo_set_default-oaJIlaRWss
        [stderr]
        Cloning into 'repo_set_default-oaJIlaRWss'...
        # Defer repo cleanup (0.000s)
        > defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
        # Ensure that no default is set (2.091s)
        > cd $SCRIPT_NAME-$RANDOM_STRING
        $WORK/repo_set_default-oaJIlaRWss
        > exec gh repo set-default --view
        [stderr]
        X No default remote repository has been set. To learn more about the default repository, run: gh repo set-default --help
        > stderr 'no default repository has been set; use `gh repo set-default` to select one'
        FAIL: testdata/repo/repo-set-default.txtar:10: no match for "no default repository has been set; use `gh repo set-default` to select one" found in stderr

--- FAIL: TestRepo (0.00s)
    --- FAIL: TestRepo/repo-set-default (11.46s)
FAIL
FAIL	github.com/cli/cli/v2/acceptance	13.022s
FAIL
```

### After

```bash
GH_ACCEPTANCE_HOST=*** GH_ACCEPTANCE_ORG=*** GH_ACCEPTANCE_TOKEN=ghp_*** GOMAXPROCS=1 go test -run ^TestRepo/repo-set-default$ -v -tags=acceptance ./acceptance
=== RUN   TestRepo
=== RUN   TestRepo/repo-set-default
=== PAUSE TestRepo/repo-set-default
=== CONT  TestRepo/repo-set-default
    testscript.go:584: WORK=$WORK
        PATH=***
        GOTRACEBACK=system
        HOME=$WORK
        TMPDIR=$WORK/.tmp
        devnull=/dev/null
        /=/
        :=:
        $=$
        exe=
        SCRIPT_NAME=repo_set_default
        GH_CONFIG_DIR=$WORK
        GH_HOST=test-prodcus01.ghe.com
        ORG=aconsuegra-test
        GH_TOKEN=ghp_************************************
        RANDOM_STRING=iAvvZSSPyB

        # Create and clone a repository with a file so it has a default branch (7.631s)
        > exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private --clone
        [stdout]
        https://test-prodcus01.ghe.com/aconsuegra-test/repo_set_default-iAvvZSSPyB
        [stderr]
        Cloning into 'repo_set_default-iAvvZSSPyB'...
        # Defer repo cleanup (0.000s)
        > defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
        # Ensure that no default is set (0.105s)
        > cd $SCRIPT_NAME-$RANDOM_STRING
        $WORK/repo_set_default-iAvvZSSPyB
        > exec gh repo set-default --view
        [stderr]
        X No default remote repository has been set. To learn more about the default repository, run: gh repo set-default --help
        > stderr 'No default remote repository has been set. To learn more about the default repository, run: gh repo set-default --help'
        # Set the default (1.594s)
        > exec gh repo set-default $ORG/$SCRIPT_NAME-$RANDOM_STRING
        # Check that the default is set (0.111s)
        > exec gh repo set-default --view
        [stdout]
        aconsuegra-test/repo_set_default-iAvvZSSPyB
        > stdout $ORG/$SCRIPT_NAME-$RANDOM_STRING
        PASS

--- PASS: TestRepo (0.00s)
    --- PASS: TestRepo/repo-set-default (11.19s)
PASS
ok  	github.com/cli/cli/v2/acceptance	11.722s
```
 