### PR TITLE
Add @cli/code-reviewers to all CODEOWNERS rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,18 @@
 * @cli/code-reviewers
 
-pkg/cmd/codespace/ @cli/codespaces
-internal/codespaces/ @cli/codespaces
+pkg/cmd/codespace/ @cli/codespaces @cli/code-reviewers
+internal/codespaces/ @cli/codespaces @cli/code-reviewers
 
 # Limit Package Security team ownership to the attestation command package and related integration tests
-pkg/cmd/attestation/ @cli/package-security
-pkg/cmd/release/attestation/ @cli/package-security
-pkg/cmd/release/verify/ @cli/package-security
-pkg/cmd/release/verify-asset/ @cli/package-security
-pkg/cmd/release/shared/ @cli/package-security
+pkg/cmd/attestation/ @cli/package-security @cli/code-reviewers
+pkg/cmd/release/attestation/ @cli/package-security @cli/code-reviewers
+pkg/cmd/release/verify/ @cli/package-security @cli/code-reviewers
+pkg/cmd/release/verify-asset/ @cli/package-security @cli/code-reviewers
+pkg/cmd/release/shared/ @cli/package-security @cli/code-reviewers
 
-test/integration/attestation-cmd @cli/package-security
+test/integration/attestation-cmd @cli/package-security @cli/code-reviewers
 
-pkg/cmd/attestation/verification/embed/tuf-repo.github.com/ @cli/tuf-root-reviewers
+pkg/cmd/attestation/verification/embed/tuf-repo.github.com/ @cli/tuf-root-reviewers @cli/code-reviewers
 
-pkg/cmd/skills/ @cli/skill-reviewers
-internal/skills/ @cli/skill-reviewers
+pkg/cmd/skills/ @cli/skill-reviewers @cli/code-reviewers
+internal/skills/ @cli/skill-reviewers @cli/code-reviewers


### PR DESCRIPTION
This ensures that an approval from `@cli/code-reviewers` can satisfy the CODEOWNERS requirement for any path, not just the catch-all wildcard rule.

Previously, paths like `pkg/cmd/skills/` or `pkg/cmd/attestation/` could only be approved by their specialist team. Now either the specialist team **or** `@cli/code-reviewers` can approve.