### PR TITLE
Add --json support to `gh agent-task view`

### DIFF
--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -106,12 +106,16 @@ type SessionError struct {
 var SessionFields = []string{
 	"id",
 	"name",
-	"status",
+	"state",
 	"repository",
+	"user",
 	"createdAt",
 	"updatedAt",
+	"completedAt",
 	"pullRequestNumber",
 	"pullRequestUrl",
+	"pullRequestTitle",
+	"pullRequestState",
 }
 
 // ExportData implements the exportable interface for JSON output.
@@ -123,7 +127,7 @@ func (s *Session) ExportData(fields []string) map[string]interface{} {
 			data[f] = s.ID
 		case "name":
 			data[f] = s.Name
-		case "status":
+		case "state":
 			data[f] = s.State
 		case "repository":
 			if s.PullRequest != nil && s.PullRequest.Repository != nil {
@@ -131,10 +135,22 @@ func (s *Session) ExportData(fields []string) map[string]interface{} {
 			} else {
 				data[f] = nil
 			}
+		case "user":
+			if s.User != nil {
+				data[f] = s.User.Login
+			} else {
+				data[f] = nil
+			}
 		case "createdAt":
 			data[f] = s.CreatedAt
 		case "updatedAt":
 			data[f] = s.LastUpdatedAt
+		case "completedAt":
+			if s.CompletedAt.IsZero() {
+				data[f] = nil
+			} else {
+				data[f] = s.CompletedAt
+			}
 		case "pullRequestNumber":
 			if s.PullRequest != nil {
 				data[f] = s.PullRequest.Number
@@ -144,6 +160,18 @@ func (s *Session) ExportData(fields []string) map[string]interface{} {
 		case "pullRequestUrl":
 			if s.PullRequest != nil {
 				data[f] = s.PullRequest.URL
+			} else {
+				data[f] = nil
+			}
+		case "pullRequestTitle":
+			if s.PullRequest != nil {
+				data[f] = s.PullRequest.Title
+			} else {
+				data[f] = nil
+			}
+		case "pullRequestState":
+			if s.PullRequest != nil {
+				data[f] = s.PullRequest.State
 			} else {
 				data[f] = nil
 			}

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -142,9 +142,17 @@ func (s *Session) ExportData(fields []string) map[string]interface{} {
 				data[f] = nil
 			}
 		case "createdAt":
-			data[f] = s.CreatedAt
+			if s.CreatedAt.IsZero() {
+				data[f] = nil
+			} else {
+				data[f] = s.CreatedAt
+			}
 		case "updatedAt":
-			data[f] = s.LastUpdatedAt
+			if s.LastUpdatedAt.IsZero() {
+				data[f] = nil
+			} else {
+				data[f] = s.LastUpdatedAt
+			}
 		case "completedAt":
 			if s.CompletedAt.IsZero() {
 				data[f] = nil

--- a/pkg/cmd/agent-task/capi/sessions.go
+++ b/pkg/cmd/agent-task/capi/sessions.go
@@ -102,6 +102,58 @@ type SessionError struct {
 	Message string
 }
 
+// SessionFields defines the available fields for JSON export of a Session.
+var SessionFields = []string{
+	"id",
+	"name",
+	"status",
+	"repository",
+	"createdAt",
+	"updatedAt",
+	"pullRequestNumber",
+	"pullRequestUrl",
+}
+
+// ExportData implements the exportable interface for JSON output.
+func (s *Session) ExportData(fields []string) map[string]interface{} {
+	data := make(map[string]interface{}, len(fields))
+	for _, f := range fields {
+		switch f {
+		case "id":
+			data[f] = s.ID
+		case "name":
+			data[f] = s.Name
+		case "status":
+			data[f] = s.State
+		case "repository":
+			if s.PullRequest != nil && s.PullRequest.Repository != nil {
+				data[f] = s.PullRequest.Repository.NameWithOwner
+			} else {
+				data[f] = nil
+			}
+		case "createdAt":
+			data[f] = s.CreatedAt
+		case "updatedAt":
+			data[f] = s.LastUpdatedAt
+		case "pullRequestNumber":
+			if s.PullRequest != nil {
+				data[f] = s.PullRequest.Number
+			} else {
+				data[f] = nil
+			}
+		case "pullRequestUrl":
+			if s.PullRequest != nil {
+				data[f] = s.PullRequest.URL
+			} else {
+				data[f] = nil
+			}
+		default:
+			data[f] = nil
+		}
+	}
+	return data
+}
+
 type resource struct {
 	ID                   string            `json:"id"`
 	UserID               uint64            `json:"user_id"`

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -37,6 +37,7 @@ type ViewOptions struct {
 	Finder     prShared.PRFinder
 	Prompter   prompter.Prompter
 	Browser    browser.Browser
+	Exporter   cmdutil.Exporter
 
 	LogRenderer func() shared.LogRenderer
 	Sleep       func(d time.Duration)
@@ -124,6 +125,8 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open agent task in the browser")
 	cmd.Flags().BoolVar(&opts.Log, "log", false, "Show agent session logs")
 	cmd.Flags().BoolVar(&opts.Follow, "follow", false, "Follow agent session logs")
+
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, capi.SessionFields)
 
 	return cmd
 }
@@ -287,6 +290,10 @@ func viewRun(opts *ViewOptions) error {
 
 	if opts.Log {
 		return printLogs(opts, capiClient, session.ID)
+	}
+
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, session)
 	}
 
 	printSession(opts, session)

--- a/pkg/cmd/agent-task/view/view.go
+++ b/pkg/cmd/agent-task/view/view.go
@@ -288,12 +288,12 @@ func viewRun(opts *ViewOptions) error {
 		opts.IO.StopProgressIndicator()
 	}
 
-	if opts.Log {
-		return printLogs(opts, capiClient, session.ID)
-	}
-
 	if opts.Exporter != nil {
 		return opts.Exporter.Write(opts.IO, session)
+	}
+
+	if opts.Log {
+		return printLogs(opts, capiClient, session.ID)
 	}
 
 	printSession(opts, session)

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -1231,7 +1231,7 @@ func Test_viewRun(t *testing.T) {
 							Number: 42,
 							URL:    "https://github.com/OWNER/REPO/pull/42",
 							Title:  "Fix login bug",
-							State:  "OPEN",
+							State:  "MERGED",
 							Repository: &api.PRRepository{
 								NameWithOwner: "OWNER/REPO",
 							},
@@ -1242,8 +1242,30 @@ func Test_viewRun(t *testing.T) {
 					}, nil
 				}
 			},
-			wantOut:    "{\"id\":\"some-session-id\",\"name\":\"Fix login bug\",\"pullRequestNumber\":42,\"pullRequestUrl\":\"https://github.com/OWNER/REPO/pull/42\",\"repository\":\"OWNER/REPO\",\"status\":\"completed\"}\n",
-			jsonFields: []string{"id", "name", "status", "repository", "pullRequestNumber", "pullRequestUrl"},
+			wantOut:    "{\"id\":\"some-session-id\",\"name\":\"Fix login bug\",\"pullRequestNumber\":42,\"pullRequestState\":\"MERGED\",\"pullRequestTitle\":\"Fix login bug\",\"pullRequestUrl\":\"https://github.com/OWNER/REPO/pull/42\",\"repository\":\"OWNER/REPO\",\"state\":\"completed\",\"user\":\"testuser\"}\n",
+			jsonFields: []string{"id", "name", "state", "repository", "user", "pullRequestNumber", "pullRequestUrl", "pullRequestTitle", "pullRequestState"},
+		},
+		{
+			name: "json output with nil pull request",
+			tty:  false,
+			opts: ViewOptions{
+				SelectorArg: "some-session-id",
+				SessionID:   "some-session-id",
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
+					return &capi.Session{
+						ID:            "some-session-id",
+						Name:          "New task",
+						State:         "in_progress",
+						CreatedAt:     sampleDate,
+						LastUpdatedAt: sampleDate,
+						ResourceType:  "pull",
+					}, nil
+				}
+			},
+			wantOut:    "{\"id\":\"some-session-id\",\"name\":\"New task\",\"pullRequestNumber\":null,\"pullRequestUrl\":null,\"repository\":null,\"state\":\"in_progress\",\"user\":null}\n",
+			jsonFields: []string{"id", "name", "state", "repository", "user", "pullRequestNumber", "pullRequestUrl"},
 		},
 	}
 

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -168,6 +168,7 @@ func Test_viewRun(t *testing.T) {
 		promptStubs      func(*testing.T, *prompter.MockPrompter)
 		capiStubs        func(*testing.T, *capi.CapiClientMock)
 		logRendererStubs func(*testing.T, *shared.LogRendererMock)
+		jsonFields       []string
 		wantOut          string
 		wantErr          error
 		wantStderr       string
@@ -1209,6 +1210,41 @@ func Test_viewRun(t *testing.T) {
 				(rendered:) <raw-logs-two>
 			`),
 		},
+		{
+			name: "json output (tty)",
+			tty:  true,
+			opts: ViewOptions{
+				SelectorArg: "some-session-id",
+				SessionID:   "some-session-id",
+			},
+			capiStubs: func(t *testing.T, m *capi.CapiClientMock) {
+				m.GetSessionFunc = func(_ context.Context, id string) (*capi.Session, error) {
+					return &capi.Session{
+						ID:            "some-session-id",
+						Name:          "Fix login bug",
+						State:         "completed",
+						CreatedAt:     sampleDate,
+						LastUpdatedAt: sampleDate,
+						CompletedAt:   sampleCompletedAt,
+						ResourceType:  "pull",
+						PullRequest: &api.PullRequest{
+							Number: 42,
+							URL:    "https://github.com/OWNER/REPO/pull/42",
+							Title:  "Fix login bug",
+							State:  "OPEN",
+							Repository: &api.PRRepository{
+								NameWithOwner: "OWNER/REPO",
+							},
+						},
+						User: &api.GitHubUser{
+							Login: "testuser",
+						},
+					}, nil
+				}
+			},
+			wantOut: "{\"id\":\"some-session-id\",\"name\":\"Fix login bug\",\"pullRequestNumber\":42,\"pullRequestUrl\":\"https://github.com/OWNER/REPO/pull/42\",\"repository\":\"OWNER/REPO\",\"status\":\"completed\"}\n",
+			jsonFields: []string{"id", "name", "status", "repository", "pullRequestNumber", "pullRequestUrl"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1242,6 +1278,12 @@ func Test_viewRun(t *testing.T) {
 			}
 			opts.LogRenderer = func() shared.LogRenderer {
 				return logRenderer
+			}
+
+			if tt.jsonFields != nil {
+				exporter := cmdutil.NewJSONExporter()
+				exporter.SetFields(tt.jsonFields)
+				opts.Exporter = exporter
 			}
 
 			err := viewRun(&opts)

--- a/pkg/cmd/agent-task/view/view_test.go
+++ b/pkg/cmd/agent-task/view/view_test.go
@@ -1242,7 +1242,7 @@ func Test_viewRun(t *testing.T) {
 					}, nil
 				}
 			},
-			wantOut: "{\"id\":\"some-session-id\",\"name\":\"Fix login bug\",\"pullRequestNumber\":42,\"pullRequestUrl\":\"https://github.com/OWNER/REPO/pull/42\",\"repository\":\"OWNER/REPO\",\"status\":\"completed\"}\n",
+			wantOut:    "{\"id\":\"some-session-id\",\"name\":\"Fix login bug\",\"pullRequestNumber\":42,\"pullRequestUrl\":\"https://github.com/OWNER/REPO/pull/42\",\"repository\":\"OWNER/REPO\",\"status\":\"completed\"}\n",
 			jsonFields: []string{"id", "name", "status", "repository", "pullRequestNumber", "pullRequestUrl"},
 		},
 	}


### PR DESCRIPTION
## Summary

Add `--json`, `--jq`, and `--template` flags to `gh agent-task view`, consistent with the pattern used by `gh pr view --json`, `gh issue view --json`, etc.

When `--json` is provided, the view command outputs structured JSON instead of human-readable formatted output. This uses the same `ExportData` interface and `SessionFields` as the companion list PR.

### Available fields
`id`, `name`, `state`, `repository`, `user`, `createdAt`, `updatedAt`, `completedAt`, `pullRequestNumber`, `pullRequestUrl`, `pullRequestTitle`, `pullRequestState`

### Example usage

```bash
# Get session details as JSON
gh agent-task view <session-id> --json id,name,state,pullRequestUrl

# Filter with jq
gh agent-task view <session-id> --json state --jq '.state'

# Use a Go template
gh agent-task view <session-id> --json name,state --template '{{.name}}: {{.state}}'
```

Companion to https://github.com/cli/cli/pull/12806 — together they address the `--json` portion of https://github.com/cli/cli/issues/12805.