### PR TITLE
fix(repo fork): honor --remote flag when repo arg matches current dir

### DIFF
--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -144,10 +144,11 @@ func NewCmdFork(f *cmdutil.Factory, runF func(*ForkOptions) error) *cobra.Comman
 
 func forkRun(opts *ForkOptions) error {
 	var repoToFork ghrepo.Interface
+	var baseRepo ghrepo.Interface
 	var err error
 	inParent := false // whether or not we're forking the repo we're currently "in"
 	if opts.Repository == "" {
-		baseRepo, err := opts.BaseRepo()
+		baseRepo, err = opts.BaseRepo()
 		if err != nil {
 			return fmt.Errorf("unable to determine base repository: %w", err)
 		}
@@ -180,6 +181,17 @@ func forkRun(opts *ForkOptions) error {
 			repoToFork, err = ghrepo.FromFullName(repoArg)
 			if err != nil {
 				return fmt.Errorf("argument error: %w", err)
+			}
+		}
+	}
+
+	if opts.Repository != "" && opts.Remote {
+		if currentRepo, currentRepoErr := opts.BaseRepo(); currentRepoErr == nil {
+			baseRepo = currentRepo
+			if strings.EqualFold(baseRepo.RepoHost(), repoToFork.RepoHost()) &&
+				strings.EqualFold(baseRepo.RepoOwner(), repoToFork.RepoOwner()) &&
+				strings.EqualFold(baseRepo.RepoName(), repoToFork.RepoName()) {
+				inParent = true
 			}
 		}
 	}

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -483,6 +483,22 @@ func TestRepoFork(t *testing.T) {
 			wantErrOut: "✓ Created fork gamehendge/REPO\n✓ Cloned fork\n! Repository OWNER/REPO set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n",
 		},
 		{
+			name: "repo arg with --remote for current repo",
+			tty:  true,
+			opts: &ForkOptions{
+				Repository: "OWNER/REPO",
+				Remote:     true,
+				RemoteName: defaultRemoteName,
+				Rename:     true,
+			},
+			httpStubs: forkPost,
+			execStubs: func(cs *run.CommandStubber) {
+				cs.Register("git remote rename origin upstream", 0, "")
+				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
+			},
+			wantErrOut: "✓ Created fork someone/REPO\n✓ Renamed remote origin to upstream\n✓ Added remote origin\n",
+		},
+		{
 			name: "repo arg url arg",
 			tty:  true,
 			opts: &ForkOptions{


### PR DESCRIPTION
Fixes #2722.

Ensures --remote configuration is applied even when an explicit repo argument is provided, if that argument resolves to the current directory context.

**Validation:**
- Added regression test case in fork_test.go
- Verified 'go test ./pkg/cmd/repo/fork' passes locally.