### PR TITLE
Fix browse decimal-only commit refs

### DIFF
--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -2,6 +2,7 @@ package browse
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -250,6 +251,15 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 			return "", nil
 		}
 		if isNumber(opts.SelectorArg) {
+			if !strings.HasPrefix(opts.SelectorArg, "#") && isCommit(opts.SelectorArg) {
+				exists, err := isCommitInRepo(baseRepo, opts, opts.SelectorArg)
+				if err != nil {
+					return "", err
+				}
+				if exists {
+					return fmt.Sprintf("commit/%s", opts.SelectorArg), nil
+				}
+			}
 			return fmt.Sprintf("issues/%s", strings.TrimPrefix(opts.SelectorArg, "#")), nil
 		}
 		if isCommit(opts.SelectorArg) {
@@ -352,6 +362,28 @@ var commitHash = regexp.MustCompile(`\A[a-f0-9]{7,64}\z`)
 
 func isCommit(arg string) bool {
 	return commitHash.MatchString(arg)
+}
+
+func isCommitInRepo(baseRepo ghrepo.Interface, opts *BrowseOptions, commitRef string) (bool, error) {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return false, err
+	}
+
+	var result struct {
+		SHA string `json:"sha"`
+	}
+	path := fmt.Sprintf("repos/%s/%s/commits/%s", baseRepo.RepoOwner(), baseRepo.RepoName(), url.PathEscape(commitRef))
+	err = api.NewClientFromHTTP(httpClient).REST(baseRepo.RepoHost(), http.MethodGet, path, nil, &result)
+	if err != nil {
+		var httpErr api.HTTPError
+		if errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusUnprocessableEntity) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
 }
 
 // gitClient is used to implement functions that can be performed on both local and remote git repositories

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -357,6 +357,42 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL: "https://github.com/kevin/MinTy/issues/217",
 		},
 		{
+			name: "decimal-only commit hash in selector arg",
+			opts: BrowseOptions{
+				SelectorArg: "309628980",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/kevin/MinTy/commits/309628980"),
+					httpmock.JSONResponse(map[string]string{"sha": "3096289800000000000000000000000000000000"}),
+				)
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/commit/309628980",
+		},
+		{
+			name: "decimal-only selector falls back to issue when commit is not found",
+			opts: BrowseOptions{
+				SelectorArg: "1234567",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/kevin/MinTy/commits/1234567"),
+					httpmock.StatusStringResponse(http.StatusUnprocessableEntity, "No commit found for SHA"),
+				)
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/issues/1234567",
+		},
+		{
+			name: "hashtag argument forces issue for decimal-only commit hash",
+			opts: BrowseOptions{
+				SelectorArg: "#309628980",
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/issues/309628980",
+		},
+		{
 			name: "branch flag",
 			opts: BrowseOptions{
 				Branch: "trunk",


### PR DESCRIPTION
Fixes #12357.

This checks decimal-only selector arguments that also match commit hash syntax against the repository commits API before falling back to issue URLs. `#`-prefixed selectors still force issue URLs, and non-ambiguous selectors keep the existing fast path.

Tests: `GOPROXY=https://goproxy.cn,direct go test ./pkg/cmd/browse`