### PR TITLE
Fix `help wanted` label regexp in CI automation

### DIFF
--- a/.github/workflows/scripts/check-help-wanted.sh
+++ b/.github/workflows/scripts/check-help-wanted.sh
@@ -78,7 +78,7 @@ if [ ${#ISSUES_WITHOUT_HELP_WANTED[@]} -gt 0 ]; then
     gh pr comment "$PR_URL" --body-file - <<EOF
 Thank you for your pull request! 🎉
 
-This PR appears to fix the following issues that are not labeled with \`help wanted\`:
+This PR appears to fix the following issues that are not labeled with https://github.com/cli/cli/labels/help%20wanted:
 
 $ISSUE_LIST
 As outlined in our [Contributing Guidelines](https://github.com/cli/cli/blob/trunk/.github/CONTRIBUTING.md), we expect that PRs are only created for issues that have been labeled \`help wanted\`.

--- a/.github/workflows/scripts/check-help-wanted.sh
+++ b/.github/workflows/scripts/check-help-wanted.sh
@@ -56,7 +56,7 @@ for issue_num in $CLOSING_ISSUES; do
     fi
 
     # Check if 'help wanted' label exists
-    if ! echo "$LABELS" | grep -q "help wanted"; then
+    if ! echo "$LABELS" | grep -qE '^help wanted$'; then
         ISSUES_WITHOUT_HELP_WANTED+=("$issue_num")
         echo "Issue #$issue_num does not have 'help wanted' label"
     else


### PR DESCRIPTION
Fixes #11422 

In addition to the regexp, this PR also improves the looks of the automatic comment by using the link to the `help wanted` label. This is how the comment will look like (note that other references to the `help wanted` label are left as they were to avoid too much visual noise):

  <img width="810" height="449" alt="help-wanted-comment" src="https://github.com/user-attachments/assets/41c8ddb4-77e1-4027-80ed-8e9641ea8006" />
