### PR TITLE
fix(skills): update skills installed in hidden directories

### DIFF
--- a/internal/skills/discovery/discovery.go
+++ b/internal/skills/discovery/discovery.go
@@ -26,6 +26,11 @@ var specNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
 // TreeTooLargeError is returned when a repository's git tree exceeds the
 // GitHub API truncation limit and full skill discovery is not possible.
+// ErrNoSkillsFound is returned (wrapped) when DiscoverSkills /
+// DiscoverSkillsWithOptions cannot locate any convention-discoverable skills
+// in the target repository. Callers can detect this with errors.Is.
+var ErrNoSkillsFound = errors.New("no skills found")
+
 type TreeTooLargeError struct {
 	Owner string
 	Repo  string
@@ -518,11 +523,11 @@ func DiscoverSkills(client *api.Client, host, owner, repo, commitSHA string) ([]
 	}
 	if len(skills) == 0 {
 		return nil, fmt.Errorf(
-			"no skills found in %s/%s\n"+
+			"%w in %s/%s\n"+
 				"  Expected skills in skills/*/SKILL.md, skills/{scope}/*/SKILL.md,\n"+
 				"  */SKILL.md, or plugins/*/skills/*/SKILL.md\n"+
 				"  This repository may be a curated list rather than a skills publisher",
-			owner, repo,
+			ErrNoSkillsFound, owner, repo,
 		)
 	}
 	return skills, nil
@@ -570,12 +575,12 @@ func DiscoverSkillsWithOptions(client *api.Client, host, owner, repo, commitSHA 
 
 	if len(matches) == 0 {
 		return nil, fmt.Errorf(
-			"no skills found in %s/%s\n"+
+			"%w in %s/%s\n"+
 				"  Expected skills in skills/*/SKILL.md, skills/{scope}/*/SKILL.md,\n"+
 				"  {prefix}/skills/*/SKILL.md, {prefix}/skills/{scope}/*/SKILL.md,\n"+
 				"  */SKILL.md, or plugins/*/skills/*/SKILL.md\n"+
 				"  This repository may be a curated list rather than a skills publisher",
-			owner, repo,
+			ErrNoSkillsFound, owner, repo,
 		)
 	}
 

--- a/internal/skills/discovery/discovery.go
+++ b/internal/skills/discovery/discovery.go
@@ -24,13 +24,11 @@ import (
 // 1-64 chars, lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens.
 var specNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
-// TreeTooLargeError is returned when a repository's git tree exceeds the
-// GitHub API truncation limit and full skill discovery is not possible.
-// ErrNoSkillsFound is returned (wrapped) when DiscoverSkills /
-// DiscoverSkillsWithOptions cannot locate any convention-discoverable skills
-// in the target repository. Callers can detect this with errors.Is.
+// ErrNoSkillsFound is returned (wrapped) when no skills can be discovered in the target repository.
 var ErrNoSkillsFound = errors.New("no skills found")
 
+// TreeTooLargeError is returned when a repository's git tree exceeds the
+// GitHub API truncation limit and full skill discovery is not possible.
 type TreeTooLargeError struct {
 	Owner string
 	Repo  string

--- a/pkg/cmd/skills/update/update.go
+++ b/pkg/cmd/skills/update/update.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -252,6 +253,8 @@ func updateRun(opts *UpdateOptions) error {
 	repoSkills := make(map[repoKey][]discovery.Skill)
 	repoRefs := make(map[repoKey]*discovery.ResolvedRef)
 	repoErrors := make(map[repoKey]bool)
+	// Preserves the recoverable bulk-discovery error so it can be surfaced for skills that lack a sourcePath and therefore cannot use the per-skill fallback.
+	repoRecoverableErrs := make(map[repoKey]error)
 
 	for _, s := range installed {
 		if s.owner == "" || s.repo == "" {
@@ -280,18 +283,24 @@ func updateRun(opts *UpdateOptions) error {
 			}
 			repoRefs[key] = resolved
 
-			skills, discoverErr := discovery.DiscoverSkills(apiClient, s.repoHost, s.owner, s.repo, resolved.SHA)
+			// Include hidden-dir skills (e.g. .claude/skills/) so installs made via --allow-hidden-dirs remain updatable.
+			skills, discoverErr := discovery.DiscoverSkillsWithOptions(apiClient, s.repoHost, s.owner, s.repo, resolved.SHA, discovery.DiscoverOptions{})
 			if discoverErr != nil {
-				repoErrors[key] = true
-				opts.IO.StopProgressIndicator()
-				fmt.Fprintf(opts.IO.ErrOut, "%s Skipping %s: %v\n", cs.WarningIcon(), s.name, discoverErr)
-				opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Checking %d installed skill(s) for updates", len(installed)))
-				continue
+				if !isRecoverableDiscoveryErr(discoverErr) {
+					repoErrors[key] = true
+					opts.IO.StopProgressIndicator()
+					fmt.Fprintf(opts.IO.ErrOut, "%s Skipping %s: %v\n", cs.WarningIcon(), s.name, discoverErr)
+					opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Checking %d installed skill(s) for updates", len(installed)))
+					continue
+				}
+				// Recoverable (e.g. tree too large, no convention-discovered skills): the per-skill fallback below may still resolve individual skills; the original error is reported per-skill for entries that cannot use the fallback.
+				repoRecoverableErrs[key] = discoverErr
 			}
 			repoSkills[key] = skills
 		}
 
 		resolved := repoRefs[key]
+		foundMatch := false
 		for _, remote := range repoSkills[key] {
 			matched := false
 			if s.sourcePath != "" {
@@ -299,15 +308,45 @@ func updateRun(opts *UpdateOptions) error {
 			} else {
 				matched = remote.InstallName() == s.name
 			}
-			if matched && (remote.TreeSHA != s.treeSHA || opts.Force) {
+			if matched {
+				foundMatch = true
+				if remote.TreeSHA != s.treeSHA || opts.Force {
+					updates = append(updates, pendingUpdate{
+						local:    s,
+						newSHA:   remote.TreeSHA,
+						resolved: resolved,
+						skill:    remote,
+					})
+				}
+				break
+			}
+		}
+
+		// Fallback for skills installed by exact path (e.g. via --allow-hidden-dirs into a non-conventional location like skills/.curated/).
+		if !foundMatch && s.sourcePath != "" {
+			remote, pathErr := discovery.DiscoverSkillByPath(apiClient, s.repoHost, s.owner, s.repo, resolved.SHA, s.sourcePath)
+			if pathErr != nil {
+				opts.IO.StopProgressIndicator()
+				fmt.Fprintf(opts.IO.ErrOut, "%s Skipping %s: %v\n", cs.WarningIcon(), s.name, pathErr)
+				opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Checking %d installed skill(s) for updates", len(installed)))
+				continue
+			}
+			if remote.TreeSHA != s.treeSHA || opts.Force {
 				updates = append(updates, pendingUpdate{
 					local:    s,
 					newSHA:   remote.TreeSHA,
 					resolved: resolved,
-					skill:    remote,
+					skill:    *remote,
 				})
-				break
 			}
+			continue
+		}
+
+		// Surface the original repo-level discovery error for skills that lack a sourcePath (legacy installs without github-path metadata) and could not be located via bulk discovery.
+		if !foundMatch && s.sourcePath == "" && repoRecoverableErrs[key] != nil {
+			opts.IO.StopProgressIndicator()
+			fmt.Fprintf(opts.IO.ErrOut, "%s Skipping %s: %v\n", cs.WarningIcon(), s.name, repoRecoverableErrs[key])
+			opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Checking %d installed skill(s) for updates", len(installed)))
 		}
 	}
 
@@ -583,4 +622,13 @@ func promptForSkillOrigin(p prompter.Prompter, skillName string) (owner, repo, r
 		return "", "", fmt.Sprintf("invalid repository %q: expected owner/repo", input), false, nil
 	}
 	return r.RepoOwner(), r.RepoName(), "", true, nil
+}
+
+// isRecoverableDiscoveryErr reports whether a repository-level discovery failure can be retried via the per-skill DiscoverSkillByPath fallback.
+func isRecoverableDiscoveryErr(err error) bool {
+	var treeTooLarge *discovery.TreeTooLargeError
+	if errors.As(err, &treeTooLarge) {
+		return true
+	}
+	return errors.Is(err, discovery.ErrNoSkillsFound)
 }

--- a/pkg/cmd/skills/update/update.go
+++ b/pkg/cmd/skills/update/update.go
@@ -282,7 +282,6 @@ func updateRun(opts *UpdateOptions) error {
 			}
 			repoRefs[key] = resolved
 
-			// Include hidden-dir skills so installs made via --allow-hidden-dirs remain updatable.
 			skills, discoverErr := discovery.DiscoverSkillsWithOptions(apiClient, s.repoHost, s.owner, s.repo, resolved.SHA, discovery.DiscoverOptions{})
 			if discoverErr != nil {
 				if !isRecoverableDiscoveryErr(discoverErr) {
@@ -620,7 +619,6 @@ func promptForSkillOrigin(p prompter.Prompter, skillName string) (owner, repo, r
 	return r.RepoOwner(), r.RepoName(), "", true, nil
 }
 
-// isRecoverableDiscoveryErr reports whether bulk discovery can be retried per-skill via DiscoverSkillByPath.
 func isRecoverableDiscoveryErr(err error) bool {
 	var treeTooLarge *discovery.TreeTooLargeError
 	if errors.As(err, &treeTooLarge) {

--- a/pkg/cmd/skills/update/update.go
+++ b/pkg/cmd/skills/update/update.go
@@ -253,7 +253,6 @@ func updateRun(opts *UpdateOptions) error {
 	repoSkills := make(map[repoKey][]discovery.Skill)
 	repoRefs := make(map[repoKey]*discovery.ResolvedRef)
 	repoErrors := make(map[repoKey]bool)
-	// Preserves the recoverable bulk-discovery error so it can be surfaced for skills that lack a sourcePath and therefore cannot use the per-skill fallback.
 	repoRecoverableErrs := make(map[repoKey]error)
 
 	for _, s := range installed {
@@ -283,7 +282,7 @@ func updateRun(opts *UpdateOptions) error {
 			}
 			repoRefs[key] = resolved
 
-			// Include hidden-dir skills (e.g. .claude/skills/) so installs made via --allow-hidden-dirs remain updatable.
+			// Include hidden-dir skills so installs made via --allow-hidden-dirs remain updatable.
 			skills, discoverErr := discovery.DiscoverSkillsWithOptions(apiClient, s.repoHost, s.owner, s.repo, resolved.SHA, discovery.DiscoverOptions{})
 			if discoverErr != nil {
 				if !isRecoverableDiscoveryErr(discoverErr) {
@@ -293,7 +292,6 @@ func updateRun(opts *UpdateOptions) error {
 					opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Checking %d installed skill(s) for updates", len(installed)))
 					continue
 				}
-				// Recoverable (e.g. tree too large, no convention-discovered skills): the per-skill fallback below may still resolve individual skills; the original error is reported per-skill for entries that cannot use the fallback.
 				repoRecoverableErrs[key] = discoverErr
 			}
 			repoSkills[key] = skills
@@ -322,7 +320,6 @@ func updateRun(opts *UpdateOptions) error {
 			}
 		}
 
-		// Fallback for skills installed by exact path (e.g. via --allow-hidden-dirs into a non-conventional location like skills/.curated/).
 		if !foundMatch && s.sourcePath != "" {
 			remote, pathErr := discovery.DiscoverSkillByPath(apiClient, s.repoHost, s.owner, s.repo, resolved.SHA, s.sourcePath)
 			if pathErr != nil {
@@ -342,7 +339,6 @@ func updateRun(opts *UpdateOptions) error {
 			continue
 		}
 
-		// Surface the original repo-level discovery error for skills that lack a sourcePath (legacy installs without github-path metadata) and could not be located via bulk discovery.
 		if !foundMatch && s.sourcePath == "" && repoRecoverableErrs[key] != nil {
 			opts.IO.StopProgressIndicator()
 			fmt.Fprintf(opts.IO.ErrOut, "%s Skipping %s: %v\n", cs.WarningIcon(), s.name, repoRecoverableErrs[key])
@@ -624,7 +620,7 @@ func promptForSkillOrigin(p prompter.Prompter, skillName string) (owner, repo, r
 	return r.RepoOwner(), r.RepoName(), "", true, nil
 }
 
-// isRecoverableDiscoveryErr reports whether a repository-level discovery failure can be retried via the per-skill DiscoverSkillByPath fallback.
+// isRecoverableDiscoveryErr reports whether bulk discovery can be retried per-skill via DiscoverSkillByPath.
 func isRecoverableDiscoveryErr(err error) bool {
 	var treeTooLarge *discovery.TreeTooLargeError
 	if errors.As(err, &treeTooLarge) {

--- a/pkg/cmd/skills/update/update_test.go
+++ b/pkg/cmd/skills/update/update_test.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/internal/skills/discovery"
 	"github.com/cli/cli/v2/internal/skills/registry"
 
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -1161,6 +1163,173 @@ func TestUpdateRun(t *testing.T) {
 			wantStderr: "1 update(s) available:",
 			wantStdout: "pinned-skill",
 		},
+		{
+			// Regression for #13542: skills installed via --allow-hidden-dirs
+			// must remain updatable even when the source repo exposes them
+			// only under hidden directories.
+			name: "updates skill installed from a hidden directory",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				skillDir := filepath.Join(dir, "gh-address-comments")
+				require.NoError(t, os.MkdirAll(skillDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(heredoc.Doc(`
+					---
+					name: gh-address-comments
+					metadata:
+					  github-repo: https://github.com/openai/skills
+					  github-tree-sha: oldhiddensha
+					  github-path: skills/.curated/gh-address-comments
+					---
+				`)), 0o644))
+			},
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/openai/skills/releases/latest"),
+					httpmock.StringResponse(`{"tag_name": "v1.0.0"}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/openai/skills/git/ref/tags/v1.0.0"),
+					httpmock.StringResponse(`{"object": {"sha": "commithidden1", "type": "commit"}}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/openai/skills/git/trees/commithidden1"),
+					httpmock.StringResponse(`{"sha": "commithidden1", "tree": [{"path": "skills/.curated/gh-address-comments/SKILL.md", "type": "blob", "sha": "blobhidden1"}, {"path": "skills/.curated/gh-address-comments", "type": "tree", "sha": "newhiddensha"}, {"path": "skills/.curated", "type": "tree", "sha": "treeshaCurated"}, {"path": "skills", "type": "tree", "sha": "treeshaSkills"}], "truncated": false}`),
+				)
+				// The DiscoverSkillByPath fallback queries the parent directory
+				// via the contents API, then fetches the skill's own tree.
+				reg.Register(
+					httpmock.REST("GET", "repos/openai/skills/contents/skills%2F.curated"),
+					httpmock.StringResponse(`[{"name": "gh-address-comments", "path": "skills/.curated/gh-address-comments", "sha": "newhiddensha", "type": "dir"}]`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/openai/skills/git/trees/newhiddensha"),
+					httpmock.StringResponse(`{"sha": "newhiddensha", "tree": [{"path": "SKILL.md", "type": "blob", "sha": "blobhidden1"}], "truncated": false}`),
+				)
+			},
+			opts: func(ios *iostreams.IOStreams, dir string, reg *httpmock.Registry) *UpdateOptions {
+				ios.SetStdoutTTY(true)
+				ios.SetStderrTTY(true)
+				return &UpdateOptions{
+					IO:     ios,
+					Config: func() (gh.Config, error) { return config.NewBlankConfig(), nil },
+					HttpClient: func() (*http.Client, error) {
+						return &http.Client{Transport: reg}, nil
+					},
+					Prompter:  &prompter.PrompterMock{},
+					GitClient: &git.Client{RepoDir: dir},
+					Dir:       dir,
+					DryRun:    true,
+				}
+			},
+			wantStderr: "1 update(s) available:",
+			wantStdout: "gh-address-comments",
+		},
+		{
+			// When the source repo's tree is too large for bulk discovery,
+			// the per-skill fallback via the contents API must still resolve
+			// updates for skills with a recorded sourcePath.
+			name: "falls back to per-skill discovery when repository tree is truncated",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				skillDir := filepath.Join(dir, "huge-repo-skill")
+				require.NoError(t, os.MkdirAll(skillDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(heredoc.Doc(`
+					---
+					name: huge-repo-skill
+					metadata:
+					  github-repo: https://github.com/giant/skills
+					  github-tree-sha: oldhugesha
+					  github-path: skills/huge-repo-skill
+					---
+				`)), 0o644))
+			},
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/giant/skills/releases/latest"),
+					httpmock.StringResponse(`{"tag_name": "v3.0.0"}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/giant/skills/git/ref/tags/v3.0.0"),
+					httpmock.StringResponse(`{"object": {"sha": "commithuge", "type": "commit"}}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/giant/skills/git/trees/commithuge"),
+					httpmock.StringResponse(`{"sha": "commithuge", "tree": [], "truncated": true}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/giant/skills/contents/skills"),
+					httpmock.StringResponse(`[{"name": "huge-repo-skill", "path": "skills/huge-repo-skill", "sha": "newhugesha", "type": "dir"}]`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/giant/skills/git/trees/newhugesha"),
+					httpmock.StringResponse(`{"sha": "newhugesha", "tree": [{"path": "SKILL.md", "type": "blob", "sha": "blobhuge"}], "truncated": false}`),
+				)
+			},
+			opts: func(ios *iostreams.IOStreams, dir string, reg *httpmock.Registry) *UpdateOptions {
+				ios.SetStdoutTTY(true)
+				ios.SetStderrTTY(true)
+				return &UpdateOptions{
+					IO:     ios,
+					Config: func() (gh.Config, error) { return config.NewBlankConfig(), nil },
+					HttpClient: func() (*http.Client, error) {
+						return &http.Client{Transport: reg}, nil
+					},
+					Prompter:  &prompter.PrompterMock{},
+					GitClient: &git.Client{RepoDir: dir},
+					Dir:       dir,
+					DryRun:    true,
+				}
+			},
+			wantStderr: "1 update(s) available:",
+			wantStdout: "huge-repo-skill",
+		},
+		{
+			// Legacy installs without github-path metadata cannot use the
+			// per-skill fallback. The repository-level discovery error must
+			// still be surfaced (regression for silent skip).
+			name: "warns when bulk discovery fails and skill lacks sourcePath",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				skillDir := filepath.Join(dir, "legacy-skill")
+				require.NoError(t, os.MkdirAll(skillDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(heredoc.Doc(`
+					---
+					name: legacy-skill
+					metadata:
+					  github-repo: https://github.com/legacy/skills
+					  github-tree-sha: oldlegacysha
+					---
+				`)), 0o644))
+			},
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/legacy/skills/releases/latest"),
+					httpmock.StringResponse(`{"tag_name": "v1.0.0"}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/legacy/skills/git/ref/tags/v1.0.0"),
+					httpmock.StringResponse(`{"object": {"sha": "commitlegacy", "type": "commit"}}`),
+				)
+				// Tree contains no convention-discoverable SKILL.md.
+				reg.Register(
+					httpmock.REST("GET", "repos/legacy/skills/git/trees/commitlegacy"),
+					httpmock.StringResponse(`{"sha": "commitlegacy", "tree": [{"path": "README.md", "type": "blob", "sha": "readmesha"}], "truncated": false}`),
+				)
+			},
+			opts: func(ios *iostreams.IOStreams, dir string, reg *httpmock.Registry) *UpdateOptions {
+				ios.SetStdoutTTY(false)
+				return &UpdateOptions{
+					IO:     ios,
+					Config: func() (gh.Config, error) { return config.NewBlankConfig(), nil },
+					HttpClient: func() (*http.Client, error) {
+						return &http.Client{Transport: reg}, nil
+					},
+					GitClient: &git.Client{RepoDir: dir},
+					Dir:       dir,
+				}
+			},
+			wantStderr: "Skipping legacy-skill: no skills found",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1195,6 +1364,47 @@ func TestUpdateRun(t *testing.T) {
 			if tt.verify != nil {
 				tt.verify(t, dir)
 			}
+		})
+	}
+}
+
+func TestIsRecoverableDiscoveryErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil is not recoverable",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "wrapped ErrNoSkillsFound is recoverable",
+			err:  fmt.Errorf("%w in owner/repo", discovery.ErrNoSkillsFound),
+			want: true,
+		},
+		{
+			name: "TreeTooLargeError is recoverable",
+			err:  &discovery.TreeTooLargeError{Owner: "owner", Repo: "repo"},
+			want: true,
+		},
+		{
+			name: "wrapped TreeTooLargeError is recoverable",
+			err:  fmt.Errorf("discover failed: %w", &discovery.TreeTooLargeError{Owner: "owner", Repo: "repo"}),
+			want: true,
+		},
+		{
+			name: "unrelated error is not recoverable",
+			err:  errors.New("network failure"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRecoverableDiscoveryErr(tt.err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/cmd/skills/update/update_test.go
+++ b/pkg/cmd/skills/update/update_test.go
@@ -1164,7 +1164,6 @@ func TestUpdateRun(t *testing.T) {
 			wantStdout: "pinned-skill",
 		},
 		{
-			// Regression for #13542.
 			name: "updates skill installed from a hidden directory",
 			setup: func(t *testing.T, dir string) {
 				t.Helper()

--- a/pkg/cmd/skills/update/update_test.go
+++ b/pkg/cmd/skills/update/update_test.go
@@ -1164,9 +1164,7 @@ func TestUpdateRun(t *testing.T) {
 			wantStdout: "pinned-skill",
 		},
 		{
-			// Regression for #13542: skills installed via --allow-hidden-dirs
-			// must remain updatable even when the source repo exposes them
-			// only under hidden directories.
+			// Regression for #13542.
 			name: "updates skill installed from a hidden directory",
 			setup: func(t *testing.T, dir string) {
 				t.Helper()
@@ -1195,8 +1193,6 @@ func TestUpdateRun(t *testing.T) {
 					httpmock.REST("GET", "repos/openai/skills/git/trees/commithidden1"),
 					httpmock.StringResponse(`{"sha": "commithidden1", "tree": [{"path": "skills/.curated/gh-address-comments/SKILL.md", "type": "blob", "sha": "blobhidden1"}, {"path": "skills/.curated/gh-address-comments", "type": "tree", "sha": "newhiddensha"}, {"path": "skills/.curated", "type": "tree", "sha": "treeshaCurated"}, {"path": "skills", "type": "tree", "sha": "treeshaSkills"}], "truncated": false}`),
 				)
-				// The DiscoverSkillByPath fallback queries the parent directory
-				// via the contents API, then fetches the skill's own tree.
 				reg.Register(
 					httpmock.REST("GET", "repos/openai/skills/contents/skills%2F.curated"),
 					httpmock.StringResponse(`[{"name": "gh-address-comments", "path": "skills/.curated/gh-address-comments", "sha": "newhiddensha", "type": "dir"}]`),
@@ -1225,9 +1221,6 @@ func TestUpdateRun(t *testing.T) {
 			wantStdout: "gh-address-comments",
 		},
 		{
-			// When the source repo's tree is too large for bulk discovery,
-			// the per-skill fallback via the contents API must still resolve
-			// updates for skills with a recorded sourcePath.
 			name: "falls back to per-skill discovery when repository tree is truncated",
 			setup: func(t *testing.T, dir string) {
 				t.Helper()
@@ -1284,9 +1277,6 @@ func TestUpdateRun(t *testing.T) {
 			wantStdout: "huge-repo-skill",
 		},
 		{
-			// Legacy installs without github-path metadata cannot use the
-			// per-skill fallback. The repository-level discovery error must
-			// still be surfaced (regression for silent skip).
 			name: "warns when bulk discovery fails and skill lacks sourcePath",
 			setup: func(t *testing.T, dir string) {
 				t.Helper()
@@ -1310,7 +1300,6 @@ func TestUpdateRun(t *testing.T) {
 					httpmock.REST("GET", "repos/legacy/skills/git/ref/tags/v1.0.0"),
 					httpmock.StringResponse(`{"object": {"sha": "commitlegacy", "type": "commit"}}`),
 				)
-				// Tree contains no convention-discoverable SKILL.md.
 				reg.Register(
 					httpmock.REST("GET", "repos/legacy/skills/git/trees/commitlegacy"),
 					httpmock.StringResponse(`{"sha": "commitlegacy", "tree": [{"path": "README.md", "type": "blob", "sha": "readmesha"}], "truncated": false}`),


### PR DESCRIPTION
fixes #13542

## Summary

`gh skill update` calls `discovery.DiscoverSkills`, which drops hidden-dir conventions and returns `no skills found` when the filtered list is empty. Skills installed via `--allow-hidden-dirs` (e.g. under `skills/.curated/`) are therefore reported as `Skipping <name>: no skills found in <repo>` and never updated, even though their exact source path is recorded in metadata.

Per @niik in the issue:
> The update command calls `discovery.DiscoverSkills()` which explicitly filters out hidden-directory skills (like those under `.curated/`), even though install with `--allow-hidden-dirs` correctly installs them. The update path needs to either respect the `--allow-hidden-dirs` flag or detect from the lock file that the skill was installed from a hidden directory and adjust discovery accordingly.

And @SamMorrowDrums:
> I think it makes sense to allow the update to check in a sensible order for locations where skill may live in repo!

This PR follows the "sensible order" path.

## Approach

1. Switch the bulk discovery call from `DiscoverSkills` to `DiscoverSkillsWithOptions` so hidden-dir candidates such as `.claude/skills/<name>/SKILL.md` participate in the per-skill matching loop. Matching keys on the exact `sourcePath` recorded at install time, so widening the candidate list cannot cause false matches.
2. Treat `ErrNoSkillsFound` and `TreeTooLargeError` from bulk discovery as recoverable: don't bail the whole repo; instead let the per-skill fallback try to resolve individual skills.
3. After the bulk-match loop, when no match was found and `sourcePath` is set, fall back to `DiscoverSkillByPath(sourcePath)`. This is the same path-based lookup `install` uses for path-style installs and resolves entries whose namespace component fails discovery's `validateName` regex (e.g. `.curated`).
4. Expose `discovery.ErrNoSkillsFound` as a sentinel and detect it via `errors.Is`, so the recoverable-error check no longer relies on string-matching the error message.
5. For legacy installs that lack `github-path` metadata (and therefore cannot use the fallback), the original repo-level error is preserved per-key and surfaced per skill instead of being silently swallowed.

No new user-facing flag is added; the existing `github-path` metadata recorded at install time is sufficient signal.

## Files changed

- `internal/skills/discovery/discovery.go` — add `ErrNoSkillsFound` sentinel; rewrap existing `no skills found` errors with `%w`.
- `pkg/cmd/skills/update/update.go` — switch to `DiscoverSkillsWithOptions`, add per-skill `DiscoverSkillByPath` fallback, preserve repo-level recoverable error for skills that cannot use the fallback, add `isRecoverableDiscoveryErr` helper.
- `pkg/cmd/skills/update/update_test.go` — regression test for the issue scenario, `TreeTooLargeError` fallback path, silent-skip warning for sourcePath-less installs, unit tests for `isRecoverableDiscoveryErr`.

## Test plan

- [x] `go test -race ./pkg/cmd/skills/update/... ./internal/skills/discovery/...`
- [x] `go test ./pkg/cmd/skills/...` (all skills subpackages)
- [x] `go vet ./pkg/cmd/skills/update/... ./internal/skills/discovery/...`
- [x] `gofmt -l` clean on touched files
- [x] Manual end-to-end against the live `openai/skills` repository, reproducing the issue scenario:
  1. `gh skill install openai/skills skills/.curated/gh-address-comments --dir <tmp> --allow-hidden-dirs` → installs, `SKILL.md` records `github-path: skills/.curated/gh-address-comments` and `github-tree-sha: 042316be...`.
  2. `gh skill update --dir <tmp>` → reports `All skills are up to date.` (pre-fix output was `! Skipping gh-address-comments: no skills found in openai/skills`).
  3. Manually rewriting the stored `github-tree-sha` to zeros and re-running `gh skill update --dir <tmp> --dry-run --all` → reports `1 update(s) available: gh-address-comments (openai/skills) > 042316be [main]`, confirming the fallback resolves to the real remote SHA.

## Follow-up

The fallback path issues `contents` + `git/trees` API calls per skill when bulk discovery is unavailable. For users with many skills from a single oversized repo, a parent-directory-level cache for the contents API could collapse multiple lookups into one — left as a follow-up to keep this PR scoped to the bug fix.