### PR TITLE
Enhance v2 project handling around nulls

### DIFF
--- a/api/queries_projects_v2.go
+++ b/api/queries_projects_v2.go
@@ -106,6 +106,9 @@ func ProjectsV2ItemsForIssue(client *Client, repo ghrepo.Interface, issue *Issue
 			return err
 		}
 		for _, projectItemNode := range query.Repository.Issue.ProjectItems.Nodes {
+			if projectItemNode == nil {
+				continue
+			}
 			items.Nodes = append(items.Nodes, &ProjectV2Item{
 				ID: projectItemNode.ID,
 				Project: ProjectV2ItemProject{
@@ -175,6 +178,9 @@ func ProjectsV2ItemsForPullRequest(client *Client, repo ghrepo.Interface, pr *Pu
 		}
 
 		for _, projectItemNode := range query.Repository.PullRequest.ProjectItems.Nodes {
+			if projectItemNode == nil {
+				continue
+			}
 			items.Nodes = append(items.Nodes, &ProjectV2Item{
 				ID: projectItemNode.ID,
 				Project: ProjectV2ItemProject{

--- a/api/queries_projects_v2_test.go
+++ b/api/queries_projects_v2_test.go
@@ -129,6 +129,17 @@ func TestProjectsV2ItemsForIssue(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "skips null project items for issue",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query IssueProjectItems\b`),
+					httpmock.GraphQLQuery(`{"data":{"repository":{"issue":{"projectItems":{"totalCount":1,"nodes":[null]}}}}}`,
+						func(query string, inputs map[string]interface{}) {}),
+				)
+			},
+			expectItems: ProjectItems{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -185,6 +196,17 @@ func TestProjectsV2ItemsForPullRequest(t *testing.T) {
 				)
 			},
 			expectError: true,
+		},
+		{
+			name: "skips null project items for pull request",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query PullRequestProjectItems\b`),
+					httpmock.GraphQLQuery(`{"data":{"repository":{"pullRequest":{"projectItems":{"totalCount":1,"nodes":[null]}}}}}`,
+						func(query string, inputs map[string]interface{}) {}),
+				)
+			},
+			expectItems: ProjectItems{},
 		},
 		{
 			name: "retrieves project items that have status columns",


### PR DESCRIPTION
Relates #12325

This commit applies familiar conditional protections around v2 project items to avoid panics including:

https://github.com/cli/cli/blob/baf629918338c8fed6570a2252118f5630362282/pkg/cmd/status/status.go#L473-L492

https://github.com/cli/cli/blob/baf629918338c8fed6570a2252118f5630362282/pkg/cmd/pr/view/view.go#L459-L468

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
