### PR TITLE
Update issue triage guidelines and label usage

### DIFF
--- a/docs/triage.md
+++ b/docs/triage.md
@@ -6,9 +6,11 @@ As we get more issues and pull requests opened on the GitHub CLI, we've decided 
 
 Review and label [open issues missing either the `enhancement`, `bug`, or `docs` label](https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+-label%3Abug%2Cenhancement%2Cdocs+) and the label(s) corresponding to the command space prefixed with `gh-`, such as `gh-pr` for the `gh pr` command set, or `gh-extension` for the `gh extension` command set. 
 
-Then, engage with the issue and community with the goal to remove the `needs-triage` label from the issue. The heuristics for triaging the different issue types are as follow:
+The heuristics for triaging the different issue types are as follows:
 
 ### Bugs
+
+For bugs, the FR should engage with the issue and community with the goal to remove the `needs-triage` label from the issue.
 
 To be considered triaged, `bug` issues require the following:
 
@@ -23,33 +25,55 @@ To be considered triaged, `bug` issues require the following:
 | `p2` | Affects more than a few users but doesn't prevent core functions |
 | `p3` | Affects a small number of users or is largely cosmetic |
 
-### Enhancements
+### Enhancements & Docs
 
-To be considered triaged, `enhancement` issues require either
+For `enhancement` issues, the FR's role is to prepare the issue for team review and triage.
 
-- Clearly defined Acceptance Criteria as above 
-- The `needs-investigation` or `needs-design` label with a clearly defined set of open questions to be investigated.
+When a new issue is opened, the FR **should**:
 
-### Docs
+- Acknowledge the issue
+- Assign themselves to the issue
+- Ensure there is enough information to understand the enhancement's scope and value
+- Ask the user for more information about value and use-case, if necessary
+- Leave the `needs-triage` label on the issue
+- Add the `needs-user-input` and `needs-investigation` labels as needed
 
-To be considered triaged, `docs` issues require clearly defined Acceptance Criteria, as defined above 
+When the FR has enough information to be triaged, they should:
+- Remove the `needs-user-input` and `needs-investigation` labels
+- Remove their assignment from the issue
 
-## Additional triaging processes and labels
+The FR should **avoid**:
 
-Before removing the `needs-triage` label, consider adding any of the following labels below.
+- Thoroughly investigating the enhancement's technical feasibility
+- Prematurely accepting the enhancement request
+- Removing the `needs-triage` label
+- Labeling issues as `help wanted`
+
+## Additional triaging labels
+
+The FR can consider adding any of the following labels below.
 
 | Label | Description |
 | - | - |
 | `discuss` | Some issues require discussion with the internal team. Adding this label will automatically open up an internal discussion with the team to facilitate this discussion. |
 | `core` |  Defines what we would like to do internally. We tend to lean towards `help wanted` by default, and adding `core` should be reserved for trickier issues or implementations we have strong opinions/preferences about. |
-| `good first issue` | Used to denote when an issue may be a good candidate for a first-time contributor to the CLI. These are usually small and well defined issues. |
-| `help wanted` |  Defines what we feel the community could solve should they care to contribute, respectively. We tend to lean towards `help wanted` by default, and adding `core` should be reserved for trickier issues or implementations we have strong opinions/preferences about. |
-| `invalid` | Added to spam and abusive issues. |
 | `needs-user-input` | After asking any contributors for more information, add this label so it is clear that the issue has been responded to and we are waiting on the user. |
+| `needs-investigation` | Used when the issue requires further investigation before it can be reviewed and triaged. This is often used for issues that are not clearly bugs or enhancements, or when the FR needs to gather more information before proceeding. |
+| `invalid` | Added to spam and abusive issues. |
+
+### Labels for team enhancement triaging
+
+The FR should **avoid** adding these labels outside of team enhancement triage.
+
+| Label | Description |
+| - | - |
+| `good first issue` | Used to denote when an issue may be a good candidate for a first-time contributor to the CLI. These are usually small and well defined issues. |
+| `help wanted` | These issues are ready for community contribution. |
+| `help wanted candidate` | Used to denote when an issue may be a good candidate for community contribution. Issues labelled this way are discussed internally and may be promoted to `help wanted`. |
 
 ## Expectations for community pull requests
 
-All incoming pull requests are assigned to one of the engineers for review on a round-robin basis.
+All incoming pull requests are assigned to one of the engineers for review on a load balanced basis.
 The person in a triage role for a week could take a glance at these pull requests, mostly to see whether
 the changeset is feasible and to allow the associated CI run for new contributors.
 

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -73,7 +73,7 @@ The FR should **avoid** adding these labels outside of team enhancement triage.
 
 ## Expectations for community pull requests
 
-All incoming pull requests are assigned to one of the engineers for review on a load balanced basis.
+All incoming pull requests are assigned to one of the engineers for review on a load-balanced basis.
 The person in a triage role for a week could take a glance at these pull requests, mostly to see whether
 the changeset is feasible and to allow the associated CI run for new contributors.
 

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -25,7 +25,7 @@ To be considered triaged, `bug` issues require the following:
 | `p2` | Affects more than a few users but doesn't prevent core functions |
 | `p3` | Affects a small number of users or is largely cosmetic |
 
-### Enhancements & Docs
+### Enhancements and Docs
 
 For `enhancement` issues, the FR's role is to prepare the issue for team review and triage.
 


### PR DESCRIPTION
Clarifies the triage process for bugs, enhancements, and docs issues, including the responsibilities of the first responder (FR). Expands and reorganizes label definitions, adds new labels for investigation and team triage, and updates the pull request assignment process to be load balanced. Improves instructions for engaging with issues and managing labels.
