### PR TITLE
text: use EscapedPath in DisplayURL so percent-encoded chars survive

### DIFF
--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -77,7 +77,7 @@ func DisplayURL(urlStr string) string {
 	if scheme == "" {
 		scheme = "https"
 	}
-	return scheme + "://" + u.Hostname() + u.Path
+	return scheme + "://" + u.Hostname() + u.EscapedPath()
 }
 
 // RemoveDiacritics returns the input value without "diacritics", or accent marks

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -173,6 +173,11 @@ func TestDisplayURL(t *testing.T) {
 			url:  "http://github.com/cli/cli/issues/9470",
 			want: "http://github.com/cli/cli/issues/9470",
 		},
+		{
+			name: "preserve percent-encoded characters in path",
+			url:  `https://github.com/OWNER/REPO/compare/main...test-%22quoted%22-branch-pr`,
+			want: `https://github.com/OWNER/REPO/compare/main...test-%22quoted%22-branch-pr`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
\`DisplayURL\` built its return string from \`u.Path\`, which is the decoded form. A branch with chars that need encoding (quotes is the example in the issue) printed as the raw unescaped path, so the URL \`gh pr create\` echoed back to the terminal wasn't a valid URL. \`u.EscapedPath()\` is the godoc-recommended way to print a URL's path back out, since it preserves the original \`RawPath\` or re-encodes \`Path\` correctly when there isn't one.

Added a regression case to \`TestDisplayURL\` that's the exact repro from the issue.

fixes #13546