### PR TITLE
fix(skills): match skills by install name in preview command

### DIFF
--- a/pkg/cmd/skills/preview/preview.go
+++ b/pkg/cmd/skills/preview/preview.go
@@ -391,7 +391,7 @@ func isMarkdownFile(filePath string) bool {
 func selectSkill(opts *PreviewOptions, skills []discovery.Skill) (discovery.Skill, error) {
 	if opts.SkillName != "" {
 		for _, s := range skills {
-			if s.DisplayName() == opts.SkillName || s.Name == opts.SkillName {
+			if s.DisplayName() == opts.SkillName || s.Name == opts.SkillName || s.InstallName() == opts.SkillName {
 				return s, nil
 			}
 		}

--- a/pkg/cmd/skills/preview/preview.go
+++ b/pkg/cmd/skills/preview/preview.go
@@ -391,7 +391,14 @@ func isMarkdownFile(filePath string) bool {
 func selectSkill(opts *PreviewOptions, skills []discovery.Skill) (discovery.Skill, error) {
 	if opts.SkillName != "" {
 		for _, s := range skills {
-			if s.DisplayName() == opts.SkillName || s.Name == opts.SkillName || s.InstallName() == opts.SkillName {
+			if s.DisplayName() == opts.SkillName || s.Name == opts.SkillName {
+				return s, nil
+			}
+		}
+		// Fall back to InstallName so that namespaced identifiers produced
+		// by the post-install hint (e.g. "namespace/skill") are accepted.
+		for _, s := range skills {
+			if s.InstallName() == opts.SkillName {
 				return s, nil
 			}
 		}

--- a/pkg/cmd/skills/preview/preview_test.go
+++ b/pkg/cmd/skills/preview/preview_test.go
@@ -207,6 +207,51 @@ func TestPreviewRun(t *testing.T) {
 			wantStdout: "My Skill",
 		},
 		{
+			name: "preview plugins skill matched by install name",
+			tty:  true,
+			opts: &PreviewOptions{
+				repo:      ghrepo.New("owner", "repo"),
+				SkillName: "aws-common/aws-mcp-setup",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/owner/repo/releases/latest"),
+					httpmock.StringResponse(`{"tag_name": "v1.0.0"}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/owner/repo/git/ref/tags/v1.0.0"),
+					httpmock.StringResponse(`{"object": {"sha": "abc123", "type": "commit"}}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/owner/repo/git/trees/abc123"),
+					httpmock.StringResponse(`{
+						"sha": "abc123",
+						"truncated": false,
+						"tree": [
+							{"path": "plugins", "type": "tree", "sha": "tree-plugins"},
+							{"path": "plugins/aws-common", "type": "tree", "sha": "tree-awscommon"},
+							{"path": "plugins/aws-common/skills", "type": "tree", "sha": "tree-awsskills"},
+							{"path": "plugins/aws-common/skills/aws-mcp-setup", "type": "tree", "sha": "treeSHA3"},
+							{"path": "plugins/aws-common/skills/aws-mcp-setup/SKILL.md", "type": "blob", "sha": "blob789"}
+						]
+					}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/owner/repo/git/trees/treeSHA3"),
+					httpmock.StringResponse(`{
+						"tree": [
+							{"path": "SKILL.md", "type": "blob", "sha": "blob789", "size": 50}
+						]
+					}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/owner/repo/git/blobs/blob789"),
+					httpmock.StringResponse(`{"sha": "blob789", "content": "`+encodedContent+`", "encoding": "base64"}`),
+				)
+			},
+			wantStdout: "My Skill",
+		},
+		{
 			name: "skill not found",
 			tty:  true,
 			opts: &PreviewOptions{


### PR DESCRIPTION
## Summary

Fixes #13248

After `gh skill install`, the output suggests a `gh skill preview` command using the skill's `InstallName()` (e.g., `aws-common/aws-mcp-setup` for plugins-convention skills). However, the preview command's `selectSkill` function only matched against `DisplayName()` and `Name`, neither of which matched:

- `DisplayName()` for plugins convention = `[plugins] aws-common/aws-mcp-setup`
- `Name` = `aws-mcp-setup`
- `InstallName()` = `aws-common/aws-mcp-setup` (what the install hint outputs)

## Changes

- **`pkg/cmd/skills/preview/preview.go`**: Added `s.InstallName()` as an additional match criterion in `selectSkill`, so namespaced skill identifiers from the install hint are accepted.
- **`pkg/cmd/skills/preview/preview_test.go`**: Added test case for plugins-convention skills matched by install name.

## End-to-end verification

Before fix:
```
$ gh skill preview zxkane/aws-skills aws-common/aws-mcp-setup@e4ef2e2147aa5d7b812af8970064dd822c7678ec
skill "aws-common/aws-mcp-setup" not found in zxkane/aws-skills
```

After fix:
```
$ gh skill preview zxkane/aws-skills aws-common/aws-mcp-setup@e4ef2e2147aa5d7b812af8970064dd822c7678ec
[plugins] aws-common/aws-mcp-setup/
└── SKILL.md

── SKILL.md ──

# AWS MCP Server Configuration Guide
...
```