### PR TITLE
Alias `gh extension uninstall` to `gh extension remove`

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -458,9 +458,10 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 			return cmd
 		}(),
 		&cobra.Command{
-			Use:   "remove <name>",
-			Short: "Remove an installed extension",
-			Args:  cobra.ExactArgs(1),
+			Use:     "remove <name>",
+			Short:   "Remove an installed extension",
+			Aliases: []string{"uninstall"},
+			Args:    cobra.ExactArgs(1),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				extName := normalizeExtensionSelector(args[0])
 				if err := m.Remove(extName); err != nil {


### PR DESCRIPTION
### Description

Registers `uninstall` as an official cobra alias of `gh extension remove` so it shows up in `--help` and pairs naturally with `gh extension install`.

### Key Points

- Adds `Aliases: []string{"uninstall"}` to the `remove` subcommand in the [extension command file](https://github.com/cli/cli/blob/6b867633f3cc10cf97c6f8b3cc95108fc61bd6a0/pkg/cmd/extension/command.go#L460-L465). Cobra surfaces it under `ALIASES` in `--help` automatically.
- `remove` stays the canonical name, so docs and the acceptance txtar are untouched.
- No new unit test: the alias is one declarative cobra field with no branching, and existing `remove` cases cover the RunE.

### Notes for reviewers

Single-commit PR, one file touched. Manual sanity check after building:

```
$ gh extension remove --help
...
ALIASES
  gh ext uninstall, gh extension uninstall, gh extensions uninstall
```

### Additional Context

- Closes [cli/cli#13598](https://github.com/cli/cli/issues/13598). The issue lays out the motivation: `install` / `uninstall` is the more discoverable pairing, and aliasing avoids a breaking rename of `remove`.