### PR TITLE
api: deduplicate check runs in ChecksStatus to fix pr status false failures

### DIFF
--- a/api/pull_request_test.go
+++ b/api/pull_request_test.go
@@ -411,3 +411,51 @@ func statusContextNode(state string) string {
 		"state": "%s"
 	}`, state)
 }
+
+// TestChecksStatus_DeduplicatesCancelledRuns reproduces the scenario from
+// https://github.com/cli/cli/issues/12895: when a CI job is re-triggered
+// after a cancellation, the stale cancelled run should not be counted as a
+// failure alongside the newer successful run.
+func TestChecksStatus_DeduplicatesCancelledRuns(t *testing.T) {
+	t.Parallel()
+
+	// Two runs for the same check: an older cancelled run and a newer
+	// successful one. Only the successful one should count.
+	payload := `
+	{ "statusCheckRollup": { "nodes": [{ "commit": {
+		"statusCheckRollup": {
+			"contexts": {
+				"nodes": [
+					{
+						"__typename": "CheckRun",
+						"name": "test / unit",
+						"status": "COMPLETED",
+						"conclusion": "CANCELLED",
+						"startedAt": "2024-01-01T00:00:00Z",
+						"checkSuite": { "workflowRun": { "event": "push", "workflow": { "name": "CI" } } }
+					},
+					{
+						"__typename": "CheckRun",
+						"name": "test / unit",
+						"status": "COMPLETED",
+						"conclusion": "SUCCESS",
+						"startedAt": "2024-01-01T01:00:00Z",
+						"checkSuite": { "workflowRun": { "event": "push", "workflow": { "name": "CI" } } }
+					}
+				]
+			}
+		}
+	} }] } }
+	`
+
+	var pr PullRequest
+	require.NoError(t, json.Unmarshal([]byte(payload), &pr))
+
+	// Only the newer successful run should be counted; the stale cancelled
+	// run must be ignored.
+	expectedChecksStatus := PullRequestChecksStatus{
+		Passing: 1,
+		Total:   1,
+	}
+	require.Equal(t, expectedChecksStatus, pr.ChecksStatus())
+}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"time"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -366,8 +367,9 @@ func (pr *PullRequest) ChecksStatus() PullRequestChecksStatus {
 		return summary
 	}
 
-	// If we don't have the counts by state, then we'll need to summarise by looking at the more detailed contexts
-	for _, c := range contexts.Nodes {
+	// If we don't have the counts by state, then we'll need to summarise by looking at the more detailed contexts.
+	// Deduplicate first so that stale cancelled runs do not inflate the failure count when a newer run succeeded.
+	for _, c := range deduplicateCheckContexts(contexts.Nodes) {
 		// Nodes are a discriminated union of CheckRun or StatusContext and we can match on
 		// the TypeName to narrow the type.
 		if c.TypeName == "CheckRun" {
@@ -402,6 +404,50 @@ func (pr *PullRequest) ChecksStatus() PullRequestChecksStatus {
 	}
 
 	return summary
+}
+
+// deduplicateCheckContexts returns a deduplicated copy of contexts, keeping
+// only the most recent run per unique check. This prevents stale cancelled
+// runs from being counted alongside a newer successful run for the same check,
+// matching the behaviour of pkg/cmd/pr/checks/aggregate.go's eliminateDuplicates.
+//
+// Deduplication keys:
+//   - StatusContext: the Context field (check name in the CI context)
+//   - CheckRun: composite of Name + workflow name + event
+//
+// Contexts that have no identifying fields are always included without
+// deduplication.
+func deduplicateCheckContexts(contexts []CheckContext) []CheckContext {
+	sorted := make([]CheckContext, len(contexts))
+	copy(sorted, contexts)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].StartedAt.After(sorted[j].StartedAt)
+	})
+
+	seenChecks := make(map[string]struct{})
+	seenContexts := make(map[string]struct{})
+	unique := make([]CheckContext, 0, len(sorted))
+
+	for _, ctx := range sorted {
+		if ctx.Context != "" {
+			// StatusContext: deduplicate by context name.
+			if _, exists := seenContexts[ctx.Context]; exists {
+				continue
+			}
+			seenContexts[ctx.Context] = struct{}{}
+		} else if ctx.Name != "" {
+			// CheckRun: deduplicate by name + workflow + event.
+			key := fmt.Sprintf("%s/%s/%s", ctx.Name, ctx.CheckSuite.WorkflowRun.Workflow.Name, ctx.CheckSuite.WorkflowRun.Event)
+			if _, exists := seenChecks[key]; exists {
+				continue
+			}
+			seenChecks[key] = struct{}{}
+		}
+		// No identifying fields: include unconditionally.
+		unique = append(unique, ctx)
+	}
+
+	return unique
 }
 
 type checkStatus int


### PR DESCRIPTION
## What

`gh pr status` reported a PR as failing even after a failed CI job was
re-triggered and succeeded. The previous cancelled run remained in the
status check rollup alongside the new successful run, and both were
counted, so the summary showed failures that no longer applied.

## Fix

Apply the same deduplication logic that `gh pr checks` already uses
(via `eliminateDuplicates` in `pkg/cmd/pr/checks/aggregate.go`) inside
`ChecksStatus()` in `api/queries_pr.go`.

Before computing the summary from `contexts.Nodes`, the new
`deduplicateCheckContexts` helper:

1. Sorts contexts by `StartedAt` descending (most recent first)
2. Keeps only the first occurrence per unique check:
   - StatusContext nodes: keyed on the `Context` field
   - CheckRun nodes: keyed on `name + workflow + event`
3. Passes through any nodes that have no identifying fields unchanged

This ensures that only the most recent run for each check is counted,
matching the behaviour of `gh pr checks`.

Fixes #12895