### PR TITLE
fix(agent-task/capi): don't re-attach Bearer on cross-host redirect

### DIFF
--- a/pkg/cmd/agent-task/capi/client.go
+++ b/pkg/cmd/agent-task/capi/client.go
@@ -62,16 +62,30 @@ func newCAPITransport(token string, capiBaseURL string, rp http.RoundTripper) *c
 }
 
 func (ct *capiTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", "Bearer "+ct.token)
+	var redirectHostnameChange bool
+	if req.Response != nil && req.Response.Request != nil {
+		redirectHostnameChange = reqHost(req) != reqHost(req.Response.Request)
+	}
+
+	if !redirectHostnameChange {
+		req.Header.Set("Authorization", "Bearer "+ct.token)
+	}
 
 	// Since this RoundTrip is reused for both Copilot API and
 	// GitHub API requests, we conditionally add the integration
 	// ID only when performing requests to the Copilot API.
-	if req.URL.Host == ct.capiHost {
+	if !redirectHostnameChange && req.URL.Host == ct.capiHost {
 		req.Header.Add("Copilot-Integration-Id", "copilot-4-cli")
 
 		// Ensure we are not using GitHub API versions while targeting CAPI.
 		req.Header.Set("X-GitHub-Api-Version", "2026-01-09")
 	}
 	return ct.rp.RoundTrip(req)
+}
+
+func reqHost(r *http.Request) string {
+	if r.Host != "" {
+		return r.Host
+	}
+	return r.URL.Host
 }

--- a/pkg/cmd/agent-task/capi/client_redirect_test.go
+++ b/pkg/cmd/agent-task/capi/client_redirect_test.go
@@ -1,0 +1,95 @@
+package capi
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCAPITransport_DoesNotLeakBearerOnCrossHostRedirect(t *testing.T) {
+	const secretToken = "test-bearer-must-not-leak"
+
+	var (
+		mu               sync.Mutex
+		attackerAuthSeen string
+	)
+
+	attackerLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	attackerSrv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attackerAuthSeen = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})}
+	go func() { _ = attackerSrv.Serve(attackerLn) }()
+	defer attackerSrv.Close()
+	attackerURL := "http://" + attackerLn.Addr().String()
+
+	legitSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", attackerURL+"/leaked")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer legitSrv.Close()
+
+	httpClient := &http.Client{Transport: http.DefaultTransport}
+	httpClient.Transport = newCAPITransport(secretToken, legitSrv.URL, httpClient.Transport)
+
+	req, err := http.NewRequest("GET", legitSrv.URL+"/v1/jobs", nil)
+	require.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, attackerAuthSeen,
+		"capiTransport must not re-attach the Bearer token on a cross-host redirect; "+
+			"got Authorization=%q on the cross-host hop", attackerAuthSeen)
+}
+
+func TestCAPITransport_AttachesBearerOnSameHostRedirect(t *testing.T) {
+	const secretToken = "test-bearer-allowed-same-host"
+
+	var (
+		mu              sync.Mutex
+		secondHopAuth   string
+		secondHopCalled bool
+	)
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/v1/jobs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", srv.URL+"/v1/jobs/second-hop")
+		w.WriteHeader(http.StatusFound)
+	})
+	mux.HandleFunc("/v1/jobs/second-hop", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		secondHopCalled = true
+		secondHopAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	httpClient := &http.Client{Transport: http.DefaultTransport}
+	httpClient.Transport = newCAPITransport(secretToken, srv.URL, httpClient.Transport)
+
+	req, err := http.NewRequest("GET", srv.URL+"/v1/jobs", nil)
+	require.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.True(t, secondHopCalled, "second hop on same host should have been reached")
+	assert.Equal(t, "Bearer "+secretToken, secondHopAuth,
+		"capiTransport must still attach the Bearer token on a same-host redirect")
+}


### PR DESCRIPTION
## Description

Fixes #13464.

(Re-opening this PR — the previous one (#13463) was auto-closed by the contribution-requirements bot because the linked issue #13464 had not been triaged with the `help wanted` label yet. The fix below is unchanged.)

`capiTransport.RoundTrip` (`pkg/cmd/agent-task/capi/client.go`) was setting the `Authorization` header on every request unconditionally. On a redirect follow-up to a different host, this re-attached the Bearer token after the Go stdlib had stripped it.

This PR matches the pattern already used by `api.AddAuthTokenHeader` (`api/http_client.go:108`): inspect `req.Response.Request` to detect a redirect follow-up, compare its host with the current request's host, and skip re-attaching the token when they differ. Same-host redirects continue to carry the token, which matches the stdlib's own behaviour.

This keeps the two transports consistent with each other.

## Key changes

- **`pkg/cmd/agent-task/capi/client.go`**: in `(*capiTransport).RoundTrip`, compute `redirectHostnameChange` the same way `api.AddAuthTokenHeader` does, and skip setting `Authorization` and the CAPI-only `Copilot-Integration-Id` / `X-GitHub-Api-Version` headers when the host changed during a redirect. Adds a small `reqHost` helper mirroring `api/http_client.go:getHost`.

- **`pkg/cmd/agent-task/capi/client_redirect_test.go`**: adds two regression tests using loopback HTTP servers on different ports:
  - `TestCAPITransport_DoesNotLeakBearerOnCrossHostRedirect` — first server 302s to the second; asserts the second server receives an empty `Authorization` header.
  - `TestCAPITransport_AttachesBearerOnSameHostRedirect` — same-host redirect must still carry the Bearer token, documenting intended behaviour and preventing over-correction.