### PR TITLE
Respect `--title` and `--body` in `pr create` web mode (second attempt)

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -596,34 +596,33 @@ func createRun(opts *CreateOptions) error {
 
 var regexPattern = regexp.MustCompile(`(?m)^`)
 
-func initDefaultTitleBody(ctx CreateContext, state *shared.IssueMetadataState, useFirstCommit bool, addBody bool) error {
+func computeDefaultTitleBody(ctx CreateContext, useFirstCommit bool, addBody bool) (string, string, error) {
 	commits, err := ctx.GitClient.Commits(context.Background(), ctx.BaseTrackingBranch, ctx.PRRefs.UnqualifiedHeadRef())
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
 	if len(commits) == 1 || useFirstCommit {
-		state.Title = commits[len(commits)-1].Title
-		state.Body = commits[len(commits)-1].Body
-	} else {
-		state.Title = humanize(ctx.PRRefs.UnqualifiedHeadRef())
-		var body strings.Builder
-		for i := len(commits) - 1; i >= 0; i-- {
-			fmt.Fprintf(&body, "- **%s**\n", commits[i].Title)
-			if addBody {
-				x := regexPattern.ReplaceAllString(commits[i].Body, "  ")
-				fmt.Fprintf(&body, "%s", x)
-
-				if i > 0 {
-					fmt.Fprintln(&body)
-					fmt.Fprintln(&body)
-				}
-			}
-		}
-		state.Body = body.String()
+		return commits[len(commits)-1].Title, commits[len(commits)-1].Body, nil
 	}
 
-	return nil
+	title := humanize(ctx.PRRefs.UnqualifiedHeadRef())
+	var sb strings.Builder
+	for i := len(commits) - 1; i >= 0; i-- {
+		fmt.Fprintf(&sb, "- **%s**\n", commits[i].Title)
+		if addBody {
+			x := regexPattern.ReplaceAllString(commits[i].Body, "  ")
+			fmt.Fprintf(&sb, "%s", x)
+
+			if i > 0 {
+				fmt.Fprintln(&sb)
+				fmt.Fprintln(&sb)
+			}
+		}
+	}
+	body := sb.String()
+
+	return title, body, nil
 }
 
 func NewIssueState(ctx CreateContext, opts CreateOptions) (*shared.IssueMetadataState, error) {
@@ -646,12 +645,21 @@ func NewIssueState(ctx CreateContext, opts CreateOptions) (*shared.IssueMetadata
 		ProjectTitles: opts.Projects,
 		Milestones:    milestoneTitles,
 		Draft:         opts.IsDraft,
+		Title:         opts.Title,
+		Body:          opts.Body,
 	}
 
 	if opts.FillVerbose || opts.Autofill || opts.FillFirst || !opts.TitleProvided || !opts.BodyProvided {
-		err := initDefaultTitleBody(ctx, state, opts.FillFirst, opts.FillVerbose)
+		title, body, err := computeDefaultTitleBody(ctx, opts.FillFirst, opts.FillVerbose)
 		if err != nil && (opts.FillVerbose || opts.Autofill || opts.FillFirst) {
 			return nil, fmt.Errorf("could not compute title or body defaults: %w", err)
+		} else {
+			if !opts.TitleProvided {
+				state.Title = title
+			}
+			if !opts.BodyProvided {
+				state.Body = body
+			}
 		}
 	}
 

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1129,7 +1129,13 @@ func Test_createRun(t *testing.T) {
 					httpmock.StringResponse(`{"data": {"viewer": {"login": "OWNER"} } }`))
 			},
 			cmdStubs: func(cs *run.CommandStubber) {
-				cs.Register(`git( .+)? log( .+)? origin/master\.\.\.feature`, 0, "")
+				// Here we simulate a non-empty git history, and we want to see that the title/body fields are not populated from it, since no fill option is provided.
+				cs.Register(
+					"git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry origin/master...feature",
+					0,
+					"56b6f8bb7c9e3a30093cd17e48934ce354148e80\u0000second commit of pr\u0000\u0000\n"+
+						"3a9b48085046d156c5acce8f3b3a0532cd706a4a\u0000first commit of pr\u0000first commit description\u0000\n",
+				)
 				cs.Register("git rev-parse --symbolic-full-name feature@{push}", 0, "refs/remotes/origin/feature")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 1, "")
 				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 1, "")
@@ -1146,6 +1152,182 @@ func Test_createRun(t *testing.T) {
 			},
 			expectedErrOut: "Opening https://github.com/OWNER/REPO/compare/master...feature in your browser.\n",
 			expectedBrowse: "https://github.com/OWNER/REPO/compare/master...feature?body=&expand=1",
+		},
+		{
+			name: "web with --fill",
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.WebMode = true
+				opts.HeadBranch = "feature"
+				opts.Autofill = true
+				return func() {}
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				cs.Register(
+					"git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry origin/master...feature",
+					0,
+					"56b6f8bb7c9e3a30093cd17e48934ce354148e80\u0000second commit of pr\u0000\u0000\n"+
+						"3a9b48085046d156c5acce8f3b3a0532cd706a4a\u0000first commit of pr\u0000first commit description\u0000\n",
+				)
+			},
+			expectedBrowse: "https://github.com/OWNER/REPO/compare/master...feature?body=-+%2A%2Afirst+commit+of+pr%2A%2A%0A-+%2A%2Asecond+commit+of+pr%2A%2A%0A&expand=1&title=feature",
+		},
+		{
+			name: "web with --fill-first",
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.WebMode = true
+				opts.HeadBranch = "feature"
+				opts.FillFirst = true
+				return func() {}
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				cs.Register(
+					"git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry origin/master...feature",
+					0,
+					"56b6f8bb7c9e3a30093cd17e48934ce354148e80\u0000second commit of pr\u0000\u0000\n"+
+						"3a9b48085046d156c5acce8f3b3a0532cd706a4a\u0000first commit of pr\u0000first commit description\u0000\n",
+				)
+			},
+			expectedBrowse: "https://github.com/OWNER/REPO/compare/master...feature?body=first+commit+description&expand=1&title=first+commit+of+pr",
+		},
+		{
+			name: "web with --title",
+			tty:  true,
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.WebMode = true
+				opts.TitleProvided = true
+				opts.Title = "foo"
+				return func() {}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.StubRepoResponse("OWNER", "REPO")
+				reg.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StringResponse(`{"data": {"viewer": {"login": "OWNER"} } }`))
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				// Here we simulate a non-empty git history, and we want to see that the body field is not populated from it, since no fill option is provided.
+				cs.Register(
+					"git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry origin/master...feature",
+					0,
+					"56b6f8bb7c9e3a30093cd17e48934ce354148e80\u0000second commit of pr\u0000\u0000\n"+
+						"3a9b48085046d156c5acce8f3b3a0532cd706a4a\u0000first commit of pr\u0000first commit description\u0000\n",
+				)
+				cs.Register("git rev-parse --symbolic-full-name feature@{push}", 0, "refs/remotes/origin/feature")
+				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 1, "")
+				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 1, "")
+				cs.Register(`git push --set-upstream origin HEAD:refs/heads/feature`, 0, "")
+			},
+			promptStubs: func(pm *prompter.PrompterMock) {
+				pm.SelectFunc = func(p, _ string, opts []string) (int, error) {
+					if p == "Where should we push the 'feature' branch?" {
+						return 0, nil
+					} else {
+						return -1, prompter.NoSuchPromptErr(p)
+					}
+				}
+			},
+			expectedErrOut: "Opening https://github.com/OWNER/REPO/compare/master...feature in your browser.\n",
+			expectedBrowse: "https://github.com/OWNER/REPO/compare/master...feature?body=&expand=1&title=foo",
+		},
+		{
+			name: "web with --body",
+			tty:  true,
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.WebMode = true
+				opts.BodyProvided = true
+				opts.Body = "foo"
+				return func() {}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.StubRepoResponse("OWNER", "REPO")
+				reg.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StringResponse(`{"data": {"viewer": {"login": "OWNER"} } }`))
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				// Here we simulate a non-empty git history, and we want to see that the title field is not populated from it, since no fill option is provided.
+				cs.Register(
+					"git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry origin/master...feature",
+					0,
+					"56b6f8bb7c9e3a30093cd17e48934ce354148e80\u0000second commit of pr\u0000\u0000\n"+
+						"3a9b48085046d156c5acce8f3b3a0532cd706a4a\u0000first commit of pr\u0000first commit description\u0000\n",
+				)
+				cs.Register("git rev-parse --symbolic-full-name feature@{push}", 0, "refs/remotes/origin/feature")
+				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 1, "")
+				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 1, "")
+				cs.Register(`git push --set-upstream origin HEAD:refs/heads/feature`, 0, "")
+			},
+			promptStubs: func(pm *prompter.PrompterMock) {
+				pm.SelectFunc = func(p, _ string, opts []string) (int, error) {
+					if p == "Where should we push the 'feature' branch?" {
+						return 0, nil
+					} else {
+						return -1, prompter.NoSuchPromptErr(p)
+					}
+				}
+			},
+			expectedErrOut: "Opening https://github.com/OWNER/REPO/compare/master...feature in your browser.\n",
+			expectedBrowse: "https://github.com/OWNER/REPO/compare/master...feature?body=foo&expand=1",
+		},
+		{
+			name: "web with --title and --body",
+			tty:  true,
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.WebMode = true
+				opts.TitleProvided = true
+				opts.Title = "foo"
+				opts.BodyProvided = true
+				opts.Body = "bar"
+				return func() {}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.StubRepoResponse("OWNER", "REPO")
+				reg.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StringResponse(`{"data": {"viewer": {"login": "OWNER"} } }`))
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				// Since both --title and --body options are provided, and also --fill is set, then no git log history
+				// should be used, thus no stub for it.
+				cs.Register("git rev-parse --symbolic-full-name feature@{push}", 0, "refs/remotes/origin/feature")
+				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 1, "")
+				cs.Register(`git show-ref --verify -- HEAD refs/remotes/origin/feature`, 1, "")
+				cs.Register(`git push --set-upstream origin HEAD:refs/heads/feature`, 0, "")
+			},
+			promptStubs: func(pm *prompter.PrompterMock) {
+				pm.SelectFunc = func(p, _ string, opts []string) (int, error) {
+					if p == "Where should we push the 'feature' branch?" {
+						return 0, nil
+					} else {
+						return -1, prompter.NoSuchPromptErr(p)
+					}
+				}
+			},
+			expectedErrOut: "Opening https://github.com/OWNER/REPO/compare/master...feature in your browser.\n",
+			expectedBrowse: "https://github.com/OWNER/REPO/compare/master...feature?body=bar&expand=1&title=foo",
+		},
+		{
+			name: "web with --title, --body and --fill (#10547)",
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.WebMode = true
+				opts.HeadBranch = "feature"
+				opts.TitleProvided = true
+				opts.Title = "foo"
+				opts.BodyProvided = true
+				opts.Body = "bar"
+				opts.Autofill = true
+				return func() {}
+			},
+			cmdStubs: func(cs *run.CommandStubber) {
+				// Here we simulate a non-empty git history, and we want to see that the title/body fields are not populated from it, since no fill option is provided.
+				cs.Register(
+					"git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry origin/master...feature",
+					0,
+					"56b6f8bb7c9e3a30093cd17e48934ce354148e80\u0000second commit of pr\u0000\u0000\n"+
+						"3a9b48085046d156c5acce8f3b3a0532cd706a4a\u0000first commit of pr\u0000first commit description\u0000\n",
+				)
+			},
+			expectedBrowse: "https://github.com/OWNER/REPO/compare/master...feature?body=bar&expand=1&title=foo",
 		},
 		{
 			name: "web project",


### PR DESCRIPTION
Fixes #10527 

This is a second attempt to fix the issue. The last PR (#10547) caused a regression by breaking the behaviour of `pr create --web` (i.e. with no `--title`, `--body`, or `-fill*` options).

In this PR:
- The underlying issue is resolved with a test case to confirm it. Unexpected of side effects of the `initDefaultTitleBody` is now fixed.
- A number of new test cases are added for the web mode operation to make sure we're covering more scenarios; I can't say *all*, though.
- An old web mode test that didn't capture the breaking changes of the last PR is now corrected to fully verify the `pr create --web` function. More on this specific test case in the following.

## Retrospective on the test case

The reason we didn't notice the breaking change in the last PR was landed, was this ineffective test case that was supposed to verify the behaviour of `pr create --web` (with no further options):

https://github.com/cli/cli/blob/dbff7c5655863cf1c1bf443fe8e41195e0074282/pkg/cmd/pr/create/create_test.go#L1118-L1149

Specifically, the below neutral stub is the reason why the breaking change didn't surface. Because it's simulating an empty git log, so with or without trying to fill the title and body fields the behaviour would be the same.

https://github.com/cli/cli/blob/dbff7c5655863cf1c1bf443fe8e41195e0074282/pkg/cmd/pr/create/create_test.go#L1132

