### PR TITLE
feat(discussion): add discussion edit command

### DIFF
--- a/pkg/cmd/discussion/client/client.go
+++ b/pkg/cmd/discussion/client/client.go
@@ -15,6 +15,7 @@ type DiscussionClient interface {
 	GetWithComments(repo ghrepo.Interface, number int, commentLimit int, after string, newest bool) (*Discussion, error)
 	GetCommentReplies(repo ghrepo.Interface, number int, commentID string, limit int, after string, newest bool) (*Discussion, error)
 	ListCategories(repo ghrepo.Interface) ([]DiscussionCategory, error)
+	ListLabels(repo ghrepo.Interface) ([]DiscussionLabel, error)
 	Create(repo ghrepo.Interface, input CreateDiscussionInput) (*Discussion, error)
 	Update(repo ghrepo.Interface, input UpdateDiscussionInput) (*Discussion, error)
 	Close(repo ghrepo.Interface, id string, reason CloseReason) (*Discussion, error)

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -1018,9 +1018,6 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 		CreateDiscussion struct {
 			Discussion struct {
 				discussionListNode
-				Comments struct {
-					TotalCount int
-				}
 			}
 		} `graphql:"createDiscussion(input: $input)"`
 	}
@@ -1039,7 +1036,6 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 	}
 
 	d := mapDiscussionFromListNode(mutation.CreateDiscussion.Discussion.discussionListNode)
-	d.Comments = DiscussionCommentList{TotalCount: mutation.CreateDiscussion.Discussion.Comments.TotalCount}
 
 	for _, rg := range mutation.CreateDiscussion.Discussion.ReactionGroups {
 		d.ReactionGroups = append(d.ReactionGroups, ReactionGroup{

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -877,7 +877,10 @@ func (c *discussionClient) resolveLabels(repo ghrepo.Interface, labelNames []str
 
 // editDiscussionLabels adds and removes labels on a discussion. Removals are
 // applied before additions. Either slice may be nil or empty to skip that step.
-func (c *discussionClient) editDiscussionLabels(repo ghrepo.Interface, discussionID string, addIDs, removeIDs []string) error {
+// Returns the discussion state as returned by the last mutation executed.
+func (c *discussionClient) editDiscussionLabels(repo ghrepo.Interface, discussionID string, addIDs, removeIDs []string) (*discussionListNode, error) {
+	var node *discussionListNode
+
 	if len(removeIDs) > 0 {
 		ids := make([]githubv4.ID, len(removeIDs))
 		for i, id := range removeIDs {
@@ -886,7 +889,11 @@ func (c *discussionClient) editDiscussionLabels(repo ghrepo.Interface, discussio
 
 		var mutation struct {
 			RemoveLabelsFromLabelable struct {
-				Typename string `graphql:"__typename"`
+				Labelable struct {
+					Discussion struct {
+						discussionListNode
+					} `graphql:"... on Discussion"`
+				}
 			} `graphql:"removeLabelsFromLabelable(input: $input)"`
 		}
 
@@ -898,8 +905,9 @@ func (c *discussionClient) editDiscussionLabels(repo ghrepo.Interface, discussio
 		}
 
 		if err := c.gql.Mutate(repo.RepoHost(), "RemoveLabelsFromDiscussion", &mutation, variables); err != nil {
-			return err
+			return nil, err
 		}
+		node = &mutation.RemoveLabelsFromLabelable.Labelable.Discussion.discussionListNode
 	}
 
 	if len(addIDs) > 0 {
@@ -910,7 +918,11 @@ func (c *discussionClient) editDiscussionLabels(repo ghrepo.Interface, discussio
 
 		var mutation struct {
 			AddLabelsToLabelable struct {
-				Typename string `graphql:"__typename"`
+				Labelable struct {
+					Discussion struct {
+						discussionListNode
+					} `graphql:"... on Discussion"`
+				}
 			} `graphql:"addLabelsToLabelable(input: $input)"`
 		}
 
@@ -922,11 +934,12 @@ func (c *discussionClient) editDiscussionLabels(repo ghrepo.Interface, discussio
 		}
 
 		if err := c.gql.Mutate(repo.RepoHost(), "AddLabelsToDiscussion", &mutation, variables); err != nil {
-			return err
+			return nil, err
 		}
+		node = &mutation.AddLabelsToLabelable.Labelable.Discussion.discussionListNode
 	}
 
-	return nil
+	return node, nil
 }
 
 func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionInput) (*Discussion, error) {
@@ -969,67 +982,106 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 		return nil, err
 	}
 
-	d := mapDiscussionFromListNode(mutation.CreateDiscussion.Discussion.discussionListNode)
-
-	for _, rg := range mutation.CreateDiscussion.Discussion.ReactionGroups {
-		d.ReactionGroups = append(d.ReactionGroups, ReactionGroup{
-			Content:    rg.Content,
-			TotalCount: rg.Users.TotalCount,
-		})
-	}
+	node := &mutation.CreateDiscussion.Discussion.discussionListNode
 
 	if len(resolvedLabels) > 0 {
 		labelIDs := make([]string, len(resolvedLabels))
 		for i, l := range resolvedLabels {
 			labelIDs[i] = l.ID
 		}
-		if err := c.editDiscussionLabels(repo, d.ID, labelIDs, nil); err != nil {
+		labelNode, err := c.editDiscussionLabels(repo, node.ID, labelIDs, nil)
+		if err != nil {
 			return nil, err
 		}
-		d.Labels = resolvedLabels
+		node = labelNode
+	}
+
+	d := mapDiscussionFromListNode(*node)
+
+	for _, rg := range node.ReactionGroups {
+		d.ReactionGroups = append(d.ReactionGroups, ReactionGroup{
+			Content:    rg.Content,
+			TotalCount: rg.Users.TotalCount,
+		})
 	}
 
 	return &d, nil
 }
 
 func (c *discussionClient) Update(repo ghrepo.Interface, input UpdateDiscussionInput) (*Discussion, error) {
-	if input.Title == nil && input.Body == nil && input.CategoryID == nil {
+	hasFieldUpdate := input.Title != nil || input.Body != nil || input.CategoryID != nil
+	hasLabelUpdate := len(input.AddLabels) > 0 || len(input.RemoveLabels) > 0
+
+	if !hasFieldUpdate && !hasLabelUpdate {
 		return nil, fmt.Errorf("nothing to update")
 	}
 
-	gqlInput := githubv4.UpdateDiscussionInput{
-		DiscussionID: githubv4.ID(input.DiscussionID),
-	}
-	if input.Title != nil {
-		gqlInput.Title = githubv4.NewString(githubv4.String(*input.Title))
-	}
-	if input.Body != nil {
-		gqlInput.Body = githubv4.NewString(githubv4.String(*input.Body))
-	}
-	if input.CategoryID != nil {
-		id := githubv4.ID(*input.CategoryID)
-		gqlInput.CategoryID = &id
+	var node *discussionListNode
+
+	if hasFieldUpdate {
+		gqlInput := githubv4.UpdateDiscussionInput{
+			DiscussionID: githubv4.ID(input.DiscussionID),
+		}
+		if input.Title != nil {
+			gqlInput.Title = githubv4.NewString(githubv4.String(*input.Title))
+		}
+		if input.Body != nil {
+			gqlInput.Body = githubv4.NewString(githubv4.String(*input.Body))
+		}
+		if input.CategoryID != nil {
+			id := githubv4.ID(*input.CategoryID)
+			gqlInput.CategoryID = &id
+		}
+
+		var mutation struct {
+			UpdateDiscussion struct {
+				Discussion struct {
+					discussionListNode
+				}
+			} `graphql:"updateDiscussion(input: $input)"`
+		}
+
+		variables := map[string]interface{}{
+			"input": gqlInput,
+		}
+
+		if err := c.gql.Mutate(repo.RepoHost(), "UpdateDiscussion", &mutation, variables); err != nil {
+			return nil, err
+		}
+
+		node = &mutation.UpdateDiscussion.Discussion.discussionListNode
 	}
 
-	var mutation struct {
-		UpdateDiscussion struct {
-			Discussion struct {
-				discussionListNode
-			}
-		} `graphql:"updateDiscussion(input: $input)"`
+	if hasLabelUpdate {
+		allNames := append(input.AddLabels, input.RemoveLabels...)
+		resolved, err := c.resolveLabels(repo, allNames)
+		if err != nil {
+			return nil, err
+		}
+		labelByName := make(map[string]string, len(resolved))
+		for _, l := range resolved {
+			labelByName[strings.ToLower(l.Name)] = l.ID
+		}
+
+		addIDs := make([]string, 0, len(input.AddLabels))
+		for _, name := range input.AddLabels {
+			addIDs = append(addIDs, labelByName[strings.ToLower(name)])
+		}
+		removeIDs := make([]string, 0, len(input.RemoveLabels))
+		for _, name := range input.RemoveLabels {
+			removeIDs = append(removeIDs, labelByName[strings.ToLower(name)])
+		}
+
+		labelNode, err := c.editDiscussionLabels(repo, input.DiscussionID, addIDs, removeIDs)
+		if err != nil {
+			return nil, err
+		}
+		node = labelNode
 	}
 
-	variables := map[string]interface{}{
-		"input": gqlInput,
-	}
+	d := mapDiscussionFromListNode(*node)
 
-	if err := c.gql.Mutate(repo.RepoHost(), "UpdateDiscussion", &mutation, variables); err != nil {
-		return nil, err
-	}
-
-	d := mapDiscussionFromListNode(mutation.UpdateDiscussion.Discussion.discussionListNode)
-
-	for _, rg := range mutation.UpdateDiscussion.Discussion.ReactionGroups {
+	for _, rg := range node.ReactionGroups {
 		d.ReactionGroups = append(d.ReactionGroups, ReactionGroup{
 			Content:    rg.Content,
 			TotalCount: rg.Users.TotalCount,

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -941,27 +941,58 @@ func (c *discussionClient) resolveLabels(repo ghrepo.Interface, labelNames []str
 	return result, nil
 }
 
-// addLabelsToDiscussion applies labels to a discussion via the addLabelsToLabelable mutation.
-func (c *discussionClient) addLabelsToDiscussion(repo ghrepo.Interface, discussionID string, labelIDs []string) error {
-	ids := make([]githubv4.ID, len(labelIDs))
-	for i, id := range labelIDs {
-		ids[i] = githubv4.ID(id)
+// editDiscussionLabels adds and removes labels on a discussion. Removals are
+// applied before additions. Either slice may be nil or empty to skip that step.
+func (c *discussionClient) editDiscussionLabels(repo ghrepo.Interface, discussionID string, addIDs, removeIDs []string) error {
+	if len(removeIDs) > 0 {
+		ids := make([]githubv4.ID, len(removeIDs))
+		for i, id := range removeIDs {
+			ids[i] = githubv4.ID(id)
+		}
+
+		var mutation struct {
+			RemoveLabelsFromLabelable struct {
+				Typename string `graphql:"__typename"`
+			} `graphql:"removeLabelsFromLabelable(input: $input)"`
+		}
+
+		variables := map[string]interface{}{
+			"input": githubv4.RemoveLabelsFromLabelableInput{
+				LabelableID: githubv4.ID(discussionID),
+				LabelIDs:    ids,
+			},
+		}
+
+		if err := c.gql.Mutate(repo.RepoHost(), "RemoveLabelsFromDiscussion", &mutation, variables); err != nil {
+			return err
+		}
 	}
 
-	var mutation struct {
-		AddLabelsToLabelable struct {
-			Typename string `graphql:"__typename"`
-		} `graphql:"addLabelsToLabelable(input: $input)"`
+	if len(addIDs) > 0 {
+		ids := make([]githubv4.ID, len(addIDs))
+		for i, id := range addIDs {
+			ids[i] = githubv4.ID(id)
+		}
+
+		var mutation struct {
+			AddLabelsToLabelable struct {
+				Typename string `graphql:"__typename"`
+			} `graphql:"addLabelsToLabelable(input: $input)"`
+		}
+
+		variables := map[string]interface{}{
+			"input": githubv4.AddLabelsToLabelableInput{
+				LabelableID: githubv4.ID(discussionID),
+				LabelIDs:    ids,
+			},
+		}
+
+		if err := c.gql.Mutate(repo.RepoHost(), "AddLabelsToDiscussion", &mutation, variables); err != nil {
+			return err
+		}
 	}
 
-	variables := map[string]interface{}{
-		"input": githubv4.AddLabelsToLabelableInput{
-			LabelableID: githubv4.ID(discussionID),
-			LabelIDs:    ids,
-		},
-	}
-
-	return c.gql.Mutate(repo.RepoHost(), "AddLabelsToDiscussion", &mutation, variables)
+	return nil
 }
 
 func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionInput) (*Discussion, error) {
@@ -1022,7 +1053,7 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 		for i, l := range resolvedLabels {
 			labelIDs[i] = l.ID
 		}
-		if err := c.addLabelsToDiscussion(repo, d.ID, labelIDs); err != nil {
+		if err := c.editDiscussionLabels(repo, d.ID, labelIDs, nil); err != nil {
 			return nil, err
 		}
 		d.Labels = resolvedLabels

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -846,40 +846,6 @@ func (c *discussionClient) ListLabels(repo ghrepo.Interface) ([]DiscussionLabel,
 	return labels, nil
 }
 
-// resolveLabels matches the requested label names case-insensitively against
-// the repository's labels. Returns an error if any name is not found.
-func (c *discussionClient) resolveLabels(repo ghrepo.Interface, labelNames []string) ([]DiscussionLabel, error) {
-	if len(labelNames) == 0 {
-		return nil, nil
-	}
-
-	allLabels, err := c.ListLabels(repo)
-	if err != nil {
-		return nil, err
-	}
-
-	byName := make(map[string]DiscussionLabel, len(allLabels))
-	for _, l := range allLabels {
-		byName[strings.ToLower(l.Name)] = l
-	}
-
-	result := make([]DiscussionLabel, 0, len(labelNames))
-	var missing []string
-	for _, name := range labelNames {
-		if l, ok := byName[strings.ToLower(name)]; ok {
-			result = append(result, l)
-		} else {
-			missing = append(missing, name)
-		}
-	}
-
-	if len(missing) > 0 {
-		return nil, fmt.Errorf("labels not found: %s", strings.Join(missing, ", "))
-	}
-
-	return result, nil
-}
-
 // editDiscussionLabels adds and removes labels on a discussion. Removals are
 // applied before additions. Either slice may be nil or empty to skip that step.
 // Returns the discussion state as returned by the last mutation executed.
@@ -956,16 +922,6 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 		return nil, fmt.Errorf("the '%s/%s' repository has discussions disabled", repo.RepoOwner(), repo.RepoName())
 	}
 
-	// Resolve labels before creating the discussion so that an unknown label
-	// name aborts without leaving a half-created discussion behind.
-	var resolvedLabels []DiscussionLabel
-	if len(input.Labels) > 0 {
-		resolvedLabels, err = c.resolveLabels(repo, input.Labels)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	var mutation struct {
 		CreateDiscussion struct {
 			Discussion struct {
@@ -989,12 +945,8 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 
 	node := &mutation.CreateDiscussion.Discussion.discussionListNode
 
-	if len(resolvedLabels) > 0 {
-		labelIDs := make([]string, len(resolvedLabels))
-		for i, l := range resolvedLabels {
-			labelIDs[i] = l.ID
-		}
-		labelNode, err := c.editDiscussionLabels(repo, node.ID, labelIDs, nil)
+	if len(input.LabelIDs) > 0 {
+		labelNode, err := c.editDiscussionLabels(repo, node.ID, input.LabelIDs, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -1015,7 +967,7 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 
 func (c *discussionClient) Update(repo ghrepo.Interface, input UpdateDiscussionInput) (*Discussion, error) {
 	hasFieldUpdate := input.Title != nil || input.Body != nil || input.CategoryID != nil
-	hasLabelUpdate := len(input.AddLabels) > 0 || len(input.RemoveLabels) > 0
+	hasLabelUpdate := len(input.AddLabelIDs) > 0 || len(input.RemoveLabelIDs) > 0
 
 	if !hasFieldUpdate && !hasLabelUpdate {
 		return nil, fmt.Errorf("nothing to update")
@@ -1058,26 +1010,7 @@ func (c *discussionClient) Update(repo ghrepo.Interface, input UpdateDiscussionI
 	}
 
 	if hasLabelUpdate {
-		allNames := append(input.AddLabels, input.RemoveLabels...)
-		resolved, err := c.resolveLabels(repo, allNames)
-		if err != nil {
-			return nil, err
-		}
-		labelByName := make(map[string]string, len(resolved))
-		for _, l := range resolved {
-			labelByName[strings.ToLower(l.Name)] = l.ID
-		}
-
-		addIDs := make([]string, 0, len(input.AddLabels))
-		for _, name := range input.AddLabels {
-			addIDs = append(addIDs, labelByName[strings.ToLower(name)])
-		}
-		removeIDs := make([]string, 0, len(input.RemoveLabels))
-		for _, name := range input.RemoveLabels {
-			removeIDs = append(removeIDs, labelByName[strings.ToLower(name)])
-		}
-
-		labelNode, err := c.editDiscussionLabels(repo, input.DiscussionID, addIDs, removeIDs)
+		labelNode, err := c.editDiscussionLabels(repo, input.DiscussionID, input.AddLabelIDs, input.RemoveLabelIDs)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -53,72 +53,6 @@ func mapActorFromListNode(n actorNode) DiscussionActor {
 	return a
 }
 
-// rawActorNode is a JSON-compatible actor type for use with c.gql.GraphQL() (raw
-// query strings). Unlike actorNode, it does not use shurcooL graphql struct tags
-// and works with standard json.Unmarshal. GitHub flattens inline fragment fields
-// (... on User { id name }) to the top level of the actor object in JSON responses.
-type rawActorNode struct {
-	TypeName string `json:"__typename"`
-	Login    string
-	ID       string
-	Name     string
-}
-
-func mapActorFromRawNode(n rawActorNode) DiscussionActor {
-	a := DiscussionActor{Login: n.Login}
-	switch n.TypeName {
-	case "User":
-		a.ID = n.ID
-		a.Name = n.Name
-	case "Bot":
-		a.ID = n.ID
-	}
-	return a
-}
-
-// updateDiscussionDiscNode is the JSON response shape for the discussion field
-// inside an updateDiscussion mutation response.
-type updateDiscussionDiscNode struct {
-	ID          string
-	Number      int
-	Title       string
-	Body        string
-	URL         string
-	Closed      bool
-	StateReason string
-	Author      rawActorNode
-	Category    struct {
-		ID           string
-		Name         string
-		Slug         string
-		Emoji        string
-		IsAnswerable bool
-	}
-	Labels struct {
-		Nodes []struct {
-			ID    string
-			Name  string
-			Color string
-		}
-	}
-	IsAnswered     bool
-	AnswerChosenAt time.Time
-	AnswerChosenBy *rawActorNode
-	ReactionGroups []struct {
-		Content string
-		Users   struct {
-			TotalCount int
-		}
-	}
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	ClosedAt  time.Time
-	Locked    bool
-	Comments  struct {
-		TotalCount int
-	}
-}
-
 // discussionListNode is the GraphQL response shape for a discussion in
 // list and search results. It covers high-level fields only (no comments, or
 // other detail-level data that commands like view would need).
@@ -1058,83 +992,48 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 	return &d, nil
 }
 
-const updateDiscussionMutation = `
-mutation UpdateDiscussion($input: UpdateDiscussionInput!) {
-  updateDiscussion(input: $input) {
-    discussion {
-      id number title body url closed stateReason
-      isAnswered answerChosenAt
-      author { __typename login ... on User { id name } ... on Bot { id } }
-      answerChosenBy { __typename login ... on User { id name } ... on Bot { id } }
-      category { id name slug emoji isAnswerable }
-      labels(first: 20) { nodes { id name color } }
-      reactionGroups { content users { totalCount } }
-      createdAt updatedAt closedAt locked
-      comments { totalCount }
-    }
-  }
-}`
-
 func (c *discussionClient) Update(repo ghrepo.Interface, input UpdateDiscussionInput) (*Discussion, error) {
-	inputMap := map[string]interface{}{
-		"discussionId": input.DiscussionID,
+	if input.Title == nil && input.Body == nil && input.CategoryID == nil {
+		return nil, fmt.Errorf("nothing to update")
+	}
+
+	gqlInput := githubv4.UpdateDiscussionInput{
+		DiscussionID: githubv4.ID(input.DiscussionID),
 	}
 	if input.Title != nil {
-		inputMap["title"] = *input.Title
+		gqlInput.Title = githubv4.NewString(githubv4.String(*input.Title))
 	}
 	if input.Body != nil {
-		inputMap["body"] = *input.Body
+		gqlInput.Body = githubv4.NewString(githubv4.String(*input.Body))
 	}
 	if input.CategoryID != nil {
-		inputMap["categoryId"] = *input.CategoryID
+		id := githubv4.ID(*input.CategoryID)
+		gqlInput.CategoryID = &id
+	}
+
+	var mutation struct {
+		UpdateDiscussion struct {
+			Discussion struct {
+				discussionListNode
+			}
+		} `graphql:"updateDiscussion(input: $input)"`
 	}
 
 	variables := map[string]interface{}{
-		"input": inputMap,
+		"input": gqlInput,
 	}
 
-	var result struct {
-		UpdateDiscussion struct {
-			Discussion updateDiscussionDiscNode
-		}
-	}
-	if err := c.gql.GraphQL(repo.RepoHost(), updateDiscussionMutation, variables, &result); err != nil {
+	if err := c.gql.Mutate(repo.RepoHost(), "UpdateDiscussion", &mutation, variables); err != nil {
 		return nil, err
 	}
 
-	disc := result.UpdateDiscussion.Discussion
-	d := Discussion{
-		ID:             disc.ID,
-		Number:         disc.Number,
-		Title:          disc.Title,
-		Body:           disc.Body,
-		URL:            disc.URL,
-		Closed:         disc.Closed,
-		StateReason:    disc.StateReason,
-		Author:         mapActorFromRawNode(disc.Author),
-		Category:       DiscussionCategory{ID: disc.Category.ID, Name: disc.Category.Name, Slug: disc.Category.Slug, Emoji: disc.Category.Emoji, IsAnswerable: disc.Category.IsAnswerable},
-		Answered:       disc.IsAnswered,
-		AnswerChosenAt: disc.AnswerChosenAt,
-		CreatedAt:      disc.CreatedAt,
-		UpdatedAt:      disc.UpdatedAt,
-		ClosedAt:       disc.ClosedAt,
-		Locked:         disc.Locked,
-		Comments:       DiscussionCommentList{TotalCount: disc.Comments.TotalCount},
-	}
+	d := mapDiscussionFromListNode(mutation.UpdateDiscussion.Discussion.discussionListNode)
 
-	if disc.AnswerChosenBy != nil {
-		a := mapActorFromRawNode(*disc.AnswerChosenBy)
-		d.AnswerChosenBy = &a
-	}
-
-	d.Labels = make([]DiscussionLabel, len(disc.Labels.Nodes))
-	for i, l := range disc.Labels.Nodes {
-		d.Labels[i] = DiscussionLabel{ID: l.ID, Name: l.Name, Color: l.Color}
-	}
-
-	d.ReactionGroups = make([]ReactionGroup, 0, len(disc.ReactionGroups))
-	for _, rg := range disc.ReactionGroups {
-		d.ReactionGroups = append(d.ReactionGroups, ReactionGroup{Content: rg.Content, TotalCount: rg.Users.TotalCount})
+	for _, rg := range mutation.UpdateDiscussion.Discussion.ReactionGroups {
+		d.ReactionGroups = append(d.ReactionGroups, ReactionGroup{
+			Content:    rg.Content,
+			TotalCount: rg.Users.TotalCount,
+		})
 	}
 
 	return &d, nil

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -53,6 +53,72 @@ func mapActorFromListNode(n actorNode) DiscussionActor {
 	return a
 }
 
+// rawActorNode is a JSON-compatible actor type for use with c.gql.GraphQL() (raw
+// query strings). Unlike actorNode, it does not use shurcooL graphql struct tags
+// and works with standard json.Unmarshal. GitHub flattens inline fragment fields
+// (... on User { id name }) to the top level of the actor object in JSON responses.
+type rawActorNode struct {
+	TypeName string `json:"__typename"`
+	Login    string
+	ID       string
+	Name     string
+}
+
+func mapActorFromRawNode(n rawActorNode) DiscussionActor {
+	a := DiscussionActor{Login: n.Login}
+	switch n.TypeName {
+	case "User":
+		a.ID = n.ID
+		a.Name = n.Name
+	case "Bot":
+		a.ID = n.ID
+	}
+	return a
+}
+
+// updateDiscussionDiscNode is the JSON response shape for the discussion field
+// inside an updateDiscussion mutation response.
+type updateDiscussionDiscNode struct {
+	ID          string
+	Number      int
+	Title       string
+	Body        string
+	URL         string
+	Closed      bool
+	StateReason string
+	Author      rawActorNode
+	Category    struct {
+		ID           string
+		Name         string
+		Slug         string
+		Emoji        string
+		IsAnswerable bool
+	}
+	Labels struct {
+		Nodes []struct {
+			ID    string
+			Name  string
+			Color string
+		}
+	}
+	IsAnswered     bool
+	AnswerChosenAt time.Time
+	AnswerChosenBy *rawActorNode
+	ReactionGroups []struct {
+		Content string
+		Users   struct {
+			TotalCount int
+		}
+	}
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	ClosedAt  time.Time
+	Locked    bool
+	Comments  struct {
+		TotalCount int
+	}
+}
+
 // discussionListNode is the GraphQL response shape for a discussion in
 // list and search results. It covers high-level fields only (no comments, or
 // other detail-level data that commands like view would need).
@@ -965,8 +1031,86 @@ func (c *discussionClient) Create(repo ghrepo.Interface, input CreateDiscussionI
 	return &d, nil
 }
 
-func (c *discussionClient) Update(_ ghrepo.Interface, _ UpdateDiscussionInput) (*Discussion, error) {
-	return nil, fmt.Errorf("not implemented")
+const updateDiscussionMutation = `
+mutation UpdateDiscussion($input: UpdateDiscussionInput!) {
+  updateDiscussion(input: $input) {
+    discussion {
+      id number title body url closed stateReason
+      isAnswered answerChosenAt
+      author { __typename login ... on User { id name } ... on Bot { id } }
+      answerChosenBy { __typename login ... on User { id name } ... on Bot { id } }
+      category { id name slug emoji isAnswerable }
+      labels(first: 20) { nodes { id name color } }
+      reactionGroups { content users { totalCount } }
+      createdAt updatedAt closedAt locked
+      comments { totalCount }
+    }
+  }
+}`
+
+func (c *discussionClient) Update(repo ghrepo.Interface, input UpdateDiscussionInput) (*Discussion, error) {
+	inputMap := map[string]interface{}{
+		"discussionId": input.DiscussionID,
+	}
+	if input.Title != nil {
+		inputMap["title"] = *input.Title
+	}
+	if input.Body != nil {
+		inputMap["body"] = *input.Body
+	}
+	if input.CategoryID != nil {
+		inputMap["categoryId"] = *input.CategoryID
+	}
+
+	variables := map[string]interface{}{
+		"input": inputMap,
+	}
+
+	var result struct {
+		UpdateDiscussion struct {
+			Discussion updateDiscussionDiscNode
+		}
+	}
+	if err := c.gql.GraphQL(repo.RepoHost(), updateDiscussionMutation, variables, &result); err != nil {
+		return nil, err
+	}
+
+	disc := result.UpdateDiscussion.Discussion
+	d := Discussion{
+		ID:             disc.ID,
+		Number:         disc.Number,
+		Title:          disc.Title,
+		Body:           disc.Body,
+		URL:            disc.URL,
+		Closed:         disc.Closed,
+		StateReason:    disc.StateReason,
+		Author:         mapActorFromRawNode(disc.Author),
+		Category:       DiscussionCategory{ID: disc.Category.ID, Name: disc.Category.Name, Slug: disc.Category.Slug, Emoji: disc.Category.Emoji, IsAnswerable: disc.Category.IsAnswerable},
+		Answered:       disc.IsAnswered,
+		AnswerChosenAt: disc.AnswerChosenAt,
+		CreatedAt:      disc.CreatedAt,
+		UpdatedAt:      disc.UpdatedAt,
+		ClosedAt:       disc.ClosedAt,
+		Locked:         disc.Locked,
+		Comments:       DiscussionCommentList{TotalCount: disc.Comments.TotalCount},
+	}
+
+	if disc.AnswerChosenBy != nil {
+		a := mapActorFromRawNode(*disc.AnswerChosenBy)
+		d.AnswerChosenBy = &a
+	}
+
+	d.Labels = make([]DiscussionLabel, len(disc.Labels.Nodes))
+	for i, l := range disc.Labels.Nodes {
+		d.Labels[i] = DiscussionLabel{ID: l.ID, Name: l.Name, Color: l.Color}
+	}
+
+	d.ReactionGroups = make([]ReactionGroup, 0, len(disc.ReactionGroups))
+	for _, rg := range disc.ReactionGroups {
+		d.ReactionGroups = append(d.ReactionGroups, ReactionGroup{Content: rg.Content, TotalCount: rg.Users.TotalCount})
+	}
+
+	return &d, nil
 }
 
 func (c *discussionClient) Close(_ ghrepo.Interface, _ string, _ CloseReason) (*Discussion, error) {

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -805,13 +805,8 @@ func (c *discussionClient) getRepositoryMeta(repo ghrepo.Interface) (*repository
 	}, nil
 }
 
-// resolveLabels fetches all labels for a repository and matches the requested names
-// case-insensitively. Returns an error if any requested label name is not found.
-func (c *discussionClient) resolveLabels(repo ghrepo.Interface, labelNames []string) ([]DiscussionLabel, error) {
-	if len(labelNames) == 0 {
-		return nil, nil
-	}
-
+// ListLabels fetches all labels for a repository, ordered alphabetically by name.
+func (c *discussionClient) ListLabels(repo ghrepo.Interface) ([]DiscussionLabel, error) {
 	var query struct {
 		Repository struct {
 			Labels struct {
@@ -824,7 +819,7 @@ func (c *discussionClient) resolveLabels(repo ghrepo.Interface, labelNames []str
 					HasNextPage bool
 					EndCursor   string
 				}
-			} `graphql:"labels(first: 100, after: $endCursor)"`
+			} `graphql:"labels(first: 100, after: $endCursor, orderBy: {field: NAME, direction: ASC})"`
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
@@ -834,23 +829,13 @@ func (c *discussionClient) resolveLabels(repo ghrepo.Interface, labelNames []str
 		"endCursor": (*githubv4.String)(nil),
 	}
 
-	wanted := make(map[string]bool, len(labelNames))
-	for _, n := range labelNames {
-		wanted[strings.ToLower(n)] = true
-	}
-
-	found := make(map[string]DiscussionLabel, len(labelNames))
+	var labels []DiscussionLabel
 	for {
-		if err := c.gql.Query(repo.RepoHost(), "RepositoryLabels", &query, variables); err != nil {
+		if err := c.gql.Query(repo.RepoHost(), "RepositoryLabelsForDiscussions", &query, variables); err != nil {
 			return nil, err
 		}
 		for _, n := range query.Repository.Labels.Nodes {
-			if wanted[strings.ToLower(n.Name)] {
-				found[strings.ToLower(n.Name)] = DiscussionLabel{ID: n.ID, Name: n.Name, Color: n.Color}
-			}
-		}
-		if len(found) == len(wanted) {
-			break
+			labels = append(labels, DiscussionLabel{ID: n.ID, Name: n.Name, Color: n.Color})
 		}
 		if !query.Repository.Labels.PageInfo.HasNextPage {
 			break
@@ -858,20 +843,40 @@ func (c *discussionClient) resolveLabels(repo ghrepo.Interface, labelNames []str
 		variables["endCursor"] = githubv4.String(query.Repository.Labels.PageInfo.EndCursor)
 	}
 
-	if len(found) != len(wanted) {
-		var missing []string
-		for _, name := range labelNames {
-			if _, ok := found[strings.ToLower(name)]; !ok {
-				missing = append(missing, name)
-			}
-		}
-		return nil, fmt.Errorf("labels not found: %s", strings.Join(missing, ", "))
+	return labels, nil
+}
+
+// resolveLabels matches the requested label names case-insensitively against
+// the repository's labels. Returns an error if any name is not found.
+func (c *discussionClient) resolveLabels(repo ghrepo.Interface, labelNames []string) ([]DiscussionLabel, error) {
+	if len(labelNames) == 0 {
+		return nil, nil
+	}
+
+	allLabels, err := c.ListLabels(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	byName := make(map[string]DiscussionLabel, len(allLabels))
+	for _, l := range allLabels {
+		byName[strings.ToLower(l.Name)] = l
 	}
 
 	result := make([]DiscussionLabel, 0, len(labelNames))
+	var missing []string
 	for _, name := range labelNames {
-		result = append(result, found[strings.ToLower(name)])
+		if l, ok := byName[strings.ToLower(name)]; ok {
+			result = append(result, l)
+		} else {
+			missing = append(missing, name)
+		}
 	}
+
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("labels not found: %s", strings.Join(missing, ", "))
+	}
+
 	return result, nil
 }
 

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -3067,3 +3067,192 @@ func TestCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdate(t *testing.T) {
+	repo := ghrepo.New("OWNER", "REPO")
+
+	titleStr := "Updated title"
+	bodyStr := "Updated body"
+	catID := "CAT_2"
+
+	tests := []struct {
+		name       string
+		input      UpdateDiscussionInput
+		httpStubs  func(*testing.T, *httpmock.Registry)
+		wantErr    string
+		assertDisc *Discussion
+	}{
+		{
+			name: "maps all fields",
+			input: UpdateDiscussionInput{
+				DiscussionID: "D_1",
+				Title:        &titleStr,
+				Body:         &bodyStr,
+				CategoryID:   &catID,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateDiscussion\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"updateDiscussion": {
+									"discussion": {
+										"id": "D_1",
+										"number": 5,
+										"title": "Updated title",
+										"body": "Updated body",
+										"url": "https://github.com/OWNER/REPO/discussions/5",
+										"closed": false,
+										"stateReason": "",
+										"isAnswered": false,
+										"answerChosenAt": "0001-01-01T00:00:00Z",
+										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
+										"category": {"id": "CAT_2", "name": "Q&A", "slug": "q-a", "emoji": ":question:", "isAnswerable": true},
+										"answerChosenBy": null,
+										"labels": {"nodes": []},
+										"reactionGroups": [{"content": "THUMBS_UP", "users": {"totalCount": 0}}],
+										"createdAt": "2025-06-01T00:00:00Z",
+										"updatedAt": "2025-06-02T00:00:00Z",
+										"closedAt": "0001-01-01T00:00:00Z",
+										"locked": false,
+										"comments": {"totalCount": 0}
+									}
+								}
+							}
+						}
+					`)),
+				)
+			},
+			assertDisc: &Discussion{
+				ID:     "D_1",
+				Number: 5,
+				Title:  "Updated title",
+				Body:   "Updated body",
+				URL:    "https://github.com/OWNER/REPO/discussions/5",
+				Author: DiscussionActor{ID: "U1", Login: "alice", Name: "Alice"},
+				Category: DiscussionCategory{
+					ID:           "CAT_2",
+					Name:         "Q&A",
+					Slug:         "q-a",
+					Emoji:        ":question:",
+					IsAnswerable: true,
+				},
+				Labels:         []DiscussionLabel{},
+				ReactionGroups: []ReactionGroup{{Content: "THUMBS_UP", TotalCount: 0}},
+				CreatedAt:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt:      time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "partial update title only",
+			input: UpdateDiscussionInput{
+				DiscussionID: "D_1",
+				Title:        &titleStr,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateDiscussion\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"updateDiscussion": {
+									"discussion": {
+										"id": "D_1",
+										"number": 5,
+										"title": "Updated title",
+										"body": "Original body",
+										"url": "https://github.com/OWNER/REPO/discussions/5",
+										"closed": false,
+										"stateReason": "",
+										"isAnswered": false,
+										"answerChosenAt": "0001-01-01T00:00:00Z",
+										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
+										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": ":speech_balloon:", "isAnswerable": false},
+										"answerChosenBy": null,
+										"labels": {"nodes": []},
+										"reactionGroups": [],
+										"createdAt": "2025-06-01T00:00:00Z",
+										"updatedAt": "2025-06-02T00:00:00Z",
+										"closedAt": "0001-01-01T00:00:00Z",
+										"locked": false,
+										"comments": {"totalCount": 0}
+									}
+								}
+							}
+						}
+					`)),
+				)
+			},
+			assertDisc: &Discussion{
+				ID:     "D_1",
+				Number: 5,
+				Title:  "Updated title",
+				Body:   "Original body",
+				URL:    "https://github.com/OWNER/REPO/discussions/5",
+				Author: DiscussionActor{ID: "U1", Login: "alice", Name: "Alice"},
+				Category: DiscussionCategory{
+					ID:    "CAT_1",
+					Name:  "General",
+					Slug:  "general",
+					Emoji: ":speech_balloon:",
+				},
+				Labels:         []DiscussionLabel{},
+				ReactionGroups: []ReactionGroup{},
+				CreatedAt:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt:      time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "mutation error",
+			input: UpdateDiscussionInput{
+				DiscussionID: "D_1",
+				Title:        &titleStr,
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateDiscussion\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"updateDiscussion": null
+							},
+							"errors": [
+								{
+									"type": "NOT_FOUND",
+									"message": "Could not resolve to a Discussion with the global id of 'D_1'."
+								}
+							]
+						}
+					`)),
+				)
+			},
+			wantErr: "Could not resolve to a Discussion with the global id of 'D_1'.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, reg)
+			}
+
+			c := newTestDiscussionClient(reg)
+			d, err := c.Update(repo, tt.input)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, d)
+			require.NotNil(t, tt.assertDisc, "assertDisc must be set for non-error cases")
+			assert.Equal(t, tt.assertDisc, d)
+		})
+	}
+}

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -2539,8 +2539,7 @@ func TestCreate(t *testing.T) {
 										"createdAt": "2025-06-01T00:00:00Z",
 										"updatedAt": "2025-06-01T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false,
-										"comments": {"totalCount": 0}
+										"locked": false
 									}
 								}
 							}
@@ -2678,8 +2677,7 @@ func TestCreate(t *testing.T) {
 										"createdAt": "2025-06-01T00:00:00Z",
 										"updatedAt": "2025-06-01T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false,
-										"comments": {"totalCount": 0}
+										"locked": false
 									}
 								}
 							}
@@ -2783,8 +2781,7 @@ func TestCreate(t *testing.T) {
 										"createdAt": "2025-06-01T00:00:00Z",
 										"updatedAt": "2025-06-01T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false,
-										"comments": {"totalCount": 0}
+										"locked": false
 									}
 								}
 							}
@@ -2874,8 +2871,7 @@ func TestCreate(t *testing.T) {
 										"createdAt": "2025-06-01T00:00:00Z",
 										"updatedAt": "2025-06-01T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false,
-										"comments": {"totalCount": 0}
+										"locked": false
 									}
 								}
 							}
@@ -3003,8 +2999,7 @@ func TestCreate(t *testing.T) {
 										"createdAt": "2025-06-01T00:00:00Z",
 										"updatedAt": "2025-06-01T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false,
-										"comments": {"totalCount": 0}
+										"locked": false
 									}
 								}
 							}

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -3068,6 +3068,115 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestEditDiscussionLabels(t *testing.T) {
+	repo := ghrepo.New("OWNER", "REPO")
+
+	tests := []struct {
+		name      string
+		addIDs    []string
+		removeIDs []string
+		setupMock func(reg *httpmock.Registry)
+		wantErr   string
+	}{
+		{
+			name:      "adds and removes labels",
+			addIDs:    []string{"L_bug", "L_enh"},
+			removeIDs: []string{"L_old"},
+			setupMock: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQLMutationMatcher(`mutation RemoveLabelsFromDiscussion\b`, func(input map[string]interface{}) bool {
+						assert.Equal(t, "D_1", input["labelableId"])
+						assert.Equal(t, []interface{}{"L_old"}, input["labelIds"])
+						return true
+					}),
+					httpmock.StringResponse(`{"data":{"removeLabelsFromLabelable":{"__typename":"Labelable"}}}`),
+				)
+				reg.Register(
+					httpmock.GraphQLMutationMatcher(`mutation AddLabelsToDiscussion\b`, func(input map[string]interface{}) bool {
+						assert.Equal(t, "D_1", input["labelableId"])
+						assert.Equal(t, []interface{}{"L_bug", "L_enh"}, input["labelIds"])
+						return true
+					}),
+					httpmock.StringResponse(`{"data":{"addLabelsToLabelable":{"__typename":"Labelable"}}}`),
+				)
+			},
+		},
+		{
+			name:      "only adds labels",
+			addIDs:    []string{"L_bug"},
+			removeIDs: nil,
+			setupMock: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation AddLabelsToDiscussion\b`),
+					httpmock.StringResponse(`{"data":{"addLabelsToLabelable":{"__typename":"Labelable"}}}`),
+				)
+			},
+		},
+		{
+			name:      "only removes labels",
+			addIDs:    nil,
+			removeIDs: []string{"L_old"},
+			setupMock: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation RemoveLabelsFromDiscussion\b`),
+					httpmock.StringResponse(`{"data":{"removeLabelsFromLabelable":{"__typename":"Labelable"}}}`),
+				)
+			},
+		},
+		{
+			name:      "skips both when empty",
+			addIDs:    nil,
+			removeIDs: nil,
+			setupMock: func(reg *httpmock.Registry) {},
+		},
+		{
+			name:      "remove error stops before add",
+			addIDs:    []string{"L_bug"},
+			removeIDs: []string{"L_old"},
+			setupMock: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation RemoveLabelsFromDiscussion\b`),
+					httpmock.StringResponse(`{"data":null,"errors":[{"message":"could not remove labels"}]}`),
+				)
+			},
+			wantErr: "could not remove labels",
+		},
+		{
+			name:      "add error is returned",
+			addIDs:    []string{"L_bug"},
+			removeIDs: nil,
+			setupMock: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation AddLabelsToDiscussion\b`),
+					httpmock.StringResponse(`{"data":null,"errors":[{"message":"could not add labels"}]}`),
+				)
+			},
+			wantErr: "could not add labels",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			tt.setupMock(reg)
+
+			client := newTestDiscussionClient(reg).(*discussionClient)
+
+			err := client.editDiscussionLabels(repo, "D_1", tt.addIDs, tt.removeIDs)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	repo := ghrepo.New("OWNER", "REPO")
 

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -2720,7 +2720,39 @@ func TestCreate(t *testing.T) {
 				)
 				reg.Register(
 					httpmock.GraphQL(`mutation AddLabelsToDiscussion\b`),
-					httpmock.StringResponse(`{"data":{"addLabelsToLabelable":{"__typename":"Discussion"}}}`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"addLabelsToLabelable": {
+									"labelable": {
+										"id": "D_new",
+										"number": 99,
+										"title": "New Discussion",
+										"body": "Discussion body",
+										"url": "https://github.com/OWNER/REPO/discussions/99",
+										"closed": false,
+										"stateReason": "",
+										"isAnswered": false,
+										"answerChosenAt": "0001-01-01T00:00:00Z",
+										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
+										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": ":speech_balloon:", "isAnswerable": false},
+										"answerChosenBy": null,
+										"labels": {
+											"nodes": [
+												{"id": "L_bug", "name": "bug", "color": "d73a4a"},
+												{"id": "L_enh", "name": "enhancement", "color": "a2eeef"}
+											]
+										},
+										"reactionGroups": [],
+										"createdAt": "2025-06-01T00:00:00Z",
+										"updatedAt": "2025-06-01T00:00:00Z",
+										"closedAt": "0001-01-01T00:00:00Z",
+										"locked": false
+									}
+								}
+							}
+						}
+					`)),
 				)
 			},
 			assertDisc: &Discussion{
@@ -2810,7 +2842,39 @@ func TestCreate(t *testing.T) {
 				)
 				reg.Register(
 					httpmock.GraphQL(`mutation AddLabelsToDiscussion\b`),
-					httpmock.StringResponse(`{"data":{"addLabelsToLabelable":{"__typename":"Discussion"}}}`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"addLabelsToLabelable": {
+									"labelable": {
+										"id": "D_new",
+										"number": 99,
+										"title": "New Discussion",
+										"body": "Discussion body",
+										"url": "https://github.com/OWNER/REPO/discussions/99",
+										"closed": false,
+										"stateReason": "",
+										"isAnswered": false,
+										"answerChosenAt": "0001-01-01T00:00:00Z",
+										"author": { "__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
+										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": ":speech_balloon:", "isAnswerable": false},
+										"answerChosenBy": null,
+										"labels": {
+											"nodes": [
+												{"id": "L_bug", "name": "bug", "color": "d73a4a"},
+												{"id": "L_enh", "name": "enhancement", "color": "a2eeef"}
+											]
+										},
+										"reactionGroups": [],
+										"createdAt": "2025-06-01T00:00:00Z",
+										"updatedAt": "2025-06-01T00:00:00Z",
+										"closedAt": "0001-01-01T00:00:00Z",
+										"locked": false
+									}
+								}
+							}
+						}
+					`)),
 				)
 			},
 			assertDisc: &Discussion{
@@ -2904,7 +2968,39 @@ func TestCreate(t *testing.T) {
 						assert.Equal(t, []interface{}{"L_bug", "L_enh"}, labelIDs)
 						return true
 					}),
-					httpmock.StringResponse(`{"data":{"addLabelsToLabelable":{"__typename":"Discussion"}}}`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"addLabelsToLabelable": {
+									"labelable": {
+										"id": "D_new",
+										"number": 99,
+										"title": "New Discussion",
+										"body": "Discussion body",
+										"url": "https://github.com/OWNER/REPO/discussions/99",
+										"closed": false,
+										"stateReason": "",
+										"isAnswered": false,
+										"answerChosenAt": "0001-01-01T00:00:00Z",
+										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
+										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": ":speech_balloon:", "isAnswerable": false},
+										"answerChosenBy": null,
+										"labels": {
+											"nodes": [
+												{"id": "L_bug", "name": "bug", "color": "d73a4a"},
+												{"id": "L_enh", "name": "enhancement", "color": "a2eeef"}
+											]
+										},
+										"reactionGroups": [{"content": "THUMBS_UP","users": {"totalCount": 0}}],
+										"createdAt": "2025-06-01T00:00:00Z",
+										"updatedAt": "2025-06-01T00:00:00Z",
+										"closedAt": "0001-01-01T00:00:00Z",
+										"locked": false
+									}
+								}
+							}
+						}
+					`)),
 				)
 			},
 			assertDisc: &Discussion{
@@ -3066,12 +3162,42 @@ func TestCreate(t *testing.T) {
 func TestEditDiscussionLabels(t *testing.T) {
 	repo := ghrepo.New("OWNER", "REPO")
 
+	baseNode := func() discussionListNode {
+		return discussionListNode{
+			ID:     "D_1",
+			Number: 5,
+			Title:  "T",
+			Body:   "B",
+			URL:    "https://github.com/OWNER/REPO/discussions/5",
+			Author: actorNode{
+				TypeName: "User",
+				Login:    "alice",
+				User:     struct{ ID, Name string }{ID: "U1", Name: "Alice"},
+				Bot:      struct{ ID string }{ID: "U1"},
+			},
+			Category: struct {
+				ID           string
+				Name         string
+				Slug         string
+				Emoji        string
+				IsAnswerable bool
+			}{ID: "CAT_1", Name: "General", Slug: "general"},
+			ReactionGroups: []struct {
+				Content string
+				Users   struct{ TotalCount int }
+			}{},
+			CreatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		}
+	}
+
 	tests := []struct {
 		name      string
 		addIDs    []string
 		removeIDs []string
 		setupMock func(reg *httpmock.Registry)
 		wantErr   string
+		wantNode  func() discussionListNode
 	}{
 		{
 			name:      "adds and removes labels",
@@ -3084,7 +3210,8 @@ func TestEditDiscussionLabels(t *testing.T) {
 						assert.Equal(t, []interface{}{"L_old"}, input["labelIds"])
 						return true
 					}),
-					httpmock.StringResponse(`{"data":{"removeLabelsFromLabelable":{"__typename":"Labelable"}}}`),
+					// This response is superseded by the subsequent add mutation so we don't need all fields.
+					httpmock.StringResponse(`{"data":{"removeLabelsFromLabelable":{"labelable":{"id": "D_1"}}}}`),
 				)
 				reg.Register(
 					httpmock.GraphQLMutationMatcher(`mutation AddLabelsToDiscussion\b`, func(input map[string]interface{}) bool {
@@ -3092,8 +3219,52 @@ func TestEditDiscussionLabels(t *testing.T) {
 						assert.Equal(t, []interface{}{"L_bug", "L_enh"}, input["labelIds"])
 						return true
 					}),
-					httpmock.StringResponse(`{"data":{"addLabelsToLabelable":{"__typename":"Labelable"}}}`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"addLabelsToLabelable": {
+									"labelable": {
+										"id": "D_1",
+										"number": 5,
+										"title": "T",
+										"body": "B",
+										"url": "https://github.com/OWNER/REPO/discussions/5",
+										"closed": false,
+										"stateReason": "",
+										"isAnswered": false,
+										"answerChosenAt": "0001-01-01T00:00:00Z",
+										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
+										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": "", "isAnswerable": false},
+										"answerChosenBy": null,
+										"labels": {
+											"nodes": [
+												{"id": "L_bug", "name": "bug", "color": "d73a4a"},
+												{"id": "L_enh", "name": "enhancement", "color": "a2eeef"}
+											]
+										},
+										"reactionGroups": [],
+										"createdAt": "2025-06-01T00:00:00Z",
+										"updatedAt": "2025-06-01T00:00:00Z",
+										"closedAt": "0001-01-01T00:00:00Z",
+										"locked": false
+									}
+								}
+							}
+						}
+					`)),
 				)
+			},
+			wantNode: func() discussionListNode {
+				n := baseNode()
+				n.Labels.Nodes = []struct {
+					ID    string
+					Name  string
+					Color string
+				}{
+					{ID: "L_bug", Name: "bug", Color: "d73a4a"},
+					{ID: "L_enh", Name: "enhancement", Color: "a2eeef"},
+				}
+				return n
 			},
 		},
 		{
@@ -3103,8 +3274,50 @@ func TestEditDiscussionLabels(t *testing.T) {
 			setupMock: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`mutation AddLabelsToDiscussion\b`),
-					httpmock.StringResponse(`{"data":{"addLabelsToLabelable":{"__typename":"Labelable"}}}`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"addLabelsToLabelable": {
+									"labelable": {
+										"id": "D_1",
+										"number": 5,
+										"title": "T",
+										"body": "B",
+										"url": "https://github.com/OWNER/REPO/discussions/5",
+										"closed": false,
+										"stateReason": "",
+										"isAnswered": false,
+										"answerChosenAt": "0001-01-01T00:00:00Z",
+										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
+										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": "", "isAnswerable": false},
+										"answerChosenBy": null,
+										"labels": {
+											"nodes": [
+												{"id": "L_bug", "name": "bug", "color": "d73a4a"}
+											]
+										},
+										"reactionGroups": [],
+										"createdAt": "2025-06-01T00:00:00Z",
+										"updatedAt": "2025-06-01T00:00:00Z",
+										"closedAt": "0001-01-01T00:00:00Z",
+										"locked": false
+									}
+								}
+							}
+						}
+					`)),
 				)
+			},
+			wantNode: func() discussionListNode {
+				n := baseNode()
+				n.Labels.Nodes = []struct {
+					ID    string
+					Name  string
+					Color string
+				}{
+					{ID: "L_bug", Name: "bug", Color: "d73a4a"},
+				}
+				return n
 			},
 		},
 		{
@@ -3114,8 +3327,46 @@ func TestEditDiscussionLabels(t *testing.T) {
 			setupMock: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`mutation RemoveLabelsFromDiscussion\b`),
-					httpmock.StringResponse(`{"data":{"removeLabelsFromLabelable":{"__typename":"Labelable"}}}`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"removeLabelsFromLabelable": {
+									"labelable": {
+										"id": "D_1",
+										"number": 5,
+										"title": "T",
+										"body": "B",
+										"url": "https://github.com/OWNER/REPO/discussions/5",
+										"closed": false,
+										"stateReason": "",
+										"isAnswered": false,
+										"answerChosenAt": "0001-01-01T00:00:00Z",
+										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
+										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": "", "isAnswerable": false},
+										"answerChosenBy": null,
+										"labels": {
+											"nodes": []
+										},
+										"reactionGroups": [],
+										"createdAt": "2025-06-01T00:00:00Z",
+										"updatedAt": "2025-06-01T00:00:00Z",
+										"closedAt": "0001-01-01T00:00:00Z",
+										"locked": false
+									}
+								}
+							}
+						}
+					`)),
 				)
+			},
+			wantNode: func() discussionListNode {
+				n := baseNode()
+				n.Labels.Nodes = []struct {
+					ID    string
+					Name  string
+					Color string
+				}{}
+				return n
 			},
 		},
 		{
@@ -3159,7 +3410,7 @@ func TestEditDiscussionLabels(t *testing.T) {
 
 			client := newTestDiscussionClient(reg).(*discussionClient)
 
-			err := client.editDiscussionLabels(repo, "D_1", tt.addIDs, tt.removeIDs)
+			node, err := client.editDiscussionLabels(repo, "D_1", tt.addIDs, tt.removeIDs)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -3168,6 +3419,12 @@ func TestEditDiscussionLabels(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			if tt.wantNode == nil {
+				assert.Nil(t, node)
+			} else {
+				require.NotNil(t, node)
+				assert.Equal(t, tt.wantNode(), *node)
+			}
 		})
 	}
 }
@@ -3200,6 +3457,8 @@ func TestUpdate(t *testing.T) {
 				Title:        &titleStr,
 				Body:         &bodyStr,
 				CategoryID:   &catID,
+				AddLabels:    []string{"bug", "enhancement"},
+				RemoveLabels: []string{"old", "stale"},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
@@ -3221,7 +3480,7 @@ func TestUpdate(t *testing.T) {
 										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
 										"category": {"id": "CAT_2", "name": "Q&A", "slug": "q-a", "emoji": ":question:", "isAnswerable": true},
 										"answerChosenBy": null,
-										"labels": {"nodes": []},
+										"labels": {"nodes": [{"id": "L_bug", "name": "bug", "color": "d73a4a"}, {"id": "L_enh", "name": "enhancement", "color": "a2eeef"}]},
 										"reactionGroups": [{"content": "THUMBS_UP", "users": {"totalCount": 0}}],
 										"createdAt": "2025-06-01T00:00:00Z",
 										"updatedAt": "2025-06-02T00:00:00Z",
@@ -3232,6 +3491,34 @@ func TestUpdate(t *testing.T) {
 							}
 						}
 					`)),
+				)
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLabels\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"repository": {
+									"labels": {
+										"nodes": [
+											{"id": "L_bug", "name": "bug", "color": "d73a4a"},
+											{"id": "L_enh", "name": "enhancement", "color": "a2eeef"},
+											{"id": "L_old", "name": "old", "color": "000000"},
+											{"id": "L_stale", "name": "stale", "color": "111111"}
+										],
+										"pageInfo": {"hasNextPage": false, "endCursor": ""}
+									}
+								}
+							}
+						}
+					`)),
+				)
+				reg.Register(
+					httpmock.GraphQL(`mutation RemoveLabelsFromDiscussion\b`),
+					httpmock.StringResponse(`{"data":{"removeLabelsFromLabelable":{"labelable":{"id":"D_1","number":5,"title":"Updated title","body":"Updated body","url":"https://github.com/OWNER/REPO/discussions/5","closed":false,"stateReason":"","isAnswered":false,"answerChosenAt":"0001-01-01T00:00:00Z","author":{"__typename":"User","login":"alice","id":"U1","name":"Alice"},"category":{"id":"CAT_2","name":"Q&A","slug":"q-a","emoji":":question:","isAnswerable":true},"answerChosenBy":null,"labels":{"nodes":[]},"reactionGroups":[{"content":"THUMBS_UP","users":{"totalCount":0}}],"createdAt":"2025-06-01T00:00:00Z","updatedAt":"2025-06-02T00:00:00Z","closedAt":"0001-01-01T00:00:00Z","locked":false}}}}`),
+				)
+				reg.Register(
+					httpmock.GraphQL(`mutation AddLabelsToDiscussion\b`),
+					httpmock.StringResponse(`{"data":{"addLabelsToLabelable":{"labelable":{"id":"D_1","number":5,"title":"Updated title","body":"Updated body","url":"https://github.com/OWNER/REPO/discussions/5","closed":false,"stateReason":"","isAnswered":false,"answerChosenAt":"0001-01-01T00:00:00Z","author":{"__typename":"User","login":"alice","id":"U1","name":"Alice"},"category":{"id":"CAT_2","name":"Q&A","slug":"q-a","emoji":":question:","isAnswerable":true},"answerChosenBy":null,"labels":{"nodes":[{"id":"L_bug","name":"bug","color":"d73a4a"},{"id":"L_enh","name":"enhancement","color":"a2eeef"}]},"reactionGroups":[{"content":"THUMBS_UP","users":{"totalCount":0}}],"createdAt":"2025-06-01T00:00:00Z","updatedAt":"2025-06-02T00:00:00Z","closedAt":"0001-01-01T00:00:00Z","locked":false}}}}`),
 				)
 			},
 			assertDisc: &Discussion{
@@ -3248,7 +3535,7 @@ func TestUpdate(t *testing.T) {
 					Emoji:        ":question:",
 					IsAnswerable: true,
 				},
-				Labels:         []DiscussionLabel{},
+				Labels:         []DiscussionLabel{{ID: "L_bug", Name: "bug", Color: "d73a4a"}, {ID: "L_enh", Name: "enhancement", Color: "a2eeef"}},
 				ReactionGroups: []ReactionGroup{{Content: "THUMBS_UP", TotalCount: 0}},
 				CreatedAt:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
 				UpdatedAt:      time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
@@ -3336,6 +3623,60 @@ func TestUpdate(t *testing.T) {
 				)
 			},
 			wantErr: "Could not resolve to a Discussion with the global id of 'D_1'.",
+		},
+		{
+			name: "label only update",
+			input: UpdateDiscussionInput{
+				DiscussionID: "D_1",
+				AddLabels:    []string{"bug", "enhancement"},
+				RemoveLabels: []string{"old", "stale"},
+			},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLabels\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"repository": {
+									"labels": {
+										"nodes": [
+											{"id": "L_bug", "name": "bug", "color": "d73a4a"},
+											{"id": "L_enh", "name": "enhancement", "color": "a2eeef"},
+											{"id": "L_old", "name": "old", "color": "000000"},
+											{"id": "L_stale", "name": "stale", "color": "111111"}
+										],
+										"pageInfo": {"hasNextPage": false, "endCursor": ""}
+									}
+								}
+							}
+						}
+					`)),
+				)
+				reg.Register(
+					httpmock.GraphQL(`mutation RemoveLabelsFromDiscussion\b`),
+					httpmock.StringResponse(`{"data":{"removeLabelsFromLabelable":{"labelable":{"id":"D_1","number":5,"title":"T","body":"B","url":"https://github.com/OWNER/REPO/discussions/5","closed":false,"stateReason":"","isAnswered":false,"answerChosenAt":"0001-01-01T00:00:00Z","author":{"__typename":"User","login":"alice","id":"U1","name":"Alice"},"category":{"id":"CAT_1","name":"General","slug":"general","emoji":"","isAnswerable":false},"answerChosenBy":null,"labels":{"nodes":[]},"reactionGroups":[],"createdAt":"2025-06-01T00:00:00Z","updatedAt":"2025-06-01T00:00:00Z","closedAt":"0001-01-01T00:00:00Z","locked":false}}}}`),
+				)
+				reg.Register(
+					httpmock.GraphQL(`mutation AddLabelsToDiscussion\b`),
+					httpmock.StringResponse(`{"data":{"addLabelsToLabelable":{"labelable":{"id":"D_1","number":5,"title":"T","body":"B","url":"https://github.com/OWNER/REPO/discussions/5","closed":false,"stateReason":"","isAnswered":false,"answerChosenAt":"0001-01-01T00:00:00Z","author":{"__typename":"User","login":"alice","id":"U1","name":"Alice"},"category":{"id":"CAT_1","name":"General","slug":"general","emoji":"","isAnswerable":false},"answerChosenBy":null,"labels":{"nodes":[{"id":"L_bug","name":"bug","color":"d73a4a"},{"id":"L_enh","name":"enhancement","color":"a2eeef"}]},"reactionGroups":[],"createdAt":"2025-06-01T00:00:00Z","updatedAt":"2025-06-01T00:00:00Z","closedAt":"0001-01-01T00:00:00Z","locked":false}}}}`),
+				)
+			},
+			assertDisc: &Discussion{
+				ID:     "D_1",
+				Number: 5,
+				Title:  "T",
+				Body:   "B",
+				URL:    "https://github.com/OWNER/REPO/discussions/5",
+				Author: DiscussionActor{ID: "U1", Login: "alice", Name: "Alice"},
+				Category: DiscussionCategory{
+					ID:   "CAT_1",
+					Name: "General",
+					Slug: "general",
+				},
+				Labels:    []DiscussionLabel{{ID: "L_bug", Name: "bug", Color: "d73a4a"}, {ID: "L_enh", Name: "enhancement", Color: "a2eeef"}},
+				CreatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+			},
 		},
 	}
 

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -2641,148 +2641,12 @@ func TestCreate(t *testing.T) {
 			wantErr: "Could not resolve to a node with the global id of 'BAD_CAT'.",
 		},
 		{
-			name: "paginates labels across multiple pages",
+			name: "creates discussion with labels via addLabels mutation",
 			input: CreateDiscussionInput{
 				CategoryID: "CAT_1",
 				Title:      "New Discussion",
 				Body:       "Discussion body",
-				Labels:     []string{"bug", "enhancement"},
-			},
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryMeta\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", true)),
-				)
-				reg.Register(
-					httpmock.GraphQL(`mutation CreateDiscussion\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"createDiscussion": {
-									"discussion": {
-										"id": "D_new",
-										"number": 99,
-										"title": "New Discussion",
-										"body": "Discussion body",
-										"url": "https://github.com/OWNER/REPO/discussions/99",
-										"closed": false,
-										"stateReason": "",
-										"isAnswered": false,
-										"answerChosenAt": "0001-01-01T00:00:00Z",
-										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
-										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": ":speech_balloon:", "isAnswerable": false},
-										"answerChosenBy": null,
-										"labels": {"nodes": []},
-										"reactionGroups": [],
-										"createdAt": "2025-06-01T00:00:00Z",
-										"updatedAt": "2025-06-01T00:00:00Z",
-										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false
-									}
-								}
-							}
-						}
-					`)),
-				)
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"repository": {
-									"labels": {
-										"nodes": [
-											{"id": "L_bug", "name": "bug", "color": "d73a4a"}
-										],
-										"pageInfo": {"hasNextPage": true, "endCursor": "LABEL_CUR_1"}
-									}
-								}
-							}
-						}
-					`)),
-				)
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"repository": {
-									"labels": {
-										"nodes": [
-											{"id": "L_enh", "name": "enhancement", "color": "a2eeef"}
-										],
-										"pageInfo": {"hasNextPage": false, "endCursor": ""}
-									}
-								}
-							}
-						}
-					`)),
-				)
-				reg.Register(
-					httpmock.GraphQL(`mutation AddLabelsToDiscussion\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"addLabelsToLabelable": {
-									"labelable": {
-										"id": "D_new",
-										"number": 99,
-										"title": "New Discussion",
-										"body": "Discussion body",
-										"url": "https://github.com/OWNER/REPO/discussions/99",
-										"closed": false,
-										"stateReason": "",
-										"isAnswered": false,
-										"answerChosenAt": "0001-01-01T00:00:00Z",
-										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
-										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": ":speech_balloon:", "isAnswerable": false},
-										"answerChosenBy": null,
-										"labels": {
-											"nodes": [
-												{"id": "L_bug", "name": "bug", "color": "d73a4a"},
-												{"id": "L_enh", "name": "enhancement", "color": "a2eeef"}
-											]
-										},
-										"reactionGroups": [],
-										"createdAt": "2025-06-01T00:00:00Z",
-										"updatedAt": "2025-06-01T00:00:00Z",
-										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false
-									}
-								}
-							}
-						}
-					`)),
-				)
-			},
-			assertDisc: &Discussion{
-				ID:     "D_new",
-				Number: 99,
-				Title:  "New Discussion",
-				Body:   "Discussion body",
-				URL:    "https://github.com/OWNER/REPO/discussions/99",
-				Author: DiscussionActor{ID: "U1", Login: "alice", Name: "Alice"},
-				Category: DiscussionCategory{
-					ID:    "CAT_1",
-					Name:  "General",
-					Slug:  "general",
-					Emoji: ":speech_balloon:",
-				},
-				Labels: []DiscussionLabel{
-					{ID: "L_bug", Name: "bug", Color: "d73a4a"},
-					{ID: "L_enh", Name: "enhancement", Color: "a2eeef"},
-				},
-				CreatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
-				UpdatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
-			},
-		},
-		{
-			name: "creates discussion with labels",
-			input: CreateDiscussionInput{
-				CategoryID: "CAT_1",
-				Title:      "New Discussion",
-				Body:       "Discussion body",
-				Labels:     []string{"bug", "enhancement"},
+				LabelIDs:   []string{"L_bug", "L_enh"},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
@@ -2814,24 +2678,6 @@ func TestCreate(t *testing.T) {
 										"updatedAt": "2025-06-01T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
 										"locked": false
-									}
-								}
-							}
-						}
-					`)),
-				)
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"repository": {
-									"labels": {
-										"nodes": [
-											{"id": "L_bug", "name": "bug", "color": "d73a4a"},
-											{"id": "L_enh", "name": "enhancement", "color": "a2eeef"}
-										],
-										"pageInfo": {"hasNextPage": false, "endCursor": ""}
 									}
 								}
 							}
@@ -2904,45 +2750,12 @@ func TestCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "label not found returns error without creating discussion",
-			input: CreateDiscussionInput{
-				CategoryID: "CAT_1",
-				Title:      "Test",
-				Body:       "Body",
-				Labels:     []string{"nonexistent", "also-missing"},
-			},
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryMeta\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", true)),
-				)
-				// No CreateDiscussion stub — reg.Verify(t) proves it is never called,
-				// confirming that label validation is atomic with discussion creation.
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"repository": {
-									"labels": {
-										"nodes": [],
-										"pageInfo": {"hasNextPage": false, "endCursor": ""}
-									}
-								}
-							}
-						}
-					`)),
-				)
-			},
-			wantErr: `labels not found: nonexistent, also-missing`,
-		},
-		{
 			name: "add labels mutation failure returns error",
 			input: CreateDiscussionInput{
 				CategoryID: "CAT_1",
 				Title:      "Test",
 				Body:       "Body",
-				Labels:     []string{"bug"},
+				LabelIDs:   []string{"L_bug"},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
@@ -2974,23 +2787,6 @@ func TestCreate(t *testing.T) {
 										"updatedAt": "2025-06-01T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
 										"locked": false
-									}
-								}
-							}
-						}
-					`)),
-				)
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"repository": {
-									"labels": {
-										"nodes": [
-											{"id": "L_bug", "name": "bug", "color": "d73a4a"}
-										],
-										"pageInfo": {"hasNextPage": false, "endCursor": ""}
 									}
 								}
 							}
@@ -3465,12 +3261,12 @@ func TestUpdate(t *testing.T) {
 		{
 			name: "maps all fields",
 			input: UpdateDiscussionInput{
-				DiscussionID: "D_1",
-				Title:        &titleStr,
-				Body:         &bodyStr,
-				CategoryID:   &catID,
-				AddLabels:    []string{"bug", "enhancement"},
-				RemoveLabels: []string{"old", "stale"},
+				DiscussionID:   "D_1",
+				Title:          &titleStr,
+				Body:           &bodyStr,
+				CategoryID:     &catID,
+				AddLabelIDs:    []string{"L_bug", "L_enh"},
+				RemoveLabelIDs: []string{"L_old", "L_stale"},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
@@ -3498,26 +3294,6 @@ func TestUpdate(t *testing.T) {
 										"updatedAt": "2025-06-02T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
 										"locked": false
-									}
-								}
-							}
-						}
-					`)),
-				)
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"repository": {
-									"labels": {
-										"nodes": [
-											{"id": "L_bug", "name": "bug", "color": "d73a4a"},
-											{"id": "L_enh", "name": "enhancement", "color": "a2eeef"},
-											{"id": "L_old", "name": "old", "color": "000000"},
-											{"id": "L_stale", "name": "stale", "color": "111111"}
-										],
-										"pageInfo": {"hasNextPage": false, "endCursor": ""}
 									}
 								}
 							}
@@ -3639,31 +3415,11 @@ func TestUpdate(t *testing.T) {
 		{
 			name: "label only update",
 			input: UpdateDiscussionInput{
-				DiscussionID: "D_1",
-				AddLabels:    []string{"bug", "enhancement"},
-				RemoveLabels: []string{"old", "stale"},
+				DiscussionID:   "D_1",
+				AddLabelIDs:    []string{"L_bug", "L_enh"},
+				RemoveLabelIDs: []string{"L_old", "L_stale"},
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"repository": {
-									"labels": {
-										"nodes": [
-											{"id": "L_bug", "name": "bug", "color": "d73a4a"},
-											{"id": "L_enh", "name": "enhancement", "color": "a2eeef"},
-											{"id": "L_old", "name": "old", "color": "000000"},
-											{"id": "L_stale", "name": "stale", "color": "111111"}
-										],
-										"pageInfo": {"hasNextPage": false, "endCursor": ""}
-									}
-								}
-							}
-						}
-					`)),
-				)
 				reg.Register(
 					httpmock.GraphQL(`mutation RemoveLabelsFromDiscussion\b`),
 					httpmock.StringResponse(`{"data":{"removeLabelsFromLabelable":{"labelable":{"id":"D_1","number":5,"title":"T","body":"B","url":"https://github.com/OWNER/REPO/discussions/5","closed":false,"stateReason":"","isAnswered":false,"answerChosenAt":"0001-01-01T00:00:00Z","author":{"__typename":"User","login":"alice","id":"U1","name":"Alice"},"category":{"id":"CAT_1","name":"General","slug":"general","emoji":"","isAnswerable":false},"answerChosenBy":null,"labels":{"nodes":[]},"reactionGroups":[],"createdAt":"2025-06-01T00:00:00Z","updatedAt":"2025-06-01T00:00:00Z","closedAt":"0001-01-01T00:00:00Z","locked":false}}}}`),

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -2685,7 +2685,7 @@ func TestCreate(t *testing.T) {
 					`)),
 				)
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabels\b`),
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
@@ -2702,7 +2702,7 @@ func TestCreate(t *testing.T) {
 					`)),
 				)
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabels\b`),
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
@@ -2735,128 +2735,6 @@ func TestCreate(t *testing.T) {
 										"isAnswered": false,
 										"answerChosenAt": "0001-01-01T00:00:00Z",
 										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
-										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": ":speech_balloon:", "isAnswerable": false},
-										"answerChosenBy": null,
-										"labels": {
-											"nodes": [
-												{"id": "L_bug", "name": "bug", "color": "d73a4a"},
-												{"id": "L_enh", "name": "enhancement", "color": "a2eeef"}
-											]
-										},
-										"reactionGroups": [],
-										"createdAt": "2025-06-01T00:00:00Z",
-										"updatedAt": "2025-06-01T00:00:00Z",
-										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false
-									}
-								}
-							}
-						}
-					`)),
-				)
-			},
-			assertDisc: &Discussion{
-				ID:     "D_new",
-				Number: 99,
-				Title:  "New Discussion",
-				Body:   "Discussion body",
-				URL:    "https://github.com/OWNER/REPO/discussions/99",
-				Author: DiscussionActor{ID: "U1", Login: "alice", Name: "Alice"},
-				Category: DiscussionCategory{
-					ID:    "CAT_1",
-					Name:  "General",
-					Slug:  "general",
-					Emoji: ":speech_balloon:",
-				},
-				Labels: []DiscussionLabel{
-					{ID: "L_bug", Name: "bug", Color: "d73a4a"},
-					{ID: "L_enh", Name: "enhancement", Color: "a2eeef"},
-				},
-				CreatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
-				UpdatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
-			},
-		},
-		{
-			name: "stops paginating labels when all found",
-			input: CreateDiscussionInput{
-				CategoryID: "CAT_1",
-				Title:      "New Discussion",
-				Body:       "Discussion body",
-				Labels:     []string{"bug", "enhancement"},
-			},
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryMeta\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", true)),
-				)
-				reg.Register(
-					httpmock.GraphQL(`mutation CreateDiscussion\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"createDiscussion": {
-									"discussion": {
-										"id": "D_new",
-										"number": 99,
-										"title": "New Discussion",
-										"body": "Discussion body",
-										"url": "https://github.com/OWNER/REPO/discussions/99",
-										"closed": false,
-										"stateReason": "",
-										"isAnswered": false,
-										"answerChosenAt": "0001-01-01T00:00:00Z",
-										"author": {"__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
-										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": ":speech_balloon:", "isAnswerable": false},
-										"answerChosenBy": null,
-										"labels": {"nodes": []},
-										"reactionGroups": [],
-										"createdAt": "2025-06-01T00:00:00Z",
-										"updatedAt": "2025-06-01T00:00:00Z",
-										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false
-									}
-								}
-							}
-						}
-					`)),
-				)
-				// Register a single page that returns both labels but claims more pages exist.
-				// The code should stop paginating once all wanted labels are found.
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabels\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"repository": {
-									"labels": {
-										"nodes": [
-											{"id": "L_bug", "name": "bug", "color": "d73a4a"},
-											{"id": "L_enh", "name": "enhancement", "color": "a2eeef"}
-										],
-										"pageInfo": {"hasNextPage": true, "endCursor": "LABEL_CUR_999"}
-									}
-								}
-							}
-						}
-					`)),
-				)
-				reg.Register(
-					httpmock.GraphQL(`mutation AddLabelsToDiscussion\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"addLabelsToLabelable": {
-									"labelable": {
-										"id": "D_new",
-										"number": 99,
-										"title": "New Discussion",
-										"body": "Discussion body",
-										"url": "https://github.com/OWNER/REPO/discussions/99",
-										"closed": false,
-										"stateReason": "",
-										"isAnswered": false,
-										"answerChosenAt": "0001-01-01T00:00:00Z",
-										"author": { "__typename": "User", "login": "alice", "id": "U1", "name": "Alice"},
 										"category": {"id": "CAT_1", "name": "General", "slug": "general", "emoji": ":speech_balloon:", "isAnswerable": false},
 										"answerChosenBy": null,
 										"labels": {
@@ -2943,7 +2821,7 @@ func TestCreate(t *testing.T) {
 					`)),
 				)
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabels\b`),
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
@@ -3041,7 +2919,7 @@ func TestCreate(t *testing.T) {
 				// No CreateDiscussion stub — reg.Verify(t) proves it is never called,
 				// confirming that label validation is atomic with discussion creation.
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabels\b`),
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
@@ -3103,7 +2981,7 @@ func TestCreate(t *testing.T) {
 					`)),
 				)
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabels\b`),
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
@@ -3155,6 +3033,140 @@ func TestCreate(t *testing.T) {
 			require.NotNil(t, d)
 			require.NotNil(t, tt.assertDisc, "assertDisc must be set for non-error cases")
 			assert.Equal(t, tt.assertDisc, d)
+		})
+	}
+}
+
+func TestListLabels(t *testing.T) {
+	repo := ghrepo.New("OWNER", "REPO")
+
+	tests := []struct {
+		name      string
+		httpStubs func(*httpmock.Registry)
+		want      []DiscussionLabel
+		wantErr   string
+	}{
+		{
+			name: "single page",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"repository": {
+									"labels": {
+										"nodes": [
+											{"id": "L_bug", "name": "bug", "color": "d73a4a"},
+											{"id": "L_enh", "name": "enhancement", "color": "a2eeef"}
+										],
+										"pageInfo": {"hasNextPage": false, "endCursor": ""}
+									}
+								}
+							}
+						}
+					`)),
+				)
+			},
+			want: []DiscussionLabel{
+				{ID: "L_bug", Name: "bug", Color: "d73a4a"},
+				{ID: "L_enh", Name: "enhancement", Color: "a2eeef"},
+			},
+		},
+		{
+			name: "multiple pages",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"repository": {
+									"labels": {
+										"nodes": [
+											{"id": "L_bug", "name": "bug", "color": "d73a4a"}
+										],
+										"pageInfo": {"hasNextPage": true, "endCursor": "CUR_1"}
+									}
+								}
+							}
+						}
+					`)),
+				)
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"repository": {
+									"labels": {
+										"nodes": [
+											{"id": "L_enh", "name": "enhancement", "color": "a2eeef"}
+										],
+										"pageInfo": {"hasNextPage": false, "endCursor": ""}
+									}
+								}
+							}
+						}
+					`)),
+				)
+			},
+			want: []DiscussionLabel{
+				{ID: "L_bug", Name: "bug", Color: "d73a4a"},
+				{ID: "L_enh", Name: "enhancement", Color: "a2eeef"},
+			},
+		},
+		{
+			name: "empty repository",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
+					httpmock.StringResponse(heredoc.Doc(`
+						{
+							"data": {
+								"repository": {
+									"labels": {
+										"nodes": [],
+										"pageInfo": {"hasNextPage": false, "endCursor": ""}
+									}
+								}
+							}
+						}
+					`)),
+				)
+			},
+			want: nil,
+		},
+		{
+			name: "query error",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
+					httpmock.StringResponse(`{"data":null,"errors":[{"message":"something went wrong"}]}`),
+				)
+			},
+			wantErr: "something went wrong",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			tt.httpStubs(reg)
+
+			client := newTestDiscussionClient(reg).(*discussionClient)
+			labels, err := client.ListLabels(repo)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, labels)
 		})
 	}
 }
@@ -3493,7 +3505,7 @@ func TestUpdate(t *testing.T) {
 					`)),
 				)
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabels\b`),
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
@@ -3633,7 +3645,7 @@ func TestUpdate(t *testing.T) {
 			},
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryLabels\b`),
+					httpmock.GraphQL(`query RepositoryLabelsForDiscussions\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -3187,6 +3187,13 @@ func TestUpdate(t *testing.T) {
 		assertDisc *Discussion
 	}{
 		{
+			name: "nothing to update",
+			input: UpdateDiscussionInput{
+				DiscussionID: "D_1",
+			},
+			wantErr: "nothing to update",
+		},
+		{
 			name: "maps all fields",
 			input: UpdateDiscussionInput{
 				DiscussionID: "D_1",
@@ -3219,8 +3226,7 @@ func TestUpdate(t *testing.T) {
 										"createdAt": "2025-06-01T00:00:00Z",
 										"updatedAt": "2025-06-02T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false,
-										"comments": {"totalCount": 0}
+										"locked": false
 									}
 								}
 							}
@@ -3279,8 +3285,7 @@ func TestUpdate(t *testing.T) {
 										"createdAt": "2025-06-01T00:00:00Z",
 										"updatedAt": "2025-06-02T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false,
-										"comments": {"totalCount": 0}
+										"locked": false
 									}
 								}
 							}
@@ -3301,10 +3306,9 @@ func TestUpdate(t *testing.T) {
 					Slug:  "general",
 					Emoji: ":speech_balloon:",
 				},
-				Labels:         []DiscussionLabel{},
-				ReactionGroups: []ReactionGroup{},
-				CreatedAt:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
-				UpdatedAt:      time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+				Labels:    []DiscussionLabel{},
+				CreatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
 			},
 		},
 		{

--- a/pkg/cmd/discussion/client/client_mock.go
+++ b/pkg/cmd/discussion/client/client_mock.go
@@ -42,6 +42,9 @@ var _ DiscussionClient = &DiscussionClientMock{}
 //			ListCategoriesFunc: func(repo ghrepo.Interface) ([]DiscussionCategory, error) {
 //				panic("mock out the ListCategories method")
 //			},
+//			ListLabelsFunc: func(repo ghrepo.Interface) ([]DiscussionLabel, error) {
+//				panic("mock out the ListLabels method")
+//			},
 //			LockFunc: func(repo ghrepo.Interface, id string, reason string) error {
 //				panic("mock out the Lock method")
 //			},
@@ -93,6 +96,9 @@ type DiscussionClientMock struct {
 
 	// ListCategoriesFunc mocks the ListCategories method.
 	ListCategoriesFunc func(repo ghrepo.Interface) ([]DiscussionCategory, error)
+
+	// ListLabelsFunc mocks the ListLabels method.
+	ListLabelsFunc func(repo ghrepo.Interface) ([]DiscussionLabel, error)
 
 	// LockFunc mocks the Lock method.
 	LockFunc func(repo ghrepo.Interface, id string, reason string) error
@@ -195,6 +201,11 @@ type DiscussionClientMock struct {
 			// Repo is the repo argument value.
 			Repo ghrepo.Interface
 		}
+		// ListLabels holds details about calls to the ListLabels method.
+		ListLabels []struct {
+			// Repo is the repo argument value.
+			Repo ghrepo.Interface
+		}
 		// Lock holds details about calls to the Lock method.
 		Lock []struct {
 			// Repo is the repo argument value.
@@ -259,6 +270,7 @@ type DiscussionClientMock struct {
 	lockGetWithComments   sync.RWMutex
 	lockList              sync.RWMutex
 	lockListCategories    sync.RWMutex
+	lockListLabels        sync.RWMutex
 	lockLock              sync.RWMutex
 	lockMarkAnswer        sync.RWMutex
 	lockReopen            sync.RWMutex
@@ -597,6 +609,38 @@ func (mock *DiscussionClientMock) ListCategoriesCalls() []struct {
 	mock.lockListCategories.RLock()
 	calls = mock.calls.ListCategories
 	mock.lockListCategories.RUnlock()
+	return calls
+}
+
+// ListLabels calls ListLabelsFunc.
+func (mock *DiscussionClientMock) ListLabels(repo ghrepo.Interface) ([]DiscussionLabel, error) {
+	if mock.ListLabelsFunc == nil {
+		panic("DiscussionClientMock.ListLabelsFunc: method is nil but DiscussionClient.ListLabels was just called")
+	}
+	callInfo := struct {
+		Repo ghrepo.Interface
+	}{
+		Repo: repo,
+	}
+	mock.lockListLabels.Lock()
+	mock.calls.ListLabels = append(mock.calls.ListLabels, callInfo)
+	mock.lockListLabels.Unlock()
+	return mock.ListLabelsFunc(repo)
+}
+
+// ListLabelsCalls gets all the calls that were made to ListLabels.
+// Check the length with:
+//
+//	len(mockedDiscussionClient.ListLabelsCalls())
+func (mock *DiscussionClientMock) ListLabelsCalls() []struct {
+	Repo ghrepo.Interface
+} {
+	var calls []struct {
+		Repo ghrepo.Interface
+	}
+	mock.lockListLabels.RLock()
+	calls = mock.calls.ListLabels
+	mock.lockListLabels.RUnlock()
 	return calls
 }
 

--- a/pkg/cmd/discussion/client/types.go
+++ b/pkg/cmd/discussion/client/types.go
@@ -336,8 +336,10 @@ type CreateDiscussionInput struct {
 // UpdateDiscussionInput holds optional parameters for updating a discussion.
 // Nil pointer fields are left unchanged.
 type UpdateDiscussionInput struct {
-	DiscussionID string
-	Title        *string
-	Body         *string
-	CategoryID   *string
+	DiscussionID   string
+	Title          *string
+	Body           *string
+	CategoryID     *string
+	AddLabels    []string
+	RemoveLabels []string
 }

--- a/pkg/cmd/discussion/client/types.go
+++ b/pkg/cmd/discussion/client/types.go
@@ -330,7 +330,7 @@ type CreateDiscussionInput struct {
 	CategoryID string
 	Title      string
 	Body       string
-	Labels     []string
+	LabelIDs   []string
 }
 
 // UpdateDiscussionInput holds optional parameters for updating a discussion.
@@ -340,6 +340,6 @@ type UpdateDiscussionInput struct {
 	Title          *string
 	Body           *string
 	CategoryID     *string
-	AddLabels    []string
-	RemoveLabels []string
+	AddLabelIDs    []string
+	RemoveLabelIDs []string
 }

--- a/pkg/cmd/discussion/create/create.go
+++ b/pkg/cmd/discussion/create/create.go
@@ -146,11 +146,26 @@ func createRun(opts *CreateOptions) error {
 		}
 	}
 
+	var labelIDs []string
+	if len(opts.Labels) > 0 {
+		opts.IO.StartProgressIndicator()
+		allLabels, err := c.ListLabels(repo)
+		opts.IO.StopProgressIndicator()
+		if err != nil {
+			return err
+		}
+
+		labelIDs, err = shared.ResolveLabels(allLabels, opts.Labels)
+		if err != nil {
+			return err
+		}
+	}
+
 	input := client.CreateDiscussionInput{
 		CategoryID: category.ID,
 		Title:      opts.Title,
 		Body:       opts.Body,
-		Labels:     opts.Labels,
+		LabelIDs:   labelIDs,
 	}
 
 	opts.IO.StartProgressIndicator()

--- a/pkg/cmd/discussion/create/create_test.go
+++ b/pkg/cmd/discussion/create/create_test.go
@@ -166,8 +166,14 @@ func TestCreateRun(t *testing.T) {
 				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
 					return sampleCategories(), nil
 				}
+				m.ListLabelsFunc = func(repo ghrepo.Interface) ([]client.DiscussionLabel, error) {
+					return []client.DiscussionLabel{
+						{ID: "L_bug", Name: "bug"},
+						{ID: "L_enh", Name: "enhancement"},
+					}, nil
+				}
 				m.CreateFunc = func(repo ghrepo.Interface, input client.CreateDiscussionInput) (*client.Discussion, error) {
-					assert.Equal(t, []string{"enhancement", "bug"}, input.Labels)
+					assert.Equal(t, []string{"L_enh", "L_bug"}, input.LabelIDs)
 					return sampleDiscussion(), nil
 				}
 			},

--- a/pkg/cmd/discussion/discussion.go
+++ b/pkg/cmd/discussion/discussion.go
@@ -3,6 +3,7 @@ package discussion
 import (
 	"github.com/MakeNowJust/heredoc"
 	cmdCreate "github.com/cli/cli/v2/pkg/cmd/discussion/create"
+	cmdEdit "github.com/cli/cli/v2/pkg/cmd/discussion/edit"
 	cmdList "github.com/cli/cli/v2/pkg/cmd/discussion/list"
 	cmdView "github.com/cli/cli/v2/pkg/cmd/discussion/view"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -40,6 +41,7 @@ func NewCmdDiscussion(f *cmdutil.Factory) *cobra.Command {
 	)
 
 	cmdutil.AddGroup(cmd, "Targeted commands",
+		cmdEdit.NewCmdEdit(f, nil),
 		cmdView.NewCmdView(f, nil),
 	)
 

--- a/pkg/cmd/discussion/edit/edit.go
+++ b/pkg/cmd/discussion/edit/edit.go
@@ -136,11 +136,18 @@ func editRun(opts *EditOptions) error {
 		DiscussionID: discussion.ID,
 	}
 
+	// noFlagsSet omits BodyFile intentionally: ReadFile above already copied its
+	// contents into opts.Body, so Body == "" implies no body update was requested.
 	noFlagsSet := opts.Title == "" && opts.Body == "" && opts.Category == ""
 	if noFlagsSet {
 		// Interactive mode: prompt user to select which fields to edit.
 		if err := promptEdit(opts, discussion, c, repo, &input); err != nil {
 			return err
+		}
+		// If the user dismissed the prompt without selecting anything, skip the
+		// API call — there is nothing to update.
+		if input.Title == nil && input.Body == nil && input.CategoryID == nil {
+			return nil
 		}
 	} else {
 		// Non-interactive: apply only the flags that were set.

--- a/pkg/cmd/discussion/edit/edit.go
+++ b/pkg/cmd/discussion/edit/edit.go
@@ -1,0 +1,233 @@
+package edit
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+// EditOptions holds the configuration for the discussion edit command.
+type EditOptions struct {
+	IO         *iostreams.IOStreams
+	HttpClient func() (*http.Client, error)
+	BaseRepo   func() (ghrepo.Interface, error)
+	Client     func() (client.DiscussionClient, error)
+	Prompter   prompter.Prompter
+
+	DiscussionNumber int
+	Title            string
+	Body             string
+	BodyFile         string
+	Category         string
+}
+
+// NewCmdEdit returns a cobra command for editing a GitHub Discussion.
+func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Command {
+	opts := &EditOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+		Prompter:   f.Prompter,
+		Client:     shared.DiscussionClientFunc(f),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "edit {<number> | <url>}",
+		Short: "Edit a discussion (preview)",
+		Long: heredoc.Docf(`
+			Edit a GitHub Discussion.
+
+			With %[1]s--title%[1]s, %[1]s--body%[1]s, and %[1]s--category%[1]s flags, the discussion is updated
+			non-interactively. Omitting all flags triggers interactive prompts when connected to a terminal.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# Edit interactively
+			$ gh discussion edit 123
+
+			# Set a new title
+			$ gh discussion edit 123 --title "Updated title"
+
+			# Change the category
+			$ gh discussion edit 123 --category "Ideas"
+
+			# Update body from a file
+			$ gh discussion edit 123 --body-file body.md
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.MutuallyExclusive("specify only one of --body or --body-file",
+				opts.Body != "", opts.BodyFile != ""); err != nil {
+				return err
+			}
+
+			number, repo, err := shared.ParseDiscussionArg(args[0])
+			if err != nil {
+				return cmdutil.FlagErrorf("%s", err)
+			}
+
+			if repo != nil {
+				opts.BaseRepo = func() (ghrepo.Interface, error) {
+					return repo, nil
+				}
+			} else {
+				opts.BaseRepo = f.BaseRepo
+			}
+
+			opts.DiscussionNumber = number
+
+			noFlagsSet := opts.Title == "" && opts.Body == "" && opts.BodyFile == "" && opts.Category == ""
+			if noFlagsSet && !opts.IO.CanPrompt() {
+				return cmdutil.FlagErrorf("specify at least one of --title, --body, --body-file, or --category when not running interactively")
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return editRun(opts)
+		},
+	}
+
+	cmdutil.EnableRepoOverride(cmd, f)
+
+	cmd.Flags().StringVarP(&opts.Title, "title", "t", "", "New title for the discussion")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "New body for the discussion")
+	cmd.Flags().StringVarP(&opts.BodyFile, "body-file", "F", "", "Read body text from file (use \"-\" to read from standard input)")
+	cmd.Flags().StringVarP(&opts.Category, "category", "c", "", "New category name or slug for the discussion")
+
+	return cmd
+}
+
+func editRun(opts *EditOptions) error {
+	repo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	c, err := opts.Client()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicator()
+	discussion, err := c.GetByNumber(repo, opts.DiscussionNumber)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return fmt.Errorf("fetching discussion: %w", err)
+	}
+
+	// Resolve body from file if provided.
+	if opts.BodyFile != "" {
+		bodyBytes, err := cmdutil.ReadFile(opts.BodyFile, opts.IO.In)
+		if err != nil {
+			return err
+		}
+		opts.Body = string(bodyBytes)
+	}
+
+	input := client.UpdateDiscussionInput{
+		DiscussionID: discussion.ID,
+	}
+
+	noFlagsSet := opts.Title == "" && opts.Body == "" && opts.Category == ""
+	if noFlagsSet {
+		// Interactive mode: prompt user to select which fields to edit.
+		if err := promptEdit(opts, discussion, c, repo, &input); err != nil {
+			return err
+		}
+	} else {
+		// Non-interactive: apply only the flags that were set.
+		if opts.Title != "" {
+			if strings.TrimSpace(opts.Title) == "" {
+				return cmdutil.FlagErrorf("title cannot be blank")
+			}
+			input.Title = &opts.Title
+		}
+		if opts.Body != "" {
+			input.Body = &opts.Body
+		}
+		if opts.Category != "" {
+			opts.IO.StartProgressIndicator()
+			categories, err := c.ListCategories(repo)
+			opts.IO.StopProgressIndicator()
+			if err != nil {
+				return fmt.Errorf("fetching categories: %w", err)
+			}
+			cat, err := shared.MatchCategory(opts.Category, categories)
+			if err != nil {
+				return err
+			}
+			input.CategoryID = &cat.ID
+		}
+	}
+
+	opts.IO.StartProgressIndicator()
+	updated, err := c.Update(repo, input)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return fmt.Errorf("failed to update discussion: %w", err)
+	}
+
+	fmt.Fprintln(opts.IO.Out, updated.URL)
+	return nil
+}
+
+// promptEdit runs the interactive flow, populating input with user choices.
+func promptEdit(opts *EditOptions, discussion *client.Discussion, c client.DiscussionClient, repo ghrepo.Interface, input *client.UpdateDiscussionInput) error {
+	choices := []string{"title", "body", "category"}
+	selected, err := opts.Prompter.MultiSelect("What would you like to edit?", nil, choices)
+	if err != nil {
+		return err
+	}
+	if len(selected) == 0 {
+		return nil
+	}
+
+	for _, idx := range selected {
+		switch choices[idx] {
+		case "title":
+			title, err := opts.Prompter.Input("Discussion title", discussion.Title)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(title) == "" {
+				return fmt.Errorf("title cannot be blank")
+			}
+			input.Title = &title
+
+		case "body":
+			body, err := opts.Prompter.MarkdownEditor("Discussion body", discussion.Body, false)
+			if err != nil {
+				return err
+			}
+			input.Body = &body
+
+		case "category":
+			opts.IO.StartProgressIndicator()
+			categories, err := c.ListCategories(repo)
+			opts.IO.StopProgressIndicator()
+			if err != nil {
+				return fmt.Errorf("fetching categories: %w", err)
+			}
+			names := make([]string, len(categories))
+			for i, cat := range categories {
+				names[i] = cat.Name
+			}
+			currentName := discussion.Category.Name
+			idx, err := opts.Prompter.Select("Discussion category", currentName, names)
+			if err != nil {
+				return err
+			}
+			input.CategoryID = &categories[idx].ID
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/discussion/edit/edit.go
+++ b/pkg/cmd/discussion/edit/edit.go
@@ -71,11 +71,6 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := cmdutil.MutuallyExclusive("specify only one of --body or --body-file",
-				opts.Body != "", opts.BodyFile != ""); err != nil {
-				return err
-			}
-
 			number, repo, err := shared.ParseDiscussionArg(args[0])
 			if err != nil {
 				return cmdutil.FlagErrorWrap(err)
@@ -91,10 +86,14 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 
 			opts.DiscussionNumber = number
 
-			flags := cmd.Flags()
-			opts.TitleProvided = flags.Changed("title")
-			opts.BodyProvided = flags.Changed("body") || flags.Changed("body-file")
-			opts.CategoryProvided = flags.Changed("category")
+			if err := cmdutil.MutuallyExclusive("specify only one of --body or --body-file",
+				cmd.Flags().Changed("body"), cmd.Flags().Changed("body-file")); err != nil {
+				return err
+			}
+
+			opts.TitleProvided = cmd.Flags().Changed("title")
+			opts.BodyProvided = cmd.Flags().Changed("body") || cmd.Flags().Changed("body-file")
+			opts.CategoryProvided = cmd.Flags().Changed("category")
 			opts.LabelsProvided = len(opts.AddLabels) > 0 || len(opts.RemoveLabels) > 0
 
 			noFlagsSet := !opts.TitleProvided && !opts.BodyProvided && !opts.CategoryProvided && !opts.LabelsProvided

--- a/pkg/cmd/discussion/edit/edit.go
+++ b/pkg/cmd/discussion/edit/edit.go
@@ -23,11 +23,19 @@ type EditOptions struct {
 	Client     func() (client.DiscussionClient, error)
 	Prompter   prompter.Prompter
 
+	Interactive      bool
+	TitleProvided    bool
+	BodyProvided     bool
+	CategoryProvided bool
+	LabelsProvided   bool
+
 	DiscussionNumber int
 	Title            string
 	Body             string
 	BodyFile         string
 	Category         string
+	AddLabels        []string
+	RemoveLabels     []string
 }
 
 // NewCmdEdit returns a cobra command for editing a GitHub Discussion.
@@ -42,24 +50,24 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "edit {<number> | <url>}",
 		Short: "Edit a discussion (preview)",
-		Long: heredoc.Docf(`
+		Long: heredoc.Doc(`
 			Edit a GitHub Discussion.
 
-			With %[1]s--title%[1]s, %[1]s--body%[1]s, and %[1]s--category%[1]s flags, the discussion is updated
-			non-interactively. Omitting all flags triggers interactive prompts when connected to a terminal.
-		`, "`"),
+			Without flags, the command runs interactively when connected to a terminal.
+			Use flags to update specific fields non-interactively.
+		`),
 		Example: heredoc.Doc(`
 			# Edit interactively
 			$ gh discussion edit 123
 
-			# Set a new title
-			$ gh discussion edit 123 --title "Updated title"
-
-			# Change the category
-			$ gh discussion edit 123 --category "Ideas"
+			# Update title, body, and category
+			$ gh discussion edit 123 --title "Updated title" --body "Updated body" --category "Ideas"
 
 			# Update body from a file
 			$ gh discussion edit 123 --body-file body.md
+
+			# Add and remove labels
+			$ gh discussion edit 123 --add-label "bug,help wanted" --remove-label "stale"
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -83,10 +91,18 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 
 			opts.DiscussionNumber = number
 
-			noFlagsSet := opts.Title == "" && opts.Body == "" && opts.BodyFile == "" && opts.Category == ""
+			flags := cmd.Flags()
+			opts.TitleProvided = flags.Changed("title")
+			opts.BodyProvided = flags.Changed("body") || flags.Changed("body-file")
+			opts.CategoryProvided = flags.Changed("category")
+			opts.LabelsProvided = len(opts.AddLabels) > 0 || len(opts.RemoveLabels) > 0
+
+			noFlagsSet := !opts.TitleProvided && !opts.BodyProvided && !opts.CategoryProvided && !opts.LabelsProvided
 			if noFlagsSet && !opts.IO.CanPrompt() {
-				return cmdutil.FlagErrorf("specify at least one of --title, --body, --body-file, or --category when not running interactively")
+				return cmdutil.FlagErrorf("specify at least one flag to update the discussion non-interactively")
 			}
+
+			opts.Interactive = noFlagsSet
 
 			if runF != nil {
 				return runF(opts)
@@ -101,6 +117,8 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "New body for the discussion")
 	cmd.Flags().StringVarP(&opts.BodyFile, "body-file", "F", "", "Read body text from file (use \"-\" to read from standard input)")
 	cmd.Flags().StringVarP(&opts.Category, "category", "c", "", "New category name or slug for the discussion")
+	cmd.Flags().StringSliceVar(&opts.AddLabels, "add-label", nil, "Add labels by `name`")
+	cmd.Flags().StringSliceVar(&opts.RemoveLabels, "remove-label", nil, "Remove labels by `name`")
 
 	return cmd
 }
@@ -120,47 +138,40 @@ func editRun(opts *EditOptions) error {
 	discussion, err := c.GetByNumber(repo, opts.DiscussionNumber)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
-		return fmt.Errorf("fetching discussion: %w", err)
-	}
-
-	// Resolve body from file if provided.
-	if opts.BodyFile != "" {
-		bodyBytes, err := cmdutil.ReadFile(opts.BodyFile, opts.IO.In)
-		if err != nil {
-			return err
-		}
-		opts.Body = string(bodyBytes)
+		return err
 	}
 
 	input := client.UpdateDiscussionInput{
 		DiscussionID: discussion.ID,
 	}
 
-	// noFlagsSet omits BodyFile intentionally: ReadFile above already copied its
-	// contents into opts.Body, so Body == "" implies no body update was requested.
-	noFlagsSet := opts.Title == "" && opts.Body == "" && opts.Category == ""
-	if noFlagsSet {
-		// Interactive mode: prompt user to select which fields to edit.
-		if err := promptEdit(opts, discussion, c, repo, &input); err != nil {
+	if opts.Interactive {
+		changed, err := promptEdit(opts, discussion, c, repo, &input)
+		if err != nil {
 			return err
 		}
-		// If the user dismissed the prompt without selecting anything, skip the
-		// API call — there is nothing to update.
-		if input.Title == nil && input.Body == nil && input.CategoryID == nil {
-			return nil
+
+		if !changed {
+			return fmt.Errorf("no changes made")
 		}
 	} else {
-		// Non-interactive: apply only the flags that were set.
-		if opts.Title != "" {
+		if opts.TitleProvided {
 			if strings.TrimSpace(opts.Title) == "" {
 				return cmdutil.FlagErrorf("title cannot be blank")
 			}
 			input.Title = &opts.Title
 		}
-		if opts.Body != "" {
+		if opts.BodyProvided {
+			if opts.BodyFile != "" {
+				bodyBytes, err := cmdutil.ReadFile(opts.BodyFile, opts.IO.In)
+				if err != nil {
+					return err
+				}
+				opts.Body = string(bodyBytes)
+			}
 			input.Body = &opts.Body
 		}
-		if opts.Category != "" {
+		if opts.CategoryProvided {
 			opts.IO.StartProgressIndicator()
 			categories, err := c.ListCategories(repo)
 			opts.IO.StopProgressIndicator()
@@ -173,68 +184,90 @@ func editRun(opts *EditOptions) error {
 			}
 			input.CategoryID = &cat.ID
 		}
+
+		if opts.LabelsProvided {
+			opts.IO.StartProgressIndicator()
+			allLabels, err := c.ListLabels(repo)
+			opts.IO.StopProgressIndicator()
+			if err != nil {
+				return fmt.Errorf("fetching labels: %w", err)
+			}
+			if len(opts.AddLabels) > 0 {
+				input.AddLabelIDs, err = shared.ResolveLabels(allLabels, opts.AddLabels)
+				if err != nil {
+					return err
+				}
+			}
+			if len(opts.RemoveLabels) > 0 {
+				input.RemoveLabelIDs, err = shared.ResolveLabels(allLabels, opts.RemoveLabels)
+				if err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	opts.IO.StartProgressIndicator()
 	updated, err := c.Update(repo, input)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
-		return fmt.Errorf("failed to update discussion: %w", err)
+		return err
 	}
 
 	fmt.Fprintln(opts.IO.Out, updated.URL)
 	return nil
 }
 
-// promptEdit runs the interactive flow, populating input with user choices.
-func promptEdit(opts *EditOptions, discussion *client.Discussion, c client.DiscussionClient, repo ghrepo.Interface, input *client.UpdateDiscussionInput) error {
-	choices := []string{"title", "body", "category"}
+// promptEdit runs the interactive flow, populating input with user choices. It returns a boolean indicating whether any
+// changes were made, and an error if the process failed.
+func promptEdit(opts *EditOptions, discussion *client.Discussion, c client.DiscussionClient, repo ghrepo.Interface, input *client.UpdateDiscussionInput) (bool, error) {
+	choices := []string{"Title", "Body", "Category"}
 	selected, err := opts.Prompter.MultiSelect("What would you like to edit?", nil, choices)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if len(selected) == 0 {
-		return nil
+		return false, nil
 	}
 
 	for _, idx := range selected {
 		switch choices[idx] {
-		case "title":
-			title, err := opts.Prompter.Input("Discussion title", discussion.Title)
+		case "Title":
+			title, err := opts.Prompter.Input("Title", discussion.Title)
 			if err != nil {
-				return err
+				return false, err
 			}
 			if strings.TrimSpace(title) == "" {
-				return fmt.Errorf("title cannot be blank")
+				return false, fmt.Errorf("title cannot be blank")
 			}
 			input.Title = &title
 
-		case "body":
-			body, err := opts.Prompter.MarkdownEditor("Discussion body", discussion.Body, false)
+		case "Body":
+			body, err := opts.Prompter.MarkdownEditor("Body", discussion.Body, false)
 			if err != nil {
-				return err
+				return false, err
 			}
 			input.Body = &body
 
-		case "category":
+		case "Category":
 			opts.IO.StartProgressIndicator()
 			categories, err := c.ListCategories(repo)
 			opts.IO.StopProgressIndicator()
 			if err != nil {
-				return fmt.Errorf("fetching categories: %w", err)
+				return false, err
 			}
 			names := make([]string, len(categories))
 			for i, cat := range categories {
 				names[i] = cat.Name
 			}
 			currentName := discussion.Category.Name
-			idx, err := opts.Prompter.Select("Discussion category", currentName, names)
+			idx, err := opts.Prompter.Select("Category", currentName, names)
 			if err != nil {
-				return err
+				return false, err
 			}
 			input.CategoryID = &categories[idx].ID
 		}
 	}
 
-	return nil
+	return true, nil
 }

--- a/pkg/cmd/discussion/edit/edit.go
+++ b/pkg/cmd/discussion/edit/edit.go
@@ -70,7 +70,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 
 			number, repo, err := shared.ParseDiscussionArg(args[0])
 			if err != nil {
-				return cmdutil.FlagErrorf("%s", err)
+				return cmdutil.FlagErrorWrap(err)
 			}
 
 			if repo != nil {

--- a/pkg/cmd/discussion/edit/edit_test.go
+++ b/pkg/cmd/discussion/edit/edit_test.go
@@ -1,0 +1,459 @@
+package edit
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdEdit(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         string
+		isTTY        bool
+		wantOpts     EditOptions
+		wantBaseRepo ghrepo.Interface
+		wantErr      string
+	}{
+		{
+			name:  "all flags",
+			args:  "123 --title 'New title' --body 'New body' --category 'Ideas'",
+			isTTY: true,
+			wantOpts: EditOptions{
+				DiscussionNumber: 123,
+				Title:            "New title",
+				Body:             "New body",
+				Category:         "Ideas",
+			},
+		},
+		{
+			name:  "url arg overrides base repo",
+			args:  "https://github.com/OWNER2/REPO2/discussions/42",
+			isTTY: true,
+			wantOpts: EditOptions{
+				DiscussionNumber: 42,
+			},
+			wantBaseRepo: ghrepo.New("OWNER2", "REPO2"),
+		},
+		{
+			name:    "mutual exclusion --body and --body-file",
+			args:    "123 --body 'inline' --body-file body.md",
+			isTTY:   true,
+			wantErr: "specify only one of --body or --body-file",
+		},
+		{
+			name:    "no flags no TTY",
+			args:    "123",
+			isTTY:   false,
+			wantErr: "specify at least one of --title, --body, --body-file, or --category when not running interactively",
+		},
+		{
+			name:    "no args",
+			args:    "",
+			isTTY:   true,
+			wantErr: "accepts 1 arg(s)",
+		},
+		{
+			name:    "extra args",
+			args:    "123 extra",
+			isTTY:   true,
+			wantErr: "accepts 1 arg(s)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStdoutTTY(tt.isTTY)
+			f := &cmdutil.Factory{IOStreams: ios}
+			var gotOpts *EditOptions
+			cmd := NewCmdEdit(f, func(opts *EditOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			argv, err := shlex.Split(tt.args)
+			require.NoError(t, err)
+			cmd.SetArgs(argv)
+
+			_, err = cmd.ExecuteC()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOpts.DiscussionNumber, gotOpts.DiscussionNumber)
+			assert.Equal(t, tt.wantOpts.Title, gotOpts.Title)
+			assert.Equal(t, tt.wantOpts.Body, gotOpts.Body)
+			assert.Equal(t, tt.wantOpts.Category, gotOpts.Category)
+
+			if tt.wantBaseRepo != nil {
+				baseRepo, err := gotOpts.BaseRepo()
+				require.NoError(t, err)
+				assert.True(t, ghrepo.IsSame(tt.wantBaseRepo, baseRepo))
+			}
+		})
+	}
+}
+
+func TestEditRun(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      EditOptions
+		isTTY     bool
+		setupMock func(*client.DiscussionClientMock)
+		prompter  *prompter.PrompterMock
+		wantErr   string
+		wantOut   string
+	}{
+		{
+			name: "success non-tty title only",
+			opts: EditOptions{
+				Title: "Updated title",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, "D_1", input.DiscussionID)
+					require.NotNil(t, input.Title)
+					assert.Equal(t, "Updated title", *input.Title)
+					assert.Nil(t, input.Body)
+					assert.Nil(t, input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "success non-tty body only",
+			opts: EditOptions{
+				Body: "Updated body",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.Title)
+					require.NotNil(t, input.Body)
+					assert.Equal(t, "Updated body", *input.Body)
+					assert.Nil(t, input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "success non-tty category change",
+			opts: EditOptions{
+				Category: "Q&A",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.Title)
+					assert.Nil(t, input.Body)
+					require.NotNil(t, input.CategoryID)
+					assert.Equal(t, "CAT2", *input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "success non-tty all flags",
+			opts: EditOptions{
+				Title:    "New title",
+				Body:     "New body",
+				Category: "General",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					require.NotNil(t, input.Title)
+					assert.Equal(t, "New title", *input.Title)
+					require.NotNil(t, input.Body)
+					assert.Equal(t, "New body", *input.Body)
+					require.NotNil(t, input.CategoryID)
+					assert.Equal(t, "CAT1", *input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "non-tty blank title returns error",
+			opts: EditOptions{
+				Title: "   ",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+			},
+			wantErr: "title cannot be blank",
+		},
+		{
+			name: "non-tty unknown category",
+			opts: EditOptions{
+				Category: "nonexistent",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+			},
+			wantErr: `unknown category: "nonexistent"`,
+		},
+		{
+			name: "non-tty list categories error",
+			opts: EditOptions{
+				Category: "General",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return nil, fmt.Errorf("network error")
+				}
+			},
+			wantErr: "fetching categories: network error",
+		},
+		{
+			name: "GetByNumber error",
+			opts: EditOptions{
+				Title: "whatever",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return nil, fmt.Errorf("not found")
+				}
+			},
+			wantErr: "fetching discussion: not found",
+		},
+		{
+			name: "Update error",
+			opts: EditOptions{
+				Title: "Updated title",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					return nil, fmt.Errorf("mutation failed")
+				}
+			},
+			wantErr: "failed to update discussion: mutation failed",
+		},
+		{
+			name:  "tty interactive select title",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					require.NotNil(t, input.Title)
+					assert.Equal(t, "New title", *input.Title)
+					assert.Nil(t, input.Body)
+					assert.Nil(t, input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					assert.Equal(t, []string{"title", "body", "category"}, options)
+					return []int{0}, nil
+				},
+				InputFunc: func(prompt, defaultValue string) (string, error) {
+					assert.Equal(t, "Original title", defaultValue)
+					return "New title", nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty interactive select body",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.Title)
+					require.NotNil(t, input.Body)
+					assert.Equal(t, "New body text", *input.Body)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					return []int{1}, nil // body is index 1
+				},
+				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
+					assert.Equal(t, "Original body", defaultValue)
+					return "New body text", nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty interactive select category",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
+					return sampleCategories(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.Title)
+					assert.Nil(t, input.Body)
+					require.NotNil(t, input.CategoryID)
+					assert.Equal(t, "CAT2", *input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					return []int{2}, nil // category is index 2
+				},
+				SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
+					assert.Equal(t, "General", defaultValue)
+					assert.Equal(t, []string{"General", "Q&A", "Show and tell"}, options)
+					return 1, nil // select "Q&A"
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty interactive nothing selected still calls Update",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, "D_1", input.DiscussionID)
+					assert.Nil(t, input.Title)
+					assert.Nil(t, input.Body)
+					assert.Nil(t, input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					return []int{}, nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name:  "tty interactive blank title returns error",
+			isTTY: true,
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
+					return []int{0}, nil
+				},
+				InputFunc: func(prompt, defaultValue string) (string, error) {
+					return "   ", nil
+				},
+			},
+			wantErr: "title cannot be blank",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, stdout, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+
+			mockClient := &client.DiscussionClientMock{}
+			if tt.setupMock != nil {
+				tt.setupMock(mockClient)
+			}
+
+			opts := tt.opts
+			opts.IO = ios
+			opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.New("OWNER", "REPO"), nil
+			}
+			opts.Client = func() (client.DiscussionClient, error) {
+				return mockClient, nil
+			}
+			if tt.prompter != nil {
+				opts.Prompter = tt.prompter
+			}
+
+			err := editRun(&opts)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOut, stdout.String())
+		})
+	}
+}
+
+func sampleCategories() []client.DiscussionCategory {
+	return []client.DiscussionCategory{
+		{ID: "CAT1", Name: "General", Slug: "general"},
+		{ID: "CAT2", Name: "Q&A", Slug: "q-a"},
+		{ID: "CAT3", Name: "Show and tell", Slug: "show-and-tell"},
+	}
+}
+
+func sampleDiscussion() *client.Discussion {
+	return &client.Discussion{
+		ID:     "D_1",
+		Number: 5,
+		Title:  "Original title",
+		Body:   "Original body",
+		URL:    "https://github.com/OWNER/REPO/discussions/5",
+		Category: client.DiscussionCategory{
+			ID:   "CAT1",
+			Name: "General",
+			Slug: "general",
+		},
+	}
+}

--- a/pkg/cmd/discussion/edit/edit_test.go
+++ b/pkg/cmd/discussion/edit/edit_test.go
@@ -32,8 +32,11 @@ func TestNewCmdEdit(t *testing.T) {
 			isTTY: true,
 			wantOpts: EditOptions{
 				DiscussionNumber: 123,
+				TitleProvided:    true,
 				Title:            "New title",
+				BodyProvided:     true,
 				Body:             "New body",
+				CategoryProvided: true,
 				Category:         "Ideas",
 			},
 		},
@@ -43,8 +46,29 @@ func TestNewCmdEdit(t *testing.T) {
 			isTTY: true,
 			wantOpts: EditOptions{
 				DiscussionNumber: 42,
+				Interactive:      true,
 			},
 			wantBaseRepo: ghrepo.New("OWNER2", "REPO2"),
+		},
+		{
+			name:  "interactive mode when no flags and tty",
+			args:  "123",
+			isTTY: true,
+			wantOpts: EditOptions{
+				DiscussionNumber: 123,
+				Interactive:      true,
+			},
+		},
+		{
+			name:  "labels flags",
+			args:  "123 --add-label 'bug,help wanted' --remove-label stale",
+			isTTY: true,
+			wantOpts: EditOptions{
+				DiscussionNumber: 123,
+				AddLabels:        []string{"bug", "help wanted"},
+				RemoveLabels:     []string{"stale"},
+				LabelsProvided:   true,
+			},
 		},
 		{
 			name:    "mutual exclusion --body and --body-file",
@@ -56,7 +80,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:    "no flags no TTY",
 			args:    "123",
 			isTTY:   false,
-			wantErr: "specify at least one of --title, --body, --body-file, or --category when not running interactively",
+			wantErr: "specify at least one flag to update the discussion non-interactively",
 		},
 		{
 			name:    "no args",
@@ -99,9 +123,16 @@ func TestNewCmdEdit(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantOpts.DiscussionNumber, gotOpts.DiscussionNumber)
+			assert.Equal(t, tt.wantOpts.Interactive, gotOpts.Interactive)
+			assert.Equal(t, tt.wantOpts.TitleProvided, gotOpts.TitleProvided)
+			assert.Equal(t, tt.wantOpts.BodyProvided, gotOpts.BodyProvided)
+			assert.Equal(t, tt.wantOpts.CategoryProvided, gotOpts.CategoryProvided)
+			assert.Equal(t, tt.wantOpts.LabelsProvided, gotOpts.LabelsProvided)
 			assert.Equal(t, tt.wantOpts.Title, gotOpts.Title)
 			assert.Equal(t, tt.wantOpts.Body, gotOpts.Body)
 			assert.Equal(t, tt.wantOpts.Category, gotOpts.Category)
+			assert.Equal(t, tt.wantOpts.AddLabels, gotOpts.AddLabels)
+			assert.Equal(t, tt.wantOpts.RemoveLabels, gotOpts.RemoveLabels)
 
 			if tt.wantBaseRepo != nil {
 				baseRepo, err := gotOpts.BaseRepo()
@@ -117,6 +148,7 @@ func TestEditRun(t *testing.T) {
 		name            string
 		opts            EditOptions
 		bodyFileContent string // if non-empty, creates a temp file and sets opts.BodyFile
+		stdinContent    string // if non-empty, writes to stdin buffer
 		isTTY           bool
 		setupMock       func(*client.DiscussionClientMock)
 		prompter        *prompter.PrompterMock
@@ -126,7 +158,8 @@ func TestEditRun(t *testing.T) {
 		{
 			name: "success non-tty title only",
 			opts: EditOptions{
-				Title: "Updated title",
+				Title:         "Updated title",
+				TitleProvided: true,
 			},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
@@ -146,7 +179,8 @@ func TestEditRun(t *testing.T) {
 		{
 			name: "success non-tty body only",
 			opts: EditOptions{
-				Body: "Updated body",
+				Body:         "Updated body",
+				BodyProvided: true,
 			},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
@@ -165,7 +199,8 @@ func TestEditRun(t *testing.T) {
 		{
 			name: "success non-tty category change",
 			opts: EditOptions{
-				Category: "Q&A",
+				Category:         "Q&A",
+				CategoryProvided: true,
 			},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
@@ -185,11 +220,93 @@ func TestEditRun(t *testing.T) {
 			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
 		},
 		{
+			name: "success non-tty add/remove labels only",
+			opts: EditOptions{
+				AddLabels:      []string{"bug", "enhancement"},
+				RemoveLabels:   []string{"stale"},
+				LabelsProvided: true,
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListLabelsFunc = func(repo ghrepo.Interface) ([]client.DiscussionLabel, error) {
+					return []client.DiscussionLabel{
+						{ID: "L_bug", Name: "bug"},
+						{ID: "L_enh", Name: "enhancement"},
+						{ID: "L_stale", Name: "stale"},
+					}, nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.Title)
+					assert.Nil(t, input.Body)
+					assert.Nil(t, input.CategoryID)
+					assert.Equal(t, []string{"L_bug", "L_enh"}, input.AddLabelIDs)
+					assert.Equal(t, []string{"L_stale"}, input.RemoveLabelIDs)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "success non-tty add labels only",
+			opts: EditOptions{
+				AddLabels:      []string{"bug", "enhancement"},
+				LabelsProvided: true,
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListLabelsFunc = func(repo ghrepo.Interface) ([]client.DiscussionLabel, error) {
+					return []client.DiscussionLabel{
+						{ID: "L_bug", Name: "bug"},
+						{ID: "L_enh", Name: "enhancement"},
+					}, nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Equal(t, []string{"L_bug", "L_enh"}, input.AddLabelIDs)
+					assert.Nil(t, input.RemoveLabelIDs)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
+			name: "success non-tty remove labels only",
+			opts: EditOptions{
+				RemoveLabels:   []string{"stale"},
+				LabelsProvided: true,
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListLabelsFunc = func(repo ghrepo.Interface) ([]client.DiscussionLabel, error) {
+					return []client.DiscussionLabel{
+						{ID: "L_stale", Name: "stale"},
+					}, nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.AddLabelIDs)
+					assert.Equal(t, []string{"L_stale"}, input.RemoveLabelIDs)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
+		{
 			name: "success non-tty all flags",
 			opts: EditOptions{
-				Title:    "New title",
-				Body:     "New body",
-				Category: "General",
+				Title:            "New title",
+				Body:             "New body",
+				Category:         "General",
+				AddLabels:        []string{"bug"},
+				RemoveLabels:     []string{"stale"},
+				TitleProvided:    true,
+				BodyProvided:     true,
+				CategoryProvided: true,
+				LabelsProvided:   true,
 			},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
@@ -198,6 +315,12 @@ func TestEditRun(t *testing.T) {
 				m.ListCategoriesFunc = func(repo ghrepo.Interface) ([]client.DiscussionCategory, error) {
 					return sampleCategories(), nil
 				}
+				m.ListLabelsFunc = func(repo ghrepo.Interface) ([]client.DiscussionLabel, error) {
+					return []client.DiscussionLabel{
+						{ID: "L_bug", Name: "bug"},
+						{ID: "L_stale", Name: "stale"},
+					}, nil
+				}
 				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
 					require.NotNil(t, input.Title)
 					assert.Equal(t, "New title", *input.Title)
@@ -205,6 +328,8 @@ func TestEditRun(t *testing.T) {
 					assert.Equal(t, "New body", *input.Body)
 					require.NotNil(t, input.CategoryID)
 					assert.Equal(t, "CAT1", *input.CategoryID)
+					assert.Equal(t, []string{"L_bug"}, input.AddLabelIDs)
+					assert.Equal(t, []string{"L_stale"}, input.RemoveLabelIDs)
 					return sampleDiscussion(), nil
 				}
 			},
@@ -213,7 +338,8 @@ func TestEditRun(t *testing.T) {
 		{
 			name: "non-tty blank title returns error",
 			opts: EditOptions{
-				Title: "   ",
+				Title:         "   ",
+				TitleProvided: true,
 			},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
@@ -225,7 +351,8 @@ func TestEditRun(t *testing.T) {
 		{
 			name: "non-tty unknown category",
 			opts: EditOptions{
-				Category: "nonexistent",
+				Category:         "nonexistent",
+				CategoryProvided: true,
 			},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
@@ -240,7 +367,8 @@ func TestEditRun(t *testing.T) {
 		{
 			name: "non-tty list categories error",
 			opts: EditOptions{
-				Category: "General",
+				Category:         "General",
+				CategoryProvided: true,
 			},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
@@ -250,24 +378,44 @@ func TestEditRun(t *testing.T) {
 					return nil, fmt.Errorf("network error")
 				}
 			},
-			wantErr: "fetching categories: network error",
+			wantErr: "network error",
+		},
+		{
+			name: "non-tty unresolvable label returns error",
+			opts: EditOptions{
+				AddLabels:      []string{"bug", "nonexistent", "also-missing"},
+				LabelsProvided: true,
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.ListLabelsFunc = func(repo ghrepo.Interface) ([]client.DiscussionLabel, error) {
+					return []client.DiscussionLabel{
+						{ID: "L_bug", Name: "bug"},
+					}, nil
+				}
+			},
+			wantErr: "labels not found: nonexistent, also-missing",
 		},
 		{
 			name: "GetByNumber error",
 			opts: EditOptions{
-				Title: "whatever",
+				Title:         "whatever",
+				TitleProvided: true,
 			},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
 					return nil, fmt.Errorf("not found")
 				}
 			},
-			wantErr: "fetching discussion: not found",
+			wantErr: "not found",
 		},
 		{
 			name: "Update error",
 			opts: EditOptions{
-				Title: "Updated title",
+				Title:         "Updated title",
+				TitleProvided: true,
 			},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
@@ -277,11 +425,12 @@ func TestEditRun(t *testing.T) {
 					return nil, fmt.Errorf("mutation failed")
 				}
 			},
-			wantErr: "failed to update discussion: mutation failed",
+			wantErr: "mutation failed",
 		},
 		{
 			name:  "tty interactive select title",
 			isTTY: true,
+			opts:  EditOptions{Interactive: true},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
 					return sampleDiscussion(), nil
@@ -296,7 +445,7 @@ func TestEditRun(t *testing.T) {
 			},
 			prompter: &prompter.PrompterMock{
 				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
-					assert.Equal(t, []string{"title", "body", "category"}, options)
+					assert.Equal(t, []string{"Title", "Body", "Category"}, options)
 					return []int{0}, nil
 				},
 				InputFunc: func(prompt, defaultValue string) (string, error) {
@@ -309,6 +458,7 @@ func TestEditRun(t *testing.T) {
 		{
 			name:  "tty interactive select body",
 			isTTY: true,
+			opts:  EditOptions{Interactive: true},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
 					return sampleDiscussion(), nil
@@ -334,6 +484,7 @@ func TestEditRun(t *testing.T) {
 		{
 			name:  "tty interactive select category",
 			isTTY: true,
+			opts:  EditOptions{Interactive: true},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
 					return sampleDiscussion(), nil
@@ -364,22 +515,25 @@ func TestEditRun(t *testing.T) {
 		{
 			name:  "tty interactive nothing selected is a no-op",
 			isTTY: true,
+			opts:  EditOptions{Interactive: true},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
 					return sampleDiscussion(), nil
 				}
-				// UpdateFunc intentionally not set: Update must not be called when nothing is selected.
 			},
 			prompter: &prompter.PrompterMock{
 				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
 					return []int{}, nil
 				},
 			},
-			wantOut: "",
+			wantErr: "no changes made",
 		},
 		{
 			name:            "success non-tty body-file",
 			bodyFileContent: "Body from file",
+			opts: EditOptions{
+				BodyProvided: true,
+			},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
 					return sampleDiscussion(), nil
@@ -397,6 +551,7 @@ func TestEditRun(t *testing.T) {
 		{
 			name:  "tty interactive blank title returns error",
 			isTTY: true,
+			opts:  EditOptions{Interactive: true},
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
 					return sampleDiscussion(), nil
@@ -412,13 +567,38 @@ func TestEditRun(t *testing.T) {
 			},
 			wantErr: "title cannot be blank",
 		},
+		{
+			name:         "success non-tty body-file from stdin",
+			stdinContent: "Body from stdin",
+			opts: EditOptions{
+				BodyFile:     "-",
+				BodyProvided: true,
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.Title)
+					require.NotNil(t, input.Body)
+					assert.Equal(t, "Body from stdin", *input.Body)
+					assert.Nil(t, input.CategoryID)
+					return sampleDiscussion(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ios, _, stdout, _ := iostreams.Test()
+			ios, stdin, stdout, _ := iostreams.Test()
 			ios.SetStdoutTTY(tt.isTTY)
 			ios.SetStdinTTY(tt.isTTY)
+
+			if tt.stdinContent != "" {
+				stdin.WriteString(tt.stdinContent)
+			}
 
 			mockClient := &client.DiscussionClientMock{}
 			if tt.setupMock != nil {

--- a/pkg/cmd/discussion/edit/edit_test.go
+++ b/pkg/cmd/discussion/edit/edit_test.go
@@ -3,6 +3,8 @@ package edit
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -112,13 +114,14 @@ func TestNewCmdEdit(t *testing.T) {
 
 func TestEditRun(t *testing.T) {
 	tests := []struct {
-		name      string
-		opts      EditOptions
-		isTTY     bool
-		setupMock func(*client.DiscussionClientMock)
-		prompter  *prompter.PrompterMock
-		wantErr   string
-		wantOut   string
+		name            string
+		opts            EditOptions
+		bodyFileContent string // if non-empty, creates a temp file and sets opts.BodyFile
+		isTTY           bool
+		setupMock       func(*client.DiscussionClientMock)
+		prompter        *prompter.PrompterMock
+		wantErr         string
+		wantOut         string
 	}{
 		{
 			name: "success non-tty title only",
@@ -359,24 +362,35 @@ func TestEditRun(t *testing.T) {
 			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
 		},
 		{
-			name:  "tty interactive nothing selected still calls Update",
+			name:  "tty interactive nothing selected is a no-op",
 			isTTY: true,
 			setupMock: func(m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
 					return sampleDiscussion(), nil
 				}
-				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
-					assert.Equal(t, "D_1", input.DiscussionID)
-					assert.Nil(t, input.Title)
-					assert.Nil(t, input.Body)
-					assert.Nil(t, input.CategoryID)
-					return sampleDiscussion(), nil
-				}
+				// UpdateFunc intentionally not set: Update must not be called when nothing is selected.
 			},
 			prompter: &prompter.PrompterMock{
 				MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
 					return []int{}, nil
 				},
+			},
+			wantOut: "",
+		},
+		{
+			name:            "success non-tty body-file",
+			bodyFileContent: "Body from file",
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.UpdateFunc = func(repo ghrepo.Interface, input client.UpdateDiscussionInput) (*client.Discussion, error) {
+					assert.Nil(t, input.Title)
+					require.NotNil(t, input.Body)
+					assert.Equal(t, "Body from file", *input.Body)
+					assert.Nil(t, input.CategoryID)
+					return sampleDiscussion(), nil
+				}
 			},
 			wantOut: "https://github.com/OWNER/REPO/discussions/5\n",
 		},
@@ -412,6 +426,12 @@ func TestEditRun(t *testing.T) {
 			}
 
 			opts := tt.opts
+			if tt.bodyFileContent != "" {
+				dir := t.TempDir()
+				f := filepath.Join(dir, "body.md")
+				require.NoError(t, os.WriteFile(f, []byte(tt.bodyFileContent), 0600))
+				opts.BodyFile = f
+			}
 			opts.IO = ios
 			opts.BaseRepo = func() (ghrepo.Interface, error) {
 				return ghrepo.New("OWNER", "REPO"), nil

--- a/pkg/cmd/discussion/shared/labels.go
+++ b/pkg/cmd/discussion/shared/labels.go
@@ -1,0 +1,36 @@
+package shared
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
+)
+
+// ResolveLabels matches user-provided label names (case-insensitive) against a
+// set of known labels and returns the corresponding IDs. If any names cannot be
+// matched, all unrecognized names are reported in the returned error.
+func ResolveLabels(allLabels []client.DiscussionLabel, names []string) ([]string, error) {
+	byName := make(map[string]string, len(allLabels))
+	for _, l := range allLabels {
+		byName[strings.ToLower(l.Name)] = l.ID
+	}
+
+	var ids []string
+	var missing []string
+
+	for _, name := range names {
+		id, ok := byName[strings.ToLower(name)]
+		if !ok {
+			missing = append(missing, name)
+		} else {
+			ids = append(ids, id)
+		}
+	}
+
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("labels not found: %s", strings.Join(missing, ", "))
+	}
+
+	return ids, nil
+}

--- a/pkg/cmd/discussion/shared/labels_test.go
+++ b/pkg/cmd/discussion/shared/labels_test.go
@@ -1,0 +1,73 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveLabels(t *testing.T) {
+	tests := []struct {
+		name      string
+		allLabels []client.DiscussionLabel
+		names     []string
+		wantIDs   []string
+		wantErr   string
+	}{
+		{
+			name:      "empty source labels and empty names",
+			allLabels: nil,
+			names:     nil,
+			wantIDs:   nil,
+		},
+		{
+			name:      "empty source labels with non-empty names",
+			allLabels: nil,
+			names:     []string{"bug", "enhancement"},
+			wantErr:   "labels not found: bug, enhancement",
+		},
+		{
+			name: "non-empty source labels with empty names",
+			allLabels: []client.DiscussionLabel{
+				{ID: "L1", Name: "bug"},
+				{ID: "L2", Name: "enhancement"},
+			},
+			names:   nil,
+			wantIDs: nil,
+		},
+		{
+			name: "all names match",
+			allLabels: []client.DiscussionLabel{
+				{ID: "L1", Name: "bug"},
+				{ID: "L2", Name: "Enhancement"},
+				{ID: "L3", Name: "documentation"},
+			},
+			names:   []string{"enhancement", "Bug"},
+			wantIDs: []string{"L2", "L1"},
+		},
+		{
+			name: "some names missing",
+			allLabels: []client.DiscussionLabel{
+				{ID: "L1", Name: "bug"},
+				{ID: "L2", Name: "enhancement"},
+			},
+			names:   []string{"bug", "invalid", "unknown"},
+			wantErr: "labels not found: invalid, unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids, err := ResolveLabels(tt.allLabels, tt.names)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantErr, err.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantIDs, ids)
+			}
+		})
+	}
+}

--- a/pkg/cmd/discussion/view/view.go
+++ b/pkg/cmd/discussion/view/view.go
@@ -164,7 +164,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 
 			number, repo, err := shared.ParseDiscussionArg(args[0])
 			if err != nil {
-				return cmdutil.FlagErrorf("%s", err)
+				return cmdutil.FlagErrorWrap(err)
 			}
 
 			if repo != nil {


### PR DESCRIPTION
_This is the updated version of https://github.com/cli/cli/pull/13384 and https://github.com/cli/cli/pull/13390._

## Changes

Adds the `gh discussion edit` command for editing GitHub Discussions, supporting both interactive and non-interactive workflows.

### Command

```
gh discussion edit {<number> | <url>} [flags]
```

**Flags:**
- `--title`, `-t` : Set a new title
- `--body`, `-b` : Set a new body
- `--body-file`, `-F` : Read body from file (use `-` for stdin)
- `--category`, `-c` : Change the category (by name or slug)
- `--add-label` : Add labels by name
- `--remove-label` : Remove labels by name

**Interactive mode:** When no flags are provided and the terminal is interactive, prompts the user to select which fields to edit (title, body, category).

### Client layer

- `editDiscussionLabels`: Adds/removes labels on a discussion via `addLabelsToLabelable` and `removeLabelsFromLabelable` mutations.
- `ListLabels`: Fetches all repository labels with pagination, ordered alphabetically.
- `Update`: Accepts label IDs directly (no internal resolution).
- `Create`: Also updated to accept label IDs directly for consistency.
- Removed `resolveLabels` from the client; label name resolution is now the command layer's responsibility via `shared.ResolveLabels`.
- Used strongly-typed `githubv4.UpdateDiscussionInput` for the update mutation (replacing raw `map[string]interface{}`).

### Shared utilities

- `shared.ResolveLabels(allLabels, names)`: Case-insensitive label name to ID resolution. Reports all unrecognized names in a single error.

### Other fixes

- Skips the `Update` API call when the user selects nothing to edit in interactive mode.
- Uses `flags.Changed()` for detecting flag presence (allows setting body to empty string).
- Wraps errors from client methods for clearer context.


## Screenshots

### Interactive mode

1. Select fields to update
<img width="1008" height="90" alt="image" src="https://github.com/user-attachments/assets/be05bef6-4dce-44bf-a78e-9b907ef70d46" />

2. Populate new values
<img width="1004" height="173" alt="image" src="https://github.com/user-attachments/assets/b2bb8fa8-b0e0-475a-a7ff-a7d6fcf29b0b" />

3. Submit
<img width="1009" height="87" alt="image" src="https://github.com/user-attachments/assets/9d8e9c31-020f-4961-8ce7-d43bf685ca0d" />

### Non-interactive mode

<img width="1036" height="91" alt="image" src="https://github.com/user-attachments/assets/5fc60e1b-227a-4ee1-b5b7-2b6281561c5f" />
