### PR TITLE
chore: sign APT repository with both keys

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -327,12 +327,19 @@ jobs:
           GPG_KEY: ${{ secrets.GPG_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_KEYGRIP: ${{ secrets.GPG_KEYGRIP }}
+          GPG_PUBKEY_2026: ${{ secrets.GPG_PUBKEY_2026 }}
+          GPG_KEY_2026: ${{ secrets.GPG_KEY_2026 }}
+          GPG_PASSPHRASE_2026: ${{ secrets.GPG_PASSPHRASE_2026 }}
+          GPG_KEYGRIP_2026: ${{ secrets.GPG_KEYGRIP_2026 }}
         run: |
           base64 -d <<<"$GPG_PUBKEY" | gpg --import --no-tty --batch --yes
           base64 -d <<<"$GPG_KEY" | gpg --import --no-tty --batch --yes
+          base64 -d <<<"$GPG_PUBKEY_2026" | gpg --import --no-tty --batch --yes
+          base64 -d <<<"$GPG_KEY_2026" | gpg --import --no-tty --batch --yes
           echo "allow-preset-passphrase" > ~/.gnupg/gpg-agent.conf
           gpg-connect-agent RELOADAGENT /bye
           base64 -d <<<"$GPG_PASSPHRASE" | /usr/lib/gnupg2/gpg-preset-passphrase --preset "$GPG_KEYGRIP"
+          base64 -d <<<"$GPG_PASSPHRASE_2026" | /usr/lib/gnupg2/gpg-preset-passphrase --preset "$GPG_KEYGRIP_2026"
       - name: Sign RPMs
         if: inputs.environment == 'production'
         run: |
@@ -353,7 +360,7 @@ jobs:
           ./script/createrepo.sh
           cp -r dist/repodata site/packages/rpm/
           pushd site/packages/rpm
-          [ "$GPG_SIGN" = "false" ] || gpg --yes --detach-sign --armor repodata/repomd.xml
+          [ "$GPG_SIGN" = "false" ] || gpg --yes --detach-sign --armor --default-key 2C6106201985B60E6C7AC87323F3D4EA75716059 repodata/repomd.xml
           popd
       - name: Run reprepro
         env:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -375,12 +375,19 @@ jobs:
           GPG_KEY: ${{ secrets.GPG_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_KEYGRIP: ${{ secrets.GPG_KEYGRIP }}
+          GPG_PUBKEY_2026: ${{ secrets.GPG_PUBKEY_2026 }}
+          GPG_KEY_2026: ${{ secrets.GPG_KEY_2026 }}
+          GPG_PASSPHRASE_2026: ${{ secrets.GPG_PASSPHRASE_2026 }}
+          GPG_KEYGRIP_2026: ${{ secrets.GPG_KEYGRIP_2026 }}
         run: |
           base64 -d <<<"$GPG_PUBKEY" | gpg --import --no-tty --batch --yes
           base64 -d <<<"$GPG_KEY" | gpg --import --no-tty --batch --yes
+          base64 -d <<<"$GPG_PUBKEY_2026" | gpg --import --no-tty --batch --yes
+          base64 -d <<<"$GPG_KEY_2026" | gpg --import --no-tty --batch --yes
           echo "allow-preset-passphrase" > ~/.gnupg/gpg-agent.conf
           gpg-connect-agent RELOADAGENT /bye
           base64 -d <<<"$GPG_PASSPHRASE" | /usr/lib/gnupg2/gpg-preset-passphrase --preset "$GPG_KEYGRIP"
+          base64 -d <<<"$GPG_PASSPHRASE_2026" | /usr/lib/gnupg2/gpg-preset-passphrase --preset "$GPG_KEYGRIP_2026"
       - name: Sign RPMs
         if: inputs.environment == 'production'
         run: |
@@ -400,7 +407,7 @@ jobs:
           ./script/createrepo.sh
           cp -r dist/repodata site/packages/rpm/
           pushd site/packages/rpm
-          gpg --yes --detach-sign --armor repodata/repomd.xml
+          gpg --yes --detach-sign --armor --default-key 2C6106201985B60E6C7AC87323F3D4EA75716059 repodata/repomd.xml
           popd
       - name: Run reprepro
         if: ${{ inputs.environment == 'production' }}

--- a/script/distributions
+++ b/script/distributions
@@ -4,7 +4,7 @@ Codename: stable
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian stable repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 
 Origin: gh
 Label: gh
@@ -12,7 +12,7 @@ Codename: oldstable
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian oldstable repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 
 Origin: gh
 Label: gh
@@ -20,7 +20,7 @@ Codename: testing
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian testing repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 
 Origin: gh
 Label: gh
@@ -28,7 +28,7 @@ Codename: unstable
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian unstable repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 
 Origin: gh
 Label: gh
@@ -36,7 +36,7 @@ Codename: sid
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian unstable repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 
 Origin: gh
 Label: gh
@@ -44,7 +44,7 @@ Codename: buster
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian buster repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 
 Origin: gh
 Label: gh
@@ -52,7 +52,7 @@ Codename: bullseye
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian bullseye repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 
 Origin: gh
 Label: gh
@@ -60,7 +60,7 @@ Codename: stretch
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian stretch repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 
 Origin: gh
 Label: gh
@@ -68,7 +68,7 @@ Codename: jessie
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - debian jessie repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 
 Origin: gh
 Label: gh
@@ -76,7 +76,7 @@ Codename: focal
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu focal repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 DebOverride: override.ubuntu
 
 Origin: gh
@@ -85,7 +85,7 @@ Codename: precise
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu precise repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 DebOverride: override.ubuntu
 
 Origin: gh
@@ -94,7 +94,7 @@ Codename: bionic
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu bionic repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 DebOverride: override.ubuntu
 
 Origin: gh
@@ -103,7 +103,7 @@ Codename: trusty
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu trusty repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 DebOverride: override.ubuntu
 
 Origin: gh
@@ -112,7 +112,7 @@ Codename: xenial
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu xenial repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 DebOverride: override.ubuntu
 
 Origin: gh
@@ -121,7 +121,7 @@ Codename: groovy
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu groovy repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 DebOverride: override.ubuntu
 
 Origin: gh
@@ -130,7 +130,7 @@ Codename: eoan
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu eoan repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 DebOverride: override.ubuntu
 
 Origin: gh
@@ -139,7 +139,7 @@ Codename: disco
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu disco repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 DebOverride: override.ubuntu
 
 Origin: gh
@@ -148,7 +148,7 @@ Codename: cosmic
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu cosmic repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 DebOverride: override.ubuntu
 
 Origin: gh
@@ -157,7 +157,7 @@ Codename: hirsute
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu hirsute repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 DebOverride: override.ubuntu
 
 Origin: gh
@@ -166,7 +166,7 @@ Codename: kali-rolling
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - kali repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 
 Origin: gh
 Label: gh
@@ -174,5 +174,5 @@ Codename: impish
 Architectures: i386 amd64 armhf arm64
 Components: main
 Description: The GitHub CLI - ubuntu impish repo
-SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059
+SignWith: 2C6106201985B60E6C7AC87323F3D4EA75716059 7F38BBB59D064DBCB3D84D725612B36462313325
 DebOverride: override.ubuntu

--- a/script/rpmmacros
+++ b/script/rpmmacros
@@ -1,1 +1,1 @@
-%_gpg_name GitHub CLI <opensource+cli@github.com>
+%_gpg_name 2C6106201985B60E6C7AC87323F3D4EA75716059


### PR DESCRIPTION
## Summary

Updates the deployment workflow to sign the Linux APT repository with both the old and new PGP keys, enabling a smooth key rotation for APT users. The RPM repository continues to be signed with the current key.

## Changes

- Import and preset the new PGP key alongside the existing key during release
- Update `script/distributions` to dual-sign all APT distributions with both keys
- Pin `--default-key` on the RPM repomd.xml signing step to explicitly use the current key (avoids ambiguity with two keys in the keyring)
- Switch `script/rpmmacros` from email-based UID to explicit fingerprint for the same reason
