### PR TITLE
fix: deduplicate checks in pr status to handle cancelled runs

### DIFF
--- a/api/pull_request_test.go
+++ b/api/pull_request_test.go
@@ -411,3 +411,49 @@ func statusContextNode(state string) string {
 		"state": "%s"
 	}`, state)
 }
+
+func TestChecksStatus_DuplicateCheckRunDeduplicatesByMostRecent(t *testing.T) {
+	t.Parallel()
+
+	// Reproduces issue #12895: concurrency cancel-in-progress produces both a
+	// cancelled run and a newer successful run for the same check. Before the
+	// fix, both were counted and the status showed as failing.
+	payload := fmt.Sprintf(`
+	{ "statusCheckRollup": { "nodes": [{ "commit": {
+		"statusCheckRollup": {
+			"contexts": {
+				"nodes": [
+					{
+						"__typename": "CheckRun",
+						"name": "CI",
+						"status": "COMPLETED",
+						"conclusion": "CANCELLED",
+						"startedAt": "2025-01-01T10:00:00Z",
+						"checkSuite": { "workflowRun": { "event": "push", "workflow": { "name": "test" } } }
+					},
+					{
+						"__typename": "CheckRun",
+						"name": "CI",
+						"status": "COMPLETED",
+						"conclusion": "SUCCESS",
+						"startedAt": "2025-01-01T11:00:00Z",
+						"checkSuite": { "workflowRun": { "event": "push", "workflow": { "name": "test" } } }
+					}
+				]
+			}
+		}
+	} }] } }
+	`)
+
+	var pr PullRequest
+	require.NoError(t, json.Unmarshal([]byte(payload), &pr))
+
+	// The older cancelled run is dropped; only the newer successful run counts.
+	expectedChecksStatus := PullRequestChecksStatus{
+		Passing: 1,
+		Failing: 0,
+		Pending: 0,
+		Total:   1,
+	}
+	require.Equal(t, expectedChecksStatus, pr.ChecksStatus())
+}

--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"time"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -366,8 +367,10 @@ func (pr *PullRequest) ChecksStatus() PullRequestChecksStatus {
 		return summary
 	}
 
-	// If we don't have the counts by state, then we'll need to summarise by looking at the more detailed contexts
-	for _, c := range contexts.Nodes {
+	// If we don't have the counts by state, then we'll need to summarise by looking at the more detailed
+	// contexts. Deduplicate first to avoid counting cancelled runs alongside their newer successful
+	// counterparts, which can happen with concurrency cancel-in-progress. See issue #12895.
+	for _, c := range eliminateDuplicateContexts(contexts.Nodes) {
 		// Nodes are a discriminated union of CheckRun or StatusContext and we can match on
 		// the TypeName to narrow the type.
 		if c.TypeName == "CheckRun" {
@@ -402,6 +405,36 @@ func (pr *PullRequest) ChecksStatus() PullRequestChecksStatus {
 	}
 
 	return summary
+}
+
+// eliminateDuplicateContexts filters a set of check contexts to only the most
+// recent when duplicate runs exist for the same check (e.g. cancelled runs
+// alongside newer successful ones from concurrency cancel-in-progress).
+// Mirrors pkg/cmd/pr/checks/aggregate.go eliminateDuplicates.
+func eliminateDuplicateContexts(contexts []CheckContext) []CheckContext {
+	sort.Slice(contexts, func(i, j int) bool { return contexts[i].StartedAt.After(contexts[j].StartedAt) })
+
+	mapChecks := make(map[string]struct{})
+	mapContexts := make(map[string]struct{})
+	unique := make([]CheckContext, 0, len(contexts))
+
+	for _, ctx := range contexts {
+		if ctx.Context != "" {
+			if _, exists := mapContexts[ctx.Context]; exists {
+				continue
+			}
+			mapContexts[ctx.Context] = struct{}{}
+		} else {
+			key := fmt.Sprintf("%s/%s/%s", ctx.Name, ctx.CheckSuite.WorkflowRun.Workflow.Name, ctx.CheckSuite.WorkflowRun.Event)
+			if _, exists := mapChecks[key]; exists {
+				continue
+			}
+			mapChecks[key] = struct{}{}
+		}
+		unique = append(unique, ctx)
+	}
+
+	return unique
 }
 
 type checkStatus int


### PR DESCRIPTION
## Summary

When a workflow uses concurrency with cancel-in-progress: true, the GraphQL status check rollup returns both the cancelled run and the newer successful run for the same check name. ChecksStatus() counted both, so gh pr status and gh pr view showed the PR as failing even when the latest run succeeded.

## Root cause

ChecksStatus() iterated contexts.Nodes without deduplication. Meanwhile gh pr checks already deduplicates via eliminateDuplicates in pkg/cmd/pr/checks/aggregate.go.

## Fix

Add eliminateDuplicateContexts to the api package (mirroring the proven logic from aggregate.go) and apply it before counting nodes. The deduplication is only applied to the detailed-nodes path, not the CountByState fast path.

Fixes #12895