### PR TITLE
Fix expected error output of TestRepo/repo-rename-transfer-ownership

### DIFF
--- a/acceptance/testdata/repo/repo-rename-transfer-ownership.txtar
+++ b/acceptance/testdata/repo/repo-rename-transfer-ownership.txtar
@@ -3,7 +3,7 @@ exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
 
 # Attempt to rename the repo with a slash in the name
 ! exec gh repo rename $ORG/new-name --repo=$ORG/$SCRIPT_NAME-$RANDOM_STRING --yes
-stderr 'New repository name cannot contain '/' character - to transfer a repository to a new owner, you must follow additional steps on GitHub.com. For more information on transferring repository ownership, see <https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository>.'
+stderr 'New repository name cannot contain \''/\'' character - to transfer a repository to a new owner, you must follow additional steps on <github.com>. For more information on transferring repository ownership, see <https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository>.'
 
 # Defer repo deletion
 defer gh repo delete $ORG/$SCRIPT_NAME-$RANDOM_STRING --yes


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/10887

Similar to https://github.com/cli/cli/pull/10884

Another test that required massaging in the expected error output. In this case, I'm not sure if I'm escaping the single quotes `'` correctly. Happy to make changes if there is a better way!
