### PR TITLE
fix: use Search API for all visibility filters to properly exclude internal repos

### DIFF
--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -30,7 +30,7 @@ type FilterOptions struct {
 }
 
 func listRepos(client *http.Client, hostname string, limit int, owner string, filter FilterOptions) (*RepositoryList, error) {
-	if filter.Language != "" || filter.Archived || filter.NonArchived || len(filter.Topic) > 0 || filter.Visibility == "internal" {
+	if filter.Language != "" || filter.Archived || filter.NonArchived || len(filter.Topic) > 0 || filter.Visibility != "" {
 		return searchRepos(client, hostname, limit, owner, filter)
 	}
 

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -471,9 +471,9 @@ func TestRepoList_filtering(t *testing.T) {
 	defer http.Verify(t)
 
 	http.Register(
-		httpmock.GraphQL(`query RepositoryList\b`),
+		httpmock.GraphQL(`query RepositoryListSearch\b`),
 		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
-			assert.Equal(t, "PRIVATE", params["privacy"])
+			assert.Equal(t, "sort:updated-desc fork:true is:private user:@me", params["query"])
 			assert.Equal(t, float64(2), params["perPage"])
 		}),
 	)


### PR DESCRIPTION
When using --visibility=private, the GraphQL query was also returning internal repos. This fix uses the Search API for all visibility filters (not just 'internal'), which correctly filters repos by visibility.

Fixes #12900