### PR TITLE
pr create: handle --fill when upstream branch name differs

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -640,7 +640,15 @@ func createRun(opts *CreateOptions) error {
 var regexPattern = regexp.MustCompile(`(?m)^`)
 
 func initDefaultTitleBody(ctx CreateContext, state *shared.IssueMetadataState, useFirstCommit bool, addBody bool) error {
-	commits, err := ctx.GitClient.Commits(context.Background(), ctx.BaseTrackingBranch, ctx.PRRefs.UnqualifiedHeadRef())
+	commitHeadRef := ctx.PRRefs.UnqualifiedHeadRef()
+	if !ctx.GitClient.HasLocalBranch(context.Background(), commitHeadRef) {
+		currentBranch, err := ctx.GitClient.CurrentBranch(context.Background())
+		if err == nil && currentBranch != "" {
+			commitHeadRef = currentBranch
+		}
+	}
+
+	commits, err := ctx.GitClient.Commits(context.Background(), ctx.BaseTrackingBranch, commitHeadRef)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- when `gh pr create --fill` computes commit defaults, it used the PR head branch name for `git log` ranges
- if a local branch tracks a differently-named upstream branch, that upstream name may not exist locally and `git log base...head` fails
- fall back to the current local branch when the PR head branch name is not present locally, so commit extraction still works

## Testing
- `go test ./pkg/cmd/pr/create -run TestNewCmdCreate -count=1`

Fixes #12800
