### PR TITLE
fix(text): preserve percent-encoding in DisplayURL

### DIFF
--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -77,7 +77,7 @@ func DisplayURL(urlStr string) string {
 	if scheme == "" {
 		scheme = "https"
 	}
-	return scheme + "://" + u.Hostname() + u.Path
+	return (&url.URL{Scheme: scheme, Host: u.Hostname(), Path: u.Path}).String()
 }
 
 // RemoveDiacritics returns the input value without "diacritics", or accent marks

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -174,6 +174,11 @@ func TestDisplayURL(t *testing.T) {
 			url:  "http://github.com/cli/cli/issues/9470",
 			want: "http://github.com/cli/cli/issues/9470",
 		},
+		{
+			name: "preserve percent-encoding in path",
+			url:  "https://github.com/OWNER/REPO/compare/main...test-%22quoted%22-branch?expand=1",
+			want: "https://github.com/OWNER/REPO/compare/main...test-%22quoted%22-branch",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
DisplayURL was reconstructing the URL with `u.Hostname() + u.Path`, which decodes percent-encoded characters (e.g. `%22` → `"`) in the path and drops query strings entirely. Use `url.URL{}.String()` instead, which re-encodes the path via `EscapedPath()` and preserves the original encoding.

Fixes #13546