### PR TITLE
Add workflow to automate go version bumping

### DIFF
--- a/.github/workflows/bump-go.yml
+++ b/.github/workflows/bump-go.yml
@@ -1,0 +1,17 @@
+name: Bump Go
+on:
+  schedule:
+    - cron: "0 3 * * *" # 3 AM UTC
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  bump-go:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Bump Go version
+        run: |
+          bash .github/workflows/scripts/bump-go.sh --apply go.mod

--- a/.github/workflows/scripts/bump-go.sh
+++ b/.github/workflows/scripts/bump-go.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# bump-go.sh — Update go.mod `go` directive and toolchain to latest stable Go release.
+#
+# Usage:
+#   ./bump-go.sh [--apply|-a] <path/to/go.mod>
+#
+# By default the script runs in *dry‑run* mode: it creates a local branch,
+# commits the version bump, shows the exact patch, **checks for an existing PR**
+# with the same title, and exits. Nothing is pushed. The temporary branch is
+# deleted automatically on exit, so your working tree stays clean. Pass
+# --apply (or -a) to push the branch and open a new PR *only if one doesn’t
+# already exist*.
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [--apply|-a] <path/to/go.mod>" >&2
+  exit 1
+}
+
+# ---- Argument parsing -------------------------------------------------------
+APPLY=0
+GO_MOD=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply|-a) APPLY=1 ;;
+    -h|--help)  usage ;;
+    *)          [[ -z "$GO_MOD" ]] && GO_MOD="$1" || usage ;;
+  esac
+  shift
+done
+
+[[ -z "$GO_MOD" ]] && usage
+[[ -f "$GO_MOD" ]] || { echo "Error: '$GO_MOD' not found" >&2; exit 1; }
+
+# ---- Discover latest stable Go release --------------------------------------
+echo "Fetching latest stable Go version…"
+LATEST_JSON=$(curl -fsSL https://go.dev/dl/?mode=json | jq -c '[.[] | select(.stable==true)][0]')
+FULL_VERSION=$(jq -r '.version' <<< "$LATEST_JSON")        # e.g. go1.23.4
+TOOLCHAIN_VERSION="${FULL_VERSION#go}"                     # e.g. 1.23.4
+GO_DIRECTIVE_VERSION=$(cut -d. -f1-2 <<< "$TOOLCHAIN_VERSION")
+
+echo "  → go : $GO_DIRECTIVE_VERSION"
+echo "  → toolchain : $TOOLCHAIN_VERSION"
+
+# ---- Prepare Git branch ---------------------------------------------------
+CURRENT_GO_DIRECTIVE=$(grep -E '^go ' "$GO_MOD" | cut -d ' ' -f2)
+CURRENT_TOOLCHAIN_DIRECTIVE=$(grep -E '^toolchain ' "$GO_MOD" | cut -d ' ' -f2)
+
+if [[ "$CURRENT_GO_DIRECTIVE" = "$GO_DIRECTIVE_VERSION" && \
+      "$CURRENT_TOOLCHAIN_DIRECTIVE" = "go$TOOLCHAIN_VERSION" ]]; then
+  echo "Already on latest Go version: $CURRENT_GO_DIRECTIVE (toolchain: $CURRENT_TOOLCHAIN_DIRECTIVE)"
+  exit 0
+fi
+
+BRANCH="bump-go-$TOOLCHAIN_VERSION"
+cleanup() {
+  git checkout - >/dev/null 2>&1 || true
+  git branch -D "$BRANCH" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "Creating branch $BRANCH"
+git switch -c "$BRANCH" >/dev/null 2>&1
+
+# ---- Patch go.mod -----------------------------------------------------------
+if [[ "$CURRENT_GO_DIRECTIVE" != "$GO_DIRECTIVE_VERSION" ]]; then
+  sed -Ei.bak "s/^go [0-9]+\.[0-9]+.*$/go $GO_DIRECTIVE_VERSION/" "$GO_MOD"
+  echo "  • go directive $CURRENT_GO_DIRECTIVE → $GO_DIRECTIVE_VERSION"
+fi
+
+if [[ "$CURRENT_TOOLCHAIN_DIRECTIVE" != "go$TOOLCHAIN_VERSION" ]]; then
+  sed -Ei.bak "s/^toolchain go[0-9]+\.[0-9]+\.[0-9]+.*$/toolchain go$TOOLCHAIN_VERSION/" "$GO_MOD"
+  echo "  • toolchain $CURRENT_TOOLCHAIN_DIRECTIVE → go$TOOLCHAIN_VERSION"
+fi
+
+rm -f "$GO_MOD.bak"
+
+git add "$GO_MOD"
+
+# ---- Commit -----------------------------------------------------------------
+COMMIT_MSG="Bump Go to $TOOLCHAIN_VERSION"
+git commit -m "$COMMIT_MSG" >/dev/null
+COMMIT_HASH=$(git rev-parse --short HEAD)
+
+PR_TITLE="$COMMIT_MSG"
+
+# ---- Check for existing PR --------------------------------------------------
+existing_pr=$(gh search prs --repo cli/cli --match title "$PR_TITLE" --json title --jq "map(select(.title == \"$PR_TITLE\") | .title) | length > 0")
+
+if [[ "$existing_pr" == "true" ]]; then
+  echo "Found an existing open PR titled '$PR_TITLE'. Skipping push/PR creation."
+  if [[ $APPLY -eq 0 ]]; then
+    echo -e "\n=== DRY‑RUN DIFF (commit $COMMIT_HASH):\n"
+    git --no-pager show --color "$COMMIT_HASH"
+  fi
+  exit 0
+fi
+
+# ---- Dry‑run handling -------------------------------------------------------
+if [[ $APPLY -eq 0 ]]; then
+  echo -e "\n=== DRY‑RUN DIFF (commit $COMMIT_HASH):\n"
+  git --no-pager show --color "$COMMIT_HASH"
+  echo -e "\nIf --apply were provided, script would continue with:\n  git push -u origin $BRANCH\n  gh pr create --title \"$PR_TITLE\" --body <body>\n"
+  exit 0
+fi
+
+# ---- Push & PR --------------------------------------------------------------
+PR_BODY=$(cat <<EOF
+This PR updates Go to the latest stable release.
+
+* **go directive:** \`$GO_DIRECTIVE_VERSION\`
+* **toolchain:** \`$TOOLCHAIN_VERSION\`
+EOF
+)
+
+git push -u origin "$BRANCH"
+
+gh pr create --title "$PR_TITLE" --body "$PR_BODY" --fill
+
+echo "Done!"


### PR DESCRIPTION
## Description

Fixes #11165 

### Demo

#### With major upgrade

```
➜ cat go.mod | grep "go "
go 1.23
...

➜ cat go.mod | grep "toolchain"
toolchain go1.23.0

➜ .github/workflows/scripts/bump-go.sh go.mod
Fetching latest stable Go version…
  → go : 1.24
  → toolchain : 1.24.4
Creating branch bump-go-1.24.4
  • go directive 1.23 → 1.24
  • toolchain go1.23.0 → go1.24.4

=== DRY‑RUN DIFF (commit 7fe51adbd):

commit 7fe51adbdf6cae29efba857d4b870ddb9d8d9b90 (HEAD -> bump-go-1.24.4)
Author: William Martin <williammartin@github.com>
Date:   Mon Jun 30 16:32:06 2025 +0200

    Bump Go to 1.24.4

diff --git a/go.mod b/go.mod
index 5baed1a81..e5d499aee 100644
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/cli/cli/v2

-go 1.23
+go 1.24

-toolchain go1.23.0
+toolchain go1.24.4

 require (
        github.com/AlecAivazis/survey/v2 v2.3.7

If --apply were provided, script would continue with:
  git push -u origin bump-go-1.24.4
  gh pr create --title "Bump Go to 1.24.4" --body <body>
```

#### With minor version bump

```
➜ cat go.mod | grep "go "
go 1.24
...

➜ cat go.mod | grep "toolchain"
toolchain go1.24.3

➜  .github/workflows/scripts/bump-go.sh go.mod
Fetching latest stable Go version…
  → go : 1.24
  → toolchain : 1.24.4
Creating branch bump-go-1.24.4
  • toolchain go1.24.3 → go1.24.4

=== DRY‑RUN DIFF (commit 2e6aae963):

commit 2e6aae9633d78cd46c377836399bcee391fb4687 (HEAD -> bump-go-1.24.4)
Author: William Martin <williammartin@github.com>
Date:   Mon Jun 30 16:33:04 2025 +0200

    Bump Go to 1.24.4

diff --git a/go.mod b/go.mod
index 9416d6b57..e5d499aee 100644
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cli/cli/v2

 go 1.24

-toolchain go1.24.3
+toolchain go1.24.4

 require (
        github.com/AlecAivazis/survey/v2 v2.3.7

If --apply were provided, script would continue with:
  git push -u origin bump-go-1.24.4
  gh pr create --title "Bump Go to 1.24.4" --body <body>
```

#### With no upgrade

```
➜  .github/workflows/scripts/bump-go.sh go.mod
Fetching latest stable Go version…
  → go : 1.24
  → toolchain : 1.24.4
Already on latest Go version: 1.24 (toolchain: go1.24.4)
```

### Note to Reviewers

I went back to the original issue and cut devcontainer from scope because the releases are not coupled to the Go releases but on a cadence. We can certainly do more work to automate that, but I think it is lower value.