### PR TITLE
fix: support non-zipped artifacts in gh run download

### DIFF
--- a/pkg/cmd/run/download/download.go
+++ b/pkg/cmd/run/download/download.go
@@ -28,7 +28,7 @@ type DownloadOptions struct {
 
 type platform interface {
 	List(runID string) ([]shared.Artifact, error)
-	Download(url string, dir safepaths.Absolute) error
+	Download(url string, name string, dir safepaths.Absolute) error
 }
 
 type iprompter interface {
@@ -187,7 +187,7 @@ func runDownload(opts *DownloadOptions) error {
 			}
 		}
 
-		err := opts.Platform.Download(a.DownloadURL, destDir)
+		err := opts.Platform.Download(a.DownloadURL, a.Name, destDir)
 		if err != nil {
 			return fmt.Errorf("error downloading %s: %w", a.Name, err)
 		}

--- a/pkg/cmd/run/download/http.go
+++ b/pkg/cmd/run/download/http.go
@@ -23,11 +23,11 @@ func (p *apiPlatform) List(runID string) ([]shared.Artifact, error) {
 	return shared.ListArtifacts(p.client, p.repo, runID)
 }
 
-func (p *apiPlatform) Download(url string, dir safepaths.Absolute) error {
-	return downloadArtifact(p.client, url, dir)
+func (p *apiPlatform) Download(url string, name string, dir safepaths.Absolute) error {
+	return downloadArtifact(p.client, url, name, dir)
 }
 
-func downloadArtifact(httpClient *http.Client, url string, destDir safepaths.Absolute) error {
+func downloadArtifact(httpClient *http.Client, url string, name string, destDir safepaths.Absolute) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err
@@ -45,6 +45,30 @@ func downloadArtifact(httpClient *http.Client, url string, destDir safepaths.Abs
 		return api.HandleHTTPError(resp)
 	}
 
+	// Check if the artifact is a zip file by checking Content-Type
+	contentType := resp.Header.Get("Content-Type")
+	isZip := contentType == "application/zip" || contentType == "application/x-zip-compressed"
+
+	if !isZip {
+		// Non-zipped artifact: write directly to destination
+		destPath, err := destDir.Join(name)
+		if err != nil {
+			return fmt.Errorf("error creating destination path: %w", err)
+		}
+		outFile, err := os.Create(destPath.String())
+		if err != nil {
+			return fmt.Errorf("error creating output file: %w", err)
+		}
+		defer outFile.Close()
+
+		_, err = io.Copy(outFile, resp.Body)
+		if err != nil {
+			return fmt.Errorf("error writing artifact: %w", err)
+		}
+		return nil
+	}
+
+	// Zipped artifact: extract to destination
 	tmpfile, err := os.CreateTemp("", "gh-artifact.*.zip")
 	if err != nil {
 		return fmt.Errorf("error initializing temporary file: %w", err)

--- a/pkg/cmd/run/download/http_test.go
+++ b/pkg/cmd/run/download/http_test.go
@@ -72,7 +72,7 @@ func Test_Download(t *testing.T) {
 	api := &apiPlatform{
 		client: &http.Client{Transport: reg},
 	}
-	require.NoError(t, api.Download("https://api.github.com/repos/OWNER/REPO/actions/artifacts/12345/zip", destDir))
+	require.NoError(t, api.Download("https://api.github.com/repos/OWNER/REPO/actions/artifacts/12345/zip", "myproject", destDir))
 
 	var paths []string
 	parentPrefix := tmpDir + string(filepath.Separator)


### PR DESCRIPTION
Fixes #13012

GitHub Actions now supports uploading artifacts with `archive: false`, but the CLI always attempts to unzip artifacts regardless of their format. This causes a "not a valid zip file" error when downloading non-zipped artifacts.

**Root Cause**
The `downloadArtifact` function in `http.go` always treats downloaded artifacts as zip files and attempts to extract them without checking the Content-Type header.

**Fix**
- Check Content-Type header to detect if artifact is a zip file
- If Content-Type is not `application/zip` or `application/x-zip-compressed`, write the file directly to destination without attempting to unzip
- Pass artifact name through the download pipeline to ensure correct filename for non-zipped artifacts

**Changes**
- Modified `platform` interface to accept artifact name parameter
- Updated `downloadArtifact` to check Content-Type and handle non-zipped artifacts
- Updated test to match new signature

**Testing**
- Existing test updated to match new interface signature
- Manual testing with non-zipped artifacts would verify the fix
