### PR TITLE
fix(pr create): preserve provided input for --recover after submit errors

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -437,9 +437,13 @@ func createRun(opts *CreateOptions) error {
 		if !(opts.Autofill || opts.FillFirst) {
 			state.Title = opts.Title
 			state.Body = opts.Body
+			if opts.Title != "" || opts.Body != "" {
+				state.MarkDirty()
+			}
 		}
 		if opts.Template != "" {
 			state.Template = opts.Template
+			state.MarkDirty()
 		}
 		err = handlePush(*opts, *ctx)
 		if err != nil {
@@ -458,10 +462,12 @@ func createRun(opts *CreateOptions) error {
 
 	if opts.TitleProvided {
 		state.Title = opts.Title
+		state.MarkDirty()
 	}
 
 	if opts.BodyProvided {
 		state.Body = opts.Body
+		state.MarkDirty()
 	}
 
 	existingPR, _, err := opts.Finder.Find(shared.FindOptions{


### PR DESCRIPTION
Fixes #12824

## Summary
- mark issue metadata state as dirty when `--title`/`--body` values are provided directly
- mark state as dirty in `--web` flow when explicit title/body/template values are set
- this ensures failed `gh pr create` submissions surface a usable `--recover` file instead of discarding authored input

## Testing
- go test ./pkg/cmd/pr/create -run Test -count=1