### PR TITLE
Disable auth check for local-only skill flags

### DIFF
--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -199,6 +199,7 @@ func NewCmdInstall(f *cmdutil.Factory, runF func(*InstallOptions) error) *cobra.
 	cmd.Flags().StringVar(&opts.Dir, "dir", "", "Install to a custom directory (overrides --agent and --scope)")
 	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Overwrite existing skills without prompting")
 	cmd.Flags().BoolVar(&opts.FromLocal, "from-local", false, "Treat the argument as a local directory path instead of a repository")
+	cmdutil.DisableAuthCheckFlag(cmd.Flags().Lookup("from-local"))
 
 	return cmd
 }


### PR DESCRIPTION
Stacked on #13165.

Adds `cmdutil.DisableAuthCheckFlag` for two flags that don't require authentication:

- **`--from-local`** on `gh skill install` — installs from a local directory, no GitHub API calls needed
- **`--dry-run`** on `gh skill publish` — validates locally without publishing

This follows the same pattern used by `attestation verify` for its `--bundle` flag ([verify.go#L231](https://github.com/cli/cli/blob/a6f6ab330f4e21b8ae2e87c3409c79a421fdebd1/pkg/cmd/attestation/verify/verify.go#L231)). Auth is only skipped when the flag is explicitly passed by the user; all other flows retain their auth requirements.