### PR TITLE
Add squash merge commit flags to gh repo edit

### DIFF
--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -70,23 +70,25 @@ type EditRepositoryInput struct {
 	enableSecretScanning               *bool
 	enableSecretScanningPushProtection *bool
 
-	AllowForking        *bool                     `json:"allow_forking,omitempty"`
-	AllowUpdateBranch   *bool                     `json:"allow_update_branch,omitempty"`
-	DefaultBranch       *string                   `json:"default_branch,omitempty"`
-	DeleteBranchOnMerge *bool                     `json:"delete_branch_on_merge,omitempty"`
-	Description         *string                   `json:"description,omitempty"`
-	EnableAutoMerge     *bool                     `json:"allow_auto_merge,omitempty"`
-	EnableIssues        *bool                     `json:"has_issues,omitempty"`
-	EnableMergeCommit   *bool                     `json:"allow_merge_commit,omitempty"`
-	EnableProjects      *bool                     `json:"has_projects,omitempty"`
-	EnableDiscussions   *bool                     `json:"has_discussions,omitempty"`
-	EnableRebaseMerge   *bool                     `json:"allow_rebase_merge,omitempty"`
-	EnableSquashMerge   *bool                     `json:"allow_squash_merge,omitempty"`
-	EnableWiki          *bool                     `json:"has_wiki,omitempty"`
-	Homepage            *string                   `json:"homepage,omitempty"`
-	IsTemplate          *bool                     `json:"is_template,omitempty"`
-	SecurityAndAnalysis *SecurityAndAnalysisInput `json:"security_and_analysis,omitempty"`
-	Visibility          *string                   `json:"visibility,omitempty"`
+	AllowForking             *bool                     `json:"allow_forking,omitempty"`
+	AllowUpdateBranch        *bool                     `json:"allow_update_branch,omitempty"`
+	DefaultBranch            *string                   `json:"default_branch,omitempty"`
+	DeleteBranchOnMerge      *bool                     `json:"delete_branch_on_merge,omitempty"`
+	Description              *string                   `json:"description,omitempty"`
+	EnableAutoMerge          *bool                     `json:"allow_auto_merge,omitempty"`
+	EnableIssues             *bool                     `json:"has_issues,omitempty"`
+	EnableMergeCommit        *bool                     `json:"allow_merge_commit,omitempty"`
+	EnableProjects           *bool                     `json:"has_projects,omitempty"`
+	EnableDiscussions        *bool                     `json:"has_discussions,omitempty"`
+	EnableRebaseMerge        *bool                     `json:"allow_rebase_merge,omitempty"`
+	EnableSquashMerge        *bool                     `json:"allow_squash_merge,omitempty"`
+	SquashMergeCommitTitle   *string                   `json:"squash_merge_commit_title,omitempty"`
+	SquashMergeCommitMessage *string                   `json:"squash_merge_commit_message,omitempty"`
+	EnableWiki               *bool                     `json:"has_wiki,omitempty"`
+	Homepage                 *string                   `json:"homepage,omitempty"`
+	IsTemplate               *bool                     `json:"is_template,omitempty"`
+	SecurityAndAnalysis      *SecurityAndAnalysisInput `json:"security_and_analysis,omitempty"`
+	Visibility               *string                   `json:"visibility,omitempty"`
 }
 
 func NewCmdEdit(f *cmdutil.Factory, runF func(options *EditOptions) error) *cobra.Command {
@@ -184,6 +186,8 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(options *EditOptions) error) *cobr
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableDiscussions, "enable-discussions", "", "Enable discussions in the repository")
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableMergeCommit, "enable-merge-commit", "", "Enable merging pull requests via merge commit")
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableSquashMerge, "enable-squash-merge", "", "Enable merging pull requests via squashed commit")
+	cmdutil.NilStringFlag(cmd, &opts.Edits.SquashMergeCommitTitle, "squash-merge-commit-title", "", "Set the default value for a squash merge commit title {PR_TITLE,COMMIT_OR_PR_TITLE}")
+	cmdutil.NilStringFlag(cmd, &opts.Edits.SquashMergeCommitMessage, "squash-merge-commit-message", "", "Set the default value for a squash merge commit message {PR_BODY,COMMIT_MESSAGES,BLANK}")
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableRebaseMerge, "enable-rebase-merge", "", "Enable merging pull requests via rebase")
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.EnableAutoMerge, "enable-auto-merge", "", "Enable auto-merge functionality")
 	cmdutil.NilBoolFlag(cmd, &opts.Edits.enableAdvancedSecurity, "enable-advanced-security", "", "Enable advanced security in the repository")


### PR DESCRIPTION
This PR adds support for the `squash_merge_commit_message` and `squash_merge_commit_title` flags to the `gh repo edit` command. These flags allow users to configure the default commit title and message format when merging pull requests via squash merge.

## Changes

- Added `SquashMergeCommitTitle` and `SquashMergeCommitMessage` fields to the `EditRepositoryInput` struct
- Added `--squash-merge-commit-title` and `--squash-merge-commit-message` flags to the `gh repo edit` command

## Usage

```bash
gh repo edit --squash-merge-commit-message "PR_BODY" --squash-merge-commit-title "PR_TITLE"
```

Valid values for `--squash-merge-commit-message`:
- `PR_BODY`
- `COMMIT_MESSAGES`
- `BLANK`

Valid values for `--squash-merge-commit-title`:
- `PR_TITLE`
- `COMMIT_OR_PR_TITLE`

Fixes #10092