### PR TITLE
build: customizable install `PREFIX`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,9 @@ endif
 ## Install/uninstall tasks are here for use on *nix platform. On Windows, there is no equivalent.
 
 DESTDIR :=
-prefix  := /usr/local
-bindir  := ${prefix}/bin
-datadir := ${prefix}/share
+PREFIX  ?= /usr/local
+bindir  := ${PREFIX}/bin
+datadir := ${PREFIX}/share
 mandir  := ${datadir}/man
 
 .PHONY: install


### PR DESCRIPTION
## Summary

Allows overriding install `PREFIX`.

```sh
PREFIX=~/.local/share make install

# gh is installed in ~/.local/share
/bin/ls -al ~/.local/share/bin/gh
-rwxr-xr-x. 1 scarf scarf 78800383 Sep 11 01:24 /home/scarf/.local/share/bin/gh

```

## Rationale

currently github CLI can only be installed on `/usr/local` which is too inflexible and requires sudo permission when building and installing locally, when it shouldn't really.