### PR TITLE
feat(repo clone): add --no-upstream flag

### DIFF
--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -19,32 +19,32 @@ import (
 )
 
 type CloneOptions struct {
-        HttpClient func() (*http.Client, error)
-        GitClient  *git.Client
-        Config     func() (gh.Config, error)
-        IO         *iostreams.IOStreams
+	HttpClient func() (*http.Client, error)
+	GitClient  *git.Client
+	Config     func() (gh.Config, error)
+	IO         *iostreams.IOStreams
 
-        GitArgs      []string
-        Repository   string
-        UpstreamName string
-        NoUpstream   bool
+	GitArgs      []string
+	Repository   string
+	UpstreamName string
+	NoUpstream   bool
 }
 
 func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Command {
-        opts := &CloneOptions{
-                IO:         f.IOStreams,
-                HttpClient: f.HttpClient,
-                GitClient:  f.GitClient,
-                Config:     f.Config,
-        }
+	opts := &CloneOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		GitClient:  f.GitClient,
+		Config:     f.Config,
+	}
 
-        cmd := &cobra.Command{
-                DisableFlagsInUseLine: true,
+	cmd := &cobra.Command{
+		DisableFlagsInUseLine: true,
 
-                Use:   "clone <repository> [<directory>] [-- <gitflags>...]",
-                Args:  cmdutil.MinimumArgs(1, "cannot clone: repository argument required"),
-                Short: "Clone a repository locally",
-                Long: heredoc.Docf(`
+		Use:   "clone <repository> [<directory>] [-- <gitflags>...]",
+		Args:  cmdutil.MinimumArgs(1, "cannot clone: repository argument required"),
+		Short: "Clone a repository locally",
+		Long: heredoc.Docf(`
                         Clone a GitHub repository locally. Pass additional %[1]sgit clone%[1]s flags by listing
                         them after %[1]s--%[1]s.
 
@@ -64,7 +64,7 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
 
                         If the repository is a fork, its parent repository will be set as the default remote repository.
                 `, "`"),
-                Example: heredoc.Doc(`
+		Example: heredoc.Doc(`
                         # Clone a repository from a specific org
                         $ gh repo clone cli/cli
 
@@ -84,21 +84,22 @@ func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Comm
                         # Clone a repository with additional git clone flags
                         $ gh repo clone cli/cli -- --depth=1
                 `),
-                RunE: func(cmd *cobra.Command, args []string) error {
-                        opts.Repository = args[0]
-                        opts.GitArgs = args[1:]
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Repository = args[0]
+			opts.GitArgs = args[1:]
 
-                        if runF != nil {
-                                return runF(opts)
-                        }
+			if runF != nil {
+				return runF(opts)
+			}
 
-                        return cloneRun(opts)
-                },
-        }
+			return cloneRun(opts)
+		},
+	}
 
-        cmd.Flags().StringVarP(&opts.UpstreamName, "upstream-remote-name", "u", "upstream", "Upstream remote name when cloning a fork")
-        cmd.Flags().BoolVar(&opts.NoUpstream, "no-upstream", false, "Do not add an upstream remote if the repository is a fork")
-        cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {		if err == pflag.ErrHelp {
+	cmd.Flags().StringVarP(&opts.UpstreamName, "upstream-remote-name", "u", "upstream", "Upstream remote name when cloning a fork")
+	cmd.Flags().BoolVar(&opts.NoUpstream, "no-upstream", false, "Do not add an upstream remote if the repository is a fork")
+	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		if err == pflag.ErrHelp {
 			return err
 		}
 		return cmdutil.FlagErrorf("%w\nSeparate git clone flags with '--'.", err)
@@ -191,13 +192,13 @@ func cloneRun(opts *CloneOptions) error {
 		return err
 	}
 
-	                // If the repo is a fork, add the parent as an upstream remote and set the parent as the default repo.
+	// If the repo is a fork, add the parent as an upstream remote and set the parent as the default repo.
 
-	                if canonicalRepo.Parent != nil && !opts.NoUpstream {
+	if canonicalRepo.Parent != nil && !opts.NoUpstream {
 
-	                        protocol := cfg.GitProtocol(canonicalRepo.Parent.RepoHost()).Value
+		protocol := cfg.GitProtocol(canonicalRepo.Parent.RepoHost()).Value
 
-	                        upstreamURL := ghrepo.FormatRemoteURL(canonicalRepo.Parent, protocol)
+		upstreamURL := ghrepo.FormatRemoteURL(canonicalRepo.Parent, protocol)
 
 		upstreamName := opts.UpstreamName
 		if opts.UpstreamName == "@owner" {

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -19,80 +19,86 @@ import (
 )
 
 type CloneOptions struct {
-	HttpClient func() (*http.Client, error)
-	GitClient  *git.Client
-	Config     func() (gh.Config, error)
-	IO         *iostreams.IOStreams
+        HttpClient func() (*http.Client, error)
+        GitClient  *git.Client
+        Config     func() (gh.Config, error)
+        IO         *iostreams.IOStreams
 
-	GitArgs      []string
-	Repository   string
-	UpstreamName string
+        GitArgs      []string
+        Repository   string
+        UpstreamName string
+        NoUpstream   bool
 }
 
 func NewCmdClone(f *cmdutil.Factory, runF func(*CloneOptions) error) *cobra.Command {
-	opts := &CloneOptions{
-		IO:         f.IOStreams,
-		HttpClient: f.HttpClient,
-		GitClient:  f.GitClient,
-		Config:     f.Config,
-	}
+        opts := &CloneOptions{
+                IO:         f.IOStreams,
+                HttpClient: f.HttpClient,
+                GitClient:  f.GitClient,
+                Config:     f.Config,
+        }
 
-	cmd := &cobra.Command{
-		DisableFlagsInUseLine: true,
+        cmd := &cobra.Command{
+                DisableFlagsInUseLine: true,
 
-		Use:   "clone <repository> [<directory>] [-- <gitflags>...]",
-		Args:  cmdutil.MinimumArgs(1, "cannot clone: repository argument required"),
-		Short: "Clone a repository locally",
-		Long: heredoc.Docf(`
-			Clone a GitHub repository locally. Pass additional %[1]sgit clone%[1]s flags by listing
-			them after %[1]s--%[1]s.
+                Use:   "clone <repository> [<directory>] [-- <gitflags>...]",
+                Args:  cmdutil.MinimumArgs(1, "cannot clone: repository argument required"),
+                Short: "Clone a repository locally",
+                Long: heredoc.Docf(`
+                        Clone a GitHub repository locally. Pass additional %[1]sgit clone%[1]s flags by listing
+                        them after %[1]s--%[1]s.
 
-			If the %[1]sOWNER/%[1]s portion of the %[1]sOWNER/REPO%[1]s repository argument is omitted, it
-			defaults to the name of the authenticating user.
+                        If the %[1]sOWNER/%[1]s portion of the %[1]sOWNER/REPO%[1]s repository argument is omitted, it
+                        defaults to the name of the authenticating user.
 
-			When a protocol scheme is not provided in the repository argument, the %[1]sgit_protocol%[1]s will be
-			chosen from your configuration, which can be checked via %[1]sgh config get git_protocol%[1]s. If the protocol
-			scheme is provided, the repository will be cloned using the specified protocol.
+                        When a protocol scheme is not provided in the repository argument, the %[1]sgit_protocol%[1]s will be
+                        chosen from your configuration, which can be checked via %[1]sgh config get git_protocol%[1]s. If the protocol
+                        scheme is provided, the repository will be cloned using the specified protocol.
 
-			If the repository is a fork, its parent repository will be added as an additional
-			git remote called %[1]supstream%[1]s. The remote name can be configured using %[1]s--upstream-remote-name%[1]s.
-			The %[1]s--upstream-remote-name%[1]s option supports an %[1]s@owner%[1]s value which will name
-			the remote after the owner of the parent repository.
+                        If the repository is a fork, its parent repository will be added as an additional
+                        git remote called %[1]supstream%[1]s. The remote name can be configured using %[1]s--upstream-remote-name%[1]s.
+                        The %[1]s--upstream-remote-name%[1]s option supports an %[1]s@owner%[1]s value which will name
+                        the remote after the owner of the parent repository.
 
-			If the repository is a fork, its parent repository will be set as the default remote repository.
-		`, "`"),
-		Example: heredoc.Doc(`
-			# Clone a repository from a specific org
-			$ gh repo clone cli/cli
+                        To skip adding an upstream remote, use the %[1]s--no-upstream%[1]s flag.
 
-			# Clone a repository from your own account
-			$ gh repo clone myrepo
+                        If the repository is a fork, its parent repository will be set as the default remote repository.
+                `, "`"),
+                Example: heredoc.Doc(`
+                        # Clone a repository from a specific org
+                        $ gh repo clone cli/cli
 
-			# Clone a repo, overriding git protocol configuration
-			$ gh repo clone https://github.com/cli/cli
-			$ gh repo clone git@github.com:cli/cli.git
+                        # Clone a repository from your own account
+                        $ gh repo clone myrepo
 
-			# Clone a repository to a custom directory
-			$ gh repo clone cli/cli workspace/cli
+                        # Clone a repo, overriding git protocol configuration
+                        $ gh repo clone https://github.com/cli/cli
+                        $ gh repo clone git@github.com:cli/cli.git
 
-			# Clone a repository with additional git clone flags
-			$ gh repo clone cli/cli -- --depth=1
-		`),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.Repository = args[0]
-			opts.GitArgs = args[1:]
+                        # Clone a repository to a custom directory
+                        $ gh repo clone cli/cli workspace/cli
 
-			if runF != nil {
-				return runF(opts)
-			}
+                        # Clone a repository without adding an upstream remote
+                        $ gh repo clone myfork --no-upstream
 
-			return cloneRun(opts)
-		},
-	}
+                        # Clone a repository with additional git clone flags
+                        $ gh repo clone cli/cli -- --depth=1
+                `),
+                RunE: func(cmd *cobra.Command, args []string) error {
+                        opts.Repository = args[0]
+                        opts.GitArgs = args[1:]
 
-	cmd.Flags().StringVarP(&opts.UpstreamName, "upstream-remote-name", "u", "upstream", "Upstream remote name when cloning a fork")
-	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		if err == pflag.ErrHelp {
+                        if runF != nil {
+                                return runF(opts)
+                        }
+
+                        return cloneRun(opts)
+                },
+        }
+
+        cmd.Flags().StringVarP(&opts.UpstreamName, "upstream-remote-name", "u", "upstream", "Upstream remote name when cloning a fork")
+        cmd.Flags().BoolVar(&opts.NoUpstream, "no-upstream", false, "Do not add an upstream remote if the repository is a fork")
+        cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {		if err == pflag.ErrHelp {
 			return err
 		}
 		return cmdutil.FlagErrorf("%w\nSeparate git clone flags with '--'.", err)
@@ -185,10 +191,13 @@ func cloneRun(opts *CloneOptions) error {
 		return err
 	}
 
-	// If the repo is a fork, add the parent as an upstream remote and set the parent as the default repo.
-	if canonicalRepo.Parent != nil {
-		protocol := cfg.GitProtocol(canonicalRepo.Parent.RepoHost()).Value
-		upstreamURL := ghrepo.FormatRemoteURL(canonicalRepo.Parent, protocol)
+	                // If the repo is a fork, add the parent as an upstream remote and set the parent as the default repo.
+
+	                if canonicalRepo.Parent != nil && !opts.NoUpstream {
+
+	                        protocol := cfg.GitProtocol(canonicalRepo.Parent.RepoHost()).Value
+
+	                        upstreamURL := ghrepo.FormatRemoteURL(canonicalRepo.Parent, protocol)
 
 		upstreamName := opts.UpstreamName
 		if opts.UpstreamName == "@owner" {

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -54,9 +54,17 @@ func TestNewCmdClone(t *testing.T) {
 				GitArgs:    []string{"--depth", "1", "--recurse-submodules"},
 			},
 		},
-		{
-			name:    "unknown argument",
-			args:    "OWNER/REPO --depth 1",
+		                {
+		                        name: "no-upstream flag",
+		                        args: "OWNER/REPO --no-upstream",
+		                        wantOpts: CloneOptions{
+		                                Repository: "OWNER/REPO",
+		                                GitArgs:    []string{},
+		                                NoUpstream: true,
+		                        },
+		                },
+		                {
+		                        name:    "unknown argument",			args:    "OWNER/REPO --depth 1",
 			wantErr: "unknown flag: --depth\nSeparate git clone flags with '--'.",
 		},
 	}
@@ -387,12 +395,50 @@ func TestSimplifyURL(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			u, err := url.Parse(tt.raw)
-			require.NoError(t, err)
-			result := simplifyURL(u)
-			assert.Equal(t, tt.expectedRaw, result.String())
-		})
+	        for _, tt := range tests {
+	                t.Run(tt.name, func(t *testing.T) {
+	                        u, err := url.Parse(tt.raw)
+	                        require.NoError(t, err)
+	                        result := simplifyURL(u)
+	                        assert.Equal(t, tt.expectedRaw, result.String())
+	                })
+	        }
 	}
-}
+	
+	func Test_RepoClone_hasParent_noUpstream(t *testing.T) {
+		reg := &httpmock.Registry{}
+		defer reg.Verify(t)
+		reg.Register(
+			httpmock.GraphQL(`query RepositoryInfo\b`),
+			httpmock.StringResponse(`
+	                                { "data": { "repository": {
+	                                        "name": "REPO",
+	                                        "owner": {
+	                                                "login": "OWNER"
+	                                        },
+	                                        "parent": {
+	                                                "name": "ORIG",
+	                                                "owner": {
+	                                                        "login": "hubot"
+	                                                },
+	                                                "defaultBranchRef": {
+	                                                        "name": "trunk"
+	                                                }
+	                                        }
+	                                } } }
+	                                `))
+	
+		httpClient := &http.Client{Transport: reg}
+	
+		cs, cmdTeardown := run.Stub()
+		defer cmdTeardown(t)
+	
+		// We only expect git clone, but NO upstream-related git commands
+		cs.Register(`git clone https://github.com/OWNER/REPO.git`, 0, "")
+	
+		_, err := runCloneCommand(httpClient, "OWNER/REPO --no-upstream")
+		if err != nil {
+			t.Fatalf("error running command `repo clone`: %v", err)
+		}
+	}
+	

--- a/pkg/cmd/repo/clone/clone_test.go
+++ b/pkg/cmd/repo/clone/clone_test.go
@@ -54,17 +54,17 @@ func TestNewCmdClone(t *testing.T) {
 				GitArgs:    []string{"--depth", "1", "--recurse-submodules"},
 			},
 		},
-		                {
-		                        name: "no-upstream flag",
-		                        args: "OWNER/REPO --no-upstream",
-		                        wantOpts: CloneOptions{
-		                                Repository: "OWNER/REPO",
-		                                GitArgs:    []string{},
-		                                NoUpstream: true,
-		                        },
-		                },
-		                {
-		                        name:    "unknown argument",			args:    "OWNER/REPO --depth 1",
+		{
+			name: "no-upstream flag",
+			args: "OWNER/REPO --no-upstream",
+			wantOpts: CloneOptions{
+				Repository: "OWNER/REPO",
+				GitArgs:    []string{},
+				NoUpstream: true,
+			},
+		},
+		{
+			name: "unknown argument", args: "OWNER/REPO --depth 1",
 			wantErr: "unknown flag: --depth\nSeparate git clone flags with '--'.",
 		},
 	}
@@ -395,22 +395,22 @@ func TestSimplifyURL(t *testing.T) {
 		},
 	}
 
-	        for _, tt := range tests {
-	                t.Run(tt.name, func(t *testing.T) {
-	                        u, err := url.Parse(tt.raw)
-	                        require.NoError(t, err)
-	                        result := simplifyURL(u)
-	                        assert.Equal(t, tt.expectedRaw, result.String())
-	                })
-	        }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.raw)
+			require.NoError(t, err)
+			result := simplifyURL(u)
+			assert.Equal(t, tt.expectedRaw, result.String())
+		})
 	}
-	
-	func Test_RepoClone_hasParent_noUpstream(t *testing.T) {
-		reg := &httpmock.Registry{}
-		defer reg.Verify(t)
-		reg.Register(
-			httpmock.GraphQL(`query RepositoryInfo\b`),
-			httpmock.StringResponse(`
+}
+
+func Test_RepoClone_hasParent_noUpstream(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.StringResponse(`
 	                                { "data": { "repository": {
 	                                        "name": "REPO",
 	                                        "owner": {
@@ -427,18 +427,17 @@ func TestSimplifyURL(t *testing.T) {
 	                                        }
 	                                } } }
 	                                `))
-	
-		httpClient := &http.Client{Transport: reg}
-	
-		cs, cmdTeardown := run.Stub()
-		defer cmdTeardown(t)
-	
-		// We only expect git clone, but NO upstream-related git commands
-		cs.Register(`git clone https://github.com/OWNER/REPO.git`, 0, "")
-	
-		_, err := runCloneCommand(httpClient, "OWNER/REPO --no-upstream")
-		if err != nil {
-			t.Fatalf("error running command `repo clone`: %v", err)
-		}
+
+	httpClient := &http.Client{Transport: reg}
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	// We only expect git clone, but NO upstream-related git commands
+	cs.Register(`git clone https://github.com/OWNER/REPO.git`, 0, "")
+
+	_, err := runCloneCommand(httpClient, "OWNER/REPO --no-upstream")
+	if err != nil {
+		t.Fatalf("error running command `repo clone`: %v", err)
 	}
-	
+}


### PR DESCRIPTION
Fixes #8274.

This PR adds a `--no-upstream` flag to the `repo clone` command.

When cloning a fork, GitHub CLI currently adds the parent repository as an `upstream` remote by default. This flag allows users to skip this behavior and only clone the repository with the default `origin` remote.

Changes:
- Added `NoUpstream` to `CloneOptions`.
- Added `--no-upstream` flag to the command.
- Updated `cloneRun` to skip upstream logic if the flag is provided.
- Added unit tests and a functional test to verify the new behavior.