### PR TITLE
URL-encode parentPath in skills discovery API call

### DIFF
--- a/internal/skills/discovery/discovery.go
+++ b/internal/skills/discovery/discovery.go
@@ -491,7 +491,7 @@ func DiscoverSkillByPath(client *api.Client, host, owner, repo, commitSHA, skill
 	}
 
 	parentPath := path.Dir(skillPath)
-	apiPath := fmt.Sprintf("repos/%s/%s/contents/%s?ref=%s", url.PathEscape(owner), url.PathEscape(repo), parentPath, commitSHA)
+	apiPath := fmt.Sprintf("repos/%s/%s/contents/%s?ref=%s", url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(parentPath), commitSHA)
 
 	var contents []struct {
 		Name string `json:"name"`

--- a/internal/skills/discovery/discovery_test.go
+++ b/internal/skills/discovery/discovery_test.go
@@ -699,7 +699,7 @@ func TestDiscoverSkillByPath(t *testing.T) {
 			skillPath: "skills/monalisa/issue-triage",
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/skills/monalisa"),
+					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/skills%2Fmonalisa"),
 					httpmock.JSONResponse([]map[string]interface{}{
 						{"name": "issue-triage", "path": "skills/monalisa/issue-triage", "sha": "tree-sha", "type": "dir"},
 					}))
@@ -719,6 +719,31 @@ func TestDiscoverSkillByPath(t *testing.T) {
 			},
 			wantName: "issue-triage",
 			wantNS:   "monalisa",
+		},
+		{
+			name:      "parent path with spaces is URL encoded",
+			skillPath: "my skills/code-review",
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/monalisa/octocat-skills/contents/my%20skills"),
+					httpmock.JSONResponse([]map[string]interface{}{
+						{"name": "code-review", "path": "my skills/code-review", "sha": "tree-sha", "type": "dir"},
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree-sha"),
+					httpmock.JSONResponse(map[string]interface{}{
+						"sha": "tree-sha", "truncated": false,
+						"tree": []map[string]interface{}{
+							{"path": "SKILL.md", "type": "blob", "sha": "blob-sha"},
+						},
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/blob-sha"),
+					httpmock.JSONResponse(map[string]interface{}{
+						"sha": "blob-sha", "encoding": "base64", "content": "IyBTa2lsbA==",
+					}))
+			},
+			wantName: "code-review",
 		},
 		{
 			name:      "strips trailing SKILL.md from path",


### PR DESCRIPTION
Stacked on #13165.

The `parentPath` parameter in the contents API path (`DiscoverSkillByPath`) was not URL-encoded, which would cause failures when paths contain spaces or other special characters.

### Changes
- Apply `url.PathEscape()` to `parentPath` in the `fmt.Sprintf` call in `discovery.go`, consistent with all other API path construction in the file
- `commitSHA` is left unescaped since SHAs are hex-only and never need encoding
- Update the existing test stub to use the escaped path
- Add a new test case (`parent path with spaces is URL encoded`) that exercises a path with spaces

Fixes the review comment from #13165.