### PR TITLE
fix(repo): handle existing upstream remote in fork clone

### DIFF
--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -365,6 +365,66 @@ func forkRun(opts *ForkOptions) error {
 			upstreamURL := ghrepo.FormatRemoteURL(repoToFork, protocol)
 			upstreamRemote := "upstream"
 
+			// Check if upstream remote already exists (e.g., from cloning a fork)
+			remotes, err := gc.Remotes(ctx)
+			if err != nil {
+				return err
+			}
+
+			// Check if a remote named "upstream" already exists
+			for _, remote := range remotes {
+				if remote.Name == upstreamRemote {
+					// If the existing upstream points to a different URL, rename it
+					existingURL := ""
+					if remote.FetchURL != nil {
+						existingURL = remote.FetchURL.String()
+					} else if remote.PushURL != nil {
+						existingURL = remote.PushURL.String()
+					}
+
+					// Normalize URLs for comparison (remove .git suffix if present)
+					normalizedExisting := strings.TrimSuffix(existingURL, ".git")
+					normalizedNew := strings.TrimSuffix(upstreamURL, ".git")
+
+					if normalizedExisting != normalizedNew {
+						// Rename the existing upstream remote to avoid conflict
+						renameTarget := "upstream-old"
+						renameCmd, err := gc.Command(ctx, "remote", "rename", upstreamRemote, renameTarget)
+						if err != nil {
+							return err
+						}
+						_, err = renameCmd.Output()
+						if err != nil {
+							return err
+						}
+
+						if connectedToTerminal {
+							fmt.Fprintf(stderr, "%s Renamed existing remote %s to %s\n", cs.SuccessIcon(), cs.Bold(upstreamRemote), cs.Bold(renameTarget))
+						}
+					} else {
+						// The upstream already points to the correct repository, skip adding it
+						if connectedToTerminal {
+							fmt.Fprintf(stderr, "%s Using existing remote %s\n", cs.SuccessIcon(), cs.Bold(upstreamRemote))
+						}
+						// Skip adding the remote since it already exists and points to the right place
+						if err := gc.SetRemoteResolution(ctx, upstreamRemote, "base"); err != nil {
+							return err
+						}
+
+						if err := gc.Fetch(ctx, upstreamRemote, ""); err != nil {
+							return err
+						}
+
+						if connectedToTerminal {
+							fmt.Fprintf(stderr, "%s Cloned fork\n", cs.SuccessIcon())
+							fmt.Fprintf(stderr, "%s Repository %s set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n", cs.WarningIcon(), cs.Bold(ghrepo.FullName(repoToFork)))
+						}
+						return nil
+					}
+					break
+				}
+			}
+
 			if _, err := gc.AddRemote(ctx, upstreamRemote, upstreamURL, []string{}); err != nil {
 				return err
 			}

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -444,6 +444,8 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone --depth 1 https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote -v`, 0, "origin\thttps://github.com/someone/REPO.git (fetch)\norigin\thttps://github.com/someone/REPO.git (push)\n")
+				cs.Register(`git -C REPO config --get-regexp \^remote\\.\.\*\\.gh-resolved\$`, 1, "")
 				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
@@ -476,6 +478,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/gamehendge/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote -v`, 0, "origin\thttps://github.com/gamehendge/REPO.git (fetch)\norigin\thttps://github.com/gamehendge/REPO.git (push)\n")
+				cs.Register(`git -C REPO config --get-regexp \^remote\\.\.\*\\.gh-resolved\$`, 1, "")
 				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
@@ -492,6 +496,8 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote -v`, 0, "origin\thttps://github.com/someone/REPO.git (fetch)\norigin\thttps://github.com/someone/REPO.git (push)\n")
+				cs.Register(`git -C REPO config --get-regexp \^remote\\.\.\*\\.gh-resolved\$`, 1, "")
 				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
@@ -528,6 +534,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote -v`, 0, "origin\thttps://github.com/someone/REPO.git (fetch)\norigin\thttps://github.com/someone/REPO.git (push)\n")
+				cs.Register(`git -C REPO config --get-regexp \^remote\\.\.\*\\.gh-resolved\$`, 1, "")
 				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
@@ -552,6 +560,8 @@ func TestRepoFork(t *testing.T) {
 			},
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote -v`, 0, "origin\thttps://github.com/someone/REPO.git (fetch)\norigin\thttps://github.com/someone/REPO.git (push)\n")
+				cs.Register(`git -C REPO config --get-regexp \^remote\\.\.\*\\.gh-resolved\$`, 1, "")
 				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
@@ -589,6 +599,8 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote -v`, 0, "origin\thttps://github.com/someone/REPO.git (fetch)\norigin\thttps://github.com/someone/REPO.git (push)\n")
+				cs.Register(`git -C REPO config --get-regexp \^remote\\.\.\*\\.gh-resolved\$`, 1, "")
 				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
@@ -604,6 +616,8 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote -v`, 0, "origin\thttps://github.com/someone/REPO.git (fetch)\norigin\thttps://github.com/someone/REPO.git (push)\n")
+				cs.Register(`git -C REPO config --get-regexp \^remote\\.\.\*\\.gh-resolved\$`, 1, "")
 				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
@@ -696,6 +710,8 @@ func TestRepoFork(t *testing.T) {
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 128, "")
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 128, "")
 				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO remote -v`, 0, "origin\thttps://github.com/someone/REPO.git (fetch)\norigin\thttps://github.com/someone/REPO.git (push)\n")
+				cs.Register(`git -C REPO config --get-regexp \^remote\\.\.\*\\.gh-resolved\$`, 1, "")
 				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
 				cs.Register(`git -C REPO fetch upstream`, 0, "")
 				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
@@ -716,6 +732,44 @@ func TestRepoFork(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  `failed to clone fork: failed to run git: git -c credential.helper= -c credential.helper=!"[^"]+" auth git-credential clone https://github.com/someone/REPO\.git exited with status 65`,
+		},
+		{
+			name: "clone with existing upstream remote pointing to different repo",
+			tty:  true,
+			opts: &ForkOptions{
+				Repository: "OWNER/REPO",
+				Clone:      true,
+			},
+			httpStubs: forkPost,
+			execStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				// Simulate existing upstream remote pointing to a different repository
+				cs.Register(`git -C REPO remote -v`, 0, "origin\thttps://github.com/someone/REPO.git (fetch)\norigin\thttps://github.com/someone/REPO.git (push)\nupstream\thttps://github.com/original/REPO.git (fetch)\nupstream\thttps://github.com/original/REPO.git (push)\n")
+				cs.Register(`git -C REPO config --get-regexp \^remote\\.\.\*\\.gh-resolved\$`, 1, "")
+				cs.Register(`git -C REPO remote rename upstream upstream-old`, 0, "")
+				cs.Register(`git -C REPO remote add upstream https://github\.com/OWNER/REPO\.git`, 0, "")
+				cs.Register(`git -C REPO fetch upstream`, 0, "")
+				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
+			},
+			wantErrOut: "✓ Created fork someone/REPO\n✓ Renamed existing remote upstream to upstream-old\n✓ Cloned fork\n! Repository OWNER/REPO set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n",
+		},
+		{
+			name: "clone with existing upstream remote pointing to same repo",
+			tty:  true,
+			opts: &ForkOptions{
+				Repository: "OWNER/REPO",
+				Clone:      true,
+			},
+			httpStubs: forkPost,
+			execStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git clone https://github.com/someone/REPO\.git`, 0, "")
+				// Simulate existing upstream remote already pointing to the correct repository
+				cs.Register(`git -C REPO remote -v`, 0, "origin\thttps://github.com/someone/REPO.git (fetch)\norigin\thttps://github.com/someone/REPO.git (push)\nupstream\thttps://github.com/OWNER/REPO.git (fetch)\nupstream\thttps://github.com/OWNER/REPO.git (push)\n")
+				cs.Register(`git -C REPO config --get-regexp \^remote\\.\.\*\\.gh-resolved\$`, 1, "")
+				cs.Register(`git -C REPO fetch upstream`, 0, "")
+				cs.Register(`git -C REPO config --add remote.upstream.gh-resolved base`, 0, "")
+			},
+			wantErrOut: "✓ Created fork someone/REPO\n✓ Using existing remote upstream\n✓ Cloned fork\n! Repository OWNER/REPO set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n",
 		},
 	}
 


### PR DESCRIPTION
## Summary

  Fixes #11884

  This PR resolves an issue where `gh repo fork` fails with "remote upstream already exists" when run on a repository that was cloned as a fork.

  ## Problem

  When users clone a forked repository using `gh repo clone`, the CLI automatically adds an "upstream" remote pointing to the parent repository. If the user then runs `gh repo fork` to fork that repository
  again, the command would fail because it tried to add a new "upstream" remote without checking if one already existed.

  **Reproduction steps:**
  ```bash
  gh repo clone someone/repo  # Clone a fork (adds upstream automatically)
  cd repo
  gh repo fork --clone                        # Fails: "remote upstream already exists"

  Solution

  Added logic to check for existing "upstream" remotes after cloning in the fork command. The fix handles two scenarios:

  1. Upstream exists with different URL → Renames existing remote to "upstream-old", then adds new upstream
  2. Upstream exists with correct URL → Reuses existing remote without error

  This brings the clone scenario behavior in line with the in-parent scenario, which already had proper conflict handling.

  Changes

  - Modified pkg/cmd/repo/fork/fork.go to check for existing upstream remotes before adding a new one
  - Added URL normalization to handle .git suffix differences
  - Added two test cases covering both scenarios (different URL and same URL)
  - Updated existing test stubs to handle the new git remote -v calls

  Testing

  All tests pass:
  go test ./pkg/cmd/repo/fork/... -v
