### PR TITLE
Migrate Windows code signing from client secret to OIDC

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -206,14 +206,19 @@ jobs:
         env:
           TAG_NAME: ${{ inputs.tag_name }}
         run: git tag "$TAG_NAME"
-      # Azure Code Signing leverages the environment variables for secrets that complement the metadata.json
-      # file generated above (AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID)
-      # For more information, see https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential?view=azure-dotnet
+      - name: Authenticate to Azure for code signing
+        if: inputs.environment == 'production'
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.SPN_GITHUB_CLI_SIGNING_CLIENT_ID }}
+          tenant-id: ${{ secrets.SPN_GITHUB_CLI_SIGNING_TENANT_ID }}
+          allow-no-subscriptions: true
+      # Azure Code Signing authenticates via OIDC (azure/login above). AZURE_CLIENT_ID and AZURE_TENANT_ID
+      # are still passed so DefaultAzureCredential can identify the service principal.
       - name: Build release binaries
         shell: bash
         env:
           AZURE_CLIENT_ID: ${{ secrets.SPN_GITHUB_CLI_SIGNING_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.SPN_GITHUB_CLI_SIGNING }}
           AZURE_TENANT_ID: ${{ secrets.SPN_GITHUB_CLI_SIGNING_TENANT_ID }}
           DLIB_PATH: ${{ runner.temp }}\acs\bin\x64\Azure.CodeSigning.Dlib.dll
           METADATA_PATH: ${{ runner.temp }}\acs\metadata.json
@@ -255,7 +260,6 @@ jobs:
         shell: pwsh
         env:
           AZURE_CLIENT_ID: ${{ secrets.SPN_GITHUB_CLI_SIGNING_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.SPN_GITHUB_CLI_SIGNING }}
           AZURE_TENANT_ID: ${{ secrets.SPN_GITHUB_CLI_SIGNING_TENANT_ID }}
           DLIB_PATH: ${{ runner.temp }}\acs\bin\x64\Azure.CodeSigning.Dlib.dll
           METADATA_PATH: ${{ runner.temp }}\acs\metadata.json


### PR DESCRIPTION
## Summary

Replaces `AZURE_CLIENT_SECRET`-based authentication for Windows code signing with OIDC federated identity credentials via `azure/login@v2`.

## Changes

- Add `azure/login@v2` step before signing (production only) to establish OIDC session
- Remove `AZURE_CLIENT_SECRET` from both the .exe signing (GoReleaser) and .msi signing steps
- Keep `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` env vars for `DefaultAzureCredential` identification

## Pre-requisites completed

- [x] OIDC subject customization set on `cli/cli` (`repository_owner_id`, `repository_id`, `context`)
- [x] `id-token: write` permission already present at workflow level

## Companion work

Modeled after desktop's identical migration: [desktop/desktop#21786](https://github.com/desktop/desktop/pull/21786)

## Notes for reviewer

Please see the successful test run using this workflow: https://github.com/cli/cli/actions/runs/22981502108/job/66722159067