### PR TITLE
💡 (gh repo delete) Add warning when `--yes` is ignored without a repository, Closes: #12033

### DIFF
--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -62,6 +62,7 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 				if !opts.IO.CanPrompt() {
 					return cmdutil.FlagErrorf("cannot non-interactively delete current repository. Please specify a repository or run interactively")
 				}
+				_, _ = fmt.Fprintln(opts.IO.ErrOut, "Warning: `--yes` is ignored since no repository was specified")
 				opts.Confirmed = false
 			}
 

--- a/pkg/cmd/repo/delete/delete_test.go
+++ b/pkg/cmd/repo/delete/delete_test.go
@@ -42,7 +42,6 @@ func TestNewCmdDelete(t *testing.T) {
 			output:     DeleteOptions{RepoArg: "OWNER/REPO"},
 			wantErr:    true,
 			wantErrMsg: "--yes required when not running interactively",
-			wantStderr: "Error: --yes required when not running interactively\n",
 		},
 		{
 			name:   "base repo resolution",
@@ -63,14 +62,12 @@ func TestNewCmdDelete(t *testing.T) {
 			input:      "--yes",
 			wantErr:    true,
 			wantErrMsg: "cannot non-interactively delete current repository. Please specify a repository or run interactively",
-			wantStderr: "Error: cannot non-interactively delete current repository. Please specify a repository or run interactively\n",
 		},
 		{
 			name:       "confirm flag error when no argument notty",
 			input:      "--confirm",
 			wantErr:    true,
 			wantErrMsg: "cannot non-interactively delete current repository. Please specify a repository or run interactively",
-			wantStderr: "Error: cannot non-interactively delete current repository. Please specify a repository or run interactively\n",
 		},
 		{
 			name:       "confirm flag also ignored when no argument tty",
@@ -103,13 +100,13 @@ func TestNewCmdDelete(t *testing.T) {
 
 			_, err = cmd.ExecuteC()
 
-			assert.Equal(t, tt.wantStderr, stdErr.String())
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Equal(t, tt.wantErrMsg, err.Error())
 				return
 			}
 			assert.NoError(t, err)
+			assert.Equal(t, tt.wantStderr, stdErr.String())
 			assert.Equal(t, tt.output.RepoArg, gotOpts.RepoArg)
 		})
 	}

--- a/pkg/cmd/repo/delete/delete_test.go
+++ b/pkg/cmd/repo/delete/delete_test.go
@@ -16,12 +16,13 @@ import (
 
 func TestNewCmdDelete(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		tty     bool
-		output  DeleteOptions
-		wantErr bool
-		errMsg  string
+		name       string
+		input      string
+		tty        bool
+		output     DeleteOptions
+		wantErr    bool
+		wantErrMsg string
+		wantStderr string
 	}{
 		{
 			name:   "confirm flag",
@@ -36,11 +37,12 @@ func TestNewCmdDelete(t *testing.T) {
 			output: DeleteOptions{RepoArg: "OWNER/REPO", Confirmed: true},
 		},
 		{
-			name:    "no confirmation notty",
-			input:   "OWNER/REPO",
-			output:  DeleteOptions{RepoArg: "OWNER/REPO"},
-			wantErr: true,
-			errMsg:  "--yes required when not running interactively",
+			name:       "no confirmation notty",
+			input:      "OWNER/REPO",
+			output:     DeleteOptions{RepoArg: "OWNER/REPO"},
+			wantErr:    true,
+			wantErrMsg: "--yes required when not running interactively",
+			wantStderr: "Error: --yes required when not running interactively\n",
 		},
 		{
 			name:   "base repo resolution",
@@ -49,33 +51,39 @@ func TestNewCmdDelete(t *testing.T) {
 			output: DeleteOptions{},
 		},
 		{
-			name:   "yes flag ignored when no argument tty",
-			tty:    true,
-			input:  "--yes",
-			output: DeleteOptions{Confirmed: false}, // --yes should be ignored
+			name:       "yes flag ignored when no argument tty",
+			tty:        true,
+			input:      "--yes",
+			output:     DeleteOptions{Confirmed: false}, // --yes should be ignored
+			wantErr:    false,
+			wantStderr: "Warning: `--yes` is ignored since no repository was specified\n",
 		},
 		{
-			name:    "yes flag error when no argument notty",
-			input:   "--yes",
-			wantErr: true,
-			errMsg:  "cannot non-interactively delete current repository. Please specify a repository or run interactively",
+			name:       "yes flag error when no argument notty",
+			input:      "--yes",
+			wantErr:    true,
+			wantErrMsg: "cannot non-interactively delete current repository. Please specify a repository or run interactively",
+			wantStderr: "Error: cannot non-interactively delete current repository. Please specify a repository or run interactively\n",
 		},
 		{
-			name:    "confirm flag error when no argument notty",
-			input:   "--confirm",
-			wantErr: true,
-			errMsg:  "cannot non-interactively delete current repository. Please specify a repository or run interactively",
+			name:       "confirm flag error when no argument notty",
+			input:      "--confirm",
+			wantErr:    true,
+			wantErrMsg: "cannot non-interactively delete current repository. Please specify a repository or run interactively",
+			wantStderr: "Error: cannot non-interactively delete current repository. Please specify a repository or run interactively\n",
 		},
 		{
-			name:   "confirm flag also ignored when no argument tty",
-			tty:    true,
-			input:  "--confirm",
-			output: DeleteOptions{Confirmed: false}, // --confirm should also be ignored
+			name:       "confirm flag also ignored when no argument tty",
+			tty:        true,
+			input:      "--confirm",
+			output:     DeleteOptions{Confirmed: false}, // --confirm should also be ignored
+			wantStderr: "Warning: `--yes` is ignored since no repository was specified\n",
+			// Note: This does not confuse the user, as deprecation warnings are shown: "Flag --confirm has been deprecated, use `--yes` instead"
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ios, _, _, _ := iostreams.Test()
+			ios, _, _, stdErr := iostreams.Test()
 			ios.SetStdinTTY(tt.tty)
 			ios.SetStdoutTTY(tt.tty)
 			f := &cmdutil.Factory{
@@ -91,12 +99,14 @@ func TestNewCmdDelete(t *testing.T) {
 			cmd.SetArgs(argv)
 			cmd.SetIn(&bytes.Buffer{})
 			cmd.SetOut(&bytes.Buffer{})
-			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetErr(stdErr)
 
 			_, err = cmd.ExecuteC()
+
+			assert.Equal(t, tt.wantStderr, stdErr.String())
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.Equal(t, tt.errMsg, err.Error())
+				assert.Equal(t, tt.wantErrMsg, err.Error())
 				return
 			}
 			assert.NoError(t, err)


### PR DESCRIPTION
Fixes #12033

## Description

When `gh repo delete --yes` is used **without** an explicit `OWNER/REPO`, the flag is ignored (for safety).
Users may miss this and assume non-interactive deletion. This PR surfaces a clear notice in interactive mode and preserves an error in non-interactive mode, making the behavior explicit and script-friendly.

## Changes

* In interactive (TTY) runs with `--yes` but no `OWNER/REPO`, print:

  ```
  Warning: `--yes` is ignored since no repository was specified
  ```

## Expected behavior

* `gh repo delete --yes` (TTY) → emits warning; proceeds interactively.
* `gh repo delete --yes` (non-TTY) → returns the existing error; no warning.
* `gh repo delete OWNER/REPO --yes` → unchanged (non-interactive deletion).

## Notes

To verify that the warning is printed to stderr **only in interactive environments**, I added assertions for both wantStderr and wantErrMsg.
While this may look slightly redundant, the logic for printing errors and warnings to stderr is handled internally by Cobra.

> ## Acceptance Criteria
> **Given** I'm running `gh` interactively from a cloned repo directory **When** I run `gh repo delete --yes` **Then** I see the below warning message on stderr and then the prompt to confirm the repo name:
> 
> ```
> Warning: `--yes` is ignored since no repository was specified
> ```

https://github.com/cli/cli/issues/12033#issuecomment-3456127338



