### PR TITLE
Add GH_API_URL env var to redirect API requests to a custom endpoint

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -70,6 +72,10 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 		return nil, err
 	}
 
+	if apiURL := os.Getenv("GH_API_URL"); apiURL != "" {
+		client.Transport = AddAPIURLOverride(client.Transport, apiURL)
+	}
+
 	if opts.Config != nil {
 		client.Transport = AddAuthTokenHeader(client.Transport, opts.Config)
 	}
@@ -112,6 +118,31 @@ func AddAuthTokenHeader(rt http.RoundTripper, cfg tokenGetter) http.RoundTripper
 					req.Header.Set(authorization, fmt.Sprintf("token %s", token))
 				}
 			}
+		}
+		return rt.RoundTrip(req)
+	}}
+}
+
+// AddAPIURLOverride rewrites GitHub API requests to a custom base URL.
+// It replaces the scheme, host, and prepends the override URL's path to
+// the original request path for any request targeting api.github.com.
+// Redirect requests (where req.Response is set) are not rewritten to
+// avoid interfering with CDN or storage redirect URLs.
+func AddAPIURLOverride(rt http.RoundTripper, apiURL string) http.RoundTripper {
+	parsed, err := url.Parse(apiURL)
+	if err != nil || parsed.Host == "" {
+		return rt
+	}
+	return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+		if req.Response != nil {
+			return rt.RoundTrip(req)
+		}
+		if strings.EqualFold(req.URL.Hostname(), "api.github.com") {
+			req = req.Clone(req.Context())
+			req.URL.Scheme = parsed.Scheme
+			req.URL.Host = parsed.Host
+			req.URL.Path = strings.TrimRight(parsed.Path, "/") + req.URL.Path
+			req.Host = parsed.Host
 		}
 		return rt.RoundTrip(req)
 	}}

--- a/api/http_client.go
+++ b/api/http_client.go
@@ -130,7 +130,7 @@ func AddAuthTokenHeader(rt http.RoundTripper, cfg tokenGetter) http.RoundTripper
 // avoid interfering with CDN or storage redirect URLs.
 func AddAPIURLOverride(rt http.RoundTripper, apiURL string) http.RoundTripper {
 	parsed, err := url.Parse(apiURL)
-	if err != nil || parsed.Host == "" {
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
 		return rt
 	}
 	return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
@@ -142,6 +142,7 @@ func AddAPIURLOverride(rt http.RoundTripper, apiURL string) http.RoundTripper {
 			req.URL.Scheme = parsed.Scheme
 			req.URL.Host = parsed.Host
 			req.URL.Path = strings.TrimRight(parsed.Path, "/") + req.URL.Path
+			req.URL.RawPath = ""
 			req.Host = parsed.Host
 		}
 		return rt.RoundTrip(req)

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -372,6 +372,13 @@ func TestAddAPIURLOverride(t *testing.T) {
 			wantURL:    "https://api.github.com/repos/cli/cli",
 			wantHost:   "",
 		},
+		{
+			name:       "override URL without scheme returns passthrough",
+			apiURL:     "//proxy.example.com",
+			requestURL: "https://api.github.com/repos/cli/cli",
+			wantURL:    "https://api.github.com/repos/cli/cli",
+			wantHost:   "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -315,6 +315,136 @@ func TestHTTPClientSanitizeControlCharactersC1(t *testing.T) {
 	assert.Equal(t, "monalisa¡", issue.Author.Login)
 }
 
+func TestAddAPIURLOverride(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiURL     string
+		requestURL string
+		wantURL    string
+		wantHost   string
+	}{
+		{
+			name:       "rewrites api.github.com to override URL",
+			apiURL:     "https://proxy.example.com",
+			requestURL: "https://api.github.com/repos/cli/cli",
+			wantURL:    "https://proxy.example.com/repos/cli/cli",
+			wantHost:   "proxy.example.com",
+		},
+		{
+			name:       "rewrites api.github.com with path prefix",
+			apiURL:     "https://proxy.example.com/github",
+			requestURL: "https://api.github.com/repos/cli/cli",
+			wantURL:    "https://proxy.example.com/github/repos/cli/cli",
+			wantHost:   "proxy.example.com",
+		},
+		{
+			name:       "rewrites api.github.com with trailing slash in override",
+			apiURL:     "https://proxy.example.com/github/",
+			requestURL: "https://api.github.com/repos/cli/cli",
+			wantURL:    "https://proxy.example.com/github/repos/cli/cli",
+			wantHost:   "proxy.example.com",
+		},
+		{
+			name:       "rewrites graphql endpoint",
+			apiURL:     "https://proxy.example.com",
+			requestURL: "https://api.github.com/graphql",
+			wantURL:    "https://proxy.example.com/graphql",
+			wantHost:   "proxy.example.com",
+		},
+		{
+			name:       "does not rewrite non-github hosts",
+			apiURL:     "https://proxy.example.com",
+			requestURL: "https://example.com/api/v3/repos",
+			wantURL:    "https://example.com/api/v3/repos",
+			wantHost:   "",
+		},
+		{
+			name:       "handles case-insensitive hostname match",
+			apiURL:     "https://proxy.example.com",
+			requestURL: "https://API.GITHUB.COM/repos/cli/cli",
+			wantURL:    "https://proxy.example.com/repos/cli/cli",
+			wantHost:   "proxy.example.com",
+		},
+		{
+			name:       "invalid override URL returns passthrough",
+			apiURL:     "://not-a-url",
+			requestURL: "https://api.github.com/repos/cli/cli",
+			wantURL:    "https://api.github.com/repos/cli/cli",
+			wantHost:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotReq *http.Request
+			inner := &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+				gotReq = req
+				return &http.Response{StatusCode: http.StatusOK}, nil
+			}}
+
+			transport := AddAPIURLOverride(inner, tt.apiURL)
+
+			req, err := http.NewRequest("GET", tt.requestURL, nil)
+			require.NoError(t, err)
+
+			_, err = transport.RoundTrip(req)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantURL, gotReq.URL.String())
+			if tt.wantHost != "" {
+				assert.Equal(t, tt.wantHost, gotReq.Host)
+			}
+		})
+	}
+}
+
+func TestAddAPIURLOverrideSkipsRedirects(t *testing.T) {
+	var gotReq *http.Request
+	inner := &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}}
+
+	transport := AddAPIURLOverride(inner, "https://proxy.example.com")
+
+	// Simulate a redirect request by setting req.Response
+	req, err := http.NewRequest("GET", "https://api.github.com/repos/cli/cli", nil)
+	require.NoError(t, err)
+	req.Response = &http.Response{
+		Request: req,
+	}
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	// URL should NOT be rewritten for redirect requests
+	assert.Equal(t, "https://api.github.com/repos/cli/cli", gotReq.URL.String())
+}
+
+func TestAddAPIURLOverridePreservesAuth(t *testing.T) {
+	var gotReq *http.Request
+	inner := &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+		gotReq = req
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}}
+
+	// Build the chain: AddAuthTokenHeader → AddAPIURLOverride → inner
+	// This mirrors the real transport chain order
+	cfg := tinyConfig{"github.com:oauth_token": "MYTOKEN"}
+	transport := AddAuthTokenHeader(AddAPIURLOverride(inner, "https://proxy.example.com"), cfg)
+
+	req, err := http.NewRequest("GET", "https://api.github.com/repos/cli/cli", nil)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	// Auth header should be set (resolved from api.github.com before rewrite)
+	assert.Equal(t, "token MYTOKEN", gotReq.Header.Get("Authorization"))
+	// URL should be rewritten
+	assert.Equal(t, "https://proxy.example.com/repos/cli/cli", gotReq.URL.String())
+}
+
 type tinyConfig map[string]string
 
 func (c tinyConfig) ActiveToken(host string) (string, string) {

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -58,9 +58,11 @@ var HelpTopics = []helpTopic{
 			This is useful for routing traffic through an API proxy or gateway. For example, setting
 			%[1]sGH_API_URL=https://proxy.example.com/github%[1]s will rewrite a request from
 			%[1]shttps://api.github.com/repos/cli/cli%[1]s to %[1]shttps://proxy.example.com/github/repos/cli/cli%[1]s.
-			Authentication headers are resolved before the URL is rewritten, so existing credentials
-			for %[1]sgithub.com%[1]s continue to work. This setting only affects requests to %[1]sapi.github.com%[1]s
-			and does not apply to GitHub Enterprise Server hosts.
+			Authentication headers are resolved before the URL is rewritten, so the rewritten request
+			sent to the %[1]sGH_API_URL%[1]s host will include any resolved credentials, including the
+			%[1]sAuthorization%[1]s token. Only point this at a trusted proxy or gateway under your control.
+			This setting only affects requests to %[1]sapi.github.com%[1]s and does not apply to GitHub
+			Enterprise Server hosts.
 
 			%[1]sGH_REPO%[1]s: specify the GitHub repository in the %[1]s[HOST/]OWNER/REPO%[1]s format for commands
 			that otherwise operate on a local repository.

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -54,6 +54,14 @@ var HelpTopics = []helpTopic{
 			authenticated with, the stored credentials will be used. Otherwise, setting %[1]sGH_TOKEN%[1]s or
 			%[1]sGH_ENTERPRISE_TOKEN%[1]s is required, depending on the targeted host.
 
+			%[1]sGH_API_URL%[1]s: redirect API requests destined for %[1]sapi.github.com%[1]s to a custom base URL.
+			This is useful for routing traffic through an API proxy or gateway. For example, setting
+			%[1]sGH_API_URL=https://proxy.example.com/github%[1]s will rewrite a request from
+			%[1]shttps://api.github.com/repos/cli/cli%[1]s to %[1]shttps://proxy.example.com/github/repos/cli/cli%[1]s.
+			Authentication headers are resolved before the URL is rewritten, so existing credentials
+			for %[1]sgithub.com%[1]s continue to work. This setting only affects requests to %[1]sapi.github.com%[1]s
+			and does not apply to GitHub Enterprise Server hosts.
+
 			%[1]sGH_REPO%[1]s: specify the GitHub repository in the %[1]s[HOST/]OWNER/REPO%[1]s format for commands
 			that otherwise operate on a local repository.
 


### PR DESCRIPTION
## Summary

- Adds `GH_API_URL` environment variable that redirects all `api.github.com` requests to a custom base URL
- Enables routing `gh` API traffic through a proxy or gateway without disrupting authentication
- Only affects `github.com` requests — GitHub Enterprise Server hosts are unaffected

## Motivation

There is currently no way to route `gh` CLI API traffic through a custom proxy that needs to inspect or transform requests. `HTTPS_PROXY` uses CONNECT tunneling which is opaque. `GH_HOST` only changes the hostname for host resolution, not the API endpoint URL.

This is useful for:
- API gateways that add rate limiting, logging, or access control
- Development/testing proxies that intercept GitHub API calls
- Corporate environments that route traffic through internal proxies

## Design

A transport-level URL rewriter (`AddAPIURLOverride`) is inserted in the HTTP transport chain between `AddAuthTokenHeader` and the go-gh transport. This placement ensures:

1. **Auth works correctly**: `AddAuthTokenHeader` sees the original `api.github.com` host, resolves the token from stored credentials, and sets the `Authorization` header
2. **URL is then rewritten**: The rewriter changes scheme, host, and prepends any path prefix from the override URL
3. **All request types covered**: REST, GraphQL (Do/Mutate/Query), and `gh api` commands all go through this transport
4. **Redirects are safe**: Redirect requests (where `req.Response` is set) are not rewritten, so CDN/storage redirect URLs work normally

### Example

```bash
export GH_API_URL=https://proxy.example.com/github
gh repo view cli/cli
# Request: https://api.github.com/repos/cli/cli
# Rewritten to: https://proxy.example.com/github/repos/cli/cli
```

## Changes

- `api/http_client.go`: Added `AddAPIURLOverride` transport function and wired it into `NewHTTPClient`
- `api/http_client_test.go`: Added table-driven tests for URL rewriting, redirect skipping, and auth preservation
- `pkg/cmd/root/help_topic.go`: Documented `GH_API_URL` in the environment variables help topic

## Testing

- 9 new test cases covering: basic rewriting, path prefix handling, trailing slashes, GraphQL endpoint, non-github hosts, case-insensitive matching, invalid URLs, redirect skipping, and auth header preservation
- All existing tests continue to pass