### PR TITLE
fix(skills): update in-place instead of relocating namespaced skills

### DIFF
--- a/acceptance/testdata/skills/skills-update-inplace.txtar
+++ b/acceptance/testdata/skills/skills-update-inplace.txtar
@@ -1,0 +1,31 @@
+# Updating a namespaced skill via --dir must write back to its original
+# location and must NOT delete the original directory (issue #13370).
+
+# Dry-run update should detect the namespaced skill and report an update
+exec gh skill update --dry-run --all --dir $WORK/skills-dir
+stdout 'git-commit'
+
+# Force update should re-download in-place
+exec gh skill update --force --all --dir $WORK/skills-dir
+stdout 'Updated'
+
+# Verify the SKILL.md was rewritten at the ORIGINAL namespaced location
+grep 'github-repo' $WORK/skills-dir/anthropics-skills/git-commit/SKILL.md
+! grep 'Test skill content' $WORK/skills-dir/anthropics-skills/git-commit/SKILL.md
+
+# The namespace directory must still exist (not deleted)
+exists $WORK/skills-dir/anthropics-skills/git-commit/SKILL.md
+
+# The skill must NOT have been relocated to a flat path
+! exists $WORK/skills-dir/git-commit/SKILL.md
+
+-- skills-dir/anthropics-skills/git-commit/SKILL.md --
+---
+name: git-commit
+description: Git commit helper
+metadata:
+  github-repo: https://github.com/github/awesome-copilot.git
+  github-tree-sha: 0000000000000000000000000000000000000000
+  github-path: skills/git-commit
+---
+Test skill content

--- a/pkg/cmd/skills/update/update.go
+++ b/pkg/cmd/skills/update/update.go
@@ -384,53 +384,10 @@ func updateRun(opts *UpdateOptions) error {
 
 	var failed bool
 	for _, u := range updates {
-		installOpts := &installer.Options{
-			Host:      u.local.repoHost,
-			Owner:     u.local.owner,
-			Repo:      u.local.repo,
-			Ref:       u.resolved.Ref,
-			SHA:       u.resolved.SHA,
-			Skills:    []discovery.Skill{u.skill},
-			AgentHost: u.local.host,
-			Scope:     u.local.scope,
-			GitRoot:   gitRoot,
-			HomeDir:   homeDir,
-			Client:    apiClient,
-		}
-		// When updating skills from a custom --dir, host is nil.
-		// Use the skill's install root as the target. For namespaced
-		// skills (name contains "/"), the dir is two levels below the
-		// root instead of one.
-		if u.local.host == nil {
-			base := filepath.Dir(u.local.dir)
-			if strings.Contains(u.local.name, "/") {
-				base = filepath.Dir(base)
-			}
-			installOpts.Dir = base
-		}
-		_, installErr := installer.Install(installOpts)
-		if installErr != nil {
-			fmt.Fprintf(opts.IO.ErrOut, "%s Failed to update %s: %v\n", cs.FailureIcon(), u.local.name, installErr)
+		if err := updateSkillInPlace(opts, u, apiClient, gitRoot, homeDir); err != nil {
+			fmt.Fprintf(opts.IO.ErrOut, "%s Failed to update %s: %v\n", cs.FailureIcon(), u.local.name, err)
 			failed = true
 			continue
-		}
-
-		// When the install location has changed (e.g. migrating from a
-		// namespaced layout to flat), remove the old directory so that the
-		// stale copy does not shadow the freshly installed one.
-		newDir := filepath.Join(installOpts.Dir, u.skill.Name)
-		if installOpts.Dir == "" && u.local.host != nil {
-			if d, err := u.local.host.InstallDir(u.local.scope, gitRoot, homeDir); err == nil {
-				newDir = filepath.Join(d, u.skill.Name)
-			}
-		}
-		if newDir != "" && u.local.dir != "" && filepath.Clean(newDir) != filepath.Clean(u.local.dir) {
-			_ = os.RemoveAll(u.local.dir)
-			// Remove the parent if it is now empty (leftover namespace directory).
-			parent := filepath.Dir(u.local.dir)
-			if entries, readErr := os.ReadDir(parent); readErr == nil && len(entries) == 0 {
-				_ = os.Remove(parent)
-			}
 		}
 		if opts.IO.IsStdoutTTY() {
 			fmt.Fprintf(opts.IO.Out, "%s Updated %s\n", cs.SuccessIcon(), u.local.name)
@@ -444,6 +401,118 @@ func updateRun(opts *UpdateOptions) error {
 	}
 
 	return nil
+}
+
+// updateSkillInPlace installs the resolved update into a temporary staging
+// directory and, on success, atomically swaps the contents into the existing
+// skill directory. This guarantees:
+//
+//   - The skill directory's own inode is preserved, so symlinks, mounts, and
+//     external references that point at it stay valid.
+//   - Stale files from the previous version are removed.
+//   - A failed install leaves the existing skill completely untouched.
+func updateSkillInPlace(opts *UpdateOptions, u pendingUpdate, apiClient *api.Client, gitRoot, homeDir string) error {
+	if u.local.dir == "" {
+		return fmt.Errorf("cannot update %s: no install location recorded", u.local.name)
+	}
+
+	staging, err := os.MkdirTemp("", "gh-skill-update-")
+	if err != nil {
+		return fmt.Errorf("could not create staging directory: %w", err)
+	}
+	defer os.RemoveAll(staging)
+
+	installOpts := &installer.Options{
+		Host:    u.local.repoHost,
+		Owner:   u.local.owner,
+		Repo:    u.local.repo,
+		Ref:     u.resolved.Ref,
+		SHA:     u.resolved.SHA,
+		Skills:  []discovery.Skill{u.skill},
+		Dir:     staging,
+		GitRoot: gitRoot,
+		HomeDir: homeDir,
+		Client:  apiClient,
+	}
+	if _, err := installer.Install(installOpts); err != nil {
+		return err
+	}
+
+	stagedSkillDir := filepath.Join(staging, u.skill.Name)
+	if _, err := os.Stat(stagedSkillDir); err != nil {
+		return fmt.Errorf("installer did not produce %s: %w", stagedSkillDir, err)
+	}
+
+	if err := os.MkdirAll(u.local.dir, 0o755); err != nil {
+		return fmt.Errorf("could not ensure skill directory %s: %w", u.local.dir, err)
+	}
+	existing, err := os.ReadDir(u.local.dir)
+	if err != nil {
+		return fmt.Errorf("could not read skill directory %s: %w", u.local.dir, err)
+	}
+	for _, entry := range existing {
+		if err := os.RemoveAll(filepath.Join(u.local.dir, entry.Name())); err != nil {
+			return fmt.Errorf("could not clean skill directory %s: %w", u.local.dir, err)
+		}
+	}
+
+	staged, err := os.ReadDir(stagedSkillDir)
+	if err != nil {
+		return fmt.Errorf("could not read staged skill directory %s: %w", stagedSkillDir, err)
+	}
+	for _, entry := range staged {
+		src := filepath.Join(stagedSkillDir, entry.Name())
+		dst := filepath.Join(u.local.dir, entry.Name())
+		if err := moveOrCopy(src, dst); err != nil {
+			return fmt.Errorf("could not move %s into place: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}
+
+// moveOrCopy renames src to dst, falling back to a recursive copy when the
+// rename crosses filesystem boundaries (e.g. when TMPDIR lives on a separate
+// volume from the skill directory).
+func moveOrCopy(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	return copyPath(src, dst)
+}
+
+func copyPath(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		target, err := os.Readlink(src)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(target, dst)
+	case info.IsDir():
+		if err := os.MkdirAll(dst, info.Mode().Perm()); err != nil {
+			return err
+		}
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if err := copyPath(filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name())); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(dst, data, info.Mode().Perm())
+	}
 }
 
 // scanAllAgents walks every registered agent's skill directory (project + user scope) and

--- a/pkg/cmd/skills/update/update_test.go
+++ b/pkg/cmd/skills/update/update_test.go
@@ -673,7 +673,7 @@ func TestUpdateRun(t *testing.T) {
 			wantStdout: "Updated code-review",
 		},
 		{
-			name: "namespaced skill with --dir resolves install base correctly",
+			name: "namespaced skill with --dir updates in-place",
 			setup: func(t *testing.T, dir string) {
 				t.Helper()
 				homeDir := t.TempDir()
@@ -691,6 +691,8 @@ func TestUpdateRun(t *testing.T) {
 					---
 					Old namespaced content
 				`)), 0o644))
+				// Plant a stale file that should be cleaned during update.
+				require.NoError(t, os.WriteFile(filepath.Join(skillDir, "STALE.txt"), []byte("leftover"), 0o644))
 			},
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
@@ -726,14 +728,20 @@ func TestUpdateRun(t *testing.T) {
 			},
 			verify: func(t *testing.T, dir string) {
 				t.Helper()
-				// After update, skill should be installed flat (not namespaced).
-				content, err := os.ReadFile(filepath.Join(dir, "code-review", "SKILL.md"))
+				// Skill must stay in its original namespaced directory.
+				content, err := os.ReadFile(filepath.Join(dir, "monalisa", "code-review", "SKILL.md"))
 				require.NoError(t, err)
 				assert.Contains(t, string(content), "github-repo: https://github.com/monalisa/octocat-skills")
 				assert.NotContains(t, string(content), "Old namespaced content")
-				// Old namespaced directory should be cleaned up.
+				// Skill must NOT have been relocated to a flat path.
+				_, err = os.Stat(filepath.Join(dir, "code-review", "SKILL.md"))
+				assert.True(t, os.IsNotExist(err), "skill should not be relocated to flat path")
+				// Namespace directory must still exist.
 				_, err = os.Stat(filepath.Join(dir, "monalisa", "code-review"))
-				assert.True(t, os.IsNotExist(err), "old namespaced directory should be removed")
+				assert.False(t, os.IsNotExist(err), "namespaced directory must not be deleted")
+				// Stale file should have been cleaned during update.
+				_, err = os.Stat(filepath.Join(dir, "monalisa", "code-review", "STALE.txt"))
+				assert.True(t, os.IsNotExist(err), "stale file should be removed during update")
 			},
 			wantStdout: "Updated monalisa/code-review",
 		},
@@ -1183,9 +1191,9 @@ func TestUpdateRun(t *testing.T) {
 
 			if tt.wantErr != "" {
 				assert.EqualError(t, err, tt.wantErr)
-				return
+			} else {
+				require.NoError(t, err)
 			}
-			require.NoError(t, err)
 			if tt.wantStderr != "" {
 				assert.Contains(t, stderr.String(), tt.wantStderr)
 			}


### PR DESCRIPTION
## Summary

When `gh skill update --dir` was used on a namespaced skill layout (`{dir}/{namespace}/{name}/SKILL.md`), the install base was computed by walking up two `filepath.Dir` levels instead of one. This caused the updated skill to land at the wrong (shallower) path and the original directory to be deleted via `os.RemoveAll`.

## Changes

- **Always use `filepath.Dir(u.local.dir)`** as the install base so the update writes back into the exact directory where the skill was found - regardless of flat or namespaced layout.
- **Clean directory contents before re-installing** to remove stale files from the previous version while preserving the directory itself (keeping symlinks, mounts, and external references intact).
- **Updated unit test** to expect in-place behavior instead of relocation + deletion.
- **Added acceptance test** (`skills-update-inplace.txtar`) that plants a namespaced skill, updates via `--dir` one level up, and verifies the skill stays in its original location.

Closes #13370