### PR TITLE
Derive digest algorithm from ref length in release verify commands

### DIFF
--- a/pkg/cmd/release/shared/fetch.go
+++ b/pkg/cmd/release/shared/fetch.go
@@ -170,6 +170,19 @@ func FetchRefSHA(ctx context.Context, httpClient *http.Client, repo ghrepo.Inter
 	return ref.Object.SHA, nil
 }
 
+// DigestAlgForRef returns the digest algorithm name corresponding to the given
+// git ref SHA. SHA-1 git object IDs are 40 hex characters and SHA-256 git
+// object IDs are 64 hex characters. Unknown lengths default to "sha1" to
+// preserve backwards-compatible behavior.
+func DigestAlgForRef(digest string) string {
+	switch len(digest) {
+	case 64:
+		return "sha256"
+	default:
+		return "sha1"
+	}
+}
+
 // FetchRelease finds a published repository release by its tagName, or a draft release by its pending tag name.
 func FetchRelease(ctx context.Context, httpClient *http.Client, repo ghrepo.Interface, tagName string) (*Release, error) {
 	cc, cancel := context.WithCancel(ctx)

--- a/pkg/cmd/release/shared/fetch_test.go
+++ b/pkg/cmd/release/shared/fetch_test.go
@@ -92,3 +92,38 @@ func TestFetchRefSHA(t *testing.T) {
 		})
 	}
 }
+
+func TestDigestAlgForRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		digest   string
+		expected string
+	}{
+		{
+			name:     "sha1 (40 hex chars)",
+			digest:   "1234567890abcdef1234567890abcdef12345678",
+			expected: "sha1",
+		},
+		{
+			name:     "sha256 (64 hex chars)",
+			digest:   "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expected: "sha256",
+		},
+		{
+			name:     "empty string defaults to sha1",
+			digest:   "",
+			expected: "sha1",
+		},
+		{
+			name:     "unexpected length defaults to sha1",
+			digest:   "abc",
+			expected: "sha1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, DigestAlgForRef(tt.digest))
+		})
+	}
+}

--- a/pkg/cmd/release/verify-asset/verify_asset.go
+++ b/pkg/cmd/release/verify-asset/verify_asset.go
@@ -142,7 +142,7 @@ func verifyAssetRun(config *VerifyAssetConfig) error {
 		return err
 	}
 
-	releaseRefDigest := artifact.NewDigestedArtifactForRelease(ref, "sha1")
+	releaseRefDigest := artifact.NewDigestedArtifactForRelease(ref, shared.DigestAlgForRef(ref))
 
 	// Find attestations for the release tag SHA
 	attestations, err := config.AttClient.GetByDigest(api.FetchParams{

--- a/pkg/cmd/release/verify-asset/verify_asset_test.go
+++ b/pkg/cmd/release/verify-asset/verify_asset_test.go
@@ -166,7 +166,7 @@ func Test_verifyAssetRun_SuccessNoTagArg(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func Test_verifyAssetRun_FailedNoAttestations(t *testing.T) {
+func Test_verifyAssetRun_FailedNoAttestations_SHA1(t *testing.T) {
 	ios, _, _, _ := iostreams.Test()
 	tagName := "v1"
 
@@ -180,6 +180,14 @@ func Test_verifyAssetRun_FailedNoAttestations(t *testing.T) {
 
 	releaseAssetPath := test.NormalizeRelativePath("../../attestation/test/data/github_release_artifact.zip")
 
+	var capturedParams api.FetchParams
+	attClient := &api.MockClient{
+		OnGetByDigest: func(params api.FetchParams) ([]*api.Attestation, error) {
+			capturedParams = params
+			return api.OnGetByDigestFailure(params)
+		},
+	}
+
 	cfg := &VerifyAssetConfig{
 		Opts: &VerifyAssetOptions{
 			AssetFilePath: releaseAssetPath,
@@ -189,12 +197,14 @@ func Test_verifyAssetRun_FailedNoAttestations(t *testing.T) {
 		},
 		IO:          ios,
 		HttpClient:  &http.Client{Transport: fakeHTTP},
-		AttClient:   api.NewFailTestClient(),
+		AttClient:   attClient,
 		AttVerifier: nil,
 	}
 
 	err = verifyAssetRun(cfg)
 	require.ErrorContains(t, err, "no attestations found for tag v1")
+	require.ErrorContains(t, err, "sha1:"+fakeSHA)
+	require.Equal(t, "sha1:"+fakeSHA, capturedParams.Digest)
 }
 
 func Test_verifyAssetRun_FailedNoAttestations_SHA256(t *testing.T) {
@@ -211,6 +221,14 @@ func Test_verifyAssetRun_FailedNoAttestations_SHA256(t *testing.T) {
 
 	releaseAssetPath := test.NormalizeRelativePath("../../attestation/test/data/github_release_artifact.zip")
 
+	var capturedParams api.FetchParams
+	attClient := &api.MockClient{
+		OnGetByDigest: func(params api.FetchParams) ([]*api.Attestation, error) {
+			capturedParams = params
+			return api.OnGetByDigestFailure(params)
+		},
+	}
+
 	cfg := &VerifyAssetConfig{
 		Opts: &VerifyAssetOptions{
 			AssetFilePath: releaseAssetPath,
@@ -220,13 +238,14 @@ func Test_verifyAssetRun_FailedNoAttestations_SHA256(t *testing.T) {
 		},
 		IO:          ios,
 		HttpClient:  &http.Client{Transport: fakeHTTP},
-		AttClient:   api.NewFailTestClient(),
+		AttClient:   attClient,
 		AttVerifier: nil,
 	}
 
 	err = verifyAssetRun(cfg)
 	require.ErrorContains(t, err, "no attestations found for tag v1")
 	require.ErrorContains(t, err, "sha256:"+fakeSHA)
+	require.Equal(t, "sha256:"+fakeSHA, capturedParams.Digest)
 }
 
 func Test_verifyAssetRun_FailedTagNotInAttestation(t *testing.T) {

--- a/pkg/cmd/release/verify-asset/verify_asset_test.go
+++ b/pkg/cmd/release/verify-asset/verify_asset_test.go
@@ -197,6 +197,38 @@ func Test_verifyAssetRun_FailedNoAttestations(t *testing.T) {
 	require.ErrorContains(t, err, "no attestations found for tag v1")
 }
 
+func Test_verifyAssetRun_FailedNoAttestations_SHA256(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	tagName := "v1"
+
+	fakeHTTP := &httpmock.Registry{}
+	defer fakeHTTP.Verify(t)
+	fakeSHA := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	shared.StubFetchRefSHA(t, fakeHTTP, "owner", "repo", tagName, fakeSHA)
+
+	baseRepo, err := ghrepo.FromFullName("owner/repo")
+	require.NoError(t, err)
+
+	releaseAssetPath := test.NormalizeRelativePath("../../attestation/test/data/github_release_artifact.zip")
+
+	cfg := &VerifyAssetConfig{
+		Opts: &VerifyAssetOptions{
+			AssetFilePath: releaseAssetPath,
+			TagName:       tagName,
+			BaseRepo:      baseRepo,
+			Exporter:      nil,
+		},
+		IO:          ios,
+		HttpClient:  &http.Client{Transport: fakeHTTP},
+		AttClient:   api.NewFailTestClient(),
+		AttVerifier: nil,
+	}
+
+	err = verifyAssetRun(cfg)
+	require.ErrorContains(t, err, "no attestations found for tag v1")
+	require.ErrorContains(t, err, "sha256:"+fakeSHA)
+}
+
 func Test_verifyAssetRun_FailedTagNotInAttestation(t *testing.T) {
 	ios, _, _, _ := iostreams.Test()
 

--- a/pkg/cmd/release/verify/verify.go
+++ b/pkg/cmd/release/verify/verify.go
@@ -130,7 +130,7 @@ func verifyRun(config *VerifyConfig) error {
 		return err
 	}
 
-	releaseRefDigest := artifact.NewDigestedArtifactForRelease(ref, "sha1")
+	releaseRefDigest := artifact.NewDigestedArtifactForRelease(ref, shared.DigestAlgForRef(ref))
 
 	// Find all the attestations for the release tag SHA
 	attestations, err := config.AttClient.GetByDigest(api.FetchParams{

--- a/pkg/cmd/release/verify/verify_test.go
+++ b/pkg/cmd/release/verify/verify_test.go
@@ -131,6 +131,35 @@ func Test_verifyRun_FailedNoAttestations(t *testing.T) {
 	require.ErrorContains(t, err, "no attestations for tag v1")
 }
 
+func Test_verifyRun_FailedNoAttestations_SHA256(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	tagName := "v1"
+
+	fakeHTTP := &httpmock.Registry{}
+	defer fakeHTTP.Verify(t)
+	fakeSHA := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	shared.StubFetchRefSHA(t, fakeHTTP, "owner", "repo", tagName, fakeSHA)
+
+	baseRepo, err := ghrepo.FromFullName("owner/repo")
+	require.NoError(t, err)
+
+	cfg := &VerifyConfig{
+		Opts: &VerifyOptions{
+			TagName:  tagName,
+			BaseRepo: baseRepo,
+			Exporter: nil,
+		},
+		IO:          ios,
+		HttpClient:  &http.Client{Transport: fakeHTTP},
+		AttClient:   api.NewFailTestClient(),
+		AttVerifier: nil,
+	}
+
+	err = verifyRun(cfg)
+	require.ErrorContains(t, err, "no attestations for tag v1")
+	require.ErrorContains(t, err, "sha256:"+fakeSHA)
+}
+
 func Test_verifyRun_FailedTagNotInAttestation(t *testing.T) {
 	ios, _, _, _ := iostreams.Test()
 

--- a/pkg/cmd/release/verify/verify_test.go
+++ b/pkg/cmd/release/verify/verify_test.go
@@ -103,7 +103,7 @@ func Test_verifyRun_Success(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func Test_verifyRun_FailedNoAttestations(t *testing.T) {
+func Test_verifyRun_FailedNoAttestations_SHA1(t *testing.T) {
 	ios, _, _, _ := iostreams.Test()
 	tagName := "v1"
 
@@ -115,6 +115,14 @@ func Test_verifyRun_FailedNoAttestations(t *testing.T) {
 	baseRepo, err := ghrepo.FromFullName("owner/repo")
 	require.NoError(t, err)
 
+	var capturedParams api.FetchParams
+	attClient := &api.MockClient{
+		OnGetByDigest: func(params api.FetchParams) ([]*api.Attestation, error) {
+			capturedParams = params
+			return api.OnGetByDigestFailure(params)
+		},
+	}
+
 	cfg := &VerifyConfig{
 		Opts: &VerifyOptions{
 			TagName:  tagName,
@@ -123,12 +131,14 @@ func Test_verifyRun_FailedNoAttestations(t *testing.T) {
 		},
 		IO:          ios,
 		HttpClient:  &http.Client{Transport: fakeHTTP},
-		AttClient:   api.NewFailTestClient(),
+		AttClient:   attClient,
 		AttVerifier: nil,
 	}
 
 	err = verifyRun(cfg)
 	require.ErrorContains(t, err, "no attestations for tag v1")
+	require.ErrorContains(t, err, "sha1:"+fakeSHA)
+	require.Equal(t, "sha1:"+fakeSHA, capturedParams.Digest)
 }
 
 func Test_verifyRun_FailedNoAttestations_SHA256(t *testing.T) {
@@ -143,6 +153,14 @@ func Test_verifyRun_FailedNoAttestations_SHA256(t *testing.T) {
 	baseRepo, err := ghrepo.FromFullName("owner/repo")
 	require.NoError(t, err)
 
+	var capturedParams api.FetchParams
+	attClient := &api.MockClient{
+		OnGetByDigest: func(params api.FetchParams) ([]*api.Attestation, error) {
+			capturedParams = params
+			return api.OnGetByDigestFailure(params)
+		},
+	}
+
 	cfg := &VerifyConfig{
 		Opts: &VerifyOptions{
 			TagName:  tagName,
@@ -151,13 +169,14 @@ func Test_verifyRun_FailedNoAttestations_SHA256(t *testing.T) {
 		},
 		IO:          ios,
 		HttpClient:  &http.Client{Transport: fakeHTTP},
-		AttClient:   api.NewFailTestClient(),
+		AttClient:   attClient,
 		AttVerifier: nil,
 	}
 
 	err = verifyRun(cfg)
 	require.ErrorContains(t, err, "no attestations for tag v1")
 	require.ErrorContains(t, err, "sha256:"+fakeSHA)
+	require.Equal(t, "sha256:"+fakeSHA, capturedParams.Digest)
 }
 
 func Test_verifyRun_FailedTagNotInAttestation(t *testing.T) {


### PR DESCRIPTION
Fixes #13429

### Summary

The `gh release verify` and `gh release verify-asset` commands hard-coded a `sha1:` prefix when constructing the digest identifier for a release tag's commit SHA. Once GitHub repositories using SHA-256 commit digests are supported, that ref will be a 64-character SHA-256 hash and labeling it as `sha1:` is both misleading in user-facing output and incorrect for the attestation lookup.

### Changes

- Added a small shared helper `DigestAlgForRef(digest string) string` in `pkg/cmd/release/shared/fetch.go` that returns `"sha256"` for 64-character digests and `"sha1"` otherwise (preserving existing behavior).
- Replaced the hard-coded `"sha1"` argument in `pkg/cmd/release/verify/verify.go` and `pkg/cmd/release/verify-asset/verify_asset.go` with a call to the new helper.
- Added unit tests for `DigestAlgForRef` covering SHA-1, SHA-256, empty, and unexpected lengths.
- Added `*_SHA256` variants of the existing `FailedNoAttestations` tests in both commands that assert the error message includes `sha256:<digest>`.

### Verification

- `go test ./pkg/cmd/release/shared/... ./pkg/cmd/release/verify/... ./pkg/cmd/release/verify-asset/...` passes.
- `go build ./...` passes.
- Existing SHA-1 tests continue to pass (no regression).
