### PR TITLE
Fix auth status messaging for network failures

### DIFF
--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -20,11 +21,17 @@ import (
 )
 
 type authEntryState string
+type authFailureKind string
 
 const (
 	authEntryStateSuccess = "success"
 	authEntryStateTimeout = "timeout"
 	authEntryStateError   = "error"
+
+	authFailureKindNone        authFailureKind = ""
+	authFailureKindInvalidAuth authFailureKind = "invalid_auth"
+	authFailureKindNetwork     authFailureKind = "network"
+	authFailureKindUnknown     authFailureKind = "unknown"
 )
 
 type authEntry struct {
@@ -37,6 +44,8 @@ type authEntry struct {
 	Token       string         `json:"token,omitempty"`
 	Scopes      string         `json:"scopes,omitempty"`
 	GitProtocol string         `json:"gitProtocol"`
+
+	failureKind authFailureKind
 }
 
 type authStatus struct {
@@ -86,19 +95,22 @@ func (e authEntry) String(cs *iostreams.ColorScheme) string {
 		}
 
 	case authEntryStateError:
-		if e.Login != "" {
-			sb.WriteString(fmt.Sprintf("  %s Failed to log in to %s account %s (%s)\n", cs.Red("X"), e.Host, cs.Bold(e.Login), e.TokenSource))
-		} else {
-			sb.WriteString(fmt.Sprintf("  %s Failed to log in to %s using token (%s)\n", cs.Red("X"), e.Host, e.TokenSource))
-		}
+		sb.WriteString(errorHeader(cs, e))
 		activeStr := fmt.Sprintf("%v", e.Active)
 		sb.WriteString(fmt.Sprintf("  - Active account: %s\n", cs.Bold(activeStr)))
-		sb.WriteString(fmt.Sprintf("  - The token in %s is invalid.\n", e.TokenSource))
-		if authTokenWriteable(e.TokenSource) {
-			loginInstructions := fmt.Sprintf("gh auth login -h %s", e.Host)
-			logoutInstructions := fmt.Sprintf("gh auth logout -h %s -u %s", e.Host, e.Login)
-			sb.WriteString(fmt.Sprintf("  - To re-authenticate, run: %s\n", cs.Bold(loginInstructions)))
-			sb.WriteString(fmt.Sprintf("  - To forget about this account, run: %s\n", cs.Bold(logoutInstructions)))
+		switch e.failureKind {
+		case authFailureKindInvalidAuth:
+			sb.WriteString(fmt.Sprintf("  - The token in %s is invalid.\n", e.TokenSource))
+			if authTokenWriteable(e.TokenSource) {
+				loginInstructions := fmt.Sprintf("gh auth login -h %s", e.Host)
+				logoutInstructions := fmt.Sprintf("gh auth logout -h %s -u %s", e.Host, e.Login)
+				sb.WriteString(fmt.Sprintf("  - To re-authenticate, run: %s\n", cs.Bold(loginInstructions)))
+				sb.WriteString(fmt.Sprintf("  - To forget about this account, run: %s\n", cs.Bold(logoutInstructions)))
+			}
+		case authFailureKindNetwork:
+			sb.WriteString(fmt.Sprintf("  - Authentication status could not be determined due to a network error: %s\n", e.Error))
+		default:
+			sb.WriteString(fmt.Sprintf("  - Authentication status could not be determined: %s\n", e.Error))
 		}
 
 	case authEntryStateTimeout:
@@ -112,6 +124,21 @@ func (e authEntry) String(cs *iostreams.ColorScheme) string {
 	}
 
 	return sb.String()
+}
+
+func errorHeader(cs *iostreams.ColorScheme, e authEntry) string {
+	switch e.failureKind {
+	case authFailureKindNetwork, authFailureKindUnknown:
+		if e.Login != "" {
+			return fmt.Sprintf("  %s Failed to verify authentication for %s account %s (%s)\n", cs.Red("X"), e.Host, cs.Bold(e.Login), e.TokenSource)
+		}
+		return fmt.Sprintf("  %s Failed to verify authentication for %s using token (%s)\n", cs.Red("X"), e.Host, e.TokenSource)
+	default:
+		if e.Login != "" {
+			return fmt.Sprintf("  %s Failed to log in to %s account %s (%s)\n", cs.Red("X"), e.Host, cs.Bold(e.Login), e.TokenSource)
+		}
+		return fmt.Sprintf("  %s Failed to log in to %s using token (%s)\n", cs.Red("X"), e.Host, e.TokenSource)
+	}
 }
 
 type StatusOptions struct {
@@ -383,7 +410,7 @@ func buildEntry(httpClient *http.Client, opts buildEntryOptions) authEntry {
 		var err error
 		entry.Login, err = api.CurrentLoginName(apiClient, opts.hostname)
 		if err != nil {
-			entry.State = authEntryStateError
+			entry.State, entry.failureKind = classifyAuthError(err)
 			entry.Error = err.Error()
 			return entry
 		}
@@ -392,21 +419,48 @@ func buildEntry(httpClient *http.Client, opts buildEntryOptions) authEntry {
 	// Get scopes for token.
 	scopesHeader, err := shared.GetScopes(httpClient, opts.hostname, opts.token)
 	if err != nil {
-		var networkError net.Error
-		if errors.As(err, &networkError) && networkError.Timeout() {
-			entry.State = authEntryStateTimeout
-			entry.Error = err.Error()
-			return entry
-		}
-
-		entry.State = authEntryStateError
+		entry.State, entry.failureKind = classifyAuthError(err)
 		entry.Error = err.Error()
 		return entry
 	}
 	entry.Scopes = scopesHeader
 
 	entry.State = authEntryStateSuccess
+	entry.failureKind = authFailureKindNone
 	return entry
+}
+
+func classifyAuthError(err error) (authEntryState, authFailureKind) {
+	var urlError *url.Error
+	if errors.As(err, &urlError) {
+		if urlError.Timeout() {
+			return authEntryStateTimeout, authFailureKindNetwork
+		}
+		return authEntryStateError, authFailureKindNetwork
+	}
+
+	var networkError net.Error
+	if errors.As(err, &networkError) {
+		if networkError.Timeout() {
+			return authEntryStateTimeout, authFailureKindNetwork
+		}
+		return authEntryStateError, authFailureKindNetwork
+	}
+
+	var httpErr api.HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode == http.StatusUnauthorized {
+			return authEntryStateError, authFailureKindInvalidAuth
+		}
+		return authEntryStateError, authFailureKindUnknown
+	}
+
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "401 Unauthorized") || strings.Contains(errMsg, "Bad credentials") {
+		return authEntryStateError, authFailureKindInvalidAuth
+	}
+
+	return authEntryStateError, authFailureKindUnknown
 }
 
 func authTokenWriteable(src string) bool {

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -126,6 +128,52 @@ func Test_statusRun(t *testing.T) {
 			`),
 		},
 		{
+			name: "network error",
+			opts: StatusOptions{
+				Hostname: "github.com",
+			},
+			cfgStubs: func(t *testing.T, c gh.Config) {
+				login(t, c, "github.com", "monalisa", "abc123", "https")
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", ""), func(req *http.Request) (*http.Response, error) {
+					return nil, &url.Error{
+						Op:  "Get",
+						URL: "https://api.github.com/",
+						Err: &net.DNSError{Err: "no such host", Name: "api.github.com"},
+					}
+				})
+			},
+			wantErr: cmdutil.SilentError,
+			wantErrOut: heredoc.Doc(`
+				github.com
+				  X Failed to verify authentication for github.com account monalisa (GH_CONFIG_DIR/hosts.yml)
+				  - Active account: true
+				  - Authentication status could not be determined due to a network error: Get "https://api.github.com/": Get "https://api.github.com/": lookup api.github.com: no such host
+			`),
+		},
+		{
+			name: "network error from env token",
+			opts: StatusOptions{},
+			env:  map[string]string{"GH_TOKEN": "gho_abc123"},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.GraphQL(`query UserCurrent\b`), func(req *http.Request) (*http.Response, error) {
+					return nil, &url.Error{
+						Op:  "Post",
+						URL: "https://api.github.com/graphql",
+						Err: &net.DNSError{Err: "no such host", Name: "api.github.com"},
+					}
+				})
+			},
+			wantErr: cmdutil.SilentError,
+			wantErrOut: heredoc.Doc(`
+				github.com
+				  X Failed to verify authentication for github.com using token (GH_TOKEN)
+				  - Active account: true
+				  - Authentication status could not be determined due to a network error: Post "https://api.github.com/graphql": Post "https://api.github.com/graphql": lookup api.github.com: no such host
+			`),
+		},
+		{
 			name: "hostname set",
 			opts: StatusOptions{
 				Hostname: "ghe.io",
@@ -176,7 +224,7 @@ func Test_statusRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				// mock for HeaderHasMinimumScopes api requests to a non-github.com host
-				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(400, "no bueno"))
+				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(401, `{"message":"Bad credentials"}`))
 			},
 			wantErr: cmdutil.SilentError,
 			wantErrOut: heredoc.Doc(`
@@ -221,7 +269,7 @@ func Test_statusRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				// mocks for HeaderHasMinimumScopes api requests to a non-github.com host
-				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(400, "no bueno"))
+				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(401, `{"message":"Bad credentials"}`))
 			},
 			wantErr: cmdutil.SilentError,
 			wantErrOut: heredoc.Doc(`
@@ -286,6 +334,23 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_******
 				  - Token scopes: none
+			`),
+		},
+		{
+			name: "bad token from env",
+			opts: StatusOptions{},
+			env:  map[string]string{"GH_TOKEN": "gho_abc123"},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserCurrent\b`),
+					httpmock.StatusStringResponse(401, `{"message":"Bad credentials"}`))
+			},
+			wantErr: cmdutil.SilentError,
+			wantErrOut: heredoc.Doc(`
+				github.com
+				  X Failed to log in to github.com using token (GH_TOKEN)
+				  - Active account: true
+				  - The token in GH_TOKEN is invalid.
 			`),
 		},
 		{
@@ -414,7 +479,7 @@ func Test_statusRun(t *testing.T) {
 				// Get scopes for monalisa-ghe-2
 				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.ScopesResponder("repo,read:org"))
 				// Error getting scopes for monalisa-ghe
-				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(404, "{}"))
+				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(401, `{"message":"Bad credentials"}`))
 				// Get username for monalisa-ghe-2
 				reg.Register(
 					httpmock.GraphQL(`query UserCurrent\b`),
@@ -520,7 +585,7 @@ func Test_statusRun(t *testing.T) {
 				// Get scopes for monalisa-2
 				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
 				// Error getting scopes for monalisa-ghe-2
-				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(404, "{}"))
+				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(401, `{"message":"Bad credentials"}`))
 			},
 			wantErr: cmdutil.SilentError,
 			wantErrOut: heredoc.Doc(`
@@ -653,9 +718,9 @@ func Test_statusRun(t *testing.T) {
 			},
 			httpStubs: func(reg *httpmock.Registry) {
 				// mock for HeaderHasMinimumScopes api requests to a non-github.com host
-				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(400, "no bueno"))
+				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.StatusStringResponse(401, `{"message":"Bad credentials"}`))
 			},
-			wantOut: `{"hosts":{"ghe.io":[{"state":"error","error":"HTTP 400 (https://ghe.io/api/v3/)","active":true,"host":"ghe.io","login":"monalisa-ghe","tokenSource":"GH_CONFIG_DIR/hosts.yml","gitProtocol":"https"}]}}` + "\n",
+			wantOut: `{"hosts":{"ghe.io":[{"state":"error","error":"HTTP 401 (https://ghe.io/api/v3/)","active":true,"host":"ghe.io","login":"monalisa-ghe","tokenSource":"GH_CONFIG_DIR/hosts.yml","gitProtocol":"https"}]}}` + "\n",
 			wantErr: nil, // should not return error in machine-readable mode
 		},
 		{
@@ -667,9 +732,30 @@ func Test_statusRun(t *testing.T) {
 				// mock for HeaderHasMinimumScopes api requests to a non-github.com host
 				reg.Register(
 					httpmock.GraphQL(`query UserCurrent\b`),
-					httpmock.StatusStringResponse(400, `no bueno`))
+					httpmock.StatusStringResponse(401, `{"message":"Bad credentials"}`))
 			},
-			wantOut: `{"hosts":{"github.com":[{"state":"error","error":"non-200 OK status code:  body: \"no bueno\"","active":true,"host":"github.com","login":"","tokenSource":"GH_TOKEN","gitProtocol":"https"}]}}` + "\n",
+			wantOut: `{"hosts":{"github.com":[{"state":"error","error":"non-200 OK status code:  body: \"{\\\"message\\\":\\\"Bad credentials\\\"}\"","active":true,"host":"github.com","login":"","tokenSource":"GH_TOKEN","gitProtocol":"https"}]}}` + "\n",
+			wantErr: nil, // should not return error in machine-readable mode
+		},
+		{
+			name: "json, network error",
+			opts: StatusOptions{
+				Hostname: "github.com",
+			},
+			jsonFields: []string{"hosts"},
+			cfgStubs: func(t *testing.T, c gh.Config) {
+				login(t, c, "github.com", "monalisa", "abc123", "https")
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", ""), func(req *http.Request) (*http.Response, error) {
+					return nil, &url.Error{
+						Op:  "Get",
+						URL: "https://api.github.com/",
+						Err: &net.DNSError{Err: "no such host", Name: "api.github.com"},
+					}
+				})
+			},
+			wantOut: `{"hosts":{"github.com":[{"state":"error","error":"Get \"https://api.github.com/\": Get \"https://api.github.com/\": lookup api.github.com: no such host","active":true,"host":"github.com","login":"monalisa","tokenSource":"GH_CONFIG_DIR/hosts.yml","gitProtocol":"https"}]}}` + "\n",
 			wantErr: nil, // should not return error in machine-readable mode
 		},
 		{


### PR DESCRIPTION
## Summary
gh auth status currently reports that a token is invalid when the underlying auth check failed because the network request itself failed, for example in a sandboxed environment or during DNS resolution failures.

This change keeps the existing JSON output shape intact, but updates the human-readable status text to distinguish invalid credentials from transport-level verification failures for both stored tokens and environment tokens.

## What Changed
- classify auth check failures as invalid-auth, network, timeout, or unknown for display purposes
- keep JSON state values unchanged as success, error, or timeout
- only show re-authentication guidance for actual invalid-credential failures
- add coverage for stored-token and env-token network failures, plus real invalid-credential cases

## Verification
env GOCACHE=/tmp/go-build GOMODCACHE=/tmp/gomodcache go test ./pkg/cmd/auth/status -count=1
