### PR TITLE
Paginate files and commits in `gh pr view --json`

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -55,7 +55,11 @@ type PullRequest struct {
 	PotentialMergeCommit *Commit
 
 	Files struct {
-		Nodes []PullRequestFile
+		Nodes    []PullRequestFile
+		PageInfo struct {
+			HasNextPage bool
+			EndCursor   string
+		}
 	}
 
 	Author              Author
@@ -79,6 +83,10 @@ type PullRequest struct {
 	Commits struct {
 		TotalCount int
 		Nodes      []PullRequestCommit
+		PageInfo   struct {
+			HasNextPage bool
+			EndCursor   string
+		}
 	}
 	StatusCheckRollup struct {
 		Nodes []StatusCheckRollupNode
@@ -285,7 +293,7 @@ type PullRequestCommitCommit struct {
 			Email string
 			User  GitHubUser
 		}
-	}
+	} `graphql:"authors(first: 100)"`
 	MessageHeadline string
 	MessageBody     string
 	CommittedDate   time.Time

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -150,7 +150,8 @@ var prFiles = shortenQuery(`
 			deletions,
 			path,
 			changeType
-		}
+		},
+		pageInfo{hasNextPage,endCursor}
 	}
 `)
 
@@ -171,7 +172,8 @@ var prCommits = shortenQuery(`
 				committedDate,
 				authoredDate
 			}
-		}
+		},
+		pageInfo{hasNextPage,endCursor}
 	}
 `)
 

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -26,7 +26,7 @@ func TestPullRequestGraphQL(t *testing.T) {
 		{
 			name:   "compressed query",
 			fields: []string{"files"},
-			want:   "files(first: 100) {nodes {additions,deletions,path,changeType}}",
+			want:   "files(first: 100) {nodes {additions,deletions,path,changeType},pageInfo{hasNextPage,endCursor}}",
 		},
 		{
 			name:   "invalid fields",
@@ -72,7 +72,7 @@ func TestIssueGraphQL(t *testing.T) {
 		{
 			name:   "compressed query",
 			fields: []string{"files"},
-			want:   "files(first: 100) {nodes {additions,deletions,path,changeType}}",
+			want:   "files(first: 100) {nodes {additions,deletions,path,changeType},pageInfo{hasNextPage,endCursor}}",
 		},
 		{
 			name:   "projectItems",

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -29,6 +29,11 @@ func TestPullRequestGraphQL(t *testing.T) {
 			want:   "files(first: 100) {nodes {additions,deletions,path,changeType},pageInfo{hasNextPage,endCursor}}",
 		},
 		{
+			name:   "commits includes pageInfo",
+			fields: []string{"commits"},
+			want:   "commits(first: 100) {nodes {commit {authors(first:100) {nodes {name,email,user{id,login}}},messageHeadline,messageBody,oid,committedDate,authoredDate}},pageInfo{hasNextPage,endCursor}}",
+		},
+		{
 			name:   "invalid fields",
 			fields: []string{"isPinned", "stateReason", "number"},
 			want:   "number",

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -279,6 +279,16 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 			return preloadPrClosingIssuesReferences(httpClient, f.baseRefRepo, pr)
 		})
 	}
+	if fields.Contains("files") {
+		g.Go(func() error {
+			return preloadPrFiles(httpClient, f.baseRefRepo, pr)
+		})
+	}
+	if fields.Contains("commits") {
+		g.Go(func() error {
+			return preloadPrCommits(httpClient, f.baseRefRepo, pr)
+		})
+	}
 	if fields.Contains("statusCheckRollup") {
 		g.Go(func() error {
 			return preloadPrChecks(httpClient, f.baseRefRepo, pr)
@@ -557,6 +567,97 @@ func preloadPrClosingIssuesReferences(client *http.Client, repo ghrepo.Interface
 	}
 
 	pr.ClosingIssuesReferences.PageInfo.HasNextPage = false
+	return nil
+}
+
+func preloadPrFiles(client *http.Client, repo ghrepo.Interface, pr *api.PullRequest) error {
+	if !pr.Files.PageInfo.HasNextPage {
+		return nil
+	}
+
+	type response struct {
+		Node struct {
+			PullRequest struct {
+				Files struct {
+					Nodes    []api.PullRequestFile
+					PageInfo struct {
+						HasNextPage bool
+						EndCursor   string
+					}
+				} `graphql:"files(first: 100, after: $endCursor)"`
+			} `graphql:"...on PullRequest"`
+		} `graphql:"node(id: $id)"`
+	}
+
+	variables := map[string]interface{}{
+		"id":        githubv4.ID(pr.ID),
+		"endCursor": githubv4.String(pr.Files.PageInfo.EndCursor),
+	}
+
+	gql := api.NewClientFromHTTP(client)
+
+	for {
+		var query response
+		err := gql.Query(repo.RepoHost(), "FilesForPullRequest", &query, variables)
+		if err != nil {
+			return err
+		}
+
+		pr.Files.Nodes = append(pr.Files.Nodes, query.Node.PullRequest.Files.Nodes...)
+
+		if !query.Node.PullRequest.Files.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Node.PullRequest.Files.PageInfo.EndCursor)
+	}
+
+	pr.Files.PageInfo.HasNextPage = false
+	return nil
+}
+
+func preloadPrCommits(client *http.Client, repo ghrepo.Interface, pr *api.PullRequest) error {
+	if !pr.Commits.PageInfo.HasNextPage {
+		return nil
+	}
+
+	type response struct {
+		Node struct {
+			PullRequest struct {
+				Commits struct {
+					Nodes    []api.PullRequestCommit
+					PageInfo struct {
+						HasNextPage bool
+						EndCursor   string
+					}
+				} `graphql:"commits(first: 100, after: $endCursor)"`
+			} `graphql:"...on PullRequest"`
+		} `graphql:"node(id: $id)"`
+	}
+
+	variables := map[string]interface{}{
+		"id":        githubv4.ID(pr.ID),
+		"endCursor": githubv4.String(pr.Commits.PageInfo.EndCursor),
+	}
+
+	gql := api.NewClientFromHTTP(client)
+
+	for {
+		var query response
+		err := gql.Query(repo.RepoHost(), "CommitsForPullRequest", &query, variables)
+		if err != nil {
+			return err
+		}
+
+		pr.Commits.Nodes = append(pr.Commits.Nodes, query.Node.PullRequest.Commits.Nodes...)
+		pr.Commits.TotalCount = len(pr.Commits.Nodes)
+
+		if !query.Node.PullRequest.Commits.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Node.PullRequest.Commits.PageInfo.EndCursor)
+	}
+
+	pr.Commits.PageInfo.HasNextPage = false
 	return nil
 }
 

--- a/pkg/cmd/pr/shared/finder_test.go
+++ b/pkg/cmd/pr/shared/finder_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/cli/cli/v2/api"
 	ghContext "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -1007,4 +1008,150 @@ func (s *stubProgressIndicator) StartProgressIndicator() {
 
 func (s *stubProgressIndicator) StopProgressIndicator() {
 	s.stopCalled = true
+}
+
+func TestPreloadPrFiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupPR   func() *api.PullRequest
+		httpStub  func(*httpmock.Registry)
+		wantPaths []string
+	}{
+		{
+			name: "no pagination needed",
+			setupPR: func() *api.PullRequest {
+				pr := &api.PullRequest{}
+				pr.Files.Nodes = []api.PullRequestFile{
+					{Path: "file1.go"},
+				}
+				return pr
+			},
+			wantPaths: []string{"file1.go"},
+		},
+		{
+			name: "paginates through additional pages",
+			setupPR: func() *api.PullRequest {
+				pr := &api.PullRequest{ID: "PR_123"}
+				pr.Files.Nodes = []api.PullRequestFile{
+					{Path: "file1.go"},
+				}
+				pr.Files.PageInfo.HasNextPage = true
+				pr.Files.PageInfo.EndCursor = "page1"
+				return pr
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query FilesForPullRequest\b`),
+					httpmock.StringResponse(`{"data":{"node":{"files":{
+						"nodes":[{"path":"file2.go","additions":5,"deletions":2,"changeType":"ADDED"}],
+						"pageInfo":{"hasNextPage":true,"endCursor":"page2"}}}}}`),
+				)
+				r.Register(
+					httpmock.GraphQL(`query FilesForPullRequest\b`),
+					httpmock.StringResponse(`{"data":{"node":{"files":{
+						"nodes":[{"path":"file3.go","additions":1,"deletions":0,"changeType":"ADDED"}],
+						"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`),
+				)
+			},
+			wantPaths: []string{"file1.go", "file2.go", "file3.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			if tt.httpStub != nil {
+				tt.httpStub(reg)
+			}
+
+			client := &http.Client{Transport: reg}
+			repo := ghrepo.New("OWNER", "REPO")
+			pr := tt.setupPR()
+
+			err := preloadPrFiles(client, repo, pr)
+			require.NoError(t, err)
+
+			var gotPaths []string
+			for _, f := range pr.Files.Nodes {
+				gotPaths = append(gotPaths, f.Path)
+			}
+			assert.Equal(t, tt.wantPaths, gotPaths)
+			assert.False(t, pr.Files.PageInfo.HasNextPage)
+		})
+	}
+}
+
+func TestPreloadPrCommits(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupPR  func() *api.PullRequest
+		httpStub func(*httpmock.Registry)
+		wantOIDs []string
+	}{
+		{
+			name: "no pagination needed",
+			setupPR: func() *api.PullRequest {
+				pr := &api.PullRequest{}
+				pr.Commits.TotalCount = 1
+				pr.Commits.Nodes = []api.PullRequestCommit{
+					{Commit: api.PullRequestCommitCommit{OID: "aaa"}},
+				}
+				return pr
+			},
+			wantOIDs: []string{"aaa"},
+		},
+		{
+			name: "paginates through additional pages",
+			setupPR: func() *api.PullRequest {
+				pr := &api.PullRequest{ID: "PR_123"}
+				pr.Commits.Nodes = []api.PullRequestCommit{
+					{Commit: api.PullRequestCommitCommit{OID: "aaa"}},
+				}
+				pr.Commits.PageInfo.HasNextPage = true
+				pr.Commits.PageInfo.EndCursor = "page1"
+				return pr
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query CommitsForPullRequest\b`),
+					httpmock.StringResponse(`{"data":{"node":{"commits":{
+						"nodes":[{"commit":{"oid":"bbb","authors":{"nodes":[]},"messageHeadline":"second","messageBody":"","committedDate":"2025-01-01T00:00:00Z","authoredDate":"2025-01-01T00:00:00Z"}}],
+						"pageInfo":{"hasNextPage":true,"endCursor":"page2"}}}}}`),
+				)
+				r.Register(
+					httpmock.GraphQL(`query CommitsForPullRequest\b`),
+					httpmock.StringResponse(`{"data":{"node":{"commits":{
+						"nodes":[{"commit":{"oid":"ccc","authors":{"nodes":[]},"messageHeadline":"third","messageBody":"","committedDate":"2025-01-01T00:00:00Z","authoredDate":"2025-01-01T00:00:00Z"}}],
+						"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`),
+				)
+			},
+			wantOIDs: []string{"aaa", "bbb", "ccc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+			if tt.httpStub != nil {
+				tt.httpStub(reg)
+			}
+
+			client := &http.Client{Transport: reg}
+			repo := ghrepo.New("OWNER", "REPO")
+			pr := tt.setupPR()
+
+			err := preloadPrCommits(client, repo, pr)
+			require.NoError(t, err)
+
+			var gotOIDs []string
+			for _, c := range pr.Commits.Nodes {
+				gotOIDs = append(gotOIDs, c.Commit.OID)
+			}
+			assert.Equal(t, tt.wantOIDs, gotOIDs)
+			assert.Equal(t, len(tt.wantOIDs), pr.Commits.TotalCount)
+			assert.False(t, pr.Commits.PageInfo.HasNextPage)
+		})
+	}
 }

--- a/pkg/cmd/pr/shared/finder_test.go
+++ b/pkg/cmd/pr/shared/finder_test.go
@@ -1016,6 +1016,7 @@ func TestPreloadPrFiles(t *testing.T) {
 		setupPR   func() *api.PullRequest
 		httpStub  func(*httpmock.Registry)
 		wantPaths []string
+		wantErr   bool
 	}{
 		{
 			name: "no pagination needed",
@@ -1055,6 +1056,32 @@ func TestPreloadPrFiles(t *testing.T) {
 			},
 			wantPaths: []string{"file1.go", "file2.go", "file3.go"},
 		},
+		{
+			name: "subsequent page error is returned",
+			setupPR: func() *api.PullRequest {
+				pr := &api.PullRequest{ID: "PR_123"}
+				pr.Files.Nodes = []api.PullRequestFile{
+					{Path: "file1.go"},
+				}
+				pr.Files.PageInfo.HasNextPage = true
+				pr.Files.PageInfo.EndCursor = "page1"
+				return pr
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query FilesForPullRequest\b`),
+					httpmock.StringResponse(`{"data":{"node":{"files":{
+						"nodes":[{"path":"file2.go","additions":5,"deletions":2,"changeType":"ADDED"}],
+						"pageInfo":{"hasNextPage":true,"endCursor":"page2"}}}}}`),
+				)
+				r.Register(
+					httpmock.GraphQL(`query FilesForPullRequest\b`),
+					httpmock.StatusStringResponse(500, "server error"),
+				)
+			},
+			wantPaths: []string{"file1.go", "file2.go"},
+			wantErr:   true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1070,14 +1097,18 @@ func TestPreloadPrFiles(t *testing.T) {
 			pr := tt.setupPR()
 
 			err := preloadPrFiles(client, repo, pr)
-			require.NoError(t, err)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.False(t, pr.Files.PageInfo.HasNextPage)
+			}
 
 			var gotPaths []string
 			for _, f := range pr.Files.Nodes {
 				gotPaths = append(gotPaths, f.Path)
 			}
 			assert.Equal(t, tt.wantPaths, gotPaths)
-			assert.False(t, pr.Files.PageInfo.HasNextPage)
 		})
 	}
 }
@@ -1088,6 +1119,7 @@ func TestPreloadPrCommits(t *testing.T) {
 		setupPR  func() *api.PullRequest
 		httpStub func(*httpmock.Registry)
 		wantOIDs []string
+		wantErr  bool
 	}{
 		{
 			name: "no pagination needed",
@@ -1128,6 +1160,32 @@ func TestPreloadPrCommits(t *testing.T) {
 			},
 			wantOIDs: []string{"aaa", "bbb", "ccc"},
 		},
+		{
+			name: "subsequent page error is returned",
+			setupPR: func() *api.PullRequest {
+				pr := &api.PullRequest{ID: "PR_123"}
+				pr.Commits.Nodes = []api.PullRequestCommit{
+					{Commit: api.PullRequestCommitCommit{OID: "aaa"}},
+				}
+				pr.Commits.PageInfo.HasNextPage = true
+				pr.Commits.PageInfo.EndCursor = "page1"
+				return pr
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query CommitsForPullRequest\b`),
+					httpmock.StringResponse(`{"data":{"node":{"commits":{
+						"nodes":[{"commit":{"oid":"bbb","authors":{"nodes":[]},"messageHeadline":"second","messageBody":"","committedDate":"2025-01-01T00:00:00Z","authoredDate":"2025-01-01T00:00:00Z"}}],
+						"pageInfo":{"hasNextPage":true,"endCursor":"page2"}}}}}`),
+				)
+				r.Register(
+					httpmock.GraphQL(`query CommitsForPullRequest\b`),
+					httpmock.StatusStringResponse(500, "server error"),
+				)
+			},
+			wantOIDs: []string{"aaa", "bbb"},
+			wantErr:  true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1143,15 +1201,19 @@ func TestPreloadPrCommits(t *testing.T) {
 			pr := tt.setupPR()
 
 			err := preloadPrCommits(client, repo, pr)
-			require.NoError(t, err)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, len(tt.wantOIDs), pr.Commits.TotalCount)
+				assert.False(t, pr.Commits.PageInfo.HasNextPage)
+			}
 
 			var gotOIDs []string
 			for _, c := range pr.Commits.Nodes {
 				gotOIDs = append(gotOIDs, c.Commit.OID)
 			}
 			assert.Equal(t, tt.wantOIDs, gotOIDs)
-			assert.Equal(t, len(tt.wantOIDs), pr.Commits.TotalCount)
-			assert.False(t, pr.Commits.PageInfo.HasNextPage)
 		})
 	}
 }


### PR DESCRIPTION
`gh pr view --json files` and `--json commits` silently truncate at 100 items because the initial query never follows pagination.

This adds `PageInfo` to the `Files` and `Commits` structs, requests `pageInfo` in the GraphQL fragments, and adds `preloadPrFiles` / `preloadPrCommits` that page through remaining results in the existing errgroup. This matches the pattern already used by reviews, comments, and closingIssuesReferences.

Also adds the `graphql:"authors(first: 100)"` tag to `PullRequestCommitCommit.Authors` so the struct-based pagination query includes the required argument (the raw GraphQL fragment already had it).

Fixes #13338