### PR TITLE
Strip ANSI escapes from run logs

### DIFF
--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -26,6 +27,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/text/transform"
 )
+
+var terminalEscapeSequenceRE = regexp.MustCompile(`\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x07\x1b]*(?:\x07|\x1b\\)|k[^\x07\x1b]*(?:\x07|\x1b\\)|[@-_])`)
 
 type RunLogCache struct {
 	cacheDir string
@@ -581,10 +584,22 @@ func displayLogSegments(w io.Writer, segments []logSegment) error {
 }
 
 func copyLogWithLinePrefix(w io.Writer, r io.Reader, prefix string) error {
-	sanitized := transform.NewReader(r, &asciisanitizer.Sanitizer{})
-	scanner := bufio.NewScanner(sanitized)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		fmt.Fprintf(w, "%s%s\n", prefix, scanner.Text())
+		line, err := sanitizeLogLine(scanner.Text())
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "%s%s\n", prefix, line)
 	}
-	return nil
+	return scanner.Err()
+}
+
+func sanitizeLogLine(line string) (string, error) {
+	stripped := terminalEscapeSequenceRE.ReplaceAllString(line, "")
+	sanitized, err := io.ReadAll(transform.NewReader(bytes.NewReader([]byte(stripped)), &asciisanitizer.Sanitizer{}))
+	if err != nil {
+		return "", err
+	}
+	return string(sanitized), nil
 }

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -2763,26 +2763,32 @@ func TestCopyLogWithLinePrefix_TerminalEscapeSequences(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
+		want  string
 	}{
 		{
 			name:  "OSC title set sequence",
 			input: "normal prefix\x1b]0;HIJACKED TITLE\x07trailing text\n",
+			want:  "jobname\tstep\tnormal prefixtrailing text\n",
 		},
 		{
 			name:  "CSI color sequence",
-			input: "\x1b[31mRED TEXT\x1b[0m normal text\n",
+			input: "\x1b[1;93m  •\x1b[m \x1b[1;93mskipping announce\x1b[m\n",
+			want:  "jobname\tstep\t  • skipping announce\n",
 		},
 		{
 			name:  "screen title set sequence used in original report",
 			input: "\x1bk;echo this is an arbitrary command;\x1b\\\n",
+			want:  "jobname\tstep\t\n",
 		},
 		{
 			name:  "CSI window title query",
 			input: "before\x1b[21tafter\n",
+			want:  "jobname\tstep\tbeforeafter\n",
 		},
 		{
 			name:  "multiple escape sequences",
 			input: "\x1b]0;title\x07\x1b[31mred\x1b[0m\x1b[21t\n",
+			want:  "jobname\tstep\tred\n",
 		},
 	}
 
@@ -2793,8 +2799,11 @@ func TestCopyLogWithLinePrefix_TerminalEscapeSequences(t *testing.T) {
 			require.NoError(t, err)
 
 			output := buf.String()
+			assert.Equal(t, tt.want, output)
 			assert.NotContains(t, output, "\x1b",
 				"output should not contain raw ESC (0x1b) bytes, got: %q", output)
+			assert.NotContains(t, output, "^[",
+				"output should not contain escaped terminal control bytes, got: %q", output)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #13434

## Summary
- strip terminal escape sequences from run log lines before applying the existing ASCII control sanitizer
- keep malformed or remaining control bytes protected by the sanitizer
- add regression coverage for SGR color escapes plus existing title/control escape cases

## Testing
- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache go test ./pkg/cmd/run/view -run TestCopyLogWithLinePrefix_TerminalEscapeSequences -count=1`
- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache go test ./pkg/cmd/run/view -count=1`
- `GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache go test ./pkg/cmd/run/... -count=1`
- `git diff --check`

`GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache go test ./...` was also run; it fails in unrelated environment-sensitive packages: `internal/ghcmd` pager expectations resolve to `cat`, `internal/prompter` accessible prompt tests time out, and `pkg/surveyext` prompt tests expect ANSI color output while this environment emits plain text.