### PR TITLE
fix(auth logout): clear credentials from git credential helper on logout

### DIFF
--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -6,26 +6,30 @@ import (
 	"slices"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/pkg/cmd/auth/shared"
+	"github.com/cli/cli/v2/pkg/cmd/auth/shared/gitcredentials"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/spf13/cobra"
 )
 
 type LogoutOptions struct {
-	IO       *iostreams.IOStreams
-	Config   func() (gh.Config, error)
-	Prompter shared.Prompt
-	Hostname string
-	Username string
+	IO        *iostreams.IOStreams
+	Config    func() (gh.Config, error)
+	GitClient *git.Client
+	Prompter  shared.Prompt
+	Hostname  string
+	Username  string
 }
 
 func NewCmdLogout(f *cmdutil.Factory, runF func(*LogoutOptions) error) *cobra.Command {
 	opts := &LogoutOptions{
-		IO:       f.IOStreams,
-		Config:   f.Config,
-		Prompter: f.Prompter,
+		IO:        f.IOStreams,
+		Config:    f.Config,
+		GitClient: f.GitClient,
+		Prompter:  f.Prompter,
 	}
 
 	cmd := &cobra.Command{
@@ -153,15 +157,29 @@ func logoutRun(opts *LogoutOptions) error {
 	// We can ignore the error here because a host must always have an active user
 	preLogoutActiveUser, _ := authCfg.ActiveUser(hostname)
 
+	cs := opts.IO.ColorScheme()
+
 	if err := authCfg.Logout(hostname, username); err != nil {
 		return err
+	}
+
+	// Clear credentials from the git credential helper. During login, if the
+	// user opted to authenticate git, we stored the token via
+	// `git credential approve`. We now call `git credential reject` to remove
+	// it. This is safe even when gh itself is the credential helper, because
+	// gh's erase operation is a no-op.
+	credentialUpdater := &gitcredentials.Updater{GitClient: opts.GitClient}
+	if err := credentialUpdater.Reject(hostname); err != nil {
+		// Log but don't fail the logout if credential rejection fails,
+		// e.g., git may not be installed.
+		fmt.Fprintf(opts.IO.ErrOut, "%s Failed to remove credentials from git credential helper: %v\n",
+			cs.WarningIcon(), err)
 	}
 
 	postLogoutActiveUser, _ := authCfg.ActiveUser(hostname)
 	hasSwitchedToNewUser := preLogoutActiveUser != postLogoutActiveUser &&
 		postLogoutActiveUser != ""
 
-	cs := opts.IO.ColorScheme()
 	fmt.Fprintf(opts.IO.ErrOut, "%s Logged out of %s account %s\n",
 		cs.SuccessIcon(), hostname, cs.Bold(username))
 

--- a/pkg/cmd/auth/logout/logout_test.go
+++ b/pkg/cmd/auth/logout/logout_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/prompter"
@@ -338,6 +339,8 @@ func Test_logoutRun_tty(t *testing.T) {
 			}
 			tt.opts.Prompter = pm
 
+			tt.opts.GitClient = &git.Client{GitPath: "some/path/git"}
+
 			err := logoutRun(tt.opts)
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
@@ -525,6 +528,8 @@ func Test_logoutRun_nontty(t *testing.T) {
 			ios.SetStdinTTY(false)
 			ios.SetStdoutTTY(false)
 			tt.opts.IO = ios
+
+			tt.opts.GitClient = &git.Client{GitPath: "some/path/git"}
 
 			err := logoutRun(tt.opts)
 			if tt.wantErr != "" {

--- a/pkg/cmd/auth/shared/gitcredentials/updater.go
+++ b/pkg/cmd/auth/shared/gitcredentials/updater.go
@@ -13,12 +13,10 @@ type Updater struct {
 	GitClient *git.Client
 }
 
-// Update updates the git credentials for a given hostname, first by rejecting any existing credentials and then
-// approving the new credentials.
-func (u *Updater) Update(hostname, username, password string) error {
+// Reject removes any stored credentials for a given hostname from the git credential helper.
+func (u *Updater) Reject(hostname string) error {
 	ctx := context.TODO()
 
-	// clear previous cached credentials
 	rejectCmd, err := u.GitClient.Command(ctx, "credential", "reject")
 	if err != nil {
 		return err
@@ -30,9 +28,17 @@ func (u *Updater) Update(hostname, username, password string) error {
 	`, hostname))
 
 	_, err = rejectCmd.Output()
-	if err != nil {
+	return err
+}
+
+// Update updates the git credentials for a given hostname, first by rejecting any existing credentials and then
+// approving the new credentials.
+func (u *Updater) Update(hostname, username, password string) error {
+	if err := u.Reject(hostname); err != nil {
 		return err
 	}
+
+	ctx := context.TODO()
 
 	approveCmd, err := u.GitClient.Command(ctx, "credential", "approve")
 	if err != nil {
@@ -47,9 +53,5 @@ func (u *Updater) Update(hostname, username, password string) error {
 	`, hostname, username, password))
 
 	_, err = approveCmd.Output()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }


### PR DESCRIPTION
During login, if the user opts to authenticate git, the token is stored in the configured git credential helper via `git credential approve`. On logout, only gh's internal keyring was cleared, leaving the token in external helpers (e.g., osxkeychain, wincred). Now we also call `git credential reject` to remove it.

Fixes #13111
