### PR TITLE
Bump Go from 1.25.7 to 1.26.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.6.0
+          version: v2.11.0
 
       # Verify that license generation succeeds for all release platforms (GOOS/GOARCH).
       # This catches issues like new dependencies with unrecognized licenses before release time.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cli/cli/v2
 
-go 1.25.7
+go 1.26.1
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
Bump Go to 1.26.1 to resolve these vulnerabilities:

- GO-2026-4603: html/template URL escaping
- GO-2026-4602: os FileInfo root escape
- GO-2026-4601: net/url IPv6 parsing
- GO-2026-4600: crypto/x509 malformed cert panic
- GO-2026-4599: crypto/x509 email constraint enforcement

Also bumps golangci-lint from v2.6.0 to v2.11.0, as v2.6.0 was built with Go 1.25 and cannot lint Go 1.26 code.