### PR TITLE
fix(copilot): hint to run copilot directly when exec fails

### DIFF
--- a/pkg/cmd/copilot/copilot.go
+++ b/pkg/cmd/copilot/copilot.go
@@ -183,10 +183,10 @@ func runCopilot(opts *CopilotOptions) error {
 			os.Exit(exitErr.ExitCode())
 		}
 		if foundInPath {
-			// The binary exists in PATH but exec failed, possibly due to
+			// We found a `copilot` binary but exec failed, possibly due to
 			// unusual characters in the path (see https://github.com/cli/cli/issues/13106).
 			// Suggest running copilot directly as a workaround.
-			return fmt.Errorf("%w\nTry running `copilot` directly without `gh`.", err)
+			return fmt.Errorf("%w\nFailed to run '%s', try running `copilot` directly without `gh`.", err, copilotPath)
 		}
 		return err
 	}

--- a/pkg/cmd/copilot/copilot.go
+++ b/pkg/cmd/copilot/copilot.go
@@ -142,8 +142,9 @@ func runCopilot(opts *CopilotOptions) error {
 		return nil
 	}
 
-	copilotPath := findCopilotBinary()
-	if copilotPath == "" {
+	copilotPath := findCopilotBinaryFunc()
+	foundInPath := copilotPath != ""
+	if !foundInPath {
 		if opts.IO.CanPrompt() {
 			confirmed, err := opts.Prompter.Confirm("GitHub Copilot CLI is not installed. Would you like to install it?", true)
 			if err != nil {
@@ -175,11 +176,17 @@ func runCopilot(opts *CopilotOptions) error {
 	externalCmd.Stderr = opts.IO.ErrOut
 	externalCmd.Env = append(os.Environ(), "COPILOT_GH=true")
 
-	if err := externalCmd.Run(); err != nil {
+	if err := runExternalCmdFunc(externalCmd); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			// We terminate with os.Exit here, preserving the exit code from Copilot CLI,
 			// and also preventing stdio writes by callers up the stack.
 			os.Exit(exitErr.ExitCode())
+		}
+		if foundInPath {
+			// The binary exists in PATH but exec failed, possibly due to
+			// unusual characters in the path (see https://github.com/cli/cli/issues/13106).
+			// Suggest running copilot directly as a workaround.
+			return fmt.Errorf("%w\nTry running `copilot` directly without `gh`.", err)
 		}
 		return err
 	}
@@ -199,6 +206,14 @@ func copilotBinaryPath() string {
 	}
 	return filepath.Join(copilotInstallDir(), binaryName)
 }
+
+var runExternalCmdFunc = runExternalCmd
+
+func runExternalCmd(cmd *exec.Cmd) error {
+	return cmd.Run()
+}
+
+var findCopilotBinaryFunc = findCopilotBinary
 
 // findCopilotBinary returns the path to the Copilot CLI binary, if installed,
 // with the following order of precedence:

--- a/pkg/cmd/copilot/copilot_test.go
+++ b/pkg/cmd/copilot/copilot_test.go
@@ -613,7 +613,7 @@ func TestRunCopilot_execFailureHint(t *testing.T) {
 	err := runCopilot(opts)
 	require.Error(t, err)
 	require.ErrorIs(t, err, execErr)
-	require.Contains(t, err.Error(), "Try running `copilot` directly without `gh`.")
+	require.Contains(t, err.Error(), "try running `copilot` directly without `gh`.")
 }
 
 func TestCopilotCommandIsSampledAt100(t *testing.T) {

--- a/pkg/cmd/copilot/copilot_test.go
+++ b/pkg/cmd/copilot/copilot_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -587,6 +588,32 @@ func TestDownloadCopilot(t *testing.T) {
 		require.NoError(t, err, "downloadCopilot() error")
 		require.Equal(t, localPath, path, "downloadCopilot() path mismatch")
 	})
+}
+
+func TestRunCopilot_execFailureHint(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	opts := &CopilotOptions{
+		IO:          ios,
+		CopilotArgs: []string{},
+	}
+
+	origFind := findCopilotBinaryFunc
+	findCopilotBinaryFunc = func() string {
+		return "/usr/bin/copilot"
+	}
+	t.Cleanup(func() { findCopilotBinaryFunc = origFind })
+
+	execErr := fmt.Errorf("exec failed: something went wrong")
+	origRun := runExternalCmdFunc
+	runExternalCmdFunc = func(_ *exec.Cmd) error {
+		return execErr
+	}
+	t.Cleanup(func() { runExternalCmdFunc = origRun })
+
+	err := runCopilot(opts)
+	require.Error(t, err)
+	require.ErrorIs(t, err, execErr)
+	require.Contains(t, err.Error(), "Try running `copilot` directly without `gh`.")
 }
 
 func TestCopilotCommandIsSampledAt100(t *testing.T) {


### PR DESCRIPTION
## Summary

When `gh copilot` finds the `copilot` binary but fails to execute it (e.g., due to unusual characters like parentheses in the file path on Windows), the error message now includes a hint:

```
Failed to run '<path>', try running `copilot` directly without `gh`.
```

## Details

On Windows, `cmd.exe` shims (e.g., those planted by VS Code or npm) can fail when the path contains special characters like `(`. Since `gh copilot` invokes the binary via `os/exec`, these failures surface as opaque errors. This change adds a practical workaround hint so users can still use Copilot CLI directly.

Related to #13106