### PR TITLE
Drop legacy DEBUG value

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,17 +8,7 @@ import (
 )
 
 func IsDebugEnabled() (bool, string) {
-	debugValue, isDebugSet := os.LookupEnv("GH_DEBUG")
-	legacyDebugValue := os.Getenv("DEBUG")
-
-	if !isDebugSet {
-		switch legacyDebugValue {
-		case "true", "1", "yes", "api":
-			return true, legacyDebugValue
-		default:
-			return false, legacyDebugValue
-		}
-	}
+	debugValue := os.LookupEnv("GH_DEBUG")
 
 	switch debugValue {
 	case "false", "0", "no", "":


### PR DESCRIPTION
Thank you for publishing an awesome CLI. I am proposing to remove this legacy DEBUG env var check. It messes with my repo since we have heavy use of the npm package, `debug`, which uses this environment variable for enabling certain debug logs..

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
