### PR TITLE
enable custom Content-Type

### DIFF
--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -61,6 +61,7 @@ type CreateOptions struct {
 	VerifyTag          bool
 	NotesFromTag       bool
 	FailOnNoCommits    bool
+	ContentType        string
 }
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
@@ -155,7 +156,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 			if len(args) > 0 {
 				opts.TagName = args[0]
-				opts.Assets, err = shared.AssetsFromArgs(args[1:])
+				opts.Assets, err = shared.AssetsFromArgs(args[1:], opts.ContentType)
 				if err != nil {
 					return err
 				}
@@ -205,6 +206,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmd.Flags().BoolVarP(&opts.VerifyTag, "verify-tag", "", false, "Abort in case the git tag doesn't already exist in the remote repository")
 	cmd.Flags().BoolVarP(&opts.NotesFromTag, "notes-from-tag", "", false, "Fetch notes from the tag annotation or message of commit associated with tag")
 	cmd.Flags().BoolVar(&opts.FailOnNoCommits, "fail-on-no-commits", false, "Fail if there are no commits since the last release (no impact on the first release)")
+	cmd.Flags().StringVar(&opts.ContentType, "content-type", "", "Content-Type to use for all uploaded assets")
 
 	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "target")
 

--- a/pkg/cmd/release/shared/upload.go
+++ b/pkg/cmd/release/shared/upload.go
@@ -36,7 +36,7 @@ type AssetForUpload struct {
 	ExistingURL string
 }
 
-func AssetsFromArgs(args []string) (assets []*AssetForUpload, err error) {
+func AssetsFromArgs(args []string, mimeType string) (assets []*AssetForUpload, err error) {
 	labeledArgs, unlabeledArgs := cmdutil.Partition(args, func(arg string) bool {
 		return strings.Contains(arg, "#")
 	})
@@ -62,6 +62,10 @@ func AssetsFromArgs(args []string) (assets []*AssetForUpload, err error) {
 			return
 		}
 
+		if mimeType == "" {
+			mimeType = typeForFilename(fi.Name())
+		}
+
 		assets = append(assets, &AssetForUpload{
 			Open: func() (io.ReadCloser, error) {
 				return os.Open(fn)
@@ -69,7 +73,7 @@ func AssetsFromArgs(args []string) (assets []*AssetForUpload, err error) {
 			Size:     fi.Size(),
 			Name:     fi.Name(),
 			Label:    label,
-			MIMEType: typeForFilename(fi.Name()),
+			MIMEType: mimeType,
 		})
 	}
 	return

--- a/pkg/cmd/release/upload/upload.go
+++ b/pkg/cmd/release/upload/upload.go
@@ -27,6 +27,7 @@ type UploadOptions struct {
 	// maximum number of simultaneous uploads
 	Concurrency       int
 	OverwriteExisting bool
+	ContentType       string
 }
 
 func NewCmdUpload(f *cmdutil.Factory, runF func(*UploadOptions) error) *cobra.Command {
@@ -43,6 +44,9 @@ func NewCmdUpload(f *cmdutil.Factory, runF func(*UploadOptions) error) *cobra.Co
 
 			To define a display label for an asset, append text starting with %[1]s#%[1]s after the
 			file name.
+
+			By default, the Content-Type of each asset is automatically detected based on the file
+			extension. Use %[1]s--content-type%[1]s to manually specify a Content-Type for all assets.
 		`, "`"),
 		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -52,7 +56,7 @@ func NewCmdUpload(f *cmdutil.Factory, runF func(*UploadOptions) error) *cobra.Co
 			opts.TagName = args[0]
 
 			var err error
-			opts.Assets, err = shared.AssetsFromArgs(args[1:])
+			opts.Assets, err = shared.AssetsFromArgs(args[1:], opts.ContentType)
 			if err != nil {
 				return err
 			}
@@ -67,6 +71,7 @@ func NewCmdUpload(f *cmdutil.Factory, runF func(*UploadOptions) error) *cobra.Co
 	}
 
 	cmd.Flags().BoolVar(&opts.OverwriteExisting, "clobber", false, "Overwrite existing assets of the same name")
+	cmd.Flags().StringVar(&opts.ContentType, "content-type", "", "Content-Type to use for all uploaded assets")
 
 	return cmd
 }


### PR DESCRIPTION
This enables three cases. Namely where Content-Type detection is:

1. incorrect,
2. one of multiple correct options or
3. unable to detect custom types.

Fixes: https://github.com/cli/cli/issues/11795