### PR TITLE
`gh agent-task list`: Implement repo scoping support

### DIFF
--- a/pkg/cmd/agent-task/capi/client.go
+++ b/pkg/cmd/agent-task/capi/client.go
@@ -14,6 +14,7 @@ const capiHost = "api.githubcopilot.com"
 // may be replaced with test doubles in unit tests.
 type CapiClient interface {
 	ListSessionsForViewer(ctx context.Context, limit int) ([]*Session, error)
+	ListSessionsForRepo(ctx context.Context, owner string, repo string, limit int) ([]*Session, error)
 }
 
 // CAPIClient is a client for interacting with the Copilot API

--- a/pkg/cmd/agent-task/list/list.go
+++ b/pkg/cmd/agent-task/list/list.go
@@ -85,11 +85,13 @@ func listRun(opts *ListOptions) error {
 	defer opts.IO.StopProgressIndicator()
 	var sessions []*capi.Session
 	ctx := context.Background()
+
+	var repo ghrepo.Interface
 	if opts.BaseRepo != nil {
-		repo, err := opts.BaseRepo()
-		if err != nil {
-			return err
-		}
+		repo, _ = opts.BaseRepo()
+	}
+
+	if repo != nil && repo.RepoOwner() != "" && repo.RepoName() != "" {
 		sessions, err = capiClient.ListSessionsForRepo(ctx, repo.RepoOwner(), repo.RepoName(), opts.Limit)
 		if err != nil {
 			return err

--- a/pkg/cmd/agent-task/list/list.go
+++ b/pkg/cmd/agent-task/list/list.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmd/agent-task/capi"
 	"github.com/cli/cli/v2/pkg/cmd/agent-task/shared"
@@ -23,6 +24,7 @@ type ListOptions struct {
 	Config     func() (gh.Config, error)
 	Limit      int
 	CapiClient func() (*capi.CAPIClient, error)
+	BaseRepo   func() (ghrepo.Interface, error)
 }
 
 // NewCmdList creates the list command
@@ -38,11 +40,19 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Short: "List agent tasks",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Support -R/--repo override
+			if f != nil {
+				opts.BaseRepo = f.BaseRepo
+			}
 			if runF != nil {
 				return runF(opts)
 			}
 			return listRun(opts)
 		},
+	}
+
+	if f != nil {
+		cmdutil.EnableRepoOverride(cmd, f)
 	}
 
 	opts.CapiClient = func() (*capi.CAPIClient, error) {
@@ -73,9 +83,22 @@ func listRun(opts *ListOptions) error {
 
 	opts.IO.StartProgressIndicatorWithLabel("Fetching agent tasks...")
 	defer opts.IO.StopProgressIndicator()
-	sessions, err := capiClient.ListSessionsForViewer(context.Background(), opts.Limit)
-	if err != nil {
-		return err
+	var sessions []*capi.Session
+	ctx := context.Background()
+	if opts.BaseRepo != nil {
+		repo, err := opts.BaseRepo()
+		if err != nil {
+			return err
+		}
+		sessions, err = capiClient.ListSessionsForRepo(ctx, repo.RepoOwner(), repo.RepoName(), opts.Limit)
+		if err != nil {
+			return err
+		}
+	} else {
+		sessions, err = capiClient.ListSessionsForViewer(ctx, opts.Limit)
+		if err != nil {
+			return err
+		}
 	}
 	opts.IO.StopProgressIndicator()
 

--- a/pkg/cmd/agent-task/list/list_test.go
+++ b/pkg/cmd/agent-task/list/list_test.go
@@ -114,10 +114,12 @@ func Test_listRun(t *testing.T) {
 			wantOut:  "no agent tasks found\n",
 		},
 		{
-			name:        "repo resolution error surfaces",
+			name:        "repo resolution error does not surface",
 			tty:         true,
 			baseRepoErr: errors.New("ambiguous repo"),
-			wantErr:     errors.New("ambiguous repo"),
+			wantErr:     nil,
+			stubs:       func(reg *httpmock.Registry) { registerEmptySessionsMock(reg) },
+			wantOut:     "no agent tasks found\n",
 		},
 		{
 			name:     "repo scoped many sessions (tty)",

--- a/pkg/cmd/agent-task/list/list_test.go
+++ b/pkg/cmd/agent-task/list/list_test.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -8,17 +9,19 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/agent-task/capi"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewCmdList(t *testing.T) {
 	tests := []struct {
 		name     string
-		cli      string
+		args     string
 		wantOpts ListOptions
 	}{
 		{
@@ -50,10 +53,13 @@ func Test_listRun(t *testing.T) {
 	createdAt := sixHoursAgo.Format(time.RFC3339)
 
 	tests := []struct {
-		name    string
-		tty     bool
-		stubs   func(*httpmock.Registry)
-		wantOut string
+		name        string
+		tty         bool
+		stubs       func(*httpmock.Registry)
+		baseRepo    ghrepo.Interface
+		baseRepoErr error
+		wantOut     string
+		wantErr     error
 	}{
 		{
 			name:    "no sessions",
@@ -65,8 +71,10 @@ func Test_listRun(t *testing.T) {
 			name:  "single session (tty)",
 			tty:   true,
 			stubs: func(reg *httpmock.Registry) { registerSingleSessionMock(reg, createdAt) },
-			wantOut: "SESSION ID  PULL REQUEST  REPO        SESSION STATE  CREATED\n" +
-				"sess1       #42           OWNER/REPO  completed      about 6 hours ago\n",
+			wantOut: heredoc.Doc(`
+			SESSION ID  PULL REQUEST  REPO        SESSION STATE  CREATED
+			sess1       #42           OWNER/REPO  completed      about 6 hours ago
+			`),
 		},
 		{
 			name:    "single session (nontty)",
@@ -78,20 +86,62 @@ func Test_listRun(t *testing.T) {
 			name:  "many sessions (tty)",
 			tty:   true,
 			stubs: func(reg *httpmock.Registry) { registerManySessionsMock(reg, createdAt) },
-			wantOut: "SESSION ID  PULL REQUEST  REPO        SESSION STATE  CREATED\n" +
-				"s1          #101          OWNER/REPO  completed      about 6 hours ago\n" +
-				"s2          #102          OWNER/REPO  failed         about 6 hours ago\n" +
-				"s3          #103          OWNER/REPO  in_progress    about 6 hours ago\n" +
-				"s4          #104          OWNER/REPO  queued         about 6 hours ago\n" +
-				"s5          #105          OWNER/REPO  canceled       about 6 hours ago\n" +
-				"s6          #106          OWNER/REPO  mystery        about 6 hours ago\n",
+			wantOut: heredoc.Doc(`
+			SESSION ID  PULL REQUEST  REPO        SESSION STATE  CREATED
+			s1          #101          OWNER/REPO  completed      about 6 hours ago
+			s2          #102          OWNER/REPO  failed         about 6 hours ago
+			s3          #103          OWNER/REPO  in_progress    about 6 hours ago
+			s4          #104          OWNER/REPO  queued         about 6 hours ago
+			s5          #105          OWNER/REPO  canceled       about 6 hours ago
+			s6          #106          OWNER/REPO  mystery        about 6 hours ago
+			`),
+		},
+		{
+			name:     "repo scoped single session",
+			tty:      true,
+			stubs:    func(reg *httpmock.Registry) { registerRepoSingleSessionMock(reg, createdAt, "OWNER", "REPO") },
+			baseRepo: ghrepo.New("OWNER", "REPO"),
+			wantOut: heredoc.Doc(`
+			SESSION ID  PULL REQUEST  REPO        SESSION STATE  CREATED
+			sessR1      #55           OWNER/REPO  completed      about 6 hours ago
+			`),
+		},
+		{
+			name:     "repo scoped no sessions",
+			tty:      true,
+			stubs:    func(reg *httpmock.Registry) { registerRepoEmptySessionsMock(reg, "OWNER", "REPO") },
+			baseRepo: ghrepo.New("OWNER", "REPO"),
+			wantOut:  "no agent tasks found\n",
+		},
+		{
+			name:        "repo resolution error surfaces",
+			tty:         true,
+			baseRepoErr: errors.New("ambiguous repo"),
+			wantErr:     errors.New("ambiguous repo"),
+		},
+		{
+			name:     "repo scoped many sessions (tty)",
+			tty:      true,
+			stubs:    func(reg *httpmock.Registry) { registerRepoManySessionsMock(reg, createdAt, "OWNER", "REPO") },
+			baseRepo: ghrepo.New("OWNER", "REPO"),
+			wantOut: heredoc.Doc(`
+			SESSION ID  PULL REQUEST  REPO        SESSION STATE  CREATED
+			r1          #301          OWNER/REPO  completed      about 6 hours ago
+			r2          #302          OWNER/REPO  failed         about 6 hours ago
+			r3          #303          OWNER/REPO  in_progress    about 6 hours ago
+			r4          #304          OWNER/REPO  queued         about 6 hours ago
+			r5          #305          OWNER/REPO  canceled       about 6 hours ago
+			r6          #306          OWNER/REPO  mystery        about 6 hours ago
+			`),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reg := &httpmock.Registry{}
-			tt.stubs(reg)
+			if tt.stubs != nil {
+				tt.stubs(reg)
+			}
 
 			cfg := config.NewBlankConfig()
 			cfg.Set("github.com", "oauth_token", "OTOKEN")
@@ -108,19 +158,275 @@ func Test_listRun(t *testing.T) {
 				Limit:      30,
 				CapiClient: func() (*capi.CAPIClient, error) { return capiClient, nil },
 			}
+			if tt.baseRepo != nil || tt.baseRepoErr != nil {
+				baseRepo := tt.baseRepo
+				baseRepoErr := tt.baseRepoErr
+				opts.BaseRepo = func() (ghrepo.Interface, error) { return baseRepo, baseRepoErr }
+			}
 
 			err := listRun(opts)
-			assert.NoError(t, err)
-
-			got := stdout.String()
-			if tt.wantOut == "" && tt.name == "single session (tty)" {
-				t.Logf("Captured output for single session (tty):\n%s", got)
-				t.Fatalf("fill in wantOut with the above output and re-run tests")
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				require.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				require.NoError(t, err)
 			}
-			assert.Equal(t, tt.wantOut, got)
+			got := stdout.String()
+			require.Equal(t, tt.wantOut, got)
 			reg.Verify(t)
 		})
 	}
+}
+
+// registerRepoSingleSessionMock mocks repo-scoped endpoint with one session and hydration.
+func registerRepoSingleSessionMock(reg *httpmock.Registry, createdAt, owner, repo string) {
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("GET", "agents/sessions/nwo/"+owner+"/"+repo), "api.githubcopilot.com"),
+		httpmock.StringResponse(heredoc.Docf(`{
+			"sessions": [
+				{
+					"id": "sessR1",
+					"name": "Repo build",
+					"user_id": 1,
+					"agent_id": 2,
+					"logs": "",
+					"state": "completed",
+					"owner_id": 10,
+					"repo_id": 1000,
+					"resource_type": "pull",
+					"resource_id": 3000,
+					"created_at": "%[1]s"
+				}
+			]
+		}`, createdAt)),
+	)
+	// Second page empty (pagination end)
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("GET", "agents/sessions/nwo/"+owner+"/"+repo), "api.githubcopilot.com"),
+		httpmock.StringResponse(heredoc.Doc(`{
+			"sessions": []
+		}`)),
+	)
+	// Hydration
+	reg.Register(
+		httpmock.GraphQL(`query FetchPRs`),
+		httpmock.StringResponse(heredoc.Docf(`{
+	"data": {
+		"nodes": [
+			{
+				"id": "PR_nodeR1",
+				"fullDatabaseId": "3000",
+				"number": 55,
+				"title": "Improve build",
+				"state": "OPEN",
+				"url": "https://github.com/%[2]s/%[3]s/pull/55",
+				"body": "",
+				"createdAt": "%[1]s",
+				"updatedAt": "%[1]s",
+				"repository": { "nameWithOwner": "%[2]s/%[3]s" }
+			}
+		]
+	}
+}`, createdAt, owner, repo)),
+	)
+}
+
+// registerRepoEmptySessionsMock mocks repo-scoped endpoint returning no sessions.
+func registerRepoEmptySessionsMock(reg *httpmock.Registry, owner, repo string) {
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("GET", "agents/sessions/nwo/"+owner+"/"+repo), "api.githubcopilot.com"),
+		httpmock.StringResponse(heredoc.Doc(`{
+	"sessions": []
+}`)),
+	)
+}
+
+// registerRepoManySessionsMock mirrors registerManySessionsMock but for repo-scoped endpoint
+func registerRepoManySessionsMock(reg *httpmock.Registry, createdAt, owner, repo string) {
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("GET", "agents/sessions/nwo/"+owner+"/"+repo), "api.githubcopilot.com"),
+		httpmock.StringResponse(heredoc.Docf(`{
+			"sessions": [
+				{
+					"id": "r1",
+					"name": "A",
+					"user_id": 1,
+					"agent_id": 2,
+					"logs": "",
+					"state": "completed",
+					"owner_id": 10,
+					"repo_id": 1000,
+					"resource_type": "pull",
+					"resource_id": 3001,
+					"created_at": "%[1]s"
+				},
+				{
+					"id": "r2",
+					"name": "B",
+					"user_id": 1,
+					"agent_id": 2,
+					"logs": "",
+					"state": "failed",
+					"owner_id": 10,
+					"repo_id": 1000,
+					"resource_type": "pull",
+					"resource_id": 3002,
+					"created_at": "%[1]s"
+				},
+				{
+					"id": "r3",
+					"name": "C",
+					"user_id": 1,
+					"agent_id": 2,
+					"logs": "",
+					"state": "in_progress",
+					"owner_id": 10,
+					"repo_id": 1000,
+					"resource_type": "pull",
+					"resource_id": 3003,
+					"created_at": "%[1]s"
+				},
+				{
+					"id": "r4",
+					"name": "D",
+					"user_id": 1,
+					"agent_id": 2,
+					"logs": "",
+					"state": "queued",
+					"owner_id": 10,
+					"repo_id": 1000,
+					"resource_type": "pull",
+					"resource_id": 3004,
+					"created_at": "%[1]s"
+				},
+				{
+					"id": "r5",
+					"name": "E",
+					"user_id": 1,
+					"agent_id": 2,
+					"logs": "",
+					"state": "canceled",
+					"owner_id": 10,
+					"repo_id": 1000,
+					"resource_type": "pull",
+					"resource_id": 3005,
+					"created_at": "%[1]s"
+				},
+				{
+					"id": "r6",
+					"name": "F",
+					"user_id": 1,
+					"agent_id": 2,
+					"logs": "",
+					"state": "mystery",
+					"owner_id": 10,
+					"repo_id": 1000,
+					"resource_type": "pull",
+					"resource_id": 3006,
+					"created_at": "%[1]s"
+				}
+			]
+		}`, createdAt)),
+	)
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("GET", "agents/sessions/nwo/"+owner+"/"+repo), "api.githubcopilot.com"),
+		httpmock.StringResponse(heredoc.Doc(`{
+			"sessions": []
+		}`)),
+	)
+	reg.Register(
+		httpmock.GraphQL(`query FetchPRs`),
+		httpmock.StringResponse(heredoc.Docf(`{
+			"data": {
+				"nodes": [
+					{
+						"id": "PR_r1",
+						"fullDatabaseId": "3001",
+						"number": 301,
+						"title": "PR 301",
+						"state": "OPEN",
+						"url": "https://github.com/%[2]s/%[3]s/pull/301",
+						"body": "",
+						"createdAt": "%[1]s",
+						"updatedAt": "%[1]s",
+						"repository": {
+							"nameWithOwner": "%[2]s/%[3]s"
+						}
+					},
+					{
+						"id": "PR_r2",
+						"fullDatabaseId": "3002",
+						"number": 302,
+						"title": "PR 302",
+						"state": "OPEN",
+						"url": "https://github.com/%[2]s/%[3]s/pull/302",
+						"body": "",
+						"createdAt": "%[1]s",
+						"updatedAt": "%[1]s",
+						"repository": {
+							"nameWithOwner": "%[2]s/%[3]s"
+						}
+					},
+					{
+						"id": "PR_r3",
+						"fullDatabaseId": "3003",
+						"number": 303,
+						"title": "PR 303",
+						"state": "OPEN",
+						"url": "https://github.com/%[2]s/%[3]s/pull/303",
+						"body": "",
+						"createdAt": "%[1]s",
+						"updatedAt": "%[1]s",
+						"repository": {
+							"nameWithOwner": "%[2]s/%[3]s"
+						}
+					},
+					{
+						"id": "PR_r4",
+						"fullDatabaseId": "3004",
+						"number": 304,
+						"title": "PR 304",
+						"state": "OPEN",
+						"url": "https://github.com/%[2]s/%[3]s/pull/304",
+						"body": "",
+						"createdAt": "%[1]s",
+						"updatedAt": "%[1]s",
+						"repository": {
+							"nameWithOwner": "%[2]s/%[3]s"
+						}
+					},
+					{
+						"id": "PR_r5",
+						"fullDatabaseId": "3005",
+						"number": 305,
+						"title": "PR 305",
+						"state": "OPEN",
+						"url": "https://github.com/%[2]s/%[3]s/pull/305",
+						"body": "",
+						"createdAt": "%[1]s",
+						"updatedAt": "%[1]s",
+						"repository": {
+							"nameWithOwner": "%[2]s/%[3]s"
+						}
+					},
+					{
+						"id": "PR_r6",
+						"fullDatabaseId": "3006",
+						"number": 306,
+						"title": "PR 306",
+						"state": "OPEN",
+						"url": "https://github.com/%[2]s/%[3]s/pull/306",
+						"body": "",
+						"createdAt": "%[1]s",
+						"updatedAt": "%[1]s",
+						"repository": {
+							"nameWithOwner": "%[2]s/%[3]s"
+						}
+					}
+				]
+			}
+		}`, createdAt, owner, repo)),
+	)
 }
 
 // registerEmptySessionsMock registers a single empty page of sessions
@@ -128,8 +434,8 @@ func registerEmptySessionsMock(reg *httpmock.Registry) {
 	reg.Register(
 		httpmock.WithHost(httpmock.REST("GET", "agents/sessions"), "api.githubcopilot.com"),
 		httpmock.StringResponse(heredoc.Doc(`{
-	"sessions": []
-}`)),
+			"sessions": []
+		}`)),
 	)
 }
 
@@ -159,29 +465,33 @@ func registerSingleSessionMock(reg *httpmock.Registry, createdAt string) {
 	// Second page empty to terminate pagination
 	reg.Register(
 		httpmock.WithHost(httpmock.REST("GET", "agents/sessions"), "api.githubcopilot.com"),
-		httpmock.StringResponse(`{"sessions": []}`),
+		httpmock.StringResponse(heredoc.Doc(`{
+			"sessions": []
+		}`)),
 	)
 	// GraphQL hydration
 	reg.Register(
 		httpmock.GraphQL(`query FetchPRs`),
 		httpmock.StringResponse(heredoc.Docf(`{
-	"data": {
-		"nodes": [
-			{
-				"id": "PR_node",
-				"fullDatabaseId": "2000",
-				"number": 42,
-				"title": "Improve docs",
-				"state": "OPEN",
-				"url": "https://github.com/OWNER/REPO/pull/42",
-				"body": "",
-				"createdAt": "%[1]s",
-				"updatedAt": "%[1]s",
-				"repository": { "nameWithOwner": "OWNER/REPO" }
+			"data": {
+				"nodes": [
+					{
+						"id": "PR_node",
+						"fullDatabaseId": "2000",
+						"number": 42,
+						"title": "Improve docs",
+						"state": "OPEN",
+						"url": "https://github.com/OWNER/REPO/pull/42",
+						"body": "",
+						"createdAt": "%[1]s",
+						"updatedAt": "%[1]s",
+						"repository": {
+							"nameWithOwner": "OWNER/REPO"
+						}
+					}
+				]
 			}
-		]
-	}
-}`, createdAt)),
+		}`, createdAt)),
 	)
 }
 
@@ -277,7 +587,9 @@ func registerManySessionsMock(reg *httpmock.Registry, createdAt string) {
 	// Second page empty
 	reg.Register(
 		httpmock.WithHost(httpmock.REST("GET", "agents/sessions"), "api.githubcopilot.com"),
-		httpmock.StringResponse(`{"sessions": []}`),
+		httpmock.StringResponse(heredoc.Doc(`{
+			"sessions": []
+		}`)),
 	)
 	// GraphQL hydration for 6 PRs
 	reg.Register(
@@ -295,7 +607,9 @@ func registerManySessionsMock(reg *httpmock.Registry, createdAt string) {
 						"body": "",
 						"createdAt": "%[1]s",
 						"updatedAt": "%[1]s",
-						"repository": { "nameWithOwner": "OWNER/REPO" }
+						"repository": {
+							"nameWithOwner": "OWNER/REPO"
+						}
 					},
 					{
 						"id": "PR_node2",
@@ -307,7 +621,9 @@ func registerManySessionsMock(reg *httpmock.Registry, createdAt string) {
 						"body": "",
 						"createdAt": "%[1]s",
 						"updatedAt": "%[1]s",
-						"repository": { "nameWithOwner": "OWNER/REPO" }
+						"repository": {
+							"nameWithOwner": "OWNER/REPO"
+						}
 					},
 					{
 						"id": "PR_node3",
@@ -319,7 +635,9 @@ func registerManySessionsMock(reg *httpmock.Registry, createdAt string) {
 						"body": "",
 						"createdAt": "%[1]s",
 						"updatedAt": "%[1]s",
-						"repository": { "nameWithOwner": "OWNER/REPO" }
+						"repository": {
+							"nameWithOwner": "OWNER/REPO"
+						}
 					},
 					{
 						"id": "PR_node4",
@@ -331,7 +649,9 @@ func registerManySessionsMock(reg *httpmock.Registry, createdAt string) {
 						"body": "",
 						"createdAt": "%[1]s",
 						"updatedAt": "%[1]s",
-						"repository": { "nameWithOwner": "OWNER/REPO" }
+						"repository": {
+							"nameWithOwner": "OWNER/REPO"
+						}
 					},
 					{
 						"id": "PR_node5",
@@ -343,7 +663,9 @@ func registerManySessionsMock(reg *httpmock.Registry, createdAt string) {
 						"body": "",
 						"createdAt": "%[1]s",
 						"updatedAt": "%[1]s",
-						"repository": { "nameWithOwner": "OWNER/REPO" }
+						"repository": {
+							"nameWithOwner": "OWNER/REPO"
+						}
 					},
 					{
 						"id": "PR_node6",
@@ -355,7 +677,9 @@ func registerManySessionsMock(reg *httpmock.Registry, createdAt string) {
 						"body": "",
 						"createdAt": "%[1]s",
 						"updatedAt": "%[1]s",
-						"repository": { "nameWithOwner": "OWNER/REPO" }
+						"repository": {
+							"nameWithOwner": "OWNER/REPO"
+						}
 					}
 				]
 			}


### PR DESCRIPTION
Adds support for `--repo` or deriving the repo from the CWD.

Intentionally not changing the table rendering to a simpler format (in other words, remove the repo column). We can do that later if it's important. 