### PR TITLE
SHA pin first-party GitHub Actions

### DIFF
--- a/.github/workflows/bump-go.yml
+++ b/.github/workflows/bump-go.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,29 +25,29 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
         if: matrix.language == 'go'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.35.5
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.35.5
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: "/language:${{ matrix.language }}"
           upload: false
           output: sarif-results
 
       - name: Upload filtered SARIF
-        uses: github/codeql-action/upload-sarif@v4.35.5
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -46,9 +46,9 @@ jobs:
     if: contains(inputs.platforms, 'linux')
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Install GoReleaser
@@ -72,7 +72,7 @@ jobs:
         run: |
           go run ./cmd/gen-docs --website --doc-path dist/manual
           tar -czvf dist/manual.tar.gz -C dist -- manual
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linux
           if-no-files-found: error
@@ -89,9 +89,9 @@ jobs:
     if: contains(inputs.platforms, 'macos')
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Configure macOS signing
@@ -152,7 +152,7 @@ jobs:
         run: |
           shopt -s failglob
           script/pkgmacos "$TAG_NAME"
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos
           if-no-files-found: error
@@ -169,9 +169,9 @@ jobs:
     if: contains(inputs.platforms, 'windows')
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Install GoReleaser
@@ -269,7 +269,7 @@ jobs:
           Get-ChildItem -Path .\dist -Filter *.msi | ForEach-Object {
             .\script\sign.ps1 $_.FullName
           }
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows
           if-no-files-found: error
@@ -285,11 +285,11 @@ jobs:
     if: inputs.release
     steps:
       - name: Checkout cli/cli
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Merge built artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: Checkout documentation site
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: github/cli.github.com
           path: site

--- a/.github/workflows/detect-spam.yml
+++ b/.github/workflows/detect-spam.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run spam detection
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
 
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
 

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -12,10 +12,10 @@ jobs:
       security-events: write
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
 
@@ -26,6 +26,6 @@ jobs:
           go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 -format sarif ./... > gh.sarif
 
       - name: Upload SARIF report
-        uses: github/codeql-action/upload-sarif@v4.35.5
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: gh.sarif

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
 
@@ -67,10 +67,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
 


### PR DESCRIPTION
Closes #13490.

## What

Replaces every `actions/*` and `github/*` `uses:` reference in `.github/workflows/*.yml` with the equivalent commit SHA, preserving the human-readable version in a trailing comment. This matches the convention already used for third-party action pins in this repo, e.g. `golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0`.

Unique pins introduced:

| Action | Pinned to |
| --- | --- |
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` |
| `actions/setup-go` | `4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0` |
| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1` |
| `actions/download-artifact` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1` |
| `github/codeql-action/{init,analyze,upload-sarif}` | `7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0` |

`actions/attest` was already SHA-pinned and is unchanged.

Some screenshots to verify shas above:

<img width="1567" height="301" alt="image" src="https://github.com/user-attachments/assets/a31ccbe6-9705-4780-8a77-9702f1713296" />

<img width="1588" height="312" alt="image" src="https://github.com/user-attachments/assets/6d3f7154-d50a-4fc7-948d-4f86392fefa4" />

<img width="1636" height="315" alt="image" src="https://github.com/user-attachments/assets/79e73dbf-f25d-4a9a-a36e-dfa1262b0db4" />

<img width="1733" height="478" alt="image" src="https://github.com/user-attachments/assets/12ecfa2e-08a7-4f86-9e8b-cadde368d601" />

<img width="1725" height="677" alt="image" src="https://github.com/user-attachments/assets/5fcea07c-e2af-4dfa-a53c-aca57bc486e7" />

## Why

Per #13490: with the 3-day dependabot cooldown configured for both `gomod` and `github-actions`, version-tag references give no real benefit (dependabot still opens PRs on patch releases) while leaving us exposed to tag-mutation supply chain attacks on first-party namespaces. SHA pinning is the more consistent and defensible posture and matches what we already do for third-party actions.

## Verification

- Every changed `checkout`/`setup-go`/`codeql-action`/`upload-artifact` call is exercised by the `lint`, `go`, `codeql`, and `govulncheck` workflows on this PR.
- The release-only paths in `deployment.yml` (`download-artifact`, additional `upload-artifact`/`checkout` invocations) are not exercised by PR workflows. Since this change only swaps the ref (no argument changes), and the same actions are exercised elsewhere on PR, the residual risk at the next release is low.
- Dependabot natively parses `<sha> # vX.Y.Z` pins and will bump both the SHA and the comment on the next patch release, validating the chosen format.

## Out of scope

- `desktop/gh-cli-and-desktop-shared-workflows/...@main` reusable workflow references. These are jointly owned with the desktop team and we should pin the actions used **in** them, but I don't think we suffer much exposure by keeping first party on `@main`?