### PR TITLE
Require repository name for visibility changes

### DIFF
--- a/pkg/cmd/repo/edit/edit.go
+++ b/pkg/cmd/repo/edit/edit.go
@@ -467,11 +467,13 @@ func interactiveRepoEdit(opts *EditOptions, r *api.Repository) error {
 				fmt.Fprintf(opts.IO.ErrOut, "%s Changing the repository visibility to %s will cause permanent loss of %s and %s.\n", cs.WarningIcon(), selectedVisibility, text.Pluralize(r.StargazerCount, "star"), text.Pluralize(r.Watchers.TotalCount, "watcher"))
 			}
 
-			confirmed, err := p.Confirm(fmt.Sprintf("Do you want to change visibility to %s?", selectedVisibility), false)
+			repoFullName := ghrepo.FullName(opts.Repository)
+			confirmationPrompt := fmt.Sprintf("Type %s to confirm changing visibility to %s", repoFullName, selectedVisibility)
+			confirmedRepository, err := p.Input(confirmationPrompt, "")
 			if err != nil {
 				return err
 			}
-			if confirmed {
+			if confirmedRepository == repoFullName {
 				opts.Edits.Visibility = &selectedVisibility
 			}
 		case optionMergeOptions:

--- a/pkg/cmd/repo/edit/edit_test.go
+++ b/pkg/cmd/repo/edit/edit_test.go
@@ -406,7 +406,7 @@ func Test_editRun_interactive(t *testing.T) {
 			},
 		},
 		{
-			name: "skipping visibility without confirmation",
+			name: "skipping visibility without matching repository confirmation",
 			opts: EditOptions{
 				Repository:      ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				InteractiveMode: true,
@@ -420,8 +420,8 @@ func Test_editRun_interactive(t *testing.T) {
 					func(_, _ string, opts []string) (int, error) {
 						return prompter.IndexFor(opts, "private")
 					})
-				pm.RegisterConfirm("Do you want to change visibility to private?", func(_ string, _ bool) (bool, error) {
-					return false, nil
+				pm.RegisterInput("Type OWNER/REPO to confirm changing visibility to private", func(_, _ string) (string, error) {
+					return "OWNER/OTHER", nil
 				})
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
@@ -454,7 +454,7 @@ func Test_editRun_interactive(t *testing.T) {
 			wantsStderr: "Changing the repository visibility to private will cause permanent loss of 10 stars and 0 watchers.",
 		},
 		{
-			name: "changing visibility with confirmation",
+			name: "changing visibility with matching repository confirmation",
 			opts: EditOptions{
 				Repository:      ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 				InteractiveMode: true,
@@ -468,8 +468,8 @@ func Test_editRun_interactive(t *testing.T) {
 					func(_, _ string, opts []string) (int, error) {
 						return prompter.IndexFor(opts, "private")
 					})
-				pm.RegisterConfirm("Do you want to change visibility to private?", func(_ string, _ bool) (bool, error) {
-					return true, nil
+				pm.RegisterInput("Type OWNER/REPO to confirm changing visibility to private", func(_, _ string) (string, error) {
+					return "OWNER/REPO", nil
 				})
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {


### PR DESCRIPTION
Fixes #13435

## Summary

This updates the interactive `gh repo edit` visibility flow to require typing the full `OWNER/REPO` repository name before applying a visibility change, instead of accepting a yes/no confirmation.

The non-interactive `--accept-visibility-change-consequences` behavior is unchanged.

## Motivation

Changing a public repository to private can have lasting consequences for stars, watchers, forks, and repository network state. A recent Hexo incident showed how easy it is to run `gh repo edit` from the wrong local checkout and only notice the repository name after the change has already happened: https://github.com/hexojs/site/pull/2534

Requiring the full repository name makes the interactive CLI flow closer to the safer confirmation pattern used by repository deletion and GitHub.com.

## Testing

- `go test ./pkg/cmd/repo/edit`
