### PR TITLE
docs: clarify --clone boolean flag

### DIFF
--- a/docs/primer/foundations/README.md
+++ b/docs/primer/foundations/README.md
@@ -33,7 +33,8 @@ We generally follow this structure:
   - File names
 - The possible flag values depend on the flag:
   - `--state` takes `{closed | open | merged}`
-  - `--clone` is a boolean flag
+  - `--clone` is a boolean flag.
+  - Use `--clone`, `--clone=true`, or `--clone=false` to make the choice explicit.
   - `--title` takes a string
   - `--limit` takes an integer
 


### PR DESCRIPTION
## Summary
Clarify `--clone` as a boolean flag in the Primer foundations docs, and show `--clone=false` explicitly.

Fixes #5925

## Validation
- Reviewed the issue discussion
- Updated `docs/primer/foundations/README.md`
- Ran `git diff --check`