### PR TITLE
Fix concurrent map writes in codespace port forwarding

### DIFF
--- a/internal/codespaces/connection/connection.go
+++ b/internal/codespaces/connection/connection.go
@@ -33,9 +33,7 @@ type CodespaceConnection struct {
 
 	// ManagerMu serializes access to TunnelManager operations which mutate
 	// shared state on the Tunnel object and are not goroutine-safe.
-	// This is a pointer so that shallow copies of CodespaceConnection
-	// (e.g. in NewPortForwarder) share the same mutex.
-	ManagerMu *sync.Mutex
+	ManagerMu sync.Mutex
 }
 
 // NewCodespaceConnection initializes a connection to a codespace.
@@ -84,7 +82,6 @@ func NewCodespaceConnection(ctx context.Context, codespace *api.Codespace, httpC
 		Options:                    options,
 		Tunnel:                     tunnel,
 		AllowedPortPrivacySettings: allowedPortPrivacySettings,
-		ManagerMu:                  &sync.Mutex{},
 	}, nil
 }
 

--- a/internal/codespaces/connection/connection.go
+++ b/internal/codespaces/connection/connection.go
@@ -30,6 +30,12 @@ type CodespaceConnection struct {
 	Options                    *tunnels.TunnelRequestOptions
 	Tunnel                     *tunnels.Tunnel
 	AllowedPortPrivacySettings []string
+
+	// ManagerMu serializes access to TunnelManager operations which mutate
+	// shared state on the Tunnel object and are not goroutine-safe.
+	// This is a pointer so that shallow copies of CodespaceConnection
+	// (e.g. in NewPortForwarder) share the same mutex.
+	ManagerMu *sync.Mutex
 }
 
 // NewCodespaceConnection initializes a connection to a codespace.
@@ -78,6 +84,7 @@ func NewCodespaceConnection(ctx context.Context, codespace *api.Codespace, httpC
 		Options:                    options,
 		Tunnel:                     tunnel,
 		AllowedPortPrivacySettings: allowedPortPrivacySettings,
+		ManagerMu:                  &sync.Mutex{},
 	}, nil
 }
 

--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -36,7 +36,7 @@ type ForwardPortOpts struct {
 }
 
 type CodespacesPortForwarder struct {
-	connection      connection.CodespaceConnection
+	connection      *connection.CodespaceConnection
 	keepAliveReason chan string
 }
 
@@ -54,7 +54,7 @@ type PortForwarder interface {
 // NewPortForwarder returns a new PortForwarder for the specified codespace.
 func NewPortForwarder(ctx context.Context, codespaceConnection *connection.CodespaceConnection) (fwd PortForwarder, err error) {
 	return &CodespacesPortForwarder{
-		connection:      *codespaceConnection,
+		connection:      codespaceConnection,
 		keepAliveReason: make(chan string, 1),
 	}, nil
 }
@@ -108,9 +108,31 @@ func (fwd *CodespacesPortForwarder) ForwardPort(ctx context.Context, opts Forwar
 		return fmt.Errorf("error converting port: %w", err)
 	}
 
-	// Serialize TunnelManager operations which mutate shared state on the
-	// Tunnel object and are not goroutine-safe.
+	if err := fwd.createTunnelPort(ctx, port, opts); err != nil {
+		return err
+	}
+
+	// Connect to the tunnel
+	err = fwd.connection.Connect(ctx)
+	if err != nil {
+		return fmt.Errorf("connect failed: %v", err)
+	}
+
+	// Inform the host that we've forwarded the port locally
+	err = fwd.connection.TunnelClient.RefreshPorts(ctx)
+	if err != nil {
+		return fmt.Errorf("refresh ports failed: %v", err)
+	}
+
+	return nil
+}
+
+// createTunnelPort creates a tunnel port while holding the manager mutex.
+// TunnelManager operations mutate shared state on the Tunnel object and are
+// not goroutine-safe, so all calls are serialized under ManagerMu.
+func (fwd *CodespacesPortForwarder) createTunnelPort(ctx context.Context, port uint16, opts ForwardPortOpts) error {
 	fwd.connection.ManagerMu.Lock()
+	defer fwd.connection.ManagerMu.Unlock()
 
 	// In v0.0.25 of dev-tunnels, the dev-tunnel manager `CreateTunnelPort` would "accept" requests that
 	// change the port protocol but they would not result in any actual change. This has changed, resulting in
@@ -124,7 +146,6 @@ func (fwd *CodespacesPortForwarder) ForwardPort(ctx context.Context, opts Forwar
 
 	existingPort, err := fwd.connection.TunnelManager.GetTunnelPort(ctx, fwd.connection.Tunnel, opts.Port, fwd.connection.Options)
 	if err != nil && !strings.Contains(err.Error(), "404") {
-		fwd.connection.ManagerMu.Unlock()
 		return fmt.Errorf("error checking whether tunnel port already exists: %v", err)
 	}
 
@@ -147,7 +168,6 @@ func (fwd *CodespacesPortForwarder) ForwardPort(ctx context.Context, opts Forwar
 
 		// If the requested visibility is not allowed, return an error
 		if !allowed {
-			fwd.connection.ManagerMu.Unlock()
 			return fmt.Errorf("visibility %s is not allowed", opts.Visibility)
 		}
 
@@ -168,21 +188,8 @@ func (fwd *CodespacesPortForwarder) ForwardPort(ctx context.Context, opts Forwar
 
 	// Create the tunnel port
 	_, err = fwd.connection.TunnelManager.CreateTunnelPort(ctx, fwd.connection.Tunnel, tunnelPort, fwd.connection.Options)
-	fwd.connection.ManagerMu.Unlock()
 	if err != nil && !strings.Contains(err.Error(), "409") {
 		return fmt.Errorf("create tunnel port failed: %v", err)
-	}
-
-	// Connect to the tunnel
-	err = fwd.connection.Connect(ctx)
-	if err != nil {
-		return fmt.Errorf("connect failed: %v", err)
-	}
-
-	// Inform the host that we've forwarded the port locally
-	err = fwd.connection.TunnelClient.RefreshPorts(ctx)
-	if err != nil {
-		return fmt.Errorf("refresh ports failed: %v", err)
 	}
 
 	return nil
@@ -251,8 +258,9 @@ func (fwd *CodespacesPortForwarder) ConnectToForwardedPort(ctx context.Context, 
 // ListPorts fetches the list of ports that are currently forwarded.
 func (fwd *CodespacesPortForwarder) ListPorts(ctx context.Context) (ports []*tunnels.TunnelPort, err error) {
 	fwd.connection.ManagerMu.Lock()
+	defer fwd.connection.ManagerMu.Unlock()
+
 	ports, err = fwd.connection.TunnelManager.ListTunnelPorts(ctx, fwd.connection.Tunnel, fwd.connection.Options)
-	fwd.connection.ManagerMu.Unlock()
 	if err != nil {
 		return nil, fmt.Errorf("error listing ports: %w", err)
 	}

--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -108,6 +108,10 @@ func (fwd *CodespacesPortForwarder) ForwardPort(ctx context.Context, opts Forwar
 		return fmt.Errorf("error converting port: %w", err)
 	}
 
+	// Serialize TunnelManager operations which mutate shared state on the
+	// Tunnel object and are not goroutine-safe.
+	fwd.connection.ManagerMu.Lock()
+
 	// In v0.0.25 of dev-tunnels, the dev-tunnel manager `CreateTunnelPort` would "accept" requests that
 	// change the port protocol but they would not result in any actual change. This has changed, resulting in
 	// an error `Invalid arguments. The tunnel port protocol cannot be changed.`. It's not clear why the previous
@@ -120,6 +124,7 @@ func (fwd *CodespacesPortForwarder) ForwardPort(ctx context.Context, opts Forwar
 
 	existingPort, err := fwd.connection.TunnelManager.GetTunnelPort(ctx, fwd.connection.Tunnel, opts.Port, fwd.connection.Options)
 	if err != nil && !strings.Contains(err.Error(), "404") {
+		fwd.connection.ManagerMu.Unlock()
 		return fmt.Errorf("error checking whether tunnel port already exists: %v", err)
 	}
 
@@ -142,6 +147,7 @@ func (fwd *CodespacesPortForwarder) ForwardPort(ctx context.Context, opts Forwar
 
 		// If the requested visibility is not allowed, return an error
 		if !allowed {
+			fwd.connection.ManagerMu.Unlock()
 			return fmt.Errorf("visibility %s is not allowed", opts.Visibility)
 		}
 
@@ -162,6 +168,7 @@ func (fwd *CodespacesPortForwarder) ForwardPort(ctx context.Context, opts Forwar
 
 	// Create the tunnel port
 	_, err = fwd.connection.TunnelManager.CreateTunnelPort(ctx, fwd.connection.Tunnel, tunnelPort, fwd.connection.Options)
+	fwd.connection.ManagerMu.Unlock()
 	if err != nil && !strings.Contains(err.Error(), "409") {
 		return fmt.Errorf("create tunnel port failed: %v", err)
 	}
@@ -243,7 +250,9 @@ func (fwd *CodespacesPortForwarder) ConnectToForwardedPort(ctx context.Context, 
 
 // ListPorts fetches the list of ports that are currently forwarded.
 func (fwd *CodespacesPortForwarder) ListPorts(ctx context.Context) (ports []*tunnels.TunnelPort, err error) {
+	fwd.connection.ManagerMu.Lock()
 	ports, err = fwd.connection.TunnelManager.ListTunnelPorts(ctx, fwd.connection.Tunnel, fwd.connection.Options)
+	fwd.connection.ManagerMu.Unlock()
 	if err != nil {
 		return nil, fmt.Errorf("error listing ports: %w", err)
 	}
@@ -253,7 +262,9 @@ func (fwd *CodespacesPortForwarder) ListPorts(ctx context.Context) (ports []*tun
 
 // UpdatePortVisibility changes the visibility (private, org, public) of the specified port.
 func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, remotePort int, visibility string) error {
+	fwd.connection.ManagerMu.Lock()
 	tunnelPort, err := fwd.connection.TunnelManager.GetTunnelPort(ctx, fwd.connection.Tunnel, remotePort, fwd.connection.Options)
+	fwd.connection.ManagerMu.Unlock()
 	if err != nil {
 		return fmt.Errorf("error getting tunnel port: %w", err)
 	}
@@ -268,7 +279,9 @@ func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, re
 	if err != nil {
 		return fmt.Errorf("error converting port: %w", err)
 	}
+	fwd.connection.ManagerMu.Lock()
 	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, port, fwd.connection.Options)
+	fwd.connection.ManagerMu.Unlock()
 	if err != nil {
 		return fmt.Errorf("error deleting tunnel port: %w", err)
 	}

--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -270,30 +270,28 @@ func (fwd *CodespacesPortForwarder) ListPorts(ctx context.Context) (ports []*tun
 
 // UpdatePortVisibility changes the visibility (private, org, public) of the specified port.
 func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, remotePort int, visibility string) error {
-	tunnelPort, err := func() (*tunnels.TunnelPort, error) {
-		fwd.connection.ManagerMu.Lock()
-		defer fwd.connection.ManagerMu.Unlock()
-		return fwd.connection.TunnelManager.GetTunnelPort(ctx, fwd.connection.Tunnel, remotePort, fwd.connection.Options)
-	}()
+	fwd.connection.ManagerMu.Lock()
+	tunnelPort, err := fwd.connection.TunnelManager.GetTunnelPort(ctx, fwd.connection.Tunnel, remotePort, fwd.connection.Options)
 	if err != nil {
+		fwd.connection.ManagerMu.Unlock()
 		return fmt.Errorf("error getting tunnel port: %w", err)
 	}
 
 	// If the port visibility isn't changing, don't do anything
 	if AccessControlEntriesToVisibility(tunnelPort.AccessControl.Entries) == visibility {
+		fwd.connection.ManagerMu.Unlock()
 		return nil
 	}
 
 	// Delete the existing tunnel port to update
 	port, err := convertIntToUint16(remotePort)
 	if err != nil {
+		fwd.connection.ManagerMu.Unlock()
 		return fmt.Errorf("error converting port: %w", err)
 	}
-	if err := func() error {
-		fwd.connection.ManagerMu.Lock()
-		defer fwd.connection.ManagerMu.Unlock()
-		return fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, port, fwd.connection.Options)
-	}(); err != nil {
+	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, port, fwd.connection.Options)
+	fwd.connection.ManagerMu.Unlock()
+	if err != nil {
 		return fmt.Errorf("error deleting tunnel port: %w", err)
 	}
 

--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -270,9 +270,11 @@ func (fwd *CodespacesPortForwarder) ListPorts(ctx context.Context) (ports []*tun
 
 // UpdatePortVisibility changes the visibility (private, org, public) of the specified port.
 func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, remotePort int, visibility string) error {
-	fwd.connection.ManagerMu.Lock()
-	tunnelPort, err := fwd.connection.TunnelManager.GetTunnelPort(ctx, fwd.connection.Tunnel, remotePort, fwd.connection.Options)
-	fwd.connection.ManagerMu.Unlock()
+	tunnelPort, err := func() (*tunnels.TunnelPort, error) {
+		fwd.connection.ManagerMu.Lock()
+		defer fwd.connection.ManagerMu.Unlock()
+		return fwd.connection.TunnelManager.GetTunnelPort(ctx, fwd.connection.Tunnel, remotePort, fwd.connection.Options)
+	}()
 	if err != nil {
 		return fmt.Errorf("error getting tunnel port: %w", err)
 	}
@@ -287,10 +289,11 @@ func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, re
 	if err != nil {
 		return fmt.Errorf("error converting port: %w", err)
 	}
-	fwd.connection.ManagerMu.Lock()
-	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, port, fwd.connection.Options)
-	fwd.connection.ManagerMu.Unlock()
-	if err != nil {
+	if err := func() error {
+		fwd.connection.ManagerMu.Lock()
+		defer fwd.connection.ManagerMu.Unlock()
+		return fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, port, fwd.connection.Options)
+	}(); err != nil {
 		return fmt.Errorf("error deleting tunnel port: %w", err)
 	}
 

--- a/internal/codespaces/portforwarder/port_forwarder_test.go
+++ b/internal/codespaces/portforwarder/port_forwarder_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/internal/codespaces/connection"
 	"github.com/microsoft/dev-tunnels/go/tunnels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -32,26 +34,16 @@ func TestNewPortForwarder(t *testing.T) {
 
 	// Create the mock HTTP client
 	httpClient, err := connection.NewMockHttpClient()
-	if err != nil {
-		t.Fatalf("NewHttpClient returned an error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Call the function being tested
 	conn, err := connection.NewCodespaceConnection(ctx, codespace, httpClient)
-	if err != nil {
-		t.Fatalf("NewCodespaceConnection returned an error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Create the new port forwarder
 	portForwarder, err := NewPortForwarder(ctx, conn)
-	if err != nil {
-		t.Fatalf("NewPortForwarder returned an error: %v", err)
-	}
-
-	// Check that the port forwarder was created successfully
-	if portForwarder == nil {
-		t.Fatal("NewPortForwarder returned nil")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, portForwarder)
 }
 
 func TestAccessControlEntriesToVisibility(t *testing.T) {
@@ -97,9 +89,7 @@ func TestAccessControlEntriesToVisibility(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			visibility := AccessControlEntriesToVisibility(test.accessControlEntries)
-			if visibility != test.expected {
-				t.Errorf("expected %q, got %q", test.expected, visibility)
-			}
+			assert.Equal(t, test.expected, visibility)
 		})
 	}
 }
@@ -132,9 +122,7 @@ func TestIsInternalPort(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			isInternal := IsInternalPort(test.port)
-			if isInternal != test.expected {
-				t.Errorf("expected %v, got %v", test.expected, isInternal)
-			}
+			assert.Equal(t, test.expected, isInternal)
 		})
 	}
 }
@@ -164,39 +152,24 @@ func TestForwardPortDefaultsToHTTPProtocol(t *testing.T) {
 	httpClient, err := connection.NewMockHttpClient(
 		connection.WithSpecificPorts(tunnelPorts),
 	)
-	if err != nil {
-		t.Fatalf("NewMockHttpClient returned an error: %v", err)
-	}
+	require.NoError(t, err)
 
 	connection, err := connection.NewCodespaceConnection(t.Context(), codespace, httpClient)
-	if err != nil {
-		t.Fatalf("NewCodespaceConnection returned an error: %v", err)
-	}
+	require.NoError(t, err)
 
 	fwd, err := NewPortForwarder(t.Context(), connection)
-	if err != nil {
-		t.Fatalf("NewPortForwarder returned an error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// When we forward a port without an existing one to use for a protocol, it should default to HTTP.
-	if err := fwd.ForwardPort(t.Context(), ForwardPortOpts{
+	err = fwd.ForwardPort(t.Context(), ForwardPortOpts{
 		Port: 1337,
-	}); err != nil {
-		t.Fatalf("ForwardPort returned an error: %v", err)
-	}
+	})
+	require.NoError(t, err)
 
 	ports, err := fwd.ListPorts(t.Context())
-	if err != nil {
-		t.Fatalf("ListPorts returned an error: %v", err)
-	}
-
-	if len(ports) != 1 {
-		t.Fatalf("expected 1 port, got %d", len(ports))
-	}
-
-	if ports[0].Protocol != string(tunnels.TunnelProtocolHttp) {
-		t.Fatalf("expected port protocol to be http, got %s", ports[0].Protocol)
-	}
+	require.NoError(t, err)
+	require.Len(t, ports, 1)
+	assert.Equal(t, string(tunnels.TunnelProtocolHttp), ports[0].Protocol)
 }
 
 func TestConcurrentForwardPortDoesNotRace(t *testing.T) {
@@ -223,23 +196,17 @@ func TestConcurrentForwardPortDoesNotRace(t *testing.T) {
 	httpClient, err := connection.NewMockHttpClient(
 		connection.WithSpecificPorts(tunnelPorts),
 	)
-	if err != nil {
-		t.Fatalf("NewMockHttpClient returned an error: %v", err)
-	}
+	require.NoError(t, err)
 
 	conn, err := connection.NewCodespaceConnection(t.Context(), codespace, httpClient)
-	if err != nil {
-		t.Fatalf("NewCodespaceConnection returned an error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Forward multiple ports concurrently from the same connection,
 	// mirroring what ForwardPorts does in ports.go.
 	group, ctx := errgroup.WithContext(t.Context())
 	for port := 3000; port < 3010; port++ {
 		fwd, err := NewPortForwarder(ctx, conn)
-		if err != nil {
-			t.Fatalf("NewPortForwarder returned an error: %v", err)
-		}
+		require.NoError(t, err)
 
 		group.Go(func() error {
 			return fwd.ForwardPort(ctx, ForwardPortOpts{
@@ -248,9 +215,7 @@ func TestConcurrentForwardPortDoesNotRace(t *testing.T) {
 		})
 	}
 
-	if err := group.Wait(); err != nil {
-		t.Fatalf("ForwardPort returned an error: %v", err)
-	}
+	require.NoError(t, group.Wait())
 }
 
 func TestForwardPortRespectsProtocolOfExistingTunneledPorts(t *testing.T) {
@@ -285,38 +250,23 @@ func TestForwardPortRespectsProtocolOfExistingTunneledPorts(t *testing.T) {
 	httpClient, err := connection.NewMockHttpClient(
 		connection.WithSpecificPorts(tunnelPorts),
 	)
-	if err != nil {
-		t.Fatalf("NewMockHttpClient returned an error: %v", err)
-	}
+	require.NoError(t, err)
 
 	connection, err := connection.NewCodespaceConnection(t.Context(), codespace, httpClient)
-	if err != nil {
-		t.Fatalf("NewCodespaceConnection returned an error: %v", err)
-	}
+	require.NoError(t, err)
 
 	fwd, err := NewPortForwarder(t.Context(), connection)
-	if err != nil {
-		t.Fatalf("NewPortForwarder returned an error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// When we forward a port, it would typically default to HTTP, to which the mock server would respond with a 400,
 	// but it should respect the existing port's protocol and forward it as HTTPS.
-	if err := fwd.ForwardPort(t.Context(), ForwardPortOpts{
+	err = fwd.ForwardPort(t.Context(), ForwardPortOpts{
 		Port: 1337,
-	}); err != nil {
-		t.Fatalf("ForwardPort returned an error: %v", err)
-	}
+	})
+	require.NoError(t, err)
 
 	ports, err := fwd.ListPorts(t.Context())
-	if err != nil {
-		t.Fatalf("ListPorts returned an error: %v", err)
-	}
-
-	if len(ports) != 1 {
-		t.Fatalf("expected 1 port, got %d", len(ports))
-	}
-
-	if ports[0].Protocol != string(tunnels.TunnelProtocolHttps) {
-		t.Fatalf("expected port protocol to be https, got %s", ports[0].Protocol)
-	}
+	require.NoError(t, err)
+	require.Len(t, ports, 1)
+	assert.Equal(t, string(tunnels.TunnelProtocolHttps), ports[0].Protocol)
 }

--- a/internal/codespaces/portforwarder/port_forwarder_test.go
+++ b/internal/codespaces/portforwarder/port_forwarder_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cli/cli/v2/internal/codespaces/api"
 	"github.com/cli/cli/v2/internal/codespaces/connection"
 	"github.com/microsoft/dev-tunnels/go/tunnels"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestNewPortForwarder(t *testing.T) {
@@ -195,6 +196,60 @@ func TestForwardPortDefaultsToHTTPProtocol(t *testing.T) {
 
 	if ports[0].Protocol != string(tunnels.TunnelProtocolHttp) {
 		t.Fatalf("expected port protocol to be http, got %s", ports[0].Protocol)
+	}
+}
+
+func TestConcurrentForwardPortDoesNotRace(t *testing.T) {
+	codespace := &api.Codespace{
+		Name:  "codespace-name",
+		State: api.CodespaceStateAvailable,
+		Connection: api.CodespaceConnection{
+			TunnelProperties: api.TunnelProperties{
+				ConnectAccessToken:     "tunnel access-token",
+				ManagePortsAccessToken: "manage-ports-token",
+				ServiceUri:             "http://global.rel.tunnels.api.visualstudio.com/",
+				TunnelId:               "tunnel-id",
+				ClusterId:              "usw2",
+				Domain:                 "domain.com",
+			},
+		},
+		RuntimeConstraints: api.RuntimeConstraints{
+			AllowedPortPrivacySettings: []string{"public", "private"},
+		},
+	}
+
+	tunnelPorts := map[int]tunnels.TunnelPort{}
+
+	httpClient, err := connection.NewMockHttpClient(
+		connection.WithSpecificPorts(tunnelPorts),
+	)
+	if err != nil {
+		t.Fatalf("NewMockHttpClient returned an error: %v", err)
+	}
+
+	conn, err := connection.NewCodespaceConnection(t.Context(), codespace, httpClient)
+	if err != nil {
+		t.Fatalf("NewCodespaceConnection returned an error: %v", err)
+	}
+
+	// Forward multiple ports concurrently from the same connection,
+	// mirroring what ForwardPorts does in ports.go.
+	group, ctx := errgroup.WithContext(t.Context())
+	for port := 3000; port < 3010; port++ {
+		fwd, err := NewPortForwarder(ctx, conn)
+		if err != nil {
+			t.Fatalf("NewPortForwarder returned an error: %v", err)
+		}
+
+		group.Go(func() error {
+			return fwd.ForwardPort(ctx, ForwardPortOpts{
+				Port: port,
+			})
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		t.Fatalf("ForwardPort returned an error: %v", err)
 	}
 }
 

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"os/signal"
+
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -135,12 +135,7 @@ func Main() exitCode {
 		}
 	}
 
-	// Intercept SIGINT/SIGTERM so that defers (e.g. telemetry flush) run
-	// before the process exits. Without this, the Go runtime's default
-	// signal handler calls os.Exit immediately, skipping all defers.
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
-	defer stop()
-
+	ctx := context.Background()
 	updateCtx, updateCancel := context.WithCancel(ctx)
 	defer updateCancel()
 	updateMessageChan := make(chan *update.ReleaseInfo)

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -134,7 +135,12 @@ func Main() exitCode {
 		}
 	}
 
-	ctx := context.Background()
+	// Intercept SIGINT/SIGTERM so that defers (e.g. telemetry flush) run
+	// before the process exits. Without this, the Go runtime's default
+	// signal handler calls os.Exit immediately, skipping all defers.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
 	updateCtx, updateCancel := context.WithCancel(ctx)
 	defer updateCancel()
 	updateMessageChan := make(chan *update.ReleaseInfo)

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-
 	"path/filepath"
 	"slices"
 	"strconv"


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/13399

When forwarding multiple ports concurrently with `gh cs ports forward`, the dev-tunnels `TunnelManager` mutates shared state on the `Tunnel` object in `buildUri()`, which is not goroutine-safe. This causes a `fatal error: concurrent map writes` panic.

## Root cause

`ForwardPorts` runs all port forwards concurrently via `errgroup`, sharing a single `CodespaceConnection`. The shallow copy in `NewPortForwarder` (`*codespaceConnection` dereference) means all forwarders share the same `TunnelManager` and `Tunnel` pointers, so concurrent calls to `GetTunnelPort` / `CreateTunnelPort` race on the shared map.

## Fix

- **Store connection as a pointer** - changed `CodespacesPortForwarder.connection` from `connection.CodespaceConnection` (value) to `*connection.CodespaceConnection` (pointer), eliminating the unnecessary shallow copy. Since all the important fields (`TunnelManager`, `TunnelClient`, `Tunnel`, `Options`) were already pointers, the copy was pointless and created this class of bug.
- **Added `sync.Mutex`** (`ManagerMu`) to `CodespaceConnection` to serialize `TunnelManager` operations that mutate shared state on the `Tunnel` object. Because the connection is now shared by pointer, a plain `sync.Mutex` (not a pointer) works naturally.
- **Extracted `createTunnelPort` helper** from `ForwardPort` so the mutex-guarded critical section uses `defer` to unlock, replacing fragile manual `Unlock()` calls on each error path.
- `Connect` and `RefreshPorts` already have their own synchronization and are left outside the lock.

## Test

Added `TestConcurrentForwardPortDoesNotRace` which forwards 10 ports concurrently from a shared connection, reproducing the race detected by `go test -race`.

## Performance

The mutex serializes `TunnelManager` API calls that were previously concurrent. Benchmarking with a real codespace (5 ports, 5 runs each) shows no measurable impact:

| | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | **Avg** |
|---|---|---|---|---|---|---|
| **Stock CLI (v2.92.0)** | 1.03s | 0.89s | 0.90s | 0.91s | 1.18s | **0.98s** |
| **Fixed CLI** | 1.04s | 1.04s | 0.89s | 0.98s | 1.08s | **1.01s** |

The serialization overhead is negligible because the bottleneck is network round-trips to the dev-tunnels API and SSH tunnel setup, not CPU time in the critical section.