### PR TITLE
fix(auth): respect http_unix_socket during auth flow

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -3,14 +3,35 @@ package api
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/utils"
 	ghAPI "github.com/cli/go-gh/v2/pkg/api"
 	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 )
+
+// NewPlainHTTPClient returns an http.Client that respects the http_unix_socket configuration.
+// It is plain in that it does not add any of the default headers that NewHTTPClient adds.
+func NewPlainHTTPClient() (*http.Client, error) {
+	var transport http.RoundTripper = http.DefaultTransport
+	if cfg, err := config.NewConfig(); err == nil {
+		if unixSocket := cfg.HTTPUnixSocket(""); unixSocket.Value != "" {
+			dial := func(network, addr string) (net.Conn, error) {
+				return net.Dial("unix", unixSocket.Value)
+			}
+			transport = &http.Transport{
+				Dial:              dial,
+				DialTLS:           dial,
+				DisableKeepAlives: true,
+			}
+		}
+	}
+	return &http.Client{Transport: transport}, nil
+}
 
 type tokenGetter interface {
 	ActiveToken(string) (string, string)

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -17,24 +17,22 @@ import (
 	"github.com/cli/cli/v2/utils"
 	"github.com/cli/oauth"
 	"github.com/henvic/httpretty"
-
 	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 )
-
 var (
 	// The "GitHub CLI" OAuth app
 	oauthClientID = "178c6fc778ccc68e1d6a"
 	// This value is safe to be embedded in version control
 	oauthClientSecret = "34ddeff2b558a23d38fba8a6de74f086ede1cc0b"
-
 	jsonTypeRE = regexp.MustCompile(`[/+]json($|;)`)
 )
-
 func AuthFlow(oauthHost string, IO *iostreams.IOStreams, notice string, additionalScopes []string, isInteractive bool, b browser.Browser, isCopyToClipboard bool) (string, string, error) {
 	w := IO.ErrOut
 	cs := IO.ColorScheme()
-
-	httpClient := &http.Client{}
+	httpClient, err := api.NewPlainHTTPClient()
+	if err != nil {
+		return "", "", err
+	}
 	debugEnabled, debugValue := utils.IsDebugEnabled()
 	if debugEnabled {
 		logTraffic := strings.Contains(debugValue, "api")

--- a/pkg/cmd/auth/refresh/refresh.go
+++ b/pkg/cmd/auth/refresh/refresh.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/authflow"
 	"github.com/cli/cli/v2/internal/gh"
@@ -48,7 +49,6 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 			t, u, err := authflow.AuthFlow(hostname, io, "", scopes, interactive, f.Browser, clipboard)
 			return token(t), username(u), err
 		},
-		HttpClient: &http.Client{},
 		GitClient:  f.GitClient,
 		Prompter:   f.Prompter,
 	}
@@ -100,6 +100,12 @@ func NewCmdRefresh(f *cmdutil.Factory, runF func(*RefreshOptions) error) *cobra.
 			if !opts.Interactive && opts.Hostname == "" {
 				return cmdutil.FlagErrorf("--hostname required when not running interactively")
 			}
+
+			httpClient, err := api.NewPlainHTTPClient()
+			if err != nil {
+				return err
+			}
+			opts.HttpClient = httpClient
 
 			opts.MainExecutable = f.Executable()
 			if runF != nil {


### PR DESCRIPTION
Maybesfixes #11891 ?

The http.Client used during OAuth authentication was not configured to use the 'http_unix_socket' value from the user's config. This caused authentication to fail for users who rely on a Unix socket for HTTP traffic.

This commit fixes the issue by creating a shared api.NewPlainHTTPClient that correctly configures the transport to use the Unix socket if one is specified. This new function is now used in both the auth flow and auth refresh commands, ensuring consistent behavior.

Additionally, this resolves an issue where the wrong Accept header was being sent during the OAuth device flow, which resulted in an HTTP 406 error.

This should be reviewed skeptically because:

 - The author has no experience with the internals of the git CLI
 - Some users may have come to rely on the broken behavior and might be surprised that the device auth flow suddenly starts working and showing a device code instead of running the browser flow.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
