### PR TITLE
Add automated feature request response workflow

### DIFF
--- a/.github/workflows/feature-request-comment.yml
+++ b/.github/workflows/feature-request-comment.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   add-comment-to-feature-request-issues:
-    if: github.event.label.name == 'feature-request'
+    if: github.event.label.name == 'enhancement'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/feature-request-comment.yml
+++ b/.github/workflows/feature-request-comment.yml
@@ -1,0 +1,36 @@
+name: Add feature-request comment
+on:
+  issues:
+    types:
+      - labeled
+
+permissions:
+  issues: write
+
+jobs:
+  add-comment-to-feature-request-issues:
+    if: github.event.label.name == 'feature-request'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      NUMBER: ${{ github.event.issue.number }}
+      BODY: >
+        Thank you for your issue! We have categorized it as a feature request,
+        and it has been added to our backlog. In doing so, **we are not
+        committing to implementing this feature at this time**, but, we will
+        consider it for future releases based on community feedback and our own
+        product roadmap. 
+
+
+        Unless you see the
+        https://github.com/cli/cli/labels/help%20wanted label, we are
+        not currently looking for external contributions for this feature.
+
+
+        **If you come across this issue and would like to see it implemented,
+        please add a thumbs up!** This will help us prioritize the feature.
+        Please only comment if you have additional information or viewpoints to
+        contribute.
+    steps:
+      - run: gh issue comment "$NUMBER" --body "$BODY"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically comment on issues labeled as "feature-request."

This change is to support our new most-reactions-first approach to triaging enhancements.

Adapted from [GitHub Desktop's comment workflow](https://github.com/desktop/desktop/blob/development/.github/workflows/feature-request-comment.yml).