### PR TITLE
Enable exclude_repo_admins for issue triage

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -7,6 +7,8 @@ jobs:
   label-incoming:
     if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'unlabeled'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-label-incoming.yml@main
+    with:
+      exclude_repo_admins: true
     permissions:
       issues: write
 


### PR DESCRIPTION
## Summary

Enable `exclude_repo_admins: true` on the `label-incoming` job so that issues opened by repo admins won't be auto-labeled with `needs-triage`.

## Depends on

- desktop/gh-cli-and-desktop-shared-workflows#10 (adds the `exclude_repo_admins` input)

## How it works

When an issue is opened/reopened, the shared workflow checks the author's repo permission via `GET /repos/{owner}/{repo}/collaborators/{username}/permission`. If the author is an `admin`, the `needs-triage` label is not applied. This uses the default `GITHUB_TOKEN` — no additional secrets required.