### PR TITLE
Ensure `api` and `auth` commands record agentic invocations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,12 @@ go test -tags acceptance ./acceptance      # Acceptance tests
 make lint                                  # golangci-lint (same as CI)
 ```
 
+**Before committing, ensure both tests and linter pass:**
+```bash
+go test ./...
+make lint
+```
+
 ## Architecture
 
 Entry point: `cmd/gh/main.go` → `internal/ghcmd.Main()` → `pkg/cmd/root.NewCmdRoot()`.

--- a/internal/authflow/flow.go
+++ b/internal/authflow/flow.go
@@ -97,7 +97,7 @@ func AuthFlow(httpClient *http.Client, oauthHost string, IO *iostreams.IOStreams
 		return "", "", err
 	}
 
-	userLogin, err := getViewer(oauthHost, token.Token, IO.ErrOut)
+	userLogin, err := getViewer(httpClient, oauthHost, token.Token)
 	if err != nil {
 		return "", "", err
 	}
@@ -123,16 +123,10 @@ func (c cfg) ActiveToken(hostname string) (string, string) {
 	return c.token, "oauth_token"
 }
 
-func getViewer(hostname, token string, logWriter io.Writer) (string, error) {
-	opts := api.HTTPClientOptions{
-		Config: cfg{token: token},
-		Log:    logWriter,
-	}
-	client, err := api.NewHTTPClient(opts)
-	if err != nil {
-		return "", err
-	}
-	return api.CurrentLoginName(api.NewClientFromHTTP(client), hostname)
+func getViewer(httpClient *http.Client, hostname, token string) (string, error) {
+	authedClient := *httpClient
+	authedClient.Transport = api.AddAuthTokenHeader(httpClient.Transport, cfg{token: token})
+	return api.CurrentLoginName(api.NewClientFromHTTP(&authedClient), hostname)
 }
 
 func waitForEnter(r io.Reader) error {

--- a/internal/authflow/flow_test.go
+++ b/internal/authflow/flow_test.go
@@ -10,34 +10,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_getViewer_preservesUserAgent(t *testing.T) {
+func Test_getViewer_leavesUserAgent(t *testing.T) {
 	var receivedUA string
 	var receivedAuth string
 
-	// Outer transport sets User-Agent, simulating the factory-built client's header middleware.
-	// Inner transport captures headers as-received to verify they survived the wrapping.
 	plainClient := &http.Client{
 		Transport: &roundTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
-			req.Header.Set("User-Agent", "GitHub CLI 1.2.3 Agent/copilot-cli")
-			return (&http.Client{
-				Transport: &roundTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
-					receivedUA = req.Header.Get("User-Agent")
-					receivedAuth = req.Header.Get("Authorization")
-					return &http.Response{
-						StatusCode: 200,
-						Header:     http.Header{"Content-Type": []string{"application/json"}},
-						Body:       io.NopCloser(bytes.NewBufferString(`{"data":{"viewer":{"login":"monalisa"}}}`)),
-						Request:    req,
-					}, nil
-				}},
-			}).Transport.RoundTrip(req)
+			receivedUA = req.Header.Get("User-Agent")
+			receivedAuth = req.Header.Get("Authorization")
+
+			return &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(bytes.NewBufferString(`{"data":{"viewer":{"login":"monalisa"}}}`)),
+				Request:    req,
+			}, nil
 		}},
 	}
 
 	login, err := getViewer(plainClient, "github.com", "test-token")
 	require.NoError(t, err)
 	assert.Equal(t, "monalisa", login)
-	assert.Equal(t, "GitHub CLI 1.2.3 Agent/copilot-cli", receivedUA)
+	assert.Empty(t, receivedUA, "User-Agent header should be left unset so that downstream transports can set it")
 	assert.Equal(t, "token test-token", receivedAuth)
 }
 

--- a/internal/authflow/flow_test.go
+++ b/internal/authflow/flow_test.go
@@ -1,10 +1,53 @@
 package authflow
 
 import (
+	"bytes"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func Test_getViewer_preservesUserAgent(t *testing.T) {
+	var receivedUA string
+	var receivedAuth string
+
+	// Outer transport sets User-Agent, simulating the factory-built client's header middleware.
+	// Inner transport captures headers as-received to verify they survived the wrapping.
+	plainClient := &http.Client{
+		Transport: &roundTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+			req.Header.Set("User-Agent", "GitHub CLI 1.2.3 Agent/copilot-cli")
+			return (&http.Client{
+				Transport: &roundTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+					receivedUA = req.Header.Get("User-Agent")
+					receivedAuth = req.Header.Get("Authorization")
+					return &http.Response{
+						StatusCode: 200,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(bytes.NewBufferString(`{"data":{"viewer":{"login":"monalisa"}}}`)),
+						Request:    req,
+					}, nil
+				}},
+			}).Transport.RoundTrip(req)
+		}},
+	}
+
+	login, err := getViewer(plainClient, "github.com", "test-token")
+	require.NoError(t, err)
+	assert.Equal(t, "monalisa", login)
+	assert.Equal(t, "GitHub CLI 1.2.3 Agent/copilot-cli", receivedUA)
+	assert.Equal(t, "token test-token", receivedAuth)
+}
+
+type roundTripper struct {
+	roundTrip func(*http.Request) (*http.Response, error)
+}
+
+func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.roundTrip(req)
+}
 
 func Test_getCallbackURI(t *testing.T) {
 	tests := []struct {

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -34,12 +34,13 @@ const (
 )
 
 type ApiOptions struct {
-	AppVersion string
-	BaseRepo   func() (ghrepo.Interface, error)
-	Branch     func() (string, error)
-	Config     func() (gh.Config, error)
-	HttpClient func() (*http.Client, error)
-	IO         *iostreams.IOStreams
+	AppVersion    string
+	InvokingAgent string
+	BaseRepo      func() (ghrepo.Interface, error)
+	Branch        func() (string, error)
+	Config        func() (gh.Config, error)
+	HttpClient    func() (*http.Client, error)
+	IO            *iostreams.IOStreams
 
 	Hostname            string
 	RequestMethod       string
@@ -62,11 +63,12 @@ type ApiOptions struct {
 
 func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command {
 	opts := ApiOptions{
-		AppVersion: f.AppVersion,
-		BaseRepo:   f.BaseRepo,
-		Branch:     f.Branch,
-		Config:     f.Config,
-		IO:         f.IOStreams,
+		AppVersion:    f.AppVersion,
+		InvokingAgent: f.InvokingAgent,
+		BaseRepo:      f.BaseRepo,
+		Branch:        f.Branch,
+		Config:        f.Config,
+		IO:            f.IOStreams,
 	}
 
 	cmd := &cobra.Command{
@@ -385,6 +387,7 @@ func apiRun(opts *ApiOptions) error {
 			}
 			opts := api.HTTPClientOptions{
 				AppVersion:     opts.AppVersion,
+				InvokingAgent:  opts.InvokingAgent,
 				CacheTTL:       opts.CacheTTL,
 				Config:         cfg.Authentication(),
 				EnableCache:    opts.CacheTTL > 0,

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -1388,6 +1388,36 @@ func Test_apiRun_cache(t *testing.T) {
 	assert.Equal(t, "", stderr.String(), "stderr")
 }
 
+func Test_apiRun_invokingAgent(t *testing.T) {
+	var receivedUA string
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(s.Close)
+
+	ios, _, _, _ := iostreams.Test()
+	options := ApiOptions{
+		IO:            ios,
+		AppVersion:    "1.2.3",
+		InvokingAgent: "copilot-cli",
+		Config: func() (gh.Config, error) {
+			return &ghmock.ConfigMock{
+				AuthenticationFunc: func() gh.AuthConfig {
+					cfg := &config.AuthConfig{}
+					cfg.SetActiveToken("token", "stub")
+					return cfg
+				},
+			}, nil
+		},
+		RequestPath: s.URL,
+	}
+
+	require.NoError(t, apiRun(&options))
+	assert.Contains(t, receivedUA, "GitHub CLI 1.2.3")
+	assert.Contains(t, receivedUA, "Agent/copilot-cli")
+}
+
 func Test_openUserFile(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "gh-test")
 	if err != nil {

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -29,6 +29,7 @@ var ssoURLRE = regexp.MustCompile(`\burl=([^;]+)`)
 func New(appVersion string, invokingAgent string) *cmdutil.Factory {
 	f := &cmdutil.Factory{
 		AppVersion:     appVersion,
+		InvokingAgent:  invokingAgent,
 		Config:         configFunc(), // No factory dependencies
 		ExecutableName: "gh",
 	}

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -19,6 +19,7 @@ import (
 type Factory struct {
 	AppVersion     string
 	ExecutableName string
+	InvokingAgent  string
 
 	Browser          browser.Browser
 	ExtensionManager extensions.ExtensionManager


### PR DESCRIPTION
## Description

When we added the [invoking agent to the `User-Agent` header in API requests](https://github.com/cli/cli/pull/13023), we missed two spots.

Firsty, `gh api` constructs its own http client inline, so we needed to thread that down through the factory like we do with `appVersion`.

Secondly, the `gh auth login` starts using the `plainHTTPClient` (which does have the `InvokingAgent` set) but after obtaining a token, it constructed a new client to `getViewer` that dropped configuration on the existing client. This is why we had a lot of empty versions when looking at request logs. Now we copy it and wrap the transport to include the newly obtained token.