### PR TITLE
Introduce multiselect with search without wiring into commandsets

### DIFF
--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -21,6 +21,15 @@ type Prompter interface {
 	Select(prompt string, defaultValue string, options []string) (int, error)
 	// MultiSelect prompts the user to select one or more options from a list of options.
 	MultiSelect(prompt string, defaults []string, options []string) ([]int, error)
+	// MultiSelectWithSearch is MultiSelect with an added search option to the list,
+	// prompting the user for text input to filter the options via the searchFunc.
+	// Items selected in the search are persisted in the list after subsequent searches.
+	// Items passed in persistentOptions are always shown in the list, even when not selected.
+	// Unlike MultiSelect, MultiselectWithSearch returns the selected option strings,
+	// not their indices, since the list of options is dynamic.
+	// The searchFunc args and return values are: func(query) (map[keys]labels, moreResultsCount, searchError)
+	// Where the selected keys are eventually returned by MultiSelectWithSearch and the labels are what is shown to the user in the prompt.
+	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
 	// Input prompts the user to enter a string value.
 	Input(prompt string, defaultValue string) (string, error)
 	// Password prompts the user to enter a password.
@@ -320,6 +329,10 @@ func (p *accessiblePrompter) MarkdownEditor(prompt, defaultValue string, blankAl
 	return text, nil
 }
 
+func (p *accessiblePrompter) MultiSelectWithSearch(prompt, searchPrompt string, defaultValues, persistentValues []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+	return multiSelectWithSearch(p, prompt, searchPrompt, defaultValues, persistentValues, searchFunc)
+}
+
 type surveyPrompter struct {
 	prompter  *ghPrompter.Prompter
 	stdin     ghPrompter.FileReader
@@ -334,6 +347,147 @@ func (p *surveyPrompter) Select(prompt, defaultValue string, options []string) (
 
 func (p *surveyPrompter) MultiSelect(prompt string, defaultValues, options []string) ([]int, error) {
 	return p.prompter.MultiSelect(prompt, defaultValues, options)
+}
+
+func (p *surveyPrompter) MultiSelectWithSearch(prompt string, searchPrompt string, defaultValues, persistentValues []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+	return multiSelectWithSearch(p, prompt, searchPrompt, defaultValues, persistentValues, searchFunc)
+}
+
+func multiSelectWithSearch(p Prompter, prompt, searchPrompt string, defaultValues, persistentValues []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+	selectedOptions := defaultValues
+
+	// The optionKeyLabels map is used to uniquely identify optionKeyLabels
+	// and provide optional display labels.
+	optionKeyLabels := make(map[string]string)
+	for _, k := range selectedOptions {
+		optionKeyLabels[k] = k
+	}
+
+	searchResultKeys, searchResultLabels, moreResults, err := searchFunc("")
+	if err != nil {
+		return nil, fmt.Errorf("failed to search: %w", err)
+	}
+
+	for i, k := range searchResultKeys {
+		optionKeyLabels[k] = searchResultLabels[i]
+	}
+
+	for {
+		// Build dynamic option list ->  search sentinel, selections, search results, persistent options.
+		optionKeys := make([]string, 0, 1+len(selectedOptions)+len(searchResultKeys)+len(persistentValues))
+		optionLabels := make([]string, 0, len(optionKeys))
+
+		// 1. Search sentinel.
+		optionKeys = append(optionKeys, "")
+		if moreResults > 0 {
+			optionLabels = append(optionLabels, fmt.Sprintf("Search (%d more)", moreResults))
+		} else {
+			optionLabels = append(optionLabels, "Search")
+		}
+
+		// 2. Selections
+		for _, k := range selectedOptions {
+			l := optionKeyLabels[k]
+
+			if l == "" {
+				l = k
+			}
+
+			optionKeys = append(optionKeys, k)
+			optionLabels = append(optionLabels, l)
+		}
+
+		// 3. Search results
+		for _, k := range searchResultKeys {
+			// It's already selected or persistent, if we add here we'll have duplicates.
+			if slices.Contains(selectedOptions, k) || slices.Contains(persistentValues, k) {
+				continue
+			}
+
+			l := optionKeyLabels[k]
+			if l == "" {
+				l = k
+			}
+			optionKeys = append(optionKeys, k)
+			optionLabels = append(optionLabels, l)
+		}
+
+		// 4. Persistent options
+		for _, k := range persistentValues {
+			if slices.Contains(selectedOptions, k) {
+				continue
+			}
+
+			l := optionKeyLabels[k]
+			if l == "" {
+				l = k
+			}
+
+			optionKeys = append(optionKeys, k)
+			optionLabels = append(optionLabels, l)
+		}
+
+		selectedOptionLabels := make([]string, len(selectedOptions))
+		for i, k := range selectedOptions {
+			l := optionKeyLabels[k]
+			if l == "" {
+				l = k
+			}
+			selectedOptionLabels[i] = l
+		}
+
+		selectedIdxs, err := p.MultiSelect(prompt, selectedOptionLabels, optionLabels)
+		if err != nil {
+			return nil, err
+		}
+
+		pickedSearch := false
+		var newSelectedOptions []string
+		for _, idx := range selectedIdxs {
+			if idx == 0 { // Search sentinel selected
+				pickedSearch = true
+				continue
+			}
+
+			if idx < 0 || idx >= len(optionKeys) {
+				continue
+			}
+
+			key := optionKeys[idx]
+			if key == "" {
+				continue
+			}
+
+			newSelectedOptions = append(newSelectedOptions, key)
+		}
+
+		selectedOptions = newSelectedOptions
+		for _, k := range selectedOptions {
+			if _, ok := optionKeyLabels[k]; !ok {
+				optionKeyLabels[k] = k
+			}
+		}
+
+		if pickedSearch {
+			query, err := p.Input(searchPrompt, "")
+			if err != nil {
+				return nil, err
+			}
+
+			searchResultKeys, searchResultLabels, moreResults, err = searchFunc(query)
+			if err != nil {
+				return nil, err
+			}
+
+			for i, k := range searchResultKeys {
+				optionKeyLabels[k] = searchResultLabels[i]
+			}
+
+			continue
+		}
+
+		return selectedOptions, nil
+	}
 }
 
 func (p *surveyPrompter) Input(prompt, defaultValue string) (string, error) {

--- a/internal/prompter/prompter_mock.go
+++ b/internal/prompter/prompter_mock.go
@@ -38,6 +38,9 @@ var _ Prompter = &PrompterMock{}
 //			MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
 //				panic("mock out the MultiSelect method")
 //			},
+//			MultiSelectWithSearchFunc: func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+//				panic("mock out the MultiSelectWithSearch method")
+//			},
 //			PasswordFunc: func(prompt string) (string, error) {
 //				panic("mock out the Password method")
 //			},
@@ -71,6 +74,9 @@ type PrompterMock struct {
 
 	// MultiSelectFunc mocks the MultiSelect method.
 	MultiSelectFunc func(prompt string, defaults []string, options []string) ([]int, error)
+
+	// MultiSelectWithSearchFunc mocks the MultiSelectWithSearch method.
+	MultiSelectWithSearchFunc func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
 
 	// PasswordFunc mocks the Password method.
 	PasswordFunc func(prompt string) (string, error)
@@ -123,6 +129,19 @@ type PrompterMock struct {
 			// Options is the options argument value.
 			Options []string
 		}
+		// MultiSelectWithSearch holds details about calls to the MultiSelectWithSearch method.
+		MultiSelectWithSearch []struct {
+			// Prompt is the prompt argument value.
+			Prompt string
+			// SearchPrompt is the searchPrompt argument value.
+			SearchPrompt string
+			// Defaults is the defaults argument value.
+			Defaults []string
+			// PersistentOptions is the persistentOptions argument value.
+			PersistentOptions []string
+			// SearchFunc is the searchFunc argument value.
+			SearchFunc func(string) ([]string, []string, int, error)
+		}
 		// Password holds details about calls to the Password method.
 		Password []struct {
 			// Prompt is the prompt argument value.
@@ -138,15 +157,16 @@ type PrompterMock struct {
 			Options []string
 		}
 	}
-	lockAuthToken       sync.RWMutex
-	lockConfirm         sync.RWMutex
-	lockConfirmDeletion sync.RWMutex
-	lockInput           sync.RWMutex
-	lockInputHostname   sync.RWMutex
-	lockMarkdownEditor  sync.RWMutex
-	lockMultiSelect     sync.RWMutex
-	lockPassword        sync.RWMutex
-	lockSelect          sync.RWMutex
+	lockAuthToken             sync.RWMutex
+	lockConfirm               sync.RWMutex
+	lockConfirmDeletion       sync.RWMutex
+	lockInput                 sync.RWMutex
+	lockInputHostname         sync.RWMutex
+	lockMarkdownEditor        sync.RWMutex
+	lockMultiSelect           sync.RWMutex
+	lockMultiSelectWithSearch sync.RWMutex
+	lockPassword              sync.RWMutex
+	lockSelect                sync.RWMutex
 }
 
 // AuthToken calls AuthTokenFunc.
@@ -384,6 +404,54 @@ func (mock *PrompterMock) MultiSelectCalls() []struct {
 	mock.lockMultiSelect.RLock()
 	calls = mock.calls.MultiSelect
 	mock.lockMultiSelect.RUnlock()
+	return calls
+}
+
+// MultiSelectWithSearch calls MultiSelectWithSearchFunc.
+func (mock *PrompterMock) MultiSelectWithSearch(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+	if mock.MultiSelectWithSearchFunc == nil {
+		panic("PrompterMock.MultiSelectWithSearchFunc: method is nil but Prompter.MultiSelectWithSearch was just called")
+	}
+	callInfo := struct {
+		Prompt            string
+		SearchPrompt      string
+		Defaults          []string
+		PersistentOptions []string
+		SearchFunc        func(string) ([]string, []string, int, error)
+	}{
+		Prompt:            prompt,
+		SearchPrompt:      searchPrompt,
+		Defaults:          defaults,
+		PersistentOptions: persistentOptions,
+		SearchFunc:        searchFunc,
+	}
+	mock.lockMultiSelectWithSearch.Lock()
+	mock.calls.MultiSelectWithSearch = append(mock.calls.MultiSelectWithSearch, callInfo)
+	mock.lockMultiSelectWithSearch.Unlock()
+	return mock.MultiSelectWithSearchFunc(prompt, searchPrompt, defaults, persistentOptions, searchFunc)
+}
+
+// MultiSelectWithSearchCalls gets all the calls that were made to MultiSelectWithSearch.
+// Check the length with:
+//
+//	len(mockedPrompter.MultiSelectWithSearchCalls())
+func (mock *PrompterMock) MultiSelectWithSearchCalls() []struct {
+	Prompt            string
+	SearchPrompt      string
+	Defaults          []string
+	PersistentOptions []string
+	SearchFunc        func(string) ([]string, []string, int, error)
+} {
+	var calls []struct {
+		Prompt            string
+		SearchPrompt      string
+		Defaults          []string
+		PersistentOptions []string
+		SearchFunc        func(string) ([]string, []string, int, error)
+	}
+	mock.lockMultiSelectWithSearch.RLock()
+	calls = mock.calls.MultiSelectWithSearch
+	mock.lockMultiSelectWithSearch.RUnlock()
 	return calls
 }
 

--- a/internal/prompter/test.go
+++ b/internal/prompter/test.go
@@ -25,10 +25,11 @@ func NewMockPrompter(t *testing.T) *MockPrompter {
 type MockPrompter struct {
 	t *testing.T
 	ghPrompter.PrompterMock
-	authTokenStubs       []authTokenStub
-	confirmDeletionStubs []confirmDeletionStub
-	inputHostnameStubs   []inputHostnameStub
-	markdownEditorStubs  []markdownEditorStub
+	authTokenStubs             []authTokenStub
+	confirmDeletionStubs       []confirmDeletionStub
+	inputHostnameStubs         []inputHostnameStub
+	markdownEditorStubs        []markdownEditorStub
+	multiSelectWithSearchStubs []multiSelectWithSearchStub
 }
 
 type authTokenStub struct {
@@ -47,6 +48,12 @@ type inputHostnameStub struct {
 type markdownEditorStub struct {
 	prompt string
 	fn     func(string, string, bool) (string, error)
+}
+
+type multiSelectWithSearchStub struct {
+	prompt       string
+	searchPrompt string
+	fn           func(string, string, []string, []string) ([]string, error)
 }
 
 func (m *MockPrompter) AuthToken() (string, error) {
@@ -90,6 +97,16 @@ func (m *MockPrompter) MarkdownEditor(prompt, defaultValue string, blankAllowed 
 		return "", NoSuchPromptErr(prompt)
 	}
 	return s.fn(prompt, defaultValue, blankAllowed)
+}
+
+func (m *MockPrompter) MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+	var s multiSelectWithSearchStub
+	if len(m.multiSelectWithSearchStubs) == 0 {
+		return nil, NoSuchPromptErr(prompt)
+	}
+	s = m.multiSelectWithSearchStubs[0]
+	m.multiSelectWithSearchStubs = m.multiSelectWithSearchStubs[1:len(m.multiSelectWithSearchStubs)]
+	return s.fn(prompt, searchPrompt, defaults, persistentOptions)
 }
 
 func (m *MockPrompter) RegisterAuthToken(stub func() (string, error)) {

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -35,11 +35,11 @@ const (
 )
 
 type Prompt interface {
-	Input(string, string) (string, error)
-	Select(string, string, []string) (int, error)
-	MarkdownEditor(string, string, bool) (string, error)
-	Confirm(string, bool) (bool, error)
-	MultiSelect(string, []string, []string) ([]int, error)
+	Input(prompt string, defaultValue string) (string, error)
+	Select(prompt string, defaultValue string, options []string) (int, error)
+	MarkdownEditor(prompt string, defaultValue string, blankAllowed bool) (string, error)
+	Confirm(prompt string, defaultValue bool) (bool, error)
+	MultiSelect(prompt string, defaults []string, options []string) ([]int, error)
 }
 
 func ConfirmIssueSubmission(p Prompt, allowPreview bool, allowMetadata bool) (Action, error) {

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -40,6 +40,7 @@ type Prompt interface {
 	MarkdownEditor(prompt string, defaultValue string, blankAllowed bool) (string, error)
 	Confirm(prompt string, defaultValue bool) (bool, error)
 	MultiSelect(prompt string, defaults []string, options []string) ([]int, error)
+	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
 }
 
 func ConfirmIssueSubmission(p Prompt, allowPreview bool, allowMetadata bool) (Action, error) {
@@ -207,6 +208,7 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 	// Populate the list of selectable assignees and their default selections.
 	// This logic maps the default assignees from `state` to the corresponding actors or users
 	// so that the correct display names are preselected in the prompt.
+	// TODO: KW21 This will need to go away since we're going to dynamically load assignees via search.
 	var assignees []string
 	var assigneesDefault []string
 	if state.ActorAssignees {
@@ -264,6 +266,9 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 			fmt.Fprintln(io.ErrOut, "warning: no available reviewers")
 		}
 	}
+	// TODO: KW21 This will need to change to use MultiSelectWithSearch once it's implemented.
+	// MultiSelectWithSearch will return the selected strings directly instead of indices,
+	// so the logic here will need to be updated accordingly.
 	if isChosen("Assignees") {
 		if len(assignees) > 0 {
 			selected, err := p.MultiSelect("Assignees", assigneesDefault, assignees)

--- a/pkg/cmd/preview/prompter/prompter.go
+++ b/pkg/cmd/preview/prompter/prompter.go
@@ -2,6 +2,7 @@ package prompter
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/gh"
@@ -25,32 +26,35 @@ func NewCmdPrompter(f *cmdutil.Factory, runF func(*prompterOptions) error) *cobr
 	}
 
 	const (
-		selectPrompt          = "select"
-		multiSelectPrompt     = "multi-select"
-		inputPrompt           = "input"
-		passwordPrompt        = "password"
-		confirmPrompt         = "confirm"
-		authTokenPrompt       = "auth-token"
-		confirmDeletionPrompt = "confirm-deletion"
-		inputHostnamePrompt   = "input-hostname"
-		markdownEditorPrompt  = "markdown-editor"
+		selectPrompt                = "select"
+		multiSelectPrompt           = "multi-select"
+		multiSelectWithSearchPrompt = "multi-select-with-search"
+		inputPrompt                 = "input"
+		passwordPrompt              = "password"
+		confirmPrompt               = "confirm"
+		authTokenPrompt             = "auth-token"
+		confirmDeletionPrompt       = "confirm-deletion"
+		inputHostnamePrompt         = "input-hostname"
+		markdownEditorPrompt        = "markdown-editor"
 	)
 
 	prompterTypeFuncMap := map[string]func(prompter.Prompter, *iostreams.IOStreams) error{
-		selectPrompt:          runSelect,
-		multiSelectPrompt:     runMultiSelect,
-		inputPrompt:           runInput,
-		passwordPrompt:        runPassword,
-		confirmPrompt:         runConfirm,
-		authTokenPrompt:       runAuthToken,
-		confirmDeletionPrompt: runConfirmDeletion,
-		inputHostnamePrompt:   runInputHostname,
-		markdownEditorPrompt:  runMarkdownEditor,
+		selectPrompt:                runSelect,
+		multiSelectPrompt:           runMultiSelect,
+		multiSelectWithSearchPrompt: runMultiSelectWithSearch,
+		inputPrompt:                 runInput,
+		passwordPrompt:              runPassword,
+		confirmPrompt:               runConfirm,
+		authTokenPrompt:             runAuthToken,
+		confirmDeletionPrompt:       runConfirmDeletion,
+		inputHostnamePrompt:         runInputHostname,
+		markdownEditorPrompt:        runMarkdownEditor,
 	}
 
 	allPromptsOrder := []string{
 		selectPrompt,
 		multiSelectPrompt,
+		multiSelectWithSearchPrompt,
 		inputPrompt,
 		passwordPrompt,
 		confirmPrompt,
@@ -70,6 +74,7 @@ func NewCmdPrompter(f *cmdutil.Factory, runF func(*prompterOptions) error) *cobr
 			Available prompt types:
 			- select
 			- multi-select
+			- multi-select-with-search
 			- input
 			- password
 			- confirm
@@ -146,6 +151,42 @@ func runMultiSelect(p prompter.Prompter, io *iostreams.IOStreams) error {
 	for _, f := range favorites {
 		fmt.Fprintf(io.Out, "Favorite cuisine: %s\n", cuisines[f])
 	}
+	return nil
+}
+
+func runMultiSelectWithSearch(p prompter.Prompter, io *iostreams.IOStreams) error {
+	fmt.Fprintln(io.Out, "Demonstrating Multi Select With Search")
+	persistentOptions := []string{"persistent-option-1"}
+	searchFunc := func(input string) ([]string, []string, int, error) {
+		var searchResultKeys []string
+		var searchResultLabels []string
+
+		if input == "" {
+			moreResults := 2 // Indicate that there are more results available
+			searchResultKeys = []string{"initial-result-1", "initial-result-2"}
+			searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
+			return searchResultKeys, searchResultLabels, moreResults, nil
+		}
+
+		// In a real implementation, this function would perform a search based on the input.
+		// Here, we return a static set of options for demonstration purposes.
+		moreResults := 0
+		searchResultKeys = []string{"search-result-1", "search-result-2"}
+		searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
+		return searchResultKeys, searchResultLabels, moreResults, nil
+	}
+
+	selections, err := p.MultiSelectWithSearch("Select an option", "Search for an option", []string{}, persistentOptions, searchFunc)
+	if err != nil {
+		return err
+	}
+
+	if len(selections) == 0 {
+		fmt.Fprintln(io.Out, "No options selected.")
+		return nil
+	}
+
+	fmt.Fprintf(io.Out, "Selected options: %s\n", strings.Join(selections, ", "))
 	return nil
 }
 


### PR DESCRIPTION
### Description

This introduces a new multiselect prompter that can search by executing a `searchFunc` that is passed into it. The intention is to eventually wire this into `gh pr edit`, `gh issue edit`, `gh pr create`, and `gh issue create`, so it's important this be reusable.

This is one step on the path for https://github.com/cli/cli/issues/11501

I've wired this up to `gh preview prompter multi-select-with-search` - please use that as a way to actually execute this prompter and play with the code and values being passed into the prompter and returned from the search func 😁 

Additionally, please note this is merging into a feature branch, not `trunk` 🙏 

### Copilot-generated overview

**New Prompt Feature: MultiSelectWithSearch**

* Added `MultiSelectWithSearch` to the `Prompter` interface, allowing users to select multiple options from a list that can be dynamically filtered via a search function. This prompt returns selected option strings rather than indices. [[1]](diffhunk://#diff-737546d0df277da165ecbe00a6f46fc12110abf76006d101879a8c63c401c809R24-R32) [[2]](diffhunk://#diff-28a1259daa71a17aa71823b8d7f4350fd5b8bbef8fda916fe89a25689271c023L38-R43)
* Implemented `MultiSelectWithSearch` for both `accessiblePrompter` and `surveyPrompter`, with logic to handle search, persistent options, and option labeling. [[1]](diffhunk://#diff-737546d0df277da165ecbe00a6f46fc12110abf76006d101879a8c63c401c809R332-R335) [[2]](diffhunk://#diff-737546d0df277da165ecbe00a6f46fc12110abf76006d101879a8c63c401c809R352-R492)

**Testing and Mocking Infrastructure**

* Added extensive tests for `MultiSelectWithSearch` covering basic flow, pre-selected defaults, and persistence of selections between searches in `accessible_prompter_test.go`.
* Updated the `PrompterMock` to support `MultiSelectWithSearch`, including call tracking and thread safety. [[1]](diffhunk://#diff-a7b62a333e14408b2d4da9b69ed912f240ebebd4a037b377aa3d1b4a90d59807R41-R43) [[2]](diffhunk://#diff-a7b62a333e14408b2d4da9b69ed912f240ebebd4a037b377aa3d1b4a90d59807R78-R80) [[3]](diffhunk://#diff-a7b62a333e14408b2d4da9b69ed912f240ebebd4a037b377aa3d1b4a90d59807R132-R144) [[4]](diffhunk://#diff-a7b62a333e14408b2d4da9b69ed912f240ebebd4a037b377aa3d1b4a90d59807R167) [[5]](diffhunk://#diff-a7b62a333e14408b2d4da9b69ed912f240ebebd4a037b377aa3d1b4a90d59807R410-R457)
* Enhanced the `MockPrompter` in test helpers to stub and simulate `MultiSelectWithSearch` calls. [[1]](diffhunk://#diff-6878406579e4dd4fe90713762d7b37805975daa18f148787be401b01e4e306eeR32) [[2]](diffhunk://#diff-6878406579e4dd4fe90713762d7b37805975daa18f148787be401b01e4e306eeR53-R58) [[3]](diffhunk://#diff-6878406579e4dd4fe90713762d7b37805975daa18f148787be401b01e4e306eeR102-R111)

**Preparatory and Minor Changes**

* Added a new prompt type constant for `multi-select-with-search` in the preview prompter command.
* Added TODO comments in `MetadataSurvey` to indicate upcoming changes to use `MultiSelectWithSearch` for assignees and reviewers. [[1]](diffhunk://#diff-28a1259daa71a17aa71823b8d7f4350fd5b8bbef8fda916fe89a25689271c023R211) [[2]](diffhunk://#diff-28a1259daa71a17aa71823b8d7f4350fd5b8bbef8fda916fe89a25689271c023R269-R271)
* Minor import cleanup and commented-out logger option in tests for debugging. [[1]](diffhunk://#diff-21b951878553f7d5efc330b27e2138a214ec2069a99e69906027a45c33cc7fd7R5) [[2]](diffhunk://#diff-82485e94f5af7a870eb550334bf2ff2291d992b4c7bd66507184e587632143d6R806)