### PR TITLE
browse: disambiguate decimal-only short hash via API

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1562,6 +1562,26 @@ func RepoExists(client *Client, repo ghrepo.Interface) (bool, error) {
 	}
 }
 
+// CommitExists reports whether a commit SHA exists in the given repository.
+func CommitExists(client *Client, repo ghrepo.Interface, sha string) (bool, error) {
+	path := fmt.Sprintf("%srepos/%s/%s/commits/%s",
+		ghinstance.RESTPrefix(repo.RepoHost()),
+		repo.RepoOwner(), repo.RepoName(), sha)
+	resp, err := client.HTTP().Head(path)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case 200:
+		return true, nil
+	case 404, 422:
+		return false, nil
+	default:
+		return false, ghAPI.HandleHTTPError(resp)
+	}
+}
+
 // RepoLicenses fetches available repository licenses.
 // It uses API v3 because licenses are not supported by GraphQL.
 func RepoLicenses(httpClient *http.Client, hostname string) ([]License, error) {

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -241,6 +241,22 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 			return "", nil
 		}
 		if isNumber(opts.SelectorArg) {
+			if isCommit(opts.SelectorArg) {
+				// The argument is both a valid issue/PR number and a valid commit SHA
+				// (all decimal digits, 7+ chars). Query the API to disambiguate.
+				httpClient, err := opts.HttpClient()
+				if err != nil {
+					return "", err
+				}
+				apiClient := api.NewClientFromHTTP(httpClient)
+				exists, err := api.CommitExists(apiClient, baseRepo, opts.SelectorArg)
+				if err != nil {
+					return "", err
+				}
+				if exists {
+					return fmt.Sprintf("commit/%s", opts.SelectorArg), nil
+				}
+			}
 			return fmt.Sprintf("issues/%s", strings.TrimPrefix(opts.SelectorArg, "#")), nil
 		}
 		if isCommit(opts.SelectorArg) {

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -584,6 +584,36 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL: "https://github.com/bchadwic/test/commit/6e3689d5",
 			wantsErr:    false,
 		},
+		{
+			name: "decimal-only selector arg that is an existing commit",
+			opts: BrowseOptions{
+				SelectorArg: "1234567",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("HEAD", "repos/bchadwic/test/commits/1234567"),
+					httpmock.StatusStringResponse(200, ""),
+				)
+			},
+			baseRepo:    ghrepo.New("bchadwic", "test"),
+			expectedURL: "https://github.com/bchadwic/test/commit/1234567",
+			wantsErr:    false,
+		},
+		{
+			name: "decimal-only selector arg that is not an existing commit",
+			opts: BrowseOptions{
+				SelectorArg: "1234567",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("HEAD", "repos/bchadwic/test/commits/1234567"),
+					httpmock.StatusStringResponse(404, ""),
+				)
+			},
+			baseRepo:    ghrepo.New("bchadwic", "test"),
+			expectedURL: "https://github.com/bchadwic/test/issues/1234567",
+			wantsErr:    false,
+		},
 
 		{
 			name: "commit hash with extension",


### PR DESCRIPTION
Fixes #12357

## What changed

When a selector argument passed to `gh browse` consists entirely of decimal digits (0–9) and is at least 7 characters long, it satisfies **both** `isNumber` and `isCommit`. The previous code always prioritised `isNumber`, so `gh browse 309628980` would silently open an issues URL even when that string referred to an actual git commit SHA.

This PR resolves the ambiguity by making a `HEAD` request to the GitHub Commits API whenever both conditions are true. If the SHA resolves to a real commit, the commit URL is returned; otherwise the code falls back to the issues URL — no change in behaviour for unambiguous inputs.

### Files changed

| File | Change |
|---|---|
| `api/queries_repo.go` | Add `CommitExists` helper (mirrors existing `RepoExists`) |
| `pkg/cmd/browse/browse.go` | Call `CommitExists` when selector is ambiguous |
| `pkg/cmd/browse/browse_test.go` | Two new table-driven cases for the ambiguous path |

## Validation

Static analysis only (per project policy — no host execution of build commands).

- Traced the full call path through `runBrowse` → `parseSection` → `isNumber` / `isCommit`.  
- Verified existing tests are unaffected: short inputs like `"217"` (3 digits) still fail `isCommit` (requires 7+ chars) and never hit the API.  
- Inputs containing non-decimal hex chars (e.g. `6e3689d5`) still fail `isNumber` and go directly to the `isCommit` branch.  
- New test cases mock the HEAD endpoint for `repos/{owner}/{repo}/commits/{sha}` with 200 and 404 and assert the correct URL is produced.

## Security impact

No new permissions, network calls beyond the existing `opts.HttpClient`, or secret handling changes.

## Rollback

`git revert 3ddbcd490` — single commit, three files, clean revert.