### PR TITLE
Enable extended PR screening for external PRs

### DIFF
--- a/.github/workflows/triage-pull-requests.yml
+++ b/.github/workflows/triage-pull-requests.yml
@@ -31,6 +31,10 @@ jobs:
       github.event_name == 'pull_request_target' &&
       (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'edited')
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
+    with:
+      enable_pr_screening: true
+      days_until_close: 4
+      large_pr_days_until_close: 2
     permissions:
       issues: read
       pull-requests: write
@@ -38,6 +42,10 @@ jobs:
   close-unmet-requirements:
     if: github.event_name == 'schedule'
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
+    with:
+      enable_pr_screening: true
+      days_until_close: 4
+      large_pr_days_until_close: 2
     permissions:
       issues: read
       pull-requests: write


### PR DESCRIPTION
Opts in to the new PR screening features in the shared triage workflow:
- Instantly closes PRs with zero file changes
- Detects same-author resubmissions of recently closed PRs
- **Fast-tracks small, well-described fixes to ready-for-review**
     - **This one I am leery of having many false positives so would like to hear feedback from the team if we want to turn it off if we are finding it to be too lenient after trying it out. I think could be the best candidate for and iteration of adding agentic analysis**
- Accelerates closure of large unsolicited PRs (2 days vs 7)
- Updates regular unmet requirements time to close to 4 days/

Depends on desktop/gh-cli-and-desktop-shared-workflows#17
