### PR TITLE
fix(skills): install universal agent to ~/.agents/skills

### DIFF
--- a/internal/skills/registry/registry.go
+++ b/internal/skills/registry/registry.go
@@ -299,7 +299,7 @@ var Agents = []AgentHost{
 		ID:         "universal",
 		Name:       "Universal",
 		ProjectDir: sharedProjectSkillsDir,
-		UserDir:    ".config/agents/skills",
+		UserDir:    sharedProjectSkillsDir,
 	},
 	{
 		ID:         "warp",

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -126,6 +126,25 @@ func TestInstallDir(t *testing.T) {
 			wantDir: filepath.Join("/tmp/monalisa-repo", ".agents", "skills"),
 		},
 		{
+			// Issue #13494: Universal must use the shared .agents/skills dir
+			// at user scope so compliant clients (Copilot, Pi, OpenCode) pick up
+			// skills per the agentskills.io cross-client convention.
+			name:    "universal project scope",
+			hostID:  "universal",
+			scope:   ScopeProject,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/tmp/monalisa-repo", ".agents", "skills"),
+		},
+		{
+			name:    "universal user scope",
+			hostID:  "universal",
+			scope:   ScopeUser,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/home/monalisa", ".agents", "skills"),
+		},
+		{
 			name:    "project scope without git root",
 			hostID:  "github-copilot",
 			scope:   ScopeProject,


### PR DESCRIPTION
The Universal agent host installed user-scoped skills to ~/.config/agents/skills, which is not the location scanned by the majority of compliant clients (Copilot CLI, Pi, OpenCode).

Per the agentskills.io cross-client convention (https://agentskills.io/client-implementation/adding-skills-support), user-level skills for compliant clients live under ~/.agents/skills.

This PR switches UserDir for the universal agent to the shared project skills directory constant, matching the convention already used by Warp and Cline. Adds regression tests covering both project and user scope.

Fixes #13494