### PR TITLE
Handle GitHub server/api env host resolution

### DIFF
--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -195,6 +195,31 @@ func TestHostsIncludesEnvVar(t *testing.T) {
 	// Then the host in the env var is included
 	require.Contains(t, hosts, "ghe.io")
 }
+func TestHostsIncludesGitHubServerURL(t *testing.T) {
+	// Given the GITHUB_SERVER_URL env var is set
+	authCfg := newTestAuthConfig(t)
+	t.Setenv("GITHUB_SERVER_URL", "https://corp.ghe.com")
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
+	// When we get the hosts
+	hosts := authCfg.Hosts()
+
+	// Then the host in the env var is included
+	require.Contains(t, hosts, "corp.ghe.com")
+}
+
+func TestHostsIncludesGitHubAPIURL(t *testing.T) {
+	// Given the GITHUB_API_URL env var is set
+	authCfg := newTestAuthConfig(t)
+	t.Setenv("GITHUB_API_URL", "https://api.corp.ghe.com")
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
+	// When we get the hosts
+	hosts := authCfg.Hosts()
+
+	// Then the host in the env var is included
+	require.Contains(t, hosts, "corp.ghe.com")
+}
 
 func TestDefaultHostFromEnvVar(t *testing.T) {
 	// Given the GH_HOST env var is set
@@ -207,6 +232,31 @@ func TestDefaultHostFromEnvVar(t *testing.T) {
 	// Then the returned host and source are using the env var
 	require.Equal(t, "ghe.io", defaultHost)
 	require.Equal(t, "GH_HOST", source)
+}
+func TestDefaultHostFromGitHubServerURL(t *testing.T) {
+	// Given the GITHUB_SERVER_URL env var is set
+	authCfg := newTestAuthConfig(t)
+	t.Setenv("GITHUB_SERVER_URL", "https://corp.ghe.com")
+
+	// When we get the DefaultHost
+	defaultHost, source := authCfg.DefaultHost()
+
+	// Then the returned host and source are using the env var
+	require.Equal(t, "corp.ghe.com", defaultHost)
+	require.Equal(t, "GITHUB_SERVER_URL", source)
+}
+
+func TestDefaultHostFromGitHubAPIURL(t *testing.T) {
+	// Given the GITHUB_API_URL env var is set
+	authCfg := newTestAuthConfig(t)
+	t.Setenv("GITHUB_API_URL", "https://api.corp.ghe.com")
+
+	// When we get the DefaultHost
+	defaultHost, source := authCfg.DefaultHost()
+
+	// Then the returned host and source are using the env var
+	require.Equal(t, "corp.ghe.com", defaultHost)
+	require.Equal(t, "GITHUB_API_URL", source)
 }
 
 func TestDefaultHostNotLoggedIn(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,9 +3,11 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/keyring"
@@ -314,11 +316,93 @@ func (c *AuthConfig) ActiveUser(hostname string) (string, error) {
 	return c.cfg.Get([]string{hostsKey, hostname, userKey})
 }
 
+// githubHostFromEnv resolves a GitHub host from GITHUB_SERVER_URL or GITHUB_API_URL.
+func githubHostFromEnv() (string, string) {
+	if host, source := hostnameFromGitHubServerURL(); host != "" {
+		return host, source
+	}
+	if host, source := hostnameFromGitHubAPIURL(); host != "" {
+		return host, source
+	}
+	return "", ""
+}
+
+// hostnameFromGitHubServerURL returns the normalized host derived from GITHUB_SERVER_URL.
+func hostnameFromGitHubServerURL() (string, string) {
+	if raw := os.Getenv("GITHUB_SERVER_URL"); raw != "" {
+		if host := hostnameFromURL(raw); host != "" {
+			return ghauth.NormalizeHostname(host), "GITHUB_SERVER_URL"
+		}
+	}
+	return "", ""
+}
+
+// hostnameFromGitHubAPIURL returns the normalized host derived from GITHUB_API_URL.
+func hostnameFromGitHubAPIURL() (string, string) {
+	if raw := os.Getenv("GITHUB_API_URL"); raw != "" {
+		if host := hostnameFromURL(raw); host != "" {
+			host = strings.ToLower(host)
+			if strings.HasPrefix(host, "api.") && (host == "api.github.com" || strings.HasSuffix(host, ".ghe.com")) {
+				host = strings.TrimPrefix(host, "api.")
+			}
+			return ghauth.NormalizeHostname(host), "GITHUB_API_URL"
+		}
+	}
+	return "", ""
+}
+
+// hostnameFromURL extracts a lowercase hostname from a URL or host string.
+func hostnameFromURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	parsed, err := url.Parse(trimmed)
+	if err == nil {
+		if parsed.Host != "" {
+			return strings.ToLower(parsed.Hostname())
+		}
+		if parsed.Path != "" {
+			parts := strings.Split(parsed.Path, "/")
+			if len(parts) > 0 && parts[0] != "" {
+				return strings.ToLower(parts[0])
+			}
+		}
+	}
+	return ""
+}
+
 func (c *AuthConfig) Hosts() []string {
 	if c.hostsOverride != nil {
 		return c.hostsOverride()
 	}
-	return ghauth.KnownHosts()
+	hosts := ghauth.KnownHosts()
+	envHost, _ := githubHostFromEnv()
+	if envHost != "" {
+		if token, _ := ghauth.TokenFromEnvOrConfig(envHost); token != "" && !slices.Contains(hosts, envHost) {
+			hosts = append(hosts, envHost)
+		}
+		if envHost != ghauth.NormalizeHostname("github.com") && os.Getenv("GH_HOST") == "" && !c.hasHostConfig("github.com") {
+			hosts = slices.DeleteFunc(hosts, func(host string) bool {
+				return host == "github.com"
+			})
+		}
+	}
+	return hosts
+}
+
+// hasHostConfig reports whether the config contains the given host.
+func (c *AuthConfig) hasHostConfig(hostname string) bool {
+	keys, err := c.cfg.Keys([]string{hostsKey})
+	if err != nil {
+		return false
+	}
+	for _, key := range keys {
+		if key == hostname {
+			return true
+		}
+	}
+	return false
 }
 
 // SetHosts will override any hosts resolution and return the given
@@ -332,6 +416,12 @@ func (c *AuthConfig) SetHosts(hosts []string) {
 func (c *AuthConfig) DefaultHost() (string, string) {
 	if c.defaultHostOverride != nil {
 		return c.defaultHostOverride()
+	}
+	if host := os.Getenv("GH_HOST"); host != "" {
+		return host, "GH_HOST"
+	}
+	if host, source := githubHostFromEnv(); host != "" {
+		return host, source
 	}
 	return ghauth.DefaultHost()
 }

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -289,6 +289,34 @@ func Test_statusRun(t *testing.T) {
 			`),
 		},
 		{
+			name: "token from env with server url",
+			opts: StatusOptions{},
+			env: map[string]string{
+				"GITHUB_TOKEN":      "gho_abc123",
+				"GITHUB_SERVER_URL": "https://corp.ghe.com",
+				"GITHUB_API_URL":    "https://api.corp.ghe.com",
+			},
+			cfgStubs: func(t *testing.T, c gh.Config) {},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.WithHost(httpmock.REST("GET", ""), "api.corp.ghe.com"),
+					httpmock.ScopesResponder("repo,read:org"),
+				)
+				reg.Register(
+					httpmock.WithHost(httpmock.GraphQL(`query UserCurrent\b`), "api.corp.ghe.com"),
+					httpmock.StringResponse(`{"data":{"viewer":{"login":"monalisa"}}}`),
+				)
+			},
+			wantOut: heredoc.Doc(`
+				corp.ghe.com
+				  ✓ Logged in to corp.ghe.com account monalisa (GITHUB_TOKEN)
+				  - Active account: true
+				  - Git operations protocol: https
+				  - Token: gho_******
+				  - Token scopes: 'repo', 'read:org'
+			`),
+		},
+		{
 			name: "server-to-server token",
 			opts: StatusOptions{},
 			cfgStubs: func(t *testing.T, c gh.Config) {


### PR DESCRIPTION
## Summary
- Resolve auth host selection from GITHUB_SERVER_URL / GITHUB_API_URL
- Prefer the env-derived host for default host/host list when a non-github.com server is configured
- Add tests for env host resolution and auth status behavior

## Testing
- go test ./internal/config -run TestHostsIncludesGitHubServerURL -count=1
- go test ./pkg/cmd/auth/status -run Test_statusRun -count=1

Fixes #12666