### PR TITLE
Clean up deferred issue update helper

### DIFF
--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -449,7 +449,7 @@ func deferredUpdateIssueOptions(client *api.Client, baseRepo ghrepo.Interface, i
 			var err error
 			typeID, err = issueShared.ResolveIssueTypeName(client, baseRepo, opts.IssueType)
 			if err != nil {
-				return updateOpts, err
+				return api.DeferredUpdateIssueOptions{}, err
 			}
 		}
 		updateOpts.IssueTypeID = typeID
@@ -458,7 +458,7 @@ func deferredUpdateIssueOptions(client *api.Client, baseRepo ghrepo.Interface, i
 	if opts.Parent != "" {
 		parentID, err := issueShared.ResolveIssueRef(client, baseRepo, opts.Parent)
 		if err != nil {
-			return updateOpts, fmt.Errorf("resolving --parent reference %q: %w", opts.Parent, err)
+			return api.DeferredUpdateIssueOptions{}, fmt.Errorf("resolving --parent reference %q: %w", opts.Parent, err)
 		}
 		updateOpts.ParentID = parentID
 	}
@@ -466,7 +466,7 @@ func deferredUpdateIssueOptions(client *api.Client, baseRepo ghrepo.Interface, i
 	for _, ref := range opts.BlockedBy {
 		id, err := issueShared.ResolveIssueRef(client, baseRepo, ref)
 		if err != nil {
-			return updateOpts, fmt.Errorf("resolving --blocked-by reference %q: %w", ref, err)
+			return api.DeferredUpdateIssueOptions{}, fmt.Errorf("resolving --blocked-by reference %q: %w", ref, err)
 		}
 		updateOpts.AddBlockedByIDs = append(updateOpts.AddBlockedByIDs, id)
 	}
@@ -474,7 +474,7 @@ func deferredUpdateIssueOptions(client *api.Client, baseRepo ghrepo.Interface, i
 	for _, ref := range opts.Blocking {
 		id, err := issueShared.ResolveIssueRef(client, baseRepo, ref)
 		if err != nil {
-			return updateOpts, fmt.Errorf("resolving --blocking reference %q: %w", ref, err)
+			return api.DeferredUpdateIssueOptions{}, fmt.Errorf("resolving --blocking reference %q: %w", ref, err)
 		}
 		updateOpts.AddBlockingIDs = append(updateOpts.AddBlockingIDs, id)
 	}

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -185,6 +185,12 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 				opts.Editable.IssueType.Edited = true
 			}
 
+			// hasDeferredFlags covers edit flags that flow through the
+			// deferred update path rather than the prShared.Editable struct,
+			// so they would otherwise be invisible to Editable.Dirty() below.
+			// Note that --type (set) is intentionally absent: it lights up
+			// opts.Editable.IssueType.Edited above, which Editable.Dirty()
+			// already picks up. Only --remove-type needs to be listed here.
 			hasDeferredFlags := opts.RemoveIssueType ||
 				flags.Changed("parent") || opts.RemoveParent ||
 				len(opts.AddSubIssues) > 0 || len(opts.RemoveSubIssues) > 0 ||

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -482,7 +482,7 @@ func deferredUpdateIssueOptions(client *api.Client, baseRepo ghrepo.Interface, i
 	} else if editOpts.Parent != "" {
 		parentID, err := issueShared.ResolveIssueRef(client, baseRepo, editOpts.Parent)
 		if err != nil {
-			return updateOpts, fmt.Errorf("resolving --parent reference %q: %w", editOpts.Parent, err)
+			return api.DeferredUpdateIssueOptions{}, fmt.Errorf("resolving --parent reference %q: %w", editOpts.Parent, err)
 		}
 		updateOpts.ParentID = parentID
 	}
@@ -490,14 +490,14 @@ func deferredUpdateIssueOptions(client *api.Client, baseRepo ghrepo.Interface, i
 	for _, ref := range editOpts.AddSubIssues {
 		id, err := issueShared.ResolveIssueRef(client, baseRepo, ref)
 		if err != nil {
-			return updateOpts, fmt.Errorf("resolving --add-sub-issue reference %q: %w", ref, err)
+			return api.DeferredUpdateIssueOptions{}, fmt.Errorf("resolving --add-sub-issue reference %q: %w", ref, err)
 		}
 		updateOpts.AddSubIssueIDs = append(updateOpts.AddSubIssueIDs, id)
 	}
 	for _, ref := range editOpts.RemoveSubIssues {
 		id, err := issueShared.ResolveIssueRef(client, baseRepo, ref)
 		if err != nil {
-			return updateOpts, fmt.Errorf("resolving --remove-sub-issue reference %q: %w", ref, err)
+			return api.DeferredUpdateIssueOptions{}, fmt.Errorf("resolving --remove-sub-issue reference %q: %w", ref, err)
 		}
 		updateOpts.RemoveSubIssueIDs = append(updateOpts.RemoveSubIssueIDs, id)
 	}
@@ -505,14 +505,14 @@ func deferredUpdateIssueOptions(client *api.Client, baseRepo ghrepo.Interface, i
 	for _, ref := range editOpts.AddBlockedBy {
 		id, err := issueShared.ResolveIssueRef(client, baseRepo, ref)
 		if err != nil {
-			return updateOpts, fmt.Errorf("resolving --add-blocked-by reference %q: %w", ref, err)
+			return api.DeferredUpdateIssueOptions{}, fmt.Errorf("resolving --add-blocked-by reference %q: %w", ref, err)
 		}
 		updateOpts.AddBlockedByIDs = append(updateOpts.AddBlockedByIDs, id)
 	}
 	for _, ref := range editOpts.RemoveBlockedBy {
 		id, err := issueShared.ResolveIssueRef(client, baseRepo, ref)
 		if err != nil {
-			return updateOpts, fmt.Errorf("resolving --remove-blocked-by reference %q: %w", ref, err)
+			return api.DeferredUpdateIssueOptions{}, fmt.Errorf("resolving --remove-blocked-by reference %q: %w", ref, err)
 		}
 		updateOpts.RemoveBlockedByIDs = append(updateOpts.RemoveBlockedByIDs, id)
 	}
@@ -520,14 +520,14 @@ func deferredUpdateIssueOptions(client *api.Client, baseRepo ghrepo.Interface, i
 	for _, ref := range editOpts.AddBlocking {
 		id, err := issueShared.ResolveIssueRef(client, baseRepo, ref)
 		if err != nil {
-			return updateOpts, fmt.Errorf("resolving --add-blocking reference %q: %w", ref, err)
+			return api.DeferredUpdateIssueOptions{}, fmt.Errorf("resolving --add-blocking reference %q: %w", ref, err)
 		}
 		updateOpts.AddBlockingIDs = append(updateOpts.AddBlockingIDs, id)
 	}
 	for _, ref := range editOpts.RemoveBlocking {
 		id, err := issueShared.ResolveIssueRef(client, baseRepo, ref)
 		if err != nil {
-			return updateOpts, fmt.Errorf("resolving --remove-blocking reference %q: %w", ref, err)
+			return api.DeferredUpdateIssueOptions{}, fmt.Errorf("resolving --remove-blocking reference %q: %w", ref, err)
 		}
 		updateOpts.RemoveBlockingIDs = append(updateOpts.RemoveBlockingIDs, id)
 	}


### PR DESCRIPTION
### Description

Address two unresolved review threads from [#13411](https://github.com/cli/cli/pull/13411): tighten the `deferredUpdateIssueOptions` helper to stop returning a partial struct on error, and document the asymmetric handling of `--type` and `--remove-type` in `gh issue edit`.

### Key Points

- The helper in [`pkg/cmd/issue/create/create.go`](https://github.com/cli/cli/blob/trunk/pkg/cmd/issue/create/create.go) and [`pkg/cmd/issue/edit/edit.go`](https://github.com/cli/cli/blob/trunk/pkg/cmd/issue/edit/edit.go) used to return a partially-populated `api.DeferredUpdateIssueOptions` alongside the error on every failure path. Callers already discard the struct when err is non-nil, so the partial value was invisible in practice but invited future misuse. The fix returns a zero-value struct on error so the contract matches reality.
- The `hasDeferredFlags` block in `gh issue edit` lists `--remove-type` but not `--type`. That is intentional (the set form flows through `Editable.IssueType.Edited` and is picked up by `Editable.Dirty()`), but the split is non-obvious. A comment now makes the reasoning explicit.

### Notes for reviewers

Two atomic commits, both reviewable on their own:

1. `refactor(issue): drop half-baked return value from deferredUpdateIssueOptions` - the contract tightening across `create.go` and `edit.go`.
2. `docs(issue): clarify --type handling in edit hasDeferredFlags` - comment only, no behavior change.

No new tests: the refactor preserves end-to-end behavior, and existing run-function table tests (`Test_createRun`, `Test_editRun`) already cover the affected paths.

### Additional Context

- #13411 is the merged PR where these threads originated; this PR closes out the two follow-ups that were deferred at merge time.