### PR TITLE
feat(discussion): add comment command

### DIFF
--- a/acceptance/testdata/discussion/discussion-comment.txtar
+++ b/acceptance/testdata/discussion/discussion-comment.txtar
@@ -1,0 +1,108 @@
+# Create a repository with a file so it has a default branch
+exec gh repo create $ORG/$SCRIPT_NAME-$RANDOM_STRING --add-readme --private
+
+# Defer repo cleanup
+defer gh repo delete --yes $ORG/$SCRIPT_NAME-$RANDOM_STRING
+
+# Clone the repo
+exec gh repo clone $ORG/$SCRIPT_NAME-$RANDOM_STRING
+cd $SCRIPT_NAME-$RANDOM_STRING
+
+# Enable discussions
+exec gh api repos/$ORG/$SCRIPT_NAME-$RANDOM_STRING -X PATCH -F has_discussions=true
+
+# Create a discussion to comment on
+exec gh discussion create --title 'Comment Test' --body 'Discussion for comment tests' --category 'General'
+stdout2env DISCUSSION_URL
+
+# Add a top-level comment
+exec gh discussion comment $DISCUSSION_URL --body 'Comment from flag'
+stdout 'discussioncomment'
+
+# Add another comment from file
+exec gh discussion comment $DISCUSSION_URL --body-file $WORK/comment-body.txt
+stdout 'discussioncomment'
+
+# Verify comments appear in view
+exec gh discussion view $DISCUSSION_URL --comments --order oldest --json comments
+stdout2env COMMENTS_JSON
+jq-assert COMMENTS_JSON '.comments.nodes | length' '^2$'
+jq-assert COMMENTS_JSON '.comments.nodes[0].body' 'Comment from flag'
+jq-assert COMMENTS_JSON '.comments.nodes[1].body' 'Comment from file'
+
+# Get the first comment ID for reply and edit tests
+jq2env COMMENTS_JSON '.comments.nodes[0].id' FIRST_COMMENT_ID
+jq2env COMMENTS_JSON '.comments.nodes[1].id' SECOND_COMMENT_ID
+
+# Add a reply to the first comment
+exec gh discussion comment $DISCUSSION_URL --reply-to $FIRST_COMMENT_ID --body 'Reply to first'
+stdout 'discussioncomment'
+
+# Add a reply to the second comment from file
+exec gh discussion comment $DISCUSSION_URL --reply-to $SECOND_COMMENT_ID --body-file $WORK/reply-body.txt
+stdout 'discussioncomment'
+
+# Verify the reply appears
+exec gh discussion view $DISCUSSION_URL --replies $FIRST_COMMENT_ID --json comments
+stdout2env REPLIES_JSON
+jq-assert REPLIES_JSON '.comments.nodes[0].replies.nodes | length' '^1$'
+jq-assert REPLIES_JSON '.comments.nodes[0].replies.nodes[0].body' 'Reply to first'
+jq2env REPLIES_JSON '.comments.nodes[0].replies.nodes[0].id' FIRST_REPLY_ID
+
+exec gh discussion view $DISCUSSION_URL --replies $SECOND_COMMENT_ID --json comments
+stdout2env REPLIES_JSON
+jq-assert REPLIES_JSON '.comments.nodes[0].replies.nodes | length' '^1$'
+jq-assert REPLIES_JSON '.comments.nodes[0].replies.nodes[0].body' 'Reply from file'
+jq2env REPLIES_JSON '.comments.nodes[0].replies.nodes[0].id' SECOND_REPLY_ID
+
+# Edit the first comment
+exec gh discussion comment $DISCUSSION_URL --edit $FIRST_COMMENT_ID --body 'Edited first comment'
+stdout 'discussioncomment'
+
+# Edit the second comment from file
+exec gh discussion comment $DISCUSSION_URL --edit $SECOND_COMMENT_ID --body-file $WORK/edit-comment-body.txt
+stdout 'discussioncomment'
+
+# Edit the first reply
+exec gh discussion comment $DISCUSSION_URL --edit $FIRST_REPLY_ID --body 'Edited first reply'
+stdout 'discussioncomment'
+
+# Edit the second reply from file
+exec gh discussion comment $DISCUSSION_URL --edit $SECOND_REPLY_ID --body-file $WORK/edit-reply-body.txt
+stdout 'discussioncomment'
+
+# Verify edits appear
+exec gh discussion view $DISCUSSION_URL --comments --order oldest --json comments
+stdout2env EDITED_COMMENTS_JSON
+jq-assert EDITED_COMMENTS_JSON '.comments.nodes[0].body' 'Edited first comment'
+jq-assert EDITED_COMMENTS_JSON '.comments.nodes[0].replies.nodes[0].body' 'Edited first reply'
+jq-assert EDITED_COMMENTS_JSON '.comments.nodes[1].body' 'Edited comment from file'
+jq-assert EDITED_COMMENTS_JSON '.comments.nodes[1].replies.nodes[0].body' 'Edited reply from file'
+
+# Delete with --yes should fail when run non-interactively
+! exec gh discussion comment $DISCUSSION_URL --delete $SECOND_COMMENT_ID
+stderr '--yes'
+
+# Delete the second comment and its reply
+#
+# Note that if we only delete the comment, the reply will still exist and the API will keep returning the comment
+# (parent), but with an empty body. We delete them both here to avoid confusing assertions later.
+exec gh discussion comment $DISCUSSION_URL --delete $SECOND_COMMENT_ID --yes
+exec gh discussion comment $DISCUSSION_URL --delete $SECOND_REPLY_ID --yes
+
+# Verify deletion
+exec gh discussion view $DISCUSSION_URL --comments --json comments
+stdout2env DELETED_COMMENTS_JSON
+jq-assert DELETED_COMMENTS_JSON '.comments.nodes | length' '^1$'
+jq-assert DELETED_COMMENTS_JSON '.comments.nodes[0].body' 'Edited first comment'
+jq-assert DELETED_COMMENTS_JSON '.comments.nodes[0].replies.nodes | length' '^1$'
+jq-assert DELETED_COMMENTS_JSON '.comments.nodes[0].replies.nodes[0].body' 'Edited first reply'
+
+-- comment-body.txt --
+Comment from file
+-- reply-body.txt --
+Reply from file
+-- edit-comment-body.txt --
+Edited comment from file
+-- edit-reply-body.txt --
+Edited reply from file

--- a/acceptance/testdata/discussion/discussion-comment.txtar
+++ b/acceptance/testdata/discussion/discussion-comment.txtar
@@ -35,11 +35,11 @@ jq2env COMMENTS_JSON '.comments.nodes[0].id' FIRST_COMMENT_ID
 jq2env COMMENTS_JSON '.comments.nodes[1].id' SECOND_COMMENT_ID
 
 # Add a reply to the first comment
-exec gh discussion comment $DISCUSSION_URL --reply-to $FIRST_COMMENT_ID --body 'Reply to first'
+exec gh discussion comment $FIRST_COMMENT_ID --body 'Reply to first'
 stdout 'discussioncomment'
 
 # Add a reply to the second comment from file
-exec gh discussion comment $DISCUSSION_URL --reply-to $SECOND_COMMENT_ID --body-file $WORK/reply-body.txt
+exec gh discussion comment $SECOND_COMMENT_ID --body-file $WORK/reply-body.txt
 stdout 'discussioncomment'
 
 # Verify the reply appears
@@ -56,19 +56,19 @@ jq-assert REPLIES_JSON '.comments.nodes[0].replies.nodes[0].body' 'Reply from fi
 jq2env REPLIES_JSON '.comments.nodes[0].replies.nodes[0].id' SECOND_REPLY_ID
 
 # Edit the first comment
-exec gh discussion comment $DISCUSSION_URL --edit $FIRST_COMMENT_ID --body 'Edited first comment'
+exec gh discussion comment $FIRST_COMMENT_ID --edit --body 'Edited first comment'
 stdout 'discussioncomment'
 
 # Edit the second comment from file
-exec gh discussion comment $DISCUSSION_URL --edit $SECOND_COMMENT_ID --body-file $WORK/edit-comment-body.txt
+exec gh discussion comment $SECOND_COMMENT_ID --edit --body-file $WORK/edit-comment-body.txt
 stdout 'discussioncomment'
 
 # Edit the first reply
-exec gh discussion comment $DISCUSSION_URL --edit $FIRST_REPLY_ID --body 'Edited first reply'
+exec gh discussion comment $FIRST_REPLY_ID --edit --body 'Edited first reply'
 stdout 'discussioncomment'
 
 # Edit the second reply from file
-exec gh discussion comment $DISCUSSION_URL --edit $SECOND_REPLY_ID --body-file $WORK/edit-reply-body.txt
+exec gh discussion comment $SECOND_REPLY_ID --edit --body-file $WORK/edit-reply-body.txt
 stdout 'discussioncomment'
 
 # Verify edits appear
@@ -80,23 +80,57 @@ jq-assert EDITED_COMMENTS_JSON '.comments.nodes[1].body' 'Edited comment from fi
 jq-assert EDITED_COMMENTS_JSON '.comments.nodes[1].replies.nodes[0].body' 'Edited reply from file'
 
 # Delete with --yes should fail when run non-interactively
-! exec gh discussion comment $DISCUSSION_URL --delete $SECOND_COMMENT_ID
+! exec gh discussion comment $SECOND_COMMENT_ID --delete
 stderr '--yes'
 
 # Delete the second comment and its reply
 #
 # Note that if we only delete the comment, the reply will still exist and the API will keep returning the comment
 # (parent), but with an empty body. We delete them both here to avoid confusing assertions later.
-exec gh discussion comment $DISCUSSION_URL --delete $SECOND_COMMENT_ID --yes
-exec gh discussion comment $DISCUSSION_URL --delete $SECOND_REPLY_ID --yes
+exec gh discussion comment $SECOND_COMMENT_ID --delete --yes
+exec gh discussion comment $SECOND_REPLY_ID --delete --yes
 
 # Verify deletion
-exec gh discussion view $DISCUSSION_URL --comments --json comments
+exec gh discussion view $DISCUSSION_URL --comments --order oldest --json comments
 stdout2env DELETED_COMMENTS_JSON
 jq-assert DELETED_COMMENTS_JSON '.comments.nodes | length' '^1$'
 jq-assert DELETED_COMMENTS_JSON '.comments.nodes[0].body' 'Edited first comment'
 jq-assert DELETED_COMMENTS_JSON '.comments.nodes[0].replies.nodes | length' '^1$'
 jq-assert DELETED_COMMENTS_JSON '.comments.nodes[0].replies.nodes[0].body' 'Edited first reply'
+
+# Test add, edit, and delete using comment URLs instead of node IDs
+
+# Get the URL of the remaining comment
+jq2env DELETED_COMMENTS_JSON '.comments.nodes[0].url' FIRST_COMMENT_URL
+
+# Add a reply using the comment URL
+exec gh discussion comment $FIRST_COMMENT_URL --body 'Reply via URL'
+stdout2env REPLY_URL
+stdout 'discussioncomment'
+
+# Verify the reply
+exec gh discussion view $DISCUSSION_URL --replies $FIRST_COMMENT_URL --order oldest --json comments
+stdout2env URL_REPLIES_JSON
+jq-assert URL_REPLIES_JSON '.comments.nodes[0].replies.nodes | length' '^2$'
+
+# Edit the reply using its URL
+exec gh discussion comment $REPLY_URL --edit --body 'Edited reply via URL'
+stdout 'discussioncomment'
+
+# Verify the edit
+exec gh discussion view $DISCUSSION_URL --replies $FIRST_COMMENT_URL --order oldest --json comments
+stdout2env EDITED_URL_REPLIES_JSON
+jq-assert EDITED_URL_REPLIES_JSON '.comments.nodes[0].replies.nodes[0].body' 'Edited first reply'
+jq-assert EDITED_URL_REPLIES_JSON '.comments.nodes[0].replies.nodes[1].body' 'Edited reply via URL'
+
+# Delete the reply using its URL
+exec gh discussion comment $REPLY_URL --delete --yes
+
+# Verify deletion
+exec gh discussion view $DISCUSSION_URL --replies $FIRST_COMMENT_URL --order oldest --json comments
+stdout2env FINAL_URL_REPLIES_JSON
+jq-assert FINAL_URL_REPLIES_JSON '.comments.nodes[0].replies.nodes | length' '^1$'
+jq-assert FINAL_URL_REPLIES_JSON '.comments.nodes[0].replies.nodes[0].body' 'Edited first reply'
 
 -- comment-body.txt --
 Comment from file

--- a/acceptance/testdata/discussion/discussion-list.txtar
+++ b/acceptance/testdata/discussion/discussion-list.txtar
@@ -34,9 +34,8 @@ exec gh discussion create --title 'Second Discussion' --body 'Second body' --cat
 # Create a Q&A discussion and mark it as answered
 exec gh discussion create --title 'QA Discussion' --body 'QA body' --category 'Q&A'
 stdout2env QA_URL
-exec gh discussion view $QA_URL --json id --jq '.id'
-stdout2env QA_ID
-exec gh api graphql -f query='mutation { addDiscussionComment(input: {discussionId: "'$QA_ID'", body: "This is the answer"}) { comment { id } } }' --jq '.data.addDiscussionComment.comment.id'
+exec gh discussion comment $QA_URL --body 'This is the answer'
+exec gh discussion view $QA_URL --comments --json comments --jq '.comments.nodes[0].id'
 stdout2env QA_COMMENT_ID
 exec gh api graphql -f query='mutation { markDiscussionCommentAsAnswer(input: {id: "'$QA_COMMENT_ID'"}) { discussion { id } } }'
 

--- a/acceptance/testdata/discussion/discussion-view.txtar
+++ b/acceptance/testdata/discussion/discussion-view.txtar
@@ -47,8 +47,8 @@ jq2env COMMENTS_JSON '.comments.nodes[0].id' COMMENT1_ID
 jq2env COMMENTS_JSON '.comments.nodes[1].id' COMMENT2_ID
 
 # Add replies to the first comment
-exec gh discussion comment $DISCUSSION_URL --reply-to $COMMENT1_ID --body 'Reply one to first'
-exec gh discussion comment $DISCUSSION_URL --reply-to $COMMENT1_ID --body 'Reply two to first'
+exec gh discussion comment $COMMENT1_ID --body 'Reply one to first'
+exec gh discussion comment $COMMENT1_ID --body 'Reply two to first'
 
 # View with --comments in non-interactive mode
 exec gh discussion view $DISCUSSION_URL --comments
@@ -114,3 +114,11 @@ jq-assert RPAGE2_JSON '.comments.nodes[0].replies.nodes | length' '^1$'
 jq-assert RPAGE2_JSON '.comments.nodes[0].replies.nodes[0].body' 'Reply two to first'
 jq-assert RPAGE2_JSON '.comments.nodes[0].replies.cursor' '.+'
 jq-assert RPAGE2_JSON '.comments.nodes[0].replies | has("next")' 'false'
+
+# Test --replies with a comment URL instead of node ID
+jq2env COMMENTS_JSON '.comments.nodes[0].url' COMMENT1_URL
+exec gh discussion view $DISCUSSION_URL --replies $COMMENT1_URL --order oldest --json comments
+stdout2env URL_REPLIES_JSON
+jq-assert URL_REPLIES_JSON '.comments.nodes[0].replies.nodes | length' '^2$'
+jq-assert URL_REPLIES_JSON '.comments.nodes[0].replies.nodes[0].body' 'Reply one to first'
+jq-assert URL_REPLIES_JSON '.comments.nodes[0].replies.nodes[1].body' 'Reply two to first'

--- a/acceptance/testdata/discussion/discussion-view.txtar
+++ b/acceptance/testdata/discussion/discussion-view.txtar
@@ -41,7 +41,7 @@ exec gh discussion comment $DISCUSSION_URL --body 'First comment body'
 exec gh discussion comment $DISCUSSION_URL --body 'Second comment body'
 
 # Get comment IDs for reply tests
-exec gh discussion view $DISCUSSION_URL --comments --order oldest --json comments
+exec gh discussion view $DISCUSSION_URL --order oldest --json comments
 stdout2env COMMENTS_JSON
 jq2env COMMENTS_JSON '.comments.nodes[0].id' COMMENT1_ID
 jq2env COMMENTS_JSON '.comments.nodes[1].id' COMMENT2_ID
@@ -55,19 +55,19 @@ exec gh discussion view $DISCUSSION_URL --comments
 stdout 'First comment body'
 stdout 'Second comment body'
 
-# View with --comments in JSON mode
-exec gh discussion view $DISCUSSION_URL --comments --order oldest --json number,title,comments
+# View with comments in JSON mode
+exec gh discussion view $DISCUSSION_URL --order oldest --json number,title,comments
 stdout2env COMMENTS_JSON
 jq-assert COMMENTS_JSON '.comments.nodes[0].body' 'First comment body'
 jq-assert COMMENTS_JSON '.comments.nodes[1].body' 'Second comment body'
 
 # View replies for the first comment in non-interactive mode
-exec gh discussion view $DISCUSSION_URL --replies $COMMENT1_ID --order oldest
+exec gh discussion view $COMMENT1_ID --order oldest
 stdout 'Reply one to first'
 stdout 'Reply two to first'
 
 # View replies in JSON mode
-exec gh discussion view $DISCUSSION_URL --replies $COMMENT1_ID --order oldest --json number,title,comments
+exec gh discussion view $COMMENT1_ID --order oldest --json comments
 stdout2env REPLIES_JSON
 jq-assert REPLIES_JSON '.comments.nodes[0].replies.nodes[0].body' 'Reply one to first'
 jq-assert REPLIES_JSON '.comments.nodes[0].replies.nodes[1].body' 'Reply two to first'
@@ -75,12 +75,12 @@ jq-assert REPLIES_JSON '.comments.nodes[0].replies | has("cursor")' 'false'
 jq-assert REPLIES_JSON '.comments.nodes[0].replies | has("next")' 'false'
 
 # View replies of the second comment and confirm it has none
-exec gh discussion view $DISCUSSION_URL --replies $COMMENT2_ID --json number,title,comments
+exec gh discussion view $COMMENT2_ID --json number,title,comments
 stdout2env REPLIES2_JSON
 jq-assert REPLIES2_JSON '.comments.nodes[0].replies.totalCount' '^0$'
 
 # Pagination: limit comments to 1 and verify totalCount and next cursor
-exec gh discussion view $DISCUSSION_URL --comments --order oldest --limit 1 --json comments
+exec gh discussion view $DISCUSSION_URL --order oldest --limit 1 --json comments
 stdout2env PAGE1_JSON
 jq-assert PAGE1_JSON '.comments.totalCount' '^2$'
 jq-assert PAGE1_JSON '.comments.nodes | length' '^1$'
@@ -90,7 +90,7 @@ jq-assert PAGE1_JSON '.comments.next' '.+'
 
 # Fetch the second page of comments using the cursor
 jq2env PAGE1_JSON '.comments.next' COMMENTS_CURSOR
-exec gh discussion view $DISCUSSION_URL --comments --order oldest --limit 1 --after $COMMENTS_CURSOR --json comments
+exec gh discussion view $DISCUSSION_URL --order oldest --limit 1 --after $COMMENTS_CURSOR --json comments
 stdout2env PAGE2_JSON
 jq-assert PAGE2_JSON '.comments.nodes | length' '^1$'
 jq-assert PAGE2_JSON '.comments.nodes[0].body' 'Second comment body'
@@ -98,7 +98,7 @@ jq-assert PAGE2_JSON '.comments.cursor' '.+'
 jq-assert PAGE2_JSON '.comments | has("next")' 'false'
 
 # Pagination: limit replies to 1 and verify totalCount and next cursor
-exec gh discussion view $DISCUSSION_URL --replies $COMMENT1_ID --order oldest --limit 1 --json comments
+exec gh discussion view $COMMENT1_ID --order oldest --limit 1 --json comments
 stdout2env RPAGE1_JSON
 jq-assert RPAGE1_JSON '.comments.nodes[0].replies.totalCount' '^2$'
 jq-assert RPAGE1_JSON '.comments.nodes[0].replies.nodes | length' '^1$'
@@ -108,16 +108,16 @@ jq-assert RPAGE1_JSON '.comments.nodes[0].replies.next' '.+'
 
 # Fetch the second page of replies using the cursor
 jq2env RPAGE1_JSON '.comments.nodes[0].replies.next' REPLIES_CURSOR
-exec gh discussion view $DISCUSSION_URL --replies $COMMENT1_ID --order oldest --limit 1 --after $REPLIES_CURSOR --json comments
+exec gh discussion view $COMMENT1_ID --order oldest --limit 1 --after $REPLIES_CURSOR --json comments
 stdout2env RPAGE2_JSON
 jq-assert RPAGE2_JSON '.comments.nodes[0].replies.nodes | length' '^1$'
 jq-assert RPAGE2_JSON '.comments.nodes[0].replies.nodes[0].body' 'Reply two to first'
 jq-assert RPAGE2_JSON '.comments.nodes[0].replies.cursor' '.+'
 jq-assert RPAGE2_JSON '.comments.nodes[0].replies | has("next")' 'false'
 
-# Test --replies with a comment URL instead of node ID
+# Fetch replies with a comment URL instead of node ID
 jq2env COMMENTS_JSON '.comments.nodes[0].url' COMMENT1_URL
-exec gh discussion view $DISCUSSION_URL --replies $COMMENT1_URL --order oldest --json comments
+exec gh discussion view $COMMENT1_URL --order oldest --json comments
 stdout2env URL_REPLIES_JSON
 jq-assert URL_REPLIES_JSON '.comments.nodes[0].replies.nodes | length' '^2$'
 jq-assert URL_REPLIES_JSON '.comments.nodes[0].replies.nodes[0].body' 'Reply one to first'

--- a/acceptance/testdata/discussion/discussion-view.txtar
+++ b/acceptance/testdata/discussion/discussion-view.txtar
@@ -36,19 +36,19 @@ jq-assert VIEW_JSON '.body' 'Discussion body content'
 jq-assert VIEW_JSON '.labels[0].name' 'bug'
 jq-assert VIEW_JSON '.labels[1].name' 'enhancement'
 
-# Get the discussion node ID for adding comments via API
-jq2env VIEW_JSON '.id' DISCUSSION_ID
+# Add two comments using the comment command
+exec gh discussion comment $DISCUSSION_URL --body 'First comment body'
+exec gh discussion comment $DISCUSSION_URL --body 'Second comment body'
 
-# Add two comments via API
-exec gh api graphql -f query='mutation { addDiscussionComment(input: {discussionId: "'$DISCUSSION_ID'", body: "First comment body"}) { comment { id } } }' --jq '.data.addDiscussionComment.comment.id'
-stdout2env COMMENT1_ID
-
-exec gh api graphql -f query='mutation { addDiscussionComment(input: {discussionId: "'$DISCUSSION_ID'", body: "Second comment body"}) { comment { id } } }' --jq '.data.addDiscussionComment.comment.id'
-stdout2env COMMENT2_ID
+# Get comment IDs for reply tests
+exec gh discussion view $DISCUSSION_URL --comments --order oldest --json comments
+stdout2env COMMENTS_JSON
+jq2env COMMENTS_JSON '.comments.nodes[0].id' COMMENT1_ID
+jq2env COMMENTS_JSON '.comments.nodes[1].id' COMMENT2_ID
 
 # Add replies to the first comment
-exec gh api graphql -f query='mutation { addDiscussionComment(input: {discussionId: "'$DISCUSSION_ID'", replyToId: "'$COMMENT1_ID'", body: "Reply one to first"}) { comment { id } } }'
-exec gh api graphql -f query='mutation { addDiscussionComment(input: {discussionId: "'$DISCUSSION_ID'", replyToId: "'$COMMENT1_ID'", body: "Reply two to first"}) { comment { id } } }'
+exec gh discussion comment $DISCUSSION_URL --reply-to $COMMENT1_ID --body 'Reply one to first'
+exec gh discussion comment $DISCUSSION_URL --reply-to $COMMENT1_ID --body 'Reply two to first'
 
 # View with --comments in non-interactive mode
 exec gh discussion view $DISCUSSION_URL --comments

--- a/pkg/cmd/discussion/client/client.go
+++ b/pkg/cmd/discussion/client/client.go
@@ -22,4 +22,13 @@ type DiscussionClient interface {
 	// Update updates a discussion. The returned discussion may be non-nil even
 	// when err is non-nil, indicating a secondary mutation failure (e.g., labels).
 	Update(repo ghrepo.Interface, input UpdateDiscussionInput) (*Discussion, error)
+	// AddComment adds a comment or reply to a discussion. If replyToID is
+	// non-empty, the comment is created as a reply to that comment.
+	AddComment(repo ghrepo.Interface, discussionID, body, replyToID string) (*DiscussionComment, error)
+	// UpdateComment updates the body of an existing discussion comment or reply.
+	UpdateComment(repo ghrepo.Interface, commentID, body string) (*DiscussionComment, error)
+	// DeleteComment deletes a discussion comment or reply.
+	DeleteComment(repo ghrepo.Interface, commentID string) error
+	// GetComment fetches a single discussion comment by node ID.
+	GetComment(repo ghrepo.Interface, commentID string) (*DiscussionComment, error)
 }

--- a/pkg/cmd/discussion/client/client.go
+++ b/pkg/cmd/discussion/client/client.go
@@ -31,4 +31,7 @@ type DiscussionClient interface {
 	DeleteComment(repo ghrepo.Interface, commentID string) error
 	// GetComment fetches a single discussion comment by node ID.
 	GetComment(repo ghrepo.Interface, commentID string) (*DiscussionComment, error)
+	// ResolveCommentNodeID constructs a discussion comment node ID from a
+	// repository and a comment database ID (the numeric ID from the URL fragment).
+	ResolveCommentNodeID(repo ghrepo.Interface, commentDatabaseID int64) (string, error)
 }

--- a/pkg/cmd/discussion/client/client.go
+++ b/pkg/cmd/discussion/client/client.go
@@ -37,7 +37,7 @@ type DiscussionClient interface {
 	// DeleteComment deletes a discussion comment or reply.
 	DeleteComment(repo ghrepo.Interface, commentID string) error
 	// GetComment fetches a single discussion comment by node ID.
-	GetComment(repo ghrepo.Interface, commentID string) (*DiscussionComment, error)
+	GetComment(host string, commentID string) (*DiscussionComment, error)
 	// ResolveCommentNodeID constructs a discussion comment node ID from a
 	// repository and a comment database ID (the numeric ID from the URL fragment).
 	ResolveCommentNodeID(repo ghrepo.Interface, commentDatabaseID int64) (string, error)

--- a/pkg/cmd/discussion/client/client.go
+++ b/pkg/cmd/discussion/client/client.go
@@ -9,12 +9,19 @@ import "github.com/cli/cli/v2/internal/ghrepo"
 
 // DiscussionClient defines operations for interacting with the GitHub Discussions API.
 type DiscussionClient interface {
+	// List returns discussions in a repository matching the given filters.
 	List(repo ghrepo.Interface, filters ListFilters, after string, limit int) (*DiscussionListResult, error)
+	// Search returns discussions in a repository matching the given search filters.
 	Search(repo ghrepo.Interface, filters SearchFilters, after string, limit int) (*DiscussionListResult, error)
+	// GetByNumber returns a single discussion by its number.
 	GetByNumber(repo ghrepo.Interface, number int32) (*Discussion, error)
+	// GetWithComments returns a discussion along with a page of its comments.
 	GetWithComments(repo ghrepo.Interface, number int32, commentLimit int, after string, newest bool) (*Discussion, error)
-	GetCommentReplies(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*Discussion, error)
+	// GetCommentReplies returns a comment's parent discussion along with a page of the comment's replies.
+	GetCommentReplies(host string, commentID string, limit int, after string, newest bool) (*Discussion, error)
+	// ListCategories returns the discussion categories available in a repository.
 	ListCategories(repo ghrepo.Interface) ([]DiscussionCategory, error)
+	// ListLabels returns the labels available in a repository.
 	ListLabels(repo ghrepo.Interface) ([]DiscussionLabel, error)
 	// Create creates a discussion. The returned discussion may be non-nil even
 	// when err is non-nil, indicating a secondary mutation failure (e.g., labels).

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,6 +13,7 @@ import (
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/shurcooL/githubv4"
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 // maxPageSize is the maximum number of items per page allowed by the GitHub GraphQL API.
@@ -801,17 +804,19 @@ func (c *discussionClient) ListCategories(repo ghrepo.Interface) ([]DiscussionCa
 	return categories, nil
 }
 
-// repositoryMeta holds the node ID and feature flags fetched for a repository.
+// repositoryMeta holds the node ID, database ID, and feature flags fetched for a repository.
 type repositoryMeta struct {
 	ID                    string
+	DatabaseId            int64
 	HasDiscussionsEnabled bool
 }
 
-// getRepositoryMeta fetches the node ID and discussion-enabled flag for a repository.
+// getRepositoryMeta fetches the node ID, database ID, and discussion-enabled flag for a repository.
 func (c *discussionClient) getRepositoryMeta(repo ghrepo.Interface) (*repositoryMeta, error) {
 	var query struct {
 		Repository struct {
 			ID                    string
+			DatabaseId            int64
 			HasDiscussionsEnabled bool
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
@@ -827,6 +832,7 @@ func (c *discussionClient) getRepositoryMeta(repo ghrepo.Interface) (*repository
 
 	return &repositoryMeta{
 		ID:                    query.Repository.ID,
+		DatabaseId:            query.Repository.DatabaseId,
 		HasDiscussionsEnabled: query.Repository.HasDiscussionsEnabled,
 	}, nil
 }
@@ -1212,13 +1218,16 @@ func (c *discussionClient) GetComment(repo ghrepo.Interface, commentID string) (
 		Node struct {
 			Typename          string `graphql:"__typename"`
 			DiscussionComment struct {
-				ID             string
-				URL            string `graphql:"url"`
-				Author         actorNode
-				Body           string
-				CreatedAt      time.Time
-				IsAnswer       bool
-				UpvoteCount    int
+				ID         string
+				URL        string `graphql:"url"`
+				Author     actorNode
+				Body       string
+				CreatedAt  time.Time
+				IsAnswer   bool
+				UpvoteCount int
+				Discussion struct {
+					ID string
+				}
 				ReactionGroups []struct {
 					Content string
 					Users   struct {
@@ -1243,13 +1252,14 @@ func (c *discussionClient) GetComment(repo ghrepo.Interface, commentID string) (
 
 	src := query.Node.DiscussionComment
 	comment := &DiscussionComment{
-		ID:          src.ID,
-		URL:         src.URL,
-		Author:      mapActorFromListNode(src.Author),
-		Body:        src.Body,
-		CreatedAt:   src.CreatedAt,
-		IsAnswer:    src.IsAnswer,
-		UpvoteCount: src.UpvoteCount,
+		ID:           src.ID,
+		URL:          src.URL,
+		DiscussionID: src.Discussion.ID,
+		Author:       mapActorFromListNode(src.Author),
+		Body:         src.Body,
+		CreatedAt:    src.CreatedAt,
+		IsAnswer:     src.IsAnswer,
+		UpvoteCount:  src.UpvoteCount,
 	}
 	for _, rg := range src.ReactionGroups {
 		comment.ReactionGroups = append(comment.ReactionGroups, ReactionGroup{
@@ -1258,4 +1268,27 @@ func (c *discussionClient) GetComment(repo ghrepo.Interface, commentID string) (
 		})
 	}
 	return comment, nil
+}
+
+// ResolveCommentNodeID constructs a discussion comment node ID from a
+// repository and a comment database ID. It fetches the repository's database
+// ID via the API, then encodes the data into a  "DC_" prefixed node ID.
+func (c *discussionClient) ResolveCommentNodeID(repo ghrepo.Interface, commentDatabaseID int64) (string, error) {
+	meta, err := c.getRepositoryMeta(repo)
+	if err != nil {
+		return "", err
+	}
+
+	buf := bytes.Buffer{}
+	parts := []int64{0, meta.DatabaseId, commentDatabaseID}
+
+	encoder := msgpack.NewEncoder(&buf)
+	encoder.UseCompactInts(true)
+
+	if err := encoder.Encode(parts); err != nil {
+		return "", fmt.Errorf("encoding comment node ID: %w", err)
+	}
+
+	encoded := base64.RawURLEncoding.EncodeToString(buf.Bytes())
+	return "DC_" + encoded, nil
 }

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -1218,14 +1218,14 @@ func (c *discussionClient) GetComment(repo ghrepo.Interface, commentID string) (
 		Node struct {
 			Typename          string `graphql:"__typename"`
 			DiscussionComment struct {
-				ID         string
-				URL        string `graphql:"url"`
-				Author     actorNode
-				Body       string
-				CreatedAt  time.Time
-				IsAnswer   bool
+				ID          string
+				URL         string `graphql:"url"`
+				Author      actorNode
+				Body        string
+				CreatedAt   time.Time
+				IsAnswer    bool
 				UpvoteCount int
-				Discussion struct {
+				Discussion  struct {
 					ID string
 				}
 				ReactionGroups []struct {

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -596,24 +596,14 @@ func (c *discussionClient) GetWithComments(repo ghrepo.Interface, number int32, 
 	return &d, nil
 }
 
-// GetCommentReplies fetches a discussion and a single comment with its
-// paginated replies. It uses the top-level node(id:) query for the comment
-// because the Discussion type does not expose a comment(id:) field.
-func (c *discussionClient) GetCommentReplies(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*Discussion, error) {
-	meta, err := c.getRepositoryMeta(repo)
-	if err != nil {
-		return nil, err
-	}
-	if !meta.HasDiscussionsEnabled {
-		return nil, fmt.Errorf("the '%s/%s' repository has discussions disabled", repo.RepoOwner(), repo.RepoName())
-	}
-
+// GetCommentReplies fetches a single comment with its paginated replies, along
+// with its parent discussion. It uses the top-level node(id:) query because the
+// comment node ID is self-contained: the parent discussion (number, repository,
+// and detail fields) is resolved from the comment itself rather than from a
+// separate repository(owner:).discussion(number:) lookup. The host argument
+// selects the GraphQL endpoint.
+func (c *discussionClient) GetCommentReplies(host string, commentID string, limit int, after string, newest bool) (*Discussion, error) {
 	var query struct {
-		Repository struct {
-			Discussion struct {
-				discussionListNode
-			} `graphql:"discussion(number: $number)"`
-		} `graphql:"repository(owner: $owner, name: $name)"`
 		Node *struct {
 			DiscussionComment struct {
 				ID             string
@@ -629,14 +619,8 @@ func (c *discussionClient) GetCommentReplies(repo ghrepo.Interface, number int32
 						TotalCount int
 					}
 				}
-				Discussion struct {
-					Number     int
-					Repository struct {
-						Owner struct{ Login string }
-						Name  string
-					}
-				}
-				Replies struct {
+				Discussion discussionListNode
+				Replies    struct {
 					TotalCount int
 					PageInfo   struct {
 						EndCursor       string
@@ -651,9 +635,6 @@ func (c *discussionClient) GetCommentReplies(repo ghrepo.Interface, number int32
 	}
 
 	variables := map[string]interface{}{
-		"owner":     githubv4.String(repo.RepoOwner()),
-		"name":      githubv4.String(repo.RepoName()),
-		"number":    githubv4.Int(number),
 		"commentID": githubv4.ID(commentID),
 		"first":     (*githubv4.Int)(nil),
 		"last":      (*githubv4.Int)(nil),
@@ -673,7 +654,7 @@ func (c *discussionClient) GetCommentReplies(repo ghrepo.Interface, number int32
 		}
 	}
 
-	if err := c.gql.Query(repo.RepoHost(), "DiscussionCommentReplies", &query, variables); err != nil {
+	if err := c.gql.Query(host, "DiscussionCommentReplies", &query, variables); err != nil {
 		return nil, err
 	}
 
@@ -687,14 +668,9 @@ func (c *discussionClient) GetCommentReplies(repo ghrepo.Interface, number int32
 		return nil, fmt.Errorf("node %s is not a discussion comment", commentID)
 	}
 
-	if !strings.EqualFold(src.Discussion.Repository.Owner.Login, repo.RepoOwner()) ||
-		!strings.EqualFold(src.Discussion.Repository.Name, repo.RepoName()) {
-		return nil, fmt.Errorf("comment %s does not belong to %s/%s", commentID, repo.RepoOwner(), repo.RepoName())
-	}
+	d := mapDiscussionFromListNode(src.Discussion)
 
-	d := mapDiscussionFromListNode(query.Repository.Discussion.discussionListNode)
-
-	for _, rg := range query.Repository.Discussion.ReactionGroups {
+	for _, rg := range src.Discussion.ReactionGroups {
 		d.ReactionGroups = append(d.ReactionGroups, ReactionGroup{
 			Content:    rg.Content,
 			TotalCount: rg.Users.TotalCount,

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -1189,7 +1189,7 @@ func (c *discussionClient) DeleteComment(repo ghrepo.Interface, commentID string
 }
 
 // GetComment fetches a single discussion comment by node ID.
-func (c *discussionClient) GetComment(repo ghrepo.Interface, commentID string) (*DiscussionComment, error) {
+func (c *discussionClient) GetComment(host string, commentID string) (*DiscussionComment, error) {
 	var query struct {
 		Node struct {
 			Typename          string `graphql:"__typename"`
@@ -1218,7 +1218,7 @@ func (c *discussionClient) GetComment(repo ghrepo.Interface, commentID string) (
 		"id": githubv4.ID(commentID),
 	}
 
-	if err := c.gql.Query(repo.RepoHost(), "GetDiscussionComment", &query, variables); err != nil {
+	if err := c.gql.Query(host, "GetDiscussionComment", &query, variables); err != nil {
 		return nil, err
 	}
 

--- a/pkg/cmd/discussion/client/client_impl.go
+++ b/pkg/cmd/discussion/client/client_impl.go
@@ -1075,3 +1075,187 @@ func (c *discussionClient) Update(repo ghrepo.Interface, input UpdateDiscussionI
 	}
 	return &d, nil
 }
+
+// AddComment adds a comment to a discussion. If replyToID is non-empty, the
+// comment is created as a reply to that comment.
+func (c *discussionClient) AddComment(repo ghrepo.Interface, discussionID, body, replyToID string) (*DiscussionComment, error) {
+	var mutation struct {
+		AddDiscussionComment struct {
+			Comment struct {
+				ID             string
+				URL            string `graphql:"url"`
+				Author         actorNode
+				Body           string
+				CreatedAt      time.Time
+				IsAnswer       bool
+				UpvoteCount    int
+				ReactionGroups []struct {
+					Content string
+					Users   struct {
+						TotalCount int
+					}
+				} `graphql:"reactionGroups"`
+			}
+		} `graphql:"addDiscussionComment(input: $input)"`
+	}
+
+	input := githubv4.AddDiscussionCommentInput{
+		DiscussionID: githubv4.ID(discussionID),
+		Body:         githubv4.String(body),
+	}
+	if replyToID != "" {
+		id := githubv4.ID(replyToID)
+		input.ReplyToID = &id
+	}
+
+	variables := map[string]interface{}{
+		"input": input,
+	}
+
+	if err := c.gql.Mutate(repo.RepoHost(), "AddDiscussionComment", &mutation, variables); err != nil {
+		return nil, err
+	}
+
+	src := mutation.AddDiscussionComment.Comment
+	comment := &DiscussionComment{
+		ID:          src.ID,
+		URL:         src.URL,
+		Author:      mapActorFromListNode(src.Author),
+		Body:        src.Body,
+		CreatedAt:   src.CreatedAt,
+		IsAnswer:    src.IsAnswer,
+		UpvoteCount: src.UpvoteCount,
+	}
+	for _, rg := range src.ReactionGroups {
+		comment.ReactionGroups = append(comment.ReactionGroups, ReactionGroup{
+			Content:    rg.Content,
+			TotalCount: rg.Users.TotalCount,
+		})
+	}
+	return comment, nil
+}
+
+// UpdateComment updates the body of an existing discussion comment or reply.
+func (c *discussionClient) UpdateComment(repo ghrepo.Interface, commentID, body string) (*DiscussionComment, error) {
+	var mutation struct {
+		UpdateDiscussionComment struct {
+			Comment struct {
+				ID             string
+				URL            string `graphql:"url"`
+				Author         actorNode
+				Body           string
+				CreatedAt      time.Time
+				IsAnswer       bool
+				UpvoteCount    int
+				ReactionGroups []struct {
+					Content string
+					Users   struct {
+						TotalCount int
+					}
+				} `graphql:"reactionGroups"`
+			}
+		} `graphql:"updateDiscussionComment(input: $input)"`
+	}
+
+	variables := map[string]interface{}{
+		"input": githubv4.UpdateDiscussionCommentInput{
+			CommentID: githubv4.ID(commentID),
+			Body:      githubv4.String(body),
+		},
+	}
+
+	if err := c.gql.Mutate(repo.RepoHost(), "UpdateDiscussionComment", &mutation, variables); err != nil {
+		return nil, err
+	}
+
+	src := mutation.UpdateDiscussionComment.Comment
+	comment := &DiscussionComment{
+		ID:          src.ID,
+		URL:         src.URL,
+		Author:      mapActorFromListNode(src.Author),
+		Body:        src.Body,
+		CreatedAt:   src.CreatedAt,
+		IsAnswer:    src.IsAnswer,
+		UpvoteCount: src.UpvoteCount,
+	}
+	for _, rg := range src.ReactionGroups {
+		comment.ReactionGroups = append(comment.ReactionGroups, ReactionGroup{
+			Content:    rg.Content,
+			TotalCount: rg.Users.TotalCount,
+		})
+	}
+	return comment, nil
+}
+
+// DeleteComment deletes a discussion comment or reply.
+func (c *discussionClient) DeleteComment(repo ghrepo.Interface, commentID string) error {
+	var mutation struct {
+		DeleteDiscussionComment struct {
+			Comment struct {
+				ID string
+			}
+		} `graphql:"deleteDiscussionComment(input: $input)"`
+	}
+
+	variables := map[string]interface{}{
+		"input": githubv4.DeleteDiscussionCommentInput{
+			ID: githubv4.ID(commentID),
+		},
+	}
+
+	return c.gql.Mutate(repo.RepoHost(), "DeleteDiscussionComment", &mutation, variables)
+}
+
+// GetComment fetches a single discussion comment by node ID.
+func (c *discussionClient) GetComment(repo ghrepo.Interface, commentID string) (*DiscussionComment, error) {
+	var query struct {
+		Node struct {
+			Typename          string `graphql:"__typename"`
+			DiscussionComment struct {
+				ID             string
+				URL            string `graphql:"url"`
+				Author         actorNode
+				Body           string
+				CreatedAt      time.Time
+				IsAnswer       bool
+				UpvoteCount    int
+				ReactionGroups []struct {
+					Content string
+					Users   struct {
+						TotalCount int
+					}
+				} `graphql:"reactionGroups"`
+			} `graphql:"... on DiscussionComment"`
+		} `graphql:"node(id: $id)"`
+	}
+
+	variables := map[string]interface{}{
+		"id": githubv4.ID(commentID),
+	}
+
+	if err := c.gql.Query(repo.RepoHost(), "GetDiscussionComment", &query, variables); err != nil {
+		return nil, err
+	}
+
+	if query.Node.Typename != "DiscussionComment" {
+		return nil, fmt.Errorf("node %s is not a discussion comment (got %s)", commentID, query.Node.Typename)
+	}
+
+	src := query.Node.DiscussionComment
+	comment := &DiscussionComment{
+		ID:          src.ID,
+		URL:         src.URL,
+		Author:      mapActorFromListNode(src.Author),
+		Body:        src.Body,
+		CreatedAt:   src.CreatedAt,
+		IsAnswer:    src.IsAnswer,
+		UpvoteCount: src.UpvoteCount,
+	}
+	for _, rg := range src.ReactionGroups {
+		comment.ReactionGroups = append(comment.ReactionGroups, ReactionGroup{
+			Content:    rg.Content,
+			TotalCount: rg.Users.TotalCount,
+		})
+	}
+	return comment, nil
+}

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -3769,7 +3769,7 @@ func TestGetComment(t *testing.T) {
 
 			repo := ghrepo.New("OWNER", "REPO")
 			c := newTestDiscussionClient(reg)
-			comment, err := c.GetComment(repo, tt.commentID)
+			comment, err := c.GetComment(repo.RepoHost(), tt.commentID)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -3599,3 +3599,374 @@ func TestUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestAddComment(t *testing.T) {
+	tests := []struct {
+		name         string
+		discussionID string
+		body         string
+		replyToID    string
+		httpStubs    func(*testing.T, *httpmock.Registry)
+		wantErr      string
+		wantComment  *DiscussionComment
+	}{
+		{
+			name:         "adds top-level comment",
+			discussionID: "D_123",
+			body:         "Hello world",
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQLMutationMatcher(`mutation AddDiscussionComment\b`, func(input map[string]interface{}) bool {
+						assert.Equal(t, "D_123", input["discussionId"])
+						assert.Equal(t, "Hello world", input["body"])
+						assert.Nil(t, input["replyToId"])
+						return true
+					}),
+					httpmock.StringResponse(`{
+						"data": {
+							"addDiscussionComment": {
+								"comment": {
+									"id": "DC_1",
+									"url": "https://github.com/OWNER/REPO/discussions/1#discussioncomment-1",
+									"author": {"__typename": "User", "login": "monalisa", "id": "U1", "name": "Mona"},
+									"body": "Hello world",
+									"createdAt": "2025-06-01T00:00:00Z",
+									"isAnswer": false,
+									"upvoteCount": 1,
+									"reactionGroups": [{"content": "THUMBS_UP", "users": {"totalCount": 0}}]
+								}
+							}
+						}
+					}`),
+				)
+			},
+			wantComment: &DiscussionComment{
+				ID:             "DC_1",
+				URL:            "https://github.com/OWNER/REPO/discussions/1#discussioncomment-1",
+				Author:         DiscussionActor{ID: "U1", Login: "monalisa", Name: "Mona"},
+				Body:           "Hello world",
+				CreatedAt:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				UpvoteCount:    1,
+				ReactionGroups: []ReactionGroup{{Content: "THUMBS_UP", TotalCount: 0}},
+			},
+		},
+		{
+			name:         "adds reply to comment",
+			discussionID: "D_123",
+			body:         "Reply text",
+			replyToID:    "DC_parent",
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQLMutationMatcher(`mutation AddDiscussionComment\b`, func(input map[string]interface{}) bool {
+						assert.Equal(t, "D_123", input["discussionId"])
+						assert.Equal(t, "Reply text", input["body"])
+						assert.Equal(t, "DC_parent", input["replyToId"])
+						return true
+					}),
+					httpmock.StringResponse(`{
+						"data": {
+							"addDiscussionComment": {
+								"comment": {
+									"id": "DC_reply",
+									"url": "https://github.com/OWNER/REPO/discussions/1#discussioncomment-2",
+									"author": {"__typename": "User", "login": "monalisa", "id": "U1", "name": "Mona"},
+									"body": "Reply text",
+									"createdAt": "2025-06-01T00:00:00Z",
+									"isAnswer": false,
+									"upvoteCount": 1,
+									"reactionGroups": [{"content": "THUMBS_UP", "users": {"totalCount": 0}}]
+								}
+							}
+						}
+					}`),
+				)
+			},
+			wantComment: &DiscussionComment{
+				ID:             "DC_reply",
+				URL:            "https://github.com/OWNER/REPO/discussions/1#discussioncomment-2",
+				Author:         DiscussionActor{ID: "U1", Login: "monalisa", Name: "Mona"},
+				Body:           "Reply text",
+				CreatedAt:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				UpvoteCount:    1,
+				ReactionGroups: []ReactionGroup{{Content: "THUMBS_UP", TotalCount: 0}},
+			},
+		},
+		{
+			name:         "mutation error",
+			discussionID: "D_bad",
+			body:         "text",
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation AddDiscussionComment\b`),
+					httpmock.StringResponse(`{"data":null,"errors":[{"message":"not found"}]}`),
+				)
+			},
+			wantErr: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, reg)
+			}
+
+			repo := ghrepo.New("OWNER", "REPO")
+			c := newTestDiscussionClient(reg)
+			comment, err := c.AddComment(repo, tt.discussionID, tt.body, tt.replyToID)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, comment)
+			assert.Equal(t, tt.wantComment, comment)
+		})
+	}
+}
+
+func TestUpdateComment(t *testing.T) {
+	tests := []struct {
+		name        string
+		commentID   string
+		body        string
+		httpStubs   func(*testing.T, *httpmock.Registry)
+		wantErr     string
+		wantComment *DiscussionComment
+	}{
+		{
+			name:      "updates comment body",
+			commentID: "DC_1",
+			body:      "Updated body",
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQLMutationMatcher(`mutation UpdateDiscussionComment\b`, func(input map[string]interface{}) bool {
+						assert.Equal(t, "DC_1", input["commentId"])
+						assert.Equal(t, "Updated body", input["body"])
+						return true
+					}),
+					httpmock.StringResponse(`{
+						"data": {
+							"updateDiscussionComment": {
+								"comment": {
+									"id": "DC_1",
+									"url": "https://github.com/OWNER/REPO/discussions/1#discussioncomment-1",
+									"author": {"__typename": "User", "login": "monalisa", "id": "U1", "name": "Mona"},
+									"body": "Updated body",
+									"createdAt": "2025-06-01T00:00:00Z",
+									"isAnswer": true,
+									"upvoteCount": 5,
+									"reactionGroups": [{"content": "HEART", "users": {"totalCount": 3}}]
+								}
+							}
+						}
+					}`),
+				)
+			},
+			wantComment: &DiscussionComment{
+				ID:             "DC_1",
+				URL:            "https://github.com/OWNER/REPO/discussions/1#discussioncomment-1",
+				Author:         DiscussionActor{ID: "U1", Login: "monalisa", Name: "Mona"},
+				Body:           "Updated body",
+				CreatedAt:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				IsAnswer:       true,
+				UpvoteCount:    5,
+				ReactionGroups: []ReactionGroup{{Content: "HEART", TotalCount: 3}},
+			},
+		},
+		{
+			name:      "mutation error",
+			commentID: "DC_bad",
+			body:      "text",
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateDiscussionComment\b`),
+					httpmock.StringResponse(`{"data":null,"errors":[{"message":"not found"}]}`),
+				)
+			},
+			wantErr: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, reg)
+			}
+
+			repo := ghrepo.New("OWNER", "REPO")
+			c := newTestDiscussionClient(reg)
+			comment, err := c.UpdateComment(repo, tt.commentID, tt.body)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, comment)
+			assert.Equal(t, tt.wantComment, comment)
+		})
+	}
+}
+
+func TestDeleteComment(t *testing.T) {
+	tests := []struct {
+		name      string
+		commentID string
+		httpStubs func(*httpmock.Registry)
+		wantErr   string
+	}{
+		{
+			name:      "deletes comment",
+			commentID: "DC_1",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation DeleteDiscussionComment\b`),
+					httpmock.StringResponse(`{"data":{"deleteDiscussionComment":{"comment":{"id":"DC_1"}}}}`),
+				)
+			},
+		},
+		{
+			name:      "mutation error",
+			commentID: "DC_bad",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`mutation DeleteDiscussionComment\b`),
+					httpmock.StringResponse(`{"data":null,"errors":[{"message":"not found"}]}`),
+				)
+			},
+			wantErr: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			if tt.httpStubs != nil {
+				tt.httpStubs(reg)
+			}
+
+			repo := ghrepo.New("OWNER", "REPO")
+			c := newTestDiscussionClient(reg)
+			err := c.DeleteComment(repo, tt.commentID)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGetComment(t *testing.T) {
+	tests := []struct {
+		name        string
+		commentID   string
+		httpStubs   func(*httpmock.Registry)
+		wantErr     string
+		wantComment *DiscussionComment
+	}{
+		{
+			name:      "fetches comment",
+			commentID: "DC_1",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query GetDiscussionComment\b`),
+					httpmock.StringResponse(`{
+						"data": {
+							"node": {
+								"__typename": "DiscussionComment",
+								"id": "DC_1",
+								"url": "https://github.com/OWNER/REPO/discussions/1#discussioncomment-1",
+								"author": {"__typename": "User", "login": "monalisa", "id": "U1", "name": "Mona"},
+								"body": "Comment body",
+								"createdAt": "2025-06-01T00:00:00Z",
+								"isAnswer": false,
+								"upvoteCount": 2,
+								"reactionGroups": [{"content": "THUMBS_UP", "users": {"totalCount": 1}}]
+							}
+						}
+					}`),
+				)
+			},
+			wantComment: &DiscussionComment{
+				ID:             "DC_1",
+				URL:            "https://github.com/OWNER/REPO/discussions/1#discussioncomment-1",
+				Author:         DiscussionActor{ID: "U1", Login: "monalisa", Name: "Mona"},
+				Body:           "Comment body",
+				CreatedAt:      time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+				UpvoteCount:    2,
+				ReactionGroups: []ReactionGroup{{Content: "THUMBS_UP", TotalCount: 1}},
+			},
+		},
+		{
+			name:      "wrong node type",
+			commentID: "I_123",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query GetDiscussionComment\b`),
+					httpmock.StringResponse(`{
+						"data": {
+							"node": {
+								"__typename": "Issue"
+							}
+						}
+					}`),
+				)
+			},
+			wantErr: "is not a discussion comment (got Issue)",
+		},
+		{
+			name:      "not found",
+			commentID: "DC_bad",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query GetDiscussionComment\b`),
+					httpmock.StringResponse(`{"data":null,"errors":[{"message":"Could not resolve to a node"}]}`),
+				)
+			},
+			wantErr: "Could not resolve to a node",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			if tt.httpStubs != nil {
+				tt.httpStubs(reg)
+			}
+
+			repo := ghrepo.New("OWNER", "REPO")
+			c := newTestDiscussionClient(reg)
+			comment, err := c.GetComment(repo, tt.commentID)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, comment)
+			assert.Equal(t, tt.wantComment, comment)
+		})
+	}
+}

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -2533,6 +2533,7 @@ func repoMetaResp(id string, discussionsEnabled bool) string {
 		"data": {
 			"repository": {
 				"id": %q,
+				"databaseId": 982069338,
 				"hasDiscussionsEnabled": %t
 			}
 		}
@@ -3967,6 +3968,63 @@ func TestGetComment(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, comment)
 			assert.Equal(t, tt.wantComment, comment)
+		})
+	}
+}
+
+func TestResolveCommentNodeID(t *testing.T) {
+	tests := []struct {
+		name             string
+		commentDatabaseID int64
+		httpStubs        func(*httpmock.Registry)
+		wantNodeID       string
+		wantErr          string
+	}{
+		{
+			name:             "encodes node ID correctly",
+			commentDatabaseID: 17196842,
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
+					httpmock.StringResponse(repoMetaResp("R_1", true)),
+				)
+			},
+			wantNodeID: "DC_kwDOOokwWs4BBmcq",
+		},
+		{
+			name:             "repo not found",
+			commentDatabaseID: 123,
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
+					httpmock.StringResponse(`{"data":null,"errors":[{"message":"repo not found"}]}`),
+				)
+			},
+			wantErr: "repo not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := ghrepo.New("OWNER", "REPO")
+			reg := &httpmock.Registry{}
+			defer reg.Verify(t)
+
+			if tt.httpStubs != nil {
+				tt.httpStubs(reg)
+			}
+
+			c := newTestDiscussionClient(reg)
+			nodeID, err := c.ResolveCommentNodeID(repo, tt.commentDatabaseID)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantNodeID, nodeID)
 		})
 	}
 }

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -3974,14 +3974,14 @@ func TestGetComment(t *testing.T) {
 
 func TestResolveCommentNodeID(t *testing.T) {
 	tests := []struct {
-		name             string
+		name              string
 		commentDatabaseID int64
-		httpStubs        func(*httpmock.Registry)
-		wantNodeID       string
-		wantErr          string
+		httpStubs         func(*httpmock.Registry)
+		wantNodeID        string
+		wantErr           string
 	}{
 		{
-			name:             "encodes node ID correctly",
+			name:              "encodes node ID correctly",
 			commentDatabaseID: 17196842,
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(
@@ -3992,7 +3992,7 @@ func TestResolveCommentNodeID(t *testing.T) {
 			wantNodeID: "DC_kwDOOokwWs4BBmcq",
 		},
 		{
-			name:             "repo not found",
+			name:              "repo not found",
 			commentDatabaseID: 123,
 			httpStubs: func(reg *httpmock.Registry) {
 				reg.Register(

--- a/pkg/cmd/discussion/client/client_impl_test.go
+++ b/pkg/cmd/discussion/client/client_impl_test.go
@@ -1813,8 +1813,6 @@ func TestGetWithComments(t *testing.T) {
 }
 
 func TestGetCommentReplies(t *testing.T) {
-	repo := ghrepo.New("OWNER", "REPO")
-
 	tests := []struct {
 		name       string
 		commentID  string
@@ -1832,15 +1830,19 @@ func TestGetCommentReplies(t *testing.T) {
 			newest:    false,
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", true)),
-				)
-				reg.Register(
 					httpmock.GraphQL(`query DiscussionCommentReplies\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
-								"repository": {
+								"node": {
+									"id": "DC_abc",
+									"url": "https://github.com/OWNER/REPO/discussions/42#discussioncomment-1",
+									"author": {"__typename": "User", "login": "octocat", "id": "U_octocat", "name": "Octocat"},
+									"body": "Top-level comment",
+									"createdAt": "2025-03-01T00:00:00Z",
+									"isAnswer": true,
+									"upvoteCount": 5,
+									"reactionGroups": [{"content": "HEART", "users": {"totalCount": 2}}],
 									"discussion": {
 										"id": "D_1",
 										"number": 42,
@@ -1860,18 +1862,7 @@ func TestGetCommentReplies(t *testing.T) {
 										"updatedAt": "2025-01-02T00:00:00Z",
 										"closedAt": "2025-06-01T00:00:00Z",
 										"locked": true
-									}
-								},
-								"node": {
-									"id": "DC_abc",
-									"url": "https://github.com/OWNER/REPO/discussions/42#discussioncomment-1",
-									"author": {"__typename": "User", "login": "octocat", "id": "U_octocat", "name": "Octocat"},
-									"body": "Top-level comment",
-									"createdAt": "2025-03-01T00:00:00Z",
-									"isAnswer": true,
-									"upvoteCount": 5,
-									"reactionGroups": [{"content": "HEART", "users": {"totalCount": 2}}],
-									"discussion": {"number": 42, "repository": {"owner": {"login": "OWNER"}, "name": "REPO"}},
+									},
 									"replies": {
 										"totalCount": 1,
 										"pageInfo": {"endCursor": "REP_CUR", "hasNextPage": true, "startCursor": "REP_START", "hasPreviousPage": false},
@@ -1962,15 +1953,19 @@ func TestGetCommentReplies(t *testing.T) {
 			newest:    false,
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", true)),
-				)
-				reg.Register(
 					httpmock.GraphQL(`query DiscussionCommentReplies\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
-								"repository": {
+								"node": {
+									"id": "DC_abc",
+									"url": "",
+									"author": {"__typename": "User", "login": "alice"},
+									"body": "Comment",
+									"createdAt": "2025-01-01T00:00:00Z",
+									"isAnswer": false,
+									"upvoteCount": 0,
+									"reactionGroups": [],
 									"discussion": {
 										"id": "D_1",
 										"number": 1,
@@ -1990,18 +1985,7 @@ func TestGetCommentReplies(t *testing.T) {
 										"updatedAt": "2024-01-01T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
 										"locked": false
-									}
-								},
-								"node": {
-									"id": "DC_abc",
-									"url": "",
-									"author": {"__typename": "User", "login": "alice"},
-									"body": "Comment",
-									"createdAt": "2025-01-01T00:00:00Z",
-									"isAnswer": false,
-									"upvoteCount": 0,
-									"reactionGroups": [],
-									"discussion": {"number": 42, "repository": {"owner": {"login": "OWNER"}, "name": "REPO"}},
+									},
 									"replies": {
 										"totalCount": 3,
 										"pageInfo": {"endCursor": "CUR_B", "hasNextPage": true, "startCursor": "CUR_A", "hasPreviousPage": false},
@@ -2053,15 +2037,19 @@ func TestGetCommentReplies(t *testing.T) {
 			newest:    true,
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", true)),
-				)
-				reg.Register(
 					httpmock.GraphQL(`query DiscussionCommentReplies\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
-								"repository": {
+								"node": {
+									"id": "DC_abc",
+									"url": "",
+									"author": {"__typename": "User", "login": "alice"},
+									"body": "Comment",
+									"createdAt": "2025-01-01T00:00:00Z",
+									"isAnswer": false,
+									"upvoteCount": 0,
+									"reactionGroups": [],
 									"discussion": {
 										"id": "D_1",
 										"number": 1,
@@ -2081,18 +2069,7 @@ func TestGetCommentReplies(t *testing.T) {
 										"updatedAt": "2024-01-01T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
 										"locked": false
-									}
-								},
-								"node": {
-									"id": "DC_abc",
-									"url": "",
-									"author": {"__typename": "User", "login": "alice"},
-									"body": "Comment",
-									"createdAt": "2025-01-01T00:00:00Z",
-									"isAnswer": false,
-									"upvoteCount": 0,
-									"reactionGroups": [],
-									"discussion": {"number": 42, "repository": {"owner": {"login": "OWNER"}, "name": "REPO"}},
+									},
 									"replies": {
 										"totalCount": 5,
 										"pageInfo": {"endCursor": "CUR_END", "hasNextPage": false, "startCursor": "CUR_Y", "hasPreviousPage": true},
@@ -2143,15 +2120,19 @@ func TestGetCommentReplies(t *testing.T) {
 			newest:    true,
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", true)),
-				)
-				reg.Register(
 					httpmock.GraphQL(`query DiscussionCommentReplies\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
-								"repository": {
+								"node": {
+									"id": "DC_abc",
+									"url": "",
+									"author": {"__typename": "User", "login": "alice"},
+									"body": "Comment",
+									"createdAt": "2025-01-01T00:00:00Z",
+									"isAnswer": false,
+									"upvoteCount": 0,
+									"reactionGroups": [],
 									"discussion": {
 										"id": "D_1",
 										"number": 1,
@@ -2171,18 +2152,7 @@ func TestGetCommentReplies(t *testing.T) {
 										"updatedAt": "2024-01-01T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
 										"locked": false
-									}
-								},
-								"node": {
-									"id": "DC_abc",
-									"url": "",
-									"author": {"__typename": "User", "login": "alice"},
-									"body": "Comment",
-									"createdAt": "2025-01-01T00:00:00Z",
-									"isAnswer": false,
-									"upvoteCount": 0,
-									"reactionGroups": [],
-									"discussion": {"number": 42, "repository": {"owner": {"login": "OWNER"}, "name": "REPO"}},
+									},
 									"replies": {
 										"totalCount": 3,
 										"pageInfo": {"endCursor": "", "hasNextPage": false, "startCursor": "CUR_START", "hasPreviousPage": true},
@@ -2233,15 +2203,19 @@ func TestGetCommentReplies(t *testing.T) {
 			newest:    false,
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", true)),
-				)
-				reg.Register(
 					httpmock.GraphQL(`query DiscussionCommentReplies\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
-								"repository": {
+								"node": {
+									"id": "DC_abc",
+									"url": "",
+									"author": {"__typename": "User", "login": "alice"},
+									"body": "Comment",
+									"createdAt": "2025-01-01T00:00:00Z",
+									"isAnswer": false,
+									"upvoteCount": 0,
+									"reactionGroups": [],
 									"discussion": {
 										"id": "D_1",
 										"number": 1,
@@ -2261,18 +2235,7 @@ func TestGetCommentReplies(t *testing.T) {
 										"updatedAt": "2024-01-01T00:00:00Z",
 										"closedAt": "0001-01-01T00:00:00Z",
 										"locked": false
-									}
-								},
-								"node": {
-									"id": "DC_abc",
-									"url": "",
-									"author": {"__typename": "User", "login": "alice"},
-									"body": "Comment",
-									"createdAt": "2025-01-01T00:00:00Z",
-									"isAnswer": false,
-									"upvoteCount": 0,
-									"reactionGroups": [],
-									"discussion": {"number": 42, "repository": {"owner": {"login": "OWNER"}, "name": "REPO"}},
+									},
 									"replies": {
 										"totalCount": 1,
 										"pageInfo": {"endCursor": "CUR_ONLY", "hasNextPage": false, "startCursor": "CUR_ONLY", "hasPreviousPage": false},
@@ -2304,81 +2267,16 @@ func TestGetCommentReplies(t *testing.T) {
 			},
 		},
 		{
-			name:      "discussions disabled",
-			commentID: "DC_abc",
-			limit:     10,
-			newest:    false,
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", false)),
-				)
-			},
-			wantErr: "has discussions disabled",
-		},
-		{
-			name:      "repo not found",
-			commentID: "DC_abc",
-			limit:     10,
-			newest:    false,
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"repository": null
-							},
-							"errors": [
-								{
-									"type": "NOT_FOUND",
-									"path": ["repository"],
-									"message": "Could not resolve to a Repository with the name 'OWNER/REPO'."
-								}
-							]
-						}
-					`)),
-				)
-			},
-			wantErr: "Could not resolve to a Repository",
-		},
-		{
 			name:      "reply node not found",
 			commentID: "DC_invalid",
 			limit:     10,
 			newest:    false,
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", true)),
-				)
-				reg.Register(
 					httpmock.GraphQL(`query DiscussionCommentReplies\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
-								"repository": {
-									"discussion": {
-										"id": "D_1",
-										"number": 1,
-										"title": "Test",
-										"body": "",
-										"url": "",
-										"closed": false,
-										"stateReason": "",
-										"isAnswered": false,
-										"answerChosenAt": "0001-01-01T00:00:00Z",
-										"author": {"__typename": "User", "login": "alice"},
-										"category": {"id": "C1", "name": "General", "slug": "general", "emoji": "", "isAnswerable": false},
-										"answerChosenBy": null,
-										"labels": {"nodes": []},
-										"reactionGroups": [],
-										"createdAt": "2024-01-01T00:00:00Z",
-										"updatedAt": "2024-01-01T00:00:00Z",
-										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false
-									}
-								},
 								"node": null
 							},
 							"errors": [
@@ -2401,36 +2299,10 @@ func TestGetCommentReplies(t *testing.T) {
 			newest:    false,
 			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
-					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", true)),
-				)
-				reg.Register(
 					httpmock.GraphQL(`query DiscussionCommentReplies\b`),
 					httpmock.StringResponse(heredoc.Doc(`
 						{
 							"data": {
-								"repository": {
-									"discussion": {
-										"id": "D_1",
-										"number": 1,
-										"title": "Test",
-										"body": "",
-										"url": "",
-										"closed": false,
-										"stateReason": "",
-										"isAnswered": false,
-										"answerChosenAt": "0001-01-01T00:00:00Z",
-										"author": {"__typename": "User", "login": "alice"},
-										"category": {"id": "C1", "name": "General", "slug": "general", "emoji": "", "isAnswerable": false},
-										"answerChosenBy": null,
-										"labels": {"nodes": []},
-										"reactionGroups": [],
-										"createdAt": "2024-01-01T00:00:00Z",
-										"updatedAt": "2024-01-01T00:00:00Z",
-										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false
-									}
-								},
 								"node": {}
 							}
 						}
@@ -2438,66 +2310,6 @@ func TestGetCommentReplies(t *testing.T) {
 				)
 			},
 			wantErr: "node I_notacomment is not a discussion comment",
-		},
-		{
-			name:      "comment belongs to different repo",
-			commentID: "DC_other",
-			limit:     10,
-			newest:    false,
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query RepositoryMetaForDiscussions\b`),
-					httpmock.StringResponse(repoMetaResp("R_1", true)),
-				)
-				reg.Register(
-					httpmock.GraphQL(`query DiscussionCommentReplies\b`),
-					httpmock.StringResponse(heredoc.Doc(`
-						{
-							"data": {
-								"repository": {
-									"discussion": {
-										"id": "D_1",
-										"number": 1,
-										"title": "Test",
-										"body": "",
-										"url": "",
-										"closed": false,
-										"stateReason": "",
-										"isAnswered": false,
-										"answerChosenAt": "0001-01-01T00:00:00Z",
-										"author": {"__typename": "User", "login": "alice"},
-										"category": {"id": "C1", "name": "General", "slug": "general", "emoji": "", "isAnswerable": false},
-										"answerChosenBy": null,
-										"labels": {"nodes": []},
-										"reactionGroups": [],
-										"createdAt": "2024-01-01T00:00:00Z",
-										"updatedAt": "2024-01-01T00:00:00Z",
-										"closedAt": "0001-01-01T00:00:00Z",
-										"locked": false
-									}
-								},
-								"node": {
-									"id": "DC_other",
-									"url": "",
-									"author": {"__typename": "User", "login": "alice"},
-									"body": "Comment",
-									"createdAt": "2025-01-01T00:00:00Z",
-									"isAnswer": false,
-									"upvoteCount": 0,
-									"reactionGroups": [],
-									"discussion": {"number": 99, "repository": {"owner": {"login": "OTHER"}, "name": "DIFFERENT"}},
-									"replies": {
-										"totalCount": 0,
-										"pageInfo": {"endCursor": "", "hasNextPage": false, "startCursor": "", "hasPreviousPage": false},
-										"nodes": []
-									}
-								}
-							}
-						}
-					`)),
-				)
-			},
-			wantErr: "comment DC_other does not belong to OWNER/REPO",
 		},
 	}
 
@@ -2511,7 +2323,7 @@ func TestGetCommentReplies(t *testing.T) {
 			}
 
 			c := newTestDiscussionClient(reg)
-			d, err := c.GetCommentReplies(repo, 1, tt.commentID, tt.limit, tt.after, tt.newest)
+			d, err := c.GetCommentReplies("github.com", tt.commentID, tt.limit, tt.after, tt.newest)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)

--- a/pkg/cmd/discussion/client/client_mock.go
+++ b/pkg/cmd/discussion/client/client_mock.go
@@ -48,6 +48,9 @@ var _ DiscussionClient = &DiscussionClientMock{}
 //			ListLabelsFunc: func(repo ghrepo.Interface) ([]DiscussionLabel, error) {
 //				panic("mock out the ListLabels method")
 //			},
+//			ResolveCommentNodeIDFunc: func(repo ghrepo.Interface, commentDatabaseID int64) (string, error) {
+//				panic("mock out the ResolveCommentNodeID method")
+//			},
 //			SearchFunc: func(repo ghrepo.Interface, filters SearchFilters, after string, limit int) (*DiscussionListResult, error) {
 //				panic("mock out the Search method")
 //			},
@@ -93,6 +96,9 @@ type DiscussionClientMock struct {
 
 	// ListLabelsFunc mocks the ListLabels method.
 	ListLabelsFunc func(repo ghrepo.Interface) ([]DiscussionLabel, error)
+
+	// ResolveCommentNodeIDFunc mocks the ResolveCommentNodeID method.
+	ResolveCommentNodeIDFunc func(repo ghrepo.Interface, commentDatabaseID int64) (string, error)
 
 	// SearchFunc mocks the Search method.
 	SearchFunc func(repo ghrepo.Interface, filters SearchFilters, after string, limit int) (*DiscussionListResult, error)
@@ -193,6 +199,13 @@ type DiscussionClientMock struct {
 			// Repo is the repo argument value.
 			Repo ghrepo.Interface
 		}
+		// ResolveCommentNodeID holds details about calls to the ResolveCommentNodeID method.
+		ResolveCommentNodeID []struct {
+			// Repo is the repo argument value.
+			Repo ghrepo.Interface
+			// CommentDatabaseID is the commentDatabaseID argument value.
+			CommentDatabaseID int64
+		}
 		// Search holds details about calls to the Search method.
 		Search []struct {
 			// Repo is the repo argument value.
@@ -221,19 +234,20 @@ type DiscussionClientMock struct {
 			Body string
 		}
 	}
-	lockAddComment        sync.RWMutex
-	lockCreate            sync.RWMutex
-	lockDeleteComment     sync.RWMutex
-	lockGetByNumber       sync.RWMutex
-	lockGetComment        sync.RWMutex
-	lockGetCommentReplies sync.RWMutex
-	lockGetWithComments   sync.RWMutex
-	lockList              sync.RWMutex
-	lockListCategories    sync.RWMutex
-	lockListLabels        sync.RWMutex
-	lockSearch            sync.RWMutex
-	lockUpdate            sync.RWMutex
-	lockUpdateComment     sync.RWMutex
+	lockAddComment           sync.RWMutex
+	lockCreate               sync.RWMutex
+	lockDeleteComment        sync.RWMutex
+	lockGetByNumber          sync.RWMutex
+	lockGetComment           sync.RWMutex
+	lockGetCommentReplies    sync.RWMutex
+	lockGetWithComments      sync.RWMutex
+	lockList                 sync.RWMutex
+	lockListCategories       sync.RWMutex
+	lockListLabels           sync.RWMutex
+	lockResolveCommentNodeID sync.RWMutex
+	lockSearch               sync.RWMutex
+	lockUpdate               sync.RWMutex
+	lockUpdateComment        sync.RWMutex
 }
 
 // AddComment calls AddCommentFunc.
@@ -629,6 +643,42 @@ func (mock *DiscussionClientMock) ListLabelsCalls() []struct {
 	mock.lockListLabels.RLock()
 	calls = mock.calls.ListLabels
 	mock.lockListLabels.RUnlock()
+	return calls
+}
+
+// ResolveCommentNodeID calls ResolveCommentNodeIDFunc.
+func (mock *DiscussionClientMock) ResolveCommentNodeID(repo ghrepo.Interface, commentDatabaseID int64) (string, error) {
+	if mock.ResolveCommentNodeIDFunc == nil {
+		panic("DiscussionClientMock.ResolveCommentNodeIDFunc: method is nil but DiscussionClient.ResolveCommentNodeID was just called")
+	}
+	callInfo := struct {
+		Repo              ghrepo.Interface
+		CommentDatabaseID int64
+	}{
+		Repo:              repo,
+		CommentDatabaseID: commentDatabaseID,
+	}
+	mock.lockResolveCommentNodeID.Lock()
+	mock.calls.ResolveCommentNodeID = append(mock.calls.ResolveCommentNodeID, callInfo)
+	mock.lockResolveCommentNodeID.Unlock()
+	return mock.ResolveCommentNodeIDFunc(repo, commentDatabaseID)
+}
+
+// ResolveCommentNodeIDCalls gets all the calls that were made to ResolveCommentNodeID.
+// Check the length with:
+//
+//	len(mockedDiscussionClient.ResolveCommentNodeIDCalls())
+func (mock *DiscussionClientMock) ResolveCommentNodeIDCalls() []struct {
+	Repo              ghrepo.Interface
+	CommentDatabaseID int64
+} {
+	var calls []struct {
+		Repo              ghrepo.Interface
+		CommentDatabaseID int64
+	}
+	mock.lockResolveCommentNodeID.RLock()
+	calls = mock.calls.ResolveCommentNodeID
+	mock.lockResolveCommentNodeID.RUnlock()
 	return calls
 }
 

--- a/pkg/cmd/discussion/client/client_mock.go
+++ b/pkg/cmd/discussion/client/client_mock.go
@@ -18,11 +18,20 @@ var _ DiscussionClient = &DiscussionClientMock{}
 //
 //		// make and configure a mocked DiscussionClient
 //		mockedDiscussionClient := &DiscussionClientMock{
+//			AddCommentFunc: func(repo ghrepo.Interface, discussionID string, body string, replyToID string) (*DiscussionComment, error) {
+//				panic("mock out the AddComment method")
+//			},
 //			CreateFunc: func(repo ghrepo.Interface, input CreateDiscussionInput) (*Discussion, error) {
 //				panic("mock out the Create method")
 //			},
+//			DeleteCommentFunc: func(repo ghrepo.Interface, commentID string) error {
+//				panic("mock out the DeleteComment method")
+//			},
 //			GetByNumberFunc: func(repo ghrepo.Interface, number int32) (*Discussion, error) {
 //				panic("mock out the GetByNumber method")
+//			},
+//			GetCommentFunc: func(repo ghrepo.Interface, commentID string) (*DiscussionComment, error) {
+//				panic("mock out the GetComment method")
 //			},
 //			GetCommentRepliesFunc: func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*Discussion, error) {
 //				panic("mock out the GetCommentReplies method")
@@ -45,6 +54,9 @@ var _ DiscussionClient = &DiscussionClientMock{}
 //			UpdateFunc: func(repo ghrepo.Interface, input UpdateDiscussionInput) (*Discussion, error) {
 //				panic("mock out the Update method")
 //			},
+//			UpdateCommentFunc: func(repo ghrepo.Interface, commentID string, body string) (*DiscussionComment, error) {
+//				panic("mock out the UpdateComment method")
+//			},
 //		}
 //
 //		// use mockedDiscussionClient in code that requires DiscussionClient
@@ -52,11 +64,20 @@ var _ DiscussionClient = &DiscussionClientMock{}
 //
 //	}
 type DiscussionClientMock struct {
+	// AddCommentFunc mocks the AddComment method.
+	AddCommentFunc func(repo ghrepo.Interface, discussionID string, body string, replyToID string) (*DiscussionComment, error)
+
 	// CreateFunc mocks the Create method.
 	CreateFunc func(repo ghrepo.Interface, input CreateDiscussionInput) (*Discussion, error)
 
+	// DeleteCommentFunc mocks the DeleteComment method.
+	DeleteCommentFunc func(repo ghrepo.Interface, commentID string) error
+
 	// GetByNumberFunc mocks the GetByNumber method.
 	GetByNumberFunc func(repo ghrepo.Interface, number int32) (*Discussion, error)
+
+	// GetCommentFunc mocks the GetComment method.
+	GetCommentFunc func(repo ghrepo.Interface, commentID string) (*DiscussionComment, error)
 
 	// GetCommentRepliesFunc mocks the GetCommentReplies method.
 	GetCommentRepliesFunc func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*Discussion, error)
@@ -79,8 +100,22 @@ type DiscussionClientMock struct {
 	// UpdateFunc mocks the Update method.
 	UpdateFunc func(repo ghrepo.Interface, input UpdateDiscussionInput) (*Discussion, error)
 
+	// UpdateCommentFunc mocks the UpdateComment method.
+	UpdateCommentFunc func(repo ghrepo.Interface, commentID string, body string) (*DiscussionComment, error)
+
 	// calls tracks calls to the methods.
 	calls struct {
+		// AddComment holds details about calls to the AddComment method.
+		AddComment []struct {
+			// Repo is the repo argument value.
+			Repo ghrepo.Interface
+			// DiscussionID is the discussionID argument value.
+			DiscussionID string
+			// Body is the body argument value.
+			Body string
+			// ReplyToID is the replyToID argument value.
+			ReplyToID string
+		}
 		// Create holds details about calls to the Create method.
 		Create []struct {
 			// Repo is the repo argument value.
@@ -88,12 +123,26 @@ type DiscussionClientMock struct {
 			// Input is the input argument value.
 			Input CreateDiscussionInput
 		}
+		// DeleteComment holds details about calls to the DeleteComment method.
+		DeleteComment []struct {
+			// Repo is the repo argument value.
+			Repo ghrepo.Interface
+			// CommentID is the commentID argument value.
+			CommentID string
+		}
 		// GetByNumber holds details about calls to the GetByNumber method.
 		GetByNumber []struct {
 			// Repo is the repo argument value.
 			Repo ghrepo.Interface
 			// Number is the number argument value.
 			Number int32
+		}
+		// GetComment holds details about calls to the GetComment method.
+		GetComment []struct {
+			// Repo is the repo argument value.
+			Repo ghrepo.Interface
+			// CommentID is the commentID argument value.
+			CommentID string
 		}
 		// GetCommentReplies holds details about calls to the GetCommentReplies method.
 		GetCommentReplies []struct {
@@ -162,9 +211,21 @@ type DiscussionClientMock struct {
 			// Input is the input argument value.
 			Input UpdateDiscussionInput
 		}
+		// UpdateComment holds details about calls to the UpdateComment method.
+		UpdateComment []struct {
+			// Repo is the repo argument value.
+			Repo ghrepo.Interface
+			// CommentID is the commentID argument value.
+			CommentID string
+			// Body is the body argument value.
+			Body string
+		}
 	}
+	lockAddComment        sync.RWMutex
 	lockCreate            sync.RWMutex
+	lockDeleteComment     sync.RWMutex
 	lockGetByNumber       sync.RWMutex
+	lockGetComment        sync.RWMutex
 	lockGetCommentReplies sync.RWMutex
 	lockGetWithComments   sync.RWMutex
 	lockList              sync.RWMutex
@@ -172,6 +233,51 @@ type DiscussionClientMock struct {
 	lockListLabels        sync.RWMutex
 	lockSearch            sync.RWMutex
 	lockUpdate            sync.RWMutex
+	lockUpdateComment     sync.RWMutex
+}
+
+// AddComment calls AddCommentFunc.
+func (mock *DiscussionClientMock) AddComment(repo ghrepo.Interface, discussionID string, body string, replyToID string) (*DiscussionComment, error) {
+	if mock.AddCommentFunc == nil {
+		panic("DiscussionClientMock.AddCommentFunc: method is nil but DiscussionClient.AddComment was just called")
+	}
+	callInfo := struct {
+		Repo         ghrepo.Interface
+		DiscussionID string
+		Body         string
+		ReplyToID    string
+	}{
+		Repo:         repo,
+		DiscussionID: discussionID,
+		Body:         body,
+		ReplyToID:    replyToID,
+	}
+	mock.lockAddComment.Lock()
+	mock.calls.AddComment = append(mock.calls.AddComment, callInfo)
+	mock.lockAddComment.Unlock()
+	return mock.AddCommentFunc(repo, discussionID, body, replyToID)
+}
+
+// AddCommentCalls gets all the calls that were made to AddComment.
+// Check the length with:
+//
+//	len(mockedDiscussionClient.AddCommentCalls())
+func (mock *DiscussionClientMock) AddCommentCalls() []struct {
+	Repo         ghrepo.Interface
+	DiscussionID string
+	Body         string
+	ReplyToID    string
+} {
+	var calls []struct {
+		Repo         ghrepo.Interface
+		DiscussionID string
+		Body         string
+		ReplyToID    string
+	}
+	mock.lockAddComment.RLock()
+	calls = mock.calls.AddComment
+	mock.lockAddComment.RUnlock()
+	return calls
 }
 
 // Create calls CreateFunc.
@@ -210,6 +316,42 @@ func (mock *DiscussionClientMock) CreateCalls() []struct {
 	return calls
 }
 
+// DeleteComment calls DeleteCommentFunc.
+func (mock *DiscussionClientMock) DeleteComment(repo ghrepo.Interface, commentID string) error {
+	if mock.DeleteCommentFunc == nil {
+		panic("DiscussionClientMock.DeleteCommentFunc: method is nil but DiscussionClient.DeleteComment was just called")
+	}
+	callInfo := struct {
+		Repo      ghrepo.Interface
+		CommentID string
+	}{
+		Repo:      repo,
+		CommentID: commentID,
+	}
+	mock.lockDeleteComment.Lock()
+	mock.calls.DeleteComment = append(mock.calls.DeleteComment, callInfo)
+	mock.lockDeleteComment.Unlock()
+	return mock.DeleteCommentFunc(repo, commentID)
+}
+
+// DeleteCommentCalls gets all the calls that were made to DeleteComment.
+// Check the length with:
+//
+//	len(mockedDiscussionClient.DeleteCommentCalls())
+func (mock *DiscussionClientMock) DeleteCommentCalls() []struct {
+	Repo      ghrepo.Interface
+	CommentID string
+} {
+	var calls []struct {
+		Repo      ghrepo.Interface
+		CommentID string
+	}
+	mock.lockDeleteComment.RLock()
+	calls = mock.calls.DeleteComment
+	mock.lockDeleteComment.RUnlock()
+	return calls
+}
+
 // GetByNumber calls GetByNumberFunc.
 func (mock *DiscussionClientMock) GetByNumber(repo ghrepo.Interface, number int32) (*Discussion, error) {
 	if mock.GetByNumberFunc == nil {
@@ -243,6 +385,42 @@ func (mock *DiscussionClientMock) GetByNumberCalls() []struct {
 	mock.lockGetByNumber.RLock()
 	calls = mock.calls.GetByNumber
 	mock.lockGetByNumber.RUnlock()
+	return calls
+}
+
+// GetComment calls GetCommentFunc.
+func (mock *DiscussionClientMock) GetComment(repo ghrepo.Interface, commentID string) (*DiscussionComment, error) {
+	if mock.GetCommentFunc == nil {
+		panic("DiscussionClientMock.GetCommentFunc: method is nil but DiscussionClient.GetComment was just called")
+	}
+	callInfo := struct {
+		Repo      ghrepo.Interface
+		CommentID string
+	}{
+		Repo:      repo,
+		CommentID: commentID,
+	}
+	mock.lockGetComment.Lock()
+	mock.calls.GetComment = append(mock.calls.GetComment, callInfo)
+	mock.lockGetComment.Unlock()
+	return mock.GetCommentFunc(repo, commentID)
+}
+
+// GetCommentCalls gets all the calls that were made to GetComment.
+// Check the length with:
+//
+//	len(mockedDiscussionClient.GetCommentCalls())
+func (mock *DiscussionClientMock) GetCommentCalls() []struct {
+	Repo      ghrepo.Interface
+	CommentID string
+} {
+	var calls []struct {
+		Repo      ghrepo.Interface
+		CommentID string
+	}
+	mock.lockGetComment.RLock()
+	calls = mock.calls.GetComment
+	mock.lockGetComment.RUnlock()
 	return calls
 }
 
@@ -531,5 +709,45 @@ func (mock *DiscussionClientMock) UpdateCalls() []struct {
 	mock.lockUpdate.RLock()
 	calls = mock.calls.Update
 	mock.lockUpdate.RUnlock()
+	return calls
+}
+
+// UpdateComment calls UpdateCommentFunc.
+func (mock *DiscussionClientMock) UpdateComment(repo ghrepo.Interface, commentID string, body string) (*DiscussionComment, error) {
+	if mock.UpdateCommentFunc == nil {
+		panic("DiscussionClientMock.UpdateCommentFunc: method is nil but DiscussionClient.UpdateComment was just called")
+	}
+	callInfo := struct {
+		Repo      ghrepo.Interface
+		CommentID string
+		Body      string
+	}{
+		Repo:      repo,
+		CommentID: commentID,
+		Body:      body,
+	}
+	mock.lockUpdateComment.Lock()
+	mock.calls.UpdateComment = append(mock.calls.UpdateComment, callInfo)
+	mock.lockUpdateComment.Unlock()
+	return mock.UpdateCommentFunc(repo, commentID, body)
+}
+
+// UpdateCommentCalls gets all the calls that were made to UpdateComment.
+// Check the length with:
+//
+//	len(mockedDiscussionClient.UpdateCommentCalls())
+func (mock *DiscussionClientMock) UpdateCommentCalls() []struct {
+	Repo      ghrepo.Interface
+	CommentID string
+	Body      string
+} {
+	var calls []struct {
+		Repo      ghrepo.Interface
+		CommentID string
+		Body      string
+	}
+	mock.lockUpdateComment.RLock()
+	calls = mock.calls.UpdateComment
+	mock.lockUpdateComment.RUnlock()
 	return calls
 }

--- a/pkg/cmd/discussion/client/client_mock.go
+++ b/pkg/cmd/discussion/client/client_mock.go
@@ -33,7 +33,7 @@ var _ DiscussionClient = &DiscussionClientMock{}
 //			GetCommentFunc: func(repo ghrepo.Interface, commentID string) (*DiscussionComment, error) {
 //				panic("mock out the GetComment method")
 //			},
-//			GetCommentRepliesFunc: func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*Discussion, error) {
+//			GetCommentRepliesFunc: func(host string, commentID string, limit int, after string, newest bool) (*Discussion, error) {
 //				panic("mock out the GetCommentReplies method")
 //			},
 //			GetWithCommentsFunc: func(repo ghrepo.Interface, number int32, commentLimit int, after string, newest bool) (*Discussion, error) {
@@ -83,7 +83,7 @@ type DiscussionClientMock struct {
 	GetCommentFunc func(repo ghrepo.Interface, commentID string) (*DiscussionComment, error)
 
 	// GetCommentRepliesFunc mocks the GetCommentReplies method.
-	GetCommentRepliesFunc func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*Discussion, error)
+	GetCommentRepliesFunc func(host string, commentID string, limit int, after string, newest bool) (*Discussion, error)
 
 	// GetWithCommentsFunc mocks the GetWithComments method.
 	GetWithCommentsFunc func(repo ghrepo.Interface, number int32, commentLimit int, after string, newest bool) (*Discussion, error)
@@ -152,10 +152,8 @@ type DiscussionClientMock struct {
 		}
 		// GetCommentReplies holds details about calls to the GetCommentReplies method.
 		GetCommentReplies []struct {
-			// Repo is the repo argument value.
-			Repo ghrepo.Interface
-			// Number is the number argument value.
-			Number int32
+			// Host is the host argument value.
+			Host string
 			// CommentID is the commentID argument value.
 			CommentID string
 			// Limit is the limit argument value.
@@ -439,20 +437,18 @@ func (mock *DiscussionClientMock) GetCommentCalls() []struct {
 }
 
 // GetCommentReplies calls GetCommentRepliesFunc.
-func (mock *DiscussionClientMock) GetCommentReplies(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*Discussion, error) {
+func (mock *DiscussionClientMock) GetCommentReplies(host string, commentID string, limit int, after string, newest bool) (*Discussion, error) {
 	if mock.GetCommentRepliesFunc == nil {
 		panic("DiscussionClientMock.GetCommentRepliesFunc: method is nil but DiscussionClient.GetCommentReplies was just called")
 	}
 	callInfo := struct {
-		Repo      ghrepo.Interface
-		Number    int32
+		Host      string
 		CommentID string
 		Limit     int
 		After     string
 		Newest    bool
 	}{
-		Repo:      repo,
-		Number:    number,
+		Host:      host,
 		CommentID: commentID,
 		Limit:     limit,
 		After:     after,
@@ -461,7 +457,7 @@ func (mock *DiscussionClientMock) GetCommentReplies(repo ghrepo.Interface, numbe
 	mock.lockGetCommentReplies.Lock()
 	mock.calls.GetCommentReplies = append(mock.calls.GetCommentReplies, callInfo)
 	mock.lockGetCommentReplies.Unlock()
-	return mock.GetCommentRepliesFunc(repo, number, commentID, limit, after, newest)
+	return mock.GetCommentRepliesFunc(host, commentID, limit, after, newest)
 }
 
 // GetCommentRepliesCalls gets all the calls that were made to GetCommentReplies.
@@ -469,16 +465,14 @@ func (mock *DiscussionClientMock) GetCommentReplies(repo ghrepo.Interface, numbe
 //
 //	len(mockedDiscussionClient.GetCommentRepliesCalls())
 func (mock *DiscussionClientMock) GetCommentRepliesCalls() []struct {
-	Repo      ghrepo.Interface
-	Number    int32
+	Host      string
 	CommentID string
 	Limit     int
 	After     string
 	Newest    bool
 } {
 	var calls []struct {
-		Repo      ghrepo.Interface
-		Number    int32
+		Host      string
 		CommentID string
 		Limit     int
 		After     string

--- a/pkg/cmd/discussion/client/client_mock.go
+++ b/pkg/cmd/discussion/client/client_mock.go
@@ -30,7 +30,7 @@ var _ DiscussionClient = &DiscussionClientMock{}
 //			GetByNumberFunc: func(repo ghrepo.Interface, number int32) (*Discussion, error) {
 //				panic("mock out the GetByNumber method")
 //			},
-//			GetCommentFunc: func(repo ghrepo.Interface, commentID string) (*DiscussionComment, error) {
+//			GetCommentFunc: func(host string, commentID string) (*DiscussionComment, error) {
 //				panic("mock out the GetComment method")
 //			},
 //			GetCommentRepliesFunc: func(host string, commentID string, limit int, after string, newest bool) (*Discussion, error) {
@@ -80,7 +80,7 @@ type DiscussionClientMock struct {
 	GetByNumberFunc func(repo ghrepo.Interface, number int32) (*Discussion, error)
 
 	// GetCommentFunc mocks the GetComment method.
-	GetCommentFunc func(repo ghrepo.Interface, commentID string) (*DiscussionComment, error)
+	GetCommentFunc func(host string, commentID string) (*DiscussionComment, error)
 
 	// GetCommentRepliesFunc mocks the GetCommentReplies method.
 	GetCommentRepliesFunc func(host string, commentID string, limit int, after string, newest bool) (*Discussion, error)
@@ -145,8 +145,8 @@ type DiscussionClientMock struct {
 		}
 		// GetComment holds details about calls to the GetComment method.
 		GetComment []struct {
-			// Repo is the repo argument value.
-			Repo ghrepo.Interface
+			// Host is the host argument value.
+			Host string
 			// CommentID is the commentID argument value.
 			CommentID string
 		}
@@ -401,21 +401,21 @@ func (mock *DiscussionClientMock) GetByNumberCalls() []struct {
 }
 
 // GetComment calls GetCommentFunc.
-func (mock *DiscussionClientMock) GetComment(repo ghrepo.Interface, commentID string) (*DiscussionComment, error) {
+func (mock *DiscussionClientMock) GetComment(host string, commentID string) (*DiscussionComment, error) {
 	if mock.GetCommentFunc == nil {
 		panic("DiscussionClientMock.GetCommentFunc: method is nil but DiscussionClient.GetComment was just called")
 	}
 	callInfo := struct {
-		Repo      ghrepo.Interface
+		Host      string
 		CommentID string
 	}{
-		Repo:      repo,
+		Host:      host,
 		CommentID: commentID,
 	}
 	mock.lockGetComment.Lock()
 	mock.calls.GetComment = append(mock.calls.GetComment, callInfo)
 	mock.lockGetComment.Unlock()
-	return mock.GetCommentFunc(repo, commentID)
+	return mock.GetCommentFunc(host, commentID)
 }
 
 // GetCommentCalls gets all the calls that were made to GetComment.
@@ -423,11 +423,11 @@ func (mock *DiscussionClientMock) GetComment(repo ghrepo.Interface, commentID st
 //
 //	len(mockedDiscussionClient.GetCommentCalls())
 func (mock *DiscussionClientMock) GetCommentCalls() []struct {
-	Repo      ghrepo.Interface
+	Host      string
 	CommentID string
 } {
 	var calls []struct {
-		Repo      ghrepo.Interface
+		Host      string
 		CommentID string
 	}
 	mock.lockGetComment.RLock()

--- a/pkg/cmd/discussion/client/types.go
+++ b/pkg/cmd/discussion/client/types.go
@@ -172,6 +172,7 @@ func (l DiscussionLabel) Export() map[string]interface{} {
 type DiscussionComment struct {
 	ID             string
 	URL            string
+	DiscussionID   string
 	Author         DiscussionActor
 	Body           string
 	CreatedAt      time.Time

--- a/pkg/cmd/discussion/comment/comment.go
+++ b/pkg/cmd/discussion/comment/comment.go
@@ -1,0 +1,238 @@
+package comment
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+// CommentOptions holds the configuration for the discussion comment command.
+type CommentOptions struct {
+	IO       *iostreams.IOStreams
+	BaseRepo func() (ghrepo.Interface, error)
+	Client   func() (client.DiscussionClient, error)
+	Prompter prompter.Prompter
+
+	DiscussionNumber int32
+	Body             string
+	BodyFile         string
+	ReplyTo          string
+	EditID           string
+	DeleteID         string
+	Yes              bool
+}
+
+// NewCmdComment returns the "discussion comment" command.
+func NewCmdComment(f *cmdutil.Factory, runF func(*CommentOptions) error) *cobra.Command {
+	opts := &CommentOptions{
+		IO:       f.IOStreams,
+		Prompter: f.Prompter,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "comment {<number> | <url>}",
+		Short: "Add, edit, or delete a comment on a discussion",
+		Long: heredoc.Docf(`
+			Manage comments on a GitHub discussion.
+
+			Without flags, adds a new top-level comment. Use %[1]s--reply-to%[1]s to reply to
+			an existing comment, %[1]s--edit%[1]s to update a comment, or %[1]s--delete%[1]s to remove one.
+
+			The body can be supplied via %[1]s--body%[1]s, %[1]s--body-file%[1]s, or interactively through
+			an editor.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# Add a comment
+			$ gh discussion comment 123 --body "my comment"
+
+			# Reply to a comment
+			$ gh discussion comment 123 --reply-to DC_abc123 --body "my comment"
+
+			# Edit a comment
+			$ gh discussion comment 123 --edit DC_abc123 --body "my comment"
+
+			# Delete a comment
+			$ gh discussion comment 123 --delete DC_abc123
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.BaseRepo = f.BaseRepo
+			opts.Client = shared.DiscussionClientFunc(f)
+
+			if err := cmdutil.MutuallyExclusive("specify only one of --reply-to, --edit, or --delete",
+				cmd.Flags().Changed("reply-to"), cmd.Flags().Changed("edit"), cmd.Flags().Changed("delete")); err != nil {
+				return err
+			}
+			if err := cmdutil.MutuallyExclusive("specify only one of --body or --body-file",
+				cmd.Flags().Changed("body"), cmd.Flags().Changed("body-file")); err != nil {
+				return err
+			}
+			if cmd.Flags().Changed("delete") {
+				if cmd.Flags().Changed("body") || cmd.Flags().Changed("body-file") {
+					return cmdutil.FlagErrorf("--delete cannot be combined with --body, --body-file, or --editor")
+				}
+			}
+
+			if opts.Yes && opts.DeleteID == "" {
+				return cmdutil.FlagErrorf("--yes can only be used with --delete")
+			}
+
+			if !opts.IO.CanPrompt() && !opts.Yes && opts.DeleteID != "" {
+				return cmdutil.FlagErrorf("--yes is required when not running interactively and using --delete")
+			}
+
+			if !opts.IO.CanPrompt() && !cmd.Flags().Changed("delete") {
+				if !cmd.Flags().Changed("body") && !cmd.Flags().Changed("body-file") {
+					return cmdutil.FlagErrorf("--body or --body-file is required when not running interactively")
+				}
+			}
+
+			number, repo, err := shared.ParseDiscussionArg(args[0])
+			if err != nil {
+				return cmdutil.FlagErrorWrap(err)
+			}
+			opts.DiscussionNumber = number
+
+			if repo != nil {
+				opts.BaseRepo = func() (ghrepo.Interface, error) {
+					return repo, nil
+				}
+			} else {
+				opts.BaseRepo = f.BaseRepo
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return commentRun(opts)
+		},
+	}
+
+	cmdutil.EnableRepoOverride(cmd, f)
+
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Comment body text")
+	cmd.Flags().StringVarP(&opts.BodyFile, "body-file", "F", "", "Read body text from file (use \"-\" to read from stdin)")
+	cmd.Flags().StringVar(&opts.ReplyTo, "reply-to", "", "Reply to a comment by its node ID")
+	cmd.Flags().StringVar(&opts.EditID, "edit", "", "Edit a comment by its node ID")
+	cmd.Flags().StringVar(&opts.DeleteID, "delete", "", "Delete a comment by its node ID")
+	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the delete confirmation prompt")
+
+	return cmd
+}
+
+func commentRun(opts *CommentOptions) error {
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	c, err := opts.Client()
+	if err != nil {
+		return err
+	}
+
+	if opts.DeleteID != "" {
+		return runDelete(opts, c, baseRepo)
+	}
+	if opts.EditID != "" {
+		return runEdit(opts, c, baseRepo)
+	}
+	return runAdd(opts, c, baseRepo)
+}
+
+func runDelete(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.Interface) error {
+	if _, err := c.GetComment(baseRepo, opts.DeleteID); err != nil {
+		return err
+	}
+
+	if !opts.Yes {
+		confirmed, err := opts.Prompter.Confirm("Are you sure you want to delete this comment?", false)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return cmdutil.CancelError
+		}
+	}
+
+	if err := c.DeleteComment(baseRepo, opts.DeleteID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runEdit(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.Interface) error {
+	existing, err := c.GetComment(baseRepo, opts.EditID)
+	if err != nil {
+		return err
+	}
+
+	body, err := resolveBody(opts, existing.Body)
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicator()
+	comment, err := c.UpdateComment(baseRepo, opts.EditID, body)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(opts.IO.Out, comment.URL)
+	return nil
+}
+
+func runAdd(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.Interface) error {
+	body, err := resolveBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicator()
+	discussion, err := c.GetByNumber(baseRepo, opts.DiscussionNumber)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicator()
+	comment, err := c.AddComment(baseRepo, discussion.ID, body, opts.ReplyTo)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(opts.IO.Out, comment.URL)
+	return nil
+}
+
+// resolveBody determines the comment body from flags or interactive input.
+// defaultBody is used as the initial content in the editor (e.g., existing comment body for edits).
+func resolveBody(opts *CommentOptions, defaultBody string) (string, error) {
+	if opts.BodyFile != "" {
+		b, err := cmdutil.ReadFile(opts.BodyFile, opts.IO.In)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+
+	if opts.Body != "" {
+		return opts.Body, nil
+	}
+
+	body, err := opts.Prompter.MarkdownEditor("Body", defaultBody, false)
+	if err != nil {
+		return "", err
+	}
+
+	return body, nil
+}

--- a/pkg/cmd/discussion/comment/comment.go
+++ b/pkg/cmd/discussion/comment/comment.go
@@ -20,13 +20,13 @@ type CommentOptions struct {
 	Client   func() (client.DiscussionClient, error)
 	Prompter prompter.Prompter
 
-	DiscussionNumber int32
-	Body             string
-	BodyFile         string
-	ReplyTo          string
-	EditID           string
-	DeleteID         string
-	Yes              bool
+	ParsedArg *shared.ParsedDiscussionOrCommentArg
+
+	Body     string
+	BodyFile string
+	Edit     bool
+	Delete   bool
+	Yes      bool
 }
 
 // NewCmdComment returns the "discussion comment" command.
@@ -37,75 +37,88 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*CommentOptions) error) *cobra.
 	}
 
 	cmd := &cobra.Command{
-		Use:   "comment {<number> | <url>}",
-		Short: "Add, edit, or delete a comment on a discussion",
+		Use:   "comment {<number> | <discussion-url> | <comment-id> | <comment-url>} [flags]",
+		Short: "Add, edit, or delete a comment or a reply on a discussion (preview)",
 		Long: heredoc.Docf(`
-			Manage comments on a GitHub discussion.
+			Manage comments or replies on a GitHub discussion.
 
-			Without flags, adds a new top-level comment. Use %[1]s--reply-to%[1]s to reply to
-			an existing comment, %[1]s--edit%[1]s to update a comment, or %[1]s--delete%[1]s to remove one.
+			The positional argument can be a discussion number or URL (to add a new
+			top-level comment), or a comment node ID or comment URL (to reply, edit,
+			or delete that comment).
 
-			The body can be supplied via %[1]s--body%[1]s, %[1]s--body-file%[1]s, or interactively through
-			an editor.
+			When the argument is a discussion number or URL, the default action is to
+			add a new top-level comment. Likewise, if the argument is a comment URL or ID
+			the default action is to add a reply.
+
+			Use %[1]s--edit%[1]s to update the comment/reply body, or %[1]s--delete%[1]s to remove it.
+
+			The body can be supplied via %[1]s--body%[1]s, %[1]s--body-file%[1]s, or interactively
+			through an editor.
 		`, "`"),
 		Example: heredoc.Doc(`
-			# Add a comment
-			$ gh discussion comment 123 --body "my comment"
+			# Add a top-level comment to discussion #123
+			$ gh discussion comment 123 --body 'Thanks'
 
-			# Reply to a comment
-			$ gh discussion comment 123 --reply-to DC_abc123 --body "my comment"
+			# Reply to a comment using its URL
+			$ gh discussion comment 'https://github.com/OWNER/REPO/discussions/123#discussioncomment-456' --body 'Thanks'
 
-			# Edit a comment
-			$ gh discussion comment 123 --edit DC_abc123 --body "my comment"
+			# Reply to a comment using its node ID
+			$ gh discussion comment DC_abc123 --body 'Thanks'
 
-			# Delete a comment
-			$ gh discussion comment 123 --delete DC_abc123
+			# Edit a comment/reply
+			$ gh discussion comment 'https://github.com/OWNER/REPO/discussions/123#discussioncomment-456' --edit --body 'Thanks'
+
+			# Delete a comment/reply
+			$ gh discussion comment 'https://github.com/OWNER/REPO/discussions/123#discussioncomment-456' --delete
+
+			# Delete a comment/reply without confirmation prompt
+			$ gh discussion comment 'https://github.com/OWNER/REPO/discussions/123#discussioncomment-456' --delete --yes
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.BaseRepo = f.BaseRepo
 			opts.Client = shared.DiscussionClientFunc(f)
 
-			if err := cmdutil.MutuallyExclusive("specify only one of --reply-to, --edit, or --delete",
-				cmd.Flags().Changed("reply-to"), cmd.Flags().Changed("edit"), cmd.Flags().Changed("delete")); err != nil {
+			if err := cmdutil.MutuallyExclusive("specify only one of --edit or --delete",
+				cmd.Flags().Changed("edit"), cmd.Flags().Changed("delete")); err != nil {
 				return err
+			}
+			if opts.Delete {
+				if cmd.Flags().Changed("body") || cmd.Flags().Changed("body-file") {
+					return cmdutil.FlagErrorf("--delete cannot be combined with --body or --body-file")
+				}
+			}
+			if opts.Yes && !opts.Delete {
+				return cmdutil.FlagErrorf("--yes can only be used with --delete")
+			}
+			if !opts.IO.CanPrompt() && opts.Delete && !opts.Yes {
+				return cmdutil.FlagErrorf("--yes is required when not running interactively with --delete")
+			}
+			if !opts.IO.CanPrompt() && !opts.Delete {
+				if !cmd.Flags().Changed("body") && !cmd.Flags().Changed("body-file") {
+					return cmdutil.FlagErrorf("--body or --body-file is required when not running interactively")
+				}
 			}
 			if err := cmdutil.MutuallyExclusive("specify only one of --body or --body-file",
 				cmd.Flags().Changed("body"), cmd.Flags().Changed("body-file")); err != nil {
 				return err
 			}
-			if cmd.Flags().Changed("delete") {
-				if cmd.Flags().Changed("body") || cmd.Flags().Changed("body-file") {
-					return cmdutil.FlagErrorf("--delete cannot be combined with --body, --body-file, or --editor")
-				}
-			}
 
-			if opts.Yes && opts.DeleteID == "" {
-				return cmdutil.FlagErrorf("--yes can only be used with --delete")
-			}
-
-			if !opts.IO.CanPrompt() && !opts.Yes && opts.DeleteID != "" {
-				return cmdutil.FlagErrorf("--yes is required when not running interactively and using --delete")
-			}
-
-			if !opts.IO.CanPrompt() && !cmd.Flags().Changed("delete") {
-				if !cmd.Flags().Changed("body") && !cmd.Flags().Changed("body-file") {
-					return cmdutil.FlagErrorf("--body or --body-file is required when not running interactively")
-				}
-			}
-
-			number, repo, err := shared.ParseDiscussionArg(args[0])
+			parsed, err := shared.ParseDiscussionOrCommentArg(args[0])
 			if err != nil {
-				return cmdutil.FlagErrorWrap(err)
+				return err
 			}
-			opts.DiscussionNumber = number
 
-			if repo != nil {
+			opts.ParsedArg = parsed
+
+			if (opts.Edit || opts.Delete) && (parsed.CommentNodeID == "" && parsed.CommentDatabaseID == 0) {
+				return cmdutil.FlagErrorf("--edit and --delete require a comment ID or comment URL as argument")
+			}
+
+			if opts.ParsedArg.Repo != nil {
 				opts.BaseRepo = func() (ghrepo.Interface, error) {
-					return repo, nil
+					return parsed.Repo, nil
 				}
-			} else {
-				opts.BaseRepo = f.BaseRepo
 			}
 
 			if runF != nil {
@@ -115,14 +128,13 @@ func NewCmdComment(f *cmdutil.Factory, runF func(*CommentOptions) error) *cobra.
 		},
 	}
 
-	cmdutil.EnableRepoOverride(cmd, f)
-
 	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Comment body text")
-	cmd.Flags().StringVarP(&opts.BodyFile, "body-file", "F", "", "Read body text from file (use \"-\" to read from stdin)")
-	cmd.Flags().StringVar(&opts.ReplyTo, "reply-to", "", "Reply to a comment by its node ID")
-	cmd.Flags().StringVar(&opts.EditID, "edit", "", "Edit a comment by its node ID")
-	cmd.Flags().StringVar(&opts.DeleteID, "delete", "", "Delete a comment by its node ID")
+	cmd.Flags().StringVarP(&opts.BodyFile, "body-file", "F", "", "Read body text from file (use \"-\" to read from standard input)")
+	cmd.Flags().BoolVar(&opts.Edit, "edit", false, "Edit the specified comment")
+	cmd.Flags().BoolVar(&opts.Delete, "delete", false, "Delete the specified comment")
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the delete confirmation prompt")
+
+	cmdutil.EnableRepoOverride(cmd, f)
 
 	return cmd
 }
@@ -138,17 +150,25 @@ func commentRun(opts *CommentOptions) error {
 		return err
 	}
 
-	if opts.DeleteID != "" {
+	if opts.Delete {
 		return runDelete(opts, c, baseRepo)
 	}
-	if opts.EditID != "" {
+	if opts.Edit {
 		return runEdit(opts, c, baseRepo)
+	}
+	if opts.ParsedArg.CommentNodeID != "" || opts.ParsedArg.CommentDatabaseID != 0 {
+		return runReply(opts, c, baseRepo)
 	}
 	return runAdd(opts, c, baseRepo)
 }
 
 func runDelete(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.Interface) error {
-	if _, err := c.GetComment(baseRepo, opts.DeleteID); err != nil {
+	commentID, err := resolveCommentID(opts, c, baseRepo)
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.GetComment(baseRepo, commentID); err != nil {
 		return err
 	}
 
@@ -162,14 +182,16 @@ func runDelete(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.
 		}
 	}
 
-	if err := c.DeleteComment(baseRepo, opts.DeleteID); err != nil {
-		return err
-	}
-	return nil
+	return c.DeleteComment(baseRepo, commentID)
 }
 
 func runEdit(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.Interface) error {
-	existing, err := c.GetComment(baseRepo, opts.EditID)
+	commentID, err := resolveCommentID(opts, c, baseRepo)
+	if err != nil {
+		return err
+	}
+
+	existing, err := c.GetComment(baseRepo, commentID)
 	if err != nil {
 		return err
 	}
@@ -180,7 +202,36 @@ func runEdit(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.In
 	}
 
 	opts.IO.StartProgressIndicator()
-	comment, err := c.UpdateComment(baseRepo, opts.EditID, body)
+	comment, err := c.UpdateComment(baseRepo, commentID, body)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(opts.IO.Out, comment.URL)
+	return nil
+}
+
+func runReply(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.Interface) error {
+	commentID, err := resolveCommentID(opts, c, baseRepo)
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicator()
+	existing, err := c.GetComment(baseRepo, commentID)
+	opts.IO.StopProgressIndicator()
+	if err != nil {
+		return err
+	}
+
+	body, err := resolveBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	opts.IO.StartProgressIndicator()
+	comment, err := c.AddComment(baseRepo, existing.DiscussionID, body, commentID)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
@@ -197,14 +248,14 @@ func runAdd(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.Int
 	}
 
 	opts.IO.StartProgressIndicator()
-	discussion, err := c.GetByNumber(baseRepo, opts.DiscussionNumber)
+	discussion, err := c.GetByNumber(baseRepo, opts.ParsedArg.Number)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
 	}
 
 	opts.IO.StartProgressIndicator()
-	comment, err := c.AddComment(baseRepo, discussion.ID, body, opts.ReplyTo)
+	comment, err := c.AddComment(baseRepo, discussion.ID, body, "")
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err
@@ -212,6 +263,19 @@ func runAdd(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.Int
 
 	fmt.Fprintln(opts.IO.Out, comment.URL)
 	return nil
+}
+
+// resolveCommentID returns the comment node ID, resolving it from the database
+// ID via the API if the arg was a comment URL.
+func resolveCommentID(opts *CommentOptions, c client.DiscussionClient, repo ghrepo.Interface) (string, error) {
+	if opts.ParsedArg.CommentNodeID != "" {
+		return opts.ParsedArg.CommentNodeID, nil
+	}
+	if opts.ParsedArg.CommentDatabaseID != 0 {
+		return c.ResolveCommentNodeID(repo, opts.ParsedArg.CommentDatabaseID)
+	}
+	// We should never reach here due to checks at flag parsing.
+	return "", fmt.Errorf("no comment ID/URL available")
 }
 
 // resolveBody determines the comment body from flags or interactive input.

--- a/pkg/cmd/discussion/comment/comment.go
+++ b/pkg/cmd/discussion/comment/comment.go
@@ -168,7 +168,7 @@ func runDelete(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.
 		return err
 	}
 
-	if _, err := c.GetComment(baseRepo, commentID); err != nil {
+	if _, err := c.GetComment(baseRepo.RepoHost(), commentID); err != nil {
 		return err
 	}
 
@@ -191,7 +191,7 @@ func runEdit(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.In
 		return err
 	}
 
-	existing, err := c.GetComment(baseRepo, commentID)
+	existing, err := c.GetComment(baseRepo.RepoHost(), commentID)
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func runReply(opts *CommentOptions, c client.DiscussionClient, baseRepo ghrepo.I
 	}
 
 	opts.IO.StartProgressIndicator()
-	existing, err := c.GetComment(baseRepo, commentID)
+	existing, err := c.GetComment(baseRepo.RepoHost(), commentID)
 	opts.IO.StopProgressIndicator()
 	if err != nil {
 		return err

--- a/pkg/cmd/discussion/comment/comment_test.go
+++ b/pkg/cmd/discussion/comment/comment_test.go
@@ -121,6 +121,12 @@ func TestNewCmdComment(t *testing.T) {
 			wantErr: "--body or --body-file is required when not running interactively",
 		},
 		{
+			name:    "delete without yes non-tty is error",
+			args:    "123 --delete DC_1",
+			isTTY:   false,
+			wantErr: "--yes is required when not running interactively",
+		},
+		{
 			name:    "no args",
 			args:    "",
 			isTTY:   true,
@@ -328,7 +334,8 @@ func TestCommentRun(t *testing.T) {
 			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
 		},
 		{
-			name: "delete comment with confirmation",
+			name:  "delete comment with confirmation",
+			isTTY: true,
 			opts: CommentOptions{
 				DiscussionNumber: 5,
 				DeleteID:         "DC_1",
@@ -369,7 +376,8 @@ func TestCommentRun(t *testing.T) {
 			wantOut: "",
 		},
 		{
-			name: "delete comment declined",
+			name:  "delete comment declined",
+			isTTY: true,
 			opts: CommentOptions{
 				DiscussionNumber: 5,
 				DeleteID:         "DC_1",

--- a/pkg/cmd/discussion/comment/comment_test.go
+++ b/pkg/cmd/discussion/comment/comment_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/shared"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
 	"github.com/google/shlex"
@@ -31,70 +32,95 @@ func TestNewCmdComment(t *testing.T) {
 			args:  "123 --body 'Hello world'",
 			isTTY: true,
 			wantOpts: CommentOptions{
-				DiscussionNumber: 123,
-				Body:             "Hello world",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{Number: 123},
+				Body:      "Hello world",
 			},
 		},
 		{
-			name:  "add reply",
-			args:  "123 --reply-to DC_abc --body 'Reply text'",
+			name:  "reply to comment by node ID",
+			args:  "DC_abc --body 'Reply text'",
 			isTTY: true,
 			wantOpts: CommentOptions{
-				DiscussionNumber: 123,
-				Body:             "Reply text",
-				ReplyTo:          "DC_abc",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_abc"},
+				Body:      "Reply text",
 			},
 		},
 		{
-			name:  "edit comment with body",
-			args:  "123 --edit DC_abc --body 'Updated'",
+			name:  "reply to comment by comment URL",
+			args:  "https://github.com/OWNER/REPO/discussions/5#discussioncomment-999 --body 'Reply text'",
 			isTTY: true,
 			wantOpts: CommentOptions{
-				DiscussionNumber: 123,
-				EditID:           "DC_abc",
-				Body:             "Updated",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{
+					Number:            5,
+					CommentDatabaseID: 999,
+				},
+				Body: "Reply text",
 			},
+			wantBaseRepo: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 		},
 		{
-			name:  "delete comment",
-			args:  "123 --delete DC_abc",
+			name:  "edit comment by node ID",
+			args:  "DC_abc --edit --body 'Updated'",
 			isTTY: true,
 			wantOpts: CommentOptions{
-				DiscussionNumber: 123,
-				DeleteID:         "DC_abc",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_abc"},
+				Edit:      true,
+				Body:      "Updated",
 			},
 		},
 		{
-			name:  "delete with yes",
-			args:  "123 --delete DC_abc --yes",
+			name:  "edit comment by comment URL",
+			args:  "https://github.com/OWNER/REPO/discussions/5#discussioncomment-999 --edit --body 'Updated'",
 			isTTY: true,
 			wantOpts: CommentOptions{
-				DiscussionNumber: 123,
-				DeleteID:         "DC_abc",
-				Yes:              true,
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{
+					Number:            5,
+					CommentDatabaseID: 999,
+				},
+				Edit: true,
+				Body: "Updated",
 			},
+			wantBaseRepo: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
 		},
 		{
-			name:  "url arg overrides base repo",
-			args:  "https://github.com/OTHER/REPO2/discussions/42 --body 'text'",
+			name:  "delete comment by node ID",
+			args:  "DC_abc --delete --yes",
 			isTTY: true,
 			wantOpts: CommentOptions{
-				DiscussionNumber: 42,
-				Body:             "text",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_abc"},
+				Delete:    true,
+				Yes:       true,
 			},
-			wantBaseRepo: ghrepo.New("OTHER", "REPO2"),
 		},
 		{
-			name:    "mutual exclusion reply-to and edit",
-			args:    "123 --reply-to DC_1 --edit DC_2",
+			name:  "delete comment by comment URL",
+			args:  "https://github.com/OWNER/REPO/discussions/5#discussioncomment-999 --delete --yes",
+			isTTY: true,
+			wantOpts: CommentOptions{
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{
+					Number:            5,
+					CommentDatabaseID: 999,
+				},
+				Delete: true,
+				Yes:    true,
+			},
+			wantBaseRepo: ghrepo.NewWithHost("OWNER", "REPO", "github.com"),
+		},
+		{
+			name:  "discussion URL as argument",
+			args:  "https://github.com/OTHER/REPO2/discussions/42 --body 'comment'",
+			isTTY: true,
+			wantOpts: CommentOptions{
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{Number: 42},
+				Body:      "comment",
+			},
+			wantBaseRepo: ghrepo.NewWithHost("OTHER", "REPO2", "github.com"),
+		},
+		{
+			name:    "mutual exclusion edit and delete",
+			args:    "DC_abc --edit --delete",
 			isTTY:   true,
-			wantErr: "specify only one of --reply-to, --edit, or --delete",
-		},
-		{
-			name:    "mutual exclusion reply-to and delete",
-			args:    "123 --reply-to DC_1 --delete DC_2",
-			isTTY:   true,
-			wantErr: "specify only one of --reply-to, --edit, or --delete",
+			wantErr: "specify only one of --edit or --delete",
 		},
 		{
 			name:    "mutual exclusion body and body-file",
@@ -104,15 +130,45 @@ func TestNewCmdComment(t *testing.T) {
 		},
 		{
 			name:    "delete with body is invalid",
-			args:    "123 --delete DC_1 --body 'text'",
+			args:    "DC_abc --delete --body 'text'",
 			isTTY:   true,
-			wantErr: "--delete cannot be combined with --body, --body-file, or --editor",
+			wantErr: "--delete cannot be combined with --body or --body-file",
+		},
+		{
+			name:    "delete with body is invalid",
+			args:    "DC_abc --delete --body-file /some/path",
+			isTTY:   true,
+			wantErr: "--delete cannot be combined with --body or --body-file",
 		},
 		{
 			name:    "yes without delete is invalid",
 			args:    "123 --yes --body 'text'",
 			isTTY:   true,
 			wantErr: "--yes can only be used with --delete",
+		},
+		{
+			name:    "edit requires comment arg but given discussion number",
+			args:    "123 --edit --body 'text'",
+			isTTY:   true,
+			wantErr: "--edit and --delete require a comment ID or comment URL",
+		},
+		{
+			name:    "edit requires comment arg but given discussion URL",
+			args:    "https://github.com/OWNER/REPO/discussions/123 --edit --body 'text'",
+			isTTY:   true,
+			wantErr: "--edit and --delete require a comment ID or comment URL",
+		},
+		{
+			name:    "delete requires comment arg but given discussion number",
+			args:    "123 --delete --yes",
+			isTTY:   true,
+			wantErr: "--edit and --delete require a comment ID or comment URL",
+		},
+		{
+			name:    "delete requires comment arg but given discussion URL",
+			args:    "https://github.com/OWNER/REPO/discussions/123 --delete --yes",
+			isTTY:   true,
+			wantErr: "--edit and --delete require a comment ID or comment URL",
 		},
 		{
 			name:    "no body non-tty is error",
@@ -122,9 +178,9 @@ func TestNewCmdComment(t *testing.T) {
 		},
 		{
 			name:    "delete without yes non-tty is error",
-			args:    "123 --delete DC_1",
+			args:    "DC_abc --delete",
 			isTTY:   false,
-			wantErr: "--yes is required when not running interactively",
+			wantErr: "--yes is required when not running interactively with --delete",
 		},
 		{
 			name:    "no args",
@@ -160,12 +216,15 @@ func TestNewCmdComment(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantOpts.DiscussionNumber, gotOpts.DiscussionNumber)
+			require.NotNil(t, gotOpts.ParsedArg)
+			if tt.wantOpts.ParsedArg != nil {
+				assert.Equal(t, tt.wantOpts.ParsedArg.Number, gotOpts.ParsedArg.Number)
+				assert.Equal(t, tt.wantOpts.ParsedArg.CommentNodeID, gotOpts.ParsedArg.CommentNodeID)
+				assert.Equal(t, tt.wantOpts.ParsedArg.CommentDatabaseID, gotOpts.ParsedArg.CommentDatabaseID)
+			}
 			assert.Equal(t, tt.wantOpts.Body, gotOpts.Body)
-			assert.Equal(t, tt.wantOpts.BodyFile, gotOpts.BodyFile)
-			assert.Equal(t, tt.wantOpts.ReplyTo, gotOpts.ReplyTo)
-			assert.Equal(t, tt.wantOpts.EditID, gotOpts.EditID)
-			assert.Equal(t, tt.wantOpts.DeleteID, gotOpts.DeleteID)
+			assert.Equal(t, tt.wantOpts.Edit, gotOpts.Edit)
+			assert.Equal(t, tt.wantOpts.Delete, gotOpts.Delete)
 			assert.Equal(t, tt.wantOpts.Yes, gotOpts.Yes)
 
 			if tt.wantBaseRepo != nil {
@@ -184,18 +243,18 @@ func TestCommentRun(t *testing.T) {
 		bodyFileContent string
 		stdinContent    string
 		isTTY           bool
-		setupMock       func(*client.DiscussionClientMock)
+		setupMock       func(*testing.T, *client.DiscussionClientMock)
 		prompter        *prompter.PrompterMock
 		wantErr         string
 		wantOut         string
 	}{
 		{
-			name: "add comment with body",
+			name: "non-tty add comment with body",
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				Body:             "Hello world",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{Number: 5},
+				Body:      "Hello world",
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
 					assert.Equal(t, int32(5), number)
 					return sampleDiscussion(), nil
@@ -210,32 +269,12 @@ func TestCommentRun(t *testing.T) {
 			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
 		},
 		{
-			name: "add reply with body",
+			name: "non-tty add comment with body-file",
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				Body:             "Reply text",
-				ReplyTo:          "DC_parent",
-			},
-			setupMock: func(m *client.DiscussionClientMock) {
-				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
-					return sampleDiscussion(), nil
-				}
-				m.AddCommentFunc = func(repo ghrepo.Interface, discussionID, body, replyToID string) (*client.DiscussionComment, error) {
-					assert.Equal(t, "D_1", discussionID)
-					assert.Equal(t, "Reply text", body)
-					assert.Equal(t, "DC_parent", replyToID)
-					return sampleComment(), nil
-				}
-			},
-			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
-		},
-		{
-			name: "add comment with body-file",
-			opts: CommentOptions{
-				DiscussionNumber: 5,
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{Number: 5},
 			},
 			bodyFileContent: "Body from file",
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
 					return sampleDiscussion(), nil
 				}
@@ -247,13 +286,13 @@ func TestCommentRun(t *testing.T) {
 			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
 		},
 		{
-			name: "add comment with body-file from stdin",
+			name: "non-tty add comment with body-file from stdin",
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				BodyFile:         "-",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{Number: 5},
+				BodyFile:  "-",
 			},
 			stdinContent: "Body from stdin",
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
 					return sampleDiscussion(), nil
 				}
@@ -265,12 +304,12 @@ func TestCommentRun(t *testing.T) {
 			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
 		},
 		{
-			name:  "add comment interactive editor",
+			name:  "tty add comment interactive editor",
 			isTTY: true,
 			opts: CommentOptions{
-				DiscussionNumber: 5,
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{Number: 5},
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
 					return sampleDiscussion(), nil
 				}
@@ -281,7 +320,6 @@ func TestCommentRun(t *testing.T) {
 			},
 			prompter: &prompter.PrompterMock{
 				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
-					assert.False(t, blankAllowed)
 					assert.Equal(t, "", defaultValue)
 					return "Editor body", nil
 				},
@@ -289,13 +327,66 @@ func TestCommentRun(t *testing.T) {
 			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
 		},
 		{
-			name: "edit comment with body",
+			name: "non-tty reply to comment by node ID",
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				EditID:           "DC_1",
-				Body:             "Updated body",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_parent"},
+				Body:      "Reply text",
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					return &client.DiscussionComment{
+						ID:           "DC_parent",
+						URL:          "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1",
+						DiscussionID: "D_1",
+						Body:         "Parent comment",
+					}, nil
+				}
+				m.AddCommentFunc = func(repo ghrepo.Interface, discussionID, body, replyToID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "D_1", discussionID)
+					assert.Equal(t, "Reply text", body)
+					assert.Equal(t, "DC_parent", replyToID)
+					return sampleComment(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
+		},
+		{
+			name: "non-tty reply via comment URL",
+			opts: CommentOptions{
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{
+					Number:            5,
+					CommentDatabaseID: 17196842,
+				},
+				Body: "Reply text",
+			},
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
+				m.ResolveCommentNodeIDFunc = func(repo ghrepo.Interface, commentDatabaseID int64) (string, error) {
+					assert.Equal(t, int64(17196842), commentDatabaseID)
+					return "DC_resolved", nil
+				}
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "DC_resolved", commentID)
+					return &client.DiscussionComment{
+						ID:           "DC_resolved",
+						DiscussionID: "D_1",
+					}, nil
+				}
+				m.AddCommentFunc = func(repo ghrepo.Interface, discussionID, body, replyToID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "D_1", discussionID)
+					assert.Equal(t, "DC_resolved", replyToID)
+					return sampleComment(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
+		},
+		{
+			name: "non-tty edit comment via node ID with body",
+			opts: CommentOptions{
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_1"},
+				Edit:      true,
+				Body:      "Updated body",
+			},
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
 					assert.Equal(t, "DC_1", commentID)
 					return sampleComment(), nil
@@ -309,13 +400,57 @@ func TestCommentRun(t *testing.T) {
 			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
 		},
 		{
-			name:  "edit comment interactive editor pre-populates",
+			name: "non-tty edit comment via comment URL with body",
+			opts: CommentOptions{
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{Number: 5, CommentDatabaseID: 999},
+				Edit:      true,
+				Body:      "Updated body",
+			},
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
+				m.ResolveCommentNodeIDFunc = func(repo ghrepo.Interface, commentDatabaseID int64) (string, error) {
+					assert.Equal(t, int64(999), commentDatabaseID)
+					return "DC_resolved", nil
+				}
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "DC_resolved", commentID)
+					return sampleComment(), nil
+				}
+				m.UpdateCommentFunc = func(repo ghrepo.Interface, commentID, body string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "DC_resolved", commentID)
+					assert.Equal(t, "Updated body", body)
+					return sampleComment(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
+		},
+		{
+			name: "non-tty edit comment with body-file from stdin",
+			opts: CommentOptions{
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_1"},
+				Edit:      true,
+				BodyFile:  "-",
+			},
+			stdinContent: "Edited from stdin",
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					return sampleComment(), nil
+				}
+				m.UpdateCommentFunc = func(repo ghrepo.Interface, commentID, body string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "DC_1", commentID)
+					assert.Equal(t, "Edited from stdin", body)
+					return sampleComment(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
+		},
+		{
+			name:  "tty edit comment via node ID interactive editor pre-populates",
 			isTTY: true,
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				EditID:           "DC_1",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_1"},
+				Edit:      true,
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
 					return sampleComment(), nil
 				}
@@ -326,7 +461,6 @@ func TestCommentRun(t *testing.T) {
 			},
 			prompter: &prompter.PrompterMock{
 				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
-					assert.False(t, blankAllowed)
 					assert.Equal(t, "Original comment body", defaultValue)
 					return "Edited in editor", nil
 				},
@@ -334,15 +468,14 @@ func TestCommentRun(t *testing.T) {
 			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
 		},
 		{
-			name:  "delete comment with confirmation",
+			name:  "tty delete comment via node ID with confirmation",
 			isTTY: true,
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				DeleteID:         "DC_1",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_1"},
+				Delete:    true,
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
-					assert.Equal(t, "DC_1", commentID)
 					return sampleComment(), nil
 				}
 				m.DeleteCommentFunc = func(repo ghrepo.Interface, commentID string) error {
@@ -359,13 +492,41 @@ func TestCommentRun(t *testing.T) {
 			wantOut: "",
 		},
 		{
-			name: "delete comment with --yes skips prompt",
+			name:  "tty delete comment via comment URL with confirmation",
+			isTTY: true,
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				DeleteID:         "DC_1",
-				Yes:              true,
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{Number: 5, CommentDatabaseID: 999},
+				Delete:    true,
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
+				m.ResolveCommentNodeIDFunc = func(repo ghrepo.Interface, commentDatabaseID int64) (string, error) {
+					return "DC_resolved", nil
+				}
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "DC_resolved", commentID)
+					return sampleComment(), nil
+				}
+				m.DeleteCommentFunc = func(repo ghrepo.Interface, commentID string) error {
+					assert.Equal(t, "DC_resolved", commentID)
+					return nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				ConfirmFunc: func(prompt string, defaultValue bool) (bool, error) {
+					return true, nil
+				},
+			},
+			wantOut: "",
+		},
+		{
+			name:  "tty delete comment with --yes skips prompt",
+			isTTY: true,
+			opts: CommentOptions{
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_1"},
+				Delete:    true,
+				Yes:       true,
+			},
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
 					return sampleComment(), nil
 				}
@@ -376,13 +537,13 @@ func TestCommentRun(t *testing.T) {
 			wantOut: "",
 		},
 		{
-			name:  "delete comment declined",
+			name:  "tty delete comment declined",
 			isTTY: true,
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				DeleteID:         "DC_1",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_1"},
+				Delete:    true,
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
 					return sampleComment(), nil
 				}
@@ -395,12 +556,12 @@ func TestCommentRun(t *testing.T) {
 			wantErr: "CancelError",
 		},
 		{
-			name: "add comment discussion not found",
+			name: "GetByNumber error",
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				Body:             "text",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{Number: 5},
+				Body:      "text",
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
 					return nil, fmt.Errorf("not found")
 				}
@@ -408,12 +569,12 @@ func TestCommentRun(t *testing.T) {
 			wantErr: "not found",
 		},
 		{
-			name: "add comment mutation failed",
+			name: "AddComment error",
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				Body:             "text",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{Number: 5},
+				Body:      "text",
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
 					return sampleDiscussion(), nil
 				}
@@ -424,44 +585,47 @@ func TestCommentRun(t *testing.T) {
 			wantErr: "mutation failed",
 		},
 		{
-			name: "edit comment not found",
+			name: "UpdateComment mutation error",
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				EditID:           "DC_bad",
-				Body:             "text",
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_1"},
+				Edit:      true,
+				Body:      "text",
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
-					return nil, fmt.Errorf("comment not found")
-				}
-			},
-			wantErr: "comment not found",
-		},
-		{
-			name: "edit comment mutation error",
-			opts: CommentOptions{
-				DiscussionNumber: 5,
-				EditID:           "DC_1",
-				Body:             "text",
-			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
 					return sampleComment(), nil
 				}
 				m.UpdateCommentFunc = func(repo ghrepo.Interface, commentID, body string) (*client.DiscussionComment, error) {
-					return nil, fmt.Errorf("edit comment mutation failed")
+					return nil, fmt.Errorf("update mutation failed")
 				}
 			},
-			wantErr: "edit comment mutation failed",
+			wantErr: "update mutation failed",
 		},
 		{
-			name: "delete comment not found",
+			name: "DeleteComment mutation error",
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				DeleteID:         "DC_bad",
-				Yes:              true,
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_1"},
+				Delete:    true,
+				Yes:       true,
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					return sampleComment(), nil
+				}
+				m.DeleteCommentFunc = func(repo ghrepo.Interface, commentID string) error {
+					return fmt.Errorf("delete mutation failed")
+				}
+			},
+			wantErr: "delete mutation failed",
+		},
+		{
+			name: "GetComment error on edit",
+			opts: CommentOptions{
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_bad"},
+				Edit:      true,
+				Body:      "text",
+			},
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
 					return nil, fmt.Errorf("comment not found")
 				}
@@ -469,21 +633,18 @@ func TestCommentRun(t *testing.T) {
 			wantErr: "comment not found",
 		},
 		{
-			name: "delete comment mutation error",
+			name: "GetComment error on delete",
 			opts: CommentOptions{
-				DiscussionNumber: 5,
-				DeleteID:         "DC_1",
-				Yes:              true,
+				ParsedArg: &shared.ParsedDiscussionOrCommentArg{CommentNodeID: "DC_bad"},
+				Delete:    true,
+				Yes:       true,
 			},
-			setupMock: func(m *client.DiscussionClientMock) {
+			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
 				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
-					return sampleComment(), nil
-				}
-				m.DeleteCommentFunc = func(repo ghrepo.Interface, commentID string) error {
-					return fmt.Errorf("delete comment mutation failed")
+					return nil, fmt.Errorf("comment not found")
 				}
 			},
-			wantErr: "delete comment mutation failed",
+			wantErr: "comment not found",
 		},
 	}
 
@@ -499,7 +660,7 @@ func TestCommentRun(t *testing.T) {
 
 			mockClient := &client.DiscussionClientMock{}
 			if tt.setupMock != nil {
-				tt.setupMock(mockClient)
+				tt.setupMock(t, mockClient)
 			}
 
 			opts := tt.opts

--- a/pkg/cmd/discussion/comment/comment_test.go
+++ b/pkg/cmd/discussion/comment/comment_test.go
@@ -333,7 +333,7 @@ func TestCommentRun(t *testing.T) {
 				Body:      "Reply text",
 			},
 			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					return &client.DiscussionComment{
 						ID:           "DC_parent",
 						URL:          "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1",
@@ -364,7 +364,7 @@ func TestCommentRun(t *testing.T) {
 					assert.Equal(t, int64(17196842), commentDatabaseID)
 					return "DC_resolved", nil
 				}
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					assert.Equal(t, "DC_resolved", commentID)
 					return &client.DiscussionComment{
 						ID:           "DC_resolved",
@@ -387,7 +387,7 @@ func TestCommentRun(t *testing.T) {
 				Body:      "Updated body",
 			},
 			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					assert.Equal(t, "DC_1", commentID)
 					return sampleComment(), nil
 				}
@@ -411,7 +411,7 @@ func TestCommentRun(t *testing.T) {
 					assert.Equal(t, int64(999), commentDatabaseID)
 					return "DC_resolved", nil
 				}
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					assert.Equal(t, "DC_resolved", commentID)
 					return sampleComment(), nil
 				}
@@ -432,7 +432,7 @@ func TestCommentRun(t *testing.T) {
 			},
 			stdinContent: "Edited from stdin",
 			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					return sampleComment(), nil
 				}
 				m.UpdateCommentFunc = func(repo ghrepo.Interface, commentID, body string) (*client.DiscussionComment, error) {
@@ -451,7 +451,7 @@ func TestCommentRun(t *testing.T) {
 				Edit:      true,
 			},
 			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					return sampleComment(), nil
 				}
 				m.UpdateCommentFunc = func(repo ghrepo.Interface, commentID, body string) (*client.DiscussionComment, error) {
@@ -475,7 +475,7 @@ func TestCommentRun(t *testing.T) {
 				Delete:    true,
 			},
 			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					return sampleComment(), nil
 				}
 				m.DeleteCommentFunc = func(repo ghrepo.Interface, commentID string) error {
@@ -502,7 +502,7 @@ func TestCommentRun(t *testing.T) {
 				m.ResolveCommentNodeIDFunc = func(repo ghrepo.Interface, commentDatabaseID int64) (string, error) {
 					return "DC_resolved", nil
 				}
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					assert.Equal(t, "DC_resolved", commentID)
 					return sampleComment(), nil
 				}
@@ -527,7 +527,7 @@ func TestCommentRun(t *testing.T) {
 				Yes:       true,
 			},
 			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					return sampleComment(), nil
 				}
 				m.DeleteCommentFunc = func(repo ghrepo.Interface, commentID string) error {
@@ -544,7 +544,7 @@ func TestCommentRun(t *testing.T) {
 				Delete:    true,
 			},
 			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					return sampleComment(), nil
 				}
 			},
@@ -592,7 +592,7 @@ func TestCommentRun(t *testing.T) {
 				Body:      "text",
 			},
 			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					return sampleComment(), nil
 				}
 				m.UpdateCommentFunc = func(repo ghrepo.Interface, commentID, body string) (*client.DiscussionComment, error) {
@@ -609,7 +609,7 @@ func TestCommentRun(t *testing.T) {
 				Yes:       true,
 			},
 			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					return sampleComment(), nil
 				}
 				m.DeleteCommentFunc = func(repo ghrepo.Interface, commentID string) error {
@@ -626,7 +626,7 @@ func TestCommentRun(t *testing.T) {
 				Body:      "text",
 			},
 			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					return nil, fmt.Errorf("comment not found")
 				}
 			},
@@ -640,7 +640,7 @@ func TestCommentRun(t *testing.T) {
 				Yes:       true,
 			},
 			setupMock: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					return nil, fmt.Errorf("comment not found")
 				}
 			},

--- a/pkg/cmd/discussion/comment/comment_test.go
+++ b/pkg/cmd/discussion/comment/comment_test.go
@@ -1,0 +1,542 @@
+package comment
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/internal/prompter"
+	"github.com/cli/cli/v2/pkg/cmd/discussion/client"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmdComment(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         string
+		isTTY        bool
+		wantOpts     CommentOptions
+		wantBaseRepo ghrepo.Interface
+		wantErr      string
+	}{
+		{
+			name:  "add comment with body",
+			args:  "123 --body 'Hello world'",
+			isTTY: true,
+			wantOpts: CommentOptions{
+				DiscussionNumber: 123,
+				Body:             "Hello world",
+			},
+		},
+		{
+			name:  "add reply",
+			args:  "123 --reply-to DC_abc --body 'Reply text'",
+			isTTY: true,
+			wantOpts: CommentOptions{
+				DiscussionNumber: 123,
+				Body:             "Reply text",
+				ReplyTo:          "DC_abc",
+			},
+		},
+		{
+			name:  "edit comment with body",
+			args:  "123 --edit DC_abc --body 'Updated'",
+			isTTY: true,
+			wantOpts: CommentOptions{
+				DiscussionNumber: 123,
+				EditID:           "DC_abc",
+				Body:             "Updated",
+			},
+		},
+		{
+			name:  "delete comment",
+			args:  "123 --delete DC_abc",
+			isTTY: true,
+			wantOpts: CommentOptions{
+				DiscussionNumber: 123,
+				DeleteID:         "DC_abc",
+			},
+		},
+		{
+			name:  "delete with yes",
+			args:  "123 --delete DC_abc --yes",
+			isTTY: true,
+			wantOpts: CommentOptions{
+				DiscussionNumber: 123,
+				DeleteID:         "DC_abc",
+				Yes:              true,
+			},
+		},
+		{
+			name:  "url arg overrides base repo",
+			args:  "https://github.com/OTHER/REPO2/discussions/42 --body 'text'",
+			isTTY: true,
+			wantOpts: CommentOptions{
+				DiscussionNumber: 42,
+				Body:             "text",
+			},
+			wantBaseRepo: ghrepo.New("OTHER", "REPO2"),
+		},
+		{
+			name:    "mutual exclusion reply-to and edit",
+			args:    "123 --reply-to DC_1 --edit DC_2",
+			isTTY:   true,
+			wantErr: "specify only one of --reply-to, --edit, or --delete",
+		},
+		{
+			name:    "mutual exclusion reply-to and delete",
+			args:    "123 --reply-to DC_1 --delete DC_2",
+			isTTY:   true,
+			wantErr: "specify only one of --reply-to, --edit, or --delete",
+		},
+		{
+			name:    "mutual exclusion body and body-file",
+			args:    "123 --body 'inline' --body-file body.md",
+			isTTY:   true,
+			wantErr: "specify only one of --body or --body-file",
+		},
+		{
+			name:    "delete with body is invalid",
+			args:    "123 --delete DC_1 --body 'text'",
+			isTTY:   true,
+			wantErr: "--delete cannot be combined with --body, --body-file, or --editor",
+		},
+		{
+			name:    "yes without delete is invalid",
+			args:    "123 --yes --body 'text'",
+			isTTY:   true,
+			wantErr: "--yes can only be used with --delete",
+		},
+		{
+			name:    "no body non-tty is error",
+			args:    "123",
+			isTTY:   false,
+			wantErr: "--body or --body-file is required when not running interactively",
+		},
+		{
+			name:    "no args",
+			args:    "",
+			isTTY:   true,
+			wantErr: "accepts 1 arg(s)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			ios.SetStdinTTY(tt.isTTY)
+			ios.SetStdoutTTY(tt.isTTY)
+			f := &cmdutil.Factory{IOStreams: ios}
+			var gotOpts *CommentOptions
+			cmd := NewCmdComment(f, func(opts *CommentOptions) error {
+				gotOpts = opts
+				return nil
+			})
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			argv, err := shlex.Split(tt.args)
+			require.NoError(t, err)
+			cmd.SetArgs(argv)
+
+			_, err = cmd.ExecuteC()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOpts.DiscussionNumber, gotOpts.DiscussionNumber)
+			assert.Equal(t, tt.wantOpts.Body, gotOpts.Body)
+			assert.Equal(t, tt.wantOpts.BodyFile, gotOpts.BodyFile)
+			assert.Equal(t, tt.wantOpts.ReplyTo, gotOpts.ReplyTo)
+			assert.Equal(t, tt.wantOpts.EditID, gotOpts.EditID)
+			assert.Equal(t, tt.wantOpts.DeleteID, gotOpts.DeleteID)
+			assert.Equal(t, tt.wantOpts.Yes, gotOpts.Yes)
+
+			if tt.wantBaseRepo != nil {
+				baseRepo, err := gotOpts.BaseRepo()
+				require.NoError(t, err)
+				assert.True(t, ghrepo.IsSame(tt.wantBaseRepo, baseRepo))
+			}
+		})
+	}
+}
+
+func TestCommentRun(t *testing.T) {
+	tests := []struct {
+		name            string
+		opts            CommentOptions
+		bodyFileContent string
+		stdinContent    string
+		isTTY           bool
+		setupMock       func(*client.DiscussionClientMock)
+		prompter        *prompter.PrompterMock
+		wantErr         string
+		wantOut         string
+	}{
+		{
+			name: "add comment with body",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				Body:             "Hello world",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
+					assert.Equal(t, int32(5), number)
+					return sampleDiscussion(), nil
+				}
+				m.AddCommentFunc = func(repo ghrepo.Interface, discussionID, body, replyToID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "D_1", discussionID)
+					assert.Equal(t, "Hello world", body)
+					assert.Equal(t, "", replyToID)
+					return sampleComment(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
+		},
+		{
+			name: "add reply with body",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				Body:             "Reply text",
+				ReplyTo:          "DC_parent",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.AddCommentFunc = func(repo ghrepo.Interface, discussionID, body, replyToID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "D_1", discussionID)
+					assert.Equal(t, "Reply text", body)
+					assert.Equal(t, "DC_parent", replyToID)
+					return sampleComment(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
+		},
+		{
+			name: "add comment with body-file",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+			},
+			bodyFileContent: "Body from file",
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.AddCommentFunc = func(repo ghrepo.Interface, discussionID, body, replyToID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "Body from file", body)
+					return sampleComment(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
+		},
+		{
+			name: "add comment with body-file from stdin",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				BodyFile:         "-",
+			},
+			stdinContent: "Body from stdin",
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.AddCommentFunc = func(repo ghrepo.Interface, discussionID, body, replyToID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "Body from stdin", body)
+					return sampleComment(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
+		},
+		{
+			name:  "add comment interactive editor",
+			isTTY: true,
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.AddCommentFunc = func(repo ghrepo.Interface, discussionID, body, replyToID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "Editor body", body)
+					return sampleComment(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
+					assert.False(t, blankAllowed)
+					assert.Equal(t, "", defaultValue)
+					return "Editor body", nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
+		},
+		{
+			name: "edit comment with body",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				EditID:           "DC_1",
+				Body:             "Updated body",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "DC_1", commentID)
+					return sampleComment(), nil
+				}
+				m.UpdateCommentFunc = func(repo ghrepo.Interface, commentID, body string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "DC_1", commentID)
+					assert.Equal(t, "Updated body", body)
+					return sampleComment(), nil
+				}
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
+		},
+		{
+			name:  "edit comment interactive editor pre-populates",
+			isTTY: true,
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				EditID:           "DC_1",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					return sampleComment(), nil
+				}
+				m.UpdateCommentFunc = func(repo ghrepo.Interface, commentID, body string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "Edited in editor", body)
+					return sampleComment(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				MarkdownEditorFunc: func(prompt, defaultValue string, blankAllowed bool) (string, error) {
+					assert.False(t, blankAllowed)
+					assert.Equal(t, "Original comment body", defaultValue)
+					return "Edited in editor", nil
+				},
+			},
+			wantOut: "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1\n",
+		},
+		{
+			name: "delete comment with confirmation",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				DeleteID:         "DC_1",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "DC_1", commentID)
+					return sampleComment(), nil
+				}
+				m.DeleteCommentFunc = func(repo ghrepo.Interface, commentID string) error {
+					assert.Equal(t, "DC_1", commentID)
+					return nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				ConfirmFunc: func(prompt string, defaultValue bool) (bool, error) {
+					assert.False(t, defaultValue)
+					return true, nil
+				},
+			},
+			wantOut: "",
+		},
+		{
+			name: "delete comment with --yes skips prompt",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				DeleteID:         "DC_1",
+				Yes:              true,
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					return sampleComment(), nil
+				}
+				m.DeleteCommentFunc = func(repo ghrepo.Interface, commentID string) error {
+					return nil
+				}
+			},
+			wantOut: "",
+		},
+		{
+			name: "delete comment declined",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				DeleteID:         "DC_1",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					return sampleComment(), nil
+				}
+			},
+			prompter: &prompter.PrompterMock{
+				ConfirmFunc: func(prompt string, defaultValue bool) (bool, error) {
+					return false, nil
+				},
+			},
+			wantErr: "CancelError",
+		},
+		{
+			name: "add comment discussion not found",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				Body:             "text",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
+					return nil, fmt.Errorf("not found")
+				}
+			},
+			wantErr: "not found",
+		},
+		{
+			name: "add comment mutation failed",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				Body:             "text",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetByNumberFunc = func(repo ghrepo.Interface, number int32) (*client.Discussion, error) {
+					return sampleDiscussion(), nil
+				}
+				m.AddCommentFunc = func(repo ghrepo.Interface, discussionID, body, replyToID string) (*client.DiscussionComment, error) {
+					return nil, fmt.Errorf("mutation failed")
+				}
+			},
+			wantErr: "mutation failed",
+		},
+		{
+			name: "edit comment not found",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				EditID:           "DC_bad",
+				Body:             "text",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					return nil, fmt.Errorf("comment not found")
+				}
+			},
+			wantErr: "comment not found",
+		},
+		{
+			name: "edit comment mutation error",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				EditID:           "DC_1",
+				Body:             "text",
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					return sampleComment(), nil
+				}
+				m.UpdateCommentFunc = func(repo ghrepo.Interface, commentID, body string) (*client.DiscussionComment, error) {
+					return nil, fmt.Errorf("edit comment mutation failed")
+				}
+			},
+			wantErr: "edit comment mutation failed",
+		},
+		{
+			name: "delete comment not found",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				DeleteID:         "DC_bad",
+				Yes:              true,
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					return nil, fmt.Errorf("comment not found")
+				}
+			},
+			wantErr: "comment not found",
+		},
+		{
+			name: "delete comment mutation error",
+			opts: CommentOptions{
+				DiscussionNumber: 5,
+				DeleteID:         "DC_1",
+				Yes:              true,
+			},
+			setupMock: func(m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					return sampleComment(), nil
+				}
+				m.DeleteCommentFunc = func(repo ghrepo.Interface, commentID string) error {
+					return fmt.Errorf("delete comment mutation failed")
+				}
+			},
+			wantErr: "delete comment mutation failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, stdin, stdout, _ := iostreams.Test()
+			ios.SetStdoutTTY(tt.isTTY)
+			ios.SetStdinTTY(tt.isTTY)
+
+			if tt.stdinContent != "" {
+				stdin.WriteString(tt.stdinContent)
+			}
+
+			mockClient := &client.DiscussionClientMock{}
+			if tt.setupMock != nil {
+				tt.setupMock(mockClient)
+			}
+
+			opts := tt.opts
+			if tt.bodyFileContent != "" {
+				dir := t.TempDir()
+				f := filepath.Join(dir, "body.md")
+				require.NoError(t, os.WriteFile(f, []byte(tt.bodyFileContent), 0600))
+				opts.BodyFile = f
+			}
+			opts.IO = ios
+			opts.BaseRepo = func() (ghrepo.Interface, error) {
+				return ghrepo.New("OWNER", "REPO"), nil
+			}
+			opts.Client = func() (client.DiscussionClient, error) {
+				return mockClient, nil
+			}
+			if tt.prompter != nil {
+				opts.Prompter = tt.prompter
+			}
+
+			err := commentRun(&opts)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOut, stdout.String())
+		})
+	}
+}
+
+func sampleDiscussion() *client.Discussion {
+	return &client.Discussion{
+		ID:     "D_1",
+		Number: 5,
+		Title:  "Sample discussion",
+		URL:    "https://github.com/OWNER/REPO/discussions/5",
+	}
+}
+
+func sampleComment() *client.DiscussionComment {
+	return &client.DiscussionComment{
+		ID:   "DC_1",
+		URL:  "https://github.com/OWNER/REPO/discussions/5#discussioncomment-1",
+		Body: "Original comment body",
+	}
+}

--- a/pkg/cmd/discussion/create/create.go
+++ b/pkg/cmd/discussion/create/create.go
@@ -37,7 +37,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	}
 
 	cmd := &cobra.Command{
-		Use:   "create",
+		Use:   "create [flags]",
 		Short: "Create a new discussion (preview)",
 		Long: heredoc.Doc(`
 			Create a new GitHub Discussion in a repository.

--- a/pkg/cmd/discussion/discussion.go
+++ b/pkg/cmd/discussion/discussion.go
@@ -2,6 +2,7 @@ package discussion
 
 import (
 	"github.com/MakeNowJust/heredoc"
+	cmdComment "github.com/cli/cli/v2/pkg/cmd/discussion/comment"
 	cmdCreate "github.com/cli/cli/v2/pkg/cmd/discussion/create"
 	cmdEdit "github.com/cli/cli/v2/pkg/cmd/discussion/edit"
 	cmdList "github.com/cli/cli/v2/pkg/cmd/discussion/list"
@@ -41,6 +42,7 @@ func NewCmdDiscussion(f *cmdutil.Factory) *cobra.Command {
 	)
 
 	cmdutil.AddGroup(cmd, "Targeted commands",
+		cmdComment.NewCmdComment(f, nil),
 		cmdEdit.NewCmdEdit(f, nil),
 		cmdView.NewCmdView(f, nil),
 	)

--- a/pkg/cmd/discussion/edit/edit.go
+++ b/pkg/cmd/discussion/edit/edit.go
@@ -45,7 +45,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "edit {<number> | <url>}",
+		Use:   "edit {<number> | <discussion-url>} [flags]",
 		Short: "Edit a discussion (preview)",
 		Long: heredoc.Doc(`
 			Edit a GitHub Discussion.

--- a/pkg/cmd/discussion/shared/lookup.go
+++ b/pkg/cmd/discussion/shared/lookup.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
 )
@@ -40,4 +41,64 @@ func ParseDiscussionArg(arg string) (int32, ghrepo.Interface, error) {
 	num, _ := strconv.ParseInt(m[3], 10, 32)
 	repo := ghrepo.NewWithHost(m[1], m[2], u.Hostname())
 	return int32(num), repo, nil
+}
+
+// ParsedDiscussionOrCommentArg holds the result of parsing a comment command argument.
+// Depending on the input, different fields are populated:
+//   - Discussion number (e.g., "123") or URL (e.g., "https://github.com/OWNER/REPO/discussions/123"):
+//     Number and optionally Repo are set.
+//   - Comment URL (e.g., "https://github.com/OWNER/REPO/discussions/123#discussioncomment-456"):
+//     Number, Repo, and CommentDatabaseID are set.
+//   - Comment node ID (e.g., "DC_kwDOOokwWs4BBmcq"):
+//     only CommentNodeID is set.
+type ParsedDiscussionOrCommentArg struct {
+	Number            int32
+	Repo              ghrepo.Interface
+	CommentDatabaseID int64
+	CommentNodeID     string
+}
+
+// ParseDiscussionOrCommentArg parses a positional argument that can be a discussion number,
+// discussion URL, comment node ID (DC_...), or comment URL (with a "#discussioncomment-NNNNN" fragment).
+func ParseDiscussionOrCommentArg(arg string) (*ParsedDiscussionOrCommentArg, error) {
+	if strings.HasPrefix(arg, "DC_") {
+		return &ParsedDiscussionOrCommentArg{CommentNodeID: arg}, nil
+	}
+
+	if num, err := strconv.ParseInt(arg, 10, 32); err == nil {
+		return &ParsedDiscussionOrCommentArg{Number: int32(num)}, nil
+	}
+	if len(arg) > 1 && arg[0] == '#' {
+		if num, err := strconv.ParseInt(arg[1:], 10, 32); err == nil {
+			return &ParsedDiscussionOrCommentArg{Number: int32(num)}, nil
+		}
+	}
+
+	u, err := url.Parse(arg)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return nil, fmt.Errorf("invalid argument: %q (expected a discussion number, URL, or comment ID)", arg)
+	}
+
+	m := discussionURLRE.FindStringSubmatch(u.Path)
+	if m == nil {
+		return nil, fmt.Errorf("invalid discussion URL: %q", arg)
+	}
+
+	num, _ := strconv.ParseInt(m[3], 10, 32)
+	repo := ghrepo.NewWithHost(m[1], m[2], u.Hostname())
+
+	if fragment := u.Fragment; strings.HasPrefix(fragment, "discussioncomment-") {
+		commentNumStr := strings.TrimPrefix(fragment, "discussioncomment-")
+		commentNum, err := strconv.ParseInt(commentNumStr, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid comment ID in URL fragment: %q", fragment)
+		}
+		return &ParsedDiscussionOrCommentArg{
+			Number:            int32(num),
+			Repo:              repo,
+			CommentDatabaseID: commentNum,
+		}, nil
+	}
+
+	return &ParsedDiscussionOrCommentArg{Number: int32(num), Repo: repo}, nil
 }

--- a/pkg/cmd/discussion/shared/lookup_test.go
+++ b/pkg/cmd/discussion/shared/lookup_test.go
@@ -117,3 +117,157 @@ func TestParseDiscussionArg(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDiscussionOrCommentArg(t *testing.T) {
+	tests := []struct {
+		name              string
+		arg               string
+		wantNumber        int32
+		wantOwner         string
+		wantRepo          string
+		wantHost          string
+		wantCommentNodeID string
+		wantCommentDBID   int64
+		wantErr           string
+	}{
+		// Same cases as ParseDiscussionArg
+		{
+			name:    "empty",
+			arg:     "",
+			wantErr: `invalid argument: "" (expected a discussion number, URL, or comment ID)`,
+		},
+		{
+			name:    "whitespaces",
+			arg:     "  ",
+			wantErr: `invalid argument: "  " (expected a discussion number, URL, or comment ID)`,
+		},
+		{
+			name:    "invalid string",
+			arg:     "not-a-number",
+			wantErr: `invalid argument: "not-a-number" (expected a discussion number, URL, or comment ID)`,
+		},
+		{
+			name:    "hash only",
+			arg:     "#",
+			wantErr: `invalid argument: "#" (expected a discussion number, URL, or comment ID)`,
+		},
+		{
+			name:    "hash non-numeric",
+			arg:     "#abc",
+			wantErr: `invalid argument: "#abc" (expected a discussion number, URL, or comment ID)`,
+		},
+		{
+			name:    "URL with wrong path",
+			arg:     "https://github.com/owner/repo/issues/10",
+			wantErr: `invalid discussion URL: "https://github.com/owner/repo/issues/10"`,
+		},
+		{
+			name:    "URL missing number",
+			arg:     "https://github.com/owner/repo/discussions/",
+			wantErr: `invalid discussion URL: "https://github.com/owner/repo/discussions/"`,
+		},
+		{
+			name:    "comment URL with invalid fragment",
+			arg:     "https://github.com/owner/repo/discussions/5#discussioncomment-abc",
+			wantErr: `invalid comment ID in URL fragment: "discussioncomment-abc"`,
+		},
+		{
+			name:       "zero",
+			arg:        "0",
+			wantNumber: 0,
+		},
+		{
+			name:       "plain number",
+			arg:        "42",
+			wantNumber: 42,
+		},
+		{
+			name:       "hash number",
+			arg:        "#99",
+			wantNumber: 99,
+		},
+		{
+			name:       "HTTPS discussion URL",
+			arg:        "https://github.com/cli/cli/discussions/123",
+			wantNumber: 123,
+			wantOwner:  "cli",
+			wantRepo:   "cli",
+			wantHost:   "github.com",
+		},
+		{
+			name:            "HTTPS comment URL",
+			arg:             "https://github.com/cli/cli/discussions/123#discussioncomment-789",
+			wantNumber:      123,
+			wantOwner:       "cli",
+			wantRepo:        "cli",
+			wantHost:        "github.com",
+			wantCommentDBID: 789,
+		},
+		{
+			name:       "HTTP discussion URL",
+			arg:        "http://github.com/owner/repo/discussions/7",
+			wantNumber: 7,
+			wantOwner:  "owner",
+			wantRepo:   "repo",
+			wantHost:   "github.com",
+		},
+		{
+			name:            "HTTP comment URL",
+			arg:             "http://github.com/owner/repo/discussions/7#discussioncomment-456",
+			wantNumber:      7,
+			wantOwner:       "owner",
+			wantRepo:        "repo",
+			wantHost:        "github.com",
+			wantCommentDBID: 456,
+		},
+		{
+			name:       "GHES discussion URL",
+			arg:        "https://git.example.com/org/project/discussions/55",
+			wantNumber: 55,
+			wantOwner:  "org",
+			wantRepo:   "project",
+			wantHost:   "git.example.com",
+		},
+		{
+			name:            "GHES comment URL",
+			arg:             "https://git.example.com/org/project/discussions/55#discussioncomment-100",
+			wantNumber:      55,
+			wantOwner:       "org",
+			wantRepo:        "project",
+			wantHost:        "git.example.com",
+			wantCommentDBID: 100,
+		},
+		{
+			name:              "comment node ID",
+			arg:               "DC_kwDOOokwWs4BBmcq",
+			wantCommentNodeID: "DC_kwDOOokwWs4BBmcq",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseDiscussionOrCommentArg(tt.arg)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantNumber, result.Number)
+			assert.Equal(t, tt.wantCommentNodeID, result.CommentNodeID)
+			assert.Equal(t, tt.wantCommentDBID, result.CommentDatabaseID)
+
+			if tt.wantOwner != "" || tt.wantRepo != "" || tt.wantHost != "" {
+				require.NotNil(t, result.Repo)
+				assert.Equal(t, tt.wantOwner, result.Repo.RepoOwner())
+				assert.Equal(t, tt.wantRepo, result.Repo.RepoName())
+				assert.Equal(t, tt.wantHost, result.Repo.RepoHost())
+			} else {
+				assert.Nil(t, result.Repo)
+			}
+		})
+	}
+}

--- a/pkg/cmd/discussion/view/view.go
+++ b/pkg/cmd/discussion/view/view.go
@@ -80,17 +80,16 @@ type ViewOptions struct {
 	Browser  browser.Browser
 	Client   func() (client.DiscussionClient, error)
 
-	DiscussionNumber   int32
-	WebMode            bool
-	Comments           bool
-	RepliesArg         string
-	RepliesCommentID   string
-	RepliesCommentDBID int64
-	Limit              int
-	After              string
-	Order              string
-	Exporter           cmdutil.Exporter
-	Now                func() time.Time
+	DiscussionNumber  int32
+	WebMode           bool
+	Comments          bool
+	CommentNodeID     string
+	CommentDatabaseID int64
+	Limit             int
+	After             string
+	Order             string
+	Exporter          cmdutil.Exporter
+	Now               func() time.Time
 }
 
 // NewCmdView creates the "discussion view" command.
@@ -102,7 +101,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "view {<number> | <url>} [flags]",
+		Use:   "view {<number> | <discussion-url> | <comment-id> | <comment-url>} [flags]",
 		Short: "View a discussion (preview)",
 		Long: heredoc.Docf(`
 			Display the title, body, and other information about a discussion.
@@ -110,12 +109,13 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 			To see the comments on a discussion, pass %[1]s--comments%[1]s. A few latest replies
 			of each comment will also be retrieved regardless of the selected ordering.
 
-			For a full thread of a comment, pass %[1]s--replies%[1]s with a comment node ID or
-			comment URL (e.g., %[1]shttps://github.com/OWNER/REPO/discussions/123#discussioncomment-456%[1]s).
+			To see the full reply thread of a single comment, pass a comment node ID or
+			comment URL as the argument instead of a discussion
+			(e.g., %[1]shttps://github.com/OWNER/REPO/discussions/123#discussioncomment-456%[1]s).
 
 			Pagination and ordering can be controlled via %[1]s--order%[1]s, %[1]s--limit%[1]s, and %[1]s--after%[1]s flags.
 
-			Use %[1]s--web%[1]s to open the discussion in a web browser instead.
+			Use %[1]s--web%[1]s to open the discussion or comment in a web browser instead.
 		`, "`"),
 		Example: heredoc.Doc(`
 			# View a discussion by number
@@ -136,14 +136,14 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 			# Fetch the next page of comments
 			$ gh discussion view 123 --comments --after CURSOR
 
-			# View replies on a specific comment by node ID
-			$ gh discussion view 123 --replies DC_abc123
+			# View the reply thread of a comment by node ID
+			$ gh discussion view DC_abc123
 
-			# View replies on a comment using the its URL
-			$ gh discussion view --replies 'https://github.com/OWNER/REPO/discussions/123#discussioncomment-456'
+			# View the reply thread of a comment by URL
+			$ gh discussion view 'https://github.com/OWNER/REPO/discussions/123#discussioncomment-456'
 
 			# Paginate through replies
-			$ gh discussion view 123 --replies DC_abc123 --limit 10 --after CURSOR
+			$ gh discussion view DC_abc123 --limit 10 --after CURSOR
 
 			# Open in browser
 			$ gh discussion view 123 --web
@@ -152,57 +152,37 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.BaseRepo = f.BaseRepo
 
-			if err := cmdutil.MutuallyExclusive("specify only one of --comments, --replies, or --web",
-				opts.Comments, opts.RepliesArg != "", opts.WebMode); err != nil {
+			if err := cmdutil.MutuallyExclusive("specify only one of --comments or --web",
+				opts.Comments, opts.WebMode); err != nil {
 				return err
 			}
 
-			number, repo, err := shared.ParseDiscussionArg(args[0])
+			parsed, err := shared.ParseDiscussionOrCommentArg(args[0])
 			if err != nil {
 				return cmdutil.FlagErrorWrap(err)
 			}
 
-			if repo != nil {
+			if parsed.Repo != nil {
 				opts.BaseRepo = func() (ghrepo.Interface, error) {
-					return repo, nil
+					return parsed.Repo, nil
 				}
 			}
 
-			opts.DiscussionNumber = number
+			opts.DiscussionNumber = parsed.Number
+			opts.CommentNodeID = parsed.CommentNodeID
+			opts.CommentDatabaseID = parsed.CommentDatabaseID
 
-			repliesMode := cmd.Flags().Changed("replies")
-			if repliesMode {
-				parsed, err := shared.ParseDiscussionOrCommentArg(opts.RepliesArg)
-				if err != nil {
-					return cmdutil.FlagErrorf("invalid value for --replies: %w", err)
-				}
-				if parsed.CommentNodeID == "" && parsed.CommentDatabaseID == 0 {
-					return cmdutil.FlagErrorf("--replies requires a comment node ID or comment URL")
-				}
-				if parsed.CommentNodeID != "" {
-					opts.RepliesCommentID = parsed.CommentNodeID
-				} else {
-					// In this case a full comment URL is parsed, so repo and discussion number are also extracted and
-					// should be used instead of the positional argument.
-					opts.RepliesCommentDBID = parsed.CommentDatabaseID
-					opts.DiscussionNumber = parsed.Number
-					opts.BaseRepo = func() (ghrepo.Interface, error) {
-						return parsed.Repo, nil
-					}
-				}
-			}
+			repliesMode := opts.CommentNodeID != "" || opts.CommentDatabaseID != 0
 
-			commentsMode := needsComments(opts)
-
-			paginatedMode := commentsMode || repliesMode
+			paginatedMode := repliesMode || needsComments(opts)
 			if cmd.Flags().Changed("order") && !paginatedMode {
-				return cmdutil.FlagErrorf("--order requires --comments or --replies")
+				return cmdutil.FlagErrorf("--order requires --comments or a comment argument")
 			}
 			if cmd.Flags().Changed("limit") && !paginatedMode {
-				return cmdutil.FlagErrorf("--limit requires --comments or --replies")
+				return cmdutil.FlagErrorf("--limit requires --comments or a comment argument")
 			}
 			if cmd.Flags().Changed("after") && !paginatedMode {
-				return cmdutil.FlagErrorf("--after requires --comments or --replies")
+				return cmdutil.FlagErrorf("--after requires --comments or a comment argument")
 			}
 			if opts.Limit < 1 {
 				return cmdutil.FlagErrorf("invalid limit: %d", opts.Limit)
@@ -221,13 +201,22 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 
 	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open a discussion in the browser")
 	cmd.Flags().BoolVarP(&opts.Comments, "comments", "c", false, "View discussion comments")
-	cmd.Flags().StringVar(&opts.RepliesArg, "replies", "", "View replies on a specific comment (node ID or comment URL)")
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum number of comments or replies to fetch")
 	cmd.Flags().StringVar(&opts.After, "after", "", "Cursor for the next page")
 	cmdutil.StringEnumFlag(cmd, &opts.Order, "order", "", orderNewest, []string{orderOldest, orderNewest}, "Order of comments or replies")
 	cmdutil.AddJSONFlags(cmd, &opts.Exporter, discussionFields)
 
 	return cmd
+}
+
+// resolveCommentNodeID returns the comment node ID for the current invocation,
+// resolving it from a comment database ID (parsed from a comment URL) when the
+// node ID is not already known.
+func resolveCommentNodeID(c client.DiscussionClient, repo ghrepo.Interface, opts *ViewOptions) (string, error) {
+	if opts.CommentNodeID != "" {
+		return opts.CommentNodeID, nil
+	}
+	return c.ResolveCommentNodeID(repo, opts.CommentDatabaseID)
 }
 
 // needsComments returns true when the command should fetch full comment data,
@@ -242,34 +231,50 @@ func viewRun(opts *ViewOptions) error {
 		return err
 	}
 
-	if opts.WebMode {
-		openURL := ghrepo.GenerateRepoURL(repo, "discussions/%d", opts.DiscussionNumber)
-		if opts.IO.IsStderrTTY() {
-			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", text.DisplayURL(openURL))
-		}
-		return opts.Browser.Browse(openURL)
-	}
-
 	c, err := opts.Client()
 	if err != nil {
 		return err
 	}
 
+	repliesMode := opts.CommentNodeID != "" || opts.CommentDatabaseID != 0
+
+	if opts.WebMode {
+		if !repliesMode {
+			openURL := ghrepo.GenerateRepoURL(repo, "discussions/%d", opts.DiscussionNumber)
+			if opts.IO.IsStderrTTY() {
+				fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", text.DisplayURL(openURL))
+			}
+			return opts.Browser.Browse(openURL)
+		}
+
+		opts.IO.StartProgressIndicator()
+		commentID, err := resolveCommentNodeID(c, repo, opts)
+		if err != nil {
+			opts.IO.StopProgressIndicator()
+			return err
+		}
+		comment, err := c.GetComment(repo, commentID)
+		opts.IO.StopProgressIndicator()
+		if err != nil {
+			return err
+		}
+		if opts.IO.IsStderrTTY() {
+			fmt.Fprintf(opts.IO.ErrOut, "Opening %s in your browser.\n", text.DisplayURL(comment.URL))
+		}
+		return opts.Browser.Browse(comment.URL)
+	}
+
 	opts.IO.DetectTerminalTheme()
 	opts.IO.StartProgressIndicator()
 
-	if opts.RepliesCommentID != "" || opts.RepliesCommentDBID != 0 {
-		commentID := opts.RepliesCommentID
-		if commentID == "" {
-			resolved, err := c.ResolveCommentNodeID(repo, opts.RepliesCommentDBID)
-			if err != nil {
-				opts.IO.StopProgressIndicator()
-				return err
-			}
-			commentID = resolved
+	if repliesMode {
+		commentID, err := resolveCommentNodeID(c, repo, opts)
+		if err != nil {
+			opts.IO.StopProgressIndicator()
+			return err
 		}
 
-		discussion, err := c.GetCommentReplies(repo, opts.DiscussionNumber, commentID, opts.Limit, opts.After, opts.Order == orderNewest)
+		discussion, err := c.GetCommentReplies(repo.RepoHost(), commentID, opts.Limit, opts.After, opts.Order == orderNewest)
 		opts.IO.StopProgressIndicator()
 		if err != nil {
 			return err

--- a/pkg/cmd/discussion/view/view.go
+++ b/pkg/cmd/discussion/view/view.go
@@ -253,7 +253,7 @@ func viewRun(opts *ViewOptions) error {
 			opts.IO.StopProgressIndicator()
 			return err
 		}
-		comment, err := c.GetComment(repo, commentID)
+		comment, err := c.GetComment(repo.RepoHost(), commentID)
 		opts.IO.StopProgressIndicator()
 		if err != nil {
 			return err

--- a/pkg/cmd/discussion/view/view.go
+++ b/pkg/cmd/discussion/view/view.go
@@ -174,6 +174,10 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 
 			repliesMode := opts.CommentNodeID != "" || opts.CommentDatabaseID != 0
 
+			if repliesMode && opts.Comments {
+				return cmdutil.FlagErrorf("--comments is not supported with a comment argument")
+			}
+
 			paginatedMode := repliesMode || needsComments(opts)
 			if cmd.Flags().Changed("order") && !paginatedMode {
 				return cmdutil.FlagErrorf("--order requires --comments or a comment argument")

--- a/pkg/cmd/discussion/view/view.go
+++ b/pkg/cmd/discussion/view/view.go
@@ -80,15 +80,17 @@ type ViewOptions struct {
 	Browser  browser.Browser
 	Client   func() (client.DiscussionClient, error)
 
-	DiscussionNumber int32
-	WebMode          bool
-	Comments         bool
-	Replies          string
-	Limit            int
-	After            string
-	Order            string
-	Exporter         cmdutil.Exporter
-	Now              func() time.Time
+	DiscussionNumber   int32
+	WebMode            bool
+	Comments           bool
+	RepliesArg         string
+	RepliesCommentID   string
+	RepliesCommentDBID int64
+	Limit              int
+	After              string
+	Order              string
+	Exporter           cmdutil.Exporter
+	Now                func() time.Time
 }
 
 // NewCmdView creates the "discussion view" command.
@@ -100,7 +102,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 	}
 
 	cmd := &cobra.Command{
-		Use:   "view {<number> | <url>}",
+		Use:   "view {<number> | <url>} [flags]",
 		Short: "View a discussion (preview)",
 		Long: heredoc.Docf(`
 			Display the title, body, and other information about a discussion.
@@ -108,7 +110,8 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 			To see the comments on a discussion, pass %[1]s--comments%[1]s. A few latest replies
 			of each comment will also be retrieved regardless of the selected ordering.
 
-			For a full thread of a comment, pass %[1]s--replies <COMMENT-ID>%[1]s.
+			For a full thread of a comment, pass %[1]s--replies%[1]s with a comment node ID or
+			comment URL (e.g., %[1]shttps://github.com/OWNER/REPO/discussions/123#discussioncomment-456%[1]s).
 
 			Pagination and ordering can be controlled via %[1]s--order%[1]s, %[1]s--limit%[1]s, and %[1]s--after%[1]s flags.
 
@@ -133,23 +136,62 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 			# Fetch the next page of comments
 			$ gh discussion view 123 --comments --after CURSOR
 
-			# View replies on a specific comment
-			$ gh discussion view 123 --replies COMMENT-ID
+			# View replies on a specific comment by node ID
+			$ gh discussion view 123 --replies DC_abc123
+
+			# View replies on a comment using the its URL
+			$ gh discussion view --replies 'https://github.com/OWNER/REPO/discussions/123#discussioncomment-456'
 
 			# Paginate through replies
-			$ gh discussion view 123 --replies COMMENT-ID --limit 10 --after CURSOR
+			$ gh discussion view 123 --replies DC_abc123 --limit 10 --after CURSOR
 
 			# Open in browser
 			$ gh discussion view 123 --web
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.BaseRepo = f.BaseRepo
+
 			if err := cmdutil.MutuallyExclusive("specify only one of --comments, --replies, or --web",
-				opts.Comments, opts.Replies != "", opts.WebMode); err != nil {
+				opts.Comments, opts.RepliesArg != "", opts.WebMode); err != nil {
 				return err
 			}
 
-			repliesMode := opts.Replies != ""
+			number, repo, err := shared.ParseDiscussionArg(args[0])
+			if err != nil {
+				return cmdutil.FlagErrorWrap(err)
+			}
+
+			if repo != nil {
+				opts.BaseRepo = func() (ghrepo.Interface, error) {
+					return repo, nil
+				}
+			}
+
+			opts.DiscussionNumber = number
+
+			repliesMode := cmd.Flags().Changed("replies")
+			if repliesMode {
+				parsed, err := shared.ParseDiscussionOrCommentArg(opts.RepliesArg)
+				if err != nil {
+					return cmdutil.FlagErrorf("invalid value for --replies: %w", err)
+				}
+				if parsed.CommentNodeID == "" && parsed.CommentDatabaseID == 0 {
+					return cmdutil.FlagErrorf("--replies requires a comment node ID or comment URL")
+				}
+				if parsed.CommentNodeID != "" {
+					opts.RepliesCommentID = parsed.CommentNodeID
+				} else {
+					// In this case a full comment URL is parsed, so repo and discussion number are also extracted and
+					// should be used instead of the positional argument.
+					opts.RepliesCommentDBID = parsed.CommentDatabaseID
+					opts.DiscussionNumber = parsed.Number
+					opts.BaseRepo = func() (ghrepo.Interface, error) {
+						return parsed.Repo, nil
+					}
+				}
+			}
+
 			commentsMode := needsComments(opts)
 
 			paginatedMode := commentsMode || repliesMode
@@ -166,20 +208,6 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 				return cmdutil.FlagErrorf("invalid limit: %d", opts.Limit)
 			}
 
-			number, repo, err := shared.ParseDiscussionArg(args[0])
-			if err != nil {
-				return cmdutil.FlagErrorWrap(err)
-			}
-
-			if repo != nil {
-				opts.BaseRepo = func() (ghrepo.Interface, error) {
-					return repo, nil
-				}
-			} else {
-				opts.BaseRepo = f.BaseRepo
-			}
-
-			opts.DiscussionNumber = number
 			opts.Client = shared.DiscussionClientFunc(f)
 
 			if runF != nil {
@@ -193,7 +221,7 @@ func NewCmdView(f *cmdutil.Factory, runF func(*ViewOptions) error) *cobra.Comman
 
 	cmd.Flags().BoolVarP(&opts.WebMode, "web", "w", false, "Open a discussion in the browser")
 	cmd.Flags().BoolVarP(&opts.Comments, "comments", "c", false, "View discussion comments")
-	cmd.Flags().StringVar(&opts.Replies, "replies", "", "View replies on a specific comment by its node ID")
+	cmd.Flags().StringVar(&opts.RepliesArg, "replies", "", "View replies on a specific comment (node ID or comment URL)")
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum number of comments or replies to fetch")
 	cmd.Flags().StringVar(&opts.After, "after", "", "Cursor for the next page")
 	cmdutil.StringEnumFlag(cmd, &opts.Order, "order", "", orderNewest, []string{orderOldest, orderNewest}, "Order of comments or replies")
@@ -230,8 +258,18 @@ func viewRun(opts *ViewOptions) error {
 	opts.IO.DetectTerminalTheme()
 	opts.IO.StartProgressIndicator()
 
-	if opts.Replies != "" {
-		discussion, err := c.GetCommentReplies(repo, opts.DiscussionNumber, opts.Replies, opts.Limit, opts.After, opts.Order == orderNewest)
+	if opts.RepliesCommentID != "" || opts.RepliesCommentDBID != 0 {
+		commentID := opts.RepliesCommentID
+		if commentID == "" {
+			resolved, err := c.ResolveCommentNodeID(repo, opts.RepliesCommentDBID)
+			if err != nil {
+				opts.IO.StopProgressIndicator()
+				return err
+			}
+			commentID = resolved
+		}
+
+		discussion, err := c.GetCommentReplies(repo, opts.DiscussionNumber, commentID, opts.Limit, opts.After, opts.Order == orderNewest)
 		opts.IO.StopProgressIndicator()
 		if err != nil {
 			return err

--- a/pkg/cmd/discussion/view/view_test.go
+++ b/pkg/cmd/discussion/view/view_test.go
@@ -355,8 +355,8 @@ func TestViewRun(t *testing.T) {
 			name: "web comment by node id",
 			tty:  true,
 			clientStub: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
-					assert.Equal(t, "OWNER/REPO", ghrepo.FullName(repo))
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "github.com", host)
 					assert.Equal(t, "DC_abc", commentID)
 					return &client.DiscussionComment{
 						URL: "https://github.com/OWNER/REPO/discussions/123#discussioncomment-456",
@@ -378,7 +378,7 @@ func TestViewRun(t *testing.T) {
 					assert.Equal(t, int64(456), commentDatabaseID)
 					return "DC_resolved", nil
 				}
-				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+				m.GetCommentFunc = func(host string, commentID string) (*client.DiscussionComment, error) {
 					assert.Equal(t, "DC_resolved", commentID)
 					return &client.DiscussionComment{
 						URL: "https://github.com/OWNER/REPO/discussions/123#discussioncomment-456",

--- a/pkg/cmd/discussion/view/view_test.go
+++ b/pkg/cmd/discussion/view/view_test.go
@@ -142,11 +142,24 @@ func TestNewCmdView(t *testing.T) {
 			},
 		},
 		{
+			name: "replies flag with comment url",
+			args: "123 --replies https://github.com/OWNER/REPO2/discussions/123#discussioncomment-456",
+			wantOpts: ViewOptions{
+				DiscussionNumber:   123,
+				RepliesCommentDBID: 456,
+				RepliesArg:         "https://github.com/OWNER/REPO2/discussions/123#discussioncomment-456",
+				Limit:              30,
+				Order:              "newest",
+			},
+			wantRepo: "OWNER/REPO2",
+		},
+		{
 			name: "replies flag",
 			args: "123 --replies DC_abc",
 			wantOpts: ViewOptions{
 				DiscussionNumber: 123,
-				Replies:          "DC_abc",
+				RepliesArg:       "DC_abc",
+				RepliesCommentID: "DC_abc",
 				Limit:            30,
 				Order:            "newest",
 			},
@@ -156,7 +169,8 @@ func TestNewCmdView(t *testing.T) {
 			args: "123 --replies DC_abc --limit 10",
 			wantOpts: ViewOptions{
 				DiscussionNumber: 123,
-				Replies:          "DC_abc",
+				RepliesArg:       "DC_abc",
+				RepliesCommentID: "DC_abc",
 				Limit:            10,
 				Order:            "newest",
 			},
@@ -166,7 +180,8 @@ func TestNewCmdView(t *testing.T) {
 			args: "123 --replies DC_abc --after CURSOR",
 			wantOpts: ViewOptions{
 				DiscussionNumber: 123,
-				Replies:          "DC_abc",
+				RepliesArg:       "DC_abc",
+				RepliesCommentID: "DC_abc",
 				Limit:            30,
 				After:            "CURSOR",
 				Order:            "newest",
@@ -177,7 +192,8 @@ func TestNewCmdView(t *testing.T) {
 			args: "123 --replies DC_abc --order oldest",
 			wantOpts: ViewOptions{
 				DiscussionNumber: 123,
-				Replies:          "DC_abc",
+				RepliesArg:       "DC_abc",
+				RepliesCommentID: "DC_abc",
 				Limit:            30,
 				Order:            "oldest",
 			},
@@ -261,7 +277,9 @@ func TestNewCmdView(t *testing.T) {
 			assert.Equal(t, tt.wantOpts.DiscussionNumber, gotOpts.DiscussionNumber)
 			assert.Equal(t, tt.wantOpts.WebMode, gotOpts.WebMode)
 			assert.Equal(t, tt.wantOpts.Comments, gotOpts.Comments)
-			assert.Equal(t, tt.wantOpts.Replies, gotOpts.Replies)
+			assert.Equal(t, tt.wantOpts.RepliesArg, gotOpts.RepliesArg)
+			assert.Equal(t, tt.wantOpts.RepliesCommentDBID, gotOpts.RepliesCommentDBID)
+			assert.Equal(t, tt.wantOpts.RepliesCommentID, gotOpts.RepliesCommentID)
 			assert.Equal(t, tt.wantOpts.Limit, gotOpts.Limit)
 			assert.Equal(t, tt.wantOpts.After, gotOpts.After)
 			assert.Equal(t, tt.wantOpts.Order, gotOpts.Order)
@@ -723,7 +741,46 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				Replies: "DC_abc",
+				RepliesCommentID: "DC_abc",
+			},
+			wantStdout: heredoc.Doc(`
+				octocat commented less than a minute ago ✓ Answer
+
+				  This is the parent comment                                                  
+
+				👍 3
+
+				  hubot commented less than a minute ago
+				  
+				    First reply                                                                 
+				  
+				  
+				  monalisa commented less than a minute ago
+				  
+				    Second reply                                                                
+				  
+				  
+			`),
+		},
+		{
+			name: "replies via comment URL tty",
+			tty:  true,
+			clientStub: func(t *testing.T, m *client.DiscussionClientMock) {
+				m.ResolveCommentNodeIDFunc = func(repo ghrepo.Interface, commentDatabaseID int64) (string, error) {
+					assert.Equal(t, int64(9999999), commentDatabaseID)
+					return "DC_resolved", nil
+				}
+				m.GetCommentRepliesFunc = func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
+					assert.Equal(t, "OWNER/REPO", ghrepo.FullName(repo))
+					assert.Equal(t, int32(123), number)
+					assert.Equal(t, "DC_resolved", commentID)
+					assert.Equal(t, 30, limit)
+					assert.Equal(t, true, newest)
+					return exampleDiscussionWithReplies(""), nil
+				}
+			},
+			opts: ViewOptions{
+				RepliesCommentDBID: 9999999,
 			},
 			wantStdout: heredoc.Doc(`
 				octocat commented less than a minute ago ✓ Answer
@@ -759,7 +816,7 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				Replies: "DC_abc",
+				RepliesCommentID: "DC_abc",
 			},
 			wantStdout: heredoc.Doc(`
 				octocat commented less than a minute ago ✓ Answer
@@ -796,8 +853,8 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				Replies: "DC_abc",
-				Order:   "oldest",
+				RepliesCommentID: "DC_abc",
+				Order:            "oldest",
 			},
 			wantStdout: heredoc.Doc(`
 				comment:	octocat	2025-03-02T00:00:00Z	https://github.com/OWNER/REPO/discussions/123#discussioncomment-1	answer
@@ -826,8 +883,8 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				Replies: "DC_abc",
-				Order:   "oldest",
+				RepliesCommentID: "DC_abc",
+				Order:            "oldest",
 			},
 			wantStdout: heredoc.Doc(`
 				comment:	octocat	2025-03-02T00:00:00Z	https://github.com/OWNER/REPO/discussions/123#discussioncomment-1	answer
@@ -857,8 +914,8 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				Replies:  "DC_abc",
-				Exporter: jsonExporter("comments"),
+				RepliesCommentID: "DC_abc",
+				Exporter:         jsonExporter("comments"),
 			},
 			wantStdout: compactJSON(heredoc.Doc(`
 				{
@@ -921,8 +978,8 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				Replies:  "DC_abc",
-				Exporter: jsonExporter("comments"),
+				RepliesCommentID: "DC_abc",
+				Exporter:         jsonExporter("comments"),
 			},
 			wantStdout: compactJSON(heredoc.Doc(`
 				{

--- a/pkg/cmd/discussion/view/view_test.go
+++ b/pkg/cmd/discussion/view/view_test.go
@@ -190,14 +190,14 @@ func TestNewCmdView(t *testing.T) {
 			},
 		},
 		{
-			name: "comment node id ignores comments flag",
-			args: "DC_abc --comments",
-			wantOpts: ViewOptions{
-				CommentNodeID: "DC_abc",
-				Comments:      true,
-				Limit:         30,
-				Order:         "newest",
-			},
+			name:    "comment node id with comments flag errors",
+			args:    "DC_abc --comments",
+			wantErr: "--comments is not supported with a comment argument",
+		},
+		{
+			name:    "comment URL with comments flag errors",
+			args:    "https://github.com/OWNER/REPO2/discussions/123#discussioncomment-456 --comments",
+			wantErr: "--comments is not supported with a comment argument",
 		},
 		{
 			name:    "comments with web is mutually exclusive",
@@ -881,7 +881,7 @@ func TestViewRun(t *testing.T) {
 			},
 			opts: ViewOptions{
 				CommentNodeID: "DC_abc",
-				Order:            "oldest",
+				Order:         "oldest",
 			},
 			wantStdout: heredoc.Doc(`
 				comment:	octocat	2025-03-02T00:00:00Z	https://github.com/OWNER/REPO/discussions/123#discussioncomment-1	answer
@@ -910,7 +910,7 @@ func TestViewRun(t *testing.T) {
 			},
 			opts: ViewOptions{
 				CommentNodeID: "DC_abc",
-				Order:            "oldest",
+				Order:         "oldest",
 			},
 			wantStdout: heredoc.Doc(`
 				comment:	octocat	2025-03-02T00:00:00Z	https://github.com/OWNER/REPO/discussions/123#discussioncomment-1	answer
@@ -940,7 +940,7 @@ func TestViewRun(t *testing.T) {
 			},
 			opts: ViewOptions{
 				CommentNodeID: "DC_abc",
-				Exporter:         jsonExporter("comments"),
+				Exporter:      jsonExporter("comments"),
 			},
 			wantStdout: compactJSON(heredoc.Doc(`
 				{
@@ -1003,7 +1003,7 @@ func TestViewRun(t *testing.T) {
 			},
 			opts: ViewOptions{
 				CommentNodeID: "DC_abc",
-				Exporter:         jsonExporter("comments"),
+				Exporter:      jsonExporter("comments"),
 			},
 			wantStdout: compactJSON(heredoc.Doc(`
 				{

--- a/pkg/cmd/discussion/view/view_test.go
+++ b/pkg/cmd/discussion/view/view_test.go
@@ -83,7 +83,7 @@ func TestNewCmdView(t *testing.T) {
 		{
 			name:    "invalid argument",
 			args:    "not-a-number",
-			wantErr: "invalid discussion argument",
+			wantErr: "invalid argument",
 		},
 		{
 			name:    "no arguments",
@@ -142,91 +142,82 @@ func TestNewCmdView(t *testing.T) {
 			},
 		},
 		{
-			name: "replies flag with comment url",
-			args: "123 --replies https://github.com/OWNER/REPO2/discussions/123#discussioncomment-456",
+			name: "comment url positional",
+			args: "https://github.com/OWNER/REPO2/discussions/123#discussioncomment-456",
 			wantOpts: ViewOptions{
-				DiscussionNumber:   123,
-				RepliesCommentDBID: 456,
-				RepliesArg:         "https://github.com/OWNER/REPO2/discussions/123#discussioncomment-456",
-				Limit:              30,
-				Order:              "newest",
+				DiscussionNumber:  123,
+				CommentDatabaseID: 456,
+				Limit:             30,
+				Order:             "newest",
 			},
 			wantRepo: "OWNER/REPO2",
 		},
 		{
-			name: "replies flag",
-			args: "123 --replies DC_abc",
+			name: "comment node id positional",
+			args: "DC_abc",
 			wantOpts: ViewOptions{
-				DiscussionNumber: 123,
-				RepliesArg:       "DC_abc",
-				RepliesCommentID: "DC_abc",
-				Limit:            30,
-				Order:            "newest",
+				CommentNodeID: "DC_abc",
+				Limit:         30,
+				Order:         "newest",
 			},
 		},
 		{
-			name: "replies with limit",
-			args: "123 --replies DC_abc --limit 10",
+			name: "comment node id with limit",
+			args: "DC_abc --limit 10",
 			wantOpts: ViewOptions{
-				DiscussionNumber: 123,
-				RepliesArg:       "DC_abc",
-				RepliesCommentID: "DC_abc",
-				Limit:            10,
-				Order:            "newest",
+				CommentNodeID: "DC_abc",
+				Limit:         10,
+				Order:         "newest",
 			},
 		},
 		{
-			name: "replies with after",
-			args: "123 --replies DC_abc --after CURSOR",
+			name: "comment node id with after",
+			args: "DC_abc --after CURSOR",
 			wantOpts: ViewOptions{
-				DiscussionNumber: 123,
-				RepliesArg:       "DC_abc",
-				RepliesCommentID: "DC_abc",
-				Limit:            30,
-				After:            "CURSOR",
-				Order:            "newest",
+				CommentNodeID: "DC_abc",
+				Limit:         30,
+				After:         "CURSOR",
+				Order:         "newest",
 			},
 		},
 		{
-			name: "replies with order oldest",
-			args: "123 --replies DC_abc --order oldest",
+			name: "comment node id with order oldest",
+			args: "DC_abc --order oldest",
 			wantOpts: ViewOptions{
-				DiscussionNumber: 123,
-				RepliesArg:       "DC_abc",
-				RepliesCommentID: "DC_abc",
-				Limit:            30,
-				Order:            "oldest",
+				CommentNodeID: "DC_abc",
+				Limit:         30,
+				Order:         "oldest",
 			},
 		},
 		{
-			name:    "replies with comments is mutually exclusive",
-			args:    "123 --replies DC_abc --comments",
-			wantErr: "specify only one of --comments, --replies, or --web",
-		},
-		{
-			name:    "replies with web is mutually exclusive",
-			args:    "123 --replies DC_abc --web",
-			wantErr: "specify only one of --comments, --replies, or --web",
+			name: "comment node id ignores comments flag",
+			args: "DC_abc --comments",
+			wantOpts: ViewOptions{
+				CommentNodeID: "DC_abc",
+				Comments:      true,
+				Limit:         30,
+				Order:         "newest",
+			},
 		},
 		{
 			name:    "comments with web is mutually exclusive",
 			args:    "123 --comments --web",
-			wantErr: "specify only one of --comments, --replies, or --web",
+			wantErr: "specify only one of --comments or --web",
 		},
 		{
-			name:    "order requires comments or replies",
+			name:    "order requires comments or comment arg",
 			args:    "123 --order newest",
-			wantErr: "--order requires --comments or --replies",
+			wantErr: "--order requires --comments or a comment argument",
 		},
 		{
-			name:    "limit requires comments or replies",
+			name:    "limit requires comments or comment arg",
 			args:    "123 --limit 5",
-			wantErr: "--limit requires --comments or --replies",
+			wantErr: "--limit requires --comments or a comment argument",
 		},
 		{
-			name:    "after requires comments or replies",
+			name:    "after requires comments or comment arg",
 			args:    "123 --after CURSOR",
-			wantErr: "--after requires --comments or --replies",
+			wantErr: "--after requires --comments or a comment argument",
 		},
 		{
 			name:    "invalid limit zero",
@@ -277,9 +268,8 @@ func TestNewCmdView(t *testing.T) {
 			assert.Equal(t, tt.wantOpts.DiscussionNumber, gotOpts.DiscussionNumber)
 			assert.Equal(t, tt.wantOpts.WebMode, gotOpts.WebMode)
 			assert.Equal(t, tt.wantOpts.Comments, gotOpts.Comments)
-			assert.Equal(t, tt.wantOpts.RepliesArg, gotOpts.RepliesArg)
-			assert.Equal(t, tt.wantOpts.RepliesCommentDBID, gotOpts.RepliesCommentDBID)
-			assert.Equal(t, tt.wantOpts.RepliesCommentID, gotOpts.RepliesCommentID)
+			assert.Equal(t, tt.wantOpts.CommentDatabaseID, gotOpts.CommentDatabaseID)
+			assert.Equal(t, tt.wantOpts.CommentNodeID, gotOpts.CommentNodeID)
 			assert.Equal(t, tt.wantOpts.Limit, gotOpts.Limit)
 			assert.Equal(t, tt.wantOpts.After, gotOpts.After)
 			assert.Equal(t, tt.wantOpts.Order, gotOpts.Order)
@@ -360,6 +350,47 @@ func TestViewRun(t *testing.T) {
 			},
 			wantStderr:  "Opening https://github.com/OWNER/REPO/discussions/123 in your browser.\n",
 			wantBrowser: "https://github.com/OWNER/REPO/discussions/123",
+		},
+		{
+			name: "web comment by node id",
+			tty:  true,
+			clientStub: func(t *testing.T, m *client.DiscussionClientMock) {
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "OWNER/REPO", ghrepo.FullName(repo))
+					assert.Equal(t, "DC_abc", commentID)
+					return &client.DiscussionComment{
+						URL: "https://github.com/OWNER/REPO/discussions/123#discussioncomment-456",
+					}, nil
+				}
+			},
+			opts: ViewOptions{
+				WebMode:       true,
+				CommentNodeID: "DC_abc",
+			},
+			wantStderr:  "Opening https://github.com/OWNER/REPO/discussions/123 in your browser.\n",
+			wantBrowser: "https://github.com/OWNER/REPO/discussions/123#discussioncomment-456",
+		},
+		{
+			name: "web comment by url",
+			tty:  true,
+			clientStub: func(t *testing.T, m *client.DiscussionClientMock) {
+				m.ResolveCommentNodeIDFunc = func(repo ghrepo.Interface, commentDatabaseID int64) (string, error) {
+					assert.Equal(t, int64(456), commentDatabaseID)
+					return "DC_resolved", nil
+				}
+				m.GetCommentFunc = func(repo ghrepo.Interface, commentID string) (*client.DiscussionComment, error) {
+					assert.Equal(t, "DC_resolved", commentID)
+					return &client.DiscussionComment{
+						URL: "https://github.com/OWNER/REPO/discussions/123#discussioncomment-456",
+					}, nil
+				}
+			},
+			opts: ViewOptions{
+				WebMode:           true,
+				CommentDatabaseID: 456,
+			},
+			wantStderr:  "Opening https://github.com/OWNER/REPO/discussions/123 in your browser.\n",
+			wantBrowser: "https://github.com/OWNER/REPO/discussions/123#discussioncomment-456",
 		},
 		{
 			name: "not answerable tty",
@@ -730,9 +761,8 @@ func TestViewRun(t *testing.T) {
 			name: "replies tty",
 			tty:  true,
 			clientStub: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentRepliesFunc = func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
-					assert.Equal(t, "OWNER/REPO", ghrepo.FullName(repo))
-					assert.Equal(t, int32(123), number)
+				m.GetCommentRepliesFunc = func(host string, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
+					assert.Equal(t, "github.com", host)
 					assert.Equal(t, "DC_abc", commentID)
 					assert.Equal(t, 30, limit)
 					assert.Equal(t, "", after)
@@ -741,7 +771,7 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				RepliesCommentID: "DC_abc",
+				CommentNodeID: "DC_abc",
 			},
 			wantStdout: heredoc.Doc(`
 				octocat commented less than a minute ago ✓ Answer
@@ -770,9 +800,8 @@ func TestViewRun(t *testing.T) {
 					assert.Equal(t, int64(9999999), commentDatabaseID)
 					return "DC_resolved", nil
 				}
-				m.GetCommentRepliesFunc = func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
-					assert.Equal(t, "OWNER/REPO", ghrepo.FullName(repo))
-					assert.Equal(t, int32(123), number)
+				m.GetCommentRepliesFunc = func(host string, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
+					assert.Equal(t, "github.com", host)
 					assert.Equal(t, "DC_resolved", commentID)
 					assert.Equal(t, 30, limit)
 					assert.Equal(t, true, newest)
@@ -780,7 +809,7 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				RepliesCommentDBID: 9999999,
+				CommentDatabaseID: 9999999,
 			},
 			wantStdout: heredoc.Doc(`
 				octocat commented less than a minute ago ✓ Answer
@@ -805,9 +834,8 @@ func TestViewRun(t *testing.T) {
 			name: "replies pagination tty",
 			tty:  true,
 			clientStub: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentRepliesFunc = func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
-					assert.Equal(t, "OWNER/REPO", ghrepo.FullName(repo))
-					assert.Equal(t, int32(123), number)
+				m.GetCommentRepliesFunc = func(host string, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
+					assert.Equal(t, "github.com", host)
 					assert.Equal(t, "DC_abc", commentID)
 					assert.Equal(t, 30, limit)
 					assert.Equal(t, "", after)
@@ -816,7 +844,7 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				RepliesCommentID: "DC_abc",
+				CommentNodeID: "DC_abc",
 			},
 			wantStdout: heredoc.Doc(`
 				octocat commented less than a minute ago ✓ Answer
@@ -842,9 +870,8 @@ func TestViewRun(t *testing.T) {
 		{
 			name: "replies nontty",
 			clientStub: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentRepliesFunc = func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
-					assert.Equal(t, "OWNER/REPO", ghrepo.FullName(repo))
-					assert.Equal(t, int32(123), number)
+				m.GetCommentRepliesFunc = func(host string, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
+					assert.Equal(t, "github.com", host)
 					assert.Equal(t, "DC_abc", commentID)
 					assert.Equal(t, 30, limit)
 					assert.Equal(t, "", after)
@@ -853,7 +880,7 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				RepliesCommentID: "DC_abc",
+				CommentNodeID: "DC_abc",
 				Order:            "oldest",
 			},
 			wantStdout: heredoc.Doc(`
@@ -872,9 +899,8 @@ func TestViewRun(t *testing.T) {
 		{
 			name: "replies pagination nontty",
 			clientStub: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentRepliesFunc = func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
-					assert.Equal(t, "OWNER/REPO", ghrepo.FullName(repo))
-					assert.Equal(t, int32(123), number)
+				m.GetCommentRepliesFunc = func(host string, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
+					assert.Equal(t, "github.com", host)
 					assert.Equal(t, "DC_abc", commentID)
 					assert.Equal(t, 30, limit)
 					assert.Equal(t, "", after)
@@ -883,7 +909,7 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				RepliesCommentID: "DC_abc",
+				CommentNodeID: "DC_abc",
 				Order:            "oldest",
 			},
 			wantStdout: heredoc.Doc(`
@@ -903,9 +929,8 @@ func TestViewRun(t *testing.T) {
 		{
 			name: "replies json",
 			clientStub: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentRepliesFunc = func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
-					assert.Equal(t, "OWNER/REPO", ghrepo.FullName(repo))
-					assert.Equal(t, int32(123), number)
+				m.GetCommentRepliesFunc = func(host string, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
+					assert.Equal(t, "github.com", host)
 					assert.Equal(t, "DC_abc", commentID)
 					assert.Equal(t, 30, limit)
 					assert.Equal(t, "", after)
@@ -914,7 +939,7 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				RepliesCommentID: "DC_abc",
+				CommentNodeID: "DC_abc",
 				Exporter:         jsonExporter("comments"),
 			},
 			wantStdout: compactJSON(heredoc.Doc(`
@@ -967,9 +992,8 @@ func TestViewRun(t *testing.T) {
 		{
 			name: "replies json pagination",
 			clientStub: func(t *testing.T, m *client.DiscussionClientMock) {
-				m.GetCommentRepliesFunc = func(repo ghrepo.Interface, number int32, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
-					assert.Equal(t, "OWNER/REPO", ghrepo.FullName(repo))
-					assert.Equal(t, int32(123), number)
+				m.GetCommentRepliesFunc = func(host string, commentID string, limit int, after string, newest bool) (*client.Discussion, error) {
+					assert.Equal(t, "github.com", host)
 					assert.Equal(t, "DC_abc", commentID)
 					assert.Equal(t, 30, limit)
 					assert.Equal(t, "", after)
@@ -978,7 +1002,7 @@ func TestViewRun(t *testing.T) {
 				}
 			},
 			opts: ViewOptions{
-				RepliesCommentID: "DC_abc",
+				CommentNodeID: "DC_abc",
 				Exporter:         jsonExporter("comments"),
 			},
 			wantStdout: compactJSON(heredoc.Doc(`


### PR DESCRIPTION
## Add `gh discussion comment` command

This PR adds a new `gh discussion comment` command for managing comments and replies on GitHub Discussions, along with UX improvements to the `view` command.

### `gh discussion comment`

The command supports adding, editing, and deleting comments and replies. The positional argument determines the action context:

**Adding a top-level comment:**
```
gh discussion comment 123 --body "Thanks for raising this"
gh discussion comment 123 --body-file response.md
```

**Replying to a comment (positional arg is a comment ID or URL):**
```
gh discussion comment DC_abc123 --body "Good point"
gh discussion comment "https://github.com/OWNER/REPO/discussions/123#discussioncomment-456" --body "I agree"
```

**Editing a comment or reply:**
```
gh discussion comment DC_abc123 --edit --body "Updated text"
gh discussion comment "https://github.com/OWNER/REPO/discussions/123#discussioncomment-456" --edit --body-file updated.md
```

**Deleting a comment or reply:**
```
gh discussion comment DC_abc123 --delete --yes
gh discussion comment "https://github.com/OWNER/REPO/discussions/123#discussioncomment-456" --delete --yes
```

When no `--body` or `--body-file` is provided in an interactive terminal, an editor is opened for input. For edits, the editor is pre-populated with the existing comment body.

Comment URLs are resolved to node IDs via msgpack encoding of the repository database ID and comment database ID extracted from the URL fragment.

### Changes to `gh discussion view`

The `--replies` flag now accepts both comment node IDs and comment URLs:

```
gh discussion view 123 --replies DC_abc123
gh discussion view 123 --replies "https://github.com/OWNER/REPO/discussions/123#discussioncomment-456"
```

When a URL is provided, the repository and discussion number from the URL override the positional argument.

### Tests

- Added acceptance tests for the `comment` command covering add, reply, edit (including from file), delete (with confirmation prompt check), and URL-based operations.
- Updated existing acceptance tests (`discussion-view.txtar`, `discussion-list.txtar`) to use the new `comment` command instead of raw `gh api graphql` mutations.
- Added a test case in `discussion-view.txtar` to verify `--replies` works with a comment URL.
- Unit tests cover flag parsing, all run paths (add/reply/edit/delete), comment URL resolution, body-file/stdin input, editor pre-population, and error cases.
