### PR TITLE
`gh agent-task create`: return proper error message when resp is not a JSON

### DIFF
--- a/pkg/cmd/agent-task/capi/job.go
+++ b/pkg/cmd/agent-task/capi/job.go
@@ -90,6 +90,11 @@ func (c *CAPIClient) CreateJob(ctx context.Context, owner, repo, problemStatemen
 
 	var j Job
 	if err := json.NewDecoder(res.Body).Decode(&j); err != nil {
+		if res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusOK { // accept 201 or 200
+			// This happens when there's an error like unauthorized (401).
+			statusText := fmt.Sprintf("%d %s", res.StatusCode, http.StatusText(res.StatusCode))
+			return nil, fmt.Errorf("failed to create job: %s", statusText)
+		}
 		return nil, fmt.Errorf("failed to decode create job response: %w", err)
 	}
 

--- a/pkg/cmd/agent-task/capi/job_test.go
+++ b/pkg/cmd/agent-task/capi/job_test.go
@@ -330,7 +330,17 @@ func TestCreateJob(t *testing.T) {
 			wantErr: "failed to create job: 500 Internal Server Error",
 		},
 		{
-			name: "invalid JSON response",
+			name: "invalid JSON response, non-HTTP 200",
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.WithHost(httpmock.REST("POST", "agents/swe/v1/jobs/OWNER/REPO"), "api.githubcopilot.com"),
+					httpmock.StatusStringResponse(401, `Unauthorized`),
+				)
+			},
+			wantErr: "failed to create job: 401 Unauthorized",
+		},
+		{
+			name: "invalid JSON response, HTTP 200",
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.WithHost(httpmock.REST("POST", "agents/swe/v1/jobs/OWNER/REPO"), "api.githubcopilot.com"),


### PR DESCRIPTION
## A/C verification

> **Given** I don't have write permissions on repo `OWNER/REPO`
> **When** I run `gh agent-task create --repo OWNER/REPO <TASK-DESCRIPTION>`
> **Then** I get a proper message (instead of JSON unmarshalling error)

Confirmed:

```
$ gh agent-task create --repo OWNER/REPO 'create a text file with lorem ipsum'
failed to create job: 401 Unauthorized
exit status 1
```