### PR TITLE
Display v2 projects in `gh issue view`

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -166,7 +166,8 @@ type ProjectCards struct {
 }
 
 type ProjectItems struct {
-	Nodes []*ProjectV2Item
+	Nodes      []*ProjectV2Item
+	TotalCount int
 }
 
 type ProjectInfo struct {

--- a/api/queries_projects_v2.go
+++ b/api/queries_projects_v2.go
@@ -82,8 +82,9 @@ func ProjectsV2ItemsForIssue(client *Client, repo ghrepo.Interface, issue *Issue
 		Repository struct {
 			Issue struct {
 				ProjectItems struct {
-					Nodes    []*projectV2Item
-					PageInfo struct {
+					TotalCount int
+					Nodes      []*projectV2Item
+					PageInfo   struct {
 						HasNextPage bool
 						EndCursor   string
 					}


### PR DESCRIPTION
Relates #10708

These changes enhance `gh issue view` to display v2 projects that contain the issue during interactive and non-interactive modes.
