### PR TITLE
chore: add `workflow_dispatch` to govulncheck triggers

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -2,6 +2,8 @@ name: Go Vulnerability Check
 on:
   schedule:
     - cron: "0 0 * * 1" # Every Monday at midnight UTC
+  workflow_dispatch:
+
 jobs:
   govulncheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds the `workflow_dispatch` to the `govulncheck` workflow.
