### PR TITLE
Read-only mode for `gh` via `GH_READ_ONLY` env var

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -7,12 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
-	"slices"
 	"strings"
 	"time"
 
 	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
+	"github.com/cli/cli/v2/internal/ghenv"
 	"github.com/cli/cli/v2/utils"
 	ghAPI "github.com/cli/go-gh/v2/pkg/api"
 	ghauth "github.com/cli/go-gh/v2/pkg/auth"

--- a/api/http_client.go
+++ b/api/http_client.go
@@ -1,9 +1,14 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -81,6 +86,12 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 			wrappedTransport:  client.Transport,
 			telemetryDisabler: opts.TelemetryDisabler,
 		}
+	}
+
+	// Consulted here, in the single client constructor, so callers that build
+	// their own options (e.g. `gh api`) can't bypass it.
+	if ghenv.ReadOnly() {
+		client.Transport = ReadOnlyMiddleware(client.Transport)
 	}
 
 	return client, nil
@@ -168,6 +179,160 @@ func AddAuthTokenHeader(rt http.RoundTripper, cfg tokenGetter) http.RoundTripper
 		}
 		return rt.RoundTrip(req)
 	}}
+}
+
+var ErrReadOnly = errors.New("gh is in read-only mode (GH_READ_ONLY): this operation would modify data and was blocked")
+
+func ReadOnlyMiddleware(rt http.RoundTripper) http.RoundTripper {
+	return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+		if err := checkReadOnly(req); err != nil {
+			return nil, err
+		}
+		return rt.RoundTrip(req)
+	}}
+}
+
+func checkReadOnly(req *http.Request) error {
+	// HTTP methods are case-sensitive per the spec but GitHub treats them
+	// case-insensitively, and `gh api -X get` reaches here as "get", so
+	// normalize before comparing to avoid blocking a lowercase read.
+	switch strings.ToUpper(req.Method) {
+	case http.MethodGet, http.MethodHead:
+		return nil
+	}
+
+	if isGraphQLEndpoint(req.URL.Path) {
+		isMutation, err := requestIsGraphQLMutation(req)
+		if err != nil {
+			// Fail closed: if we cannot determine the operation type, block it.
+			return ErrReadOnly
+		}
+		if !isMutation {
+			return nil
+		}
+	}
+
+	return ErrReadOnly
+}
+
+// "/graphql" on github.com, "/api/graphql" on GHES
+func isGraphQLEndpoint(path string) bool {
+	return path == "/graphql" || path == "/api/graphql"
+}
+
+// Reads and restores req.Body, so the request stays sendable afterward.
+func requestIsGraphQLMutation(req *http.Request) (bool, error) {
+	if req.Body == nil {
+		return false, nil
+	}
+
+	defer req.Body.Close()
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return false, err
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+
+	var payload struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false, err
+	}
+
+	return containsTopLevelMutation(payload.Query), nil
+}
+
+// containsTopLevelMutation detects a mutation *operation* — not merely the word
+// "mutation", which may also be a field or operation name.
+func containsTopLevelMutation(query string) bool {
+	depth := 0
+	// expectKeyword is true at the start of the document and after a top-level
+	// definition closes, i.e. exactly where an operation/fragment keyword would
+	// appear next.
+	expectKeyword := true
+
+	for i := 0; i < len(query); {
+		c := query[i]
+
+		switch {
+		case c == '#':
+			// Comment runs to end of line.
+			for i < len(query) && query[i] != '\n' {
+				i++
+			}
+		case c == '"':
+			i = skipGraphQLString(query, i)
+		case c == '{':
+			depth++
+			expectKeyword = false
+			i++
+		case c == '}':
+			if depth > 0 {
+				depth--
+			}
+			if depth == 0 {
+				expectKeyword = true
+			}
+			i++
+		case isNameByte(c):
+			start := i
+			for i < len(query) && isNameByte(query[i]) {
+				i++
+			}
+			if depth == 0 && expectKeyword {
+				if query[start:i] == "mutation" {
+					return true
+				}
+				// The definition keyword has been seen; do not treat later
+				// top-level identifiers (e.g. the operation name) as keywords.
+				expectKeyword = false
+			}
+		default:
+			i++
+		}
+	}
+
+	return false
+}
+
+// skipGraphQLString returns the index just past the string literal at query[i].
+func skipGraphQLString(query string, i int) int {
+	if strings.HasPrefix(query[i:], `"""`) {
+		i += 3
+		for i < len(query) {
+			if strings.HasPrefix(query[i:], `"""`) {
+				return i + 3
+			}
+			i++
+		}
+		return i
+	}
+
+	i++ // opening quote
+	for i < len(query) {
+		switch query[i] {
+		case '\\':
+			i += 2
+		case '"':
+			return i + 1
+		default:
+			i++
+		}
+	}
+	return i
+}
+
+func isNameByte(c byte) bool {
+	return c == '_' ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9')
 }
 
 // ExtractHeader extracts a named header from any response received by this client and,

--- a/api/read_only_test.go
+++ b/api/read_only_test.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingTripper records whether it was invoked and echoes back a 200 response.
+type recordingTripper struct {
+	called  bool
+	gotBody string
+}
+
+func (rt *recordingTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.called = true
+	if req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		rt.gotBody = string(b)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Request:    req,
+	}, nil
+}
+
+func newRequest(t *testing.T, method, url, body string) *http.Request {
+	t.Helper()
+	var r io.Reader
+	if body != "" {
+		r = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, r)
+	require.NoError(t, err)
+	return req
+}
+
+func TestReadOnlyMiddleware(t *testing.T) {
+	tests := []struct {
+		name        string
+		method      string
+		url         string
+		body        string
+		wantBlocked bool
+	}{
+		{
+			name:   "REST GET is allowed",
+			method: http.MethodGet,
+			url:    "https://api.github.com/repos/cli/cli",
+		},
+		{
+			name:   "REST HEAD is allowed",
+			method: http.MethodHead,
+			url:    "https://api.github.com/repos/cli/cli",
+		},
+		{
+			name:   "REST lowercase get is allowed",
+			method: "get",
+			url:    "https://api.github.com/repos/cli/cli",
+		},
+		{
+			name:        "REST POST is blocked",
+			method:      http.MethodPost,
+			url:         "https://api.github.com/repos/cli/cli/issues",
+			body:        `{"title":"x"}`,
+			wantBlocked: true,
+		},
+		{
+			name:        "REST PATCH is blocked",
+			method:      http.MethodPatch,
+			url:         "https://api.github.com/repos/cli/cli/issues/1",
+			wantBlocked: true,
+		},
+		{
+			name:        "REST PUT is blocked",
+			method:      http.MethodPut,
+			url:         "https://api.github.com/repos/cli/cli/issues/1/lock",
+			wantBlocked: true,
+		},
+		{
+			name:        "REST DELETE is blocked",
+			method:      http.MethodDelete,
+			url:         "https://api.github.com/repos/cli/cli/issues/1/lock",
+			wantBlocked: true,
+		},
+		{
+			name:   "GraphQL query is allowed",
+			method: http.MethodPost,
+			url:    "https://api.github.com/graphql",
+			body:   `{"query":"query { viewer { login } }"}`,
+		},
+		{
+			name:   "GraphQL anonymous query is allowed",
+			method: http.MethodPost,
+			url:    "https://api.github.com/graphql",
+			body:   `{"query":"{ viewer { login } }"}`,
+		},
+		{
+			name:        "GraphQL mutation is blocked",
+			method:      http.MethodPost,
+			url:         "https://api.github.com/graphql",
+			body:        `{"query":"mutation { addStar(input:{starrableId:\"x\"}) { clientMutationId } }"}`,
+			wantBlocked: true,
+		},
+		{
+			name:        "GraphQL named mutation is blocked",
+			method:      http.MethodPost,
+			url:         "https://api.github.com/graphql",
+			body:        `{"query":"mutation AddStar($id: ID!) { addStar(input:{starrableId:$id}) { clientMutationId } }"}`,
+			wantBlocked: true,
+		},
+		{
+			name:        "GraphQL mutation after a fragment is blocked",
+			method:      http.MethodPost,
+			url:         "https://api.github.com/graphql",
+			body:        `{"query":"fragment f on Repository { name } mutation { addStar(input:{starrableId:\"x\"}) { clientMutationId } }"}`,
+			wantBlocked: true,
+		},
+		{
+			name:   "GraphQL query named mutation is allowed",
+			method: http.MethodPost,
+			url:    "https://api.github.com/graphql",
+			body:   `{"query":"query mutation { viewer { login } }"}`,
+		},
+		{
+			name:   "GraphQL enterprise endpoint query is allowed",
+			method: http.MethodPost,
+			url:    "https://ghe.example.com/api/graphql",
+			body:   `{"query":"query { viewer { login } }"}`,
+		},
+		{
+			name:        "GraphQL enterprise endpoint mutation is blocked",
+			method:      http.MethodPost,
+			url:         "https://ghe.example.com/api/graphql",
+			body:        `{"query":"mutation { addStar(input:{starrableId:\"x\"}) { clientMutationId } }"}`,
+			wantBlocked: true,
+		},
+		{
+			name:        "unparseable GraphQL body fails closed",
+			method:      http.MethodPost,
+			url:         "https://api.github.com/graphql",
+			body:        `not json`,
+			wantBlocked: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := &recordingTripper{}
+			rt := ReadOnlyMiddleware(inner)
+			req := newRequest(t, tt.method, tt.url, tt.body)
+
+			res, err := rt.RoundTrip(req)
+
+			if tt.wantBlocked {
+				assert.ErrorIs(t, err, ErrReadOnly)
+				assert.False(t, inner.called, "blocked request must not reach the network")
+				return
+			}
+
+			require.NoError(t, err)
+			assert.True(t, inner.called, "allowed request must reach the network")
+			assert.Equal(t, http.StatusOK, res.StatusCode)
+			// The body must survive inspection so the real request can be sent.
+			if tt.body != "" {
+				assert.Equal(t, tt.body, inner.gotBody)
+			}
+		})
+	}
+}
+
+func TestNewHTTPClientReadOnly(t *testing.T) {
+	t.Setenv("GH_READ_ONLY", "1")
+	client, err := NewHTTPClient(HTTPClientOptions{})
+	require.NoError(t, err)
+
+	req := newRequest(t, http.MethodPost, "https://api.github.com/repos/cli/cli/issues", `{"title":"x"}`)
+	_, err = client.Transport.RoundTrip(req)
+	assert.ErrorIs(t, err, ErrReadOnly)
+}
+
+func TestNewHTTPClientReadOnlyDisabledByDefault(t *testing.T) {
+	t.Setenv("GH_READ_ONLY", "")
+	client, err := NewHTTPClient(HTTPClientOptions{})
+	require.NoError(t, err)
+
+	// With read-only off, the request should not be rejected by our middleware.
+	// It may still fail to reach the (nonexistent) server, but never with ErrReadOnly.
+	req := newRequest(t, http.MethodPost, "https://api.github.com/repos/cli/cli/issues", `{"title":"x"}`)
+	_, err = client.Transport.RoundTrip(req)
+	assert.False(t, errors.Is(err, ErrReadOnly))
+}
+
+func TestContainsTopLevelMutation(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{name: "anonymous query", query: `{ viewer { login } }`},
+		{name: "named query", query: `query Q { viewer { login } }`},
+		{name: "query keyword only", query: `query { viewer { login } }`},
+		{name: "subscription", query: `subscription { x }`},
+		{name: "field named mutation", query: `query { mutation { login } }`, want: false},
+		{name: "operation named mutation", query: `query mutation { viewer { login } }`, want: false},
+		{name: "mutation", query: `mutation { addStar }`, want: true},
+		{name: "named mutation", query: `mutation M { addStar }`, want: true},
+		{name: "fragment then mutation", query: `fragment f on R { name } mutation { addStar }`, want: true},
+		{name: "mutation in comment only", query: "# mutation\nquery { viewer { login } }", want: false},
+		{name: "mutation in string only", query: `query { search(query: "mutation") { x } }`, want: false},
+		{name: "block string contains mutation", query: `query { f(q: """mutation""") }`, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, containsTopLevelMutation(tt.query))
+		})
+	}
+}

--- a/git/client.go
+++ b/git/client.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cli/cli/v2/internal/ghenv"
 	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/safeexec"
 )
@@ -140,6 +141,9 @@ func CredentialPatternFromHost(host string) CredentialPattern {
 // AuthenticatedCommand is a wrapper around Command that included configuration to use gh
 // as the credential helper for git.
 func (c *Client) AuthenticatedCommand(ctx context.Context, credentialPattern CredentialPattern, args ...string) (*Command, error) {
+	if ghenv.ReadOnly() && len(args) > 0 && args[0] == "push" {
+		return nil, errors.New("gh is in read-only mode (GH_READ_ONLY): refusing to run 'git push'")
+	}
 	if c.GhPath == "" {
 		// Assumes that gh is in PATH.
 		c.GhPath = "gh"

--- a/git/client_test.go
+++ b/git/client_test.go
@@ -1783,6 +1783,40 @@ func TestClientPush(t *testing.T) {
 	}
 }
 
+func TestClientReadOnly(t *testing.T) {
+	t.Run("Push is blocked when GH_READ_ONLY is set", func(t *testing.T) {
+		t.Setenv("GH_READ_ONLY", "1")
+		client := Client{GitPath: "path/to/git"}
+		err := client.Push(context.Background(), "origin", "trunk")
+		require.ErrorContains(t, err, "read-only mode")
+	})
+
+	t.Run("raw push via AuthenticatedCommand is blocked", func(t *testing.T) {
+		t.Setenv("GH_READ_ONLY", "1")
+		client := Client{GitPath: "path/to/git"}
+		_, err := client.AuthenticatedCommand(context.Background(), AllMatchingCredentialsPattern, "push", "origin", "--mirror")
+		require.ErrorContains(t, err, "read-only mode")
+	})
+
+	t.Run("fetch is allowed when GH_READ_ONLY is set", func(t *testing.T) {
+		t.Setenv("GH_READ_ONLY", "1")
+		client := Client{GhPath: "path/to/gh", GitPath: "path/to/git"}
+		cmd, err := client.AuthenticatedCommand(context.Background(), AllMatchingCredentialsPattern, "fetch")
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+	})
+
+	t.Run("falsey GH_READ_ONLY does not block push", func(t *testing.T) {
+		t.Setenv("GH_READ_ONLY", "0")
+		cmdCtx := createMockedCommandContext(t, map[args]commandResult{
+			`path/to/git -c credential.helper= -c credential.helper=!"gh" auth git-credential push --set-upstream origin trunk`: {ExitStatus: 0},
+		})
+		client := Client{GitPath: "path/to/git", commandContext: cmdCtx}
+		err := client.Push(context.Background(), "origin", "trunk")
+		require.NoError(t, err)
+	})
+}
+
 func TestClientClone(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/ghenv/ghenv.go
+++ b/internal/ghenv/ghenv.go
@@ -1,0 +1,14 @@
+package ghenv
+
+import (
+	"os"
+	"slices"
+)
+
+func ReadOnly() bool {
+	value, ok := os.LookupEnv("GH_READ_ONLY")
+	if !ok {
+		return false
+	}
+	return !slices.Contains([]string{"false", "0", "no", ""}, value)
+}

--- a/internal/ghenv/ghenv_test.go
+++ b/internal/ghenv/ghenv_test.go
@@ -1,0 +1,26 @@
+package ghenv
+
+import "testing"
+
+func TestReadOnly(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{value: "1", want: true},
+		{value: "true", want: true},
+		{value: "yes", want: true},
+		{value: "", want: false},
+		{value: "0", want: false},
+		{value: "false", want: false},
+		{value: "no", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Setenv("GH_READ_ONLY", tt.value)
+			if got := ReadOnly(); got != tt.want {
+				t.Errorf("ReadOnly() with GH_READ_ONLY=%q = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -219,6 +219,10 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 				authentication token for API requests to GitHub Enterprise.
 
 				GH_HOST: make the request to a GitHub host other than %[1]sgithub.com%[1]s.
+
+				GH_READ_ONLY: set to a truthy value to block requests that would modify data on the
+				server. Read requests are allowed; REST writes and GraphQL mutations are rejected
+				before they are sent.
 			`, "`"),
 		},
 		Args: cobra.ExactArgs(1),

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -107,6 +107,11 @@ var HelpTopics = []helpTopic{
 
 			%[1]sGH_PROMPT_DISABLED%[1]s: set to any value to disable interactive prompting in the terminal.
 
+			%[1]sGH_READ_ONLY%[1]s: set to a truthy value to block any operation that would modify data on
+			the server. Requests that read data are allowed; REST writes and GraphQL mutations are
+			rejected before they are sent. This is useful when granting an automated agent broad
+			permission to inspect resources without the ability to change them.
+
 			%[1]sGH_PATH%[1]s: set the path to the gh executable, useful for when gh can not properly determine
 			its own path such as in the cygwin terminal.
 


### PR DESCRIPTION
## Read-only mode for `gh` via `GH_READ_ONLY` env var

*Context: I did this during a recent internal hackathon among the open source folks at [Posit](https://opensource.posit.co/), where I work. I've read the [contributing guidelines](https://github.com/cli/cli?tab=contributing-ov-file#readme) and realize this issue is neither marked as `help wanted`, nor does it have acceptance criteria yet! So I know this PR is unlikely to be merged. I share it as a working implementation of a safety feature related to discussion in #12522 and #12624. This was done with the help of Claude (I've never written Go), with strong human oversight.*

### What it does

Adds an opt-in read-only mode, enabled by setting the `GH_READ_ONLY` environment variable to something truthy. When set, `gh` can read and inspect GitHub resources, but cannot mutate anything on the server. This affects work via the REST and GraphQL APIs and any `git push` that `gh` performs (such as in `gh pr create`). Blocked operations fail before anything reaches GitHub, with a non-zero exit status. This would allow a conservative user to give broad permission for `gh *`, including the `gh api` raw passthrough, knowing that nothing will be modified on the server.

In terms of HTTP calls, you can't just block everything other than GET, since GitHub's GraphQL API uses POST for [every operation](https://docs.github.com/en/graphql/guides/forming-calls-with-graphql). Therefore the guard inspects the request body to distinguish a query (allowed) from a mutation (blocked).

### Test drive

`gh-with-readonly` is my local `gh` build from this branch.
By default, it works just like `gh`:

```
$ gh-with-readonly --version                                               
gh version 2.93.0-55-g44ed22017 (2026-06-08)
https://github.com/cli/cli/releases/latest

$ gh-with-readonly api user --jq .login
jennybc

$ gh-with-readonly pr list -R cli/cli -L 2

Showing 2 of 47 open pull requests in cli/cli

ID      TITLE                                                         BRANCH                                                 CREATED AT       
#13620  feat(discussion): add comment command                         babakks/add-discussion-comment                         about 5 hours ago
#13619  chore(deps): bump github/codeql-action from 4.36.1 to 4.36.2  dependabot/github_actions/github/codeql-action-4.36.2  about 8 hours ago
```

With `GH_READ_ONLY` set, you can still read via GraphQL. However, you can't change things on the server, e.g. you can't star a repo.

```
$ export GH_READ_ONLY=true  

$ gh-with-readonly pr list -R cli/cli -L 2

Showing 2 of 47 open pull requests in cli/cli

ID      TITLE                                   BRANCH                                  CREATED AT       
#13620  feat(discussion): add comment command   babakks/add-discussion-comment          about 6 hours ago
#13619  chore(deps): bump github/codeql-act...  dependabot/github_actions/github/co...  about 9 hours ago

$ gh-with-readonly api --method PUT "user/starred/jennybc/gh-readonly-demo"
Put "https://api.github.com/user/starred/jennybc/gh-readonly-demo": gh is in read-only mode (GH_READ_ONLY): this operation would modify data and was blocked
$ echo "exit=$?"
exit=1
```

Temporarily unset `GH_READ_ONLY`, so we can star a repo:

```
$ GH_READ_ONLY= gh-with-readonly api --method PUT "user/starred/jennybc/gh-readonly-demo"
```

Confirm the star exists and try (and fail) to delete it:

```
$ gh-with-readonly api "user/starred/jennybc/gh-readonly-demo" -i | head -1
HTTP/2.0 204 No Content

$ gh-with-readonly api --method DELETE "user/starred/jennybc/gh-readonly-demo"
Delete "https://api.github.com/user/starred/jennybc/gh-readonly-demo": gh is in read-only mode (GH_READ_ONLY): this operation would modify data and was blocked
```

### `gh` shim to intercept agents

How to make sure agents use `gh` in read-only mode?

Proof of concept: I place a `gh` shim that looks for the env vars set by agents (e.g. `AGENT`, `CLAUDECODE`, `GEMINI_CLI`, `CURSOR_AGENT`) and executes such calls with `GH_READ_ONLY` set. This is not part of the PR, it's just so I can exercise the feature with local agents.

```
agent_env_vars=(AGENT CLAUDECODE GEMINI_CLI CURSOR_AGENT)
for var in "${agent_env_vars[@]}"; do
  if [ -n "${!var}" ]; then
    GH_READ_ONLY=1 exec "$HOME/.local/bin/gh-with-readonly" "$@"
  fi
done
```

Otherwise, the shim falls back to stock `gh` (not shown).

When I direct Claude Code to do things like create an issue or label, it is unable to do so:

```
⏺ Bash(gh issue create -R jennybc/gh-readonly-demo -t "Shim test" -b "testing" ; echo "exit=$?")
Post "https://api.github.com/graphql": gh is in read-only mode (GH_READ_ONLY): this operation would modify data and was blocked
exit=1

⏺ Bash(gh label create shim-test -R jennybc/gh-readonly-demo -c FF0000 ; echo "exit=$?")
Post "https://api.github.com/repos/jennybc/gh-readonly-demo/labels": gh is in read-only mode (GH_READ_ONLY): this operation would modify data and was blocked
exit=1
```

### Notes

* An environment variable felt better than a flag, in the sense that it doesn't absolutely rely on a (cooperative) agent following instructions.
* Enforcement at client constructors (`api.NewHTTPClient` and `git.Client.AuthenticatedCommand`) seems like the most efficient way to get read-only behavior for all commands, given that the `gh` surface doesn't make it easy to distinguish reads from writes.
* This is meant for a cooperative agent and doesn't remove the need for a sandbox or a read-only token, depending on context.
* Only prevents remote mutations via `gh`. Local writes (e.g. `gh config set`) are unaffected, as is a `git push` outside of `gh`.
* Covered by unit tests in api, git, and internal/ghenv: REST writes blocked, GET/HEAD allowed, GraphQL query allowed / mutation blocked, push blocked, off by default.
