### PR TITLE
visible for  `release verify`  and `release verify-asset` cmd

### DIFF
--- a/pkg/cmd/release/verify-asset/verify_asset.go
+++ b/pkg/cmd/release/verify-asset/verify_asset.go
@@ -55,8 +55,7 @@ func NewCmdVerifyAsset(f *cmdutil.Factory, runF func(*VerifyAssetConfig) error) 
 			* The asset's digest matches the subject in the attestation
 			* The attestation is associated with the specified release
 		`),
-		Hidden: true,
-		Args:   cobra.MaximumNArgs(2),
+		Args: cobra.MaximumNArgs(2),
 		Example: heredoc.Doc(`
 			# Verify an asset from the latest release
 			$ gh release verify-asset ./dist/my-asset.zip

--- a/pkg/cmd/release/verify-asset/verify_asset.go
+++ b/pkg/cmd/release/verify-asset/verify_asset.go
@@ -40,20 +40,14 @@ func NewCmdVerifyAsset(f *cmdutil.Factory, runF func(*VerifyAssetConfig) error) 
 
 	cmd := &cobra.Command{
 		Use:   "verify-asset [<tag>] <file-path>",
-		Short: "Verify that a given asset originated from a specific GitHub Release.",
+		Short: "Verify that a given asset originated from a release",
 		Long: heredoc.Doc(`
 			Verify that a given asset file originated from a specific GitHub Release using cryptographically signed attestations.
 
-			## Understanding Verification
-
 			An attestation is a claim made by GitHub regarding a release and its assets.
 
-			## What This Command Does
-
-			This command checks that the asset you provide matches an attestation produced by GitHub for a particular release. 
-			It ensures the asset's integrity by validating:
-			* The asset's digest matches the subject in the attestation
-			* The attestation is associated with the specified release
+  			This command checks that the asset you provide matches a valid attestation for the specified release (or the latest release, if no tag is given).
+			It ensures the asset's integrity by validating that the asset's digest matches the subject in the attestation and that the attestation is associated with the release.
 		`),
 		Args: cobra.MaximumNArgs(2),
 		Example: heredoc.Doc(`

--- a/pkg/cmd/release/verify/verify.go
+++ b/pkg/cmd/release/verify/verify.go
@@ -42,19 +42,15 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 
 	cmd := &cobra.Command{
 		Use:   "verify [<tag>]",
-		Short: "Verify the attestation for a GitHub Release.",
+		Short: "Verify the attestation for a release",
 		Args:  cobra.MaximumNArgs(1),
 		Long: heredoc.Doc(`
 			Verify that a GitHub Release is accompanied by a valid cryptographically signed attestation.
 
-			## Understanding Verification
-
 			An attestation is a claim made by GitHub regarding a release and its assets.
 
-			## What This Command Does
-
-			This command checks that the specified release (or the latest release, if no tag is given) has a valid attestation.
-			It fetches the attestation for the release and prints out metadata about all assets referenced in the attestation, including their digests.
+			This command checks that the specified release (or the latest release, if no tag is given) has a valid attestation. 
+			It fetches the attestation for the release and prints metadata about all assets referenced in the attestation, including their digests.
 		`),
 		Example: heredoc.Doc(`
 			# Verify the latest release

--- a/pkg/cmd/release/verify/verify.go
+++ b/pkg/cmd/release/verify/verify.go
@@ -41,10 +41,9 @@ func NewCmdVerify(f *cmdutil.Factory, runF func(config *VerifyConfig) error) *co
 	opts := &VerifyOptions{}
 
 	cmd := &cobra.Command{
-		Use:    "verify [<tag>]",
-		Short:  "Verify the attestation for a GitHub Release.",
-		Hidden: true,
-		Args:   cobra.MaximumNArgs(1),
+		Use:   "verify [<tag>]",
+		Short: "Verify the attestation for a GitHub Release.",
+		Args:  cobra.MaximumNArgs(1),
 		Long: heredoc.Doc(`
 			Verify that a GitHub Release is accompanied by a valid cryptographically signed attestation.
 


### PR DESCRIPTION
This pull request makes the update to the `release verify` and `release verify-asset` commands by making them visible in the CLI. 
