### PR TITLE
docs: fix acceptance token typo

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -20,7 +20,7 @@ The organization in which the acceptance tests can manage resources in. Consider
 
 #### `GH_ACCEPTANCE_TOKEN`
 
-The token to use for authenticatin with the `GH_ACCEPTANCE_HOST`. This must already have the necessary scopes for each test, and must have permissions to act in the `GH_ACCEPTANCE_ORG`. See [Effective Test Authoring](#effective-test-authoring) for how tests must handle tokens without sufficient scopes.
+The token to use for authentication with the `GH_ACCEPTANCE_HOST`. This must already have the necessary scopes for each test, and must have permissions to act in the `GH_ACCEPTANCE_ORG`. See [Effective Test Authoring](#effective-test-authoring) for how tests must handle tokens without sufficient scopes.
 
 It's recommended to create and use a Legacy PAT for this; Fine-Grained PATs do not offer all the necessary privileges required. You can use an OAuth token provided via `gh auth login --web` and can provide it to the acceptance tests via `GH_ACCEPTANCE_TOKEN=$(gh auth token --hostname <host>)` but this can be a bit confusing and annoying if you `gh auth login` again without `-s` and lose the required scopes.
 


### PR DESCRIPTION
## Summary
- fix "authenticatin" -> "authentication" in the acceptance test README

## Related issue
- N/A (trivial docs typo fix)

## Guideline alignment
- `.github/CONTRIBUTING.md` exists on `trunk`
- `.github/PULL_REQUEST_TEMPLATE.md` exists on `trunk`
- This PR is docs-only and does not expand scope beyond the README typo fix

## Validation
- Not run (docs-only change)
