### PR TITLE
Disable auth check for `gh extension install`

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -415,6 +415,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 			}
 			cmd.Flags().BoolVar(&forceFlag, "force", false, "Force upgrade extension, or ignore if latest already installed")
 			cmd.Flags().StringVar(&pinFlag, "pin", "", "Pin extension to a release tag or commit ref")
+			cmdutil.DisableAuthCheck(cmd)
 			return cmd
 		}(),
 		func() *cobra.Command {


### PR DESCRIPTION
Remove the authentication gate for `gh extension install`, allowing users to install extensions without being logged in.

## Motivation

The global auth check blocks `gh extension install` from running at all when a user isn't authenticated. This is unnecessarily restrictive since installing extensions from public repositories or local directories doesn't inherently require authentication.

This is especially painful in Codespaces environments where SAML-scoped tokens trigger 403 errors when installing public extensions (#6675). Users currently have to `unset GITHUB_TOKEN` as a workaround. 

## Why this is OK

Look at what `gh aw` needs to do today to make extension installation reliable: https://github.com/github/gh-aw/blob/main/install-gh-aw.sh

What this says is that extension installation is going to happen unauthenticated whether we make it easier or not. We might as well make it easier and keep people installing through our core commands.

Related: #2680 (allow certain requests to be unauthenticated).

## What this changes

Adds `cmdutil.DisableAuthCheck` to the `extension install` subcommand, bypassing the pre-execution login gate. This does **not** make unauthenticated API requests all the time. If a token is available it will still be used. It simply removes the requirement to be logged in before the command can run.