### PR TITLE
Fix Debian CLI package link in installation guide

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -209,7 +209,7 @@ conda update gh --channel conda-forge
 
 ### Debian Community
 
-The [GitHub CLI package](https://packages.debian.org/bookworm/gh) is supported by the Debian community with updates powered by [Debian Go Packaging Team](https://salsa.debian.org/go-team/packages/gh).
+The [GitHub CLI package](https://packages.debian.org/stable/gh) is supported by the Debian community with updates powered by [Debian Go Packaging Team](https://salsa.debian.org/go-team/packages/gh).
 
 > [!NOTE]
 > As of November 2025, GitHub CLI maintainers strongly recommend [official Debian packages](#debian) especially as the community-distributed `2.45.x` / `2.46.x` version is broken due to deprecated GitHub APIs.


### PR DESCRIPTION
Update the GitHub CLI package link for Debian.

Fixes #12290 

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
