### PR TITLE
CI: Update lint govulncheck to use source mode

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,5 +62,4 @@ jobs:
       # See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck#hdr-Exit_codes for more information on exit codes.
       - name: Check Go vulnerabilities
         run: |
-          make
-          go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 -mode=binary bin/gh
+          go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,6 +60,9 @@ jobs:
 
       # `govulncheck` exits unsuccessfully if vulnerabilities are found, providing results in stdout.
       # See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck#hdr-Exit_codes for more information on exit codes.
+      #
+      # On go1.25, To make `-mode binary` work we need to make sure the binary is built with `go build -builtvsc=false`
+      # Since our builds do not use `-builtvsc=false`, we run in source mode here instead.
       - name: Check Go vulnerabilities
         run: |
           go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,8 +61,8 @@ jobs:
       # `govulncheck` exits unsuccessfully if vulnerabilities are found, providing results in stdout.
       # See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck#hdr-Exit_codes for more information on exit codes.
       #
-      # On go1.25, To make `-mode binary` work we need to make sure the binary is built with `go build -builtvsc=false`
-      # Since our builds do not use `-builtvsc=false`, we run in source mode here instead.
+      # On go1.25, To make `-mode binary` work we need to make sure the binary is built with `go build -buildvcs=false`
+      # Since our builds do not use `-buildvcs=false`, we run in source mode here instead.
       - name: Check Go vulnerabilities
         run: |
           go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 ./...


### PR DESCRIPTION
Related to https://github.com/cli/cli/pull/11926

Switch lint workflow to scan source code instead of binary due to false positive problems with govulncheck in Go 1.25

Also removes the build since that is no longer required.