### PR TITLE
Second fix for file not found in help-wanted check

### DIFF
--- a/.github/workflows/pr-help-wanted.yml
+++ b/.github/workflows/pr-help-wanted.yml
@@ -12,6 +12,9 @@ jobs:
   check-help-wanted:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Check for issues without help-wanted label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a step to the GitHub Actions workflow to ensure the repository is checked out before running the "Check for issues without help-wanted label" step.