### PR TITLE
docs: fix broken anchor link in release-process-deep-dive

### DIFF
--- a/docs/release-process-deep-dive.md
+++ b/docs/release-process-deep-dive.md
@@ -579,7 +579,7 @@ A git commit is created in the `cli.github.com` site repository containing the c
 
 ### Site Package Repositories
 
-The `cli.github.com` website hosts RPM and Debian package repositories to support the [official sources installation instructions](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#official-sources). In order to provide a secure installation method, artifacts in these repositories are signed by a GPG key, which must be loaded into `gpg` for use in later steps. Comments have been added to provide clarity to the script:
+The `cli.github.com` website hosts RPM and Debian package repositories to support the [official sources installation instructions](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#recommended-official). In order to provide a secure installation method, artifacts in these repositories are signed by a GPG key, which must be loaded into `gpg` for use in later steps. Comments have been added to provide clarity to the script:
 
 ```sh
 # Import the public and private keys into gpg non-interactively


### PR DESCRIPTION
In `docs/release-process-deep-dive.md`, the "Site Package Repositories" section links to the official sources installation instructions using `docs/install_linux.md#official-sources`. That anchor is dead: the install doc refactor in 60af6bcb (Aug 2025) renamed the heading, so `install_linux.md` no longer has an "Official sources" heading.

The current heading is `## Recommended _(Official)_`, whose anchor is `#recommended-official`. This points the link at that heading so it resolves again.

Single line change, docs only.
