### PR TITLE
issue list: add flag to show assignees

### DIFF
--- a/pkg/cmd/issue/list/fixtures/issueListWithAssignees.json
+++ b/pkg/cmd/issue/list/fixtures/issueListWithAssignees.json
@@ -1,0 +1,76 @@
+{
+  "data": {
+    "repository": {
+      "hasIssuesEnabled": true,
+      "issues": {
+        "totalCount": 3,
+        "nodes": [
+          {
+            "number": 1,
+            "title": "issue with no assignees",
+            "url": "https://github.com/OWNER/REPO/issues/1",
+            "updatedAt": "2022-08-24T22:01:12Z",
+            "labels": {
+              "nodes": [],
+              "totalCount": 0
+            },
+            "assignees": {
+              "nodes": [],
+              "totalCount": 0
+            }
+          },
+          {
+            "number": 2,
+            "title": "issue with one assignee",
+            "url": "https://github.com/OWNER/REPO/issues/2",
+            "updatedAt": "2022-07-20T19:01:12Z",
+            "labels": {
+              "nodes": [],
+              "totalCount": 0
+            },
+            "assignees": {
+              "nodes": [
+                {
+                  "id": "U_1",
+                  "login": "alice",
+                  "name": "Alice"
+                }
+              ],
+              "totalCount": 1
+            }
+          },
+          {
+            "number": 3,
+            "title": "issue with multiple assignees",
+            "url": "https://github.com/OWNER/REPO/issues/3",
+            "updatedAt": "2020-01-26T19:01:12Z",
+            "labels": {
+              "nodes": [],
+              "totalCount": 0
+            },
+            "assignees": {
+              "nodes": [
+                {
+                  "id": "U_1",
+                  "login": "alice",
+                  "name": "Alice"
+                },
+                {
+                  "id": "U_2",
+                  "login": "bob",
+                  "name": "Bob"
+                },
+                {
+                  "id": "U_3",
+                  "login": "charlie",
+                  "name": "Charlie"
+                }
+              ],
+              "totalCount": 3
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -29,17 +29,18 @@ type ListOptions struct {
 	BaseRepo   func() (ghrepo.Interface, error)
 	Browser    browser.Browser
 
-	Assignee     string
-	Labels       []string
-	State        string
-	LimitResults int
-	Author       string
-	Mention      string
-	Milestone    string
-	Search       string
-	IssueType    string
-	WebMode      bool
-	Exporter     cmdutil.Exporter
+	Assignee      string
+	Labels        []string
+	State         string
+	LimitResults  int
+	Author        string
+	Mention       string
+	Milestone     string
+	Search        string
+	IssueType     string
+	WebMode       bool
+	ShowAssignees bool
+	Exporter      cmdutil.Exporter
 
 	Detector fd.Detector
 	Now      func() time.Time
@@ -79,6 +80,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			$ gh issue list --search "error no:assignee sort:created-asc"
 			$ gh issue list --state all
 			$ gh issue list --type Bug
+			$ gh issue list --show-assignees
 		`),
 		Aliases: []string{"ls"},
 		Args:    cmdutil.NoArgsQuoteReminder,
@@ -116,6 +118,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter by milestone number or title")
 	cmd.Flags().StringVarP(&opts.Search, "search", "S", "", "Search issues with `query`")
 	cmd.Flags().StringVar(&opts.IssueType, "type", "", "Filter by issue type `name`")
+	cmd.Flags().BoolVar(&opts.ShowAssignees, "show-assignees", false, "Show assignees in issue list output")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.IssueFields)
 
 	return cmd
@@ -151,6 +154,9 @@ func listRun(opts *ListOptions) error {
 		opts.Detector = fd.NewDetector(cachedClient, baseRepo.RepoHost())
 	}
 	fields := append(defaultFields, "stateReason")
+	if opts.ShowAssignees {
+		fields = append(fields, "assignees")
+	}
 
 	filterOptions := prShared.FilterOptions{
 		Entity:    "issue",
@@ -223,7 +229,7 @@ func listRun(opts *ListOptions) error {
 		fmt.Fprintf(opts.IO.Out, "\n%s\n\n", title)
 	}
 
-	issueShared.PrintIssues(opts.IO, opts.Now(), "", len(listResult.Issues), listResult.Issues)
+	issueShared.PrintIssues(opts.IO, opts.Now(), "", len(listResult.Issues), listResult.Issues, opts.ShowAssignees)
 
 	return nil
 }

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -41,6 +41,15 @@ func TestNewCmdList(t *testing.T) {
 				LimitResults: 30,
 			},
 		},
+		{
+			name: "show-assignees flag",
+			cli:  "--show-assignees",
+			wants: ListOptions{
+				ShowAssignees: true,
+				State:         "open",
+				LimitResults:  30,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -67,6 +76,7 @@ func TestNewCmdList(t *testing.T) {
 			require.NotNil(t, gotOpts)
 
 			assert.Equal(t, tt.wants.IssueType, gotOpts.IssueType)
+			assert.Equal(t, tt.wants.ShowAssignees, gotOpts.ShowAssignees)
 			assert.Equal(t, tt.wants.State, gotOpts.State)
 			assert.Equal(t, tt.wants.LimitResults, gotOpts.LimitResults)
 		})
@@ -160,6 +170,31 @@ func TestIssueList_tty(t *testing.T) {
 		#1  number won   label   about 1 day ago
 		#2  number too   label   about 1 month ago
 		#4  number fore  label   about 2 years ago
+	`), output.String())
+	assert.Equal(t, ``, output.Stderr())
+}
+
+func TestIssueList_tty_withShowAssignees(t *testing.T) {
+	http := &httpmock.Registry{}
+	defer http.Verify(t)
+
+	http.Register(
+		httpmock.GraphQL(`query IssueList\b`),
+		httpmock.FileResponse("./fixtures/issueListWithAssignees.json"))
+
+	output, err := runCommand(http, true, "--show-assignees")
+	if err != nil {
+		t.Errorf("error running command `issue list --show-assignees`: %v", err)
+	}
+
+	assert.Equal(t, heredoc.Doc(`
+
+		Showing 3 of 3 open issues in OWNER/REPO
+
+		ID  TITLE                          LABELS  UPDATED            ASSIGNEES
+		#1  issue with no assignees                about 1 day ago    -
+		#2  issue with one assignee                about 1 month ago  alice
+		#3  issue with multiple assignees          about 2 years ago  alice+2
 	`), output.String())
 	assert.Equal(t, ``, output.Stderr())
 }

--- a/pkg/cmd/issue/shared/display.go
+++ b/pkg/cmd/issue/shared/display.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cli/cli/v2/pkg/iostreams"
 )
 
-func PrintIssues(io *iostreams.IOStreams, now time.Time, prefix string, totalCount int, issues []api.Issue) {
+func PrintIssues(io *iostreams.IOStreams, now time.Time, prefix string, totalCount int, issues []api.Issue, showAssignees bool) {
 	cs := io.ColorScheme()
 	isTTY := io.IsStdoutTTY()
 	headers := []string{"ID"}
@@ -25,6 +25,9 @@ func PrintIssues(io *iostreams.IOStreams, now time.Time, prefix string, totalCou
 		"LABELS",
 		"UPDATED",
 	)
+	if showAssignees {
+		headers = append(headers, "ASSIGNEES")
+	}
 	table := tableprinter.New(io, tableprinter.WithHeader(headers...))
 	for _, issue := range issues {
 		issueNum := strconv.Itoa(issue.Number)
@@ -39,6 +42,9 @@ func PrintIssues(io *iostreams.IOStreams, now time.Time, prefix string, totalCou
 		table.AddField(text.RemoveExcessiveWhitespace(issue.Title))
 		table.AddField(issueLabelList(&issue, cs, isTTY))
 		table.AddTimeField(now, issue.UpdatedAt, cs.Muted)
+		if showAssignees {
+			table.AddField(formatAssignees(&issue))
+		}
 		table.EndRow()
 	}
 	_ = table.Render()
@@ -46,6 +52,17 @@ func PrintIssues(io *iostreams.IOStreams, now time.Time, prefix string, totalCou
 	if remaining > 0 {
 		fmt.Fprintf(io.Out, cs.Muted("%sAnd %d more\n"), prefix, remaining)
 	}
+}
+
+func formatAssignees(issue *api.Issue) string {
+	count := len(issue.Assignees.Nodes)
+	if count == 0 {
+		return "-"
+	}
+	if count == 1 {
+		return issue.Assignees.Nodes[0].Login
+	}
+	return fmt.Sprintf("%s+%d", issue.Assignees.Nodes[0].Login, count-1)
 }
 
 func issueLabelList(issue *api.Issue, cs *iostreams.ColorScheme, colorize bool) string {

--- a/pkg/cmd/issue/shared/display_test.go
+++ b/pkg/cmd/issue/shared/display_test.go
@@ -1,0 +1,71 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatAssignees(t *testing.T) {
+	tests := []struct {
+		name     string
+		issue    *api.Issue
+		expected string
+	}{
+		{
+			name: "no assignees",
+			issue: &api.Issue{
+				Assignees: api.Assignees{
+					Nodes: []api.GitHubUser{},
+				},
+			},
+			expected: "-",
+		},
+		{
+			name: "one assignee",
+			issue: &api.Issue{
+				Assignees: api.Assignees{
+					Nodes: []api.GitHubUser{
+						{Login: "alice"},
+					},
+				},
+			},
+			expected: "alice",
+		},
+		{
+			name: "two assignees",
+			issue: &api.Issue{
+				Assignees: api.Assignees{
+					Nodes: []api.GitHubUser{
+						{Login: "alice"},
+						{Login: "bob"},
+					},
+				},
+			},
+			expected: "alice+1",
+		},
+		{
+			name: "three assignees",
+			issue: &api.Issue{
+				Assignees: api.Assignees{
+					Nodes: []api.GitHubUser{
+						{Login: "alice"},
+						{Login: "bob"},
+						{Login: "charlie"},
+					},
+				},
+			},
+			expected: "alice+2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatAssignees(tt.issue)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Made with Bob

--- a/pkg/cmd/issue/status/status.go
+++ b/pkg/cmd/issue/status/status.go
@@ -112,7 +112,7 @@ func statusRun(opts *StatusOptions) error {
 
 	prShared.PrintHeader(opts.IO, "Issues assigned to you")
 	if issuePayload.Assigned.TotalCount > 0 {
-		issueShared.PrintIssues(opts.IO, time.Now(), "  ", issuePayload.Assigned.TotalCount, issuePayload.Assigned.Issues)
+		issueShared.PrintIssues(opts.IO, time.Now(), "  ", issuePayload.Assigned.TotalCount, issuePayload.Assigned.Issues, false)
 	} else {
 		message := "  There are no issues assigned to you"
 		prShared.PrintMessage(opts.IO, message)
@@ -121,7 +121,7 @@ func statusRun(opts *StatusOptions) error {
 
 	prShared.PrintHeader(opts.IO, "Issues mentioning you")
 	if issuePayload.Mentioned.TotalCount > 0 {
-		issueShared.PrintIssues(opts.IO, time.Now(), "  ", issuePayload.Mentioned.TotalCount, issuePayload.Mentioned.Issues)
+		issueShared.PrintIssues(opts.IO, time.Now(), "  ", issuePayload.Mentioned.TotalCount, issuePayload.Mentioned.Issues, false)
 	} else {
 		prShared.PrintMessage(opts.IO, "  There are no issues mentioning you")
 	}
@@ -129,7 +129,7 @@ func statusRun(opts *StatusOptions) error {
 
 	prShared.PrintHeader(opts.IO, "Issues opened by you")
 	if issuePayload.Authored.TotalCount > 0 {
-		issueShared.PrintIssues(opts.IO, time.Now(), "  ", issuePayload.Authored.TotalCount, issuePayload.Authored.Issues)
+		issueShared.PrintIssues(opts.IO, time.Now(), "  ", issuePayload.Authored.TotalCount, issuePayload.Authored.Issues, false)
 	} else {
 		prShared.PrintMessage(opts.IO, "  There are no issues opened by you")
 	}


### PR DESCRIPTION
## Summary

This PR adds an opt-in `--show-assignees` flag to `gh issue list`.

When the flag is provided, the default table output includes a new `ASSIGNEES` column. Existing `gh issue list` output remains unchanged when the flag is omitted.

Fixes #8744.

## Motivation

`gh issue list` currently allows filtering by assignee using `--assignee`, and assignee data is available through `--json assignees`, but the default table output does not show who an issue is assigned to.

This makes it harder to quickly scan issue ownership from the terminal, especially for maintainers triaging many issues. Users currently need to open the web UI or use `--json`/`--jq` to see assignee information.

This PR adds a small opt-in flag so users can view assignees directly in the normal issue list output without changing the default behavior.

## Behavior

Default output remains unchanged:

```bash
gh issue list --repo cli/cli --limit 5
```

With the new flag:

```bash
gh issue list --repo cli/cli --limit 5 --show-assignees
```

Example output:

```text
ID      TITLE                                      LABELS        UPDATED          ASSIGNEES
#123    Example issue with no assignee             bug           about 1 day ago  -
#124    Example issue with one assignee            enhancement   about 2 days ago alice
#125    Example issue with multiple assignees       help wanted   about 3 days ago alice+2
```

Assignee display format:

* no assignees: `-`
* one assignee: `login`
* multiple assignees: `firstLogin+N`

## Manual verification

Verified default output remains unchanged:

```bash
./bin/gh issue list --repo cli/cli --limit 5
```

Verified the new `ASSIGNEES` column is shown only when requested:

```bash
./bin/gh issue list --repo cli/cli --limit 5 --show-assignees
```

Verified multiple-assignee formatting using a Kubernetes issue with multiple assignees:

```bash
./bin/gh issue list --repo kubernetes/kubernetes --state all --search "138149" --show-assignees
```

Observed output included:

```text
ID       TITLE                                                            LABELS                                                          UPDATED          ASSIGNEES
#138149  Migrate DRA components to support granular authorization on ...  sig/network, sig/node, sig/auth, help wanted, good first is...  about 1 day ago  praveen0raj+9
```

Verified JSON output still works:

```bash
./bin/gh issue list --repo cli/cli --limit 5 --json number,title,assignees
```

## Tests

Added/updated tests for:

* parsing the new `--show-assignees` flag
* rendering issue list output with the `ASSIGNEES` column
* formatting no assignees as `-`
* formatting one assignee as `login`
* formatting multiple assignees as `firstLogin+N`
* preserving existing behavior for callers that do not request assignee output

Test commands run:

```bash
go test ./pkg/cmd/issue/list
go test ./pkg/cmd/issue/shared
go test ./pkg/cmd/issue/status
go test ./pkg/cmd/issue/...
go build -o ./bin/gh ./cmd/gh
```
