### PR TITLE
Add --json and --jq flags to gh pr create

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -74,6 +74,8 @@ type CreateOptions struct {
 	Template            string
 
 	DryRun bool
+
+	Exporter cmdutil.Exporter
 }
 
 // creationRefs is an interface that provides the necessary information for creating a pull request in the API.
@@ -331,6 +333,10 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("`--dry-run` is not supported when using `--web`")
 			}
 
+			if opts.Exporter.IsFormat() && opts.WebMode {
+				return cmdutil.FlagErrorf("`--json` is not supported when using `--web`")
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -359,6 +365,9 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	fl.StringVar(&opts.RecoverFile, "recover", "", "Recover input from a failed run of create")
 	fl.StringVarP(&opts.Template, "template", "T", "", "Template `file` to use as starting body text")
 	fl.BoolVar(&opts.DryRun, "dry-run", false, "Print details instead of creating the PR. May still push git changes.")
+
+	// Add --json and --jq flags for structured output
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.PullRequestFields)
 
 	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "base", "head")
 
@@ -1066,6 +1075,9 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 	pr, err := api.CreatePullRequest(client, ctx.PRRefs.BaseRepo(), params)
 	opts.IO.StopProgressIndicator()
 	if pr != nil {
+		if opts.Exporter.IsFormat() {
+			return opts.Exporter.Write(opts.IO, pr)
+		}
 		fmt.Fprintln(opts.IO.Out, pr.URL)
 	}
 	if err != nil {


### PR DESCRIPTION
Fixes #11247

## Problem

`gh pr create` does not support `--json` and `--jq` flags, unlike most other `gh` commands (`gh pr view`, `gh pr list`, `gh issue create`, etc.). Users must parse the URL output to extract the PR number:

```bash
PR_URL=$(gh pr create --title "Fix" --body "Desc" | tail -n1)
PR_NUMBER=$(basename "$PR_URL")
```

## What changed

- Added `Exporter cmdutil.Exporter` field to `CreateOptions`
- Registered `--json` and `--jq` flags via `cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.PullRequestFields)`
- After successful PR creation, if `--json` is specified, the PR data is exported as JSON instead of printing the URL
- Added validation: `--json` is not supported with `--web` mode

## Usage

```bash
# Get PR number directly
PR_NUMBER=$(gh pr create --title "Fix" --body "Desc" --json number --jq '.number')

# Get full PR data as JSON
gh pr create --title "Fix" --body "Desc" --json number,url,title,createdAt
```

## Validation

- `go build ./pkg/cmd/pr/create/` — compiles
- Follows the same pattern as `gh pr view` (`pkg/cmd/pr/view/view.go:79`)
- `api.PullRequestFields` already defines all exportable fields