### PR TITLE
docs: fix duplicated word in primer README

### DIFF
--- a/docs/primer/README.md
+++ b/docs/primer/README.md
@@ -4,7 +4,7 @@ These guidelines are a collection of principles, foundations and usage guideline
 
 ## [Components](components)
 
-Design guidance on how we format content in in the Terminal through text formatting, color and font weights.
+Design guidance on how we format content in the Terminal through text formatting, color and font weights.
 
 ## [Foundations](foundations)
 


### PR DESCRIPTION
The design primer index read "how we format content in in the Terminal" — removed the duplicated "in".
