### PR TITLE
fix: prevent visibility change on forked repositories in repo edit

### DIFF
--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -257,6 +257,7 @@ func editRun(ctx context.Context, opts *EditOptions) error {
 			// TODO: GitHub Enterprise Server does not support has_discussions yet
 			// "hasDiscussionsEnabled",
 			"homepageUrl",
+			"isFork",
 			"isInOrganization",
 			"isTemplate",
 			"mergeCommitAllowed",
@@ -295,6 +296,17 @@ func editRun(ctx context.Context, opts *EditOptions) error {
 		}
 		if !repo.ViewerCanAdminister {
 			return fmt.Errorf("you do not have sufficient permissions to edit repository security and analysis features")
+		}
+	}
+
+	if !opts.InteractiveMode && opts.Edits.Visibility != nil {
+		apiClient := api.NewClientFromHTTP(opts.HTTPClient)
+		fetchedRepo, err := api.FetchRepository(apiClient, opts.Repository, []string{"isFork"})
+		if err != nil {
+			return err
+		}
+		if fetchedRepo.IsFork {
+			return fmt.Errorf("cannot change the visibility of a forked repository")
 		}
 	}
 
@@ -453,6 +465,9 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 			}
 			opts.Edits.EnableProjects = &a
 		case optionVisibility:
+			if r.IsFork {
+				return fmt.Errorf("cannot change the visibility of a forked repository")
+			}
 			cs := opts.IO.ColorScheme()
 			fmt.Fprintf(opts.IO.ErrOut, "%s Danger zone: changing repository visibility can have unexpected consequences; consult https://gh.io/setting-repository-visibility before continuing.\n", cs.WarningIcon())
 

--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -387,13 +387,20 @@ func interactiveChoice(p iprompter, r *api.Repository) ([]string, error) {
 	if r.IsInOrganization {
 		options = append(options, optionAllowForking)
 	}
+	var filteredOptions []string
+	for _, o := range options {
+		if o == optionVisibility && r.IsFork {
+			continue
+		}
+		filteredOptions = append(filteredOptions, o)
+	}
 	var answers []string
-	selected, err := p.MultiSelect("What do you want to edit?", nil, options)
+	selected, err := p.MultiSelect("What do you want to edit?", nil, filteredOptions)
 	if err != nil {
 		return nil, err
 	}
 	for _, i := range selected {
-		answers = append(answers, options[i])
+		answers = append(answers, filteredOptions[i])
 	}
 
 	return answers, err
@@ -465,9 +472,6 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 			}
 			opts.Edits.EnableProjects = &a
 		case optionVisibility:
-			if r.IsFork {
-				return fmt.Errorf("cannot change the visibility of a forked repository")
-			}
 			cs := opts.IO.ColorScheme()
 			fmt.Fprintf(opts.IO.ErrOut, "%s Danger zone: changing repository visibility can have unexpected consequences; consult https://gh.io/setting-repository-visibility before continuing.\n", cs.WarningIcon())
 

--- a/pkg/cmd/repo/edit/edit_test.go
+++ b/pkg/cmd/repo/edit/edit_test.go
@@ -709,10 +709,23 @@ func Test_editRun_interactive(t *testing.T) {
 				InteractiveMode: true,
 			},
 			promptStubs: func(pm *prompter.MockPrompter) {
-				pm.RegisterMultiSelect("What do you want to edit?", nil, editList,
-					func(_ string, _, opts []string) ([]int, error) {
-						return []int{8}, nil
-					})
+				// Verify that "Visibility" is not in the list of options
+				pm.RegisterMultiSelect("What do you want to edit?", nil, []string{
+					"Default Branch Name",
+					"Description",
+					"Home Page URL",
+					"Issues",
+					"Merge Options",
+					"Projects",
+					"Template Repository",
+					"Topics",
+					"Wikis",
+				}, func(_ string, _, _ []string) ([]int, error) {
+					return []int{1}, nil // Select Description instead
+				})
+				pm.RegisterInput("Description of the repository", func(_, _ string) (string, error) {
+					return "new description", nil
+				})
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
@@ -735,8 +748,13 @@ func Test_editRun_interactive(t *testing.T) {
 							}
 						}
 					}`))
+				reg.Register(
+					httpmock.REST("PATCH", "repos/OWNER/REPO"),
+					httpmock.RESTPayload(200, `{}`, func(payload map[string]interface{}) {
+						assert.Equal(t, "new description", payload["description"])
+						assert.NotContains(t, payload, "visibility")
+					}))
 			},
-			wantsErr: "cannot change the visibility of a forked repository",
 		},
 		{
 			name: "updates repo merge options without squash",

--- a/pkg/cmd/repo/edit/edit_test.go
+++ b/pkg/cmd/repo/edit/edit_test.go
@@ -308,6 +308,28 @@ func Test_editRun(t *testing.T) {
 			},
 			wantsErr: "you do not have sufficient permissions to edit repository security and analysis features",
 		},
+		{
+			name: "non-interactive visibility change on fork",
+			opts: EditOptions{
+				Repository: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
+				Edits: EditRepositoryInput{
+					Visibility: sp("private"),
+				},
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryInfo\b`),
+					httpmock.StringResponse(`
+					{
+						"data": {
+							"repository": {
+								"isFork": true
+							}
+						}
+					}`))
+			},
+			wantsErr: "cannot change the visibility of a forked repository",
+		},
 	}
 
 	for _, tt := range tests {
@@ -679,6 +701,42 @@ func Test_editRun_interactive(t *testing.T) {
 						assert.Equal(t, []interface{}{"a", "b", "c", "d"}, payload["names"])
 					}))
 			},
+		},
+		{
+			name: "visibility change on fork",
+			opts: EditOptions{
+				Repository:      ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
+				InteractiveMode: true,
+			},
+			promptStubs: func(pm *prompter.MockPrompter) {
+				pm.RegisterMultiSelect("What do you want to edit?", nil, editList,
+					func(_ string, _, opts []string) ([]int, error) {
+						return []int{8}, nil
+					})
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryInfo\b`),
+					httpmock.StringResponse(`
+					{
+						"data": {
+							"repository": {
+								"isFork": true,
+								"visibility": "public",
+								"description": "description",
+								"homePageUrl": "https://url.com",
+								"defaultBranchRef": {
+									"name": "main"
+								},
+								"isInOrganization": false,
+								"repositoryTopics": {
+									"nodes": []
+								}
+							}
+						}
+					}`))
+			},
+			wantsErr: "cannot change the visibility of a forked repository",
 		},
 		{
 			name: "updates repo merge options without squash",


### PR DESCRIPTION
Fixes #13233.

Previously, `gh repo edit` would report success when attempting to change the visibility of a fork, even though the change was silently ignored by the API (since forks follow their upstream repository's visibility).

This PR adds a local check to:
1. Block the 'Visibility' option in interactive mode if the repo is a fork.
2. Return an error if `--visibility` is used non-interactively on a fork.

Added test cases to verify both interactive and non-interactive error handling.