### PR TITLE
Fix: Accessible multiselect prompt respects default selections

### DIFF
--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -76,6 +76,27 @@ func TestAccessiblePrompter(t *testing.T) {
 		assert.Equal(t, []int{0, 1}, multiSelectValue)
 	})
 
+	t.Run("MultiSelect - default values are respected by being pre-selected", func(t *testing.T) {
+		console := newTestVirtualTerminal(t)
+		p := newTestAccessiblePrompter(t, console)
+
+		go func() {
+			// Wait for prompt to appear
+			_, err := console.ExpectString("Select a number")
+			require.NoError(t, err)
+
+			// Don't select anything because the default should be selected.
+
+			// This confirms selections
+			_, err = console.SendLine("0")
+			require.NoError(t, err)
+		}()
+
+		multiSelectValue, err := p.MultiSelect("Select a number", []string{"2"}, []string{"1", "2", "3"})
+		require.NoError(t, err)
+		assert.Equal(t, []int{1}, multiSelectValue)
+	})
+
 	t.Run("Input", func(t *testing.T) {
 		console := newTestVirtualTerminal(t)
 		p := newTestAccessiblePrompter(t, console)

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -2,6 +2,7 @@ package prompter
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -100,6 +101,14 @@ func (p *accessiblePrompter) MultiSelect(prompt string, defaults []string, optio
 	var result []int
 	formOptions := make([]huh.Option[int], len(options))
 	for i, o := range options {
+		// If this option is in the defaults slice,
+		// let's add it's index to the result slice and huh
+		// will treat it as a default selection.
+		// TODO: does an invalid default value constitute a panic?
+		if slices.Contains(defaults, o) {
+			result = append(result, i)
+		}
+
 		formOptions[i] = huh.NewOption(o, i)
 	}
 


### PR DESCRIPTION
Fixes #10900 


### Demo

Note the `✓` beside `BagToad` in the assignees list:

```
❯ GH_ACCESSIBLE_PROMPTER=true gh issue edit 1
What would you like to edit?
1.   Title
2.   Body
3.   Assignees
4.   Labels
5.   Projects
6.   Milestone

Select up to 6 options. 0 to continue.
Select: 3
Selected: Assignees

What would you like to edit?
1.   Title
2.   Body
3. ✓ Assignees
4.   Labels
5.   Projects
6.   Milestone

Select up to 6 options. 0 to continue.
Select: 0
Selected: Assignees
                   
Assignees
1. ✓ BagToad

Select up to 1 options. 0 to continue.
```