### PR TITLE
Lint source.md

### DIFF
--- a/docs/source.md
+++ b/docs/source.md
@@ -18,6 +18,7 @@
 3. Build and install
 
    #### Unix-like systems
+
    ```sh
    # installs to '/usr/local' by default; sudo may be required, or sudo -E for configured go environments
    $ make install
@@ -27,15 +28,18 @@
    ```
 
    #### Windows
+
    ```pwsh
    # build the `bin\gh.exe` binary
    > go run script\build.go
    ```
+
    There is no install step available on Windows.
 
 4. Run `gh version` to check if it worked.
 
    #### Windows
+
    Run `bin\gh version` to check if it worked.
 
 ## Cross-compiling binaries for different platforms
@@ -44,10 +48,12 @@ You can use any platform with Go installed to build a binary that is intended fo
 or CPU architecture. This is achieved by setting environment variables such as GOOS and GOARCH.
 
 For example, to compile the `gh` binary for the 32-bit Raspberry Pi OS:
+
 ```sh
 # on a Unix-like system:
 $ GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 make clean bin/gh
 ```
+
 ```pwsh
 # on Windows, pass environment variables as arguments to the build script:
 > go run script\build.go clean bin\gh GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0


### PR DESCRIPTION
Fixes:
- **MD022** / blanks-around-headings  Headings should be surrounded by blank lines
- **MD031** / blanks-around-fences Fenced code blocks should be surrounded by blank lines
