### PR TITLE
Add missing //go:build integration tag to verify_integration_test.go

### DIFF
--- a/pkg/cmd/attestation/verify/verify_integration_test.go
+++ b/pkg/cmd/attestation/verify/verify_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package verify
 
 import (


### PR DESCRIPTION
## Summary

- Add the `//go:build integration` build tag to `pkg/cmd/attestation/verify/verify_integration_test.go`, which was the only integration test file in the attestation package missing this tag.

## Problem

The four tests in `verify_integration_test.go` (`TestVerifyIntegration`, `TestVerifyIntegrationCustomIssuer`, `TestVerifyIntegrationReusableWorkflow`, `TestVerifyIntegrationReusableWorkflowSignerWorkflow`) call `verification.NewLiveSigstoreVerifier()` which requires network access to Sigstore and GitHub TUF servers to initialize trusted roots.

Unlike the other integration test files in the same package (`attestation_integration_test.go`, `sigstore_integration_test.go`, `inspect_integration_test.go`), this file was missing the `//go:build integration` tag. This caused these tests to run during a regular `go test ./...` and fail with `no valid Sigstore verifiers could be initialized` in network-isolated build environments (e.g. openSUSE package builds).

## Fix

Add `//go:build integration` as the first line, matching the convention used by all other integration test files. These tests will continue to run in CI where `-tags=integration` is passed explicitly (see `.github/workflows/go.yml`).