### PR TITLE
Update actions/checkout to v6 in extension workflow templates

### DIFF
--- a/pkg/cmd/extension/ext_tmpls/goBinWorkflow.yml
+++ b/pkg/cmd/extension/ext_tmpls/goBinWorkflow.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cli/gh-extension-precompile@v2
         with:
           generate_attestations: true

--- a/pkg/cmd/extension/ext_tmpls/otherBinWorkflow.yml
+++ b/pkg/cmd/extension/ext_tmpls/otherBinWorkflow.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cli/gh-extension-precompile@v2
         with:
           build_script_override: "script/build.sh"


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
## Summary

Update `actions/checkout` from v4 to v6 in extension workflow templates.

## Changes

- `pkg/cmd/extension/ext_tmpls/goBinWorkflow.yml`
- `pkg/cmd/extension/ext_tmpls/otherBinWorkflow.yml`

Fix https://github.com/cli/cli/issues/12392