### PR TITLE
Introduce `gh agent-task`

### DIFF
--- a/pkg/cmd/agent-task/agent_task.go
+++ b/pkg/cmd/agent-task/agent_task.go
@@ -22,7 +22,7 @@ func NewCmdAgentTask(f *cmdutil.Factory) *cobra.Command {
 		// This is required to run this root command. We want to
 		// run it to test PersistentPreRunE behavior.
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			return cmd.Help()
 		},
 	}
 	return cmd

--- a/pkg/cmd/agent-task/agent_task.go
+++ b/pkg/cmd/agent-task/agent_task.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/go-gh/v2/pkg/auth"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdAgentTask creates the base `agent-task` command.
+func NewCmdAgentTask(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "agent-task",
+		Aliases: []string{"agent-tasks", "agent", "agents"},
+		Short:   "Manage agent tasks (preview)",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return requireOAuthToken(f)
+		},
+		// This is required to run this root command. We want to
+		// run it to test PersistentPreRunE behavior.
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	return cmd
+}
+
+// requireOAuthToken ensures an OAuth (device flow) token is present and valid.
+// agent-task subcommands inherit this check via PersistentPreRunE.
+func requireOAuthToken(f *cmdutil.Factory) error {
+	cfg, err := f.Config()
+	if err != nil {
+		return err
+	}
+
+	authCfg := cfg.Authentication()
+	host, _ := authCfg.DefaultHost()
+	if host == "" {
+		return errors.New("no default host configured; run 'gh auth login'")
+	}
+
+	if auth.IsEnterprise(host) {
+		return errors.New("agent tasks are not supported on this host")
+	}
+
+	token, source := authCfg.ActiveToken(host)
+
+	// Tokens from sources "oauth_token" and "keyring" are likely
+	// minted through our device flow.
+	tokenSourceIsDeviceFlow := source == "oauth_token" || source == "keyring"
+	// Tokens with "gho_" prefix are OAuth tokens.
+	tokenIsOAuth := strings.HasPrefix(token, "gho_")
+
+	// Reject if the token is not from a device flow source or is not an OAuth token
+	if !tokenSourceIsDeviceFlow || !tokenIsOAuth {
+		return fmt.Errorf("this command requires an OAuth token. Re-authenticate with: gh auth login")
+	}
+	return nil
+}

--- a/pkg/cmd/agent-task/agent_task_test.go
+++ b/pkg/cmd/agent-task/agent_task_test.go
@@ -41,7 +41,7 @@ func TestOAuthTokenAccepted(t *testing.T) {
 	cmd := NewCmdAgentTask(f)
 	err := cmd.Execute()
 	require.NoError(t, err)
-	require.Equal(t, "", stdout.String())
+	require.Empty(t, stdout.String())
 }
 
 func TestKeyringOAuthTokenAccepted(t *testing.T) {

--- a/pkg/cmd/agent-task/agent_task_test.go
+++ b/pkg/cmd/agent-task/agent_task_test.go
@@ -1,0 +1,172 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	ghmock "github.com/cli/cli/v2/internal/gh/mock"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/require"
+)
+
+// setupMockOAuthConfig configures a blank config with a default host and optional token behavior.
+func setupMockOAuthConfig(t *testing.T, tokenSource string) gh.Config {
+	t.Helper()
+	c := config.NewBlankConfig()
+	switch tokenSource {
+	case "oauth_token":
+		// valid OAuth device flow token stored in config
+		c.Set("github.com", "oauth_token", "gho_OAUTH123")
+	case "keyring":
+		// valid OAuth device flow token stored in keyring
+		c.Set("github.com", "oauth_token", "gho_OAUTH123")
+	case "GH_TOKEN":
+		// classic style token stored in config (will fail prefix check)
+		c.Set("github.com", "oauth_token", "ghp_CLASSIC123")
+	case "GH_ENTERPRISE_TOKEN":
+		// enterprise style token stored in config (will fail prefix check)
+		c.Set("something.ghes.com", "oauth_token", "ghe_ENTERPRISE123")
+	}
+	return c
+}
+
+func TestOAuthTokenAccepted(t *testing.T) {
+	f := &cmdutil.Factory{}
+	ios, _, stdout, _ := iostreams.Test()
+	f.IOStreams = ios
+	f.Config = func() (gh.Config, error) { return setupMockOAuthConfig(t, "oauth_token"), nil }
+
+	cmd := NewCmdAgentTask(f)
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Equal(t, "", stdout.String())
+}
+
+func TestKeyringOAuthTokenAccepted(t *testing.T) {
+	f := &cmdutil.Factory{}
+	ios, _, stdout, _ := iostreams.Test()
+	f.IOStreams = ios
+	f.Config = func() (gh.Config, error) { return setupMockOAuthConfig(t, "keyring"), nil }
+
+	cmd := NewCmdAgentTask(f)
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Equal(t, "", stdout.String())
+}
+
+func TestEnvVarTokenRejected(t *testing.T) {
+	f := &cmdutil.Factory{}
+	ios, _, _, _ := iostreams.Test()
+	f.IOStreams = ios
+	f.Config = func() (gh.Config, error) { return setupMockOAuthConfig(t, "GH_TOKEN"), nil }
+	cmd := NewCmdAgentTask(f)
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires an OAuth token")
+}
+
+func TestEnterpriseTokenIgnored(t *testing.T) {
+	// This test ignores the test helper because we want to test a specific config state
+	t.Run("enterprise token alone is ignored and rejected", func(t *testing.T) {
+		f := &cmdutil.Factory{}
+		ios, _, _, _ := iostreams.Test()
+		f.IOStreams = ios
+		f.Config = func() (gh.Config, error) {
+			return func() gh.Config {
+				c := config.NewBlankConfig()
+				c.Set("something.ghes.com", "oauth_token", "ghe_ENTERPRISE123")
+				return c
+			}(), nil
+		}
+
+		cmd := NewCmdAgentTask(f)
+		err := cmd.Execute()
+		require.Error(t, err)
+	})
+
+	t.Run("github.com oauth is accepted and enterprise token ignored", func(t *testing.T) {
+		f := &cmdutil.Factory{}
+		ios, _, _, _ := iostreams.Test()
+		f.IOStreams = ios
+		f.Config = func() (gh.Config, error) {
+			return func() gh.Config {
+				c := config.NewBlankConfig()
+				c.Set("something.ghes.com", "oauth_token", "ghe_ENTERPRISE123")
+				c.Set("github.com", "oauth_token", "gho_OAUTH123")
+				return c
+			}(), nil
+		}
+
+		cmd := NewCmdAgentTask(f)
+		err := cmd.Execute()
+		require.NoError(t, err)
+	})
+
+}
+
+func TestEnterpriseHostRejected(t *testing.T) {
+	f := &cmdutil.Factory{}
+	ios, _, _, _ := iostreams.Test()
+	f.IOStreams = ios
+
+	f.Config = func() (gh.Config, error) {
+		return &ghmock.ConfigMock{
+			AuthenticationFunc: func() gh.AuthConfig {
+				c := &config.AuthConfig{}
+				c.SetDefaultHost("something.ghes.com", "GH_HOST")
+				return c
+			},
+		}, nil
+	}
+
+	cmd := NewCmdAgentTask(f)
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not supported on this host")
+}
+
+func TestEmptyHostRejected(t *testing.T) {
+	f := &cmdutil.Factory{}
+	ios, _, _, _ := iostreams.Test()
+	f.IOStreams = ios
+
+	f.Config = func() (gh.Config, error) {
+		return &ghmock.ConfigMock{
+			AuthenticationFunc: func() gh.AuthConfig {
+				c := &config.AuthConfig{}
+				c.SetDefaultHost("", "GH_HOST")
+				return c
+			},
+		}, nil
+	}
+
+	cmd := NewCmdAgentTask(f)
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no default host configured")
+}
+
+func TestNoAuthRejected(t *testing.T) {
+	f := &cmdutil.Factory{}
+	ios, _, _, _ := iostreams.Test()
+	f.IOStreams = ios
+	// No token configured
+	f.Config = func() (gh.Config, error) { return setupMockOAuthConfig(t, ""), nil }
+
+	cmd := NewCmdAgentTask(f)
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestAliasAreSet(t *testing.T) {
+	f := &cmdutil.Factory{}
+	ios, _, _, _ := iostreams.Test()
+	f.IOStreams = ios
+	f.Config = func() (gh.Config, error) { return setupMockOAuthConfig(t, "oauth_token"), nil }
+
+	cmd := NewCmdAgentTask(f)
+
+	require.ElementsMatch(t, []string{"agent-tasks", "agent", "agents"}, cmd.Aliases)
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	accessibilityCmd "github.com/cli/cli/v2/pkg/cmd/accessibility"
 	actionsCmd "github.com/cli/cli/v2/pkg/cmd/actions"
+	agentTaskCmd "github.com/cli/cli/v2/pkg/cmd/agent-task"
 	aliasCmd "github.com/cli/cli/v2/pkg/cmd/alias"
 	"github.com/cli/cli/v2/pkg/cmd/alias/shared"
 	apiCmd "github.com/cli/cli/v2/pkg/cmd/api"
@@ -126,6 +127,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 	cmd.AddCommand(versionCmd.NewCmdVersion(f, version, buildDate))
 	cmd.AddCommand(accessibilityCmd.NewCmdAccessibility(f))
 	cmd.AddCommand(actionsCmd.NewCmdActions(f))
+	cmd.AddCommand(agentTaskCmd.NewCmdAgentTask(f))
 	cmd.AddCommand(aliasCmd.NewCmdAlias(f))
 	cmd.AddCommand(authCmd.NewCmdAuth(f))
 	cmd.AddCommand(attestationCmd.NewCmdAttestation(f))


### PR DESCRIPTION
Introduce `gh agent-task` with the following aliases:

- `gh agent-tasks`
- `gh agent`
- `gh agents`

This establishes the root command for future `gh agent-task` sub-commands.

This also implements a persistent OAuth token requirement that will run for all future sub-commands. 

> [!IMPORTANT]
> NOT merging into `trunk` 