### PR TITLE
pr merge: use enqueuePullRequest for repos with merge queues

### DIFF
--- a/pkg/cmd/pr/merge/http.go
+++ b/pkg/cmd/pr/merge/http.go
@@ -32,11 +32,20 @@ type mergePayload struct {
 	pullRequestID   string
 	method          PullRequestMergeMethod
 	auto            bool
+	mergeQueue      bool
 	commitSubject   string
 	commitBody      string
 	setCommitBody   bool
 	expectedHeadOid string
 	authorEmail     string
+}
+
+// enqueuePullRequestInput holds the fields required by the enqueuePullRequest
+// GraphQL mutation. It is defined here because the shurcooL/githubv4 package
+// does not yet expose this type.
+type enqueuePullRequestInput struct {
+	PullRequestID   githubv4.ID           `json:"pullRequestId"`
+	ExpectedHeadOid *githubv4.GitObjectID `json:"expectedHeadOid,omitempty"`
 }
 
 // TODO: drop after githubv4 gets updated
@@ -84,6 +93,32 @@ func mergePullRequest(client *http.Client, payload mergePayload) error {
 	}
 
 	gql := api.NewClientFromHTTP(client)
+
+	// When adding to a merge queue, use enqueuePullRequest directly. This is
+	// necessary for repositories where auto-merge is disabled
+	// (autoMergeAllowed=false) but a merge queue is still configured: the
+	// enablePullRequestAutoMerge mutation requires auto-merge to be allowed,
+	// while enqueuePullRequest works regardless of that setting.
+	if payload.mergeQueue {
+		queueInput := enqueuePullRequestInput{
+			PullRequestID: githubv4.ID(payload.pullRequestID),
+		}
+		if payload.expectedHeadOid != "" {
+			oid := githubv4.GitObjectID(payload.expectedHeadOid)
+			queueInput.ExpectedHeadOid = &oid
+		}
+		var queueMutation struct {
+			EnqueuePullRequest struct {
+				MergeQueueEntry struct {
+					ID string
+				}
+			} `graphql:"enqueuePullRequest(input: $input)"`
+		}
+		queueVars := map[string]interface{}{
+			"input": queueInput,
+		}
+		return gql.Mutate(payload.repo.RepoHost(), "PullRequestEnqueue", &queueMutation, queueVars)
+	}
 
 	if payload.auto {
 		var mutation struct {

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -300,8 +300,11 @@ func (m *mergeContext) merge() error {
 			// only warn for now
 			_ = m.warnf("%s The merge strategy for %s is set by the merge queue\n", m.cs.Yellow("!"), m.pr.BaseRefName)
 		}
-		// auto merge will either enable auto merge or add to the merge queue
-		payload.auto = true
+		// Use enqueuePullRequest directly so that repositories with merge
+		// queues but auto-merge disabled (allow_auto_merge=false) are
+		// handled correctly. enablePullRequestAutoMerge requires auto-merge
+		// to be allowed and would fail in that configuration.
+		payload.mergeQueue = true
 	} else {
 		// get user input if not already given
 		if m.opts.MergeStrategyEmpty {

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -1823,10 +1823,11 @@ func TestPrAddToMergeQueueWithMergeMethod(t *testing.T) {
 		baseRepo("OWNER", "REPO", "main"),
 	)
 	http.Register(
-		httpmock.GraphQL(`mutation PullRequestAutoMerge\b`),
+		httpmock.GraphQL(`mutation PullRequestEnqueue\b`),
 		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
-			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
+			// enqueuePullRequest does not take a mergeMethod; the queue decides
+			assert.NotContains(t, input, "mergeMethod")
 		}),
 	)
 
@@ -1862,10 +1863,9 @@ func TestPrAddToMergeQueueClean(t *testing.T) {
 	)
 
 	http.Register(
-		httpmock.GraphQL(`mutation PullRequestAutoMerge\b`),
+		httpmock.GraphQL(`mutation PullRequestEnqueue\b`),
 		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
-			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 		}),
 	)
 
@@ -1902,10 +1902,54 @@ func TestPrAddToMergeQueueBlocked(t *testing.T) {
 	)
 
 	http.Register(
-		httpmock.GraphQL(`mutation PullRequestAutoMerge\b`),
+		httpmock.GraphQL(`mutation PullRequestEnqueue\b`),
 		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
-			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
+		}),
+	)
+
+	cs, cmdTeardown := run.Stub()
+	defer cmdTeardown(t)
+	cs.Register(`git rev-parse --verify refs/heads/`, 0, "")
+
+	output, err := runCommand(http, nil, "blueberries", true, "pr merge 1")
+	if err != nil {
+		t.Fatalf("error running command `pr merge`: %v", err)
+	}
+
+	assert.Equal(t, "", output.String())
+	assert.Equal(t, "✓ Pull request OWNER/REPO#1 will be added to the merge queue for main when ready\n", output.Stderr())
+}
+
+// TestPrAddToMergeQueueAutoMergeDisabled reproduces the scenario from
+// https://github.com/cli/cli/issues/13398: the repository has a merge queue
+// configured but auto-merge is disabled (allow_auto_merge=false). Previously
+// the CLI called enablePullRequestAutoMerge which requires auto-merge to be
+// allowed, causing an API error. It should call enqueuePullRequest instead.
+func TestPrAddToMergeQueueAutoMergeDisabled(t *testing.T) {
+	http := initFakeHTTP()
+	defer http.Verify(t)
+
+	shared.StubFinderForRunCommandStyleTests(t,
+		"1",
+		&api.PullRequest{
+			ID:                  "THE-ID",
+			Number:              1,
+			State:               "OPEN",
+			Title:               "The title of the PR",
+			MergeStateStatus:    "CLEAN",
+			IsInMergeQueue:      false,
+			IsMergeQueueEnabled: true,
+			BaseRefName:         "main",
+		},
+		baseRepo("OWNER", "REPO", "main"),
+	)
+
+	// enqueuePullRequest must be used regardless of the allow_auto_merge setting
+	http.Register(
+		httpmock.GraphQL(`mutation PullRequestEnqueue\b`),
+		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
+			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
 		}),
 	)
 


### PR DESCRIPTION
## What

`gh pr merge` fails when a repository has a merge queue enabled but the
"Allow auto-merge" setting is disabled (`allow_auto_merge=false`).

The CLI was using the `enablePullRequestAutoMerge` mutation as a
catch-all for both enabling auto-merge and enqueuing a PR into a merge
queue. That mutation requires auto-merge to be allowed on the repository
and returns an API error when it is not.

## Fix

When `shouldAddToMergeQueue()` is true, call the `enqueuePullRequest`
GraphQL mutation directly. This mutation works regardless of the
repository's auto-merge setting and is the correct API call for adding a
PR to a merge queue.

- Added `mergeQueue bool` field to `mergePayload` to distinguish between
  "enable auto-merge" and "add to merge queue" intent
- `mergePullRequest` in `http.go` now calls `enqueuePullRequest` when
  `payload.mergeQueue` is true
- Updated existing merge queue tests to expect `PullRequestEnqueue`
  instead of `PullRequestAutoMerge`
- Added a test for the specific case reported in the issue

Fixes #13398