### PR TITLE
Add support for assigning newly created issues to Copilot

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1063,6 +1063,7 @@ func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoRes
 		}
 	}
 
+	// TODO: Should this retrieve actors separate from `user`?
 	// there is no way to look up projects nor milestones by name, so preload them all
 	mi := RepoMetadataInput{
 		ProjectsV1: input.ProjectsV1,
@@ -1079,6 +1080,8 @@ func RepoResolveMetadataIDs(client *Client, repo ghrepo.Interface, input RepoRes
 
 	query := &bytes.Buffer{}
 	fmt.Fprint(query, "query RepositoryResolveMetadataIDs {\n")
+	// TODO: Should we really be using the `user` query to lookup bots even though it technically works?
+	// This logic is used to lookup information about assignees that were explicitly defined upfront
 	for i, u := range users {
 		fmt.Fprintf(query, "u%03d: user(login:%q){id,login}\n", i, u)
 	}

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -16,6 +16,7 @@ import (
 	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/pkg/set"
 	"github.com/spf13/cobra"
 )
 
@@ -68,6 +69,10 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			Adding an issue to projects requires authorization with the %[1]sproject%[1]s scope.
 			To authorize, run %[1]sgh auth refresh -s project%[1]s.
+
+			The %[1]s--assignee%[1]s flag supports the following special values:
+			- %[1]s@me%[1]s: assign yourself
+			- %[1]s@copilot%[1]s: assign Copilot (not supported on GitHub Enterprise Server)
 		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh issue create --title "I found a bug" --body "Nothing works"
@@ -75,6 +80,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			$ gh issue create --label bug --label "help wanted"
 			$ gh issue create --assignee monalisa,hubot
 			$ gh issue create --assignee "@me"
+			$ gh issue create --assignee "@copilot"
 			$ gh issue create --project "Roadmap"
 			$ gh issue create --template "Bug Report"
 		`),
@@ -158,6 +164,10 @@ func createRun(opts *CreateOptions) (err error) {
 	}
 
 	projectsV1Support := opts.Detector.ProjectsV1()
+	issueFeatures, err := opts.Detector.IssueFeatures()
+	if err != nil {
+		return err
+	}
 
 	isTerminal := opts.IO.IsStdoutTTY()
 
@@ -166,20 +176,29 @@ func createRun(opts *CreateOptions) (err error) {
 		milestones = []string{opts.Milestone}
 	}
 
+	// Replace special values in assignees
+	assigneeSet := set.NewStringSet()
 	meReplacer := prShared.NewMeReplacer(apiClient, baseRepo.RepoHost())
+	copilotReplacer := prShared.NewCopilotReplacer()
 	assignees, err := meReplacer.ReplaceSlice(opts.Assignees)
 	if err != nil {
 		return err
 	}
 
+	if issueFeatures.ActorIsAssignable {
+		assignees = copilotReplacer.ReplaceSlice(assignees)
+	}
+	assigneeSet.AddValues(assignees)
+
 	tb := prShared.IssueMetadataState{
-		Type:          prShared.IssueMetadata,
-		Assignees:     assignees,
-		Labels:        opts.Labels,
-		ProjectTitles: opts.Projects,
-		Milestones:    milestones,
-		Title:         opts.Title,
-		Body:          opts.Body,
+		Type:           prShared.IssueMetadata,
+		ActorAssignees: issueFeatures.ActorIsAssignable,
+		Assignees:      assigneeSet.ToSlice(),
+		Labels:         opts.Labels,
+		ProjectTitles:  opts.Projects,
+		Milestones:     milestones,
+		Title:          opts.Title,
+		Body:           opts.Body,
 	}
 
 	if opts.RecoverFile != "" {

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -107,6 +107,7 @@ func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, par
 		return err
 	}
 
+	// TODO: Think we need to adapt the logic in `Editable.AssigneeIds()` which is called by `UpdateIssue()` here to replace @me and @copilot
 	assigneeIDs, err := tb.MetadataResult.MembersToIDs(tb.Assignees)
 	if err != nil {
 		return fmt.Errorf("could not assign user: %w", err)

--- a/pkg/cmd/pr/shared/state.go
+++ b/pkg/cmd/pr/shared/state.go
@@ -18,7 +18,8 @@ const (
 type IssueMetadataState struct {
 	Type metadataStateType
 
-	Draft bool
+	Draft          bool
+	ActorAssignees bool
 
 	Body  string
 	Title string


### PR DESCRIPTION
This draft pull request is a working prototype to assign Copilot to newly created issues.  It is being opened to discuss changes around how `gh issue create` and potentially `gh pr create` retrieve metadata for their experiences and how they build upon the work from `gh issue edit` and `gh pr edit`.

## Topics for discussion

### Should `gh issue create` resolve actors via `user` query?

`gh issue edit` and `gh pr edit` resolve assignees or actors through `RepoMetadata(...)`:

https://github.com/cli/cli/blob/c93136b5f01a9b2e86c82a428497d173ae803001/api/queries_repo.go#L928-L965

`gh issue create` use this same logic for both interactive and non-interactive use cases with a minor distinction:

#### Resolve assignee logins

Assignees provided via `--assignee` are initially processed for `@me` and `@copilot` early on:

https://github.com/cli/cli/blob/49821b20f9157a7ac795ed1c6e72fd7023e6a900/pkg/cmd/issue/create/create.go#L179-L202

Once `gh issue create` determines this is non-interactive, these assignees are resolved by `AddMetadataToIssueParams(...)`:

https://github.com/cli/cli/blob/49821b20f9157a7ac795ed1c6e72fd7023e6a900/pkg/cmd/issue/create/create.go#L370-L373

https://github.com/cli/cli/blob/49821b20f9157a7ac795ed1c6e72fd7023e6a900/pkg/cmd/pr/shared/params.go#L101-L114

https://github.com/cli/cli/blob/49821b20f9157a7ac795ed1c6e72fd7023e6a900/pkg/cmd/pr/shared/params.go#L58-L87

It's here in `RepoResolveMetadataIDs(...)` where `gh issue create` and `gh pr create` call `RepoMetadata(...)` however assignees are resolved through `user` queries:

https://github.com/cli/cli/blob/49821b20f9157a7ac795ed1c6e72fd7023e6a900/api/queries_repo.go#L1046-L1087

#### Interactive prompting for assignees

The only addition to this logic from above is that prompting for assignees reuses the `RepoMetadata(...)` to retrieve actors or assignees based on feature detection:

https://github.com/cli/cli/blob/49821b20f9157a7ac795ed1c6e72fd7023e6a900/pkg/cmd/issue/create/create.go#L307-L317

https://github.com/cli/cli/blob/49821b20f9157a7ac795ed1c6e72fd7023e6a900/pkg/cmd/pr/shared/survey.go#L155-L191