### PR TITLE
fix: remove projectCards from issue/pr view JSON fields

### DIFF
--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -323,7 +323,6 @@ var sharedIssuePRFields = []string{
 	"labels",
 	"milestone",
 	"number",
-	"projectCards",
 	"projectItems",
 	"reactionGroups",
 	"state",

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -11,8 +11,6 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
-	fd "github.com/cli/cli/v2/internal/featuredetection"
-	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
@@ -30,7 +28,6 @@ type ViewOptions struct {
 	IO         *iostreams.IOStreams
 	BaseRepo   func() (ghrepo.Interface, error)
 	Browser    browser.Browser
-	Detector   fd.Detector
 
 	IssueNumber int
 	WebMode     bool
@@ -118,15 +115,6 @@ func viewRun(opts *ViewOptions) error {
 		}
 
 		lookupFields.Add("projectItems")
-		// TODO projectsV1Deprecation
-		// Remove this section as we should no longer add projectCards
-		if opts.Detector == nil {
-			cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
-			opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
-		}
-		if opts.Detector.ProjectsV1() == gh.ProjectsV1Supported {
-			lookupFields.Add("projectCards")
-		}
 	}
 
 	opts.IO.DetectTerminalTheme()

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -117,16 +117,14 @@ func viewRun(opts *ViewOptions) error {
 			lookupFields.Remove("lastComment")
 		}
 
+		lookupFields.Add("projectItems")
 		// TODO projectsV1Deprecation
 		// Remove this section as we should no longer add projectCards
 		if opts.Detector == nil {
 			cachedClient := api.NewCachedHTTPClient(httpClient, time.Hour*24)
 			opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
 		}
-
-		lookupFields.Add("projectItems")
-		projectsV1Support := opts.Detector.ProjectsV1()
-		if projectsV1Support == gh.ProjectsV1Supported {
+		if opts.Detector.ProjectsV1() == gh.ProjectsV1Supported {
 			lookupFields.Add("projectCards")
 		}
 	}

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cli/cli/v2/test"
 	"github.com/google/shlex"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJSONFields(t *testing.T) {
@@ -47,9 +48,10 @@ func TestJSONFields(t *testing.T) {
 	})
 }
 
-func TestJSONField_projectCards_unknown(t *testing.T) {
+func TestJSONFieldProjectCardsUnknown(t *testing.T) {
 	_, err := runCommand(nil, true, "123 --json projectCards")
-	assert.ErrorContains(t, err, `Unknown JSON field: "projectCards"`)
+	require.Error(t, err)
+	require.ErrorContains(t, err, `Unknown JSON field: "projectCards"`)
 }
 
 func TestNewCmdView(t *testing.T) {

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/config"
-	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/run"
@@ -37,7 +36,6 @@ func TestJSONFields(t *testing.T) {
 		"labels",
 		"milestone",
 		"number",
-		"projectCards",
 		"projectItems",
 		"reactionGroups",
 		"state",
@@ -47,6 +45,11 @@ func TestJSONFields(t *testing.T) {
 		"isPinned",
 		"stateReason",
 	})
+}
+
+func TestJSONField_projectCards_unknown(t *testing.T) {
+	_, err := runCommand(nil, true, "123 --json projectCards")
+	assert.ErrorContains(t, err, `Unknown JSON field: "projectCards"`)
 }
 
 func TestNewCmdView(t *testing.T) {
@@ -524,69 +527,6 @@ func TestIssueView_nontty_Comments(t *testing.T) {
 			test.ExpectLines(t, output.String(), tc.expectedOutputs...)
 		})
 	}
-}
-
-// TODO projectsV1Deprecation
-// Remove this test.
-func TestProjectsV1Deprecation(t *testing.T) {
-	t.Run("when projects v1 is supported, is included in query", func(t *testing.T) {
-		ios, _, _, _ := iostreams.Test()
-
-		reg := &httpmock.Registry{}
-		reg.Register(
-			httpmock.GraphQL(`projectCards`),
-			// Simulate a GraphQL error to early exit the test.
-			httpmock.StatusStringResponse(500, ""),
-		)
-
-		_, cmdTeardown := run.Stub()
-		defer cmdTeardown(t)
-
-		// Ignore the error because we have no way to really stub it without
-		// fully stubbing a GQL error structure in the request body.
-		_ = viewRun(&ViewOptions{
-			IO: ios,
-			HttpClient: func() (*http.Client, error) {
-				return &http.Client{Transport: reg}, nil
-			},
-			BaseRepo: func() (ghrepo.Interface, error) {
-				return ghrepo.New("OWNER", "REPO"), nil
-			},
-
-			Detector:    &fd.EnabledDetectorMock{},
-			IssueNumber: 123,
-		})
-
-		// Verify that our request contained projectCards
-		reg.Verify(t)
-	})
-
-	t.Run("when projects v1 is not supported, is not included in query", func(t *testing.T) {
-		ios, _, _, _ := iostreams.Test()
-
-		reg := &httpmock.Registry{}
-		reg.Exclude(t, httpmock.GraphQL(`projectCards`))
-
-		_, cmdTeardown := run.Stub()
-		defer cmdTeardown(t)
-
-		// Ignore the error because we're not really interested in it.
-		_ = viewRun(&ViewOptions{
-			IO: ios,
-			HttpClient: func() (*http.Client, error) {
-				return &http.Client{Transport: reg}, nil
-			},
-			BaseRepo: func() (ghrepo.Interface, error) {
-				return ghrepo.New("OWNER", "REPO"), nil
-			},
-
-			Detector:    &fd.DisabledDetectorMock{},
-			IssueNumber: 123,
-		})
-
-		// Verify that our request contained projectCards
-		reg.Verify(t)
-	})
 }
 
 // mockEmptyV2ProjectItems registers GraphQL queries to report an issue is not contained on any v2 projects.

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -75,7 +75,7 @@ func TestJSONFields(t *testing.T) {
 	})
 }
 
-func TestJSONField_projectCards_unknown(t *testing.T) {
+func TestJSONFieldProjectCardsUnknown(t *testing.T) {
 	_, err := runCommand(nil, "", true, "123 --json projectCards")
 	require.Error(t, err)
 	require.ErrorContains(t, err, `Unknown JSON field: "projectCards"`)

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
-	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/run"
 	"github.com/cli/cli/v2/pkg/cmd/pr/shared"
@@ -63,7 +62,6 @@ func TestJSONFields(t *testing.T) {
 		"milestone",
 		"number",
 		"potentialMergeCommit",
-		"projectCards",
 		"projectItems",
 		"reactionGroups",
 		"reviewDecision",
@@ -75,6 +73,12 @@ func TestJSONFields(t *testing.T) {
 		"updatedAt",
 		"url",
 	})
+}
+
+func TestJSONField_projectCards_unknown(t *testing.T) {
+	_, err := runCommand(nil, "", true, "123 --json projectCards")
+	require.Error(t, err)
+	require.ErrorContains(t, err, `Unknown JSON field: "projectCards"`)
 }
 
 func Test_NewCmdView(t *testing.T) {
@@ -873,75 +877,4 @@ func TestPRView_nontty_Comments(t *testing.T) {
 			test.ExpectLines(t, output.String(), tt.expectedOutputs...)
 		})
 	}
-}
-
-// TODO projectsV1Deprecation
-// Remove this test.
-func TestProjectsV1Deprecation(t *testing.T) {
-	t.Run("when projects v1 is supported, is included in query", func(t *testing.T) {
-		ios, _, _, _ := iostreams.Test()
-
-		reg := &httpmock.Registry{}
-		reg.Register(
-			httpmock.GraphQL(`projectCards`),
-			// Simulate a GraphQL error to early exit the test.
-			httpmock.StatusStringResponse(500, ""),
-		)
-
-		f := &cmdutil.Factory{
-			IOStreams: ios,
-			HttpClient: func() (*http.Client, error) {
-				return &http.Client{Transport: reg}, nil
-			},
-		}
-
-		_, cmdTeardown := run.Stub()
-		defer cmdTeardown(t)
-
-		// Ignore the error because we have no way to really stub it without
-		// fully stubbing a GQL error structure in the request body.
-		_ = viewRun(&ViewOptions{
-			IO:       ios,
-			Finder:   shared.NewFinder(f),
-			Detector: &fd.EnabledDetectorMock{},
-
-			SelectorArg: "https://github.com/cli/cli/pull/123",
-		})
-
-		// Verify that our request contained projectCards
-		reg.Verify(t)
-	})
-
-	t.Run("when projects v1 is not supported, is not included in query", func(t *testing.T) {
-		ios, _, _, _ := iostreams.Test()
-
-		reg := &httpmock.Registry{}
-		reg.Exclude(
-			t,
-			httpmock.GraphQL(`projectCards`),
-		)
-
-		f := &cmdutil.Factory{
-			IOStreams: ios,
-			HttpClient: func() (*http.Client, error) {
-				return &http.Client{Transport: reg}, nil
-			},
-		}
-
-		_, cmdTeardown := run.Stub()
-		defer cmdTeardown(t)
-
-		// Ignore the error because we have no way to really stub it without
-		// fully stubbing a GQL error structure in the request body.
-		_ = viewRun(&ViewOptions{
-			IO:       ios,
-			Finder:   shared.NewFinder(f),
-			Detector: &fd.DisabledDetectorMock{},
-
-			SelectorArg: "https://github.com/cli/cli/pull/123",
-		})
-
-		// Verify that our request contained projectCards
-		reg.Verify(t)
-	})
 }


### PR DESCRIPTION
CLOSES: #11769

Removed `projectCards` from shared issue/PR JSON field definitions in `api/query_builder.go`, and legacy test/behavior paths that assumed conditional inclusion of `projectCards` based on Projects v1 support; and `--json projectCards` is now rejected as an unknown field rather than silently accepted (+ explicitly assert that requesting `--json projectCards` returns an unknown-field error)