### PR TITLE
fix: preserve defers on ctrl-c

### DIFF
--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -139,7 +140,8 @@ func Main() exitCode {
 		}
 	}
 
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
 	updateCtx, updateCancel := context.WithCancel(ctx)
 	defer updateCancel()
 	updateMessageChan := make(chan *update.ReleaseInfo)

--- a/pkg/cmd/codespace/common.go
+++ b/pkg/cmd/codespace/common.go
@@ -168,10 +168,7 @@ func (p *Prompter) Ask(qs []*survey.Question, response interface{}) error {
 	if err == terminal.InterruptErr {
 		self, _ := os.FindProcess(os.Getpid())
 		_ = self.Signal(os.Interrupt) // assumes POSIX
-
-		// Suspend the goroutine, to avoid a race between
-		// return from main and async delivery of INT signal.
-		select {}
+		return terminal.InterruptErr
 	}
 	return err
 }

--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -41,7 +42,7 @@ var CancelError = errors.New("CancelError")
 var PendingError = errors.New("PendingError")
 
 func IsUserCancellation(err error) bool {
-	return errors.Is(err, CancelError) || errors.Is(err, terminal.InterruptErr)
+	return errors.Is(err, CancelError) || errors.Is(err, terminal.InterruptErr) || errors.Is(err, context.Canceled)
 }
 
 func MutuallyExclusive(message string, conditions ...bool) error {

--- a/pkg/cmdutil/errors_test.go
+++ b/pkg/cmdutil/errors_test.go
@@ -1,0 +1,30 @@
+package cmdutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/AlecAivazis/survey/v2/terminal"
+)
+
+func TestIsUserCancellation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "cancel error", err: CancelError, want: true},
+		{name: "terminal interrupt", err: terminal.InterruptErr, want: true},
+		{name: "context canceled", err: context.Canceled, want: true},
+		{name: "other error", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsUserCancellation(tt.err); got != tt.want {
+				t.Fatalf("IsUserCancellation(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -378,9 +378,8 @@ func (s *IOStreams) StartAlternateScreenBuffer() {
 
 			go func() {
 				<-ch
+				signal.Stop(ch)
 				s.StopAlternateScreenBuffer()
-
-				os.Exit(1)
 			}()
 		}
 	}


### PR DESCRIPTION
## Summary
- Add top-level signal-aware cancellation so ctrl-c can unwind cleanly
- Remove the alternate-screen os.Exit path that skipped defers
- Treat context.Canceled as user cancellation
- Return cancellation from the Codespaces prompt path instead of hanging

## Verification
- go test ./pkg/cmdutil ./pkg/iostreams ./pkg/cmd/codespace/... ./internal/ghcmd
