### PR TITLE
`issue edit`, `pr edit`: Support special non-interactive (flags) assignee name `@copilot`

### DIFF
--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -60,11 +60,17 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 
 			Editing issues' projects requires authorization with the %[1]sproject%[1]s scope.
 			To authorize, run %[1]sgh auth refresh -s project%[1]s.
+
+			The %[1]s--add-assignee%[1]s and %[1]s--remove-assignee%[1]s flags both support
+			the following special values:
+			- %[1]s@me%[1]s: assign or unassign yourself
+			- %[1]s@copilot%[1]s: assign or unassign Copilot
 		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh issue edit 23 --title "I found a bug" --body "Nothing works"
 			$ gh issue edit 23 --add-label "bug,help wanted" --remove-label "core"
 			$ gh issue edit 23 --add-assignee "@me" --remove-assignee monalisa,hubot
+			$ gh issue edit 23 --add-assignee "@copilot"
 			$ gh issue edit 23 --add-project "Roadmap" --remove-project v1,v2
 			$ gh issue edit 23 --milestone "Version 1"
 			$ gh issue edit 23 --remove-milestone

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -64,7 +64,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			The %[1]s--add-assignee%[1]s and %[1]s--remove-assignee%[1]s flags both support
 			the following special values:
 			- %[1]s@me%[1]s: assign or unassign yourself
-			- %[1]s@copilot%[1]s: assign or unassign Copilot
+			- %[1]s@copilot%[1]s: assign or unassign Copilot (not supported on GitHub Enterprise Server)
 		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh issue edit 23 --title "I found a bug" --body "Nothing works"

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -64,7 +64,10 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			The %[1]s--add-assignee%[1]s and %[1]s--remove-assignee%[1]s flags both support
 			the following special values:
 			- %[1]s@me%[1]s: assign or unassign yourself
-			- %[1]s@copilot%[1]s: assign or unassign Copilot
+			- %[1]s@copilot%[1]s: assign or unassign Copilot (not supported on GitHub Enterprise Server)
+
+			The %[1]s--add-reviewer%[1]s and %[1]s--remove-reviewer%[1]s flags do not support
+			these special values.
 		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh pr edit 23 --title "I found a bug" --body "Nothing works"

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -60,12 +60,18 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 
 			Editing a pull request's projects requires authorization with the %[1]sproject%[1]s scope.
 			To authorize, run %[1]sgh auth refresh -s project%[1]s.
+
+			The %[1]s--add-assignee%[1]s and %[1]s--remove-assignee%[1]s flags both support
+			the following special values:
+			- %[1]s@me%[1]s: assign or unassign yourself
+			- %[1]s@copilot%[1]s: assign or unassign Copilot
 		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh pr edit 23 --title "I found a bug" --body "Nothing works"
 			$ gh pr edit 23 --add-label "bug,help wanted" --remove-label "core"
 			$ gh pr edit 23 --add-reviewer monalisa,hubot  --remove-reviewer myorg/team-name
 			$ gh pr edit 23 --add-assignee "@me" --remove-assignee monalisa,hubot
+			$ gh pr edit 23 --add-assignee "@copilot"
 			$ gh pr edit 23 --add-project "Roadmap" --remove-project v1,v2
 			$ gh pr edit 23 --milestone "Version 1"
 			$ gh pr edit 23 --remove-milestone

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -128,10 +128,7 @@ func (e Editable) AssigneeIds(client *api.Client, repo ghrepo.Interface) (*[]str
 
 			// Only suppported for actor assignees.
 			if e.Assignees.ActorAssignees {
-				replaced, err = copilotReplacer.ReplaceSlice(replaced)
-				if err != nil {
-					return nil, err
-				}
+				replaced = copilotReplacer.ReplaceSlice(replaced)
 			}
 
 			return replaced, nil

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -120,7 +120,6 @@ func (e Editable) AssigneeIds(client *api.Client, repo ghrepo.Interface) (*[]str
 		meReplacer := NewMeReplacer(client, repo.RepoHost())
 		copilotReplacer := NewCopilotReplacer()
 
-		// A closure to replace special assignee names with the actual logins.
 		replaceSpecialAssigneeNames := func(value []string) ([]string, error) {
 			replaced, err := meReplacer.ReplaceSlice(value)
 			if err != nil {

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -320,22 +320,18 @@ func NewCopilotReplacer() *CopilotReplacer {
 	return &CopilotReplacer{}
 }
 
-func (r *CopilotReplacer) replace(handle string) (string, error) {
+func (r *CopilotReplacer) replace(handle string) string {
 	if strings.EqualFold(handle, "@copilot") {
-		return "copilot-swe-agent", nil
+		return "copilot-swe-agent"
 	}
-	return handle, nil
+	return handle
 }
 
 // Replace replaces usages of `@copilot` in a slice with Copilot's login.
-func (r *CopilotReplacer) ReplaceSlice(handles []string) ([]string, error) {
+func (r *CopilotReplacer) ReplaceSlice(handles []string) []string {
 	res := make([]string, len(handles))
 	for i, h := range handles {
-		var err error
-		res[i], err = r.replace(h)
-		if err != nil {
-			return nil, err
-		}
+		res[i] = r.replace(h)
 	}
-	return res, nil
+	return res
 }

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -312,3 +312,30 @@ func (r *MeReplacer) ReplaceSlice(handles []string) ([]string, error) {
 	}
 	return res, nil
 }
+
+// CopilotReplacer resolves usages of `@copilot` to Copilot's login.
+type CopilotReplacer struct{}
+
+func NewCopilotReplacer() *CopilotReplacer {
+	return &CopilotReplacer{}
+}
+
+func (r *CopilotReplacer) replace(handle string) (string, error) {
+	if strings.EqualFold(handle, "@copilot") {
+		return "copilot-swe-agent", nil
+	}
+	return handle, nil
+}
+
+// Replace replaces usages of `@copilot` in a slice with Copilot's login.
+func (r *CopilotReplacer) ReplaceSlice(handles []string) ([]string, error) {
+	res := make([]string, len(handles))
+	for i, h := range handles {
+		var err error
+		res[i], err = r.replace(h)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -233,8 +233,7 @@ func TestCopilotReplacer_ReplaceSlice(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewCopilotReplacer()
-			got, err := r.ReplaceSlice(tt.args.handles)
-			require.NoError(t, err)
+			got := r.ReplaceSlice(tt.args.handles)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -192,42 +192,51 @@ func TestCopilotReplacer_ReplaceSlice(t *testing.T) {
 		handles []string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    []string
-		wantErr bool
+		name string
+		args args
+		want []string
 	}{
 		{
 			name: "replaces @copilot with copilot-swe-agent",
 			args: args{
 				handles: []string{"monalisa", "@copilot", "hubot"},
 			},
-			want:    []string{"monalisa", "copilot-swe-agent", "hubot"},
-			wantErr: false,
+			want: []string{"monalisa", "copilot-swe-agent", "hubot"},
 		},
 		{
 			name: "handles no @copilot mentions",
 			args: args{
 				handles: []string{"monalisa", "user", "hubot"},
 			},
-			want:    []string{"monalisa", "user", "hubot"},
-			wantErr: false,
+			want: []string{"monalisa", "user", "hubot"},
 		},
 		{
 			name: "replaces multiple @copilot mentions",
 			args: args{
 				handles: []string{"@copilot", "user", "@copilot"},
 			},
-			want:    []string{"copilot-swe-agent", "user", "copilot-swe-agent"},
-			wantErr: false,
+			want: []string{"copilot-swe-agent", "user", "copilot-swe-agent"},
 		},
 		{
 			name: "handles @copilot case-insensitively",
 			args: args{
 				handles: []string{"@Copilot", "user", "@CoPiLoT"},
 			},
-			want:    []string{"copilot-swe-agent", "user", "copilot-swe-agent"},
-			wantErr: false,
+			want: []string{"copilot-swe-agent", "user", "copilot-swe-agent"},
+		},
+		{
+			name: "handles nil slice",
+			args: args{
+				handles: nil,
+			},
+			want: []string{},
+		},
+		{
+			name: "handles empty slice",
+			args: args{
+				handles: []string{},
+			},
+			want: []string{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -187,6 +187,59 @@ func TestMeReplacer_Replace(t *testing.T) {
 	}
 }
 
+func TestCopilotReplacer_ReplaceSlice(t *testing.T) {
+	type args struct {
+		handles []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "replaces @copilot with copilot-swe-agent",
+			args: args{
+				handles: []string{"monalisa", "@copilot", "hubot"},
+			},
+			want:    []string{"monalisa", "copilot-swe-agent", "hubot"},
+			wantErr: false,
+		},
+		{
+			name: "handles no @copilot mentions",
+			args: args{
+				handles: []string{"monalisa", "user", "hubot"},
+			},
+			want:    []string{"monalisa", "user", "hubot"},
+			wantErr: false,
+		},
+		{
+			name: "replaces multiple @copilot mentions",
+			args: args{
+				handles: []string{"@copilot", "user", "@copilot"},
+			},
+			want:    []string{"copilot-swe-agent", "user", "copilot-swe-agent"},
+			wantErr: false,
+		},
+		{
+			name: "handles @copilot case-insensitively",
+			args: args{
+				handles: []string{"@Copilot", "user", "@CoPiLoT"},
+			},
+			want:    []string{"copilot-swe-agent", "user", "copilot-swe-agent"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewCopilotReplacer()
+			got, err := r.ReplaceSlice(tt.args.handles)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func Test_QueryHasStateClause(t *testing.T) {
 	tests := []struct {
 		searchQuery string


### PR DESCRIPTION
This introduces functionality to handle `@copilot` mentions in assignee flag lists by replacing them with the appropriate login.