### PR TITLE
`gh agent-task create`: Fix `--follow` not killing the progress indicator

### DIFF
--- a/pkg/cmd/agent-task/create/create.go
+++ b/pkg/cmd/agent-task/create/create.go
@@ -166,6 +166,8 @@ func createRun(opts *CreateOptions) error {
 	}
 
 	if opts.Follow {
+		opts.IO.StopProgressIndicator()
+		fmt.Fprintf(opts.IO.Out, "Displaying session logs for job %s. Press Ctrl+C to stop.\n", job.ID)
 		return followLogs(opts, client, job.SessionID)
 	}
 

--- a/pkg/cmd/agent-task/create/create_test.go
+++ b/pkg/cmd/agent-task/create/create_test.go
@@ -488,6 +488,7 @@ func Test_createRun(t *testing.T) {
 				}
 			},
 			wantStdout: heredoc.Doc(`
+				Displaying session logs for job job123. Press Ctrl+C to stop.
 				(rendered:) <raw-logs-one>
 				(rendered:) <raw-logs-two>
 			`),


### PR DESCRIPTION
Fixes `--follow` not stopping the progress indicator. Also includes a nice message to indicate what is happening because even after we create the agent task, there's a period of time where we poll and receive nothing as the task session starts. We want there to be some sort of feedback in that period of time to not make the user panic and think it has hanged.
