### PR TITLE
Add nil guards for project card/item node dereferences

### DIFF
--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -196,17 +196,23 @@ type ProjectV2ItemStatus struct {
 }
 
 func (p ProjectCards) ProjectNames() []string {
-	names := make([]string, len(p.Nodes))
-	for i, c := range p.Nodes {
-		names[i] = c.Project.Name
+	var names []string
+	for _, c := range p.Nodes {
+		if c == nil {
+			continue
+		}
+		names = append(names, c.Project.Name)
 	}
 	return names
 }
 
 func (p ProjectItems) ProjectTitles() []string {
-	titles := make([]string, len(p.Nodes))
-	for i, c := range p.Nodes {
-		titles[i] = c.Project.Title
+	var titles []string
+	for _, c := range p.Nodes {
+		if c == nil {
+			continue
+		}
+		titles = append(titles, c.Project.Title)
 	}
 	return titles
 }

--- a/api/queries_issue_test.go
+++ b/api/queries_issue_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectCards_ProjectNames_NilNode(t *testing.T) {
+	tests := []struct {
+		name     string
+		cards    ProjectCards
+		expected []string
+	}{
+		{
+			name: "all nil nodes",
+			cards: ProjectCards{
+				Nodes:      []*ProjectInfo{nil, nil},
+				TotalCount: 2,
+			},
+			expected: nil,
+		},
+		{
+			name: "mixed nil and valid nodes",
+			cards: ProjectCards{
+				Nodes: []*ProjectInfo{
+					nil,
+					{
+						Project: struct {
+							Name string `json:"name"`
+						}{Name: "My Project"},
+						Column: struct {
+							Name string `json:"name"`
+						}{Name: "In Progress"},
+					},
+					nil,
+				},
+				TotalCount: 3,
+			},
+			expected: []string{"My Project"},
+		},
+		{
+			name: "no nodes",
+			cards: ProjectCards{
+				Nodes:      []*ProjectInfo{},
+				TotalCount: 0,
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.cards.ProjectNames()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProjectItems_ProjectTitles_NilNode(t *testing.T) {
+	tests := []struct {
+		name     string
+		items    ProjectItems
+		expected []string
+	}{
+		{
+			name: "all nil nodes",
+			items: ProjectItems{
+				Nodes:      []*ProjectV2Item{nil, nil},
+				TotalCount: 2,
+			},
+			expected: nil,
+		},
+		{
+			name: "mixed nil and valid nodes",
+			items: ProjectItems{
+				Nodes: []*ProjectV2Item{
+					nil,
+					{
+						ID: "ITEM1",
+						Project: ProjectV2ItemProject{
+							ID:    "PROJ1",
+							Title: "v2 Project",
+						},
+						Status: ProjectV2ItemStatus{
+							Name: "Done",
+						},
+					},
+					nil,
+				},
+				TotalCount: 3,
+			},
+			expected: []string{"v2 Project"},
+		},
+		{
+			name: "no nodes",
+			items: ProjectItems{
+				Nodes:      []*ProjectV2Item{},
+				TotalCount: 0,
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.items.ProjectTitles()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -281,8 +281,11 @@ func editRun(opts *EditOptions) error {
 		}
 		editable.Labels.Default = issue.Labels.Names()
 		editable.Projects.Default = append(issue.ProjectCards.ProjectNames(), issue.ProjectItems.ProjectTitles()...)
-		projectItems := map[string]string{}
+	projectItems := map[string]string{}
 		for _, n := range issue.ProjectItems.Nodes {
+			if n == nil {
+				continue
+			}
 			projectItems[n.Project.ID] = n.ID
 		}
 		editable.Projects.ProjectItems = projectItems

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -321,6 +321,9 @@ func issueProjectList(issue api.Issue) string {
 	projectNames := make([]string, 0, count)
 
 	for _, project := range issue.ProjectItems.Nodes {
+		if project == nil {
+			continue
+		}
 		colName := project.Status.Name
 		if colName == "" {
 			colName = "No Status"
@@ -330,6 +333,9 @@ func issueProjectList(issue api.Issue) string {
 
 	// TODO: Remove v1 classic project logic when completely deprecated
 	for _, project := range issue.ProjectCards.Nodes {
+		if project == nil {
+			continue
+		}
 		colName := project.Column.Name
 		if colName == "" {
 			colName = "Awaiting triage"

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/config"
 	fd "github.com/cli/cli/v2/internal/featuredetection"
@@ -524,6 +525,58 @@ func TestIssueView_nontty_Comments(t *testing.T) {
 			test.ExpectLines(t, output.String(), tc.expectedOutputs...)
 		})
 	}
+}
+
+func TestIssueProjectList_NilNodes(t *testing.T) {
+	// Regression test: issueProjectList must not panic when Nodes contain nil entries.
+	issues := []api.Issue{
+		{
+			ProjectCards: api.ProjectCards{
+				Nodes:      []*api.ProjectInfo{nil},
+				TotalCount: 1,
+			},
+			ProjectItems: api.ProjectItems{
+				Nodes:      []*api.ProjectV2Item{nil},
+				TotalCount: 1,
+			},
+		},
+		{
+			ProjectCards: api.ProjectCards{
+				Nodes: []*api.ProjectInfo{
+					nil,
+					{
+						Project: struct {
+							Name string `json:"name"`
+						}{Name: "Classic Project"},
+						Column: struct {
+							Name string `json:"name"`
+						}{Name: "Done"},
+					},
+				},
+				TotalCount: 2,
+			},
+			ProjectItems: api.ProjectItems{
+				Nodes: []*api.ProjectV2Item{
+					nil,
+					{
+						ID: "ITEM1",
+						Project: api.ProjectV2ItemProject{ID: "P1", Title: "v2 Board"},
+						Status:  api.ProjectV2ItemStatus{Name: "In Progress"},
+					},
+				},
+				TotalCount: 2,
+			},
+		},
+	}
+
+	// All-nil nodes should produce empty string.
+	result := issueProjectList(issues[0])
+	assert.Equal(t, "", result)
+
+	// Mixed nil and valid nodes should list only valid entries.
+	result = issueProjectList(issues[1])
+	assert.Contains(t, result, "v2 Board (In Progress)")
+	assert.Contains(t, result, "Classic Project (Done)")
 }
 
 // TODO projectsV1Deprecation

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -282,6 +282,9 @@ func editRun(opts *EditOptions) error {
 	editable.Projects.Default = append(pr.ProjectCards.ProjectNames(), pr.ProjectItems.ProjectTitles()...)
 	projectItems := map[string]string{}
 	for _, n := range pr.ProjectItems.Nodes {
+		if n == nil {
+			continue
+		}
 		projectItems[n.Project.ID] = n.ID
 	}
 	editable.Projects.ProjectItems = projectItems

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -449,6 +449,9 @@ func prProjectList(pr api.PullRequest) string {
 	projectNames := make([]string, 0, len(pr.ProjectCards.Nodes))
 
 	for _, project := range pr.ProjectItems.Nodes {
+		if project == nil {
+			continue
+		}
 		colName := project.Status.Name
 		if colName == "" {
 			colName = "No Status"


### PR DESCRIPTION
## Problem

When the GitHub GraphQL API returns `null` entries inside `projectCards.nodes` or `projectItems.nodes` arrays, several `gh issue` and `gh pr` code paths dereference these nil pointers without any guard, causing a panic (segmentation fault).

This was partially fixed for `gh pr view` in #8566, which added `if project == nil { continue }` in `prProjectList()` for `ProjectCards.Nodes`. However, the equivalent `gh issue` paths and the `ProjectItems.Nodes` iterations were never hardened.

### Reproduction

Constructing a `ProjectCards{Nodes: []*ProjectInfo{nil}}` and calling `ProjectNames()` triggers the panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
  goroutine 8 [running]:
  github.com/cli/cli/v2/api.ProjectCards.ProjectNames(...)
    api/queries_issue.go:201
```

The same class of nil dereference exists in:

- `api/queries_issue.go` -- `ProjectCards.ProjectNames()` (line 201) and `ProjectItems.ProjectTitles()` (line 209)
- `pkg/cmd/issue/view/view.go` -- `issueProjectList()` iterates both `ProjectItems.Nodes` and `ProjectCards.Nodes` without nil checks
- `pkg/cmd/issue/edit/edit.go` -- iterates `ProjectItems.Nodes` without nil check when building project defaults
- `pkg/cmd/pr/edit/edit.go` -- same pattern as issue edit
- `pkg/cmd/pr/view/view.go` -- `prProjectList()` guards `ProjectCards.Nodes` but not `ProjectItems.Nodes`

### Root Cause

`ProjectCards.Nodes` is typed `[]*ProjectInfo` and `ProjectItems.Nodes` is typed `[]*ProjectV2Item`. The GraphQL API can return `null` elements in these arrays (e.g. when a project card reference is deleted or inaccessible). Code that iterates these slices and immediately dereferences fields (like `c.Project.Name`) will panic on nil entries.

## Fix

Added `if <node> == nil { continue }` guards in all six affected code paths, matching the existing pattern from `prProjectList()` for `ProjectCards.Nodes`.

### Files Changed

- `api/queries_issue.go` -- `ProjectCards.ProjectNames()` and `ProjectItems.ProjectTitles()` now skip nil nodes
- `pkg/cmd/issue/view/view.go` -- `issueProjectList()` guards both `ProjectItems.Nodes` and `ProjectCards.Nodes` loops
- `pkg/cmd/issue/edit/edit.go` -- `ProjectItems.Nodes` iteration guarded
- `pkg/cmd/pr/edit/edit.go` -- `ProjectItems.Nodes` iteration guarded
- `pkg/cmd/pr/view/view.go` -- `prProjectList()` now also guards `ProjectItems.Nodes` (already guarded `ProjectCards.Nodes`)

## Tests

Added regression tests that construct slices containing nil nodes and verify no panic occurs and output is correct:

- `TestProjectCards_ProjectNames_NilNode` -- 3 sub-tests (all nil, mixed, empty) in `api/queries_issue_test.go`
- `TestProjectItems_ProjectTitles_NilNode` -- 3 sub-tests (all nil, mixed, empty) in `api/queries_issue_test.go`
- `TestIssueProjectList_NilNodes` -- tests `issueProjectList()` with nil nodes in both `ProjectCards` and `ProjectItems` in `pkg/cmd/issue/view/view_test.go`

All existing tests continue to pass across all five affected packages.

Fixes #12762