### PR TITLE
fix formatting of enum values in flag help text

### DIFF
--- a/pkg/cmd/completion/completion_test.go
+++ b/pkg/cmd/completion/completion_test.go
@@ -39,7 +39,7 @@ func TestNewCmdCompletion(t *testing.T) {
 		{
 			name:    "unsupported shell",
 			args:    "completion -s csh",
-			wantErr: "invalid argument \"csh\" for \"-s, --shell\" flag: valid values are {bash|zsh|fish|powershell}",
+			wantErr: "invalid argument \"csh\" for \"-s, --shell\" flag: expected one of \"bash\", \"zsh\", \"fish\", \"powershell\"",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cmd/label/list_test.go
+++ b/pkg/cmd/label/list_test.go
@@ -63,7 +63,7 @@ func TestNewCmdList(t *testing.T) {
 			name:    "sort invalid flag",
 			input:   "--sort invalid",
 			wantErr: true,
-			errMsg:  `invalid argument "invalid" for "--sort" flag: valid values are {created|name}`,
+			errMsg:  `invalid argument "invalid" for "--sort" flag: expected one of "created", "name"`,
 		},
 		{
 			name:   "order asc flag",
@@ -79,7 +79,7 @@ func TestNewCmdList(t *testing.T) {
 			name:    "order invalid flag",
 			input:   "--order invalid",
 			wantErr: true,
-			errMsg:  `invalid argument "invalid" for "--order" flag: valid values are {asc|desc}`,
+			errMsg:  `invalid argument "invalid" for "--order" flag: expected one of "asc", "desc"`,
 		},
 		{
 			name:    "search flag with sort flag",

--- a/pkg/cmd/pr/diff/diff_test.go
+++ b/pkg/cmd/pr/diff/diff_test.go
@@ -111,7 +111,7 @@ func Test_NewCmdDiff(t *testing.T) {
 			name:    "invalid --color argument",
 			args:    "--color doublerainbow",
 			isTTY:   true,
-			wantErr: "invalid argument \"doublerainbow\" for \"--color\" flag: valid values are {always|never|auto}",
+			wantErr: "invalid argument \"doublerainbow\" for \"--color\" flag: expected one of \"always\", \"never\", \"auto\"",
 		},
 		{
 			name:  "web mode",

--- a/pkg/cmd/project/edit/edit_test.go
+++ b/pkg/cmd/project/edit/edit_test.go
@@ -30,7 +30,7 @@ func TestNewCmdEdit(t *testing.T) {
 			name:        "visibility-error",
 			cli:         "--visibility v",
 			wantsErr:    true,
-			wantsErrMsg: "invalid argument \"v\" for \"--visibility\" flag: valid values are {PUBLIC|PRIVATE}",
+			wantsErrMsg: "invalid argument \"v\" for \"--visibility\" flag: expected one of \"PUBLIC\", \"PRIVATE\"",
 		},
 		{
 			name:        "no-args",

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -285,7 +285,7 @@ func TestNewCmdList(t *testing.T) {
 		{
 			name:     "invalid visibility",
 			cli:      "--visibility=bad",
-			wantsErr: "invalid argument \"bad\" for \"--visibility\" flag: valid values are {public|private|internal}",
+			wantsErr: "invalid argument \"bad\" for \"--visibility\" flag: expected one of \"public\", \"private\", \"internal\"",
 		},
 		{
 			name:     "no forks with sources",

--- a/pkg/cmd/search/commits/commits_test.go
+++ b/pkg/cmd/search/commits/commits_test.go
@@ -66,7 +66,7 @@ func TestNewCmdCommits(t *testing.T) {
 			name:    "invalid order flag",
 			input:   "--order invalid",
 			wantErr: true,
-			errMsg:  "invalid argument \"invalid\" for \"--order\" flag: valid values are {asc|desc}",
+			errMsg:  "invalid argument \"invalid\" for \"--order\" flag: expected one of \"asc\", \"desc\"",
 		},
 		{
 			name: "qualifier flags",

--- a/pkg/cmd/search/issues/issues_test.go
+++ b/pkg/cmd/search/issues/issues_test.go
@@ -87,7 +87,7 @@ func TestNewCmdIssues(t *testing.T) {
 			name:    "invalid order flag",
 			input:   "--order invalid",
 			wantErr: true,
-			errMsg:  "invalid argument \"invalid\" for \"--order\" flag: valid values are {asc|desc}",
+			errMsg:  "invalid argument \"invalid\" for \"--order\" flag: expected one of \"asc\", \"desc\"",
 		},
 		{
 			name:  "include-prs flag",

--- a/pkg/cmd/search/prs/prs_test.go
+++ b/pkg/cmd/search/prs/prs_test.go
@@ -87,7 +87,7 @@ func TestNewCmdPrs(t *testing.T) {
 			name:    "invalid order flag",
 			input:   "--order invalid",
 			wantErr: true,
-			errMsg:  "invalid argument \"invalid\" for \"--order\" flag: valid values are {asc|desc}",
+			errMsg:  "invalid argument \"invalid\" for \"--order\" flag: expected one of \"asc\", \"desc\"",
 		},
 		{
 			name:  "app flag",

--- a/pkg/cmd/search/repos/repos_test.go
+++ b/pkg/cmd/search/repos/repos_test.go
@@ -66,7 +66,7 @@ func TestNewCmdRepos(t *testing.T) {
 			name:    "invalid order flag",
 			input:   "--order invalid",
 			wantErr: true,
-			errMsg:  "invalid argument \"invalid\" for \"--order\" flag: valid values are {asc|desc}",
+			errMsg:  "invalid argument \"invalid\" for \"--order\" flag: expected one of \"asc\", \"desc\"",
 		},
 		{
 			name: "qualifier flags",

--- a/pkg/cmdutil/flags.go
+++ b/pkg/cmdutil/flags.go
@@ -66,7 +66,11 @@ func RegisterBranchCompletionFlags(gitc gitClient, cmd *cobra.Command, flags ...
 }
 
 func formatValuesForUsageDocs(values []string) string {
-	return fmt.Sprintf("{%s}", strings.Join(values, "|"))
+	quoted := make([]string, len(values))
+	for i, v := range values {
+		quoted[i] = fmt.Sprintf("%q", v)
+	}
+	return fmt.Sprintf("one of %s", strings.Join(quoted, ", "))
 }
 
 type stringValue struct {
@@ -131,7 +135,7 @@ type enumValue struct {
 
 func (e *enumValue) Set(value string) error {
 	if !isIncluded(value, e.options) {
-		return fmt.Errorf("valid values are %s", formatValuesForUsageDocs(e.options))
+		return fmt.Errorf("expected %s", formatValuesForUsageDocs(e.options))
 	}
 	*e.string = value
 	return nil
@@ -154,7 +158,7 @@ func (e *enumMultiValue) Set(value string) error {
 	items := strings.Split(value, ",")
 	for _, item := range items {
 		if !isIncluded(item, e.options) {
-			return fmt.Errorf("valid values are %s", formatValuesForUsageDocs(e.options))
+			return fmt.Errorf("expected %s", formatValuesForUsageDocs(e.options))
 		}
 	}
 	*e.value = append(*e.value, items...)

--- a/pkg/cmdutil/json_flags_test.go
+++ b/pkg/cmdutil/json_flags_test.go
@@ -228,7 +228,7 @@ func TestAddFormatFlags(t *testing.T) {
 			name:        "invalid format field",
 			args:        []string{"--format", "idontexist"},
 			wantsExport: nil,
-			wantsError:  "invalid argument \"idontexist\" for \"--format\" flag: valid values are {json}",
+			wantsError:  "invalid argument \"idontexist\" for \"--format\" flag: expected one of \"json\"",
 		},
 		{
 			name:        "cannot combine --format with --web",


### PR DESCRIPTION
Fixes #8349

Enum values in flag docs looked like `{created_at|last_accessed_at|size_in_bytes}` which was pretty rough on the eyes. Swapped it out for a cleaner format:

```
-S, --sort <string>   Sort fetched caches: one of "created_at", "last_accessed_at", "size_in_bytes"
```

Same treatment for error messages - instead of `valid values are {asc|desc}` it now says `expected one of "asc", "desc"`.