### PR TITLE
refactor: use strings.FieldsFuncSeq to reduce memory allocations

### DIFF
--- a/pkg/cmd/gist/list/list.go
+++ b/pkg/cmd/gist/list/list.go
@@ -250,7 +250,7 @@ func printContent(io *iostreams.IOStreams, gists []shared.Gist, filter *regexp.R
 			}
 
 			if file.Content != "" {
-				for _, line := range strings.FieldsFunc(file.Content, split) {
+				for line := range strings.FieldsFuncSeq(file.Content, split) {
 					if filter.MatchString(line) {
 						if line, err = highlightMatch(line, filter, &matched, normal, cs.Highlight); err != nil {
 							return err


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->



Inspired by https://go-review.googlesource.com/c/go/+/639536

After using strings.FieldsFuncSeq, the number of memory allocations has been reduced from 2 to 0.

The following is the complete benchamark code and results:

```go
package main

import (
	"strings"
	"testing"
)

func isSlashRune(r rune) bool { return r == '/' || r == '\\' }

func containsDotDotLoop(v string) bool {
	if !strings.Contains(v, "..") {
		return false
	}
	for _, ent := range strings.FieldsFunc(v, isSlashRune) {
		if ent == ".." {
			return true
		}
	}
	return false
}

func containsDotDotSeq(v string) bool {
	if !strings.Contains(v, "..") {
		return false
	}
	for ent := range strings.FieldsFuncSeq(v, isSlashRune) {
		if ent == ".." {
			return true
		}
	}
	return false
}

func BenchmarkDotDot(b *testing.B) {
	testCases := []string{
		"/path/to/somewhere",
		"/path/../to/somewhere",
		"/really/long/path/with/many/segments",
		"../../../deep/path",
	}

	b.Run("Loop", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			for _, tc := range testCases {
				containsDotDotLoop(tc)
			}
		}
	})

	b.Run("Seq", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			for _, tc := range testCases {
				containsDotDotSeq(tc)
			}
		}
	})
}
```

```shell
go test -bench=. -benchmem

goos: darwin
goarch: arm64
pkg: bc
cpu: Apple M1
BenchmarkDotDot/Loop-8         	 6133270	       193.7 ns/op	     144 B/op	       2 allocs/op
BenchmarkDotDot/Seq-8          	23172360	        51.19 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	bc	2.633s
```
