### PR TITLE
fix(pr edit): use REST API for simple edits to avoid scope issues

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -888,4 +890,27 @@ func ComparePullRequestBaseBranchWith(client *Client, repo ghrepo.Interface, prN
 		return nil, err
 	}
 	return &result.Repository.PullRequest.BaseRef.Compare, nil
+}
+
+// PullRequestUpdateParams contains the parameters for updating a pull request via REST API.
+// Only non-nil fields will be included in the update request.
+type PullRequestUpdateParams struct {
+	Title *string `json:"title,omitempty"`
+	Body  *string `json:"body,omitempty"`
+	Base  *string `json:"base,omitempty"`
+}
+
+// PullRequestUpdateREST updates a pull request using the REST API.
+// This requires only the 'repo' scope, unlike GraphQL mutations which may require
+// additional scopes like 'read:org' when resolving user/team information.
+func PullRequestUpdateREST(client *Client, repo ghrepo.Interface, number int, params PullRequestUpdateParams) error {
+	path := fmt.Sprintf("repos/%s/%s/pulls/%d", repo.RepoOwner(), repo.RepoName(), number)
+
+	body := &bytes.Buffer{}
+	enc := json.NewEncoder(body)
+	if err := enc.Encode(params); err != nil {
+		return err
+	}
+
+	return client.REST(repo.RepoHost(), "PATCH", path, body, nil)
 }

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -266,7 +266,8 @@ func editRun(opts *EditOptions) error {
 	// Fast path: for simple edits (only title/body/base), use REST API directly.
 	// This avoids GraphQL queries that require additional OAuth scopes (read:org)
 	// which aren't necessary for editing your own PR's basic fields.
-	if !opts.Interactive && isSimpleEdit(opts.Editable) {
+	// Only use this path when a PR number is explicitly provided (not current branch mode).
+	if !opts.Interactive && isSimpleEdit(opts.Editable) && opts.SelectorArg != "" {
 		return editRunSimple(opts, httpClient)
 	}
 
@@ -390,13 +391,8 @@ func editRun(opts *EditOptions) error {
 // This path requires only 'repo' scope, avoiding the additional scopes that
 // GraphQL queries need when resolving user information.
 func editRunSimple(opts *EditOptions, httpClient *http.Client) error {
-	baseRepo, err := opts.BaseRepo()
-	if err != nil {
-		return err
-	}
-
-	// Parse PR number from selector
-	prNumber, err := parsePRNumber(opts.SelectorArg, baseRepo)
+	// Parse PR number and repo from selector
+	repo, prNumber, err := parsePRSelector(opts.SelectorArg, opts.BaseRepo)
 	if err != nil {
 		return err
 	}
@@ -415,7 +411,7 @@ func editRunSimple(opts *EditOptions, httpClient *http.Client) error {
 
 	opts.IO.StartProgressIndicator()
 	apiClient := api.NewClientFromHTTP(httpClient)
-	err = api.PullRequestUpdateREST(apiClient, baseRepo, prNumber, params)
+	err = api.PullRequestUpdateREST(apiClient, repo, prNumber, params)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
@@ -423,25 +419,32 @@ func editRunSimple(opts *EditOptions, httpClient *http.Client) error {
 
 	// Print the PR URL
 	fmt.Fprintf(opts.IO.Out, "https://%s/%s/%s/pull/%d\n",
-		baseRepo.RepoHost(), baseRepo.RepoOwner(), baseRepo.RepoName(), prNumber)
+		repo.RepoHost(), repo.RepoOwner(), repo.RepoName(), prNumber)
 
 	return nil
 }
 
-// parsePRNumber extracts the PR number from the selector argument.
-func parsePRNumber(selector string, repo ghrepo.Interface) (int, error) {
-	// If it's a URL, parse it
-	if _, prNumber, _, err := shared.ParseURL(selector); err == nil {
-		return prNumber, nil
+// parsePRSelector extracts the repo and PR number from the selector argument.
+// The selector can be a PR number (with optional # prefix) or a full PR URL.
+func parsePRSelector(selector string, baseRepoFn func() (ghrepo.Interface, error)) (ghrepo.Interface, int, error) {
+	// If it's a URL, parse it to get both repo and number
+	if urlRepo, prNumber, _, err := shared.ParseURL(selector); err == nil {
+		return urlRepo, prNumber, nil
+	}
+
+	// Not a URL, so we need the base repo
+	baseRepo, err := baseRepoFn()
+	if err != nil {
+		return nil, 0, err
 	}
 
 	// Try to parse as a number (with optional # prefix)
 	selector = strings.TrimPrefix(selector, "#")
 	prNumber, err := strconv.Atoi(selector)
 	if err != nil {
-		return 0, fmt.Errorf("could not parse PR number from %q", selector)
+		return nil, 0, fmt.Errorf("could not parse PR number from %q", selector)
 	}
-	return prNumber, nil
+	return baseRepo, prNumber, nil
 }
 
 // reviewerSearchFunc is intended to be an arg for MultiSelectWithSearch

--- a/pkg/cmd/pr/edit/edit.go
+++ b/pkg/cmd/pr/edit/edit.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -243,10 +244,30 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	return cmd
 }
 
+// isSimpleEdit returns true if only title, body, and/or base are being edited.
+// Simple edits can use the REST API which only requires 'repo' scope, avoiding
+// the additional scopes (read:org, read:discussion) that GraphQL queries require
+// when resolving user/team information.
+func isSimpleEdit(e shared.Editable) bool {
+	return !e.Reviewers.Edited &&
+		!e.Assignees.Edited &&
+		!e.Labels.Edited &&
+		!e.Projects.Edited &&
+		!e.Milestone.Edited &&
+		(e.Title.Edited || e.Body.Edited || e.Base.Edited)
+}
+
 func editRun(opts *EditOptions) error {
 	httpClient, err := opts.HttpClient()
 	if err != nil {
 		return err
+	}
+
+	// Fast path: for simple edits (only title/body/base), use REST API directly.
+	// This avoids GraphQL queries that require additional OAuth scopes (read:org)
+	// which aren't necessary for editing your own PR's basic fields.
+	if !opts.Interactive && isSimpleEdit(opts.Editable) {
+		return editRunSimple(opts, httpClient)
 	}
 
 	if opts.Detector == nil {
@@ -363,6 +384,64 @@ func editRun(opts *EditOptions) error {
 	fmt.Fprintln(opts.IO.Out, pr.URL)
 
 	return nil
+}
+
+// editRunSimple handles simple edits (title/body/base only) using REST API.
+// This path requires only 'repo' scope, avoiding the additional scopes that
+// GraphQL queries need when resolving user information.
+func editRunSimple(opts *EditOptions, httpClient *http.Client) error {
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	// Parse PR number from selector
+	prNumber, err := parsePRNumber(opts.SelectorArg, baseRepo)
+	if err != nil {
+		return err
+	}
+
+	// Build update params from editable fields
+	params := api.PullRequestUpdateParams{}
+	if opts.Editable.Title.Edited {
+		params.Title = &opts.Editable.Title.Value
+	}
+	if opts.Editable.Body.Edited {
+		params.Body = &opts.Editable.Body.Value
+	}
+	if opts.Editable.Base.Edited {
+		params.Base = &opts.Editable.Base.Value
+	}
+
+	opts.IO.StartProgressIndicator()
+	apiClient := api.NewClientFromHTTP(httpClient)
+	err = api.PullRequestUpdateREST(apiClient, baseRepo, prNumber, params)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return err
+	}
+
+	// Print the PR URL
+	fmt.Fprintf(opts.IO.Out, "https://%s/%s/%s/pull/%d\n",
+		baseRepo.RepoHost(), baseRepo.RepoOwner(), baseRepo.RepoName(), prNumber)
+
+	return nil
+}
+
+// parsePRNumber extracts the PR number from the selector argument.
+func parsePRNumber(selector string, repo ghrepo.Interface) (int, error) {
+	// If it's a URL, parse it
+	if _, prNumber, _, err := shared.ParseURL(selector); err == nil {
+		return prNumber, nil
+	}
+
+	// Try to parse as a number (with optional # prefix)
+	selector = strings.TrimPrefix(selector, "#")
+	prNumber, err := strconv.Atoi(selector)
+	if err != nil {
+		return 0, fmt.Errorf("could not parse PR number from %q", selector)
+	}
+	return prNumber, nil
 }
 
 // reviewerSearchFunc is intended to be an arg for MultiSelectWithSearch

--- a/pkg/cmd/pr/edit/edit_test.go
+++ b/pkg/cmd/pr/edit/edit_test.go
@@ -1464,3 +1464,130 @@ func TestProjectsV1Deprecation(t *testing.T) {
 		reg.Verify(t)
 	})
 }
+
+func TestIsSimpleEdit(t *testing.T) {
+	tests := []struct {
+		name     string
+		editable shared.Editable
+		want     bool
+	}{
+		{
+			name: "only title edited",
+			editable: shared.Editable{
+				Title: shared.EditableString{Edited: true},
+			},
+			want: true,
+		},
+		{
+			name: "only body edited",
+			editable: shared.Editable{
+				Body: shared.EditableString{Edited: true},
+			},
+			want: true,
+		},
+		{
+			name: "title and body edited",
+			editable: shared.Editable{
+				Title: shared.EditableString{Edited: true},
+				Body:  shared.EditableString{Edited: true},
+			},
+			want: true,
+		},
+		{
+			name: "only base edited",
+			editable: shared.Editable{
+				Base: shared.EditableString{Edited: true},
+			},
+			want: true,
+		},
+		{
+			name: "reviewers edited",
+			editable: shared.Editable{
+				Title:     shared.EditableString{Edited: true},
+				Reviewers: shared.EditableSlice{Edited: true},
+			},
+			want: false,
+		},
+		{
+			name: "assignees edited",
+			editable: shared.Editable{
+				Body:      shared.EditableString{Edited: true},
+				Assignees: shared.EditableSlice{Edited: true},
+			},
+			want: false,
+		},
+		{
+			name: "labels edited",
+			editable: shared.Editable{
+				Title:  shared.EditableString{Edited: true},
+				Labels: shared.EditableSlice{Edited: true},
+			},
+			want: false,
+		},
+		{
+			name: "projects edited",
+			editable: shared.Editable{
+				Body:     shared.EditableString{Edited: true},
+				Projects: shared.EditableProjects{Edited: true},
+			},
+			want: false,
+		},
+		{
+			name: "milestone edited",
+			editable: shared.Editable{
+				Title:     shared.EditableString{Edited: true},
+				Milestone: shared.EditableString{Edited: true},
+			},
+			want: false,
+		},
+		{
+			name:     "nothing edited",
+			editable: shared.Editable{},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSimpleEdit(tt.editable)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEditRunSimple_UsesRESTAPI(t *testing.T) {
+	ios, _, stdout, _ := iostreams.Test()
+
+	reg := &httpmock.Registry{}
+	// Expect a REST PATCH call, NOT a GraphQL query
+	reg.Register(
+		httpmock.REST("PATCH", "repos/cli/cli/pulls/123"),
+		httpmock.StringResponse(`{}`),
+	)
+
+	opts := &EditOptions{
+		IO: ios,
+		HttpClient: func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		},
+		BaseRepo: func() (ghrepo.Interface, error) {
+			return ghrepo.New("cli", "cli"), nil
+		},
+		SelectorArg: "123",
+		Editable: shared.Editable{
+			Body: shared.EditableString{
+				Value:  "new body content",
+				Edited: true,
+			},
+		},
+	}
+
+	err := editRun(opts)
+	require.NoError(t, err)
+
+	// Verify REST was called, not GraphQL
+	reg.Verify(t)
+
+	// Check output contains the PR URL
+	assert.Contains(t, stdout.String(), "cli/cli/pull/123")
+}


### PR DESCRIPTION
## Summary

When editing only title, body, or base of a pull request, the command now uses the REST API directly instead of going through GraphQL.

Fixes #13575

## Problem

`gh pr edit --body` fails with a scope error:

```
GraphQL: Your token has not been granted the required scopes to execute this query.
The 'login' field requires one of the following scopes: ['read:org'], but your token
has only been granted the: ['repo'] scopes.
```

The workaround (REST API) works fine with just `repo` scope:

```bash
curl -X PATCH \
  -H "Authorization: token $(gh auth token)" \
  https://api.github.com/repos/OWNER/REPO/pulls/NUMBER \
  -d '{"body": "new body"}'
```

## Root Cause

The GraphQL query fetches fields like `author` and `reviewRequests` which resolve user/team information requiring additional OAuth scopes (`read:org`, `read:discussion`). These fields aren't needed for simple title/body/base edits.

## Solution

For simple edits (only title, body, and/or base — no reviewers, assignees, labels, projects, or milestone), skip the GraphQL path entirely and use REST's `PATCH /repos/{owner}/{repo}/pulls/{number}` endpoint which only requires `repo` scope.

## Changes

- Add `PullRequestUpdateREST` function in `api/queries_pr.go`
- Add `isSimpleEdit` helper to detect when REST path can be used  
- Add `editRunSimple` function for the REST-based edit flow
- Add tests for the new functionality

## Testing

- Added unit tests for `isSimpleEdit` with various edit combinations
- Added integration test verifying REST API is called for simple edits

---

*Fixed by Renamon 🦊*