### PR TITLE
docs: drop --repo gh-cli from dnf install lines

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -100,7 +100,7 @@ To install:
 ```bash
 sudo dnf install dnf5-plugins
 sudo dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
-sudo dnf install gh --repo gh-cli
+sudo dnf install gh
 ```
 
 To upgrade:
@@ -119,7 +119,7 @@ To install:
 ```bash
 sudo dnf install 'dnf-command(config-manager)'
 sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-sudo dnf install gh --repo gh-cli
+sudo dnf install gh
 ```
 
 To upgrade:


### PR DESCRIPTION
Closes #12808.

The documented \`dnf\` install lines pin resolution to the gh-cli repo with \`--repo gh-cli\`. That repo only ships the \`gh\` package, so on a fresh Fedora install without \`git\` already present the install fails with:

\`\`\`
nothing provides git needed by gh-2.87.3-1.x86_64 from gh-cli
\`\`\`

Dropped \`--repo gh-cli\` from the install command in both the DNF5 and DNF4 sections. dnf still pulls \`gh\` from the gh-cli repo (it's where the package lives) but can now resolve \`git\` from the system repos. The upgrade lines already use a bare \`dnf update gh\` so they're unchanged.

Matches what @niik proposed in the issue thread after spotting that other projects (docker, vagrant) use \`addrepo\` without the restrictive \`--repo\` flag.