### PR TITLE
`gh agent-task create`: support selecting base branch with `--base`/`-b`

### DIFF
--- a/pkg/cmd/agent-task/capi/client.go
+++ b/pkg/cmd/agent-task/capi/client.go
@@ -15,7 +15,7 @@ const capiHost = "api.githubcopilot.com"
 type CapiClient interface {
 	ListSessionsForViewer(ctx context.Context, limit int) ([]*Session, error)
 	ListSessionsForRepo(ctx context.Context, owner string, repo string, limit int) ([]*Session, error)
-	CreateJob(ctx context.Context, owner, repo, problemStatement string) (*Job, error)
+	CreateJob(ctx context.Context, owner, repo, problemStatement, baseBranch string) (*Job, error)
 	GetJob(ctx context.Context, owner, repo, jobID string) (*Job, error)
 }
 

--- a/pkg/cmd/agent-task/create/create.go
+++ b/pkg/cmd/agent-task/create/create.go
@@ -27,6 +27,7 @@ type CreateOptions struct {
 	Config           func() (gh.Config, error)
 	ProblemStatement string
 	BackOff          backoff.BackOff
+	BaseBranch       string
 }
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
@@ -84,6 +85,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	}
 
 	cmd.Flags().StringVarP(&fromFileName, "from-file", "F", "", "Read task description from file")
+	cmd.Flags().StringVarP(&opts.BaseBranch, "base", "b", "", "Base branch for the task")
 
 	opts.CapiClient = func() (capi.CapiClient, error) {
 		cfg, err := f.Config()
@@ -124,7 +126,7 @@ func createRun(opts *CreateOptions) error {
 	opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Creating agent task in %s/%s...", repo.RepoOwner(), repo.RepoName()))
 	defer opts.IO.StopProgressIndicator()
 
-	job, err := client.CreateJob(ctx, repo.RepoOwner(), repo.RepoName(), opts.ProblemStatement)
+	job, err := client.CreateJob(ctx, repo.RepoOwner(), repo.RepoName(), opts.ProblemStatement, opts.BaseBranch)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/agent-task/create/create_test.go
+++ b/pkg/cmd/agent-task/create/create_test.go
@@ -20,15 +20,13 @@ import (
 
 // Test basic option parsing & repository requirement
 func TestNewCmdCreate_Args(t *testing.T) {
-	type tc struct {
+	tests := []struct {
 		name        string
 		args        []string
 		fileContent string         // if non-empty, create temp file and substitute {{FILE}} token in args
 		wantOpts    *CreateOptions // nil when expecting error
 		expectedErr string
-	}
-
-	tests := []tc{
+	}{
 		{
 			name:        "no args nor file",
 			args:        []string{},


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked onto #11657  

### Base branch support for agent tasks

* Updated the `CreateJob` method in `CapiClient` and its implementation to accept a new `baseBranch` argument, and include it as `base_ref` in the pull request payload if provided (`pkg/cmd/agent-task/capi/client.go`, `pkg/cmd/agent-task/capi/job.go`). [[1]](diffhunk://#diff-07222d1d6949783f6aa013290a50e5e167365e5d104e34a74d16613b230e5b1cL18-R18) [[2]](diffhunk://#diff-954e86fc7cc5684cae57314a19878d304590510416c4b0c601caf2e64168ebf1L56-R57) [[3]](diffhunk://#diff-954e86fc7cc5684cae57314a19878d304590510416c4b0c601caf2e64168ebf1R67-R77) [[4]](diffhunk://#diff-954e86fc7cc5684cae57314a19878d304590510416c4b0c601caf2e64168ebf1R43)
* Added a `BaseBranch` field to the `CreateOptions` struct and exposed a new `--base`/`-b` CLI flag for users to specify the base branch when creating a task (`pkg/cmd/agent-task/create/create.go`). [[1]](diffhunk://#diff-a55d61688be3e1d4dd64f4e338bfd1d87b3ec77045a9abf67af94887fd7e4dd9R30) [[2]](diffhunk://#diff-a55d61688be3e1d4dd64f4e338bfd1d87b3ec77045a9abf67af94887fd7e4dd9R88)
* Updated the call to `CreateJob` in the create command to pass the `BaseBranch` value (`pkg/cmd/agent-task/create/create.go`).

### Test coverage for base branch functionality

* Added a new test case to verify that the base branch is correctly included in the create job payload when specified, and updated option parsing in tests to handle the new field (`pkg/cmd/agent-task/create/create_test.go`). [[1]](diffhunk://#diff-eef5e92fba7aed7ed350901fc81dcf25ea5e32c77f9f9db1b4f38b724fdd597bR152-R180) [[2]](diffhunk://#diff-eef5e92fba7aed7ed350901fc81dcf25ea5e32c77f9f9db1b4f38b724fdd597bR278) [[3]](diffhunk://#diff-eef5e92fba7aed7ed350901fc81dcf25ea5e32c77f9f9db1b4f38b724fdd597bL23-R29)