### PR TITLE
Add repo_default_remote config option

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ const (
 	pagerKey              = "pager"
 	promptKey             = "prompt"
 	preferEditorPromptKey = "prefer_editor_prompt"
+	repoDefaultRemote     = "repo_default_remote"
 	spinnerKey            = "spinner"
 	userKey               = "user"
 	usersKey              = "users"
@@ -162,6 +163,11 @@ func (c *cfg) Prompt(hostname string) gh.ConfigEntry {
 func (c *cfg) PreferEditorPrompt(hostname string) gh.ConfigEntry {
 	// Intentionally panic if there is no user provided value or default value (which would be a programmer error)
 	return c.GetOrDefault(hostname, preferEditorPromptKey).Unwrap()
+}
+
+func (c *cfg) RepoDefaultRemote(hostname string) gh.ConfigEntry {
+	// Intentionally panic if there is no user provided value or default value (which would be a programmer error)
+	return c.GetOrDefault(hostname, repoDefaultRemote).Unwrap()
 }
 
 func (c *cfg) Spinner(hostname string) gh.ConfigEntry {
@@ -680,6 +686,14 @@ var Options = []ConfigOption{
 		AllowedValues: []string{"enabled", "disabled"},
 		CurrentValue: func(c gh.Config, hostname string) string {
 			return c.Spinner(hostname).Value
+		},
+	},
+	{
+		Key:          repoDefaultRemote,
+		Description:  "the default remote name to use for gh repo/pr/issue/workflow/etc.",
+		DefaultValue: "",
+		CurrentValue: func(c gh.Config, hostname string) string {
+			return c.RepoDefaultRemote(hostname).Value
 		},
 	},
 }

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -55,6 +55,8 @@ type Config interface {
 	Prompt(hostname string) ConfigEntry
 	// PreferEditorPrompt returns the configured editor-based prompt, optionally scoped by host.
 	PreferEditorPrompt(hostname string) ConfigEntry
+	// RepoDefaultRemote returns the configured repo default remote name, optionally scoped by host.
+	RepoDefaultRemote(hostname string) ConfigEntry
 	// Spinner returns the configured spinner setting, optionally scoped by host.
 	Spinner(hostname string) ConfigEntry
 

--- a/internal/gh/mock/config.go
+++ b/internal/gh/mock/config.go
@@ -64,6 +64,9 @@ var _ gh.Config = &ConfigMock{}
 //			PromptFunc: func(hostname string) gh.ConfigEntry {
 //				panic("mock out the Prompt method")
 //			},
+//			RepoDefaultRemoteFunc: func(hostname string) gh.ConfigEntry {
+//				panic("mock out the RepoDefaultRemote method")
+//			},
 //			SetFunc: func(hostname string, key string, value string)  {
 //				panic("mock out the Set method")
 //			},
@@ -127,6 +130,9 @@ type ConfigMock struct {
 
 	// PromptFunc mocks the Prompt method.
 	PromptFunc func(hostname string) gh.ConfigEntry
+
+	// RepoDefaultRemoteFunc mocks the RepoDefaultRemote method.
+	RepoDefaultRemoteFunc func(hostname string) gh.ConfigEntry
 
 	// SetFunc mocks the Set method.
 	SetFunc func(hostname string, key string, value string)
@@ -213,6 +219,11 @@ type ConfigMock struct {
 			// Hostname is the hostname argument value.
 			Hostname string
 		}
+		// RepoDefaultRemote holds details about calls to the RepoDefaultRemote method.
+		RepoDefaultRemote []struct {
+			// Hostname is the hostname argument value.
+			Hostname string
+		}
 		// Set holds details about calls to the Set method.
 		Set []struct {
 			// Hostname is the hostname argument value.
@@ -249,6 +260,7 @@ type ConfigMock struct {
 	lockPager              sync.RWMutex
 	lockPreferEditorPrompt sync.RWMutex
 	lockPrompt             sync.RWMutex
+	lockRepoDefaultRemote  sync.RWMutex
 	lockSet                sync.RWMutex
 	lockSpinner            sync.RWMutex
 	lockVersion            sync.RWMutex
@@ -478,6 +490,22 @@ func (mock *ConfigMock) Editor(hostname string) gh.ConfigEntry {
 	mock.calls.Editor = append(mock.calls.Editor, callInfo)
 	mock.lockEditor.Unlock()
 	return mock.EditorFunc(hostname)
+}
+
+// RepoDefaultRemote calls RepoDefaultRemoteFunc.
+func (mock *ConfigMock) RepoDefaultRemote(hostname string) gh.ConfigEntry {
+	if mock.RepoDefaultRemoteFunc == nil {
+		panic("ConfigMock.RepoDefaultRemoteFunc: method is nil but Config.RepoDefaultRemote was just called")
+	}
+	callInfo := struct {
+		Hostname string
+	}{
+		Hostname: hostname,
+	}
+	mock.lockRepoDefaultRemote.Lock()
+	mock.calls.RepoDefaultRemote = append(mock.calls.RepoDefaultRemote, callInfo)
+	mock.lockRepoDefaultRemote.Unlock()
+	return mock.RepoDefaultRemoteFunc(hostname)
 }
 
 // EditorCalls gets all the calls that were made to Editor.

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -163,6 +163,27 @@ func SmartBaseRepoFunc(f *cmdutil.Factory) func() (ghrepo.Interface, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// Optional global fallback for default repo selection via repo_default_remote
+		// Apply only when there is no per-repo resolution already present.
+		// This preserves precedence of: --repo, GH_REPO, and `gh repo set-default`.
+		_, err = remotes.ResolvedRemote()
+		if err != nil {
+			if cfg, cerr := f.Config(); cerr == nil {
+				if opt := cfg.GetOrDefault("", "repo_default_remote"); opt.IsSome() {
+					if entry, ok := opt.Value(); ok {
+						key := entry.Value
+						if key != "" {
+							if named, nerr := remotes.FindByName(key); nerr == nil && named != nil {
+								return named.Repo, nil
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Fall back to existing network-aware resolution and interactive prompting behavior
 		resolvedRepos, err := ghContext.ResolveRemotesToRepos(remotes, apiClient, "")
 		if err != nil {
 			return nil, err

--- a/pkg/cmd/factory/default_test.go
+++ b/pkg/cmd/factory/default_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	o "github.com/cli/cli/v2/pkg/option"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -738,6 +739,119 @@ func TestPlainHttpClient(t *testing.T) {
 	assert.Nil(t, receivedHeaders.Values("Content-Type"))
 	assert.Nil(t, receivedHeaders.Values("Accept"))
 	assert.Nil(t, receivedHeaders.Values("Time-Zone"))
+}
+
+func Test_SmartBaseRepo_RepoDefaultRemote(t *testing.T) {
+	pu, _ := url.Parse("https://github.com/newowner/newrepo.git")
+
+	tests := []struct {
+		name      string
+		remotes   git.RemoteSet
+		cfgMock   *ghmock.ConfigMock
+		wantsErr  bool
+		wantsName string
+		wantsOwner string
+		wantsHost string
+	}{
+		{
+			name: "fallback selects named remote",
+			remotes: git.RemoteSet{
+				git.NewRemote("origin", "https://github.com/owner/repo.git"),
+			},
+			cfgMock: func() *ghmock.ConfigMock {
+				m := &ghmock.ConfigMock{}
+				m.AuthenticationFunc = func() gh.AuthConfig {
+					a := &config.AuthConfig{}
+					a.SetHosts([]string{"github.com"})
+					a.SetActiveToken("", "")
+					a.SetDefaultHost("github.com", "hosts")
+					return a
+				}
+				m.GetOrDefaultFunc = func(hostname string, key string) o.Option[gh.ConfigEntry] {
+					if key == "repo_default_remote" {
+						return o.Some(gh.ConfigEntry{Value: "origin", Source: gh.ConfigUserProvided})
+					}
+					return o.None[gh.ConfigEntry]()
+				}
+				return m
+			}(),
+			wantsName: "repo",
+			wantsOwner: "owner",
+			wantsHost: "github.com",
+		},
+		{
+			name: "fallback ignored when remote already resolved",
+			remotes: git.RemoteSet{
+				&git.Remote{Name: "origin", Resolved: "base", FetchURL: pu, PushURL: pu},
+			},
+			cfgMock: func() *ghmock.ConfigMock {
+				m := &ghmock.ConfigMock{}
+				m.AuthenticationFunc = func() gh.AuthConfig {
+					a := &config.AuthConfig{}
+					a.SetHosts([]string{"github.com"})
+					a.SetActiveToken("", "")
+					a.SetDefaultHost("github.com", "hosts")
+					return a
+				}
+				m.GetOrDefaultFunc = func(hostname string, key string) o.Option[gh.ConfigEntry] {
+					if key == "repo_default_remote" {
+						return o.Some(gh.ConfigEntry{Value: "origin", Source: gh.ConfigUserProvided})
+					}
+					return o.None[gh.ConfigEntry]()
+				}
+				return m
+			}(),
+			wantsName: "newrepo",
+			wantsOwner: "newowner",
+			wantsHost: "github.com",
+		},
+		{
+			name: "fallback set but non-GitHub remote",
+			remotes: git.RemoteSet{
+				git.NewRemote("origin", "https://example.com/owner/repo.git"),
+			},
+			cfgMock: func() *ghmock.ConfigMock {
+				m := &ghmock.ConfigMock{}
+				m.AuthenticationFunc = func() gh.AuthConfig {
+					a := &config.AuthConfig{}
+					// Known hosts do not include example.com, so remote will be filtered out
+					a.SetHosts([]string{"github.com"})
+					a.SetActiveToken("", "")
+					a.SetDefaultHost("github.com", "hosts")
+					return a
+				}
+				m.GetOrDefaultFunc = func(hostname string, key string) o.Option[gh.ConfigEntry] {
+					if key == "repo_default_remote" {
+						return o.Some(gh.ConfigEntry{Value: "origin", Source: gh.ConfigUserProvided})
+					}
+					return o.None[gh.ConfigEntry]()
+				}
+				return m
+			}(),
+			wantsErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := New("1")
+			rr := &remoteResolver{
+				readRemotes: func() (git.RemoteSet, error) { return tt.remotes, nil },
+				getConfig:   func() (gh.Config, error) { return tt.cfgMock, nil },
+			}
+			f.Remotes = rr.Resolver()
+			f.BaseRepo = SmartBaseRepoFunc(f)
+			repo, err := f.BaseRepo()
+			if tt.wantsErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantsName, repo.RepoName())
+			assert.Equal(t, tt.wantsOwner, repo.RepoOwner())
+			assert.Equal(t, tt.wantsHost, repo.RepoHost())
+		})
+	}
 }
 
 func TestNewGitClient(t *testing.T) {


### PR DESCRIPTION
## Problem

At the moment, it’s a bit cumbersome having to explicitly set the **default remote** in every single local Git repository just to be able to use commands like `gh repo`, `gh pr`, `gh issue`, `gh workflow`, etc.

I constantly run into the following error:

```
X No default remote repository has been set.
To learn more about the default repository, run: gh repo set-default --help

please run `gh repo set-default` to select a default remote repository.
```

## Context

For my workflow, the canonical default remote name `origin` _always_ points to the **source repository**.
Fork remotes typically have short two-character initials (for user forks) or the organization name (for org forks).
In other words, `origin` is universally the correct default for my setup.

## Solution

To avoid having to manually run `gh repo set-default origin`, I added a simple, optional global override:

```sh
gh config set repo_default_remote origin
```

Once set, I no longer see the “No default repository” error — `gh` automatically uses the specified remote (e.g., `origin`) when no explicit repo is configured.

## Behavior / Precedence

The new `repo_default_remote` config key is an **opt-in** global setting.
When unset (the default), existing behavior remains unchanged.
When set, repository resolution follows this precedence (highest → lowest):

  1. `-R` / `--repo` flag
  2. `GH_REPO` environment variable
  3. Per-repo default set via `gh repo set-default`
  4. **NEW (optional global fallback):** `repo_default_remote`
  5. Otherwise → existing “No default repository…” error

---

Directly relates to #9399 (while it does not auto-default to any name, it provides a simple one-time way to solve the issue).

Also related:

#9398
#9149
#8659