### PR TITLE
Fix invalid ANSI SGR escape code in JSON and diff colorization

### DIFF
--- a/pkg/cmd/pr/diff/diff.go
+++ b/pkg/cmd/pr/diff/diff.go
@@ -190,7 +190,7 @@ func fetchDiff(httpClient *http.Client, baseRepo ghrepo.Interface, prNumber int,
 const lineBufferSize = 4096
 
 var (
-	colorHeader   = []byte("\x1b[1;38m")
+	colorHeader   = []byte("\x1b[1;37m")
 	colorAddition = []byte("\x1b[32m")
 	colorRemoval  = []byte("\x1b[31m")
 	colorReset    = []byte("\x1b[m")

--- a/pkg/cmd/pr/diff/diff_test.go
+++ b/pkg/cmd/pr/diff/diff_test.go
@@ -179,7 +179,7 @@ func Test_diffRun(t *testing.T) {
 				Patch:       false,
 			},
 			wantFields: []string{"number"},
-			wantStdout: fmt.Sprintf(testDiff, "\x1b[m", "\x1b[1;38m", "\x1b[32m", "\x1b[31m"),
+			wantStdout: fmt.Sprintf(testDiff, "\x1b[m", "\x1b[1;37m", "\x1b[32m", "\x1b[31m"),
 			httpStubs: func(reg *httpmock.Registry) {
 				stubDiffRequest(reg, "application/vnd.github.v3.diff", fmt.Sprintf(testDiff, "", "", "", ""))
 			},
@@ -313,7 +313,7 @@ func Test_colorDiffLines(t *testing.T) {
 				"%[4]s+foo%[2]s\n%[5]s-b%[1]sr%[2]s\n%[3]s+++ baz%[2]s\n",
 				strings.Repeat("a", 2*lineBufferSize),
 				"\x1b[m",
-				"\x1b[1;38m",
+				"\x1b[1;37m",
 				"\x1b[32m",
 				"\x1b[31m",
 			),

--- a/pkg/jsoncolor/jsoncolor.go
+++ b/pkg/jsoncolor/jsoncolor.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	colorDelim  = "1;38" // bright white
+	colorDelim  = "1;37" // bold white
 	colorKey    = "1;34" // bright blue
 	colorNull   = "36"   // cyan
 	colorString = "32"   // green

--- a/pkg/jsoncolor/jsoncolor_test.go
+++ b/pkg/jsoncolor/jsoncolor_test.go
@@ -34,7 +34,7 @@ func TestWrite(t *testing.T) {
 				r:      bytes.NewBufferString(`{}`),
 				indent: "",
 			},
-			wantW:   "\x1b[1;38m{\x1b[m\x1b[1;38m}\x1b[m\n",
+			wantW:   "\x1b[1;37m{\x1b[m\x1b[1;37m}\x1b[m\n",
 			wantErr: false,
 		},
 		{
@@ -43,9 +43,9 @@ func TestWrite(t *testing.T) {
 				r:      bytes.NewBufferString(`{"hash":{"a":1,"b":2},"array":[3,4]}`),
 				indent: "\t",
 			},
-			wantW: "\x1b[1;38m{\x1b[m\n\t\x1b[1;34m\"hash\"\x1b[m\x1b[1;38m:\x1b[m " +
-				"\x1b[1;38m{\x1b[m\n\t\t\x1b[1;34m\"a\"\x1b[m\x1b[1;38m:\x1b[m 1\x1b[1;38m,\x1b[m\n\t\t\x1b[1;34m\"b\"\x1b[m\x1b[1;38m:\x1b[m 2\n\t\x1b[1;38m}\x1b[m\x1b[1;38m,\x1b[m" +
-				"\n\t\x1b[1;34m\"array\"\x1b[m\x1b[1;38m:\x1b[m \x1b[1;38m[\x1b[m\n\t\t3\x1b[1;38m,\x1b[m\n\t\t4\n\t\x1b[1;38m]\x1b[m\n\x1b[1;38m}\x1b[m\n",
+			wantW: "\x1b[1;37m{\x1b[m\n\t\x1b[1;34m\"hash\"\x1b[m\x1b[1;37m:\x1b[m " +
+				"\x1b[1;37m{\x1b[m\n\t\t\x1b[1;34m\"a\"\x1b[m\x1b[1;37m:\x1b[m 1\x1b[1;37m,\x1b[m\n\t\t\x1b[1;34m\"b\"\x1b[m\x1b[1;37m:\x1b[m 2\n\t\x1b[1;37m}\x1b[m\x1b[1;37m,\x1b[m" +
+				"\n\t\x1b[1;34m\"array\"\x1b[m\x1b[1;37m:\x1b[m \x1b[1;37m[\x1b[m\n\t\t3\x1b[1;37m,\x1b[m\n\t\t4\n\t\x1b[1;37m]\x1b[m\n\x1b[1;37m}\x1b[m\n",
 			wantErr: false,
 		},
 		{
@@ -63,7 +63,7 @@ func TestWrite(t *testing.T) {
 				r:      bytes.NewBufferString(`{{`),
 				indent: "",
 			},
-			wantW:   "\x1b[1;38m{\x1b[m\n",
+			wantW:   "\x1b[1;37m{\x1b[m\n",
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
Fix invalid ANSI SGR escape code in JSON and diff colorization

Fixes #12683

## Description

The delimiter/header color constant `1;38` produces an invalid ANSI escape sequence. SGR parameter `38` is the extended foreground color prefix and requires sub-parameters (e.g. `38;5;n` for 256-color or `38;2;r;g;b` for 24-bit). Using it bare with `m` is undefined behavior.

## References

This is specified in:
- [ECMA-48 §8.3.117, p.61 (Select Graphic Rendition)](https://www.ecma-international.org/wp-content/uploads/ECMA-48_5th_edition_june_1991.pdf); parameter 38 requires subsequent parameters to define a color (sub-parameter format delegated to ISO/IEC 8613-6 / ITU T.416)
- [ECMA-48 SGR reference (strasis.com)](https://www.strasis.com/documentation/limelight-xe/reference/ecma-48-sgr-codes); clearly shows `38` requires `5;n` or `2;r;g;b`
- [Wikipedia: ANSI escape code - SGR parameters](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters); documents that `38` must be followed by `;5;n` or `;2;r;g;b`

I guess most terminals silently ignore the malformed `38` and only apply `1` (bold), which is why this went unnoticed since the code was introduced in #1114 (June 2020). The comment `// bright white` alludes to the original intent being a white color; `38` appears to have been a typo for `37`.

## Changes

Replace `1;38` with `1;37` (bold white) in:
- `pkg/jsoncolor/jsoncolor.go`: used for JSON delimiters (`{}[]:,`)
- `pkg/cmd/pr/diff/diff.go`: used for diff headers
