### PR TITLE
docs: add search qualifier examples

### DIFF
--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -59,6 +59,9 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 			# Search issues with numerous comments
 			$ gh search issues --comments=">100"
 
+			# Search closed issues in the cli organization that mention OAuth
+			$ gh search issues "OAuth" --owner=cli --state=closed
+
 			# Search issues without label "bug"
 			$ gh search issues -- -label:bug
 

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -61,6 +61,9 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 			# Search pull requests with numerous reactions
 			$ gh search prs --reactions=">100"
 
+			# Search merged pull requests in cli repository that mention release notes
+			$ gh search prs "release notes" --repo=cli/cli --merged
+
 			# Search pull requests without label "bug"
 			$ gh search prs -- -label:bug
 


### PR DESCRIPTION
Fixes #13678

Adds examples to `gh search issues` and `gh search prs` showing how a keyword search can be combined with qualifier flags.

Verification:
- `go test ./pkg/cmd/search/issues -count=1`
- `go test ./pkg/cmd/search/prs -count=1`
- `git diff --check`
