### PR TITLE
Fix typo in comment for `gh issue develop` branch checkout command

### DIFF
--- a/pkg/cmd/issue/develop/develop.go
+++ b/pkg/cmd/issue/develop/develop.go
@@ -61,7 +61,7 @@ func NewCmdDevelop(f *cmdutil.Factory, runF func(*DevelopOptions) error) *cobra.
 			# Create a branch for issue 123 based on the my-feature branch
 			$ gh issue develop 123 --base my-feature
 
-			# Create a branch for issue 123 and checkout it out
+			# Create a branch for issue 123 and check it out
 			$ gh issue develop 123 --checkout
 
 			# Create a branch in repo monalisa/cli for issue 123 in repo cli/cli


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Just fixing a typo in examples for `gh issue develop`
