### PR TITLE
feat: `gh auth` Automatically copy one-time OAuth code to clipboard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
+	github.com/atotto/clipboard v0.1.4
 	github.com/briandowns/spinner v1.23.2
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cenkalti/backoff/v5 v5.0.2
@@ -84,7 +85,6 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.19.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -57,16 +57,15 @@ func AuthFlow(oauthHost string, IO *iostreams.IOStreams, notice string, addition
 		Scopes:       scopes,
 		DisplayCode: func(code, verificationURL string) error {
 			if isCopyToClipboard {
-				if err := clipboard.WriteAll(code); err != nil {
-					fmt.Fprintf(w, "%s Failed to copy one-time code to clipboard\n", cs.Red("!"))
-					fmt.Fprintf(w, "  %s\n", err)
-					fmt.Fprintf(w, "%s First copy your one-time code: %s\n", cs.Yellow("!"), cs.Bold(code))
-				} else {
+				err := clipboard.WriteAll(code)
+				if err == nil {
 					fmt.Fprintf(w, "%s One-time code (%s) copied to clipboard\n", cs.Yellow("!"), cs.Bold(code))
+					return nil
 				}
-			} else {
-				fmt.Fprintf(w, "%s First copy your one-time code: %s\n", cs.Yellow("!"), cs.Bold(code))
+				fmt.Fprintf(w, "%s Failed to copy one-time code to clipboard\n", cs.Red("!"))
+				fmt.Fprintf(w, "  %s\n", err)
 			}
+			fmt.Fprintf(w, "%s First copy your one-time code: %s\n", cs.Yellow("!"), cs.Bold(code))
 			return nil
 		},
 		BrowseURL: func(authURL string) error {

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -60,7 +60,7 @@ func AuthFlow(oauthHost string, IO *iostreams.IOStreams, notice string, addition
 				if err := clipboard.WriteAll(code); err != nil {
 					return err
 				}
-				fmt.Fprintf(w, "One-time code copied (%s) to clipboard\n", cs.Bold(code))
+				fmt.Fprintf(w, "%s One-time code (%s) copied to clipboard\n", cs.Yellow("!"), cs.Bold(code))
 			} else {
 				fmt.Fprintf(w, "%s First copy your one-time code: %s\n", cs.Yellow("!"), cs.Bold(code))
 			}

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -60,7 +60,7 @@ func AuthFlow(oauthHost string, IO *iostreams.IOStreams, notice string, addition
 				if err := clipboard.WriteAll(code); err != nil {
 					return err
 				}
-				fmt.Fprintf(w, "One-time code copied to clipboard")
+				fmt.Fprintf(w, "One-time code copied (%s) to clipboard\n", cs.Bold(code))
 			} else {
 				fmt.Fprintf(w, "%s First copy your one-time code: %s\n", cs.Yellow("!"), cs.Bold(code))
 			}

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/atotto/clipboard"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/ghinstance"
@@ -29,7 +30,7 @@ var (
 	jsonTypeRE = regexp.MustCompile(`[/+]json($|;)`)
 )
 
-func AuthFlow(oauthHost string, IO *iostreams.IOStreams, notice string, additionalScopes []string, isInteractive bool, b browser.Browser) (string, string, error) {
+func AuthFlow(oauthHost string, IO *iostreams.IOStreams, notice string, additionalScopes []string, isInteractive bool, b browser.Browser, isCopyToClipboard bool) (string, string, error) {
 	w := IO.ErrOut
 	cs := IO.ColorScheme()
 
@@ -55,7 +56,14 @@ func AuthFlow(oauthHost string, IO *iostreams.IOStreams, notice string, addition
 		CallbackURI:  getCallbackURI(oauthHost),
 		Scopes:       scopes,
 		DisplayCode: func(code, verificationURL string) error {
-			fmt.Fprintf(w, "%s First copy your one-time code: %s\n", cs.Yellow("!"), cs.Bold(code))
+			if isCopyToClipboard {
+				if err := clipboard.WriteAll(code); err != nil {
+					return err
+				}
+				fmt.Fprintf(w, "One-time code copied to clipboard")
+			} else {
+				fmt.Fprintf(w, "%s First copy your one-time code: %s\n", cs.Yellow("!"), cs.Bold(code))
+			}
 			return nil
 		},
 		BrowseURL: func(authURL string) error {

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -58,9 +58,12 @@ func AuthFlow(oauthHost string, IO *iostreams.IOStreams, notice string, addition
 		DisplayCode: func(code, verificationURL string) error {
 			if isCopyToClipboard {
 				if err := clipboard.WriteAll(code); err != nil {
-					return err
+					fmt.Fprintf(w, "%s Failed to copy one-time code to clipboard\n", cs.Red("!"))
+					fmt.Fprintf(w, "  %s\n", err)
+					fmt.Fprintf(w, "%s First copy your one-time code: %s\n", cs.Yellow("!"), cs.Bold(code))
+				} else {
+					fmt.Fprintf(w, "%s One-time code (%s) copied to clipboard\n", cs.Yellow("!"), cs.Bold(code))
 				}
-				fmt.Fprintf(w, "%s One-time code (%s) copied to clipboard\n", cs.Yellow("!"), cs.Bold(code))
 			} else {
 				fmt.Fprintf(w, "%s First copy your one-time code: %s\n", cs.Yellow("!"), cs.Bold(code))
 			}

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -96,7 +96,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			# Start interactive setup
 			$ gh auth login
 
-			# Login with your browser and copy OAuth code
+			# Open a browser to authenticate and copy one-time OAuth code to clipboard
 			$ gh auth login --web --clipboard
 
 			# Authenticate against github.com by reading the token from a file

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -38,6 +38,7 @@ type LoginOptions struct {
 	GitProtocol      string
 	InsecureStorage  bool
 	SkipSSHKeyPrompt bool
+	Clipboard        bool
 }
 
 func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Command {
@@ -95,6 +96,9 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 			# Start interactive setup
 			$ gh auth login
 
+			# Login with your browser and copy OAuth code
+			$ gh auth login --web --clipboard
+
 			# Authenticate against github.com by reading the token from a file
 			$ gh auth login --with-token < mytoken.txt
 
@@ -145,6 +149,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", nil, "Additional authentication scopes to request")
 	cmd.Flags().BoolVar(&tokenStdin, "with-token", false, "Read token from standard input")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open a browser to authenticate")
+	cmd.Flags().BoolVarP(&opts.Clipboard, "clipboard", "c", false, "Copy one-time OAuth device code to clipboard")
 	cmdutil.StringEnumFlag(cmd, &opts.GitProtocol, "git-protocol", "p", "", []string{"ssh", "https"}, "The protocol to use for git operations on this host")
 
 	// secure storage became the default on 2023/4/04; this flag is left as a no-op for backwards compatibility
@@ -227,6 +232,7 @@ func loginRun(opts *LoginOptions) error {
 		},
 		SecureStorage:    !opts.InsecureStorage,
 		SkipSSHKeyPrompt: opts.SkipSSHKeyPrompt,
+		CopyToClipboard:  opts.Clipboard,
 	})
 }
 

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -130,6 +130,26 @@ func Test_NewCmdLogin(t *testing.T) {
 			},
 		},
 		{
+			name:     "tty web and clipboard",
+			stdinTTY: true,
+			cli:      "--web --clipboard",
+			wants: LoginOptions{
+				Hostname:    "github.com",
+				Web:         true,
+				Interactive: true,
+				Clipboard:   true,
+			},
+		},
+		{
+			name: "nontty web and clipboard",
+			cli:  "--web --clipboard",
+			wants: LoginOptions{
+				Hostname:  "github.com",
+				Web:       true,
+				Clipboard: true,
+			},
+		},
+		{
 			name:     "tty web",
 			stdinTTY: true,
 			cli:      "--web",
@@ -273,6 +293,7 @@ func Test_NewCmdLogin(t *testing.T) {
 			assert.Equal(t, tt.wants.Web, gotOpts.Web)
 			assert.Equal(t, tt.wants.Interactive, gotOpts.Interactive)
 			assert.Equal(t, tt.wants.Scopes, gotOpts.Scopes)
+			assert.Equal(t, tt.wants.Clipboard, gotOpts.Clipboard)
 		})
 	}
 }

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -91,7 +91,7 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 			# Open a browser to re-authenticate with the default minimum scopes
 			$ gh auth refresh --reset-scopes
 
-			# Automatically copy one-time OAuth code
+			# Open a browser to re-authenticate and copy one-time OAuth code to clipboard
 			$ gh auth refresh --clipboard
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -92,7 +92,7 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 			$ gh auth refresh --reset-scopes
 
 			# Automatically copy one-time OAuth code
-			$ gh auth login --clipboard
+			$ gh auth refresh --clipboard
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Interactive = opts.IO.CanPrompt()

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -33,18 +33,19 @@ type RefreshOptions struct {
 	Scopes       []string
 	RemoveScopes []string
 	ResetScopes  bool
-	AuthFlow     func(*iostreams.IOStreams, string, []string, bool) (token, username, error)
+	AuthFlow     func(*iostreams.IOStreams, string, []string, bool, bool) (token, username, error)
 
 	Interactive     bool
 	InsecureStorage bool
+	Clipboard       bool
 }
 
 func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.Command {
 	opts := &RefreshOptions{
 		IO:     f.IOStreams,
 		Config: f.Config,
-		AuthFlow: func(io *iostreams.IOStreams, hostname string, scopes []string, interactive bool) (token, username, error) {
-			t, u, err := authflow.AuthFlow(hostname, io, "", scopes, interactive, f.Browser)
+		AuthFlow: func(io *iostreams.IOStreams, hostname string, scopes []string, interactive bool, clipboard bool) (token, username, error) {
+			t, u, err := authflow.AuthFlow(hostname, io, "", scopes, interactive, f.Browser, clipboard)
 			return token(t), username(u), err
 		},
 		HttpClient: &http.Client{},
@@ -89,6 +90,9 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 
 			# Open a browser to re-authenticate with the default minimum scopes
 			$ gh auth refresh --reset-scopes
+
+			# Automatically copy one-time OAuth code
+			$ gh auth login --clipboard
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Interactive = opts.IO.CanPrompt()
@@ -109,6 +113,7 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 	cmd.Flags().StringSliceVarP(&opts.Scopes, "scopes", "s", nil, "Additional authentication scopes for gh to have")
 	cmd.Flags().StringSliceVarP(&opts.RemoveScopes, "remove-scopes", "r", nil, "Authentication scopes to remove from gh")
 	cmd.Flags().BoolVar(&opts.ResetScopes, "reset-scopes", false, "Reset authentication scopes to the default minimum set of scopes")
+	cmd.Flags().BoolVarP(&opts.Clipboard, "clipboard", "c", false, "Copy one-time OAuth device code to clipboard")
 	// secure storage became the default on 2023/4/04; this flag is left as a no-op for backwards compatibility
 	var secureStorage bool
 	cmd.Flags().BoolVar(&secureStorage, "secure-storage", false, "Save authentication credentials in secure credential store")
@@ -199,7 +204,7 @@ func refreshRun(opts *RefreshOptions) error {
 
 	additionalScopes.RemoveValues(opts.RemoveScopes)
 
-	authedToken, authedUser, err := opts.AuthFlow(opts.IO, hostname, additionalScopes.ToSlice(), opts.Interactive)
+	authedToken, authedUser, err := opts.AuthFlow(opts.IO, hostname, additionalScopes.ToSlice(), opts.Interactive, opts.Clipboard)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -40,6 +40,7 @@ type LoginOptions struct {
 	CredentialFlow   *GitCredentialFlow
 	SecureStorage    bool
 	SkipSSHKeyPrompt bool
+	CopyToClipboard  bool
 
 	sshContext ssh.Context
 }
@@ -148,7 +149,7 @@ func Login(opts *LoginOptions) error {
 
 	if authMode == 0 {
 		var err error
-		authToken, username, err = authflow.AuthFlow(hostname, opts.IO, "", append(opts.Scopes, additionalScopes...), opts.Interactive, opts.Browser)
+		authToken, username, err = authflow.AuthFlow(hostname, opts.IO, "", append(opts.Scopes, additionalScopes...), opts.Interactive, opts.Browser, opts.CopyToClipboard)
 		if err != nil {
 			return fmt.Errorf("failed to authenticate via web browser: %w", err)
 		}


### PR DESCRIPTION
Fixes #11354
# Description
Add `-c/--clipboard` flag to `gh auth login` and `gh auth refresh` which copies one-time OAuth device code to clipboard instead of just printing it.
# Notes
* feat: add ability to copy one-time OAuth code while logging in