### PR TITLE
pr create: normalize --base remote/branch refs

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -783,7 +783,10 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 			return nil, err
 		}
 
-		baseBranch := opts.BaseBranch
+		baseBranch, err := normalizeBaseBranch(remotes, opts.BaseBranch)
+		if err != nil {
+			return nil, err
+		}
 		if baseBranch == "" {
 			baseBranch = branchConfig.MergeBase
 		}
@@ -816,7 +819,10 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 		return nil, err
 	}
 
-	baseBranch := opts.BaseBranch
+	baseBranch, err := normalizeBaseBranch(remotes, opts.BaseBranch)
+	if err != nil {
+		return nil, err
+	}
 	if baseBranch == "" {
 		baseBranch = branchConfig.MergeBase
 	}
@@ -1015,6 +1021,23 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 			baseRefs:         baseRefs,
 		}), nil
 	}
+}
+
+func normalizeBaseBranch(remotes ghContext.Remotes, baseBranch string) (string, error) {
+	if baseBranch == "" {
+		return "", nil
+	}
+
+	parts := strings.SplitN(baseBranch, "/", 2)
+	if len(parts) != 2 {
+		return baseBranch, nil
+	}
+
+	if _, err := remotes.FindByName(parts[0]); err != nil {
+		return baseBranch, nil
+	}
+
+	return parts[1], nil
 }
 
 func getRemotes(opts *CreateOptions) (ghContext.Remotes, error) {

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -1485,6 +1485,19 @@ func Test_createRun(t *testing.T) {
 				opts.Title = "my title"
 				opts.Body = "my body"
 				opts.HeadBranch = "otherowner:feature"
+				opts.BaseBranch = "upstream/master"
+				opts.Remotes = func() (context.Remotes, error) {
+					return context.Remotes{
+						{
+							Remote: &git.Remote{Name: "upstream", Resolved: "base"},
+							Repo:   ghrepo.New("OWNER", "REPO"),
+						},
+						{
+							Remote: &git.Remote{Name: "origin"},
+							Repo:   ghrepo.New("monalisa", "REPO"),
+						},
+					}, nil
+				}
 				return func() {}
 			},
 			expectedOut: "https://github.com/OWNER/REPO/pull/12\n",


### PR DESCRIPTION
Fixes #12824

## Summary
- treat `--base <remote>/<branch>` as a remote-tracking selector when the remote exists locally
- normalize the API payload to send only the branch name (for example, `develop` instead of `upstream/develop`)
- preserve existing behavior for branch names that are not local remote-tracking refs

## Testing
- `go test ./pkg/cmd/pr/create -count=1`
- added coverage in `Test_createRun/--head contains <user>:<branch> syntax` to verify `--base upstream/master` normalizes to `master` in GraphQL input
