### PR TITLE
Add support of checking out closed PR whose branch is deleted

### DIFF
--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -171,6 +171,9 @@ func cmdsForExistingRemote(remote *cliContext.Remote, pr *api.PullRequest, opts 
 	remoteBranch := fmt.Sprintf("%s/%s", remote.Name, pr.HeadRefName)
 
 	refSpec := fmt.Sprintf("+refs/heads/%s", pr.HeadRefName)
+	if !pr.IsOpen() {
+		refSpec = fmt.Sprintf("+refs/pull/%d/head", pr.Number)
+	}
 	if !opts.Detach {
 		refSpec += fmt.Sprintf(":refs/remotes/%s", remoteBranch)
 	}

--- a/pkg/cmd/pr/checkout/checkout_test.go
+++ b/pkg/cmd/pr/checkout/checkout_test.go
@@ -554,6 +554,26 @@ func TestPRCheckout_existingBranch(t *testing.T) {
 	assert.Equal(t, "", output.Stderr())
 }
 
+func TestPRCheckout_closedPR(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	baseRepo, pr := _stubPR("OWNER/REPO", "OWNER/REPO:feature", 123, "PR title", "CLOSED", false)
+	shared.StubFinderForRunCommandStyleTests(t, "123", pr, baseRepo)
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+	cs.Register(`git fetch origin \+refs/pull/123/head:refs/remotes/origin/feature --no-tags`, 0, "")
+	cs.Register(`git show-ref --verify -- refs/heads/feature`, 0, "")
+	cs.Register(`git checkout feature`, 0, "")
+	cs.Register(`git merge --ff-only refs/remotes/origin/feature`, 0, "")
+
+	output, err := runCommand(http, nil, "master", `123`, baseRepo)
+	assert.NoError(t, err)
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, "", output.Stderr())
+}
+
 func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 	remotes := context.Remotes{
 		{


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Adds support of checking out a closed PR whose branch is deleted. Closes #8628.

In addition, if a branch with the same name as a closed PR exists, there is an issue where the new branch is checked out, which will also be fixed.
