### PR TITLE
fix(repo list): use search for private visibility

### DIFF
--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -30,7 +30,7 @@ type FilterOptions struct {
 }
 
 func listRepos(client *http.Client, hostname string, limit int, owner string, filter FilterOptions) (*RepositoryList, error) {
-	if filter.Language != "" || filter.Archived || filter.NonArchived || len(filter.Topic) > 0 || filter.Visibility == "internal" {
+	if filter.Language != "" || filter.Archived || filter.NonArchived || len(filter.Topic) > 0 || filter.Visibility == "internal" || filter.Visibility == "private" {
 		return searchRepos(client, hostname, limit, owner, filter)
 	}
 

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -471,9 +471,9 @@ func TestRepoList_filtering(t *testing.T) {
 	defer http.Verify(t)
 
 	http.Register(
-		httpmock.GraphQL(`query RepositoryList\b`),
-		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
-			assert.Equal(t, "PRIVATE", params["privacy"])
+		httpmock.GraphQL(`query RepositoryListSearch\b`),
+		httpmock.GraphQLQuery(`{"data":{"search":{"repositoryCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}`, func(_ string, params map[string]interface{}) {
+			assert.Equal(t, "sort:updated-desc fork:true is:private user:@me", params["query"])
 			assert.Equal(t, float64(2), params["perPage"])
 		}),
 	)


### PR DESCRIPTION
## Summary
`gh repo list --visibility private` currently takes the GraphQL repository-owner path, which uses `RepositoryPrivacy`. That enum cannot distinguish `PRIVATE` from `INTERNAL`, so internal repositories are returned alongside truly private ones.

This change routes `--visibility private` through the existing search-backed listing path, matching the workaround and implementation direction discussed in #12900. The search API uses `is:private`, which excludes internal repositories correctly.

## Changes
- route `gh repo list --visibility private` through `searchRepos(...)`
- keep the existing GraphQL path for visibilities that can still be represented accurately there
- add a regression test that asserts the private filter now issues the `is:private` search query

## Testing
- `go test ./pkg/cmd/repo/list`

Closes #12900.
