### PR TITLE
Fix incorrect integer conversion from int to uint16 in port forwarder

### DIFF
--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -266,7 +266,7 @@ func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, re
 	// Delete the existing tunnel port to update
 	port, err := convertIntToUint16(remotePort)
 	if err != nil {
-		return err
+		return fmt.Errorf("error converting port: %w", err)
 	}
 	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, port, fwd.connection.Options)
 	if err != nil {

--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -264,7 +264,11 @@ func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, re
 	}
 
 	// Delete the existing tunnel port to update
-	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, uint16(remotePort), fwd.connection.Options)
+	port, err := convertIntToUint16(remotePort)
+	if err != nil {
+		return err
+	}
+	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, port, fwd.connection.Options)
 	if err != nil {
 		return fmt.Errorf("error deleting tunnel port: %w", err)
 	}


### PR DESCRIPTION
## Summary

Use the existing `convertIntToUint16` helper with bounds checking instead of a raw `uint16()` cast on `remotePort` in `UpdatePortVisibility`. This prevents potential integer overflow when the port value exceeds the uint16 range (0–65535).

Fixes https://github.com/cli/cli/security/code-scanning/137 (`go/incorrect-integer-conversion`, CWE-190, CWE-681).