### PR TITLE
refactor: deduplicate scope error handling between api/client.go and project queries

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -203,7 +203,6 @@ func GenerateScopeErrorForGQL(gqlErr *ghAPI.GraphQLError) error {
 	}
 	if missing.Len() > 0 {
 		s := missing.ToSlice()
-		// TODO: this duplicates parts of generateScopesSuggestion
 		return fmt.Errorf(
 			"error: your authentication token is missing required scopes %v\n"+
 				"To request it, run:  gh auth refresh -s %s",

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/cli/cli/v2/pkg/set"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -1664,40 +1662,13 @@ func (c *Client) UnlinkProjectFromTeam(projectID string, teamID string) error {
 }
 
 func handleError(err error) error {
-	var gerr api.GraphQLError
-	if errors.As(err, &gerr) {
-		missing := set.NewStringSet()
-		for _, e := range gerr.Errors {
-			if e.Type != "INSUFFICIENT_SCOPES" {
-				continue
-			}
-			missing.AddValues(requiredScopesFromServerMessage(e.Message))
-		}
-		if missing.Len() > 0 {
-			s := missing.ToSlice()
-			// TODO: this duplicates parts of generateScopesSuggestion
-			return fmt.Errorf(
-				"error: your authentication token is missing required scopes %v\n"+
-					"To request it, run:  gh auth refresh -s %s",
-				s,
-				strings.Join(s, ","))
+	var gqlErr api.GraphQLError
+	if errors.As(err, &gqlErr) {
+		if scopeErr := api.GenerateScopeErrorForGQL(gqlErr.GraphQLError); scopeErr != nil {
+			return scopeErr
 		}
 	}
 	return err
-}
-
-var scopesRE = regexp.MustCompile(`one of the following scopes: \[(.+?)]`)
-
-func requiredScopesFromServerMessage(msg string) []string {
-	m := scopesRE.FindStringSubmatch(msg)
-	if m == nil {
-		return nil
-	}
-	var scopes []string
-	for _, mm := range strings.Split(m[1], ",") {
-		scopes = append(scopes, strings.Trim(mm, "' "))
-	}
-	return scopes
 }
 
 func projectFieldValueData(v FieldValueNodes) interface{} {

--- a/pkg/cmd/project/shared/queries/queries_test.go
+++ b/pkg/cmd/project/shared/queries/queries_test.go
@@ -3,7 +3,6 @@ package queries
 import (
 	"io"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -562,37 +561,6 @@ func TestProjectFields_NoLimit(t *testing.T) {
 	project, err := client.ProjectFields(owner, 1, 0)
 	assert.NoError(t, err)
 	assert.Len(t, project.Fields.Nodes, 3)
-}
-
-func Test_requiredScopesFromServerMessage(t *testing.T) {
-	tests := []struct {
-		name string
-		msg  string
-		want []string
-	}{
-		{
-			name: "no scopes",
-			msg:  "SERVER OOPSIE",
-			want: []string(nil),
-		},
-		{
-			name: "one scope",
-			msg:  "Your token has not been granted the required scopes to execute this query. The 'dataType' field requires one of the following scopes: ['read:project'], but your token has only been granted the: ['codespace', repo'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens.",
-			want: []string{"read:project"},
-		},
-		{
-			name: "multiple scopes",
-			msg:  "Your token has not been granted the required scopes to execute this query. The 'dataType' field requires one of the following scopes: ['read:project', 'read:discussion', 'codespace'], but your token has only been granted the: [repo'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens.",
-			want: []string{"read:project", "read:discussion", "codespace"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := requiredScopesFromServerMessage(tt.msg); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("requiredScopesFromServerMessage() = %v, want %v", got, tt.want)
-			}
-		})
-	}
 }
 
 func TestNewProject_nonTTY(t *testing.T) {


### PR DESCRIPTION
Fixes #12823

Both `api/client.go` and `pkg/cmd/project/shared/queries/queries.go` had their own copy of `requiredScopesFromServerMessage` and the same `INSUFFICIENT_SCOPES` parsing logic. The existing code even had a TODO noting this: `// TODO: this duplicates parts of generateScopesSuggestion`.

This PR removes the duplicated functions from `queries.go` and has `handleError` call `api.GenerateScopeErrorForGQL` instead. The duplicate test was also removed since `api/client_test.go` already covers `requiredScopesFromServerMessage`.

**Changes:**
- `queries.go`: replaced `handleError` internals with a call to `api.GenerateScopeErrorForGQL`, removed `requiredScopesFromServerMessage` and `scopesRE`
- `queries_test.go`: removed `Test_requiredScopesFromServerMessage` (covered by `api/client_test.go:TestRequiredScopesFromServerMessage`)
- `api/client.go`: removed the now-resolved TODO comment