### PR TITLE
fix: `gh cs ssh` can hide errors on port forwarding

### DIFF
--- a/internal/codespaces/rpc/invoker.go
+++ b/internal/codespaces/rpc/invoker.go
@@ -114,12 +114,13 @@ func connect(ctx context.Context, fwd portforwarder.PortForwarder) (Invoker, err
 
 	var conn *grpc.ClientConn
 	go func() {
-		// Attempt to connect to the port
+		// Attempt to connect to the forwarded local port.
 		opts := []grpc.DialOption{
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(),
 		}
-		conn, err = grpc.NewClient(localAddress, opts...)
-		ch <- err // nil if we successfully connected
+		conn, err = grpc.DialContext(ctx, localAddress, opts...)
+		ch <- err // nil only once the connection is actually established
 	}()
 
 	// Wait for the connection to be established or for the context to be cancelled

--- a/internal/codespaces/rpc/invoker_test.go
+++ b/internal/codespaces/rpc/invoker_test.go
@@ -2,15 +2,20 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"testing"
+	"time"
 
+	"github.com/cli/cli/v2/internal/codespaces/portforwarder"
 	"github.com/cli/cli/v2/internal/codespaces/rpc/codespace"
 	"github.com/cli/cli/v2/internal/codespaces/rpc/jupyter"
 	"github.com/cli/cli/v2/internal/codespaces/rpc/ssh"
 	rpctest "github.com/cli/cli/v2/internal/codespaces/rpc/test"
+	"github.com/microsoft/dev-tunnels/go/tunnels"
 	"google.golang.org/grpc"
 )
 
@@ -309,5 +314,73 @@ func TestStartSSHServerFailure(t *testing.T) {
 	}
 	if user != "" {
 		t.Fatalf("expected %s, got %s", "", user)
+	}
+}
+
+type blockingFailPortForwarder struct {
+	failCh chan struct{}
+	err    error
+}
+
+func (f blockingFailPortForwarder) Close() error {
+	return nil
+}
+
+func (f blockingFailPortForwarder) ConnectToForwardedPort(context.Context, io.ReadWriteCloser, portforwarder.ForwardPortOpts) error {
+	panic("unimplemented")
+}
+
+func (f blockingFailPortForwarder) ForwardPort(context.Context, portforwarder.ForwardPortOpts) error {
+	panic("unimplemented")
+}
+
+func (f blockingFailPortForwarder) GetKeepAliveReason() string {
+	return ""
+}
+
+func (f blockingFailPortForwarder) KeepAlive(string) {
+}
+
+func (f blockingFailPortForwarder) ForwardPortToListener(context.Context, portforwarder.ForwardPortOpts, *net.TCPListener) error {
+	<-f.failCh
+	return f.err
+}
+
+func (f blockingFailPortForwarder) ListPorts(context.Context) ([]*tunnels.TunnelPort, error) {
+	panic("unimplemented")
+}
+
+func (f blockingFailPortForwarder) UpdatePortVisibility(context.Context, int, string) error {
+	panic("unimplemented")
+}
+
+func TestCreateInvokerReturnsPortForwardError(t *testing.T) {
+	expectedErr := errors.New("port forward failed")
+	failCh := make(chan struct{})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := CreateInvoker(context.Background(), blockingFailPortForwarder{
+			failCh: failCh,
+			err:    expectedErr,
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("CreateInvoker returned before port forwarding failed: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(failCh)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("expected %v, got %v", expectedErr, err)
+		}
+	case <-time.After(ConnectionTimeout):
+		t.Fatal("timed out waiting for CreateInvoker to return")
 	}
 }


### PR DESCRIPTION
## Summary

Make codespaces RPC setup wait for a real gRPC connection instead of treating lazy client construction as success, so port-forward failures from `gh cs ssh` surface immediately.

## Changes

- replace the lazy `grpc.NewClient` setup in `internal/codespaces/rpc/invoker.go` with a blocking `grpc.DialContext(..., grpc.WithBlock())`
- keep waiting on the same setup race, but only report success once the forwarded local port is actually connected
- add a regression test that reproduces the hidden port-forward error case and asserts the error bubbles up from `CreateInvoker`

## Testing

- `go test ./internal/codespaces/rpc/...`
- `go test ./internal/codespaces/...`

Fixes cli/cli#11206
