### PR TITLE
Bound archive extraction size to guard against decompression bombs

### DIFF
--- a/internal/zip/zip.go
+++ b/internal/zip/zip.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 
@@ -17,11 +18,25 @@ const (
 	execMode os.FileMode = 0755
 )
 
-// ExtractZip extracts the contents of a zip archive to destDir.
+// ExtractZip extracts the contents of a zip archive to destDir. Each entry is
+// bounded to its declared uncompressed size to guard against decompression
+// bombs, but no cumulative total-size limit is imposed, since this is used to
+// extract arbitrarily large artifacts (e.g. `gh run download`). Callers that
+// extract a fixed-size payload and want a total cap should use
+// ExtractZipWithLimit.
 // Files that would result in path traversal are silently skipped.
 // Files that would produce any other error cause the extraction to be aborted,
 // and the error is returned.
 func ExtractZip(zr *zip.Reader, destDir safepaths.Absolute) error {
+	return ExtractZipWithLimit(zr, destDir, 0)
+}
+
+// ExtractZipWithLimit behaves like ExtractZip but aborts if the cumulative
+// uncompressed size of the extracted entries would exceed maxTotalSize bytes,
+// which guards against decompression bombs. A maxTotalSize <= 0 disables the
+// total limit (the per-entry declared-size bound still applies).
+func ExtractZipWithLimit(zr *zip.Reader, destDir safepaths.Absolute, maxTotalSize int64) error {
+	var totalWritten int64
 	for _, zf := range zr.File {
 		fpath, err := destDir.Join(zf.Name)
 		if err != nil {
@@ -32,14 +47,27 @@ func ExtractZip(zr *zip.Reader, destDir safepaths.Absolute) error {
 			return err
 		}
 
-		if err := extractZipFile(zf, fpath); err != nil {
+		// Bound this entry to whatever remains of the total budget so that a
+		// single oversized entry cannot exhaust disk before the total is checked.
+		remaining := int64(-1) // unlimited
+		if maxTotalSize > 0 {
+			remaining = maxTotalSize - totalWritten
+		}
+
+		written, err := extractZipFile(zf, fpath, remaining)
+		if err != nil {
 			return fmt.Errorf("error extracting %q: %w", zf.Name, err)
 		}
+		totalWritten += written
 	}
 	return nil
 }
 
-func extractZipFile(zf *zip.File, dest safepaths.Absolute) (extractErr error) {
+// extractZipFile writes a single zip entry and returns the number of bytes
+// written. The copy is bounded by the entry's declared uncompressed size and,
+// when remaining >= 0, by the remaining total-archive budget; exceeding either
+// aborts extraction (a decompression-bomb guard).
+func extractZipFile(zf *zip.File, dest safepaths.Absolute, remaining int64) (written int64, extractErr error) {
 	zm := zf.Mode()
 	if zm.IsDir() {
 		extractErr = os.MkdirAll(dest.String(), dirMode)
@@ -68,7 +96,32 @@ func extractZipFile(zf *zip.File, dest safepaths.Absolute) (extractErr error) {
 		}
 	}()
 
-	_, extractErr = io.Copy(df, f)
+	// Bound extraction to the entry's declared uncompressed size and, if set, the
+	// remaining total budget. Counting the bytes actually written (rather than
+	// trusting the header) defends against a decompressed stream that overruns
+	// either bound. We read one extra byte so an overrun is detectable.
+	if zf.UncompressedSize64 >= math.MaxInt64 {
+		extractErr = fmt.Errorf("zip entry %q declares an implausible uncompressed size", zf.Name)
+		return
+	}
+	declaredSize := int64(zf.UncompressedSize64)
+
+	limit := declaredSize
+	if remaining >= 0 && remaining < limit {
+		limit = remaining
+	}
+
+	written, extractErr = io.Copy(df, io.LimitReader(f, limit+1))
+	if extractErr != nil {
+		return
+	}
+	if written > declaredSize {
+		extractErr = fmt.Errorf("zip entry %q exceeds its declared uncompressed size of %d bytes", zf.Name, declaredSize)
+		return
+	}
+	if remaining >= 0 && written > remaining {
+		extractErr = fmt.Errorf("zip entry %q would exceed the maximum allowed uncompressed archive size", zf.Name)
+	}
 	return
 }
 

--- a/internal/zip/zip_test.go
+++ b/internal/zip/zip_test.go
@@ -2,8 +2,10 @@ package zip
 
 import (
 	"archive/zip"
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/internal/safepaths"
@@ -24,4 +26,51 @@ func Test_extractZip(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(extractPath.String(), "src", "main.go"))
 	require.NoError(t, err)
+}
+
+// makeZipReader builds an in-memory zip archive from name->content pairs.
+func makeZipReader(t *testing.T, files map[string]string) *zip.Reader {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	return zr
+}
+
+func Test_extractZip_withinTotalSizeBudget(t *testing.T) {
+	extractPath, err := safepaths.ParseAbsolute(filepath.Join(t.TempDir(), "out"))
+	require.NoError(t, err)
+
+	zr := makeZipReader(t, map[string]string{"a.txt": "hello"})
+
+	require.NoError(t, ExtractZipWithLimit(zr, extractPath, 1<<20))
+
+	got, err := os.ReadFile(filepath.Join(extractPath.String(), "a.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(got))
+}
+
+func Test_extractZip_exceedsTotalSizeBudget(t *testing.T) {
+	extractPath, err := safepaths.ParseAbsolute(filepath.Join(t.TempDir(), "out"))
+	require.NoError(t, err)
+
+	// Two highly-compressible entries totalling 1200 uncompressed bytes; a
+	// 1000-byte budget must reject the archive (a decompression-bomb guard that
+	// counts bytes actually written, not the compressed footprint).
+	zr := makeZipReader(t, map[string]string{
+		"a.txt": strings.Repeat("A", 600),
+		"b.txt": strings.Repeat("B", 600),
+	})
+
+	err = ExtractZipWithLimit(zr, extractPath, 1000)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "maximum allowed uncompressed")
 }

--- a/pkg/cmd/copilot/copilot.go
+++ b/pkg/cmd/copilot/copilot.go
@@ -394,16 +394,22 @@ func extractZip(path, destDir string) error {
 		}
 	}
 
-	if err := ghzip.ExtractZip(&zipReader.Reader, absPath); err != nil {
+	if err := ghzip.ExtractZipWithLimit(&zipReader.Reader, absPath, maxCopilotExtractedBytes); err != nil {
 		return err
 	}
 
 	return nil
 }
 
+// maxCopilotExtractedBytes bounds the cumulative uncompressed size of the
+// Copilot CLI archive to guard against decompression bombs. It is far larger
+// than the CLI itself while preventing a malicious release from exhausting disk.
+const maxCopilotExtractedBytes int64 = 2 << 30 // 2 GiB
+
 // extractTarGz reads a TAR.GZ archive from r and extracts its contents into destDir.
 // It returns an error if the archive cannot be read,
-// or if any file or directory within the archive cannot be created or written.
+// or if any file or directory within the archive cannot be created or written,
+// or if the cumulative uncompressed size exceeds maxCopilotExtractedBytes.
 func extractTarGz(r io.Reader, destDir string) error {
 	gzr, err := gzip.NewReader(r)
 	if err != nil {
@@ -416,6 +422,7 @@ func extractTarGz(r io.Reader, destDir string) error {
 		return err
 	}
 
+	var totalWritten int64
 	tr := tar.NewReader(gzr)
 	for {
 		header, err := tr.Next()
@@ -436,29 +443,52 @@ func extractTarGz(r io.Reader, destDir string) error {
 			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 				return fmt.Errorf("failed to create parent directory: %w", err)
 			}
-			if err := extractFile(target, os.FileMode(header.Mode)&0777, tr); err != nil {
+			written, err := extractFile(target, os.FileMode(header.Mode)&0777, header.Size, maxCopilotExtractedBytes-totalWritten, tr)
+			if err != nil {
 				return err
 			}
+			totalWritten += written
 		}
 	}
 	return nil
 }
 
-// extractFile creates a file at target with the given mode and copies content from r.
-func extractFile(target string, mode os.FileMode, r io.Reader) (err error) {
+// extractFile creates a file at target with the given mode and copies from r,
+// returning the number of bytes written. The copy is bounded both by the entry's
+// declared size (from the tar header) and by maxBytes (the remaining whole-archive
+// budget); exceeding either aborts extraction rather than writing unbounded data
+// to disk. Both bounds are decompression-bomb guards that count bytes actually
+// written rather than trusting the header.
+func extractFile(target string, mode os.FileMode, size, maxBytes int64, r io.Reader) (written int64, err error) {
 	out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {
-		return fmt.Errorf("failed to create file: %w", err)
+		return 0, fmt.Errorf("failed to create file: %w", err)
 	}
 	defer func() {
 		if cerr := out.Close(); err == nil && cerr != nil {
 			err = fmt.Errorf("failed to close file: %w", cerr)
 		}
 	}()
-	if _, err := io.Copy(out, r); err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+
+	limit := size
+	if maxBytes < limit {
+		limit = maxBytes
 	}
-	return nil
+	if limit < 0 {
+		limit = 0
+	}
+
+	written, err = io.Copy(out, io.LimitReader(r, limit+1))
+	if err != nil {
+		return written, fmt.Errorf("failed to write file: %w", err)
+	}
+	if written > size {
+		return written, fmt.Errorf("file %q exceeds its declared size of %d bytes", target, size)
+	}
+	if written > maxBytes {
+		return written, fmt.Errorf("file %q would exceed the maximum allowed uncompressed archive size", target)
+	}
+	return written, nil
 }
 
 func removeCopilot(installDir string) error {

--- a/pkg/cmd/copilot/copilot_test.go
+++ b/pkg/cmd/copilot/copilot_test.go
@@ -269,6 +269,41 @@ func TestExtractTarGz(t *testing.T) {
 	})
 }
 
+func TestExtractFile(t *testing.T) {
+	t.Run("writes content within the declared size and budget", func(t *testing.T) {
+		content := []byte("hello world")
+		target := filepath.Join(t.TempDir(), "out")
+
+		n, err := extractFile(target, 0644, int64(len(content)), 1<<20, bytes.NewReader(content))
+		require.NoError(t, err)
+		require.Equal(t, int64(len(content)), n)
+
+		got, err := os.ReadFile(target)
+		require.NoError(t, err)
+		require.Equal(t, content, got)
+	})
+
+	t.Run("rejects a stream larger than the declared size (decompression bomb guard)", func(t *testing.T) {
+		// The reader yields more bytes than the declared size, simulating a
+		// decompressed stream that overruns what its archive header advertises.
+		target := filepath.Join(t.TempDir(), "out")
+
+		_, err := extractFile(target, 0644, 4, 1<<20, bytes.NewReader([]byte("way too much data")))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds its declared size")
+	})
+
+	t.Run("rejects content exceeding the remaining archive budget", func(t *testing.T) {
+		// The declared per-file size is generous, but only a few bytes of the
+		// whole-archive budget remain, so extraction must abort.
+		target := filepath.Join(t.TempDir(), "out")
+
+		_, err := extractFile(target, 0644, 1<<20, 4, bytes.NewReader([]byte("too much for the budget")))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "maximum allowed uncompressed")
+	})
+}
+
 func TestExtractZip(t *testing.T) {
 	t.Run("extracts files correctly", func(t *testing.T) {
 		zipDir := t.TempDir()


### PR DESCRIPTION
## Description

`gh` extracts zip and tar.gz archives with an unbounded `io.Copy`, so a crafted archive can decompress without limit and exhaust local disk (a "decompression bomb"). This PR bounds extraction.

Affected paths:
- `internal/zip` (`extractZipFile`) — used by `gh run download` and the Copilot installer
- `pkg/cmd/copilot` (`extractFile`) — tar.gz

A `zip` entry reader is not inherently bounded by the central-directory `UncompressedSize64`, so an entry whose decompressed stream overruns its declared size could write unbounded data.

This is a hardening / defense-in-depth change — local disk-exhaustion DoS (e.g. `gh run download` on a run whose artifact, possibly uploaded by a fork PR's workflow, is a bomb). No code execution or data disclosure, so opening as a public PR; happy to move it to a private advisory if you'd prefer.

## What changed

Two bounds, both counting bytes **actually written** (so a lying header can't bypass them):

- **Per-entry:** every extracted file is bounded to its declared uncompressed size via `io.LimitReader` and aborts on overrun. Applied everywhere, including `gh run download`, with **no behavior change for legitimately large artifacts**.
- **Per-archive (opt-in):** `ExtractZipWithLimit` adds a cumulative total-size budget for callers extracting a fixed-size payload; the Copilot installer uses it (2 GiB) for its zip and tar.gz paths.

`internal/zip.ExtractZip` imposes **no** total cap, since artifacts may be arbitrarily large — the per-entry bound is the hardening there.

### Open question for reviewers
Should `gh run download` also get an (overridable) total-size budget? I left it uncapped to avoid breaking legitimately large artifacts, but a config/flag could add belt-and-suspenders if you'd like.

## How tested

- New unit tests: `Test_extractZip_exceedsTotalSizeBudget`, `Test_extractZip_withinTotalSizeBudget`, and `TestExtractFile` (declared-size + budget guards).
- `go test ./internal/zip/... ./pkg/cmd/copilot/...` passes; `go vet` and `golangci-lint run` are clean on the changed packages.
