### PR TITLE
browse: disambiguate decimal-only short hashes

### DIFF
--- a/pkg/cmd/browse/browse.go
+++ b/pkg/cmd/browse/browse.go
@@ -3,6 +3,7 @@ package browse
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/browser"
+	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/cmdutil"
@@ -249,6 +251,24 @@ func parseSection(baseRepo ghrepo.Interface, opts *BrowseOptions) (string, error
 		if opts.SelectorArg == "" {
 			return "", nil
 		}
+		if strings.HasPrefix(opts.SelectorArg, "#") && isNumber(opts.SelectorArg) {
+			return fmt.Sprintf("issues/%s", strings.TrimPrefix(opts.SelectorArg, "#")), nil
+		}
+		if isNumber(opts.SelectorArg) && isCommit(opts.SelectorArg) {
+			httpClient, err := opts.HttpClient()
+			if err != nil {
+				return "", err
+			}
+
+			isCommitRef, err := commitRefExists(httpClient, baseRepo, opts.SelectorArg)
+			if err != nil {
+				return "", err
+			}
+			if isCommitRef {
+				return fmt.Sprintf("commit/%s", opts.SelectorArg), nil
+			}
+			return fmt.Sprintf("issues/%s", opts.SelectorArg), nil
+		}
 		if isNumber(opts.SelectorArg) {
 			return fmt.Sprintf("issues/%s", strings.TrimPrefix(opts.SelectorArg, "#")), nil
 		}
@@ -352,6 +372,34 @@ var commitHash = regexp.MustCompile(`\A[a-f0-9]{7,64}\z`)
 
 func isCommit(arg string) bool {
 	return commitHash.MatchString(arg)
+}
+
+func commitRefExists(httpClient *http.Client, baseRepo ghrepo.Interface, ref string) (bool, error) {
+	path := fmt.Sprintf("%srepos/%s/%s/commits/%s", ghinstance.RESTPrefix(baseRepo.RepoHost()), baseRepo.RepoOwner(), baseRepo.RepoName(), ref)
+	req, err := http.NewRequest("GET", path, nil)
+	if err != nil {
+		return false, err
+	}
+
+	req.Header.Set("Accept", "application/vnd.github.v3.sha")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 || resp.StatusCode == 422 {
+		return false, nil
+	}
+	if resp.StatusCode > 299 {
+		return false, api.HandleHTTPError(resp)
+	}
+
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // gitClient is used to implement functions that can be performed on both local and remote git repositories

--- a/pkg/cmd/browse/browse_test.go
+++ b/pkg/cmd/browse/browse_test.go
@@ -357,6 +357,45 @@ func Test_runBrowse(t *testing.T) {
 			expectedURL: "https://github.com/kevin/MinTy/issues/217",
 		},
 		{
+			name: "decimal-only short hash in selector arg resolves to remote commit",
+			opts: BrowseOptions{
+				SelectorArg: "309628980",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/bchadwic/test/commits/309628980"),
+					httpmock.StringResponse("309628980abcdef"),
+				)
+			},
+			baseRepo:    ghrepo.New("bchadwic", "test"),
+			expectedURL: "https://github.com/bchadwic/test/commit/309628980",
+			wantsErr:    false,
+		},
+		{
+			name: "decimal-only short hash in selector arg falls back to issue when remote commit does not exist",
+			opts: BrowseOptions{
+				SelectorArg: "1234567",
+			},
+			httpStub: func(r *httpmock.Registry) {
+				r.Register(
+					httpmock.REST("GET", "repos/bchadwic/test/commits/1234567"),
+					httpmock.StatusStringResponse(422, "Unprocessable Entity"),
+				)
+			},
+			baseRepo:    ghrepo.New("bchadwic", "test"),
+			expectedURL: "https://github.com/bchadwic/test/issues/1234567",
+			wantsErr:    false,
+		},
+		{
+			name: "issue with hashtag forces issue over decimal-only short hash",
+			opts: BrowseOptions{
+				SelectorArg: "#309628980",
+			},
+			baseRepo:    ghrepo.New("bchadwic", "test"),
+			expectedURL: "https://github.com/bchadwic/test/issues/309628980",
+			wantsErr:    false,
+		},
+		{
 			name: "branch flag",
 			opts: BrowseOptions{
 				Branch: "trunk",


### PR DESCRIPTION
Fixes #12357

## Summary
- treat `#<digits>` as an explicit issue selector before any commit disambiguation
- check the repo commit API only for ambiguous decimal-only selectors that also match short SHA length
- add browse tests for the remote-commit, issue-fallback, and forced-issue cases from the acceptance criteria

## Testing
- Unable to run `go test ./pkg/cmd/browse` in this environment because the `go` toolchain is not installed on the host