### PR TITLE
Fix dnf config-manager command for repo addition

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -55,7 +55,7 @@ To install:
 
 ```bash
 sudo dnf install dnf5-plugins
-sudo dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
+sudo dnf config-manager addrepo --add-repo=https://cli.github.com/packages/rpm/gh-cli.repo
 sudo dnf install gh --repo gh-cli
 ```
 


### PR DESCRIPTION
Corrected outdated dnf flag
`--from-repofile` -> `--add-repo`