### PR TITLE
fix: preserve GraphQL error type for scope errors in handleResponse

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -181,10 +181,6 @@ func handleResponse(err error) error {
 
 	var gqlErr *ghAPI.GraphQLError
 	if errors.As(err, &gqlErr) {
-		scopeErr := GenerateScopeErrorForGQL(gqlErr)
-		if scopeErr != nil {
-			return scopeErr
-		}
 		return GraphQLError{
 			GraphQLError: gqlErr,
 		}

--- a/api/queries_projects_v2_test.go
+++ b/api/queries_projects_v2_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/pkg/httpmock"
+	ghAPI "github.com/cli/go-gh/v2/pkg/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -330,6 +331,25 @@ func TestProjectsV2IgnorableError(t *testing.T) {
 			assert.Equal(t, tt.expectOut, out)
 		})
 	}
+}
+
+func TestProjectsV2IgnorableError_AfterHandleResponse(t *testing.T) {
+	// Regression test for https://github.com/cli/cli/issues/12904
+	// Scope errors from GraphQL responses must remain ignorable after
+	// handleResponse wraps them, so that gh pr view and similar commands
+	// don't fatally error when the token lacks read:project scope.
+	gqlErr := &ghAPI.GraphQLError{
+		Errors: []ghAPI.GraphQLErrorItem{
+			{
+				Type:    "INSUFFICIENT_SCOPES",
+				Message: "field requires one of the following scopes: ['read:project']",
+			},
+		},
+	}
+	wrapped := handleResponse(gqlErr)
+	require.NotNil(t, wrapped)
+	assert.True(t, ProjectsV2IgnorableError(wrapped),
+		"scope error after handleResponse should be ignorable, got: %v", wrapped)
 }
 
 func stripSpace(str string) string {


### PR DESCRIPTION
Fixes #12904

PR #12596 added `GenerateScopeErrorForGQL()` inside `handleResponse()`, which rewrites `INSUFFICIENT_SCOPES` GraphQL errors into plain `fmt.Errorf` strings before callers see them. This broke `ProjectsV2IgnorableError()` which checks for the original API substring to silently suppress `read:project` scope errors.

After the rewrite, `gh pr view`, `gh pr edit`, `gh issue view` etc. all fatally error instead of gracefully ignoring the missing project scope.

The fix removes `GenerateScopeErrorForGQL` from `handleResponse()` so scope errors flow through as `GraphQLError` like any other GraphQL error. `ProjectsV2IgnorableError` can then match the original message and suppress it as intended.

`gh project` commands still get user-friendly scope messages through their own `handleError` in `pkg/cmd/project/shared/queries`, which already calls `GenerateScopeErrorForGQL` independently.

**Changes:**
- `api/client.go`: removed scope error rewriting from `handleResponse`
- `api/queries_projects_v2_test.go`: added regression test that verifies scope errors remain ignorable after passing through `handleResponse`