### PR TITLE
fix(repo-edit): return error when changing visibility of a fork

### DIFF
--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -181,6 +181,17 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(options *EditOptions) error) *cobr
 				return cmdutil.FlagErrorf("use of --visibility flag requires --accept-visibility-change-consequences flag")
 			}
 
+			if opts.Edits.Visibility != nil && !opts.InteractiveMode {
+				apiClient := api.NewClientFromHTTP(opts.HTTPClient)
+				repo, err := api.FetchRepository(apiClient, opts.Repository, []string{"isFork"})
+				if err != nil {
+					return err
+				}
+				if repo.IsFork {
+					return fmt.Errorf("changing visibility of a forked repository is not supported")
+				}
+			}
+
 			if opts.Edits.squashMergeCommitMsg != nil {
 				if opts.Edits.EnableSquashMerge == nil {
 					return cmdutil.FlagErrorf("--squash-merge-commit-message requires --enable-squash-merge")
@@ -257,6 +268,7 @@ func editRun(ctx context.Context, opts *EditOptions) error {
 			// TODO: GitHub Enterprise Server does not support has_discussions yet
 			// "hasDiscussionsEnabled",
 			"homepageUrl",
+			"isFork",
 			"isInOrganization",
 			"isTemplate",
 			"mergeCommitAllowed",
@@ -453,6 +465,9 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 			}
 			opts.Edits.EnableProjects = &a
 		case optionVisibility:
+			if r.IsFork {
+				return fmt.Errorf("changing visibility of a forked repository is not supported")
+			}
 			cs := opts.IO.ColorScheme()
 			fmt.Fprintf(opts.IO.ErrOut, "%s Danger zone: changing repository visibility can have unexpected consequences; consult https://gh.io/setting-repository-visibility before continuing.\n", cs.WarningIcon())
 


### PR DESCRIPTION
## Summary

Fixes #13233.

When running `gh repo edit --visibility <value>` on a forked repository, GitHub silently ignores the visibility change (since forks cannot have their visibility changed independently from the parent). Previously the CLI reported success (`✓ Edited repository`) even though no change was made.

## Changes

This PR adds validation to detect forked repositories before attempting a visibility change:

1. **Non-interactive mode (`--visibility` flag):** Before calling the API, the code now fetches the `isFork` field and returns an error if the repo is a fork.

2. **Interactive mode (`gh repo edit`):** When the user selects "Visibility" from the menu, the code now checks `isFork` and returns an error before presenting visibility options.

**Error message:** `changing visibility of a forked repository is not supported`

## Technical Details

- Added `isFork` to the list of fields retrieved when fetching repository info in interactive mode
- Added fork detection in the non-interactive flag validation path (after the `--accept-visibility-change-consequences` check)
- Added fork detection in `interactiveRepoEdit()` before presenting visibility options

---

*AI-assisted fix via OpenClaw subagent*