### PR TITLE
Accessible prompter always displays selection defaults in a format readable by a screen reader

### DIFF
--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -171,7 +171,7 @@ func TestAccessiblePrompter(t *testing.T) {
 
 		go func() {
 			// Wait for prompt to appear
-			_, err := console.ExpectString("Enter some characters (default: 12345abcdefg)")
+			_, err := console.ExpectString("Enter some characters (default: 12345abcdefg):")
 			require.NoError(t, err)
 
 			// Enter nothing

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -140,6 +140,26 @@ func TestAccessiblePrompter(t *testing.T) {
 		assert.Equal(t, dummyDefaultValue, inputValue)
 	})
 
+	t.Run("Input - default value is in prompt and in readable format", func(t *testing.T) {
+		console := newTestVirtualTerminal(t)
+		p := newTestAccessiblePrompter(t, console)
+		dummyDefaultValue := "12345abcdefg"
+
+		go func() {
+			// Wait for prompt to appear
+			_, err := console.ExpectString("Enter some characters (default: 12345abcdefg)")
+			require.NoError(t, err)
+
+			// Enter nothing
+			_, err = console.SendLine("")
+			require.NoError(t, err)
+		}()
+
+		inputValue, err := p.Input("Enter some characters", dummyDefaultValue)
+		require.NoError(t, err)
+		assert.Equal(t, dummyDefaultValue, inputValue)
+	})
+
 	t.Run("Password", func(t *testing.T) {
 		console := newTestVirtualTerminal(t)
 		p := newTestAccessiblePrompter(t, console)

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -78,6 +78,29 @@ func TestAccessiblePrompter(t *testing.T) {
 		assert.Equal(t, expectedIndex, selectValue)
 	})
 
+	t.Run("Select - default value is in prompt and in readable format", func(t *testing.T) {
+		console := newTestVirtualTerminal(t)
+		p := newTestAccessiblePrompter(t, console)
+		dummyDefaultValue := "12345abcdefg"
+		options := []string{"1", "2", dummyDefaultValue}
+
+		go func() {
+			// Wait for prompt to appear
+			_, err := console.ExpectString("Select a number (default: 12345abcdefg)")
+			require.NoError(t, err)
+
+			// Just press enter to accept the default
+			_, err = console.SendLine("")
+			require.NoError(t, err)
+		}()
+
+		selectValue, err := p.Select("Select a number", dummyDefaultValue, options)
+		require.NoError(t, err)
+
+		expectedIndex := slices.Index(options, dummyDefaultValue)
+		assert.Equal(t, expectedIndex, selectValue)
+	})
+
 	t.Run("MultiSelect", func(t *testing.T) {
 		console := newTestVirtualTerminal(t)
 		p := newTestAccessiblePrompter(t, console)
@@ -171,7 +194,7 @@ func TestAccessiblePrompter(t *testing.T) {
 
 		go func() {
 			// Wait for prompt to appear
-			_, err := console.ExpectString("Enter some characters (default: 12345abcdefg):")
+			_, err := console.ExpectString("Enter some characters (default: 12345abcdefg)")
 			require.NoError(t, err)
 
 			// Enter nothing

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -304,6 +304,26 @@ func TestAccessiblePrompter(t *testing.T) {
 		require.Equal(t, false, confirmValue)
 	})
 
+	t.Run("Confirm - default value is in prompt and in readable format", func(t *testing.T) {
+		console := newTestVirtualTerminal(t)
+		p := newTestAccessiblePrompter(t, console)
+		defaultValue := true
+
+		go func() {
+			// Wait for prompt to appear
+			_, err := console.ExpectString("Are you sure (default: yes)")
+			require.NoError(t, err)
+
+			// Enter nothing
+			_, err = console.SendLine("")
+			require.NoError(t, err)
+		}()
+
+		confirmValue, err := p.Confirm("Are you sure", defaultValue)
+		require.NoError(t, err)
+		require.Equal(t, defaultValue, confirmValue)
+	})
+
 	t.Run("AuthToken", func(t *testing.T) {
 		console := newTestVirtualTerminal(t)
 		p := newTestAccessiblePrompter(t, console)

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -147,6 +147,37 @@ func TestAccessiblePrompter(t *testing.T) {
 		assert.Equal(t, []int{1}, multiSelectValue)
 	})
 
+	t.Run("MultiSelect - default value is in prompt and in readable format", func(t *testing.T) {
+		console := newTestVirtualTerminal(t)
+		p := newTestAccessiblePrompter(t, console)
+		dummyDefaultValues := []string{"foo", "bar"}
+		options := []string{"1", "2"}
+		options = append(options, dummyDefaultValues...)
+
+		go func() {
+			// Wait for prompt to appear
+			_, err := console.ExpectString("Select a number (defaults: foo, bar)")
+			require.NoError(t, err)
+
+			// Don't select anything because the defaults should be selected.
+
+			// This confirms selections
+			_, err = console.SendLine("0")
+			require.NoError(t, err)
+		}()
+
+		multiSelectValues, err := p.MultiSelect("Select a number", dummyDefaultValues, options)
+		require.NoError(t, err)
+		var expectedIndices []int
+
+		// Get the indices of the default values within the options slice
+		// as that's what we expect the prompter to return when no selections are made.
+		for _, defaultValue := range dummyDefaultValues {
+			expectedIndices = append(expectedIndices, slices.Index(options, defaultValue))
+		}
+		assert.Equal(t, expectedIndices, multiSelectValues)
+	})
+
 	t.Run("Input", func(t *testing.T) {
 		console := newTestVirtualTerminal(t)
 		p := newTestAccessiblePrompter(t, console)

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -126,7 +126,6 @@ func (p *accessiblePrompter) MultiSelect(prompt string, defaults []string, optio
 		// If this option is in the defaults slice,
 		// let's add its index to the result slice and huh
 		// will treat it as a default selection.
-		// TODO: does an invalid default value constitute a panic?
 		if slices.Contains(defaults, o) {
 			result = append(result, i)
 		}

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -79,12 +79,15 @@ func (p *accessiblePrompter) newForm(groups ...*huh.Group) *huh.Form {
 
 // addDefaultsToPrompt adds default values to the prompt string.
 func (p *accessiblePrompter) addDefaultsToPrompt(prompt string, defaultValues []string) string {
+	// We don't show empty default values in the prompt.
+	defaultValues = slices.DeleteFunc(defaultValues, func(s string) bool {
+		return s == ""
+	})
+
 	if len(defaultValues) == 1 {
-		prompt = fmt.Sprintf("%s (default: %s):", prompt, defaultValues[0])
+		prompt = fmt.Sprintf("%s (default: %s)", prompt, defaultValues[0])
 	} else if len(defaultValues) > 1 {
-		prompt = fmt.Sprintf("%s (defaults: %s):", prompt, strings.Join(defaultValues, ", "))
-	} else {
-		prompt = fmt.Sprintf("%s:", prompt)
+		prompt = fmt.Sprintf("%s (defaults: %s)", prompt, strings.Join(defaultValues, ", "))
 	}
 
 	return prompt
@@ -93,6 +96,7 @@ func (p *accessiblePrompter) addDefaultsToPrompt(prompt string, defaultValues []
 func (p *accessiblePrompter) Select(prompt, defaultValue string, options []string) (int, error) {
 	var result int
 	formOptions := []huh.Option[int]{}
+	prompt = p.addDefaultsToPrompt(prompt, []string{defaultValue})
 	for i, o := range options {
 		// If this option is the default value, assign its index
 		// to the result variable. huh will treat it as a default selection.

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -77,10 +77,15 @@ func (p *accessiblePrompter) newForm(groups ...*huh.Group) *huh.Form {
 		WithOutput(p.stdout)
 }
 
-func (p *accessiblePrompter) Select(prompt, _ string, options []string) (int, error) {
+func (p *accessiblePrompter) Select(prompt, defaultValue string, options []string) (int, error) {
 	var result int
 	formOptions := []huh.Option[int]{}
 	for i, o := range options {
+		// If this option is the default value, assign its index
+		// to the result variable. huh will treat it as a default selection.
+		if defaultValue == o {
+			result = i
+		}
 		formOptions = append(formOptions, huh.NewOption(o, i))
 	}
 

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -121,6 +121,7 @@ func (p *accessiblePrompter) Select(prompt, defaultValue string, options []strin
 
 func (p *accessiblePrompter) MultiSelect(prompt string, defaults []string, options []string) ([]int, error) {
 	var result []int
+	prompt = p.addDefaultsToPrompt(prompt, defaults)
 	formOptions := make([]huh.Option[int], len(options))
 	for i, o := range options {
 		// If this option is in the defaults slice,

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -189,6 +189,11 @@ func (p *accessiblePrompter) Password(prompt string) (string, error) {
 
 func (p *accessiblePrompter) Confirm(prompt string, defaultValue bool) (bool, error) {
 	result := defaultValue
+	if defaultValue {
+		prompt = p.addDefaultsToPrompt(prompt, []string{"yes"})
+	} else {
+		prompt = p.addDefaultsToPrompt(prompt, []string{"no"})
+	}
 	form := p.newForm(
 		huh.NewGroup(
 			huh.NewConfirm().

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -131,7 +131,11 @@ func (p *accessiblePrompter) MultiSelect(prompt string, defaults []string, optio
 
 func (p *accessiblePrompter) Input(prompt, defaultValue string) (string, error) {
 	result := defaultValue
-	prompt = fmt.Sprintf("%s (%s)", prompt, defaultValue)
+	if defaultValue != "" {
+		prompt = fmt.Sprintf("%s (default: %s)", prompt, defaultValue)
+	} else {
+		prompt = fmt.Sprintf("%s:", prompt)
+	}
 	form := p.newForm(
 		huh.NewGroup(
 			huh.NewInput().

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -77,6 +77,19 @@ func (p *accessiblePrompter) newForm(groups ...*huh.Group) *huh.Form {
 		WithOutput(p.stdout)
 }
 
+// addDefaultsToPrompt adds default values to the prompt string.
+func (p *accessiblePrompter) addDefaultsToPrompt(prompt string, defaultValues []string) string {
+	if len(defaultValues) == 1 {
+		prompt = fmt.Sprintf("%s (default: %s):", prompt, defaultValues[0])
+	} else if len(defaultValues) > 1 {
+		prompt = fmt.Sprintf("%s (defaults: %s):", prompt, strings.Join(defaultValues, ", "))
+	} else {
+		prompt = fmt.Sprintf("%s:", prompt)
+	}
+
+	return prompt
+}
+
 func (p *accessiblePrompter) Select(prompt, defaultValue string, options []string) (int, error) {
 	var result int
 	formOptions := []huh.Option[int]{}
@@ -136,11 +149,7 @@ func (p *accessiblePrompter) MultiSelect(prompt string, defaults []string, optio
 
 func (p *accessiblePrompter) Input(prompt, defaultValue string) (string, error) {
 	result := defaultValue
-	if defaultValue != "" {
-		prompt = fmt.Sprintf("%s (default: %s)", prompt, defaultValue)
-	} else {
-		prompt = fmt.Sprintf("%s:", prompt)
-	}
+	prompt = p.addDefaultsToPrompt(prompt, []string{defaultValue})
 	form := p.newForm(
 		huh.NewGroup(
 			huh.NewInput().


### PR DESCRIPTION
Fixes #10936 

> [!NOTE]
> I encourage reviewers to try out this branch with a screen reader because I did and it sounds quite good in my opinion 😄  

Proposed experience demo with `repo create`:

```
What would you like to do? 
1. Create a new repository on github.com from scratch
2. Create a new repository on github.com from a template repository
3. Push an existing local repository to github.com
Input a number between 1 and 3: 1

Repository name testing-a11y

Repository owner (default: BagToad) 
1. BagToad
<snip>
Input a number between 1 and 17: 

Description testing

Visibility (default: Public) 
1. Public
2. Private
Input a number between 1 and 2: 2

Would you like to add a README file? (default: no) [y/N] 

Would you like to add a .gitignore? (default: no) [y/N] 

Would you like to add a license? (default: no) [y/N] 

This will create "testing-a11y" as a private repository on github.com. Continue? (default: yes) [Y/n] 
```

Proposed experience demo with `gh issue edit`, showing multi select defaults:

```
Assignees (defaults: BagToad, Evil-Bagtoad) 
Select up to 3 options.
1. ✓ BagToad
2.   Fred
3. ✓ Evil-Bagtoad
0.   Confirm selection
Input a number between 0 and 3: 
```