### PR TITLE
fix(pr/merge): actually delete remote branch when PR is already merged

### DIFF
--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -457,25 +457,24 @@ func (m *mergeContext) deleteRemoteBranch() error {
 		return nil
 	}
 
-	if !m.merged {
-		apiClient := api.NewClientFromHTTP(m.httpClient)
-		err := api.BranchDeleteRemote(apiClient, m.baseRepo, m.pr.HeadRefName)
-		if err != nil {
-			// Normally, the API returns 422, with the message "Reference does not exist"
-			// when the branch has already been deleted. It also returns 404 with the same
-			// message, but that rarely happens. In both cases, we should not return an
-			// error because the goal is already achieved.
+	// Issue the delete unconditionally; the 422/404 handling below absorbs the case where the branch is already gone (e.g. repo's "auto-delete head branches" setting handled it).
+	apiClient := api.NewClientFromHTTP(m.httpClient)
+	err := api.BranchDeleteRemote(apiClient, m.baseRepo, m.pr.HeadRefName)
+	if err != nil {
+		// Normally, the API returns 422, with the message "Reference does not exist"
+		// when the branch has already been deleted. It also returns 404 with the same
+		// message, but that rarely happens. In both cases, we should not return an
+		// error because the goal is already achieved.
 
-			var isAlreadyDeletedError bool
-			if httpErr := (api.HTTPError{}); errors.As(err, &httpErr) {
-				// TODO: since the API returns 422 for a couple of other reasons, for more accuracy
-				// we might want to check the error message against "Reference does not exist".
-				isAlreadyDeletedError = httpErr.StatusCode == http.StatusUnprocessableEntity || httpErr.StatusCode == http.StatusNotFound
-			}
+		var isAlreadyDeletedError bool
+		if httpErr := (api.HTTPError{}); errors.As(err, &httpErr) {
+			// TODO: since the API returns 422 for a couple of other reasons, for more accuracy
+			// we might want to check the error message against "Reference does not exist".
+			isAlreadyDeletedError = httpErr.StatusCode == http.StatusUnprocessableEntity || httpErr.StatusCode == http.StatusNotFound
+		}
 
-			if !isAlreadyDeletedError {
-				return fmt.Errorf("failed to delete remote branch %s: %w", m.cs.Cyan(m.pr.HeadRefName), err)
-			}
+		if !isAlreadyDeletedError {
+			return fmt.Errorf("failed to delete remote branch %s: %w", m.cs.Cyan(m.pr.HeadRefName), err)
 		}
 	}
 

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -457,7 +457,6 @@ func (m *mergeContext) deleteRemoteBranch() error {
 		return nil
 	}
 
-	// Issue the delete unconditionally; the 422/404 handling below absorbs the case where the branch is already gone (e.g. repo's "auto-delete head branches" setting handled it).
 	apiClient := api.NewClientFromHTTP(m.httpClient)
 	err := api.BranchDeleteRemote(apiClient, m.baseRepo, m.pr.HeadRefName)
 	if err != nil {

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -660,6 +660,55 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 	`), output.Stderr())
 }
 
+// Regression for #12980: --delete-branch on a PR that is already merged must
+// still issue the remote DELETE rather than silently skipping it while
+// printing "Deleted remote branch".
+func TestPrMerge_deleteBranch_alreadyMerged(t *testing.T) {
+	http := initFakeHTTP()
+	defer http.Verify(t)
+
+	shared.StubFinderForRunCommandStyleTests(t,
+		"",
+		&api.PullRequest{
+			ID:               "PR_10",
+			Number:           10,
+			State:            "MERGED",
+			Title:            "Blueberries are a good fruit",
+			HeadRefName:      "blueberries",
+			BaseRefName:      "main",
+			MergeStateStatus: "CLEAN",
+		},
+		baseRepo("OWNER", "REPO", "main"),
+	)
+
+	// No PullRequestMerge mutation is expected because the PR is already merged.
+	// The DELETE call must still fire; that is the bug fix.
+	http.Register(
+		httpmock.REST("DELETE", "repos/OWNER/REPO/git/refs/heads/blueberries"),
+		httpmock.StringResponse(`{}`))
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+
+	cs.Register(`git rev-parse --verify refs/heads/main`, 0, "")
+	cs.Register(`git checkout main`, 0, "")
+	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
+	cs.Register(`git branch -D blueberries`, 0, "")
+	cs.Register(`git pull --ff-only`, 0, "")
+
+	output, err := runCommand(http, nil, "blueberries", true, `pr merge --delete-branch`)
+	if err != nil {
+		t.Fatalf("Got unexpected error running `pr merge` %s", err)
+	}
+
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, heredoc.Doc(`
+		! Pull request OWNER/REPO#10 was already merged
+		✓ Deleted local branch blueberries and switched to branch main
+		✓ Deleted remote branch blueberries
+	`), output.Stderr())
+}
+
 func TestPrMerge_deleteBranch_apiError(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -1195,6 +1244,10 @@ func TestPrMerge_alreadyMerged(t *testing.T) {
 		baseRepo("OWNER", "REPO", "main"),
 	)
 
+	http.Register(
+		httpmock.REST("DELETE", "repos/OWNER/REPO/git/refs/heads/blueberries"),
+		httpmock.StringResponse(`{}`))
+
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
@@ -1263,17 +1316,22 @@ func TestPrMerge_alreadyMerged_withMergeStrategy_TTY(t *testing.T) {
 			ID:                  "THE-ID",
 			Number:              4,
 			State:               "MERGED",
+			HeadRefName:         "blueberries",
 			HeadRepositoryOwner: api.Owner{Login: "OWNER"},
 			MergeStateStatus:    "CLEAN",
 		},
 		baseRepo("OWNER", "REPO", "main"),
 	)
 
+	http.Register(
+		httpmock.REST("DELETE", "repos/OWNER/REPO/git/refs/heads/blueberries"),
+		httpmock.StringResponse(`{}`))
+
 	cs, cmdTeardown := run.Stub()
 	defer cmdTeardown(t)
 
-	cs.Register(`git rev-parse --verify refs/heads/`, 0, "")
-	cs.Register(`git branch -D `, 0, "")
+	cs.Register(`git rev-parse --verify refs/heads/blueberries`, 0, "")
+	cs.Register(`git branch -D blueberries`, 0, "")
 
 	pm := &prompter.PrompterMock{
 		ConfirmFunc: func(p string, d bool) (bool, error) {
@@ -1285,13 +1343,13 @@ func TestPrMerge_alreadyMerged_withMergeStrategy_TTY(t *testing.T) {
 		},
 	}
 
-	output, err := runCommand(http, pm, "blueberries", true, "pr merge 4 --merge")
+	output, err := runCommand(http, pm, "main", true, "pr merge 4 --merge")
 	if err != nil {
 		t.Fatalf("Got unexpected error running `pr merge` %s", err)
 	}
 
 	assert.Equal(t, "", output.String())
-	assert.Equal(t, "✓ Deleted local branch \n✓ Deleted remote branch \n", output.Stderr())
+	assert.Equal(t, "✓ Deleted local branch blueberries\n✓ Deleted remote branch blueberries\n", output.Stderr())
 }
 
 func TestPrMerge_alreadyMerged_withMergeStrategy_crossRepo(t *testing.T) {

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -660,9 +660,6 @@ func TestPrMerge_deleteBranch(t *testing.T) {
 	`), output.Stderr())
 }
 
-// Regression for #12980: --delete-branch on a PR that is already merged must
-// still issue the remote DELETE rather than silently skipping it while
-// printing "Deleted remote branch".
 func TestPrMerge_deleteBranch_alreadyMerged(t *testing.T) {
 	http := initFakeHTTP()
 	defer http.Verify(t)
@@ -681,8 +678,6 @@ func TestPrMerge_deleteBranch_alreadyMerged(t *testing.T) {
 		baseRepo("OWNER", "REPO", "main"),
 	)
 
-	// No PullRequestMerge mutation is expected because the PR is already merged.
-	// The DELETE call must still fire; that is the bug fix.
 	http.Register(
 		httpmock.REST("DELETE", "repos/OWNER/REPO/git/refs/heads/blueberries"),
 		httpmock.StringResponse(`{}`))


### PR DESCRIPTION
fixes #12980

## Summary

When `gh pr merge -d` runs against a PR that is already merged, the command prints `✓ Deleted remote branch <name>` without ever issuing the `DELETE` API request. If the repository has "Automatically delete head branches" disabled, the branch remains on the remote despite the success message (steps to reproduce in the issue).

Per @williammartin in #12980:

> the message: `✓ Deleted remote branch myBranch` Is obviously wrong and either needs to either not report this and show a warning, or do it anyway with a warning, which is what the local branch deletion does.

This PR takes the second path — actually do the deletion — because it mirrors the symmetric local-branch behaviour, which already runs unconditionally after the "Pull request was already merged" warning.

## Change

`pkg/cmd/pr/merge/merge.go:460` — remove the `if !m.merged` guard wrapping the DELETE call. The existing 422/404 ("Reference does not exist") handler absorbs the case where GitHub's auto-delete setting already removed the branch, so the always-call approach is safe.

The early-return at the top of `deleteRemoteBranch` (`!m.deleteBranch || m.crossRepoPR || m.autoMerge`) still protects cross-repo PRs, auto-merge flows, and the case where the user did not opt in to branch deletion.

## Test plan

- [x] New regression test `TestPrMerge_deleteBranch_alreadyMerged` registers the DELETE stub and asserts the full expected output for the `gh pr merge -d` on an already-merged PR scenario; `defer http.Verify(t)` ensures the DELETE call actually fires.
- [x] Updated two existing tests that asserted the pre-fix (no-DELETE) behaviour:
  - `TestPrMerge_alreadyMerged` — register DELETE stub
  - `TestPrMerge_alreadyMerged_withMergeStrategy_TTY` — register DELETE stub, fill in the previously-empty `HeadRefName` fixture, switch `runCommand`'s current branch to `"main"` so the test stays on its original code path with realistic data
- [x] `go test -race ./pkg/cmd/pr/merge/...` passes
- [x] `go test ./pkg/cmd/pr/...` passes (no sibling regressions)
- [x] `go vet` / `gofmt -l` clean on touched files