### PR TITLE
`gh agent-task create`: support providing task description from a file using `-F`/`--from-file`

### DIFF
--- a/pkg/cmd/agent-task/capi/client.go
+++ b/pkg/cmd/agent-task/capi/client.go
@@ -15,7 +15,7 @@ const capiHost = "api.githubcopilot.com"
 type CapiClient interface {
 	ListSessionsForViewer(ctx context.Context, limit int) ([]*Session, error)
 	ListSessionsForRepo(ctx context.Context, owner string, repo string, limit int) ([]*Session, error)
-	CreateJob(ctx context.Context, owner, repo, problemStatement string) (*Job, error)
+	CreateJob(ctx context.Context, owner, repo, problemStatement, baseBranch string) (*Job, error)
 	GetJob(ctx context.Context, owner, repo, jobID string) (*Job, error)
 }
 

--- a/pkg/cmd/agent-task/create/create.go
+++ b/pkg/cmd/agent-task/create/create.go
@@ -141,9 +141,9 @@ func createRun(opts *CreateOptions) error {
 	// Ensure we have a backoff strategy.
 	if opts.BackOff == nil {
 		opts.BackOff = backoff.NewExponentialBackOff(
-			backoff.WithMaxElapsedTime(4*time.Second),
+			backoff.WithMaxElapsedTime(10*time.Second),
 			backoff.WithInitialInterval(300*time.Millisecond),
-			backoff.WithMaxInterval(2*time.Second),
+			backoff.WithMaxInterval(10*time.Second),
 			backoff.WithMultiplier(1.5),
 		)
 	}

--- a/pkg/cmd/agent-task/create/create.go
+++ b/pkg/cmd/agent-task/create/create.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -50,7 +49,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			if len(args) > 0 {
 				opts.ProblemStatement = args[0]
 			} else if fromFileName != "" {
-				fileContent, err := os.ReadFile(fromFileName)
+				fileContent, err := cmdutil.ReadFile(fromFileName, opts.IO.In)
 				if err != nil {
 					return cmdutil.FlagErrorf("could not read task description file: %v", err)
 				}

--- a/pkg/cmd/agent-task/create/create.go
+++ b/pkg/cmd/agent-task/create/create.go
@@ -27,6 +27,7 @@ type CreateOptions struct {
 	Config           func() (gh.Config, error)
 	ProblemStatement string
 	BackOff          backoff.BackOff
+	BaseBranch       string
 }
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
@@ -84,6 +85,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	}
 
 	cmd.Flags().StringVarP(&fromFileName, "from-file", "F", "", "Read task description from file")
+	cmd.Flags().StringVarP(&opts.BaseBranch, "base", "b", "", "Base branch for the task")
 
 	opts.CapiClient = func() (capi.CapiClient, error) {
 		cfg, err := f.Config()
@@ -124,7 +126,7 @@ func createRun(opts *CreateOptions) error {
 	opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Creating agent task in %s/%s...", repo.RepoOwner(), repo.RepoName()))
 	defer opts.IO.StopProgressIndicator()
 
-	job, err := client.CreateJob(ctx, repo.RepoOwner(), repo.RepoName(), opts.ProblemStatement)
+	job, err := client.CreateJob(ctx, repo.RepoOwner(), repo.RepoName(), opts.ProblemStatement, opts.BaseBranch)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/agent-task/create/create_test.go
+++ b/pkg/cmd/agent-task/create/create_test.go
@@ -20,15 +20,13 @@ import (
 
 // Test basic option parsing & repository requirement
 func TestNewCmdCreate_Args(t *testing.T) {
-	type tc struct {
+	tests := []struct {
 		name        string
 		args        []string
 		fileContent string         // if non-empty, create temp file and substitute {{FILE}} token in args
 		wantOpts    *CreateOptions // nil when expecting error
 		expectedErr string
-	}
-
-	tests := []tc{
+	}{
 		{
 			name:        "no args nor file",
 			args:        []string{},


### PR DESCRIPTION
**Command enhancements:**

* Added support for the `-F`/`--from-file` flag to read the task description from a file, with mutually exclusive enforcement between inline argument and file input. Error handling for missing, unreadable, or empty files is included. (`pkg/cmd/agent-task/create/create.go`)
* Updated command usage and examples to reflect the new file input option. (`pkg/cmd/agent-task/create/create.go`)

**Also included backoff strategy update:**

* Increased the maximum elapsed time and interval for the exponential backoff strategy in `createRun` to improve likelihood of properly fetching job (`pkg/cmd/agent-task/create/create.go`)