### PR TITLE
fix: show user-friendly progress labels in project commands

### DIFF
--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -89,9 +89,10 @@ const (
 )
 
 // doQueryWithProgressIndicator wraps API calls with a progress indicator.
-// The query name is used in the progress indicator label.
-func (c *Client) doQueryWithProgressIndicator(name string, query interface{}, variables map[string]interface{}) error {
-	c.io.StartProgressIndicatorWithLabel(fmt.Sprintf("Fetching %s", name))
+// The label parameter is displayed in the progress indicator, while name is
+// the GraphQL operation name sent to the API.
+func (c *Client) doQueryWithProgressIndicator(label string, name string, query interface{}, variables map[string]interface{}) error {
+	c.io.StartProgressIndicatorWithLabel(fmt.Sprintf("Fetching %s", label))
 	defer c.io.StopProgressIndicator()
 	err := c.apiClient.Query(name, query, variables)
 	return handleError(err)
@@ -705,13 +706,13 @@ func (c *Client) ProjectItems(o *Owner, number int32, limit int, queryStr string
 		}
 		queryName = "ViewerProjectWithItems"
 	}
-	err := c.doQueryWithProgressIndicator(queryName, query, variables)
+	err := c.doQueryWithProgressIndicator("project items", queryName, query, variables)
 	if err != nil {
 		return project, err
 	}
 	project = query.Project()
 
-	items, err := paginateAttributes(c, query, variables, queryName, "firstItems", "afterItems", limit, query.Nodes())
+	items, err := paginateAttributes(c, query, variables, "project items", queryName, "firstItems", "afterItems", limit, query.Nodes())
 	if err != nil {
 		return project, err
 	}
@@ -895,7 +896,7 @@ type projectAttribute interface {
 // nodes is the list of attributes that have already been fetched.
 //
 // the return value is a slice of the newly fetched attributes appended to nodes.
-func paginateAttributes[N projectAttribute](c *Client, p pager[N], variables map[string]any, queryName string, firstKey string, afterKey string, limit int, nodes []N) ([]N, error) {
+func paginateAttributes[N projectAttribute](c *Client, p pager[N], variables map[string]any, label string, queryName string, firstKey string, afterKey string, limit int, nodes []N) ([]N, error) {
 	hasNextPage := p.HasNextPage()
 	cursor := p.EndCursor()
 	for {
@@ -910,7 +911,7 @@ func paginateAttributes[N projectAttribute](c *Client, p pager[N], variables map
 
 		// set the cursor to the end of the last page
 		variables[afterKey] = (*githubv4.String)(&cursor)
-		err := c.doQueryWithProgressIndicator(queryName, p, variables)
+		err := c.doQueryWithProgressIndicator(label, queryName, p, variables)
 		if err != nil {
 			return nodes, err
 		}
@@ -1067,13 +1068,13 @@ func (c *Client) ProjectFields(o *Owner, number int32, limit int) (*Project, err
 		query = &viewerOwnerWithFields{}
 		queryName = "ViewerProjectWithFields"
 	}
-	err := c.doQueryWithProgressIndicator(queryName, query, variables)
+	err := c.doQueryWithProgressIndicator("project fields", queryName, query, variables)
 	if err != nil {
 		return project, err
 	}
 	project = query.Project()
 
-	fields, err := paginateAttributes(c, query, variables, queryName, "firstFields", "afterFields", limit, query.Nodes())
+	fields, err := paginateAttributes(c, query, variables, "project fields", queryName, "firstFields", "afterFields", limit, query.Nodes())
 	if err != nil {
 		return project, err
 	}
@@ -1188,7 +1189,7 @@ const ViewerOwner OwnerType = "VIEWER"
 // ViewerLoginName returns the login name of the viewer.
 func (c *Client) ViewerLoginName() (string, error) {
 	var query viewerLogin
-	err := c.doQueryWithProgressIndicator("Viewer", &query, map[string]interface{}{})
+	err := c.doQueryWithProgressIndicator("user login", "Viewer", &query, map[string]interface{}{})
 	if err != nil {
 		return "", err
 	}
@@ -1199,7 +1200,7 @@ func (c *Client) ViewerLoginName() (string, error) {
 func (c *Client) OwnerIDAndType(login string) (string, OwnerType, error) {
 	if login == "@me" || login == "" {
 		var query viewerLogin
-		err := c.doQueryWithProgressIndicator("ViewerOwner", &query, nil)
+		err := c.doQueryWithProgressIndicator("owner", "ViewerOwner", &query, nil)
 		if err != nil {
 			return "", "", err
 		}
@@ -1220,7 +1221,7 @@ func (c *Client) OwnerIDAndType(login string) (string, OwnerType, error) {
 		} `graphql:"organization(login: $login)"`
 	}
 
-	err := c.doQueryWithProgressIndicator("UserOrgOwner", &query, variables)
+	err := c.doQueryWithProgressIndicator("owner", "UserOrgOwner", &query, variables)
 	if err != nil {
 		// Due to the way the queries are structured, we don't know if a login belongs to a user
 		// or to an org, even though they are unique. To deal with this, we try both - if neither
@@ -1263,7 +1264,7 @@ func (c *Client) IssueOrPullRequestID(rawURL string) (string, error) {
 		"url": githubv4.URI{URL: uri},
 	}
 	var query issueOrPullRequest
-	err = c.doQueryWithProgressIndicator("GetIssueOrPullRequest", &query, variables)
+	err = c.doQueryWithProgressIndicator("item", "GetIssueOrPullRequest", &query, variables)
 	if err != nil {
 		return "", err
 	}
@@ -1325,7 +1326,7 @@ func (c *Client) userOrgLogins() ([]loginTypes, error) {
 		"after": (*githubv4.String)(nil),
 	}
 
-	err := c.doQueryWithProgressIndicator("ViewerLoginAndOrgs", &v, variables)
+	err := c.doQueryWithProgressIndicator("accounts", "ViewerLoginAndOrgs", &v, variables)
 	if err != nil {
 		return l, err
 	}
@@ -1363,7 +1364,7 @@ func (c *Client) paginateOrgLogins(l []loginTypes, cursor string) ([]loginTypes,
 		"after": githubv4.String(cursor),
 	}
 
-	err := c.doQueryWithProgressIndicator("ViewerLoginAndOrgs", &v, variables)
+	err := c.doQueryWithProgressIndicator("accounts", "ViewerLoginAndOrgs", &v, variables)
 	if err != nil {
 		return l, err
 	}
@@ -1458,16 +1459,16 @@ func (c *Client) NewProject(canPrompt bool, o *Owner, number int32, fields bool)
 		if o.Type == UserOwner {
 			var query userOwner
 			variables["login"] = githubv4.String(o.Login)
-			err := c.doQueryWithProgressIndicator("UserProject", &query, variables)
+			err := c.doQueryWithProgressIndicator("project", "UserProject", &query, variables)
 			return newProjectFromQueryWithoutItemsQuery(query.Owner.Project), err
 		} else if o.Type == OrgOwner {
 			variables["login"] = githubv4.String(o.Login)
 			var query orgOwner
-			err := c.doQueryWithProgressIndicator("OrgProject", &query, variables)
+			err := c.doQueryWithProgressIndicator("project", "OrgProject", &query, variables)
 			return newProjectFromQueryWithoutItemsQuery(query.Owner.Project), err
 		} else if o.Type == ViewerOwner {
 			var query viewerOwner
-			err := c.doQueryWithProgressIndicator("ViewerProject", &query, variables)
+			err := c.doQueryWithProgressIndicator("project", "ViewerProject", &query, variables)
 			return newProjectFromQueryWithoutItemsQuery(query.Owner.Project), err
 		}
 		return nil, errors.New("unknown owner type")
@@ -1542,7 +1543,7 @@ func (c *Client) Projects(login string, t OwnerType, limit int, fields bool) (Pr
 		// the cost.
 		if t == UserOwner {
 			var query userProjects
-			if err := c.doQueryWithProgressIndicator("UserProjects", &query, variables); err != nil {
+			if err := c.doQueryWithProgressIndicator("projects", "UserProjects", &query, variables); err != nil {
 				return projects, err
 			}
 			for _, p := range query.Owner.Projects.Nodes {
@@ -1553,7 +1554,7 @@ func (c *Client) Projects(login string, t OwnerType, limit int, fields bool) (Pr
 			projects.TotalCount = query.Owner.Projects.TotalCount
 		} else if t == OrgOwner {
 			var query orgProjects
-			if err := c.doQueryWithProgressIndicator("OrgProjects", &query, variables); err != nil {
+			if err := c.doQueryWithProgressIndicator("projects", "OrgProjects", &query, variables); err != nil {
 				return projects, err
 			}
 			for _, p := range query.Owner.Projects.Nodes {
@@ -1564,7 +1565,7 @@ func (c *Client) Projects(login string, t OwnerType, limit int, fields bool) (Pr
 			projects.TotalCount = query.Owner.Projects.TotalCount
 		} else if t == ViewerOwner {
 			var query viewerProjects
-			if err := c.doQueryWithProgressIndicator("ViewerProjects", &query, variables); err != nil {
+			if err := c.doQueryWithProgressIndicator("projects", "ViewerProjects", &query, variables); err != nil {
 				return projects, err
 			}
 			for _, p := range query.Owner.Projects.Nodes {


### PR DESCRIPTION
Fixes #12040

## Problem

`gh project list` and other project commands show internal GraphQL operation names in the progress indicator instead of user-friendly text. For example:

| Actual | Expected |
|--------|----------|
| `Fetching UserOrgOwner` | `Fetching owner` |
| `Fetching OrgProjects` | `Fetching projects` |

## Solution

The `doQueryWithProgressIndicator` helper was using the same string for both the GraphQL operation name (sent to the API) and the user-facing progress label. This adds a separate `label` parameter so the two concerns are decoupled. All 15 call sites are updated with descriptive labels:

- `"owner"` for ownership lookups
- `"projects"` for project list queries
- `"project"` for single project queries
- `"project items"` / `"project fields"` for item/field fetches
- `"accounts"` for user/org login lookups
- `"user login"` for viewer login
- `"item"` for issue/PR resolution

## Testing

All existing tests pass (`go test ./pkg/cmd/project/...`). The change only affects the display label; GraphQL operation names are unchanged.