### PR TITLE
fix: clarify scope error while creating issues for projects

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/cli/cli/v2/pkg/set"
 	ghAPI "github.com/cli/go-gh/v2/pkg/api"
 	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 )
@@ -178,12 +179,50 @@ func handleResponse(err error) error {
 
 	var gqlErr *ghAPI.GraphQLError
 	if errors.As(err, &gqlErr) {
+		scopeErr := GenerateScopeErrorForGQL(gqlErr)
+		if scopeErr != nil {
+			return scopeErr
+		}
 		return GraphQLError{
 			GraphQLError: gqlErr,
 		}
 	}
 
 	return err
+}
+
+func GenerateScopeErrorForGQL(gqlErr *ghAPI.GraphQLError) error {
+	missing := set.NewStringSet()
+	for _, e := range gqlErr.Errors {
+		if e.Type != "INSUFFICIENT_SCOPES" {
+			continue
+		}
+		missing.AddValues(requiredScopesFromServerMessage(e.Message))
+	}
+	if missing.Len() > 0 {
+		s := missing.ToSlice()
+		// TODO: this duplicates parts of generateScopesSuggestion
+		return fmt.Errorf(
+			"error: your authentication token is missing required scopes %v\n"+
+				"To request it, run:  gh auth refresh -s %s",
+			s,
+			strings.Join(s, ","))
+	}
+	return nil
+}
+
+var scopesRE = regexp.MustCompile(`one of the following scopes: \[(.+?)]`)
+
+func requiredScopesFromServerMessage(msg string) []string {
+	m := scopesRE.FindStringSubmatch(msg)
+	if m == nil {
+		return nil
+	}
+	var scopes []string
+	for _, mm := range strings.Split(m[1], ",") {
+		scopes = append(scopes, strings.Trim(mm, "' "))
+	}
+	return scopes
 }
 
 // ScopesSuggestion is an error messaging utility that prints the suggestion to request additional OAuth

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -254,4 +255,80 @@ func TestHTTPHeaders(t *testing.T) {
 		assert.Equal(t, value, gotReq.Header.Get(name), name)
 	}
 	assert.Equal(t, "", stderr.String())
+}
+
+func TestGenerateScopeErrorForGQL(t *testing.T) {
+	tests := []struct {
+		name     string
+		gqlError *api.GraphQLError
+		wantErr  bool
+		expected string
+	}{
+		{
+			name: "missing scope",
+			gqlError: &api.GraphQLError{
+				Errors: []api.GraphQLErrorItem{
+					{
+						Type:    "INSUFFICIENT_SCOPES",
+						Message: "The 'addProjectV2ItemById' field requires one of the following scopes: ['project']",
+					},
+				},
+			},
+			wantErr: true,
+			expected: "error: your authentication token is missing required scopes [project]\n" +
+				"To request it, run:  gh auth refresh -s project",
+		},
+
+		{
+			name: "ignore non-scope errors",
+			gqlError: &api.GraphQLError{
+				Errors: []api.GraphQLErrorItem{
+					{
+						Type:    "NOT_FOUND",
+						Message: "Could not resolve to a Repository",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := GenerateScopeErrorForGQL(tt.gqlError)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+				assert.Equal(t, tt.expected, err.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestRequiredScopesFromServerMessage(t *testing.T) {
+	tests := []struct {
+		msg      string
+		expected []string
+	}{
+		{
+			msg:      "requires one of the following scopes: ['project']",
+			expected: []string{"project"},
+		},
+		{
+			msg:      "requires one of the following scopes: ['repo', 'read:org']",
+			expected: []string{"repo", "read:org"},
+		},
+		{
+			msg:      "no match here",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			output := requiredScopesFromServerMessage(tt.msg)
+			assert.Equal(t, tt.expected, output)
+		})
+	}
 }


### PR DESCRIPTION
### Summary
Enhanced GraphQL error handling to provide more user-friendly and actionable messages when a token lacks the necessary permissions. Instead of a verbose technical trace, users now receive a concise list of missing scopes and a direct command to resolve the issue via gh auth refresh.

### Changes
- Modified handleResponse to intercept GraphQL errors and check for INSUFFICIENT_SCOPES types.
- Implemented GenerateScopeErrorForGQL to extract specific required scopes from the API response message.
- Added requiredScopesFromServerMessage using regex to parse scope requirements (e.g., project, repo) from the server's text.

### Note
I basically replicated the logic being used for queries (`handleError` found in `pkg/cmd/project/shared/queries/queries.go`)
<img width="701" height="471" alt="image" src="https://github.com/user-attachments/assets/e081a66f-a8b0-46b1-9c62-b582c113c6aa" />


### Example
# Before (Raw GraphQL Trace):
`GraphQL: Your token has not been granted the required scopes to execute this query. The 'addProjectV2ItemById' field requires one of the following scopes: ['project'], but your token has only been granted the: ['gist', 'read:org', 'read:project', 'repo', 'workflow'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens.`

# Now (Clean CLI Error):
```
error: your authentication token is missing required scopes [project]
To request it, run:  gh auth refresh -s project
```

### Test plan
- Added test cases for newly-created functions
- All existing tests pass

Fixes #12585 
