### PR TITLE
`gh pr edit`: adopt interactive assignee select with search

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -715,16 +715,15 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 			Issue struct {
 				SuggestedActors struct {
 					Nodes []struct {
+					    TypeName string `graphql:"__typename"`
 						User struct {
 							ID       string
 							Login    string
 							Name     string
-							TypeName string `graphql:"__typename"`
 						} `graphql:"... on User"`
 						Bot struct {
 							ID       string
 							Login    string
-							TypeName string `graphql:"__typename"`
 						} `graphql:"... on Bot"`
 					}
 				} `graphql:"suggestedActors(first: 10, query: $query)"`
@@ -732,16 +731,15 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 			PullRequest struct {
 				SuggestedActors struct {
 					Nodes []struct {
+					    TypeName string `graphql:"__typename"`
 						User struct {
 							ID       string
 							Login    string
-							Name     string
-							TypeName string `graphql:"__typename"`
+							Name     string							
 						} `graphql:"... on User"`
 						Bot struct {
 							ID       string
 							Login    string
-							TypeName string `graphql:"__typename"`
 						} `graphql:"... on Bot"`
 					}
 				} `graphql:"suggestedActors(first: 10, query: $query)"`
@@ -764,16 +762,15 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 	}
 
 	var nodes []struct {
+		TypeName string `graphql:"__typename"`
 		User struct {
 			ID       string
 			Login    string
 			Name     string
-			TypeName string `graphql:"__typename"`
 		} `graphql:"... on User"`
 		Bot struct {
 			ID       string
 			Login    string
-			TypeName string `graphql:"__typename"`
 		} `graphql:"... on Bot"`
 	}
 
@@ -789,12 +786,12 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 	viewerIncluded := false
 
 	for _, n := range nodes {
-		if n.User.TypeName == "User" && n.User.Login != "" {
+		if n.TypeName == "User" && n.User.Login != "" {
 			actors = append(actors, AssignableUser{id: n.User.ID, login: n.User.Login, name: n.User.Name})
 			if query == "" && viewerLogin != "" && n.User.Login == viewerLogin {
 				viewerIncluded = true
 			}
-		} else if n.Bot.TypeName == "Bot" && n.Bot.Login != "" {
+		} else if n.TypeName == "Bot" && n.Bot.Login != "" {
 			actors = append(actors, AssignableBot{id: n.Bot.ID, login: n.Bot.Login})
 			if query == "" && viewerLogin != "" && n.Bot.Login == viewerLogin {
 				viewerIncluded = true

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -803,6 +803,8 @@ func newTestVirtualTerminal(t *testing.T) *expect.Console {
 		failOnExpectError(t),
 		failOnSendError(t),
 		expect.WithDefaultTimeout(time.Second),
+		// Use this logger to debug expect based tests by printing the
+		// characters being read to stdout.
 		// expect.WithLogger(log.New(os.Stdout, "", 0)),
 	}
 

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -228,26 +228,36 @@ func TestAccessiblePrompter(t *testing.T) {
 		console := newTestVirtualTerminal(t)
 		p := newTestAccessiblePrompter(t, console)
 		persistentOptions := []string{"persistent-option-1"}
-		searchFunc := func(input string) ([]string, []string, int, error) {
-			var searchResultKeys []string
-			var searchResultLabels []string
+	searchFunc := func(input string) prompter.MultiSelectSearchResult {
+		var searchResultKeys []string
+		var searchResultLabels []string
 
-			// Initial search with no input
-			if input == "" {
-				moreResults := 2
-				searchResultKeys = []string{"initial-result-1", "initial-result-2"}
-				searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
-				return searchResultKeys, searchResultLabels, moreResults, nil
+		// Initial search with no input
+		if input == "" {
+			moreResults := 2
+			searchResultKeys = []string{"initial-result-1", "initial-result-2"}
+			searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
+			return prompter.MultiSelectSearchResult{
+				Keys:        searchResultKeys,
+				Labels:      searchResultLabels,
+				MoreResults: moreResults,
+				Err:         nil,
 			}
-
-			// Subsequent search with input
-			moreResults := 0
-			searchResultKeys = []string{"search-result-1", "search-result-2"}
-			searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
-			return searchResultKeys, searchResultLabels, moreResults, nil
 		}
 
-		go func() {
+		// Subsequent search with input
+		moreResults := 0
+		searchResultKeys = []string{"search-result-1", "search-result-2"}
+		searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
+		return prompter.MultiSelectSearchResult{
+			Keys:        searchResultKeys,
+			Labels:      searchResultLabels,
+			MoreResults: moreResults,
+			Err:         nil,
+		}
+	}
+
+	go func() {
 			// Wait for prompt to appear
 			_, err := console.ExpectString("Select an option \r\n")
 			require.NoError(t, err)
@@ -291,16 +301,26 @@ func TestAccessiblePrompter(t *testing.T) {
 		initialSearchResultKeys := []string{"initial-result-1"}
 		initialSearchResultLabels := []string{"Initial Result Label 1"}
 		defaultOptions := initialSearchResultKeys
-		searchFunc := func(input string) ([]string, []string, int, error) {
+		searchFunc := func(input string) prompter.MultiSelectSearchResult {
 			// Initial search with no input
 			if input == "" {
 				moreResults := 2
-				return initialSearchResultKeys, initialSearchResultLabels, moreResults, nil
+				return prompter.MultiSelectSearchResult{
+					Keys:        initialSearchResultKeys,
+					Labels:      initialSearchResultLabels,
+					MoreResults: moreResults,
+					Err:         nil,
+				}
 			}
 
 			// No search selected, so this should fail the test.
 			t.FailNow()
-			return nil, nil, 0, nil
+			return prompter.MultiSelectSearchResult{
+				Keys:        nil,
+				Labels:      nil,
+				MoreResults: 0,
+				Err:         nil,
+			}
 		}
 
 		go func() {
@@ -325,21 +345,36 @@ func TestAccessiblePrompter(t *testing.T) {
 		moreResultKeys := []string{"more-result-1"}
 		moreResultLabels := []string{"More Result Label 1"}
 
-		searchFunc := func(input string) ([]string, []string, int, error) {
+		searchFunc := func(input string) prompter.MultiSelectSearchResult {
 			// Initial search with no input
 			if input == "" {
 				moreResults := 2
-				return initialSearchResultKeys, initialSearchResultLabels, moreResults, nil
+				return prompter.MultiSelectSearchResult{
+					Keys:        initialSearchResultKeys,
+					Labels:      initialSearchResultLabels,
+					MoreResults: moreResults,
+					Err:         nil,
+				}
 			}
 
 			// Subsequent search with input "more"
 			if input == "more" {
-				return moreResultKeys, moreResultLabels, 0, nil
+				return prompter.MultiSelectSearchResult{
+					Keys:        moreResultKeys,
+					Labels:      moreResultLabels,
+					MoreResults: 0,
+					Err:         nil,
+				}
 			}
 
 			// No other searches expected
 			t.FailNow()
-			return nil, nil, 0, nil
+			return prompter.MultiSelectSearchResult{
+				Keys:        nil,
+				Labels:      nil,
+				MoreResults: 0,
+				Err:         nil,
+			}
 		}
 
 		go func() {

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -228,15 +228,27 @@ func TestAccessiblePrompter(t *testing.T) {
 		console := newTestVirtualTerminal(t)
 		p := newTestAccessiblePrompter(t, console)
 		persistentOptions := []string{"persistent-option-1"}
-	searchFunc := func(input string) prompter.MultiSelectSearchResult {
-		var searchResultKeys []string
-		var searchResultLabels []string
+		searchFunc := func(input string) prompter.MultiSelectSearchResult {
+			var searchResultKeys []string
+			var searchResultLabels []string
 
-		// Initial search with no input
-		if input == "" {
-			moreResults := 2
-			searchResultKeys = []string{"initial-result-1", "initial-result-2"}
-			searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
+			// Initial search with no input
+			if input == "" {
+				moreResults := 2
+				searchResultKeys = []string{"initial-result-1", "initial-result-2"}
+				searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
+				return prompter.MultiSelectSearchResult{
+					Keys:        searchResultKeys,
+					Labels:      searchResultLabels,
+					MoreResults: moreResults,
+					Err:         nil,
+				}
+			}
+
+			// Subsequent search with input
+			moreResults := 0
+			searchResultKeys = []string{"search-result-1", "search-result-2"}
+			searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
 			return prompter.MultiSelectSearchResult{
 				Keys:        searchResultKeys,
 				Labels:      searchResultLabels,
@@ -245,19 +257,7 @@ func TestAccessiblePrompter(t *testing.T) {
 			}
 		}
 
-		// Subsequent search with input
-		moreResults := 0
-		searchResultKeys = []string{"search-result-1", "search-result-2"}
-		searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
-		return prompter.MultiSelectSearchResult{
-			Keys:        searchResultKeys,
-			Labels:      searchResultLabels,
-			MoreResults: moreResults,
-			Err:         nil,
-		}
-	}
-
-	go func() {
+		go func() {
 			// Wait for prompt to appear
 			_, err := console.ExpectString("Select an option \r\n")
 			require.NoError(t, err)

--- a/internal/prompter/prompter_mock.go
+++ b/internal/prompter/prompter_mock.go
@@ -38,7 +38,7 @@ var _ Prompter = &PrompterMock{}
 //			MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
 //				panic("mock out the MultiSelect method")
 //			},
-//			MultiSelectWithSearchFunc: func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+//			MultiSelectWithSearchFunc: func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) MultiSelectSearchResult) ([]string, error) {
 //				panic("mock out the MultiSelectWithSearch method")
 //			},
 //			PasswordFunc: func(prompt string) (string, error) {
@@ -76,7 +76,7 @@ type PrompterMock struct {
 	MultiSelectFunc func(prompt string, defaults []string, options []string) ([]int, error)
 
 	// MultiSelectWithSearchFunc mocks the MultiSelectWithSearch method.
-	MultiSelectWithSearchFunc func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
+	MultiSelectWithSearchFunc func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) MultiSelectSearchResult) ([]string, error)
 
 	// PasswordFunc mocks the Password method.
 	PasswordFunc func(prompt string) (string, error)
@@ -140,7 +140,7 @@ type PrompterMock struct {
 			// PersistentOptions is the persistentOptions argument value.
 			PersistentOptions []string
 			// SearchFunc is the searchFunc argument value.
-			SearchFunc func(string) ([]string, []string, int, error)
+			SearchFunc func(string) MultiSelectSearchResult
 		}
 		// Password holds details about calls to the Password method.
 		Password []struct {
@@ -408,7 +408,7 @@ func (mock *PrompterMock) MultiSelectCalls() []struct {
 }
 
 // MultiSelectWithSearch calls MultiSelectWithSearchFunc.
-func (mock *PrompterMock) MultiSelectWithSearch(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+func (mock *PrompterMock) MultiSelectWithSearch(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) MultiSelectSearchResult) ([]string, error) {
 	if mock.MultiSelectWithSearchFunc == nil {
 		panic("PrompterMock.MultiSelectWithSearchFunc: method is nil but Prompter.MultiSelectWithSearch was just called")
 	}
@@ -417,7 +417,7 @@ func (mock *PrompterMock) MultiSelectWithSearch(prompt string, searchPrompt stri
 		SearchPrompt      string
 		Defaults          []string
 		PersistentOptions []string
-		SearchFunc        func(string) ([]string, []string, int, error)
+		SearchFunc        func(string) MultiSelectSearchResult
 	}{
 		Prompt:            prompt,
 		SearchPrompt:      searchPrompt,
@@ -440,14 +440,14 @@ func (mock *PrompterMock) MultiSelectWithSearchCalls() []struct {
 	SearchPrompt      string
 	Defaults          []string
 	PersistentOptions []string
-	SearchFunc        func(string) ([]string, []string, int, error)
+	SearchFunc        func(string) MultiSelectSearchResult
 } {
 	var calls []struct {
 		Prompt            string
 		SearchPrompt      string
 		Defaults          []string
 		PersistentOptions []string
-		SearchFunc        func(string) ([]string, []string, int, error)
+		SearchFunc        func(string) MultiSelectSearchResult
 	}
 	mock.lockMultiSelectWithSearch.RLock()
 	calls = mock.calls.MultiSelectWithSearch

--- a/internal/prompter/test.go
+++ b/internal/prompter/test.go
@@ -99,7 +99,7 @@ func (m *MockPrompter) MarkdownEditor(prompt, defaultValue string, blankAllowed 
 	return s.fn(prompt, defaultValue, blankAllowed)
 }
 
-func (m *MockPrompter) MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+func (m *MockPrompter) MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) MultiSelectSearchResult) ([]string, error) {
 	var s multiSelectWithSearchStub
 	if len(m.multiSelectWithSearchStubs) == 0 {
 		return nil, NoSuchPromptErr(prompt)

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -845,7 +845,7 @@ func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry) {
 		{ "data": { "repository": { "suggestedActors": {
 			"nodes": [
 				{ "login": "hubot", "id": "HUBOTID", "__typename": "Bot" },
-				{ "login": "MonaLisa", "id": "MONAID", "name": "Mona Display Name", "__typename": "User" }
+				{ "login": "monalisa", "id": "MONAID", "name": "Mona Display Name", "__typename": "User" }
 			],
 			"pageInfo": { "hasNextPage": false }
 		} } } }

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -294,7 +294,7 @@ func editRun(opts *EditOptions) error {
 	apiClient := api.NewClientFromHTTP(httpClient)
 
 	// Wire up search functions for assignees and reviewers.
-	// TODO: Wire up reviewer search func.
+	// TODO KW: Wire up reviewer search func if/when it exists.
 	if issueFeatures.ActorIsAssignable {
 		editable.AssigneeSearchFunc = assigneeSearchFunc(apiClient, repo, &editable, pr.ID)
 	}

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -295,7 +295,9 @@ func editRun(opts *EditOptions) error {
 
 	// Wire up search functions for assignees and reviewers.
 	// TODO: Wire up reviewer search func.
-	editable.AssigneeSearchFunc = assigneeSearchFunc(apiClient, repo, &editable, pr.ID)
+	if issueFeatures.ActorIsAssignable {
+		editable.AssigneeSearchFunc = assigneeSearchFunc(apiClient, repo, &editable, pr.ID)
+	}
 
 	opts.IO.StartProgressIndicator()
 	err = opts.Fetcher.EditableOptionsFetch(apiClient, repo, &editable, opts.Detector.ProjectsV1())

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -354,8 +354,8 @@ func assigneeSearchFunc(apiClient *api.Client, repo ghrepo.Interface, editable *
 			}
 		}
 
-		var logins []string
-		var displayNames []string
+		logins := make([]string, 0, len(actors))
+		displayNames := make([]string, 0, len(actors))
 
 		for _, a := range actors {
 			if a.Login() != "" {

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -714,7 +714,13 @@ func Test_editRun(t *testing.T) {
 					editFields: func(e *shared.Editable, _ string) error {
 						e.Title.Value = "new title"
 						e.Body.Value = "new body"
-						e.Assignees.Value = []string{"monalisa", "hubot"}
+						// When ActorAssignees is enabled, the interactive flow returns display names (or logins for non-users)
+						e.Assignees.Value = []string{"monalisa (Mona Display Name)", "hubot"}
+						// Populate metadata to simulate what searchFunc would do during prompting
+						e.Metadata.AssignableActors = []api.AssignableActor{
+							api.NewAssignableBot("HUBOTID", "hubot"),
+							api.NewAssignableUser("MONAID", "monalisa", "Mona Display Name"),
+						}
 						e.Labels.Value = []string{"feature", "TODO", "bug"}
 						e.Labels.Add = []string{"feature", "TODO", "bug"}
 						e.Labels.Remove = []string{"docs"}
@@ -728,7 +734,8 @@ func Test_editRun(t *testing.T) {
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				// interactive but reviewers not chosen; need everything except reviewers/teams
-				mockRepoMetadata(reg, mockRepoMetadataOptions{assignees: true, labels: true, projects: true, milestones: true})
+				// assignees: false because searchFunc handles dynamic fetching (metadata populated in test mock)
+				mockRepoMetadata(reg, mockRepoMetadataOptions{assignees: false, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
 				mockPullRequestUpdateActorAssignees(reg)
 				mockPullRequestUpdateLabels(reg)
@@ -822,8 +829,13 @@ func Test_editRun(t *testing.T) {
 						require.Equal(t, []string{"hubot"}, e.Assignees.Default)
 						require.Equal(t, []string{"hubot"}, e.Assignees.DefaultLogins)
 
-						// Adding MonaLisa as PR assignee, should preserve hubot.
-						e.Assignees.Value = []string{"hubot", "MonaLisa (Mona Display Name)"}
+						// Adding monalisa as PR assignee, should preserve hubot.
+						e.Assignees.Value = []string{"hubot", "monalisa (Mona Display Name)"}
+						// Populate metadata to simulate what searchFunc would do during prompting
+						e.Metadata.AssignableActors = []api.AssignableActor{
+							api.NewAssignableBot("HUBOTID", "hubot"),
+							api.NewAssignableUser("MONAID", "monalisa", "Mona Display Name"),
+						}
 						return nil
 					},
 				},
@@ -831,17 +843,8 @@ func Test_editRun(t *testing.T) {
 				EditorRetriever: testEditorRetriever{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryAssignableActors\b`),
-					httpmock.StringResponse(`
-					{ "data": { "repository": { "suggestedActors": {
-						"nodes": [
-							{ "login": "hubot", "id": "HUBOTID", "__typename": "Bot" },
-							{ "login": "MonaLisa", "id": "MONAID", "name": "Mona Display Name", "__typename": "User" }
-						],
-						"pageInfo": { "hasNextPage": false }
-					} } } }
-					`))
+				// No RepositoryAssignableActors query needed - searchFunc handles dynamic fetching
+				// (metadata populated in test mock)
 				mockPullRequestUpdate(reg)
 				reg.Register(
 					httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
@@ -886,7 +889,7 @@ func Test_editRun(t *testing.T) {
 					{ "data": { "repository": { "assignableUsers": {
 						"nodes": [
 							{ "login": "hubot", "id": "HUBOTID" },
-							{ "login": "MonaLisa", "id": "MONAID" }
+							{ "login": "monalisa", "id": "MONAID" }
 						],
 						"pageInfo": { "hasNextPage": false }
 					} } } }
@@ -1001,7 +1004,7 @@ func mockRepoMetadata(reg *httpmock.Registry, opt mockRepoMetadataOptions) {
 			{ "data": { "repository": { "suggestedActors": {
 				"nodes": [
 					{ "login": "hubot", "id": "HUBOTID", "__typename": "Bot" },
-					{ "login": "MonaLisa", "id": "MONAID", "name": "Mona Display Name", "__typename": "User" }
+					{ "login": "monalisa", "id": "MONAID", "name": "Mona Display Name", "__typename": "User" }
 				],
 				"pageInfo": { "hasNextPage": false }
 			} } } }

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -430,9 +430,15 @@ func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable,
 	fetchAssignees := false
 	if editable.Assignees.Edited {
 		// Similar as above, this is likely an interactive flow if no Add/Remove slices are set.
-		// The addition here is that we also check for an assignee search func because
-		// if that is set, the prompter will handle dynamic fetching of assignees.
+		// The addition here is that we also check for an assignee search func.
+		// If we have a search func, we don't need to fetch assignees since we
+		// assume that will be done dynamically in the prompting flow.
 		if len(editable.Assignees.Add) == 0 && len(editable.Assignees.Remove) == 0 && editable.AssigneeSearchFunc == nil {
+			fetchAssignees = true
+		}
+		// However, if we have Add/Remove operations (non-interactive flow),
+		// we do need to fetch the assignees.
+		if len(editable.Assignees.Add) > 0 || len(editable.Assignees.Remove) > 0 {
 			fetchAssignees = true
 		}
 	}

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/set"
 )
 
@@ -16,7 +17,7 @@ type Editable struct {
 	Reviewers          EditableSlice
 	ReviewerSearchFunc func(string) ([]string, []string, error)
 	Assignees          EditableAssignees
-	AssigneeSearchFunc func(string) ([]string, []string, int, error)
+	AssigneeSearchFunc func(string) prompter.MultiSelectSearchResult
 	Labels             EditableSlice
 	Projects           EditableProjects
 	Milestone          EditableString
@@ -279,7 +280,7 @@ type EditPrompter interface {
 	Input(string, string) (string, error)
 	MarkdownEditor(string, string, bool) (string, error)
 	MultiSelect(string, []string, []string) ([]int, error)
-	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
+	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) prompter.MultiSelectSearchResult) ([]string, error)
 	Confirm(string, bool) (bool, error)
 }
 

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/surveyext"
@@ -40,7 +41,7 @@ type Prompt interface {
 	MarkdownEditor(prompt string, defaultValue string, blankAllowed bool) (string, error)
 	Confirm(prompt string, defaultValue bool) (bool, error)
 	MultiSelect(prompt string, defaults []string, options []string) ([]int, error)
-	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
+	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) prompter.MultiSelectSearchResult) ([]string, error)
 }
 
 func ConfirmIssueSubmission(p Prompt, allowPreview bool, allowMetadata bool) (Action, error) {

--- a/pkg/cmd/preview/prompter/prompter.go
+++ b/pkg/cmd/preview/prompter/prompter.go
@@ -157,7 +157,7 @@ func runMultiSelect(p prompter.Prompter, io *iostreams.IOStreams) error {
 func runMultiSelectWithSearch(p prompter.Prompter, io *iostreams.IOStreams) error {
 	fmt.Fprintln(io.Out, "Demonstrating Multi Select With Search")
 	persistentOptions := []string{"persistent-option-1"}
-	searchFunc := func(input string) ([]string, []string, int, error) {
+	searchFunc := func(input string) prompter.MultiSelectSearchResult {
 		var searchResultKeys []string
 		var searchResultLabels []string
 
@@ -165,7 +165,12 @@ func runMultiSelectWithSearch(p prompter.Prompter, io *iostreams.IOStreams) erro
 			moreResults := 2 // Indicate that there are more results available
 			searchResultKeys = []string{"initial-result-1", "initial-result-2"}
 			searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
-			return searchResultKeys, searchResultLabels, moreResults, nil
+			return prompter.MultiSelectSearchResult{
+				Keys:        searchResultKeys,
+				Labels:      searchResultLabels,
+				MoreResults: moreResults,
+				Err:         nil,
+			}
 		}
 
 		// In a real implementation, this function would perform a search based on the input.
@@ -173,7 +178,12 @@ func runMultiSelectWithSearch(p prompter.Prompter, io *iostreams.IOStreams) erro
 		moreResults := 0
 		searchResultKeys = []string{"search-result-1", "search-result-2"}
 		searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
-		return searchResultKeys, searchResultLabels, moreResults, nil
+		return prompter.MultiSelectSearchResult{
+			Keys:        searchResultKeys,
+			Labels:      searchResultLabels,
+			MoreResults: moreResults,
+			Err:         nil,
+		}
 	}
 
 	selections, err := p.MultiSelectWithSearch("Select an option", "Search for an option", []string{}, persistentOptions, searchFunc)


### PR DESCRIPTION
- Introduces a new query to fetch assignable actors in batches of 10 with an optional search query.
- Migrates `gh pr edit` to use the new `MultiSelectWithSearch` UX, backed by the above new query
- Updates the signature of `MutliSelectWithSearch`'s `searchFunc` to return a richer `MultiSelectSearchResult` type
- Noninteractive flows remain unchanged due API limitations.