### PR TITLE
Add trust disclaimer to extension help text

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -50,6 +50,10 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 			When an extension is executed, gh will check for new versions once every 24 hours and display
 			an upgrade notice. See %[1]sgh help environment%[1]s for information on disabling extension notices.
 
+			Extensions are not verified, signed, or endorsed by GitHub. When you install or upgrade
+  			an extension, you are trusting its publisher. It is your responsibility to review the
+  			source and provenance of any extension before use.
+
 			For the list of available extensions, see <https://github.com/topics/gh-extension>.
 		`, "`"),
 		Aliases: []string{"extensions", "ext"},


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->


Extensions are community-maintained and not verified, signed, or endorsed by GitHub. This adds a brief note to gh ext help output so users understand they are responsible for reviewing the source and provenance of any extension before installing or upgrading.

This aligns with how other package ecosystems (npm, Homebrew, VS Code) communicate the trust model for third-party plugins.