### PR TITLE
Fix browse decimal short hash routing

### DIFF
--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -2,6 +2,7 @@ package browse
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -250,6 +251,20 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 			return "", nil
 		}
 		if isNumber(opts.SelectorArg) {
+			if isCommit(opts.SelectorArg) {
+				httpClient, err := opts.HttpClient()
+				if err != nil {
+					return "", err
+				}
+				apiClient := api.NewClientFromHTTP(httpClient)
+				commitExists, err := refResolvesToCommit(apiClient, baseRepo, opts.SelectorArg)
+				if err != nil {
+					return "", err
+				}
+				if commitExists {
+					return fmt.Sprintf("commit/%s", opts.SelectorArg), nil
+				}
+			}
 			return fmt.Sprintf("issues/%s", strings.TrimPrefix(opts.SelectorArg, "#")), nil
 		}
 		if isCommit(opts.SelectorArg) {
@@ -352,6 +367,21 @@ var commitHash = regexp.MustCompile(`\A[a-f0-9]{7,64}\z`)
 
 func isCommit(arg string) bool {
 	return commitHash.MatchString(arg)
+}
+
+func refResolvesToCommit(client *api.Client, repo ghrepo.Interface, ref string) (bool, error) {
+	path := fmt.Sprintf("repos/%s/%s/commits/%s", url.PathEscape(repo.RepoOwner()), url.PathEscape(repo.RepoName()), url.PathEscape(ref))
+	err := client.REST(repo.RepoHost(), "GET", path, nil, nil)
+	if err == nil {
+		return true, nil
+	}
+
+	var httpErr api.HTTPError
+	if errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusNotFound || httpErr.StatusCode == http.StatusUnprocessableEntity) {
+		return false, nil
+	}
+
+	return false, err
 }
 
 // gitClient is used to implement functions that can be performed on both local and remote git repositories

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -357,6 +357,42 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL: "https://github.com/kevin/MinTy/issues/217",
 		},
 		{
+			name: "ambiguous decimal-only short hash that is a valid commit",
+			opts: BrowseOptions{
+				SelectorArg: "309628980",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/kevin/MinTy/commits/309628980"),
+					httpmock.StringResponse("{}"),
+				)
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/commit/309628980",
+		},
+		{
+			name: "ambiguous decimal-only string that is not a commit",
+			opts: BrowseOptions{
+				SelectorArg: "1234567",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/kevin/MinTy/commits/1234567"),
+					httpmock.StatusStringResponse(404, "{}"),
+				)
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/issues/1234567",
+		},
+		{
+			name: "hashtag decimal-only argument forces issue",
+			opts: BrowseOptions{
+				SelectorArg: "#309628980",
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedURL: "https://github.com/kevin/MinTy/issues/309628980",
+		},
+		{
 			name: "branch flag",
 			opts: BrowseOptions{
 				Branch: "trunk",

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -283,6 +283,7 @@ func Test_runBrowse(t *testing.T) {
 		baseRepo      ghrepo.Interface
 		defaultBranch string
 		expectedURL   string
+		expectedErr   string
 		wantsErr      bool
 	}{
 		{
@@ -383,6 +384,21 @@ func Test_runBrowse(t *testing.T) {
 			},
 			baseRepo:    ghrepo.New("kevin", "MinTy"),
 			expectedURL: "https://github.com/kevin/MinTy/issues/1234567",
+		},
+		{
+			name: "ambiguous decimal-only commit lookup error returns error",
+			opts: BrowseOptions{
+				SelectorArg: "1234567",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/kevin/MinTy/commits/1234567"),
+					httpmock.StatusStringResponse(500, `{"message":"server error"}`),
+				)
+			},
+			baseRepo:    ghrepo.New("kevin", "MinTy"),
+			expectedErr: "HTTP 500",
+			wantsErr:    true,
 		},
 		{
 			name: "hashtag decimal-only argument forces issue",
@@ -743,6 +759,9 @@ func Test_runBrowse(t *testing.T) {
 			err := runBrowse(&opts)
 			if tt.wantsErr {
 				assert.Error(t, err)
+				if tt.expectedErr != "" {
+					assert.ErrorContains(t, err, tt.expectedErr)
+				}
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
Clean replacement for #13558.

Fixes #12357.

## Summary

- disambiguate decimal-only selector arguments that also look like short commit hashes by checking whether the ref resolves to a commit
- keep numeric issue routing when the commit lookup returns 404/422, and keep `#<number>` as an explicit issue override
- include the review-requested regression that a non-fallback commit lookup error, such as HTTP 500, is returned instead of silently routing to `issues/<selector>`

## Validation

- `PATH=/home/rage/.cache/codex-tools/go1.26.3/bin:$PATH GOTOOLCHAIN=local go test -count=1 ./pkg/cmd/browse`
- `PATH=/home/rage/.cache/codex-tools/go1.26.3/bin:$PATH GOTOOLCHAIN=local go test -count=1 ./pkg/cmd/browse -run 'Test_runBrowse/(ambiguous_decimal-only_short_hash_that_is_a_valid_commit|ambiguous_decimal-only_string_that_is_not_a_commit|ambiguous_decimal-only_commit_lookup_error_returns_error)'`
- `git diff --check upstream/trunk...HEAD`
- `PATH=/home/rage/.cache/codex-tools/go1.26.3/bin:$PATH GH_CONFIG_DIR=/home/rage/.config/gh GOTOOLCHAIN=local go run ./cmd/gh browse -n 309628980 -R cli/cli` -> `https://github.com/cli/cli/commit/309628980`
- `PATH=/home/rage/.cache/codex-tools/go1.26.3/bin:$PATH GH_CONFIG_DIR=/home/rage/.config/gh GOTOOLCHAIN=local go run ./cmd/gh browse -n 1234567 -R cli/cli` -> `https://github.com/cli/cli/issues/1234567`
- `PATH=/home/rage/.cache/codex-tools/go1.26.3/bin:$PATH GH_CONFIG_DIR=/home/rage/.config/gh GOTOOLCHAIN=local go run ./cmd/gh browse -n '#309628980' -R cli/cli` -> `https://github.com/cli/cli/issues/309628980`
