### PR TITLE
Ensure hostnames are visible in CLI website

### DIFF
--- a/acceptance/testdata/repo/repo-rename-transfer-ownership.txtar
+++ b/acceptance/testdata/repo/repo-rename-transfer-ownership.txtar
@@ -3,7 +3,7 @@ exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
 
 # Attempt to rename the repo with a slash in the name
 ! exec gh repo rename $ORG/new-name --repo=$ORG/$SCRIPT_NAME-$RANDOM_STRING --yes
-stderr 'New repository name cannot contain \''/\'' character - to transfer a repository to a new owner, you must follow additional steps on <github.com>. For more information on transferring repository ownership, see <https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository>.'
+stderr 'New repository name cannot contain \''/\'' character - to transfer a repository to a new owner, see <https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository>.'
 
 # Defer repo deletion
 defer gh repo delete $ORG/$SCRIPT_NAME-$RANDOM_STRING --yes

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -199,15 +199,15 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 			[.[].data.viewer.repositories.nodes[]] as $r | count(select($r[].isFork))/count($r[])'
 		`),
 		Annotations: map[string]string{
-			"help:environment": heredoc.Doc(`
+			"help:environment": heredoc.Docf(`
 				GH_TOKEN, GITHUB_TOKEN (in order of precedence): an authentication token for
-				<github.com> API requests.
+				%[1]sgithub.com%[1]s API requests.
 
 				GH_ENTERPRISE_TOKEN, GITHUB_ENTERPRISE_TOKEN (in order of precedence): an
 				authentication token for API requests to GitHub Enterprise.
 
-				GH_HOST: make the request to a GitHub host other than <github.com>.
-			`),
+				GH_HOST: make the request to a GitHub host other than %[1]sgithub.com%[1]s.
+			`, "`"),
 		},
 		Args: cobra.ExactArgs(1),
 		PreRun: func(c *cobra.Command, args []string) {

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -95,7 +95,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			# Start interactive setup
 			$ gh auth login
 
-			# Authenticate against <github.com> by reading the token from a file
+			# Authenticate against github.com by reading the token from a file
 			$ gh auth login --with-token < mytoken.txt
 
 			# Authenticate with specific host

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -300,7 +300,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 
 					For GitHub repositories, the repository argument can be specified in
 					%[1]sOWNER/REPO%[1]s format or as a full repository URL.
-					The URL format is useful when the repository is not hosted on <github.com>.
+					The URL format is useful when the repository is not hosted on %[1]sgithub.com%[1]s.
 
 					For remote repositories, the GitHub CLI first looks for the release artifacts assuming
 					that it's a binary extension i.e. prebuilt binaries provided as part of the release.

--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -59,7 +59,7 @@ func NewCmdRename(f *cmdutil.Factory, runf func(*RenameOptions) error) *cobra.Co
 			with %[1]s--repo%[1]s is renamed.
 
 			To transfer repository ownership to another user account or organization,
-			you must follow additional steps on <github.com>.
+			you must follow additional steps on %[1]sgithub.com%[1]s.
 
 			For more information on transferring repository ownership, see:
 			<https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository>

--- a/pkg/cmd/repo/rename/rename.go
+++ b/pkg/cmd/repo/rename/rename.go
@@ -126,7 +126,7 @@ func renameRun(opts *RenameOptions) error {
 	}
 
 	if strings.Contains(newRepoName, "/") {
-		return fmt.Errorf("New repository name cannot contain '/' character - to transfer a repository to a new owner, you must follow additional steps on <github.com>. For more information on transferring repository ownership, see <https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository>.")
+		return fmt.Errorf("New repository name cannot contain '/' character - to transfer a repository to a new owner, see <https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository>.")
 	}
 
 	if opts.DoConfirm {

--- a/pkg/cmd/repo/rename/rename_test.go
+++ b/pkg/cmd/repo/rename/rename_test.go
@@ -227,7 +227,7 @@ func TestRenameRun(t *testing.T) {
 				newRepoSelector: "org/new-name",
 			},
 			wantErr: true,
-			errMsg:  "New repository name cannot contain '/' character - to transfer a repository to a new owner, you must follow additional steps on <github.com>. For more information on transferring repository ownership, see <https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository>.",
+			errMsg:  "New repository name cannot contain '/' character - to transfer a repository to a new owner, see <https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository>.",
 		},
 	}
 

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -43,7 +43,7 @@ var HelpTopics = []helpTopic{
 		short: "Environment variables that can be used with gh",
 		long: heredoc.Docf(`
 			%[1]sGH_TOKEN%[1]s, %[1]sGITHUB_TOKEN%[1]s (in order of precedence): an authentication token that will be used when
-			a command targets either <github.com> or a subdomain of <ghe.com>. Setting this avoids being prompted to
+			a command targets either %[1]sgithub.com%[1]s or a subdomain of %[1]sghe.com%[1]s. Setting this avoids being prompted to
 			authenticate and takes precedence over previously stored credentials.
 
 			%[1]sGH_ENTERPRISE_TOKEN%[1]s, %[1]sGITHUB_ENTERPRISE_TOKEN%[1]s (in order of precedence): an authentication

--- a/pkg/cmd/search/code/code.go
+++ b/pkg/cmd/search/code/code.go
@@ -33,16 +33,16 @@ func NewCmdCode(f *cmdutil.Factory, runF func(*CodeOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "code <query>",
 		Short: "Search within code",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Search within code in GitHub repositories.
 
 			The search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-code>
 
 			Note that these search results are powered by what is now a legacy GitHub code search engine.
-			The results might not match what is seen on <github.com>, and new features like regex search
+			The results might not match what is seen on %[1]sgithub.com%[1]s, and new features like regex search
 			are not yet available via the GitHub API.
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			# Search code matching "react" and "lifecycle"
 			$ gh search code react lifecycle


### PR DESCRIPTION
Fixes #11294

This commit changes `<github.com>` and `<ghe.com>` references to ``github.com`` and ``ghe.com`` so they are visible on the GitHub CLI marketing website.

GitHub Pages will render URLs with a protocol as clickable links, however hostnames are treated as HTML elements and not rendered.

### Questions

1. Is there a better way to ensure people understand the formatting conventions?

   Rather than people having to run across issues and PRs like #8404, I wondered if there was an easier way to help maintainers and contributors figure out the right thing to do.

### Demo

- `bin/gh api --help`

  ```
  ENVIRONMENT VARIABLES
    GH_TOKEN, GITHUB_TOKEN (in order of precedence): an authentication token for
    `github.com` API requests.
    
    GH_ENTERPRISE_TOKEN, GITHUB_ENTERPRISE_TOKEN (in order of precedence): an
    authentication token for API requests to GitHub Enterprise.
    
    GH_HOST: make the request to a GitHub host other than `github.com`.
  ```

- `bin/gh ext install --help`

  ```
  Install a GitHub CLI extension from a GitHub or local repository.
  
  For GitHub repositories, the repository argument can be specified in
  `OWNER/REPO` format or as a full repository URL.
  The URL format is useful when the repository is not hosted on `github.com`.
  ```

- `bin/gh repo rename --help`

  ```
  Rename a GitHub repository.
  
  `<new-name>` is the desired repository name without the owner.
  
  By default, the current repository is renamed. Otherwise, the repository specified
  with `--repo` is renamed.
  
  To transfer repository ownership to another user account or organization,
  you must follow additional steps on `github.com`.
  ```

- `bin/gh help environment`

  ```
  `GH_TOKEN`, `GITHUB_TOKEN` (in order of precedence): an authentication token that will be used when
  a command targets either `github.com` or a subdomain of `ghe.com`. Setting this avoids being prompted to
  authenticate and takes precedence over previously stored credentials.
  
  `GH_ENTERPRISE_TOKEN`, `GITHUB_ENTERPRISE_TOKEN` (in order of precedence): an authentication
  token that will be used when a command targets a GitHub Enterprise Server host.
  
  `GH_HOST`: specify the GitHub hostname for commands where a hostname has not been provided, or
  cannot be inferred from the context of a local Git repository. If this host was previously
  authenticated with, the stored credentials will be used. Otherwise, setting `GH_TOKEN` or
  `GH_ENTERPRISE_TOKEN` is required, depending on the targeted host.
  ```

- `bin/gh search code --help`

  ```
  Search within code in GitHub repositories.
  
  The search syntax is documented at:
  <https://docs.github.com/search-github/searching-on-github/searching-code>
  
  Note that these search results are powered by what is now a legacy GitHub code search engine.
  The results might not match what is seen on `github.com`, and new features like regex search
  are not yet available via the GitHub API.
  ```
