### PR TITLE
feat: different exit code for gh pr create when PR already exists

### DIFF
--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -47,6 +47,7 @@ const (
 	exitCancel  exitCode = 2
 	exitAuth    exitCode = 4
 	exitPending exitCode = 8
+	exitPRExists exitCode = 32
 )
 
 func Main() exitCode {
@@ -196,8 +197,12 @@ func Main() exitCode {
 		var noResultsError cmdutil.NoResultsError
 		var extError *root.ExternalCommandExitError
 		var authError *root.AuthError
+		var prExistsError *cmdutil.PRAlreadyExistsError
 		if err == cmdutil.SilentError {
 			return exitError
+		} else if errors.As(err, &prExistsError) {
+			fmt.Fprintln(stderr, prExistsError.Error())
+			return exitPRExists
 		} else if err == cmdutil.PendingError {
 			return exitPending
 		} else if cmdutil.IsUserCancellation(err) {

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -478,8 +478,10 @@ func createRun(opts *CreateOptions) error {
 		return fmt.Errorf("error checking for existing pull request: %w", err)
 	}
 	if err == nil {
-		return fmt.Errorf("a pull request for branch %q into branch %q already exists:\n%s",
-			ctx.PRRefs.QualifiedHeadRef(), ctx.PRRefs.BaseRef(), existingPR.URL)
+		return &cmdutil.PRAlreadyExistsError{
+			Message: fmt.Sprintf("a pull request for branch %q into branch %q already exists:\n%s",
+				ctx.PRRefs.QualifiedHeadRef(), ctx.PRRefs.BaseRef(), existingPR.URL),
+		}
 	}
 
 	message := "\nCreating pull request for %s into %s in %s\n\n"

--- a/pkg/cmdutil/errors.go
+++ b/pkg/cmdutil/errors.go
@@ -40,6 +40,16 @@ var CancelError = errors.New("CancelError")
 // PendingError signals nothing failed but something is pending
 var PendingError = errors.New("PendingError")
 
+// PRAlreadyExistsError signals that a pull request already exists.
+// This uses exit code 32 so scripts can distinguish it from other errors.
+type PRAlreadyExistsError struct {
+	Message string
+}
+
+func (e *PRAlreadyExistsError) Error() string {
+	return e.Message
+}
+
 func IsUserCancellation(err error) bool {
 	return errors.Is(err, CancelError) || errors.Is(err, terminal.InterruptErr)
 }


### PR DESCRIPTION
This came up in #13571. Right now when you run `gh pr create` and the PR already exists, it exits with code 1 just like any other error. That makes it hard to tell in a script whether the command actually failed or if the PR is just already there.

I added a new error type that returns exit code 32 for the already-exists case. That way you can do something like:

```
gh pr create --title "Fix" --body "..."
if [ $? -eq 32 ]; then
  echo "PR already exists, moving on"
fi
```

Let me know if 32 is a bad choice for the exit code. I just picked something higher than the existing ones.