### PR TITLE
Use advanced issue search

### DIFF
--- a/internal/featuredetection/detector_mock.go
+++ b/internal/featuredetection/detector_mock.go
@@ -20,6 +20,10 @@ func (md *DisabledDetectorMock) ProjectsV1() gh.ProjectsV1Support {
 	return gh.ProjectsV1Unsupported
 }
 
+func (md *DisabledDetectorMock) SearchFeatures() (SearchFeatures, error) {
+	return advancedIssueSearchNotSupported, nil
+}
+
 type EnabledDetectorMock struct{}
 
 func (md *EnabledDetectorMock) IssueFeatures() (IssueFeatures, error) {
@@ -36,4 +40,35 @@ func (md *EnabledDetectorMock) RepositoryFeatures() (RepositoryFeatures, error) 
 
 func (md *EnabledDetectorMock) ProjectsV1() gh.ProjectsV1Support {
 	return gh.ProjectsV1Supported
+}
+
+func (md *EnabledDetectorMock) SearchFeatures() (SearchFeatures, error) {
+	return advancedIssueSearchNotSupported, nil
+}
+
+type AdvancedIssueSearchDetectorMock struct {
+	EnabledDetectorMock
+	searchFeatures SearchFeatures
+}
+
+func (md *AdvancedIssueSearchDetectorMock) SearchFeatures() (SearchFeatures, error) {
+	return md.searchFeatures, nil
+}
+
+func AdvancedIssueSearchUnsupported() *AdvancedIssueSearchDetectorMock {
+	return &AdvancedIssueSearchDetectorMock{
+		searchFeatures: advancedIssueSearchNotSupported,
+	}
+}
+
+func AdvancedSearchSupportedAsOptIn() *AdvancedIssueSearchDetectorMock {
+	return &AdvancedIssueSearchDetectorMock{
+		searchFeatures: advancedIssueSearchSupportedAsOptIn,
+	}
+}
+
+func AdvancedSearchSupportedAsOnlyBackend() *AdvancedIssueSearchDetectorMock {
+	return &AdvancedIssueSearchDetectorMock{
+		searchFeatures: advancedIssueSearchSupportedAsOnlyBackend,
+	}
 }

--- a/internal/featuredetection/detector_mock.go
+++ b/internal/featuredetection/detector_mock.go
@@ -61,13 +61,13 @@ func AdvancedIssueSearchUnsupported() *AdvancedIssueSearchDetectorMock {
 	}
 }
 
-func AdvancedSearchSupportedAsOptIn() *AdvancedIssueSearchDetectorMock {
+func AdvancedIssueSearchSupportedAsOptIn() *AdvancedIssueSearchDetectorMock {
 	return &AdvancedIssueSearchDetectorMock{
 		searchFeatures: advancedIssueSearchSupportedAsOptIn,
 	}
 }
 
-func AdvancedSearchSupportedAsOnlyBackend() *AdvancedIssueSearchDetectorMock {
+func AdvancedIssueSearchSupportedAsOnlyBackend() *AdvancedIssueSearchDetectorMock {
 	return &AdvancedIssueSearchDetectorMock{
 		searchFeatures: advancedIssueSearchSupportedAsOnlyBackend,
 	}

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -285,13 +285,13 @@ func (d *detector) SearchFeatures() (SearchFeatures, error) {
 	// Regarding the release of advanced issue search (AIS, for short), there
 	// are three time spans/periods:
 	//
-	// 1. Pre-deprecation (< 4 Sep): where both legacy search and AIS are available
+	// 1. Pre-deprecation: where both legacy search and AIS are available
 	//    - GraphQL: `ISSUE` and `ISSUE_ADVANCED` search types in GraphQL behave differently
 	//    - REST:    `advance_search=true` query parameter can be used to switch to AIS
-	// 2. Deprecation (>= 4 Sep): only AIS available
+	// 2. Deprecation: only AIS available
 	//    - GraphQL: `ISSUE` and `ISSUE_ADVANCED` search types in GraphQL behave the same (AIS)
 	//    - REST:    `advance_search` query parameter has no effect (AIS)
-	// 3. Cleanup (>= TBD): only AIS available
+	// 3. Cleanup: only AIS available
 	//    - GraphQL: `ISSUE` search type in GraphQL is the only available option (AIS)
 	//    - REST:    `advance_search` query parameter has no effect (AIS)
 	//

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -16,6 +16,7 @@ type Detector interface {
 	PullRequestFeatures() (PullRequestFeatures, error)
 	RepositoryFeatures() (RepositoryFeatures, error)
 	ProjectsV1() gh.ProjectsV1Support
+	SearchFeatures() (SearchFeatures, error)
 }
 
 type IssueFeatures struct {
@@ -53,6 +54,48 @@ var allRepositoryFeatures = RepositoryFeatures{
 	PullRequestTemplateQuery: true,
 	VisibilityField:          true,
 	AutoMerge:                true,
+}
+
+type SearchFeatures struct {
+	// AdvancedIssueSearch indicates whether the host supports advanced issue
+	// search via API calls.
+	AdvancedIssueSearchAPI bool
+	// AdvancedIssueSearchOptIn indicates whether the host supports advanced
+	// issue search as an opt-in feature, which has to be explicitly enabled in
+	// API calls.
+	AdvancedIssueSearchAPIOptIn bool
+	// AdvancedIssueSearchWebInIssuesTab indicates whether the host supports
+	// advanced issue search syntax in the Issues tab of repositories.
+	AdvancedIssueSearchWebInIssuesTab bool
+
+	// TODO(babakks): when advanced issue search is supported in Pull Requests
+	// tab, or in global search we can introduce more fields to reflect the
+	// support status
+}
+
+// advancedIssueSearchNotSupported mimics GHE <3.18 where advanced issue search
+// is either not supported or is not meant to be used due to not being stable
+// enough (i.e. in preview).
+var advancedIssueSearchNotSupported = SearchFeatures{
+	AdvancedIssueSearchAPI: false,
+}
+
+// advancedIssueSearchSupportedAsOptIn mimics github.com and GHE >=3.18 before
+// the full cleanup of temp types (i.e. ISSUE_ADVANCED search type is still
+// present on the schema).
+var advancedIssueSearchSupportedAsOptIn = SearchFeatures{
+	AdvancedIssueSearchAPI:            true,
+	AdvancedIssueSearchAPIOptIn:       true,
+	AdvancedIssueSearchWebInIssuesTab: true,
+}
+
+// advancedIssueSearchSupportedAsOnlyBackend mimics github.com and GHE >=3.18
+// after the full cleanup of temp types (i.e. ISSUE_ADVANCED search type is
+// removed from the schema).
+var advancedIssueSearchSupportedAsOnlyBackend = SearchFeatures{
+	AdvancedIssueSearchAPI:            true,
+	AdvancedIssueSearchAPIOptIn:       false,
+	AdvancedIssueSearchWebInIssuesTab: true,
 }
 
 type detector struct {
@@ -223,6 +266,92 @@ func (d *detector) ProjectsV1() gh.ProjectsV1Support {
 	}
 
 	return gh.ProjectsV1Unsupported
+}
+
+const (
+	enterpriseAdvancedIssueSearchSupport = "3.18.0"
+)
+
+func (d *detector) SearchFeatures() (SearchFeatures, error) {
+	// Regarding the release of advanced issue search (AIS, for short), there
+	// are three time spans/periods:
+	//
+	// 1. Pre-deprecation (< 4 Sep): where both legacy search and AIS are available
+	//    - GraphQL: `ISSUE` and `ISSUE_ADVANCED` search types in GraphQL behave differently
+	//    - REST:    `advance_search=true` query parameter can be used to switch to AIS
+	// 2. Deprecation (>= 4 Sep): only AIS available
+	//    - GraphQL: `ISSUE` and `ISSUE_ADVANCED` search types in GraphQL behave the same (AIS)
+	//    - REST:    `advance_search` query parameter has no effect (AIS)
+	// 3. Cleanup (>= TBD): only AIS available
+	//    - GraphQL: `ISSUE` search type in GraphQL is the only available option (AIS)
+	//    - REST:    `advance_search` query parameter has no effect (AIS)
+	//
+	// Since there's no schema-wise difference between pre-deprecation and
+	// deprecation periods (i.e. `ISSUE_ADVANCED` is available during both),
+	// we cannot figure out the exact time period. The consensus is to to use
+	// the advanced search syntax during both periods.
+
+	var feature SearchFeatures
+
+	if ghauth.IsEnterprise(d.host) {
+		enterpriseAISSupportVersion, err := version.NewVersion(enterpriseAdvancedIssueSearchSupport)
+		if err != nil {
+			return SearchFeatures{}, err
+		}
+
+		hostVersion, err := resolveEnterpriseVersion(d.httpClient, d.host)
+		if err != nil {
+			return SearchFeatures{}, err
+		}
+
+		if hostVersion.GreaterThanOrEqual(enterpriseAISSupportVersion) {
+			// As of August 2025, advanced issue search is going to be available
+			// on GHES 3.18+, including Issues tabs in repositories.
+			feature.AdvancedIssueSearchAPI = true
+			feature.AdvancedIssueSearchWebInIssuesTab = true
+
+			// TODO(babakks): when the advanced search syntax is supported in
+			// global search or Pull Requests tabs (in repositories), we can
+			// enable the corresponding fields.
+		}
+	} else {
+		// As of August 2025, advanced issue search is available on github.com,
+		// including Issues tabs in repositories.
+		feature.AdvancedIssueSearchAPI = true
+		feature.AdvancedIssueSearchWebInIssuesTab = true
+
+		// TODO(babakks): when the advanced search syntax is supported in global
+		// search or Pull Requests tabs (in repositories), we can enable the
+		// corresponding fields.
+	}
+
+	if !feature.AdvancedIssueSearchAPI {
+		return feature, nil
+	}
+
+	var searchTypeFeatureDetection struct {
+		SearchType struct {
+			EnumValues []struct {
+				Name string
+			} `graphql:"enumValues(includeDeprecated: true)"`
+		} `graphql:"SearchType: __type(name: \"SearchType\")"`
+	}
+
+	gql := api.NewClientFromHTTP(d.httpClient)
+	if err := gql.Query(d.host, "SearchType_enumValues", &searchTypeFeatureDetection, nil); err != nil {
+		return SearchFeatures{}, err
+	}
+
+	for _, enumValue := range searchTypeFeatureDetection.SearchType.EnumValues {
+		if enumValue.Name == "ISSUE_ADVANCED" {
+			// As long as ISSUE_ADVANCED is present on the schema, we should
+			// explicitly opt-in when making API calls.
+			feature.AdvancedIssueSearchAPIOptIn = true
+			break
+		}
+	}
+
+	return feature, nil
 }
 
 func resolveEnterpriseVersion(httpClient *http.Client, host string) (*version.Version, error) {

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -68,9 +68,9 @@ type SearchFeatures struct {
 	// advanced issue search syntax in the Issues tab of repositories.
 	AdvancedIssueSearchWebInIssuesTab bool
 
-	// TODO(babakks): when advanced issue search is supported in Pull Requests
-	// tab, or in global search we can introduce more fields to reflect the
-	// support status
+	// TODO advancedSearchFuture
+	// When advanced issue search is supported in Pull Requests tab, or in
+	// global search we can introduce more fields to reflect the support status.
 }
 
 // advancedIssueSearchNotSupported mimics GHE <3.18 where advanced issue search
@@ -273,6 +273,9 @@ const (
 )
 
 func (d *detector) SearchFeatures() (SearchFeatures, error) {
+	// TODO advancedIssueSearchCleanup
+	// Once GHES 3.17 support ends, we don't need this and, probably, the entire search feature detection.
+
 	// Regarding the release of advanced issue search (AIS, for short), there
 	// are three time spans/periods:
 	//
@@ -310,9 +313,10 @@ func (d *detector) SearchFeatures() (SearchFeatures, error) {
 			feature.AdvancedIssueSearchAPI = true
 			feature.AdvancedIssueSearchWebInIssuesTab = true
 
-			// TODO(babakks): when the advanced search syntax is supported in
-			// global search or Pull Requests tabs (in repositories), we can
-			// enable the corresponding fields.
+			// TODO advancedSearchFuture
+			// When the advanced search syntax is supported in global search or
+			// Pull Requests tabs (in repositories), we can add and enable the
+			// corresponding fields.
 		}
 	} else {
 		// As of August 2025, advanced issue search is available on github.com,
@@ -320,8 +324,9 @@ func (d *detector) SearchFeatures() (SearchFeatures, error) {
 		feature.AdvancedIssueSearchAPI = true
 		feature.AdvancedIssueSearchWebInIssuesTab = true
 
-		// TODO(babakks): when the advanced search syntax is supported in global
-		// search or Pull Requests tabs (in repositories), we can enable the
+		// TODO advancedSearchFuture
+		// When the advanced search syntax is supported in global search or
+		// Pull Requests tabs (in repositories), we can add and enable the
 		// corresponding fields.
 	}
 

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -64,9 +64,6 @@ type SearchFeatures struct {
 	// issue search as an opt-in feature, which has to be explicitly enabled in
 	// API calls.
 	AdvancedIssueSearchAPIOptIn bool
-	// AdvancedIssueSearchWebInIssuesTab indicates whether the host supports
-	// advanced issue search syntax in the Issues tab of repositories.
-	AdvancedIssueSearchWebInIssuesTab bool
 
 	// TODO advancedSearchFuture
 	// When advanced issue search is supported in Pull Requests tab, or in
@@ -84,18 +81,16 @@ var advancedIssueSearchNotSupported = SearchFeatures{
 // the full cleanup of temp types (i.e. ISSUE_ADVANCED search type is still
 // present on the schema).
 var advancedIssueSearchSupportedAsOptIn = SearchFeatures{
-	AdvancedIssueSearchAPI:            true,
-	AdvancedIssueSearchAPIOptIn:       true,
-	AdvancedIssueSearchWebInIssuesTab: true,
+	AdvancedIssueSearchAPI:      true,
+	AdvancedIssueSearchAPIOptIn: true,
 }
 
 // advancedIssueSearchSupportedAsOnlyBackend mimics github.com and GHE >=3.18
 // after the full cleanup of temp types (i.e. ISSUE_ADVANCED search type is
 // removed from the schema).
 var advancedIssueSearchSupportedAsOnlyBackend = SearchFeatures{
-	AdvancedIssueSearchAPI:            true,
-	AdvancedIssueSearchAPIOptIn:       false,
-	AdvancedIssueSearchWebInIssuesTab: true,
+	AdvancedIssueSearchAPI:      true,
+	AdvancedIssueSearchAPIOptIn: false,
 }
 
 type detector struct {
@@ -317,7 +312,6 @@ func (d *detector) SearchFeatures() (SearchFeatures, error) {
 			// As of August 2025, advanced issue search is going to be available
 			// on GHES 3.18+, including Issues tabs in repositories.
 			feature.AdvancedIssueSearchAPI = true
-			feature.AdvancedIssueSearchWebInIssuesTab = true
 
 			// TODO advancedSearchFuture
 			// When the advanced search syntax is supported in global search or
@@ -328,7 +322,6 @@ func (d *detector) SearchFeatures() (SearchFeatures, error) {
 		// As of August 2025, advanced issue search is available on github.com,
 		// including Issues tabs in repositories.
 		feature.AdvancedIssueSearchAPI = true
-		feature.AdvancedIssueSearchWebInIssuesTab = true
 
 		// TODO advancedSearchFuture
 		// When the advanced search syntax is supported in global search or

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -269,6 +269,12 @@ func (d *detector) ProjectsV1() gh.ProjectsV1Support {
 }
 
 const (
+	// enterpriseAdvancedIssueSearchSupport is the minimum version of GHES that
+	// supports advanced issue search and gh should use it.
+	//
+	// Note that advanced issue search is also available on GHES 3.17, but it's
+	// at the preview stage and is not as mature as it is on github.com or later
+	// GHES version.
 	enterpriseAdvancedIssueSearchSupport = "3.18.0"
 )
 

--- a/pkg/cmd/extension/browse/browse_test.go
+++ b/pkg/cmd/extension/browse/browse_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cli/cli/v2/internal/config"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/repo/view"
@@ -125,7 +126,7 @@ func Test_getExtensionRepos(t *testing.T) {
 		}),
 	)
 
-	searcher := search.NewSearcher(client, "github.com")
+	searcher := search.NewSearcher(client, "github.com", &fd.DisabledDetectorMock{})
 	emMock := &extensions.ExtensionManagerMock{}
 	emMock.ListFunc = func() []extensions.Extension {
 		return []extensions.Extension{

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/git"
+	"github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/internal/text"
@@ -164,7 +165,8 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					query.Qualifiers = qualifiers
 
 					host, _ := cfg.Authentication().DefaultHost()
-					searcher := search.NewSearcher(client, host)
+					detector := featuredetection.NewDetector(client, host)
+					searcher := search.NewSearcher(client, host, detector)
 
 					if webMode {
 						url := searcher.URL(query)
@@ -507,7 +509,8 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 						return err
 					}
 
-					searcher := search.NewSearcher(api.NewCachedHTTPClient(client, time.Hour*24), host)
+					detector := featuredetection.NewDetector(client, host)
+					searcher := search.NewSearcher(api.NewCachedHTTPClient(client, time.Hour*24), host, detector)
 
 					gc.Stderr = gio.Discard
 

--- a/pkg/cmd/issue/list/http.go
+++ b/pkg/cmd/issue/list/http.go
@@ -114,6 +114,10 @@ loop:
 }
 
 func searchIssues(client *api.Client, detector fd.Detector, repo ghrepo.Interface, filters prShared.FilterOptions, limit int) (*api.IssuesAndTotalCount, error) {
+	// TODO advancedIssueSearchCleanup
+	// We won't need feature detection when GHES 3.17 support ends, since
+	// the advanced issue search is the only available search backend for
+	// issues.
 	features, err := detector.SearchFeatures()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/httpmock"
@@ -164,4 +165,50 @@ func TestIssueList_pagination(t *testing.T) {
 	assert.Equal(t, []string{"user1"}, getAssignees(res.Issues[0]))
 	assert.Equal(t, []string{"enhancement"}, getLabels(res.Issues[1]))
 	assert.Equal(t, []string{"user2"}, getAssignees(res.Issues[1]))
+}
+
+func TestSearchIssuesAndAdvancedSearch(t *testing.T) {
+	tests := []struct {
+		name           string
+		detector       fd.Detector
+		wantSearchType string
+	}{
+		{
+			name:           "advanced issue search not supported",
+			detector:       fd.AdvancedIssueSearchUnsupported(),
+			wantSearchType: "ISSUE",
+		},
+		{
+			name:           "advanced issue search supported as opt-in",
+			detector:       fd.AdvancedIssueSearchSupportedAsOptIn(),
+			wantSearchType: "ISSUE_ADVANCED",
+		},
+		{
+			name:           "advanced issue search supported as only backend",
+			detector:       fd.AdvancedIssueSearchSupportedAsOnlyBackend(),
+			wantSearchType: "ISSUE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			reg.Register(
+				httpmock.GraphQL(`query IssueSearch\b`),
+				httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]interface{}) {
+					assert.Equal(t, tt.wantSearchType, vars["type"])
+					// Since no repeated usage of special search qualifiers is possible
+					// with our current implementation, we can assert against the same
+					// query for both search backend (i.e. legacy and advanced issue search).
+					assert.Equal(t, "repo:OWNER/REPO state:open type:issue", vars["query"])
+				}))
+
+			httpClient := &http.Client{Transport: reg}
+			client := api.NewClientFromHTTP(httpClient)
+
+			searchIssues(client, tt.detector, ghrepo.New("OWNER", "REPO"), prShared.FilterOptions{State: "open"}, 30)
+		})
+	}
 }

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -167,6 +167,8 @@ func TestIssueList_pagination(t *testing.T) {
 	assert.Equal(t, []string{"user2"}, getAssignees(res.Issues[1]))
 }
 
+// TODO advancedIssueSearchCleanup
+// Remove this test once GHES 3.17 support ends.
 func TestSearchIssuesAndAdvancedSearch(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -58,6 +58,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List issues in a repository",
+		// TODO advancedIssueSearchCleanup
+		// Update the links and remove the mention at GHES 3.17 version.
 		Long: heredoc.Doc(`
 			List issues in a GitHub repository. By default, this only lists open issues.
 
@@ -170,6 +172,11 @@ func listRun(opts *ListOptions) error {
 	isTerminal := opts.IO.IsStdoutTTY()
 
 	if opts.WebMode {
+		// TODO advancedIssueSearchCleanup
+		// We won't need feature detection when GHES 3.17 support ends, since
+		// the advanced issue search is the only available search backend for
+		// issues, and the GUI (i.e. Issues tab of repos) already supports the
+		// advanced syntax.
 		searchFeatures, err := opts.Detector.SearchFeatures()
 		if err != nil {
 			return err

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -63,12 +63,12 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Long: heredoc.Docf(`
 			List issues in a GitHub repository. By default, this only lists open issues.
 
-			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x, the command
-			performs search by using the advanced issue search syntax, which is documented at:
-			<https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more>
-
 			The search query syntax is documented here:
 			<https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests>
+
+			On supported GitHub hosts, advanced issue search syntax can be used in the
+			%[1]s--search%[1]s query. For more information about advanced issue search, see:
+			<https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests#building-advanced-filters-for-issues>
 		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh issue list --label "bug" --label "help wanted"

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -61,6 +61,11 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Long: heredoc.Doc(`
 			List issues in a GitHub repository. By default, this only lists open issues.
 
+			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x,
+			the command performs search by using the advanced issue search syntax, which
+			is documented at:
+			<https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more>
+
 			The search query syntax is documented here:
 			<https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests>
 		`),

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -60,17 +60,16 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Short: "List issues in a repository",
 		// TODO advancedIssueSearchCleanup
 		// Update the links and remove the mention at GHES 3.17 version.
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			List issues in a GitHub repository. By default, this only lists open issues.
 
-			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x,
-			the command performs search by using the advanced issue search syntax, which
-			is documented at:
+			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x, the command
+			performs search by using the advanced issue search syntax, which is documented at:
 			<https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more>
 
 			The search query syntax is documented here:
 			<https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests>
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			$ gh issue list --label "bug" --label "help wanted"
 			$ gh issue list --author monalisa

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -181,10 +181,11 @@ func listRun(opts *ListOptions) error {
 			return err
 		}
 
-		advancedSyntaxSupported := searchFeatures.AdvancedIssueSearchAPI && searchFeatures.AdvancedIssueSearchWebInIssuesTab
-
 		issueListURL := ghrepo.GenerateRepoURL(baseRepo, "issues")
-		openURL, err := prShared.ListURLWithQuery(issueListURL, filterOptions, advancedSyntaxSupported)
+
+		// Note that if the advanced issue search API is available, the syntax is
+		// also supported in the Issues tab.
+		openURL, err := prShared.ListURLWithQuery(issueListURL, filterOptions, searchFeatures.AdvancedIssueSearchAPI)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/config"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/run"
@@ -210,6 +211,7 @@ func TestIssueList_web(t *testing.T) {
 		BaseRepo: func() (ghrepo.Interface, error) {
 			return ghrepo.New("OWNER", "REPO"), nil
 		},
+		Detector:     fd.AdvancedIssueSearchUnsupported(),
 		WebMode:      true,
 		State:        "all",
 		Assignee:     "peter",
@@ -230,9 +232,10 @@ func TestIssueList_web(t *testing.T) {
 
 func Test_issueList(t *testing.T) {
 	type args struct {
-		repo    ghrepo.Interface
-		filters prShared.FilterOptions
-		limit   int
+		detector fd.Detector
+		repo     ghrepo.Interface
+		filters  prShared.FilterOptions
+		limit    int
 	}
 	tests := []struct {
 		name      string
@@ -243,8 +246,9 @@ func Test_issueList(t *testing.T) {
 		{
 			name: "default",
 			args: args{
-				limit: 30,
-				repo:  ghrepo.New("OWNER", "REPO"),
+				detector: fd.AdvancedIssueSearchUnsupported(),
+				limit:    30,
+				repo:     ghrepo.New("OWNER", "REPO"),
 				filters: prShared.FilterOptions{
 					Entity: "issue",
 					State:  "open",
@@ -270,8 +274,9 @@ func Test_issueList(t *testing.T) {
 		{
 			name: "milestone by number",
 			args: args{
-				limit: 30,
-				repo:  ghrepo.New("OWNER", "REPO"),
+				detector: fd.AdvancedIssueSearchUnsupported(),
+				limit:    30,
+				repo:     ghrepo.New("OWNER", "REPO"),
 				filters: prShared.FilterOptions{
 					Entity:    "issue",
 					State:     "open",
@@ -309,8 +314,9 @@ func Test_issueList(t *testing.T) {
 		{
 			name: "milestone by title",
 			args: args{
-				limit: 30,
-				repo:  ghrepo.New("OWNER", "REPO"),
+				detector: fd.AdvancedIssueSearchUnsupported(),
+				limit:    30,
+				repo:     ghrepo.New("OWNER", "REPO"),
 				filters: prShared.FilterOptions{
 					Entity:    "issue",
 					State:     "open",
@@ -341,8 +347,9 @@ func Test_issueList(t *testing.T) {
 		{
 			name: "@me syntax",
 			args: args{
-				limit: 30,
-				repo:  ghrepo.New("OWNER", "REPO"),
+				detector: fd.AdvancedIssueSearchUnsupported(),
+				limit:    30,
+				repo:     ghrepo.New("OWNER", "REPO"),
 				filters: prShared.FilterOptions{
 					Entity:   "issue",
 					State:    "open",
@@ -377,8 +384,9 @@ func Test_issueList(t *testing.T) {
 		{
 			name: "@me with search",
 			args: args{
-				limit: 30,
-				repo:  ghrepo.New("OWNER", "REPO"),
+				detector: fd.AdvancedIssueSearchUnsupported(),
+				limit:    30,
+				repo:     ghrepo.New("OWNER", "REPO"),
 				filters: prShared.FilterOptions{
 					Entity:   "issue",
 					State:    "open",
@@ -412,8 +420,9 @@ func Test_issueList(t *testing.T) {
 		{
 			name: "with labels",
 			args: args{
-				limit: 30,
-				repo:  ghrepo.New("OWNER", "REPO"),
+				detector: fd.AdvancedIssueSearchUnsupported(),
+				limit:    30,
+				repo:     ghrepo.New("OWNER", "REPO"),
 				filters: prShared.FilterOptions{
 					Entity: "issue",
 					State:  "open",
@@ -450,7 +459,7 @@ func Test_issueList(t *testing.T) {
 				tt.httpStubs(httpreg)
 			}
 			client := &http.Client{Transport: httpreg}
-			_, err := issueList(client, tt.args.repo, tt.args.filters, tt.args.limit)
+			_, err := issueList(client, tt.args.detector, tt.args.repo, tt.args.filters, tt.args.limit)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -507,6 +516,7 @@ func TestIssueList_withProjectItems(t *testing.T) {
 	client := &http.Client{Transport: reg}
 	issuesAndTotalCount, err := issueList(
 		client,
+		fd.AdvancedIssueSearchUnsupported(),
 		ghrepo.New("OWNER", "REPO"),
 		prShared.FilterOptions{
 			Entity: "issue",
@@ -581,6 +591,7 @@ func TestIssueList_Search_withProjectItems(t *testing.T) {
 	client := &http.Client{Transport: reg}
 	issuesAndTotalCount, err := issueList(
 		client,
+		fd.AdvancedIssueSearchUnsupported(),
 		ghrepo.New("OWNER", "REPO"),
 		prShared.FilterOptions{
 			Entity: "issue",

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -190,6 +190,8 @@ func TestIssueList_disabledIssues(t *testing.T) {
 	}
 }
 
+// TODO advancedIssueSearchCleanup
+// Simplify this test to only a single test case once GHES 3.17 support ends.
 func TestIssueList_web(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -299,6 +301,8 @@ func Test_issueList(t *testing.T) {
 		{
 			name: "milestone by number",
 			args: args{
+				// TODO advancedIssueSearchCleanup
+				// No need for feature detection once GHES 3.17 support ends.
 				detector: fd.AdvancedIssueSearchSupportedAsOptIn(),
 				limit:    30,
 				repo:     ghrepo.New("OWNER", "REPO"),
@@ -339,6 +343,8 @@ func Test_issueList(t *testing.T) {
 		{
 			name: "milestone by title",
 			args: args{
+				// TODO advancedIssueSearchCleanup
+				// No need for feature detection once GHES 3.17 support ends.
 				detector: fd.AdvancedIssueSearchSupportedAsOptIn(),
 				limit:    30,
 				repo:     ghrepo.New("OWNER", "REPO"),
@@ -408,6 +414,8 @@ func Test_issueList(t *testing.T) {
 		{
 			name: "@me with search",
 			args: args{
+				// TODO advancedIssueSearchCleanup
+				// No need for feature detection once GHES 3.17 support ends.
 				detector: fd.AdvancedIssueSearchSupportedAsOptIn(),
 				limit:    30,
 				repo:     ghrepo.New("OWNER", "REPO"),
@@ -444,6 +452,8 @@ func Test_issueList(t *testing.T) {
 		{
 			name: "with labels",
 			args: args{
+				// TODO advancedIssueSearchCleanup
+				// No need for feature detection once GHES 3.17 support ends.
 				detector: fd.AdvancedIssueSearchSupportedAsOptIn(),
 				limit:    30,
 				repo:     ghrepo.New("OWNER", "REPO"),
@@ -615,6 +625,8 @@ func TestIssueList_Search_withProjectItems(t *testing.T) {
 	client := &http.Client{Transport: reg}
 	issuesAndTotalCount, err := issueList(
 		client,
+		// TODO advancedIssueSearchCleanup
+		// No need for feature detection once GHES 3.17 support ends.
 		fd.AdvancedIssueSearchSupportedAsOptIn(),
 		ghrepo.New("OWNER", "REPO"),
 		prShared.FilterOptions{

--- a/pkg/cmd/pr/list/http.go
+++ b/pkg/cmd/pr/list/http.go
@@ -30,6 +30,10 @@ func listPullRequests(httpClient *http.Client, detector fd.Detector, repo ghrepo
 }
 
 func searchPullRequests(httpClient *http.Client, detector fd.Detector, repo ghrepo.Interface, filters prShared.FilterOptions, limit int) (*api.PullRequestAndTotalCount, error) {
+	// TODO advancedIssueSearchCleanup
+	// We won't need feature detection when GHES 3.17 support ends, since
+	// the advanced issue search is the only available search backend for
+	// issues.
 	features, err := detector.SearchFeatures()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pr/list/http_test.go
+++ b/pkg/cmd/pr/list/http_test.go
@@ -78,6 +78,8 @@ func Test_ListPullRequests(t *testing.T) {
 		{
 			name: "with labels",
 			args: args{
+				// TODO advancedIssueSearchCleanup
+				// No need for feature detection once GHES 3.17 support ends.
 				detector: fd.AdvancedIssueSearchSupportedAsOptIn(),
 				repo:     ghrepo.New("OWNER", "REPO"),
 				limit:    30,
@@ -104,6 +106,8 @@ func Test_ListPullRequests(t *testing.T) {
 		{
 			name: "with author",
 			args: args{
+				// TODO advancedIssueSearchCleanup
+				// No need for feature detection once GHES 3.17 support ends.
 				detector: fd.AdvancedIssueSearchSupportedAsOptIn(),
 				repo:     ghrepo.New("OWNER", "REPO"),
 				limit:    30,
@@ -130,6 +134,8 @@ func Test_ListPullRequests(t *testing.T) {
 		{
 			name: "with search",
 			args: args{
+				// TODO advancedIssueSearchCleanup
+				// No need for feature detection once GHES 3.17 support ends.
 				detector: fd.AdvancedIssueSearchSupportedAsOptIn(),
 				repo:     ghrepo.New("OWNER", "REPO"),
 				limit:    30,
@@ -171,6 +177,8 @@ func Test_ListPullRequests(t *testing.T) {
 	}
 }
 
+// TODO advancedIssueSearchCleanup
+// Remove this test once GHES 3.17 support ends.
 func TestSearchPullRequestsAndAdvancedSearch(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -58,17 +58,16 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Short: "List pull requests in a repository",
 		// TODO advancedIssueSearchCleanup
 		// Update the links and remove the mention at GHES 3.17 version.
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			List pull requests in a GitHub repository. By default, this only lists open PRs.
 
-			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x,
-			the command performs search by using the advanced issue search syntax, which
-			is documented at:
+			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x, the command
+			performs search by using the advanced issue search syntax, which is documented at:
 			<https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more>
 
 			The search query syntax is documented here:
 			<https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests>
-		`),
+		`, "`"),
 		Example: heredoc.Doc(`
 			# List PRs authored by you
 			$ gh pr list --author "@me"

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -61,12 +61,12 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Long: heredoc.Docf(`
 			List pull requests in a GitHub repository. By default, this only lists open PRs.
 
-			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x, the command
-			performs search by using the advanced issue search syntax, which is documented at:
-			<https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more>
-
 			The search query syntax is documented here:
 			<https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests>
+			
+			On supported GitHub hosts, advanced issue search syntax can be used in the
+			%[1]s--search%[1]s query. For more information about advanced issue search, see:
+			<https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests#building-advanced-filters-for-issues>
 		`, "`"),
 		Example: heredoc.Doc(`
 			# List PRs authored by you

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -56,6 +56,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List pull requests in a repository",
+		// TODO advancedIssueSearchCleanup
+		// Update the links and remove the mention at GHES 3.17 version.
 		Long: heredoc.Doc(`
 			List pull requests in a GitHub repository. By default, this only lists open PRs.
 
@@ -177,9 +179,10 @@ func listRun(opts *ListOptions) error {
 	if opts.WebMode {
 		prListURL := ghrepo.GenerateRepoURL(baseRepo, "pulls")
 
-		// TODO(babakks): As of August 2025, the advanced issue search syntax is
-		// not supported in Pull Requests tab of repositories. When it's supported
-		// we can change the argument to true.
+		// TODO advancedSearchFuture
+		// As of August 2025, the advanced issue search syntax is not supported
+		// in Pull Requests tab of repositories. When it's supported we can
+		// change the argument to true.
 		openURL, err := shared.ListURLWithQuery(prListURL, filters, false)
 		if err != nil {
 			return err

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -59,6 +59,11 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Long: heredoc.Doc(`
 			List pull requests in a GitHub repository. By default, this only lists open PRs.
 
+			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x,
+			the command performs search by using the advanced issue search syntax, which
+			is documented at:
+			<https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more>
+
 			The search query syntax is documented here:
 			<https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests>
 		`),

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -192,6 +192,8 @@ func TestPRList_filteringAssignee(t *testing.T) {
 			assert.Equal(t, `assignee:hubot base:develop is:merged label:"needs tests" repo:OWNER/REPO type:pr`, params["q"].(string))
 		}))
 
+	// TODO advancedIssueSearchCleanup
+	// No need for feature detection once GHES 3.17 support ends.
 	_, err := runCommand(http, fd.AdvancedIssueSearchSupportedAsOptIn(), true, `-s merged -l "needs tests" -a hubot -B develop`)
 	assert.Error(t, err)
 }
@@ -225,6 +227,8 @@ func TestPRList_filteringDraft(t *testing.T) {
 					assert.Equal(t, test.expectedQuery, params["q"].(string))
 				}))
 
+			// TODO advancedIssueSearchCleanup
+			// No need for feature detection once GHES 3.17 support ends.
 			_, err := runCommand(http, fd.AdvancedIssueSearchSupportedAsOptIn(), true, test.cli)
 			assert.Error(t, err)
 		})
@@ -270,6 +274,8 @@ func TestPRList_filteringAuthor(t *testing.T) {
 					assert.Equal(t, test.expectedQuery, params["q"].(string))
 				}))
 
+			// TODO advancedIssueSearchCleanup
+			// No need for feature detection once GHES 3.17 support ends.
 			_, err := runCommand(http, fd.AdvancedIssueSearchSupportedAsOptIn(), true, test.cli)
 			assert.Error(t, err)
 		})
@@ -443,6 +449,8 @@ func TestPRList_Search_withProjectItems(t *testing.T) {
 	client := &http.Client{Transport: reg}
 	prsAndTotalCount, err := listPullRequests(
 		client,
+		// TODO advancedIssueSearchCleanup
+		// No need for feature detection once GHES 3.17 support ends.
 		fd.AdvancedIssueSearchSupportedAsOptIn(),
 		ghrepo.New("OWNER", "REPO"),
 		prShared.FilterOptions{

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -80,7 +80,7 @@ func TestPRList(t *testing.T) {
 
 	http.Register(httpmock.GraphQL(`query PullRequestList\b`), httpmock.FileResponse("./fixtures/prList.json"))
 
-	output, err := runCommand(http, fd.AdvancedIssueSearchUnsupported(), true, "")
+	output, err := runCommand(http, nil, true, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func TestPRList_nontty(t *testing.T) {
 
 	http.Register(httpmock.GraphQL(`query PullRequestList\b`), httpmock.FileResponse("./fixtures/prList.json"))
 
-	output, err := runCommand(http, fd.AdvancedIssueSearchUnsupported(), false, "")
+	output, err := runCommand(http, nil, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func TestPRList_filtering(t *testing.T) {
 			assert.Equal(t, []interface{}{"OPEN", "CLOSED", "MERGED"}, params["state"].([]interface{}))
 		}))
 
-	output, err := runCommand(http, fd.AdvancedIssueSearchUnsupported(), true, `-s all`)
+	output, err := runCommand(http, nil, true, `-s all`)
 	assert.Error(t, err)
 
 	assert.Equal(t, "", output.String())
@@ -141,7 +141,7 @@ func TestPRList_filteringRemoveDuplicate(t *testing.T) {
 		httpmock.GraphQL(`query PullRequestList\b`),
 		httpmock.FileResponse("./fixtures/prListWithDuplicates.json"))
 
-	output, err := runCommand(http, fd.AdvancedIssueSearchUnsupported(), true, "")
+	output, err := runCommand(http, nil, true, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestPRList_filteringClosed(t *testing.T) {
 			assert.Equal(t, []interface{}{"CLOSED", "MERGED"}, params["state"].([]interface{}))
 		}))
 
-	_, err := runCommand(http, fd.AdvancedIssueSearchUnsupported(), true, `-s closed`)
+	_, err := runCommand(http, nil, true, `-s closed`)
 	assert.Error(t, err)
 }
 
@@ -178,7 +178,7 @@ func TestPRList_filteringHeadBranch(t *testing.T) {
 			assert.Equal(t, interface{}("bug-fix"), params["headBranch"])
 		}))
 
-	_, err := runCommand(http, fd.AdvancedIssueSearchUnsupported(), true, `-H bug-fix`)
+	_, err := runCommand(http, nil, true, `-H bug-fix`)
 	assert.Error(t, err)
 }
 
@@ -192,7 +192,7 @@ func TestPRList_filteringAssignee(t *testing.T) {
 			assert.Equal(t, `assignee:hubot base:develop is:merged label:"needs tests" repo:OWNER/REPO type:pr`, params["q"].(string))
 		}))
 
-	_, err := runCommand(http, fd.AdvancedIssueSearchUnsupported(), true, `-s merged -l "needs tests" -a hubot -B develop`)
+	_, err := runCommand(http, fd.AdvancedIssueSearchSupportedAsOptIn(), true, `-s merged -l "needs tests" -a hubot -B develop`)
 	assert.Error(t, err)
 }
 
@@ -225,7 +225,7 @@ func TestPRList_filteringDraft(t *testing.T) {
 					assert.Equal(t, test.expectedQuery, params["q"].(string))
 				}))
 
-			_, err := runCommand(http, fd.AdvancedIssueSearchUnsupported(), true, test.cli)
+			_, err := runCommand(http, fd.AdvancedIssueSearchSupportedAsOptIn(), true, test.cli)
 			assert.Error(t, err)
 		})
 	}
@@ -270,7 +270,7 @@ func TestPRList_filteringAuthor(t *testing.T) {
 					assert.Equal(t, test.expectedQuery, params["q"].(string))
 				}))
 
-			_, err := runCommand(http, fd.AdvancedIssueSearchUnsupported(), true, test.cli)
+			_, err := runCommand(http, fd.AdvancedIssueSearchSupportedAsOptIn(), true, test.cli)
 			assert.Error(t, err)
 		})
 	}
@@ -279,7 +279,7 @@ func TestPRList_filteringAuthor(t *testing.T) {
 func TestPRList_withInvalidLimitFlag(t *testing.T) {
 	http := initFakeHTTP()
 	defer http.Verify(t)
-	_, err := runCommand(http, fd.AdvancedIssueSearchUnsupported(), true, `--limit=0`)
+	_, err := runCommand(http, nil, true, `--limit=0`)
 	assert.EqualError(t, err, "invalid value for --limit: 0")
 }
 
@@ -314,7 +314,7 @@ func TestPRList_web(t *testing.T) {
 			_, cmdTeardown := run.Stub()
 			defer cmdTeardown(t)
 
-			output, err := runCommand(http, fd.AdvancedIssueSearchUnsupported(), true, "--web "+test.cli)
+			output, err := runCommand(http, nil, true, "--web "+test.cli)
 			if err != nil {
 				t.Errorf("error running command `pr list` with `--web` flag: %v", err)
 			}
@@ -372,7 +372,7 @@ func TestPRList_withProjectItems(t *testing.T) {
 	client := &http.Client{Transport: reg}
 	prsAndTotalCount, err := listPullRequests(
 		client,
-		fd.AdvancedIssueSearchUnsupported(),
+		nil,
 		ghrepo.New("OWNER", "REPO"),
 		prShared.FilterOptions{
 			Entity: "pr",
@@ -436,14 +436,14 @@ func TestPRList_Search_withProjectItems(t *testing.T) {
 			require.Equal(t, map[string]interface{}{
 				"limit": float64(30),
 				"q":     "just used to force the search API branch repo:OWNER/REPO state:open type:pr",
-				"type":  "ISSUE",
+				"type":  "ISSUE_ADVANCED",
 			}, params)
 		}))
 
 	client := &http.Client{Transport: reg}
 	prsAndTotalCount, err := listPullRequests(
 		client,
-		fd.AdvancedIssueSearchUnsupported(),
+		fd.AdvancedIssueSearchSupportedAsOptIn(),
 		ghrepo.New("OWNER", "REPO"),
 		prShared.FilterOptions{
 			Entity: "pr",

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -228,7 +228,7 @@ func SearchQueryBuild(options FilterOptions, advancedIssueSearchSyntax bool) str
 	if advancedIssueSearchSyntax {
 		q = query.AdvancedIssueSearchString()
 	} else {
-		q = query.String()
+		q = query.StandardSearchString()
 	}
 
 	if options.Search != "" {

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -186,20 +186,20 @@ func (opts *FilterOptions) IsDefault() bool {
 	return true
 }
 
-func ListURLWithQuery(listURL string, options FilterOptions) (string, error) {
+func ListURLWithQuery(listURL string, options FilterOptions, advancedIssueSearchSyntax bool) (string, error) {
 	u, err := url.Parse(listURL)
 	if err != nil {
 		return "", err
 	}
 
 	params := u.Query()
-	params.Set("q", SearchQueryBuild(options))
+	params.Set("q", SearchQueryBuild(options, advancedIssueSearchSyntax))
 	u.RawQuery = params.Encode()
 
 	return u.String(), nil
 }
 
-func SearchQueryBuild(options FilterOptions) string {
+func SearchQueryBuild(options FilterOptions, advancedIssueSearchSyntax bool) string {
 	var is, state string
 	switch options.State {
 	case "open", "closed":
@@ -207,7 +207,7 @@ func SearchQueryBuild(options FilterOptions) string {
 	case "merged":
 		is = "merged"
 	}
-	q := search.Query{
+	query := search.Query{
 		Qualifiers: search.Qualifiers{
 			Assignee:  options.Assignee,
 			Author:    options.Author,
@@ -223,10 +223,18 @@ func SearchQueryBuild(options FilterOptions) string {
 			Type:      options.Entity,
 		},
 	}
-	if options.Search != "" {
-		return fmt.Sprintf("%s %s", options.Search, q.String())
+
+	var q string
+	if advancedIssueSearchSyntax {
+		q = query.AdvancedIssueSearchString()
+	} else {
+		q = query.String()
 	}
-	return q.String()
+
+	if options.Search != "" {
+		return fmt.Sprintf("%s %s", options.Search, q)
+	}
+	return q
 }
 
 func QueryHasStateClause(searchQuery string) bool {

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -19,8 +19,9 @@ func Test_listURLWithQuery(t *testing.T) {
 	falseBool := false
 
 	type args struct {
-		listURL string
-		options FilterOptions
+		listURL                   string
+		options                   FilterOptions
+		advancedIssueSearchSyntax bool
 	}
 
 	tests := []struct {
@@ -101,7 +102,7 @@ func Test_listURLWithQuery(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ListURLWithQuery(tt.args.listURL, tt.args.options)
+			got, err := ListURLWithQuery(tt.args.listURL, tt.args.options, tt.args.advancedIssueSearchSyntax)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("listURLWithQuery() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -43,6 +43,19 @@ func Test_listURLWithQuery(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "blank, advanced search",
+			args: args{
+				listURL: "https://example.com/path?a=b",
+				options: FilterOptions{
+					Entity: "issue",
+					State:  "open",
+				},
+				advancedIssueSearchSyntax: true,
+			},
+			want:    "https://example.com/path?a=b&q=state%3Aopen+type%3Aissue",
+			wantErr: false,
+		},
+		{
 			name: "draft",
 			args: args{
 				listURL: "https://example.com/path",
@@ -56,6 +69,20 @@ func Test_listURLWithQuery(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "draft, advanced search",
+			args: args{
+				listURL: "https://example.com/path",
+				options: FilterOptions{
+					Entity: "pr",
+					State:  "open",
+					Draft:  &trueBool,
+				},
+				advancedIssueSearchSyntax: true,
+			},
+			want:    "https://example.com/path?q=draft%3Atrue+state%3Aopen+type%3Apr",
+			wantErr: false,
+		},
+		{
 			name: "non-draft",
 			args: args{
 				listURL: "https://example.com/path",
@@ -64,6 +91,20 @@ func Test_listURLWithQuery(t *testing.T) {
 					State:  "open",
 					Draft:  &falseBool,
 				},
+			},
+			want:    "https://example.com/path?q=draft%3Afalse+state%3Aopen+type%3Apr",
+			wantErr: false,
+		},
+		{
+			name: "non-draft, advanced search",
+			args: args{
+				listURL: "https://example.com/path",
+				options: FilterOptions{
+					Entity: "pr",
+					State:  "open",
+					Draft:  &falseBool,
+				},
+				advancedIssueSearchSyntax: true,
 			},
 			want:    "https://example.com/path?q=draft%3Afalse+state%3Aopen+type%3Apr",
 			wantErr: false,
@@ -86,6 +127,24 @@ func Test_listURLWithQuery(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "all, advanced search",
+			args: args{
+				listURL: "https://example.com/path",
+				options: FilterOptions{
+					Entity:     "issue",
+					State:      "open",
+					Assignee:   "bo",
+					Author:     "ka",
+					BaseBranch: "trunk",
+					HeadBranch: "bug-fix",
+					Mention:    "nu",
+				},
+				advancedIssueSearchSyntax: true,
+			},
+			want:    "https://example.com/path?q=assignee%3Abo+author%3Aka+base%3Atrunk+head%3Abug-fix+mentions%3Anu+state%3Aopen+type%3Aissue",
+			wantErr: false,
+		},
+		{
 			name: "spaces in values",
 			args: args{
 				listURL: "https://example.com/path",
@@ -95,6 +154,21 @@ func Test_listURLWithQuery(t *testing.T) {
 					Labels:    []string{"docs", "help wanted"},
 					Milestone: `Codename "What Was Missing"`,
 				},
+			},
+			want:    "https://example.com/path?q=label%3A%22help+wanted%22+label%3Adocs+milestone%3A%22Codename+%5C%22What+Was+Missing%5C%22%22+state%3Aopen+type%3Apr",
+			wantErr: false,
+		},
+		{
+			name: "spaces in values, advanced search",
+			args: args{
+				listURL: "https://example.com/path",
+				options: FilterOptions{
+					Entity:    "pr",
+					State:     "open",
+					Labels:    []string{"docs", "help wanted"},
+					Milestone: `Codename "What Was Missing"`,
+				},
+				advancedIssueSearchSyntax: true,
 			},
 			want:    "https://example.com/path?q=label%3A%22help+wanted%22+label%3Adocs+milestone%3A%22Codename+%5C%22What+Was+Missing%5C%22%22+state%3Aopen+type%3Apr",
 			wantErr: false,

--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -213,5 +213,5 @@ func searchQuery(owner string, filter FilterOptions) string {
 		},
 	}
 
-	return q.String()
+	return q.StandardSearchString()
 }

--- a/pkg/cmd/search/code/code_test.go
+++ b/pkg/cmd/search/code/code_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/config"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	ghmock "github.com/cli/cli/v2/internal/gh/mock"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -336,7 +337,7 @@ func TestCodeRun(t *testing.T) {
 						Extension: "go",
 					},
 				},
-				Searcher: search.NewSearcher(nil, "github.com"),
+				Searcher: search.NewSearcher(nil, "github.com", &fd.DisabledDetectorMock{}),
 				WebMode:  true,
 			},
 			wantBrowse: "https://github.com/search?q=map+path%3Atesting.go&type=code",
@@ -354,7 +355,7 @@ func TestCodeRun(t *testing.T) {
 						Extension: ".cpp",
 					},
 				},
-				Searcher: search.NewSearcher(nil, "github.com"),
+				Searcher: search.NewSearcher(nil, "github.com", &fd.DisabledDetectorMock{}),
 				WebMode:  true,
 			},
 			wantBrowse: "https://github.com/search?q=map+path%3Atesting.cpp&type=code",
@@ -381,7 +382,7 @@ func TestCodeRun(t *testing.T) {
 						Extension: "go",
 					},
 				},
-				Searcher: search.NewSearcher(nil, "example.com"),
+				Searcher: search.NewSearcher(nil, "example.com", &fd.DisabledDetectorMock{}),
 				WebMode:  true,
 			},
 			wantBrowse: "https://example.com/search?q=map+extension%3Ago+filename%3Atesting&type=code",

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -37,9 +37,9 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
 
-			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x,
-			the command performs advanced issue search. The advanced syntax is documented at:
-			<https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more>
+			On supported GitHub hosts, advanced issue search syntax can be used in the
+			%[1]s--search%[1]s query. For more information about advanced issue search, see:
+			<https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests#building-advanced-filters-for-issues>
 
 			For more information on handling search queries containing a hyphen, run %[1]sgh search --help%[1]s.
 		`, "`"),

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -35,6 +35,10 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
 
+			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x,
+			the command performs advanced issue search. The advanced syntax is documented at:
+			<https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more>
+
 			For more information on handling search queries containing a hyphen, run %[1]sgh search --help%[1]s.
 		`, "`"),
 		Example: heredoc.Doc(`

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -26,6 +26,8 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 	cmd := &cobra.Command{
 		Use:   "issues [<query>]",
 		Short: "Search for issues",
+		// TODO advancedIssueSearchCleanup
+		// Update the links and remove the mention at GHES 3.17 version.
 		Long: heredoc.Docf(`
 			Search for issues on GitHub.
 

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -39,9 +39,9 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
 
-			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x,
-			the command performs advanced issue search. The advanced syntax is documented at:
-			<https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more>
+			On supported GitHub hosts, advanced issue search syntax can be used in the
+			%[1]s--search%[1]s query. For more information about advanced issue search, see:
+			<https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests#building-advanced-filters-for-issues>
 
 			For more information on handling search queries containing a hyphen, run %[1]sgh search --help%[1]s.
 		`, "`"),

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -28,6 +28,8 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 	cmd := &cobra.Command{
 		Use:   "prs [<query>]",
 		Short: "Search for pull requests",
+		// TODO advancedIssueSearchCleanup
+		// Update the links and remove the mention at GHES 3.17 version.
 		Long: heredoc.Docf(`
 			Search for pull requests on GitHub.
 

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -37,6 +37,10 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 			GitHub search syntax is documented at:
 			<https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests>
 
+			When runs against %[1]sgithub.com%[1]s or GHE versions newer than 3.17.x,
+			the command performs advanced issue search. The advanced syntax is documented at:
+			<https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more>
+
 			For more information on handling search queries containing a hyphen, run %[1]sgh search --help%[1]s.
 		`, "`"),
 		Example: heredoc.Doc(`

--- a/pkg/cmd/search/shared/shared.go
+++ b/pkg/cmd/search/shared/shared.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cli/cli/v2/internal/browser"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -42,12 +43,16 @@ func Searcher(f *cmdutil.Factory) (search.Searcher, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	host, _ := cfg.Authentication().DefaultHost()
 	client, err := f.HttpClient()
 	if err != nil {
 		return nil, err
 	}
-	return search.NewSearcher(client, host), nil
+
+	detector := fd.NewDetector(client, host)
+
+	return search.NewSearcher(client, host, detector), nil
 }
 
 func SearchIssues(opts *IssuesOptions) error {

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -137,8 +137,12 @@ func formatSpecialQualifiers(qualifier string, vs []string, valuesToOR []string)
 		all = append(all, groupWithOR(qualifier, specials))
 	}
 	if len(rest) > 0 {
-		all = append(all, concat(qualifier, rest))
+		for _, v := range rest {
+			all = append(all, fmt.Sprintf("%s:%s", qualifier, quote(v)))
+		}
 	}
+
+	slices.Sort(all)
 	return strings.Join(all, " ")
 }
 
@@ -155,18 +159,9 @@ func groupWithOR(qualifier string, vs []string) string {
 	if len(all) == 1 {
 		return all[0]
 	}
-	return fmt.Sprintf("(%s)", strings.Join(all, " OR "))
-}
 
-func concat(qualifier string, vs []string) string {
-	if len(vs) == 0 {
-		return ""
-	}
-	all := make([]string, 0, len(vs))
-	for _, v := range vs {
-		all = append(all, fmt.Sprintf("%s:%s", qualifier, quote(v)))
-	}
-	return strings.Join(all, " ")
+	slices.Sort(all)
+	return fmt.Sprintf("(%s)", strings.Join(all, " OR "))
 }
 
 func (q Qualifiers) Map() map[string][]string {

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -101,7 +101,7 @@ type Qualifiers struct {
 //
 // At the moment, the advanced search syntax is only available for searching
 // issues, and it's called advanced issue search.
-func (q Query) String() string {
+func (q Query) StandardSearchString() string {
 	qualifiers := formatQualifiers(q.Qualifiers, nil)
 	keywords := formatKeywords(q.Keywords)
 	all := append(keywords, qualifiers...)

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -87,8 +87,20 @@ type Qualifiers struct {
 }
 
 // String returns the string representation of the query which can be used with
-// search API (except for advanced issue search), global search GUI (i.e.
-// github.com/search), or Pull Requests tab (in repositories).
+// the legacy search backend, which is used in global search GUI (i.e.
+// github.com/search), or Pull Requests tab (in repositories). Note that this is
+// a common query format that can be used to search for various entity types
+// (e.g., issues, commits, repositories, etc)
+//
+// With the legacy search backend, the query is made of concatenating keywords
+// and qualifiers with whitespaces. Note that at the backend side, most of the
+// repeated qualifiers are AND-ed, while a handful of qualifiers (i.e.
+// is:private/public, repo:, user:, or in:) are implicitly OR-ed. The legacy
+// search backend does not support the advanced syntax which allows for nested
+// queries and explicit OR operators.
+//
+// At the moment, the advanced search syntax is only available for searching
+// issues, and it's called advanced issue search.
 func (q Query) String() string {
 	qualifiers := formatQualifiers(q.Qualifiers, nil)
 	keywords := formatKeywords(q.Keywords)
@@ -100,6 +112,17 @@ func (q Query) String() string {
 // compatible with the advanced issue search syntax. The query can be used in
 // Issues tab (of repositories) and the Issues dashboard (i.e.
 // github.com/issues).
+//
+// As the name suggests, this query syntax is only supported for searching
+// issues (i.e. issues and PRs). The advanced syntax allows nested queries and
+// explicit OR operators. Unlike the legacy search backend, the advanced issue
+// search does not OR repeated instances of special qualifiers (i.e.
+// is:private/public, repo:, user:, or in:).
+//
+// To keep the gh experience consistent and backward-compatible, the mentioned
+// special qualifiers are explicitly grouped and combined with an OR operator.
+//
+// The advanced syntax is documented at https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more
 func (q Query) AdvancedIssueSearchString() string {
 	qualifiers := formatQualifiers(q.Qualifiers, formatAdvancedIssueSearch)
 	keywords := formatKeywords(q.Keywords)

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -131,7 +131,33 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 					In:   []string{"title", "body", "comments", "foo"}, // "foo" is to ensure only "title", "body", and "comments" are grouped
 				},
 			},
-			out: `keyword (in:title OR in:body OR in:comments) in:foo (is:private OR is:public) is:foo (repo:foo/bar OR repo:foo/baz) (user:johndoe OR user:janedoe)`,
+			out: `keyword (in:body OR in:comments OR in:title) in:foo (is:private OR is:public) is:foo (repo:foo/bar OR repo:foo/baz) (user:janedoe OR user:johndoe)`,
+		},
+		{
+			name: "special qualifiers without special values",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					Is: []string{"foo", "bar"},
+					In: []string{"foo", "bar"},
+				},
+			},
+			out: `keyword in:bar in:foo is:bar is:foo`,
+		},
+		{
+			name: "non-special qualifiers used multiple times",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					In:      []string{"foo", "bar"},
+					Is:      []string{"foo", "bar"},
+					Label:   []string{"foo", "bar"},
+					License: []string{"foo", "bar"},
+					No:      []string{"foo", "bar"},
+					Topic:   []string{"foo", "bar"},
+				},
+			},
+			out: `keyword in:bar in:foo is:bar is:foo label:bar label:foo license:bar license:foo no:bar no:foo topic:bar topic:foo`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -8,7 +8,7 @@ import (
 
 var trueBool = true
 
-func TestQueryString(t *testing.T) {
+func TestStandardSearchString(t *testing.T) {
 	tests := []struct {
 		name  string
 		query Query
@@ -73,7 +73,7 @@ func TestQueryString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.out, tt.query.String())
+			assert.Equal(t, tt.out, tt.query.StandardSearchString())
 		})
 	}
 }

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -149,8 +149,8 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 			query: Query{
 				Keywords: []string{"keyword"},
 				Qualifiers: Qualifiers{
-					In:      []string{"foo", "bar"},
-					Is:      []string{"foo", "bar"},
+					In:      []string{"foo", "bar"}, // "in:" is a special qualifier but its values here are not special
+					Is:      []string{"foo", "bar"}, // "is:" is a special qualifier but its values here are not special
 					Label:   []string{"foo", "bar"},
 					License: []string{"foo", "bar"},
 					No:      []string{"foo", "bar"},

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -126,12 +126,12 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 				Keywords: []string{"keyword"},
 				Qualifiers: Qualifiers{
 					Repo: []string{"foo/bar", "foo/baz"},
-					Is:   []string{"private", "public", "foo"}, // "foo" is to ensure only "public" and "private" are grouped
+					Is:   []string{"private", "public", "issue", "pr", "open", "closed", "locked", "unlocked", "merged", "unmerged", "blocked", "blocking", "foo"}, // "foo" is to ensure only "public" and "private" are grouped
 					User: []string{"johndoe", "janedoe"},
 					In:   []string{"title", "body", "comments", "foo"}, // "foo" is to ensure only "title", "body", and "comments" are grouped
 				},
 			},
-			out: `keyword (in:body OR in:comments OR in:title) in:foo (is:private OR is:public) is:foo (repo:foo/bar OR repo:foo/baz) (user:janedoe OR user:johndoe)`,
+			out: `keyword (in:body OR in:comments OR in:title) in:foo (is:blocked OR is:blocking) (is:closed OR is:open) (is:issue OR is:pr) (is:locked OR is:unlocked) (is:merged OR is:unmerged) (is:private OR is:public) is:foo (repo:foo/bar OR repo:foo/baz) (user:janedoe OR user:johndoe)`,
 		},
 		{
 			name: "special qualifiers without special values",
@@ -158,6 +158,16 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 				},
 			},
 			out: `keyword in:bar in:foo is:bar is:foo label:bar label:foo license:bar license:foo no:bar no:foo topic:bar topic:foo`,
+		},
+		{
+			name: "unused special qualifiers should be missing from the query",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					Label: []string{"foo", "bar"},
+				},
+			},
+			out: `keyword label:bar label:foo`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -108,6 +108,16 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 			out: `label:"quote qualifier"`,
 		},
 		{
+			name: "unused qualifiers should not appear in query",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					Label: []string{"foo", "bar"},
+				},
+			},
+			out: `keyword label:bar label:foo`,
+		},
+		{
 			name: "special qualifiers when used once",
 			query: Query{
 				Keywords: []string{"keyword"},
@@ -134,6 +144,9 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 			out: `keyword (in:body OR in:comments OR in:title) in:foo (is:blocked OR is:blocking) (is:closed OR is:open) (is:issue OR is:pr) (is:locked OR is:unlocked) (is:merged OR is:unmerged) (is:private OR is:public) is:foo (repo:foo/bar OR repo:foo/baz) (user:janedoe OR user:johndoe)`,
 		},
 		{
+			// Since this is a general purpose package, we can't assume with know all
+			// use cases of special qualifiers. So, here we ensure unknown values are
+			// not OR-ed by default.
 			name: "special qualifiers without special values",
 			query: Query{
 				Keywords: []string{"keyword"},
@@ -158,16 +171,6 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 				},
 			},
 			out: `keyword in:bar in:foo is:bar is:foo label:bar label:foo license:bar license:foo no:bar no:foo topic:bar topic:foo`,
-		},
-		{
-			name: "unused special qualifiers should be missing from the query",
-			query: Query{
-				Keywords: []string{"keyword"},
-				Qualifiers: Qualifiers{
-					Label: []string{"foo", "bar"},
-				},
-			},
-			out: `keyword label:bar label:foo`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghinstance"
 )
 
@@ -34,8 +35,9 @@ type Searcher interface {
 }
 
 type searcher struct {
-	client *http.Client
-	host   string
+	client   *http.Client
+	detector fd.Detector
+	host     string
 }
 
 type httpError struct {
@@ -52,10 +54,11 @@ type httpErrorItem struct {
 	Resource string
 }
 
-func NewSearcher(client *http.Client, host string) Searcher {
+func NewSearcher(client *http.Client, host string, detector fd.Detector) Searcher {
 	return &searcher{
-		client: client,
-		host:   host,
+		client:   client,
+		host:     host,
+		detector: detector,
 	}
 }
 

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -210,6 +210,10 @@ func (s searcher) search(query Query, result interface{}) (*http.Response, error
 	qs.Set("per_page", strconv.Itoa(query.Limit))
 
 	if query.Kind == KindIssues {
+		// TODO advancedIssueSearchCleanup
+		// We won't need feature detection when GHES 3.17 support ends, since
+		// the advanced issue search is the only available search backend for
+		// issues.
 		features, err := s.detector.SearchFeatures()
 		if err != nil {
 			return nil, err
@@ -269,10 +273,11 @@ func (s searcher) URL(query Query) string {
 	qs := url.Values{}
 	qs.Set("type", query.Kind)
 
-	// TODO(babakks): currently, the global search GUI does not support the
-	// advanced issue search syntax (even for the issues/PRs tab on the
-	// sidebar). When the GUI is updated, we can use feature detection, and, if
-	// available, use the advanced search syntax.
+	// TODO advancedSearchFuture
+	// Currently, the global search GUI does not support the advanced issue
+	// search syntax (even for the issues/PRs tab on the sidebar). When the GUI
+	// is updated, we can use feature detection, and, if available, use the
+	// advanced search syntax.
 	qs.Set("q", query.String())
 
 	if query.Order != "" {

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -220,7 +220,7 @@ func (s searcher) search(query Query, result interface{}) (*http.Response, error
 		}
 
 		if !features.AdvancedIssueSearchAPI {
-			qs.Set("q", query.String())
+			qs.Set("q", query.StandardSearchString())
 		} else {
 			qs.Set("q", query.AdvancedIssueSearchString())
 
@@ -230,7 +230,7 @@ func (s searcher) search(query Query, result interface{}) (*http.Response, error
 			}
 		}
 	} else {
-		qs.Set("q", query.String())
+		qs.Set("q", query.StandardSearchString())
 	}
 
 	if query.Order != "" {
@@ -278,7 +278,7 @@ func (s searcher) URL(query Query) string {
 	// search syntax (even for the issues/PRs tab on the sidebar). When the GUI
 	// is updated, we can use feature detection, and, if available, use the
 	// advanced search syntax.
-	qs.Set("q", query.String())
+	qs.Set("q", query.StandardSearchString())
 
 	if query.Order != "" {
 		qs.Set(orderKey, query.Order)

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -263,11 +263,18 @@ func (s searcher) search(query Query, result interface{}) (*http.Response, error
 	return resp, nil
 }
 
+// URL returns URL to the global search in web GUI (i.e. github.com/search).
 func (s searcher) URL(query Query) string {
 	path := fmt.Sprintf("https://%s/search", s.host)
 	qs := url.Values{}
 	qs.Set("type", query.Kind)
+
+	// TODO(babakks): currently, the global search GUI does not support the
+	// advanced issue search syntax (even for the issues/PRs tab on the
+	// sidebar). When the GUI is updated, we can use feature detection, and, if
+	// available, use the advanced search syntax.
 	qs.Set("q", query.String())
+
 	if query.Order != "" {
 		qs.Set(orderKey, query.Order)
 	}

--- a/pkg/search/searcher_test.go
+++ b/pkg/search/searcher_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
 )
@@ -265,7 +266,7 @@ func TestSearcherCode(t *testing.T) {
 			if tt.host == "" {
 				tt.host = "github.com"
 			}
-			searcher := NewSearcher(client, tt.host)
+			searcher := NewSearcher(client, tt.host, &fd.DisabledDetectorMock{})
 			result, err := searcher.Code(tt.query)
 			if tt.wantErr {
 				assert.EqualError(t, err, tt.errMsg)
@@ -551,7 +552,7 @@ func TestSearcherCommits(t *testing.T) {
 			if tt.host == "" {
 				tt.host = "github.com"
 			}
-			searcher := NewSearcher(client, tt.host)
+			searcher := NewSearcher(client, tt.host, &fd.DisabledDetectorMock{})
 			result, err := searcher.Commits(tt.query)
 			if tt.wantErr {
 				assert.EqualError(t, err, tt.errMsg)
@@ -837,7 +838,7 @@ func TestSearcherRepositories(t *testing.T) {
 			if tt.host == "" {
 				tt.host = "github.com"
 			}
-			searcher := NewSearcher(client, tt.host)
+			searcher := NewSearcher(client, tt.host, &fd.DisabledDetectorMock{})
 			result, err := searcher.Repositories(tt.query)
 			if tt.wantErr {
 				assert.EqualError(t, err, tt.errMsg)
@@ -1123,7 +1124,7 @@ func TestSearcherIssues(t *testing.T) {
 			if tt.host == "" {
 				tt.host = "github.com"
 			}
-			searcher := NewSearcher(client, tt.host)
+			searcher := NewSearcher(client, tt.host, fd.AdvancedIssueSearchUnsupported())
 			result, err := searcher.Issues(tt.query)
 			if tt.wantErr {
 				assert.EqualError(t, err, tt.errMsg)
@@ -1179,7 +1180,7 @@ func TestSearcherURL(t *testing.T) {
 			if tt.host == "" {
 				tt.host = "github.com"
 			}
-			searcher := NewSearcher(nil, tt.host)
+			searcher := NewSearcher(nil, tt.host, nil)
 			assert.Equal(t, tt.url, searcher.URL(tt.query))
 		})
 	}

--- a/pkg/search/searcher_test.go
+++ b/pkg/search/searcher_test.go
@@ -1161,6 +1161,8 @@ func TestSearcherIssuesAdvancedSyntax(t *testing.T) {
 		wantErr    string
 	}{
 		{
+			// TODO advancedIssueSearchCleanup
+			// Remove this test case once GHES 3.17 support ends.
 			name:     "advanced issue search not supported",
 			detector: fd.AdvancedIssueSearchUnsupported(),
 			query:    query,
@@ -1170,6 +1172,8 @@ func TestSearcherIssuesAdvancedSyntax(t *testing.T) {
 			},
 		},
 		{
+			// TODO advancedIssueSearchCleanup
+			// Remove this test case once GHES 3.17 support ends.
 			name:     "advanced issue search supported as an opt-in feature",
 			detector: fd.AdvancedIssueSearchSupportedAsOptIn(),
 			query:    query,
@@ -1179,6 +1183,8 @@ func TestSearcherIssuesAdvancedSyntax(t *testing.T) {
 			},
 		},
 		{
+			// TODO advancedIssueSearchCleanup
+			// No need for feature detection once GHES 3.17 support ends.
 			name:     "advanced issue search supported as the only search backend",
 			detector: fd.AdvancedIssueSearchSupportedAsOnlyBackend(),
 			query:    query,


### PR DESCRIPTION
This PR updates `gh` to use advanced issue search, if available.

Here are a couple of notes regarding the changes:

- The `search` package (in `pkg/search`) is a general-purpose/independent component that handles the search for a couple of other commands. That is why, it now supports `is:blocked`, `is:blocking` or even handles the combination of `is:merged` and `is:unmerged` in a query, although no other part of the code actually uses these. It's just to eliminate the extra knowledge about what other packages need.

- For mock feature detectors, where a feature detector was need but it's not really important for the test case (like asserting something other than the query), a mock that reflects the current status of the advanced issue search is used (which is *supported as opt-in*). This is to keep the tests up-to-date with the state of `github.com` and reflect the fact that `gh` prefers advanced issue search if it's available on the host.

- For test cases where the code path should not involve any feature detection (e.g. when a list operation should take place, rather than a search), a `nil` detector is passed.

- Two markers added to the code to help us identify the places we need to change in the future:
  - **`// TODO advancedIssueSearchCleanup`:** actionable when GHES 3.17 goes out of support and we don't need to maintain compatibility with the old issue search backend.
  - **`// TODO advancedSearchFuture`:** actionable when the advanced search syntax is available on global search or Pull Requests tabs.

## A/C verification

### A. On `github.com`

#### 1. `gh search issues` (REST API)

> **When** I run these commands:
> ```sh
> gh search issues --sort created --repo cli/cli --repo cli/go-gh hyperlink
> gh search issues --sort created --repo cli/cli --match title,body,comments foo
> gh search issues --sort created --repo cli/cli --visibility private,public foo
> gh search issues --sort created --owner @me --owner cli
> ```
> **Then** the result is **not empty**, the query contains **OR-ed qualifiers**, and the API request URL includes the `advanced_search=true` query parameter

All confirmed, just an example here. HTTP request (note the `advanced_search=true`):
```
/search/issues?advanced_search=true&page=1&per_page=30&q=hyperlink+%28repo%3Acli%2Fcli+OR+repo%3Acli%2Fgo-gh%29+type%3Aissue&sort=created
```

URL-decoded query:
```
hyperlink (repo:cli/cli OR repo:cli/go-gh) type:issue
```

> **When** I run above commands with `--web`
> **Then** I see the old search syntax (i.e. no OR-ed qualifiers) in the global search GUI

Confirmed:
<img width="435" height="61" alt="gh-search-issue-web" src="https://github.com/user-attachments/assets/f755068b-1a53-444e-9f14-aa33dbf7591f" />

#### 2. `gh search prs` (REST API)

> **When** I run these commands:
> ```sh
> gh search prs --sort created --repo cli/cli --repo cli/go-gh hyperlink
> gh search prs --sort created --repo cli/cli --match title,body,comments foo
> gh search prs --sort created --repo cli/cli --visibility private,public foo
> gh search prs --sort created --owner @me --owner cli
> ```
> **Then** the result is **not empty**, the query contains **OR-ed qualifiers**, and the API request URL includes the `advanced_search=true` query parameter

All confirmed, just an example here. HTTP request (note the `advanced_search=true`):
```
/search/issues?advanced_search=true&page=1&per_page=30&q=hyperlink+%28repo%3Acli%2Fcli+OR+repo%3Acli%2Fgo-gh%29+type%3Apr&sort=created
```

URL-decoded query:
```
hyperlink (repo:cli/cli OR repo:cli/go-gh) type:pr
```

> **When** I run above commands with `--web` 
> **Then** I see the old search syntax (i.e. no OR-ed qualifiers) in the global search GUI

Confirmed:
<img width="418" height="54" alt="gh-search-prs-web" src="https://github.com/user-attachments/assets/34b783b0-3dd6-4081-ae6c-808890e9b34d" />

#### 3. `gh issue list` (GraphQL)

> **Given** I'm in the local clone of the `cli/cli` repo
> **When** I run `gh issue list --search gh --label bug` (to enforce a search API call)
> **Then** the result is the same as it would when using the latest `gh` release, and the `type` argument is set to `ISSUE_ADVANCED`

Confirmed (note the `ISSUE_ADVANCED`):
```
GraphQL variables: {"limit":30,"owner":"cli","query":"gh label:bug repo:cli/cli state:open type:issue","repo":"cli","type":"ISSUE_ADVANCED"}
```

The results are the same:

```
$ diff <(gh issue list --search gh --label bug) <(./bin/gh issue list --search gh --label bug)
$ echo $?
0
```

> **Given** I'm in the local clone of the `cli/cli` repo
> **When** I run `gh issue list --search gh --label bug --web`
> **Then** the pre-populated query is the same as it would when using the latest `gh` release

Confirmed. On latest `gh`:
<img width="288" height="46" alt="gh-issue-list-web-old" src="https://github.com/user-attachments/assets/c9fffc43-da3a-43e5-b6f5-d301d047ce26" />

Current PR:
<img width="283" height="51" alt="gh-issue-list-web-new" src="https://github.com/user-attachments/assets/0c90c9af-feb0-43bc-8358-7d9fb0f61e36" />

#### 4. `gh pr list` (GraphQL)

> **Given** I'm in the local clone of the `cli/cli` repo
> **When** I run `gh pr list --search gh --label external` (to enforce a search API call)
> **Then** the result is the same as it would when using the latest `gh` release, and the `type` argument is set to `ISSUE_ADVANCED`

Confirmed (note the `ISSUE_ADVANCED`):
```
GraphQL variables: {"limit":30,"q":"gh label:external repo:cli/cli state:open type:pr","type":"ISSUE_ADVANCED"}
```

The results are the same:

```
$ diff <(gh pr list --search gh --label external) <(./bin/gh pr list --search gh --label external)
$ echo $?
0
```

> **Given** I'm in the local clone of the `cli/cli` repo
> **When** I run `gh pr list --search gh --label external --web`
> **Then** the pre-populated query is the same as it would when using the latest `gh` release

Confirmed. On latest `gh`:
<img width="376" height="44" alt="gh-pr-list-web-old" src="https://github.com/user-attachments/assets/814fdc43-4aa0-44b8-91bd-7bf0e94e8ce1" />

Current PR:
<img width="348" height="38" alt="gh-pr-list-web-new" src="https://github.com/user-attachments/assets/24e66d3c-daa5-4172-bfaa-d06c20435080" />

### B. On GHES 3.17

Asserting the GHES instance version:

```sh
GH_HOST="<HOST>" gh api /meta --jq '.installed_version' | cat
# 3.17.0
```
#### 1. `gh search issues` (REST API)

> **When** I run 
> ```sh
> GH_HOST="<HOST>" USER="<USER>" gh search issues --sort created --repo "$USER/repo-a" --repo "$USER/repo-b" foo
> ```
> **Then** the result is the same as it would when using the latest `gh` release, the query **does not** contain **OR-ed qualifiers**, and the API request URL does not include the `advanced_search=true` query parameter

Confirmed. Both show the same output (although expected 2, not 2x2 hits!):

```
Showing 4 of 4 issues

REPO            ID  TITLE  LABELS  UPDATED           
babakks/repo-b  #1  foo            about 13 hours ago
babakks/repo-b  #1  foo            about 13 hours ago
babakks/repo-a  #1  foo            about 14 hours ago
babakks/repo-a  #1  foo            about 14 hours ago
```

Also, no `advanced_search=true` and no `OR`s in query in the HTTP request:

```
GET /api/v3/search/issues?page=1&per_page=30&q=foo+repo%3Ababakks%2Frepo-a+repo%3Ababakks%2Frepo-b+type%3Aissue&sort=created HTTP/1.1
```

> **When** I run above commands with `--web`
> **Then** I see the old search syntax (i.e. no OR-ed qualifiers) in the global search GUI

Confirmed; since the GUI does not show the query here's the browser's address bar:
<img width="934" height="48" alt="ghes-search-issues-web" src="https://github.com/user-attachments/assets/758e4f60-c2ed-492b-9642-d87e113f05b1" />

#### 2. `gh search prs` (REST API)

> **When** I run 
> ```sh
> GH_HOST="<HOST>" USER="<USER>" gh search prs --sort created --repo "$USER/repo-a" --repo "$USER/repo-b" foo
> ```
> **Then** the result is the same as it would when using the latest `gh` release, the query **does not** contain **OR-ed qualifiers**, and the API request URL does not include the `advanced_search=true` query parameter

Confirmed. Both show the same output (this time really 2 hits!):

```
Showing 2 of 2 pull requests

REPO            ID  TITLE  LABELS  UPDATED           
babakks/repo-b  #2  foo            about 14 hours ago
babakks/repo-a  #2  foo            about 14 hours ago
```

Also, no `advanced_search=true` and no `OR`s in query in the HTTP request:

```
GET /api/v3/search/issues?page=1&per_page=30&q=foo+repo%3Ababakks%2Frepo-a+repo%3Ababakks%2Frepo-b+type%3Apr&sort=created HTTP/1.1
```

> **When** I run above commands with `--web`
> **Then** I see the old search syntax (i.e. no OR-ed qualifiers) in the global search GUI

Confirmed; since the GUI does not show the query here's the browser's address bar:
<img width="911" height="44" alt="ghes-search-prs-web" src="https://github.com/user-attachments/assets/ed55062a-4628-4756-aa1e-c6d82f3f03e0" />

#### 3. `gh issue list` (GraphQL)

> **Given** I'm in the local clone of one the repos
> **When** I run `gh issue list --search foo` (to enforce a search API call)
> **Then** the result is the same as it would when using the latest `gh` release, and the `type` argument is set to `ISSUE`

Confirmed the outputs are the same (although it should be only one hit, not two!):

```
Showing 2 of 2 issues in babakks/repo-a that match your search

ID  TITLE  LABELS  UPDATED           
#1  foo            about 14 hours ago
#1  foo            about 14 hours ago
```

Also `type` is `ISSUE`:

```
GraphQL variables: {"limit":30,"owner":"babakks","query":"foo repo:babakks/repo-a state:open type:issue","repo":"repo-a","type":"ISSUE"}
```

> **Given** I'm in the local clone of one the repos
> **When** I run `gh issue list --search foo --web`
> **Then** the pre-populated query is the same as it would when using the latest `gh` release

Confirmed. On latest `gh`:
<img width="299" height="44" alt="ghes-issue-list-web-old" src="https://github.com/user-attachments/assets/0a35e6b4-6fa9-4667-b10e-46048e09fded" />

Current PR:
<img width="308" height="43" alt="ghes-issue-list-web-new" src="https://github.com/user-attachments/assets/bdd7bd39-c66f-441a-b5e9-65ab4f1d11d1" />

#### 4. `gh pr list` (GraphQL)

> **Given** I'm in the local clone of one the repos
> **When** I run `gh pr list --search foo` (to enforce a search API call)
> **Then** the result is the same as it would when using the latest `gh` release, and the `type` argument is set to `ISSUE`

Confirmed the outputs are the same:

```
Showing 1 of 1 pull request in babakks/repo-a that matches your search

ID  TITLE  BRANCH      CREATED AT        
#2  foo    new-branch  about 14 hours ago
```

Also `type` is `ISSUE`:

```
GraphQL variables: {"limit":30,"q":"foo repo:babakks/repo-a state:open type:pr","type":"ISSUE"}
```

> **Given** I'm in the local clone of one the repos
> **When** I run `gh pr list --search foo --web`
> **Then** the pre-populated query is the same as it would when using the latest `gh` release

Confirmed. On latest `gh`:
<img width="268" height="38" alt="ghes-pr-list-web-old" src="https://github.com/user-attachments/assets/96a0b732-b8db-4afd-9251-0ea846e163f8" />

Current PR:
<img width="272" height="42" alt="ghes-pr-list-web-new" src="https://github.com/user-attachments/assets/c45bb3cc-ad29-4c69-8f2f-624ff6326cf0" />

