### PR TITLE
refactor tests: use `slices.Equal` to simplify code

### DIFF
--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
@@ -163,7 +164,7 @@ func Test_RepoMetadata(t *testing.T) {
 	if err != nil {
 		t.Errorf("error resolving members: %v", err)
 	}
-	if !sliceEqual(memberIDs, expectedMemberIDs) {
+	if !slices.Equal(memberIDs, expectedMemberIDs) {
 		t.Errorf("expected members %v, got %v", expectedMemberIDs, memberIDs)
 	}
 
@@ -172,7 +173,7 @@ func Test_RepoMetadata(t *testing.T) {
 	if err != nil {
 		t.Errorf("error resolving teams: %v", err)
 	}
-	if !sliceEqual(teamIDs, expectedTeamIDs) {
+	if !slices.Equal(teamIDs, expectedTeamIDs) {
 		t.Errorf("expected teams %v, got %v", expectedTeamIDs, teamIDs)
 	}
 
@@ -181,7 +182,7 @@ func Test_RepoMetadata(t *testing.T) {
 	if err != nil {
 		t.Errorf("error resolving labels: %v", err)
 	}
-	if !sliceEqual(labelIDs, expectedLabelIDs) {
+	if !slices.Equal(labelIDs, expectedLabelIDs) {
 		t.Errorf("expected labels %v, got %v", expectedLabelIDs, labelIDs)
 	}
 
@@ -191,10 +192,10 @@ func Test_RepoMetadata(t *testing.T) {
 	if err != nil {
 		t.Errorf("error resolving projects: %v", err)
 	}
-	if !sliceEqual(projectIDs, expectedProjectIDs) {
+	if !slices.Equal(projectIDs, expectedProjectIDs) {
 		t.Errorf("expected projects %v, got %v", expectedProjectIDs, projectIDs)
 	}
-	if !sliceEqual(projectV2IDs, expectedProjectV2IDs) {
+	if !slices.Equal(projectV2IDs, expectedProjectV2IDs) {
 		t.Errorf("expected projectsV2 %v, got %v", expectedProjectV2IDs, projectV2IDs)
 	}
 
@@ -279,7 +280,7 @@ func Test_ProjectNamesToPaths(t *testing.T) {
 		}
 
 		expectedProjectPaths := []string{"ORG/1", "OWNER/REPO/2", "ORG/2", "OWNER/REPO/4", "MONALISA/5"}
-		if !sliceEqual(projectPaths, expectedProjectPaths) {
+		if !slices.Equal(projectPaths, expectedProjectPaths) {
 			t.Errorf("expected projects paths %v, got %v", expectedProjectPaths, projectPaths)
 		}
 	})
@@ -337,7 +338,7 @@ func Test_ProjectNamesToPaths(t *testing.T) {
 		}
 
 		expectedProjectPaths := []string{"ORG/2", "OWNER/REPO/4", "MONALISA/5"}
-		if !sliceEqual(projectPaths, expectedProjectPaths) {
+		if !slices.Equal(projectPaths, expectedProjectPaths) {
 			t.Errorf("expected projects paths %v, got %v", expectedProjectPaths, projectPaths)
 		}
 	})
@@ -449,20 +450,6 @@ func TestMembersToIDs(t *testing.T) {
 		_, err := repoMetadataResult.MembersToIDs([]string{"monalisa"})
 		require.Error(t, err)
 	})
-}
-
-func sliceEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-
-	return true
 }
 
 func Test_RepoMilestones(t *testing.T) {

--- a/pkg/cmd/codespace/delete_test.go
+++ b/pkg/cmd/codespace/delete_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -322,7 +323,7 @@ func TestDelete(t *testing.T) {
 				gotDeleted = append(gotDeleted, delArgs.Name)
 			}
 			sort.Strings(gotDeleted)
-			if !sliceEquals(gotDeleted, tt.wantDeleted) {
+			if !slices.Equal(gotDeleted, tt.wantDeleted) {
 				t.Errorf("deleted %q, want %q", gotDeleted, tt.wantDeleted)
 			}
 			if out := stdout.String(); out != tt.wantStdout {
@@ -333,18 +334,6 @@ func TestDelete(t *testing.T) {
 			}
 		})
 	}
-}
-
-func sliceEquals(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func sortLines(s string) string {


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).