### PR TITLE
Remove extra flag default from help usage

### DIFF
--- a/pkg/cmd/agent-task/list/list.go
+++ b/pkg/cmd/agent-task/list/list.go
@@ -51,7 +51,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		},
 	}
 
-	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", defaultLimit, fmt.Sprintf("Maximum number of agent tasks to fetch (default %d)", defaultLimit))
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", defaultLimit, "Maximum number of agent tasks to fetch")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open agent tasks in the browser")
 
 	return cmd


### PR DESCRIPTION
Fixes #12153

Very simple fix removing extra default value from `gh agent list --help`:

```shell
$ bin/gh agent list --help
List agent tasks (preview)

USAGE
  gh agent-task list [flags]

FLAGS
  -L, --limit int   Maximum number of agent tasks to fetch (default 30)
  -w, --web         Open agent tasks in the browser

INHERITED FLAGS
  --help   Show help for command

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility`
```

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
