### PR TITLE
feat: add `gh contributions` to display contributions graph

### DIFF
--- a/pkg/cmd/contributions/contributions.go
+++ b/pkg/cmd/contributions/contributions.go
@@ -24,7 +24,6 @@ type ContributionsOptions struct {
 	HttpClient func() (*http.Client, error)
 	HostConfig hostConfig
 	IO         *iostreams.IOStreams
-	Now        func() time.Time
 
 	User     string
 	From     string
@@ -37,7 +36,6 @@ func NewCmdContributions(f *cmdutil.Factory, runF func(*ContributionsOptions) er
 	opts := &ContributionsOptions{
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
-		Now:        time.Now,
 	}
 
 	cmd := &cobra.Command{
@@ -139,7 +137,7 @@ func contributionsRun(opts *ContributionsOptions) error {
 // exportable shapes the result for JSON output, flattening days for
 // easier consumption.
 func exportable(r *ContributionsResult) map[string]any {
-	days := make([]ContributionDay, 0)
+	days := make([]ContributionDay, 0, len(r.Calendar.Weeks)*7)
 	for _, w := range r.Calendar.Weeks {
 		days = append(days, w.ContributionDays...)
 	}
@@ -200,7 +198,7 @@ func hexToRGB(h string) (int, int, int) {
 	return r, g, b
 }
 
-const dayLabelWidth = 4
+const dayLabelWidth = 3
 
 func renderCalendar(io *iostreams.IOStreams, r *ContributionsResult) error {
 	cs := io.ColorScheme()

--- a/pkg/cmd/contributions/contributions.go
+++ b/pkg/cmd/contributions/contributions.go
@@ -1,0 +1,329 @@
+// Package contributions implements the `gh contributions` command which
+// displays a user's GitHub contribution calendar in the terminal.
+package contributions
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/text"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type hostConfig interface {
+	DefaultHost() (string, string)
+}
+
+// ContributionsOptions holds the parsed flags and dependencies for the command.
+type ContributionsOptions struct {
+	HttpClient func() (*http.Client, error)
+	HostConfig hostConfig
+	IO         *iostreams.IOStreams
+	Now        func() time.Time
+
+	User     string
+	From     string
+	To       string
+	Exporter cmdutil.Exporter
+}
+
+// NewCmdContributions creates the `gh contributions` command.
+func NewCmdContributions(f *cmdutil.Factory, runF func(*ContributionsOptions) error) *cobra.Command {
+	opts := &ContributionsOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Now:        time.Now,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "contributions",
+		Short: "Show a user's contribution calendar",
+		Long: heredoc.Doc(`
+			Display a contribution calendar in the terminal, mirroring the
+			heat map shown on a user's GitHub profile.
+
+			By default, the calendar for the authenticated user is shown.
+			Pass --user to view contributions for someone else.
+
+			Use --from and --to to constrain the range. Both flags accept
+			YYYY-MM-DD or RFC3339 timestamps. The GitHub API allows ranges
+			of up to one year.
+		`),
+		Example: heredoc.Doc(`
+			# Show your own contributions over the last year
+			$ gh contributions
+
+			# Show another user's contributions
+			$ gh contributions --user octocat
+
+			# Restrict to a specific date range
+			$ gh contributions --from 2024-01-01 --to 2024-06-30
+
+			# Emit JSON for scripting
+			$ gh contributions --json totalContributions,days
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+			opts.HostConfig = cfg.Authentication()
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return contributionsRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.User, "user", "u", "", "GitHub login to show contributions for (defaults to the authenticated user)")
+	cmd.Flags().StringVar(&opts.From, "from", "", "Start of the date range (YYYY-MM-DD or RFC3339)")
+	cmd.Flags().StringVar(&opts.To, "to", "", "End of the date range (YYYY-MM-DD or RFC3339)")
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, []string{"login", "totalContributions", "from", "to", "days"})
+
+	return cmd
+}
+
+func parseDate(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("invalid date %q: expected YYYY-MM-DD or RFC3339", s)
+}
+
+func contributionsRun(opts *ContributionsOptions) error {
+	from, err := parseDate(opts.From)
+	if err != nil {
+		return cmdutil.FlagErrorf("%s", err.Error())
+	}
+	to, err := parseDate(opts.To)
+	if err != nil {
+		return cmdutil.FlagErrorf("%s", err.Error())
+	}
+	if !from.IsZero() && !to.IsZero() && to.Before(from) {
+		return cmdutil.FlagErrorf("--to must be on or after --from")
+	}
+
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return fmt.Errorf("could not create client: %w", err)
+	}
+	hostname, _ := opts.HostConfig.DefaultHost()
+
+	opts.IO.StartProgressIndicator()
+	result, err := fetchContributions(httpClient, hostname, opts.User, from, to)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return err
+	}
+
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, exportable(result))
+	}
+
+	return renderCalendar(opts.IO, result)
+}
+
+// exportable shapes the result for JSON output, flattening days for
+// easier consumption.
+func exportable(r *ContributionsResult) map[string]any {
+	days := make([]ContributionDay, 0)
+	for _, w := range r.Calendar.Weeks {
+		days = append(days, w.ContributionDays...)
+	}
+	out := map[string]any{
+		"login":              r.Login,
+		"totalContributions": r.Calendar.TotalContributions,
+		"days":               days,
+	}
+	if !r.From.IsZero() {
+		out["from"] = r.From.Format(time.RFC3339)
+	} else {
+		out["from"] = nil
+	}
+	if !r.To.IsZero() {
+		out["to"] = r.To.Format(time.RFC3339)
+	} else {
+		out["to"] = nil
+	}
+	return out
+}
+
+// Hex colors taken from GitHub's dark contribution calendar palette.
+var levelHex = map[string]string{
+	"NONE":            "39414a",
+	"FIRST_QUARTILE":  "0e4429",
+	"SECOND_QUARTILE": "006d32",
+	"THIRD_QUARTILE":  "26a641",
+	"FOURTH_QUARTILE": "39d353",
+}
+
+const cellGlyph = "■"
+
+func cell(cs *iostreams.ColorScheme, level string) string {
+	hex, ok := levelHex[level]
+	if !ok {
+		hex = levelHex["NONE"]
+	}
+	if cs.Enabled && cs.TrueColor {
+		r, g, b := hexToRGB(hex)
+		return fmt.Sprintf("\x1b[38;2;%d;%d;%dm%s\x1b[0m", r, g, b, cellGlyph)
+	}
+	switch level {
+	case "NONE", "":
+		return cs.Muted(cellGlyph)
+	case "FIRST_QUARTILE", "SECOND_QUARTILE":
+		return cs.Green(cellGlyph)
+	default:
+		return cs.GreenBold(cellGlyph)
+	}
+}
+
+func hexToRGB(h string) (int, int, int) {
+	if len(h) != 6 {
+		return 0, 0, 0
+	}
+	var r, g, b int
+	_, _ = fmt.Sscanf(h, "%02x%02x%02x", &r, &g, &b)
+	return r, g, b
+}
+
+const dayLabelWidth = 4
+
+func renderCalendar(io *iostreams.IOStreams, r *ContributionsResult) error {
+	cs := io.ColorScheme()
+	out := io.Out
+
+	weeks := r.Calendar.Weeks
+	if width := io.TerminalWidth(); width > 0 {
+		// Each week takes 2 columns; reserve dayLabelWidth for the row labels.
+		maxWeeks := max((width-dayLabelWidth)/2, 1)
+		if len(weeks) > maxWeeks {
+			weeks = weeks[len(weeks)-maxWeeks:]
+		}
+	}
+
+	rangeLabel := "in the last year"
+	if !r.From.IsZero() || !r.To.IsZero() {
+		fromStr := "..."
+		toStr := "..."
+		if !r.From.IsZero() {
+			fromStr = r.From.Format("2006-01-02")
+		}
+		if !r.To.IsZero() {
+			toStr = r.To.Format("2006-01-02")
+		}
+		rangeLabel = fmt.Sprintf("from %s to %s", fromStr, toStr)
+	}
+	who := r.Login
+	if who == "" {
+		who = "you"
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, " %s %s\n",
+		cs.Bold(text.Pluralize(r.Calendar.TotalContributions, "contribution")),
+		cs.Mutedf("%s by %s", rangeLabel, who),
+	)
+	fmt.Fprintln(out)
+
+	if len(weeks) == 0 {
+		fmt.Fprintln(out, cs.Muted("No contribution data."))
+		return nil
+	}
+
+	monthRow := strings.Repeat(" ", dayLabelWidth)
+	monthRow += renderMonthLabels(weeks)
+	fmt.Fprintln(out, monthRow)
+
+	dayLabels := []string{"", "M", "", "W", "", "F", ""}
+	for d := range 7 {
+		var sb strings.Builder
+		label := dayLabels[d]
+		if label == "" {
+			sb.WriteString(strings.Repeat(" ", dayLabelWidth))
+		} else {
+			sb.WriteString(cs.Muted(label))
+			sb.WriteString(strings.Repeat(" ", dayLabelWidth-len(label)))
+		}
+		for _, w := range weeks {
+			if d < len(w.ContributionDays) {
+				sb.WriteString(cell(cs, w.ContributionDays[d].ContributionLevel))
+			} else {
+				sb.WriteString(" ")
+			}
+			sb.WriteString(" ")
+		}
+		fmt.Fprintln(out, sb.String())
+	}
+
+	fmt.Fprintln(out)
+	// Legend: "Less ■ ■ ■ ■ ■ More" is 5 + (5*2) + 4 = 19 visible chars.
+	const legendWidth = 19
+	graphWidth := dayLabelWidth + len(weeks)*2
+	padding := max(graphWidth-legendWidth-5, 0)
+	var legend strings.Builder
+	legend.WriteString(strings.Repeat(" ", padding))
+	legend.WriteString(cs.Muted("Less "))
+	for _, lvl := range []string{"NONE", "FIRST_QUARTILE", "SECOND_QUARTILE", "THIRD_QUARTILE", "FOURTH_QUARTILE"} {
+		legend.WriteString(cell(cs, lvl))
+		legend.WriteString(" ")
+	}
+	legend.WriteString(cs.Muted("More"))
+	fmt.Fprintln(out, legend.String())
+
+	return nil
+}
+
+// renderMonthLabels writes month abbreviations above the first week of
+// each new month. Each week occupies 2 character columns.
+func renderMonthLabels(weeks []ContributionWeek) string {
+	const colW = 2
+	const labelLen = 3
+	cols := make([]rune, len(weeks)*colW+labelLen)
+	for i := range cols {
+		cols[i] = ' '
+	}
+
+	var prevMonth time.Month
+	for i, w := range weeks {
+		if len(w.ContributionDays) == 0 {
+			continue
+		}
+		t, err := time.Parse("2006-01-02", w.ContributionDays[0].Date)
+		if err != nil {
+			continue
+		}
+		m := t.Month()
+		if m == prevMonth {
+			continue
+		}
+		label := m.String()[:labelLen]
+		start := i * colW
+		overlaps := false
+		for k := 0; k < labelLen && start+k < len(cols); k++ {
+			if cols[start+k] != ' ' {
+				overlaps = true
+				break
+			}
+		}
+		if !overlaps && start+labelLen <= len(cols) {
+			for k, ch := range label {
+				cols[start+k] = ch
+			}
+		}
+		prevMonth = m
+	}
+	return strings.TrimRight(string(cols), " ")
+}

--- a/pkg/cmd/contributions/contributions_test.go
+++ b/pkg/cmd/contributions/contributions_test.go
@@ -1,0 +1,275 @@
+package contributions
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testHostConfig string
+
+func (c testHostConfig) DefaultHost() (string, string) { return string(c), "" }
+
+func TestNewCmdContributions(t *testing.T) {
+	tests := []struct {
+		name    string
+		cli     string
+		wants   ContributionsOptions
+		wantErr string
+	}{
+		{name: "defaults"},
+		{name: "user", cli: "-u octocat", wants: ContributionsOptions{User: "octocat"}},
+		{name: "from/to", cli: "--from 2024-01-01 --to 2024-06-30", wants: ContributionsOptions{From: "2024-01-01", To: "2024-06-30"}},
+		{name: "rejects positional arg", cli: "octocat", wantErr: `unknown command "octocat"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+				Config: func() (gh.Config, error) {
+					return config.NewBlankConfig(), nil
+				},
+			}
+
+			argv, err := shlex.Split(tt.cli)
+			require.NoError(t, err)
+
+			var got *ContributionsOptions
+			cmd := NewCmdContributions(f, func(opts *ContributionsOptions) error {
+				got = opts
+				return nil
+			})
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			_, err = cmd.ExecuteC()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wants.User, got.User)
+			assert.Equal(t, tt.wants.From, got.From)
+			assert.Equal(t, tt.wants.To, got.To)
+		})
+	}
+}
+
+func TestParseDate(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		got, err := parseDate("")
+		require.NoError(t, err)
+		assert.True(t, got.IsZero())
+	})
+	t.Run("date only", func(t *testing.T) {
+		got, err := parseDate("2024-03-15")
+		require.NoError(t, err)
+		assert.Equal(t, 2024, got.Year())
+		assert.Equal(t, time.March, got.Month())
+		assert.Equal(t, 15, got.Day())
+	})
+	t.Run("rfc3339", func(t *testing.T) {
+		got, err := parseDate("2024-03-15T10:30:00Z")
+		require.NoError(t, err)
+		assert.Equal(t, 10, got.Hour())
+	})
+	t.Run("invalid", func(t *testing.T) {
+		_, err := parseDate("not-a-date")
+		require.Error(t, err)
+	})
+}
+
+func TestContributionsRun_BadDateRange(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	opts := &ContributionsOptions{
+		IO:         ios,
+		HostConfig: testHostConfig("github.com"),
+		HttpClient: func() (*http.Client, error) { return &http.Client{}, nil },
+		From:       "2024-06-01",
+		To:         "2024-01-01",
+	}
+	err := contributionsRun(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--to must be on or after --from")
+}
+
+func TestContributionsRun_RendersCalendar(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.GraphQL(`query ViewerContributions\b`),
+		httpmock.StringResponse(`{
+			"data": {
+				"viewer": {
+					"login": "octocat",
+					"contributionsCollection": {
+						"contributionCalendar": {
+							"totalContributions": 42,
+							"weeks": [
+								{"contributionDays": [
+									{"date": "2024-01-07", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-08", "contributionCount": 5, "contributionLevel": "SECOND_QUARTILE"},
+									{"date": "2024-01-09", "contributionCount": 1, "contributionLevel": "FIRST_QUARTILE"},
+									{"date": "2024-01-10", "contributionCount": 10, "contributionLevel": "FOURTH_QUARTILE"},
+									{"date": "2024-01-11", "contributionCount": 7, "contributionLevel": "THIRD_QUARTILE"},
+									{"date": "2024-01-12", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-13", "contributionCount": 0, "contributionLevel": "NONE"}
+								]},
+								{"contributionDays": [
+									{"date": "2024-01-14", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-15", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-16", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-17", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-18", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-19", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-20", "contributionCount": 0, "contributionLevel": "NONE"}
+								]},
+								{"contributionDays": [
+									{"date": "2024-01-21", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-22", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-23", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-24", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-25", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-26", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-27", "contributionCount": 0, "contributionLevel": "NONE"}
+								]},
+								{"contributionDays": [
+									{"date": "2024-01-28", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-29", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-30", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-01-31", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-02-01", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-02-02", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-02-03", "contributionCount": 0, "contributionLevel": "NONE"}
+								]},
+								{"contributionDays": [
+									{"date": "2024-02-04", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-02-05", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-02-06", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-02-07", "contributionCount": 2, "contributionLevel": "FIRST_QUARTILE"},
+									{"date": "2024-02-08", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-02-09", "contributionCount": 0, "contributionLevel": "NONE"},
+									{"date": "2024-02-10", "contributionCount": 0, "contributionLevel": "NONE"}
+								]}
+							]
+						}
+					}
+				}
+			}
+		}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+	opts := &ContributionsOptions{
+		IO:         ios,
+		HostConfig: testHostConfig("github.com"),
+		HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+	}
+	require.NoError(t, contributionsRun(opts))
+
+	out := stdout.String()
+	assert.Contains(t, out, "42")
+	assert.Contains(t, out, "contributions")
+	assert.Contains(t, out, "octocat")
+	assert.Contains(t, out, "Jan")
+	assert.Contains(t, out, "Feb")
+	assert.Contains(t, out, "Less")
+	assert.Contains(t, out, "More")
+	assert.Contains(t, out, "M")
+	assert.Contains(t, out, "W")
+	assert.Contains(t, out, "F")
+}
+
+func TestContributionsRun_JSON(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.GraphQL(`query UserContributions\b`),
+		httpmock.StringResponse(`{
+			"data": {
+				"user": {
+					"login": "octocat",
+					"contributionsCollection": {
+						"contributionCalendar": {
+							"totalContributions": 3,
+							"weeks": [
+								{"contributionDays": [
+									{"date": "2024-01-01", "contributionCount": 1, "contributionLevel": "FIRST_QUARTILE"},
+									{"date": "2024-01-02", "contributionCount": 2, "contributionLevel": "FIRST_QUARTILE"}
+								]}
+							]
+						}
+					}
+				}
+			}
+		}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+	exp := cmdutil.NewJSONExporter()
+	exp.SetFields([]string{"login", "totalContributions", "days"})
+	opts := &ContributionsOptions{
+		IO:         ios,
+		HostConfig: testHostConfig("github.com"),
+		HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+		User:       "octocat",
+		Exporter:   exp,
+	}
+	require.NoError(t, contributionsRun(opts))
+
+	out := stdout.String()
+	assert.Contains(t, out, `"login":"octocat"`)
+	assert.Contains(t, out, `"totalContributions":3`)
+	assert.Contains(t, out, `"date":"2024-01-01"`)
+}
+
+func TestContributionsRun_UserNotFound(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.GraphQL(`query UserContributions\b`),
+		httpmock.StringResponse(`{"data": {"user": null}}`),
+	)
+
+	ios, _, _, _ := iostreams.Test()
+	opts := &ContributionsOptions{
+		IO:         ios,
+		HostConfig: testHostConfig("github.com"),
+		HttpClient: func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+		User:       "ghost",
+	}
+	err := contributionsRun(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+}
+
+func TestRenderMonthLabels(t *testing.T) {
+	weeks := []ContributionWeek{
+		{ContributionDays: []ContributionDay{{Date: "2024-01-07"}}},
+		{ContributionDays: []ContributionDay{{Date: "2024-01-14"}}},
+		{ContributionDays: []ContributionDay{{Date: "2024-01-21"}}},
+		{ContributionDays: []ContributionDay{{Date: "2024-01-28"}}},
+		{ContributionDays: []ContributionDay{{Date: "2024-02-04"}}},
+	}
+	got := renderMonthLabels(weeks)
+	assert.True(t, strings.HasPrefix(got, "Jan"), "want Jan prefix, got %q", got)
+	assert.Contains(t, got, "Feb")
+}

--- a/pkg/cmd/contributions/contributions_test.go
+++ b/pkg/cmd/contributions/contributions_test.go
@@ -191,9 +191,10 @@ func TestContributionsRun_RendersCalendar(t *testing.T) {
 	assert.Contains(t, out, "Feb")
 	assert.Contains(t, out, "Less")
 	assert.Contains(t, out, "More")
-	assert.Contains(t, out, "M")
-	assert.Contains(t, out, "W")
-	assert.Contains(t, out, "F")
+	// Day labels are rendered as a left-aligned column of width dayLabelWidth (4),
+	assert.Contains(t, out, "M ")
+	assert.Contains(t, out, "W ")
+	assert.Contains(t, out, "F ")
 }
 
 func TestContributionsRun_JSON(t *testing.T) {

--- a/pkg/cmd/contributions/http.go
+++ b/pkg/cmd/contributions/http.go
@@ -1,0 +1,125 @@
+package contributions
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/cli/cli/v2/api"
+)
+
+// ContributionDay represents a single day's contributions in the calendar.
+type ContributionDay struct {
+	Date              string `json:"date"`
+	ContributionCount int    `json:"contributionCount"`
+	ContributionLevel string `json:"contributionLevel"`
+}
+
+// ContributionWeek is a single week (up to 7 days) in the calendar.
+type ContributionWeek struct {
+	ContributionDays []ContributionDay `json:"contributionDays"`
+}
+
+// ContributionCalendar holds the full calendar data returned by the API.
+type ContributionCalendar struct {
+	TotalContributions int                `json:"totalContributions"`
+	Weeks              []ContributionWeek `json:"weeks"`
+}
+
+// ContributionsResult bundles the calendar with the resolved login.
+type ContributionsResult struct {
+	Login    string               `json:"login"`
+	From     time.Time            `json:"from"`
+	To       time.Time            `json:"to"`
+	Calendar ContributionCalendar `json:"calendar"`
+}
+
+const calendarFragment = `
+fragment Calendar on ContributionsCollection {
+	contributionCalendar {
+		totalContributions
+		weeks {
+			contributionDays {
+				date
+				contributionCount
+				contributionLevel
+			}
+		}
+	}
+}
+`
+
+// fetchContributions retrieves the contribution calendar for the given user
+// (or the authenticated viewer if login is empty). from/to may be zero values.
+func fetchContributions(client *http.Client, hostname, login string, from, to time.Time) (*ContributionsResult, error) {
+	c := api.NewClientFromHTTP(client)
+
+	variables := map[string]interface{}{}
+	if !from.IsZero() {
+		variables["from"] = from.Format(time.RFC3339)
+	}
+	if !to.IsZero() {
+		variables["to"] = to.Format(time.RFC3339)
+	}
+
+	if login == "" {
+		query := calendarFragment + `
+		query ViewerContributions($from: DateTime, $to: DateTime) {
+			viewer {
+				login
+				contributionsCollection(from: $from, to: $to) {
+					...Calendar
+				}
+			}
+		}`
+		var resp struct {
+			Viewer struct {
+				Login                   string
+				ContributionsCollection struct {
+					ContributionCalendar ContributionCalendar
+				}
+			}
+		}
+		if err := c.GraphQL(hostname, query, variables, &resp); err != nil {
+			return nil, err
+		}
+		return &ContributionsResult{
+			Login:    resp.Viewer.Login,
+			From:     from,
+			To:       to,
+			Calendar: resp.Viewer.ContributionsCollection.ContributionCalendar,
+		}, nil
+	}
+
+	query := calendarFragment + `
+	query UserContributions($login: String!, $from: DateTime, $to: DateTime) {
+		user(login: $login) {
+			login
+			contributionsCollection(from: $from, to: $to) {
+				...Calendar
+			}
+		}
+	}`
+	variables["login"] = login
+
+	var resp struct {
+		User *struct {
+			Login                   string
+			ContributionsCollection struct {
+				ContributionCalendar ContributionCalendar
+			}
+		}
+	}
+	if err := c.GraphQL(hostname, query, variables, &resp); err != nil {
+		return nil, err
+	}
+	if resp.User == nil {
+		return nil, fmt.Errorf("could not find user %q", login)
+	}
+	return &ContributionsResult{
+		Login:    resp.User.Login,
+		From:     from,
+		To:       to,
+		Calendar: resp.User.ContributionsCollection.ContributionCalendar,
+	}, nil
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -20,6 +20,7 @@ import (
 	codespaceCmd "github.com/cli/cli/v2/pkg/cmd/codespace"
 	completionCmd "github.com/cli/cli/v2/pkg/cmd/completion"
 	configCmd "github.com/cli/cli/v2/pkg/cmd/config"
+	contributionsCmd "github.com/cli/cli/v2/pkg/cmd/contributions"
 	copilotCmd "github.com/cli/cli/v2/pkg/cmd/copilot"
 	extensionCmd "github.com/cli/cli/v2/pkg/cmd/extension"
 	"github.com/cli/cli/v2/pkg/cmd/factory"
@@ -153,6 +154,7 @@ func NewCmdRoot(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, versi
 
 	// Root commands with standalone functionality and no subcommands
 	cmd.AddCommand(copilotCmd.NewCmdCopilot(f, nil))
+	cmd.AddCommand(contributionsCmd.NewCmdContributions(f, nil))
 	cmd.AddCommand(statusCmd.NewCmdStatus(f, nil))
 	cmd.AddCommand(creditsCmd.NewCmdCredits(f, nil))
 	cmd.AddCommand(licensesCmd.NewCmdLicenses(f))


### PR DESCRIPTION

<img width="1918" height="1700" alt="image" src="https://github.com/user-attachments/assets/6a2c4766-3237-4598-85e8-4b04686ec76b" />


Adds `gh contributions` to display GitHub contributions graph on the terminal.
