### PR TITLE
Fix 'unknown owner type' error in project commands

### DIFF
--- a/pkg/cmd/project/shared/queries/owner_test.go
+++ b/pkg/cmd/project/shared/queries/owner_test.go
@@ -1,0 +1,239 @@
+package queries
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOwnerIDAndType(t *testing.T) {
+	tests := []struct {
+		name         string
+		login        string
+		httpResponse string
+		httpStatus   int
+		wantID       string
+		wantType     OwnerType
+		wantErrMsg   string
+	}{
+		{
+			name:  "user found, org NOT_FOUND",
+			login: "monalisa",
+			httpResponse: `{
+				"data": {
+					"user": {"login": "monalisa", "id": "USER_1"},
+					"organization": {"login": "", "id": ""}
+				},
+				"errors": [
+					{"type": "NOT_FOUND", "path": ["organization"], "message": "Could not resolve to an Organization"}
+				]
+			}`,
+			httpStatus: 200,
+			wantID:     "USER_1",
+			wantType:   UserOwner,
+		},
+		{
+			name:  "org found, user NOT_FOUND",
+			login: "github",
+			httpResponse: `{
+				"data": {
+					"user": {"login": "", "id": ""},
+					"organization": {"login": "github", "id": "ORG_1"}
+				},
+				"errors": [
+					{"type": "NOT_FOUND", "path": ["user"], "message": "Could not resolve to a User"}
+				]
+			}`,
+			httpStatus: 200,
+			wantID:     "ORG_1",
+			wantType:   OrgOwner,
+		},
+		{
+			name:  "both NOT_FOUND",
+			login: "nonexistent",
+			httpResponse: `{
+				"data": {
+					"user": {"login": "", "id": ""},
+					"organization": {"login": "", "id": ""}
+				},
+				"errors": [
+					{"type": "NOT_FOUND", "path": ["user"], "message": "Could not resolve to a User"},
+					{"type": "NOT_FOUND", "path": ["organization"], "message": "Could not resolve to an Organization"}
+				]
+			}`,
+			httpStatus: 200,
+			wantErrMsg: "Could not resolve to a User",
+		},
+		{
+			name:  "non-NOT_FOUND GraphQL error returns original error",
+			login: "restricted-org",
+			httpResponse: `{
+				"data": {
+					"user": {"login": "", "id": ""},
+					"organization": {"login": "", "id": ""}
+				},
+				"errors": [
+					{"type": "FORBIDDEN", "path": ["organization"], "message": "Resource not accessible"}
+				]
+			}`,
+			httpStatus: 200,
+			wantErrMsg: "Resource not accessible",
+		},
+		{
+			name:  "NOT_FOUND for org alongside FORBIDDEN for user returns original error",
+			login: "mixed-errors",
+			httpResponse: `{
+				"data": {
+					"user": {"login": "", "id": ""},
+					"organization": {"login": "", "id": ""}
+				},
+				"errors": [
+					{"type": "FORBIDDEN", "path": ["user"], "message": "Resource not accessible"},
+					{"type": "NOT_FOUND", "path": ["organization"], "message": "Could not resolve to an Organization"}
+				]
+			}`,
+			httpStatus: 200,
+			wantErrMsg: "Resource not accessible",
+		},
+		{
+			name:  "NOT_FOUND for user alongside FORBIDDEN for org returns original error",
+			login: "mixed-errors-2",
+			httpResponse: `{
+				"data": {
+					"user": {"login": "", "id": ""},
+					"organization": {"login": "", "id": ""}
+				},
+				"errors": [
+					{"type": "NOT_FOUND", "path": ["user"], "message": "Could not resolve to a User"},
+					{"type": "FORBIDDEN", "path": ["organization"], "message": "Resource not accessible"}
+				]
+			}`,
+			httpStatus: 200,
+			wantErrMsg: "Resource not accessible",
+		},
+		{
+			name:  "no error, user result populated",
+			login: "monalisa",
+			httpResponse: `{
+				"data": {
+					"user": {"login": "monalisa", "id": "USER_1"},
+					"organization": {"login": "", "id": ""}
+				}
+			}`,
+			httpStatus: 200,
+			wantID:     "USER_1",
+			wantType:   UserOwner,
+		},
+		{
+			name:  "no error, org result populated",
+			login: "github",
+			httpResponse: `{
+				"data": {
+					"user": {"login": "", "id": ""},
+					"organization": {"login": "github", "id": "ORG_1"}
+				}
+			}`,
+			httpStatus: 200,
+			wantID:     "ORG_1",
+			wantType:   OrgOwner,
+		},
+		{
+			name:  "viewer login with @me",
+			login: "@me",
+			httpResponse: `{
+				"data": {
+					"viewer": {"login": "monalisa", "id": "VIEWER_1"}
+				}
+			}`,
+			httpStatus: 200,
+			wantID:     "VIEWER_1",
+			wantType:   ViewerOwner,
+		},
+		{
+			name:  "viewer login with empty string",
+			login: "",
+			httpResponse: `{
+				"data": {
+					"viewer": {"login": "monalisa", "id": "VIEWER_1"}
+				}
+			}`,
+			httpStatus: 200,
+			wantID:     "VIEWER_1",
+			wantType:   ViewerOwner,
+		},
+		{
+			name:  "NOT_FOUND for org but user ID empty returns original error",
+			login: "ghost",
+			httpResponse: `{
+				"data": {
+					"user": {"login": "", "id": ""},
+					"organization": {"login": "", "id": ""}
+				},
+				"errors": [
+					{"type": "NOT_FOUND", "path": ["organization"], "message": "Could not resolve to an Organization"}
+				]
+			}`,
+			httpStatus: 200,
+			wantErrMsg: "Could not resolve to an Organization",
+		},
+		{
+			name:  "NOT_FOUND for user but org ID empty returns original error",
+			login: "ghost",
+			httpResponse: `{
+				"data": {
+					"user": {"login": "", "id": ""},
+					"organization": {"login": "", "id": ""}
+				},
+				"errors": [
+					{"type": "NOT_FOUND", "path": ["user"], "message": "Could not resolve to a User"}
+				]
+			}`,
+			httpStatus: 200,
+			wantErrMsg: "Could not resolve to a User",
+		},
+		{
+			name:       "HTTP error returns error",
+			login:      "monalisa",
+			httpStatus: 502,
+			httpResponse: `{
+				"message": "Bad Gateway"
+			}`,
+			wantErrMsg: "non-200 OK status code",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			httpClient := &http.Client{
+				Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: tt.httpStatus,
+						Header: http.Header{
+							"Content-Type": []string{"application/json"},
+						},
+						Body: io.NopCloser(strings.NewReader(tt.httpResponse)),
+					}, nil
+				}),
+			}
+
+			client := NewClient(httpClient, "github.com", ios)
+			gotID, gotType, err := client.OwnerIDAndType(tt.login)
+
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantID, gotID)
+			assert.Equal(t, tt.wantType, gotType)
+		})
+	}
+}

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -1222,19 +1222,29 @@ func (c *Client) OwnerIDAndType(login string) (string, OwnerType, error) {
 
 	err := c.doQueryWithProgressIndicator("UserOrgOwner", &query, variables)
 	if err != nil {
-		// Due to the way the queries are structured, we don't know if a login belongs to a user
-		// or to an org, even though they are unique. To deal with this, we try both - if neither
-		// is found, we return the error.
+		// The query asks for both user and organization simultaneously. Since logins are
+		// unique on GitHub, we expect one to succeed and the other to return NOT_FOUND.
+		// We use that NOT_FOUND pattern to determine which type the login belongs to.
+		// If we get a different error (e.g., FORBIDDEN), we return it directly.
 		var graphErr api.GraphQLError
 		if errors.As(err, &graphErr) {
 			if graphErr.Match("NOT_FOUND", "user") && graphErr.Match("NOT_FOUND", "organization") {
 				return "", "", err
-			} else if graphErr.Match("NOT_FOUND", "organization") { // org isn't found must be a user
+			} else if graphErr.Match("NOT_FOUND", "organization") && query.User.Id != "" {
 				return query.User.Id, UserOwner, nil
-			} else if graphErr.Match("NOT_FOUND", "user") { // user isn't found must be an org
+			} else if graphErr.Match("NOT_FOUND", "user") && query.Organization.Id != "" {
 				return query.Organization.Id, OrgOwner, nil
 			}
 		}
+		return "", "", err
+	}
+
+	// When the query succeeds without error, determine owner type from the response.
+	if query.User.Id != "" {
+		return query.User.Id, UserOwner, nil
+	}
+	if query.Organization.Id != "" {
+		return query.Organization.Id, OrgOwner, nil
 	}
 
 	return "", "", errors.New("unknown owner type")


### PR DESCRIPTION
## Problem

`gh project item-list` (and other project commands) can fail with the unhelpful error message `unknown owner type` when the underlying GraphQL query returns non-`NOT_FOUND` errors (e.g., `FORBIDDEN`, permission issues in GitHub Actions). The original error is discarded, making it difficult to diagnose what actually went wrong.

Reported by @cheshire137, who found that `gh api graphql` worked fine for the same query, but `gh project item-list` failed.

## Root Cause

`OwnerIDAndType()` in `pkg/cmd/project/shared/queries/queries.go` queries both `user(login:)` and `organization(login:)` simultaneously. It uses GraphQL error matching to determine which type the login belongs to. However:

1. **Non-`NOT_FOUND` errors were swallowed**: If the GraphQL response contained errors other than `NOT_FOUND` (e.g., `FORBIDDEN` from token permissions), the code fell through to a generic `unknown owner type` error, discarding the real error.

2. **Missing success path**: When the query succeeded without errors (`err == nil`), the function fell through to the error return without checking response data.

## Fix

- Return the original error when it doesn't match the expected `NOT_FOUND` pattern
- Guard the `NOT_FOUND` success paths to also verify the expected entity ID is populated
- Handle the `err == nil` success path by checking which entity has a non-empty ID

## Tests

Added comprehensive table-driven tests covering:
- User found (org `NOT_FOUND`) → `UserOwner` ✅
- Org found (user `NOT_FOUND`) → `OrgOwner` ✅  
- Both `NOT_FOUND` → returns error ✅
- Non-`NOT_FOUND` GraphQL error → **returns original error** (was: `unknown owner type`) ✅
- Mixed `NOT_FOUND` + `FORBIDDEN` → **returns original error** ✅
- No error, user populated → `UserOwner` ✅
- No error, org populated → `OrgOwner` ✅
- `NOT_FOUND` but entity ID empty → returns error ✅
- HTTP errors → returns error ✅
- Viewer login (`@me` / empty) → `ViewerOwner` ✅