### PR TITLE
fix: route --visibility private through Search API to exclude internal repos

### DIFF
--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -30,7 +30,7 @@ type FilterOptions struct {
 }
 
 func listRepos(client *http.Client, hostname string, limit int, owner string, filter FilterOptions) (*RepositoryList, error) {
-	if filter.Language != "" || filter.Archived || filter.NonArchived || len(filter.Topic) > 0 || filter.Visibility == "internal" {
+	if filter.Language != "" || filter.Archived || filter.NonArchived || len(filter.Topic) > 0 || filter.Visibility == "internal" || filter.Visibility == "private" {
 		return searchRepos(client, hostname, limit, owner, filter)
 	}
 

--- a/pkg/cmd/repo/list/http_test.go
+++ b/pkg/cmd/repo/list/http_test.go
@@ -60,6 +60,50 @@ func Test_listReposWithLanguage(t *testing.T) {
 	assert.Equal(t, `sort:updated-desc fork:true language:go user:@me`, searchData.Variables["query"])
 }
 
+func Test_listReposWithVisibilityPrivate(t *testing.T) {
+	reg := httpmock.Registry{}
+	defer reg.Verify(t)
+
+	var searchData struct {
+		Query     string
+		Variables map[string]interface{}
+	}
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryListSearch\b`),
+		func(req *http.Request) (*http.Response, error) {
+			jsonData, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			err = json.Unmarshal(jsonData, &searchData)
+			if err != nil {
+				return nil, err
+			}
+
+			respBody, err := os.Open("./fixtures/repoSearch.json")
+			if err != nil {
+				return nil, err
+			}
+
+			return &http.Response{
+				StatusCode: 200,
+				Request:    req,
+				Body:       respBody,
+			}, nil
+		},
+	)
+
+	client := http.Client{Transport: &reg}
+	res, err := listRepos(&client, "github.com", 10, "myorg", FilterOptions{
+		Visibility: "private",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, true, res.FromSearch)
+	assert.Equal(t, `sort:updated-desc fork:true is:private user:myorg`, searchData.Variables["query"])
+	assert.Equal(t, 3, res.TotalCount)
+}
+
 func Test_searchQuery(t *testing.T) {
 	type args struct {
 		owner  string

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -471,10 +471,10 @@ func TestRepoList_filtering(t *testing.T) {
 	defer http.Verify(t)
 
 	http.Register(
-		httpmock.GraphQL(`query RepositoryList\b`),
-		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
-			assert.Equal(t, "PRIVATE", params["privacy"])
+		httpmock.GraphQL(`query RepositoryListSearch\b`),
+		httpmock.GraphQLQuery(`{"data":{"search":{"repositoryCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`, func(_ string, params map[string]interface{}) {
 			assert.Equal(t, float64(2), params["perPage"])
+			assert.Equal(t, `sort:updated-desc fork:true is:private user:@me`, params["query"])
 		}),
 	)
 


### PR DESCRIPTION
Fixes #12900

- When `--visibility private` is used, route through the Search API with `is:private` instead of the REST endpoint
- The REST API's `type=private` filter includes both private and internal repos, while the Search API's `is:private` correctly distinguishes them
- Adds test to verify internal repos are excluded from private visibility results