### PR TITLE
Apply `go fix` to remove deprecated `// +build` tags

### DIFF
--- a/pkg/cmd/attestation/artifact/artifact_posix_test.go
+++ b/pkg/cmd/attestation/artifact/artifact_posix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package artifact
 

--- a/pkg/cmd/attestation/artifact/artifact_windows_test.go
+++ b/pkg/cmd/attestation/artifact/artifact_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package artifact
 

--- a/pkg/cmd/extension/symlink_other.go
+++ b/pkg/cmd/extension/symlink_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package extension
 

--- a/pkg/findsh/find.go
+++ b/pkg/findsh/find.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package findsh
 

--- a/pkg/iostreams/console.go
+++ b/pkg/iostreams/console.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package iostreams
 

--- a/pkg/iostreams/console_windows.go
+++ b/pkg/iostreams/console_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package iostreams
 

--- a/pkg/iostreams/epipe_other.go
+++ b/pkg/iostreams/epipe_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package iostreams
 


### PR DESCRIPTION
Fixes #12055

As of Go 1.18, `// +build` tags are deprecated in favour of more flexible `//go:build` tags. I just used `go fix ./...`, as of Go [official docs](https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md#transition), to fix the issues. We had both tags, so we're fine with just removing the old-style tags.
