### PR TITLE
fix(browse): disambiguate numeric short SHAs from issue/PR numbers

### DIFF
--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -2,6 +2,7 @@ package browse
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -241,6 +242,20 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 			return "", nil
 		}
 		if isNumber(opts.SelectorArg) {
+			if isCommit(opts.SelectorArg) {
+				httpClient, err := opts.HttpClient()
+				if err != nil {
+					return "", err
+				}
+				apiClient := api.NewClientFromHTTP(httpClient)
+				exists, err := commitRefExists(apiClient, baseRepo, opts.SelectorArg)
+				if err != nil {
+					return "", err
+				}
+				if exists {
+					return fmt.Sprintf("commit/%s", opts.SelectorArg), nil
+				}
+			}
 			return fmt.Sprintf("issues/%s", strings.TrimPrefix(opts.SelectorArg, "#")), nil
 		}
 		if isCommit(opts.SelectorArg) {
@@ -336,6 +351,22 @@ var commitHash = regexp.MustCompile(`\A[a-f0-9]{7,64}\z`)
 
 func isCommit(arg string) bool {
 	return commitHash.MatchString(arg)
+}
+
+func commitRefExists(apiClient *api.Client, repo ghrepo.Interface, ref string) (bool, error) {
+	path := fmt.Sprintf("repos/%s/%s/commits/%s", repo.RepoOwner(), repo.RepoName(), ref)
+	var response struct{}
+	err := apiClient.REST(repo.RepoHost(), "GET", path, nil, &response)
+	if err == nil {
+		return true, nil
+	}
+
+	var httpErr api.HTTPError
+	if errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusUnprocessableEntity) {
+		return false, nil
+	}
+
+	return false, err
 }
 
 // gitClient is used to implement functions that can be performed on both local and remote git repositories

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -325,6 +325,34 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL: "https://github.com/kevin/MinTy/issues/217",
 		},
 		{
+			name: "number-only short hash in selector arg resolves to commit when commit exists",
+			opts: BrowseOptions{
+				SelectorArg: "309628980",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/kevin/MinTy/commits/309628980"),
+					httpmock.StringResponse(`{"sha":"309628980"}`),
+				)
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/commit/309628980",
+		},
+		{
+			name: "number-only short hash in selector arg resolves to issue when commit is not found",
+			opts: BrowseOptions{
+				SelectorArg: "309628980",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/kevin/MinTy/commits/309628980"),
+					httpmock.StatusStringResponse(422, "{}"),
+				)
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/issues/309628980",
+		},
+		{
 			name: "issue with hashtag argument",
 			opts: BrowseOptions{
 				SelectorArg: "#217",


### PR DESCRIPTION
## Summary

Fix `gh browse` selector disambiguation for numeric-only short SHAs.

Today, if the selector arg is numeric (e.g. `309628980`), `gh browse` treats it as an issue/PR number before considering commit refs. This causes decimal-only short SHAs to resolve to `issues/<n>` instead of `commit/<sha>`.

This change updates `browse` to disambiguate in the ambiguous case:
- if selector is both numeric and commit-like, check whether it resolves to a commit in the target repo
- if commit exists, open the commit URL
- otherwise, fall back to issue URL behavior

## Changes

- Updated `parseSection` in `pkg/cmd/browse/browse.go` to validate ambiguous numeric+commit-like selectors via API.
- Added `commitRefExists` helper that calls:
  - `GET /repos/{owner}/{repo}/commits/{ref}`
  - treats `404`/`422` as “commit not found”
- Added tests in `pkg/cmd/browse/browse_test.go` for:
  - numeric short SHA that exists as commit -> commit URL
  - numeric short SHA not found as commit -> issue URL

## Testing

- `go test ./pkg/cmd/browse`
- Added targeted cases under `Test_runBrowse` for ambiguous numeric selectors.

Fixes #12357
