### PR TITLE
Make filtering by bot authors more discoverable

### DIFF
--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -74,6 +74,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		Example: heredoc.Doc(`
 			$ gh issue list --label "bug" --label "help wanted"
 			$ gh issue list --author monalisa
+			$ gh issue list --app dependabot
 			$ gh issue list --assignee "@me"
 			$ gh issue list --milestone "The big 1.0"
 			$ gh issue list --search "error no:assignee sort:created-asc"
@@ -110,7 +111,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Filter by label")
 	cmdutil.StringEnumFlag(cmd, &opts.State, "state", "s", "open", []string{"open", "closed", "all"}, "Filter by state")
 	cmd.Flags().IntVarP(&opts.LimitResults, "limit", "L", 30, "Maximum number of issues to fetch")
-	cmd.Flags().StringVarP(&opts.Author, "author", "A", "", "Filter by author")
+	cmd.Flags().StringVarP(&opts.Author, "author", "A", "", "Filter by author (use --app to filter by a GitHub App)")
 	cmd.Flags().StringVar(&appAuthor, "app", "", "Filter by GitHub App author")
 	cmd.Flags().StringVar(&opts.Mention, "mention", "", "Filter by mention")
 	cmd.Flags().StringVarP(&opts.Milestone, "milestone", "m", "", "Filter by milestone number or title")

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -72,6 +72,9 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 			# List PRs authored by you
 			$ gh pr list --author "@me"
 
+			# List PRs opened by a GitHub App such as Dependabot
+			$ gh pr list --app dependabot
+
 			# List PRs with a specific head branch name
 			$ gh pr list --head "typo"
 
@@ -115,7 +118,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 	cmd.Flags().StringVarP(&opts.BaseBranch, "base", "B", "", "Filter by base branch")
 	cmd.Flags().StringVarP(&opts.HeadBranch, "head", "H", "", `Filter by head branch ("<owner>:<branch>" syntax not supported)`)
 	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Filter by label")
-	cmd.Flags().StringVarP(&opts.Author, "author", "A", "", "Filter by author")
+	cmd.Flags().StringVarP(&opts.Author, "author", "A", "", "Filter by author (use --app to filter by a GitHub App)")
 	cmd.Flags().StringVar(&appAuthor, "app", "", "Filter by GitHub App author")
 	cmd.Flags().StringVarP(&opts.Assignee, "assignee", "a", "", "Filter by assignee")
 	cmd.Flags().StringVarP(&opts.Search, "search", "S", "", "Search pull requests with `query`")

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -147,7 +147,7 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 	cmd.Flags().StringVar(&appAuthor, "app", "", "Filter by GitHub App author")
 	cmdutil.NilBoolFlag(cmd, &opts.Query.Qualifiers.Archived, "archived", "", "Filter based on the repository archived state {true|false}")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Assignee, "assignee", "", "Filter by assignee")
-	cmd.Flags().StringVar(&opts.Query.Qualifiers.Author, "author", "", "Filter by author")
+	cmd.Flags().StringVar(&opts.Query.Qualifiers.Author, "author", "", "Filter by author (use --app to filter by a GitHub App)")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Closed, "closed", "", "Filter on closed at `date`")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Commenter, "commenter", "", "Filter based on comments by `user`")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Comments, "comments", "", "Filter on `number` of comments")

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -158,7 +158,7 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 	cmd.Flags().StringVar(&appAuthor, "app", "", "Filter by GitHub App author")
 	cmdutil.NilBoolFlag(cmd, &opts.Query.Qualifiers.Archived, "archived", "", "Filter based on the repository archived state {true|false}")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Assignee, "assignee", "", "Filter by assignee")
-	cmd.Flags().StringVar(&opts.Query.Qualifiers.Author, "author", "", "Filter by author")
+	cmd.Flags().StringVar(&opts.Query.Qualifiers.Author, "author", "", "Filter by author (use --app to filter by a GitHub App)")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Closed, "closed", "", "Filter on closed at `date`")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Commenter, "commenter", "", "Filter based on comments by `user`")
 	cmd.Flags().StringVar(&opts.Query.Qualifiers.Comments, "comments", "", "Filter on `number` of comments")

--- a/skills/gh/SKILL.md
+++ b/skills/gh/SKILL.md
@@ -58,6 +58,9 @@ Pass `--repo OWNER/REPO` (`-R`) to override the resolved CWD repo.
   anything cross-repo or filtered by author/label.
 - `gh issue list --search "..."` and `gh pr list --search "..."` take the
   query as one quoted string (it is a flag value) and are scoped to one repo.
+- Bots author as GitHub Apps, so `--author dependabot` matches nothing. Use
+  `--app dependabot` (on `pr`/`issue list` and `search prs|issues`; expands
+  to `author:app/<slug>`) or `--author "dependabot[bot]"`.
 
 ## Issue types, sub-issues, and relationships
 

--- a/skills/gh/SKILL.md
+++ b/skills/gh/SKILL.md
@@ -48,12 +48,16 @@ Pass `--repo OWNER/REPO` (`-R`) to override the resolved CWD repo.
 
 - `gh search issues|prs|code|repos|commits|users` uses GitHub's search
   index and accepts the full search syntax (`is:open`, `author:`,
-  `label:`, `repo:owner/name`, `in:title`, ...). Pass the entire query as
-  one quoted string, the same way you would for `--search`:
-  `gh search issues "is:open author:foo repo:cli/cli"`. Prefer it for
+  `label:`, `repo:owner/name`, `in:title`, ...). Pass each qualifier as
+  its own bare token, not as one quoted string:
+  `gh search issues repo:cli/cli is:open author:monalisa` works, but
+  `gh search issues "repo:cli/cli is:open"` is read as a single phrase and
+  fails with `Invalid search query`. Quote only multi-word free text
+  (`gh search issues "broken feature"`). Most qualifiers also have a
+  dedicated flag (`--repo`, `--author`, `--label`, ...). Prefer search for
   anything cross-repo or filtered by author/label.
-- `gh issue list --search "..."` and `gh pr list --search "..."` accept
-  the same syntax but are scoped to one repo.
+- `gh issue list --search "..."` and `gh pr list --search "..."` take the
+  query as one quoted string (it is a flag value) and are scoped to one repo.
 
 ## Issue types, sub-issues, and relationships
 

--- a/skills/gh/SKILL.md
+++ b/skills/gh/SKILL.md
@@ -51,8 +51,8 @@ Pass `--repo OWNER/REPO` (`-R`) to override the resolved CWD repo.
   `label:`, `repo:owner/name`, `in:title`, ...). Pass each qualifier as
   its own bare token, not as one quoted string:
   `gh search issues repo:cli/cli is:open author:monalisa` works, but
-  `gh search issues "repo:cli/cli is:open"` is read as a single phrase and
-  fails with `Invalid search query`. Quote only multi-word free text
+  `gh search issues "repo:cli/cli is:open"` is treated as a single keyword (parsed as `repo:"cli/cli is:open"`)
+  and fails with `Invalid search query`. Quote only multi-word free text
   (`gh search issues "broken feature"`). Most qualifiers also have a
   dedicated flag (`--repo`, `--author`, `--label`, ...). Prefer search for
   anything cross-repo or filtered by author/label.


### PR DESCRIPTION
### Description

Surface the existing `--app` flag (for example `gh pr list --app dependabot`) in `--author` help text and command examples, and add a short note to the `gh` agent skill, so filtering by a bot author is discoverable instead of silently returning nothing for `--author dependabot`.

### Key Points

- The `--app` flag already exists on `pr list`, `issue list`, `search prs`, and `search issues`, and expands to `author:app/<slug>`. Nothing pointed `--author` users to it, so `--author dependabot` quietly returns an empty list.
- `--author` help text now cross-references `--app`, and each command gains an `--app dependabot` example.
- While in the skill, I also corrected its search guidance. It told agents to pass a whole `gh search` query as one quoted string, which actually fails with `Invalid search query`. The working form is separate qualifier tokens or flags.

### Notes for reviewers

Three atomic commits:

- [`docs(pr, issue, search): surface --app flag for bot authors`](https://github.com/cli/cli/commit/3efd4d95b) changes help text and examples across the four commands.
- [`docs(skill): fix gh search query syntax guidance`](https://github.com/cli/cli/commit/4a31d5965) corrects the quoted-string advice in the [`gh` skill](https://github.com/cli/cli/blob/a74367d82/skills/gh/SKILL.md).
- [`docs(skill): note bot / GitHub App author filtering`](https://github.com/cli/cli/commit/a74367d82) adds one bullet on `--app` and the `[bot]` login form.

### Additional Context

- [#5888](https://github.com/cli/cli/issues/5888) is the original report that you could not filter by an app author. Good background on why `--app` exists.
- [#5180](https://github.com/cli/cli/pull/5180) is the PR that added the `--app` flag this change makes discoverable.