### PR TITLE
Fix `skills publish --fix` to not publish

### DIFF
--- a/pkg/cmd/skills/publish/publish.go
+++ b/pkg/cmd/skills/publish/publish.go
@@ -140,7 +140,7 @@ func NewCmdPublish(f *cmdutil.Factory, runF func(*PublishOptions) error) *cobra.
 			$ gh skill publish --dry-run
 
 			# Strip install metadata without publishing
-			$ gh skills publish --fix
+			$ gh skill publish --fix
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -413,7 +413,7 @@ func publishRun(opts *PublishOptions) error {
 
 	if opts.Fix {
 		if fixes > 0 {
-			fmt.Fprintf(opts.IO.ErrOut, "\nFixed %d file(s). Review and commit the changes, then run %s to publish.\n", fixes, "gh skills publish")
+			fmt.Fprintf(opts.IO.ErrOut, "\nFixed %d file(s). Review and commit the changes, then run %s to publish.\n", fixes, "gh skill publish")
 		} else {
 			fmt.Fprintf(opts.IO.ErrOut, "\nNo issues to fix.\n")
 		}

--- a/pkg/cmd/skills/publish/publish.go
+++ b/pkg/cmd/skills/publish/publish.go
@@ -147,6 +147,9 @@ func NewCmdPublish(f *cmdutil.Factory, runF func(*PublishOptions) error) *cobra.
 			if len(args) == 1 {
 				opts.Dir = args[0]
 			}
+			if err := cmdutil.MutuallyExclusive("specify only one of `--fix` or `--dry-run`", opts.Fix, opts.DryRun); err != nil {
+				return err
+			}
 			if runF != nil {
 				return runF(opts)
 			}
@@ -1069,7 +1072,7 @@ func renderDiagnosticsTTY(opts *PublishOptions, skillCount int, diagnostics []pu
 		fmt.Fprintf(opts.IO.ErrOut, "\n%s\n", d.message)
 	}
 
-	if errors == 0 {
+	if errors == 0 && !opts.Fix {
 		if owner != "" && repo != "" {
 			fmt.Fprintf(opts.IO.ErrOut, "\n%s Repository: %s/%s\n", cs.Green("Ready to publish!"), owner, repo)
 		} else {

--- a/pkg/cmd/skills/publish/publish.go
+++ b/pkg/cmd/skills/publish/publish.go
@@ -126,7 +126,8 @@ func NewCmdPublish(f *cmdutil.Factory, runF func(*PublishOptions) error) *cobra.
 
 			Use %[1]s--dry-run%[1]s to validate without publishing.
 			Use %[1]s--tag%[1]s to publish non-interactively with a specific tag.
-			Use %[1]s--fix%[1]s to automatically strip install metadata from committed files.
+			Use %[1]s--fix%[1]s to automatically strip install metadata from committed files
+			without publishing. Review and commit the changes, then run publish again.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# Validate and publish interactively
@@ -138,7 +139,7 @@ func NewCmdPublish(f *cmdutil.Factory, runF func(*PublishOptions) error) *cobra.
 			# Validate only (no publish)
 			$ gh skill publish --dry-run
 
-			# Validate and strip install metadata
+			# Strip install metadata without publishing
 			$ gh skills publish --fix
 		`),
 		Args: cobra.MaximumNArgs(1),
@@ -153,7 +154,7 @@ func NewCmdPublish(f *cmdutil.Factory, runF func(*PublishOptions) error) *cobra.
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.Fix, "fix", false, "Auto-fix issues where possible (e.g. strip install metadata)")
+	cmd.Flags().BoolVar(&opts.Fix, "fix", false, "Auto-fix issues where possible without publishing (e.g. strip install metadata)")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Validate without publishing")
 	cmd.Flags().StringVar(&opts.Tag, "tag", "", "Version tag for the release (e.g. v1.0.0)")
 
@@ -407,6 +408,15 @@ func publishRun(opts *PublishOptions) error {
 	// --- Publish flow ---
 	if opts.DryRun {
 		fmt.Fprintf(opts.IO.ErrOut, "\nDry run complete. Use without --dry-run to publish.\n")
+		return nil
+	}
+
+	if opts.Fix {
+		if fixes > 0 {
+			fmt.Fprintf(opts.IO.ErrOut, "\nFixed %d file(s). Review and commit the changes, then run %s to publish.\n", fixes, "gh skills publish")
+		} else {
+			fmt.Fprintf(opts.IO.ErrOut, "\nNo issues to fix.\n")
+		}
 		return nil
 	}
 

--- a/pkg/cmd/skills/publish/publish_test.go
+++ b/pkg/cmd/skills/publish/publish_test.go
@@ -457,6 +457,7 @@ func TestPublishRun(t *testing.T) {
 				return &PublishOptions{IO: ios, Dir: dir, Fix: true}
 			},
 			wantStdout: "stripped install metadata",
+			wantStderr: "Fixed 1 file(s). Review and commit the changes",
 			verify: func(t *testing.T, dir string) {
 				t.Helper()
 				fixed, err := os.ReadFile(filepath.Join(dir, "skills", "test-skill", "SKILL.md"))

--- a/pkg/cmd/skills/publish/publish_test.go
+++ b/pkg/cmd/skills/publish/publish_test.go
@@ -86,13 +86,15 @@ func TestNewCmdPublish(t *testing.T) {
 		wantsOpts PublishOptions
 	}{
 		{
-			name: "all flags",
-			cli:  "./monalisa-skills --dry-run --fix --tag v1.0.0",
+			name:     "fix and dry-run are mutually exclusive",
+			cli:      "./monalisa-skills --dry-run --fix --tag v1.0.0",
+			wantsErr: true,
+		},
+		{
+			name: "fix flag only",
+			cli:  "--fix",
 			wantsOpts: PublishOptions{
-				Dir:    "./monalisa-skills",
-				DryRun: true,
-				Fix:    true,
-				Tag:    "v1.0.0",
+				Fix: true,
 			},
 		},
 		{


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

When `--fix` is used with `gh skills publish`, the command rewrites SKILL.md files on disk (stripping `metadata.github-*` keys). Since those changes are uncommitted, continuing to publish would release the old content -- the repo is out of sync. This makes `--fix` behave like `--dry-run`: it applies the fixes, tells the user to commit, and returns early without publishing.

### Changes

- Add an early return after diagnostics when `--fix` is set, printing a message that tells the user to review and commit before re-running publish
- Update `--fix` flag description and help text to clarify it does not publish
- Add `wantStderr` assertion to the existing `--fix` test case