### PR TITLE
feat: automatically prompt for default remote in browse and PR create commands

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -2,13 +2,16 @@
 package context
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
 	"sort"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/iostreams"
 )
 
@@ -58,7 +61,7 @@ type ResolvedRemotes struct {
 	apiClient    *api.Client
 }
 
-func (r *ResolvedRemotes) BaseRepo(io *iostreams.IOStreams) (ghrepo.Interface, error) {
+func (r *ResolvedRemotes) BaseRepo(io *iostreams.IOStreams, prompter prompter.Prompter, gitClient *git.Client) (ghrepo.Interface, error) {
 	if r.baseOverride != nil {
 		return r.baseOverride, nil
 	}
@@ -96,16 +99,33 @@ func (r *ResolvedRemotes) BaseRepo(io *iostreams.IOStreams) (ghrepo.Interface, e
 		return repos[0], nil
 	}
 
-	cs := io.ColorScheme()
+	if prompter != nil && gitClient != nil {
+		var repoNames []string
+		for _, repo := range repos {
+			repoNames = append(repoNames, ghrepo.FullName(repo))
+		}
 
-	fmt.Fprintf(io.ErrOut,
-		"%s No default remote repository has been set. To learn more about the default repository, run: gh repo set-default --help\n",
-		cs.FailureIcon())
+		selected, err := prompter.Select("Which repository should be the default?", "", repoNames)
+		if err != nil {
+			return nil, fmt.Errorf("could not prompt: %w", err)
+		}
+		selectedRepo := repos[selected]
 
-	fmt.Fprintln(io.Out)
+		resolution := "base"
+		selectedRemote, _ := r.RemoteForRepo(selectedRepo)
+		if selectedRemote == nil {
+			resolution = ghrepo.FullName(selectedRepo)
+			selectedRemote = r.remotes[0]
+		}
 
-	return nil, errors.New(
-		"please run `gh repo set-default` to select a default remote repository.")
+		if err := gitClient.SetRemoteResolution(context.Background(), selectedRemote.Name, resolution); err != nil {
+			return nil, err
+		}
+
+		return selectedRepo, nil
+	}
+
+	return r.remotes[0], nil
 }
 
 func (r *ResolvedRemotes) HeadRepos() ([]*api.Repository, error) {

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -167,7 +167,7 @@ func SmartBaseRepoFunc(f *cmdutil.Factory) func() (ghrepo.Interface, error) {
 		if err != nil {
 			return nil, err
 		}
-		baseRepo, err := resolvedRepos.BaseRepo(f.IOStreams)
+		baseRepo, err := resolvedRepos.BaseRepo(f.IOStreams, f.Prompter, f.GitClient)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -722,7 +722,7 @@ func NewCreateContext(opts *CreateOptions) (*CreateContext, error) {
 	}
 
 	var baseRepo *api.Repository
-	if br, err := resolvedRemotes.BaseRepo(opts.IO); err == nil {
+	if br, err := resolvedRemotes.BaseRepo(opts.IO, opts.Prompter.(prompter.Prompter), opts.GitClient); err == nil {
 		if r, ok := br.(*api.Repository); ok {
 			baseRepo = r
 		} else {
@@ -1314,7 +1314,7 @@ func requestableReviewersForCompletion(opts *CreateOptions) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	baseRepo, err := repoContext.BaseRepo(opts.IO)
+	baseRepo, err := repoContext.BaseRepo(opts.IO, opts.Prompter.(prompter.Prompter), opts.GitClient)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

This PR implements new interactions when running the `gh browse` or `gh pr create` commands, which will ask the user which remote repository should be set as default if it is not set already. Previously, the output just explained that the default repo has to be set with the `gh repo set-default` command and the user had to manually copy and paste the command into the command line. I find it pretty useful, if this would happen automatically, as it would improve my usual workflow.

### Related

- Closes #13006