### PR TITLE
Fix const in PR finder tests

### DIFF
--- a/pkg/cmd/pr/shared/finder_test.go
+++ b/pkg/cmd/pr/shared/finder_test.go
@@ -728,7 +728,7 @@ func TestFindAssignableActors(t *testing.T) {
 		pr, _, err := f.Find(FindOptions{
 			Detector: &fd.DisabledDetectorMock{},
 			Fields:   []string{"assignees"},
-			Selector: "https://github.com/cli/cli/pull/123",
+			Selector: "https://github.com/cli/cli/pull/13",
 		})
 		require.NoError(t, err)
 
@@ -772,7 +772,7 @@ func TestFindAssignableActors(t *testing.T) {
 		pr, _, err := f.Find(FindOptions{
 			Detector: &fd.EnabledDetectorMock{},
 			Fields:   []string{"assignees"},
-			Selector: "https://github.com/cli/cli/pull/123",
+			Selector: "https://github.com/cli/cli/pull/13",
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
Related to #11057

This is a small PR to fix a semantic error in our test case setups.

