### PR TITLE
Add `--force` flag to `gh run cancel`

### DIFF
--- a/pkg/cmd/run/cancel/cancel.go
+++ b/pkg/cmd/run/cancel/cancel.go
@@ -23,6 +23,7 @@ type CancelOptions struct {
 	Prompt bool
 
 	RunID string
+	Force bool
 }
 
 func NewCmdCancel(f *cmdutil.Factory, runF func(*CancelOptions) error) *cobra.Command {
@@ -55,6 +56,8 @@ func NewCmdCancel(f *cmdutil.Factory, runF func(*CancelOptions) error) *cobra.Co
 			return runCancel(opts)
 		},
 	}
+
+	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Force cancel a workflow run when it doesn't respond to regular cancel")
 
 	return cmd
 }
@@ -115,7 +118,9 @@ func runCancel(opts *CancelOptions) error {
 		}
 	}
 
-	err = cancelWorkflowRun(client, repo, fmt.Sprintf("%d", run.ID))
+	force := opts.Force
+
+	err = cancelWorkflowRun(client, repo, fmt.Sprintf("%d", run.ID), force)
 	if err != nil {
 		var httpErr api.HTTPError
 		if errors.As(err, &httpErr) {
@@ -127,13 +132,22 @@ func runCancel(opts *CancelOptions) error {
 		return err
 	}
 
-	fmt.Fprintf(opts.IO.Out, "%s Request to cancel workflow %s submitted.\n", cs.SuccessIcon(), runID)
+	if force {
+		fmt.Fprintf(opts.IO.Out, "%s Request to force cancel workflow %s submitted.\n", cs.SuccessIcon(), runID)
+	} else {
+		fmt.Fprintf(opts.IO.Out, "%s Request to cancel workflow %s submitted.\n", cs.SuccessIcon(), runID)
+	}
 
 	return nil
 }
 
-func cancelWorkflowRun(client *api.Client, repo ghrepo.Interface, runID string) error {
-	path := fmt.Sprintf("repos/%s/actions/runs/%s/cancel", ghrepo.FullName(repo), runID)
+func cancelWorkflowRun(client *api.Client, repo ghrepo.Interface, runID string, force bool) error {
+	var path string
+	if force {
+		path = fmt.Sprintf("repos/%s/actions/runs/%s/force-cancel", ghrepo.FullName(repo), runID)
+	} else {
+		path = fmt.Sprintf("repos/%s/actions/runs/%s/cancel", ghrepo.FullName(repo), runID)
+	}
 
 	err := client.REST(repo.RepoHost(), "POST", path, nil, nil)
 	if err != nil {

--- a/pkg/cmd/run/cancel/cancel.go
+++ b/pkg/cmd/run/cancel/cancel.go
@@ -57,7 +57,7 @@ func NewCmdCancel(f *cmdutil.Factory, runF func(*CancelOptions) error) *cobra.Co
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Force cancel a workflow run when it doesn't respond to regular cancel")
+	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Force cancel a workflow run")
 
 	return cmd
 }

--- a/pkg/cmd/run/cancel/cancel.go
+++ b/pkg/cmd/run/cancel/cancel.go
@@ -57,7 +57,7 @@ func NewCmdCancel(f *cmdutil.Factory, runF func(*CancelOptions) error) *cobra.Co
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Force cancel a workflow run")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Force cancel a workflow run")
 
 	return cmd
 }


### PR DESCRIPTION
Fixes #11073.
# Description
Add `--force` flag to `gh run cancel` command which will force-cancel workflow run.
# Notes
* feat: add `--force` flag to `gh run cancel`