### PR TITLE
fix(repo fork): error on --remote with repo arg

### DIFF
--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -103,6 +103,10 @@ func NewCmdFork(f *cmdutil.Factory, runF func(*ForkOptions) error) *cobra.Comman
 				opts.GitArgs = args[1:]
 			}
 
+			if opts.Repository != "" && opts.Remote {
+				return cmdutil.FlagErrorf("cannot use `--remote` when forking a repository specified via argument; run `gh repo fork --remote` from within the local repository instead")
+			}
+
 			if cmd.Flags().Changed("org") && opts.Organization == "" {
 				return cmdutil.FlagErrorf("--org cannot be blank")
 			}

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -60,6 +60,12 @@ func TestNewCmdFork(t *testing.T) {
 			},
 		},
 		{
+			name:    "repo with --remote",
+			cli:     "foo/bar --remote",
+			wantErr: true,
+			errMsg:  "cannot use `--remote` when forking a repository specified via argument; run `gh repo fork --remote` from within the local repository instead",
+		},
+		{
 			name:    "blank remote name",
 			cli:     "--remote --remote-name=''",
 			wantErr: true,


### PR DESCRIPTION
Fixes cli/cli#2722.

When `gh repo fork` is invoked with an explicit repository argument, the command intentionally avoids touching the local git repository (including configuring remotes). This makes `--remote` silently ineffective and confusing.

This change makes that situation explicit by returning a flag error when `--remote` is used together with a repository argument.

Test plan:
- `go test ./pkg/cmd/repo/fork -run TestNewCmdFork`
