### PR TITLE
Fix remote resolution when url.*.insteadOf rewrites GitHub URLs

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -187,6 +187,20 @@ func (c *Client) Remotes(ctx context.Context) (RemoteSet, error) {
 	}
 
 	remotes := parseRemotes(outputLines(remoteOut))
+
+	// Overwrite fetch/push URLs with the raw values from git config, which are
+	// not subject to url.<base>.insteadOf rewriting. This is important because
+	// gh needs to match remote hostnames against known GitHub hosts, and
+	// insteadOf rules can rewrite github.com URLs to something unrecognizable.
+	rawURLArgs := []string{"config", "--get-regexp", `^remote\..*\.(url|pushurl)$`}
+	rawURLCmd, err := c.Command(ctx, rawURLArgs...)
+	if err == nil {
+		rawURLOut, rawURLErr := rawURLCmd.Output()
+		if rawURLErr == nil {
+			populateRawRemoteURLs(remotes, outputLines(rawURLOut))
+		}
+	}
+
 	populateResolvedRemotes(remotes, outputLines(configOut))
 	sort.Sort(remotes)
 	return remotes, nil
@@ -959,6 +973,53 @@ func populateResolvedRemotes(remotes RemoteSet, resolved []string) {
 		for _, r := range remotes {
 			if r.Name == name {
 				r.Resolved = parts[1]
+				break
+			}
+		}
+	}
+}
+
+// populateRawRemoteURLs overwrites the FetchURL and PushURL on each remote with
+// the raw (non-rewritten) values read from git config. git remote -v applies
+// url.<base>.insteadOf rules which can obscure the original hostname, making it
+// impossible for gh to match remotes against known GitHub hosts.
+func populateRawRemoteURLs(remotes RemoteSet, configLines []string) {
+	for _, l := range configLines {
+		// Lines look like:
+		//   remote.origin.url https://github.com/owner/repo.git
+		//   remote.origin.pushurl https://github.com/owner/repo.git
+		parts := strings.SplitN(l, " ", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		key := parts[0] // e.g. remote.origin.url
+		rawURL := parts[1]
+
+		// Split key into ["remote", "<name>", "url"|"pushurl"]
+		kp := strings.SplitN(key, ".", 3)
+		if len(kp) < 3 {
+			continue
+		}
+		name := kp[1]
+		urlType := kp[2]
+
+		parsedURL, err := ParseURL(rawURL)
+		if err != nil {
+			continue
+		}
+
+		for _, r := range remotes {
+			if r.Name == name {
+				switch urlType {
+				case "url":
+					r.FetchURL = parsedURL
+					// Also update PushURL to the raw value. If the remote has
+					// a separate pushurl config entry it will be processed
+					// after this and override PushURL again.
+					r.PushURL = parsedURL
+				case "pushurl":
+					r.PushURL = parsedURL
+				}
 				break
 			}
 		}

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -182,6 +182,165 @@ func TestClientRemotes_no_resolved_remote(t *testing.T) {
 	assert.Equal(t, "test", rs[3].Name)
 }
 
+func TestClientRemotes_insteadOf(t *testing.T) {
+	tempDir := t.TempDir()
+	initRepo(t, tempDir)
+	gitDir := filepath.Join(tempDir, ".git")
+	remoteFile := filepath.Join(gitDir, "config")
+
+	// Simulate a setup where insteadOf rewrites github.com URLs to localhost.
+	// The raw config stores github.com URLs, but git remote -v would show
+	// localhost URLs due to url.<base>.insteadOf.
+	remotes := `
+[url "http://localhost:9989/"]
+	insteadOf = https://github.com/
+[remote "origin"]
+	url = https://github.com/owner/repo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "upstream"]
+	url = https://github.com/upstream-owner/repo.git
+	fetch = +refs/heads/*:refs/remotes/upstream/*
+	gh-resolved = base
+`
+	f, err := os.OpenFile(remoteFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
+	assert.NoError(t, err)
+	_, err = f.Write([]byte(remotes))
+	assert.NoError(t, err)
+	err = f.Close()
+	assert.NoError(t, err)
+
+	client := Client{
+		RepoDir: tempDir,
+	}
+	rs, err := client.Remotes(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(rs))
+
+	// Remotes should use the raw github.com URLs, not the rewritten localhost ones.
+	assert.Equal(t, "upstream", rs[0].Name)
+	assert.Equal(t, "github.com", rs[0].FetchURL.Host)
+	assert.Equal(t, "/upstream-owner/repo.git", rs[0].FetchURL.Path)
+	assert.Equal(t, "base", rs[0].Resolved)
+
+	assert.Equal(t, "origin", rs[1].Name)
+	assert.Equal(t, "github.com", rs[1].FetchURL.Host)
+	assert.Equal(t, "/owner/repo.git", rs[1].FetchURL.Path)
+}
+
+func TestPopulateRawRemoteURLs(t *testing.T) {
+	tests := []struct {
+		name        string
+		remotes     RemoteSet
+		configLines []string
+		wantFetch   map[string]string // remote name -> expected FetchURL host
+		wantPush    map[string]string // remote name -> expected PushURL host
+	}{
+		{
+			name: "overwrites fetch and push URLs with raw values",
+			remotes: RemoteSet{
+				{Name: "origin",
+					FetchURL: &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+					PushURL:  &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+				},
+			},
+			configLines: []string{
+				"remote.origin.url https://github.com/owner/repo.git",
+			},
+			wantFetch: map[string]string{"origin": "github.com"},
+			wantPush:  map[string]string{"origin": "github.com"},
+		},
+		{
+			name: "separate pushurl overrides push URL",
+			remotes: RemoteSet{
+				{Name: "origin",
+					FetchURL: &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+					PushURL:  &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+				},
+			},
+			configLines: []string{
+				"remote.origin.url https://github.com/owner/repo.git",
+				"remote.origin.pushurl https://push.example.com/owner/repo.git",
+			},
+			wantFetch: map[string]string{"origin": "github.com"},
+			wantPush:  map[string]string{"origin": "push.example.com"},
+		},
+		{
+			name: "multiple remotes",
+			remotes: RemoteSet{
+				{Name: "origin",
+					FetchURL: &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+					PushURL:  &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+				},
+				{Name: "upstream",
+					FetchURL: &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/up/repo.git"},
+					PushURL:  &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/up/repo.git"},
+				},
+			},
+			configLines: []string{
+				"remote.origin.url https://github.com/owner/repo.git",
+				"remote.upstream.url https://github.com/up/repo.git",
+			},
+			wantFetch: map[string]string{"origin": "github.com", "upstream": "github.com"},
+			wantPush:  map[string]string{"origin": "github.com", "upstream": "github.com"},
+		},
+		{
+			name: "unmatched remote in config is ignored",
+			remotes: RemoteSet{
+				{Name: "origin",
+					FetchURL: &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+					PushURL:  &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+				},
+			},
+			configLines: []string{
+				"remote.origin.url https://github.com/owner/repo.git",
+				"remote.nonexistent.url https://github.com/other/repo.git",
+			},
+			wantFetch: map[string]string{"origin": "github.com"},
+			wantPush:  map[string]string{"origin": "github.com"},
+		},
+		{
+			name: "malformed config lines are skipped",
+			remotes: RemoteSet{
+				{Name: "origin",
+					FetchURL: &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+					PushURL:  &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+				},
+			},
+			configLines: []string{
+				"not-a-valid-line",
+				"remote.origin.url https://github.com/owner/repo.git",
+			},
+			wantFetch: map[string]string{"origin": "github.com"},
+			wantPush:  map[string]string{"origin": "github.com"},
+		},
+		{
+			name: "empty config lines",
+			remotes: RemoteSet{
+				{Name: "origin",
+					FetchURL: &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+					PushURL:  &url.URL{Scheme: "http", Host: "localhost:9989", Path: "/owner/repo.git"},
+				},
+			},
+			configLines: []string{""},
+			wantFetch:   map[string]string{"origin": "localhost:9989"},
+			wantPush:    map[string]string{"origin": "localhost:9989"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			populateRawRemoteURLs(tt.remotes, tt.configLines)
+			for _, r := range tt.remotes {
+				if wantHost, ok := tt.wantFetch[r.Name]; ok {
+					assert.Equal(t, wantHost, r.FetchURL.Host, "FetchURL host for %s", r.Name)
+				}
+				if wantHost, ok := tt.wantPush[r.Name]; ok {
+					assert.Equal(t, wantHost, r.PushURL.Host, "PushURL host for %s", r.Name)
+				}
+			}
+		})
+	}
+}
+
 func TestParseRemotes(t *testing.T) {
 	remoteList := []string{
 		"mona\tgit@github.com:monalisa/myfork.git (fetch)",


### PR DESCRIPTION
## Summary

When `url.<base>.insteadOf` rules are configured in git config (e.g. to route traffic through a corporate proxy), `git remote -v` returns the rewritten URLs. This causes `gh` to fail to match remotes against known GitHub hosts, breaking commands like `gh pr list`, `gh issue list`, `gh repo set-default`, etc.

Fixes #12916

## Changes

**`git/client.go`**: In the `Remotes()` function, after parsing remotes from `git remote -v`, additionally read raw URLs via:

```
git config --get-regexp ^remote\..*\.(url|pushurl)$
```

This returns the original, un-rewritten URLs as stored in `.git/config`. We overwrite the `FetchURL`/`PushURL` on each remote with these raw values via the new `populateRawRemoteURLs()` helper. This is a single extra git config read with negligible cost.

The raw URL read is best-effort: if it fails for any reason, the original `git remote -v` URLs are preserved (no behaviour change).

**`git/client_test.go`**: Added two test functions:

- `TestClientRemotes_insteadOf` — integration test that writes an `insteadOf` rule into the repo config and verifies that `Remotes()` still returns `github.com` hostnames.
- `TestPopulateRawRemoteURLs` — table-driven unit test covering: basic overwrite, separate `pushurl`, multiple remotes, unknown remotes, malformed lines, and empty lines.

## Why this approach

`gh` already has a `Translator` interface (used by `go-gh/pkg/ssh`) to handle SSH hostname aliases. However, that translator only handles `scheme == "ssh"` and has no awareness of HTTP `insteadOf` rewrites. Rather than extending the translator (which would require reverse-mapping the `insteadOf` rules), reading the raw config values directly is simpler, more reliable, and does not affect git transport commands (which continue to use the rewritten URLs as normal through git itself).