### PR TITLE
feat: add pr review-thread command for managing review threads

### DIFF
--- a/pkg/cmd/pr/pr.go
+++ b/pkg/cmd/pr/pr.go
@@ -16,6 +16,7 @@ import (
 	cmdReopen "github.com/cli/cli/v2/pkg/cmd/pr/reopen"
 	cmdRevert "github.com/cli/cli/v2/pkg/cmd/pr/revert"
 	cmdReview "github.com/cli/cli/v2/pkg/cmd/pr/review"
+	cmdReviewThread "github.com/cli/cli/v2/pkg/cmd/pr/reviewthread"
 	cmdStatus "github.com/cli/cli/v2/pkg/cmd/pr/status"
 	cmdUpdateBranch "github.com/cli/cli/v2/pkg/cmd/pr/update-branch"
 	cmdView "github.com/cli/cli/v2/pkg/cmd/pr/view"
@@ -58,6 +59,7 @@ func NewCmdPR(f *cmdutil.Factory) *cobra.Command {
 		cmdCheckout.NewCmdCheckout(f, nil),
 		cmdChecks.NewCmdChecks(f, nil),
 		cmdReview.NewCmdReview(f, nil),
+		cmdReviewThread.NewCmdReviewThread(f),
 		cmdMerge.NewCmdMerge(f, nil),
 		cmdUpdateBranch.NewCmdUpdateBranch(f, nil),
 		cmdReady.NewCmdReady(f, nil),

--- a/pkg/cmd/pr/reviewthread/list.go
+++ b/pkg/cmd/pr/reviewthread/list.go
@@ -1,0 +1,196 @@
+package reviewthread
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type ListOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+
+	Finder shared.PRFinder
+
+	SelectorArg    string
+	UnresolvedOnly bool
+}
+
+type ReviewThread struct {
+	ID         string
+	IsResolved bool
+	Path       string
+	Line       int
+	Body       string
+}
+
+func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Command {
+	opts := &ListOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list [<number> | <url> | <branch>]",
+		Short: "List review threads for a pull request",
+		Long: `List review threads for a pull request.
+
+Without an argument, the pull request that belongs to the current branch is used.`,
+		Example: `  # List all review threads for current PR
+  gh pr review-thread list
+
+  # List unresolved review threads for PR #123
+  gh pr review-thread list 123 --unresolved`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Finder = shared.NewFinder(f)
+
+			if len(args) > 0 {
+				opts.SelectorArg = args[0]
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return listRun(opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.UnresolvedOnly, "unresolved", false, "Show only unresolved threads")
+
+	return cmd
+}
+
+func listRun(opts *ListOptions) error {
+	findOptions := shared.FindOptions{
+		Selector: opts.SelectorArg,
+		Fields:   []string{"number"},
+	}
+	pr, baseRepo, err := opts.Finder.Find(findOptions)
+	if err != nil {
+		return err
+	}
+
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	apiClient := api.NewClientFromHTTP(httpClient)
+	threads, err := listReviewThreads(apiClient, baseRepo, pr.Number, opts.UnresolvedOnly)
+	if err != nil {
+		return fmt.Errorf("failed to list threads: %w", err)
+	}
+
+	if len(threads) == 0 {
+		cs := opts.IO.ColorScheme()
+		if opts.UnresolvedOnly {
+			fmt.Fprintf(opts.IO.Out, "%s No unresolved review threads found\n", cs.SuccessIcon())
+		} else {
+			fmt.Fprintf(opts.IO.Out, "%s No review threads found\n", cs.WarningIcon())
+		}
+		return nil
+	}
+
+	cs := opts.IO.ColorScheme()
+	for _, thread := range threads {
+		status := "unresolved"
+		if thread.IsResolved {
+			status = "resolved"
+		}
+		fmt.Fprintf(opts.IO.Out, "%s %s %s:%d\n",
+			cs.Bold(thread.ID),
+			cs.Gray(fmt.Sprintf("[%s]", status)),
+			thread.Path,
+			thread.Line,
+		)
+		if thread.Body != "" {
+			fmt.Fprintf(opts.IO.Out, "  %s\n", thread.Body)
+		}
+	}
+
+	return nil
+}
+
+func listReviewThreads(client *api.Client, repo ghrepo.Interface, prNumber int, unresolvedOnly bool) ([]ReviewThread, error) {
+	query := `
+		query ListReviewThreads($owner: String!, $repo: String!, $number: Int!) {
+			repository(owner: $owner, name: $repo) {
+				pullRequest(number: $number) {
+					reviewThreads(first: 100) {
+						nodes {
+							id
+							isResolved
+							comments(first: 1) {
+								nodes {
+									path
+									line
+									body
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"owner":  repo.RepoOwner(),
+		"repo":   repo.RepoName(),
+		"number": prNumber,
+	}
+
+	var response struct {
+		Repository struct {
+			PullRequest struct {
+				ReviewThreads struct {
+					Nodes []struct {
+						ID         string
+						IsResolved bool
+						Comments   struct {
+							Nodes []struct {
+								Path string
+								Line int
+								Body string
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	err := client.GraphQL(repo.RepoHost(), query, variables, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	var threads []ReviewThread
+	for _, node := range response.Repository.PullRequest.ReviewThreads.Nodes {
+		if unresolvedOnly && node.IsResolved {
+			continue
+		}
+
+		thread := ReviewThread{
+			ID:         node.ID,
+			IsResolved: node.IsResolved,
+		}
+
+		if len(node.Comments.Nodes) > 0 {
+			thread.Path = node.Comments.Nodes[0].Path
+			thread.Line = node.Comments.Nodes[0].Line
+			thread.Body = node.Comments.Nodes[0].Body
+		}
+
+		threads = append(threads, thread)
+	}
+
+	return threads, nil
+}

--- a/pkg/cmd/pr/reviewthread/list_test.go
+++ b/pkg/cmd/pr/reviewthread/list_test.go
@@ -1,0 +1,246 @@
+package reviewthread
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/test"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func runListCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
+
+	factory := &cmdutil.Factory{
+		IOStreams: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: rt}, nil
+		},
+	}
+
+	cmd := NewCmdList(factory, nil)
+
+	argv, err := shlex.Split(cli)
+	if err != nil {
+		return nil, err
+	}
+	cmd.SetArgs(argv)
+
+	cmd.SetIn(&bytes.Buffer{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	_, err = cmd.ExecuteC()
+	return &test.CmdOut{
+		OutBuf: stdout,
+		ErrBuf: stderr,
+	}, err
+}
+
+func TestList(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	baseRepo := ghrepo.New("OWNER", "REPO")
+	pr := &api.PullRequest{
+		Number: 123,
+	}
+	shared.StubFinderForRunCommandStyleTests(t, "123", pr, baseRepo)
+
+	http.Register(
+		httpmock.GraphQL(`query ListReviewThreads\b`),
+		httpmock.StringResponse(`{
+			"data": {
+				"repository": {
+					"pullRequest": {
+						"reviewThreads": {
+							"nodes": [
+								{
+									"id": "THREAD_1",
+									"isResolved": false,
+									"comments": {
+										"nodes": [
+											{
+												"path": "src/main.go",
+												"line": 42,
+												"body": "Please fix this"
+											}
+										]
+									}
+								},
+								{
+									"id": "THREAD_2",
+									"isResolved": true,
+									"comments": {
+										"nodes": [
+											{
+												"path": "src/test.go",
+												"line": 10,
+												"body": "Already fixed"
+											}
+										]
+									}
+								}
+							]
+						}
+					}
+				}
+			}
+		}`),
+	)
+
+	output, err := runListCommand(http, true, "123")
+	assert.NoError(t, err)
+	assert.Contains(t, output.String(), "THREAD_1")
+	assert.Contains(t, output.String(), "THREAD_2")
+	assert.Contains(t, output.String(), "src/main.go:42")
+	assert.Contains(t, output.String(), "src/test.go:10")
+	assert.Contains(t, output.String(), "unresolved")
+	assert.Contains(t, output.String(), "resolved")
+}
+
+func TestList_unresolvedOnly(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	baseRepo := ghrepo.New("OWNER", "REPO")
+	pr := &api.PullRequest{
+		Number: 123,
+	}
+	shared.StubFinderForRunCommandStyleTests(t, "123", pr, baseRepo)
+
+	http.Register(
+		httpmock.GraphQL(`query ListReviewThreads\b`),
+		httpmock.StringResponse(`{
+			"data": {
+				"repository": {
+					"pullRequest": {
+						"reviewThreads": {
+							"nodes": [
+								{
+									"id": "THREAD_1",
+									"isResolved": false,
+									"comments": {
+										"nodes": [
+											{
+												"path": "src/main.go",
+												"line": 42,
+												"body": "Please fix this"
+											}
+										]
+									}
+								},
+								{
+									"id": "THREAD_2",
+									"isResolved": true,
+									"comments": {
+										"nodes": [
+											{
+												"path": "src/test.go",
+												"line": 10,
+												"body": "Already fixed"
+											}
+										]
+									}
+								}
+							]
+						}
+					}
+				}
+			}
+		}`),
+	)
+
+	output, err := runListCommand(http, true, "123 --unresolved")
+	assert.NoError(t, err)
+	assert.Contains(t, output.String(), "THREAD_1")
+	assert.NotContains(t, output.String(), "THREAD_2")
+	assert.Contains(t, output.String(), "[unresolved]")
+	assert.NotContains(t, output.String(), "[resolved]")
+}
+
+func TestList_noThreads(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	baseRepo := ghrepo.New("OWNER", "REPO")
+	pr := &api.PullRequest{
+		Number: 123,
+	}
+	shared.StubFinderForRunCommandStyleTests(t, "123", pr, baseRepo)
+
+	http.Register(
+		httpmock.GraphQL(`query ListReviewThreads\b`),
+		httpmock.StringResponse(`{
+			"data": {
+				"repository": {
+					"pullRequest": {
+						"reviewThreads": {
+							"nodes": []
+						}
+					}
+				}
+			}
+		}`),
+	)
+
+	output, err := runListCommand(http, true, "123")
+	assert.NoError(t, err)
+	assert.Contains(t, output.String(), "No review threads found")
+}
+
+func TestList_noUnresolvedThreads(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	baseRepo := ghrepo.New("OWNER", "REPO")
+	pr := &api.PullRequest{
+		Number: 123,
+	}
+	shared.StubFinderForRunCommandStyleTests(t, "123", pr, baseRepo)
+
+	http.Register(
+		httpmock.GraphQL(`query ListReviewThreads\b`),
+		httpmock.StringResponse(`{
+			"data": {
+				"repository": {
+					"pullRequest": {
+						"reviewThreads": {
+							"nodes": [
+								{
+									"id": "THREAD_1",
+									"isResolved": true,
+									"comments": {
+										"nodes": [
+											{
+												"path": "src/main.go",
+												"line": 42,
+												"body": "Already fixed"
+											}
+										]
+									}
+								}
+							]
+						}
+					}
+				}
+			}
+		}`),
+	)
+
+	output, err := runListCommand(http, true, "123 --unresolved")
+	assert.NoError(t, err)
+	assert.Contains(t, output.String(), "No unresolved review threads found")
+}

--- a/pkg/cmd/pr/reviewthread/resolve.go
+++ b/pkg/cmd/pr/reviewthread/resolve.go
@@ -1,0 +1,93 @@
+package reviewthread
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type ResolveOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+
+	ThreadID string
+}
+
+func NewCmdResolve(f *cmdutil.Factory, runF func(*ResolveOptions) error) *cobra.Command {
+	opts := &ResolveOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "resolve <thread-id>",
+		Short: "Resolve a review thread",
+		Long: `Resolve a pull request review thread.
+
+The thread ID can be obtained from the GitHub GraphQL API or by using
+'gh pr review-thread list' command.`,
+		Example: `  # Resolve a review thread
+  gh pr review-thread resolve MDEyOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFk...`,
+		Args: cmdutil.ExactArgs(1, "thread ID required"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.ThreadID = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return resolveRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+func resolveRun(opts *ResolveOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	apiClient := api.NewClientFromHTTP(httpClient)
+	err = resolveReviewThread(apiClient, opts.ThreadID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve thread: %w", err)
+	}
+
+	cs := opts.IO.ColorScheme()
+	fmt.Fprintf(opts.IO.Out, "%s Resolved review thread\n", cs.SuccessIcon())
+
+	return nil
+}
+
+func resolveReviewThread(client *api.Client, threadID string) error {
+	query := `
+		mutation ResolveReviewThread($threadId: ID!) {
+			resolveReviewThread(input: {threadId: $threadId}) {
+				thread {
+					id
+					isResolved
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"threadId": threadID,
+	}
+
+	var response struct {
+		ResolveReviewThread struct {
+			Thread struct {
+				ID         string
+				IsResolved bool
+			}
+		}
+	}
+
+	return client.GraphQL("", query, variables, &response)
+}

--- a/pkg/cmd/pr/reviewthread/resolve_test.go
+++ b/pkg/cmd/pr/reviewthread/resolve_test.go
@@ -1,0 +1,85 @@
+package reviewthread
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/test"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func runResolveCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
+
+	factory := &cmdutil.Factory{
+		IOStreams: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: rt}, nil
+		},
+	}
+
+	cmd := NewCmdResolve(factory, nil)
+
+	argv, err := shlex.Split(cli)
+	if err != nil {
+		return nil, err
+	}
+	cmd.SetArgs(argv)
+
+	cmd.SetIn(&bytes.Buffer{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	_, err = cmd.ExecuteC()
+	return &test.CmdOut{
+		OutBuf: stdout,
+		ErrBuf: stderr,
+	}, err
+}
+
+func TestResolveNoArgs(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	_, err := runResolveCommand(http, true, "")
+
+	assert.EqualError(t, err, "thread ID required")
+}
+
+func TestResolve(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.GraphQL(`mutation ResolveReviewThread\b`),
+		httpmock.StringResponse(`{"data": {"resolveReviewThread": {"thread": {"id": "THREAD_ID", "isResolved": true}}}}`),
+	)
+
+	output, err := runResolveCommand(http, true, "THREAD_ID")
+	assert.NoError(t, err)
+	assert.Equal(t, "✓ Resolved review thread\n", output.String())
+	assert.Equal(t, "", output.Stderr())
+}
+
+func TestResolve_apiError(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.GraphQL(`mutation ResolveReviewThread\b`),
+		httpmock.StringResponse(`{"errors": [{"message": "Could not resolve thread"}]}`),
+	)
+
+	_, err := runResolveCommand(http, true, "INVALID_THREAD_ID")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve thread")
+}

--- a/pkg/cmd/pr/reviewthread/reviewthread.go
+++ b/pkg/cmd/pr/reviewthread/reviewthread.go
@@ -1,0 +1,39 @@
+package reviewthread
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdReviewThread(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "review-thread <command>",
+		Short: "Manage pull request review threads",
+		Long: heredoc.Doc(`
+			Manage pull request review threads.
+
+			Review threads are created when comments are left on specific lines of code
+			during a pull request review. These threads can be resolved or unresolved to
+			track which feedback has been addressed.
+		`),
+		Example: heredoc.Doc(`
+			# Resolve a review thread
+			$ gh pr review-thread resolve <thread-id>
+
+			# Unresolve a review thread
+			$ gh pr review-thread unresolve <thread-id>
+
+			# List unresolved review threads for a PR
+			$ gh pr review-thread list 123 --unresolved
+		`),
+	}
+
+	cmdutil.EnableRepoOverride(cmd, f)
+
+	cmd.AddCommand(NewCmdResolve(f, nil))
+	cmd.AddCommand(NewCmdUnresolve(f, nil))
+	cmd.AddCommand(NewCmdList(f, nil))
+
+	return cmd
+}

--- a/pkg/cmd/pr/reviewthread/reviewthread_test.go
+++ b/pkg/cmd/pr/reviewthread/reviewthread_test.go
@@ -1,0 +1,36 @@
+package reviewthread
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdReviewThread(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+
+	factory := &cmdutil.Factory{
+		IOStreams: ios,
+	}
+
+	cmd := NewCmdReviewThread(factory)
+
+	assert.Equal(t, "review-thread <command>", cmd.Use)
+	assert.Equal(t, "Manage pull request review threads", cmd.Short)
+	assert.True(t, cmd.HasSubCommands())
+
+	// Verify all subcommands are present
+	subcommands := cmd.Commands()
+	assert.Equal(t, 3, len(subcommands))
+
+	subcommandNames := make(map[string]bool)
+	for _, subcmd := range subcommands {
+		subcommandNames[subcmd.Name()] = true
+	}
+
+	assert.True(t, subcommandNames["resolve"], "resolve subcommand should exist")
+	assert.True(t, subcommandNames["unresolve"], "unresolve subcommand should exist")
+	assert.True(t, subcommandNames["list"], "list subcommand should exist")
+}

--- a/pkg/cmd/pr/reviewthread/unresolve.go
+++ b/pkg/cmd/pr/reviewthread/unresolve.go
@@ -1,0 +1,93 @@
+package reviewthread
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type UnresolveOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+
+	ThreadID string
+}
+
+func NewCmdUnresolve(f *cmdutil.Factory, runF func(*UnresolveOptions) error) *cobra.Command {
+	opts := &UnresolveOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "unresolve <thread-id>",
+		Short: "Unresolve a review thread",
+		Long: `Unresolve a pull request review thread that was previously resolved.
+
+The thread ID can be obtained from the GitHub GraphQL API or by using
+'gh pr review-thread list' command.`,
+		Example: `  # Unresolve a review thread
+  gh pr review-thread unresolve MDEyOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFk...`,
+		Args: cmdutil.ExactArgs(1, "thread ID required"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.ThreadID = args[0]
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return unresolveRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+func unresolveRun(opts *UnresolveOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	apiClient := api.NewClientFromHTTP(httpClient)
+	err = unresolveReviewThread(apiClient, opts.ThreadID)
+	if err != nil {
+		return fmt.Errorf("failed to unresolve thread: %w", err)
+	}
+
+	cs := opts.IO.ColorScheme()
+	fmt.Fprintf(opts.IO.Out, "%s Unresolved review thread\n", cs.SuccessIcon())
+
+	return nil
+}
+
+func unresolveReviewThread(client *api.Client, threadID string) error {
+	query := `
+		mutation UnresolveReviewThread($threadId: ID!) {
+			unresolveReviewThread(input: {threadId: $threadId}) {
+				thread {
+					id
+					isResolved
+				}
+			}
+		}
+	`
+
+	variables := map[string]interface{}{
+		"threadId": threadID,
+	}
+
+	var response struct {
+		UnresolveReviewThread struct {
+			Thread struct {
+				ID         string
+				IsResolved bool
+			}
+		}
+	}
+
+	return client.GraphQL("", query, variables, &response)
+}

--- a/pkg/cmd/pr/reviewthread/unresolve_test.go
+++ b/pkg/cmd/pr/reviewthread/unresolve_test.go
@@ -1,0 +1,85 @@
+package reviewthread
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/cli/v2/test"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func runUnresolveCommand(rt http.RoundTripper, isTTY bool, cli string) (*test.CmdOut, error) {
+	ios, _, stdout, stderr := iostreams.Test()
+	ios.SetStdoutTTY(isTTY)
+	ios.SetStdinTTY(isTTY)
+	ios.SetStderrTTY(isTTY)
+
+	factory := &cmdutil.Factory{
+		IOStreams: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: rt}, nil
+		},
+	}
+
+	cmd := NewCmdUnresolve(factory, nil)
+
+	argv, err := shlex.Split(cli)
+	if err != nil {
+		return nil, err
+	}
+	cmd.SetArgs(argv)
+
+	cmd.SetIn(&bytes.Buffer{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	_, err = cmd.ExecuteC()
+	return &test.CmdOut{
+		OutBuf: stdout,
+		ErrBuf: stderr,
+	}, err
+}
+
+func TestUnresolveNoArgs(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	_, err := runUnresolveCommand(http, true, "")
+
+	assert.EqualError(t, err, "thread ID required")
+}
+
+func TestUnresolve(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.GraphQL(`mutation UnresolveReviewThread\b`),
+		httpmock.StringResponse(`{"data": {"unresolveReviewThread": {"thread": {"id": "THREAD_ID", "isResolved": false}}}}`),
+	)
+
+	output, err := runUnresolveCommand(http, true, "THREAD_ID")
+	assert.NoError(t, err)
+	assert.Equal(t, "✓ Unresolved review thread\n", output.String())
+	assert.Equal(t, "", output.Stderr())
+}
+
+func TestUnresolve_apiError(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.GraphQL(`mutation UnresolveReviewThread\b`),
+		httpmock.StringResponse(`{"errors": [{"message": "Could not unresolve thread"}]}`),
+	)
+
+	_, err := runUnresolveCommand(http, true, "INVALID_THREAD_ID")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unresolve thread")
+}


### PR DESCRIPTION
## Summary

This PR adds a new `gh pr review-thread` command to manage pull request review threads via the GitHub GraphQL API.

Implements three subcommands:
- `list` - List all review threads for a PR with optional `--unresolved` filter
- `resolve` - Mark a review thread as resolved
- `unresolve` - Mark a review thread as unresolved

## Motivation

Closes #12419

Currently, there's no way to resolve or unresolve PR review threads from the CLI. This forces users to switch to the web UI to manage conversation threads, breaking their terminal workflow.

## Implementation Details

- Added new package `pkg/cmd/pr/reviewthread/` with command structure following existing patterns (similar to `pkg/cmd/label/`)
- Uses GraphQL mutations: `resolveReviewThread` and `unresolveReviewThread`
- Uses GraphQL query `ListReviewThreads` to list threads with filtering support
- Integrated into main PR command structure under "Targeted commands" group
- Includes comprehensive test coverage (11 tests) for all commands and subcommands

**Files added:**
- `pkg/cmd/pr/reviewthread/reviewthread.go` - Main command coordinator
- `pkg/cmd/pr/reviewthread/resolve.go` - Resolve thread implementation
- `pkg/cmd/pr/reviewthread/unresolve.go` - Unresolve thread implementation
- `pkg/cmd/pr/reviewthread/list.go` - List threads with filtering
- Corresponding test files: `*_test.go` for each command

**File modified:**
- `pkg/cmd/pr/pr.go` - Added review-thread command integration

## Usage Examples

```bash
# List all review threads for current PR
gh pr review-thread list

# List all review threads for PR #123
gh pr review-thread list 123

# List unresolved threads for PR #123
gh pr review-thread list 123 --unresolved

# Resolve a thread (get thread ID from list command)
gh pr review-thread resolve MDEyOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFk...

# Unresolve a thread
gh pr review-thread unresolve MDEyOlB1bGxSZXF1ZXN0UmV2aWV3VGhyZWFk...
```

## Test Coverage

All commands have comprehensive test coverage:
- `reviewthread_test.go` - Tests command structure and subcommand registration
- `resolve_test.go` - Tests resolve command (3 tests)
- `unresolve_test.go` - Tests unresolve command (3 tests)
- `list_test.go` - Tests list command with filtering (4 tests)

Total: 11 tests, all passing.

```bash
$ go test ./pkg/cmd/pr/reviewthread/... -v
=== RUN   TestList
--- PASS: TestList (0.00s)
=== RUN   TestList_unresolvedOnly
--- PASS: TestList_unresolvedOnly (0.00s)
=== RUN   TestList_noThreads
--- PASS: TestList_noThreads (0.00s)
=== RUN   TestList_noUnresolvedThreads
--- PASS: TestList_noUnresolvedThreads (0.00s)
=== RUN   TestResolveNoArgs
--- PASS: TestResolveNoArgs (0.00s)
=== RUN   TestResolve
--- PASS: TestResolve (0.00s)
=== RUN   TestResolve_apiError
--- PASS: TestResolve_apiError (0.00s)
=== RUN   TestNewCmdReviewThread
--- PASS: TestNewCmdReviewThread (0.00s)
=== RUN   TestUnresolveNoArgs
--- PASS: TestUnresolveNoArgs (0.00s)
=== RUN   TestUnresolve
--- PASS: TestUnresolve (0.00s)
=== RUN   TestUnresolve_apiError
--- PASS: TestUnresolve_apiError (0.00s)
PASS
ok      github.com/cli/cli/v2/pkg/cmd/pr/reviewthread   0.544s
```

## Tested Locally

Built and tested locally with `make build`:

```bash
$ ./bin/gh pr review-thread --help
Manage pull request review threads.

Review threads are created when comments are left on specific lines of code
during a pull request review. These threads can be resolved or unresolved to
track which feedback has been addressed.

USAGE
  gh pr review-thread <command> [flags]

AVAILABLE COMMANDS
  list:          List review threads for a pull request
  resolve:       Resolve a review thread
  unresolve:     Unresolve a review thread
```