### PR TITLE
Improve help wanted check skipping logic

### DIFF
--- a/.github/workflows/pr-help-wanted.yml
+++ b/.github/workflows/pr-help-wanted.yml
@@ -20,12 +20,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+          PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
         if: "!github.event.pull_request.draft"
         run: |
-          # Skip if PR is from a bot or org member
-          if [ "$PR_AUTHOR_TYPE" = "Bot" ] || gh api orgs/cli/public_members/"${PR_AUTHOR}" --silent 2>/dev/null; then
-            exit 0
-          fi
-
           # Run the script to check for issues without help-wanted label
           bash .github/workflows/scripts/check-help-wanted.sh ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/scripts/check-help-wanted.sh
+++ b/.github/workflows/scripts/check-help-wanted.sh
@@ -12,6 +12,12 @@ if [ -z "$PR_URL" ]; then
     exit 1
 fi
 
+# Skip if PR is from a bot or org member
+if [ "$PR_AUTHOR_TYPE" = "Bot" ] || [ "$PR_AUTHOR_ASSOCIATION" = "MEMBER" ]; then
+    echo "Skipping check for PR #$PR_URL as it is from a bot ($PR_AUTHOR_TYPE) or an org member ($PR_AUTHOR_ASSOCIATION)"
+    exit 0
+fi
+
 # Extract PR number from URL for logging
 PR_NUM="$(basename "$PR_URL")"
 

--- a/.github/workflows/scripts/check-help-wanted.sh
+++ b/.github/workflows/scripts/check-help-wanted.sh
@@ -13,8 +13,8 @@ if [ -z "$PR_URL" ]; then
 fi
 
 # Skip if PR is from a bot or org member
-if [ "$PR_AUTHOR_TYPE" = "Bot" ] || [ "$PR_AUTHOR_ASSOCIATION" = "MEMBER" ]; then
-    echo "Skipping check for PR #$PR_URL as it is from a bot ($PR_AUTHOR_TYPE) or an org member ($PR_AUTHOR_ASSOCIATION)"
+if [ "$PR_AUTHOR_TYPE" = "Bot" ] || [ "$PR_AUTHOR_ASSOCIATION" = "MEMBER" ] || [ "$PR_AUTHOR_ASSOCIATION" = "OWNER" ]; then
+    echo "Skipping check for PR #$PR_URL as it is from a bot ($PR_AUTHOR_TYPE) or an org member ($PR_AUTHOR_ASSOCIATION: MEMBER/OWNER)"
     exit 0
 fi
 


### PR DESCRIPTION
- Moves more checks out of the workflow to the script
- Proposes using `PR_AUTHOR_ASSOCIATION` to skip checks for org members instead of an API call.