### PR TITLE
`gh agent-task create`: remove unnecessary prompt and use pager

### DIFF
--- a/pkg/cmd/agent-task/create/create.go
+++ b/pkg/cmd/agent-task/create/create.go
@@ -70,6 +70,9 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			// Populate ProblemStatement from arg
 			if len(args) > 0 {
 				opts.ProblemStatement = args[0]
+				if strings.TrimSpace(opts.ProblemStatement) == "" {
+					return cmdutil.FlagErrorf("task description cannot be empty")
+				}
 			} else if opts.ProblemStatementFile == "" && !opts.IO.CanPrompt() {
 				return cmdutil.FlagErrorf("a task description or -F is required when running non-interactively")
 			}

--- a/pkg/cmd/agent-task/create/create_test.go
+++ b/pkg/cmd/agent-task/create/create_test.go
@@ -47,6 +47,21 @@ func TestNewCmdCreate(t *testing.T) {
 			},
 		},
 		{
+			name:    "empty arg",
+			args:    "''",
+			wantErr: "task description cannot be empty",
+		},
+		{
+			name:    "whitespace arg",
+			args:    "'   '",
+			wantErr: "task description cannot be empty",
+		},
+		{
+			name:    "whitespace and newline arg",
+			args:    "'\n'",
+			wantErr: "task description cannot be empty",
+		},
+		{
 			name:    "mutually exclusive arg and file",
 			args:    "'some task inline' -F foo.md",
 			wantErr: "only one of -F or arg can be provided",
@@ -96,7 +111,7 @@ func TestNewCmdCreate(t *testing.T) {
 
 			_, err = cmd.ExecuteC()
 			if tt.wantErr != "" {
-				require.Error(t, err, tt.wantErr)
+				require.EqualError(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/cmd/agent-task/create/create_test.go
+++ b/pkg/cmd/agent-task/create/create_test.go
@@ -473,8 +473,6 @@ func Test_createRun(t *testing.T) {
 				}
 			},
 			wantStdout: heredoc.Doc(`
-				https://github.com/OWNER/REPO/pull/42/agent-sessions/sess1
-				
 				(rendered:) <raw-logs-one>
 				(rendered:) <raw-logs-two>
 			`),


### PR DESCRIPTION
With this PR:
- unnecessary prompts are removed
- a pager is started when `--follow` is provided, in which case we don't print the session URL (hence no polling for it)