### PR TITLE
Fix `pr create --fill` when local branch name differs from remote

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -187,6 +187,7 @@ type CreateContext struct {
 	// and this is a small price to pay for the convenience of not having to do a lot
 	// more design.
 	BaseTrackingBranch string
+	HeadTrackingBranch string
 	Client             *api.Client
 	GitClient          *git.Client
 }
@@ -640,7 +641,7 @@ func createRun(opts *CreateOptions) error {
 var regexPattern = regexp.MustCompile(`(?m)^`)
 
 func initDefaultTitleBody(ctx CreateContext, state *shared.IssueMetadataState, useFirstCommit bool, addBody bool) error {
-	commits, err := ctx.GitClient.Commits(context.Background(), ctx.BaseTrackingBranch, ctx.PRRefs.UnqualifiedHeadRef())
+	commits, err := ctx.GitClient.Commits(context.Background(), ctx.BaseTrackingBranch, ctx.HeadTrackingBranch)
 	if err != nil {
 		return err
 	}
@@ -760,6 +761,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 			GitClient:          opts.GitClient,
 			PRRefs:             refs,
 			BaseTrackingBranch: baseTrackingBranch,
+			HeadTrackingBranch: refs.UnqualifiedHeadRef(),
 		}
 	}
 
@@ -870,10 +872,12 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 					qualifiedHeadRef = shared.NewQualifiedHeadRef(headRepo.RepoOwner(), defaultPRHead.BranchName)
 				}
 
-				return newCreateContext(skipPushRefs{
+				ctx := newCreateContext(skipPushRefs{
 					qualifiedHeadRef: qualifiedHeadRef,
 					baseRefs:         baseRefs,
-				}), nil
+				})
+				ctx.HeadTrackingBranch = fmt.Sprintf("%s/%s", headRemote.Name, defaultPRHead.BranchName)
+				return ctx, nil
 			}
 		}
 	}
@@ -936,10 +940,12 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 				qualifiedHeadRef = shared.NewQualifiedHeadRef(remote.RepoOwner(), ref.Branch)
 			}
 
-			return newCreateContext(skipPushRefs{
+			ctx := newCreateContext(skipPushRefs{
 				qualifiedHeadRef: qualifiedHeadRef,
 				baseRefs:         baseRefs,
-			}), nil
+			})
+			ctx.HeadTrackingBranch = fmt.Sprintf("%s/%s", ref.Remote, ref.Branch)
+			return ctx, nil
 		}
 	}
 

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -844,6 +844,42 @@ func Test_createRun(t *testing.T) {
 			expectedErrOut: "\nCreating pull request for my-feat2 into master in OWNER/REPO\n\n",
 		},
 		{
+			name: "fill when pushed to different branch name",
+			tty:  true,
+			setup: func(opts *CreateOptions, t *testing.T) func() {
+				opts.Autofill = true
+				return func() {}
+			},
+			httpStubs: func(reg *httpmock.Registry, t *testing.T) {
+				reg.Register(
+					httpmock.GraphQL(`mutation PullRequestCreate\b`),
+					httpmock.GraphQLMutation(`
+			{ "data": { "createPullRequest": { "pullRequest": {
+				"URL": "https://github.com/OWNER/REPO/pull/12"
+			} } } }
+			`, func(input map[string]interface{}) {
+						assert.Equal(t, "REPOID", input["repositoryId"].(string))
+						assert.Equal(t, "master", input["baseRefName"].(string))
+						assert.Equal(t, "my-feat2", input["headRefName"].(string))
+					}))
+			},
+			customBranchConfig: true,
+			cmdStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git config --get-regexp \^branch\\\.feature\\\.`, 0, heredoc.Doc(`
+			branch.feature.remote origin
+			branch.feature.merge refs/heads/my-feat2
+		`))
+				cs.Register("git rev-parse --symbolic-full-name feature@{push}", 0, "refs/remotes/origin/my-feat2")
+				cs.Register("git show-ref --verify -- HEAD refs/remotes/origin/my-feat2", 0, heredoc.Doc(`
+			deadbeef HEAD
+			deadbeef refs/remotes/origin/my-feat2
+		`))
+				cs.Register(`git -c log.ShowSignature=false log --pretty=format:%H%x00%s%x00%b%x00 --cherry origin/master\.\.\.origin/my-feat2`, 0, "d3476a1\x00first commit\x00\x00")
+			},
+			expectedOut:    "https://github.com/OWNER/REPO/pull/12\n",
+			expectedErrOut: "\nCreating pull request for my-feat2 into master in OWNER/REPO\n\n",
+		},
+		{
 			name: "non legacy template",
 			tty:  true,
 			setup: func(opts *CreateOptions, t *testing.T) func() {


### PR DESCRIPTION
When a local branch (e.g. `feature`) tracks a differently-named remote
branch (e.g. `origin/my-feat2`), `initDefaultTitleBody()` passed the
bare remote branch name (`my-feat2`) to `git log`, producing:

    fatal: ambiguous argument 'origin/main...my-feat2'

Add `HeadTrackingBranch` to `CreateContext` so the two skip-push code
paths can supply the fully-qualified remote tracking ref
(`origin/my-feat2`), matching `BaseTrackingBranch` (`origin/main`).

Fixes #5896
Fixes #12800
Partially addresses #11041 (fixes --fill; the --head mismatch is a
separate issue)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
