### PR TITLE
Add Digest to ReleaseAsset struct

### DIFF
--- a/pkg/cmd/release/shared/fetch.go
+++ b/pkg/cmd/release/shared/fetch.go
@@ -71,6 +71,7 @@ type ReleaseAsset struct {
 	Name   string
 	Label  string
 	Size   int64
+	Digest *string
 	State  string
 	APIURL string `json:"url"`
 
@@ -107,6 +108,7 @@ func (rel *Release) ExportData(fields []string) map[string]interface{} {
 					"name":          a.Name,
 					"label":         a.Label,
 					"size":          a.Size,
+					"digest":        a.Digest,
 					"state":         a.State,
 					"createdAt":     a.CreatedAt,
 					"updatedAt":     a.UpdatedAt,

--- a/pkg/cmd/release/view/view.go
+++ b/pkg/cmd/release/view/view.go
@@ -158,6 +158,11 @@ func renderReleaseTTY(io *iostreams.IOStreams, release *shared.Release) error {
 		table := tableprinter.New(io, tableprinter.NoHeader)
 		for _, a := range release.Assets {
 			table.AddField(a.Name)
+			if a.Digest == nil {
+				table.AddField("")
+			} else {
+				table.AddField(*a.Digest)
+			}
 			table.AddField(humanFileSize(a.Size))
 			table.EndRow()
 		}

--- a/pkg/cmd/release/view/view.go
+++ b/pkg/cmd/release/view/view.go
@@ -154,7 +154,6 @@ func renderReleaseTTY(io *iostreams.IOStreams, release *shared.Release) error {
 
 	if len(release.Assets) > 0 {
 		fmt.Fprintln(w, cs.Bold("Assets"))
-		//nolint:staticcheck // SA1019: Showing NAME|SIZE headers adds nothing to table.
 		table := tableprinter.New(io, tableprinter.WithHeader("Name", "Digest", "Size"))
 		for _, a := range release.Assets {
 			table.AddField(a.Name)

--- a/pkg/cmd/release/view/view.go
+++ b/pkg/cmd/release/view/view.go
@@ -155,7 +155,7 @@ func renderReleaseTTY(io *iostreams.IOStreams, release *shared.Release) error {
 	if len(release.Assets) > 0 {
 		fmt.Fprintln(w, cs.Bold("Assets"))
 		//nolint:staticcheck // SA1019: Showing NAME|SIZE headers adds nothing to table.
-		table := tableprinter.New(io, tableprinter.NoHeader)
+		table := tableprinter.New(io, tableprinter.WithHeader("Name", "Digest", "Size"))
 		for _, a := range release.Assets {
 			table.AddField(a.Name)
 			if a.Digest == nil {

--- a/pkg/cmd/release/view/view_test.go
+++ b/pkg/cmd/release/view/view_test.go
@@ -150,8 +150,8 @@ func Test_viewRun(t *testing.T) {
 				
 				
 				Assets
-				windows.zip  12 B
-				linux.tgz    34 B
+				windows.zip  sha256:deadc0de  12 B
+				linux.tgz                     34 B
 				
 				View on GitHub: https://github.com/OWNER/REPO/releases/tags/v1.2.3
 			`),
@@ -174,8 +174,8 @@ func Test_viewRun(t *testing.T) {
 
 
 				Assets
-				windows.zip  12 B
-				linux.tgz    34 B
+				windows.zip  sha256:deadc0de  12 B
+				linux.tgz                     34 B
 
 				View on GitHub: https://github.com/OWNER/REPO/releases/tags/v1.2.3
 			`),
@@ -248,8 +248,8 @@ func Test_viewRun(t *testing.T) {
 				"published_at": "%[1]s",
 				"html_url": "https://github.com/OWNER/REPO/releases/tags/v1.2.3",
 				"assets": [
-					{ "name": "windows.zip", "size": 12 },
-					{ "name": "linux.tgz", "size": 34 }
+					{ "name": "windows.zip", "size": 12, "digest": "sha256:deadc0de" },
+					{ "name": "linux.tgz", "size": 34, "digest": null }
 				]
 			}`, tt.releasedAt.Format(time.RFC3339), tt.releaseBody))
 

--- a/pkg/cmd/release/view/view_test.go
+++ b/pkg/cmd/release/view/view_test.go
@@ -150,6 +150,7 @@ func Test_viewRun(t *testing.T) {
 				
 				
 				Assets
+				NAME         DIGEST           SIZE
 				windows.zip  sha256:deadc0de  12 B
 				linux.tgz                     34 B
 				
@@ -174,6 +175,7 @@ func Test_viewRun(t *testing.T) {
 
 
 				Assets
+				NAME         DIGEST           SIZE
 				windows.zip  sha256:deadc0de  12 B
 				linux.tgz                     34 B
 


### PR DESCRIPTION
Exposes the release asset digest as part of the `release view` command.

When available, the digest will be included as part of the table of asset information displayed:

```
$ gh release view v5 --repo bdehamer/delme 

v5
bdehamer released this about 13 days ago

  important release notes                                                                                   


Assets
a.zip  sha256:f7165848f9f5ddc578d7adbd1f566a394169385c73bd88bf60df7e759db8e08d  797 B
b.zip  sha256:8b7eb1572346692ffd3ae01248c70a341ae3aa8be1df8b12346b50acb9002282  5.41 KiB

View on GitHub: https://github.com/bdehamer/delme/releases/tag/v5
```

Will also appear in the JSON output for release assets:

```
$ gh release view v5 --repo bdehamer/delme --json assets

{
  "assets": [
    {
      "apiUrl": "https://api.github.com/repos/bdehamer/delme/releases/assets/254398346",
      "contentType": "application/zip",
      "createdAt": "2025-05-13T23:02:36Z",
      "digest": "sha256:f7165848f9f5ddc578d7adbd1f566a394169385c73bd88bf60df7e759db8e08d",
      "downloadCount": 2,
      "id": "RA_kwDONgBHzM4PKc-K",
      "label": "",
      "name": "a.zip",
      "size": 797,
      "state": "uploaded",
      "updatedAt": "2025-05-13T23:02:36Z",
      "url": "https://github.com/bdehamer/delme/releases/download/v5/a.zip"
    },
    {
      "apiUrl": "https://api.github.com/repos/bdehamer/delme/releases/assets/254398345",
      "contentType": "application/zip",
      "createdAt": "2025-05-13T23:02:35Z",
      "digest": "sha256:8b7eb1572346692ffd3ae01248c70a341ae3aa8be1df8b12346b50acb9002282",
      "downloadCount": 2,
      "id": "RA_kwDONgBHzM4PKc-J",
      "label": "",
      "name": "b.zip",
      "size": 5544,
      "state": "uploaded",
      "updatedAt": "2025-05-13T23:02:36Z",
      "url": "https://github.com/bdehamer/delme/releases/download/v5/b.zip"
    }
  ]
}
```

The digest is a null'able field in the releases API and may not be available for all assets. When not present, a null value will be displayed in the output.

```
$ gh release view v1.1.0 --repo bdehamer/attest-demo --json assets

{
  "assets": [
    {
      "apiUrl": "https://api.github.com/repos/bdehamer/attest-demo/releases/assets/243811664",
      "contentType": "application/zip",
      "createdAt": "2025-04-05T16:40:13Z",
      "digest": null,
      "downloadCount": 2,
      "id": "RA_kwDOL0GfDc4OiEVQ",
      "label": "",
      "name": "artifact.zip",
      "size": 1639350,
      "state": "uploaded",
      "updatedAt": "2025-04-05T16:40:14Z",
      "url": "https://github.com/bdehamer/attest-demo/releases/download/v1.1.0/artifact.zip"
    }
  ]
}
```