### PR TITLE
Feature detect v1 projects on interactive `pr create`

### DIFF
--- a/internal/prompter/test.go
+++ b/internal/prompter/test.go
@@ -141,6 +141,18 @@ func IndexFor(options []string, answer string) (int, error) {
 	return -1, NoSuchAnswerErr(answer, options)
 }
 
+func IndexesFor(options []string, answers ...string) ([]int, error) {
+	indexes := make([]int, len(answers))
+	for i, answer := range answers {
+		index, err := IndexFor(options, answer)
+		if err != nil {
+			return nil, err
+		}
+		indexes[i] = index
+	}
+	return indexes, nil
+}
+
 func NoSuchPromptErr(prompt string) error {
 	return fmt.Errorf("no such prompt '%s'", prompt)
 }

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -533,7 +533,7 @@ func createRun(opts *CreateOptions) error {
 			}
 		}
 
-		openURL, err = generateCompareURL(*ctx, *state, gh.ProjectsV1Supported)
+		openURL, err = generateCompareURL(*ctx, *state, projectsV1Support)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -456,7 +456,6 @@ func createRun(opts *CreateOptions) error {
 		if err != nil {
 			return err
 		}
-		// TODO wm: revisit project support
 		return submitPR(*opts, *ctx, *state, projectsV1Support)
 	}
 
@@ -553,8 +552,7 @@ func createRun(opts *CreateOptions) error {
 				Repo:      ctx.PRRefs.BaseRepo(),
 				State:     state,
 			}
-			// TODO wm: revisit project support
-			err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.PRRefs.BaseRepo(), fetcher, state, gh.ProjectsV1Supported)
+			err = shared.MetadataSurvey(opts.Prompter, opts.IO, ctx.PRRefs.BaseRepo(), fetcher, state, projectsV1Support)
 			if err != nil {
 				return err
 			}
@@ -583,12 +581,10 @@ func createRun(opts *CreateOptions) error {
 
 	if action == shared.SubmitDraftAction {
 		state.Draft = true
-		// TODO wm: revisit project support
 		return submitPR(*opts, *ctx, *state, projectsV1Support)
 	}
 
 	if action == shared.SubmitAction {
-		// TODO wm: revisit project support
 		return submitPR(*opts, *ctx, *state, projectsV1Support)
 	}
 
@@ -1237,7 +1233,6 @@ func generateCompareURL(ctx CreateContext, state shared.IssueMetadataState, proj
 		ctx.PRRefs.BaseRepo(),
 		"compare/%s...%s?expand=1",
 		url.PathEscape(ctx.PRRefs.BaseRef()), url.PathEscape(ctx.PRRefs.QualifiedHeadRef()))
-	// TODO wm: revisit project support
 	url, err := shared.WithPrAndIssueQueryParams(ctx.Client, ctx.PRRefs.BaseRepo(), u, state, projectsV1Support)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Description

Relates to: https://github.com/cli/cli/issues/10714
Builds on: https://github.com/cli/cli/pull/10911

This PR tackles projectv1 deprecation on pr creation for the interactive mode.

### Reviewer Notes

**DO NOT MERGE** into base branch, wait for base branch to be merged into trunk.

You can verify the presence or absence of `projects` by running:

```
GH_DEBUG=api ./bin/gh pr create 2>&1
```

And proceeding through the interactive prompts to add a project, and submit a PR with a project added to the metadata.

This exists for queries `RepositoryProjectList` and `OrganizationProjectList`