### PR TITLE
Handle interrupt signals through gh root context

### DIFF
--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -139,7 +140,9 @@ func Main() exitCode {
 		}
 	}
 
-	ctx := context.Background()
+	ctx, stopInterrupts := interruptContext(context.Background(), signal.NotifyContext)
+	defer stopInterrupts()
+
 	updateCtx, updateCancel := context.WithCancel(ctx)
 	defer updateCancel()
 	updateMessageChan := make(chan *update.ReleaseInfo)
@@ -200,7 +203,7 @@ func Main() exitCode {
 			return exitError
 		} else if err == cmdutil.PendingError {
 			return exitPending
-		} else if cmdutil.IsUserCancellation(err) {
+		} else if isCancelError(err) {
 			if errors.Is(err, terminal.InterruptErr) {
 				// ensure the next shell prompt will start on its own line
 				fmt.Fprint(stderr, "\n")
@@ -270,6 +273,21 @@ func Main() exitCode {
 	}
 
 	return exitOK
+}
+
+type signalNotifyContextFunc func(context.Context, ...os.Signal) (context.Context, context.CancelFunc)
+
+func interruptContext(parent context.Context, notify signalNotifyContextFunc) (context.Context, context.CancelFunc) {
+	ctx, stop := notify(parent, os.Interrupt)
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
+	return ctx, stop
+}
+
+func isCancelError(err error) bool {
+	return errors.Is(err, context.Canceled) || cmdutil.IsUserCancellation(err)
 }
 
 // isExtensionCommand returns true if args resolve to an extension command.

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -2,11 +2,15 @@ package ghcmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net"
 	"net/url"
+	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/config"
@@ -82,6 +86,52 @@ check your internet connection or https://githubstatus.com
 			}
 		})
 	}
+}
+
+func Test_interruptContext(t *testing.T) {
+	sourceCtx, cancelSource := context.WithCancel(context.Background())
+	defer cancelSource()
+
+	var gotSignals []os.Signal
+	var stopOnce sync.Once
+	stopCalled := make(chan struct{})
+	notify := func(_ context.Context, signals ...os.Signal) (context.Context, context.CancelFunc) {
+		gotSignals = append(gotSignals, signals...)
+		return sourceCtx, func() {
+			stopOnce.Do(func() {
+				close(stopCalled)
+			})
+		}
+	}
+
+	ctx, stop := interruptContext(context.Background(), notify)
+	defer stop()
+
+	assert.Equal(t, []os.Signal{os.Interrupt}, gotSignals)
+	assert.NoError(t, ctx.Err())
+
+	cancelSource()
+
+	select {
+	case <-stopCalled:
+	case <-time.After(time.Second):
+		t.Fatal("expected interrupt signal notification to stop after context cancellation")
+	}
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+func Test_contextCanceledUsesCancelExitCode(t *testing.T) {
+	t.Run("context canceled", func(t *testing.T) {
+		assert.True(t, isCancelError(context.Canceled))
+	})
+
+	t.Run("user cancellation", func(t *testing.T) {
+		assert.True(t, isCancelError(cmdutil.CancelError))
+	})
+
+	t.Run("other error", func(t *testing.T) {
+		assert.False(t, isCancelError(errors.New("boom")))
+	})
 }
 
 func Test_newIOStreams_pager(t *testing.T) {


### PR DESCRIPTION
Fixes #13401.

`ghcmd.Main` already runs Cobra with a context, but that context was `context.Background()`. Ctrl+C could still use the default interrupt behavior, which can exit before deferred cleanup such as telemetry flushing runs.

This derives the root context from `signal.NotifyContext` for `os.Interrupt`, then treats `context.Canceled` as the existing cancel exit path. After the first interrupt cancels the context, signal notification is stopped so a second interrupt can still terminate normally.

Tested with:
- `go test -p 1 ./internal/ghcmd -run "Test_interruptContext|Test_contextCanceledUsesCancelExitCode" -count=1 -v`
- `go test -p 1 ./internal/ghcmd -skip "Test_executable|Test_executable_relative" -count=1`

The unskipped package run fails locally on Windows because `Test_executable` and `Test_executable_relative` create symlinks and this shell does not have that privilege.