### PR TITLE
Display immutable field in `release view` command

### DIFF
--- a/pkg/cmd/release/shared/fetch.go
+++ b/pkg/cmd/release/shared/fetch.go
@@ -30,6 +30,7 @@ var ReleaseFields = []string{
 	"id",
 	"isDraft",
 	"isPrerelease",
+	"isImmutable",
 	"name",
 	"publishedAt",
 	"tagName",
@@ -48,6 +49,7 @@ type Release struct {
 	Body         string     `json:"body"`
 	IsDraft      bool       `json:"draft"`
 	IsPrerelease bool       `json:"prerelease"`
+	IsImmutable  bool       `json:"immutable"`
 	CreatedAt    time.Time  `json:"created_at"`
 	PublishedAt  *time.Time `json:"published_at"`
 

--- a/pkg/cmd/release/view/view.go
+++ b/pkg/cmd/release/view/view.go
@@ -181,6 +181,7 @@ func renderReleasePlain(w io.Writer, release *shared.Release) error {
 	fmt.Fprintf(w, "tag:\t%s\n", release.TagName)
 	fmt.Fprintf(w, "draft:\t%v\n", release.IsDraft)
 	fmt.Fprintf(w, "prerelease:\t%v\n", release.IsPrerelease)
+	fmt.Fprintf(w, "immutable:\t%v\n", release.IsImmutable)
 	fmt.Fprintf(w, "author:\t%s\n", release.Author.Login)
 	fmt.Fprintf(w, "created:\t%s\n", release.CreatedAt.Format(time.RFC3339))
 	if !release.IsDraft {

--- a/pkg/cmd/release/view/view_test.go
+++ b/pkg/cmd/release/view/view_test.go
@@ -31,6 +31,7 @@ func TestJSONFields(t *testing.T) {
 		"id",
 		"isDraft",
 		"isPrerelease",
+		"isImmutable",
 		"name",
 		"publishedAt",
 		"tagName",
@@ -196,6 +197,7 @@ func Test_viewRun(t *testing.T) {
 				tag:	v1.2.3
 				draft:	false
 				prerelease:	false
+				immutable:	true
 				author:	MonaLisa
 				created:	2020-08-31T15:44:24+02:00
 				published:	2020-08-31T15:44:24+02:00
@@ -220,6 +222,7 @@ func Test_viewRun(t *testing.T) {
 				tag:	v1.2.3
 				draft:	false
 				prerelease:	false
+				immutable:	true
 				author:	MonaLisa
 				created:	2020-08-31T15:44:24+02:00
 				published:	2020-08-31T15:44:24+02:00
@@ -244,6 +247,7 @@ func Test_viewRun(t *testing.T) {
 			shared.StubFetchRelease(t, fakeHTTP, "OWNER", "REPO", tt.opts.TagName, fmt.Sprintf(`{
 				"tag_name": "v1.2.3",
 				"draft": false,
+				"immutable": true,
 				"author": { "login": "MonaLisa" },
 				"body": "%[2]s",
 				"created_at": "%[1]s",


### PR DESCRIPTION
Updates the `release view` command to expose the `isImmutable` field for releases.

This field indicates whether or not a given release is immutable.

**Examples**

`gh release view` with JSON fields:
```bash
$ gh release view v1 --json "name,isImmutable"
{
  "isImmutable": true,
  "name": "v1"
}
```

`gh release view` with no TTY:
```
$ gh release view v1 | cat               
title:	v1
tag:	v1
draft:	false
prerelease:	false
immutable:	true
author:	bdehamer
created:	2025-06-23T20:37:31Z
published:	2025-06-23T20:45:02Z
url:	https://github.com/bdehamer/releases-demo/releases/tag/v1
asset:	artifact.zip
--
### New Features
. . .
```