### PR TITLE
Fix flaky accessible prompter Password test timeout

### DIFF
--- a/internal/prompter/accessible_prompter_test.go
+++ b/internal/prompter/accessible_prompter_test.go
@@ -34,7 +34,7 @@ import (
 // but doesn't mandate that prompts always look exactly the same.
 func TestAccessiblePrompter(t *testing.T) {
 
-	beforePasswordSendTimeout := 100 * time.Microsecond
+	beforePasswordSendTimeout := 100 * time.Millisecond
 
 	t.Run("Select", func(t *testing.T) {
 		console := newTestVirtualTerminal(t)


### PR DESCRIPTION
## Summary

- Increase `beforePasswordSendTimeout` from `100 * time.Microsecond` (0.1ms) to `100 * time.Millisecond` (100ms) in `TestAccessiblePrompter`
- The previous 100 microsecond delay was insufficient for `huh` to disable echo mode on the PTY before input was sent, causing the password to be echoed to the terminal and the subsequent regex assertion to fail
- This race condition manifests in slow or constrained environments such as network-isolated build containers (e.g. openSUSE OBS)

## Details

The `TestAccessiblePrompter/Password` subtest sends a password to the terminal after a brief delay (`beforePasswordSendTimeout`) that gives `huh` time to set `EchoModeNone` on the PTY. With only 100 microseconds, the echo mode is not yet disabled when input arrives, so the password appears in the terminal output and the assertion that verifies the password is hidden fails:

```
expect.go:76: Failed to find ["^(\\x1b\\[\\d;]*m)* \\r\\n\\r\\n$"] in "\x1b[m 12345abcdefg\r\n\r\n\r\n": read |0: i/o timeout
```

Increasing to 100 milliseconds adds negligible overhead (at most 300ms total across the 3 uses of this timeout) while providing sufficient headroom for the PTY echo mode to be configured.