### PR TITLE
Alias mappings against singular / plural confusions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -564,6 +564,14 @@ pager:
 # Aliases allow you to create nicknames for gh commands
 aliases:
   co: pr checkout
+  commits: commit
+  issues: issue
+  prs: pr
+  repos: repo
+  search commit: search commits
+  search issue: search issues
+  search pr: search prs
+  search repo: search repos
 # The path to a unix socket through which to send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
 http_unix_socket:
 # What web browser gh should use when opening URLs. If blank, will refer to environment.


### PR DESCRIPTION
( When getting started with using this tool, I would always stumble over this, so sending a PR now. 
  This is unlikely to be the best approach to fix it & I hope there's a way so these aliases do not show up in the config file or bash completion.. Regards! : )
