### PR TITLE
`gh agent-task list`: implement `-w`/`--web` to open global agent tasks page in a browser

### DIFF
--- a/pkg/cmd/agent-task/list/list.go
+++ b/pkg/cmd/agent-task/list/list.go
@@ -46,9 +46,9 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Support -R/--repo override
-			if f != nil {
-				opts.BaseRepo = f.BaseRepo
-			}
+
+			opts.BaseRepo = f.BaseRepo
+
 			if opts.Limit < 1 {
 				return cmdutil.FlagErrorf("invalid limit: %v", opts.Limit)
 			}

--- a/pkg/cmd/agent-task/list/list.go
+++ b/pkg/cmd/agent-task/list/list.go
@@ -126,8 +126,7 @@ func listRun(opts *ListOptions) error {
 	opts.IO.StopProgressIndicator()
 
 	if len(sessions) == 0 {
-		fmt.Fprintln(opts.IO.Out, "no agent tasks found")
-		return nil
+		return cmdutil.NewNoResultsError("no agent tasks found")
 	}
 
 	cs := opts.IO.ColorScheme()

--- a/pkg/cmd/agent-task/list/list.go
+++ b/pkg/cmd/agent-task/list/list.go
@@ -107,6 +107,8 @@ func listRun(opts *ListOptions) error {
 
 	var repo ghrepo.Interface
 	if opts.BaseRepo != nil {
+		// We swallow this error because when CWD is not a repo and
+		// the --repo flag is not set, we use the global/user session listing.
 		repo, _ = opts.BaseRepo()
 	}
 

--- a/pkg/cmd/agent-task/list/list.go
+++ b/pkg/cmd/agent-task/list/list.go
@@ -84,6 +84,10 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 func listRun(opts *ListOptions) error {
 	if opts.Web {
+		// Currently the web GUI does not have a page that supports filtering
+		// based on repo, so we just open the agents dashboard with no args.
+		// If that page is ever added in the future, we should route to that
+		// page instead of the global one when --repo is set.
 		const webURL = "https://github.com/copilot/agents"
 		if opts.IO.IsStdoutTTY() {
 			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", text.DisplayURL(webURL))

--- a/pkg/cmd/agent-task/list/list_test.go
+++ b/pkg/cmd/agent-task/list/list_test.go
@@ -46,6 +46,11 @@ func TestNewCmdList(t *testing.T) {
 			wantErr: "invalid limit: 0",
 		},
 		{
+			name:    "negative limit",
+			args:    "--limit -5",
+			wantErr: "invalid limit: -5",
+		},
+		{
 			name: "web flag",
 			args: "--web",
 			wantOpts: ListOptions{

--- a/pkg/cmd/agent-task/list/list_test.go
+++ b/pkg/cmd/agent-task/list/list_test.go
@@ -231,7 +231,7 @@ func Test_listRun(t *testing.T) {
 				Browser: br,
 				CapiClient: func() (*capi.CAPIClient, error) {
 					if tt.web {
-						panic("CapiClient should not be invoked when --web is set")
+						require.FailNow(t, "CapiClient was called with --web")
 					}
 					return capiClient, nil
 				},

--- a/pkg/cmd/agent-task/list/list_test.go
+++ b/pkg/cmd/agent-task/list/list_test.go
@@ -191,6 +191,15 @@ func Test_listRun(t *testing.T) {
 			wantStderr:     "Opening https://github.com/copilot/agents in your browser.\n",
 			wantBrowserURL: "https://github.com/copilot/agents",
 		},
+		{
+			name:           "web mode with repo still uses global URL, even when --repo is set",
+			tty:            true,
+			web:            true,
+			baseRepo:       ghrepo.New("OWNER", "REPO"),
+			wantOut:        "",
+			wantStderr:     "Opening https://github.com/copilot/agents in your browser.\n",
+			wantBrowserURL: "https://github.com/copilot/agents",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/agent-task/list/list_test.go
+++ b/pkg/cmd/agent-task/list/list_test.go
@@ -77,9 +77,7 @@ func TestNewCmdList(t *testing.T) {
 }
 
 func Test_listRun(t *testing.T) {
-	sixHours, _ := time.ParseDuration("6h")
-	sixHoursAgo := time.Now().Add(-sixHours)
-	createdAt := sixHoursAgo.Format(time.RFC3339)
+	createdAt := time.Now().Add(-6 * time.Hour).Format(time.RFC3339) // 6h ago
 
 	tests := []struct {
 		name           string

--- a/pkg/cmd/agent-task/list/list_test.go
+++ b/pkg/cmd/agent-task/list/list_test.go
@@ -96,7 +96,7 @@ func Test_listRun(t *testing.T) {
 			name:    "no sessions",
 			tty:     true,
 			stubs:   func(reg *httpmock.Registry) { registerEmptySessionsMock(reg) },
-			wantOut: "no agent tasks found\n",
+			wantErr: cmdutil.NewNoResultsError("no agent tasks found"),
 		},
 		{
 			name:  "limit truncates sessions",
@@ -154,15 +154,14 @@ func Test_listRun(t *testing.T) {
 			tty:      true,
 			stubs:    func(reg *httpmock.Registry) { registerRepoEmptySessionsMock(reg, "OWNER", "REPO") },
 			baseRepo: ghrepo.New("OWNER", "REPO"),
-			wantOut:  "no agent tasks found\n",
+			wantErr:  cmdutil.NewNoResultsError("no agent tasks found"),
 		},
 		{
 			name:        "repo resolution error does not surface",
 			tty:         true,
 			baseRepoErr: errors.New("ambiguous repo"),
-			wantErr:     nil,
+			wantErr:     cmdutil.NewNoResultsError("no agent tasks found"),
 			stubs:       func(reg *httpmock.Registry) { registerEmptySessionsMock(reg) },
-			wantOut:     "no agent tasks found\n",
 		},
 		{
 			name:     "repo scoped many sessions (tty)",
@@ -238,11 +237,7 @@ func Test_listRun(t *testing.T) {
 			}
 			got := stdout.String()
 			require.Equal(t, tt.wantOut, got)
-			if tt.wantStderr != "" {
-				require.Equal(t, tt.wantStderr, stderr.String())
-			} else {
-				require.Equal(t, "", stderr.String())
-			}
+			require.Equal(t, tt.wantStderr, stderr.String())
 			if tt.web {
 				br.Verify(t, tt.wantBrowserURL)
 			}


### PR DESCRIPTION
> [!WARNING]
> This is stacked onto #11620. Please merge #11620 first! 

Introduces a `--web` flag to the agent-task list command, allowing users to open the agent tasks page in their browser. 