### PR TITLE
Fix step order for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
@@ -36,12 +42,6 @@ jobs:
             paths-ignore:
               - 'third-party/**'
               - 'third-party-licenses.*.md'
-
-      - name: Setup Go
-        if: matrix.language == 'go'
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Our CodeQL workflow is showing a warning that:

> Go was installed after the `codeql-action/init` Action was run
> To avoid interfering with the CodeQL analysis, perform all installation steps before calling the github/codeql-action/init Action.

I'd like to address that warning by adjusting the step order as described by the warning. 