### PR TITLE
Fix redundant API call in gh issue view --comments (#12606)

### DIFF
--- a/pkg/cmd/issue/view/fixtures/issueView_previewSingleComment.json
+++ b/pkg/cmd/issue/view/fixtures/issueView_previewSingleComment.json
@@ -138,7 +138,11 @@
               ]
             }
           ],
-          "totalCount": 6
+          "totalCount": 6,
+          "pageInfo": {
+            "hasNextPage": true,
+            "endCursor": "Y3Vyc29yOnYyOjg5"
+          }
         },
         "url": "https://github.com/OWNER/REPO/issues/123"
       }

--- a/pkg/cmd/issue/view/http.go
+++ b/pkg/cmd/issue/view/http.go
@@ -20,14 +20,13 @@ func preloadIssueComments(client *http.Client, repo ghrepo.Interface, issue *api
 		} `graphql:"node(id: $id)"`
 	}
 
+	if !issue.Comments.PageInfo.HasNextPage {
+		return nil
+	}
+
 	variables := map[string]interface{}{
 		"id":        githubv4.ID(issue.ID),
-		"endCursor": (*githubv4.String)(nil),
-	}
-	if issue.Comments.PageInfo.HasNextPage {
-		variables["endCursor"] = githubv4.String(issue.Comments.PageInfo.EndCursor)
-	} else {
-		issue.Comments.Nodes = issue.Comments.Nodes[0:0]
+		"endCursor": githubv4.String(issue.Comments.PageInfo.EndCursor),
 	}
 
 	gql := api.NewClientFromHTTP(client)

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -144,8 +144,6 @@ func viewRun(opts *ViewOptions) error {
 	}
 
 	if lookupFields.Contains("comments") {
-		// FIXME: this re-fetches the comments connection even though the initial set of 100 were
-		// fetched in the previous request.
 		err := preloadIssueComments(httpClient, baseRepo, issue)
 		if err != nil {
 			return err


### PR DESCRIPTION

This PR fixes a redundant API call in 'gh issue view --comments' by returning early if no more pages are available

### Changes
- Added early return in 'preloadIssueComments' if 'HasNextPage' is false.
- Removed stale FIXME comment.
- Updated test fixtures to maintain pagination coverage.

### Verification
- Verified with a reproduction test case.
- Ran full test suite for 'pkg/cmd/issue/view' (39 tests passed).
Fixes #12606 