### PR TITLE
Fix: Honor --remote flag when repository specified via argument

### DIFF
--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -237,7 +237,11 @@ func forkRun(opts *ForkOptions) error {
 		}
 	}
 
-	if (inParent && (!opts.Remote && !opts.PromptRemote)) || (!inParent && (!opts.Clone && !opts.PromptClone)) {
+	// Exit early only if user doesn't want remote OR clone
+	if inParent && !opts.Remote && !opts.PromptRemote {
+		return nil
+	}
+	if !inParent && !opts.Clone && !opts.PromptClone && !opts.Remote && !opts.PromptRemote {
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #2722

## Summary
The `--remote` flag was being ignored when a repository was specified as an argument to `gh repo fork`.

## Changes
Modified the early return logic in `fork.go` to properly check the `--remote` flag in both scenarios:
- When forking from within a parent repository
- When forking a repository specified via argument

## Testing
All existing tests pass:
```
cd pkg/cmd/repo/fork && go test -v
```