### PR TITLE
Terminate ssh/scp options with "--" separator

### DIFF
--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -71,10 +71,8 @@ func newSSHCommand(ctx context.Context, port int, dst string, cmdArgs []string, 
 
 	cmdArgs = append(cmdArgs, connArgs...)
 	cmdArgs = append(cmdArgs, "-C") // Compression
-	// End of ssh options. Ensures the destination is treated as a positional
-	// argument and never parsed as an option.
-	cmdArgs = append(cmdArgs, "--")
-	cmdArgs = append(cmdArgs, dst) // user@host
+	cmdArgs = append(cmdArgs, "--") // end of ssh options
+	cmdArgs = append(cmdArgs, dst)  // user@host
 
 	if command != nil {
 		cmdArgs = append(cmdArgs, command...)
@@ -121,9 +119,7 @@ func newSCPCommand(ctx context.Context, port int, dst string, cmdArgs []string) 
 	}
 
 	cmdArgs = append(cmdArgs, connArgs...)
-	// End of scp options. Ensures the following file arguments are treated as
-	// positional and never parsed as options.
-	cmdArgs = append(cmdArgs, "--")
+	cmdArgs = append(cmdArgs, "--") // end of scp options
 
 	for _, arg := range command {
 		// Replace "remote:" prefix with (e.g.) "root@localhost:".

--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -151,10 +151,17 @@ func parseSCPArgs(args []string) (cmdArgs, command []string, err error) {
 
 // parseArgs parses arguments into two distinct slices of flags and command. Parsing stops
 // as soon as a non-flag argument is found assuming the remaining arguments are the command.
-// It returns an error if a unary flag is provided without an argument.
+// A bare "--" is treated as the end-of-options marker: it is dropped and everything after it
+// is returned as the command. It returns an error if a unary flag is provided without an argument.
 func parseArgs(args []string, unaryFlags string) (cmdArgs, command []string, err error) {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+
+		// "--" marks the end of options; everything after it is the command.
+		if arg == "--" {
+			command = args[i+1:]
+			break
+		}
 
 		// if we've started parsing the command, set it to the rest of the args
 		if !strings.HasPrefix(arg, "-") {

--- a/internal/codespaces/ssh.go
+++ b/internal/codespaces/ssh.go
@@ -71,7 +71,10 @@ func newSSHCommand(ctx context.Context, port int, dst string, cmdArgs []string, 
 
 	cmdArgs = append(cmdArgs, connArgs...)
 	cmdArgs = append(cmdArgs, "-C") // Compression
-	cmdArgs = append(cmdArgs, dst)  // user@host
+	// End of ssh options. Ensures the destination is treated as a positional
+	// argument and never parsed as an option.
+	cmdArgs = append(cmdArgs, "--")
+	cmdArgs = append(cmdArgs, dst) // user@host
 
 	if command != nil {
 		cmdArgs = append(cmdArgs, command...)
@@ -118,6 +121,9 @@ func newSCPCommand(ctx context.Context, port int, dst string, cmdArgs []string) 
 	}
 
 	cmdArgs = append(cmdArgs, connArgs...)
+	// End of scp options. Ensures the following file arguments are treated as
+	// positional and never parsed as options.
+	cmdArgs = append(cmdArgs, "--")
 
 	for _, arg := range command {
 		// Replace "remote:" prefix with (e.g.) "root@localhost:".

--- a/internal/codespaces/ssh_test.go
+++ b/internal/codespaces/ssh_test.go
@@ -3,7 +3,11 @@ package codespaces
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -154,10 +158,11 @@ func checkParseResult(t *testing.T, tcase parseTestCase, gotArgs, gotCmd []strin
 	}
 }
 
-// TestNewSSHCommandUsesEndOfOptionsSeparator verifies that the ssh argv
-// includes the "--" end-of-options separator immediately before the
-// destination, so the destination is always parsed as a positional argument.
+// TestNewSSHCommandUsesEndOfOptionsSeparator asserts that "--" is placed
+// immediately before the destination in the ssh argv.
 func TestNewSSHCommandUsesEndOfOptionsSeparator(t *testing.T) {
+	stubExecutablesOnPath(t, "ssh")
+
 	cmd, _, err := newSSHCommand(context.Background(), 1234, "user@localhost", []string{"-v"}, []string{"echo", "hello"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -181,10 +186,11 @@ func TestNewSSHCommandUsesEndOfOptionsSeparator(t *testing.T) {
 	}
 }
 
-// TestNewSCPCommandUsesEndOfOptionsSeparator verifies that the scp argv
-// includes the "--" end-of-options separator before the file arguments,
-// so file paths are always parsed as positional arguments.
+// TestNewSCPCommandUsesEndOfOptionsSeparator asserts that "--" precedes
+// the file arguments in the scp argv.
 func TestNewSCPCommandUsesEndOfOptionsSeparator(t *testing.T) {
+	stubExecutablesOnPath(t, "scp")
+
 	cmd, err := newSCPCommand(context.Background(), 1234, "user@localhost", []string{"local/file", "remote:file"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -205,4 +211,28 @@ func TestNewSCPCommandUsesEndOfOptionsSeparator(t *testing.T) {
 	if dashDashIdx > localIdx {
 		t.Errorf("expected \"--\" to precede file arguments, got args: %v", args)
 	}
+}
+
+// stubExecutablesOnPath creates empty executable files for names in a temp
+// dir and prepends it to PATH for the test, so safeexec.LookPath resolves
+// without requiring the real binaries on the host.
+func stubExecutablesOnPath(t *testing.T, names ...string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	for _, name := range names {
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		path := filepath.Join(dir, name)
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0755)
+		if err != nil {
+			t.Fatalf("failed to create stub %s: %v", name, err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("failed to close stub %s: %v", name, err)
+		}
+	}
+
+	t.Setenv("PATH", strings.Join([]string{dir, os.Getenv("PATH")}, string(os.PathListSeparator)))
 }

--- a/internal/codespaces/ssh_test.go
+++ b/internal/codespaces/ssh_test.go
@@ -208,8 +208,8 @@ func TestNewSCPCommandUsesEndOfOptionsSeparator(t *testing.T) {
 		t.Fatalf("expected file arg in scp args, got: %v", args)
 	}
 
-	if dashDashIdx > localIdx {
-		t.Errorf("expected \"--\" to precede file arguments, got args: %v", args)
+	if dashDashIdx+1 != localIdx {
+		t.Errorf("expected \"--\" to immediately precede file arguments, got args: %v", args)
 	}
 }
 

--- a/internal/codespaces/ssh_test.go
+++ b/internal/codespaces/ssh_test.go
@@ -1,7 +1,9 @@
 package codespaces
 
 import (
+	"context"
 	"fmt"
+	"slices"
 	"testing"
 )
 
@@ -149,5 +151,58 @@ func checkParseResult(t *testing.T, tcase parseTestCase, gotArgs, gotCmd []strin
 	commandStr, parsedCommandStr := fmt.Sprintf("%s", gotCmd), fmt.Sprintf("%s", tcase.Command)
 	if commandStr != parsedCommandStr {
 		t.Errorf("command does not match parsed command. got: '%s', expected: '%s'", commandStr, parsedCommandStr)
+	}
+}
+
+// TestNewSSHCommandUsesEndOfOptionsSeparator verifies that the ssh argv
+// includes the "--" end-of-options separator immediately before the
+// destination, so the destination is always parsed as a positional argument.
+func TestNewSSHCommandUsesEndOfOptionsSeparator(t *testing.T) {
+	cmd, _, err := newSSHCommand(context.Background(), 1234, "user@localhost", []string{"-v"}, []string{"echo", "hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// cmd.Args[0] is the ssh executable path; the rest are arguments.
+	args := cmd.Args[1:]
+
+	dashDashIdx := slices.Index(args, "--")
+	if dashDashIdx == -1 {
+		t.Fatalf("expected ssh args to contain a \"--\" separator, got: %v", args)
+	}
+
+	dstIdx := slices.Index(args, "user@localhost")
+	if dstIdx == -1 {
+		t.Fatalf("expected destination in ssh args, got: %v", args)
+	}
+
+	if dashDashIdx+1 != dstIdx {
+		t.Errorf("expected \"--\" to immediately precede destination, got args: %v", args)
+	}
+}
+
+// TestNewSCPCommandUsesEndOfOptionsSeparator verifies that the scp argv
+// includes the "--" end-of-options separator before the file arguments,
+// so file paths are always parsed as positional arguments.
+func TestNewSCPCommandUsesEndOfOptionsSeparator(t *testing.T) {
+	cmd, err := newSCPCommand(context.Background(), 1234, "user@localhost", []string{"local/file", "remote:file"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	args := cmd.Args[1:]
+
+	dashDashIdx := slices.Index(args, "--")
+	if dashDashIdx == -1 {
+		t.Fatalf("expected scp args to contain a \"--\" separator, got: %v", args)
+	}
+
+	localIdx := slices.Index(args, "local/file")
+	if localIdx == -1 {
+		t.Fatalf("expected file arg in scp args, got: %v", args)
+	}
+
+	if dashDashIdx > localIdx {
+		t.Errorf("expected \"--\" to precede file arguments, got args: %v", args)
 	}
 }

--- a/internal/codespaces/ssh_test.go
+++ b/internal/codespaces/ssh_test.go
@@ -72,6 +72,21 @@ func TestParseSSHArgs(t *testing.T) {
 			Command:    []string{"echo", "-b", "test"},
 		},
 		{
+			Args:       []string{"-v", "--", "echo", "hi"},
+			ParsedArgs: []string{"-v"},
+			Command:    []string{"echo", "hi"},
+		},
+		{
+			Args:       []string{"--", "-Fconfig", "arg"},
+			ParsedArgs: []string{},
+			Command:    []string{"-Fconfig", "arg"},
+		},
+		{
+			Args:       []string{"-v", "--"},
+			ParsedArgs: []string{"-v"},
+			Command:    nil,
+		},
+		{
 			Args:       []string{"-b"},
 			ParsedArgs: nil,
 			Command:    nil,
@@ -113,6 +128,11 @@ func TestParseSCPArgs(t *testing.T) {
 			Args:       []string{"local/file", "remote:file"},
 			ParsedArgs: []string{},
 			Command:    []string{"local/file", "remote:file"},
+		},
+		{
+			Args:       []string{"--", "-Fconfig", "remote:file"},
+			ParsedArgs: []string{},
+			Command:    []string{"-Fconfig", "remote:file"},
 		},
 		{
 			Args:       []string{"-c"},


### PR DESCRIPTION
## Summary
Closes - https://github.com/github/codespaces/issues/23695
Append the POSIX end-of-options `--` marker before the destination in `newSSHCommand` and before the file arguments in `newSCPCommand` (`internal/codespaces/ssh.go`).

`--` is the standard convention to signal "stop parsing options". Adding it here guarantees that the destination/file arguments are always treated as positional, regardless of their contents, and matches common-practice hardening across other CLIs that shell out to`ssh`/`scp`.

## Changes

- `internal/codespaces/ssh.go` — insert `"--"` immediately before the destination in `newSSHCommand`, and before the file list in`newSCPCommand`.
- `internal/codespaces/ssh_test.go` — add tests covering both separators (`TestNewSSHCommandUsesEndOfOptionsSeparator`,`TestNewSCPCommandUsesEndOfOptionsSeparator`).

## Validation

- `go test ./internal/codespaces/` passes 
- Manually confirmed `ssh -- user@host` and `scp -- src dst` behave identically to the pre-change invocations for normal inputs.