### PR TITLE
Add --account flag to git-credential helper

### DIFF
--- a/pkg/cmd/auth/gitcredential/helper.go
+++ b/pkg/cmd/auth/gitcredential/helper.go
@@ -117,7 +117,7 @@ func helperRun(opts *CredentialOptions) error {
 	lookupHost := wants["host"]
 
 	if opts.Account != "" {
-		if wants["username"] != "" && !strings.EqualFold(wants["username"], opts.Account) {
+		if wants["username"] != "" && wants["username"] != tokenUser && !strings.EqualFold(wants["username"], opts.Account) {
 			return cmdutil.SilentError
 		}
 		tokenLookupHost := lookupHost

--- a/pkg/cmd/auth/gitcredential/helper.go
+++ b/pkg/cmd/auth/gitcredential/helper.go
@@ -16,6 +16,7 @@ const tokenUser = "x-access-token"
 type config interface {
 	ActiveToken(string) (string, string)
 	ActiveUser(string) (string, error)
+	TokenForUser(hostname, user string) (string, string, error)
 }
 
 type CredentialOptions struct {
@@ -23,6 +24,7 @@ type CredentialOptions struct {
 	Config func() (config, error)
 
 	Operation string
+	Account   string
 }
 
 func NewCmdCredential(f *cmdutil.Factory, runF func(*CredentialOptions) error) *cobra.Command {
@@ -51,6 +53,8 @@ func NewCmdCredential(f *cmdutil.Factory, runF func(*CredentialOptions) error) *
 			return helperRun(opts)
 		},
 	}
+
+	cmd.Flags().StringVar(&opts.Account, "account", "", "Use credentials for a specific GitHub account")
 
 	return cmd
 }
@@ -111,6 +115,26 @@ func helperRun(opts *CredentialOptions) error {
 	}
 
 	lookupHost := wants["host"]
+
+	if opts.Account != "" {
+		if wants["username"] != "" && !strings.EqualFold(wants["username"], opts.Account) {
+			return fmt.Errorf("gh auth git-credential: --account %q conflicts with requested username %q", opts.Account, wants["username"])
+		}
+		tokenLookupHost := lookupHost
+		if strings.HasPrefix(tokenLookupHost, "gist.") {
+			tokenLookupHost = strings.TrimPrefix(tokenLookupHost, "gist.")
+		}
+		gotToken, _, tokenErr := cfg.TokenForUser(tokenLookupHost, opts.Account)
+		if tokenErr != nil {
+			return fmt.Errorf("gh auth git-credential: account %q not found on %s", opts.Account, lookupHost)
+		}
+		fmt.Fprint(opts.IO.Out, "protocol=https\n")
+		fmt.Fprintf(opts.IO.Out, "host=%s\n", wants["host"])
+		fmt.Fprintf(opts.IO.Out, "username=%s\n", opts.Account)
+		fmt.Fprintf(opts.IO.Out, "password=%s\n", gotToken)
+		return nil
+	}
+
 	var gotUser string
 	gotToken, source := cfg.ActiveToken(lookupHost)
 	if gotToken == "" && strings.HasPrefix(lookupHost, "gist.") {

--- a/pkg/cmd/auth/gitcredential/helper.go
+++ b/pkg/cmd/auth/gitcredential/helper.go
@@ -118,7 +118,7 @@ func helperRun(opts *CredentialOptions) error {
 
 	if opts.Account != "" {
 		if wants["username"] != "" && !strings.EqualFold(wants["username"], opts.Account) {
-			return fmt.Errorf("gh auth git-credential: --account %q conflicts with requested username %q", opts.Account, wants["username"])
+			return cmdutil.SilentError
 		}
 		tokenLookupHost := lookupHost
 		if strings.HasPrefix(tokenLookupHost, "gist.") {
@@ -126,7 +126,7 @@ func helperRun(opts *CredentialOptions) error {
 		}
 		gotToken, _, tokenErr := cfg.TokenForUser(tokenLookupHost, opts.Account)
 		if tokenErr != nil {
-			return fmt.Errorf("gh auth git-credential: account %q not found on %s", opts.Account, lookupHost)
+			return cmdutil.SilentError
 		}
 		fmt.Fprint(opts.IO.Out, "protocol=https\n")
 		fmt.Fprintf(opts.IO.Out, "host=%s\n", wants["host"])

--- a/pkg/cmd/auth/gitcredential/helper_test.go
+++ b/pkg/cmd/auth/gitcredential/helper_test.go
@@ -18,6 +18,14 @@ func (c tinyConfig) ActiveUser(host string) (string, error) {
 	return c[fmt.Sprintf("%s:%s", host, "user")], nil
 }
 
+func (c tinyConfig) TokenForUser(hostname, user string) (string, string, error) {
+	key := fmt.Sprintf("%s:users:%s:oauth_token", hostname, user)
+	if token, ok := c[key]; ok {
+		return token, "oauth_token", nil
+	}
+	return "", "", fmt.Errorf("no token for %s on %s", user, hostname)
+}
+
 func Test_helperRun(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -234,6 +242,86 @@ func Test_helperRun(t *testing.T) {
 			opts: CredentialOptions{
 				Operation: "unknown",
 			},
+			wantErr: true,
+		},
+		{
+			name: "account with existing token",
+			opts: CredentialOptions{
+				Operation: "get",
+				Account:   "user2",
+				Config: func() (config, error) {
+					return tinyConfig{
+						"example.com:users:user2:oauth_token": "TOKEN2",
+					}, nil
+				},
+			},
+			input: heredoc.Doc(`
+				protocol=https
+				host=example.com
+			`),
+			wantStdout: heredoc.Doc(`
+				protocol=https
+				host=example.com
+				username=user2
+				password=TOKEN2
+			`),
+			wantErr: false,
+		},
+		{
+			name: "account token not found",
+			opts: CredentialOptions{
+				Operation: "get",
+				Account:   "user2",
+				Config: func() (config, error) {
+					return tinyConfig{}, nil
+				},
+			},
+			input: heredoc.Doc(`
+				protocol=https
+				host=example.com
+			`),
+			wantErr: true,
+		},
+		{
+			name: "account matches requested username",
+			opts: CredentialOptions{
+				Operation: "get",
+				Account:   "user2",
+				Config: func() (config, error) {
+					return tinyConfig{
+						"example.com:users:user2:oauth_token": "TOKEN2",
+					}, nil
+				},
+			},
+			input: heredoc.Doc(`
+				protocol=https
+				host=example.com
+				username=user2
+			`),
+			wantStdout: heredoc.Doc(`
+				protocol=https
+				host=example.com
+				username=user2
+				password=TOKEN2
+			`),
+			wantErr: false,
+		},
+		{
+			name: "account conflicts with requested username",
+			opts: CredentialOptions{
+				Operation: "get",
+				Account:   "user2",
+				Config: func() (config, error) {
+					return tinyConfig{
+						"example.com:users:user2:oauth_token": "TOKEN2",
+					}, nil
+				},
+			},
+			input: heredoc.Doc(`
+				protocol=https
+				host=example.com
+				username=user1
+			`),
 			wantErr: true,
 		},
 	}

--- a/pkg/cmd/auth/gitcredential/helper_test.go
+++ b/pkg/cmd/auth/gitcredential/helper_test.go
@@ -324,6 +324,53 @@ func Test_helperRun(t *testing.T) {
 			`),
 			wantErr: true,
 		},
+		{
+			name: "account with gist host",
+			opts: CredentialOptions{
+				Operation: "get",
+				Account:   "user2",
+				Config: func() (config, error) {
+					return tinyConfig{
+						"github.com:users:user2:oauth_token": "TOKEN2",
+					}, nil
+				},
+			},
+			input: heredoc.Doc(`
+				protocol=https
+				host=gist.github.com
+			`),
+			wantStdout: heredoc.Doc(`
+				protocol=https
+				host=gist.github.com
+				username=user2
+				password=TOKEN2
+			`),
+			wantErr: false,
+		},
+		{
+			name: "account with x-access-token username is not a conflict",
+			opts: CredentialOptions{
+				Operation: "get",
+				Account:   "user2",
+				Config: func() (config, error) {
+					return tinyConfig{
+						"example.com:users:user2:oauth_token": "TOKEN2",
+					}, nil
+				},
+			},
+			input: heredoc.Doc(`
+				protocol=https
+				host=example.com
+				username=x-access-token
+			`),
+			wantStdout: heredoc.Doc(`
+				protocol=https
+				host=example.com
+				username=user2
+				password=TOKEN2
+			`),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #9111 

To use specified account for git-credential:

~/.gitconfig:
```
[credential "https://github.com"]
	helper = !/opt/homebrew/bin/gh auth git-credential
	
[includeIf "gitdir:~/work"]
    path = ~/work/.gitconfig
```

~/work/.gitconfig:
```
[credential "https://github.com"]
	helper = !/opt/homebrew/bin/gh auth git-credential --account work-account
```