### PR TITLE
Grammar: replace "resolve to" with "resolve"

### DIFF
--- a/acceptance/testdata/repo/repo-delete.txtar
+++ b/acceptance/testdata/repo/repo-delete.txtar
@@ -10,4 +10,4 @@ exec gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
 
 # Ensure that the repo was deleted
 ! exec gh repo view $ORG/$SCRIPT_NAME-$RANDOM_STRING
-stderr 'Could not resolve to a Repository with the name'
+stderr 'Could not resolve a Repository with the name'

--- a/api/queries_org.go
+++ b/api/queries_org.go
@@ -67,7 +67,7 @@ func OrganizationTeam(client *Client, hostname string, org string, teamSlug stri
 		return nil, err
 	}
 	if query.Organization.Team.ID == "" {
-		return nil, fmt.Errorf("could not resolve to a Team with the slug of '%s'", teamSlug)
+		return nil, fmt.Errorf("could not resolve a Team with the slug of '%s'", teamSlug)
 	}
 
 	return &query.Organization.Team, nil

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	errorResolvingOrganization = "Could not resolve to an Organization"
+	errorResolvingOrganization = "Could not resolve an Organization"
 )
 
 // Repository contains information about a GitHub repo
@@ -299,7 +299,7 @@ func FetchRepository(client *Client, repo ghrepo.Interface, fields []string) (*R
 			GraphQLError: &ghAPI.GraphQLError{
 				Errors: []ghAPI.GraphQLErrorItem{{
 					Type:    "NOT_FOUND",
-					Message: fmt.Sprintf("Could not resolve to a Repository with the name '%s/%s'.", repo.RepoOwner(), repo.RepoName()),
+					Message: fmt.Sprintf("Could not resolve a Repository with the name '%s/%s'.", repo.RepoOwner(), repo.RepoName()),
 				}},
 			},
 		}
@@ -352,7 +352,7 @@ func GitHubRepo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 			GraphQLError: &ghAPI.GraphQLError{
 				Errors: []ghAPI.GraphQLErrorItem{{
 					Type:    "NOT_FOUND",
-					Message: fmt.Sprintf("Could not resolve to a Repository with the name '%s/%s'.", repo.RepoOwner(), repo.RepoName()),
+					Message: fmt.Sprintf("Could not resolve a Repository with the name '%s/%s'.", repo.RepoOwner(), repo.RepoName()),
 				}},
 			},
 		}

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -28,7 +28,7 @@ func TestGitHubRepo_notFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("GitHubRepo did not return an error")
 	}
-	if wants := "GraphQL: Could not resolve to a Repository with the name 'OWNER/REPO'."; err.Error() != wants {
+	if wants := "GraphQL: Could not resolve a Repository with the name 'OWNER/REPO'."; err.Error() != wants {
 		t.Errorf("GitHubRepo error: want %q, got %q", wants, err.Error())
 	}
 	if repo != nil {

--- a/pkg/cmd/issue/close/close_test.go
+++ b/pkg/cmd/issue/close/close_test.go
@@ -239,7 +239,7 @@ func TestCloseRun(t *testing.T) {
 					httpmock.StringResponse(`{
             "data": { "repository": { "hasIssuesEnabled": false, "issue": null } },
             "errors": [ { "type": "NOT_FOUND", "path": [ "repository", "issue" ],
-            "message": "Could not resolve to an issue or pull request with the number of 13."
+            "message": "Could not resolve an issue or pull request with the number of 13."
 					} ] }`),
 				)
 			},

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -816,7 +816,7 @@ func TestIssueCreate_metadata(t *testing.T) {
 			"errors": [{
 				"type": "NOT_FOUND",
 				"path": [ "organization" ],
-				"message": "Could not resolve to an Organization with the login of 'OWNER'."
+				"message": "Could not resolve an Organization with the login of 'OWNER'."
 			}]
 		}
 		`))

--- a/pkg/cmd/issue/delete/delete_test.go
+++ b/pkg/cmd/issue/delete/delete_test.go
@@ -166,13 +166,13 @@ func TestIssueDelete_doesNotExist(t *testing.T) {
 		httpmock.GraphQL(`query IssueByNumber\b`),
 		httpmock.StringResponse(`
 			{ "errors": [
-				{ "message": "Could not resolve to an Issue with the number of 13." }
+				{ "message": "Could not resolve an Issue with the number of 13." }
 			] }
 			`),
 	)
 
 	_, err := runCommand(httpRegistry, nil, true, "13")
-	if err == nil || err.Error() != "GraphQL: Could not resolve to an Issue with the number of 13." {
+	if err == nil || err.Error() != "GraphQL: Could not resolve an Issue with the number of 13." {
 		t.Errorf("error running command `issue delete`: %v", err)
 	}
 }
@@ -198,7 +198,7 @@ func TestIssueDelete_issuesDisabled(t *testing.T) {
 						"repository",
 						"issue"
 					],
-					"message": "Could not resolve to an issue or pull request with the number of 13."
+					"message": "Could not resolve an issue or pull request with the number of 13."
 				}
 			]
 		}`),

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -494,7 +494,7 @@ func Test_editRun(t *testing.T) {
 						{ "errors": [
 							{
 								"type": "NOT_FOUND",
-								"message": "Could not resolve to an Issue with the number of 9999."
+								"message": "Could not resolve an Issue with the number of 9999."
 							}
 						] }`),
 				)

--- a/pkg/cmd/issue/reopen/reopen_test.go
+++ b/pkg/cmd/issue/reopen/reopen_test.go
@@ -140,7 +140,7 @@ func TestIssueReopen_issuesDisabled(t *testing.T) {
 						"repository",
 						"issue"
 					],
-					"message": "Could not resolve to an issue or pull request with the number of 2."
+					"message": "Could not resolve an issue or pull request with the number of 2."
 				}
 			]
 		}`),

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -303,7 +303,7 @@ func TestIssueView_web_notFound(t *testing.T) {
 		httpmock.GraphQL(`query IssueByNumber\b`),
 		httpmock.StringResponse(`
 			{ "errors": [
-				{ "message": "Could not resolve to an Issue with the number of 9999." }
+				{ "message": "Could not resolve an Issue with the number of 9999." }
 			] }
 			`),
 	)
@@ -312,7 +312,7 @@ func TestIssueView_web_notFound(t *testing.T) {
 	defer cmdTeardown(t)
 
 	_, err := runCommand(http, true, "-w 9999")
-	if err == nil || err.Error() != "GraphQL: Could not resolve to an Issue with the number of 9999." {
+	if err == nil || err.Error() != "GraphQL: Could not resolve an Issue with the number of 9999." {
 		t.Errorf("error running command `issue view`: %v", err)
 	}
 }
@@ -338,7 +338,7 @@ func TestIssueView_disabledIssues(t *testing.T) {
 							"repository",
 							"issue"
 						],
-						"message": "Could not resolve to an issue or pull request with the number of 6666."
+						"message": "Could not resolve an issue or pull request with the number of 6666."
 					}
 				]
 			}

--- a/pkg/cmd/label/clone_test.go
+++ b/pkg/cmd/label/clone_test.go
@@ -417,7 +417,7 @@ func TestCloneRun(t *testing.T) {
 									"column": 1
 								  }
 								],
-								"message": "Could not resolve to a Repository with the name 'cli/invalid'."
+								"message": "Could not resolve a Repository with the name 'cli/invalid'."
 							  }
 							]
 						}`),
@@ -427,7 +427,7 @@ func TestCloneRun(t *testing.T) {
 				)
 			},
 			wantErr:    true,
-			wantErrMsg: "GraphQL: Could not resolve to a Repository with the name 'cli/invalid'. (repository)",
+			wantErrMsg: "GraphQL: Could not resolve a Repository with the name 'cli/invalid'. (repository)",
 		},
 		{
 			name: "create error",

--- a/pkg/cmd/workflow/disable/disable_test.go
+++ b/pkg/cmd/workflow/disable/disable_test.go
@@ -253,7 +253,7 @@ func TestDisableRun(t *testing.T) {
 					}))
 			},
 			wantErr:    true,
-			wantErrOut: "could not resolve to a unique workflow; found: another.yml yetanother.yml",
+			wantErrOut: "could not resolve a unique workflow; found: another.yml yetanother.yml",
 		},
 	}
 

--- a/pkg/cmd/workflow/enable/enable_test.go
+++ b/pkg/cmd/workflow/enable/enable_test.go
@@ -293,7 +293,7 @@ func TestEnableRun(t *testing.T) {
 					}))
 			},
 			wantErr:    true,
-			wantErrOut: "could not resolve to a unique workflow; found: disabled.yml anotherDisabled.yml",
+			wantErrOut: "could not resolve a unique workflow; found: disabled.yml anotherDisabled.yml",
 		},
 	}
 

--- a/pkg/cmd/workflow/shared/shared.go
+++ b/pkg/cmd/workflow/shared/shared.go
@@ -222,7 +222,7 @@ func ResolveWorkflow(p iprompter, io *iostreams.IOStreams, client *api.Client, r
 	}
 
 	if !io.CanPrompt() {
-		errMsg := "could not resolve to a unique workflow; found:"
+		errMsg := "could not resolve a unique workflow; found:"
 		for _, workflow := range workflows {
 			errMsg += fmt.Sprintf(" %s", workflow.Base())
 		}


### PR DESCRIPTION
The phrasing "could not resolve to xyz" made me think an empty string was being pasted in, like `"Could not resolve " + input + " to..."`. Some debugging later, I discovered the string actually literally appears in the CLI. I suggest "resolve" should be used without "to" ("could not resolve a repository"). "Resolve abc to def" is fine, but I didn't find such usage here.