### PR TITLE
fix(api): ignore stale GraphQL rate-limit headers from cache

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -85,7 +85,21 @@ func AddCacheTTLHeader(rt http.RoundTripper, ttl time.Duration) http.RoundTrippe
 		if req.Header.Get(cacheTTL) == "" {
 			req.Header.Set(cacheTTL, ttl.String())
 		}
-		return rt.RoundTrip(req)
+
+		resp, err := rt.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+
+		// Cached responses may contain stale rate-limit headers from the original
+		// request time; never propagate those back to callers on cache-enabled
+		// requests.
+		resp.Header.Del("X-Ratelimit-Limit")
+		resp.Header.Del("X-Ratelimit-Remaining")
+		resp.Header.Del("X-Ratelimit-Reset")
+		resp.Header.Del("X-Ratelimit-Used")
+
+		return resp, nil
 	}}
 }
 

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -264,6 +265,34 @@ func TestHTTPClientSanitizeJSONControlCharactersC0(t *testing.T) {
 	assert.Equal(t, "10^P 11^Q 12^R 13^S 14^T 15^U 16^V 17^W 18^X 19^Y 1A^Z 1B^[ 1C^\\ 1D^] 1E^^ 1F^_", issue.Author.Name)
 	assert.Equal(t, "monalisa \\u00^[", issue.Author.Login)
 	assert.Equal(t, "Escaped ^[ \\^[ \\^[ \\\\^[", issue.ActiveLockReason)
+}
+
+func TestAddCacheTTLHeader_StripsRateLimitHeaders(t *testing.T) {
+	rt := AddCacheTTLHeader(funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "1h0m0s", req.Header.Get(cacheTTL))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"X-Ratelimit-Limit":     []string{"5000"},
+				"X-Ratelimit-Remaining": []string{"0"},
+				"X-Ratelimit-Reset":     []string{"1234567890"},
+				"X-Ratelimit-Used":      []string{"5001"},
+			},
+			Body: io.NopCloser(strings.NewReader("{}")),
+		}, nil
+	}}, time.Hour)
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/graphql", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Empty(t, resp.Header.Get("X-Ratelimit-Limit"))
+	assert.Empty(t, resp.Header.Get("X-Ratelimit-Remaining"))
+	assert.Empty(t, resp.Header.Get("X-Ratelimit-Reset"))
+	assert.Empty(t, resp.Header.Get("X-Ratelimit-Used"))
 }
 
 func TestHTTPClientSanitizeControlCharactersC1(t *testing.T) {


### PR DESCRIPTION
## Summary
- strip `X-Ratelimit-Limit`, `X-Ratelimit-Remaining`, `X-Ratelimit-Reset`, and `X-Ratelimit-Used` headers from responses when `X-Gh-Cache-Ttl` is enabled
- add a regression test that proves cache-enabled responses no longer overwrite live rate-limit state with stale header values
- keep existing cache behavior intact for non-rate-limit headers and non-cached requests

## Testing
- `go test ./api -run 'TestAddCacheTTLHeader|TestClient_Do_WithRateLimitFromHeaders'`

## Related
Fixes #12812
