### PR TITLE
fix: install zsh completion to vendor-completions for Debian packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -104,5 +104,12 @@ nfpms: #build:linux
         dst: "/usr/share/bash-completion/completions/gh"
       - src: "./share/fish/vendor_completions.d/gh.fish"
         dst: "/usr/share/fish/vendor_completions.d/gh.fish"
-      - src: "./share/zsh/site-functions/_gh"
-        dst: "/usr/share/zsh/site-functions/_gh"
+    overrides:
+      deb:
+        contents:
+          - src: "./share/zsh/site-functions/_gh"
+            dst: "/usr/share/zsh/vendor-completions/_gh"
+      rpm:
+        contents:
+          - src: "./share/zsh/site-functions/_gh"
+            dst: "/usr/share/zsh/site-functions/_gh"

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -100,7 +100,7 @@ To install:
 ```bash
 sudo dnf install dnf5-plugins
 sudo dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
-sudo dnf install gh --repo gh-cli
+sudo dnf install gh --enablerepo gh-cli
 ```
 
 To upgrade:
@@ -119,7 +119,7 @@ To install:
 ```bash
 sudo dnf install 'dnf-command(config-manager)'
 sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-sudo dnf install gh --repo gh-cli
+sudo dnf install gh --enablerepo gh-cli
 ```
 
 To upgrade:


### PR DESCRIPTION
## Summary

Uses goreleaser nfpm overrides to install the zsh completion file to `/usr/share/zsh/vendor-completions/_gh` for Debian packages, while keeping `/usr/share/zsh/site-functions/_gh` for RPM packages.

## Problem

On Debian/Ubuntu, zsh does not include `/usr/share/zsh/site-functions` in the default `fpath`. The correct directory for third-party completion files is `/usr/share/zsh/vendor-completions`, as documented in `/usr/share/doc/zsh-common/README.Debian`.

As a result, after installing `gh` from the official Debian package, zsh completion does not work unless the user manually adds the directory to `fpath` or uses `eval "$(gh completion -s zsh)"`.

Note: The `gh` package in the official Debian/Ubuntu repositories already installs to `/usr/share/zsh/vendor-completions/_gh` (see [Ubuntu filelist](https://packages.ubuntu.com/noble/amd64/gh/filelist)).

## Solution

- Removed the zsh completion entry from the shared `contents` section
- Added per-format overrides: `deb` installs to `vendor-completions`, `rpm` installs to `site-functions`

Closes #13166

## Test Plan

- Build deb and rpm packages with goreleaser
- Verify deb package contains `_gh` at `/usr/share/zsh/vendor-completions/_gh`
- Verify rpm package contains `_gh` at `/usr/share/zsh/site-functions/_gh`
- On Ubuntu, verify zsh discovers `gh` completion automatically via `zsh -fc 'print -rl -- $fpath'`