### PR TITLE
Update build and release workflow to use Actions network firewall private preview

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   validate-tag-name:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     steps:
       - name: Validate tag name format
         env:
@@ -41,7 +41,7 @@ jobs:
           fi
   linux:
     needs: validate-tag-name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     environment: ${{ inputs.environment }}
     if: contains(inputs.platforms, 'linux')
     steps:
@@ -279,7 +279,7 @@ jobs:
             dist/*.msi
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     needs: [linux, macos, windows]
     environment: ${{ inputs.environment }}
     if: inputs.release

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-24.04-firewall, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-24.04-firewall, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
We're doing a private preview of the Actions network firewall that logs all outbound network activity and uploads it as an Actions workflow artifact to the job. See for example https://github.com/steiza/sigstore-go/actions/runs/27418947268 (scroll down to "Artifacts").

I added github.com/cli to the feature flag so that it can use the private preview. If there are any issues, simply revert the `runs-on:` back to `ubuntu-latest`.