### PR TITLE
Align triage.md with current triage process

### DIFF
--- a/docs/triage.md
+++ b/docs/triage.md
@@ -71,7 +71,7 @@ The pull request will be auto-assigned to an engineer on the team; that engineer
 
 The primary goal of triaging spam and abuse is to remove distracting and offensive content from our community.
 
-- **Spam issues:** Add the `invalid` label and close as "won't do".
+- **Spam issues:** Add the `invalid` label (auto-closes as "won't do").
 - **Spam comments:** Mark as spam using GitHub's built-in feature.
 - **Abusive content:** Defined by our [Code of Conduct](../.github/CODE-OF-CONDUCT.md). Remove the content. Repeat offenses or particularly offensive abuse should be reported and the user blocked.
 

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -1,117 +1,102 @@
 # Triage role
 
-As we get more issues and pull requests opened on the GitHub CLI, we've decided on a weekly rotation triage role as defined by our First Responder (FR) rotation. The primary responsibility of the FR during that week is to triage incoming issues from the Open Source community, as defined below. An issue is considered "triaged" when the `needs-triage` label is removed.
+The primary responsibility of the First Responder (FR) during their weekly rotation is to triage incoming issues and pull requests from the open source community. An issue is considered "triaged" when the `needs-triage` label is removed.
 
-## Expectations for triaging incoming issues
+## Quick Guide
 
-Review and label [open issues missing either the `enhancement`, `bug`, or `docs` label](https://github.com/cli/cli/issues?q=is%3Aopen+is%3Aissue+-label%3Abug%2Cenhancement%2Cdocs+) and the label(s) corresponding to the command space prefixed with `gh-`, such as `gh-pr` for the `gh pr` command set, or `gh-extension` for the `gh extension` command set. 
+Pick an issue from the triage queue.
 
-The heuristics for triaging the different issue types are as follows:
+**Your goal:** Do what is needed to remove the `needs-triage` label.
 
-### Bugs
+1. **Can we close it?**
+   - Duplicate → Comment and close as duplicate, linking the original
+   - Spam → Add `invalid` or `suspected-spam` (auto-closes)
+   - Abuse → Add `invalid`, remove content, report, block (see [Spam and abuse](#spam-and-abuse))
+   - Off-topic → Add `off-topic` (auto-closes with comment)
 
-For bugs, the FR should engage with the issue and community with the goal to remove the `needs-triage` label from the issue.
+2. **Is it a bug?**
+   - Reproducible → Add `bug` and a priority label (`priority-1`, `priority-2`, or `priority-3`)
+   - Not reproducible → Add `unable-to-reproduce` (auto-requests info, 14-day timer)
 
-To be considered triaged, `bug` issues require the following:
+3. **Is it an enhancement?**
+   - Clear value → Add `enhancement` (auto-posts backlog comment)
+   - Unclear → Comment for clarification and add `more-info-needed` (14-day timer)
 
-- A severity label `priority-1`, `priority-2`, and `priority-3`
-- Clearly defined Acceptance Criteria, added to the Issue as a standalone comment (see [example](https://github.com/cli/cli/issues/9469#issuecomment-2292315743))
+4. **Is it a pull request?** (see [Community pull requests](#community-pull-requests))
+   - Spam or AI sludge → Add `invalid` (auto-closes)
+   - Tiny fix (e.g., typo) → Review, test, and merge directly
+   - Not linked to a help-wanted issue → Add `no-help-wanted-issue` (auto-closes with comment)
+   - Valid → Add `ready-for-review` and run CI (auto-removes `needs-triage`, auto-posts acknowledging comment)
 
-#### Bug severities
+The `needs-triage` label is automatically removed when end-state labels (`enhancement`, `bug`, `ready-for-review`) are applied or the issue is closed.
 
-| Severity | Description |
-| - | - |
-| `priority-1` | Affects a large population and inhibits work |
-| `priority-2` | Affects more than a few users but doesn't prevent core functions |
+## Bug Triage
+
+1. Try to reproduce the issue
+2. If reproducible (or strongly suspect an intermittent bug) → add `bug` and a priority label
+3. If not reproducible → add `unable-to-reproduce` (auto-requests info, 14-day timer) or request clarification with `more-info-needed`
+
+### Bug Priorities
+
+| Priority | Description |
+|----------|-------------|
+| `priority-1` | Affects a large population and inhibits work. **Escalate in Slack; may require a hotfix.** |
+| `priority-2` | Affects more than a few users but does not prevent core functions |
 | `priority-3` | Affects a small number of users or is largely cosmetic |
 
-### Enhancements and Docs
+## Enhancement Triage
 
-For `enhancement` issues, the FR's role is to prepare the issue for team review and triage.
+**Do:**
+- Ensure the value is clear (ask if needed) and apply `more-info-needed` while waiting for clarification
+- Apply the `enhancement` label once value is clear (auto-posts backlog comment)
 
-When a new issue is opened, the FR **should**:
+**Don't:**
+- Deep-dive technical feasibility
+- Prematurely accept or suggest the feature will be added
 
-- Acknowledge the issue
-- Assign themselves to the issue
-- Ensure there is enough information to understand the enhancement's scope and value
-- Ask the user for more information about value and use-case, if necessary
-- Leave the `needs-triage` label on the issue
-- Add the `more-info-needed` and `needs-investigation` labels as needed
+## Community Pull Requests
 
-When the FR has enough information to be triaged, they should:
-- Remove the `more-info-needed` and `needs-investigation` labels
-- Remove their assignment from the issue
+Community pull requests receive `needs-triage` (as well as `external`) just like issues do, but **are not meant to be reviewed as part of triage.**
 
-The FR should **avoid**:
+The triager's responsibility is to do a quick pass:
 
-- Thoroughly investigating the enhancement's technical feasibility
-- Prematurely accepting the enhancement request
-- Removing the `needs-triage` label
-- Labeling issues as `help wanted`
+1. **Spam or AI sludge** → Add `invalid` label (auto-closes). Block user if necessary.
+2. **Tiny mergeable fix** (e.g., typo) → Review, test, and merge.
+3. **Not related to a help-wanted issue** → Add `no-help-wanted-issue` (auto-closes with comment).
+4. **Valid for review** → Add `ready-for-review` and run CI (auto-removes `needs-triage`, auto-posts acknowledging comment).
 
-## Additional triaging labels
+The pull request will be auto-assigned to an engineer on the team; that engineer will wait to review until `needs-triage` is removed.
 
-The FR can consider adding any of the following labels below.
-
-| Label | Description |
-| - | - |
-| `discuss` | Some issues require discussion with the internal team. Adding this label will automatically open up an internal discussion with the team to facilitate this discussion. |
-| `core` |  Defines what we would like to do internally. We tend to lean towards `help wanted` by default, and adding `core` should be reserved for trickier issues or implementations we have strong opinions/preferences about. |
-| `more-info-needed` | After asking any contributors for more information, add this label so it is clear that the issue has been responded to and we are waiting on the user. |
-| `needs-investigation` | Used when the issue requires further investigation before it can be reviewed and triaged. This is often used for issues that are not clearly bugs or enhancements, or when the FR needs to gather more information before proceeding. |
-| `invalid` | Added to spam and abusive issues. |
-
-### Labels for team enhancement triaging
-
-The FR should **avoid** adding these labels outside of team enhancement triage.
-
-| Label | Description |
-| - | - |
-| `good first issue` | Used to denote when an issue may be a good candidate for a first-time contributor to the CLI. These are usually small and well defined issues. |
-| `help wanted` | These issues are ready for community contribution. |
-| `help wanted candidate` | Used to denote when an issue may be a good candidate for community contribution. Issues labelled this way are discussed internally and may be promoted to `help wanted`. |
-
-## Expectations for community pull requests
-
-All incoming pull requests are assigned to one of the engineers for review on a load-balanced basis.
-The person in a triage role for a week could take a glance at these pull requests, mostly to see whether
-the changeset is feasible and to allow the associated CI run for new contributors.
-
-## Spam and abuse
+## Spam and Abuse
 
 The primary goal of triaging spam and abuse is to remove distracting and offensive content from our community.
 
-We get a lot of spam. Whenever you determine an issue as spam, add the `invalid` label and close it as "won't do". For spammy comments, simply mark them as spam using GitHub's built-in spam feature.
+- **Spam issues:** Add the `invalid` label and close as "won't do".
+- **Spam comments:** Mark as spam using GitHub's built-in feature.
+- **Abusive content:** Defined by our [Code of Conduct](../.github/CODE-OF-CONDUCT.md). Remove the content. Repeat offenses or particularly offensive abuse should be reported and the user blocked.
 
-Abusive contributions are defined by our [Code of Conduct](../.github/CODE-OF-CONDUCT.md). Any contribution you determine abusive should be removed. Repeat offenses or particularly offensive abuse should be reported using GitHub's reporting features and the user blocked. If an entire issue is abusive, label it as `invalid` and close as "won't do".
+## Automated Workflows
 
-## Weekly PR audit
-
-In the interest of not letting our open PR list get out of hand (20+ total PRs _or_ multiple PRs
-over a few months old), try to audit open PRs each week with the goal of getting them merged and/or
-closed. It's likely too much work to deal with every PR, but even getting a few closer to done is
-helpful.
-
-For each PR, ask:
-
-- is this too stale (more than two months old or too many conflicts)? close with comment
-- is this really close but author is absent? push commits to finish, request review
-- is this waiting on triage? go through the PR triage flow
-
-## Useful aliases
-
-This gist has some useful aliases for first responders:
-
-https://gist.github.com/vilmibm/ee6ed8a783e4fef5b69b2ed42d743b1a
+| Label | Automation |
+|-------|------------|
+| `needs-triage` | Auto-added on open; removed when classified or closed |
+| `more-info-needed` | Auto-closes after 14 days without response |
+| `unable-to-reproduce` | Auto-adds `more-info-needed` + posts comment |
+| `enhancement` | Auto-posts backlog comment |
+| `invalid` | Auto-closes immediately |
+| `suspected-spam` | Auto-closes immediately |
+| `off-topic` | Auto-posts explanation comment + closes |
+| `no-help-wanted-issue` | Auto-posts explanation comment + closes |
+| `ready-for-review` | Auto-removes `needs-triage` + posts acknowledging comment |
 
 ## Examples
 
-We want our project to be a safe and encouraging open-source environment. Below are some examples
-of how to empathetically respond to or close an issue/PR:
+We want our project to be a safe and encouraging open-source environment. Below are some examples of how to empathetically respond to or close an issue/PR:
 
-- [Closing a quality PR its scope is too large](https://github.com/cli/cli/pull/1161)
+- [Closing a quality PR when its scope is too large](https://github.com/cli/cli/pull/1161)
 - [Closing a stale PR](https://github.com/cli/cli/pull/557#issuecomment-639077269)
 - [Closing a PR that doesn't follow our CONTRIBUTING policy](https://github.com/cli/cli/pull/864)
 - [Responding to a bug report](https://github.com/desktop/desktop/issues/9195#issuecomment-592243129)
-- [Closing an issue that out of scope](https://github.com/cli/cli/issues/777#issuecomment-612926229)
+- [Closing an issue that is out of scope](https://github.com/cli/cli/issues/777#issuecomment-612926229)
 - [Closing an issue with a feature request](https://github.com/desktop/desktop/issues/9722#issuecomment-625461766)
+

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -40,7 +40,7 @@ The `needs-triage` label is automatically removed when end-state labels (`enhanc
 
 | Priority | Description |
 |----------|-------------|
-| `priority-1` | Affects a large population and inhibits work. **Escalate in Slack; may require a hotfix.** |
+| `priority-1` | Affects a large population and inhibits work. **Escalate internally via the appropriate incident channel; may require a hotfix.** |
 | `priority-2` | Affects more than a few users but does not prevent core functions |
 | `priority-3` | Affects a small number of users or is largely cosmetic |
 


### PR DESCRIPTION
## Summary

Updates `docs/triage.md` to reflect the current triage process used by the team.

### Key changes

- **Bug triage:** Removed requirement for standalone acceptance-criteria comment. Bugs are triaged via reproduction + `bug` + priority label.
- **Enhancement triage:** Goal is now to **remove** `needs-triage` by classifying to an end-state (`bug`, `enhancement`, `ready-for-review`, or close), rather than leaving `needs-triage` on.
- **Labels:** Removed references to `help wanted candidate`, `core`, `needs-investigation` labels that are no longer part of the triage workflow. Added current automation labels (`unable-to-reproduce`, `suspected-spam`, `off-topic`, `no-help-wanted-issue`).
- **PR triage:** Clarified that triage is a quick validity check, not a review. Added `ready-for-review` workflow and auto-assignment.
- **Added automated workflows table** documenting label-triggered automations.
- **Removed:** Weekly PR audit section (superseded by automated stale PR handling), useful aliases section (stale gist link), `discuss` label details.
- **Preserved:** Bug priority table, spam/abuse handling, community examples section.

Closes https://github.com/github/gh-cli-and-desktop/issues/3 (partial)