### PR TITLE
Avoid requesting PR reviewer twice

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -709,19 +709,22 @@ func (m *RepoMetadataResult) MembersToIDs(names []string) ([]string, error) {
 		}
 
 		// Look for ID in assignable actors if not found in assignable users
-		for _, a := range m.AssignableActors {
-			if strings.EqualFold(assigneeLogin, a.Login()) {
-				ids = append(ids, a.ID())
-				found = true
-				break
-			}
-			if strings.EqualFold(assigneeLogin, a.DisplayName()) {
-				ids = append(ids, a.ID())
-				found = true
-				break
+		if !found {
+			for _, a := range m.AssignableActors {
+				if strings.EqualFold(assigneeLogin, a.Login()) {
+					ids = append(ids, a.ID())
+					found = true
+					break
+				}
+				if strings.EqualFold(assigneeLogin, a.DisplayName()) {
+					ids = append(ids, a.ID())
+					found = true
+					break
+				}
 			}
 		}
 
+		// And if we still didn't find an ID, return an error
 		if !found {
 			return nil, fmt.Errorf("'%s' not found", assigneeLogin)
 		}


### PR DESCRIPTION
# Description

Fixes https://github.com/cli/cli/issues/11097

A user can appear in both `assignableUsers` and `assignableActors`, so we need to only proceed to actors if we didn't find a mapping in users. I think this was probably @BagToad's intention but missed that the `break` only works one `for` loop deep.