### PR TITLE
`gh pr edit`: Only fetch org teams for reviewers when required

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -637,7 +637,12 @@ func AddPullRequestReviews(client *Client, repo ghrepo.Interface, prNumber int, 
 		return nil
 	}
 
-	path := fmt.Sprintf("repos/%s/%s/pulls/%d/requested_reviewers", repo.RepoOwner(), repo.RepoName(), prNumber)
+	path := fmt.Sprintf(
+		"repos/%s/%s/pulls/%d/requested_reviewers",
+		url.PathEscape(repo.RepoOwner()),
+		url.PathEscape(repo.RepoName()),
+		prNumber,
+	)
 	body := struct {
 		Reviewers     []string `json:"reviewers,omitempty"`
 		TeamReviewers []string `json:"team_reviewers,omitempty"`
@@ -666,7 +671,12 @@ func RemovePullRequestReviews(client *Client, repo ghrepo.Interface, prNumber in
 		teams = []string{}
 	}
 
-	path := fmt.Sprintf("repos/%s/%s/pulls/%d/requested_reviewers", repo.RepoOwner(), repo.RepoName(), prNumber)
+	path := fmt.Sprintf(
+		"repos/%s/%s/pulls/%d/requested_reviewers",
+		url.PathEscape(repo.RepoOwner()),
+		url.PathEscape(repo.RepoName()),
+		prNumber,
+	)
 	body := struct {
 		Reviewers     []string `json:"reviewers"`
 		TeamReviewers []string `json:"team_reviewers"`

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -631,7 +631,7 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 	return pr, nil
 }
 
-// AddPullRequestReviews updates the requested reviewers on a pull request using the REST API.
+// AddPullRequestReviews adds the given user and team reviewers to a pull request using the REST API.
 func AddPullRequestReviews(client *Client, repo ghrepo.Interface, prNumber int, users, teams []string) error {
 	if len(users) == 0 && len(teams) == 0 {
 		return nil

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -664,13 +664,6 @@ func RemovePullRequestReviews(client *Client, repo ghrepo.Interface, prNumber in
 		return nil
 	}
 
-	if users == nil {
-		users = []string{}
-	}
-	if teams == nil {
-		teams = []string{}
-	}
-
 	path := fmt.Sprintf(
 		"repos/%s/%s/pulls/%d/requested_reviewers",
 		url.PathEscape(repo.RepoOwner()),
@@ -678,8 +671,8 @@ func RemovePullRequestReviews(client *Client, repo ghrepo.Interface, prNumber in
 		prNumber,
 	)
 	body := struct {
-		Reviewers     []string `json:"reviewers"`
-		TeamReviewers []string `json:"team_reviewers"`
+		Reviewers     []string `json:"reviewers,omitempty"`
+		TeamReviewers []string `json:"team_reviewers,omitempty"`
 	}{
 		Reviewers:     users,
 		TeamReviewers: teams,

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/set"
-	"github.com/shurcooL/githubv4"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -439,15 +438,4 @@ type editorRetriever struct {
 
 func (e editorRetriever) Retrieve() (string, error) {
 	return cmdutil.DetermineEditor(e.config)
-}
-
-func ghIds(s *[]string) *[]githubv4.ID {
-	if s == nil {
-		return nil
-	}
-	ids := make([]githubv4.ID, len(*s))
-	for i, v := range *s {
-		ids[i] = v
-	}
-	return &ids
 }

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -172,7 +172,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			}
 
 			if opts.Interactive && !opts.IO.CanPrompt() {
-				return cmdutil.FlagErrorf("--tile, --body, --reviewer, --assignee, --label, --project, or --milestone required when not running interactively")
+				return cmdutil.FlagErrorf("--title, --body, --reviewer, --assignee, --label, --project, or --milestone required when not running interactively")
 			}
 
 			if runF != nil {

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -354,7 +354,7 @@ func Test_editRun(t *testing.T) {
 	tests := []struct {
 		name      string
 		input     *EditOptions
-		httpStubs func(*httpmock.Registry)
+		httpStubs func(*httpmock.Registry, *testing.T)
 		stdout    string
 		stderr    string
 	}{
@@ -411,11 +411,11 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry) {
-				mockRepoMetadata(reg, false)
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true, teamReviewers: false, assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
 				mockPullRequestUpdateActorAssignees(reg)
-				mockPullRequestReviewersUpdate(reg)
+				mockPullRequestAddReviewers(reg)
 				mockPullRequestUpdateLabels(reg)
 				mockProjectV2ItemUpdate(reg)
 			},
@@ -469,8 +469,8 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry) {
-				mockRepoMetadata(reg, true)
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				mockRepoMetadata(reg, mockRepoMetadataOptions{assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
 				mockPullRequestUpdateActorAssignees(reg)
 				mockPullRequestUpdateLabels(reg)
@@ -483,8 +483,19 @@ func Test_editRun(t *testing.T) {
 			input: &EditOptions{
 				Detector:    &fd.EnabledDetectorMock{},
 				SelectorArg: "123",
-				Finder: shared.NewMockFinder("123", &api.PullRequest{
+				Finder: shared.NewMockFinder("123", &api.PullRequest{ // include existing reviewers so removal logic triggers
 					URL: "https://github.com/OWNER/REPO/pull/123",
+					ReviewRequests: api.ReviewRequests{Nodes: []struct{ RequestedReviewer api.RequestedReviewer }{
+						{RequestedReviewer: api.RequestedReviewer{TypeName: "Team", Slug: "core", Organization: struct {
+							Login string `json:"login"`
+						}{Login: "OWNER"}}},
+						{RequestedReviewer: api.RequestedReviewer{TypeName: "Team", Slug: "external", Organization: struct {
+							Login string `json:"login"`
+						}{Login: "OWNER"}}},
+						{RequestedReviewer: api.RequestedReviewer{TypeName: "User", Login: "monalisa"}},
+						{RequestedReviewer: api.RequestedReviewer{TypeName: "User", Login: "hubot"}},
+						{RequestedReviewer: api.RequestedReviewer{TypeName: "User", Login: "dependabot"}},
+					}},
 				}, ghrepo.New("OWNER", "REPO")),
 				Interactive: false,
 				Editable: shared.Editable{
@@ -501,8 +512,9 @@ func Test_editRun(t *testing.T) {
 						Edited: true,
 					},
 					Reviewers: shared.EditableSlice{
-						Remove: []string{"OWNER/core", "OWNER/external", "monalisa", "hubot", "dependabot"},
-						Edited: true,
+						Default: []string{"OWNER/core", "OWNER/external", "monalisa", "hubot", "dependabot"},
+						Remove:  []string{"OWNER/core", "OWNER/external", "monalisa", "hubot", "dependabot"},
+						Edited:  true,
 					},
 					Assignees: shared.EditableAssignees{
 						EditableSlice: shared.EditableSlice{
@@ -530,13 +542,104 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry) {
-				mockRepoMetadata(reg, false)
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true, teamReviewers: false, assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
-				mockPullRequestReviewersUpdate(reg)
+				mockPullRequestRemoveReviewers(reg)
 				mockPullRequestUpdateLabels(reg)
 				mockPullRequestUpdateActorAssignees(reg)
 				mockProjectV2ItemUpdate(reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		// Conditional team fetching cases
+		{
+			name: "non-interactive add only user reviewers skips team fetch",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder:      shared.NewMockFinder("123", &api.PullRequest{URL: "https://github.com/OWNER/REPO/pull/123"}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Reviewers: shared.EditableSlice{Add: []string{"monalisa", "hubot"}, Edited: true},
+				},
+				Fetcher: testFetcher{},
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				// reviewers only (users), no team reviewers fetched
+				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true})
+				// explicitly assert that no OrganizationTeamList query occurs
+				reg.Exclude(t, httpmock.GraphQL(`query OrganizationTeamList\b`))
+				mockPullRequestUpdate(reg)
+				mockPullRequestAddReviewers(reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		{
+			name: "non-interactive add contains team reviewers skips team fetch",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder:      shared.NewMockFinder("123", &api.PullRequest{URL: "https://github.com/OWNER/REPO/pull/123"}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Reviewers: shared.EditableSlice{Add: []string{"monalisa", "OWNER/core"}, Edited: true},
+				},
+				Fetcher: testFetcher{},
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				// reviewer add includes team but non-interactive Add/Remove provided -> no team fetch
+				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true})
+				reg.Exclude(t, httpmock.GraphQL(`query OrganizationTeamList\b`))
+				mockPullRequestUpdate(reg)
+				mockPullRequestAddReviewers(reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		{
+			name: "non-interactive reviewers remove contains team skips team fetch",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder: shared.NewMockFinder("123", &api.PullRequest{URL: "https://github.com/OWNER/REPO/pull/123", ReviewRequests: api.ReviewRequests{Nodes: []struct{ RequestedReviewer api.RequestedReviewer }{
+					{RequestedReviewer: api.RequestedReviewer{TypeName: "Team", Slug: "core", Organization: struct {
+						Login string `json:"login"`
+					}{Login: "OWNER"}}},
+					{RequestedReviewer: api.RequestedReviewer{TypeName: "User", Login: "monalisa"}},
+				}}}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Reviewers: shared.EditableSlice{Remove: []string{"monalisa", "OWNER/core"}, Edited: true},
+				},
+				Fetcher: testFetcher{},
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true})
+				reg.Exclude(t, httpmock.GraphQL(`query OrganizationTeamList\b`))
+				mockPullRequestUpdate(reg)
+				mockPullRequestRemoveReviewers(reg)
+			},
+			stdout: "https://github.com/OWNER/REPO/pull/123\n",
+		},
+		{
+			name: "non-interactive mutate reviewers with no change to existing team reviewers skips team fetch",
+			input: &EditOptions{
+				Detector:    &fd.EnabledDetectorMock{},
+				SelectorArg: "123",
+				Finder:      shared.NewMockFinder("123", &api.PullRequest{URL: "https://github.com/OWNER/REPO/pull/123"}, ghrepo.New("OWNER", "REPO")),
+				Interactive: false,
+				Editable: shared.Editable{
+					Reviewers: shared.EditableSlice{Add: []string{"monalisa"}, Remove: []string{"hubot"}, Default: []string{"OWNER/core"}, Edited: true},
+				},
+				Fetcher: testFetcher{},
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				// reviewers only (users), no team reviewers fetched
+				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true})
+				// explicitly assert that no OrganizationTeamList query occurs
+				reg.Exclude(t, httpmock.GraphQL(`query OrganizationTeamList\b`))
+				mockPullRequestUpdate(reg)
+				mockPullRequestAddReviewers(reg)
 			},
 			stdout: "https://github.com/OWNER/REPO/pull/123\n",
 		},
@@ -576,11 +679,11 @@ func Test_editRun(t *testing.T) {
 				Fetcher:         testFetcher{},
 				EditorRetriever: testEditorRetriever{},
 			},
-			httpStubs: func(reg *httpmock.Registry) {
-				mockRepoMetadata(reg, false)
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true, teamReviewers: true, assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
 				mockPullRequestUpdateActorAssignees(reg)
-				mockPullRequestReviewersUpdate(reg)
+				mockPullRequestAddReviewers(reg)
 				mockPullRequestUpdateLabels(reg)
 				mockProjectV2ItemUpdate(reg)
 			},
@@ -620,8 +723,9 @@ func Test_editRun(t *testing.T) {
 				Fetcher:         testFetcher{},
 				EditorRetriever: testEditorRetriever{},
 			},
-			httpStubs: func(reg *httpmock.Registry) {
-				mockRepoMetadata(reg, true)
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				// interactive but reviewers not chosen; need everything except reviewers/teams
+				mockRepoMetadata(reg, mockRepoMetadataOptions{assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
 				mockPullRequestUpdateActorAssignees(reg)
 				mockPullRequestUpdateLabels(reg)
@@ -634,8 +738,19 @@ func Test_editRun(t *testing.T) {
 			input: &EditOptions{
 				Detector:    &fd.EnabledDetectorMock{},
 				SelectorArg: "123",
-				Finder: shared.NewMockFinder("123", &api.PullRequest{
+				Finder: shared.NewMockFinder("123", &api.PullRequest{ // include existing reviewers
 					URL: "https://github.com/OWNER/REPO/pull/123",
+					ReviewRequests: api.ReviewRequests{Nodes: []struct{ RequestedReviewer api.RequestedReviewer }{
+						{RequestedReviewer: api.RequestedReviewer{TypeName: "Team", Slug: "core", Organization: struct {
+							Login string `json:"login"`
+						}{Login: "OWNER"}}},
+						{RequestedReviewer: api.RequestedReviewer{TypeName: "Team", Slug: "external", Organization: struct {
+							Login string `json:"login"`
+						}{Login: "OWNER"}}},
+						{RequestedReviewer: api.RequestedReviewer{TypeName: "User", Login: "monalisa"}},
+						{RequestedReviewer: api.RequestedReviewer{TypeName: "User", Login: "hubot"}},
+						{RequestedReviewer: api.RequestedReviewer{TypeName: "User", Login: "dependabot"}},
+					}},
 				}, ghrepo.New("OWNER", "REPO")),
 				Interactive: true,
 				Surveyor: testSurveyor{
@@ -665,10 +780,10 @@ func Test_editRun(t *testing.T) {
 				Fetcher:         testFetcher{},
 				EditorRetriever: testEditorRetriever{},
 			},
-			httpStubs: func(reg *httpmock.Registry) {
-				mockRepoMetadata(reg, false)
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true, teamReviewers: true, assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
-				mockPullRequestReviewersUpdate(reg)
+				mockPullRequestRemoveReviewers(reg)
 				mockPullRequestUpdateActorAssignees(reg)
 				mockPullRequestUpdateLabels(reg)
 				mockProjectV2ItemUpdate(reg)
@@ -712,7 +827,7 @@ func Test_editRun(t *testing.T) {
 				Fetcher:         testFetcher{},
 				EditorRetriever: testEditorRetriever{},
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`query RepositoryAssignableActors\b`),
 					httpmock.StringResponse(`
@@ -759,7 +874,7 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
 				// Notice there is no call to mockReplaceActorsForAssignable()
 				// and no GraphQL call to RepositoryAssignableActors below.
 				reg.Register(
@@ -787,7 +902,7 @@ func Test_editRun(t *testing.T) {
 
 			reg := &httpmock.Registry{}
 			defer reg.Verify(t)
-			tt.httpStubs(reg)
+			tt.httpStubs(reg, t)
 
 			httpClient := func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
 			baseRepo := func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil }
@@ -804,10 +919,21 @@ func Test_editRun(t *testing.T) {
 	}
 }
 
-func mockRepoMetadata(reg *httpmock.Registry, skipReviewers bool) {
-	reg.Register(
-		httpmock.GraphQL(`query RepositoryAssignableActors\b`),
-		httpmock.StringResponse(`
+type mockRepoMetadataOptions struct {
+	reviewers     bool
+	teamReviewers bool // reviewers must also be true for this to have an effect.
+	assignees     bool
+	labels        bool
+	projects      bool // includes both legacy (v1) and v2
+	milestones    bool
+}
+
+func mockRepoMetadata(reg *httpmock.Registry, opt mockRepoMetadataOptions) {
+	// Assignable actors (users/bots) are fetched when reviewers OR assignees edited with ActorAssignees enabled.
+	if opt.reviewers || opt.assignees {
+		reg.Register(
+			httpmock.GraphQL(`query RepositoryAssignableActors\b`),
+			httpmock.StringResponse(`
 			{ "data": { "repository": { "suggestedActors": {
 				"nodes": [
 					{ "login": "hubot", "id": "HUBOTID", "__typename": "Bot" },
@@ -816,9 +942,11 @@ func mockRepoMetadata(reg *httpmock.Registry, skipReviewers bool) {
 				"pageInfo": { "hasNextPage": false }
 			} } } }
 			`))
-	reg.Register(
-		httpmock.GraphQL(`query RepositoryLabelList\b`),
-		httpmock.StringResponse(`
+	}
+	if opt.labels {
+		reg.Register(
+			httpmock.GraphQL(`query RepositoryLabelList\b`),
+			httpmock.StringResponse(`
 		{ "data": { "repository": { "labels": {
 			"nodes": [
 				{ "name": "feature", "id": "FEATUREID" },
@@ -829,9 +957,11 @@ func mockRepoMetadata(reg *httpmock.Registry, skipReviewers bool) {
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
-	reg.Register(
-		httpmock.GraphQL(`query RepositoryMilestoneList\b`),
-		httpmock.StringResponse(`
+	}
+	if opt.milestones {
+		reg.Register(
+			httpmock.GraphQL(`query RepositoryMilestoneList\b`),
+			httpmock.StringResponse(`
 		{ "data": { "repository": { "milestones": {
 			"nodes": [
 				{ "title": "GA", "id": "GAID" },
@@ -840,9 +970,11 @@ func mockRepoMetadata(reg *httpmock.Registry, skipReviewers bool) {
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
-	reg.Register(
-		httpmock.GraphQL(`query RepositoryProjectList\b`),
-		httpmock.StringResponse(`
+	}
+	if opt.projects {
+		reg.Register(
+			httpmock.GraphQL(`query RepositoryProjectList\b`),
+			httpmock.StringResponse(`
 		{ "data": { "repository": { "projects": {
 			"nodes": [
 				{ "name": "Cleanup", "id": "CLEANUPID" },
@@ -851,9 +983,9 @@ func mockRepoMetadata(reg *httpmock.Registry, skipReviewers bool) {
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
-	reg.Register(
-		httpmock.GraphQL(`query OrganizationProjectList\b`),
-		httpmock.StringResponse(`
+		reg.Register(
+			httpmock.GraphQL(`query OrganizationProjectList\b`),
+			httpmock.StringResponse(`
 		{ "data": { "organization": { "projects": {
 			"nodes": [
 				{ "name": "Triage", "id": "TRIAGEID" }
@@ -861,9 +993,9 @@ func mockRepoMetadata(reg *httpmock.Registry, skipReviewers bool) {
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
-	reg.Register(
-		httpmock.GraphQL(`query RepositoryProjectV2List\b`),
-		httpmock.StringResponse(`
+		reg.Register(
+			httpmock.GraphQL(`query RepositoryProjectV2List\b`),
+			httpmock.StringResponse(`
 		{ "data": { "repository": { "projectsV2": {
 			"nodes": [
 				{ "title": "CleanupV2", "id": "CLEANUPV2ID" },
@@ -872,9 +1004,9 @@ func mockRepoMetadata(reg *httpmock.Registry, skipReviewers bool) {
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
-	reg.Register(
-		httpmock.GraphQL(`query OrganizationProjectV2List\b`),
-		httpmock.StringResponse(`
+		reg.Register(
+			httpmock.GraphQL(`query OrganizationProjectV2List\b`),
+			httpmock.StringResponse(`
 		{ "data": { "organization": { "projectsV2": {
 			"nodes": [
 				{ "title": "TriageV2", "id": "TRIAGEV2ID" }
@@ -882,9 +1014,9 @@ func mockRepoMetadata(reg *httpmock.Registry, skipReviewers bool) {
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
-	reg.Register(
-		httpmock.GraphQL(`query UserProjectV2List\b`),
-		httpmock.StringResponse(`
+		reg.Register(
+			httpmock.GraphQL(`query UserProjectV2List\b`),
+			httpmock.StringResponse(`
 		{ "data": { "viewer": { "projectsV2": {
 			"nodes": [
 				{ "title": "MonalisaV2", "id": "MONALISAV2ID" }
@@ -892,7 +1024,8 @@ func mockRepoMetadata(reg *httpmock.Registry, skipReviewers bool) {
 			"pageInfo": { "hasNextPage": false }
 		} } } }
 		`))
-	if !skipReviewers {
+	}
+	if opt.teamReviewers && opt.reviewers { // teams only relevant if reviewers edited
 		reg.Register(
 			httpmock.GraphQL(`query OrganizationTeamList\b`),
 			httpmock.StringResponse(`
@@ -904,11 +1037,13 @@ func mockRepoMetadata(reg *httpmock.Registry, skipReviewers bool) {
         "pageInfo": { "hasNextPage": false }
       } } } }
 		`))
+	}
+	if opt.reviewers { // Current user fetched only when reviewers requested
 		reg.Register(
 			httpmock.GraphQL(`query UserCurrent\b`),
 			httpmock.StringResponse(`
-		  { "data": { "viewer": { "login": "monalisa" } } }
-		`))
+	  { "data": { "viewer": { "login": "monalisa" } } }
+	`))
 	}
 }
 
@@ -927,9 +1062,15 @@ func mockPullRequestUpdateActorAssignees(reg *httpmock.Registry) {
 	)
 }
 
-func mockPullRequestReviewersUpdate(reg *httpmock.Registry) {
+func mockPullRequestAddReviewers(reg *httpmock.Registry) {
 	reg.Register(
-		httpmock.GraphQL(`mutation PullRequestUpdateRequestReviews\b`),
+		httpmock.REST("POST", "repos/OWNER/REPO/pulls/0/requested_reviewers"),
+		httpmock.StringResponse(`{}`))
+}
+
+func mockPullRequestRemoveReviewers(reg *httpmock.Registry) {
+	reg.Register(
+		httpmock.REST("DELETE", "repos/OWNER/REPO/pulls/0/requested_reviewers"),
 		httpmock.StringResponse(`{}`))
 }
 

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -616,6 +616,7 @@ func Test_editRun(t *testing.T) {
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true})
+				// explicitly assert that no OrganizationTeamList query occurs
 				reg.Exclude(t, httpmock.GraphQL(`query OrganizationTeamList\b`))
 				mockPullRequestUpdate(reg)
 				mockPullRequestRemoveReviewers(reg)

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -590,6 +590,7 @@ func Test_editRun(t *testing.T) {
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				// reviewer add includes team but non-interactive Add/Remove provided -> no team fetch
 				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true})
+				// explicitly assert that no OrganizationTeamList query occurs
 				reg.Exclude(t, httpmock.GraphQL(`query OrganizationTeamList\b`))
 				mockPullRequestUpdate(reg)
 				mockPullRequestAddReviewers(reg)

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -354,7 +354,7 @@ func Test_editRun(t *testing.T) {
 	tests := []struct {
 		name      string
 		input     *EditOptions
-		httpStubs func(*httpmock.Registry, *testing.T)
+		httpStubs func(*testing.T, *httpmock.Registry)
 		stdout    string
 		stderr    string
 	}{
@@ -411,7 +411,7 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true, teamReviewers: false, assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
 				mockPullRequestUpdateActorAssignees(reg)
@@ -469,7 +469,7 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockRepoMetadata(reg, mockRepoMetadataOptions{assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
 				mockPullRequestUpdateActorAssignees(reg)
@@ -542,7 +542,7 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true, teamReviewers: false, assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
 				mockPullRequestRemoveReviewers(reg)
@@ -565,7 +565,7 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				// reviewers only (users), no team reviewers fetched
 				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true})
 				// explicitly assert that no OrganizationTeamList query occurs
@@ -587,7 +587,7 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				// reviewer add includes team but non-interactive Add/Remove provided -> no team fetch
 				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true})
 				reg.Exclude(t, httpmock.GraphQL(`query OrganizationTeamList\b`))
@@ -613,7 +613,7 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true})
 				reg.Exclude(t, httpmock.GraphQL(`query OrganizationTeamList\b`))
 				mockPullRequestUpdate(reg)
@@ -633,7 +633,7 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				// reviewers only (users), no team reviewers fetched
 				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true})
 				// explicitly assert that no OrganizationTeamList query occurs
@@ -679,7 +679,7 @@ func Test_editRun(t *testing.T) {
 				Fetcher:         testFetcher{},
 				EditorRetriever: testEditorRetriever{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true, teamReviewers: true, assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
 				mockPullRequestUpdateActorAssignees(reg)
@@ -723,7 +723,7 @@ func Test_editRun(t *testing.T) {
 				Fetcher:         testFetcher{},
 				EditorRetriever: testEditorRetriever{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				// interactive but reviewers not chosen; need everything except reviewers/teams
 				mockRepoMetadata(reg, mockRepoMetadataOptions{assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
@@ -780,7 +780,7 @@ func Test_editRun(t *testing.T) {
 				Fetcher:         testFetcher{},
 				EditorRetriever: testEditorRetriever{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				mockRepoMetadata(reg, mockRepoMetadataOptions{reviewers: true, teamReviewers: true, assignees: true, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
 				mockPullRequestRemoveReviewers(reg)
@@ -827,7 +827,7 @@ func Test_editRun(t *testing.T) {
 				Fetcher:         testFetcher{},
 				EditorRetriever: testEditorRetriever{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query RepositoryAssignableActors\b`),
 					httpmock.StringResponse(`
@@ -874,7 +874,7 @@ func Test_editRun(t *testing.T) {
 				},
 				Fetcher: testFetcher{},
 			},
-			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				// Notice there is no call to mockReplaceActorsForAssignable()
 				// and no GraphQL call to RepositoryAssignableActors below.
 				reg.Register(
@@ -902,7 +902,7 @@ func Test_editRun(t *testing.T) {
 
 			reg := &httpmock.Registry{}
 			defer reg.Verify(t)
-			tt.httpStubs(reg, t)
+			tt.httpStubs(t, reg)
 
 			httpClient := func() (*http.Client, error) { return &http.Client{Transport: reg}, nil }
 			baseRepo := func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil }


### PR DESCRIPTION
### Description

This pull request refactors how pull request reviewer updates are handled, switching from the GraphQL API to the REST API for adding and removing reviewers. It also improves the logic for managing reviewer lists, especially in non-interactive and interactive editing modes, and updates the test suite to cover these changes and edge cases.

Also fixes a bug where the PR author was included in the interactive list of reviewers. With GraphQL this selection would be ignored, but the REST API actually returns an error if the PR author is provided, so we need to fix that now to avoid confusion.

fixes #4844

### Considerations

Moving to the REST API with this allows us to add/remove as separate operations, eliminating the need to fetch org teams and org team IDs. This is good, because it allows the `GITHUB_TOKEN` and other repo scoped authentication types to proceed with requesting a user review.

However, there's a drawback that we now will require _two operations_, one for adding reviewers and one for removing. 

I am fine with this trade-off because I suspect the typical use-case will only involve either requesting a reviewer or removing a reviewer as discrete operations. Meaning, in most cases we'll never actually perform two API calls. Nonetheless the risk is there.

This implementation also proposes that these two API requests be performed concurrently. I suspect this is optimal, but I am unsure of any sort of race-condition that could arise. In particular in the case of removing and adding the same reviewer, but that could be seen as user error. 

### Testing

This was tested in Actions to prove that it will allow requesting a user reviewer without requiring access to teams, meaning the `GITHUB_TOKEN` could be used where currently `gh` will fail.

<details><summary>Test workflow</summary>
<p>

```Yaml

name: Test Team Reviewer

on:
  workflow_dispatch:
    inputs:
      pr_number:
        description: 'PR number to add reviewer to'
        required: true
        type: string

jobs:
  add-individual-reviewer-local-gh:
    runs-on: self-hosted
    continue-on-error: true
    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Add individual reviewer using local gh binary (should pass if permissions allow)
        env:
            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          <LOCAL_GH_PATH>/gh pr edit ${{ github.event.inputs.pr_number }} --add-reviewer "<INDIVIDUAL_REVIEWER_USERNAME>"

  add-team-reviewer-local-gh:
    runs-on: self-hosted
    continue-on-error: true
    needs: add-individual-reviewer-local-gh
    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Add team reviewer using local gh binary (may fail if token lacks team review permission)
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          <LOCAL_GH_PATH>/gh pr edit ${{ github.event.inputs.pr_number }} --add-reviewer "<ORG_SLUG>/<TEAM_SLUG>"

  add-team-reviewer-system-gh:
    runs-on: self-hosted
    continue-on-error: true
    needs: add-team-reviewer-local-gh
    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Add team reviewer using system gh (may fail if permissions insufficient)
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          gh pr edit ${{ github.event.inputs.pr_number }} --add-reviewer "<ORG_SLUG>/<TEAM_SLUG>"

  add-individual-reviewer-system-gh:
    runs-on: self-hosted
    continue-on-error: true
    needs: add-team-reviewer-system-gh
    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Add individual reviewer using system gh
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          gh pr edit ${{ github.event.inputs.pr_number }} --add-reviewer "<INDIVIDUAL_REVIEWER_USERNAME>"
```

</p>
</details>  

You can see the first job is successful, which is what we're going for. We want the `GITHUB_TOKEN` to be able to request a review from a user as long as there isn't teams included in the review request.

<img width="602" height="101" alt="image" src="https://github.com/user-attachments/assets/d8d471d5-5d1a-46d0-890d-d83e75bdab9f" />

> [!NOTE]
> This was also tested with a team reviewer _already_ requested to prove that we will not fetch team reviewers beyond what the PR metadata gives us already through the non-interactive flow. Therein lies the key reason to switch to the REST API here.

### Further Improvements

It should be noted that the REST API doesn't return a satisfying or useful error message when you provide it a team reviewer without having access to org teams, as in the case of the `GITHUB_TOKEN`:

<img width="1110" height="56" alt="image" src="https://github.com/user-attachments/assets/663e48c1-09ce-4a9d-bca4-8e6ef68b0434" />

Perhaps there is further work to be done in the future to improve this error messaging client-side.