### PR TITLE
issue create: avoid querying default branch when checking issue availability

### DIFF
--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -239,7 +239,7 @@ func createRun(opts *CreateOptions) (err error) {
 		fmt.Fprintf(opts.IO.ErrOut, "\nCreating issue in %s\n\n", ghrepo.FullName(baseRepo))
 	}
 
-	repo, err := api.GitHubRepo(apiClient, baseRepo)
+	repo, err := api.FetchRepository(apiClient, baseRepo, []string{"hasIssuesEnabled"})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- switch `gh issue create` to fetch only `hasIssuesEnabled` instead of the full `GitHubRepo` payload
- remove the unnecessary `defaultBranchRef` GraphQL field access from the issue-create path
- keep permission scope aligned with issue creation so fine-grained PATs without Contents: Read can still create issues

## Testing
- go test ./pkg/cmd/issue/create -run TestIssueCreate -count=1

## Related
- Fixes #12798