### PR TITLE
feat: Use Bearer scheme for auth token headers

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -100,7 +100,7 @@ func AddAuthTokenHeader(rt http.RoundTripper, cfg tokenGetter) http.RoundTripper
 			if !redirectHostnameChange {
 				hostname := ghauth.NormalizeHostname(getHost(req))
 				if token, _ := cfg.ActiveToken(hostname); token != "" {
-					req.Header.Set(authorization, fmt.Sprintf("token %s", token))
+					req.Header.Set(authorization, fmt.Sprintf("Bearer %s", token))
 				}
 			}
 		}

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -38,7 +38,7 @@ func TestNewHTTPClient(t *testing.T) {
 			},
 			host: "github.com",
 			wantHeader: map[string]string{
-				"authorization": "token MYTOKEN",
+				"authorization": "Bearer MYTOKEN",
 				"user-agent":    "GitHub CLI v1.2.3",
 				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
 			},
@@ -52,7 +52,7 @@ func TestNewHTTPClient(t *testing.T) {
 			},
 			host: "example.com",
 			wantHeader: map[string]string{
-				"authorization": "token GHETOKEN",
+				"authorization": "Bearer GHETOKEN",
 				"user-agent":    "GitHub CLI v1.2.3",
 				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
 			},
@@ -97,7 +97,7 @@ func TestNewHTTPClient(t *testing.T) {
 			},
 			host: "github.com",
 			wantHeader: map[string]string{
-				"authorization": "token MYTOKEN",
+				"authorization": "Bearer MYTOKEN",
 				"user-agent":    "GitHub CLI v1.2.3",
 				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
 			},
@@ -107,7 +107,7 @@ func TestNewHTTPClient(t *testing.T) {
 				> GET / HTTP/1.1
 				> Host: github.com
 				> Accept: application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview
-				> Authorization: token ████████████████████
+				> Authorization: Bearer ████████████████████
 				> Content-Type: application/json; charset=utf-8
 				> Time-Zone: <timezone>
 				> User-Agent: GitHub CLI v1.2.3
@@ -186,7 +186,7 @@ func TestHTTPClientRedirectAuthenticationHeaderHandling(t *testing.T) {
 	res, err := client.Do(req)
 	require.NoError(t, err)
 
-	assert.Equal(t, "token REDIRECT-TOKEN", redirectRequest.Header.Get(authorization))
+	assert.Equal(t, "Bearer REDIRECT-TOKEN", redirectRequest.Header.Get(authorization))
 	assert.Equal(t, "", request.Header.Get(authorization))
 	assert.Equal(t, 204, res.StatusCode)
 }

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -262,7 +262,7 @@ func GetCurrentLogin(httpClient httpClient, hostname, authToken string) (string,
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Authorization", "token "+authToken)
+	req.Header.Set("Authorization", "Bearer "+authToken)
 	res, err := httpClient.Do(req)
 	if err != nil {
 		return "", err

--- a/pkg/cmd/auth/shared/oauth_scopes.go
+++ b/pkg/cmd/auth/shared/oauth_scopes.go
@@ -40,7 +40,7 @@ func GetScopes(httpClient httpClient, hostname, authToken string) (string, error
 		return "", err
 	}
 
-	req.Header.Set("Authorization", "token "+authToken)
+	req.Header.Set("Authorization", "Bearer "+authToken)
 
 	res, err := httpClient.Do(req)
 	if err != nil {

--- a/pkg/cmd/auth/shared/oauth_scopes_test.go
+++ b/pkg/cmd/auth/shared/oauth_scopes_test.go
@@ -52,7 +52,7 @@ func Test_HasMinimumScopes(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, gotAuthorization, "token ATOKEN")
+			assert.Equal(t, gotAuthorization, "Bearer ATOKEN")
 		})
 	}
 }


### PR DESCRIPTION
Updating Auth header token to use `Bearer` scheme instead of `token`

Ref:
https://beeceptor.com/docs/concepts/authorization-header/#examples