### PR TITLE
Respect `--exit-status` with `--log` and `--log-failed` in `run view`

### DIFF
--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -331,7 +331,14 @@ func runView(opts *ViewOptions) error {
 			return err
 		}
 
-		return displayLogSegments(opts.IO.Out, segments)
+		if err := displayLogSegments(opts.IO.Out, segments); err != nil {
+			return err
+		}
+
+		if opts.ExitStatus && shared.IsFailureState(run.Conclusion) {
+			return cmdutil.SilentError
+		}
+		return nil
 	}
 
 	prNumber := ""

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -1049,6 +1049,64 @@ func TestViewRun(t *testing.T) {
 			wantOut: quuxTheBarfLogOutput,
 		},
 		{
+			name: "exit status respected with log-failed, failed run",
+			opts: &ViewOptions{
+				RunID:      "1234",
+				LogFailed:  true,
+				ExitStatus: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/1234"),
+					httpmock.JSONResponse(shared.FailedRun))
+				reg.Register(
+					httpmock.REST("GET", "runs/1234/jobs"),
+					httpmock.JSONResponse(shared.JobsPayload{
+						Jobs: []shared.Job{
+							shared.SuccessfulJob,
+							shared.FailedJob,
+						},
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/1234/logs"),
+					httpmock.BinaryResponse(zipArchive))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/123"),
+					httpmock.JSONResponse(shared.TestWorkflow))
+			},
+			wantOut: quuxTheBarfLogOutput,
+			wantErr: true,
+		},
+		{
+			name: "exit status respected with log, failed run",
+			opts: &ViewOptions{
+				RunID:      "1234",
+				Log:        true,
+				ExitStatus: true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/1234"),
+					httpmock.JSONResponse(shared.FailedRun))
+				reg.Register(
+					httpmock.REST("GET", "runs/1234/jobs"),
+					httpmock.JSONResponse(shared.JobsPayload{
+						Jobs: []shared.Job{
+							shared.SuccessfulJob,
+							shared.FailedJob,
+						},
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/runs/1234/logs"),
+					httpmock.BinaryResponse(zipArchive))
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/actions/workflows/123"),
+					httpmock.JSONResponse(shared.TestWorkflow))
+			},
+			wantOut: expectedRunLogOutput,
+			wantErr: true,
+		},
+		{
 			name: "interactive with log, with no step logs available (#10551)",
 			tty:  true,
 			opts: &ViewOptions{


### PR DESCRIPTION
## Description

Fixes https://github.com/cli/cli/issues/12674

When `--exit-status` was passed alongside `--log` or `--log-failed`, the command always exited 0 because the log display code path returned early without checking the run's conclusion.

This adds the exit-status check after displaying logs, matching the behavior of the non-log code paths.

### Acceptance Criteria

**Given** I have a failing job
**When** I run `gh run view` with `--exit-status` and either `--log` or `--log-failed`
**Then** the exit status of `gh` is non-zero

#### Before, with no log flag

```
➜ GH_PAGER=cat gh run view --repo cli/cli --exit-status 21973995883 || echo $?


X trunk Bump Go · 21973995883
Triggered via schedule about 11 hours ago

JOBS
X bump-go in 13s (ID 63481482065)
  ✓ Set up job
  ✓ Checkout repository
  ✓ Set up Go
  X Bump Go version
  - Post Set up Go
  ✓ Post Checkout repository
  ✓ Complete job

ANNOTATIONS
X Process completed with exit code 1.
bump-go: .github#15


To see what failed, try: gh run view 21973995883 --log-failed
View this run on GitHub: https://github.com/cli/cli/actions/runs/21973995883

➜  echo $?
1
```

#### Before, with log flag

```
➜  wm-run-view-exit-status-not-respected git:(wm-run-view-exit-status-not-respected) GH_PAGER=cat gh run view --repo cli/cli --log-failed --exit-status 21973995883

bump-go	UNKNOWN STEP	2026-02-13T03:53:41.0131892Z Current runner version: '2.331.0'
bump-go	UNKNOWN STEP	2026-02-13T03:53:41.0154343Z ##[group]Runner Image Provisioner
bump-go	UNKNOWN STEP	2026-02-13T03:53:41.0155291Z Hosted Compute Agent
...

➜ echo $?
0
```

#### After, with log flag

```
➜  GH_PAGER=cat ./bin/gh run view --repo cli/cli --log-failed --exit-status 21973995883

bump-go	UNKNOWN STEP	2026-02-13T03:53:41.0131892Z Current runner version: '2.331.0'
bump-go	UNKNOWN STEP	2026-02-13T03:53:41.0154343Z ##[group]Runner Image Provisioner
bump-go	UNKNOWN STEP	2026-02-13T03:53:41.0155291Z Hosted Compute Agent
...

➜ echo $?
1
```

### Reviewer Notes

I have not extended this to `--json` flags, which feels like a much bigger conceptual lift.