### PR TITLE
Add Junie agent support to GitHub skills

### DIFF
--- a/internal/agents/detect.go
+++ b/internal/agents/detect.go
@@ -15,6 +15,7 @@ const (
 	agentCodex      AgentName = "codex"
 	agentCopilotCLI AgentName = "copilot-cli"
 	agentGeminiCLI  AgentName = "gemini-cli"
+	agentJunie      AgentName = "junie"
 	agentOpencode   AgentName = "opencode"
 )
 
@@ -78,6 +79,11 @@ func detectWith(lookup func(string) (string, bool)) AgentName {
 	// No first-party docs
 	if isSet("COPILOT_CLI") {
 		return agentCopilotCLI
+	}
+
+	// Junie
+	if isSet("JUNIE_DATA") || isSet("MATTERHORN_SESSION_ID") {
+		return agentJunie
 	}
 
 	// OpenCode — https://github.com/anomalyco/opencode

--- a/internal/agents/detect_test.go
+++ b/internal/agents/detect_test.go
@@ -119,6 +119,16 @@ func TestDetectWith(t *testing.T) {
 			wantAgent: "copilot-cli",
 		},
 		{
+			name:      "JUNIE_DATA",
+			env:       map[string]string{"JUNIE_DATA": "/tmp/junie/data"},
+			wantAgent: "junie",
+		},
+		{
+			name:      "MATTERHORN_SESSION_ID",
+			env:       map[string]string{"MATTERHORN_SESSION_ID": "a3f8d1c2-4b7e-4d9a-8c5f-2e6b1a9c3d7f"},
+			wantAgent: "junie",
+		},
+		{
 			name:      "OPENCODE",
 			env:       map[string]string{"OPENCODE": "1"},
 			wantAgent: "opencode",

--- a/internal/skills/registry/registry.go
+++ b/internal/skills/registry/registry.go
@@ -66,6 +66,12 @@ var Agents = []AgentHost{
 		UserDir:    ".gemini/skills",
 	},
 	{
+		ID:         "junie",
+		Name:       "Junie",
+		ProjectDir: ".junie/skills",
+		UserDir:    ".junie/skills",
+	},
+	{
 		ID:         "antigravity",
 		Name:       "Antigravity",
 		ProjectDir: sharedProjectSkillsDir,

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -20,6 +20,7 @@ func TestFindByID(t *testing.T) {
 		{name: "cursor", id: "cursor", wantName: "Cursor"},
 		{name: "codex", id: "codex", wantName: "Codex"},
 		{name: "gemini", id: "gemini", wantName: "Gemini CLI"},
+		{name: "junie", id: "junie", wantName: "Junie"},
 		{name: "antigravity", id: "antigravity", wantName: "Antigravity"},
 		{name: "unknown agent", id: "nonexistent", wantErr: "unknown agent"},
 	}
@@ -96,6 +97,22 @@ func TestInstallDir(t *testing.T) {
 			wantDir: filepath.Join("/tmp/monalisa-repo", ".agents", "skills"),
 		},
 		{
+			name:    "junie project scope",
+			hostID:  "junie",
+			scope:   ScopeProject,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/tmp/monalisa-repo", ".junie", "skills"),
+		},
+		{
+			name:    "junie user scope",
+			hostID:  "junie",
+			scope:   ScopeUser,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/home/monalisa", ".junie", "skills"),
+		},
+		{
 			name:    "antigravity project scope",
 			hostID:  "antigravity",
 			scope:   ScopeProject,
@@ -167,7 +184,7 @@ func TestRepoNameFromRemote(t *testing.T) {
 
 func TestUniqueProjectDirs(t *testing.T) {
 	dirs := UniqueProjectDirs()
-	assert.Equal(t, []string{".agents/skills", ".claude/skills"}, dirs)
+	assert.Equal(t, []string{".agents/skills", ".claude/skills", ".junie/skills"}, dirs)
 }
 
 func TestScopeLabels(t *testing.T) {

--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -83,6 +83,7 @@ func NewCmdInstall(f *cmdutil.Factory, runF func(*InstallOptions) error) *cobra.
 			  - Cursor         (%[1]s.agents/skills%[1]s, %[1]s~/.cursor/skills%[1]s)
 			  - Codex          (%[1]s.agents/skills%[1]s, %[1]s~/.codex/skills%[1]s)
 			  - Gemini CLI     (%[1]s.agents/skills%[1]s, %[1]s~/.gemini/skills%[1]s)
+			  - Junie          (%[1]s.junie/skills%[1]s, %[1]s~/.junie/skills%[1]s)
 			  - Antigravity    (%[1]s.agents/skills%[1]s, %[1]s~/.gemini/antigravity/skills%[1]s)
 
 			Use %[1]s--agent%[1]s and %[1]s--scope%[1]s to control placement, or %[1]s--dir%[1]s for a

--- a/pkg/cmd/skills/update/update.go
+++ b/pkg/cmd/skills/update/update.go
@@ -80,7 +80,7 @@ func NewCmdUpdate(f *cmdutil.Factory, runF func(*UpdateOptions) error) *cobra.Co
 			tree SHA (from %[1]sSKILL.md%[1]s frontmatter) against the remote repository.
 
 			Scans all known agent host directories (Copilot, Claude, Cursor, Codex,
-			Gemini, Antigravity) in both project and user scope automatically.
+			Gemini, Junie, Antigravity) in both project and user scope automatically.
 
 			Without arguments, checks all installed skills. With skill names,
 			checks only those specific skills.


### PR DESCRIPTION
This PR adds support for the Junie AI agent to the gh CLI skills system, enabling Junie users to install, update, and manage GitHub skills alongside other supported agents.

Fixes: https://github.com/cli/cli/issues/13202