### PR TITLE
Refactor cfg out of CAPI Client

### DIFF
--- a/pkg/cmd/agent-task/capi/client.go
+++ b/pkg/cmd/agent-task/capi/client.go
@@ -3,8 +3,6 @@ package capi
 import (
 	"context"
 	"net/http"
-
-	"github.com/cli/cli/v2/internal/gh"
 )
 
 //go:generate moq -rm -out client_mock.go . CapiClient
@@ -27,22 +25,19 @@ type CapiClient interface {
 // CAPIClient is a client for interacting with the Copilot API
 type CAPIClient struct {
 	httpClient *http.Client
-	authCfg    gh.AuthConfig
+	host       string
 }
 
-// NewCAPIClient creates a new CAPI client. Provide a token and an HTTP client which
+// NewCAPIClient creates a new CAPI client. Provide a token, host, and an HTTP client which
 // will be used as the base transport for CAPI requests.
 //
 // The provided HTTP client will be mutated for use with CAPI, so it should not
 // be reused elsewhere.
-func NewCAPIClient(httpClient *http.Client, authCfg gh.AuthConfig) *CAPIClient {
-	host, _ := authCfg.DefaultHost()
-	token, _ := authCfg.ActiveToken(host)
-
+func NewCAPIClient(httpClient *http.Client, token string, host string) *CAPIClient {
 	httpClient.Transport = newCAPITransport(token, httpClient.Transport)
 	return &CAPIClient{
 		httpClient: httpClient,
-		authCfg:    authCfg,
+		host:       host,
 	}
 }
 

--- a/pkg/cmd/agent-task/capi/job_test.go
+++ b/pkg/cmd/agent-task/capi/job_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -168,8 +167,7 @@ func TestGetJob(t *testing.T) {
 
 			httpClient := &http.Client{Transport: reg}
 
-			cfg := config.NewBlankConfig()
-			capiClient := NewCAPIClient(httpClient, cfg.Authentication())
+			capiClient := NewCAPIClient(httpClient, "", "github.com")
 
 			job, err := capiClient.GetJob(context.Background(), "OWNER", "REPO", "job123")
 
@@ -412,8 +410,7 @@ func TestCreateJob(t *testing.T) {
 
 			httpClient := &http.Client{Transport: reg}
 
-			cfg := config.NewBlankConfig()
-			capiClient := NewCAPIClient(httpClient, cfg.Authentication())
+			capiClient := NewCAPIClient(httpClient, "", "github.com")
 
 			job, err := capiClient.CreateJob(context.Background(), "OWNER", "REPO", "Do the thing", tt.baseBranch, tt.customAgent)
 

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -366,8 +366,7 @@ func (c *CAPIClient) hydrateSessionPullRequestsAndUsers(sessions []session) ([]*
 	ids = append(ids, userNodeIds...)
 
 	// TODO handle pagination
-	host, _ := c.authCfg.DefaultHost()
-	err := apiClient.Query(host, "FetchPRsAndUsersForAgentTaskSessions", &resp, map[string]any{
+	err := apiClient.Query(c.host, "FetchPRsAndUsersForAgentTaskSessions", &resp, map[string]any{
 		"ids": ids,
 	})
 

--- a/pkg/cmd/agent-task/capi/sessions_test.go
+++ b/pkg/cmd/agent-task/capi/sessions_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
-
-	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1163,8 +1161,7 @@ func TestListLatestSessionsForViewer(t *testing.T) {
 
 			httpClient := &http.Client{Transport: reg}
 
-			cfg := config.NewBlankConfig()
-			capiClient := NewCAPIClient(httpClient, cfg.Authentication())
+			capiClient := NewCAPIClient(httpClient, "", "github.com")
 
 			if tt.perPage != 0 {
 				last := defaultSessionsPerPage
@@ -1543,8 +1540,7 @@ func TestListSessionsByResourceID(t *testing.T) {
 
 			httpClient := &http.Client{Transport: reg}
 
-			cfg := config.NewBlankConfig()
-			capiClient := NewCAPIClient(httpClient, cfg.Authentication())
+			capiClient := NewCAPIClient(httpClient, "", "github.com")
 
 			if tt.perPage != 0 {
 				last := defaultSessionsPerPage
@@ -1823,8 +1819,7 @@ func TestGetSession(t *testing.T) {
 
 			httpClient := &http.Client{Transport: reg}
 
-			cfg := config.NewBlankConfig()
-			capiClient := NewCAPIClient(httpClient, cfg.Authentication())
+			capiClient := NewCAPIClient(httpClient, "", "github.com")
 
 			session, err := capiClient.GetSession(context.Background(), "some-uuid")
 
@@ -1900,8 +1895,7 @@ func TestGetPullRequestDatabaseID(t *testing.T) {
 
 			httpClient := &http.Client{Transport: reg}
 
-			cfg := config.NewBlankConfig()
-			capiClient := NewCAPIClient(httpClient, cfg.Authentication())
+			capiClient := NewCAPIClient(httpClient, "", "github.com")
 
 			databaseID, url, err := capiClient.GetPullRequestDatabaseID(context.Background(), "github.com", "OWNER", "REPO", 42)
 

--- a/pkg/cmd/agent-task/shared/capi.go
+++ b/pkg/cmd/agent-task/shared/capi.go
@@ -28,7 +28,9 @@ func CapiClientFunc(f *cmdutil.Factory) func() (capi.CapiClient, error) {
 		}
 
 		authCfg := cfg.Authentication()
-		return capi.NewCAPIClient(httpClient, authCfg), nil
+		host, _ := authCfg.DefaultHost()
+		token, _ := authCfg.ActiveToken(host)
+		return capi.NewCAPIClient(httpClient, token, host), nil
 	}
 }
 


### PR DESCRIPTION
## Description

I was reading the CAPI Client code and it seemed surprising to me that it needed a dependency on the `gh` package since ostensibly, it stands on its own. Seems simpler to just give the client what it needs.