### PR TITLE
fix(repo create): support gitfile-based repositories with --source

### DIFF
--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -794,10 +794,12 @@ func localRepoType(gitClient *git.Client) (repoType, error) {
 	switch projectDir {
 	case ".":
 		return bare, nil
-	case ".git":
-		return working, nil
 	default:
-		return unknown, nil
+		// Any other successful output from git rev-parse --git-dir means
+		// the directory is a valid git repository. This covers normal repos
+		// (.git), gitfile-based repos (e.g. submodules), and worktrees where
+		// the command returns an absolute path to the actual git directory.
+		return working, nil
 	}
 }
 

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -831,6 +831,39 @@ func Test_createRun(t *testing.T) {
 			errMsg:  "some-dir is not a git repository. Run `git -C \"some-dir\" init` to initialize it",
 		},
 		{
+			name: "noninteractive create from source with gitfile",
+			opts: &CreateOptions{
+				Interactive: false,
+				Source:      ".",
+				Name:        "REPO",
+				Visibility:  "PRIVATE",
+			},
+			tty: false,
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation RepositoryCreate\b`),
+					httpmock.StringResponse(`
+					{
+						"data": {
+							"createRepository": {
+								"repository": {
+									"id": "REPOID",
+									"name": "REPO",
+									"owner": {"login":"OWNER"},
+									"url": "https://github.com/OWNER/REPO"
+								}
+							}
+						}
+					}`))
+			},
+			execStubs: func(cs *run.CommandStubber) {
+				cs.Register(`git -C . rev-parse --git-dir`, 0, "/Users/user/main-repo/.git/worktrees/wt")
+				cs.Register(`git -C . rev-parse HEAD`, 0, "commithash")
+				cs.Register(`git -C . remote add origin https://github.com/OWNER/REPO`, 0, "")
+			},
+			wantStdout: "https://github.com/OWNER/REPO\n",
+		},
+		{
 			name: "noninteractive clone from scratch",
 			opts: &CreateOptions{
 				Interactive: false,


### PR DESCRIPTION
## Description

When `.git` is a file (gitfile) pointing to the actual git directory — as in worktrees or submodules — `gh repo create --source .` fails with:

```
current directory is not a git repository. Run `git init` to initialize it
```

This happens because `localRepoType()` uses `git rev-parse --git-dir` and only matches two cases:
- `.` → bare repo
- `.git` → normal working repo

But for gitfile-based repos, the command returns an absolute path (e.g., `/Users/user/main-repo/.git/worktrees/wt`), which falls through to `default` → `unknown`, and is then treated as "not a git repo".

## Fix

Treat any successful output from `git rev-parse --git-dir` as a working repository. A successful exit code confirms the directory is a valid git repo regardless of the returned path.

## Testing

- Added a test case `noninteractive create from source with gitfile` that simulates a gitfile scenario (absolute path returned by `git rev-parse --git-dir`)
- All existing tests continue to pass
- `go vet` clean

Fixes #13555