### PR TITLE
`gh pr edit`: Assign actors to pull requests

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -84,6 +84,7 @@ type PullRequest struct {
 	}
 
 	Assignees      Assignees
+	AssignedActors AssignedActors
 	Labels         Labels
 	ProjectCards   ProjectCards
 	ProjectItems   ProjectItems

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -922,7 +922,7 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 			g.Go(func() error {
 				actors, err := RepoAssignableActors(client, repo)
 				if err != nil {
-					return fmt.Errorf("error fetching assignees: %w", err)
+					return fmt.Errorf("error fetching assignable actors: %w", err)
 				}
 				result.AssignableActors = actors
 
@@ -943,7 +943,7 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 			g.Go(func() error {
 				users, err := RepoAssignableUsers(client, repo)
 				if err != nil {
-					err = fmt.Errorf("error fetching assignees: %w", err)
+					err = fmt.Errorf("error fetching assignable users: %w", err)
 				}
 				result.AssignableUsers = users
 				return err

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -918,39 +918,30 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 	var g errgroup.Group
 
 	if input.Assignees || input.Reviewers {
-
 		if input.ActorAssignees {
 			g.Go(func() error {
 				actors, err := RepoAssignableActors(client, repo)
 				if err != nil {
-					err = fmt.Errorf("error fetching assignees: %w", err)
+					return fmt.Errorf("error fetching assignees: %w", err)
 				}
 				result.AssignableActors = actors
-				return err
-			})
 
-			// If reviewers are also requested, we still need to fetch the assignable users
-			// since commands use assignable users for reviewers too,
-			// but Actors are not supported for requesting review (need to confirm this).
-			// TODO KW: find out how to do this in the above query so we don't need to
-			// run two potentially expensive queries. When we fetch Actors, this
-			// should still return Users - Users are distinguishable from other Actors
-			// by having a name property. Maybe we can use the Name to filter out
-			// non-user Actors and populate the users list for reviewers based on
-			// that.
-			// Note: this only matters for `gh pr` flows, which currently does not
-			// request actor assignees, so we probably won't hit this until
-			// `gh pr` reqeuests actor assignees.
-			if input.Reviewers {
-				g.Go(func() error {
-					users, err := RepoAssignableUsers(client, repo)
-					if err != nil {
-						err = fmt.Errorf("error fetching assignees: %w", err)
+				// Processing the bots out from the actors
+				// because requesting a reviewer leverages
+				// result.AssignableUsers.
+				// Note: this prevents us from needing to make another
+				// request to fetch assignable users when the user has
+				// selected to modify both reviewers and assignees.
+				var users []AssignableUser
+				for _, a := range actors {
+					if _, ok := a.(AssignableUser); !ok {
+						continue
 					}
-					result.AssignableUsers = users
-					return err
-				})
-			}
+					users = append(users, a.(AssignableUser))
+				}
+				result.AssignableUsers = users
+				return nil
+			})
 		} else {
 			// Not using Actors, fetch legacy assignable users.
 			g.Go(func() error {
@@ -962,7 +953,6 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 				return err
 			})
 		}
-
 	}
 
 	if input.Reviewers {

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -696,7 +696,7 @@ func (m *RepoMetadataResult) MembersToIDs(names []string) ([]string, error) {
 	for _, assigneeLogin := range names {
 		found := false
 		for _, u := range m.AssignableUsers {
-			if strings.EqualFold(assigneeLogin, (u.Login())) {
+			if strings.EqualFold(assigneeLogin, u.Login()) {
 				ids = append(ids, u.ID())
 				found = true
 				break

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -926,12 +926,8 @@ func RepoMetadata(client *Client, repo ghrepo.Interface, input RepoMetadataInput
 				}
 				result.AssignableActors = actors
 
-				// Processing the bots out from the actors
-				// because requesting a reviewer leverages
-				// result.AssignableUsers.
-				// Note: this prevents us from needing to make another
-				// request to fetch assignable users when the user has
-				// selected to modify both reviewers and assignees.
+				// Filter actors for users to use for pull request reviewers,
+				// skip retrieving the same info through RepoAssignableUsers().
 				var users []AssignableUser
 				for _, a := range actors {
 					if _, ok := a.(AssignableUser); !ok {

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -238,7 +238,7 @@ func editRun(opts *EditOptions) error {
 	editable.Base.Default = pr.BaseRefName
 	editable.Reviewers.Default = pr.ReviewRequests.Logins()
 	if issueFeatures.ActorIsAssignable {
-		// editable.Assignees.ActorAssignees = true
+		editable.Assignees.ActorAssignees = true
 		editable.Assignees.Default = pr.AssignedActors.Logins()
 	} else {
 		editable.Assignees.Default = pr.Assignees.Logins()

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -201,12 +201,12 @@ func editRun(opts *EditOptions) error {
 		Detector: opts.Detector,
 	}
 
-	if opts.Detector == nil {
-		httpClient, err := opts.HttpClient()
-		if err != nil {
-			return err
-		}
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
 
+	if opts.Detector == nil {
 		baseRepo, err := opts.BaseRepo()
 		if err != nil {
 			return err
@@ -262,10 +262,6 @@ func editRun(opts *EditOptions) error {
 		}
 	}
 
-	httpClient, err := opts.HttpClient()
-	if err != nil {
-		return err
-	}
 	apiClient := api.NewClientFromHTTP(httpClient)
 
 	opts.IO.StartProgressIndicator()

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -21,9 +21,6 @@ import (
 type EditOptions struct {
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
-	// TODO projectsV1Deprecation
-	// Remove this detector since it is only used for test validation.
-	Detector fd.Detector
 
 	Finder          shared.PRFinder
 	Surveyor        Surveyor

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -507,9 +507,11 @@ func Test_editRun(t *testing.T) {
 			tt.httpStubs(reg)
 
 			httpClient := func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
+			baseRepo := func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil }
 
 			tt.input.IO = ios
 			tt.input.HttpClient = httpClient
+			tt.input.BaseRepo = baseRepo
 
 			err := editRun(tt.input)
 			assert.NoError(t, err)

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -500,7 +500,7 @@ func Test_editRun(t *testing.T) {
 			stdout: "https://github.com/OWNER/REPO/pull/123\n",
 		},
 		{
-			name: "Legacy assignee user are fetched and updated on unsupported GitHub Hosts",
+			name: "Legacy assignee users are fetched and updated on unsupported GitHub Hosts",
 			input: &EditOptions{
 				Detector:    &fd.DisabledDetectorMock{},
 				SelectorArg: "123",

--- a/pkg/cmd/pr/shared/editable_http.go
+++ b/pkg/cmd/pr/shared/editable_http.go
@@ -103,7 +103,7 @@ func replaceActorAssigneesForEditable(apiClient *api.Client, repo ghrepo.Interfa
 
 	var mutation struct {
 		ReplaceActorsForAssignable struct {
-			Typename string `graphql:"__typename"`
+			TypeName string `graphql:"__typename"`
 		} `graphql:"replaceActorsForAssignable(input: $input)"`
 	}
 


### PR DESCRIPTION
### Description

This introduces support for handling "Actor" assignees (e.g., bots) in addition to user assignees for pull requests. The changes include updates to GraphQL queries and associated tests to accommodate this new functionality.

These changes cover both interactive and non-interactive (flags) flows.

> [!NOTE]
> This intentionally does not merge into trunk, as part of a stacked PR workflow.
> Please only merge once #10960 has merged


### Acceptance Criteria

> **Given** I have a PR where an Actor is assignable
> **Given** I am authenticated with a GitHub host that supports the `Actor` type.
> **When** I run `gh pr edit <issuenum>` and select to edit `Assignees`
> **Then**  I receive a list of assignees that includes assignable Actors, and the Actors already assigned to the PR are pre-selected.
> **When** I select one or more Actors from the list, and proceed
> **Then** I see those selected Actors assigned to the pr


```
❯ gh pr edit 2
? What would you like to edit? Assignees
? Assignees  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
> [x]  ActorToad
  [x]  BagToad
```

> **Given** I have a PR where an Actor is assignable and
> **Given** I am authenticated with a GitHub host that supports the `Actor` type.
> **When** I run `gh pr edit <issuenum> --add-assignee <actorname>...`
> **Then** I see the specified Actor(s) are assigned to the PR

```
❯ gh pr edit 2 --add-assignee ActorToad
https://github.com/BagToad/reponame/pull/2
```

> **Given** I have a pr where an Actor is assigned already
> **Given** I am authenticated with a GitHub host that supports the `Actor` type.
> **When** I run `gh pr edit <issuenum> --remove-assignee <actorname>...`
> **Then** I see the specified Actor(s) are unassigned from the PR

```
❯ gh pr edit 2 --remove-assignee ActorToad
https://github.com/BagToad/reponame/pull/2
```

> [!NOTE]
> omitted `gh pr view` commands to prove the above because `pr view` doesn't return the non-user assignees, and that's expected. The above AC was verified by viewing the PRs in a browser. 

