### PR TITLE
`gh agent-task view`: Fix default value in session selection prompt

### DIFF
--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -185,7 +185,7 @@ func viewRun(opts *ViewOptions) error {
 			}
 
 			opts.IO.StopProgressIndicator()
-			selected, err := opts.Prompter.Select("Select a session", options[0], options)
+			selected, err := opts.Prompter.Select("Select a session", "", options)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Updated the call to `Prompter.Select` to use an empty string as the default value instead of `options[0]`, ensuring no session is preselected by default.

### Before change
<img width="586" height="158" alt="image" src="https://github.com/user-attachments/assets/9fc3b076-0a00-4dce-9bcd-de7d0cd45298" />

### After change
<img width="593" height="162" alt="image" src="https://github.com/user-attachments/assets/7e8aec3d-b8c4-4090-8482-de96752eec21" />
