### PR TITLE
pr status: add limit flag

### DIFF
--- a/pkg/cmd/pr/status/http.go
+++ b/pkg/cmd/pr/status/http.go
@@ -18,6 +18,7 @@ type requestOptions struct {
 	Username       string
 	Fields         []string
 	ConflictStatus bool
+	LimitResults   int
 
 	CheckRunAndStatusContextCountsSupported bool
 }
@@ -122,7 +123,6 @@ func pullRequestStatus(httpClient *http.Client, repo ghrepo.Interface, options r
 	`
 
 	currentUsername, err := getCurrentUsername(options.Username, repo.RepoHost(), apiClient)
-
 	if err != nil {
 		return nil, err
 	}
@@ -145,6 +145,10 @@ func pullRequestStatus(httpClient *http.Client, repo ghrepo.Interface, options r
 		"number":        options.CurrentPR,
 	}
 
+	if options.LimitResults > 0 {
+		variables["per_page"] = options.LimitResults
+	}
+
 	var resp response
 	if err := apiClient.GraphQL(repo.RepoHost(), query, variables, &resp); err != nil {
 		return nil, err
@@ -160,7 +164,7 @@ func pullRequestStatus(httpClient *http.Client, repo ghrepo.Interface, options r
 		reviewRequested = append(reviewRequested, edge.Node)
 	}
 
-	var currentPR = resp.Repository.PullRequest
+	currentPR := resp.Repository.PullRequest
 	if currentPR == nil {
 		for _, edge := range resp.Repository.PullRequests.Edges {
 			if edge.Node.HeadLabel() == currentPRHeadRef {

--- a/pkg/cmd/pr/status/status.go
+++ b/pkg/cmd/pr/status/status.go
@@ -37,16 +37,19 @@ type StatusOptions struct {
 	ConflictStatus  bool
 
 	Detector fd.Detector
+
+	LimitResults int
 }
 
 func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Command {
 	opts := &StatusOptions{
-		IO:         f.IOStreams,
-		HttpClient: f.HttpClient,
-		GitClient:  f.GitClient,
-		Config:     f.Config,
-		Remotes:    f.Remotes,
-		Branch:     f.Branch,
+		IO:           f.IOStreams,
+		HttpClient:   f.HttpClient,
+		GitClient:    f.GitClient,
+		Config:       f.Config,
+		Remotes:      f.Remotes,
+		Branch:       f.Branch,
+		LimitResults: 10,
 	}
 
 	cmd := &cobra.Command{
@@ -66,6 +69,10 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 			opts.BaseRepo = f.BaseRepo
 			opts.HasRepoOverride = cmd.Flags().Changed("repo")
 
+			if opts.LimitResults < 1 {
+				return cmdutil.FlagErrorf("invalid value for --limit: %v", opts.LimitResults)
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -74,6 +81,7 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 	}
 
 	cmd.Flags().BoolVarP(&opts.ConflictStatus, "conflict-status", "c", false, "Display the merge conflict status of each pull request")
+	cmd.Flags().IntVarP(&opts.LimitResults, "limit", "L", opts.LimitResults, "Maximum number of items to fetch")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.PullRequestFields)
 
 	return cmd
@@ -142,6 +150,7 @@ func statusRun(opts *StatusOptions) error {
 	if opts.Exporter != nil {
 		options.Fields = opts.Exporter.Fields()
 	}
+	options.LimitResults = opts.LimitResults
 
 	if opts.Detector == nil {
 		cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)

--- a/pkg/cmd/pr/status/status_test.go
+++ b/pkg/cmd/pr/status/status_test.go
@@ -90,6 +90,16 @@ func initFakeHTTP() *httpmock.Registry {
 	return &httpmock.Registry{}
 }
 
+func TestPRStatus_invalidLimit(t *testing.T) {
+	http := initFakeHTTP()
+	defer http.Verify(t)
+
+	_, err := runCommand(http, "", true, "--limit 0")
+	if err == nil || !strings.Contains(err.Error(), "invalid value for --limit") {
+		t.Fatalf("expected limit validation error, got: %v", err)
+	}
+}
+
 func TestPRStatus(t *testing.T) {
 	http := initFakeHTTP()
 	defer http.Verify(t)


### PR DESCRIPTION
Adds --limit/-L to gh pr status (defaults to 10) to fetch more than 10 PRs. Fixes #12306.