### PR TITLE
`gh pr view` and `gh issue view`: show friendly display names for all actors

### DIFF
--- a/api/queries_comments.go
+++ b/api/queries_comments.go
@@ -129,7 +129,7 @@ func (c Comment) Identifier() string {
 }
 
 func (c Comment) AuthorLogin() string {
-	return c.Author.Login
+	return copilotDisplayName(c.Author.Login)
 }
 
 func (c Comment) Association() string {

--- a/api/queries_comments.go
+++ b/api/queries_comments.go
@@ -129,7 +129,7 @@ func (c Comment) Identifier() string {
 }
 
 func (c Comment) AuthorLogin() string {
-	return copilotDisplayName(c.Author.Login)
+	return c.Author.DisplayName()
 }
 
 func (c Comment) Association() string {

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -234,6 +234,11 @@ type Author struct {
 	Login string
 }
 
+// DisplayName returns a user-friendly name via actorDisplayName.
+func (a Author) DisplayName() string {
+	return actorDisplayName("", a.Login, a.Name)
+}
+
 func (author Author) MarshalJSON() ([]byte, error) {
 	if author.ID == "" {
 		return json.Marshal(map[string]interface{}{
@@ -258,6 +263,11 @@ type CommentAuthor struct {
 	//		ID   string
 	//		Name string
 	//	} `graphql:"... on User"`
+}
+
+// DisplayName returns a user-friendly name via actorDisplayName.
+func (a CommentAuthor) DisplayName() string {
+	return actorDisplayName("", a.Login, "")
 }
 
 // IssueCreate creates an issue in a GitHub repository

--- a/api/queries_pr_review.go
+++ b/api/queries_pr_review.go
@@ -143,6 +143,7 @@ type RequestedReviewer struct {
 
 const teamTypeName = "Team"
 const botTypeName = "Bot"
+const userTypeName = "User"
 
 func (r RequestedReviewer) LoginOrSlug() string {
 	if r.TypeName == teamTypeName {

--- a/api/queries_pr_review.go
+++ b/api/queries_pr_review.go
@@ -52,7 +52,7 @@ func (prr PullRequestReview) Identifier() string {
 }
 
 func (prr PullRequestReview) AuthorLogin() string {
-	return copilotDisplayName(prr.Author.Login)
+	return prr.Author.DisplayName()
 }
 
 func (prr PullRequestReview) Association() string {
@@ -151,21 +151,13 @@ func (r RequestedReviewer) LoginOrSlug() string {
 	return r.Login
 }
 
-// DisplayName returns a user-friendly name for the reviewer.
-// For Copilot bot, returns "Copilot (AI)". For teams, returns "org/slug".
-// For users, returns "login (Name)" if name is available, otherwise just login.
+// DisplayName returns a user-friendly name for the reviewer via actorDisplayName.
+// Teams are handled separately as "org/slug".
 func (r RequestedReviewer) DisplayName() string {
 	if r.TypeName == teamTypeName {
 		return fmt.Sprintf("%s/%s", r.Organization.Login, r.Slug)
 	}
-	displayName := copilotDisplayName(r.Login)
-	if displayName != r.Login {
-		return displayName
-	}
-	if r.Name != "" {
-		return fmt.Sprintf("%s (%s)", r.Login, r.Name)
-	}
-	return r.Login
+	return actorDisplayName(r.TypeName, r.Login, r.Name)
 }
 
 func (r ReviewRequests) Logins() []string {
@@ -222,7 +214,7 @@ func NewReviewerBot(login string) ReviewerBot {
 }
 
 func (b ReviewerBot) DisplayName() string {
-	return copilotDisplayName(b.login)
+	return actorDisplayName("Bot", b.login, "")
 }
 
 func (r ReviewerBot) sealedReviewerCandidate() {}

--- a/api/queries_pr_review.go
+++ b/api/queries_pr_review.go
@@ -52,7 +52,7 @@ func (prr PullRequestReview) Identifier() string {
 }
 
 func (prr PullRequestReview) AuthorLogin() string {
-	return prr.Author.Login
+	return copilotDisplayName(prr.Author.Login)
 }
 
 func (prr PullRequestReview) Association() string {
@@ -158,8 +158,9 @@ func (r RequestedReviewer) DisplayName() string {
 	if r.TypeName == teamTypeName {
 		return fmt.Sprintf("%s/%s", r.Organization.Login, r.Slug)
 	}
-	if r.TypeName == botTypeName && r.Login == CopilotReviewerLogin {
-		return "Copilot (AI)"
+	displayName := copilotDisplayName(r.Login)
+	if displayName != r.Login {
+		return displayName
 	}
 	if r.Name != "" {
 		return fmt.Sprintf("%s (%s)", r.Login, r.Name)
@@ -221,10 +222,7 @@ func NewReviewerBot(login string) ReviewerBot {
 }
 
 func (b ReviewerBot) DisplayName() string {
-	if b.login == CopilotReviewerLogin {
-		return fmt.Sprintf("%s (AI)", CopilotActorName)
-	}
-	return b.Login()
+	return copilotDisplayName(b.login)
 }
 
 func (r ReviewerBot) sealedReviewerCandidate() {}

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1087,6 +1087,16 @@ const CopilotAssigneeLogin = "copilot-swe-agent"
 const CopilotReviewerLogin = "copilot-pull-request-reviewer"
 const CopilotActorName = "Copilot"
 
+// copilotDisplayName returns "Copilot (AI)" if the login is a known Copilot bot login,
+// otherwise returns the login unchanged. Use this to translate raw bot logins into
+// user-friendly display names in command output.
+func copilotDisplayName(login string) string {
+	if login == CopilotReviewerLogin || login == CopilotAssigneeLogin {
+		return fmt.Sprintf("%s (AI)", CopilotActorName)
+	}
+	return login
+}
+
 type AssignableActor interface {
 	DisplayName() string
 	ID() string
@@ -1145,10 +1155,7 @@ func NewAssignableBot(id, login string) AssignableBot {
 }
 
 func (b AssignableBot) DisplayName() string {
-	if b.login == CopilotAssigneeLogin {
-		return fmt.Sprintf("%s (AI)", CopilotActorName)
-	}
-	return b.Login()
+	return copilotDisplayName(b.login)
 }
 
 func (b AssignableBot) ID() string {

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1135,7 +1135,7 @@ func NewAssignableUser(id, login, name string) AssignableUser {
 
 // DisplayName returns a user-friendly name via actorDisplayName.
 func (u AssignableUser) DisplayName() string {
-	return actorDisplayName("User", u.login, u.name)
+	return actorDisplayName(userTypeName, u.login, u.name)
 }
 
 func (u AssignableUser) ID() string {
@@ -1165,7 +1165,7 @@ func NewAssignableBot(id, login string) AssignableBot {
 }
 
 func (b AssignableBot) DisplayName() string {
-	return actorDisplayName("Bot", b.login, "")
+	return actorDisplayName(botTypeName, b.login, "")
 }
 
 func (b AssignableBot) ID() string {

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -147,6 +147,11 @@ type GitHubUser struct {
 	DatabaseID int64  `json:"databaseId"`
 }
 
+// DisplayName returns a user-friendly name via actorDisplayName.
+func (u GitHubUser) DisplayName() string {
+	return actorDisplayName("", u.Login, u.Name)
+}
+
 // Actor is a superset of User and Bot, among others.
 // At the time of writing, some of these fields
 // are not directly supported by the Actor type and
@@ -1087,12 +1092,20 @@ const CopilotAssigneeLogin = "copilot-swe-agent"
 const CopilotReviewerLogin = "copilot-pull-request-reviewer"
 const CopilotActorName = "Copilot"
 
-// copilotDisplayName returns "Copilot (AI)" if the login is a known Copilot bot login,
-// otherwise returns the login unchanged. Use this to translate raw bot logins into
-// user-friendly display names in command output.
-func copilotDisplayName(login string) string {
-	if login == CopilotReviewerLogin || login == CopilotAssigneeLogin {
+// actorDisplayName returns a user-friendly display name for any actor.
+// It handles bots (e.g. Copilot → "Copilot (AI)"), users with names
+// ("login (Name)"), and falls back to just login. Empty typeName is
+// treated as a possible bot or user — the login is checked against
+// known bot logins first.
+func actorDisplayName(typeName, login, name string) string {
+	if login == CopilotReviewerLogin || login == CopilotAssigneeLogin || login == CopilotActorName {
 		return fmt.Sprintf("%s (AI)", CopilotActorName)
+	}
+	if typeName == botTypeName {
+		return login
+	}
+	if name != "" {
+		return fmt.Sprintf("%s (%s)", login, name)
 	}
 	return login
 }
@@ -1120,12 +1133,9 @@ func NewAssignableUser(id, login, name string) AssignableUser {
 	}
 }
 
-// DisplayName returns a formatted string that uses Login and Name to be displayed e.g. 'Login (Name)' or 'Login'
+// DisplayName returns a user-friendly name via actorDisplayName.
 func (u AssignableUser) DisplayName() string {
-	if u.name != "" {
-		return fmt.Sprintf("%s (%s)", u.login, u.name)
-	}
-	return u.login
+	return actorDisplayName("User", u.login, u.name)
 }
 
 func (u AssignableUser) ID() string {
@@ -1155,7 +1165,7 @@ func NewAssignableBot(id, login string) AssignableBot {
 }
 
 func (b AssignableBot) DisplayName() string {
-	return copilotDisplayName(b.login)
+	return actorDisplayName("Bot", b.login, "")
 }
 
 func (b AssignableBot) ID() string {

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -563,6 +563,26 @@ func TestDisplayName(t *testing.T) {
 	}
 }
 
+func TestCopilotDisplayName(t *testing.T) {
+	tests := []struct {
+		login string
+		want  string
+	}{
+		{login: "copilot-pull-request-reviewer", want: "Copilot (AI)"},
+		{login: "copilot-swe-agent", want: "Copilot (AI)"},
+		{login: "octocat", want: "octocat"},
+		{login: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.login, func(t *testing.T) {
+			got := copilotDisplayName(tt.login)
+			if got != tt.want {
+				t.Errorf("copilotDisplayName(%q) = %q, want %q", tt.login, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRepoExists(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -583,10 +583,7 @@ func TestActorDisplayName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := actorDisplayName(tt.typeName, tt.login, tt.actName)
-			if got != tt.want {
-				t.Errorf("actorDisplayName(%q, %q, %q) = %q, want %q", tt.typeName, tt.login, tt.actName, got, tt.want)
-			}
+			require.Equal(t, tt.want, actorDisplayName(tt.typeName, tt.login, tt.actName))
 		})
 	}
 }

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -563,21 +563,29 @@ func TestDisplayName(t *testing.T) {
 	}
 }
 
-func TestCopilotDisplayName(t *testing.T) {
+func TestActorDisplayName(t *testing.T) {
 	tests := []struct {
-		login string
-		want  string
+		name     string
+		typeName string
+		login    string
+		actName  string
+		want     string
 	}{
-		{login: "copilot-pull-request-reviewer", want: "Copilot (AI)"},
-		{login: "copilot-swe-agent", want: "Copilot (AI)"},
-		{login: "octocat", want: "octocat"},
-		{login: "", want: ""},
+		{name: "copilot reviewer", typeName: "Bot", login: "copilot-pull-request-reviewer", want: "Copilot (AI)"},
+		{name: "copilot assignee", typeName: "Bot", login: "copilot-swe-agent", want: "Copilot (AI)"},
+		{name: "copilot without typename", typeName: "", login: "copilot-pull-request-reviewer", want: "Copilot (AI)"},
+		{name: "copilot actor name login", typeName: "", login: "Copilot", want: "Copilot (AI)"},
+		{name: "regular bot", typeName: "Bot", login: "dependabot", want: "dependabot"},
+		{name: "user with name", typeName: "User", login: "octocat", actName: "Mona Lisa", want: "octocat (Mona Lisa)"},
+		{name: "user without name", typeName: "User", login: "octocat", want: "octocat"},
+		{name: "unknown type with name", typeName: "", login: "octocat", actName: "Mona Lisa", want: "octocat (Mona Lisa)"},
+		{name: "empty login", typeName: "", login: "", want: ""},
 	}
 	for _, tt := range tests {
-		t.Run(tt.login, func(t *testing.T) {
-			got := copilotDisplayName(tt.login)
+		t.Run(tt.name, func(t *testing.T) {
+			got := actorDisplayName(tt.typeName, tt.login, tt.actName)
 			if got != tt.want {
-				t.Errorf("copilotDisplayName(%q) = %q, want %q", tt.login, got, tt.want)
+				t.Errorf("actorDisplayName(%q, %q, %q) = %q, want %q", tt.typeName, tt.login, tt.actName, got, tt.want)
 			}
 		})
 	}

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -197,7 +197,7 @@ func printRawIssuePreview(out io.Writer, issue *api.Issue) error {
 	// processing many issues with head and grep.
 	fmt.Fprintf(out, "title:\t%s\n", issue.Title)
 	fmt.Fprintf(out, "state:\t%s\n", issue.State)
-	fmt.Fprintf(out, "author:\t%s\n", issue.Author.Login)
+	fmt.Fprintf(out, "author:\t%s\n", issue.Author.DisplayName())
 	fmt.Fprintf(out, "labels:\t%s\n", labels)
 	fmt.Fprintf(out, "comments:\t%d\n", issue.Comments.TotalCount)
 	fmt.Fprintf(out, "assignees:\t%s\n", assignees)
@@ -222,7 +222,7 @@ func printHumanIssuePreview(opts *ViewOptions, baseRepo ghrepo.Interface, issue 
 	fmt.Fprintf(out,
 		"%s • %s opened %s • %s\n",
 		issueStateTitleWithColor(cs, issue),
-		issue.Author.Login,
+		issue.Author.DisplayName(),
 		text.FuzzyAgo(opts.Now(), issue.CreatedAt),
 		text.Pluralize(issue.Comments.TotalCount, "comment"),
 	)
@@ -298,7 +298,7 @@ func issueAssigneeList(issue api.Issue) string {
 
 	AssigneeNames := make([]string, 0, len(issue.Assignees.Nodes))
 	for _, assignee := range issue.Assignees.Nodes {
-		AssigneeNames = append(AssigneeNames, assignee.Login)
+		AssigneeNames = append(AssigneeNames, assignee.DisplayName())
 	}
 
 	list := strings.Join(AssigneeNames, ", ")

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -149,7 +149,7 @@ func printRawPrPreview(io *iostreams.IOStreams, pr *api.PullRequest) error {
 
 	fmt.Fprintf(out, "title:\t%s\n", pr.Title)
 	fmt.Fprintf(out, "state:\t%s\n", prStateWithDraft(pr))
-	fmt.Fprintf(out, "author:\t%s\n", pr.Author.Login)
+	fmt.Fprintf(out, "author:\t%s\n", pr.Author.DisplayName())
 	fmt.Fprintf(out, "labels:\t%s\n", labels)
 	fmt.Fprintf(out, "assignees:\t%s\n", assignees)
 	fmt.Fprintf(out, "reviewers:\t%s\n", reviewers)
@@ -188,7 +188,7 @@ func printHumanPrPreview(opts *ViewOptions, baseRepo ghrepo.Interface, pr *api.P
 	fmt.Fprintf(out,
 		"%s • %s wants to merge %s into %s from %s • %s\n",
 		shared.StateTitleWithColor(cs, *pr),
-		pr.Author.Login,
+		pr.Author.DisplayName(),
 		text.Pluralize(pr.Commits.TotalCount, "commit"),
 		pr.BaseRefName,
 		pr.HeadRefName,
@@ -406,7 +406,7 @@ func prAssigneeList(pr api.PullRequest) string {
 
 	AssigneeNames := make([]string, 0, len(pr.Assignees.Nodes))
 	for _, assignee := range pr.Assignees.Nodes {
-		AssigneeNames = append(AssigneeNames, assignee.Login)
+		AssigneeNames = append(AssigneeNames, assignee.DisplayName())
 	}
 
 	list := strings.Join(AssigneeNames, ", ")

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -351,7 +351,7 @@ func parseReviewers(pr api.PullRequest) []*reviewerState {
 
 	for _, review := range pr.Reviews.Nodes {
 		if review.Author.Login != pr.Author.Login {
-			name := review.Author.Login
+			name := review.AuthorLogin()
 			if name == "" {
 				name = ghostName
 			}
@@ -364,7 +364,7 @@ func parseReviewers(pr api.PullRequest) []*reviewerState {
 
 	// Overwrite reviewer's state if a review request for the same reviewer exists.
 	for _, reviewRequest := range pr.ReviewRequests.Nodes {
-		name := reviewRequest.RequestedReviewer.LoginOrSlug()
+		name := reviewRequest.RequestedReviewer.DisplayName()
 		reviewerStates[name] = &reviewerState{
 			Name:  name,
 			State: requestedReviewState,


### PR DESCRIPTION
## Description

`gh pr view` and `gh issue view` currently display raw bot logins like `copilot-pull-request-reviewer` and `Copilot` for Copilot's reviewer/assignee status and comments, and don't show user names alongside logins. This adds a generic `actorDisplayName` function that produces user-friendly display names for all actor types, and wires it into all display paths across both commands.


## Key changes

- **`actorDisplayName(typeName, login, name)`**: New unexported function in `api/queries_repo.go` that handles all actor display name logic in one place. Known Copilot logins → `Copilot (AI)`, regular bots → login, users with names → `login (Name)`, fallback → login.
- **`DisplayName()` on all actor types**: `Author`, `CommentAuthor`, `GitHubUser`, `AssignableUser`, `AssignableBot`, `RequestedReviewer`, and `ReviewerBot` all delegate to `actorDisplayName` with their available fields.
- **`PullRequestReview.AuthorLogin()`** and **`Comment.AuthorLogin()`**: Now return friendly names via their type's `DisplayName()`.
- **`gh pr view`**: `parseReviewers()`, `prAssigneeList()`, and author display all use `DisplayName()`.
- **`gh issue view`**: `issueAssigneeList()` and author display use `DisplayName()`.

## Notes for reviewers

- The translation only affects human-readable display output. JSON output via `--json` is unaffected — it still returns raw logins from the API.
- `actorDisplayName` handles three known Copilot logins: `copilot-pull-request-reviewer` (code review), `copilot-swe-agent` (assignment via suggestedActors), and `Copilot` (assignment via legacy assignees field).
- The `parseReviewers()` change switches review requests from `LoginOrSlug()` to `DisplayName()` — no behavioral change for non-Copilot reviewers since `DisplayName()` returns the same values for teams and regular users.

## Acceptance testing

**github.com** (8 scenarios, 8/8 passed): [Acceptance test results](https://gist.github.com/BagToad/e30e9e44663dfc4b53b7d6feb9ae90d5)