### PR TITLE
Fix `auth login` and `auth refresh` to use UNIX socket

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -17,22 +17,24 @@ type tokenGetter interface {
 }
 
 type HTTPClientOptions struct {
-	AppVersion     string
-	CacheTTL       time.Duration
-	Config         tokenGetter
-	EnableCache    bool
-	Log            io.Writer
-	LogColorize    bool
-	LogVerboseHTTP bool
+	AppVersion         string
+	CacheTTL           time.Duration
+	Config             tokenGetter
+	EnableCache        bool
+	Log                io.Writer
+	LogColorize        bool
+	LogVerboseHTTP     bool
+	SkipDefaultHeaders bool
 }
 
 func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 	// Provide invalid host, and token values so gh.HTTPClient will not automatically resolve them.
 	// The real host and token are inserted at request time.
 	clientOpts := ghAPI.ClientOptions{
-		Host:         "none",
-		AuthToken:    "none",
-		LogIgnoreEnv: true,
+		Host:               "none",
+		AuthToken:          "none",
+		LogIgnoreEnv:       true,
+		SkipDefaultHeaders: opts.SkipDefaultHeaders,
 	}
 
 	debugEnabled, debugValue := utils.IsDebugEnabled()

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -26,7 +26,7 @@ func TestNewHTTPClient(t *testing.T) {
 		name       string
 		args       args
 		host       string
-		wantHeader map[string]string
+		wantHeader map[string][]string
 		wantStderr string
 	}{
 		{
@@ -37,10 +37,10 @@ func TestNewHTTPClient(t *testing.T) {
 				logVerboseHTTP: false,
 			},
 			host: "github.com",
-			wantHeader: map[string]string{
-				"authorization": "token MYTOKEN",
-				"user-agent":    "GitHub CLI v1.2.3",
-				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
+			wantHeader: map[string][]string{
+				"authorization": {"token MYTOKEN"},
+				"user-agent":    {"GitHub CLI v1.2.3"},
+				"accept":        {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
 			},
 			wantStderr: "",
 		},
@@ -51,10 +51,10 @@ func TestNewHTTPClient(t *testing.T) {
 				appVersion: "v1.2.3",
 			},
 			host: "example.com",
-			wantHeader: map[string]string{
-				"authorization": "token GHETOKEN",
-				"user-agent":    "GitHub CLI v1.2.3",
-				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
+			wantHeader: map[string][]string{
+				"authorization": {"token GHETOKEN"},
+				"user-agent":    {"GitHub CLI v1.2.3"},
+				"accept":        {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
 			},
 			wantStderr: "",
 		},
@@ -66,10 +66,10 @@ func TestNewHTTPClient(t *testing.T) {
 				logVerboseHTTP: false,
 			},
 			host: "github.com",
-			wantHeader: map[string]string{
-				"authorization": "",
-				"user-agent":    "GitHub CLI v1.2.3",
-				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
+			wantHeader: map[string][]string{
+				"authorization": nil, // should not be set
+				"user-agent":    {"GitHub CLI v1.2.3"},
+				"accept":        {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
 			},
 			wantStderr: "",
 		},
@@ -81,10 +81,10 @@ func TestNewHTTPClient(t *testing.T) {
 				logVerboseHTTP: false,
 			},
 			host: "example.com",
-			wantHeader: map[string]string{
-				"authorization": "",
-				"user-agent":    "GitHub CLI v1.2.3",
-				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
+			wantHeader: map[string][]string{
+				"authorization": nil, // should not be set
+				"user-agent":    {"GitHub CLI v1.2.3"},
+				"accept":        {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
 			},
 			wantStderr: "",
 		},
@@ -96,10 +96,10 @@ func TestNewHTTPClient(t *testing.T) {
 				logVerboseHTTP: true,
 			},
 			host: "github.com",
-			wantHeader: map[string]string{
-				"authorization": "token MYTOKEN",
-				"user-agent":    "GitHub CLI v1.2.3",
-				"accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
+			wantHeader: map[string][]string{
+				"authorization": {"token MYTOKEN"},
+				"user-agent":    {"GitHub CLI v1.2.3"},
+				"accept":        {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
 			},
 			wantStderr: heredoc.Doc(`
 				* Request at <time>
@@ -148,7 +148,7 @@ func TestNewHTTPClient(t *testing.T) {
 			require.NoError(t, err)
 
 			for name, value := range tt.wantHeader {
-				assert.Equal(t, value, gotReq.Header.Get(name), name)
+				assert.Equal(t, value, gotReq.Header.Values(name), name)
 			}
 
 			assert.Equal(t, 204, res.StatusCode)

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.7.0
-	github.com/henvic/httpretty v0.1.4
 	github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec
 	github.com/in-toto/attestation v1.1.2
 	github.com/joho/godotenv v1.5.1
@@ -148,6 +147,7 @@ require (
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/henvic/httpretty v0.1.4 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/in-toto/in-toto-golang v0.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -20,12 +20,13 @@ import (
 )
 
 type LoginOptions struct {
-	IO         *iostreams.IOStreams
-	Config     func() (gh.Config, error)
-	HttpClient func() (*http.Client, error)
-	GitClient  *git.Client
-	Prompter   shared.Prompt
-	Browser    browser.Browser
+	IO              *iostreams.IOStreams
+	Config          func() (gh.Config, error)
+	HttpClient      func() (*http.Client, error)
+	PlainHttpClient func() (*http.Client, error)
+	GitClient       *git.Client
+	Prompter        shared.Prompt
+	Browser         browser.Browser
 
 	MainExecutable string
 
@@ -43,12 +44,13 @@ type LoginOptions struct {
 
 func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Command {
 	opts := &LoginOptions{
-		IO:         f.IOStreams,
-		Config:     f.Config,
-		HttpClient: f.HttpClient,
-		GitClient:  f.GitClient,
-		Prompter:   f.Prompter,
-		Browser:    f.Browser,
+		IO:              f.IOStreams,
+		Config:          f.Config,
+		HttpClient:      f.HttpClient,
+		PlainHttpClient: f.PlainHttpClient,
+		GitClient:       f.GitClient,
+		Prompter:        f.Prompter,
+		Browser:         f.Browser,
 	}
 
 	var tokenStdin bool
@@ -190,6 +192,11 @@ func loginRun(opts *LoginOptions) error {
 		return cmdutil.SilentError
 	}
 
+	plainHTTPClient, err := opts.PlainHttpClient()
+	if err != nil {
+		return err
+	}
+
 	httpClient, err := opts.HttpClient()
 	if err != nil {
 		return err
@@ -210,16 +217,17 @@ func loginRun(opts *LoginOptions) error {
 	}
 
 	return shared.Login(&shared.LoginOptions{
-		IO:          opts.IO,
-		Config:      authCfg,
-		HTTPClient:  httpClient,
-		Hostname:    hostname,
-		Interactive: opts.Interactive,
-		Web:         opts.Web,
-		Scopes:      opts.Scopes,
-		GitProtocol: opts.GitProtocol,
-		Prompter:    opts.Prompter,
-		Browser:     opts.Browser,
+		IO:              opts.IO,
+		Config:          authCfg,
+		HTTPClient:      httpClient,
+		PlainHTTPClient: plainHTTPClient,
+		Hostname:        hostname,
+		Interactive:     opts.Interactive,
+		Web:             opts.Web,
+		Scopes:          opts.Scopes,
+		GitProtocol:     opts.GitProtocol,
+		Prompter:        opts.Prompter,
+		Browser:         opts.Browser,
 		CredentialFlow: &shared.GitCredentialFlow{
 			Prompter: opts.Prompter,
 			HelperConfig: &gitcredentials.HelperConfig{

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -483,6 +483,9 @@ func Test_loginRun_nontty(t *testing.T) {
 			tt.opts.HttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: reg}, nil
 			}
+			tt.opts.PlainHttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
 			if tt.httpStubs != nil {
 				tt.httpStubs(reg)
 			}
@@ -773,6 +776,9 @@ func Test_loginRun_Survey(t *testing.T) {
 
 			reg := &httpmock.Registry{}
 			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.PlainHttpClient = func() (*http.Client, error) {
 				return &http.Client{Transport: reg}, nil
 			}
 			if tt.httpStubs != nil {

--- a/pkg/cmd/auth/refresh/refresh_test.go
+++ b/pkg/cmd/auth/refresh/refresh_test.go
@@ -471,7 +471,7 @@ func Test_refreshRun(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			aa := authArgs{}
-			tt.opts.AuthFlow = func(_ *iostreams.IOStreams, hostname string, scopes []string, interactive bool, clipboard bool) (token, username, error) {
+			tt.opts.AuthFlow = func(_ *http.Client, _ *iostreams.IOStreams, hostname string, scopes []string, interactive bool, clipboard bool) (token, username, error) {
 				aa.hostname = hostname
 				aa.scopes = scopes
 				aa.interactive = interactive
@@ -514,7 +514,9 @@ func Test_refreshRun(t *testing.T) {
 					}, nil
 				},
 			)
-			tt.opts.HttpClient = &http.Client{Transport: httpReg}
+			tt.opts.PlainHttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: httpReg}, nil
+			}
 
 			pm := &prompter.PrompterMock{}
 			if tt.prompterStubs != nil {

--- a/pkg/cmd/auth/shared/login_flow.go
+++ b/pkg/cmd/auth/shared/login_flow.go
@@ -30,6 +30,7 @@ type LoginOptions struct {
 	IO               *iostreams.IOStreams
 	Config           iconfig
 	HTTPClient       *http.Client
+	PlainHTTPClient  *http.Client
 	Hostname         string
 	Interactive      bool
 	Web              bool
@@ -149,7 +150,7 @@ func Login(opts *LoginOptions) error {
 
 	if authMode == 0 {
 		var err error
-		authToken, username, err = authflow.AuthFlow(hostname, opts.IO, "", append(opts.Scopes, additionalScopes...), opts.Interactive, opts.Browser, opts.CopyToClipboard)
+		authToken, username, err = authflow.AuthFlow(opts.PlainHTTPClient, hostname, opts.IO, "", append(opts.Scopes, additionalScopes...), opts.Interactive, opts.Browser, opts.CopyToClipboard)
 		if err != nil {
 			return fmt.Errorf("failed to authenticate via web browser: %w", err)
 		}

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -30,7 +30,11 @@ type Factory struct {
 	Branch     func() (string, error)
 	Config     func() (gh.Config, error)
 	HttpClient func() (*http.Client, error)
-	Remotes    func() (context.Remotes, error)
+	// PlainHttpClient is a special HTTP client that does not automatically set
+	// auth and other headers. This is meant to be used in situations where the
+	// client needs to specify the headers itself (e.g. during login).
+	PlainHttpClient func() (*http.Client, error)
+	Remotes         func() (context.Remotes, error)
 }
 
 // Executable is the path to the currently invoked binary


### PR DESCRIPTION
Fixes #11891

This is a fix + refactor around how `gh` instantiates special HTTP clients for authentication purposes.

Below is a bit about the changes, and then instructions to verify the PR fixes the UNIX socket support during login.

## Rationale

As a bit of context, almost every `gh` command uses `f.HttpClient` to get a new HTTP client instance. The client is created by `cli/go-gh` and is equipped with various layers of custom roundtrip overrides that take care of:

- Using UNIX sockets, if applicable
- Setting HTTP request headers (e.g. `Authorization`, `User-Agent`, `Accept`, or `Content-Type`)
  - The `Authorization` header is a bit tricky as it gets set at `gh` side.
- Adding verbose logging, if applicable

However, there were two places where a zero HTTP client (i.e. `http.Client{}`) was used instead of the central one; in `auth login` and in `auth refresh`. Both cases needed a plain HTTP client for their job and hence the workaround. The problem with these two outliers were:

1. UNIX socket config was ignored (the underlying issue)
2. The debug logging had to be duplicated
3. The `User-Agent` header was left to Golang's default `Go-http-client/2.0`
4. It wasn't testable

## Changes

**To fix 1 and 2,** we needed to use the HTTP client created by `cli/go-gh`. Thankfully, there is an option named `SkipDefaultHeaders` in `cli/go-gh`, that we could just expose and use in `cli/cli` to create plain HTTP clients.

**To resolve 3,** we needed to pull up the HTTP client instantiation to the command level where we have the information about the `gh` version (i.e. `f.AppVersion`). However, if we were going to do that exactly at the command-level, then we had to something similar to what is done in the `factory` package, in `httpClientFunc` ([here](https://github.com/cli/cli/blob/5eb6549dc79770363054ca019e1f930eb83a6e45/pkg/cmd/factory/default.go#L188-L208)). The better approach seemed to pull up the changes to the `factory` package and then provide a *plain* counterpart to `HttpClient` in the `factory` struct. This is what's done in this PR; a new field, named `PlainHttpClient` is now added to `factory`.

**Problem 4** is now resolved by adding an `http.Client` parameter to the [`OAuthFlow`](https://github.com/cli/cli/blob/5685b9a443f0d32f200a3796a8cecb30e85e7aa0/internal/authflow/flow.go#L30) function.

Note that in the `auth login` command, both HTTP client (ordinary and plain) are used. The plain one is only used for the OAuth flow, and the rest of the API calls are made through the ordinary one. Although usages of the ordinary client could be changed to use the plain one (except for one case where a function in `ssh add` command package is called), but I decided to not do that in case we break things unknowingly; it'd probably be fine, though.

## Testing UNIX socket support

### Against GHES

It's best to make a testing directory and do these within:

1. Run `make` and copy the built binary to the testing directory.
1. Make a UNIX socket via `socat`:
   ```sh
   socat -v unix-listen:temp.sock,fork openssl:<HOST>:443
   ```
   This will block and show verbose logs, so keep the terminal window open. A UNIX socket, named `temp.sock` will be created in the working directory.
1. Open a new shell in the same directory and set the `gh` config directory once for all.
   ```sh
   export GH_CONFIG_DIR=$(pwd)
   export GH_DEBUG=api
   ```
1. Configure `gh` to use the UNIX socket:
   ```sh
   ./gh config set http_unix_socket temp.sock
   ```
1. Run `auth login`, select *Other* and enter the hostname:
   ```sh
   ./gh auth login -c
   ```
   **Verify:** the login process finished successfully and `socat` logs contain the same calls as in `gh` debug output (note the responses in `socat` logs are `gzip`-ed so it's fine if request bodies match). FWIW in the issue (#11891), the OAuth flow calls didn't pass through the socket.
1. Run the followings one-by-one and verify:
   ```sh
   ./gh auth refresh -c
   ./gh auth refresh -c --scopes read:public_key
   ./gh auth refresh -c --remove-scopes read:public_key
   ./gh auth status
   ```
   **Verify:** the command finished successfully and the calls are visible on `socat` logs.
1. Run arbitrary non-`auth` commands and verify they work as expected:
   ```sh
   ./gh repo list
   ./gh api user
   ./gh issue list --repo <OWNER>/<REPO>
   ./gh pr list --repo <OWNER>/<REPO>
   ```

### Against `github.com`

Testing against `github.com` is a bit tricky, since we use two different domains during the login process; `github.com` for OAuth and `api.github.com` for secondary calls (e.g. discovering scopes). It's best to make a testing directory and do these within:

1. Run `make` and copy the built binary to the testing directory.
1. Make a script, named `hack.sh`, to dynamically handle arbitrary domains:
   ```sh
   #!/bin/bash

   _request="$(timeout 1 cat)"
   _host="$(echo "$_request" | grep -iE "^Host: " | cut -d' ' -f2 | tr -d '\r\n')"

   if [ -z "$_host" ]; then
       echo -e "no Host header in request"
       exit 1
   fi

   echo "$_request" | openssl s_client -quiet -verify_quiet -tls1_3 -connect "$_host:443"
   ```
1. Make a UNIX socket and `socat` it to the script:
   ```sh
   socat -v unix-listen:temp.sock,fork system:'bash hack.sh'
   ```
   This will block and show verbose logs, so keep the terminal window open. A UNIX socket, named `temp.sock` will be created in the working directory.
1. Open a new shell in the same directory and set the `gh` config directory once for all.
   ```sh
   export GH_CONFIG_DIR=$(pwd)
   export GH_DEBUG=api
   ```
1. Configure `gh` to use the UNIX socket:
   ```sh
   ./gh config set http_unix_socket temp.sock
   ```
1. Run `auth login` and select `GitHub.com` for host:
   ```sh
   ./gh auth login -c
   ```
   **Verify:** the login process finished successfully and `socat` logs contain the same calls as in `gh` debug output (note the responses in `socat` logs are `gzip`-ed so it's fine if request bodies match). FWIW in the issue (#11891), the OAuth flow calls didn't pass through the socket.
1. Run the followings one-by-one and verify:
   ```sh
   ./gh auth refresh -c
   ./gh auth refresh -c --scopes read:public_key
   ./gh auth refresh -c --remove-scopes read:public_key
   ./gh auth status
   ```
   **Verify:** the command finished successfully and the calls are visible on `socat` logs.
1. Run arbitrary non-`auth` commands and verify they work as expected:
   ```sh
   ./gh repo list
   ./gh api user
   ./gh issue list --repo cli/cli
   ./gh pr list --repo cli/cli
   ```
