### PR TITLE
Add manual dispatch to bump-go workflow

### DIFF
--- a/.github/workflows/bump-go.yml
+++ b/.github/workflows/bump-go.yml
@@ -2,6 +2,7 @@ name: Bump Go
 on:
   schedule:
     - cron: "0 3 * * *" # 3 AM UTC
+  workflow_dispatch:
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
Enable manual runs of the Bump Go workflow by adding the workflow_dispatch trigger alongside the existing scheduled cron. This allows maintainers to trigger the bump process on-demand while keeping the daily 3 AM UTC schedule intact.