### PR TITLE
Error if go-licenses is not on the PATH

### DIFF
--- a/script/licenses
+++ b/script/licenses
@@ -5,6 +5,12 @@ if [ "$CI" != "true" ]; then
     go install github.com/google/go-licenses@latest
 fi
 
+# Verify go-licenses is available
+if ! command -v go-licenses &> /dev/null; then
+    echo "Error: go-licenses is not installed or not on PATH"
+    exit 1
+fi
+
 # Setup temporary directory to collect updated third-party source code
 export TEMPDIR="$(mktemp -d)"
 trap "rm -fr ${TEMPDIR}" EXIT


### PR DESCRIPTION
## Description

When I ran `make licenses` it deleted all my licenses. The script is supposed to install `go-licenses` but I didn't have the installation location on my path. Better to just exit.

Potentially we could gate the `go install`, but I chose not to because I'm happy for it to keep updating me to `latest` when I run this script.