### PR TITLE
fix(project): suggest 'project' scope instead of 'read:project'

### DIFF
--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -1450,6 +1450,11 @@ func handleError(err error) error {
 		}
 		if missing.Len() > 0 {
 			s := missing.ToSlice()
+			for i, scope := range s {
+				if scope == "read:project" {
+					s[i] = "project"
+				}
+			}
 			// TODO: this duplicates parts of generateScopesSuggestion
 			return fmt.Errorf(
 				"error: your authentication token is missing required scopes %v\n"+


### PR DESCRIPTION
## Summary

This PR fixes #12585.

**Problem:** Users receive a confusing error loop when attempting to view projects without sufficient scopes. The CLI suggests adding `read:project`, but upon doing so, the operation fails again requiring [project](cci:2://file:///d:/repo-d/open/cli/pkg/cmd/project/shared/queries/queries.go:671:0-673:1) (write access), leading to a frustrating double-auth cycle.

**Solution:** The error handling logic now detects when `read:project` is the missing scope and proactively suggests the broader [project](cci:2://file:///d:/repo-d/open/cli/pkg/cmd/project/shared/queries/queries.go:671:0-673:1) scope instead. This ensures users get the necessary permissions in a single step.

---

## Technical Details

| Attribute | Value |
|-----------|-------|
| **Language** | Go |
| **Affected Files** | [pkg/cmd/project/shared/queries/queries.go](cci:7://file:///d:/repo-d/open/cli/pkg/cmd/project/shared/queries/queries.go:0:0-0:0) |
| **Verification** | `go test ./pkg/cmd/project/shared/queries` |

### Changes Made

- Modified [handleError](cci:1://file:///d:/repo-d/open/cli/pkg/cmd/project/shared/queries/queries.go:1440:0-1466:1) in [pkg/cmd/project/shared/queries/queries.go](cci:7://file:///d:/repo-d/open/cli/pkg/cmd/project/shared/queries/queries.go:0:0-0:0) to intercept `read:project` and upgrade the suggestion to [project](cci:2://file:///d:/repo-d/open/cli/pkg/cmd/project/shared/queries/queries.go:671:0-673:1).

---

## Quality Checklist

- [x] I have read the CONTRIBUTING.md file
- [x] I have followed the project's code style
- [x] I have verified my changes work as expected