### PR TITLE
Fix flaky TestHuhPrompterMultiSelectWithSearchPersistence on slow architectures

### DIFF
--- a/internal/prompter/huh_prompter_test.go
+++ b/internal/prompter/huh_prompter_test.go
@@ -2,6 +2,7 @@ package prompter
 
 import (
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,8 +19,9 @@ import (
 // bubbletea event loop.
 
 type interactionStep struct {
-	bytes []byte
-	delay time.Duration // pause before sending (lets the event loop settle)
+	bytes  []byte
+	delay  time.Duration // pause before sending (lets the event loop settle)
+	waitFn func()        // if non-nil, called instead of time.Sleep(delay)
 }
 
 type interaction struct {
@@ -33,9 +35,15 @@ func newInteraction(steps ...interactionStep) interaction {
 func (ix interaction) run(t *testing.T, w *io.PipeWriter) {
 	t.Helper()
 	for _, s := range ix.steps {
-		time.Sleep(s.delay)
-		_, err := w.Write(s.bytes)
-		require.NoError(t, err)
+		if s.waitFn != nil {
+			s.waitFn()
+		} else {
+			time.Sleep(s.delay)
+		}
+		if s.bytes != nil {
+			_, err := w.Write(s.bytes)
+			require.NoError(t, err)
+		}
 	}
 }
 
@@ -98,9 +106,43 @@ func clearLine() interactionStep {
 	return interactionStep{bytes: []byte{0x01, 0x0b}}
 }
 
-// waitForOptions adds extra delay to let OptionsFunc load before continuing.
+// waitForOptions adds extra delay to let the bubbletea event loop settle
+// after switching modes when no async search is triggered.
 func waitForOptions() interactionStep {
 	return interactionStep{bytes: nil, delay: 50 * time.Millisecond}
+}
+
+// waitForSearch returns an interactionStep that blocks until the field's
+// current async search completes. It wires a one-shot callback into the
+// field's onSearchDone hook and waits for it to fire, avoiding fixed-duration
+// sleeps that are too short on slow architectures such as s390x under QEMU.
+//
+// The wait is bounded by the test's deadline (from -timeout) so a hung search
+// fails the test with a clear message rather than blocking the whole test run.
+func waitForSearch(t *testing.T, field *multiSelectSearchField) interactionStep {
+	t.Helper()
+	done := make(chan struct{})
+	var once sync.Once
+	field.onSearchDone.Store(func() {
+		once.Do(func() { close(done) })
+	})
+
+	var timeout <-chan time.Time
+	if deadline, ok := t.Deadline(); ok {
+		timeout = time.After(time.Until(deadline))
+	} else {
+		timeout = time.After(30 * time.Second)
+	}
+
+	return interactionStep{
+		waitFn: func() {
+			select {
+			case <-done:
+			case <-timeout:
+				t.Fatal("timed out waiting for async search to complete")
+			}
+		},
+	}
 }
 
 // --- Test harness ---
@@ -475,13 +517,16 @@ func TestHuhPrompterMultiSelectWithSearchPersistence(t *testing.T) {
 		f, result := p.buildMultiSelectWithSearchForm(
 			"Select", "Search", nil, nil, staticSearchFunc,
 		)
+		// waitForSearch must be created before runForm so the hook is in place
+		// before the async search fires.
+		searchDone := waitForSearch(t, result)
 		runForm(t, f, newInteraction(
-			tab(), waitForOptions(),
-			toggle(),        // toggle result-a
-			shiftTab(),      // back to search input
-			typeKeys("foo"), // change query
-			tab(), waitForOptions(),
-			enter(), // submit — result-a should persist
+			tab(), waitForOptions(), // switch to select mode (no async search)
+			toggle(),          // toggle result-a
+			shiftTab(),        // back to search input
+			typeKeys("foo"),   // change query
+			tab(), searchDone, // submit query → async search; wait for completion
+			enter(), // submit form — guaranteed search is done
 		))
 		assert.Equal(t, []string{"result-a"}, result.selectedKeys())
 	})

--- a/internal/prompter/multi_select_with_search.go
+++ b/internal/prompter/multi_select_with_search.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync/atomic"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
@@ -47,6 +48,13 @@ type multiSelectSearchField struct {
 	theme     huh.Theme
 	hasDarkBg bool
 	position  huh.FieldPosition
+
+	// onSearchDone stores a func() that is called each time an async search
+	// completes. It is unset in production and used only in tests to
+	// synchronize on search completion without relying on fixed-duration
+	// sleeps. atomic.Value is used because the hook is written by the test
+	// goroutine and invoked by bubbletea's event-loop goroutine.
+	onSearchDone atomic.Value
 }
 
 type msMode int
@@ -170,6 +178,10 @@ func (m *multiSelectSearchField) applySearchResult(query string, result MultiSel
 	m.options = options
 	m.cursor = 0
 	m.err = nil
+
+	if hook, ok := m.onSearchDone.Load().(func()); ok {
+		hook()
+	}
 }
 
 func (m *multiSelectSearchField) selectedKeys() []string {


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/13727

The test was using a fixed 50ms sleep (`waitForOptions()`) to wait for an async bubbletea search goroutine before sending the next keystroke. On slow architectures such as s390x under QEMU emulation, the goroutine scheduling and event loop round-trip can exceed 50ms, causing the `enter` key to arrive while `m.loading` is still `true`. In that state the field silently drops all keystrokes, the form never advances, and the 5s overall deadline fires with "form.Run() did not complete in time".

The fix replaces the blind sleep with proper channel-based synchronization. An `onSearchDone func()` hook is added to `multiSelectSearchField` (nil in production, set only in tests) and called at the end of `applySearchResult`. A new test helper `waitForSearch(field)` wires a one-shot `sync.Once`-guarded channel into that hook and blocks until it fires - guaranteeing the search is truly complete before the next step is sent, regardless of scheduler timing or machine speed.

## Error log
```
[  770s] --- FAIL: TestHuhPrompterMultiSelectWithSearchPersistence (5.42s)
[  770s]     --- FAIL: TestHuhPrompterMultiSelectWithSearchPersistence/selections_persist_after_changing_search_query (5.31s)                                                                                                      Context
[  770s]         huh_prompter_test.go:478: form.Run() did not complete in time                                                                                                                                                     54,494 tokens
[  770s] FAIL                                                                                                                                                                                                                      5% used
[  770s] FAIL  github.com/cli/cli/v2/internal/prompter  11.841s
```