### PR TITLE
Revert "fix: clarify scope error while creating issues for projects"

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cli/cli/v2/pkg/set"
 	ghAPI "github.com/cli/go-gh/v2/pkg/api"
 	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 )
@@ -181,50 +180,12 @@ func handleResponse(err error) error {
 
 	var gqlErr *ghAPI.GraphQLError
 	if errors.As(err, &gqlErr) {
-		scopeErr := GenerateScopeErrorForGQL(gqlErr)
-		if scopeErr != nil {
-			return scopeErr
-		}
 		return GraphQLError{
 			GraphQLError: gqlErr,
 		}
 	}
 
 	return err
-}
-
-func GenerateScopeErrorForGQL(gqlErr *ghAPI.GraphQLError) error {
-	missing := set.NewStringSet()
-	for _, e := range gqlErr.Errors {
-		if e.Type != "INSUFFICIENT_SCOPES" {
-			continue
-		}
-		missing.AddValues(requiredScopesFromServerMessage(e.Message))
-	}
-	if missing.Len() > 0 {
-		s := missing.ToSlice()
-		// TODO: this duplicates parts of generateScopesSuggestion
-		return fmt.Errorf(
-			"error: your authentication token is missing required scopes %v\n"+
-				"To request it, run:  gh auth refresh -s %s",
-			s,
-			strings.Join(s, ","))
-	}
-	return nil
-}
-
-var scopesRE = regexp.MustCompile(`one of the following scopes: \[(.+?)]`)
-
-func requiredScopesFromServerMessage(msg string) []string {
-	m := scopesRE.FindStringSubmatch(msg)
-	if m == nil {
-		return nil
-	}
-	var scopes []string
-	for _, mm := range strings.Split(m[1], ",") {
-		scopes = append(scopes, strings.Trim(mm, "' "))
-	}
-	return scopes
 }
 
 // ScopesSuggestion is an error messaging utility that prints the suggestion to request additional OAuth

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/cli/go-gh/v2/pkg/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -256,80 +255,4 @@ func TestHTTPHeaders(t *testing.T) {
 		assert.Equal(t, value, gotReq.Header.Get(name), name)
 	}
 	assert.Equal(t, "", stderr.String())
-}
-
-func TestGenerateScopeErrorForGQL(t *testing.T) {
-	tests := []struct {
-		name     string
-		gqlError *api.GraphQLError
-		wantErr  bool
-		expected string
-	}{
-		{
-			name: "missing scope",
-			gqlError: &api.GraphQLError{
-				Errors: []api.GraphQLErrorItem{
-					{
-						Type:    "INSUFFICIENT_SCOPES",
-						Message: "The 'addProjectV2ItemById' field requires one of the following scopes: ['project']",
-					},
-				},
-			},
-			wantErr: true,
-			expected: "error: your authentication token is missing required scopes [project]\n" +
-				"To request it, run:  gh auth refresh -s project",
-		},
-
-		{
-			name: "ignore non-scope errors",
-			gqlError: &api.GraphQLError{
-				Errors: []api.GraphQLErrorItem{
-					{
-						Type:    "NOT_FOUND",
-						Message: "Could not resolve to a Repository",
-					},
-				},
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := GenerateScopeErrorForGQL(tt.gqlError)
-			if tt.wantErr {
-				assert.NotNil(t, err)
-				assert.Equal(t, tt.expected, err.Error())
-			} else {
-				assert.Nil(t, err)
-			}
-		})
-	}
-}
-
-func TestRequiredScopesFromServerMessage(t *testing.T) {
-	tests := []struct {
-		msg      string
-		expected []string
-	}{
-		{
-			msg:      "requires one of the following scopes: ['project']",
-			expected: []string{"project"},
-		},
-		{
-			msg:      "requires one of the following scopes: ['repo', 'read:org']",
-			expected: []string{"repo", "read:org"},
-		},
-		{
-			msg:      "no match here",
-			expected: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.msg, func(t *testing.T) {
-			output := requiredScopesFromServerMessage(tt.msg)
-			assert.Equal(t, tt.expected, output)
-		})
-	}
 }


### PR DESCRIPTION
## Description
 
Reverts cli/cli#12596

Fixes https://github.com/cli/cli/issues/12904

This PR introduced a change that adjusted the stringified error message returned in GQL response when there were missing scopes. However, that error message was interrogated by [`ProjectsV2IgnorableError`](https://github.com/cli/cli/blob/4a3f7d9ce0eb7c0c22004441c63efc916dcd0b86/api/queries_projects_v2.go#L328-L339) in order to gracefully degrade the experience on `pr` and `issue view` commands when `read:projects` was missing.

We could move this forward, but I actually think the implementation in that PR was incorrect because it previously showed an error message that made sense for personal access tokens and was changed to a message that only made sense for OAuth tokens. And so it just sort of swapped the problem around. I'm gonna reopen that issue, but if we were to address it again we would need to interrogate the type of token or provide an error message that covered both cases.

### Acceptance Test

#### Before

```
➜  cli git:(trunk) GH_ACCEPTANCE_SCRIPT=pr-view.txtar GH_ACCEPTANCE_HOST=github.com GH_ACCEPTANCE_ORG=gh-acceptance-testing GH_ACCEPTANCE_TOKEN=$(gh auth token) go test -tags=acceptance -run ^TestPullRequests$ ./acceptance
--- FAIL: TestPullRequests (0.00s)
    --- FAIL: TestPullRequests/pr-view (9.67s)
        testscript.go:584: # Use gh as a credential helper (0.735s)
            # Create a repository with a file so it has a default branch (1.273s)
            # Defer repo cleanup (0.000s)
            # Clone the repo (1.914s)
            # Prepare a branch to PR (1.181s)
            # Create the PR (2.270s)
            # View the PR (2.249s)
            > exec gh pr view $PR_URL
            [stderr]
            error: your authentication token is missing required scopes [read:project]
            To request it, run:  gh auth refresh -s read:project
            [exit status 1]
            FAIL: testdata/pr/pr-view.txtar:28: unexpected command failure

FAIL
FAIL	github.com/cli/cli/v2/acceptance	10.296s
FAIL
```

#### After

```
➜  cli git:(revert-12596-fix/clarify-scope-error) ✗ GH_ACCEPTANCE_SCRIPT=pr-view.txtar GH_ACCEPTANCE_HOST=github.com GH_ACCEPTANCE_ORG=gh-acceptance-testing GH_ACCEPTANCE_TOKEN=$(gh auth token) go test -tags=acceptance -run ^TestPullRequests$ ./acceptance
ok  	github.com/cli/cli/v2/acceptance	10.317s
```
