### PR TITLE
Add a new --clipboard flag to pr create command to copy the created PR URL

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/atotto/clipboard"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/cli/cli/v2/api"
 	ghContext "github.com/cli/cli/v2/context"
@@ -63,11 +64,12 @@ type CreateOptions struct {
 	BaseBranch string
 	HeadBranch string
 
-	Reviewers []string
-	Assignees []string
-	Labels    []string
-	Projects  []string
-	Milestone string
+	Reviewers       []string
+	Assignees       []string
+	Labels          []string
+	Projects        []string
+	Milestone       string
+	CopyToClipboard bool
 
 	MaintainerCanModify bool
 	Template            string
@@ -347,6 +349,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	fl.StringVar(&opts.RecoverFile, "recover", "", "Recover input from a failed run of create")
 	fl.StringVarP(&opts.Template, "template", "T", "", "Template `file` to use as starting body text")
 	fl.BoolVar(&opts.DryRun, "dry-run", false, "Print details instead of creating the PR. May still push git changes.")
+	fl.BoolVarP(&opts.CopyToClipboard, "clipboard", "c", false, "Copy the pull request URL to clipboard")
 
 	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "base", "head")
 
@@ -1017,7 +1020,18 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 	pr, err := api.CreatePullRequest(client, ctx.PRRefs.BaseRepo(), params)
 	opts.IO.StopProgressIndicator()
 	if pr != nil {
-		fmt.Fprintln(opts.IO.Out, pr.URL)
+		if opts.CopyToClipboard {
+			// Copy the pull request to the clipboard (fallback to printing URL on error)
+			clipErr := clipboard.WriteAll(pr.URL)
+			if clipErr != nil {
+				fmt.Fprintln(opts.IO.ErrOut, "Failed to copy pull request URL to clipboard")
+				fmt.Fprintf(opts.IO.ErrOut, "  %s\n", clipErr)
+				fmt.Fprintln(opts.IO.Out, pr.URL)
+			}
+		} else {
+			// Print the pull request URL to stdout
+			fmt.Fprintln(opts.IO.Out, pr.URL)
+		}
 	}
 	if err != nil {
 		if pr != nil {

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -1027,6 +1027,8 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 				fmt.Fprintln(opts.IO.ErrOut, "Failed to copy pull request URL to clipboard")
 				fmt.Fprintf(opts.IO.ErrOut, "  %s\n", clipErr)
 				fmt.Fprintln(opts.IO.Out, pr.URL)
+			} else {
+				fmt.Fprintf(opts.IO.Out, "Pull request URL copied to clipboard: %s\n", pr.URL)
 			}
 		} else {
 			// Print the pull request URL to stdout


### PR DESCRIPTION
This pull request adds a new feature to the `pr create` command, allowing users to copy the pull request URL directly to their clipboard with a new `--clipboard` (or `-c`) flag. This enhances user convenience by streamlining the process of sharing or using the PR URL after creation.

Key changes:

**New Feature: Clipboard Support**
* Added a `--clipboard` (`-c`) flag to the `pr create` command, enabling users to copy the pull request URL to their clipboard upon creation.
* Updated the PR submission logic to copy the URL to the clipboard if the flag is set, and to print an error message if copying to the clipboard fails.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
