### PR TITLE
`gh agent-task view`: display session error if any

### DIFF
--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -43,6 +43,7 @@ type session struct {
 	EventURL        string    `json:"event_url"`
 	EventType       string    `json:"event_type"`
 	PremiumRequests float64   `json:"premium_requests"`
+	WorkflowRunID   uint64    `json:"workflow_run_id,omitempty"`
 	Error           *struct {
 		Code    string `json:"code"`
 		Message string `json:"message"`
@@ -87,6 +88,7 @@ type Session struct {
 	EventURL        string
 	EventType       string
 	PremiumRequests float64
+	WorkflowRunID   uint64
 	Error           *SessionError
 
 	PullRequest *api.PullRequest
@@ -467,6 +469,7 @@ func fromAPISession(s session) *Session {
 		EventURL:        s.EventURL,
 		EventType:       s.EventType,
 		PremiumRequests: s.PremiumRequests,
+		WorkflowRunID:   s.WorkflowRunID,
 	}
 	if s.Error != nil {
 		result.Error = &SessionError{

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -339,6 +339,8 @@ func (c *CAPIClient) hydrateSessionPullRequestsAndUsers(sessions []session) ([]*
 	for _, session := range sessions {
 		if session.ResourceType == "pull" {
 			prNodeID := session.ResourceGlobalID
+			// TODO: probably this can be dropped since the API should always
+			// keep returning the resource global ID.
 			if session.ResourceGlobalID == "" {
 				prNodeID = generatePullRequestNodeID(int64(session.RepoID), session.ResourceID)
 			}

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -43,6 +43,10 @@ type session struct {
 	EventURL        string    `json:"event_url"`
 	EventType       string    `json:"event_type"`
 	PremiumRequests float64   `json:"premium_requests"`
+	Error           *struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
 }
 
 // A shim of a full pull request because looking up by node ID
@@ -83,9 +87,15 @@ type Session struct {
 	EventURL        string
 	EventType       string
 	PremiumRequests float64
+	Error           *SessionError
 
 	PullRequest *api.PullRequest
 	User        *api.GitHubUser
+}
+
+type SessionError struct {
+	Code    string
+	Message string
 }
 
 // ListLatestSessionsForViewer lists all agent sessions for the
@@ -442,7 +452,7 @@ func generateUserNodeID(userID int64) string {
 }
 
 func fromAPISession(s session) *Session {
-	return &Session{
+	result := Session{
 		ID:              s.ID,
 		Name:            s.Name,
 		UserID:          s.UserID,
@@ -460,4 +470,11 @@ func fromAPISession(s session) *Session {
 		EventType:       s.EventType,
 		PremiumRequests: s.PremiumRequests,
 	}
+	if s.Error != nil {
+		result.Error = &SessionError{
+			Code:    s.Error.Code,
+			Message: s.Error.Message,
+		}
+	}
+	return &result
 }

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -101,7 +101,7 @@ type SessionError struct {
 	Message string
 }
 
-type Resource struct {
+type resource struct {
 	ID                   string            `json:"id"`
 	UserID               uint64            `json:"user_id"`
 	ResourceType         string            `json:"resource_type"`
@@ -295,7 +295,7 @@ func (c *CAPIClient) ListSessionsByResourceID(ctx context.Context, resourceType 
 		return nil, fmt.Errorf("failed to list sessions: %s", res.Status)
 	}
 
-	var response Resource
+	var response resource
 	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
 		return nil, fmt.Errorf("failed to decode sessions response: %w", err)
 	}

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -302,16 +302,19 @@ func (c *CAPIClient) ListSessionsByResourceID(ctx context.Context, resourceType 
 
 	sessions := make([]session, 0, len(response.Sessions))
 	for _, s := range response.Sessions {
-		sessions = append(sessions, session{
+		session := session{
 			ID:               s.SessionID,
 			Name:             s.Name,
 			UserID:           int64(response.UserID),
 			ResourceType:     response.ResourceType,
 			ResourceID:       response.ResourceID,
 			ResourceGlobalID: response.ResourceGlobalID,
-			LastUpdatedAt:    time.Unix(s.SessionLastUpdatedAt, 0),
 			State:            s.SessionState,
-		})
+		}
+		if s.SessionLastUpdatedAt != 0 {
+			session.LastUpdatedAt = time.Unix(s.SessionLastUpdatedAt, 0).UTC()
+		}
+		sessions = append(sessions, session)
 	}
 
 	result, err := c.hydrateSessionPullRequestsAndUsers(sessions)

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -108,7 +108,6 @@ func (c *CAPIClient) ListLatestSessionsForViewer(ctx context.Context, limit int)
 	url := baseCAPIURL + "/agents/sessions"
 	pageSize := defaultSessionsPerPage
 
-	sessions := make([]session, 0, limit+pageSize)
 	seenResources := make(map[int64]struct{})
 	latestSessions := make([]session, 0, limit)
 	for page := 1; ; page++ {
@@ -140,7 +139,6 @@ func (c *CAPIClient) ListLatestSessionsForViewer(ctx context.Context, limit int)
 
 		// Process only the newly fetched page worth of sessions.
 		pageSessions := response.Sessions
-		sessions = append(sessions, pageSessions...)
 
 		// De-duplicate sessions by resource ID.
 		// Because the API returns newest first, once we've seen

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -330,10 +330,6 @@ func (c *CAPIClient) hydrateSessionPullRequestsAndUsers(sessions []session) ([]*
 		return nil, nil
 	}
 
-	// When the session is fetched via the resources endpoint, the session user
-	// ID can be zero, which means it's the viewer user.
-	var includeViewer bool
-
 	prNodeIds := make([]string, 0, len(sessions))
 	userNodeIds := make([]string, 0, len(sessions))
 	for _, session := range sessions {
@@ -349,13 +345,9 @@ func (c *CAPIClient) hydrateSessionPullRequestsAndUsers(sessions []session) ([]*
 			}
 		}
 
-		if session.UserID != 0 {
-			userNodeId := generateUserNodeID(session.UserID)
-			if !slices.Contains(userNodeIds, userNodeId) {
-				userNodeIds = append(userNodeIds, userNodeId)
-			}
-		} else {
-			includeViewer = true
+		userNodeId := generateUserNodeID(session.UserID)
+		if !slices.Contains(userNodeIds, userNodeId) {
+			userNodeIds = append(userNodeIds, userNodeId)
 		}
 	}
 	apiClient := api.NewClientFromHTTP(c.httpClient)
@@ -366,7 +358,6 @@ func (c *CAPIClient) hydrateSessionPullRequestsAndUsers(sessions []session) ([]*
 			PullRequest sessionPullRequest `graphql:"... on PullRequest"`
 			User        api.GitHubUser     `graphql:"... on User"`
 		} `graphql:"nodes(ids: $ids)"`
-		Viewer api.GitHubUser `graphql:"viewer @include(if: $includeViewer)"`
 	}
 
 	ids := make([]string, 0, len(prNodeIds)+len(userNodeIds))
@@ -376,8 +367,7 @@ func (c *CAPIClient) hydrateSessionPullRequestsAndUsers(sessions []session) ([]*
 	// TODO handle pagination
 	host, _ := c.authCfg.DefaultHost()
 	err := apiClient.Query(host, "FetchPRsAndUsersForAgentTaskSessions", &resp, map[string]any{
-		"ids":           ids,
-		"includeViewer": includeViewer,
+		"ids": ids,
 	})
 
 	if err != nil {
@@ -413,12 +403,7 @@ func (c *CAPIClient) hydrateSessionPullRequestsAndUsers(sessions []session) ([]*
 	for _, s := range sessions {
 		newSession := fromAPISession(s)
 		newSession.PullRequest = prMap[strconv.FormatInt(s.ResourceID, 10)]
-		if s.UserID != 0 {
-			newSession.User = userMap[s.UserID]
-		} else {
-			newSession.UserID = resp.Viewer.DatabaseID
-			newSession.User = &resp.Viewer
-		}
+		newSession.User = userMap[s.UserID]
 		newSessions = append(newSessions, newSession)
 	}
 

--- a/pkg/cmd/agent-task/capi/sessions_test.go
+++ b/pkg/cmd/agent-task/capi/sessions_test.go
@@ -1300,108 +1300,6 @@ func TestListSessionsByResourceID(t *testing.T) {
 						sampleDateString,
 					), func(q string, vars map[string]interface{}) {
 						assert.Equal(t, []interface{}{"PR_kwDNA-jNB9A", "U_kgAB"}, vars["ids"])
-						assert.Equal(t, false, vars["includeViewer"])
-					}),
-				)
-			},
-			wantOut: []*Session{
-				{
-					ID:            "sess1",
-					CreatedAt:     time.Time{},
-					LastUpdatedAt: sampleDate,
-					Name:          "Build artifacts",
-					UserID:        1,
-					State:         "completed",
-					ResourceType:  "pull",
-					ResourceID:    2000,
-					PullRequest: &api.PullRequest{
-						ID:             "PR_node",
-						FullDatabaseID: "2000",
-						Number:         42,
-						Title:          "Improve docs",
-						State:          "OPEN",
-						IsDraft:        true,
-						URL:            "https://github.com/OWNER/REPO/pull/42",
-						Body:           "",
-						CreatedAt:      sampleDate,
-						UpdatedAt:      sampleDate,
-						Repository: &api.PRRepository{
-							NameWithOwner: "OWNER/REPO",
-						},
-					},
-					User: &api.GitHubUser{
-						Login:      "octocat",
-						Name:       "Octocat",
-						DatabaseID: 1,
-					},
-				},
-			},
-		},
-		{
-			name:  "single session with zero user ID",
-			limit: 10,
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.WithHost(httpmock.REST("GET", "agents/resource/pull/999"), "api.githubcopilot.com"),
-					httpmock.StringResponse(heredoc.Docf(`
-						{
-							"id": "resource:pull:2000",
-							"user_id": 0,
-							"resource_global_id": "PR_kwDNA-jNB9A",
-							"resource_type": "pull",
-							"resource_id": 2000,
-							"session_count": 1,
-							"last_updated_at": %[1]d,
-							"state": "completed",
-							"resource_state": "draft",
-							"sessions": [
-								{
-									"id": "sess1",
-									"name": "Build artifacts",
-									"state": "completed",
-									"last_updated_at": %[1]d
-								}
-							]
-						}`,
-						sampleDateTimestamp,
-					)),
-				)
-				// GraphQL hydration
-				reg.Register(
-					httpmock.GraphQL(`query FetchPRsAndUsersForAgentTaskSessions\b`),
-					httpmock.GraphQLQuery(heredoc.Docf(`
-						{
-							"data": {
-								"nodes": [
-									{
-										"__typename": "PullRequest",
-										"id": "PR_node",
-										"fullDatabaseId": "2000",
-										"number": 42,
-										"title": "Improve docs",
-										"state": "OPEN",
-										"isDraft": true,
-										"url": "https://github.com/OWNER/REPO/pull/42",
-										"body": "",
-										"createdAt": "%[1]s",
-										"updatedAt": "%[1]s",
-										"repository": {
-											"nameWithOwner": "OWNER/REPO"
-										}
-									}
-								],
-								"viewer": {
-									"login": "octocat",
-									"name": "Octocat",
-									"databaseId": 1
-								}
-							}
-						}`,
-						sampleDateString,
-					), func(q string, vars map[string]interface{}) {
-						// Should not fetch user by ID since it's zero
-						assert.Equal(t, []interface{}{"PR_kwDNA-jNB9A"}, vars["ids"])
-						assert.Equal(t, true, vars["includeViewer"])
 					}),
 				)
 			},
@@ -1525,7 +1423,6 @@ func TestListSessionsByResourceID(t *testing.T) {
 						sampleDateString,
 					), func(q string, vars map[string]interface{}) {
 						assert.Equal(t, []interface{}{"PR_kwDNA-jNB9A", "U_kgAB"}, vars["ids"])
-						assert.Equal(t, false, vars["includeViewer"])
 					}),
 				)
 			},

--- a/pkg/cmd/agent-task/capi/sessions_test.go
+++ b/pkg/cmd/agent-task/capi/sessions_test.go
@@ -988,6 +988,112 @@ func TestListLatestSessionsForViewer(t *testing.T) {
 			},
 		},
 		{
+			name:  "workflow run id is included",
+			limit: 10,
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.WithHost(
+						httpmock.QueryMatcher("GET", "agents/sessions", url.Values{
+							"page_number": {"1"},
+							"page_size":   {"50"},
+							"sort":        {"last_updated_at,desc"},
+						}),
+						"api.githubcopilot.com",
+					),
+					httpmock.StringResponse(heredoc.Docf(`
+						{
+							"sessions": [
+								{
+									"id": "sessA",
+									"name": "Build artifacts",
+									"user_id": 1,
+									"agent_id": 2,
+									"logs": "",
+									"state": "failed",
+									"owner_id": 10,
+									"repo_id": 1000,
+									"resource_type": "pull",
+									"resource_id": 3000,
+									"created_at": "%[1]s",
+									"workflow_run_id": 9999
+								}
+							]
+						}`,
+						sampleDateString,
+					)),
+				)
+
+				// GraphQL hydration
+				reg.Register(
+					httpmock.GraphQL(`query FetchPRsAndUsersForAgentTaskSessions\b`),
+					httpmock.GraphQLQuery(heredoc.Docf(`
+						{
+							"data": {
+								"nodes": [
+									{
+										"__typename": "PullRequest",
+										"id": "PR_node3000",
+										"fullDatabaseId": "3000",
+										"number": 100,
+										"title": "Improve docs",
+										"state": "OPEN",
+										"isDraft": true,
+										"url": "https://github.com/OWNER/REPO/pull/100",
+										"body": "",
+										"createdAt": "%[1]s",
+										"updatedAt": "%[1]s",
+										"repository": {"nameWithOwner": "OWNER/REPO"}
+									},
+									{
+										"__typename": "User",
+										"login": "octocat",
+										"name": "Octocat",
+										"databaseId": 1
+									}
+								]
+							}
+						}`,
+						sampleDateString,
+					), func(q string, vars map[string]interface{}) {
+						// Expected encoded node IDs for resource IDs 3000 and user octocat
+						assert.Equal(t, []interface{}{"PR_kwDNA-jNC7g", "U_kgAB"}, vars["ids"])
+					}),
+				)
+			},
+			wantOut: []*Session{
+				{
+					ID:            "sessA",
+					Name:          "Build artifacts",
+					UserID:        1,
+					AgentID:       2,
+					Logs:          "",
+					State:         "failed",
+					OwnerID:       10,
+					RepoID:        1000,
+					ResourceType:  "pull",
+					ResourceID:    3000,
+					CreatedAt:     sampleDate,
+					WorkflowRunID: 9999,
+					PullRequest: &api.PullRequest{
+						ID:             "PR_node3000",
+						FullDatabaseID: "3000",
+						Number:         100,
+						Title:          "Improve docs",
+						State:          "OPEN",
+						IsDraft:        true,
+						URL:            "https://github.com/OWNER/REPO/pull/100",
+						Body:           "",
+						CreatedAt:      sampleDate,
+						UpdatedAt:      sampleDate,
+						Repository: &api.PRRepository{
+							NameWithOwner: "OWNER/REPO",
+						},
+					},
+					User: &api.GitHubUser{Login: "octocat", Name: "Octocat", DatabaseID: 1},
+				},
+			},
+		},
+		{
 			name:  "API error",
 			limit: 10,
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -333,7 +333,9 @@ func printSession(opts *ViewOptions, session *capi.Session) {
 		fmt.Fprintf(opts.IO.Out, "%s %s\n", cs.FailureIconWithColor(cs.Red), message)
 
 		if workflowRunURL != "" {
-			fmt.Fprintf(opts.IO.Out, "See the detailed logs in GitHub Actions:\n%s\n", workflowRunURL)
+			// We don't need to prefix the link with any text (e.g. "checkout the logs here")
+			// because the error message already contains all the information.
+			fmt.Fprintf(opts.IO.Out, "%s\n", workflowRunURL)
 		}
 	}
 

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -224,10 +224,6 @@ func viewRun(opts *ViewOptions) error {
 			prURL = pr.URL
 		}
 
-		// TODO(babakks): currently we just fetch a pre-defined number of
-		// matching sessions to avoid hitting the API too many times, but it's
-		// technically possible for a PR to be associated with lots of sessions
-		// (i.e. above our selected limit).
 		sessions, err := capiClient.ListSessionsByResourceID(ctx, "pull", prID, defaultLimit)
 		if err != nil {
 			return fmt.Errorf("failed to list sessions for pull request: %w", err)

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -317,6 +317,26 @@ func printSession(opts *ViewOptions, session *capi.Session) {
 
 	fmt.Fprintf(opts.IO.Out, "%s%s\n", cs.Muted(usedPremiumRequestsNote), cs.Muted(durationNote))
 
+	if session.Error != nil {
+		var workflowRunURL string
+		if session.WorkflowRunID != 0 && session.PullRequest != nil {
+			if u, err := url.Parse(session.PullRequest.URL); err == nil {
+				workflowRunURL = fmt.Sprintf("%s://%s/%s/actions/runs/%d", u.Scheme, u.Host, session.PullRequest.Repository.NameWithOwner, session.WorkflowRunID)
+			}
+		}
+
+		message := session.Error.Message
+		if message == "" {
+			message = "An error occurred"
+		}
+		fmt.Fprintln(opts.IO.Out, "")
+		fmt.Fprintf(opts.IO.Out, "%s %s\n", cs.FailureIconWithColor(cs.Red), message)
+
+		if workflowRunURL != "" {
+			fmt.Fprintf(opts.IO.Out, "See the detailed logs in GitHub Actions:\n%s\n", workflowRunURL)
+		}
+	}
+
 	if !opts.Log {
 		fmt.Fprintln(opts.IO.Out, "")
 		fmt.Fprintf(opts.IO.Out, "For detailed session logs, try:\ngh agent-task view '%s' --log\n", session.ID)

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -337,8 +337,7 @@ func printSession(opts *ViewOptions, session *capi.Session) {
 		if message == "" {
 			message = "An error occurred"
 		}
-		fmt.Fprintln(opts.IO.Out, "")
-		fmt.Fprintf(opts.IO.Out, "%s %s\n", cs.FailureIconWithColor(cs.Red), message)
+		fmt.Fprintf(opts.IO.Out, "\n%s %s\n", cs.FailureIconWithColor(cs.Red), message)
 
 		if workflowRunURL != "" {
 			// We don't need to prefix the link with any text (e.g. "checkout the logs here")
@@ -348,16 +347,13 @@ func printSession(opts *ViewOptions, session *capi.Session) {
 	}
 
 	if !opts.Log {
-		fmt.Fprintln(opts.IO.Out, "")
-		fmt.Fprintf(opts.IO.Out, "For detailed session logs, try:\ngh agent-task view '%s' --log\n", session.ID)
+		fmt.Fprintf(opts.IO.Out, "\nFor detailed session logs, try:\ngh agent-task view '%s' --log\n", session.ID)
 	} else if !opts.Follow {
-		fmt.Fprintln(opts.IO.Out, "")
-		fmt.Fprintf(opts.IO.Out, "To follow session logs, try:\ngh agent-task view '%s' --log --follow\n", session.ID)
+		fmt.Fprintf(opts.IO.Out, "\nTo follow session logs, try:\ngh agent-task view '%s' --log --follow\n", session.ID)
 	}
 
 	if session.PullRequest != nil {
-		fmt.Fprintln(opts.IO.Out, "")
-		fmt.Fprintln(opts.IO.Out, cs.Muted("View this session on GitHub:"))
+		fmt.Fprintln(opts.IO.Out, cs.Muted("\nView this session on GitHub:"))
 		fmt.Fprintln(opts.IO.Out, cs.Muted(fmt.Sprintf("%s/agent-sessions/%s", session.PullRequest.URL, url.PathEscape(session.ID))))
 	}
 }

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -296,17 +296,10 @@ func viewRun(opts *ViewOptions) error {
 func printSession(opts *ViewOptions, session *capi.Session) {
 	cs := opts.IO.ColorScheme()
 
-	if session.PullRequest != nil {
-		fmt.Fprintf(opts.IO.Out, "%s • %s • %s%s\n",
-			shared.ColorFuncForSessionState(*session, cs)(shared.SessionStateString(session.State)),
-			cs.Bold(session.PullRequest.Title),
-			session.PullRequest.Repository.NameWithOwner,
-			cs.ColorFromString(prShared.ColorForPRState(*session.PullRequest))(fmt.Sprintf("#%d", session.PullRequest.Number)),
-		)
-	} else {
-		// This can happen when the session is just created and a PR is not yet available for it
-		fmt.Fprintf(opts.IO.Out, "%s\n", shared.ColorFuncForSessionState(*session, cs)(shared.SessionStateString(session.State)))
-	}
+	fmt.Fprintf(opts.IO.Out, "%s • %s\n",
+		shared.ColorFuncForSessionState(*session, cs)(shared.SessionStateString(session.State)),
+		cs.Bold(session.Name),
+	)
 
 	if session.User != nil {
 		fmt.Fprintf(opts.IO.Out, "Started on behalf of %s %s\n", session.User.Login, text.FuzzyAgo(time.Now(), session.CreatedAt))
@@ -324,6 +317,15 @@ func printSession(opts *ViewOptions, session *capi.Session) {
 	}
 
 	fmt.Fprintf(opts.IO.Out, "%s%s\n", cs.Muted(usedPremiumRequestsNote), cs.Muted(durationNote))
+
+	// Note that when the session is just created, a PR is not yet available for it.
+	if session.PullRequest != nil {
+		fmt.Fprintf(opts.IO.Out, "\n%s%s • %s\n",
+			session.PullRequest.Repository.NameWithOwner,
+			cs.ColorFromString(prShared.ColorForPRState(*session.PullRequest))(fmt.Sprintf("#%d", session.PullRequest.Number)),
+			cs.Bold(session.PullRequest.Title),
+		)
+	}
 
 	if session.Error != nil {
 		var workflowRunURL string
@@ -347,9 +349,9 @@ func printSession(opts *ViewOptions, session *capi.Session) {
 	}
 
 	if !opts.Log {
-		fmt.Fprintf(opts.IO.Out, "\nFor detailed session logs, try:\ngh agent-task view '%s' --log\n", session.ID)
+		fmt.Fprint(opts.IO.Out, cs.Mutedf("\nFor detailed session logs, try:\ngh agent-task view '%s' --log\n", session.ID))
 	} else if !opts.Follow {
-		fmt.Fprintf(opts.IO.Out, "\nTo follow session logs, try:\ngh agent-task view '%s' --log --follow\n", session.ID)
+		fmt.Fprint(opts.IO.Out, cs.Mutedf("\nTo follow session logs, try:\ngh agent-task view '%s' --log --follow\n", session.ID))
 	}
 
 	if session.PullRequest != nil {

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -215,6 +215,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "completed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						CompletedAt:     sampleCompletedAt,
 						PremiumRequests: 1.5,
@@ -233,9 +234,11 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Ready for review • fix something • OWNER/REPO#101
+				Ready for review • session one
 				Started on behalf of octocat about 6 hours ago
 				Used 1.5 premium request(s) • Duration 5m0s
+
+				OWNER/REPO#101 • fix something
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -258,6 +261,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "completed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						CompletedAt:     sampleCompletedAt,
 						PremiumRequests: 1.5,
@@ -273,9 +277,11 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Ready for review • fix something • OWNER/REPO#101
+				Ready for review • session one
 				Started about 6 hours ago
 				Used 1.5 premium request(s) • Duration 5m0s
+
+				OWNER/REPO#101 • fix something
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -298,6 +304,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "completed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						CompletedAt:     sampleCompletedAt,
 						PremiumRequests: 1.5,
@@ -308,7 +315,7 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Ready for review
+				Ready for review • session one
 				Started on behalf of octocat about 6 hours ago
 				Used 1.5 premium request(s) • Duration 5m0s
 
@@ -330,6 +337,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "completed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						CompletedAt:     sampleCompletedAt,
 						PremiumRequests: 1.5,
@@ -337,7 +345,7 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Ready for review
+				Ready for review • session one
 				Started about 6 hours ago
 				Used 1.5 premium request(s) • Duration 5m0s
 
@@ -358,6 +366,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "completed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						CompletedAt:     sampleCompletedAt,
 						PremiumRequests: 0,
@@ -376,9 +385,11 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Ready for review • fix something • OWNER/REPO#101
+				Ready for review • session one
 				Started on behalf of octocat about 6 hours ago
 				Used 0 premium request(s) • Duration 5m0s
+
+				OWNER/REPO#101 • fix something
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -400,6 +411,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "in_progress",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						PremiumRequests: 1.5,
 						PullRequest: &api.PullRequest{
@@ -417,9 +429,11 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				In progress • fix something • OWNER/REPO#101
+				In progress • session one
 				Started on behalf of octocat about 6 hours ago
 				Used 1.5 premium request(s)
+
+				OWNER/REPO#101 • fix something
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -441,6 +455,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "failed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						PremiumRequests: 1.5,
 						Error: &capi.SessionError{
@@ -461,9 +476,11 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Failed • fix something • OWNER/REPO#101
+				Failed • session one
 				Started on behalf of octocat about 6 hours ago
 				Used 1.5 premium request(s)
+
+				OWNER/REPO#101 • fix something
 
 				X blah blah
 
@@ -487,6 +504,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "failed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						PremiumRequests: 1.5,
 						WorkflowRunID:   9999,
@@ -508,9 +526,11 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Failed • fix something • OWNER/REPO#101
+				Failed • session one
 				Started on behalf of octocat about 6 hours ago
 				Used 1.5 premium request(s)
+
+				OWNER/REPO#101 • fix something
 
 				X blah blah
 				https://github.com/OWNER/REPO/actions/runs/9999
@@ -696,6 +716,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "completed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						CompletedAt:     sampleCompletedAt,
 						PremiumRequests: 1.5,
@@ -714,9 +735,11 @@ func Test_viewRun(t *testing.T) {
 				}
 			},
 			wantOut: heredoc.Doc(`
-				Ready for review • fix something • OWNER/REPO#101
+				Ready for review • session one
 				Started on behalf of octocat about 6 hours ago
 				Used 1.5 premium request(s) • Duration 5m0s
+
+				OWNER/REPO#101 • fix something
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -799,9 +822,11 @@ func Test_viewRun(t *testing.T) {
 				)
 			},
 			wantOut: heredoc.Doc(`
-				Ready for review • fix something • OWNER/REPO#101
+				Ready for review • session one
 				Started on behalf of octocat about 6 hours ago
 				Used 1.5 premium request(s) • Duration 5m0s
+
+				OWNER/REPO#101 • fix something
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log
@@ -886,9 +911,11 @@ func Test_viewRun(t *testing.T) {
 				)
 			},
 			wantOut: heredoc.Doc(`
-				Ready for review • fix something • OWNER/REPO#101
+				Ready for review • session one
 				Started on behalf of octocat about 6 hours ago
 				Used 1.5 premium request(s) • Duration 5m0s
+
+				OWNER/REPO#101 • fix something
 
 				For detailed session logs, try:
 				gh agent-task view 'some-session-id' --log

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -572,6 +572,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "completed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						CompletedAt:     sampleCompletedAt,
 						PremiumRequests: 1.5,
@@ -596,6 +597,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "completed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						CompletedAt:     sampleCompletedAt,
 						PremiumRequests: 1.5,
@@ -970,6 +972,7 @@ func Test_viewRun(t *testing.T) {
 						{
 							ID:              "some-session-id",
 							State:           "completed",
+							Name:            "session one",
 							CreatedAt:       sampleDate,
 							CompletedAt:     sampleCompletedAt,
 							PremiumRequests: 1.5,
@@ -1127,6 +1130,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "completed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						CompletedAt:     sampleCompletedAt,
 						PremiumRequests: 1.5,
@@ -1166,6 +1170,7 @@ func Test_viewRun(t *testing.T) {
 					return &capi.Session{
 						ID:              "some-session-id",
 						State:           "completed",
+						Name:            "session one",
 						CreatedAt:       sampleDate,
 						CompletedAt:     sampleCompletedAt,
 						PremiumRequests: 1.5,

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -682,22 +682,33 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:              "some-session-id",
-							State:           "completed",
-							CreatedAt:       sampleDate,
-							CompletedAt:     sampleCompletedAt,
-							PremiumRequests: 1.5,
-							PullRequest: &api.PullRequest{
-								Title:  "fix something",
-								Number: 101,
-								URL:    "https://github.com/OWNER/REPO/pull/101",
-								Repository: &api.PRRepository{
-									NameWithOwner: "OWNER/REPO",
-								},
+							ID:            "some-session-id",
+							Name:          "session one",
+							State:         "completed",
+							LastUpdatedAt: sampleCompletedAt,
+							// Rest of the fields are not not meant to be used or relied upon
+						},
+					}, nil
+				}
+
+				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
+					assert.Equal(t, "some-session-id", id)
+					return &capi.Session{
+						ID:              "some-session-id",
+						State:           "completed",
+						CreatedAt:       sampleDate,
+						CompletedAt:     sampleCompletedAt,
+						PremiumRequests: 1.5,
+						PullRequest: &api.PullRequest{
+							Title:  "fix something",
+							Number: 101,
+							URL:    "https://github.com/OWNER/REPO/pull/101",
+							Repository: &api.PRRepository{
+								NameWithOwner: "OWNER/REPO",
 							},
-							User: &api.GitHubUser{
-								Login: "octocat",
-							},
+						},
+						User: &api.GitHubUser{
+							Login: "octocat",
 						},
 					}, nil
 				}
@@ -735,42 +746,42 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:              "some-session-id",
-							Name:            "session one",
-							State:           "completed",
-							CreatedAt:       sampleDate,
-							CompletedAt:     sampleCompletedAt,
-							PremiumRequests: 1.5,
-							PullRequest: &api.PullRequest{
-								Title:  "fix something",
-								Number: 101,
-								URL:    "https://github.com/OWNER/REPO/pull/101",
-								Repository: &api.PRRepository{
-									NameWithOwner: "OWNER/REPO",
-								},
-							},
-							User: &api.GitHubUser{
-								Login: "octocat",
-							},
+							ID:            "some-session-id",
+							Name:          "session one",
+							State:         "completed",
+							LastUpdatedAt: sampleCompletedAt,
+							// Rest of the fields are not not meant to be used or relied upon
 						},
 						{
-							ID:              "some-other-session-id",
-							Name:            "session two",
-							State:           "completed",
-							CreatedAt:       sampleDate,
-							CompletedAt:     sampleCompletedAt,
-							PremiumRequests: 1.5,
-							PullRequest: &api.PullRequest{
-								Title:  "fix something",
-								Number: 101,
-								URL:    "https://github.com/OWNER/REPO/pull/101",
-								Repository: &api.PRRepository{
-									NameWithOwner: "OWNER/REPO",
-								},
+							ID:            "some-other-session-id",
+							Name:          "session two",
+							State:         "completed",
+							LastUpdatedAt: sampleCompletedAt,
+							// Rest of the fields are not not meant to be used or relied upon
+						},
+					}, nil
+				}
+
+				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
+					assert.Equal(t, "some-session-id", id)
+					return &capi.Session{
+						ID:              "some-session-id",
+						Name:            "session one",
+						State:           "completed",
+						CreatedAt:       sampleDate,
+						LastUpdatedAt:   sampleCompletedAt,
+						CompletedAt:     sampleCompletedAt,
+						PremiumRequests: 1.5,
+						PullRequest: &api.PullRequest{
+							Title:  "fix something",
+							Number: 101,
+							URL:    "https://github.com/OWNER/REPO/pull/101",
+							Repository: &api.PRRepository{
+								NameWithOwner: "OWNER/REPO",
 							},
-							User: &api.GitHubUser{
-								Login: "octocat",
-							},
+						},
+						User: &api.GitHubUser{
+							Login: "octocat",
 						},
 					}, nil
 				}
@@ -779,11 +790,11 @@ func Test_viewRun(t *testing.T) {
 				pm.RegisterSelect(
 					"Select a session",
 					[]string{
-						"✓ session one • about 6 hours ago",
-						"✓ session two • about 6 hours ago",
+						"✓ session one • updated about 5 hours ago",
+						"✓ session two • updated about 5 hours ago",
 					},
 					func(_, _ string, opts []string) (int, error) {
-						return prompter.IndexFor(opts, "✓ session one • about 6 hours ago")
+						return prompter.IndexFor(opts, "✓ session one • updated about 5 hours ago")
 					},
 				)
 			},
@@ -822,42 +833,42 @@ func Test_viewRun(t *testing.T) {
 					assert.Equal(t, defaultLimit, limit)
 					return []*capi.Session{
 						{
-							ID:              "some-session-id",
-							Name:            "session one",
-							State:           "completed",
-							CreatedAt:       sampleDate,
-							CompletedAt:     sampleCompletedAt,
-							PremiumRequests: 1.5,
-							PullRequest: &api.PullRequest{
-								Title:  "fix something",
-								Number: 101,
-								URL:    "https://github.com/OWNER/REPO/pull/101",
-								Repository: &api.PRRepository{
-									NameWithOwner: "OWNER/REPO",
-								},
-							},
-							User: &api.GitHubUser{
-								Login: "octocat",
-							},
+							ID:            "some-session-id",
+							Name:          "session one",
+							State:         "completed",
+							LastUpdatedAt: sampleCompletedAt,
+							// Rest of the fields are not not meant to be used or relied upon
 						},
 						{
-							ID:              "some-other-session-id",
-							Name:            "session two",
-							State:           "completed",
-							CreatedAt:       sampleDate,
-							CompletedAt:     sampleCompletedAt,
-							PremiumRequests: 1.5,
-							PullRequest: &api.PullRequest{
-								Title:  "fix something",
-								Number: 101,
-								URL:    "https://github.com/OWNER/REPO/pull/101",
-								Repository: &api.PRRepository{
-									NameWithOwner: "OWNER/REPO",
-								},
+							ID:            "some-other-session-id",
+							Name:          "session two",
+							State:         "completed",
+							LastUpdatedAt: sampleCompletedAt,
+							// Rest of the fields are not not meant to be used or relied upon
+						},
+					}, nil
+				}
+
+				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
+					assert.Equal(t, "some-session-id", id)
+					return &capi.Session{
+						ID:              "some-session-id",
+						Name:            "session one",
+						State:           "completed",
+						CreatedAt:       sampleDate,
+						CompletedAt:     sampleCompletedAt,
+						LastUpdatedAt:   sampleCompletedAt,
+						PremiumRequests: 1.5,
+						PullRequest: &api.PullRequest{
+							Title:  "fix something",
+							Number: 101,
+							URL:    "https://github.com/OWNER/REPO/pull/101",
+							Repository: &api.PRRepository{
+								NameWithOwner: "OWNER/REPO",
 							},
-							User: &api.GitHubUser{
-								Login: "octocat",
-							},
+						},
+						User: &api.GitHubUser{
+							Login: "octocat",
 						},
 					}, nil
 				}
@@ -866,11 +877,11 @@ func Test_viewRun(t *testing.T) {
 				pm.RegisterSelect(
 					"Select a session",
 					[]string{
-						"✓ session one • about 6 hours ago",
-						"✓ session two • about 6 hours ago",
+						"✓ session one • updated about 5 hours ago",
+						"✓ session two • updated about 5 hours ago",
 					},
 					func(_, _ string, opts []string) (int, error) {
-						return prompter.IndexFor(opts, "✓ session one • about 6 hours ago")
+						return prompter.IndexFor(opts, "✓ session one • updated about 5 hours ago")
 					},
 				)
 			},

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -513,7 +513,6 @@ func Test_viewRun(t *testing.T) {
 				Used 1.5 premium request(s)
 
 				X blah blah
-				See the detailed logs in GitHub Actions:
 				https://github.com/OWNER/REPO/actions/runs/9999
 
 				For detailed session logs, try:


### PR DESCRIPTION
This PR includes the session error, if any, in the overview mode.

<img width="794" height="204" alt="gh-agent-task-view-error" src="https://github.com/user-attachments/assets/c4231fb6-fc82-494d-9f08-9e9062c3b8c5" />


Also the in prompt when there are multiple sessions are now a bit different. Before, it was like:

```
? Select a session  [Use arrows to move, type to filter]
> X Review from @babakks • about 32 minutes ago
  ✓ Initial implementation • about 5 hours ago
```

But now, I had to change it to:
```
? Select a session  [Use arrows to move, type to filter]
> X Review from @babakks • updated about 32 minutes ago
  ✓ Initial implementation • updated about 5 hours ago
```