### PR TITLE
Add gh discussion edit command

### DIFF
--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -53,6 +53,72 @@ func mapActorFromListNode(n actorNode) DiscussionActor {
 	return a
 }
 
+// rawActorNode is a JSON-compatible actor type for use with c.gql.GraphQL() (raw
+// query strings). Unlike actorNode, it does not use shurcooL graphql struct tags
+// and works with standard json.Unmarshal. GitHub flattens inline fragment fields
+// (... on User { id name }) to the top level of the actor object in JSON responses.
+type rawActorNode struct {
+	TypeName string `json:"__typename"`
+	Login    string
+	ID       string
+	Name     string
+}
+
+func mapActorFromRawNode(n rawActorNode) DiscussionActor {
+	a := DiscussionActor{Login: n.Login}
+	switch n.TypeName {
+	case "User":
+		a.ID = n.ID
+		a.Name = n.Name
+	case "Bot":
+		a.ID = n.ID
+	}
+	return a
+}
+
+// updateDiscussionDiscNode is the JSON response shape for the discussion field
+// inside an updateDiscussion mutation response.
+type updateDiscussionDiscNode struct {
+	ID          string
+	Number      int
+	Title       string
+	Body        string
+	URL         string
+	Closed      bool
+	StateReason string
+	Author      rawActorNode
+	Category    struct {
+		ID           string
+		Name         string
+		Slug         string
+		Emoji        string
+		IsAnswerable bool
+	}
+	Labels struct {
+		Nodes []struct {
+			ID    string
+			Name  string
+			Color string
+		}
+	}
+	IsAnswered     bool
+	AnswerChosenAt time.Time
+	AnswerChosenBy *rawActorNode
+	ReactionGroups []struct {
+		Content string
+		Users   struct {
+			TotalCount int
+		}
+	}
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	ClosedAt  time.Time
+	Locked    bool
+	Comments  struct {
+		TotalCount int
+	}
+}
+
 // discussionListNode is the GraphQL response shape for a discussion in
 // list and search results. It covers high-level fields only (no comments, or
 // other detail-level data that commands like view would need).
@@ -965,8 +1031,86 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 	return &d, nil
 }
 
-func (c *discussionClient) Update(_ ghrepo.Interface, _ UpdateDiscussionInput) (*Discussion, error) {
-	return nil, fmt.Errorf("not implemented")
+const updateDiscussionMutation = `
+mutation UpdateDiscussion($input: UpdateDiscussionInput!) {
+  updateDiscussion(input: $input) {
+    discussion {
+      id number title body url closed stateReason
+      isAnswered answerChosenAt
+      author { __typename login ... on User { id name } ... on Bot { id } }
+      answerChosenBy { __typename login ... on User { id name } ... on Bot { id } }
+      category { id name slug emoji isAnswerable }
+      labels(first: 20) { nodes { id name color } }
+      reactionGroups { content users { totalCount } }
+      createdAt updatedAt closedAt locked
+      comments { totalCount }
+    }
+  }
+}`
+
+func (c *discussionClient) Update(repo ghrepo.Interface, input UpdateDiscussionInput) (*Discussion, error) {
+	inputMap := map[string]interface{}{
+		"discussionId": input.DiscussionID,
+	}
+	if input.Title != nil {
+		inputMap["title"] = *input.Title
+	}
+	if input.Body != nil {
+		inputMap["body"] = *input.Body
+	}
+	if input.CategoryID != nil {
+		inputMap["categoryId"] = *input.CategoryID
+	}
+
+	variables := map[string]interface{}{
+		"input": inputMap,
+	}
+
+	var result struct {
+		UpdateDiscussion struct {
+			Discussion updateDiscussionDiscNode
+		}
+	}
+	if err := c.gql.GraphQL(repo.RepoHost(), updateDiscussionMutation, variables, &result); err != nil {
+		return nil, err
+	}
+
+	disc := result.UpdateDiscussion.Discussion
+	d := Discussion{
+		ID:             disc.ID,
+		Number:         disc.Number,
+		Title:          disc.Title,
+		Body:           disc.Body,
+		URL:            disc.URL,
+		Closed:         disc.Closed,
+		StateReason:    disc.StateReason,
+		Author:         mapActorFromRawNode(disc.Author),
+		Category:       DiscussionCategory{ID: disc.Category.ID, Name: disc.Category.Name, Slug: disc.Category.Slug, Emoji: disc.Category.Emoji, IsAnswerable: disc.Category.IsAnswerable},
+		Answered:       disc.IsAnswered,
+		AnswerChosenAt: disc.AnswerChosenAt,
+		CreatedAt:      disc.CreatedAt,
+		UpdatedAt:      disc.UpdatedAt,
+		ClosedAt:       disc.ClosedAt,
+		Locked:         disc.Locked,
+		Comments:       DiscussionCommentList{TotalCount: disc.Comments.TotalCount},
+	}
+
+	if disc.AnswerChosenBy != nil {
+		a := mapActorFromRawNode(*disc.AnswerChosenBy)
+		d.AnswerChosenBy = &a
+	}
+
+	d.Labels = make([]DiscussionLabel, len(disc.Labels.Nodes))
+	for i, l := range disc.Labels.Nodes {
+		d.Labels[i] = DiscussionLabel{ID: l.ID, Name: l.Name, Color: l.Color}
+	}
+
+	d.ReactionGroups = make([]ReactionGroup, 0, len(disc.ReactionGroups))
+	for _, rg := range disc.ReactionGroups {
+		d.ReactionGroups = append(d.ReactionGroups, ReactionGroup{Content: rg.Content, TotalCount: rg.Users.TotalCount})
+	}
+
+	return &d, nil
 }
 
 func (c *discussionClient) Close(_ ghrepo.Interface, _ string, _ CloseReason) (*Discussion, error) {

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -3067,3 +3067,192 @@ func TestCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdate(t *testing.T) {
+	repo := ghrepo.New("OWNER", "REPO")
+
+	titleStr := "Updated title"
+	bodyStr := "Updated body"
+	catID := "CAT_2"
+
+	tests := []struct {
+		name       string
+		input      UpdateDiscussionInput
+		httpStubs  func(*testing.T, *httpmock.Registry)
+		wantErr    string
+		assertDisc *Discussion
+	}{
+		{
+			name: "maps all fields",
+			input: UpdateDiscussionInput{
+				DiscussionID: "D_1",
+				Title:        &titleStr,
+				Body:         &bodyStr,
+				CategoryID:   &catID,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateDiscussion\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"updateDiscussion": {
+									"discussion": {
+										"id": "D_1",
+										"number": 5,
+										"title": "Updated title",
+										"body": "Updated body",
+										"url": "https://github.com/OWNER/REPO/discussions/5",
+										"closed": false,
+										"stateReason": "",
+										"isAnswered": false,
+										"answerChosenAt": "0001-01-01T00:00:00Z",
+										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
+										"category": {"id": "CAT_2", "name": "Q&A", "slug": "q-a", "emoji": ":question:", "isAnswerable": true},
+										"answerChosenBy": null,
+										"labels": {"nodes": []},
+										"reactionGroups": [{"content": "THUMBS_UP", "users": {"totalCount": 0}}],
+										"createdAt": "2025-06-01T00:00:00Z",
+										"updatedAt": "2025-06-02T00:00:00Z",
+										"closedAt": "0001-01-01T00:00:00Z",
+										"locked": false,
+										"comments": {"totalCount": 0}
+									}
+								}
+							}
+						}
+					`)),
+				)
+			},
+			assertDisc: &Discussion{
+				ID:     "D_1",
+				Number: 5,
+				Title:  "Updated title",
+				Body:   "Updated body",
+				URL:    "https://github.com/OWNER/REPO/discussions/5",
+				Author: DiscussionActor{ID: "U1", Login: "alice", Name: "Alice"},
+				Category: DiscussionCategory{
+					ID:           "CAT_2",
+					Name:         "Q&A",
+					Slug:         "q-a",
+					Emoji:        ":question:",
+					IsAnswerable: true,
+				},
+				Labels:         []DiscussionLabel{},
+				ReactionGroups: []ReactionGroup{{Content: "THUMBS_UP", TotalCount: 0}},
+				CreatedAt:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt:      time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "partial update title only",
+			input: UpdateDiscussionInput{
+				DiscussionID: "D_1",
+				Title:        &titleStr,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateDiscussion\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"updateDiscussion": {
+									"discussion": {
+										"id": "D_1",
+										"number": 5,
+										"title": "Updated title",
+										"body": "Original body",
+										"url": "https://github.com/OWNER/REPO/discussions/5",
+										"closed": false,
+										"stateReason": "",
+										"isAnswered": false,
+										"answerChosenAt": "0001-01-01T00:00:00Z",
+										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
+										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": ":speech_balloon:", "isAnswerable": false},
+										"answerChosenBy": null,
+										"labels": {"nodes": []},
+										"reactionGroups": [],
+										"createdAt": "2025-06-01T00:00:00Z",
+										"updatedAt": "2025-06-02T00:00:00Z",
+										"closedAt": "0001-01-01T00:00:00Z",
+										"locked": false,
+										"comments": {"totalCount": 0}
+									}
+								}
+							}
+						}
+					`)),
+				)
+			},
+			assertDisc: &Discussion{
+				ID:     "D_1",
+				Number: 5,
+				Title:  "Updated title",
+				Body:   "Original body",
+				URL:    "https://github.com/OWNER/REPO/discussions/5",
+				Author: DiscussionActor{ID: "U1", Login: "alice", Name: "Alice"},
+				Category: DiscussionCategory{
+					ID:    "CAT_1",
+					Name:  "General",
+					Slug:  "general",
+					Emoji: ":speech_balloon:",
+				},
+				Labels:         []DiscussionLabel{},
+				ReactionGroups: []ReactionGroup{},
+				CreatedAt:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt:      time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "mutation error",
+			input: UpdateDiscussionInput{
+				DiscussionID: "D_1",
+				Title:        &titleStr,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateDiscussion\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"updateDiscussion": null
+							},
+							"errors": [
+								{
+									"type": "NOT_FOUND",
+									"message": "Could not resolve to a Discussion with the global id of 'D_1'."
+								}
+							]
+						}
+					`)),
+				)
+			},
+			wantErr: "Could not resolve to a Discussion with the global id of 'D_1'.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, reg)
+			}
+
+			c := newTestDiscussionClient(reg)
+			d, err := c.Update(repo, tt.input)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, d)
+			require.NotNil(t, tt.assertDisc, "assertDisc must be set for non-error cases")
+			assert.Equal(t, tt.assertDisc, d)
+		})
+	}
+}

--- a/pkg/cmd/discussion/discussion.go
+++ b/pkg/cmd/discussion/discussion.go
@@ -3,6 +3,7 @@ package discussion
 import (
 	"github.com/MakeNowJust/heredoc"
 	cmdCreate "github.com/cli/cli/v2/pkg/cmd/discussion/create"
+	cmdEdit "github.com/cli/cli/v2/pkg/cmd/discussion/edit"
 	cmdList "github.com/cli/cli/v2/pkg/cmd/discussion/list"
 	cmdView "github.com/cli/cli/v2/pkg/cmd/discussion/view"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -40,6 +41,7 @@ func NewCmdDiscussion(f *cmdutil.Factory) *cobra.Command {
 	)
 
 	cmdutil.AddGroup(cmd, "Targeted commands",
+		cmdEdit.NewCmdEdit(f, nil),
 		cmdView.NewCmdView(f, nil),
 	)
 

--- a/pkg/cmd/discussion/edit/edit.go
+++ b/pkg/cmd/discussion/edit/edit.go
@@ -1,0 +1,233 @@
+package edit
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+// EditOptions holds the configuration for the discussion edit command.
+type EditOptions struct {
+	IO         *iostreams.IOStreams
+	HttpClient func() (*http.Client, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+	Client     func() (client.DiscussionClient, error)
+	Prompter   prompter.Prompter
+
+	DiscussionNumber int
+	Title            string
+	Body             string
+	BodyFile         string
+	Category         string
+}
+
+// NewCmdEdit returns a cobra command for editing a GitHub Discussion.
+func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Command {
+	opts := &EditOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Prompter:   f.Prompter,
+		Client:     shared.DiscussionClientFunc(f),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "edit {<number> | <url>}",
+		Short: "Edit a discussion (preview)",
+		Long: heredoc.Docf(`
+			Edit a GitHub Discussion.
+
+			With %[1]s--title%[1]s, %[1]s--body%[1]s, and %[1]s--category%[1]s flags, the discussion is updated
+			non-interactively. Omitting all flags triggers interactive prompts when connected to a terminal.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# Edit interactively
+			$ gh discussion edit 123
+
+			# Set a new title
+			$ gh discussion edit 123 --title "Updated title"
+
+			# Change the category
+			$ gh discussion edit 123 --category "Ideas"
+
+			# Update body from a file
+			$ gh discussion edit 123 --body-file body.md
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.MutuallyExclusive("specify only one of --body or --body-file",
+				opts.Body != "", opts.BodyFile != ""); err != nil {
+				return err
+			}
+
+			number, repo, err := shared.ParseDiscussionArg(args[0])
+			if err != nil {
+				return cmdutil.FlagErrorf("%s", err)
+			}
+
+			if repo != nil {
+				opts.BaseRepo = func() (ghrepo.Interface, error) {
+					return repo, nil
+				}
+			} else {
+				opts.BaseRepo = f.BaseRepo
+			}
+
+			opts.DiscussionNumber = number
+
+			noFlagsSet := opts.Title == "" && opts.Body == "" && opts.BodyFile == "" && opts.Category == ""
+			if noFlagsSet && !opts.IO.CanPrompt() {
+				return cmdutil.FlagErrorf("specify at least one of --title, --body, --body-file, or --category when not running interactively")
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return editRun(opts)
+		},
+	}
+
+	cmdutil.EnableRepoOverride(cmd, f)
+
+	cmd.Flags().StringVarP(&opts.Title, "title", "t", "", "New title for the discussion")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "New body for the discussion")
+	cmd.Flags().StringVarP(&opts.BodyFile, "body-file", "F", "", "Read body text from file (use \"-\" to read from standard input)")
+	cmd.Flags().StringVarP(&opts.Category, "category", "c", "", "New category name or slug for the discussion")
+
+	return cmd
+}
+
+func editRun(opts *EditOptions) error {
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	c, err := opts.Client()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicator()
+	discussion, err := c.GetByNumber(repo, opts.DiscussionNumber)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return fmt.Errorf("fetching discussion: %w", err)
+	}
+
+	// Resolve body from file if provided.
+	if opts.BodyFile != "" {
+		bodyBytes, err := cmdutil.ReadFile(opts.BodyFile, opts.IO.In)
+		if err != nil {
+			return err
+		}
+		opts.Body = string(bodyBytes)
+	}
+
+	input := client.UpdateDiscussionInput{
+		DiscussionID: discussion.ID,
+	}
+
+	noFlagsSet := opts.Title == "" && opts.Body == "" && opts.Category == ""
+	if noFlagsSet {
+		// Interactive mode: prompt user to select which fields to edit.
+		if err := promptEdit(opts, discussion, c, repo, &input); err != nil {
+			return err
+		}
+	} else {
+		// Non-interactive: apply only the flags that were set.
+		if opts.Title != "" {
+			if strings.TrimSpace(opts.Title) == "" {
+				return cmdutil.FlagErrorf("title cannot be blank")
+			}
+			input.Title = &opts.Title
+		}
+		if opts.Body != "" {
+			input.Body = &opts.Body
+		}
+		if opts.Category != "" {
+			opts.IO.StartProgressIndicator()
+			categories, err := c.ListCategories(repo)
+			opts.IO.StopProgressIndicator()
+			if err != nil {
+				return fmt.Errorf("fetching categories: %w", err)
+			}
+			cat, err := shared.MatchCategory(opts.Category, categories)
+			if err != nil {
+				return err
+			}
+			input.CategoryID = &cat.ID
+		}
+	}
+
+	opts.IO.StartProgressIndicator()
+	updated, err := c.Update(repo, input)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return fmt.Errorf("failed to update discussion: %w", err)
+	}
+
+	fmt.Fprintln(opts.IO.Out, updated.URL)
+	return nil
+}
+
+// promptEdit runs the interactive flow, populating input with user choices.
+func promptEdit(opts *EditOptions, discussion *client.Discussion, c client.DiscussionClient, repo ghrepo.Interface, input *client.UpdateDiscussionInput) error {
+	choices := []string{"title", "body", "category"}
+	selected, err := opts.Prompter.MultiSelect("What would you like to edit?", nil, choices)
+	if err != nil {
+		return err
+	}
+	if len(selected) == 0 {
+		return nil
+	}
+
+	for _, idx := range selected {
+		switch choices[idx] {
+		case "title":
+			title, err := opts.Prompter.Input("Discussion title", discussion.Title)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(title) == "" {
+				return fmt.Errorf("title cannot be blank")
+			}
+			input.Title = &title
+
+		case "body":
+			body, err := opts.Prompter.MarkdownEditor("Discussion body", discussion.Body, false)
+			if err != nil {
+				return err
+			}
+			input.Body = &body
+
+		case "category":
+			opts.IO.StartProgressIndicator()
+			categories, err := c.ListCategories(repo)
+			opts.IO.StopProgressIndicator()
+			if err != nil {
+				return fmt.Errorf("fetching categories: %w", err)
+			}
+			names := make([]string, len(categories))
+			for i, cat := range categories {
+				names[i] = cat.Name
+			}
+			currentName := discussion.Category.Name
+			idx, err := opts.Prompter.Select("Discussion category", currentName, names)
+			if err != nil {
+				return err
+			}
+			input.CategoryID = &categories[idx].ID
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/discussion/edit/edit_test.go
+++ b/pkg/cmd/discussion/edit/edit_test.go
@@ -1,0 +1,459 @@
+package edit
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdEdit(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         string
+		isTTY        bool
+		wantOpts     EditOptions
+		wantBaseRepo ghrepo.Interface
+		wantErr      string
+	}{
+		{
+			name:  "all flags",
+			args:  "123 --title 'New title' --body 'New body' --category 'Ideas'",
+			isTTY: true,
+			wantOpts: EditOptions{
+				DiscussionNumber: 123,
+				Title:            "New title",
+				Body:             "New body",
+				Category:         "Ideas",
+			},
+		},
+		{
+			name:  "url arg overrides base repo",
+			args:  "https://github.com/OWNER2/REPO2/discussions/42",
+			isTTY: true,
+			wantOpts: EditOptions{
+				DiscussionNumber: 42,
+			},
+			wantBaseRepo: ghrepo.New("OWNER2", "REPO2"),
+		},
+		{
+			name:    "mutual exclusion --body and --body-file",
+			args:    "123 --body 'inline' --body-file body.md",
+			isTTY:   true,
+			wantErr: "specify only one of --body or --body-file",
+		},
+		{
+			name:    "no flags no TTY",
+			args:    "123",
+			isTTY:   false,
+			wantErr: "specify at least one of --title, --body, --body-file, or --category when not running interactively",
+		},
+		{
+			name:    "no args",
+			args:    "",
+			isTTY:   true,
+			wantErr: "accepts 1 arg(s)",
+		},
+		{
+			name:    "extra args",
+			args:    "123 extra",
+			isTTY:   true,
+			wantErr: "accepts 1 arg(s)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStdoutTTY(tt.isTTY)
+			f := &cmdutil.Factory{IOStreams: ios}
+			var gotOpts *EditOptions
+			cmd := NewCmdEdit(f, func(opts *EditOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			argv, err := shlex.Split(tt.args)
+			require.NoError(t, err)
+			cmd.SetArgs(argv)
+
+			_, err = cmd.ExecuteC()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOpts.DiscussionNumber, gotOpts.DiscussionNumber)
+			assert.Equal(t, tt.wantOpts.Title, gotOpts.Title)
+			assert.Equal(t, tt.wantOpts.Body, gotOpts.Body)
+			assert.Equal(t, tt.wantOpts.Category, gotOpts.Category)
+
+			if tt.wantBaseRepo != nil {
+				baseRepo, err := gotOpts.BaseRepo()
+				require.NoError(t, err)
+				assert.True(t, ghrepo.IsSame(tt.wantBaseRepo, baseRepo))
+			}
+		})
+	}
+}
+
+func TestEditRun(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      EditOptions
+		isTTY     bool
+		setupMock func(*client.DiscussionClientMock)
+		prompter  *prompter.PrompterMock
+		wantErr   string
+		wantOut   string
+	}{
+		{
+			name: "success non-tty title only",
+			opts: EditOptions{
+				Title: "Updated title",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, "D_1", input.DiscussionID)
+					require.NotNil(t, input.Title)
+					assert.Equal(t, "Updated title", *input.Title)
+					assert.Nil(t, input.Body)
+					assert.Nil(t, input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "success non-tty body only",
+			opts: EditOptions{
+				Body: "Updated body",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.Title)
+					require.NotNil(t, input.Body)
+					assert.Equal(t, "Updated body", *input.Body)
+					assert.Nil(t, input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "success non-tty category change",
+			opts: EditOptions{
+				Category: "Q&A",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.Title)
+					assert.Nil(t, input.Body)
+					require.NotNil(t, input.CategoryID)
+					assert.Equal(t, "CAT2", *input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "success non-tty all flags",
+			opts: EditOptions{
+				Title:    "New title",
+				Body:     "New body",
+				Category: "General",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					require.NotNil(t, input.Title)
+					assert.Equal(t, "New title", *input.Title)
+					require.NotNil(t, input.Body)
+					assert.Equal(t, "New body", *input.Body)
+					require.NotNil(t, input.CategoryID)
+					assert.Equal(t, "CAT1", *input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "non-tty blank title returns error",
+			opts: EditOptions{
+				Title: "   ",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+			},
+			wantErr: "title cannot be blank",
+		},
+		{
+			name: "non-tty unknown category",
+			opts: EditOptions{
+				Category: "nonexistent",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+			},
+			wantErr: `unknown category: "nonexistent"`,
+		},
+		{
+			name: "non-tty list categories error",
+			opts: EditOptions{
+				Category: "General",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return nil, fmt.Errorf("network error")
+				}
+			},
+			wantErr: "fetching categories: network error",
+		},
+		{
+			name: "GetByNumber error",
+			opts: EditOptions{
+				Title: "whatever",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return nil, fmt.Errorf("not found")
+				}
+			},
+			wantErr: "fetching discussion: not found",
+		},
+		{
+			name: "Update error",
+			opts: EditOptions{
+				Title: "Updated title",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					return nil, fmt.Errorf("mutation failed")
+				}
+			},
+			wantErr: "failed to update discussion: mutation failed",
+		},
+		{
+			name:  "tty interactive select title",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					require.NotNil(t, input.Title)
+					assert.Equal(t, "New title", *input.Title)
+					assert.Nil(t, input.Body)
+					assert.Nil(t, input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					assert.Equal(t, []string{"title", "body", "category"}, options)
+					return []int{0}, nil
+				},
+				InputFunc: func(prompt, defaultValue string) (string, error) {
+					assert.Equal(t, "Original title", defaultValue)
+					return "New title", nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty interactive select body",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.Title)
+					require.NotNil(t, input.Body)
+					assert.Equal(t, "New body text", *input.Body)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					return []int{1}, nil // body is index 1
+				},
+				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
+					assert.Equal(t, "Original body", defaultValue)
+					return "New body text", nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty interactive select category",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.Title)
+					assert.Nil(t, input.Body)
+					require.NotNil(t, input.CategoryID)
+					assert.Equal(t, "CAT2", *input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					return []int{2}, nil // category is index 2
+				},
+				SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
+					assert.Equal(t, "General", defaultValue)
+					assert.Equal(t, []string{"General", "Q&A", "Show and tell"}, options)
+					return 1, nil // select "Q&A"
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty interactive nothing selected still calls Update",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, "D_1", input.DiscussionID)
+					assert.Nil(t, input.Title)
+					assert.Nil(t, input.Body)
+					assert.Nil(t, input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					return []int{}, nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty interactive blank title returns error",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					return []int{0}, nil
+				},
+				InputFunc: func(prompt, defaultValue string) (string, error) {
+					return "   ", nil
+				},
+			},
+			wantErr: "title cannot be blank",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, stdout, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+
+			mockClient := &client.DiscussionClientMock{}
+			if tt.setupMock != nil {
+				tt.setupMock(mockClient)
+			}
+
+			opts := tt.opts
+			opts.IO = ios
+			opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.New("OWNER", "REPO"), nil
+			}
+			opts.Client = func() (client.DiscussionClient, error) {
+				return mockClient, nil
+			}
+			if tt.prompter != nil {
+				opts.Prompter = tt.prompter
+			}
+
+			err := editRun(&opts)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOut, stdout.String())
+		})
+	}
+}
+
+func sampleCategories() []client.DiscussionCategory {
+	return []client.DiscussionCategory{
+		{ID: "CAT1", Name: "General", Slug: "general"},
+		{ID: "CAT2", Name: "Q&A", Slug: "q-a"},
+		{ID: "CAT3", Name: "Show and tell", Slug: "show-and-tell"},
+	}
+}
+
+func sampleDiscussion() *client.Discussion {
+	return &client.Discussion{
+		ID:     "D_1",
+		Number: 5,
+		Title:  "Original title",
+		Body:   "Original body",
+		URL:    "https://github.com/OWNER/REPO/discussions/5",
+		Category: client.DiscussionCategory{
+			ID:   "CAT1",
+			Name: "General",
+			Slug: "general",
+		},
+	}
+}


### PR DESCRIPTION
Implements `gh discussion edit <number|url>` following established conventions from `create`, `view`, and `gh issue edit`.

## Features
- `--title/-t` — set new title
- `--body/-b` — set new body  
- `--body-file/-F` — read body from file (mutually exclusive with `--body`)
- `--category/-c` — change category (name or slug)
- Non-interactive mode (flags only)
- Interactive mode (TTY prompts when no flags provided)
- Accepts discussion number, `#number`, or URL

## Changes
- `edit.go` + `edit_test.go` — new command
- `client_impl.go` — `Update()` method with raw GraphQL (avoids shurcooL JSON marshaling issues with `__typename`)
- `client_impl_test.go` — `TestUpdate` subtests
- `discussion.go` — wires `NewCmdEdit`


Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>