### PR TITLE
feat: remove accents when creating branches using `gh issue develop <issue_id> --checkout`

### DIFF
--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -17,6 +17,8 @@ import (
 var whitespaceRE = regexp.MustCompile(`\s+`)
 var nonAlphanumericRE = regexp.MustCompile(`[^a-z0-9]+`)
 
+const maxBranchTitleLength = 200
+
 func Indent(s, indent string) string {
 	return text.Indent(s, indent)
 }
@@ -161,8 +163,8 @@ func GenerateBranchName(issueNumber int, title string) string {
 	cleanTitle = nonAlphanumericRE.ReplaceAllString(cleanTitle, "-")
 	cleanTitle = strings.Trim(cleanTitle, "-")
 
-	if len(cleanTitle) > 200 {
-		cleanTitle = cleanTitle[:200]
+	if len(cleanTitle) > maxBranchTitleLength {
+		cleanTitle = cleanTitle[:maxBranchTitleLength]
 		cleanTitle = strings.Trim(cleanTitle, "-")
 	}
 

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -15,6 +15,7 @@ import (
 )
 
 var whitespaceRE = regexp.MustCompile(`\s+`)
+var nonAlphanumericRE = regexp.MustCompile(`[^a-z0-9]+`)
 
 func Indent(s, indent string) string {
 	return text.Indent(s, indent)
@@ -157,7 +158,7 @@ func GenerateBranchName(issueNumber int, title string) string {
 	cleanTitle := RemoveDiacritics(title)
 
 	cleanTitle = strings.ToLower(cleanTitle)
-	cleanTitle = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(cleanTitle, "-")
+	cleanTitle = nonAlphanumericRE.ReplaceAllString(cleanTitle, "-")
 	cleanTitle = strings.Trim(cleanTitle, "-")
 
 	if len(cleanTitle) > 200 {

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -149,3 +149,25 @@ func FormatSlice(values []string, lineLength uint, indent uint, prependWith stri
 	}
 	return builder.String()
 }
+
+// GenerateBranchName creates a sanitized branch name from an issue number and title.
+// The resulting branch name follows the format "{issueNumber}-{cleanTitle}" or just "{issueNumber}"
+// if the title becomes empty after sanitization.
+func GenerateBranchName(issueNumber int, title string) string {
+	cleanTitle := RemoveDiacritics(title)
+
+	cleanTitle = strings.ToLower(cleanTitle)
+	cleanTitle = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(cleanTitle, "-")
+	cleanTitle = strings.Trim(cleanTitle, "-")
+
+	if len(cleanTitle) > 200 {
+		cleanTitle = cleanTitle[:200]
+		cleanTitle = strings.Trim(cleanTitle, "-")
+	}
+
+	if cleanTitle == "" {
+		return fmt.Sprintf("%d", issueNumber)
+	}
+
+	return fmt.Sprintf("%d-%s", issueNumber, cleanTitle)
+}

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -181,3 +181,67 @@ func TestDisplayURL(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateBranchName(t *testing.T) {
+	tests := []struct {
+		name        string
+		issueNumber int
+		title       string
+		want        string
+	}{
+		{
+			name:        "simple title",
+			issueNumber: 123,
+			title:       "Fix bug in parser",
+			want:        "123-fix-bug-in-parser",
+		},
+		{
+			name:        "title with special characters",
+			issueNumber: 456,
+			title:       "Add support for @mentions & #hashtags!",
+			want:        "456-add-support-for-mentions-hashtags",
+		},
+		{
+			name:        "title with accents",
+			issueNumber: 789,
+			title:       "Améliorer la qualité du código",
+			want:        "789-ameliorer-la-qualite-du-codigo",
+		},
+		{
+			name:        "empty title",
+			issueNumber: 999,
+			title:       "",
+			want:        "999",
+		},
+		{
+			name:        "title with only special characters",
+			issueNumber: 111,
+			title:       "!!!@@@###",
+			want:        "111",
+		},
+		{
+			name:        "very long title",
+			issueNumber: 222,
+			title:       "This is a very long title that should be truncated because it exceeds the maximum length limit of 200 characters and we need to make sure it gets properly truncated without breaking the branch name format and functionality",
+			want:        "222-this-is-a-very-long-title-that-should-be-truncated-because-it-exceeds-the-maximum-length-limit-of-200-characters-and-we-need-to-make-sure-it-gets-properly-truncated-without-breaking-the-branch-name-fo",
+		},
+		{
+			name:        "title with multiple consecutive special chars",
+			issueNumber: 333,
+			title:       "Fix   multiple---spaces___and___dashes",
+			want:        "333-fix-multiple-spaces-and-dashes",
+		},
+		{
+			name:        "title starting and ending with special chars",
+			issueNumber: 444,
+			title:       "---Fix this issue---",
+			want:        "444-fix-this-issue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GenerateBranchName(tt.issueNumber, tt.title))
+		})
+	}
+}

--- a/pkg/cmd/issue/develop/develop.go
+++ b/pkg/cmd/issue/develop/develop.go
@@ -191,20 +191,20 @@ func developRunCreate(opts *DevelopOptions, apiClient *api.Client, issueRepo ghr
 		return err
 	}
 
-	branchName := opts.Name
-	if branchName == "" {
-		branchName = text.GenerateBranchName(issue.Number, issue.Title)
+	requestedBranchName := opts.Name
+	if requestedBranchName == "" {
+		requestedBranchName = text.GenerateBranchName(issue.Number, issue.Title)
 	}
 
 	opts.IO.StartProgressIndicator()
-	createdBranchName, err := api.CreateLinkedBranch(apiClient, branchRepo.RepoHost(), repoID, issue.ID, branchID, branchName)
+	createdBranchName, err := api.CreateLinkedBranch(apiClient, branchRepo.RepoHost(), repoID, issue.ID, branchID, requestedBranchName)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
 	}
 
 	if opts.BaseBranch != "" {
-		err = opts.GitClient.SetBranchConfig(ctx.Background(), branchName, git.MergeBaseConfig, opts.BaseBranch)
+		err = opts.GitClient.SetBranchConfig(ctx.Background(), requestedBranchName, git.MergeBaseConfig, opts.BaseBranch)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/issue/develop/develop.go
+++ b/pkg/cmd/issue/develop/develop.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/tableprinter"
+	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -190,14 +191,18 @@ func developRunCreate(opts *DevelopOptions, apiClient *api.Client, issueRepo ghr
 		return err
 	}
 
+	branchName := opts.Name
+	if branchName == "" {
+		branchName = text.GenerateBranchName(issue.Number, issue.Title)
+	}
+
 	opts.IO.StartProgressIndicator()
-	branchName, err := api.CreateLinkedBranch(apiClient, branchRepo.RepoHost(), repoID, issue.ID, branchID, opts.Name)
+	createdBranchName, err := api.CreateLinkedBranch(apiClient, branchRepo.RepoHost(), repoID, issue.ID, branchID, branchName)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
 	}
 
-	// Remember which branch to target when creating a PR.
 	if opts.BaseBranch != "" {
 		err = opts.GitClient.SetBranchConfig(ctx.Background(), branchName, git.MergeBaseConfig, opts.BaseBranch)
 		if err != nil {
@@ -205,9 +210,9 @@ func developRunCreate(opts *DevelopOptions, apiClient *api.Client, issueRepo ghr
 		}
 	}
 
-	fmt.Fprintf(opts.IO.Out, "%s/%s/tree/%s\n", branchRepo.RepoHost(), ghrepo.FullName(branchRepo), branchName)
+	fmt.Fprintf(opts.IO.Out, "%s/%s/tree/%s\n", branchRepo.RepoHost(), ghrepo.FullName(branchRepo), createdBranchName)
 
-	return checkoutBranch(opts, branchRepo, branchName)
+	return checkoutBranch(opts, branchRepo, createdBranchName)
 }
 
 func developRunList(opts *DevelopOptions, apiClient *api.Client, issueRepo ghrepo.Interface, issue *api.Issue) error {

--- a/pkg/cmd/issue/develop/develop_test.go
+++ b/pkg/cmd/issue/develop/develop_test.go
@@ -511,6 +511,117 @@ func TestDevelopRun(t *testing.T) {
 			},
 			wantErr: "could not find branch \"does-not-exist-branch\" in OWNER/REPO",
 		},
+		{
+			name: "develop new branch with accents in title",
+			opts: &DevelopOptions{
+				IssueNumber: 456,
+			},
+			remotes: map[string]string{
+				"origin": "OWNER/REPO",
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`query LinkedBranchFeature\b`),
+					httpmock.StringResponse(featureEnabledPayload),
+				)
+				reg.Register(
+					httpmock.GraphQL(`query IssueByNumber\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"hasIssuesEnabled":true,"issue":{"id": "ISSUEID","number":456,"title":"Créer les tâches avec açã"}}}}`),
+				)
+				reg.Register(
+					httpmock.GraphQL(`query FindRepoBranchID\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"id":"REPOID","defaultBranchRef":{"target":{"oid":"DEFAULTOID"}},"ref":{"target":{"oid":""}}}}}`),
+				)
+				reg.Register(
+					httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
+					httpmock.GraphQLMutation(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"3","ref":{"name":"456-creer-les-taches-avec-aca"}}}}}`,
+						func(inputs map[string]interface{}) {
+							assert.Equal(t, "REPOID", inputs["repositoryId"])
+							assert.Equal(t, "ISSUEID", inputs["issueId"])
+							assert.Equal(t, "DEFAULTOID", inputs["oid"])
+							assert.Equal(t, "456-creer-les-taches-avec-aca", inputs["name"])
+						}),
+				)
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch origin \+refs/heads/456-creer-les-taches-avec-aca:refs/remotes/origin/456-creer-les-taches-avec-aca`, 0, "")
+			},
+			expectedOut: "github.com/OWNER/REPO/tree/456-creer-les-taches-avec-aca\n",
+		},
+		{
+			name: "develop new branch with mixed international characters",
+			opts: &DevelopOptions{
+				IssueNumber: 789,
+			},
+			remotes: map[string]string{
+				"origin": "OWNER/REPO",
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`query LinkedBranchFeature\b`),
+					httpmock.StringResponse(featureEnabledPayload),
+				)
+				reg.Register(
+					httpmock.GraphQL(`query IssueByNumber\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"hasIssuesEnabled":true,"issue":{"id": "MIXEDID","number":789,"title":"Añadir función para niños & múltiples caractères spéciaux"}}}}`),
+				)
+				reg.Register(
+					httpmock.GraphQL(`query FindRepoBranchID\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"id":"REPOID","defaultBranchRef":{"target":{"oid":"DEFAULTOID"}},"ref":{"target":{"oid":""}}}}}`),
+				)
+				reg.Register(
+					httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
+					httpmock.GraphQLMutation(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"4","ref":{"name":"789-anadir-funcion-para-ninos-multiples-caracteres-speciaux"}}}}}`,
+						func(inputs map[string]interface{}) {
+							assert.Equal(t, "REPOID", inputs["repositoryId"])
+							assert.Equal(t, "MIXEDID", inputs["issueId"])
+							assert.Equal(t, "DEFAULTOID", inputs["oid"])
+							assert.Equal(t, "789-anadir-funcion-para-ninos-multiples-caracteres-speciaux", inputs["name"])
+						}),
+				)
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch origin \+refs/heads/789-anadir-funcion-para-ninos-multiples-caracteres-speciaux:refs/remotes/origin/789-anadir-funcion-para-ninos-multiples-caracteres-speciaux`, 0, "")
+			},
+			expectedOut: "github.com/OWNER/REPO/tree/789-anadir-funcion-para-ninos-multiples-caracteres-speciaux\n",
+		},
+		{
+			name: "develop new branch with special characters only",
+			opts: &DevelopOptions{
+				IssueNumber: 999,
+			},
+			remotes: map[string]string{
+				"origin": "OWNER/REPO",
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`query LinkedBranchFeature\b`),
+					httpmock.StringResponse(featureEnabledPayload),
+				)
+				reg.Register(
+					httpmock.GraphQL(`query IssueByNumber\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"hasIssuesEnabled":true,"issue":{"id": "SPECIALID","number":999,"title":"!@#$%^&*()"}}}}`),
+				)
+				reg.Register(
+					httpmock.GraphQL(`query FindRepoBranchID\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"id":"REPOID","defaultBranchRef":{"target":{"oid":"DEFAULTOID"}},"ref":{"target":{"oid":""}}}}}`),
+				)
+				reg.Register(
+					httpmock.GraphQL(`mutation CreateLinkedBranch\b`),
+					httpmock.GraphQLMutation(`{"data":{"createLinkedBranch":{"linkedBranch":{"id":"5","ref":{"name":"999"}}}}}`,
+						func(inputs map[string]interface{}) {
+							assert.Equal(t, "REPOID", inputs["repositoryId"])
+							assert.Equal(t, "SPECIALID", inputs["issueId"])
+							assert.Equal(t, "DEFAULTOID", inputs["oid"])
+							assert.Equal(t, "999", inputs["name"])
+						}),
+				)
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch origin \+refs/heads/999:refs/remotes/origin/999`, 0, "")
+			},
+			expectedOut: "github.com/OWNER/REPO/tree/999\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
It avoids problems like this:
![image](https://github.com/user-attachments/assets/6a1a9dbc-7a6d-46b9-b471-37d36b124b8f)
