### PR TITLE
Remove misleading text

### DIFF
--- a/pkg/cmd/skills/search/search.go
+++ b/pkg/cmd/skills/search/search.go
@@ -540,7 +540,7 @@ func promptInstall(opts *SearchOptions, skills []skillResult) error {
 	}
 
 	indices, err := opts.Prompter.MultiSelect(
-		"Select skills to install (press Enter to skip):",
+		"Select skills to install:",
 		nil,
 		options,
 	)


### PR DESCRIPTION
`(press Enter to skip)` is wrong, as pressing Enter selects a skill. This PR removes it