### PR TITLE
Hidden trusted root flag for release verify

### DIFF
--- a/pkg/cmd/release/shared/attestation.go
+++ b/pkg/cmd/release/shared/attestation.go
@@ -25,9 +25,10 @@ type Verifier interface {
 }
 
 type AttestationVerifier struct {
-	AttClient  api.Client
-	HttpClient *http.Client
-	IO         *iostreams.IOStreams
+	AttClient   api.Client
+	HttpClient  *http.Client
+	IO          *iostreams.IOStreams
+	TrustedRoot string
 }
 
 func (v *AttestationVerifier) VerifyAttestation(art *artifact.DigestedArtifact, att *api.Attestation) (*verification.AttestationProcessingResult, error) {
@@ -41,6 +42,7 @@ func (v *AttestationVerifier) VerifyAttestation(art *artifact.DigestedArtifact, 
 		Logger:       att_io.NewHandler(v.IO),
 		NoPublicGood: true,
 		TrustDomain:  td,
+		TrustedRoot:  v.TrustedRoot,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/release/verify-asset/verify_asset.go
+++ b/pkg/cmd/release/verify-asset/verify_asset.go
@@ -116,7 +116,7 @@ func NewCmdVerifyAsset(f *cmdutil.Factory, runF func(*VerifyAssetConfig) error) 
 		},
 	}
 	cmdutil.AddFormatFlags(cmd, &opts.Exporter)
-	cmd.Flags().StringVarP(&opts.TrustedRoot, "custom-trusted-root", "", "", "Path to a trusted_root.jsonl file; likely for offline verification")
+	cmd.Flags().StringVarP(&opts.TrustedRoot, "custom-trusted-root", "", "", "Path to a trusted_root.jsonl file; likely for offline verification.")
 	cmd.Flags().MarkHidden("custom-trusted-root")
 
 	return cmd

--- a/pkg/cmd/release/verify-asset/verify_asset.go
+++ b/pkg/cmd/release/verify-asset/verify_asset.go
@@ -24,6 +24,7 @@ type VerifyAssetOptions struct {
 	BaseRepo      ghrepo.Interface
 	Exporter      cmdutil.Exporter
 	AssetFilePath string
+	TrustedRoot   string
 }
 
 type VerifyAssetConfig struct {
@@ -93,9 +94,10 @@ func NewCmdVerifyAsset(f *cmdutil.Factory, runF func(*VerifyAssetConfig) error) 
 			attClient := api.NewLiveClient(httpClient, baseRepo.RepoHost(), att_io.NewHandler(io))
 
 			attVerifier := &shared.AttestationVerifier{
-				AttClient:  attClient,
-				HttpClient: httpClient,
-				IO:         io,
+				AttClient:   attClient,
+				HttpClient:  httpClient,
+				IO:          io,
+				TrustedRoot: opts.TrustedRoot,
 			}
 
 			config := &VerifyAssetConfig{
@@ -114,6 +116,8 @@ func NewCmdVerifyAsset(f *cmdutil.Factory, runF func(*VerifyAssetConfig) error) 
 		},
 	}
 	cmdutil.AddFormatFlags(cmd, &opts.Exporter)
+	cmd.Flags().StringVarP(&opts.TrustedRoot, "custom-trusted-root", "", "", "Path to a trusted_root.jsonl file; likely for offline verification")
+	cmd.Flags().MarkHidden("custom-trusted-root")
 
 	return cmd
 }

--- a/pkg/cmd/release/verify/verify.go
+++ b/pkg/cmd/release/verify/verify.go
@@ -109,7 +109,7 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 		},
 	}
 	cmdutil.AddFormatFlags(cmd, &opts.Exporter)
-	cmd.Flags().StringVarP(&opts.TrustedRoot, "custom-trusted-root", "", "", "Path to a trusted_root.jsonl file; likely for offline verification")
+	cmd.Flags().StringVarP(&opts.TrustedRoot, "custom-trusted-root", "", "", "Path to a trusted_root.jsonl file; likely for offline verification.")
 	cmd.Flags().MarkHidden("custom-trusted-root")
 
 	return cmd

--- a/pkg/cmd/release/verify/verify.go
+++ b/pkg/cmd/release/verify/verify.go
@@ -23,9 +23,10 @@ import (
 )
 
 type VerifyOptions struct {
-	TagName  string
-	BaseRepo ghrepo.Interface
-	Exporter cmdutil.Exporter
+	TagName     string
+	BaseRepo    ghrepo.Interface
+	Exporter    cmdutil.Exporter
+	TrustedRoot string
 }
 
 type VerifyConfig struct {
@@ -87,9 +88,10 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 			attClient := api.NewLiveClient(httpClient, baseRepo.RepoHost(), att_io.NewHandler(io))
 
 			attVerifier := &shared.AttestationVerifier{
-				AttClient:  attClient,
-				HttpClient: httpClient,
-				IO:         io,
+				AttClient:   attClient,
+				HttpClient:  httpClient,
+				IO:          io,
+				TrustedRoot: opts.TrustedRoot,
 			}
 
 			config := &VerifyConfig{
@@ -107,6 +109,8 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 		},
 	}
 	cmdutil.AddFormatFlags(cmd, &opts.Exporter)
+	cmd.Flags().StringVarP(&opts.TrustedRoot, "custom-trusted-root", "", "", "Path to a trusted_root.jsonl file; likely for offline verification")
+	cmd.Flags().MarkHidden("custom-trusted-root")
 
 	return cmd
 }


### PR DESCRIPTION
This pull request adds support for specifying a custom trusted root file for attestation verification in both the release `verify` and `verify-asset` commands. This allows  a custom `trusted_root.jsonl` file, enabling verification scenarios for alternative trust roots.