### PR TITLE
feat(cache delete): allow for delete all caches for a ref

### DIFF
--- a/pkg/cmd/cache/delete/delete.go
+++ b/pkg/cmd/cache/delete/delete.go
@@ -109,7 +109,7 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.DeleteAll, "all", "a", false, "Delete all caches")
+	cmd.Flags().BoolVarP(&opts.DeleteAll, "all", "a", false, "Delete all caches, can be used with --ref to delete all caches for a specific ref")
 	cmd.Flags().StringVarP(&opts.Ref, "ref", "r", "", "Delete by cache key and ref, formatted as refs/heads/<branch name> or refs/pull/<number>/merge")
 	cmd.Flags().BoolVar(&opts.SucceedOnNoCaches, "succeed-on-no-caches", false, "Return exit code 0 if no caches found. Must be used in conjunction with `--all`")
 


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
Fixes #12102

To cleanup caches from PR branches once they are merged, the current approach is to create a script that list all the caches for the PR ref, gets the IDs, and then iterate through each ID to delete the cache. This approach is also used in the official GitHub [documentation](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manage-caches#force-deleting-cache-entries). Having to do this scripting and choosing some number for the limit of caches to fetch, which might not include everything, seems needlessly complex.

This PR adds the capability to pass both `--all` and `--ref`, making cleaning up all the caches after a PR is merged as simple as `gh cache delete --all --ref refs/pull/<PR-number>/merge`.