### PR TITLE
Add supports for terminal hyperlinks in output (v2)

### DIFF
--- a/pkg/cmd/gist/list/list.go
+++ b/pkg/cmd/gist/list/list.go
@@ -199,7 +199,7 @@ func printTable(io *iostreams.IOStreams, gists []shared.Gist, filter *regexp.Reg
 		tp.AddField(gist.ID)
 		tp.AddField(
 			text.RemoveExcessiveWhitespace(description),
-			tableprinter.WithColor(highlightDescription),
+			tableprinter.WithColor(cs.WithHyperlink(gist.HTMLURL, highlightDescription)),
 		)
 		tp.AddField(
 			text.Pluralize(fileCount, "file"),

--- a/pkg/cmd/gist/shared/shared.go
+++ b/pkg/cmd/gist/shared/shared.go
@@ -109,6 +109,7 @@ func ListGists(client *http.Client, hostname string, limit int, filter *regexp.R
 					IsPublic  bool
 					Name      string
 					UpdatedAt time.Time
+					URL       string
 				}
 				PageInfo struct {
 					HasNextPage bool
@@ -174,6 +175,7 @@ pagination:
 				Files:       files,
 				UpdatedAt:   gist.UpdatedAt,
 				Public:      gist.IsPublic,
+				HTMLURL:     gist.URL,
 			}
 
 			if filter == nil || filterFunc(&gist) {

--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -32,7 +32,11 @@ func PrintIssues(io *iostreams.IOStreams, now time.Time, prefix string, totalCou
 			issueNum = "#" + issueNum
 		}
 		issueNum = prefix + issueNum
-		table.AddField(issueNum, tableprinter.WithColor(cs.ColorFromString(prShared.ColorForIssueState(issue))))
+		colorFunc := cs.ColorFromString(prShared.ColorForIssueState(issue))
+		issueURL := issue.URL
+		table.AddField(issueNum, tableprinter.WithColor(func(t string) string {
+			return colorFunc(cs.Hyperlink(t, issueURL))
+		}))
 		if !isTTY {
 			table.AddField(issue.State)
 		}

--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -32,11 +32,8 @@ func PrintIssues(io *iostreams.IOStreams, now time.Time, prefix string, totalCou
 			issueNum = "#" + issueNum
 		}
 		issueNum = prefix + issueNum
-		colorFunc := cs.ColorFromString(prShared.ColorForIssueState(issue))
-		issueURL := issue.URL
-		table.AddField(issueNum, tableprinter.WithColor(func(t string) string {
-			return colorFunc(cs.Hyperlink(t, issueURL))
-		}))
+		table.AddField(issueNum, tableprinter.WithColor(cs.WithHyperlink(issue.URL,
+			cs.ColorFromString(prShared.ColorForIssueState(issue)))))
 		if !isTTY {
 			table.AddField(issue.State)
 		}

--- a/pkg/cmd/pr/checks/output.go
+++ b/pkg/cmd/pr/checks/output.go
@@ -10,6 +10,7 @@ import (
 
 func addRow(tp *tableprinter.TablePrinter, io *iostreams.IOStreams, o check) {
 	cs := io.ColorScheme()
+	isLinkEnabled := io.IsLinkEnabled()
 	elapsed := ""
 
 	if !o.StartedAt.IsZero() && !o.CompletedAt.IsZero() {
@@ -43,10 +44,15 @@ func addRow(tp *tableprinter.TablePrinter, io *iostreams.IOStreams, o check) {
 			name += fmt.Sprintf(" (%s)", o.Event)
 		}
 		tp.AddField(mark, tableprinter.WithColor(markColor))
-		tp.AddField(name)
+		link := o.Link
+		tp.AddField(name, tableprinter.WithColor(func(t string) string {
+			return cs.Hyperlink(t, link)
+		}))
 		tp.AddField(o.Description)
 		tp.AddField(elapsed)
-		tp.AddField(o.Link)
+		if !isLinkEnabled {
+			tp.AddField(o.Link)
+		}
 	} else {
 		tp.AddField(o.Name)
 		if o.Bucket == "cancel" {
@@ -94,7 +100,10 @@ func printSummary(io *iostreams.IOStreams, counts checkCounts) {
 func printTable(io *iostreams.IOStreams, checks []check) error {
 	var headers []string
 	if io.IsStdoutTTY() {
-		headers = []string{"", "NAME", "DESCRIPTION", "ELAPSED", "URL"}
+		headers = []string{"", "NAME", "DESCRIPTION", "ELAPSED"}
+		if !io.IsLinkEnabled() {
+			headers = append(headers, "URL")
+		}
 	} else {
 		headers = []string{"NAME", "STATUS", "ELAPSED", "URL", "DESCRIPTION"}
 	}

--- a/pkg/cmd/pr/checks/output.go
+++ b/pkg/cmd/pr/checks/output.go
@@ -44,10 +44,7 @@ func addRow(tp *tableprinter.TablePrinter, io *iostreams.IOStreams, o check) {
 			name += fmt.Sprintf(" (%s)", o.Event)
 		}
 		tp.AddField(mark, tableprinter.WithColor(markColor))
-		link := o.Link
-		tp.AddField(name, tableprinter.WithColor(func(t string) string {
-			return cs.Hyperlink(t, link)
-		}))
+		tp.AddField(name, tableprinter.WithColor(cs.WithHyperlink(o.Link, nil)))
 		tp.AddField(o.Description)
 		tp.AddField(elapsed)
 		if !isLinkEnabled {

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -238,8 +238,11 @@ func listRun(opts *ListOptions) error {
 		if isTTY {
 			prNum = "#" + prNum
 		}
-
-		table.AddField(prNum, tableprinter.WithColor(cs.ColorFromString(shared.ColorForPRState(pr))))
+		prURL := pr.URL
+		colorFunc := cs.ColorFromString(shared.ColorForPRState(pr))
+		table.AddField(prNum, tableprinter.WithColor(func(t string) string {
+			return colorFunc(cs.Hyperlink(t, prURL))
+		}))
 		table.AddField(text.RemoveExcessiveWhitespace(pr.Title))
 		table.AddField(pr.HeadLabel(), tableprinter.WithColor(cs.Cyan))
 		if !isTTY {

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -238,11 +238,9 @@ func listRun(opts *ListOptions) error {
 		if isTTY {
 			prNum = "#" + prNum
 		}
-		prURL := pr.URL
-		colorFunc := cs.ColorFromString(shared.ColorForPRState(pr))
-		table.AddField(prNum, tableprinter.WithColor(func(t string) string {
-			return colorFunc(cs.Hyperlink(t, prURL))
-		}))
+
+		table.AddField(prNum, tableprinter.WithColor(cs.WithHyperlink(pr.URL,
+			cs.ColorFromString(shared.ColorForPRState(pr)))))
 		table.AddField(text.RemoveExcessiveWhitespace(pr.Title))
 		table.AddField(pr.HeadLabel(), tableprinter.WithColor(cs.Cyan))
 		if !isTTY {

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -142,6 +142,9 @@ func listRun(opts *ListOptions) error {
 	if features.VisibilityField {
 		fields = append(defaultFields, "visibility")
 	}
+	if opts.IO.IsLinkEnabled() {
+		fields = append(fields, "url")
+	}
 
 	filter := FilterOptions{
 		Visibility:  opts.Visibility,
@@ -192,7 +195,7 @@ func listRun(opts *ListOptions) error {
 			t = &repo.CreatedAt
 		}
 
-		tp.AddField(repo.NameWithOwner, tableprinter.WithColor(cs.Bold))
+		tp.AddField(repo.NameWithOwner, tableprinter.WithColor(cs.WithHyperlink(repo.URL, cs.Bold)))
 		tp.AddField(text.RemoveExcessiveWhitespace(repo.Description))
 		tp.AddField(info, tableprinter.WithColor(infoColor))
 		tp.AddTimeField(opts.Now(), *t, cs.Muted)

--- a/pkg/cmd/search/commits/commits.go
+++ b/pkg/cmd/search/commits/commits.go
@@ -159,8 +159,8 @@ func displayResults(io *iostreams.IOStreams, now time.Time, results search.Commi
 	cs := io.ColorScheme()
 	tp := tableprinter.New(io, tableprinter.WithHeader("Repo", "SHA", "Message", "Author", "Created"))
 	for _, commit := range results.Items {
-		tp.AddField(commit.Repo.FullName)
-		tp.AddField(commit.Sha)
+		tp.AddField(commit.Repo.FullName, tableprinter.WithColor(cs.WithHyperlink(commit.Repo.URL, nil)))
+		tp.AddField(commit.Sha, tableprinter.WithColor(cs.WithHyperlink(commit.URL, nil)))
 		tp.AddField(text.RemoveExcessiveWhitespace(commit.Info.Message))
 		tp.AddField(commit.Author.Login)
 		tp.AddTimeField(now, commit.Info.Author.Date, cs.Muted)

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -177,7 +177,7 @@ func displayResults(io *iostreams.IOStreams, now time.Time, results search.Repos
 		if repo.IsPrivate {
 			infoColor = cs.Yellow
 		}
-		tp.AddField(repo.FullName, tableprinter.WithColor(cs.Bold))
+		tp.AddField(repo.FullName, tableprinter.WithColor(cs.WithHyperlink(repo.URL, cs.Bold)))
 		tp.AddField(text.RemoveExcessiveWhitespace(repo.Description))
 		tp.AddField(info, tableprinter.WithColor(infoColor))
 		tp.AddTimeField(now, repo.UpdatedAt, cs.Muted)

--- a/pkg/cmd/search/shared/shared.go
+++ b/pkg/cmd/search/shared/shared.go
@@ -126,10 +126,12 @@ func displayIssueResults(io *iostreams.IOStreams, now time.Time, et EntityType, 
 			issueNum = "#" + issueNum
 		}
 		if issue.IsPullRequest() {
-			color := tableprinter.WithColor(cs.ColorFromString(colorForPRState(issue.State())))
+			color := tableprinter.WithColor(cs.WithHyperlink(issue.URL,
+				cs.ColorFromString(colorForPRState(issue.State()))))
 			tp.AddField(issueNum, color)
 		} else {
-			color := tableprinter.WithColor(cs.ColorFromString(colorForIssueState(issue.State(), issue.StateReason)))
+			color := tableprinter.WithColor(cs.WithHyperlink(issue.URL,
+				cs.ColorFromString(colorForIssueState(issue.State(), issue.StateReason))))
 			tp.AddField(issueNum, color)
 		}
 		if !tp.IsTTY() {

--- a/pkg/iostreams/color.go
+++ b/pkg/iostreams/color.go
@@ -268,8 +268,32 @@ func (c *ColorScheme) Hyperlink(text, url string) string {
 	if !c.linkEnabled {
 		return text
 	}
+
+	// Make trailing spaces not to be part of the link as it looks ugly, ...
+	link_text := strings.TrimRight(text, " ")
+	trailing_spaces := text[len(link_text):]
+	if link_text == "" {
+		// ... but still allow spaces-only text to be clickable.
+		link_text = text
+		trailing_spaces = ""
+	}
+
 	// https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
-	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", url, text)
+	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\%s", url, link_text, trailing_spaces)
+}
+
+func (c *ColorScheme) WithHyperlink(url string, colorize func(string) string) func(string) string {
+	if colorize == nil {
+		colorize = func(s string) string { return s }
+	}
+	if !c.linkEnabled {
+		return colorize
+	}
+	return func(text string) string {
+		// Call c.Hyperlink first, then colorize.
+		// Otherwise space-trimming logic in c.Hyperlink wouldn't work.
+		return colorize(c.Hyperlink(text, url))
+	}
 }
 
 // Label stylizes text based on label's RGB hex color.

--- a/pkg/iostreams/color.go
+++ b/pkg/iostreams/color.go
@@ -53,6 +53,8 @@ type ColorScheme struct {
 	Accessible bool
 	// ColorLabels is whether labels are colored based on their truecolor RGB hex color.
 	ColorLabels bool
+	// linkEnabled is whether terminal hyperlinks should be rendered.
+	linkEnabled bool
 	// Theme is the terminal background color theme used to contextually color text for light, dark, or none at all.
 	Theme string
 }
@@ -260,6 +262,14 @@ func (c *ColorScheme) ColorFromString(s string) func(string) string {
 	}
 
 	return fn
+}
+
+func (c *ColorScheme) Hyperlink(text, url string) string {
+	if !c.linkEnabled {
+		return text
+	}
+	// https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", url, text)
 }
 
 // Label stylizes text based on label's RGB hex color.

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -75,6 +75,7 @@ type IOStreams struct {
 	colorEnabled            bool
 	colorLabels             bool
 	accessibleColorsEnabled bool
+	linkEnabled             bool
 
 	pagerCommand string
 	pagerProcess *os.Process
@@ -108,6 +109,10 @@ func (s *IOStreams) HasTrueColor() bool {
 
 func (s *IOStreams) ColorLabels() bool {
 	return s.colorLabels
+}
+
+func (s *IOStreams) IsLinkEnabled() bool {
+	return s.linkEnabled
 }
 
 // DetectTerminalTheme is a utility to call before starting the output pager so that the terminal background
@@ -424,6 +429,7 @@ func (s *IOStreams) ColorScheme() *ColorScheme {
 		TrueColor:     s.HasTrueColor(),
 		Accessible:    s.AccessibleColorsEnabled(),
 		ColorLabels:   s.ColorLabels(),
+		linkEnabled:   s.IsLinkEnabled(),
 		Theme:         s.TerminalTheme(),
 	}
 }
@@ -495,6 +501,7 @@ func System() *IOStreams {
 		In:           os.Stdin,
 		Out:          stdout,
 		ErrOut:       stderr,
+		linkEnabled:  os.Getenv("GH_HYPERLINK") != "",
 		pagerCommand: os.Getenv("PAGER"),
 		term:         &terminal,
 	}


### PR DESCRIPTION
This is a resurrection of #3309.

# Why revisit this PR again

The previous PR got closed due to lack of support from terminals. Situation improved since then.

Chronology: In 2021 and 2022 the team decided not to merge it due to lack of support in terminal emulators. In 2024, @williammartin suggested that it [could be revisited](https://github.com/cli/cli/pull/8709#issuecomment-1972811950).

Referring to points from the original PR:
- According to https://github.com/Alhadis/OSC8-Adoption, a lot of major terminal emulators support this OSC. Also, tmux. (tho requires configuration)
- OSC 8 support in `less` seems to be actively maintained: https://github.com/search?q=repo%3Agwsw%2Fless+OSC+8&type=commits. I see no issues on my setup.

# Details

In this PR, hyperlinks are enabled when `GH_HYPERLINK` is non-empty. When enabled, the following arbitrarily chosen[^1] tables are updated:
- `gh pr checks`: `NAME` is link to the job; `URL` is removed
- `gh issue/pr list`: `ID` is link to the issue/pr
- `gh gist list`: `DESCRIPTION` is link to the gist
- `gh repo list`: `NAME` is link to the repo
- `gh search commits`: `REPO` and `SHA` are links to the repo and commit
- `gh search issues/prs`: `ID` is link to the issue/pr
- `gh search repos`: `REPO` is link to the repo

[^1]: I think there are still a lot of remaining tables that could be augmented by hyperlinks.