### PR TITLE
feat: Add GH_AUTH_SCHEME environment variable for Bearer token support

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -87,6 +88,8 @@ func AddCacheTTLHeader(rt http.RoundTripper, ttl time.Duration) http.RoundTrippe
 }
 
 // AddAuthTokenHeader adds an authentication token header for the host specified by the request.
+// The authentication scheme can be customized using the GH_AUTH_SCHEME environment variable.
+// If not set, defaults to "token" for backward compatibility. Set to "Bearer" for Bearer token auth.
 func AddAuthTokenHeader(rt http.RoundTripper, cfg tokenGetter) http.RoundTripper {
 	return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
 		// If the header is already set in the request, don't overwrite it.
@@ -100,7 +103,12 @@ func AddAuthTokenHeader(rt http.RoundTripper, cfg tokenGetter) http.RoundTripper
 			if !redirectHostnameChange {
 				hostname := ghauth.NormalizeHostname(getHost(req))
 				if token, _ := cfg.ActiveToken(hostname); token != "" {
-					req.Header.Set(authorization, fmt.Sprintf("token %s", token))
+					// Support GH_AUTH_SCHEME environment variable to customize auth scheme
+					authScheme := os.Getenv("GH_AUTH_SCHEME")
+					if authScheme == "" {
+						authScheme = "token" // Default to existing behavior
+					}
+					req.Header.Set(authorization, fmt.Sprintf("%s %s", authScheme, token))
 				}
 			}
 		}

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -189,6 +190,73 @@ func TestHTTPClientRedirectAuthenticationHeaderHandling(t *testing.T) {
 	assert.Equal(t, "token REDIRECT-TOKEN", redirectRequest.Header.Get(authorization))
 	assert.Equal(t, "", request.Header.Get(authorization))
 	assert.Equal(t, 204, res.StatusCode)
+}
+
+func TestAddAuthTokenHeaderWithCustomScheme(t *testing.T) {
+	tests := []struct {
+		name           string
+		authScheme     string
+		expectedHeader string
+	}{
+		{
+			name:           "default token scheme",
+			authScheme:     "",
+			expectedHeader: "token MYTOKEN",
+		},
+		{
+			name:           "Bearer scheme",
+			authScheme:     "Bearer",
+			expectedHeader: "Bearer MYTOKEN",
+		},
+		{
+			name:           "custom scheme",
+			authScheme:     "Custom",
+			expectedHeader: "Custom MYTOKEN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original env var
+			originalScheme := os.Getenv("GH_AUTH_SCHEME")
+			defer func() {
+				if originalScheme != "" {
+					os.Setenv("GH_AUTH_SCHEME", originalScheme)
+				} else {
+					os.Unsetenv("GH_AUTH_SCHEME")
+				}
+			}()
+
+			// Set test env var
+			if tt.authScheme != "" {
+				os.Setenv("GH_AUTH_SCHEME", tt.authScheme)
+			} else {
+				os.Unsetenv("GH_AUTH_SCHEME")
+			}
+
+			var gotReq *http.Request
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotReq = r
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer ts.Close()
+
+			client, err := NewHTTPClient(HTTPClientOptions{
+				Config: tinyConfig{"github.com:oauth_token": "MYTOKEN"},
+			})
+			require.NoError(t, err)
+
+			req, err := http.NewRequest("GET", ts.URL, nil)
+			req.Host = "github.com"
+			require.NoError(t, err)
+
+			res, err := client.Do(req)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedHeader, gotReq.Header.Get("Authorization"))
+			assert.Equal(t, 204, res.StatusCode)
+		})
+	}
 }
 
 func TestHTTPClientSanitizeJSONControlCharactersC0(t *testing.T) {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -49,6 +49,9 @@ var HelpTopics = []helpTopic{
 			%[1]sGH_ENTERPRISE_TOKEN%[1]s, %[1]sGITHUB_ENTERPRISE_TOKEN%[1]s (in order of precedence): an authentication
 			token that will be used when a command targets a GitHub Enterprise Server host.
 
+			%[1]sGH_AUTH_SCHEME%[1]s: the authentication scheme to use for API requests. Defaults to %[1]stoken%[1]s for
+			backward compatibility. Set to %[1]sBearer%[1]s to use Bearer token authentication format.
+
 			%[1]sGH_HOST%[1]s: specify the GitHub hostname for commands where a hostname has not been provided, or
 			cannot be inferred from the context of a local Git repository. If this host was previously
 			authenticated with, the stored credentials will be used. Otherwise, setting %[1]sGH_TOKEN%[1]s or


### PR DESCRIPTION
## Summary
- Add support for GH_AUTH_SCHEME environment variable in AddAuthTokenHeader
- Defaults to 'token' for backward compatibility
- Set to 'Bearer' to use Bearer token authentication format
- Add comprehensive tests for different auth schemes
- Update environment variables documentation

This allows users to customize the authentication scheme used in
Authorization headers for all internal GitHub CLI API calls.

Related to issue: https://github.com/githubcustomers/Uber/issues/69

Customer Support thread: https://support.github.com/ticket/personal/0/3739042
Customer Reliability Engineer stated they would `open a feature request that references your policy requirement.` But I do not have the feature request link.

They also mentioned that other customers have run into this issue before and have had to create a proxy for this specific auth issue. I would prefer not to do that if it is a common pitfall of the CLI and would rather solve the issue with a change upstream.

This is a backwards compatible change to support the current default (`Authorization: token`) while adding support for `Authorization: Bearer` scheme auth which is required for JWT auth with GitHub APIs as referenced in GitHub docs here: https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28

## Test Plan
 - Added unit test coverage
 - Tested with a local install
 ```
$ gh --version
gh version 2.78.0-61-ga08fa994d (2025-09-12)
https://github.com/cli/cli/releases/latest
```
 
 
 ```
$ GH_AUTH_SCHEME="" GH_DEBUG=api gh pr create
[git remote -v]
[git config --get-regexp ^remote\..*\.gh-resolved$]
* Request at 2025-09-12 10:08:51.566744 -0700 PDT m=+0.833645209
* Request to https://github.uberinternal.com/api/graphql
> POST /api/graphql HTTP/1.1
> Host: github.uberinternal.com
> Accept: application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview
> Authorization: token ████████████████████
> Content-Length: 407
> Content-Type: application/json; charset=utf-8
> Graphql-Features: merge_queue
> Time-Zone: America/Los_Angeles
> User-Agent: GitHub CLI v2.78.0-61-ga08fa994d
```


```
$ GH_AUTH_SCHEME=Bearer GH_DEBUG=api gh pr create
[git remote -v]
[git config --get-regexp ^remote\..*\.gh-resolved$]
* Request at 2025-09-12 10:20:25.852278 -0700 PDT m=+0.848363917
* Request to https://github.uberinternal.com/api/graphql
> POST /api/graphql HTTP/1.1
> Host: github.uberinternal.com
> Accept: application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview
> Authorization: Bearer ████████████████████
> Content-Length: 407
> Content-Type: application/json; charset=utf-8
> Graphql-Features: merge_queue
> Time-Zone: America/Los_Angeles
> User-Agent: GitHub CLI v2.78.0-61-ga08fa994d
```