### PR TITLE
Remove dependency on persistent token

### DIFF
--- a/.github/workflows/detect-spam.yml
+++ b/.github/workflows/detect-spam.yml
@@ -4,20 +4,19 @@ on:
     types: [opened]
 
 permissions:
-  contents: none
-  issues: write
-  models: read
+  contents: read # check out the repo to run the spam-detection scripts.
+  issues: write # read issue contents (gh issue view), comment, label, and close issues detected as spam.
+  models: read # run inference via `gh models run` for spam classification.
 
 jobs:
   issue-spam:
     runs-on: ubuntu-latest
-    environment: cli-automation
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Run spam detection
         env:
-          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
         run: |
           ./.github/workflows/scripts/spam-detection/process-issue.sh "$ISSUE_URL"


### PR DESCRIPTION
## Description

This token used to be used for lots more things and had a lot more privilege than necessary. Think it can just go away in favour of an actions token.