### PR TITLE
Handle missing archive URLs on release download

### DIFF
--- a/pkg/cmd/release/download/download.go
+++ b/pkg/cmd/release/download/download.go
@@ -165,10 +165,24 @@ func downloadRun(opts *DownloadOptions) error {
 	var toDownload []shared.ReleaseAsset
 	isArchive := false
 	if opts.ArchiveType != "" {
-		var archiveURL = release.ZipballURL
+		var archiveURL string
 		if opts.ArchiveType == "tar.gz" {
 			archiveURL = release.TarballURL
+		} else {
+			archiveURL = release.ZipballURL
 		}
+
+		if archiveURL == "" {
+			errMessage := fmt.Sprintf(
+				"release %q with tag %q, does not have a %q archive asset.",
+				release.Name, release.TagName, opts.ArchiveType,
+			)
+			if release.IsDraft {
+				errMessage += " Most likely, this is because it is a draft."
+			}
+			return errors.New(errMessage)
+		}
+
 		// create pseudo-Asset with no name and pointing to ZipBallURL or TarBallURL
 		toDownload = append(toDownload, shared.ReleaseAsset{APIURL: archiveURL})
 		isArchive = true

--- a/pkg/cmd/release/download/download_test.go
+++ b/pkg/cmd/release/download/download_test.go
@@ -462,6 +462,66 @@ func Test_downloadRun(t *testing.T) {
 			wantStdout: `1234`,
 			wantStderr: ``,
 		},
+		{
+			name:  "draft release with null tarball_url and zipball_url",
+			isTTY: true,
+			opts: DownloadOptions{
+				TagName:     "v1.2.3",
+				ArchiveType: "tar.gz",
+				Destination: "tmp/packages",
+				Concurrency: 2,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{
+					"tag_name": "v1.2.3",
+					"name": "patch-36",
+					"assets": [
+						{ "name": "windows-32bit.zip", "size": 12,
+						  "url": "https://api.github.com/assets/1234" },
+						{ "name": "windows-64bit.zip", "size": 34,
+						  "url": "https://api.github.com/assets/3456" },
+						{ "name": "linux.tgz", "size": 56,
+						  "url": "https://api.github.com/assets/5678" }
+					],
+					"tarball_url": null,
+					"zipball_url": null,
+					"draft": true
+				}`)
+			},
+			wantStdout: ``,
+			wantStderr: ``,
+			wantErr:    "release \"patch-36\" with tag \"v1.2.3\", does not have a \"tar.gz\" archive asset. Most likely, this is because it is a draft.",
+		},
+		{
+			name:  "non-draft release with null tarball_url and zipball_url",
+			isTTY: true,
+			opts: DownloadOptions{
+				TagName:     "v1.2.3",
+				ArchiveType: "tar.gz",
+				Destination: "tmp/packages",
+				Concurrency: 2,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{
+					"tag_name": "v1.2.3",
+					"name": "patch-36",
+					"assets": [
+						{ "name": "windows-32bit.zip", "size": 12,
+						  "url": "https://api.github.com/assets/1234" },
+						{ "name": "windows-64bit.zip", "size": 34,
+						  "url": "https://api.github.com/assets/3456" },
+						{ "name": "linux.tgz", "size": 56,
+						  "url": "https://api.github.com/assets/5678" }
+					],
+					"tarball_url": null,
+					"zipball_url": null,
+					"draft": false
+				}`)
+			},
+			wantStdout: ``,
+			wantStderr: ``,
+			wantErr:    "release \"patch-36\" with tag \"v1.2.3\", does not have a \"tar.gz\" archive asset.",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Creating this on behalf of @gitulisca

## Description

Fixes https://github.com/cli/cli/issues/10797

Without this change, attempts to download releases with no archive URLs (e.g. draft releases), will return the error:
    > Get "": unsupported protocol scheme ""
 
This change will handle that scenario and return an informative error message

In order to support easily testing this change, it is based on a commit that reworks the `downloadRun` tests so that each test table entry stubs requests, and the registry is Verified. Previously, stubbed requests were not verified, which meant it was hard to tell which stub was required for which test.

## Testing

Implementation tested by building the cli and downloading a draft release