### PR TITLE
Fix accessible prompter flaky tests

### DIFF
--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -34,7 +34,7 @@ import (
 // but doesn't mandate that prompts always look exactly the same.
 func TestAccessiblePrompter(t *testing.T) {
 
-	beforePasswordSendTimeout := 20 * time.Microsecond
+	beforePasswordSendTimeout := 100 * time.Microsecond
 
 	t.Run("Select", func(t *testing.T) {
 		console := newTestVirtualTerminal(t)


### PR DESCRIPTION
Fixes #10976 

This PR just increases the `beforePasswordSendTimeout` from 20 ms to 100 ms.
