### PR TITLE
fix: prevent panic when processing null project items

### DIFF
--- a/api/queries_projects_v2.go
+++ b/api/queries_projects_v2.go
@@ -106,6 +106,9 @@ func ProjectsV2ItemsForIssue(client *Client, repo ghrepo.Interface, issue *Issue
 			return err
 		}
 		for _, projectItemNode := range query.Repository.Issue.ProjectItems.Nodes {
+			if projectItemNode == nil {
+				continue
+			}
 			items.Nodes = append(items.Nodes, &ProjectV2Item{
 				ID: projectItemNode.ID,
 				Project: ProjectV2ItemProject{
@@ -175,6 +178,9 @@ func ProjectsV2ItemsForPullRequest(client *Client, repo ghrepo.Interface, pr *Pu
 		}
 
 		for _, projectItemNode := range query.Repository.PullRequest.ProjectItems.Nodes {
+			if projectItemNode == nil {
+				continue
+			}
 			items.Nodes = append(items.Nodes, &ProjectV2Item{
 				ID: projectItemNode.ID,
 				Project: ProjectV2ItemProject{

--- a/api/queries_projects_v2_test.go
+++ b/api/queries_projects_v2_test.go
@@ -129,6 +129,17 @@ func TestProjectsV2ItemsForIssue(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "skips null project items for issue",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query IssueProjectItems\b`),
+					httpmock.GraphQLQuery(`{"data":{"repository":{"issue":{"projectItems":{"totalCount":1,"nodes":[null]}}}}}`,
+						func(query string, inputs map[string]interface{}) {}),
+				)
+			},
+			expectItems: ProjectItems{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -185,6 +196,17 @@ func TestProjectsV2ItemsForPullRequest(t *testing.T) {
 				)
 			},
 			expectError: true,
+		},
+		{
+			name: "skips null project items for pull request",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query PullRequestProjectItems\b`),
+					httpmock.GraphQLQuery(`{"data":{"repository":{"pullRequest":{"projectItems":{"totalCount":1,"nodes":[null]}}}}}`,
+						func(query string, inputs map[string]interface{}) {}),
+				)
+			},
+			expectItems: ProjectItems{},
 		},
 		{
 			name: "retrieves project items that have status columns",


### PR DESCRIPTION
The GraphQL API can return `null` nodes in the `projectItems` connection, causing a runtime panic (nil pointer dereference) when the CLI attempted to access fields on these nil nodes. This crash occurs even with personal access tokens with full read access.

Adds a check to safely skip `nil` nodes in `ProjectsV2ItemsForIssue` and `ProjectsV2ItemsForPullRequest`.

Fixes #12325