### PR TITLE
Add Debian/Ubuntu to unofficial packages

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -396,6 +396,13 @@ To upgrade:
 spack uninstall gh && spack install gh
 ```
 
+### Ubuntu Community
+
+The [GitHub CLI package](https://packages.ubuntu.com/noble/gh) is synced from [upstream Debian Community package](#debian-community).
+
+> [!NOTE]
+> As of November 2025, GitHub CLI maintainers strongly recommend [official Debian packages](#debian) especially as the community-distributed `2.45.x` / `2.46.x` version is broken due to deprecated GitHub APIs.
+
 ### Void Linux
 
 The [GitHub CLI package](https://voidlinux.org/packages/?arch=x86_64&q=github-cli): is supported by the Void Linux community with updates powered by [void-linux/void-packages](https://github.com/void-linux/void-packages/tree/master/srcpkgs/github-cli).
@@ -405,13 +412,6 @@ To install:
 ```bash
 sudo xbps-install github-cli
 ```
-
-### Ubuntu Community
-
-The [GitHub CLI package](https://packages.ubuntu.com/noble/gh) is synced from [upstream Debian Community package](#debian-community).
-
-> [!NOTE]
-> As of November 2025, GitHub CLI maintainers strongly recommend [official Debian packages](#debian) especially as the community-distributed `2.45.x` / `2.46.x` version is broken due to deprecated GitHub APIs.
 
 ### Webi
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -207,6 +207,13 @@ To upgrade:
 conda update gh --channel conda-forge
 ```
 
+### Debian Community
+
+The [GitHub CLI package](https://packages.debian.org/bookworm/gh) is supported by the Debian community with updates powered by [Debian Go Packaging Team](https://salsa.debian.org/go-team/packages/gh).
+
+> [!NOTE]
+> As of November 2025, GitHub CLI maintainers strongly recommend [official Debian packages](#debian) especially as the community-distributed `2.45.x` / `2.46.x` version is broken due to deprecated GitHub APIs.
+
 ### Fedora Community
 
 The [GitHub CLI package](https://packages.fedoraproject.org/pkgs/gh/gh/) is supported by the Fedora community with updates powered by [Fedora Project](https://src.fedoraproject.org/rpms/gh).
@@ -398,6 +405,13 @@ To install:
 ```bash
 sudo xbps-install github-cli
 ```
+
+### Ubuntu Community
+
+The [GitHub CLI package](https://packages.ubuntu.com/noble/gh) is synced from [upstream Debian Community package](#debian-community).
+
+> [!NOTE]
+> As of November 2025, GitHub CLI maintainers strongly recommend [official Debian packages](#debian) especially as the community-distributed `2.45.x` / `2.46.x` version is broken due to deprecated GitHub APIs.
 
 ### Webi
 


### PR DESCRIPTION
Fixes #12182

This pull request updates the Linux installation docs to recognize the Debian and Ubuntu community repositories as unofficial, community packages along with notes about lagging version creating problems for users.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
