### PR TITLE
Add error telemetry

### DIFF
--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -261,7 +261,7 @@ func Main() exitCode {
 				fmt.Fprintf(&s, "%v\n", dnsErr)
 			}
 			fmt.Fprint(&s, "check your internet connection or https://githubstatus.com")
-			err = gherrs.GeneralError{Message: s.String()}
+			err = gherrs.GeneralError{WrappedErr: err, Message: s.String()}
 		case strings.Contains(err.Error(), "Incorrect function"):
 			var s strings.Builder
 			fmt.Fprintln(&s, "You appear to be running in MinTTY without pseudo terminal support.")

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -184,7 +183,7 @@ func Main() exitCode {
 	}
 
 	// translate `gh help <command>` to `gh <command> --help` for extensions.
-	if len(expandedArgs) >= 2 && expandedArgs[0] == "help" && isExtensionCommand(rootCmd, expandedArgs[1:]) {
+	if len(expandedArgs) >= 2 && expandedArgs[0] == "help" && root.IsExtensionCommand(rootCmd, expandedArgs[1:]) {
 		expandedArgs = expandedArgs[1:]
 		expandedArgs = append(expandedArgs, "--help")
 	}
@@ -201,16 +200,10 @@ func Main() exitCode {
 			return
 		}
 
-		// For telemetry-disabled commands, check whether this is a built-in
-		// alias that stored the expanded command path. If so, record
-		// telemetry using that path; otherwise skip entirely.
+		// For telemetry-disabled commands, skip telemetry entirely.
 		commandPath := executedCmd.CommandPath()
 		if cmdutil.IsTelemetryDisabled(executedCmd) {
-			expanded, ok := cmdutil.ExpandedCommandPath(executedCmd)
-			if !ok {
-				return
-			}
-			commandPath = expanded
+			return
 		}
 
 		var flags []string
@@ -366,6 +359,15 @@ func newErrDims(mappedErr, originalErr error) ghtelemetry.Dimensions {
 	}
 }
 
+// noiseErrorTypes are common stdlib wrapper types that provide no analytical
+// value in telemetry. We skip them to keep the errTypes dimension focused on
+// domain-specific error types that are actually interesting.
+var noiseErrorTypes = map[string]bool{
+	"errors.errorString": true,
+	"errors.joinError":   true,
+	"fmt.wrapError":      true,
+}
+
 // This is a pretty janky way to get some privacy-respecting visibility into
 // what kind of error we're dealing with. It is not at all intended to be comprehensive.
 func grabAllUnwrappableNestedErrorTypes(err error) string {
@@ -378,16 +380,10 @@ func grabAllUnwrappableNestedErrorTypes(err error) string {
 			continue
 		}
 
-		// Drop the pointer part of the type name, since it doesn't add much value and just makes the output more noisy,
-		// and may make it harder to analyse if we change it in future.
-		t := reflect.TypeOf(current)
-		for t != nil && t.Kind() == reflect.Ptr {
-			t = t.Elem()
+		t := strings.TrimPrefix(fmt.Sprintf("%T", current), "*")
+		if !noiseErrorTypes[t] {
+			types = append(types, t)
 		}
-		if t == nil {
-			continue
-		}
-		types = append(types, t.String())
 
 		// Traverse single-wrapped errors and multi-errors (e.g. errors.Join).
 		if u, ok := current.(interface{ Unwrap() error }); ok {
@@ -399,12 +395,6 @@ func grabAllUnwrappableNestedErrorTypes(err error) string {
 		}
 	}
 	return strings.Join(types, ",")
-}
-
-// isExtensionCommand returns true if args resolve to an extension command.
-func isExtensionCommand(rootCmd *cobra.Command, args []string) bool {
-	c, _, err := rootCmd.Find(args)
-	return err == nil && c != nil && c.GroupID == "extension"
 }
 
 func authRecoveryCommand(cfg gh.Config, httpErr api.HTTPError) string {

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
+	"maps"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	"github.com/cli/cli/v2/internal/config/migration"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
+	"github.com/cli/cli/v2/internal/gherrs"
 	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/internal/update"
 	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
@@ -37,16 +39,14 @@ import (
 	"github.com/cli/safeexec"
 	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type exitCode int
 
 const (
-	exitOK      exitCode = 0
-	exitError   exitCode = 1
-	exitCancel  exitCode = 2
-	exitAuth    exitCode = 4
-	exitPending exitCode = 8
+	exitOK    exitCode = 0
+	exitError exitCode = 1
 )
 
 func Main() exitCode {
@@ -191,61 +191,121 @@ func Main() exitCode {
 
 	rootCmd.SetArgs(expandedArgs)
 
-	if cmd, err := rootCmd.ExecuteContextC(ctx); err != nil {
-		var pagerPipeError *iostreams.ErrClosedPagerPipe
-		var noResultsError cmdutil.NoResultsError
-		var extError *root.ExternalCommandExitError
-		var authError *root.AuthError
-		if err == cmdutil.SilentError {
-			return exitError
-		} else if err == cmdutil.PendingError {
-			return exitPending
-		} else if cmdutil.IsUserCancellation(err) {
+	var executedCmd *cobra.Command
+	var errorDims ghtelemetry.Dimensions
+	defer func() {
+		if executedCmd == nil {
+			telemetryService.Record(ghtelemetry.Event{
+				Type: "missing_command",
+			})
+			return
+		}
+
+		if cmdutil.IsTelemetryDisabled(executedCmd) {
+			return
+		}
+
+		var flags []string
+		executedCmd.Flags().Visit(func(f *pflag.Flag) {
+			flags = append(flags, f.Name)
+		})
+		slices.Sort(flags)
+
+		var dimensions = ghtelemetry.Dimensions{
+			"command": executedCmd.CommandPath(),
+			"flags":   strings.Join(flags, ","),
+		}
+		maps.Copy(dimensions, errorDims)
+
+		telemetryService.Record(ghtelemetry.Event{
+			Type:       "command_invocation",
+			Dimensions: dimensions,
+		})
+	}()
+
+	if executedCmd, err = rootCmd.ExecuteContextC(ctx); err != nil {
+		var pagerPipeErr *iostreams.ErrClosedPagerPipe
+		var noResultsErr cmdutil.NoResultsError
+		var extErr *root.ExternalCommandExitError
+		var authErr *root.AuthError
+		var dnsErr *net.DNSError
+		var flagErr *cmdutil.FlagError
+		var httpErr api.HTTPError
+
+		switch {
+		case errors.Is(err, cmdutil.SilentError):
+			err = gherrs.SilentError
+		case errors.Is(err, cmdutil.PendingError):
+			err = gherrs.PendingError
+		case cmdutil.IsUserCancellation(err):
+			// This should be fixed at the prompting layer.
 			if errors.Is(err, terminal.InterruptErr) {
-				// ensure the next shell prompt will start on its own line
 				fmt.Fprint(stderr, "\n")
 			}
-			return exitCancel
-		} else if errors.As(err, &authError) {
-			return exitAuth
-		} else if errors.As(err, &pagerPipeError) {
-			// ignore the error raised when piping to a closed pager
-			return exitOK
-		} else if errors.As(err, &noResultsError) {
+			err = gherrs.UserCancellationError
+		case errors.As(err, &authErr):
+			err = gherrs.AuthError
+		case errors.As(err, &pagerPipeErr):
+			err = nil // user quit the pager, not really an error
+		case errors.As(err, &noResultsErr):
 			if cmdFactory.IOStreams.IsStdoutTTY() {
-				fmt.Fprintln(stderr, noResultsError.Error())
+				fmt.Fprintln(stderr, noResultsErr.Error())
 			}
-			// no results is not a command failure
+			err = nil // no data to show, not really an error
+		case errors.As(err, &extErr):
+			err = &gherrs.ExtensionExecError{Code: extErr.ExitCode()}
+		case errors.As(err, &dnsErr):
+			var s strings.Builder
+			fmt.Fprintf(&s, "error connecting to %s\n", dnsErr.Name)
+			if hasDebug {
+				fmt.Fprintf(&s, "%v\n", dnsErr)
+			}
+			fmt.Fprint(&s, "check your internet connection or https://githubstatus.com")
+			err = gherrs.GeneralError{Message: s.String()}
+		case strings.Contains(err.Error(), "Incorrect function"):
+			var s strings.Builder
+			fmt.Fprintln(&s, "You appear to be running in MinTTY without pseudo terminal support.")
+			fmt.Fprint(&s, "To learn about workarounds for this error, run:  gh help mintty")
+			err = gherrs.GeneralError{WrappedErr: err, Message: s.String()}
+		default:
+			if errors.As(err, &flagErr) || strings.HasPrefix(err.Error(), "unknown command ") {
+				var s strings.Builder
+				if !strings.HasSuffix(err.Error(), "\n") {
+					fmt.Fprintln(&s)
+				}
+				fmt.Fprint(&s, executedCmd.UsageString())
+				err = gherrs.GeneralError{WrappedErr: err, Message: s.String()}
+			} else if errors.As(err, &httpErr) && httpErr.StatusCode == 401 {
+				authCommand := "gh auth login"
+				if cfg, cfgErr := cmdFactory.Config(); cfgErr == nil {
+					authCommand = authRecoveryCommand(cfg, httpErr)
+				}
+				err = gherrs.GeneralError{WrappedErr: err, Message: fmt.Sprintf("Try authenticating with:  %s", authCommand)}
+			} else if u := factory.SSOURL(); u != "" {
+				err = gherrs.GeneralError{WrappedErr: err, Message: fmt.Sprintf("Authorize in your web browser:  %s", u)}
+			} else if msg := httpErr.ScopesSuggestion(); msg != "" {
+				err = gherrs.GeneralError{WrappedErr: err, Message: msg}
+			}
+		}
+
+		if err == nil {
 			return exitOK
-		} else if errors.As(err, &extError) {
-			// pass on exit codes from extensions and shell aliases
-			return exitCode(extError.ExitCode())
 		}
 
-		printError(stderr, err, cmd, hasDebug)
+		errorDims = newErrDims(err)
 
-		if strings.Contains(err.Error(), "Incorrect function") {
-			fmt.Fprintln(stderr, "You appear to be running in MinTTY without pseudo terminal support.")
-			fmt.Fprintln(stderr, "To learn about workarounds for this error, run:  gh help mintty")
-			return exitError
+		var silenced gherrs.Silenced
+		if !errors.As(err, &silenced) {
+			fmt.Fprintln(stderr, err)
 		}
 
-		var httpErr api.HTTPError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == 401 {
-			authCommand := "gh auth login"
-			if cfg, cfgErr := cmdFactory.Config(); cfgErr == nil {
-				authCommand = authRecoveryCommand(cfg, httpErr)
-			}
-			fmt.Fprintf(stderr, "Try authenticating with:  %s\n", authCommand)
-		} else if u := factory.SSOURL(); u != "" {
-			// handles organization SAML enforcement error
-			fmt.Fprintf(stderr, "Authorize in your web browser:  %s\n", u)
-		} else if msg := httpErr.ScopesSuggestion(); msg != "" {
-			fmt.Fprintln(stderr, msg)
+		if exitCoder, ok := errors.AsType[gherrs.ExitCoder](err); ok {
+			return exitCode(exitCoder.ExitCode())
 		}
 
 		return exitError
 	}
+
 	if root.HasFailed() {
 		return exitError
 	}
@@ -272,32 +332,42 @@ func Main() exitCode {
 	return exitOK
 }
 
+func newErrDims(err error) ghtelemetry.Dimensions {
+	errTypes := grabAllUnwrappableNestedErrorTypes(err)
+
+	if errors.Is(err, gherrs.PendingError) || errors.Is(err, gherrs.UserCancellationError) {
+		return ghtelemetry.Dimensions{"outcome": "success", "errTypes": errTypes}
+	}
+
+	return ghtelemetry.Dimensions{
+		"outcome":  "error",
+		"errTypes": errTypes,
+	}
+}
+
+// This is a pretty janky way to get some privacy-respecting visibility into
+// what kind of error we're dealing with. It is not at all intended to be comprehensive.
+func grabAllUnwrappableNestedErrorTypes(err error) string {
+	var types []string
+	for i := 0; err != nil && i < 100; i, err = i+1, errors.Unwrap(err) {
+		// Drop the pointer part of the type name, since it doesn't add much value and just makes the output more noisy,
+		// and may make it harder to analyse if we change it in future.
+		t := reflect.TypeOf(err)
+		for t != nil && t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
+		if t == nil {
+			continue
+		}
+		types = append(types, t.String())
+	}
+	return strings.Join(types, ",")
+}
+
 // isExtensionCommand returns true if args resolve to an extension command.
 func isExtensionCommand(rootCmd *cobra.Command, args []string) bool {
 	c, _, err := rootCmd.Find(args)
 	return err == nil && c != nil && c.GroupID == "extension"
-}
-
-func printError(out io.Writer, err error, cmd *cobra.Command, debug bool) {
-	var dnsError *net.DNSError
-	if errors.As(err, &dnsError) {
-		fmt.Fprintf(out, "error connecting to %s\n", dnsError.Name)
-		if debug {
-			fmt.Fprintln(out, dnsError)
-		}
-		fmt.Fprintln(out, "check your internet connection or https://githubstatus.com")
-		return
-	}
-
-	fmt.Fprintln(out, err)
-
-	var flagError *cmdutil.FlagError
-	if errors.As(err, &flagError) || strings.HasPrefix(err.Error(), "unknown command ") {
-		if !strings.HasSuffix(err.Error(), "\n") {
-			fmt.Fprintln(out)
-		}
-		fmt.Fprintln(out, cmd.UsageString())
-	}
 }
 
 func authRecoveryCommand(cfg gh.Config, httpErr api.HTTPError) string {

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -201,8 +201,16 @@ func Main() exitCode {
 			return
 		}
 
+		// For telemetry-disabled commands, check whether this is a built-in
+		// alias that stored the expanded command path. If so, record
+		// telemetry using that path; otherwise skip entirely.
+		commandPath := executedCmd.CommandPath()
 		if cmdutil.IsTelemetryDisabled(executedCmd) {
-			return
+			expanded, ok := cmdutil.ExpandedCommandPath(executedCmd)
+			if !ok {
+				return
+			}
+			commandPath = expanded
 		}
 
 		var flags []string
@@ -212,7 +220,7 @@ func Main() exitCode {
 		slices.Sort(flags)
 
 		var dimensions = ghtelemetry.Dimensions{
-			"command": executedCmd.CommandPath(),
+			"command": commandPath,
 			"flags":   strings.Join(flags, ","),
 		}
 		maps.Copy(dimensions, errorDims)
@@ -265,7 +273,11 @@ func Main() exitCode {
 				fmt.Fprintf(&s, "%v\n", dnsErr)
 			}
 			fmt.Fprint(&s, "check your internet connection or https://githubstatus.com")
-			err = gherrs.GeneralError{WrappedErr: err, Message: s.String()}
+			// Do not set WrappedErr here - the original DNS error is captured
+			// separately via originalErr for telemetry, and including it in the
+			// displayed Error() would prepend the raw DNS message before the
+			// user-friendly guidance.
+			err = gherrs.GeneralError{Message: s.String()}
 		case strings.Contains(err.Error(), "Incorrect function"):
 			var s strings.Builder
 			fmt.Fprintln(&s, "You appear to be running in MinTTY without pseudo terminal support.")
@@ -315,6 +327,7 @@ func Main() exitCode {
 	}
 
 	if root.HasFailed() {
+		errorDims = ghtelemetry.Dimensions{"outcome": "error"}
 		return exitError
 	}
 

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -224,6 +224,10 @@ func Main() exitCode {
 	}()
 
 	if executedCmd, err = rootCmd.ExecuteContextC(ctx); err != nil {
+		// Preserve the original error before the switch may replace it with a
+		// gherrs sentinel. This lets telemetry capture the real error chain.
+		originalErr := err
+
 		var pagerPipeErr *iostreams.ErrClosedPagerPipe
 		var noResultsErr cmdutil.NoResultsError
 		var extErr *root.ExternalCommandExitError
@@ -268,6 +272,8 @@ func Main() exitCode {
 			fmt.Fprint(&s, "To learn about workarounds for this error, run:  gh help mintty")
 			err = gherrs.GeneralError{WrappedErr: err, Message: s.String()}
 		default:
+			httpErrMatched := errors.As(err, &httpErr)
+
 			if errors.As(err, &flagErr) || strings.HasPrefix(err.Error(), "unknown command ") {
 				var s strings.Builder
 				if !strings.HasSuffix(err.Error(), "\n") {
@@ -275,16 +281,18 @@ func Main() exitCode {
 				}
 				fmt.Fprint(&s, executedCmd.UsageString())
 				err = gherrs.GeneralError{WrappedErr: err, Message: s.String()}
-			} else if errors.As(err, &httpErr) && httpErr.StatusCode == 401 {
+			} else if httpErrMatched && httpErr.StatusCode == 401 {
 				authCommand := "gh auth login"
 				if cfg, cfgErr := cmdFactory.Config(); cfgErr == nil {
 					authCommand = authRecoveryCommand(cfg, httpErr)
 				}
 				err = gherrs.GeneralError{WrappedErr: err, Message: fmt.Sprintf("Try authenticating with:  %s", authCommand)}
-			} else if u := factory.SSOURL(); u != "" {
-				err = gherrs.GeneralError{WrappedErr: err, Message: fmt.Sprintf("Authorize in your web browser:  %s", u)}
-			} else if msg := httpErr.ScopesSuggestion(); msg != "" {
-				err = gherrs.GeneralError{WrappedErr: err, Message: msg}
+			} else if httpErrMatched {
+				if u := factory.SSOURL(); u != "" {
+					err = gherrs.GeneralError{WrappedErr: err, Message: fmt.Sprintf("Authorize in your web browser:  %s", u)}
+				} else if msg := httpErr.ScopesSuggestion(); msg != "" {
+					err = gherrs.GeneralError{WrappedErr: err, Message: msg}
+				}
 			}
 		}
 
@@ -292,7 +300,7 @@ func Main() exitCode {
 			return exitOK
 		}
 
-		errorDims = newErrDims(err)
+		errorDims = newErrDims(err, originalErr)
 
 		var silenced gherrs.Silenced
 		if !errors.As(err, &silenced) {
@@ -332,10 +340,10 @@ func Main() exitCode {
 	return exitOK
 }
 
-func newErrDims(err error) ghtelemetry.Dimensions {
-	errTypes := grabAllUnwrappableNestedErrorTypes(err)
+func newErrDims(mappedErr, originalErr error) ghtelemetry.Dimensions {
+	errTypes := grabAllUnwrappableNestedErrorTypes(originalErr)
 
-	if errors.Is(err, gherrs.PendingError) || errors.Is(err, gherrs.UserCancellationError) {
+	if errors.Is(mappedErr, gherrs.PendingError) || errors.Is(mappedErr, gherrs.UserCancellationError) {
 		return ghtelemetry.Dimensions{"outcome": "success", "errTypes": errTypes}
 	}
 
@@ -349,10 +357,17 @@ func newErrDims(err error) ghtelemetry.Dimensions {
 // what kind of error we're dealing with. It is not at all intended to be comprehensive.
 func grabAllUnwrappableNestedErrorTypes(err error) string {
 	var types []string
-	for i := 0; err != nil && i < 100; i, err = i+1, errors.Unwrap(err) {
+	queue := []error{err}
+	for len(queue) > 0 && len(types) < 100 {
+		current := queue[0]
+		queue = queue[1:]
+		if current == nil {
+			continue
+		}
+
 		// Drop the pointer part of the type name, since it doesn't add much value and just makes the output more noisy,
 		// and may make it harder to analyse if we change it in future.
-		t := reflect.TypeOf(err)
+		t := reflect.TypeOf(current)
 		for t != nil && t.Kind() == reflect.Ptr {
 			t = t.Elem()
 		}
@@ -360,6 +375,15 @@ func grabAllUnwrappableNestedErrorTypes(err error) string {
 			continue
 		}
 		types = append(types, t.String())
+
+		// Traverse single-wrapped errors and multi-errors (e.g. errors.Join).
+		if u, ok := current.(interface{ Unwrap() error }); ok {
+			if next := u.Unwrap(); next != nil {
+				queue = append(queue, next)
+			}
+		} else if u, ok := current.(interface{ Unwrap() []error }); ok {
+			queue = append(queue, u.Unwrap()...)
+		}
 	}
 	return strings.Join(types, ",")
 }

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -538,24 +538,24 @@ func Test_grabAllUnwrappableNestedErrorTypes(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "generic error",
+			name: "generic error is noise and filtered",
 			err:  errors.New("boom"),
-			want: "errors.errorString",
+			want: "",
 		},
 		{
-			name: "single fmt wrap",
+			name: "single fmt wrap filters noise",
 			err:  fmt.Errorf("context: %w", gherrs.SilentError),
-			want: "fmt.wrapError,gherrs.silentError",
+			want: "gherrs.silentError",
 		},
 		{
-			name: "double fmt wrap",
+			name: "double fmt wrap filters noise",
 			err:  fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", gherrs.SilentError)),
-			want: "fmt.wrapError,fmt.wrapError,gherrs.silentError",
+			want: "gherrs.silentError",
 		},
 		{
-			name: "errors.Join captures all branches",
+			name: "errors.Join captures interesting branches",
 			err:  errors.Join(errors.New("a"), fmt.Errorf("wrap: %w", gherrs.SilentError)),
-			want: "errors.joinError,errors.errorString,fmt.wrapError,gherrs.silentError",
+			want: "gherrs.silentError",
 		},
 	}
 	for _, tt := range tests {
@@ -567,12 +567,14 @@ func Test_grabAllUnwrappableNestedErrorTypes(t *testing.T) {
 }
 
 func Test_grabAllUnwrappableNestedErrorTypes_boundedByDepthLimit(t *testing.T) {
-	// Build a chain deeper than the 100-element bound to ensure the loop terminates.
-	err := errors.New("leaf")
+	// Build a chain deeper than the 100-element bound using a non-noise
+	// error type so that entries are not filtered out.
+	err := gherrs.GeneralError{Message: "leaf"}
+	var wrapped error = err
 	for range 101 {
-		err = fmt.Errorf("wrap: %w", err)
+		wrapped = gherrs.GeneralError{WrappedErr: wrapped, Message: "wrap"}
 	}
-	got := grabAllUnwrappableNestedErrorTypes(err)
+	got := grabAllUnwrappableNestedErrorTypes(wrapped)
 	parts := strings.Split(got, ",")
 	assert.Len(t, parts, 100, "should be bounded to 100 entries")
 }
@@ -588,7 +590,7 @@ func Test_newErrDims(t *testing.T) {
 			name:        "generic error is failure",
 			mappedErr:   errors.New("boom"),
 			originalErr: errors.New("boom"),
-			want:        ghtelemetry.Dimensions{"outcome": "error", "errTypes": "errors.errorString"},
+			want:        ghtelemetry.Dimensions{"outcome": "error", "errTypes": ""},
 		},
 		{
 			name:        "silent error is failure",
@@ -606,7 +608,7 @@ func Test_newErrDims(t *testing.T) {
 			name:        "wrapped user cancellation error is success",
 			mappedErr:   gherrs.UserCancellationError,
 			originalErr: fmt.Errorf("wrapped: %w", gherrs.UserCancellationError),
-			want:        ghtelemetry.Dimensions{"outcome": "success", "errTypes": "fmt.wrapError,gherrs.userCancellationError"},
+			want:        ghtelemetry.Dimensions{"outcome": "success", "errTypes": "gherrs.userCancellationError"},
 		},
 		{
 			name:        "pending error is success",
@@ -618,7 +620,7 @@ func Test_newErrDims(t *testing.T) {
 			name:        "mapped sentinel preserves original error chain for errTypes",
 			mappedErr:   gherrs.SilentError,
 			originalErr: fmt.Errorf("context: %w", errors.New("root cause")),
-			want:        ghtelemetry.Dimensions{"outcome": "error", "errTypes": "fmt.wrapError,errors.errorString"},
+			want:        ghtelemetry.Dimensions{"outcome": "error", "errTypes": ""},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -2,87 +2,26 @@ package ghcmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
+	"io"
 	"net/url"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	ghmock "github.com/cli/cli/v2/internal/gh/mock"
-	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/internal/gherrs"
+	"github.com/cli/cli/v2/internal/telemetry"
 	ghAPI "github.com/cli/go-gh/v2/pkg/api"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func Test_printError(t *testing.T) {
-	cmd := &cobra.Command{}
-
-	type args struct {
-		err   error
-		cmd   *cobra.Command
-		debug bool
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantOut string
-	}{
-		{
-			name: "generic error",
-			args: args{
-				err:   errors.New("the app exploded"),
-				cmd:   nil,
-				debug: false,
-			},
-			wantOut: "the app exploded\n",
-		},
-		{
-			name: "DNS error",
-			args: args{
-				err: fmt.Errorf("DNS oopsie: %w", &net.DNSError{
-					Name: "api.github.com",
-				}),
-				cmd:   nil,
-				debug: false,
-			},
-			wantOut: `error connecting to api.github.com
-check your internet connection or https://githubstatus.com
-`,
-		},
-		{
-			name: "Cobra flag error",
-			args: args{
-				err:   cmdutil.FlagErrorf("unknown flag --foo"),
-				cmd:   cmd,
-				debug: false,
-			},
-			wantOut: "unknown flag --foo\n\nUsage:\n\n",
-		},
-		{
-			name: "unknown Cobra command error",
-			args: args{
-				err:   errors.New("unknown command foo"),
-				cmd:   cmd,
-				debug: false,
-			},
-			wantOut: "unknown command foo\n\nUsage:\n\n",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			out := &bytes.Buffer{}
-			printError(out, tt.args.err, tt.args.cmd, tt.args.debug)
-			if gotOut := out.String(); gotOut != tt.wantOut {
-				t.Errorf("printError() = %q, want %q", gotOut, tt.wantOut)
-			}
-		})
-	}
-}
 
 func Test_newIOStreams_pager(t *testing.T) {
 	tests := []struct {
@@ -585,4 +524,238 @@ func Test_authRecoveryCommand(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_grabAllUnwrappableNestedErrorTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: "",
+		},
+		{
+			name: "generic error",
+			err:  errors.New("boom"),
+			want: "errors.errorString",
+		},
+		{
+			name: "single fmt wrap",
+			err:  fmt.Errorf("context: %w", gherrs.SilentError),
+			want: "fmt.wrapError,gherrs.silentError",
+		},
+		{
+			name: "double fmt wrap",
+			err:  fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", gherrs.SilentError)),
+			want: "fmt.wrapError,fmt.wrapError,gherrs.silentError",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := grabAllUnwrappableNestedErrorTypes(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_grabAllUnwrappableNestedErrorTypes_boundedAgainstCycles(t *testing.T) {
+	// Build a chain deeper than the 100-element bound to ensure the loop terminates.
+	err := errors.New("leaf")
+	for range 101 {
+		err = fmt.Errorf("wrap: %w", err)
+	}
+	got := grabAllUnwrappableNestedErrorTypes(err)
+	parts := strings.Split(got, ",")
+	assert.Len(t, parts, 100, "should be bounded to 100 entries")
+}
+
+func Test_newErrDims(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want ghtelemetry.Dimensions
+	}{
+		{
+			name: "generic error is failure",
+			err:  errors.New("boom"),
+			want: ghtelemetry.Dimensions{"outcome": "error", "errTypes": "errors.errorString"},
+		},
+		{
+			name: "silent error is failure",
+			err:  gherrs.SilentError,
+			want: ghtelemetry.Dimensions{"outcome": "error", "errTypes": "gherrs.silentError"},
+		},
+		{
+			name: "user cancellation error is success",
+			err:  gherrs.UserCancellationError,
+			want: ghtelemetry.Dimensions{"outcome": "success", "errTypes": "gherrs.userCancellationError"},
+		},
+		{
+			name: "wrapped user cancellation error is success",
+			err:  fmt.Errorf("wrapped: %w", gherrs.UserCancellationError),
+			want: ghtelemetry.Dimensions{"outcome": "success", "errTypes": "fmt.wrapError,gherrs.userCancellationError"},
+		},
+		{
+			name: "pending error is success",
+			err:  gherrs.PendingError,
+			want: ghtelemetry.Dimensions{"outcome": "success", "errTypes": "gherrs.pendingError"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, newErrDims(tt.err))
+		})
+	}
+}
+
+// runMainAndCaptureTelemetry runs Main() with the provided args in an isolated
+// config/state directory with telemetry logging enabled, and returns the exit
+// code and the telemetry payloads that were flushed to stderr.
+//
+// This is intentionally a janky end-to-end test: Main() reads from os.Args and
+// writes to os.Stderr/os.Stdout, so we swap those process-globals around the
+// call. Tests using this helper cannot run in parallel.
+//
+// The expectation in the long run is that we will pull this out of ghcmd.Main.
+func runMainAndCaptureTelemetry(t *testing.T, args []string) (exitCode, []telemetry.SendTelemetryPayload) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tmpDir)
+	t.Setenv("GH_DATA_DIR", tmpDir)
+	t.Setenv("GH_STATE_DIR", tmpDir)
+
+	// Enable telemetry in log mode so payloads are written to stderr rather than
+	// spawned as a subprocess.
+	t.Setenv("GH_PRIVATE_ENABLE_TELEMETRY", "1")
+	t.Setenv("GH_TELEMETRY", "log")
+
+	// Prevent being classified as a GHES user, which would force NoOpService.
+	t.Setenv("GH_HOST", "")
+	t.Setenv("GH_ENTERPRISE_TOKEN", "")
+	t.Setenv("GITHUB_ENTERPRISE_TOKEN", "")
+
+	// Disable color to keep the LogFlusher output easy to parse.
+	t.Setenv("NO_COLOR", "1")
+
+	origArgs := os.Args
+	t.Cleanup(func() { os.Args = origArgs })
+	os.Args = args
+
+	origStderr := os.Stderr
+	stderrR, stderrW, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = stderrW
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	origStdout := os.Stdout
+	stdoutR, stdoutW, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = stdoutW
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	// Drain stdout and stderr in the background so command output does not
+	// fill the pipe buffer and block the process.
+	stdoutDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, stdoutR)
+		close(stdoutDone)
+	}()
+
+	var stderrBytes []byte
+	stderrDone := make(chan struct{})
+	go func() {
+		stderrBytes, _ = io.ReadAll(stderrR)
+		close(stderrDone)
+	}()
+
+	exit := Main()
+
+	require.NoError(t, stderrW.Close())
+	require.NoError(t, stdoutW.Close())
+	<-stdoutDone
+	<-stderrDone
+
+	return exit, parseTelemetryPayloads(t, stderrBytes)
+}
+
+// parseTelemetryPayloads extracts JSON payloads written by telemetry.LogFlusher
+// from the given stderr capture. LogFlusher prefixes each payload with a
+// "Telemetry payload:" header followed by indented JSON.
+func parseTelemetryPayloads(t *testing.T, stderr []byte) []telemetry.SendTelemetryPayload {
+	t.Helper()
+
+	const header = "Telemetry payload:"
+	var payloads []telemetry.SendTelemetryPayload
+
+	remaining := stderr
+	for {
+		idx := bytes.Index(remaining, []byte(header))
+		if idx < 0 {
+			break
+		}
+		remaining = remaining[idx+len(header):]
+
+		// Locate the JSON object starting with '{' and let json.Decoder parse
+		// exactly one payload so braces inside JSON strings do not affect
+		// boundary detection.
+		start := bytes.IndexByte(remaining, '{')
+		if start < 0 {
+			break
+		}
+
+		decoder := json.NewDecoder(bytes.NewReader(remaining[start:]))
+		var p telemetry.SendTelemetryPayload
+		require.NoError(t, decoder.Decode(&p))
+		payloads = append(payloads, p)
+
+		consumed := int(decoder.InputOffset())
+		if consumed <= 0 {
+			break
+		}
+		remaining = remaining[start+consumed:]
+	}
+
+	return payloads
+}
+
+func findCommandInvocation(payloads []telemetry.SendTelemetryPayload) *telemetry.PayloadEvent {
+	for _, p := range payloads {
+		for i := range p.Events {
+			if p.Events[i].Type == "command_invocation" {
+				return &p.Events[i]
+			}
+		}
+	}
+	return nil
+}
+
+func TestMain_recordsCommandInvocationTelemetry_versionSubcommand(t *testing.T) {
+	exit, payloads := runMainAndCaptureTelemetry(t, []string{"gh", "version"})
+
+	assert.Equal(t, exitOK, exit)
+
+	event := findCommandInvocation(payloads)
+	require.NotNil(t, event, "expected a command_invocation event in telemetry payloads")
+
+	assert.Equal(t, "gh version", event.Dimensions["command"])
+	// Successful runs do not populate outcome/errTypes, only error runs do.
+	assert.NotContains(t, event.Dimensions, "outcome")
+	assert.NotContains(t, event.Dimensions, "errTypes")
+}
+
+func TestMain_recordsCommandInvocationTelemetry_flagError(t *testing.T) {
+	exit, payloads := runMainAndCaptureTelemetry(t, []string{"gh", "version", "--definitely-not-a-real-flag"})
+
+	assert.Equal(t, exitError, exit)
+
+	event := findCommandInvocation(payloads)
+	require.NotNil(t, event, "expected a command_invocation event in telemetry payloads")
+
+	assert.Equal(t, "gh version", event.Dimensions["command"])
+	assert.Equal(t, "error", event.Dimensions["outcome"])
+	assert.NotEmpty(t, event.Dimensions["errTypes"], "errTypes should be populated on error")
 }

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -561,7 +561,7 @@ func Test_grabAllUnwrappableNestedErrorTypes(t *testing.T) {
 	}
 }
 
-func Test_grabAllUnwrappableNestedErrorTypes_boundedAgainstCycles(t *testing.T) {
+func Test_grabAllUnwrappableNestedErrorTypes_boundedByDepthLimit(t *testing.T) {
 	// Build a chain deeper than the 100-element bound to ensure the loop terminates.
 	err := errors.New("leaf")
 	for range 101 {
@@ -758,4 +758,31 @@ func TestMain_recordsCommandInvocationTelemetry_flagError(t *testing.T) {
 	assert.Equal(t, "gh version", event.Dimensions["command"])
 	assert.Equal(t, "error", event.Dimensions["outcome"])
 	assert.NotEmpty(t, event.Dimensions["errTypes"], "errTypes should be populated on error")
+}
+
+func TestMain_recordsCommandInvocationTelemetry_flagsDimension(t *testing.T) {
+	exit, payloads := runMainAndCaptureTelemetry(t, []string{"gh", "api", "--method", "GET", "--hostname", "example.com", "/"})
+
+	// The command will fail (no auth), but that's fine - we only care about
+	// the flags dimension being present and sorted.
+	_ = exit
+
+	event := findCommandInvocation(payloads)
+	require.NotNil(t, event, "expected a command_invocation event in telemetry payloads")
+
+	assert.Equal(t, "gh api", event.Dimensions["command"])
+	flags := event.Dimensions["flags"]
+	assert.Contains(t, flags, "hostname")
+	assert.Contains(t, flags, "method")
+	// Flags should be sorted alphabetically.
+	assert.Equal(t, "hostname,method", flags)
+}
+
+func TestMain_telemetryDisabledCommand_noCommandInvocationEvent(t *testing.T) {
+	exit, payloads := runMainAndCaptureTelemetry(t, []string{"gh", "completion"})
+
+	assert.Equal(t, exitOK, exit)
+
+	event := findCommandInvocation(payloads)
+	assert.Nil(t, event, "telemetry-disabled commands should not emit command_invocation")
 }

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -552,6 +552,11 @@ func Test_grabAllUnwrappableNestedErrorTypes(t *testing.T) {
 			err:  fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", gherrs.SilentError)),
 			want: "fmt.wrapError,fmt.wrapError,gherrs.silentError",
 		},
+		{
+			name: "errors.Join captures all branches",
+			err:  errors.Join(errors.New("a"), fmt.Errorf("wrap: %w", gherrs.SilentError)),
+			want: "errors.joinError,errors.errorString,fmt.wrapError,gherrs.silentError",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -574,39 +579,51 @@ func Test_grabAllUnwrappableNestedErrorTypes_boundedByDepthLimit(t *testing.T) {
 
 func Test_newErrDims(t *testing.T) {
 	tests := []struct {
-		name string
-		err  error
-		want ghtelemetry.Dimensions
+		name        string
+		mappedErr   error
+		originalErr error
+		want        ghtelemetry.Dimensions
 	}{
 		{
-			name: "generic error is failure",
-			err:  errors.New("boom"),
-			want: ghtelemetry.Dimensions{"outcome": "error", "errTypes": "errors.errorString"},
+			name:        "generic error is failure",
+			mappedErr:   errors.New("boom"),
+			originalErr: errors.New("boom"),
+			want:        ghtelemetry.Dimensions{"outcome": "error", "errTypes": "errors.errorString"},
 		},
 		{
-			name: "silent error is failure",
-			err:  gherrs.SilentError,
-			want: ghtelemetry.Dimensions{"outcome": "error", "errTypes": "gherrs.silentError"},
+			name:        "silent error is failure",
+			mappedErr:   gherrs.SilentError,
+			originalErr: gherrs.SilentError,
+			want:        ghtelemetry.Dimensions{"outcome": "error", "errTypes": "gherrs.silentError"},
 		},
 		{
-			name: "user cancellation error is success",
-			err:  gherrs.UserCancellationError,
-			want: ghtelemetry.Dimensions{"outcome": "success", "errTypes": "gherrs.userCancellationError"},
+			name:        "user cancellation error is success",
+			mappedErr:   gherrs.UserCancellationError,
+			originalErr: gherrs.UserCancellationError,
+			want:        ghtelemetry.Dimensions{"outcome": "success", "errTypes": "gherrs.userCancellationError"},
 		},
 		{
-			name: "wrapped user cancellation error is success",
-			err:  fmt.Errorf("wrapped: %w", gherrs.UserCancellationError),
-			want: ghtelemetry.Dimensions{"outcome": "success", "errTypes": "fmt.wrapError,gherrs.userCancellationError"},
+			name:        "wrapped user cancellation error is success",
+			mappedErr:   gherrs.UserCancellationError,
+			originalErr: fmt.Errorf("wrapped: %w", gherrs.UserCancellationError),
+			want:        ghtelemetry.Dimensions{"outcome": "success", "errTypes": "fmt.wrapError,gherrs.userCancellationError"},
 		},
 		{
-			name: "pending error is success",
-			err:  gherrs.PendingError,
-			want: ghtelemetry.Dimensions{"outcome": "success", "errTypes": "gherrs.pendingError"},
+			name:        "pending error is success",
+			mappedErr:   gherrs.PendingError,
+			originalErr: gherrs.PendingError,
+			want:        ghtelemetry.Dimensions{"outcome": "success", "errTypes": "gherrs.pendingError"},
+		},
+		{
+			name:        "mapped sentinel preserves original error chain for errTypes",
+			mappedErr:   gherrs.SilentError,
+			originalErr: fmt.Errorf("context: %w", errors.New("root cause")),
+			want:        ghtelemetry.Dimensions{"outcome": "error", "errTypes": "fmt.wrapError,errors.errorString"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, newErrDims(tt.err))
+			assert.Equal(t, tt.want, newErrDims(tt.mappedErr, tt.originalErr))
 		})
 	}
 }

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -655,6 +655,11 @@ func runMainAndCaptureTelemetry(t *testing.T, args []string) (exitCode, []teleme
 	t.Setenv("GH_ENTERPRISE_TOKEN", "")
 	t.Setenv("GITHUB_ENTERPRISE_TOKEN", "")
 
+	// Clear GitHub.com auth tokens so tests don't accidentally make real API
+	// requests when running in environments that have them set.
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
+
 	// Disable color to keep the LogFlusher output easy to parse.
 	t.Setenv("NO_COLOR", "1")
 

--- a/internal/gherrs/errors.go
+++ b/internal/gherrs/errors.go
@@ -23,7 +23,7 @@ type Silenced interface {
 	silent()
 }
 
-var SilentError = silentError{}
+var SilentError error = silentError{}
 
 type silentError struct{}
 
@@ -37,7 +37,7 @@ func (e silentError) ExitCode() ExitCode {
 
 func (e silentError) silent() {}
 
-var PendingError = pendingError{}
+var PendingError error = pendingError{}
 
 type pendingError struct{}
 
@@ -51,7 +51,7 @@ func (e pendingError) ExitCode() ExitCode {
 
 func (e pendingError) silent() {}
 
-var UserCancellationError = userCancellationError{}
+var UserCancellationError error = userCancellationError{}
 
 type userCancellationError struct{}
 
@@ -65,7 +65,7 @@ func (e userCancellationError) ExitCode() ExitCode {
 
 func (e userCancellationError) silent() {}
 
-var AuthError = authError{}
+var AuthError error = authError{}
 
 type authError struct{}
 

--- a/internal/gherrs/errors.go
+++ b/internal/gherrs/errors.go
@@ -1,0 +1,114 @@
+package gherrs
+
+type ExitCode int
+
+const (
+	exitError   ExitCode = 1
+	exitCancel  ExitCode = 2
+	exitAuth    ExitCode = 4
+	exitPending ExitCode = 8
+)
+
+type ExitCoder interface {
+	error
+	ExitCode() ExitCode
+}
+
+type Silenced interface {
+	error
+	silent()
+}
+
+var SilentError = silentError{}
+
+type silentError struct{}
+
+func (e silentError) Error() string {
+	return "silent"
+}
+
+func (e silentError) ExitCode() ExitCode {
+	return exitError
+}
+
+func (e silentError) silent() {}
+
+var PendingError = pendingError{}
+
+type pendingError struct{}
+
+func (e pendingError) Error() string {
+	return "pending"
+}
+
+func (e pendingError) ExitCode() ExitCode {
+	return exitPending
+}
+
+func (e pendingError) silent() {}
+
+var UserCancellationError = userCancellationError{}
+
+type userCancellationError struct{}
+
+func (e userCancellationError) Error() string {
+	return "user cancellation"
+}
+
+func (e userCancellationError) ExitCode() ExitCode {
+	return exitCancel
+}
+
+func (e userCancellationError) silent() {}
+
+var AuthError = authError{}
+
+type authError struct{}
+
+func (e authError) Error() string {
+	return "authentication error"
+}
+
+func (e authError) ExitCode() ExitCode {
+	return exitAuth
+}
+
+func (e authError) silent() {}
+
+type ExtensionExecError struct {
+	Code int
+}
+
+func (e ExtensionExecError) Error() string {
+	return "extension execution error"
+}
+
+func (e ExtensionExecError) ExitCode() ExitCode {
+	return ExitCode(e.Code)
+}
+
+func (e ExtensionExecError) silent() {}
+
+type GeneralError struct {
+	WrappedErr error
+	Message    string
+}
+
+func (e GeneralError) Error() string {
+	switch {
+	case e.WrappedErr != nil && e.Message != "":
+		return e.WrappedErr.Error() + "\n" + e.Message
+	case e.WrappedErr != nil:
+		return e.WrappedErr.Error()
+	default:
+		return e.Message
+	}
+}
+
+func (e GeneralError) Unwrap() error {
+	return e.WrappedErr
+}
+
+func (e GeneralError) ExitCode() ExitCode {
+	return exitError
+}

--- a/internal/gherrs/errors.go
+++ b/internal/gherrs/errors.go
@@ -1,5 +1,6 @@
 package gherrs
 
+// ExitCode represents the numeric exit status returned by the CLI process.
 type ExitCode int
 
 const (
@@ -9,11 +10,14 @@ const (
 	exitPending ExitCode = 8
 )
 
+// ExitCoder is implemented by errors that carry a specific process exit code.
 type ExitCoder interface {
 	error
 	ExitCode() ExitCode
 }
 
+// Silenced is implemented by errors whose message should not be printed to
+// stderr. The process still exits with the error's exit code.
 type Silenced interface {
 	error
 	silent()
@@ -75,6 +79,8 @@ func (e authError) ExitCode() ExitCode {
 
 func (e authError) silent() {}
 
+// ExtensionExecError indicates that an extension process exited with a
+// non-zero status. Code holds the extension's exit code.
 type ExtensionExecError struct {
 	Code int
 }
@@ -89,6 +95,9 @@ func (e ExtensionExecError) ExitCode() ExitCode {
 
 func (e ExtensionExecError) silent() {}
 
+// GeneralError wraps an underlying error with an additional user-facing
+// message. When both WrappedErr and Message are set, Error() returns both
+// separated by a newline.
 type GeneralError struct {
 	WrappedErr error
 	Message    string

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -31,7 +31,7 @@ func NewCmdAuth(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(authTokenCmd.NewCmdToken(f, nil))
 	cmd.AddCommand(authSwitchCmd.NewCmdSwitch(f, nil))
 
-	cmdutil.DisableTelemetryForSubcommands(cmd)
+	cmdutil.DisableTelemetryRecursively(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/root/alias.go
+++ b/pkg/cmd/root/alias.go
@@ -61,6 +61,11 @@ func NewCmdAlias(io *iostreams.IOStreams, aliasName, aliasValue string) *cobra.C
 				return err
 			}
 			root := c.Root()
+			// Resolve the expanded command so its path can be recorded for
+			// telemetry without exposing the user-defined alias name.
+			if resolved, _, resolveErr := root.Find(expandedArgs); resolveErr == nil && resolved != nil {
+				cmdutil.SetExpandedCommandPath(c, resolved.CommandPath())
+			}
 			root.SetArgs(expandedArgs)
 			return root.Execute()
 		},

--- a/pkg/cmd/root/alias.go
+++ b/pkg/cmd/root/alias.go
@@ -61,11 +61,6 @@ func NewCmdAlias(io *iostreams.IOStreams, aliasName, aliasValue string) *cobra.C
 				return err
 			}
 			root := c.Root()
-			// Resolve the expanded command so its path can be recorded for
-			// telemetry without exposing the user-defined alias name.
-			if resolved, _, resolveErr := root.Find(expandedArgs); resolveErr == nil && resolved != nil {
-				cmdutil.SetExpandedCommandPath(c, resolved.CommandPath())
-			}
 			root.SetArgs(expandedArgs)
 			return root.Execute()
 		},

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -258,3 +258,9 @@ func NewCmdRoot(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, versi
 	referenceCmd.SetHelpFunc(longPager(f.IOStreams))
 	return cmd, nil
 }
+
+// IsExtensionCommand returns true if args resolve to an extension command.
+func IsExtensionCommand(rootCmd *cobra.Command, args []string) bool {
+	c, _, err := rootCmd.Find(args)
+	return err == nil && c != nil && c.GroupID == "extension"
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -248,7 +248,6 @@ func NewCmdRoot(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, versi
 	}
 
 	cmdutil.DisableAuthCheck(cmd)
-	cmdutil.RecordTelemetryForSubcommands(cmd, telemetry)
 
 	// The reference command produces paged output that displays information on every other command.
 	// Therefore, we explicitly set the Long text and HelpFunc here after all other commands are registered.

--- a/pkg/cmdutil/telemetry.go
+++ b/pkg/cmdutil/telemetry.go
@@ -1,51 +1,8 @@
 package cmdutil
 
 import (
-	"slices"
-	"strings"
-
-	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
-
-func RecordTelemetry(cmd *cobra.Command, telemetry ghtelemetry.EventRecorder) {
-	if isTelemetryDisabled(cmd) {
-		return
-	}
-
-	if cmd.RunE == nil {
-		return
-	}
-
-	currentRunE := cmd.RunE
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		runErr := currentRunE(cmd, args)
-
-		var flags []string
-		cmd.Flags().Visit(func(f *pflag.Flag) {
-			flags = append(flags, f.Name)
-		})
-		slices.Sort(flags)
-
-		telemetry.Record(ghtelemetry.Event{
-			Type: "command_invocation",
-			Dimensions: map[string]string{
-				"command": cmd.CommandPath(),
-				"flags":   strings.Join(flags, ","),
-			},
-		})
-
-		return runErr
-	}
-}
-
-func RecordTelemetryForSubcommands(cmd *cobra.Command, telemetry ghtelemetry.EventRecorder) {
-	for _, c := range cmd.Commands() {
-		RecordTelemetry(c, telemetry)
-		RecordTelemetryForSubcommands(c, telemetry)
-	}
-}
 
 func DisableTelemetry(cmd *cobra.Command) {
 	if cmd.Annotations == nil {
@@ -54,13 +11,16 @@ func DisableTelemetry(cmd *cobra.Command) {
 	cmd.Annotations["telemetry"] = "disabled"
 }
 
-func DisableTelemetryForSubcommands(cmd *cobra.Command) {
+// DisableTelemetryRecursively marks the given command and all of its descendants
+// as telemetry-disabled, so that no command_invocation event is recorded when
+// any of them is executed.
+func DisableTelemetryRecursively(cmd *cobra.Command) {
+	DisableTelemetry(cmd)
 	for _, c := range cmd.Commands() {
-		DisableTelemetry(c)
-		DisableTelemetryForSubcommands(c)
+		DisableTelemetryRecursively(c)
 	}
 }
 
-func isTelemetryDisabled(cmd *cobra.Command) bool {
+func IsTelemetryDisabled(cmd *cobra.Command) bool {
 	return cmd.Annotations["telemetry"] == "disabled"
 }

--- a/pkg/cmdutil/telemetry.go
+++ b/pkg/cmdutil/telemetry.go
@@ -4,6 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// DisableTelemetry marks the given command so that no command_invocation
+// telemetry event is recorded when it is executed.
 func DisableTelemetry(cmd *cobra.Command) {
 	if cmd.Annotations == nil {
 		cmd.Annotations = map[string]string{}
@@ -21,6 +23,25 @@ func DisableTelemetryRecursively(cmd *cobra.Command) {
 	}
 }
 
+// IsTelemetryDisabled reports whether the given command has been marked as
+// telemetry-disabled via DisableTelemetry or DisableTelemetryRecursively.
 func IsTelemetryDisabled(cmd *cobra.Command) bool {
 	return cmd.Annotations["telemetry"] == "disabled"
+}
+
+// SetExpandedCommandPath stores the command path that a built-in alias expands
+// to, so that telemetry can record the expanded path instead of the
+// user-defined alias name.
+func SetExpandedCommandPath(cmd *cobra.Command, path string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations["expanded_command_path"] = path
+}
+
+// ExpandedCommandPath returns the expanded command path stored by
+// SetExpandedCommandPath, or empty string and false if none was set.
+func ExpandedCommandPath(cmd *cobra.Command) (string, bool) {
+	path, ok := cmd.Annotations["expanded_command_path"]
+	return path, ok
 }

--- a/pkg/cmdutil/telemetry.go
+++ b/pkg/cmdutil/telemetry.go
@@ -28,20 +28,3 @@ func DisableTelemetryRecursively(cmd *cobra.Command) {
 func IsTelemetryDisabled(cmd *cobra.Command) bool {
 	return cmd.Annotations["telemetry"] == "disabled"
 }
-
-// SetExpandedCommandPath stores the command path that a built-in alias expands
-// to, so that telemetry can record the expanded path instead of the
-// user-defined alias name.
-func SetExpandedCommandPath(cmd *cobra.Command, path string) {
-	if cmd.Annotations == nil {
-		cmd.Annotations = map[string]string{}
-	}
-	cmd.Annotations["expanded_command_path"] = path
-}
-
-// ExpandedCommandPath returns the expanded command path stored by
-// SetExpandedCommandPath, or empty string and false if none was set.
-func ExpandedCommandPath(cmd *cobra.Command) (string, bool) {
-	path, ok := cmd.Annotations["expanded_command_path"]
-	return path, ok
-}

--- a/pkg/cmdutil/telemetry_test.go
+++ b/pkg/cmdutil/telemetry_test.go
@@ -1,168 +1,97 @@
 package cmdutil_test
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestRecordTelemetry(t *testing.T) {
-	t.Run("records command path and flags", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		cmd := &cobra.Command{
-			Use:  "list",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
-		cmd.Flags().Bool("web", false, "")
-		cmd.Flags().String("repo", "", "")
+func TestIsTelemetryDisabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			want:        false,
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			want:        false,
+		},
+		{
+			name:        "unrelated annotation",
+			annotations: map[string]string{"other": "value"},
+			want:        false,
+		},
+		{
+			name:        "telemetry annotation set to disabled",
+			annotations: map[string]string{"telemetry": "disabled"},
+			want:        true,
+		},
+		{
+			name:        "telemetry annotation set to another value",
+			annotations: map[string]string{"telemetry": "enabled"},
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Annotations: tt.annotations}
+			assert.Equal(t, tt.want, cmdutil.IsTelemetryDisabled(cmd))
+		})
+	}
+}
 
-		parent := &cobra.Command{Use: "pr"}
-		root := &cobra.Command{Use: "gh"}
-		root.AddCommand(parent)
-		parent.AddCommand(cmd)
+func TestDisableTelemetry(t *testing.T) {
+	t.Run("adds the disabled annotation when annotations are nil", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		assert.False(t, cmdutil.IsTelemetryDisabled(cmd))
 
-		cmdutil.RecordTelemetry(cmd, recorder)
-
-		require.NoError(t, cmd.Flags().Set("web", "true"))
-		require.NoError(t, cmd.Flags().Set("repo", "cli/cli"))
-		require.NoError(t, cmd.RunE(cmd, nil))
-
-		require.Len(t, recorder.Events, 1)
-		event := recorder.Events[0]
-		assert.Equal(t, "command_invocation", event.Type)
-		assert.Equal(t, "gh pr list", event.Dimensions["command"])
-		assert.Equal(t, "repo,web", event.Dimensions["flags"])
-	})
-
-	t.Run("is a no-op when original RunE is nil", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		cmd := &cobra.Command{Use: "test"}
-
-		cmdutil.RecordTelemetry(cmd, recorder)
-
-		assert.Nil(t, cmd.RunE, "RunE should remain nil when it was nil before")
-		assert.Empty(t, recorder.Events, "no telemetry should be recorded")
-	})
-
-	t.Run("propagates error from original RunE", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		expectedErr := fmt.Errorf("something went wrong")
-		cmd := &cobra.Command{
-			Use:  "fail",
-			RunE: func(cmd *cobra.Command, args []string) error { return expectedErr },
-		}
-
-		cmdutil.RecordTelemetry(cmd, recorder)
-
-		err := cmd.RunE(cmd, nil)
-		assert.ErrorIs(t, err, expectedErr)
-		// Telemetry is still recorded even on error
-		require.Len(t, recorder.Events, 1)
-		assert.Equal(t, "command_invocation", recorder.Events[0].Type)
-	})
-
-	t.Run("flags are sorted alphabetically", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		cmd := &cobra.Command{
-			Use:  "test",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
-		cmd.Flags().Bool("zebra", false, "")
-		cmd.Flags().Bool("alpha", false, "")
-		cmd.Flags().Bool("middle", false, "")
-
-		cmdutil.RecordTelemetry(cmd, recorder)
-
-		require.NoError(t, cmd.Flags().Set("zebra", "true"))
-		require.NoError(t, cmd.Flags().Set("alpha", "true"))
-		require.NoError(t, cmd.Flags().Set("middle", "true"))
-		require.NoError(t, cmd.RunE(cmd, nil))
-
-		require.Len(t, recorder.Events, 1)
-		assert.Equal(t, "alpha,middle,zebra", recorder.Events[0].Dimensions["flags"])
-	})
-
-	t.Run("no flags set records empty flags string", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		cmd := &cobra.Command{
-			Use:  "test",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
-		cmd.Flags().Bool("unused", false, "")
-
-		cmdutil.RecordTelemetry(cmd, recorder)
-		require.NoError(t, cmd.RunE(cmd, nil))
-
-		require.Len(t, recorder.Events, 1)
-		assert.Equal(t, "", recorder.Events[0].Dimensions["flags"])
-	})
-
-	t.Run("skips commands with telemetry disabled", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-		cmd := &cobra.Command{
-			Use:  "internal",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
 		cmdutil.DisableTelemetry(cmd)
-		cmdutil.RecordTelemetry(cmd, recorder)
 
-		require.NoError(t, cmd.RunE(cmd, nil))
-		assert.Empty(t, recorder.Events, "telemetry should not be recorded for disabled commands")
+		assert.True(t, cmdutil.IsTelemetryDisabled(cmd))
+		assert.Equal(t, "disabled", cmd.Annotations["telemetry"])
+	})
+
+	t.Run("preserves existing annotations", func(t *testing.T) {
+		cmd := &cobra.Command{Annotations: map[string]string{"other": "value"}}
+
+		cmdutil.DisableTelemetry(cmd)
+
+		assert.True(t, cmdutil.IsTelemetryDisabled(cmd))
+		assert.Equal(t, "value", cmd.Annotations["other"])
 	})
 }
 
-func TestRecordTelemetryForSubcommands(t *testing.T) {
-	t.Run("instruments nested subcommands", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
+func TestDisableTelemetryRecursively(t *testing.T) {
+	t.Run("disables telemetry on the root and all descendants", func(t *testing.T) {
+		root := &cobra.Command{Use: "root"}
+		child := &cobra.Command{Use: "child"}
+		grandchild := &cobra.Command{Use: "grandchild"}
+		sibling := &cobra.Command{Use: "sibling"}
 
-		root := &cobra.Command{Use: "gh"}
-		parent := &cobra.Command{Use: "pr"}
-		child := &cobra.Command{
-			Use:  "list",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
-		root.AddCommand(parent)
-		parent.AddCommand(child)
+		child.AddCommand(grandchild)
+		root.AddCommand(child, sibling)
 
-		cmdutil.RecordTelemetryForSubcommands(root, recorder)
-		require.NoError(t, child.RunE(child, nil))
+		cmdutil.DisableTelemetryRecursively(root)
 
-		require.Len(t, recorder.Events, 1)
-		assert.Equal(t, "command_invocation", recorder.Events[0].Type)
-		assert.Equal(t, "gh pr list", recorder.Events[0].Dimensions["command"])
+		assert.True(t, cmdutil.IsTelemetryDisabled(root), "root should also be disabled")
+		assert.True(t, cmdutil.IsTelemetryDisabled(child))
+		assert.True(t, cmdutil.IsTelemetryDisabled(grandchild))
+		assert.True(t, cmdutil.IsTelemetryDisabled(sibling))
 	})
 
-	t.Run("skips subcommands with nil RunE", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
+	t.Run("leaf command is still disabled", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "leaf"}
 
-		root := &cobra.Command{Use: "gh"}
-		child := &cobra.Command{Use: "help"} // no RunE
-		root.AddCommand(child)
+		cmdutil.DisableTelemetryRecursively(cmd)
 
-		cmdutil.RecordTelemetryForSubcommands(root, recorder)
-
-		assert.Nil(t, child.RunE, "nil RunE should remain nil")
-	})
-
-	t.Run("skips subcommands with telemetry disabled", func(t *testing.T) {
-		recorder := &telemetry.EventRecorderSpy{}
-
-		root := &cobra.Command{Use: "gh"}
-		child := &cobra.Command{
-			Use:  "send-telemetry",
-			RunE: func(cmd *cobra.Command, args []string) error { return nil },
-		}
-		cmdutil.DisableTelemetry(child)
-		root.AddCommand(child)
-
-		cmdutil.RecordTelemetryForSubcommands(root, recorder)
-		require.NoError(t, child.RunE(child, nil))
-
-		assert.Empty(t, recorder.Events, "disabled commands should not record telemetry")
+		assert.True(t, cmdutil.IsTelemetryDisabled(cmd))
 	})
 }


### PR DESCRIPTION
## Motivation

Today, when a command fails we have no visibility into what kinds of errors users are hitting. This makes it hard to prioritize reliability work or catch regressions early.

## What this does

Records error information alongside the existing `command_invocation` telemetry event so we can understand failure patterns at scale. Each error event includes a classification (`outcome`) and the chain of error types (`errTypes`) - no user data, just type names.

To support this cleanly, the PR also:

- **Centralizes telemetry recording** in `ghcmd.Main()` instead of wiring it per-command through Cobra, reducing boilerplate and making it harder to accidentally skip.
- **Introduces `internal/gherrs`** to give exit codes and silencing behavior a proper home, replacing scattered sentinel checks across the codebase.
- **Simplifies `pkg/cmdutil/telemetry.go`** down to just disable/check helpers now that recording lives in one place.

## Validating the data

The new telemetry dimensions are covered by end-to-end tests that capture real `Main()` output, so we will catch regressions if the shape of the data changes.