### PR TITLE
`gh agent-task view`: add `--web` flag

### DIFF
--- a/pkg/cmd/agent-task/capi/client.go
+++ b/pkg/cmd/agent-task/capi/client.go
@@ -21,7 +21,7 @@ type CapiClient interface {
 	GetJob(ctx context.Context, owner, repo, jobID string) (*Job, error)
 	GetSession(ctx context.Context, id string) (*Session, error)
 	ListSessionsByResourceID(ctx context.Context, resourceType string, resourceID int64, limit int) ([]*Session, error)
-	GetPullRequestDatabaseID(ctx context.Context, hostname string, owner string, repo string, number int) (int64, error)
+	GetPullRequestDatabaseID(ctx context.Context, hostname string, owner string, repo string, number int) (int64, string, error)
 }
 
 // CAPIClient is a client for interacting with the Copilot API

--- a/pkg/cmd/agent-task/capi/client_mock.go
+++ b/pkg/cmd/agent-task/capi/client_mock.go
@@ -24,7 +24,7 @@ var _ CapiClient = &CapiClientMock{}
 //			GetJobFunc: func(ctx context.Context, owner string, repo string, jobID string) (*Job, error) {
 //				panic("mock out the GetJob method")
 //			},
-//			GetPullRequestDatabaseIDFunc: func(ctx context.Context, hostname string, owner string, repo string, number int) (int64, error) {
+//			GetPullRequestDatabaseIDFunc: func(ctx context.Context, hostname string, owner string, repo string, number int) (int64, string, error) {
 //				panic("mock out the GetPullRequestDatabaseID method")
 //			},
 //			GetSessionFunc: func(ctx context.Context, id string) (*Session, error) {
@@ -53,7 +53,7 @@ type CapiClientMock struct {
 	GetJobFunc func(ctx context.Context, owner string, repo string, jobID string) (*Job, error)
 
 	// GetPullRequestDatabaseIDFunc mocks the GetPullRequestDatabaseID method.
-	GetPullRequestDatabaseIDFunc func(ctx context.Context, hostname string, owner string, repo string, number int) (int64, error)
+	GetPullRequestDatabaseIDFunc func(ctx context.Context, hostname string, owner string, repo string, number int) (int64, string, error)
 
 	// GetSessionFunc mocks the GetSession method.
 	GetSessionFunc func(ctx context.Context, id string) (*Session, error)
@@ -245,7 +245,7 @@ func (mock *CapiClientMock) GetJobCalls() []struct {
 }
 
 // GetPullRequestDatabaseID calls GetPullRequestDatabaseIDFunc.
-func (mock *CapiClientMock) GetPullRequestDatabaseID(ctx context.Context, hostname string, owner string, repo string, number int) (int64, error) {
+func (mock *CapiClientMock) GetPullRequestDatabaseID(ctx context.Context, hostname string, owner string, repo string, number int) (int64, string, error) {
 	if mock.GetPullRequestDatabaseIDFunc == nil {
 		panic("CapiClientMock.GetPullRequestDatabaseIDFunc: method is nil but CapiClient.GetPullRequestDatabaseID was just called")
 	}

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -18,6 +18,8 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 )
 
+const AgentsHomeURL = "https://github.com/copilot/agents"
+
 var defaultSessionsPerPage = 50
 
 var ErrSessionNotFound = errors.New("not found")

--- a/pkg/cmd/agent-task/list/list.go
+++ b/pkg/cmd/agent-task/list/list.go
@@ -70,7 +70,7 @@ func listRun(opts *ListOptions) error {
 		// based on repo, so we just open the agents dashboard with no args.
 		// If that page is ever added in the future, we should route to that
 		// page instead of the global one when --repo is set.
-		const webURL = "https://github.com/copilot/agents"
+		webURL := capi.AgentsHomeURL
 		if opts.IO.IsStdoutTTY() {
 			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", text.DisplayURL(webURL))
 		}

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -51,9 +51,25 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 
 	cmd := &cobra.Command{
 		Use:   "view [<session-id> | <pr-number> | <pr-url> | <pr-branch>]",
-		Short: "View an agent task session",
+		Short: "View an agent task session (preview)",
 		Long: heredoc.Doc(`
 			View an agent task session.
+		`),
+		Example: heredoc.Doc(`
+			# View an agent task by session ID
+			$ gh agent-task view e2fa49d2-f164-4a56-ab99-498090b8fcdf
+
+			# View an agent task by pull request number in current repo
+			$ gh agent-task view 12345
+
+			# View an agent task by pull request number
+			$ gh agent-task view --repo OWNER/REPO 12345
+
+			# View an agent task by pull request reference
+			$ gh agent-task view OWNER/REPO#12345
+
+			# View a pull request agents tasks in the browser
+			$ gh agent-task view 12345 --web
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -109,6 +109,7 @@ func viewRun(opts *ViewOptions) error {
 		}
 	} else {
 		var resourceID int64
+		var prURL string
 
 		if opts.SelectorArg != "" {
 			// Finder does not support the PR/issue reference format (e.g. owner/repo#123)
@@ -127,7 +128,7 @@ func viewRun(opts *ViewOptions) error {
 					return fmt.Errorf("agent tasks are not supported on this host: %s", hostname)
 				}
 
-				resourceID, err = capiClient.GetPullRequestDatabaseID(ctx, hostname, repo.RepoOwner(), repo.RepoName(), num)
+				resourceID, prURL, err = capiClient.GetPullRequestDatabaseID(ctx, hostname, repo.RepoOwner(), repo.RepoName(), num)
 				if err != nil {
 					return fmt.Errorf("failed to fetch pull request: %w", err)
 				}
@@ -155,6 +156,7 @@ func viewRun(opts *ViewOptions) error {
 			}
 
 			resourceID = databaseID
+			prURL = pr.URL
 		}
 
 		// TODO(babakks): currently we just fetch a pre-defined number of

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -113,6 +113,8 @@ func viewRun(opts *ViewOptions) error {
 			return err
 		}
 
+		opts.IO.StopProgressIndicator()
+
 		if opts.Web {
 			var webURL string
 			if sess.PullRequest != nil {
@@ -196,6 +198,8 @@ func viewRun(opts *ViewOptions) error {
 			return cmdutil.SilentError
 		}
 
+		opts.IO.StopProgressIndicator()
+
 		if opts.Web {
 			// Note that, we needed to make sure the PR exists and it has at least one session
 			// associated with it, other wise the `/agent-sessions` page would display the 404
@@ -224,7 +228,6 @@ func viewRun(opts *ViewOptions) error {
 				))
 			}
 
-			opts.IO.StopProgressIndicator()
 			selected, err := opts.Prompter.Select("Select a session", "", options)
 			if err != nil {
 				return err
@@ -233,8 +236,6 @@ func viewRun(opts *ViewOptions) error {
 			session = sessions[selected]
 		}
 	}
-
-	opts.IO.StopProgressIndicator()
 
 	out := opts.IO.Out
 

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmd/agent-task/capi"
@@ -68,6 +69,15 @@ func TestNewCmdList(t *testing.T) {
 				SelectorArg: "some-arg",
 			},
 		},
+		{
+			name: "web mode",
+			tty:  true,
+			args: "some-arg -w",
+			wantOpts: ViewOptions{
+				SelectorArg: "some-arg",
+				Web:         true,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,14 +126,15 @@ func Test_viewRun(t *testing.T) {
 	sampleDate := time.Now().Add(-6 * time.Hour) // 6h ago
 
 	tests := []struct {
-		name        string
-		tty         bool
-		opts        ViewOptions
-		promptStubs func(*testing.T, *prompter.MockPrompter)
-		capiStubs   func(*testing.T, *capi.CapiClientMock)
-		wantOut     string
-		wantErr     error
-		wantStderr  string
+		name           string
+		tty            bool
+		opts           ViewOptions
+		promptStubs    func(*testing.T, *prompter.MockPrompter)
+		capiStubs      func(*testing.T, *capi.CapiClientMock)
+		wantOut        string
+		wantErr        error
+		wantStderr     string
+		wantBrowserURL string
 	}{
 		{
 			name: "with session id, not found (tty)",
@@ -274,13 +285,84 @@ func Test_viewRun(t *testing.T) {
 			`),
 		},
 		{
+			name: "with session id, not found, web mode (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "some-session-id",
+				SessionID:   "some-session-id",
+				Web:         true,
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.GetSessionFunc = func(_ context.Context, _ string) (*capi.Session, error) {
+					return nil, capi.ErrSessionNotFound
+				}
+			},
+			wantStderr: "session not found\n",
+			wantErr:    cmdutil.SilentError,
+		},
+		{
+			name: "with session id, without pr data, web mode (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "some-session-id",
+				SessionID:   "some-session-id",
+				Web:         true,
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
+					assert.Equal(t, "some-session-id", id)
+					return &capi.Session{
+						ID:        "some-session-id",
+						State:     "completed",
+						CreatedAt: sampleDate,
+						// User data is irrelevant in this case
+					}, nil
+				}
+			},
+			wantBrowserURL: "https://github.com/copilot/agents",
+			wantStderr:     "Opening https://github.com/copilot/agents in your browser.\n",
+		},
+		{
+			name: "with session id, with pr data, web mode (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "some-session-id",
+				SessionID:   "some-session-id",
+				Web:         true,
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
+					assert.Equal(t, "some-session-id", id)
+					return &capi.Session{
+						ID:        "some-session-id",
+						State:     "completed",
+						CreatedAt: sampleDate,
+						PullRequest: &api.PullRequest{
+							Title:  "fix something",
+							Number: 101,
+							URL:    "https://github.com/OWNER/REPO/pull/101",
+							Repository: &api.PRRepository{
+								NameWithOwner: "OWNER/REPO",
+							},
+						},
+						// User data is irrelevant in this case
+					}, nil
+				}
+			},
+			wantBrowserURL: "https://github.com/OWNER/REPO/pull/101/agent-sessions/some-session-id",
+			wantStderr:     "Opening https://github.com/OWNER/REPO/pull/101/agent-sessions/some-session-id in your browser.\n",
+		},
+		{
 			name: "with pr number, api error (tty)",
 			tty:  true,
 			opts: ViewOptions{
 				SelectorArg: "pr-number",
 				Finder: prShared.NewMockFinder(
 					"pr-number",
-					&api.PullRequest{FullDatabaseID: "999999"},
+					&api.PullRequest{
+						FullDatabaseID: "999999",
+						URL:            "https://github.com/OWNER/REPO/pull/101",
+					},
 					ghrepo.New("OWNER", "REPO"),
 				),
 			},
@@ -312,8 +394,8 @@ func Test_viewRun(t *testing.T) {
 				},
 			},
 			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
-				m.GetPullRequestDatabaseIDFunc = func(_ context.Context, _ string, _ string, _ string, _ int) (int64, error) {
-					return 0, errors.New("some error")
+				m.GetPullRequestDatabaseIDFunc = func(_ context.Context, _ string, _ string, _ string, _ int) (int64, string, error) {
+					return 0, "", errors.New("some error")
 				}
 			},
 			wantErr: errors.New("failed to fetch pull request: some error"),
@@ -328,8 +410,8 @@ func Test_viewRun(t *testing.T) {
 				},
 			},
 			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
-				m.GetPullRequestDatabaseIDFunc = func(_ context.Context, _ string, _ string, _ string, _ int) (int64, error) {
-					return 999999, nil
+				m.GetPullRequestDatabaseIDFunc = func(_ context.Context, _ string, _ string, _ string, _ int) (int64, string, error) {
+					return 999999, "some-url", nil
 				}
 				m.ListSessionsByResourceIDFunc = func(_ context.Context, _ string, _ int64, _ int) ([]*capi.Session, error) {
 					return nil, errors.New("some error")
@@ -344,7 +426,10 @@ func Test_viewRun(t *testing.T) {
 				SelectorArg: "pr-number",
 				Finder: prShared.NewMockFinder(
 					"pr-number",
-					&api.PullRequest{FullDatabaseID: "999999"},
+					&api.PullRequest{
+						FullDatabaseID: "999999",
+						URL:            "https://github.com/OWNER/REPO/pull/101",
+					},
 					ghrepo.New("OWNER", "REPO"),
 				),
 			},
@@ -388,7 +473,10 @@ func Test_viewRun(t *testing.T) {
 				SelectorArg: "pr-number",
 				Finder: prShared.NewMockFinder(
 					"pr-number",
-					&api.PullRequest{FullDatabaseID: "999999"},
+					&api.PullRequest{
+						FullDatabaseID: "999999",
+						URL:            "https://github.com/OWNER/REPO/pull/101",
+					},
 					ghrepo.New("OWNER", "REPO"),
 				),
 			},
@@ -421,9 +509,9 @@ func Test_viewRun(t *testing.T) {
 							State:     "completed",
 							CreatedAt: sampleDate,
 							PullRequest: &api.PullRequest{
-								Title:  "fix something else",
-								Number: 102,
-								URL:    "https://github.com/OWNER/REPO/pull/102",
+								Title:  "fix something",
+								Number: 101,
+								URL:    "https://github.com/OWNER/REPO/pull/101",
 								Repository: &api.PRRepository{
 									NameWithOwner: "OWNER/REPO",
 								},
@@ -459,18 +547,18 @@ func Test_viewRun(t *testing.T) {
 			name: "with pr reference, success, multiple sessions with pr and user data (tty)",
 			tty:  true,
 			opts: ViewOptions{
-				SelectorArg: "OWNER/REPO#999",
+				SelectorArg: "OWNER/REPO#101",
 				BaseRepo: func() (ghrepo.Interface, error) {
 					return ghrepo.New("OWNER", "REPO"), nil
 				},
 			},
 			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
-				m.GetPullRequestDatabaseIDFunc = func(_ context.Context, hostname string, owner string, repo string, number int) (int64, error) {
+				m.GetPullRequestDatabaseIDFunc = func(_ context.Context, hostname string, owner string, repo string, number int) (int64, string, error) {
 					assert.Equal(t, "github.com", hostname)
 					assert.Equal(t, "OWNER", owner)
 					assert.Equal(t, "REPO", repo)
-					assert.Equal(t, 999, number)
-					return 999999, nil
+					assert.Equal(t, 101, number)
+					return 999999, "https://github.com/OWNER/REPO/pull/101", nil
 				}
 				m.ListSessionsByResourceIDFunc = func(_ context.Context, resourceType string, resourceID int64, limit int) ([]*capi.Session, error) {
 					assert.Equal(t, "pull", resourceType)
@@ -500,9 +588,9 @@ func Test_viewRun(t *testing.T) {
 							State:     "completed",
 							CreatedAt: sampleDate,
 							PullRequest: &api.PullRequest{
-								Title:  "fix something else",
-								Number: 102,
-								URL:    "https://github.com/OWNER/REPO/pull/102",
+								Title:  "fix something",
+								Number: 101,
+								URL:    "https://github.com/OWNER/REPO/pull/101",
 								Repository: &api.PRRepository{
 									NameWithOwner: "OWNER/REPO",
 								},
@@ -534,6 +622,189 @@ func Test_viewRun(t *testing.T) {
 				https://github.com/OWNER/REPO/pull/101/agent-sessions/some-session-id
 			`),
 		},
+		{
+			name: "with pr number, api error, web mode (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "pr-number",
+				Finder: prShared.NewMockFinder(
+					"pr-number",
+					&api.PullRequest{
+						FullDatabaseID: "999999",
+						URL:            "https://github.com/OWNER/REPO/pull/101",
+					},
+					ghrepo.New("OWNER", "REPO"),
+				),
+				Web: true,
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.ListSessionsByResourceIDFunc = func(_ context.Context, _ string, _ int64, _ int) ([]*capi.Session, error) {
+					return nil, errors.New("some error")
+				}
+			},
+			wantErr: errors.New("failed to list sessions for pull request: some error"),
+		},
+		{
+			name: "with pr number, single session with pr data, web mode (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "pr-number",
+				Finder: prShared.NewMockFinder(
+					"pr-number",
+					&api.PullRequest{
+						FullDatabaseID: "999999",
+						URL:            "https://github.com/OWNER/REPO/pull/101",
+					},
+					ghrepo.New("OWNER", "REPO"),
+				),
+				Web: true,
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.ListSessionsByResourceIDFunc = func(_ context.Context, resourceType string, resourceID int64, limit int) ([]*capi.Session, error) {
+					assert.Equal(t, "pull", resourceType)
+					assert.Equal(t, int64(999999), resourceID)
+					assert.Equal(t, defaultLimit, limit)
+					return []*capi.Session{
+						{
+							ID:        "some-session-id",
+							State:     "completed",
+							CreatedAt: sampleDate,
+							PullRequest: &api.PullRequest{
+								Title:  "fix something",
+								Number: 101,
+								URL:    "https://github.com/OWNER/REPO/pull/101",
+								Repository: &api.PRRepository{
+									NameWithOwner: "OWNER/REPO",
+								},
+							},
+							// User data is irrelevant in this case
+						},
+					}, nil
+				}
+			},
+			wantBrowserURL: "https://github.com/OWNER/REPO/pull/101/agent-sessions",
+			wantStderr:     "Opening https://github.com/OWNER/REPO/pull/101/agent-sessions in your browser.\n",
+		},
+		{
+			name: "with pr number, multiple session with pr data, web mode (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "pr-number",
+				Finder: prShared.NewMockFinder(
+					"pr-number",
+					&api.PullRequest{
+						FullDatabaseID: "999999",
+						URL:            "https://github.com/OWNER/REPO/pull/101",
+					},
+					ghrepo.New("OWNER", "REPO"),
+				),
+				Web: true,
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.ListSessionsByResourceIDFunc = func(_ context.Context, resourceType string, resourceID int64, limit int) ([]*capi.Session, error) {
+					assert.Equal(t, "pull", resourceType)
+					assert.Equal(t, int64(999999), resourceID)
+					assert.Equal(t, defaultLimit, limit)
+					return []*capi.Session{
+						{
+							ID:        "some-session-id",
+							Name:      "session one",
+							State:     "completed",
+							CreatedAt: sampleDate,
+							PullRequest: &api.PullRequest{
+								Title:  "fix something",
+								Number: 101,
+								URL:    "https://github.com/OWNER/REPO/pull/101",
+								Repository: &api.PRRepository{
+									NameWithOwner: "OWNER/REPO",
+								},
+							},
+							// User data is irrelevant in this case
+						},
+						{
+							ID:        "some-other-session-id",
+							Name:      "session two",
+							State:     "completed",
+							CreatedAt: sampleDate,
+							PullRequest: &api.PullRequest{
+								Title:  "fix something",
+								Number: 101,
+								URL:    "https://github.com/OWNER/REPO/pull/101",
+								Repository: &api.PRRepository{
+									NameWithOwner: "OWNER/REPO",
+								},
+							},
+							// User data is irrelevant in this case
+						},
+					}, nil
+				}
+			},
+			wantBrowserURL: "https://github.com/OWNER/REPO/pull/101/agent-sessions",
+			wantStderr:     "Opening https://github.com/OWNER/REPO/pull/101/agent-sessions in your browser.\n",
+		},
+		{
+			name: "with pr reference, multiple sessions with pr and user data, web mode (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "OWNER/REPO#101",
+				BaseRepo: func() (ghrepo.Interface, error) {
+					return ghrepo.New("OWNER", "REPO"), nil
+				},
+				Web: true,
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.GetPullRequestDatabaseIDFunc = func(_ context.Context, hostname string, owner string, repo string, number int) (int64, string, error) {
+					assert.Equal(t, "github.com", hostname)
+					assert.Equal(t, "OWNER", owner)
+					assert.Equal(t, "REPO", repo)
+					assert.Equal(t, 101, number)
+					return 999999, "https://github.com/OWNER/REPO/pull/101", nil
+				}
+				m.ListSessionsByResourceIDFunc = func(_ context.Context, resourceType string, resourceID int64, limit int) ([]*capi.Session, error) {
+					assert.Equal(t, "pull", resourceType)
+					assert.Equal(t, int64(999999), resourceID)
+					assert.Equal(t, defaultLimit, limit)
+					return []*capi.Session{
+						{
+							ID:        "some-session-id",
+							Name:      "session one",
+							State:     "completed",
+							CreatedAt: sampleDate,
+							PullRequest: &api.PullRequest{
+								Title:  "fix something",
+								Number: 101,
+								URL:    "https://github.com/OWNER/REPO/pull/101",
+								Repository: &api.PRRepository{
+									NameWithOwner: "OWNER/REPO",
+								},
+							},
+							User: &api.GitHubUser{
+								Login: "octocat",
+							},
+						},
+						{
+							ID:        "some-other-session-id",
+							Name:      "session two",
+							State:     "completed",
+							CreatedAt: sampleDate,
+							PullRequest: &api.PullRequest{
+								Title:  "fix something",
+								Number: 101,
+								URL:    "https://github.com/OWNER/REPO/pull/101",
+								Repository: &api.PRRepository{
+									NameWithOwner: "OWNER/REPO",
+								},
+							},
+							User: &api.GitHubUser{
+								Login: "octocat",
+							},
+						},
+					}, nil
+				}
+			},
+			wantBrowserURL: "https://github.com/OWNER/REPO/pull/101/agent-sessions",
+			wantStderr:     "Opening https://github.com/OWNER/REPO/pull/101/agent-sessions in your browser.\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -551,9 +822,12 @@ func Test_viewRun(t *testing.T) {
 			ios, _, stdout, stderr := iostreams.Test()
 			ios.SetStdoutTTY(tt.tty)
 
+			browser := &browser.Stub{}
+
 			opts := tt.opts
 			opts.IO = ios
 			opts.Prompter = prompter
+			opts.Browser = browser
 			opts.CapiClient = func() (capi.CapiClient, error) {
 				return capiClientMock, nil
 			}
@@ -566,9 +840,9 @@ func Test_viewRun(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			got := stdout.String()
-			require.Equal(t, tt.wantOut, got)
-			require.Equal(t, tt.wantStderr, stderr.String())
+			assert.Equal(t, tt.wantOut, stdout.String())
+			assert.Equal(t, tt.wantStderr, stderr.String())
+			assert.Equal(t, tt.wantBrowserURL, browser.BrowsedURL())
 		})
 	}
 }

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -356,9 +356,9 @@ func Test_viewRun(t *testing.T) {
 			name: "with pr number, api error (tty)",
 			tty:  true,
 			opts: ViewOptions{
-				SelectorArg: "pr-number",
+				SelectorArg: "101",
 				Finder: prShared.NewMockFinder(
-					"pr-number",
+					"101",
 					&api.PullRequest{
 						FullDatabaseID: "999999",
 						URL:            "https://github.com/OWNER/REPO/pull/101",
@@ -377,7 +377,7 @@ func Test_viewRun(t *testing.T) {
 			name: "with pr reference, unsupported hostname (tty)",
 			tty:  true,
 			opts: ViewOptions{
-				SelectorArg: "OWNER/REPO#999",
+				SelectorArg: "OWNER/REPO#101",
 				BaseRepo: func() (ghrepo.Interface, error) {
 					return ghrepo.NewWithHost("OWNER", "REPO", "foo.com"), nil
 				},
@@ -388,7 +388,7 @@ func Test_viewRun(t *testing.T) {
 			name: "with pr reference, api error when fetching pr database ID (tty)",
 			tty:  true,
 			opts: ViewOptions{
-				SelectorArg: "OWNER/REPO#999",
+				SelectorArg: "OWNER/REPO#101",
 				BaseRepo: func() (ghrepo.Interface, error) {
 					return ghrepo.New("OWNER", "REPO"), nil
 				},
@@ -404,7 +404,7 @@ func Test_viewRun(t *testing.T) {
 			name: "with pr reference, api error when fetching session (tty)",
 			tty:  true,
 			opts: ViewOptions{
-				SelectorArg: "OWNER/REPO#999",
+				SelectorArg: "OWNER/REPO#101",
 				BaseRepo: func() (ghrepo.Interface, error) {
 					return ghrepo.New("OWNER", "REPO"), nil
 				},
@@ -420,12 +420,12 @@ func Test_viewRun(t *testing.T) {
 			wantErr: errors.New("failed to list sessions for pull request: some error"),
 		},
 		{
-			name: "with pr number, success, single session with pr and user data (tty)",
+			name: "with pr number, success, single session (tty)",
 			tty:  true,
 			opts: ViewOptions{
-				SelectorArg: "pr-number",
+				SelectorArg: "101",
 				Finder: prShared.NewMockFinder(
-					"pr-number",
+					"101",
 					&api.PullRequest{
 						FullDatabaseID: "999999",
 						URL:            "https://github.com/OWNER/REPO/pull/101",
@@ -467,12 +467,12 @@ func Test_viewRun(t *testing.T) {
 			`),
 		},
 		{
-			name: "with pr number, success, multiple sessions with pr and user data (tty)",
+			name: "with pr number, success, multiple sessions (tty)",
 			tty:  true,
 			opts: ViewOptions{
-				SelectorArg: "pr-number",
+				SelectorArg: "101",
 				Finder: prShared.NewMockFinder(
-					"pr-number",
+					"101",
 					&api.PullRequest{
 						FullDatabaseID: "999999",
 						URL:            "https://github.com/OWNER/REPO/pull/101",
@@ -544,7 +544,7 @@ func Test_viewRun(t *testing.T) {
 			`),
 		},
 		{
-			name: "with pr reference, success, multiple sessions with pr and user data (tty)",
+			name: "with pr reference, success, multiple sessions (tty)",
 			tty:  true,
 			opts: ViewOptions{
 				SelectorArg: "OWNER/REPO#101",
@@ -626,9 +626,9 @@ func Test_viewRun(t *testing.T) {
 			name: "with pr number, api error, web mode (tty)",
 			tty:  true,
 			opts: ViewOptions{
-				SelectorArg: "pr-number",
+				SelectorArg: "101",
 				Finder: prShared.NewMockFinder(
-					"pr-number",
+					"101",
 					&api.PullRequest{
 						FullDatabaseID: "999999",
 						URL:            "https://github.com/OWNER/REPO/pull/101",
@@ -645,12 +645,12 @@ func Test_viewRun(t *testing.T) {
 			wantErr: errors.New("failed to list sessions for pull request: some error"),
 		},
 		{
-			name: "with pr number, single session with pr data, web mode (tty)",
+			name: "with pr number, single session, web mode (tty)",
 			tty:  true,
 			opts: ViewOptions{
-				SelectorArg: "pr-number",
+				SelectorArg: "101",
 				Finder: prShared.NewMockFinder(
-					"pr-number",
+					"101",
 					&api.PullRequest{
 						FullDatabaseID: "999999",
 						URL:            "https://github.com/OWNER/REPO/pull/101",
@@ -686,12 +686,12 @@ func Test_viewRun(t *testing.T) {
 			wantStderr:     "Opening https://github.com/OWNER/REPO/pull/101/agent-sessions in your browser.\n",
 		},
 		{
-			name: "with pr number, multiple session with pr data, web mode (tty)",
+			name: "with pr number, multiple sessions, web mode (tty)",
 			tty:  true,
 			opts: ViewOptions{
-				SelectorArg: "pr-number",
+				SelectorArg: "101",
 				Finder: prShared.NewMockFinder(
-					"pr-number",
+					"101",
 					&api.PullRequest{
 						FullDatabaseID: "999999",
 						URL:            "https://github.com/OWNER/REPO/pull/101",
@@ -743,7 +743,7 @@ func Test_viewRun(t *testing.T) {
 			wantStderr:     "Opening https://github.com/OWNER/REPO/pull/101/agent-sessions in your browser.\n",
 		},
 		{
-			name: "with pr reference, multiple sessions with pr and user data, web mode (tty)",
+			name: "with pr reference, multiple sessions, web mode (tty)",
 			tty:  true,
 			opts: ViewOptions{
 				SelectorArg: "OWNER/REPO#101",
@@ -778,9 +778,7 @@ func Test_viewRun(t *testing.T) {
 									NameWithOwner: "OWNER/REPO",
 								},
 							},
-							User: &api.GitHubUser{
-								Login: "octocat",
-							},
+							// User data is irrelevant in this case
 						},
 						{
 							ID:        "some-other-session-id",
@@ -795,9 +793,7 @@ func Test_viewRun(t *testing.T) {
 									NameWithOwner: "OWNER/REPO",
 								},
 							},
-							User: &api.GitHubUser{
-								Login: "octocat",
-							},
+							// User data is irrelevant in this case
 						},
 					}, nil
 				}


### PR DESCRIPTION
This PR adds `--web` to `agent-task view`.

Note that the `/agent-sessions` page of PRs, is only available (i.e. not returning `HTTP 404`) when there's at least one session attached to the PR. This means, even in `--web` mode we have to fetch the sessions associated with a PR to make sure navigating user to the `/agent-sessions` page does not show any error. I've added an A/C for this at the end.

## A/C verification

### Directly open named session ID

> **Given** I have a session ID to view (a1234b-a1234b) attached to PR 1234
> **Given** My CWD is repo foo/bar
> **When** I run `gh agent-task view a1234b-a1234b --web`
> **Then** my browser opens a new tab to `https://github.com/foo/bar/pull/1234/agent-sessions/a1234b-a1234b`

Confirmed:
<img width="1013" height="53" alt="gh-agent-task-view-web-session-id" src="https://github.com/user-attachments/assets/516d645c-db70-43af-ac00-25f32db26390" />


### Require no disambiguation with `--web` and PR number

> [!NOTE]
> Since `https://github.com/foo/bar/pull/1234/agent-sessions/` is a valid PR specific page requiring no session ID, we can simply open that page, expecting the user to disambiguate which session in the UI. Thus, we do not need to prompt for it. This flow deviates from the non `--web` flow.

> **Given** I have a session ID to view (a1234b-a1234b) attached to PR 1234
> **Given** My CWD is repo foo/bar
> **When** I run `gh agent-task view 1234 --web`
> **Then** my browser opens a new tab to `https://github.com/foo/bar/pull/1234/agent-sessions/`

Confirmed (PR with only one session attached):

<img width="877" height="55" alt="gh-agent-task-view-web-pr-single-session" src="https://github.com/user-attachments/assets/fc0dd5fc-529d-4145-8e37-e9b140837faa" />

Confirmed (PR with more than one sessions attached):

<img width="883" height="57" alt="gh-agent-task-view-web-pr-multi-session" src="https://github.com/user-attachments/assets/b71e3a68-152a-430f-bdf2-040d4288bf8e" />

### No sessions associated with a PR

**Given** I have PR (1234) without any sessions attached to it
**When** I run `gh agent-task view 1234 --web`
**Then** I get the same error as running in non-web mode

Confirmed:
<img width="874" height="71" alt="gh-agent-task-view-web-no-session" src="https://github.com/user-attachments/assets/c663e30e-a758-4c8d-b47a-63ecaf002e83" />
