### PR TITLE
Add setup-go to bump-go workflow

### DIFF
--- a/.github/workflows/bump-go.yml
+++ b/.github/workflows/bump-go.yml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
       - name: Bump Go version
         env:
           GIT_COMMITTER_NAME: cli automation


### PR DESCRIPTION
## Description

Hopefully fixes https://github.com/cli/cli/actions/runs/16094838218/job/45417833155

Ideally, this will ensure that we have an up to date version when we run go mod tidy.