### PR TITLE
UI: Enhance 'repo view' with clean visual hierarchy and padding

### DIFF
--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -163,13 +163,19 @@ func viewRun(opts *ViewOptions) error {
 		return nil
 	}
 
+	// Upgraded template using clean, structured spacing, explicit labels, and visual zones
 	repoTmpl := heredoc.Doc(`
-		{{.FullName}}
-		{{.Description}}
+		
+		{{.LabelRepository}} {{.FullName}}
+		{{.LabelAbout}}      {{.Description}}
 
-		{{.Readme}}
+		{{.Divider}}
 
-		{{.View}}
+{{.Readme}}
+
+		{{.Divider}}
+		  {{.View}}
+		
 	`)
 
 	tmpl, err := template.New("repo").Parse(repoTmpl)
@@ -181,7 +187,7 @@ func viewRun(opts *ViewOptions) error {
 
 	var readmeContent string
 	if readme == nil {
-		readmeContent = cs.Muted("This repository does not have a README")
+		readmeContent = "  " + cs.Muted("This repository does not have a README")
 	} else if isMarkdownFile(readme.Filename) {
 		var err error
 		readmeContent, err = markdown.Render(readme.Content,
@@ -200,16 +206,23 @@ func viewRun(opts *ViewOptions) error {
 		description = cs.Muted("No description provided")
 	}
 
+	// Populating our ultra-minimal structured template data
 	repoData := struct {
-		FullName    string
-		Description string
-		Readme      string
-		View        string
+		LabelRepository string
+		LabelAbout      string
+		FullName        string
+		Description     string
+		Divider         string
+		Readme          string
+		View            string
 	}{
-		FullName:    cs.Bold(fullName),
-		Description: description,
-		Readme:      readmeContent,
-		View:        cs.Mutedf("View this repository on GitHub: %s", openURL),
+		LabelRepository: cs.Muted("» repository:"),
+		LabelAbout:      cs.Muted("» about:     "),
+		FullName:        cs.Bold(fullName),
+		Description:     description,
+		Divider:         cs.Muted("────────────────────────────────────────────────────────────"),
+		Readme:          readmeContent,
+		View:            cs.Mutedf("🔗 View on web: %s", openURL),
 	}
 
 	return tmpl.Execute(stdout, repoData)


### PR DESCRIPTION
Fixes #13608

What does this PR do?
This PR upgrades the terminal UI for gh repo view, transitioning the output from a dense block of raw text into a sleek, highly readable format.

Why is this needed? (The DevEx problem)
Currently, the command dumps the repository description and README into the terminal with no separation or padding. This creates unnecessary cognitive load and eye strain for developers trying to scan the repository details quickly.

The Solution
Structured Padding: Added vertical margins to give the interface necessary breathing room.

Muted Labels: Introduced explicit, muted key-value markers (» repository:, » about:) using cs.Muted().

Visual Zoning: Implemented clean geometric dividers to box in the README content, preventing it from bleeding into system messages.

By muting the structural elements, the actual repository data visually pops, bringing the terminal output up to modern, hyper-professional developer tool standards.
<img width="1252" height="625" alt="Screenshot 2026-06-07 162614" src="https://github.com/user-attachments/assets/6d62d34c-aa77-483f-9d58-5ffa8c1a2240" />
<img width="1249" height="626" alt="Screenshot 2026-06-07 162642" src="https://github.com/user-attachments/assets/72681e3a-386a-4b77-a44f-824c158af0df" />
<img width="1232" height="626" alt="Screenshot 2026-06-07 162655" src="https://github.com/user-attachments/assets/51efba67-d1fb-4c94-b966-eb78f70490b9" />
<img width="1252" height="602" alt="Screenshot 2026-06-07 162710" src="https://github.com/user-attachments/assets/96725e03-f30e-42e7-8030-e8540cba81b6" />
<img width="1214" height="599" alt="Screenshot 2026-06-07 162721" src="https://github.com/user-attachments/assets/58b4dde3-7bb5-4f5a-b8f4-62be623998bd" />
