### PR TITLE
Bump Golangci-lint to `v2.6.0`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1.6
+          version: v2.6.0
 
   # Discover vulnerabilities within Go standard libraries used to build GitHub CLI using govulncheck.
   govulncheck:


### PR DESCRIPTION
Fixes #12007 