### PR TITLE
api: only disable telemetry for hosts the user has authenticated to

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -80,6 +80,7 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 		client.Transport = telemetryDisablerTransport{
 			wrappedTransport:  client.Transport,
 			telemetryDisabler: opts.TelemetryDisabler,
+			config:            opts.Config,
 		}
 	}
 
@@ -160,11 +161,20 @@ func getHost(r *http.Request) string {
 type telemetryDisablerTransport struct {
 	wrappedTransport  http.RoundTripper
 	telemetryDisabler ghtelemetry.Disabler
+	config            tokenGetter
 }
 
 func (t telemetryDisablerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if ghauth.IsEnterprise(getHost(req)) {
-		t.telemetryDisabler.Disable()
+	host := getHost(req)
+	// Only disable telemetry for hosts the user has actually authenticated
+	// to (i.e. configured GHES instances). Hitting a third-party URL like
+	// the dev-tunnels API or a release asset shouldn't take telemetry
+	// down for the rest of the invocation.
+	if ghauth.IsEnterprise(host) && t.config != nil {
+		token, _ := t.config.ActiveToken(host)
+		if token != "" {
+			t.telemetryDisabler.Disable()
+		}
 	}
 	return t.wrappedTransport.RoundTrip(req)
 }

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -321,24 +321,35 @@ func TestNewHTTPClientTelemetryDisabler(t *testing.T) {
 	}))
 	defer ts.Close()
 
+	cfgWithGHES := tinyConfig{"ghes.example.com:oauth_token": "configured-token"}
 	tests := []struct {
 		name         string
 		host         string
+		config       tokenGetter
 		wantDisabled bool
 	}{
 		{
-			name:         "enterprise host triggers disable",
+			name:         "configured enterprise host triggers disable",
 			host:         "ghes.example.com",
+			config:       cfgWithGHES,
 			wantDisabled: true,
 		},
 		{
 			name:         "github.com does not trigger disable",
 			host:         "github.com",
+			config:       cfgWithGHES,
 			wantDisabled: false,
 		},
 		{
 			name:         "tenancy host does not trigger disable",
 			host:         "my-company.ghe.com",
+			config:       cfgWithGHES,
+			wantDisabled: false,
+		},
+		{
+			name:         "unconfigured third-party host does not trigger disable",
+			host:         "global.rel.tunnels.api.visualstudio.com",
+			config:       cfgWithGHES,
 			wantDisabled: false,
 		},
 	}
@@ -348,6 +359,7 @@ func TestNewHTTPClientTelemetryDisabler(t *testing.T) {
 			disabler := &fakeTelemetryDisabler{}
 			client, err := NewHTTPClient(HTTPClientOptions{
 				TelemetryDisabler: disabler,
+				Config:            tt.config,
 			})
 			require.NoError(t, err)
 


### PR DESCRIPTION
Closes #13402.

`telemetryDisablerTransport` disabled telemetry for any request whose host wasn't `github.com` / a tenancy host / `github.localhost`. That covers a lot of non-enterprise traffic the CLI legitimately makes:

| Command | Non-GitHub host |
| --- | --- |
| `gh cs ports forward/list/visibility/jupyter` | `global.rel.tunnels.api.visualstudio.com` |
| `gh cs ssh` / `gh cs logs` / `gh cs rebuild` | same |
| `gh api <full-url>` | anything the user passes |
| `gh attestation download/verify/inspect` | bundle URLs |
| `gh extension install/upgrade` | release asset URLs |

Only disable telemetry when the request hits a host that's actually configured in the user's auth (`ActiveToken` returns a token for it). That preserves the privacy intent for real GHES users without collateral damage on every long-running codespace command.