### PR TITLE
repo list: route --visibility private through the search backend

### DIFF
--- a/pkg/cmd/repo/list/http.go
+++ b/pkg/cmd/repo/list/http.go
@@ -30,7 +30,12 @@ type FilterOptions struct {
 }
 
 func listRepos(client *http.Client, hostname string, limit int, owner string, filter FilterOptions) (*RepositoryList, error) {
-	if filter.Language != "" || filter.Archived || filter.NonArchived || len(filter.Topic) > 0 || filter.Visibility == "internal" {
+	// The GraphQL repositoryOwner.repositories(privacy: PRIVATE) filter also
+	// returns internal repositories because the RepositoryPrivacy enum only
+	// distinguishes PUBLIC and PRIVATE. Route private and internal queries
+	// through the search backend so that is:private and is:internal are
+	// honored exactly.
+	if filter.Language != "" || filter.Archived || filter.NonArchived || len(filter.Topic) > 0 || filter.Visibility == "internal" || filter.Visibility == "private" {
 		return searchRepos(client, hostname, limit, owner, filter)
 	}
 

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -470,10 +470,12 @@ func TestRepoList_filtering(t *testing.T) {
 	http := &httpmock.Registry{}
 	defer http.Verify(t)
 
+	// --visibility=private must use the search backend so private and
+	// internal repositories are not conflated (see #12900).
 	http.Register(
-		httpmock.GraphQL(`query RepositoryList\b`),
+		httpmock.GraphQL(`query RepositoryListSearch\b`),
 		httpmock.GraphQLQuery(`{}`, func(_ string, params map[string]interface{}) {
-			assert.Equal(t, "PRIVATE", params["privacy"])
+			assert.Equal(t, `sort:updated-desc fork:true is:private user:@me`, params["query"])
 			assert.Equal(t, float64(2), params["perPage"])
 		}),
 	)


### PR DESCRIPTION
Fixes #12900

## Summary
`gh repo list OWNER --visibility private` was returning internal repositories alongside private ones. The GraphQL `repositoryOwner.repositories(privacy: PRIVATE)` filter is backed by the `RepositoryPrivacy` enum, which only distinguishes `PUBLIC` and `PRIVATE`, so internal repos get bucketed into the private result set.

## Fix
`listRepos` already routes `--visibility internal` through the search backend (which supports exact `is:private` / `is:internal` qualifiers). This PR extends the same routing to `--visibility private`, so both visibility filters honor the distinction exactly.

## Tests
Updated `TestRepoList_filtering` to assert the search path is used for `--visibility=private` and that the query string contains `is:private`.

## Verification
- `go test ./pkg/cmd/repo/list/... -v` — pass
- `go test ./...` — pass
- `make lint` — 0 issues

## Links
- [Agent conversation](https://app.warp.dev/conversation/ab33fe54-678a-4b85-bae1-70f8845cc4f0)
- [Plan](https://app.warp.dev/drive/notebook/P7FLfOEk2EXnYKkM3FwmkU)

Co-Authored-By: Oz <oz-agent@warp.dev>