### PR TITLE
Filter the `third-party/` folder out of CodeQL results

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,12 +38,25 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-          config: |
-            paths-ignore:
-              - 'third-party/**'
-              - 'third-party-licenses.*.md'
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
+          category: "/language:${{ matrix.language }}"
+          upload: false
+          output: sarif-results
+
+      - name: Filter SARIF for third-party code
+        if: matrix.language == 'go'
+        uses: advanced-security/filter-sarif@bc96d9fb9338c5b48cc440b1b4d0a350b26a20db # v1.0.0
+        with:
+          patterns: |
+            -third-party/**
+          input: sarif-results/${{ matrix.language }}.sarif
+          output: sarif-results/${{ matrix.language }}.sarif
+
+      - name: Upload filtered SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: sarif-results/${{ matrix.language }}.sarif
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds SARIF filtering for Go analysis to exclude third-party code from results and updates the workflow to upload filtered SARIF files

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
