### PR TITLE
Add cli/skill-reviewers as CODEOWNERS for skills packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,6 @@ pkg/cmd/release/shared/ @cli/package-security
 test/integration/attestation-cmd @cli/package-security
 
 pkg/cmd/attestation/verification/embed/tuf-repo.github.com/ @cli/tuf-root-reviewers
+
+pkg/cmd/skills/ @cli/skill-reviewers
+internal/skills/ @cli/skill-reviewers


### PR DESCRIPTION
Adds `@cli/skill-reviewers` as code owners for:

- `pkg/cmd/skills/`
- `internal/skills/`