### PR TITLE
gh pr checkout: prefix branch name for fork PRs

### DIFF
--- a/acceptance/testdata/pr/pr-checkout-with-url-from-fork.txtar
+++ b/acceptance/testdata/pr/pr-checkout-with-url-from-fork.txtar
@@ -35,4 +35,4 @@ stdout2env PR_URL
 # Checkout the PR by full URL in the upstream repo
 cd ${WORK}/${REPO}
 exec gh pr checkout ${PR_URL}
-stderr 'Switched to branch ''feature-branch'''
+stderr 'Switched to a new branch ''${ORG}/feature-branch'''

--- a/pkg/cmd/pr/checkout/checkout.go
+++ b/pkg/cmd/pr/checkout/checkout.go
@@ -181,6 +181,8 @@ func cmdsForExistingRemote(remote *cliContext.Remote, pr *api.PullRequest, opts 
 	localBranch := pr.HeadRefName
 	if opts.BranchName != "" {
 		localBranch = opts.BranchName
+	} else if pr.IsCrossRepository {
+		localBranch = fmt.Sprintf("%s/%s", remote.Name, pr.HeadRefName)
 	}
 
 	switch {
@@ -214,6 +216,8 @@ func cmdsForMissingRemote(pr *api.PullRequest, baseURLOrName, repoHost, defaultB
 	localBranch := pr.HeadRefName
 	if opts.BranchName != "" {
 		localBranch = opts.BranchName
+	} else if pr.IsCrossRepository && pr.HeadRepositoryOwner.Login != "" {
+		localBranch = fmt.Sprintf("%s/%s", pr.HeadRepositoryOwner.Login, pr.HeadRefName)
 	} else if pr.HeadRefName == defaultBranch {
 		// avoid naming the new branch the same as the default branch
 		localBranch = fmt.Sprintf("%s/%s", pr.HeadRepositoryOwner.Login, localBranch)

--- a/pkg/cmd/pr/checkout/checkout_test.go
+++ b/pkg/cmd/pr/checkout/checkout_test.go
@@ -294,6 +294,33 @@ func Test_checkoutRun(t *testing.T) {
 			},
 		},
 		{
+			name: "fork with existing remote uses prefixed branch name",
+			opts: &CheckoutOptions{
+				PRResolver: func() PRResolver {
+					baseRepo, pr := stubPR("OWNER/REPO:master", "hubot/REPO:feature")
+					return &stubPRResolver{
+						pr:       pr,
+						baseRepo: baseRepo,
+					}
+				}(),
+				Config: func() (gh.Config, error) {
+					return config.NewBlankConfig(), nil
+				},
+				Branch: func() (string, error) {
+					return "main", nil
+				},
+			},
+			remotes: map[string]string{
+				"origin":     "OWNER/REPO",
+				"robot-fork": "hubot/REPO",
+			},
+			runStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git fetch robot-fork \+refs/heads/feature:refs/remotes/robot-fork/feature --no-tags`, 0, "")
+				cs.Register(`git show-ref --verify -- refs/heads/robot-fork/feature`, 1, "")
+				cs.Register(`git checkout -b robot-fork/feature --track robot-fork/feature`, 0, "")
+			},
+		},
+		{
 			name: "when the PR resolver errors, then that error is bubbled up",
 			opts: &CheckoutOptions{
 				PRResolver: &stubPRResolver{
@@ -576,8 +603,8 @@ func TestPRCheckout_differentRepo_remoteExists(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 	cs.Register(`git fetch robot-fork \+refs/heads/feature:refs/remotes/robot-fork/feature --no-tags`, 0, "")
-	cs.Register(`git show-ref --verify -- refs/heads/feature`, 1, "")
-	cs.Register(`git checkout -b feature --track robot-fork/feature`, 0, "")
+	cs.Register(`git show-ref --verify -- refs/heads/robot-fork/feature`, 1, "")
+	cs.Register(`git checkout -b robot-fork/feature --track robot-fork/feature`, 0, "")
 
 	output, err := runCommand(http, remotes, "master", `123`, baseRepo)
 	assert.NoError(t, err)
@@ -595,12 +622,12 @@ func TestPRCheckout_differentRepo(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin refs/pull/123/head:feature --no-tags`, 0, "")
-	cs.Register(`git config branch\.feature\.merge`, 1, "")
-	cs.Register(`git checkout feature`, 0, "")
-	cs.Register(`git config branch\.feature\.remote origin`, 0, "")
-	cs.Register(`git config branch\.feature\.pushRemote origin`, 0, "")
-	cs.Register(`git config branch\.feature\.merge refs/pull/123/head`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:hubot/feature --no-tags`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.merge`, 1, "")
+	cs.Register(`git checkout hubot/feature`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.remote origin`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.pushRemote origin`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.merge refs/pull/123/head`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`, baseRepo)
 	assert.NoError(t, err)
@@ -618,12 +645,12 @@ func TestPRCheckout_differentRepoForce(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin refs/pull/123/head:feature --no-tags --force`, 0, "")
-	cs.Register(`git config branch\.feature\.merge`, 1, "")
-	cs.Register(`git checkout feature`, 0, "")
-	cs.Register(`git config branch\.feature\.remote origin`, 0, "")
-	cs.Register(`git config branch\.feature\.pushRemote origin`, 0, "")
-	cs.Register(`git config branch\.feature\.merge refs/pull/123/head`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:hubot/feature --no-tags --force`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.merge`, 1, "")
+	cs.Register(`git checkout hubot/feature`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.remote origin`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.pushRemote origin`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.merge refs/pull/123/head`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123 --force`, baseRepo)
 	assert.NoError(t, err)
@@ -640,9 +667,9 @@ func TestPRCheckout_differentRepo_existingBranch(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin refs/pull/123/head:feature --no-tags`, 0, "")
-	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
-	cs.Register(`git checkout feature`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:hubot/feature --no-tags`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.merge`, 0, "refs/heads/feature\n")
+	cs.Register(`git checkout hubot/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`, baseRepo)
 	assert.NoError(t, err)
@@ -659,9 +686,12 @@ func TestPRCheckout_detachedHead(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin refs/pull/123/head:feature --no-tags`, 0, "")
-	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
-	cs.Register(`git checkout feature`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:hubot/feature --no-tags`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.merge`, 1, "")
+	cs.Register(`git checkout hubot/feature`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.remote origin`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.pushRemote origin`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.merge refs/pull/123/head`, 0, "")
 
 	output, err := runCommand(http, nil, "", `123`, baseRepo)
 	assert.NoError(t, err)
@@ -679,10 +709,10 @@ func TestPRCheckout_differentRepo_currentBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 	cs.Register(`git fetch origin refs/pull/123/head --no-tags`, 0, "")
-	cs.Register(`git config branch\.feature\.merge`, 0, "refs/heads/feature\n")
+	cs.Register(`git config branch\.hubot/feature\.merge`, 0, "refs/heads/feature\n")
 	cs.Register(`git merge --ff-only FETCH_HEAD`, 0, "")
 
-	output, err := runCommand(http, nil, "feature", `123`, baseRepo)
+	output, err := runCommand(http, nil, "hubot/feature", `123`, baseRepo)
 	assert.NoError(t, err)
 	assert.Equal(t, "", output.String())
 	assert.Equal(t, "", output.Stderr())
@@ -715,12 +745,12 @@ func TestPRCheckout_maintainerCanModify(t *testing.T) {
 
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
-	cs.Register(`git fetch origin refs/pull/123/head:feature --no-tags`, 0, "")
-	cs.Register(`git config branch\.feature\.merge`, 1, "")
-	cs.Register(`git checkout feature`, 0, "")
-	cs.Register(`git config branch\.feature\.remote https://github\.com/hubot/REPO\.git`, 0, "")
-	cs.Register(`git config branch\.feature\.pushRemote https://github\.com/hubot/REPO\.git`, 0, "")
-	cs.Register(`git config branch\.feature\.merge refs/heads/feature`, 0, "")
+	cs.Register(`git fetch origin refs/pull/123/head:hubot/feature --no-tags`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.merge`, 1, "")
+	cs.Register(`git checkout hubot/feature`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.remote https://github\.com/hubot/REPO\.git`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.pushRemote https://github\.com/hubot/REPO\.git`, 0, "")
+	cs.Register(`git config branch\.hubot/feature\.merge refs/heads/feature`, 0, "")
 
 	output, err := runCommand(http, nil, "master", `123`, baseRepo)
 	assert.NoError(t, err)


### PR DESCRIPTION
When checking out a PR from a fork, prefix the local branch name to avoid collisions. Use the remote name if the fork remote exists locally (e.g., robot-fork/feature), otherwise use the fork owner (e.g., hubot/feature). Same-repo PRs keep the branch name unchanged.

Fixes #866

----

### AI Summary

This pull request improves the handling of branch names when checking out pull requests from forks or cross-repository PRs. The main change is that local branch names are now prefixed with the fork owner's name or remote name, which helps avoid conflicts and makes branch origins clearer. The test suite has been updated to reflect this new naming convention and ensure correct behavior.

Branch naming improvements for cross-repository PRs:

* Changed logic in `cmdsForExistingRemote` and `cmdsForMissingRemote` in `checkout.go` so that when checking out a PR from a fork, the local branch name is now prefixed with the remote or fork owner's name (e.g., `robot-fork/feature` or `hubot/feature`) instead of just `feature`. [[1]](diffhunk://#diff-b5ec653aa1e550e4c5f2df8ad7fc22dfbaedf71270cb5a328d7327f2a8093d66R184-R185) [[2]](diffhunk://#diff-b5ec653aa1e550e4c5f2df8ad7fc22dfbaedf71270cb5a328d7327f2a8093d66R219-R220)
* Updated the error message in `pr-checkout-with-url-from-fork.txtar` to reflect the new branch naming convention when checking out a PR from a fork.

Test suite updates:

* Added and modified tests in `checkout_test.go` to validate the new branch naming logic, including scenarios with existing remotes, force checkout, detached head, current branch, maintainer modification, and existing branches, ensuring that all relevant git commands use the prefixed branch name. [[1]](diffhunk://#diff-07163dfcfd41075bfab5e342655c4088e1fec667cc2e51d04e1185df58c454ffR296-R322) [[2]](diffhunk://#diff-07163dfcfd41075bfab5e342655c4088e1fec667cc2e51d04e1185df58c454ffL579-R607) [[3]](diffhunk://#diff-07163dfcfd41075bfab5e342655c4088e1fec667cc2e51d04e1185df58c454ffL598-R630) [[4]](diffhunk://#diff-07163dfcfd41075bfab5e342655c4088e1fec667cc2e51d04e1185df58c454ffL621-R653) [[5]](diffhunk://#diff-07163dfcfd41075bfab5e342655c4088e1fec667cc2e51d04e1185df58c454ffL643-R672) [[6]](diffhunk://#diff-07163dfcfd41075bfab5e342655c4088e1fec667cc2e51d04e1185df58c454ffL662-R694) [[7]](diffhunk://#diff-07163dfcfd41075bfab5e342655c4088e1fec667cc2e51d04e1185df58c454ffL682-R715) [[8]](diffhunk://#diff-07163dfcfd41075bfab5e342655c4088e1fec667cc2e51d04e1185df58c454ffL718-R753)