### PR TITLE
fix(issue): avoid fetching unnecessary fields for discovery

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -314,8 +314,9 @@ func FetchRepository(client *Client, repo ghrepo.Interface, fields []string) (*R
 	return InitRepoHostname(result.Repository, repo.RepoHost()), nil
 }
 
-// IssueRepoInfo fetches only the repository fields needed for issue creation,
-// avoiding fields like defaultBranchRef that require additional token permissions.
+// IssueRepoInfo fetches only the repository fields needed for issue operations such as
+// issue creation and transfer, avoiding fields like defaultBranchRef that require additional
+// token permissions.
 func IssueRepoInfo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 	query := `
 	query IssueRepositoryInfo($owner: String!, $name: String!) {
@@ -338,6 +339,8 @@ func IssueRepoInfo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 	if err := client.GraphQL(repo.RepoHost(), query, variables, &result); err != nil {
 		return nil, err
 	}
+	// The GraphQL API should have returned an error in case of a missing repository, but this isn't
+	// guaranteed to happen when an authentication token with insufficient permissions is being used.
 	if result.Repository == nil {
 		return nil, GraphQLError{
 			GraphQLError: &ghAPI.GraphQLError{

--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -314,6 +314,44 @@ func FetchRepository(client *Client, repo ghrepo.Interface, fields []string) (*R
 	return InitRepoHostname(result.Repository, repo.RepoHost()), nil
 }
 
+// IssueRepoInfo fetches only the repository fields needed for issue creation,
+// avoiding fields like defaultBranchRef that require additional token permissions.
+func IssueRepoInfo(client *Client, repo ghrepo.Interface) (*Repository, error) {
+	query := `
+	query IssueRepositoryInfo($owner: String!, $name: String!) {
+		repository(owner: $owner, name: $name) {
+			id
+			name
+			owner { login }
+			hasIssuesEnabled
+			viewerPermission
+		}
+	}`
+	variables := map[string]interface{}{
+		"owner": repo.RepoOwner(),
+		"name":  repo.RepoName(),
+	}
+
+	var result struct {
+		Repository *Repository
+	}
+	if err := client.GraphQL(repo.RepoHost(), query, variables, &result); err != nil {
+		return nil, err
+	}
+	if result.Repository == nil {
+		return nil, GraphQLError{
+			GraphQLError: &ghAPI.GraphQLError{
+				Errors: []ghAPI.GraphQLErrorItem{{
+					Type:    "NOT_FOUND",
+					Message: fmt.Sprintf("Could not resolve to a Repository with the name '%s/%s'.", repo.RepoOwner(), repo.RepoName()),
+				}},
+			},
+		}
+	}
+
+	return InitRepoHostname(result.Repository, repo.RepoHost()), nil
+}
+
 func GitHubRepo(client *Client, repo ghrepo.Interface) (*Repository, error) {
 	query := `
 	fragment repo on Repository {

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -26,15 +26,181 @@ func TestGitHubRepo_notFound(t *testing.T) {
 
 	client := newTestClient(httpReg)
 	repo, err := GitHubRepo(client, ghrepo.New("OWNER", "REPO"))
-	if err == nil {
-		t.Fatal("GitHubRepo did not return an error")
+	require.EqualError(t, err, "GraphQL: Could not resolve to a Repository with the name 'OWNER/REPO'.")
+	assert.Nil(t, repo)
+}
+
+func TestGitHubRepo_success(t *testing.T) {
+	httpReg := &httpmock.Registry{}
+	defer httpReg.Verify(t)
+
+	httpReg.Register(
+		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.StringResponse(`
+		{ "data": { "repository": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"hasIssuesEnabled": true,
+			"description": "a cool repo",
+			"hasWikiEnabled": true,
+			"viewerPermission": "ADMIN",
+			"defaultBranchRef": {"name": "main"},
+			"parent": null,
+			"mergeCommitAllowed": true,
+			"rebaseMergeAllowed": true,
+			"squashMergeAllowed": false
+		} } }`))
+
+	client := newTestClient(httpReg)
+	repo, err := GitHubRepo(client, ghrepo.New("OWNER", "REPO"))
+	require.NoError(t, err)
+	assert.Equal(t, &Repository{
+		ID:                 "REPOID",
+		Name:               "REPO",
+		Owner:              RepositoryOwner{Login: "OWNER"},
+		HasIssuesEnabled:   true,
+		Description:        "a cool repo",
+		HasWikiEnabled:     true,
+		ViewerPermission:   "ADMIN",
+		DefaultBranchRef:   BranchRef{Name: "main"},
+		MergeCommitAllowed: true,
+		RebaseMergeAllowed: true,
+		hostname:           "github.com",
+	}, repo)
+	assert.True(t, repo.ViewerCanPush())
+	assert.True(t, repo.ViewerCanTriage())
+}
+
+func TestGitHubRepo_withParent(t *testing.T) {
+	httpReg := &httpmock.Registry{}
+	defer httpReg.Verify(t)
+
+	httpReg.Register(
+		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.StringResponse(`
+		{ "data": { "repository": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"hasIssuesEnabled": true,
+			"description": "",
+			"hasWikiEnabled": false,
+			"viewerPermission": "READ",
+			"defaultBranchRef": {"name": "main"},
+			"parent": {
+				"id": "PARENTID",
+				"name": "PARENT-REPO",
+				"owner": {"login": "PARENT-OWNER"},
+				"hasIssuesEnabled": true,
+				"description": "parent repo",
+				"hasWikiEnabled": true,
+				"viewerPermission": "READ",
+				"defaultBranchRef": {"name": "develop"}
+			},
+			"mergeCommitAllowed": false,
+			"rebaseMergeAllowed": false,
+			"squashMergeAllowed": true
+		} } }`))
+
+	client := newTestClient(httpReg)
+	repo, err := GitHubRepo(client, ghrepo.New("OWNER", "REPO"))
+	require.NoError(t, err)
+	wantParent := &Repository{
+		ID:               "PARENTID",
+		Name:             "PARENT-REPO",
+		Owner:            RepositoryOwner{Login: "PARENT-OWNER"},
+		HasIssuesEnabled: true,
+		Description:      "parent repo",
+		HasWikiEnabled:   true,
+		ViewerPermission: "READ",
+		DefaultBranchRef: BranchRef{Name: "develop"},
+		hostname:         "github.com",
 	}
-	if wants := "GraphQL: Could not resolve to a Repository with the name 'OWNER/REPO'."; err.Error() != wants {
-		t.Errorf("GitHubRepo error: want %q, got %q", wants, err.Error())
-	}
-	if repo != nil {
-		t.Errorf("GitHubRepo: expected nil repo, got %v", repo)
-	}
+	assert.Equal(t, &Repository{
+		ID:                 "REPOID",
+		Name:               "REPO",
+		Owner:              RepositoryOwner{Login: "OWNER"},
+		HasIssuesEnabled:   true,
+		ViewerPermission:   "READ",
+		DefaultBranchRef:   BranchRef{Name: "main"},
+		Parent:             wantParent,
+		SquashMergeAllowed: true,
+		hostname:           "github.com",
+	}, repo)
+	assert.False(t, repo.ViewerCanPush())
+	assert.False(t, repo.ViewerCanTriage())
+}
+
+func TestIssueRepoInfo_notFound(t *testing.T) {
+	httpReg := &httpmock.Registry{}
+	defer httpReg.Verify(t)
+
+	httpReg.Register(
+		httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+		httpmock.StringResponse(`{ "data": { "repository": null } }`))
+
+	client := newTestClient(httpReg)
+	repo, err := IssueRepoInfo(client, ghrepo.New("OWNER", "REPO"))
+	require.EqualError(t, err, "GraphQL: Could not resolve to a Repository with the name 'OWNER/REPO'.")
+	assert.Nil(t, repo)
+}
+
+func TestIssueRepoInfo_success(t *testing.T) {
+	httpReg := &httpmock.Registry{}
+	defer httpReg.Verify(t)
+
+	httpReg.Register(
+		httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+		httpmock.StringResponse(`
+		{ "data": { "repository": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"hasIssuesEnabled": true,
+			"viewerPermission": "WRITE"
+		} } }`))
+
+	client := newTestClient(httpReg)
+	repo, err := IssueRepoInfo(client, ghrepo.New("OWNER", "REPO"))
+	require.NoError(t, err)
+	assert.Equal(t, &Repository{
+		ID:               "REPOID",
+		Name:             "REPO",
+		Owner:            RepositoryOwner{Login: "OWNER"},
+		HasIssuesEnabled: true,
+		ViewerPermission: "WRITE",
+		hostname:         "github.com",
+	}, repo)
+	assert.True(t, repo.ViewerCanTriage())
+}
+
+func TestIssueRepoInfo_issuesDisabled(t *testing.T) {
+	httpReg := &httpmock.Registry{}
+	defer httpReg.Verify(t)
+
+	httpReg.Register(
+		httpmock.GraphQL(`query IssueRepositoryInfo\b`),
+		httpmock.StringResponse(`
+		{ "data": { "repository": {
+			"id": "REPOID",
+			"name": "REPO",
+			"owner": {"login": "OWNER"},
+			"hasIssuesEnabled": false,
+			"viewerPermission": "READ"
+		} } }`))
+
+	client := newTestClient(httpReg)
+	repo, err := IssueRepoInfo(client, ghrepo.New("OWNER", "REPO"))
+	require.NoError(t, err)
+	assert.Equal(t, &Repository{
+		ID:               "REPOID",
+		Name:             "REPO",
+		Owner:            RepositoryOwner{Login: "OWNER"},
+		ViewerPermission: "READ",
+		hostname:         "github.com",
+	}, repo)
+	assert.False(t, repo.ViewerCanTriage())
 }
 
 func Test_RepoMetadata(t *testing.T) {

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -239,7 +239,7 @@ func createRun(opts *CreateOptions) (err error) {
 		fmt.Fprintf(opts.IO.ErrOut, "\nCreating issue in %s\n\n", ghrepo.FullName(baseRepo))
 	}
 
-	repo, err := api.GitHubRepo(apiClient, baseRepo)
+	repo, err := api.IssueRepoInfo(apiClient, baseRepo)
 	if err != nil {
 		return
 	}

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -411,7 +411,7 @@ func Test_createRun(t *testing.T) {
 			name: "editor",
 			httpStubs: func(r *httpmock.Registry) {
 				r.Register(
-					httpmock.GraphQL(`query RepositoryInfo\b`),
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 					httpmock.StringResponse(`
 						{ "data": { "repository": {
 							"id": "REPOID",
@@ -440,7 +440,7 @@ func Test_createRun(t *testing.T) {
 			name: "editor and template",
 			httpStubs: func(r *httpmock.Registry) {
 				r.Register(
-					httpmock.GraphQL(`query RepositoryInfo\b`),
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 					httpmock.StringResponse(`
 			{ "data": { "repository": {
 				"id": "REPOID",
@@ -516,7 +516,7 @@ func Test_createRun(t *testing.T) {
 			},
 			httpStubs: func(r *httpmock.Registry) {
 				r.Register(
-					httpmock.GraphQL(`query RepositoryInfo\b`),
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 					httpmock.StringResponse(`
 						{ "data": { "repository": {
 							"id": "REPOID",
@@ -589,7 +589,7 @@ func Test_createRun(t *testing.T) {
 			},
 			httpStubs: func(r *httpmock.Registry) {
 				r.Register(
-					httpmock.GraphQL(`query RepositoryInfo\b`),
+					httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 					httpmock.StringResponse(`
 						{ "data": { "repository": {
 							"id": "REPOID",
@@ -721,7 +721,7 @@ func TestIssueCreate(t *testing.T) {
 	defer http.Verify(t)
 
 	http.Register(
-		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
 				"id": "REPOID",
@@ -754,7 +754,7 @@ func TestIssueCreate_recover(t *testing.T) {
 	defer http.Verify(t)
 
 	http.Register(
-		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
 				"id": "REPOID",
@@ -838,7 +838,7 @@ func TestIssueCreate_nonLegacyTemplate(t *testing.T) {
 	defer http.Verify(t)
 
 	http.Register(
-		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
 				"id": "REPOID",
@@ -901,7 +901,7 @@ func TestIssueCreate_continueInBrowser(t *testing.T) {
 	defer http.Verify(t)
 
 	http.Register(
-		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
 				"id": "REPOID",
@@ -947,7 +947,7 @@ func TestIssueCreate_metadata(t *testing.T) {
 	http := &httpmock.Registry{}
 	defer http.Verify(t)
 
-	http.StubRepoInfoResponse("OWNER", "REPO", "main")
+	http.StubIssueRepoInfoResponse("OWNER", "REPO")
 	http.Register(
 		httpmock.GraphQL(`query RepositoryAssignableActors\b`),
 		httpmock.StringResponse(`
@@ -1057,7 +1057,7 @@ func TestIssueCreate_disabledIssues(t *testing.T) {
 	defer http.Verify(t)
 
 	http.Register(
-		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 		httpmock.StringResponse(`
 			{ "data": { "repository": {
 				"id": "REPOID",
@@ -1084,7 +1084,7 @@ func TestIssueCreate_AtMeAssignee(t *testing.T) {
 		`),
 	)
 	http.Register(
-		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 		httpmock.StringResponse(`
 		{ "data": { "repository": {
 			"id": "REPOID",
@@ -1127,7 +1127,7 @@ func TestIssueCreate_AtCopilotAssignee(t *testing.T) {
 	defer http.Verify(t)
 
 	http.Register(
-		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 		httpmock.StringResponse(`
 		{ "data": { "repository": {
 			"id": "REPOID",
@@ -1168,7 +1168,7 @@ func TestIssueCreate_projectsV2(t *testing.T) {
 	http := &httpmock.Registry{}
 	defer http.Verify(t)
 
-	http.StubRepoInfoResponse("OWNER", "REPO", "main")
+	http.StubIssueRepoInfoResponse("OWNER", "REPO")
 	http.Register(
 		httpmock.GraphQL(`query RepositoryProjectList\b`),
 		httpmock.StringResponse(`
@@ -1261,7 +1261,7 @@ func TestProjectsV1Deprecation(t *testing.T) {
 			ios, _, _, _ := iostreams.Test()
 
 			reg := &httpmock.Registry{}
-			reg.StubRepoInfoResponse("OWNER", "REPO", "main")
+			reg.StubIssueRepoInfoResponse("OWNER", "REPO")
 			reg.Register(
 				// ( is required to avoid matching projectsV2
 				httpmock.GraphQL(`projects\(`),
@@ -1298,7 +1298,7 @@ func TestProjectsV1Deprecation(t *testing.T) {
 			ios, _, _, _ := iostreams.Test()
 
 			reg := &httpmock.Registry{}
-			reg.StubRepoInfoResponse("OWNER", "REPO", "main")
+			reg.StubIssueRepoInfoResponse("OWNER", "REPO")
 			// ( is required to avoid matching projectsV2
 			reg.Exclude(t, httpmock.GraphQL(`projects\(`))
 

--- a/pkg/cmd/issue/transfer/transfer.go
+++ b/pkg/cmd/issue/transfer/transfer.go
@@ -105,7 +105,7 @@ func issueTransfer(httpClient *http.Client, issueID string, destRepo ghrepo.Inte
 		destinationRepoID = r.ID
 	} else {
 		apiClient := api.NewClientFromHTTP(httpClient)
-		r, err := api.GitHubRepo(apiClient, destRepo)
+		r, err := api.IssueRepoInfo(apiClient, destRepo)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cmd/issue/transfer/transfer_test.go
+++ b/pkg/cmd/issue/transfer/transfer_test.go
@@ -169,7 +169,7 @@ func Test_transferRunSuccessfulIssueTransfer(t *testing.T) {
 			} } }`))
 
 	http.Register(
-		httpmock.GraphQL(`query RepositoryInfo\b`),
+		httpmock.GraphQL(`query IssueRepositoryInfo\b`),
 		httpmock.StringResponse(`
 				{ "data": { "repository": {
 						"id": "dest-id",

--- a/pkg/httpmock/legacy.go
+++ b/pkg/httpmock/legacy.go
@@ -22,6 +22,20 @@ func (r *Registry) StubRepoInfoResponse(owner, repo, branch string) {
 		`, repo, owner, branch)))
 }
 
+func (r *Registry) StubIssueRepoInfoResponse(owner, repo string) {
+	r.Register(
+		GraphQL(`query IssueRepositoryInfo\b`),
+		StringResponse(fmt.Sprintf(`
+		{ "data": { "repository": {
+			"id": "REPOID",
+			"name": "%s",
+			"owner": {"login": "%s"},
+			"hasIssuesEnabled": true,
+			"viewerPermission": "WRITE"
+		} } }
+		`, repo, owner)))
+}
+
 func (r *Registry) StubRepoResponse(owner, repo string) {
 	r.StubRepoResponseWithPermission(owner, repo, "WRITE")
 }


### PR DESCRIPTION
Fixes #12798

Add a new `IssueRepoInfo` API function that fetches only the minimal fields needed for issue operations (`id`, `name`, `owner`, `hasIssuesEnabled`, `viewerPermission`), and switch both `issue create` and `issue transfer` to use it instead of `GitHubRepo`, which also fetches `defaultBranchRef` and merge-strategy fields that require additional token permissions beyond what issue commands need.

## Review notes

Most of the changes in this PR are test stub updates — switching mock query names from `RepositoryInfo` to `IssueRepositoryInfo` and using the new `StubIssueRepoInfoResponse` helper. The core logic change is minimal: a new `IssueRepoInfo` function in `api/queries_repo.go` and a one-line swap in each of `issue create` and `issue transfer`. Each test stub was individually reviewed to confirm the response body only contains fields within `IssueRepoInfo`'s scope and no adjustments beyond the query name were needed.

## Alternative approach (#12873)

An alternative fix in #12873 uses `FetchRepository` with only `hasIssuesEnabled`, but this misses `id` (needed by the `IssueCreate` mutation for `repositoryId`) and `viewerPermission` (needed by `ViewerCanTriage()` to decide whether to show the metadata prompt in interactive mode). A dedicated function like `IssueRepoInfo` avoids this kind of issue by encapsulating the exact fields required, rather than pushing that responsibility onto each caller.