### PR TITLE
Potential fix for code scanning alert no. 169: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,5 +1,6 @@
 name: Discussion Triage
 run-name: ${{ github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title }}
+permissions: {}
 on:
   issues:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/cli/cli/security/code-scanning/169](https://github.com/cli/cli/security/code-scanning/169)

This workflow does not need any `GITHUB_TOKEN` permissions as it uses `CLI_DISCUSSION_TRIAGE_TOKEN`.

This proposes we remove all the permissions because they are not needed, and we do so with the `permissions: {}` syntax, [documented here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#defining-access-for-the-github_token-scopes).