### PR TITLE
Trigger triage check-requirements on ready_for_review

### DIFF
--- a/.github/workflows/triage-pull-requests.yml
+++ b/.github/workflows/triage-pull-requests.yml
@@ -29,7 +29,7 @@ jobs:
   check-requirements:
     if: >-
       github.event_name == 'pull_request_target' &&
-      (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'edited')
+      (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'edited' || github.event.action == 'ready_for_review')
     uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
     with:
       enable_pr_screening: true


### PR DESCRIPTION
When an external PR is opened as draft and later marked ready for review, the calling `check-requirements` job here only matched `opened`/`reopened`/`edited`, so the shared screening workflow wasn't invoked on the `ready_for_review` event. PRs that open as draft slip past auto-screening (no `unmet-requirements` label, no auto-close timer).

Adds `ready_for_review` to the job's `if:` filter.

Pairs with desktop/gh-cli-and-desktop-shared-workflows#18, which fixes the called workflow's own internal filters. Both must land for screening to resume on draft-then-ready PRs.