### PR TITLE
Fix brew update notifications

### DIFF
--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -29,14 +29,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// updaterEnabled is a statically linked build property set in gh formula within homebrew/homebrew-core
-// used to control whether users are notified of newer GitHub CLI releases.
-// This needs to be set to 'cli/cli' as it affects where update.CheckForUpdate() checks for releases.
-// It is unclear whether this means that only homebrew builds will check for updates or not.
-// Development builds leave this empty as impossible to determine if newer or not.
-// For more information, <https://github.com/Homebrew/homebrew-core/blob/master/Formula/g/gh.rb>.
-var updaterEnabled = ""
-
 type exitCode int
 
 const (

--- a/internal/ghcmd/update_disabled.go
+++ b/internal/ghcmd/update_disabled.go
@@ -2,10 +2,5 @@
 
 package ghcmd
 
-// updaterEnabled is a statically linked build property set in gh formula within homebrew/homebrew-core
-// used to control whether users are notified of newer GitHub CLI releases.
-// This needs to be set to 'cli/cli' as it affects where update.CheckForUpdate() checks for releases.
-// It is unclear whether this means that only homebrew builds will check for updates or not.
-// Development builds leave this empty as impossible to determine if newer or not.
-// For more information, <https://github.com/Homebrew/homebrew-core/blob/master/Formula/g/gh.rb>.
+// See update_enabled.go comment for more information.
 var updaterEnabled = ""

--- a/internal/ghcmd/update_disabled.go
+++ b/internal/ghcmd/update_disabled.go
@@ -1,0 +1,11 @@
+//go:build !updateable
+
+package ghcmd
+
+// updaterEnabled is a statically linked build property set in gh formula within homebrew/homebrew-core
+// used to control whether users are notified of newer GitHub CLI releases.
+// This needs to be set to 'cli/cli' as it affects where update.CheckForUpdate() checks for releases.
+// It is unclear whether this means that only homebrew builds will check for updates or not.
+// Development builds leave this empty as impossible to determine if newer or not.
+// For more information, <https://github.com/Homebrew/homebrew-core/blob/master/Formula/g/gh.rb>.
+var updaterEnabled = ""

--- a/internal/ghcmd/update_enabled.go
+++ b/internal/ghcmd/update_enabled.go
@@ -2,10 +2,17 @@
 
 package ghcmd
 
-// updaterEnabled is a statically linked build property set in gh formula within homebrew/homebrew-core
-// used to control whether users are notified of newer GitHub CLI releases.
-// This needs to be set to 'cli/cli' as it affects where update.CheckForUpdate() checks for releases.
-// It is unclear whether this means that only homebrew builds will check for updates or not.
-// Development builds leave this empty as impossible to determine if newer or not.
-// For more information, <https://github.com/Homebrew/homebrew-core/blob/master/Formula/g/gh.rb>.
+// `updateable` is a build tag set in the gh formula within homebrew/homebrew-core
+// and is used to control whether users are notified of newer GitHub CLI releases.
+//
+// Currently, updaterEnabled needs to be set to 'cli/cli' as it affects where
+// update.CheckForUpdate() checks for releases. It is unclear to what extent
+// this updaterEnabled is being used by unofficial forks or builds, so we decided
+// to leave it available for injection as a string variable for now.
+//
+// Development builds do not generate update messages by default.
+//
+// For more information, see:
+// - the Homebrew formula for gh: <https://github.com/Homebrew/homebrew-core/blob/master/Formula/g/gh.rb>.
+// - a discussion about adding this build tag: <https://github.com/cli/cli/pull/11024#discussion_r2107597618>.
 var updaterEnabled = "cli/cli"

--- a/internal/ghcmd/update_enabled.go
+++ b/internal/ghcmd/update_enabled.go
@@ -1,0 +1,11 @@
+//go:build updateable
+
+package ghcmd
+
+// updaterEnabled is a statically linked build property set in gh formula within homebrew/homebrew-core
+// used to control whether users are notified of newer GitHub CLI releases.
+// This needs to be set to 'cli/cli' as it affects where update.CheckForUpdate() checks for releases.
+// It is unclear whether this means that only homebrew builds will check for updates or not.
+// Development builds leave this empty as impossible to determine if newer or not.
+// For more information, <https://github.com/Homebrew/homebrew-core/blob/master/Formula/g/gh.rb>.
+var updaterEnabled = "cli/cli"

--- a/script/build.go
+++ b/script/build.go
@@ -55,7 +55,13 @@ var tasks = map[string]func(string) error{
 
 		buildTags, _ := os.LookupEnv("GO_BUILDTAGS")
 
-		return run("go", "build", "-trimpath", "-tags", buildTags, "-ldflags", ldflags, "-o", exe, "./cmd/gh")
+		args := []string{"go", "build", "-trimpath"}
+		if buildTags != "" {
+			args = append(args, "-tags", buildTags)
+		}
+		args = append(args, "-ldflags", ldflags, "-o", exe, "./cmd/gh")
+
+		return run(args...)
 	},
 	"manpages": func(_ string) error {
 		return run("go", "run", "./cmd/gen-docs", "--man-page", "--doc-path", "./share/man/man1/")

--- a/script/build.go
+++ b/script/build.go
@@ -53,7 +53,9 @@ var tasks = map[string]func(string) error{
 			ldflags = fmt.Sprintf("-X github.com/cli/cli/v2/internal/authflow.oauthClientID=%s %s", os.Getenv("GH_OAUTH_CLIENT_ID"), ldflags)
 		}
 
-		return run("go", "build", "-trimpath", "-ldflags", ldflags, "-o", exe, "./cmd/gh")
+		buildTags, _ := os.LookupEnv("GO_BUILDTAGS")
+
+		return run("go", "build", "-trimpath", "-tags", buildTags, "-ldflags", ldflags, "-o", exe, "./cmd/gh")
 	},
 	"manpages": func(_ string) error {
 		return run("go", "run", "./cmd/gen-docs", "--man-page", "--doc-path", "./share/man/man1/")


### PR DESCRIPTION
Fixes #10242 

### Description

This attempts to follow the suggestion in https://github.com/cli/cli/issues/10242#issuecomment-2822691143 to add a build tag for controlling the `updaterEnabled` value instead of a statically linked build property. I'm proposing this build tag be passed in via an environment variable, which means [Brew's build ](https://github.com/Homebrew/homebrew-core/blob/c9df24367b134397f03022199e0c426118c9979c/Formula/g/gh.rb#L34-L39) would be edited to look something like this:

```Ruby
    with_env(
      "GH_VERSION" => gh_version,
      "GO_LDFLAGS" => "-s -w",
      "GO_BUILDTAGS" => "updateable",
    ) do
      system "make", "bin/gh", "manpages"
    end
```

I decided to put it in the same `ghcmd` package so the var can remain un-exported. I needed to create two files so that we get one value when the build tag is set and another when it is not set; without the two files for the two cases, we get a compile error, as you'd expect.

### Testing

> [!NOTE]
> This testing was performed on a Mac. 

After checking out this branch...

```
# Delete the update cache
rm ~/.local/state/gh/state.yml

# Cleanup just in case
make clean 

# Build it with an "old" version and the correct build tag
GH_VERSION="0.0.1" GO_BUILDTAGS="updateable" make

# Run a somewhat long running command:
./bin/gh pr list
```

### Demo

```
❯ ./bin/gh pr list              

Showing 30 of 42 open pull requests in cli/cli

ID      TITLE                                 BRANCH                               CREATED AT            
<truncated for brevity>


A new release of gh is available: 0.0.1 → 2.73.0
https://github.com/cli/cli/releases/tag/v2.73.0

```