### PR TITLE
Ensure GoReleaser does not break on Mac OS and Linux when skipping Windows `.rsyso` generation script

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ before:
     - >- # On linux the completions are used in nfpms below, but on macos they are used outside in the deployment build.
       {{ if eq .Runtime.Goos "windows" }}echo{{ end }} make completions
     - >- # We need to create the `.syso` files (per architecture) to embed Windows resources (version info)
-      {{ if ne .Runtime.Goos "windows" }}echo{{ end }} pwsh .\script\gen-winres.ps1 '{{ .Version }} ({{time "2006-01-02"}})' '{{ .Version }}' .\script\versioninfo.template.json .\cmd\gh\
+      {{ if ne .Runtime.Goos "windows" }}echo{{ end }} pwsh '.\script\gen-winres.ps1' '{{ .Version }} ({{time "2006-01-02"}})' '{{ .Version }}' '.\script\versioninfo.template.json' '.\cmd\gh\'
 builds:
   - id: macos #build:macos
     goos: [darwin]


### PR DESCRIPTION
This is a fix following errors in https://github.com/cli/cli/actions/runs/16169374641/job/45638835337 where Linux and Mac OS builds have a problem with unescaped Windows arguments.

Ideally, we would appreciate a way to conditionalize [GoReleaser build hooks](https://goreleaser.com/customization/builds/hooks/) without resorting to the `echo` trick being employed.  It's unclear if this feature exists or is only a [GoReleaser Pro feature](https://goreleaser.com/pro/)

## Testing

Working with @babakks, we built and tested this locally to confirm that the `.rsyso` files were being generated and incorporated into the Windows build, resulting in the `gh.exe` executable details reflecting the version

![windows-build](https://github.com/user-attachments/assets/7a3efb4d-fc19-4eac-9e12-7e66fe121e91)
