### PR TITLE
Enable matching of repo structure during clone

### DIFF
--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -27,6 +27,7 @@ type CloneOptions struct {
 	GitArgs      []string
 	Repository   string
 	UpstreamName string
+	Mirror       bool
 }
 
 func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Command {
@@ -77,6 +78,9 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 
 			# Clone a repository with additional git clone flags
 			$ gh repo clone cli/cli -- --depth=1
+
+			# Clone into an owner/repo directory structure
+			$ gh repo clone cli/cli --mirror
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Repository = args[0]
@@ -91,6 +95,7 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 	}
 
 	cmd.Flags().StringVarP(&opts.UpstreamName, "upstream-remote-name", "u", "upstream", "Upstream remote name when cloning a fork")
+	cmd.Flags().BoolVarP(&opts.Mirror, "mirror", "m", false, "Clone into a directory structure matching owner/repo")
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		if err == pflag.ErrHelp {
 			return err
@@ -180,7 +185,28 @@ func cloneRun(opts *CloneOptions) error {
 
 	gitClient := opts.GitClient
 	ctx := context.Background()
-	cloneDir, err := gitClient.Clone(ctx, canonicalCloneURL, opts.GitArgs)
+	
+	// If --mirror flag is used, modify GitArgs to include the owner/repo directory structure
+	gitArgs := opts.GitArgs
+	if opts.Mirror {
+		// Check if user already specified a directory (first non-flag argument)
+		hasExplicitDir := false
+		for _, arg := range gitArgs {
+			if !strings.HasPrefix(arg, "-") {
+				hasExplicitDir = true
+				break
+			}
+		}
+		
+		// Only add directory structure if user didn't specify one
+		// Prepend directory to gitArgs so parseCloneArgs picks it up as target
+		if !hasExplicitDir {
+			mirrorDir := fmt.Sprintf("%s/%s", canonicalRepo.RepoOwner(), canonicalRepo.RepoName())
+			gitArgs = append([]string{mirrorDir}, gitArgs...)
+		}
+	}
+	
+	cloneDir, err := gitClient.Clone(ctx, canonicalCloneURL, gitArgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -27,7 +27,7 @@ type CloneOptions struct {
 	GitArgs      []string
 	Repository   string
 	UpstreamName string
-	Mirror       bool
+	Match        bool
 }
 
 func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Command {
@@ -79,12 +79,15 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 			# Clone a repository with additional git clone flags
 			$ gh repo clone cli/cli -- --depth=1
 
-			# Clone into an owner/repo directory structure
-			$ gh repo clone cli/cli --mirror
+			# Clone into an owner/repo directory structure (takes precedence over directory argument)
+			$ gh repo clone cli/cli --match
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Repository = args[0]
 			opts.GitArgs = args[1:]
+			if opts.Match {
+				opts.GitArgs = append([]string{opts.Repository}, opts.GitArgs...)
+			}
 
 			if runF != nil {
 				return runF(opts)
@@ -95,7 +98,7 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 	}
 
 	cmd.Flags().StringVarP(&opts.UpstreamName, "upstream-remote-name", "u", "upstream", "Upstream remote name when cloning a fork")
-	cmd.Flags().BoolVarP(&opts.Mirror, "mirror", "m", false, "Clone into a directory structure matching owner/repo")
+	cmd.Flags().BoolVarP(&opts.Match, "match", "m", false, "Clone into a directory structure matching owner/repo")
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		if err == pflag.ErrHelp {
 			return err
@@ -185,28 +188,8 @@ func cloneRun(opts *CloneOptions) error {
 
 	gitClient := opts.GitClient
 	ctx := context.Background()
-	
-	// If --mirror flag is used, modify GitArgs to include the owner/repo directory structure
-	gitArgs := opts.GitArgs
-	if opts.Mirror {
-		// Check if user already specified a directory (first non-flag argument)
-		hasExplicitDir := false
-		for _, arg := range gitArgs {
-			if !strings.HasPrefix(arg, "-") {
-				hasExplicitDir = true
-				break
-			}
-		}
-		
-		// Only add directory structure if user didn't specify one
-		// Prepend directory to gitArgs so parseCloneArgs picks it up as target
-		if !hasExplicitDir {
-			mirrorDir := fmt.Sprintf("%s/%s", canonicalRepo.RepoOwner(), canonicalRepo.RepoName())
-			gitArgs = append([]string{mirrorDir}, gitArgs...)
-		}
-	}
-	
-	cloneDir, err := gitClient.Clone(ctx, canonicalCloneURL, gitArgs)
+
+	cloneDir, err := gitClient.Clone(ctx, canonicalCloneURL, opts.GitArgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -79,14 +79,16 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 			# Clone a repository with additional git clone flags
 			$ gh repo clone cli/cli -- --depth=1
 
-			# Clone into an owner/repo directory structure (takes precedence over directory argument)
+			# Clone into an owner/repo directory matching structure
 			$ gh repo clone cli/cli --match
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Repository = args[0]
 			opts.GitArgs = args[1:]
 			if opts.Match {
+				// Match flag will take precedence over the directory argument
 				opts.GitArgs = append([]string{opts.Repository}, opts.GitArgs...)
+
 			}
 
 			if runF != nil {

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -47,11 +47,28 @@ func TestNewCmdClone(t *testing.T) {
 			},
 		},
 		{
+			name: "directory argument",
+			args: "OWNER/REPO mydir another",
+			wantOpts: CloneOptions{
+				Repository: "OWNER/REPO",
+				GitArgs:    []string{"mydir", "another"},
+			},
+		},
+		{
 			name: "mirror flag",
 			args: "OWNER/REPO --match",
 			wantOpts: CloneOptions{
 				Repository: "OWNER/REPO",
 				GitArgs:    []string{"OWNER/REPO"},
+				Match:      true,
+			},
+		},
+		{
+			name: "mirror flag",
+			args: "OWNER/REPO mydir --match",
+			wantOpts: CloneOptions{
+				Repository: "OWNER/REPO",
+				GitArgs:    []string{"OWNER/REPO", "mydir"},
 				Match:      true,
 			},
 		},

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -47,6 +47,24 @@ func TestNewCmdClone(t *testing.T) {
 			},
 		},
 		{
+			name: "mirror flag",
+			args: "OWNER/REPO --mirror",
+			wantOpts: CloneOptions{
+				Repository: "OWNER/REPO",
+				GitArgs:    []string{"OWNER/REPO"},
+				Mirror:     true,
+			},
+		},
+		{
+			name: "mirror flag with git args",
+			args: "OWNER/REPO --mirror -- --depth 1",
+			wantOpts: CloneOptions{
+				Repository: "OWNER/REPO",
+				GitArgs:    []string{"--depth", "1"},
+				Mirror:     true,
+			},
+		},
+		{
 			name: "git clone arguments",
 			args: "OWNER/REPO -- --depth 1 --recurse-submodules",
 			wantOpts: CloneOptions{
@@ -92,6 +110,7 @@ func TestNewCmdClone(t *testing.T) {
 
 			assert.Equal(t, tt.wantOpts.Repository, opts.Repository)
 			assert.Equal(t, tt.wantOpts.GitArgs, opts.GitArgs)
+			assert.Equal(t, tt.wantOpts.Mirror, opts.Mirror)
 		})
 	}
 }
@@ -194,6 +213,21 @@ func Test_RepoClone(t *testing.T) {
 			name: "wiki URL with extra path parts",
 			args: "https://github.com/owner/repo.wiki/extra/path?key=value#fragment",
 			want: "git clone https://github.com/OWNER/REPO.wiki.git",
+		},
+		{
+			name: "mirror flag",
+			args: "OWNER/REPO --mirror",
+			want: "git clone https://github.com/OWNER/REPO.git OWNER/REPO",
+		},
+		{
+			name: "mirror flag with git args",
+			args: "OWNER/REPO --mirror -- --depth 1",
+			want: "git clone --depth 1 https://github.com/OWNER/REPO.git OWNER/REPO",
+		},
+		{
+			name: "mirror flag with explicit directory is ignored",
+			args: "OWNER/REPO custom_dir --mirror",
+			want: "git clone https://github.com/OWNER/REPO.git custom_dir",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -48,20 +48,20 @@ func TestNewCmdClone(t *testing.T) {
 		},
 		{
 			name: "mirror flag",
-			args: "OWNER/REPO --mirror",
+			args: "OWNER/REPO --match",
 			wantOpts: CloneOptions{
 				Repository: "OWNER/REPO",
 				GitArgs:    []string{"OWNER/REPO"},
-				Mirror:     true,
+				Match:      true,
 			},
 		},
 		{
 			name: "mirror flag with git args",
-			args: "OWNER/REPO --mirror -- --depth 1",
+			args: "OWNER/REPO --match -- --depth 1",
 			wantOpts: CloneOptions{
 				Repository: "OWNER/REPO",
-				GitArgs:    []string{"--depth", "1"},
-				Mirror:     true,
+				GitArgs:    []string{"OWNER/REPO", "--depth", "1"},
+				Match:      true,
 			},
 		},
 		{
@@ -110,7 +110,7 @@ func TestNewCmdClone(t *testing.T) {
 
 			assert.Equal(t, tt.wantOpts.Repository, opts.Repository)
 			assert.Equal(t, tt.wantOpts.GitArgs, opts.GitArgs)
-			assert.Equal(t, tt.wantOpts.Mirror, opts.Mirror)
+			assert.Equal(t, tt.wantOpts.Match, opts.Match)
 		})
 	}
 }
@@ -216,18 +216,18 @@ func Test_RepoClone(t *testing.T) {
 		},
 		{
 			name: "mirror flag",
-			args: "OWNER/REPO --mirror",
+			args: "OWNER/REPO --match",
 			want: "git clone https://github.com/OWNER/REPO.git OWNER/REPO",
 		},
 		{
 			name: "mirror flag with git args",
-			args: "OWNER/REPO --mirror -- --depth 1",
+			args: "OWNER/REPO --match -- --depth 1",
 			want: "git clone --depth 1 https://github.com/OWNER/REPO.git OWNER/REPO",
 		},
 		{
 			name: "mirror flag with explicit directory is ignored",
-			args: "OWNER/REPO custom_dir --mirror",
-			want: "git clone https://github.com/OWNER/REPO.git custom_dir",
+			args: "OWNER/REPO custom_dir --match",
+			want: "git clone https://github.com/OWNER/REPO.git OWNER/REPO",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
When creating a repo clone, it's often convenient to match the org with the repo name.
During a normal `gh repo clone` operation, and wanting to contribute to various CLI repo, you would default to the code attempting to be checked out in the same `cli` directory. 
e.g.
* https://github.com/cli/cli - `gh repo clone cli/cli`
* https://github.com/npm/cli - `gh repo clone npm/cli`
* https://github.com/httpie/cli - `gh repo clone httpie/cli`

Trying to run any of the above commands in a common `~/go/src/github.com` directory would result in the following error:
```
fatal: destination path 'cli' already exists and is not an empty directory.
failed to run git: exit status 128
```

You can obviously pass your own repo name, but it can get quite verbose to type (aka https://github.com/react-native-community/cli)

This PR adds the `--match` flag, allowing for a simple flag to indicate your desire to match the owner/repo dir structure. 
going from: 
```
$ gh repo clone cli/cli
Cloning into 'cli'...
```
to then having to be explicit:
```
$ gh repo clone react-native-community/cli react-native-community/cli
Cloning into 'react-native-community/cli'...
```
to what you were trying to do in the first place:
```
$ gh repo clone react-native-community/cli --match
Cloning into 'react-native-community/cli'...
```

Fixes #11904 