### PR TITLE
Fix typo: remove extra space in README.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GitHub CLI is supported for users on GitHub.com, GitHub Enterprise Cloud, and Gi
 
 ## Documentation
 
-For [installation options see below](#installation), for usage instructions [see the manual]( https://cli.github.com/manual/).
+For [installation options see below](#installation), for usage instructions [see the manual](https://cli.github.com/manual/).
 
 ## Contributing
 


### PR DESCRIPTION
Fixed a small typo in README.md - removed an extra space before the URL in the manual link.

Before: `[see the manual]( https://cli.github.com/manual/)`
After: `[see the manual](https://cli.github.com/manual/)`