### PR TITLE
Pin REST API version to 2022-11-28

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -16,6 +16,8 @@ import (
 
 const (
 	accept          = "Accept"
+	apiVersion      = "X-GitHub-Api-Version"
+	apiVersionValue = "2022-11-28"
 	authorization   = "Authorization"
 	cacheTTL        = "X-GH-CACHE-TTL"
 	graphqlFeatures = "GraphQL-Features"
@@ -264,6 +266,7 @@ func clientOptions(hostname string, transport http.RoundTripper) ghAPI.ClientOpt
 		AuthToken: "none",
 		Headers: map[string]string{
 			authorization: "",
+			apiVersion:    apiVersionValue,
 		},
 		Host:               hostname,
 		SkipDefaultHeaders: true,

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -245,10 +245,11 @@ func TestHTTPHeaders(t *testing.T) {
 	assert.NoError(t, err)
 
 	wantHeader := map[string]string{
-		"Accept":        "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
-		"Authorization": "token MYTOKEN",
-		"Content-Type":  "application/json; charset=utf-8",
-		"User-Agent":    "GitHub CLI v1.2.3",
+		"Accept":               "application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview",
+		"Authorization":        "token MYTOKEN",
+		"Content-Type":         "application/json; charset=utf-8",
+		"User-Agent":           "GitHub CLI v1.2.3",
+		"X-GitHub-Api-Version": "2022-11-28",
 	}
 	for name, value := range wantHeader {
 		assert.Equal(t, value, gotReq.Header.Get(name), name)

--- a/api/http_client.go
+++ b/api/http_client.go
@@ -49,7 +49,8 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 	}
 
 	headers := map[string]string{
-		userAgent: fmt.Sprintf("GitHub CLI %s", opts.AppVersion),
+		userAgent:  fmt.Sprintf("GitHub CLI %s", opts.AppVersion),
+		apiVersion: apiVersionValue,
 	}
 	clientOpts.Headers = headers
 

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -39,9 +39,10 @@ func TestNewHTTPClient(t *testing.T) {
 			},
 			host: "github.com",
 			wantHeader: map[string][]string{
-				"authorization": {"token MYTOKEN"},
-				"user-agent":    {"GitHub CLI v1.2.3"},
-				"accept":        {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
+				"authorization":        {"token MYTOKEN"},
+				"user-agent":           {"GitHub CLI v1.2.3"},
+				"x-github-api-version": {"2022-11-28"},
+				"accept":               {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
 			},
 			wantStderr: "",
 		},
@@ -53,9 +54,10 @@ func TestNewHTTPClient(t *testing.T) {
 			},
 			host: "example.com",
 			wantHeader: map[string][]string{
-				"authorization": {"token GHETOKEN"},
-				"user-agent":    {"GitHub CLI v1.2.3"},
-				"accept":        {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
+				"authorization":        {"token GHETOKEN"},
+				"user-agent":           {"GitHub CLI v1.2.3"},
+				"x-github-api-version": {"2022-11-28"},
+				"accept":               {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
 			},
 			wantStderr: "",
 		},
@@ -68,9 +70,10 @@ func TestNewHTTPClient(t *testing.T) {
 			},
 			host: "github.com",
 			wantHeader: map[string][]string{
-				"authorization": nil, // should not be set
-				"user-agent":    {"GitHub CLI v1.2.3"},
-				"accept":        {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
+				"authorization":        nil, // should not be set
+				"user-agent":           {"GitHub CLI v1.2.3"},
+				"x-github-api-version": {"2022-11-28"},
+				"accept":               {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
 			},
 			wantStderr: "",
 		},
@@ -83,9 +86,10 @@ func TestNewHTTPClient(t *testing.T) {
 			},
 			host: "example.com",
 			wantHeader: map[string][]string{
-				"authorization": nil, // should not be set
-				"user-agent":    {"GitHub CLI v1.2.3"},
-				"accept":        {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
+				"authorization":        nil, // should not be set
+				"user-agent":           {"GitHub CLI v1.2.3"},
+				"x-github-api-version": {"2022-11-28"},
+				"accept":               {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
 			},
 			wantStderr: "",
 		},
@@ -98,9 +102,10 @@ func TestNewHTTPClient(t *testing.T) {
 			},
 			host: "github.com",
 			wantHeader: map[string][]string{
-				"authorization": {"token MYTOKEN"},
-				"user-agent":    {"GitHub CLI v1.2.3"},
-				"accept":        {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
+				"authorization":        {"token MYTOKEN"},
+				"user-agent":           {"GitHub CLI v1.2.3"},
+				"x-github-api-version": {"2022-11-28"},
+				"accept":               {"application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview"},
 			},
 			wantStderr: heredoc.Doc(`
 				* Request at <time>
@@ -112,6 +117,7 @@ func TestNewHTTPClient(t *testing.T) {
 				> Content-Type: application/json; charset=utf-8
 				> Time-Zone: <timezone>
 				> User-Agent: GitHub CLI v1.2.3
+				> X-Github-Api-Version: 2022-11-28
 
 				< HTTP/1.1 204 No Content
 				< Date: <time>
@@ -128,10 +134,11 @@ func TestNewHTTPClient(t *testing.T) {
 			},
 			host: "github.com",
 			wantHeader: map[string][]string{
-				"accept":        nil,
-				"authorization": nil,
-				"content-type":  nil,
-				"user-agent":    {"GitHub CLI v1.2.3"},
+				"accept":               nil,
+				"authorization":        nil,
+				"content-type":         nil,
+				"user-agent":           {"GitHub CLI v1.2.3"},
+				"x-github-api-version": {"2022-11-28"},
 			},
 			wantStderr: heredoc.Doc(`
 				* Request at <time>
@@ -140,6 +147,7 @@ func TestNewHTTPClient(t *testing.T) {
 				> Host: github.com
 				> Time-Zone: <timezone>
 				> User-Agent: GitHub CLI v1.2.3
+				> X-Github-Api-Version: 2022-11-28
 
 				< HTTP/1.1 204 No Content
 				< Date: <time>

--- a/pkg/cmd/factory/default_test.go
+++ b/pkg/cmd/factory/default_test.go
@@ -734,6 +734,7 @@ func TestPlainHttpClient(t *testing.T) {
 
 	assert.Equal(t, 204, res.StatusCode)
 	assert.Equal(t, []string{"GitHub CLI v1.2.3"}, receivedHeaders.Values("User-Agent"))
+	assert.Equal(t, []string{"2022-11-28"}, receivedHeaders.Values("X-GitHub-Api-Version"))
 	assert.Nil(t, receivedHeaders.Values("Authorization"))
 	assert.Nil(t, receivedHeaders.Values("Content-Type"))
 	assert.Nil(t, receivedHeaders.Values("Accept"))


### PR DESCRIPTION
## Description

Companion to https://github.com/cli/go-gh/pull/213.

In https://github.com/cli/go-gh/pull/213, `go-gh` starts including `X-GitHub-Api-Version: 2022-11-28` in each API client request, unless the consumer sets `SkipDefaultHeaders: true`. The CLI sets this in two places, so we need to ensure both paths provide the header explicitly.

### Before

```
➜ GH_DEBUG=api gh pr list
[git remote -v]
[git config --get-regexp ^remote\..*\.gh-resolved$]
* Request at 2026-02-13 19:50:26.119198 +0100 CET m=+0.069410376
* Request to https://api.github.com/graphql
> POST /graphql HTTP/1.1
> Host: api.github.com
> Accept: application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview
> Authorization: token ████████████████████
> Content-Length: 381
> Content-Type: application/json; charset=utf-8
> Graphql-Features: merge_queue
> Time-Zone: Europe/Amsterdam
> User-Agent: GitHub CLI 2.86.0
```

### After

```
➜ GH_DEBUG=api ./bin/gh pr list
[git remote -v]
[git config --get-regexp ^remote\..*\.gh-resolved$]
* Request at 2026-02-13 19:51:04.912836 +0100 CET m=+0.075533960
* Request to https://api.github.com/graphql
> POST /graphql HTTP/1.1
> Host: api.github.com
> Accept: application/vnd.github.merge-info-preview+json, application/vnd.github.nebula-preview
> Authorization: token ████████████████████
> Content-Length: 381
> Content-Type: application/json; charset=utf-8
> Graphql-Features: merge_queue
> Time-Zone: Europe/Amsterdam
> User-Agent: GitHub CLI v2.86.0-88-gd1aab0393
> X-Github-Api-Version: 2022-11-28 <-------
```