### PR TITLE
fix(issue): accept local issue template filenames as fallback

### DIFF
--- a/pkg/cmd/pr/shared/templates.go
+++ b/pkg/cmd/pr/shared/templates.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 
 	"github.com/cli/cli/v2/api"
@@ -225,7 +226,41 @@ func (m *templateManager) Select(name string) (Template, error) {
 		}
 	}
 
+	if !m.isPR {
+		if t := m.selectIssueTemplateByFilename(name); t != nil {
+			return t, nil
+		}
+	}
+
 	return nil, fmt.Errorf("template %q not found", name)
+}
+
+func (m *templateManager) selectIssueTemplateByFilename(name string) Template {
+	if !m.allowFS {
+		return nil
+	}
+
+	dir := m.rootDir
+	if dir == "" {
+		gitClient := &git.Client{}
+		var err error
+		dir, err = gitClient.ToplevelDir(context.Background())
+		if err != nil {
+			return nil
+		}
+	}
+
+	for _, templatePath := range githubtemplate.FindNonLegacy(dir, "ISSUE_TEMPLATE") {
+		if path.Base(templatePath) == name {
+			return &filesystemIssueTemplate{filesystemTemplate{path: templatePath}}
+		}
+	}
+
+	if legacyTemplate := githubtemplate.FindLegacy(dir, "ISSUE_TEMPLATE"); legacyTemplate != "" && path.Base(legacyTemplate) == name {
+		return &filesystemIssueTemplate{filesystemTemplate{path: legacyTemplate}}
+	}
+
+	return nil
 }
 
 func (m *templateManager) memoizedFetch() error {
@@ -294,12 +329,20 @@ type filesystemTemplate struct {
 	path string
 }
 
+type filesystemIssueTemplate struct {
+	filesystemTemplate
+}
+
 func (t *filesystemTemplate) Name() string {
 	return githubtemplate.ExtractName(t.path)
 }
 
 func (t *filesystemTemplate) NameForSubmit() string {
 	return ""
+}
+
+func (t *filesystemIssueTemplate) NameForSubmit() string {
+	return t.Name()
 }
 
 func (t *filesystemTemplate) Body() []byte {

--- a/pkg/cmd/pr/shared/templates_test.go
+++ b/pkg/cmd/pr/shared/templates_test.go
@@ -223,3 +223,44 @@ func TestTemplateManagerSelect(t *testing.T) {
 		})
 	}
 }
+
+func TestTemplateManagerSelect_IssueTemplateByFilenameFallback(t *testing.T) {
+	rootDir := t.TempDir()
+	templateFile := filepath.Join(rootDir, ".github", "ISSUE_TEMPLATE", "task.md")
+	_ = os.MkdirAll(filepath.Dir(templateFile), 0755)
+	_ = os.WriteFile(templateFile, []byte(`---
+name: Task
+title: 'task: '
+---
+
+Describe the task
+`), 0644)
+
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.GraphQL(`query IssueTemplates\b`),
+		httpmock.StringResponse(`
+		{ "data": { "repository": { "issueTemplates": [
+			{ "name": "Task", "body": "Describe the task", "title": "task: " }
+		] } } }`),
+	)
+
+	m := templateManager{
+		repo:       ghrepo.NewWithHost("OWNER", "REPO", "example.com"),
+		rootDir:    rootDir,
+		allowFS:    true,
+		isPR:       false,
+		httpClient: &http.Client{Transport: reg},
+		detector:   &fd.EnabledDetectorMock{},
+	}
+
+	tmpl, err := m.Select("task.md")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Task", tmpl.Name())
+	assert.Equal(t, "Task", tmpl.NameForSubmit())
+	assert.Equal(t, "task: ", tmpl.Title())
+	assert.Equal(t, "Describe the task\n", string(tmpl.Body()))
+}


### PR DESCRIPTION
Fixes #10202

This pull request makes `gh issue create --template` accept local markdown issue template filenames as a fallback, while keeping the existing lookup by template name.

Current behavior is inconsistent:
- `gh pr create --template` resolves templates by filename
- `gh issue create --template` resolves templates by template name only

This change keeps the current preferred issue-template route intact and only adds a fallback when that name lookup misses:
- keep `gh issue create --template "Task"` working as it does today
- also accept `gh issue create --template task.md` when the local template exists in `.github/ISSUE_TEMPLATE/`
- preserve the submitted template name so the GraphQL `issueTemplate` input still uses the server-side template name instead of the filename

That makes the command more forgiving for local workflows without changing pull request template behavior.

## Testing
- go test ./pkg/cmd/pr/shared ./pkg/cmd/issue/create
