### PR TITLE
Adding a note to `gh search` docs to explain the usage of `--` to exclude certain results

### DIFF
--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -305,7 +305,7 @@ var HelpTopics = []helpTopic{
 		`),
 	},
 	{
-		name:  "search",
+		name:  "search-syntax",
 		short: "Search syntax for gh commands",
 		long: heredoc.Docf(`
 			Excluding search results that match a qualifier

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -304,35 +304,6 @@ var HelpTopics = []helpTopic{
 			control some behavior.
 		`),
 	},
-	{
-		name:  "search-syntax",
-		short: "Search syntax for gh commands",
-		long: heredoc.Docf(`
-			Excluding search results that match a qualifier
-
-			In a browser, the GitHub search syntax supports excluding results that match a search qualifier
-			by prefixing the qualifier with a hyphen. For example, to search for issues that
-			do not have the label "bug", you would use %[1]s-label:bug%[1]s as a search qualifier.
-
-			%[1]sgh%[1]s supports this syntax in %[1]sgh search%[1]s as well, but it requires extra
-			syntax to avoid the hyphen being interpreted as a command line flag because it begins with a hyphen.
-
-			On Unix-like systems, you can use the %[1]s--%[1]s argument to indicate that
-			the arguments that follow are not a flag, but rather a query string. For example:
-
-			$ gh search issues -- "my-search-query -label:bug"
-
-			On PowerShell, you must use both the %[1]s--%[2]s%[1]s argument and the %[1]s--%[1]s argument to
-			produce the same effect. For example:
-
-			$ gh --%[2]s search issues -- "my search query -label:bug"
-
-			See the following for more information:
-			- GitHub search syntax: <https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#exclude-results-that-match-a-qualifier>
-			- The PowerShell stop parse flag %[1]s--%[2]s%[1]s: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing?view=powershell-7.5#the-stop-parsing-token>
-			- The Unix-like %[1]s--%[1]s argument: <https://www.gnu.org/software/bash/manual/bash.html#Shell-Builtin-Commands-1>
-		`, "`", "%"),
-	},
 }
 
 func NewCmdHelpTopic(ios *iostreams.IOStreams, ht helpTopic) *cobra.Command {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -304,6 +304,35 @@ var HelpTopics = []helpTopic{
 			control some behavior.
 		`),
 	},
+	{
+		name:  "search",
+		short: "Search syntax for gh commands",
+		long: heredoc.Docf(`
+			Excluding search results that match a qualifier
+
+			In a browser, the GitHub search syntax supports excluding results that match a search qualifier
+			by prefixing the qualifier with a hyphen. For example, to search for issues that
+			do not have the label "bug", you would use %[1]s-label:bug%[1]s as a search qualifier.
+
+			%[1]sgh%[1]s supports this syntax in %[1]sgh search%[1]s as well, but it requires extra
+			syntax to avoid the hyphen being interpreted as a command line flag because it begins with a hyphen.
+
+			On Unix-like systems, you can use the %[1]s--%[1]s argument to indicate that
+			the arguments that follow are not a flag, but rather a query string. For example:
+
+			$ gh search issues -- "my-search-query -label:bug"
+
+			On PowerShell, you must use both the %[1]s--%[2]s%[1]s argument and the %[1]s--%[1]s argument to
+			produce the same effect. For example:
+
+			$ gh --%[2]s search issues -- "my search query -label:bug"
+
+			See the following for more information:
+			- GitHub search syntax: <https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#exclude-results-that-match-a-qualifier>
+			- The PowerShell stop parse flag %[1]s--%[2]s%[1]s: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing?view=powershell-7.5#the-stop-parsing-token>
+			- The Unix-like %[1]s--%[1]s argument: <https://www.gnu.org/software/bash/manual/bash.html#Shell-Builtin-Commands-1>
+		`, "`", "%"),
+	},
 }
 
 func NewCmdHelpTopic(ios *iostreams.IOStreams, ht helpTopic) *cobra.Command {

--- a/pkg/cmd/search/code/code.go
+++ b/pkg/cmd/search/code/code.go
@@ -46,6 +46,9 @@ func NewCmdCode(f *cmdutil.Factory, runF func(*CodeOptions) error) *cobra.Comman
 			Note that these search results are powered by what is now a legacy GitHub code search engine.
 			The results might not match what is seen on %[1]sgithub.com%[1]s, and new features like regex search
 			are not yet available via the GitHub API.
+
+			Note: When using GitHub search syntax to exclude results (e.g. '-language:xml'), you must use 
+			a '--' delimiter before the search query to separate it from command flags.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Search code matching "react" and "lifecycle"

--- a/pkg/cmd/search/code/code.go
+++ b/pkg/cmd/search/code/code.go
@@ -47,8 +47,7 @@ func NewCmdCode(f *cmdutil.Factory, runF func(*CodeOptions) error) *cobra.Comman
 			The results might not match what is seen on %[1]sgithub.com%[1]s, and new features like regex search
 			are not yet available via the GitHub API.
 
-			Note: When using GitHub search syntax to exclude results (e.g. '-language:xml'), you must use 
-			a '--' delimiter before the search query to separate it from command flags.
+			For more information on handling search queries containing a hyphen, run %[1]sgh help search-syntax%[1]s.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Search code matching "react" and "lifecycle"

--- a/pkg/cmd/search/code/code.go
+++ b/pkg/cmd/search/code/code.go
@@ -47,7 +47,7 @@ func NewCmdCode(f *cmdutil.Factory, runF func(*CodeOptions) error) *cobra.Comman
 			The results might not match what is seen on %[1]sgithub.com%[1]s, and new features like regex search
 			are not yet available via the GitHub API.
 
-			For more information on handling search queries containing a hyphen, run %[1]sgh help search-syntax%[1]s.
+			For more information on handling search queries containing a hyphen, run %[1]sgh search --help%[1]s.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Search code matching "react" and "lifecycle"

--- a/pkg/cmd/search/commits/commits.go
+++ b/pkg/cmd/search/commits/commits.go
@@ -37,7 +37,7 @@ func NewCmdCommits(f *cmdutil.Factory, runF func(*CommitsOptions) error) *cobra.
 	cmd := &cobra.Command{
 		Use:   "commits [<query>]",
 		Short: "Search for commits",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Search for commits on GitHub.
 
 			The command supports constructing queries using the GitHub search syntax,
@@ -46,9 +46,8 @@ func NewCmdCommits(f *cmdutil.Factory, runF func(*CommitsOptions) error) *cobra.
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-commits>
 
-			Note: When using GitHub search syntax to exclude results (e.g. '-user:monalisa'), you must use 
-			a '--' delimiter before the search query to separate it from command flags.
-		`),
+			For more information on handling search queries containing a hyphen, run %[1]sgh help search-syntax%[1]s.
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Search commits matching set of keywords "readme" and "typo"
 			$ gh search commits readme typo

--- a/pkg/cmd/search/commits/commits.go
+++ b/pkg/cmd/search/commits/commits.go
@@ -46,7 +46,7 @@ func NewCmdCommits(f *cmdutil.Factory, runF func(*CommitsOptions) error) *cobra.
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-commits>
 
-			For more information on handling search queries containing a hyphen, run %[1]sgh help search-syntax%[1]s.
+			For more information on handling search queries containing a hyphen, run %[1]sgh search --help%[1]s.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Search commits matching set of keywords "readme" and "typo"

--- a/pkg/cmd/search/commits/commits.go
+++ b/pkg/cmd/search/commits/commits.go
@@ -45,6 +45,9 @@ func NewCmdCommits(f *cmdutil.Factory, runF func(*CommitsOptions) error) *cobra.
 
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-commits>
+
+			Note: When using GitHub search syntax to exclude results (e.g. '-user:monalisa'), you must use 
+			a '--' delimiter before the search query to separate it from command flags.
 		`),
 		Example: heredoc.Doc(`
 			# Search commits matching set of keywords "readme" and "typo"

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -35,7 +35,7 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
 
-			For more information on handling search queries containing a hyphen, run %[1]sgh help search-syntax%[1]s.
+			For more information on handling search queries containing a hyphen, run %[1]sgh search --help%[1]s.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Search issues matching set of keywords "readme" and "typo"

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -26,7 +26,7 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 	cmd := &cobra.Command{
 		Use:   "issues [<query>]",
 		Short: "Search for issues",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Search for issues on GitHub.
 
 			The command supports constructing queries using the GitHub search syntax,
@@ -35,9 +35,8 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
 
-			Note: When using GitHub search syntax to exclude results (e.g. '-label:bug'), you must use 
-			a '--' delimiter before the search query to separate it from command flags.
-		`),
+			For more information on handling search queries containing a hyphen, run %[1]sgh help search-syntax%[1]s.
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Search issues matching set of keywords "readme" and "typo"
 			$ gh search issues readme typo

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -34,6 +34,9 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
+
+			Note: When using GitHub search syntax to exclude results (e.g. '-label:bug'), you must use 
+			a '--' delimiter before the search query to separate it from command flags.
 		`),
 		Example: heredoc.Doc(`
 			# Search issues matching set of keywords "readme" and "typo"

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -28,7 +28,7 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 	cmd := &cobra.Command{
 		Use:   "prs [<query>]",
 		Short: "Search for pull requests",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Search for pull requests on GitHub.
 
 			The command supports constructing queries using the GitHub search syntax,
@@ -37,9 +37,8 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
 
-			Note: When using GitHub search syntax to exclude results (e.g. '-label:bug'), you must use 
-			a '--' delimiter before the search query to separate it from command flags.
-		`),
+			For more information on handling search queries containing a hyphen, run %[1]sgh help search-syntax%[1]s.
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Search pull requests matching set of keywords "fix" and "bug"
 			$ gh search prs fix bug

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -36,6 +36,9 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
+
+			Note: When using GitHub search syntax to exclude results (e.g. '-label:bug'), you must use 
+			a '--' delimiter before the search query to separate it from command flags.
 		`),
 		Example: heredoc.Doc(`
 			# Search pull requests matching set of keywords "fix" and "bug"

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -37,7 +37,7 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
 
-			For more information on handling search queries containing a hyphen, run %[1]sgh help search-syntax%[1]s.
+			For more information on handling search queries containing a hyphen, run %[1]sgh search --help%[1]s.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Search pull requests matching set of keywords "fix" and "bug"

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -47,7 +47,7 @@ func NewCmdRepos(f *cmdutil.Factory, runF func(*ReposOptions) error) *cobra.Comm
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-for-repositories>
 
-			For more information on handling search queries containing a hyphen, run %[1]sgh help search-syntax%[1]s.
+			For more information on handling search queries containing a hyphen, run %[1]sgh search --help%[1]s.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Search repositories matching set of keywords "cli" and "shell"

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -38,7 +38,7 @@ func NewCmdRepos(f *cmdutil.Factory, runF func(*ReposOptions) error) *cobra.Comm
 	cmd := &cobra.Command{
 		Use:   "repos [<query>]",
 		Short: "Search for repositories",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Search for repositories on GitHub.
 
 			The command supports constructing queries using the GitHub search syntax,
@@ -47,9 +47,8 @@ func NewCmdRepos(f *cmdutil.Factory, runF func(*ReposOptions) error) *cobra.Comm
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-for-repositories>
 
-			Note: When using GitHub search syntax to exclude results (e.g. '-topic:linux'), you must use 
-			a '--' delimiter before the search query to separate it from command flags.
-		`),
+			For more information on handling search queries containing a hyphen, run %[1]sgh help search-syntax%[1]s.
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Search repositories matching set of keywords "cli" and "shell"
 			$ gh search repos cli shell

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -46,6 +46,9 @@ func NewCmdRepos(f *cmdutil.Factory, runF func(*ReposOptions) error) *cobra.Comm
 
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-for-repositories>
+
+			Note: When using GitHub search syntax to exclude results (e.g. '-topic:linux'), you must use 
+			a '--' delimiter before the search query to separate it from command flags.
 		`),
 		Example: heredoc.Doc(`
 			# Search repositories matching set of keywords "cli" and "shell"

--- a/pkg/cmd/search/search.go
+++ b/pkg/cmd/search/search.go
@@ -26,7 +26,7 @@ func NewCmdSearch(f *cmdutil.Factory) *cobra.Command {
 			do not have the label "bug", you would use %[1]s-label:bug%[1]s as a search qualifier.
 
 			%[1]sgh%[1]s supports this syntax in %[1]sgh search%[1]s as well, but it requires extra
-			syntax to avoid the hyphen being interpreted as a command line flag because it begins with a hyphen.
+			command line arguments to avoid the hyphen being interpreted as a command line flag because it begins with a hyphen.
 
 			On Unix-like systems, you can use the %[1]s--%[1]s argument to indicate that
 			the arguments that follow are not a flag, but rather a query string. For example:

--- a/pkg/cmd/search/search.go
+++ b/pkg/cmd/search/search.go
@@ -3,6 +3,7 @@ package search
 import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
+	"github.com/MakeNowJust/heredoc"
 
 	searchCodeCmd "github.com/cli/cli/v2/pkg/cmd/search/code"
 	searchCommitsCmd "github.com/cli/cli/v2/pkg/cmd/search/commits"
@@ -15,7 +16,33 @@ func NewCmdSearch(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search <command>",
 		Short: "Search for repositories, issues, and pull requests",
-		Long:  "Search across all of GitHub.",
+		Long:  heredoc.Docf(`
+			Search across all of GitHub.
+
+			Excluding search results that match a qualifier
+
+			In a browser, the GitHub search syntax supports excluding results that match a search qualifier
+			by prefixing the qualifier with a hyphen. For example, to search for issues that
+			do not have the label "bug", you would use %[1]s-label:bug%[1]s as a search qualifier.
+
+			%[1]sgh%[1]s supports this syntax in %[1]sgh search%[1]s as well, but it requires extra
+			syntax to avoid the hyphen being interpreted as a command line flag because it begins with a hyphen.
+
+			On Unix-like systems, you can use the %[1]s--%[1]s argument to indicate that
+			the arguments that follow are not a flag, but rather a query string. For example:
+
+			$ gh search issues -- "my-search-query -label:bug"
+
+			On PowerShell, you must use both the %[1]s--%[2]s%[1]s argument and the %[1]s--%[1]s argument to
+			produce the same effect. For example:
+
+			$ gh --%[2]s search issues -- "my search query -label:bug"
+
+			See the following for more information:
+			- GitHub search syntax: <https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#exclude-results-that-match-a-qualifier>
+			- The PowerShell stop parse flag %[1]s--%[2]s%[1]s: <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing?view=powershell-7.5#the-stop-parsing-token>
+			- The Unix-like %[1]s--%[1]s argument: <https://www.gnu.org/software/bash/manual/bash.html#Shell-Builtin-Commands-1>
+		`, "`", "%"),
 	}
 
 	cmd.AddCommand(searchCodeCmd.NewCmdCode(f, nil))

--- a/pkg/cmd/search/search.go
+++ b/pkg/cmd/search/search.go
@@ -1,9 +1,9 @@
 package search
 
 import (
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
-	"github.com/MakeNowJust/heredoc"
 
 	searchCodeCmd "github.com/cli/cli/v2/pkg/cmd/search/code"
 	searchCommitsCmd "github.com/cli/cli/v2/pkg/cmd/search/commits"
@@ -16,7 +16,7 @@ func NewCmdSearch(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search <command>",
 		Short: "Search for repositories, issues, and pull requests",
-		Long:  heredoc.Docf(`
+		Long: heredoc.Docf(`
 			Search across all of GitHub.
 
 			Excluding search results that match a qualifier


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes #10480

This PR improves the `gh search` docs by explaining the usage of (`--`) when using **GitHub search syntax** as query to **exclude** results based on qualifiers. 

Docs for the following `gh` commands are updated:
- `gh search code`
- `gh search commit`
- `gh search issues`
- `gh search prs`
- `gh search repos`

### Looking for feedback / Things to still figure out:

1.  Any improvements in the language used for the note.

2. While testing the `--` behaviour, I found that the `--` syntax does not work as expected on Powershell. This might require an addition to the docs notifying this unexpected behaviour to the users.
**Command I used to test on Powershell:** `gh search issues distribution -- repo:rubyforgood/human-essentials -label:stale`
**Issue:** results included issues with the `stale` label

<hr/>

#### References used:
- https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
    > Use a minus (hyphen) symbol to exclude results that match a qualifier. For example, to ignore issues created by the "octocat" user, you'd use -author:octocat in your search. Note that this does not work for [missing metadata qualifiers](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-missing-metadata).

- https://docs.github.com/en/search-github/getting-started-with-searching-on-github/understanding-the-search-syntax#exclude-results-that-match-a-qualifier
    > You can narrow down search results by excluding one or more subsets. To exclude all results that are matched by a qualifier, prefix the search qualifier with a hyphen (-).

- https://github.com/cli/cli/blob/2b89358543d1fe9c0be902992a05d6f6a2fe4b15/pkg/cmd/search/prs/prs.go#L34-L35

