### PR TITLE
fix: output response body when running api with --verbose flag

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -423,6 +423,18 @@ func apiRun(opts *ApiOptions) error {
 			return err
 		}
 
+		// In verbose mode, buffer the response body so it can be printed and
+		// also processed for error detection and GraphQL pagination.
+		if opts.Verbose {
+			bodyBytes, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			resp.Body.Close()
+			fmt.Fprint(opts.IO.Out, string(bodyBytes))
+			resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+
 		if !isGraphQL {
 			requestPath, hasNextPage = findNextPage(resp)
 			requestBody = nil // prevent repeating GET parameters

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -656,6 +656,35 @@ func Test_apiRun(t *testing.T) {
 			stderr: ``,
 			isatty: true,
 		},
+		{
+			name: "verbose mode outputs response body",
+			options: ApiOptions{
+				Verbose: true,
+			},
+			httpResponse: &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"status":"ok"}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			},
+			err:    nil,
+			stdout: `{"status":"ok"}`,
+			stderr: ``,
+			isatty: false,
+		},
+		{
+			name: "verbose mode outputs plain text response body",
+			options: ApiOptions{
+				Verbose: true,
+			},
+			httpResponse: &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBufferString(`octocat art here`)),
+			},
+			err:    nil,
+			stdout: `octocat art here`,
+			stderr: ``,
+			isatty: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -685,6 +685,37 @@ func Test_apiRun(t *testing.T) {
 			stderr: ``,
 			isatty: false,
 		},
+		{
+			name: "verbose mode still parses GraphQL errors",
+			options: ApiOptions{
+				Verbose:     true,
+				RequestPath: "graphql",
+			},
+			httpResponse: &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"errors": [{"message":"BROKEN"}, {"message":"TWICE"}]}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+			},
+			err:    cmdutil.SilentError,
+			stdout: `{"errors": [{"message":"BROKEN"}, {"message":"TWICE"}]}`,
+			stderr: "gh: BROKEN\nTWICE\n",
+			isatty: false,
+		},
+		{
+			name: "verbose mode still parses REST errors",
+			options: ApiOptions{
+				Verbose: true,
+			},
+			httpResponse: &http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"message": "BAD REQUEST"}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+			},
+			err:    cmdutil.SilentError,
+			stdout: `{"message": "BAD REQUEST"}`,
+			stderr: "gh: BAD REQUEST (HTTP 400)\n",
+			isatty: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1032,6 +1063,95 @@ func Test_apiRun_paginationGraphQL(t *testing.T) {
 	endCursor, hasCursor := requestData.Variables["endCursor"].(string)
 	assert.Equal(t, true, hasCursor)
 	assert.Equal(t, "PAGE1_END", endCursor)
+}
+
+func Test_apiRun_paginationGraphQL_verbose(t *testing.T) {
+	ios, _, stdout, stderr := iostreams.Test()
+
+	requestCount := 0
+	responses := []*http.Response{
+		{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{`application/json`}},
+			Body: io.NopCloser(bytes.NewBufferString(heredoc.Doc(`
+			{
+				"data": {
+					"nodes": ["page one"],
+					"pageInfo": {
+						"endCursor": "PAGE1_END",
+						"hasNextPage": true
+					}
+				}
+			}`))),
+		},
+		{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{`application/json`}},
+			Body: io.NopCloser(bytes.NewBufferString(heredoc.Doc(`
+			{
+				"data": {
+					"nodes": ["page two"],
+					"pageInfo": {
+						"endCursor": "PAGE2_END",
+						"hasNextPage": false
+					}
+				}
+			}`))),
+		},
+	}
+
+	options := ApiOptions{
+		IO: ios,
+		HttpClient: func() (*http.Client, error) {
+			var tr roundTripper = func(req *http.Request) (*http.Response, error) {
+				resp := responses[requestCount]
+				resp.Request = req
+				requestCount++
+				return resp, nil
+			}
+			return &http.Client{Transport: tr}, nil
+		},
+		Config: func() (gh.Config, error) {
+			return config.NewBlankConfig(), nil
+		},
+
+		RawFields:     []string{"foo=bar"},
+		RequestMethod: "POST",
+		RequestPath:   "graphql",
+		Paginate:      true,
+		Verbose:       true,
+	}
+
+	err := apiRun(&options)
+	require.NoError(t, err)
+
+	// Verbose mode should print each page's body and pagination should still advance.
+	assert.Contains(t, stdout.String(), `"nodes": ["page one"]`)
+	assert.Contains(t, stdout.String(), `"nodes": ["page two"]`)
+	assert.Equal(t, "", stderr.String(), "stderr")
+
+	// Verify endCursor was used for the second request.
+	var requestData struct {
+		Variables map[string]interface{}
+	}
+
+	bb, err := io.ReadAll(responses[0].Request.Body)
+	require.NoError(t, err)
+	err = json.Unmarshal(bb, &requestData)
+	require.NoError(t, err)
+	_, hasCursor := requestData.Variables["endCursor"].(string)
+	assert.Equal(t, false, hasCursor)
+
+	bb, err = io.ReadAll(responses[1].Request.Body)
+	require.NoError(t, err)
+	err = json.Unmarshal(bb, &requestData)
+	require.NoError(t, err)
+	endCursor, hasCursor := requestData.Variables["endCursor"].(string)
+	assert.Equal(t, true, hasCursor)
+	assert.Equal(t, "PAGE1_END", endCursor)
+
+	// Verify both pages were requested.
+	assert.Equal(t, 2, requestCount)
 }
 
 func Test_apiRun_paginationGraphQL_slurp(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix response body not being output when using `gh api --verbose /octocat`
- Buffer the response body, print it to stdout, and restore resp.Body for error handling and GraphQL pagination
- Add test coverage for verbose mode output

## Context

The `--verbose` flag was not outputting the response body because `resp.Body` is a stream that can only be read once. The verbose HTTP logger from `go-gh` consumed the body during the round-trip, leaving nothing for `processResponse` to read. Additionally, `bodyWriter` was set to `io.Discard` in verbose mode.

## Root Cause

In `pkg/cmd/api/api.go`, when `--verbose` is set:
1. The HTTP client's transport layer logs the response body during the round-trip
2. `processResponse()` then tries to read `resp.Body` again, but it's already consumed
3. Even if there were content, `bodyWriter = io.Discard` would throw it away

## Solution

After receiving the response, buffer the body, print it directly to stdout, and restore `resp.Body` with a fresh reader so error handling and GraphQL pagination continue to work correctly.

Fixes #12566