### PR TITLE
`gh release upload`: Clarify `--clobber` flag deletes assets before re-uploading

### DIFF
--- a/pkg/cmd/release/upload/upload.go
+++ b/pkg/cmd/release/upload/upload.go
@@ -43,6 +43,9 @@ func NewCmdUpload(f *cmdutil.Factory, runF func(*UploadOptions) error) *cobra.Co
 
 			To define a display label for an asset, append text starting with %[1]s#%[1]s after the
 			file name.
+
+			When using %[1]s--clobber%[1]s, existing assets are deleted before new assets are uploaded.
+			If the upload fails, the original assets will be lost.
 		`, "`"),
 		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -66,7 +69,7 @@ func NewCmdUpload(f *cmdutil.Factory, runF func(*UploadOptions) error) *cobra.Co
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.OverwriteExisting, "clobber", false, "Overwrite existing assets of the same name")
+	cmd.Flags().BoolVar(&opts.OverwriteExisting, "clobber", false, "Delete and re-upload existing assets of the same name")
 
 	return cmd
 }


### PR DESCRIPTION
The `--clobber` flag on `gh release upload` currently says "Overwrite existing assets of the same name", which implies an atomic replacement. In reality, existing assets are **deleted first** and then new ones are uploaded; if the upload is interrupted, the original assets are lost.

This updates the flag description and long help text to make the delete-then-upload behavior explicit.

Fixes #8822