### PR TITLE
Allow agents as application for secrets

### DIFF
--- a/pkg/cmd/secret/delete/delete.go
+++ b/pkg/cmd/secret/delete/delete.go
@@ -81,7 +81,7 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "Delete a secret for an organization")
 	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "Delete a secret for an environment")
 	cmd.Flags().BoolVarP(&opts.UserSecrets, "user", "u", false, "Delete a secret for your user")
-	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", "", []string{shared.Actions, shared.Codespaces, shared.Dependabot}, "Delete a secret for a specific application")
+	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", "", []string{shared.Actions, shared.Agents, shared.Codespaces, shared.Dependabot}, "Delete a secret for a specific application")
 
 	return cmd
 }

--- a/pkg/cmd/secret/delete/delete.go
+++ b/pkg/cmd/secret/delete/delete.go
@@ -40,9 +40,9 @@ func NewCmdDelete(f *cmdutil.Factory, runF func(*DeleteOptions) error) *cobra.Co
 		Short: "Delete secrets",
 		Long: heredoc.Doc(`
 			Delete a secret on one of the following levels:
-			- repository (default): available to GitHub Actions runs or Dependabot in a repository
+			- repository (default): available to GitHub Actions runs, Agents sessions, or Dependabot in a repository
 			- environment: available to GitHub Actions runs for a deployment environment in a repository
-			- organization: available to GitHub Actions runs, Dependabot, or Codespaces within an organization
+			- organization: available to GitHub Actions runs, Agents sessions, Dependabot, or Codespaces within an organization
 			- user: available to Codespaces for your user
 		`),
 		Args: cobra.ExactArgs(1),

--- a/pkg/cmd/secret/delete/delete_test.go
+++ b/pkg/cmd/secret/delete/delete_test.go
@@ -89,6 +89,23 @@ func TestNewCmdDelete(t *testing.T) {
 				Application: "Codespaces",
 			},
 		},
+		{
+			name: "Agents org",
+			cli:  "cool --app agents --org UmbrellaCorporation",
+			wants: DeleteOptions{
+				SecretName:  "cool",
+				OrgName:     "UmbrellaCorporation",
+				Application: "Agents",
+			},
+		},
+		{
+			name: "Agents repo",
+			cli:  "cool --app Agents",
+			wants: DeleteOptions{
+				SecretName:  "cool",
+				Application: "Agents",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/secret/delete/delete_test.go
+++ b/pkg/cmd/secret/delete/delete_test.go
@@ -329,6 +329,17 @@ func Test_removeRun_repo(t *testing.T) {
 			},
 		},
 		{
+			name: "Agents",
+			opts: &DeleteOptions{
+				Application: "agents",
+				SecretName:  "cool_agents_secret",
+			},
+			host: "github.com",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.WithHost(httpmock.REST("DELETE", "repos/owner/repo/agents/secrets/cool_agents_secret"), "api.github.com"), httpmock.StatusStringResponse(204, "No Content"))
+			},
+		},
+		{
 			name: "defaults to Actions",
 			opts: &DeleteOptions{
 				SecretName: "cool_secret",
@@ -449,6 +460,14 @@ func Test_removeRun_org(t *testing.T) {
 				OrgName:     "UmbrellaCorporation",
 			},
 			wantPath: "orgs/UmbrellaCorporation/codespaces/secrets/tVirus",
+		},
+		{
+			name: "Agents org",
+			opts: &DeleteOptions{
+				Application: "agents",
+				OrgName:     "UmbrellaCorporation",
+			},
+			wantPath: "orgs/UmbrellaCorporation/agents/secrets/tVirus",
 		},
 	}
 

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -98,7 +98,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.OrgName, "org", "o", "", "List secrets for an organization")
 	cmd.Flags().StringVarP(&opts.EnvName, "env", "e", "", "List secrets for an environment")
 	cmd.Flags().BoolVarP(&opts.UserSecrets, "user", "u", false, "List a secret for your user")
-	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", "", []string{shared.Actions, shared.Codespaces, shared.Dependabot}, "List secrets for a specific application")
+	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", "", []string{shared.Actions, shared.Agents, shared.Codespaces, shared.Dependabot}, "List secrets for a specific application")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, secretFields)
 	return cmd
 }

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -60,9 +60,9 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Short: "List secrets",
 		Long: heredoc.Doc(`
 			List secrets on one of the following levels:
-			- repository (default): available to GitHub Actions runs or Dependabot in a repository
+			- repository (default): available to GitHub Actions runs, Agents sessions, or Dependabot in a repository
 			- environment: available to GitHub Actions runs for a deployment environment in a repository
-			- organization: available to GitHub Actions runs, Dependabot, or Codespaces within an organization
+			- organization: available to GitHub Actions runs, Agents sessions, Dependabot, or Codespaces within an organization
 			- user: available to Codespaces for your user
 		`),
 		Aliases: []string{"ls"},

--- a/pkg/cmd/secret/list/list_test.go
+++ b/pkg/cmd/secret/list/list_test.go
@@ -74,6 +74,21 @@ func Test_NewCmdList(t *testing.T) {
 				OrgName:     "UmbrellaCorporation",
 			},
 		},
+		{
+			name: "Agents repo",
+			cli:  "--app Agents",
+			wants: ListOptions{
+				Application: "Agents",
+			},
+		},
+		{
+			name: "Agents org",
+			cli:  "--app Agents --org UmbrellaCorporation",
+			wants: ListOptions{
+				Application: "Agents",
+				OrgName:     "UmbrellaCorporation",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/secret/list/list_test.go
+++ b/pkg/cmd/secret/list/list_test.go
@@ -458,6 +458,58 @@ func Test_listRun(t *testing.T) {
 				"SECRET_THREE\t1975-11-30T00:00:00Z\tSELECTED",
 			},
 		},
+		{
+			name: "Agents repo tty",
+			tty:  true,
+			opts: &ListOptions{
+				Application: "Agents",
+			},
+			wantOut: []string{
+				"NAME          UPDATED",
+				"SECRET_ONE    about 34 years ago",
+				"SECRET_TWO    about 2 years ago",
+				"SECRET_THREE  about 47 years ago",
+			},
+		},
+		{
+			name: "Agents repo not tty",
+			tty:  false,
+			opts: &ListOptions{
+				Application: "Agents",
+			},
+			wantOut: []string{
+				"SECRET_ONE\t1988-10-11T00:00:00Z",
+				"SECRET_TWO\t2020-12-04T00:00:00Z",
+				"SECRET_THREE\t1975-11-30T00:00:00Z",
+			},
+		},
+		{
+			name: "Agents org tty",
+			tty:  true,
+			opts: &ListOptions{
+				Application: "Agents",
+				OrgName:     "UmbrellaCorporation",
+			},
+			wantOut: []string{
+				"NAME          UPDATED             VISIBILITY",
+				"SECRET_ONE    about 34 years ago  Visible to all repositories",
+				"SECRET_TWO    about 2 years ago   Visible to private repositories",
+				"SECRET_THREE  about 47 years ago  Visible to 2 selected repositories",
+			},
+		},
+		{
+			name: "Agents org not tty",
+			tty:  false,
+			opts: &ListOptions{
+				Application: "Agents",
+				OrgName:     "UmbrellaCorporation",
+			},
+			wantOut: []string{
+				"SECRET_ONE\t1988-10-11T00:00:00Z\tALL",
+				"SECRET_TWO\t2020-12-04T00:00:00Z\tPRIVATE",
+				"SECRET_THREE\t1975-11-30T00:00:00Z\tSELECTED",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -557,6 +609,8 @@ func Test_listRun(t *testing.T) {
 
 			if tt.opts.Application == "Dependabot" {
 				path = strings.Replace(path, "actions", "dependabot", 1)
+			} else if tt.opts.Application == "Agents" {
+				path = strings.Replace(path, "actions", "agents", 1)
 			}
 
 			reg.Register(httpmock.REST("GET", path), httpmock.JSONResponse(payload))

--- a/pkg/cmd/secret/secret.go
+++ b/pkg/cmd/secret/secret.go
@@ -15,7 +15,7 @@ func NewCmdSecret(f *cmdutil.Factory) *cobra.Command {
 		Short: "Manage GitHub secrets",
 		Long: heredoc.Docf(`
 			Secrets can be set at the repository, or organization level for use in
-			GitHub Actions, Agents or Dependabot. User, organization, and repository secrets can be set for
+			GitHub Actions, Agents, or Dependabot. User, organization, and repository secrets can be set for
 			use in GitHub Codespaces. Environment secrets can be set for use in
 			GitHub Actions. Run %[1]sgh help secret set%[1]s to learn how to get started.
 		`, "`"),

--- a/pkg/cmd/secret/secret.go
+++ b/pkg/cmd/secret/secret.go
@@ -15,7 +15,7 @@ func NewCmdSecret(f *cmdutil.Factory) *cobra.Command {
 		Short: "Manage GitHub secrets",
 		Long: heredoc.Docf(`
 			Secrets can be set at the repository, or organization level for use in
-			GitHub Actions or Dependabot. User, organization, and repository secrets can be set for
+			GitHub Actions, Agents or Dependabot. User, organization, and repository secrets can be set for
 			use in GitHub Codespaces. Environment secrets can be set for use in
 			GitHub Actions. Run %[1]sgh help secret set%[1]s to learn how to get started.
 		`, "`"),

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -195,7 +195,7 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "The value for the secret (reads from standard input if not specified)")
 	cmd.Flags().BoolVar(&opts.DoNotStore, "no-store", false, "Print the encrypted, base64-encoded value instead of storing it on GitHub")
 	cmd.Flags().StringVarP(&opts.EnvFile, "env-file", "f", "", "Load secret names and values from a dotenv-formatted `file`")
-	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", "", []string{shared.Actions, shared.Codespaces, shared.Dependabot}, "Set the application for a secret")
+	cmdutil.StringEnumFlag(cmd, &opts.Application, "app", "a", "", []string{shared.Actions, shared.Agents, shared.Codespaces, shared.Dependabot}, "Set the application for a secret")
 
 	return cmd
 }

--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -63,9 +63,9 @@ func NewCmdSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Command 
 		Short: "Create or update secrets",
 		Long: heredoc.Doc(`
 			Set a value for a secret on one of the following levels:
-			- repository (default): available to GitHub Actions runs or Dependabot in a repository
+			- repository (default): available to GitHub Actions runs, Agents sessions, or Dependabot in a repository
 			- environment: available to GitHub Actions runs for a deployment environment in a repository
-			- organization: available to GitHub Actions runs, Dependabot, or Codespaces within an organization
+			- organization: available to GitHub Actions runs, Agents sessions, Dependabot, or Codespaces within an organization
 			- user: available to Codespaces for your user
 
 			Organization and user secrets can optionally be restricted to only be available to

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -213,6 +213,29 @@ func TestNewCmdSet(t *testing.T) {
 				Application:     "Codespaces",
 			},
 		},
+		{
+			name: "Agents org",
+			args: `random_secret --org coolOrg --body "random value" --visibility selected --repos "coolRepo,cli/cli" --app Agents`,
+			wants: SetOptions{
+				SecretName:      "random_secret",
+				Visibility:      shared.Selected,
+				RepositoryNames: []string{"coolRepo", "cli/cli"},
+				Body:            "random value",
+				OrgName:         "coolOrg",
+				Application:     "Agents",
+			},
+		},
+		{
+			name: "Agents repo",
+			args: `cool_secret --body "a secret" --app Agents`,
+			wants: SetOptions{
+				SecretName:  "cool_secret",
+				Visibility:  shared.Private,
+				Body:        "a secret",
+				OrgName:     "",
+				Application: "Agents",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -408,6 +408,13 @@ func Test_setRun_repo(t *testing.T) {
 			wantApp: "actions",
 		},
 		{
+			name: "Agents",
+			opts: &SetOptions{
+				Application: "agents",
+			},
+			wantApp: "agents",
+		},
+		{
 			name: "Dependabot",
 			opts: &SetOptions{
 				Application: "dependabot",

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -603,6 +603,37 @@ func Test_setRun_org(t *testing.T) {
 			wantRepositories: []int64{},
 			wantApp:          "dependabot",
 		},
+		{
+			name: "Agents",
+			opts: &SetOptions{
+				OrgName:     "UmbrellaCorporation",
+				Visibility:  shared.All,
+				Application: shared.Agents,
+			},
+			wantApp: "agents",
+		},
+		{
+			name: "Agents selected visibility",
+			opts: &SetOptions{
+				OrgName:         "UmbrellaCorporation",
+				Visibility:      shared.Selected,
+				Application:     shared.Agents,
+				RepositoryNames: []string{"birkin", "UmbrellaCorporation/wesker"},
+			},
+			wantRepositories: []int64{1, 2},
+			wantApp:          "agents",
+		},
+		{
+			name: "Agents no repos visibility",
+			opts: &SetOptions{
+				OrgName:         "UmbrellaCorporation",
+				Visibility:      shared.Selected,
+				Application:     shared.Agents,
+				RepositoryNames: []string{},
+			},
+			wantRepositories: []int64{},
+			wantApp:          "agents",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/secret/shared/shared.go
+++ b/pkg/cmd/secret/shared/shared.go
@@ -20,6 +20,7 @@ type App string
 
 const (
 	Actions    = "actions"
+	Agents     = "agents"
 	Codespaces = "codespaces"
 	Dependabot = "dependabot"
 	Unknown    = "unknown"
@@ -66,6 +67,8 @@ func GetSecretApp(app string, entity SecretEntity) (App, error) {
 	switch strings.ToLower(app) {
 	case Actions:
 		return Actions, nil
+	case Agents:
+		return Agents, nil
 	case Codespaces:
 		return Codespaces, nil
 	case Dependabot:
@@ -84,6 +87,8 @@ func IsSupportedSecretEntity(app App, entity SecretEntity) bool {
 	switch app {
 	case Actions:
 		return entity == Repository || entity == Organization || entity == Environment
+	case Agents:
+		return entity == Repository || entity == Organization
 	case Codespaces:
 		return entity == User || entity == Organization || entity == Repository
 	case Dependabot:

--- a/pkg/cmd/secret/shared/shared_test.go
+++ b/pkg/cmd/secret/shared/shared_test.go
@@ -167,6 +167,19 @@ func TestIsSupportedSecretEntity(t *testing.T) {
 			},
 		},
 		{
+			name: "Agents",
+			app:  Agents,
+			supportedEntities: []SecretEntity{
+				Repository,
+				Organization,
+			},
+			unsupportedEntities: []SecretEntity{
+				Environment,
+				User,
+				Unknown,
+			},
+		},
+		{
 			name: "Codespaces",
 			app:  Codespaces,
 			supportedEntities: []SecretEntity{

--- a/pkg/cmd/secret/shared/shared_test.go
+++ b/pkg/cmd/secret/shared/shared_test.go
@@ -82,6 +82,11 @@ func TestGetSecretApp(t *testing.T) {
 			want: Actions,
 		},
 		{
+			name: "Agents",
+			app:  "agents",
+			want: Agents,
+		},
+		{
 			name: "Codespaces",
 			app:  "codespaces",
 			want: Codespaces,


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/13419

I built it locally and ran `bin/gh secret set TEST_SECRET -a agents -b 123 -o <my-org>` and it worked exactly as expected.

What might be missing is another test? I looked through it and added a little bit but maybe a maintainer has a little more input regarding that.