### PR TITLE
Added tenancy aware release verify commands

### DIFF
--- a/pkg/cmd/release/verify-asset/verify_asset.go
+++ b/pkg/cmd/release/verify-asset/verify_asset.go
@@ -8,7 +8,6 @@ import (
 
 	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 
-	att_auth "github.com/cli/cli/v2/pkg/cmd/attestation/auth"
 	"github.com/cli/cli/v2/pkg/iostreams"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -86,9 +85,8 @@ func NewCmdVerifyAsset(f *cmdutil.Factory, runF func(*VerifyAssetConfig) error) 
 				opts.Hostname, _ = ghauth.DefaultHost()
 			}
 
-			err := att_auth.IsHostSupported(opts.Hostname)
-			if err != nil {
-				return err
+			if ghauth.IsEnterprise(opts.Hostname) {
+				return fmt.Errorf("an unsupported host was detected. Note that gh release verify-asset does not currently support GHES")
 			}
 
 			baseRepo, err := f.BaseRepo()

--- a/pkg/cmd/release/verify-asset/verify_asset.go
+++ b/pkg/cmd/release/verify-asset/verify_asset.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"path/filepath"
 
+	ghauth "github.com/cli/go-gh/v2/pkg/auth"
+
+	att_auth "github.com/cli/cli/v2/pkg/cmd/attestation/auth"
 	"github.com/cli/cli/v2/pkg/iostreams"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -21,6 +24,7 @@ import (
 
 type VerifyAssetOptions struct {
 	TagName       string
+	Hostname      string
 	BaseRepo      ghrepo.Interface
 	Exporter      cmdutil.Exporter
 	AssetFilePath string
@@ -78,10 +82,20 @@ func NewCmdVerifyAsset(f *cmdutil.Factory, runF func(*VerifyAssetConfig) error) 
 
 			opts.AssetFilePath = filepath.Clean(opts.AssetFilePath)
 
+			if opts.Hostname == "" {
+				opts.Hostname, _ = ghauth.DefaultHost()
+			}
+
+			err := att_auth.IsHostSupported(opts.Hostname)
+			if err != nil {
+				return err
+			}
+
 			baseRepo, err := f.BaseRepo()
 			if err != nil {
 				return fmt.Errorf("failed to determine base repository: %w", err)
 			}
+			baseRepo = ghrepo.NewWithHost(baseRepo.RepoOwner(), baseRepo.RepoName(), opts.Hostname)
 			opts.BaseRepo = baseRepo
 
 			httpClient, err := f.HttpClient()
@@ -114,6 +128,7 @@ func NewCmdVerifyAsset(f *cmdutil.Factory, runF func(*VerifyAssetConfig) error) 
 		},
 	}
 	cmdutil.AddFormatFlags(cmd, &opts.Exporter)
+	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "", "", "Configure host to use")
 
 	return cmd
 }

--- a/pkg/cmd/release/verify-asset/verify_asset_test.go
+++ b/pkg/cmd/release/verify-asset/verify_asset_test.go
@@ -54,7 +54,7 @@ func TestNewCmdVerifyAsset_Args(t *testing.T) {
 			wantTag:  "v1.2.3",
 			wantFile: test.NormalizeRelativePath("../../attestation/test/data/github_release_artifact.zip"),
 			wantHost: "foo.ghe.com", // expected fallback or previous valid host
-			wantErr:  "An unsupported host was detected. Note that gh attestation does not currently support GHES",
+			wantErr:  "an unsupported host was detected. Note that gh release verify-asset does not currently support GHES",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/release/verify-asset/verify_asset_test.go
+++ b/pkg/cmd/release/verify-asset/verify_asset_test.go
@@ -25,6 +25,7 @@ func TestNewCmdVerifyAsset_Args(t *testing.T) {
 		args     []string
 		wantTag  string
 		wantFile string
+		wantHost string
 		wantErr  string
 	}{
 		{
@@ -32,17 +33,28 @@ func TestNewCmdVerifyAsset_Args(t *testing.T) {
 			args:     []string{"v1.2.3", "../../attestation/test/data/github_release_artifact.zip"},
 			wantTag:  "v1.2.3",
 			wantFile: test.NormalizeRelativePath("../../attestation/test/data/github_release_artifact.zip"),
+			wantHost: "github.com",
 		},
 		{
-			name: "valid flag with no tag",
-
+			name:     "valid flag with no tag",
 			args:     []string{"../../attestation/test/data/github_release_artifact.zip"},
 			wantFile: test.NormalizeRelativePath("../../attestation/test/data/github_release_artifact.zip"),
+			wantHost: "github.com",
 		},
 		{
-			name:    "no args",
-			args:    []string{},
-			wantErr: "you must specify an asset filepath",
+			name:     "valid hostname",
+			args:     []string{"v1.2.3", "../../attestation/test/data/github_release_artifact.zip", "--hostname", "foo.ghe.com"},
+			wantTag:  "v1.2.3",
+			wantFile: test.NormalizeRelativePath("../../attestation/test/data/github_release_artifact.zip"),
+			wantHost: "foo.ghe.com",
+		},
+		{
+			name:     "invalid hostname",
+			args:     []string{"v1.2.3", "../../attestation/test/data/github_release_artifact.zip", "--hostname", "foo.bar.com"},
+			wantTag:  "v1.2.3",
+			wantFile: test.NormalizeRelativePath("../../attestation/test/data/github_release_artifact.zip"),
+			wantHost: "foo.ghe.com", // expected fallback or previous valid host
+			wantErr:  "An unsupported host was detected. Note that gh attestation does not currently support GHES",
 		},
 	}
 	for _, tt := range tests {
@@ -78,6 +90,11 @@ func TestNewCmdVerifyAsset_Args(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantTag, cfg.Opts.TagName)
 				assert.Equal(t, tt.wantFile, cfg.Opts.AssetFilePath)
+
+				baseRepo := ghrepo.NewWithHost("owner", "repo", tt.wantHost)
+				assert.Equal(t, baseRepo.RepoHost(), cfg.Opts.BaseRepo.RepoHost())
+				assert.Equal(t, baseRepo.RepoOwner(), cfg.Opts.BaseRepo.RepoOwner())
+				assert.Equal(t, baseRepo.RepoName(), cfg.Opts.BaseRepo.RepoName())
 			}
 		})
 	}

--- a/pkg/cmd/release/verify/verify.go
+++ b/pkg/cmd/release/verify/verify.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/artifact"
-	att_auth "github.com/cli/cli/v2/pkg/cmd/attestation/auth"
 	att_io "github.com/cli/cli/v2/pkg/cmd/attestation/io"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/verification"
 	"github.com/cli/cli/v2/pkg/cmd/release/shared"
@@ -78,9 +77,8 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 				opts.Hostname, _ = ghauth.DefaultHost()
 			}
 
-			err := att_auth.IsHostSupported(opts.Hostname)
-			if err != nil {
-				return err
+			if ghauth.IsEnterprise(opts.Hostname) {
+				return fmt.Errorf("an unsupported host was detected. Note that gh release verify does not currently support GHES")
 			}
 
 			baseRepo, err := f.BaseRepo()

--- a/pkg/cmd/release/verify/verify.go
+++ b/pkg/cmd/release/verify/verify.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/cli/cli/v2/internal/ghinstance"
-
 	"github.com/MakeNowJust/heredoc"
 	v1 "github.com/in-toto/attestation/go/v1"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -89,6 +87,7 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 			if err != nil {
 				return fmt.Errorf("failed to determine base repository: %w", err)
 			}
+			baseRepo = ghrepo.NewWithHost(baseRepo.RepoOwner(), baseRepo.RepoName(), opts.Hostname)
 
 			opts.BaseRepo = baseRepo
 
@@ -114,22 +113,6 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 				AttVerifier: attVerifier,
 				IO:          io,
 			}
-
-			// Prepare for tenancy if detected
-			if ghauth.IsTenancy(opts.Hostname) {
-				td, err := opts.APIClient.GetTrustDomain()
-				if err != nil {
-					return fmt.Errorf("error getting trust domain, make sure you are authenticated against the host: %w", err)
-				}
-
-				tenant, found := ghinstance.TenantName(opts.Hostname)
-				if !found {
-					return fmt.Errorf("invalid hostname provided: '%s'",
-						opts.Hostname)
-				}
-				config.TrustDomain = td
-				opts.Tenant = tenant
-			}
 			if runF != nil {
 				return runF(config)
 			}
@@ -137,6 +120,7 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 		},
 	}
 	cmdutil.AddFormatFlags(cmd, &opts.Exporter)
+	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "", "", "Configure host to use")
 
 	return cmd
 }

--- a/pkg/cmd/release/verify/verify.go
+++ b/pkg/cmd/release/verify/verify.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/cli/cli/v2/internal/ghinstance"
+
 	"github.com/MakeNowJust/heredoc"
 	v1 "github.com/in-toto/attestation/go/v1"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -13,16 +15,19 @@ import (
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/api"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/artifact"
+	att_auth "github.com/cli/cli/v2/pkg/cmd/attestation/auth"
 	att_io "github.com/cli/cli/v2/pkg/cmd/attestation/io"
 	"github.com/cli/cli/v2/pkg/cmd/attestation/verification"
 	"github.com/cli/cli/v2/pkg/cmd/release/shared"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
 
 type VerifyOptions struct {
+	Hostname string
 	TagName  string
 	BaseRepo ghrepo.Interface
 	Exporter cmdutil.Exporter
@@ -71,6 +76,15 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 				opts.TagName = args[0]
 			}
 
+			if opts.Hostname == "" {
+				opts.Hostname, _ = ghauth.DefaultHost()
+			}
+
+			err := att_auth.IsHostSupported(opts.Hostname)
+			if err != nil {
+				return err
+			}
+
 			baseRepo, err := f.BaseRepo()
 			if err != nil {
 				return fmt.Errorf("failed to determine base repository: %w", err)
@@ -78,13 +92,14 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 
 			opts.BaseRepo = baseRepo
 
+			// set hostname
 			httpClient, err := f.HttpClient()
 			if err != nil {
 				return err
 			}
 
 			io := f.IOStreams
-			attClient := api.NewLiveClient(httpClient, baseRepo.RepoHost(), att_io.NewHandler(io))
+			attClient := api.NewLiveClient(httpClient, opts.Hostname, att_io.NewHandler(io))
 
 			attVerifier := &shared.AttestationVerifier{
 				AttClient:  attClient,
@@ -100,6 +115,21 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 				IO:          io,
 			}
 
+			// Prepare for tenancy if detected
+			if ghauth.IsTenancy(opts.Hostname) {
+				td, err := opts.APIClient.GetTrustDomain()
+				if err != nil {
+					return fmt.Errorf("error getting trust domain, make sure you are authenticated against the host: %w", err)
+				}
+
+				tenant, found := ghinstance.TenantName(opts.Hostname)
+				if !found {
+					return fmt.Errorf("invalid hostname provided: '%s'",
+						opts.Hostname)
+				}
+				config.TrustDomain = td
+				opts.Tenant = tenant
+			}
 			if runF != nil {
 				return runF(config)
 			}

--- a/pkg/cmd/release/verify/verify_test.go
+++ b/pkg/cmd/release/verify/verify_test.go
@@ -48,7 +48,7 @@ func TestNewCmdVerify_Args(t *testing.T) {
 			args:         []string{"v1.2.3", "--hostname", "invalid.host"},
 			wantTag:      "v1.2.3",
 			wantHostname: "foo.ghe.com",
-			wantErr:      "An unsupported host was detected. Note that gh attestation does not currently support GHES",
+			wantErr:      "an unsupported host was detected. Note that gh release verify does not currently support GHES",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/release/verify/verify_test.go
+++ b/pkg/cmd/release/verify/verify_test.go
@@ -19,20 +19,36 @@ import (
 
 func TestNewCmdVerify_Args(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    []string
-		wantTag string
-		wantErr string
+		name         string
+		args         []string
+		wantTag      string
+		wantErr      string
+		wantHostname string
 	}{
 		{
-			name:    "valid tag arg",
-			args:    []string{"v1.2.3"},
-			wantTag: "v1.2.3",
+			name:         "valid tag arg",
+			args:         []string{"v1.2.3"},
+			wantTag:      "v1.2.3",
+			wantHostname: "github.com",
 		},
 		{
-			name:    "no tag arg",
-			args:    []string{},
-			wantTag: "",
+			name:         "no tag arg",
+			args:         []string{},
+			wantTag:      "",
+			wantHostname: "github.com",
+		},
+		{
+			name:         "valid hostname",
+			args:         []string{"v1.2.3", "--hostname", "foo.ghe.com"},
+			wantTag:      "v1.2.3",
+			wantHostname: "foo.ghe.com",
+		},
+		{
+			name:         "invalid hostname",
+			args:         []string{"v1.2.3", "--hostname", "invalid.host"},
+			wantTag:      "v1.2.3",
+			wantHostname: "foo.ghe.com",
+			wantErr:      "An unsupported host was detected. Note that gh attestation does not currently support GHES",
 		},
 	}
 	for _, tt := range tests {
@@ -60,8 +76,18 @@ func TestNewCmdVerify_Args(t *testing.T) {
 
 			_, err := cmd.ExecuteC()
 
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantTag, cfg.Opts.TagName)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantTag, cfg.Opts.TagName)
+
+				baseRepo := ghrepo.NewWithHost("owner", "repo", tt.wantHostname)
+				assert.Equal(t, baseRepo.RepoHost(), cfg.Opts.BaseRepo.RepoHost())
+				assert.Equal(t, baseRepo.RepoOwner(), cfg.Opts.BaseRepo.RepoOwner())
+				assert.Equal(t, baseRepo.RepoName(), cfg.Opts.BaseRepo.RepoName())
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR introduces a functionality to configure `gh release verify` and `gh release verify-asset` the host using --hostname flag instead of using GH_HOST environment variable.

