### PR TITLE
feat: add gh discussion create command

### DIFF
--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -907,6 +907,16 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 		return nil, fmt.Errorf("the '%s/%s' repository has discussions disabled", repo.RepoOwner(), repo.RepoName())
 	}
 
+	// Resolve labels before creating the discussion so that an unknown label
+	// name aborts without leaving a half-created discussion behind.
+	var resolvedLabels []DiscussionLabel
+	if len(input.Labels) > 0 {
+		resolvedLabels, err = c.resolveLabels(repo, input.Labels)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	var mutation struct {
 		CreateDiscussion struct {
 			Discussion struct {
@@ -941,11 +951,7 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 		})
 	}
 
-	if len(input.Labels) > 0 {
-		resolvedLabels, err := c.resolveLabels(repo, input.Labels)
-		if err != nil {
-			return nil, err
-		}
+	if len(resolvedLabels) > 0 {
 		labelIDs := make([]string, len(resolvedLabels))
 		for i, l := range resolvedLabels {
 			labelIDs[i] = l.ID

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -2934,7 +2934,7 @@ func TestCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "label not found returns error",
+			name: "label not found returns error without creating discussion",
 			input: CreateDiscussionInput{
 				CategoryID: "CAT_1",
 				Title:      "Test",
@@ -2946,38 +2946,8 @@ func TestCreate(t *testing.T) {
 					httpmock.GraphQL(`query RepositoryMeta\b`),
 					httpmock.StringResponse(repoMetaResp("R_1", true)),
 				)
-				reg.Register(
-					httpmock.GraphQL(`mutation CreateDiscussion\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"createDiscussion": {
-									"discussion": {
-										"id": "D_new",
-										"number": 99,
-										"title": "Test",
-										"body": "Body",
-										"url": "https://github.com/OWNER/REPO/discussions/99",
-										"closed": false,
-										"stateReason": "",
-										"isAnswered": false,
-										"answerChosenAt": "0001-01-01T00:00:00Z",
-										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
-										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": ":speech_balloon:", "isAnswerable": false},
-										"answerChosenBy": null,
-										"labels": {"nodes": []},
-										"reactionGroups": [],
-										"createdAt": "2025-06-01T00:00:00Z",
-										"updatedAt": "2025-06-01T00:00:00Z",
-										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false,
-										"comments": {"totalCount": 0}
-									}
-								}
-							}
-						}
-					`)),
-				)
+				// No CreateDiscussion stub — reg.Verify(t) proves it is never called,
+				// confirming that label validation is atomic with discussion creation.
 				reg.Register(
 					httpmock.GraphQL(`query RepositoryLabels\b`),
 					httpmock.StringResponse(heredoc.Doc(`

--- a/pkg/cmd/discussion/create/create.go
+++ b/pkg/cmd/discussion/create/create.go
@@ -57,6 +57,22 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 		Args: cmdutil.NoArgsQuoteReminder,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.BaseRepo = f.BaseRepo
+
+			if opts.Title != "" && strings.TrimSpace(opts.Title) == "" {
+				return cmdutil.FlagErrorf("title cannot be blank")
+			}
+			if opts.Body != "" && strings.TrimSpace(opts.Body) == "" {
+				return cmdutil.FlagErrorf("body cannot be blank")
+			}
+			if opts.Category != "" && strings.TrimSpace(opts.Category) == "" {
+				return cmdutil.FlagErrorf("category cannot be blank")
+			}
+
+			needsInput := opts.Title == "" || opts.Category == "" || opts.Body == ""
+			if needsInput && !opts.IO.CanPrompt() {
+				return cmdutil.FlagErrorf("--title, --body, and --category are required when not running interactively")
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -83,36 +99,19 @@ func createRun(opts *CreateOptions) error {
 		return err
 	}
 
-	interactive := opts.IO.CanPrompt()
-
-	if !interactive {
-		if opts.Title == "" {
-			return cmdutil.FlagErrorf("--title required when not running interactively")
-		}
-		if opts.Category == "" {
-			return cmdutil.FlagErrorf("--category required when not running interactively")
-		}
-		if opts.Body == "" {
-			return cmdutil.FlagErrorf("--body required when not running interactively")
-		}
-	}
-
 	categories, err := c.ListCategories(repo)
 	if err != nil {
 		return fmt.Errorf("fetching categories: %w", err)
 	}
 
 	if opts.Title == "" {
-		if !interactive {
-			return cmdutil.FlagErrorf("--title required when not running interactively")
-		}
 		opts.Title, err = opts.Prompter.Input("Discussion title", "")
 		if err != nil {
 			return err
 		}
-	}
-	if strings.TrimSpace(opts.Title) == "" {
-		return cmdutil.FlagErrorf("title cannot be blank")
+		if strings.TrimSpace(opts.Title) == "" {
+			return fmt.Errorf("title cannot be blank")
+		}
 	}
 
 	var category *client.DiscussionCategory
@@ -122,9 +121,6 @@ func createRun(opts *CreateOptions) error {
 			return err
 		}
 	} else {
-		if !interactive {
-			return cmdutil.FlagErrorf("--category required when not running interactively")
-		}
 		names := make([]string, len(categories))
 		for i, cat := range categories {
 			names[i] = cat.Name
@@ -137,12 +133,12 @@ func createRun(opts *CreateOptions) error {
 	}
 
 	if opts.Body == "" {
-		if !interactive {
-			return cmdutil.FlagErrorf("--body required when not running interactively")
-		}
 		opts.Body, err = opts.Prompter.MarkdownEditor("Discussion body", "", false)
 		if err != nil {
 			return err
+		}
+		if strings.TrimSpace(opts.Body) == "" {
+			return fmt.Errorf("body cannot be blank")
 		}
 	}
 
@@ -160,11 +156,10 @@ func createRun(opts *CreateOptions) error {
 
 	if opts.IO.IsStdoutTTY() {
 		cs := opts.IO.ColorScheme()
-		fmt.Fprintf(opts.IO.Out, "%s Created discussion #%d: %s\n",
-			cs.SuccessIcon(), discussion.Number, discussion.URL)
-	} else {
-		fmt.Fprintln(opts.IO.Out, discussion.URL)
+		fmt.Fprintf(opts.IO.ErrOut, "%s Created discussion #%d\n",
+			cs.SuccessIcon(), discussion.Number)
 	}
+	fmt.Fprintln(opts.IO.Out, discussion.URL)
 
 	return nil
 }

--- a/pkg/cmd/discussion/create/create.go
+++ b/pkg/cmd/discussion/create/create.go
@@ -40,7 +40,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a new discussion",
+		Short: "Create a new discussion (preview)",
 		Long: heredoc.Doc(`
 			Create a new GitHub Discussion in a repository.
 

--- a/pkg/cmd/discussion/create/create.go
+++ b/pkg/cmd/discussion/create/create.go
@@ -101,7 +101,9 @@ func createRun(opts *CreateOptions) error {
 		return err
 	}
 
+	opts.IO.StartProgressIndicator()
 	categories, err := c.ListCategories(repo)
+	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("fetching categories: %w", err)
 	}
@@ -151,7 +153,9 @@ func createRun(opts *CreateOptions) error {
 		Labels:     opts.Labels,
 	}
 
+	opts.IO.StartProgressIndicator()
 	discussion, err := c.Create(repo, input)
+	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return fmt.Errorf("failed to create discussion: %w", err)
 	}

--- a/pkg/cmd/discussion/create/create.go
+++ b/pkg/cmd/discussion/create/create.go
@@ -153,14 +153,9 @@ func createRun(opts *CreateOptions) error {
 
 	discussion, err := c.Create(repo, input)
 	if err != nil {
-		return fmt.Errorf("creating discussion: %w", err)
+		return fmt.Errorf("failed to create discussion: %w", err)
 	}
 
-	if opts.IO.IsStdoutTTY() {
-		cs := opts.IO.ColorScheme()
-		fmt.Fprintf(opts.IO.ErrOut, "%s Created discussion #%d\n",
-			cs.SuccessIcon(), discussion.Number)
-	}
 	fmt.Fprintln(opts.IO.Out, discussion.URL)
 
 	return nil

--- a/pkg/cmd/discussion/create/create.go
+++ b/pkg/cmd/discussion/create/create.go
@@ -80,6 +80,8 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 		},
 	}
 
+	cmdutil.EnableRepoOverride(cmd, f)
+
 	cmd.Flags().StringVarP(&opts.Title, "title", "t", "", "Title for the discussion")
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Body for the discussion")
 	cmd.Flags().StringVarP(&opts.Category, "category", "c", "", "Category name or slug for the discussion")

--- a/pkg/cmd/discussion/create/create.go
+++ b/pkg/cmd/discussion/create/create.go
@@ -1,0 +1,161 @@
+package create
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+// CreateOptions holds the configuration for the discussion create command.
+type CreateOptions struct {
+	IO         *iostreams.IOStreams
+	HttpClient func() (*http.Client, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+	Client     func() (client.DiscussionClient, error)
+	Prompter   prompter.Prompter
+
+	Title    string
+	Body     string
+	Category string
+	Labels   []string
+}
+
+// NewCmdCreate returns a cobra command for creating a GitHub Discussion.
+func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
+	opts := &CreateOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Prompter:   f.Prompter,
+		Client:     shared.DiscussionClientFunc(f),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new discussion",
+		Long: heredoc.Doc(`
+			Create a new GitHub Discussion in a repository.
+
+			With '--title' and '--category', a discussion is created non-interactively.
+			Omitting either flag triggers interactive prompts when connected to a terminal.
+
+			The '--body' flag provides the discussion body. Without it you will be
+			prompted to enter one in your default editor.
+		`),
+		Example: heredoc.Doc(`
+			# Create interactively
+			$ gh discussion create
+
+			# Create non-interactively
+			$ gh discussion create --title "My question" --category "Q&A" --body "Details here"
+		`),
+		Args: cmdutil.NoArgsQuoteReminder,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.BaseRepo = f.BaseRepo
+			if runF != nil {
+				return runF(opts)
+			}
+			return createRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Title, "title", "t", "", "Title for the discussion")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Body for the discussion")
+	cmd.Flags().StringVarP(&opts.Category, "category", "c", "", "Category name or slug for the discussion")
+	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Labels to apply to the discussion")
+
+	return cmd
+}
+
+func createRun(opts *CreateOptions) error {
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	c, err := opts.Client()
+	if err != nil {
+		return err
+	}
+
+	categories, err := c.ListCategories(repo)
+	if err != nil {
+		return fmt.Errorf("fetching categories: %w", err)
+	}
+
+	interactive := opts.IO.CanPrompt()
+
+	if opts.Title == "" {
+		if !interactive {
+			return cmdutil.FlagErrorf("--title required when not running interactively")
+		}
+		opts.Title, err = opts.Prompter.Input("Discussion title", "")
+		if err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(opts.Title) == "" {
+		return cmdutil.FlagErrorf("title cannot be blank")
+	}
+
+	var category *client.DiscussionCategory
+	if opts.Category != "" {
+		category, err = shared.MatchCategory(opts.Category, categories)
+		if err != nil {
+			return err
+		}
+	} else {
+		if !interactive {
+			return cmdutil.FlagErrorf("--category required when not running interactively")
+		}
+		names := make([]string, len(categories))
+		for i, cat := range categories {
+			names[i] = cat.Name
+		}
+		idx, err := opts.Prompter.Select("Discussion category", "", names)
+		if err != nil {
+			return err
+		}
+		category = &categories[idx]
+	}
+
+	if opts.Body == "" {
+		if !interactive {
+			return cmdutil.FlagErrorf("--body required when not running interactively")
+		}
+		opts.Body, err = opts.Prompter.MarkdownEditor("Discussion body", "", true)
+		if err != nil {
+			return err
+		}
+	}
+
+	input := client.CreateDiscussionInput{
+		CategoryID: category.ID,
+		Title:      opts.Title,
+		Body:       opts.Body,
+		Labels:     opts.Labels,
+	}
+
+	discussion, err := c.Create(repo, input)
+	if err != nil {
+		return fmt.Errorf("creating discussion: %w", err)
+	}
+
+	if opts.IO.IsStdoutTTY() {
+		cs := opts.IO.ColorScheme()
+		fmt.Fprintf(opts.IO.Out, "%s Created discussion #%d: %s\n",
+			cs.SuccessIcon(), discussion.Number, discussion.URL)
+	} else {
+		fmt.Fprintln(opts.IO.Out, discussion.URL)
+	}
+
+	return nil
+}

--- a/pkg/cmd/discussion/create/create.go
+++ b/pkg/cmd/discussion/create/create.go
@@ -44,11 +44,8 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 		Long: heredoc.Doc(`
 			Create a new GitHub Discussion in a repository.
 
-			With '--title' and '--category', a discussion is created non-interactively.
-			Omitting either flag triggers interactive prompts when connected to a terminal.
-
-			The '--body' flag provides the discussion body. Without it you will be
-			prompted to enter one in your default editor.
+			With '--title', '--body', and '--category', a discussion is created non-interactively.
+			Omitting any of these flags triggers interactive prompts when connected to a terminal.
 		`),
 		Example: heredoc.Doc(`
 			# Create interactively
@@ -86,12 +83,24 @@ func createRun(opts *CreateOptions) error {
 		return err
 	}
 
+	interactive := opts.IO.CanPrompt()
+
+	if !interactive {
+		if opts.Title == "" {
+			return cmdutil.FlagErrorf("--title required when not running interactively")
+		}
+		if opts.Category == "" {
+			return cmdutil.FlagErrorf("--category required when not running interactively")
+		}
+		if opts.Body == "" {
+			return cmdutil.FlagErrorf("--body required when not running interactively")
+		}
+	}
+
 	categories, err := c.ListCategories(repo)
 	if err != nil {
 		return fmt.Errorf("fetching categories: %w", err)
 	}
-
-	interactive := opts.IO.CanPrompt()
 
 	if opts.Title == "" {
 		if !interactive {
@@ -131,7 +140,7 @@ func createRun(opts *CreateOptions) error {
 		if !interactive {
 			return cmdutil.FlagErrorf("--body required when not running interactively")
 		}
-		opts.Body, err = opts.Prompter.MarkdownEditor("Discussion body", "", true)
+		opts.Body, err = opts.Prompter.MarkdownEditor("Discussion body", "", false)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/discussion/create/create_test.go
+++ b/pkg/cmd/discussion/create/create_test.go
@@ -33,11 +33,12 @@ func sampleDiscussion() *client.Discussion {
 
 func TestNewCmdCreate(t *testing.T) {
 	tests := []struct {
-		name     string
-		args     string
-		isTTY    bool
-		wantOpts CreateOptions
-		wantErr  string
+		name         string
+		args         string
+		isTTY        bool
+		wantOpts     CreateOptions
+		wantBaseRepo ghrepo.Interface
+		wantErr      string
 	}{
 		{
 			name:     "no flags",
@@ -86,6 +87,17 @@ func TestNewCmdCreate(t *testing.T) {
 			isTTY:   true,
 			wantErr: "body cannot be blank",
 		},
+		{
+			name:         "repo override",
+			args:         "--title 'Test' --body 'Body' --category 'Q&A' -R OWNER/REPO",
+			isTTY:        true,
+			wantBaseRepo: ghrepo.New("OWNER", "REPO"),
+			wantOpts: CreateOptions{
+				Title:    "Test",
+				Body:     "Body",
+				Category: "Q&A",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -94,9 +106,9 @@ func TestNewCmdCreate(t *testing.T) {
 			ios.SetStdinTTY(tt.isTTY)
 			ios.SetStdoutTTY(tt.isTTY)
 			f := &cmdutil.Factory{IOStreams: ios}
-			var capturedOpts *CreateOptions
+			var gotOpts *CreateOptions
 			cmd := NewCmdCreate(f, func(opts *CreateOptions) error {
-				capturedOpts = opts
+				gotOpts = opts
 				return nil
 			})
 			cmd.SetIn(&bytes.Buffer{})
@@ -114,10 +126,16 @@ func TestNewCmdCreate(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantOpts.Title, capturedOpts.Title)
-			assert.Equal(t, tt.wantOpts.Body, capturedOpts.Body)
-			assert.Equal(t, tt.wantOpts.Category, capturedOpts.Category)
-			assert.Equal(t, tt.wantOpts.Labels, capturedOpts.Labels)
+			assert.Equal(t, tt.wantOpts.Title, gotOpts.Title)
+			assert.Equal(t, tt.wantOpts.Body, gotOpts.Body)
+			assert.Equal(t, tt.wantOpts.Category, gotOpts.Category)
+			assert.Equal(t, tt.wantOpts.Labels, gotOpts.Labels)
+
+			if tt.wantBaseRepo != nil {
+				baseRepo, err := gotOpts.BaseRepo()
+				require.NoError(t, err)
+				assert.True(t, ghrepo.IsSame(tt.wantBaseRepo, baseRepo))
+			}
 		})
 	}
 }

--- a/pkg/cmd/discussion/create/create_test.go
+++ b/pkg/cmd/discussion/create/create_test.go
@@ -151,12 +151,8 @@ func TestCreateRun_nonInteractive(t *testing.T) {
 				Body:     "Details",
 				Category: "General",
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
-				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
-					return sampleCategories(), nil
-				}
-			},
-			wantErr: "--title required when not running interactively",
+			setupMock: func(m *client.DiscussionClientMock) {},
+			wantErr:   "--title required when not running interactively",
 		},
 		{
 			name: "missing category returns error",
@@ -164,12 +160,8 @@ func TestCreateRun_nonInteractive(t *testing.T) {
 				Title: "My question",
 				Body:  "Details",
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
-				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
-					return sampleCategories(), nil
-				}
-			},
-			wantErr: "--category required when not running interactively",
+			setupMock: func(m *client.DiscussionClientMock) {},
+			wantErr:   "--category required when not running interactively",
 		},
 		{
 			name: "missing body returns error",
@@ -177,12 +169,8 @@ func TestCreateRun_nonInteractive(t *testing.T) {
 				Title:    "My question",
 				Category: "General",
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
-				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
-					return sampleCategories(), nil
-				}
-			},
-			wantErr: "--body required when not running interactively",
+			setupMock: func(m *client.DiscussionClientMock) {},
+			wantErr:   "--body required when not running interactively",
 		},
 		{
 			name: "unknown category returns error",
@@ -282,6 +270,7 @@ func TestCreateRun_tty(t *testing.T) {
 			return 0, nil
 		},
 		MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
+			assert.False(t, blankAllowed, "body editor should not allow blank input")
 			return "Some body text", nil
 		},
 	}
@@ -335,4 +324,33 @@ func TestCreateRun_tty_partialFlags(t *testing.T) {
 	err := createRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Created discussion #5")
+}
+
+func TestCreateRun_tty_blankTitle(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	ios.SetStdoutTTY(true)
+	ios.SetStdinTTY(true)
+
+	mockClient := &client.DiscussionClientMock{
+		ListCategoriesFunc: func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+			return sampleCategories(), nil
+		},
+	}
+
+	pm := &prompter.PrompterMock{
+		InputFunc: func(prompt, defaultValue string) (string, error) {
+			return "   ", nil // whitespace only
+		},
+	}
+
+	opts := &CreateOptions{
+		IO:       ios,
+		BaseRepo: func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil },
+		Client:   func() (client.DiscussionClient, error) { return mockClient, nil },
+		Prompter: pm,
+	}
+
+	err := createRun(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "title cannot be blank")
 }

--- a/pkg/cmd/discussion/create/create_test.go
+++ b/pkg/cmd/discussion/create/create_test.go
@@ -35,41 +35,65 @@ func TestNewCmdCreate(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     string
+		isTTY    bool
 		wantOpts CreateOptions
 		wantErr  string
 	}{
 		{
 			name:     "no flags",
 			args:     "",
+			isTTY:    true,
 			wantOpts: CreateOptions{},
 		},
 		{
-			name: "title flag",
-			args: "--title 'My question'",
-			wantOpts: CreateOptions{
-				Title: "My question",
-			},
-		},
-		{
-			name: "all flags",
-			args: "--title 'My question' --body 'Details' --category 'Q&A' --label bug",
+			name:  "all flags",
+			args:  "--title 'My question' --body 'Details' --category 'Q&A' --label bug,enhancement",
+			isTTY: true,
 			wantOpts: CreateOptions{
 				Title:    "My question",
 				Body:     "Details",
 				Category: "Q&A",
-				Labels:   []string{"bug"},
+				Labels:   []string{"bug", "enhancement"},
 			},
 		},
 		{
 			name:    "extra args",
 			args:    "extra",
+			isTTY:   true,
 			wantErr: "unknown argument",
+		},
+		{
+			name:    "missing required flags non-interactively",
+			args:    "--title 'My question'",
+			isTTY:   false,
+			wantErr: "--title, --body, and --category are required when not running interactively",
+		},
+		{
+			name:    "blank title",
+			args:    "--title '   '",
+			isTTY:   true,
+			wantErr: "title cannot be blank",
+		},
+		{
+			name:    "blank category",
+			args:    "--category '   '",
+			isTTY:   true,
+			wantErr: "category cannot be blank",
+		},
+		{
+			name:    "blank body",
+			args:    "--body '   '",
+			isTTY:   true,
+			wantErr: "body cannot be blank",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := &cmdutil.Factory{}
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStdoutTTY(tt.isTTY)
+			f := &cmdutil.Factory{IOStreams: ios}
 			var capturedOpts *CreateOptions
 			cmd := NewCmdCreate(f, func(opts *CreateOptions) error {
 				capturedOpts = opts
@@ -146,33 +170,6 @@ func TestCreateRun_nonInteractive(t *testing.T) {
 			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
 		},
 		{
-			name: "missing title returns error",
-			opts: CreateOptions{
-				Body:     "Details",
-				Category: "General",
-			},
-			setupMock: func(m *client.DiscussionClientMock) {},
-			wantErr:   "--title required when not running interactively",
-		},
-		{
-			name: "missing category returns error",
-			opts: CreateOptions{
-				Title: "My question",
-				Body:  "Details",
-			},
-			setupMock: func(m *client.DiscussionClientMock) {},
-			wantErr:   "--category required when not running interactively",
-		},
-		{
-			name: "missing body returns error",
-			opts: CreateOptions{
-				Title:    "My question",
-				Category: "General",
-			},
-			setupMock: func(m *client.DiscussionClientMock) {},
-			wantErr:   "--body required when not running interactively",
-		},
-		{
 			name: "unknown category returns error",
 			opts: CreateOptions{
 				Title:    "My question",
@@ -245,7 +242,7 @@ func TestCreateRun_nonInteractive(t *testing.T) {
 }
 
 func TestCreateRun_tty(t *testing.T) {
-	ios, _, stdout, _ := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 	ios.SetStdoutTTY(true)
 	ios.SetStdinTTY(true)
 
@@ -284,13 +281,13 @@ func TestCreateRun_tty(t *testing.T) {
 
 	err := createRun(opts)
 	require.NoError(t, err)
-	assert.Contains(t, stdout.String(), "Created discussion #5")
-	assert.Contains(t, stdout.String(), "https://github.com/OWNER/REPO/discussions/5")
+	assert.Contains(t, stderr.String(), "Created discussion #5")
+	assert.Equal(t, "https://github.com/OWNER/REPO/discussions/5\n", stdout.String())
 }
 
 func TestCreateRun_tty_partialFlags(t *testing.T) {
 	// Title and body provided, category via prompt
-	ios, _, stdout, _ := iostreams.Test()
+	ios, _, stdout, stderr := iostreams.Test()
 	ios.SetStdoutTTY(true)
 	ios.SetStdinTTY(true)
 
@@ -323,7 +320,8 @@ func TestCreateRun_tty_partialFlags(t *testing.T) {
 
 	err := createRun(opts)
 	require.NoError(t, err)
-	assert.Contains(t, stdout.String(), "Created discussion #5")
+	assert.Contains(t, stderr.String(), "Created discussion #5")
+	assert.Equal(t, "https://github.com/OWNER/REPO/discussions/5\n", stdout.String())
 }
 
 func TestCreateRun_tty_blankTitle(t *testing.T) {

--- a/pkg/cmd/discussion/create/create_test.go
+++ b/pkg/cmd/discussion/create/create_test.go
@@ -15,22 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func sampleCategories() []client.DiscussionCategory {
-	return []client.DiscussionCategory{
-		{ID: "CAT1", Name: "General", Slug: "general"},
-		{ID: "CAT2", Name: "Q&A", Slug: "q-a"},
-		{ID: "CAT3", Name: "Show and tell", Slug: "show-and-tell"},
-	}
-}
-
-func sampleDiscussion() *client.Discussion {
-	return &client.Discussion{
-		Number: 5,
-		Title:  "My question",
-		URL:    "https://github.com/OWNER/REPO/discussions/5",
-	}
-}
-
 func TestNewCmdCreate(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -140,16 +124,18 @@ func TestNewCmdCreate(t *testing.T) {
 	}
 }
 
-func TestCreateRun_nonInteractive(t *testing.T) {
+func TestCreateRun(t *testing.T) {
 	tests := []struct {
 		name      string
 		opts      CreateOptions
+		isTTY     bool
+		setupMock func(*client.DiscussionClientMock)
+		prompter  *prompter.PrompterMock
 		wantErr   string
 		wantOut   string
-		setupMock func(*client.DiscussionClientMock)
 	}{
 		{
-			name: "creates discussion successfully",
+			name: "success non-tty",
 			opts: CreateOptions{
 				Title:    "My question",
 				Body:     "Details",
@@ -169,26 +155,26 @@ func TestCreateRun_nonInteractive(t *testing.T) {
 			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
 		},
 		{
-			name: "creates with label",
+			name: "success non-tty with label",
 			opts: CreateOptions{
 				Title:    "Feature request",
 				Body:     "Details",
 				Category: "general",
-				Labels:   []string{"enhancement"},
+				Labels:   []string{"enhancement", "bug"},
 			},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
 					return sampleCategories(), nil
 				}
 				m.CreateFunc = func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
-					assert.Equal(t, []string{"enhancement"}, input.Labels)
+					assert.Equal(t, []string{"enhancement", "bug"}, input.Labels)
 					return sampleDiscussion(), nil
 				}
 			},
 			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
 		},
 		{
-			name: "unknown category returns error",
+			name: "non-tty unknown category",
 			opts: CreateOptions{
 				Title:    "My question",
 				Body:     "Details",
@@ -202,7 +188,7 @@ func TestCreateRun_nonInteractive(t *testing.T) {
 			wantErr: `unknown category: "nonexistent"`,
 		},
 		{
-			name: "ListCategories error propagates",
+			name: "non-tty list categories query errors",
 			opts: CreateOptions{
 				Title:    "My question",
 				Body:     "Details",
@@ -216,7 +202,7 @@ func TestCreateRun_nonInteractive(t *testing.T) {
 			wantErr: "fetching categories: network error",
 		},
 		{
-			name: "Create error propagates",
+			name: "non-tty create mutation errors",
 			opts: CreateOptions{
 				Title:    "My question",
 				Body:     "Details",
@@ -230,22 +216,189 @@ func TestCreateRun_nonInteractive(t *testing.T) {
 					return nil, fmt.Errorf("mutation failed")
 				}
 			},
-			wantErr: "creating discussion: mutation failed",
+			wantErr: "failed to create discussion: mutation failed",
+		},
+		{
+			name:  "tty prompts for all fields",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.CreateFunc = func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, "My question", input.Title)
+					assert.Equal(t, "CAT1", input.CategoryID)
+					assert.Equal(t, "Some body text", input.Body)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				InputFunc: func(prompt, defaultValue string) (string, error) {
+					return "My question", nil
+				},
+				SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
+					assert.Equal(t, []string{"General", "Q&A", "Show and tell"}, options)
+					return 0, nil
+				},
+				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
+					assert.False(t, blankAllowed, "body editor should not allow blank input")
+					return "Some body text", nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty does not prompt when all flags provided",
+			isTTY: true,
+			opts: CreateOptions{
+				Title:    "My question",
+				Body:     "Details",
+				Category: "Q&A",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.CreateFunc = func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, "CAT2", input.CategoryID)
+					assert.Equal(t, "My question", input.Title)
+					assert.Equal(t, "Details", input.Body)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty partial flags prompts only for missing category",
+			isTTY: true,
+			opts: CreateOptions{
+				Title: "Pre-filled title",
+				Body:  "Pre-filled body",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.CreateFunc = func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, "Pre-filled title", input.Title)
+					assert.Equal(t, "CAT2", input.CategoryID)
+					assert.Equal(t, "Pre-filled body", input.Body)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
+					return 1, nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty partial flags prompts only for missing body",
+			isTTY: true,
+			opts: CreateOptions{
+				Title:    "Pre-filled title",
+				Category: "Q&A",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.CreateFunc = func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, "Pre-filled title", input.Title)
+					assert.Equal(t, "CAT2", input.CategoryID)
+					assert.Equal(t, "Prompted body", input.Body)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
+					return "Prompted body", nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty partial flags prompts only for missing title",
+			isTTY: true,
+			opts: CreateOptions{
+				Body:     "Pre-filled body",
+				Category: "General",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.CreateFunc = func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, "Prompted title", input.Title)
+					assert.Equal(t, "CAT1", input.CategoryID)
+					assert.Equal(t, "Pre-filled body", input.Body)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				InputFunc: func(prompt, defaultValue string) (string, error) {
+					return "Prompted title", nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty blank title returns error",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				InputFunc: func(prompt, defaultValue string) (string, error) {
+					return "   ", nil
+				},
+			},
+			wantErr: "title cannot be blank",
+		},
+		{
+			name:  "tty blank body returns error",
+			isTTY: true,
+			opts: CreateOptions{
+				Title:    "Valid title",
+				Category: "General",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
+					return "   ", nil
+				},
+			},
+			wantErr: "body cannot be blank",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ios, _, stdout, _ := iostreams.Test()
-			// non-interactive: no TTY
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
 
 			mockClient := &client.DiscussionClientMock{}
 			tt.setupMock(mockClient)
 
 			opts := tt.opts
 			opts.IO = ios
-			opts.BaseRepo = func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil }
-			opts.Client = func() (client.DiscussionClient, error) { return mockClient, nil }
+			opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.New("OWNER", "REPO"), nil
+			}
+			opts.Client = func() (client.DiscussionClient, error) {
+				return mockClient, nil
+			}
+			if tt.prompter != nil {
+				opts.Prompter = tt.prompter
+			}
 
 			err := createRun(&opts)
 			if tt.wantErr != "" {
@@ -259,114 +412,18 @@ func TestCreateRun_nonInteractive(t *testing.T) {
 	}
 }
 
-func TestCreateRun_tty(t *testing.T) {
-	ios, _, stdout, stderr := iostreams.Test()
-	ios.SetStdoutTTY(true)
-	ios.SetStdinTTY(true)
-
-	mockClient := &client.DiscussionClientMock{
-		ListCategoriesFunc: func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
-			return sampleCategories(), nil
-		},
-		CreateFunc: func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
-			assert.Equal(t, "My question", input.Title)
-			assert.Equal(t, "CAT1", input.CategoryID)
-			assert.Equal(t, "Some body text", input.Body)
-			return sampleDiscussion(), nil
-		},
+func sampleCategories() []client.DiscussionCategory {
+	return []client.DiscussionCategory{
+		{ID: "CAT1", Name: "General", Slug: "general"},
+		{ID: "CAT2", Name: "Q&A", Slug: "q-a"},
+		{ID: "CAT3", Name: "Show and tell", Slug: "show-and-tell"},
 	}
-
-	pm := &prompter.PrompterMock{
-		InputFunc: func(prompt, defaultValue string) (string, error) {
-			return "My question", nil
-		},
-		SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
-			assert.Equal(t, []string{"General", "Q&A", "Show and tell"}, options)
-			return 0, nil
-		},
-		MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
-			assert.False(t, blankAllowed, "body editor should not allow blank input")
-			return "Some body text", nil
-		},
-	}
-
-	opts := &CreateOptions{
-		IO:       ios,
-		BaseRepo: func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil },
-		Client:   func() (client.DiscussionClient, error) { return mockClient, nil },
-		Prompter: pm,
-	}
-
-	err := createRun(opts)
-	require.NoError(t, err)
-	assert.Contains(t, stderr.String(), "Created discussion #5")
-	assert.Equal(t, "https://github.com/OWNER/REPO/discussions/5\n", stdout.String())
 }
 
-func TestCreateRun_tty_partialFlags(t *testing.T) {
-	// Title and body provided, category via prompt
-	ios, _, stdout, stderr := iostreams.Test()
-	ios.SetStdoutTTY(true)
-	ios.SetStdinTTY(true)
-
-	mockClient := &client.DiscussionClientMock{
-		ListCategoriesFunc: func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
-			return sampleCategories(), nil
-		},
-		CreateFunc: func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
-			assert.Equal(t, "Pre-filled title", input.Title)
-			assert.Equal(t, "CAT2", input.CategoryID)
-			assert.Equal(t, "Pre-filled body", input.Body)
-			return sampleDiscussion(), nil
-		},
+func sampleDiscussion() *client.Discussion {
+	return &client.Discussion{
+		Number: 5,
+		Title:  "My question",
+		URL:    "https://github.com/OWNER/REPO/discussions/5",
 	}
-
-	pm := &prompter.PrompterMock{
-		SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
-			return 1, nil // select Q&A
-		},
-	}
-
-	opts := &CreateOptions{
-		IO:       ios,
-		BaseRepo: func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil },
-		Client:   func() (client.DiscussionClient, error) { return mockClient, nil },
-		Prompter: pm,
-		Title:    "Pre-filled title",
-		Body:     "Pre-filled body",
-	}
-
-	err := createRun(opts)
-	require.NoError(t, err)
-	assert.Contains(t, stderr.String(), "Created discussion #5")
-	assert.Equal(t, "https://github.com/OWNER/REPO/discussions/5\n", stdout.String())
-}
-
-func TestCreateRun_tty_blankTitle(t *testing.T) {
-	ios, _, _, _ := iostreams.Test()
-	ios.SetStdoutTTY(true)
-	ios.SetStdinTTY(true)
-
-	mockClient := &client.DiscussionClientMock{
-		ListCategoriesFunc: func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
-			return sampleCategories(), nil
-		},
-	}
-
-	pm := &prompter.PrompterMock{
-		InputFunc: func(prompt, defaultValue string) (string, error) {
-			return "   ", nil // whitespace only
-		},
-	}
-
-	opts := &CreateOptions{
-		IO:       ios,
-		BaseRepo: func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil },
-		Client:   func() (client.DiscussionClient, error) { return mockClient, nil },
-		Prompter: pm,
-	}
-
-	err := createRun(opts)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "title cannot be blank")
 }

--- a/pkg/cmd/discussion/create/create_test.go
+++ b/pkg/cmd/discussion/create/create_test.go
@@ -1,0 +1,338 @@
+package create
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleCategories() []client.DiscussionCategory {
+	return []client.DiscussionCategory{
+		{ID: "CAT1", Name: "General", Slug: "general"},
+		{ID: "CAT2", Name: "Q&A", Slug: "q-a"},
+		{ID: "CAT3", Name: "Show and tell", Slug: "show-and-tell"},
+	}
+}
+
+func sampleDiscussion() *client.Discussion {
+	return &client.Discussion{
+		Number: 5,
+		Title:  "My question",
+		URL:    "https://github.com/OWNER/REPO/discussions/5",
+	}
+}
+
+func TestNewCmdCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     string
+		wantOpts CreateOptions
+		wantErr  string
+	}{
+		{
+			name:     "no flags",
+			args:     "",
+			wantOpts: CreateOptions{},
+		},
+		{
+			name: "title flag",
+			args: "--title 'My question'",
+			wantOpts: CreateOptions{
+				Title: "My question",
+			},
+		},
+		{
+			name: "all flags",
+			args: "--title 'My question' --body 'Details' --category 'Q&A' --label bug",
+			wantOpts: CreateOptions{
+				Title:    "My question",
+				Body:     "Details",
+				Category: "Q&A",
+				Labels:   []string{"bug"},
+			},
+		},
+		{
+			name:    "extra args",
+			args:    "extra",
+			wantErr: "unknown argument",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &cmdutil.Factory{}
+			var capturedOpts *CreateOptions
+			cmd := NewCmdCreate(f, func(opts *CreateOptions) error {
+				capturedOpts = opts
+				return nil
+			})
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			argv, err := shlex.Split(tt.args)
+			require.NoError(t, err)
+			cmd.SetArgs(argv)
+
+			_, err = cmd.ExecuteC()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOpts.Title, capturedOpts.Title)
+			assert.Equal(t, tt.wantOpts.Body, capturedOpts.Body)
+			assert.Equal(t, tt.wantOpts.Category, capturedOpts.Category)
+			assert.Equal(t, tt.wantOpts.Labels, capturedOpts.Labels)
+		})
+	}
+}
+
+func TestCreateRun_nonInteractive(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      CreateOptions
+		wantErr   string
+		wantOut   string
+		setupMock func(*client.DiscussionClientMock)
+	}{
+		{
+			name: "creates discussion successfully",
+			opts: CreateOptions{
+				Title:    "My question",
+				Body:     "Details",
+				Category: "Q&A",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.CreateFunc = func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, "CAT2", input.CategoryID)
+					assert.Equal(t, "My question", input.Title)
+					assert.Equal(t, "Details", input.Body)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "creates with label",
+			opts: CreateOptions{
+				Title:    "Feature request",
+				Body:     "Details",
+				Category: "general",
+				Labels:   []string{"enhancement"},
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.CreateFunc = func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, []string{"enhancement"}, input.Labels)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "missing title returns error",
+			opts: CreateOptions{
+				Body:     "Details",
+				Category: "General",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+			},
+			wantErr: "--title required when not running interactively",
+		},
+		{
+			name: "missing category returns error",
+			opts: CreateOptions{
+				Title: "My question",
+				Body:  "Details",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+			},
+			wantErr: "--category required when not running interactively",
+		},
+		{
+			name: "missing body returns error",
+			opts: CreateOptions{
+				Title:    "My question",
+				Category: "General",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+			},
+			wantErr: "--body required when not running interactively",
+		},
+		{
+			name: "unknown category returns error",
+			opts: CreateOptions{
+				Title:    "My question",
+				Body:     "Details",
+				Category: "nonexistent",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+			},
+			wantErr: `unknown category: "nonexistent"`,
+		},
+		{
+			name: "ListCategories error propagates",
+			opts: CreateOptions{
+				Title:    "My question",
+				Body:     "Details",
+				Category: "General",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return nil, fmt.Errorf("network error")
+				}
+			},
+			wantErr: "fetching categories: network error",
+		},
+		{
+			name: "Create error propagates",
+			opts: CreateOptions{
+				Title:    "My question",
+				Body:     "Details",
+				Category: "General",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.CreateFunc = func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
+					return nil, fmt.Errorf("mutation failed")
+				}
+			},
+			wantErr: "creating discussion: mutation failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, stdout, _ := iostreams.Test()
+			// non-interactive: no TTY
+
+			mockClient := &client.DiscussionClientMock{}
+			tt.setupMock(mockClient)
+
+			opts := tt.opts
+			opts.IO = ios
+			opts.BaseRepo = func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil }
+			opts.Client = func() (client.DiscussionClient, error) { return mockClient, nil }
+
+			err := createRun(&opts)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOut, stdout.String())
+		})
+	}
+}
+
+func TestCreateRun_tty(t *testing.T) {
+	ios, _, stdout, _ := iostreams.Test()
+	ios.SetStdoutTTY(true)
+	ios.SetStdinTTY(true)
+
+	mockClient := &client.DiscussionClientMock{
+		ListCategoriesFunc: func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+			return sampleCategories(), nil
+		},
+		CreateFunc: func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
+			assert.Equal(t, "My question", input.Title)
+			assert.Equal(t, "CAT1", input.CategoryID)
+			assert.Equal(t, "Some body text", input.Body)
+			return sampleDiscussion(), nil
+		},
+	}
+
+	pm := &prompter.PrompterMock{
+		InputFunc: func(prompt, defaultValue string) (string, error) {
+			return "My question", nil
+		},
+		SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
+			assert.Equal(t, []string{"General", "Q&A", "Show and tell"}, options)
+			return 0, nil
+		},
+		MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
+			return "Some body text", nil
+		},
+	}
+
+	opts := &CreateOptions{
+		IO:       ios,
+		BaseRepo: func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil },
+		Client:   func() (client.DiscussionClient, error) { return mockClient, nil },
+		Prompter: pm,
+	}
+
+	err := createRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Created discussion #5")
+	assert.Contains(t, stdout.String(), "https://github.com/OWNER/REPO/discussions/5")
+}
+
+func TestCreateRun_tty_partialFlags(t *testing.T) {
+	// Title and body provided, category via prompt
+	ios, _, stdout, _ := iostreams.Test()
+	ios.SetStdoutTTY(true)
+	ios.SetStdinTTY(true)
+
+	mockClient := &client.DiscussionClientMock{
+		ListCategoriesFunc: func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+			return sampleCategories(), nil
+		},
+		CreateFunc: func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
+			assert.Equal(t, "Pre-filled title", input.Title)
+			assert.Equal(t, "CAT2", input.CategoryID)
+			assert.Equal(t, "Pre-filled body", input.Body)
+			return sampleDiscussion(), nil
+		},
+	}
+
+	pm := &prompter.PrompterMock{
+		SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
+			return 1, nil // select Q&A
+		},
+	}
+
+	opts := &CreateOptions{
+		IO:       ios,
+		BaseRepo: func() (ghrepo.Interface, error) { return ghrepo.New("OWNER", "REPO"), nil },
+		Client:   func() (client.DiscussionClient, error) { return mockClient, nil },
+		Prompter: pm,
+		Title:    "Pre-filled title",
+		Body:     "Pre-filled body",
+	}
+
+	err := createRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Created discussion #5")
+}

--- a/pkg/cmd/discussion/discussion.go
+++ b/pkg/cmd/discussion/discussion.go
@@ -2,6 +2,7 @@ package discussion
 
 import (
 	"github.com/MakeNowJust/heredoc"
+	cmdCreate "github.com/cli/cli/v2/pkg/cmd/discussion/create"
 	cmdList "github.com/cli/cli/v2/pkg/cmd/discussion/list"
 	cmdView "github.com/cli/cli/v2/pkg/cmd/discussion/view"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -34,6 +35,7 @@ func NewCmdDiscussion(f *cmdutil.Factory) *cobra.Command {
 	cmdutil.EnableRepoOverride(cmd, f)
 
 	cmdutil.AddGroup(cmd, "General commands",
+		cmdCreate.NewCmdCreate(f, nil),
 		cmdList.NewCmdList(f, nil),
 	)
 


### PR DESCRIPTION
Implements the `gh discussion create` CLI command, wiring up the Create client method from #13316.

## Changes

- New `pkg/cmd/discussion/create/` package with `create.go` and `create_test.go`
- Registers the command in `discussion.go` under the "General commands" group
- Flags: `--title/-t`, `--body/-b`, `--category/-c`, `--label/-l`
- Interactive prompting (TTY) when required flags are missing
- Non-interactive mode requiring all flags

## Part of stacked PRs
This is part of the `gh discussion` command series targeting `feature/discussion`.