### PR TITLE
Fix root-level SKILL.md discovery

### DIFF
--- a/internal/skills/discovery/discovery.go
+++ b/internal/skills/discovery/discovery.go
@@ -396,6 +396,10 @@ func matchSkillConventions(entry treeEntry) *skillMatch {
 		return nil
 	}
 
+	if entry.Path == "SKILL.md" {
+		return &skillMatch{entry: entry, skillDir: ".", convention: "root"}
+	}
+
 	dir := path.Dir(entry.Path)
 	parentDir := path.Dir(dir)
 	skillName := path.Base(dir)
@@ -542,6 +546,9 @@ func DiscoverSkillsWithOptions(client *api.Client, host, owner, repo, commitSHA 
 	}
 
 	treeSHAs := make(map[string]string)
+	if tree.SHA != "" {
+		treeSHAs["."] = tree.SHA
+	}
 	for _, entry := range tree.Tree {
 		if entry.Type == "tree" {
 			treeSHAs[entry.Path] = entry.SHA
@@ -581,13 +588,24 @@ func DiscoverSkillsWithOptions(client *api.Client, host, owner, repo, commitSHA 
 
 	var skills []Skill
 	for _, m := range matches {
+		name := m.name
+		description := ""
+		if name == "" {
+			var ok bool
+			name, description, ok = rootSkillNameAndDescription(client, host, owner, repo, m.entry)
+			if !ok {
+				continue
+			}
+		}
+
 		skills = append(skills, Skill{
-			Name:       m.name,
-			Namespace:  m.namespace,
-			Path:       m.skillDir,
-			BlobSHA:    m.entry.SHA,
-			TreeSHA:    treeSHAs[m.skillDir],
-			Convention: m.convention,
+			Name:        name,
+			Namespace:   m.namespace,
+			Description: description,
+			Path:        m.skillDir,
+			BlobSHA:     m.entry.SHA,
+			TreeSHA:     treeSHAs[m.skillDir],
+			Convention:  m.convention,
 		})
 	}
 
@@ -596,6 +614,25 @@ func DiscoverSkillsWithOptions(client *api.Client, host, owner, repo, commitSHA 
 	})
 
 	return skills, nil
+}
+
+func rootSkillNameAndDescription(client *api.Client, host, owner, repo string, entry treeEntry) (string, string, bool) {
+	name := repo
+	description := ""
+	if entry.SHA != "" {
+		content, err := FetchBlob(client, host, owner, repo, entry.SHA)
+		if err == nil {
+			result, err := frontmatter.Parse(content)
+			if err == nil {
+				if result.Metadata.Name != "" {
+					name = result.Metadata.Name
+				}
+				description = result.Metadata.Description
+			}
+		}
+	}
+
+	return name, description, validateName(name)
 }
 
 // fetchDescription fetches and parses the frontmatter description for a skill.
@@ -657,8 +694,12 @@ func FetchDescriptionsConcurrent(client *api.Client, host, owner, repo string, s
 
 // DiscoverSkillByPath looks up a single skill by its exact path in the repository.
 func DiscoverSkillByPath(client *api.Client, host, owner, repo, commitSHA, skillPath string) (*Skill, error) {
-	skillPath = strings.TrimSuffix(skillPath, "/SKILL.md")
 	skillPath = strings.TrimSuffix(skillPath, "/")
+	if skillPath == "." || skillPath == "SKILL.md" {
+		return discoverRootSkillByPath(client, host, owner, repo, commitSHA)
+	}
+
+	skillPath = strings.TrimSuffix(skillPath, "/SKILL.md")
 
 	skillName := path.Base(skillPath)
 	if !validateName(skillName) {
@@ -742,9 +783,47 @@ func DiscoverSkillByPath(client *api.Client, host, owner, repo, commitSHA, skill
 	return skill, nil
 }
 
+func discoverRootSkillByPath(client *api.Client, host, owner, repo, commitSHA string) (*Skill, error) {
+	apiPath := fmt.Sprintf("repos/%s/%s/git/trees/%s", url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(commitSHA))
+	var tree treeResponse
+	if err := client.REST(host, "GET", apiPath, nil, &tree); err != nil {
+		return nil, fmt.Errorf("could not fetch repository tree: %w", err)
+	}
+
+	var skillEntry treeEntry
+	for _, entry := range tree.Tree {
+		if entry.Path == "SKILL.md" && entry.Type == "blob" {
+			skillEntry = entry
+			break
+		}
+	}
+	if skillEntry.SHA == "" {
+		return nil, fmt.Errorf("no SKILL.md found at repository root in %s/%s", owner, repo)
+	}
+
+	name, description, ok := rootSkillNameAndDescription(client, host, owner, repo, skillEntry)
+	if !ok {
+		return nil, fmt.Errorf("invalid skill name %q in SKILL.md", name)
+	}
+
+	return &Skill{
+		Name:        name,
+		Description: description,
+		Path:        ".",
+		BlobSHA:     skillEntry.SHA,
+		TreeSHA:     tree.SHA,
+		Convention:  "root",
+	}, nil
+}
+
 // DiscoverSkillFiles returns all file paths belonging to a skill directory
 // by fetching the skill's subtree directly using its tree SHA.
 func DiscoverSkillFiles(client *api.Client, host, owner, repo, treeSHA, skillPath string) ([]SkillFile, error) {
+	prefix := skillPath
+	if prefix == "." {
+		prefix = ""
+	}
+
 	apiPath := fmt.Sprintf("repos/%s/%s/git/trees/%s?recursive=true", url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(treeSHA))
 	var tree treeResponse
 	if err := client.REST(host, "GET", apiPath, nil, &tree); err != nil {
@@ -753,14 +832,18 @@ func DiscoverSkillFiles(client *api.Client, host, owner, repo, treeSHA, skillPat
 
 	if tree.Truncated {
 		// Recursive fetch was truncated. Fall back to walking subtrees individually.
-		return walkTree(client, host, owner, repo, treeSHA, skillPath, 0)
+		return walkTree(client, host, owner, repo, treeSHA, prefix, 0)
 	}
 
 	var files []SkillFile
 	for _, entry := range tree.Tree {
 		if entry.Type == "blob" {
+			filePath := entry.Path
+			if prefix != "" {
+				filePath = prefix + "/" + entry.Path
+			}
 			files = append(files, SkillFile{
-				Path: skillPath + "/" + entry.Path,
+				Path: filePath,
 				SHA:  entry.SHA,
 				Size: entry.Size,
 			})

--- a/internal/skills/discovery/discovery_test.go
+++ b/internal/skills/discovery/discovery_test.go
@@ -91,6 +91,11 @@ func TestMatchSkillConventions(t *testing.T) {
 			wantConvention: "root",
 		},
 		{
+			name:           "root-level SKILL.md single-skill repo",
+			path:           "SKILL.md",
+			wantConvention: "root",
+		},
+		{
 			name:    "root convention excludes skills dir",
 			path:    "skills/SKILL.md",
 			wantNil: true,
@@ -862,6 +867,27 @@ func TestDiscoverSkills(t *testing.T) {
 			wantSkills: []string{"code-review", "issue-triage"},
 		},
 		{
+			name: "discovers root-level SKILL.md from frontmatter",
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/abc123"),
+					httpmock.JSONResponse(map[string]interface{}{
+						"sha": "root-tree-sha", "truncated": false,
+						"tree": []map[string]interface{}{
+							{"path": "SKILL.md", "type": "blob", "sha": "root-blob-sha"},
+							{"path": "README.md", "type": "blob", "sha": "readme"},
+						},
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/root-blob-sha"),
+					httpmock.JSONResponse(map[string]interface{}{
+						"sha": "root-blob-sha", "encoding": "base64",
+						"content": "LS0tCm5hbWU6IGh1bWFuaXplcgpkZXNjcmlwdGlvbjogSHVtYW5pemVzIHRleHQKLS0tCiMgSHVtYW5pemVyCg==",
+					}))
+			},
+			wantSkills: []string{"humanizer"},
+		},
+		{
 			name: "truncated tree returns error",
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
@@ -1156,6 +1182,28 @@ func TestDiscoverSkillByPath(t *testing.T) {
 					}))
 			},
 			wantName: "code-review",
+		},
+		{
+			name:      "discovers root-level SKILL.md by explicit path",
+			skillPath: "SKILL.md",
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/abc123"),
+					httpmock.JSONResponse(map[string]interface{}{
+						"sha": "root-tree-sha", "truncated": false,
+						"tree": []map[string]interface{}{
+							{"path": "SKILL.md", "type": "blob", "sha": "root-blob-sha"},
+						},
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/blobs/root-blob-sha"),
+					httpmock.JSONResponse(map[string]interface{}{
+						"sha": "root-blob-sha", "encoding": "base64",
+						"content": "LS0tCm5hbWU6IHJvb3Qtc2tpbGwKZGVzY3JpcHRpb246IFJvb3QgbGV2ZWwgc2tpbGwKLS0tCiMgUm9vdAo=",
+					}))
+			},
+			wantName:       "root-skill",
+			wantConvention: "root",
 		},
 		{
 			name:      "invalid skill name",
@@ -1492,12 +1540,14 @@ func TestMatchSkillPath(t *testing.T) {
 func TestDiscoverSkillFiles(t *testing.T) {
 	tests := []struct {
 		name      string
+		skillPath string
 		stubs     func(*httpmock.Registry)
 		wantPaths []string
 		wantErr   string
 	}{
 		{
-			name: "returns files with skill path prefix",
+			name:      "returns files with skill path prefix",
+			skillPath: "skills/code-review",
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
@@ -1513,7 +1563,8 @@ func TestDiscoverSkillFiles(t *testing.T) {
 			wantPaths: []string{"skills/code-review/SKILL.md", "skills/code-review/scripts/setup.sh"},
 		},
 		{
-			name: "truncated tree falls back to walkTree",
+			name:      "truncated tree falls back to walkTree",
+			skillPath: "skills/code-review",
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
@@ -1532,7 +1583,24 @@ func TestDiscoverSkillFiles(t *testing.T) {
 			wantPaths: []string{"skills/code-review/SKILL.md"},
 		},
 		{
-			name: "API error",
+			name:      "root skill paths are not prefixed",
+			skillPath: ".",
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
+					httpmock.JSONResponse(map[string]interface{}{
+						"sha": "tree123", "truncated": false,
+						"tree": []map[string]interface{}{
+							{"path": "SKILL.md", "type": "blob", "sha": "sha1", "size": 10},
+							{"path": "README.md", "type": "blob", "sha": "sha2", "size": 20},
+						},
+					}))
+			},
+			wantPaths: []string{"SKILL.md", "README.md"},
+		},
+		{
+			name:      "API error",
+			skillPath: "skills/code-review",
 			stubs: func(reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.REST("GET", "repos/monalisa/octocat-skills/git/trees/tree123"),
@@ -1548,7 +1616,7 @@ func TestDiscoverSkillFiles(t *testing.T) {
 			tt.stubs(reg)
 			client := api.NewClientFromHTTP(&http.Client{Transport: reg})
 
-			files, err := DiscoverSkillFiles(client, "github.com", "monalisa", "octocat-skills", "tree123", "skills/code-review")
+			files, err := DiscoverSkillFiles(client, "github.com", "monalisa", "octocat-skills", "tree123", tt.skillPath)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -1239,9 +1239,13 @@ func filterHiddenDirSkills(opts *InstallOptions, allSkills []discovery.Skill) ([
 // installs from the re-publisher.
 // Returns (repo to redirect to, whether upstream was detected, error).
 func checkUpstreamProvenance(opts *InstallOptions, client *api.Client, hostname string, skill discovery.Skill, commitSHA string) (ghrepo.Interface, bool, error) {
+	skillFilePath := skill.Path + "/SKILL.md"
+	if skill.Path == "." {
+		skillFilePath = "SKILL.md"
+	}
 	apiPath := fmt.Sprintf("repos/%s/%s/contents/%s?ref=%s",
 		opts.repo.RepoOwner(), opts.repo.RepoName(),
-		skill.Path+"/SKILL.md", commitSHA)
+		skillFilePath, commitSHA)
 	var fileResp struct {
 		Content  string `json:"content"`
 		Encoding string `json:"encoding"`

--- a/pkg/cmd/skills/preview/preview.go
+++ b/pkg/cmd/skills/preview/preview.go
@@ -443,6 +443,11 @@ func selectSkill(opts *PreviewOptions, skills []discovery.Skill) (discovery.Skil
 				return s, nil
 			}
 		}
+		for _, s := range skills {
+			if skillPathMatches(s, opts.SkillName) {
+				return s, nil
+			}
+		}
 		return discovery.Skill{}, fmt.Errorf("skill %q not found in %s", opts.SkillName, ghrepo.FullName(opts.repo))
 	}
 
@@ -461,6 +466,17 @@ func selectSkill(opts *PreviewOptions, skills []discovery.Skill) (discovery.Skil
 	}
 
 	return skills[idx], nil
+}
+
+func skillPathMatches(skill discovery.Skill, input string) bool {
+	input = strings.TrimSuffix(input, "/")
+	if input == "SKILL.md" {
+		input = "."
+	} else {
+		input = strings.TrimSuffix(input, "/SKILL.md")
+	}
+
+	return input == skill.Path
 }
 
 // treeNode represents a file or directory in the tree for rendering.

--- a/pkg/cmd/skills/preview/preview_test.go
+++ b/pkg/cmd/skills/preview/preview_test.go
@@ -109,6 +109,50 @@ func TestNewCmdPreview(t *testing.T) {
 	}
 }
 
+func TestSelectSkillMatchesPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		skills   []discovery.Skill
+		wantName string
+		wantPath string
+	}{
+		{
+			name:  "root SKILL.md path",
+			input: "SKILL.md",
+			skills: []discovery.Skill{
+				{Name: "humanizer", Path: ".", Convention: "root"},
+			},
+			wantName: "humanizer",
+			wantPath: ".",
+		},
+		{
+			name:  "regular SKILL.md path",
+			input: "skills/code-review/SKILL.md",
+			skills: []discovery.Skill{
+				{Name: "code-review", Path: "skills/code-review"},
+			},
+			wantName: "code-review",
+			wantPath: "skills/code-review",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &PreviewOptions{
+				repo:      ghrepo.New("owner", "repo"),
+				SkillName: tt.input,
+			}
+
+			skill, err := selectSkill(opts, tt.skills)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, skill.Name)
+			assert.Equal(t, tt.wantPath, skill.Path)
+		})
+	}
+}
+
 func TestPreviewRun(t *testing.T) {
 	skillContent := heredoc.Doc(`
 		---


### PR DESCRIPTION
Fixes #13552

## Summary
- recognize repository-root `SKILL.md` entries during remote skill discovery
- derive root skill names/descriptions from frontmatter with the repo name as fallback
- allow explicit `SKILL.md` path selection for preview/install and root skill file listing

## Verification
- `go test ./internal/skills/discovery ./pkg/cmd/skills/preview ./pkg/cmd/skills/install`
- `git diff --check`
- `GH_PAGER=cat go run ./cmd/gh skill preview blader/humanizer SKILL.md > /tmp/preview-root-skill.out`
- `go run ./cmd/gh skill install blader/humanizer SKILL.md --dir /tmp/humanizer-skill-test --force`
