### PR TITLE
Avoid fetching logs for skipped jobs

### DIFF
--- a/pkg/cmd/run/shared/shared.go
+++ b/pkg/cmd/run/shared/shared.go
@@ -319,6 +319,10 @@ func IsFailureState(c Conclusion) bool {
 	}
 }
 
+func IsSkipped(c Conclusion) bool {
+	return c == Skipped
+}
+
 type RunsPayload struct {
 	TotalCount   int   `json:"total_count"`
 	WorkflowRuns []Run `json:"workflow_runs"`

--- a/pkg/cmd/run/shared/test.go
+++ b/pkg/cmd/run/shared/test.go
@@ -158,6 +158,18 @@ var LegacySuccessfulJobWithoutStepLogs Job = Job{
 	},
 }
 
+var SkippedJob Job = Job{
+	ID:          13,
+	Status:      Completed,
+	Conclusion:  Skipped,
+	Name:        "cool job",
+	StartedAt:   TestRunStartTime,
+	CompletedAt: TestRunStartTime,
+	URL:         "https://github.com/jobs/13",
+	RunID:       3,
+	Steps:       []Step{},
+}
+
 var FailedJob Job = Job{
 	ID:          20,
 	Status:      Completed,

--- a/pkg/cmd/run/view/logs.go
+++ b/pkg/cmd/run/view/logs.go
@@ -91,6 +91,10 @@ func populateLogSegments(httpClient *http.Client, repo ghrepo.Interface, jobs []
 
 	apiLogFetcherCount := 0
 	for _, job := range jobs {
+		if shared.IsSkipped(job.Conclusion) {
+			continue
+		}
+
 		if onlyFailed && !shared.IsFailureState(job.Conclusion) {
 			continue
 		}

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -2255,6 +2255,29 @@ func TestViewRun(t *testing.T) {
 			errMsg:  "job 20 is still in progress; logs will be available when it is complete",
 		},
 		{
+			name: "job log but job is skipped",
+			tty:  false,
+			opts: &ViewOptions{
+				JobID: "13",
+				Log:   true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/jobs/13"),
+					httpmock.JSONResponse(shared.SkippedJob))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/3"),
+					httpmock.JSONResponse(shared.SuccessfulRun))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/3/logs"),
+					httpmock.BinaryResponse(emptyZipArchive))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/123"),
+					httpmock.JSONResponse(shared.TestWorkflow))
+			},
+			wantOut: "",
+		},
+		{
 			name: "noninteractive with job",
 			opts: &ViewOptions{
 				JobID: "10",


### PR DESCRIPTION
Fixes #11311

This PR adds a check to avoid fetching logs for skipped jobs.

## A/C verification

This workflow run is a example of with a skipped job:
https://github.com/cli/cli/actions/runs/16168765316

### 1. An entire run log, with skipped job(s)

**Given** I have a run with one or more skipped jobs
**When** I run `gh run view --log <RUN-ID>`
**Then** The available job logs are displayed without error

#### Verification

Before:

```sh
gh run view --log 16168765316 | cat
# log not found: 45636838855
```

Now:

```sh
gh run view --log 16168765316 | cat
# (no error, empty content)
```

### 2. A single job that is skipped

**Given** I have a run with one or more skipped jobs
**When** I run `gh run view --log --job <JOB-ID>`
**Then** An empty log trail is displayed without error

#### Verification

Before:

```sh
gh run view --log --job 45636838855 | cat
# log not found: 45636838855
```

Now:

```sh
gh run view --log --job 45636838855 | cat
# (no error, empty content)
```