### PR TITLE
Add databaseId to assignees GraphQL fragment

### DIFF
--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -108,6 +108,32 @@ func TestIssue_ExportData(t *testing.T) {
 			`),
 		},
 		{
+			name:   "assignees",
+			fields: []string{"assignees"},
+			inputJSON: heredoc.Doc(`
+				{ "assignees": { "nodes": [
+					{
+						"id": "MDQ6VXNlcjE=",
+						"login": "monalisa",
+						"name": "Mona Lisa",
+						"databaseId": 1234
+					}
+				] } }
+			`),
+			outputJSON: heredoc.Doc(`
+				{
+					"assignees": [
+						{
+							"id": "MDQ6VXNlcjE=",
+							"login": "monalisa",
+							"name": "Mona Lisa",
+							"databaseId": 1234
+						}
+					]
+				}
+			`),
+		},
+		{
 			name:   "linked pull requests",
 			fields: []string{"closedByPullRequestsReferences"},
 			inputJSON: heredoc.Doc(`
@@ -311,6 +337,32 @@ func TestPullRequest_ExportData(t *testing.T) {
 								"name": "Todo"
 							},
 							"title": "Some Project"
+						}
+					]
+				}
+			`),
+		},
+		{
+			name:   "assignees",
+			fields: []string{"assignees"},
+			inputJSON: heredoc.Doc(`
+				{ "assignees": { "nodes": [
+					{
+						"id": "MDQ6VXNlcjE=",
+						"login": "monalisa",
+						"name": "Mona Lisa",
+						"databaseId": 1234
+					}
+				] } }
+			`),
+			outputJSON: heredoc.Doc(`
+				{
+					"assignees": [
+						{
+							"id": "MDQ6VXNlcjE=",
+							"login": "monalisa",
+							"name": "Mona Lisa",
+							"databaseId": 1234
 						}
 					]
 				}

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -388,7 +388,7 @@ func IssueGraphQL(fields []string) string {
 		case "headRepository":
 			q = append(q, `headRepository{id,name}`)
 		case "assignees":
-			q = append(q, `assignees(first:100){nodes{id,login,name},totalCount}`)
+			q = append(q, `assignees(first:100){nodes{id,login,name,databaseId},totalCount}`)
 		case "assignedActors":
 			q = append(q, assignedActors)
 		case "labels":

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -21,7 +21,7 @@ func TestPullRequestGraphQL(t *testing.T) {
 		{
 			name:   "fields with nested structures",
 			fields: []string{"author", "assignees"},
-			want:   "author{login,...on User{id,name}},assignees(first:100){nodes{id,login,name},totalCount}",
+			want:   "author{login,...on User{id,name}},assignees(first:100){nodes{id,login,name,databaseId},totalCount}",
 		},
 		{
 			name:   "compressed query",
@@ -67,7 +67,7 @@ func TestIssueGraphQL(t *testing.T) {
 		{
 			name:   "fields with nested structures",
 			fields: []string{"author", "assignees"},
-			want:   "author{login,...on User{id,name}},assignees(first:100){nodes{id,login,name},totalCount}",
+			want:   "author{login,...on User{id,name}},assignees(first:100){nodes{id,login,name,databaseId},totalCount}",
 		},
 		{
 			name:   "compressed query",


### PR DESCRIPTION
## Summary

- Fixes `databaseId` always being `0` for assignees in `--json` output (e.g. `gh issue view --json assignees`)
- The `GitHubUser` struct already has a `DatabaseID` field, but the GraphQL query fragment for assignees never requested `databaseId` from the API, so it always defaulted to Go's zero value

## Details

The assignees fragment in `query_builder.go` requested only `id`, `login`, and `name`:

```graphql
assignees(first:100){nodes{id,login,name},totalCount}
```

This meant the `DatabaseID int64` field on `GitHubUser` was never populated, producing `"databaseId": 0` in JSON output. The fix adds `databaseId` to the fragment:

```graphql
assignees(first:100){nodes{id,login,name,databaseId},totalCount}
```

`PullRequestGraphQL` delegates to `IssueGraphQL`, so both issue and PR queries are fixed by this single change.

## Behavioral note

This is an additive change to `--json assignees` output — `databaseId` will now contain the real value instead of `0`. This is not breaking for JSON consumers, but downstream scripts doing strict schema validation may notice the corrected field.

## Testing

- Updated query builder tests in `query_builder_test.go` for both `TestPullRequestGraphQL` and `TestIssueGraphQL` to expect the new field in the query string
- Added `ExportData` round-trip test cases in `export_pr_test.go` for both `TestIssue_ExportData` and `TestPullRequest_ExportData` that verify a non-zero `databaseId` (1234) survives JSON serialization