### PR TITLE
Surface keyring access failures from ActiveToken

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -22,6 +22,7 @@ type HTTPClientOptions struct {
 	InvokingAgent      string
 	CacheTTL           time.Duration
 	Config             tokenGetter
+	TokenResolver      func(string) (string, error)
 	EnableCache        bool
 	Log                io.Writer
 	LogColorize        bool
@@ -72,7 +73,9 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 		return nil, err
 	}
 
-	if opts.Config != nil {
+	if opts.TokenResolver != nil {
+		client.Transport = addAuthTokenHeader(client.Transport, opts.TokenResolver)
+	} else if opts.Config != nil {
 		client.Transport = AddAuthTokenHeader(client.Transport, opts.Config)
 	}
 
@@ -150,6 +153,13 @@ func AddCacheTTLHeader(rt http.RoundTripper, ttl time.Duration) http.RoundTrippe
 
 // AddAuthTokenHeader adds an authentication token header for the host specified by the request.
 func AddAuthTokenHeader(rt http.RoundTripper, cfg tokenGetter) http.RoundTripper {
+	return addAuthTokenHeader(rt, func(hostname string) (string, error) {
+		token, _ := cfg.ActiveToken(hostname)
+		return token, nil
+	})
+}
+
+func addAuthTokenHeader(rt http.RoundTripper, tokenResolver func(string) (string, error)) http.RoundTripper {
 	return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
 		// If the header is already set in the request, don't overwrite it.
 		if req.Header.Get(authorization) == "" {
@@ -157,11 +167,14 @@ func AddAuthTokenHeader(rt http.RoundTripper, cfg tokenGetter) http.RoundTripper
 			if req.Response != nil && req.Response.Request != nil {
 				redirectHostnameChange = getHost(req) != getHost(req.Response.Request)
 			}
-			// Only set header if an initial request or redirect request to the same host as the initial request.
-			// If the host has changed during a redirect do not add the authentication token header.
-			if !redirectHostnameChange {
+			// The Zen endpoint is intentionally usable without authentication.
+			if !redirectHostnameChange && req.URL.Path != "/zen" {
 				hostname := ghauth.NormalizeHostname(getHost(req))
-				if token, _ := cfg.ActiveToken(hostname); token != "" {
+				token, err := tokenResolver(hostname)
+				if err != nil {
+					return nil, err
+				}
+				if token != "" {
 					req.Header.Set(authorization, fmt.Sprintf("token %s", token))
 				}
 			}

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -442,6 +443,103 @@ type tinyConfig map[string]string
 
 func (c tinyConfig) ActiveToken(host string) (string, string) {
 	return c[fmt.Sprintf("%s:%s", host, "oauth_token")], "oauth_token"
+}
+
+func TestAddAuthTokenHeaderResolutionPaths(t *testing.T) {
+	resolutionErr := errors.New("simulated keyring failure")
+
+	tests := []struct {
+		name             string
+		path             string
+		token            string
+		err              error
+		wantErr          error
+		wantInnerCalled  bool
+		wantResolverCall bool
+		wantAuthHeader   string
+	}{
+		{
+			name:             "resolution error fails the request",
+			err:              resolutionErr,
+			wantErr:          resolutionErr,
+			wantInnerCalled:  false,
+			wantResolverCall: true,
+		},
+		{
+			name:             "resolved token is attached as Authorization",
+			token:            "RESOLVED-TOKEN",
+			wantInnerCalled:  true,
+			wantResolverCall: true,
+			wantAuthHeader:   "token RESOLVED-TOKEN",
+		},
+		{
+			name:             "empty token with no error proceeds anonymously",
+			wantInnerCalled:  true,
+			wantResolverCall: true,
+		},
+		{
+			name:            "zen proceeds without resolving a token",
+			path:            "/zen",
+			err:             resolutionErr,
+			wantInnerCalled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var innerCalled bool
+			var resolverCalled bool
+			var captured *http.Request
+			inner := funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+				innerCalled = true
+				captured = req
+				return &http.Response{StatusCode: http.StatusOK}, nil
+			}}
+			rt := addAuthTokenHeader(inner, func(string) (string, error) {
+				resolverCalled = true
+				return tt.token, tt.err
+			})
+
+			req, err := http.NewRequest("GET", "https://api.github.com"+tt.path, nil)
+			require.NoError(t, err)
+
+			_, err = rt.RoundTrip(req)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantInnerCalled, innerCalled)
+			assert.Equal(t, tt.wantResolverCall, resolverCalled)
+			if tt.wantInnerCalled {
+				require.NotNil(t, captured)
+				assert.Equal(t, tt.wantAuthHeader, captured.Header.Get(authorization))
+			}
+		})
+	}
+}
+
+func TestNewHTTPClientUsesTokenResolver(t *testing.T) {
+	resolutionErr := errors.New("simulated keyring failure")
+	var requestReceived bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(HTTPClientOptions{
+		Config: tinyConfig{},
+		TokenResolver: func(string) (string, error) {
+			return "", resolutionErr
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = client.Get(server.URL)
+
+	require.ErrorIs(t, err, resolutionErr)
+	assert.False(t, requestReceived)
 }
 
 var requestAtRE = regexp.MustCompile(`(?m)^\* Request at .+`)

--- a/internal/config/auth_config_test.go
+++ b/internal/config/auth_config_test.go
@@ -76,6 +76,202 @@ func TestHasNoActiveToken(t *testing.T) {
 	require.False(t, hasActiveToken, "expected there to be no active token")
 }
 
+func TestActiveTokenWithErrorFallsBackWhenActiveUserIsBlank(t *testing.T) {
+	authCfg := newTestAuthConfig(t)
+	authCfg.cfg.Set([]string{hostsKey, "github.com", userKey}, "")
+	require.NoError(t, keyring.Set(keyringServiceName("github.com"), "", "test-token"))
+
+	token, source, err := authCfg.ActiveTokenWithError("github.com")
+
+	require.NoError(t, err)
+	require.Equal(t, "test-token", token)
+	require.Equal(t, "keyring", source)
+}
+
+func TestActiveTokenWithErrorSurfacesKeyringFailure(t *testing.T) {
+	// Given a host with a configured user whose token lives in the keyring
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "", true)
+	require.NoError(t, err)
+
+	// And a keyring that subsequently fails on every access (simulating a
+	// macOS Keychain access timeout or other non-ErrNotFound failure)
+	keyringErr := errors.New("simulated keyring failure")
+	keyring.MockInitWithError(keyringErr)
+
+	// When we resolve the active token via ActiveTokenWithError
+	token, _, err := authCfg.ActiveTokenWithError("github.com")
+
+	// Then the failure is surfaced rather than silently producing an empty
+	// token, so callers can distinguish "no token here" from "keyring is
+	// inaccessible" and avoid sending unauthenticated requests.
+	require.Empty(t, token)
+	require.Error(t, err)
+	require.ErrorIs(t, err, keyringErr)
+	require.ErrorContains(t, err, "github.com")
+}
+
+func TestActiveTokenWithErrorSurfacesUserScopedFailureWhenUnkeyedFallbackIsAbsent(t *testing.T) {
+	// Given a host with a configured user whose user-scoped keyring lookup
+	// fails with a real keyring access error (not ErrNotFound), while the
+	// legacy unkeyed fallback slot is genuinely empty (ErrNotFound).
+	//
+	// This is the regression case for the silent-failure bug: the fallback's
+	// "not found" must not be allowed to mask the user-scoped lookup's real
+	// failure, otherwise AddAuthTokenHeader will proceed unauthenticated.
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "", true)
+	require.NoError(t, err)
+
+	keyringErr := errors.New("simulated user-scoped keyring failure")
+	keyring.MockGetOverride(func(_, user string) (string, error) {
+		if user == "" {
+			return "", keyring.ErrNotFound
+		}
+		return "", keyringErr
+	})
+	t.Cleanup(func() { keyring.MockGetOverride(nil) })
+
+	// When we resolve the active token via ActiveTokenWithError
+	token, _, err := authCfg.ActiveTokenWithError("github.com")
+
+	// Then the user-scoped failure is surfaced rather than being masked by
+	// the fallback's ErrNotFound.
+	require.Empty(t, token)
+	require.Error(t, err)
+	require.ErrorIs(t, err, keyringErr)
+	require.ErrorContains(t, err, "github.com")
+}
+
+func TestActiveTokenWithErrorPrefersFallbackErrorWhenBothLookupsFail(t *testing.T) {
+	// Given a host with a configured user where the user-scoped keyring lookup
+	// fails with a real error AND the legacy unkeyed fallback also fails with
+	// a different real error. This locks in the current precedence: when both
+	// lookups produce non-ErrNotFound errors the fallback's error wins, since
+	// the swap at config.go only fires when the fallback returns ErrNotFound.
+	// Either error is "real" enough to surface; this test is characterization:
+	// flipping precedence would silently change which error message users see,
+	// so any future change should be deliberate and update this test.
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "", true)
+	require.NoError(t, err)
+
+	userScopedErr := errors.New("simulated user-scoped failure")
+	unkeyedErr := errors.New("simulated unkeyed failure")
+	keyring.MockGetOverride(func(_, user string) (string, error) {
+		if user == "" {
+			return "", unkeyedErr
+		}
+		return "", userScopedErr
+	})
+	t.Cleanup(func() { keyring.MockGetOverride(nil) })
+
+	// When we resolve the active token via ActiveTokenWithError
+	token, _, err := authCfg.ActiveTokenWithError("github.com")
+
+	// Then a real failure is surfaced. The fallback's error is the one that
+	// reaches the wrapper; the user-scoped error is intentionally not
+	// preferred when both are real.
+	require.Empty(t, token)
+	require.Error(t, err)
+	require.ErrorIs(t, err, unkeyedErr)
+	require.NotErrorIs(t, err, userScopedErr)
+	require.ErrorContains(t, err, "github.com")
+}
+
+func TestActiveTokenWithErrorSurfacesUnkeyedFailureWhenUserScopedReturnsNotFound(t *testing.T) {
+	// Given a host with a configured user whose user-scoped keyring lookup
+	// returns ErrNotFound (legitimately empty) while the legacy unkeyed slot
+	// fails with a real keyring access error. The user-scoped ErrNotFound
+	// must not be stashed (it's not a real failure), so the unkeyed real
+	// error reaches the wrapper.
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "", true)
+	require.NoError(t, err)
+
+	unkeyedErr := errors.New("simulated unkeyed failure")
+	keyring.MockGetOverride(func(_, user string) (string, error) {
+		if user == "" {
+			return "", unkeyedErr
+		}
+		return "", keyring.ErrNotFound
+	})
+	t.Cleanup(func() { keyring.MockGetOverride(nil) })
+
+	// When we resolve the active token via ActiveTokenWithError
+	token, _, err := authCfg.ActiveTokenWithError("github.com")
+
+	// Then the unkeyed real failure is surfaced.
+	require.Empty(t, token)
+	require.Error(t, err)
+	require.ErrorIs(t, err, unkeyedErr)
+	require.ErrorContains(t, err, "github.com")
+}
+
+func TestActiveTokenSilentlyDiscardsKeyringFailure(t *testing.T) {
+	// Given the same scenario as above
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "", true)
+	require.NoError(t, err)
+	keyring.MockInitWithError(errors.New("simulated keyring failure"))
+
+	// When we resolve the active token via the original ActiveToken
+	token, _ := authCfg.ActiveToken("github.com")
+
+	// Then it returns empty without surfacing the error, preserving its
+	// historical signature for existing callers that have not migrated to
+	// ActiveTokenWithError.
+	require.Empty(t, token)
+}
+
+func TestActiveTokenWithErrorDoesNotSurfaceErrNotFound(t *testing.T) {
+	// Given a fresh config with no users and a clean keyring (ErrNotFound
+	// is the legitimate "no token configured for this host" signal)
+	authCfg := newTestAuthConfig(t)
+
+	// When we resolve the active token via ActiveTokenWithError
+	token, _, err := authCfg.ActiveTokenWithError("github.com")
+
+	// Then the empty token is returned without an error, so callers can
+	// proceed anonymously against unconfigured hosts.
+	require.Empty(t, token)
+	require.NoError(t, err)
+}
+
+func TestActiveTokenWithErrorReturnsEnvTokenWithoutKeyring(t *testing.T) {
+	// Given an environment-provided token and a keyring that would fail if
+	// it were consulted
+	t.Setenv("GH_TOKEN", "env-test-token")
+	authCfg := newTestAuthConfig(t)
+	keyring.MockInitWithError(errors.New("keyring should not be consulted"))
+
+	// When we resolve the active token via ActiveTokenWithError
+	token, source, err := authCfg.ActiveTokenWithError("github.com")
+
+	// Then the env-var path short-circuits keyring access entirely and
+	// returns successfully without error.
+	require.NoError(t, err)
+	require.Equal(t, "env-test-token", token)
+	require.Equal(t, "GH_TOKEN", source)
+}
+
+func TestActiveTokenWithErrorReturnsKeyringToken(t *testing.T) {
+	// Given a host with a configured user and a healthy keyring containing
+	// that user's token
+	authCfg := newTestAuthConfig(t)
+	_, err := authCfg.Login("github.com", "test-user", "test-token", "", true)
+	require.NoError(t, err)
+
+	// When we resolve the active token via ActiveTokenWithError
+	token, source, err := authCfg.ActiveTokenWithError("github.com")
+
+	// Then it returns the keyring-stored token with the "keyring" source
+	// label and no error.
+	require.NoError(t, err)
+	require.Equal(t, "test-token", token)
+	require.Equal(t, "keyring", source)
+}
+
 func TestTokenStoredInConfig(t *testing.T) {
 	// Given the user has logged in insecurely
 	authCfg := newTestAuthConfig(t)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,29 +234,66 @@ type AuthConfig struct {
 // ActiveToken will retrieve the active auth token for the given hostname,
 // searching environment variables, plain text config, and
 // lastly encrypted storage.
+//
+// Errors encountered while resolving the token (notably keyring access
+// failures such as timeouts on macOS Keychain) are discarded so this
+// method's signature stays unchanged for existing callers. Code that
+// needs to distinguish "no token here" from "token resolution failed"
+// should use ActiveTokenWithError instead.
 func (c *AuthConfig) ActiveToken(hostname string) (string, string) {
+	token, source, _ := c.ActiveTokenWithError(hostname)
+	return token, source
+}
+
+// ActiveTokenWithError is like ActiveToken but additionally returns any
+// error encountered while resolving the active token. The most important
+// case is a keyring access failure (e.g. *keyring.TimeoutError): callers
+// that receive a non-nil error should treat it as a real auth-resolution
+// failure rather than silently proceeding without a token.
+//
+// A non-nil error is returned only when a keyring lookup fails with an
+// error other than keyring.ErrNotFound. ErrNotFound is the legitimate
+// "no token here" signal and is not surfaced as an error so that
+// genuinely anonymous requests against unconfigured hosts keep working.
+func (c *AuthConfig) ActiveTokenWithError(hostname string) (string, string, error) {
 	if c.tokenOverride != nil {
-		return c.tokenOverride(hostname)
+		token, source := c.tokenOverride(hostname)
+		return token, source, nil
 	}
 	token, source := ghauth.TokenFromEnvOrConfig(hostname)
-	if token == "" {
-		var user string
-		var err error
-		if user, err = c.ActiveUser(hostname); err == nil {
-			token, err = c.TokenFromKeyringForUser(hostname, user)
-		}
-		if err != nil {
-			// We should generally be able to find a token for the active user,
-			// but in some cases such as if the keyring was set up in a very old
-			// version of the CLI, it may only have a unkeyed token, so fallback
-			// to it.
-			token, err = c.TokenFromKeyring(hostname)
-		}
-		if err == nil {
-			source = "keyring"
-		}
+	if token != "" {
+		return token, source, nil
 	}
-	return token, source
+
+	var err error
+	var primaryKeyringErr error
+	user, activeUserErr := c.ActiveUser(hostname)
+	if activeUserErr == nil && user != "" {
+		token, err = c.TokenFromKeyringForUser(hostname, user)
+		if err != nil && !errors.Is(err, keyring.ErrNotFound) {
+			primaryKeyringErr = err
+		}
+	} else {
+		err = activeUserErr
+	}
+	if err != nil || user == "" {
+		// We should generally be able to find a token for the active user,
+		// but in some cases such as if the keyring was set up in a very old
+		// version of the CLI, it may only have a unkeyed token, so fallback
+		// to it.
+		token, err = c.TokenFromKeyring(hostname)
+	}
+	if err == nil {
+		source = "keyring"
+		return token, source, nil
+	}
+	if primaryKeyringErr != nil && errors.Is(err, keyring.ErrNotFound) {
+		err = primaryKeyringErr
+	}
+	if errors.Is(err, keyring.ErrNotFound) {
+		return token, source, nil
+	}
+	return token, source, fmt.Errorf("couldn't resolve auth token from keyring for %q: %w", hostname, err)
 }
 
 // HasActiveToken returns true when a token for the hostname is present.

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -110,6 +110,12 @@ type AuthConfig interface {
 	// general configuration, and finally encrypted storage.
 	ActiveToken(hostname string) (token string, source string)
 
+	// ActiveTokenWithError is like ActiveToken but additionally returns any error encountered while resolving
+	// the active token, such as a keyring access timeout. Callers that need to distinguish "no token configured
+	// for this host" from "token resolution failed" should prefer this method so a keyring failure does not
+	// silently produce an unauthenticated request.
+	ActiveTokenWithError(hostname string) (token string, source string, err error)
+
 	// HasEnvToken returns true when a token has been specified in an environment variable, else returns false.
 	HasEnvToken() bool
 

--- a/internal/keyring/keyring.go
+++ b/internal/keyring/keyring.go
@@ -33,8 +33,20 @@ func Set(service, user, secret string) error {
 	}
 }
 
+// getOverride, when non-nil, intercepts Get calls before they reach the
+// underlying provider. It exists solely to let tests simulate per-(service,user)
+// failure modes that the upstream mock can only express globally.
+var getOverride func(service, user string) (string, error)
+
 // Get secret from keyring given service and user name.
 func Get(service, user string) (string, error) {
+	if fn := getOverride; fn != nil {
+		val, err := fn(service, user)
+		if errors.Is(err, keyring.ErrNotFound) {
+			return "", ErrNotFound
+		}
+		return val, err
+	}
 	ch := make(chan struct {
 		val string
 		err error
@@ -75,8 +87,24 @@ func Delete(service, user string) error {
 
 func MockInit() {
 	keyring.MockInit()
+	getOverride = nil
 }
 
 func MockInitWithError(err error) {
 	keyring.MockInitWithError(err)
+	getOverride = nil
+}
+
+// MockGetOverride installs fn as an interceptor for Get calls. Pass nil to
+// remove the override. Intended for tests that need per-(service,user) failure
+// modes which the upstream mock cannot express.
+//
+// The override is stored in a package-level variable without synchronization,
+// so callers must not use this with t.Parallel(). Either MockInit or
+// MockInitWithError will clear the override, preserving the isolation
+// contract for tests that reset keyring state at setup; callers should still
+// prefer registering t.Cleanup to restore nil promptly when the override is
+// only needed for one test.
+func MockGetOverride(fn func(service, user string) (string, error)) {
+	getOverride = fn
 }

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -387,6 +387,7 @@ func apiRun(opts *ApiOptions) error {
 	if err != nil {
 		return err
 	}
+	authConfig := cfg.Authentication()
 
 	if opts.HttpClient == nil {
 		opts.HttpClient = func() (*http.Client, error) {
@@ -395,10 +396,14 @@ func apiRun(opts *ApiOptions) error {
 				log = opts.IO.Out
 			}
 			opts := api.HTTPClientOptions{
-				AppVersion:     opts.AppVersion,
-				InvokingAgent:  opts.InvokingAgent,
-				CacheTTL:       opts.CacheTTL,
-				Config:         cfg.Authentication(),
+				AppVersion:    opts.AppVersion,
+				InvokingAgent: opts.InvokingAgent,
+				CacheTTL:      opts.CacheTTL,
+				Config:        authConfig,
+				TokenResolver: func(hostname string) (string, error) {
+					token, _, err := authConfig.ActiveTokenWithError(hostname)
+					return token, err
+				},
 				EnableCache:    opts.CacheTTL > 0,
 				Log:            log,
 				LogColorize:    opts.IO.ColorEnabled(),
@@ -412,7 +417,7 @@ func apiRun(opts *ApiOptions) error {
 		return err
 	}
 
-	host, _ := cfg.Authentication().DefaultHost()
+	host, _ := authConfig.DefaultHost()
 
 	if opts.Hostname != "" {
 		host = opts.Hostname

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -191,8 +191,13 @@ func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams,
 		if err != nil {
 			return nil, err
 		}
+		authConfig := cfg.Authentication()
 		opts := api.HTTPClientOptions{
-			Config:            cfg.Authentication(),
+			Config: authConfig,
+			TokenResolver: func(hostname string) (string, error) {
+				token, _, err := authConfig.ActiveTokenWithError(hostname)
+				return token, err
+			},
 			Log:               ios.ErrOut,
 			LogColorize:       ios.ColorEnabled(),
 			AppVersion:        appVersion,


### PR DESCRIPTION
Fixes #13317.

## Summary

`gh api` and `gh api graphql` were silently sending requests **without an `Authorization` header** when `gh`'s keyring lookup failed — typically when the 3-second timeout in `internal/keyring/keyring.go` fired against a macOS Keychain entry whose ACL had drifted (e.g. an entry written by an older `gh` that now requires an interactive approval the non-TTY child process can't surface). Users saw only `HTTP 401` (REST) or `HTTP 403 "API rate limit exceeded for <IP>"` (GraphQL) with no signal that the local keyring was the cause.

The bug was a silent error discard at two layers:

1. `(*config.AuthConfig).ActiveToken` swallowed keyring errors from `TokenFromKeyringForUser` / `TokenFromKeyring` and returned `("", source)`.
2. `AddAuthTokenHeader.RoundTrip` then saw an empty token and proceeded with no header — indistinguishable from a legitimate anonymous request.

## What changed

- Added `ActiveTokenWithError(hostname) (token, source, err)` to `gh.AuthConfig` and `*config.AuthConfig` that surfaces non-`ErrNotFound` keyring errors.
- Refactored `(*AuthConfig).ActiveToken` as a thin wrapper that calls `ActiveTokenWithError` and discards the error, preserving its existing signature for every current caller.
- Required `ActiveTokenWithError` on `api/http_client.go`'s local `tokenGetter` interface; updated the `cfg` adapter in `internal/authflow/flow.go` and the `tinyConfig` test mock to match.
- `AddAuthTokenHeader.RoundTrip` now calls `ActiveTokenWithError`. On non-nil error it fails the request with that error; on nil error + empty token it proceeds anonymously (preserves anonymous-endpoint behavior); on nil error + non-empty token it attaches the `Authorization` header as before.
- `keyring.ErrNotFound` continues to be the legitimate "no token configured for this host" signal and is **not** surfaced as an error, so anonymous requests against unconfigured hosts keep working unchanged.

## What stays the same

- The `gh.AuthConfig.ActiveToken` signature and behavior for every existing caller.
- Test mocks that don't directly satisfy `tokenGetter` (e.g. `stubAuthConfig` in `pkg/cmd/attestation/trustedroot/trustedroot_test.go`) — `stubAuthConfig` embeds `config.AuthConfig` so it inherits the new method automatically.
- Anonymous-endpoint behavior (`gh api zen` against a host with no configured user still proceeds without an `Authorization` header).

## Alternatives considered

<details>
<summary><strong>Opt-in type-assertion shim (avoid changing <code>gh.AuthConfig</code>)</strong></summary>

Initially this PR added an unexported `errorTokenGetter` interface in `api/http_client.go` that `RoundTrip` would type-assert against, with `*config.AuthConfig` opportunistically satisfying it. The advantage was zero churn to `gh.AuthConfig` — no interface change, no mock updates for downstream consumers.

Rejected because the new error-aware behavior would only fire by accident of static type propagation, the contract would be untestable from the interface seam (any future code constructing `HTTPClientOptions` from a `gh.AuthConfig` value rather than the concrete type would silently get the legacy path), and an opt-in shim is brittle for a fix to a *silent-failure* bug. Adding `ActiveTokenWithError` to the interface makes the contract explicit and verifiable.

</details>

<details>
<summary><strong>Naming: <code>ActiveTokenE</code> vs. <code>ActiveTokenWithError</code> vs. <code>ResolveActiveToken</code></strong></summary>

`ActiveTokenE` (single-letter `E` suffix) is concise and used in some Go projects, but has no precedent in cli/cli — would be inventing a convention.

`ResolveActiveToken` discriminates well from `ActiveToken`, but pairs awkwardly with the existing method-on-noun naming throughout `gh.AuthConfig` (`ActiveUser`, `TokenFromKeyring`, etc.).

Chose `ActiveTokenWithError` because it composes naturally with `ActiveToken` (clear sibling relationship), is self-documenting in error-checking call sites, and matches the existing explicit-suffix precedent in this codebase (e.g. `keyring.MockInitWithError` in `internal/keyring/keyring.go`).

</details>

<details>
<summary><strong>Logging from inside <code>ActiveToken</code> (surface error without signature change)</strong></summary>

A smaller-footprint alternative: keep `ActiveToken` unchanged but write a warning to `os.Stderr` when both keyring lookups fail with non-`ErrNotFound` errors. The user would see a "warning: keyring access failed" line followed by the downstream 401/403, which is at least diagnosable.

Rejected because (1) logging from a config-layer getter is the wrong architectural seam — it doesn't compose with structured loggers or with cli/cli's `--verbose` plumbing, (2) the request still goes out unauthenticated, so scripts and CI consumers still get misleading exit codes, and (3) it leaves the underlying contract bug in place for every future caller. Returning the error is the right fix; logging would be a band-aid.

</details>

<details>
<summary><strong>Marking <code>ActiveToken</code> as <code>// Deprecated:</code> in this PR</strong></summary>

Could be added as a one-line annotation on the existing method to steer new code toward `ActiveTokenWithError`.

Deferred to a follow-up PR because adding the marker now would generate `SA1019` warnings on every existing call site (`pkg/cmd/auth/status/status.go:238`, `pkg/cmd/auth/refresh/refresh.go:178,229`, `pkg/cmd/auth/token/token.go:81`, `pkg/cmd/auth/shared/writeable.go:10`, `pkg/cmd/config/get/get.go:58`, plus internal usages) without giving them a migration path in the same PR. Better to land this fix first, then a follow-up that migrates the call sites and adds the marker together. Happy to do both in one PR if maintainers prefer.

</details>

## Follow-ups (not in this PR)

Other call sites of `ActiveToken` would benefit from migrating to `ActiveTokenWithError` so the same class of silent failure can't recur in those code paths. Left for a follow-up to keep this PR focused:

- `pkg/cmd/auth/status/status.go:238` — `gh auth status` can mis-report keyring failures as "no token"
- `pkg/cmd/auth/refresh/refresh.go:178,229`
- `pkg/cmd/auth/token/token.go:81`
- `pkg/cmd/auth/shared/writeable.go:10`
- `pkg/cmd/config/get/get.go:58`

Adding `// Deprecated:` to `ActiveToken` is also deferred to that follow-up — adding it now would generate `SA1019` warnings on every existing call site without giving users a migration path.

## Test plan

- `go vet ./...` clean.
- `go test ./... -short` passes (full suite).
- New tests in `internal/config/auth_config_test.go`:
  - `TestActiveTokenWithErrorSurfacesKeyringFailure` — keyring error is wrapped and returned.
  - `TestActiveTokenSilentlyDiscardsKeyringFailure` — `ActiveToken` (the wrapper) preserves its no-error contract.
  - `TestActiveTokenWithErrorDoesNotSurfaceErrNotFound` — `ErrNotFound` returns `(token="", err=nil)`.
  - `TestActiveTokenWithErrorReturnsEnvTokenWithoutKeyring` — env-var path short-circuits keyring entirely.
  - `TestActiveTokenWithErrorReturnsKeyringToken` — successful keyring resolution returns `(token, "keyring", nil)`.
- New table-driven `TestAddAuthTokenHeaderResolutionPaths` in `api/http_client_test.go` covering: error fails the request, resolved token is attached, empty token without error proceeds anonymously.
- Manually verified the patched binary built from this branch continues to authenticate correctly against a healthy macOS Keychain (`gh api user` returns `HTTP/2 200, x-ratelimit-limit: 5000, resource: core`; same for GraphQL).