### PR TITLE
Ensure automation uses pinned go-licenses version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,8 +54,11 @@ jobs:
       # actions/setup-go does not setup the installed toolchain to be preferred over the system install,
       # which causes go-licenses to raise "Package ... does not have module info" errors.
       # for more information, https://github.com/google/go-licenses/issues/244#issuecomment-1885098633
+      #
+      # go-licenses has been pinned for automation use.
       - name: Check licenses
         run: |
           export GOROOT=$(go env GOROOT)
           export PATH=${GOROOT}/bin:$PATH
+          go install github.com/google/go-licenses@5348b744d0983d85713295ea08a20cca1654a45e
           make licenses-check

--- a/script/licenses
+++ b/script/licenses
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-go install github.com/google/go-licenses@latest
+# Manage go-licenses version externally for CI
+if [ "$CI" != "true" ]; then
+    go install github.com/google/go-licenses@latest
+fi
 
 # Setup temporary directory to collect updated third-party source code
 export TEMPDIR="$(mktemp -d)"

--- a/script/licenses-check
+++ b/script/licenses-check
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-go install github.com/google/go-licenses@latest
+# Manage go-licenses version externally for CI
+if [ "$CI" != "true" ]; then
+    go install github.com/google/go-licenses@latest
+fi
 
 # Setup temporary directory for generated license reports
 export TEMPDIR="$(mktemp -d)"


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Relates #111
Relates #11047

This is a follow up regarding a concern raised by @bagtoad around pinning `go-licenses` version for CI purposes.

[GitHub Actions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables) and other CI tools set / respect the `CI` environment variable as a general indicator of CI/CD.  We could have also used `GITHUB_ACTIONS` env var, too.