### PR TITLE
Sort artifacts by creation time to download latest from reruns

### DIFF
--- a/pkg/cmd/run/download/download.go
+++ b/pkg/cmd/run/download/download.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sort"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/safepaths"
@@ -152,6 +153,12 @@ func runDownload(opts *DownloadOptions) error {
 
 	opts.IO.StartProgressIndicator()
 	defer opts.IO.StopProgressIndicator()
+
+	// Sort artifacts by creation time descending so that when we deduplicate
+	// by name below, we keep the most recent artifact (e.g. from a rerun).
+	sort.Slice(artifacts, func(i, j int) bool {
+		return artifacts[i].CreatedAt.After(artifacts[j].CreatedAt)
+	})
 
 	// track downloaded artifacts and avoid re-downloading any of the same name, isolate if multiple artifacts
 	downloaded := set.NewStringSet()

--- a/pkg/cmd/run/shared/artifacts.go
+++ b/pkg/cmd/run/shared/artifacts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghinstance"
@@ -12,10 +13,11 @@ import (
 )
 
 type Artifact struct {
-	Name        string `json:"name"`
-	Size        uint64 `json:"size_in_bytes"`
-	DownloadURL string `json:"archive_download_url"`
-	Expired     bool   `json:"expired"`
+	Name        string    `json:"name"`
+	Size        uint64    `json:"size_in_bytes"`
+	DownloadURL string    `json:"archive_download_url"`
+	Expired     bool      `json:"expired"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 type artifactsPayload struct {


### PR DESCRIPTION
When a workflow is rerun, GitHub creates new artifacts with the same name but newer timestamps. Right now `gh run download` just grabs whichever artifact comes first from the API (the oldest one), because it deduplicates by name and the API returns artifacts in creation order.

This sorts the artifact list by `created_at` descending before iterating, so the dedup check (`downloaded.Contains`) naturally keeps the most recent version of each artifact name.

**Changes:**
- Added `CreatedAt` field to `Artifact` struct (it was already in the API response, just not being parsed)
- Sort artifacts by `CreatedAt` descending before the download loop

All existing tests pass.

Fixes #12437