### PR TITLE
build(scripts): update createrepo.sh to use Fedora 40 and dnf

### DIFF
--- a/script/createrepo.sh
+++ b/script/createrepo.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
-mkdir createrepo
+mkdir -p createrepo
 cat > createrepo/Dockerfile << EOF
-FROM fedora:32
-RUN yum install -y createrepo_c
+FROM fedora:40
+RUN dnf install -y createrepo_c && dnf clean all
 ENTRYPOINT ["createrepo", "/packages"]
 EOF
 


### PR DESCRIPTION
The current `createrepo.sh` script uses an EOL Fedora version (32) and the deprecated `yum` package manager. 

This PR updates the internal helper script to:
1. Use `fedora:40` as the base image.
2. Switch from `yum` to `dnf`.
3. Add `dnf clean all` to optimize the build process.
4. Use `mkdir -p` for safer directory creation.

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #12844 `
-->
