### PR TITLE
Add `workflow_dispatch` support to PR Help Wanted check

### DIFF
--- a/.github/workflows/pr-help-wanted.yml
+++ b/.github/workflows/pr-help-wanted.yml
@@ -4,8 +4,8 @@ on:
     types: [opened]
   workflow_dispatch:
     inputs:
-      pr_url:
-        description: "Pull Request URL to check"
+      pr_number:
+        description: "Pull Request number to check"
         required: true
         type: string
 
@@ -26,11 +26,12 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.inputs.pr_url }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
         run: |
-          # We only need to grab the URL from the dispatch event input,
+          # We only need to construct the PR URL from the dispatch event input,
           # and the isDraft status of the PR. The draft status is
           # used to decide whether to run the help-wanted check/script.
+          PR_URL="https://github.com/cli/cli/pull/${PR_NUMBER}"
           echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
           echo "is_draft=$(gh pr view "${PR_URL}" --json isDraft --jq '.isDraft')" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/pr-help-wanted.yml
+++ b/.github/workflows/pr-help-wanted.yml
@@ -46,7 +46,7 @@ jobs:
           PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
           PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           PR_URL: ${{ github.event.pull_request.html_url || steps.pr-vars-dispatch.outputs.pr_url }}
-        if: github.event.pull_request.draft == 'false' || steps.pr-vars-dispatch.outputs.is_draft == 'false'
+          PR_IS_DRAFT: ${{ github.event.pull_request.draft == 'false' || steps.pr-vars-dispatch.outputs.is_draft == 'false' }}
         run: |
           # Run the script to check for issues without help-wanted label
           bash .github/workflows/scripts/check-help-wanted.sh "${PR_URL}"

--- a/.github/workflows/pr-help-wanted.yml
+++ b/.github/workflows/pr-help-wanted.yml
@@ -2,6 +2,12 @@ name: PR Help Wanted Check
 on:
   pull_request_target:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr_url:
+        description: "Pull Request URL to check"
+        required: true
+        type: string
 
 permissions:
   contents: none
@@ -15,13 +21,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set PR variables for workflow_dispatch event
+        id: pr-vars-dispatch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.inputs.pr_url }}
+        run: |
+          # We only need to grab the URL from the dispatch event input,
+          # and the isDraft status of the PR. The draft status is
+          # used to decide whether to run the help-wanted check/script.
+          echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
+          echo "is_draft=$(gh pr view "${PR_URL}" --json isDraft --jq '.isDraft')" >> $GITHUB_OUTPUT
+
       - name: Check for issues without help-wanted label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            # These variables are optionally used in the check-help-wanted.sh
+            # script for additional checks; but they are not strictly necessary
+            # for the script to run. This is why we are okay with them being
+            # empty when the event is workflow_dispatch.
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
           PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-        if: "!github.event.pull_request.draft"
+          PR_URL: ${{ github.event.pull_request.html_url || steps.pr-vars-dispatch.outputs.pr_url }}
+        if: github.event.pull_request.draft == 'false' || steps.pr-vars-dispatch.outputs.is_draft == 'false'
         run: |
           # Run the script to check for issues without help-wanted label
-          bash .github/workflows/scripts/check-help-wanted.sh ${{ github.event.pull_request.html_url }}
+          bash .github/workflows/scripts/check-help-wanted.sh "${PR_URL}"

--- a/.github/workflows/pr-help-wanted.yml
+++ b/.github/workflows/pr-help-wanted.yml
@@ -28,12 +28,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.inputs.pr_number }}
         run: |
-          # We only need to construct the PR URL from the dispatch event input,
-          # and the isDraft status of the PR. The draft status is
-          # used to decide whether to run the help-wanted check/script.
-          PR_URL="https://github.com/cli/cli/pull/${PR_NUMBER}"
-          echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
-          echo "is_draft=$(gh pr view "${PR_URL}" --json isDraft --jq '.isDraft')" >> $GITHUB_OUTPUT
+          # We only need to construct the PR URL from the dispatch event input.
+          echo "pr_url=https://github.com/cli/cli/pull/${PR_NUMBER}" >> $GITHUB_OUTPUT
 
       - name: Check for issues without help-wanted label
         env:
@@ -46,7 +42,6 @@ jobs:
           PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
           PR_AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           PR_URL: ${{ github.event.pull_request.html_url || steps.pr-vars-dispatch.outputs.pr_url }}
-          PR_IS_DRAFT: ${{ github.event.pull_request.draft == 'false' || steps.pr-vars-dispatch.outputs.is_draft == 'false' }}
         run: |
           # Run the script to check for issues without help-wanted label
           bash .github/workflows/scripts/check-help-wanted.sh "${PR_URL}"

--- a/.github/workflows/scripts/check-help-wanted.sh
+++ b/.github/workflows/scripts/check-help-wanted.sh
@@ -15,6 +15,9 @@ fi
 # Skip if PR is from a bot or org member
 if [ "$PR_AUTHOR_TYPE" = "Bot" ] || [ "$PR_AUTHOR_ASSOCIATION" = "MEMBER" ] || [ "$PR_AUTHOR_ASSOCIATION" = "OWNER" ]; then
     echo "Skipping check for PR #$PR_URL as it is from a bot ($PR_AUTHOR_TYPE) or an org member ($PR_AUTHOR_ASSOCIATION: MEMBER/OWNER)"
+# Skip if PR is a draft
+if [ "$PR_IS_DRAFT" = "true" ]; then
+    echo "Skipping check for PR $PR_URL as it is a draft"
     exit 0
 fi
 

--- a/.github/workflows/scripts/check-help-wanted.sh
+++ b/.github/workflows/scripts/check-help-wanted.sh
@@ -19,7 +19,7 @@ if [ "$PR_AUTHOR_TYPE" = "Bot" ] || [ "$PR_AUTHOR_ASSOCIATION" = "MEMBER" ] || [
 fi
 
 # Skip if PR is a draft
-if [ "$PR_IS_DRAFT" = "true" ]; then
+if [ "$PR_IS_DRAFT" != "false" ]; then
     echo "Skipping check for PR $PR_URL as it is a draft"
     exit 0
 fi

--- a/.github/workflows/scripts/check-help-wanted.sh
+++ b/.github/workflows/scripts/check-help-wanted.sh
@@ -14,7 +14,10 @@ fi
 
 # Skip if PR is from a bot or org member
 if [ "$PR_AUTHOR_TYPE" = "Bot" ] || [ "$PR_AUTHOR_ASSOCIATION" = "MEMBER" ] || [ "$PR_AUTHOR_ASSOCIATION" = "OWNER" ]; then
-    echo "Skipping check for PR #$PR_URL as it is from a bot ($PR_AUTHOR_TYPE) or an org member ($PR_AUTHOR_ASSOCIATION: MEMBER/OWNER)"
+    echo "Skipping check for PR $PR_URL as it is from a bot ($PR_AUTHOR_TYPE) or an org member ($PR_AUTHOR_ASSOCIATION: MEMBER/OWNER)"
+    exit 0
+fi
+
 # Skip if PR is a draft
 if [ "$PR_IS_DRAFT" = "true" ]; then
     echo "Skipping check for PR $PR_URL as it is a draft"

--- a/.github/workflows/scripts/check-help-wanted.sh
+++ b/.github/workflows/scripts/check-help-wanted.sh
@@ -19,7 +19,7 @@ if [ "$PR_AUTHOR_TYPE" = "Bot" ] || [ "$PR_AUTHOR_ASSOCIATION" = "MEMBER" ] || [
 fi
 
 # Skip if PR is a draft
-if [ "$PR_IS_DRAFT" != "false" ]; then
+if [ "$(gh pr view "${PR_URL}" --json isDraft --jq '.isDraft')" != "false" ]; then
     echo "Skipping check for PR $PR_URL as it is a draft"
     exit 0
 fi


### PR DESCRIPTION
This update allows the PR Help Wanted workflow to be triggered manually via `workflow_dispatch` with a specified PR URL. It also adds logic to fetch some PR details using the GitHub CLI for manual runs.


Fixes https://github.com/cli/cli/pull/11179
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
