### PR TITLE
Add repository-scoped auth mapping and repo-aware status

### DIFF
--- a/context/remote.go
+++ b/context/remote.go
@@ -57,6 +57,34 @@ func (r Remotes) ResolvedRemote() (*Remote, error) {
 	return nil, fmt.Errorf("no resolved remote found")
 }
 
+// RepoContext returns the most specific repository context from remotes,
+// preferring remotes resolved as "base", then explicitly resolved values,
+// and finally the first remote.
+func (r Remotes) RepoContext() (ghrepo.Interface, bool) {
+	if len(r) == 0 {
+		return nil, false
+	}
+
+	for _, remote := range r {
+		if remote.Resolved == "base" {
+			return remote, true
+		}
+
+		if remote.Resolved == "" {
+			continue
+		}
+
+		repo, err := ghrepo.FromFullName(remote.Resolved)
+		if err != nil {
+			continue
+		}
+
+		return ghrepo.NewWithHost(repo.RepoOwner(), repo.RepoName(), remote.RepoHost()), true
+	}
+
+	return r[0], true
+}
+
 func remoteNameSortScore(name string) int {
 	switch strings.ToLower(name) {
 	case "upstream":

--- a/context/remote_test.go
+++ b/context/remote_test.go
@@ -137,3 +137,47 @@ func Test_FilterByHosts(t *testing.T) {
 	assert.Equal(t, r1, f[0])
 	assert.Equal(t, r2, f[1])
 }
+
+func Test_Remotes_RepoContext(t *testing.T) {
+	t.Run("returns false for empty", func(t *testing.T) {
+		repo, ok := Remotes{}.RepoContext()
+		assert.False(t, ok)
+		assert.Nil(t, repo)
+	})
+
+	t.Run("prefers resolved base remote", func(t *testing.T) {
+		list := Remotes{
+			&Remote{Remote: &git.Remote{Name: "origin", Resolved: ""}, Repo: ghrepo.NewWithHost("owner", "repo", "github.com")},
+			&Remote{Remote: &git.Remote{Name: "upstream", Resolved: "base"}, Repo: ghrepo.NewWithHost("base-owner", "base-repo", "github.com")},
+		}
+
+		repo, ok := list.RepoContext()
+		assert.True(t, ok)
+		assert.Equal(t, "base-owner", repo.RepoOwner())
+		assert.Equal(t, "base-repo", repo.RepoName())
+	})
+
+	t.Run("uses explicit resolved repo", func(t *testing.T) {
+		list := Remotes{
+			&Remote{Remote: &git.Remote{Name: "origin", Resolved: "other-owner/other-repo"}, Repo: ghrepo.NewWithHost("owner", "repo", "github.com")},
+		}
+
+		repo, ok := list.RepoContext()
+		assert.True(t, ok)
+		assert.Equal(t, "other-owner", repo.RepoOwner())
+		assert.Equal(t, "other-repo", repo.RepoName())
+		assert.Equal(t, "github.com", repo.RepoHost())
+	})
+
+	t.Run("falls back to first remote", func(t *testing.T) {
+		list := Remotes{
+			&Remote{Remote: &git.Remote{Name: "origin", Resolved: ""}, Repo: ghrepo.NewWithHost("owner", "repo", "github.com")},
+			&Remote{Remote: &git.Remote{Name: "fork", Resolved: ""}, Repo: ghrepo.NewWithHost("other", "repo", "github.com")},
+		}
+
+		repo, ok := list.RepoContext()
+		assert.True(t, ok)
+		assert.Equal(t, "owner", repo.RepoOwner())
+		assert.Equal(t, "repo", repo.RepoName())
+	})
+}

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -825,6 +825,42 @@ func TestTokenWithActiveUserNotInKeyringFallsBackToBlank(t *testing.T) {
 	require.Equal(t, "test-token", token)
 }
 
+func TestUserForRepositoryPrioritizesExactMatchOverOwnerMatch(t *testing.T) {
+	authCfg := newTestAuthConfig(t)
+
+	require.NoError(t, authCfg.SetUserForOwner("github.com", "devolutions", "work-user"))
+	require.NoError(t, authCfg.SetUserForRepository("github.com", "devolutions", "github-cli", "repo-user"))
+
+	user, ok := authCfg.UserForRepository("github.com", "Devolutions", "github-cli")
+	require.True(t, ok)
+	require.Equal(t, "repo-user", user)
+
+	user, ok = authCfg.UserForRepository("github.com", "devolutions", "other-repo")
+	require.True(t, ok)
+	require.Equal(t, "work-user", user)
+
+	_, ok = authCfg.UserForRepository("github.com", "unknown-owner", "repo")
+	require.False(t, ok)
+}
+
+func TestRepositoryUserMappingsCRUD(t *testing.T) {
+	authCfg := newTestAuthConfig(t)
+
+	require.NoError(t, authCfg.SetUserForOwner("github.com", "awakecoding", "personal-user"))
+	require.NoError(t, authCfg.SetUserForRepository("github.com", "devolutions", "github-cli", "work-user"))
+
+	mappings := authCfg.RepositoryUserMappings("github.com")
+	require.Equal(t, "personal-user", mappings.Owners["awakecoding"])
+	require.Equal(t, "work-user", mappings.Repos["devolutions"]["github-cli"])
+
+	require.NoError(t, authCfg.DeleteUserForOwner("github.com", "awakecoding"))
+	require.NoError(t, authCfg.DeleteUserForRepository("github.com", "devolutions", "github-cli"))
+
+	mappings = authCfg.RepositoryUserMappings("github.com")
+	require.Empty(t, mappings.Owners)
+	require.Empty(t, mappings.Repos)
+}
+
 func TestLogoutRightAfterMigrationRemovesHost(t *testing.T) {
 	// Given we have logged in before migration
 	authCfg := newTestAuthConfig(t)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/keyring"
@@ -34,6 +35,9 @@ const (
 	userKey               = "user"
 	usersKey              = "users"
 	versionKey            = "version"
+	accountMapKey         = "account_map"
+	ownersMapKey          = "owners"
+	reposMapKey           = "repos"
 )
 
 func NewConfig() (gh.Config, error) {
@@ -223,6 +227,11 @@ type AuthConfig struct {
 	defaultHostOverride func() (string, string)
 	hostsOverride       func() []string
 	tokenOverride       func(string) (string, string)
+}
+
+type RepositoryUserMappings struct {
+	Owners map[string]string
+	Repos  map[string]map[string]string
 }
 
 // ActiveToken will retrieve the active auth token for the given hostname,
@@ -503,6 +512,121 @@ func (c *AuthConfig) TokenForUser(hostname, user string) (string, string, error)
 	}
 
 	return "", "default", fmt.Errorf("no token found for '%s'", user)
+}
+
+func (c *AuthConfig) UserForRepository(hostname, owner, repo string) (string, bool) {
+	hostname = ghauth.NormalizeHostname(hostname)
+	owner = normalizeMappingPart(owner)
+	repo = normalizeMappingPart(repo)
+
+	if hostname == "" || owner == "" || repo == "" {
+		return "", false
+	}
+
+	if username, err := c.cfg.Get([]string{hostsKey, hostname, accountMapKey, reposMapKey, owner, repo}); err == nil && username != "" {
+		return username, true
+	}
+
+	if username, err := c.cfg.Get([]string{hostsKey, hostname, accountMapKey, ownersMapKey, owner}); err == nil && username != "" {
+		return username, true
+	}
+
+	return "", false
+}
+
+func (c *AuthConfig) SetUserForOwner(hostname, owner, user string) error {
+	hostname = ghauth.NormalizeHostname(hostname)
+	owner = normalizeMappingPart(owner)
+	user = strings.TrimSpace(user)
+
+	if hostname == "" || owner == "" || user == "" {
+		return errors.New("hostname, owner, and user are required")
+	}
+
+	c.cfg.Set([]string{hostsKey, hostname, accountMapKey, ownersMapKey, owner}, user)
+	return nil
+}
+
+func (c *AuthConfig) SetUserForRepository(hostname, owner, repo, user string) error {
+	hostname = ghauth.NormalizeHostname(hostname)
+	owner = normalizeMappingPart(owner)
+	repo = normalizeMappingPart(repo)
+	user = strings.TrimSpace(user)
+
+	if hostname == "" || owner == "" || repo == "" || user == "" {
+		return errors.New("hostname, owner, repo, and user are required")
+	}
+
+	c.cfg.Set([]string{hostsKey, hostname, accountMapKey, reposMapKey, owner, repo}, user)
+	return nil
+}
+
+func (c *AuthConfig) DeleteUserForOwner(hostname, owner string) error {
+	hostname = ghauth.NormalizeHostname(hostname)
+	owner = normalizeMappingPart(owner)
+
+	if hostname == "" || owner == "" {
+		return errors.New("hostname and owner are required")
+	}
+
+	return c.cfg.Remove([]string{hostsKey, hostname, accountMapKey, ownersMapKey, owner})
+}
+
+func (c *AuthConfig) DeleteUserForRepository(hostname, owner, repo string) error {
+	hostname = ghauth.NormalizeHostname(hostname)
+	owner = normalizeMappingPart(owner)
+	repo = normalizeMappingPart(repo)
+
+	if hostname == "" || owner == "" || repo == "" {
+		return errors.New("hostname, owner, and repo are required")
+	}
+
+	return c.cfg.Remove([]string{hostsKey, hostname, accountMapKey, reposMapKey, owner, repo})
+}
+
+func (c *AuthConfig) RepositoryUserMappings(hostname string) RepositoryUserMappings {
+	hostname = ghauth.NormalizeHostname(hostname)
+	out := RepositoryUserMappings{
+		Owners: map[string]string{},
+		Repos:  map[string]map[string]string{},
+	}
+
+	owners, err := c.cfg.Keys([]string{hostsKey, hostname, accountMapKey, ownersMapKey})
+	if err == nil {
+		for _, owner := range owners {
+			if username, getErr := c.cfg.Get([]string{hostsKey, hostname, accountMapKey, ownersMapKey, owner}); getErr == nil && username != "" {
+				out.Owners[owner] = username
+			}
+		}
+	}
+
+	repoOwners, err := c.cfg.Keys([]string{hostsKey, hostname, accountMapKey, reposMapKey})
+	if err == nil {
+		for _, owner := range repoOwners {
+			repos, repoErr := c.cfg.Keys([]string{hostsKey, hostname, accountMapKey, reposMapKey, owner})
+			if repoErr != nil {
+				continue
+			}
+
+			for _, repo := range repos {
+				username, getErr := c.cfg.Get([]string{hostsKey, hostname, accountMapKey, reposMapKey, owner, repo})
+				if getErr != nil || username == "" {
+					continue
+				}
+
+				if _, ok := out.Repos[owner]; !ok {
+					out.Repos[owner] = map[string]string{}
+				}
+				out.Repos[owner][repo] = username
+			}
+		}
+	}
+
+	return out
+}
+
+func normalizeMappingPart(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
 }
 
 func keyringServiceName(hostname string) string {

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -168,6 +168,12 @@ type AuthConfig interface {
 	SetDefaultHost(host, source string)
 }
 
+// RepositoryUserResolver provides repository-scoped account lookup behavior for
+// authentication implementations that support dynamic account selection.
+type RepositoryUserResolver interface {
+	UserForRepository(hostname, owner, repo string) (string, bool)
+}
+
 // AliasConfig defines an interface for managing command aliases.
 type AliasConfig interface {
 	// Get retrieves the expansion for a specified alias.

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	gitCredentialCmd "github.com/cli/cli/v2/pkg/cmd/auth/gitcredential"
 	authLoginCmd "github.com/cli/cli/v2/pkg/cmd/auth/login"
+	authMapCmd "github.com/cli/cli/v2/pkg/cmd/auth/map"
 	authLogoutCmd "github.com/cli/cli/v2/pkg/cmd/auth/logout"
 	authRefreshCmd "github.com/cli/cli/v2/pkg/cmd/auth/refresh"
 	authSetupGitCmd "github.com/cli/cli/v2/pkg/cmd/auth/setupgit"
@@ -30,6 +31,7 @@ func NewCmdAuth(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(authSetupGitCmd.NewCmdSetupGit(f, nil))
 	cmd.AddCommand(authTokenCmd.NewCmdToken(f, nil))
 	cmd.AddCommand(authSwitchCmd.NewCmdSwitch(f, nil))
+	cmd.AddCommand(authMapCmd.NewCmdMap(f))
 
 	return cmd
 }

--- a/pkg/cmd/auth/map/map.go
+++ b/pkg/cmd/auth/map/map.go
@@ -1,0 +1,352 @@
+package authmap
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type mapScope struct {
+	hostname string
+	owner    string
+	repo     string
+	ownerAll bool
+}
+
+type repositoryMapper interface {
+	SetUserForOwner(hostname, owner, user string) error
+	SetUserForRepository(hostname, owner, repo, user string) error
+	DeleteUserForOwner(hostname, owner string) error
+	DeleteUserForRepository(hostname, owner, repo string) error
+	RepositoryUserMappings(hostname string) config.RepositoryUserMappings
+}
+
+type SetOptions struct {
+	IO       *iostreams.IOStreams
+	Config   func() (gh.Config, error)
+	Scope    string
+	Username string
+	Hostname string
+}
+
+type ListOptions struct {
+	IO       *iostreams.IOStreams
+	Config   func() (gh.Config, error)
+	Hostname string
+}
+
+type RemoveOptions struct {
+	IO       *iostreams.IOStreams
+	Config   func() (gh.Config, error)
+	Scope    string
+	Hostname string
+}
+
+func NewCmdMap(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "map <command>",
+		Short: "Manage repository account mappings",
+		Long: heredoc.Docf(`
+			Manage mappings that select a specific authenticated account for repository scopes.
+
+			Scopes can be:
+			- %[1]sOWNER/*%[1]s
+			- %[1]sOWNER/REPO%[1]s
+			- %[1]sHOST/OWNER/*%[1]s
+			- %[1]sHOST/OWNER/REPO%[1]s
+
+			Mappings are applied for API requests when a repository context is available.
+		`, "`"),
+	}
+
+	cmd.AddCommand(newCmdSet(f))
+	cmd.AddCommand(newCmdList(f))
+	cmd.AddCommand(newCmdRemove(f))
+
+	return cmd
+}
+
+func newCmdSet(f *cmdutil.Factory) *cobra.Command {
+	opts := &SetOptions{
+		IO:     f.IOStreams,
+		Config: f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "set <scope>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Set a repository account mapping",
+		Example: heredoc.Doc(`
+			# Use account 'work-user' for all repos under Devolutions on github.com
+			$ gh auth map set Devolutions/* --user work-user
+
+			# Use account 'personal-user' for one specific repository
+			$ gh auth map set github.com/awakecoding/MsRdpEx --user personal-user
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Scope = args[0]
+			return setRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Username, "user", "u", "", "Account username to associate with this scope")
+	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "Hostname to apply when scope omits host")
+	_ = cmd.MarkFlagRequired("user")
+
+	return cmd
+}
+
+func newCmdList(f *cmdutil.Factory) *cobra.Command {
+	opts := &ListOptions{
+		IO:     f.IOStreams,
+		Config: f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Args:  cobra.ExactArgs(0),
+		Short: "List repository account mappings",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "Show mappings for a single hostname")
+
+	return cmd
+}
+
+func newCmdRemove(f *cmdutil.Factory) *cobra.Command {
+	opts := &RemoveOptions{
+		IO:     f.IOStreams,
+		Config: f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "remove <scope>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove a repository account mapping",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Scope = args[0]
+			return removeRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "Hostname to apply when scope omits host")
+
+	return cmd
+}
+
+func setRun(opts *SetOptions) error {
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+	authCfg := cfg.Authentication()
+
+	defaultHost, _ := authCfg.DefaultHost()
+	scope, err := parseScope(opts.Scope, opts.Hostname, defaultHost)
+	if err != nil {
+		return err
+	}
+
+	knownUsers := authCfg.UsersForHost(scope.hostname)
+	if !slicesContainsFold(knownUsers, opts.Username) {
+		return fmt.Errorf("not logged in to %s account %s", scope.hostname, opts.Username)
+	}
+
+	mapper, ok := authCfg.(repositoryMapper)
+	if !ok {
+		return fmt.Errorf("repository mappings are not supported by this configuration")
+	}
+
+	if scope.ownerAll {
+		err = mapper.SetUserForOwner(scope.hostname, scope.owner, opts.Username)
+	} else {
+		err = mapper.SetUserForRepository(scope.hostname, scope.owner, scope.repo, opts.Username)
+	}
+	if err != nil {
+		return err
+	}
+
+	if err := cfg.Write(); err != nil {
+		return fmt.Errorf("failed to write config to disk: %w", err)
+	}
+
+	if scope.ownerAll {
+		fmt.Fprintf(opts.IO.Out, "%s/%s/* => %s\n", scope.hostname, scope.owner, opts.Username)
+	} else {
+		fmt.Fprintf(opts.IO.Out, "%s/%s/%s => %s\n", scope.hostname, scope.owner, scope.repo, opts.Username)
+	}
+
+	return nil
+}
+
+func listRun(opts *ListOptions) error {
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+	authCfg := cfg.Authentication()
+
+	mapper, ok := authCfg.(repositoryMapper)
+	if !ok {
+		return fmt.Errorf("repository mappings are not supported by this configuration")
+	}
+
+	hosts := []string{}
+	if opts.Hostname != "" {
+		hosts = []string{strings.ToLower(strings.TrimSpace(opts.Hostname))}
+	} else {
+		hosts = authCfg.Hosts()
+		sort.Strings(hosts)
+	}
+
+	printed := false
+	for _, host := range hosts {
+		mappings := mapper.RepositoryUserMappings(host)
+		if len(mappings.Owners) == 0 && len(mappings.Repos) == 0 {
+			continue
+		}
+
+		fmt.Fprintln(opts.IO.Out, host)
+
+		owners := make([]string, 0, len(mappings.Owners))
+		for owner := range mappings.Owners {
+			owners = append(owners, owner)
+		}
+		sort.Strings(owners)
+		for _, owner := range owners {
+			fmt.Fprintf(opts.IO.Out, "  %s/* => %s\n", owner, mappings.Owners[owner])
+		}
+
+		repoOwners := make([]string, 0, len(mappings.Repos))
+		for owner := range mappings.Repos {
+			repoOwners = append(repoOwners, owner)
+		}
+		sort.Strings(repoOwners)
+		for _, owner := range repoOwners {
+			repos := make([]string, 0, len(mappings.Repos[owner]))
+			for repo := range mappings.Repos[owner] {
+				repos = append(repos, repo)
+			}
+			sort.Strings(repos)
+			for _, repo := range repos {
+				fmt.Fprintf(opts.IO.Out, "  %s/%s => %s\n", owner, repo, mappings.Repos[owner][repo])
+			}
+		}
+
+		printed = true
+	}
+
+	if !printed {
+		fmt.Fprintln(opts.IO.Out, "No repository account mappings configured.")
+	}
+
+	return nil
+}
+
+func removeRun(opts *RemoveOptions) error {
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+	authCfg := cfg.Authentication()
+
+	defaultHost, _ := authCfg.DefaultHost()
+	scope, err := parseScope(opts.Scope, opts.Hostname, defaultHost)
+	if err != nil {
+		return err
+	}
+
+	mapper, ok := authCfg.(repositoryMapper)
+	if !ok {
+		return fmt.Errorf("repository mappings are not supported by this configuration")
+	}
+
+	if scope.ownerAll {
+		err = mapper.DeleteUserForOwner(scope.hostname, scope.owner)
+	} else {
+		err = mapper.DeleteUserForRepository(scope.hostname, scope.owner, scope.repo)
+	}
+	if err != nil {
+		return err
+	}
+
+	if err := cfg.Write(); err != nil {
+		return fmt.Errorf("failed to write config to disk: %w", err)
+	}
+
+	return nil
+}
+
+func parseScope(scope, hostnameFlag, defaultHost string) (mapScope, error) {
+	hostnameFlag = strings.ToLower(strings.TrimSpace(hostnameFlag))
+	defaultHost = strings.ToLower(strings.TrimSpace(defaultHost))
+	scope = strings.TrimSpace(scope)
+
+	if scope == "" {
+		return mapScope{}, fmt.Errorf("scope cannot be blank")
+	}
+
+	parts := strings.Split(scope, "/")
+	for _, p := range parts {
+		if strings.TrimSpace(p) == "" {
+			return mapScope{}, fmt.Errorf("invalid scope %q", scope)
+		}
+	}
+
+	var out mapScope
+	switch len(parts) {
+	case 2:
+		out.hostname = hostnameFlag
+		if out.hostname == "" {
+			out.hostname = defaultHost
+		}
+		out.owner = strings.ToLower(parts[0])
+		if parts[1] == "*" {
+			out.ownerAll = true
+		} else {
+			out.repo = strings.ToLower(parts[1])
+		}
+	case 3:
+		out.hostname = strings.ToLower(parts[0])
+		if hostnameFlag != "" && hostnameFlag != out.hostname {
+			return mapScope{}, fmt.Errorf("scope host %q conflicts with --hostname %q", out.hostname, hostnameFlag)
+		}
+		out.owner = strings.ToLower(parts[1])
+		if parts[2] == "*" {
+			out.ownerAll = true
+		} else {
+			out.repo = strings.ToLower(parts[2])
+		}
+	default:
+		return mapScope{}, fmt.Errorf("invalid scope %q: expected OWNER/*, OWNER/REPO, HOST/OWNER/*, or HOST/OWNER/REPO", scope)
+	}
+
+	if out.hostname == "" {
+		return mapScope{}, fmt.Errorf("unable to determine hostname; pass --hostname or include HOST in scope")
+	}
+
+	if !out.ownerAll && out.repo == "" {
+		return mapScope{}, fmt.Errorf("invalid scope %q", scope)
+	}
+
+	return out, nil
+}
+
+func slicesContainsFold(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cmd/auth/map/map_test.go
+++ b/pkg/cmd/auth/map/map_test.go
@@ -1,0 +1,109 @@
+package authmap
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseScope(t *testing.T) {
+	tests := []struct {
+		name        string
+		scope       string
+		hostname    string
+		defaultHost string
+		want        mapScope
+		wantErr     string
+	}{
+		{
+			name:        "owner wildcard with default host",
+			scope:       "devolutions/*",
+			defaultHost: "github.com",
+			want: mapScope{
+				hostname: "github.com",
+				owner:    "devolutions",
+				ownerAll: true,
+			},
+		},
+		{
+			name:  "exact repo with explicit host",
+			scope: "github.com/awakecoding/msrdpex",
+			want: mapScope{
+				hostname: "github.com",
+				owner:    "awakecoding",
+				repo:     "msrdpex",
+			},
+		},
+		{
+			name:        "invalid scope",
+			scope:       "invalid",
+			defaultHost: "github.com",
+			wantErr:     "invalid scope",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseScope(tt.scope, tt.hostname, tt.defaultHost)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSetListAndRemoveRun(t *testing.T) {
+	ios, _, stdout, _ := iostreams.Test()
+	cfg, _ := config.NewIsolatedTestConfig(t)
+
+	authCfg := cfg.Authentication()
+	_, err := authCfg.Login("github.com", "work-user", "work-token", "", false)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "personal-user", "personal-token", "", false)
+	require.NoError(t, err)
+
+	configFn := func() (gh.Config, error) {
+		return cfg, nil
+	}
+
+	err = setRun(&SetOptions{
+		IO:       ios,
+		Config:   configFn,
+		Scope:    "devolutions/*",
+		Username: "work-user",
+	})
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "github.com/devolutions/* => work-user")
+
+	stdout.Reset()
+	err = listRun(&ListOptions{
+		IO:     ios,
+		Config: configFn,
+	})
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "devolutions/* => work-user")
+
+	stdout.Reset()
+	err = removeRun(&RemoveOptions{
+		IO:     ios,
+		Config: configFn,
+		Scope:  "devolutions/*",
+	})
+	require.NoError(t, err)
+
+	stdout.Reset()
+	err = listRun(&ListOptions{
+		IO:       ios,
+		Config:   configFn,
+		Hostname: "github.com",
+	})
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "No repository account mappings configured")
+}

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
+	ghContext "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -116,6 +118,7 @@ func (e authEntry) String(cs *iostreams.ColorScheme) string {
 
 type StatusOptions struct {
 	HttpClient func() (*http.Client, error)
+	Remotes    func() (ghContext.Remotes, error)
 	IO         *iostreams.IOStreams
 	Config     func() (gh.Config, error)
 	Exporter   cmdutil.Exporter
@@ -128,6 +131,7 @@ type StatusOptions struct {
 func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Command {
 	opts := &StatusOptions{
 		HttpClient: f.HttpClient,
+		Remotes:    f.Remotes,
 		IO:         f.IOStreams,
 		Config:     f.Config,
 	}
@@ -298,6 +302,8 @@ func statusRun(opts *StatusOptions) error {
 		return nil
 	}
 
+	currentRepo := currentRepositoryStatusForAuth(opts.Remotes, authCfg)
+
 	prevEntry := false
 	for _, hostname := range hostnames {
 		entries, ok := statuses.Hosts[hostname]
@@ -308,6 +314,10 @@ func statusRun(opts *StatusOptions) error {
 		stream := stdout
 		if finalErr != nil {
 			stream = stderr
+		}
+
+		if !prevEntry && currentRepo != nil {
+			fmt.Fprintf(stream, "%s\n\n", currentRepo.display(cs))
 		}
 
 		if prevEntry {
@@ -324,6 +334,101 @@ func statusRun(opts *StatusOptions) error {
 	}
 
 	return finalErr
+}
+
+type repositoryUserResolver interface {
+	UserForRepository(hostname, owner, repo string) (string, bool)
+}
+
+type currentRepositoryStatus struct {
+	repoDisplay      string
+	effectiveAccount string
+	reason           string
+}
+
+func (c currentRepositoryStatus) display(cs *iostreams.ColorScheme) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s %s\n", cs.SuccessIcon(), cs.Bold("Current repository auth")))
+	sb.WriteString(fmt.Sprintf("  - Repository: %s\n", cs.Bold(c.repoDisplay)))
+	sb.WriteString(fmt.Sprintf("  - Effective account: %s\n", cs.Bold(c.effectiveAccount)))
+	sb.WriteString(fmt.Sprintf("  - Source: %s", c.reason))
+	return sb.String()
+}
+
+func currentRepositoryStatusForAuth(remotesFn func() (ghContext.Remotes, error), authCfg gh.AuthConfig) *currentRepositoryStatus {
+	if remotesFn == nil {
+		return nil
+	}
+
+	remotes, err := remotesFn()
+	if err != nil || len(remotes) == 0 {
+		return nil
+	}
+
+	repo, ok := repoContextFromRemotes(remotes)
+	if !ok {
+		return nil
+	}
+
+	hostname := repo.RepoHost()
+	repoDisplay := fmt.Sprintf("%s/%s/%s", hostname, repo.RepoOwner(), repo.RepoName())
+
+	if mapper, ok := authCfg.(repositoryUserResolver); ok {
+		if mappedUser, found := mapper.UserForRepository(hostname, repo.RepoOwner(), repo.RepoName()); found {
+			if _, _, tokenErr := authCfg.TokenForUser(hostname, mappedUser); tokenErr == nil {
+				return &currentRepositoryStatus{
+					repoDisplay:      repoDisplay,
+					effectiveAccount: mappedUser,
+					reason:           "repository mapping",
+				}
+			}
+		}
+	}
+
+	_, tokenSource := authCfg.ActiveToken(hostname)
+	if !authTokenWriteable(tokenSource) {
+		return &currentRepositoryStatus{
+			repoDisplay:      repoDisplay,
+			effectiveAccount: tokenSource,
+			reason:           "environment token",
+		}
+	}
+
+	activeUser, err := authCfg.ActiveUser(hostname)
+	if err != nil || activeUser == "" {
+		return nil
+	}
+
+	return &currentRepositoryStatus{
+		repoDisplay:      repoDisplay,
+		effectiveAccount: activeUser,
+		reason:           "active host account",
+	}
+}
+
+func repoContextFromRemotes(remotes ghContext.Remotes) (ghrepo.Interface, bool) {
+	if len(remotes) == 0 {
+		return nil, false
+	}
+
+	for _, remote := range remotes {
+		if remote.Resolved == "base" {
+			return remote, true
+		}
+
+		if remote.Resolved == "" {
+			continue
+		}
+
+		repo, err := ghrepo.FromFullName(remote.Resolved)
+		if err != nil {
+			continue
+		}
+
+		return ghrepo.NewWithHost(repo.RepoOwner(), repo.RepoName(), remote.RepoHost()), true
+	}
+
+	return remotes[0], true
 }
 
 func maskToken(token string) string {

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -336,10 +336,6 @@ func statusRun(opts *StatusOptions) error {
 	return finalErr
 }
 
-type repositoryUserResolver interface {
-	UserForRepository(hostname, owner, repo string) (string, bool)
-}
-
 type currentRepositoryStatus struct {
 	repoDisplay      string
 	effectiveAccount string
@@ -373,7 +369,7 @@ func currentRepositoryStatusForAuth(remotesFn func() (ghContext.Remotes, error),
 	hostname := repo.RepoHost()
 	repoDisplay := fmt.Sprintf("%s/%s/%s", hostname, repo.RepoOwner(), repo.RepoName())
 
-	if mapper, ok := authCfg.(repositoryUserResolver); ok {
+	if mapper, ok := authCfg.(gh.RepositoryUserResolver); ok {
 		if mappedUser, found := mapper.UserForRepository(hostname, repo.RepoOwner(), repo.RepoName()); found {
 			if _, _, tokenErr := authCfg.TokenForUser(hostname, mappedUser); tokenErr == nil {
 				return &currentRepositoryStatus{
@@ -407,28 +403,7 @@ func currentRepositoryStatusForAuth(remotesFn func() (ghContext.Remotes, error),
 }
 
 func repoContextFromRemotes(remotes ghContext.Remotes) (ghrepo.Interface, bool) {
-	if len(remotes) == 0 {
-		return nil, false
-	}
-
-	for _, remote := range remotes {
-		if remote.Resolved == "base" {
-			return remote, true
-		}
-
-		if remote.Resolved == "" {
-			continue
-		}
-
-		repo, err := ghrepo.FromFullName(remote.Resolved)
-		if err != nil {
-			continue
-		}
-
-		return ghrepo.NewWithHost(repo.RepoOwner(), repo.RepoName(), remote.RepoHost()), true
-	}
-
-	return remotes[0], true
+	return remotes.RepoContext()
 }
 
 func maskToken(token string) string {

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -10,8 +10,11 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
+	ghContext "github.com/cli/cli/v2/context"
+	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -264,6 +267,76 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: ssh
 				  - Token: gho_******
 				  - Token scopes: none
+			`),
+		},
+		{
+			name: "shows mapped account for current repository",
+			opts: StatusOptions{
+				Active: true,
+				Remotes: func() (ghContext.Remotes, error) {
+					return ghContext.Remotes{
+						&ghContext.Remote{
+							Remote: &git.Remote{Name: "origin"},
+							Repo:   ghrepo.NewWithHost("awakecoding", "MsRdpEx", "github.com"),
+						},
+					}, nil
+				},
+			},
+			cfgStubs: func(t *testing.T, c gh.Config) {
+				login(t, c, "github.com", "awakecoding", "gho_awake123", "https")
+				login(t, c, "github.com", "work-user", "gho_work123", "https")
+				authCfg, ok := c.Authentication().(*config.AuthConfig)
+				require.True(t, ok)
+				require.NoError(t, authCfg.SetUserForOwner("github.com", "awakecoding", "awakecoding"))
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
+			},
+			wantOut: heredoc.Doc(`
+				✓ Current repository auth
+				  - Repository: github.com/awakecoding/MsRdpEx
+				  - Effective account: awakecoding
+				  - Source: repository mapping
+
+				github.com
+				  ✓ Logged in to github.com account work-user (GH_CONFIG_DIR/hosts.yml)
+				  - Active account: true
+				  - Git operations protocol: https
+				  - Token: gho_*******
+				  - Token scopes: 'repo', 'read:org'
+			`),
+		},
+		{
+			name: "shows active host account for current repository when unmapped",
+			opts: StatusOptions{
+				Active: true,
+				Remotes: func() (ghContext.Remotes, error) {
+					return ghContext.Remotes{
+						&ghContext.Remote{
+							Remote: &git.Remote{Name: "origin"},
+							Repo:   ghrepo.NewWithHost("Devolutions", "github-cli", "github.com"),
+						},
+					}, nil
+				},
+			},
+			cfgStubs: func(t *testing.T, c gh.Config) {
+				login(t, c, "github.com", "work-user", "gho_work123", "https")
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
+			},
+			wantOut: heredoc.Doc(`
+				✓ Current repository auth
+				  - Repository: github.com/Devolutions/github-cli
+				  - Effective account: work-user
+				  - Source: active host account
+
+				github.com
+				  ✓ Logged in to github.com account work-user (GH_CONFIG_DIR/hosts.yml)
+				  - Active account: true
+				  - Git operations protocol: https
+				  - Token: gho_*******
+				  - Token scopes: 'repo', 'read:org'
 			`),
 		},
 		{

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -193,8 +193,19 @@ func httpClientFunc(f *cmdutil.Factory, appVersion string) func() (*http.Client,
 		if err != nil {
 			return nil, err
 		}
+
+		authCfg := cfg.Authentication()
+		tokenGetter := interface{ ActiveToken(string) (string, string) }(authCfg)
+		if f.Remotes != nil {
+			if remotes, remotesErr := f.Remotes(); remotesErr == nil {
+				if repoContext, ok := repoContextFromRemotes(remotes); ok {
+					tokenGetter = withRepositoryTokenMapping(authCfg, repoContext)
+				}
+			}
+		}
+
 		opts := api.HTTPClientOptions{
-			Config:      cfg.Authentication(),
+			Config:      tokenGetter,
 			Log:         io.ErrOut,
 			LogColorize: io.ColorEnabled(),
 			AppVersion:  appVersion,

--- a/pkg/cmd/factory/dynamic_token_getter.go
+++ b/pkg/cmd/factory/dynamic_token_getter.go
@@ -1,0 +1,84 @@
+package factory
+
+import (
+	"strings"
+
+	ghContext "github.com/cli/cli/v2/context"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
+)
+
+type repositoryUserResolver interface {
+	UserForRepository(hostname, owner, repo string) (string, bool)
+}
+
+type dynamicRepoTokenGetter struct {
+	authCfg gh.AuthConfig
+	repo    ghrepo.Interface
+	mapper  repositoryUserResolver
+}
+
+func withRepositoryTokenMapping(authCfg gh.AuthConfig, repo ghrepo.Interface) interface{ ActiveToken(string) (string, string) } {
+	if repo == nil {
+		return authCfg
+	}
+
+	mapper, ok := authCfg.(repositoryUserResolver)
+	if !ok {
+		return authCfg
+	}
+
+	return dynamicRepoTokenGetter{
+		authCfg: authCfg,
+		repo:    repo,
+		mapper:  mapper,
+	}
+}
+
+func (t dynamicRepoTokenGetter) ActiveToken(hostname string) (string, string) {
+	defaultToken, defaultSource := t.authCfg.ActiveToken(hostname)
+
+	if strings.HasSuffix(defaultSource, "_TOKEN") {
+		return defaultToken, defaultSource
+	}
+
+	if !strings.EqualFold(hostname, t.repo.RepoHost()) {
+		return defaultToken, defaultSource
+	}
+
+	mappedUser, ok := t.mapper.UserForRepository(hostname, t.repo.RepoOwner(), t.repo.RepoName())
+	if !ok {
+		return defaultToken, defaultSource
+	}
+
+	mappedToken, mappedSource, err := t.authCfg.TokenForUser(hostname, mappedUser)
+	if err != nil || mappedToken == "" {
+		return defaultToken, defaultSource
+	}
+
+	return mappedToken, mappedSource
+}
+
+func repoContextFromRemotes(remotes ghContext.Remotes) (ghrepo.Interface, bool) {
+	if len(remotes) == 0 {
+		return nil, false
+	}
+
+	for _, remote := range remotes {
+		if remote.Resolved == "base" {
+			return remote, true
+		}
+		if remote.Resolved == "" {
+			continue
+		}
+
+		repo, err := ghrepo.FromFullName(remote.Resolved)
+		if err != nil {
+			continue
+		}
+
+		return ghrepo.NewWithHost(repo.RepoOwner(), repo.RepoName(), remote.RepoHost()), true
+	}
+
+	return remotes[0], true
+}

--- a/pkg/cmd/factory/dynamic_token_getter.go
+++ b/pkg/cmd/factory/dynamic_token_getter.go
@@ -8,14 +8,10 @@ import (
 	"github.com/cli/cli/v2/internal/ghrepo"
 )
 
-type repositoryUserResolver interface {
-	UserForRepository(hostname, owner, repo string) (string, bool)
-}
-
 type dynamicRepoTokenGetter struct {
 	authCfg gh.AuthConfig
 	repo    ghrepo.Interface
-	mapper  repositoryUserResolver
+	mapper  gh.RepositoryUserResolver
 }
 
 func withRepositoryTokenMapping(authCfg gh.AuthConfig, repo ghrepo.Interface) interface{ ActiveToken(string) (string, string) } {
@@ -23,7 +19,7 @@ func withRepositoryTokenMapping(authCfg gh.AuthConfig, repo ghrepo.Interface) in
 		return authCfg
 	}
 
-	mapper, ok := authCfg.(repositoryUserResolver)
+	mapper, ok := authCfg.(gh.RepositoryUserResolver)
 	if !ok {
 		return authCfg
 	}
@@ -58,27 +54,6 @@ func (t dynamicRepoTokenGetter) ActiveToken(hostname string) (string, string) {
 
 	return mappedToken, mappedSource
 }
-
 func repoContextFromRemotes(remotes ghContext.Remotes) (ghrepo.Interface, bool) {
-	if len(remotes) == 0 {
-		return nil, false
-	}
-
-	for _, remote := range remotes {
-		if remote.Resolved == "base" {
-			return remote, true
-		}
-		if remote.Resolved == "" {
-			continue
-		}
-
-		repo, err := ghrepo.FromFullName(remote.Resolved)
-		if err != nil {
-			continue
-		}
-
-		return ghrepo.NewWithHost(repo.RepoOwner(), repo.RepoName(), remote.RepoHost()), true
-	}
-
-	return remotes[0], true
+	return remotes.RepoContext()
 }

--- a/pkg/cmd/factory/dynamic_token_getter_test.go
+++ b/pkg/cmd/factory/dynamic_token_getter_test.go
@@ -1,0 +1,62 @@
+package factory
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithRepositoryTokenMappingUsesMappedUserToken(t *testing.T) {
+	cfg, _ := config.NewIsolatedTestConfig(t)
+	authCfg := cfg.Authentication()
+
+	_, err := authCfg.Login("github.com", "work-user", "work-token", "", false)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "personal-user", "personal-token", "", false)
+	require.NoError(t, err)
+	require.NoError(t, authCfg.SwitchUser("github.com", "personal-user"))
+
+	repoMapper := authCfg.(*config.AuthConfig)
+	require.NoError(t, repoMapper.SetUserForOwner("github.com", "devolutions", "work-user"))
+
+	getter := withRepositoryTokenMapping(authCfg, ghrepo.NewWithHost("devolutions", "github-cli", "github.com"))
+	token, source := getter.ActiveToken("github.com")
+
+	require.Equal(t, "work-token", token)
+	require.Equal(t, "oauth_token", source)
+}
+
+func TestWithRepositoryTokenMappingFallsBackToDefaultActiveToken(t *testing.T) {
+	cfg, _ := config.NewIsolatedTestConfig(t)
+	authCfg := cfg.Authentication()
+
+	_, err := authCfg.Login("github.com", "personal-user", "personal-token", "", false)
+	require.NoError(t, err)
+
+	getter := withRepositoryTokenMapping(authCfg, ghrepo.NewWithHost("devolutions", "github-cli", "github.com"))
+	token, source := getter.ActiveToken("github.com")
+
+	require.Equal(t, "personal-token", token)
+	require.Equal(t, "oauth_token", source)
+}
+
+func TestWithRepositoryTokenMappingRespectsEnvTokenPrecedence(t *testing.T) {
+	t.Setenv("GH_TOKEN", "env-token")
+
+	cfg, _ := config.NewIsolatedTestConfig(t)
+	authCfg := cfg.Authentication()
+
+	_, err := authCfg.Login("github.com", "work-user", "work-token", "", false)
+	require.NoError(t, err)
+
+	repoMapper := authCfg.(*config.AuthConfig)
+	require.NoError(t, repoMapper.SetUserForOwner("github.com", "devolutions", "work-user"))
+
+	getter := withRepositoryTokenMapping(authCfg, ghrepo.NewWithHost("devolutions", "github-cli", "github.com"))
+	token, source := getter.ActiveToken("github.com")
+
+	require.Equal(t, "env-token", token)
+	require.Equal(t, "GH_TOKEN", source)
+}


### PR DESCRIPTION
## Summary
This PR adds repository-scoped account selection to GitHub CLI so users can work across multiple accounts on the same host without repeatedly running a global `gh auth switch`.

It also updates `gh auth status` to show the **effective account for the current repository** while preserving existing global host/account status output.

Fixes https://github.com/cli/cli/issues/12459 and https://github.com/cli/cli/pull/12628 in a slightly different way than suggested. I prefer the current approach as it does not rely on external SSH configuration. The auth mapping mechanism is simple and works at the GitHub CLI level. A few simple mapping rules should do the trick to eliminate issues when using multiple GitHub accounts at the same time.

## Motivation
This addresses multi-account workflow friction described in:
- https://awakecoding.com/posts/configuring-ssh-for-personal-and-work-github-accounts/

In short: git/SSH can already route identities per repo/org, but `gh` previously required manual global account switching.

## What changed
### 1) Repository account mappings
Added a new command group:
- `gh auth map set <scope> --user <login>`
- `gh auth map list [--hostname <host>]`
- `gh auth map remove <scope>`

Supported scopes:
- `OWNER/*`
- `OWNER/REPO`
- `HOST/OWNER/*`
- `HOST/OWNER/REPO`

Matching behavior:
1. Exact repo match (`owner/repo`)
2. Owner wildcard match (`owner/*`)
3. Fallback to existing host-active account behavior

Environment token precedence is preserved (`GH_TOKEN`, `GITHUB_TOKEN`, etc.).

### 2) Dynamic token selection during API requests
`gh` now resolves a repository context from remotes and applies repository mapping when selecting a token for API requests, instead of requiring global active-user mutation.

### 3) Repository-aware auth status
`gh auth status` now prints a concise current-repository summary:
- repository
- effective account
- source (`repository mapping`, `active host account`, or `environment token`)

Global host/account sections remain unchanged below the summary.

## Example
```bash
gh auth map set github.com/awakecoding/* --user awakecoding
gh auth map set github.com/Devolutions/* --user mamoreau-devolutions
gh auth status --active
```

## Validation
- `go test ./internal/config ./pkg/cmd/factory ./pkg/cmd/auth/map ./pkg/cmd/auth/status`
- `go build ./...`

## Notes
- This keeps backward compatibility for users who do not configure mappings.
- Global `gh auth switch` behavior is unchanged.