### PR TITLE
Add regression test for required scopes parsing

### DIFF
--- a/pkg/cmd/project/shared/queries/queries_test.go
+++ b/pkg/cmd/project/shared/queries/queries_test.go
@@ -585,6 +585,11 @@ func Test_requiredScopesFromServerMessage(t *testing.T) {
 			msg:  "Your token has not been granted the required scopes to execute this query. The 'dataType' field requires one of the following scopes: ['read:project', 'read:discussion', 'codespace'], but your token has only been granted the: [repo'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens.",
 			want: []string{"read:project", "read:discussion", "codespace"},
 		},
+		{
+			name: "project scope required for addProjectV2ItemById",
+			msg: "Your token has not been granted the required scopes to execute this query. The 'addProjectV2ItemById' field requires one of the following scopes: ['project'], but your token has only been granted the: ['gist', 'read:org', 'read:project', 'repo', 'workflow'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens.",
+			want: []string{"project"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #12585

### What this PR does
Adds a regression test for requiredScopesFromServerMessage to cover the GraphQL error message reported in #12585 (addProjectV2ItemById -> ['project']).

### Why
The current behavior depends on parsing the server error message text. This test locks in the expected scope extraction for this specific message so future refactors or upstream wording changes don't silently regress scope detection.

### How to verify
go test -count=1 ./pkg/cmd/project/shared/queries -run Test_requiredScopesFromServerMessage