### PR TITLE
Exclude `third-party` source from golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,9 @@ linters:
    # set, and we should have separate work to enable them if we truly want them.
    - staticcheck
    - errcheck
+  exclusions:
+    paths:
+      - third-party
 
 formatters:
   enable:


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Relates #11047

**When** `golangci-lint run` is executed
**Then** lint problems with `third-party` source code should not be raised
