### PR TITLE
Remove unused `GH_TOKEN` env variable from workflow

### DIFF
--- a/.github/workflows/pr-help-wanted.yml
+++ b/.github/workflows/pr-help-wanted.yml
@@ -25,7 +25,6 @@ jobs:
         id: pr-vars-dispatch
         if: github.event_name == 'workflow_dispatch'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.inputs.pr_number }}
         run: |
           # We only need to construct the PR URL from the dispatch event input.


### PR DESCRIPTION
The GH_TOKEN environment variable was set but not used in the pr-vars-dispatch step. This commit removes it for clarity and to avoid confusion.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
