### PR TITLE
Update installation commands for GitHub CLI

### DIFF
--- a/docs/install_windows.md
+++ b/docs/install_windows.md
@@ -11,13 +11,13 @@ The [GitHub CLI package](https://winget.run/pkg/GitHub/cli) is supported by Micr
 To install:
 
 ```pwsh
-winget install --id GitHub.cli
+winget install --id GitHub.cli --source winget
 ```
 
 To upgrade:
 
 ```pwsh
-winget upgrade --id GitHub.cli
+winget upgrade --id GitHub.cli --source winget
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Added '--source winget' option to install and upgrade commands.

On machines where the `Store` source is enabled but the license to use the store is not granted specifying the source is required. 

This does not have any negative effect.
