### PR TITLE
`gh issue edit`: actors are assignable to issues

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -38,6 +38,7 @@ type Issue struct {
 	Comments         Comments
 	Author           Author
 	Assignees        Assignees
+	AssignedActors   ActorAssignees
 	Labels           Labels
 	ProjectCards     ProjectCards
 	ProjectItems     ProjectItems
@@ -87,6 +88,21 @@ func (a Assignees) Logins() []string {
 	logins := make([]string, len(a.Nodes))
 	for i, a := range a.Nodes {
 		logins[i] = a.Login
+	}
+	return logins
+}
+
+type ActorAssignees struct {
+	Edges []struct {
+		Node Actor
+	}
+	TotalCount int
+}
+
+func (a ActorAssignees) Logins() []string {
+	logins := make([]string, len(a.Edges))
+	for i, a := range a.Edges {
+		logins[i] = a.Node.Login
 	}
 	return logins
 }

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -38,7 +38,7 @@ type Issue struct {
 	Comments         Comments
 	Author           Author
 	Assignees        Assignees
-	AssignedActors   ActorAssignees
+	ActorAssignees   ActorAssignees
 	Labels           Labels
 	ProjectCards     ProjectCards
 	ProjectItems     ProjectItems

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -38,7 +38,7 @@ type Issue struct {
 	Comments         Comments
 	Author           Author
 	Assignees        Assignees
-	ActorAssignees   ActorAssignees
+	AssignedActors   AssignedActors
 	Labels           Labels
 	ProjectCards     ProjectCards
 	ProjectItems     ProjectItems
@@ -92,7 +92,7 @@ func (a Assignees) Logins() []string {
 	return logins
 }
 
-type ActorAssignees struct {
+type AssignedActors struct {
 	Edges []struct {
 		Node Actor
 	}
@@ -100,7 +100,7 @@ type ActorAssignees struct {
 }
 
 // TODO kw: Display names for actors with special display names.
-func (a ActorAssignees) Logins() []string {
+func (a AssignedActors) Logins() []string {
 	logins := make([]string, len(a.Edges))
 	for i, a := range a.Edges {
 		logins[i] = a.Node.Login

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -99,6 +99,7 @@ type ActorAssignees struct {
 	TotalCount int
 }
 
+// TODO kw: Display names for actors with special display names.
 func (a ActorAssignees) Logins() []string {
 	logins := make([]string, len(a.Edges))
 	for i, a := range a.Edges {

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -146,6 +146,13 @@ type GitHubUser struct {
 	Name  string `json:"name"`
 }
 
+// Actor is a superset of User and Bot
+// At the time of writing, it does not support Name.
+type Actor struct {
+	ID    string `json:"id"`
+	Login string `json:"login"`
+}
+
 // BranchRef is the branch name in a GitHub repository
 type BranchRef struct {
 	Name string `json:"name"`

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -940,7 +940,7 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 			// that.
 			// Note: this only matters for `gh pr` flows, which currently does not
 			// request actor assignees, so we probably won't hit this until
-			// `gh pr` reqeuests actor assignees.
+			// `gh pr` requests actor assignees.
 			if input.Reviewers {
 				g.Go(func() error {
 					users, err := RepoAssignableUsers(client, repo)

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1202,8 +1202,6 @@ type AssignableUser struct {
 	name  string
 }
 
-// NewAssignableUser is a test helper to create a new AssignableUser
-// since the ID and Login are private fields
 func NewAssignableUser(id, login, name string) AssignableUser {
 	return AssignableUser{
 		id:    id,

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -929,7 +929,7 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 				return err
 			})
 
-			// If reviewers are requested, we still need to fetch the assignable users
+			// If reviewers are also requested, we still need to fetch the assignable users
 			// since commands use assignable users for reviewers too,
 			// but Actors are not supported for requesting review (need to confirm this).
 			// TODO KW: find out how to do this in the above query so we don't need to
@@ -938,6 +938,9 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 			// by having a name property. Maybe we can use the Name to filter out
 			// non-user Actors and populate the users list for reviewers based on
 			// that.
+			// Note: this only matters for `gh pr` flows, which currently does not
+			// request actor assignees, so we probably won't hit this until
+			// `gh pr` reqeuests actor assignees.
 			if input.Reviewers {
 				g.Go(func() error {
 					users, err := RepoAssignableUsers(client, repo)

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -696,7 +696,7 @@ func (m *RepoMetadataResult) MembersToIDs(names []string) ([]string, error) {
 	for _, assigneeLogin := range names {
 		found := false
 		for _, u := range m.AssignableUsers {
-			if strings.EqualFold(assigneeLogin, (u.Login())) {
+			if strings.EqualFold(assigneeLogin, u.Login()) {
 				ids = append(ids, u.ID())
 				found = true
 				break

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -704,9 +704,9 @@ func (m *RepoMetadataResult) MembersToIDs(names []string) ([]string, error) {
 		}
 
 		// Look for ID in assignable actors if not found in assignable users
-		for _, u := range m.AssignableActors {
-			if strings.EqualFold(assigneeLogin, u.Login) {
-				ids = append(ids, u.ID)
+		for _, a := range m.AssignableActors {
+			if strings.EqualFold(assigneeLogin, a.Login) {
+				ids = append(ids, a.ID)
 				found = true
 				break
 			}

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -526,17 +526,17 @@ func Test_RepoMilestones(t *testing.T) {
 func TestDisplayName(t *testing.T) {
 	tests := []struct {
 		name     string
-		assignee RepoAssignee
+		assignee AssignableUser
 		want     string
 	}{
 		{
 			name:     "assignee with name",
-			assignee: RepoAssignee{"123", "octocat123", "Octavious Cath"},
+			assignee: AssignableUser{"123", "octocat123", "Octavious Cath"},
 			want:     "octocat123 (Octavious Cath)",
 		},
 		{
 			name:     "assignee without name",
-			assignee: RepoAssignee{"123", "octocat123", ""},
+			assignee: AssignableUser{"123", "octocat123", ""},
 			want:     "octocat123",
 		},
 	}

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -366,6 +366,8 @@ func IssueGraphQL(fields []string) string {
 			q = append(q, `headRepository{id,name}`)
 		case "assignees":
 			q = append(q, `assignees(first:100){nodes{id,login,name},totalCount}`)
+		case "assignedActors":
+			q = append(q, `assignedActors(first: 10){edges{node{...on Actor{login}}},totalCount}`)
 		case "labels":
 			q = append(q, `labels(first:100){nodes{id,name,description,color},totalCount}`)
 		case "projectCards":

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -73,7 +73,7 @@ func (d *detector) IssueFeatures() (IssueFeatures, error) {
 
 	features := IssueFeatures{
 		StateReason:       false,
-		ActorIsAssignable: false,
+		ActorIsAssignable: false, // replaceActorsForAssignable GraphQL mutation unavailable on GHES
 	}
 
 	var featureDetection struct {

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -18,11 +18,13 @@ type Detector interface {
 }
 
 type IssueFeatures struct {
-	StateReason bool
+	StateReason       bool
+	ActorIsAssignable bool
 }
 
 var allIssueFeatures = IssueFeatures{
-	StateReason: true,
+	StateReason:       true,
+	ActorIsAssignable: true,
 }
 
 type PullRequestFeatures struct {
@@ -70,7 +72,8 @@ func (d *detector) IssueFeatures() (IssueFeatures, error) {
 	}
 
 	features := IssueFeatures{
-		StateReason: false,
+		StateReason:       false,
+		ActorIsAssignable: false,
 	}
 
 	var featureDetection struct {

--- a/internal/featuredetection/feature_detection_test.go
+++ b/internal/featuredetection/feature_detection_test.go
@@ -23,7 +23,8 @@ func TestIssueFeatures(t *testing.T) {
 			name:     "github.com",
 			hostname: "github.com",
 			wantFeatures: IssueFeatures{
-				StateReason: true,
+				StateReason:       true,
+				ActorIsAssignable: true,
 			},
 			wantErr: false,
 		},
@@ -31,7 +32,8 @@ func TestIssueFeatures(t *testing.T) {
 			name:     "ghec data residency (ghe.com)",
 			hostname: "stampname.ghe.com",
 			wantFeatures: IssueFeatures{
-				StateReason: true,
+				StateReason:       true,
+				ActorIsAssignable: true,
 			},
 			wantErr: false,
 		},
@@ -42,7 +44,8 @@ func TestIssueFeatures(t *testing.T) {
 				`query Issue_fields\b`: `{"data": {}}`,
 			},
 			wantFeatures: IssueFeatures{
-				StateReason: false,
+				StateReason:       false,
+				ActorIsAssignable: false,
 			},
 			wantErr: false,
 		},

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -280,7 +280,7 @@ func editRun(opts *EditOptions) error {
 		// We use Actors as the default assignees if Actors are assignable
 		// on this GitHub host.
 		if editable.Assignees.ActorAssignees {
-			editable.Assignees.Default = issue.AssignedActors.Logins()
+			editable.Assignees.Default = issue.ActorAssignees.Logins()
 		} else {
 			editable.Assignees.Default = issue.Assignees.Logins()
 		}

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -211,7 +211,7 @@ func editRun(opts *EditOptions) error {
 	if editable.Assignees.Edited {
 		if issueFeatures.ActorIsAssignable {
 			editable.Assignees.ActorAssignees = true
-			lookupFields = append(lookupFields, `assignedActors`)
+			lookupFields = append(lookupFields, "assignedActors")
 		} else {
 			lookupFields = append(lookupFields, "assignees")
 		}

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -267,7 +267,7 @@ func editRun(opts *EditOptions) error {
 		// We use Actors as the default assignees if Actors are assignable
 		// on this GitHub host.
 		if editable.Assignees.ActorAssignees {
-			editable.Assignees.Default = issue.ActorAssignees.Logins()
+			editable.Assignees.Default = issue.AssignedActors.Logins()
 		} else {
 			editable.Assignees.Default = issue.Assignees.Logins()
 		}

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -197,9 +197,35 @@ func editRun(opts *EditOptions) error {
 		}
 	}
 
+	if opts.Detector == nil {
+		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
+		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
+	}
+
+	issueFeatures, err := opts.Detector.IssueFeatures()
+	if err != nil {
+		return err
+	}
+
 	lookupFields := []string{"id", "number", "title", "body", "url"}
 	if editable.Assignees.Edited {
-		lookupFields = append(lookupFields, "assignees")
+		if issueFeatures.ActorIsAssignable {
+			// At the time of writing, only 10 Actors can be assigned to an issue.
+			assignedActors := heredoc.Doc(`
+				assignedActors(first: 10) {
+					edges {
+						node {
+							... on Actor {
+								login
+							}
+						}
+					}
+				}
+			`)
+			lookupFields = append(lookupFields, assignedActors)
+		} else {
+			lookupFields = append(lookupFields, "assignees")
+		}
 	}
 	if editable.Labels.Edited {
 		lookupFields = append(lookupFields, "labels")
@@ -207,11 +233,6 @@ func editRun(opts *EditOptions) error {
 	if editable.Projects.Edited {
 		// TODO projectsV1Deprecation
 		// Remove this section as we should no longer add projectCards
-		if opts.Detector == nil {
-			cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
-			opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
-		}
-
 		projectsV1Support := opts.Detector.ProjectsV1()
 		if projectsV1Support == gh.ProjectsV1Supported {
 			lookupFields = append(lookupFields, "projectCards")
@@ -254,7 +275,13 @@ func editRun(opts *EditOptions) error {
 
 		editable.Title.Default = issue.Title
 		editable.Body.Default = issue.Body
-		editable.Assignees.Default = issue.Assignees.Logins()
+		// We use Actors as the default assignees if Actors are assignable
+		// on this GitHub host.
+		if issueFeatures.ActorIsAssignable {
+			editable.Assignees.Default = issue.AssignedActors.Logins()
+		} else {
+			editable.Assignees.Default = issue.Assignees.Logins()
+		}
 		editable.Labels.Default = issue.Labels.Names()
 		editable.Projects.Default = append(issue.ProjectCards.ProjectNames(), issue.ProjectItems.ProjectTitles()...)
 		projectItems := map[string]string{}

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -210,6 +210,8 @@ func editRun(opts *EditOptions) error {
 	lookupFields := []string{"id", "number", "title", "body", "url"}
 	if editable.Assignees.Edited {
 		if issueFeatures.ActorIsAssignable {
+			editable.Assignees.ActorAssignees = true
+
 			// At the time of writing, only 10 Actors can be assigned to an issue.
 			assignedActors := heredoc.Doc(`
 				assignedActors(first: 10) {
@@ -277,7 +279,7 @@ func editRun(opts *EditOptions) error {
 		editable.Body.Default = issue.Body
 		// We use Actors as the default assignees if Actors are assignable
 		// on this GitHub host.
-		if issueFeatures.ActorIsAssignable {
+		if editable.Assignees.ActorAssignees {
 			editable.Assignees.Default = issue.AssignedActors.Logins()
 		} else {
 			editable.Assignees.Default = issue.Assignees.Logins()

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -211,20 +211,7 @@ func editRun(opts *EditOptions) error {
 	if editable.Assignees.Edited {
 		if issueFeatures.ActorIsAssignable {
 			editable.Assignees.ActorAssignees = true
-
-			// At the time of writing, only 10 Actors can be assigned to an issue.
-			assignedActors := heredoc.Doc(`
-				assignedActors(first: 10) {
-					edges {
-						node {
-							... on Actor {
-								login
-							}
-						}
-					}
-				}
-			`)
-			lookupFields = append(lookupFields, assignedActors)
+			lookupFields = append(lookupFields, `assignedActors`)
 		} else {
 			lookupFields = append(lookupFields, "assignees")
 		}

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -394,6 +394,7 @@ func Test_editRun(t *testing.T) {
 				mockIssueProjectItemsGet(t, reg)
 				mockRepoMetadata(t, reg)
 				mockIssueUpdate(t, reg)
+				mockIssueUpdateActorAssignees(t, reg)
 				mockIssueUpdateLabels(t, reg)
 				mockProjectV2ItemUpdate(t, reg)
 			},
@@ -441,6 +442,8 @@ func Test_editRun(t *testing.T) {
 				mockIssueProjectItemsGet(t, reg)
 				mockIssueUpdate(t, reg)
 				mockIssueUpdate(t, reg)
+				mockIssueUpdateActorAssignees(t, reg)
+				mockIssueUpdateActorAssignees(t, reg)
 				mockIssueUpdateLabels(t, reg)
 				mockIssueUpdateLabels(t, reg)
 				mockProjectV2ItemUpdate(t, reg)
@@ -547,6 +550,14 @@ func Test_editRun(t *testing.T) {
 				mockIssueNumberGet(t, reg, 456)
 				// Updating 123 should succeed.
 				reg.Register(
+					httpmock.GraphQLMutationMatcher(`mutation ReplaceActorsForAssignable\b`, func(m map[string]interface{}) bool {
+						return m["assignableId"] == "123"
+					}),
+					httpmock.GraphQLMutation(`
+					{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }`,
+						func(inputs map[string]interface{}) {}),
+				)
+				reg.Register(
 					httpmock.GraphQLMutationMatcher(`mutation IssueUpdate\b`, func(m map[string]interface{}) bool {
 						return m["id"] == "123"
 					}),
@@ -555,6 +566,14 @@ func Test_editRun(t *testing.T) {
 						func(inputs map[string]interface{}) {}),
 				)
 				// Updating 456 should fail.
+				reg.Register(
+					httpmock.GraphQLMutationMatcher(`mutation ReplaceActorsForAssignable\b`, func(m map[string]interface{}) bool {
+						return m["assignableId"] == "456"
+					}),
+					httpmock.GraphQLMutation(`
+							{ "errors": [ { "message": "test error" } ] }`,
+						func(inputs map[string]interface{}) {}),
+				)
 				reg.Register(
 					httpmock.GraphQLMutationMatcher(`mutation IssueUpdate\b`, func(m map[string]interface{}) bool {
 						return m["id"] == "456"
@@ -603,6 +622,7 @@ func Test_editRun(t *testing.T) {
 				mockIssueProjectItemsGet(t, reg)
 				mockRepoMetadata(t, reg)
 				mockIssueUpdate(t, reg)
+				mockIssueUpdateActorAssignees(t, reg)
 				mockIssueUpdateLabels(t, reg)
 				mockProjectV2ItemUpdate(t, reg)
 			},
@@ -792,6 +812,15 @@ func mockIssueUpdate(t *testing.T, reg *httpmock.Registry) {
 	)
 }
 
+func mockIssueUpdateActorAssignees(t *testing.T, reg *httpmock.Registry) {
+	reg.Register(
+		httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
+		httpmock.GraphQLMutation(`
+		{ "data": { "replaceActorsForAssignable": { "__typename": "" } } }`,
+			func(inputs map[string]interface{}) {}),
+	)
+}
+
 func mockIssueUpdateLabels(t *testing.T, reg *httpmock.Registry) {
 	reg.Register(
 		httpmock.GraphQL(`mutation LabelAdd\b`),
@@ -814,6 +843,85 @@ func mockProjectV2ItemUpdate(t *testing.T, reg *httpmock.Registry) {
 		{ "data": { "add_000": { "item": { "id": "1" } }, "delete_001": { "item": { "id": "2" } } } }`,
 			func(inputs map[string]interface{}) {}),
 	)
+}
+
+func TestActorIsAssignable(t *testing.T) {
+	t.Run("when actors are assignable, query includes assignedActors", func(t *testing.T) {
+		ios, _, _, _ := iostreams.Test()
+
+		reg := &httpmock.Registry{}
+		reg.Register(
+			httpmock.GraphQL(`assignedActors`),
+			// Simulate a GraphQL error to early exit the test.
+			httpmock.StatusStringResponse(500, ""),
+		)
+
+		_, cmdTeardown := run.Stub()
+		defer cmdTeardown(t)
+
+		// Ignore the error because we don't care.
+		_ = editRun(&EditOptions{
+			IO: ios,
+			HttpClient: func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			},
+			BaseRepo: func() (ghrepo.Interface, error) {
+				return ghrepo.New("OWNER", "REPO"), nil
+			},
+			Detector:     &fd.EnabledDetectorMock{},
+			IssueNumbers: []int{123},
+			Editable: prShared.Editable{
+				Assignees: prShared.EditableAssignees{
+					EditableSlice: prShared.EditableSlice{
+						Add:    []string{"monalisa", "octocat"},
+						Edited: true,
+					},
+				},
+			},
+		})
+
+		reg.Verify(t)
+	})
+
+	t.Run("when actors are not assignable, query includes assignees instead", func(t *testing.T) {
+		ios, _, _, _ := iostreams.Test()
+
+		reg := &httpmock.Registry{}
+		// This test should NOT include assignedActors in the query
+		reg.Exclude(t, httpmock.GraphQL(`assignedActors`))
+		// It should include the regular assignees field
+		reg.Register(
+			httpmock.GraphQL(`assignees`),
+			// Simulate a GraphQL error to early exit the test.
+			httpmock.StatusStringResponse(500, ""),
+		)
+
+		_, cmdTeardown := run.Stub()
+		defer cmdTeardown(t)
+
+		// Ignore the error because we're not really interested in it.
+		_ = editRun(&EditOptions{
+			IO: ios,
+			HttpClient: func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			},
+			BaseRepo: func() (ghrepo.Interface, error) {
+				return ghrepo.New("OWNER", "REPO"), nil
+			},
+			Detector:     &fd.DisabledDetectorMock{},
+			IssueNumbers: []int{123},
+			Editable: prShared.Editable{
+				Assignees: prShared.EditableAssignees{
+					EditableSlice: prShared.EditableSlice{
+						Add:    []string{"monalisa", "octocat"},
+						Edited: true,
+					},
+				},
+			},
+		})
+
+		reg.Verify(t)
+	})
 }
 
 // TODO projectsV1Deprecation
@@ -897,85 +1005,6 @@ func TestProjectsV1Deprecation(t *testing.T) {
 		})
 
 		// Verify that our request contained projectCards
-		reg.Verify(t)
-	})
-}
-
-func TestActorIsAssignable(t *testing.T) {
-	t.Run("when actors are assignable, query includes assignedActors", func(t *testing.T) {
-		ios, _, _, _ := iostreams.Test()
-
-		reg := &httpmock.Registry{}
-		reg.Register(
-			httpmock.GraphQL(`assignedActors`),
-			// Simulate a GraphQL error to early exit the test.
-			httpmock.StatusStringResponse(500, ""),
-		)
-
-		_, cmdTeardown := run.Stub()
-		defer cmdTeardown(t)
-
-		// Ignore the error because we don't care.
-		_ = editRun(&EditOptions{
-			IO: ios,
-			HttpClient: func() (*http.Client, error) {
-				return &http.Client{Transport: reg}, nil
-			},
-			BaseRepo: func() (ghrepo.Interface, error) {
-				return ghrepo.New("OWNER", "REPO"), nil
-			},
-			Detector:     &fd.EnabledDetectorMock{},
-			IssueNumbers: []int{123},
-			Editable: prShared.Editable{
-				Assignees: prShared.EditableAssignees{
-					EditableSlice: prShared.EditableSlice{
-						Add:    []string{"monalisa", "octocat"},
-						Edited: true,
-					},
-				},
-			},
-		})
-
-		reg.Verify(t)
-	})
-
-	t.Run("when actors are not assignable, query includes assignees instead", func(t *testing.T) {
-		ios, _, _, _ := iostreams.Test()
-
-		reg := &httpmock.Registry{}
-		// This test should NOT include assignedActors in the query
-		reg.Exclude(t, httpmock.GraphQL(`assignedActors`))
-		// It should include the regular assignees field
-		reg.Register(
-			httpmock.GraphQL(`assignees`),
-			// Simulate a GraphQL error to early exit the test.
-			httpmock.StatusStringResponse(500, ""),
-		)
-
-		_, cmdTeardown := run.Stub()
-		defer cmdTeardown(t)
-
-		// Ignore the error because we're not really interested in it.
-		_ = editRun(&EditOptions{
-			IO: ios,
-			HttpClient: func() (*http.Client, error) {
-				return &http.Client{Transport: reg}, nil
-			},
-			BaseRepo: func() (ghrepo.Interface, error) {
-				return ghrepo.New("OWNER", "REPO"), nil
-			},
-			Detector:     &fd.DisabledDetectorMock{},
-			IssueNumbers: []int{123},
-			Editable: prShared.Editable{
-				Assignees: prShared.EditableAssignees{
-					EditableSlice: prShared.EditableSlice{
-						Add:    []string{"monalisa", "octocat"},
-						Edited: true,
-					},
-				},
-			},
-		})
-
 		reg.Verify(t)
 	})
 }

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -574,14 +574,6 @@ func Test_editRun(t *testing.T) {
 							{ "errors": [ { "message": "test error" } ] }`,
 						func(inputs map[string]interface{}) {}),
 				)
-				reg.Register(
-					httpmock.GraphQLMutationMatcher(`mutation IssueUpdate\b`, func(m map[string]interface{}) bool {
-						return m["id"] == "456"
-					}),
-					httpmock.GraphQLMutation(`
-							{ "errors": [ { "message": "test error" } ] }`,
-						func(inputs map[string]interface{}) {}),
-				)
 			},
 			stdout: heredoc.Doc(`
 				https://github.com/OWNER/REPO/issue/123

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -528,8 +528,8 @@ func Test_editRun(t *testing.T) {
 					httpmock.StringResponse(`
 					{ "data": { "repository": { "suggestedActors": {
 						"nodes": [
-							{ "login": "hubot", "id": "HUBOTID" },
-							{ "login": "MonaLisa", "id": "MONAID" }
+							{ "login": "hubot", "id": "HUBOTID", "__typename": "Bot" },
+							{ "login": "MonaLisa", "id": "MONAID", "__typename": "User" }
 						],
 						"pageInfo": { "hasNextPage": false, "endCursor": "Mg" }
 					} } } }
@@ -706,8 +706,8 @@ func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry) {
 		httpmock.StringResponse(`
 		{ "data": { "repository": { "suggestedActors": {
 			"nodes": [
-				{ "login": "hubot", "id": "HUBOTID" },
-				{ "login": "MonaLisa", "id": "MONAID" }
+				{ "login": "hubot", "id": "HUBOTID", "__typename": "Bot" },
+				{ "login": "MonaLisa", "id": "MONAID", "__typename": "User" }
 			],
 			"pageInfo": { "hasNextPage": false }
 		} } } }

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -701,18 +701,6 @@ func mockIssueProjectItemsGet(_ *testing.T, reg *httpmock.Registry) {
 }
 
 func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry) {
-	// reg.Register(
-	// 	httpmock.GraphQL(`query RepositoryAssignableUsers\b`),
-	// 	httpmock.StringResponse(`
-	// 	{ "data": { "repository": { "assignableUsers": {
-	// 		"nodes": [
-	// 			{ "login": "hubot", "id": "HUBOTID" },
-	// 			{ "login": "MonaLisa", "id": "MONAID" }
-	// 		],
-	// 		"pageInfo": { "hasNextPage": false }
-	// 	} } } }
-	// 	`))
-
 	reg.Register(
 		httpmock.GraphQL(`query RepositoryAssignableActors\b`),
 		httpmock.StringResponse(`
@@ -721,7 +709,7 @@ func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry) {
 				{ "login": "hubot", "id": "HUBOTID" },
 				{ "login": "MonaLisa", "id": "MONAID" }
 			],
-			"pageInfo": { "hasNextPage": false, "endCursor": "Mg" }
+			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
 

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -165,9 +165,11 @@ func TestNewCmdEdit(t *testing.T) {
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: shared.Editable{
-					Assignees: shared.EditableSlice{
-						Add:    []string{"monalisa", "hubot"},
-						Edited: true,
+					Assignees: shared.EditableAssignees{
+						EditableSlice: shared.EditableSlice{
+							Add:    []string{"monalisa", "hubot"},
+							Edited: true,
+						},
 					},
 				},
 			},
@@ -179,9 +181,11 @@ func TestNewCmdEdit(t *testing.T) {
 			output: EditOptions{
 				SelectorArg: "23",
 				Editable: shared.Editable{
-					Assignees: shared.EditableSlice{
-						Remove: []string{"monalisa", "hubot"},
-						Edited: true,
+					Assignees: shared.EditableAssignees{
+						EditableSlice: shared.EditableSlice{
+							Remove: []string{"monalisa", "hubot"},
+							Edited: true,
+						},
 					},
 				},
 			},
@@ -359,10 +363,12 @@ func Test_editRun(t *testing.T) {
 						Remove: []string{"dependabot"},
 						Edited: true,
 					},
-					Assignees: shared.EditableSlice{
-						Add:    []string{"monalisa", "hubot"},
-						Remove: []string{"octocat"},
-						Edited: true,
+					Assignees: shared.EditableAssignees{
+						EditableSlice: shared.EditableSlice{
+							Add:    []string{"monalisa", "hubot"},
+							Remove: []string{"octocat"},
+							Edited: true,
+						},
 					},
 					Labels: shared.EditableSlice{
 						Add:    []string{"feature", "TODO", "bug"},
@@ -413,10 +419,12 @@ func Test_editRun(t *testing.T) {
 						Value:  "base-branch-name",
 						Edited: true,
 					},
-					Assignees: shared.EditableSlice{
-						Add:    []string{"monalisa", "hubot"},
-						Remove: []string{"octocat"},
-						Edited: true,
+					Assignees: shared.EditableAssignees{
+						EditableSlice: shared.EditableSlice{
+							Add:    []string{"monalisa", "hubot"},
+							Remove: []string{"octocat"},
+							Edited: true,
+						},
 					},
 					Labels: shared.EditableSlice{
 						Add:    []string{"feature", "TODO", "bug"},

--- a/pkg/cmd/pr/shared/completion.go
+++ b/pkg/cmd/pr/shared/completion.go
@@ -21,13 +21,13 @@ func RequestableReviewersForCompletion(httpClient *http.Client, repo ghrepo.Inte
 
 	results := []string{}
 	for _, user := range metadata.AssignableUsers {
-		if strings.EqualFold(user.Login, metadata.CurrentLogin) {
+		if strings.EqualFold(user.Login(), metadata.CurrentLogin) {
 			continue
 		}
-		if user.Name != "" {
-			results = append(results, fmt.Sprintf("%s\t%s", user.Login, user.Name))
+		if user.Name() != "" {
+			results = append(results, fmt.Sprintf("%s\t%s", user.Login(), user.Name()))
 		} else {
-			results = append(results, user.Login)
+			results = append(results, user.Login())
 		}
 	}
 	for _, team := range metadata.Teams {

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -407,11 +407,11 @@ func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable)
 
 	var users []string
 	for _, u := range metadata.AssignableUsers {
-		users = append(users, u.Login)
+		users = append(users, u.Login())
 	}
 	var actors []string
 	for _, a := range metadata.AssignableActors {
-		actors = append(actors, a.Login)
+		actors = append(actors, a.Login())
 	}
 	var teams []string
 	for _, t := range metadata.Teams {

--- a/pkg/cmd/pr/shared/editable_http.go
+++ b/pkg/cmd/pr/shared/editable_http.go
@@ -103,7 +103,7 @@ func replaceActorAssigneesForEditable(apiClient *api.Client, repo ghrepo.Interfa
 
 	var mutation struct {
 		ReplaceActorsForAssignable struct {
-			Typename string `graphql:"__typename"`
+			TypeName string `graphql:"__typename"`
 		} `graphql:"replaceActorsForAssignable(input: $input)"`
 	}
 

--- a/pkg/cmd/pr/shared/editable_http.go
+++ b/pkg/cmd/pr/shared/editable_http.go
@@ -62,6 +62,10 @@ func UpdateIssue(httpClient *http.Client, repo ghrepo.Interface, id string, isPR
 		wg.Go(func() error {
 			// updateIssue mutation does not support Actors so assignment needs to
 			// be in a separate request when our assignees are Actors.
+			// Note: this is intentionally done synchronously with updating
+			// other issue fields to ensure consistency with how legacy
+			// user assignees are handled.
+			// https://github.com/cli/cli/pull/10960#discussion_r2086725348
 			if options.Assignees.Edited && options.Assignees.ActorAssignees {
 				apiClient := api.NewClientFromHTTP(httpClient)
 				assigneeIds, err := options.AssigneeIds(apiClient, repo)

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -192,7 +192,7 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 
 	var reviewers []string
 	for _, u := range metadataResult.AssignableUsers {
-		if u.Login != metadataResult.CurrentLogin {
+		if u.Login() != metadataResult.CurrentLogin {
 			reviewers = append(reviewers, u.DisplayName())
 		}
 	}

--- a/pkg/cmd/pr/shared/survey_test.go
+++ b/pkg/cmd/pr/shared/survey_test.go
@@ -28,9 +28,9 @@ func TestMetadataSurvey_selectAll(t *testing.T) {
 
 	fetcher := &metadataFetcher{
 		metadataResult: &api.RepoMetadataResult{
-			AssignableUsers: []api.RepoAssignee{
-				{Login: "hubot"},
-				{Login: "monalisa"},
+			AssignableUsers: []api.AssignableUser{
+				api.NewAssignableUser("", "hubot", ""),
+				api.NewAssignableUser("", "monalisa", ""),
 			},
 			Labels: []api.RepoLabel{
 				{Name: "help wanted"},


### PR DESCRIPTION
### Description

This introduces support for handling "Actor" assignees (e.g., bots) in addition to user assignees for issues. The changes include updates to feature detection, GraphQL queries, and associated tests to accommodate this new functionality.

These changes cover both interactive and non-interactive (flags) flows.

> [!NOTE]
> This intentionally does not merge into trunk, as part of a stacked PR workflow.

### Acceptance Criteria

> **Given** I have an issue where an Actor is assignable and
> **Given** I am authenticated with a GitHub host that supports the `Actor` type.
> **When** I run `gh issue edit <issuenum>` and select to edit `Assignees`
> **Then**  I receive a list of assignees that includes assignable Actors, and the Actors already assigned to the issue are pre-selected.
> **When** I select one or more Actors from the list, and proceed
> **Then** I see those selected Actors assigned to the issue

```
❯ gh issue edit 1 
? What would you like to edit? Assignees
? Assignees  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
> [ ]  ActorToad
  [x]  BagToad

# Note: showing the above was pre-selected ☝️ before selecting ActorToad

? Assignees  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
> [x]  ActorToad
  [x]  BagToad

? Submit? Yes
https://github.com/BagToad/reponame/issues/1

❯ gh issue view 1
some title#1
Open • BagToad opened about 15 days ago • 0 comments
Assignees: BagToad, ActorToad
```


> **Given** I have an issue where an Actor is assignable and
> **Given** I am authenticated with a GitHub host that supports the `Actor` type.
> **When** I run `gh issue edit <issuenum> --add-assignee <actorname>...`
> **Then** I see the specified Actor(s) are assigned to the issue

> **Given** I have an issue where an Actor is assigned already
> **Given** I am authenticated with a GitHub host that supports the `Actor` type.
> **When** I run `gh issue edit <issuenum> --remove-assignee <actorname>...`
> **Then** I see the specified Actor(s) are unassigned from the issue

```
❯ gh issue edit 1 --add-assignee ActorToad
https://github.com/BagToad/reponame/issues/1

❯ gh issue view 1
some title#1
Open • BagToad opened about 15 days ago • 0 comments
Assignees: BagToad, ActorToad

❯ gh issue edit 1 --remove-assignee ActorToad
https://github.com/BagToad/reponame/issues/1

❯ gh issue view 1
some title#1
Open • BagToad opened about 15 days ago • 0 comments
Assignees: BagToad
```
