### PR TITLE
fix(pr merge): skip checkout when base branch is in another worktree

### DIFF
--- a/git/client.go
+++ b/git/client.go
@@ -615,6 +615,40 @@ func (c *Client) DeleteLocalBranch(ctx context.Context, branch string) error {
 	return nil
 }
 
+// DeleteBranchRef removes a branch ref via git update-ref, which succeeds even
+// when the branch is checked out in a worktree (unlike git branch -D).
+func (c *Client) DeleteBranchRef(ctx context.Context, branch string) error {
+	args := []string{"update-ref", "-d", "refs/heads/" + branch}
+	cmd, err := c.Command(ctx, args...)
+	if err != nil {
+		return err
+	}
+	_, err = cmd.Output()
+	return err
+}
+
+// IsBranchCheckedOutElsewhere reports whether the given branch is the current
+// branch in any git worktree. It is used to detect cases where switching to a
+// branch would fail because it is already checked out elsewhere.
+func (c *Client) IsBranchCheckedOutElsewhere(ctx context.Context, branch string) (bool, error) {
+	args := []string{"worktree", "list", "--porcelain"}
+	cmd, err := c.Command(ctx, args...)
+	if err != nil {
+		return false, err
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	needle := "branch refs/heads/" + branch
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimRight(line, "\r") == needle {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (c *Client) CheckoutBranch(ctx context.Context, branch string) error {
 	args := []string{"checkout", branch}
 	cmd, err := c.Command(ctx, args...)

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -421,6 +421,21 @@ func (m *mergeContext) deleteLocalBranch() error {
 		}
 
 		targetBranch := m.pr.BaseRefName
+
+		// When the base branch is already checked out in another worktree we
+		// cannot switch to it here. Delete the branch ref directly instead of
+		// going through checkout, so the caller's worktree is left untouched.
+		inWorktree, err := m.opts.GitClient.IsBranchCheckedOutElsewhere(ctx, targetBranch)
+		if err != nil {
+			inWorktree = false // non-fatal; fall through to normal checkout
+		}
+		if inWorktree {
+			if err := m.opts.GitClient.DeleteBranchRef(ctx, m.pr.HeadRefName); err != nil {
+				return fmt.Errorf("failed to delete local branch %s: %w", m.cs.Cyan(m.pr.HeadRefName), err)
+			}
+			return m.infof("%s Deleted local branch %s\n", m.cs.SuccessIconWithColor(m.cs.Red), m.cs.Cyan(m.pr.HeadRefName))
+		}
+
 		if m.opts.GitClient.HasLocalBranch(ctx, targetBranch) {
 			if err := m.opts.GitClient.CheckoutBranch(ctx, targetBranch); err != nil {
 				return err

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -641,6 +641,7 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
+	cs.Register(`git worktree list --porcelain`, 0, "worktree /some/path\nHEAD abc123\nbranch refs/heads/blueberries\n")
 	cs.Register(`git rev-parse --verify refs/heads/main`, 0, "")
 	cs.Register(`git checkout main`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
@@ -656,6 +657,59 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 	assert.Equal(t, heredoc.Doc(`
 		✓ Merged pull request OWNER/REPO#10 (Blueberries are a good fruit)
 		✓ Deleted local branch blueberries and switched to branch main
+		✓ Deleted remote branch blueberries
+	`), output.Stderr())
+}
+
+func TestPrMerge_deleteBranch_baseInWorktree(t *testing.T) {
+	http := initFakeHTTP()
+	defer http.Verify(t)
+
+	shared.StubFinderForRunCommandStyleTests(t,
+		"",
+		&api.PullRequest{
+			ID:               "PR_10",
+			Number:           10,
+			State:            "OPEN",
+			Title:            "Blueberries are a good fruit",
+			HeadRefName:      "blueberries",
+			BaseRefName:      "main",
+			MergeStateStatus: "CLEAN",
+		},
+		baseRepo("OWNER", "REPO", "main"),
+	)
+
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestMerge\b`),
+		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+			assert.Equal(t, "PR_10", input["pullRequestId"].(string))
+			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
+			assert.NotContains(t, input, "commitHeadline")
+		}))
+	http.Register(
+		httpmock.REST("DELETE", "repos/OWNER/REPO/git/refs/heads/blueberries"),
+		httpmock.StringResponse(`{}`))
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	// Simulate a two-worktree layout: main checked out in the parent worktree,
+	// blueberries checked out here. git checkout main would fail in this state.
+	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "") // NewMergeContext: localBranchExists
+	cs.Register(`git worktree list --porcelain`, 0,
+		"worktree /path/to/repo\nHEAD abc123\nbranch refs/heads/main\n\n"+
+			"worktree /path/to/repo-blueberries\nHEAD def456\nbranch refs/heads/blueberries\n")
+	cs.Register(`git update-ref -d refs/heads/blueberries`, 0, "")
+
+	output, err := runCommand(http, nil, "blueberries", true, `pr merge --merge --delete-branch`)
+	if err != nil {
+		t.Fatalf("Got unexpected error running `pr merge` %s", err)
+	}
+
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, heredoc.Doc(`
+		✓ Merged pull request OWNER/REPO#10 (Blueberries are a good fruit)
+		✓ Deleted local branch blueberries
 		✓ Deleted remote branch blueberries
 	`), output.Stderr())
 }
@@ -738,6 +792,7 @@ func TestPrMerge_deleteBranch_apiError(t *testing.T) {
 			cs, cmdTeardown := run.Stub()
 			defer cmdTeardown(t)
 
+			cs.Register(`git worktree list --porcelain`, 0, "worktree /some/path\nHEAD abc123\nbranch refs/heads/blueberries\n")
 			cs.Register(`git rev-parse --verify refs/heads/main`, 0, "")
 			cs.Register(`git checkout main`, 0, "")
 			cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
@@ -812,6 +867,7 @@ func TestPrMerge_deleteBranch_nonDefault(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
+	cs.Register(`git worktree list --porcelain`, 0, "worktree /some/path\nHEAD abc123\nbranch refs/heads/blueberries\n")
 	cs.Register(`git rev-parse --verify refs/heads/fruit`, 0, "")
 	cs.Register(`git checkout fruit`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
@@ -861,6 +917,7 @@ func TestPrMerge_deleteBranch_onlyLocally(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
+	cs.Register(`git worktree list --porcelain`, 0, "worktree /some/path\nHEAD abc123\nbranch refs/heads/blueberries\n")
 	cs.Register(`git rev-parse --verify refs/heads/main`, 0, "")
 	cs.Register(`git checkout main`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
@@ -911,6 +968,7 @@ func TestPrMerge_deleteBranch_checkoutNewBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
+	cs.Register(`git worktree list --porcelain`, 0, "worktree /some/path\nHEAD abc123\nbranch refs/heads/blueberries\n")
 	cs.Register(`git rev-parse --verify refs/heads/fruit`, 1, "")
 	cs.Register(`git checkout -b fruit --track origin/fruit`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
@@ -1198,6 +1256,7 @@ func TestPrMerge_alreadyMerged(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
+	cs.Register(`git worktree list --porcelain`, 0, "worktree /some/path\nHEAD abc123\nbranch refs/heads/blueberries\n")
 	cs.Register(`git rev-parse --verify refs/heads/main`, 0, "")
 	cs.Register(`git checkout main`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
@@ -1441,6 +1500,7 @@ func TestPRMergeTTY_withDeleteBranch(t *testing.T) {
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
+	cs.Register(`git worktree list --porcelain`, 0, "worktree /some/path\nHEAD abc123\nbranch refs/heads/blueberries\n")
 	cs.Register(`git rev-parse --verify refs/heads/main`, 0, "")
 	cs.Register(`git checkout main`, 0, "")
 	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")


### PR DESCRIPTION
## Summary

When using git worktrees with a layout like:

```
parent-worktree:  /path/to/repo           (branch: main)
issue-worktree:   /path/to/repo-issue-N   (branch: feature-x)
```

Running `gh pr merge --squash --delete-branch` from inside `repo-issue-N` fails with:

```
fatal: 'main' is already used by worktree at '/path/to/repo'
```

The PR merges on GitHub successfully, but `--delete-branch` aborts because it tries `git checkout main` locally — which git rejects when that branch is already checked out in another worktree.

## Fix

Before attempting `git checkout <base>`, check whether the base branch is already present in any worktree via `git worktree list --porcelain`. If it is, skip the checkout and delete the local branch directly via `git update-ref -d refs/heads/<branch>`, which succeeds regardless of worktree state.

This leaves the caller's worktree untouched and produces a clean deletion without switching branches.

## Changes

- `git/client.go`: add `IsBranchCheckedOutElsewhere` (worktree list parser) and `DeleteBranchRef` (update-ref deletion)
- `pkg/cmd/pr/merge/merge.go`: use the new helpers in `deleteLocalBranch()`
- `pkg/cmd/pr/merge/merge_test.go`: add `TestPrMerge_deleteBranch_baseInWorktree`; update existing delete-branch tests to stub `git worktree list --porcelain`

## Testing

```
go test ./pkg/cmd/pr/merge/... ./git/...  # all pass
```

Closes #3442