### PR TITLE
Add missing TODO comments for featuredetection if-statements

### DIFF
--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -132,6 +132,7 @@ func apiClose(httpClient *http.Client, repo ghrepo.Interface, issue *api.Issue, 
 		if err != nil {
 			return err
 		}
+		// TODO stateReasonCleanup
 		if !features.StateReason {
 			// If StateReason is not supported silently close issue without setting StateReason.
 			reason = ""

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -186,6 +186,7 @@ func createRun(opts *CreateOptions) (err error) {
 		return err
 	}
 
+	// TODO actorIsAssignableCleanup
 	if issueFeatures.ActorIsAssignable {
 		assignees = copilotReplacer.ReplaceSlice(assignees)
 	}

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -215,6 +215,7 @@ func editRun(opts *EditOptions) error {
 
 	lookupFields := []string{"id", "number", "title", "body", "url"}
 	if editable.Assignees.Edited {
+		// TODO actorIsAssignableCleanup
 		if issueFeatures.ActorIsAssignable {
 			editable.Assignees.ActorAssignees = true
 			lookupFields = append(lookupFields, "assignedActors")

--- a/pkg/cmd/issue/list/http.go
+++ b/pkg/cmd/issue/list/http.go
@@ -164,8 +164,10 @@ func searchIssues(client *api.Client, detector fd.Detector, repo ghrepo.Interfac
 	filters.Repo = ghrepo.FullName(repo)
 	filters.Entity = "issue"
 
+	// TODO advancedIssueSearchCleanup
 	if features.AdvancedIssueSearchAPI {
 		variables["query"] = prShared.SearchQueryBuild(filters, true)
+		// TODO advancedIssueSearchCleanup
 		if features.AdvancedIssueSearchAPIOptIn {
 			variables["type"] = "ISSUE_ADVANCED"
 		} else {

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -152,6 +152,7 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 	fields := defaultFields
+	// TODO stateReasonCleanup
 	if features.StateReason {
 		fields = append(defaultFields, "stateReason")
 	}

--- a/pkg/cmd/issue/shared/lookup.go
+++ b/pkg/cmd/issue/shared/lookup.go
@@ -145,6 +145,7 @@ func FindIssueOrPR(httpClient *http.Client, repo ghrepo.Interface, number int, f
 		if err != nil {
 			return nil, err
 		}
+		// TODO stateReasonCleanup
 		if !features.StateReason {
 			fieldSet.Remove("stateReason")
 		}

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -251,6 +251,7 @@ func editRun(opts *EditOptions) error {
 		return err
 	}
 
+	// TODO actorIsAssignableCleanup
 	if issueFeatures.ActorIsAssignable {
 		findOptions.Fields = append(findOptions.Fields, "assignedActors")
 	} else {
@@ -269,6 +270,7 @@ func editRun(opts *EditOptions) error {
 	editable.Base.Default = pr.BaseRefName
 	editable.Reviewers.Default = pr.ReviewRequests.DisplayNames()
 	editable.Reviewers.DefaultLogins = pr.ReviewRequests.Logins()
+	// TODO actorIsAssignableCleanup
 	if issueFeatures.ActorIsAssignable {
 		editable.Assignees.ActorAssignees = true
 		editable.Assignees.Default = pr.AssignedActors.DisplayNames()
@@ -299,6 +301,7 @@ func editRun(opts *EditOptions) error {
 	// Wire up search functions for assignees and reviewers.
 	// When these aren't wired up, it triggers a downstream fallback
 	// to legacy reviewer/assignee fetching.
+	// TODO actorIsAssignableCleanup
 	if issueFeatures.ActorIsAssignable {
 		editable.AssigneeSearchFunc = assigneeSearchFunc(apiClient, repo, &editable, pr.ID)
 		editable.ReviewerSearchFunc = reviewerSearchFunc(apiClient, repo, &editable, pr.ID)

--- a/pkg/cmd/pr/list/http.go
+++ b/pkg/cmd/pr/list/http.go
@@ -75,8 +75,10 @@ func searchPullRequests(httpClient *http.Client, detector fd.Detector, repo ghre
 	filters.Repo = ghrepo.FullName(repo)
 	filters.Entity = "pr"
 
+	// TODO advancedIssueSearchCleanup
 	if features.AdvancedIssueSearchAPI {
 		variables["q"] = prShared.SearchQueryBuild(filters, true)
+		// TODO advancedIssueSearchCleanup
 		if features.AdvancedIssueSearchAPIOptIn {
 			variables["type"] = "ISSUE_ADVANCED"
 		} else {

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -219,6 +219,7 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 		if err != nil {
 			return nil, nil, err
 		}
+		// TODO mergeQueueCleanup
 		if !prFeatures.MergeQueue {
 			fields.Remove("isInMergeQueue")
 			fields.Remove("isMergeQueueEnabled")

--- a/pkg/cmd/release/list/http.go
+++ b/pkg/cmd/release/list/http.go
@@ -55,6 +55,7 @@ func fetchReleases(httpClient *http.Client, repo ghrepo.Interface, limit int, ex
 	// `@skip(condition)` here because if the field doesn't exist on the schema
 	// then the whole query would still fail regardless of the condition being
 	// met or not.
+	// TODO immutableReleaseFullSupport
 	if !releaseFeatures.ImmutableReleases {
 		return fetchReleasesWithoutImmutableReleases(httpClient, repo, limit, excludeDrafts, excludePreReleases, order)
 	}

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -233,9 +233,11 @@ func editRun(ctx context.Context, opts *EditOptions) error {
 			"squashMergeAllowed",
 			"watchers",
 		}
+		// TODO repoFeaturesCleanup
 		if repoFeatures.VisibilityField {
 			fieldsToRetrieve = append(fieldsToRetrieve, "visibility")
 		}
+		// TODO repoFeaturesCleanup
 		if repoFeatures.AutoMerge {
 			fieldsToRetrieve = append(fieldsToRetrieve, "autoMergeAllowed")
 		}

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -139,6 +139,7 @@ func listRun(opts *ListOptions) error {
 	}
 
 	fields := defaultFields
+	// TODO repoFeaturesCleanup
 	if features.VisibilityField {
 		fields = append(defaultFields, "visibility")
 	}

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -217,6 +217,7 @@ func (s searcher) search(query Query, result interface{}) (string, error) {
 		} else {
 			qs.Set("q", query.AdvancedIssueSearchString())
 
+			// TODO advancedIssueSearchCleanup
 			if features.AdvancedIssueSearchAPIOptIn {
 				// Advanced syntax should be explicitly enabled
 				qs.Set("advanced_search", "true")


### PR DESCRIPTION
Adds greppable TODO identifiers above all if-statements that reference featuredetection struct fields, as required by the featuredetection linter introduced in [kw/fd-linter-poc](https://github.com/cli/cli/tree/kw/fd-linter-poc). 

All 18 violations fixed across 11 files. The TODO identifiers used are:

- **`stateReasonCleanup`**: `StateReason` checks (3 sites)
- **`actorIsAssignableCleanup`**: `ActorIsAssignable` checks (5 sites)
- **`advancedIssueSearchCleanup`**: `AdvancedIssueSearchAPI`/`OptIn` checks (5 sites)
- **`mergeQueueCleanup`**: `MergeQueue` check (1 site)
- **`immutableReleaseFullSupport`**: `ImmutableReleases` check (1 site, moved closer)
- **`repoFeaturesCleanup`**: `VisibilityField`/`AutoMerge` checks (3 sites)