### PR TITLE
Fork with default branch only during pr create

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -1128,7 +1128,7 @@ func handlePush(opts CreateOptions, ctx CreateContext) error {
 	forkableRefs, requiresFork := refs.(forkableRefs)
 	if requiresFork {
 		opts.IO.StartProgressIndicator()
-		forkedRepo, err := api.ForkRepo(ctx.Client, forkableRefs.BaseRepo(), "", "", false)
+		forkedRepo, err := api.ForkRepo(ctx.Client, forkableRefs.BaseRepo(), "", "", true)
 		opts.IO.StopProgressIndicator()
 		if err != nil {
 			return fmt.Errorf("error forking repo: %w", err)

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -214,7 +214,8 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			Upon success, the URL of the created pull request will be printed.
 
 			When the current branch isn't fully pushed to a git remote, a prompt will ask where
-			to push the branch and offer an option to fork the base repository. Use %[1]s--head%[1]s to
+			to push the branch and offer an option to fork the base repository. Any fork created this
+			way will only have the default branch of the upstream repository. Use %[1]s--head%[1]s to
 			explicitly skip any forking or pushing behavior.
 
 			%[1]s--head%[1]s supports %[1]s<user>:<branch>%[1]s syntax to select a head repo owned by %[1]s<user>%[1]s.

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -894,11 +894,13 @@ func Test_createRun(t *testing.T) {
 					httpmock.StringResponse(`{"data": {"viewer": {"login": "monalisa"} } }`))
 				reg.Register(
 					httpmock.REST("POST", "repos/OWNER/REPO/forks"),
-					httpmock.StatusStringResponse(201, `
+					httpmock.RESTPayload(201, `
 							{ "node_id": "NODEID",
 							  "name": "REPO",
 							  "owner": {"login": "monalisa"}
-							}`))
+							}`, func(payload map[string]interface{}) {
+						assert.Equal(t, true, payload["default_branch_only"])
+					}))
 				reg.Register(
 					httpmock.GraphQL(`mutation PullRequestCreate\b`),
 					httpmock.GraphQLMutation(`


### PR DESCRIPTION
## Description

Fixes #12670

When `gh pr create` auto-forks a repo, pass `default_branch_only=true` to the fork API.

During `pr create`, the fork exists solely as a place to push the PR head branch, so it's pretty unlikely that this will be a breaking change (but of course, not guaranteed). I think it's fine to make this change and then see if we have to do any apologies.

### Reviewer Notes

I haven't actually tried this out yet, juggling a few things, but I will ensure it has my eyes before merging.