### PR TITLE
fix(telemetry): prevent tzutil console flash on Windows

### DIFF
--- a/internal/telemetry/detach_windows.go
+++ b/internal/telemetry/detach_windows.go
@@ -10,7 +10,15 @@ import (
 
 // detachAttrs returns SysProcAttr configured to place the child in its own
 // process group so that console signals (Ctrl+C) delivered to the parent's
-// group are not forwarded to the child.
+// group are not forwarded to the child, and to suppress any console window
+// for the child and its descendants.
+//
+// CREATE_NO_WINDOW is preferred over DETACHED_PROCESS here: DETACHED_PROCESS
+// removes the console entirely, which causes any console-subsystem descendant
+// (e.g. tzutil.exe invoked transitively to resolve the local IANA timezone)
+// to allocate a fresh conhost window, producing a visible flash on every gh
+// invocation. CREATE_NO_WINDOW gives the child a non-visible console that
+// descendants can inherit, avoiding the flash.
 func detachAttrs() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS}
+	return &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_NO_WINDOW}
 }


### PR DESCRIPTION
Fixes #13354

## Summary

On Windows, every `gh` invocation that records telemetry produces a brief console window flash. The flash is `tzutil.exe /g` being spawned by the `gh send-telemetry` subprocess to resolve the local IANA timezone (via the transitive dependency `github.com/thlib/go-timezone-local`).

With Windows Terminal configured to keep windows open after exit (e.g. `closeOnExit: never`), these conhost instances accumulate.

## Root cause

`internal/telemetry/detach_windows.go` spawns the telemetry subprocess with `DETACHED_PROCESS`. Per the [Win32 process creation flags reference](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags):

- **`DETACHED_PROCESS`** — child has no console at all. Any console-subsystem descendant (`tzutil.exe`) then allocates a fresh conhost on first stdio access, producing the visible flash.
- **`CREATE_NO_WINDOW`** — child runs as a console application *without* a visible console window. Descendants inherit the non-visible console and don't allocate a new one.

`DETACHED_PROCESS` and `CREATE_NO_WINDOW` are mutually exclusive. `CREATE_NEW_PROCESS_GROUP` remains compatible with the chosen flag.

## Reproduction

Captured process tree on Windows 11:

    gh.exe (parent shell invocation)
    └── gh.exe send-telemetry    (spawned with DETACHED_PROCESS — no console)
        └── tzutil.exe /g        (allocates fresh conhost — visible flash)

`gh send-telemetry` invokes `tzlocal.localTZfromTzutil()` from `github.com/thlib/go-timezone-local`, which performs `exec.Command("tzutil", "/g")` with no Windows-specific window-suppression flags — so the inherited (absent) console determines visibility.

## Fix

Replace `DETACHED_PROCESS` with `CREATE_NO_WINDOW`. Single-line behavioural change plus an explanatory comment.