### PR TITLE
browse: disambiguate decimal-only short SHAs

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1685,6 +1685,26 @@ func RepoExists(client *Client, repo ghrepo.Interface) (bool, error) {
 	}
 }
 
+func CommitExists(client *Client, repo ghrepo.Interface, ref string) (bool, error) {
+	path := fmt.Sprintf("%srepos/%s/%s/commits/%s", ghinstance.RESTPrefix(repo.RepoHost()), repo.RepoOwner(), repo.RepoName(), ref)
+
+	resp, err := client.HTTP().Get(path)
+	if err != nil {
+		return false, err
+	}
+
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case 200:
+		return true, nil
+	case 404, 409, 422:
+		return false, nil
+	default:
+		return false, ghAPI.HandleHTTPError(resp)
+	}
+}
+
 // RepoLicenses fetches available repository licenses.
 // It uses API v3 because licenses are not supported by GraphQL.
 func RepoLicenses(httpClient *http.Client, hostname string) ([]License, error) {

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -823,6 +823,100 @@ func TestRepoExists(t *testing.T) {
 	}
 }
 
+func TestCommitExists(t *testing.T) {
+	tests := []struct {
+		name       string
+		httpStub   func(*httpmock.Registry)
+		repo       ghrepo.Interface
+		ref        string
+		exists     bool
+		wantErrMsg string
+	}{
+		{
+			name: "commit exists",
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/commits/309628980"),
+					httpmock.StringResponse("{}"),
+				)
+			},
+			repo:   ghrepo.New("OWNER", "REPO"),
+			ref:    "309628980",
+			exists: true,
+		},
+		{
+			name: "commit does not exist",
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/commits/1234567"),
+					httpmock.StatusStringResponse(404, "Not Found"),
+				)
+			},
+			repo:   ghrepo.New("OWNER", "REPO"),
+			ref:    "1234567",
+			exists: false,
+		},
+		{
+			name: "commit ref is invalid",
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/commits/7654321"),
+					httpmock.StatusStringResponse(422, "Unprocessable Entity"),
+				)
+			},
+			repo:   ghrepo.New("OWNER", "REPO"),
+			ref:    "7654321",
+			exists: false,
+		},
+		{
+			name: "commit lookup is conflicted",
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/commits/7654322"),
+					httpmock.StatusStringResponse(409, "Conflict"),
+				)
+			},
+			repo:   ghrepo.New("OWNER", "REPO"),
+			ref:    "7654322",
+			exists: false,
+		},
+		{
+			name: "http error",
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/commits/9999999"),
+					httpmock.StatusStringResponse(500, "Internal Server Error"),
+				)
+			},
+			repo:       ghrepo.New("OWNER", "REPO"),
+			ref:        "9999999",
+			exists:     false,
+			wantErrMsg: "HTTP 500 (https://api.github.com/repos/OWNER/REPO/commits/9999999)",
+		},
+	}
+	for _, tt := range tests {
+		reg := &httpmock.Registry{}
+		if tt.httpStub != nil {
+			tt.httpStub(reg)
+		}
+
+		client := newTestClient(reg)
+
+		t.Run(tt.name, func(t *testing.T) {
+			exists, err := CommitExists(client, tt.repo, tt.ref)
+			if tt.wantErrMsg != "" {
+				assert.Equal(t, tt.wantErrMsg, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if exists != tt.exists {
+				t.Errorf("CommitExists() returns %v, expected %v", exists, tt.exists)
+			}
+		})
+	}
+}
+
 func TestForkRepoReturnsErrorWhenForkIsNotPossible(t *testing.T) {
 	// Given our API returns 202 with a Fork that is the same as
 	// the repo we provided

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -250,6 +250,19 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 			return "", nil
 		}
 		if isNumber(opts.SelectorArg) {
+			if isCommit(opts.SelectorArg) {
+				httpClient, err := opts.HttpClient()
+				if err != nil {
+					return "", err
+				}
+				exists, err := api.CommitExists(api.NewClientFromHTTP(httpClient), baseRepo, opts.SelectorArg)
+				if err != nil {
+					return "", err
+				}
+				if exists {
+					return fmt.Sprintf("commit/%s", opts.SelectorArg), nil
+				}
+			}
 			return fmt.Sprintf("issues/%s", strings.TrimPrefix(opts.SelectorArg, "#")), nil
 		}
 		if isCommit(opts.SelectorArg) {

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -357,6 +357,56 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL: "https://github.com/kevin/MinTy/issues/217",
 		},
 		{
+			name: "decimal-only short hash in selector arg that resolves to a commit",
+			opts: BrowseOptions{
+				SelectorArg: "309628980",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/kevin/MinTy/commits/309628980"),
+					httpmock.StringResponse("{}"),
+				)
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/commit/309628980",
+		},
+		{
+			name: "decimal-only short hash in selector arg that does not resolve to a commit",
+			opts: BrowseOptions{
+				SelectorArg: "1234567",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/kevin/MinTy/commits/1234567"),
+					httpmock.StatusStringResponse(404, "Not Found"),
+				)
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/issues/1234567",
+		},
+		{
+			name: "decimal-only short hash in selector arg with conflicted commit lookup falls back to an issue",
+			opts: BrowseOptions{
+				SelectorArg: "7654322",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/kevin/MinTy/commits/7654322"),
+					httpmock.StatusStringResponse(409, "Conflict"),
+				)
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/issues/7654322",
+		},
+		{
+			name: "decimal-only short hash with hashtag argument",
+			opts: BrowseOptions{
+				SelectorArg: "#309628980",
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/issues/309628980",
+		},
+		{
 			name: "branch flag",
 			opts: BrowseOptions{
 				Branch: "trunk",


### PR DESCRIPTION
Fixes #12357

When the selector is all decimal digits and at least 7 characters long, `gh browse` currently treats it as an issue number before it considers that it might also be a short SHA. In a fresh clone of this repo, `gh browse -n 968720862` prints `https://github.com/cli/cli/issues/968720862` even though `968720862` is a valid short SHA.

This change only disambiguates that ambiguous case:
- if the selector is both numeric and commit-like, check the commits API
- open the commit URL when it resolves
- fall back to the issue URL for `404`, `409`, and `422`
- preserve `#<number>` forcing issue behavior and avoid extra API calls for unambiguous inputs

Validation:
- `go test ./pkg/cmd/browse ./api`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0 run ./pkg/cmd/browse ./api`
- `go run ./cmd/gh browse -n 968720862` -> `https://github.com/cli/cli/commit/968720862`

Note: `go test ./...` hit unrelated local timeouts in `internal/prompter` during validation.
