### PR TITLE
Remove third-party license debris

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,15 +46,6 @@ jobs:
           upload: false
           output: sarif-results
 
-      - name: Filter SARIF for third-party code
-        if: matrix.language == 'go'
-        uses: advanced-security/filter-sarif@2da736ff05ef065cb2894ac6892e47b5eac2c3c0 # v1.1.0.1.1
-        with:
-          patterns: |
-            -third-party/**
-          input: sarif-results/${{ matrix.language }}.sarif
-          output: sarif-results/${{ matrix.language }}.sarif
-
       - name: Upload filtered SARIF
         uses: github/codeql-action/upload-sarif@v4
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,8 +29,6 @@ linters:
     # - staticcheck
     # - errcheck
   exclusions:
-    paths:
-      - third-party
     rules:
       - path: _test\.go$
         linters:
@@ -62,9 +60,6 @@ linters:
 formatters:
   enable:
     - gofmt
-  exclusions:
-    paths:
-      - third-party
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
## Description

When we [reworked our license bundling](https://github.com/cli/cli/pull/12625), references to `third-party` (where licenses used to be included in the git repo) weren't removed.