### PR TITLE
Include immutable field in `release list` command

### DIFF
--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -17,6 +17,7 @@ var releaseFields = []string{
 	"isDraft",
 	"isLatest",
 	"isPrerelease",
+	"isImmutable",
 	"createdAt",
 	"publishedAt",
 }
@@ -27,6 +28,7 @@ type Release struct {
 	IsDraft      bool
 	IsLatest     bool
 	IsPrerelease bool
+	IsImmutable  bool `graphql:"immutable"`
 	CreatedAt    time.Time
 	PublishedAt  time.Time
 }

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -239,6 +239,7 @@ func TestExportReleases(t *testing.T) {
 		IsDraft:      true,
 		IsLatest:     false,
 		IsPrerelease: true,
+		IsImmutable:  true,
 		CreatedAt:    createdAt,
 		PublishedAt:  publishedAt,
 	}}
@@ -246,6 +247,6 @@ func TestExportReleases(t *testing.T) {
 	exporter.SetFields(releaseFields)
 	require.NoError(t, exporter.Write(ios, rs))
 	require.JSONEq(t,
-		`[{"createdAt":"2024-01-01T00:00:00Z","isDraft":true,"isLatest":false,"isPrerelease":true,"name":"v1","publishedAt":"2024-02-01T00:00:00Z","tagName":"tag"}]`,
+		`[{"createdAt":"2024-01-01T00:00:00Z","isDraft":true,"isLatest":false,"isPrerelease":true,"isImmutable":true,"name":"v1","publishedAt":"2024-02-01T00:00:00Z","tagName":"tag"}]`,
 		stdout.String())
 }


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes: https://github.com/cli/cli/issues/11272

Updates the json fields exposed by the `release list` command to include `isImmutable`. The `isImmutable` flag indicates whether or not a given release has been published as an immutable release.
