### PR TITLE
chore: update Go version to 1.24 in devcontainer configuration and docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/go:1.23",
+	"image": "mcr.microsoft.com/devcontainers/go:1.24",
 	"features": {
 		"ghcr.io/devcontainers/features/sshd:1": {}
 	},

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ We accept pull requests for bug fixes and features where we've discussed the app
 ## Building the project
 
 Prerequisites:
-- Go 1.23+
+- Go 1.24+
 
 Build with:
 * Unix-like systems: `make`

--- a/docs/source.md
+++ b/docs/source.md
@@ -1,6 +1,6 @@
 # Installation from source
 
-1. Verify that you have Go 1.23+ installed
+1. Verify that you have Go 1.24+ installed
 
    ```sh
    $ go version


### PR DESCRIPTION
Even though the Go version in go.mod was 1.24, the image in devcontainer.json was still 1.23.
This pull request updates the Go development container image to a newer version.
