### PR TITLE
Exclude `third-party` from Golangci-lint formatting paths

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,9 @@ linters:
 formatters:
   enable:
     - gofmt
+  exclusions:
+    paths:
+      - third-party
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
Fixes #12057 
