### PR TITLE
Address post-merge review feedback for skills commands

### DIFF
--- a/internal/skills/discovery/discovery_test.go
+++ b/internal/skills/discovery/discovery_test.go
@@ -925,21 +925,21 @@ func TestMatchesSkillPath(t *testing.T) {
 
 func TestMatchSkillPath(t *testing.T) {
 	tests := []struct {
-		testName      string
+		name          string
 		path          string
 		wantName      string
 		wantNamespace string
 	}{
-		{testName: "skills convention", path: "skills/code-review/SKILL.md", wantName: "code-review", wantNamespace: ""},
-		{testName: "namespaced convention", path: "skills/monalisa/issue-triage/SKILL.md", wantName: "issue-triage", wantNamespace: "monalisa"},
-		{testName: "plugins convention", path: "plugins/hubot/skills/pr-summary/SKILL.md", wantName: "pr-summary", wantNamespace: "hubot"},
-		{testName: "non-skill file", path: "README.md", wantName: "", wantNamespace: ""},
-		{testName: "same name different namespace 1", path: "skills/kynan/commit/SKILL.md", wantName: "commit", wantNamespace: "kynan"},
-		{testName: "same name different namespace 2", path: "skills/will/commit/SKILL.md", wantName: "commit", wantNamespace: "will"},
-		{testName: "root convention", path: "my-skill/SKILL.md", wantName: "my-skill", wantNamespace: ""},
+		{name: "skills convention", path: "skills/code-review/SKILL.md", wantName: "code-review", wantNamespace: ""},
+		{name: "namespaced convention", path: "skills/monalisa/issue-triage/SKILL.md", wantName: "issue-triage", wantNamespace: "monalisa"},
+		{name: "plugins convention", path: "plugins/hubot/skills/pr-summary/SKILL.md", wantName: "pr-summary", wantNamespace: "hubot"},
+		{name: "non-skill file", path: "README.md", wantName: "", wantNamespace: ""},
+		{name: "same name different namespace 1", path: "skills/kynan/commit/SKILL.md", wantName: "commit", wantNamespace: "kynan"},
+		{name: "same name different namespace 2", path: "skills/will/commit/SKILL.md", wantName: "commit", wantNamespace: "will"},
+		{name: "root convention", path: "my-skill/SKILL.md", wantName: "my-skill", wantNamespace: ""},
 	}
 	for _, tt := range tests {
-		t.Run(tt.testName, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			name, namespace := MatchSkillPath(tt.path)
 			assert.Equal(t, tt.wantName, name)
 			assert.Equal(t, tt.wantNamespace, namespace)

--- a/pkg/cmd/skills/publish/publish.go
+++ b/pkg/cmd/skills/publish/publish.go
@@ -42,8 +42,7 @@ type PublishOptions struct {
 	DryRun bool
 	Tag    string
 
-	client *api.Client // injectable for tests; nil means use factory
-	host   string      // resolved from config in production
+	host string // resolved from config in production
 }
 
 // publishDiagnostic is a single validation finding.
@@ -178,11 +177,10 @@ func publishRun(opts *PublishOptions) error {
 
 	canPrompt := opts.IO.CanPrompt()
 
-	// Use injected client or create one from the factory HttpClient.
-	// Initialization is deferred until after local validation so that
+	// Client initialization is deferred until after local validation so that
 	// simple errors (missing skills/, bad SKILL.md, etc.) are reported
 	// without requiring an HTTP client.
-	client := opts.client
+	var client *api.Client
 	host := opts.host
 
 	var diagnostics []publishDiagnostic
@@ -343,14 +341,11 @@ func publishRun(opts *PublishOptions) error {
 	hasTopic := false
 	var existingTags []tagEntry
 	if owner != "" && repo != "" {
-		// Create API client from factory if not already injected (tests inject directly).
-		if client == nil {
-			httpClient, err := opts.HttpClient()
-			if err != nil {
-				return err
-			}
-			client = api.NewClientFromHTTP(httpClient)
+		httpClient, err := opts.HttpClient()
+		if err != nil {
+			return err
 		}
+		client = api.NewClientFromHTTP(httpClient)
 
 		if host == "" && repoInfo != nil {
 			host = repoInfo.Repo.RepoHost()
@@ -658,10 +653,11 @@ func ensurePushed(opts *PublishOptions, dir, remoteName string) error {
 	}
 
 	ref := fmt.Sprintf("HEAD:refs/heads/%s", currentBranch)
-	fmt.Fprintf(opts.IO.ErrOut, "%s Pushing %s to %s\n", cs.SuccessIcon(), currentBranch, remoteName)
+	fmt.Fprintf(opts.IO.ErrOut, "Pushing %s to %s...\n", currentBranch, remoteName)
 	if err := gitClient.Push(ctx, remoteName, ref); err != nil {
 		return fmt.Errorf("failed to push branch %s: %w", currentBranch, err)
 	}
+	fmt.Fprintf(opts.IO.ErrOut, "%s Pushed %s to %s\n", cs.SuccessIcon(), currentBranch, remoteName)
 
 	return nil
 }
@@ -924,7 +920,9 @@ type gitHubRemote struct {
 }
 
 // detectGitHubRemote attempts to detect the GitHub owner/repo from git remotes
-// in the given directory.
+// in the given directory. Remotes are tried in the order returned by
+// gitClient.Remotes (upstream > github > origin > rest), so the first
+// GitHub-pointing remote wins.
 func detectGitHubRemote(gitClient *git.Client, dir string) (*gitHubRemote, error) {
 	if gitClient == nil {
 		return nil, nil
@@ -933,26 +931,11 @@ func detectGitHubRemote(gitClient *git.Client, dir string) (*gitHubRemote, error
 	dirClient := gitClient.Copy()
 	dirClient.RepoDir = dir
 
-	// Try origin first
-	if url, err := dirClient.RemoteURL(context.Background(), "origin"); err == nil {
-		repo, parseErr := parseGitHubURL(url)
-		if parseErr != nil {
-			return nil, parseErr
-		}
-		if repo != nil {
-			return &gitHubRemote{Repo: repo, RemoteName: "origin"}, nil
-		}
-	}
-
-	// Fall back to any remote that points to GitHub
 	remotes, err := dirClient.Remotes(context.Background())
 	if err != nil {
 		return nil, nil //nolint:nilerr // failing to list remotes is not an error; it just means no repo detected
 	}
 	for _, r := range remotes {
-		if r.Name == "origin" {
-			continue
-		}
 		if url, err := dirClient.RemoteURL(context.Background(), r.Name); err == nil {
 			repo, parseErr := parseGitHubURL(url)
 			if parseErr != nil {

--- a/pkg/cmd/skills/publish/publish_test.go
+++ b/pkg/cmd/skills/publish/publish_test.go
@@ -161,11 +161,11 @@ func TestPublishRun_UnsupportedHost(t *testing.T) {
 	ios, _, _, _ := iostreams.Test()
 	initGitRepo(t, dir, map[string]string{"origin": "https://github.com/monalisa/skills-repo.git"})
 	err := publishRun(&PublishOptions{
-		IO:        ios,
-		Dir:       dir,
-		GitClient: &git.Client{},
+		IO:         ios,
+		Dir:        dir,
+		GitClient:  &git.Client{},
 		HttpClient: func() (*http.Client, error) { return &http.Client{}, nil },
-		host:      "acme.ghes.com",
+		host:       "acme.ghes.com",
 	})
 	require.ErrorContains(t, err, "supports only github.com")
 }
@@ -285,12 +285,12 @@ func TestPublishRun(t *testing.T) {
 			opts: func(ios *iostreams.IOStreams, dir string, reg *httpmock.Registry) *PublishOptions {
 				t.Helper()
 				return &PublishOptions{
-					IO:        ios,
-					Dir:       dir,
-					DryRun:    true,
-					GitClient: &git.Client{},
+					IO:         ios,
+					Dir:        dir,
+					DryRun:     true,
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "1 skill(s) validated successfully",
@@ -322,12 +322,12 @@ func TestPublishRun(t *testing.T) {
 			opts: func(ios *iostreams.IOStreams, dir string, reg *httpmock.Registry) *PublishOptions {
 				t.Helper()
 				return &PublishOptions{
-					IO:        ios,
-					Dir:       dir,
-					DryRun:    true,
-					GitClient: &git.Client{},
+					IO:         ios,
+					Dir:        dir,
+					DryRun:     true,
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "1 skill(s) validated successfully",
@@ -356,12 +356,12 @@ func TestPublishRun(t *testing.T) {
 					"origin": "https://github.com/monalisa/skills-repo.git",
 				})
 				return &PublishOptions{
-					IO:        ios,
-					Dir:       dir,
-					DryRun:    true,
-					GitClient: &git.Client{},
+					IO:         ios,
+					Dir:        dir,
+					DryRun:     true,
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "1 skill(s) validated successfully",
@@ -415,9 +415,9 @@ func TestPublishRun(t *testing.T) {
 					Prompter: &prompter.PrompterMock{
 						ConfirmFunc: func(msg string, def bool) (bool, error) { return true, nil },
 					},
-					GitClient: &git.Client{},
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "Published v1.0.1",
@@ -563,11 +563,11 @@ func TestPublishRun(t *testing.T) {
 					"origin": "https://github.com/octocat/secure-repo.git",
 				})
 				return &PublishOptions{
-					IO:        ios,
-					Dir:       dir,
-					GitClient: &git.Client{},
+					IO:         ios,
+					Dir:        dir,
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "secret scanning is not enabled",
@@ -616,11 +616,11 @@ func TestPublishRun(t *testing.T) {
 					"origin": "https://github.com/octocat/tag-repo.git",
 				})
 				return &PublishOptions{
-					IO:        ios,
-					Dir:       dir,
-					GitClient: &git.Client{},
+					IO:         ios,
+					Dir:        dir,
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "tag protection",
@@ -679,12 +679,12 @@ func TestPublishRun(t *testing.T) {
 					"origin": "https://github.com/octocat/code-repo.git",
 				})
 				return &PublishOptions{
-					IO:        ios,
-					Dir:       dir,
-					DryRun:    true,
-					GitClient: &git.Client{},
+					IO:         ios,
+					Dir:        dir,
+					DryRun:     true,
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStderr: "code scanning",
@@ -744,12 +744,12 @@ func TestPublishRun(t *testing.T) {
 					"origin": "https://github.com/octocat/dep-repo.git",
 				})
 				return &PublishOptions{
-					IO:        ios,
-					Dir:       dir,
-					DryRun:    true,
-					GitClient: &git.Client{},
+					IO:         ios,
+					Dir:        dir,
+					DryRun:     true,
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStderr: "Dependabot",
@@ -894,12 +894,12 @@ func TestPublishRun(t *testing.T) {
 					"upstream": "git@github.com:octocat/repo.git",
 				})
 				return &PublishOptions{
-					IO:        ios,
-					Dir:       dir,
-					DryRun:    true,
-					GitClient: &git.Client{},
+					IO:         ios,
+					Dir:        dir,
+					DryRun:     true,
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStderr: "octocat/repo",
@@ -986,9 +986,9 @@ func TestPublishRun(t *testing.T) {
 					Prompter: &prompter.PrompterMock{
 						ConfirmFunc: func(msg string, def bool) (bool, error) { return true, nil },
 					},
-					GitClient: &git.Client{},
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "Added \"agent-skills\" topic",
@@ -1058,12 +1058,12 @@ func TestPublishRun(t *testing.T) {
 					"origin": "https://github.com/monalisa/skills-repo.git",
 				})
 				return &PublishOptions{
-					IO:        ios,
-					Dir:       dir,
-					Tag:       "v2.3.5",
-					GitClient: &git.Client{},
+					IO:         ios,
+					Dir:        dir,
+					Tag:        "v2.3.5",
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "Published v2.3.5",
@@ -1090,12 +1090,12 @@ func TestPublishRun(t *testing.T) {
 					"origin": "https://github.com/monalisa/skills-repo.git",
 				})
 				return &PublishOptions{
-					IO:        ios,
-					Dir:       dir,
-					Tag:       "v1.0.0", // same as stubAllSecureRemote's existing tag
-					GitClient: &git.Client{},
+					IO:         ios,
+					Dir:        dir,
+					Tag:        "v1.0.0", // same as stubAllSecureRemote's existing tag
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantErr: "tag v1.0.0 already exists",
@@ -1123,11 +1123,11 @@ func TestPublishRun(t *testing.T) {
 					"origin": "https://github.com/monalisa/skills-repo.git",
 				})
 				return &PublishOptions{
-					IO:        ios,
-					Dir:       dir,
-					GitClient: &git.Client{},
+					IO:         ios,
+					Dir:        dir,
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "ok",
@@ -1236,9 +1236,9 @@ func TestPublishRun(t *testing.T) {
 							return "v1.0.0", nil // accept suggested tag
 						},
 					},
-					GitClient: &git.Client{},
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "Published v1.0.0",
@@ -1293,9 +1293,9 @@ func TestPublishRun(t *testing.T) {
 							return "beta-1", nil
 						},
 					},
-					GitClient: &git.Client{},
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "Published beta-1",
@@ -1349,9 +1349,9 @@ func TestPublishRun(t *testing.T) {
 							return "v1.0.1", nil
 						},
 					},
-					GitClient: &git.Client{},
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantErr:    "CancelError",
@@ -1413,9 +1413,9 @@ func TestPublishRun(t *testing.T) {
 							return "v1.0.1", nil
 						},
 					},
-					GitClient: &git.Client{},
+					GitClient:  &git.Client{},
 					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-					host:      "github.com",
+					host:       "github.com",
 				}
 			},
 			wantStdout: "Enabled immutable releases",
@@ -1527,12 +1527,12 @@ func TestPublishRun_DirArgUsesTargetRemote(t *testing.T) {
 	stubAllSecureRemote(reg, "monalisa", "target-repo")
 
 	err := publishRun(&PublishOptions{
-		IO:        ios,
-		Dir:       targetRepo,
-		DryRun:    true,
-		GitClient: &git.Client{RepoDir: cwdRepo},
+		IO:         ios,
+		Dir:        targetRepo,
+		DryRun:     true,
+		GitClient:  &git.Client{RepoDir: cwdRepo},
 		HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-		host:      "github.com",
+		host:       "github.com",
 	})
 
 	require.NoError(t, err)

--- a/pkg/cmd/skills/publish/publish_test.go
+++ b/pkg/cmd/skills/publish/publish_test.go
@@ -164,7 +164,7 @@ func TestPublishRun_UnsupportedHost(t *testing.T) {
 		IO:         ios,
 		Dir:        dir,
 		GitClient:  &git.Client{},
-		HttpClient: func() (*http.Client, error) { return &http.Client{}, nil },
+		HttpClient: func() (*http.Client, error) { return nil, nil },
 		host:       "acme.ghes.com",
 	})
 	require.ErrorContains(t, err, "supports only github.com")

--- a/pkg/cmd/skills/publish/publish_test.go
+++ b/pkg/cmd/skills/publish/publish_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -165,7 +164,7 @@ func TestPublishRun_UnsupportedHost(t *testing.T) {
 		IO:        ios,
 		Dir:       dir,
 		GitClient: &git.Client{},
-		client:    api.NewClientFromHTTP(&http.Client{}),
+		HttpClient: func() (*http.Client, error) { return &http.Client{}, nil },
 		host:      "acme.ghes.com",
 	})
 	require.ErrorContains(t, err, "supports only github.com")
@@ -290,7 +289,7 @@ func TestPublishRun(t *testing.T) {
 					Dir:       dir,
 					DryRun:    true,
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -327,7 +326,7 @@ func TestPublishRun(t *testing.T) {
 					Dir:       dir,
 					DryRun:    true,
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -361,7 +360,7 @@ func TestPublishRun(t *testing.T) {
 					Dir:       dir,
 					DryRun:    true,
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -417,7 +416,7 @@ func TestPublishRun(t *testing.T) {
 						ConfirmFunc: func(msg string, def bool) (bool, error) { return true, nil },
 					},
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -567,7 +566,7 @@ func TestPublishRun(t *testing.T) {
 					IO:        ios,
 					Dir:       dir,
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -620,7 +619,7 @@ func TestPublishRun(t *testing.T) {
 					IO:        ios,
 					Dir:       dir,
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -684,7 +683,7 @@ func TestPublishRun(t *testing.T) {
 					Dir:       dir,
 					DryRun:    true,
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -749,7 +748,7 @@ func TestPublishRun(t *testing.T) {
 					Dir:       dir,
 					DryRun:    true,
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -899,7 +898,7 @@ func TestPublishRun(t *testing.T) {
 					Dir:       dir,
 					DryRun:    true,
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -988,7 +987,7 @@ func TestPublishRun(t *testing.T) {
 						ConfirmFunc: func(msg string, def bool) (bool, error) { return true, nil },
 					},
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -1063,7 +1062,7 @@ func TestPublishRun(t *testing.T) {
 					Dir:       dir,
 					Tag:       "v2.3.5",
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -1095,7 +1094,7 @@ func TestPublishRun(t *testing.T) {
 					Dir:       dir,
 					Tag:       "v1.0.0", // same as stubAllSecureRemote's existing tag
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -1127,7 +1126,7 @@ func TestPublishRun(t *testing.T) {
 					IO:        ios,
 					Dir:       dir,
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -1238,7 +1237,7 @@ func TestPublishRun(t *testing.T) {
 						},
 					},
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -1295,7 +1294,7 @@ func TestPublishRun(t *testing.T) {
 						},
 					},
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -1351,7 +1350,7 @@ func TestPublishRun(t *testing.T) {
 						},
 					},
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -1415,7 +1414,7 @@ func TestPublishRun(t *testing.T) {
 						},
 					},
 					GitClient: &git.Client{},
-					client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+					HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 					host:      "github.com",
 				}
 			},
@@ -1532,7 +1531,7 @@ func TestPublishRun_DirArgUsesTargetRemote(t *testing.T) {
 		Dir:       targetRepo,
 		DryRun:    true,
 		GitClient: &git.Client{RepoDir: cwdRepo},
-		client:    api.NewClientFromHTTP(&http.Client{Transport: reg}),
+		HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
 		host:      "github.com",
 	})
 

--- a/pkg/cmd/skills/search/search.go
+++ b/pkg/cmd/skills/search/search.go
@@ -770,17 +770,15 @@ func fetchPrimaryPages(client *api.Client, host, query string, displayPage, disp
 	return allItems, totalCount, nil
 }
 
-// skillResultKey is a typed map key for deduplicating code search results
-// by (repo, namespace, skill name). All fields are lowercased for
-// case-insensitive comparison.
-type skillResultKey struct {
-	repo      string
-	namespace string
-	skillName string
-}
-
 // deduplicateResults extracts unique (repo, namespace, skill name) triples from code search hits.
 func deduplicateResults(items []codeSearchItem) []skillResult {
+	// skillResultKey is a typed map key that deduplicates by (repo, namespace,
+	// skill name). All fields are lowercased for case-insensitive comparison.
+	type skillResultKey struct {
+		repo      string
+		namespace string
+		skillName string
+	}
 	seen := make(map[skillResultKey]struct{})
 	var results []skillResult
 

--- a/pkg/cmd/skills/search/search.go
+++ b/pkg/cmd/skills/search/search.go
@@ -770,9 +770,18 @@ func fetchPrimaryPages(client *api.Client, host, query string, displayPage, disp
 	return allItems, totalCount, nil
 }
 
+// skillResultKey is a typed map key for deduplicating code search results
+// by (repo, namespace, skill name). All fields are lowercased for
+// case-insensitive comparison.
+type skillResultKey struct {
+	repo      string
+	namespace string
+	skillName string
+}
+
 // deduplicateResults extracts unique (repo, namespace, skill name) triples from code search hits.
 func deduplicateResults(items []codeSearchItem) []skillResult {
-	seen := make(map[string]struct{})
+	seen := make(map[skillResultKey]struct{})
 	var results []skillResult
 
 	for _, item := range items {
@@ -780,7 +789,11 @@ func deduplicateResults(items []codeSearchItem) []skillResult {
 		if skillName == "" {
 			continue
 		}
-		key := item.Repository.FullName + "/" + namespace + "/" + skillName
+		key := skillResultKey{
+			repo:      strings.ToLower(item.Repository.FullName),
+			namespace: strings.ToLower(namespace),
+			skillName: strings.ToLower(skillName),
+		}
 		if _, ok := seen[key]; ok {
 			continue
 		}


### PR DESCRIPTION
## Summary

Addresses review feedback from PRs #13167, #13168, #13170, and #13171 that was deferred to post-merge follow-ups on the `sm/add-skills-command` branch.

Closes #13184

## Changes

### PR #13168 — Use factory pattern for HTTP client injection
- Removed direct `opts.client` field from `PublishOptions`
- Tests now set `opts.HttpClient` to return a stubbed `*http.Client` via `httpmock.Registry`, matching the standard factory pattern used across the codebase
- Removed "test-aware" nil-client fallback from `publishRun`

### PR #13170 — Search deduplication improvements
- **Renamed `testName` → `name`** in `TestMatchSkillPath` test struct (`discovery_test.go`)
- **Typed struct keys for dedup map**: Replaced string-concatenated map key in `deduplicateResults` with a typed `skillResultKey` struct — more idiomatic Go, avoids potential key collision
- **Case-insensitive deduplication**: `deduplicateResults` now normalizes repo, namespace, and skill name with `strings.ToLower()`, matching the behavior of `deduplicateByName`
- **Whitespace fix**: Already resolved in a prior commit (verified all tabs)

### PR #13171 — Remote selection and push UX
- **Simplified remote selection**: `detectGitHubRemote` now iterates `Remotes()` directly (which returns upstream > github > origin > rest) instead of manually trying origin first then falling back
- **Fixed push icon timing**: Removed premature `SuccessIcon` before push; now shows a plain "Pushing..." message, then `SuccessIcon` only after push succeeds

### Deferred
- **Replace real git in tests with `run.CommandStubber`** (PR #13171 feedback): Converting 20+ test cases from real git to command stubs is a substantial refactor best handled in a separate issue