### PR TITLE
Isolate user-provided search query from contextual qualifiers

### DIFF
--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -443,7 +443,7 @@ func Test_issueList(t *testing.T) {
 							"owner": "OWNER",
 							"repo":  "REPO",
 							"limit": float64(30),
-							"query": "auth bug assignee:@me author:@me mentions:@me repo:OWNER/REPO state:open type:issue",
+							"query": "( auth bug ) assignee:@me author:@me mentions:@me repo:OWNER/REPO state:open type:issue",
 							"type":  "ISSUE_ADVANCED",
 						}, params)
 					}))
@@ -618,7 +618,7 @@ func TestIssueList_Search_withProjectItems(t *testing.T) {
 				"repo":  "REPO",
 				"type":  "ISSUE_ADVANCED",
 				"limit": float64(30),
-				"query": "just used to force the search API branch repo:OWNER/REPO type:issue",
+				"query": "( just used to force the search API branch ) repo:OWNER/REPO type:issue",
 			}, params)
 		}))
 

--- a/pkg/cmd/pr/list/http_test.go
+++ b/pkg/cmd/pr/list/http_test.go
@@ -149,7 +149,7 @@ func Test_ListPullRequests(t *testing.T) {
 					httpmock.GraphQL(`query PullRequestSearch\b`),
 					httpmock.GraphQLQuery(`{"data":{}}`, func(query string, vars map[string]interface{}) {
 						want := map[string]interface{}{
-							"q":     "one world in:title repo:OWNER/REPO state:open type:pr",
+							"q":     "( one world in:title ) repo:OWNER/REPO state:open type:pr",
 							"type":  "ISSUE_ADVANCED",
 							"limit": float64(30),
 						}

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -441,7 +441,7 @@ func TestPRList_Search_withProjectItems(t *testing.T) {
 		  }`, func(_ string, params map[string]interface{}) {
 			require.Equal(t, map[string]interface{}{
 				"limit": float64(30),
-				"q":     "just used to force the search API branch repo:OWNER/REPO state:open type:pr",
+				"q":     "( just used to force the search API branch ) repo:OWNER/REPO state:open type:pr",
 				"type":  "ISSUE_ADVANCED",
 			}, params)
 		}))

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -222,19 +222,13 @@ func SearchQueryBuild(options FilterOptions, advancedIssueSearchSyntax bool) str
 			Is:        []string{is},
 			Type:      options.Entity,
 		},
+		KeywordsVerbatim: options.Search,
 	}
 
-	var q string
-	if advancedIssueSearchSyntax {
-		q = query.AdvancedIssueSearchString()
-	} else {
-		q = query.StandardSearchString()
+	if !advancedIssueSearchSyntax {
+		return query.StandardSearchString()
 	}
-
-	if options.Search != "" {
-		return fmt.Sprintf("%s %s", options.Search, q)
-	}
-	return q
+	return query.AdvancedIssueSearchString()
 }
 
 func QueryHasStateClause(searchQuery string) bool {

--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -222,7 +222,7 @@ func SearchQueryBuild(options FilterOptions, advancedIssueSearchSyntax bool) str
 			Is:        []string{is},
 			Type:      options.Entity,
 		},
-		KeywordsVerbatim: options.Search,
+		ImmutableKeywords: options.Search,
 	}
 
 	if !advancedIssueSearchSyntax {

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -148,11 +148,16 @@ func (q Query) AdvancedIssueSearchString() string {
 		keywords = strings.Join(formatKeywords(q.Keywords), " ")
 	}
 
+	if qualifiers == "" && keywords == "" {
+		return ""
+	}
+
 	if qualifiers != "" && keywords != "" {
 		// We should surround keywords with brackets to avoid leaking of any operators, especially "OR"s.
 		return fmt.Sprintf("( %s ) %s", keywords, qualifiers)
 	}
-	if qualifiers == "" {
+
+	if keywords != "" {
 		return keywords
 	}
 	return qualifiers

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -21,14 +21,15 @@ type Query struct {
 	// as needed. This is useful when the input can be supplied as a list of
 	// search keywords.
 	//
-	// This field is mutually exclusive with KeywordsVerbatim.
+	// This field is overridden by ImmutableKeywords.
 	Keywords []string
-	// KeywordsVerbatim holds the search keywords as a single string, and will
+
+	// ImmutableKeywords holds the search keywords as a single string, and will
 	// be treated as is (e.g. no additional quoting). This is useful when the
 	// input is meant to be taken verbatim from the user.
 	//
-	// This field is mutually exclusive with Keywords.
-	KeywordsVerbatim string
+	// This field takes precedence over Keywords.
+	ImmutableKeywords string
 
 	Kind       string
 	Limit      int
@@ -117,8 +118,8 @@ type Qualifiers struct {
 func (q Query) StandardSearchString() string {
 	qualifiers := formatQualifiers(q.Qualifiers, nil)
 	var keywords []string
-	if q.KeywordsVerbatim != "" {
-		keywords = []string{q.KeywordsVerbatim}
+	if q.ImmutableKeywords != "" {
+		keywords = []string{q.ImmutableKeywords}
 	} else if ks := formatKeywords(q.Keywords); len(ks) > 0 {
 		keywords = ks
 	}
@@ -143,7 +144,7 @@ func (q Query) StandardSearchString() string {
 // The advanced syntax is documented at https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more
 func (q Query) AdvancedIssueSearchString() string {
 	qualifiers := strings.Join(formatQualifiers(q.Qualifiers, formatAdvancedIssueSearch), " ")
-	keywords := q.KeywordsVerbatim
+	keywords := q.ImmutableKeywords
 	if keywords == "" {
 		keywords = strings.Join(formatKeywords(q.Keywords), " ")
 	}

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -75,29 +75,29 @@ func TestStandardSearchString(t *testing.T) {
 			out: `topic:"quote qualifier"`,
 		},
 		{
-			name: "respects verbatim keywords",
+			name: "respects immutable keywords",
 			query: Query{
-				KeywordsVerbatim: "verbatim keyword that should be left as is",
+				ImmutableKeywords: "immutable keyword that should be left as is",
 			},
-			out: `verbatim keyword that should be left as is`,
+			out: `immutable keyword that should be left as is`,
 		},
 		{
-			name: "respects verbatim keywords, with qualifiers",
+			name: "respects immutable keywords, with qualifiers",
 			query: Query{
-				KeywordsVerbatim: "verbatim keyword that should be left as is",
+				ImmutableKeywords: "immutable keyword that should be left as is",
 				Qualifiers: Qualifiers{
 					Topic: []string{"quote qualifier"},
 				},
 			},
-			out: `verbatim keyword that should be left as is topic:"quote qualifier"`,
+			out: `immutable keyword that should be left as is topic:"quote qualifier"`,
 		},
 		{
-			name: "prioritises verbatim keywords over keywords slice",
+			name: "prioritises immutable keywords over keywords slice",
 			query: Query{
-				Keywords:         []string{"foo", "bar"},
-				KeywordsVerbatim: "verbatim keyword",
+				Keywords:          []string{"foo", "bar"},
+				ImmutableKeywords: "immutable keyword",
 			},
-			out: `verbatim keyword`,
+			out: `immutable keyword`,
 		},
 	}
 	for _, tt := range tests {
@@ -141,29 +141,29 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 			out: `label:"quote qualifier"`,
 		},
 		{
-			name: "respects verbatim keywords",
+			name: "respects immutable keywords",
 			query: Query{
-				KeywordsVerbatim: "verbatim keyword that should be left as is",
+				ImmutableKeywords: "immutable keyword that should be left as is",
 			},
-			out: `verbatim keyword that should be left as is`,
+			out: `immutable keyword that should be left as is`,
 		},
 		{
-			name: "respects verbatim keywords, with qualifiers",
+			name: "respects immutable keywords, with qualifiers",
 			query: Query{
-				KeywordsVerbatim: "verbatim keyword that should be left as is",
+				ImmutableKeywords: "immutable keyword that should be left as is",
 				Qualifiers: Qualifiers{
 					Topic: []string{"quote qualifier"},
 				},
 			},
-			out: `( verbatim keyword that should be left as is ) topic:"quote qualifier"`,
+			out: `( immutable keyword that should be left as is ) topic:"quote qualifier"`,
 		},
 		{
-			name: "prioritises verbatim keywords over keywords slice",
+			name: "prioritises immutable keywords over keywords slice",
 			query: Query{
-				Keywords:         []string{"foo", "bar"},
-				KeywordsVerbatim: "verbatim keyword",
+				Keywords:          []string{"foo", "bar"},
+				ImmutableKeywords: "immutable keyword",
 			},
-			out: `verbatim keyword`,
+			out: `immutable keyword`,
 		},
 		{
 			name: "unused qualifiers should not appear in query",

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -15,6 +15,10 @@ func TestStandardSearchString(t *testing.T) {
 		out   string
 	}{
 		{
+			name: "empty query",
+			out:  "",
+		},
+		{
 			name: "converts query to string",
 			query: Query{
 				Keywords: []string{"some", "keywords"},
@@ -70,6 +74,31 @@ func TestStandardSearchString(t *testing.T) {
 			},
 			out: `topic:"quote qualifier"`,
 		},
+		{
+			name: "respects verbatim keywords",
+			query: Query{
+				KeywordsVerbatim: "verbatim keyword that should be left as is",
+			},
+			out: `verbatim keyword that should be left as is`,
+		},
+		{
+			name: "respects verbatim keywords, with qualifiers",
+			query: Query{
+				KeywordsVerbatim: "verbatim keyword that should be left as is",
+				Qualifiers: Qualifiers{
+					Topic: []string{"quote qualifier"},
+				},
+			},
+			out: `verbatim keyword that should be left as is topic:"quote qualifier"`,
+		},
+		{
+			name: "prioritises verbatim keywords over keywords slice",
+			query: Query{
+				Keywords:         []string{"foo", "bar"},
+				KeywordsVerbatim: "verbatim keyword",
+			},
+			out: `verbatim keyword`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -84,6 +113,10 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 		query Query
 		out   string
 	}{
+		{
+			name: "empty query",
+			out:  "",
+		},
 		{
 			name: "quotes keywords",
 			query: Query{
@@ -108,6 +141,31 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 			out: `label:"quote qualifier"`,
 		},
 		{
+			name: "respects verbatim keywords",
+			query: Query{
+				KeywordsVerbatim: "verbatim keyword that should be left as is",
+			},
+			out: `verbatim keyword that should be left as is`,
+		},
+		{
+			name: "respects verbatim keywords, with qualifiers",
+			query: Query{
+				KeywordsVerbatim: "verbatim keyword that should be left as is",
+				Qualifiers: Qualifiers{
+					Topic: []string{"quote qualifier"},
+				},
+			},
+			out: `( verbatim keyword that should be left as is ) topic:"quote qualifier"`,
+		},
+		{
+			name: "prioritises verbatim keywords over keywords slice",
+			query: Query{
+				Keywords:         []string{"foo", "bar"},
+				KeywordsVerbatim: "verbatim keyword",
+			},
+			out: `verbatim keyword`,
+		},
+		{
 			name: "unused qualifiers should not appear in query",
 			query: Query{
 				Keywords: []string{"keyword"},
@@ -115,7 +173,7 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 					Label: []string{"foo", "bar"},
 				},
 			},
-			out: `keyword label:bar label:foo`,
+			out: `( keyword ) label:bar label:foo`,
 		},
 		{
 			name: "special qualifiers when used once",
@@ -128,7 +186,7 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 					In:   []string{"title"},
 				},
 			},
-			out: `keyword in:title is:private repo:foo/bar user:johndoe`,
+			out: `( keyword ) in:title is:private repo:foo/bar user:johndoe`,
 		},
 		{
 			name: "special qualifiers are OR-ed when used multiple times",
@@ -141,7 +199,7 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 					In:   []string{"title", "body", "comments", "foo"}, // "foo" is to ensure only "title", "body", and "comments" are grouped
 				},
 			},
-			out: `keyword (in:body OR in:comments OR in:title) in:foo (is:blocked OR is:blocking) (is:closed OR is:open) (is:issue OR is:pr) (is:locked OR is:unlocked) (is:merged OR is:unmerged) (is:private OR is:public) is:foo (repo:foo/bar OR repo:foo/baz) (user:janedoe OR user:johndoe)`,
+			out: `( keyword ) (in:body OR in:comments OR in:title) in:foo (is:blocked OR is:blocking) (is:closed OR is:open) (is:issue OR is:pr) (is:locked OR is:unlocked) (is:merged OR is:unmerged) (is:private OR is:public) is:foo (repo:foo/bar OR repo:foo/baz) (user:janedoe OR user:johndoe)`,
 		},
 		{
 			// Since this is a general purpose package, we can't assume with know all
@@ -155,7 +213,7 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 					In: []string{"foo", "bar"},
 				},
 			},
-			out: `keyword in:bar in:foo is:bar is:foo`,
+			out: `( keyword ) in:bar in:foo is:bar is:foo`,
 		},
 		{
 			name: "non-special qualifiers used multiple times",
@@ -170,7 +228,7 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 					Topic:   []string{"foo", "bar"},
 				},
 			},
-			out: `keyword in:bar in:foo is:bar is:foo label:bar label:foo license:bar license:foo no:bar no:foo topic:bar topic:foo`,
+			out: `( keyword ) in:bar in:foo is:bar is:foo label:bar label:foo license:bar license:foo no:bar no:foo topic:bar topic:foo`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/search/searcher_test.go
+++ b/pkg/search/searcher_test.go
@@ -1178,7 +1178,7 @@ func TestSearcherIssuesAdvancedSyntax(t *testing.T) {
 			detector: fd.AdvancedIssueSearchSupportedAsOptIn(),
 			query:    query,
 			wantValues: url.Values{
-				"q":               []string{"keyword author:johndoe (in:body OR in:comments OR in:title) (is:private OR is:public) label:bar label:foo (repo:foo/bar OR repo:foo/baz) (user:janedoe OR user:johndoe)"},
+				"q":               []string{"( keyword ) author:johndoe (in:body OR in:comments OR in:title) (is:private OR is:public) label:bar label:foo (repo:foo/bar OR repo:foo/baz) (user:janedoe OR user:johndoe)"},
 				"advanced_search": []string{"true"}, // opt-in
 			},
 		},
@@ -1189,7 +1189,7 @@ func TestSearcherIssuesAdvancedSyntax(t *testing.T) {
 			detector: fd.AdvancedIssueSearchSupportedAsOnlyBackend(),
 			query:    query,
 			wantValues: url.Values{
-				"q":               []string{"keyword author:johndoe (in:body OR in:comments OR in:title) (is:private OR is:public) label:bar label:foo (repo:foo/bar OR repo:foo/baz) (user:janedoe OR user:johndoe)"},
+				"q":               []string{"( keyword ) author:johndoe (in:body OR in:comments OR in:title) (is:private OR is:public) label:bar label:foo (repo:foo/bar OR repo:foo/baz) (user:janedoe OR user:johndoe)"},
 				"advanced_search": nil, // assert absence
 			},
 		},


### PR DESCRIPTION
Fixes #11774 

**Search Query Construction Improvements:**

* Added a new `ImmutableKeywords` field to the `Query` struct, allowing search keywords to be treated as a single, verbatim string that overrides the standard `Keywords` list. (`pkg/search/query.go` [pkg/search/query.goR19-R33](diffhunk://#diff-7f926ad46fcd01fcc4958db18335de9a3fa293b271134984a8bb8f38dddc4928R19-R33))
* Updated the logic in `StandardSearchString` and `AdvancedIssueSearchString` to prioritize `ImmutableKeywords` over the `Keywords` slice, and to handle empty queries gracefully. (`pkg/search/query.go` [[1]](diffhunk://#diff-7f926ad46fcd01fcc4958db18335de9a3fa293b271134984a8bb8f38dddc4928L106-R125) [[2]](diffhunk://#diff-7f926ad46fcd01fcc4958db18335de9a3fa293b271134984a8bb8f38dddc4928L127-R164)
* Modified `AdvancedIssueSearchString` to always wrap keywords in parentheses when both keywords and qualifiers are present, ensuring correct operator precedence and preventing issues with search parsing. (`pkg/search/query.go` [pkg/search/query.goL127-R164](diffhunk://#diff-7f926ad46fcd01fcc4958db18335de9a3fa293b271134984a8bb8f38dddc4928L127-R164))

**Parameter and API Changes:**

* Updated the `SearchQueryBuild` function to pass `options.Search` as `ImmutableKeywords` and simplified the logic for query construction, especially for advanced issue search. (`pkg/cmd/pr/shared/params.go` [pkg/cmd/pr/shared/params.goR225-R231](diffhunk://#diff-e34f6b5a9d3e819833e8620190674506de9b9b3ad7b402c31eef67ff83b794bcR225-R231))
* Changed the expected query format in multiple tests to reflect the new parenthesized keyword behavior for advanced issue search. (`pkg/cmd/issue/list/list_test.go` [[1]](diffhunk://#diff-bf99f4cd0c8062358ba80f590df5aa0d1200305b45d9845de6937f401ddf1cbbL446-R446) `pkg/cmd/issue/list/list_test.go` [[2]](diffhunk://#diff-bf99f4cd0c8062358ba80f590df5aa0d1200305b45d9845de6937f401ddf1cbbL621-R621) `pkg/cmd/pr/list/http_test.go` [[3]](diffhunk://#diff-d7cc9f8518c52d37db495e8a0510d22f1bee901a597fe2495d7da6afcb454f9eL152-R152) `pkg/cmd/pr/list/list_test.go` [[4]](diffhunk://#diff-af69a3467517fe5ffb218be7b4e64617bb744d6e585447a65c3018a8784e4997L444-R444) `pkg/search/searcher_test.go` [[5]](diffhunk://#diff-35157ef0686b31046139ff643127b6cc9b4ca1e70c806f87eda4c246c17c3013L1181-R1181) [[6]](diffhunk://#diff-35157ef0686b31046139ff643127b6cc9b4ca1e70c806f87eda4c246c17c3013L1192-R1192)

**Testing Enhancements:**

* Added and updated tests to verify the behavior of `ImmutableKeywords`, the precedence over the keywords slice, and the new parenthesized format for advanced queries. (`pkg/search/query_test.go` [[1]](diffhunk://#diff-1902edacc0174c280f5f71bc568263280ec3bb130bf3cd47422f8047b0196bc7R17-R20) [[2]](diffhunk://#diff-1902edacc0174c280f5f71bc568263280ec3bb130bf3cd47422f8047b0196bc7R77-R101) [[3]](diffhunk://#diff-1902edacc0174c280f5f71bc568263280ec3bb130bf3cd47422f8047b0196bc7R116-R119) [[4]](diffhunk://#diff-1902edacc0174c280f5f71bc568263280ec3bb130bf3cd47422f8047b0196bc7R143-R167) [[5]](diffhunk://#diff-1902edacc0174c280f5f71bc568263280ec3bb130bf3cd47422f8047b0196bc7L118-R176) [[6]](diffhunk://#diff-1902edacc0174c280f5f71bc568263280ec3bb130bf3cd47422f8047b0196bc7L131-R189) [[7]](diffhunk://#diff-1902edacc0174c280f5f71bc568263280ec3bb130bf3cd47422f8047b0196bc7L144-R202) [[8]](diffhunk://#diff-1902edacc0174c280f5f71bc568263280ec3bb130bf3cd47422f8047b0196bc7L158-R216) [[9]](diffhunk://#diff-1902edacc0174c280f5f71bc568263280ec3bb130bf3cd47422f8047b0196bc7L173-R231)