### PR TITLE
Fix fmt.Errorf format argument in ParseFullReference

### DIFF
--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -349,7 +349,7 @@ func ParseFullReference(s string) (ghrepo.Interface, int, error) {
 
 	number, err := strconv.Atoi(m[3])
 	if err != nil {
-		return nil, 0, fmt.Errorf("invalid reference: %q", s)
+		return nil, 0, fmt.Errorf("invalid reference: %q; %w", s, err)
 	}
 
 	owner := m[1]

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -349,7 +349,7 @@ func ParseFullReference(s string) (ghrepo.Interface, int, error) {
 
 	number, err := strconv.Atoi(m[3])
 	if err != nil {
-		return nil, 0, fmt.Errorf("invalid reference: %q", number)
+		return nil, 0, fmt.Errorf("invalid reference: %q", s)
 	}
 
 	owner := m[1]

--- a/pkg/cmd/pr/shared/finder_test.go
+++ b/pkg/cmd/pr/shared/finder_test.go
@@ -160,6 +160,11 @@ func TestParseFullReference(t *testing.T) {
 			arg:     "OWNER/#123",
 			wantErr: `invalid reference: "OWNER/#123"`,
 		},
+		{
+			name:    "invalid full form, too large number",
+			arg:     "OWNER/REPO#9999999999999999999",
+			wantErr: `invalid reference: "OWNER/REPO#9999999999999999999"; strconv.Atoi: parsing "9999999999999999999": value out of range`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The error path passed an int to `fmt.Errorf` with `%q`, which expects a string. Use the original reference string to avoid a format mismatch.

Found testing package in Fedora:

    ./finder.go:352:49: fmt.Errorf format %q has arg number of wrong type int