### PR TITLE
Fix bug when removing all PR reviewers

### DIFF
--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -283,8 +283,7 @@ func updatePullRequestReviews(httpClient *http.Client, repo ghrepo.Interface, id
 	if err != nil {
 		return err
 	}
-	if (userIds == nil || len(*userIds) == 0) &&
-		(teamIds == nil || len(*teamIds) == 0) {
+	if userIds == nil && teamIds == nil {
 		return nil
 	}
 	union := githubv4.Boolean(false)

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -764,7 +764,7 @@ func (s testSurveyor) EditFields(e *shared.Editable, _ string) error {
 	e.Body.Value = "new body"
 	if !s.skipReviewers {
 		if s.removeAllReviewers {
-			e.Reviewers.Remove = []string{"monalisa", "hubot", "OWNER/core", "OWNER/external"}
+			e.Reviewers.Remove = []string{"monalisa", "hubot", "OWNER/core", "OWNER/external", "dependabot"}
 		} else {
 			e.Reviewers.Value = []string{"monalisa", "hubot", "OWNER/core", "OWNER/external"}
 		}

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -447,6 +447,64 @@ func Test_editRun(t *testing.T) {
 			stdout: "https://github.com/OWNER/REPO/pull/123\n",
 		},
 		{
+			name: "non-interactive remove all reviewers",
+			input: &EditOptions{
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL: "https://github.com/OWNER/REPO/pull/123",
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Title: shared.EditableString{
+						Value:  "new title",
+						Edited: true,
+					},
+					Body: shared.EditableString{
+						Value:  "new body",
+						Edited: true,
+					},
+					Base: shared.EditableString{
+						Value:  "base-branch-name",
+						Edited: true,
+					},
+					Reviewers: shared.EditableSlice{
+						Remove: []string{"OWNER/core", "OWNER/external", "monalisa", "hubot", "dependabot"},
+						Edited: true,
+					},
+					Assignees: shared.EditableSlice{
+						Add:    []string{"monalisa", "hubot"},
+						Remove: []string{"octocat"},
+						Edited: true,
+					},
+					Labels: shared.EditableSlice{
+						Add:    []string{"feature", "TODO", "bug"},
+						Remove: []string{"docs"},
+						Edited: true,
+					},
+					Projects: shared.EditableProjects{
+						EditableSlice: shared.EditableSlice{
+							Add:    []string{"Cleanup", "CleanupV2"},
+							Remove: []string{"Roadmap", "RoadmapV2"},
+							Edited: true,
+						},
+					},
+					Milestone: shared.EditableString{
+						Value:  "GA",
+						Edited: true,
+					},
+				},
+				Fetcher: testFetcher{},
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				mockRepoMetadata(reg, false)
+				mockPullRequestUpdate(reg)
+				mockPullRequestReviewersUpdate(reg)
+				mockPullRequestUpdateLabels(reg)
+				mockProjectV2ItemUpdate(reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		{
 			name: "interactive",
 			input: &EditOptions{
 				SelectorArg: "123",
@@ -482,6 +540,27 @@ func Test_editRun(t *testing.T) {
 			httpStubs: func(reg *httpmock.Registry) {
 				mockRepoMetadata(reg, true)
 				mockPullRequestUpdate(reg)
+				mockPullRequestUpdateLabels(reg)
+				mockProjectV2ItemUpdate(reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		{
+			name: "interactive remove all reviewers",
+			input: &EditOptions{
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{
+					URL: "https://github.com/OWNER/REPO/pull/123",
+				}, ghrepo.New("OWNER", "REPO")),
+				Interactive:     true,
+				Surveyor:        testSurveyor{removeAllReviewers: true},
+				Fetcher:         testFetcher{},
+				EditorRetriever: testEditorRetriever{},
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				mockRepoMetadata(reg, false)
+				mockPullRequestUpdate(reg)
+				mockPullRequestReviewersUpdate(reg)
 				mockPullRequestUpdateLabels(reg)
 				mockProjectV2ItemUpdate(reg)
 			},
@@ -658,7 +737,8 @@ func mockProjectV2ItemUpdate(reg *httpmock.Registry) {
 
 type testFetcher struct{}
 type testSurveyor struct {
-	skipReviewers bool
+	skipReviewers      bool
+	removeAllReviewers bool
 }
 type testEditorRetriever struct{}
 
@@ -683,7 +763,11 @@ func (s testSurveyor) EditFields(e *shared.Editable, _ string) error {
 	e.Title.Value = "new title"
 	e.Body.Value = "new body"
 	if !s.skipReviewers {
-		e.Reviewers.Value = []string{"monalisa", "hubot", "OWNER/core", "OWNER/external"}
+		if s.removeAllReviewers {
+			e.Reviewers.Remove = []string{"monalisa", "hubot", "OWNER/core", "OWNER/external"}
+		} else {
+			e.Reviewers.Value = []string{"monalisa", "hubot", "OWNER/core", "OWNER/external"}
+		}
 	}
 	e.Assignees.Value = []string{"monalisa", "hubot"}
 	e.Labels.Value = []string{"feature", "TODO", "bug"}


### PR DESCRIPTION
Fixes #10958 

This PR fixes a bug that prevented users from removing all reviewers assigned to a PR. The cause was a guard clause that aborted further processing if the slices of user IDs and team IDs were either `nil` or empty, when it should have only checked against `nil`.

## Acceptance Criteria

### Removing user reviewer

**Given** I have a PR with **only** a user reviewer assigned to it
**When** I run `gh pr edit --remove-reviewer <user>`
**Then** the PR is updated and has no reviewers

**Works as expected; tested on the current PR.**

### Removing team reviewer

**Given** I have a PR with **only** a team reviewer assigned to it
**When** I run `gh pr edit --remove-reviewer <org>/<team>`
**Then** the PR is updated and has no reviewers

**Works as expected; tested on a test org with teams.**

### Removing both

**Given** I have a PR with both a user and a team reviewer assigned to it
**When** I run `gh pr edit --remove-reviewer <user>,<org>/<team>`
**Then** the PR is updated and has no reviewers

**Works as expected; tested on the current PR.**

