### PR TITLE
fix: `gh repo sync` handles linked worktrees safely

### DIFF
--- a/pkg/cmd/repo/sync/git.go
+++ b/pkg/cmd/repo/sync/git.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cli/cli/v2/git"
 )
@@ -24,7 +23,7 @@ type gitExecuter struct {
 }
 
 func (g *gitExecuter) UpdateBranch(branch, ref string) error {
-	cmd, err := g.client.Command(context.Background(), "update-ref", fmt.Sprintf("refs/heads/%s", branch), ref)
+	cmd, err := g.client.Command(context.Background(), "branch", "--force", branch, ref)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/repo/sync/sync_test.go
+++ b/pkg/cmd/repo/sync/sync_test.go
@@ -260,6 +260,22 @@ func Test_SyncRun(t *testing.T) {
 			wantStdout: "✓ Synced the \"trunk\" branch from \"OWNER/REPO\" to local repository\n",
 		},
 		{
+			name: "sync local repo with parent - existing branch checked out in another worktree",
+			tty:  true,
+			opts: &SyncOptions{
+				Branch: "trunk",
+			},
+			gitStubs: func(mgc *mockGitClient) {
+				mgc.On("Fetch", "origin", "refs/heads/trunk").Return(nil).Once()
+				mgc.On("HasLocalBranch", "trunk").Return(true).Once()
+				mgc.On("IsAncestor", "trunk", "FETCH_HEAD").Return(true, nil).Once()
+				mgc.On("CurrentBranch").Return("test", nil).Once()
+				mgc.On("UpdateBranch", "trunk", "FETCH_HEAD").Return(assert.AnError).Once()
+			},
+			wantErr: true,
+			errMsg:  assert.AnError.Error(),
+		},
+		{
 			name: "sync local repo with parent - create new branch",
 			tty:  true,
 			opts: &SyncOptions{


### PR DESCRIPTION
## Summary

Avoid silently corrupting a linked worktree during `gh repo sync` by no longer updating an existing local branch with `git update-ref`. Instead, use `git branch --force`, which safely refuses to move a branch when it is checked out in another worktree.

## Changes

- replace the local-branch update path in `pkg/cmd/repo/sync/git.go` from `git update-ref` to `git branch --force`
- add a regression test covering the case where the branch exists locally but is checked out in another worktree and the branch update fails

## Testing

- `go test ./pkg/cmd/repo/sync/...`

Fixes cli/cli#12927