### PR TITLE
fix: use merge ref for PR discovery when push.default=simple

### DIFF
--- a/pkg/cmd/pr/shared/find_refs_resolution.go
+++ b/pkg/cmd/pr/shared/find_refs_resolution.go
@@ -332,10 +332,14 @@ func tryDetermineDefaultPushTarget(gitClient GitConfigClient, localBranchName st
 		return defaultPushTarget{}, err
 	}
 
-	// We assume the PR's branch name is the same as whatever was provided, unless the user has specified
-	// push.default = upstream or tracking, then we use the branch name from the merge ref if it exists. Otherwise, we fall back to the local branch name
+	// We assume the PR's branch name is the same as whatever was provided, unless:
+	// - push.default is upstream or tracking: always use the merge ref
+	// - push.default is simple: use the merge ref because @{push} failed above, which
+	//   means the local branch name differs from the remote tracking branch name. In
+	//   simple mode, git refuses to push when names differ, but for PR discovery we
+	//   still want to use the remote branch name from the merge ref.
 	remoteBranch := localBranchName
-	if pushDefault == git.PushDefaultUpstream || pushDefault == git.PushDefaultTracking {
+	if pushDefault == git.PushDefaultUpstream || pushDefault == git.PushDefaultTracking || pushDefault == git.PushDefaultSimple {
 		mergeRef := strings.TrimPrefix(branchConfig.MergeRef, "refs/heads/")
 		if mergeRef != "" {
 			remoteBranch = mergeRef

--- a/pkg/cmd/pr/shared/find_refs_resolution_test.go
+++ b/pkg/cmd/pr/shared/find_refs_resolution_test.go
@@ -427,7 +427,7 @@ func TestTryDetermineDefaultPRHead(t *testing.T) {
 		require.Equal(t, "feature-branch", defaultPRHead.BranchName)
 	})
 
-	t.Run("when the push default is tracking or upstream, use the merge ref", func(t *testing.T) {
+	t.Run("when the push default is tracking, upstream, or simple, use the merge ref", func(t *testing.T) {
 		t.Parallel()
 
 		testCases := []struct {
@@ -435,6 +435,7 @@ func TestTryDetermineDefaultPRHead(t *testing.T) {
 		}{
 			{pushDefault: git.PushDefaultTracking},
 			{pushDefault: git.PushDefaultUpstream},
+			{pushDefault: git.PushDefaultSimple},
 		}
 
 		for _, tc := range testCases {
@@ -461,6 +462,34 @@ func TestTryDetermineDefaultPRHead(t *testing.T) {
 				require.Equal(t, "main", defaultPRHead.BranchName)
 			})
 		}
+
+		t.Run("simple mode with local branch name different from remote (fork PR scenario)", func(t *testing.T) {
+			t.Parallel()
+
+			// Simulates: local branch "feature-branch-fork" tracking origin/feature-branch
+			// with push.default=simple. @{push} fails because local name != remote name
+			// under simple mode. The merge ref should be used to find the correct remote
+			// branch name for PR discovery.
+			repoResolvedFromPushRemoteClient := stubGitConfigClient{
+				pushRevisionFn: stubPushRevision(git.RemoteTrackingRef{}, errors.New("fatal: cannot resolve 'simple' push to a single destination")),
+				readBranchConfigFn: stubBranchConfig(git.BranchConfig{
+					RemoteName: "origin",
+					MergeRef:   "refs/heads/feature-branch",
+				}, nil),
+				pushDefaultFn:       stubPushDefault(git.PushDefaultSimple, nil),
+				remotePushDefaultFn: stubRemotePushDefault("", nil),
+			}
+
+			defaultPRHead, err := TryDetermineDefaultPRHead(
+				repoResolvedFromPushRemoteClient,
+				stubRemoteToRepoResolver(ghContext.Remotes{&baseRemote, &forkRemote}, nil),
+				"feature-branch-fork",
+			)
+			require.NoError(t, err)
+
+			require.True(t, ghrepo.IsSame(defaultPRHead.Repo.Unwrap(), forkRepo), "expected repos to be the same")
+			require.Equal(t, "feature-branch", defaultPRHead.BranchName)
+		})
 
 		t.Run("but if the merge ref is empty, use the provided branch name", func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## Summary

When `push.default=simple` (the default) and the local branch name differs from the remote tracking branch name (e.g., `feature-branch-fork` tracking `origin/feature-branch`), `git rev-parse --abbrev-ref @{push}` fails with "cannot resolve 'simple' push to a single destination".

The fallback code in `tryDetermineDefaultPushTarget()` was using the local branch name as the remote branch name, causing `gh pr view` and `gh pr status` to search for a non-existent branch like `owner:feature-branch-fork` instead of the correct `owner:feature-branch`.

This fix adds `PushDefaultSimple` to the condition that checks the merge ref from branch config (`branch.<name>.merge`), so the correct remote branch name is used for PR discovery. This is safe because at this point in the code, `@{push}` has already failed — meaning simple mode could not resolve, so the merge ref is the best source of truth for the remote branch name.

### Common scenarios where this occurs:
- Fork PRs where the head branch has the same name as the base branch (e.g., `main` → `main`), causing `gh pr checkout` to create a prefixed local branch
- Users who manually create local branches with different names tracking remote branches (e.g., `git checkout -b my-local-name origin/remote-name`)

### Regression from
This is a regression from PR #9208 (commit 7fc35fd, merged Jan 2025, shipped in gh v2.85.0).

Fixes #12203
Fixes #7590