### PR TITLE
update: persist check timestamp before release lookup

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -87,10 +87,22 @@ func ShouldCheckForUpdate() bool {
 }
 
 // CheckForUpdate checks whether an update exists for the GitHub CLI based on recency of last check within past 24 hours.
+//
+// The update check runs concurrently with the user's command in a goroutine, so
+// the state timestamp is persisted before the HTTP request is issued. This way,
+// if the user's command fails fast and the process exits before the release
+// lookup completes, subsequent invocations still honor the 24-hour cooldown
+// instead of re-issuing a request on every failure (see #12599).
 func CheckForUpdate(ctx context.Context, client *http.Client, stateFilePath, repo, currentVersion string) (*ReleaseInfo, error) {
 	stateEntry, _ := getStateEntry(stateFilePath)
 	if stateEntry != nil && time.Since(stateEntry.CheckedForUpdateAt).Hours() < 24 {
 		return nil, nil
+	}
+
+	// Persist the check time before making the network request so that the
+	// cooldown is honored even if the process exits before the request finishes.
+	if err := setStateEntry(stateFilePath, time.Now(), ReleaseInfo{}); err != nil {
+		return nil, err
 	}
 
 	releaseInfo, err := getLatestReleaseInfo(ctx, client, repo)
@@ -98,8 +110,7 @@ func CheckForUpdate(ctx context.Context, client *http.Client, stateFilePath, rep
 		return nil, err
 	}
 
-	err = setStateEntry(stateFilePath, time.Now(), *releaseInfo)
-	if err != nil {
+	if err := setStateEntry(stateFilePath, time.Now(), *releaseInfo); err != nil {
 		return nil, err
 	}
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -122,6 +122,41 @@ func TestCheckForUpdate(t *testing.T) {
 	}
 }
 
+func TestCheckForUpdate_cooldownOnFailure(t *testing.T) {
+	// When the release lookup fails (or is interrupted before it completes),
+	// the state file must still record the check time so the 24-hour cooldown
+	// kicks in on the next invocation. Otherwise a command that reliably
+	// fails fast would re-issue the GitHub releases request every time
+	// (see cli/cli#12599).
+	statePath := tempFilePath()
+
+	reg := &httpmock.Registry{}
+	httpClient := &http.Client{}
+	httpmock.ReplaceTripper(httpClient, reg)
+	reg.Register(
+		httpmock.REST("GET", "repos/OWNER/REPO/releases/latest"),
+		httpmock.StatusStringResponse(500, `{"message":"boom"}`),
+	)
+
+	_, err := CheckForUpdate(context.TODO(), httpClient, statePath, "OWNER/REPO", "v1.0.0")
+	require.Error(t, err)
+
+	entry, entryErr := getStateEntry(statePath)
+	require.NoError(t, entryErr)
+	require.NotNil(t, entry)
+	require.False(t, entry.CheckedForUpdateAt.IsZero(), "expected check time to be recorded even on failure")
+
+	// Drop the recorded HTTP request so the mock registry only expects the
+	// one we just made. A second call within the cooldown window must not
+	// issue another request.
+	reg.Requests = nil
+
+	rel, err := CheckForUpdate(context.TODO(), httpClient, statePath, "OWNER/REPO", "v1.0.0")
+	require.NoError(t, err)
+	require.Nil(t, rel)
+	require.Empty(t, reg.Requests, "expected no HTTP request during cooldown window")
+}
+
 func TestCheckForExtensionUpdate(t *testing.T) {
 	now := time.Date(2024, 12, 17, 12, 0, 0, 0, time.UTC)
 	previousTooSoon := now.Add(-23 * time.Hour).Add(-59 * time.Minute).Add(-59 * time.Second)


### PR DESCRIPTION
Fixes #12599

## Summary
The GitHub CLI's update checker runs concurrently with the user's command. When the user's command fails fast — for example, because the target host is unreachable and the dial returns in a few milliseconds — the process can terminate before the update goroutine finishes fetching `repos/cli/cli/releases/latest`. That left the state file empty, so the next invocation repeated the releases request, as observed in #12599.

## Fix
Persist the check timestamp in `internal/update/update.go` **before** issuing the HTTP request. The 24-hour cooldown is now honored even if the process exits mid-flight. On the happy path the release info is still written afterward, so the notification UX is unchanged.

## Tests
Added `TestCheckForUpdate_cooldownOnFailure` which:
1. Stubs `releases/latest` to return 500
2. Asserts the state file now has a `CheckedForUpdateAt` timestamp
3. Calls `CheckForUpdate` again and asserts that no further HTTP request is made (the cooldown is honored)

## Verification
- `go test ./internal/update/... -v` — pass (all existing tests + new test)
- `go test ./...` — pass
- `make lint` — 0 issues

## Links
- [Agent conversation](https://app.warp.dev/conversation/ab33fe54-678a-4b85-bae1-70f8845cc4f0)
- [Plan](https://app.warp.dev/drive/notebook/P7FLfOEk2EXnYKkM3FwmkU)

Co-Authored-By: Oz <oz-agent@warp.dev>
