### PR TITLE
Add --json support to `gh agent-task list`

### DIFF
--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -106,12 +106,16 @@ type SessionError struct {
 var SessionFields = []string{
 	"id",
 	"name",
-	"status",
+	"state",
 	"repository",
+	"user",
 	"createdAt",
 	"updatedAt",
+	"completedAt",
 	"pullRequestNumber",
 	"pullRequestUrl",
+	"pullRequestTitle",
+	"pullRequestState",
 }
 
 // ExportData implements the exportable interface for JSON output.
@@ -123,7 +127,7 @@ func (s *Session) ExportData(fields []string) map[string]interface{} {
 			data[f] = s.ID
 		case "name":
 			data[f] = s.Name
-		case "status":
+		case "state":
 			data[f] = s.State
 		case "repository":
 			if s.PullRequest != nil && s.PullRequest.Repository != nil {
@@ -131,10 +135,22 @@ func (s *Session) ExportData(fields []string) map[string]interface{} {
 			} else {
 				data[f] = nil
 			}
+		case "user":
+			if s.User != nil {
+				data[f] = s.User.Login
+			} else {
+				data[f] = nil
+			}
 		case "createdAt":
 			data[f] = s.CreatedAt
 		case "updatedAt":
 			data[f] = s.LastUpdatedAt
+		case "completedAt":
+			if s.CompletedAt.IsZero() {
+				data[f] = nil
+			} else {
+				data[f] = s.CompletedAt
+			}
 		case "pullRequestNumber":
 			if s.PullRequest != nil {
 				data[f] = s.PullRequest.Number
@@ -144,6 +160,18 @@ func (s *Session) ExportData(fields []string) map[string]interface{} {
 		case "pullRequestUrl":
 			if s.PullRequest != nil {
 				data[f] = s.PullRequest.URL
+			} else {
+				data[f] = nil
+			}
+		case "pullRequestTitle":
+			if s.PullRequest != nil {
+				data[f] = s.PullRequest.Title
+			} else {
+				data[f] = nil
+			}
+		case "pullRequestState":
+			if s.PullRequest != nil {
+				data[f] = s.PullRequest.State
 			} else {
 				data[f] = nil
 			}

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -142,9 +142,17 @@ func (s *Session) ExportData(fields []string) map[string]interface{} {
 				data[f] = nil
 			}
 		case "createdAt":
-			data[f] = s.CreatedAt
+			if s.CreatedAt.IsZero() {
+				data[f] = nil
+			} else {
+				data[f] = s.CreatedAt
+			}
 		case "updatedAt":
-			data[f] = s.LastUpdatedAt
+			if s.LastUpdatedAt.IsZero() {
+				data[f] = nil
+			} else {
+				data[f] = s.LastUpdatedAt
+			}
 		case "completedAt":
 			if s.CompletedAt.IsZero() {
 				data[f] = nil

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -102,6 +102,58 @@ type SessionError struct {
 	Message string
 }
 
+// SessionFields defines the available fields for JSON export of a Session.
+var SessionFields = []string{
+	"id",
+	"name",
+	"status",
+	"repository",
+	"createdAt",
+	"updatedAt",
+	"pullRequestNumber",
+	"pullRequestUrl",
+}
+
+// ExportData implements the exportable interface for JSON output.
+func (s *Session) ExportData(fields []string) map[string]interface{} {
+	data := make(map[string]interface{}, len(fields))
+	for _, f := range fields {
+		switch f {
+		case "id":
+			data[f] = s.ID
+		case "name":
+			data[f] = s.Name
+		case "status":
+			data[f] = s.State
+		case "repository":
+			if s.PullRequest != nil && s.PullRequest.Repository != nil {
+				data[f] = s.PullRequest.Repository.NameWithOwner
+			} else {
+				data[f] = nil
+			}
+		case "createdAt":
+			data[f] = s.CreatedAt
+		case "updatedAt":
+			data[f] = s.LastUpdatedAt
+		case "pullRequestNumber":
+			if s.PullRequest != nil {
+				data[f] = s.PullRequest.Number
+			} else {
+				data[f] = nil
+			}
+		case "pullRequestUrl":
+			if s.PullRequest != nil {
+				data[f] = s.PullRequest.URL
+			} else {
+				data[f] = nil
+			}
+		default:
+			data[f] = nil
+		}
+	}
+	return data
+}
+
 type resource struct {
 	ID                   string            `json:"id"`
 	UserID               uint64            `json:"user_id"`

--- a/pkg/cmd/agent-task/list/list.go
+++ b/pkg/cmd/agent-task/list/list.go
@@ -90,7 +90,7 @@ func listRun(opts *ListOptions) error {
 
 	opts.IO.StopProgressIndicator()
 
-	if len(sessions) == 0 {
+	if len(sessions) == 0 && opts.Exporter == nil {
 		return cmdutil.NewNoResultsError("no agent tasks found")
 	}
 

--- a/pkg/cmd/agent-task/list/list.go
+++ b/pkg/cmd/agent-task/list/list.go
@@ -25,6 +25,7 @@ type ListOptions struct {
 	CapiClient func() (capi.CapiClient, error)
 	Web        bool
 	Browser    browser.Browser
+	Exporter   cmdutil.Exporter
 }
 
 // NewCmdList creates the list command
@@ -53,6 +54,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", defaultLimit, "Maximum number of agent tasks to fetch")
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open agent tasks in the browser")
+
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, capi.SessionFields)
 
 	return cmd
 }
@@ -89,6 +92,10 @@ func listRun(opts *ListOptions) error {
 
 	if len(sessions) == 0 {
 		return cmdutil.NewNoResultsError("no agent tasks found")
+	}
+
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, sessions)
 	}
 
 	if err := opts.IO.StartPager(); err == nil {

--- a/pkg/cmd/agent-task/list/list_test.go
+++ b/pkg/cmd/agent-task/list/list_test.go
@@ -99,6 +99,7 @@ func Test_listRun(t *testing.T) {
 		capiStubs      func(*testing.T, *capi.CapiClientMock)
 		limit          int
 		web            bool
+		jsonFields     []string
 		wantOut        string
 		wantErr        error
 		wantStderr     string
@@ -286,6 +287,33 @@ func Test_listRun(t *testing.T) {
 			wantStderr:     "Opening https://github.com/copilot/agents in your browser.\n",
 			wantBrowserURL: "https://github.com/copilot/agents",
 		},
+		{
+			name: "json output",
+			tty:  false,
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.ListLatestSessionsForViewerFunc = func(ctx context.Context, limit int) ([]*capi.Session, error) {
+					return []*capi.Session{
+						{
+							ID:            "abc-123",
+							Name:          "s1",
+							State:         "completed",
+							CreatedAt:     sampleDate,
+							LastUpdatedAt: sampleDate,
+							ResourceType:  "pull",
+							PullRequest: &api.PullRequest{
+								Number: 101,
+								URL:    "https://github.com/OWNER/REPO/pull/101",
+								Repository: &api.PRRepository{
+									NameWithOwner: "OWNER/REPO",
+								},
+							},
+						},
+					}, nil
+				}
+			},
+			jsonFields: []string{"id", "name", "status", "repository", "pullRequestNumber", "pullRequestUrl"},
+			wantOut:    "[{\"id\":\"abc-123\",\"name\":\"s1\",\"pullRequestNumber\":101,\"pullRequestUrl\":\"https://github.com/OWNER/REPO/pull/101\",\"repository\":\"OWNER/REPO\",\"status\":\"completed\"}]\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -314,6 +342,12 @@ func Test_listRun(t *testing.T) {
 					}
 					return capiClientMock, nil
 				},
+			}
+
+			if tt.jsonFields != nil {
+				exporter := cmdutil.NewJSONExporter()
+				exporter.SetFields(tt.jsonFields)
+				opts.Exporter = exporter
 			}
 
 			err := listRun(opts)

--- a/pkg/cmd/agent-task/list/list_test.go
+++ b/pkg/cmd/agent-task/list/list_test.go
@@ -299,9 +299,13 @@ func Test_listRun(t *testing.T) {
 							State:         "completed",
 							CreatedAt:     sampleDate,
 							LastUpdatedAt: sampleDate,
+							CompletedAt:   sampleDate,
 							ResourceType:  "pull",
+							User:          &api.GitHubUser{Login: "monalisa"},
 							PullRequest: &api.PullRequest{
 								Number: 101,
+								Title:  "Fix login bug",
+								State:  "MERGED",
 								URL:    "https://github.com/OWNER/REPO/pull/101",
 								Repository: &api.PRRepository{
 									NameWithOwner: "OWNER/REPO",
@@ -311,8 +315,39 @@ func Test_listRun(t *testing.T) {
 					}, nil
 				}
 			},
-			jsonFields: []string{"id", "name", "status", "repository", "pullRequestNumber", "pullRequestUrl"},
-			wantOut:    "[{\"id\":\"abc-123\",\"name\":\"s1\",\"pullRequestNumber\":101,\"pullRequestUrl\":\"https://github.com/OWNER/REPO/pull/101\",\"repository\":\"OWNER/REPO\",\"status\":\"completed\"}]\n",
+			jsonFields: []string{"id", "name", "state", "repository", "user", "pullRequestNumber", "pullRequestUrl", "pullRequestTitle", "pullRequestState"},
+			wantOut:    "[{\"id\":\"abc-123\",\"name\":\"s1\",\"pullRequestNumber\":101,\"pullRequestState\":\"MERGED\",\"pullRequestTitle\":\"Fix login bug\",\"pullRequestUrl\":\"https://github.com/OWNER/REPO/pull/101\",\"repository\":\"OWNER/REPO\",\"state\":\"completed\",\"user\":\"monalisa\"}]\n",
+		},
+		{
+			name: "json output with no sessions returns empty array",
+			tty:  false,
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.ListLatestSessionsForViewerFunc = func(ctx context.Context, limit int) ([]*capi.Session, error) {
+					return nil, nil
+				}
+			},
+			jsonFields: []string{"id", "name", "state"},
+			wantOut:    "[]\n",
+		},
+		{
+			name: "json output with nil pull request",
+			tty:  false,
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.ListLatestSessionsForViewerFunc = func(ctx context.Context, limit int) ([]*capi.Session, error) {
+					return []*capi.Session{
+						{
+							ID:            "abc-456",
+							Name:          "s2",
+							State:         "in_progress",
+							CreatedAt:     sampleDate,
+							LastUpdatedAt: sampleDate,
+							ResourceType:  "pull",
+						},
+					}, nil
+				}
+			},
+			jsonFields: []string{"id", "name", "state", "repository", "user", "pullRequestNumber", "pullRequestUrl", "pullRequestTitle", "pullRequestState"},
+			wantOut:    "[{\"id\":\"abc-456\",\"name\":\"s2\",\"pullRequestNumber\":null,\"pullRequestState\":null,\"pullRequestTitle\":null,\"pullRequestUrl\":null,\"repository\":null,\"state\":\"in_progress\",\"user\":null}]\n",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Add `--json`, `--jq`, and `--template` flags to `gh agent-task list`, consistent with the pattern used by `gh pr list --json`, `gh issue list --json`, etc.

This implements the `ExportData` interface on `capi.Session` and defines `SessionFields` for the available JSON fields:
- `id` — Session ID
- `name` — Session name/title
- `state` — Current state (e.g. `completed`, `in_progress`, `failed`)
- `repository` — `owner/repo`
- `user` — User login
- `createdAt` — When the session started
- `updatedAt` — Last activity timestamp
- `completedAt` — When the session completed (null if still running)
- `pullRequestNumber` — Associated PR number
- `pullRequestUrl` — Associated PR URL
- `pullRequestTitle` — Associated PR title
- `pullRequestState` — Associated PR state (OPEN/CLOSED/MERGED)

### Example usage

```bash
# Get all sessions as JSON
gh agent-task list --json id,name,state

# Filter with jq
gh agent-task list --json id,state --jq '.[] | select(.state == "in_progress")'

# Use a Go template
gh agent-task list --json id,name --template '{{range .}}{{.id}} {{.name}}{{"\\n"}}{{end}}'
```

Partial fix for https://github.com/cli/cli/issues/12805 — this PR covers `list`; a companion PR (#12807) adds the same to `view`.