### PR TITLE
Pin reusable triage workflows to a commit SHA

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -228,7 +228,7 @@ jobs:
         run: script/release --local "$TAG_NAME" --platform windows
       - name: Set up MSBuild
         id: setupmsbuild
-        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
       - name: Build MSI
         shell: bash
         env:

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -6,13 +6,13 @@ on:
 jobs:
   label-incoming:
     if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'unlabeled'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-label-incoming.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-label-incoming.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       issues: write
 
   close-invalid:
     if: github.event.action == 'labeled'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-invalid.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-invalid.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       contents: read
       issues: write
@@ -20,42 +20,42 @@ jobs:
 
   close-suspected-spam:
     if: github.event.action == 'labeled'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-suspected-spam.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-suspected-spam.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       issues: write
 
   close-single-word:
     if: github.event.action == 'opened'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-single-word-issues.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-single-word-issues.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       issues: write
 
   close-off-topic:
     if: github.event.action == 'labeled'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-off-topic.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-off-topic.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       issues: write
 
   enhancement-comment:
     if: github.event.action == 'labeled'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-enhancement-comment.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-enhancement-comment.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       issues: write
 
   unable-to-reproduce:
     if: github.event.action == 'labeled'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-unable-to-reproduce-comment.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-unable-to-reproduce-comment.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       issues: write
 
   remove-needs-triage:
     if: github.event.action == 'labeled'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-remove-needs-triage.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-remove-needs-triage.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       issues: write
 
   on-issue-close:
     if: github.event.action == 'closed'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-on-issue-close.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-on-issue-close.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       issues: write

--- a/.github/workflows/triage-pull-requests.yml
+++ b/.github/workflows/triage-pull-requests.yml
@@ -10,7 +10,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request_target' &&
       (github.event.action == 'opened' || github.event.action == 'reopened')
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-label-external-pr.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-label-external-pr.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       issues: write
       pull-requests: write
@@ -20,7 +20,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request_target' &&
       github.event.action == 'opened'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-from-default-branch.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-from-default-branch.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     with:
       default_branch: trunk
     permissions:
@@ -30,7 +30,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request_target' &&
       (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'edited' || github.event.action == 'ready_for_review')
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     with:
       enable_pr_screening: true
       days_until_close: 4
@@ -41,7 +41,7 @@ jobs:
 
   close-unmet-requirements:
     if: github.event_name == 'schedule'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-pr-requirements.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     with:
       enable_pr_screening: true
       days_until_close: 4
@@ -54,7 +54,7 @@ jobs:
     if: >-
       github.event_name == 'pull_request_target' &&
       github.event.action == 'labeled'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-no-help-wanted.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-close-no-help-wanted.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       pull-requests: write
 
@@ -62,6 +62,6 @@ jobs:
     if: >-
       github.event_name == 'pull_request_target' &&
       github.event.action == 'labeled'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-ready-for-review.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-ready-for-review.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       pull-requests: write

--- a/.github/workflows/triage-scheduled-tasks.yml
+++ b/.github/workflows/triage-scheduled-tasks.yml
@@ -11,13 +11,13 @@ on:
 jobs:
   no-response:
     if: github.event_name == 'issue_comment' || github.event.schedule == '5 * * * *'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-no-response-close.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-no-response-close.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       issues: write
 
   stale:
     if: github.event.schedule == '0 3 * * *'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-stale-issues.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/triage-stale-issues.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     with:
       days_before_stale: 30
       days_before_close: -1
@@ -29,6 +29,6 @@ jobs:
 
   pitch-surface:
     if: github.event.schedule == '0 14 1 * *' || github.event_name == 'workflow_dispatch'
-    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/pitch-surface-top-issues.yml@main
+    uses: desktop/gh-cli-and-desktop-shared-workflows/.github/workflows/pitch-surface-top-issues.yml@df758d511475056e61d6d3a123621a854f10c646 # v0.0.1
     permissions:
       issues: write


### PR DESCRIPTION
### Description

Our triage automation calls reusable workflows from [`desktop/gh-cli-and-desktop-shared-workflows`](https://github.com/desktop/gh-cli-and-desktop-shared-workflows) by `@main`, so every run executed whatever sat at that branch's tip. This pins all 18 references to the commit behind that repo's [`v0.0.1`](https://github.com/desktop/gh-cli-and-desktop-shared-workflows/releases/tag/v0.0.1) release.

### Key Points

- Pinned to the release commit, not the bare branch tip. The trailing `# v0.0.1` comment is what lets Dependabot recognize the version and raise a PR when upstream cuts a new release.
- A `@main` reference produces no Dependabot updates at all, so this also restores update visibility.
- Added the missing `# v3.0.0` comment to the already-pinned `setup-msbuild` step so every pin documents its version.

### Notes for reviewers

This is a mechanical find-and-replace. To verify:

- The three triage workflow files no longer contain `@main`; all 18 calls now point to `df758d5`.
- That SHA is the target of `v0.0.1` in the upstream repo.
- The deployment workflow change is comment-only.