### PR TITLE
fix: honor --pin when --force is specified on extension install

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -378,8 +378,16 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 
 					if ext, err := checkValidExtension(cmd.Root(), m, repo.RepoName(), repo.RepoOwner()); err != nil {
 						// If an existing extension was found and --force was specified, attempt to upgrade.
+						// However, if --pin is also set, we should reinstall with the pin rather than
+						// upgrading, since the user explicitly requested a specific version.
 						if forceFlag && ext != nil {
-							return upgradeFunc(ext.Name(), forceFlag)
+							if pinFlag != "" {
+								if err := m.Remove(ext.Name()); err != nil {
+									return err
+								}
+							} else {
+								return upgradeFunc(ext.Name(), forceFlag)
+							}
 						}
 
 						if errors.Is(err, alreadyInstalledError) {


### PR DESCRIPTION
`gh extension install OWNER/REPO --pin <tag> --force` ignores the pin when the extension is already installed. The `--force` flag routes to the upgrade path, which installs latest instead of the specified tag.

The fix passes the pin tag through to the upgrade path so `--force` respects `--pin`.

Fixes #13602