### PR TITLE
Fix cancelled-only PR checks summary

### DIFF
--- a/pkg/cmd/pr/checks/checks_test.go
+++ b/pkg/cmd/pr/checks/checks_test.go
@@ -205,6 +205,35 @@ func Test_checksRun(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name: "only cancelled tty",
+			tty:  true,
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query PullRequestStatusChecks\b`),
+					httpmock.FileResponse("./fixtures/onlyCancelled.json"),
+				)
+			},
+			wantOut: heredoc.Doc(`
+				Some checks were cancelled
+				1 cancelled, 0 failing, 0 successful, 0 skipped, and 0 pending checks
+
+				   NAME       DESCRIPTION  ELAPSED  URL
+				-  sad tests               1m26s    sweet link
+			`),
+			wantErr: "",
+		},
+		{
+			name: "only cancelled",
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query PullRequestStatusChecks\b`),
+					httpmock.FileResponse("./fixtures/onlyCancelled.json"),
+				)
+			},
+			wantOut: "sad tests\tfail\t1m26s\tsweet link\t\n",
+			wantErr: "",
+		},
+		{
 			name: "some pending tty",
 			tty:  true,
 			httpStubs: func(reg *httpmock.Registry) {

--- a/pkg/cmd/pr/checks/fixtures/onlyCancelled.json
+++ b/pkg/cmd/pr/checks/fixtures/onlyCancelled.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "node": {
+      "statusCheckRollup": {
+        "nodes": [
+          {
+            "commit": {
+              "oid": "abc",
+              "statusCheckRollup": {
+                "contexts": {
+                  "nodes": [
+                    {
+                      "conclusion": "CANCELLED",
+                      "status": "COMPLETED",
+                      "name": "sad tests",
+                      "completedAt": "2020-08-27T19:00:12Z",
+                      "startedAt": "2020-08-27T18:58:46Z",
+                      "detailsUrl": "sweet link"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/pkg/cmd/pr/checks/output.go
+++ b/pkg/cmd/pr/checks/output.go
@@ -68,7 +68,7 @@ func addRow(tp *tableprinter.TablePrinter, io *iostreams.IOStreams, o check) {
 
 func printSummary(io *iostreams.IOStreams, counts checkCounts) {
 	summary := ""
-	if counts.Failed+counts.Passed+counts.Skipping+counts.Pending > 0 {
+	if counts.Failed+counts.Passed+counts.Skipping+counts.Pending+counts.Canceled > 0 {
 		if counts.Failed > 0 {
 			summary = "Some checks were not successful"
 		} else if counts.Pending > 0 {


### PR DESCRIPTION
## Summary

Fixes a bug where `gh pr checks` prints a blank summary when all check runs are cancelled.

The summary guard did not include `counts.Canceled`, causing the cancelled-only case to skip the summary output entirely.

## Changes

* Include `counts.Canceled` in the summary guard condition.
* Add a regression test for cancelled-only check runs.
* Add fixture data for the cancelled-only scenario.

## Testing

```bash
go test ./pkg/cmd/pr/checks/...
```
Fixes #13680
