### PR TITLE
Revert "[gh config] Escape pipe symbol in Long desc for website manual"

### DIFF
--- a/internal/docs/markdown.go
+++ b/internal/docs/markdown.go
@@ -142,8 +142,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 		fmt.Fprintf(w, "```\n%s\n```\n\n", cmd.UseLine())
 	}
 	if hasLong {
-		longWithEscapedPipe := strings.ReplaceAll(cmd.Long, "|", "&#124;")
-		fmt.Fprintf(w, "%s\n\n", longWithEscapedPipe)
+		fmt.Fprintf(w, "%s\n\n", cmd.Long)
 	}
 
 	for _, g := range root.GroupedCommands(cmd) {

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -16,7 +16,7 @@ import (
 func NewCmdConfig(f *cmdutil.Factory) *cobra.Command {
 	longDoc := strings.Builder{}
 	longDoc.WriteString("Display or change configuration settings for gh.\n\n")
-	longDoc.WriteString("Current respected settings:\n\n")
+	longDoc.WriteString("Current respected settings:\n")
 	for _, co := range config.Options {
 		longDoc.WriteString(fmt.Sprintf("- `%s`: %s", co.Key, co.Description))
 		if len(co.AllowedValues) > 0 {


### PR DESCRIPTION
Reverts cli/cli#10371

Part of a fix for https://github.com/cli/cli/issues/10678