### PR TITLE
Replace SITE_DEPLOY_PAT with gh-cli-site-deployer App

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -288,13 +288,25 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Merge built artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - name: Generate site deploy token
+        id: site-deploy-token
+        if: inputs.environment == 'production'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.SITE_DEPLOY_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SITE_DEPLOY_APP_PRIVATE_KEY }}
+          owner: github
+          repositories: cli.github.com
       - name: Checkout documentation site
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: github/cli.github.com
           path: site
           fetch-depth: 0
-          token: ${{ secrets.SITE_DEPLOY_PAT }}
+          # In non-production environments the App token step is skipped, so
+          # fall back to github.token for anonymous read access to the public
+          # cli.github.com repo (push is gated separately on DO_PUBLISH).
+          token: ${{ steps.site-deploy-token.outputs.token || github.token }}
       - name: Update site man pages
         env:
           GIT_COMMITTER_NAME: cli automation

--- a/docs/release-process-deep-dive.md
+++ b/docs/release-process-deep-dive.md
@@ -442,13 +442,25 @@ release:
         uses: actions/checkout@v4
       - name: Merge built artifacts
         uses: actions/download-artifact@v4
+      - name: Generate site deploy token
+        id: site-deploy-token
+        if: inputs.environment == 'production'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.SITE_DEPLOY_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SITE_DEPLOY_APP_PRIVATE_KEY }}
+          owner: github
+          repositories: cli.github.com
       - name: Checkout documentation site
         uses: actions/checkout@v4
         with:
           repository: github/cli.github.com
           path: site
           fetch-depth: 0
-          token: ${{ secrets.SITE_DEPLOY_PAT }}
+          # In non-production environments the App token step is skipped, so
+          # fall back to github.token for anonymous read access to the public
+          # cli.github.com repo (push is gated separately on DO_PUBLISH).
+          token: ${{ steps.site-deploy-token.outputs.token || github.token }}
       - name: Update site man pages
         env:
           GIT_COMMITTER_NAME: cli automation


### PR DESCRIPTION
## Summary

Replaces the personally-held `SITE_DEPLOY_PAT` used by the release workflow with an installation token from the new `gh-cli-site-deployer` GitHub App that is installed on the `github/cli.github.com` repository.

An example of this working can be seen for @babakks and @BagToad at https://github.com/williammartin/gh-cli-site-deployer-smoke-test/actions/runs/26300057269

Note: the secrets aren't in the production environment yet, awaiting federation, or manual addition, but would like review of this first.