### PR TITLE
Add Bot typename to `reviewRequests` query

### DIFF
--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -99,6 +99,7 @@ var prReviewRequests = shortenQuery(`
 		nodes {
 			requestedReviewer {
 				__typename,
+				...on Bot{login},
 				...on User{login},
 				...on Team{
 					organization{login}


### PR DESCRIPTION
This PR fixes #11245

Seems to be a simple change where if a PR has only Copilot as a reviewer, it would get only the `__typename` from the query and not the `login` from that reviewer if it's a Bot.