### PR TITLE
Allow downloading release assets without authentication

### DIFF
--- a/pkg/cmd/release/download/download.go
+++ b/pkg/cmd/release/download/download.go
@@ -111,6 +111,8 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 	cmd.Flags().BoolVar(&opts.OverwriteExisting, "clobber", false, "Overwrite existing files of the same name")
 	cmd.Flags().BoolVar(&opts.SkipExisting, "skip-existing", false, "Skip downloading when files of the same name exist")
 
+	cmdutil.DisableAuthCheck(cmd)
+
 	return cmd
 }
 

--- a/pkg/cmd/release/download/download_test.go
+++ b/pkg/cmd/release/download/download_test.go
@@ -219,6 +219,37 @@ func Test_downloadRun(t *testing.T) {
 			},
 		},
 		{
+			name:  "downloads published release when the draft lookup is unauthorized",
+			isTTY: true,
+			opts: DownloadOptions{
+				TagName:     "v1.2.3",
+				Destination: ".",
+				Concurrency: 2,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/OWNER/REPO/releases/tags/v1.2.3"),
+					httpmock.StringResponse(`{
+						"assets": [
+							{ "name": "linux.tgz", "size": 56, "url": "https://api.github.com/assets/5678" }
+						]
+					}`),
+				)
+				// An unauthenticated draft lookup fails over GraphQL and must not
+				// mask the published release found over REST.
+				reg.Register(
+					httpmock.GraphQL(`query RepositoryReleaseByTag\b`),
+					httpmock.StatusStringResponse(403, `{"message":"This endpoint requires you to be authenticated."}`),
+				)
+				reg.Register(httpmock.REST("GET", "assets/5678"), httpmock.StringResponse(`5678`))
+			},
+			wantStdout: ``,
+			wantStderr: ``,
+			wantFiles: []string{
+				"linux.tgz",
+			},
+		},
+		{
 			name:  "download assets matching pattern into destination directory",
 			isTTY: true,
 			opts: DownloadOptions{

--- a/pkg/cmd/release/shared/fetch.go
+++ b/pkg/cmd/release/shared/fetch.go
@@ -201,15 +201,27 @@ func FetchRelease(ctx context.Context, httpClient *http.Client, repo ghrepo.Inte
 		results <- fetchResult{release: release, error: err}
 	}()
 
-	res := <-results
-	if errors.Is(res.error, ErrReleaseNotFound) {
-		res = <-results
-		cancel() // satisfy the linter even though no goroutines are running anymore
-	} else {
+	// Prefer a release found by either lookup. A single failed lookup, such as
+	// the draft lookup when unauthenticated, must not mask a release found by
+	// the other; only report an error when both lookups fail.
+	first := <-results
+	if first.error == nil {
 		cancel()
 		<-results // drain the channel
+		return first.release, nil
 	}
-	return res.release, res.error
+
+	second := <-results
+	cancel() // satisfy the linter even though no goroutines are running anymore
+	if second.error == nil {
+		return second.release, nil
+	}
+
+	// Both lookups failed; prefer reporting the release as not found.
+	if errors.Is(second.error, ErrReleaseNotFound) {
+		return nil, second.error
+	}
+	return nil, first.error
 }
 
 // FetchLatestRelease finds the latest published release for a repository.

--- a/pkg/cmdutil/repo_override.go
+++ b/pkg/cmdutil/repo_override.go
@@ -9,11 +9,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func executeParentHooks(cmd *cobra.Command, args []string) error {
-	for cmd.HasParent() {
-		cmd = cmd.Parent()
-		if cmd.PersistentPreRunE != nil {
-			return cmd.PersistentPreRunE(cmd, args)
+// executeParentHook re-runs the nearest ancestor's persistent pre-run hook,
+// which the hook installed by EnableRepoOverride would otherwise shadow. By
+// default cobra runs only the nearest PersistentPreRunE found walking up from
+// the invoked command, so without this the nearest ancestor hook, such as the
+// root auth gate, would never run for a repo-override command.
+//
+// That ancestor hook receives the invoked leaf cmd, not the ancestor, matching
+// how cobra passes the leaf to every persistent hook:
+// https://github.com/spf13/cobra/blob/v1.10.2/command.go#L984-L986
+//
+// cobra's EnableTraverseRunHooks global is the native equivalent and runs the
+// whole root-to-leaf chain for us, but it is global. Enabling it would change
+// pre-run behavior for every command: double-running the parents that issue
+// develop and EnableRepoOverride re-run by hand, and un-suppressing the root
+// gate that agent-task and skills intentionally shadow.
+func executeParentHook(overrideCmd, cmd *cobra.Command, args []string) error {
+	for p := overrideCmd.Parent(); p != nil; p = p.Parent() {
+		if p.PersistentPreRunE != nil {
+			return p.PersistentPreRunE(cmd, args)
 		}
 	}
 	return nil
@@ -47,8 +61,9 @@ func EnableRepoOverride(cmd *cobra.Command, f *Factory) {
 		return results, cobra.ShellCompDirectiveNoFileComp
 	})
 
+	overrideCmd := cmd
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		if err := executeParentHooks(cmd, args); err != nil {
+		if err := executeParentHook(overrideCmd, cmd, args); err != nil {
 			return err
 		}
 		repoOverride, _ := cmd.Flags().GetString("repo")

--- a/pkg/cmdutil/repo_override_test.go
+++ b/pkg/cmdutil/repo_override_test.go
@@ -1,0 +1,70 @@
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_EnableRepoOverride_authCheckIntegration is an integration test for the
+// coupling between repo override and the root auth gate, wired through cobra's
+// persistent pre-run hooks. EnableRepoOverride replaces a command's
+// PersistentPreRunE, so cobra no longer reaches the root auth gate on its own;
+// the override hook re-runs the ancestor hooks itself. That re-run must evaluate
+// the command the user actually invoked, the same way cobra hands the target
+// command to parent hooks:
+// https://github.com/spf13/cobra/blob/v1.10.2/command.go#L984-L986
+// This pins that a leaf's DisableAuthCheck is honored under a repo-override
+// parent.
+func Test_EnableRepoOverride_authCheckIntegration(t *testing.T) {
+	tests := []struct {
+		name            string
+		disableAuthLeaf bool
+		wantAuthChecked bool
+	}{
+		{
+			name:            "leaf opts out, honored under repo-override parent",
+			disableAuthLeaf: true,
+			wantAuthChecked: false,
+		},
+		{
+			name:            "leaf does not opt out, auth still checked",
+			disableAuthLeaf: false,
+			wantAuthChecked: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotAuthChecked, ranLeaf bool
+
+			// Stand in for the real root auth gate: it judges whatever command
+			// it is handed, so it must receive the invoked leaf command.
+			root := &cobra.Command{Use: "root"}
+			root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+				gotAuthChecked = IsAuthCheckEnabled(cmd)
+				return nil
+			}
+
+			parent := &cobra.Command{Use: "parent"}
+			EnableRepoOverride(parent, &Factory{})
+			root.AddCommand(parent)
+
+			leaf := &cobra.Command{
+				Use:  "leaf",
+				RunE: func(cmd *cobra.Command, args []string) error { ranLeaf = true; return nil },
+			}
+			if tt.disableAuthLeaf {
+				DisableAuthCheck(leaf)
+			}
+			parent.AddCommand(leaf)
+
+			root.SetArgs([]string{"parent", "leaf"})
+			require.NoError(t, root.Execute())
+
+			require.True(t, ranLeaf, "leaf command should have executed")
+			require.Equal(t, tt.wantAuthChecked, gotAuthChecked)
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/2680


### Description

`gh release download` now works without authentication against public repositories, matching `gh extension install`. A token is still used when one is present.

### Key Points

This change has three parts, from simplest to subtlest:

- **Why drop the auth gate** - the login requirement is unnecessary for public downloads.
- **Fixing the by-tag race to be success oriented** - an anonymous draft-lookup 403 no longer masks a release the REST lookup found.
- **Honoring the gate under repo override** - the cobra plumbing fix that makes the dropped gate apply to `download`.

#### Why drop the auth gate

Release endpoints for public repositories are readable anonymously over REST, so the login gate is unnecessary. Removing it is the same one-line `cmdutil.DisableAuthCheck` change that #13176 made for `gh extension install`.

The same logic here applies as with `gh extension install`:

> What this says is that extension installation is going to happen unauthenticated whether we make it easier or not. We might as well make it easier and keep people installing through our core commands.

In `gh release download` - people are going to just `curl` the endpoint directly, and that degrades their experience since we provide a lot of abstractions over the API that make `gh` much more than a `curl`/`gh api` call.

But I'll broaden the conversation - we got feedback that folks are using `gh release download` more in CI and they want to secure their CI by not providing `gh` a token unless it's necessary. If you're downloading a public asset, that's not necessary and we force you to use a larger than necessary token scope.

#### Fixing the by-tag race to be success oriented

The by-tag path creates problems that make this deviate a bit from `gh ext install` - that's one reason why this diff is a bit bigger. [`FetchRelease`](https://github.com/cli/cli/blob/f0a128ad1c33a41b7d1bdc93b5d507c842713d8a/pkg/cmd/release/shared/fetch.go) races a published-release REST lookup against a draft-release GraphQL lookup. GraphQL rejects anonymous requests, so the draft lookup returns a 403. The old selector returned the first result unless it was exactly `ErrReleaseNotFound`, so that 403 could win the race and mask a release the REST lookup found.

The selector now prefers a found release and only errors when both lookups fail. We used to return whichever result arrived first, treating only a not-found error as a reason to wait for the second:

```go
// Before - a non-not-found error from either lookup wins
res := <-results
if errors.Is(res.error, ErrReleaseNotFound) {
    res = <-results
    cancel()
} else {
    cancel()
    <-results // drain the channel
}
return res.release, res.error
```

Now we take a success from either lookup, and only surface an error when both fail:

```go
// Now - a found release wins; an error needs both lookups to fail
first := <-results
if first.error == nil {
    cancel()
    <-results // drain the channel
    return first.release, nil
}

second := <-results
cancel()
if second.error == nil {
    return second.release, nil
}
if errors.Is(second.error, ErrReleaseNotFound) {
    return nil, second.error
}
return nil, first.error
```

This also stops a transient draft-lookup failure from masking a real release for authenticated users.

#### Honoring the gate under repo override

Removing the gate did not take effect on its own. `release` enables the `-R/--repo` override, and that installs a `PersistentPreRunE` on the `release` command. cobra runs only the nearest such hook walking up from the command you invoked, so the override hook shadows the [root auth gate](https://github.com/cli/cli/blob/7b681a4e8b67d203ccdaab5ff54570bdf6ca3669/pkg/cmd/root/root.go). The override re-runs the nearest ancestor hook to make up for that, but it handed *the ancestor* to the hook as the command, so the auth gate judged `release` instead of `download` and never saw download's `DisableAuthCheck`.

The fix keeps the invoked command and passes that leaf up, the node cobra would have judged if the repo override didn't muck with it:

```go
// Before - climbs by reassigning cmd, so the gate is judged against the ancestor
for cmd.HasParent() {
    cmd = cmd.Parent()
    if cmd.PersistentPreRunE != nil {
        return cmd.PersistentPreRunE(cmd, args)
    }
}

// Now - keep the invoked leaf and pass it up
for p := overrideCmd.Parent(); p != nil; p = p.Parent() {
    if p.PersistentPreRunE != nil {
        return p.PersistentPreRunE(cmd, args)
    }
}
```

This mirrors [cobra's own `execute` loop](https://github.com/spf13/cobra/blob/v1.10.2/command.go#L984-L986), which walks the parents but always hands them the leaf command. cobra's `EnableTraverseRunHooks` global would run the whole chain for us and maybe is a better long term fix, but it is process-wide and would change pre-run behavior for every command, so I'm not touching it here.

I guarded this with an integration test, since the bug only surfaces with the pieces wired together. [`Test_EnableRepoOverride_authCheckIntegration`](https://github.com/cli/cli/blob/7b681a4e8b67d203ccdaab5ff54570bdf6ca3669/pkg/cmdutil/repo_override_test.go) builds a root gate, a repo-override parent, and a leaf, then asserts the gate judged the leaf: opting out with `DisableAuthCheck` skips the check, otherwise the gate still runs. It lives in `cmdutil` beside the helper, since the coupling is the helper's, not any one command's.

### Notes for reviewers

Three atomic commits:

- `fix(release): don't let a failed draft lookup mask a found release` changes the selector in [`FetchRelease`](https://github.com/cli/cli/blob/f0a128ad1c33a41b7d1bdc93b5d507c842713d8a/pkg/cmd/release/shared/fetch.go) and adds a regression case to the existing `Test_downloadRun` table.
- `feat(release): allow download without authentication` removes the gate in the [download command](https://github.com/cli/cli/blob/f0a128ad1c33a41b7d1bdc93b5d507c842713d8a/pkg/cmd/release/download/download.go).
- `fix(cmdutil): honor DisableAuthCheck under repo-override parents` fixes [the repo-override helper](https://github.com/cli/cli/blob/7b681a4e8b67d203ccdaab5ff54570bdf6ca3669/pkg/cmdutil/repo_override.go) so the gate removal actually takes effect, and adds an integration test that pins the coupling between repo override and the root auth gate.

### Additional Context
- #2680 is the standing request to allow unauthenticated public requests, and its motivating example is `gh release download` on a public repo.
- #13176 removed the same gate for `gh extension install` and is the precedent this follows.