### PR TITLE
Add PGP key rotation PoC

### DIFF
--- a/script/debian-devel
+++ b/script/debian-devel
@@ -3,7 +3,7 @@
 # Enable strict mode
 set -eo pipefail
 
-SCRIPT=$(basename $0)
+SCRIPT=$(basename "$0")
 ARCHITECTURES=("i386" "amd64" "arm64" "armhf")
 
 # Check if DEBUG is set to true or 1, enable debug print statements if so
@@ -117,7 +117,7 @@ Expire-Date: seconds=$((1 * 60))
   GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export > pgp-key.gpg # Binary version
 
   KEY1_FINGERPRINT="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --list-options show-only-fpr-mbox | cut -f1 -d' ' | head -n 1)"
-  echo -n "$KEY1_FINGERPRINT" > $ARTIFACTS_DIR/key1-fingerprint
+  echo -n "$KEY1_FINGERPRINT" > "$ARTIFACTS_DIR/key1-fingerprint"
 
   echo "Generated PGP key with fingerprint: $KEY1_FINGERPRINT"
 
@@ -211,7 +211,7 @@ Description: A statically compiled Go program that prints hello" > DEBIAN/contro
   mkdir -p "$ARTIFACTS_DIR/apt-repo"
 
   # make reprepro config template file
-  cat <<EOF > $ARTIFACTS_DIR/distributions.template
+  cat <<EOF > "$ARTIFACTS_DIR/distributions.template"
 Origin: Example Repository
 Label: Example
 Codename: stable
@@ -226,7 +226,7 @@ EOF
   # separate temp directory.
   mkdir -p "$ARTIFACTS_DIR/temp-reprepro-1/conf"
   cd "$ARTIFACTS_DIR/temp-reprepro-1/conf"
-  cp $ARTIFACTS_DIR/distributions.template distributions
+  cp "$ARTIFACTS_DIR/distributions.template" distributions
   sed -i "s/<FINGERPRINT-PLACEHOLDER>/$KEY1_FINGERPRINT/g" distributions
 
   cd "$ARTIFACTS_DIR/temp-reprepro-1"
@@ -236,7 +236,7 @@ EOF
   done
   cp -a dists/ pool/ "$ARTIFACTS_DIR/apt-repo/"
 
-  echo "These is the content of the Packages file (for amd64):"
+  echo "This is the content of the Packages file (for amd64):"
   cat dists/stable/main/binary-amd64/Packages
   echo "! Note that there should be two entries above; hello-world and the archive-keyring package."
 
@@ -286,7 +286,7 @@ newkey() {
   # Verify that the current key is not yet expired
   header "Step 1: Verifying the current key is not yet expired"
 
-  KEY1_FINGERPRINT="$(cat $ARTIFACTS_DIR/key1-fingerprint)"
+  KEY1_FINGERPRINT="$(cat "$ARTIFACTS_DIR/key1-fingerprint")"
 
   expiry_date="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --with-colons --fingerprint $KEY1_FINGERPRINT | grep -E "^pub:" | cut -f7 -d:)"
   current_date="$(date +%s)"
@@ -326,7 +326,7 @@ Expire-Date: seconds=$((15 * 60))
   new_keys_list="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --with-colons)"
   added_key="$(comm -1 -3 <(echo "$existing_keys_list" | sort) <(echo "$new_keys_list" | sort))"
   KEY2_FINGERPRINT="$(echo "$added_key" | grep -E "^fpr:" | cut -f10 -d: | head -n1)"
-  echo -n "$KEY2_FINGERPRINT" > $ARTIFACTS_DIR/key2-fingerprint
+  echo -n "$KEY2_FINGERPRINT" > "$ARTIFACTS_DIR/key2-fingerprint"
 
   echo "Generated PGP key with fingerprint: $KEY2_FINGERPRINT"
 
@@ -352,7 +352,7 @@ Expire-Date: seconds=$((15 * 60))
   # Create a new temp directory before calling reprepro.
   mkdir -p "$ARTIFACTS_DIR/temp-reprepro-2/conf"
   cd "$ARTIFACTS_DIR/temp-reprepro-2/conf"
-  cp $ARTIFACTS_DIR/distributions.template distributions
+  cp "$ARTIFACTS_DIR/distributions.template" distributions
   sed -i "s/<FINGERPRINT-PLACEHOLDER>/$KEY1_FINGERPRINT $KEY2_FINGERPRINT/g" distributions
 
   cd "$ARTIFACTS_DIR/temp-reprepro-2"
@@ -388,8 +388,8 @@ Expire-Date: seconds=$((15 * 60))
 deprecate() {
   header "Step 1: Verifying the old/first key is expired"
 
-  KEY1_FINGERPRINT="$(cat $ARTIFACTS_DIR/key1-fingerprint)"
-  KEY2_FINGERPRINT="$(cat $ARTIFACTS_DIR/key2-fingerprint)"
+  KEY1_FINGERPRINT="$(cat "$ARTIFACTS_DIR/key1-fingerprint")"
+  KEY2_FINGERPRINT="$(cat "$ARTIFACTS_DIR/key2-fingerprint")"
 
   expiry_date="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --with-colons --fingerprint $KEY1_FINGERPRINT | grep -E "^pub:" | cut -f7 -d:)"
   current_date="$(date +%s)"
@@ -405,7 +405,7 @@ deprecate() {
 
   # create a copy of the files of the previous version of the archive keyring package
   cp -r "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_all" "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_all"
-  # update the keyring file with the new keyring (including both keys)
+  # update the keyring file with the new keyring (now with only the latest key)
   cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_all"
   GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export $KEY2_FINGERPRINT > usr/share/keyrings/example-archive-keyring.gpg
   # bump the version in the debian control file
@@ -422,7 +422,7 @@ deprecate() {
   # Create a new temp directory before calling reprepro.
   mkdir -p "$ARTIFACTS_DIR/temp-reprepro-3/conf"
   cd "$ARTIFACTS_DIR/temp-reprepro-3/conf"
-  cp $ARTIFACTS_DIR/distributions.template distributions
+  cp "$ARTIFACTS_DIR/distributions.template" distributions
   sed -i "s/<FINGERPRINT-PLACEHOLDER>/$KEY2_FINGERPRINT/g" distributions
 
   cd "$ARTIFACTS_DIR/temp-reprepro-3"
@@ -511,7 +511,7 @@ teardown() {
   fi
 
   # Remove the preferences from preferences.d
-  if [ -f /etc/apt/preferences.d/example ]; then
+  if [ -f /etc/apt/preferences.d/example.pref ]; then
     header "Removing the preferences from /etc/apt/preferences.d..."
     sudo rm /etc/apt/preferences.d/example.pref
     echo "Preferences removed."

--- a/script/debian-devel
+++ b/script/debian-devel
@@ -1,19 +1,5 @@
 #!/bin/bash
 
-# Hint: run this at the root of the repo to spin up an Ubuntu container with
-# this script lively mounted in `/root`:
-#
-#   docker run -it -d --name gpg-playground -v "$(pwd)/script/debian-devel:/root/debian-devel" ubuntu:22.04
-#
-# And then use this to exec into the container:
-#
-#   docker exec -it gpg-playground bash
-#
-# To get rid of the container:
-#
-#   docker stop gpg-playground && docker rm gpg-playground
-#
-
 # Enable strict mode
 set -eo pipefail
 

--- a/script/debian-devel
+++ b/script/debian-devel
@@ -285,7 +285,6 @@ newkey() {
 
   # Get the list of existing keys
   existing_keys_list="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --with-colons)"
-  KEY1_FINGERPRINT="$(echo "$existing_keys_list" | grep -E "^fpr:" | cut -f10 -d: | head -n1)"
 
   cd "$ARTIFACTS_DIR"
   echo "%echo Generating an example PGP key

--- a/script/debian-devel
+++ b/script/debian-devel
@@ -31,7 +31,7 @@ prompt_continue() {
 
 # Function to prompt for the artifacts directory and ensure it exists
 prompt_for_artifacts_dir() {
-  read -p "Please provide a directory location for storing all artifacts (leave empty for default: $DEFAULT_ARTIFACTS_DIR): "
+  read -p "Please provide a directory location for storing all artifacts (leave empty for default: $DEFAULT_ARTIFACTS_DIR): " ARTIFACTS_DIR
   # Use default if the user provides no input
   if [ -z "$ARTIFACTS_DIR" ]; then
     ARTIFACTS_DIR="$DEFAULT_ARTIFACTS_DIR"
@@ -41,7 +41,7 @@ prompt_for_artifacts_dir() {
 
 # Function to handle the setup process
 setup() {
-  # Step 1: Install prerequisites (including Go)
+  # Step 0: Install prerequisites (including Go)
   if ! command -v sudo &> /dev/null; then
     # This is to make sure the script runs on both containers and VMs.
     apt-get update
@@ -49,7 +49,7 @@ setup() {
   fi
   echo "Step 1: Installing prerequisites (Go, dpkg-dev, gpg, tree, Python)"
   sudo apt-get update
-  sudo apt-get install -y golang-go dpkg-dev gpg tree python3
+  sudo apt-get install -y golang-go dpkg-dev gpg reprepro tree python3
   prompt_continue "Next, we will ask you to provide a directory location to store all artifacts."
 
   # Prompt for the artifacts directory
@@ -65,6 +65,75 @@ setup() {
   fi
   tree "$ARTIFACTS_DIR"
   prompt_continue "Next, we will create a simple Go program within the specified directory."
+
+  # Step 1: Create a PGP key/cert that expires in 1 minute
+  echo "Step 1: Creating a PGP key/cert that expires in 1 minute"
+  cd "$ARTIFACTS_DIR"
+  echo "%echo Generating an example PGP key
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: example
+Name-Email: example@example.com
+Expire-Date: $(date -u -d '+1 minute' '+%Y%m%dT%H%M%S')
+%no-ask-passphrase
+%no-protection
+%commit" > example-pgp-key.batch
+
+  mkdir -m 700 "temp-gpg-home"
+  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --no-tty --batch --gen-key example-pgp-key.batch
+  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --list-keys
+  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --armor --export-secret-keys example > pgp-key.private # ASCII version
+  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --armor --export example > pgp-key.public # ASCII version
+  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --export example > pgp-key.gpg # Binary version
+
+  KEY1_FINGERPRINT="$(gpg --list-keys --list-options show-only-fpr-mbox | cut -f1 -d' ' | head -n 1)"
+  echo "Generated PGP key with fingerprint: $KEY1_FINGERPRINT"
+
+  tree
+
+  # Step 2: Create directory structure for the archive keyring deb package
+  echo "Step 2: Creating directory structure for the archive keyring deb package"
+  mkdir -p "$ARTIFACTS_DIR/example-archive-keyring"
+  cd "$ARTIFACTS_DIR/example-archive-keyring"
+  mkdir -p usr/share/keyrings
+  gpg --export-options export-minimal --export $KEY1_FINGERPRINT > usr/share/keyrings/example.pgp
+
+  mkdir -p usr/bin
+  cp "$ARTIFACTS_DIR/hello-world-program/hello-world" usr/bin/
+  echo "Binary copied to usr/bin/hello-world."
+  tree "$ARTIFACTS_DIR"
+  prompt_continue "Next, we will create the necessary control file for the deb package."
+
+  # Step 5: Create DEBIAN control file
+  echo "Step 5: Creating DEBIAN control file"
+  mkdir -p DEBIAN
+  echo "Package: hello-world
+Version: 0.0.1
+Maintainer: example <example@example.com>
+Architecture: $ARCH
+Homepage: http://example.com
+Description: A statically compiled Go program that prints hello" > DEBIAN/control
+  echo "Control file created at $ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH/DEBIAN/control."
+  tree "$ARTIFACTS_DIR"
+  prompt_continue "Next, we will build the .deb package from the files we have set up."
+
+  # Step 6: Build the deb package
+  echo "Step 6: Building the .deb package"
+  cd "$ARTIFACTS_DIR"
+  dpkg --build hello-world_0.0.1-1_$ARCH
+  echo "Deb package created: hello-world_0.0.1-1_$ARCH.deb"
+  tree "$ARTIFACTS_DIR"
+  prompt_continue "Next, we will inspect the .deb package to verify its contents."
+
+  # Step 7: Inspect the deb package
+  echo "Step 7: Inspecting the .deb package"
+  dpkg-deb --info hello-world_0.0.1-1_$ARCH.deb
+  dpkg-deb --contents hello-world_0.0.1-1_$ARCH.deb
+  prompt_continue "Next, we will set up a directory structure for hosting this package in an apt repository."
+
+
+
+
 
   # Step 2: Create Go Program
   echo "Step 2: Creating a simple Go program"

--- a/script/debian-devel
+++ b/script/debian-devel
@@ -1,13 +1,17 @@
 #!/bin/bash
 
 # Hint: run this at the root of the repo to spin up an Ubuntu container with
-# this script lively mounted:
+# this script lively mounted in `/root`:
 #
-#   docker run -it -d --name gpg-playground -v "$(pwd)/script/debian-devel:/root/debian-devel" python:3
+#   docker run -it -d --name gpg-playground -v "$(pwd)/script/debian-devel:/root/debian-devel" ubuntu:22.04
 #
 # And then use this to exec into the container:
 #
 #   docker exec -it gpg-playground bash
+#
+# To get rid of the container:
+#
+#   docker stop gpg-playground && docker rm gpg-playground
 #
 
 # Enable strict mode
@@ -41,7 +45,7 @@ prompt_for_artifacts_dir() {
 
 # Function to handle the setup process
 setup() {
-  # Step 0: Install prerequisites (including Go)
+  # Step 0: Install prerequisites
   if ! command -v sudo &> /dev/null; then
     # This is to make sure the script runs on both containers and VMs.
     apt-get update
@@ -50,13 +54,11 @@ setup() {
 
   echo "Step 1: Installing prerequisites"
   sudo apt-get update
-  sudo apt-get install --no-upgrade -y dpkg-dev gpg reprepro tree python3
+  sudo apt-get install --no-upgrade -y dpkg-dev busybox gpg reprepro tree
   prompt_continue "Next, we will ask you to provide a directory location to store all artifacts."
 
-  # Prompt for the artifacts directory
   prompt_for_artifacts_dir
 
-  # Check if directory exists, if not, create it
   if [ ! -d "$ARTIFACTS_DIR" ]; then
     echo "Directory does not exist. Creating $ARTIFACTS_DIR..."
     mkdir -p "$ARTIFACTS_DIR"
@@ -64,40 +66,41 @@ setup() {
   else
     echo "Directory $ARTIFACTS_DIR already exists."
   fi
-  tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will create a apt repository in the specified directory."
 
-  # Step 1: Create a PGP key/cert that expires in 1 minute
-  echo "Step 1: Creating a PGP key/cert that expires in 1 minute"
+  prompt_continue "Next, we will create our first signing key to use it later."
+  echo "Step 2: Creating a PGP key/cert that expires in 1 minute"
+
   cd "$ARTIFACTS_DIR"
   echo "%echo Generating an example PGP key
 Key-Type: RSA
 Key-Length: 4096
-Name-Real: example
+Name-Real: example-key-1
 Name-Email: example@example.com
-Expire-Date: $(date -u -d '+1 minute' '+%Y%m%dT%H%M%S')
+Expire-Date: seconds=$((1 * 60))
 %no-ask-passphrase
 %no-protection
-%commit" > example-pgp-key.batch
+%commit" > example-pgp-key-1.batch
 
-  mkdir -m 700 "temp-gpg-home"
-  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --no-tty --batch --gen-key example-pgp-key.batch
+  mkdir -m 700 -p "$ARTIFACTS_DIR/temp-gpg-home"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --no-tty --batch --gen-key example-pgp-key-1.batch
   GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys
-  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --armor --export-secret-keys example > pgp-key.private # ASCII version
-  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --armor --export example > pgp-key.public # ASCII version
-  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export example > pgp-key.gpg # Binary version
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --armor --export-secret-keys > pgp-key.private # ASCII version
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --armor --export > pgp-key.public # ASCII version
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export > pgp-key.gpg # Binary version
 
   KEY1_FINGERPRINT="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --list-options show-only-fpr-mbox | cut -f1 -d' ' | head -n 1)"
+  echo -n "$KEY1_FINGERPRINT" > $ARTIFACTS_DIR/key1-fingerprint
+
   echo "Generated PGP key with fingerprint: $KEY1_FINGERPRINT"
 
-  tree
+  # Step 3: Create the archive keyring deb package
+  prompt_continue "Next, we will create the archive-keyring deb file."
+  echo "Step 3: Creating the archive-keyring deb file"
 
-  # Step 2: Create the archive keyring deb package
-  echo "Step 2: Creating directory structure for the archive keyring deb package"
   mkdir -p "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH"
   cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH"
   mkdir -p usr/share/keyrings
-  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export-options export-minimal --export $KEY1_FINGERPRINT > usr/share/keyrings/example-archive-keyring.gpg
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export > usr/share/keyrings/example-archive-keyring.gpg
   mkdir -p etc/apt/sources.list.d
   echo -n "# Created by example-archive-keyring package
 deb [arch=$ARCH allow-insecure=yes signed-by=/usr/share/keyrings/example-archive-keyring.gpg] http://127.0.0.1:8000/apt-repo stable main
@@ -117,10 +120,14 @@ Pin-Priority: 100
 " > etc/apt/preferences.d/example.pref
 
   mkdir -p DEBIAN
+  # The "Section:" and "Priority:" values are to make the deb files similar to what
+  # we build in our CI. Also, omitting them from here will result in reprepro failure.
   echo -n "Package: example-archive-keyring
 Version: 0.0.1
 Maintainer: example <example@example.com>
 Architecture: $ARCH
+Section:
+Priority: optional
 Homepage: http://example.com
 Description: Example archive keyring
 " > DEBIAN/control
@@ -134,202 +141,295 @@ Description: Example archive keyring
   # dpkg-deb --info example-archive-keyring_0.0.1-1_$ARCH.deb
   # dpkg-deb --contents example-archive-keyring_0.0.1-1_$ARCH.deb
 
-  prompt_continue "Next, we will create a simple Go program to be the binary in our repository"
+  # Step 4: Create simple program
+  prompt_continue "Next, we will create the hello-world deb file."
+  echo "Step 4: Creating the hello-world deb file"
 
-  # Step 3: Create simple program
-  echo "Step 3: Creating a simple program"
   mkdir -p "$ARTIFACTS_DIR/hello-world-program"
   echo '#include <stdio.h>
 int main() {
-    printf("hello packaged world\n");
+    printf("hello packaged world (TIMESTAMP)\n");
     return 0;
-}' > $ARTIFACTS_DIR/hello-world-program/hello.c
+}' | sed "s/TIMESTAMP/$(date "+%s")/g" > $ARTIFACTS_DIR/hello-world-program/hello.c
 
-  # Step 4: Compile the program
-  echo "Step 4: Compiling the program"
   cd "$ARTIFACTS_DIR/hello-world-program"
   gcc -o hello-world hello.c
-  tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will create the directory structure for the deb package."
 
-  # Step 5: Create directory structure for deb package
-  echo "Step 5: Creating directory structure for the deb package"
+  # Create directory structure for deb package
   mkdir -p "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH"
   cd "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH"
   mkdir -p usr/bin
   cp "$ARTIFACTS_DIR/hello-world-program/hello-world" usr/bin/
   echo "Binary copied to usr/bin/hello-world."
-  tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will create the necessary control file for the deb package."
 
-  # Step 6: Create DEBIAN control file
-  echo "Step 6: Creating DEBIAN control file"
+  # Create DEBIAN control file
   mkdir -p DEBIAN
+  # The "Section:" and "Priority:" values are to make the deb files similar to what
+  # we build in our CI. Also, omitting them from here will result in reprepro failure.
   echo "Package: hello-world
 Version: 0.0.1
 Maintainer: example <example@example.com>
 Architecture: $ARCH
+Section:
+Priority: optional
 Homepage: http://example.com
 Description: A statically compiled Go program that prints hello" > DEBIAN/control
-  echo "Control file created at $ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH/DEBIAN/control."
-  tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will build the .deb package from the files we have set up."
 
-  # Step 7: Build the deb package
-  echo "Step 7: Building the .deb package"
+  # Build the deb package
   cd "$ARTIFACTS_DIR"
   dpkg --build hello-world_0.0.1-1_$ARCH
   echo "Deb package created: hello-world_0.0.1-1_$ARCH.deb"
-  tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will inspect the .deb package to verify its contents."
 
-  # Step 8: Inspect the deb package
-  echo "Step 8: Inspecting the .deb package"
-  dpkg-deb --info hello-world_0.0.1-1_$ARCH.deb
-  dpkg-deb --contents hello-world_0.0.1-1_$ARCH.deb
-  prompt_continue "Next, we will set up a directory structure for hosting this package in an apt repository."
+  # Inspect the deb package
+  # dpkg-deb --info hello-world_0.0.1-1_$ARCH.deb
+  # dpkg-deb --contents hello-world_0.0.1-1_$ARCH.deb
 
-  # Step 9: Create apt repository directory structure
-  echo "Step 9: Creating apt repository directory structure"
-  mkdir -p "$ARTIFACTS_DIR/apt-repo/pool/main/"
-  cp "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH.deb" "$ARTIFACTS_DIR/apt-repo/pool/main/"
-  cp "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH.deb" "$ARTIFACTS_DIR/apt-repo/pool/main/"
-  mkdir -p "$ARTIFACTS_DIR/apt-repo/dists/stable/main/binary-$ARCH"
-  tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will generate the 'Packages' file, which lists the available deb packages in the repository."
+  # Step 5: Create apt repository using reprepro
+  prompt_continue "Next, we will create an apt repository using reprepro."
+  echo "Step 5: Creating apt repository using reprepro"
 
-  # Step 10: Generate Packages file
-  echo "Step 10: Generating Packages file"
-  cd "$ARTIFACTS_DIR/apt-repo"
-  dpkg-scanpackages --arch $ARCH pool/ > dists/stable/main/binary-$ARCH/Packages
-  cat dists/stable/main/binary-$ARCH/Packages | gzip -9 > dists/stable/main/binary-$ARCH/Packages.gz
+  mkdir -p "$ARTIFACTS_DIR/apt-repo"
 
-  echo "Packages file content:"
-  cat dists/stable/main/binary-$ARCH/Packages
-  echo "There should be two entries above, one for the binary and one for the archive keyring."
-
-  tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will create a Release file, which is required by apt repositories."
-
-  # Step 11: Create Release file with a bash script (with debugging logs to stderr)
-  echo "Step 11: Generating Release file using bash script with detailed debugging"
-  cat <<EOF > "$ARTIFACTS_DIR/generate-release.sh"
-#!/bin/bash
-set -e
-
-# Enable debug output if DEBUG is set to true or 1
-DEBUG="\${DEBUG:-false}"
-
-# Debug function to print messages to stderr if DEBUG is enabled
-debug_log() {
-    if [[ "\$DEBUG" == "true" || "\$DEBUG" == "1" ]]; then
-        echo "[DEBUG] \$1" >&2
-    fi
-}
-
-# Function to handle hashing with more detailed debugging
-do_hash() {
-    HASH_NAME=\$1
-    HASH_CMD=\$2
-    echo "\${HASH_NAME}:"
-
-    # Find all files and remove the './' prefix
-    for f in \$(find . -type f); do
-        f=\$(echo "\$f" | cut -c3-)
-
-        # Skip the Release file itself
-        if [ "\$f" = "Release" ]; then
-            debug_log "Skipping the Release file: \$f"
-            continue
-        fi
-
-        # Check file permissions and existence before hashing
-        if [ -r "\$f" ]; then
-            debug_log "Processing file: \$f"
-            debug_log "File permissions: \$(ls -l "\$f")"
-            echo " \$(\${HASH_CMD} "\$f" | cut -d' ' -f1) \$(wc -c < "\$f") \$f"
-        else
-            debug_log "[ERROR] Permission denied or file not readable: \$f"
-            echo "[ERROR] Permission denied or file not readable: \$f" >&2
-            exit 1
-        fi
-    done
-}
-
-# Start logging
-debug_log "Generating Release file with detailed debugging..."
-
-# Output Release file metadata
-cat <<EOF2
+  # make reprepro config template file
+  cat <<EOF > $ARTIFACTS_DIR/distributions.template
 Origin: Example Repository
 Label: Example
-Suite: stable
 Codename: stable
-Version: 1.0
 Architectures: <ARCH-PLACEHOLDER>
 Components: main
 Description: An example software repository
-Date: \$(date -Ru)
-EOF2
-
-# Perform MD5, SHA1, and SHA256 hashes with debugging
-do_hash "MD5Sum" "md5sum"
-do_hash "SHA1" "sha1sum"
-do_hash "SHA256" "sha256sum"
-
-debug_log "Release file generation complete."
+SignWith: <FINGERPRINT-PLACEHOLDER>
 EOF
 
-  sed -i "s/<ARCH-PLACEHOLDER>/$ARCH/g" "$ARTIFACTS_DIR/generate-release.sh"
-  chmod +x "$ARTIFACTS_DIR/generate-release.sh"
+  # Create a temp directory before calling reprepro. This is to mimic the stateless
+  # implementation we have in our CI workflow. Further reprepro calls will have a
+  # separate temp directory.
+  mkdir -p "$ARTIFACTS_DIR/temp-reprepro-1/conf"
+  cd "$ARTIFACTS_DIR/temp-reprepro-1/conf"
+  cp $ARTIFACTS_DIR/distributions.template distributions
+  sed -i "s/<ARCH-PLACEHOLDER>/$ARCH/g" distributions
+  sed -i "s/<FINGERPRINT-PLACEHOLDER>/$KEY1_FINGERPRINT/g" distributions
 
-  cd "$ARTIFACTS_DIR/apt-repo/dists/stable"
-  "$ARTIFACTS_DIR/generate-release.sh" > Release
-  echo "Release file generated."
-  tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will sign the release with a PGP key."
+  cd "$ARTIFACTS_DIR/temp-reprepro-1"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH.deb"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH.deb"
+  cp -a dists/ pool/ "$ARTIFACTS_DIR/apt-repo/"
 
-  # Step 12: Sign the release with the created PGP key
-  echo "Step 12: Signing the release with the created PGP key"
+  echo "These is the content of the Packages file:"
+  cat dists/stable/main/binary-$ARCH/Packages
+  echo "! Note that there should be two entries above; hello-world and the archive-keyring package."
+
+  # Step 6: Serve the repository using a local HTTP server
+  prompt_continue "Next, we will host the repository using a simple HTTP server."
+  echo "Step 6: Hosting repository with a simple HTTP server"
+
   cd "$ARTIFACTS_DIR"
+  busybox httpd -p 8000 # runs in background by default
+  echo "HTTP server started at http://127.0.0.1:8000"
 
-  # Sign the Release file and also make the InRelease file
-  cat ./apt-repo/dists/stable/Release | GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --local-user $KEY1_FINGERPRINT -abs > apt-repo/dists/stable/Release.gpg
-  cat ./apt-repo/dists/stable/Release | GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --local-user $KEY1_FINGERPRINT -abs --clearsign > apt-repo/dists/stable/InRelease
+  # Step 7: Add the apt repo entry to the host machine
+  prompt_continue "Next, we will add the apt repo entry to the host machine."
+  echo "Step 7: Adding apt repo entry to /etc/apt/sources.list.d"
 
   # Install the trust anchor (public key) on the host system for later verification.
-
+  #
   # Note: This trust anchor installation is the manual step that should be done when the
   # package is installed for the first time. That is we should still include this step
   # in our installation docs as we already have it. Future automatic upgrades of the
   # archive-keyring package will update the installed keyring, so the user would not
   # need to do this step ever again.
+  
   sudo mkdir -p -m 755 /usr/share/keyrings
-  sudo cp pgp-key.gpg /usr/share/keyrings/example-archive-keyring.gpg
+  sudo cp "$ARTIFACTS_DIR/pgp-key.gpg" /usr/share/keyrings/example-archive-keyring.gpg
   sudo chmod go+r /usr/share/keyrings/example-archive-keyring.gpg
 
-  tree
-  prompt_continue "Next, we will host the repository using Python's HTTP server for testing."
-
-  # Step 13: Serve the repository using a local HTTP server
-  echo "Step 13: Hosting repository with Python HTTP server"
-  cd "$ARTIFACTS_DIR"
-  python3 -m http.server 8000 > /dev/null 2>&1 &
-  echo "HTTP server started at http://127.0.0.1:8000"
-  prompt_continue "Next, we will add the local repository to the system's sources list and update apt."
-
-  # Step 14: Add the repository to the system's sources
-  echo "Step 14: Adding repository to /etc/apt/sources.list.d"
   echo "deb [arch=$ARCH allow-insecure=yes signed-by=/usr/share/keyrings/example-archive-keyring.gpg] http://127.0.0.1:8000/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/example.list
   echo "! Note that with this config, apt allows plain HTTP comms but still verifies package signatures."
-  prompt_continue "Next, we will update apt and install the archive keyring and 'hello-world' packages from the repository."
+  echo ""
+  echo "! If you wait here until the generated key expires, you'll see the next step fails due to the expired key."
 
-  # Step 15: Update and install the packages
-  echo "Step 15: Updating apt and installing the packages"
+  # Step 8: Update and install the packages
+  prompt_continue "Next, we will update apt and install the archive keyring and 'hello-world' packages from the repository."
+  echo "Step 8: Updating apt and installing the packages"
+
   sudo apt-get update # We don't need --allow-insecure-repositories
   sudo apt-get install -y example-archive-keyring hello-world
   echo "Hello World and the archive keyring packages installed successfully."
   echo "! Note that there should be no warnings about unverified packages in the logs above."
+}
+
+# Function to handle the signing key rotation process
+newkey() {
+  prompt_continue "Next, we will ask you to provide the directory location you used for the setup step."
+
+  prompt_for_artifacts_dir
+
+  # Verify that the current key is not yet expired
+  prompt_continue "Next, we confirm the current signing key is not yet expired."
+  echo "Step 1: Verifying the current key is not yet expired"
+
+  KEY1_FINGERPRINT="$(cat $ARTIFACTS_DIR/key1-fingerprint)"
+
+  expiry_date="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --with-colons --fingerprint $KEY1_FINGERPRINT | grep -E "^pub:" | cut -f7 -d:)"
+  current_date="$(date +%s)"
+  if [ "$expiry_date" -lt "$current_date" ]; then
+    echo "The key is already expired. Please 'teardown' and start over."
+    exit 1
+  else
+    echo "Confirmed that the current signing key is still valid."
+  fi
+
+  # Generate a new key and add it to the keyring
+  prompt_continue "Next, we will generate a new PGP key that expires in 15 mins, and add it to the keyring."
+  echo "Step 2: Generating a new PGP key (expires in 15 mins) and add it to the keyring"
+
+  # Get the list of existing keys
+  existing_keys_list="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --with-colons)"
+  KEY1_FINGERPRINT="$(echo "$existing_keys_list" | grep -E "^fpr:" | cut -f10 -d: | head -n1)"
+
+  cd "$ARTIFACTS_DIR"
+  echo "%echo Generating an example PGP key
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: example-key-2
+Name-Email: example@example.com
+Expire-Date: seconds=$((15 * 60))
+%no-ask-passphrase
+%no-protection
+%commit" > example-pgp-key-2.batch
+
+  mkdir -m 700 -p "$ARTIFACTS_DIR/temp-gpg-home"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --no-tty --batch --gen-key example-pgp-key-2.batch
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --armor --export-secret-keys > pgp-key.private # ASCII version
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --armor --export > pgp-key.public # ASCII version
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export > pgp-key.gpg # Binary version
+
+  new_keys_list="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --with-colons)"
+  added_key="$(comm -1 -3 <(echo "$existing_keys_list" | sort) <(echo "$new_keys_list" | sort))"
+  KEY2_FINGERPRINT="$(echo "$added_key" | grep -E "^fpr:" | cut -f10 -d: | head -n1)"
+  echo -n "$KEY2_FINGERPRINT" > $ARTIFACTS_DIR/key2-fingerprint
+
+  echo "Generated PGP key with fingerprint: $KEY2_FINGERPRINT"
+
+  # Step 3: Make a new version of the archive keyring package to deliver the updated keyring (including both keys)
+  prompt_continue "Next, we will generate the new archive-keyring package and update the apt repository."
+  echo "Step 3: Generating the new archive-keyring package and updating the apt repository."
+
+  # create a copy of the files of the previous version of the archive keyring package
+  cp -r "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH" "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_$ARCH"
+  # update the keyring file with the new keyring (including both keys)
+  cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_$ARCH"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export > usr/share/keyrings/example-archive-keyring.gpg
+  # bump the version in the debian control file
+  sed -i 's/Version: 0\.0\.1/Version: 0.0.2/' DEBIAN/control
+
+  cd "$ARTIFACTS_DIR"
+  dpkg --build example-archive-keyring_0.0.2-1_$ARCH
+  echo "Deb package created: example-archive-keyring_0.0.2-1_$ARCH.deb"
+
+  # To inspect the .deb package:
+  # dpkg-deb --info example-archive-keyring_0.0.2-1_$ARCH.deb
+  # dpkg-deb --contents example-archive-keyring_0.0.2-1_$ARCH.deb
+
+  # Create a new temp directory before calling reprepro.
+  mkdir -p "$ARTIFACTS_DIR/temp-reprepro-2/conf"
+  cd "$ARTIFACTS_DIR/temp-reprepro-2/conf"
+  cp $ARTIFACTS_DIR/distributions.template distributions
+  sed -i "s/<ARCH-PLACEHOLDER>/$ARCH/g" distributions
+  sed -i "s/<FINGERPRINT-PLACEHOLDER>/$KEY1_FINGERPRINT $KEY2_FINGERPRINT/g" distributions
+
+  cd "$ARTIFACTS_DIR/temp-reprepro-2"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH.deb"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_$ARCH.deb"
+  cp -a dists/ pool/ "$ARTIFACTS_DIR/apt-repo/"
+
+  cd "$ARTIFACTS_DIR/apt-repo"
+  echo "New packages:"
+  cat dists/stable/main/binary-$ARCH/Packages
+  echo "! Note that there should be two entries above, with the archive keyring version bumped to 0.0.2."
+  echo "The apt repository has been updated with the new archive keyring package."
+
+  # Step 4: Upgrade the archive keyring package on the host system
+  prompt_continue "Next, we will upgrade the archive keyring package on the host system."
+  echo "Step 4: Upgrading the archive keyring package on the host system."
+
+  sudo apt-get update
+  sudo apt-get install -y --only-upgrade example-archive-keyring
+
+   echo "archive-keyring package upgraded successfully."
+   echo "! Note that in the above logs the archive-keyring is now bumped to 0.0.2."
+}
+
+deprecate() {
+  prompt_continue "Next, we will ask you to provide the directory location you used for the setup step."
+
+  prompt_for_artifacts_dir
+
+  # Step 1: Verify that the old/first current key is expired
+  prompt_continue "Next, we confirm the old/first signing key is expired."
+  echo "Step 1: Verifying the old/first key is expired"
+
+  KEY1_FINGERPRINT="$(cat $ARTIFACTS_DIR/key1-fingerprint)"
+  KEY2_FINGERPRINT="$(cat $ARTIFACTS_DIR/key2-fingerprint)"
+
+  expiry_date="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --with-colons --fingerprint $KEY1_FINGERPRINT | grep -E "^pub:" | cut -f7 -d:)"
+  current_date="$(date +%s)"
+  if [ "$expiry_date" -gt "$current_date" ]; then
+    echo "The old/first key is not yet expired. Please wait until it expires and retry."
+    echo "time to expiry (seconds): $(( $expiry_date - $current_date ))"
+    exit 1
+  else
+    echo "Confirmed that the old/first signing key is expired."
+  fi
+
+  # Step 2: Make a new version of the archive keyring package with the old key removed
+  prompt_continue "Next, we will generate the new archive-keyring package with the old key removed, and update the apt repo."
+  echo "Step 2: Generating the new archive-keyring package with the old key removed."
+
+  # create a copy of the files of the previous version of the archive keyring package
+  cp -r "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_$ARCH" "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_$ARCH"
+  # update the keyring file with the new keyring (including both keys)
+  cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_$ARCH"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export $KEY2_FINGERPRINT > usr/share/keyrings/example-archive-keyring.gpg
+  # bump the version in the debian control file
+  sed -i 's/Version: 0\.0\.2/Version: 0.0.3/' DEBIAN/control
+
+  cd "$ARTIFACTS_DIR"
+  dpkg --build example-archive-keyring_0.0.3-1_$ARCH
+  echo "Deb package created: example-archive-keyring_0.0.3-1_$ARCH.deb"
+
+  # To inspect the .deb package:
+  # dpkg-deb --info example-archive-keyring_0.0.3-1_$ARCH.deb
+  # dpkg-deb --contents example-archive-keyring_0.0.3-1_$ARCH.deb
+
+  # Create a new temp directory before calling reprepro.
+  mkdir -p "$ARTIFACTS_DIR/temp-reprepro-3/conf"
+  cd "$ARTIFACTS_DIR/temp-reprepro-3/conf"
+  cp $ARTIFACTS_DIR/distributions.template distributions
+  sed -i "s/<ARCH-PLACEHOLDER>/$ARCH/g" distributions
+  sed -i "s/<FINGERPRINT-PLACEHOLDER>/$KEY2_FINGERPRINT/g" distributions
+
+  cd "$ARTIFACTS_DIR/temp-reprepro-3"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH.deb"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_$ARCH.deb"
+  cp -a dists/ pool/ "$ARTIFACTS_DIR/apt-repo/"
+
+  cd "$ARTIFACTS_DIR/apt-repo"
+  echo "New packages:"
+  cat dists/stable/main/binary-$ARCH/Packages
+  echo "! Note that there should be two entries above, with the archive keyring version bumped to 0.0.3."
+  echo "The apt repository has been updated with the new archive keyring package."
+
+  # Step 4: Upgrade the archive keyring package on the host system
+  prompt_continue "Next, we will upgrade the archive keyring package on the host system."
+  echo "Step 4: Upgrading the archive keyring package on the host system."
+
+  sudo apt-get update
+  sudo apt-get install -y --only-upgrade example-archive-keyring
+
+  echo "archive-keyring package upgraded successfully."
+  echo "! Note that in the above logs the archive-keyring is now bumped to 0.0.3."
 }
 
 # Function to handle the teardown process
@@ -339,10 +439,10 @@ teardown() {
 
   echo "Teardown: Cleaning up everything."
 
-  # Kill the Python HTTP server if it's running
-  if pgrep -f "python3 -m http.server" > /dev/null; then
-    echo "Stopping the Python HTTP server..."
-    pkill -f "python3 -m http.server"
+  # Kill the HTTP server if it's running
+  if pgrep -f "busybox httpd" > /dev/null; then
+    echo "Stopping the HTTP server..."
+    pkill -f "busybox httpd"
     echo "Server stopped."
   fi
 
@@ -406,14 +506,19 @@ teardown() {
   echo "Cleaning apt cache..."
   sudo apt-get clean
   echo "Cleanup complete."
+  sudo apt-get update
 }
 
 # Check for the setup or teardown argument
 if [ "$1" == "setup" ]; then
   setup
+elif [ "$1" == "newkey" ]; then
+  newkey
+elif [ "$1" == "deprecate" ]; then
+  deprecate
 elif [ "$1" == "teardown" ]; then
   teardown
 else
-  echo "Usage: $0 {setup|teardown}"
+  echo "Usage: $0 {setup|newkey|deprecate|teardown}"
   exit 1
 fi

--- a/script/debian-devel
+++ b/script/debian-devel
@@ -1,0 +1,340 @@
+#!/bin/bash
+
+# Hint: run this at the root of the repo to spin up an Ubuntu container with
+# this script lively mounted:
+#
+#   docker run -it -d --name gpg-playground -v "$(pwd)/script/debian-devel:/root/debian-devel" ubuntu:22.04
+#
+# And then use this to exec into the container:
+#
+#   docker exec -it gpg-playground bash
+#
+
+# Enable strict mode
+set -eo pipefail
+
+ARCH=$(dpkg --print-architecture)
+
+# Check if DEBUG is set to true or 1, enable debug print statements if so
+if [[ "$DEBUG" == "true" || "$DEBUG" == "1" ]]; then
+  set -x
+fi
+
+# Default artifacts directory
+DEFAULT_ARTIFACTS_DIR="$(pwd)/deb-repo-test"
+
+# Function to prompt user to continue to the next step with explanations
+prompt_continue() {
+  echo
+  read -p "$1 Press Enter to continue..."
+}
+
+# Function to prompt for the artifacts directory and ensure it exists
+prompt_for_artifacts_dir() {
+  read -p "Please provide a directory location for storing all artifacts (leave empty for default: $DEFAULT_ARTIFACTS_DIR): "
+  # Use default if the user provides no input
+  if [ -z "$ARTIFACTS_DIR" ]; then
+    ARTIFACTS_DIR="$DEFAULT_ARTIFACTS_DIR"
+    echo "No directory provided. Using default: $ARTIFACTS_DIR"
+  fi
+}
+
+# Function to handle the setup process
+setup() {
+  # Step 1: Install prerequisites (including Go)
+  if ! command -v sudo &> /dev/null; then
+    # This is to make sure the script runs on both containers and VMs.
+    apt-get update
+    apt-get install -y sudo
+  fi
+  echo "Step 1: Installing prerequisites (Go, dpkg-dev, gpg, tree, Python)"
+  sudo apt-get update
+  sudo apt-get install -y golang-go dpkg-dev gpg tree python3
+  prompt_continue "Next, we will ask you to provide a directory location to store all artifacts."
+
+  # Prompt for the artifacts directory
+  prompt_for_artifacts_dir
+
+  # Check if directory exists, if not, create it
+  if [ ! -d "$ARTIFACTS_DIR" ]; then
+    echo "Directory does not exist. Creating $ARTIFACTS_DIR..."
+    mkdir -p "$ARTIFACTS_DIR"
+    echo "Directory $ARTIFACTS_DIR created."
+  else
+    echo "Directory $ARTIFACTS_DIR already exists."
+  fi
+  tree "$ARTIFACTS_DIR"
+  prompt_continue "Next, we will create a simple Go program within the specified directory."
+
+  # Step 2: Create Go Program
+  echo "Step 2: Creating a simple Go program"
+  mkdir -p "$ARTIFACTS_DIR/hello-world-program"
+  cat <<EOF > "$ARTIFACTS_DIR/hello-world-program/main.go"
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("hello statically compiled world")
+}
+EOF
+
+  # Step 3: Compile the Go program statically
+  echo "Step 3: Compiling the Go program statically"
+  cd "$ARTIFACTS_DIR/hello-world-program"
+  CGO_ENABLED=0 go build -o hello-world -ldflags="-extldflags=-static" main.go
+  echo "Go program compiled as a static binary."
+  tree "$ARTIFACTS_DIR"
+  prompt_continue "Next, we will create the directory structure for the deb package."
+
+  # Step 4: Create directory structure for deb package
+  echo "Step 4: Creating directory structure for the deb package"
+  mkdir -p "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH"
+  cd "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH"
+  mkdir -p usr/bin
+  cp "$ARTIFACTS_DIR/hello-world-program/hello-world" usr/bin/
+  echo "Binary copied to usr/bin/hello-world."
+  tree "$ARTIFACTS_DIR"
+  prompt_continue "Next, we will create the necessary control file for the deb package."
+
+  # Step 5: Create DEBIAN control file
+  echo "Step 5: Creating DEBIAN control file"
+  mkdir -p DEBIAN
+  echo "Package: hello-world
+Version: 0.0.1
+Maintainer: example <example@example.com>
+Architecture: $ARCH
+Homepage: http://example.com
+Description: A statically compiled Go program that prints hello" > DEBIAN/control
+  echo "Control file created at $ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH/DEBIAN/control."
+  tree "$ARTIFACTS_DIR"
+  prompt_continue "Next, we will build the .deb package from the files we have set up."
+
+  # Step 6: Build the deb package
+  echo "Step 6: Building the .deb package"
+  cd "$ARTIFACTS_DIR"
+  dpkg --build hello-world_0.0.1-1_$ARCH
+  echo "Deb package created: hello-world_0.0.1-1_$ARCH.deb"
+  tree "$ARTIFACTS_DIR"
+  prompt_continue "Next, we will inspect the .deb package to verify its contents."
+
+  # Step 7: Inspect the deb package
+  echo "Step 7: Inspecting the .deb package"
+  dpkg-deb --info hello-world_0.0.1-1_$ARCH.deb
+  dpkg-deb --contents hello-world_0.0.1-1_$ARCH.deb
+  prompt_continue "Next, we will set up a directory structure for hosting this package in an apt repository."
+
+  # Step 8: Create apt repository directory structure
+  echo "Step 8: Creating apt repository directory structure"
+  mkdir -p "$ARTIFACTS_DIR/apt-repo/pool/main/"
+  cp "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH.deb" "$ARTIFACTS_DIR/apt-repo/pool/main/"
+  mkdir -p "$ARTIFACTS_DIR/apt-repo/dists/stable/main/binary-$ARCH"
+  tree "$ARTIFACTS_DIR"
+  prompt_continue "Next, we will generate the 'Packages' file, which lists the available deb packages in the repository."
+
+  # Step 9: Generate Packages file
+  echo "Step 9: Generating Packages file"
+  cd "$ARTIFACTS_DIR/apt-repo"
+  dpkg-scanpackages --arch $ARCH pool/ > dists/stable/main/binary-$ARCH/Packages
+  cat dists/stable/main/binary-$ARCH/Packages | gzip -9 > dists/stable/main/binary-$ARCH/Packages.gz
+  tree "$ARTIFACTS_DIR"
+  prompt_continue "Next, we will create a Release file, which is required by apt repositories."
+  
+  # Step 10: Create Release file with a bash script (with debugging logs to stderr)
+  echo "Step 10: Generating Release file using bash script with detailed debugging"
+  cat <<EOF > "$ARTIFACTS_DIR/generate-release.sh"
+#!/bin/bash
+set -e
+
+# Enable debug output if DEBUG is set to true or 1
+DEBUG="\${DEBUG:-false}"
+
+# Debug function to print messages to stderr if DEBUG is enabled
+debug_log() {
+    if [[ "\$DEBUG" == "true" || "\$DEBUG" == "1" ]]; then
+        echo "[DEBUG] \$1" >&2
+    fi
+}
+
+# Function to handle hashing with more detailed debugging
+do_hash() {
+    HASH_NAME=\$1
+    HASH_CMD=\$2
+    echo "\${HASH_NAME}:"
+
+    # Find all files and remove the './' prefix
+    for f in \$(find . -type f); do
+        f=\$(echo "\$f" | cut -c3-)
+
+        # Skip the Release file itself
+        if [ "\$f" = "Release" ]; then
+            debug_log "Skipping the Release file: \$f"
+            continue
+        fi
+
+        # Check file permissions and existence before hashing
+        if [ -r "\$f" ]; then
+            debug_log "Processing file: \$f"
+            debug_log "File permissions: \$(ls -l "\$f")"
+            echo " \$(\${HASH_CMD} "\$f" | cut -d' ' -f1) \$(wc -c < "\$f") \$f"
+        else
+            debug_log "[ERROR] Permission denied or file not readable: \$f"
+            echo "[ERROR] Permission denied or file not readable: \$f" >&2
+            exit 1
+        fi
+    done
+}
+
+# Start logging
+debug_log "Generating Release file with detailed debugging..."
+
+# Output Release file metadata
+cat <<EOF2
+Origin: Example Repository
+Label: Example
+Suite: stable
+Codename: stable
+Version: 1.0
+Architectures: <ARCH-PLACEHOLDER>
+Components: main
+Description: An example software repository
+Date: \$(date -Ru)
+EOF2
+
+# Perform MD5, SHA1, and SHA256 hashes with debugging
+do_hash "MD5Sum" "md5sum"
+do_hash "SHA1" "sha1sum"
+do_hash "SHA256" "sha256sum"
+
+debug_log "Release file generation complete."
+EOF
+
+  sed -i "s/<ARCH-PLACEHOLDER>/$ARCH/g" "$ARTIFACTS_DIR/generate-release.sh"
+  chmod +x "$ARTIFACTS_DIR/generate-release.sh"
+
+  cd "$ARTIFACTS_DIR/apt-repo/dists/stable"
+  "$ARTIFACTS_DIR/generate-release.sh" > Release
+  echo "Release file generated."
+  tree "$ARTIFACTS_DIR"
+  prompt_continue "Next, we will sign the release with a PGP key."
+
+  # Step 11: Sign the release with a PGP key that expires in 1 minute
+  echo "Step 11: Signing the release with a PGP key"
+  cd "$ARTIFACTS_DIR"
+  echo "%echo Generating an example PGP key
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: example
+Name-Email: example@example.com
+Expire-Date: $(date -u -d '+1 minute' '+%Y%m%dT%H%M%S')
+%no-ask-passphrase
+%no-protection
+%commit" > example-pgp-key.batch
+
+  mkdir -m 700 "temp-gpg-home"
+  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --no-tty --batch --gen-key example-pgp-key.batch
+  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --list-keys
+  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --armor --export-secret-keys example > pgp-key.private
+  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --armor --export example > pgp-key.public
+  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --export example > pgp-key.gpg
+
+  # Sign the Release file and also make the InRelease file
+  cat ./apt-repo/dists/stable/Release | GNUPGHOME="$(pwd)/temp-gpg-home" gpg --default-key example -abs > apt-repo/dists/stable/Release.gpg
+  cat ./apt-repo/dists/stable/Release | GNUPGHOME="$(pwd)/temp-gpg-home" gpg --default-key example -abs --clearsign > apt-repo/dists/stable/InRelease
+
+  # Copy the public key to the host system for later verification
+  sudo mkdir -p -m 755 /etc/apt/keyrings
+  sudo cp pgp-key.gpg /etc/apt/keyrings/example-archive-keyring.gpg
+  sudo chmod go+r /etc/apt/keyrings/example-archive-keyring.gpg
+
+  tree
+  prompt_continue "Next, we will host the repository using Python's HTTP server for testing."
+
+  # Step 12: Serve the repository using a local HTTP server
+  echo "Step 12: Hosting repository with Python HTTP server"
+  cd "$ARTIFACTS_DIR"
+  python3 -m http.server 8000 > /dev/null 2>&1 &
+  echo "HTTP server started at http://127.0.0.1:8000"
+  prompt_continue "Next, we will add the local repository to the system's sources list and update apt."
+
+  # Step 13: Add the repository to the system's sources
+  echo "Step 13: Adding repository to /etc/apt/sources.list.d"
+  echo "deb [arch=$ARCH allow-insecure=yes signed-by=/etc/apt/keyrings/example-archive-keyring.gpg] http://127.0.0.1:8000/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/example.list
+  echo "! Note that with this config, apt allows plain HTTP comms but still verifies package signatures."
+  prompt_continue "Next, we will update apt and install the 'hello-world' package from the repository."
+
+  # Step 14: Update and install the package
+  echo "Step 14: Updating apt and installing the package"
+  sudo apt-get update # We don't need --allow-insecure-repositories
+  sudo apt-get install -y hello-world
+  echo "Hello World package installed successfully."
+  echo "! Note that there should be no warnings about unverified packages in the logs above."
+}
+
+# Function to handle the teardown process
+teardown() {
+  # Prompt for the artifacts directory during teardown
+  prompt_for_artifacts_dir
+
+  echo "Teardown: Cleaning up everything."
+
+  # Kill the Python HTTP server if it's running
+  if pgrep -f "python3 -m http.server" > /dev/null; then
+    echo "Stopping the Python HTTP server..."
+    pkill -f "python3 -m http.server"
+    echo "Server stopped."
+  fi
+
+  # Check if the hello-world package is installed, and remove it safely
+  if dpkg -l | grep -q "^ii  hello-world"; then
+    echo "Removing the hello-world package..."
+    sudo apt-get remove --purge -y hello-world
+    echo "Package hello-world removed."
+  else
+    echo "Package hello-world is not installed, skipping removal."
+  fi
+
+  # Remove the repository from sources.list.d
+  if [ -f /etc/apt/sources.list.d/example.list ]; then
+    echo "Removing the repository from /etc/apt/sources.list.d..."
+    sudo rm /etc/apt/sources.list.d/example.list
+    echo "Repository removed."
+  fi
+
+  # Remove the PGP keyring
+  if [ -f /etc/apt/keyrings/example-archive-keyring.gpg ]; then
+    echo "Removing the PGP keyring from /etc/apt/keyrings..."
+    sudo rm /etc/apt/keyrings/example-archive-keyring.gpg
+    echo "PGP keyring removed."
+  fi
+
+  # Kill gpg-agent
+  if pgrep "^gpg-agent" > /dev/null; then
+    echo "Stopping the GPG agent..."
+    pkill "^gpg-agent"
+    echo "GPG agent stopped."
+  fi
+
+  # Remove the artifacts directory
+  if [ -d "$ARTIFACTS_DIR" ]; then
+    echo "No directory provided. Using default: $ARTIFACTS_DIR"
+    echo "Removing the artifacts directory: $ARTIFACTS_DIR"
+    rm -rf "$ARTIFACTS_DIR"
+    echo "Artifacts directory removed."
+  fi
+
+  # Clean apt cache
+  echo "Cleaning apt cache..."
+  sudo apt-get clean
+  echo "Cleanup complete."
+}
+
+# Check for the setup or teardown argument
+if [ "$1" == "setup" ]; then
+  setup
+elif [ "$1" == "teardown" ]; then
+  teardown
+else
+  echo "Usage: $0 {setup|teardown}"
+  exit 1
+fi

--- a/script/debian-devel
+++ b/script/debian-devel
@@ -3,7 +3,7 @@
 # Hint: run this at the root of the repo to spin up an Ubuntu container with
 # this script lively mounted:
 #
-#   docker run -it -d --name gpg-playground -v "$(pwd)/script/debian-devel:/root/debian-devel" ubuntu:22.04
+#   docker run -it -d --name gpg-playground -v "$(pwd)/script/debian-devel:/root/debian-devel" python:3
 #
 # And then use this to exec into the container:
 #
@@ -47,9 +47,10 @@ setup() {
     apt-get update
     apt-get install -y sudo
   fi
-  echo "Step 1: Installing prerequisites (Go, dpkg-dev, gpg, tree, Python)"
+
+  echo "Step 1: Installing prerequisites"
   sudo apt-get update
-  sudo apt-get install -y golang-go dpkg-dev gpg reprepro tree python3
+  sudo apt-get install --no-upgrade -y dpkg-dev gpg reprepro tree python3
   prompt_continue "Next, we will ask you to provide a directory location to store all artifacts."
 
   # Prompt for the artifacts directory
@@ -64,7 +65,7 @@ setup() {
     echo "Directory $ARTIFACTS_DIR already exists."
   fi
   tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will create a simple Go program within the specified directory."
+  prompt_continue "Next, we will create a apt repository in the specified directory."
 
   # Step 1: Create a PGP key/cert that expires in 1 minute
   echo "Step 1: Creating a PGP key/cert that expires in 1 minute"
@@ -80,84 +81,79 @@ Expire-Date: $(date -u -d '+1 minute' '+%Y%m%dT%H%M%S')
 %commit" > example-pgp-key.batch
 
   mkdir -m 700 "temp-gpg-home"
-  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --no-tty --batch --gen-key example-pgp-key.batch
-  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --list-keys
-  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --armor --export-secret-keys example > pgp-key.private # ASCII version
-  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --armor --export example > pgp-key.public # ASCII version
-  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --export example > pgp-key.gpg # Binary version
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --no-tty --batch --gen-key example-pgp-key.batch
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --armor --export-secret-keys example > pgp-key.private # ASCII version
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --armor --export example > pgp-key.public # ASCII version
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export example > pgp-key.gpg # Binary version
 
-  KEY1_FINGERPRINT="$(gpg --list-keys --list-options show-only-fpr-mbox | cut -f1 -d' ' | head -n 1)"
+  KEY1_FINGERPRINT="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --list-options show-only-fpr-mbox | cut -f1 -d' ' | head -n 1)"
   echo "Generated PGP key with fingerprint: $KEY1_FINGERPRINT"
 
   tree
 
-  # Step 2: Create directory structure for the archive keyring deb package
+  # Step 2: Create the archive keyring deb package
   echo "Step 2: Creating directory structure for the archive keyring deb package"
-  mkdir -p "$ARTIFACTS_DIR/example-archive-keyring"
-  cd "$ARTIFACTS_DIR/example-archive-keyring"
+  mkdir -p "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH"
+  cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH"
   mkdir -p usr/share/keyrings
-  gpg --export-options export-minimal --export $KEY1_FINGERPRINT > usr/share/keyrings/example.pgp
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export-options export-minimal --export $KEY1_FINGERPRINT > usr/share/keyrings/example-archive-keyring.gpg
+  mkdir -p etc/apt/sources.list.d
+  echo -n "# Created by example-archive-keyring package
+deb [arch=$ARCH allow-insecure=yes signed-by=/usr/share/keyrings/example-archive-keyring.gpg] http://127.0.0.1:8000/apt-repo stable main
+" > etc/apt/sources.list.d/example.list
 
-  mkdir -p usr/bin
-  cp "$ARTIFACTS_DIR/hello-world-program/hello-world" usr/bin/
-  echo "Binary copied to usr/bin/hello-world."
-  tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will create the necessary control file for the deb package."
+  # Add the preferences file to enable automatic upgrades for the archive keyring package.
+  # The `Pin-Priority: 100` ensures that the package is considered for upgrades.
+  #
+  # See:
+  # - https://wiki.debian.org/DebianRepository/UseThirdParty#Standard_pinning
+  # - https://wiki.debian.org/DebianRepository/UseThirdParty#Certificate_rollover_and_updates
+  mkdir -p etc/apt/preferences.d
+  echo -n "# Created by example-archive-keyring package
+Package: example-archive-keyring
+Pin: origin example.com
+Pin-Priority: 100
+" > etc/apt/preferences.d/example.pref
 
-  # Step 5: Create DEBIAN control file
-  echo "Step 5: Creating DEBIAN control file"
   mkdir -p DEBIAN
-  echo "Package: hello-world
+  echo -n "Package: example-archive-keyring
 Version: 0.0.1
 Maintainer: example <example@example.com>
 Architecture: $ARCH
 Homepage: http://example.com
-Description: A statically compiled Go program that prints hello" > DEBIAN/control
-  echo "Control file created at $ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH/DEBIAN/control."
-  tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will build the .deb package from the files we have set up."
+Description: Example archive keyring
+" > DEBIAN/control
+  echo "Control file for example-archive-keyring created at $ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH/DEBIAN/control"
 
-  # Step 6: Build the deb package
-  echo "Step 6: Building the .deb package"
   cd "$ARTIFACTS_DIR"
-  dpkg --build hello-world_0.0.1-1_$ARCH
-  echo "Deb package created: hello-world_0.0.1-1_$ARCH.deb"
-  tree "$ARTIFACTS_DIR"
-  prompt_continue "Next, we will inspect the .deb package to verify its contents."
+  dpkg --build example-archive-keyring_0.0.1-1_$ARCH
+  echo "Deb package created: example-archive-keyring_0.0.1-1_$ARCH.deb"
 
-  # Step 7: Inspect the deb package
-  echo "Step 7: Inspecting the .deb package"
-  dpkg-deb --info hello-world_0.0.1-1_$ARCH.deb
-  dpkg-deb --contents hello-world_0.0.1-1_$ARCH.deb
-  prompt_continue "Next, we will set up a directory structure for hosting this package in an apt repository."
+  # To inspect the .deb package:
+  # dpkg-deb --info example-archive-keyring_0.0.1-1_$ARCH.deb
+  # dpkg-deb --contents example-archive-keyring_0.0.1-1_$ARCH.deb
 
+  prompt_continue "Next, we will create a simple Go program to be the binary in our repository"
 
-
-
-
-  # Step 2: Create Go Program
-  echo "Step 2: Creating a simple Go program"
+  # Step 3: Create simple program
+  echo "Step 3: Creating a simple program"
   mkdir -p "$ARTIFACTS_DIR/hello-world-program"
-  cat <<EOF > "$ARTIFACTS_DIR/hello-world-program/main.go"
-package main
+  echo '#include <stdio.h>
+int main() {
+    printf("hello packaged world\n");
+    return 0;
+}' > $ARTIFACTS_DIR/hello-world-program/hello.c
 
-import "fmt"
-
-func main() {
-    fmt.Println("hello statically compiled world")
-}
-EOF
-
-  # Step 3: Compile the Go program statically
-  echo "Step 3: Compiling the Go program statically"
+  # Step 4: Compile the program
+  echo "Step 4: Compiling the program"
   cd "$ARTIFACTS_DIR/hello-world-program"
-  CGO_ENABLED=0 go build -o hello-world -ldflags="-extldflags=-static" main.go
-  echo "Go program compiled as a static binary."
+  gcc -o hello-world hello.c
   tree "$ARTIFACTS_DIR"
   prompt_continue "Next, we will create the directory structure for the deb package."
 
-  # Step 4: Create directory structure for deb package
-  echo "Step 4: Creating directory structure for the deb package"
+  # Step 5: Create directory structure for deb package
+  echo "Step 5: Creating directory structure for the deb package"
   mkdir -p "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH"
   cd "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH"
   mkdir -p usr/bin
@@ -166,8 +162,8 @@ EOF
   tree "$ARTIFACTS_DIR"
   prompt_continue "Next, we will create the necessary control file for the deb package."
 
-  # Step 5: Create DEBIAN control file
-  echo "Step 5: Creating DEBIAN control file"
+  # Step 6: Create DEBIAN control file
+  echo "Step 6: Creating DEBIAN control file"
   mkdir -p DEBIAN
   echo "Package: hello-world
 Version: 0.0.1
@@ -179,38 +175,44 @@ Description: A statically compiled Go program that prints hello" > DEBIAN/contro
   tree "$ARTIFACTS_DIR"
   prompt_continue "Next, we will build the .deb package from the files we have set up."
 
-  # Step 6: Build the deb package
-  echo "Step 6: Building the .deb package"
+  # Step 7: Build the deb package
+  echo "Step 7: Building the .deb package"
   cd "$ARTIFACTS_DIR"
   dpkg --build hello-world_0.0.1-1_$ARCH
   echo "Deb package created: hello-world_0.0.1-1_$ARCH.deb"
   tree "$ARTIFACTS_DIR"
   prompt_continue "Next, we will inspect the .deb package to verify its contents."
 
-  # Step 7: Inspect the deb package
-  echo "Step 7: Inspecting the .deb package"
+  # Step 8: Inspect the deb package
+  echo "Step 8: Inspecting the .deb package"
   dpkg-deb --info hello-world_0.0.1-1_$ARCH.deb
   dpkg-deb --contents hello-world_0.0.1-1_$ARCH.deb
   prompt_continue "Next, we will set up a directory structure for hosting this package in an apt repository."
 
-  # Step 8: Create apt repository directory structure
-  echo "Step 8: Creating apt repository directory structure"
+  # Step 9: Create apt repository directory structure
+  echo "Step 9: Creating apt repository directory structure"
   mkdir -p "$ARTIFACTS_DIR/apt-repo/pool/main/"
+  cp "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH.deb" "$ARTIFACTS_DIR/apt-repo/pool/main/"
   cp "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH.deb" "$ARTIFACTS_DIR/apt-repo/pool/main/"
   mkdir -p "$ARTIFACTS_DIR/apt-repo/dists/stable/main/binary-$ARCH"
   tree "$ARTIFACTS_DIR"
   prompt_continue "Next, we will generate the 'Packages' file, which lists the available deb packages in the repository."
 
-  # Step 9: Generate Packages file
-  echo "Step 9: Generating Packages file"
+  # Step 10: Generate Packages file
+  echo "Step 10: Generating Packages file"
   cd "$ARTIFACTS_DIR/apt-repo"
   dpkg-scanpackages --arch $ARCH pool/ > dists/stable/main/binary-$ARCH/Packages
   cat dists/stable/main/binary-$ARCH/Packages | gzip -9 > dists/stable/main/binary-$ARCH/Packages.gz
+
+  echo "Packages file content:"
+  cat dists/stable/main/binary-$ARCH/Packages
+  echo "There should be two entries above, one for the binary and one for the archive keyring."
+
   tree "$ARTIFACTS_DIR"
   prompt_continue "Next, we will create a Release file, which is required by apt repositories."
-  
-  # Step 10: Create Release file with a bash script (with debugging logs to stderr)
-  echo "Step 10: Generating Release file using bash script with detailed debugging"
+
+  # Step 11: Create Release file with a bash script (with debugging logs to stderr)
+  echo "Step 11: Generating Release file using bash script with detailed debugging"
   cat <<EOF > "$ARTIFACTS_DIR/generate-release.sh"
 #!/bin/bash
 set -e
@@ -287,56 +289,46 @@ EOF
   tree "$ARTIFACTS_DIR"
   prompt_continue "Next, we will sign the release with a PGP key."
 
-  # Step 11: Sign the release with a PGP key that expires in 1 minute
-  echo "Step 11: Signing the release with a PGP key"
+  # Step 12: Sign the release with the created PGP key
+  echo "Step 12: Signing the release with the created PGP key"
   cd "$ARTIFACTS_DIR"
-  echo "%echo Generating an example PGP key
-Key-Type: RSA
-Key-Length: 4096
-Name-Real: example
-Name-Email: example@example.com
-Expire-Date: $(date -u -d '+1 minute' '+%Y%m%dT%H%M%S')
-%no-ask-passphrase
-%no-protection
-%commit" > example-pgp-key.batch
-
-  mkdir -m 700 "temp-gpg-home"
-  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --no-tty --batch --gen-key example-pgp-key.batch
-  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --list-keys
-  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --armor --export-secret-keys example > pgp-key.private
-  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --armor --export example > pgp-key.public
-  GNUPGHOME="$(pwd)/temp-gpg-home" gpg --export example > pgp-key.gpg
 
   # Sign the Release file and also make the InRelease file
-  cat ./apt-repo/dists/stable/Release | GNUPGHOME="$(pwd)/temp-gpg-home" gpg --default-key example -abs > apt-repo/dists/stable/Release.gpg
-  cat ./apt-repo/dists/stable/Release | GNUPGHOME="$(pwd)/temp-gpg-home" gpg --default-key example -abs --clearsign > apt-repo/dists/stable/InRelease
+  cat ./apt-repo/dists/stable/Release | GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --local-user $KEY1_FINGERPRINT -abs > apt-repo/dists/stable/Release.gpg
+  cat ./apt-repo/dists/stable/Release | GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --local-user $KEY1_FINGERPRINT -abs --clearsign > apt-repo/dists/stable/InRelease
 
-  # Copy the public key to the host system for later verification
-  sudo mkdir -p -m 755 /etc/apt/keyrings
-  sudo cp pgp-key.gpg /etc/apt/keyrings/example-archive-keyring.gpg
-  sudo chmod go+r /etc/apt/keyrings/example-archive-keyring.gpg
+  # Install the trust anchor (public key) on the host system for later verification.
+
+  # Note: This trust anchor installation is the manual step that should be done when the
+  # package is installed for the first time. That is we should still include this step
+  # in our installation docs as we already have it. Future automatic upgrades of the
+  # archive-keyring package will update the installed keyring, so the user would not
+  # need to do this step ever again.
+  sudo mkdir -p -m 755 /usr/share/keyrings
+  sudo cp pgp-key.gpg /usr/share/keyrings/example-archive-keyring.gpg
+  sudo chmod go+r /usr/share/keyrings/example-archive-keyring.gpg
 
   tree
   prompt_continue "Next, we will host the repository using Python's HTTP server for testing."
 
-  # Step 12: Serve the repository using a local HTTP server
-  echo "Step 12: Hosting repository with Python HTTP server"
+  # Step 13: Serve the repository using a local HTTP server
+  echo "Step 13: Hosting repository with Python HTTP server"
   cd "$ARTIFACTS_DIR"
   python3 -m http.server 8000 > /dev/null 2>&1 &
   echo "HTTP server started at http://127.0.0.1:8000"
   prompt_continue "Next, we will add the local repository to the system's sources list and update apt."
 
-  # Step 13: Add the repository to the system's sources
-  echo "Step 13: Adding repository to /etc/apt/sources.list.d"
-  echo "deb [arch=$ARCH allow-insecure=yes signed-by=/etc/apt/keyrings/example-archive-keyring.gpg] http://127.0.0.1:8000/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/example.list
+  # Step 14: Add the repository to the system's sources
+  echo "Step 14: Adding repository to /etc/apt/sources.list.d"
+  echo "deb [arch=$ARCH allow-insecure=yes signed-by=/usr/share/keyrings/example-archive-keyring.gpg] http://127.0.0.1:8000/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/example.list
   echo "! Note that with this config, apt allows plain HTTP comms but still verifies package signatures."
-  prompt_continue "Next, we will update apt and install the 'hello-world' package from the repository."
+  prompt_continue "Next, we will update apt and install the archive keyring and 'hello-world' packages from the repository."
 
-  # Step 14: Update and install the package
-  echo "Step 14: Updating apt and installing the package"
+  # Step 15: Update and install the packages
+  echo "Step 15: Updating apt and installing the packages"
   sudo apt-get update # We don't need --allow-insecure-repositories
-  sudo apt-get install -y hello-world
-  echo "Hello World package installed successfully."
+  sudo apt-get install -y example-archive-keyring hello-world
+  echo "Hello World and the archive keyring packages installed successfully."
   echo "! Note that there should be no warnings about unverified packages in the logs above."
 }
 
@@ -363,18 +355,17 @@ teardown() {
     echo "Package hello-world is not installed, skipping removal."
   fi
 
-  # Remove the repository from sources.list.d
-  if [ -f /etc/apt/sources.list.d/example.list ]; then
-    echo "Removing the repository from /etc/apt/sources.list.d..."
-    sudo rm /etc/apt/sources.list.d/example.list
-    echo "Repository removed."
-  fi
-
-  # Remove the PGP keyring
+  # Remove the PGP keyrings
   if [ -f /etc/apt/keyrings/example-archive-keyring.gpg ]; then
     echo "Removing the PGP keyring from /etc/apt/keyrings..."
     sudo rm /etc/apt/keyrings/example-archive-keyring.gpg
-    echo "PGP keyring removed."
+    echo "PGP keyring removed from /etc/apt/keyrings."
+  fi
+
+  if [ -f /usr/share/keyrings/example-archive-keyring.gpg ]; then
+    echo "Removing the PGP keyring from /usr/share/keyrings..."
+    sudo rm /usr/share/keyrings/example-archive-keyring.gpg
+    echo "PGP keyring removed from /usr/share/keyrings."
   fi
 
   # Kill gpg-agent
@@ -390,6 +381,25 @@ teardown() {
     echo "Removing the artifacts directory: $ARTIFACTS_DIR"
     rm -rf "$ARTIFACTS_DIR"
     echo "Artifacts directory removed."
+  fi
+
+  # Remove installed test packages
+  if [ -f /etc/apt/sources.list.d/example.list ]; then
+    sudo apt-get remove example-archive-keyring hello-world -y || echo "Test packages not installed, skipping removal."
+  fi
+
+  # Remove apt source remains (if not removed by the above command)
+  if [ -f /etc/apt/sources.list.d/example.list ]; then
+    echo "Removing the repository from /etc/apt/sources.list.d..."
+    sudo rm /etc/apt/sources.list.d/example.list
+    echo "Repository removed."
+  fi
+
+  # Remove the preferences from preferences.d
+  if [ -f /etc/apt/preferences.d/example ]; then
+    echo "Removing the preferences from /etc/apt/preferences.d..."
+    sudo rm /etc/apt/preferences.d/example.pref
+    echo "Preferences removed."
   fi
 
   # Clean apt cache

--- a/script/debian-devel
+++ b/script/debian-devel
@@ -17,6 +17,7 @@
 # Enable strict mode
 set -eo pipefail
 
+SCRIPT=$(basename $0)
 ARCHITECTURES=("i386" "amd64" "arm64" "armhf")
 
 # Check if DEBUG is set to true or 1, enable debug print statements if so
@@ -25,39 +26,80 @@ if [[ "$DEBUG" == "true" || "$DEBUG" == "1" ]]; then
 fi
 
 # Default artifacts directory
-DEFAULT_ARTIFACTS_DIR="$(pwd)/deb-repo-test"
+ARTIFACTS_DIR="$(pwd)/deb-repo-test"
+
+bold() {
+  echo -e "\033[1m$1\033[0m"
+}
+
+header() {
+  echo
+  echo "================================================================================"
+  bold "$1"
+  echo
+}
 
 # Function to prompt user to continue to the next step with explanations
 prompt_continue() {
   echo
-  read -p "$1 Press Enter to continue..."
+  read -p "Press Enter to continue..."
 }
 
-# Function to prompt for the artifacts directory and ensure it exists
-prompt_for_artifacts_dir() {
-  read -p "Please provide a directory location for storing all artifacts (leave empty for default: $DEFAULT_ARTIFACTS_DIR): " ARTIFACTS_DIR
-  # Use default if the user provides no input
-  if [ -z "$ARTIFACTS_DIR" ]; then
-    ARTIFACTS_DIR="$DEFAULT_ARTIFACTS_DIR"
-    echo "No directory provided. Using default: $ARTIFACTS_DIR"
+# Function to start up Docker container for environment
+docker_setup() {
+  # If the gpg-playground container already exists, prompt the user whether to tear it down
+  if [ "$(docker ps -a -q -f name=gpg-playground)" ]; then
+    read -p "Do you want to teardown the existing container and recreate it? (y/n): " choice
+    if [[ "$choice" == "y" || "$choice" == "Y" ]]; then
+      docker_teardown
+    else
+      echo "Skip setup and using existing container."
+      docker exec -it gpg-playground bash
+      exit 0
+    fi
   fi
+
+  echo "Setting up a new container."
+  docker run -it -d --name gpg-playground -v "$(pwd)/script/debian-devel:/root/debian-devel" -w "/root" ubuntu:22.04
+
+  # Set up MOTD to display on shell entry
+  docker exec gpg-playground bash -c "cat >> /root/.bashrc << EOF
+
+# Display MOTD
+cat << "MOTD"
+================================================================================
+  Self-bootstrapping Debian Repository Development Environment
+================================================================================
+
+Welcome to the gpg-playground container!
+
+Available commands:
+  $SCRIPT setup      - Create initial Debian repository and packages
+  $SCRIPT newkey     - Generate new signing key
+  $SCRIPT deprecate  - Deprecate old signing key
+  $SCRIPT teardown   - Clean up repository and configuration
+
+Run $SCRIPT without arguments for full help.
+
+================================================================================
+MOTD
+EOF"
+
+  docker exec -it gpg-playground bash
 }
 
 # Function to handle the setup process
 setup() {
-  # Step 0: Install prerequisites
+  header "Step 1: Installing prerequisites"
+
   if ! command -v sudo &> /dev/null; then
     # This is to make sure the script runs on both containers and VMs.
     apt-get update
     apt-get install -y sudo
   fi
 
-  echo "Step 1: Installing prerequisites"
   sudo apt-get update
   sudo apt-get install --no-upgrade -y busybox gpg reprepro tree
-  prompt_continue "Next, we will ask you to provide a directory location to store all artifacts."
-
-  prompt_for_artifacts_dir
 
   if [ ! -d "$ARTIFACTS_DIR" ]; then
     echo "Directory does not exist. Creating $ARTIFACTS_DIR..."
@@ -67,8 +109,8 @@ setup() {
     echo "Directory $ARTIFACTS_DIR already exists."
   fi
 
-  prompt_continue "Next, we will create our first signing key to use it later."
-  echo "Step 2: Creating a PGP key/cert that expires in 1 minute"
+  prompt_continue
+  header "Step 2: Creating a PGP key/cert that expires in 1 minute"
 
   cd "$ARTIFACTS_DIR"
   echo "%echo Generating an example PGP key
@@ -93,9 +135,8 @@ Expire-Date: seconds=$((1 * 60))
 
   echo "Generated PGP key with fingerprint: $KEY1_FINGERPRINT"
 
-  # Step 3: Create the archive keyring deb package
-  prompt_continue "Next, we will create the archive-keyring deb file."
-  echo "Step 3: Creating the archive-keyring deb file"
+  prompt_continue
+  header "Step 3: Creating the archive-keyring deb file"
 
   mkdir -p "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_all"
   cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_all"
@@ -141,9 +182,8 @@ Description: Example archive keyring
   # dpkg-deb --info example-archive-keyring_0.0.1-1_all.deb
   # dpkg-deb --contents example-archive-keyring_0.0.1-1_all.deb
 
-  # Step 4: Create simple program
-  prompt_continue "Next, we will create the hello-world deb files for supported architectures."
-  echo "Step 4: Creating the hello-world deb files for supported architectures"
+  prompt_continue
+  header "Step 4: Creating the hello-world deb files for supported architectures"
 
   for arch in "${ARCHITECTURES[@]}"; do
     mkdir -p "$ARTIFACTS_DIR/hello-world_0.0.1-1_$arch"
@@ -179,9 +219,8 @@ Description: A statically compiled Go program that prints hello" > DEBIAN/contro
     # dpkg-deb --contents hello-world_0.0.1-1_$arch.deb
   done
 
-  # Step 5: Create apt repository using reprepro
-  prompt_continue "Next, we will create an apt repository using reprepro."
-  echo "Step 5: Creating apt repository using reprepro"
+  prompt_continue
+  header "Step 5: Creating apt repository using reprepro"
 
   mkdir -p "$ARTIFACTS_DIR/apt-repo"
 
@@ -215,17 +254,15 @@ EOF
   cat dists/stable/main/binary-amd64/Packages
   echo "! Note that there should be two entries above; hello-world and the archive-keyring package."
 
-  # Step 6: Serve the repository using a local HTTP server
-  prompt_continue "Next, we will host the repository using a simple HTTP server."
-  echo "Step 6: Hosting repository with a simple HTTP server"
+  prompt_continue
+  header "Step 6: Hosting repository with a simple HTTP server"
 
   cd "$ARTIFACTS_DIR"
   busybox httpd -p 8000 # runs in background by default
   echo "HTTP server started at http://127.0.0.1:8000"
 
-  # Step 7: Add the apt repo entry to the host machine
-  prompt_continue "Next, we will add the apt repo entry to the host machine."
-  echo "Step 7: Adding apt repo entry to /etc/apt/sources.list.d"
+  prompt_continue
+  header "Step 7: Adding apt repo entry to /etc/apt/sources.list.d"
 
   # Install the trust anchor (public key) on the host system for later verification.
   #
@@ -234,50 +271,50 @@ EOF
   # in our installation docs as we already have it. Future automatic upgrades of the
   # archive-keyring package will update the installed keyring, so the user would not
   # need to do this step ever again.
-  
+
   sudo mkdir -p -m 755 /usr/share/keyrings
   sudo cp "$ARTIFACTS_DIR/pgp-key.gpg" /usr/share/keyrings/example-archive-keyring.gpg
   sudo chmod go+r /usr/share/keyrings/example-archive-keyring.gpg
 
   echo "deb [arch=$(echo "${ARCHITECTURES[@]}" | sed 's/ /,/g') allow-insecure=yes signed-by=/usr/share/keyrings/example-archive-keyring.gpg] http://127.0.0.1:8000/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/example.list
+  echo
   echo "! Note that with this config, apt allows plain HTTP comms but still verifies package signatures."
-  echo ""
   echo "! If you wait here until the generated key expires, you'll see the next step fails due to the expired key."
 
-  # Step 8: Update and install the packages
-  prompt_continue "Next, we will update apt and install the archive keyring and 'hello-world' packages from the repository."
-  echo "Step 8: Updating apt and installing the packages"
+  prompt_continue
+  header "Step 8: Updating apt and installing the packages"
 
   sudo apt-get update # We don't need --allow-insecure-repositories
   sudo apt-get install -y example-archive-keyring hello-world
-  echo "Hello World and the archive keyring packages installed successfully."
+
+  echo
+  bold "✅ Hello World and the archive keyring packages installed successfully."
+  echo
+  echo "Run 'newkey' target next to rotate the signing key."
+  echo
   echo "! Note that there should be no warnings about unverified packages in the logs above."
 }
 
 # Function to handle the signing key rotation process
 newkey() {
-  prompt_continue "Next, we will ask you to provide the directory location you used for the setup step."
-
-  prompt_for_artifacts_dir
-
   # Verify that the current key is not yet expired
-  prompt_continue "Next, we confirm the current signing key is not yet expired."
-  echo "Step 1: Verifying the current key is not yet expired"
+  header "Step 1: Verifying the current key is not yet expired"
 
   KEY1_FINGERPRINT="$(cat $ARTIFACTS_DIR/key1-fingerprint)"
 
   expiry_date="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --with-colons --fingerprint $KEY1_FINGERPRINT | grep -E "^pub:" | cut -f7 -d:)"
   current_date="$(date +%s)"
   if [ "$expiry_date" -lt "$current_date" ]; then
-    echo "The key is already expired. Please 'teardown' and start over."
+    echo
+    bold "⚠️ The key is already expired. Please 'teardown' and start over."
     exit 1
   else
     echo "Confirmed that the current signing key is still valid."
   fi
 
   # Generate a new key and add it to the keyring
-  prompt_continue "Next, we will generate a new PGP key that expires in 15 mins, and add it to the keyring."
-  echo "Step 2: Generating a new PGP key (expires in 15 mins) and add it to the keyring"
+  prompt_continue
+  header "Step 2: Generating a new PGP key (expires in 15 mins) and add it to the keyring"
 
   # Get the list of existing keys
   existing_keys_list="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --with-colons)"
@@ -307,9 +344,8 @@ Expire-Date: seconds=$((15 * 60))
 
   echo "Generated PGP key with fingerprint: $KEY2_FINGERPRINT"
 
-  # Step 3: Make a new version of the archive keyring package to deliver the updated keyring (including both keys)
-  prompt_continue "Next, we will generate the new archive-keyring package and update the apt repository."
-  echo "Step 3: Generating the new archive-keyring package and updating the apt repository."
+  prompt_continue
+  header "Step 3: Generating the new archive-keyring package and updating the apt repository."
 
   # create a copy of the files of the previous version of the archive keyring package
   cp -r "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_all" "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_all"
@@ -343,45 +379,43 @@ Expire-Date: seconds=$((15 * 60))
   cd "$ARTIFACTS_DIR/apt-repo"
   echo "New packages (for amd64):"
   cat dists/stable/main/binary-amd64/Packages
-  echo "! Note that there should be two entries above, with the archive keyring version bumped to 0.0.2."
-  echo "The apt repository has been updated with the new archive keyring package."
 
-  # Step 4: Upgrade the archive keyring package on the host system
-  prompt_continue "Next, we will upgrade the archive keyring package on the host system."
-  echo "Step 4: Upgrading the archive keyring package on the host system."
+  echo
+  bold "✅ apt repository has been updated with the new archive keyring package."
+  echo
+  echo "! Note that there should be two entries above, with the archive keyring version bumped to 0.0.2."
+
+  prompt_continue
+  header "Step 4: Upgrading the archive keyring package on the host system."
 
   sudo apt-get update
   sudo apt-get install -y --only-upgrade example-archive-keyring
 
-   echo "archive-keyring package upgraded successfully."
-   echo "! Note that in the above logs the archive-keyring is now bumped to 0.0.2."
+  echo
+  bold "✅ archive-keyring package upgraded successfully."
+  echo
+  echo "Run 'deprecate' target next to deprecate the old key."
+  echo
+  echo "! Note that in the above logs the archive-keyring is now bumped to 0.0.2."
 }
 
 deprecate() {
-  prompt_continue "Next, we will ask you to provide the directory location you used for the setup step."
-
-  prompt_for_artifacts_dir
-
-  # Step 1: Verify that the old/first current key is expired
-  prompt_continue "Next, we confirm the old/first signing key is expired."
-  echo "Step 1: Verifying the old/first key is expired"
+  header "Step 1: Verifying the old/first key is expired"
 
   KEY1_FINGERPRINT="$(cat $ARTIFACTS_DIR/key1-fingerprint)"
   KEY2_FINGERPRINT="$(cat $ARTIFACTS_DIR/key2-fingerprint)"
 
   expiry_date="$(GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --list-keys --with-colons --fingerprint $KEY1_FINGERPRINT | grep -E "^pub:" | cut -f7 -d:)"
   current_date="$(date +%s)"
+
   if [ "$expiry_date" -gt "$current_date" ]; then
-    echo "The old/first key is not yet expired. Please wait until it expires and retry."
-    echo "time to expiry (seconds): $(( $expiry_date - $current_date ))"
-    exit 1
-  else
-    echo "Confirmed that the old/first signing key is expired."
+    SLEEP=$(( $expiry_date - $current_date + 2 ))
+    bold "Sleeping $SLEEP seconds to allow the old/first key to expire."
+    sleep $SLEEP
   fi
 
-  # Step 2: Make a new version of the archive keyring package with the old key removed
-  prompt_continue "Next, we will generate the new archive-keyring package with the old key removed, and update the apt repo."
-  echo "Step 2: Generating the new archive-keyring package with the old key removed."
+  prompt_continue
+  header "Step 2: Generating the new archive-keyring package with the old key removed."
 
   # create a copy of the files of the previous version of the archive keyring package
   cp -r "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_all" "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_all"
@@ -415,37 +449,36 @@ deprecate() {
   cd "$ARTIFACTS_DIR/apt-repo"
   echo "New packages (for amd64):"
   cat dists/stable/main/binary-amd64/Packages
-  echo "! Note that there should be two entries above, with the archive keyring version bumped to 0.0.3."
-  echo "The apt repository has been updated with the new archive keyring package."
 
-  # Step 4: Upgrade the archive keyring package on the host system
-  prompt_continue "Next, we will upgrade the archive keyring package on the host system."
-  echo "Step 4: Upgrading the archive keyring package on the host system."
+  echo
+  bold "✅ apt repository has been updated with the new archive keyring package."
+  echo
+  echo "! Note that there should be two entries above, with the archive keyring version bumped to 0.0.3."
+
+  prompt_continue
+  header "Step 3: Upgrading the archive keyring package on the host system."
 
   sudo apt-get update
   sudo apt-get install -y --only-upgrade example-archive-keyring
 
-  echo "archive-keyring package upgraded successfully."
+  echo
+  bold "✅ archive-keyring package upgraded successfully."
+  echo
   echo "! Note that in the above logs the archive-keyring is now bumped to 0.0.3."
 }
 
 # Function to handle the teardown process
 teardown() {
-  # Prompt for the artifacts directory during teardown
-  prompt_for_artifacts_dir
-
-  echo "Teardown: Cleaning up everything."
-
   # Kill the HTTP server if it's running
   if pgrep -f "busybox httpd" > /dev/null; then
-    echo "Stopping the HTTP server..."
+    header "Stopping the HTTP server..."
     pkill -f "busybox httpd"
     echo "Server stopped."
   fi
 
   # Check if the hello-world package is installed, and remove it safely
   if dpkg -l | grep -q "^ii  hello-world"; then
-    echo "Removing the hello-world package..."
+    header "Removing the hello-world package..."
     sudo apt-get remove --purge -y hello-world
     echo "Package hello-world removed."
   else
@@ -454,28 +487,27 @@ teardown() {
 
   # Remove the PGP keyrings
   if [ -f /etc/apt/keyrings/example-archive-keyring.gpg ]; then
-    echo "Removing the PGP keyring from /etc/apt/keyrings..."
+    header "Removing the PGP keyring from /etc/apt/keyrings..."
     sudo rm /etc/apt/keyrings/example-archive-keyring.gpg
     echo "PGP keyring removed from /etc/apt/keyrings."
   fi
 
   if [ -f /usr/share/keyrings/example-archive-keyring.gpg ]; then
-    echo "Removing the PGP keyring from /usr/share/keyrings..."
+    header "Removing the PGP keyring from /usr/share/keyrings..."
     sudo rm /usr/share/keyrings/example-archive-keyring.gpg
     echo "PGP keyring removed from /usr/share/keyrings."
   fi
 
   # Kill gpg-agent
   if pgrep "^gpg-agent" > /dev/null; then
-    echo "Stopping the GPG agent..."
+    header "Stopping the GPG agent..."
     pkill "^gpg-agent"
     echo "GPG agent stopped."
   fi
 
   # Remove the artifacts directory
   if [ -d "$ARTIFACTS_DIR" ]; then
-    echo "No directory provided. Using default: $ARTIFACTS_DIR"
-    echo "Removing the artifacts directory: $ARTIFACTS_DIR"
+    header "Removing the artifacts directory: $ARTIFACTS_DIR"
     rm -rf "$ARTIFACTS_DIR"
     echo "Artifacts directory removed."
   fi
@@ -487,27 +519,34 @@ teardown() {
 
   # Remove apt source remains (if not removed by the above command)
   if [ -f /etc/apt/sources.list.d/example.list ]; then
-    echo "Removing the repository from /etc/apt/sources.list.d..."
+    header "Removing the repository from /etc/apt/sources.list.d..."
     sudo rm /etc/apt/sources.list.d/example.list
     echo "Repository removed."
   fi
 
   # Remove the preferences from preferences.d
   if [ -f /etc/apt/preferences.d/example ]; then
-    echo "Removing the preferences from /etc/apt/preferences.d..."
+    header "Removing the preferences from /etc/apt/preferences.d..."
     sudo rm /etc/apt/preferences.d/example.pref
     echo "Preferences removed."
   fi
 
   # Clean apt cache
-  echo "Cleaning apt cache..."
+  header "Cleaning apt cache..."
   sudo apt-get clean
-  echo "Cleanup complete."
   sudo apt-get update
+  echo "Cleanup complete."
+}
+
+# Function to start up Docker container for environment
+docker_teardown() {
+  docker stop gpg-playground && docker rm gpg-playground
 }
 
 # Check for the setup or teardown argument
-if [ "$1" == "setup" ]; then
+if [ "$1" == "docker_setup" ]; then
+  docker_setup
+elif [ "$1" == "setup" ]; then
   setup
 elif [ "$1" == "newkey" ]; then
   newkey
@@ -515,7 +554,22 @@ elif [ "$1" == "deprecate" ]; then
   deprecate
 elif [ "$1" == "teardown" ]; then
   teardown
+elif [ "$1" == "docker_teardown" ]; then
+  docker_teardown
 else
-  echo "Usage: $0 {setup|newkey|deprecate|teardown}"
+  echo "
+$(bold "Self-bootstrapping Debian repository development tool")
+
+Usage: $SCRIPT TARGET
+
+The following targets are typical order used to setup and exercise the GitHub CLI Debian packaging process:
+
+- $(bold docker_setup):     create Docker container for testing environment
+- $(bold setup):            create initial Debian repository, create and sign sample application and keyring archive packages
+- $(bold newkey):           generate new signing key, update keyring archive package
+- $(bold deprecate):        deprecate old signing key, update keyring archive package, sign new sample application package
+- $(bold teardown):         clean up Debian repository and local configuration
+- $(bold docker_teardown):  stop and remove Docker container
+"
   exit 1
 fi

--- a/script/debian-devel
+++ b/script/debian-devel
@@ -17,7 +17,7 @@
 # Enable strict mode
 set -eo pipefail
 
-ARCH=$(dpkg --print-architecture)
+ARCHITECTURES=("i386" "amd64" "arm64" "armhf")
 
 # Check if DEBUG is set to true or 1, enable debug print statements if so
 if [[ "$DEBUG" == "true" || "$DEBUG" == "1" ]]; then
@@ -54,7 +54,7 @@ setup() {
 
   echo "Step 1: Installing prerequisites"
   sudo apt-get update
-  sudo apt-get install --no-upgrade -y dpkg-dev busybox gpg reprepro tree
+  sudo apt-get install --no-upgrade -y busybox gpg reprepro tree
   prompt_continue "Next, we will ask you to provide a directory location to store all artifacts."
 
   prompt_for_artifacts_dir
@@ -97,13 +97,13 @@ Expire-Date: seconds=$((1 * 60))
   prompt_continue "Next, we will create the archive-keyring deb file."
   echo "Step 3: Creating the archive-keyring deb file"
 
-  mkdir -p "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH"
-  cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH"
+  mkdir -p "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_all"
+  cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_all"
   mkdir -p usr/share/keyrings
   GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export > usr/share/keyrings/example-archive-keyring.gpg
   mkdir -p etc/apt/sources.list.d
   echo -n "# Created by example-archive-keyring package
-deb [arch=$ARCH allow-insecure=yes signed-by=/usr/share/keyrings/example-archive-keyring.gpg] http://127.0.0.1:8000/apt-repo stable main
+deb [arch=$(echo "${ARCHITECTURES[@]}" | sed 's/ /,/g') allow-insecure=yes signed-by=/usr/share/keyrings/example-archive-keyring.gpg] http://127.0.0.1:8000/apt-repo stable main
 " > etc/apt/sources.list.d/example.list
 
   # Add the preferences file to enable automatic upgrades for the archive keyring package.
@@ -125,64 +125,59 @@ Pin-Priority: 100
   echo -n "Package: example-archive-keyring
 Version: 0.0.1
 Maintainer: example <example@example.com>
-Architecture: $ARCH
+Architecture: all
 Section:
 Priority: optional
 Homepage: http://example.com
 Description: Example archive keyring
 " > DEBIAN/control
-  echo "Control file for example-archive-keyring created at $ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH/DEBIAN/control"
+  echo "Control file for example-archive-keyring created at $ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_all/DEBIAN/control"
 
   cd "$ARTIFACTS_DIR"
-  dpkg --build example-archive-keyring_0.0.1-1_$ARCH
-  echo "Deb package created: example-archive-keyring_0.0.1-1_$ARCH.deb"
+  dpkg --build example-archive-keyring_0.0.1-1_all
+  echo "Deb package created: example-archive-keyring_0.0.1-1_all.deb"
 
   # To inspect the .deb package:
-  # dpkg-deb --info example-archive-keyring_0.0.1-1_$ARCH.deb
-  # dpkg-deb --contents example-archive-keyring_0.0.1-1_$ARCH.deb
+  # dpkg-deb --info example-archive-keyring_0.0.1-1_all.deb
+  # dpkg-deb --contents example-archive-keyring_0.0.1-1_all.deb
 
   # Step 4: Create simple program
-  prompt_continue "Next, we will create the hello-world deb file."
-  echo "Step 4: Creating the hello-world deb file"
+  prompt_continue "Next, we will create the hello-world deb files for supported architectures."
+  echo "Step 4: Creating the hello-world deb files for supported architectures"
 
-  mkdir -p "$ARTIFACTS_DIR/hello-world-program"
-  echo '#include <stdio.h>
-int main() {
-    printf("hello packaged world (TIMESTAMP)\n");
-    return 0;
-}' | sed "s/TIMESTAMP/$(date "+%s")/g" > $ARTIFACTS_DIR/hello-world-program/hello.c
+  for arch in "${ARCHITECTURES[@]}"; do
+    mkdir -p "$ARTIFACTS_DIR/hello-world_0.0.1-1_$arch"
+    cd "$ARTIFACTS_DIR/hello-world_0.0.1-1_$arch"
 
-  cd "$ARTIFACTS_DIR/hello-world-program"
-  gcc -o hello-world hello.c
+    mkdir -p usr/bin
+    cat << EOF > usr/bin/hello-world
+#!/bin/bash
+echo "hello world (packaged for $arch)"
+EOF
+    chmod +x usr/bin/hello-world
 
-  # Create directory structure for deb package
-  mkdir -p "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH"
-  cd "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH"
-  mkdir -p usr/bin
-  cp "$ARTIFACTS_DIR/hello-world-program/hello-world" usr/bin/
-  echo "Binary copied to usr/bin/hello-world."
-
-  # Create DEBIAN control file
-  mkdir -p DEBIAN
-  # The "Section:" and "Priority:" values are to make the deb files similar to what
-  # we build in our CI. Also, omitting them from here will result in reprepro failure.
-  echo "Package: hello-world
+    # Create DEBIAN control file
+    mkdir -p DEBIAN
+    # The "Section:" and "Priority:" values are to make the deb files similar to what
+    # we build in our CI. Also, omitting them from here will result in reprepro failure.
+    echo "Package: hello-world
 Version: 0.0.1
 Maintainer: example <example@example.com>
-Architecture: $ARCH
+Architecture: $arch
 Section:
 Priority: optional
 Homepage: http://example.com
 Description: A statically compiled Go program that prints hello" > DEBIAN/control
 
-  # Build the deb package
-  cd "$ARTIFACTS_DIR"
-  dpkg --build hello-world_0.0.1-1_$ARCH
-  echo "Deb package created: hello-world_0.0.1-1_$ARCH.deb"
+    # Build the deb package
+    cd "$ARTIFACTS_DIR"
+    dpkg --build hello-world_0.0.1-1_$arch
+    echo "Deb package created: hello-world_0.0.1-1_$arch.deb"
 
-  # Inspect the deb package
-  # dpkg-deb --info hello-world_0.0.1-1_$ARCH.deb
-  # dpkg-deb --contents hello-world_0.0.1-1_$ARCH.deb
+    # Inspect the deb package
+    # dpkg-deb --info hello-world_0.0.1-1_$arch.deb
+    # dpkg-deb --contents hello-world_0.0.1-1_$arch.deb
+  done
 
   # Step 5: Create apt repository using reprepro
   prompt_continue "Next, we will create an apt repository using reprepro."
@@ -195,7 +190,7 @@ Description: A statically compiled Go program that prints hello" > DEBIAN/contro
 Origin: Example Repository
 Label: Example
 Codename: stable
-Architectures: <ARCH-PLACEHOLDER>
+Architectures: ${ARCHITECTURES[@]}
 Components: main
 Description: An example software repository
 SignWith: <FINGERPRINT-PLACEHOLDER>
@@ -207,16 +202,17 @@ EOF
   mkdir -p "$ARTIFACTS_DIR/temp-reprepro-1/conf"
   cd "$ARTIFACTS_DIR/temp-reprepro-1/conf"
   cp $ARTIFACTS_DIR/distributions.template distributions
-  sed -i "s/<ARCH-PLACEHOLDER>/$ARCH/g" distributions
   sed -i "s/<FINGERPRINT-PLACEHOLDER>/$KEY1_FINGERPRINT/g" distributions
 
   cd "$ARTIFACTS_DIR/temp-reprepro-1"
-  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH.deb"
-  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH.deb"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_all.deb"
+  for arch in "${ARCHITECTURES[@]}"; do
+    GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/hello-world_0.0.1-1_$arch.deb"
+  done
   cp -a dists/ pool/ "$ARTIFACTS_DIR/apt-repo/"
 
-  echo "These is the content of the Packages file:"
-  cat dists/stable/main/binary-$ARCH/Packages
+  echo "These is the content of the Packages file (for amd64):"
+  cat dists/stable/main/binary-amd64/Packages
   echo "! Note that there should be two entries above; hello-world and the archive-keyring package."
 
   # Step 6: Serve the repository using a local HTTP server
@@ -243,7 +239,7 @@ EOF
   sudo cp "$ARTIFACTS_DIR/pgp-key.gpg" /usr/share/keyrings/example-archive-keyring.gpg
   sudo chmod go+r /usr/share/keyrings/example-archive-keyring.gpg
 
-  echo "deb [arch=$ARCH allow-insecure=yes signed-by=/usr/share/keyrings/example-archive-keyring.gpg] http://127.0.0.1:8000/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/example.list
+  echo "deb [arch=$(echo "${ARCHITECTURES[@]}" | sed 's/ /,/g') allow-insecure=yes signed-by=/usr/share/keyrings/example-archive-keyring.gpg] http://127.0.0.1:8000/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/example.list
   echo "! Note that with this config, apt allows plain HTTP comms but still verifies package signatures."
   echo ""
   echo "! If you wait here until the generated key expires, you'll see the next step fails due to the expired key."
@@ -316,36 +312,37 @@ Expire-Date: seconds=$((15 * 60))
   echo "Step 3: Generating the new archive-keyring package and updating the apt repository."
 
   # create a copy of the files of the previous version of the archive keyring package
-  cp -r "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_$ARCH" "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_$ARCH"
+  cp -r "$ARTIFACTS_DIR/example-archive-keyring_0.0.1-1_all" "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_all"
   # update the keyring file with the new keyring (including both keys)
-  cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_$ARCH"
+  cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_all"
   GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export > usr/share/keyrings/example-archive-keyring.gpg
   # bump the version in the debian control file
   sed -i 's/Version: 0\.0\.1/Version: 0.0.2/' DEBIAN/control
 
   cd "$ARTIFACTS_DIR"
-  dpkg --build example-archive-keyring_0.0.2-1_$ARCH
-  echo "Deb package created: example-archive-keyring_0.0.2-1_$ARCH.deb"
+  dpkg --build example-archive-keyring_0.0.2-1_all
+  echo "Deb package created: example-archive-keyring_0.0.2-1_all.deb"
 
   # To inspect the .deb package:
-  # dpkg-deb --info example-archive-keyring_0.0.2-1_$ARCH.deb
-  # dpkg-deb --contents example-archive-keyring_0.0.2-1_$ARCH.deb
+  # dpkg-deb --info example-archive-keyring_0.0.2-1_all.deb
+  # dpkg-deb --contents example-archive-keyring_0.0.2-1_all.deb
 
   # Create a new temp directory before calling reprepro.
   mkdir -p "$ARTIFACTS_DIR/temp-reprepro-2/conf"
   cd "$ARTIFACTS_DIR/temp-reprepro-2/conf"
   cp $ARTIFACTS_DIR/distributions.template distributions
-  sed -i "s/<ARCH-PLACEHOLDER>/$ARCH/g" distributions
   sed -i "s/<FINGERPRINT-PLACEHOLDER>/$KEY1_FINGERPRINT $KEY2_FINGERPRINT/g" distributions
 
   cd "$ARTIFACTS_DIR/temp-reprepro-2"
-  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH.deb"
-  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_$ARCH.deb"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_all.deb"
+  for arch in "${ARCHITECTURES[@]}"; do
+    GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/hello-world_0.0.1-1_$arch.deb"
+  done
   cp -a dists/ pool/ "$ARTIFACTS_DIR/apt-repo/"
 
   cd "$ARTIFACTS_DIR/apt-repo"
-  echo "New packages:"
-  cat dists/stable/main/binary-$ARCH/Packages
+  echo "New packages (for amd64):"
+  cat dists/stable/main/binary-amd64/Packages
   echo "! Note that there should be two entries above, with the archive keyring version bumped to 0.0.2."
   echo "The apt repository has been updated with the new archive keyring package."
 
@@ -387,36 +384,37 @@ deprecate() {
   echo "Step 2: Generating the new archive-keyring package with the old key removed."
 
   # create a copy of the files of the previous version of the archive keyring package
-  cp -r "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_$ARCH" "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_$ARCH"
+  cp -r "$ARTIFACTS_DIR/example-archive-keyring_0.0.2-1_all" "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_all"
   # update the keyring file with the new keyring (including both keys)
-  cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_$ARCH"
+  cd "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_all"
   GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" gpg --export $KEY2_FINGERPRINT > usr/share/keyrings/example-archive-keyring.gpg
   # bump the version in the debian control file
   sed -i 's/Version: 0\.0\.2/Version: 0.0.3/' DEBIAN/control
 
   cd "$ARTIFACTS_DIR"
-  dpkg --build example-archive-keyring_0.0.3-1_$ARCH
-  echo "Deb package created: example-archive-keyring_0.0.3-1_$ARCH.deb"
+  dpkg --build example-archive-keyring_0.0.3-1_all
+  echo "Deb package created: example-archive-keyring_0.0.3-1_all.deb"
 
   # To inspect the .deb package:
-  # dpkg-deb --info example-archive-keyring_0.0.3-1_$ARCH.deb
-  # dpkg-deb --contents example-archive-keyring_0.0.3-1_$ARCH.deb
+  # dpkg-deb --info example-archive-keyring_0.0.3-1_all.deb
+  # dpkg-deb --contents example-archive-keyring_0.0.3-1_all.deb
 
   # Create a new temp directory before calling reprepro.
   mkdir -p "$ARTIFACTS_DIR/temp-reprepro-3/conf"
   cd "$ARTIFACTS_DIR/temp-reprepro-3/conf"
   cp $ARTIFACTS_DIR/distributions.template distributions
-  sed -i "s/<ARCH-PLACEHOLDER>/$ARCH/g" distributions
   sed -i "s/<FINGERPRINT-PLACEHOLDER>/$KEY2_FINGERPRINT/g" distributions
 
   cd "$ARTIFACTS_DIR/temp-reprepro-3"
-  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/hello-world_0.0.1-1_$ARCH.deb"
-  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_$ARCH.deb"
+  GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/example-archive-keyring_0.0.3-1_all.deb"
+  for arch in "${ARCHITECTURES[@]}"; do
+    GNUPGHOME="$ARTIFACTS_DIR/temp-gpg-home" reprepro includedeb stable "$ARTIFACTS_DIR/hello-world_0.0.1-1_$arch.deb"
+  done
   cp -a dists/ pool/ "$ARTIFACTS_DIR/apt-repo/"
 
   cd "$ARTIFACTS_DIR/apt-repo"
-  echo "New packages:"
-  cat dists/stable/main/binary-$ARCH/Packages
+  echo "New packages (for amd64):"
+  cat dists/stable/main/binary-amd64/Packages
   echo "! Note that there should be two entries above, with the archive keyring version bumped to 0.0.3."
   echo "The apt repository has been updated with the new archive keyring package."
 


### PR DESCRIPTION
This PR adds the PGP key rotation PoC to `trunk`. This is meant to be used for future reference and as a self-explanatory sample script to simulate steps of updating our APT repository when we need to rotate our PGP signing keys.

> [!IMPORTANT]
> This is just a PoC and is not meant to be used for production purposes.
