### PR TITLE
record check timestamp before HTTP request

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -93,12 +93,22 @@ func CheckForUpdate(ctx context.Context, client *http.Client, stateFilePath, rep
 		return nil, nil
 	}
 
-	releaseInfo, err := getLatestReleaseInfo(ctx, client, repo)
+	// Write timestamp before HTTP request to prevent repeated checks if request is canceled
+	now := time.Now()
+	err := setStateEntry(stateFilePath, now, ReleaseInfo{})
 	if err != nil {
 		return nil, err
 	}
 
-	err = setStateEntry(stateFilePath, time.Now(), *releaseInfo)
+	releaseInfo, err := getLatestReleaseInfo(ctx, client, repo)
+	if err != nil {
+		// Returning error preserves existing behavior; timestamp already written
+		// to avoid repeated update checks on subsequent runs.
+		return nil, err
+	}
+
+	// Update state with actual release info
+	err = setStateEntry(stateFilePath, now, *releaseInfo)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When commands finish quickly, updateCancel() can cancel the update-check context before the goroutine writes the state file. That leaves checked_for_update_at unchanged, causing an update API request to run on every invocation.

This change writes the checked_for_update_at timestamp before the HTTP request, then updates the state entry with release info after a successful request. If the request is canceled or fails, the timestamp still prevents repeated checks for 24h while preserving the existing error behavior.

Fixes #12599

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
