### PR TITLE
Fix non-TTY `gh issue view --comments` output for zero-comment issues

### DIFF
--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -186,15 +186,10 @@ func viewRun(opts *ViewOptions) error {
 		return printHumanIssuePreview(opts, baseRepo, issue)
 	}
 
-	if opts.Comments {
-		fmt.Fprint(opts.IO.Out, prShared.RawCommentList(issue.Comments, api.PullRequestReviews{}))
-		return nil
-	}
-
-	return printRawIssuePreview(opts.IO.Out, issue)
+	return printRawIssuePreview(opts.IO.Out, issue, opts.Comments)
 }
 
-func printRawIssuePreview(out io.Writer, issue *api.Issue) error {
+func printRawIssuePreview(out io.Writer, issue *api.Issue, includeComments bool) error {
 	assignees := issueAssigneeList(*issue)
 	labels := issueLabelList(issue, nil)
 	projects := issueProjectList(*issue)
@@ -234,6 +229,10 @@ func printRawIssuePreview(out io.Writer, issue *api.Issue) error {
 	fmt.Fprintf(out, "number:\t%d\n", issue.Number)
 	fmt.Fprintln(out, "--")
 	fmt.Fprintln(out, issue.Body)
+	if includeComments && len(issue.Comments.Nodes) > 0 {
+		fmt.Fprintln(out, "--")
+		fmt.Fprint(out, prShared.RawCommentList(issue.Comments, api.PullRequestReviews{}))
+	}
 	return nil
 }
 

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -487,6 +487,12 @@ func TestIssueView_nontty_Comments(t *testing.T) {
 				mockEmptyV2ProjectItems(t, r)
 			},
 			expectedOutputs: []string{
+				`title:\tsome title`,
+				`state:\tOPEN`,
+				`author:\tmarseilles`,
+				`comments:\t6`,
+				`number:\t123`,
+				`some body`,
 				`author:\tmonalisa`,
 				`association:\t`,
 				`edited:\ttrue`,
@@ -507,6 +513,64 @@ func TestIssueView_nontty_Comments(t *testing.T) {
 				`association:\tcollaborator`,
 				`edited:\tfalse`,
 				`Comment 5`,
+			},
+		},
+		"with comments flag and no comments": {
+			cli: "123 --comments",
+			httpStubs: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.GraphQL(`query IssueByNumber\b`),
+					httpmock.JSONResponse(map[string]any{
+						"data": map[string]any{
+							"repository": map[string]any{
+								"hasIssuesEnabled": true,
+								"issue": map[string]any{
+									"number":    123,
+									"title":     "some title",
+									"body":      "some body",
+									"state":     "OPEN",
+									"createdAt": "2020-01-01T12:00:00Z",
+									"author": map[string]any{
+										"login": "marseilles",
+									},
+									"assignees": map[string]any{
+										"nodes":      []any{},
+										"totalCount": 0,
+									},
+									"labels": map[string]any{
+										"nodes":      []any{},
+										"totalCount": 0,
+									},
+									"projectItems": map[string]any{
+										"nodes":      []any{},
+										"totalCount": 0,
+									},
+									"milestone": map[string]any{
+										"title": "",
+									},
+									"comments": map[string]any{
+										"nodes":      []any{},
+										"totalCount": 0,
+										"pageInfo": map[string]any{
+											"hasNextPage": false,
+											"endCursor":   nil,
+										},
+									},
+									"url": "https://github.com/OWNER/REPO/issues/123",
+								},
+							},
+						},
+					}),
+				)
+				mockEmptyV2ProjectItems(t, r)
+			},
+			expectedOutputs: []string{
+				`title:\tsome title`,
+				`state:\tOPEN`,
+				`author:\tmarseilles`,
+				`comments:\t0`,
+				`number:\t123`,
+				`some body`,
 			},
 		},
 		"with invalid comments flag": {


### PR DESCRIPTION
Fixes #13452

## Summary
- include the raw issue preview in non-TTY output when `gh issue view --comments` is used
- keep appending raw comments after the preview when comments exist
- add a regression test for the zero-comment case

## Testing
- `go test ./pkg/cmd/issue/view/...`
- built `gh` locally and reran the issue reproduction commands against `saurabhav88/EnviousWispr#779`
- `go test ./...` hits an unrelated local `safe.bareRepository` failure in `git/client_test.go`
- `make lint` requires `golangci-lint` in the local environment
