### PR TITLE
Run govulncheck daily instead of weekly

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,7 +1,7 @@
 name: Go Vulnerability Check
 on:
   schedule:
-    - cron: "0 0 * * 1" # Every Monday at midnight UTC
+    - cron: "0 0 * * *" # Every day at midnight UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Updates the `govulncheck` workflow cron schedule from weekly (Mondays at midnight UTC) to daily at midnight UTC, so vulnerability reports surface more promptly. Dunno why it didn't ran so infrequently, seems like a 6 day lag is unreasonably long.