### PR TITLE
docs: use --enablerepo for Fedora install command

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -56,7 +56,7 @@ To install:
 ```bash
 sudo dnf install dnf5-plugins
 sudo dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
-sudo dnf install gh --repo gh-cli
+sudo dnf install gh --enablerepo gh-cli
 ```
 
 To upgrade:
@@ -75,7 +75,7 @@ To install:
 ```bash
 sudo dnf install 'dnf-command(config-manager)'
 sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-sudo dnf install gh --repo gh-cli
+sudo dnf install gh --enablerepo gh-cli
 ```
 
 To upgrade:


### PR DESCRIPTION
## Summary
- replace the Fedora DNF4 and DNF5 install examples to use `--enablerepo gh-cli` instead of `--repo gh-cli`
- aligns install instructions with the working command reported in the issue

## Testing
- not run (docs-only change; no automated test target validates distro install command snippets)

Fixes #12808
