### PR TITLE
Document dependency CVE policy in SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -11,6 +11,8 @@ If you believe you have found a security vulnerability in GitHub CLI, you can re
 
 **Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
 
+A dependency having a CVE does not mean `gh` has a vulnerability. We use [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) to determine whether vulnerable symbols are actually reachable from `gh`'s code. If you are reporting a dependency CVE, please include evidence that the issue is exploitable in `gh`: a call chain into the affected symbols or a proof of concept. Reports that only list a dependency version and CVE without demonstrating impact will be closed.
+
 Thanks for helping make GitHub safe for everyone.
 
   [private vulnerability reporting]: https://github.com/cli/cli/security/advisories


### PR DESCRIPTION
Adds a paragraph to SECURITY.md clarifying that a dependency having a CVE does not mean `gh` has a vulnerability. We use `govulncheck` for symbol-level reachability analysis, and we ask reporters to demonstrate exploitability before we act on dependency CVE reports.