### PR TITLE
Report that v1 classic projects are detected on GHES 3.16.x or older

### DIFF
--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -211,8 +211,6 @@ const (
 )
 
 func (d *detector) ProjectsV1() gh.ProjectsV1Support {
-	// Currently, projects v1 support is entirely dependent on the host. As this is deprecated in GHES,
-	// we will do feature detection on whether the GHES version has support.
 	if !ghauth.IsEnterprise(d.host) {
 		return gh.ProjectsV1Unsupported
 	}

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/hashicorp/go-version"
 	"golang.org/x/sync/errgroup"
 
 	ghauth "github.com/cli/go-gh/v2/pkg/auth"
@@ -205,12 +206,37 @@ func (d *detector) RepositoryFeatures() (RepositoryFeatures, error) {
 	return features, nil
 }
 
+const (
+	enterpriseProjectsV1Removed = "3.17.0"
+)
+
 func (d *detector) ProjectsV1() gh.ProjectsV1Support {
 	// Currently, projects v1 support is entirely dependent on the host. As this is deprecated in GHES,
 	// we will do feature detection on whether the GHES version has support.
-	if ghauth.IsEnterprise(d.host) {
+	if !ghauth.IsEnterprise(d.host) {
+		return gh.ProjectsV1Unsupported
+	}
+
+	hostVersion, hostVersionErr := resolveEnterpriseVersion(d.httpClient, d.host)
+	v1ProjectCutoffVersion, v1ProjectCutoffVersionErr := version.NewVersion(enterpriseProjectsV1Removed)
+
+	if hostVersionErr == nil && v1ProjectCutoffVersionErr == nil && hostVersion.LessThan(v1ProjectCutoffVersion) {
 		return gh.ProjectsV1Supported
 	}
 
 	return gh.ProjectsV1Unsupported
+}
+
+func resolveEnterpriseVersion(httpClient *http.Client, host string) (*version.Version, error) {
+	var metaResponse struct {
+		InstalledVersion string `json:"installed_version"`
+	}
+
+	apiClient := api.NewClientFromHTTP(httpClient)
+	err := apiClient.REST(host, "GET", "meta", nil, &metaResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return version.NewVersion(metaResponse.InstalledVersion)
 }


### PR DESCRIPTION
Relates https://github.com/cli/cli/issues/10716

This change updates the feature detection logic around v1 classic projects, basing the decision on the installed version of GHES.

Going forward, v1 classic projects will only be supported on GHES 3.16 or older.
