### PR TITLE
Record accessibility feature state in telemetry

### DIFF
--- a/acceptance/testdata/telemetry/accessibility-dimensions-disabled.txtar
+++ b/acceptance/testdata/telemetry/accessibility-dimensions-disabled.txtar
@@ -1,0 +1,9 @@
+# Telemetry log mode records accessibility features as disabled by default
+env GH_TELEMETRY=log
+env GH_TELEMETRY_SAMPLE_RATE=100
+
+exec gh version
+stderr '"accessible_colors": "false"'
+stderr '"accessible_prompter": "false"'
+stderr '"color_labels": "false"'
+stderr '"spinner_disabled": "false"'

--- a/acceptance/testdata/telemetry/accessibility-dimensions.txtar
+++ b/acceptance/testdata/telemetry/accessibility-dimensions.txtar
@@ -1,0 +1,13 @@
+# Telemetry log mode records accessibility feature state as dimensions
+env GH_TELEMETRY=log
+env GH_TELEMETRY_SAMPLE_RATE=100
+env GH_ACCESSIBLE_COLORS=true
+env GH_ACCESSIBLE_PROMPTER=true
+env GH_COLOR_LABELS=true
+env GH_SPINNER_DISABLED=true
+
+exec gh version
+stderr '"accessible_colors": "true"'
+stderr '"accessible_prompter": "true"'
+stderr '"color_labels": "true"'
+stderr '"spinner_disabled": "true"'

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -71,11 +71,15 @@ func Main() exitCode {
 	ghExecutablePath := executablePath("gh")
 
 	additionalCommonDimensions := ghtelemetry.Dimensions{
-		"version":        strings.TrimPrefix(buildVersion, "v"),
-		"is_tty":         strconv.FormatBool(ioStreams.IsStdoutTTY()),
-		"agent":          string(agents.Detect()),
-		"ci":             strconv.FormatBool(ci.IsCI()),
-		"github_actions": strconv.FormatBool(ci.IsGitHubActions()),
+		"version":             strings.TrimPrefix(buildVersion, "v"),
+		"is_tty":              strconv.FormatBool(ioStreams.IsStdoutTTY()),
+		"agent":               string(agents.Detect()),
+		"ci":                  strconv.FormatBool(ci.IsCI()),
+		"github_actions":      strconv.FormatBool(ci.IsGitHubActions()),
+		"accessible_colors":   strconv.FormatBool(ioStreams.AccessibleColorsEnabled()),
+		"accessible_prompter": strconv.FormatBool(ioStreams.AccessiblePrompterEnabled()),
+		"color_labels":        strconv.FormatBool(ioStreams.ColorLabels()),
+		"spinner_disabled":    strconv.FormatBool(ioStreams.GetSpinnerDisabled()),
 	}
 
 	var telemetryService ghtelemetry.Service


### PR DESCRIPTION
## Description

Closes https://github.com/github/cli/issues/1161

## Summary

Adds four accessibility feature dimensions to the common dimensions:
- `accessible_colors` - whether the accessible color palette is enabled
- `accessible_prompter` - whether the accessible prompter is enabled
- `color_labels` - whether color labels are enabled
- `spinner_disabled` - whether the spinner is disabled

All values are boolean strings (`"true"`/`"false"`), following the same pattern as the existing `is_tty`, `ci`, and `github_actions` dimensions.

## Testing

```
➜ GH_ACCEPTANCE_HOST=github.com GH_ACCEPTANCE_ORG=gh-acceptance-testing GH_ACCEPTANCE_TOKEN=<redacted> go test -tags=acceptance -run ^TestTelemetry$ ./acceptance
ok  	github.com/cli/cli/v2/acceptance	1.772s
```