### PR TITLE
Bump Go in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/go:1.25",
+	"image": "mcr.microsoft.com/devcontainers/go:1.26",
 	"features": {
 		"ghcr.io/devcontainers/features/sshd:1": {}
 	},


### PR DESCRIPTION
When trying to contribute with a codespace, I noticed I couldn't build or test due to a mismatch in the Go version.