### PR TITLE
Ensure gh executes in workflow check script

### DIFF
--- a/.github/workflows/pr-help-wanted.yml
+++ b/.github/workflows/pr-help-wanted.yml
@@ -20,8 +20,7 @@ jobs:
         if: !github.event.pull_request.draft
         run: |
           # Skip if PR is from a bot or org member
-          if [ "$PR_AUTHOR_TYPE" = "Bot" ] || "gh api orgs/cli/public_members/${PR_AUTHOR}" --silent 2>/dev/null
-          then
+          if [ "$PR_AUTHOR_TYPE" = "Bot" ] || gh api orgs/cli/public_members/"${PR_AUTHOR}" --silent 2>/dev/null; then
             exit 0
           fi
 


### PR DESCRIPTION
## Description

Pretty sure the quotes make the `gh` command not execute at all.