### PR TITLE
Improve assertion for disabled echo mode

### DIFF
--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -5,7 +5,6 @@ package prompter_test
 import (
 	"fmt"
 	"io"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -170,7 +169,7 @@ func TestAccessiblePrompter(t *testing.T) {
 		// expected string matches any part of the stream, we have to use an
 		// anchored regexp (i.e., with ^ and $) to make sure the password/token
 		// is not printed at all.
-		_, err = console.Expect(expect.Regexp(regexp.MustCompile("^ \r\n\r\n$")))
+		_, err = console.Expect(expect.RegexpPattern("^ \r\n\r\n$"))
 		require.NoError(t, err)
 	})
 
@@ -241,7 +240,7 @@ func TestAccessiblePrompter(t *testing.T) {
 		// expected string matches any part of the stream, we have to use an
 		// anchored regexp (i.e., with ^ and $) to make sure the password/token
 		// is not printed at all.
-		_, err = console.Expect(expect.Regexp(regexp.MustCompile("^ \r\n\r\n$")))
+		_, err = console.Expect(expect.RegexpPattern("^ \r\n\r\n$"))
 		require.NoError(t, err)
 	})
 
@@ -286,7 +285,7 @@ func TestAccessiblePrompter(t *testing.T) {
 		// expected string matches any part of the stream, we have to use an
 		// anchored regexp (i.e., with ^ and $) to make sure the password/token
 		// is not printed at all.
-		_, err = console.Expect(expect.Regexp(regexp.MustCompile("^ \r\n\r\n$")))
+		_, err = console.Expect(expect.RegexpPattern("^ \r\n\r\n$"))
 		require.NoError(t, err)
 	})
 

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -5,6 +5,7 @@ package prompter_test
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -164,7 +165,12 @@ func TestAccessiblePrompter(t *testing.T) {
 
 		// Ensure the dummy password is not printed to the screen,
 		// asserting that echo mode is disabled.
-		_, err = console.ExpectString(" \r\n\r\n")
+		//
+		// Note that since console.ExpectString returns successful if the
+		// expected string matches any part of the stream, we have to use an
+		// anchored regexp (i.e., with ^ and $) to make sure the password/token
+		// is not printed at all.
+		_, err = console.Expect(expect.Regexp(regexp.MustCompile("^ \r\n\r\n$")))
 		require.NoError(t, err)
 	})
 
@@ -230,7 +236,12 @@ func TestAccessiblePrompter(t *testing.T) {
 
 		// Ensure the dummy password is not printed to the screen,
 		// asserting that echo mode is disabled.
-		_, err = console.ExpectString(" \r\n\r\n")
+		//
+		// Note that since console.ExpectString returns successful if the
+		// expected string matches any part of the stream, we have to use an
+		// anchored regexp (i.e., with ^ and $) to make sure the password/token
+		// is not printed at all.
+		_, err = console.Expect(expect.Regexp(regexp.MustCompile("^ \r\n\r\n$")))
 		require.NoError(t, err)
 	})
 
@@ -252,6 +263,10 @@ func TestAccessiblePrompter(t *testing.T) {
 			_, err = console.ExpectString("token is required")
 			require.NoError(t, err)
 
+			// Wait for the retry prompt
+			_, err = console.ExpectString("Paste your authentication token:")
+			require.NoError(t, err)
+
 			// Wait to ensure huh has time to set the echo mode
 			time.Sleep(beforePasswordSendTimeout)
 
@@ -266,7 +281,12 @@ func TestAccessiblePrompter(t *testing.T) {
 
 		// Ensure the dummy password is not printed to the screen,
 		// asserting that echo mode is disabled.
-		_, err = console.ExpectString(" \r\n\r\n")
+		//
+		// Note that since console.ExpectString returns successful if the
+		// expected string matches any part of the stream, we have to use an
+		// anchored regexp (i.e., with ^ and $) to make sure the password/token
+		// is not printed at all.
+		_, err = console.Expect(expect.Regexp(regexp.MustCompile("^ \r\n\r\n$")))
 		require.NoError(t, err)
 	})
 


### PR DESCRIPTION
Relates to #10916

This PR is follow up to #10918 to further improve the assertion for disabled echo mode, by replacing `console.ExpectString` with `console.Expect(expect.RegExp("..."))`.

The reason for this change is that `console.ExpectString("...")` looks for the given string at any part of the unconsumed stdout stream, and successfully returns if it finds a match. So, to make sure no password/token is actually echoed we need to assert that the entire (unconsumed part of the) stream does not include the entered password/token. The solution is using `console.Expect(expect.RegExp("..."))` with an anchored regexp.

I have explained this in the tests so that we know why we're doing it this way.
