### PR TITLE
docs(release create): difference `--generate-notes` and `--notes-from-tag`

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -94,9 +94,11 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			To create a release from an annotated git tag, first create one locally with
 			git, push the tag to GitHub, then run this command.
-			Use %[1]s--notes-from-tag%[1]s to automatically generate the release notes
+			Use %[1]s--notes-from-tag%[1]s to get the release notes
 			from the annotated git tag.
+			It will use annotation of git tag if it is annotated, associated with tag commit's message otherwise.
 
+			Use %[1]s--generate-notes%[1]s to automatically generate notes using GitHub Release Notes API.
 			When using automatically generated release notes, a release title will also be automatically
 			generated unless a title was explicitly passed. Additional release notes can be prepended to
 			automatically generated notes by using the %[1]s--notes%[1]s flag.
@@ -116,13 +118,13 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			# Non-interactively create a release
 			$ gh release create v1.2.3 --notes "bugfix release"
 
-			# Use automatically generated release notes
+			# Use automatically generated via GitHub Release Notes API release notes
 			$ gh release create v1.2.3 --generate-notes
 
 			# Use release notes from a file
 			$ gh release create v1.2.3 -F release-notes.md
 
-			# Use annotated tag notes
+			# Use tag annotation or associated commit message as notes
 			$ gh release create v1.2.3 --notes-from-tag
 
 			# Don't mark the release as latest
@@ -198,11 +200,11 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmd.Flags().StringVarP(&opts.Body, "notes", "n", "", "Release notes")
 	cmd.Flags().StringVarP(&notesFile, "notes-file", "F", "", "Read release notes from `file` (use \"-\" to read from standard input)")
 	cmd.Flags().StringVarP(&opts.DiscussionCategory, "discussion-category", "", "", "Start a discussion in the specified category")
-	cmd.Flags().BoolVarP(&opts.GenerateNotes, "generate-notes", "", false, "Automatically generate title and notes for the release")
+	cmd.Flags().BoolVarP(&opts.GenerateNotes, "generate-notes", "", false, "Automatically generate title and notes for the release via GitHub Release Notes API")
 	cmd.Flags().StringVar(&opts.NotesStartTag, "notes-start-tag", "", "Tag to use as the starting point for generating release notes")
 	cmdutil.NilBoolFlag(cmd, &opts.IsLatest, "latest", "", "Mark this release as \"Latest\" (default [automatic based on date and version]). --latest=false to explicitly NOT set as latest")
 	cmd.Flags().BoolVarP(&opts.VerifyTag, "verify-tag", "", false, "Abort in case the git tag doesn't already exist in the remote repository")
-	cmd.Flags().BoolVarP(&opts.NotesFromTag, "notes-from-tag", "", false, "Automatically generate notes from annotated tag")
+	cmd.Flags().BoolVarP(&opts.NotesFromTag, "notes-from-tag", "", false, "Fetch notes from the tag annotation or message of commit associated with tag")
 	cmd.Flags().BoolVar(&opts.FailOnNoCommits, "fail-on-no-commits", false, "Fail if there are no commits since the last release (no impact on the first release)")
 
 	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "target")

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -94,9 +94,8 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			To create a release from an annotated git tag, first create one locally with
 			git, push the tag to GitHub, then run this command.
-			Use %[1]s--notes-from-tag%[1]s to get the release notes
-			from the annotated git tag.
-			It will use annotation of git tag if it is annotated, associated with tag commit's message otherwise.
+			Use %[1]s--notes-from-tag%[1]s to get the release notes from the annotated git tag.
+			If the tag is not annotated, the commit message will be used instead.
 
 			Use %[1]s--generate-notes%[1]s to automatically generate notes using GitHub Release Notes API.
 			When using automatically generated release notes, a release title will also be automatically


### PR DESCRIPTION
Fixes #8372 
# Description
Improve docs of `gh release create` to distinguish difference between `--generate-notes` and `--notes-from-tag` flags.
# Showcase
```sh
$ ./bin/gh release create --help
Create a new GitHub Release for a repository.

A list of asset files may be given to upload to the new release. To define a
display label for an asset, append text starting with `#` after the file name.

If a matching git tag does not yet exist, one will automatically get created
from the latest state of the default branch.
Use `--target` to point to a different branch or commit for the automatic tag creation.
Use `--verify-tag` to abort the release if the tag doesn't already exist.
To fetch the new tag locally after the release, do `git fetch --tags origin`.

To create a release from an annotated git tag, first create one locally with
git, push the tag to GitHub, then run this command.
Use `--notes-from-tag` to get the release notes
from the annotated git tag.
It will use annotation of git tag if it is annotated, associated with tag commit's message otherwise.

Use `--generate-notes` to automatically generate notes using GitHub Release Notes API.
When using automatically generated release notes, a release title will also be automatically
generated unless a title was explicitly passed. Additional release notes can be prepended to
automatically generated notes by using the `--notes` flag.

By default, the release is created even if there are no new commits since the last release.
This may result in the same or duplicate release which may not be desirable in some cases.
Use `--fail-on-no-commits` to fail if no new commits are available. This flag has no
effect if there are no existing releases or this is the very first release.


USAGE
  gh release create [<tag>] [<filename>... | <pattern>...]

ALIASES
  gh release new

FLAGS
      --discussion-category string   Start a discussion in the specified category
  -d, --draft                        Save the release as a draft instead of publishing it
      --fail-on-no-commits           Fail if there are no commits since the last release (no impact on the first release)
      --generate-notes               Automatically generate title and notes for the release via GitHub Release Notes API
      --latest                       Mark this release as "Latest" (default [automatic based on date and version]). --latest=false to explicitly NOT set as latest
  -n, --notes string                 Release notes
  -F, --notes-file file              Read release notes from file (use "-" to read from standard input)
      --notes-from-tag               Fetch notes from the tag annotation or message of commit associated with tag
      --notes-start-tag string       Tag to use as the starting point for generating release notes
  -p, --prerelease                   Mark the release as a prerelease
      --target branch                Target branch or full commit SHA (default [main branch])
  -t, --title string                 Release title
      --verify-tag                   Abort in case the git tag doesn't already exist in the remote repository

INHERITED FLAGS
      --help                     Show help for command
  -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format

EXAMPLES
  # Interactively create a release
  $ gh release create

  # Interactively create a release from specific tag
  $ gh release create v1.2.3

  # Non-interactively create a release
  $ gh release create v1.2.3 --notes "bugfix release"

  # Use automatically generated via GitHub Release Notes API release notes
  $ gh release create v1.2.3 --generate-notes

  # Use release notes from a file
  $ gh release create v1.2.3 -F release-notes.md

  # Use tag annotation or associated commit message as notes
  $ gh release create v1.2.3 --notes-from-tag

  # Don't mark the release as latest
  $ gh release create v1.2.3 --latest=false

  # Upload all tarballs in a directory as release assets
  $ gh release create v1.2.3 ./dist/*.tgz

  # Upload a release asset with a display label
  $ gh release create v1.2.3 '/path/to/asset.zip#My display label'

  # Create a release and start a discussion
  $ gh release create v1.2.3 --discussion-category "General"

  # Create a release only if there are new commits available since the last release
  $ gh release create v1.2.3 --fail-on-no-commits

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility`
```