### PR TITLE
fix(secret/set): strip trailing CR from env-file secrets on Windows

### DIFF
--- a/pkg/cmd/secret/set/set.go
+++ b/pkg/cmd/secret/set/set.go
@@ -397,7 +397,7 @@ func getSecretsFromOptions(opts *SetOptions) (map[string][]byte, error) {
 			return nil, fmt.Errorf("no secrets found in file")
 		}
 		for key, value := range envs {
-			secrets[key] = []byte(value)
+			secrets[key] = bytes.TrimRight([]byte(value), "\r")
 		}
 		return secrets, nil
 	}

--- a/pkg/cmd/secret/set/set_test.go
+++ b/pkg/cmd/secret/set/set_test.go
@@ -926,6 +926,19 @@ func Test_getSecretsFromOptions(t *testing.T) {
 				"QUOTED": "my value",
 			},
 		},
+		{
+			name: "secrets from file with CRLF line endings",
+			opts: SetOptions{
+				Body: "",
+				EnvFile: genFile("FOO=bar\r\nQUOTED=\"my value\"\r\n#IGNORED=true\r\nexport SHELL=bash\r\n"),
+			},
+			stdin: `FOO=bar`,
+			want: map[string]string{
+				"FOO":    "bar",
+				"SHELL":  "bash",
+				"QUOTED": "my value",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
CRLF line endings cause a trailing carriage return to be included in secret values parsed from --env-file on Windows. The stdin path already strips this with bytes.TrimRight in getBody, but the env-file path skips it.

This applies bytes.TrimRight to each secret value after godotenv.Parse, matching the existing pattern.

Fixes https://github.com/cli/cli/issues/13588