### PR TITLE
`gh agent-task view`: support PR number arg

### DIFF
--- a/pkg/cmd/agent-task/capi/client.go
+++ b/pkg/cmd/agent-task/capi/client.go
@@ -20,6 +20,7 @@ type CapiClient interface {
 	CreateJob(ctx context.Context, owner, repo, problemStatement, baseBranch string) (*Job, error)
 	GetJob(ctx context.Context, owner, repo, jobID string) (*Job, error)
 	GetSession(ctx context.Context, id string) (*Session, error)
+	ListSessionsByResourceID(ctx context.Context, resourceType string, resourceID int64, limit int) ([]*Session, error)
 }
 
 // CAPIClient is a client for interacting with the Copilot API

--- a/pkg/cmd/agent-task/capi/client.go
+++ b/pkg/cmd/agent-task/capi/client.go
@@ -21,6 +21,7 @@ type CapiClient interface {
 	GetJob(ctx context.Context, owner, repo, jobID string) (*Job, error)
 	GetSession(ctx context.Context, id string) (*Session, error)
 	ListSessionsByResourceID(ctx context.Context, resourceType string, resourceID int64, limit int) ([]*Session, error)
+	GetPullRequestDatabaseID(ctx context.Context, hostname string, owner string, repo string, number int) (int64, error)
 }
 
 // CAPIClient is a client for interacting with the Copilot API

--- a/pkg/cmd/agent-task/capi/client_mock.go
+++ b/pkg/cmd/agent-task/capi/client_mock.go
@@ -24,6 +24,9 @@ var _ CapiClient = &CapiClientMock{}
 //			GetJobFunc: func(ctx context.Context, owner string, repo string, jobID string) (*Job, error) {
 //				panic("mock out the GetJob method")
 //			},
+//			GetPullRequestDatabaseIDFunc: func(ctx context.Context, hostname string, owner string, repo string, number int) (int64, error) {
+//				panic("mock out the GetPullRequestDatabaseID method")
+//			},
 //			GetSessionFunc: func(ctx context.Context, id string) (*Session, error) {
 //				panic("mock out the GetSession method")
 //			},
@@ -48,6 +51,9 @@ type CapiClientMock struct {
 
 	// GetJobFunc mocks the GetJob method.
 	GetJobFunc func(ctx context.Context, owner string, repo string, jobID string) (*Job, error)
+
+	// GetPullRequestDatabaseIDFunc mocks the GetPullRequestDatabaseID method.
+	GetPullRequestDatabaseIDFunc func(ctx context.Context, hostname string, owner string, repo string, number int) (int64, error)
 
 	// GetSessionFunc mocks the GetSession method.
 	GetSessionFunc func(ctx context.Context, id string) (*Session, error)
@@ -86,6 +92,19 @@ type CapiClientMock struct {
 			Repo string
 			// JobID is the jobID argument value.
 			JobID string
+		}
+		// GetPullRequestDatabaseID holds details about calls to the GetPullRequestDatabaseID method.
+		GetPullRequestDatabaseID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Hostname is the hostname argument value.
+			Hostname string
+			// Owner is the owner argument value.
+			Owner string
+			// Repo is the repo argument value.
+			Repo string
+			// Number is the number argument value.
+			Number int
 		}
 		// GetSession holds details about calls to the GetSession method.
 		GetSession []struct {
@@ -126,6 +145,7 @@ type CapiClientMock struct {
 	}
 	lockCreateJob                sync.RWMutex
 	lockGetJob                   sync.RWMutex
+	lockGetPullRequestDatabaseID sync.RWMutex
 	lockGetSession               sync.RWMutex
 	lockListSessionsByResourceID sync.RWMutex
 	lockListSessionsForRepo      sync.RWMutex
@@ -221,6 +241,54 @@ func (mock *CapiClientMock) GetJobCalls() []struct {
 	mock.lockGetJob.RLock()
 	calls = mock.calls.GetJob
 	mock.lockGetJob.RUnlock()
+	return calls
+}
+
+// GetPullRequestDatabaseID calls GetPullRequestDatabaseIDFunc.
+func (mock *CapiClientMock) GetPullRequestDatabaseID(ctx context.Context, hostname string, owner string, repo string, number int) (int64, error) {
+	if mock.GetPullRequestDatabaseIDFunc == nil {
+		panic("CapiClientMock.GetPullRequestDatabaseIDFunc: method is nil but CapiClient.GetPullRequestDatabaseID was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		Hostname string
+		Owner    string
+		Repo     string
+		Number   int
+	}{
+		Ctx:      ctx,
+		Hostname: hostname,
+		Owner:    owner,
+		Repo:     repo,
+		Number:   number,
+	}
+	mock.lockGetPullRequestDatabaseID.Lock()
+	mock.calls.GetPullRequestDatabaseID = append(mock.calls.GetPullRequestDatabaseID, callInfo)
+	mock.lockGetPullRequestDatabaseID.Unlock()
+	return mock.GetPullRequestDatabaseIDFunc(ctx, hostname, owner, repo, number)
+}
+
+// GetPullRequestDatabaseIDCalls gets all the calls that were made to GetPullRequestDatabaseID.
+// Check the length with:
+//
+//	len(mockedCapiClient.GetPullRequestDatabaseIDCalls())
+func (mock *CapiClientMock) GetPullRequestDatabaseIDCalls() []struct {
+	Ctx      context.Context
+	Hostname string
+	Owner    string
+	Repo     string
+	Number   int
+} {
+	var calls []struct {
+		Ctx      context.Context
+		Hostname string
+		Owner    string
+		Repo     string
+		Number   int
+	}
+	mock.lockGetPullRequestDatabaseID.RLock()
+	calls = mock.calls.GetPullRequestDatabaseID
+	mock.lockGetPullRequestDatabaseID.RUnlock()
 	return calls
 }
 

--- a/pkg/cmd/agent-task/capi/client_mock.go
+++ b/pkg/cmd/agent-task/capi/client_mock.go
@@ -27,6 +27,9 @@ var _ CapiClient = &CapiClientMock{}
 //			GetSessionFunc: func(ctx context.Context, id string) (*Session, error) {
 //				panic("mock out the GetSession method")
 //			},
+//			ListSessionsByResourceIDFunc: func(ctx context.Context, resourceType string, resourceID int64, limit int) ([]*Session, error) {
+//				panic("mock out the ListSessionsByResourceID method")
+//			},
 //			ListSessionsForRepoFunc: func(ctx context.Context, owner string, repo string, limit int) ([]*Session, error) {
 //				panic("mock out the ListSessionsForRepo method")
 //			},
@@ -48,6 +51,9 @@ type CapiClientMock struct {
 
 	// GetSessionFunc mocks the GetSession method.
 	GetSessionFunc func(ctx context.Context, id string) (*Session, error)
+
+	// ListSessionsByResourceIDFunc mocks the ListSessionsByResourceID method.
+	ListSessionsByResourceIDFunc func(ctx context.Context, resourceType string, resourceID int64, limit int) ([]*Session, error)
 
 	// ListSessionsForRepoFunc mocks the ListSessionsForRepo method.
 	ListSessionsForRepoFunc func(ctx context.Context, owner string, repo string, limit int) ([]*Session, error)
@@ -88,6 +94,17 @@ type CapiClientMock struct {
 			// ID is the id argument value.
 			ID string
 		}
+		// ListSessionsByResourceID holds details about calls to the ListSessionsByResourceID method.
+		ListSessionsByResourceID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ResourceType is the resourceType argument value.
+			ResourceType string
+			// ResourceID is the resourceID argument value.
+			ResourceID int64
+			// Limit is the limit argument value.
+			Limit int
+		}
 		// ListSessionsForRepo holds details about calls to the ListSessionsForRepo method.
 		ListSessionsForRepo []struct {
 			// Ctx is the ctx argument value.
@@ -107,11 +124,12 @@ type CapiClientMock struct {
 			Limit int
 		}
 	}
-	lockCreateJob             sync.RWMutex
-	lockGetJob                sync.RWMutex
-	lockGetSession            sync.RWMutex
-	lockListSessionsForRepo   sync.RWMutex
-	lockListSessionsForViewer sync.RWMutex
+	lockCreateJob                sync.RWMutex
+	lockGetJob                   sync.RWMutex
+	lockGetSession               sync.RWMutex
+	lockListSessionsByResourceID sync.RWMutex
+	lockListSessionsForRepo      sync.RWMutex
+	lockListSessionsForViewer    sync.RWMutex
 }
 
 // CreateJob calls CreateJobFunc.
@@ -239,6 +257,50 @@ func (mock *CapiClientMock) GetSessionCalls() []struct {
 	mock.lockGetSession.RLock()
 	calls = mock.calls.GetSession
 	mock.lockGetSession.RUnlock()
+	return calls
+}
+
+// ListSessionsByResourceID calls ListSessionsByResourceIDFunc.
+func (mock *CapiClientMock) ListSessionsByResourceID(ctx context.Context, resourceType string, resourceID int64, limit int) ([]*Session, error) {
+	if mock.ListSessionsByResourceIDFunc == nil {
+		panic("CapiClientMock.ListSessionsByResourceIDFunc: method is nil but CapiClient.ListSessionsByResourceID was just called")
+	}
+	callInfo := struct {
+		Ctx          context.Context
+		ResourceType string
+		ResourceID   int64
+		Limit        int
+	}{
+		Ctx:          ctx,
+		ResourceType: resourceType,
+		ResourceID:   resourceID,
+		Limit:        limit,
+	}
+	mock.lockListSessionsByResourceID.Lock()
+	mock.calls.ListSessionsByResourceID = append(mock.calls.ListSessionsByResourceID, callInfo)
+	mock.lockListSessionsByResourceID.Unlock()
+	return mock.ListSessionsByResourceIDFunc(ctx, resourceType, resourceID, limit)
+}
+
+// ListSessionsByResourceIDCalls gets all the calls that were made to ListSessionsByResourceID.
+// Check the length with:
+//
+//	len(mockedCapiClient.ListSessionsByResourceIDCalls())
+func (mock *CapiClientMock) ListSessionsByResourceIDCalls() []struct {
+	Ctx          context.Context
+	ResourceType string
+	ResourceID   int64
+	Limit        int
+} {
+	var calls []struct {
+		Ctx          context.Context
+		ResourceType string
+		ResourceID   int64
+		Limit        int
+	}
+	mock.lockListSessionsByResourceID.RLock()
+	calls = mock.calls.ListSessionsByResourceID
+	mock.lockListSessionsByResourceID.RUnlock()
 	return calls
 }
 

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -309,9 +309,11 @@ func (c *CAPIClient) hydrateSessionPullRequestsAndUsers(sessions []session) ([]*
 	prNodeIds := make([]string, 0, len(sessions))
 	userNodeIds := make([]string, 0, len(sessions))
 	for _, session := range sessions {
-		prNodeID := generatePullRequestNodeID(int64(session.RepoID), session.ResourceID)
-		if !slices.Contains(prNodeIds, prNodeID) {
-			prNodeIds = append(prNodeIds, prNodeID)
+		if session.ResourceType == "pull" {
+			prNodeID := generatePullRequestNodeID(int64(session.RepoID), session.ResourceID)
+			if !slices.Contains(prNodeIds, prNodeID) {
+				prNodeIds = append(prNodeIds, prNodeID)
+			}
 		}
 
 		userNodeId := generateUserNodeID(session.UserID)

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -132,7 +132,6 @@ func (c *CAPIClient) ListSessionsForViewer(ctx context.Context, limit int) ([]*S
 		sessions = sessions[:limit]
 	}
 
-	// Hydrate the result with pull request data.
 	result, err := c.hydrateSessionPullRequestsAndUsers(sessions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch session resources: %w", err)
@@ -193,7 +192,6 @@ func (c *CAPIClient) ListSessionsForRepo(ctx context.Context, owner string, repo
 		sessions = sessions[:limit]
 	}
 
-	// Hydrate the result with pull request data.
 	result, err := c.hydrateSessionPullRequestsAndUsers(sessions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch session resources: %w", err)
@@ -292,7 +290,6 @@ func (c *CAPIClient) ListSessionsByResourceID(ctx context.Context, resourceType 
 		sessions = sessions[:limit]
 	}
 
-	// Hydrate the result with pull request data.
 	result, err := c.hydrateSessionPullRequestsAndUsers(sessions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch session resources: %w", err)

--- a/pkg/cmd/agent-task/capi/sessions_test.go
+++ b/pkg/cmd/agent-task/capi/sessions_test.go
@@ -1039,7 +1039,7 @@ func TestListSessionsByResourceIDRequiresResource(t *testing.T) {
 	assert.EqualError(t, err, "missing resource type/ID")
 	_, err = client.ListSessionsByResourceID(context.Background(), "only-resource-type", 0, 0)
 	assert.EqualError(t, err, "missing resource type/ID")
-	_, err = client.ListSessionsByResourceID(context.Background(), "", 999, 0)
+	_, err = client.ListSessionsByResourceID(context.Background(), "", 0, 0)
 	assert.EqualError(t, err, "missing resource type/ID")
 }
 

--- a/pkg/cmd/agent-task/capi/sessions_test.go
+++ b/pkg/cmd/agent-task/capi/sessions_test.go
@@ -876,6 +876,445 @@ func TestListSessionsForRepo(t *testing.T) {
 	}
 }
 
+func TestListSessionsByResourceIDRequiresResource(t *testing.T) {
+	client := &CAPIClient{}
+
+	_, err := client.ListSessionsByResourceID(context.Background(), "", 999, 0)
+	assert.EqualError(t, err, "missing resource type/ID")
+	_, err = client.ListSessionsByResourceID(context.Background(), "only-resource-type", 0, 0)
+	assert.EqualError(t, err, "missing resource type/ID")
+	_, err = client.ListSessionsByResourceID(context.Background(), "", 999, 0)
+	assert.EqualError(t, err, "missing resource type/ID")
+}
+
+func TestListSessionsByResourceID(t *testing.T) {
+	sampleDateString := "2025-08-29T00:00:00Z"
+	sampleDate, err := time.Parse(time.RFC3339, sampleDateString)
+	require.NoError(t, err)
+
+	resourceID := int64(999)
+	resourceType := "pull"
+
+	tests := []struct {
+		name      string
+		perPage   int
+		limit     int
+		httpStubs func(*testing.T, *httpmock.Registry)
+		wantErr   string
+		wantOut   []*Session
+	}{
+		{
+			name:    "zero limit",
+			limit:   0,
+			wantOut: nil,
+		},
+		{
+			name:  "no sessions",
+			limit: 10,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.WithHost(
+						httpmock.QueryMatcher("GET", "agents/sessions/resource/pull/999", url.Values{
+							"page_number": {"1"},
+							"page_size":   {"50"},
+						}),
+						"api.githubcopilot.com",
+					),
+					httpmock.StringResponse(`{"sessions":[]}`),
+				)
+			},
+			wantOut: nil,
+		},
+		{
+			name:  "single session",
+			limit: 10,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.WithHost(
+						httpmock.QueryMatcher("GET", "agents/sessions/resource/pull/999", url.Values{
+							"page_number": {"1"},
+							"page_size":   {"50"},
+						}),
+						"api.githubcopilot.com",
+					),
+					httpmock.StringResponse(heredoc.Docf(`
+						{
+							"sessions": [
+								{
+									"id": "sess1",
+									"name": "Build artifacts",
+									"user_id": 1,
+									"agent_id": 2,
+									"logs": "",
+									"state": "completed",
+									"owner_id": 10,
+									"repo_id": 1000,
+									"resource_type": "pull",
+									"resource_id": 2000,
+									"created_at": "%[1]s"
+								}
+							]
+						}`,
+						sampleDateString,
+					)),
+				)
+				// GraphQL hydration
+				reg.Register(
+					httpmock.GraphQL(`query FetchPRsAndUsersForAgentTaskSessions\b`),
+					httpmock.GraphQLQuery(heredoc.Docf(`
+						{
+							"data": {
+								"nodes": [
+									{
+										"__typename": "PullRequest",
+										"id": "PR_node",
+										"fullDatabaseId": "2000",
+										"number": 42,
+										"title": "Improve docs",
+										"state": "OPEN",
+										"isDraft": true,
+										"url": "https://github.com/OWNER/REPO/pull/42",
+										"body": "",
+										"createdAt": "%[1]s",
+										"updatedAt": "%[1]s",
+										"repository": {
+											"nameWithOwner": "OWNER/REPO"
+										}
+									},
+									{
+										"__typename": "User",
+										"login": "octocat",
+										"name": "Octocat",
+										"databaseId": 1
+									}
+								]
+							}
+						}`,
+						sampleDateString,
+					), func(q string, vars map[string]interface{}) {
+						assert.Equal(t, []interface{}{"PR_kwDNA-jNB9A", "U_kgAB"}, vars["ids"])
+					}),
+				)
+			},
+			wantOut: []*Session{
+				{
+
+					ID:           "sess1",
+					Name:         "Build artifacts",
+					UserID:       1,
+					AgentID:      2,
+					Logs:         "",
+					State:        "completed",
+					OwnerID:      10,
+					RepoID:       1000,
+					ResourceType: "pull",
+					ResourceID:   2000,
+					CreatedAt:    sampleDate,
+					PullRequest: &api.PullRequest{
+						ID:             "PR_node",
+						FullDatabaseID: "2000",
+						Number:         42,
+						Title:          "Improve docs",
+						State:          "OPEN",
+						IsDraft:        true,
+						URL:            "https://github.com/OWNER/REPO/pull/42",
+						Body:           "",
+						CreatedAt:      sampleDate,
+						UpdatedAt:      sampleDate,
+						Repository: &api.PRRepository{
+							NameWithOwner: "OWNER/REPO",
+						},
+					},
+					User: &api.GitHubUser{
+						Login:      "octocat",
+						Name:       "Octocat",
+						DatabaseID: 1,
+					},
+				},
+			},
+		},
+		{
+			name:    "multiple sessions, paginated",
+			perPage: 1, // to enforce pagination
+			limit:   2,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.WithHost(
+						httpmock.QueryMatcher("GET", "agents/sessions/resource/pull/999", url.Values{
+							"page_number": {"1"},
+							"page_size":   {"1"},
+						}),
+						"api.githubcopilot.com",
+					),
+					httpmock.StringResponse(heredoc.Docf(`
+						{
+							"sessions": [
+								{
+									"id": "sess1",
+									"name": "Build artifacts",
+									"user_id": 1,
+									"agent_id": 2,
+									"logs": "",
+									"state": "completed",
+									"owner_id": 10,
+									"repo_id": 1000,
+									"resource_type": "pull",
+									"resource_id": 2000,
+									"created_at": "%[1]s"
+								}
+							]
+						}`,
+						sampleDateString,
+					)),
+				)
+
+				// Second page
+				reg.Register(
+					httpmock.WithHost(
+						httpmock.QueryMatcher("GET", "agents/sessions/resource/pull/999", url.Values{
+							"page_number": {"2"},
+							"page_size":   {"1"},
+						}),
+						"api.githubcopilot.com",
+					),
+					httpmock.StringResponse(heredoc.Docf(`
+						{
+							"sessions": [
+								{
+									"id": "sess2",
+									"name": "Build artifacts",
+									"user_id": 1,
+									"agent_id": 2,
+									"logs": "",
+									"state": "completed",
+									"owner_id": 10,
+									"repo_id": 1000,
+									"resource_type": "pull",
+									"resource_id": 2001,
+									"created_at": "%[1]s"
+								}
+							]
+						}`,
+						sampleDateString,
+					)),
+				)
+				// GraphQL hydration
+				reg.Register(
+					httpmock.GraphQL(`query FetchPRsAndUsersForAgentTaskSessions\b`),
+					httpmock.GraphQLQuery(heredoc.Docf(`
+						{
+							"data": {
+								"nodes": [
+									{
+										"__typename": "PullRequest",
+										"id": "PR_node",
+										"fullDatabaseId": "2000",
+										"number": 42,
+										"title": "Improve docs",
+										"state": "OPEN",
+										"isDraft": true,
+										"url": "https://github.com/OWNER/REPO/pull/42",
+										"body": "",
+										"createdAt": "%[1]s",
+										"updatedAt": "%[1]s",
+										"repository": {
+											"nameWithOwner": "OWNER/REPO"
+										}
+									},
+									{
+										"__typename": "PullRequest",
+										"id": "PR_node",
+										"fullDatabaseId": "2001",
+										"number": 43,
+										"title": "Improve docs",
+										"state": "OPEN",
+										"isDraft": true,
+										"url": "https://github.com/OWNER/REPO/pull/43",
+										"body": "",
+										"createdAt": "%[1]s",
+										"updatedAt": "%[1]s",
+										"repository": {
+											"nameWithOwner": "OWNER/REPO"
+										}
+									},
+									{
+										"__typename": "User",
+										"login": "octocat",
+										"name": "Octocat",
+										"databaseId": 1
+									}
+								]
+							}
+						}`,
+						sampleDateString,
+					), func(q string, vars map[string]interface{}) {
+						assert.Equal(t, []interface{}{"PR_kwDNA-jNB9A", "PR_kwDNA-jNB9E", "U_kgAB"}, vars["ids"])
+					}),
+				)
+			},
+			wantOut: []*Session{
+				{
+					ID:           "sess1",
+					Name:         "Build artifacts",
+					UserID:       1,
+					AgentID:      2,
+					Logs:         "",
+					State:        "completed",
+					OwnerID:      10,
+					RepoID:       1000,
+					ResourceType: "pull",
+					ResourceID:   2000,
+					CreatedAt:    sampleDate,
+					PullRequest: &api.PullRequest{
+						ID:             "PR_node",
+						FullDatabaseID: "2000",
+						Number:         42,
+						Title:          "Improve docs",
+						State:          "OPEN",
+						IsDraft:        true,
+						URL:            "https://github.com/OWNER/REPO/pull/42",
+						Body:           "",
+						CreatedAt:      sampleDate,
+						UpdatedAt:      sampleDate,
+						Repository: &api.PRRepository{
+							NameWithOwner: "OWNER/REPO",
+						},
+					},
+					User: &api.GitHubUser{
+						Login:      "octocat",
+						Name:       "Octocat",
+						DatabaseID: 1,
+					},
+				},
+				{
+					ID:           "sess2",
+					Name:         "Build artifacts",
+					UserID:       1,
+					AgentID:      2,
+					Logs:         "",
+					State:        "completed",
+					OwnerID:      10,
+					RepoID:       1000,
+					ResourceType: "pull",
+					ResourceID:   2001,
+					CreatedAt:    sampleDate,
+					PullRequest: &api.PullRequest{
+						ID:             "PR_node",
+						FullDatabaseID: "2001",
+						Number:         43,
+						Title:          "Improve docs",
+						State:          "OPEN",
+						IsDraft:        true,
+						URL:            "https://github.com/OWNER/REPO/pull/43",
+						Body:           "",
+						CreatedAt:      sampleDate,
+						UpdatedAt:      sampleDate,
+						Repository: &api.PRRepository{
+							NameWithOwner: "OWNER/REPO",
+						},
+					},
+					User: &api.GitHubUser{
+						Login:      "octocat",
+						Name:       "Octocat",
+						DatabaseID: 1,
+					},
+				},
+			},
+		},
+		{
+			name:  "API error",
+			limit: 10,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.WithHost(
+						httpmock.QueryMatcher("GET", "agents/sessions/resource/pull/999", url.Values{
+							"page_number": {"1"},
+							"page_size":   {"50"},
+						}),
+						"api.githubcopilot.com",
+					),
+					httpmock.StatusStringResponse(500, "{}"),
+				)
+			},
+			wantErr: "failed to list sessions:",
+		}, {
+			name:  "API error at hydration",
+			limit: 10,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.WithHost(
+						httpmock.QueryMatcher("GET", "agents/sessions/resource/pull/999", url.Values{
+							"page_number": {"1"},
+							"page_size":   {"50"},
+						}),
+						"api.githubcopilot.com",
+					),
+					httpmock.StringResponse(heredoc.Docf(`
+						{
+							"sessions": [
+								{
+									"id": "sess1",
+									"name": "Build artifacts",
+									"user_id": 1,
+									"agent_id": 2,
+									"logs": "",
+									"state": "completed",
+									"owner_id": 10,
+									"repo_id": 1000,
+									"resource_type": "pull",
+									"resource_id": 2000,
+									"created_at": "%[1]s"
+								}
+							]
+						}`,
+						sampleDateString,
+					)),
+				)
+				// GraphQL hydration
+				reg.Register(
+					httpmock.GraphQL(`query FetchPRsAndUsersForAgentTaskSessions\b`),
+					httpmock.StatusStringResponse(500, `{}`),
+				)
+			},
+			wantErr: `failed to fetch session resources: non-200 OK status code:`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, reg)
+			}
+			defer reg.Verify(t)
+
+			httpClient := &http.Client{Transport: reg}
+
+			cfg := config.NewBlankConfig()
+			capiClient := NewCAPIClient(httpClient, cfg.Authentication())
+
+			if tt.perPage != 0 {
+				last := defaultSessionsPerPage
+				defaultSessionsPerPage = tt.perPage
+				defer func() {
+					defaultSessionsPerPage = last
+				}()
+			}
+
+			sessions, err := capiClient.ListSessionsByResourceID(context.Background(), resourceType, resourceID, tt.limit)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Nil(t, sessions)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantOut, sessions)
+		})
+	}
+}
+
 func TestGetSessionRequiresID(t *testing.T) {
 	client := &CAPIClient{}
 

--- a/pkg/cmd/agent-task/shared/capi.go
+++ b/pkg/cmd/agent-task/shared/capi.go
@@ -1,9 +1,13 @@
 package shared
 
 import (
+	"regexp"
+
 	"github.com/cli/cli/v2/pkg/cmd/agent-task/capi"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 )
+
+var uuidRE = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
 
 func CapiClientFunc(f *cmdutil.Factory) func() (capi.CapiClient, error) {
 	return func() (capi.CapiClient, error) {
@@ -20,4 +24,8 @@ func CapiClientFunc(f *cmdutil.Factory) func() (capi.CapiClient, error) {
 		authCfg := cfg.Authentication()
 		return capi.NewCAPIClient(httpClient, authCfg), nil
 	}
+}
+
+func IsSessionID(s string) bool {
+	return uuidRE.MatchString(s)
 }

--- a/pkg/cmd/agent-task/shared/capi_test.go
+++ b/pkg/cmd/agent-task/shared/capi_test.go
@@ -1,0 +1,20 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSession(t *testing.T) {
+	assert.True(t, IsSessionID("00000000-0000-0000-0000-000000000000"))
+	assert.True(t, IsSessionID("e2fa49d2-f164-4a56-ab99-498090b8fcdf"))
+	assert.True(t, IsSessionID("E2FA49D2-F164-4A56-AB99-498090B8FCDF"))
+
+	assert.False(t, IsSessionID(""))
+	assert.False(t, IsSessionID(" "))
+	assert.False(t, IsSessionID("\n"))
+	assert.False(t, IsSessionID("not-a-uuid"))
+	assert.False(t, IsSessionID("000000000000000000000000000000000000"))
+	assert.False(t, IsSessionID("00000000-0000-0000-0000-000000000000-extra"))
+}

--- a/pkg/cmd/agent-task/shared/display.go
+++ b/pkg/cmd/agent-task/shared/display.go
@@ -24,6 +24,7 @@ func ColorFuncForSessionState(s capi.Session, cs *iostreams.ColorScheme) func(st
 	return stateColor
 }
 
+// SessionStateString returns the humane/capitalised form of the given session state.
 func SessionStateString(state string) string {
 	switch state {
 	case "queued":

--- a/pkg/cmd/agent-task/shared/display.go
+++ b/pkg/cmd/agent-task/shared/display.go
@@ -46,3 +46,17 @@ func SessionStateString(state string) string {
 		return state
 	}
 }
+
+type ColorFunc func(string) string
+
+func SessionSymbol(cs *iostreams.ColorScheme, state string) string {
+	noColor := func(s string) string { return s }
+	switch state {
+	case "completed":
+		return cs.SuccessIconWithColor(noColor)
+	case "failed", "timed_out", "cancelled":
+		return cs.FailureIconWithColor(noColor)
+	default:
+		return "-"
+	}
+}

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -206,7 +206,7 @@ func viewRun(opts *ViewOptions) error {
 			cs.ColorFromString(prShared.ColorForPRState(*session.PullRequest))(fmt.Sprintf("#%d", session.PullRequest.Number)),
 		)
 	} else {
-		// Should never happen, but we need to cover the path
+		// This can happen when the session is just created and a PR is not yet available for it
 		fmt.Fprintf(out, "%s\n", shared.ColorFuncForSessionState(*session, cs)(shared.SessionStateString(session.State)))
 	}
 

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultLimit = 60
+const defaultLimit = 40
 
 type ViewOptions struct {
 	IO         *iostreams.IOStreams

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmd/agent-task/capi"
+	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/google/shlex"
@@ -99,6 +101,13 @@ func TestNewCmdList(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantOpts.SelectorArg, gotOpts.SelectorArg)
+			assert.Equal(t, tt.wantOpts.SessionID, gotOpts.SessionID)
+
+			if tt.wantBaseRepo != nil {
+				baseRepo, err := gotOpts.BaseRepo()
+				require.NoError(t, err)
+				assert.True(t, ghrepo.IsSame(tt.wantBaseRepo, baseRepo))
+			}
 		})
 	}
 }
@@ -108,19 +117,23 @@ func Test_viewRun(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		selectorArg string
 		tty         bool
+		opts        ViewOptions
+		promptStubs func(*testing.T, *prompter.MockPrompter)
 		capiStubs   func(*testing.T, *capi.CapiClientMock)
 		wantOut     string
 		wantErr     error
 		wantStderr  string
 	}{
 		{
-			name:        "not found (tty)",
-			tty:         true,
-			selectorArg: "some-session-id",
+			name: "with session id, not found (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "some-session-id",
+				SessionID:   "some-session-id",
+			},
 			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
-				m.GetSessionFunc = func(ctx context.Context, selector string) (*capi.Session, error) {
+				m.GetSessionFunc = func(_ context.Context, _ string) (*capi.Session, error) {
 					return nil, capi.ErrSessionNotFound
 				}
 			},
@@ -128,43 +141,29 @@ func Test_viewRun(t *testing.T) {
 			wantErr:    cmdutil.SilentError,
 		},
 		{
-			name:        "not found (nontty)",
-			selectorArg: "some-session-id",
-			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
-				m.GetSessionFunc = func(ctx context.Context, selector string) (*capi.Session, error) {
-					return nil, capi.ErrSessionNotFound
-				}
+			name: "with session id, api error (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "some-session-id",
+				SessionID:   "some-session-id",
 			},
-			wantStderr: "session not found\n",
-			wantErr:    cmdutil.SilentError,
-		},
-		{
-			name:        "API error (tty)",
-			tty:         true,
-			selectorArg: "some-session-id",
 			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
-				m.GetSessionFunc = func(ctx context.Context, selector string) (*capi.Session, error) {
+				m.GetSessionFunc = func(_ context.Context, _ string) (*capi.Session, error) {
 					return nil, errors.New("some error")
 				}
 			},
 			wantErr: errors.New("some error"),
 		},
 		{
-			name:        "API error (nontty)",
-			selectorArg: "some-session-id",
-			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
-				m.GetSessionFunc = func(ctx context.Context, selector string) (*capi.Session, error) {
-					return nil, errors.New("some error")
-				}
+			name: "with session id, success, with pr and user data (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "some-session-id",
+				SessionID:   "some-session-id",
 			},
-			wantErr: errors.New("some error"),
-		},
-		{
-			name:        "success, with PR and user data (tty)",
-			tty:         true,
-			selectorArg: "some-session-id",
 			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
-				m.GetSessionFunc = func(ctx context.Context, selector string) (*capi.Session, error) {
+				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
+					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
 						ID:        "some-session-id",
 						State:     "completed",
@@ -186,17 +185,21 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Completed • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
-				
+
 				View this session on GitHub:
 				https://github.com/OWNER/REPO/pull/101/agent-sessions/some-session-id
 			`),
 		},
 		{
-			name:        "success, without user data (tty)",
-			tty:         true,
-			selectorArg: "some-session-id",
+			name: "with session id, success, without user data (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "some-session-id",
+				SessionID:   "some-session-id",
+			},
 			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
-				m.GetSessionFunc = func(ctx context.Context, selector string) (*capi.Session, error) {
+				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
+					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
 						ID:        "some-session-id",
 						State:     "completed",
@@ -215,17 +218,21 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Completed • fix something • OWNER/REPO#101
 				Started about 6 hours ago
-				
+
 				View this session on GitHub:
 				https://github.com/OWNER/REPO/pull/101/agent-sessions/some-session-id
 			`),
 		},
 		{
-			name:        "success, without PR data (tty)",
-			tty:         true,
-			selectorArg: "some-session-id",
+			name: "with session id, success, without pr data (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "some-session-id",
+				SessionID:   "some-session-id",
+			},
 			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
-				m.GetSessionFunc = func(ctx context.Context, selector string) (*capi.Session, error) {
+				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
+					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
 						ID:        "some-session-id",
 						State:     "completed",
@@ -242,11 +249,15 @@ func Test_viewRun(t *testing.T) {
 			`),
 		},
 		{
-			name:        "success, without PR nor user data (tty)",
-			tty:         true,
-			selectorArg: "some-session-id",
+			name: "with session id, success, without pr nor user data (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "some-session-id",
+				SessionID:   "some-session-id",
+			},
 			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
-				m.GetSessionFunc = func(ctx context.Context, selector string) (*capi.Session, error) {
+				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
+					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
 						ID:        "some-session-id",
 						State:     "completed",
@@ -257,6 +268,267 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Completed
 				Started about 6 hours ago
+			`),
+		},
+		{
+			name: "with pr number, api error (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "pr-number",
+				Finder: prShared.NewMockFinder(
+					"pr-number",
+					&api.PullRequest{FullDatabaseID: "999999"},
+					ghrepo.New("OWNER", "REPO"),
+				),
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.ListSessionsByResourceIDFunc = func(_ context.Context, _ string, _ int64, _ int) ([]*capi.Session, error) {
+					return nil, errors.New("some error")
+				}
+			},
+			wantErr: errors.New("failed to list sessions for pull request: some error"),
+		},
+		{
+			name: "with pr reference, unsupported hostname (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "OWNER/REPO#999",
+				BaseRepo: func() (ghrepo.Interface, error) {
+					return ghrepo.NewWithHost("OWNER", "REPO", "foo.com"), nil
+				},
+			},
+			wantErr: errors.New("agent tasks are not supported on this host: foo.com"),
+		},
+		{
+			name: "with pr reference, api error when fetching pr database ID (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "OWNER/REPO#999",
+				BaseRepo: func() (ghrepo.Interface, error) {
+					return ghrepo.New("OWNER", "REPO"), nil
+				},
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.GetPullRequestDatabaseIDFunc = func(_ context.Context, _ string, _ string, _ string, _ int) (int64, error) {
+					return 0, errors.New("some error")
+				}
+			},
+			wantErr: errors.New("failed to fetch pull request: some error"),
+		},
+		{
+			name: "with pr reference, api error when fetching session (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "OWNER/REPO#999",
+				BaseRepo: func() (ghrepo.Interface, error) {
+					return ghrepo.New("OWNER", "REPO"), nil
+				},
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.GetPullRequestDatabaseIDFunc = func(_ context.Context, _ string, _ string, _ string, _ int) (int64, error) {
+					return 999999, nil
+				}
+				m.ListSessionsByResourceIDFunc = func(_ context.Context, _ string, _ int64, _ int) ([]*capi.Session, error) {
+					return nil, errors.New("some error")
+				}
+			},
+			wantErr: errors.New("failed to list sessions for pull request: some error"),
+		},
+		{
+			name: "with pr number, success, single session with pr and user data (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "pr-number",
+				Finder: prShared.NewMockFinder(
+					"pr-number",
+					&api.PullRequest{FullDatabaseID: "999999"},
+					ghrepo.New("OWNER", "REPO"),
+				),
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.ListSessionsByResourceIDFunc = func(_ context.Context, resourceType string, resourceID int64, limit int) ([]*capi.Session, error) {
+					assert.Equal(t, "pull", resourceType)
+					assert.Equal(t, int64(999999), resourceID)
+					assert.Equal(t, defaultLimit, limit)
+					return []*capi.Session{
+						{
+							ID:        "some-session-id",
+							State:     "completed",
+							CreatedAt: sampleDate,
+							PullRequest: &api.PullRequest{
+								Title:  "fix something",
+								Number: 101,
+								URL:    "https://github.com/OWNER/REPO/pull/101",
+								Repository: &api.PRRepository{
+									NameWithOwner: "OWNER/REPO",
+								},
+							},
+							User: &api.GitHubUser{
+								Login: "octocat",
+							},
+						},
+					}, nil
+				}
+			},
+			wantOut: heredoc.Doc(`
+				Completed • fix something • OWNER/REPO#101
+				Started on behalf of octocat about 6 hours ago
+
+				View this session on GitHub:
+				https://github.com/OWNER/REPO/pull/101/agent-sessions/some-session-id
+			`),
+		},
+		{
+			name: "with pr number, success, multiple sessions with pr and user data (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "pr-number",
+				Finder: prShared.NewMockFinder(
+					"pr-number",
+					&api.PullRequest{FullDatabaseID: "999999"},
+					ghrepo.New("OWNER", "REPO"),
+				),
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.ListSessionsByResourceIDFunc = func(_ context.Context, resourceType string, resourceID int64, limit int) ([]*capi.Session, error) {
+					assert.Equal(t, "pull", resourceType)
+					assert.Equal(t, int64(999999), resourceID)
+					assert.Equal(t, defaultLimit, limit)
+					return []*capi.Session{
+						{
+							ID:        "some-session-id",
+							Name:      "session one",
+							State:     "completed",
+							CreatedAt: sampleDate,
+							PullRequest: &api.PullRequest{
+								Title:  "fix something",
+								Number: 101,
+								URL:    "https://github.com/OWNER/REPO/pull/101",
+								Repository: &api.PRRepository{
+									NameWithOwner: "OWNER/REPO",
+								},
+							},
+							User: &api.GitHubUser{
+								Login: "octocat",
+							},
+						},
+						{
+							ID:        "some-other-session-id",
+							Name:      "session two",
+							State:     "completed",
+							CreatedAt: sampleDate,
+							PullRequest: &api.PullRequest{
+								Title:  "fix something else",
+								Number: 102,
+								URL:    "https://github.com/OWNER/REPO/pull/102",
+								Repository: &api.PRRepository{
+									NameWithOwner: "OWNER/REPO",
+								},
+							},
+							User: &api.GitHubUser{
+								Login: "octocat",
+							},
+						},
+					}, nil
+				}
+			},
+			promptStubs: func(t *testing.T, pm *prompter.MockPrompter) {
+				pm.RegisterSelect(
+					"Select a session",
+					[]string{
+						"✓ session one • about 6 hours ago",
+						"✓ session two • about 6 hours ago",
+					},
+					func(_, _ string, opts []string) (int, error) {
+						return prompter.IndexFor(opts, "✓ session one • about 6 hours ago")
+					},
+				)
+			},
+			wantOut: heredoc.Doc(`
+				Completed • fix something • OWNER/REPO#101
+				Started on behalf of octocat about 6 hours ago
+
+				View this session on GitHub:
+				https://github.com/OWNER/REPO/pull/101/agent-sessions/some-session-id
+			`),
+		},
+		{
+			name: "with pr reference, success, multiple sessions with pr and user data (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "OWNER/REPO#999",
+				BaseRepo: func() (ghrepo.Interface, error) {
+					return ghrepo.New("OWNER", "REPO"), nil
+				},
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.GetPullRequestDatabaseIDFunc = func(_ context.Context, hostname string, owner string, repo string, number int) (int64, error) {
+					assert.Equal(t, "github.com", hostname)
+					assert.Equal(t, "OWNER", owner)
+					assert.Equal(t, "REPO", repo)
+					assert.Equal(t, 999, number)
+					return 999999, nil
+				}
+				m.ListSessionsByResourceIDFunc = func(_ context.Context, resourceType string, resourceID int64, limit int) ([]*capi.Session, error) {
+					assert.Equal(t, "pull", resourceType)
+					assert.Equal(t, int64(999999), resourceID)
+					assert.Equal(t, defaultLimit, limit)
+					return []*capi.Session{
+						{
+							ID:        "some-session-id",
+							Name:      "session one",
+							State:     "completed",
+							CreatedAt: sampleDate,
+							PullRequest: &api.PullRequest{
+								Title:  "fix something",
+								Number: 101,
+								URL:    "https://github.com/OWNER/REPO/pull/101",
+								Repository: &api.PRRepository{
+									NameWithOwner: "OWNER/REPO",
+								},
+							},
+							User: &api.GitHubUser{
+								Login: "octocat",
+							},
+						},
+						{
+							ID:        "some-other-session-id",
+							Name:      "session two",
+							State:     "completed",
+							CreatedAt: sampleDate,
+							PullRequest: &api.PullRequest{
+								Title:  "fix something else",
+								Number: 102,
+								URL:    "https://github.com/OWNER/REPO/pull/102",
+								Repository: &api.PRRepository{
+									NameWithOwner: "OWNER/REPO",
+								},
+							},
+							User: &api.GitHubUser{
+								Login: "octocat",
+							},
+						},
+					}, nil
+				}
+			},
+			promptStubs: func(t *testing.T, pm *prompter.MockPrompter) {
+				pm.RegisterSelect(
+					"Select a session",
+					[]string{
+						"✓ session one • about 6 hours ago",
+						"✓ session two • about 6 hours ago",
+					},
+					func(_, _ string, opts []string) (int, error) {
+						return prompter.IndexFor(opts, "✓ session one • about 6 hours ago")
+					},
+				)
+			},
+			wantOut: heredoc.Doc(`
+				Completed • fix something • OWNER/REPO#101
+				Started on behalf of octocat about 6 hours ago
+
+				View this session on GitHub:
+				https://github.com/OWNER/REPO/pull/101/agent-sessions/some-session-id
 			`),
 		},
 	}
@@ -268,18 +540,22 @@ func Test_viewRun(t *testing.T) {
 				tt.capiStubs(t, capiClientMock)
 			}
 
+			prompter := prompter.NewMockPrompter(t)
+			if tt.promptStubs != nil {
+				tt.promptStubs(t, prompter)
+			}
+
 			ios, _, stdout, stderr := iostreams.Test()
 			ios.SetStdoutTTY(tt.tty)
 
-			opts := &ViewOptions{
-				IO: ios,
-				CapiClient: func() (capi.CapiClient, error) {
-					return capiClientMock, nil
-				},
-				SelectorArg: tt.selectorArg,
+			opts := tt.opts
+			opts.IO = ios
+			opts.Prompter = prompter
+			opts.CapiClient = func() (capi.CapiClient, error) {
+				return capiClientMock, nil
 			}
 
-			err := viewRun(opts)
+			err := viewRun(&opts)
 			if tt.wantErr != nil {
 				assert.Error(t, err)
 				require.EqualError(t, err, tt.wantErr.Error())

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -191,6 +191,7 @@ func Test_viewRun(t *testing.T) {
 			`),
 		},
 		{
+			// The user data should always be there, but we need to cover the code path.
 			name: "with session id, success, without user data (tty)",
 			tty:  true,
 			opts: ViewOptions{
@@ -224,6 +225,7 @@ func Test_viewRun(t *testing.T) {
 			`),
 		},
 		{
+			// This can happen when the session is just created and a PR is not yet available for it.
 			name: "with session id, success, without pr data (tty)",
 			tty:  true,
 			opts: ViewOptions{
@@ -249,6 +251,7 @@ func Test_viewRun(t *testing.T) {
 			`),
 		},
 		{
+			// The user data should always be there, but we need to cover the code path.
 			name: "with session id, success, without pr nor user data (tty)",
 			tty:  true,
 			opts: ViewOptions{

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -328,6 +328,31 @@ func ParseURL(prURL string) (ghrepo.Interface, int, error) {
 	return repo, prNumber, nil
 }
 
+var fullReferenceRE = regexp.MustCompile(`^(?:([^/]+)/([^/]+))#(\d+)$`)
+
+// ParseFullReference parses a short issue/pull request reference of the form
+// "owner/repo#number", where owner, repo and number are all required.
+func ParseFullReference(s string) (ghrepo.Interface, int, error) {
+	if s == "" {
+		return nil, 0, errors.New("empty reference")
+	}
+
+	m := fullReferenceRE.FindStringSubmatch(s)
+	if m == nil {
+		return nil, 0, fmt.Errorf("invalid reference: %q", s)
+	}
+
+	number, err := strconv.Atoi(m[3])
+	if err != nil {
+		return nil, 0, fmt.Errorf("invalid reference: %q", number)
+	}
+
+	owner := m[1]
+	repo := m[2]
+
+	return ghrepo.New(owner, repo), number, nil
+}
+
 func findByNumber(httpClient *http.Client, repo ghrepo.Interface, number int, fields []string) (*api.PullRequest, error) {
 	type response struct {
 		Repository struct {


### PR DESCRIPTION
This PR adds support for PR number/URL/reference as an argument to `agent-task view`.

## A/C verification (for PR arg support)

### Happy paths

> **Given** I have a PR with **one** session associated with it
> **When** I run `gh agent-task view 1234 --repo foo/bar`
> **Then** I see some metadata information about that session

Confirmed:
<img width="942" height="105" alt="gh-agent-task-view-pr-num" src="https://github.com/user-attachments/assets/6dd00ef1-9b91-49c7-9dc1-afe82d1e6555" />

> **Given** I have a PR with **more than one** session associated with it
> **When** I run `gh agent-task view 1234 --repo foo/bar`
> **Then** I am prompted for a session to view, and
> **When** I select a session in the list
> **Then** I see some metadata about that session

Confirmed:
<img width="942" height="95" alt="gh-agent-task-view-pr-select-session" src="https://github.com/user-attachments/assets/6e6f0c06-7a47-4040-968a-93df4831758b" />

<img width="948" height="119" alt="gh-agent-task-view-pr-select-session-selected" src="https://github.com/user-attachments/assets/15cbba84-7dad-4cb8-8759-42c4c0766395" />

### Additional PR formats

> **Given** I have a PR with **one** session associated with it
> **When** I run `gh agent-task view #1234 --repo foo/bar`
> **Then** I see some metadata information about that session

Confirmed:
<img width="966" height="102" alt="gh-agent-task-view-pr-hash-num" src="https://github.com/user-attachments/assets/82832098-c8b7-43df-aea9-cc2c13823a55" />

> **Given** I have a PR with **one** session associated with it
> **When** I run `gh agent-task view foo/bar#1234`
> **Then** I see some metadata information about that session

Confirmed:
<img width="878" height="102" alt="gh-agent-task-view-pr-reference" src="https://github.com/user-attachments/assets/ab3cfdee-7e4a-4882-8de9-3b81acf57a4c" />

> **Given** I have a PR with **one** session associated with it
> **When** I run `gh agent-task view https://github.com/foo/bar/pull/1234`
> **Then** I see some metadata information about that session

Confirmed:
<img width="1080" height="102" alt="gh-agent-task-view-pr-url" src="https://github.com/user-attachments/assets/d191bd56-f193-468b-a85d-43b1d57dc75b" />

### Prompting requires a TTY

> **Given** I am running without a TTY
> **When** I run `gh agent-task view 1234 --repo foo/bar`
> **Then**  I receive an error message indicating that only session IDs are supported in non-interactive mode

Confirmed:
<img width="1037" height="71" alt="gh-agent-task-view-pr-nontty" src="https://github.com/user-attachments/assets/16b39ad0-bcc3-44ef-80e3-adc9efb45ba4" />

### Zero value paths

> **Given** I have a PR with no sessions associated with it
> **When** I run `gh agent-task view #1234 --repo foo/bar`
> **Then** I see an error message about no sessions being found

Confirmed:
<img width="926" height="70" alt="gh-agent-task-view-pr-no-session" src="https://github.com/user-attachments/assets/ec6f098d-5511-4834-bf67-dbef7c69aa55" />


> **Given** I have no such PR
> **When** I run `gh agent-task view #1234 --repo foo/bar`
> **Then** I see an error message about no PR being found

Confirmed:
<img width="946" height="76" alt="gh-agent-task-view-pr-not-found" src="https://github.com/user-attachments/assets/ed71838f-c0a3-4353-b98d-9f7d8af16016" />


## A/C verification (for base repo detection)

> **Given** my CWD is a repository and
> **Given** I have **one** session for the PR
> **When** I run `gh agent-task view 1234`
> **Then** I see metadata for that session

Confirmed:
<img width="843" height="111" alt="gh-agent-view-base-repo-pr-num" src="https://github.com/user-attachments/assets/a1e9a75e-4849-4943-b17e-5e15a4feb2c5" />


> **Given** my CWD is a repository and
> **Given** I have **more than one** session for the PR
> **When** I run `gh agent-task view 1234`
> **Then** I am prompted for a session to select and
> **When** I select a session
> **Then** I see metadata for that session

Confirmed:
<img width="605" height="93" alt="gh-agent-view-base-repo-pr-select" src="https://github.com/user-attachments/assets/07c66193-64d5-4ffe-9871-1a910931954a" />
<img width="944" height="147" alt="gh-agent-view-base-repo-pr-selected" src="https://github.com/user-attachments/assets/ddcab38b-85ee-485d-a39d-a43546bf0c9d" />
