### PR TITLE
Support custom CLAUDE_CONFIG_DIR in install

### DIFF
--- a/internal/skills/registry/registry.go
+++ b/internal/skills/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -29,6 +30,8 @@ const (
 	ScopeUser    Scope = "user"
 
 	DefaultAgentID = "github-copilot"
+
+	claudeConfigDirEnv = "CLAUDE_CONFIG_DIR"
 
 	sharedProjectSkillsDir = ".agents/skills"
 )
@@ -387,6 +390,11 @@ func (h *AgentHost) InstallDir(scope Scope, gitRoot, homeDir string) (string, er
 		}
 		return filepath.Join(gitRoot, h.ProjectDir), nil
 	case ScopeUser:
+		if h.ID == "claude-code" {
+			if configDir := os.Getenv(claudeConfigDirEnv); configDir != "" {
+				return filepath.Join(configDir, "skills"), nil
+			}
+		}
 		if homeDir == "" {
 			return "", fmt.Errorf("could not determine home directory")
 		}

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -83,7 +83,7 @@ func TestInstallDir(t *testing.T) {
 			wantDir: filepath.Join("/home/monalisa", ".claude", "skills"),
 		},
 		{
-			name: "claude code user scope",
+			name: "claude code user scope, respect env var",
 			setup: func(t *testing.T) {
 				t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join("/home", "monalisa", ".config", "claude"))
 			},

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -72,6 +72,14 @@ func TestInstallDir(t *testing.T) {
 			wantDir: filepath.Join("/tmp/monalisa-repo", ".claude", "skills"),
 		},
 		{
+			name:    "claude code user scope",
+			hostID:  "claude-code",
+			scope:   ScopeUser,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/home/monalisa", ".claude", "skills"),
+		},
+		{
 			name:    "cursor project scope",
 			hostID:  "cursor",
 			scope:   ScopeProject,
@@ -142,6 +150,17 @@ func TestInstallDir(t *testing.T) {
 			assert.Equal(t, tt.wantDir, dir)
 		})
 	}
+}
+
+func TestInstallDir_ClaudeConfigDir(t *testing.T) {
+	t.Setenv(claudeConfigDirEnv, filepath.Join("/home", "monalisa", ".config", "claude"))
+
+	host, err := FindByID("claude-code")
+	require.NoError(t, err)
+
+	dir, err := host.InstallDir(ScopeUser, "/tmp/monalisa-repo", "/home/monalisa")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home", "monalisa", ".config", "claude", "skills"), dir)
 }
 
 func TestRepoNameFromRemote(t *testing.T) {

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -38,6 +38,8 @@ func TestFindByID(t *testing.T) {
 }
 
 func TestInstallDir(t *testing.T) {
+	t.Setenv(claudeConfigDirEnv, "")
+
 	tests := []struct {
 		name    string
 		hostID  string

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -42,6 +42,7 @@ func TestInstallDir(t *testing.T) {
 
 	tests := []struct {
 		name    string
+		setup   func(*testing.T)
 		hostID  string
 		scope   Scope
 		gitRoot string
@@ -80,6 +81,17 @@ func TestInstallDir(t *testing.T) {
 			gitRoot: "/tmp/monalisa-repo",
 			homeDir: "/home/monalisa",
 			wantDir: filepath.Join("/home/monalisa", ".claude", "skills"),
+		},
+		{
+			name: "claude code user scope",
+			setup: func(t *testing.T) {
+				t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join("/home", "monalisa", ".config", "claude"))
+			},
+			hostID:  "claude-code",
+			scope:   ScopeUser,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/home", "monalisa", ".config", "claude", "skills"),
 		},
 		{
 			name:    "cursor project scope",
@@ -140,6 +152,10 @@ func TestInstallDir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+
 			host, err := FindByID(tt.hostID)
 			require.NoError(t, err)
 
@@ -152,17 +168,6 @@ func TestInstallDir(t *testing.T) {
 			assert.Equal(t, tt.wantDir, dir)
 		})
 	}
-}
-
-func TestInstallDir_ClaudeConfigDir(t *testing.T) {
-	t.Setenv(claudeConfigDirEnv, filepath.Join("/home", "monalisa", ".config", "claude"))
-
-	host, err := FindByID("claude-code")
-	require.NoError(t, err)
-
-	dir, err := host.InstallDir(ScopeUser, "/tmp/monalisa-repo", "/home/monalisa")
-	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/home", "monalisa", ".config", "claude", "skills"), dir)
 }
 
 func TestRepoNameFromRemote(t *testing.T) {

--- a/pkg/cmd/skills/install/install_test.go
+++ b/pkg/cmd/skills/install/install_test.go
@@ -1537,6 +1537,40 @@ func TestInstallProgress(t *testing.T) {
 	assert.NotNil(t, installProgress(ios, 2))
 }
 
+func TestInstallRun_ClaudeCodeUserScopeUsesConfigDir(t *testing.T) {
+	homeDir := t.TempDir()
+	claudeConfigDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeConfigDir)
+
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	stubResolveVersion(reg, "monalisa", "skills-repo", "v1.0.0", "abc123")
+	stubDiscoverTree(reg, "monalisa", "skills-repo", "abc123",
+		singleSkillTreeJSON("git-commit", "treeSHA", "blobSHA"))
+	stubInstallFiles(reg, "monalisa", "skills-repo", "treeSHA", "blobSHA", gitCommitContent)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	err := installRun(&InstallOptions{
+		IO:           ios,
+		HttpClient:   func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+		GitClient:    &git.Client{RepoDir: t.TempDir()},
+		SkillSource:  "monalisa/skills-repo",
+		SkillName:    "git-commit",
+		Agent:        "claude-code",
+		Scope:        "user",
+		ScopeChanged: true,
+		Telemetry:    &telemetry.NoOpService{},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Installed git-commit")
+	assert.FileExists(t, filepath.Join(claudeConfigDir, "skills", "git-commit", "SKILL.md"))
+	assert.NoFileExists(t, filepath.Join(homeDir, ".claude", "skills", "git-commit", "SKILL.md"))
+}
+
 func TestInstallRun_DeduplicatesSharedProjectDirAcrossHosts(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/pkg/cmd/skills/install/install_test.go
+++ b/pkg/cmd/skills/install/install_test.go
@@ -292,6 +292,7 @@ func TestInstallRun(t *testing.T) {
 		wantErr    string
 		wantStdout string
 		wantStderr string
+		assert     func(t *testing.T)
 	}{
 		{
 			name:  "non-interactive without repo errors",
@@ -1480,6 +1481,37 @@ func TestInstallRun(t *testing.T) {
 			wantStdout: "Installed hidden-skill",
 			wantStderr: "Skills in hidden directories",
 		},
+		{
+			name: "respect claude code config dir env var for user scope",
+			setup: func(t *testing.T) {
+				t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+			},
+			stubs: func(reg *httpmock.Registry) {
+				stubResolveVersion(reg, "monalisa", "skills-repo", "v1.0.0", "abc123")
+				stubDiscoverTree(reg, "monalisa", "skills-repo", "abc123",
+					singleSkillTreeJSON("git-commit", "treeSHA", "blobSHA"))
+				stubInstallFiles(reg, "monalisa", "skills-repo", "treeSHA", "blobSHA", gitCommitContent)
+			},
+			opts: func(ios *iostreams.IOStreams, reg *httpmock.Registry) *InstallOptions {
+				t.Helper()
+				return &InstallOptions{
+					IO:           ios,
+					HttpClient:   func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+					GitClient:    &git.Client{RepoDir: t.TempDir()},
+					SkillSource:  "monalisa/skills-repo",
+					SkillName:    "git-commit",
+					Agent:        "claude-code",
+					Scope:        "user",
+					ScopeChanged: true,
+					Telemetry:    &telemetry.NoOpService{},
+				}
+			},
+			assert: func(t *testing.T) {
+				assert.FileExists(t, filepath.Join(os.Getenv("CLAUDE_CONFIG_DIR"), "skills", "git-commit", "SKILL.md"))
+				assert.NoFileExists(t, filepath.Join(os.Getenv("HOME"), ".claude", "skills", "git-commit", "SKILL.md"))
+			},
+			wantStdout: "Installed git-commit",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1525,6 +1557,9 @@ func TestInstallRun(t *testing.T) {
 			if tt.verify != nil {
 				tt.verify(t)
 			}
+			if tt.assert != nil {
+				tt.assert(t)
+			}
 		})
 	}
 }
@@ -1535,40 +1570,6 @@ func TestInstallProgress(t *testing.T) {
 	assert.Nil(t, installProgress(ios, 0))
 	assert.NotNil(t, installProgress(ios, 1))
 	assert.NotNil(t, installProgress(ios, 2))
-}
-
-func TestInstallRun_ClaudeCodeUserScopeUsesConfigDir(t *testing.T) {
-	homeDir := t.TempDir()
-	claudeConfigDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
-	t.Setenv("USERPROFILE", homeDir)
-	t.Setenv("CLAUDE_CONFIG_DIR", claudeConfigDir)
-
-	reg := &httpmock.Registry{}
-	defer reg.Verify(t)
-
-	stubResolveVersion(reg, "monalisa", "skills-repo", "v1.0.0", "abc123")
-	stubDiscoverTree(reg, "monalisa", "skills-repo", "abc123",
-		singleSkillTreeJSON("git-commit", "treeSHA", "blobSHA"))
-	stubInstallFiles(reg, "monalisa", "skills-repo", "treeSHA", "blobSHA", gitCommitContent)
-
-	ios, _, stdout, _ := iostreams.Test()
-
-	err := installRun(&InstallOptions{
-		IO:           ios,
-		HttpClient:   func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
-		GitClient:    &git.Client{RepoDir: t.TempDir()},
-		SkillSource:  "monalisa/skills-repo",
-		SkillName:    "git-commit",
-		Agent:        "claude-code",
-		Scope:        "user",
-		ScopeChanged: true,
-		Telemetry:    &telemetry.NoOpService{},
-	})
-	require.NoError(t, err)
-	assert.Contains(t, stdout.String(), "Installed git-commit")
-	assert.FileExists(t, filepath.Join(claudeConfigDir, "skills", "git-commit", "SKILL.md"))
-	assert.NoFileExists(t, filepath.Join(homeDir, ".claude", "skills", "git-commit", "SKILL.md"))
 }
 
 func TestInstallRun_DeduplicatesSharedProjectDirAcrossHosts(t *testing.T) {


### PR DESCRIPTION
<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->

Fixes https://github.com/cli/cli/issues/13262

## Summary

This updates Claude Code user-scope skill directory resolution to honor `CLAUDE_CONFIG_DIR` when it is set. User-scope installs for Claude Code now write to `$CLAUDE_CONFIG_DIR/skills`, falling back to the existing `~/.claude/skills` location when the environment variable is not present.

The change lives in the shared agent registry path resolver so `gh skill install`, `gh skill list`, and `gh skill update` all use the same location for Claude Code user-scope skills.

## Tests

- Added registry coverage for Claude Code's default user-scope path and `CLAUDE_CONFIG_DIR` override.
- Added an install regression test that verifies `gh skill install --agent claude-code --scope user` writes under `$CLAUDE_CONFIG_DIR/skills` and not `~/.claude/skills`.
- Ran `go test ./internal/skills/registry ./pkg/cmd/skills/...`.
