### PR TITLE
fix(sync): prevent silent worktree corruption when synced branch is checked out elsewhere

### DIFF
--- a/pkg/cmd/repo/sync/git.go
+++ b/pkg/cmd/repo/sync/git.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cli/cli/v2/git"
 )
@@ -15,6 +16,7 @@ type gitClient interface {
 	HasLocalBranch(string) bool
 	IsAncestor(string, string) (bool, error)
 	IsDirty() (bool, error)
+	IsBranchCheckedOutInAnyWorktree(string) (bool, error)
 	MergeFastForward(string) error
 	ResetHard(string) error
 }
@@ -82,6 +84,36 @@ func (g *gitExecuter) IsDirty() (bool, error) {
 		return false, err
 	}
 	return changeCount != 0, nil
+}
+
+// IsBranchCheckedOutInAnyWorktree checks if the given branch is checked out
+// in any git worktree (not just the current one). This prevents silent corruption
+// when using git update-ref on a branch that's checked out elsewhere.
+func (g *gitExecuter) IsBranchCheckedOutInAnyWorktree(branch string) (bool, error) {
+	args := []string{"worktree", "list", "--porcelain"}
+	cmd, err := g.client.Command(context.Background(), args...)
+	if err != nil {
+		return false, err
+	}
+	output, err := cmd.Output()
+	if err != nil {
+		// If worktree command fails (e.g., older git), fall back to false
+		// which means we can't detect it, but won't block the operation
+		return false, nil
+	}
+
+	// Parse porcelain output: each worktree entry has "branch refs/heads/xxx" lines
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "branch ") {
+			ref := strings.TrimPrefix(line, "branch ")
+			// Match refs/heads/<branch>
+			if ref == fmt.Sprintf("refs/heads/%s", branch) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func (g *gitExecuter) MergeFastForward(ref string) error {

--- a/pkg/cmd/repo/sync/mocks.go
+++ b/pkg/cmd/repo/sync/mocks.go
@@ -43,6 +43,11 @@ func (g *mockGitClient) IsDirty() (bool, error) {
 	return args.Bool(0), args.Error(1)
 }
 
+func (g *mockGitClient) IsBranchCheckedOutInAnyWorktree(b string) (bool, error) {
+	args := g.Called(b)
+	return args.Bool(0), args.Error(1)
+}
+
 func (g *mockGitClient) MergeFastForward(a string) error {
 	args := g.Called(a)
 	return args.Error(0)

--- a/pkg/cmd/repo/sync/sync.go
+++ b/pkg/cmd/repo/sync/sync.go
@@ -257,6 +257,14 @@ func executeLocalRepoSync(srcRepo ghrepo.Interface, remote string, opts *SyncOpt
 			}
 		}
 	} else {
+		// Check if branch is checked out in ANY worktree (not just the current one).
+		// Using git update-ref on a branch checked out elsewhere silently corrupts
+		// that worktree's index and working tree.
+		if checkedOut, err := git.IsBranchCheckedOutInAnyWorktree(branch); err == nil && checkedOut {
+			return fmt.Errorf("refusing to sync: branch %q is checked out in another worktree\nuse `git worktree list` to see worktrees and switch to the one with %q to sync", branch, branch)
+		} else if err != nil {
+			return err
+		}
 		if hasLocalBranch {
 			if err := git.UpdateBranch(branch, "FETCH_HEAD"); err != nil {
 				return err


### PR DESCRIPTION
## Problem

`gh repo sync` uses `git update-ref` to fast-forward a branch that is not the current branch. However, it only checks whether the branch is checked out in the **current** worktree. When the synced branch is checked out in a **different** worktree, `git update-ref` advances the ref without updating that worktree's index or working tree, leaving it in a silently corrupted state.

## Reproduction

```bash
# Setup: main checked out in another worktree
mkdir repo && cd repo && git init
echo test > file && git add . && git commit -m init

# Create worktree with main checked out
git worktree add ./wt main

# From main worktree, run gh repo sync
gh repo sync  # Uses git update-ref, corrupts ./wt
```

## Fix

1. Add `IsBranchCheckedOutInAnyWorktree()` method that uses `git worktree list --porcelain` to check all worktrees
2. In `executeLocalRepoSync`, call this check before using `git update-ref`
3. Return a clear error if the branch is checked out in another worktree

## Changes

- `pkg/cmd/repo/sync/git.go`: Added `IsBranchCheckedOutInAnyWorktree` to interface and implementation
- `pkg/cmd/repo/sync/sync.go`: Added worktree check before `UpdateBranch`
- `pkg/cmd/repo/sync/mocks.go`: Added mock for new method

## Error message

When the branch is checked out in another worktree, users now see:
```
refusing to sync: branch "main" is checked out in another worktree
use `git worktree list` to see worktrees and switch to the one with "main" to sync
```

Fixes #12927