### PR TITLE
Incorporate govulncheck into workflows

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,27 @@
+name: Go Vulnerability Check
+on:
+  schedule:
+    - cron: "0 0 * * 1" # Every Monday at midnight UTC
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      # `govulncheck -format sarif` exits successfully regardless of results, which are not in stdout.
+      # See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck#hdr-Exit_codes for more information on exit codes.
+      - name: Check Go vulnerabilities
+        run: |
+          make
+          go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 -mode=binary -format sarif bin/gh > gh.sarif
+
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@9b02dc2f60288b463e7a66e39c78829b62780db7 # 2.22.1
+        with:
+          sarif_file: gh.sarif

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,8 @@ on:
       - go.sum
       - ".github/licenses.tmpl"
       - "script/licenses*"
-
 permissions:
   contents: read
-
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,6 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -64,3 +63,22 @@ jobs:
           export PATH=${GOROOT}/bin:$PATH
           go install github.com/google/go-licenses@5348b744d0983d85713295ea08a20cca1654a45e
           make licenses-check
+
+  # Discover vulnerabilities within Go standard libraries used to build GitHub CLI using govulncheck.
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      # `govulncheck` exits unsuccessfully if vulnerabilities are found, providing results in stdout.
+      # See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck#hdr-Exit_codes for more information on exit codes.
+      - name: Check Go vulnerabilities
+        run: |
+          make
+          go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 -mode=binary bin/gh


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #11209

This pull request enhances the GitHub CLI workflows to detect and report vulnerabilities in Go standard libraries used by `gh`:

1. `lint.yml` workflow will report vulnerabilities during pull requests
2. `govulncheck.yml` workflow will report vulnerabilities as code security alerts on schedule
