### PR TITLE
Add `isImmutable` to `release list` JSON output

### DIFF
--- a/internal/featuredetection/detector_mock.go
+++ b/internal/featuredetection/detector_mock.go
@@ -24,6 +24,10 @@ func (md *DisabledDetectorMock) SearchFeatures() (SearchFeatures, error) {
 	return advancedIssueSearchNotSupported, nil
 }
 
+func (md *DisabledDetectorMock) ReleaseFeatures() (ReleaseFeatures, error) {
+	return ReleaseFeatures{}, nil
+}
+
 type EnabledDetectorMock struct{}
 
 func (md *EnabledDetectorMock) IssueFeatures() (IssueFeatures, error) {
@@ -44,6 +48,12 @@ func (md *EnabledDetectorMock) ProjectsV1() gh.ProjectsV1Support {
 
 func (md *EnabledDetectorMock) SearchFeatures() (SearchFeatures, error) {
 	return advancedIssueSearchNotSupported, nil
+}
+
+func (md *EnabledDetectorMock) ReleaseFeatures() (ReleaseFeatures, error) {
+	return ReleaseFeatures{
+		ImmutableReleases: true,
+	}, nil
 }
 
 type AdvancedIssueSearchDetectorMock struct {

--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -44,12 +44,12 @@ func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, ex
 	// support immutable releases, which would probably be when GHES 3.18 goes
 	// EOL. At that point we can remove this if statement.
 	//
-	// Note 1: This could be have been done differently by using dual two
-	// separate query types or even using plain text/string queries. But, both
-	// would require us to refactor them back in the future, to the single,
-	// strongly-typed query approach as it was before. So, duplicating the entire
-	// function for now seems like the lesser evil, with a quicker and less risky
-	// clean up in the near future.
+	// Note 1: This could have been done differently by using two separate query
+	// types or even using plain text/string queries. But, both would require us
+	// to refactor them back in the future, to the single, strongly-typed query
+	// approach as it was before. So, duplicating the entire function for now
+	// seems like the lesser evil, with a quicker and less risky clean up in the
+	// near future.
 	//
 	// Note 2: We couldn't use GraphQL directives like `@include(condition)` or
 	// `@skip`(condition) here because if the field doesn't exist on the schema

--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -52,7 +52,7 @@ func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, ex
 	// near future.
 	//
 	// Note 2: We couldn't use GraphQL directives like `@include(condition)` or
-	// `@skip`(condition) here because if the field doesn't exist on the schema
+	// `@skip(condition)` here because if the field doesn't exist on the schema
 	// then the whole query would still fail regardless of the condition being
 	// met or not.
 	if !releaseFeatures.ImmutableReleases {

--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/shurcooL/githubv4"
@@ -17,6 +18,7 @@ var releaseFields = []string{
 	"isDraft",
 	"isLatest",
 	"isPrerelease",
+	"isImmutable",
 	"createdAt",
 	"publishedAt",
 }
@@ -25,6 +27,7 @@ type Release struct {
 	Name         string
 	TagName      string
 	IsDraft      bool
+	IsImmutable  bool `graphql:"immutable"`
 	IsLatest     bool
 	IsPrerelease bool
 	CreatedAt    time.Time
@@ -35,7 +38,27 @@ func (r *Release) ExportData(fields []string) map[string]interface{} {
 	return cmdutil.StructExportData(r, fields)
 }
 
-func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, excludeDrafts bool, excludePreReleases bool, order string) ([]Release, error) {
+func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, excludeDrafts bool, excludePreReleases bool, order string, releaseFeatures fd.ReleaseFeatures) ([]Release, error) {
+	// TODO: immutableReleaseFullSupport
+	// This is a temporary workaround until all supported GHES versions fully
+	// support immutable releases, which would probably be when GHES 3.18 goes
+	// EOL. At that point we can remove this if statement.
+	//
+	// Note 1: This could be have been done differently by using dual two
+	// separate query types or even using plain text/string queries. But, both
+	// would require us to refactor them back in the future, to the single,
+	// strongly-typed query approach as it was before. So, duplicating the entire
+	// function for now seems like the lesser evil, with a quicker and less risky
+	// clean up in the near future.
+	//
+	// Note 2: We couldn't use GraphQL directives like `@include(condition)` or
+	// `@skip`(condition) here because if the field doesn't exist on the schema
+	// then the whole query would still fail regardless of the condition being
+	// met or not.
+	if !releaseFeatures.ImmutableReleases {
+		return fetchReleasesWithoutImmutableReleases(httpClient, repo, limit, excludeDrafts, excludePreReleases, order)
+	}
+
 	type responseData struct {
 		Repository struct {
 			Releases struct {
@@ -80,6 +103,91 @@ loop:
 				continue
 			}
 			releases = append(releases, r)
+			if len(releases) == limit {
+				break loop
+			}
+		}
+
+		if !query.Repository.Releases.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Repository.Releases.PageInfo.EndCursor)
+	}
+
+	return releases, nil
+}
+
+// TODO: immutableReleaseFullSupport
+// This is a temporary workaround until all supported GHES versions fully
+// support immutable releases, which would be when GHES 3.18 goes EOL. At that
+// point we can remove this function.
+func fetchReleasesWithoutImmutableReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, excludeDrafts bool, excludePreReleases bool, order string) ([]Release, error) {
+	type releaseOld struct {
+		Name         string
+		TagName      string
+		IsDraft      bool
+		IsLatest     bool
+		IsPrerelease bool
+		CreatedAt    time.Time
+		PublishedAt  time.Time
+	}
+
+	fromReleaseOld := func(old releaseOld) Release {
+		return Release{
+			Name:         old.Name,
+			TagName:      old.TagName,
+			IsDraft:      old.IsDraft,
+			IsLatest:     old.IsLatest,
+			IsPrerelease: old.IsPrerelease,
+			CreatedAt:    old.CreatedAt,
+			PublishedAt:  old.PublishedAt,
+		}
+	}
+
+	type responseData struct {
+		Repository struct {
+			Releases struct {
+				Nodes    []releaseOld
+				PageInfo struct {
+					HasNextPage bool
+					EndCursor   string
+				}
+			} `graphql:"releases(first: $perPage, orderBy: {field: CREATED_AT, direction: $direction}, after: $endCursor)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	perPage := limit
+	if limit > 100 {
+		perPage = 100
+	}
+
+	variables := map[string]interface{}{
+		"owner":     githubv4.String(repo.RepoOwner()),
+		"name":      githubv4.String(repo.RepoName()),
+		"perPage":   githubv4.Int(perPage),
+		"endCursor": (*githubv4.String)(nil),
+		"direction": githubv4.OrderDirection(strings.ToUpper(order)),
+	}
+
+	gql := api.NewClientFromHTTP(httpClient)
+
+	var releases []Release
+loop:
+	for {
+		var query responseData
+		err := gql.Query(repo.RepoHost(), "RepositoryReleaseList", &query, variables)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, r := range query.Repository.Releases.Nodes {
+			if excludeDrafts && r.IsDraft {
+				continue
+			}
+			if excludePreReleases && r.IsPrerelease {
+				continue
+			}
+			releases = append(releases, fromReleaseOld(r))
 			if len(releases) == limit {
 				break loop
 			}

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -72,7 +72,7 @@ func listRun(opts *ListOptions) error {
 	}
 
 	// TODO: immutableReleaseFullSupport
-	// The detector is not needed when covered GHES version fully support
+	// The detector is not needed when covered GHES versions fully support
 	// immutable releases (probably when 3.18 goes EOL).
 	if opts.Detector == nil {
 		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)


### PR DESCRIPTION
Fixes #11272

## Notes for reviewers

- Since the GraphQL query has to be different based on the host's support for immutable releases, I had three options for implementation:
  1. plain text query compilation (i.e. dynamically adding the `immutable` field if applicable)
  2. dynamic handling of two strongly-typed query types in the same function
  3. duplicating the strongly-typed query function into two separate ones
  
  I decided to go with the 3rd option since it's more readable and simpler to cleanup (i.e. by just deleting the duplicated function) while keeping our strongly-typed query approach. The cleanup should happen after all covered GHES versions fully support immutable releases. **This decision is based on the assumption that there'll be no new Release-level fields/features like this.** I might be wrong, in which case I believe it'd be best to go with the first approach (plain text queries) which will make room for adding more fields as we go. Please comment if that's the case and I'll take care of it. Needless to mention the 2nd option is super complex with basically duplicating everything in a single function; harder to read/maintain and aesthetically unpleasant.

- Another assumption here, is that new GHES versions will be shipped with immutable releases. So at some point we can comeback and clean up the dual behaviour and bring the simple code back. As I checked, the latest GHES 3.18 does not support immutable releases. So I guess we should at least wait until 3.18 goes EOL. If this is not the right assumption, please let me know. This'll be another reason for going with plain text queries.

## A/C Verification

> **Given** I'm using `gh` against `github.com`
> **When** I run `gh release list -R OWNER/REPO`
> **Then** I see no changes in the output structure

Confirmed. The `isImmutable` field is only visible in `JSON` mode.

> **Given** I'm using `gh` against `github.com`
> **When** I run `gh release list -R OWNER/REPO --json name,isImmutable`
> **Then** I see the `isImmutable` field is correctly assigned

Confirmed: (I enabled immutable releases on this before making the second release)
```
$ gh release list -R gh-babakks/foo --json name,isImmutable | jq 
[
  {
    "isImmutable": false,
    "name": "title"
  },
  {
    "isImmutable": true,
    "name": "v1.1.2"
  }
]
```

> **Given** I'm using `gh` against a GHES host that does not support immutable releases
> **When** I run `gh release list -R OWNER/REPO --json name,isImmutable`
> **Then** I see the `isImmutable` field is set to `false` for all entries

Confirmed by testing against GHES 3.18:

```
$ GH_HOST=<HOST> gh release list -R gh-babakks/foo --json name,isImmutable | jq
[
  {
    "isImmutable": false,
    "name": "title"
  }
]
```

> **Given** I'm using `gh` against a GHES host that supports immutable releases
> **When** I run `gh release list -R OWNER/REPO --json name,isImmutable`
> **Then** I see the `isImmutable` field is correctly assigned

*Unable to confirm since we yet to have such a GHES version.*

