### PR TITLE
Do not send telemetry for aliases

### DIFF
--- a/acceptance/testdata/telemetry/no-telemetry-for-alias.txtar
+++ b/acceptance/testdata/telemetry/no-telemetry-for-alias.txtar
@@ -1,0 +1,18 @@
+# Aliases should not leak their user-defined names via telemetry, but the
+# resolved inner command should still record normally — its path is a core
+# gh command and conveys no user-authored identifier.
+
+env GH_PRIVATE_ENABLE_TELEMETRY=1
+env GH_TELEMETRY=log
+env GH_TELEMETRY_SAMPLE_RATE=100
+
+# Create a regular (non-shell) alias that resolves to an existing command.
+exec gh alias set secret-project-alias version
+
+# Invoking the alias must not produce any event carrying the alias name.
+exec gh secret-project-alias
+! stderr 'secret-project-alias'
+
+# The resolved inner command still records telemetry as normal.
+stderr 'Telemetry payload:'
+stderr '"command": "gh version"'

--- a/pkg/cmd/root/alias.go
+++ b/pkg/cmd/root/alias.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/run"
 	"github.com/cli/cli/v2/internal/text"
+	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/findsh"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/google/shlex"
@@ -17,7 +18,7 @@ import (
 )
 
 func NewCmdShellAlias(io *iostreams.IOStreams, aliasName, aliasValue string) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   aliasName,
 		Short: fmt.Sprintf("Shell alias for %q", text.Truncate(80, aliasValue)),
 		RunE: func(c *cobra.Command, args []string) error {
@@ -39,16 +40,19 @@ func NewCmdShellAlias(io *iostreams.IOStreams, aliasName, aliasValue string) *co
 			}
 			return nil
 		},
-		GroupID: "alias",
-		Annotations: map[string]string{
-			"skipAuthCheck": "true",
-		},
+		GroupID:            "alias",
 		DisableFlagParsing: true,
 	}
+	cmdutil.DisableAuthCheck(cmd)
+	// Aliases are user-defined names and must not be reported as telemetry
+	// dimensions, since the name itself may be sensitive (e.g. project or
+	// organization names).
+	cmdutil.DisableTelemetry(cmd)
+	return cmd
 }
 
 func NewCmdAlias(io *iostreams.IOStreams, aliasName, aliasValue string) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   aliasName,
 		Short: fmt.Sprintf("Alias for %q", text.Truncate(80, aliasValue)),
 		RunE: func(c *cobra.Command, args []string) error {
@@ -60,12 +64,15 @@ func NewCmdAlias(io *iostreams.IOStreams, aliasName, aliasValue string) *cobra.C
 			root.SetArgs(expandedArgs)
 			return root.Execute()
 		},
-		GroupID: "alias",
-		Annotations: map[string]string{
-			"skipAuthCheck": "true",
-		},
+		GroupID:            "alias",
 		DisableFlagParsing: true,
 	}
+	cmdutil.DisableAuthCheck(cmd)
+	// Aliases are user-defined names and must not be reported as telemetry
+	// dimensions, since the name itself may be sensitive (e.g. project or
+	// organization names).
+	cmdutil.DisableTelemetry(cmd)
+	return cmd
 }
 
 // ExpandAlias processes argv to see if it should be rewritten according to a user's aliases.


### PR DESCRIPTION
## Description

We shouldn't be recording telemetry for outer aliases e.g. `gh my-secret-alias`, but we should be resolving for the inner command. Nested alias -> alias works as expected, only recording the inner command:

```
➜  telemetry git:(wm/no-alias-telemetry) GH_PRIVATE_ENABLE_TELEMETRY=true GH_TELEMETRY_SAMPLE_RATE=100 GH_TELEMETRY=log ./bin/gh secret-project-alias cli/cli
Telemetry payload:
{
  "events": [
    {
      "type": "command_invocation",
      "dimensions": {
        "agent": "",
        "architecture": "arm64",
        "command": "gh repo view",
        "device_id": "1e9a73a6-c8bd-4e1e-be02-78f4b11de4e1",
        "flags": "",
        "invocation_id": "95a5e637-2698-4166-9abc-5b66d4ee0624",
        "is_tty": "true",
        "os": "darwin",
        "timestamp": "2026-04-16T20:17:51.741Z",
        "version": "2.89.0-105-g47db47f03"
      }
    }
  ]
}
```