### PR TITLE
Fix infinite loop in `gh release list --limit 0`

### DIFF
--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -44,6 +44,10 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			// support `-R, --repo` override
 			opts.BaseRepo = f.BaseRepo
 
+			if opts.LimitResults < 1 {
+				return cmdutil.FlagErrorf("invalid limit: %v", opts.LimitResults)
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -59,6 +59,11 @@ func Test_NewCmdList(t *testing.T) {
 			},
 		},
 		{
+			name:    "zero limit",
+			args:    "--limit 0",
+			wantErr: "invalid limit: 0",
+		},
+		{
 			name: "with order",
 			args: "--order asc",
 			want: ListOptions{


### PR DESCRIPTION
## Problem

`gh release list --limit 0` loops infinitely, hitting the GraphQL API without terminating. All other list subcommands correctly reject `--limit 0`:

```
gh issue list --limit 0   → invalid limit: 0
gh pr list --limit 0      → invalid value for --limit: 0
gh repo list --limit 0    → invalid limit: 0
gh release list --limit 0 → 💥 infinite loop
```

## Fix

Add limit validation (< 1 check) in the `release list` command, consistent with other subcommands. Includes a test.

Closes #13078