### PR TITLE
feat: simplify GitHub CLI installation on Linux by using a script

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -15,16 +15,10 @@ These packages are supported by the GitHub CLI maintainers with updates powered 
 To install:
 
 ```bash
-(type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
-	&& sudo mkdir -p -m 755 /etc/apt/keyrings \
-	&& out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-	&& cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-	&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-	&& sudo mkdir -p -m 755 /etc/apt/sources.list.d \
-	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-	&& sudo apt update \
-	&& sudo apt install gh -y
+curl -fsSL https://raw.githubusercontent.com/cli/cli/trunk/script/install-gh-apt.sh | bash
 ```
+
+This script adds our official APT repository and installs `gh`.
 
 To upgrade:
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -14,12 +14,12 @@ These packages are supported by the GitHub CLI maintainers with updates powered 
 
 To install:
 
-With curl:
+With `curl`:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/cli/cli/trunk/script/install-gh-apt.sh | bash
 ```
 
-With wget:
+With `wget`:
 ```bash
 wget -qO- https://raw.githubusercontent.com/cli/cli/trunk/script/install-gh-apt.sh | bash
 ```

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -14,8 +14,14 @@ These packages are supported by the GitHub CLI maintainers with updates powered 
 
 To install:
 
+With curl:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/cli/cli/trunk/script/install-gh-apt.sh | bash
+```
+
+With wget:
+```bash
+wget -qO- https://raw.githubusercontent.com/cli/cli/trunk/script/install-gh-apt.sh | bash
 ```
 
 This script adds our official APT repository and installs `gh`.

--- a/script/install-gh-apt.sh
+++ b/script/install-gh-apt.sh
@@ -12,7 +12,7 @@ sudo mkdir -p -m 755 /etc/apt/keyrings
 
 # Download key
 out=$(mktemp)
-wget -nv -O "$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg
+wget --https-only --secure-protocol=TLSv1_2 --fail -nv -O "$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg
 sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg < "$out" > /dev/null
 sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
 

--- a/script/install-gh-apt.sh
+++ b/script/install-gh-apt.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install wget if missing
+if ! command -v wget >/dev/null; then
+  sudo apt update
+  sudo apt install -y wget
+fi
+
+# Create keyring directory
+sudo mkdir -p -m 755 /etc/apt/keyrings
+
+# Download key
+out=$(mktemp)
+wget -nv -O "$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg
+sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg < "$out" > /dev/null
+sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+
+# Add sources.list entry
+sudo mkdir -p -m 755 /etc/apt/sources.list.d
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+
+# Update and install gh
+sudo apt update
+sudo apt install -y gh

--- a/script/install-gh-apt.sh
+++ b/script/install-gh-apt.sh
@@ -14,6 +14,7 @@ sudo mkdir -p -m 755 /etc/apt/keyrings
 out=$(mktemp)
 wget --https-only --secure-protocol=TLSv1_2 --fail -nv -O "$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg
 sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg < "$out" > /dev/null
+rm -f "$out"
 sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
 
 # Add sources.list entry


### PR DESCRIPTION
## Problem
Fixes #11640

## Solution

Replaced the manual installation steps in the documentation with a single command that executes a new script. The script handles the installation of wget, sets up the keyring, adds the APT repository, and installs the GitHub CLI.

