### PR TITLE
Add monthly pitch surfacing workflow

### DIFF
--- a/.github/workflows/triage-scheduled-tasks.yml
+++ b/.github/workflows/triage-scheduled-tasks.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: '5 * * * *'   # Hourly — no-response close
     - cron: '0 3 * * *'   # Daily at 3 AM UTC — stale issues
+    - cron: '0 14 1 * *'  # Monthly on the 1st at 2 PM UTC — pitch surfacing
 
 jobs:
   no-response:
@@ -22,5 +23,11 @@ jobs:
       start_date: '2025-07-10T00:00:00Z'
       stale_issue_label: 'stale'
       exempt_issue_labels: 'keep'
+    permissions:
+      issues: write
+
+  pitch-surface:
+    if: github.event.schedule == '0 14 1 * *' || github.event_name == 'workflow_dispatch'
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/pitch-surface-top-issues.yml@main
     permissions:
       issues: write

--- a/.github/workflows/triage-scheduled-tasks.yml
+++ b/.github/workflows/triage-scheduled-tasks.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   no-response:
+    if: github.event_name == 'issue_comment' || github.event.schedule == '5 * * * *'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-no-response-close.yml@main
     permissions:
       issues: write


### PR DESCRIPTION
Adds a monthly scheduled job (1st of each month at 2 PM UTC) that surfaces the top 30 most-engaged open issues (by reactions + comments) and applies the `pitch` label. Also runs on manual `workflow_dispatch` for on-demand use before meetings.

Uses the shared reusable workflow from `desktop/gh-cli-and-desktop-shared-workflows`.