### PR TITLE
chore: bump to go1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/cli/cli/v2
 
 go 1.26.1
 
+toolchain go1.26.2
+
 require (
 	charm.land/bubbles/v2 v2.0.0
 	charm.land/bubbletea/v2 v2.0.2


### PR DESCRIPTION
This PR bumps Go version to 1.26.2 to resolve the following vulnerabilities reported by `govulncheck`:

<details><summary>Details</summary>
<p>

```shellsession
$ govulncheck -show verbose -mode binary $(which gh)
...
Vulnerability #1: GO-2026-4947
    Unexpected work during chain building in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-4947
  Standard library
    Found in: crypto/x509@go1.26.1
    Fixed in: crypto/x509@go1.26.2
    Vulnerable symbols found:
      #1: x509.Certificate.Verify
      #2: x509.Certificate.Verify
      #3: x509.Certificate.Verify

Vulnerability #2: GO-2026-4946
    Inefficient policy validation in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-4946
  Standard library
    Found in: crypto/x509@go1.26.1
    Fixed in: crypto/x509@go1.26.2
    Vulnerable symbols found:
      #1: x509.Certificate.Verify
      #2: x509.Certificate.Verify
      #3: x509.Certificate.Verify

Vulnerability #3: GO-2026-4870
    Unauthenticated TLS 1.3 KeyUpdate record can cause persistent connection
    retention and DoS in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-4870
  Standard library
    Found in: crypto/tls@go1.26.1
    Fixed in: crypto/tls@go1.26.2
    Vulnerable symbols found:
      #1: tls.Conn.Handshake
      #2: tls.Conn.HandshakeContext
      #3: tls.Conn.Read
      #4: tls.Conn.Write
      #5: tls.Dial
      Use '-show traces' to see the other 5 found symbols

Vulnerability #4: GO-2026-4869
    Unbounded allocation for old GNU sparse in archive/tar
  More info: https://pkg.go.dev/vuln/GO-2026-4869
  Standard library
    Found in: archive/tar@go1.26.1
    Fixed in: archive/tar@go1.26.2
    Vulnerable symbols found:
      #1: tar.Reader.Next

Vulnerability #5: GO-2026-4866
    Case-sensitive excludedSubtrees name constraints cause Auth Bypass in
    crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-4866
  Standard library
    Found in: crypto/x509@go1.26.1
    Fixed in: crypto/x509@go1.26.2
    Vulnerable symbols found:
      #1: x509.Certificate.Verify
      #2: x509.Certificate.Verify
      #3: x509.Certificate.Verify

Vulnerability #6: GO-2026-4865
    JsBraceDepth Context Tracking Bugs (XSS) in html/template
  More info: https://pkg.go.dev/vuln/GO-2026-4865
  Standard library
    Found in: html/template@go1.26.1
    Fixed in: html/template@go1.26.2
    Vulnerable symbols found:
      #1: template.Error.Error
      #2: template.HTMLEscaper
      #3: template.JSEscape
      #4: template.JSEscapeString
      #5: template.JSEscaper
      Use '-show traces' to see the other 15 found symbols

Vulnerability #7: GO-2026-4864
    TOCTOU permits root escape on Linux via Root.Chmod in os in
    internal/syscall/unix
  More info: https://pkg.go.dev/vuln/GO-2026-4864
  Standard library
    Found in: internal/syscall/unix@go1.26.1
    Fixed in: internal/syscall/unix@go1.26.2
    Platforms: linux
    Vulnerable symbols found:
      #1: unix.Fchmodat
```

</p>
</details> 
