### PR TITLE
run view: strip ANSI escape sequences from log output

### DIFF
--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -26,6 +27,14 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/text/transform"
 )
+
+// ansiEscapeRe matches ANSI/VT100 terminal escape sequences so they can be
+// stripped from log output before display. This covers the most common cases:
+//   - CSI sequences (e.g. color codes): ESC [ ... final-byte
+//   - OSC sequences (e.g. title changes): ESC ] ... BEL or ST
+//   - Screen window title sequences: ESC k ... ST
+//   - Two-character Fe escape sequences: ESC followed by a final byte
+var ansiEscapeRe = regexp.MustCompile(`\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[^\x1b].*?\x1b\\|[@-Z\\-_])`)
 
 type RunLogCache struct {
 	cacheDir string
@@ -581,10 +590,17 @@ func displayLogSegments(w io.Writer, segments []logSegment) error {
 }
 
 func copyLogWithLinePrefix(w io.Writer, r io.Reader, prefix string) error {
-	sanitized := transform.NewReader(r, &asciisanitizer.Sanitizer{})
-	scanner := bufio.NewScanner(sanitized)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		fmt.Fprintf(w, "%s%s\n", prefix, scanner.Text())
+		// Strip ANSI escape sequences before sanitizing. Without this step, the
+		// sanitizer converts the ESC byte to the visible string "^[", leaving
+		// the rest of the escape sequence (e.g. "[32m") as readable garbage.
+		stripped := ansiEscapeRe.ReplaceAllLiteral(scanner.Bytes(), nil)
+		sanitized, err := io.ReadAll(transform.NewReader(bytes.NewReader(stripped), &asciisanitizer.Sanitizer{}))
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "%s%s\n", prefix, sanitized)
 	}
 	return nil
 }

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -2761,28 +2761,34 @@ var expectedLegacyRunLogOutputWithNoSteps = fmt.Sprintf("%s%s", legacyCoolJobRun
 
 func TestCopyLogWithLinePrefix_TerminalEscapeSequences(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
+		name     string
+		input    string
+		wantText string // expected text content after stripping (without prefix)
 	}{
 		{
-			name:  "OSC title set sequence",
-			input: "normal prefix\x1b]0;HIJACKED TITLE\x07trailing text\n",
+			name:     "OSC title set sequence",
+			input:    "normal prefix\x1b]0;HIJACKED TITLE\x07trailing text\n",
+			wantText: "normal prefix trailing text",
 		},
 		{
-			name:  "CSI color sequence",
-			input: "\x1b[31mRED TEXT\x1b[0m normal text\n",
+			name:     "CSI color sequence",
+			input:    "\x1b[31mRED TEXT\x1b[0m normal text\n",
+			wantText: "RED TEXT normal text",
 		},
 		{
-			name:  "screen title set sequence used in original report",
-			input: "\x1bk;echo this is an arbitrary command;\x1b\\\n",
+			name:     "screen title set sequence used in original report",
+			input:    "\x1bk;echo this is an arbitrary command;\x1b\\\n",
+			wantText: "",
 		},
 		{
-			name:  "CSI window title query",
-			input: "before\x1b[21tafter\n",
+			name:     "CSI window title query",
+			input:    "before\x1b[21tafter\n",
+			wantText: "beforeafter",
 		},
 		{
-			name:  "multiple escape sequences",
-			input: "\x1b]0;title\x07\x1b[31mred\x1b[0m\x1b[21t\n",
+			name:     "multiple escape sequences",
+			input:    "\x1b]0;title\x07\x1b[31mred\x1b[0m\x1b[21t\n",
+			wantText: "red",
 		},
 	}
 
@@ -2795,6 +2801,10 @@ func TestCopyLogWithLinePrefix_TerminalEscapeSequences(t *testing.T) {
 			output := buf.String()
 			assert.NotContains(t, output, "\x1b",
 				"output should not contain raw ESC (0x1b) bytes, got: %q", output)
+			assert.NotContains(t, output, "^[",
+				"output should not contain sanitizer-escaped ESC sequences (^[), got: %q", output)
+			assert.Equal(t, "jobname\tstep\t"+tt.wantText+"\n", output,
+				"output should contain only the plain text content")
 		})
 	}
 }


### PR DESCRIPTION
## What

When viewing workflow run logs with `gh run view --log`, the output contained visible garbage like `^[[32m` instead of clean text. This happened because:

1. Log lines from the Actions API contain ANSI color codes (e.g. `\x1b[32m`)
2. The `asciisanitizer.Sanitizer` converts the ESC byte (`\x1b`) to the two-character string `^[`
3. The remaining bytes of the escape sequence (`[32m`) are left in place as literal text
4. The result is readable garbage: `^[[32m`

## Fix

Strip ANSI/VT100 escape sequences from each log line *before* passing them through the sanitizer. This removes the full sequence rather than just converting the ESC byte, so the output contains only the plain log text.

The regex covers:
- CSI sequences (color codes, cursor movement, etc.): `ESC [ ... final-byte`
- OSC sequences (title changes, hyperlinks): `ESC ] ... BEL or ST`
- Screen/tmux window title sequences: `ESC k ... ST`
- Two-character Fe escape sequences

## Testing

Updated `TestCopyLogWithLinePrefix_TerminalEscapeSequences` to assert that escape-derived sequences (`^[`) do not appear in the output and that the plain text content is preserved.

Fixes #13434