### PR TITLE
Remove auto-labels from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: "\U0001F41B Bug report"
 about: Report a bug or unexpected behavior while using GitHub CLI
 title: ''
-labels: bug
+labels: ''
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/submit-a-design-proposal.md
+++ b/.github/ISSUE_TEMPLATE/submit-a-design-proposal.md
@@ -2,7 +2,7 @@
 name: "🎨 Submit a design proposal"
 about: Submit a design to resolve an open issue that has both `needs-design` and `help-wanted` labels
 title: ''
-labels: enhancement
+labels: ''
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/submit-a-request.md
+++ b/.github/ISSUE_TEMPLATE/submit-a-request.md
@@ -2,7 +2,7 @@
 name: "⭐ Submit a request"
 about: Surface a feature or problem that you think should be solved
 title: ''
-labels: enhancement
+labels: ''
 assignees: ''
 
 ---


### PR DESCRIPTION
## Problem

The `bug_report`, `submit-a-request`, and `submit-a-design-proposal` issue templates currently auto-apply `bug` and `enhancement` labels respectively. This means issues arrive pre-labeled with type classifications that may not be accurate — an issue filed as a "bug" might actually be an enhancement, and vice versa.

During FR triage, these template-applied labels can't be trusted, making it harder to distinguish between issues that have been properly triaged and those that just have auto-applied labels.

## Solution

Remove the auto-applied labels from all three issue templates:
- `bug_report.md`: removed `bug` label
- `submit-a-request.md`: removed `enhancement` label  
- `submit-a-design-proposal.md`: removed `enhancement` label

This ensures all type classification happens during triage, giving the team confidence that labeled issues have actually been reviewed.

> **Note:** Issues will still receive the `needs-triage` label (applied separately), so the triage workflow is unaffected.