### PR TITLE
Add PR review helper commands under `gh pr` (inline comments and review flows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,22 @@ For [installation options see below](#installation), for usage instructions [see
 
 ### Pull request review helpers
 
-Use `gh pr` review helpers to script GraphQL pending review flows and REST comment automation without hand-writing payloads. Commands honor the active repository context and accept the standard `-R|--repo` override.
+Use `gh pr` subcommands to script review workflows without hand-writing REST or GraphQL payloads.
 
 ```sh
+# list comments from the latest submitted review by the current user
+gh pr see-comments 42 --latest -R octo/demo
+
+# reply to a specific review comment and auto-submit any pending review
+gh pr reply-comment 42 --comment-id 123456789 \
+  --body "Thanks for catching that!" --auto-submit-pending -R octo/demo
+
 # GraphQL pending review flow (open → add inline thread → submit)
-gh pr review pending open   --pr 42
-gh pr review pending add    --pr 42 --review-id REVIEW_ID \
-  --path src/main.go --line 87 --side RIGHT --body "nit: rename for clarity"
-gh pr review pending submit --pr 42 --review-id REVIEW_ID --event COMMENT
+gh pr review pending open   42 -R octo/demo
+gh pr review pending add    42 --review-id REVIEW_ID \
+  --path src/main.go --line 87 --side RIGHT --body "nit: rename for clarity" -R octo/demo
+gh pr review pending submit 42 --review-id REVIEW_ID --event COMMENT -R octo/demo
 
-# Fetch inline comments from the latest submitted review by the current user
-gh pr see-comments --pr 42 --latest
-
-# Reply to a review comment with automatic pending review submission when needed
-gh pr reply-comment --pr 42 --comment-id COMMENT_ID \
-  --body "Thanks for the catch" --auto-submit-pending
-
-# Specify another repository explicitly
-gh pr review pending open --pr 123 -R octo/demo
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ GitHub CLI is supported for users on GitHub.com, GitHub Enterprise Cloud, and Gi
 
 For [installation options see below](#installation), for usage instructions [see the manual]( https://cli.github.com/manual/).
 
+### Pull request review helpers
+
+Use `gh pr` review helpers to script GraphQL pending review flows and REST comment automation without hand-writing payloads.
+
+```sh
+# GraphQL pending review flow (open → add inline thread → submit)
+gh pr review pending open   --org octo --repo demo --pr 42
+gh pr review pending add    --org octo --repo demo --pr 42 --review-id REVIEW_ID \
+  --path src/main.go --line 87 --side RIGHT --body "nit: rename for clarity"
+gh pr review pending submit --org octo --repo demo --pr 42 --review-id REVIEW_ID --event COMMENT
+
+# Fetch inline comments from the latest submitted review by the current user
+gh pr see-comments --org octo --repo demo --pr 42 --latest
+
+# Reply to a review comment with automatic pending review submission when needed
+gh pr reply-comment --org octo --repo demo --pr 42 --comment-id COMMENT_ID \
+  --body "Thanks for the catch" --auto-submit-pending
+```
+
 ## Contributing
 
 If anything feels off or if you feel that some functionality is missing, please check out the [contributing page](.github/CONTRIBUTING.md). There you will find instructions for sharing your feedback, building the tool locally, and submitting pull requests to the project.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ For [installation options see below](#installation), for usage instructions [see
 
 Use `gh pr` subcommands to script review workflows without hand-writing REST or GraphQL payloads.
 
+All helper commands accept the standard `gh pr` selectors (number, URL, or `owner/repo#number`) and honor `-R/--repo` even when run outside a git checkout.
+
 ```sh
 # list comments from the latest submitted review by the current user
 gh pr see-comments 42 --latest -R octo/demo

--- a/README.md
+++ b/README.md
@@ -12,21 +12,24 @@ For [installation options see below](#installation), for usage instructions [see
 
 ### Pull request review helpers
 
-Use `gh pr` review helpers to script GraphQL pending review flows and REST comment automation without hand-writing payloads.
+Use `gh pr` review helpers to script GraphQL pending review flows and REST comment automation without hand-writing payloads. Commands honor the active repository context and accept the standard `-R|--repo` override.
 
 ```sh
 # GraphQL pending review flow (open → add inline thread → submit)
-gh pr review pending open   --org octo --repo demo --pr 42
-gh pr review pending add    --org octo --repo demo --pr 42 --review-id REVIEW_ID \
+gh pr review pending open   --pr 42
+gh pr review pending add    --pr 42 --review-id REVIEW_ID \
   --path src/main.go --line 87 --side RIGHT --body "nit: rename for clarity"
-gh pr review pending submit --org octo --repo demo --pr 42 --review-id REVIEW_ID --event COMMENT
+gh pr review pending submit --pr 42 --review-id REVIEW_ID --event COMMENT
 
 # Fetch inline comments from the latest submitted review by the current user
-gh pr see-comments --org octo --repo demo --pr 42 --latest
+gh pr see-comments --pr 42 --latest
 
 # Reply to a review comment with automatic pending review submission when needed
-gh pr reply-comment --org octo --repo demo --pr 42 --comment-id COMMENT_ID \
+gh pr reply-comment --pr 42 --comment-id COMMENT_ID \
   --body "Thanks for the catch" --auto-submit-pending
+
+# Specify another repository explicitly
+gh pr review pending open --pr 123 -R octo/demo
 ```
 
 ## Contributing

--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -14,8 +14,10 @@ import (
 	cmdMerge "github.com/cli/cli/v2/pkg/cmd/pr/merge"
 	cmdReady "github.com/cli/cli/v2/pkg/cmd/pr/ready"
 	cmdReopen "github.com/cli/cli/v2/pkg/cmd/pr/reopen"
+	cmdReplyComment "github.com/cli/cli/v2/pkg/cmd/pr/reply-comment"
 	cmdRevert "github.com/cli/cli/v2/pkg/cmd/pr/revert"
 	cmdReview "github.com/cli/cli/v2/pkg/cmd/pr/review"
+	cmdSeeComments "github.com/cli/cli/v2/pkg/cmd/pr/see-comments"
 	cmdStatus "github.com/cli/cli/v2/pkg/cmd/pr/status"
 	cmdUpdateBranch "github.com/cli/cli/v2/pkg/cmd/pr/update-branch"
 	cmdView "github.com/cli/cli/v2/pkg/cmd/pr/view"
@@ -62,6 +64,8 @@ func NewCmdPR(f *cmdutil.Factory) *cobra.Command {
 		cmdUpdateBranch.NewCmdUpdateBranch(f, nil),
 		cmdReady.NewCmdReady(f, nil),
 		cmdComment.NewCmdComment(f, nil),
+		cmdSeeComments.NewCmdSeeComments(f),
+		cmdReplyComment.NewCmdReplyComment(f),
 		cmdClose.NewCmdClose(f, nil),
 		cmdReopen.NewCmdReopen(f, nil),
 		cmdRevert.NewCmdRevert(f, nil),

--- a/pkg/cmd/pr/reply-comment/reply_comment.go
+++ b/pkg/cmd/pr/reply-comment/reply_comment.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -21,22 +21,21 @@ const autoSubmitSummary = "Auto-submitting pending review to unblock threaded re
 type ReplyCommentOptions struct {
 	IO         *iostreams.IOStreams
 	HttpClient func() (*http.Client, error)
-	Config     func() (gh.Config, error)
+	BaseRepo   func() (ghrepo.Interface, error)
 
-	Org               string
-	Repo              string
 	Pull              int
 	CommentID         int64
 	Body              string
 	AutoSubmitPending bool
-	Hostname          string
+
+	repo ghrepo.Interface
 }
 
 func NewCmdReplyComment(f *cmdutil.Factory) *cobra.Command {
 	opts := &ReplyCommentOptions{
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
-		Config:     f.Config,
+		BaseRepo:   f.BaseRepo,
 	}
 
 	cmd := &cobra.Command{
@@ -60,16 +59,11 @@ func NewCmdReplyComment(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.Org, "org", "", "Organization that owns the repository")
-	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository name")
 	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
 	cmd.Flags().Int64Var(&opts.CommentID, "comment-id", 0, "Review comment identifier to reply to")
 	cmd.Flags().StringVar(&opts.Body, "body", "", "Reply text")
 	cmd.Flags().BoolVar(&opts.AutoSubmitPending, "auto-submit-pending", false, "Submit pending reviews before replying")
-	cmd.Flags().StringVar(&opts.Hostname, "hostname", "", "GitHub hostname (default to authenticated host)")
 
-	_ = cmd.MarkFlagRequired("org")
-	_ = cmd.MarkFlagRequired("repo")
 	_ = cmd.MarkFlagRequired("pr")
 	_ = cmd.MarkFlagRequired("comment-id")
 	_ = cmd.MarkFlagRequired("body")
@@ -78,14 +72,9 @@ func NewCmdReplyComment(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runReplyComment(ctx context.Context, opts *ReplyCommentOptions) error {
-	cfg, err := opts.Config()
+	repo, err := opts.resolveRepo()
 	if err != nil {
 		return err
-	}
-
-	host, _ := cfg.Authentication().DefaultHost()
-	if opts.Hostname != "" {
-		host = opts.Hostname
 	}
 
 	httpClient, err := opts.HttpClient()
@@ -93,35 +82,38 @@ func runReplyComment(ctx context.Context, opts *ReplyCommentOptions) error {
 		return err
 	}
 
-	service := reviewapi.NewService(httpClient, host)
+	service := reviewapi.NewService(httpClient, repo.RepoHost())
+	owner := repo.RepoOwner()
+	name := repo.RepoName()
+	fullName := ghrepo.FullName(repo)
 
-	reply, err := service.ReplyToComment(ctx, opts.Org, opts.Repo, opts.Pull, opts.CommentID, opts.Body)
+	reply, err := service.ReplyToComment(ctx, owner, name, opts.Pull, opts.CommentID, opts.Body)
 	if err != nil {
 		var pendingErr *reviewapi.PendingReviewError
 		if errors.As(err, &pendingErr) {
 			if !opts.AutoSubmitPending {
-				return fmt.Errorf("pending review detected for %s/%s#%d. Submit the review or re-run with --auto-submit-pending, or use the GraphQL review thread mutation.", opts.Org, opts.Repo, opts.Pull)
+				return fmt.Errorf("pending review detected for %s#%d. Submit the review or re-run with --auto-submit-pending, or use the GraphQL review thread mutation.", fullName, opts.Pull)
 			}
 
 			reviewer, loginErr := service.CurrentLogin(ctx)
 			if loginErr != nil {
-				return formatReplyError(loginErr, opts, "failed to resolve authenticated user")
+				return formatReplyError(loginErr, fullName, "failed to resolve authenticated user")
 			}
 
-			submitted, submitErr := service.SubmitPendingReviews(ctx, opts.Org, opts.Repo, opts.Pull, reviewer, autoSubmitSummary)
+			submitted, submitErr := service.SubmitPendingReviews(ctx, owner, name, opts.Pull, reviewer, autoSubmitSummary)
 			if submitErr != nil {
-				return formatReplyError(submitErr, opts, "failed to submit pending review")
+				return formatReplyError(submitErr, fullName, "failed to submit pending review")
 			}
 			if submitted == 0 {
 				return fmt.Errorf("no pending reviews owned by %s found on pull request #%d", reviewer, opts.Pull)
 			}
 
-			reply, err = service.ReplyToComment(ctx, opts.Org, opts.Repo, opts.Pull, opts.CommentID, opts.Body)
+			reply, err = service.ReplyToComment(ctx, owner, name, opts.Pull, opts.CommentID, opts.Body)
 			if err != nil {
-				return formatReplyError(err, opts, "failed to post reply after submitting pending review")
+				return formatReplyError(err, fullName, "failed to post reply after submitting pending review")
 			}
 		} else {
-			return formatReplyError(err, opts, "failed to post reply")
+			return formatReplyError(err, fullName, "failed to post reply")
 		}
 	}
 
@@ -134,7 +126,22 @@ func runReplyComment(ctx context.Context, opts *ReplyCommentOptions) error {
 	return nil
 }
 
-func formatReplyError(err error, opts *ReplyCommentOptions, prefix string) error {
+func (o *ReplyCommentOptions) resolveRepo() (ghrepo.Interface, error) {
+	if o.repo != nil {
+		return o.repo, nil
+	}
+	if o.BaseRepo == nil {
+		return nil, errors.New("repository resolver is not configured")
+	}
+	repo, err := o.BaseRepo()
+	if err != nil {
+		return nil, err
+	}
+	o.repo = repo
+	return repo, nil
+}
+
+func formatReplyError(err error, fullName string, prefix string) error {
 	switch e := err.(type) {
 	case *reviewapi.PullRequestNotFoundError:
 		return fmt.Errorf("%s: %w", prefix, e)
@@ -148,9 +155,9 @@ func formatReplyError(err error, opts *ReplyCommentOptions, prefix string) error
 	if errors.As(err, &httpErr) {
 		switch httpErr.StatusCode {
 		case http.StatusForbidden:
-			return fmt.Errorf("%s: access denied (%s)", prefix, httpErr.Message)
+			return fmt.Errorf("%s: access denied for %s (%s)", prefix, fullName, httpErr.Message)
 		case http.StatusNotFound:
-			return fmt.Errorf("%s: resource not found (%s)", prefix, httpErr.Message)
+			return fmt.Errorf("%s: resource not found in %s (%s)", prefix, fullName, httpErr.Message)
 		case http.StatusUnprocessableEntity:
 			return fmt.Errorf("%s: validation failed (%s)", prefix, httpErr.Message)
 		default:

--- a/pkg/cmd/pr/reply-comment/reply_comment.go
+++ b/pkg/cmd/pr/reply-comment/reply_comment.go
@@ -1,0 +1,162 @@
+package reply_comment
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+const autoSubmitSummary = "Auto-submitting pending review to unblock threaded reply via gh CLI."
+
+type ReplyCommentOptions struct {
+	IO         *iostreams.IOStreams
+	HttpClient func() (*http.Client, error)
+	Config     func() (gh.Config, error)
+
+	Org               string
+	Repo              string
+	Pull              int
+	CommentID         int64
+	Body              string
+	AutoSubmitPending bool
+	Hostname          string
+}
+
+func NewCmdReplyComment(f *cmdutil.Factory) *cobra.Command {
+	opts := &ReplyCommentOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Config:     f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "reply-comment",
+		Short: "Reply to a pull request review comment",
+		Long: heredoc.Doc(`
+			Reply to an existing pull request review comment by comment identifier.
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Pull <= 0 {
+				return cmdutil.FlagErrorf("invalid value for --pr: %d", opts.Pull)
+			}
+			if opts.CommentID <= 0 {
+				return cmdutil.FlagErrorf("invalid value for --comment-id: %d", opts.CommentID)
+			}
+			if opts.Body == "" {
+				return cmdutil.FlagErrorf("--body is required")
+			}
+
+			return runReplyComment(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Org, "org", "", "Organization that owns the repository")
+	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository name")
+	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().Int64Var(&opts.CommentID, "comment-id", 0, "Review comment identifier to reply to")
+	cmd.Flags().StringVar(&opts.Body, "body", "", "Reply text")
+	cmd.Flags().BoolVar(&opts.AutoSubmitPending, "auto-submit-pending", false, "Submit pending reviews before replying")
+	cmd.Flags().StringVar(&opts.Hostname, "hostname", "", "GitHub hostname (default to authenticated host)")
+
+	_ = cmd.MarkFlagRequired("org")
+	_ = cmd.MarkFlagRequired("repo")
+	_ = cmd.MarkFlagRequired("pr")
+	_ = cmd.MarkFlagRequired("comment-id")
+	_ = cmd.MarkFlagRequired("body")
+
+	return cmd
+}
+
+func runReplyComment(ctx context.Context, opts *ReplyCommentOptions) error {
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	host, _ := cfg.Authentication().DefaultHost()
+	if opts.Hostname != "" {
+		host = opts.Hostname
+	}
+
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	service := reviewapi.NewService(httpClient, host)
+
+	reply, err := service.ReplyToComment(ctx, opts.Org, opts.Repo, opts.Pull, opts.CommentID, opts.Body)
+	if err != nil {
+		var pendingErr *reviewapi.PendingReviewError
+		if errors.As(err, &pendingErr) {
+			if !opts.AutoSubmitPending {
+				return fmt.Errorf("pending review detected for %s/%s#%d. Submit the review or re-run with --auto-submit-pending, or use the GraphQL review thread mutation.", opts.Org, opts.Repo, opts.Pull)
+			}
+
+			reviewer, loginErr := service.CurrentLogin(ctx)
+			if loginErr != nil {
+				return formatReplyError(loginErr, opts, "failed to resolve authenticated user")
+			}
+
+			submitted, submitErr := service.SubmitPendingReviews(ctx, opts.Org, opts.Repo, opts.Pull, reviewer, autoSubmitSummary)
+			if submitErr != nil {
+				return formatReplyError(submitErr, opts, "failed to submit pending review")
+			}
+			if submitted == 0 {
+				return fmt.Errorf("no pending reviews owned by %s found on pull request #%d", reviewer, opts.Pull)
+			}
+
+			reply, err = service.ReplyToComment(ctx, opts.Org, opts.Repo, opts.Pull, opts.CommentID, opts.Body)
+			if err != nil {
+				return formatReplyError(err, opts, "failed to post reply after submitting pending review")
+			}
+		} else {
+			return formatReplyError(err, opts, "failed to post reply")
+		}
+	}
+
+	encoder := json.NewEncoder(opts.IO.Out)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(reply); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func formatReplyError(err error, opts *ReplyCommentOptions, prefix string) error {
+	switch e := err.(type) {
+	case *reviewapi.PullRequestNotFoundError:
+		return fmt.Errorf("%s: %w", prefix, e)
+	case *reviewapi.ReviewNotFoundError:
+		return fmt.Errorf("%s: %w", prefix, e)
+	case *reviewapi.CommentNotFoundError:
+		return fmt.Errorf("%s: %w", prefix, e)
+	}
+
+	var httpErr api.HTTPError
+	if errors.As(err, &httpErr) {
+		switch httpErr.StatusCode {
+		case http.StatusForbidden:
+			return fmt.Errorf("%s: access denied (%s)", prefix, httpErr.Message)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s: resource not found (%s)", prefix, httpErr.Message)
+		case http.StatusUnprocessableEntity:
+			return fmt.Errorf("%s: validation failed (%s)", prefix, httpErr.Message)
+		default:
+			return fmt.Errorf("%s: %s", prefix, httpErr.Error())
+		}
+	}
+
+	return fmt.Errorf("%s: %w", prefix, err)
+}

--- a/pkg/cmd/pr/reply-comment/reply_comment.go
+++ b/pkg/cmd/pr/reply-comment/reply_comment.go
@@ -10,7 +10,6 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
-	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -25,11 +24,10 @@ type ReplyCommentOptions struct {
 	HttpClient func() (*http.Client, error)
 	Config     func() (gh.Config, error)
 
-	BaseRepo func() (ghrepo.Interface, error)
+	Finder shared.PRFinder
 
-	Repo              ghrepo.Interface
-	Selector          string
-	Pull              int
+	SelectorArg       string
+	PullFlag          int
 	CommentID         int64
 	Body              string
 	AutoSubmitPending bool
@@ -41,9 +39,6 @@ func NewCmdReplyComment(f *cmdutil.Factory) *cobra.Command {
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
 		Config:     f.Config,
-		BaseRepo: func() (ghrepo.Interface, error) {
-			return f.BaseRepo()
-		},
 	}
 
 	cmd := &cobra.Command{
@@ -54,13 +49,9 @@ func NewCmdReplyComment(f *cmdutil.Factory) *cobra.Command {
         `),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Finder = shared.NewFinder(f)
 			if len(args) > 0 {
-				opts.Selector = args[0]
-			}
-			if opts.Pull <= 0 {
-				if opts.Selector == "" {
-					return cmdutil.FlagErrorf("must specify a pull request via --pr or as an argument")
-				}
+				opts.SelectorArg = args[0]
 			}
 			if opts.CommentID <= 0 {
 				return cmdutil.FlagErrorf("invalid value for --comment-id: %d", opts.CommentID)
@@ -69,11 +60,17 @@ func NewCmdReplyComment(f *cmdutil.Factory) *cobra.Command {
 				return cmdutil.FlagErrorf("--body is required")
 			}
 
+			selector, err := shared.NormalizePullRequestSelector(opts.SelectorArg, opts.PullFlag)
+			if err != nil {
+				return err
+			}
+			opts.SelectorArg = selector
+
 			return runReplyComment(cmd.Context(), opts)
 		},
 	}
 
-	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().IntVar(&opts.PullFlag, "pr", 0, "Pull request number")
 	cmd.Flags().Int64Var(&opts.CommentID, "comment-id", 0, "Review comment identifier to reply to")
 	cmd.Flags().StringVar(&opts.Body, "body", "", "Reply text")
 	cmd.Flags().BoolVar(&opts.AutoSubmitPending, "auto-submit-pending", false, "Submit pending reviews before replying")
@@ -85,19 +82,30 @@ func NewCmdReplyComment(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runReplyComment(ctx context.Context, opts *ReplyCommentOptions) error {
-	repo, number, err := shared.ResolvePullRequest(opts.BaseRepo, opts.Selector, opts.Pull)
+	if opts.Finder == nil {
+		return errors.New("pull request finder is not configured")
+	}
+
+	findOptions := shared.FindOptions{
+		Selector:        opts.SelectorArg,
+		Fields:          []string{"number"},
+		DisableProgress: true,
+	}
+	pr, repo, err := opts.Finder.Find(findOptions)
 	if err != nil {
 		return err
 	}
-	opts.Repo = repo
-	opts.Pull = number
+	pullNumber := pr.Number
 
 	cfg, err := opts.Config()
 	if err != nil {
 		return err
 	}
 
-	host := repo.RepoHost()
+	host := ""
+	if repo != nil {
+		host = repo.RepoHost()
+	}
 	if host == "" {
 		host, _ = cfg.Authentication().DefaultHost()
 	}
@@ -114,12 +122,12 @@ func runReplyComment(ctx context.Context, opts *ReplyCommentOptions) error {
 	owner := repo.RepoOwner()
 	name := repo.RepoName()
 
-	reply, err := service.ReplyToComment(ctx, owner, name, opts.Pull, opts.CommentID, opts.Body)
+	reply, err := service.ReplyToComment(ctx, owner, name, pullNumber, opts.CommentID, opts.Body)
 	if err != nil {
 		var pendingErr *reviewapi.PendingReviewError
 		if errors.As(err, &pendingErr) {
 			if !opts.AutoSubmitPending {
-				return fmt.Errorf("pending review detected for %s/%s#%d. Submit the review or re-run with --auto-submit-pending, or use the GraphQL review thread mutation.", owner, name, opts.Pull)
+				return fmt.Errorf("pending review detected for %s/%s#%d. Submit the review or re-run with --auto-submit-pending, or use the GraphQL review thread mutation.", owner, name, pullNumber)
 			}
 
 			reviewer, loginErr := service.CurrentLogin(ctx)
@@ -127,15 +135,15 @@ func runReplyComment(ctx context.Context, opts *ReplyCommentOptions) error {
 				return formatReplyError(loginErr, "failed to resolve authenticated user")
 			}
 
-			submitted, submitErr := service.SubmitPendingReviews(ctx, owner, name, opts.Pull, reviewer, autoSubmitSummary)
+			submitted, submitErr := service.SubmitPendingReviews(ctx, owner, name, pullNumber, reviewer, autoSubmitSummary)
 			if submitErr != nil {
 				return formatReplyError(submitErr, "failed to submit pending review")
 			}
 			if submitted == 0 {
-				return fmt.Errorf("no pending reviews owned by %s found on pull request #%d", reviewer, opts.Pull)
+				return fmt.Errorf("no pending reviews owned by %s found on pull request #%d", reviewer, pullNumber)
 			}
 
-			reply, err = service.ReplyToComment(ctx, owner, name, opts.Pull, opts.CommentID, opts.Body)
+			reply, err = service.ReplyToComment(ctx, owner, name, pullNumber, opts.CommentID, opts.Body)
 			if err != nil {
 				return formatReplyError(err, "failed to post reply after submitting pending review")
 			}

--- a/pkg/cmd/pr/reply-comment/reply_comment.go
+++ b/pkg/cmd/pr/reply-comment/reply_comment.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
+	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/spf13/cobra"
@@ -21,32 +23,44 @@ const autoSubmitSummary = "Auto-submitting pending review to unblock threaded re
 type ReplyCommentOptions struct {
 	IO         *iostreams.IOStreams
 	HttpClient func() (*http.Client, error)
-	BaseRepo   func() (ghrepo.Interface, error)
+	Config     func() (gh.Config, error)
 
+	BaseRepo func() (ghrepo.Interface, error)
+
+	Repo              ghrepo.Interface
+	Selector          string
 	Pull              int
 	CommentID         int64
 	Body              string
 	AutoSubmitPending bool
-
-	repo ghrepo.Interface
+	Hostname          string
 }
 
 func NewCmdReplyComment(f *cmdutil.Factory) *cobra.Command {
 	opts := &ReplyCommentOptions{
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
-		BaseRepo:   f.BaseRepo,
+		Config:     f.Config,
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return f.BaseRepo()
+		},
 	}
 
 	cmd := &cobra.Command{
-		Use:   "reply-comment",
+		Use:   "reply-comment [<number> | <url> | <owner>/<repo>#<number>]",
 		Short: "Reply to a pull request review comment",
 		Long: heredoc.Doc(`
-			Reply to an existing pull request review comment by comment identifier.
-		`),
+            Reply to an existing pull request review comment by comment identifier.
+        `),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.Selector = args[0]
+			}
 			if opts.Pull <= 0 {
-				return cmdutil.FlagErrorf("invalid value for --pr: %d", opts.Pull)
+				if opts.Selector == "" {
+					return cmdutil.FlagErrorf("must specify a pull request via --pr or as an argument")
+				}
 			}
 			if opts.CommentID <= 0 {
 				return cmdutil.FlagErrorf("invalid value for --comment-id: %d", opts.CommentID)
@@ -63,8 +77,7 @@ func NewCmdReplyComment(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().Int64Var(&opts.CommentID, "comment-id", 0, "Review comment identifier to reply to")
 	cmd.Flags().StringVar(&opts.Body, "body", "", "Reply text")
 	cmd.Flags().BoolVar(&opts.AutoSubmitPending, "auto-submit-pending", false, "Submit pending reviews before replying")
-
-	_ = cmd.MarkFlagRequired("pr")
+	cmd.Flags().StringVar(&opts.Hostname, "hostname", "", "GitHub hostname (default to authenticated host)")
 	_ = cmd.MarkFlagRequired("comment-id")
 	_ = cmd.MarkFlagRequired("body")
 
@@ -72,9 +85,24 @@ func NewCmdReplyComment(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runReplyComment(ctx context.Context, opts *ReplyCommentOptions) error {
-	repo, err := opts.resolveRepo()
+	repo, number, err := shared.ResolvePullRequest(opts.BaseRepo, opts.Selector, opts.Pull)
 	if err != nil {
 		return err
+	}
+	opts.Repo = repo
+	opts.Pull = number
+
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	host := repo.RepoHost()
+	if host == "" {
+		host, _ = cfg.Authentication().DefaultHost()
+	}
+	if opts.Hostname != "" {
+		host = opts.Hostname
 	}
 
 	httpClient, err := opts.HttpClient()
@@ -82,27 +110,26 @@ func runReplyComment(ctx context.Context, opts *ReplyCommentOptions) error {
 		return err
 	}
 
-	service := reviewapi.NewService(httpClient, repo.RepoHost())
+	service := reviewapi.NewService(httpClient, host)
 	owner := repo.RepoOwner()
 	name := repo.RepoName()
-	fullName := ghrepo.FullName(repo)
 
 	reply, err := service.ReplyToComment(ctx, owner, name, opts.Pull, opts.CommentID, opts.Body)
 	if err != nil {
 		var pendingErr *reviewapi.PendingReviewError
 		if errors.As(err, &pendingErr) {
 			if !opts.AutoSubmitPending {
-				return fmt.Errorf("pending review detected for %s#%d. Submit the review or re-run with --auto-submit-pending, or use the GraphQL review thread mutation.", fullName, opts.Pull)
+				return fmt.Errorf("pending review detected for %s/%s#%d. Submit the review or re-run with --auto-submit-pending, or use the GraphQL review thread mutation.", owner, name, opts.Pull)
 			}
 
 			reviewer, loginErr := service.CurrentLogin(ctx)
 			if loginErr != nil {
-				return formatReplyError(loginErr, fullName, "failed to resolve authenticated user")
+				return formatReplyError(loginErr, "failed to resolve authenticated user")
 			}
 
 			submitted, submitErr := service.SubmitPendingReviews(ctx, owner, name, opts.Pull, reviewer, autoSubmitSummary)
 			if submitErr != nil {
-				return formatReplyError(submitErr, fullName, "failed to submit pending review")
+				return formatReplyError(submitErr, "failed to submit pending review")
 			}
 			if submitted == 0 {
 				return fmt.Errorf("no pending reviews owned by %s found on pull request #%d", reviewer, opts.Pull)
@@ -110,10 +137,10 @@ func runReplyComment(ctx context.Context, opts *ReplyCommentOptions) error {
 
 			reply, err = service.ReplyToComment(ctx, owner, name, opts.Pull, opts.CommentID, opts.Body)
 			if err != nil {
-				return formatReplyError(err, fullName, "failed to post reply after submitting pending review")
+				return formatReplyError(err, "failed to post reply after submitting pending review")
 			}
 		} else {
-			return formatReplyError(err, fullName, "failed to post reply")
+			return formatReplyError(err, "failed to post reply")
 		}
 	}
 
@@ -126,22 +153,7 @@ func runReplyComment(ctx context.Context, opts *ReplyCommentOptions) error {
 	return nil
 }
 
-func (o *ReplyCommentOptions) resolveRepo() (ghrepo.Interface, error) {
-	if o.repo != nil {
-		return o.repo, nil
-	}
-	if o.BaseRepo == nil {
-		return nil, errors.New("repository resolver is not configured")
-	}
-	repo, err := o.BaseRepo()
-	if err != nil {
-		return nil, err
-	}
-	o.repo = repo
-	return repo, nil
-}
-
-func formatReplyError(err error, fullName string, prefix string) error {
+func formatReplyError(err error, prefix string) error {
 	switch e := err.(type) {
 	case *reviewapi.PullRequestNotFoundError:
 		return fmt.Errorf("%s: %w", prefix, e)
@@ -155,9 +167,9 @@ func formatReplyError(err error, fullName string, prefix string) error {
 	if errors.As(err, &httpErr) {
 		switch httpErr.StatusCode {
 		case http.StatusForbidden:
-			return fmt.Errorf("%s: access denied for %s (%s)", prefix, fullName, httpErr.Message)
+			return fmt.Errorf("%s: access denied (%s)", prefix, httpErr.Message)
 		case http.StatusNotFound:
-			return fmt.Errorf("%s: resource not found in %s (%s)", prefix, fullName, httpErr.Message)
+			return fmt.Errorf("%s: resource not found (%s)", prefix, httpErr.Message)
 		case http.StatusUnprocessableEntity:
 			return fmt.Errorf("%s: validation failed (%s)", prefix, httpErr.Message)
 		default:

--- a/pkg/cmd/pr/reply-comment/reply_comment_test.go
+++ b/pkg/cmd/pr/reply-comment/reply_comment_test.go
@@ -3,6 +3,7 @@ package reply_comment
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -20,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer) {
+func newTestFactory(t *testing.T, rt http.RoundTripper, repo ghrepo.Interface, repoErr error) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer) {
 	t.Helper()
 	ios, _, stdout, stderr := iostreams.Test()
 	ios.SetStdoutTTY(false)
@@ -30,18 +31,27 @@ func newTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory, *byte
 	cfg := config.NewBlankConfig()
 	cfg.Authentication().SetDefaultHost("github.com", "default")
 
-	return &cmdutil.Factory{
+	factory := &cmdutil.Factory{
 		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
-		BaseRepo: func() (ghrepo.Interface, error) {
-			return ghrepo.NewWithHost("ORG", "REPO", "github.com"), nil
-		},
 		Config: func() (gh.Config, error) {
 			return cfg, nil
 		},
-	}, stdout, stderr
+	}
+
+	factory.BaseRepo = func() (ghrepo.Interface, error) {
+		if repoErr != nil {
+			return nil, repoErr
+		}
+		if repo != nil {
+			return repo, nil
+		}
+		return ghrepo.FromFullName("ORG/REPO")
+	}
+
+	return factory, stdout, stderr
 }
 
 func TestReplyComment_AutoSubmitPending(t *testing.T) {
@@ -102,11 +112,13 @@ func TestReplyComment_AutoSubmitPending(t *testing.T) {
 		httpmock.JSONResponse(reply),
 	)
 
-	f, stdout, stderr := newTestFactory(t, reg)
+	repo, err := ghrepo.FromFullName("ORG/REPO")
+	require.NoError(t, err)
+	f, stdout, stderr := newTestFactory(t, reg, repo, nil)
 	cmd := NewCmdReplyComment(f)
-	cmd.SetArgs([]string{"--pr", "123", "--comment-id", "456", "--body", "Thanks!", "--auto-submit-pending"})
+	cmd.SetArgs([]string{"123", "--comment-id", "456", "--body", "Thanks!", "--auto-submit-pending"})
 
-	_, err := cmd.ExecuteC()
+	_, err = cmd.ExecuteC()
 	require.NoError(t, err)
 	assert.Equal(t, "", stderr.String())
 	assert.JSONEq(t, `{"id":333,"in_reply_to_id":456,"body":"Thanks!","user":{"login":"octocat"},"created_at":"2024-05-06T07:08:09Z"}`, stdout.String())
@@ -118,4 +130,53 @@ func TestReplyComment_AutoSubmitPending(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 2, reqCount, "expected two requests to reply endpoint")
+}
+
+func TestReplyComment_RepoOverrideWithoutGit(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("POST", "repos/octo/demo/pulls/10/comments/50/replies"), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{"id": 99}),
+	)
+
+	noRepoErr := errors.New("no repository")
+	f, stdout, stderr := newTestFactory(t, reg, nil, noRepoErr)
+	f.BaseRepo = cmdutil.OverrideBaseRepoFunc(f, "octo/demo")
+
+	cmd := NewCmdReplyComment(f)
+	cmd.SetArgs([]string{"10", "--comment-id", "50", "--body", "Thanks"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	assert.Equal(t, float64(99), payload["id"])
+}
+
+func TestReplyComment_FullReferenceWithoutGit(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("POST", "repos/octo/demo/pulls/10/comments/50/replies"), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{"id": 101}),
+	)
+
+	noRepoErr := errors.New("no repository")
+	f, stdout, stderr := newTestFactory(t, reg, nil, noRepoErr)
+
+	cmd := NewCmdReplyComment(f)
+	cmd.SetArgs([]string{"octo/demo#10", "--comment-id", "50", "--body", "ack"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	assert.Equal(t, float64(101), payload["id"])
 }

--- a/pkg/cmd/pr/reply-comment/reply_comment_test.go
+++ b/pkg/cmd/pr/reply-comment/reply_comment_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -33,6 +34,9 @@ func newTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory, *byte
 		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.NewWithHost("ORG", "REPO", "github.com"), nil
 		},
 		Config: func() (gh.Config, error) {
 			return cfg, nil
@@ -100,7 +104,7 @@ func TestReplyComment_AutoSubmitPending(t *testing.T) {
 
 	f, stdout, stderr := newTestFactory(t, reg)
 	cmd := NewCmdReplyComment(f)
-	cmd.SetArgs([]string{"--org", "ORG", "--repo", "REPO", "--pr", "123", "--comment-id", "456", "--body", "Thanks!", "--auto-submit-pending"})
+	cmd.SetArgs([]string{"--pr", "123", "--comment-id", "456", "--body", "Thanks!", "--auto-submit-pending"})
 
 	_, err := cmd.ExecuteC()
 	require.NoError(t, err)

--- a/pkg/cmd/pr/reply-comment/reply_comment_test.go
+++ b/pkg/cmd/pr/reply-comment/reply_comment_test.go
@@ -10,9 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -112,13 +114,14 @@ func TestReplyComment_AutoSubmitPending(t *testing.T) {
 		httpmock.JSONResponse(reply),
 	)
 
-	repo, err := ghrepo.FromFullName("ORG/REPO")
-	require.NoError(t, err)
+	repo, repoErr := ghrepo.FromFullName("ORG/REPO")
+	require.NoError(t, repoErr)
+	shared.StubFinderForRunCommandStyleTests(t, "123", &api.PullRequest{Number: 123}, repo)
 	f, stdout, stderr := newTestFactory(t, reg, repo, nil)
 	cmd := NewCmdReplyComment(f)
 	cmd.SetArgs([]string{"123", "--comment-id", "456", "--body", "Thanks!", "--auto-submit-pending"})
 
-	_, err = cmd.ExecuteC()
+	_, err := cmd.ExecuteC()
 	require.NoError(t, err)
 	assert.Equal(t, "", stderr.String())
 	assert.JSONEq(t, `{"id":333,"in_reply_to_id":456,"body":"Thanks!","user":{"login":"octocat"},"created_at":"2024-05-06T07:08:09Z"}`, stdout.String())
@@ -140,6 +143,10 @@ func TestReplyComment_RepoOverrideWithoutGit(t *testing.T) {
 		httpmock.WithHost(httpmock.REST("POST", "repos/octo/demo/pulls/10/comments/50/replies"), "api.github.com"),
 		httpmock.JSONResponse(map[string]interface{}{"id": 99}),
 	)
+
+	overrideRepo, overrideErr := ghrepo.FromFullName("octo/demo")
+	require.NoError(t, overrideErr)
+	shared.StubFinderForRunCommandStyleTests(t, "10", &api.PullRequest{Number: 10}, overrideRepo)
 
 	noRepoErr := errors.New("no repository")
 	f, stdout, stderr := newTestFactory(t, reg, nil, noRepoErr)
@@ -166,6 +173,9 @@ func TestReplyComment_FullReferenceWithoutGit(t *testing.T) {
 		httpmock.JSONResponse(map[string]interface{}{"id": 101}),
 	)
 
+	repo := ghrepo.NewWithHost("octo", "demo", "github.com")
+	shared.StubFinderForRunCommandStyleTests(t, "octo/demo#10", &api.PullRequest{Number: 10}, repo)
+
 	noRepoErr := errors.New("no repository")
 	f, stdout, stderr := newTestFactory(t, reg, nil, noRepoErr)
 
@@ -179,4 +189,31 @@ func TestReplyComment_FullReferenceWithoutGit(t *testing.T) {
 	var payload map[string]interface{}
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
 	assert.Equal(t, float64(101), payload["id"])
+}
+
+func TestReplyComment_URLSelector(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("POST", "repos/octo/demo/pulls/10/comments/50/replies"), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{"id": 202}),
+	)
+
+	selector := "https://github.com/octo/demo/pull/10"
+	repo := ghrepo.NewWithHost("octo", "demo", "github.com")
+	shared.StubFinderForRunCommandStyleTests(t, selector, &api.PullRequest{Number: 10}, repo)
+
+	f, stdout, stderr := newTestFactory(t, reg, nil, nil)
+
+	cmd := NewCmdReplyComment(f)
+	cmd.SetArgs([]string{selector, "--comment-id", "50", "--body", "ack"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	assert.Equal(t, float64(202), payload["id"])
 }

--- a/pkg/cmd/pr/reply-comment/reply_comment_test.go
+++ b/pkg/cmd/pr/reply-comment/reply_comment_test.go
@@ -1,0 +1,117 @@
+package reply_comment
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	ghapi "github.com/cli/go-gh/v2/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(false)
+	ios.SetStdinTTY(false)
+	ios.SetStderrTTY(false)
+
+	cfg := config.NewBlankConfig()
+	cfg.Authentication().SetDefaultHost("github.com", "default")
+
+	return &cmdutil.Factory{
+		IOStreams: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: rt}, nil
+		},
+		Config: func() (gh.Config, error) {
+			return cfg, nil
+		},
+	}, stdout, stderr
+}
+
+func TestReplyComment_AutoSubmitPending(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	pendingErr := ghapi.HTTPError{
+		Message: "Validation Failed",
+		Errors: []ghapi.HTTPErrorItem{
+			{Message: "\"user_id\" can only have one pending review per pull request."},
+		},
+	}
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("POST", "repos/ORG/REPO/pulls/123/comments/456/replies"), "api.github.com"),
+		httpmock.JSONErrorResponse(422, pendingErr),
+	)
+
+	reviews := []map[string]interface{}{
+		{
+			"id":           9001,
+			"state":        "PENDING",
+			"user":         map[string]interface{}{"login": "octocat"},
+			"submitted_at": nil,
+		},
+	}
+	reg.Register(
+		httpmock.WithHost(httpmock.QueryMatcher("GET", "repos/ORG/REPO/pulls/123/reviews", url.Values{"per_page": {"100"}}), "api.github.com"),
+		httpmock.JSONResponse(reviews),
+	)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("GET", "user"), "api.github.com"),
+		httpmock.JSONResponse(map[string]string{"login": "octocat"}),
+	)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("POST", "repos/ORG/REPO/pulls/123/reviews/9001/events"), "api.github.com"),
+		func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			var payload map[string]string
+			require.NoError(t, json.Unmarshal(body, &payload))
+			assert.Equal(t, "COMMENT", payload["event"])
+			assert.Equal(t, autoSubmitSummary, payload["body"])
+			return httpmock.JSONResponse(map[string]interface{}{"id": 9001})(req)
+		},
+	)
+
+	reply := map[string]interface{}{
+		"id":             333,
+		"in_reply_to_id": 456,
+		"body":           "Thanks!",
+		"user":           map[string]interface{}{"login": "octocat"},
+		"created_at":     time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC),
+	}
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("POST", "repos/ORG/REPO/pulls/123/comments/456/replies"), "api.github.com"),
+		httpmock.JSONResponse(reply),
+	)
+
+	f, stdout, stderr := newTestFactory(t, reg)
+	cmd := NewCmdReplyComment(f)
+	cmd.SetArgs([]string{"--org", "ORG", "--repo", "REPO", "--pr", "123", "--comment-id", "456", "--body", "Thanks!", "--auto-submit-pending"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, `{"id":333,"in_reply_to_id":456,"body":"Thanks!","user":{"login":"octocat"},"created_at":"2024-05-06T07:08:09Z"}`, stdout.String())
+
+	reqCount := 0
+	for _, req := range reg.Requests {
+		if req.URL.Path == "/repos/ORG/REPO/pulls/123/comments/456/replies" {
+			reqCount++
+		}
+	}
+	assert.Equal(t, 2, reqCount, "expected two requests to reply endpoint")
+}

--- a/pkg/cmd/pr/review/pending_review_cmds.go
+++ b/pkg/cmd/pr/review/pending_review_cmds.go
@@ -33,7 +33,7 @@ func NewCmdReviewOpen(f *cmdutil.Factory) *cobra.Command {
 		shared: PendingReviewSharedOptions{
 			IO:         f.IOStreams,
 			HttpClient: f.HttpClient,
-			Config:     f.Config,
+			BaseRepo:   f.BaseRepo,
 		},
 	}
 
@@ -41,7 +41,7 @@ func NewCmdReviewOpen(f *cmdutil.Factory) *cobra.Command {
 		Use:   "open",
 		Short: "Open a pending review",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.shared.ValidateRepoArgs(); err != nil {
+			if err := opts.shared.ValidateInputs(); err != nil {
 				return err
 			}
 			return runReviewOpen(cmd.Context(), opts)
@@ -55,12 +55,12 @@ func NewCmdReviewOpen(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runReviewOpen(ctx context.Context, opts *reviewOpenOptions) error {
-	service, err := opts.shared.BuildService()
+	service, repo, err := opts.shared.BuildService()
 	if err != nil {
 		return err
 	}
 
-	review, err := service.OpenReview(ctx, opts.shared.Org, opts.shared.Repo, opts.shared.Pull, opts.Commit)
+	review, err := service.OpenReview(ctx, repo.RepoOwner(), repo.RepoName(), opts.shared.Pull, opts.Commit)
 	if err != nil {
 		return FormatReviewRunError(err, "failed to open review")
 	}
@@ -88,7 +88,7 @@ func NewCmdReviewAdd(f *cmdutil.Factory) *cobra.Command {
 		shared: PendingReviewSharedOptions{
 			IO:         f.IOStreams,
 			HttpClient: f.HttpClient,
-			Config:     f.Config,
+			BaseRepo:   f.BaseRepo,
 		},
 		Side: "RIGHT",
 	}
@@ -97,7 +97,7 @@ func NewCmdReviewAdd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "add",
 		Short: "Add an inline comment thread to a pending review",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.shared.ValidateRepoArgs(); err != nil {
+			if err := opts.shared.ValidateInputs(); err != nil {
 				return err
 			}
 			if strings.TrimSpace(opts.ReviewID) == "" {
@@ -132,7 +132,7 @@ func NewCmdReviewAdd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runReviewAdd(ctx context.Context, opts *reviewAddOptions) error {
-	service, err := opts.shared.BuildService()
+	service, repo, err := opts.shared.BuildService()
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func runReviewAdd(ctx context.Context, opts *reviewAddOptions) error {
 		Body:      opts.Body,
 	}
 
-	thread, err := service.AddReviewThread(ctx, opts.shared.Org, opts.shared.Repo, opts.shared.Pull, input)
+	thread, err := service.AddReviewThread(ctx, repo.RepoOwner(), repo.RepoName(), opts.shared.Pull, input)
 	if err != nil {
 		return FormatReviewRunError(err, "failed to add review thread")
 	}
@@ -190,7 +190,7 @@ func NewCmdReviewSubmit(f *cmdutil.Factory) *cobra.Command {
 		shared: PendingReviewSharedOptions{
 			IO:         f.IOStreams,
 			HttpClient: f.HttpClient,
-			Config:     f.Config,
+			BaseRepo:   f.BaseRepo,
 		},
 		Event: "COMMENT",
 	}
@@ -199,7 +199,7 @@ func NewCmdReviewSubmit(f *cmdutil.Factory) *cobra.Command {
 		Use:   "submit",
 		Short: "Submit a pending review",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.shared.ValidateRepoArgs(); err != nil {
+			if err := opts.shared.ValidateInputs(); err != nil {
 				return err
 			}
 			if strings.TrimSpace(opts.ReviewID) == "" {
@@ -221,7 +221,7 @@ func NewCmdReviewSubmit(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runReviewSubmit(ctx context.Context, opts *reviewSubmitOptions) error {
-	service, err := opts.shared.BuildService()
+	service, repo, err := opts.shared.BuildService()
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func runReviewSubmit(ctx context.Context, opts *reviewSubmitOptions) error {
 		return cmdutil.FlagErrorf("%s", err)
 	}
 
-	review, err := service.SubmitReview(ctx, opts.shared.Org, opts.shared.Repo, opts.shared.Pull, opts.ReviewID, event, opts.Body)
+	review, err := service.SubmitReview(ctx, repo.RepoOwner(), repo.RepoName(), opts.shared.Pull, opts.ReviewID, event, opts.Body)
 	if err != nil {
 		return FormatReviewRunError(err, "failed to submit review")
 	}

--- a/pkg/cmd/pr/review/pending_review_cmds.go
+++ b/pkg/cmd/pr/review/pending_review_cmds.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
+	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -35,9 +35,6 @@ func NewCmdReviewOpen(f *cmdutil.Factory) *cobra.Command {
 			IO:         f.IOStreams,
 			HttpClient: f.HttpClient,
 			Config:     f.Config,
-			BaseRepo: func() (ghrepo.Interface, error) {
-				return f.BaseRepo()
-			},
 		},
 	}
 
@@ -46,8 +43,9 @@ func NewCmdReviewOpen(f *cmdutil.Factory) *cobra.Command {
 		Short: "Open a pending review",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.shared.Finder = shared.NewFinder(f)
 			if len(args) > 0 {
-				opts.shared.Selector = args[0]
+				opts.shared.SelectorArg = args[0]
 			}
 			if err := opts.shared.ResolvePullRequest(); err != nil {
 				return err
@@ -97,9 +95,6 @@ func NewCmdReviewAdd(f *cmdutil.Factory) *cobra.Command {
 			IO:         f.IOStreams,
 			HttpClient: f.HttpClient,
 			Config:     f.Config,
-			BaseRepo: func() (ghrepo.Interface, error) {
-				return f.BaseRepo()
-			},
 		},
 		Side: "RIGHT",
 	}
@@ -109,8 +104,9 @@ func NewCmdReviewAdd(f *cmdutil.Factory) *cobra.Command {
 		Short: "Add an inline comment thread to a pending review",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.shared.Finder = shared.NewFinder(f)
 			if len(args) > 0 {
-				opts.shared.Selector = args[0]
+				opts.shared.SelectorArg = args[0]
 			}
 			if err := opts.shared.ResolvePullRequest(); err != nil {
 				return err
@@ -206,9 +202,6 @@ func NewCmdReviewSubmit(f *cmdutil.Factory) *cobra.Command {
 			IO:         f.IOStreams,
 			HttpClient: f.HttpClient,
 			Config:     f.Config,
-			BaseRepo: func() (ghrepo.Interface, error) {
-				return f.BaseRepo()
-			},
 		},
 		Event: "COMMENT",
 	}
@@ -218,8 +211,9 @@ func NewCmdReviewSubmit(f *cmdutil.Factory) *cobra.Command {
 		Short: "Submit a pending review",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.shared.Finder = shared.NewFinder(f)
 			if len(args) > 0 {
-				opts.shared.Selector = args[0]
+				opts.shared.SelectorArg = args[0]
 			}
 			if err := opts.shared.ResolvePullRequest(); err != nil {
 				return err

--- a/pkg/cmd/pr/review/pending_review_cmds.go
+++ b/pkg/cmd/pr/review/pending_review_cmds.go
@@ -1,0 +1,244 @@
+package review
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdReviewPending(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pending",
+		Short: "Manage pending pull request reviews",
+		Long:  "Open, update, and submit pending pull request reviews.",
+	}
+
+	cmd.AddCommand(NewCmdReviewOpen(f))
+	cmd.AddCommand(NewCmdReviewAdd(f))
+	cmd.AddCommand(NewCmdReviewSubmit(f))
+
+	return cmd
+}
+
+type reviewOpenOptions struct {
+	shared PendingReviewSharedOptions
+	Commit string
+}
+
+func NewCmdReviewOpen(f *cmdutil.Factory) *cobra.Command {
+	opts := &reviewOpenOptions{
+		shared: PendingReviewSharedOptions{
+			IO:         f.IOStreams,
+			HttpClient: f.HttpClient,
+			Config:     f.Config,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "open",
+		Short: "Open a pending review",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.shared.ValidateRepoArgs(); err != nil {
+				return err
+			}
+			return runReviewOpen(cmd.Context(), opts)
+		},
+	}
+
+	opts.shared.RegisterFlags(cmd)
+	cmd.Flags().StringVar(&opts.Commit, "commit", "", "Commit SHA to anchor the review (defaults to PR head)")
+
+	return cmd
+}
+
+func runReviewOpen(ctx context.Context, opts *reviewOpenOptions) error {
+	service, err := opts.shared.BuildService()
+	if err != nil {
+		return err
+	}
+
+	review, err := service.OpenReview(ctx, opts.shared.Org, opts.shared.Repo, opts.shared.Pull, opts.Commit)
+	if err != nil {
+		return FormatReviewRunError(err, "failed to open review")
+	}
+
+	return EncodeJSON(opts.shared.IO, map[string]interface{}{
+		"id":           review.ID,
+		"state":        review.State,
+		"submitted_at": FormatTime(review.SubmittedAt),
+	})
+}
+
+type reviewAddOptions struct {
+	shared    PendingReviewSharedOptions
+	ReviewID  string
+	Path      string
+	Line      int
+	Side      string
+	StartLine int
+	StartSide string
+	Body      string
+}
+
+func NewCmdReviewAdd(f *cmdutil.Factory) *cobra.Command {
+	opts := &reviewAddOptions{
+		shared: PendingReviewSharedOptions{
+			IO:         f.IOStreams,
+			HttpClient: f.HttpClient,
+			Config:     f.Config,
+		},
+		Side: "RIGHT",
+	}
+
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add an inline comment thread to a pending review",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.shared.ValidateRepoArgs(); err != nil {
+				return err
+			}
+			if strings.TrimSpace(opts.ReviewID) == "" {
+				return cmdutil.FlagErrorf("--review-id is required")
+			}
+			if strings.TrimSpace(opts.Path) == "" {
+				return cmdutil.FlagErrorf("--path is required")
+			}
+			if opts.Line <= 0 {
+				return cmdutil.FlagErrorf("invalid value for --line: %d", opts.Line)
+			}
+			if opts.Body == "" {
+				return cmdutil.FlagErrorf("--body is required")
+			}
+			if opts.StartLine != 0 && opts.StartSide == "" {
+				return cmdutil.FlagErrorf("--start-side is required when --start-line is provided")
+			}
+			return runReviewAdd(cmd.Context(), opts)
+		},
+	}
+
+	opts.shared.RegisterFlags(cmd)
+	cmd.Flags().StringVar(&opts.ReviewID, "review-id", "", "GraphQL review identifier")
+	cmd.Flags().StringVar(&opts.Path, "path", "", "File path for the comment thread")
+	cmd.Flags().IntVar(&opts.Line, "line", 0, "Line number for the comment thread")
+	cmd.Flags().StringVar(&opts.Side, "side", "RIGHT", "Diff side for the comment (LEFT or RIGHT)")
+	cmd.Flags().IntVar(&opts.StartLine, "start-line", 0, "Optional start line for multi-line comments")
+	cmd.Flags().StringVar(&opts.StartSide, "start-side", "", "Optional start side for multi-line comments (LEFT or RIGHT)")
+	cmd.Flags().StringVar(&opts.Body, "body", "", "Comment body")
+
+	return cmd
+}
+
+func runReviewAdd(ctx context.Context, opts *reviewAddOptions) error {
+	service, err := opts.shared.BuildService()
+	if err != nil {
+		return err
+	}
+
+	side, err := NormalizeSide(opts.Side)
+	if err != nil {
+		return cmdutil.FlagErrorf("%s", err)
+	}
+
+	var startLine *int
+	var startSide *string
+	if opts.StartLine != 0 {
+		if opts.StartLine <= 0 {
+			return cmdutil.FlagErrorf("invalid value for --start-line: %d", opts.StartLine)
+		}
+		normalized, err := NormalizeSide(opts.StartSide)
+		if err != nil {
+			return cmdutil.FlagErrorf("%s", err)
+		}
+		startLine = &opts.StartLine
+		startSide = &normalized
+	}
+
+	input := reviewapi.AddReviewThreadInput{
+		ReviewID:  opts.ReviewID,
+		Path:      opts.Path,
+		Line:      opts.Line,
+		Side:      side,
+		StartLine: startLine,
+		StartSide: startSide,
+		Body:      opts.Body,
+	}
+
+	thread, err := service.AddReviewThread(ctx, opts.shared.Org, opts.shared.Repo, opts.shared.Pull, input)
+	if err != nil {
+		return FormatReviewRunError(err, "failed to add review thread")
+	}
+
+	return EncodeJSON(opts.shared.IO, map[string]interface{}{
+		"id":          thread.ID,
+		"path":        thread.Path,
+		"is_outdated": thread.IsOutdated,
+	})
+}
+
+type reviewSubmitOptions struct {
+	shared   PendingReviewSharedOptions
+	ReviewID string
+	Event    string
+	Body     string
+}
+
+func NewCmdReviewSubmit(f *cmdutil.Factory) *cobra.Command {
+	opts := &reviewSubmitOptions{
+		shared: PendingReviewSharedOptions{
+			IO:         f.IOStreams,
+			HttpClient: f.HttpClient,
+			Config:     f.Config,
+		},
+		Event: "COMMENT",
+	}
+
+	cmd := &cobra.Command{
+		Use:   "submit",
+		Short: "Submit a pending review",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.shared.ValidateRepoArgs(); err != nil {
+				return err
+			}
+			if strings.TrimSpace(opts.ReviewID) == "" {
+				return cmdutil.FlagErrorf("--review-id is required")
+			}
+			if strings.TrimSpace(opts.Event) == "" {
+				return cmdutil.FlagErrorf("--event is required")
+			}
+			return runReviewSubmit(cmd.Context(), opts)
+		},
+	}
+
+	opts.shared.RegisterFlags(cmd)
+	cmd.Flags().StringVar(&opts.ReviewID, "review-id", "", "GraphQL review identifier")
+	cmd.Flags().StringVar(&opts.Event, "event", "COMMENT", "Submit event (APPROVE, COMMENT, REQUEST_CHANGES)")
+	cmd.Flags().StringVar(&opts.Body, "body", "", "Optional review summary body")
+
+	return cmd
+}
+
+func runReviewSubmit(ctx context.Context, opts *reviewSubmitOptions) error {
+	service, err := opts.shared.BuildService()
+	if err != nil {
+		return err
+	}
+
+	event, err := NormalizeEvent(opts.Event)
+	if err != nil {
+		return cmdutil.FlagErrorf("%s", err)
+	}
+
+	review, err := service.SubmitReview(ctx, opts.shared.Org, opts.shared.Repo, opts.shared.Pull, opts.ReviewID, event, opts.Body)
+	if err != nil {
+		return FormatReviewRunError(err, "failed to submit review")
+	}
+
+	return EncodeJSON(opts.shared.IO, map[string]interface{}{
+		"id":           review.ID,
+		"state":        review.State,
+		"submitted_at": FormatTime(review.SubmittedAt),
+	})
+}

--- a/pkg/cmd/pr/review/pending_review_cmds.go
+++ b/pkg/cmd/pr/review/pending_review_cmds.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -33,15 +34,22 @@ func NewCmdReviewOpen(f *cmdutil.Factory) *cobra.Command {
 		shared: PendingReviewSharedOptions{
 			IO:         f.IOStreams,
 			HttpClient: f.HttpClient,
-			BaseRepo:   f.BaseRepo,
+			Config:     f.Config,
+			BaseRepo: func() (ghrepo.Interface, error) {
+				return f.BaseRepo()
+			},
 		},
 	}
 
 	cmd := &cobra.Command{
-		Use:   "open",
+		Use:   "open [<number> | <url> | <owner>/<repo>#<number>]",
 		Short: "Open a pending review",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.shared.ValidateInputs(); err != nil {
+			if len(args) > 0 {
+				opts.shared.Selector = args[0]
+			}
+			if err := opts.shared.ResolvePullRequest(); err != nil {
 				return err
 			}
 			return runReviewOpen(cmd.Context(), opts)
@@ -55,12 +63,12 @@ func NewCmdReviewOpen(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runReviewOpen(ctx context.Context, opts *reviewOpenOptions) error {
-	service, repo, err := opts.shared.BuildService()
+	service, err := opts.shared.BuildService()
 	if err != nil {
 		return err
 	}
 
-	review, err := service.OpenReview(ctx, repo.RepoOwner(), repo.RepoName(), opts.shared.Pull, opts.Commit)
+	review, err := service.OpenReview(ctx, opts.shared.Repo.RepoOwner(), opts.shared.Repo.RepoName(), opts.shared.Pull, opts.Commit)
 	if err != nil {
 		return FormatReviewRunError(err, "failed to open review")
 	}
@@ -88,16 +96,23 @@ func NewCmdReviewAdd(f *cmdutil.Factory) *cobra.Command {
 		shared: PendingReviewSharedOptions{
 			IO:         f.IOStreams,
 			HttpClient: f.HttpClient,
-			BaseRepo:   f.BaseRepo,
+			Config:     f.Config,
+			BaseRepo: func() (ghrepo.Interface, error) {
+				return f.BaseRepo()
+			},
 		},
 		Side: "RIGHT",
 	}
 
 	cmd := &cobra.Command{
-		Use:   "add",
+		Use:   "add [<number> | <url> | <owner>/<repo>#<number>]",
 		Short: "Add an inline comment thread to a pending review",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.shared.ValidateInputs(); err != nil {
+			if len(args) > 0 {
+				opts.shared.Selector = args[0]
+			}
+			if err := opts.shared.ResolvePullRequest(); err != nil {
 				return err
 			}
 			if strings.TrimSpace(opts.ReviewID) == "" {
@@ -132,7 +147,7 @@ func NewCmdReviewAdd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runReviewAdd(ctx context.Context, opts *reviewAddOptions) error {
-	service, repo, err := opts.shared.BuildService()
+	service, err := opts.shared.BuildService()
 	if err != nil {
 		return err
 	}
@@ -166,7 +181,7 @@ func runReviewAdd(ctx context.Context, opts *reviewAddOptions) error {
 		Body:      opts.Body,
 	}
 
-	thread, err := service.AddReviewThread(ctx, repo.RepoOwner(), repo.RepoName(), opts.shared.Pull, input)
+	thread, err := service.AddReviewThread(ctx, opts.shared.Repo.RepoOwner(), opts.shared.Repo.RepoName(), opts.shared.Pull, input)
 	if err != nil {
 		return FormatReviewRunError(err, "failed to add review thread")
 	}
@@ -190,16 +205,23 @@ func NewCmdReviewSubmit(f *cmdutil.Factory) *cobra.Command {
 		shared: PendingReviewSharedOptions{
 			IO:         f.IOStreams,
 			HttpClient: f.HttpClient,
-			BaseRepo:   f.BaseRepo,
+			Config:     f.Config,
+			BaseRepo: func() (ghrepo.Interface, error) {
+				return f.BaseRepo()
+			},
 		},
 		Event: "COMMENT",
 	}
 
 	cmd := &cobra.Command{
-		Use:   "submit",
+		Use:   "submit [<number> | <url> | <owner>/<repo>#<number>]",
 		Short: "Submit a pending review",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.shared.ValidateInputs(); err != nil {
+			if len(args) > 0 {
+				opts.shared.Selector = args[0]
+			}
+			if err := opts.shared.ResolvePullRequest(); err != nil {
 				return err
 			}
 			if strings.TrimSpace(opts.ReviewID) == "" {
@@ -221,7 +243,7 @@ func NewCmdReviewSubmit(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runReviewSubmit(ctx context.Context, opts *reviewSubmitOptions) error {
-	service, repo, err := opts.shared.BuildService()
+	service, err := opts.shared.BuildService()
 	if err != nil {
 		return err
 	}
@@ -231,7 +253,7 @@ func runReviewSubmit(ctx context.Context, opts *reviewSubmitOptions) error {
 		return cmdutil.FlagErrorf("%s", err)
 	}
 
-	review, err := service.SubmitReview(ctx, repo.RepoOwner(), repo.RepoName(), opts.shared.Pull, opts.ReviewID, event, opts.Body)
+	review, err := service.SubmitReview(ctx, opts.shared.Repo.RepoOwner(), opts.shared.Repo.RepoName(), opts.shared.Pull, opts.ReviewID, event, opts.Body)
 	if err != nil {
 		return FormatReviewRunError(err, "failed to submit review")
 	}

--- a/pkg/cmd/pr/review/pending_review_cmds_test.go
+++ b/pkg/cmd/pr/review/pending_review_cmds_test.go
@@ -284,6 +284,39 @@ func TestReviewSubmit(t *testing.T) {
 	assert.JSONEq(t, `{"id":"RV123","state":"COMMENTED","submitted_at":"2024-05-01T12:00:00Z"}`, stdout.String())
 }
 
+func TestReviewSubmit_URLSelector(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.GraphQL(`mutation SubmitPullRequestReview`), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"data": map[string]interface{}{
+				"submitPullRequestReview": map[string]interface{}{
+					"pullRequestReview": map[string]interface{}{
+						"id":          "RV123",
+						"state":       "COMMENTED",
+						"submittedAt": "2024-05-01T12:00:00Z",
+					},
+				},
+			},
+		}),
+	)
+
+	selector := "https://github.com/octo/demo/pull/5"
+	repo := ghrepo.NewWithHost("octo", "demo", "github.com")
+	shared.StubFinderForRunCommandStyleTests(t, selector, &api.PullRequest{Number: 5}, repo)
+
+	f, stdout, stderr := newPendingTestFactory(t, reg, nil, nil)
+	cmd := NewCmdReview(f, nil)
+	cmd.SetArgs([]string{"pending", "submit", selector, "--review-id", "RV123", "--event", "approve"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, `{"id":"RV123","state":"COMMENTED","submitted_at":"2024-05-01T12:00:00Z"}`, stdout.String())
+}
+
 func TestReviewOpen_RepoOverrideWithoutGit(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)

--- a/pkg/cmd/pr/review/pending_review_cmds_test.go
+++ b/pkg/cmd/pr/review/pending_review_cmds_test.go
@@ -1,0 +1,159 @@
+package review
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newPendingTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(false)
+	ios.SetStdinTTY(false)
+	ios.SetStderrTTY(false)
+
+	cfg := config.NewBlankConfig()
+	cfg.Authentication().SetDefaultHost("github.com", "default")
+
+	return &cmdutil.Factory{
+		IOStreams: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: rt}, nil
+		},
+		Config: func() (gh.Config, error) {
+			return cfg, nil
+		},
+	}, stdout, stderr
+}
+
+func TestReviewOpen(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.GraphQL(`query PullRequestID`), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"data": map[string]interface{}{
+				"repository": map[string]interface{}{
+					"pullRequest": map[string]interface{}{"id": "PRID"},
+				},
+			},
+		}),
+	)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("GET", "repos/ORG/REPO/pulls/42"), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"head": map[string]interface{}{"sha": "abc123"},
+		}),
+	)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.GraphQL(`mutation AddPullRequestReview`), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"data": map[string]interface{}{
+				"addPullRequestReview": map[string]interface{}{
+					"pullRequestReview": map[string]interface{}{
+						"id":          "RV_review",
+						"state":       "PENDING",
+						"submittedAt": nil,
+					},
+				},
+			},
+		}),
+	)
+
+	f, stdout, stderr := newPendingTestFactory(t, reg)
+	cmd := NewCmdReview(f, nil)
+	cmd.SetArgs([]string{"pending", "open", "--org", "ORG", "--repo", "REPO", "--pr", "42"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, `{"id":"RV_review","state":"PENDING","submitted_at":null}`, stdout.String())
+}
+
+func TestReviewAdd(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.GraphQL(`mutation AddPullRequestReviewThread`), "api.github.com"),
+		func(req *http.Request) (*http.Response, error) {
+			data, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			var payload struct {
+				Variables map[string]map[string]interface{} `json:"variables"`
+			}
+			require.NoError(t, json.Unmarshal(data, &payload))
+			input := payload.Variables["input"]
+			assert.Equal(t, "RV123", input["pullRequestReviewId"])
+			assert.Equal(t, "file.go", input["path"])
+			assert.EqualValues(t, 7, input["line"])
+			assert.Equal(t, "RIGHT", input["side"])
+			assert.Equal(t, "note", input["body"])
+
+			return httpmock.JSONResponse(map[string]interface{}{
+				"data": map[string]interface{}{
+					"addPullRequestReviewThread": map[string]interface{}{
+						"thread": map[string]interface{}{
+							"id":         "THREAD123",
+							"path":       "file.go",
+							"isOutdated": false,
+						},
+					},
+				},
+			})(req)
+		},
+	)
+
+	f, stdout, stderr := newPendingTestFactory(t, reg)
+	cmd := NewCmdReview(f, nil)
+	cmd.SetArgs([]string{"pending", "add", "--org", "ORG", "--repo", "REPO", "--pr", "9", "--review-id", "RV123", "--path", "file.go", "--line", "7", "--side", "right", "--body", "note"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, `{"id":"THREAD123","path":"file.go","is_outdated":false}`, stdout.String())
+}
+
+func TestReviewSubmit(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.GraphQL(`mutation SubmitPullRequestReview`), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"data": map[string]interface{}{
+				"submitPullRequestReview": map[string]interface{}{
+					"pullRequestReview": map[string]interface{}{
+						"id":          "RV123",
+						"state":       "COMMENTED",
+						"submittedAt": time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+		}),
+	)
+
+	f, stdout, stderr := newPendingTestFactory(t, reg)
+	cmd := NewCmdReview(f, nil)
+	cmd.SetArgs([]string{"pending", "submit", "--org", "ORG", "--repo", "REPO", "--pr", "5", "--review-id", "RV123", "--event", "approve"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, `{"id":"RV123","state":"COMMENTED","submitted_at":"2024-05-01T12:00:00Z"}`, stdout.String())
+}

--- a/pkg/cmd/pr/review/pending_review_cmds_test.go
+++ b/pkg/cmd/pr/review/pending_review_cmds_test.go
@@ -3,10 +3,10 @@ package review
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPendingTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer) {
+func newPendingTestFactory(t *testing.T, rt http.RoundTripper, repo ghrepo.Interface, repoErr error) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer) {
 	t.Helper()
 	ios, _, stdout, stderr := iostreams.Test()
 	ios.SetStdoutTTY(false)
@@ -28,18 +28,27 @@ func newPendingTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory
 	cfg := config.NewBlankConfig()
 	cfg.Authentication().SetDefaultHost("github.com", "default")
 
-	return &cmdutil.Factory{
+	factory := &cmdutil.Factory{
 		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
-		BaseRepo: func() (ghrepo.Interface, error) {
-			return ghrepo.NewWithHost("ORG", "REPO", "github.com"), nil
-		},
 		Config: func() (gh.Config, error) {
 			return cfg, nil
 		},
-	}, stdout, stderr
+	}
+
+	factory.BaseRepo = func() (ghrepo.Interface, error) {
+		if repoErr != nil {
+			return nil, repoErr
+		}
+		if repo != nil {
+			return repo, nil
+		}
+		return ghrepo.FromFullName("ORG/REPO")
+	}
+
+	return factory, stdout, stderr
 }
 
 func TestReviewOpen(t *testing.T) {
@@ -79,11 +88,13 @@ func TestReviewOpen(t *testing.T) {
 		}),
 	)
 
-	f, stdout, stderr := newPendingTestFactory(t, reg)
+	repo, err := ghrepo.FromFullName("ORG/REPO")
+	require.NoError(t, err)
+	f, stdout, stderr := newPendingTestFactory(t, reg, repo, nil)
 	cmd := NewCmdReview(f, nil)
-	cmd.SetArgs([]string{"pending", "open", "--pr", "42"})
+	cmd.SetArgs([]string{"pending", "open", "42"})
 
-	_, err := cmd.ExecuteC()
+	_, err = cmd.ExecuteC()
 	require.NoError(t, err)
 	assert.Equal(t, "", stderr.String())
 	assert.JSONEq(t, `{"id":"RV_review","state":"PENDING","submitted_at":null}`, stdout.String())
@@ -123,11 +134,13 @@ func TestReviewAdd(t *testing.T) {
 		},
 	)
 
-	f, stdout, stderr := newPendingTestFactory(t, reg)
+	repo, err := ghrepo.FromFullName("ORG/REPO")
+	require.NoError(t, err)
+	f, stdout, stderr := newPendingTestFactory(t, reg, repo, nil)
 	cmd := NewCmdReview(f, nil)
-	cmd.SetArgs([]string{"pending", "add", "--pr", "9", "--review-id", "RV123", "--path", "file.go", "--line", "7", "--side", "right", "--body", "note"})
+	cmd.SetArgs([]string{"pending", "add", "9", "--review-id", "RV123", "--path", "file.go", "--line", "7", "--side", "right", "--body", "note"})
 
-	_, err := cmd.ExecuteC()
+	_, err = cmd.ExecuteC()
 	require.NoError(t, err)
 	assert.Equal(t, "", stderr.String())
 	assert.JSONEq(t, `{"id":"THREAD123","path":"file.go","is_outdated":false}`, stdout.String())
@@ -145,19 +158,71 @@ func TestReviewSubmit(t *testing.T) {
 					"pullRequestReview": map[string]interface{}{
 						"id":          "RV123",
 						"state":       "COMMENTED",
-						"submittedAt": time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC),
+						"submittedAt": "2024-05-01T12:00:00Z",
 					},
 				},
 			},
 		}),
 	)
 
-	f, stdout, stderr := newPendingTestFactory(t, reg)
+	repo, err := ghrepo.FromFullName("ORG/REPO")
+	require.NoError(t, err)
+	f, stdout, stderr := newPendingTestFactory(t, reg, repo, nil)
 	cmd := NewCmdReview(f, nil)
-	cmd.SetArgs([]string{"pending", "submit", "--pr", "5", "--review-id", "RV123", "--event", "approve"})
+	cmd.SetArgs([]string{"pending", "submit", "5", "--review-id", "RV123", "--event", "approve"})
+
+	_, err = cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, `{"id":"RV123","state":"COMMENTED","submitted_at":"2024-05-01T12:00:00Z"}`, stdout.String())
+}
+
+func TestReviewOpen_RepoOverrideWithoutGit(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.GraphQL(`query PullRequestID`), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"data": map[string]interface{}{
+				"repository": map[string]interface{}{
+					"pullRequest": map[string]interface{}{"id": "PRID"},
+				},
+			},
+		}),
+	)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("GET", "repos/octo/demo/pulls/42"), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"head": map[string]interface{}{"sha": "abc123"},
+		}),
+	)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.GraphQL(`mutation AddPullRequestReview`), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"data": map[string]interface{}{
+				"addPullRequestReview": map[string]interface{}{
+					"pullRequestReview": map[string]interface{}{
+						"id":          "RV_review",
+						"state":       "PENDING",
+						"submittedAt": nil,
+					},
+				},
+			},
+		}),
+	)
+
+	noRepoErr := errors.New("no repository context")
+	f, stdout, stderr := newPendingTestFactory(t, reg, nil, noRepoErr)
+	f.BaseRepo = cmdutil.OverrideBaseRepoFunc(f, "octo/demo")
+
+	cmd := NewCmdReview(f, nil)
+	cmd.SetArgs([]string{"pending", "open", "42"})
 
 	_, err := cmd.ExecuteC()
 	require.NoError(t, err)
 	assert.Equal(t, "", stderr.String())
-	assert.JSONEq(t, `{"id":"RV123","state":"COMMENTED","submitted_at":"2024-05-01T12:00:00Z"}`, stdout.String())
+	assert.JSONEq(t, `{"id":"RV_review","state":"PENDING","submitted_at":null}`, stdout.String())
 }

--- a/pkg/cmd/pr/review/pending_review_cmds_test.go
+++ b/pkg/cmd/pr/review/pending_review_cmds_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -31,6 +32,9 @@ func newPendingTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory
 		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.NewWithHost("ORG", "REPO", "github.com"), nil
 		},
 		Config: func() (gh.Config, error) {
 			return cfg, nil
@@ -77,7 +81,7 @@ func TestReviewOpen(t *testing.T) {
 
 	f, stdout, stderr := newPendingTestFactory(t, reg)
 	cmd := NewCmdReview(f, nil)
-	cmd.SetArgs([]string{"pending", "open", "--org", "ORG", "--repo", "REPO", "--pr", "42"})
+	cmd.SetArgs([]string{"pending", "open", "--pr", "42"})
 
 	_, err := cmd.ExecuteC()
 	require.NoError(t, err)
@@ -121,7 +125,7 @@ func TestReviewAdd(t *testing.T) {
 
 	f, stdout, stderr := newPendingTestFactory(t, reg)
 	cmd := NewCmdReview(f, nil)
-	cmd.SetArgs([]string{"pending", "add", "--org", "ORG", "--repo", "REPO", "--pr", "9", "--review-id", "RV123", "--path", "file.go", "--line", "7", "--side", "right", "--body", "note"})
+	cmd.SetArgs([]string{"pending", "add", "--pr", "9", "--review-id", "RV123", "--path", "file.go", "--line", "7", "--side", "right", "--body", "note"})
 
 	_, err := cmd.ExecuteC()
 	require.NoError(t, err)
@@ -150,7 +154,7 @@ func TestReviewSubmit(t *testing.T) {
 
 	f, stdout, stderr := newPendingTestFactory(t, reg)
 	cmd := NewCmdReview(f, nil)
-	cmd.SetArgs([]string{"pending", "submit", "--org", "ORG", "--repo", "REPO", "--pr", "5", "--review-id", "RV123", "--event", "approve"})
+	cmd.SetArgs([]string{"pending", "submit", "--pr", "5", "--review-id", "RV123", "--event", "approve"})
 
 	_, err := cmd.ExecuteC()
 	require.NoError(t, err)

--- a/pkg/cmd/pr/review/pending_review_cmds_test.go
+++ b/pkg/cmd/pr/review/pending_review_cmds_test.go
@@ -8,9 +8,11 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -90,11 +92,114 @@ func TestReviewOpen(t *testing.T) {
 
 	repo, err := ghrepo.FromFullName("ORG/REPO")
 	require.NoError(t, err)
+	shared.StubFinderForRunCommandStyleTests(t, "42", &api.PullRequest{Number: 42}, repo)
 	f, stdout, stderr := newPendingTestFactory(t, reg, repo, nil)
 	cmd := NewCmdReview(f, nil)
 	cmd.SetArgs([]string{"pending", "open", "42"})
 
 	_, err = cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, `{"id":"RV_review","state":"PENDING","submitted_at":null}`, stdout.String())
+}
+
+func TestReviewOpen_FullReferenceSelector(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.GraphQL(`query PullRequestID`), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"data": map[string]interface{}{
+				"repository": map[string]interface{}{
+					"pullRequest": map[string]interface{}{"id": "PRID"},
+				},
+			},
+		}),
+	)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("GET", "repos/octo/demo/pulls/42"), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"head": map[string]interface{}{"sha": "abc123"},
+		}),
+	)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.GraphQL(`mutation AddPullRequestReview`), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"data": map[string]interface{}{
+				"addPullRequestReview": map[string]interface{}{
+					"pullRequestReview": map[string]interface{}{
+						"id":          "RV_review",
+						"state":       "PENDING",
+						"submittedAt": nil,
+					},
+				},
+			},
+		}),
+	)
+
+	selector := "octo/demo#42"
+	repo := ghrepo.NewWithHost("octo", "demo", "github.com")
+	shared.StubFinderForRunCommandStyleTests(t, selector, &api.PullRequest{Number: 42}, repo)
+
+	f, stdout, stderr := newPendingTestFactory(t, reg, nil, nil)
+	cmd := NewCmdReview(f, nil)
+	cmd.SetArgs([]string{"pending", "open", selector})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, `{"id":"RV_review","state":"PENDING","submitted_at":null}`, stdout.String())
+}
+
+func TestReviewOpen_URLSelector(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.GraphQL(`query PullRequestID`), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"data": map[string]interface{}{
+				"repository": map[string]interface{}{
+					"pullRequest": map[string]interface{}{"id": "PRID"},
+				},
+			},
+		}),
+	)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.REST("GET", "repos/octo/demo/pulls/42"), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"head": map[string]interface{}{"sha": "abc123"},
+		}),
+	)
+
+	reg.Register(
+		httpmock.WithHost(httpmock.GraphQL(`mutation AddPullRequestReview`), "api.github.com"),
+		httpmock.JSONResponse(map[string]interface{}{
+			"data": map[string]interface{}{
+				"addPullRequestReview": map[string]interface{}{
+					"pullRequestReview": map[string]interface{}{
+						"id":          "RV_review",
+						"state":       "PENDING",
+						"submittedAt": nil,
+					},
+				},
+			},
+		}),
+	)
+
+	selector := "https://github.com/octo/demo/pull/42"
+	repo := ghrepo.NewWithHost("octo", "demo", "github.com")
+	shared.StubFinderForRunCommandStyleTests(t, selector, &api.PullRequest{Number: 42}, repo)
+
+	f, stdout, stderr := newPendingTestFactory(t, reg, nil, nil)
+	cmd := NewCmdReview(f, nil)
+	cmd.SetArgs([]string{"pending", "open", selector})
+
+	_, err := cmd.ExecuteC()
 	require.NoError(t, err)
 	assert.Equal(t, "", stderr.String())
 	assert.JSONEq(t, `{"id":"RV_review","state":"PENDING","submitted_at":null}`, stdout.String())
@@ -136,6 +241,7 @@ func TestReviewAdd(t *testing.T) {
 
 	repo, err := ghrepo.FromFullName("ORG/REPO")
 	require.NoError(t, err)
+	shared.StubFinderForRunCommandStyleTests(t, "9", &api.PullRequest{Number: 9}, repo)
 	f, stdout, stderr := newPendingTestFactory(t, reg, repo, nil)
 	cmd := NewCmdReview(f, nil)
 	cmd.SetArgs([]string{"pending", "add", "9", "--review-id", "RV123", "--path", "file.go", "--line", "7", "--side", "right", "--body", "note"})
@@ -167,6 +273,7 @@ func TestReviewSubmit(t *testing.T) {
 
 	repo, err := ghrepo.FromFullName("ORG/REPO")
 	require.NoError(t, err)
+	shared.StubFinderForRunCommandStyleTests(t, "5", &api.PullRequest{Number: 5}, repo)
 	f, stdout, stderr := newPendingTestFactory(t, reg, repo, nil)
 	cmd := NewCmdReview(f, nil)
 	cmd.SetArgs([]string{"pending", "submit", "5", "--review-id", "RV123", "--event", "approve"})
@@ -213,6 +320,10 @@ func TestReviewOpen_RepoOverrideWithoutGit(t *testing.T) {
 			},
 		}),
 	)
+
+	overrideRepo, overrideErr := ghrepo.FromFullName("octo/demo")
+	require.NoError(t, overrideErr)
+	shared.StubFinderForRunCommandStyleTests(t, "42", &api.PullRequest{Number: 42}, overrideRepo)
 
 	noRepoErr := errors.New("no repository context")
 	f, stdout, stderr := newPendingTestFactory(t, reg, nil, noRepoErr)

--- a/pkg/cmd/pr/review/pending_shared.go
+++ b/pkg/cmd/pr/review/pending_shared.go
@@ -1,0 +1,141 @@
+package review
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+// PendingReviewSharedOptions contains flags and dependencies shared by review subcommands
+// that operate on pending reviews or REST helpers.
+type PendingReviewSharedOptions struct {
+	IO         *iostreams.IOStreams
+	HttpClient func() (*http.Client, error)
+	Config     func() (gh.Config, error)
+	Org        string
+	Repo       string
+	Pull       int
+	Hostname   string
+}
+
+// RegisterFlags adds the standard repository-related flags to the provided command.
+func (o *PendingReviewSharedOptions) RegisterFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.Org, "org", "", "Organization that owns the repository")
+	cmd.Flags().StringVar(&o.Repo, "repo", "", "Repository name")
+	cmd.Flags().IntVar(&o.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().StringVar(&o.Hostname, "hostname", "", "GitHub hostname (default to authenticated host)")
+}
+
+// ValidateRepoArgs ensures repository flags are populated with valid values.
+func (o *PendingReviewSharedOptions) ValidateRepoArgs() error {
+	if strings.TrimSpace(o.Org) == "" {
+		return cmdutil.FlagErrorf("--org is required")
+	}
+	if strings.TrimSpace(o.Repo) == "" {
+		return cmdutil.FlagErrorf("--repo is required")
+	}
+	if o.Pull <= 0 {
+		return cmdutil.FlagErrorf("invalid value for --pr: %d", o.Pull)
+	}
+	return nil
+}
+
+// BuildService constructs a review service using the configured HTTP client and hostname.
+func (o *PendingReviewSharedOptions) BuildService() (*reviewapi.Service, error) {
+	cfg, err := o.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	host, _ := cfg.Authentication().DefaultHost()
+	if o.Hostname != "" {
+		host = o.Hostname
+	}
+
+	httpClient, err := o.HttpClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return reviewapi.NewService(httpClient, host), nil
+}
+
+// NormalizeSide validates and normalizes a diff side identifier.
+func NormalizeSide(side string) (string, error) {
+	upper := strings.ToUpper(strings.TrimSpace(side))
+	switch upper {
+	case "LEFT", "RIGHT":
+		return upper, nil
+	default:
+		return "", fmt.Errorf("invalid side %q: must be LEFT or RIGHT", side)
+	}
+}
+
+// NormalizeEvent validates and normalizes a review submission event.
+func NormalizeEvent(event string) (string, error) {
+	upper := strings.ToUpper(strings.TrimSpace(event))
+	switch upper {
+	case "APPROVE", "COMMENT", "REQUEST_CHANGES":
+		return upper, nil
+	default:
+		return "", fmt.Errorf("invalid event %q: must be APPROVE, COMMENT, or REQUEST_CHANGES", event)
+	}
+}
+
+// EncodeJSON writes the provided payload as JSON to the command output stream.
+func EncodeJSON(ioStreams *iostreams.IOStreams, payload interface{}) error {
+	encoder := json.NewEncoder(ioStreams.Out)
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(payload)
+}
+
+// FormatTime returns the RFC3339 representation of the provided timestamp or nil when absent.
+func FormatTime(t *time.Time) interface{} {
+	if t == nil {
+		return nil
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// FormatReviewRunError maps service errors to user-friendly messages.
+func FormatReviewRunError(err error, prefix string) error {
+	switch e := err.(type) {
+	case *reviewapi.PullRequestNotFoundError:
+		return fmt.Errorf("%s: %w", prefix, e)
+	case *reviewapi.ReviewNotFoundError:
+		return fmt.Errorf("%s: %w", prefix, e)
+	case *reviewapi.CommentNotFoundError:
+		return fmt.Errorf("%s: %w", prefix, e)
+	}
+
+	var httpErr api.HTTPError
+	if errors.As(err, &httpErr) {
+		switch httpErr.StatusCode {
+		case http.StatusForbidden:
+			return fmt.Errorf("%s: access denied (%s)", prefix, httpErr.Message)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s: resource not found (%s)", prefix, httpErr.Message)
+		case http.StatusUnprocessableEntity:
+			return fmt.Errorf("%s: validation failed (%s)", prefix, httpErr.Message)
+		default:
+			return fmt.Errorf("%s: %s", prefix, httpErr.Error())
+		}
+	}
+
+	var gqlErr api.GraphQLError
+	if errors.As(err, &gqlErr) {
+		return fmt.Errorf("%s: %s", prefix, gqlErr.Error())
+	}
+
+	return fmt.Errorf("%s: %w", prefix, err)
+}

--- a/pkg/cmd/pr/review/pending_shared.go
+++ b/pkg/cmd/pr/review/pending_shared.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
+	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/spf13/cobra"
@@ -21,54 +23,58 @@ import (
 type PendingReviewSharedOptions struct {
 	IO         *iostreams.IOStreams
 	HttpClient func() (*http.Client, error)
+	Config     func() (gh.Config, error)
 	BaseRepo   func() (ghrepo.Interface, error)
+	Repo       ghrepo.Interface
+	Selector   string
 	Pull       int
-
-	repo ghrepo.Interface
+	Hostname   string
 }
 
-// RegisterFlags adds the shared pull request flag to the provided command.
+// RegisterFlags adds the standard repository-related flags to the provided command.
 func (o *PendingReviewSharedOptions) RegisterFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&o.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().StringVar(&o.Hostname, "hostname", "", "GitHub hostname (default to authenticated host)")
 }
 
-// ValidateInputs ensures required arguments are populated with valid values.
-func (o *PendingReviewSharedOptions) ValidateInputs() error {
-	if o.Pull <= 0 {
-		return cmdutil.FlagErrorf("invalid value for --pr: %d", o.Pull)
+// ResolvePullRequest resolves the repository and pull request number for a command invocation.
+func (o *PendingReviewSharedOptions) ResolvePullRequest() error {
+	repo, number, err := shared.ResolvePullRequest(o.BaseRepo, o.Selector, o.Pull)
+	if err != nil {
+		return err
 	}
+	if number <= 0 {
+		return cmdutil.FlagErrorf("must specify a pull request via --pr or as an argument")
+	}
+	o.Repo = repo
+	o.Pull = number
 	return nil
 }
 
-// ResolveRepo returns the repository associated with the command context.
-func (o *PendingReviewSharedOptions) ResolveRepo() (ghrepo.Interface, error) {
-	if o.repo != nil {
-		return o.repo, nil
-	}
-	if o.BaseRepo == nil {
-		return nil, errors.New("repository resolver is not configured")
-	}
-	repo, err := o.BaseRepo()
+// BuildService constructs a review service using the configured HTTP client and hostname.
+func (o *PendingReviewSharedOptions) BuildService() (*reviewapi.Service, error) {
+	cfg, err := o.Config()
 	if err != nil {
 		return nil, err
 	}
-	o.repo = repo
-	return repo, nil
-}
 
-// BuildService constructs a review service using the configured HTTP client and repo host.
-func (o *PendingReviewSharedOptions) BuildService() (*reviewapi.Service, ghrepo.Interface, error) {
-	repo, err := o.ResolveRepo()
-	if err != nil {
-		return nil, nil, err
+	host := ""
+	if o.Repo != nil {
+		host = o.Repo.RepoHost()
+	}
+	if host == "" {
+		host, _ = cfg.Authentication().DefaultHost()
+	}
+	if o.Hostname != "" {
+		host = o.Hostname
 	}
 
 	httpClient, err := o.HttpClient()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return reviewapi.NewService(httpClient, repo.RepoHost()), repo, nil
+	return reviewapi.NewService(httpClient, host), nil
 }
 
 // NormalizeSide validates and normalizes a diff side identifier.

--- a/pkg/cmd/pr/review/pending_shared.go
+++ b/pkg/cmd/pr/review/pending_shared.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
-	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/spf13/cobra"
 )
@@ -21,33 +20,47 @@ import (
 // PendingReviewSharedOptions contains flags and dependencies shared by review subcommands
 // that operate on pending reviews or REST helpers.
 type PendingReviewSharedOptions struct {
-	IO         *iostreams.IOStreams
-	HttpClient func() (*http.Client, error)
-	Config     func() (gh.Config, error)
-	BaseRepo   func() (ghrepo.Interface, error)
-	Repo       ghrepo.Interface
-	Selector   string
-	Pull       int
-	Hostname   string
+	IO          *iostreams.IOStreams
+	HttpClient  func() (*http.Client, error)
+	Config      func() (gh.Config, error)
+	Finder      shared.PRFinder
+	Repo        ghrepo.Interface
+	SelectorArg string
+	PullFlag    int
+	Pull        int
+	Hostname    string
 }
 
 // RegisterFlags adds the standard repository-related flags to the provided command.
 func (o *PendingReviewSharedOptions) RegisterFlags(cmd *cobra.Command) {
-	cmd.Flags().IntVar(&o.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().IntVar(&o.PullFlag, "pr", 0, "Pull request number")
 	cmd.Flags().StringVar(&o.Hostname, "hostname", "", "GitHub hostname (default to authenticated host)")
 }
 
 // ResolvePullRequest resolves the repository and pull request number for a command invocation.
 func (o *PendingReviewSharedOptions) ResolvePullRequest() error {
-	repo, number, err := shared.ResolvePullRequest(o.BaseRepo, o.Selector, o.Pull)
+	if o.Finder == nil {
+		return errors.New("pull request finder is not configured")
+	}
+
+	selector, err := shared.NormalizePullRequestSelector(o.SelectorArg, o.PullFlag)
 	if err != nil {
 		return err
 	}
-	if number <= 0 {
-		return cmdutil.FlagErrorf("must specify a pull request via --pr or as an argument")
+	o.SelectorArg = selector
+
+	findOptions := shared.FindOptions{
+		Selector:        selector,
+		Fields:          []string{"number"},
+		DisableProgress: true,
 	}
+	pr, repo, err := o.Finder.Find(findOptions)
+	if err != nil {
+		return err
+	}
+
 	o.Repo = repo
-	o.Pull = number
+	o.Pull = pr.Number
 	return nil
 }
 

--- a/pkg/cmd/pr/review/pending_shared.go
+++ b/pkg/cmd/pr/review/pending_shared.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -21,53 +21,54 @@ import (
 type PendingReviewSharedOptions struct {
 	IO         *iostreams.IOStreams
 	HttpClient func() (*http.Client, error)
-	Config     func() (gh.Config, error)
-	Org        string
-	Repo       string
+	BaseRepo   func() (ghrepo.Interface, error)
 	Pull       int
-	Hostname   string
+
+	repo ghrepo.Interface
 }
 
-// RegisterFlags adds the standard repository-related flags to the provided command.
+// RegisterFlags adds the shared pull request flag to the provided command.
 func (o *PendingReviewSharedOptions) RegisterFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Org, "org", "", "Organization that owns the repository")
-	cmd.Flags().StringVar(&o.Repo, "repo", "", "Repository name")
 	cmd.Flags().IntVar(&o.Pull, "pr", 0, "Pull request number")
-	cmd.Flags().StringVar(&o.Hostname, "hostname", "", "GitHub hostname (default to authenticated host)")
 }
 
-// ValidateRepoArgs ensures repository flags are populated with valid values.
-func (o *PendingReviewSharedOptions) ValidateRepoArgs() error {
-	if strings.TrimSpace(o.Org) == "" {
-		return cmdutil.FlagErrorf("--org is required")
-	}
-	if strings.TrimSpace(o.Repo) == "" {
-		return cmdutil.FlagErrorf("--repo is required")
-	}
+// ValidateInputs ensures required arguments are populated with valid values.
+func (o *PendingReviewSharedOptions) ValidateInputs() error {
 	if o.Pull <= 0 {
 		return cmdutil.FlagErrorf("invalid value for --pr: %d", o.Pull)
 	}
 	return nil
 }
 
-// BuildService constructs a review service using the configured HTTP client and hostname.
-func (o *PendingReviewSharedOptions) BuildService() (*reviewapi.Service, error) {
-	cfg, err := o.Config()
+// ResolveRepo returns the repository associated with the command context.
+func (o *PendingReviewSharedOptions) ResolveRepo() (ghrepo.Interface, error) {
+	if o.repo != nil {
+		return o.repo, nil
+	}
+	if o.BaseRepo == nil {
+		return nil, errors.New("repository resolver is not configured")
+	}
+	repo, err := o.BaseRepo()
 	if err != nil {
 		return nil, err
 	}
+	o.repo = repo
+	return repo, nil
+}
 
-	host, _ := cfg.Authentication().DefaultHost()
-	if o.Hostname != "" {
-		host = o.Hostname
+// BuildService constructs a review service using the configured HTTP client and repo host.
+func (o *PendingReviewSharedOptions) BuildService() (*reviewapi.Service, ghrepo.Interface, error) {
+	repo, err := o.ResolveRepo()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	httpClient, err := o.HttpClient()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return reviewapi.NewService(httpClient, host), nil
+	return reviewapi.NewService(httpClient, repo.RepoHost()), repo, nil
 }
 
 // NormalizeSide validates and normalizes a diff side identifier.

--- a/pkg/cmd/pr/review/review.go
+++ b/pkg/cmd/pr/review/review.go
@@ -142,6 +142,8 @@ func NewCmdReview(f *cmdutil.Factory, runF func(*ReviewOptions) error) *cobra.Co
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Specify the body of a review")
 	cmd.Flags().StringVarP(&bodyFile, "body-file", "F", "", "Read body text from `file` (use \"-\" to read from standard input)")
 
+	cmd.AddCommand(NewCmdReviewPending(f))
+
 	return cmd
 }
 

--- a/pkg/cmd/pr/reviewapi/reply_comment.go
+++ b/pkg/cmd/pr/reviewapi/reply_comment.go
@@ -1,0 +1,158 @@
+package reviewapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cli/cli/v2/api"
+)
+
+// PendingReviewError signals that the reply cannot proceed until pending reviews are submitted.
+type PendingReviewError struct {
+	Message string
+	Err     error
+}
+
+func (e *PendingReviewError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return "pending review must be submitted before replying"
+}
+
+func (e *PendingReviewError) Unwrap() error {
+	return e.Err
+}
+
+// CommentNotFoundError indicates the target comment could not be located.
+type CommentNotFoundError struct {
+	Owner     string
+	Repo      string
+	Number    int
+	CommentID int64
+	Err       error
+}
+
+func (e *CommentNotFoundError) Error() string {
+	return fmt.Sprintf("comment %d not found for %s/%s#%d", e.CommentID, e.Owner, e.Repo, e.Number)
+}
+
+func (e *CommentNotFoundError) Unwrap() error {
+	return e.Err
+}
+
+// Reply represents the response schema for a comment reply.
+type Reply struct {
+	ID          int64     `json:"id"`
+	InReplyToID *int64    `json:"in_reply_to_id"`
+	Body        string    `json:"body"`
+	User        UserLogin `json:"user"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// ReplyToComment posts a threaded reply to an existing review comment.
+func (s *Service) ReplyToComment(ctx context.Context, owner, repo string, prNumber int, commentID int64, body string) (*Reply, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/comments/%d/replies", owner, repo, prNumber, commentID)
+	var reply Reply
+	_, err := s.rest.PostJSON(ctx, path, nil, map[string]string{"body": body}, &reply)
+	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnprocessableEntity && isPendingReviewError(&httpErr) {
+			return nil, &PendingReviewError{Message: httpErr.Message, Err: err}
+		}
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, &CommentNotFoundError{Owner: owner, Repo: repo, Number: prNumber, CommentID: commentID, Err: err}
+		}
+		return nil, err
+	}
+
+	return &reply, nil
+}
+
+// SubmitPendingReviews submits all pending reviews for the provided reviewer.
+func (s *Service) SubmitPendingReviews(ctx context.Context, owner, repo string, prNumber int, reviewer string, summary string) (int, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, prNumber)
+	query := url.Values{}
+	query.Set("per_page", "100")
+
+	var pendingIDs []int64
+	nextPath := path
+	for {
+		var reviews []ReviewSummary
+		resp, err := s.rest.GetJSON(ctx, nextPath, query, &reviews)
+		if err != nil {
+			var httpErr api.HTTPError
+			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+				return 0, &PullRequestNotFoundError{Owner: owner, Repo: repo, Number: prNumber, Err: err}
+			}
+			return 0, err
+		}
+
+		for _, review := range reviews {
+			if !strings.EqualFold(review.User.Login, reviewer) {
+				continue
+			}
+			if !strings.EqualFold(review.State, "PENDING") {
+				continue
+			}
+			pendingIDs = append(pendingIDs, review.ID)
+		}
+
+		next, ok := NextLink(resp.Header.Get("Link"))
+		if !ok {
+			break
+		}
+		nextPath = next
+		query = nil
+	}
+
+	count := 0
+	for _, id := range pendingIDs {
+		if err := s.submitReview(ctx, owner, repo, prNumber, id, summary); err != nil {
+			return count, err
+		}
+		count++
+	}
+
+	return count, nil
+}
+
+func (s *Service) submitReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64, summary string) error {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews/%d/events", owner, repo, prNumber, reviewID)
+	body := map[string]string{"event": "COMMENT"}
+	if summary != "" {
+		body["body"] = summary
+	}
+
+	_, err := s.rest.PostJSON(ctx, path, nil, body, &struct{}{})
+	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return &ReviewNotFoundError{Owner: owner, Repo: repo, Number: prNumber, ReviewID: reviewID, Err: err}
+		}
+		return err
+	}
+
+	return nil
+}
+
+func isPendingReviewError(err *api.HTTPError) bool {
+	needle := "pending review"
+	if strings.Contains(strings.ToLower(err.Message), needle) {
+		return true
+	}
+	for _, item := range err.Errors {
+		if strings.Contains(strings.ToLower(item.Message), needle) {
+			return true
+		}
+		if strings.Contains(strings.ToLower(item.Message), "user_id") && strings.Contains(strings.ToLower(item.Message), "pending review") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cmd/pr/reviewapi/rest_client.go
+++ b/pkg/cmd/pr/reviewapi/rest_client.go
@@ -1,0 +1,277 @@
+package reviewapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghinstance"
+)
+
+var (
+	retrySchedule = []time.Duration{
+		time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+	}
+)
+
+// RestResponse captures the outcome of a REST request.
+type RestResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+// RestClient issues REST requests with standardized headers and retry handling.
+type RestClient struct {
+	client *http.Client
+	host   string
+}
+
+// NewRestClient creates a RestClient bound to the provided HTTP client and GitHub host.
+func NewRestClient(client *http.Client, host string) *RestClient {
+	return &RestClient{client: client, host: host}
+}
+
+// GetJSON performs a GET request and unmarshals the response body into dest.
+func (c *RestClient) GetJSON(ctx context.Context, path string, query url.Values, dest interface{}) (*RestResponse, error) {
+	return c.doJSON(ctx, http.MethodGet, path, query, nil, dest)
+}
+
+// PostJSON performs a POST request and unmarshals the response body into dest.
+func (c *RestClient) PostJSON(ctx context.Context, path string, query url.Values, body interface{}, dest interface{}) (*RestResponse, error) {
+	return c.doJSON(ctx, http.MethodPost, path, query, body, dest)
+}
+
+// PutJSON performs a PUT request and unmarshals the response body into dest.
+func (c *RestClient) PutJSON(ctx context.Context, path string, query url.Values, body interface{}, dest interface{}) (*RestResponse, error) {
+	return c.doJSON(ctx, http.MethodPut, path, query, body, dest)
+}
+
+func (c *RestClient) doJSON(ctx context.Context, method string, path string, query url.Values, body interface{}, dest interface{}) (*RestResponse, error) {
+	var payload []byte
+	switch v := body.(type) {
+	case nil:
+	case []byte:
+		payload = v
+	default:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		payload = encoded
+	}
+
+	resp, err := c.do(ctx, method, path, query, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	if dest == nil || len(resp.Body) == 0 {
+		return resp, nil
+	}
+
+	if err := json.Unmarshal(resp.Body, dest); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (c *RestClient) do(ctx context.Context, method string, path string, query url.Values, body []byte) (*RestResponse, error) {
+	attempt := 0
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		req, err := c.buildRequest(ctx, method, path, query, body)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			if attempt < len(retrySchedule) && isRetryableNetErr(err) {
+				if sleepErr := sleep(ctx, retrySchedule[attempt]); sleepErr != nil {
+					return nil, sleepErr
+				}
+				attempt++
+				continue
+			}
+			return nil, err
+		}
+
+		if shouldRetryStatus(resp.StatusCode) {
+			if attempt < len(retrySchedule) {
+				delay := nextDelay(resp.Header, retrySchedule[attempt])
+				resp.Body.Close()
+				if sleepErr := sleep(ctx, delay); sleepErr != nil {
+					return nil, sleepErr
+				}
+				attempt++
+				continue
+			}
+
+			err = api.HandleHTTPError(resp)
+			resp.Body.Close()
+			return nil, err
+		}
+
+		if resp.StatusCode >= 400 {
+			err = api.HandleHTTPError(resp)
+			resp.Body.Close()
+			return nil, err
+		}
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		return &RestResponse{
+			StatusCode: resp.StatusCode,
+			Header:     resp.Header.Clone(),
+			Body:       bodyBytes,
+		}, nil
+	}
+}
+
+func (c *RestClient) buildRequest(ctx context.Context, method string, path string, query url.Values, body []byte) (*http.Request, error) {
+	endpoint := path
+	if !strings.HasPrefix(path, "http://") && !strings.HasPrefix(path, "https://") {
+		endpoint = ghinstance.RESTPrefix(c.host) + strings.TrimPrefix(path, "/")
+	}
+
+	if len(query) > 0 {
+		q := query.Encode()
+		if strings.Contains(endpoint, "?") {
+			endpoint += "&" + q
+		} else {
+			endpoint += "?" + q
+		}
+	}
+
+	var reader io.Reader
+	if len(body) > 0 {
+		reader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", restAcceptHeaderValue)
+	req.Header.Set(restAPIVersionHeader, restAPIVersionValue)
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return req, nil
+}
+
+func shouldRetryStatus(code int) bool {
+	if code == http.StatusTooManyRequests {
+		return true
+	}
+	return code >= 500 && code < 600
+}
+
+func isRetryableNetErr(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout() || netErr.Temporary()
+	}
+	return false
+}
+
+func nextDelay(headers http.Header, fallback time.Duration) time.Duration {
+	retryAfter := headers.Get("Retry-After")
+	if retryAfter == "" {
+		return fallback
+	}
+
+	if seconds, err := strconv.Atoi(retryAfter); err == nil {
+		d := time.Duration(seconds) * time.Second
+		if d > 0 {
+			return d
+		}
+	}
+
+	if ts, err := http.ParseTime(retryAfter); err == nil {
+		if until := time.Until(ts); until > 0 {
+			return until
+		}
+	}
+
+	return fallback
+}
+
+func sleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+
+	t := time.NewTimer(d)
+	defer t.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// NextLink extracts the "next" relation from a Link header if present.
+func NextLink(header string) (string, bool) {
+	if header == "" {
+		return "", false
+	}
+
+	parts := strings.Split(header, ",")
+	for _, part := range parts {
+		section := strings.TrimSpace(part)
+		if !strings.HasSuffix(section, "rel=\"next\"") {
+			continue
+		}
+
+		start := strings.Index(section, "<")
+		end := strings.Index(section, ">")
+		if start == -1 || end == -1 || end <= start+1 {
+			continue
+		}
+
+		target := section[start+1 : end]
+		u, err := url.Parse(target)
+		if err != nil {
+			return target, true
+		}
+
+		if u.Scheme != "" && u.Host != "" {
+			result := u.Path
+			if u.RawQuery != "" {
+				result += "?" + u.RawQuery
+			}
+			return result, true
+		}
+
+		return target, true
+	}
+
+	return "", false
+}

--- a/pkg/cmd/pr/reviewapi/review_flow.go
+++ b/pkg/cmd/pr/reviewapi/review_flow.go
@@ -1,0 +1,258 @@
+package reviewapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/cli/cli/v2/api"
+)
+
+type GraphQLReviewState struct {
+	ID          string
+	State       string
+	SubmittedAt *time.Time
+}
+
+type ReviewThread struct {
+	ID         string
+	Path       string
+	IsOutdated bool
+}
+
+type AddReviewThreadInput struct {
+	ReviewID  string
+	Path      string
+	Line      int
+	Side      string
+	StartLine *int
+	StartSide *string
+	Body      string
+}
+
+type CreateReviewComment struct {
+	Path     string `json:"path"`
+	Position int    `json:"position"`
+	Body     string `json:"body"`
+}
+
+type CreateReviewInput struct {
+	CommitID string
+	Event    string
+	Body     string
+	Comments []CreateReviewComment
+}
+
+type RESTReviewState struct {
+	ID          int64
+	State       string
+	SubmittedAt *time.Time
+}
+
+func (s *Service) OpenReview(ctx context.Context, owner, repo string, prNumber int, commitOID string) (*GraphQLReviewState, error) {
+	if commitOID == "" {
+		sha, err := s.PullRequestHeadSHA(ctx, owner, repo, prNumber)
+		if err != nil {
+			return nil, err
+		}
+		commitOID = sha
+	}
+
+	prID, err := s.pullRequestNodeID(ctx, owner, repo, prNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	query := `mutation AddPullRequestReview($pr:ID!,$oid:GitObjectID!){
+		addPullRequestReview(input:{pullRequestId:$pr,commitOID:$oid}){
+			pullRequestReview{ id state submittedAt }
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"pr":  prID,
+		"oid": commitOID,
+	}
+
+	var result struct {
+		AddPullRequestReview struct {
+			PullRequestReview struct {
+				ID          string     `json:"id"`
+				State       string     `json:"state"`
+				SubmittedAt *time.Time `json:"submittedAt"`
+			} `json:"pullRequestReview"`
+		} `json:"addPullRequestReview"`
+	}
+
+	if err := s.gql.GraphQL(s.host, query, variables, &result); err != nil {
+		return nil, err
+	}
+
+	review := result.AddPullRequestReview.PullRequestReview
+	return &GraphQLReviewState{ID: review.ID, State: review.State, SubmittedAt: review.SubmittedAt}, nil
+}
+
+func (s *Service) AddReviewThread(ctx context.Context, _owner, _repo string, _prNumber int, input AddReviewThreadInput) (*ReviewThread, error) {
+	query := `mutation AddPullRequestReviewThread($input: AddPullRequestReviewThreadInput!){
+		addPullRequestReviewThread(input:$input){
+			thread{ id path isOutdated }
+		}
+	}`
+
+	graphqlInput := map[string]interface{}{
+		"pullRequestReviewId": input.ReviewID,
+		"path":                input.Path,
+		"line":                input.Line,
+		"side":                input.Side,
+		"body":                input.Body,
+	}
+	if input.StartLine != nil {
+		graphqlInput["startLine"] = *input.StartLine
+	}
+	if input.StartSide != nil {
+		graphqlInput["startSide"] = *input.StartSide
+	}
+
+	variables := map[string]interface{}{"input": graphqlInput}
+
+	var result struct {
+		AddPullRequestReviewThread struct {
+			Thread struct {
+				ID         string `json:"id"`
+				Path       string `json:"path"`
+				IsOutdated bool   `json:"isOutdated"`
+			} `json:"thread"`
+		} `json:"addPullRequestReviewThread"`
+	}
+
+	if err := s.gql.GraphQL(s.host, query, variables, &result); err != nil {
+		return nil, err
+	}
+
+	thread := result.AddPullRequestReviewThread.Thread
+	return &ReviewThread{ID: thread.ID, Path: thread.Path, IsOutdated: thread.IsOutdated}, nil
+}
+
+func (s *Service) SubmitReview(ctx context.Context, _owner, _repo string, _prNumber int, reviewID, event, body string) (*GraphQLReviewState, error) {
+	query := `mutation SubmitPullRequestReview($input: SubmitPullRequestReviewInput!){
+		submitPullRequestReview(input:$input){
+			pullRequestReview{ id state submittedAt }
+		}
+	}`
+
+	graphqlInput := map[string]interface{}{
+		"pullRequestReviewId": reviewID,
+		"event":               event,
+	}
+	if body != "" {
+		graphqlInput["body"] = body
+	}
+
+	variables := map[string]interface{}{"input": graphqlInput}
+
+	var result struct {
+		SubmitPullRequestReview struct {
+			PullRequestReview struct {
+				ID          string     `json:"id"`
+				State       string     `json:"state"`
+				SubmittedAt *time.Time `json:"submittedAt"`
+			} `json:"pullRequestReview"`
+		} `json:"submitPullRequestReview"`
+	}
+
+	if err := s.gql.GraphQL(s.host, query, variables, &result); err != nil {
+		return nil, err
+	}
+
+	review := result.SubmitPullRequestReview.PullRequestReview
+	return &GraphQLReviewState{ID: review.ID, State: review.State, SubmittedAt: review.SubmittedAt}, nil
+}
+
+func (s *Service) CreateReviewREST(ctx context.Context, owner, repo string, prNumber int, input CreateReviewInput) (*RESTReviewState, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, prNumber)
+
+	body := map[string]interface{}{}
+	if input.CommitID != "" {
+		body["commit_id"] = input.CommitID
+	}
+	if input.Event != "" {
+		body["event"] = input.Event
+	}
+	if input.Body != "" {
+		body["body"] = input.Body
+	}
+	if len(input.Comments) > 0 {
+		body["comments"] = input.Comments
+	}
+
+	var response struct {
+		ID          int64      `json:"id"`
+		State       string     `json:"state"`
+		SubmittedAt *time.Time `json:"submitted_at"`
+	}
+
+	_, err := s.rest.PostJSON(ctx, path, nil, body, &response)
+	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, &PullRequestNotFoundError{Owner: owner, Repo: repo, Number: prNumber, Err: err}
+		}
+		return nil, err
+	}
+
+	return &RESTReviewState{ID: response.ID, State: response.State, SubmittedAt: response.SubmittedAt}, nil
+}
+
+func (s *Service) pullRequestNodeID(ctx context.Context, owner, repo string, prNumber int) (string, error) {
+	query := `query PullRequestID($owner:String!,$name:String!,$number:Int!){
+		repository(owner:$owner,name:$name){
+			pullRequest(number:$number){ id }
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"owner":  owner,
+		"name":   repo,
+		"number": prNumber,
+	}
+
+	var result struct {
+		Repository struct {
+			PullRequest struct {
+				ID string `json:"id"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	}
+
+	if err := s.gql.GraphQL(s.host, query, variables, &result); err != nil {
+		return "", err
+	}
+
+	if result.Repository.PullRequest.ID == "" {
+		return "", &PullRequestNotFoundError{Owner: owner, Repo: repo, Number: prNumber, Err: errors.New("pull request not found")}
+	}
+
+	return result.Repository.PullRequest.ID, nil
+}
+
+func (s *Service) PullRequestHeadSHA(ctx context.Context, owner, repo string, prNumber int) (string, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, prNumber)
+	var pr struct {
+		Head struct {
+			SHA string `json:"sha"`
+		} `json:"head"`
+	}
+
+	_, err := s.rest.GetJSON(ctx, path, nil, &pr)
+	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return "", &PullRequestNotFoundError{Owner: owner, Repo: repo, Number: prNumber, Err: err}
+		}
+		return "", err
+	}
+
+	return pr.Head.SHA, nil
+}

--- a/pkg/cmd/pr/reviewapi/see_comments.go
+++ b/pkg/cmd/pr/reviewapi/see_comments.go
@@ -1,0 +1,172 @@
+package reviewapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cli/cli/v2/api"
+)
+
+// ReviewComment represents the minimal schema required by the commands.
+type ReviewComment struct {
+	ID                  int64     `json:"id"`
+	PullRequestReviewID *int64    `json:"pull_request_review_id"`
+	InReplyToID         *int64    `json:"in_reply_to_id"`
+	Path                string    `json:"path"`
+	Line                *int      `json:"line"`
+	Side                *string   `json:"side"`
+	Body                string    `json:"body"`
+	User                UserLogin `json:"user"`
+	CreatedAt           time.Time `json:"created_at"`
+}
+
+// UserLogin captures nested login fields in API responses.
+type UserLogin struct {
+	Login string `json:"login"`
+}
+
+// ReviewSummary contains metadata required to locate submitted reviews.
+type ReviewSummary struct {
+	ID          int64      `json:"id"`
+	SubmittedAt *time.Time `json:"submitted_at"`
+	User        UserLogin  `json:"user"`
+	State       string     `json:"state"`
+}
+
+// ReviewNotFoundError indicates a review lookup failed.
+type ReviewNotFoundError struct {
+	Owner    string
+	Repo     string
+	Number   int
+	ReviewID int64
+	Err      error
+}
+
+func (e *ReviewNotFoundError) Error() string {
+	return fmt.Sprintf("review %d not found for %s/%s#%d", e.ReviewID, e.Owner, e.Repo, e.Number)
+}
+
+func (e *ReviewNotFoundError) Unwrap() error {
+	return e.Err
+}
+
+// PullRequestNotFoundError indicates the target pull request is missing or inaccessible.
+type PullRequestNotFoundError struct {
+	Owner  string
+	Repo   string
+	Number int
+	Err    error
+}
+
+func (e *PullRequestNotFoundError) Error() string {
+	return fmt.Sprintf("pull request %s/%s#%d not found", e.Owner, e.Repo, e.Number)
+}
+
+func (e *PullRequestNotFoundError) Unwrap() error {
+	return e.Err
+}
+
+// NoSubmittedReviewError indicates no submitted review exists for the given reviewer.
+type NoSubmittedReviewError struct {
+	Reviewer string
+	Number   int
+}
+
+func (e *NoSubmittedReviewError) Error() string {
+	return fmt.Sprintf("no submitted reviews found for %s on pull request #%d", e.Reviewer, e.Number)
+}
+
+// LatestReviewID resolves the latest submitted review for the given reviewer.
+func (s *Service) LatestReviewID(ctx context.Context, owner, repo string, prNumber int, reviewer string) (int64, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, repo, prNumber)
+	query := url.Values{}
+	query.Set("per_page", "100")
+
+	var latestID int64
+	var latestTime time.Time
+	found := false
+
+	nextPath := path
+	for {
+		var reviews []ReviewSummary
+		resp, err := s.rest.GetJSON(ctx, nextPath, query, &reviews)
+		if err != nil {
+			var httpErr api.HTTPError
+			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+				return 0, &PullRequestNotFoundError{Owner: owner, Repo: repo, Number: prNumber, Err: err}
+			}
+			return 0, err
+		}
+
+		for _, review := range reviews {
+			if review.SubmittedAt == nil {
+				continue
+			}
+			if !strings.EqualFold(review.User.Login, reviewer) {
+				continue
+			}
+			if !found || review.SubmittedAt.After(latestTime) {
+				latestTime = *review.SubmittedAt
+				latestID = review.ID
+				found = true
+			}
+		}
+
+		link := resp.Header.Get("Link")
+		next, ok := NextLink(link)
+		if !ok {
+			break
+		}
+		nextPath = next
+		query = nil
+	}
+
+	if !found {
+		return 0, &NoSubmittedReviewError{Reviewer: reviewer, Number: prNumber}
+	}
+
+	return latestID, nil
+}
+
+// ReviewComments fetches all inline comments for the specified review.
+func (s *Service) ReviewComments(ctx context.Context, owner, repo string, prNumber int, reviewID int64) ([]ReviewComment, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews/%d/comments", owner, repo, prNumber, reviewID)
+	query := url.Values{}
+	query.Set("per_page", "100")
+
+	var allComments []ReviewComment
+	nextPath := path
+	for {
+		var comments []ReviewComment
+		resp, err := s.rest.GetJSON(ctx, nextPath, query, &comments)
+		if err != nil {
+			var httpErr api.HTTPError
+			if errors.As(err, &httpErr) {
+				if httpErr.StatusCode == http.StatusNotFound {
+					return nil, &ReviewNotFoundError{Owner: owner, Repo: repo, Number: prNumber, ReviewID: reviewID, Err: err}
+				}
+				if httpErr.StatusCode == http.StatusForbidden {
+					return nil, err
+				}
+			}
+			return nil, err
+		}
+
+		allComments = append(allComments, comments...)
+
+		link := resp.Header.Get("Link")
+		next, ok := NextLink(link)
+		if !ok {
+			break
+		}
+		nextPath = next
+		query = nil
+	}
+
+	return allComments, nil
+}

--- a/pkg/cmd/pr/reviewapi/service.go
+++ b/pkg/cmd/pr/reviewapi/service.go
@@ -1,0 +1,62 @@
+package reviewapi
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cli/cli/v2/api"
+)
+
+const (
+	restAcceptHeaderValue = "application/vnd.github+json"
+	restAPIVersionHeader  = "X-GitHub-Api-Version"
+	restAPIVersionValue   = "2022-11-28"
+)
+
+// Service provides access to GitHub REST and GraphQL APIs needed for review management commands.
+type Service struct {
+	rest *RestClient
+	gql  *api.Client
+	host string
+}
+
+// NewService constructs a Service using the provided HTTP client and hostname.
+func NewService(httpClient *http.Client, host string) *Service {
+	restClient := NewRestClient(httpClient, host)
+	gqlClient := api.NewClientFromHTTP(httpClient)
+
+	return &Service{
+		rest: restClient,
+		gql:  gqlClient,
+		host: host,
+	}
+}
+
+// Host returns the configured API hostname.
+func (s *Service) Host() string {
+	return s.host
+}
+
+// Rest exposes the REST client wrapper.
+func (s *Service) Rest() *RestClient {
+	return s.rest
+}
+
+// GraphQL exposes the GraphQL client.
+func (s *Service) GraphQL() *api.Client {
+	return s.gql
+}
+
+// CurrentLogin returns the login name for the authenticated user.
+func (s *Service) CurrentLogin(ctx context.Context) (string, error) {
+	var user struct {
+		Login string `json:"login"`
+	}
+
+	_, err := s.rest.GetJSON(ctx, "/user", nil, &user)
+	if err != nil {
+		return "", err
+	}
+
+	return user.Login, nil
+}

--- a/pkg/cmd/pr/see-comments/see_comments.go
+++ b/pkg/cmd/pr/see-comments/see_comments.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
+	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/spf13/cobra"
@@ -19,31 +21,40 @@ import (
 type SeeCommentsOptions struct {
 	IO         *iostreams.IOStreams
 	HttpClient func() (*http.Client, error)
+	Config     func() (gh.Config, error)
 	BaseRepo   func() (ghrepo.Interface, error)
 
+	Repo     ghrepo.Interface
+	Selector string
 	Pull     int
 	ReviewID int64
 	Latest   bool
 	Reviewer string
-
-	repo ghrepo.Interface
+	Hostname string
 }
 
 func NewCmdSeeComments(f *cmdutil.Factory) *cobra.Command {
 	opts := &SeeCommentsOptions{
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
-		BaseRepo:   f.BaseRepo,
+		Config:     f.Config,
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return f.BaseRepo()
+		},
 	}
 
 	cmd := &cobra.Command{
-		Use:   "see-comments",
+		Use:   "see-comments [<number> | <url> | <owner>/<repo>#<number>]",
 		Short: "List review comments for a pull request review",
 		Long: heredoc.Doc(`
-			Fetch inline review comments for a pull request review by identifier or by resolving
-			the latest submitted review from a reviewer.
-		`),
+            Fetch inline review comments for a pull request review by identifier or by resolving
+            the latest submitted review from a reviewer.
+        `),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.Selector = args[0]
+			}
 			if opts.ReviewID == 0 && !opts.Latest {
 				return cmdutil.FlagErrorf("must specify --review-id or --latest")
 			}
@@ -52,9 +63,6 @@ func NewCmdSeeComments(f *cmdutil.Factory) *cobra.Command {
 			}
 			if opts.Reviewer != "" && !opts.Latest {
 				return cmdutil.FlagErrorf("--reviewer is only valid with --latest")
-			}
-			if opts.Pull <= 0 {
-				return cmdutil.FlagErrorf("invalid value for --pr: %d", opts.Pull)
 			}
 
 			return runSeeComments(cmd.Context(), opts)
@@ -65,16 +73,30 @@ func NewCmdSeeComments(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().Int64Var(&opts.ReviewID, "review-id", 0, "Pull request review identifier")
 	cmd.Flags().BoolVar(&opts.Latest, "latest", false, "Resolve the latest submitted review")
 	cmd.Flags().StringVar(&opts.Reviewer, "reviewer", "", "Reviewer login when using --latest")
-
-	_ = cmd.MarkFlagRequired("pr")
+	cmd.Flags().StringVar(&opts.Hostname, "hostname", "", "GitHub hostname (default to authenticated host)")
 
 	return cmd
 }
 
 func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
-	repo, err := opts.resolveRepo()
+	repo, number, err := shared.ResolvePullRequest(opts.BaseRepo, opts.Selector, opts.Pull)
 	if err != nil {
 		return err
+	}
+	opts.Repo = repo
+	opts.Pull = number
+
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	host := repo.RepoHost()
+	if host == "" {
+		host, _ = cfg.Authentication().DefaultHost()
+	}
+	if opts.Hostname != "" {
+		host = opts.Hostname
 	}
 
 	httpClient, err := opts.HttpClient()
@@ -82,10 +104,7 @@ func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
 		return err
 	}
 
-	service := reviewapi.NewService(httpClient, repo.RepoHost())
-	owner := repo.RepoOwner()
-	name := repo.RepoName()
-	fullName := ghrepo.FullName(repo)
+	service := reviewapi.NewService(httpClient, host)
 
 	reviewID := opts.ReviewID
 	if opts.Latest {
@@ -93,19 +112,19 @@ func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
 		if reviewer == "" {
 			reviewer, err = service.CurrentLogin(ctx)
 			if err != nil {
-				return formatAPIError(err, fullName, "failed to resolve authenticated user")
+				return formatAPIError(err, "failed to resolve authenticated user")
 			}
 		}
 
-		reviewID, err = service.LatestReviewID(ctx, owner, name, opts.Pull, reviewer)
+		reviewID, err = service.LatestReviewID(ctx, repo.RepoOwner(), repo.RepoName(), opts.Pull, reviewer)
 		if err != nil {
-			return formatAPIError(err, fullName, "failed to locate latest review")
+			return formatAPIError(err, "failed to locate latest review")
 		}
 	}
 
-	comments, err := service.ReviewComments(ctx, owner, name, opts.Pull, reviewID)
+	comments, err := service.ReviewComments(ctx, repo.RepoOwner(), repo.RepoName(), opts.Pull, reviewID)
 	if err != nil {
-		return formatAPIError(err, fullName, "failed to fetch review comments")
+		return formatAPIError(err, "failed to fetch review comments")
 	}
 
 	encoder := json.NewEncoder(opts.IO.Out)
@@ -117,22 +136,7 @@ func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
 	return nil
 }
 
-func (o *SeeCommentsOptions) resolveRepo() (ghrepo.Interface, error) {
-	if o.repo != nil {
-		return o.repo, nil
-	}
-	if o.BaseRepo == nil {
-		return nil, errors.New("repository resolver is not configured")
-	}
-	repo, err := o.BaseRepo()
-	if err != nil {
-		return nil, err
-	}
-	o.repo = repo
-	return repo, nil
-}
-
-func formatAPIError(err error, fullName string, prefix string) error {
+func formatAPIError(err error, prefix string) error {
 	switch e := err.(type) {
 	case *reviewapi.PullRequestNotFoundError:
 		return fmt.Errorf("%s: %w", prefix, e)
@@ -146,9 +150,9 @@ func formatAPIError(err error, fullName string, prefix string) error {
 	if errors.As(err, &httpErr) {
 		switch httpErr.StatusCode {
 		case http.StatusForbidden:
-			return fmt.Errorf("%s: access denied for %s (%s)", prefix, fullName, httpErr.Message)
+			return fmt.Errorf("%s: access denied (%s)", prefix, httpErr.Message)
 		case http.StatusNotFound:
-			return fmt.Errorf("%s: resource not found in %s (%s)", prefix, fullName, httpErr.Message)
+			return fmt.Errorf("%s: resource not found (%s)", prefix, httpErr.Message)
 		case http.StatusUnprocessableEntity:
 			return fmt.Errorf("%s: validation failed (%s)", prefix, httpErr.Message)
 		default:

--- a/pkg/cmd/pr/see-comments/see_comments.go
+++ b/pkg/cmd/pr/see-comments/see_comments.go
@@ -1,0 +1,153 @@
+package see_comments
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type SeeCommentsOptions struct {
+	IO         *iostreams.IOStreams
+	HttpClient func() (*http.Client, error)
+	Config     func() (gh.Config, error)
+
+	Org      string
+	Repo     string
+	Pull     int
+	ReviewID int64
+	Latest   bool
+	Reviewer string
+	Hostname string
+}
+
+func NewCmdSeeComments(f *cmdutil.Factory) *cobra.Command {
+	opts := &SeeCommentsOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Config:     f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "see-comments",
+		Short: "List review comments for a pull request review",
+		Long: heredoc.Doc(`
+			Fetch inline review comments for a pull request review by identifier or by resolving
+			the latest submitted review from a reviewer.
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.ReviewID == 0 && !opts.Latest {
+				return cmdutil.FlagErrorf("must specify --review-id or --latest")
+			}
+			if opts.ReviewID != 0 && opts.Latest {
+				return cmdutil.FlagErrorf("flags --review-id and --latest are mutually exclusive")
+			}
+			if opts.Reviewer != "" && !opts.Latest {
+				return cmdutil.FlagErrorf("--reviewer is only valid with --latest")
+			}
+			if opts.Pull <= 0 {
+				return cmdutil.FlagErrorf("invalid value for --pr: %d", opts.Pull)
+			}
+
+			return runSeeComments(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Org, "org", "", "Organization that owns the repository")
+	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository name")
+	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().Int64Var(&opts.ReviewID, "review-id", 0, "Pull request review identifier")
+	cmd.Flags().BoolVar(&opts.Latest, "latest", false, "Resolve the latest submitted review")
+	cmd.Flags().StringVar(&opts.Reviewer, "reviewer", "", "Reviewer login when using --latest")
+	cmd.Flags().StringVar(&opts.Hostname, "hostname", "", "GitHub hostname (default to authenticated host)")
+
+	_ = cmd.MarkFlagRequired("org")
+	_ = cmd.MarkFlagRequired("repo")
+	_ = cmd.MarkFlagRequired("pr")
+
+	return cmd
+}
+
+func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	host, _ := cfg.Authentication().DefaultHost()
+	if opts.Hostname != "" {
+		host = opts.Hostname
+	}
+
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	service := reviewapi.NewService(httpClient, host)
+
+	reviewID := opts.ReviewID
+	if opts.Latest {
+		reviewer := opts.Reviewer
+		if reviewer == "" {
+			reviewer, err = service.CurrentLogin(ctx)
+			if err != nil {
+				return formatAPIError(err, opts, "failed to resolve authenticated user")
+			}
+		}
+
+		reviewID, err = service.LatestReviewID(ctx, opts.Org, opts.Repo, opts.Pull, reviewer)
+		if err != nil {
+			return formatAPIError(err, opts, "failed to locate latest review")
+		}
+	}
+
+	comments, err := service.ReviewComments(ctx, opts.Org, opts.Repo, opts.Pull, reviewID)
+	if err != nil {
+		return formatAPIError(err, opts, "failed to fetch review comments")
+	}
+
+	encoder := json.NewEncoder(opts.IO.Out)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(comments); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func formatAPIError(err error, opts *SeeCommentsOptions, prefix string) error {
+	switch e := err.(type) {
+	case *reviewapi.PullRequestNotFoundError:
+		return fmt.Errorf("%s: %w", prefix, e)
+	case *reviewapi.ReviewNotFoundError:
+		return fmt.Errorf("%s: %w", prefix, e)
+	case *reviewapi.NoSubmittedReviewError:
+		return fmt.Errorf("%s: %w", prefix, e)
+	}
+
+	var httpErr api.HTTPError
+	if errors.As(err, &httpErr) {
+		switch httpErr.StatusCode {
+		case http.StatusForbidden:
+			return fmt.Errorf("%s: access denied (%s)", prefix, httpErr.Message)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s: resource not found (%s)", prefix, httpErr.Message)
+		case http.StatusUnprocessableEntity:
+			return fmt.Errorf("%s: validation failed (%s)", prefix, httpErr.Message)
+		default:
+			return fmt.Errorf("%s: %s", prefix, httpErr.Error())
+		}
+	}
+
+	return fmt.Errorf("%s: %w", prefix, err)
+}

--- a/pkg/cmd/pr/see-comments/see_comments.go
+++ b/pkg/cmd/pr/see-comments/see_comments.go
@@ -10,7 +10,6 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
-	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -22,15 +21,14 @@ type SeeCommentsOptions struct {
 	IO         *iostreams.IOStreams
 	HttpClient func() (*http.Client, error)
 	Config     func() (gh.Config, error)
-	BaseRepo   func() (ghrepo.Interface, error)
+	Finder     shared.PRFinder
 
-	Repo     ghrepo.Interface
-	Selector string
-	Pull     int
-	ReviewID int64
-	Latest   bool
-	Reviewer string
-	Hostname string
+	SelectorArg string
+	PullFlag    int
+	ReviewID    int64
+	Latest      bool
+	Reviewer    string
+	Hostname    string
 }
 
 func NewCmdSeeComments(f *cmdutil.Factory) *cobra.Command {
@@ -38,9 +36,6 @@ func NewCmdSeeComments(f *cmdutil.Factory) *cobra.Command {
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
 		Config:     f.Config,
-		BaseRepo: func() (ghrepo.Interface, error) {
-			return f.BaseRepo()
-		},
 	}
 
 	cmd := &cobra.Command{
@@ -52,8 +47,9 @@ func NewCmdSeeComments(f *cmdutil.Factory) *cobra.Command {
         `),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Finder = shared.NewFinder(f)
 			if len(args) > 0 {
-				opts.Selector = args[0]
+				opts.SelectorArg = args[0]
 			}
 			if opts.ReviewID == 0 && !opts.Latest {
 				return cmdutil.FlagErrorf("must specify --review-id or --latest")
@@ -65,11 +61,17 @@ func NewCmdSeeComments(f *cmdutil.Factory) *cobra.Command {
 				return cmdutil.FlagErrorf("--reviewer is only valid with --latest")
 			}
 
+			selector, err := shared.NormalizePullRequestSelector(opts.SelectorArg, opts.PullFlag)
+			if err != nil {
+				return err
+			}
+			opts.SelectorArg = selector
+
 			return runSeeComments(cmd.Context(), opts)
 		},
 	}
 
-	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
+	cmd.Flags().IntVar(&opts.PullFlag, "pr", 0, "Pull request number")
 	cmd.Flags().Int64Var(&opts.ReviewID, "review-id", 0, "Pull request review identifier")
 	cmd.Flags().BoolVar(&opts.Latest, "latest", false, "Resolve the latest submitted review")
 	cmd.Flags().StringVar(&opts.Reviewer, "reviewer", "", "Reviewer login when using --latest")
@@ -79,19 +81,30 @@ func NewCmdSeeComments(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
-	repo, number, err := shared.ResolvePullRequest(opts.BaseRepo, opts.Selector, opts.Pull)
+	if opts.Finder == nil {
+		return errors.New("pull request finder is not configured")
+	}
+
+	findOptions := shared.FindOptions{
+		Selector:        opts.SelectorArg,
+		Fields:          []string{"number"},
+		DisableProgress: true,
+	}
+	pr, repo, err := opts.Finder.Find(findOptions)
 	if err != nil {
 		return err
 	}
-	opts.Repo = repo
-	opts.Pull = number
+	pullNumber := pr.Number
 
 	cfg, err := opts.Config()
 	if err != nil {
 		return err
 	}
 
-	host := repo.RepoHost()
+	host := ""
+	if repo != nil {
+		host = repo.RepoHost()
+	}
 	if host == "" {
 		host, _ = cfg.Authentication().DefaultHost()
 	}
@@ -105,7 +118,6 @@ func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
 	}
 
 	service := reviewapi.NewService(httpClient, host)
-
 	reviewID := opts.ReviewID
 	if opts.Latest {
 		reviewer := opts.Reviewer
@@ -116,13 +128,13 @@ func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
 			}
 		}
 
-		reviewID, err = service.LatestReviewID(ctx, repo.RepoOwner(), repo.RepoName(), opts.Pull, reviewer)
+		reviewID, err = service.LatestReviewID(ctx, repo.RepoOwner(), repo.RepoName(), pullNumber, reviewer)
 		if err != nil {
 			return formatAPIError(err, "failed to locate latest review")
 		}
 	}
 
-	comments, err := service.ReviewComments(ctx, repo.RepoOwner(), repo.RepoName(), opts.Pull, reviewID)
+	comments, err := service.ReviewComments(ctx, repo.RepoOwner(), repo.RepoName(), pullNumber, reviewID)
 	if err != nil {
 		return formatAPIError(err, "failed to fetch review comments")
 	}

--- a/pkg/cmd/pr/see-comments/see_comments.go
+++ b/pkg/cmd/pr/see-comments/see_comments.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
-	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/pr/reviewapi"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -19,22 +19,21 @@ import (
 type SeeCommentsOptions struct {
 	IO         *iostreams.IOStreams
 	HttpClient func() (*http.Client, error)
-	Config     func() (gh.Config, error)
+	BaseRepo   func() (ghrepo.Interface, error)
 
-	Org      string
-	Repo     string
 	Pull     int
 	ReviewID int64
 	Latest   bool
 	Reviewer string
-	Hostname string
+
+	repo ghrepo.Interface
 }
 
 func NewCmdSeeComments(f *cmdutil.Factory) *cobra.Command {
 	opts := &SeeCommentsOptions{
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
-		Config:     f.Config,
+		BaseRepo:   f.BaseRepo,
 	}
 
 	cmd := &cobra.Command{
@@ -62,30 +61,20 @@ func NewCmdSeeComments(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.Org, "org", "", "Organization that owns the repository")
-	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository name")
 	cmd.Flags().IntVar(&opts.Pull, "pr", 0, "Pull request number")
 	cmd.Flags().Int64Var(&opts.ReviewID, "review-id", 0, "Pull request review identifier")
 	cmd.Flags().BoolVar(&opts.Latest, "latest", false, "Resolve the latest submitted review")
 	cmd.Flags().StringVar(&opts.Reviewer, "reviewer", "", "Reviewer login when using --latest")
-	cmd.Flags().StringVar(&opts.Hostname, "hostname", "", "GitHub hostname (default to authenticated host)")
 
-	_ = cmd.MarkFlagRequired("org")
-	_ = cmd.MarkFlagRequired("repo")
 	_ = cmd.MarkFlagRequired("pr")
 
 	return cmd
 }
 
 func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
-	cfg, err := opts.Config()
+	repo, err := opts.resolveRepo()
 	if err != nil {
 		return err
-	}
-
-	host, _ := cfg.Authentication().DefaultHost()
-	if opts.Hostname != "" {
-		host = opts.Hostname
 	}
 
 	httpClient, err := opts.HttpClient()
@@ -93,7 +82,10 @@ func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
 		return err
 	}
 
-	service := reviewapi.NewService(httpClient, host)
+	service := reviewapi.NewService(httpClient, repo.RepoHost())
+	owner := repo.RepoOwner()
+	name := repo.RepoName()
+	fullName := ghrepo.FullName(repo)
 
 	reviewID := opts.ReviewID
 	if opts.Latest {
@@ -101,19 +93,19 @@ func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
 		if reviewer == "" {
 			reviewer, err = service.CurrentLogin(ctx)
 			if err != nil {
-				return formatAPIError(err, opts, "failed to resolve authenticated user")
+				return formatAPIError(err, fullName, "failed to resolve authenticated user")
 			}
 		}
 
-		reviewID, err = service.LatestReviewID(ctx, opts.Org, opts.Repo, opts.Pull, reviewer)
+		reviewID, err = service.LatestReviewID(ctx, owner, name, opts.Pull, reviewer)
 		if err != nil {
-			return formatAPIError(err, opts, "failed to locate latest review")
+			return formatAPIError(err, fullName, "failed to locate latest review")
 		}
 	}
 
-	comments, err := service.ReviewComments(ctx, opts.Org, opts.Repo, opts.Pull, reviewID)
+	comments, err := service.ReviewComments(ctx, owner, name, opts.Pull, reviewID)
 	if err != nil {
-		return formatAPIError(err, opts, "failed to fetch review comments")
+		return formatAPIError(err, fullName, "failed to fetch review comments")
 	}
 
 	encoder := json.NewEncoder(opts.IO.Out)
@@ -125,7 +117,22 @@ func runSeeComments(ctx context.Context, opts *SeeCommentsOptions) error {
 	return nil
 }
 
-func formatAPIError(err error, opts *SeeCommentsOptions, prefix string) error {
+func (o *SeeCommentsOptions) resolveRepo() (ghrepo.Interface, error) {
+	if o.repo != nil {
+		return o.repo, nil
+	}
+	if o.BaseRepo == nil {
+		return nil, errors.New("repository resolver is not configured")
+	}
+	repo, err := o.BaseRepo()
+	if err != nil {
+		return nil, err
+	}
+	o.repo = repo
+	return repo, nil
+}
+
+func formatAPIError(err error, fullName string, prefix string) error {
 	switch e := err.(type) {
 	case *reviewapi.PullRequestNotFoundError:
 		return fmt.Errorf("%s: %w", prefix, e)
@@ -139,9 +146,9 @@ func formatAPIError(err error, opts *SeeCommentsOptions, prefix string) error {
 	if errors.As(err, &httpErr) {
 		switch httpErr.StatusCode {
 		case http.StatusForbidden:
-			return fmt.Errorf("%s: access denied (%s)", prefix, httpErr.Message)
+			return fmt.Errorf("%s: access denied for %s (%s)", prefix, fullName, httpErr.Message)
 		case http.StatusNotFound:
-			return fmt.Errorf("%s: resource not found (%s)", prefix, httpErr.Message)
+			return fmt.Errorf("%s: resource not found in %s (%s)", prefix, fullName, httpErr.Message)
 		case http.StatusUnprocessableEntity:
 			return fmt.Errorf("%s: validation failed (%s)", prefix, httpErr.Message)
 		default:

--- a/pkg/cmd/pr/see-comments/see_comments_test.go
+++ b/pkg/cmd/pr/see-comments/see_comments_test.go
@@ -2,6 +2,7 @@ package see_comments
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/url"
 	"testing"
@@ -17,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer) {
+func newTestFactory(t *testing.T, rt http.RoundTripper, repo ghrepo.Interface, repoErr error) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer) {
 	t.Helper()
 	ios, _, stdout, stderr := iostreams.Test()
 	ios.SetStdoutTTY(false)
@@ -27,18 +28,27 @@ func newTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory, *byte
 	cfg := config.NewBlankConfig()
 	cfg.Authentication().SetDefaultHost("github.com", "default")
 
-	return &cmdutil.Factory{
+	factory := &cmdutil.Factory{
 		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
 		},
-		BaseRepo: func() (ghrepo.Interface, error) {
-			return ghrepo.NewWithHost("ORG", "REPO", "github.com"), nil
-		},
 		Config: func() (gh.Config, error) {
 			return cfg, nil
 		},
-	}, stdout, stderr
+	}
+
+	factory.BaseRepo = func() (ghrepo.Interface, error) {
+		if repoErr != nil {
+			return nil, repoErr
+		}
+		if repo != nil {
+			return repo, nil
+		}
+		return ghrepo.FromFullName("ORG/REPO")
+	}
+
+	return factory, stdout, stderr
 }
 
 func TestSeeComments_ByReviewID(t *testing.T) {
@@ -65,11 +75,13 @@ func TestSeeComments_ByReviewID(t *testing.T) {
 	)
 	reg.Register(matcher, httpmock.JSONResponse([]interface{}{comment}))
 
-	f, stdout, stderr := newTestFactory(t, reg)
+	repo, err := ghrepo.FromFullName("ORG/REPO")
+	require.NoError(t, err)
+	f, stdout, stderr := newTestFactory(t, reg, repo, nil)
 	cmd := NewCmdSeeComments(f)
-	cmd.SetArgs([]string{"--pr", "123", "--review-id", "456"})
+	cmd.SetArgs([]string{"123", "--review-id", "456"})
 
-	_, err := cmd.ExecuteC()
+	_, err = cmd.ExecuteC()
 	require.NoError(t, err)
 	assert.Equal(t, "", stderr.String())
 	assert.JSONEq(t, `[{"id":101,"pull_request_review_id":456,"in_reply_to_id":null,"path":"main.go","line":12,"side":"RIGHT","body":"Looks good","user":{"login":"octocat"},"created_at":"2024-01-02T03:04:05Z"}]`, stdout.String())
@@ -80,4 +92,29 @@ func TestSeeComments_ByReviewID(t *testing.T) {
 	req := reg.Requests[0]
 	assert.Equal(t, "application/vnd.github+json", req.Header.Get("Accept"))
 	assert.Equal(t, "2022-11-28", req.Header.Get("X-GitHub-Api-Version"))
+}
+
+func TestSeeComments_RepoOverrideWithoutGit(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	matcher := httpmock.WithHost(
+		httpmock.QueryMatcher("GET", "repos/octo/demo/pulls/55/reviews/77/comments", url.Values{"per_page": {"100"}}),
+		"api.github.com",
+	)
+	reg.Register(matcher, httpmock.JSONResponse([]interface{}{}))
+
+	// Simulate missing git repository by returning an error unless override is used.
+	noRepoErr := errors.New("no repository context")
+	f, stdout, stderr := newTestFactory(t, reg, nil, noRepoErr)
+	// Simulate passing -R by overriding BaseRepo before command execution.
+	f.BaseRepo = cmdutil.OverrideBaseRepoFunc(f, "octo/demo")
+
+	cmd := NewCmdSeeComments(f)
+	cmd.SetArgs([]string{"55", "--review-id", "77"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, "null", stdout.String())
 }

--- a/pkg/cmd/pr/see-comments/see_comments_test.go
+++ b/pkg/cmd/pr/see-comments/see_comments_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -77,6 +79,7 @@ func TestSeeComments_ByReviewID(t *testing.T) {
 
 	repo, err := ghrepo.FromFullName("ORG/REPO")
 	require.NoError(t, err)
+	shared.StubFinderForRunCommandStyleTests(t, "123", &api.PullRequest{Number: 123}, repo)
 	f, stdout, stderr := newTestFactory(t, reg, repo, nil)
 	cmd := NewCmdSeeComments(f)
 	cmd.SetArgs([]string{"123", "--review-id", "456"})
@@ -106,12 +109,63 @@ func TestSeeComments_RepoOverrideWithoutGit(t *testing.T) {
 
 	// Simulate missing git repository by returning an error unless override is used.
 	noRepoErr := errors.New("no repository context")
+	overrideRepo, overrideErr := ghrepo.FromFullName("octo/demo")
+	require.NoError(t, overrideErr)
+	shared.StubFinderForRunCommandStyleTests(t, "55", &api.PullRequest{Number: 55}, overrideRepo)
+
 	f, stdout, stderr := newTestFactory(t, reg, nil, noRepoErr)
 	// Simulate passing -R by overriding BaseRepo before command execution.
 	f.BaseRepo = cmdutil.OverrideBaseRepoFunc(f, "octo/demo")
 
 	cmd := NewCmdSeeComments(f)
 	cmd.SetArgs([]string{"55", "--review-id", "77"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, "null", stdout.String())
+}
+
+func TestSeeComments_FullReferenceSelector(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	matcher := httpmock.WithHost(
+		httpmock.QueryMatcher("GET", "repos/octo/demo/pulls/55/reviews/10/comments", url.Values{"per_page": {"100"}}),
+		"api.github.com",
+	)
+	reg.Register(matcher, httpmock.JSONResponse([]interface{}{}))
+
+	repo := ghrepo.NewWithHost("octo", "demo", "github.com")
+	shared.StubFinderForRunCommandStyleTests(t, "octo/demo#55", &api.PullRequest{Number: 55}, repo)
+
+	f, stdout, stderr := newTestFactory(t, reg, nil, nil)
+	cmd := NewCmdSeeComments(f)
+	cmd.SetArgs([]string{"octo/demo#55", "--review-id", "10"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, "null", stdout.String())
+}
+
+func TestSeeComments_URLSelector(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	matcher := httpmock.WithHost(
+		httpmock.QueryMatcher("GET", "repos/octo/demo/pulls/77/reviews/20/comments", url.Values{"per_page": {"100"}}),
+		"api.github.com",
+	)
+	reg.Register(matcher, httpmock.JSONResponse([]interface{}{}))
+
+	repo := ghrepo.NewWithHost("octo", "demo", "github.com")
+	selector := "https://github.com/octo/demo/pull/77"
+	shared.StubFinderForRunCommandStyleTests(t, selector, &api.PullRequest{Number: 77}, repo)
+
+	f, stdout, stderr := newTestFactory(t, reg, nil, nil)
+	cmd := NewCmdSeeComments(f)
+	cmd.SetArgs([]string{selector, "--review-id", "20"})
 
 	_, err := cmd.ExecuteC()
 	require.NoError(t, err)

--- a/pkg/cmd/pr/see-comments/see_comments_test.go
+++ b/pkg/cmd/pr/see-comments/see_comments_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -30,6 +31,9 @@ func newTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory, *byte
 		IOStreams: ios,
 		HttpClient: func() (*http.Client, error) {
 			return &http.Client{Transport: rt}, nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.NewWithHost("ORG", "REPO", "github.com"), nil
 		},
 		Config: func() (gh.Config, error) {
 			return cfg, nil
@@ -63,7 +67,7 @@ func TestSeeComments_ByReviewID(t *testing.T) {
 
 	f, stdout, stderr := newTestFactory(t, reg)
 	cmd := NewCmdSeeComments(f)
-	cmd.SetArgs([]string{"--org", "ORG", "--repo", "REPO", "--pr", "123", "--review-id", "456"})
+	cmd.SetArgs([]string{"--pr", "123", "--review-id", "456"})
 
 	_, err := cmd.ExecuteC()
 	require.NoError(t, err)

--- a/pkg/cmd/pr/see-comments/see_comments_test.go
+++ b/pkg/cmd/pr/see-comments/see_comments_test.go
@@ -1,0 +1,79 @@
+package see_comments
+
+import (
+	"bytes"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestFactory(t *testing.T, rt http.RoundTripper) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(false)
+	ios.SetStdinTTY(false)
+	ios.SetStderrTTY(false)
+
+	cfg := config.NewBlankConfig()
+	cfg.Authentication().SetDefaultHost("github.com", "default")
+
+	return &cmdutil.Factory{
+		IOStreams: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: rt}, nil
+		},
+		Config: func() (gh.Config, error) {
+			return cfg, nil
+		},
+	}, stdout, stderr
+}
+
+func TestSeeComments_ByReviewID(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	comment := map[string]interface{}{
+		"id":                     101,
+		"pull_request_review_id": 456,
+		"in_reply_to_id":         nil,
+		"path":                   "main.go",
+		"line":                   12,
+		"side":                   "RIGHT",
+		"body":                   "Looks good",
+		"user": map[string]interface{}{
+			"login": "octocat",
+		},
+		"created_at": time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+
+	matcher := httpmock.WithHost(
+		httpmock.QueryMatcher("GET", "repos/ORG/REPO/pulls/123/reviews/456/comments", url.Values{"per_page": {"100"}}),
+		"api.github.com",
+	)
+	reg.Register(matcher, httpmock.JSONResponse([]interface{}{comment}))
+
+	f, stdout, stderr := newTestFactory(t, reg)
+	cmd := NewCmdSeeComments(f)
+	cmd.SetArgs([]string{"--org", "ORG", "--repo", "REPO", "--pr", "123", "--review-id", "456"})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.JSONEq(t, `[{"id":101,"pull_request_review_id":456,"in_reply_to_id":null,"path":"main.go","line":12,"side":"RIGHT","body":"Looks good","user":{"login":"octocat"},"created_at":"2024-01-02T03:04:05Z"}]`, stdout.String())
+
+	if len(reg.Requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(reg.Requests))
+	}
+	req := reg.Requests[0]
+	assert.Equal(t, "application/vnd.github+json", req.Header.Get("Accept"))
+	assert.Equal(t, "2022-11-28", req.Header.Get("X-GitHub-Api-Version"))
+}

--- a/pkg/cmd/pr/shared/pull_args.go
+++ b/pkg/cmd/pr/shared/pull_args.go
@@ -4,63 +4,43 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 )
 
-// ResolvePullRequest resolves repository and pull request number from a combination of
-// positional selector and --pr flag. The selector may be a pull request URL, an
-// "owner/repo#number" reference, or a plain number with an optional leading '#'.
-// When the selector does not include repository information, the provided baseRepo
-// function is used to determine it (which honors `-R/--repo` overrides).
-func ResolvePullRequest(baseRepo func() (ghrepo.Interface, error), selector string, prFlag int) (ghrepo.Interface, int, error) {
-	if selector != "" {
-		if repo, number, _, err := ParseURL(selector); err == nil {
-			if prFlag > 0 && prFlag != number {
-				return nil, 0, cmdutil.FlagErrorf("pull request argument %q does not match --pr=%d", selector, prFlag)
-			}
-			return repo, number, nil
+// NormalizePullRequestSelector merges positional selectors and the --pr flag into a single
+// selector string that can be passed to PRFinder. It validates that the values agree when
+// both are supplied and ensures that at least one form of selector is provided.
+func NormalizePullRequestSelector(selector string, prFlag int) (string, error) {
+	selector = strings.TrimSpace(selector)
+
+	if selector != "" && prFlag > 0 {
+		if !selectorMatchesNumber(selector, prFlag) {
+			return "", cmdutil.FlagErrorf("pull request argument %q does not match --pr=%d", selector, prFlag)
 		}
-
-		if repo, number, err := ParseFullReference(selector); err == nil {
-			if prFlag > 0 && prFlag != number {
-				return nil, 0, cmdutil.FlagErrorf("pull request argument %q does not match --pr=%d", selector, prFlag)
-			}
-
-			if baseRepo != nil {
-				if base, err := baseRepo(); err == nil {
-					repo = ghrepo.NewWithHost(repo.RepoOwner(), repo.RepoName(), base.RepoHost())
-				}
-			}
-			return repo, number, nil
-		}
-
-		trimmed := strings.TrimPrefix(selector, "#")
-		if trimmed != "" {
-			if n, err := strconv.Atoi(trimmed); err == nil && n > 0 {
-				if prFlag > 0 && prFlag != n {
-					return nil, 0, cmdutil.FlagErrorf("pull request argument %q does not match --pr=%d", selector, prFlag)
-				}
-
-				repo, err := baseRepo()
-				if err != nil {
-					return nil, 0, err
-				}
-				return repo, n, nil
-			}
-		}
-
-		return nil, 0, cmdutil.FlagErrorf("invalid pull request argument: %q", selector)
+	} else if selector == "" && prFlag > 0 {
+		selector = strconv.Itoa(prFlag)
 	}
 
-	if prFlag <= 0 {
-		return nil, 0, cmdutil.FlagErrorf("must specify a pull request via --pr or as an argument")
+	if selector == "" {
+		return "", cmdutil.FlagErrorf("must specify a pull request via --pr or as an argument")
 	}
 
-	repo, err := baseRepo()
-	if err != nil {
-		return nil, 0, err
+	return selector, nil
+}
+
+func selectorMatchesNumber(selector string, target int) bool {
+	if _, number, _, err := ParseURL(selector); err == nil {
+		return number == target
 	}
 
-	return repo, prFlag, nil
+	if _, number, err := ParseFullReference(selector); err == nil {
+		return number == target
+	}
+
+	trimmed := strings.TrimPrefix(selector, "#")
+	if n, err := strconv.Atoi(trimmed); err == nil {
+		return n == target
+	}
+
+	return false
 }

--- a/pkg/cmd/pr/shared/pull_args.go
+++ b/pkg/cmd/pr/shared/pull_args.go
@@ -1,0 +1,66 @@
+package shared
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+)
+
+// ResolvePullRequest resolves repository and pull request number from a combination of
+// positional selector and --pr flag. The selector may be a pull request URL, an
+// "owner/repo#number" reference, or a plain number with an optional leading '#'.
+// When the selector does not include repository information, the provided baseRepo
+// function is used to determine it (which honors `-R/--repo` overrides).
+func ResolvePullRequest(baseRepo func() (ghrepo.Interface, error), selector string, prFlag int) (ghrepo.Interface, int, error) {
+	if selector != "" {
+		if repo, number, _, err := ParseURL(selector); err == nil {
+			if prFlag > 0 && prFlag != number {
+				return nil, 0, cmdutil.FlagErrorf("pull request argument %q does not match --pr=%d", selector, prFlag)
+			}
+			return repo, number, nil
+		}
+
+		if repo, number, err := ParseFullReference(selector); err == nil {
+			if prFlag > 0 && prFlag != number {
+				return nil, 0, cmdutil.FlagErrorf("pull request argument %q does not match --pr=%d", selector, prFlag)
+			}
+
+			if baseRepo != nil {
+				if base, err := baseRepo(); err == nil {
+					repo = ghrepo.NewWithHost(repo.RepoOwner(), repo.RepoName(), base.RepoHost())
+				}
+			}
+			return repo, number, nil
+		}
+
+		trimmed := strings.TrimPrefix(selector, "#")
+		if trimmed != "" {
+			if n, err := strconv.Atoi(trimmed); err == nil && n > 0 {
+				if prFlag > 0 && prFlag != n {
+					return nil, 0, cmdutil.FlagErrorf("pull request argument %q does not match --pr=%d", selector, prFlag)
+				}
+
+				repo, err := baseRepo()
+				if err != nil {
+					return nil, 0, err
+				}
+				return repo, n, nil
+			}
+		}
+
+		return nil, 0, cmdutil.FlagErrorf("invalid pull request argument: %q", selector)
+	}
+
+	if prFlag <= 0 {
+		return nil, 0, cmdutil.FlagErrorf("must specify a pull request via --pr or as an argument")
+	}
+
+	repo, err := baseRepo()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return repo, prFlag, nil
+}


### PR DESCRIPTION
Add PR review helper commands under `gh pr` for inline comments and review flows

Summary
The `gh` CLI is increasingly used by AI agents and automation pipelines to collaborate on pull requests. These workflows benefit from first-class access to:
- reading inline review comments,
- replying to review thread comments,
- opening a pending review, adding inline comments, and submitting the review.

Proposed commands
- `gh pr see-comments` — list inline review comments by review id or latest
- `gh pr reply-comment` — reply to a review thread comment by comment id
- `gh pr review pending open` — open a pending review
- `gh pr review pending add` — add inline review comment(s)
- `gh pr review pending submit` — submit the pending review

Implementation notes
- Reading and replying use REST endpoints.
- Pending-review composition (open → add inline → submit) uses GraphQL mutations.
- Commands follow gh conventions: standard repo resolution with `-R/--repo` override, consistent flags/help, and output options.

Related discussions
- References: #12232

