### PR TITLE
Adds multi-stream download support to gh run download

### DIFF
--- a/pkg/cmd/run/download/download.go
+++ b/pkg/cmd/run/download/download.go
@@ -21,14 +21,17 @@ type DownloadOptions struct {
 
 	DoPrompt       bool
 	RunID          string
+	ArtifactID     int64
 	DestinationDir string
 	Names          []string
 	FilePatterns   []string
+	SingleStream   bool
 }
 
 type platform interface {
 	List(runID string) ([]shared.Artifact, error)
 	Download(url string, dir safepaths.Absolute) error
+	DownloadByID(id int64, dir safepaths.Absolute) error
 }
 
 type iprompter interface {
@@ -66,13 +69,25 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 			# Download specific artifacts across all runs in a repository
 			$ gh run download -n <name1> -n <name2>
 
+			# Download a single artifact directly by its ID
+			$ gh run download -a <artifact-id>
+
 			# Select artifacts to download interactively
 			$ gh run download
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				opts.RunID = args[0]
-			} else if len(opts.Names) == 0 &&
+			}
+			if opts.ArtifactID != 0 {
+				if opts.RunID != "" {
+					return cmdutil.FlagErrorf("--artifact-id cannot be combined with a run ID argument")
+				}
+				if len(opts.Names) > 0 || len(opts.FilePatterns) > 0 {
+					return cmdutil.FlagErrorf("--artifact-id cannot be combined with --name or --pattern")
+				}
+			} else if len(args) == 0 &&
+				len(opts.Names) == 0 &&
 				len(opts.FilePatterns) == 0 &&
 				opts.IO.CanPrompt() {
 				opts.DoPrompt = true
@@ -87,8 +102,9 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 				return err
 			}
 			opts.Platform = &apiPlatform{
-				client: httpClient,
-				repo:   baseRepo,
+				client:       httpClient,
+				repo:         baseRepo,
+				singleStream: opts.SingleStream,
 			}
 
 			if runF != nil {
@@ -101,11 +117,22 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 	cmd.Flags().StringVarP(&opts.DestinationDir, "dir", "D", ".", "The directory to download artifacts into")
 	cmd.Flags().StringArrayVarP(&opts.Names, "name", "n", nil, "Download artifacts that match any of the given names")
 	cmd.Flags().StringArrayVarP(&opts.FilePatterns, "pattern", "p", nil, "Download artifacts that match a glob pattern")
+	cmd.Flags().Int64VarP(&opts.ArtifactID, "artifact-id", "a", 0, "Download a single artifact by its numeric ID")
+	cmd.Flags().BoolVar(&opts.SingleStream, "single-stream", false, "Disable parallel chunked download and use a single HTTP connection per artifact")
 
 	return cmd
 }
 
 func runDownload(opts *DownloadOptions) error {
+	absoluteDestinationDir, err := safepaths.ParseAbsolute(opts.DestinationDir)
+	if err != nil {
+		return fmt.Errorf("error parsing destination directory: %w", err)
+	}
+
+	if opts.ArtifactID != 0 {
+		return opts.Platform.DownloadByID(opts.ArtifactID, absoluteDestinationDir)
+	}
+
 	opts.IO.StartProgressIndicator()
 	artifacts, err := opts.Platform.List(opts.RunID)
 	opts.IO.StopProgressIndicator()
@@ -156,11 +183,6 @@ func runDownload(opts *DownloadOptions) error {
 	// track downloaded artifacts and avoid re-downloading any of the same name, isolate if multiple artifacts
 	downloaded := set.NewStringSet()
 	isolateArtifacts := isolateArtifacts(wantNames, wantPatterns)
-
-	absoluteDestinationDir, err := safepaths.ParseAbsolute(opts.DestinationDir)
-	if err != nil {
-		return fmt.Errorf("error parsing destination directory: %w", err)
-	}
 
 	for _, a := range artifacts {
 		if a.Expired {

--- a/pkg/cmd/run/download/download_test.go
+++ b/pkg/cmd/run/download/download_test.go
@@ -96,6 +96,41 @@ func Test_NewCmdDownload(t *testing.T) {
 				DestinationDir: ".",
 			},
 		},
+		{
+			name:  "single stream flag",
+			args:  "2345 --single-stream",
+			isTTY: true,
+			want: DownloadOptions{
+				RunID:          "2345",
+				DoPrompt:       false,
+				Names:          []string(nil),
+				DestinationDir: ".",
+				SingleStream:   true,
+			},
+		},
+		{
+			name:  "artifact id flag",
+			args:  "-a 6384611797",
+			isTTY: true,
+			want: DownloadOptions{
+				ArtifactID:     6384611797,
+				DoPrompt:       false,
+				Names:          []string(nil),
+				DestinationDir: ".",
+			},
+		},
+		{
+			name:    "artifact id with run id is rejected",
+			args:    "2345 -a 6384611797",
+			isTTY:   true,
+			wantErr: "--artifact-id cannot be combined with a run ID argument",
+		},
+		{
+			name:    "artifact id with name is rejected",
+			args:    "-a 6384611797 -n large",
+			isTTY:   true,
+			wantErr: "--artifact-id cannot be combined with --name or --pattern",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -142,6 +177,8 @@ func Test_NewCmdDownload(t *testing.T) {
 			assert.Equal(t, tt.want.FilePatterns, opts.FilePatterns)
 			assert.Equal(t, tt.want.DestinationDir, opts.DestinationDir)
 			assert.Equal(t, tt.want.DoPrompt, opts.DoPrompt)
+			assert.Equal(t, tt.want.SingleStream, opts.SingleStream)
+			assert.Equal(t, tt.want.ArtifactID, opts.ArtifactID)
 		})
 	}
 }
@@ -157,7 +194,8 @@ type testArtifact struct {
 }
 
 type fakePlatform struct {
-	runs []run
+	runs      []run
+	byIDFiles map[int64][]string
 }
 
 func (f *fakePlatform) List(runID string) ([]shared.Artifact, error) {
@@ -207,6 +245,23 @@ func (f *fakePlatform) Download(url string, dir safepaths.Absolute) error {
 	}
 
 	return errors.New("no artifact matches the provided URL")
+}
+
+func (f *fakePlatform) DownloadByID(id int64, dir safepaths.Absolute) error {
+	if err := os.MkdirAll(dir.String(), 0755); err != nil {
+		return err
+	}
+	files, ok := f.byIDFiles[id]
+	if !ok {
+		return fmt.Errorf("no artifact with id %d", id)
+	}
+	for _, file := range files {
+		path := filepath.Join(dir.String(), file)
+		if err := os.WriteFile(path, []byte{}, 0600); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func Test_runDownload(t *testing.T) {
@@ -710,6 +765,12 @@ func Test_runDownload(t *testing.T) {
 			},
 			expectedFiles: []string{},
 			wantErr:       "error downloading ..: would result in path traversal",
+		},
+		{
+			name:          "download by artifact id",
+			opts:          DownloadOptions{ArtifactID: 6384611797},
+			platform:      &fakePlatform{byIDFiles: map[int64][]string{6384611797: {"result.txt"}}},
+			expectedFiles: []string{"result.txt"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/run/download/http.go
+++ b/pkg/cmd/run/download/http.go
@@ -2,21 +2,46 @@ package download
 
 import (
 	"archive/zip"
+	"context"
+	"crypto/md5" //nolint:gosec // MD5 is used only for server-supplied integrity check, not for security
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"runtime"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safepaths"
 	ghzip "github.com/cli/cli/v2/internal/zip"
 	"github.com/cli/cli/v2/pkg/cmd/run/shared"
 )
 
+// maxPreallocBytes caps the size we will pre-allocate for a chunked download
+// to guard against a server supplying a fraudulent Content-Length.
+const maxPreallocBytes = int64(2 * 1024 * 1024 * 1024) // 2 GiB
+
+// chunkThreshold is the minimum Content-Length above which a parallel chunked
+// download is attempted. Declared as a var so tests can override it.
+var chunkThreshold = int64(32 * 1024 * 1024) // 32 MiB
+
+// chunkSize is the byte length of each Range GET request.
+var chunkSize = int64(16 * 1024 * 1024) // 16 MiB
+
+// chunkConcurrency is the maximum number of in-flight Range GET goroutines.
+// Derived from runtime.NumCPU()*2 (keeping goroutines runnable while siblings
+// block on I/O), capped at 10 to avoid overwhelming intermediate proxies.
+var chunkConcurrency = min(runtime.NumCPU()*2, 10)
+
 type apiPlatform struct {
-	client *http.Client
-	repo   ghrepo.Interface
+	client       *http.Client
+	repo         ghrepo.Interface
+	singleStream bool
 }
 
 func (p *apiPlatform) List(runID string) ([]shared.Artifact, error) {
@@ -24,10 +49,176 @@ func (p *apiPlatform) List(runID string) ([]shared.Artifact, error) {
 }
 
 func (p *apiPlatform) Download(url string, dir safepaths.Absolute) error {
-	return downloadArtifact(p.client, url, dir)
+	return downloadArtifact(p.client, url, dir, p.singleStream)
 }
 
-func downloadArtifact(httpClient *http.Client, url string, destDir safepaths.Absolute) error {
+// DownloadByID downloads the artifact with the given ID without requiring a
+// prior listing call. It constructs the REST download URL from the repo and
+// artifact ID and then delegates to the same chunked/single-stream path as
+// Download.
+func (p *apiPlatform) DownloadByID(id int64, dir safepaths.Absolute) error {
+	url := fmt.Sprintf("%srepos/%s/%s/actions/artifacts/%d/zip",
+		ghinstance.RESTPrefix(p.repo.RepoHost()),
+		p.repo.RepoOwner(), p.repo.RepoName(), id)
+	return downloadArtifact(p.client, url, dir, p.singleStream)
+}
+
+func downloadArtifact(httpClient *http.Client, url string, destDir safepaths.Absolute, singleStream bool) error {
+	if !singleStream {
+		err := downloadArtifactChunked(httpClient, url, destDir)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, errNoRangeSupport) {
+			return err
+		}
+	}
+	return downloadArtifactSingleStream(httpClient, url, destDir)
+}
+
+// errNoRangeSupport is returned by downloadArtifactChunked when the server
+// does not advertise Accept-Ranges: bytes or the artifact is below the
+// chunking threshold. It is never surfaced to the end user.
+var errNoRangeSupport = errors.New("server does not support range requests or artifact is below chunking threshold")
+
+func downloadArtifactChunked(httpClient *http.Client, url string, destDir safepaths.Absolute) error {
+	ctx := context.Background()
+
+	headReq, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return errNoRangeSupport
+	}
+	headResp, err := httpClient.Do(headReq)
+	if err != nil {
+		return errNoRangeSupport
+	}
+	_, _ = io.Copy(io.Discard, headResp.Body)
+	_ = headResp.Body.Close()
+
+	if headResp.Header.Get("Accept-Ranges") != "bytes" {
+		return errNoRangeSupport
+	}
+
+	contentLength := headResp.ContentLength
+	if contentLength <= 0 || contentLength < chunkThreshold {
+		return errNoRangeSupport
+	}
+
+	// Reject unreasonably large Content-Length values before pre-allocating.
+	if contentLength > maxPreallocBytes {
+		return errNoRangeSupport
+	}
+
+	expectedMD5 := headResp.Header.Get("Content-MD5")
+
+	tmpfile, err := os.CreateTemp("", "gh-artifact.*.zip")
+	if err != nil {
+		return fmt.Errorf("error initializing temporary file: %w", err)
+	}
+	defer func() {
+		_ = tmpfile.Close()
+		_ = os.Remove(tmpfile.Name())
+	}()
+
+	// Pre-allocate to the exact final size so concurrent WriteAt calls land in
+	// valid, non-overlapping regions.
+	if err := tmpfile.Truncate(contentLength); err != nil {
+		return fmt.Errorf("error pre-sizing temporary file: %w", err)
+	}
+
+	numChunks := (contentLength + chunkSize - 1) / chunkSize
+	g, gCtx := errgroup.WithContext(ctx)
+	sem := make(chan struct{}, chunkConcurrency)
+
+	for i := range numChunks {
+		start := i * chunkSize
+		end := start + chunkSize - 1
+		if end >= contentLength {
+			end = contentLength - 1
+		}
+		g.Go(func() error {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			return downloadChunk(gCtx, httpClient, url, tmpfile, start, end)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Verify whole-file MD5 when the server supplied one (Content-MD5 header,
+	// base64-encoded, per RFC 1864).
+	if expectedMD5 != "" {
+		if err := verifyMD5(tmpfile, contentLength, expectedMD5); err != nil {
+			return err
+		}
+	}
+
+	zipfile, err := zip.NewReader(tmpfile, contentLength)
+	if err != nil {
+		return fmt.Errorf("error extracting zip archive: %w", err)
+	}
+	return ghzip.ExtractZip(zipfile, destDir)
+}
+
+func downloadChunk(ctx context.Context, httpClient *http.Client, url string, out *os.File, start, end int64) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("error building range request: %w", err)
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error fetching bytes=%d-%d: %w", start, end, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("range request for bytes=%d-%d returned unexpected status %s", start, end, resp.Status)
+	}
+
+	if err := validateContentRange(resp.Header.Get("Content-Range"), start, end); err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(io.NewOffsetWriter(out, start), resp.Body); err != nil {
+		return fmt.Errorf("error writing bytes=%d-%d: %w", start, end, err)
+	}
+	return nil
+}
+
+// validateContentRange checks that the Content-Range response header matches
+// the byte range we requested, guarding against a server returning unexpected
+// ranges without signalling an error.
+func validateContentRange(contentRange string, start, end int64) error {
+	if contentRange == "" {
+		return nil // server omitted header; treat as valid
+	}
+	expected := fmt.Sprintf("bytes %d-%d/", start, end)
+	if len(contentRange) < len(expected) || contentRange[:len(expected)] != expected {
+		return fmt.Errorf("Content-Range mismatch: requested bytes=%d-%d but got %q", start, end, contentRange)
+	}
+	return nil
+}
+
+func verifyMD5(f *os.File, size int64, expectedBase64 string) error {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("error seeking temp file for MD5 check: %w", err)
+	}
+	h := md5.New() //nolint:gosec
+	if _, err := io.Copy(h, io.LimitReader(f, size)); err != nil {
+		return fmt.Errorf("error computing MD5: %w", err)
+	}
+	actual := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	if actual != expectedBase64 {
+		return fmt.Errorf("artifact integrity check failed: Content-MD5 mismatch (expected %s, got %s)", expectedBase64, actual)
+	}
+	return nil
+}
+
+func downloadArtifactSingleStream(httpClient *http.Client, url string, destDir safepaths.Absolute) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err

--- a/pkg/cmd/run/download/http_test.go
+++ b/pkg/cmd/run/download/http_test.go
@@ -1,12 +1,19 @@
 package download
 
 import (
+	"bytes"
+	"crypto/md5" //nolint:gosec
+	"encoding/base64"
+	"errors"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/safepaths"
@@ -104,4 +111,288 @@ func Test_Download(t *testing.T) {
 		filepath.Join("artifact", "src", "main.go"),
 		filepath.Join("artifact", "src", "util.go"),
 	}, paths)
+}
+
+func Test_DownloadByID(t *testing.T) {
+	tmpDir := t.TempDir()
+	destDir, err := safepaths.ParseAbsolute(filepath.Join(tmpDir, "artifact"))
+	require.NoError(t, err)
+
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "repos/OWNER/REPO/actions/artifacts/6384611797/zip"),
+		httpmock.FileResponse("./fixtures/myproject.zip"))
+
+	p := &apiPlatform{
+		client:       &http.Client{Transport: reg},
+		repo:         ghrepo.New("OWNER", "REPO"),
+		singleStream: true, // fixture is small; avoid HEAD round-trip in test
+	}
+	require.NoError(t, p.DownloadByID(6384611797, destDir))
+	assert.Equal(t, expectedArtifactPaths("artifact"), collectPaths(t, destDir.String()))
+}
+
+func expectedArtifactPaths(destDir string) []string {
+	return []string{
+		destDir + "/",
+		filepath.Join(destDir, "bin") + "/",
+		filepath.Join(destDir, "bin", "myexe"),
+		filepath.Join(destDir, "readme.md"),
+		filepath.Join(destDir, "src") + "/",
+		filepath.Join(destDir, "src", "main.go"),
+		filepath.Join(destDir, "src", "util.go"),
+	}
+}
+
+func collectPaths(t *testing.T, root string) []string {
+	t.Helper()
+	base := filepath.Dir(root)
+	var paths []string
+	require.NoError(t, filepath.Walk(base, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == base {
+			return nil
+		}
+		rel := strings.TrimPrefix(p, base+string(filepath.Separator))
+		if info.IsDir() {
+			rel += "/"
+		} else if info.Mode()&0111 != 0 {
+			rel += "(X)"
+		}
+		paths = append(paths, rel)
+		return nil
+	}))
+	sort.Strings(paths)
+	return paths
+}
+
+func fixtureData(t *testing.T) []byte {
+	t.Helper()
+	data, err := os.ReadFile("./fixtures/myproject.zip")
+	require.NoError(t, err)
+	return data
+}
+
+func fixtureContentMD5(t *testing.T) string {
+	t.Helper()
+	data := fixtureData(t)
+	h := md5.New() //nolint:gosec
+	_, _ = h.Write(data)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func newRangeServer(fileData []byte, contentMD5 string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if contentMD5 != "" {
+			w.Header().Set("Content-MD5", contentMD5)
+		}
+		http.ServeContent(w, r, "artifact.zip", time.Time{}, bytes.NewReader(fileData))
+	}))
+}
+
+func newNoRangeServer(fileData []byte) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(fileData)))
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Content-Type", "application/zip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(fileData)
+	}))
+}
+
+func withChunkParams(t *testing.T, threshold, size int64, concurrency int) {
+	t.Helper()
+	origThreshold, origSize, origConcurrency := chunkThreshold, chunkSize, chunkConcurrency
+	chunkThreshold = threshold
+	chunkSize = size
+	chunkConcurrency = concurrency
+	t.Cleanup(func() {
+		chunkThreshold = origThreshold
+		chunkSize = origSize
+		chunkConcurrency = origConcurrency
+	})
+}
+
+func Test_validateContentRange(t *testing.T) {
+	tests := []struct {
+		name         string
+		contentRange string
+		start        int64
+		end          int64
+		wantErr      bool
+	}{
+		{name: "matching range", contentRange: "bytes 0-999/5000", start: 0, end: 999, wantErr: false},
+		{name: "empty header is allowed", contentRange: "", start: 0, end: 999, wantErr: false},
+		{name: "mismatched start", contentRange: "bytes 100-999/5000", start: 0, end: 999, wantErr: true},
+		{name: "mismatched end", contentRange: "bytes 0-500/5000", start: 0, end: 999, wantErr: true},
+		{name: "malformed header", contentRange: "invalid", start: 0, end: 999, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateContentRange(tt.contentRange, tt.start, tt.end)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_downloadChunk(t *testing.T) {
+	const content = "0123456789ABCDEFGHIJ" // 20 bytes
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeContent(w, r, "data.bin", time.Time{}, strings.NewReader(content))
+	}))
+	defer srv.Close()
+
+	tmpfile, err := os.CreateTemp(t.TempDir(), "chunk-*.bin")
+	require.NoError(t, err)
+	require.NoError(t, tmpfile.Truncate(20))
+
+	require.NoError(t, downloadChunk(t.Context(), &http.Client{}, srv.URL, tmpfile, 5, 14))
+
+	require.NoError(t, tmpfile.Close())
+	got, err := os.ReadFile(tmpfile.Name())
+	require.NoError(t, err)
+	assert.Equal(t, "56789ABCDE", string(got[5:15]))
+}
+
+func Test_downloadArtifactChunked_noRangeSupport(t *testing.T) {
+	srv := newNoRangeServer(fixtureData(t))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	destDir, err := safepaths.ParseAbsolute(filepath.Join(tmpDir, "out"))
+	require.NoError(t, err)
+
+	err = downloadArtifactChunked(&http.Client{}, srv.URL, destDir)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNoRangeSupport))
+}
+
+func Test_downloadArtifactChunked_smallFile(t *testing.T) {
+	withChunkParams(t, 1024*1024*1024, chunkSize, chunkConcurrency)
+
+	srv := newRangeServer(fixtureData(t), "")
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	destDir, err := safepaths.ParseAbsolute(filepath.Join(tmpDir, "out"))
+	require.NoError(t, err)
+
+	err = downloadArtifactChunked(&http.Client{}, srv.URL, destDir)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errNoRangeSupport))
+}
+
+func Test_downloadArtifactChunked_happyPath(t *testing.T) {
+	data := fixtureData(t)
+	// Lower thresholds so the 1710-byte fixture triggers chunking.
+	// chunk size 600 → 3 chunks: [0-599], [600-1199], [1200-1709].
+	withChunkParams(t, 100, 600, 4)
+
+	var rangeRequests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Range") != "" {
+			rangeRequests++
+		}
+		http.ServeContent(w, r, "artifact.zip", time.Time{}, bytes.NewReader(data))
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	destDir, err := safepaths.ParseAbsolute(filepath.Join(tmpDir, "artifact"))
+	require.NoError(t, err)
+
+	require.NoError(t, downloadArtifactChunked(&http.Client{}, srv.URL, destDir))
+	assert.Equal(t, 3, rangeRequests, "expected 3 range requests for a 1710-byte file with 600-byte chunks")
+
+	assert.Equal(t, expectedArtifactPaths("artifact"), collectPaths(t, destDir.String()))
+}
+
+func Test_downloadArtifactChunked_md5Valid(t *testing.T) {
+	data := fixtureData(t)
+	withChunkParams(t, 100, 600, 4)
+
+	srv := newRangeServer(data, fixtureContentMD5(t))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	destDir, err := safepaths.ParseAbsolute(filepath.Join(tmpDir, "artifact"))
+	require.NoError(t, err)
+
+	require.NoError(t, downloadArtifactChunked(&http.Client{}, srv.URL, destDir))
+}
+
+func Test_downloadArtifactChunked_md5Mismatch(t *testing.T) {
+	data := fixtureData(t)
+	withChunkParams(t, 100, 600, 4)
+
+	srv := newRangeServer(data, "AAAAAAAAAAAAAAAAAAAAAA==") // wrong MD5
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	destDir, err := safepaths.ParseAbsolute(filepath.Join(tmpDir, "artifact"))
+	require.NoError(t, err)
+
+	err = downloadArtifactChunked(&http.Client{}, srv.URL, destDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "integrity check failed")
+}
+
+func Test_downloadArtifactSingleStream(t *testing.T) {
+	data := fixtureData(t)
+	srv := newNoRangeServer(data)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	destDir, err := safepaths.ParseAbsolute(filepath.Join(tmpDir, "artifact"))
+	require.NoError(t, err)
+
+	require.NoError(t, downloadArtifactSingleStream(&http.Client{}, srv.URL, destDir))
+	assert.Equal(t, expectedArtifactPaths("artifact"), collectPaths(t, destDir.String()))
+}
+
+func Test_downloadArtifact_singleStreamForced(t *testing.T) {
+	data := fixtureData(t)
+
+	var headSeen bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			headSeen = true
+		}
+		http.ServeContent(w, r, "artifact.zip", time.Time{}, bytes.NewReader(data))
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	destDir, err := safepaths.ParseAbsolute(filepath.Join(tmpDir, "artifact"))
+	require.NoError(t, err)
+
+	require.NoError(t, downloadArtifact(&http.Client{}, srv.URL, destDir, true))
+	assert.False(t, headSeen, "downloadArtifact with singleStream=true must not issue a HEAD request")
+	assert.Equal(t, expectedArtifactPaths("artifact"), collectPaths(t, destDir.String()))
+}
+
+func Test_downloadArtifact_chunkedFallsBack(t *testing.T) {
+	data := fixtureData(t)
+	withChunkParams(t, 100, 600, 4)
+
+	srv := newNoRangeServer(data)
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	destDir, err := safepaths.ParseAbsolute(filepath.Join(tmpDir, "artifact"))
+	require.NoError(t, err)
+
+	require.NoError(t, downloadArtifact(&http.Client{}, srv.URL, destDir, false))
+	assert.Equal(t, expectedArtifactPaths("artifact"), collectPaths(t, destDir.String()))
 }


### PR DESCRIPTION
### What is changing (detailed description of that it does)?

This PR will implement a multi-stream download approach for GitHub Actions workflow run artifacts.

Downloading larger artifacts over a single connection/single-stream isn't the optimal approach for download performance. Downloading with smaller chunks may allow for better handle of congestion and better use of throughput. 

This approach is the approach adopted by official download tools - such as Azure azcopy - offered by Blob Storage providers and is supported by the GitHub Actions Artifacts feature - or rather by the Blob Storage service it uses.

Additionally, this PR also adds the capability to download by artifact id.

Fixes: #13154

### Design decisions

- The proposed solution verifies if the remote server supports the multi-stream approach and if it doesn't, it falls back to the single-stream download
- The proposed solution allows the gh cli end user to explicitly disable multi-stream downloads and force single-stream downloads
- A conservative approach is used to determine the number of parallel streams based on the number of vCPUs available on the system with a cap to prevent potential overwhelming of proxies or NAT devices.

### Testing

- Additional unit tests were added to cover the changes introduced
- Benchmarked a 100MB artifact download 
