### PR TITLE
chore: fix zsh completion on debian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /share/fish/vendor_completions.d
 /share/man/man1
 /share/zsh/site-functions
+/share/zsh/vendor-completions
 /gh-cli
 .envrc
 /dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -106,3 +106,8 @@ nfpms: #build:linux
         dst: "/usr/share/fish/vendor_completions.d/gh.fish"
       - src: "./share/zsh/site-functions/_gh"
         dst: "/usr/share/zsh/site-functions/_gh"
+      # Debian/Ubuntu zsh does not look in /usr/share/zsh/site-functions by default,
+      # so we also install to vendor-completions. See https://github.com/cli/cli/issues/13166
+      - src: "./share/zsh/vendor-completions/_gh"
+        dst: "/usr/share/zsh/vendor-completions/_gh"
+        packager: deb

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,14 @@ manpages: script/build$(EXE)
 
 .PHONY: completions
 completions: bin/gh$(EXE)
-	mkdir -p ./share/bash-completion/completions ./share/fish/vendor_completions.d ./share/zsh/site-functions
+	mkdir -p ./share/bash-completion/completions ./share/fish/vendor_completions.d ./share/zsh/site-functions ./share/zsh/vendor-completions
 	bin/gh$(EXE) completion -s bash > ./share/bash-completion/completions/gh
 	bin/gh$(EXE) completion -s fish > ./share/fish/vendor_completions.d/gh.fish
 	bin/gh$(EXE) completion -s zsh > ./share/zsh/site-functions/_gh
+	# On Debian/Ubuntu the default zsh fpath does not include /usr/share/zsh/site-functions
+	# but does include /usr/share/zsh/vendor-completions, so we ship both paths in our
+	# .deb and .rpm packages. See https://github.com/cli/cli/issues/13166
+	cp ./share/zsh/site-functions/_gh ./share/zsh/vendor-completions/_gh
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
Fixes #13166 

Our `.deb`/`.rpm` packages install the zsh completion script at `/usr/share/zsh/site-functions/_gh`. This path is picked up by default on RPM-based distros (e.g., Fedora) but not on Debian/Ubuntu, where zsh looks in `/usr/share/zsh/vendor-completions` instead.

This PR ships the completion file under both paths. On Debian the new path is discovered correctly, while on RPM distros the new path is ignored, so there's no change in behavior.

### Changes

- **Makefile**: `completions` target now also copies `_gh` into `./share/zsh/vendor-completions/`.
- **.goreleaser.yml**: Added a new NFPMS content entry for the `vendor-completions` path.
- **.gitignore**: Added `/share/zsh/vendor-completions`.

### Note

The `install`/`uninstall` Makefile targets are intentionally left unchanged. Those are for source builds (`make install`) where the user controls the prefix, and `site-functions` is the conventional path for that case.
