### PR TITLE
docs: fix typos in code comments

### DIFF
--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -357,7 +357,7 @@ func (d *detector) SearchFeatures() (SearchFeatures, error) {
 	//
 	// Since there's no schema-wise difference between pre-deprecation and
 	// deprecation periods (i.e. `ISSUE_ADVANCED` is available during both),
-	// we cannot figure out the exact time period. The consensus is to to use
+	// we cannot figure out the exact time period. The consensus is to use
 	// the advanced search syntax during both periods.
 
 	var feature SearchFeatures

--- a/pkg/cmd/pr/shared/find_refs_resolution.go
+++ b/pkg/cmd/pr/shared/find_refs_resolution.go
@@ -21,7 +21,7 @@ import (
 // <owner>:<branch>. The GitHub API is able to interpret this format in order
 // to discover the correct fork repository.
 //
-// In other parts of the code, you may see this refered to as a HeadLabel.
+// In other parts of the code, you may see this referred to as a HeadLabel.
 type QualifiedHeadRef struct {
 	owner      o.Option[string]
 	branchName string

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -328,7 +328,7 @@ func runRun(opts *RunOptions) error {
 
 	// TODO workflowDispatchRunDetailsCleanup
 	// We will have to always set the `return_run_details` field to true, unless
-	// we opt into the the new REST API version, which will probably return the
+	// we opt into the new REST API version, which will probably return the
 	// details by default.
 	if features.DispatchRunDetails {
 		requestBody["return_run_details"] = true


### PR DESCRIPTION

**Repo:** cli/cli (⭐ 38000)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Fixes three small typos in Go source-file comments: "refered" → "referred" in `pkg/cmd/pr/shared/find_refs_resolution.go`, and a duplicated "to to" / "the the" in `internal/featuredetection/feature_detection.go` and `pkg/cmd/workflow/run/run.go`.

## Why
Comments are part of the code's documentation for maintainers. Small typos don't break functionality but add noise when reading through the code. Each fix is isolated to a single comment line and has no behavioural impact.

## Testing
No code behaviour changes — comments only. `go build ./...` is sufficient to verify nothing was accidentally broken. No new tests needed.

## Risk
Low — comment-only edits in three unrelated files.
