### PR TITLE
Use enqueuePullRequest when adding PRs to merge queue

### DIFF
--- a/pkg/cmd/pr/merge/http.go
+++ b/pkg/cmd/pr/merge/http.go
@@ -28,15 +28,21 @@ const (
 )
 
 type mergePayload struct {
-	repo            ghrepo.Interface
-	pullRequestID   string
-	method          PullRequestMergeMethod
-	auto            bool
-	commitSubject   string
-	commitBody      string
-	setCommitBody   bool
-	expectedHeadOid string
-	authorEmail     string
+	repo               ghrepo.Interface
+	pullRequestID      string
+	method             PullRequestMergeMethod
+	auto               bool
+	enqueueMergeQueue  bool
+	commitSubject      string
+	commitBody         string
+	setCommitBody      bool
+	expectedHeadOid    string
+	authorEmail        string
+}
+
+type EnqueuePullRequestInput struct {
+	PullRequestID   githubv4.ID           `json:"pullRequestId"`
+	ExpectedHeadOid *githubv4.GitObjectID `json:"expectedHeadOid,omitempty"`
 }
 
 // TODO: drop after githubv4 gets updated
@@ -84,6 +90,23 @@ func mergePullRequest(client *http.Client, payload mergePayload) error {
 	}
 
 	gql := api.NewClientFromHTTP(client)
+
+	if payload.enqueueMergeQueue {
+		enqueueInput := EnqueuePullRequestInput{
+			PullRequestID: githubv4.ID(payload.pullRequestID),
+		}
+		if payload.expectedHeadOid != "" {
+			expectedHeadOid := githubv4.GitObjectID(payload.expectedHeadOid)
+			enqueueInput.ExpectedHeadOid = &expectedHeadOid
+		}
+		var mutation struct {
+			EnqueuePullRequest struct {
+				ClientMutationId string
+			} `graphql:"enqueuePullRequest(input: $input)"`
+		}
+		variables["input"] = enqueueInput
+		return gql.Mutate(payload.repo.RepoHost(), "PullRequestEnqueue", &mutation, variables)
+	}
 
 	if payload.auto {
 		var mutation struct {

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -300,8 +300,9 @@ func (m *mergeContext) merge() error {
 			// only warn for now
 			_ = m.warnf("%s The merge strategy for %s is set by the merge queue\n", m.cs.Yellow("!"), m.pr.BaseRefName)
 		}
-		// auto merge will either enable auto merge or add to the merge queue
-		payload.auto = true
+		// merge queue uses enqueuePullRequest; enablePullRequestAutoMerge fails when
+		// allow_auto_merge is disabled on the repository (#13398).
+		payload.enqueueMergeQueue = true
 	} else {
 		// get user input if not already given
 		if m.opts.MergeStrategyEmpty {

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -1823,10 +1823,9 @@ func TestPrAddToMergeQueueWithMergeMethod(t *testing.T) {
 		baseRepo("OWNER", "REPO", "main"),
 	)
 	http.Register(
-		httpmock.GraphQL(`mutation PullRequestAutoMerge\b`),
+		httpmock.GraphQL(`mutation PullRequestEnqueue\b`),
 		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
-			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 		}),
 	)
 
@@ -1862,10 +1861,9 @@ func TestPrAddToMergeQueueClean(t *testing.T) {
 	)
 
 	http.Register(
-		httpmock.GraphQL(`mutation PullRequestAutoMerge\b`),
+		httpmock.GraphQL(`mutation PullRequestEnqueue\b`),
 		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
-			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 		}),
 	)
 
@@ -1902,10 +1900,9 @@ func TestPrAddToMergeQueueBlocked(t *testing.T) {
 	)
 
 	http.Register(
-		httpmock.GraphQL(`mutation PullRequestAutoMerge\b`),
+		httpmock.GraphQL(`mutation PullRequestEnqueue\b`),
 		httpmock.GraphQLMutation(`{}`, func(input map[string]interface{}) {
 			assert.Equal(t, "THE-ID", input["pullRequestId"].(string))
-			assert.Equal(t, "MERGE", input["mergeMethod"].(string))
 		}),
 	)
 


### PR DESCRIPTION
## Summary

Fixes #13398

When merge queue is enabled via ruleset but `allow_auto_merge` is disabled on the repository, `gh pr merge` fails because it routes merge queue requests through `enablePullRequestAutoMerge`.

Use the `enqueuePullRequest` mutation when adding a pull request to the merge queue instead.

## Test plan

- Updated merge queue tests to expect `PullRequestEnqueue`
- `go test ./pkg/cmd/pr/merge/... -run TestPrAddToMergeQueue`