### PR TITLE
`gh agent-task create`: prompt for task description using editor

### DIFF
--- a/pkg/cmd/agent-task/create/create.go
+++ b/pkg/cmd/agent-task/create/create.go
@@ -109,21 +109,21 @@ func createRun(opts *CreateOptions) error {
 		return fmt.Errorf("a repository is required; re-run in a repository or supply one with --repo owner/name")
 	}
 
-	// Prompt for ProblemStatement if not provided non-interactively
-	if opts.Prompter != nil && opts.IO.CanPrompt() {
+	if opts.ProblemStatement == "" {
+		if !opts.IO.CanPrompt() {
+			return cmdutil.FlagErrorf("a task description or -F is required when running non-interactively")
+		}
+
 		desc, err := opts.Prompter.MarkdownEditor("Enter the task description", opts.ProblemStatement, false)
 		if err != nil {
 			return err
 		}
+
 		trimmed := strings.TrimSpace(desc)
 		if trimmed == "" {
 			return cmdutil.FlagErrorf("a task description is required")
 		}
 		opts.ProblemStatement = trimmed
-	}
-
-	if opts.ProblemStatement == "" {
-		return cmdutil.FlagErrorf("a task description or -F is required when running non-interactively")
 	}
 
 	client, err := opts.CapiClient()

--- a/pkg/cmd/agent-task/create/create.go
+++ b/pkg/cmd/agent-task/create/create.go
@@ -37,6 +37,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	opts := &CreateOptions{
 		IO:         f.IOStreams,
 		CapiClient: shared.CapiClientFunc(f),
+		Config:     f.Config,
 		Prompter:   f.Prompter,
 	}
 
@@ -69,7 +70,6 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				opts.ProblemStatement = trimmed
 			}
 
-			opts.Config = f.Config
 			if runF != nil {
 				return runF(opts)
 			}

--- a/pkg/cmd/agent-task/create/create.go
+++ b/pkg/cmd/agent-task/create/create.go
@@ -110,11 +110,8 @@ func createRun(opts *CreateOptions) error {
 	}
 
 	// Prompt for ProblemStatement if not provided non-interactively
-	if opts.ProblemStatement == "" && opts.IO.CanPrompt() {
-		if opts.Prompter == nil {
-			return cmdutil.FlagErrorf("interactive prompting is not available")
-		}
-		desc, err := opts.Prompter.MarkdownEditor("Enter the task description", "", false)
+	if opts.Prompter != nil && opts.IO.CanPrompt() {
+		desc, err := opts.Prompter.MarkdownEditor("Enter the task description", opts.ProblemStatement, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This pull request enhances the `agent-task create` command by adding interactive prompting for the task description when it is not supplied via arguments or file. It also updates the related tests to cover these interactive scenarios.