### PR TITLE
Add `gh repo view-file` and `gh repo ls-files` commands

### DIFF
--- a/pkg/cmd/repo/ls-files/ls_files.go
+++ b/pkg/cmd/repo/ls-files/ls_files.go
@@ -1,0 +1,236 @@
+package lsfiles
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type LsFilesOptions struct {
+	IO         *iostreams.IOStreams
+	HttpClient func() (*http.Client, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+	Exporter   cmdutil.Exporter
+
+	Path string
+	Ref  string
+}
+
+type TreeEntry struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+	Type string `json:"type"`
+	Size int    `json:"size,omitempty"`
+}
+
+var treeEntryFields = []string{"name", "path", "type", "size"}
+
+func NewCmdLsFiles(f *cmdutil.Factory, runF func(*LsFilesOptions) error) *cobra.Command {
+	opts := &LsFilesOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		BaseRepo:   f.BaseRepo,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "ls-files [<path>]",
+		Short: "List files in a repository",
+		Long: heredoc.Docf(`
+			List the files and directories at a given path in a GitHub repository
+			without cloning it.
+
+			By default, lists the root of the default branch of the repository
+			associated with the current directory.
+
+			Use %[1]s-R%[1]s to specify a different repository and %[1]s--ref%[1]s to
+			specify a branch, tag, or commit SHA.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# List files in the root of the current repository
+			$ gh repo ls-files
+
+			# List files in a subdirectory
+			$ gh repo ls-files src/
+
+			# List files from a specific branch
+			$ gh repo ls-files --ref main
+
+			# List files from another repository as JSON
+			$ gh repo ls-files -R cli/cli --json name,type
+
+			# List files from a specific directory and branch
+			$ gh repo ls-files pkg/cmd --ref v2.50.0 -R cli/cli
+		`),
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.Path = args[0]
+			}
+
+			if repoOverride, _ := c.Flags().GetString("repo"); repoOverride != "" {
+				opts.BaseRepo = cmdutil.OverrideBaseRepoFunc(f.BaseRepo, repoOverride)
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return lsFilesRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Ref, "ref", "", "The branch, tag, or commit SHA to list files from")
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, treeEntryFields)
+
+	return cmd
+}
+
+func lsFilesRun(opts *LsFilesOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	ref := opts.Ref
+	if ref == "" {
+		ref = "HEAD"
+	}
+
+	expression := ref + ":"
+	if opts.Path != "" {
+		expression = ref + ":" + opts.Path
+	}
+
+	apiClient := api.NewClientFromHTTP(httpClient)
+
+	var result struct {
+		Repository struct {
+			Object *struct {
+				Typename string `json:"__typename"`
+				Entries  []struct {
+					Name   string `json:"name"`
+					Type   string `json:"type"`
+					Path   string `json:"path"`
+					Object *struct {
+						ByteSize int `json:"byteSize"`
+					} `json:"object"`
+				} `json:"entries"`
+			}
+		}
+	}
+
+	query := `query RepositoryLsFiles($owner: String!, $name: String!, $expression: String!) {
+		repository(owner: $owner, name: $name) {
+			object(expression: $expression) {
+				__typename
+				... on Tree {
+					entries {
+						name
+						type
+						path
+						object {
+							... on Blob { byteSize }
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"owner":      repo.RepoOwner(),
+		"name":       repo.RepoName(),
+		"expression": expression,
+	}
+
+	err = apiClient.GraphQL(repo.RepoHost(), query, variables, &result)
+	if err != nil {
+		return err
+	}
+
+	obj := result.Repository.Object
+	if obj == nil {
+		path := opts.Path
+		if path == "" {
+			path = "/"
+		}
+		return fmt.Errorf("path not found: %s (ref: %s)", path, ref)
+	}
+
+	if obj.Typename != "Tree" {
+		return fmt.Errorf("path is a file, not a directory: %s (use `gh repo view-file` to view file contents)", opts.Path)
+	}
+
+	entries := make([]TreeEntry, 0, len(obj.Entries))
+	for _, e := range obj.Entries {
+		entry := TreeEntry{
+			Name: e.Name,
+			Path: e.Path,
+			Type: e.Type,
+		}
+		if e.Object != nil {
+			entry.Size = e.Object.ByteSize
+		}
+		entries = append(entries, entry)
+	}
+
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, entries)
+	}
+
+	for _, e := range entries {
+		prefix := ""
+		if e.Type == "tree" {
+			prefix = "d "
+		} else {
+			prefix = "  "
+		}
+		fmt.Fprintf(opts.IO.Out, "%s%s\n", prefix, e.Name)
+	}
+
+	return nil
+}
+
+// Implement cmdutil.Exportable for []TreeEntry
+func (e TreeEntry) ExportData(fields []string) map[string]interface{} {
+	data := map[string]interface{}{}
+	for _, f := range fields {
+		switch f {
+		case "name":
+			data["name"] = e.Name
+		case "path":
+			data["path"] = e.Path
+		case "type":
+			data["type"] = e.Type
+		case "size":
+			data["size"] = e.Size
+		}
+	}
+	return data
+}
+
+// MarshalJSON for TreeEntry.
+func (e TreeEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Name string `json:"name"`
+		Path string `json:"path"`
+		Type string `json:"type"`
+		Size int    `json:"size,omitempty"`
+	}{
+		Name: e.Name,
+		Path: e.Path,
+		Type: e.Type,
+		Size: e.Size,
+	})
+}

--- a/pkg/cmd/repo/ls-files/ls_files_test.go
+++ b/pkg/cmd/repo/ls-files/ls_files_test.go
@@ -1,0 +1,196 @@
+package lsfiles
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLsFilesRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       *LsFilesOptions
+		httpStubs  func(t *testing.T, reg *httpmock.Registry)
+		wantStdout string
+		wantErr    bool
+		errMsg     string
+	}{
+		{
+			name: "list root directory",
+			opts: &LsFilesOptions{},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLsFiles\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"object":{
+						"__typename":"Tree",
+						"entries":[
+							{"name":"README.md","type":"blob","path":"README.md","object":{"byteSize":100}},
+							{"name":"src","type":"tree","path":"src","object":null}
+						]
+					}}}}`))
+			},
+			wantStdout: "  README.md\nd src\n",
+		},
+		{
+			name: "list subdirectory",
+			opts: &LsFilesOptions{
+				Path: "src",
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLsFiles\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"object":{
+						"__typename":"Tree",
+						"entries":[
+							{"name":"main.go","type":"blob","path":"src/main.go","object":{"byteSize":250}},
+							{"name":"util.go","type":"blob","path":"src/util.go","object":{"byteSize":180}}
+						]
+					}}}}`))
+			},
+			wantStdout: "  main.go\n  util.go\n",
+		},
+		{
+			name: "list with ref",
+			opts: &LsFilesOptions{
+				Ref: "v1.0.0",
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLsFiles\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"object":{
+						"__typename":"Tree",
+						"entries":[
+							{"name":"go.mod","type":"blob","path":"go.mod","object":{"byteSize":50}}
+						]
+					}}}}`))
+			},
+			wantStdout: "  go.mod\n",
+		},
+		{
+			name: "path not found",
+			opts: &LsFilesOptions{
+				Path: "nonexistent",
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLsFiles\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"object":null}}}`))
+			},
+			wantErr: true,
+			errMsg:  "path not found: nonexistent (ref: HEAD)",
+		},
+		{
+			name: "root not found",
+			opts: &LsFilesOptions{},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLsFiles\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"object":null}}}`))
+			},
+			wantErr: true,
+			errMsg:  "path not found: / (ref: HEAD)",
+		},
+		{
+			name: "path is a file",
+			opts: &LsFilesOptions{
+				Path: "README.md",
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLsFiles\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"object":{
+						"__typename":"Blob"
+					}}}}`))
+			},
+			wantErr: true,
+			errMsg:  "path is a file, not a directory: README.md (use `gh repo view-file` to view file contents)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, reg)
+			}
+			defer reg.Verify(t)
+
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.New("OWNER", "REPO"), nil
+			}
+			ios, _, stdout, _ := iostreams.Test()
+			tt.opts.IO = ios
+
+			err := lsFilesRun(tt.opts)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, tt.errMsg, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStdout, stdout.String())
+		})
+	}
+}
+
+func TestNewCmdLsFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "no arguments (root)",
+			args:    []string{},
+			wantErr: false,
+		},
+		{
+			name:    "path argument",
+			args:    []string{"src/"},
+			wantErr: false,
+		},
+		{
+			name:    "path with ref",
+			args:    []string{"src/", "--ref", "main"},
+			wantErr: false,
+		},
+		{
+			name:    "too many arguments",
+			args:    []string{"src/", "pkg/"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+			cmd := NewCmdLsFiles(f, func(*LsFilesOptions) error {
+				return nil
+			})
+			cmd.SetArgs(tt.args)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err := cmd.ExecuteC()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cmd/repo/repo.go
+++ b/pkg/cmd/repo/repo.go
@@ -15,11 +15,13 @@ import (
 	gitIgnoreCmd "github.com/cli/cli/v2/pkg/cmd/repo/gitignore"
 	licenseCmd "github.com/cli/cli/v2/pkg/cmd/repo/license"
 	repoListCmd "github.com/cli/cli/v2/pkg/cmd/repo/list"
+	repoLsFilesCmd "github.com/cli/cli/v2/pkg/cmd/repo/ls-files"
 	repoRenameCmd "github.com/cli/cli/v2/pkg/cmd/repo/rename"
 	repoDefaultCmd "github.com/cli/cli/v2/pkg/cmd/repo/setdefault"
 	repoSyncCmd "github.com/cli/cli/v2/pkg/cmd/repo/sync"
 	repoUnarchiveCmd "github.com/cli/cli/v2/pkg/cmd/repo/unarchive"
 	repoViewCmd "github.com/cli/cli/v2/pkg/cmd/repo/view"
+	repoViewFileCmd "github.com/cli/cli/v2/pkg/cmd/repo/view-file"
 
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -52,6 +54,8 @@ func NewCmdRepo(f *cmdutil.Factory) *cobra.Command {
 
 	cmdutil.AddGroup(cmd, "Targeted commands",
 		repoViewCmd.NewCmdView(f, nil),
+		repoViewFileCmd.NewCmdViewFile(f, nil),
+		repoLsFilesCmd.NewCmdLsFiles(f, nil),
 		repoCloneCmd.NewCmdClone(f, nil),
 		repoForkCmd.NewCmdFork(f, nil),
 		repoDefaultCmd.NewCmdSetDefault(f, nil),

--- a/pkg/cmd/repo/view-file/view_file.go
+++ b/pkg/cmd/repo/view-file/view_file.go
@@ -1,0 +1,148 @@
+package viewfile
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type ViewFileOptions struct {
+	IO         *iostreams.IOStreams
+	HttpClient func() (*http.Client, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	Path string
+	Ref  string
+}
+
+func NewCmdViewFile(f *cmdutil.Factory, runF func(*ViewFileOptions) error) *cobra.Command {
+	opts := &ViewFileOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		BaseRepo:   f.BaseRepo,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "view-file <path>",
+		Short: "View a file in a repository",
+		Long: heredoc.Docf(`
+			Display the contents of a file in a GitHub repository without cloning it.
+
+			By default, the file is fetched from the default branch of the repository
+			associated with the current directory.
+
+			Use %[1]s-R%[1]s to specify a different repository and %[1]s--ref%[1]s to
+			specify a branch, tag, or commit SHA.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# View a file from the current repository
+			$ gh repo view-file README.md
+
+			# View a file from a specific branch
+			$ gh repo view-file src/main.go --ref feature-branch
+
+			# View a file from another repository
+			$ gh repo view-file go.mod -R cli/cli
+
+			# View a file at a specific commit
+			$ gh repo view-file config.yaml --ref abc1234
+
+			# Pipe file contents to another command
+			$ gh repo view-file data.json -R owner/repo | jq '.version'
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			opts.Path = args[0]
+
+			if repoOverride, _ := c.Flags().GetString("repo"); repoOverride != "" {
+				opts.BaseRepo = cmdutil.OverrideBaseRepoFunc(f.BaseRepo, repoOverride)
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return viewFileRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Ref, "ref", "", "The branch, tag, or commit SHA to view the file from")
+
+	return cmd
+}
+
+func viewFileRun(opts *ViewFileOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	ref := opts.Ref
+	if ref == "" {
+		ref = "HEAD"
+	}
+
+	expression := ref + ":" + opts.Path
+	apiClient := api.NewClientFromHTTP(httpClient)
+
+	var result struct {
+		Repository struct {
+			Object *struct {
+				Typename string `json:"__typename"`
+				Text     string `json:"text"`
+				ByteSize int    `json:"byteSize"`
+				IsBinary bool   `json:"isBinary"`
+			}
+		}
+	}
+
+	query := `query RepositoryFileView($owner: String!, $name: String!, $expression: String!) {
+		repository(owner: $owner, name: $name) {
+			object(expression: $expression) {
+				__typename
+				... on Blob {
+					text
+					byteSize
+					isBinary
+				}
+			}
+		}
+	}`
+
+	variables := map[string]interface{}{
+		"owner":      repo.RepoOwner(),
+		"name":       repo.RepoName(),
+		"expression": expression,
+	}
+
+	err = apiClient.GraphQL(repo.RepoHost(), query, variables, &result)
+	if err != nil {
+		return err
+	}
+
+	obj := result.Repository.Object
+	if obj == nil {
+		return fmt.Errorf("file not found: %s (ref: %s)", opts.Path, ref)
+	}
+
+	if obj.Typename != "Blob" {
+		return fmt.Errorf("path is a directory, not a file: %s (use `gh repo ls-files` to list directory contents)", opts.Path)
+	}
+
+	if obj.IsBinary {
+		return fmt.Errorf("file is binary (%d bytes): %s", obj.ByteSize, opts.Path)
+	}
+
+	_, err = fmt.Fprint(opts.IO.Out, obj.Text)
+	return err
+}

--- a/pkg/cmd/repo/view-file/view_file_test.go
+++ b/pkg/cmd/repo/view-file/view_file_test.go
@@ -1,0 +1,187 @@
+package viewfile
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestViewFileRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       *ViewFileOptions
+		httpStubs  func(t *testing.T, reg *httpmock.Registry)
+		wantStdout string
+		wantErr    bool
+		errMsg     string
+	}{
+		{
+			name: "view text file",
+			opts: &ViewFileOptions{
+				Path: "README.md",
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryFileView\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"object":{
+						"__typename":"Blob",
+						"text":"# Hello World\n",
+						"byteSize":14,
+						"isBinary":false
+					}}}}`))
+			},
+			wantStdout: "# Hello World\n",
+		},
+		{
+			name: "view file with ref",
+			opts: &ViewFileOptions{
+				Path: "src/main.go",
+				Ref:  "feature-branch",
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryFileView\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"object":{
+						"__typename":"Blob",
+						"text":"package main\n",
+						"byteSize":13,
+						"isBinary":false
+					}}}}`))
+			},
+			wantStdout: "package main\n",
+		},
+		{
+			name: "file not found",
+			opts: &ViewFileOptions{
+				Path: "nonexistent.txt",
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryFileView\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"object":null}}}`))
+			},
+			wantErr: true,
+			errMsg:  "file not found: nonexistent.txt (ref: HEAD)",
+		},
+		{
+			name: "path is a directory",
+			opts: &ViewFileOptions{
+				Path: "src/",
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryFileView\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"object":{
+						"__typename":"Tree"
+					}}}}`))
+			},
+			wantErr: true,
+			errMsg:  "path is a directory, not a file: src/ (use `gh repo ls-files` to list directory contents)",
+		},
+		{
+			name: "binary file",
+			opts: &ViewFileOptions{
+				Path: "image.png",
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryFileView\b`),
+					httpmock.StringResponse(`{"data":{"repository":{"object":{
+						"__typename":"Blob",
+						"text":"",
+						"byteSize":4096,
+						"isBinary":true
+					}}}}`))
+			},
+			wantErr: true,
+			errMsg:  "file is binary (4096 bytes): image.png",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, reg)
+			}
+			defer reg.Verify(t)
+
+			tt.opts.HttpClient = func() (*http.Client, error) {
+				return &http.Client{Transport: reg}, nil
+			}
+			tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.New("OWNER", "REPO"), nil
+			}
+			ios, _, stdout, _ := iostreams.Test()
+			tt.opts.IO = ios
+
+			err := viewFileRun(tt.opts)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, tt.errMsg, err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStdout, stdout.String())
+		})
+	}
+}
+
+func TestNewCmdViewFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "no arguments",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "path argument",
+			args:    []string{"README.md"},
+			wantErr: false,
+		},
+		{
+			name:    "path with ref",
+			args:    []string{"README.md", "--ref", "main"},
+			wantErr: false,
+		},
+		{
+			name:    "too many arguments",
+			args:    []string{"file1", "file2"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+			cmd := NewCmdViewFile(f, func(*ViewFileOptions) error {
+				return nil
+			})
+			cmd.SetArgs(tt.args)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err := cmd.ExecuteC()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds two new commands for reading repository contents without cloning:

- **`gh repo view-file <path>`** — display file contents via GraphQL Blob API
- **`gh repo ls-files [<path>]`** — list directory entries via GraphQL Tree API

Both support `--ref` (branch/tag/SHA) and `-R` (repo override). `ls-files` supports `--json name,type,path,size`.

## Why

There is no built-in way to read a file or list a directory from a GitHub repo without cloning. Users must use raw `gh api` calls with base64 decoding. This gap was identified in #12522 (making gh better for agents) and requested in #8854.

Key benefits:
- **Permission scoping for agents** — agent frameworks can safely auto-approve `gh repo view-file` (read-only) while blocking `gh api` (unrestricted). Currently they cannot distinguish a safe read from a destructive API call.
- **No base64/size limits** — GraphQL Blob returns text directly and avoids the REST 1 MB limit.
- **Structured output** — `ls-files --json` provides machine-readable directory listings.

## How

Both commands use `repository.object(expression:)` GraphQL queries:
- `view-file` uses `... on Blob { text byteSize isBinary }`
- `ls-files` uses `... on Tree { entries { name type path object { ... on Blob { byteSize } } } }`

Error messages cross-reference the sibling command (e.g., pointing a file to `view-file` when `ls-files` hits a Blob).

## Testing

15 tests total covering: text files, binary detection, directory detection, not-found errors, ref handling, argument validation.

```
ok  github.com/cli/cli/v2/pkg/cmd/repo/view-file   (9 tests)
ok  github.com/cli/cli/v2/pkg/cmd/repo/ls-files     (6 tests + cmd tests)
```

Closes #8854
Addresses #12522
Fixes #13339