### PR TITLE
fix(issue list): reject pull request-only search qualifiers

### DIFF
--- a/pkg/cmd/issue/list/http.go
+++ b/pkg/cmd/issue/list/http.go
@@ -2,12 +2,15 @@ package list
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/cli/cli/v2/api"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	prShared "github.com/cli/cli/v2/pkg/cmd/pr/shared"
 )
+
+var pullRequestSearchQualifierRE = regexp.MustCompile(`(?i)\b(?:is|type):(?:pr|pull-?request)\b`)
 
 func listIssues(client *api.Client, repo ghrepo.Interface, filters prShared.FilterOptions, limit int) (*api.IssuesAndTotalCount, error) {
 	var states []string
@@ -114,6 +117,10 @@ loop:
 }
 
 func searchIssues(client *api.Client, detector fd.Detector, repo ghrepo.Interface, filters prShared.FilterOptions, limit int) (*api.IssuesAndTotalCount, error) {
+	if pullRequestSearchQualifierRE.MatchString(filters.Search) {
+		return nil, fmt.Errorf("cannot use pull request search qualifiers with `gh issue list`; use `gh pr list` instead")
+	}
+
 	// TODO advancedIssueSearchCleanup
 	// We won't need feature detection when GHES 3.17 support ends, since
 	// the advanced issue search is the only available search backend for

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -216,20 +216,54 @@ func TestSearchIssuesAndAdvancedSearch(t *testing.T) {
 }
 
 func TestSearchIssues_rejectsPullRequestQualifiers(t *testing.T) {
-	reg := &httpmock.Registry{}
-	defer reg.Verify(t)
+	tests := []struct {
+		name   string
+		search string
+	}{
+		{
+			name:   "is:pr",
+			search: "is:pr",
+		},
+		{
+			name:   "type:pr",
+			search: "type:pr",
+		},
+		{
+			name:   "type:pull-request",
+			search: "type:pull-request",
+		},
+		{
+			name:   "type:pullrequest",
+			search: "type:pullrequest",
+		},
+		{
+			name:   "case-insensitive is:PR",
+			search: "is:PR",
+		},
+		{
+			name:   "case-insensitive TYPE:Pull-Request",
+			search: "TYPE:Pull-Request",
+		},
+	}
 
-	httpClient := &http.Client{Transport: reg}
-	client := api.NewClientFromHTTP(httpClient)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
 
-	_, err := searchIssues(
-		client,
-		fd.AdvancedIssueSearchSupportedAsOnlyBackend(),
-		ghrepo.New("OWNER", "REPO"),
-		prShared.FilterOptions{Search: "is:pr"},
-		30,
-	)
+			httpClient := &http.Client{Transport: reg}
+			client := api.NewClientFromHTTP(httpClient)
 
-	assert.EqualError(t, err, "cannot use pull request search qualifiers with `gh issue list`; use `gh pr list` instead")
-	assert.Len(t, reg.Requests, 0)
+			_, err := searchIssues(
+				client,
+				fd.AdvancedIssueSearchSupportedAsOnlyBackend(),
+				ghrepo.New("OWNER", "REPO"),
+				prShared.FilterOptions{Search: tt.search},
+				30,
+			)
+
+			assert.EqualError(t, err, "cannot use pull request search qualifiers with `gh issue list`; use `gh pr list` instead")
+			assert.Len(t, reg.Requests, 0)
+		})
+	}
 }

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -214,3 +214,22 @@ func TestSearchIssuesAndAdvancedSearch(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchIssues_rejectsPullRequestQualifiers(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	httpClient := &http.Client{Transport: reg}
+	client := api.NewClientFromHTTP(httpClient)
+
+	_, err := searchIssues(
+		client,
+		fd.AdvancedIssueSearchSupportedAsOnlyBackend(),
+		ghrepo.New("OWNER", "REPO"),
+		prShared.FilterOptions{Search: "is:pr"},
+		30,
+	)
+
+	assert.EqualError(t, err, "cannot use pull request search qualifiers with `gh issue list`; use `gh pr list` instead")
+	assert.Len(t, reg.Requests, 0)
+}


### PR DESCRIPTION
Fixes #8272.

## Summary
- Detect pull-request-only qualifiers in `gh issue list --search` (`is:pr`, `type:pr`, and pull-request variants).
- Return a clear error message instead of issuing a GraphQL issue search that yields empty nodes.
- Keep normal issue search behavior unchanged.

## Why
`gh issue list -S 'is:pr'` currently produces blank rows because the search query mixes issue and PR semantics, and the response nodes don't match the expected issue shape.

This change fails fast with guidance to use `gh pr list` for PR searches.

## Test
- Added `TestSearchIssues_rejectsPullRequestQualifiers` in `pkg/cmd/issue/list/http_test.go`.
- `go test ./pkg/cmd/issue/list`
