### PR TITLE
define err in go func instead of use err defined in outer scope

### DIFF
--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -276,7 +276,7 @@ func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, re
 	done := make(chan error)
 	go func() {
 		// Connect to the tunnel
-		err = fwd.connection.Connect(ctx)
+		err := fwd.connection.Connect(ctx)
 		if err != nil {
 			done <- fmt.Errorf("connect failed: %v", err)
 			return


### PR DESCRIPTION
Two benefits:
1. make `err` allocated in stack
2. avoid `err` data race

Fixes #13001

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
