### PR TITLE
Regenerate third-party licenses on trunk pushes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,15 +7,11 @@ on:
       - "**.go"
       - go.mod
       - go.sum
-      - ".github/licenses.tmpl"
-      - "script/licenses*"
   pull_request:
     paths:
       - "**.go"
       - go.mod
       - go.sum
-      - ".github/licenses.tmpl"
-      - "script/licenses*"
 permissions:
   contents: read
 jobs:
@@ -49,18 +45,6 @@ jobs:
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: v2.1.6
-
-      # actions/setup-go does not setup the installed toolchain to be preferred over the system install,
-      # which causes go-licenses to raise "Package ... does not have module info" errors.
-      # for more information, https://github.com/google/go-licenses/issues/244#issuecomment-1885098633
-      #
-      # go-licenses has been pinned for automation use.
-      - name: Check licenses
-        run: |
-          export GOROOT=$(go env GOROOT)
-          export PATH=${GOROOT}/bin:$PATH
-          go install github.com/google/go-licenses@5348b744d0983d85713295ea08a20cca1654a45e
-          make licenses-check
 
   # Discover vulnerabilities within Go standard libraries used to build GitHub CLI using govulncheck.
   govulncheck:

--- a/.github/workflows/third-party-licenses.yml
+++ b/.github/workflows/third-party-licenses.yml
@@ -4,10 +4,11 @@ on:
     branches:
       - trunk
     paths:
+      - .github/licenses.tmpl
+      - .github/workflows/third-party-licenses.yml
       - go.mod
       - go.sum
-      - ".github/licenses.tmpl"
-      - "script/licenses*"
+      - script/licenses*
 jobs:
   # This job is responsible for updating the third-party license reports and source code.
   # It should be safe to cancel as the latest version of `go.mod` should be checked in.
@@ -16,11 +17,13 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: true
+    permissions:
+      contents: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.AUTOMATION_TOKEN }}
+          ref: trunk
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/third-party-licenses.yml
+++ b/.github/workflows/third-party-licenses.yml
@@ -1,0 +1,49 @@
+name: Third Party Licenses
+on:
+  push:
+    branches:
+      - trunk
+    paths:
+      - go.mod
+      - go.sum
+      - ".github/licenses.tmpl"
+      - "script/licenses*"
+jobs:
+  # This job is responsible for updating the third-party license reports and source code.
+  # It should be safe to cancel as the latest version of `go.mod` should be checked in.
+  regenerate-licenses:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: true
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.AUTOMATION_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Regenerate licenses
+        run: |
+          export GOROOT=$(go env GOROOT)
+          export PATH=${GOROOT}/bin:$PATH
+          go install github.com/google/go-licenses@5348b744d0983d85713295ea08a20cca1654a45e
+          make licenses
+          git diff
+
+      - name: Commit and push changes
+        run: |
+          if git diff --exit-code; then
+            echo "No third-party license changes to commit"
+          else
+            git config --local user.name "github-actions[bot]"
+            git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add third-party third-party-licenses.*.md
+            git commit -m "Generate licenses - $GITHUB_SHA"
+            git pull
+            git push origin
+          fi


### PR DESCRIPTION
Fixes #11270

This commit refactors the work done in #11047 of blocking pull requests for manual `third-party` license updates to having GitHub Actions automatically update it on pushes to `trunk`.

This will allow maintainers to streamline Dependabot PR reviews while reducing contributor friction when changing dependencies.

## Demo

1. Demonstrating running GitHub Actions workflow that is canceled by newer workflow run

   <img width="5344" height="3054" alt="Screenshot 2025-08-01 at 3 33 10 PM" src="https://github.com/user-attachments/assets/4fbf5d2b-9d08-4d85-8fb8-924f05d08332" />

1. Demonstrating multiple GitHub Actions workflows being canceled by newer workflow run

   <img width="5344" height="3054" alt="Screenshot 2025-08-01 at 3 32 58 PM" src="https://github.com/user-attachments/assets/432dc34c-fd89-4d47-9315-8f62a01927e5" />

1. Demonstrating updates to third-party license documentation

   <img width="5344" height="3054" alt="Screenshot 2025-08-01 at 3 32 49 PM" src="https://github.com/user-attachments/assets/eaac886a-f973-43b1-a316-ca03cc36824c" />
