### PR TITLE
feat(pr): add changeType field to files JSON output

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -296,9 +296,10 @@ type PullRequestCommitCommit struct {
 }
 
 type PullRequestFile struct {
-	Path      string `json:"path"`
-	Additions int    `json:"additions"`
-	Deletions int    `json:"deletions"`
+	Path       string `json:"path"`
+	Additions  int    `json:"additions"`
+	Deletions  int    `json:"deletions"`
+	ChangeType string `json:"changeType"`
 }
 
 type ReviewRequests struct {

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -148,7 +148,8 @@ var prFiles = shortenQuery(`
 		nodes {
 			additions,
 			deletions,
-			path
+			path,
+			changeType
 		}
 	}
 `)

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -26,7 +26,7 @@ func TestPullRequestGraphQL(t *testing.T) {
 		{
 			name:   "compressed query",
 			fields: []string{"files"},
-			want:   "files(first: 100) {nodes {additions,deletions,path}}",
+			want:   "files(first: 100) {nodes {additions,deletions,path,changeType}}",
 		},
 		{
 			name:   "invalid fields",
@@ -72,7 +72,7 @@ func TestIssueGraphQL(t *testing.T) {
 		{
 			name:   "compressed query",
 			fields: []string{"files"},
-			want:   "files(first: 100) {nodes {additions,deletions,path}}",
+			want:   "files(first: 100) {nodes {additions,deletions,path,changeType}}",
 		},
 		{
 			name:   "projectItems",


### PR DESCRIPTION
Adds the `changeType` field to the `files` JSON output for `gh pr list` and `gh pr view`.

This exposes the file's patch status (`ADDED`, `MODIFIED`, `DELETED`, `RENAMED`, `COPIED`, `CHANGED`) which was already available in the GraphQL API but not surfaced in the CLI output.

**Before:**
```json
{
  "files": [
    { "path": "docs/readme.md", "additions": 1, "deletions": 1 }
  ]
}
```

**After:**
```json
{
  "files": [
    { "path": "docs/readme.md", "additions": 1, "deletions": 1, "changeType": "MODIFIED" }
  ]
}
```

**Changes:**
- Added `ChangeType` field to `PullRequestFile` struct (`api/queries_pr.go`)
- Added `changeType` to the GraphQL files query (`api/query_builder.go`)
- Updated query builder test expectations

Closes #11385