### PR TITLE
Add 3 day dependabot cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  cooldown:
+    default-days: 3
   ignore:
     - dependency-name: "*"
       update-types:
@@ -12,3 +14,5 @@ updates:
   directory: "/"
   schedule:
       interval: "daily"
+  cooldown:
+    default-days: 3


### PR DESCRIPTION
Adds a 3 day cooldown period to dependabot updates for both gomod and github-actions ecosystems, mirroring the pattern used in [cli/go-gh](https://github.com/cli/go-gh/blob/trunk/.github/dependabot.yml) (with a shorter cooldown).

This reduces churn from rapidly-superseded releases by giving new versions time to settle before dependabot proposes them.