### PR TITLE
feat(pr create): add --json and --jq flags for structured output

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -560,7 +560,15 @@ func CreatePullRequest(client *Client, repo *Repository, params map[string]inter
 			createPullRequest(input: $input) {
 				pullRequest {
 					id
+					number
 					url
+					headRefName
+					baseRefName
+					isDraft
+					title
+					body
+					state
+					createdAt
 				}
 			}
 	}`

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -72,7 +72,21 @@ type CreateOptions struct {
 	MaintainerCanModify bool
 	Template            string
 
-	DryRun bool
+	DryRun   bool
+	Exporter cmdutil.Exporter
+}
+
+var prCreateFields = []string{
+	"id",
+	"number",
+	"url",
+	"headRefName",
+	"baseRefName",
+	"isDraft",
+	"title",
+	"body",
+	"state",
+	"createdAt",
 }
 
 // creationRefs is an interface that provides the necessary information for creating a pull request in the API.
@@ -330,6 +344,10 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("`--dry-run` is not supported when using `--web`")
 			}
 
+			if opts.DryRun && opts.Exporter != nil {
+				return cmdutil.FlagErrorf("`--dry-run` is not supported with `--json`")
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -358,6 +376,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	fl.StringVar(&opts.RecoverFile, "recover", "", "Recover input from a failed run of create")
 	fl.StringVarP(&opts.Template, "template", "T", "", "Template `file` to use as starting body text")
 	fl.BoolVar(&opts.DryRun, "dry-run", false, "Print details instead of creating the PR. May still push git changes.")
+	cmdutil.AddJSONFlagsWithoutTemplate(cmd, &opts.Exporter, prCreateFields)
 
 	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "base", "head")
 
@@ -1031,7 +1050,7 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 	opts.IO.StartProgressIndicator()
 	pr, err := api.CreatePullRequest(client, ctx.PRRefs.BaseRepo(), params)
 	opts.IO.StopProgressIndicator()
-	if pr != nil {
+	if pr != nil && opts.Exporter == nil {
 		fmt.Fprintln(opts.IO.Out, pr.URL)
 	}
 	if err != nil {
@@ -1039,6 +1058,9 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 			return fmt.Errorf("pull request update failed: %w", err)
 		}
 		return fmt.Errorf("pull request create failed: %w", err)
+	}
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, pr)
 	}
 	return nil
 }

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -204,6 +204,12 @@ func TestNewCmdCreate(t *testing.T) {
 			wantsErr: true,
 		},
 		{
+			name:     "dry-run and json",
+			tty:      false,
+			cli:      "--title mytitle --body '' --dry-run --json id",
+			wantsErr: true,
+		},
+		{
 			name:     "editor by cli",
 			tty:      true,
 			cli:      "--editor",
@@ -383,6 +389,84 @@ func Test_createRun(t *testing.T) {
 				return func() {}
 			},
 			expectedOut: "https://github.com/OWNER/REPO/pull/12\n",
+		},
+		{
+			name: "nontty-json",
+			tty:  false,
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "createPullRequest": { "pullRequest": {
+							"ID": "PR_kwDOA",
+							"Number": 12,
+							"URL": "https://github.com/OWNER/REPO/pull/12",
+							"HeadRefName": "feature",
+							"BaseRefName": "master",
+							"IsDraft": false,
+							"Title": "my title",
+							"Body": "my body",
+							"State": "OPEN",
+							"CreatedAt": "2025-01-01T00:00:00Z"
+						} } } }`,
+						func(input map[string]interface{}) {
+							assert.Equal(t, "REPOID", input["repositoryId"])
+							assert.Equal(t, "my title", input["title"])
+							assert.Equal(t, "my body", input["body"])
+							assert.Equal(t, "master", input["baseRefName"])
+							assert.Equal(t, "feature", input["headRefName"])
+						}))
+			},
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.TitleProvided = true
+				opts.BodyProvided = true
+				opts.Title = "my title"
+				opts.Body = "my body"
+				opts.HeadBranch = "feature"
+				exporter := cmdutil.NewJSONExporter()
+				exporter.SetFields([]string{"id", "url", "number"})
+				opts.Exporter = exporter
+				return func() {}
+			},
+			expectedOut: "{\"id\":\"PR_kwDOA\",\"number\":12,\"url\":\"https://github.com/OWNER/REPO/pull/12\"}\n",
+		},
+		{
+			name: "nontty-json-all-fields",
+			tty:  false,
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.GraphQLMutation(`
+						{ "data": { "createPullRequest": { "pullRequest": {
+							"ID": "PR_kwDOA",
+							"Number": 12,
+							"URL": "https://github.com/OWNER/REPO/pull/12",
+							"HeadRefName": "feature",
+							"BaseRefName": "master",
+							"IsDraft": true,
+							"Title": "my title",
+							"Body": "my body",
+							"State": "OPEN",
+							"CreatedAt": "2025-01-01T00:00:00Z"
+						} } } }`,
+						func(input map[string]interface{}) {
+							assert.Equal(t, "REPOID", input["repositoryId"])
+							assert.Equal(t, true, input["draft"])
+						}))
+			},
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.TitleProvided = true
+				opts.BodyProvided = true
+				opts.Title = "my title"
+				opts.Body = "my body"
+				opts.HeadBranch = "feature"
+				opts.IsDraft = true
+				exporter := cmdutil.NewJSONExporter()
+				exporter.SetFields([]string{"id", "url", "number", "headRefName", "baseRefName", "isDraft", "title", "state"})
+				opts.Exporter = exporter
+				return func() {}
+			},
+			expectedOut: "{\"baseRefName\":\"master\",\"headRefName\":\"feature\",\"id\":\"PR_kwDOA\",\"isDraft\":true,\"number\":12,\"state\":\"OPEN\",\"title\":\"my title\",\"url\":\"https://github.com/OWNER/REPO/pull/12\"}\n",
 		},
 		{
 			name: "same head and base branch should error",

--- a/pkg/cmdutil/json_flags.go
+++ b/pkg/cmdutil/json_flags.go
@@ -41,6 +41,103 @@ func AddJSONFlagsWithoutShorthand(cmd *cobra.Command, exportTarget *Exporter, fi
 	setupJsonFlags(cmd, exportTarget, fields)
 }
 
+// AddJSONFlagsWithoutTemplate registers --json and --jq without --template,
+// for use by commands that already define their own --template flag.
+func AddJSONFlagsWithoutTemplate(cmd *cobra.Command, exportTarget *Exporter, fields []string) {
+	f := cmd.Flags()
+	addJsonFlag(f)
+	addJqFlag(f, "")
+
+	setupJSONFlagsWithoutTemplate(cmd, exportTarget, fields)
+}
+
+func setupJSONFlagsWithoutTemplate(cmd *cobra.Command, exportTarget *Exporter, fields []string) {
+	_ = cmd.RegisterFlagCompletionFunc("json", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		var results []string
+		var prefix string
+		if idx := strings.LastIndexByte(toComplete, ','); idx >= 0 {
+			prefix = toComplete[:idx+1]
+			toComplete = toComplete[idx+1:]
+		}
+		toComplete = strings.ToLower(toComplete)
+		for _, f := range fields {
+			if strings.HasPrefix(strings.ToLower(f), toComplete) {
+				results = append(results, prefix+f)
+			}
+		}
+		sort.Strings(results)
+		return results, cobra.ShellCompDirectiveNoSpace
+	})
+
+	oldPreRun := cmd.PreRunE
+	cmd.PreRunE = func(c *cobra.Command, args []string) error {
+		if oldPreRun != nil {
+			if err := oldPreRun(c, args); err != nil {
+				return err
+			}
+		}
+		if export, err := checkJSONFlagsWithoutTemplate(c); err == nil {
+			if export == nil {
+				*exportTarget = nil
+			} else {
+				allowedFields := set.NewStringSet()
+				allowedFields.AddValues(fields)
+				for _, f := range export.fields {
+					if !allowedFields.Contains(f) {
+						sort.Strings(fields)
+						return JSONFlagError{fmt.Errorf("Unknown JSON field: %q\nAvailable fields:\n  %s", f, strings.Join(fields, "\n  "))}
+					}
+				}
+				*exportTarget = export
+			}
+		} else {
+			return err
+		}
+		return nil
+	}
+
+	cmd.SetFlagErrorFunc(func(c *cobra.Command, e error) error {
+		if c == cmd && e.Error() == "flag needs an argument: --json" {
+			sort.Strings(fields)
+			return JSONFlagError{fmt.Errorf("Specify one or more comma-separated fields for `--json`:\n  %s", strings.Join(fields, "\n  "))}
+		}
+		if cmd.HasParent() {
+			return cmd.Parent().FlagErrorFunc()(c, e)
+		}
+		return e
+	})
+
+	if len(fields) == 0 {
+		return
+	}
+
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations["help:json-fields"] = strings.Join(fields, ",")
+}
+
+func checkJSONFlagsWithoutTemplate(cmd *cobra.Command) (*jsonExporter, error) {
+	f := cmd.Flags()
+	jsonFlag := f.Lookup("json")
+	jqFlag := f.Lookup("jq")
+	webFlag := f.Lookup("web")
+
+	if jsonFlag.Changed {
+		if webFlag != nil && webFlag.Changed {
+			return nil, errors.New("cannot use `--web` with `--json`")
+		}
+		jv := jsonFlag.Value.(pflag.SliceValue)
+		return &jsonExporter{
+			fields: jv.GetSlice(),
+			filter: jqFlag.Value.String(),
+		}, nil
+	} else if jqFlag.Changed {
+		return nil, errors.New("cannot use `--jq` without specifying `--json`")
+	}
+	return nil, nil
+}
+
 func addJsonFlag(f *pflag.FlagSet) {
 	f.StringSlice("json", nil, "Output JSON with the specified `fields`")
 }


### PR DESCRIPTION
Closes #11247

## What

Adds `--json` and `--jq` flags to `gh pr create`, enabling scripts to extract PR metadata without parsing human-readable output.

### Before
```bash
PR_URL=$(gh pr create --title "My PR" --body "..." | tail -n1)
PR_NUMBER=$(basename "$PR_URL")
```

### After
```bash
PR_NUMBER=$(gh pr create --title "My PR" --body "..." --json number --jq '.number')
```

## Available fields

`id`, `number`, `url`, `headRefName`, `baseRefName`, `isDraft`, `title`, `body`, `state`, `createdAt`

## Implementation notes

- Uses `AddJSONFlagsWithoutTemplate` — a new helper that registers `--json` and `--jq` without `--template`, since `pr create` already defines its own `--template` flag for PR body templates.
- The GraphQL mutation now fetches all the fields listed above so they're available in the JSON output.
- `--json` is incompatible with `--dry-run` and `--web` (returns clear errors).

## Tests

- Flag validation: `--dry-run --json` returns error
- JSON output with subset of fields (`id`, `url`, `number`)
- JSON output with all available fields including `isDraft`, `headRefName`, etc.
- All existing tests continue to pass