### PR TITLE
Update spam detection to comment on and close issue

### DIFF
--- a/.github/workflows/scripts/spam-detection/process-issue.sh
+++ b/.github/workflows/scripts/spam-detection/process-issue.sh
@@ -41,4 +41,4 @@ EOF
 gh issue edit --add-label "suspected-spam" --add-label "invalid" "$_issue_url"
 gh issue close --reason 'not planned' "$_issue_url"
 
-echo "issue labelled as suspected spam"
+echo "issue processed as suspected spam: commented, closed, and labeled"

--- a/.github/workflows/scripts/spam-detection/process-issue.sh
+++ b/.github/workflows/scripts/spam-detection/process-issue.sh
@@ -39,6 +39,6 @@ We appreciate your understanding and apologize if this action was taken in error
 EOF
 
 gh issue edit --add-label "suspected-spam" --add-label "invalid" "$_issue_url"
-gh issue close "$_issue_url"
+gh issue close --reason 'not planned' "$_issue_url"
 
 echo "issue labelled as suspected spam"

--- a/.github/workflows/scripts/spam-detection/process-issue.sh
+++ b/.github/workflows/scripts/spam-detection/process-issue.sh
@@ -9,16 +9,17 @@
 
 set -euo pipefail
 
+# Determine absolute path to script directory based on where it is called from.
+# This allows the script to be run from any directory.
+SPAM_DIR="$(dirname "$(realpath "$0")")"
+
 _issue_url="$1"
 if [[ -z "$_issue_url" ]]; then
     echo "error: issue URL is empty" >&2
     exit 1
 fi
 
-_suspected_spam_label="suspected-spam"
-_check_issue_script=".github/workflows/scripts/spam-detection/check-issue.sh"
-
-_result="$($_check_issue_script "$_issue_url")"
+_result="$("$SPAM_DIR/check-issue.sh" "$_issue_url")"
 
 if [[ "$_result" == "PASS" ]]; then
     echo "detected as not-spam: $_issue_url"
@@ -27,6 +28,17 @@ fi
 
 echo "detected as spam: $_issue_url"
 
-gh issue edit --add-label "$_suspected_spam_label" "$_issue_url"
+cat << EOF | gh issue comment "$_issue_url" --body-file -
+Thank you for taking the time to create this issue.
+
+We've automatically reviewed this issue and suspect it as potentially inauthentic or spam-like content. As a result, we're closing this issue.
+
+**If this was closed by mistake**, please don't hesitate to reach out to us by commenting on this issue with additional context.
+
+We appreciate your understanding and apologize if this action was taken in error. Our automated systems help us manage the large volume of issues we receive, but we know they're not perfect.
+EOF
+
+gh issue edit --add-label "suspected-spam" --add-label "invalid" "$_issue_url"
+gh issue close "$_issue_url"
 
 echo "issue labelled as suspected spam"


### PR DESCRIPTION
Fixes #11408

These changes enhance the GitHub CLI spam detection logic to automatically comment on and close suspected spam based on the past weeks of usage.

Additionally, there were a few minor enhancements to the script, allowing it to be executed from anywhere rather than the root of the local repository.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

## Demo

**Issue:** https://github.com/tinyfists/detect-spam/issues/1

As you can see here, I reused one of the issue templates from `cli/cli` that our spam detection uses as a reference and tested on it:

```shell
$ ~/Documents/workspace/cli/cli/.github/workflows/scripts/spam-detection/process-issue.sh https://github.com/tinyfists/detect-spam/issues/1
detected as spam: https://github.com/tinyfists/detect-spam/issues/1
https://github.com/tinyfists/detect-spam/issues/1#issuecomment-3145732065
Fetching repository information...
Updating 1 issues...
https://github.com/tinyfists/detect-spam/issues/1
✓ Closed issue tinyfists/detect-spam#1 (Bug report)
issue labelled as suspected spam
```

As you can see from the issue, it worked as expected and I was able to execute the script from an arbitrary location rather than the root of the repository.
