### PR TITLE
`gh agent-task view`: polish and fix some issues

### DIFF
--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -27,21 +27,22 @@ var ErrSessionNotFound = errors.New("not found")
 
 // session is an in-flight agent task
 type session struct {
-	ID            string    `json:"id"`
-	Name          string    `json:"name"`
-	UserID        int64     `json:"user_id"`
-	AgentID       int64     `json:"agent_id"`
-	Logs          string    `json:"logs"`
-	State         string    `json:"state"`
-	OwnerID       uint64    `json:"owner_id"`
-	RepoID        uint64    `json:"repo_id"`
-	ResourceType  string    `json:"resource_type"`
-	ResourceID    int64     `json:"resource_id"`
-	LastUpdatedAt time.Time `json:"last_updated_at,omitempty"`
-	CreatedAt     time.Time `json:"created_at,omitempty"`
-	CompletedAt   time.Time `json:"completed_at,omitempty"`
-	EventURL      string    `json:"event_url"`
-	EventType     string    `json:"event_type"`
+	ID              string    `json:"id"`
+	Name            string    `json:"name"`
+	UserID          int64     `json:"user_id"`
+	AgentID         int64     `json:"agent_id"`
+	Logs            string    `json:"logs"`
+	State           string    `json:"state"`
+	OwnerID         uint64    `json:"owner_id"`
+	RepoID          uint64    `json:"repo_id"`
+	ResourceType    string    `json:"resource_type"`
+	ResourceID      int64     `json:"resource_id"`
+	LastUpdatedAt   time.Time `json:"last_updated_at,omitempty"`
+	CreatedAt       time.Time `json:"created_at,omitempty"`
+	CompletedAt     time.Time `json:"completed_at,omitempty"`
+	EventURL        string    `json:"event_url"`
+	EventType       string    `json:"event_type"`
+	PremiumRequests float64   `json:"premium_requests"`
 }
 
 // A shim of a full pull request because looking up by node ID
@@ -66,21 +67,22 @@ type sessionPullRequest struct {
 
 // Session is a hydrated in-flight agent task
 type Session struct {
-	ID            string
-	Name          string
-	UserID        int64
-	AgentID       int64
-	Logs          string
-	State         string
-	OwnerID       uint64
-	RepoID        uint64
-	ResourceType  string
-	ResourceID    int64
-	LastUpdatedAt time.Time
-	CreatedAt     time.Time
-	CompletedAt   time.Time
-	EventURL      string
-	EventType     string
+	ID              string
+	Name            string
+	UserID          int64
+	AgentID         int64
+	Logs            string
+	State           string
+	OwnerID         uint64
+	RepoID          uint64
+	ResourceType    string
+	ResourceID      int64
+	LastUpdatedAt   time.Time
+	CreatedAt       time.Time
+	CompletedAt     time.Time
+	EventURL        string
+	EventType       string
+	PremiumRequests float64
 
 	PullRequest *api.PullRequest
 	User        *api.GitHubUser
@@ -475,20 +477,21 @@ func generateUserNodeID(userID int64) string {
 
 func fromAPISession(s session) *Session {
 	return &Session{
-		ID:            s.ID,
-		Name:          s.Name,
-		UserID:        s.UserID,
-		AgentID:       s.AgentID,
-		Logs:          s.Logs,
-		State:         s.State,
-		OwnerID:       s.OwnerID,
-		RepoID:        s.RepoID,
-		ResourceType:  s.ResourceType,
-		ResourceID:    s.ResourceID,
-		LastUpdatedAt: s.LastUpdatedAt,
-		CreatedAt:     s.CreatedAt,
-		CompletedAt:   s.CompletedAt,
-		EventURL:      s.EventURL,
-		EventType:     s.EventType,
+		ID:              s.ID,
+		Name:            s.Name,
+		UserID:          s.UserID,
+		AgentID:         s.AgentID,
+		Logs:            s.Logs,
+		State:           s.State,
+		OwnerID:         s.OwnerID,
+		RepoID:          s.RepoID,
+		ResourceType:    s.ResourceType,
+		ResourceID:      s.ResourceID,
+		LastUpdatedAt:   s.LastUpdatedAt,
+		CreatedAt:       s.CreatedAt,
+		CompletedAt:     s.CompletedAt,
+		EventURL:        s.EventURL,
+		EventType:       s.EventType,
+		PremiumRequests: s.PremiumRequests,
 	}
 }

--- a/pkg/cmd/agent-task/capi/sessions_test.go
+++ b/pkg/cmd/agent-task/capi/sessions_test.go
@@ -77,7 +77,8 @@ func TestListSessionsForViewer(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2000,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -125,17 +126,18 @@ func TestListSessionsForViewer(t *testing.T) {
 			wantOut: []*Session{
 				{
 
-					ID:           "sess1",
-					Name:         "Build artifacts",
-					UserID:       1,
-					AgentID:      2,
-					Logs:         "",
-					State:        "completed",
-					OwnerID:      10,
-					RepoID:       1000,
-					ResourceType: "pull",
-					ResourceID:   2000,
-					CreatedAt:    sampleDate,
+					ID:              "sess1",
+					Name:            "Build artifacts",
+					UserID:          1,
+					AgentID:         2,
+					Logs:            "",
+					State:           "completed",
+					OwnerID:         10,
+					RepoID:          1000,
+					ResourceType:    "pull",
+					ResourceID:      2000,
+					CreatedAt:       sampleDate,
+					PremiumRequests: 0.1,
 					PullRequest: &api.PullRequest{
 						ID:             "PR_node",
 						FullDatabaseID: "2000",
@@ -186,7 +188,8 @@ func TestListSessionsForViewer(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "",
 									"resource_id": 0,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -218,17 +221,18 @@ func TestListSessionsForViewer(t *testing.T) {
 			wantOut: []*Session{
 				{
 
-					ID:           "sess1",
-					Name:         "Build artifacts",
-					UserID:       1,
-					AgentID:      2,
-					Logs:         "",
-					State:        "completed",
-					OwnerID:      10,
-					RepoID:       1000,
-					ResourceType: "",
-					ResourceID:   0,
-					CreatedAt:    sampleDate,
+					ID:              "sess1",
+					Name:            "Build artifacts",
+					UserID:          1,
+					AgentID:         2,
+					Logs:            "",
+					State:           "completed",
+					OwnerID:         10,
+					RepoID:          1000,
+					ResourceType:    "",
+					ResourceID:      0,
+					CreatedAt:       sampleDate,
+					PremiumRequests: 0.1,
 					User: &api.GitHubUser{
 						Login:      "octocat",
 						Name:       "Octocat",
@@ -264,7 +268,8 @@ func TestListSessionsForViewer(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2000,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -295,7 +300,8 @@ func TestListSessionsForViewer(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2001,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -358,17 +364,18 @@ func TestListSessionsForViewer(t *testing.T) {
 			},
 			wantOut: []*Session{
 				{
-					ID:           "sess1",
-					Name:         "Build artifacts",
-					UserID:       1,
-					AgentID:      2,
-					Logs:         "",
-					State:        "completed",
-					OwnerID:      10,
-					RepoID:       1000,
-					ResourceType: "pull",
-					ResourceID:   2000,
-					CreatedAt:    sampleDate,
+					ID:              "sess1",
+					Name:            "Build artifacts",
+					UserID:          1,
+					AgentID:         2,
+					Logs:            "",
+					State:           "completed",
+					OwnerID:         10,
+					RepoID:          1000,
+					ResourceType:    "pull",
+					ResourceID:      2000,
+					CreatedAt:       sampleDate,
+					PremiumRequests: 0.1,
 					PullRequest: &api.PullRequest{
 						ID:             "PR_node",
 						FullDatabaseID: "2000",
@@ -391,17 +398,18 @@ func TestListSessionsForViewer(t *testing.T) {
 					},
 				},
 				{
-					ID:           "sess2",
-					Name:         "Build artifacts",
-					UserID:       1,
-					AgentID:      2,
-					Logs:         "",
-					State:        "completed",
-					OwnerID:      10,
-					RepoID:       1000,
-					ResourceType: "pull",
-					ResourceID:   2001,
-					CreatedAt:    sampleDate,
+					ID:              "sess2",
+					Name:            "Build artifacts",
+					UserID:          1,
+					AgentID:         2,
+					Logs:            "",
+					State:           "completed",
+					OwnerID:         10,
+					RepoID:          1000,
+					ResourceType:    "pull",
+					ResourceID:      2001,
+					CreatedAt:       sampleDate,
+					PremiumRequests: 0.1,
 					PullRequest: &api.PullRequest{
 						ID:             "PR_node",
 						FullDatabaseID: "2001",
@@ -467,7 +475,8 @@ func TestListSessionsForViewer(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2000,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -591,7 +600,8 @@ func TestListSessionsForRepo(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2000,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -638,17 +648,18 @@ func TestListSessionsForRepo(t *testing.T) {
 			},
 			wantOut: []*Session{
 				{
-					ID:           "sess1",
-					Name:         "Build artifacts",
-					UserID:       1,
-					AgentID:      2,
-					Logs:         "",
-					State:        "completed",
-					OwnerID:      10,
-					RepoID:       1000,
-					ResourceType: "pull",
-					ResourceID:   2000,
-					CreatedAt:    sampleDate,
+					ID:              "sess1",
+					Name:            "Build artifacts",
+					UserID:          1,
+					AgentID:         2,
+					Logs:            "",
+					State:           "completed",
+					OwnerID:         10,
+					RepoID:          1000,
+					ResourceType:    "pull",
+					ResourceID:      2000,
+					CreatedAt:       sampleDate,
+					PremiumRequests: 0.1,
 					PullRequest: &api.PullRequest{
 						ID:             "PR_node",
 						FullDatabaseID: "2000",
@@ -699,7 +710,8 @@ func TestListSessionsForRepo(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "",
 									"resource_id": 0,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -731,17 +743,18 @@ func TestListSessionsForRepo(t *testing.T) {
 			wantOut: []*Session{
 				{
 
-					ID:           "sess1",
-					Name:         "Build artifacts",
-					UserID:       1,
-					AgentID:      2,
-					Logs:         "",
-					State:        "completed",
-					OwnerID:      10,
-					RepoID:       1000,
-					ResourceType: "",
-					ResourceID:   0,
-					CreatedAt:    sampleDate,
+					ID:              "sess1",
+					Name:            "Build artifacts",
+					UserID:          1,
+					AgentID:         2,
+					Logs:            "",
+					State:           "completed",
+					OwnerID:         10,
+					RepoID:          1000,
+					ResourceType:    "",
+					ResourceID:      0,
+					CreatedAt:       sampleDate,
+					PremiumRequests: 0.1,
 					User: &api.GitHubUser{
 						Login:      "octocat",
 						Name:       "Octocat",
@@ -777,7 +790,8 @@ func TestListSessionsForRepo(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2000,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -808,7 +822,8 @@ func TestListSessionsForRepo(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2001,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -871,17 +886,18 @@ func TestListSessionsForRepo(t *testing.T) {
 			},
 			wantOut: []*Session{
 				{
-					ID:           "sess1",
-					Name:         "Build artifacts",
-					UserID:       1,
-					AgentID:      2,
-					Logs:         "",
-					State:        "completed",
-					OwnerID:      10,
-					RepoID:       1000,
-					ResourceType: "pull",
-					ResourceID:   2000,
-					CreatedAt:    sampleDate,
+					ID:              "sess1",
+					Name:            "Build artifacts",
+					UserID:          1,
+					AgentID:         2,
+					Logs:            "",
+					State:           "completed",
+					OwnerID:         10,
+					RepoID:          1000,
+					ResourceType:    "pull",
+					ResourceID:      2000,
+					CreatedAt:       sampleDate,
+					PremiumRequests: 0.1,
 					PullRequest: &api.PullRequest{
 						ID:             "PR_node",
 						FullDatabaseID: "2000",
@@ -904,17 +920,18 @@ func TestListSessionsForRepo(t *testing.T) {
 					},
 				},
 				{
-					ID:           "sess2",
-					Name:         "Build artifacts",
-					UserID:       1,
-					AgentID:      2,
-					Logs:         "",
-					State:        "completed",
-					OwnerID:      10,
-					RepoID:       1000,
-					ResourceType: "pull",
-					ResourceID:   2001,
-					CreatedAt:    sampleDate,
+					ID:              "sess2",
+					Name:            "Build artifacts",
+					UserID:          1,
+					AgentID:         2,
+					Logs:            "",
+					State:           "completed",
+					OwnerID:         10,
+					RepoID:          1000,
+					ResourceType:    "pull",
+					ResourceID:      2001,
+					CreatedAt:       sampleDate,
+					PremiumRequests: 0.1,
 					PullRequest: &api.PullRequest{
 						ID:             "PR_node",
 						FullDatabaseID: "2001",
@@ -980,7 +997,8 @@ func TestListSessionsForRepo(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2000,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -1107,7 +1125,8 @@ func TestListSessionsByResourceID(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2000,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -1155,17 +1174,18 @@ func TestListSessionsByResourceID(t *testing.T) {
 			wantOut: []*Session{
 				{
 
-					ID:           "sess1",
-					Name:         "Build artifacts",
-					UserID:       1,
-					AgentID:      2,
-					Logs:         "",
-					State:        "completed",
-					OwnerID:      10,
-					RepoID:       1000,
-					ResourceType: "pull",
-					ResourceID:   2000,
-					CreatedAt:    sampleDate,
+					ID:              "sess1",
+					Name:            "Build artifacts",
+					UserID:          1,
+					AgentID:         2,
+					Logs:            "",
+					State:           "completed",
+					OwnerID:         10,
+					RepoID:          1000,
+					ResourceType:    "pull",
+					ResourceID:      2000,
+					CreatedAt:       sampleDate,
+					PremiumRequests: 0.1,
 					PullRequest: &api.PullRequest{
 						ID:             "PR_node",
 						FullDatabaseID: "2000",
@@ -1216,7 +1236,8 @@ func TestListSessionsByResourceID(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2000,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -1247,7 +1268,8 @@ func TestListSessionsByResourceID(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2001,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -1310,17 +1332,18 @@ func TestListSessionsByResourceID(t *testing.T) {
 			},
 			wantOut: []*Session{
 				{
-					ID:           "sess1",
-					Name:         "Build artifacts",
-					UserID:       1,
-					AgentID:      2,
-					Logs:         "",
-					State:        "completed",
-					OwnerID:      10,
-					RepoID:       1000,
-					ResourceType: "pull",
-					ResourceID:   2000,
-					CreatedAt:    sampleDate,
+					ID:              "sess1",
+					Name:            "Build artifacts",
+					UserID:          1,
+					AgentID:         2,
+					Logs:            "",
+					State:           "completed",
+					OwnerID:         10,
+					RepoID:          1000,
+					ResourceType:    "pull",
+					ResourceID:      2000,
+					CreatedAt:       sampleDate,
+					PremiumRequests: 0.1,
 					PullRequest: &api.PullRequest{
 						ID:             "PR_node",
 						FullDatabaseID: "2000",
@@ -1343,17 +1366,18 @@ func TestListSessionsByResourceID(t *testing.T) {
 					},
 				},
 				{
-					ID:           "sess2",
-					Name:         "Build artifacts",
-					UserID:       1,
-					AgentID:      2,
-					Logs:         "",
-					State:        "completed",
-					OwnerID:      10,
-					RepoID:       1000,
-					ResourceType: "pull",
-					ResourceID:   2001,
-					CreatedAt:    sampleDate,
+					ID:              "sess2",
+					Name:            "Build artifacts",
+					UserID:          1,
+					AgentID:         2,
+					Logs:            "",
+					State:           "completed",
+					OwnerID:         10,
+					RepoID:          1000,
+					ResourceType:    "pull",
+					ResourceID:      2001,
+					CreatedAt:       sampleDate,
+					PremiumRequests: 0.1,
 					PullRequest: &api.PullRequest{
 						ID:             "PR_node",
 						FullDatabaseID: "2001",
@@ -1419,7 +1443,8 @@ func TestListSessionsByResourceID(t *testing.T) {
 									"repo_id": 1000,
 									"resource_type": "pull",
 									"resource_id": 2000,
-									"created_at": "%[1]s"
+									"created_at": "%[1]s",
+									"premium_requests": 0.1
 								}
 							]
 						}`,
@@ -1538,7 +1563,8 @@ func TestGetSession(t *testing.T) {
 							"repo_id": 1000,
 							"resource_type": "pull",
 							"resource_id": 2000,
-							"created_at": "%[1]s"
+							"created_at": "%[1]s",
+							"premium_requests": 0.1
 						}`,
 						sampleDateString,
 					)),
@@ -1582,17 +1608,18 @@ func TestGetSession(t *testing.T) {
 				)
 			},
 			wantOut: &Session{
-				ID:           "some-uuid",
-				Name:         "Build artifacts",
-				UserID:       1,
-				AgentID:      2,
-				Logs:         "",
-				State:        "completed",
-				OwnerID:      10,
-				RepoID:       1000,
-				ResourceType: "pull",
-				ResourceID:   2000,
-				CreatedAt:    sampleDate,
+				ID:              "some-uuid",
+				Name:            "Build artifacts",
+				UserID:          1,
+				AgentID:         2,
+				Logs:            "",
+				State:           "completed",
+				OwnerID:         10,
+				RepoID:          1000,
+				ResourceType:    "pull",
+				ResourceID:      2000,
+				CreatedAt:       sampleDate,
+				PremiumRequests: 0.1,
 				PullRequest: &api.PullRequest{
 					ID:             "PR_node",
 					FullDatabaseID: "2000",
@@ -1633,7 +1660,8 @@ func TestGetSession(t *testing.T) {
 							"repo_id": 1000,
 							"resource_type": "",
 							"resource_id": 0,
-							"created_at": "%[1]s"
+							"created_at": "%[1]s",
+							"premium_requests": 0.1
 						}`,
 						sampleDateString,
 					)),
@@ -1661,17 +1689,18 @@ func TestGetSession(t *testing.T) {
 				)
 			},
 			wantOut: &Session{
-				ID:           "some-uuid",
-				Name:         "Build artifacts",
-				UserID:       1,
-				AgentID:      2,
-				Logs:         "",
-				State:        "completed",
-				OwnerID:      10,
-				RepoID:       1000,
-				ResourceType: "",
-				ResourceID:   0,
-				CreatedAt:    sampleDate,
+				ID:              "some-uuid",
+				Name:            "Build artifacts",
+				UserID:          1,
+				AgentID:         2,
+				Logs:            "",
+				State:           "completed",
+				OwnerID:         10,
+				RepoID:          1000,
+				ResourceType:    "",
+				ResourceID:      0,
+				CreatedAt:       sampleDate,
+				PremiumRequests: 0.1,
 				User: &api.GitHubUser{
 					Login:      "octocat",
 					Name:       "Octocat",
@@ -1696,7 +1725,8 @@ func TestGetSession(t *testing.T) {
 							"repo_id": 1000,
 							"resource_type": "pull",
 							"resource_id": 2000,
-							"created_at": "%[1]s"
+							"created_at": "%[1]s",
+							"premium_requests": 0.1
 						}`,
 						sampleDateString,
 					)),

--- a/pkg/cmd/agent-task/shared/display.go
+++ b/pkg/cmd/agent-task/shared/display.go
@@ -32,7 +32,7 @@ func SessionStateString(state string) string {
 	case "in_progress":
 		return "In Progress"
 	case "completed":
-		return "Completed"
+		return "Ready for review"
 	case "failed":
 		return "Failed"
 	case "idle":

--- a/pkg/cmd/agent-task/shared/display.go
+++ b/pkg/cmd/agent-task/shared/display.go
@@ -30,7 +30,7 @@ func SessionStateString(state string) string {
 	case "queued":
 		return "Queued"
 	case "in_progress":
-		return "In Progress"
+		return "In progress"
 	case "completed":
 		return "Ready for review"
 	case "failed":
@@ -38,9 +38,9 @@ func SessionStateString(state string) string {
 	case "idle":
 		return "Idle"
 	case "waiting_for_user":
-		return "Waiting for User"
+		return "Waiting for user"
 	case "timed_out":
-		return "Timed Out"
+		return "Timed out"
 	case "cancelled":
 		return "Cancelled"
 	default:

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -277,11 +277,11 @@ func viewRun(opts *ViewOptions) error {
 		}
 	}
 
-	printSession(opts, session)
-
 	if opts.Log {
 		return printLogs(opts, capiClient, session.ID)
 	}
+
+	printSession(opts, session)
 	return nil
 }
 
@@ -362,7 +362,6 @@ func printLogs(opts *ViewOptions, capiClient capi.CapiClient, sessionID string) 
 			return raw, nil
 		}
 
-		fmt.Fprintln(opts.IO.Out, "")
 		return renderer.Follow(fetcher, opts.IO.Out, opts.IO)
 	}
 
@@ -371,7 +370,6 @@ func printLogs(opts *ViewOptions, capiClient capi.CapiClient, sessionID string) 
 		return fmt.Errorf("failed to fetch session logs: %w", err)
 	}
 
-	fmt.Fprintln(opts.IO.Out, "")
 	_, err = renderer.Render(raw, opts.IO.Out, opts.IO)
 	return err
 }

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -200,8 +200,9 @@ func viewRun(opts *ViewOptions) error {
 
 		if prID == 0 {
 			findOptions := prShared.FindOptions{
-				Selector: opts.SelectorArg,
-				Fields:   []string{"id", "url", "fullDatabaseId"},
+				Selector:        opts.SelectorArg,
+				Fields:          []string{"id", "url", "fullDatabaseId"},
+				DisableProgress: true,
 			}
 
 			pr, repo, err := opts.Finder.Find(findOptions)

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -306,6 +306,15 @@ func printSession(opts *ViewOptions, session *capi.Session) {
 		fmt.Fprintf(opts.IO.Out, "Started %s\n", text.FuzzyAgo(time.Now(), session.CreatedAt))
 	}
 
+	var durationNote string
+	if session.CompletedAt.After(session.CreatedAt) {
+		durationNote = fmt.Sprintf("Duration %s", session.CompletedAt.Sub(session.CreatedAt).Round(time.Second).String())
+	}
+
+	if durationNote != "" {
+		fmt.Fprintf(opts.IO.Out, "%s\n", cs.Muted(durationNote))
+	}
+
 	if !opts.Log {
 		fmt.Fprintln(opts.IO.Out, "")
 		fmt.Fprintf(opts.IO.Out, "For detailed session logs, try:\ngh agent-task view '%s' --log\n", session.ID)

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
@@ -306,13 +307,19 @@ func printSession(opts *ViewOptions, session *capi.Session) {
 		fmt.Fprintf(opts.IO.Out, "Started %s\n", text.FuzzyAgo(time.Now(), session.CreatedAt))
 	}
 
-	var durationNote string
-	if session.CompletedAt.After(session.CreatedAt) {
-		durationNote = fmt.Sprintf("Duration %s", session.CompletedAt.Sub(session.CreatedAt).Round(time.Second).String())
+	additionalNotes := make([]string, 0, 2)
+
+	if session.PremiumRequests > 0 {
+		s := strings.TrimSuffix(fmt.Sprintf("%.1f", session.PremiumRequests), ".0")
+		additionalNotes = append(additionalNotes, fmt.Sprintf("Used %s premium request(s)", s))
 	}
 
-	if durationNote != "" {
-		fmt.Fprintf(opts.IO.Out, "%s\n", cs.Muted(durationNote))
+	if session.CompletedAt.After(session.CreatedAt) {
+		additionalNotes = append(additionalNotes, fmt.Sprintf("Duration %s", session.CompletedAt.Sub(session.CreatedAt).Round(time.Second).String()))
+	}
+
+	if len(additionalNotes) > 0 {
+		fmt.Fprintf(opts.IO.Out, "%s\n", cs.Muted(strings.Join(additionalNotes, " • ")))
 	}
 
 	if !opts.Log {

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -307,20 +307,15 @@ func printSession(opts *ViewOptions, session *capi.Session) {
 		fmt.Fprintf(opts.IO.Out, "Started %s\n", text.FuzzyAgo(time.Now(), session.CreatedAt))
 	}
 
-	additionalNotes := make([]string, 0, 2)
+	usedPremiumRequests := strings.TrimSuffix(fmt.Sprintf("%.1f", session.PremiumRequests), ".0")
+	usedPremiumRequestsNote := fmt.Sprintf("Used %s premium request(s)", usedPremiumRequests)
 
-	if session.PremiumRequests > 0 {
-		s := strings.TrimSuffix(fmt.Sprintf("%.1f", session.PremiumRequests), ".0")
-		additionalNotes = append(additionalNotes, fmt.Sprintf("Used %s premium request(s)", s))
-	}
-
+	var durationNote string
 	if session.CompletedAt.After(session.CreatedAt) {
-		additionalNotes = append(additionalNotes, fmt.Sprintf("Duration %s", session.CompletedAt.Sub(session.CreatedAt).Round(time.Second).String()))
+		durationNote = fmt.Sprintf(" • Duration %s", session.CompletedAt.Sub(session.CreatedAt).Round(time.Second).String())
 	}
 
-	if len(additionalNotes) > 0 {
-		fmt.Fprintf(opts.IO.Out, "%s\n", cs.Muted(strings.Join(additionalNotes, " • ")))
-	}
+	fmt.Fprintf(opts.IO.Out, "%s%s\n", cs.Muted(usedPremiumRequestsNote), cs.Muted(durationNote))
 
 	if !opts.Log {
 		fmt.Fprintln(opts.IO.Out, "")

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -230,7 +230,7 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Completed • fix something • OWNER/REPO#101
+				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
 
 				For detailed session logs, try:
@@ -267,7 +267,7 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Completed • fix something • OWNER/REPO#101
+				Ready for review • fix something • OWNER/REPO#101
 				Started about 6 hours ago
 
 				For detailed session logs, try:
@@ -299,7 +299,7 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Completed
+				Ready for review
 				Started on behalf of octocat about 6 hours ago
 
 				For detailed session logs, try:
@@ -325,7 +325,7 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Completed
+				Ready for review
 				Started about 6 hours ago
 
 				For detailed session logs, try:
@@ -507,7 +507,7 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Completed • fix something • OWNER/REPO#101
+				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
 
 				For detailed session logs, try:
@@ -587,7 +587,7 @@ func Test_viewRun(t *testing.T) {
 				)
 			},
 			wantOut: heredoc.Doc(`
-				Completed • fix something • OWNER/REPO#101
+				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
 
 				For detailed session logs, try:
@@ -669,7 +669,7 @@ func Test_viewRun(t *testing.T) {
 				)
 			},
 			wantOut: heredoc.Doc(`
-				Completed • fix something • OWNER/REPO#101
+				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
 
 				For detailed session logs, try:
@@ -890,7 +890,7 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Completed
+				Ready for review
 				Started on behalf of octocat about 6 hours ago
 
 				To follow session logs, try:
@@ -947,7 +947,7 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Completed
+				Ready for review
 				Started on behalf of octocat about 6 hours ago
 
 				(rendered:) <raw-logs-one>

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -932,13 +932,6 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Ready for review
-				Started on behalf of octocat about 6 hours ago
-				Used 1.5 premium request(s) • Duration 5m0s
-
-				To follow session logs, try:
-				gh agent-task view 'some-session-id' --log --follow
-
 				(rendered:) <raw-logs>
 			`),
 		},
@@ -992,10 +985,6 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Ready for review
-				Started on behalf of octocat about 6 hours ago
-				Used 1.5 premium request(s) • Duration 5m0s
-
 				(rendered:) <raw-logs-one>
 				(rendered:) <raw-logs-two>
 			`),

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -213,10 +213,11 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:          "some-session-id",
-						State:       "completed",
-						CreatedAt:   sampleDate,
-						CompletedAt: sampleCompletedAt,
+						ID:              "some-session-id",
+						State:           "completed",
+						CreatedAt:       sampleDate,
+						CompletedAt:     sampleCompletedAt,
+						PremiumRequests: 1.5,
 						PullRequest: &api.PullRequest{
 							Title:  "fix something",
 							Number: 101,
@@ -234,7 +235,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
-				Duration 5m0s
+				Used 1.5 premium request(s) • Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -255,10 +256,11 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:          "some-session-id",
-						State:       "completed",
-						CreatedAt:   sampleDate,
-						CompletedAt: sampleCompletedAt,
+						ID:              "some-session-id",
+						State:           "completed",
+						CreatedAt:       sampleDate,
+						CompletedAt:     sampleCompletedAt,
+						PremiumRequests: 1.5,
 						PullRequest: &api.PullRequest{
 							Title:  "fix something",
 							Number: 101,
@@ -273,7 +275,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review • fix something • OWNER/REPO#101
 				Started about 6 hours ago
-				Duration 5m0s
+				Used 1.5 premium request(s) • Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -294,10 +296,11 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:          "some-session-id",
-						State:       "completed",
-						CreatedAt:   sampleDate,
-						CompletedAt: sampleCompletedAt,
+						ID:              "some-session-id",
+						State:           "completed",
+						CreatedAt:       sampleDate,
+						CompletedAt:     sampleCompletedAt,
+						PremiumRequests: 1.5,
 						User: &api.GitHubUser{
 							Login: "octocat",
 						},
@@ -307,7 +310,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review
 				Started on behalf of octocat about 6 hours ago
-				Duration 5m0s
+				Used 1.5 premium request(s) • Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -325,17 +328,18 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:          "some-session-id",
-						State:       "completed",
-						CreatedAt:   sampleDate,
-						CompletedAt: sampleCompletedAt,
+						ID:              "some-session-id",
+						State:           "completed",
+						CreatedAt:       sampleDate,
+						CompletedAt:     sampleCompletedAt,
+						PremiumRequests: 1.5,
 					}, nil
 				}
 			},
 			wantOut: heredoc.Doc(`
 				Ready for review
 				Started about 6 hours ago
-				Duration 5m0s
+				Used 1.5 premium request(s) • Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -369,10 +373,11 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:          "some-session-id",
-						State:       "completed",
-						CreatedAt:   sampleDate,
-						CompletedAt: sampleCompletedAt,
+						ID:              "some-session-id",
+						State:           "completed",
+						CreatedAt:       sampleDate,
+						CompletedAt:     sampleCompletedAt,
+						PremiumRequests: 1.5,
 						// User data is irrelevant in this case
 					}, nil
 				}
@@ -392,10 +397,11 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:          "some-session-id",
-						State:       "completed",
-						CreatedAt:   sampleDate,
-						CompletedAt: sampleCompletedAt,
+						ID:              "some-session-id",
+						State:           "completed",
+						CreatedAt:       sampleDate,
+						CompletedAt:     sampleCompletedAt,
+						PremiumRequests: 1.5,
 						PullRequest: &api.PullRequest{
 							Title:  "fix something",
 							Number: 101,
@@ -499,10 +505,11 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:          "some-session-id",
-							State:       "completed",
-							CreatedAt:   sampleDate,
-							CompletedAt: sampleCompletedAt,
+							ID:              "some-session-id",
+							State:           "completed",
+							CreatedAt:       sampleDate,
+							CompletedAt:     sampleCompletedAt,
+							PremiumRequests: 1.5,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -521,7 +528,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
-				Duration 5m0s
+				Used 1.5 premium request(s) • Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -551,11 +558,12 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:          "some-session-id",
-							Name:        "session one",
-							State:       "completed",
-							CreatedAt:   sampleDate,
-							CompletedAt: sampleCompletedAt,
+							ID:              "some-session-id",
+							Name:            "session one",
+							State:           "completed",
+							CreatedAt:       sampleDate,
+							CompletedAt:     sampleCompletedAt,
+							PremiumRequests: 1.5,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -569,11 +577,12 @@ func Test_viewRun(t *testing.T) {
 							},
 						},
 						{
-							ID:          "some-other-session-id",
-							Name:        "session two",
-							State:       "completed",
-							CreatedAt:   sampleDate,
-							CompletedAt: sampleCompletedAt,
+							ID:              "some-other-session-id",
+							Name:            "session two",
+							State:           "completed",
+							CreatedAt:       sampleDate,
+							CompletedAt:     sampleCompletedAt,
+							PremiumRequests: 1.5,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -604,7 +613,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
-				Duration 5m0s
+				Used 1.5 premium request(s) • Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -636,11 +645,12 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:          "some-session-id",
-							Name:        "session one",
-							State:       "completed",
-							CreatedAt:   sampleDate,
-							CompletedAt: sampleCompletedAt,
+							ID:              "some-session-id",
+							Name:            "session one",
+							State:           "completed",
+							CreatedAt:       sampleDate,
+							CompletedAt:     sampleCompletedAt,
+							PremiumRequests: 1.5,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -654,11 +664,12 @@ func Test_viewRun(t *testing.T) {
 							},
 						},
 						{
-							ID:          "some-other-session-id",
-							Name:        "session two",
-							State:       "completed",
-							CreatedAt:   sampleDate,
-							CompletedAt: sampleCompletedAt,
+							ID:              "some-other-session-id",
+							Name:            "session two",
+							State:           "completed",
+							CreatedAt:       sampleDate,
+							CompletedAt:     sampleCompletedAt,
+							PremiumRequests: 1.5,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -689,7 +700,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
-				Duration 5m0s
+				Used 1.5 premium request(s) • Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -742,10 +753,11 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:          "some-session-id",
-							State:       "completed",
-							CreatedAt:   sampleDate,
-							CompletedAt: sampleCompletedAt,
+							ID:              "some-session-id",
+							State:           "completed",
+							CreatedAt:       sampleDate,
+							CompletedAt:     sampleCompletedAt,
+							PremiumRequests: 1.5,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -784,11 +796,12 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:          "some-session-id",
-							Name:        "session one",
-							State:       "completed",
-							CreatedAt:   sampleDate,
-							CompletedAt: sampleCompletedAt,
+							ID:              "some-session-id",
+							Name:            "session one",
+							State:           "completed",
+							CreatedAt:       sampleDate,
+							CompletedAt:     sampleCompletedAt,
+							PremiumRequests: 1.5,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -800,11 +813,12 @@ func Test_viewRun(t *testing.T) {
 							// User data is irrelevant in this case
 						},
 						{
-							ID:          "some-other-session-id",
-							Name:        "session two",
-							State:       "completed",
-							CreatedAt:   sampleDate,
-							CompletedAt: sampleCompletedAt,
+							ID:              "some-other-session-id",
+							Name:            "session two",
+							State:           "completed",
+							CreatedAt:       sampleDate,
+							CompletedAt:     sampleCompletedAt,
+							PremiumRequests: 1.5,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -845,11 +859,12 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:          "some-session-id",
-							Name:        "session one",
-							State:       "completed",
-							CreatedAt:   sampleDate,
-							CompletedAt: sampleCompletedAt,
+							ID:              "some-session-id",
+							Name:            "session one",
+							State:           "completed",
+							CreatedAt:       sampleDate,
+							CompletedAt:     sampleCompletedAt,
+							PremiumRequests: 1.5,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -861,11 +876,12 @@ func Test_viewRun(t *testing.T) {
 							// User data is irrelevant in this case
 						},
 						{
-							ID:          "some-other-session-id",
-							Name:        "session two",
-							State:       "completed",
-							CreatedAt:   sampleDate,
-							CompletedAt: sampleCompletedAt,
+							ID:              "some-other-session-id",
+							Name:            "session two",
+							State:           "completed",
+							CreatedAt:       sampleDate,
+							CompletedAt:     sampleCompletedAt,
+							PremiumRequests: 1.5,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -894,10 +910,11 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:          "some-session-id",
-						State:       "completed",
-						CreatedAt:   sampleDate,
-						CompletedAt: sampleCompletedAt,
+						ID:              "some-session-id",
+						State:           "completed",
+						CreatedAt:       sampleDate,
+						CompletedAt:     sampleCompletedAt,
+						PremiumRequests: 1.5,
 						User: &api.GitHubUser{
 							Login: "octocat",
 						},
@@ -917,7 +934,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review
 				Started on behalf of octocat about 6 hours ago
-				Duration 5m0s
+				Used 1.5 premium request(s) • Duration 5m0s
 
 				To follow session logs, try:
 				gh agent-task view 'some-session-id' --log --follow
@@ -939,10 +956,11 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:          "some-session-id",
-						State:       "completed",
-						CreatedAt:   sampleDate,
-						CompletedAt: sampleCompletedAt,
+						ID:              "some-session-id",
+						State:           "completed",
+						CreatedAt:       sampleDate,
+						CompletedAt:     sampleCompletedAt,
+						PremiumRequests: 1.5,
 						User: &api.GitHubUser{
 							Login: "octocat",
 						},
@@ -976,7 +994,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review
 				Started on behalf of octocat about 6 hours ago
-				Duration 5m0s
+				Used 1.5 premium request(s) • Duration 5m0s
 
 				(rendered:) <raw-logs-one>
 				(rendered:) <raw-logs-two>

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -159,6 +159,7 @@ func TestNewCmdList(t *testing.T) {
 
 func Test_viewRun(t *testing.T) {
 	sampleDate := time.Now().Add(-6 * time.Hour) // 6h ago
+	sampleCompletedAt := sampleDate.Add(5 * time.Minute)
 
 	tests := []struct {
 		name             string
@@ -212,9 +213,10 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:        "some-session-id",
-						State:     "completed",
-						CreatedAt: sampleDate,
+						ID:          "some-session-id",
+						State:       "completed",
+						CreatedAt:   sampleDate,
+						CompletedAt: sampleCompletedAt,
 						PullRequest: &api.PullRequest{
 							Title:  "fix something",
 							Number: 101,
@@ -232,6 +234,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
+				Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -252,9 +255,10 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:        "some-session-id",
-						State:     "completed",
-						CreatedAt: sampleDate,
+						ID:          "some-session-id",
+						State:       "completed",
+						CreatedAt:   sampleDate,
+						CompletedAt: sampleCompletedAt,
 						PullRequest: &api.PullRequest{
 							Title:  "fix something",
 							Number: 101,
@@ -269,6 +273,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review • fix something • OWNER/REPO#101
 				Started about 6 hours ago
+				Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -289,9 +294,10 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:        "some-session-id",
-						State:     "completed",
-						CreatedAt: sampleDate,
+						ID:          "some-session-id",
+						State:       "completed",
+						CreatedAt:   sampleDate,
+						CompletedAt: sampleCompletedAt,
 						User: &api.GitHubUser{
 							Login: "octocat",
 						},
@@ -301,6 +307,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review
 				Started on behalf of octocat about 6 hours ago
+				Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -318,15 +325,17 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:        "some-session-id",
-						State:     "completed",
-						CreatedAt: sampleDate,
+						ID:          "some-session-id",
+						State:       "completed",
+						CreatedAt:   sampleDate,
+						CompletedAt: sampleCompletedAt,
 					}, nil
 				}
 			},
 			wantOut: heredoc.Doc(`
 				Ready for review
 				Started about 6 hours ago
+				Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -360,9 +369,10 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:        "some-session-id",
-						State:     "completed",
-						CreatedAt: sampleDate,
+						ID:          "some-session-id",
+						State:       "completed",
+						CreatedAt:   sampleDate,
+						CompletedAt: sampleCompletedAt,
 						// User data is irrelevant in this case
 					}, nil
 				}
@@ -382,9 +392,10 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:        "some-session-id",
-						State:     "completed",
-						CreatedAt: sampleDate,
+						ID:          "some-session-id",
+						State:       "completed",
+						CreatedAt:   sampleDate,
+						CompletedAt: sampleCompletedAt,
 						PullRequest: &api.PullRequest{
 							Title:  "fix something",
 							Number: 101,
@@ -488,9 +499,10 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:        "some-session-id",
-							State:     "completed",
-							CreatedAt: sampleDate,
+							ID:          "some-session-id",
+							State:       "completed",
+							CreatedAt:   sampleDate,
+							CompletedAt: sampleCompletedAt,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -509,6 +521,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
+				Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -538,10 +551,11 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:        "some-session-id",
-							Name:      "session one",
-							State:     "completed",
-							CreatedAt: sampleDate,
+							ID:          "some-session-id",
+							Name:        "session one",
+							State:       "completed",
+							CreatedAt:   sampleDate,
+							CompletedAt: sampleCompletedAt,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -555,10 +569,11 @@ func Test_viewRun(t *testing.T) {
 							},
 						},
 						{
-							ID:        "some-other-session-id",
-							Name:      "session two",
-							State:     "completed",
-							CreatedAt: sampleDate,
+							ID:          "some-other-session-id",
+							Name:        "session two",
+							State:       "completed",
+							CreatedAt:   sampleDate,
+							CompletedAt: sampleCompletedAt,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -589,6 +604,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
+				Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -620,10 +636,11 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:        "some-session-id",
-							Name:      "session one",
-							State:     "completed",
-							CreatedAt: sampleDate,
+							ID:          "some-session-id",
+							Name:        "session one",
+							State:       "completed",
+							CreatedAt:   sampleDate,
+							CompletedAt: sampleCompletedAt,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -637,10 +654,11 @@ func Test_viewRun(t *testing.T) {
 							},
 						},
 						{
-							ID:        "some-other-session-id",
-							Name:      "session two",
-							State:     "completed",
-							CreatedAt: sampleDate,
+							ID:          "some-other-session-id",
+							Name:        "session two",
+							State:       "completed",
+							CreatedAt:   sampleDate,
+							CompletedAt: sampleCompletedAt,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -671,6 +689,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review • fix something • OWNER/REPO#101
 				Started on behalf of octocat about 6 hours ago
+				Duration 5m0s
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -723,9 +742,10 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:        "some-session-id",
-							State:     "completed",
-							CreatedAt: sampleDate,
+							ID:          "some-session-id",
+							State:       "completed",
+							CreatedAt:   sampleDate,
+							CompletedAt: sampleCompletedAt,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -764,10 +784,11 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:        "some-session-id",
-							Name:      "session one",
-							State:     "completed",
-							CreatedAt: sampleDate,
+							ID:          "some-session-id",
+							Name:        "session one",
+							State:       "completed",
+							CreatedAt:   sampleDate,
+							CompletedAt: sampleCompletedAt,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -779,10 +800,11 @@ func Test_viewRun(t *testing.T) {
 							// User data is irrelevant in this case
 						},
 						{
-							ID:        "some-other-session-id",
-							Name:      "session two",
-							State:     "completed",
-							CreatedAt: sampleDate,
+							ID:          "some-other-session-id",
+							Name:        "session two",
+							State:       "completed",
+							CreatedAt:   sampleDate,
+							CompletedAt: sampleCompletedAt,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -823,10 +845,11 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:        "some-session-id",
-							Name:      "session one",
-							State:     "completed",
-							CreatedAt: sampleDate,
+							ID:          "some-session-id",
+							Name:        "session one",
+							State:       "completed",
+							CreatedAt:   sampleDate,
+							CompletedAt: sampleCompletedAt,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -838,10 +861,11 @@ func Test_viewRun(t *testing.T) {
 							// User data is irrelevant in this case
 						},
 						{
-							ID:        "some-other-session-id",
-							Name:      "session two",
-							State:     "completed",
-							CreatedAt: sampleDate,
+							ID:          "some-other-session-id",
+							Name:        "session two",
+							State:       "completed",
+							CreatedAt:   sampleDate,
+							CompletedAt: sampleCompletedAt,
 							PullRequest: &api.PullRequest{
 								Title:  "fix something",
 								Number: 101,
@@ -870,9 +894,10 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:        "some-session-id",
-						State:     "completed",
-						CreatedAt: sampleDate,
+						ID:          "some-session-id",
+						State:       "completed",
+						CreatedAt:   sampleDate,
+						CompletedAt: sampleCompletedAt,
 						User: &api.GitHubUser{
 							Login: "octocat",
 						},
@@ -892,6 +917,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review
 				Started on behalf of octocat about 6 hours ago
+				Duration 5m0s
 
 				To follow session logs, try:
 				gh agent-task view 'some-session-id' --log --follow
@@ -913,9 +939,10 @@ func Test_viewRun(t *testing.T) {
 				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
 					assert.Equal(t, "some-session-id", id)
 					return &capi.Session{
-						ID:        "some-session-id",
-						State:     "completed",
-						CreatedAt: sampleDate,
+						ID:          "some-session-id",
+						State:       "completed",
+						CreatedAt:   sampleDate,
+						CompletedAt: sampleCompletedAt,
 						User: &api.GitHubUser{
 							Login: "octocat",
 						},
@@ -949,6 +976,7 @@ func Test_viewRun(t *testing.T) {
 			wantOut: heredoc.Doc(`
 				Ready for review
 				Started on behalf of octocat about 6 hours ago
+				Duration 5m0s
 
 				(rendered:) <raw-logs-one>
 				(rendered:) <raw-logs-two>

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -198,6 +198,7 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 		return nil, nil, err
 	}
 
+	// TODO: Decouple the PR finder from IO
 	// TODO(josebalius): Should we be guarding here?
 	if !opts.DisableProgress && f.progress != nil {
 		f.progress.StartProgressIndicator()

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -103,6 +103,8 @@ type FindOptions struct {
 	// States lists the possible PR states to scope the PR-for-branch lookup to.
 	States []string
 
+	DisableProgress bool
+
 	Detector fd.Detector
 }
 
@@ -197,7 +199,7 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 	}
 
 	// TODO(josebalius): Should we be guarding here?
-	if f.progress != nil {
+	if !opts.DisableProgress && f.progress != nil {
 		f.progress.StartProgressIndicator()
 		defer f.progress.StopProgressIndicator()
 	}


### PR DESCRIPTION
This PR fixes these issues with the `agent-task view` command:

- Omit the session overview when run with `--log`.
- Conflicting progress indicators when using `PRFinder` to locate the session via PR number/URL.
- Completed agent sessions should be displayed as *Ready for review*.
- If the task is completed, the duration should be displayed.
- The number of premium requests should be dispalyed.


This is how the output looks:

<img width="570" height="156" alt="gh-agent-task-view-with-duration-and-prem-requests" src="https://github.com/user-attachments/assets/d31e9cb2-3a41-4fcc-ae5c-853eeb7555f3" />


