### PR TITLE
fix(repo/list): route --visibility=private through search path to exclude internal repos

### DIFF
--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -30,7 +30,10 @@ type FilterOptions struct {
 }
 
 func listRepos(client *http.Client, hostname string, limit int, owner string, filter FilterOptions) (*RepositoryList, error) {
-	if filter.Language != "" || filter.Archived || filter.NonArchived || len(filter.Topic) > 0 || filter.Visibility == "internal" {
+	// The GraphQL `privacy: PRIVATE` filter returns both private and internal repositories,
+	// so route --visibility=private through the search path, where `is:private` excludes internal.
+	// See https://github.com/cli/cli/issues/12900.
+	if filter.Language != "" || filter.Archived || filter.NonArchived || len(filter.Topic) > 0 || filter.Visibility == "internal" || filter.Visibility == "private" {
 		return searchRepos(client, hostname, limit, owner, filter)
 	}
 

--- a/pkg/cmd/repo/list/http_test.go
+++ b/pkg/cmd/repo/list/http_test.go
@@ -60,6 +60,53 @@ func Test_listReposWithLanguage(t *testing.T) {
 	assert.Equal(t, `sort:updated-desc fork:true language:go user:@me`, searchData.Variables["query"])
 }
 
+// Regression test for https://github.com/cli/cli/issues/12900 — GraphQL
+// `privacy: PRIVATE` returns both private and internal repos, so
+// --visibility=private must be routed through the search path where
+// `is:private` reliably excludes internal repositories.
+func Test_listReposWithPrivateVisibility(t *testing.T) {
+	reg := httpmock.Registry{}
+	defer reg.Verify(t)
+
+	var searchData struct {
+		Query     string
+		Variables map[string]interface{}
+	}
+	reg.Register(
+		httpmock.GraphQL(`query RepositoryListSearch\b`),
+		func(req *http.Request) (*http.Response, error) {
+			jsonData, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			err = json.Unmarshal(jsonData, &searchData)
+			if err != nil {
+				return nil, err
+			}
+
+			respBody, err := os.Open("./fixtures/repoSearch.json")
+			if err != nil {
+				return nil, err
+			}
+
+			return &http.Response{
+				StatusCode: 200,
+				Request:    req,
+				Body:       respBody,
+			}, nil
+		},
+	)
+
+	client := http.Client{Transport: &reg}
+	res, err := listRepos(&client, "github.com", 10, "", FilterOptions{
+		Visibility: "private",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, true, res.FromSearch, "private visibility should go through search path")
+	assert.Equal(t, `sort:updated-desc fork:true is:private user:@me`, searchData.Variables["query"])
+}
+
 func Test_searchQuery(t *testing.T) {
 	type args struct {
 		owner  string


### PR DESCRIPTION
Fixes #12900.

## Problem

\`gh repo list OWNER --visibility private\` currently returns both private and internal repositories. Reproducer in #12900:

1. \`gh repo list OWNER --visibility private\`
2. Internal repos appear in the output.

## Root cause

The command uses two code paths in \`pkg/cmd/repo/list/http.go\`:

1. **Search path (\`searchRepos\`)** — uses GraphQL \`search\` with the \`is:private\` qualifier, which correctly returns ONLY private repos.
2. **Repositories path (\`listRepos\`)** — uses GraphQL \`repositories(privacy: $privacy)\`, where the \`PRIVATE\` value of the \`RepositoryPrivacy\` enum matches both private and internal repos (GraphQL treats "private" as "not public").

Previously only \`--visibility=internal\` was routed through the search path (because internal can't be expressed via the GraphQL repositories privacy filter at all). \`--visibility=private\` fell through to the repositories path and included internal repos.

## Fix

Route \`--visibility=private\` through the same search path used for \`--visibility=internal\`. \`is:private\` in the search query reliably excludes internal repositories.

One-line change to the routing condition:

\`\`\`go
- if ... || filter.Visibility == "internal" {
+ if ... || filter.Visibility == "internal" || filter.Visibility == "private" {
\`\`\`

\`--visibility=public\` still uses the repositories path (it works correctly there — \`PUBLIC\` in the privacy enum is unambiguous).

## Tests

Added \`Test_listReposWithPrivateVisibility\` in \`http_test.go\`. It mocks the \`RepositoryListSearch\` GraphQL endpoint, calls \`listRepos\` with \`Visibility: "private"\`, and asserts:
- \`FromSearch\` is \`true\` (search path taken, not repositories path)
- The generated query contains \`is:private\` (which GitHub search reliably scopes to private-only)

Passes locally.