### PR TITLE
Minor (1-word) documentation typo in generated `~/.config/gh/config.yml`

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -564,7 +564,7 @@ pager:
 # Aliases allow you to create nicknames for gh commands
 aliases:
   co: pr checkout
-# The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
+# The path to a unix socket through which to send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
 http_unix_socket:
 # What web browser gh should use when opening URLs. If blank, will refer to environment.
 browser:


### PR DESCRIPTION
Fixes a minor typo in the documentation comments within `~/.config/gh/config.yml` as generated by `internal/config/config.go`