### PR TITLE
repo fork: honor --remote with repo arg

### DIFF
--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -182,6 +182,14 @@ func forkRun(opts *ForkOptions) error {
 				return fmt.Errorf("argument error: %w", err)
 			}
 		}
+
+		if opts.Remote {
+			if remotes, err := opts.Remotes(); err == nil {
+				if _, err := remotes.FindByRepo(repoToFork.RepoOwner(), repoToFork.RepoName()); err == nil {
+					inParent = true
+				}
+			}
+		}
 	}
 
 	connectedToTerminal := opts.IO.IsStdoutTTY() && opts.IO.IsStderrTTY() && opts.IO.IsStdinTTY()

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -373,6 +373,22 @@ func TestRepoFork(t *testing.T) {
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Renamed remote origin to upstream\n✓ Added remote origin\n",
 		},
 		{
+			name: "repo arg matches remote --remote",
+			tty:  true,
+			opts: &ForkOptions{
+				Repository: "https://github.com/OWNER/REPO.git",
+				Remote:     true,
+				RemoteName: defaultRemoteName,
+				Rename:     true,
+			},
+			httpStubs: forkPost,
+			execStubs: func(cs *run.CommandStubber) {
+				cs.Register("git remote rename origin upstream", 0, "")
+				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
+			},
+			wantErrOut: "✓ Created fork someone/REPO\n✓ Renamed remote origin to upstream\n✓ Added remote origin\n",
+		},
+		{
 			name: "implicit nontty reuse existing remote",
 			opts: &ForkOptions{
 				Remote:     true,


### PR DESCRIPTION
## Summary
- treat a repo argument that matches a local remote as the current repo when --remote is set
- add a regression test for repo-arg + --remote

## Testing
- go test ./pkg/cmd/repo/fork -run TestRepoFork

Fixes #2722