### PR TITLE
Detect additional third-party coding agents

### DIFF
--- a/internal/agents/detect.go
+++ b/internal/agents/detect.go
@@ -160,8 +160,10 @@ func detectWith(lookup func(string) (string, bool)) AgentName {
 	// Pi
 	// No first-party docs
 	// Anchored to a path separator so it only matches ".pi/agent" as a real
-	// path segment, not an incidental substring.
-	if strings.Contains(valueOf("PATH"), "/.pi/agent") {
+	// path segment, not an incidental substring. The Windows separator is
+	// matched too, though confidence there is lower since it is unconfirmed
+	// that pi uses this layout on Windows.
+	if strings.Contains(valueOf("PATH"), "/.pi/agent") || strings.Contains(valueOf("PATH"), `\.pi\agent`) {
 		return agentPi
 	}
 

--- a/internal/agents/detect.go
+++ b/internal/agents/detect.go
@@ -56,7 +56,7 @@ func detectWith(lookup func(string) (string, bool)) AgentName {
 		return v
 	}
 
-	// Generic agent identifiers — checked first because they are the most specific signal.
+	// Generic agent identifiers - checked first because they are the most specific signal.
 	if v, ok := lookup("AI_AGENT"); ok && v != "" {
 		if name, err := parseAgentName(v); err == nil {
 			return name
@@ -70,7 +70,7 @@ func detectWith(lookup func(string) (string, bool)) AgentName {
 		return agentAmp
 	}
 
-	// OpenAI Codex CLI — https://github.com/openai/codex
+	// OpenAI Codex CLI - https://github.com/openai/codex
 	// CODEX_SANDBOX: https://github.com/openai/codex/blob/95e1d5993985019ce0ce0d10689caf1375f95120/codex-rs/core/src/spawn.rs#L25
 	// CODEX_THREAD_ID: https://github.com/openai/codex/blob/95e1d5993985019ce0ce0d10689caf1375f95120/codex-rs/core/src/exec_env.rs#L8
 	// CODEX_CI: https://github.com/openai/codex/blob/95e1d5993985019ce0ce0d10689caf1375f95120/codex-rs/core/src/unified_exec/process_manager.rs#L64
@@ -78,7 +78,7 @@ func detectWith(lookup func(string) (string, bool)) AgentName {
 		return agentCodex
 	}
 
-	// Google Gemini CLI — https://github.com/google-gemini/gemini-cli
+	// Google Gemini CLI - https://github.com/google-gemini/gemini-cli
 	// GEMINI_CLI: https://github.com/google-gemini/gemini-cli/blob/46fd7b4864111032a1c7dfa1821b2000fc7531da/docs/tools/shell.md#L96-L97
 	if isSet("GEMINI_CLI") {
 		return agentGeminiCLI
@@ -90,7 +90,7 @@ func detectWith(lookup func(string) (string, bool)) AgentName {
 		return agentCopilotCLI
 	}
 
-	// OpenCode — https://github.com/anomalyco/opencode
+	// OpenCode - https://github.com/anomalyco/opencode
 	// OPENCODE: https://github.com/anomalyco/opencode/blob/fde201c286a83ff32dda9b41d61d734a4449fe70/packages/opencode/src/index.ts#L78-L80
 	if isSet("OPENCODE") {
 		return agentOpencode
@@ -116,7 +116,7 @@ func detectWith(lookup func(string) (string, bool)) AgentName {
 		return agentReplit
 	}
 
-	// Anthropic Claude Code — https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview
+	// Anthropic Claude Code - https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview
 	// CLAUDECODE: https://code.claude.com/docs/en/env-vars (CLAUDECODE section)
 	// CLAUDE_CODE, CLAUDE_CODE_IS_COWORK: no first-party docs
 	//

--- a/internal/agents/detect.go
+++ b/internal/agents/detect.go
@@ -4,18 +4,28 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 )
 
 // AgentName is a validated agent identifier safe for use in HTTP headers.
 type AgentName string
 
 const (
-	agentAmp        AgentName = "amp"
-	agentClaudeCode AgentName = "claude-code"
-	agentCodex      AgentName = "codex"
-	agentCopilotCLI AgentName = "copilot-cli"
-	agentGeminiCLI  AgentName = "gemini-cli"
-	agentOpencode   AgentName = "opencode"
+	agentAmp         AgentName = "amp"
+	agentClaudeCode  AgentName = "claude-code"
+	agentCodex       AgentName = "codex"
+	agentCopilotCLI  AgentName = "copilot-cli"
+	agentGeminiCLI   AgentName = "gemini-cli"
+	agentOpencode    AgentName = "opencode"
+	agentAntigravity AgentName = "antigravity"
+	agentAugmentCLI  AgentName = "augment-cli"
+	agentReplit      AgentName = "replit"
+	agentGoose       AgentName = "goose"
+	agentCowork      AgentName = "cowork"
+	agentCursor      AgentName = "cursor"
+	agentCursorCLI   AgentName = "cursor-cli"
+	agentKiro        AgentName = "kiro"
+	agentPi          AgentName = "pi"
 )
 
 var validAgentName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
@@ -82,17 +92,87 @@ func detectWith(lookup func(string) (string, bool)) AgentName {
 
 	// OpenCode — https://github.com/anomalyco/opencode
 	// OPENCODE: https://github.com/anomalyco/opencode/blob/fde201c286a83ff32dda9b41d61d734a4449fe70/packages/opencode/src/index.ts#L78-L80
-	if isSet("OPENCODE") {
+	// OPENCODE_CALLER: https://github.com/anomalyco/opencode/blob/31b58b470465977f9b9b6bd9a17bfe3d76f1a229/packages/opencode/src/ide/index.ts#L40
+	// OPENCODE_CLIENT: https://github.com/anomalyco/opencode/blob/31b58b470465977f9b9b6bd9a17bfe3d76f1a229/packages/core/src/flag/flag.ts#L75-L76
+	if isSet("OPENCODE") || isSet("OPENCODE_CALLER") || isSet("OPENCODE_CLIENT") {
 		return agentOpencode
+	}
+
+	// Antigravity
+	// No first-party docs
+	if isSet("ANTIGRAVITY_AGENT") {
+		return agentAntigravity
+	}
+
+	// Augment CLI
+	// No first-party docs
+	if isSet("AUGMENT_AGENT") {
+		return agentAugmentCLI
+	}
+
+	// Replit
+	// REPL_ID is present throughout any Replit environment, not only when a
+	// Replit agent is driving the CLI, so it is a broad, low-confidence signal.
+	// REPL_ID: https://github.com/replit/go-replidentity/blob/2966ea2d227d572f6054ee8f077ad16a1be02663/examples/extract.go#L25
+	if isSet("REPL_ID") {
+		return agentReplit
 	}
 
 	// Anthropic Claude Code — https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview
 	// CLAUDECODE: https://code.claude.com/docs/en/env-vars (CLAUDECODE section)
-	// Checked last because other agents (e.g. Amp) set CLAUDECODE=1 alongside their own vars.
-	if isSet("CLAUDECODE") {
+	// CLAUDE_CODE, CLAUDE_CODE_IS_COWORK: no first-party docs
+	//
+	// Cowork is a Claude Code mode that also sets CLAUDECODE, so it is checked
+	// first to win over the generic Claude Code signal below.
+	if isSet("CLAUDE_CODE_IS_COWORK") {
+		return agentCowork
+	}
+
+	// Claude Code is checked after Amp and Cowork, which also set CLAUDECODE, so
+	// those more specific agents are detected first.
+	if isSet("CLAUDECODE") || isSet("CLAUDE_CODE") {
 		// There is a CLAUDE_CODE_ENTRYPOINT env var that is set to `cli` or `desktop` etc, but it's not documented
 		// so we don't want to rely on it too heavily. We'll just return a generic claude-code agent name.
 		return agentClaudeCode
+	}
+
+	// Cursor
+	// No first-party docs
+	// CURSOR_TRACE_ID (IDE) takes precedence over the Cursor CLI signal below.
+	if isSet("CURSOR_TRACE_ID") {
+		return agentCursor
+	}
+
+	// Cursor CLI
+	// No first-party docs
+	if isSet("CURSOR_AGENT") || valueOf("CURSOR_EXTENSION_HOST_ROLE") == "agent-exec" {
+		return agentCursorCLI
+	}
+
+	// Single-source signals matched against one environment variable. These
+	// carry lower corroboration than the presence-based agents above, so they
+	// are checked after them.
+
+	// Kiro
+	// No first-party docs
+	if valueOf("TERM_PROGRAM") == "kiro" {
+		return agentKiro
+	}
+
+	// Pi
+	// No first-party docs
+	// Anchored to a path separator so it only matches ".pi/agent" as a real
+	// path segment, not an incidental substring.
+	if strings.Contains(valueOf("PATH"), "/.pi/agent") {
+		return agentPi
+	}
+
+	// Goose is checked last because GOOSE_PROVIDER only indicates that Goose is
+	// configured as a model provider, not that it is driving the CLI, so any
+	// more specific signal above should win.
+	// GOOSE_PROVIDER: https://github.com/aaif-goose/goose/blob/48a2a3d1804ae75eb7b208a5d0d73fd976511b80/crates/goose/src/config/providers.rs#L93
+	if isSet("GOOSE_PROVIDER") {
+		return agentGoose
 	}
 
 	return ""

--- a/internal/agents/detect.go
+++ b/internal/agents/detect.go
@@ -92,6 +92,8 @@ func detectWith(lookup func(string) (string, bool)) AgentName {
 
 	// OpenCode - https://github.com/anomalyco/opencode
 	// OPENCODE: https://github.com/anomalyco/opencode/blob/fde201c286a83ff32dda9b41d61d734a4449fe70/packages/opencode/src/index.ts#L78-L80
+	// Not OPENCODE_CALLER or OPENCODE_CLIENT: they name the client that launched
+	// opencode (e.g. the VS Code extension), not the running agent.
 	if isSet("OPENCODE") {
 		return agentOpencode
 	}

--- a/internal/agents/detect.go
+++ b/internal/agents/detect.go
@@ -92,9 +92,7 @@ func detectWith(lookup func(string) (string, bool)) AgentName {
 
 	// OpenCode — https://github.com/anomalyco/opencode
 	// OPENCODE: https://github.com/anomalyco/opencode/blob/fde201c286a83ff32dda9b41d61d734a4449fe70/packages/opencode/src/index.ts#L78-L80
-	// OPENCODE_CALLER: https://github.com/anomalyco/opencode/blob/31b58b470465977f9b9b6bd9a17bfe3d76f1a229/packages/opencode/src/ide/index.ts#L40
-	// OPENCODE_CLIENT: https://github.com/anomalyco/opencode/blob/31b58b470465977f9b9b6bd9a17bfe3d76f1a229/packages/core/src/flag/flag.ts#L75-L76
-	if isSet("OPENCODE") || isSet("OPENCODE_CALLER") || isSet("OPENCODE_CLIENT") {
+	if isSet("OPENCODE") {
 		return agentOpencode
 	}
 

--- a/internal/agents/detect_test.go
+++ b/internal/agents/detect_test.go
@@ -139,16 +139,6 @@ func TestDetectWith(t *testing.T) {
 			wantAgent: "gemini-cli",
 		},
 		{
-			name:      "OPENCODE_CALLER",
-			env:       map[string]string{"OPENCODE_CALLER": "1"},
-			wantAgent: "opencode",
-		},
-		{
-			name:      "OPENCODE_CLIENT",
-			env:       map[string]string{"OPENCODE_CLIENT": "1"},
-			wantAgent: "opencode",
-		},
-		{
 			name:      "ANTIGRAVITY_AGENT",
 			env:       map[string]string{"ANTIGRAVITY_AGENT": "1"},
 			wantAgent: "antigravity",

--- a/internal/agents/detect_test.go
+++ b/internal/agents/detect_test.go
@@ -138,6 +138,106 @@ func TestDetectWith(t *testing.T) {
 			env:       map[string]string{"AI_AGENT": "bad agent", "GEMINI_CLI": "1"},
 			wantAgent: "gemini-cli",
 		},
+		{
+			name:      "OPENCODE_CALLER",
+			env:       map[string]string{"OPENCODE_CALLER": "1"},
+			wantAgent: "opencode",
+		},
+		{
+			name:      "OPENCODE_CLIENT",
+			env:       map[string]string{"OPENCODE_CLIENT": "1"},
+			wantAgent: "opencode",
+		},
+		{
+			name:      "ANTIGRAVITY_AGENT",
+			env:       map[string]string{"ANTIGRAVITY_AGENT": "1"},
+			wantAgent: "antigravity",
+		},
+		{
+			name:      "AUGMENT_AGENT",
+			env:       map[string]string{"AUGMENT_AGENT": "1"},
+			wantAgent: "augment-cli",
+		},
+		{
+			name:      "REPL_ID",
+			env:       map[string]string{"REPL_ID": "abc123"},
+			wantAgent: "replit",
+		},
+		{
+			name:      "GOOSE_PROVIDER",
+			env:       map[string]string{"GOOSE_PROVIDER": "anthropic"},
+			wantAgent: "goose",
+		},
+		{
+			name:      "claude-code takes priority over goose",
+			env:       map[string]string{"GOOSE_PROVIDER": "anthropic", "CLAUDECODE": "1"},
+			wantAgent: "claude-code",
+		},
+		{
+			name:      "kiro takes priority over goose",
+			env:       map[string]string{"GOOSE_PROVIDER": "anthropic", "TERM_PROGRAM": "kiro"},
+			wantAgent: "kiro",
+		},
+		{
+			name:      "CLAUDE_CODE_IS_COWORK detected as cowork",
+			env:       map[string]string{"CLAUDE_CODE_IS_COWORK": "1"},
+			wantAgent: "cowork",
+		},
+		{
+			name:      "cowork takes priority over CLAUDECODE",
+			env:       map[string]string{"CLAUDE_CODE_IS_COWORK": "1", "CLAUDECODE": "1"},
+			wantAgent: "cowork",
+		},
+		{
+			name:      "CLAUDE_CODE",
+			env:       map[string]string{"CLAUDE_CODE": "1"},
+			wantAgent: "claude-code",
+		},
+		{
+			name:      "CURSOR_TRACE_ID detected as cursor",
+			env:       map[string]string{"CURSOR_TRACE_ID": "abc"},
+			wantAgent: "cursor",
+		},
+		{
+			name:      "CURSOR_AGENT detected as cursor-cli",
+			env:       map[string]string{"CURSOR_AGENT": "1"},
+			wantAgent: "cursor-cli",
+		},
+		{
+			name:      "CURSOR_EXTENSION_HOST_ROLE agent-exec detected as cursor-cli",
+			env:       map[string]string{"CURSOR_EXTENSION_HOST_ROLE": "agent-exec"},
+			wantAgent: "cursor-cli",
+		},
+		{
+			name:      "CURSOR_EXTENSION_HOST_ROLE with other value is ignored",
+			env:       map[string]string{"CURSOR_EXTENSION_HOST_ROLE": "worker"},
+			wantAgent: "",
+		},
+		{
+			name:      "CURSOR_TRACE_ID takes priority over CURSOR_AGENT",
+			env:       map[string]string{"CURSOR_TRACE_ID": "abc", "CURSOR_AGENT": "1"},
+			wantAgent: "cursor",
+		},
+		{
+			name:      "TERM_PROGRAM kiro detected as kiro",
+			env:       map[string]string{"TERM_PROGRAM": "kiro"},
+			wantAgent: "kiro",
+		},
+		{
+			name:      "TERM_PROGRAM with kiro as a substring is ignored",
+			env:       map[string]string{"TERM_PROGRAM": "kirostudio"},
+			wantAgent: "",
+		},
+		{
+			name:      "PATH containing .pi/agent detected as pi",
+			env:       map[string]string{"PATH": "/usr/bin:/home/user/.pi/agent/bin"},
+			wantAgent: "pi",
+		},
+		{
+			name:      "PATH with .pi/agent not on a path boundary is ignored",
+			env:       map[string]string{"PATH": "/usr/bin:/home/user/x.pi/agent"},
+			wantAgent: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/agents/detect_test.go
+++ b/internal/agents/detect_test.go
@@ -228,6 +228,11 @@ func TestDetectWith(t *testing.T) {
 			env:       map[string]string{"PATH": "/usr/bin:/home/user/x.pi/agent"},
 			wantAgent: "",
 		},
+		{
+			name:      "PATH with Windows .pi\\agent separators detected as pi",
+			env:       map[string]string{"PATH": `C:\Windows;C:\Users\user\.pi\agent\bin`},
+			wantAgent: "pi",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Description

Extends agent detection so the User-Agent header can identify more third-party coding agents driving `gh`. Adds nine new agents and an extra environment-variable signal for one existing one.

### Key Points

New agents detected: antigravity, augment-cli, replit, goose, cowork, cursor, cursor-cli, kiro, and pi. One existing agent gains an extra signal: claude-code also matches `CLAUDE_CODE`.

Detection order encodes confidence. `AI_AGENT` still wins, followed by agent-specific variables. Two signals are deliberately low-confidence and ranked accordingly:

- `REPL_ID` is present throughout any Replit environment, not only when a Replit agent drives the CLI, so it is annotated as broad in the code.
- `GOOSE_PROVIDER` only means Goose is configured as a model provider, not that it is running, so Goose is checked absolutely last and any stronger signal wins.

The single-source block now matches precisely instead of loosely: `kiro` is an exact `TERM_PROGRAM` match, and `pi` is anchored to a path boundary (`/.pi/agent`, or the Windows `\.pi\agent`) so an incidental substring cannot trigger it.

We considered a Devin signal and dropped it. The only reliable marker is the existence of a `/opt/.devin` directory, and this detector is intentionally environment-only with no filesystem access. The environment-variable alternatives (for example an `EDITOR` substring) could produce false positives, and Devin's developer-terminal footprint is small, so a noisy signal was not worth the telemetry pollution.

### Notes for reviewers

Two files change. Start in the [`agents` detector](https://github.com/cli/cli/blob/1d4ca33b34646ce1165067377fd89f01148cbaf3/internal/agents/detect.go): the constant block lists the new identifiers, and `detectWith` runs the ordered checks top to bottom, returning on first match. Read it straight down to see the precedence. Then the [detector tests](https://github.com/cli/cli/blob/1d4ca33b34646ce1165067377fd89f01148cbaf3/internal/agents/detect_test.go) add table cases for every new agent and signal, plus the precedence and negative cases (exact `kiro`, path-boundary `pi`, Goose losing to stronger signals).

First-party documentation for each signal lives inline next to its check, or is marked `// No first-party docs` where none exists.