### PR TITLE
fix(pr): remove numberFieldOnly optimization that skips API validation

### DIFF
--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -207,7 +207,6 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 
 	fields := set.NewStringSet()
 	fields.AddValues(opts.Fields)
-	numberFieldOnly := fields.Len() == 1 && fields.Contains("number")
 	fields.AddValues([]string{"id", "number"}) // for additional preload queries below
 
 	if fields.Contains("isInMergeQueue") || fields.Contains("isMergeQueueEnabled") {
@@ -248,11 +247,6 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 
 	var pr *api.PullRequest
 	if f.prNumber > 0 {
-		// If we have a PR number, let's look it up
-		if numberFieldOnly {
-			// avoid hitting the API if we already have all the information
-			return &api.PullRequest{Number: f.prNumber}, f.baseRefRepo, nil
-		}
 		pr, err = findByNumber(httpClient, f.baseRefRepo, f.prNumber, fields.ToSlice())
 		if err != nil {
 			return pr, f.baseRefRepo, err

--- a/pkg/cmd/pr/shared/finder_test.go
+++ b/pkg/cmd/pr/shared/finder_test.go
@@ -327,25 +327,6 @@ func TestFind(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "number only",
-			args: args{
-				selector:   "13",
-				fields:     []string{"number"},
-				baseRepoFn: stubBaseRepoFn(ghrepo.New("ORIGINOWNER", "REPO"), nil),
-				branchFn: func() (string, error) {
-					return "blueberries", nil
-				},
-				gitConfigClient: stubGitConfigClient{
-					readBranchConfigFn:  stubBranchConfig(git.BranchConfig{}, nil),
-					pushDefaultFn:       stubPushDefault(git.PushDefaultSimple, nil),
-					remotePushDefaultFn: stubRemotePushDefault("", nil),
-				},
-			},
-			httpStub: nil,
-			wantPR:   13,
-			wantRepo: "https://github.com/ORIGINOWNER/REPO",
-		},
-		{
 			name: "pr number zero",
 			args: args{
 				selector:   "0",


### PR DESCRIPTION
## Summary

Fixes #13319

Removes the `numberFieldOnly` optimization in `pkg/cmd/pr/shared/finder.go` that caused `gh pr view <N> --json number` to return exit 0 even when `N` was an issue number (not a PR).

## Problem

The optimization short-circuited the API call when only the `number` field was requested, returning a synthetic `PullRequest` struct without validating that the number actually corresponds to a PR. Since `f.prNumber` is set by parsing the selector as an integer, any valid number (including issue numbers) would succeed.

## Fix

Remove the optimization entirely. It saved a single API call for an extremely uncommon query - the caller already knows the number from the argument they passed. The correctness cost is not worth the marginal performance gain.