### PR TITLE
Include categorized host in telemetry

### DIFF
--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	"github.com/cli/cli/v2/internal/ghinstance"
+	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/internal/update"
 	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
@@ -195,31 +196,7 @@ func Main() exitCode {
 
 	var executedCmd *cobra.Command
 	defer func() {
-		if executedCmd == nil {
-			telemetryService.Record(ghtelemetry.Event{
-				Type: "missing_command",
-			})
-			return
-		}
-
-		if cmdutil.IsTelemetryDisabled(executedCmd) {
-			return
-		}
-
-		var flags []string
-		executedCmd.Flags().Visit(func(f *pflag.Flag) {
-			flags = append(flags, f.Name)
-		})
-		slices.Sort(flags)
-
-		telemetryService.Record(ghtelemetry.Event{
-			Type: "command_invocation",
-			Dimensions: ghtelemetry.Dimensions{
-				"command":           executedCmd.CommandPath(),
-				"flags":             strings.Join(flags, ","),
-				"guessed_host_type": ghinstance.CategorizeHost(telemetry.GuessTargetHost(executedCmd, cmdFactory.BaseRepo, cmdFactory.Config)),
-			},
-		})
+		recordCommandTelemetry(telemetryService, executedCmd, cmdFactory.BaseRepo, cmdFactory.Config)
 	}()
 
 	if executedCmd, err = rootCmd.ExecuteContextC(ctx); err != nil {
@@ -519,5 +496,46 @@ func mightBeGHESUser(cfg gh.Config) bool {
 	// If any targeted host is Enterprise, then the user is likely a GHES user.
 	return slices.ContainsFunc(cfg.Authentication().Hosts(), func(host string) bool {
 		return ghauth.IsEnterprise(host)
+	})
+}
+
+// recordCommandTelemetry records a command_invocation telemetry event for the
+// given command, or a missing_command event when cmd is nil. Commands marked
+// as telemetry-disabled (e.g. aliases, auth, completion) are silently skipped.
+//
+// Note: user-defined aliases have telemetry disabled because alias names may
+// contain sensitive information. When a gh alias re-dispatches to a core
+// command via root.Execute(), the expanded command does not get a separate
+// telemetry event - this is an accepted trade-off for simplicity.
+func recordCommandTelemetry(
+	service ghtelemetry.Service,
+	cmd *cobra.Command,
+	baseRepo func() (ghrepo.Interface, error),
+	config func() (gh.Config, error),
+) {
+	if cmd == nil {
+		service.Record(ghtelemetry.Event{
+			Type: "missing_command",
+		})
+		return
+	}
+
+	if cmdutil.IsTelemetryDisabled(cmd) {
+		return
+	}
+
+	var flags []string
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		flags = append(flags, f.Name)
+	})
+	slices.Sort(flags)
+
+	service.Record(ghtelemetry.Event{
+		Type: "command_invocation",
+		Dimensions: ghtelemetry.Dimensions{
+			"command":           cmd.CommandPath(),
+			"flags":             strings.Join(flags, ","),
+			"guessed_host_type": ghinstance.CategorizeHost(telemetry.GuessTargetHost(cmd, baseRepo, config)),
+		},
 	})
 }

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cli/cli/v2/internal/config/migration"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
+	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/internal/update"
 	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
@@ -37,6 +38,7 @@ import (
 	"github.com/cli/safeexec"
 	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type exitCode int
@@ -191,7 +193,36 @@ func Main() exitCode {
 
 	rootCmd.SetArgs(expandedArgs)
 
-	if cmd, err := rootCmd.ExecuteContextC(ctx); err != nil {
+	var executedCmd *cobra.Command
+	defer func() {
+		if executedCmd == nil {
+			telemetryService.Record(ghtelemetry.Event{
+				Type: "missing_command",
+			})
+			return
+		}
+
+		if cmdutil.IsTelemetryDisabled(executedCmd) {
+			return
+		}
+
+		var flags []string
+		executedCmd.Flags().Visit(func(f *pflag.Flag) {
+			flags = append(flags, f.Name)
+		})
+		slices.Sort(flags)
+
+		telemetryService.Record(ghtelemetry.Event{
+			Type: "command_invocation",
+			Dimensions: ghtelemetry.Dimensions{
+				"command":           executedCmd.CommandPath(),
+				"flags":             strings.Join(flags, ","),
+				"guessed_host_type": ghinstance.CategorizeHost(telemetry.GuessTargetHost(executedCmd, cmdFactory.BaseRepo, cmdFactory.Config)),
+			},
+		})
+	}()
+
+	if executedCmd, err = rootCmd.ExecuteContextC(ctx); err != nil {
 		var pagerPipeError *iostreams.ErrClosedPagerPipe
 		var noResultsError cmdutil.NoResultsError
 		var extError *root.ExternalCommandExitError
@@ -222,7 +253,7 @@ func Main() exitCode {
 			return exitCode(extError.ExitCode())
 		}
 
-		printError(stderr, err, cmd, hasDebug)
+		printError(stderr, err, executedCmd, hasDebug)
 
 		if strings.Contains(err.Error(), "Incorrect function") {
 			fmt.Fprintln(stderr, "You appear to be running in MinTTY without pseudo terminal support.")

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	ghmock "github.com/cli/cli/v2/internal/gh/mock"
+	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	ghAPI "github.com/cli/go-gh/v2/pkg/api"
 	"github.com/spf13/cobra"
@@ -582,6 +584,88 @@ func Test_authRecoveryCommand(t *testing.T) {
 			got := authRecoveryCommand(cfg, httpErr)
 			if got != tt.want {
 				t.Errorf("authRecoveryCommand() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordCommandTelemetry(t *testing.T) {
+	tests := []struct {
+		name      string
+		cmd       *cobra.Command
+		wantEvent *ghtelemetry.Event
+	}{
+		{
+			name: "records command_invocation for normal command",
+			cmd: func() *cobra.Command {
+				root := &cobra.Command{Use: "gh"}
+				child := &cobra.Command{Use: "pr"}
+				leaf := &cobra.Command{Use: "list"}
+				leaf.Flags().String("repo", "", "")
+				root.AddCommand(child)
+				child.AddCommand(leaf)
+				return leaf
+			}(),
+			wantEvent: &ghtelemetry.Event{
+				Type: "command_invocation",
+				Dimensions: ghtelemetry.Dimensions{
+					"command":           "gh pr list",
+					"flags":             "",
+					"guessed_host_type": "uncategorized",
+				},
+			},
+		},
+		{
+			name: "records visited flags",
+			cmd: func() *cobra.Command {
+				root := &cobra.Command{Use: "gh"}
+				leaf := &cobra.Command{Use: "list"}
+				leaf.Flags().String("repo", "cli/cli", "")
+				leaf.Flags().Bool("web", true, "")
+				// Mark flags as visited by setting them
+				_ = leaf.Flags().Set("repo", "cli/cli")
+				_ = leaf.Flags().Set("web", "true")
+				root.AddCommand(leaf)
+				return leaf
+			}(),
+			wantEvent: &ghtelemetry.Event{
+				Type: "command_invocation",
+				Dimensions: ghtelemetry.Dimensions{
+					"command":           "gh list",
+					"flags":             "repo,web",
+					"guessed_host_type": "github.com",
+				},
+			},
+		},
+		{
+			name: "records missing_command when cmd is nil",
+			cmd:  nil,
+			wantEvent: &ghtelemetry.Event{
+				Type: "missing_command",
+			},
+		},
+		{
+			name: "skips telemetry-disabled commands",
+			cmd: func() *cobra.Command {
+				cmd := &cobra.Command{Use: "my-alias"}
+				cmdutil.DisableTelemetry(cmd)
+				return cmd
+			}(),
+			wantEvent: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &telemetry.CommandRecorderSpy{}
+			recordCommandTelemetry(svc, tt.cmd, nil, nil)
+			if tt.wantEvent == nil {
+				assert.Empty(t, svc.Events)
+			} else {
+				assert.Len(t, svc.Events, 1)
+				assert.Equal(t, tt.wantEvent.Type, svc.Events[0].Type)
+				if tt.wantEvent.Dimensions != nil {
+					assert.Equal(t, tt.wantEvent.Dimensions, svc.Events[0].Dimensions)
+				}
 			}
 		})
 	}

--- a/internal/ghinstance/host.go
+++ b/internal/ghinstance/host.go
@@ -98,6 +98,10 @@ func HostPrefix(hostname string) string {
 }
 
 func CategorizeHost(host string) string {
+	if host == "" {
+		return "uncategorized"
+	}
+
 	if host == defaultHostname {
 		return "github.com"
 	}

--- a/internal/ghinstance/host_test.go
+++ b/internal/ghinstance/host_test.go
@@ -204,6 +204,11 @@ func TestCategorizeHost(t *testing.T) {
 			host: "garage.github.com",
 			want: "uncategorized",
 		},
+		{
+			name: "empty host returns uncategorized",
+			host: "",
+			want: "uncategorized",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/telemetry/host.go
+++ b/internal/telemetry/host.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/ghrepo"
+	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +35,7 @@ func GuessTargetHost(
 
 	// 2. --hostname flag (used by auth, api, attestation commands)
 	if hostname, err := cmd.Flags().GetString("hostname"); err == nil && hostname != "" {
-		return hostname
+		return ghauth.NormalizeHostname(hostname)
 	}
 
 	// 3. Positional repo argument for "gh repo <subcommand> [OWNER/REPO]" commands
@@ -54,7 +55,9 @@ func GuessTargetHost(
 	}
 
 	// 5. Git remotes; expected to be BaseRepoFunc (local, no network) in root's closure.
-	if baseRepo != nil {
+	// Only attempt this for commands that are likely repo-scoped (have a --repo flag)
+	// to avoid triggering git remote discovery for host-agnostic commands like "gh version".
+	if baseRepo != nil && cmd.Flags().Lookup("repo") != nil {
 		if repo, err := baseRepo(); err == nil {
 			return repo.RepoHost()
 		}

--- a/internal/telemetry/host.go
+++ b/internal/telemetry/host.go
@@ -1,0 +1,72 @@
+package telemetry
+
+import (
+	"os"
+
+	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/spf13/cobra"
+)
+
+// GuessTargetHost determines the GitHub host that the current command targets.
+// It checks sources in priority order: explicit flags/args first (--repo flag,
+// --hostname flag, repo positional arg), then environment (GH_REPO), then
+// git remotes, and finally the configured default host.
+//
+// It returns the empty string when no signal can be found. Callers that need a
+// categorical bucket should pipe the result through ghinstance.CategorizeHost,
+// which maps "" to "uncategorized".
+//
+// The baseRepo and config parameters correspond to cmdutil.Factory's BaseRepo
+// and Config fields. They are passed as narrow functions instead of the full
+// Factory to avoid an import cycle between this package and pkg/cmdutil.
+func GuessTargetHost(
+	cmd *cobra.Command,
+	baseRepo func() (ghrepo.Interface, error),
+	config func() (gh.Config, error),
+) string {
+	// 1. --repo flag (explicit flag takes highest priority)
+	if repoFlag, err := cmd.Flags().GetString("repo"); err == nil && repoFlag != "" {
+		if r, err := ghrepo.FromFullName(repoFlag); err == nil {
+			return r.RepoHost()
+		}
+	}
+
+	// 2. --hostname flag (used by auth, api, attestation commands)
+	if hostname, err := cmd.Flags().GetString("hostname"); err == nil && hostname != "" {
+		return hostname
+	}
+
+	// 3. Positional repo argument for "gh repo <subcommand> [OWNER/REPO]" commands
+	if cmd.Parent() != nil && cmd.Parent().Name() == "repo" {
+		if args := cmd.Flags().Args(); len(args) > 0 {
+			if r, err := ghrepo.FromFullName(args[0]); err == nil {
+				return r.RepoHost()
+			}
+		}
+	}
+
+	// 4. GH_REPO env var
+	if ghRepo := os.Getenv("GH_REPO"); ghRepo != "" {
+		if r, err := ghrepo.FromFullName(ghRepo); err == nil {
+			return r.RepoHost()
+		}
+	}
+
+	// 5. Git remotes; expected to be BaseRepoFunc (local, no network) in root's closure.
+	if baseRepo != nil {
+		if repo, err := baseRepo(); err == nil {
+			return repo.RepoHost()
+		}
+	}
+
+	// 6. Default host from config / GH_HOST env
+	if config != nil {
+		if cfg, err := config(); err == nil {
+			host, _ := cfg.Authentication().DefaultHost()
+			return host
+		}
+	}
+
+	return ""
+}

--- a/internal/telemetry/host_test.go
+++ b/internal/telemetry/host_test.go
@@ -36,126 +36,159 @@ func newCmd(t *testing.T, parentName, name string, withRepoFlag, withHostnameFla
 }
 
 func TestGuessTargetHost(t *testing.T) {
-	t.Run("returns host from --repo flag", func(t *testing.T) {
-		cmd := newCmd(t, "pr", "view", true, false)
-		require.NoError(t, cmd.Flags().Set("repo", "cli/cli"))
-
-		got := telemetry.GuessTargetHost(cmd, nil, nil)
-		assert.Equal(t, "github.com", got)
-	})
-
-	t.Run("returns host from --repo flag with custom host", func(t *testing.T) {
-		cmd := newCmd(t, "pr", "view", true, false)
-		require.NoError(t, cmd.Flags().Set("repo", "ghe.example.com/cli/cli"))
-
-		got := telemetry.GuessTargetHost(cmd, nil, nil)
-		assert.Equal(t, "ghe.example.com", got)
-	})
-
-	t.Run("returns host from --hostname flag", func(t *testing.T) {
-		cmd := newCmd(t, "auth", "login", false, true)
-		require.NoError(t, cmd.Flags().Set("hostname", "ghe.example.com"))
-
-		got := telemetry.GuessTargetHost(cmd, nil, nil)
-		assert.Equal(t, "ghe.example.com", got)
-	})
-
-	t.Run("--repo takes priority over --hostname", func(t *testing.T) {
-		cmd := newCmd(t, "pr", "view", true, true)
-		require.NoError(t, cmd.Flags().Set("repo", "cli/cli"))
-		require.NoError(t, cmd.Flags().Set("hostname", "ghe.example.com"))
-
-		got := telemetry.GuessTargetHost(cmd, nil, nil)
-		assert.Equal(t, "github.com", got)
-	})
-
-	t.Run("returns host from positional arg under gh repo", func(t *testing.T) {
-		cmd := newCmd(t, "repo", "view", false, false)
-		require.NoError(t, cmd.ParseFlags([]string{"ghe.example.com/owner/repo"}))
-
-		got := telemetry.GuessTargetHost(cmd, nil, nil)
-		assert.Equal(t, "ghe.example.com", got)
-	})
-
-	t.Run("does not use positional arg outside of gh repo parent", func(t *testing.T) {
-		cmd := newCmd(t, "pr", "view", false, false)
-		require.NoError(t, cmd.ParseFlags([]string{"ghe.example.com/owner/repo"}))
-
-		got := telemetry.GuessTargetHost(cmd, nil, nil)
-		assert.Equal(t, "", got)
-	})
-
-	t.Run("returns host from GH_REPO env", func(t *testing.T) {
-		cmd := newCmd(t, "pr", "view", false, false)
-		t.Setenv("GH_REPO", "ghe.example.com/owner/repo")
-
-		got := telemetry.GuessTargetHost(cmd, nil, nil)
-		assert.Equal(t, "ghe.example.com", got)
-	})
-
-	t.Run("flag takes priority over GH_REPO env", func(t *testing.T) {
-		cmd := newCmd(t, "pr", "view", true, false)
-		t.Setenv("GH_REPO", "ghe.example.com/owner/repo")
-		require.NoError(t, cmd.Flags().Set("repo", "cli/cli"))
-
-		got := telemetry.GuessTargetHost(cmd, nil, nil)
-		assert.Equal(t, "github.com", got)
-	})
-
-	t.Run("falls back to BaseRepo from factory", func(t *testing.T) {
-		cmd := newCmd(t, "pr", "view", false, false)
-		t.Setenv("GH_REPO", "")
-		baseRepo := func() (ghrepo.Interface, error) {
-			return ghrepo.NewWithHost("owner", "repo", "ghe.example.com"), nil
-		}
-
-		got := telemetry.GuessTargetHost(cmd, baseRepo, nil)
-		assert.Equal(t, "ghe.example.com", got)
-	})
-
-	t.Run("ignores BaseRepo when it returns an error", func(t *testing.T) {
-		cmd := newCmd(t, "pr", "view", false, false)
-		t.Setenv("GH_REPO", "")
-		baseRepo := func() (ghrepo.Interface, error) {
-			return nil, errors.New("no base repo")
-		}
-
-		// Without config, we should hit the empty fallback rather than anything
-		// derived from baseRepo.
-		got := telemetry.GuessTargetHost(cmd, baseRepo, nil)
-		assert.Equal(t, "", got)
-	})
-
-	t.Run("falls back to default host from config", func(t *testing.T) {
-		cmd := newCmd(t, "pr", "view", false, false)
-		t.Setenv("GH_REPO", "")
-		cfg := &ghmock.ConfigMock{
-			AuthenticationFunc: func() gh.AuthConfig {
-				return &stubAuthConfig{defaultHost: "ghe.example.com"}
+	tests := []struct {
+		name              string
+		parentName        string
+		cmdName           string
+		withRepoFlag      bool
+		withHostnameFlag  bool
+		repoFlagValue     string
+		hostnameFlagValue string
+		parseArgs         []string
+		ghRepoEnv         string
+		baseRepo          func() (ghrepo.Interface, error)
+		config            func() (gh.Config, error)
+		want              string
+	}{
+		{
+			name:          "returns host from --repo flag",
+			parentName:    "pr",
+			cmdName:       "view",
+			withRepoFlag:  true,
+			repoFlagValue: "cli/cli",
+			want:          "github.com",
+		},
+		{
+			name:          "returns host from --repo flag with custom host",
+			parentName:    "pr",
+			cmdName:       "view",
+			withRepoFlag:  true,
+			repoFlagValue: "ghe.example.com/cli/cli",
+			want:          "ghe.example.com",
+		},
+		{
+			name:              "returns host from --hostname flag",
+			parentName:        "auth",
+			cmdName:           "login",
+			withHostnameFlag:  true,
+			hostnameFlagValue: "ghe.example.com",
+			want:              "ghe.example.com",
+		},
+		{
+			name:              "--repo takes priority over --hostname",
+			parentName:        "pr",
+			cmdName:           "view",
+			withRepoFlag:      true,
+			withHostnameFlag:  true,
+			repoFlagValue:     "cli/cli",
+			hostnameFlagValue: "ghe.example.com",
+			want:              "github.com",
+		},
+		{
+			name:       "returns host from positional arg under gh repo",
+			parentName: "repo",
+			cmdName:    "view",
+			parseArgs:  []string{"ghe.example.com/owner/repo"},
+			want:       "ghe.example.com",
+		},
+		{
+			name:       "does not use positional arg outside of gh repo parent",
+			parentName: "pr",
+			cmdName:    "view",
+			parseArgs:  []string{"ghe.example.com/owner/repo"},
+			want:       "",
+		},
+		{
+			name:       "returns host from GH_REPO env",
+			parentName: "pr",
+			cmdName:    "view",
+			ghRepoEnv:  "ghe.example.com/owner/repo",
+			want:       "ghe.example.com",
+		},
+		{
+			name:          "flag takes priority over GH_REPO env",
+			parentName:    "pr",
+			cmdName:       "view",
+			withRepoFlag:  true,
+			repoFlagValue: "cli/cli",
+			ghRepoEnv:     "ghe.example.com/owner/repo",
+			want:          "github.com",
+		},
+		{
+			name:         "falls back to BaseRepo from factory for repo-scoped commands",
+			parentName:   "pr",
+			cmdName:      "view",
+			withRepoFlag: true,
+			baseRepo: func() (ghrepo.Interface, error) {
+				return ghrepo.NewWithHost("owner", "repo", "ghe.example.com"), nil
 			},
-		}
-		config := func() (gh.Config, error) { return cfg, nil }
+			want: "ghe.example.com",
+		},
+		{
+			name:       "skips BaseRepo for commands without --repo flag",
+			parentName: "pr",
+			cmdName:    "view",
+			baseRepo: func() (ghrepo.Interface, error) {
+				return ghrepo.NewWithHost("owner", "repo", "ghe.example.com"), nil
+			},
+			want: "",
+		},
+		{
+			name:         "ignores BaseRepo when it returns an error",
+			parentName:   "pr",
+			cmdName:      "view",
+			withRepoFlag: true,
+			baseRepo: func() (ghrepo.Interface, error) {
+				return nil, errors.New("no base repo")
+			},
+			want: "",
+		},
+		{
+			name:       "falls back to default host from config",
+			parentName: "pr",
+			cmdName:    "view",
+			config: func() (gh.Config, error) {
+				return &ghmock.ConfigMock{
+					AuthenticationFunc: func() gh.AuthConfig {
+						return &stubAuthConfig{defaultHost: "ghe.example.com"}
+					},
+				}, nil
+			},
+			want: "ghe.example.com",
+		},
+		{
+			name:       "returns empty string when no signal is available",
+			parentName: "pr",
+			cmdName:    "view",
+			want:       "",
+		},
+		{
+			name:       "returns empty string when config returns an error",
+			parentName: "pr",
+			cmdName:    "view",
+			config:     func() (gh.Config, error) { return nil, errors.New("no config") },
+			want:       "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GH_REPO", tt.ghRepoEnv)
 
-		got := telemetry.GuessTargetHost(cmd, nil, config)
-		assert.Equal(t, "ghe.example.com", got)
-	})
+			cmd := newCmd(t, tt.parentName, tt.cmdName, tt.withRepoFlag, tt.withHostnameFlag)
+			if tt.repoFlagValue != "" {
+				require.NoError(t, cmd.Flags().Set("repo", tt.repoFlagValue))
+			}
+			if tt.hostnameFlagValue != "" {
+				require.NoError(t, cmd.Flags().Set("hostname", tt.hostnameFlagValue))
+			}
+			if tt.parseArgs != nil {
+				require.NoError(t, cmd.ParseFlags(tt.parseArgs))
+			}
 
-	t.Run("returns empty string when no signal is available", func(t *testing.T) {
-		cmd := newCmd(t, "pr", "view", false, false)
-		t.Setenv("GH_REPO", "")
-
-		got := telemetry.GuessTargetHost(cmd, nil, nil)
-		assert.Equal(t, "", got)
-	})
-
-	t.Run("returns empty string when config returns an error", func(t *testing.T) {
-		cmd := newCmd(t, "pr", "view", false, false)
-		t.Setenv("GH_REPO", "")
-		config := func() (gh.Config, error) { return nil, errors.New("no config") }
-
-		got := telemetry.GuessTargetHost(cmd, nil, config)
-		assert.Equal(t, "", got)
-	})
+			got := telemetry.GuessTargetHost(cmd, tt.baseRepo, tt.config)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 // stubAuthConfig is a minimal gh.AuthConfig implementation for tests that only

--- a/internal/telemetry/host_test.go
+++ b/internal/telemetry/host_test.go
@@ -1,0 +1,172 @@
+package telemetry_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/gh"
+	ghmock "github.com/cli/cli/v2/internal/gh/mock"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/telemetry"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCmd builds a "gh <parent> <name>" command tree for testing. The returned
+// command is the leaf that callers interact with.
+func newCmd(t *testing.T, parentName, name string, withRepoFlag, withHostnameFlag bool) *cobra.Command {
+	t.Helper()
+	leaf := &cobra.Command{Use: name}
+	if withRepoFlag {
+		leaf.Flags().String("repo", "", "")
+	}
+	if withHostnameFlag {
+		leaf.Flags().String("hostname", "", "")
+	}
+	root := &cobra.Command{Use: "gh"}
+	if parentName != "" {
+		parent := &cobra.Command{Use: parentName}
+		root.AddCommand(parent)
+		parent.AddCommand(leaf)
+	} else {
+		root.AddCommand(leaf)
+	}
+	return leaf
+}
+
+func TestGuessTargetHost(t *testing.T) {
+	t.Run("returns host from --repo flag", func(t *testing.T) {
+		cmd := newCmd(t, "pr", "view", true, false)
+		require.NoError(t, cmd.Flags().Set("repo", "cli/cli"))
+
+		got := telemetry.GuessTargetHost(cmd, nil, nil)
+		assert.Equal(t, "github.com", got)
+	})
+
+	t.Run("returns host from --repo flag with custom host", func(t *testing.T) {
+		cmd := newCmd(t, "pr", "view", true, false)
+		require.NoError(t, cmd.Flags().Set("repo", "ghe.example.com/cli/cli"))
+
+		got := telemetry.GuessTargetHost(cmd, nil, nil)
+		assert.Equal(t, "ghe.example.com", got)
+	})
+
+	t.Run("returns host from --hostname flag", func(t *testing.T) {
+		cmd := newCmd(t, "auth", "login", false, true)
+		require.NoError(t, cmd.Flags().Set("hostname", "ghe.example.com"))
+
+		got := telemetry.GuessTargetHost(cmd, nil, nil)
+		assert.Equal(t, "ghe.example.com", got)
+	})
+
+	t.Run("--repo takes priority over --hostname", func(t *testing.T) {
+		cmd := newCmd(t, "pr", "view", true, true)
+		require.NoError(t, cmd.Flags().Set("repo", "cli/cli"))
+		require.NoError(t, cmd.Flags().Set("hostname", "ghe.example.com"))
+
+		got := telemetry.GuessTargetHost(cmd, nil, nil)
+		assert.Equal(t, "github.com", got)
+	})
+
+	t.Run("returns host from positional arg under gh repo", func(t *testing.T) {
+		cmd := newCmd(t, "repo", "view", false, false)
+		require.NoError(t, cmd.ParseFlags([]string{"ghe.example.com/owner/repo"}))
+
+		got := telemetry.GuessTargetHost(cmd, nil, nil)
+		assert.Equal(t, "ghe.example.com", got)
+	})
+
+	t.Run("does not use positional arg outside of gh repo parent", func(t *testing.T) {
+		cmd := newCmd(t, "pr", "view", false, false)
+		require.NoError(t, cmd.ParseFlags([]string{"ghe.example.com/owner/repo"}))
+
+		got := telemetry.GuessTargetHost(cmd, nil, nil)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("returns host from GH_REPO env", func(t *testing.T) {
+		cmd := newCmd(t, "pr", "view", false, false)
+		t.Setenv("GH_REPO", "ghe.example.com/owner/repo")
+
+		got := telemetry.GuessTargetHost(cmd, nil, nil)
+		assert.Equal(t, "ghe.example.com", got)
+	})
+
+	t.Run("flag takes priority over GH_REPO env", func(t *testing.T) {
+		cmd := newCmd(t, "pr", "view", true, false)
+		t.Setenv("GH_REPO", "ghe.example.com/owner/repo")
+		require.NoError(t, cmd.Flags().Set("repo", "cli/cli"))
+
+		got := telemetry.GuessTargetHost(cmd, nil, nil)
+		assert.Equal(t, "github.com", got)
+	})
+
+	t.Run("falls back to BaseRepo from factory", func(t *testing.T) {
+		cmd := newCmd(t, "pr", "view", false, false)
+		t.Setenv("GH_REPO", "")
+		baseRepo := func() (ghrepo.Interface, error) {
+			return ghrepo.NewWithHost("owner", "repo", "ghe.example.com"), nil
+		}
+
+		got := telemetry.GuessTargetHost(cmd, baseRepo, nil)
+		assert.Equal(t, "ghe.example.com", got)
+	})
+
+	t.Run("ignores BaseRepo when it returns an error", func(t *testing.T) {
+		cmd := newCmd(t, "pr", "view", false, false)
+		t.Setenv("GH_REPO", "")
+		baseRepo := func() (ghrepo.Interface, error) {
+			return nil, errors.New("no base repo")
+		}
+
+		// Without config, we should hit the empty fallback rather than anything
+		// derived from baseRepo.
+		got := telemetry.GuessTargetHost(cmd, baseRepo, nil)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("falls back to default host from config", func(t *testing.T) {
+		cmd := newCmd(t, "pr", "view", false, false)
+		t.Setenv("GH_REPO", "")
+		cfg := &ghmock.ConfigMock{
+			AuthenticationFunc: func() gh.AuthConfig {
+				return &stubAuthConfig{defaultHost: "ghe.example.com"}
+			},
+		}
+		config := func() (gh.Config, error) { return cfg, nil }
+
+		got := telemetry.GuessTargetHost(cmd, nil, config)
+		assert.Equal(t, "ghe.example.com", got)
+	})
+
+	t.Run("returns empty string when no signal is available", func(t *testing.T) {
+		cmd := newCmd(t, "pr", "view", false, false)
+		t.Setenv("GH_REPO", "")
+
+		got := telemetry.GuessTargetHost(cmd, nil, nil)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("returns empty string when config returns an error", func(t *testing.T) {
+		cmd := newCmd(t, "pr", "view", false, false)
+		t.Setenv("GH_REPO", "")
+		config := func() (gh.Config, error) { return nil, errors.New("no config") }
+
+		got := telemetry.GuessTargetHost(cmd, nil, config)
+		assert.Equal(t, "", got)
+	})
+}
+
+// stubAuthConfig is a minimal gh.AuthConfig implementation for tests that only
+// exercise the default host lookup. The production gh.AuthConfig is a concrete
+// struct with unexported fields so we use the interface that Authentication()
+// returns instead.
+type stubAuthConfig struct {
+	gh.AuthConfig
+	defaultHost string
+}
+
+func (s *stubAuthConfig) DefaultHost() (string, string) {
+	return s.defaultHost, "default"
+}

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -31,7 +31,7 @@ func NewCmdAuth(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(authTokenCmd.NewCmdToken(f, nil))
 	cmd.AddCommand(authSwitchCmd.NewCmdSwitch(f, nil))
 
-	cmdutil.DisableTelemetryForSubcommands(cmd)
+	cmdutil.DisableTelemetryRecursively(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -248,7 +248,6 @@ func NewCmdRoot(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, versi
 	}
 
 	cmdutil.DisableAuthCheck(cmd)
-	cmdutil.RecordTelemetryForSubcommands(cmd, telemetry)
 
 	// The reference command produces paged output that displays information on every other command.
 	// Therefore, we explicitly set the Long text and HelpFunc here after all other commands are registered.

--- a/pkg/cmdutil/telemetry.go
+++ b/pkg/cmdutil/telemetry.go
@@ -1,51 +1,8 @@
 package cmdutil
 
 import (
-	"slices"
-	"strings"
-
-	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
-
-func RecordTelemetry(cmd *cobra.Command, telemetry ghtelemetry.EventRecorder) {
-	if isTelemetryDisabled(cmd) {
-		return
-	}
-
-	if cmd.RunE == nil {
-		return
-	}
-
-	currentRunE := cmd.RunE
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		runErr := currentRunE(cmd, args)
-
-		var flags []string
-		cmd.Flags().Visit(func(f *pflag.Flag) {
-			flags = append(flags, f.Name)
-		})
-		slices.Sort(flags)
-
-		telemetry.Record(ghtelemetry.Event{
-			Type: "command_invocation",
-			Dimensions: map[string]string{
-				"command": cmd.CommandPath(),
-				"flags":   strings.Join(flags, ","),
-			},
-		})
-
-		return runErr
-	}
-}
-
-func RecordTelemetryForSubcommands(cmd *cobra.Command, telemetry ghtelemetry.EventRecorder) {
-	for _, c := range cmd.Commands() {
-		RecordTelemetry(c, telemetry)
-		RecordTelemetryForSubcommands(c, telemetry)
-	}
-}
 
 func DisableTelemetry(cmd *cobra.Command) {
 	if cmd.Annotations == nil {
@@ -54,13 +11,16 @@ func DisableTelemetry(cmd *cobra.Command) {
 	cmd.Annotations["telemetry"] = "disabled"
 }
 
-func DisableTelemetryForSubcommands(cmd *cobra.Command) {
+// DisableTelemetryRecursively marks the given command and all of its descendants
+// as telemetry-disabled, so that no command_invocation event is recorded when
+// any of them is executed.
+func DisableTelemetryRecursively(cmd *cobra.Command) {
+	DisableTelemetry(cmd)
 	for _, c := range cmd.Commands() {
-		DisableTelemetry(c)
-		DisableTelemetryForSubcommands(c)
+		DisableTelemetryRecursively(c)
 	}
 }
 
-func isTelemetryDisabled(cmd *cobra.Command) bool {
+func IsTelemetryDisabled(cmd *cobra.Command) bool {
 	return cmd.Annotations["telemetry"] == "disabled"
 }

--- a/pkg/cmdutil/telemetry_test.go
+++ b/pkg/cmdutil/telemetry_test.go
@@ -1,168 +1,97 @@
 package cmdutil_test
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestRecordTelemetry(t *testing.T) {
-	t.Run("records command path and flags", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		cmd := &cobra.Command{
-			Use:  "list",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
-		cmd.Flags().Bool("web", false, "")
-		cmd.Flags().String("repo", "", "")
+func TestIsTelemetryDisabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			want:        false,
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			want:        false,
+		},
+		{
+			name:        "unrelated annotation",
+			annotations: map[string]string{"other": "value"},
+			want:        false,
+		},
+		{
+			name:        "telemetry annotation set to disabled",
+			annotations: map[string]string{"telemetry": "disabled"},
+			want:        true,
+		},
+		{
+			name:        "telemetry annotation set to another value",
+			annotations: map[string]string{"telemetry": "enabled"},
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Annotations: tt.annotations}
+			assert.Equal(t, tt.want, cmdutil.IsTelemetryDisabled(cmd))
+		})
+	}
+}
 
-		parent := &cobra.Command{Use: "pr"}
-		root := &cobra.Command{Use: "gh"}
-		root.AddCommand(parent)
-		parent.AddCommand(cmd)
+func TestDisableTelemetry(t *testing.T) {
+	t.Run("adds the disabled annotation when annotations are nil", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		assert.False(t, cmdutil.IsTelemetryDisabled(cmd))
 
-		cmdutil.RecordTelemetry(cmd, recorder)
-
-		require.NoError(t, cmd.Flags().Set("web", "true"))
-		require.NoError(t, cmd.Flags().Set("repo", "cli/cli"))
-		require.NoError(t, cmd.RunE(cmd, nil))
-
-		require.Len(t, recorder.Events, 1)
-		event := recorder.Events[0]
-		assert.Equal(t, "command_invocation", event.Type)
-		assert.Equal(t, "gh pr list", event.Dimensions["command"])
-		assert.Equal(t, "repo,web", event.Dimensions["flags"])
-	})
-
-	t.Run("is a no-op when original RunE is nil", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		cmd := &cobra.Command{Use: "test"}
-
-		cmdutil.RecordTelemetry(cmd, recorder)
-
-		assert.Nil(t, cmd.RunE, "RunE should remain nil when it was nil before")
-		assert.Empty(t, recorder.Events, "no telemetry should be recorded")
-	})
-
-	t.Run("propagates error from original RunE", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		expectedErr := fmt.Errorf("something went wrong")
-		cmd := &cobra.Command{
-			Use:  "fail",
-			RunE: func(cmd *cobra.Command, args []string) error { return expectedErr },
-		}
-
-		cmdutil.RecordTelemetry(cmd, recorder)
-
-		err := cmd.RunE(cmd, nil)
-		assert.ErrorIs(t, err, expectedErr)
-		// Telemetry is still recorded even on error
-		require.Len(t, recorder.Events, 1)
-		assert.Equal(t, "command_invocation", recorder.Events[0].Type)
-	})
-
-	t.Run("flags are sorted alphabetically", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		cmd := &cobra.Command{
-			Use:  "test",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
-		cmd.Flags().Bool("zebra", false, "")
-		cmd.Flags().Bool("alpha", false, "")
-		cmd.Flags().Bool("middle", false, "")
-
-		cmdutil.RecordTelemetry(cmd, recorder)
-
-		require.NoError(t, cmd.Flags().Set("zebra", "true"))
-		require.NoError(t, cmd.Flags().Set("alpha", "true"))
-		require.NoError(t, cmd.Flags().Set("middle", "true"))
-		require.NoError(t, cmd.RunE(cmd, nil))
-
-		require.Len(t, recorder.Events, 1)
-		assert.Equal(t, "alpha,middle,zebra", recorder.Events[0].Dimensions["flags"])
-	})
-
-	t.Run("no flags set records empty flags string", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		cmd := &cobra.Command{
-			Use:  "test",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
-		cmd.Flags().Bool("unused", false, "")
-
-		cmdutil.RecordTelemetry(cmd, recorder)
-		require.NoError(t, cmd.RunE(cmd, nil))
-
-		require.Len(t, recorder.Events, 1)
-		assert.Equal(t, "", recorder.Events[0].Dimensions["flags"])
-	})
-
-	t.Run("skips commands with telemetry disabled", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		cmd := &cobra.Command{
-			Use:  "internal",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
 		cmdutil.DisableTelemetry(cmd)
-		cmdutil.RecordTelemetry(cmd, recorder)
 
-		require.NoError(t, cmd.RunE(cmd, nil))
-		assert.Empty(t, recorder.Events, "telemetry should not be recorded for disabled commands")
+		assert.True(t, cmdutil.IsTelemetryDisabled(cmd))
+		assert.Equal(t, "disabled", cmd.Annotations["telemetry"])
+	})
+
+	t.Run("preserves existing annotations", func(t *testing.T) {
+		cmd := &cobra.Command{Annotations: map[string]string{"other": "value"}}
+
+		cmdutil.DisableTelemetry(cmd)
+
+		assert.True(t, cmdutil.IsTelemetryDisabled(cmd))
+		assert.Equal(t, "value", cmd.Annotations["other"])
 	})
 }
 
-func TestRecordTelemetryForSubcommands(t *testing.T) {
-	t.Run("instruments nested subcommands", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
+func TestDisableTelemetryRecursively(t *testing.T) {
+	t.Run("disables telemetry on the root and all descendants", func(t *testing.T) {
+		root := &cobra.Command{Use: "root"}
+		child := &cobra.Command{Use: "child"}
+		grandchild := &cobra.Command{Use: "grandchild"}
+		sibling := &cobra.Command{Use: "sibling"}
 
-		root := &cobra.Command{Use: "gh"}
-		parent := &cobra.Command{Use: "pr"}
-		child := &cobra.Command{
-			Use:  "list",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
-		root.AddCommand(parent)
-		parent.AddCommand(child)
+		child.AddCommand(grandchild)
+		root.AddCommand(child, sibling)
 
-		cmdutil.RecordTelemetryForSubcommands(root, recorder)
-		require.NoError(t, child.RunE(child, nil))
+		cmdutil.DisableTelemetryRecursively(root)
 
-		require.Len(t, recorder.Events, 1)
-		assert.Equal(t, "command_invocation", recorder.Events[0].Type)
-		assert.Equal(t, "gh pr list", recorder.Events[0].Dimensions["command"])
+		assert.True(t, cmdutil.IsTelemetryDisabled(root), "root should also be disabled")
+		assert.True(t, cmdutil.IsTelemetryDisabled(child))
+		assert.True(t, cmdutil.IsTelemetryDisabled(grandchild))
+		assert.True(t, cmdutil.IsTelemetryDisabled(sibling))
 	})
 
-	t.Run("skips subcommands with nil RunE", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
+	t.Run("leaf command is still disabled", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "leaf"}
 
-		root := &cobra.Command{Use: "gh"}
-		child := &cobra.Command{Use: "help"} // no RunE
-		root.AddCommand(child)
+		cmdutil.DisableTelemetryRecursively(cmd)
 
-		cmdutil.RecordTelemetryForSubcommands(root, recorder)
-
-		assert.Nil(t, child.RunE, "nil RunE should remain nil")
-	})
-
-	t.Run("skips subcommands with telemetry disabled", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-
-		root := &cobra.Command{Use: "gh"}
-		child := &cobra.Command{
-			Use:  "send-telemetry",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
-		cmdutil.DisableTelemetry(child)
-		root.AddCommand(child)
-
-		cmdutil.RecordTelemetryForSubcommands(root, recorder)
-		require.NoError(t, child.RunE(child, nil))
-
-		assert.Empty(t, recorder.Events, "disabled commands should not record telemetry")
+		assert.True(t, cmdutil.IsTelemetryDisabled(cmd))
 	})
 }


### PR DESCRIPTION
## Description

Categorizes the host that is most likely being targeted as `github.com` or `tenant`. It _does_ categorize `GHES`, but we turn off telemetry for GHES so we would never expect that to be included.