### PR TITLE
auth: add per-owner account mapping to fix multi-account token selection

### DIFF
--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -666,6 +666,88 @@ func TestTokenForUserNotFoundErrors(t *testing.T) {
 	require.EqualError(t, err, "no token found for 'test-user-1'")
 }
 
+func TestSetOwnerUserAndUserForOwner(t *testing.T) {
+	// Given two users logged in to a host
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "personal-user", "personal-token", "", false)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "work-user", "work-token", "", false)
+	require.NoError(t, err)
+
+	// When we set an owner mapping
+	err = authCfg.SetOwnerUser("github.com", "work-org", "work-user")
+	require.NoError(t, err)
+
+	// Then UserForOwner returns the mapped user
+	user, err := authCfg.UserForOwner("github.com", "work-org")
+	require.NoError(t, err)
+	require.Equal(t, "work-user", user)
+}
+
+func TestUserForOwnerNotFound(t *testing.T) {
+	// Given no owner mappings
+	authCfg := newTestAuthConfig(t)
+
+	// When we look up an owner with no mapping
+	_, err := authCfg.UserForOwner("github.com", "unknown-org")
+
+	// Then it returns an error
+	require.Error(t, err)
+}
+
+func TestActiveTokenUsesOwnerMappingWhenRepoOwnerSet(t *testing.T) {
+	// Given two users logged in insecurely, with an owner mapping
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "personal-user", "personal-token", "", false)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "work-user", "work-token", "", false)
+	require.NoError(t, err)
+	require.NoError(t, authCfg.SetOwnerUser("github.com", "work-org", "work-user"))
+
+	// When we set the repo owner to the mapped org and get the active token
+	authCfg.SetRepoOwner("work-org")
+	token, source := authCfg.ActiveToken("github.com")
+
+	// Then the work user's token is returned
+	require.Equal(t, "work-token", token)
+	require.Equal(t, oauthTokenKey, source)
+}
+
+func TestActiveTokenFallsBackToActiveUserWhenNoOwnerMapping(t *testing.T) {
+	// Given two users logged in, work-user is globally active, no owner mapping
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "personal-user", "personal-token", "", false)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "work-user", "work-token", "", false)
+	require.NoError(t, err)
+
+	// When we set the repo owner to an unmapped org
+	authCfg.SetRepoOwner("unknown-org")
+	token, source := authCfg.ActiveToken("github.com")
+
+	// Then the globally active user's token is returned
+	require.Equal(t, "work-token", token)
+	require.Equal(t, oauthTokenKey, source)
+}
+
+func TestActiveTokenUsesOwnerMappingFromKeyring(t *testing.T) {
+	// Given two users logged in securely, with an owner mapping
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "personal-user", "personal-token", "", true)
+	require.NoError(t, err)
+	_, err = authCfg.Login("github.com", "work-user", "work-token", "", true)
+	require.NoError(t, err)
+	require.NoError(t, authCfg.SetOwnerUser("github.com", "work-org", "work-user"))
+
+	// When we set the repo owner to the mapped org and get the active token
+	authCfg.SetRepoOwner("work-org")
+	token, source := authCfg.ActiveToken("github.com")
+
+	// Then the work user's token is returned from the keyring
+	require.Equal(t, "work-token", token)
+	require.Equal(t, "keyring", source)
+}
+
 func requireKeyWithValue(t *testing.T, cfg *ghConfig.Config, keys []string, value string) {
 	t.Helper()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ const (
 	spinnerKey            = "spinner"
 	userKey               = "user"
 	usersKey              = "users"
+	ownersKey             = "owners"
 	versionKey            = "version"
 )
 
@@ -223,11 +224,16 @@ type AuthConfig struct {
 	defaultHostOverride func() (string, string)
 	hostsOverride       func() []string
 	tokenOverride       func(string) (string, string)
+	repoOwner           string
 }
 
 // ActiveToken will retrieve the active auth token for the given hostname,
 // searching environment variables, plain text config, and
 // lastly encrypted storage.
+//
+// If a repo owner has been set via SetRepoOwner and a mapping exists for that
+// owner, the token for the mapped user will be used instead of the globally
+// active user.
 func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 	if c.tokenOverride != nil {
 		return c.tokenOverride(hostname)
@@ -236,7 +242,15 @@ func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 	if token == "" {
 		var user string
 		var err error
-		if user, err = c.ActiveUser(hostname); err == nil {
+		// If a repo owner is set and maps to a specific user, use that user's token.
+		if c.repoOwner != "" {
+			user, err = c.UserForOwner(hostname, c.repoOwner)
+		}
+		// Fall back to the globally active user if no owner mapping exists.
+		if err != nil || user == "" {
+			user, err = c.ActiveUser(hostname)
+		}
+		if err == nil {
 			token, err = c.TokenFromKeyringForUser(hostname, user)
 		}
 		if err != nil {
@@ -251,6 +265,13 @@ func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
 		}
 	}
 	return token, source
+}
+
+// SetRepoOwner sets the GitHub owner (user or org) of the current repo context.
+// When set, ActiveToken will prefer the token for the user mapped to this owner
+// over the globally active user.
+func (c *AuthConfig) SetRepoOwner(owner string) {
+	c.repoOwner = owner
 }
 
 // HasActiveToken returns true when a token for the hostname is present.
@@ -312,6 +333,19 @@ func (c *AuthConfig) TokenFromKeyringForUser(hostname, username string) (string,
 // This will not be accurate if the oauth token is set from an environment variable.
 func (c *AuthConfig) ActiveUser(hostname string) (string, error) {
 	return c.cfg.Get([]string{hostsKey, hostname, userKey})
+}
+
+// UserForOwner retrieves the gh username mapped to the given GitHub owner (user or org)
+// for the given hostname. Returns an error if no mapping exists.
+func (c *AuthConfig) UserForOwner(hostname, owner string) (string, error) {
+	return c.cfg.Get([]string{hostsKey, hostname, ownersKey, owner})
+}
+
+// SetOwnerUser stores a mapping from a GitHub owner (user or org) to a gh username
+// for the given hostname, persisting it to the config file.
+func (c *AuthConfig) SetOwnerUser(hostname, owner, username string) error {
+	c.cfg.Set([]string{hostsKey, hostname, ownersKey, owner}, username)
+	return ghConfig.Write(c.cfg)
 }
 
 func (c *AuthConfig) Hosts() []string {

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -126,6 +126,18 @@ type AuthConfig interface {
 	// This will not be accurate if the oauth token is set from an environment variable.
 	ActiveUser(hostname string) (username string, err error)
 
+	// UserForOwner retrieves the gh username mapped to the given GitHub owner (user or org)
+	// for the given hostname. Returns an error if no mapping exists.
+	UserForOwner(hostname, owner string) (username string, err error)
+
+	// SetOwnerUser stores a mapping from a GitHub owner (user or org) to a gh username
+	// for the given hostname, persisting it to the config file.
+	SetOwnerUser(hostname, owner, username string) error
+
+	// SetRepoOwner sets the GitHub owner (user or org) of the current repo context
+	// so that ActiveToken prefers the mapped user's token over the globally active user.
+	SetRepoOwner(owner string)
+
 	// Hosts retrieves a list of known hosts.
 	Hosts() []string
 

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -6,6 +6,7 @@ import (
 	authLogoutCmd "github.com/cli/cli/v2/pkg/cmd/auth/logout"
 	authRefreshCmd "github.com/cli/cli/v2/pkg/cmd/auth/refresh"
 	authSetupGitCmd "github.com/cli/cli/v2/pkg/cmd/auth/setupgit"
+	authSetUserCmd "github.com/cli/cli/v2/pkg/cmd/auth/setuser"
 	authStatusCmd "github.com/cli/cli/v2/pkg/cmd/auth/status"
 	authSwitchCmd "github.com/cli/cli/v2/pkg/cmd/auth/switch"
 	authTokenCmd "github.com/cli/cli/v2/pkg/cmd/auth/token"
@@ -30,6 +31,7 @@ func NewCmdAuth(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(authSetupGitCmd.NewCmdSetupGit(f, nil))
 	cmd.AddCommand(authTokenCmd.NewCmdToken(f, nil))
 	cmd.AddCommand(authSwitchCmd.NewCmdSwitch(f, nil))
+	cmd.AddCommand(authSetUserCmd.NewCmdSetUser(f, nil))
 
 	return cmd
 }

--- a/pkg/cmd/auth/setuser/setuser.go
+++ b/pkg/cmd/auth/setuser/setuser.go
@@ -1,0 +1,105 @@
+package authsetuser
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	ghauth "github.com/cli/go-gh/v2/pkg/auth"
+	"github.com/spf13/cobra"
+)
+
+// SetUserOptions holds the options for the set-user command.
+type SetUserOptions struct {
+	IO       *iostreams.IOStreams
+	Config   func() (gh.Config, error)
+	Hostname string
+	Owner    string
+	Username string
+}
+
+// NewCmdSetUser creates the `gh auth set-user` command.
+func NewCmdSetUser(f *cmdutil.Factory, runF func(*SetUserOptions) error) *cobra.Command {
+	opts := SetUserOptions{
+		IO:     f.IOStreams,
+		Config: f.Config,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "set-user <username>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Map a GitHub owner to an authenticated user",
+		Long: heredoc.Docf(`
+			Map a GitHub owner (user or org) to an authenticated gh account.
+
+			When gh runs a command inside a repository whose owner matches the
+			given %[1]s--owner%[1]s value, it will automatically use the token for
+			%[1]s<username>%[1]s instead of the globally active account.
+
+			This allows working with repositories owned by different GitHub accounts
+			without running %[1]sgh auth switch%[1]s between them.
+
+			Run %[1]sgh auth status%[1]s to see available authenticated accounts.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# Use your work account for all repos owned by your work org
+			$ gh auth set-user --owner xgdevops lukemckechnie
+
+			# Use your personal account for your own repos
+			$ gh auth set-user --owner galamdring galamdring
+
+			# Set a mapping for a specific GitHub Enterprise host
+			$ gh auth set-user --owner myorg --hostname enterprise.internal myuser
+		`),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts.Username = args[0]
+			if runF != nil {
+				return runF(&opts)
+			}
+			return setUserRun(&opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Owner, "owner", "o", "", "The GitHub owner (user or org) to map (required)")
+	cmd.Flags().StringVarP(&opts.Hostname, "hostname", "h", "", "The hostname of the GitHub instance (default: github.com)")
+	_ = cmd.MarkFlagRequired("owner")
+
+	return cmd
+}
+
+func setUserRun(opts *SetUserOptions) error {
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+	authCfg := cfg.Authentication()
+
+	hostname := opts.Hostname
+	if hostname == "" {
+		hostname, _ = authCfg.DefaultHost()
+	}
+	hostname = ghauth.NormalizeHostname(hostname)
+
+	// Validate that the hostname is known.
+	if !slices.Contains(authCfg.Hosts(), hostname) {
+		return fmt.Errorf("not logged in to %s", hostname)
+	}
+
+	// Validate that the username is a known authenticated user on this host.
+	if !slices.Contains(authCfg.UsersForHost(hostname), opts.Username) {
+		return fmt.Errorf("not logged in to %s as %s", hostname, opts.Username)
+	}
+
+	if err := authCfg.SetOwnerUser(hostname, opts.Owner, opts.Username); err != nil {
+		return fmt.Errorf("failed to save owner mapping: %w", err)
+	}
+
+	cs := opts.IO.ColorScheme()
+	fmt.Fprintf(opts.IO.ErrOut, "%s Mapped owner %s to user %s on %s\n",
+		cs.SuccessIcon(), cs.Bold(opts.Owner), cs.Bold(opts.Username), hostname)
+
+	return nil
+}

--- a/pkg/cmd/auth/setuser/setuser_test.go
+++ b/pkg/cmd/auth/setuser/setuser_test.go
@@ -1,0 +1,200 @@
+package authsetuser
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdSetUser(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantErr  string
+		wantOpts SetUserOptions
+	}{
+		{
+			name:  "owner and username parsed",
+			input: "--owner work-org work-user",
+			wantOpts: SetUserOptions{
+				Owner:    "work-org",
+				Username: "work-user",
+			},
+		},
+		{
+			name:  "hostname flag parsed",
+			input: "--owner work-org --hostname ghe.io work-user",
+			wantOpts: SetUserOptions{
+				Owner:    "work-org",
+				Username: "work-user",
+				Hostname: "ghe.io",
+			},
+		},
+		{
+			name:    "errors when owner flag is missing",
+			input:   "work-user",
+			wantErr: `required flag(s) "owner" not set`,
+		},
+		{
+			name:    "errors when username arg is missing",
+			input:   "--owner work-org",
+			wantErr: "accepts 1 arg(s), received 0",
+		},
+		{
+			name:    "errors when too many args",
+			input:   "--owner work-org user1 user2",
+			wantErr: "accepts 1 arg(s), received 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &cmdutil.Factory{}
+
+			argv, err := shlex.Split(tt.input)
+			require.NoError(t, err)
+
+			var gotOpts *SetUserOptions
+			cmd := NewCmdSetUser(f, func(opts *SetUserOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			// Override help so -h can be used for hostname
+			cmd.Flags().BoolP("help", "x", false, "")
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err = cmd.ExecuteC()
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOpts.Owner, gotOpts.Owner)
+			assert.Equal(t, tt.wantOpts.Username, gotOpts.Username)
+			assert.Equal(t, tt.wantOpts.Hostname, gotOpts.Hostname)
+		})
+	}
+}
+
+func TestSetUserRun(t *testing.T) {
+	tests := []struct {
+		name        string
+		owner       string
+		username    string
+		hostname    string
+		setupConfig func(*config.AuthConfig)
+		wantErr     string
+		wantMapping string
+	}{
+		{
+			name:     "maps owner to authenticated user",
+			owner:    "work-org",
+			username: "work-user",
+			setupConfig: func(authCfg *config.AuthConfig) {
+				_, err := authCfg.Login("github.com", "work-user", "work-token", "", false)
+				require.NoError(t, err)
+			},
+			wantMapping: "work-user",
+		},
+		{
+			name:     "maps personal owner to personal user",
+			owner:    "personal-user",
+			username: "personal-user",
+			setupConfig: func(authCfg *config.AuthConfig) {
+				_, err := authCfg.Login("github.com", "personal-user", "personal-token", "", false)
+				require.NoError(t, err)
+			},
+			wantMapping: "personal-user",
+		},
+		{
+			name:     "errors when not logged in to host",
+			owner:    "work-org",
+			username: "work-user",
+			setupConfig: func(authCfg *config.AuthConfig) {
+				// no users logged in
+			},
+			wantErr: "not logged in to github.com",
+		},
+		{
+			name:     "errors when username not an authenticated user on host",
+			owner:    "work-org",
+			username: "unknown-user",
+			setupConfig: func(authCfg *config.AuthConfig) {
+				_, err := authCfg.Login("github.com", "work-user", "work-token", "", false)
+				require.NoError(t, err)
+			},
+			wantErr: "not logged in to github.com as unknown-user",
+		},
+		{
+			name:     "uses explicit hostname flag",
+			owner:    "work-org",
+			username: "work-user",
+			hostname: "ghe.io",
+			setupConfig: func(authCfg *config.AuthConfig) {
+				_, err := authCfg.Login("ghe.io", "work-user", "work-token", "", false)
+				require.NoError(t, err)
+			},
+			wantMapping: "work-user",
+		},
+		{
+			name:     "errors when hostname not known",
+			owner:    "work-org",
+			username: "work-user",
+			hostname: "unknown.internal",
+			setupConfig: func(authCfg *config.AuthConfig) {
+				_, err := authCfg.Login("github.com", "work-user", "work-token", "", false)
+				require.NoError(t, err)
+			},
+			wantErr: "not logged in to unknown.internal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, _ := config.NewIsolatedTestConfig(t)
+			authCfg := cfg.Authentication().(*config.AuthConfig)
+			tt.setupConfig(authCfg)
+
+			ios, _, _, _ := iostreams.Test()
+
+			opts := &SetUserOptions{
+				IO: ios,
+				Config: func() (gh.Config, error) {
+					return cfg, nil
+				},
+				Owner:    tt.owner,
+				Username: tt.username,
+				Hostname: tt.hostname,
+			}
+
+			err := setUserRun(opts)
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+
+			hostname := tt.hostname
+			if hostname == "" {
+				hostname = "github.com"
+			}
+			user, err := authCfg.UserForOwner(hostname, tt.owner)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMapping, user)
+		})
+	}
+}

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -194,8 +194,17 @@ func httpClientFunc(f *cmdutil.Factory, appVersion string, invokingAgent string)
 		if err != nil {
 			return nil, err
 		}
+		authCfg := cfg.Authentication()
+
+		// If we can resolve the current repo's owner, set it on the auth config so
+		// that ActiveToken will prefer the token mapped to that owner over the
+		// globally active user.
+		if remotes, err := f.Remotes(); err == nil && len(remotes) > 0 {
+			authCfg.SetRepoOwner(remotes[0].RepoOwner())
+		}
+
 		opts := api.HTTPClientOptions{
-			Config:        cfg.Authentication(),
+			Config:        authCfg,
 			Log:           io.ErrOut,
 			LogColorize:   io.ColorEnabled(),
 			AppVersion:    appVersion,


### PR DESCRIPTION
## Summary

Fixes #12885.

The root cause identified in #12885 is that token retrieval doesn't use the account name as a filter — `TokenFromKeyring` looks up by service only (`gh:github.com`), so macOS Keychain returns an arbitrary entry when multiple accounts share the same host. `TokenFromKeyringForUser` already does the right thing, but isn't always called with the right user.

Rather than fixing the lookup in isolation, this PR approaches the problem from the usage side: automatically select the correct authenticated user based on who owns the current repo, so the right token is retrieved without any manual switching.

## What this adds
**`gh auth set-user --owner <owner> <username>`** — stores an owner→user mapping in `hosts.yml`:

```sh
$ gh auth set-user --owner repo_one user_one
$ gh auth set-user --owner repo_two user_two
```

**Automatic token selection** — when running any `gh` command inside a repo, the owner is resolved from the git remote and used to look up the mapped user before falling back to the globally active user. This happens in `httpClientFunc` in the factory, covering every API call with no per-command changes.

## Design notes
- No signature changes to `tokenGetter` or `AddAuthTokenHeader`
- Falls back gracefully to the globally active user when no mapping exists
- The `owners` key is new and ignored by older `gh` versions (unrecognized keys are not an error in the config library)
- Blast radius: `internal/config/config.go`, `internal/gh/gh.go`,`pkg/cmd/factory/default.go`, new `pkg/cmd/auth/setuser/` package, one line in `pkg/cmd/auth/auth.go`

## Testing
New table-driven tests cover `UserForOwner`/`SetOwnerUser` round-trip, `ActiveToken` owner mapping (keyring and insecure storage), fallback when no mapping exists, and `gh auth set-user` flag parsing and run logic. 

All existing tests pass.
