### PR TITLE
Fix pr status/view for merged fork PRs without tracking refs

### DIFF
--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -444,6 +444,14 @@ func findForRefs(httpClient *http.Client, prRefs PRFindRefs, stateFilters, field
 		}
 	}
 
+	for _, pr := range prs {
+		// Fallback for cases where fork owner info is unavailable locally.
+		isNotClosedOrMergedWhenHeadIsDefault := pr.State == "OPEN" || resp.Repository.DefaultBranchRef.Name != prRefs.QualifiedHeadRef()
+		if prRefs.Matches(pr.BaseRefName, pr.HeadRefName) && isNotClosedOrMergedWhenHeadIsDefault {
+			return &pr, nil
+		}
+	}
+
 	return nil, &NotFoundError{fmt.Errorf("no pull requests found for branch %q", prRefs.QualifiedHeadRef())}
 }
 

--- a/pkg/cmd/pr/status/http.go
+++ b/pkg/cmd/pr/status/http.go
@@ -162,11 +162,36 @@ func pullRequestStatus(httpClient *http.Client, repo ghrepo.Interface, options r
 
 	var currentPR = resp.Repository.PullRequest
 	if currentPR == nil {
+		var bestMatch *api.PullRequest
+		var bestScore int = -1
+
 		for _, edge := range resp.Repository.PullRequests.Edges {
-			if edge.Node.HeadLabel() == currentPRHeadRef {
-				currentPR = &edge.Node
-				break // Take the most recent PR for the current branch
+			pr := edge.Node
+			score := -1
+
+			if pr.HeadLabel() == currentPRHeadRef {
+				if pr.State == "OPEN" {
+					score = 4
+				} else {
+					score = 3
+				}
+			} else if pr.HeadRefName == branchWithoutOwner {
+				if pr.State == "OPEN" {
+					score = 2
+				} else {
+					score = 1
+				}
 			}
+
+			if score > bestScore {
+				bestScore = score
+				matchedPr := pr
+				bestMatch = &matchedPr
+			}
+		}
+
+		if bestMatch != nil {
+			currentPR = bestMatch
 		}
 	}
 


### PR DESCRIPTION
Fixes #12998

## Summary
This PR fixes branch-to-PR resolution for cases where a pull request was opened from a fork branch, then merged, and the local branch no longer has tracking metadata for the fork remote branch.

Both commands now fall back to matching on `headRefName` (unqualified branch name) when strict `headLabel` matching is not possible:

- `gh pr status`
- `gh pr view`

## What Changed

### Updated `pkg/cmd/pr/status/http.go`
- Improved current-branch PR selection logic with fallback matching by `HeadRefName`.
- Keeps preference for open PRs when multiple candidates exist.

### Updated `pkg/cmd/pr/shared/finder.go`
- Added fallback matching in `findForRefs` from `HeadLabel()` to `HeadRefName` when needed.

## Why

Previously, matching depended on owner-qualified head labels (for example `forkOwner:branch`).

After merge/cleanup flows where tracking refs are removed, the owner-qualified information may no longer be available locally. This caused `gh pr status` and `gh pr view` to fail to find the associated merged PR.

## Testing

### Automated
```bash
go test -count=1 ./pkg/cmd/pr/status ./pkg/cmd/pr/shared ./pkg/cmd/pr/view
```

### Manual Verification

In a repo state where the branch tracking ref is removed:

- `gh pr status` shows the merged PR for the current branch.
- `gh pr view` resolves the merged PR correctly.