### PR TITLE
Bump Go to 1.24.4 - test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/cli/cli/v2
 
-go 1.23.0
+go 1.24
 
-toolchain go1.23.5
+toolchain go1.24.4
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
This PR updates Go to the latest stable release.

* **go directive:** `1.24`
* **toolchain:** `1.24.4`