### PR TITLE
fix: #12136 correctly read stdin when --body - is used

### DIFF
--- a/pkg/cmd/pr/comment/comment.go
+++ b/pkg/cmd/pr/comment/comment.go
@@ -1,6 +1,8 @@
 package comment
 
 import (
+    "io"
+    "fmt"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
@@ -64,6 +66,14 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*shared.CommentableOptions) err
 				}
 				opts.Body = string(b)
 			}
+            if opts.Body == "-" {
+                b, err := io.ReadAll(opts.IO.In)
+                if err != nil {
+                    return fmt.Errorf("failed to read from stdin: %w", err)
+                }
+                opts.Body = string(b)
+
+            }
 
 			if runF != nil {
 				return runF(opts)


### PR DESCRIPTION
Fixes #12136

This PR fixes an issue where running:

```bash
echo foo | gh pr comment <PR_NUMBER> --body -
```
would add a comment with just a - character instead of reading the input from STDIN.

## Reproduction

Before fix:
```bash
echo foo | gh pr comment 1 --body -
# Result: Comment body was "-"
```

After fix:
```bash
echo foo | gh pr comment 1 --body -
# Result: Comment body is "foo"
```