### PR TITLE
`gh pr edit`: new interactive prompt for assignee selection, performance and accessibility improvements

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -748,12 +748,8 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 	}
 
 	variables := map[string]interface{}{
-		"id": githubv4.ID(assignableID),
-	}
-	if query != "" {
-		variables["query"] = githubv4.String(query)
-	} else {
-		variables["query"] = (*githubv4.String)(nil)
+		"id":    githubv4.ID(assignableID),
+		"query": githubv4.String(query),
 	}
 
 	var result responseData

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -715,16 +715,15 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 			Issue struct {
 				SuggestedActors struct {
 					Nodes []struct {
+					    TypeName string `graphql:"__typename"`
 						User struct {
 							ID       string
 							Login    string
 							Name     string
-							TypeName string `graphql:"__typename"`
 						} `graphql:"... on User"`
 						Bot struct {
 							ID       string
 							Login    string
-							TypeName string `graphql:"__typename"`
 						} `graphql:"... on Bot"`
 					}
 				} `graphql:"suggestedActors(first: 10, query: $query)"`
@@ -732,16 +731,15 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 			PullRequest struct {
 				SuggestedActors struct {
 					Nodes []struct {
+					    TypeName string `graphql:"__typename"`
 						User struct {
 							ID       string
 							Login    string
-							Name     string
-							TypeName string `graphql:"__typename"`
+							Name     string							
 						} `graphql:"... on User"`
 						Bot struct {
 							ID       string
 							Login    string
-							TypeName string `graphql:"__typename"`
 						} `graphql:"... on Bot"`
 					}
 				} `graphql:"suggestedActors(first: 10, query: $query)"`
@@ -764,16 +762,15 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 	}
 
 	var nodes []struct {
+		TypeName string `graphql:"__typename"`
 		User struct {
 			ID       string
 			Login    string
 			Name     string
-			TypeName string `graphql:"__typename"`
 		} `graphql:"... on User"`
 		Bot struct {
 			ID       string
 			Login    string
-			TypeName string `graphql:"__typename"`
 		} `graphql:"... on Bot"`
 	}
 
@@ -789,12 +786,12 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 	viewerIncluded := false
 
 	for _, n := range nodes {
-		if n.User.TypeName == "User" && n.User.Login != "" {
+		if n.TypeName == "User" && n.User.Login != "" {
 			actors = append(actors, AssignableUser{id: n.User.ID, login: n.User.Login, name: n.User.Name})
 			if query == "" && viewerLogin != "" && n.User.Login == viewerLogin {
 				viewerIncluded = true
 			}
-		} else if n.Bot.TypeName == "Bot" && n.Bot.Login != "" {
+		} else if n.TypeName == "Bot" && n.Bot.Login != "" {
 			actors = append(actors, AssignableBot{id: n.Bot.ID, login: n.Bot.Login})
 			if query == "" && viewerLogin != "" && n.Bot.Login == viewerLogin {
 				viewerIncluded = true

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -715,15 +715,15 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 			Issue struct {
 				SuggestedActors struct {
 					Nodes []struct {
-					    TypeName string `graphql:"__typename"`
-						User struct {
-							ID       string
-							Login    string
-							Name     string
+						TypeName string `graphql:"__typename"`
+						User     struct {
+							ID    string
+							Login string
+							Name  string
 						} `graphql:"... on User"`
 						Bot struct {
-							ID       string
-							Login    string
+							ID    string
+							Login string
 						} `graphql:"... on Bot"`
 					}
 				} `graphql:"suggestedActors(first: 10, query: $query)"`
@@ -731,15 +731,15 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 			PullRequest struct {
 				SuggestedActors struct {
 					Nodes []struct {
-					    TypeName string `graphql:"__typename"`
-						User struct {
-							ID       string
-							Login    string
-							Name     string							
+						TypeName string `graphql:"__typename"`
+						User     struct {
+							ID    string
+							Login string
+							Name  string
 						} `graphql:"... on User"`
 						Bot struct {
-							ID       string
-							Login    string
+							ID    string
+							Login string
 						} `graphql:"... on Bot"`
 					}
 				} `graphql:"suggestedActors(first: 10, query: $query)"`
@@ -763,14 +763,14 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 
 	var nodes []struct {
 		TypeName string `graphql:"__typename"`
-		User struct {
-			ID       string
-			Login    string
-			Name     string
+		User     struct {
+			ID    string
+			Login string
+			Name  string
 		} `graphql:"... on User"`
 		Bot struct {
-			ID       string
-			Login    string
+			ID    string
+			Login string
 		} `graphql:"... on Bot"`
 	}
 

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -703,7 +703,6 @@ func RemovePullRequestReviews(client *Client, repo ghrepo.Interface, prNumber in
 
 // SuggestedAssignableActors fetches up to 10 suggested actors for a specific assignable
 // (Issue or PullRequest) node ID. `assignableID` is the GraphQL node ID for the Issue/PR.
-// If query is empty, the query variable is passed as null to omit filtering.
 // Returns the actors, the total count of available assignees in the repo, and an error.
 func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignableID string, query string) ([]AssignableActor, int, error) {
 	type responseData struct {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -780,29 +780,16 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 		nodes = result.Node.Issue.SuggestedActors.Nodes
 	}
 
-	actors := make([]AssignableActor, 0, len(nodes)+1) // +1 in case we add viewer
-	viewer := result.Viewer
-	viewerLogin := viewer.Login
-	viewerIncluded := false
+	actors := make([]AssignableActor, 0, len(nodes))
 
 	for _, n := range nodes {
 		if n.TypeName == "User" && n.User.Login != "" {
 			actors = append(actors, AssignableUser{id: n.User.ID, login: n.User.Login, name: n.User.Name})
-			if query == "" && viewerLogin != "" && n.User.Login == viewerLogin {
-				viewerIncluded = true
-			}
 		} else if n.TypeName == "Bot" && n.Bot.Login != "" {
 			actors = append(actors, AssignableBot{id: n.Bot.ID, login: n.Bot.Login})
-			if query == "" && viewerLogin != "" && n.Bot.Login == viewerLogin {
-				viewerIncluded = true
-			}
 		}
 	}
 
-	// When query is blank, append viewer if not already present.
-	if query == "" && viewerLogin != "" && !viewerIncluded {
-		actors = append(actors, AssignableUser{id: viewer.ID, login: viewer.Login, name: viewer.Name})
-	}
 	return actors, nil
 }
 

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -706,11 +706,6 @@ func RemovePullRequestReviews(client *Client, repo ghrepo.Interface, prNumber in
 // If query is empty, the query variable is passed as null to omit filtering.
 func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignableID string, query string) ([]AssignableActor, error) {
 	type responseData struct {
-		Viewer struct {
-			ID    string
-			Login string
-			Name  string
-		} `graphql:"viewer"`
 		Node struct {
 			Issue struct {
 				SuggestedActors struct {

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -704,8 +704,14 @@ func RemovePullRequestReviews(client *Client, repo ghrepo.Interface, prNumber in
 // SuggestedAssignableActors fetches up to 10 suggested actors for a specific assignable
 // (Issue or PullRequest) node ID. `assignableID` is the GraphQL node ID for the Issue/PR.
 // If query is empty, the query variable is passed as null to omit filtering.
-func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignableID string, query string) ([]AssignableActor, error) {
+// Returns the actors, the total count of available assignees in the repo, and an error.
+func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignableID string, query string) ([]AssignableActor, int, error) {
 	type responseData struct {
+		Repository struct {
+			AssignableUsers struct {
+				TotalCount int
+			}
+		} `graphql:"repository(owner: $owner, name: $name)"`
 		Node struct {
 			Issue struct {
 				SuggestedActors struct {
@@ -745,12 +751,16 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 	variables := map[string]interface{}{
 		"id":    githubv4.ID(assignableID),
 		"query": githubv4.String(query),
+		"owner": githubv4.String(repo.RepoOwner()),
+		"name":  githubv4.String(repo.RepoName()),
 	}
 
 	var result responseData
 	if err := client.Query(repo.RepoHost(), "SuggestedAssignableActors", &result, variables); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
+
+	availableAssigneesCount := result.Repository.AssignableUsers.TotalCount
 
 	var nodes []struct {
 		TypeName string `graphql:"__typename"`
@@ -781,7 +791,7 @@ func SuggestedAssignableActors(client *Client, repo ghrepo.Interface, assignable
 		}
 	}
 
-	return actors, nil
+	return actors, availableAssigneesCount, nil
 }
 
 func UpdatePullRequestBranch(client *Client, repo ghrepo.Interface, params githubv4.UpdatePullRequestBranchInput) error {

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -803,6 +803,8 @@ func newTestVirtualTerminal(t *testing.T) *expect.Console {
 		failOnExpectError(t),
 		failOnSendError(t),
 		expect.WithDefaultTimeout(time.Second),
+		// Use this logger to debug expect based tests by printing the
+		// characters being read to stdout.
 		// expect.WithLogger(log.New(os.Stdout, "", 0)),
 	}
 

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -228,26 +228,36 @@ func TestAccessiblePrompter(t *testing.T) {
 		console := newTestVirtualTerminal(t)
 		p := newTestAccessiblePrompter(t, console)
 		persistentOptions := []string{"persistent-option-1"}
-		searchFunc := func(input string) ([]string, []string, int, error) {
-			var searchResultKeys []string
-			var searchResultLabels []string
+	searchFunc := func(input string) prompter.MultiSelectSearchResult {
+		var searchResultKeys []string
+		var searchResultLabels []string
 
-			// Initial search with no input
-			if input == "" {
-				moreResults := 2
-				searchResultKeys = []string{"initial-result-1", "initial-result-2"}
-				searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
-				return searchResultKeys, searchResultLabels, moreResults, nil
+		// Initial search with no input
+		if input == "" {
+			moreResults := 2
+			searchResultKeys = []string{"initial-result-1", "initial-result-2"}
+			searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
+			return prompter.MultiSelectSearchResult{
+				Keys:        searchResultKeys,
+				Labels:      searchResultLabels,
+				MoreResults: moreResults,
+				Err:         nil,
 			}
-
-			// Subsequent search with input
-			moreResults := 0
-			searchResultKeys = []string{"search-result-1", "search-result-2"}
-			searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
-			return searchResultKeys, searchResultLabels, moreResults, nil
 		}
 
-		go func() {
+		// Subsequent search with input
+		moreResults := 0
+		searchResultKeys = []string{"search-result-1", "search-result-2"}
+		searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
+		return prompter.MultiSelectSearchResult{
+			Keys:        searchResultKeys,
+			Labels:      searchResultLabels,
+			MoreResults: moreResults,
+			Err:         nil,
+		}
+	}
+
+	go func() {
 			// Wait for prompt to appear
 			_, err := console.ExpectString("Select an option \r\n")
 			require.NoError(t, err)
@@ -291,16 +301,26 @@ func TestAccessiblePrompter(t *testing.T) {
 		initialSearchResultKeys := []string{"initial-result-1"}
 		initialSearchResultLabels := []string{"Initial Result Label 1"}
 		defaultOptions := initialSearchResultKeys
-		searchFunc := func(input string) ([]string, []string, int, error) {
+		searchFunc := func(input string) prompter.MultiSelectSearchResult {
 			// Initial search with no input
 			if input == "" {
 				moreResults := 2
-				return initialSearchResultKeys, initialSearchResultLabels, moreResults, nil
+				return prompter.MultiSelectSearchResult{
+					Keys:        initialSearchResultKeys,
+					Labels:      initialSearchResultLabels,
+					MoreResults: moreResults,
+					Err:         nil,
+				}
 			}
 
 			// No search selected, so this should fail the test.
 			t.FailNow()
-			return nil, nil, 0, nil
+			return prompter.MultiSelectSearchResult{
+				Keys:        nil,
+				Labels:      nil,
+				MoreResults: 0,
+				Err:         nil,
+			}
 		}
 
 		go func() {
@@ -325,21 +345,36 @@ func TestAccessiblePrompter(t *testing.T) {
 		moreResultKeys := []string{"more-result-1"}
 		moreResultLabels := []string{"More Result Label 1"}
 
-		searchFunc := func(input string) ([]string, []string, int, error) {
+		searchFunc := func(input string) prompter.MultiSelectSearchResult {
 			// Initial search with no input
 			if input == "" {
 				moreResults := 2
-				return initialSearchResultKeys, initialSearchResultLabels, moreResults, nil
+				return prompter.MultiSelectSearchResult{
+					Keys:        initialSearchResultKeys,
+					Labels:      initialSearchResultLabels,
+					MoreResults: moreResults,
+					Err:         nil,
+				}
 			}
 
 			// Subsequent search with input "more"
 			if input == "more" {
-				return moreResultKeys, moreResultLabels, 0, nil
+				return prompter.MultiSelectSearchResult{
+					Keys:        moreResultKeys,
+					Labels:      moreResultLabels,
+					MoreResults: 0,
+					Err:         nil,
+				}
 			}
 
 			// No other searches expected
 			t.FailNow()
-			return nil, nil, 0, nil
+			return prompter.MultiSelectSearchResult{
+				Keys:        nil,
+				Labels:      nil,
+				MoreResults: 0,
+				Err:         nil,
+			}
 		}
 
 		go func() {

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -420,6 +420,21 @@ func TestAccessiblePrompter(t *testing.T) {
 		assert.Equal(t, expectedValues, multiSelectValues)
 	})
 
+	t.Run("MultiSelectWithSearch - search error propagates", func(t *testing.T) {
+		console := newTestVirtualTerminal(t)
+		p := newTestAccessiblePrompter(t, console)
+
+		searchFunc := func(input string) prompter.MultiSelectSearchResult {
+			return prompter.MultiSelectSearchResult{
+				Err: fmt.Errorf("search error"),
+			}
+		}
+
+		_, err := p.MultiSelectWithSearch("Select", "Search", []string{}, []string{}, searchFunc)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "search error")
+	})
+
 	t.Run("Input", func(t *testing.T) {
 		console := newTestVirtualTerminal(t)
 		p := newTestAccessiblePrompter(t, console)

--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -228,15 +228,27 @@ func TestAccessiblePrompter(t *testing.T) {
 		console := newTestVirtualTerminal(t)
 		p := newTestAccessiblePrompter(t, console)
 		persistentOptions := []string{"persistent-option-1"}
-	searchFunc := func(input string) prompter.MultiSelectSearchResult {
-		var searchResultKeys []string
-		var searchResultLabels []string
+		searchFunc := func(input string) prompter.MultiSelectSearchResult {
+			var searchResultKeys []string
+			var searchResultLabels []string
 
-		// Initial search with no input
-		if input == "" {
-			moreResults := 2
-			searchResultKeys = []string{"initial-result-1", "initial-result-2"}
-			searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
+			// Initial search with no input
+			if input == "" {
+				moreResults := 2
+				searchResultKeys = []string{"initial-result-1", "initial-result-2"}
+				searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
+				return prompter.MultiSelectSearchResult{
+					Keys:        searchResultKeys,
+					Labels:      searchResultLabels,
+					MoreResults: moreResults,
+					Err:         nil,
+				}
+			}
+
+			// Subsequent search with input
+			moreResults := 0
+			searchResultKeys = []string{"search-result-1", "search-result-2"}
+			searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
 			return prompter.MultiSelectSearchResult{
 				Keys:        searchResultKeys,
 				Labels:      searchResultLabels,
@@ -245,19 +257,7 @@ func TestAccessiblePrompter(t *testing.T) {
 			}
 		}
 
-		// Subsequent search with input
-		moreResults := 0
-		searchResultKeys = []string{"search-result-1", "search-result-2"}
-		searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
-		return prompter.MultiSelectSearchResult{
-			Keys:        searchResultKeys,
-			Labels:      searchResultLabels,
-			MoreResults: moreResults,
-			Err:         nil,
-		}
-	}
-
-	go func() {
+		go func() {
 			// Wait for prompt to appear
 			_, err := console.ExpectString("Select an option \r\n")
 			require.NoError(t, err)

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -27,8 +27,8 @@ type Prompter interface {
 	// Items passed in persistentOptions are always shown in the list, even when not selected.
 	// Unlike MultiSelect, MultiselectWithSearch returns the selected option strings,
 	// not their indices, since the list of options is dynamic.
-	// The searchFunc args and return values are: func(query) (map[keys]labels, moreResultsCount, searchError)
-	// Where the selected keys are eventually returned by MultiSelectWithSearch and the labels are what is shown to the user in the prompt.
+	// The searchFunc has the signature: func(query string) MultiSelectSearchResult.
+	// In the returned MultiSelectSearchResult, Keys are the values eventually returned by MultiSelectWithSearch and Labels are what is shown to the user in the prompt.
 	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) MultiSelectSearchResult) ([]string, error)
 	// Input prompts the user to enter a string value.
 	Input(prompt string, defaultValue string) (string, error)

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -21,6 +21,15 @@ type Prompter interface {
 	Select(prompt string, defaultValue string, options []string) (int, error)
 	// MultiSelect prompts the user to select one or more options from a list of options.
 	MultiSelect(prompt string, defaults []string, options []string) ([]int, error)
+	// MultiSelectWithSearch is MultiSelect with an added search option to the list,
+	// prompting the user for text input to filter the options via the searchFunc.
+	// Items selected in the search are persisted in the list after subsequent searches.
+	// Items passed in persistentOptions are always shown in the list, even when not selected.
+	// Unlike MultiSelect, MultiselectWithSearch returns the selected option strings,
+	// not their indices, since the list of options is dynamic.
+	// The searchFunc args and return values are: func(query) (map[keys]labels, moreResultsCount, searchError)
+	// Where the selected keys are eventually returned by MultiSelectWithSearch and the labels are what is shown to the user in the prompt.
+	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
 	// Input prompts the user to enter a string value.
 	Input(prompt string, defaultValue string) (string, error)
 	// Password prompts the user to enter a password.
@@ -320,6 +329,10 @@ func (p *accessiblePrompter) MarkdownEditor(prompt, defaultValue string, blankAl
 	return text, nil
 }
 
+func (p *accessiblePrompter) MultiSelectWithSearch(prompt, searchPrompt string, defaultValues, persistentValues []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+	return multiSelectWithSearch(p, prompt, searchPrompt, defaultValues, persistentValues, searchFunc)
+}
+
 type surveyPrompter struct {
 	prompter  *ghPrompter.Prompter
 	stdin     ghPrompter.FileReader
@@ -334,6 +347,147 @@ func (p *surveyPrompter) Select(prompt, defaultValue string, options []string) (
 
 func (p *surveyPrompter) MultiSelect(prompt string, defaultValues, options []string) ([]int, error) {
 	return p.prompter.MultiSelect(prompt, defaultValues, options)
+}
+
+func (p *surveyPrompter) MultiSelectWithSearch(prompt string, searchPrompt string, defaultValues, persistentValues []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+	return multiSelectWithSearch(p, prompt, searchPrompt, defaultValues, persistentValues, searchFunc)
+}
+
+func multiSelectWithSearch(p Prompter, prompt, searchPrompt string, defaultValues, persistentValues []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+	selectedOptions := defaultValues
+
+	// The optionKeyLabels map is used to uniquely identify optionKeyLabels
+	// and provide optional display labels.
+	optionKeyLabels := make(map[string]string)
+	for _, k := range selectedOptions {
+		optionKeyLabels[k] = k
+	}
+
+	searchResultKeys, searchResultLabels, moreResults, err := searchFunc("")
+	if err != nil {
+		return nil, fmt.Errorf("failed to search: %w", err)
+	}
+
+	for i, k := range searchResultKeys {
+		optionKeyLabels[k] = searchResultLabels[i]
+	}
+
+	for {
+		// Build dynamic option list ->  search sentinel, selections, search results, persistent options.
+		optionKeys := make([]string, 0, 1+len(selectedOptions)+len(searchResultKeys)+len(persistentValues))
+		optionLabels := make([]string, 0, len(optionKeys))
+
+		// 1. Search sentinel.
+		optionKeys = append(optionKeys, "")
+		if moreResults > 0 {
+			optionLabels = append(optionLabels, fmt.Sprintf("Search (%d more)", moreResults))
+		} else {
+			optionLabels = append(optionLabels, "Search")
+		}
+
+		// 2. Selections
+		for _, k := range selectedOptions {
+			l := optionKeyLabels[k]
+
+			if l == "" {
+				l = k
+			}
+
+			optionKeys = append(optionKeys, k)
+			optionLabels = append(optionLabels, l)
+		}
+
+		// 3. Search results
+		for _, k := range searchResultKeys {
+			// It's already selected or persistent, if we add here we'll have duplicates.
+			if slices.Contains(selectedOptions, k) || slices.Contains(persistentValues, k) {
+				continue
+			}
+
+			l := optionKeyLabels[k]
+			if l == "" {
+				l = k
+			}
+			optionKeys = append(optionKeys, k)
+			optionLabels = append(optionLabels, l)
+		}
+
+		// 4. Persistent options
+		for _, k := range persistentValues {
+			if slices.Contains(selectedOptions, k) {
+				continue
+			}
+
+			l := optionKeyLabels[k]
+			if l == "" {
+				l = k
+			}
+
+			optionKeys = append(optionKeys, k)
+			optionLabels = append(optionLabels, l)
+		}
+
+		selectedOptionLabels := make([]string, len(selectedOptions))
+		for i, k := range selectedOptions {
+			l := optionKeyLabels[k]
+			if l == "" {
+				l = k
+			}
+			selectedOptionLabels[i] = l
+		}
+
+		selectedIdxs, err := p.MultiSelect(prompt, selectedOptionLabels, optionLabels)
+		if err != nil {
+			return nil, err
+		}
+
+		pickedSearch := false
+		var newSelectedOptions []string
+		for _, idx := range selectedIdxs {
+			if idx == 0 { // Search sentinel selected
+				pickedSearch = true
+				continue
+			}
+
+			if idx < 0 || idx >= len(optionKeys) {
+				continue
+			}
+
+			key := optionKeys[idx]
+			if key == "" {
+				continue
+			}
+
+			newSelectedOptions = append(newSelectedOptions, key)
+		}
+
+		selectedOptions = newSelectedOptions
+		for _, k := range selectedOptions {
+			if _, ok := optionKeyLabels[k]; !ok {
+				optionKeyLabels[k] = k
+			}
+		}
+
+		if pickedSearch {
+			query, err := p.Input(searchPrompt, "")
+			if err != nil {
+				return nil, err
+			}
+
+			searchResultKeys, searchResultLabels, moreResults, err = searchFunc(query)
+			if err != nil {
+				return nil, err
+			}
+
+			for i, k := range searchResultKeys {
+				optionKeyLabels[k] = searchResultLabels[i]
+			}
+
+			continue
+		}
+
+		return selectedOptions, nil
+	}
 }
 
 func (p *surveyPrompter) Input(prompt, defaultValue string) (string, error) {

--- a/internal/prompter/prompter_mock.go
+++ b/internal/prompter/prompter_mock.go
@@ -38,6 +38,9 @@ var _ Prompter = &PrompterMock{}
 //			MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
 //				panic("mock out the MultiSelect method")
 //			},
+//			MultiSelectWithSearchFunc: func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+//				panic("mock out the MultiSelectWithSearch method")
+//			},
 //			PasswordFunc: func(prompt string) (string, error) {
 //				panic("mock out the Password method")
 //			},
@@ -71,6 +74,9 @@ type PrompterMock struct {
 
 	// MultiSelectFunc mocks the MultiSelect method.
 	MultiSelectFunc func(prompt string, defaults []string, options []string) ([]int, error)
+
+	// MultiSelectWithSearchFunc mocks the MultiSelectWithSearch method.
+	MultiSelectWithSearchFunc func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
 
 	// PasswordFunc mocks the Password method.
 	PasswordFunc func(prompt string) (string, error)
@@ -123,6 +129,19 @@ type PrompterMock struct {
 			// Options is the options argument value.
 			Options []string
 		}
+		// MultiSelectWithSearch holds details about calls to the MultiSelectWithSearch method.
+		MultiSelectWithSearch []struct {
+			// Prompt is the prompt argument value.
+			Prompt string
+			// SearchPrompt is the searchPrompt argument value.
+			SearchPrompt string
+			// Defaults is the defaults argument value.
+			Defaults []string
+			// PersistentOptions is the persistentOptions argument value.
+			PersistentOptions []string
+			// SearchFunc is the searchFunc argument value.
+			SearchFunc func(string) ([]string, []string, int, error)
+		}
 		// Password holds details about calls to the Password method.
 		Password []struct {
 			// Prompt is the prompt argument value.
@@ -138,15 +157,16 @@ type PrompterMock struct {
 			Options []string
 		}
 	}
-	lockAuthToken       sync.RWMutex
-	lockConfirm         sync.RWMutex
-	lockConfirmDeletion sync.RWMutex
-	lockInput           sync.RWMutex
-	lockInputHostname   sync.RWMutex
-	lockMarkdownEditor  sync.RWMutex
-	lockMultiSelect     sync.RWMutex
-	lockPassword        sync.RWMutex
-	lockSelect          sync.RWMutex
+	lockAuthToken             sync.RWMutex
+	lockConfirm               sync.RWMutex
+	lockConfirmDeletion       sync.RWMutex
+	lockInput                 sync.RWMutex
+	lockInputHostname         sync.RWMutex
+	lockMarkdownEditor        sync.RWMutex
+	lockMultiSelect           sync.RWMutex
+	lockMultiSelectWithSearch sync.RWMutex
+	lockPassword              sync.RWMutex
+	lockSelect                sync.RWMutex
 }
 
 // AuthToken calls AuthTokenFunc.
@@ -384,6 +404,54 @@ func (mock *PrompterMock) MultiSelectCalls() []struct {
 	mock.lockMultiSelect.RLock()
 	calls = mock.calls.MultiSelect
 	mock.lockMultiSelect.RUnlock()
+	return calls
+}
+
+// MultiSelectWithSearch calls MultiSelectWithSearchFunc.
+func (mock *PrompterMock) MultiSelectWithSearch(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+	if mock.MultiSelectWithSearchFunc == nil {
+		panic("PrompterMock.MultiSelectWithSearchFunc: method is nil but Prompter.MultiSelectWithSearch was just called")
+	}
+	callInfo := struct {
+		Prompt            string
+		SearchPrompt      string
+		Defaults          []string
+		PersistentOptions []string
+		SearchFunc        func(string) ([]string, []string, int, error)
+	}{
+		Prompt:            prompt,
+		SearchPrompt:      searchPrompt,
+		Defaults:          defaults,
+		PersistentOptions: persistentOptions,
+		SearchFunc:        searchFunc,
+	}
+	mock.lockMultiSelectWithSearch.Lock()
+	mock.calls.MultiSelectWithSearch = append(mock.calls.MultiSelectWithSearch, callInfo)
+	mock.lockMultiSelectWithSearch.Unlock()
+	return mock.MultiSelectWithSearchFunc(prompt, searchPrompt, defaults, persistentOptions, searchFunc)
+}
+
+// MultiSelectWithSearchCalls gets all the calls that were made to MultiSelectWithSearch.
+// Check the length with:
+//
+//	len(mockedPrompter.MultiSelectWithSearchCalls())
+func (mock *PrompterMock) MultiSelectWithSearchCalls() []struct {
+	Prompt            string
+	SearchPrompt      string
+	Defaults          []string
+	PersistentOptions []string
+	SearchFunc        func(string) ([]string, []string, int, error)
+} {
+	var calls []struct {
+		Prompt            string
+		SearchPrompt      string
+		Defaults          []string
+		PersistentOptions []string
+		SearchFunc        func(string) ([]string, []string, int, error)
+	}
+	mock.lockMultiSelectWithSearch.RLock()
+	calls = mock.calls.MultiSelectWithSearch
+	mock.lockMultiSelectWithSearch.RUnlock()
 	return calls
 }
 

--- a/internal/prompter/prompter_mock.go
+++ b/internal/prompter/prompter_mock.go
@@ -38,7 +38,7 @@ var _ Prompter = &PrompterMock{}
 //			MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
 //				panic("mock out the MultiSelect method")
 //			},
-//			MultiSelectWithSearchFunc: func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+//			MultiSelectWithSearchFunc: func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) MultiSelectSearchResult) ([]string, error) {
 //				panic("mock out the MultiSelectWithSearch method")
 //			},
 //			PasswordFunc: func(prompt string) (string, error) {
@@ -76,7 +76,7 @@ type PrompterMock struct {
 	MultiSelectFunc func(prompt string, defaults []string, options []string) ([]int, error)
 
 	// MultiSelectWithSearchFunc mocks the MultiSelectWithSearch method.
-	MultiSelectWithSearchFunc func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
+	MultiSelectWithSearchFunc func(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) MultiSelectSearchResult) ([]string, error)
 
 	// PasswordFunc mocks the Password method.
 	PasswordFunc func(prompt string) (string, error)
@@ -140,7 +140,7 @@ type PrompterMock struct {
 			// PersistentOptions is the persistentOptions argument value.
 			PersistentOptions []string
 			// SearchFunc is the searchFunc argument value.
-			SearchFunc func(string) ([]string, []string, int, error)
+			SearchFunc func(string) MultiSelectSearchResult
 		}
 		// Password holds details about calls to the Password method.
 		Password []struct {
@@ -408,7 +408,7 @@ func (mock *PrompterMock) MultiSelectCalls() []struct {
 }
 
 // MultiSelectWithSearch calls MultiSelectWithSearchFunc.
-func (mock *PrompterMock) MultiSelectWithSearch(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+func (mock *PrompterMock) MultiSelectWithSearch(prompt string, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) MultiSelectSearchResult) ([]string, error) {
 	if mock.MultiSelectWithSearchFunc == nil {
 		panic("PrompterMock.MultiSelectWithSearchFunc: method is nil but Prompter.MultiSelectWithSearch was just called")
 	}
@@ -417,7 +417,7 @@ func (mock *PrompterMock) MultiSelectWithSearch(prompt string, searchPrompt stri
 		SearchPrompt      string
 		Defaults          []string
 		PersistentOptions []string
-		SearchFunc        func(string) ([]string, []string, int, error)
+		SearchFunc        func(string) MultiSelectSearchResult
 	}{
 		Prompt:            prompt,
 		SearchPrompt:      searchPrompt,
@@ -440,14 +440,14 @@ func (mock *PrompterMock) MultiSelectWithSearchCalls() []struct {
 	SearchPrompt      string
 	Defaults          []string
 	PersistentOptions []string
-	SearchFunc        func(string) ([]string, []string, int, error)
+	SearchFunc        func(string) MultiSelectSearchResult
 } {
 	var calls []struct {
 		Prompt            string
 		SearchPrompt      string
 		Defaults          []string
 		PersistentOptions []string
-		SearchFunc        func(string) ([]string, []string, int, error)
+		SearchFunc        func(string) MultiSelectSearchResult
 	}
 	mock.lockMultiSelectWithSearch.RLock()
 	calls = mock.calls.MultiSelectWithSearch

--- a/internal/prompter/test.go
+++ b/internal/prompter/test.go
@@ -99,7 +99,7 @@ func (m *MockPrompter) MarkdownEditor(prompt, defaultValue string, blankAllowed 
 	return s.fn(prompt, defaultValue, blankAllowed)
 }
 
-func (m *MockPrompter) MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+func (m *MockPrompter) MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) MultiSelectSearchResult) ([]string, error) {
 	var s multiSelectWithSearchStub
 	if len(m.multiSelectWithSearchStubs) == 0 {
 		return nil, NoSuchPromptErr(prompt)

--- a/internal/prompter/test.go
+++ b/internal/prompter/test.go
@@ -25,10 +25,11 @@ func NewMockPrompter(t *testing.T) *MockPrompter {
 type MockPrompter struct {
 	t *testing.T
 	ghPrompter.PrompterMock
-	authTokenStubs       []authTokenStub
-	confirmDeletionStubs []confirmDeletionStub
-	inputHostnameStubs   []inputHostnameStub
-	markdownEditorStubs  []markdownEditorStub
+	authTokenStubs             []authTokenStub
+	confirmDeletionStubs       []confirmDeletionStub
+	inputHostnameStubs         []inputHostnameStub
+	markdownEditorStubs        []markdownEditorStub
+	multiSelectWithSearchStubs []multiSelectWithSearchStub
 }
 
 type authTokenStub struct {
@@ -47,6 +48,12 @@ type inputHostnameStub struct {
 type markdownEditorStub struct {
 	prompt string
 	fn     func(string, string, bool) (string, error)
+}
+
+type multiSelectWithSearchStub struct {
+	prompt       string
+	searchPrompt string
+	fn           func(string, string, []string, []string) ([]string, error)
 }
 
 func (m *MockPrompter) AuthToken() (string, error) {
@@ -90,6 +97,16 @@ func (m *MockPrompter) MarkdownEditor(prompt, defaultValue string, blankAllowed 
 		return "", NoSuchPromptErr(prompt)
 	}
 	return s.fn(prompt, defaultValue, blankAllowed)
+}
+
+func (m *MockPrompter) MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error) {
+	var s multiSelectWithSearchStub
+	if len(m.multiSelectWithSearchStubs) == 0 {
+		return nil, NoSuchPromptErr(prompt)
+	}
+	s = m.multiSelectWithSearchStubs[0]
+	m.multiSelectWithSearchStubs = m.multiSelectWithSearchStubs[1:len(m.multiSelectWithSearchStubs)]
+	return s.fn(prompt, searchPrompt, defaults, persistentOptions)
 }
 
 func (m *MockPrompter) RegisterAuthToken(stub func() (string, error)) {

--- a/internal/prompter/test.go
+++ b/internal/prompter/test.go
@@ -51,9 +51,7 @@ type markdownEditorStub struct {
 }
 
 type multiSelectWithSearchStub struct {
-	prompt       string
-	searchPrompt string
-	fn           func(string, string, []string, []string) ([]string, error)
+	fn func(string, string, []string, []string, func(string) MultiSelectSearchResult) ([]string, error)
 }
 
 func (m *MockPrompter) AuthToken() (string, error) {
@@ -106,7 +104,7 @@ func (m *MockPrompter) MultiSelectWithSearch(prompt, searchPrompt string, defaul
 	}
 	s = m.multiSelectWithSearchStubs[0]
 	m.multiSelectWithSearchStubs = m.multiSelectWithSearchStubs[1:len(m.multiSelectWithSearchStubs)]
-	return s.fn(prompt, searchPrompt, defaults, persistentOptions)
+	return s.fn(prompt, searchPrompt, defaults, persistentOptions, searchFunc)
 }
 
 func (m *MockPrompter) RegisterAuthToken(stub func() (string, error)) {

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -845,7 +845,7 @@ func mockRepoMetadata(_ *testing.T, reg *httpmock.Registry) {
 		{ "data": { "repository": { "suggestedActors": {
 			"nodes": [
 				{ "login": "hubot", "id": "HUBOTID", "__typename": "Bot" },
-				{ "login": "MonaLisa", "id": "MONAID", "name": "Mona Display Name", "__typename": "User" }
+				{ "login": "monalisa", "id": "MONAID", "name": "Mona Display Name", "__typename": "User" }
 			],
 			"pageInfo": { "hasNextPage": false }
 		} } } }

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -338,6 +338,11 @@ func editRun(opts *EditOptions) error {
 	return nil
 }
 
+// assigneeSearchFunc is intended to be an arg for MultiSelectWithSearch
+// to return potential assignee actors.
+// It also contains an important enclosure to update the editable's
+// assignable actors metadata for later ID resolution - this is required
+// while we continue to use IDs for mutating assignees with the GQL API.
 func assigneeSearchFunc(apiClient *api.Client, repo ghrepo.Interface, editable *shared.Editable, assignableID string) func(string) prompter.MultiSelectSearchResult {
 	searchFunc := func(input string) prompter.MultiSelectSearchResult {
 		actors, err := api.SuggestedAssignableActors(

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -294,7 +294,7 @@ func editRun(opts *EditOptions) error {
 	apiClient := api.NewClientFromHTTP(httpClient)
 
 	// Wire up search functions for assignees and reviewers.
-	// TODO: Wire up reviewer search func.
+	// TODO KW: Wire up reviewer search func if/when it exists.
 	if issueFeatures.ActorIsAssignable {
 		editable.AssigneeSearchFunc = assigneeSearchFunc(apiClient, repo, &editable, pr.ID)
 	}

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -295,7 +295,9 @@ func editRun(opts *EditOptions) error {
 
 	// Wire up search functions for assignees and reviewers.
 	// TODO: Wire up reviewer search func.
-	editable.AssigneeSearchFunc = assigneeSearchFunc(apiClient, repo, &editable, pr.ID)
+	if issueFeatures.ActorIsAssignable {
+		editable.AssigneeSearchFunc = assigneeSearchFunc(apiClient, repo, &editable, pr.ID)
+	}
 
 	opts.IO.StartProgressIndicator()
 	err = opts.Fetcher.EditableOptionsFetch(apiClient, repo, &editable, opts.Detector.ProjectsV1())

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -345,7 +345,7 @@ func editRun(opts *EditOptions) error {
 // while we continue to use IDs for mutating assignees with the GQL API.
 func assigneeSearchFunc(apiClient *api.Client, repo ghrepo.Interface, editable *shared.Editable, assignableID string) func(string) prompter.MultiSelectSearchResult {
 	searchFunc := func(input string) prompter.MultiSelectSearchResult {
-		actors, err := api.SuggestedAssignableActors(
+		actors, availableAssigneesCount, err := api.SuggestedAssignableActors(
 			apiClient,
 			repo,
 			assignableID,
@@ -382,7 +382,7 @@ func assigneeSearchFunc(apiClient *api.Client, repo ghrepo.Interface, editable *
 		return prompter.MultiSelectSearchResult{
 			Keys:        logins,
 			Labels:      displayNames,
-			MoreResults: 0,
+			MoreResults: availableAssigneesCount,
 			Err:         nil,
 		}
 	}

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -354,8 +354,8 @@ func assigneeSearchFunc(apiClient *api.Client, repo ghrepo.Interface, editable *
 			}
 		}
 
-		var logins []string
-		var displayNames []string
+		logins := make([]string, 0, len(actors))
+		displayNames := make([]string, 0, len(actors))
 
 		for _, a := range actors {
 			if a.Login() != "" {

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -843,8 +843,6 @@ func Test_editRun(t *testing.T) {
 				EditorRetriever: testEditorRetriever{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				// No RepositoryAssignableActors query needed - searchFunc handles dynamic fetching
-				// (metadata populated in test mock)
 				mockPullRequestUpdate(reg)
 				reg.Register(
 					httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -714,7 +714,13 @@ func Test_editRun(t *testing.T) {
 					editFields: func(e *shared.Editable, _ string) error {
 						e.Title.Value = "new title"
 						e.Body.Value = "new body"
-						e.Assignees.Value = []string{"monalisa", "hubot"}
+						// When ActorAssignees is enabled, the interactive flow returns display names (or logins for non-users)
+						e.Assignees.Value = []string{"monalisa (Mona Display Name)", "hubot"}
+						// Populate metadata to simulate what searchFunc would do during prompting
+						e.Metadata.AssignableActors = []api.AssignableActor{
+							api.NewAssignableBot("HUBOTID", "hubot"),
+							api.NewAssignableUser("MONAID", "monalisa", "Mona Display Name"),
+						}
 						e.Labels.Value = []string{"feature", "TODO", "bug"}
 						e.Labels.Add = []string{"feature", "TODO", "bug"}
 						e.Labels.Remove = []string{"docs"}
@@ -728,7 +734,8 @@ func Test_editRun(t *testing.T) {
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				// interactive but reviewers not chosen; need everything except reviewers/teams
-				mockRepoMetadata(reg, mockRepoMetadataOptions{assignees: true, labels: true, projects: true, milestones: true})
+				// assignees: false because searchFunc handles dynamic fetching (metadata populated in test mock)
+				mockRepoMetadata(reg, mockRepoMetadataOptions{assignees: false, labels: true, projects: true, milestones: true})
 				mockPullRequestUpdate(reg)
 				mockPullRequestUpdateActorAssignees(reg)
 				mockPullRequestUpdateLabels(reg)
@@ -822,8 +829,13 @@ func Test_editRun(t *testing.T) {
 						require.Equal(t, []string{"hubot"}, e.Assignees.Default)
 						require.Equal(t, []string{"hubot"}, e.Assignees.DefaultLogins)
 
-						// Adding MonaLisa as PR assignee, should preserve hubot.
-						e.Assignees.Value = []string{"hubot", "MonaLisa (Mona Display Name)"}
+						// Adding monalisa as PR assignee, should preserve hubot.
+						e.Assignees.Value = []string{"hubot", "monalisa (Mona Display Name)"}
+						// Populate metadata to simulate what searchFunc would do during prompting
+						e.Metadata.AssignableActors = []api.AssignableActor{
+							api.NewAssignableBot("HUBOTID", "hubot"),
+							api.NewAssignableUser("MONAID", "monalisa", "Mona Display Name"),
+						}
 						return nil
 					},
 				},
@@ -831,17 +843,8 @@ func Test_editRun(t *testing.T) {
 				EditorRetriever: testEditorRetriever{},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryAssignableActors\b`),
-					httpmock.StringResponse(`
-					{ "data": { "repository": { "suggestedActors": {
-						"nodes": [
-							{ "login": "hubot", "id": "HUBOTID", "__typename": "Bot" },
-							{ "login": "MonaLisa", "id": "MONAID", "name": "Mona Display Name", "__typename": "User" }
-						],
-						"pageInfo": { "hasNextPage": false }
-					} } } }
-					`))
+				// No RepositoryAssignableActors query needed - searchFunc handles dynamic fetching
+				// (metadata populated in test mock)
 				mockPullRequestUpdate(reg)
 				reg.Register(
 					httpmock.GraphQL(`mutation ReplaceActorsForAssignable\b`),
@@ -886,7 +889,7 @@ func Test_editRun(t *testing.T) {
 					{ "data": { "repository": { "assignableUsers": {
 						"nodes": [
 							{ "login": "hubot", "id": "HUBOTID" },
-							{ "login": "MonaLisa", "id": "MONAID" }
+							{ "login": "monalisa", "id": "MONAID" }
 						],
 						"pageInfo": { "hasNextPage": false }
 					} } } }
@@ -1001,7 +1004,7 @@ func mockRepoMetadata(reg *httpmock.Registry, opt mockRepoMetadataOptions) {
 			{ "data": { "repository": { "suggestedActors": {
 				"nodes": [
 					{ "login": "hubot", "id": "HUBOTID", "__typename": "Bot" },
-					{ "login": "MonaLisa", "id": "MONAID", "name": "Mona Display Name", "__typename": "User" }
+					{ "login": "monalisa", "id": "MONAID", "name": "Mona Display Name", "__typename": "User" }
 				],
 				"pageInfo": { "hasNextPage": false }
 			} } } }

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -430,9 +430,15 @@ func FetchOptions(client *api.Client, repo ghrepo.Interface, editable *Editable,
 	fetchAssignees := false
 	if editable.Assignees.Edited {
 		// Similar as above, this is likely an interactive flow if no Add/Remove slices are set.
-		// The addition here is that we also check for an assignee search func because
-		// if that is set, the prompter will handle dynamic fetching of assignees.
+		// The addition here is that we also check for an assignee search func.
+		// If we have a search func, we don't need to fetch assignees since we
+		// assume that will be done dynamically in the prompting flow.
 		if len(editable.Assignees.Add) == 0 && len(editable.Assignees.Remove) == 0 && editable.AssigneeSearchFunc == nil {
+			fetchAssignees = true
+		}
+		// However, if we have Add/Remove operations (non-interactive flow),
+		// we do need to fetch the assignees.
+		if len(editable.Assignees.Add) > 0 || len(editable.Assignees.Remove) > 0 {
 			fetchAssignees = true
 		}
 	}

--- a/pkg/cmd/pr/shared/editable.go
+++ b/pkg/cmd/pr/shared/editable.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/set"
 )
 
@@ -16,7 +17,7 @@ type Editable struct {
 	Reviewers          EditableSlice
 	ReviewerSearchFunc func(string) ([]string, []string, error)
 	Assignees          EditableAssignees
-	AssigneeSearchFunc func(string) ([]string, []string, int, error)
+	AssigneeSearchFunc func(string) prompter.MultiSelectSearchResult
 	Labels             EditableSlice
 	Projects           EditableProjects
 	Milestone          EditableString
@@ -279,7 +280,7 @@ type EditPrompter interface {
 	Input(string, string) (string, error)
 	MarkdownEditor(string, string, bool) (string, error)
 	MultiSelect(string, []string, []string) ([]int, error)
-	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
+	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) prompter.MultiSelectSearchResult) ([]string, error)
 	Confirm(string, bool) (bool, error)
 }
 

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -209,7 +209,6 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 	// Populate the list of selectable assignees and their default selections.
 	// This logic maps the default assignees from `state` to the corresponding actors or users
 	// so that the correct display names are preselected in the prompt.
-	// TODO: KW21 This will need to go away since we're going to dynamically load assignees via search.
 	var assignees []string
 	var assigneesDefault []string
 	if state.ActorAssignees {
@@ -267,9 +266,6 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 			fmt.Fprintln(io.ErrOut, "warning: no available reviewers")
 		}
 	}
-	// TODO: KW21 This will need to change to use MultiSelectWithSearch once it's implemented.
-	// MultiSelectWithSearch will return the selected strings directly instead of indices,
-	// so the logic here will need to be updated accordingly.
 	if isChosen("Assignees") {
 		if len(assignees) > 0 {
 			selected, err := p.MultiSelect("Assignees", assigneesDefault, assignees)

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -35,11 +35,11 @@ const (
 )
 
 type Prompt interface {
-	Input(string, string) (string, error)
-	Select(string, string, []string) (int, error)
-	MarkdownEditor(string, string, bool) (string, error)
-	Confirm(string, bool) (bool, error)
-	MultiSelect(string, []string, []string) ([]int, error)
+	Input(prompt string, defaultValue string) (string, error)
+	Select(prompt string, defaultValue string, options []string) (int, error)
+	MarkdownEditor(prompt string, defaultValue string, blankAllowed bool) (string, error)
+	Confirm(prompt string, defaultValue bool) (bool, error)
+	MultiSelect(prompt string, defaults []string, options []string) ([]int, error)
 }
 
 func ConfirmIssueSubmission(p Prompt, allowPreview bool, allowMetadata bool) (Action, error) {

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -40,6 +40,7 @@ type Prompt interface {
 	MarkdownEditor(prompt string, defaultValue string, blankAllowed bool) (string, error)
 	Confirm(prompt string, defaultValue bool) (bool, error)
 	MultiSelect(prompt string, defaults []string, options []string) ([]int, error)
+	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
 }
 
 func ConfirmIssueSubmission(p Prompt, allowPreview bool, allowMetadata bool) (Action, error) {
@@ -207,6 +208,7 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 	// Populate the list of selectable assignees and their default selections.
 	// This logic maps the default assignees from `state` to the corresponding actors or users
 	// so that the correct display names are preselected in the prompt.
+	// TODO: KW21 This will need to go away since we're going to dynamically load assignees via search.
 	var assignees []string
 	var assigneesDefault []string
 	if state.ActorAssignees {
@@ -264,6 +266,9 @@ func MetadataSurvey(p Prompt, io *iostreams.IOStreams, baseRepo ghrepo.Interface
 			fmt.Fprintln(io.ErrOut, "warning: no available reviewers")
 		}
 	}
+	// TODO: KW21 This will need to change to use MultiSelectWithSearch once it's implemented.
+	// MultiSelectWithSearch will return the selected strings directly instead of indices,
+	// so the logic here will need to be updated accordingly.
 	if isChosen("Assignees") {
 		if len(assignees) > 0 {
 			selected, err := p.MultiSelect("Assignees", assigneesDefault, assignees)

--- a/pkg/cmd/pr/shared/survey.go
+++ b/pkg/cmd/pr/shared/survey.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/cli/cli/v2/pkg/surveyext"
@@ -40,7 +41,7 @@ type Prompt interface {
 	MarkdownEditor(prompt string, defaultValue string, blankAllowed bool) (string, error)
 	Confirm(prompt string, defaultValue bool) (bool, error)
 	MultiSelect(prompt string, defaults []string, options []string) ([]int, error)
-	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) ([]string, []string, int, error)) ([]string, error)
+	MultiSelectWithSearch(prompt, searchPrompt string, defaults []string, persistentOptions []string, searchFunc func(string) prompter.MultiSelectSearchResult) ([]string, error)
 }
 
 func ConfirmIssueSubmission(p Prompt, allowPreview bool, allowMetadata bool) (Action, error) {

--- a/pkg/cmd/preview/prompter/prompter.go
+++ b/pkg/cmd/preview/prompter/prompter.go
@@ -2,6 +2,7 @@ package prompter
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/gh"
@@ -25,32 +26,35 @@ func NewCmdPrompter(f *cmdutil.Factory, runF func(*prompterOptions) error) *cobr
 	}
 
 	const (
-		selectPrompt          = "select"
-		multiSelectPrompt     = "multi-select"
-		inputPrompt           = "input"
-		passwordPrompt        = "password"
-		confirmPrompt         = "confirm"
-		authTokenPrompt       = "auth-token"
-		confirmDeletionPrompt = "confirm-deletion"
-		inputHostnamePrompt   = "input-hostname"
-		markdownEditorPrompt  = "markdown-editor"
+		selectPrompt                = "select"
+		multiSelectPrompt           = "multi-select"
+		multiSelectWithSearchPrompt = "multi-select-with-search"
+		inputPrompt                 = "input"
+		passwordPrompt              = "password"
+		confirmPrompt               = "confirm"
+		authTokenPrompt             = "auth-token"
+		confirmDeletionPrompt       = "confirm-deletion"
+		inputHostnamePrompt         = "input-hostname"
+		markdownEditorPrompt        = "markdown-editor"
 	)
 
 	prompterTypeFuncMap := map[string]func(prompter.Prompter, *iostreams.IOStreams) error{
-		selectPrompt:          runSelect,
-		multiSelectPrompt:     runMultiSelect,
-		inputPrompt:           runInput,
-		passwordPrompt:        runPassword,
-		confirmPrompt:         runConfirm,
-		authTokenPrompt:       runAuthToken,
-		confirmDeletionPrompt: runConfirmDeletion,
-		inputHostnamePrompt:   runInputHostname,
-		markdownEditorPrompt:  runMarkdownEditor,
+		selectPrompt:                runSelect,
+		multiSelectPrompt:           runMultiSelect,
+		multiSelectWithSearchPrompt: runMultiSelectWithSearch,
+		inputPrompt:                 runInput,
+		passwordPrompt:              runPassword,
+		confirmPrompt:               runConfirm,
+		authTokenPrompt:             runAuthToken,
+		confirmDeletionPrompt:       runConfirmDeletion,
+		inputHostnamePrompt:         runInputHostname,
+		markdownEditorPrompt:        runMarkdownEditor,
 	}
 
 	allPromptsOrder := []string{
 		selectPrompt,
 		multiSelectPrompt,
+		multiSelectWithSearchPrompt,
 		inputPrompt,
 		passwordPrompt,
 		confirmPrompt,
@@ -70,6 +74,7 @@ func NewCmdPrompter(f *cmdutil.Factory, runF func(*prompterOptions) error) *cobr
 			Available prompt types:
 			- select
 			- multi-select
+			- multi-select-with-search
 			- input
 			- password
 			- confirm
@@ -146,6 +151,42 @@ func runMultiSelect(p prompter.Prompter, io *iostreams.IOStreams) error {
 	for _, f := range favorites {
 		fmt.Fprintf(io.Out, "Favorite cuisine: %s\n", cuisines[f])
 	}
+	return nil
+}
+
+func runMultiSelectWithSearch(p prompter.Prompter, io *iostreams.IOStreams) error {
+	fmt.Fprintln(io.Out, "Demonstrating Multi Select With Search")
+	persistentOptions := []string{"persistent-option-1"}
+	searchFunc := func(input string) ([]string, []string, int, error) {
+		var searchResultKeys []string
+		var searchResultLabels []string
+
+		if input == "" {
+			moreResults := 2 // Indicate that there are more results available
+			searchResultKeys = []string{"initial-result-1", "initial-result-2"}
+			searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
+			return searchResultKeys, searchResultLabels, moreResults, nil
+		}
+
+		// In a real implementation, this function would perform a search based on the input.
+		// Here, we return a static set of options for demonstration purposes.
+		moreResults := 0
+		searchResultKeys = []string{"search-result-1", "search-result-2"}
+		searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
+		return searchResultKeys, searchResultLabels, moreResults, nil
+	}
+
+	selections, err := p.MultiSelectWithSearch("Select an option", "Search for an option", []string{}, persistentOptions, searchFunc)
+	if err != nil {
+		return err
+	}
+
+	if len(selections) == 0 {
+		fmt.Fprintln(io.Out, "No options selected.")
+		return nil
+	}
+
+	fmt.Fprintf(io.Out, "Selected options: %s\n", strings.Join(selections, ", "))
 	return nil
 }
 

--- a/pkg/cmd/preview/prompter/prompter.go
+++ b/pkg/cmd/preview/prompter/prompter.go
@@ -157,7 +157,7 @@ func runMultiSelect(p prompter.Prompter, io *iostreams.IOStreams) error {
 func runMultiSelectWithSearch(p prompter.Prompter, io *iostreams.IOStreams) error {
 	fmt.Fprintln(io.Out, "Demonstrating Multi Select With Search")
 	persistentOptions := []string{"persistent-option-1"}
-	searchFunc := func(input string) ([]string, []string, int, error) {
+	searchFunc := func(input string) prompter.MultiSelectSearchResult {
 		var searchResultKeys []string
 		var searchResultLabels []string
 
@@ -165,7 +165,12 @@ func runMultiSelectWithSearch(p prompter.Prompter, io *iostreams.IOStreams) erro
 			moreResults := 2 // Indicate that there are more results available
 			searchResultKeys = []string{"initial-result-1", "initial-result-2"}
 			searchResultLabels = []string{"Initial Result Label 1", "Initial Result Label 2"}
-			return searchResultKeys, searchResultLabels, moreResults, nil
+			return prompter.MultiSelectSearchResult{
+				Keys:        searchResultKeys,
+				Labels:      searchResultLabels,
+				MoreResults: moreResults,
+				Err:         nil,
+			}
 		}
 
 		// In a real implementation, this function would perform a search based on the input.
@@ -173,7 +178,12 @@ func runMultiSelectWithSearch(p prompter.Prompter, io *iostreams.IOStreams) erro
 		moreResults := 0
 		searchResultKeys = []string{"search-result-1", "search-result-2"}
 		searchResultLabels = []string{"Search Result Label 1", "Search Result Label 2"}
-		return searchResultKeys, searchResultLabels, moreResults, nil
+		return prompter.MultiSelectSearchResult{
+			Keys:        searchResultKeys,
+			Labels:      searchResultLabels,
+			MoreResults: moreResults,
+			Err:         nil,
+		}
 	}
 
 	selections, err := p.MultiSelectWithSearch("Select an option", "Search for an option", []string{}, persistentOptions, searchFunc)


### PR DESCRIPTION
## Description

Implements multiselect with search for `gh pr edit` assignees, addressing performance and accessibility issues in large organizations. Part of larger work to improve the reviewer and assignee experience in `gh`.

## Key changes

- **New `MultiSelectWithSearch` prompter**: Adds a search sentinel option to multiselect lists, allowing dynamic fetching of assignees via API search rather than loading all org members upfront
- **`SuggestedAssignableActors` API**: New GraphQL query to fetch suggested actors for an assignable (Issue/PR) node with optional search filtering
- **`gh pr edit` assignee flow**: Wires up the new prompter for interactive assignee selection when `ActorIsAssignable` feature is detected
- **Prompter interface expansion**: Both `surveyPrompter` and `accessiblePrompter` implement the new method, with full test coverage
- **Preview command**: Adds `multi-select-with-search` to `gh preview prompter` for testing

## Notes for reviewers

- This PR only covers assignees for `gh pr edit`; reviewers will follow in a subsequent PR