### PR TITLE
Bump `gh copilot` telemetry sampling to 100%

### DIFF
--- a/pkg/cmd/copilot/copilot.go
+++ b/pkg/cmd/copilot/copilot.go
@@ -20,6 +20,7 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/internal/ci"
 	"github.com/cli/cli/v2/internal/config"
+	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/internal/safepaths"
 	ghzip "github.com/cli/cli/v2/internal/zip"
@@ -37,7 +38,7 @@ type CopilotOptions struct {
 	Remove      bool
 }
 
-func NewCmdCopilot(f *cmdutil.Factory, runF func(*CopilotOptions) error) *cobra.Command {
+func NewCmdCopilot(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, runF func(*CopilotOptions) error) *cobra.Command {
 	opts := &CopilotOptions{
 		IO:         f.IOStreams,
 		HttpClient: f.HttpClient,
@@ -80,6 +81,8 @@ func NewCmdCopilot(f *cmdutil.Factory, runF func(*CopilotOptions) error) *cobra.
 		`),
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			telemetry.SetSampleRate(ghtelemetry.SAMPLE_ALL)
+
 			stopParsePos := -1
 			for i, arg := range args {
 				if arg == "--" {

--- a/pkg/cmd/copilot/copilot_test.go
+++ b/pkg/cmd/copilot/copilot_test.go
@@ -14,6 +14,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
+	"github.com/cli/cli/v2/internal/telemetry"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -110,7 +112,7 @@ func TestNewCmdCopilot(t *testing.T) {
 			assert.NoError(t, err)
 
 			var gotOpts *CopilotOptions
-			cmd := NewCmdCopilot(f, func(opts *CopilotOptions) error {
+			cmd := NewCmdCopilot(f, &telemetry.CommandRecorderSpy{}, func(opts *CopilotOptions) error {
 				gotOpts = opts
 				return nil
 			})
@@ -585,4 +587,20 @@ func TestDownloadCopilot(t *testing.T) {
 		require.NoError(t, err, "downloadCopilot() error")
 		require.Equal(t, localPath, path, "downloadCopilot() path mismatch")
 	})
+}
+
+func TestCopilotCommandIsSampledAt100(t *testing.T) {
+	spy := &telemetry.CommandRecorderSpy{}
+	factory := &cmdutil.Factory{}
+	cmd := NewCmdCopilot(factory, spy, func(opts *CopilotOptions) error {
+		return nil
+	})
+	cmd.SetArgs([]string{})
+	cmd.SetIn(&bytes.Buffer{})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	require.Equal(t, ghtelemetry.SAMPLE_ALL, spy.LastSampleRate)
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -152,7 +152,7 @@ func NewCmdRoot(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, versi
 	cmd.AddCommand(skillsCmd.NewCmdSkills(f, telemetry))
 
 	// Root commands with standalone functionality and no subcommands
-	cmd.AddCommand(copilotCmd.NewCmdCopilot(f, nil))
+	cmd.AddCommand(copilotCmd.NewCmdCopilot(f, telemetry, nil))
 	cmd.AddCommand(statusCmd.NewCmdStatus(f, nil))
 	cmd.AddCommand(creditsCmd.NewCmdCredits(f, nil))
 	cmd.AddCommand(licensesCmd.NewCmdLicenses(f))


### PR DESCRIPTION
## Description

Fixes https://github.com/github/cli/issues/1163

Bumps the telemetry sampling rate for the `gh copilot` command from 1% to 100%, to allow for better analysis of usage.