### PR TITLE
`gh agent-task view`: accept `/agent-sessions/*` URL as argument

### DIFF
--- a/pkg/cmd/agent-task/shared/capi.go
+++ b/pkg/cmd/agent-task/shared/capi.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 
 	"github.com/cli/cli/v2/pkg/cmd/agent-task/capi"
@@ -9,8 +10,10 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 )
 
-var uuidRE = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
-var agentSessionsPathRE = regexp.MustCompile(`^/agent-sessions/([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})$`)
+const uuidPattern = `[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}`
+
+var uuidRE = regexp.MustCompile(fmt.Sprintf("^%s$", uuidPattern))
+var agentSessionsPathRE = regexp.MustCompile(fmt.Sprintf("^/agent-sessions/(%s)$", uuidPattern))
 
 func CapiClientFunc(f *cmdutil.Factory) func() (capi.CapiClient, error) {
 	return func() (capi.CapiClient, error) {

--- a/pkg/cmd/agent-task/shared/capi.go
+++ b/pkg/cmd/agent-task/shared/capi.go
@@ -1,13 +1,16 @@
 package shared
 
 import (
+	"errors"
 	"regexp"
 
 	"github.com/cli/cli/v2/pkg/cmd/agent-task/capi"
+	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 )
 
 var uuidRE = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
+var agentSessionsPathRE = regexp.MustCompile(`^/agent-sessions/([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})$`)
 
 func CapiClientFunc(f *cmdutil.Factory) func() (capi.CapiClient, error) {
 	return func() (capi.CapiClient, error) {
@@ -28,4 +31,21 @@ func CapiClientFunc(f *cmdutil.Factory) func() (capi.CapiClient, error) {
 
 func IsSessionID(s string) bool {
 	return uuidRE.MatchString(s)
+}
+
+// ParsePullRequestAgentSessionURL parses session ID from a pull request's agent
+// session URL, which is of the form:
+//
+//	https://github.com/OWNER/REPO/pull/NUMBER/agent-sessions/SESSION-ID
+func ParsePullRequestAgentSessionURL(u string) (string, error) {
+	_, _, rest, err := prShared.ParseURL(u)
+	if err != nil {
+		return "", err
+	}
+
+	match := agentSessionsPathRE.FindStringSubmatch(rest)
+	if match == nil {
+		return "", errors.New("not a valid agent session URL")
+	}
+	return match[1], nil
 }

--- a/pkg/cmd/agent-task/shared/capi.go
+++ b/pkg/cmd/agent-task/shared/capi.go
@@ -12,8 +12,8 @@ import (
 
 const uuidPattern = `[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}`
 
-var uuidRE = regexp.MustCompile(fmt.Sprintf("^%s$", uuidPattern))
-var agentSessionsPathRE = regexp.MustCompile(fmt.Sprintf("^/agent-sessions/(%s)$", uuidPattern))
+var sessionIDRegexp = regexp.MustCompile(fmt.Sprintf("^%s$", uuidPattern))
+var agentSessionURLRegexp = regexp.MustCompile(fmt.Sprintf("^/agent-sessions/(%s)$", uuidPattern))
 
 func CapiClientFunc(f *cmdutil.Factory) func() (capi.CapiClient, error) {
 	return func() (capi.CapiClient, error) {
@@ -33,20 +33,20 @@ func CapiClientFunc(f *cmdutil.Factory) func() (capi.CapiClient, error) {
 }
 
 func IsSessionID(s string) bool {
-	return uuidRE.MatchString(s)
+	return sessionIDRegexp.MatchString(s)
 }
 
-// ParsePullRequestAgentSessionURL parses session ID from a pull request's agent
-// session URL, which is of the form:
+// ParseSessionIDFromURL parses session ID from a pull request's agent session
+// URL, which is of the form:
 //
-//	https://github.com/OWNER/REPO/pull/NUMBER/agent-sessions/SESSION-ID
-func ParsePullRequestAgentSessionURL(u string) (string, error) {
+//	`https://github.com/OWNER/REPO/pull/NUMBER/agent-sessions/SESSION-ID`
+func ParseSessionIDFromURL(u string) (string, error) {
 	_, _, rest, err := prShared.ParseURL(u)
 	if err != nil {
 		return "", err
 	}
 
-	match := agentSessionsPathRE.FindStringSubmatch(rest)
+	match := agentSessionURLRegexp.FindStringSubmatch(rest)
 	if match == nil {
 		return "", errors.New("not a valid agent session URL")
 	}

--- a/pkg/cmd/agent-task/shared/capi_test.go
+++ b/pkg/cmd/agent-task/shared/capi_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsSession(t *testing.T) {
@@ -17,4 +18,59 @@ func TestIsSession(t *testing.T) {
 	assert.False(t, IsSessionID("not-a-uuid"))
 	assert.False(t, IsSessionID("000000000000000000000000000000000000"))
 	assert.False(t, IsSessionID("00000000-0000-0000-0000-000000000000-extra"))
+}
+
+func TestParsePullRequestAgentSessionURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		url           string
+		wantSessionID string
+		wantErr       bool
+	}{
+		{
+			name:          "valid",
+			url:           "https://github.com/OWNER/REPO/pull/123/agent-sessions/e2fa49d2-f164-4a56-ab99-498090b8fcdf",
+			wantSessionID: "e2fa49d2-f164-4a56-ab99-498090b8fcdf",
+		},
+		{
+			name:    "invalid session id",
+			url:     "https://github.com/OWNER/REPO/pull/123/agent-sessions/fff",
+			wantErr: true,
+		},
+		{
+			name:    "no session id, trailing slash",
+			url:     "https://github.com/OWNER/REPO/pull/123/agent-sessions/",
+			wantErr: true,
+		},
+		{
+			name:    "no session id",
+			url:     "https://github.com/OWNER/REPO/pull/123/agent-sessions",
+			wantErr: true,
+		},
+		{
+			name:    "invalid pr url",
+			url:     "https://github.com/OWNER/REPO/issues/123",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			url:     "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessionID, err := ParsePullRequestAgentSessionURL(tt.url)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Zero(t, sessionID)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSessionID, sessionID)
+		})
+	}
 }

--- a/pkg/cmd/agent-task/shared/capi_test.go
+++ b/pkg/cmd/agent-task/shared/capi_test.go
@@ -61,7 +61,7 @@ func TestParsePullRequestAgentSessionURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sessionID, err := ParsePullRequestAgentSessionURL(tt.url)
+			sessionID, err := ParseSessionIDFromURL(tt.url)
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -151,7 +151,7 @@ func viewRun(opts *ViewOptions) error {
 
 		session = sess
 	} else {
-		var resourceID int64
+		var prID int64
 		var prURL string
 
 		if opts.SelectorArg != "" {
@@ -171,14 +171,14 @@ func viewRun(opts *ViewOptions) error {
 					return fmt.Errorf("agent tasks are not supported on this host: %s", hostname)
 				}
 
-				resourceID, prURL, err = capiClient.GetPullRequestDatabaseID(ctx, hostname, repo.RepoOwner(), repo.RepoName(), num)
+				prID, prURL, err = capiClient.GetPullRequestDatabaseID(ctx, hostname, repo.RepoOwner(), repo.RepoName(), num)
 				if err != nil {
 					return fmt.Errorf("failed to fetch pull request: %w", err)
 				}
 			}
 		}
 
-		if resourceID == 0 {
+		if prID == 0 {
 			findOptions := prShared.FindOptions{
 				Selector: opts.SelectorArg,
 				Fields:   []string{"id", "url", "fullDatabaseId"},
@@ -198,7 +198,7 @@ func viewRun(opts *ViewOptions) error {
 				return fmt.Errorf("failed to parse pull request: %w", err)
 			}
 
-			resourceID = databaseID
+			prID = databaseID
 			prURL = pr.URL
 		}
 
@@ -206,7 +206,7 @@ func viewRun(opts *ViewOptions) error {
 		// matching sessions to avoid hitting the API too many times, but it's
 		// technically possible for a PR to be associated with lots of sessions
 		// (i.e. above our selected limit).
-		sessions, err := capiClient.ListSessionsByResourceID(ctx, "pull", resourceID, defaultLimit)
+		sessions, err := capiClient.ListSessionsByResourceID(ctx, "pull", prID, defaultLimit)
 		if err != nil {
 			return fmt.Errorf("failed to list sessions for pull request: %w", err)
 		}

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -80,7 +80,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 				opts.SelectorArg = args[0]
 				if shared.IsSessionID(opts.SelectorArg) {
 					opts.SessionID = opts.SelectorArg
-				} else if sessionID, err := shared.ParsePullRequestAgentSessionURL(opts.SelectorArg); err == nil {
+				} else if sessionID, err := shared.ParseSessionIDFromURL(opts.SelectorArg); err == nil {
 					opts.SessionID = sessionID
 				}
 			}

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -80,6 +80,8 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 				opts.SelectorArg = args[0]
 				if shared.IsSessionID(opts.SelectorArg) {
 					opts.SessionID = opts.SelectorArg
+				} else if sessionID, err := shared.ParsePullRequestAgentSessionURL(opts.SelectorArg); err == nil {
+					opts.SessionID = sessionID
 				}
 			}
 

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -47,6 +47,15 @@ func TestNewCmdList(t *testing.T) {
 			},
 		},
 		{
+			name: "PR agent-session URL arg tty",
+			tty:  true,
+			args: "https://github.com/OWNER/REPO/pull/101/agent-sessions/00000000-0000-0000-0000-000000000000",
+			wantOpts: ViewOptions{
+				SelectorArg: "https://github.com/OWNER/REPO/pull/101/agent-sessions/00000000-0000-0000-0000-000000000000",
+				SessionID:   "00000000-0000-0000-0000-000000000000",
+			},
+		},
+		{
 			name: "non-session ID arg tty",
 			tty:  true,
 			args: "some-arg",

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -97,7 +97,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 				// needs to know the API host. If the command is run outside of
 				// a git repo, we cannot instantiate the detector unless we have
 				// already parsed the URL.
-				if baseRepo, _, err := shared.ParseURL(opts.SelectorArg); err == nil {
+				if baseRepo, _, _, err := shared.ParseURL(opts.SelectorArg); err == nil {
 					opts.BaseRepo = func() (ghrepo.Interface, error) {
 						return baseRepo, nil
 					}

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -300,7 +300,7 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 	return pr, f.baseRefRepo, g.Wait()
 }
 
-var pullURLRE = regexp.MustCompile(`^/([^/]+)/([^/]+)/pull/(\d+)(/.*)?$`)
+var pullURLRE = regexp.MustCompile(`^/([^/]+)/([^/]+)/pull/(\d+)(.*$)`)
 
 // ParseURL parses a pull request URL and returns the repository and pull
 // request number. If there is no error, the returned repo is not nil and will

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -302,12 +302,9 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 
 var pullURLRE = regexp.MustCompile(`^/([^/]+)/([^/]+)/pull/(\d+)(.*$)`)
 
-// ParseURL parses a pull request URL and returns the repository and pull
-// request number. If there is no error, the returned repo is not nil and will
-// have non-empty hostname.
-//
-// Any path components (not query params or fragments) after the pull request
-// number are also returned.
+// ParseURL parses a pull request URL and returns the repository, pull request
+// number, and any tailing path components. If there is no error, the returned
+// repo is not nil and will have non-empty hostname.
 func ParseURL(prURL string) (ghrepo.Interface, int, string, error) {
 	if prURL == "" {
 		return nil, 0, "", fmt.Errorf("invalid URL: %q", prURL)
@@ -329,8 +326,8 @@ func ParseURL(prURL string) (ghrepo.Interface, int, string, error) {
 
 	repo := ghrepo.NewWithHost(m[1], m[2], u.Hostname())
 	prNumber, _ := strconv.Atoi(m[3])
-	rest := m[4]
-	return repo, prNumber, rest, nil
+	tail := m[4]
+	return repo, prNumber, tail, nil
 }
 
 var fullReferenceRE = regexp.MustCompile(`^(?:([^/]+)/([^/]+))#(\d+)$`)

--- a/pkg/cmd/pr/shared/finder_test.go
+++ b/pkg/cmd/pr/shared/finder_test.go
@@ -44,6 +44,13 @@ func TestParseURL(t *testing.T) {
 			wantRest: "/foo/bar",
 		},
 		{
+			name:     "valid HTTP URL with .patch as rest",
+			arg:      "http://example.com/owner/repo/pull/123.patch",
+			wantRepo: ghrepo.NewWithHost("owner", "repo", "example.com"),
+			wantNum:  123,
+			wantRest: ".patch",
+		},
+		{
 			name:     "valid HTTP URL with a trailing slash",
 			arg:      "http://example.com/owner/repo/pull/123/",
 			wantRepo: ghrepo.NewWithHost("owner", "repo", "example.com"),
@@ -83,11 +90,6 @@ func TestParseURL(t *testing.T) {
 			name:    "invalid PR number",
 			arg:     "https://github.com/owner/repo/pull/foo",
 			wantErr: "not a pull request URL: https://github.com/owner/repo/pull/foo",
-		},
-		{
-			name:    "invalid PR number, non-numeric suffix",
-			arg:     "https://github.com/owner/repo/pull/123foo",
-			wantErr: "not a pull request URL: https://github.com/owner/repo/pull/123foo",
 		},
 	}
 

--- a/pkg/cmd/pr/shared/finder_test.go
+++ b/pkg/cmd/pr/shared/finder_test.go
@@ -21,6 +21,7 @@ func TestParseURL(t *testing.T) {
 		arg      string
 		wantRepo ghrepo.Interface
 		wantNum  int
+		wantRest string
 		wantErr  string
 	}{
 		{
@@ -36,13 +37,37 @@ func TestParseURL(t *testing.T) {
 			wantNum:  123,
 		},
 		{
+			name:     "valid HTTP URL with rest",
+			arg:      "http://example.com/owner/repo/pull/123/foo/bar",
+			wantRepo: ghrepo.NewWithHost("owner", "repo", "example.com"),
+			wantNum:  123,
+			wantRest: "/foo/bar",
+		},
+		{
+			name:     "valid HTTP URL with a trailing slash",
+			arg:      "http://example.com/owner/repo/pull/123/",
+			wantRepo: ghrepo.NewWithHost("owner", "repo", "example.com"),
+			wantNum:  123,
+			wantRest: "/",
+		},
+		{
 			name:    "empty URL",
 			wantErr: "invalid URL: \"\"",
+		},
+		{
+			name:    "no scheme",
+			arg:     "github.com/owner/repo/pull/123",
+			wantErr: "invalid scheme: ",
 		},
 		{
 			name:    "invalid scheme",
 			arg:     "ftp://github.com/owner/repo/pull/123",
 			wantErr: "invalid scheme: ftp",
+		},
+		{
+			name:    "no hostname",
+			arg:     "/owner/repo/pull/123",
+			wantErr: "invalid scheme: ",
 		},
 		{
 			name:    "incorrect path",
@@ -59,11 +84,16 @@ func TestParseURL(t *testing.T) {
 			arg:     "https://github.com/owner/repo/pull/foo",
 			wantErr: "not a pull request URL: https://github.com/owner/repo/pull/foo",
 		},
+		{
+			name:    "invalid PR number, non-numeric suffix",
+			arg:     "https://github.com/owner/repo/pull/123foo",
+			wantErr: "not a pull request URL: https://github.com/owner/repo/pull/123foo",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repo, num, err := ParseURL(tt.arg)
+			repo, num, rest, err := ParseURL(tt.arg)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -73,6 +103,7 @@ func TestParseURL(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tt.wantNum, num)
+			require.Equal(t, tt.wantRest, rest)
 			require.NotNil(t, repo)
 			require.True(t, ghrepo.IsSame(tt.wantRepo, repo))
 		})


### PR DESCRIPTION
This PR adds support for PR agent-session URLs, in the form of:

```
https://github.com/OWNER/REPO/pull/NUMBER/agent-sessions/SESSION-ID
```

## A/C verification

> **When** I run `gh agent-task view https://github.com/OWNER/REPO/pull/NUMBER/agent-sessions/SESSION-ID`
> **Then** I see the details of the session identified by `SESSION-ID`

Confirmed:

<img width="1242" height="136" alt="gh-agent-task-view-pr-agent-session-url" src="https://github.com/user-attachments/assets/cd8b712a-9350-457f-8c37-f0cfe342178a" />
