### PR TITLE
gh extension install: honor --pin with --force

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -379,15 +379,21 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					if ext, err := checkValidExtension(cmd.Root(), m, repo.RepoName(), repo.RepoOwner()); err != nil {
 						// If an existing extension was found and --force was specified, attempt to upgrade.
 						if forceFlag && ext != nil {
-							return upgradeFunc(ext.Name(), forceFlag)
-						}
-
-						if errors.Is(err, alreadyInstalledError) {
+							if pinFlag == "" {
+								return upgradeFunc(ext.Name(), forceFlag)
+							}
+							// upgradeFunc always installs the latest release and has no
+							// way to honor pinFlag, so remove the existing extension and
+							// fall through to the pinned install below instead (#13551).
+							if err := m.Remove(ext.Name()); err != nil {
+								return err
+							}
+						} else if errors.Is(err, alreadyInstalledError) {
 							fmt.Fprintf(io.ErrOut, "%s Extension %s is already installed\n", cs.WarningIcon(), ghrepo.FullName(repo))
 							return nil
+						} else {
+							return err
 						}
-
-						return err
 					}
 
 					io.StartProgressIndicator()

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -898,6 +898,43 @@ func TestNewCmdExtension(t *testing.T) {
 			isTTY:      true,
 			wantStdout: "✓ Successfully checked extension upgrades\n",
 		},
+		{
+			// Regression test for #13551: --force together with --pin must
+			// reinstall at the pinned tag, not silently upgrade to latest
+			// via the generic upgradeFunc path (which has no way to honor
+			// pinFlag at all).
+			name: "force install with pin when present",
+			args: []string{"install", "owner/gh-hello", "--force", "--pin", "v1.2.3"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.ListFunc = func() []extensions.Extension {
+					return []extensions.Extension{
+						&Extension{path: "owner/gh-hello", owner: "owner"},
+					}
+				}
+				em.RemoveFunc = func(name string) error {
+					return nil
+				}
+				em.InstallFunc = func(_ ghrepo.Interface, _ string) error {
+					return nil
+				}
+				em.UpgradeFunc = func(name string, force bool) error {
+					return nil
+				}
+				return func(t *testing.T) {
+					removeCalls := em.RemoveCalls()
+					assert.Equal(t, 1, len(removeCalls))
+					assert.Equal(t, "hello", removeCalls[0].Name)
+					installCalls := em.InstallCalls()
+					assert.Equal(t, 1, len(installCalls))
+					assert.Equal(t, "gh-hello", installCalls[0].InterfaceMoqParam.RepoName())
+					assert.Equal(t, "v1.2.3", installCalls[0].S)
+					upgradeCalls := em.UpgradeCalls()
+					assert.Equal(t, 0, len(upgradeCalls))
+				}
+			},
+			isTTY:      true,
+			wantStdout: "✓ Installed extension owner/gh-hello\n✓ Pinned extension at v1.2.3\n",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #13551

## Bug

When `gh extension install` was called with both `--force` and `--pin <tag>` on an already-installed extension, the command would ignore the pinned tag and silently upgrade to the latest release instead. This happened because the code routed through the generic `upgradeFunc`, which always installs the latest and has no parameter for honoring a pinned tag.

**Example:**
```bash
# Install v0.74.8
$ gh extension install github/gh-aw --pin v0.74.8

# Try to reinstall at v0.75.0
$ gh extension install github/gh-aw --force --pin v0.75.0
[aw]: upgraded from v0.74.8 to v0.76.1  ← silently upgraded to LATEST, ignored --pin
```

Expected: install at v0.75.0 (the pinned tag)
Actual: install at v0.76.1 (latest, ignoring --pin)

## Root Cause

The install command logic was:
1. If extension exists + --force: call `upgradeFunc` (always installs latest)
2. Otherwise: call `Install` with pinFlag

The `upgradeFunc` path has no way to pass a pin tag, so --pin was silently ignored when --force was set.

## Fix

When both --force and --pin are specified, remove the existing extension and fall through to the normal install path instead of calling `upgradeFunc`. This ensures the pinned tag is honored:

```go
if forceFlag && ext != nil {
    if pinFlag == "" {
        return upgradeFunc(ext.Name(), forceFlag)
    }
    // Remove + fall through to install with pinFlag
    if err := m.Remove(ext.Name()); err != nil {
        return err
    }
}
```

This makes semantic sense: `--force` means "reinstall even if already present", and `--pin <tag>` means "use this tag" — together they mean "reinstall at this tag".

## Tests

Added regression test case `force_install_with_pin_when_present` that:
- Confirms `Remove` is called on the existing extension
- Confirms `Install` is called with the pinned tag
- Confirms `Upgrade` is NOT called (the old broken path)

All existing tests pass.