### PR TITLE
update ownership of pkg/cmd/release/shared/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,10 @@ internal/codespaces/ @cli/codespaces
 
 # Limit Package Security team ownership to the attestation command package and related integration tests
 pkg/cmd/attestation/ @cli/package-security
-pkg/cmd/release/attestation @cli/package-security
-pkg/cmd/release/verify @cli/package-security
-pkg/cmd/release/verify-asset @cli/package-security
+pkg/cmd/release/attestation/ @cli/package-security
+pkg/cmd/release/verify/ @cli/package-security
+pkg/cmd/release/verify-asset/ @cli/package-security
+pkg/cmd/release/shared/ @cli/package-security
 
 test/integration/attestation-cmd @cli/package-security
 


### PR DESCRIPTION
Updates the `.github/CODEOWNERS` file to assign the ownership`pkg/cmd/release/shared/` to the Package Security team.
