### PR TITLE
Exclude 3rd party license compliance content from GHAS scanning

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,3 @@
+paths-ignore:
+  - 'third-party/**'
+  - 'third-party-licenses.*.md'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
+          config: |
+            paths-ignore:
+              - 'third-party/**'
+              - 'third-party-licenses.*.md'
 
       - name: Setup Go
         if: matrix.language == 'go'


### PR DESCRIPTION
Fixes #11126
Relates #11047 

These changes will cause GitHub Advanced Security to ignore the auto-generated content around 3rd party dependencies used by `cli/cli` from static code analysis and secret scanning.

For more information:

- https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning
- https://docs.github.com/en/code-security/secret-scanning/using-advanced-secret-scanning-and-push-protection-features/excluding-folders-and-files-from-secret-scanning

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
