### PR TITLE
CI: Update Azure Code Signing endpoint URL

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -184,7 +184,7 @@ jobs:
             CertificateProfileName = "GitHubInc"
             CodeSigningAccountName = "GitHubInc"
             CorrelationId = $Env:CORRELATION_ID
-            Endpoint =  "https://wus.codesigning.azure.net/"
+            Endpoint =  "https://wus3.codesigning.azure.net/"
           } | ConvertTo-Json | Out-File -FilePath $Env:METADATA_PATH
 
       # Azure Code Signing leverages the environment variables for secrets that complement the metadata.json


### PR DESCRIPTION
Troubleshooting CI failure by switching to a documented endpoint:

https://learn.microsoft.com/en-us/azure/trusted-signing/how-to-signing-integrations#create-a-json-file