### PR TITLE
fix(repo fork): set default repo when adding fork remote

### DIFF
--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -257,9 +257,14 @@ func forkRun(opts *ForkOptions) error {
 		if err != nil {
 			return err
 		}
+		parentRepoRemoteName := ""
+		if remote, err := remotes.FindByRepo(repoToFork.RepoOwner(), repoToFork.RepoName()); err == nil {
+			parentRepoRemoteName = remote.Name
+		}
 
 		if !protocolIsConfiguredByUser {
-			if remote, err := remotes.FindByRepo(repoToFork.RepoOwner(), repoToFork.RepoName()); err == nil {
+			if parentRepoRemoteName != "" {
+				remote, _ := remotes.FindByName(parentRepoRemoteName)
 				scheme := ""
 				if remote.FetchURL != nil {
 					scheme = remote.FetchURL.Scheme
@@ -312,6 +317,10 @@ func forkRun(opts *ForkOptions) error {
 					if connectedToTerminal {
 						fmt.Fprintf(stderr, "%s Renamed remote %s to %s\n", cs.SuccessIcon(), cs.Bold(remoteName), cs.Bold(renameTarget))
 					}
+
+					if parentRepoRemoteName == remoteName {
+						parentRepoRemoteName = renameTarget
+					}
 				} else {
 					return fmt.Errorf("a git remote named '%s' already exists", remoteName)
 				}
@@ -326,6 +335,16 @@ func forkRun(opts *ForkOptions) error {
 
 			if connectedToTerminal {
 				fmt.Fprintf(stderr, "%s Added remote %s\n", cs.SuccessIcon(), cs.Bold(remoteName))
+			}
+
+			if parentRepoRemoteName != "" {
+				if err := gitClient.SetRemoteResolution(ctx, parentRepoRemoteName, "base"); err != nil {
+					return fmt.Errorf("failed to set %s as the default/base repository: %w", parentRepoRemoteName, err)
+				}
+
+				if connectedToTerminal {
+					fmt.Fprintf(stderr, "%s Repository %s set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n", cs.WarningIcon(), cs.Bold(ghrepo.FullName(repoToFork)))
+				}
 			}
 		}
 	} else {

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -46,6 +46,7 @@ type ForkOptions struct {
 	Remote            bool
 	PromptClone       bool
 	PromptRemote      bool
+	Confirmed         bool
 	RemoteName        string
 	Organization      string
 	ForkName          string
@@ -92,7 +93,8 @@ func NewCmdFork(f *cmdutil.Factory, runF func(*ForkOptions) error) *cobra.Comman
 			origin remote is renamed to %[1]supstream%[1]s. To alter this behavior, you can set
 			a name for the new fork's remote with %[1]s--remote-name%[1]s.
 
-			The %[1]supstream%[1]s remote will be set as the default remote repository.
+			After adding a fork remote in an existing local clone, gh can set the parent
+			repository as the default repository for this directory.
 
 			Additional %[1]sgit clone%[1]s flags can be passed after %[1]s--%[1]s.
 		`, "`"),
@@ -134,6 +136,7 @@ func NewCmdFork(f *cmdutil.Factory, runF func(*ForkOptions) error) *cobra.Comman
 
 	cmd.Flags().BoolVar(&opts.Clone, "clone", false, "Clone the fork")
 	cmd.Flags().BoolVar(&opts.Remote, "remote", false, "Add a git remote for the fork")
+	cmd.Flags().BoolVar(&opts.Confirmed, "yes", false, "Skip the default-repository confirmation prompt")
 	cmd.Flags().StringVar(&opts.RemoteName, "remote-name", defaultRemoteName, "Specify the name for the new remote")
 	cmd.Flags().StringVar(&opts.Organization, "org", "", "Create the fork in an organization")
 	cmd.Flags().StringVar(&opts.ForkName, "fork-name", "", "Rename the forked repository")
@@ -338,12 +341,23 @@ func forkRun(opts *ForkOptions) error {
 			}
 
 			if parentRepoRemoteName != "" {
-				if err := gitClient.SetRemoteResolution(ctx, parentRepoRemoteName, "base"); err != nil {
-					return fmt.Errorf("failed to set %s as the default/base repository: %w", parentRepoRemoteName, err)
+				setDefaultRepo := opts.Confirmed
+				if !setDefaultRepo && connectedToTerminal {
+					setDefaultPrompt := fmt.Sprintf("Would you like to set %s as the default repository for this directory?", ghrepo.FullName(repoToFork))
+					setDefaultRepo, err = opts.Prompter.Confirm(setDefaultPrompt, false)
+					if err != nil {
+						return err
+					}
 				}
 
-				if connectedToTerminal {
-					fmt.Fprintf(stderr, "%s Repository %s set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n", cs.WarningIcon(), cs.Bold(ghrepo.FullName(repoToFork)))
+				if setDefaultRepo {
+					if err := gitClient.SetRemoteResolution(ctx, parentRepoRemoteName, "base"); err != nil {
+						return fmt.Errorf("failed to set %s as the default/base repository: %w", parentRepoRemoteName, err)
+					}
+
+					if connectedToTerminal {
+						fmt.Fprintf(stderr, "%s Repository %s set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n", cs.WarningIcon(), cs.Bold(ghrepo.FullName(repoToFork)))
+					}
 				}
 			}
 		}

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -240,8 +240,9 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git remote add fork https://github\.com/someone/REPO\.git`, 0, "")
+				cs.Register(`git config --add remote\.origin\.gh-resolved base`, 0, "")
 			},
-			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n",
+			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n! Repository OWNER/REPO set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n",
 		},
 		{
 			name: "implicit match, no configured protocol",
@@ -261,8 +262,9 @@ func TestRepoFork(t *testing.T) {
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git remote add fork git@github\.com:someone/REPO\.git`, 0, "")
+				cs.Register(`git config --add remote\.origin\.gh-resolved base`, 0, "")
 			},
-			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n",
+			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n! Repository OWNER/REPO set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n",
 		},
 		{
 			name: "implicit with negative interactive choices",
@@ -292,13 +294,14 @@ func TestRepoFork(t *testing.T) {
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
 				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git config --add remote\.upstream\.gh-resolved base`, 0, "")
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterConfirm("Would you like to add a remote for the fork?", func(_ string, _ bool) (bool, error) {
 					return true, nil
 				})
 			},
-			wantErrOut: "✓ Created fork someone/REPO\n✓ Renamed remote origin to upstream\n✓ Added remote origin\n",
+			wantErrOut: "✓ Created fork someone/REPO\n✓ Renamed remote origin to upstream\n✓ Added remote origin\n! Repository OWNER/REPO set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n",
 		},
 		{
 			name: "implicit tty reuse existing remote",
@@ -369,8 +372,9 @@ func TestRepoFork(t *testing.T) {
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
 				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git config --add remote\.upstream\.gh-resolved base`, 0, "")
 			},
-			wantErrOut: "✓ Created fork someone/REPO\n✓ Renamed remote origin to upstream\n✓ Added remote origin\n",
+			wantErrOut: "✓ Created fork someone/REPO\n✓ Renamed remote origin to upstream\n✓ Added remote origin\n! Repository OWNER/REPO set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n",
 		},
 		{
 			name: "implicit nontty reuse existing remote",
@@ -424,6 +428,7 @@ func TestRepoFork(t *testing.T) {
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register("git remote rename origin upstream", 0, "")
 				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
+				cs.Register(`git config --add remote\.upstream\.gh-resolved base`, 0, "")
 			},
 			wantOut: "https://github.com/someone/REPO\n",
 		},

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -113,6 +113,15 @@ func TestNewCmdFork(t *testing.T) {
 			},
 		},
 		{
+			name: "skip confirmation",
+			cli:  "--yes",
+			wants: ForkOptions{
+				RemoteName: "origin",
+				Rename:     true,
+				Confirmed:  true,
+			},
+		},
+		{
 			name: "to org",
 			cli:  "--org batmanshome",
 			wants: ForkOptions{
@@ -184,6 +193,7 @@ func TestNewCmdFork(t *testing.T) {
 			assert.Equal(t, tt.wants.PromptClone, gotOpts.PromptClone)
 			assert.Equal(t, tt.wants.Organization, gotOpts.Organization)
 			assert.Equal(t, tt.wants.GitArgs, gotOpts.GitArgs)
+			assert.Equal(t, tt.wants.Confirmed, gotOpts.Confirmed)
 		})
 	}
 }
@@ -242,6 +252,11 @@ func TestRepoFork(t *testing.T) {
 				cs.Register(`git remote add fork https://github\.com/someone/REPO\.git`, 0, "")
 				cs.Register(`git config --add remote\.origin\.gh-resolved base`, 0, "")
 			},
+			promptStubs: func(pm *prompter.MockPrompter) {
+				pm.RegisterConfirm("Would you like to set OWNER/REPO as the default repository for this directory?", func(_ string, _ bool) (bool, error) {
+					return true, nil
+				})
+			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n! Repository OWNER/REPO set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n",
 		},
 		{
@@ -263,6 +278,11 @@ func TestRepoFork(t *testing.T) {
 			execStubs: func(cs *run.CommandStubber) {
 				cs.Register(`git remote add fork git@github\.com:someone/REPO\.git`, 0, "")
 				cs.Register(`git config --add remote\.origin\.gh-resolved base`, 0, "")
+			},
+			promptStubs: func(pm *prompter.MockPrompter) {
+				pm.RegisterConfirm("Would you like to set OWNER/REPO as the default repository for this directory?", func(_ string, _ bool) (bool, error) {
+					return true, nil
+				})
 			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Added remote fork\n! Repository OWNER/REPO set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n",
 		},
@@ -298,6 +318,9 @@ func TestRepoFork(t *testing.T) {
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
 				pm.RegisterConfirm("Would you like to add a remote for the fork?", func(_ string, _ bool) (bool, error) {
+					return true, nil
+				})
+				pm.RegisterConfirm("Would you like to set OWNER/REPO as the default repository for this directory?", func(_ string, _ bool) (bool, error) {
 					return true, nil
 				})
 			},
@@ -374,6 +397,11 @@ func TestRepoFork(t *testing.T) {
 				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
 				cs.Register(`git config --add remote\.upstream\.gh-resolved base`, 0, "")
 			},
+			promptStubs: func(pm *prompter.MockPrompter) {
+				pm.RegisterConfirm("Would you like to set OWNER/REPO as the default repository for this directory?", func(_ string, _ bool) (bool, error) {
+					return true, nil
+				})
+			},
 			wantErrOut: "✓ Created fork someone/REPO\n✓ Renamed remote origin to upstream\n✓ Added remote origin\n! Repository OWNER/REPO set as the default repository. To learn more about the default repository, run: gh repo set-default --help\n",
 		},
 		{
@@ -423,6 +451,21 @@ func TestRepoFork(t *testing.T) {
 				Remote:     true,
 				RemoteName: defaultRemoteName,
 				Rename:     true,
+			},
+			httpStubs: forkPost,
+			execStubs: func(cs *run.CommandStubber) {
+				cs.Register("git remote rename origin upstream", 0, "")
+				cs.Register(`git remote add origin https://github.com/someone/REPO.git`, 0, "")
+			},
+			wantOut: "https://github.com/someone/REPO\n",
+		},
+		{
+			name: "implicit nontty --remote --yes",
+			opts: &ForkOptions{
+				Remote:     true,
+				RemoteName: defaultRemoteName,
+				Rename:     true,
+				Confirmed:  true,
 			},
 			httpStubs: forkPost,
 			execStubs: func(cs *run.CommandStubber) {


### PR DESCRIPTION
## Summary
- Keep the existing-clone remote-add behavior, but make default-repository updates explicit by prompting before setting remote.<parent>.gh-resolved=base.
- Add --yes to skip that confirmation in automation/non-interactive usage.
- Update repo fork tests for prompt, non-interactive skip, and --yes opt-in paths.

Fixes #12833