### PR TITLE
Enable telemetry without env var

### DIFF
--- a/acceptance/testdata/skills/skills-install.txtar
+++ b/acceptance/testdata/skills/skills-install.txtar
@@ -21,7 +21,6 @@ grep 'github-repo' $WORK/custom-skills/git-commit/SKILL.md
 
 # Telemetry: skill_install event records agent hosts, repo identifiers,
 # and (for a public repo) the installed skill name.
-env GH_PRIVATE_ENABLE_TELEMETRY=1
 env GH_TELEMETRY=log
 env GH_TELEMETRY_SAMPLE_RATE=100
 exec gh skill install github/awesome-copilot git-commit --scope user --force --agent github-copilot

--- a/acceptance/testdata/skills/skills-preview.txtar
+++ b/acceptance/testdata/skills/skills-preview.txtar
@@ -10,7 +10,6 @@ stderr 'not found'
 
 # Telemetry: skill_preview event records repo identifiers and, for a
 # public repo, the skill name.
-env GH_PRIVATE_ENABLE_TELEMETRY=1
 env GH_TELEMETRY=log
 env GH_TELEMETRY_SAMPLE_RATE=100
 exec gh skill preview github/awesome-copilot git-commit

--- a/acceptance/testdata/telemetry/command-invocation.txtar
+++ b/acceptance/testdata/telemetry/command-invocation.txtar
@@ -1,5 +1,4 @@
 # Telemetry log mode outputs command invocation event to stderr
-env GH_PRIVATE_ENABLE_TELEMETRY=1
 env GH_TELEMETRY=log
 env GH_TELEMETRY_SAMPLE_RATE=100
 

--- a/acceptance/testdata/telemetry/no-telemetry-for-alias.txtar
+++ b/acceptance/testdata/telemetry/no-telemetry-for-alias.txtar
@@ -2,7 +2,6 @@
 # resolved inner command should still record normally — its path is a core
 # gh command and conveys no user-authored identifier.
 
-env GH_PRIVATE_ENABLE_TELEMETRY=1
 env GH_TELEMETRY=log
 env GH_TELEMETRY_SAMPLE_RATE=100
 

--- a/acceptance/testdata/telemetry/no-telemetry-for-completion.txtar
+++ b/acceptance/testdata/telemetry/no-telemetry-for-completion.txtar
@@ -1,5 +1,4 @@
 # The completion command should not generate a telemetry event
-env GH_PRIVATE_ENABLE_TELEMETRY=1
 env GH_TELEMETRY=log
 env GH_TELEMETRY_SAMPLE_RATE=100
 

--- a/acceptance/testdata/telemetry/no-telemetry-for-extension.txtar
+++ b/acceptance/testdata/telemetry/no-telemetry-for-extension.txtar
@@ -3,7 +3,6 @@
 # organization or project name).
 [!exec:bash] skip
 
-env GH_PRIVATE_ENABLE_TELEMETRY=1
 env GH_TELEMETRY=log
 env GH_TELEMETRY_SAMPLE_RATE=100
 

--- a/acceptance/testdata/telemetry/no-telemetry-for-ghes-user.txtar
+++ b/acceptance/testdata/telemetry/no-telemetry-for-ghes-user.txtar
@@ -1,5 +1,4 @@
 # GHES users should not get telemetry even when telemetry is enabled
-env GH_PRIVATE_ENABLE_TELEMETRY=1
 env GH_TELEMETRY=log
 env GH_TELEMETRY_SAMPLE_RATE=100
 env GH_ENTERPRISE_TOKEN=fake-enterprise-token

--- a/acceptance/testdata/telemetry/no-telemetry-for-send-telemetry.txtar
+++ b/acceptance/testdata/telemetry/no-telemetry-for-send-telemetry.txtar
@@ -1,5 +1,4 @@
 # The send-telemetry command should not itself generate a telemetry event
-env GH_PRIVATE_ENABLE_TELEMETRY=1
 env GH_TELEMETRY=log
 env GH_TELEMETRY_SAMPLE_RATE=100
 env GH_TELEMETRY_ENDPOINT_URL=http://localhost:1

--- a/acceptance/testdata/telemetry/telemetry-failure-does-not-break-command.txtar
+++ b/acceptance/testdata/telemetry/telemetry-failure-does-not-break-command.txtar
@@ -1,5 +1,4 @@
 # Command completes successfully even when telemetry endpoint is unreachable
-env GH_PRIVATE_ENABLE_TELEMETRY=1
 env GH_TELEMETRY=enabled
 env GH_TELEMETRY_SAMPLE_RATE=100
 env GH_TELEMETRY_ENDPOINT_URL=http://localhost:1

--- a/acceptance/testdata/telemetry/telemetry-for-official-extension-stub.txtar
+++ b/acceptance/testdata/telemetry/telemetry-for-official-extension-stub.txtar
@@ -3,7 +3,6 @@
 # names come from a fixed, hard-coded registry and do not contain any
 # user-authored identifiers.
 
-env GH_PRIVATE_ENABLE_TELEMETRY=1
 env GH_TELEMETRY=log
 env GH_TELEMETRY_SAMPLE_RATE=100
 

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -84,7 +84,7 @@ func Main() exitCode {
 		telemetryService = &telemetry.NoOpService{}
 	default:
 		telemetryState := telemetry.ParseTelemetryState(cfg.Telemetry().Value)
-		telemetryDisabled := os.Getenv("GH_PRIVATE_ENABLE_TELEMETRY") == "" || mightBeGHESUser(cfg)
+		telemetryDisabled := mightBeGHESUser(cfg)
 
 		switch telemetryState {
 		case telemetry.Disabled:


### PR DESCRIPTION
## Description

Removes the env var that gates telemetry, so it will be on by default.

See https://cli.github.com/telemetry for everything around this.
