### PR TITLE
Improve update --all command if some skills don't have metadata

### DIFF
--- a/pkg/cmd/skills/update/update.go
+++ b/pkg/cmd/skills/update/update.go
@@ -338,7 +338,7 @@ func updateRun(opts *UpdateOptions) error {
 		fmt.Fprintf(opts.IO.ErrOut, "%s %s is pinned to %s (skipped)\n", cs.Muted("⊘"), s.name, s.pinned)
 	}
 	for _, name := range noMeta {
-		fmt.Fprintf(opts.IO.ErrOut, "%s %s has no GitHub metadata. Reinstall to enable updates\n", cs.WarningIcon(), name)
+		fmt.Fprintf(opts.IO.ErrOut, "%s %s has no GitHub metadata. Run `gh skill update %s` interactively to add metadata, or reinstall to enable updates\n", cs.WarningIcon(), name, name)
 	}
 
 	if len(updates) == 0 {

--- a/pkg/cmd/skills/update/update.go
+++ b/pkg/cmd/skills/update/update.go
@@ -91,6 +91,7 @@ func NewCmdUpdate(f *cmdutil.Factory, runF func(*UpdateOptions) error) *cobra.Co
 
 			Skills without GitHub metadata (e.g. installed manually or by another
 			tool) are prompted for their source repository in interactive mode.
+			With %[1]s--all%[1]s or in non-interactive mode, they are skipped with a notice.
 			The update re-downloads the skill with metadata injected, so future
 			updates work automatically.
 
@@ -221,7 +222,7 @@ func updateRun(opts *UpdateOptions) error {
 		if s.owner != "" && s.repo != "" {
 			continue
 		}
-		if !canPrompt {
+		if !canPrompt || opts.All {
 			noMeta = append(noMeta, s.name)
 			continue
 		}

--- a/pkg/cmd/skills/update/update_test.go
+++ b/pkg/cmd/skills/update/update_test.go
@@ -475,6 +475,42 @@ func TestUpdateRun(t *testing.T) {
 			wantStderr: "no GitHub metadata",
 		},
 		{
+			name: "all skips no-metadata skill without prompting",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				skillDir := filepath.Join(dir, "manual-skill")
+				require.NoError(t, os.MkdirAll(skillDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(heredoc.Doc(`
+					---
+					name: manual-skill
+					---
+					No metadata
+				`)), 0o644))
+			},
+			stubs: func(reg *httpmock.Registry) {},
+			opts: func(ios *iostreams.IOStreams, dir string, reg *httpmock.Registry) *UpdateOptions {
+				ios.SetStdoutTTY(true)
+				ios.SetStdinTTY(true)
+				ios.SetStderrTTY(true)
+				return &UpdateOptions{
+					IO:     ios,
+					Config: func() (gh.Config, error) { return config.NewBlankConfig(), nil },
+					HttpClient: func() (*http.Client, error) {
+						return &http.Client{Transport: reg}, nil
+					},
+					Prompter: &prompter.PrompterMock{
+						InputFunc: func(prompt string, defaultValue string) (string, error) {
+							return "", fmt.Errorf("unexpected prompt")
+						},
+					},
+					GitClient: &git.Client{RepoDir: dir},
+					Dir:       dir,
+					All:       true,
+				}
+			},
+			wantStderr: "no GitHub metadata",
+		},
+		{
 			name: "all up to date",
 			setup: func(t *testing.T, dir string) {
 				t.Helper()

--- a/pkg/cmd/skills/update/update_test.go
+++ b/pkg/cmd/skills/update/update_test.go
@@ -508,7 +508,7 @@ func TestUpdateRun(t *testing.T) {
 					All:       true,
 				}
 			},
-			wantStderr: "no GitHub metadata",
+			wantStderr: "Run `gh skill update manual-skill` interactively",
 		},
 		{
 			name: "all up to date",


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes https://github.com/cli/cli/issues/13369

## Summary

Fixes `gh skill update --all` so it no longer prompts for skills that are missing GitHub metadata.

When `--all` is used, skills without GitHub metadata are skipped with a notice, matching the flag's "without prompting" behavior.

## Changes

- Skip missing-metadata skills when `--all` is used instead of prompting interactively.
- Keep the warning summary so users know which skills were skipped.
- Update the warning text to explain that users can run `gh skill update <skill>` interactively to add metadata, or reinstall the skill.
- Add a regression test to verify `--all` does not prompt for missing metadata.

## Testing

- `go test ./pkg/cmd/skills/update/... -run TestUpdateRun -count=1`
- `go test ./pkg/cmd/skills/... -count=1`

