### PR TITLE
Consume dependabot minor versions for go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
   ignore:
     - dependency-name: "*"
       update-types:
-        - version-update:semver-minor
         - version-update:semver-major
 - package-ecosystem: "github-actions"
   directory: "/"


### PR DESCRIPTION
## Description

Fixes https://github.com/github/cli/issues/933

### Reviewer Notes

i decided to do the simplest thing here and just start accepting minor version upgrades with no concern for [grouping](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--) or [cooldowns](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-). I believe it makes more sense to do the baseline and adjust with data.