### PR TITLE
Add `issueFieldValues` to `gh issue view --json` fields

### DIFF
--- a/api/export_pr.go
+++ b/api/export_pr.go
@@ -111,6 +111,31 @@ func (issue *Issue) ExportData(fields []string) map[string]interface{} {
 				"nodes":      items,
 				"totalCount": issue.Blocking.TotalCount,
 			}
+		case "issueFieldValues":
+			items := make([]map[string]interface{}, 0, len(issue.IssueFieldValues.Nodes))
+			for _, n := range issue.IssueFieldValues.Nodes {
+				item := map[string]interface{}{
+					"__typename": n.Typename,
+					"field": map[string]interface{}{
+						"name":     n.Field.Name,
+						"dataType": n.Field.DataType,
+					},
+				}
+				switch n.Typename {
+				case "IssueFieldSingleSelectValue":
+					item["name"] = n.Name
+					item["optionId"] = n.OptionID
+					item["color"] = n.Color
+				case "IssueFieldTextValue":
+					item["text"] = n.Text
+				case "IssueFieldNumberValue":
+					item["number"] = n.Number
+				case "IssueFieldDateValue":
+					item["date"] = n.Date
+				}
+				items = append(items, item)
+			}
+			data[f] = items
 		default:
 			sf := fieldByName(v, f)
 			data[f] = sf.Interface()

--- a/api/export_pr_test.go
+++ b/api/export_pr_test.go
@@ -228,6 +228,37 @@ func TestIssue_ExportData(t *testing.T) {
 			`),
 		},
 		{
+			name:   "issue field values - single select",
+			fields: []string{"issueFieldValues"},
+			inputJSON: heredoc.Doc(`
+				{ "issueFieldValues": { "nodes": [
+					{
+						"__typename": "IssueFieldSingleSelectValue",
+						"name": "P2",
+						"optionId": "IFSSO_kgAC",
+						"color": "BLUE",
+						"field": { "name": "Priority", "dataType": "SINGLE_SELECT" }
+					}
+				] } }
+			`),
+			outputJSON: heredoc.Doc(`
+				{
+					"issueFieldValues": [
+						{
+							"__typename": "IssueFieldSingleSelectValue",
+							"color": "BLUE",
+							"field": {
+								"dataType": "SINGLE_SELECT",
+								"name": "Priority"
+							},
+							"name": "P2",
+							"optionId": "IFSSO_kgAC"
+						}
+					]
+				}
+			`),
+		},
+		{
 			name:   "parent",
 			fields: []string{"parent"},
 			inputJSON: heredoc.Doc(`

--- a/api/queries_issue.go
+++ b/api/queries_issue.go
@@ -57,6 +57,43 @@ type Issue struct {
 	Blocking         LinkedIssueConnection
 
 	ClosedByPullRequestsReferences ClosedByPullRequestsReferences
+
+	IssueFieldValues IssueFieldValues
+}
+
+// IssueFieldValues is a connection of native repository-level issue field
+// values set on an issue (e.g. Priority, Estimate). These are distinct from
+// ProjectV2 custom fields.
+type IssueFieldValues struct {
+	Nodes []IssueFieldValue `json:"nodes"`
+}
+
+// IssueFieldValue is the flattened representation of a single repository-level
+// issue field value. Only the fields relevant to the underlying union variant
+// are populated; the rest are zero values.
+type IssueFieldValue struct {
+	Typename string             `json:"__typename"`
+	Field    IssueFieldValueRef `json:"field"`
+
+	// SingleSelect
+	Name     string `json:"name,omitempty"`
+	OptionID string `json:"optionId,omitempty"`
+	Color    string `json:"color,omitempty"`
+
+	// Text
+	Text string `json:"text,omitempty"`
+
+	// Number
+	Number float64 `json:"number,omitempty"`
+
+	// Date (ISO 8601 string from the API)
+	Date string `json:"date,omitempty"`
+}
+
+// IssueFieldValueRef identifies the field a value belongs to.
+type IssueFieldValueRef struct {
+	Name     string `json:"name"`
+	DataType string `json:"dataType"`
 }
 
 // IssueType represents an issue type configured for a repository.

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -346,6 +346,7 @@ var issueOnlyFields = []string{
 	"subIssuesSummary",
 	"blockedBy",
 	"blocking",
+	"issueFieldValues",
 }
 
 var IssueFields = append(sharedIssuePRFields, issueOnlyFields...)
@@ -454,6 +455,14 @@ func IssueGraphQL(fields []string) string {
 			q = append(q, `blockedBy(first:50){nodes{id,number,title,url,state,repository{nameWithOwner}},totalCount}`)
 		case "blocking":
 			q = append(q, `blocking(first:50){nodes{id,number,title,url,state,repository{nameWithOwner}},totalCount}`)
+		case "issueFieldValues":
+			q = append(q, `issueFieldValues(first:50){nodes{`+
+				`__typename,`+
+				`...on IssueFieldSingleSelectValue{name,optionId,color,field{...on IssueFieldSingleSelect{name,dataType}}},`+
+				`...on IssueFieldTextValue{text:value,field{...on IssueFieldText{name,dataType}}},`+
+				`...on IssueFieldNumberValue{number:value,field{...on IssueFieldNumber{name,dataType}}},`+
+				`...on IssueFieldDateValue{date:value,field{...on IssueFieldDate{name,dataType}}}`+
+				`}}`)
 		default:
 			q = append(q, field)
 		}

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -54,6 +54,7 @@ func TestJSONFields(t *testing.T) {
 		"subIssuesSummary",
 		"blockedBy",
 		"blocking",
+		"issueFieldValues",
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds support for the new native repository-level **issue fields** (e.g. Priority, Estimate) to the JSON output of `gh issue view`, `gh issue list`, and `gh issue status`.

These fields live under the `issueFieldValues` connection on the `Issue` GraphQL type and are **distinct from ProjectV2 custom fields** — they're set directly on the issue without a project. Today the CLI has no way to surface them: `--json issueFieldValues` errors out as unsupported.

## Motivation

I hit this while reading a Priority value off an issue. The Priority sidebar widget is clearly populated, but there was no CLI-friendly way to read it. The only workaround was hand-rolling a GraphQL query via `gh api graphql`. After confirming no existing PR or issue mentioned `issueFieldValues` in cli/cli, I put this together.

## Changes

- `api/queries_issue.go`: new `IssueFieldValues` / `IssueFieldValue` types covering the four union variants (`SingleSelect`, `Text`, `Number`, `Date`)
- `api/query_builder.go`: register `issueFieldValues` in `issueOnlyFields` and emit the GraphQL fragment with inline `...on` selections for each variant
- `api/export_pr.go`: flatten union members into a clean JSON shape per typename
- `api/export_pr_test.go`: unit test for the single-select case (the most common one — Priority/Status/etc.)
- `pkg/cmd/issue/view/view_test.go`: add to the supported-fields expectation

## Output shape

Each entry carries `__typename`, the parent `field` (`name` + `dataType`), and the type-specific payload:

```json
{
  "issueFieldValues": [
    {
      "__typename": "IssueFieldSingleSelectValue",
      "color": "BLUE",
      "field": { "dataType": "SINGLE_SELECT", "name": "Priority" },
      "name": "P2",
      "optionId": "IFSSO_kgAC"
    }
  ]
}
```

Verified end-to-end against a real issue:

```
$ gh issue view 29 --repo github/local-agent-loop --json title,issueFieldValues
{"issueFieldValues":[{"__typename":"IssueFieldSingleSelectValue","color":"BLUE","field":{"dataType":"SINGLE_SELECT","name":"Priority"},"name":"P2","optionId":"IFSSO_kgAC"}],"title":"Test issue"}
```

## Notes / open questions

- Draft because I'd like a maintainer to sanity-check the union flattening shape before I invest in tests for the other three variants (Text/Number/Date) and add a section to the `gh issue view --help` examples.
- I went with a flattened shape (typename + payload at the top level) rather than nesting under a `value` key, mirroring the `projectItems` precedent. Happy to switch if a nested shape is preferred.
- No human-readable rendering yet — only JSON. Worth a follow-up to surface the values in the default `gh issue view` output too.
- Not sure if this needs a feature flag or schema availability check for older GHES versions; pointers welcome.

`go test ./api/... ./pkg/cmd/issue/...` passes.