### PR TITLE
Add api_base_url and resolver for routing API traffic

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -17,9 +18,12 @@ type tokenGetter interface {
 	ActiveToken(string) (string, string)
 }
 
+type APIBaseURLResolver func(hostname string) string
+
 type HTTPClientOptions struct {
 	AppVersion         string
 	InvokingAgent      string
+	APIBaseURL        APIBaseURLResolver
 	CacheTTL           time.Duration
 	Config             tokenGetter
 	EnableCache        bool
@@ -70,6 +74,10 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 	client, err := ghAPI.NewHTTPClient(clientOpts)
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.APIBaseURL != nil {
+		client.Transport = RewriteAPIBaseURL(client.Transport, opts.APIBaseURL)
 	}
 
 	if opts.Config != nil {
@@ -124,6 +132,48 @@ func AddAuthTokenHeader(rt http.RoundTripper, cfg tokenGetter) http.RoundTripper
 		}
 		return rt.RoundTrip(req)
 	}}
+}
+
+// RewriteAPIBaseURL rewrites requests for a canonical host to a configured API base URL.
+// This must run after auth headers are selected so tokens are looked up for the canonical host.
+func RewriteAPIBaseURL(rt http.RoundTripper, resolver APIBaseURLResolver) http.RoundTripper {
+	return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+		hostname := ghauth.NormalizeHostname(getHost(req))
+		apiBaseURL := resolver(hostname)
+		if apiBaseURL == "" {
+			return rt.RoundTrip(req)
+		}
+
+		baseURL, err := validateAPIBaseURL(hostname, apiBaseURL)
+		if err != nil {
+			return nil, err
+		}
+
+		rewrittenURL, err := url.Parse(baseURL.JoinPath(req.URL.EscapedPath()).String())
+		if err != nil {
+			return nil, fmt.Errorf("invalid api_base_url for %s: %w", hostname, err)
+		}
+		rewrittenURL.RawQuery = req.URL.RawQuery
+
+		rewritten := req.Clone(req.Context())
+		rewritten.URL = rewrittenURL
+		rewritten.Host = rewrittenURL.Host
+		return rt.RoundTrip(rewritten)
+	}}
+}
+
+func validateAPIBaseURL(hostname, rawURL string) (*url.URL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid api_base_url for %s: %w", hostname, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("invalid api_base_url for %s: must include scheme and host", hostname)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return nil, fmt.Errorf("invalid api_base_url for %s: must not include query or fragment", hostname)
+	}
+	return u, nil
 }
 
 // ExtractHeader extracts a named header from any response received by this client and,

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -15,6 +16,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	configDir, err := os.MkdirTemp("", "gh-cli-api-test")
+	if err != nil {
+		panic(err)
+	}
+
+	os.Setenv("GH_CONFIG_DIR", configDir)
+	os.Unsetenv("GH_HOST")
+
+	code := m.Run()
+	os.RemoveAll(configDir)
+	os.Exit(code)
+}
 
 func TestNewHTTPClient(t *testing.T) {
 	type args struct {
@@ -190,6 +205,7 @@ func TestNewHTTPClient(t *testing.T) {
 			})
 			require.NoError(t, err)
 
+			gotReq = nil
 			req, err := http.NewRequest("GET", ts.URL, nil)
 			req.Header.Set("time-zone", "Europe/Amsterdam")
 			req.Host = tt.host
@@ -198,6 +214,7 @@ func TestNewHTTPClient(t *testing.T) {
 			res, err := client.Do(req)
 
 			require.NoError(t, err)
+			require.NotNil(t, gotReq)
 
 			for name, value := range tt.wantHeader {
 				assert.Equal(t, value, gotReq.Header.Values(name), name)
@@ -241,6 +258,82 @@ func TestHTTPClientRedirectAuthenticationHeaderHandling(t *testing.T) {
 	assert.Equal(t, "token REDIRECT-TOKEN", redirectRequest.Header.Get(authorization))
 	assert.Equal(t, "", request.Header.Get(authorization))
 	assert.Equal(t, 204, res.StatusCode)
+}
+
+func TestHTTPClientAPIBaseURLRewriteUsesCanonicalHostForAuth(t *testing.T) {
+	var gotReq *http.Request
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReq = r
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer proxyServer.Close()
+
+	client, err := NewHTTPClient(HTTPClientOptions{
+		APIBaseURL: func(hostname string) string {
+			if hostname == "git.corp.example.com" {
+				return proxyServer.URL
+			}
+			return ""
+		},
+		Config: tinyConfig{
+			"git.corp.example.com:oauth_token":                              "CANONICAL-TOKEN",
+			strings.TrimPrefix(proxyServer.URL, "http://") + ":oauth_token": "PROXY-TOKEN",
+		},
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("GET", "https://git.corp.example.com/api/v3/user", nil)
+	require.NoError(t, err)
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+
+	require.NotNil(t, gotReq)
+	assert.Equal(t, http.StatusNoContent, res.StatusCode)
+	assert.Equal(t, "/api/v3/user", gotReq.URL.Path)
+	assert.Equal(t, strings.TrimPrefix(proxyServer.URL, "http://"), gotReq.Host)
+	assert.Equal(t, "token CANONICAL-TOKEN", gotReq.Header.Get(authorization))
+}
+
+func TestHTTPClientAPIBaseURLRewriteRejectsQueryAndFragment(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+	}{
+		{
+			name:    "rejects query",
+			baseURL: "https://github-proxy.example.com/api?foo=bar",
+		},
+		{
+			name:    "rejects fragment",
+			baseURL: "https://github-proxy.example.com/api#fragment",
+		},
+		{
+			name:    "rejects query and fragment",
+			baseURL: "https://github-proxy.example.com/api?foo=bar#fragment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewHTTPClient(HTTPClientOptions{
+				APIBaseURL: func(hostname string) string {
+					if hostname == "git.corp.example.com" {
+						return tt.baseURL
+					}
+					return ""
+				},
+			})
+			require.NoError(t, err)
+
+			req, err := http.NewRequest("GET", "https://git.corp.example.com/api/v3/user", nil)
+			require.NoError(t, err)
+
+			_, err = client.Do(req)
+			require.EqualError(t, err,
+				`Get "https://git.corp.example.com/api/v3/user": invalid api_base_url for git.corp.example.com: must not include query or fragment`)
+		})
+	}
 }
 
 func TestHTTPClientSanitizeJSONControlCharactersC0(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ const (
 	accessibleColorsKey   = "accessible_colors" // used by cli/go-gh to enable the use of customizable, accessible 4-bit colors.
 	accessiblePrompterKey = "accessible_prompter"
 	aliasesKey            = "aliases"
+	apiBaseURLKey         = "api_base_url"
 	browserKey            = "browser" // used by cli/go-gh to open URLs in web browsers
 	colorLabelsKey        = "color_labels"
 	editorKey             = "editor" // used by cli/go-gh to open interactive text editor
@@ -125,6 +126,14 @@ func (c *cfg) AccessiblePrompter(hostname string) gh.ConfigEntry {
 	return c.GetOrDefault(hostname, accessiblePrompterKey).Unwrap()
 }
 
+func (c *cfg) APIBaseURL(hostname string) gh.ConfigEntry {
+	if hostname == "" {
+		return gh.ConfigEntry{Value: "", Source: gh.ConfigDefaultProvided}
+	}
+	
+	return c.GetOrDefault(hostname, apiBaseURLKey).Unwrap()
+}
+
 func (c *cfg) Browser(hostname string) gh.ConfigEntry {
 	// Intentionally panic if there is no user provided value or default value (which would be a programmer error)
 	return c.GetOrDefault(hostname, browserKey).Unwrap()
@@ -215,7 +224,7 @@ func (c *cfg) CacheDir() string {
 func defaultFor(key string) o.Option[string] {
 	for _, co := range Options {
 		if co.Key == key {
-			return o.Some(co.DefaultValue)
+		return o.Some(co.DefaultValue)
 		}
 	}
 	return o.None[string]()
@@ -686,6 +695,14 @@ var Options = []ConfigOption{
 		AllowedValues: []string{"enabled", "disabled"},
 		CurrentValue: func(c gh.Config, hostname string) string {
 			return c.Spinner(hostname).Value
+		},
+	},
+	{
+		Key:         apiBaseURLKey,
+		Description: "the base URL to use for GitHub API requests for this host",
+		DefaultValue: "",
+		CurrentValue: func(c gh.Config, hostname string) string {
+			return c.APIBaseURL(hostname).Value
 		},
 	},
 	{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -129,6 +129,16 @@ func TestGetOrDefaultHostnameSpecificKeyFallsBackToTopLevel(t *testing.T) {
 	require.Equal(t, gh.ConfigUserProvided, entry.Source)
 }
 
+func TestAPIBaseURLDoesNotFallBackToTopLevel(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.cfg.Set([]string{apiBaseURLKey}, "https://top-level-proxy.example.com")
+
+	entry := cfg.APIBaseURL("git.corp.example.com")
+
+	require.Equal(t, "", entry.Value)
+	require.Equal(t, gh.ConfigDefaultProvided, entry.Source)
+}
+
 func TestFallbackConfig(t *testing.T) {
 	cfg := fallbackConfig()
 	requireKeyWithValue(t, cfg, []string{gitProtocolKey}, "https")

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -58,6 +58,9 @@ func NewFromString(cfgStr string) *ghmock.ConfigMock {
 	mock.AccessiblePrompterFunc = func(hostname string) gh.ConfigEntry {
 		return cfg.AccessiblePrompter(hostname)
 	}
+	mock.APIBaseURLFunc = func(hostname string) gh.ConfigEntry {
+		return cfg.APIBaseURL(hostname)
+	}
 	mock.BrowserFunc = func(hostname string) gh.ConfigEntry {
 		return cfg.Browser(hostname)
 	}

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -39,6 +39,9 @@ type Config interface {
 	AccessibleColors(hostname string) ConfigEntry
 	// AccessiblePrompter returns the configured accessible_prompter setting, optionally scoped by host.
 	AccessiblePrompter(hostname string) ConfigEntry
+	// APIBaseURL returns the host-specific API base URL override.
+	// It does not fall back to top-level config.
+	APIBaseURL(hostname string) ConfigEntry
 	// Browser returns the configured browser, optionally scoped by host.
 	Browser(hostname string) ConfigEntry
 	// ColorLabels returns the configured color_label setting, optionally scoped by host.

--- a/internal/gh/mock/config.go
+++ b/internal/gh/mock/config.go
@@ -32,6 +32,9 @@ var _ gh.Config = &ConfigMock{}
 //			AuthenticationFunc: func() gh.AuthConfig {
 //				panic("mock out the Authentication method")
 //			},
+//			APIBaseURLFunc: func(hostname string) gh.ConfigEntry {
+//				panic("mock out the APIBaseURL method")
+//			},
 //			BrowserFunc: func(hostname string) gh.ConfigEntry {
 //				panic("mock out the Browser method")
 //			},
@@ -99,6 +102,9 @@ type ConfigMock struct {
 	// AuthenticationFunc mocks the Authentication method.
 	AuthenticationFunc func() gh.AuthConfig
 
+	// APIBaseURLFunc mocks the APIBaseURL method.
+	APIBaseURLFunc func(hostname string) gh.ConfigEntry
+
 	// BrowserFunc mocks the Browser method.
 	BrowserFunc func(hostname string) gh.ConfigEntry
 
@@ -164,6 +170,11 @@ type ConfigMock struct {
 		}
 		// Authentication holds details about calls to the Authentication method.
 		Authentication []struct {
+		}
+		// APIBaseURL holds details about calls to the APIBaseURL method.
+		APIBaseURL []struct {
+			// Hostname is the hostname argument value.
+			Hostname string
 		}
 		// Browser holds details about calls to the Browser method.
 		Browser []struct {
@@ -248,6 +259,7 @@ type ConfigMock struct {
 	lockAccessiblePrompter sync.RWMutex
 	lockAliases            sync.RWMutex
 	lockAuthentication     sync.RWMutex
+	lockAPIBaseURL         sync.RWMutex
 	lockBrowser            sync.RWMutex
 	lockCacheDir           sync.RWMutex
 	lockColorLabels        sync.RWMutex
@@ -381,6 +393,38 @@ func (mock *ConfigMock) AuthenticationCalls() []struct {
 	mock.lockAuthentication.RLock()
 	calls = mock.calls.Authentication
 	mock.lockAuthentication.RUnlock()
+	return calls
+}
+
+// APIBaseURL calls APIBaseURLFunc.
+func (mock *ConfigMock) APIBaseURL(hostname string) gh.ConfigEntry {
+	callInfo := struct {
+		Hostname string
+	}{
+		Hostname: hostname,
+	}
+	mock.lockAPIBaseURL.Lock()
+	mock.calls.APIBaseURL = append(mock.calls.APIBaseURL, callInfo)
+	mock.lockAPIBaseURL.Unlock()
+	if mock.APIBaseURLFunc == nil {
+		return gh.ConfigEntry{Value: "", Source: gh.ConfigDefaultProvided}
+	}
+	return mock.APIBaseURLFunc(hostname)
+}
+
+// APIBaseURLCalls gets all the calls that were made to APIBaseURL.
+// Check the length with:
+//
+//	len(mockedConfig.APIBaseURLCalls())
+func (mock *ConfigMock) APIBaseURLCalls() []struct {
+	Hostname string
+} {
+	var calls []struct {
+		Hostname string
+	}
+	mock.lockAPIBaseURL.RLock()
+	calls = mock.calls.APIBaseURL
+	mock.lockAPIBaseURL.RUnlock()
 	return calls
 }
 

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -388,6 +388,7 @@ func apiRun(opts *ApiOptions) error {
 			opts := api.HTTPClientOptions{
 				AppVersion:     opts.AppVersion,
 				InvokingAgent:  opts.InvokingAgent,
+				APIBaseURL:     func(hostname string) string { return cfg.APIBaseURL(hostname).Value },
 				CacheTTL:       opts.CacheTTL,
 				Config:         cfg.Authentication(),
 				EnableCache:    opts.CacheTTL > 0,

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -197,6 +197,9 @@ func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams,
 			AppVersion:        appVersion,
 			InvokingAgent:     invokingAgent,
 			TelemetryDisabler: telemetryDisabler,
+			APIBaseURL: func(hostname string) string {
+				return cfg.APIBaseURL(hostname).Value
+			},
 		}
 		client, err := api.NewHTTPClient(opts)
 		if err != nil {


### PR DESCRIPTION
## Summary

Another attempt to address #12179 

Adds a host-specific `api_base_url` config option so enterprise users can keep the git remote host as the canonical `gh` host while routing API traffic to a different GitHub Enterprise API host.

This supports proxy/bastion setups like:

- git remote: `git.company.com`
- API base URL: `https://github.company.com/api/v3`

Fixes #12179 

## Design

This keeps the existing remote resolver diagnostics intact. Instead of falling back when remotes do not match `GH_HOST`, users explicitly configure the API transport override for the matched host.

API requests still select auth using the canonical host, then the HTTP transport rewrites the request to the configured `api_base_url`.

## Testing

Adds coverage for:

- API base URL rewriting while preserving canonical-host auth lookup
- rejecting invalid `api_base_url` values with query strings or fragments
- host-specific config behavior without top-level fallback