### PR TITLE
Add global --account flag for per-invocation user override

### DIFF
--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -923,6 +923,100 @@ func TestLoginSecurePostMigrationRemovesTokenFromConfig(t *testing.T) {
 	requireNoKey(t, authCfg.cfg, []string{hostsKey, "github.com", usersKey, "test-user", oauthTokenKey})
 }
 
+func TestSetActiveUserOverridesActiveUser(t *testing.T) {
+	// Given two users are logged in
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "user1", "token1", "", false)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "user2", "token2", "", false)
+	require.NoError(t, err)
+
+	// When we set an active user override
+	authCfg.SetActiveUser("user1")
+
+	// Then ActiveUser returns the overridden user
+	user, err := authCfg.ActiveUser("github.com")
+	require.NoError(t, err)
+	require.Equal(t, "user1", user)
+}
+
+func TestSetActiveUserOverridesActiveUserForAllHosts(t *testing.T) {
+	// Given users are logged in on multiple hosts
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "user1", "token1", "", false)
+	require.NoError(t, err)
+	_, err = authCfg.Login("ghe.io", "user1", "ghe-token1", "", false)
+	require.NoError(t, err)
+
+	// When we set an active user override
+	authCfg.SetActiveUser("user1")
+
+	// Then ActiveUser returns the overridden user for all hosts
+	user, err := authCfg.ActiveUser("github.com")
+	require.NoError(t, err)
+	require.Equal(t, "user1", user)
+
+	user, err = authCfg.ActiveUser("ghe.io")
+	require.NoError(t, err)
+	require.Equal(t, "user1", user)
+}
+
+func TestSetActiveUserOverridesActiveToken(t *testing.T) {
+	// Given two users are logged in with insecure storage
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "user1", "token1", "", false)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "user2", "token2", "", false)
+	require.NoError(t, err)
+
+	// The active user after login is user2 (most recently logged in)
+	user, err := authCfg.ActiveUser("github.com")
+	require.NoError(t, err)
+	require.Equal(t, "user2", user)
+
+	// When we override the active user to user1
+	authCfg.SetActiveUser("user1")
+
+	// Then ActiveToken returns user1's token
+	token, source := authCfg.ActiveToken("github.com")
+	require.Equal(t, "token1", token)
+	require.Equal(t, oauthTokenKey, source)
+}
+
+func TestSetActiveUserOverridesActiveTokenFromKeyring(t *testing.T) {
+	// Given two users are logged in with secure storage
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "user1", "token1", "", true)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "user2", "token2", "", true)
+	require.NoError(t, err)
+
+	// When we override the active user to user1
+	authCfg.SetActiveUser("user1")
+
+	// Then ActiveToken returns user1's token from the keyring
+	token, source := authCfg.ActiveToken("github.com")
+	require.Equal(t, "token1", token)
+	require.Equal(t, "keyring", source)
+}
+
+func TestSetActiveUserReturnsNoTokenForUnknownUser(t *testing.T) {
+	// Given a user is logged in
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "user1", "token1", "", false)
+	require.NoError(t, err)
+
+	// When we override to a non-existent user
+	authCfg.SetActiveUser("unknown-user")
+
+	// Then ActiveToken returns an empty token
+	token, _ := authCfg.ActiveToken("github.com")
+	require.Empty(t, token)
+
+	// And HasActiveToken returns false
+	require.False(t, authCfg.HasActiveToken("github.com"))
+}
+
 // Copied and pasted directly from the trunk branch before doing any work on
 // login, plus the addition of AuthConfig as the first arg since it is a method
 // receiver in the real implementation.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,6 +223,7 @@ type AuthConfig struct {
 	defaultHostOverride func() (string, string)
 	hostsOverride       func() []string
 	tokenOverride       func(string) (string, string)
+	activeUserOverride  string
 }
 
 // ActiveToken will retrieve the active auth token for the given hostname,
@@ -231,6 +232,13 @@ type AuthConfig struct {
 func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 	if c.tokenOverride != nil {
 		return c.tokenOverride(hostname)
+	}
+	if c.activeUserOverride != "" {
+		token, source, err := c.TokenForUser(hostname, c.activeUserOverride)
+		if err == nil {
+			return token, source
+		}
+		return "", "default"
 	}
 	token, source := ghauth.TokenFromEnvOrConfig(hostname)
 	if token == "" {
@@ -311,6 +319,9 @@ func (c *AuthConfig) TokenFromKeyringForUser(hostname, username string) (string,
 // ActiveUser will retrieve the username for the active user at the given hostname.
 // This will not be accurate if the oauth token is set from an environment variable.
 func (c *AuthConfig) ActiveUser(hostname string) (string, error) {
+	if c.activeUserOverride != "" {
+		return c.activeUserOverride, nil
+	}
 	return c.cfg.Get([]string{hostsKey, hostname, userKey})
 }
 
@@ -342,6 +353,12 @@ func (c *AuthConfig) SetDefaultHost(host, source string) {
 	c.defaultHostOverride = func() (string, string) {
 		return host, source
 	}
+}
+
+// SetActiveUser will override the active user resolution for all hosts, returning the given user
+// for all calls to ActiveUser and using that user's token for all calls to ActiveToken.
+func (c *AuthConfig) SetActiveUser(user string) {
+	c.activeUserOverride = user
 }
 
 // Login will set user, git protocol, and auth token for the given hostname.

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -166,6 +166,11 @@ type AuthConfig interface {
 	// DefaultHost.
 	// Use for testing purposes only.
 	SetDefaultHost(host, source string)
+
+	// SetActiveUser will override the active user resolution for all hosts, returning the given user
+	// for all calls to ActiveUser and using that user's token for all calls to ActiveToken.
+	// This is used by the --user flag to override the active account per-invocation.
+	SetActiveUser(user string)
 }
 
 // AliasConfig defines an interface for managing command aliases.

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -76,6 +76,11 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 			"versionInfo": versionCmd.Format(version, buildDate),
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// apply per-invocation user override if --account flag is set
+			if account, err := cmd.Flags().GetString("account"); err == nil && account != "" {
+				cfg.Authentication().SetActiveUser(account)
+			}
+
 			// require that the user is authenticated before running most commands
 			if cmdutil.IsAuthCheckEnabled(cmd) && !cmdutil.CheckAuth(cfg) {
 				parent := cmd.Parent()
@@ -94,6 +99,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) (*cobra.Command, 
 	// cmd.SetErr(f.IOStreams.ErrOut) // just let it default to os.Stderr instead
 
 	cmd.PersistentFlags().Bool("help", false, "Show help for command")
+	cmd.PersistentFlags().String("account", "", "Override the active GitHub account for a single command invocation")
 
 	// override Cobra's default behaviors unless an opt-out has been set
 	if os.Getenv("GH_COBRA") == "" {


### PR DESCRIPTION
## Summary

Adds a global `--account` persistent flag that overrides the active GitHub account for a single command invocation, eliminating the error-prone `switch -> command -> switch back` pattern.

### Usage

~~~bash
gh issue create --repo myorg/repo --account personal-account
gh pr list --repo corp/repo --account work-account
~~~

## Changes

- **`internal/gh/gh.go`**: Added `SetActiveUser(user string)` to the `AuthConfig` interface
- **`internal/config/config.go`**:
  - Added `activeUserOverride` field to `AuthConfig` struct
  - Modified `ActiveUser()` to check override before config lookup
  - Modified `ActiveToken()` to use overridden user's token via `TokenForUser`
  - Added `SetActiveUser()` method
- **`pkg/cmd/root/root.go`**: Added `--account` persistent flag, wired in `PersistentPreRunE` before auth check
- **`internal/config/auth_config_test.go`**: 5 new unit tests covering:
  - Active user override
  - Override across all hosts
  - Token resolution with insecure and secure (keyring) storage
  - Unknown user returns no token

> **Note**: The flag is named `--account` rather than `--user` to avoid conflicts with the existing `--user`/`-u` flags on several subcommands (`auth switch`, `auth token`, `auth logout`, `secret`, `codespace`, `run list`).

Fixes #13088