### PR TITLE
feat(api): Enable HTTP caching using the ETag header

### DIFF
--- a/api/etag_cache.go
+++ b/api/etag_cache.go
@@ -20,16 +20,22 @@ type etagCache struct {
 
 func newEtagCache() (*etagCache, error) {
 	dir := filepath.Join(ghConfig.CacheDir(), "etag")
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, fmt.Errorf("creating etag cache dir: %w", err)
 	}
 	return &etagCache{dir: dir}, nil
 }
 
-// cacheKey computes a SHA-256 hash of the URL and Authorization header.
+// cacheKey computes a SHA-256 hash of the URL and request headers that affect
+// authorization and response representation.
 func cacheKey(req *http.Request) string {
 	h := sha256.New()
-	fmt.Fprintf(h, "%s\n%s", req.URL.String(), req.Header.Get("Authorization"))
+	fmt.Fprintf(h, "%s\n%s\n%s\n%s",
+		req.URL.String(),
+		req.Header.Get("Authorization"),
+		req.Header.Get("Accept"),
+		req.Header.Get("X-GitHub-Api-Version"),
+	)
 	return hex.EncodeToString(h.Sum(nil))
 }
 
@@ -50,12 +56,28 @@ func (c *etagCache) Load(key string) *http.Response {
 	return resp
 }
 
-// Store serializes a full HTTP response to disk.
-func (c *etagCache) Store(key string, resp *http.Response) error {
-	f, err := os.Create(c.path(key))
+// Store serializes a full HTTP response to disk atomically.
+func (c *etagCache) Store(key string, resp *http.Response) (err error) {
+	tmp, err := os.CreateTemp(c.dir, key+".tmp-*")
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	return resp.Write(f)
+
+	tmpPath := tmp.Name()
+	defer func() {
+		if err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err = resp.Write(tmp); err != nil {
+		return err
+	}
+
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpPath, c.path(key))
 }

--- a/api/etag_cache.go
+++ b/api/etag_cache.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	ghConfig "github.com/cli/go-gh/v2/pkg/config"
+)
+
+// etagCache manages on-disk storage of full HTTP responses keyed by request.
+type etagCache struct {
+	dir string
+}
+
+func newEtagCache() (*etagCache, error) {
+	dir := filepath.Join(ghConfig.CacheDir(), "etag")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("creating etag cache dir: %w", err)
+	}
+	return &etagCache{dir: dir}, nil
+}
+
+// cacheKey computes a SHA-256 hash of the URL and Authorization header.
+func cacheKey(req *http.Request) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s\n%s", req.URL.String(), req.Header.Get("Authorization"))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func (c *etagCache) path(key string) string {
+	return filepath.Join(c.dir, key)
+}
+
+// Load reads a cached HTTP response from disk, or returns nil if not cached.
+func (c *etagCache) Load(key string) *http.Response {
+	data, err := os.ReadFile(c.path(key))
+	if err != nil {
+		return nil
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(data)), nil)
+	if err != nil {
+		return nil
+	}
+	return resp
+}
+
+// Store serializes a full HTTP response to disk.
+func (c *etagCache) Store(key string, resp *http.Response) error {
+	f, err := os.Create(c.path(key))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return resp.Write(f)
+}

--- a/api/etag_cache_test.go
+++ b/api/etag_cache_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestEtagCache(t *testing.T) *etagCache {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "etag")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	return &etagCache{dir: dir}
+}
+
+func storeTestResponse(t *testing.T, cache *etagCache, key string, headers map[string]string, body string) {
+	t.Helper()
+	h := make(http.Header)
+	for k, v := range headers {
+		h.Set(k, v)
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     h,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+	}
+	require.NoError(t, cache.Store(key, resp))
+}
+
+func TestEtagCache_StoreAndLoad(t *testing.T) {
+	cache := newTestEtagCache(t)
+	key := "testkey"
+
+	storeTestResponse(t, cache, key, map[string]string{
+		"ETag":         `W/"abc123"`,
+		"Content-Type": "application/json",
+	}, `{"id":1}`)
+
+	resp := cache.Load(key)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+
+	assert.Equal(t, `W/"abc123"`, resp.Header.Get("ETag"))
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, `{"id":1}`, string(b))
+}
+
+func TestEtagCache_Load_NotCached(t *testing.T) {
+	cache := newTestEtagCache(t)
+	assert.Nil(t, cache.Load("nonexistent"))
+}
+
+func TestEtagCache_CacheKey(t *testing.T) {
+	req1, _ := http.NewRequest("GET", "https://api.github.com/repos/cli/cli", nil)
+	req1.Header.Set("Authorization", "token AAA")
+
+	req2, _ := http.NewRequest("GET", "https://api.github.com/repos/cli/cli", nil)
+	req2.Header.Set("Authorization", "token BBB")
+
+	req3, _ := http.NewRequest("GET", "https://api.github.com/repos/cli/cli", nil)
+	req3.Header.Set("Authorization", "token AAA")
+
+	key1 := cacheKey(req1)
+	key2 := cacheKey(req2)
+	key3 := cacheKey(req3)
+
+	assert.NotEqual(t, key1, key2, "different tokens should produce different keys")
+	assert.Equal(t, key1, key3, "same URL and token should produce the same key")
+}

--- a/api/etag_cache_test.go
+++ b/api/etag_cache_test.go
@@ -15,7 +15,7 @@ import (
 func newTestEtagCache(t *testing.T) *etagCache {
 	t.Helper()
 	dir := filepath.Join(t.TempDir(), "etag")
-	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, os.MkdirAll(dir, 0700))
 	return &etagCache{dir: dir}
 }
 
@@ -79,4 +79,18 @@ func TestEtagCache_CacheKey(t *testing.T) {
 
 	assert.NotEqual(t, key1, key2, "different tokens should produce different keys")
 	assert.Equal(t, key1, key3, "same URL and token should produce the same key")
+
+	req4, _ := http.NewRequest("GET", "https://api.github.com/repos/cli/cli", nil)
+	req4.Header.Set("Authorization", "token AAA")
+	req4.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	key4 := cacheKey(req4)
+	assert.NotEqual(t, key1, key4, "different Accept headers should produce different keys")
+
+	req5, _ := http.NewRequest("GET", "https://api.github.com/repos/cli/cli", nil)
+	req5.Header.Set("Authorization", "token AAA")
+	req5.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	key5 := cacheKey(req5)
+	assert.NotEqual(t, key1, key5, "different API version headers should produce different keys")
 }

--- a/api/etag_transport.go
+++ b/api/etag_transport.go
@@ -65,10 +65,12 @@ func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // can be written to the cache when the body is closed.
 type etagCacheWriter struct {
 	io.ReadCloser
-	cache  *etagCache
-	key    string
-	header http.Header
-	buf    *bytes.Buffer
+	cache   *etagCache
+	key     string
+	header  http.Header
+	buf     *bytes.Buffer
+	sawEOF  bool
+	readErr bool
 }
 
 func (w *etagCacheWriter) Read(p []byte) (int, error) {
@@ -76,11 +78,19 @@ func (w *etagCacheWriter) Read(p []byte) (int, error) {
 	if n > 0 {
 		w.buf.Write(p[:n])
 	}
+	if err == io.EOF {
+		w.sawEOF = true
+	} else if err != nil {
+		w.readErr = true
+	}
 	return n, err
 }
 
 func (w *etagCacheWriter) Close() error {
 	err := w.ReadCloser.Close()
+	if !w.sawEOF || w.readErr {
+		return err
+	}
 	// Reconstruct a full response for caching
 	cachedResp := &http.Response{
 		StatusCode: http.StatusOK,

--- a/api/etag_transport.go
+++ b/api/etag_transport.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+)
+
+// etagTransport is an http.RoundTripper that implements ETag-based conditional requests.
+// On 304 Not Modified, it returns the full cached response.
+type etagTransport struct {
+	transport http.RoundTripper
+	cache     *etagCache
+}
+
+func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Only cache GET requests
+	if req.Method != http.MethodGet {
+		return t.transport.RoundTrip(req)
+	}
+
+	key := cacheKey(req)
+
+	// Load cached response to get the ETag for conditional request
+	cachedResp := t.cache.Load(key)
+	if cachedResp != nil {
+		if etag := cachedResp.Header.Get("ETag"); etag != "" {
+			req.Header.Set("If-None-Match", etag)
+		}
+	}
+
+	resp, err := t.transport.RoundTrip(req)
+	if err != nil {
+		if cachedResp != nil {
+			cachedResp.Body.Close()
+		}
+		return resp, err
+	}
+
+	if resp.StatusCode == http.StatusNotModified && cachedResp != nil {
+		resp.Body.Close()
+		cachedResp.Header.Set("X-GH-ETag-Cache", "HIT")
+		return cachedResp, nil
+	}
+
+	// Done with cached response if we're not using it
+	if cachedResp != nil {
+		cachedResp.Body.Close()
+	}
+
+	if resp.StatusCode == http.StatusOK && resp.Header.Get("ETag") != "" {
+		resp.Body = &etagCacheWriter{
+			ReadCloser: resp.Body,
+			cache:      t.cache,
+			key:        key,
+			header:     resp.Header.Clone(),
+			buf:        &bytes.Buffer{},
+		}
+	}
+
+	return resp, nil
+}
+
+// etagCacheWriter wraps a response body, buffering reads so the full response
+// can be written to the cache when the body is closed.
+type etagCacheWriter struct {
+	io.ReadCloser
+	cache  *etagCache
+	key    string
+	header http.Header
+	buf    *bytes.Buffer
+}
+
+func (w *etagCacheWriter) Read(p []byte) (int, error) {
+	n, err := w.ReadCloser.Read(p)
+	if n > 0 {
+		w.buf.Write(p[:n])
+	}
+	return n, err
+}
+
+func (w *etagCacheWriter) Close() error {
+	err := w.ReadCloser.Close()
+	// Reconstruct a full response for caching
+	cachedResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     w.header,
+		Body:       io.NopCloser(bytes.NewReader(w.buf.Bytes())),
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+	}
+	// Best-effort cache write
+	_ = w.cache.Store(w.key, cachedResp)
+	return err
+}

--- a/api/etag_transport_test.go
+++ b/api/etag_transport_test.go
@@ -1,0 +1,214 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEtagTransport_FirstRequest(t *testing.T) {
+	cache := newTestEtagCache(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("If-None-Match"))
+		w.Header().Set("ETag", `W/"first"`)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"name":"cli"}`))
+	}))
+	defer ts.Close()
+
+	transport := &etagTransport{
+		transport: http.DefaultTransport,
+		cache:     cache,
+	}
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(ts.URL + "/repos/cli/cli")
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, `{"name":"cli"}`, string(body))
+
+	// Verify response was cached (written on Close)
+	req, _ := http.NewRequest("GET", ts.URL+"/repos/cli/cli", nil)
+	key := cacheKey(req)
+	cached := cache.Load(key)
+	require.NotNil(t, cached)
+	defer cached.Body.Close()
+	assert.Equal(t, `W/"first"`, cached.Header.Get("ETag"))
+	assert.Equal(t, "application/json", cached.Header.Get("Content-Type"))
+}
+
+func TestEtagTransport_ConditionalHit(t *testing.T) {
+	cache := newTestEtagCache(t)
+
+	var gotIfNoneMatch string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIfNoneMatch = r.Header.Get("If-None-Match")
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer ts.Close()
+
+	// Pre-populate cache
+	req, _ := http.NewRequest("GET", ts.URL+"/repos/cli/cli", nil)
+	key := cacheKey(req)
+	storeTestResponse(t, cache, key, map[string]string{
+		"ETag":         `W/"cached"`,
+		"Content-Type": "application/json",
+	}, `{"cached":true}`)
+
+	transport := &etagTransport{
+		transport: http.DefaultTransport,
+		cache:     cache,
+	}
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(ts.URL + "/repos/cli/cli")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, `W/"cached"`, gotIfNoneMatch)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, `{"cached":true}`, string(body))
+	assert.Equal(t, "HIT", resp.Header.Get("X-GH-ETag-Cache"))
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+}
+
+func TestEtagTransport_ConditionalMiss(t *testing.T) {
+	cache := newTestEtagCache(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `W/"new"`)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"updated":true}`))
+	}))
+	defer ts.Close()
+
+	// Pre-populate cache with old data
+	req, _ := http.NewRequest("GET", ts.URL+"/repos/cli/cli", nil)
+	key := cacheKey(req)
+	storeTestResponse(t, cache, key, map[string]string{
+		"ETag":         `W/"old"`,
+		"Content-Type": "application/json",
+	}, `{"old":true}`)
+
+	transport := &etagTransport{
+		transport: http.DefaultTransport,
+		cache:     cache,
+	}
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(ts.URL + "/repos/cli/cli")
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, `{"updated":true}`, string(body))
+
+	// Verify cache was updated (written on Close)
+	cached := cache.Load(key)
+	require.NotNil(t, cached)
+	defer cached.Body.Close()
+	assert.Equal(t, `W/"new"`, cached.Header.Get("ETag"))
+}
+
+func TestEtagTransport_NonGET_Bypassed(t *testing.T) {
+	cache := newTestEtagCache(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("If-None-Match"))
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"created":true}`))
+	}))
+	defer ts.Close()
+
+	transport := &etagTransport{
+		transport: http.DefaultTransport,
+		cache:     cache,
+	}
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Post(ts.URL+"/repos/cli/cli/issues", "application/json", bytes.NewBufferString(`{}`))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}
+
+func TestEtagTransport_NoETagHeader(t *testing.T) {
+	cache := newTestEtagCache(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"no_etag":true}`))
+	}))
+	defer ts.Close()
+
+	transport := &etagTransport{
+		transport: http.DefaultTransport,
+		cache:     cache,
+	}
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(ts.URL + "/repos/cli/cli")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, `{"no_etag":true}`, string(body))
+
+	// Verify nothing was cached
+	req, _ := http.NewRequest("GET", ts.URL+"/repos/cli/cli", nil)
+	key := cacheKey(req)
+	assert.Nil(t, cache.Load(key))
+}
+
+func TestEtagTransport_CacheCorruption(t *testing.T) {
+	cache := newTestEtagCache(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer ts.Close()
+
+	// Write garbage to the cache file
+	req, _ := http.NewRequest("GET", ts.URL+"/repos/cli/cli", nil)
+	key := cacheKey(req)
+	require.NoError(t, os.WriteFile(cache.path(key), []byte("not a valid response"), 0644))
+
+	transport := &etagTransport{
+		transport: http.DefaultTransport,
+		cache:     cache,
+	}
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(ts.URL + "/repos/cli/cli")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Corrupt cache can't be parsed, so no If-None-Match is sent,
+	// but server still returned 304. No cached response to fall back to,
+	// so we get the 304 as-is.
+	assert.Equal(t, http.StatusNotModified, resp.StatusCode)
+}

--- a/api/http_client.go
+++ b/api/http_client.go
@@ -73,18 +73,19 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 		return nil, err
 	}
 
-	if opts.Config != nil {
-		client.Transport = AddAuthTokenHeader(client.Transport, opts.Config)
+	if opts.EnableETagCache {
+		cache, err := newEtagCache()
+		if err != nil {
+			return nil, err
+		}
+		client.Transport = &etagTransport{
+			transport: client.Transport,
+			cache:     cache,
+		}
 	}
 
-	if opts.EnableETagCache {
-		cache, cacheErr := newEtagCache()
-		if cacheErr == nil {
-			client.Transport = &etagTransport{
-				transport: client.Transport,
-				cache:     cache,
-			}
-		}
+	if opts.Config != nil {
+		client.Transport = AddAuthTokenHeader(client.Transport, opts.Config)
 	}
 
 	if opts.TelemetryDisabler != nil {

--- a/api/http_client.go
+++ b/api/http_client.go
@@ -23,6 +23,7 @@ type HTTPClientOptions struct {
 	CacheTTL           time.Duration
 	Config             tokenGetter
 	EnableCache        bool
+	EnableETagCache    bool
 	Log                io.Writer
 	LogColorize        bool
 	LogVerboseHTTP     bool
@@ -74,6 +75,16 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 
 	if opts.Config != nil {
 		client.Transport = AddAuthTokenHeader(client.Transport, opts.Config)
+	}
+
+	if opts.EnableETagCache {
+		cache, cacheErr := newEtagCache()
+		if cacheErr == nil {
+			client.Transport = &etagTransport{
+				transport: client.Transport,
+				cache:     cache,
+			}
+		}
 	}
 
 	if opts.TelemetryDisabler != nil {

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -57,6 +57,7 @@ type ApiOptions struct {
 	Silent              bool
 	Template            string
 	CacheTTL            time.Duration
+	ETagCache           bool
 	FilterOutput        string
 	Verbose             bool
 }
@@ -243,6 +244,18 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 				return cmdutil.FlagErrorf("the `--paginate` option is not supported for non-GET requests")
 			}
 
+			if opts.ETagCache && opts.RequestMethodPassed && !strings.EqualFold(opts.RequestMethod, "GET") {
+				return cmdutil.FlagErrorf("the `--cache-etag` flag is not supported for non-GET requests")
+			}
+
+			if err := cmdutil.MutuallyExclusive(
+				"specify only one of `--cache` or `--cache-etag`",
+				opts.CacheTTL > 0,
+				opts.ETagCache,
+			); err != nil {
+				return err
+			}
+
 			if err := cmdutil.MutuallyExclusive(
 				"the `--paginate` option is not supported with `--input`",
 				opts.Paginate,
@@ -297,6 +310,7 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 	cmd.Flags().StringVarP(&opts.Template, "template", "t", "", "Format JSON output using a Go template; see \"gh help formatting\"")
 	cmd.Flags().StringVarP(&opts.FilterOutput, "jq", "q", "", "Query to select values from the response using jq syntax")
 	cmd.Flags().DurationVar(&opts.CacheTTL, "cache", 0, "Cache the response, e.g. \"3600s\", \"60m\", \"1h\"")
+	cmd.Flags().BoolVar(&opts.ETagCache, "cache-etag", false, "Cache the response based on ETag conditional requests")
 	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "Include full HTTP request and response in the output")
 	return cmd
 }
@@ -386,14 +400,15 @@ func apiRun(opts *ApiOptions) error {
 				log = opts.IO.Out
 			}
 			opts := api.HTTPClientOptions{
-				AppVersion:     opts.AppVersion,
-				InvokingAgent:  opts.InvokingAgent,
-				CacheTTL:       opts.CacheTTL,
-				Config:         cfg.Authentication(),
-				EnableCache:    opts.CacheTTL > 0,
-				Log:            log,
-				LogColorize:    opts.IO.ColorEnabled(),
-				LogVerboseHTTP: opts.Verbose,
+				AppVersion:      opts.AppVersion,
+				InvokingAgent:   opts.InvokingAgent,
+				CacheTTL:        opts.CacheTTL,
+				Config:          cfg.Authentication(),
+				EnableCache:     opts.CacheTTL > 0,
+				EnableETagCache: opts.ETagCache,
+				Log:             log,
+				LogColorize:     opts.IO.ColorEnabled(),
+				LogVerboseHTTP:  opts.Verbose,
 			}
 			return api.NewHTTPClient(opts)
 		}

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -244,8 +244,14 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 				return cmdutil.FlagErrorf("the `--paginate` option is not supported for non-GET requests")
 			}
 
-			if opts.ETagCache && opts.RequestMethodPassed && !strings.EqualFold(opts.RequestMethod, "GET") {
-				return cmdutil.FlagErrorf("the `--cache-etag` flag is not supported for non-GET requests")
+			if opts.ETagCache {
+				effectiveMethod := opts.RequestMethod
+				if !opts.RequestMethodPassed && (len(opts.RawFields) > 0 || len(opts.MagicFields) > 0 || opts.RequestInputFile != "") {
+					effectiveMethod = "POST"
+				}
+				if !strings.EqualFold(effectiveMethod, "GET") {
+					return cmdutil.FlagErrorf("the `--cache-etag` flag is not supported for non-GET requests")
+				}
 			}
 
 			if err := cmdutil.MutuallyExclusive(

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -346,6 +346,39 @@ func Test_NewCmdApi(t *testing.T) {
 			wantsErr: true,
 		},
 		{
+			name: "with cache-etag",
+			cli:  "user --cache-etag",
+			wants: ApiOptions{
+				Hostname:            "",
+				RequestMethod:       "GET",
+				RequestMethodPassed: false,
+				RequestPath:         "user",
+				RequestInputFile:    "",
+				RawFields:           []string(nil),
+				MagicFields:         []string(nil),
+				RequestHeaders:      []string(nil),
+				ShowResponseHeaders: false,
+				Paginate:            false,
+				Silent:              false,
+				CacheTTL:            0,
+				ETagCache:           true,
+				Template:            "",
+				FilterOutput:        "",
+				Verbose:             false,
+			},
+			wantsErr: false,
+		},
+		{
+			name:     "cache-etag with cache",
+			cli:      "user --cache-etag --cache 5m",
+			wantsErr: true,
+		},
+		{
+			name:     "cache-etag with non-GET",
+			cli:      "user --cache-etag -XPOST",
+			wantsErr: true,
+		},
+		{
 			name: "with verbose",
 			cli:  "user --verbose",
 			wants: ApiOptions{
@@ -401,6 +434,7 @@ func Test_NewCmdApi(t *testing.T) {
 			assert.Equal(t, tt.wants.Paginate, opts.Paginate)
 			assert.Equal(t, tt.wants.Silent, opts.Silent)
 			assert.Equal(t, tt.wants.CacheTTL, opts.CacheTTL)
+			assert.Equal(t, tt.wants.ETagCache, opts.ETagCache)
 			assert.Equal(t, tt.wants.Template, opts.Template)
 			assert.Equal(t, tt.wants.FilterOutput, opts.FilterOutput)
 			assert.Equal(t, tt.wants.Verbose, opts.Verbose)

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -379,6 +379,16 @@ func Test_NewCmdApi(t *testing.T) {
 			wantsErr: true,
 		},
 		{
+			name:     "cache-etag with raw fields implies POST",
+			cli:      "user --cache-etag -f key=value",
+			wantsErr: true,
+		},
+		{
+			name:     "cache-etag with input implies POST",
+			cli:      "user --cache-etag --input file.json",
+			wantsErr: true,
+		},
+		{
 			name: "with verbose",
 			cli:  "user --verbose",
 			wants: ApiOptions{


### PR DESCRIPTION
Allows you to cache responses to GET requests to disk and to pass `If-None-Match` on subsequent requests, giving GitHub the opportunity of responding with `304 Not Modified`.

Fixes #13279 
