### PR TITLE
fix(agent-task/capi): use a fixed CAPI API version

### DIFF
--- a/pkg/cmd/agent-task/capi/client.go
+++ b/pkg/cmd/agent-task/capi/client.go
@@ -62,6 +62,9 @@ func (ct *capiTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// ID only when performing requests to the Copilot API.
 	if req.URL.Host == capiHost {
 		req.Header.Add("Copilot-Integration-Id", "copilot-4-cli")
+
+		// This is quick fix to ensure that we are not using GitHub API versions while targeting CAPI.
+		req.Header.Set("X-GitHub-Api-Version", "2026-01-09")
 	}
 	return ct.rp.RoundTrip(req)
 }


### PR DESCRIPTION
Fixes #12729 
Fixes #12730