### PR TITLE
Fix help-wanted label name mismatch in PR triage workflow

### DIFF
--- a/.github/workflows/triage-pull-requests.yml
+++ b/.github/workflows/triage-pull-requests.yml
@@ -31,6 +31,8 @@ jobs:
       github.event_name == 'pull_request_target' &&
       (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'edited')
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
+    with:
+      help_wanted_label: 'help wanted'
     permissions:
       issues: read
       pull-requests: write
@@ -38,6 +40,8 @@ jobs:
   close-unmet-requirements:
     if: github.event_name == 'schedule'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
+    with:
+      help_wanted_label: 'help wanted'
     permissions:
       issues: read
       pull-requests: write


### PR DESCRIPTION
The shared `triage-pr-requirements` workflow defaults `help_wanted_label` to `help-wanted` (hyphenated), but the actual repo label is `help wanted` (with a space). The `grep -qx` exact match never matched, so every external PR was incorrectly flagged as not meeting requirements.

This fix passes the correct label name explicitly to both `check-requirements` and `close-unmet-requirements` jobs.

Ref: https://github.com/cli/cli/pull/12803#issuecomment-3976756129