### PR TITLE
Ensure bump go script has git user configured

### DIFF
--- a/.github/workflows/bump-go.yml
+++ b/.github/workflows/bump-go.yml
@@ -13,5 +13,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Bump Go version
+        env:
+          GIT_COMMITTER_NAME: cli automation
+          GIT_AUTHOR_NAME: cli automation
+          GIT_COMMITTER_EMAIL: noreply@github.com
+          GIT_AUTHOR_EMAIL: noreply@github.com
         run: |
           bash .github/workflows/scripts/bump-go.sh --apply go.mod


### PR DESCRIPTION
## Description

Fixes https://github.com/cli/cli/actions/runs/16065132913

Uses same config as the [deployment.yml ](https://github.com/cli/cli/blob/f5134c48c032f81fdde803482b7f9b4f9651bb80/.github/workflows/deployment.yml#L269-L272)