### PR TITLE
Fix SetSampleRate not updating sample_rate dimension

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -283,6 +284,7 @@ func (s *service) SetSampleRate(rate int) {
 	defer s.mu.Unlock()
 
 	s.sampleRate = rate
+	s.commonDimensions["sample_rate"] = strconv.Itoa(rate)
 }
 
 func (s *service) Flush() {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -579,6 +579,24 @@ func TestServiceSampling(t *testing.T) {
 		assert.False(t, called, "flusher should not be called after SetSampleRate reduced the rate")
 	})
 
+	t.Run("SetSampleRate updates sample_rate dimension", func(t *testing.T) {
+		t.Cleanup(stubDeviceID("test-device"))
+
+		var captured SendTelemetryPayload
+		svc := newService(func(p SendTelemetryPayload) { captured = p }, ghtelemetry.Dimensions{
+			"sample_rate": "1",
+		})
+		svc.sampleRate = 1
+		svc.sampleBucket = 0
+
+		svc.SetSampleRate(100)
+		svc.Record(ghtelemetry.Event{Type: "test"})
+		svc.Flush()
+
+		require.Len(t, captured.Events, 1)
+		assert.Equal(t, "100", captured.Events[0].Dimensions["sample_rate"])
+	})
+
 	t.Run("WithSampleRate option sets rate on construction", func(t *testing.T) {
 		t.Cleanup(stubDeviceID("test-device"))
 


### PR DESCRIPTION
## Problem

The `sample_rate` common dimension is set once at service creation time in `cmd.go` (line 114) and stored in `commonDimensions`. When `SetSampleRate` is called later (e.g. by the skills command's `PersistentPreRunE`), only the internal `sampleRate` field is updated - the dimension reported in the telemetry payload is never refreshed.

This means commands like `gh skill publish` that set `SAMPLE_ALL` (100) still report `sample_rate: 1` in telemetry events.

## Fix

Update `SetSampleRate` to also write the new rate into `commonDimensions["sample_rate"]`, keeping the reported dimension in sync with the actual sampling behavior.

## Validation

- Added test confirming the dimension is updated after `SetSampleRate`
- All existing telemetry and skills tests pass