### PR TITLE
search: open Pull Requests tab for gh search prs --web

### DIFF
--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -268,7 +268,7 @@ func (s searcher) search(query Query, result interface{}) (string, error) {
 func (s searcher) URL(query Query) string {
 	path := fmt.Sprintf("https://%s/search", s.host)
 	qs := url.Values{}
-	qs.Set("type", query.Kind)
+	qs.Set("type", webSearchType(query))
 
 	// TODO advancedSearchFuture
 	// Currently, the global search GUI does not support the advanced issue
@@ -285,6 +285,17 @@ func (s searcher) URL(query Query) string {
 	}
 	url := fmt.Sprintf("%s?%s", path, qs.Encode())
 	return url
+}
+
+// webSearchType maps the query onto the tab identifier used by the global
+// search GUI at github.com/search. The Issues backend kind is shared between
+// issue and pull request searches, which are rendered in separate tabs on the
+// web, so we disambiguate via the type qualifier set by the gh search subcommand.
+func webSearchType(query Query) string {
+	if query.Kind == KindIssues && query.Qualifiers.Type == "pr" {
+		return "pullrequests"
+	}
+	return query.Kind
 }
 
 func (err httpError) Error() string {

--- a/pkg/search/searcher_test.go
+++ b/pkg/search/searcher_test.go
@@ -1256,6 +1256,36 @@ func TestSearcherURL(t *testing.T) {
 			},
 			url: "https://github.com/search?q=%22keyword+with+whitespace%22&type=repositories",
 		},
+		{
+			name: "pull request search opens pull requests tab",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Kind:     KindIssues,
+				Qualifiers: Qualifiers{
+					Type: "pr",
+				},
+			},
+			url: "https://github.com/search?q=keyword+type%3Apr&type=pullrequests",
+		},
+		{
+			name: "issue search opens issues tab",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Kind:     KindIssues,
+				Qualifiers: Qualifiers{
+					Type: "issue",
+				},
+			},
+			url: "https://github.com/search?q=keyword+type%3Aissue&type=issues",
+		},
+		{
+			name: "combined issue and pull request search defaults to issues tab",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Kind:     KindIssues,
+			},
+			url: "https://github.com/search?q=keyword&type=issues",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #10733

## Summary
`gh search prs --web` was opening the **Issues** tab on github.com/search instead of the **Pull Requests** tab. The web URL builder used `query.Kind` for the outer `type` parameter. Because `gh search prs` shares the Issues backend (`Kind=issues` with `type:pr` qualifier), the URL ended up with `type=issues`.

## Fix
Introduced a `webSearchType` helper in `pkg/search/searcher.go` that returns `pullrequests` when `Kind==issues` and `Qualifiers.Type==\"pr\"`, and otherwise returns `Kind` unchanged. This keeps existing behavior for:
- Repository, code, and commit searches (`type=<Kind>`)
- `gh search issues` (`type=issues`)
- `gh search issues --include-prs` (the combined case keeps the Issues tab, which matches today's behavior)

## Tests
Added three cases to `TestSearcherURL`:
- PR search → `type=pullrequests`
- Issue search → `type=issues`
- Combined issues-and-prs search → `type=issues`

## Verification
- `go test ./pkg/search/... -run TestSearcherURL -v` — pass
- `go test ./...` — pass
- `make lint` — 0 issues
- Smoke:
  - `gh search prs --repo cli/cli --web` → `https://github.com/search?q=repo%3Acli%2Fcli+type%3Apr&type=pullrequests` ✅
  - `gh search issues --repo cli/cli --web` → `type=issues` ✅
  - `gh search issues --include-prs --web` → `type=issues` ✅

## Links
- [Agent conversation](https://app.warp.dev/conversation/ab33fe54-678a-4b85-bae1-70f8845cc4f0)
- [Plan](https://app.warp.dev/drive/notebook/P7FLfOEk2EXnYKkM3FwmkU)

Co-Authored-By: Oz <oz-agent@warp.dev>