### PR TITLE
feat(pr create): add --json and --jq output

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -557,13 +557,14 @@ func (pr *PullRequest) DisplayableReviews() PullRequestReviews {
 func CreatePullRequest(client *Client, repo *Repository, params map[string]interface{}) (*PullRequest, error) {
 	query := `
 		mutation PullRequestCreate($input: CreatePullRequestInput!) {
-			createPullRequest(input: $input) {
-				pullRequest {
-					id
-					url
+				createPullRequest(input: $input) {
+					pullRequest {
+						id
+						number
+						url
+					}
 				}
-			}
-	}`
+		}`
 
 	inputParams := map[string]interface{}{
 		"repositoryId": repo.ID,

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -72,8 +72,11 @@ type CreateOptions struct {
 	MaintainerCanModify bool
 	Template            string
 
-	DryRun bool
+	DryRun   bool
+	Exporter cmdutil.Exporter
 }
+
+var createOutputFields = []string{"id", "url", "number"}
 
 // creationRefs is an interface that provides the necessary information for creating a pull request in the API.
 // Upcasting to concrete implementations can provide further context on other operations (forking and pushing).
@@ -329,6 +332,9 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			if opts.DryRun && opts.WebMode {
 				return cmdutil.FlagErrorf("`--dry-run` is not supported when using `--web`")
 			}
+			if opts.DryRun && opts.Exporter != nil {
+				return cmdutil.FlagErrorf("`--dry-run` is not supported with `--json`")
+			}
 
 			if runF != nil {
 				return runF(opts)
@@ -358,6 +364,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	fl.StringVar(&opts.RecoverFile, "recover", "", "Recover input from a failed run of create")
 	fl.StringVarP(&opts.Template, "template", "T", "", "Template `file` to use as starting body text")
 	fl.BoolVar(&opts.DryRun, "dry-run", false, "Print details instead of creating the PR. May still push git changes.")
+	cmdutil.AddJSONAndJQFlags(cmd, &opts.Exporter, createOutputFields)
 
 	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "base", "head")
 
@@ -1031,7 +1038,7 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 	opts.IO.StartProgressIndicator()
 	pr, err := api.CreatePullRequest(client, ctx.PRRefs.BaseRepo(), params)
 	opts.IO.StopProgressIndicator()
-	if pr != nil {
+	if pr != nil && opts.Exporter == nil {
 		fmt.Fprintln(opts.IO.Out, pr.URL)
 	}
 	if err != nil {
@@ -1039,6 +1046,9 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 			return fmt.Errorf("pull request update failed: %w", err)
 		}
 		return fmt.Errorf("pull request create failed: %w", err)
+	}
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, pr)
 	}
 	return nil
 }

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -204,6 +204,12 @@ func TestNewCmdCreate(t *testing.T) {
 			wantsErr: true,
 		},
 		{
+			name:     "dry-run and json",
+			tty:      false,
+			cli:      "--title mytitle --body '' --dry-run --json id",
+			wantsErr: true,
+		},
+		{
 			name:     "editor by cli",
 			tty:      true,
 			cli:      "--editor",
@@ -363,9 +369,11 @@ func Test_createRun(t *testing.T) {
 				reg.Register(
 					httpmock.GraphQL(`mutation PullRequestCreate\b`),
 					httpmock.GraphQLMutation(`
-						{ "data": { "createPullRequest": { "pullRequest": {
-							"URL": "https://github.com/OWNER/REPO/pull/12"
-						} } } }`,
+							{ "data": { "createPullRequest": { "pullRequest": {
+								"ID": "PR_kwDOA",
+								"Number": 12,
+								"URL": "https://github.com/OWNER/REPO/pull/12"
+							} } } }`,
 						func(input map[string]interface{}) {
 							assert.Equal(t, "REPOID", input["repositoryId"])
 							assert.Equal(t, "my title", input["title"])
@@ -383,6 +391,38 @@ func Test_createRun(t *testing.T) {
 				return func() {}
 			},
 			expectedOut: "https://github.com/OWNER/REPO/pull/12\n",
+		},
+		{
+			name: "nontty-json",
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.GraphQLMutation(`
+							{ "data": { "createPullRequest": { "pullRequest": {
+								"ID": "PR_kwDOA",
+								"Number": 12,
+								"URL": "https://github.com/OWNER/REPO/pull/12"
+							} } } }`,
+						func(input map[string]interface{}) {
+							assert.Equal(t, "REPOID", input["repositoryId"])
+							assert.Equal(t, "my title", input["title"])
+							assert.Equal(t, "my body", input["body"])
+							assert.Equal(t, "master", input["baseRefName"])
+							assert.Equal(t, "feature", input["headRefName"])
+						}))
+			},
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.TitleProvided = true
+				opts.BodyProvided = true
+				opts.Title = "my title"
+				opts.Body = "my body"
+				opts.HeadBranch = "feature"
+				exporter := cmdutil.NewJSONExporter()
+				exporter.SetFields([]string{"id", "url", "number"})
+				opts.Exporter = exporter
+				return func() {}
+			},
+			expectedOut: "{\"id\":\"PR_kwDOA\",\"number\":12,\"url\":\"https://github.com/OWNER/REPO/pull/12\"}\n",
 		},
 		{
 			name: "same head and base branch should error",

--- a/pkg/cmdutil/json_flags.go
+++ b/pkg/cmdutil/json_flags.go
@@ -29,7 +29,7 @@ func AddJSONFlags(cmd *cobra.Command, exportTarget *Exporter, fields []string) {
 	addJqFlag(f, "q")
 	addTemplateFlag(f, "t")
 
-	setupJsonFlags(cmd, exportTarget, fields)
+	setupJsonFlags(cmd, exportTarget, fields, true)
 }
 
 func AddJSONFlagsWithoutShorthand(cmd *cobra.Command, exportTarget *Exporter, fields []string) {
@@ -38,7 +38,15 @@ func AddJSONFlagsWithoutShorthand(cmd *cobra.Command, exportTarget *Exporter, fi
 	addJqFlag(f, "")
 	addTemplateFlag(f, "")
 
-	setupJsonFlags(cmd, exportTarget, fields)
+	setupJsonFlags(cmd, exportTarget, fields, true)
+}
+
+func AddJSONAndJQFlags(cmd *cobra.Command, exportTarget *Exporter, fields []string) {
+	f := cmd.Flags()
+	addJsonFlag(f)
+	addJqFlag(f, "")
+
+	setupJsonFlags(cmd, exportTarget, fields, false)
 }
 
 func addJsonFlag(f *pflag.FlagSet) {
@@ -51,7 +59,7 @@ func addTemplateFlag(f *pflag.FlagSet, shorthand string) {
 	f.StringP("template", shorthand, "", "Format JSON output using a Go template; see \"gh help formatting\"")
 }
 
-func setupJsonFlags(cmd *cobra.Command, exportTarget *Exporter, fields []string) {
+func setupJsonFlags(cmd *cobra.Command, exportTarget *Exporter, fields []string, withTemplateFlag bool) {
 
 	_ = cmd.RegisterFlagCompletionFunc("json", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		var results []string
@@ -77,7 +85,7 @@ func setupJsonFlags(cmd *cobra.Command, exportTarget *Exporter, fields []string)
 				return err
 			}
 		}
-		if export, err := checkJSONFlags(c); err == nil {
+		if export, err := checkJSONFlags(c, withTemplateFlag); err == nil {
 			if export == nil {
 				*exportTarget = nil
 			} else {
@@ -118,12 +126,21 @@ func setupJsonFlags(cmd *cobra.Command, exportTarget *Exporter, fields []string)
 	cmd.Annotations["help:json-fields"] = strings.Join(fields, ",")
 }
 
-func checkJSONFlags(cmd *cobra.Command) (*jsonExporter, error) {
+func checkJSONFlags(cmd *cobra.Command, withTemplateFlag bool) (*jsonExporter, error) {
 	f := cmd.Flags()
 	jsonFlag := f.Lookup("json")
 	jqFlag := f.Lookup("jq")
-	tplFlag := f.Lookup("template")
 	webFlag := f.Lookup("web")
+
+	var tplFlag *pflag.Flag
+	if withTemplateFlag {
+		tplFlag = f.Lookup("template")
+	}
+
+	templateValue := ""
+	if tplFlag != nil {
+		templateValue = tplFlag.Value.String()
+	}
 
 	if jsonFlag.Changed {
 		if webFlag != nil && webFlag.Changed {
@@ -133,11 +150,11 @@ func checkJSONFlags(cmd *cobra.Command) (*jsonExporter, error) {
 		return &jsonExporter{
 			fields:   jv.GetSlice(),
 			filter:   jqFlag.Value.String(),
-			template: tplFlag.Value.String(),
+			template: templateValue,
 		}, nil
 	} else if jqFlag.Changed {
 		return nil, errors.New("cannot use `--jq` without specifying `--json`")
-	} else if tplFlag.Changed {
+	} else if tplFlag != nil && tplFlag.Changed {
 		return nil, errors.New("cannot use `--template` without specifying `--json`")
 	}
 	return nil, nil

--- a/pkg/cmdutil/json_flags_test.go
+++ b/pkg/cmdutil/json_flags_test.go
@@ -157,6 +157,71 @@ func TestAddJSONFlagsWithoutShorthand(t *testing.T) {
 	}
 }
 
+func TestAddJSONAndJQFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		fields      []string
+		args        []string
+		withTplFlag bool
+		wantsExport *jsonExporter
+		wantsError  string
+	}{
+		{
+			name:   "adds json and jq flags only",
+			fields: []string{"id", "url", "number"},
+			args:   []string{"--json", "id,url"},
+			wantsExport: &jsonExporter{
+				fields:   []string{"id", "url"},
+				filter:   "",
+				template: "",
+			},
+		},
+		{
+			name:   "allows host template flag without json template semantics",
+			fields: []string{"id", "url", "number"},
+			args:   []string{"--json", "number", "--template", "pull_request_template.md"},
+			wantsExport: &jsonExporter{
+				fields:   []string{"number"},
+				filter:   "",
+				template: "",
+			},
+			withTplFlag: true,
+		},
+		{
+			name:        "cannot use jq without json",
+			fields:      []string{"id", "url", "number"},
+			args:        []string{"--jq", ".number"},
+			wantsError:  "cannot use `--jq` without specifying `--json`",
+			wantsExport: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Run: func(*cobra.Command, []string) {}}
+			if tt.withTplFlag {
+				cmd.Flags().StringP("template", "T", "", "")
+			}
+			var exporter Exporter
+			AddJSONAndJQFlags(cmd, &exporter, tt.fields)
+			cmd.SetArgs(tt.args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			_, err := cmd.ExecuteC()
+			if tt.wantsError == "" {
+				require.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantsError)
+				return
+			}
+			if tt.wantsExport == nil {
+				assert.Nil(t, exporter)
+			} else {
+				assert.Equal(t, tt.wantsExport, exporter)
+			}
+		})
+	}
+}
+
 // TestAddJSONFlagsSetsAnnotations asserts that `AddJSONFlags` function adds the
 // appropriate annotation to the command, which could later be used by doc
 // generator functions.


### PR DESCRIPTION
Fixes #11247.

## Summary
- Add `--json` and `--jq` support to `gh pr create` via a new `cmdutil.AddJSONAndJQFlags` helper (no JSON `--template` flag).
- Make JSON flag validation aware of commands that do not use JSON templating.
- Keep `gh pr create --template <file>` independent from JSON output mode.
- Reject `--dry-run` together with `--json` for `gh pr create`.
- Include `number` in the `CreatePullRequest` mutation response so `--json number` works.

## Test
- `go test ./pkg/cmdutil ./pkg/cmd/pr/create ./api`
