### PR TITLE
Add `--query` flag to `project item-list`

### DIFF
--- a/internal/featuredetection/detector_mock.go
+++ b/internal/featuredetection/detector_mock.go
@@ -20,6 +20,10 @@ func (md *DisabledDetectorMock) ProjectsV1() gh.ProjectsV1Support {
 	return gh.ProjectsV1Unsupported
 }
 
+func (md *DisabledDetectorMock) ProjectFeatures() (ProjectFeatures, error) {
+	return ProjectFeatures{}, nil
+}
+
 func (md *DisabledDetectorMock) SearchFeatures() (SearchFeatures, error) {
 	return advancedIssueSearchNotSupported, nil
 }
@@ -48,6 +52,10 @@ func (md *EnabledDetectorMock) RepositoryFeatures() (RepositoryFeatures, error) 
 
 func (md *EnabledDetectorMock) ProjectsV1() gh.ProjectsV1Support {
 	return gh.ProjectsV1Supported
+}
+
+func (md *EnabledDetectorMock) ProjectFeatures() (ProjectFeatures, error) {
+	return allProjectFeatures, nil
 }
 
 func (md *EnabledDetectorMock) SearchFeatures() (SearchFeatures, error) {

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -16,6 +16,7 @@ type Detector interface {
 	PullRequestFeatures() (PullRequestFeatures, error)
 	RepositoryFeatures() (RepositoryFeatures, error)
 	ProjectsV1() gh.ProjectsV1Support
+	ProjectFeatures() (ProjectFeatures, error)
 	SearchFeatures() (SearchFeatures, error)
 	ReleaseFeatures() (ReleaseFeatures, error)
 	ActionsFeatures() (ActionsFeatures, error)
@@ -56,6 +57,16 @@ var allRepositoryFeatures = RepositoryFeatures{
 	PullRequestTemplateQuery: true,
 	VisibilityField:          true,
 	AutoMerge:                true,
+}
+
+type ProjectFeatures struct {
+	// ProjectItemQuery indicates support for the `query` argument on
+	// ProjectV2.items.
+	ProjectItemQuery bool
+}
+
+var allProjectFeatures = ProjectFeatures{
+	ProjectItemQuery: true,
 }
 
 type SearchFeatures struct {
@@ -277,6 +288,43 @@ func (d *detector) ProjectsV1() gh.ProjectsV1Support {
 	}
 
 	return gh.ProjectsV1Unsupported
+}
+
+func (d *detector) ProjectFeatures() (ProjectFeatures, error) {
+	if !ghauth.IsEnterprise(d.host) {
+		return allProjectFeatures, nil
+	}
+
+	features := ProjectFeatures{}
+
+	var featureDetection struct {
+		ProjectV2 struct {
+			Fields []struct {
+				Name string
+				Args []struct {
+					Name string
+				}
+			} `graphql:"fields(includeDeprecated: true)"`
+		} `graphql:"ProjectV2: __type(name: \"ProjectV2\")"`
+	}
+
+	gql := api.NewClientFromHTTP(d.httpClient)
+	err := gql.Query(d.host, "ProjectV2_fields", &featureDetection, nil)
+	if err != nil {
+		return features, err
+	}
+
+	for _, field := range featureDetection.ProjectV2.Fields {
+		if field.Name == "items" {
+			for _, arg := range field.Args {
+				if arg.Name == "query" {
+					features.ProjectItemQuery = true
+				}
+			}
+		}
+	}
+
+	return features, nil
 }
 
 const (

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -61,7 +61,7 @@ var allRepositoryFeatures = RepositoryFeatures{
 
 type ProjectFeatures struct {
 	// ProjectItemQuery indicates support for the `query` argument on
-	// ProjectV2.items.
+	// ProjectV2.items (supported on github.com and GHES 3.20+).
 	ProjectItemQuery bool
 }
 
@@ -295,7 +295,7 @@ func (d *detector) ProjectFeatures() (ProjectFeatures, error) {
 		return allProjectFeatures, nil
 	}
 
-	features := ProjectFeatures{}
+	var features ProjectFeatures
 
 	var featureDetection struct {
 		ProjectV2 struct {
@@ -314,13 +314,19 @@ func (d *detector) ProjectFeatures() (ProjectFeatures, error) {
 		return features, err
 	}
 
+	found := false
 	for _, field := range featureDetection.ProjectV2.Fields {
 		if field.Name == "items" {
 			for _, arg := range field.Args {
 				if arg.Name == "query" {
 					features.ProjectItemQuery = true
+					found = true
+					break
 				}
 			}
+		}
+		if found {
+			break
 		}
 	}
 

--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -314,18 +314,14 @@ func (d *detector) ProjectFeatures() (ProjectFeatures, error) {
 		return features, err
 	}
 
-	found := false
 	for _, field := range featureDetection.ProjectV2.Fields {
 		if field.Name == "items" {
 			for _, arg := range field.Args {
 				if arg.Name == "query" {
 					features.ProjectItemQuery = true
-					found = true
 					break
 				}
 			}
-		}
-		if found {
 			break
 		}
 	}

--- a/internal/featuredetection/feature_detection_test.go
+++ b/internal/featuredetection/feature_detection_test.go
@@ -69,6 +69,7 @@ func TestIssueFeatures(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
 			httpClient := &http.Client{}
 			httpmock.ReplaceTripper(httpClient, reg)
 			for query, resp := range tt.queryResponse {

--- a/internal/featuredetection/feature_detection_test.go
+++ b/internal/featuredetection/feature_detection_test.go
@@ -655,6 +655,7 @@ func TestProjectFeatures(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
 			httpClient := &http.Client{}
 			httpmock.ReplaceTripper(httpClient, reg)
 			for query, resp := range tt.queryResponse {

--- a/internal/featuredetection/feature_detection_test.go
+++ b/internal/featuredetection/feature_detection_test.go
@@ -586,6 +586,91 @@ func TestAdvancedIssueSearchSupport(t *testing.T) {
 	}
 }
 
+func TestProjectFeatures(t *testing.T) {
+	tests := []struct {
+		name          string
+		hostname      string
+		queryResponse map[string]string
+		wantFeatures  ProjectFeatures
+		wantErr       bool
+	}{
+		{
+			name:     "github.com",
+			hostname: "github.com",
+			wantFeatures: ProjectFeatures{
+				ProjectItemQuery: true,
+			},
+		},
+		{
+			name:     "ghec data residency (ghe.com)",
+			hostname: "stampname.ghe.com",
+			wantFeatures: ProjectFeatures{
+				ProjectItemQuery: true,
+			},
+		},
+		{
+			name:     "GHE empty response",
+			hostname: "git.my.org",
+			queryResponse: map[string]string{
+				`query ProjectV2_fields\b`: `{"data": {}}`,
+			},
+			wantFeatures: ProjectFeatures{},
+		},
+		{
+			name:     "GHE items field without query arg",
+			hostname: "git.my.org",
+			queryResponse: map[string]string{
+				`query ProjectV2_fields\b`: heredoc.Doc(`
+					{ "data": { "ProjectV2": { "fields": [
+						{"name": "items", "args": [
+							{"name": "after"},
+							{"name": "first"}
+						]}
+					] } } }
+				`),
+			},
+			wantFeatures: ProjectFeatures{},
+		},
+		{
+			name:     "GHE items field with query arg",
+			hostname: "git.my.org",
+			queryResponse: map[string]string{
+				`query ProjectV2_fields\b`: heredoc.Doc(`
+					{ "data": { "ProjectV2": { "fields": [
+						{"name": "items", "args": [
+							{"name": "after"},
+							{"name": "first"},
+							{"name": "query"}
+						]}
+					] } } }
+				`),
+			},
+			wantFeatures: ProjectFeatures{
+				ProjectItemQuery: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			httpClient := &http.Client{}
+			httpmock.ReplaceTripper(httpClient, reg)
+			for query, resp := range tt.queryResponse {
+				reg.Register(httpmock.GraphQL(query), httpmock.StringResponse(resp))
+			}
+			detector := detector{host: tt.hostname, httpClient: httpClient}
+			gotFeatures, err := detector.ProjectFeatures()
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantFeatures, gotFeatures)
+		})
+	}
+}
+
 func TestReleaseFeatures(t *testing.T) {
 	withImmutableReleaseSupport := `{"data":{"Release":{"fields":[{"name":"author"},{"name":"name"},{"name":"immutable"}]}}}`
 	withoutImmutableReleaseSupport := `{"data":{"Release":{"fields":[{"name":"author"},{"name":"name"}]}}}`

--- a/pkg/cmd/project/item-list/item_list.go
+++ b/pkg/cmd/project/item-list/item_list.go
@@ -114,7 +114,7 @@ func runList(config listConfig) error {
 			return err
 		}
 		if !features.ProjectItemQuery {
-			return errors.New("the `--query` flag is not supported on this GitHub host")
+			return fmt.Errorf("the `--query` flag is not supported on this GitHub host; most likely you are targeting a version of GHES that does not yet have the query field available")
 		}
 	}
 

--- a/pkg/cmd/project/item-list/item_list.go
+++ b/pkg/cmd/project/item-list/item_list.go
@@ -2,14 +2,12 @@ package itemlist
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
-	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmd/project/shared/client"
 	"github.com/cli/cli/v2/pkg/cmd/project/shared/queries"
@@ -38,6 +36,13 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 	listCmd := &cobra.Command{
 		Short: "List the items in a project",
 		Use:   "item-list [<number>]",
+		Long: heredoc.Doc(`
+			List the items in a project.
+
+			If supported by the API host, the --query option can be used to perform advanced
+			search. For the full syntax, see:
+			https://docs.github.com/en/issues/planning-and-tracking-with-projects/customizing-views-in-your-project/filtering-projects
+		`),
 		Example: heredoc.Doc(`
 			# List the items in the current users's project "1"
 			$ gh project item-list 1 --owner "@me"
@@ -77,23 +82,25 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 				return runF(config)
 			}
 
-			httpClient, err := f.HttpClient()
-			if err != nil {
-				return err
+			if opts.query != "" {
+				httpClient, err := f.HttpClient()
+				if err != nil {
+					return err
+				}
+				cfg, err := f.Config()
+				if err != nil {
+					return err
+				}
+				host, _ := cfg.Authentication().DefaultHost()
+				config.detector = fd.NewDetector(api.NewCachedHTTPClient(httpClient, time.Hour*24), host)
 			}
-			host := os.Getenv("GH_HOST")
-			if host == "" {
-				host = ghinstance.Default()
-			}
-			config.detector = fd.NewDetector(api.NewCachedHTTPClient(httpClient, time.Hour*24), host)
 
 			return runList(config)
 		},
 	}
 
 	listCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the owner. Use \"@me\" for the current user.")
-	listCmd.Flags().StringVar(&opts.query, "query", "", `Filter items using the Projects filter syntax, e.g. "assignee:octocat -status:Done".
-For the full syntax, see <https://docs.github.com/en/issues/planning-and-tracking-with-projects/customizing-views-in-your-project/filtering-projects>`)
+	listCmd.Flags().StringVar(&opts.query, "query", "", `Filter items using the Projects filter syntax, e.g. "assignee:octocat -status:Done".`)
 	cmdutil.AddFormatFlags(listCmd, &opts.exporter)
 	listCmd.Flags().IntVarP(&opts.limit, "limit", "L", queries.LimitDefault, "Maximum number of items to fetch")
 
@@ -102,6 +109,9 @@ For the full syntax, see <https://docs.github.com/en/issues/planning-and-trackin
 
 func runList(config listConfig) error {
 	if config.opts.query != "" {
+		if config.detector == nil {
+			return fmt.Errorf("the `--query` flag is not supported on this GitHub host")
+		}
 		features, err := config.detector.ProjectFeatures()
 		if err != nil {
 			return err

--- a/pkg/cmd/project/item-list/item_list.go
+++ b/pkg/cmd/project/item-list/item_list.go
@@ -109,9 +109,6 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 
 func runList(config listConfig) error {
 	if config.opts.query != "" {
-		if config.detector == nil {
-			return fmt.Errorf("the `--query` flag is not supported on this GitHub host")
-		}
 		features, err := config.detector.ProjectFeatures()
 		if err != nil {
 			return err

--- a/pkg/cmd/project/item-list/item_list.go
+++ b/pkg/cmd/project/item-list/item_list.go
@@ -114,7 +114,7 @@ func runList(config listConfig) error {
 			return err
 		}
 		if !features.ProjectItemQuery {
-			return fmt.Errorf("the `--query` flag is not supported on this GitHub host")
+			return errors.New("the `--query` flag is not supported on this GitHub host")
 		}
 	}
 

--- a/pkg/cmd/project/item-list/item_list.go
+++ b/pkg/cmd/project/item-list/item_list.go
@@ -99,8 +99,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 		},
 	}
 
-	listCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the owner. Use \"@me\" for the current user.")
-	listCmd.Flags().StringVar(&opts.query, "query", "", `Filter items using the Projects filter syntax, e.g. "assignee:octocat -status:Done".`)
+	listCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the owner. Use \"@me\" for the current user")
+	listCmd.Flags().StringVar(&opts.query, "query", "", `Filter items using the Projects filter syntax, e.g. "assignee:octocat -status:Done"`)
 	cmdutil.AddFormatFlags(listCmd, &opts.exporter)
 	listCmd.Flags().IntVarP(&opts.limit, "limit", "L", queries.LimitDefault, "Maximum number of items to fetch")
 

--- a/pkg/cmd/project/item-list/item_list.go
+++ b/pkg/cmd/project/item-list/item_list.go
@@ -2,9 +2,14 @@ package itemlist
 
 import (
 	"fmt"
+	"os"
 	"strconv"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
+	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmd/project/shared/client"
 	"github.com/cli/cli/v2/pkg/cmd/project/shared/queries"
@@ -17,13 +22,15 @@ type listOpts struct {
 	limit    int
 	owner    string
 	number   int32
+	query    string
 	exporter cmdutil.Exporter
 }
 
 type listConfig struct {
-	io     *iostreams.IOStreams
-	client *queries.Client
-	opts   listOpts
+	io       *iostreams.IOStreams
+	client   *queries.Client
+	opts     listOpts
+	detector fd.Detector
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.Command {
@@ -34,6 +41,15 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 		Example: heredoc.Doc(`
 			# List the items in the current users's project "1"
 			$ gh project item-list 1 --owner "@me"
+
+			# List items assigned to a specific user
+			$ gh project item-list 1 --owner "@me" --query "assignee:monalisa"
+
+			# List open issues assigned to yourself
+			$ gh project item-list 1 --owner "@me" --query "assignee:@me is:issue is:open"
+
+			# List items with the "bug" label that are not done
+			$ gh project item-list 1 --owner "@me" --query "label:bug -status:Done"
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -60,11 +76,24 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 			if runF != nil {
 				return runF(config)
 			}
+
+			httpClient, err := f.HttpClient()
+			if err != nil {
+				return err
+			}
+			host := os.Getenv("GH_HOST")
+			if host == "" {
+				host = ghinstance.Default()
+			}
+			config.detector = fd.NewDetector(api.NewCachedHTTPClient(httpClient, time.Hour*24), host)
+
 			return runList(config)
 		},
 	}
 
 	listCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the owner. Use \"@me\" for the current user.")
+	listCmd.Flags().StringVar(&opts.query, "query", "", `Filter items using the Projects filter syntax, e.g. "assignee:octocat -status:Done".
+For the full syntax, see <https://docs.github.com/en/issues/planning-and-tracking-with-projects/customizing-views-in-your-project/filtering-projects>`)
 	cmdutil.AddFormatFlags(listCmd, &opts.exporter)
 	listCmd.Flags().IntVarP(&opts.limit, "limit", "L", queries.LimitDefault, "Maximum number of items to fetch")
 
@@ -72,6 +101,16 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 }
 
 func runList(config listConfig) error {
+	if config.opts.query != "" {
+		features, err := config.detector.ProjectFeatures()
+		if err != nil {
+			return err
+		}
+		if !features.ProjectItemQuery {
+			return fmt.Errorf("the `--query` flag is not supported on this GitHub host")
+		}
+	}
+
 	canPrompt := config.io.CanPrompt()
 	owner, err := config.client.NewOwner(canPrompt, config.opts.owner)
 	if err != nil {
@@ -87,7 +126,7 @@ func runList(config listConfig) error {
 		config.opts.number = project.Number
 	}
 
-	project, err := config.client.ProjectItems(owner, config.opts.number, config.opts.limit)
+	project, err := config.client.ProjectItems(owner, config.opts.number, config.opts.limit, config.opts.query)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/project/item-list/item_list.go
+++ b/pkg/cmd/project/item-list/item_list.go
@@ -39,8 +39,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 		Long: heredoc.Doc(`
 			List the items in a project.
 
-			If supported by the API host, the --query option can be used to perform advanced
-			search. For the full syntax, see:
+			If supported by the API host (github.com and GHES 3.20+), the --query option can
+			be used to perform advanced search. For the full syntax, see:
 			https://docs.github.com/en/issues/planning-and-tracking-with-projects/customizing-views-in-your-project/filtering-projects
 		`),
 		Example: heredoc.Doc(`

--- a/pkg/cmd/project/item-list/item_list_test.go
+++ b/pkg/cmd/project/item-list/item_list_test.go
@@ -669,7 +669,7 @@ func TestRunList_WithQuery(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
-				"queryItems":  "assignee:octocat -status:Done",
+				"query":       "assignee:octocat -status:Done",
 			},
 		}).
 		Reply(200).

--- a/pkg/cmd/project/item-list/item_list_test.go
+++ b/pkg/cmd/project/item-list/item_list_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
+	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/pkg/cmd/project/shared/queries"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -52,6 +53,14 @@ func TestNewCmdList(t *testing.T) {
 			},
 			wantsExporter: true,
 		},
+		{
+			name: "query",
+			cli:  `--query "assignee:octocat"`,
+			wants: listOpts{
+				limit: 30,
+				query: "assignee:octocat",
+			},
+		},
 	}
 
 	t.Setenv("GH_TOKEN", "auth-token")
@@ -83,6 +92,7 @@ func TestNewCmdList(t *testing.T) {
 
 			assert.Equal(t, tt.wants.number, gotOpts.number)
 			assert.Equal(t, tt.wants.owner, gotOpts.owner)
+			assert.Equal(t, tt.wants.query, gotOpts.query)
 			assert.Equal(t, tt.wantsExporter, gotOpts.exporter != nil)
 			assert.Equal(t, tt.wants.limit, gotOpts.limit)
 		})
@@ -130,6 +140,7 @@ func TestRunList_User_tty(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
+				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -240,6 +251,7 @@ func TestRunList_User(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
+				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -347,6 +359,7 @@ func TestRunList_Org(t *testing.T) {
 				"afterFields": nil,
 				"login":       "github",
 				"number":      1,
+				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -444,6 +457,7 @@ func TestRunList_Me(t *testing.T) {
 				"firstFields": queries.LimitMax,
 				"afterFields": nil,
 				"number":      1,
+				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -551,6 +565,7 @@ func TestRunList_JSON(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
+				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -617,4 +632,110 @@ func TestRunList_JSON(t *testing.T) {
 		t,
 		`{"items":[{"content":{"type":"Issue","body":"","title":"an issue","number":1,"repository":"cli/go-gh","url":""},"id":"issue ID"},{"content":{"type":"PullRequest","body":"","title":"a pull request","number":2,"repository":"cli/go-gh","url":""},"id":"pull request ID"},{"content":{"type":"DraftIssue","body":"","title":"draft issue","id":"draft issue ID"},"id":"draft issue ID"}],"totalCount":3}`,
 		stdout.String())
+}
+
+func TestRunList_WithQuery(t *testing.T) {
+	defer gock.Off()
+
+	// get user ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserOrgOwner.*",
+			"variables": map[string]interface{}{
+				"login": "monalisa",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"id": "an ID",
+				},
+			},
+			"errors": []interface{}{
+				map[string]interface{}{
+					"type": "NOT_FOUND",
+					"path": []string{"organization"},
+				},
+			},
+		})
+
+	// list project items with query
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		JSON(map[string]interface{}{
+			"query": "query UserProjectWithItems.*",
+			"variables": map[string]interface{}{
+				"firstItems":  queries.LimitDefault,
+				"afterItems":  nil,
+				"firstFields": queries.LimitMax,
+				"afterFields": nil,
+				"login":       "monalisa",
+				"number":      1,
+				"queryItems":  "assignee:octocat -status:Done",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"items": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"id": "issue ID",
+									"content": map[string]interface{}{
+										"__typename": "Issue",
+										"title":      "an issue",
+										"number":     1,
+										"repository": map[string]string{
+											"nameWithOwner": "cli/go-gh",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client := queries.NewTestClient()
+
+	ios, _, stdout, _ := iostreams.Test()
+	config := listConfig{
+		opts: listOpts{
+			number: 1,
+			owner:  "monalisa",
+			query:  "assignee:octocat -status:Done",
+		},
+		client:   client,
+		detector: &fd.EnabledDetectorMock{},
+		io:       ios,
+	}
+
+	err := runList(config)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"Issue\tan issue\t1\tcli/go-gh\tissue ID\n",
+		stdout.String())
+}
+
+func TestRunList_QueryUnsupported(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	config := listConfig{
+		opts: listOpts{
+			number: 1,
+			owner:  "monalisa",
+			query:  "assignee:octocat",
+		},
+		detector: &fd.DisabledDetectorMock{},
+		io:       ios,
+	}
+
+	err := runList(config)
+	assert.EqualError(t, err, "the `--query` flag is not supported on this GitHub host")
 }

--- a/pkg/cmd/project/item-list/item_list_test.go
+++ b/pkg/cmd/project/item-list/item_list_test.go
@@ -140,7 +140,6 @@ func TestRunList_User_tty(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
-				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -251,7 +250,6 @@ func TestRunList_User(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
-				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -359,7 +357,6 @@ func TestRunList_Org(t *testing.T) {
 				"afterFields": nil,
 				"login":       "github",
 				"number":      1,
-				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -457,7 +454,6 @@ func TestRunList_Me(t *testing.T) {
 				"firstFields": queries.LimitMax,
 				"afterFields": nil,
 				"number":      1,
-				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -565,7 +561,6 @@ func TestRunList_JSON(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
-				"queryItems":  "",
 			},
 		}).
 		Reply(200).

--- a/pkg/cmd/project/item-list/item_list_test.go
+++ b/pkg/cmd/project/item-list/item_list_test.go
@@ -732,5 +732,5 @@ func TestRunList_QueryUnsupported(t *testing.T) {
 	}
 
 	err := runList(config)
-	assert.EqualError(t, err, "the `--query` flag is not supported on this GitHub host")
+	assert.EqualError(t, err, "the `--query` flag is not supported on this GitHub host; most likely you are targeting a version of GHES that does not yet have the query field available")
 }

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -147,6 +147,53 @@ type Project struct {
 	}
 }
 
+type projectWithoutItemQuery struct {
+	Number           int32
+	URL              string
+	ShortDescription string
+	Public           bool
+	Closed           bool
+	Title            string
+	ID               string
+	Readme           string
+	Items            struct {
+		PageInfo   PageInfo
+		TotalCount int
+		Nodes      []ProjectItem
+	} `graphql:"items(first: $firstItems, after: $afterItems)"`
+	Fields ProjectFields `graphql:"fields(first: $firstFields, after: $afterFields)"`
+	Owner  struct {
+		TypeName string `graphql:"__typename"`
+		User     struct {
+			Login string
+		} `graphql:"... on User"`
+		Organization struct {
+			Login string
+		} `graphql:"... on Organization"`
+	}
+}
+
+func newProjectFromWithoutItemQuery(source projectWithoutItemQuery) *Project {
+	project := &Project{
+		Number:           source.Number,
+		URL:              source.URL,
+		ShortDescription: source.ShortDescription,
+		Public:           source.Public,
+		Closed:           source.Closed,
+		Title:            source.Title,
+		ID:               source.ID,
+		Readme:           source.Readme,
+		Fields:           source.Fields,
+	}
+	project.Items.PageInfo = source.Items.PageInfo
+	project.Items.TotalCount = source.Items.TotalCount
+	project.Items.Nodes = source.Items.Nodes
+	project.Owner.TypeName = source.Owner.TypeName
+	project.Owner.User.Login = source.Owner.User.Login
+	project.Owner.Organization.Login = source.Owner.Organization.Login
+	return project
+}
+
 func (p Project) DetailedItems() map[string]interface{} {
 	return map[string]interface{}{
 		"items":      serializeProjectWithItems(&p),
@@ -529,7 +576,9 @@ func (c *Client) ProjectItems(o *Owner, number int32, limit int, queryStr string
 		"firstFields": githubv4.Int(LimitMax),
 		"afterFields": (*githubv4.String)(nil),
 		"number":      githubv4.Int(number),
-		"queryItems":  githubv4.String(queryStr),
+	}
+	if queryStr != "" {
+		variables["queryItems"] = githubv4.String(queryStr)
 	}
 
 	var query pager[ProjectItem]
@@ -537,14 +586,26 @@ func (c *Client) ProjectItems(o *Owner, number int32, limit int, queryStr string
 	switch o.Type {
 	case UserOwner:
 		variables["login"] = githubv4.String(o.Login)
-		query = &userOwnerWithItems{} // must be a pointer to work with graphql queries
+		if queryStr == "" {
+			query = &userOwnerWithItemsNoQuery{} // must be a pointer to work with graphql queries
+		} else {
+			query = &userOwnerWithItems{} // must be a pointer to work with graphql queries
+		}
 		queryName = "UserProjectWithItems"
 	case OrgOwner:
 		variables["login"] = githubv4.String(o.Login)
-		query = &orgOwnerWithItems{} // must be a pointer to work with graphql queries
+		if queryStr == "" {
+			query = &orgOwnerWithItemsNoQuery{} // must be a pointer to work with graphql queries
+		} else {
+			query = &orgOwnerWithItems{} // must be a pointer to work with graphql queries
+		}
 		queryName = "OrgProjectWithItems"
 	case ViewerOwner:
-		query = &viewerOwnerWithItems{} // must be a pointer to work with graphql queries
+		if queryStr == "" {
+			query = &viewerOwnerWithItemsNoQuery{} // must be a pointer to work with graphql queries
+		} else {
+			query = &viewerOwnerWithItems{} // must be a pointer to work with graphql queries
+		}
 		queryName = "ViewerProjectWithItems"
 	}
 	err := c.doQueryWithProgressIndicator(queryName, query, variables)
@@ -568,6 +629,23 @@ type pager[N projectAttribute] interface {
 	EndCursor() string
 	Nodes() []N
 	Project() *Project
+}
+
+// userOwnerWithItemsNoQuery
+func (q userOwnerWithItemsNoQuery) HasNextPage() bool {
+	return q.Owner.Project.Items.PageInfo.HasNextPage
+}
+
+func (q userOwnerWithItemsNoQuery) EndCursor() string {
+	return string(q.Owner.Project.Items.PageInfo.EndCursor)
+}
+
+func (q userOwnerWithItemsNoQuery) Nodes() []ProjectItem {
+	return q.Owner.Project.Items.Nodes
+}
+
+func (q userOwnerWithItemsNoQuery) Project() *Project {
+	return newProjectFromWithoutItemQuery(q.Owner.Project)
 }
 
 // userOwnerWithItems
@@ -604,6 +682,23 @@ func (q orgOwnerWithItems) Project() *Project {
 	return &q.Owner.Project
 }
 
+// orgOwnerWithItemsNoQuery
+func (q orgOwnerWithItemsNoQuery) HasNextPage() bool {
+	return q.Owner.Project.Items.PageInfo.HasNextPage
+}
+
+func (q orgOwnerWithItemsNoQuery) EndCursor() string {
+	return string(q.Owner.Project.Items.PageInfo.EndCursor)
+}
+
+func (q orgOwnerWithItemsNoQuery) Nodes() []ProjectItem {
+	return q.Owner.Project.Items.Nodes
+}
+
+func (q orgOwnerWithItemsNoQuery) Project() *Project {
+	return newProjectFromWithoutItemQuery(q.Owner.Project)
+}
+
 // viewerOwnerWithItems
 func (q viewerOwnerWithItems) HasNextPage() bool {
 	return q.Owner.Project.Items.PageInfo.HasNextPage
@@ -619,6 +714,23 @@ func (q viewerOwnerWithItems) Nodes() []ProjectItem {
 
 func (q viewerOwnerWithItems) Project() *Project {
 	return &q.Owner.Project
+}
+
+// viewerOwnerWithItemsNoQuery
+func (q viewerOwnerWithItemsNoQuery) HasNextPage() bool {
+	return q.Owner.Project.Items.PageInfo.HasNextPage
+}
+
+func (q viewerOwnerWithItemsNoQuery) EndCursor() string {
+	return string(q.Owner.Project.Items.PageInfo.EndCursor)
+}
+
+func (q viewerOwnerWithItemsNoQuery) Nodes() []ProjectItem {
+	return q.Owner.Project.Items.Nodes
+}
+
+func (q viewerOwnerWithItemsNoQuery) Project() *Project {
+	return newProjectFromWithoutItemQuery(q.Owner.Project)
 }
 
 // userOwnerWithFields
@@ -911,6 +1023,13 @@ type userOwnerWithItems struct {
 	} `graphql:"user(login: $login)"`
 }
 
+// userOwnerWithItemsNoQuery is used to query the project of a user with its items, without query support.
+type userOwnerWithItemsNoQuery struct {
+	Owner struct {
+		Project projectWithoutItemQuery `graphql:"projectV2(number: $number)"`
+	} `graphql:"user(login: $login)"`
+}
+
 // userOwnerWithFields is used to query the project of a user with its fields.
 type userOwnerWithFields struct {
 	Owner struct {
@@ -933,6 +1052,13 @@ type orgOwnerWithItems struct {
 	} `graphql:"organization(login: $login)"`
 }
 
+// orgOwnerWithItemsNoQuery is used to query the project of an organization with its items, without query support.
+type orgOwnerWithItemsNoQuery struct {
+	Owner struct {
+		Project projectWithoutItemQuery `graphql:"projectV2(number: $number)"`
+	} `graphql:"organization(login: $login)"`
+}
+
 // orgOwnerWithFields is used to query the project of an organization with its fields.
 type orgOwnerWithFields struct {
 	Owner struct {
@@ -952,6 +1078,13 @@ type viewerOwner struct {
 type viewerOwnerWithItems struct {
 	Owner struct {
 		Project Project `graphql:"projectV2(number: $number)"`
+	} `graphql:"viewer"`
+}
+
+// viewerOwnerWithItemsNoQuery is used to query the project of the viewer with its items, without query support.
+type viewerOwnerWithItemsNoQuery struct {
+	Owner struct {
+		Project projectWithoutItemQuery `graphql:"projectV2(number: $number)"`
 	} `graphql:"viewer"`
 }
 

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -134,7 +134,7 @@ type Project struct {
 		PageInfo   PageInfo
 		TotalCount int
 		Nodes      []ProjectItem
-	} `graphql:"items(first: $firstItems, after: $afterItems)"`
+	} `graphql:"items(first: $firstItems, after: $afterItems, query: $queryItems)"`
 	Fields ProjectFields `graphql:"fields(first: $firstFields, after: $afterFields)"`
 	Owner  struct {
 		TypeName string `graphql:"__typename"`
@@ -508,8 +508,10 @@ func (p ProjectItem) ExportData(_ []string) map[string]interface{} {
 }
 
 // ProjectItems returns the items of a project. If the OwnerType is VIEWER, no login is required.
-// If limit is 0, the default limit is used.
-func (c *Client) ProjectItems(o *Owner, number int32, limit int) (*Project, error) {
+// If limit is 0, the default limit is used. The queryStr parameter is passed as a server-side
+// filter to the items connection, using the same syntax as the GitHub Projects filter bar
+// (e.g. "assignee:octocat", "status:done").
+func (c *Client) ProjectItems(o *Owner, number int32, limit int, queryStr string) (*Project, error) {
 	project := &Project{}
 	if limit == 0 {
 		limit = LimitDefault
@@ -527,6 +529,7 @@ func (c *Client) ProjectItems(o *Owner, number int32, limit int) (*Project, erro
 		"firstFields": githubv4.Int(LimitMax),
 		"afterFields": (*githubv4.String)(nil),
 		"number":      githubv4.Int(number),
+		"queryItems":  githubv4.String(queryStr),
 	}
 
 	var query pager[ProjectItem]

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -134,7 +134,7 @@ type Project struct {
 		PageInfo   PageInfo
 		TotalCount int
 		Nodes      []ProjectItem
-	} `graphql:"items(first: $firstItems, after: $afterItems, query: $queryItems)"`
+	} `graphql:"items(first: $firstItems, after: $afterItems, query: $query)"`
 	Fields ProjectFields `graphql:"fields(first: $firstFields, after: $afterFields)"`
 	Owner  struct {
 		TypeName string `graphql:"__typename"`
@@ -173,7 +173,7 @@ type projectDTOWithItemQuery struct {
 		PageInfo   PageInfo
 		TotalCount int
 		Nodes      []ProjectItem
-	} `graphql:"items(first: $firstItems, after: $afterItems, query: $queryItems)"`
+	} `graphql:"items(first: $firstItems, after: $afterItems, query: $query)"`
 	Fields ProjectFields `graphql:"fields(first: $firstFields, after: $afterFields)"`
 }
 
@@ -606,7 +606,7 @@ func (c *Client) ProjectItems(o *Owner, number int32, limit int, queryStr string
 		"number":      githubv4.Int(number),
 	}
 	if queryStr != "" {
-		variables["queryItems"] = githubv4.String(queryStr)
+		variables["query"] = githubv4.String(queryStr)
 	}
 
 	var query pager[ProjectItem]

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -147,7 +147,7 @@ type Project struct {
 	}
 }
 
-type projectWithoutItemQuery struct {
+type projectDTOBase struct {
 	Number           int32
 	URL              string
 	ShortDescription string
@@ -156,13 +156,7 @@ type projectWithoutItemQuery struct {
 	Title            string
 	ID               string
 	Readme           string
-	Items            struct {
-		PageInfo   PageInfo
-		TotalCount int
-		Nodes      []ProjectItem
-	} `graphql:"items(first: $firstItems, after: $afterItems)"`
-	Fields ProjectFields `graphql:"fields(first: $firstFields, after: $afterFields)"`
-	Owner  struct {
+	Owner            struct {
 		TypeName string `graphql:"__typename"`
 		User     struct {
 			Login string
@@ -173,7 +167,27 @@ type projectWithoutItemQuery struct {
 	}
 }
 
-func newProjectFromWithoutItemQuery(source projectWithoutItemQuery) *Project {
+type projectDTOWithItemQuery struct {
+	projectDTOBase
+	Items struct {
+		PageInfo   PageInfo
+		TotalCount int
+		Nodes      []ProjectItem
+	} `graphql:"items(first: $firstItems, after: $afterItems, query: $queryItems)"`
+	Fields ProjectFields `graphql:"fields(first: $firstFields, after: $afterFields)"`
+}
+
+type projectDTOWithoutItemQuery struct {
+	projectDTOBase
+	Items struct {
+		PageInfo   PageInfo
+		TotalCount int
+		Nodes      []ProjectItem
+	} `graphql:"items(first: $firstItems, after: $afterItems)"`
+	Fields ProjectFields `graphql:"fields(first: $firstFields, after: $afterFields)"`
+}
+
+func newProjectFromDTOBase(source projectDTOBase) *Project {
 	project := &Project{
 		Number:           source.Number,
 		URL:              source.URL,
@@ -183,14 +197,28 @@ func newProjectFromWithoutItemQuery(source projectWithoutItemQuery) *Project {
 		Title:            source.Title,
 		ID:               source.ID,
 		Readme:           source.Readme,
-		Fields:           source.Fields,
 	}
-	project.Items.PageInfo = source.Items.PageInfo
-	project.Items.TotalCount = source.Items.TotalCount
-	project.Items.Nodes = source.Items.Nodes
 	project.Owner.TypeName = source.Owner.TypeName
 	project.Owner.User.Login = source.Owner.User.Login
 	project.Owner.Organization.Login = source.Owner.Organization.Login
+	return project
+}
+
+func newProjectFromDTOWithItemQuery(source projectDTOWithItemQuery) *Project {
+	project := newProjectFromDTOBase(source.projectDTOBase)
+	project.Items.PageInfo = source.Items.PageInfo
+	project.Items.TotalCount = source.Items.TotalCount
+	project.Items.Nodes = source.Items.Nodes
+	project.Fields = source.Fields
+	return project
+}
+
+func newProjectFromDTOWithoutItemQuery(source projectDTOWithoutItemQuery) *Project {
+	project := newProjectFromDTOBase(source.projectDTOBase)
+	project.Items.PageInfo = source.Items.PageInfo
+	project.Items.TotalCount = source.Items.TotalCount
+	project.Items.Nodes = source.Items.Nodes
+	project.Fields = source.Fields
 	return project
 }
 
@@ -645,7 +673,7 @@ func (q userOwnerWithItemsNoQuery) Nodes() []ProjectItem {
 }
 
 func (q userOwnerWithItemsNoQuery) Project() *Project {
-	return newProjectFromWithoutItemQuery(q.Owner.Project)
+	return newProjectFromDTOWithoutItemQuery(q.Owner.Project)
 }
 
 // userOwnerWithItems
@@ -662,7 +690,7 @@ func (q userOwnerWithItems) Nodes() []ProjectItem {
 }
 
 func (q userOwnerWithItems) Project() *Project {
-	return &q.Owner.Project
+	return newProjectFromDTOWithItemQuery(q.Owner.Project)
 }
 
 // orgOwnerWithItems
@@ -679,7 +707,7 @@ func (q orgOwnerWithItems) Nodes() []ProjectItem {
 }
 
 func (q orgOwnerWithItems) Project() *Project {
-	return &q.Owner.Project
+	return newProjectFromDTOWithItemQuery(q.Owner.Project)
 }
 
 // orgOwnerWithItemsNoQuery
@@ -696,7 +724,7 @@ func (q orgOwnerWithItemsNoQuery) Nodes() []ProjectItem {
 }
 
 func (q orgOwnerWithItemsNoQuery) Project() *Project {
-	return newProjectFromWithoutItemQuery(q.Owner.Project)
+	return newProjectFromDTOWithoutItemQuery(q.Owner.Project)
 }
 
 // viewerOwnerWithItems
@@ -713,7 +741,7 @@ func (q viewerOwnerWithItems) Nodes() []ProjectItem {
 }
 
 func (q viewerOwnerWithItems) Project() *Project {
-	return &q.Owner.Project
+	return newProjectFromDTOWithItemQuery(q.Owner.Project)
 }
 
 // viewerOwnerWithItemsNoQuery
@@ -730,7 +758,7 @@ func (q viewerOwnerWithItemsNoQuery) Nodes() []ProjectItem {
 }
 
 func (q viewerOwnerWithItemsNoQuery) Project() *Project {
-	return newProjectFromWithoutItemQuery(q.Owner.Project)
+	return newProjectFromDTOWithoutItemQuery(q.Owner.Project)
 }
 
 // userOwnerWithFields
@@ -747,7 +775,7 @@ func (q userOwnerWithFields) Nodes() []ProjectField {
 }
 
 func (q userOwnerWithFields) Project() *Project {
-	return &q.Owner.Project
+	return newProjectFromDTOWithoutItemQuery(q.Owner.Project)
 }
 
 // orgOwnerWithFields
@@ -764,7 +792,7 @@ func (q orgOwnerWithFields) Nodes() []ProjectField {
 }
 
 func (q orgOwnerWithFields) Project() *Project {
-	return &q.Owner.Project
+	return newProjectFromDTOWithoutItemQuery(q.Owner.Project)
 }
 
 // viewerOwnerWithFields
@@ -781,7 +809,7 @@ func (q viewerOwnerWithFields) Nodes() []ProjectField {
 }
 
 func (q viewerOwnerWithFields) Project() *Project {
-	return &q.Owner.Project
+	return newProjectFromDTOWithoutItemQuery(q.Owner.Project)
 }
 
 type projectAttribute interface {
@@ -1009,16 +1037,16 @@ type viewerLoginOrgs struct {
 }
 
 type ownerWithLogin struct {
-	Project Project `graphql:"projectV2(number: $number)"`
+	Project projectDTOWithoutItemQuery `graphql:"projectV2(number: $number)"`
 	Login   string
 }
 
-type ownerWithProject struct {
-	Project Project `graphql:"projectV2(number: $number)"`
+type ownerWithProjectWithItemQuery struct {
+	Project projectDTOWithItemQuery `graphql:"projectV2(number: $number)"`
 }
 
 type ownerWithProjectWithoutItemQuery struct {
-	Project projectWithoutItemQuery `graphql:"projectV2(number: $number)"`
+	Project projectDTOWithoutItemQuery `graphql:"projectV2(number: $number)"`
 }
 
 // userOwner is used to query the project of a user.
@@ -1028,7 +1056,7 @@ type userOwner struct {
 
 // userOwnerWithItems is used to query the project of a user with its items.
 type userOwnerWithItems struct {
-	Owner ownerWithProject `graphql:"user(login: $login)"`
+	Owner ownerWithProjectWithItemQuery `graphql:"user(login: $login)"`
 }
 
 // userOwnerWithItemsNoQuery is used to query the project of a user with its items, without query support.
@@ -1038,7 +1066,7 @@ type userOwnerWithItemsNoQuery struct {
 
 // userOwnerWithFields is used to query the project of a user with its fields.
 type userOwnerWithFields struct {
-	Owner ownerWithProject `graphql:"user(login: $login)"`
+	Owner ownerWithProjectWithoutItemQuery `graphql:"user(login: $login)"`
 }
 
 // orgOwner is used to query the project of an organization.
@@ -1048,7 +1076,7 @@ type orgOwner struct {
 
 // orgOwnerWithItems is used to query the project of an organization with its items.
 type orgOwnerWithItems struct {
-	Owner ownerWithProject `graphql:"organization(login: $login)"`
+	Owner ownerWithProjectWithItemQuery `graphql:"organization(login: $login)"`
 }
 
 // orgOwnerWithItemsNoQuery is used to query the project of an organization with its items, without query support.
@@ -1058,7 +1086,7 @@ type orgOwnerWithItemsNoQuery struct {
 
 // orgOwnerWithFields is used to query the project of an organization with its fields.
 type orgOwnerWithFields struct {
-	Owner ownerWithProject `graphql:"organization(login: $login)"`
+	Owner ownerWithProjectWithoutItemQuery `graphql:"organization(login: $login)"`
 }
 
 // viewerOwner is used to query the project of the viewer.
@@ -1068,7 +1096,7 @@ type viewerOwner struct {
 
 // viewerOwnerWithItems is used to query the project of the viewer with its items.
 type viewerOwnerWithItems struct {
-	Owner ownerWithProject `graphql:"viewer"`
+	Owner ownerWithProjectWithItemQuery `graphql:"viewer"`
 }
 
 // viewerOwnerWithItemsNoQuery is used to query the project of the viewer with its items, without query support.
@@ -1078,7 +1106,7 @@ type viewerOwnerWithItemsNoQuery struct {
 
 // viewerOwnerWithFields is used to query the project of the viewer with its fields.
 type viewerOwnerWithFields struct {
-	Owner ownerWithProject `graphql:"viewer"`
+	Owner ownerWithProjectWithoutItemQuery `graphql:"viewer"`
 }
 
 // OwnerType is the type of the owner of a project, which can be either a user or an organization. Viewer is the current user.
@@ -1184,7 +1212,7 @@ type userProjects struct {
 		Projects struct {
 			TotalCount int
 			PageInfo   PageInfo
-			Nodes      []Project
+			Nodes      []projectDTOWithoutItemQuery
 		} `graphql:"projectsV2(first: $first, after: $after)"`
 		Login string
 	} `graphql:"user(login: $login)"`
@@ -1196,7 +1224,7 @@ type orgProjects struct {
 		Projects struct {
 			TotalCount int
 			PageInfo   PageInfo
-			Nodes      []Project
+			Nodes      []projectDTOWithoutItemQuery
 		} `graphql:"projectsV2(first: $first, after: $after)"`
 		Login string
 	} `graphql:"organization(login: $login)"`
@@ -1208,7 +1236,7 @@ type viewerProjects struct {
 		Projects struct {
 			TotalCount int
 			PageInfo   PageInfo
-			Nodes      []Project
+			Nodes      []projectDTOWithoutItemQuery
 		} `graphql:"projectsV2(first: $first, after: $after)"`
 		Login string
 	} `graphql:"viewer"`
@@ -1362,16 +1390,16 @@ func (c *Client) NewProject(canPrompt bool, o *Owner, number int32, fields bool)
 			var query userOwner
 			variables["login"] = githubv4.String(o.Login)
 			err := c.doQueryWithProgressIndicator("UserProject", &query, variables)
-			return &query.Owner.Project, err
+			return newProjectFromDTOWithoutItemQuery(query.Owner.Project), err
 		} else if o.Type == OrgOwner {
 			variables["login"] = githubv4.String(o.Login)
 			var query orgOwner
 			err := c.doQueryWithProgressIndicator("OrgProject", &query, variables)
-			return &query.Owner.Project, err
+			return newProjectFromDTOWithoutItemQuery(query.Owner.Project), err
 		} else if o.Type == ViewerOwner {
 			var query viewerOwner
 			err := c.doQueryWithProgressIndicator("ViewerProject", &query, variables)
-			return &query.Owner.Project, err
+			return newProjectFromDTOWithoutItemQuery(query.Owner.Project), err
 		}
 		return nil, errors.New("unknown owner type")
 	}
@@ -1448,7 +1476,9 @@ func (c *Client) Projects(login string, t OwnerType, limit int, fields bool) (Pr
 			if err := c.doQueryWithProgressIndicator("UserProjects", &query, variables); err != nil {
 				return projects, err
 			}
-			projects.Nodes = append(projects.Nodes, query.Owner.Projects.Nodes...)
+			for _, p := range query.Owner.Projects.Nodes {
+				projects.Nodes = append(projects.Nodes, *newProjectFromDTOWithoutItemQuery(p))
+			}
 			hasNextPage = query.Owner.Projects.PageInfo.HasNextPage
 			cursor = &query.Owner.Projects.PageInfo.EndCursor
 			projects.TotalCount = query.Owner.Projects.TotalCount
@@ -1457,7 +1487,9 @@ func (c *Client) Projects(login string, t OwnerType, limit int, fields bool) (Pr
 			if err := c.doQueryWithProgressIndicator("OrgProjects", &query, variables); err != nil {
 				return projects, err
 			}
-			projects.Nodes = append(projects.Nodes, query.Owner.Projects.Nodes...)
+			for _, p := range query.Owner.Projects.Nodes {
+				projects.Nodes = append(projects.Nodes, *newProjectFromDTOWithoutItemQuery(p))
+			}
 			hasNextPage = query.Owner.Projects.PageInfo.HasNextPage
 			cursor = &query.Owner.Projects.PageInfo.EndCursor
 			projects.TotalCount = query.Owner.Projects.TotalCount
@@ -1466,7 +1498,9 @@ func (c *Client) Projects(login string, t OwnerType, limit int, fields bool) (Pr
 			if err := c.doQueryWithProgressIndicator("ViewerProjects", &query, variables); err != nil {
 				return projects, err
 			}
-			projects.Nodes = append(projects.Nodes, query.Owner.Projects.Nodes...)
+			for _, p := range query.Owner.Projects.Nodes {
+				projects.Nodes = append(projects.Nodes, *newProjectFromDTOWithoutItemQuery(p))
+			}
 			hasNextPage = query.Owner.Projects.PageInfo.HasNextPage
 			cursor = &query.Owner.Projects.PageInfo.EndCursor
 			projects.TotalCount = query.Owner.Projects.TotalCount

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -1008,91 +1008,77 @@ type viewerLoginOrgs struct {
 	}
 }
 
+type ownerWithLogin struct {
+	Project Project `graphql:"projectV2(number: $number)"`
+	Login   string
+}
+
+type ownerWithProject struct {
+	Project Project `graphql:"projectV2(number: $number)"`
+}
+
+type ownerWithProjectWithoutItemQuery struct {
+	Project projectWithoutItemQuery `graphql:"projectV2(number: $number)"`
+}
+
 // userOwner is used to query the project of a user.
 type userOwner struct {
-	Owner struct {
-		Project Project `graphql:"projectV2(number: $number)"`
-		Login   string
-	} `graphql:"user(login: $login)"`
+	Owner ownerWithLogin `graphql:"user(login: $login)"`
 }
 
 // userOwnerWithItems is used to query the project of a user with its items.
 type userOwnerWithItems struct {
-	Owner struct {
-		Project Project `graphql:"projectV2(number: $number)"`
-	} `graphql:"user(login: $login)"`
+	Owner ownerWithProject `graphql:"user(login: $login)"`
 }
 
 // userOwnerWithItemsNoQuery is used to query the project of a user with its items, without query support.
 type userOwnerWithItemsNoQuery struct {
-	Owner struct {
-		Project projectWithoutItemQuery `graphql:"projectV2(number: $number)"`
-	} `graphql:"user(login: $login)"`
+	Owner ownerWithProjectWithoutItemQuery `graphql:"user(login: $login)"`
 }
 
 // userOwnerWithFields is used to query the project of a user with its fields.
 type userOwnerWithFields struct {
-	Owner struct {
-		Project Project `graphql:"projectV2(number: $number)"`
-	} `graphql:"user(login: $login)"`
+	Owner ownerWithProject `graphql:"user(login: $login)"`
 }
 
 // orgOwner is used to query the project of an organization.
 type orgOwner struct {
-	Owner struct {
-		Project Project `graphql:"projectV2(number: $number)"`
-		Login   string
-	} `graphql:"organization(login: $login)"`
+	Owner ownerWithLogin `graphql:"organization(login: $login)"`
 }
 
 // orgOwnerWithItems is used to query the project of an organization with its items.
 type orgOwnerWithItems struct {
-	Owner struct {
-		Project Project `graphql:"projectV2(number: $number)"`
-	} `graphql:"organization(login: $login)"`
+	Owner ownerWithProject `graphql:"organization(login: $login)"`
 }
 
 // orgOwnerWithItemsNoQuery is used to query the project of an organization with its items, without query support.
 type orgOwnerWithItemsNoQuery struct {
-	Owner struct {
-		Project projectWithoutItemQuery `graphql:"projectV2(number: $number)"`
-	} `graphql:"organization(login: $login)"`
+	Owner ownerWithProjectWithoutItemQuery `graphql:"organization(login: $login)"`
 }
 
 // orgOwnerWithFields is used to query the project of an organization with its fields.
 type orgOwnerWithFields struct {
-	Owner struct {
-		Project Project `graphql:"projectV2(number: $number)"`
-	} `graphql:"organization(login: $login)"`
+	Owner ownerWithProject `graphql:"organization(login: $login)"`
 }
 
 // viewerOwner is used to query the project of the viewer.
 type viewerOwner struct {
-	Owner struct {
-		Project Project `graphql:"projectV2(number: $number)"`
-		Login   string
-	} `graphql:"viewer"`
+	Owner ownerWithLogin `graphql:"viewer"`
 }
 
 // viewerOwnerWithItems is used to query the project of the viewer with its items.
 type viewerOwnerWithItems struct {
-	Owner struct {
-		Project Project `graphql:"projectV2(number: $number)"`
-	} `graphql:"viewer"`
+	Owner ownerWithProject `graphql:"viewer"`
 }
 
 // viewerOwnerWithItemsNoQuery is used to query the project of the viewer with its items, without query support.
 type viewerOwnerWithItemsNoQuery struct {
-	Owner struct {
-		Project projectWithoutItemQuery `graphql:"projectV2(number: $number)"`
-	} `graphql:"viewer"`
+	Owner ownerWithProjectWithoutItemQuery `graphql:"viewer"`
 }
 
 // viewerOwnerWithFields is used to query the project of the viewer with its fields.
 type viewerOwnerWithFields struct {
-	Owner struct {
-		Project Project `graphql:"projectV2(number: $number)"`
-	} `graphql:"viewer"`
+	Owner ownerWithProject `graphql:"viewer"`
 }
 
 // OwnerType is the type of the owner of a project, which can be either a user or an organization. Viewer is the current user.

--- a/pkg/cmd/project/shared/queries/queries_test.go
+++ b/pkg/cmd/project/shared/queries/queries_test.go
@@ -24,7 +24,6 @@ func TestProjectItems_DefaultLimit(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
-				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -78,7 +77,6 @@ func TestProjectItems_LowerLimit(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
-				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -129,7 +127,6 @@ func TestProjectItems_NoLimit(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
-				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -384,7 +381,6 @@ func TestProjectItems_FieldTitle(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
-				"queryItems":  "",
 			},
 		}).
 		Reply(200).

--- a/pkg/cmd/project/shared/queries/queries_test.go
+++ b/pkg/cmd/project/shared/queries/queries_test.go
@@ -1,12 +1,22 @@
 package queries
 
 import (
+	"io"
+	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestProjectItems_DefaultLimit(t *testing.T) {
 	defer gock.Off()
@@ -263,6 +273,91 @@ func TestProjectItems_WithQuery(t *testing.T) {
 			assert.Len(t, project.Items.Nodes, 1)
 		})
 	}
+}
+
+func TestProjectItems_NoQueryDoesNotUseQueryItems(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	httpClient := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			assert.NoError(t, err)
+			assert.NotContains(t, string(body), "$queryItems")
+
+			return &http.Response{
+				StatusCode: 200,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{
+					"data": {
+						"user": {
+							"projectV2": {
+								"items": {
+									"nodes": [
+										{"id": "issue ID"}
+									]
+								}
+							}
+						}
+					}
+				}`)),
+			}, nil
+		}),
+	}
+
+	client := NewClient(httpClient, "github.com", ios)
+	owner := &Owner{
+		Type:  UserOwner,
+		Login: "monalisa",
+		ID:    "user ID",
+	}
+	project, err := client.ProjectItems(owner, 1, LimitMax, "")
+	assert.NoError(t, err)
+	assert.Len(t, project.Items.Nodes, 1)
+}
+
+func TestProjects_ViewerQueryDoesNotUseQueryItems(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	httpClient := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			assert.NoError(t, err)
+			assert.NotContains(t, string(body), "$queryItems")
+
+			return &http.Response{
+				StatusCode: 200,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{
+					"data": {
+						"viewer": {
+							"projectsV2": {
+								"totalCount": 1,
+								"pageInfo": {
+									"hasNextPage": false,
+									"endCursor": ""
+								},
+								"nodes": [
+									{
+										"number": 1,
+										"title": "Roadmap"
+									}
+								]
+							}
+						}
+					}
+				}`)),
+			}, nil
+		}),
+	}
+
+	client := NewClient(httpClient, "github.com", ios)
+	projects, err := client.Projects("", ViewerOwner, 1, false)
+	assert.NoError(t, err)
+	assert.Len(t, projects.Nodes, 1)
+	assert.Equal(t, int32(1), projects.Nodes[0].Number)
+	assert.Equal(t, "Roadmap", projects.Nodes[0].Title)
 }
 
 func TestProjectFields_LowerLimit(t *testing.T) {

--- a/pkg/cmd/project/shared/queries/queries_test.go
+++ b/pkg/cmd/project/shared/queries/queries_test.go
@@ -164,6 +164,107 @@ func TestProjectItems_NoLimit(t *testing.T) {
 	assert.Len(t, project.Items.Nodes, 3)
 }
 
+func TestProjectItems_WithQuery(t *testing.T) {
+	tests := []struct {
+		name      string
+		owner     *Owner
+		queryName string
+		dataKey   string
+		vars      map[string]interface{}
+	}{
+		{
+			name: "user owner",
+			owner: &Owner{
+				Type:  UserOwner,
+				Login: "monalisa",
+				ID:    "user ID",
+			},
+			queryName: "UserProjectWithItems",
+			dataKey:   "user",
+			vars: map[string]interface{}{
+				"firstItems":  LimitMax,
+				"afterItems":  nil,
+				"firstFields": LimitMax,
+				"afterFields": nil,
+				"login":       "monalisa",
+				"number":      1,
+				"queryItems":  "assignee:octocat",
+			},
+		},
+		{
+			name: "org owner",
+			owner: &Owner{
+				Type:  OrgOwner,
+				Login: "github",
+				ID:    "org ID",
+			},
+			queryName: "OrgProjectWithItems",
+			dataKey:   "organization",
+			vars: map[string]interface{}{
+				"firstItems":  LimitMax,
+				"afterItems":  nil,
+				"firstFields": LimitMax,
+				"afterFields": nil,
+				"login":       "github",
+				"number":      1,
+				"queryItems":  "assignee:octocat",
+			},
+		},
+		{
+			name: "viewer owner",
+			owner: &Owner{
+				Type: ViewerOwner,
+				ID:   "viewer ID",
+			},
+			queryName: "ViewerProjectWithItems",
+			dataKey:   "viewer",
+			vars: map[string]interface{}{
+				"firstItems":  LimitMax,
+				"afterItems":  nil,
+				"firstFields": LimitMax,
+				"afterFields": nil,
+				"number":      1,
+				"queryItems":  "assignee:octocat",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer gock.Off()
+			gock.Observe(gock.DumpRequest)
+
+			gock.New("https://api.github.com").
+				Post("/graphql").
+				JSON(map[string]interface{}{
+					"query":     "query " + tt.queryName + ".*",
+					"variables": tt.vars,
+				}).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"data": map[string]interface{}{
+						tt.dataKey: map[string]interface{}{
+							"projectV2": map[string]interface{}{
+								"items": map[string]interface{}{
+									"nodes": []map[string]interface{}{
+										{
+											"id": "issue ID",
+										},
+									},
+								},
+							},
+						},
+					},
+				})
+
+			client := NewTestClient()
+			project, err := client.ProjectItems(tt.owner, 1, LimitMax, "assignee:octocat")
+			assert.NoError(t, err)
+			assert.Len(t, project.Items.Nodes, 1)
+		})
+	}
+}
+
 func TestProjectFields_LowerLimit(t *testing.T) {
 
 	defer gock.Off()

--- a/pkg/cmd/project/shared/queries/queries_test.go
+++ b/pkg/cmd/project/shared/queries/queries_test.go
@@ -198,7 +198,7 @@ func TestProjectItems_WithQuery(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
-				"queryItems":  "assignee:octocat",
+				"query":       "assignee:octocat",
 			},
 		},
 		{
@@ -217,7 +217,7 @@ func TestProjectItems_WithQuery(t *testing.T) {
 				"afterFields": nil,
 				"login":       "github",
 				"number":      1,
-				"queryItems":  "assignee:octocat",
+				"query":       "assignee:octocat",
 			},
 		},
 		{
@@ -234,7 +234,7 @@ func TestProjectItems_WithQuery(t *testing.T) {
 				"firstFields": LimitMax,
 				"afterFields": nil,
 				"number":      1,
-				"queryItems":  "assignee:octocat",
+				"query":       "assignee:octocat",
 			},
 		},
 	}
@@ -281,7 +281,7 @@ func TestProjectItems_NoQueryDoesNotUseQueryItems(t *testing.T) {
 		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			body, err := io.ReadAll(req.Body)
 			assert.NoError(t, err)
-			assert.NotContains(t, string(body), "$queryItems")
+			assert.NotContains(t, string(body), "$query")
 
 			return &http.Response{
 				StatusCode: 200,
@@ -322,7 +322,7 @@ func TestProjects_ViewerQueryDoesNotUseQueryItems(t *testing.T) {
 		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			body, err := io.ReadAll(req.Body)
 			assert.NoError(t, err)
-			assert.NotContains(t, string(body), "$queryItems")
+			assert.NotContains(t, string(body), "$query")
 
 			return &http.Response{
 				StatusCode: 200,

--- a/pkg/cmd/project/shared/queries/queries_test.go
+++ b/pkg/cmd/project/shared/queries/queries_test.go
@@ -24,6 +24,7 @@ func TestProjectItems_DefaultLimit(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
+				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -56,7 +57,7 @@ func TestProjectItems_DefaultLimit(t *testing.T) {
 		Login: "monalisa",
 		ID:    "user ID",
 	}
-	project, err := client.ProjectItems(owner, 1, LimitMax)
+	project, err := client.ProjectItems(owner, 1, LimitMax, "")
 	assert.NoError(t, err)
 	assert.Len(t, project.Items.Nodes, 3)
 }
@@ -77,6 +78,7 @@ func TestProjectItems_LowerLimit(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
+				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -106,7 +108,7 @@ func TestProjectItems_LowerLimit(t *testing.T) {
 		Login: "monalisa",
 		ID:    "user ID",
 	}
-	project, err := client.ProjectItems(owner, 1, 2)
+	project, err := client.ProjectItems(owner, 1, 2, "")
 	assert.NoError(t, err)
 	assert.Len(t, project.Items.Nodes, 2)
 }
@@ -127,6 +129,7 @@ func TestProjectItems_NoLimit(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
+				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -159,7 +162,7 @@ func TestProjectItems_NoLimit(t *testing.T) {
 		Login: "monalisa",
 		ID:    "user ID",
 	}
-	project, err := client.ProjectItems(owner, 1, 0)
+	project, err := client.ProjectItems(owner, 1, 0, "")
 	assert.NoError(t, err)
 	assert.Len(t, project.Items.Nodes, 3)
 }
@@ -381,6 +384,7 @@ func TestProjectItems_FieldTitle(t *testing.T) {
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
+				"queryItems":  "",
 			},
 		}).
 		Reply(200).
@@ -422,7 +426,7 @@ func TestProjectItems_FieldTitle(t *testing.T) {
 		Login: "monalisa",
 		ID:    "user ID",
 	}
-	project, err := client.ProjectItems(owner, 1, LimitMax)
+	project, err := client.ProjectItems(owner, 1, LimitMax, "")
 	assert.NoError(t, err)
 	assert.Len(t, project.Items.Nodes, 1)
 	assert.Len(t, project.Items.Nodes[0].FieldValues.Nodes, 2)


### PR DESCRIPTION
## Description

Fixes https://github.com/cli/cli/issues/12664

### Acceptance Criteria

**Given** I am targeting github.com
**When** I run `project item-list` with the `--query` flag
**Then** the query is respected in the results

```
➜ ./bin/gh project item-list 9 --owner williammartin --format json --query "assignee:williammartin-cli-triaging"
{
  "items": [
    {
      "assignees": [
        "williammartin-cli-triaging"
      ],
      "content": {
        "body": "test",
        "number": 25,
        "repository": "williammartin-test-org/test-repo",
        "title": "test title",
        "type": "Issue",
        "url": "https://github.com/williammartin-test-org/test-repo/issues/25"
      },
      "id": "PVTI_lAHOABiW9s4A1ms7zgY4CN4",
      "repository": "https://github.com/williammartin-test-org/test-repo",
      "title": "test title"
    }
  ],
  "totalCount": 1
}

➜  ./bin/gh project item-list 9 --owner williammartin --format json --query "assignee:babakks"
{
  "items": [],
  "totalCount": 0
}
```

**Given** I am targeting a version of GHES that doesn't support the query flag
**When** I run `project item-list` with the `--query` flag
**Then** I receive an informative error

```
➜ ✗ GH_HOST=ghe.io ./bin/gh project item-list 9 --owner williammartin --format json --query "assignee:babakks"
the `--query` flag is not supported on this GitHub host; most likely you are targeting a version of GHES that does not yet have the query field available
```