### PR TITLE
docs: consistently use `apt` in installation instructions

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -14,7 +14,7 @@ our release schedule.
 Install:
 
 ```bash
-(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+(type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
 	&& sudo mkdir -p -m 755 /etc/apt/keyrings \
 	&& out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 	&& cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \


### PR DESCRIPTION
Don't mix `apt` and `apt-get`, consistently use `apt`.
