### PR TITLE
Add dependabot license fixup script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,3 +114,7 @@ licenses:
 .PHONY: licenses-check
 licenses-check:
 	./script/licenses-check
+
+.PHONY: fix-dependabot-licenses
+fix-dependabot-licenses:
+	./script/fix-dependabot-licenses.sh

--- a/script/fix-dependabot-licenses.sh
+++ b/script/fix-dependabot-licenses.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Fix dependabot PRs with failing "Check Licenses" step
+# The reason this is required is because our CI requires third-party licenses
+# to be updated when dependency bumps happen, but Dependabot does not do this.
+# Usage: ./script/fix-dependabot-licenses.sh
+
+set -e
+
+echo "🔧 Running fix-dependabot-licenses - changes will be pushed"
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "❌ Git working directory is not clean. Please commit or stash changes first."
+    exit 1
+fi
+
+echo "📋 Fetching open dependabot PRs..."
+
+# Get all open PRs by dependabot
+dependabot_prs=$(gh pr list --author "app/dependabot" --state open --json number,title)
+
+if [[ -z "$dependabot_prs" || "$dependabot_prs" == "[]" ]]; then
+    echo "✅ No open dependabot PRs found"
+    exit 0
+fi
+
+echo "🔍 Found $(echo "$dependabot_prs" | jq '. | length') dependabot PRs"
+
+# Process each PR
+echo "$dependabot_prs" | jq -r '.[] | "\(.number) \(.title)"' | while read -r pr_number pr_title; do
+    echo ""
+    echo "🔍 Checking PR #$pr_number: $pr_title"
+
+    # Check if PR has failing lint step and get the first run ID
+    lint_link=$(gh pr checks "$pr_number" --json name,state,workflow,link | jq -r '.[] | select(.workflow == "Lint" and .name == "lint" and .state == "FAILURE") | .link' | head -1)
+
+    if [[ -n "$lint_link" ]]; then
+        # Extract run ID from the link
+        run_id=$(echo "$lint_link" | sed -E 's|.*/actions/runs/([0-9]+).*|\1|')
+        echo "❌ Found failing lint step in PR #$pr_number (run ID: $run_id)"
+
+        # Check if the specific "Check Licenses" step failed
+        if ! gh run view "$run_id" 2>/dev/null | grep "X Check licenses" > /dev/null; then
+            echo "✅ License check step is not failing in this run, skipping"
+            continue
+        fi
+
+        echo "❌ Confirmed: 'Check Licenses' step failed in run $run_id"
+
+        # Extract dependency name and version range from title for commit message
+        # Example: "chore(deps): bump golang.org/x/term from 0.32.0 to 0.33.0 #11266"
+        commitSuffix=$(echo "$pr_title" | sed -E 's/^chore\(deps\): //')
+
+        if [[ -z "$commitSuffix" ]]; then
+            echo "⚠️  Could not extract commit suffix from PR title: $pr_title"
+            echo "⚠️  Skipping this PR"
+            continue
+        fi
+
+        echo "📦 Commit Suffix: $commitSuffix"
+
+        echo "🔧 Checking out PR #$pr_number..."
+        gh pr checkout --force "$pr_number"
+
+        echo "🔧 Running 'make licenses'..."
+        make licenses
+
+        # Check if there are any changes to commit
+        if git diff --quiet && git diff --cached --quiet; then
+            echo "✅ No license changes needed for PR #$pr_number"
+            continue
+        fi
+
+        echo "🔧 Committing license changes..."
+        git add third-party/ third-party-licenses*
+        git commit -m "Fixed licenses for $commitSuffix"
+
+        echo "🔧 Pushing changes..."
+        git push
+        echo "✅ Fixed licenses for PR #$pr_number"
+    else
+        echo "✅ PR #$pr_number has passing/pending lint checks"
+    fi
+done
+
+echo ""
+echo "✅ All applicable dependabot PRs have been processed."


### PR DESCRIPTION
## Description

Relates to https://github.com/cli/cli/pull/11213 and https://github.com/cli/cli/pull/11047

Since we now accept minor dependabot version bumps, and since those come with license changes that result in our license check failing, I was motivated to create a quick script to resolve the 4 currently open dependabot PRs:
 * https://github.com/cli/cli/pull/11263
 * https://github.com/cli/cli/pull/11264
 * https://github.com/cli/cli/pull/11265
 * https://github.com/cli/cli/pull/11266

The script looks for all open PRs by dependabot with a failing job, where the job is failing due to a failure in license checks, then it checks out the PR, runs `make licenses` and pushes a commit back with the changes.

Big picture, it would be nice if this happened automatically and @andyfeller has pointed out docs in the past that might enable this, but I just thought I'd close out the day with some vibes.

### Run Logs

```
➜  cli git:(trunk) make fix-dependabot-licenses
./script/fix-dependabot-licenses.sh
🔧 Running fix-dependabot-licenses - changes will be pushed
📋 Fetching open dependabot PRs...
🔍 Found 4 dependabot PRs

🔍 Checking PR #11266: chore(deps): bump golang.org/x/term from 0.32.0 to 0.33.0
❌ Found failing lint step in PR #11266 (run ID: 16200159680)
❌ Confirmed: 'Check Licenses' step failed in run 16200159680
📦 Commit Suffix: bump golang.org/x/term from 0.32.0 to 0.33.0
🔧 Checking out PR #11266...
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Unpacking objects: 100% (1/1), 1.02 KiB | 208.00 KiB/s, done.
From https://github.com/cli/cli
 + 817f3847d...f30a55da9 dependabot/go_modules/golang.org/x/term-0.33.0 -> origin/dependabot/go_modules/golang.org/x/term-0.33.0  (forced update)
Switched to branch 'dependabot/go_modules/golang.org/x/term-0.33.0'
Your branch and 'origin/dependabot/go_modules/golang.org/x/term-0.33.0' have diverged,
and have 2 and 1 different commits each, respectively.
  (use "git pull" if you want to integrate the remote branch with yours)
HEAD is now at f30a55da9 chore(deps): bump golang.org/x/term from 0.32.0 to 0.33.0
🔧 Running 'make licenses'...
./script/licenses
Generating licenses for linux...
W0710 18:36:41.629278   96339 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/unix/asm_linux_arm64.s
W0710 18:36:43.499109   96339 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:36:44.385472   96339 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/cpu/cpu_arm64.s
W0710 18:36:47.441237   96339 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:36:48.230465   96339 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
W0710 18:36:57.825992   96547 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/unix/asm_linux_arm64.s
W0710 18:36:59.388073   96547 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:37:00.206877   96547 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/cpu/cpu_arm64.s
W0710 18:37:02.534494   96547 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:37:03.123744   96547 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Generating licenses for darwin...
W0710 18:37:18.743816   96750 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/unix/asm_bsd_arm64.s
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/unix/zsyscall_darwin_arm64.s
W0710 18:37:20.465653   96750 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:37:21.384097   96750 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/cpu/cpu_arm64.s
W0710 18:37:23.903649   96750 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:37:24.517251   96750 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
W0710 18:37:30.057926   96920 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/unix/asm_bsd_arm64.s
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/unix/zsyscall_darwin_arm64.s
W0710 18:37:31.543681   96920 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:37:32.327323   96920 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/cpu/cpu_arm64.s
W0710 18:37:34.699752   96920 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:37:35.373700   96920 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Generating licenses for windows...
E0710 18:37:49.593697   97114 library.go:122] Failed to find license for github.com/mattn/go-localereader: cannot find a known open source license for "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1" whose name matches regexp ^(?i)((UN)?LICEN(S|C)E|COPYING|README|NOTICE).*$ and locates up until "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1"
W0710 18:37:51.042358   97114 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:37:51.856232   97114 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/cpu/cpu_arm64.s
W0710 18:37:54.421482   97114 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:37:55.044757   97114 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
F0710 18:37:59.558957   97114 main.go:77] one or more libraries have an incompatible/unknown license: map["unknown":["github.com/mattn/go-localereader"]]
Ignore warnings
E0710 18:38:00.834210   97248 library.go:122] Failed to find license for github.com/mattn/go-localereader: cannot find a known open source license for "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1" whose name matches regexp ^(?i)((UN)?LICEN(S|C)E|COPYING|README|NOTICE).*$ and locates up until "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1"
W0710 18:38:02.153723   97248 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:38:03.005631   97248 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.34.0/cpu/cpu_arm64.s
W0710 18:38:05.525862   97248 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:38:06.137920   97248 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Licenses generated for all platforms.
🔧 Committing license changes...
[dependabot/go_modules/golang.org/x/term-0.33.0 836b73c57] Fixed licenses for bump golang.org/x/term from 0.32.0 to 0.33.0
 3 files changed, 6 insertions(+), 6 deletions(-)
🔧 Pushing changes...
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Delta compression using up to 10 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 533 bytes | 533.00 KiB/s, done.
Total 5 (delta 4), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
To https://github.com/cli/cli.git
   f30a55da9..836b73c57  dependabot/go_modules/golang.org/x/term-0.33.0 -> dependabot/go_modules/golang.org/x/term-0.33.0
✅ Fixed licenses for PR #11266

🔍 Checking PR #11265: chore(deps): bump golang.org/x/text from 0.26.0 to 0.27.0
❌ Found failing lint step in PR #11265 (run ID: 16199022130)
❌ Confirmed: 'Check Licenses' step failed in run 16199022130
📦 Commit Suffix: bump golang.org/x/text from 0.26.0 to 0.27.0
🔧 Checking out PR #11265...
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Unpacking objects: 100% (1/1), 1.04 KiB | 132.00 KiB/s, done.
From https://github.com/cli/cli
 + 4f1ed3f91...9528b54e4 dependabot/go_modules/golang.org/x/text-0.27.0 -> origin/dependabot/go_modules/golang.org/x/text-0.27.0  (forced update)
Switched to branch 'dependabot/go_modules/golang.org/x/text-0.27.0'
Your branch and 'origin/dependabot/go_modules/golang.org/x/text-0.27.0' have diverged,
and have 2 and 1 different commits each, respectively.
  (use "git pull" if you want to integrate the remote branch with yours)
HEAD is now at 9528b54e4 chore(deps): bump golang.org/x/text from 0.26.0 to 0.27.0
🔧 Running 'make licenses'...
./script/licenses
Generating licenses for linux...
W0710 18:38:32.028938   97800 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_linux_arm64.s
W0710 18:38:33.786768   97800 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:38:34.629707   97800 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:38:37.190310   97800 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:38:37.801576   97800 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
W0710 18:38:43.067945   97943 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_linux_arm64.s
W0710 18:38:44.616358   97943 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:38:45.392626   97943 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:38:47.731386   97943 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:38:48.326237   97943 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Generating licenses for darwin...
W0710 18:39:03.794527   98146 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_bsd_arm64.s
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/zsyscall_darwin_arm64.s
W0710 18:39:05.592878   98146 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:39:06.420356   98146 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:39:08.887115   98146 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:39:09.515609   98146 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
W0710 18:39:14.930480   98305 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_bsd_arm64.s
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/zsyscall_darwin_arm64.s
W0710 18:39:16.437965   98305 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:39:17.254797   98305 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:39:19.574791   98305 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:39:20.175463   98305 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Generating licenses for windows...
E0710 18:39:34.734391   98486 library.go:122] Failed to find license for github.com/mattn/go-localereader: cannot find a known open source license for "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1" whose name matches regexp ^(?i)((UN)?LICEN(S|C)E|COPYING|README|NOTICE).*$ and locates up until "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1"
W0710 18:39:36.162572   98486 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:39:37.017282   98486 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:39:39.544873   98486 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:39:40.169203   98486 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
F0710 18:39:44.632375   98486 main.go:77] one or more libraries have an incompatible/unknown license: map["unknown":["github.com/mattn/go-localereader"]]
Ignore warnings
E0710 18:39:45.942382   98640 library.go:122] Failed to find license for github.com/mattn/go-localereader: cannot find a known open source license for "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1" whose name matches regexp ^(?i)((UN)?LICEN(S|C)E|COPYING|README|NOTICE).*$ and locates up until "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1"
W0710 18:39:47.217163   98640 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:39:48.099586   98640 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:39:50.463757   98640 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:39:51.069355   98640 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Licenses generated for all platforms.
🔧 Committing license changes...
[dependabot/go_modules/golang.org/x/text-0.27.0 437a59e10] Fixed licenses for bump golang.org/x/text from 0.26.0 to 0.27.0
 3 files changed, 6 insertions(+), 6 deletions(-)
🔧 Pushing changes...
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Delta compression using up to 10 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 544 bytes | 544.00 KiB/s, done.
Total 5 (delta 4), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
To https://github.com/cli/cli.git
   9528b54e4..437a59e10  dependabot/go_modules/golang.org/x/text-0.27.0 -> dependabot/go_modules/golang.org/x/text-0.27.0
✅ Fixed licenses for PR #11265

🔍 Checking PR #11264: chore(deps): bump golang.org/x/sync from 0.15.0 to 0.16.0
❌ Found failing lint step in PR #11264 (run ID: 16198458916)
❌ Confirmed: 'Check Licenses' step failed in run 16198458916
📦 Commit Suffix: bump golang.org/x/sync from 0.15.0 to 0.16.0
🔧 Checking out PR #11264...
Switched to branch 'dependabot/go_modules/golang.org/x/sync-0.16.0'
Your branch is up to date with 'origin/dependabot/go_modules/golang.org/x/sync-0.16.0'.
HEAD is now at 049768c9e chore(deps): bump golang.org/x/sync from 0.15.0 to 0.16.0
🔧 Running 'make licenses'...
./script/licenses
Generating licenses for linux...
W0710 18:40:14.734970   99020 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_linux_arm64.s
W0710 18:40:16.713393   99020 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:40:17.522009   99020 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:40:19.958817   99020 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:40:20.583093   99020 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
W0710 18:40:25.991320   99171 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_linux_arm64.s
W0710 18:40:27.582073   99171 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:40:28.369939   99171 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:40:30.753947   99171 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:40:31.379649   99171 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Generating licenses for darwin...
W0710 18:40:46.167634   99369 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_bsd_arm64.s
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/zsyscall_darwin_arm64.s
W0710 18:40:47.967145   99369 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:40:48.931866   99369 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:40:51.542940   99369 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:40:52.188423   99369 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
W0710 18:40:58.333974   99509 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_bsd_arm64.s
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/zsyscall_darwin_arm64.s
W0710 18:40:59.918228   99509 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:41:00.696138   99509 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:41:03.074323   99509 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:41:03.694774   99509 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Generating licenses for windows...
E0710 18:41:18.012941   99726 library.go:122] Failed to find license for github.com/mattn/go-localereader: cannot find a known open source license for "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1" whose name matches regexp ^(?i)((UN)?LICEN(S|C)E|COPYING|README|NOTICE).*$ and locates up until "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1"
W0710 18:41:19.430443   99726 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:41:20.248987   99726 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:41:22.728753   99726 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:41:23.367701   99726 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
F0710 18:41:27.738877   99726 main.go:77] one or more libraries have an incompatible/unknown license: map["unknown":["github.com/mattn/go-localereader"]]
Ignore warnings
E0710 18:41:29.212380   99843 library.go:122] Failed to find license for github.com/mattn/go-localereader: cannot find a known open source license for "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1" whose name matches regexp ^(?i)((UN)?LICEN(S|C)E|COPYING|README|NOTICE).*$ and locates up until "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1"
W0710 18:41:30.466818   99843 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:41:31.253979   99843 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:41:33.619147   99843 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:41:34.475477   99843 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Licenses generated for all platforms.
🔧 Committing license changes...
[dependabot/go_modules/golang.org/x/sync-0.16.0 d63f6423f] Fixed licenses for bump golang.org/x/sync from 0.15.0 to 0.16.0
 3 files changed, 3 insertions(+), 3 deletions(-)
🔧 Pushing changes...
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Delta compression using up to 10 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 511 bytes | 511.00 KiB/s, done.
Total 5 (delta 4), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
To https://github.com/cli/cli.git
   049768c9e..d63f6423f  dependabot/go_modules/golang.org/x/sync-0.16.0 -> dependabot/go_modules/golang.org/x/sync-0.16.0
✅ Fixed licenses for PR #11264

🔍 Checking PR #11263: chore(deps): bump github.com/sigstore/protobuf-specs from 0.4.3 to 0.5.0
❌ Found failing lint step in PR #11263 (run ID: 16199063935)
❌ Confirmed: 'Check Licenses' step failed in run 16199063935
📦 Commit Suffix: bump github.com/sigstore/protobuf-specs from 0.4.3 to 0.5.0
🔧 Checking out PR #11263...
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Unpacking objects: 100% (1/1), 1.06 KiB | 181.00 KiB/s, done.
From https://github.com/cli/cli
 + 1589d1b3e...b133506f8 dependabot/go_modules/github.com/sigstore/protobuf-specs-0.5.0 -> origin/dependabot/go_modules/github.com/sigstore/protobuf-specs-0.5.0  (forced update)
Switched to branch 'dependabot/go_modules/github.com/sigstore/protobuf-specs-0.5.0'
Your branch and 'origin/dependabot/go_modules/github.com/sigstore/protobuf-specs-0.5.0' have diverged,
and have 2 and 1 different commits each, respectively.
  (use "git pull" if you want to integrate the remote branch with yours)
HEAD is now at b133506f8 chore(deps): bump github.com/sigstore/protobuf-specs from 0.4.3 to 0.5.0
🔧 Running 'make licenses'...
./script/licenses
Generating licenses for linux...
W0710 18:41:59.630765     356 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_linux_arm64.s
W0710 18:42:01.376343     356 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:42:02.250838     356 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:42:04.686173     356 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:42:05.338350     356 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
W0710 18:42:10.802605     503 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_linux_arm64.s
W0710 18:42:12.301493     503 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:42:13.064569     503 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:42:15.457203     503 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:42:16.041453     503 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Generating licenses for darwin...
W0710 18:42:31.364049     882 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_bsd_arm64.s
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/zsyscall_darwin_arm64.s
W0710 18:42:33.161827     882 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:42:33.991761     882 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:42:36.491608     882 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:42:37.126295     882 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
W0710 18:42:42.689940    1030 library.go:101] "golang.org/x/sys/unix" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/asm_bsd_arm64.s
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/unix/zsyscall_darwin_arm64.s
W0710 18:42:44.150689    1030 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:42:44.934471    1030 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:42:47.211460    1030 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:42:47.807495    1030 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Generating licenses for windows...
E0710 18:43:02.263090    1311 library.go:122] Failed to find license for github.com/mattn/go-localereader: cannot find a known open source license for "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1" whose name matches regexp ^(?i)((UN)?LICEN(S|C)E|COPYING|README|NOTICE).*$ and locates up until "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1"
W0710 18:43:03.664732    1311 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:43:04.522007    1311 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:43:07.060769    1311 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:43:07.673258    1311 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
F0710 18:43:12.353072    1311 main.go:77] one or more libraries have an incompatible/unknown license: map["unknown":["github.com/mattn/go-localereader"]]
Ignore warnings
E0710 18:43:13.610303    1451 library.go:122] Failed to find license for github.com/mattn/go-localereader: cannot find a known open source license for "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1" whose name matches regexp ^(?i)((UN)?LICEN(S|C)E|COPYING|README|NOTICE).*$ and locates up until "/Users/williammartin/go/pkg/mod/github.com/mattn/go-localereader@v0.0.1"
W0710 18:43:14.828334    1451 library.go:101] "golang.org/x/crypto/chacha20" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/crypto@v0.39.0/chacha20/chacha_arm64.s
W0710 18:43:15.593518    1451 library.go:101] "golang.org/x/sys/cpu" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/golang.org/x/sys@v0.33.0/cpu/cpu_arm64.s
W0710 18:43:17.926015    1451 library.go:101] "github.com/golang/snappy" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/decode_arm64.s
/Users/williammartin/go/pkg/mod/github.com/golang/snappy@v1.0.0/encode_arm64.s
W0710 18:43:18.526829    1451 library.go:101] "github.com/klauspost/compress/zstd/internal/xxhash" contains non-Go code that can't be inspected for further dependencies:
/Users/williammartin/go/pkg/mod/github.com/klauspost/compress@v1.18.0/zstd/internal/xxhash/xxhash_arm64.s
Licenses generated for all platforms.
🔧 Committing license changes...
[dependabot/go_modules/github.com/sigstore/protobuf-specs-0.5.0 1d0f8963e] Fixed licenses for bump github.com/sigstore/protobuf-specs from 0.4.3 to 0.5.0
 3 files changed, 3 insertions(+), 3 deletions(-)
🔧 Pushing changes...
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Delta compression using up to 10 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 536 bytes | 536.00 KiB/s, done.
Total 5 (delta 4), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
To https://github.com/cli/cli.git
   b133506f8..1d0f8963e  dependabot/go_modules/github.com/sigstore/protobuf-specs-0.5.0 -> dependabot/go_modules/github.com/sigstore/protobuf-specs-0.5.0
✅ Fixed licenses for PR #11263

✅ All applicable dependabot PRs have been processed.
```