### PR TITLE
Fix skills acceptance tests

### DIFF
--- a/acceptance/testdata/skills/skills-install-namespaced.txtar
+++ b/acceptance/testdata/skills/skills-install-namespaced.txtar
@@ -1,20 +1,21 @@
-# Two namespaced skills with the same base name in the same repo should
+# Two namespaced skills with different base names in the same repo should
 # be independently installable using path-based disambiguation.
+# Skills are installed flat (by base name) so each must have a unique name.
 
 # Use gh as a credential helper
 exec gh auth setup-git
 
-# Create a repo with two namespaced skills that share the name "deploy"
+# Create a repo with two namespaced skills that have unique base names
 exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --public --add-readme
 defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
 
 exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
 cd $SCRIPT_NAME-$RANDOM_STRING
 
-mkdir -p skills/alice/deploy
-mkdir -p skills/bob/deploy
-cp $WORK/alice-skill.md skills/alice/deploy/SKILL.md
-cp $WORK/bob-skill.md skills/bob/deploy/SKILL.md
+mkdir -p skills/alice/alice-deploy
+mkdir -p skills/bob/bob-deploy
+cp $WORK/alice-skill.md skills/alice/alice-deploy/SKILL.md
+cp $WORK/bob-skill.md skills/bob/bob-deploy/SKILL.md
 
 exec git add -A
 exec git commit -m 'Add namespaced skills'
@@ -23,25 +24,25 @@ exec git push origin main
 # Publish so the skills are discoverable
 exec gh skill publish --tag v1.0.0
 
-# Install alice's deploy skill using the full path to disambiguate
-exec gh skill install $ORG/$SCRIPT_NAME-$RANDOM_STRING skills/alice/deploy --scope user --force
-stdout 'Installed alice/deploy'
+# Install alice's skill using the full path to disambiguate
+exec gh skill install $ORG/$SCRIPT_NAME-$RANDOM_STRING skills/alice/alice-deploy --scope user --force
+stdout 'Installed alice/alice-deploy'
 
-# Install bob's deploy skill using the full path
-exec gh skill install $ORG/$SCRIPT_NAME-$RANDOM_STRING skills/bob/deploy --scope user --force
-stdout 'Installed bob/deploy'
+# Install bob's skill using the full path
+exec gh skill install $ORG/$SCRIPT_NAME-$RANDOM_STRING skills/bob/bob-deploy --scope user --force
+stdout 'Installed bob/bob-deploy'
 
-# Verify both were installed to separate directories
-exists $HOME/.copilot/skills/alice/deploy/SKILL.md
-exists $HOME/.copilot/skills/bob/deploy/SKILL.md
+# Verify both were installed to flat directories (by base name)
+exists $HOME/.copilot/skills/alice-deploy/SKILL.md
+exists $HOME/.copilot/skills/bob-deploy/SKILL.md
 
 # Verify each has the correct content
-grep 'Alice' $HOME/.copilot/skills/alice/deploy/SKILL.md
-grep 'Bob' $HOME/.copilot/skills/bob/deploy/SKILL.md
+grep 'Alice' $HOME/.copilot/skills/alice-deploy/SKILL.md
+grep 'Bob' $HOME/.copilot/skills/bob-deploy/SKILL.md
 
 -- alice-skill.md --
 ---
-name: deploy
+name: alice-deploy
 description: Alice's deployment skill
 ---
 
@@ -51,7 +52,7 @@ Deploys infrastructure using Alice's conventions.
 
 -- bob-skill.md --
 ---
-name: deploy
+name: bob-deploy
 description: Bob's deployment skill
 ---
 

--- a/acceptance/testdata/skills/skills-publish-dry-run.txtar
+++ b/acceptance/testdata/skills/skills-publish-dry-run.txtar
@@ -1,5 +1,6 @@
 # Publish dry-run from a directory with no skills/ should fail gracefully
-! exec gh skill publish --dry-run $WORK
+mkdir $WORK/empty-dir
+! exec gh skill publish --dry-run $WORK/empty-dir
 stderr 'no skills found in'
 
 # Publish dry-run against a valid skill directory should succeed
@@ -8,10 +9,6 @@ stdout 'hello-world'
 
 # Publish dry-run with --tag
 exec gh skill publish --dry-run --tag v1.0.0 $WORK/test-repo
-stdout 'hello-world'
-
-# Publish dry-run with --fix
-exec gh skill publish --dry-run --fix $WORK/test-repo
 stdout 'hello-world'
 
 -- test-repo/skills/hello-world/SKILL.md --


### PR DESCRIPTION
## Description

Two acceptance tests in `TestSkills` were failing due to code changes that weren't reflected in the test expectations:

**`skills-publish-dry-run`**: The nested skills discovery change (`9a368f45e`) made `DiscoverLocalSkills` walk deeper, so `gh skill publish --dry-run $WORK` was finding `test-repo/skills/hello-world/SKILL.md` inside $WORK instead of failing. Fixed by using an explicit empty directory for the "no skills" test case. Also removed a test case combining `--fix` and `--dry-run` which are now mutually exclusive flags.

**`skills-install-namespaced`**: PR #13266 intentionally flattened skill installs to use `skill.Name` instead of `InstallName()` because agent clients only discover immediate subdirectories. The test still expected namespaced directory layout (`alice/deploy/`). Updated to use distinct base names (`alice-deploy`, `bob-deploy`) and expect flat install paths.

### Before

```
➜  wm-unhook-skills-telem git:(trunk) GH_ACCEPTANCE_HOST=github.com \
   GH_ACCEPTANCE_ORG=gh-acceptance-testing \
   GH_ACCEPTANCE_TOKEN=$(gh auth token) \
   go test -tags=acceptance -run ^TestSkills$ ./acceptance
--- FAIL: TestSkills (0.00s)
    --- FAIL: TestSkills/skills-publish-dry-run (0.70s)
        testscript.go:584: # Publish dry-run from a directory with no skills/ should fail gracefully (0.668s)
            > ! exec gh skill publish --dry-run $WORK
            [stdout]
            warning	hello-world	recommended field missing: license
            warning		not a git repository. Initialize with: git init && gh repo create
            [stderr]

            Dry run complete. Use without --dry-run to publish.
            FAIL: testdata/skills/skills-publish-dry-run.txtar:2: unexpected command success

    --- FAIL: TestSkills/skills-search-page (1.00s)
        testscript.go:584: # Pagination returns results on page 2 (0.976s)
            > exec gh skill search --owner github copilot --page 2
            [stderr]
            GitHub API rate limit exceeded. Please wait a minute and try again.
            [exit status 1]
            FAIL: testdata/skills/skills-search-page.txtar:2: unexpected command failure

    --- FAIL: TestSkills/skills-install-namespaced (15.19s)
        testscript.go:584: # Two namespaced skills with the same base name in the same repo should
            # be independently installable using path-based disambiguation.
            # Use gh as a credential helper (0.105s)
            # Create a repo with two namespaced skills that share the name "deploy" (5.369s)
            # Publish so the skills are discoverable (4.300s)
            # Install alice's deploy skill using the full path to disambiguate (2.179s)
            # Install bob's deploy skill using the full path (2.417s)
            # Verify both were installed to separate directories (0.701s)
            > exists $HOME/.copilot/skills/alice/deploy/SKILL.md
            FAIL: testdata/skills/skills-install-namespaced.txtar:35: $WORK/.copilot/skills/alice/deploy/SKILL.md does not exist

FAIL
FAIL	github.com/cli/cli/v2/acceptance	22.645s
FAIL
```

### After

```
➜ GH_ACCEPTANCE_HOST=github.com \
   GH_ACCEPTANCE_ORG=gh-acceptance-testing \
   GH_ACCEPTANCE_TOKEN=$(gh auth token) \
   go test -tags=acceptance -run ^TestSkills$ ./acceptance
ok  	github.com/cli/cli/v2/acceptance	21.062s
```