### PR TITLE
Run Lint and Tests on `push` to `trunk` branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,9 @@
 name: Unit and Integration Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - trunk
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint
 on:
   push:
+    branches:
+      - trunk
     paths:
       - "**.go"
       - go.mod


### PR DESCRIPTION
Fixes #11310

This change causes the "Lint" and "Unit and Integration Tests" workflows to only run on `push` events on the default branch (`trunk`).

This should avoid running redundant set of jobs on pull requests.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
