### PR TITLE
chore(pkg): install zsh completion to Debian-searched path on DEB packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -104,5 +104,12 @@ nfpms: #build:linux
         dst: "/usr/share/bash-completion/completions/gh"
       - src: "./share/fish/vendor_completions.d/gh.fish"
         dst: "/usr/share/fish/vendor_completions.d/gh.fish"
+      # Debian/Ubuntu: zsh searches /usr/share/zsh/vendor-completions by default.
+      # See /usr/share/doc/zsh-common/README.Debian for the convention.
+      - src: "./share/zsh/site-functions/_gh"
+        dst: "/usr/share/zsh/vendor-completions/_gh"
+        packager: deb
+      # RHEL/Fedora-family and SUSE: zsh searches /usr/share/zsh/site-functions.
       - src: "./share/zsh/site-functions/_gh"
         dst: "/usr/share/zsh/site-functions/_gh"
+        packager: rpm


### PR DESCRIPTION
Fixes #13166.

## Problem

The `.goreleaser.yml` nfpm entry currently installs the zsh completion file at `/usr/share/zsh/site-functions/_gh` for **both** DEB and RPM packages:

```yaml
- src: "./share/zsh/site-functions/_gh"
  dst: "/usr/share/zsh/site-functions/_gh"
```

That path is in Fedora/RHEL's zsh `fpath` by default, but **Debian/Ubuntu zsh doesn't scan it by default**. On Debian-family systems, `compinit` only picks up completion from `/usr/share/zsh/vendor-completions` — documented in `/usr/share/doc/zsh-common/README.Debian`.

As a result, after `apt install gh` on Debian/Ubuntu the completion never activates unless the user manually adds the path to `fpath` or `eval "$(gh completion -s zsh)"` — even though the package already ships the completion script.

## Fix

Split the single `contents` entry into two packager-filtered entries:

| Package format | Install path | Rationale |
|---|---|---|
| `deb` | `/usr/share/zsh/vendor-completions/_gh` | Debian/Ubuntu convention |
| `rpm` | `/usr/share/zsh/site-functions/_gh` | Fedora/RHEL/SUSE convention (unchanged) |

nfpm's `contents.packager` field provides this filtering natively ([docs](https://nfpm.goreleaser.com/configuration/#packager-specific-contents)). No other changes — same completion script, same filename, just different destination per format.

## Testing

Goreleaser/nfpm config only. After this lands, a new release's `.deb` will place `_gh` in the correct directory, and `compinit` will discover it automatically on a fresh Debian/Ubuntu install. RPM users are unaffected.

Reported and reproducer in #13166.