### PR TITLE
docs(search): add examples for multiple qualifiers

### DIFF
--- a/pkg/cmd/search/code/code.go
+++ b/pkg/cmd/search/code/code.go
@@ -56,6 +56,9 @@ func NewCmdCode(f *cmdutil.Factory, runF func(*CodeOptions) error) *cobra.Comman
 			# Search code matching "error handling"
 			$ gh search code "error handling"
 
+			# Search code using multiple search syntax qualifiers as separate arguments
+			$ gh search code panic path:pkg language:go
+
 			# Search code matching "deque" in Python files
 			$ gh search code deque --language=python
 

--- a/pkg/cmd/search/code/code.go
+++ b/pkg/cmd/search/code/code.go
@@ -56,7 +56,7 @@ func NewCmdCode(f *cmdutil.Factory, runF func(*CodeOptions) error) *cobra.Comman
 			# Search code matching "error handling"
 			$ gh search code "error handling"
 
-			# Search code using multiple search syntax qualifiers as separate arguments
+			# Search code using raw search qualifiers as separate arguments
 			$ gh search code panic path:pkg language:go
 
 			# Search code matching "deque" in Python files

--- a/pkg/cmd/search/commits/commits.go
+++ b/pkg/cmd/search/commits/commits.go
@@ -55,6 +55,9 @@ func NewCmdCommits(f *cmdutil.Factory, runF func(*CommitsOptions) error) *cobra.
 			# Search commits matching phrase "bug fix"
 			$ gh search commits "bug fix"
 
+			# Search commits using multiple search syntax qualifiers as separate arguments
+			$ gh search commits fix author:monalisa merge:false
+
 			# Search commits committed by user "monalisa"
 			$ gh search commits --committer=monalisa
 

--- a/pkg/cmd/search/commits/commits.go
+++ b/pkg/cmd/search/commits/commits.go
@@ -55,7 +55,7 @@ func NewCmdCommits(f *cmdutil.Factory, runF func(*CommitsOptions) error) *cobra.
 			# Search commits matching phrase "bug fix"
 			$ gh search commits "bug fix"
 
-			# Search commits using multiple search syntax qualifiers as separate arguments
+			# Search commits using raw search qualifiers as separate arguments
 			$ gh search commits fix author:monalisa merge:false
 
 			# Search commits committed by user "monalisa"

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -50,7 +50,7 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 			# Search issues matching phrase "broken feature"
 			$ gh search issues "broken feature"
 
-			# Search issues using multiple search syntax qualifiers as separate arguments
+			# Search issues using raw search qualifiers as separate arguments
 			$ gh search issues label:bug author:monalisa state:open
 
 			# Search issues and pull requests in cli organization

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -50,6 +50,9 @@ func NewCmdIssues(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *c
 			# Search issues matching phrase "broken feature"
 			$ gh search issues "broken feature"
 
+			# Search issues using multiple search syntax qualifiers as separate arguments
+			$ gh search issues label:bug author:monalisa state:open
+
 			# Search issues and pull requests in cli organization
 			$ gh search issues --include-prs --owner=cli
 

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -52,6 +52,9 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 			# Search draft pull requests in cli repository
 			$ gh search prs --repo=cli/cli --draft
 
+			# Search pull requests using multiple search syntax qualifiers as separate arguments
+			$ gh search prs review:required status:success base:main
+
 			# Search open pull requests requesting your review
 			$ gh search prs --review-requested=@me --state=open
 

--- a/pkg/cmd/search/prs/prs.go
+++ b/pkg/cmd/search/prs/prs.go
@@ -52,8 +52,8 @@ func NewCmdPrs(f *cmdutil.Factory, runF func(*shared.IssuesOptions) error) *cobr
 			# Search draft pull requests in cli repository
 			$ gh search prs --repo=cli/cli --draft
 
-			# Search pull requests using multiple search syntax qualifiers as separate arguments
-			$ gh search prs review:required status:success base:main
+			# Search pull requests using raw search qualifiers as separate arguments
+			$ gh search prs is:merged author:monalisa
 
 			# Search open pull requests requesting your review
 			$ gh search prs --review-requested=@me --state=open

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -56,6 +56,9 @@ func NewCmdRepos(f *cmdutil.Factory, runF func(*ReposOptions) error) *cobra.Comm
 			# Search repositories matching phrase "vim plugin"
 			$ gh search repos "vim plugin"
 
+			# Search repositories using multiple search syntax qualifiers as separate arguments
+			$ gh search repos topic:artificial-intelligence stars:>5000 pushed:>2026-06-01 archived:false
+
 			# Search repositories public repos in the microsoft organization
 			$ gh search repos --owner=microsoft --visibility=public
 

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -56,8 +56,8 @@ func NewCmdRepos(f *cmdutil.Factory, runF func(*ReposOptions) error) *cobra.Comm
 			# Search repositories matching phrase "vim plugin"
 			$ gh search repos "vim plugin"
 
-			# Search repositories using multiple search syntax qualifiers as separate arguments
-			$ gh search repos topic:artificial-intelligence stars:>5000 pushed:>2026-06-01 archived:false
+			# Search repositories using raw search qualifiers as separate arguments
+			$ gh search repos topic:github 'stars:>5000'
 
 			# Search repositories public repos in the microsoft organization
 			$ gh search repos --owner=microsoft --visibility=public


### PR DESCRIPTION
## Summary
- add `gh search` examples showing multiple search-syntax qualifiers as separate CLI arguments
- cover issues, pull requests, repositories, code, and commits search help text

## Why
Issue #13678 shows that passing a full multi-qualifier query as one shell argument can be misleading. The maintainers suggested improving the docs/examples, so this PR makes that usage explicit in the built-in help output.

Closes #13678