### PR TITLE
docs: note immutable releases starting v2.93.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ For information on all pre-installed tools, see [`actions/runner-images`](https:
 
 ### Verification of binaries
 
+Starting with v2.93.0, releases of `gh` are published as immutable releases. For more information, see [Immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases).
+
 Since version 2.50.0, `gh` has been producing [Build Provenance Attestation](https://github.blog/changelog/2024-06-25-artifact-attestations-is-generally-available/), enabling a cryptographically verifiable paper-trail back to the origin GitHub repository, git revision, and build instructions used. The build provenance attestations are signed and rely on Public Good [Sigstore](https://www.sigstore.dev/) for PKI.
 
 There are two common ways to verify a downloaded release, depending on whether `gh` is already installed or not. If `gh` is installed, it's trivial to verify a new release:


### PR DESCRIPTION
We have enabled immutable releases on `gh` for our future releases.

This adds a short note to the "Verification of binaries" section of the README letting users know that releases of `gh` will be immutable starting with v2.93.0.