### PR TITLE
Add user confirmation for write commands

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,9 +17,10 @@ import (
 // Important: some of the following configuration settings are used outside of `cli/cli`,
 // they are defined here to avoid `cli/cli` being changed unexpectedly.
 const (
-	accessibleColorsKey   = "accessible_colors" // used by cli/go-gh to enable the use of customizable, accessible 4-bit colors.
-	accessiblePrompterKey = "accessible_prompter"
-	aliasesKey            = "aliases"
+	accessibleColorsKey    = "accessible_colors" // used by cli/go-gh to enable the use of customizable, accessible 4-bit colors.
+	accessiblePrompterKey  = "accessible_prompter"
+	aliasesKey             = "aliases"
+	confirmWriteCommandsKey = "confirm_write_commands"
 	browserKey            = "browser" // used by cli/go-gh to open URLs in web browsers
 	colorLabelsKey        = "color_labels"
 	editorKey             = "editor" // used by cli/go-gh to open interactive text editor
@@ -680,6 +681,19 @@ var Options = []ConfigOption{
 		AllowedValues: []string{"enabled", "disabled"},
 		CurrentValue: func(c gh.Config, hostname string) string {
 			return c.Spinner(hostname).Value
+		},
+	},
+	{
+		Key:           confirmWriteCommandsKey,
+		Description:   "require confirmation before running write commands (e.g. pr create, issue create)",
+		DefaultValue:  "disabled",
+		AllowedValues: []string{"enabled", "disabled"},
+		CurrentValue: func(c gh.Config, hostname string) string {
+			e := c.GetOrDefault(hostname, confirmWriteCommandsKey)
+			if e.IsNone() {
+				return "disabled"
+			}
+			return e.Unwrap().Value
 		},
 	},
 }

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -122,6 +122,14 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("must provide `--title` and `--body` when not running interactively")
 			}
 
+			baseRepo, err := opts.BaseRepo()
+			if err != nil {
+				return err
+			}
+			if err := cmdutil.RequireWriteConfirmation(f, baseRepo.RepoHost(), "create an issue"); err != nil {
+				return err
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -330,6 +330,14 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("`--dry-run` is not supported when using `--web`")
 			}
 
+			baseRepo, err := f.BaseRepo()
+			if err != nil {
+				return err
+			}
+			if err := cmdutil.RequireWriteConfirmation(f, baseRepo.RepoHost(), "create a pull request"); err != nil {
+				return err
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -70,6 +70,16 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("--yes required when not running interactively")
 			}
 
+			hostname, _ := ghauth.DefaultHost()
+			if opts.RepoArg == "" {
+				if baseRepo, err := opts.BaseRepo(); err == nil {
+					hostname = baseRepo.RepoHost()
+				}
+			}
+			if err := cmdutil.RequireWriteConfirmation(f, hostname, "delete the repository"); err != nil {
+				return err
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -119,6 +119,10 @@ var HelpTopics = []helpTopic{
 
 			%[1]sGH_SPINNER_DISABLED%[1]s: set to a truthy value to replace the spinner animation with
 			a textual progress indicator.
+
+			%[1]sGH_CONFIRM_WRITE_COMMANDS%[1]s: when set to %[1]senabled%[1]s, requires confirmation before running
+			write commands (e.g. %[1]spr create%[1]s, %[1]sissue create%[1]s, %[1]srepo delete%[1]s). When set to %[1]sdisabled%[1]s,
+			overrides the %[1]sconfirm_write_commands%[1]s config and skips confirmation. Useful for non-interactive scripts.
 		`, "`"),
 	},
 	{

--- a/pkg/cmdutil/write_confirmation.go
+++ b/pkg/cmdutil/write_confirmation.go
@@ -1,0 +1,60 @@
+package cmdutil
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ConfirmWriteCommandsKey is the config key for requiring confirmation on write commands.
+// It is exported so that gh config get/set and documentation can reference it.
+const ConfirmWriteCommandsKey = "confirm_write_commands"
+
+// RequireWriteConfirmation checks the confirm_write_commands config and environment.
+// If confirmation is enabled, it prompts the user to confirm the action (when in an interactive terminal).
+// When not in a TTY and confirmation is required, it returns an error explaining how to disable or bypass.
+// hostname is the GitHub host (e.g. "github.com"); actionDescription describes what will happen (e.g. "create a pull request").
+func RequireWriteConfirmation(f *Factory, hostname, actionDescription string) error {
+	confirmRequired := false
+	envVal := strings.ToLower(strings.TrimSpace(os.Getenv("GH_CONFIRM_WRITE_COMMANDS")))
+	switch envVal {
+	case "disabled", "false", "0", "no":
+		return nil
+	case "enabled", "true", "1", "yes":
+		confirmRequired = true
+	default:
+		// Env unset or unknown: check config
+		cfg, err := f.Config()
+		if err != nil {
+			return err
+		}
+		entry := cfg.GetOrDefault(hostname, ConfirmWriteCommandsKey)
+		if entry.IsNone() {
+			return nil
+		}
+		if strings.ToLower(strings.TrimSpace(entry.Unwrap().Value)) == "enabled" {
+			confirmRequired = true
+		}
+	}
+	if !confirmRequired {
+		return nil
+	}
+
+	// Confirmation is required
+	if !f.IOStreams.CanPrompt() {
+		return fmt.Errorf(
+			"write confirmation is required (confirm_write_commands is enabled). "+
+				"To run non-interactively, set GH_CONFIRM_WRITE_COMMANDS=disabled or run: gh config set %s disabled",
+			ConfirmWriteCommandsKey,
+		)
+	}
+
+	ok, err := f.Prompter.Confirm(fmt.Sprintf("This will %s. Continue?", actionDescription), false)
+	if err != nil {
+		return fmt.Errorf("failed to prompt: %w", err)
+	}
+	if !ok {
+		return CancelError
+	}
+	return nil
+}

--- a/pkg/cmdutil/write_confirmation_test.go
+++ b/pkg/cmdutil/write_confirmation_test.go
@@ -1,0 +1,105 @@
+package cmdutil
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireWriteConfirmation(t *testing.T) {
+	tests := []struct {
+		name        string
+		envVal      string
+		configValue string // set confirm_write_commands to this (empty = use default)
+		canPrompt   bool
+		promptRet   bool   // what Prompter.Confirm returns (only when canPrompt)
+		wantErr     bool
+		wantCancel  bool
+	}{
+		{
+			name:    "env disabled skips confirmation",
+			envVal:  "disabled",
+			canPrompt: true,
+			wantErr: false,
+		},
+		{
+			name:    "config disabled (default) skips confirmation",
+			envVal:  "",
+			configValue: "disabled",
+			canPrompt: true,
+			wantErr: false,
+		},
+		{
+			name:    "config enabled and can prompt, user confirms",
+			envVal:  "",
+			configValue: "enabled",
+			canPrompt: true,
+			promptRet: true,
+			wantErr: false,
+		},
+		{
+			name:    "config enabled and can prompt, user cancels",
+			envVal:  "",
+			configValue: "enabled",
+			canPrompt: true,
+			promptRet: false,
+			wantErr: true,
+			wantCancel: true,
+		},
+		{
+			name:    "config enabled and cannot prompt returns error",
+			envVal:  "",
+			configValue: "enabled",
+			canPrompt: false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVal != "" {
+				t.Setenv("GH_CONFIRM_WRITE_COMMANDS", tt.envVal)
+			} else {
+				t.Setenv("GH_CONFIRM_WRITE_COMMANDS", "")
+			}
+
+			cfg, _ := config.NewIsolatedTestConfig(t)
+			if tt.configValue != "" {
+				cfg.Set("", ConfirmWriteCommandsKey, tt.configValue)
+			}
+
+			ios := iostreams.Test()
+			ios.SetStdinTTY(tt.canPrompt)
+			ios.SetStdoutTTY(tt.canPrompt)
+
+			pm := &prompter.PrompterMock{
+				ConfirmFunc: func(prompt string, defaultValue bool) (bool, error) {
+					return tt.promptRet, nil
+				},
+			}
+
+			f := &Factory{
+				Config:    func() (gh.Config, error) { return cfg, nil },
+				IOStreams: ios,
+				Prompter:  pm,
+			}
+
+			err := RequireWriteConfirmation(f, "github.com", "create a pull request")
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantCancel {
+					assert.True(t, errors.Is(err, CancelError))
+				} else {
+					assert.Contains(t, err.Error(), "confirm_write_commands")
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #12624

## Summary

Adds an optional **confirmation step** for "write" commands so users (especially those using `gh` with AI agents or automation) can require an extra prompt before creating PRs, issues, or deleting repos.

## Changes

- **Config option** `confirm_write_commands`: when set to `enabled`, the CLI will require confirmation before running selected write commands. Default is `disabled` so existing behavior is unchanged.
- **Environment variable** `GH_CONFIRM_WRITE_COMMANDS`: overrides the config. Set to `enabled` to require confirmation, or `disabled` to skip it (e.g. in non-interactive scripts).
- **Helper** `cmdutil.RequireWriteConfirmation(f, hostname, actionDescription)` used by:
  - `gh pr create`
  - `gh issue create`
  - `gh repo delete`
- **Behavior**:
  - If confirmation is enabled and the terminal is interactive: prompt "This will <action>. Continue? (y/n)". Cancel returns `CancelError`.
  - If confirmation is enabled and not interactive (no TTY): return a clear error suggesting `GH_CONFIRM_WRITE_COMMANDS=disabled` or `gh config set confirm_write_commands disabled`.
- **Docs**: New option documented in `gh config` (via `config.Options`), and `GH_CONFIRM_WRITE_COMMANDS` added to `gh help environment`.

## Usage

```bash
# Enable confirmation (prompt before pr create, issue create, repo delete)
gh config set confirm_write_commands enabled

# Disable for a single non-interactive run
GH_CONFIRM_WRITE_COMMANDS=disabled gh pr create --title "Fix" --body "Done"
```

Made with [Cursor](https://cursor.com)