### PR TITLE
browse: disambiguate decimal-only short SHAs from issue numbers

### DIFF
--- a/api/queries_repo.go
+++ b/api/queries_repo.go
@@ -1685,6 +1685,26 @@ func RepoExists(client *Client, repo ghrepo.Interface) (bool, error) {
 	}
 }
 
+func CommitExists(client *Client, repo ghrepo.Interface, ref string) (bool, error) {
+	path := fmt.Sprintf("repos/%s/%s/commits/%s", repo.RepoOwner(), repo.RepoName(), ref)
+
+	resp, err := client.HTTP().Head(ghinstance.RESTPrefix(repo.RepoHost()) + path)
+	if err != nil {
+		return false, err
+	}
+
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case 200:
+		return true, nil
+	case 404, 422:
+		return false, nil
+	default:
+		return false, ghAPI.HandleHTTPError(resp)
+	}
+}
+
 // RepoLicenses fetches available repository licenses.
 // It uses API v3 because licenses are not supported by GraphQL.
 func RepoLicenses(httpClient *http.Client, hostname string) ([]License, error) {

--- a/api/queries_repo_test.go
+++ b/api/queries_repo_test.go
@@ -823,6 +823,79 @@ func TestRepoExists(t *testing.T) {
 	}
 }
 
+func TestCommitExists(t *testing.T) {
+	tests := []struct {
+		name       string
+		httpStub   func(*httpmock.Registry)
+		existCheck bool
+		wantErrMsg string
+	}{
+		{
+			name: "commit exists",
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("HEAD", "repos/OWNER/REPO/commits/309628980"),
+					httpmock.StringResponse("{}"),
+				)
+			},
+			existCheck: true,
+		},
+		{
+			name: "commit not found",
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("HEAD", "repos/OWNER/REPO/commits/1234567"),
+					httpmock.StatusStringResponse(404, "Not Found"),
+				)
+			},
+			existCheck: false,
+		},
+		{
+			name: "unprocessable ref",
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("HEAD", "repos/OWNER/REPO/commits/1234567"),
+					httpmock.StatusStringResponse(422, "Unprocessable Entity"),
+				)
+			},
+			existCheck: false,
+		},
+		{
+			name: "http error",
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("HEAD", "repos/OWNER/REPO/commits/1234567"),
+					httpmock.StatusStringResponse(500, "Internal Server Error"),
+				)
+			},
+			existCheck: false,
+			wantErrMsg: "HTTP 500 (https://api.github.com/repos/OWNER/REPO/commits/1234567)",
+		},
+	}
+	for _, tt := range tests {
+		reg := &httpmock.Registry{}
+		if tt.httpStub != nil {
+			tt.httpStub(reg)
+		}
+
+		client := newTestClient(reg)
+		ref := "309628980"
+		if !tt.existCheck || tt.wantErrMsg != "" {
+			ref = "1234567"
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			exist, err := CommitExists(client, ghrepo.New("OWNER", "REPO"), ref)
+			if tt.wantErrMsg != "" {
+				assert.Equal(t, tt.wantErrMsg, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.existCheck, exist)
+		})
+	}
+}
+
 func TestForkRepoReturnsErrorWhenForkIsNotPossible(t *testing.T) {
 	// Given our API returns 202 with a Fork that is the same as
 	// the repo we provided

--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -250,6 +250,22 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 			return "", nil
 		}
 		if isNumber(opts.SelectorArg) {
+			// A selector without a "#" prefix that satisfies both isNumber and
+			// isCommit is ambiguous (e.g. "309628980"). Disambiguate via API.
+			if !strings.HasPrefix(opts.SelectorArg, "#") && isCommit(opts.SelectorArg) {
+				httpClient, err := opts.HttpClient()
+				if err != nil {
+					return "", err
+				}
+				apiClient := api.NewClientFromHTTP(httpClient)
+				exists, err := api.CommitExists(apiClient, baseRepo, opts.SelectorArg)
+				if err != nil {
+					return "", err
+				}
+				if exists {
+					return fmt.Sprintf("commit/%s", opts.SelectorArg), nil
+				}
+			}
 			return fmt.Sprintf("issues/%s", strings.TrimPrefix(opts.SelectorArg, "#")), nil
 		}
 		if isCommit(opts.SelectorArg) {

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -674,6 +674,45 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL: "https://github.com/owner/repo/blame/abc123/src/app.js#L50",
 			wantsErr:    false,
 		},
+		{
+			name: "decimal-only short SHA that is a valid commit",
+			opts: BrowseOptions{
+				SelectorArg: "309628980",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("HEAD", "repos/cli/cli/commits/309628980"),
+					httpmock.StatusStringResponse(200, ""),
+				)
+			},
+			baseRepo:    ghrepo.New("cli", "cli"),
+			expectedURL: "https://github.com/cli/cli/commit/309628980",
+			wantsErr:    false,
+		},
+		{
+			name: "decimal-only string that is not a valid commit",
+			opts: BrowseOptions{
+				SelectorArg: "1234567",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("HEAD", "repos/cli/cli/commits/1234567"),
+					httpmock.StatusStringResponse(404, ""),
+				)
+			},
+			baseRepo:    ghrepo.New("cli", "cli"),
+			expectedURL: "https://github.com/cli/cli/issues/1234567",
+			wantsErr:    false,
+		},
+		{
+			name: "decimal-only short SHA with # prefix forces issue",
+			opts: BrowseOptions{
+				SelectorArg: "#309628980",
+			},
+			baseRepo:    ghrepo.New("cli", "cli"),
+			expectedURL: "https://github.com/cli/cli/issues/309628980",
+			wantsErr:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #12357

## Summary

When a selector argument passed to `gh browse` consists entirely of decimal digits and is at least 7 characters long (e.g. `309628980`), it satisfies both `isNumber` and `isCommit`. Previously `isNumber` was always checked first, so `gh browse 309628980` would open an issues URL even when that string referred to an actual commit SHA.

This PR disambiguates only in the ambiguous case by checking the commits API:

- If the selector has no `#` prefix **and** satisfies both `isNumber` and `isCommit`, call `HEAD /repos/{owner}/{repo}/commits/{ref}`
- If the commit exists (HTTP 200), open the commit URL
- If the commit does not exist (HTTP 404/422), fall back to the issues URL
- The `#` prefix still forces issue behavior
- No API call is made for unambiguous inputs (non-decimal hex chars, short numbers under 7 digits, or `#`-prefixed args)

## Acceptance Criteria Coverage

**AC1: Ambiguous decimal-only short hash that IS a valid commit**
API returns 200 → `parseSection` returns `commit/309628980`. Covered by test case "decimal-only short SHA that is a valid commit".

**AC2: Ambiguous decimal-only string that is NOT a valid commit**
API returns 404 → `parseSection` falls through to `issues/1234567`. Covered by test case "decimal-only string that is not a valid commit".

**AC3: `#` prefix forces issue**
The `strings.HasPrefix(opts.SelectorArg, "#")` check short-circuits before any API call. Covered by test case "decimal-only short SHA with # prefix forces issue".

## Changes

| File | Change |
|---|---|
| `api/queries_repo.go` | Add `CommitExists` helper (mirrors existing `RepoExists` pattern) |
| `pkg/cmd/browse/browse.go` | Disambiguate when selector is both numeric and commit-like |
| `pkg/cmd/browse/browse_test.go` | Three new test cases covering all acceptance criteria |

## Validation

```
$ go test ./pkg/cmd/browse/... ./api/...
ok   github.com/cli/cli/v2/pkg/cmd/browse
ok   github.com/cli/cli/v2/api

$ go vet ./pkg/cmd/browse/... ./api/...
(clean)

$ go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0 run ./pkg/cmd/browse/... ./api/...
0 issues.
```