### PR TITLE
fix(search): use OR operator for multiple repo/user qualifiers in web search URLs

### DIFF
--- a/pkg/cmd/search/code/code_test.go
+++ b/pkg/cmd/search/code/code_test.go
@@ -361,6 +361,22 @@ func TestCodeRun(t *testing.T) {
 			wantBrowse: "https://github.com/search?q=map+path%3Atesting.cpp&type=code",
 		},
 		{
+			name: "opens browser with OR-ed repos in web mode",
+			opts: &CodeOptions{
+				Query: search.Query{
+					Keywords: []string{"HTTPClient"},
+					Kind:     "code",
+					Limit:    30,
+					Qualifiers: search.Qualifiers{
+						Repo: []string{"cli/cli", "cli/go-gh"},
+					},
+				},
+				Searcher: search.NewSearcher(nil, "github.com", &fd.DisabledDetectorMock{}),
+				WebMode:  true,
+			},
+			wantBrowse: "https://github.com/search?q=HTTPClient+%28repo%3Acli%2Fcli+OR+repo%3Acli%2Fgo-gh%29&type=code",
+		},
+		{
 			name: "does not convert filename and extension qualifiers for GHES web search",
 			opts: &CodeOptions{
 				Config: func() (gh.Config, error) {

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -127,6 +127,30 @@ func (q Query) StandardSearchString() string {
 	return strings.TrimSpace(strings.Join(all, " "))
 }
 
+// WebSearchString returns the string representation of the query suitable for
+// use in the global search web GUI (i.e. github.com/search). Unlike the
+// standard search string, this format uses explicit OR operators for qualifiers
+// that the web search GUI does not implicitly OR, such as repo and user.
+func (q Query) WebSearchString() string {
+	qualifiers := formatQualifiers(q.Qualifiers, formatWebSearch)
+	var keywords []string
+	if q.ImmutableKeywords != "" {
+		keywords = []string{q.ImmutableKeywords}
+	} else if ks := formatKeywords(q.Keywords); len(ks) > 0 {
+		keywords = ks
+	}
+	all := append(keywords, qualifiers...)
+	return strings.TrimSpace(strings.Join(all, " "))
+}
+
+func formatWebSearch(qualifier string, vs []string) (s []string, applicable bool) {
+	switch qualifier {
+	case "repo", "user":
+		return []string{groupWithOR(qualifier, vs)}, true
+	}
+	return nil, false
+}
+
 // AdvancedIssueSearchString returns the string representation of the query
 // compatible with the advanced issue search syntax. The query can be used in
 // Issues tab (of repositories) and the Issues dashboard (i.e.

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -238,6 +238,98 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 	}
 }
 
+func TestWebSearchString(t *testing.T) {
+	tests := []struct {
+		name  string
+		query Query
+		out   string
+	}{
+		{
+			name: "empty query",
+			out:  "",
+		},
+		{
+			name: "single repo does not use OR",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					Repo: []string{"cli/cli"},
+				},
+			},
+			out: "keyword repo:cli/cli",
+		},
+		{
+			name: "multiple repos are OR-ed",
+			query: Query{
+				Keywords: []string{"HTTPClient"},
+				Qualifiers: Qualifiers{
+					Repo: []string{"cli/cli", "cli/go-gh"},
+				},
+			},
+			out: "HTTPClient (repo:cli/cli OR repo:cli/go-gh)",
+		},
+		{
+			name: "multiple users are OR-ed",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					User: []string{"johndoe", "janedoe"},
+				},
+			},
+			out: "keyword (user:janedoe OR user:johndoe)",
+		},
+		{
+			name: "repos and users are both OR-ed",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					Repo:  []string{"cli/cli", "cli/go-gh"},
+					User:  []string{"alice", "bob"},
+					Label: []string{"bug"},
+				},
+			},
+			out: "keyword label:bug (repo:cli/cli OR repo:cli/go-gh) (user:alice OR user:bob)",
+		},
+		{
+			name: "non-special qualifiers are not OR-ed",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					Repo:   []string{"cli/cli", "cli/go-gh"},
+					Label:  []string{"bug", "enhancement"},
+					Topic:  []string{"topic1", "topic2"},
+				},
+			},
+			out: "keyword label:bug label:enhancement (repo:cli/cli OR repo:cli/go-gh) topic:topic1 topic:topic2",
+		},
+		{
+			name: "respects immutable keywords with multiple repos",
+			query: Query{
+				ImmutableKeywords: "immutable keyword",
+				Qualifiers: Qualifiers{
+					Repo: []string{"cli/cli", "cli/go-gh"},
+				},
+			},
+			out: "immutable keyword (repo:cli/cli OR repo:cli/go-gh)",
+		},
+		{
+			name: "quotes qualifiers in web search",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					Repo: []string{"cli/cli", "org/repo with spaces"},
+				},
+			},
+			out: `keyword (repo:"org/repo with spaces" OR repo:cli/cli)`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, tt.query.WebSearchString())
+		})
+	}
+}
+
 func TestQualifiersMap(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -275,7 +275,10 @@ func (s searcher) URL(query Query) string {
 	// search syntax (even for the issues/PRs tab on the sidebar). When the GUI
 	// is updated, we can use feature detection, and, if available, use the
 	// advanced search syntax.
-	qs.Set("q", query.StandardSearchString())
+	//
+	// Unlike the REST API which implicitly ORs certain qualifiers like repo and
+	// user, the web search GUI ANDs them, requiring explicit OR operators.
+	qs.Set("q", query.WebSearchString())
 
 	if query.Order != "" {
 		qs.Set(orderKey, query.Order)

--- a/pkg/search/searcher_test.go
+++ b/pkg/search/searcher_test.go
@@ -1256,6 +1256,28 @@ func TestSearcherURL(t *testing.T) {
 			},
 			url: "https://github.com/search?q=%22keyword+with+whitespace%22&type=repositories",
 		},
+		{
+			name: "outputs encoded query url with OR-ed multiple repos for web search",
+			query: Query{
+				Keywords: []string{"HTTPClient"},
+				Kind:     "code",
+				Qualifiers: Qualifiers{
+					Repo: []string{"cli/cli", "cli/go-gh"},
+				},
+			},
+			url: "https://github.com/search?q=HTTPClient+%28repo%3Acli%2Fcli+OR+repo%3Acli%2Fgo-gh%29&type=code",
+		},
+		{
+			name: "outputs encoded query url with single repo unchanged for web search",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Kind:     "code",
+				Qualifiers: Qualifiers{
+					Repo: []string{"cli/cli"},
+				},
+			},
+			url: "https://github.com/search?q=keyword+repo%3Acli%2Fcli&type=code",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #9252

When constructing web search URLs with multiple --repo flags, the query
was generating unsatisfiable conditions like `repo:A repo:B` which the
GitHub web search ANDs together. The web search requires explicit OR
operators: `repo:A OR repo:B`.

Add Query.WebSearchString() method that formats repo and user qualifiers
with explicit OR operators, and use it in searcher.URL() instead of
StandardSearchString() which is used for the REST API (where these
qualifiers are implicitly OR'd).