### PR TITLE
Auto-install official extension stubs in CI

### DIFF
--- a/acceptance/testdata/telemetry/telemetry-for-official-extension-stub.txtar
+++ b/acceptance/testdata/telemetry/telemetry-for-official-extension-stub.txtar
@@ -6,10 +6,16 @@
 env GH_TELEMETRY=log
 env GH_TELEMETRY_SAMPLE_RATE=100
 
+# Ensure CI auto-install behavior does not kick in for this test;
+# we want the non-TTY "print install instructions and exit non-zero" path.
+env CI=''
+env BUILD_NUMBER=''
+env RUN_ID=''
+
 # `stack` is registered in extensions.OfficialExtensions. Since no real
-# extension is installed, the hidden stub runs and, in a non-TTY session,
-# prints install instructions without prompting.
-exec gh stack
+# extension is installed, the hidden stub runs and, in a non-TTY session
+# outside CI, prints install instructions and exits non-zero.
+! exec gh stack
 stderr 'gh extension install github/gh-stack'
 
 # The stub invocation records a command_invocation event for the stub's

--- a/pkg/cmd/root/official_extension_stub.go
+++ b/pkg/cmd/root/official_extension_stub.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/ci"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/extensions"
@@ -38,25 +39,27 @@ func NewCmdOfficialExtensionStub(io *iostreams.IOStreams, p prompter.Prompter, e
 func officialExtensionStubRun(io *iostreams.IOStreams, p prompter.Prompter, em extensions.ExtensionManager, ext *extensions.OfficialExtension) error {
 	stderr := io.ErrOut
 
-	if !io.CanPrompt() {
-		fmt.Fprint(stderr, heredoc.Docf(`
-			%[1]s is available as an official extension.
-			To install it, run:
-			  gh extension install %[2]s/%[3]s
-		`, fmt.Sprintf("gh %s", ext.Name), ext.Owner, ext.Repo))
-		return nil
-	}
-
-	prompt := heredoc.Docf(`
-		%[1]s is available as an official extension.
-		Would you like to install it now?
-	`, fmt.Sprintf("gh %s", ext.Name))
-	confirmed, err := p.Confirm(prompt, true)
-	if err != nil {
-		return err
-	}
-	if !confirmed {
-		return nil
+	if !ci.IsCI() {
+		if io.CanPrompt() {
+			prompt := heredoc.Docf(`
+				%[1]s is available as an official extension.
+				Would you like to install it now?
+			`, fmt.Sprintf("gh %s", ext.Name))
+			confirmed, err := p.Confirm(prompt, true)
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				return nil
+			}
+		} else {
+			fmt.Fprint(stderr, heredoc.Docf(`
+				%[1]s is available as an official extension.
+				To install it, run:
+				  gh extension install %[2]s/%[3]s
+			`, fmt.Sprintf("gh %s", ext.Name), ext.Owner, ext.Repo))
+			return cmdutil.SilentError
+		}
 	}
 
 	repo := ext.Repository()

--- a/pkg/cmd/root/official_extension_stub.go
+++ b/pkg/cmd/root/official_extension_stub.go
@@ -39,6 +39,7 @@ func NewCmdOfficialExtensionStub(io *iostreams.IOStreams, p prompter.Prompter, e
 func officialExtensionStubRun(io *iostreams.IOStreams, p prompter.Prompter, em extensions.ExtensionManager, ext *extensions.OfficialExtension) error {
 	stderr := io.ErrOut
 
+	// In CI, skip the prompt so agents and CI runners don't block on Y/n.
 	if !ci.IsCI() {
 		if io.CanPrompt() {
 			prompt := heredoc.Docf(`

--- a/pkg/cmd/root/official_extension_stub_test.go
+++ b/pkg/cmd/root/official_extension_stub_test.go
@@ -18,6 +18,7 @@ func TestOfficialExtensionStubRun(t *testing.T) {
 	tests := []struct {
 		name          string
 		isTTY         bool
+		ciEnv         string
 		confirmResult bool
 		confirmErr    error
 		installErr    error
@@ -26,14 +27,29 @@ func TestOfficialExtensionStubRun(t *testing.T) {
 		wantInstalled bool
 	}{
 		{
-			name:       "non-TTY prints install instructions",
+			name:          "non-TTY in CI auto-installs without prompting",
+			isTTY:         false,
+			ciEnv:         "1",
+			wantStderr:    "Successfully installed github/gh-cool",
+			wantInstalled: true,
+		},
+		{
+			name:       "non-TTY outside CI prints install instructions and returns silent error",
 			isTTY:      false,
 			wantStderr: "gh extension install github/gh-cool",
+			wantErr:    "SilentError",
 		},
 		{
 			name:          "TTY confirmed installs",
 			isTTY:         true,
 			confirmResult: true,
+			wantStderr:    "Successfully installed github/gh-cool",
+			wantInstalled: true,
+		},
+		{
+			name:          "TTY in CI auto-installs without prompting",
+			isTTY:         true,
+			ciEnv:         "1",
 			wantStderr:    "Successfully installed github/gh-cool",
 			wantInstalled: true,
 		},
@@ -60,6 +76,13 @@ func TestOfficialExtensionStubRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CI", "")
+			t.Setenv("BUILD_NUMBER", "")
+			t.Setenv("RUN_ID", "")
+			if tt.ciEnv != "" {
+				t.Setenv("CI", tt.ciEnv)
+			}
+
 			ios, _, _, stderr := iostreams.Test()
 			if tt.isTTY {
 				ios.SetStdinTTY(true)
@@ -97,7 +120,7 @@ func TestOfficialExtensionStubRun(t *testing.T) {
 				assert.Equal(t, "github", repo.RepoOwner())
 				assert.Equal(t, "gh-cool", repo.RepoName())
 				assert.Equal(t, "github.com", repo.RepoHost())
-			} else if tt.isTTY && !tt.confirmResult && tt.confirmErr == nil {
+			} else {
 				assert.Empty(t, em.InstallCalls())
 			}
 		})


### PR DESCRIPTION
### Description

Skip the install prompt when `CI` is detected so official extension stubs (like `gh aw`, `gh stack`) auto-install instead of blocking on `Y/n` in CI runners and agent sessions.

### Key Points

- The previous version of this diff mirrored [`runCopilot`](https://github.com/cli/cli/blob/trunk/pkg/cmd/copilot/copilot.go) exactly: TTY always wins, so a pseudo-TTY agent session with `CI=1` still hung on the prompt. This revision flips the order so `CI` wins over TTY.
- Intentional divergence from `gh copilot`: a follow-up could apply the same change there for consistency, but extension stubs are the more pressing case (agents call `gh <extname>` frequently).
- `CI` is detected via [`ci.IsCI()`](https://github.com/cli/cli/blob/trunk/internal/ci/ci.go) (any of `CI`, `BUILD_NUMBER`, or `RUN_ID`).

### Notes for reviewers

Two commits, reviewable in order:

1. [`fix(extension): auto-install official extension stubs in CI`](https://github.com/cli/cli/pull/13581/commits/ef8c7d8ab5c5539a5279f0c05d2d83d6a39f22be) is the behavior change. The [`official_extension_stub`](https://github.com/cli/cli/blob/ef8c7d8ab5c5539a5279f0c05d2d83d6a39f22be/pkg/cmd/root/official_extension_stub.go) file holds the new branching; the [stub test](https://github.com/cli/cli/blob/ef8c7d8ab5c5539a5279f0c05d2d83d6a39f22be/pkg/cmd/root/official_extension_stub_test.go) extends the existing run-function table test and clears CI env vars per subtest; the [acceptance test](https://github.com/cli/cli/blob/ef8c7d8ab5c5539a5279f0c05d2d83d6a39f22be/acceptance/testdata/telemetry/telemetry-for-official-extension-stub.txtar) clears CI env vars and expects non-zero exit plus install instructions on stderr.
2. [`docs(extension): explain CI bypass in stub install logic`](https://github.com/cli/cli/pull/13581/commits/61a752068e271b699b67bdb39b90a10549adf332) is a one-line comment addressing review feedback that the non-TTY+CI behavior wasn't obvious from the code.

### Additional Context

Manually verified locally with `gh stack` uninstalled. The TTY+CI case is the one this revision actually fixes versus the previous version of the diff:

```
$ CI=1 ./bin/gh stack --help              # TTY + CI
Successfully installed github/gh-stack    # exit 0

$ CI=1 ./bin/gh stack --help < /dev/null  # non-TTY + CI
Successfully installed github/gh-stack    # exit 0

$ ./bin/gh stack --help < /dev/null       # non-TTY, no CI
gh stack is available as an official extension.
To install it, run:
  gh extension install github/gh-stack    # exit 1
```
