### PR TITLE
gh run download: prefer newest artifact when names collide

### DIFF
--- a/pkg/cmd/run/download/download.go
+++ b/pkg/cmd/run/download/download.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sort"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/safepaths"
@@ -112,6 +113,22 @@ func runDownload(opts *DownloadOptions) error {
 	if err != nil {
 		return fmt.Errorf("error fetching artifacts: %w", err)
 	}
+
+	// Prefer newer artifacts when there are multiple artifacts with the same
+	// name (e.g. rerun attempts of the same workflow run can produce duplicates).
+	sort.SliceStable(artifacts, func(i, j int) bool {
+		ai, aj := artifacts[i].CreatedAt, artifacts[j].CreatedAt
+		if ai.IsZero() && aj.IsZero() {
+			return false
+		}
+		if ai.IsZero() {
+			return false
+		}
+		if aj.IsZero() {
+			return true
+		}
+		return ai.After(aj)
+	})
 
 	numValidArtifacts := 0
 	for _, a := range artifacts {

--- a/pkg/cmd/run/download/download_test.go
+++ b/pkg/cmd/run/download/download_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
@@ -581,7 +582,7 @@ func Test_runDownload(t *testing.T) {
 			},
 		},
 		{
-			name: "avoid redownloading files of the same name",
+			name: "when multiple artifacts have the same name, download the newest one",
 			opts: DownloadOptions{
 				RunID: "2345",
 			},
@@ -595,6 +596,7 @@ func Test_runDownload(t *testing.T) {
 									Name:        "artifact-1",
 									DownloadURL: "http://download.com/artifact1.zip",
 									Expired:     false,
+									CreatedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 								},
 								files: []string{
 									"artifact-1-file",
@@ -605,9 +607,10 @@ func Test_runDownload(t *testing.T) {
 									Name:        "artifact-1",
 									DownloadURL: "http://download.com/artifact2.zip",
 									Expired:     false,
+									CreatedAt:   time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
 								},
 								files: []string{
-									"artifact-2-file",
+									"artifact-1-newer-file",
 								},
 							},
 						},
@@ -615,7 +618,7 @@ func Test_runDownload(t *testing.T) {
 				},
 			},
 			expectedFiles: []string{
-				filepath.Join("artifact-1", "artifact-1-file"),
+				filepath.Join("artifact-1", "artifact-1-newer-file"),
 			},
 		},
 		{

--- a/pkg/cmd/run/shared/artifacts.go
+++ b/pkg/cmd/run/shared/artifacts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghinstance"
@@ -12,10 +13,12 @@ import (
 )
 
 type Artifact struct {
-	Name        string `json:"name"`
-	Size        uint64 `json:"size_in_bytes"`
-	DownloadURL string `json:"archive_download_url"`
-	Expired     bool   `json:"expired"`
+	Name        string    `json:"name"`
+	Size        uint64    `json:"size_in_bytes"`
+	DownloadURL string    `json:"archive_download_url"`
+	Expired     bool      `json:"expired"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 type artifactsPayload struct {


### PR DESCRIPTION
Fixes #12437.

When a workflow run is re-run, GitHub can return multiple artifacts with the same name (one per attempt). gh run download --name <artifact> previously downloaded the first occurrence and then deduped by name, which could pick an older attempt.

This change:
- Captures created_at for artifacts
- Sorts artifacts newest-first before selecting per-name
- Adds a regression test demonstrating the newer artifact is chosen when names collide