### PR TITLE
fix: suggest gh auth refresh for GraphQL scope errors

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -42,6 +42,11 @@ func (c *Client) HTTP() *http.Client {
 
 type GraphQLError struct {
 	*ghAPI.GraphQLError
+	scopesSuggestion string
+}
+
+func (err GraphQLError) ScopesSuggestion() string {
+	return err.scopesSuggestion
 }
 
 type HTTPError struct {
@@ -181,7 +186,8 @@ func handleResponse(err error) error {
 	var gqlErr *ghAPI.GraphQLError
 	if errors.As(err, &gqlErr) {
 		return GraphQLError{
-			GraphQLError: gqlErr,
+			GraphQLError:     gqlErr,
+			scopesSuggestion: generateGQLScopesSuggestion(gqlErr),
 		}
 	}
 
@@ -257,6 +263,38 @@ func generateScopesSuggestion(statusCode int, endpointNeedsScopes, tokenHasScope
 	}
 
 	return ""
+}
+
+var gqlScopesRE = regexp.MustCompile(`one of the following scopes: \[(.+?)\]`)
+
+// generateGQLScopesSuggestion inspects a GraphQL error for INSUFFICIENT_SCOPES
+// items and returns a suggestion string. The original error is left unmodified so
+// that callers like ProjectsV2IgnorableError can still match against it.
+func generateGQLScopesSuggestion(gqlErr *ghAPI.GraphQLError) string {
+	var missing []string
+	seen := map[string]bool{}
+	for _, e := range gqlErr.Errors {
+		if e.Type != "INSUFFICIENT_SCOPES" {
+			continue
+		}
+		m := gqlScopesRE.FindStringSubmatch(e.Message)
+		if m == nil {
+			continue
+		}
+		for _, s := range strings.Split(m[1], ",") {
+			s = strings.Trim(s, "' ")
+			if s != "" && !seen[s] {
+				seen[s] = true
+				missing = append(missing, s)
+			}
+		}
+	}
+	if len(missing) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"To request missing scopes, run:  gh auth refresh -s %s",
+		strings.Join(missing, ","))
 }
 
 func clientOptions(hostname string, transport http.RoundTripper) ghAPI.ClientOptions {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	ghAPI "github.com/cli/go-gh/v2/pkg/api"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/stretchr/testify/assert"
@@ -222,6 +223,88 @@ func TestHTTPError_ScopesSuggestion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGraphQLError_ScopesSuggestion(t *testing.T) {
+	tests := []struct {
+		name string
+		errs []ghAPI.GraphQLErrorItem
+		want string
+	}{
+		{
+			name: "no scope errors",
+			errs: []ghAPI.GraphQLErrorItem{
+				{Message: "something went wrong", Type: "SOME_ERROR"},
+			},
+			want: "",
+		},
+		{
+			name: "single missing scope",
+			errs: []ghAPI.GraphQLErrorItem{
+				{
+					Message: "Your token has not been granted the required scopes to execute this query. The 'addProjectV2ItemById' field requires one of the following scopes: ['project'], but your token has only been granted the: ['gist', 'read:org', 'read:project', 'repo', 'workflow'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens.",
+					Type:    "INSUFFICIENT_SCOPES",
+				},
+			},
+			want: "To request missing scopes, run:  gh auth refresh -s project",
+		},
+		{
+			name: "multiple missing scopes",
+			errs: []ghAPI.GraphQLErrorItem{
+				{
+					Message: "The 'foo' field requires one of the following scopes: ['read:project', 'read:discussion', 'codespace'], but your token has only been granted the: ['repo'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens.",
+					Type:    "INSUFFICIENT_SCOPES",
+				},
+			},
+			want: "To request missing scopes, run:  gh auth refresh -s read:project,read:discussion,codespace",
+		},
+		{
+			name: "mixed error types",
+			errs: []ghAPI.GraphQLErrorItem{
+				{Message: "not found", Type: "NOT_FOUND"},
+				{
+					Message: "The 'x' field requires one of the following scopes: ['project'], but your token has only been granted the: ['repo'] scopes.",
+					Type:    "INSUFFICIENT_SCOPES",
+				},
+			},
+			want: "To request missing scopes, run:  gh auth refresh -s project",
+		},
+		{
+			name: "insufficient scopes without parseable message",
+			errs: []ghAPI.GraphQLErrorItem{
+				{Message: "some other insufficient scope message", Type: "INSUFFICIENT_SCOPES"},
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gqlErr := GraphQLError{
+				GraphQLError:     &ghAPI.GraphQLError{Errors: tt.errs},
+				scopesSuggestion: generateGQLScopesSuggestion(&ghAPI.GraphQLError{Errors: tt.errs}),
+			}
+			if got := gqlErr.ScopesSuggestion(); got != tt.want {
+				t.Errorf("GraphQLError.ScopesSuggestion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGraphQLError_PreservesOriginalMessage(t *testing.T) {
+	// Verify that the original error message is preserved for ProjectsV2IgnorableError matching
+	originalMsg := "Your token has not been granted the required scopes to execute this query. The 'projectItems' field requires one of the following scopes: ['read:project'], but your token has only been granted the: ['repo'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens."
+	gqlErr := &ghAPI.GraphQLError{
+		Errors: []ghAPI.GraphQLErrorItem{
+			{Message: originalMsg, Type: "INSUFFICIENT_SCOPES"},
+		},
+	}
+	wrapped := handleResponse(gqlErr)
+	// The original message must still be present in Error() output
+	assert.Contains(t, wrapped.Error(), "field requires one of the following scopes: ['read:project']")
+	// And the scopes suggestion must be set
+	graphqlErr, ok := wrapped.(GraphQLError)
+	assert.True(t, ok)
+	assert.Equal(t, "To request missing scopes, run:  gh auth refresh -s read:project", graphqlErr.ScopesSuggestion())
 }
 
 func TestHTTPHeaders(t *testing.T) {

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -157,6 +157,13 @@ func Main() exitCode {
 			fmt.Fprintln(stderr, msg)
 		}
 
+		var gqlErr api.GraphQLError
+		if errors.As(err, &gqlErr) {
+			if msg := gqlErr.ScopesSuggestion(); msg != "" {
+				fmt.Fprintln(stderr, msg)
+			}
+		}
+
 		return exitError
 	}
 	if root.HasFailed() {


### PR DESCRIPTION
## Summary
- When a GraphQL query fails with `INSUFFICIENT_SCOPES`, the error now prints an actionable `gh auth refresh -s <scope>` suggestion
- Stores the suggestion as a separate field on `GraphQLError` without modifying the original `Error()` output
- This avoids the regression from the reverted #12596 and #12845, which both broke `ProjectsV2IgnorableError` by rewriting the error message

Fixes #12585

## Approach
Previous PRs called `GenerateScopeErrorForGQL()` inside `handleResponse()`, which rewrote the error message and broke string matching in `ProjectsV2IgnorableError`. This fix follows the same pattern as `HTTPError.ScopesSuggestion()`: the suggestion is computed and stored separately, then printed at the top-level error handler in `cmd.go`.

## Changes
- `api/client.go`: Added `scopesSuggestion` field and `ScopesSuggestion()` method to `GraphQLError`. New `generateGQLScopesSuggestion()` parses scope names from `INSUFFICIENT_SCOPES` errors via regex.
- `api/client_test.go`: 5 table-driven test cases for scope suggestion parsing, plus an explicit regression test verifying `Error()` still contains the original message.
- `internal/ghcmd/cmd.go`: Print GraphQL scope suggestion to stderr (matching existing HTTPError pattern).

## Test plan
- [x] `TestGraphQLError_ScopesSuggestion`: no scopes, single scope, multiple scopes, mixed types, unparseable
- [x] `TestGraphQLError_PreservesOriginalMessage`: verifies original error text preserved for ProjectsV2IgnorableError
- [x] All existing tests pass