### PR TITLE
Update govulncheck workflow to scan source code

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -21,8 +21,7 @@ jobs:
       # See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck#hdr-Exit_codes for more information on exit codes.
       - name: Check Go vulnerabilities
         run: |
-          make
-          go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 -mode=binary -format sarif bin/gh > gh.sarif
+          go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 -format sarif ./... > gh.sarif
 
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@9b02dc2f60288b463e7a66e39c78829b62780db7 # 2.22.1


### PR DESCRIPTION
### Description

Our govulncheck workflow is failing to upload SARIF results to Code Scanning.

<img width="365" height="90" alt="image" src="https://github.com/user-attachments/assets/28ce2f1a-0535-4944-b509-4153191d3f63" />

<img width="1133" height="113" alt="image" src="https://github.com/user-attachments/assets/8d1affe8-4a11-4e4d-b82f-3bc7ccf2aa50" />

[See a workflow run here](https://github.com/cli/cli/actions/runs/16711055002)

### Explanation and solution

This is happening because we are scanning in binary mode. govulncheck is unable to deduce source code line numbers (`location`) from the binary. GitHub Code Scanning _requires_ this line number information to accept a SARIF file, otherwise it cannot provide annotations directly on the vulnerable code.

The solution is to have govulncheck run on source files (`./...`) instead of the built binary in binary mode. This way, govulncheck can find the source code line numbers (`location`) and include it in the SARIF, making GitHub Code Scanning accept it.


See [`physicallocation`object](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#physicallocation-object) for additional reference on this requirement. 