### PR TITLE
Add security disclosure guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 This is the GitHub CLI (`gh`), a command-line tool for interacting with GitHub. The module path is `github.com/cli/cli/v2`.
 
+## Security Disclosures
+
+**Never** post security-related content - vulnerabilities, exploits, proofs of concept, or attack details - in any issue, pull request, comment, commit, or discussion. Stop and file a security advisory per [`.github/SECURITY.md`](.github/SECURITY.md).
+
 ## Build, Test, and Lint
 
 ```bash


### PR DESCRIPTION
### Description

Adds a Security Disclosures section to `AGENTS.md` directing agents to never post security-related content and to file an advisory instead.

### Key Points

Placed near the top of the file so it is hard to miss. It defers to [`SECURITY.md`](https://github.com/cli/cli/blob/trunk/.github/SECURITY.md) rather than restating the reporting steps, keeping one source of truth.

### Notes for reviewers

One docs-only change. Read the new Security Disclosures section in `AGENTS.md`.

### Additional Context

Our [`SECURITY.md`](https://github.com/cli/cli/blob/trunk/.github/SECURITY.md) defines the reporting process this section points to.