### PR TITLE
Only fetch project data in pr edit when editing projects

### DIFF
--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -259,15 +259,28 @@ func editRun(opts *EditOptions) error {
 		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
 	}
 
-	findOptions := shared.FindOptions{
-		Selector: opts.SelectorArg,
-		Fields:   []string{"id", "author", "url", "title", "body", "baseRefName", "reviewRequests", "labels", "projectCards", "projectItems", "milestone"},
-		Detector: opts.Detector,
+	editable := opts.Editable
+	editable.Reviewers.Selectable = true
+
+	// In interactive mode, prompt the user for which fields to edit before
+	// fetching the PR. This avoids querying fields that require extra
+	// permissions (e.g. projectItems) when the user doesn't intend to edit them.
+	if opts.Interactive {
+		err = opts.Surveyor.FieldsToEdit(&editable)
+		if err != nil {
+			return err
+		}
 	}
 
 	issueFeatures, err := opts.Detector.IssueFeatures()
 	if err != nil {
 		return err
+	}
+
+	findOptions := shared.FindOptions{
+		Selector: opts.SelectorArg,
+		Fields:   []string{"id", "author", "url", "title", "body", "baseRefName", "reviewRequests", "labels", "milestone"},
+		Detector: opts.Detector,
 	}
 
 	// TODO ApiActorsSupported
@@ -277,13 +290,17 @@ func editRun(opts *EditOptions) error {
 		findOptions.Fields = append(findOptions.Fields, "assignees")
 	}
 
+	// Only fetch project data when the user is editing projects to avoid
+	// requiring the project permission scope for unrelated edits.
+	if editable.Projects.Edited {
+		findOptions.Fields = append(findOptions.Fields, "projectCards", "projectItems")
+	}
+
 	pr, repo, err := opts.Finder.Find(findOptions)
 	if err != nil {
 		return err
 	}
 
-	editable := opts.Editable
-	editable.Reviewers.Selectable = true
 	editable.Title.Default = pr.Title
 	editable.Body.Default = pr.Body
 	editable.Base.Default = pr.BaseRefName
@@ -298,21 +315,16 @@ func editRun(opts *EditOptions) error {
 		editable.Assignees.Default = pr.Assignees.Logins()
 	}
 	editable.Labels.Default = pr.Labels.Names()
-	editable.Projects.Default = append(pr.ProjectCards.ProjectNames(), pr.ProjectItems.ProjectTitles()...)
-	projectItems := map[string]string{}
-	for _, n := range pr.ProjectItems.Nodes {
-		projectItems[n.Project.ID] = n.ID
+	if editable.Projects.Edited {
+		editable.Projects.Default = append(pr.ProjectCards.ProjectNames(), pr.ProjectItems.ProjectTitles()...)
+		projectItems := map[string]string{}
+		for _, n := range pr.ProjectItems.Nodes {
+			projectItems[n.Project.ID] = n.ID
+		}
+		editable.Projects.ProjectItems = projectItems
 	}
-	editable.Projects.ProjectItems = projectItems
 	if pr.Milestone != nil {
 		editable.Milestone.Default = pr.Milestone.Title
-	}
-
-	if opts.Interactive {
-		err = opts.Surveyor.FieldsToEdit(&editable)
-		if err != nil {
-			return err
-		}
 	}
 
 	apiClient := api.NewClientFromHTTP(httpClient)

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -1426,6 +1426,14 @@ func TestProjectsV1Deprecation(t *testing.T) {
 
 			Finder: shared.NewFinder(f),
 
+			Editable: shared.Editable{
+				Projects: shared.EditableProjects{
+					EditableSlice: shared.EditableSlice{
+						Edited: true,
+					},
+				},
+			},
+
 			SelectorArg: "https://github.com/cli/cli/pull/123",
 		})
 
@@ -1457,10 +1465,58 @@ func TestProjectsV1Deprecation(t *testing.T) {
 
 			Finder: shared.NewFinder(f),
 
+			Editable: shared.Editable{
+				Projects: shared.EditableProjects{
+					EditableSlice: shared.EditableSlice{
+						Edited: true,
+					},
+				},
+			},
+
 			SelectorArg: "https://github.com/cli/cli/pull/123",
 		})
 
 		// Verify that our request did not contain projectCards
 		reg.Verify(t)
 	})
+}
+
+func TestEditSkipsProjectFieldsWhenNotEditingProjects(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+
+	reg := &httpmock.Registry{}
+	// Ensure that neither projectCards nor projectItems appear in the query
+	reg.Exclude(t, httpmock.GraphQL(`projectCards`))
+	reg.Exclude(t, httpmock.GraphQL(`projectItems`))
+
+	f := &cmdutil.Factory{
+		IOStreams: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+	}
+
+	// Ignore the error because we have no way to really stub it without
+	// fully stubbing a GQL error structure in the request body.
+	_ = editRun(&EditOptions{
+		IO: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		Detector: &fd.EnabledDetectorMock{},
+
+		Finder: shared.NewFinder(f),
+
+		Editable: shared.Editable{
+			Title: shared.EditableString{
+				Edited: true,
+				Value:  "new title",
+			},
+		},
+
+		SelectorArg: "https://github.com/cli/cli/pull/123",
+	})
+
+	// Verify that our request did not contain project fields
+	reg.Verify(t)
 }


### PR DESCRIPTION
`gh pr edit` unconditionally fetches `projectCards` and `projectItems` fields from the GraphQL API, even when the user is only editing non-project fields like `--body` or `--title`. This causes the command to fail with permission errors when the token lacks project scope:

```
GraphQL: Resource not accessible by integration (repository.pullRequest.projectItems.nodes.0),
         Resource not accessible by integration (repository.pullRequest.projectItems.nodes.1)
```

This affects GitHub Apps, `GITHUB_TOKEN` in Actions, and fine-grained PATs that don't have the `project` permission.

## Changes

Restructure `editRun` to:

1. **Prompt before fetching** — In interactive mode, ask the user which fields to edit *before* fetching the PR. This matches the pattern already used by `gh issue edit` and avoids querying project data when the user doesn't intend to edit projects.

2. **Conditionally include project fields** — Only add `projectCards` and `projectItems` to the finder fields when `editable.Projects.Edited` is true (i.e., when `--add-project`/`--remove-project` flags are used, or the user selects "Projects" in the interactive prompt).

3. **Guard project defaults** — Only populate `editable.Projects.Default` and `editable.Projects.ProjectItems` when project data was actually fetched.

## Testing

- Updated `TestProjectsV1Deprecation` to set `Projects.Edited` so project fields are still tested when relevant
- Added `TestEditSkipsProjectFieldsWhenNotEditingProjects` to verify project fields are excluded from the query when not editing projects
- All 21 existing tests continue to pass

Closes #6274
Related: #8784, #13280