### PR TITLE
feat: add --account flag and GH_ACCOUNT env var for per-command account selection

### DIFF
--- a/internal/config/account.go
+++ b/internal/config/account.go
@@ -1,0 +1,16 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseAccount splits a "user@host" account identifier into its user and host
+// components. Returns an error with an actionable message if the format is invalid.
+func ParseAccount(account string) (user, host string, err error) {
+	idx := strings.LastIndex(account, "@")
+	if idx < 1 || idx >= len(account)-1 {
+		return "", "", fmt.Errorf(`invalid account format %q. Expected "user@host" (e.g. "monalisa@github.com")`, account)
+	}
+	return account[:idx], account[idx+1:], nil
+}

--- a/internal/config/account_test.go
+++ b/internal/config/account_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAccount(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantUser string
+		wantHost string
+		wantErr  string
+	}{
+		{
+			name:     "valid github.com account",
+			input:    "monalisa@github.com",
+			wantUser: "monalisa",
+			wantHost: "github.com",
+		},
+		{
+			name:     "valid enterprise account",
+			input:    "admin@github.enterprise.com",
+			wantUser: "admin",
+			wantHost: "github.enterprise.com",
+		},
+		{
+			name:    "missing host",
+			input:   "monalisa",
+			wantErr: `invalid account format "monalisa". Expected "user@host" (e.g. "monalisa@github.com")`,
+		},
+		{
+			name:    "missing user",
+			input:   "@github.com",
+			wantErr: `invalid account format "@github.com". Expected "user@host" (e.g. "monalisa@github.com")`,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: `invalid account format "". Expected "user@host" (e.g. "monalisa@github.com")`,
+		},
+		{
+			name:    "trailing at sign",
+			input:   "monalisa@",
+			wantErr: `invalid account format "monalisa@". Expected "user@host" (e.g. "monalisa@github.com")`,
+		},
+		{
+			name:     "host with port",
+			input:    "admin@github.example.com:8443",
+			wantUser: "admin",
+			wantHost: "github.example.com:8443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user, host, err := ParseAccount(tt.input)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantUser, user)
+			require.Equal(t, tt.wantHost, host)
+		})
+	}
+}

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -947,3 +947,53 @@ func preMigrationLogin(c *AuthConfig, hostname, username, token, gitProtocol str
 	}
 	return insecureStorageUsed, ghConfig.Write(c.cfg)
 }
+
+func TestActiveTokenWithAccountOverride(t *testing.T) {
+	// Given two users logged into the same host
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "active-user", "active-token", "", false)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "other-user", "other-token", "", false)
+	require.NoError(t, err)
+	// other-user is now active (Login activates the logged-in user)
+
+	// When we set the account override to active-user@github.com
+	authCfg.SetAccountOverride("active-user@github.com")
+
+	// Then ActiveToken returns active-user's token
+	token, source := authCfg.ActiveToken("github.com")
+	require.Equal(t, "active-token", token)
+	require.NotEmpty(t, source)
+}
+
+func TestActiveTokenWithAccountOverrideWrongHost(t *testing.T) {
+	// Given a user logged into github.com
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "monalisa", "gh-token", "", false)
+	require.NoError(t, err)
+
+	// When we set the account override to a different host
+	authCfg.SetAccountOverride("monalisa@enterprise.com")
+
+	// Then ActiveToken for github.com falls through to normal resolution
+	token, _ := authCfg.ActiveToken("github.com")
+	require.Equal(t, "gh-token", token)
+}
+
+func TestActiveUserWithAccountOverride(t *testing.T) {
+	// Given two users on the same host
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "user-one", "token-one", "", false)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "user-two", "token-two", "", false)
+	require.NoError(t, err)
+	// user-two is now active
+
+	// When we override to user-one
+	authCfg.SetAccountOverride("user-one@github.com")
+
+	// Then ActiveUser returns user-one
+	user, err := authCfg.ActiveUser("github.com")
+	require.NoError(t, err)
+	require.Equal(t, "user-one", user)
+}

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -957,8 +957,8 @@ func TestActiveTokenWithAccountOverride(t *testing.T) {
 	require.NoError(t, err)
 	// other-user is now active (Login activates the logged-in user)
 
-	// When we set the account override to active-user@github.com
-	authCfg.SetAccountOverride("active-user@github.com")
+	// When we set the account override to active-user on github.com
+	authCfg.SetAccountOverride("active-user", "github.com")
 
 	// Then ActiveToken returns active-user's token
 	token, source := authCfg.ActiveToken("github.com")
@@ -973,7 +973,7 @@ func TestActiveTokenWithAccountOverrideWrongHost(t *testing.T) {
 	require.NoError(t, err)
 
 	// When we set the account override to a different host
-	authCfg.SetAccountOverride("monalisa@enterprise.com")
+	authCfg.SetAccountOverride("monalisa", "enterprise.com")
 
 	// Then ActiveToken for github.com falls through to normal resolution
 	token, _ := authCfg.ActiveToken("github.com")
@@ -990,7 +990,7 @@ func TestActiveUserWithAccountOverride(t *testing.T) {
 	// user-two is now active
 
 	// When we override to user-one
-	authCfg.SetAccountOverride("user-one@github.com")
+	authCfg.SetAccountOverride("user-one", "github.com")
 
 	// Then ActiveUser returns user-one
 	user, err := authCfg.ActiveUser("github.com")
@@ -1003,7 +1003,7 @@ func TestDefaultHostWithAccountOverride(t *testing.T) {
 	_, err := authCfg.Login("enterprise.example.com", "admin", "ent-token", "", false)
 	require.NoError(t, err)
 
-	authCfg.SetAccountOverride("admin@enterprise.example.com")
+	authCfg.SetAccountOverride("admin", "enterprise.example.com")
 
 	host, source := authCfg.DefaultHost()
 	require.Equal(t, "enterprise.example.com", host)

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -997,3 +997,15 @@ func TestActiveUserWithAccountOverride(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "user-one", user)
 }
+
+func TestDefaultHostWithAccountOverride(t *testing.T) {
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("enterprise.example.com", "admin", "ent-token", "", false)
+	require.NoError(t, err)
+
+	authCfg.SetAccountOverride("admin@enterprise.example.com")
+
+	host, source := authCfg.DefaultHost()
+	require.Equal(t, "enterprise.example.com", host)
+	require.Equal(t, "--account", source)
+}

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -693,7 +693,7 @@ func TestUserWorksRightAfterMigration(t *testing.T) {
 
 	// When we migrate
 	var m migration.MultiAccount
-	c := cfg{authCfg.cfg}
+	c := cfg{cfg: authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
 	// Then we can still get the user correctly
@@ -710,7 +710,7 @@ func TestGitProtocolWorksRightAfterMigration(t *testing.T) {
 
 	// When we migrate
 	var m migration.MultiAccount
-	c := cfg{authCfg.cfg}
+	c := cfg{cfg: authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
 	// Then we can still get the git protocol correctly
@@ -727,7 +727,7 @@ func TestHostsWorksRightAfterMigration(t *testing.T) {
 
 	// When we migrate
 	var m migration.MultiAccount
-	c := cfg{authCfg.cfg}
+	c := cfg{cfg: authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
 	// Then we can still get the hosts correctly
@@ -743,7 +743,7 @@ func TestDefaultHostWorksRightAfterMigration(t *testing.T) {
 
 	// When we migrate
 	var m migration.MultiAccount
-	c := cfg{authCfg.cfg}
+	c := cfg{cfg: authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
 	// Then the default host is still the enterprise host
@@ -760,7 +760,7 @@ func TestTokenWorksRightAfterMigration(t *testing.T) {
 
 	// When we migrate
 	var m migration.MultiAccount
-	c := cfg{authCfg.cfg}
+	c := cfg{cfg: authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
 	// Then we can still get the token correctly
@@ -837,7 +837,7 @@ func TestLogoutRightAfterMigrationRemovesHost(t *testing.T) {
 
 	// When we migrate and logout
 	var m migration.MultiAccount
-	c := cfg{authCfg.cfg}
+	c := cfg{cfg: authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
 	require.NoError(t, authCfg.Logout(host, user))
@@ -852,7 +852,7 @@ func TestLoginInsecurePostMigrationUsesConfigForToken(t *testing.T) {
 
 	// When we migrate and login with insecure storage
 	var m migration.MultiAccount
-	c := cfg{authCfg.cfg}
+	c := cfg{cfg: authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
 	insecureStorageUsed, err := authCfg.Login("github.com", "test-user", "test-token", "", false)
@@ -871,7 +871,7 @@ func TestLoginPostMigrationSetsGitProtocol(t *testing.T) {
 	authCfg := newTestAuthConfig(t)
 
 	var m migration.MultiAccount
-	c := cfg{authCfg.cfg}
+	c := cfg{cfg: authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
 	_, err := authCfg.Login("github.com", "test-user", "test-token", "ssh", false)
@@ -890,7 +890,7 @@ func TestLoginPostMigrationSetsUser(t *testing.T) {
 	authCfg := newTestAuthConfig(t)
 
 	var m migration.MultiAccount
-	c := cfg{authCfg.cfg}
+	c := cfg{cfg: authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
 	_, err := authCfg.Login("github.com", "test-user", "test-token", "ssh", false)
@@ -912,7 +912,7 @@ func TestLoginSecurePostMigrationRemovesTokenFromConfig(t *testing.T) {
 
 	// When we migrate and login again with secure storage
 	var m migration.MultiAccount
-	c := cfg{authCfg.cfg}
+	c := cfg{cfg: authCfg.cfg}
 	require.NoError(t, c.Migrate(m))
 
 	_, err = authCfg.Login("github.com", "test-user", "test-token", "", true)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -366,14 +366,10 @@ func (c *AuthConfig) SetDefaultHost(host, source string) {
 	}
 }
 
-// SetAccountOverride sets a "user@host" account override. When set,
-// ActiveToken and ActiveUser will resolve to this account instead of
-// the configured active user.
-func (c *AuthConfig) SetAccountOverride(account string) {
-	user, host, err := ParseAccount(account)
-	if err != nil {
-		return
-	}
+// SetAccountOverride sets an account override by user and host. When set,
+// ActiveToken, ActiveUser, and DefaultHost will resolve to this account
+// instead of the configured active user.
+func (c *AuthConfig) SetAccountOverride(user, host string) {
 	c.accountOverrideUser = user
 	c.accountOverrideHost = host
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -351,6 +351,11 @@ func (c *AuthConfig) SetHosts(hosts []string) {
 }
 
 func (c *AuthConfig) DefaultHost() (string, string) {
+	if c.accountOverride != "" {
+		if _, host, err := ParseAccount(c.accountOverride); err == nil {
+			return host, "--account"
+		}
+	}
 	if c.defaultHostOverride != nil {
 		return c.defaultHostOverride()
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,12 +41,13 @@ func NewConfig() (gh.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &cfg{c}, nil
+	return &cfg{cfg: c}, nil
 }
 
 // Implements Config interface
 type cfg struct {
-	cfg *ghConfig.Config
+	cfg     *ghConfig.Config
+	authCfg *AuthConfig
 }
 
 func (c *cfg) get(hostname, key string) o.Option[string] {
@@ -111,7 +112,10 @@ func (c *cfg) Aliases() gh.AliasConfig {
 }
 
 func (c *cfg) Authentication() gh.AuthConfig {
-	return &AuthConfig{cfg: c.cfg}
+	if c.authCfg == nil {
+		c.authCfg = &AuthConfig{cfg: c.cfg}
+	}
+	return c.authCfg
 }
 
 func (c *cfg) AccessibleColors(hostname string) gh.ConfigEntry {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,6 +233,17 @@ func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 	if c.tokenOverride != nil {
 		return c.tokenOverride(hostname)
 	}
+	// When an account override is set for this host, skip the global
+	// oauth_token lookup (which would return the wrong user's token) and go
+	// directly to the per-user token store.
+	if c.accountOverride != "" {
+		if user, host, err := ParseAccount(c.accountOverride); err == nil && host == hostname {
+			token, source, err := c.TokenForUser(hostname, user)
+			if err == nil {
+				return token, source
+			}
+		}
+	}
 	token, source := ghauth.TokenFromEnvOrConfig(hostname)
 	if token == "" {
 		var user string
@@ -312,6 +323,15 @@ func (c *AuthConfig) TokenFromKeyringForUser(hostname, username string) (string,
 // ActiveUser will retrieve the username for the active user at the given hostname.
 // This will not be accurate if the oauth token is set from an environment variable.
 func (c *AuthConfig) ActiveUser(hostname string) (string, error) {
+	if c.accountOverride != "" {
+		user, host, err := ParseAccount(c.accountOverride)
+		if err != nil {
+			return "", err
+		}
+		if host == hostname {
+			return user, nil
+		}
+	}
 	return c.cfg.Get([]string{hostsKey, hostname, userKey})
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,6 +223,7 @@ type AuthConfig struct {
 	defaultHostOverride func() (string, string)
 	hostsOverride       func() []string
 	tokenOverride       func(string) (string, string)
+	accountOverride     string // "user@host", set from --account flag or GH_ACCOUNT env var
 }
 
 // ActiveToken will retrieve the active auth token for the given hostname,
@@ -342,6 +343,13 @@ func (c *AuthConfig) SetDefaultHost(host, source string) {
 	c.defaultHostOverride = func() (string, string) {
 		return host, source
 	}
+}
+
+// SetAccountOverride sets a "user@host" account override. When set,
+// ActiveToken and ActiveUser will resolve to this account instead of
+// the configured active user.
+func (c *AuthConfig) SetAccountOverride(account string) {
+	c.accountOverride = account
 }
 
 // Login will set user, git protocol, and auth token for the given hostname.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -227,7 +227,8 @@ type AuthConfig struct {
 	defaultHostOverride func() (string, string)
 	hostsOverride       func() []string
 	tokenOverride       func(string) (string, string)
-	accountOverride     string // "user@host", set from --account flag or GH_ACCOUNT env var
+	accountOverrideUser string // username from --account flag or GH_ACCOUNT
+	accountOverrideHost string // hostname from --account flag or GH_ACCOUNT
 }
 
 // ActiveToken will retrieve the active auth token for the given hostname,
@@ -240,13 +241,12 @@ func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 	// When an account override is set for this host, skip the global
 	// oauth_token lookup (which would return the wrong user's token) and go
 	// directly to the per-user token store.
-	if c.accountOverride != "" {
-		if user, host, err := ParseAccount(c.accountOverride); err == nil && host == hostname {
-			token, source, err := c.TokenForUser(hostname, user)
-			if err == nil {
-				return token, source
-			}
+	if c.accountOverrideHost == hostname {
+		token, source, err := c.TokenForUser(hostname, c.accountOverrideUser)
+		if err != nil {
+			return "", ""
 		}
+		return token, source
 	}
 	token, source := ghauth.TokenFromEnvOrConfig(hostname)
 	if token == "" {
@@ -327,14 +327,8 @@ func (c *AuthConfig) TokenFromKeyringForUser(hostname, username string) (string,
 // ActiveUser will retrieve the username for the active user at the given hostname.
 // This will not be accurate if the oauth token is set from an environment variable.
 func (c *AuthConfig) ActiveUser(hostname string) (string, error) {
-	if c.accountOverride != "" {
-		user, host, err := ParseAccount(c.accountOverride)
-		if err != nil {
-			return "", err
-		}
-		if host == hostname {
-			return user, nil
-		}
+	if c.accountOverrideHost == hostname {
+		return c.accountOverrideUser, nil
 	}
 	return c.cfg.Get([]string{hostsKey, hostname, userKey})
 }
@@ -355,10 +349,8 @@ func (c *AuthConfig) SetHosts(hosts []string) {
 }
 
 func (c *AuthConfig) DefaultHost() (string, string) {
-	if c.accountOverride != "" {
-		if _, host, err := ParseAccount(c.accountOverride); err == nil {
-			return host, "--account"
-		}
+	if c.accountOverrideHost != "" {
+		return c.accountOverrideHost, "--account"
 	}
 	if c.defaultHostOverride != nil {
 		return c.defaultHostOverride()
@@ -378,7 +370,12 @@ func (c *AuthConfig) SetDefaultHost(host, source string) {
 // ActiveToken and ActiveUser will resolve to this account instead of
 // the configured active user.
 func (c *AuthConfig) SetAccountOverride(account string) {
-	c.accountOverride = account
+	user, host, err := ParseAccount(account)
+	if err != nil {
+		return
+	}
+	c.accountOverrideUser = user
+	c.accountOverrideHost = host
 }
 
 // Login will set user, git protocol, and auth token for the given hostname.

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -30,7 +30,7 @@ func TestMigrationAppliedSuccessfully(t *testing.T) {
 	})
 
 	// When we run the migration
-	conf := cfg{c}
+	conf := cfg{cfg: c}
 	require.NoError(t, conf.Migrate(migration))
 
 	// Then our original config is updated with the migration applied
@@ -75,7 +75,7 @@ func TestMigrationAppliedBumpsVersion(t *testing.T) {
 	}
 
 	// When we migrate
-	conf := cfg{c}
+	conf := cfg{cfg: c}
 	require.NoError(t, conf.Migrate(migration))
 
 	// Then our original config is updated with the migration applied
@@ -110,7 +110,7 @@ func TestMigrationIsNoopWhenAlreadyApplied(t *testing.T) {
 	}
 
 	// When we run Migrate
-	conf := cfg{c}
+	conf := cfg{cfg: c}
 	err := conf.Migrate(migration)
 
 	// Then there is nothing done and the config is not modified
@@ -141,7 +141,7 @@ func TestMigrationErrorsWhenPreVersionMismatch(t *testing.T) {
 	}
 
 	// When we run Migrate
-	conf := cfg{c}
+	conf := cfg{cfg: c}
 	err := conf.Migrate(migration)
 
 	// Then there is an error the migration is not applied and the version is not modified
@@ -161,7 +161,7 @@ func TestMigrationErrorWritesNoFiles(t *testing.T) {
 	})
 
 	// When we run the migration
-	conf := cfg{c}
+	conf := cfg{cfg: c}
 	err := conf.Migrate(migration)
 
 	// Then the error is wrapped and bubbled
@@ -210,7 +210,7 @@ func TestMigrationWriteErrors(t *testing.T) {
 			})
 
 			// When we run the migration
-			conf := cfg{c}
+			conf := cfg{cfg: c}
 			err := conf.Migrate(migration)
 
 			// Then the error is wrapped and bubbled

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -19,7 +19,7 @@ func NewBlankConfig() *ghmock.ConfigMock {
 
 func NewFromString(cfgStr string) *ghmock.ConfigMock {
 	c := ghConfig.ReadFromString(cfgStr)
-	cfg := cfg{c}
+	cfg := cfg{cfg: c}
 	mock := &ghmock.ConfigMock{}
 	mock.GetOrDefaultFunc = func(host, key string) o.Option[gh.ConfigEntry] {
 		return cfg.GetOrDefault(host, key)
@@ -103,7 +103,7 @@ func NewIsolatedTestConfig(t *testing.T) (*cfg, func(io.Writer, io.Writer)) {
 	keyring.MockInit()
 
 	c := ghConfig.ReadFromString("")
-	cfg := cfg{c}
+	cfg := cfg{cfg: c}
 
 	// The real implementation of config.Read uses a sync.Once
 	// to read config files and initialise package level variables

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -167,10 +167,10 @@ type AuthConfig interface {
 	// Use for testing purposes only.
 	SetDefaultHost(host, source string)
 
-	// SetAccountOverride sets a "user@host" override for account selection.
-	// When set, ActiveToken and ActiveUser will resolve to this account
-	// instead of the configured active user. The override is in-memory only.
-	SetAccountOverride(account string)
+	// SetAccountOverride sets a user and host override for account selection.
+	// When set, ActiveToken, ActiveUser, and DefaultHost will resolve to this
+	// account instead of the configured active user. The override is in-memory only.
+	SetAccountOverride(user, host string)
 }
 
 // AliasConfig defines an interface for managing command aliases.

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -166,6 +166,11 @@ type AuthConfig interface {
 	// DefaultHost.
 	// Use for testing purposes only.
 	SetDefaultHost(host, source string)
+
+	// SetAccountOverride sets a "user@host" override for account selection.
+	// When set, ActiveToken and ActiveUser will resolve to this account
+	// instead of the configured active user. The override is in-memory only.
+	SetAccountOverride(account string)
 }
 
 // AliasConfig defines an interface for managing command aliases.

--- a/pkg/cmd/root/account_test.go
+++ b/pkg/cmd/root/account_test.go
@@ -1,0 +1,151 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestCmd creates a minimal cobra command with the "account" string flag,
+// simulating the flag registration done in NewCmdRoot.
+func newTestCmd(name string) *cobra.Command {
+	cmd := &cobra.Command{Use: name}
+	cmd.Flags().String("account", "", "")
+	return cmd
+}
+
+// setupTestConfig creates an isolated test config with a logged-in user and
+// returns the gh.Config interface value for use in tests.
+func setupTestConfig(t *testing.T, hostname, username, token string) gh.Config {
+	t.Helper()
+	cfg, _ := config.NewIsolatedTestConfig(t)
+	authCfg := cfg.Authentication()
+	realAuthCfg, ok := authCfg.(*config.AuthConfig)
+	require.True(t, ok, "expected *config.AuthConfig from Authentication()")
+	_, err := realAuthCfg.Login(hostname, username, token, "", false)
+	require.NoError(t, err)
+	return cfg
+}
+
+func TestApplyAccountOverride_ValidAccountSetsOverride(t *testing.T) {
+	// Given a config with a logged-in user
+	cfg := setupTestConfig(t, "github.com", "monalisa", "test-token")
+
+	cmd := newTestCmd("status")
+	require.NoError(t, cmd.Flags().Set("account", "monalisa@github.com"))
+
+	// When we apply the account override
+	err := applyAccountOverride(cmd, cfg)
+
+	// Then it should succeed with no error
+	require.NoError(t, err)
+}
+
+func TestApplyAccountOverride_GHAccountEnvVar(t *testing.T) {
+	// Given a config with a logged-in user
+	cfg := setupTestConfig(t, "github.com", "monalisa", "test-token")
+
+	// When GH_ACCOUNT env var is set (no flag)
+	t.Setenv("GH_ACCOUNT", "monalisa@github.com")
+	cmd := newTestCmd("status")
+
+	err := applyAccountOverride(cmd, cfg)
+
+	// Then it should succeed with no error (env var was picked up)
+	require.NoError(t, err)
+}
+
+func TestApplyAccountOverride_FlagTakesPrecedenceOverEnvVar(t *testing.T) {
+	// Given a config with two logged-in users on different hosts
+	cfg := setupTestConfig(t, "github.com", "monalisa", "test-token")
+	// Also log in as a second user
+	authCfg, ok := cfg.Authentication().(*config.AuthConfig)
+	require.True(t, ok)
+	_, err := authCfg.Login("github.com", "hubot", "other-token", "", false)
+	require.NoError(t, err)
+
+	// When both the flag and env var are set
+	t.Setenv("GH_ACCOUNT", "hubot@github.com")
+	cmd := newTestCmd("status")
+	require.NoError(t, cmd.Flags().Set("account", "monalisa@github.com"))
+
+	// Then the call succeeds (flag value "monalisa@github.com" is valid and takes precedence)
+	err = applyAccountOverride(cmd, cfg)
+	require.NoError(t, err)
+}
+
+func TestApplyAccountOverride_InvalidFormatProducesError(t *testing.T) {
+	cfg := setupTestConfig(t, "github.com", "monalisa", "test-token")
+
+	cmd := newTestCmd("status")
+	require.NoError(t, cmd.Flags().Set("account", "monalisa"))
+
+	// When we apply with a value missing the @host part
+	err := applyAccountOverride(cmd, cfg)
+
+	// Then we get a format error
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid account format`)
+	assert.Contains(t, err.Error(), `user@host`)
+}
+
+func TestApplyAccountOverride_UnknownAccountProducesError(t *testing.T) {
+	// Given a config with one logged-in user
+	cfg := setupTestConfig(t, "github.com", "monalisa", "test-token")
+
+	cmd := newTestCmd("status")
+	require.NoError(t, cmd.Flags().Set("account", "ghost@github.com"))
+
+	// When we apply with an account that doesn't exist
+	err := applyAccountOverride(cmd, cfg)
+
+	// Then we get an error that names the missing account and lists available ones
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `account "ghost@github.com" not found`)
+	assert.Contains(t, err.Error(), "monalisa@github.com")
+}
+
+func TestApplyAccountOverride_GHTokenWarnsAndReturnsNil(t *testing.T) {
+	// Given a config with a logged-in user
+	cfg := setupTestConfig(t, "github.com", "monalisa", "test-token")
+
+	// When GH_TOKEN is also set
+	t.Setenv("GH_TOKEN", "env-token")
+	cmd := newTestCmd("status")
+	require.NoError(t, cmd.Flags().Set("account", "monalisa@github.com"))
+
+	// Then applyAccountOverride returns nil (no error) and skips the override
+	err := applyAccountOverride(cmd, cfg)
+	require.NoError(t, err)
+}
+
+func TestApplyAccountOverride_AuthMutationCommandWarnsAndReturnsNil(t *testing.T) {
+	// Given a config with a logged-in user
+	cfg := setupTestConfig(t, "github.com", "monalisa", "test-token")
+
+	// When account is set for a mutation command (e.g. "login" under "auth")
+	authCmd := &cobra.Command{Use: "auth"}
+	loginCmd := newTestCmd("login")
+	authCmd.AddCommand(loginCmd)
+	require.NoError(t, loginCmd.Flags().Set("account", "monalisa@github.com"))
+
+	// Then applyAccountOverride returns nil (no error) but does NOT set override
+	err := applyAccountOverride(loginCmd, cfg)
+	require.NoError(t, err)
+}
+
+func TestApplyAccountOverride_NoFlagNoEnvIsNoop(t *testing.T) {
+	// Given a config (no account flag, no env var)
+	cfg := setupTestConfig(t, "github.com", "monalisa", "test-token")
+	cmd := newTestCmd("status")
+
+	// When we apply with nothing set
+	err := applyAccountOverride(cmd, cfg)
+
+	// Then it's a no-op with no error
+	require.NoError(t, err)
+}

--- a/pkg/cmd/root/account_test.go
+++ b/pkg/cmd/root/account_test.go
@@ -43,6 +43,10 @@ func TestApplyAccountOverride_ValidAccountSetsOverride(t *testing.T) {
 
 	// Then it should succeed with no error
 	require.NoError(t, err)
+
+	// Then the override should change which token is returned
+	token, _ := cfg.Authentication().ActiveToken("github.com")
+	require.Equal(t, "test-token", token)
 }
 
 func TestApplyAccountOverride_GHAccountEnvVar(t *testing.T) {
@@ -76,6 +80,10 @@ func TestApplyAccountOverride_FlagTakesPrecedenceOverEnvVar(t *testing.T) {
 	// Then the call succeeds (flag value "monalisa@github.com" is valid and takes precedence)
 	err = applyAccountOverride(cmd, cfg)
 	require.NoError(t, err)
+
+	// Then the override should resolve to monalisa's token (from the flag), not hubot's (from env)
+	token, _ := cfg.Authentication().ActiveToken("github.com")
+	require.Equal(t, "test-token", token) // monalisa's token from setupTestConfig
 }
 
 func TestApplyAccountOverride_InvalidFormatProducesError(t *testing.T) {

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -287,8 +287,24 @@ func applyAccountOverride(cmd *cobra.Command, cfg gh.Config) error {
 		return accountNotFoundError(account, authCfg)
 	}
 
+	// Warn and skip for auth mutation commands (login, logout, switch)
+	if isAuthMutationCommand(cmd) {
+		fmt.Fprintf(os.Stderr, "warning: --account is ignored for %q\n", cmd.Name())
+		return nil
+	}
+
 	authCfg.SetAccountOverride(account)
 	return nil
+}
+
+func isAuthMutationCommand(cmd *cobra.Command) bool {
+	mutationCmds := map[string]bool{"login": true, "logout": true, "switch": true}
+	if !mutationCmds[cmd.Name()] {
+		return false
+	}
+	// Check that the parent is the "auth" command
+	parent := cmd.Parent()
+	return parent != nil && parent.Name() == "auth"
 }
 
 func accountNotFoundError(account string, authCfg gh.AuthConfig) error {

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -287,35 +288,33 @@ func applyAccountOverride(cmd *cobra.Command, cfg gh.Config) error {
 		return nil
 	}
 
-	authCfg.SetAccountOverride(account)
+	authCfg.SetAccountOverride(user, host)
 	return nil
 }
 
 func isAuthMutationCommand(cmd *cobra.Command) bool {
-	mutationCmds := map[string]bool{"login": true, "logout": true, "switch": true}
-	if !mutationCmds[cmd.Name()] {
+	if !slices.Contains([]string{"login", "logout", "switch"}, cmd.Name()) {
 		return false
 	}
-	// Check that the parent is the "auth" command
 	parent := cmd.Parent()
 	return parent != nil && parent.Name() == "auth"
 }
 
 func accountNotFoundError(account string, authCfg gh.AuthConfig) error {
-	var available []string
+	var b strings.Builder
+	fmt.Fprintf(&b, "account %q not found", account)
+
+	var hasAccounts bool
 	for _, host := range authCfg.Hosts() {
 		for _, user := range authCfg.UsersForHost(host) {
-			available = append(available, user+"@"+host)
+			if !hasAccounts {
+				b.WriteString("\nAvailable accounts:\n")
+				hasAccounts = true
+			}
+			fmt.Fprintf(&b, "  %s@%s\n", user, host)
 		}
 	}
 
-	msg := fmt.Sprintf("account %q not found", account)
-	if len(available) > 0 {
-		msg += "\nAvailable accounts:\n"
-		for _, a := range available {
-			msg += fmt.Sprintf("  %s\n", a)
-		}
-	}
-	msg += `Run "gh auth login" to add a new account.`
-	return fmt.Errorf("%s", msg)
+	b.WriteString(`Run "gh auth login" to add a new account.`)
+	return errors.New(b.String())
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -3,6 +3,7 @@ package root
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
@@ -276,14 +277,7 @@ func applyAccountOverride(cmd *cobra.Command, cfg gh.Config) error {
 
 	// Validate the account exists in config
 	users := authCfg.UsersForHost(host)
-	found := false
-	for _, u := range users {
-		if u == user {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !slices.Contains(users, user) {
 		return accountNotFoundError(account, authCfg)
 	}
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
 	accessibilityCmd "github.com/cli/cli/v2/pkg/cmd/accessibility"
 	actionsCmd "github.com/cli/cli/v2/pkg/cmd/actions"
 	agentTaskCmd "github.com/cli/cli/v2/pkg/cmd/agent-task"
@@ -76,6 +78,11 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 			"versionInfo": versionCmd.Format(version, buildDate),
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Resolve --account flag or GH_ACCOUNT env var
+			if err := applyAccountOverride(cmd, cfg); err != nil {
+				return err
+			}
+
 			// require that the user is authenticated before running most commands
 			if cmdutil.IsAuthCheckEnabled(cmd) && !cmdutil.CheckAuth(cfg) {
 				parent := cmd.Parent()
@@ -94,6 +101,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 	// cmd.SetErr(f.IOStreams.ErrOut) // just let it default to os.Stderr instead
 
 	cmd.PersistentFlags().Bool("help", false, "Show help for command")
+	cmd.PersistentFlags().String("account", "", `Use the specified account for this command (format: "user@host")`)
 
 	// override Cobra's default behaviors unless an opt-out has been set
 	if os.Getenv("GH_COBRA") == "" {
@@ -239,4 +247,65 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 	referenceCmd.Long = stringifyReference(cmd)
 	referenceCmd.SetHelpFunc(longPager(f.IOStreams))
 	return cmd, nil
+}
+
+// applyAccountOverride checks for --account flag or GH_ACCOUNT env var and
+// configures the auth system to use the specified account for this command.
+func applyAccountOverride(cmd *cobra.Command, cfg gh.Config) error {
+	account, _ := cmd.Flags().GetString("account")
+	if account == "" {
+		account = os.Getenv("GH_ACCOUNT")
+	}
+	if account == "" {
+		return nil
+	}
+
+	authCfg := cfg.Authentication()
+
+	// If GH_TOKEN is set, the explicit token takes priority
+	if authCfg.HasEnvToken() {
+		fmt.Fprintf(os.Stderr, "warning: --account ignored because GH_TOKEN is set\n")
+		return nil
+	}
+
+	// Validate the account format
+	user, host, err := config.ParseAccount(account)
+	if err != nil {
+		return err
+	}
+
+	// Validate the account exists in config
+	users := authCfg.UsersForHost(host)
+	found := false
+	for _, u := range users {
+		if u == user {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return accountNotFoundError(account, authCfg)
+	}
+
+	authCfg.SetAccountOverride(account)
+	return nil
+}
+
+func accountNotFoundError(account string, authCfg gh.AuthConfig) error {
+	var available []string
+	for _, host := range authCfg.Hosts() {
+		for _, user := range authCfg.UsersForHost(host) {
+			available = append(available, user+"@"+host)
+		}
+	}
+
+	msg := fmt.Sprintf("account %q not found", account)
+	if len(available) > 0 {
+		msg += "\nAvailable accounts:\n"
+		for _, a := range available {
+			msg += fmt.Sprintf("  %s\n", a)
+		}
+	}
+	msg += `Run "gh auth login" to add a new account.`
+	return fmt.Errorf("%s", msg)
 }


### PR DESCRIPTION
> **Note:** I know the contribution guidelines say to open issues first and only push PRs for issues flagged `help-wanted`. However, there are only three such issues, and this is a real pain point using the CLI that's been around a *long* time. This fix would benefit everyone, including all the users who have commented on #326 with workarounds for the statefulness of the tool.

## Summary

- Adds a `--account user@host` persistent flag and `GH_ACCOUNT` environment variable that lets users specify which authenticated account to use per-command, eliminating the need to globally switch accounts with `gh auth switch`
- Overrides token resolution, active user, and default host for the duration of the command without modifying any persisted configuration
- Validates the account exists in config, fails loud on errors, and respects `GH_TOKEN` precedence with a warning

Closes #326

## Test plan

- [x] Unit tests for `ParseAccount` parser (7 cases)
- [x] Unit tests for `ActiveToken`, `ActiveUser`, `DefaultHost` override behavior (4 cases)
- [x] Integration tests for `applyAccountOverride` (8 cases covering flag, env var, precedence, errors, GH_TOKEN, auth mutation guard, no-op)
- [x] Full `go test ./...` passes
- [x] Manual testing with `--account user@host` against real repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)