### PR TITLE
Fix skills-publish-dry-run acceptance test error message mismatch

### DIFF
--- a/acceptance/testdata/skills/skills-publish-dry-run.txtar
+++ b/acceptance/testdata/skills/skills-publish-dry-run.txtar
@@ -1,6 +1,6 @@
 # Publish dry-run from a directory with no skills/ should fail gracefully
 ! exec gh skill publish --dry-run $WORK
-stderr 'no skills/ directory found'
+stderr 'no skills found in'
 
 # Publish dry-run against a valid skill directory should succeed
 exec gh skill publish --dry-run $WORK/test-repo


### PR DESCRIPTION
Fixes the broken acceptance test flagged in https://github.com/cli/cli/pull/13165/changes#r3093956593

The `skills-publish-dry-run` txtar test expected `no skills/ directory found` on stderr, but the actual error from `discovery.DiscoverSkills` is `no skills found in <dir>`. Updated the stderr matcher to match the current error message.

**Change:** `stderr 'no skills/ directory found'` → `stderr 'no skills found in'`