### PR TITLE
fix: show checks summary when all checks were cancelled

### DIFF
--- a/pkg/cmd/pr/checks/output.go
+++ b/pkg/cmd/pr/checks/output.go
@@ -68,7 +68,7 @@ func addRow(tp *tableprinter.TablePrinter, io *iostreams.IOStreams, o check) {
 
 func printSummary(io *iostreams.IOStreams, counts checkCounts) {
 	summary := ""
-	if counts.Failed+counts.Passed+counts.Skipping+counts.Pending > 0 {
+	if counts.Failed+counts.Passed+counts.Skipping+counts.Pending+counts.Canceled > 0 {
 		if counts.Failed > 0 {
 			summary = "Some checks were not successful"
 		} else if counts.Pending > 0 {

--- a/pkg/cmd/pr/checks/output_test.go
+++ b/pkg/cmd/pr/checks/output_test.go
@@ -1,0 +1,56 @@
+package checks
+
+import (
+	"testing"
+
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintSummary(t *testing.T) {
+	tests := []struct {
+		name   string
+		counts checkCounts
+		want   string
+	}{
+		{
+			name:   "no checks",
+			counts: checkCounts{},
+			want:   "\n\n",
+		},
+		{
+			name:   "only cancelled checks",
+			counts: checkCounts{Canceled: 2},
+			want:   "Some checks were cancelled\n2 cancelled, 0 failing, 0 successful, 0 skipped, and 0 pending checks\n\n",
+		},
+		{
+			name:   "cancelled and passing checks",
+			counts: checkCounts{Canceled: 1, Passed: 2},
+			want:   "Some checks were cancelled\n1 cancelled, 0 failing, 2 successful, 0 skipped, and 0 pending checks\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, stdout, _ := iostreams.Test()
+			ios.SetStdoutTTY(true)
+
+			printSummary(ios, tt.counts)
+
+			require.Equal(t, tt.want, stdout.String())
+		})
+	}
+
+	// Regression guard: a check set containing only cancelled checks must still
+	// produce a summary. Before the fix, the guard in printSummary omitted
+	// counts.Canceled, so a cancelled-only result printed an empty summary.
+	t.Run("cancelled-only is not silently empty", func(t *testing.T) {
+		ios, _, stdout, _ := iostreams.Test()
+		ios.SetStdoutTTY(true)
+
+		printSummary(ios, checkCounts{Canceled: 1})
+
+		assert.Contains(t, stdout.String(), "Some checks were cancelled")
+	})
+}

--- a/pkg/cmd/pr/checks/output_test.go
+++ b/pkg/cmd/pr/checks/output_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/cli/cli/v2/pkg/iostreams"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,14 +19,26 @@ func TestPrintSummary(t *testing.T) {
 			want:   "\n\n",
 		},
 		{
-			name:   "only cancelled checks",
-			counts: checkCounts{Canceled: 2},
-			want:   "Some checks were cancelled\n2 cancelled, 0 failing, 0 successful, 0 skipped, and 0 pending checks\n\n",
+			name:   "all successful",
+			counts: checkCounts{Passed: 3},
+			want:   "All checks were successful\n0 cancelled, 0 failing, 3 successful, 0 skipped, and 0 pending checks\n\n",
 		},
 		{
-			name:   "cancelled and passing checks",
-			counts: checkCounts{Canceled: 1, Passed: 2},
-			want:   "Some checks were cancelled\n1 cancelled, 0 failing, 2 successful, 0 skipped, and 0 pending checks\n\n",
+			name:   "some failed",
+			counts: checkCounts{Failed: 1, Passed: 2},
+			want:   "Some checks were not successful\n0 cancelled, 1 failing, 2 successful, 0 skipped, and 0 pending checks\n\n",
+		},
+		{
+			name:   "some pending",
+			counts: checkCounts{Pending: 1, Passed: 2},
+			want:   "Some checks are still pending\n0 cancelled, 0 failing, 2 successful, 0 skipped, and 1 pending checks\n\n",
+		},
+		{
+			// Regression: before the fix, the guard omitted counts.Canceled, so a
+			// cancelled-only result printed an empty summary.
+			name:   "only cancelled",
+			counts: checkCounts{Canceled: 2},
+			want:   "Some checks were cancelled\n2 cancelled, 0 failing, 0 successful, 0 skipped, and 0 pending checks\n\n",
 		},
 	}
 
@@ -41,16 +52,4 @@ func TestPrintSummary(t *testing.T) {
 			require.Equal(t, tt.want, stdout.String())
 		})
 	}
-
-	// Regression guard: a check set containing only cancelled checks must still
-	// produce a summary. Before the fix, the guard in printSummary omitted
-	// counts.Canceled, so a cancelled-only result printed an empty summary.
-	t.Run("cancelled-only is not silently empty", func(t *testing.T) {
-		ios, _, stdout, _ := iostreams.Test()
-		ios.SetStdoutTTY(true)
-
-		printSummary(ios, checkCounts{Canceled: 1})
-
-		assert.Contains(t, stdout.String(), "Some checks were cancelled")
-	})
 }


### PR DESCRIPTION
### Description

`gh pr checks` prints a blank summary when a PR's only checks were **cancelled**.

`printSummary` (`pkg/cmd/pr/checks/output.go`) gates the summary block on:

```go
if counts.Failed+counts.Passed+counts.Skipping+counts.Pending > 0 {
```

`counts.Canceled` is omitted, so a cancelled-only result sums to 0, the block is skipped, and the `else if counts.Canceled > 0 { "Some checks were cancelled" }` branch becomes unreachable in exactly the case it was written for. The existing "some cancelled" test masked this by pairing a cancelled check with passing ones.

### Fix

Add `counts.Canceled` to the guard.

### Testing

Added `TestPrintSummary` (`output_test.go`) with a cancelled-only case asserting the "Some checks were cancelled" summary renders. Fails before, passes after; `go test ./pkg/cmd/pr/checks/` green.

Reported in #13680.