### PR TITLE
Add per-host api_host override for custom API endpoint routing

### DIFF
--- a/api/http_client.go
+++ b/api/http_client.go
@@ -28,6 +28,7 @@ type HTTPClientOptions struct {
 	LogVerboseHTTP     bool
 	SkipDefaultHeaders bool
 	TelemetryDisabler  ghtelemetry.Disabler
+	APIHostResolver    func(string) (string, error)
 }
 
 func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
@@ -70,6 +71,10 @@ func NewHTTPClient(opts HTTPClientOptions) (*http.Client, error) {
 	client, err := ghAPI.NewHTTPClient(clientOpts)
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.APIHostResolver != nil {
+		client.Transport = addAPIHostRewriter(client.Transport, opts.APIHostResolver)
 	}
 
 	if opts.Config != nil {
@@ -211,4 +216,19 @@ func (t telemetryDisablerTransport) RoundTrip(req *http.Request) (*http.Response
 		t.telemetryDisabler.Disable()
 	}
 	return t.wrappedTransport.RoundTrip(req)
+}
+
+func addAPIHostRewriter(rt http.RoundTripper, resolver func(string) (string, error)) http.RoundTripper {
+	return &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+		apiHost, err := resolver(req.URL.Hostname())
+		if err != nil {
+			return nil, err
+		}
+		if apiHost != "" {
+			req = req.Clone(req.Context())
+			req.Host = req.URL.Host
+			req.URL.Host = apiHost
+		}
+		return rt.RoundTrip(req)
+	}}
 }

--- a/api/http_client_test.go
+++ b/api/http_client_test.go
@@ -444,6 +444,78 @@ func (c tinyConfig) ActiveToken(host string) (string, string) {
 	return c[fmt.Sprintf("%s:%s", host, "oauth_token")], "oauth_token"
 }
 
+func TestAddAPIHostRewriter(t *testing.T) {
+	t.Run("rewrites host when resolver returns a value", func(t *testing.T) {
+		var gotHost, gotReqHost string
+		inner := &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+			gotHost = req.URL.Host
+			gotReqHost = req.Host
+			return &http.Response{StatusCode: 200}, nil
+		}}
+		resolver := func(hostname string) (string, error) {
+			if hostname == "example.ghe.com" {
+				return "api-gateway.example.net", nil
+			}
+			return "", nil
+		}
+		rt := addAPIHostRewriter(inner, resolver)
+		req, _ := http.NewRequest("GET", "https://example.ghe.com/api/v3/user", nil)
+		_, _ = rt.RoundTrip(req)
+		assert.Equal(t, "api-gateway.example.net", gotHost)
+		assert.Equal(t, "example.ghe.com", gotReqHost, "req.Host should preserve original for Host header")
+		assert.Equal(t, "example.ghe.com", req.URL.Host, "original request must not be mutated")
+	})
+
+	t.Run("passes through when resolver returns empty", func(t *testing.T) {
+		var gotHost string
+		inner := &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+			gotHost = req.URL.Host
+			return &http.Response{StatusCode: 200}, nil
+		}}
+		rt := addAPIHostRewriter(inner, func(string) (string, error) { return "", nil })
+		req, _ := http.NewRequest("GET", "https://github.com/api/v3/user", nil)
+		_, _ = rt.RoundTrip(req)
+		assert.Equal(t, "github.com", gotHost)
+	})
+
+	t.Run("returns error when resolver returns error", func(t *testing.T) {
+		inner := &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+			t.Fatal("inner transport should not be called")
+			return nil, nil
+		}}
+		rt := addAPIHostRewriter(inner, func(string) (string, error) {
+			return "", fmt.Errorf("invalid api_host value")
+		})
+		req, _ := http.NewRequest("GET", "https://example.ghe.com/api/v3/user", nil)
+		_, err := rt.RoundTrip(req)
+		assert.EqualError(t, err, "invalid api_host value")
+	})
+
+	t.Run("auth sees original host when stacked correctly", func(t *testing.T) {
+		var wireHost, wireAuthHeader string
+		base := &funcTripper{roundTrip: func(req *http.Request) (*http.Response, error) {
+			wireHost = req.URL.Host
+			wireAuthHeader = req.Header.Get("Authorization")
+			return &http.Response{StatusCode: 200}, nil
+		}}
+		rewriter := addAPIHostRewriter(base, func(h string) (string, error) {
+			if h == "example.ghe.com" {
+				return "api-gateway.example.net", nil
+			}
+			return "", nil
+		})
+		cfg := tinyConfig{"example.ghe.com:oauth_token": "test-token"}
+		authed := AddAuthTokenHeader(rewriter, cfg)
+
+		req, _ := http.NewRequest("GET", "https://example.ghe.com/api/v3/user", nil)
+		_, _ = authed.RoundTrip(req)
+
+		assert.Equal(t, "api-gateway.example.net", wireHost, "request should be sent to api_host")
+		assert.Equal(t, "example.ghe.com", req.URL.Host, "original request should not be mutated")
+		assert.Equal(t, "token test-token", wireAuthHeader, "auth header should be set using original host credentials")
+	})
+}
+
 var requestAtRE = regexp.MustCompile(`(?m)^\* Request at .+`)
 var dateRE = regexp.MustCompile(`(?m)^< Date: .+`)
 var hostWithPortRE = regexp.MustCompile(`127\.0\.0\.1:\d+`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/keyring"
@@ -20,6 +21,7 @@ const (
 	accessibleColorsKey   = "accessible_colors" // used by cli/go-gh to enable the use of customizable, accessible 4-bit colors.
 	accessiblePrompterKey = "accessible_prompter"
 	aliasesKey            = "aliases"
+	apiHostKey            = "api_host"
 	browserKey            = "browser" // used by cli/go-gh to open URLs in web browsers
 	colorLabelsKey        = "color_labels"
 	editorKey             = "editor" // used by cli/go-gh to open interactive text editor
@@ -123,6 +125,14 @@ func (c *cfg) AccessibleColors(hostname string) gh.ConfigEntry {
 func (c *cfg) AccessiblePrompter(hostname string) gh.ConfigEntry {
 	// Intentionally panic if there is no user provided value or default value (which would be a programmer error)
 	return c.GetOrDefault(hostname, accessiblePrompterKey).Unwrap()
+}
+
+func (c *cfg) APIHost(hostname string) string {
+	val, err := c.cfg.Get([]string{hostsKey, hostname, apiHostKey})
+	if err == nil {
+		return val
+	}
+	return ""
 }
 
 func (c *cfg) Browser(hostname string) gh.ConfigEntry {
@@ -719,4 +729,25 @@ func DataDir() string {
 
 func ConfigDir() string {
 	return ghConfig.ConfigDir()
+}
+
+// ResolveAPIHost returns the effective api_host override for a hostname.
+// It checks the GH_API_HOST_* environment variable first, then falls back
+// to the api_host key in hosts.yml. Returns "" when no override is configured.
+func ResolveAPIHost(cfg gh.Config, hostname string) string {
+	if v := os.Getenv("GH_API_HOST_" + EncodeHostnameForEnv(hostname)); v != "" {
+		return v
+	}
+	return cfg.APIHost(hostname)
+}
+
+// EncodeHostnameForEnv encodes a hostname for use in environment variable
+// names. Dots become single underscores and hyphens become double underscores.
+// The hostname portion is kept lowercase, matching the Terraform TF_TOKEN_*
+// convention.
+func EncodeHostnameForEnv(hostname string) string {
+	h := strings.ToLower(hostname)
+	h = strings.ReplaceAll(h, "-", "__")
+	h = strings.ReplaceAll(h, ".", "_")
+	return h
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -183,6 +183,19 @@ func TestSetUserSpecificKeyNoUserPresent(t *testing.T) {
 	requireNoKey(t, c.cfg, []string{hostsKey, host, usersKey})
 }
 
+func TestAPIHost(t *testing.T) {
+	t.Run("returns empty when not configured", func(t *testing.T) {
+		cfg := newTestConfig()
+		require.Equal(t, "", cfg.APIHost("github.com"))
+	})
+
+	t.Run("returns configured value for host", func(t *testing.T) {
+		cfg := newTestConfig()
+		cfg.Set("example.ghe.com", apiHostKey, "api-gateway.example.net")
+		require.Equal(t, "api-gateway.example.net", cfg.APIHost("example.ghe.com"))
+	})
+}
+
 func TestTelemetry(t *testing.T) {
 	t.Run("returns default when not configured", func(t *testing.T) {
 		c := newTestConfig()

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -58,6 +58,9 @@ func NewFromString(cfgStr string) *ghmock.ConfigMock {
 	mock.AccessiblePrompterFunc = func(hostname string) gh.ConfigEntry {
 		return cfg.AccessiblePrompter(hostname)
 	}
+	mock.APIHostFunc = func(hostname string) string {
+		return cfg.APIHost(hostname)
+	}
 	mock.BrowserFunc = func(hostname string) gh.ConfigEntry {
 		return cfg.Browser(hostname)
 	}

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -39,6 +39,8 @@ type Config interface {
 	AccessibleColors(hostname string) ConfigEntry
 	// AccessiblePrompter returns the configured accessible_prompter setting, optionally scoped by host.
 	AccessiblePrompter(hostname string) ConfigEntry
+	// APIHost returns the configured api_host override for a given hostname, or empty if not set.
+	APIHost(hostname string) string
 	// Browser returns the configured browser, optionally scoped by host.
 	Browser(hostname string) ConfigEntry
 	// ColorLabels returns the configured color_label setting, optionally scoped by host.

--- a/internal/gh/mock/config.go
+++ b/internal/gh/mock/config.go
@@ -20,6 +20,9 @@ var _ gh.Config = &ConfigMock{}
 //
 //		// make and configure a mocked gh.Config
 //		mockedConfig := &ConfigMock{
+//			APIHostFunc: func(hostname string) string {
+//				panic("mock out the APIHost method")
+//			},
 //			AccessibleColorsFunc: func(hostname string) gh.ConfigEntry {
 //				panic("mock out the AccessibleColors method")
 //			},
@@ -87,6 +90,9 @@ var _ gh.Config = &ConfigMock{}
 //
 //	}
 type ConfigMock struct {
+	// APIHostFunc mocks the APIHost method.
+	APIHostFunc func(hostname string) string
+
 	// AccessibleColorsFunc mocks the AccessibleColors method.
 	AccessibleColorsFunc func(hostname string) gh.ConfigEntry
 
@@ -149,6 +155,11 @@ type ConfigMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// APIHost holds details about calls to the APIHost method.
+		APIHost []struct {
+			// Hostname is the hostname argument value.
+			Hostname string
+		}
 		// AccessibleColors holds details about calls to the AccessibleColors method.
 		AccessibleColors []struct {
 			// Hostname is the hostname argument value.
@@ -244,6 +255,7 @@ type ConfigMock struct {
 		Write []struct {
 		}
 	}
+	lockAPIHost            sync.RWMutex
 	lockAccessibleColors   sync.RWMutex
 	lockAccessiblePrompter sync.RWMutex
 	lockAliases            sync.RWMutex
@@ -264,6 +276,38 @@ type ConfigMock struct {
 	lockTelemetry          sync.RWMutex
 	lockVersion            sync.RWMutex
 	lockWrite              sync.RWMutex
+}
+
+// APIHost calls APIHostFunc.
+func (mock *ConfigMock) APIHost(hostname string) string {
+	if mock.APIHostFunc == nil {
+		panic("ConfigMock.APIHostFunc: method is nil but Config.APIHost was just called")
+	}
+	callInfo := struct {
+		Hostname string
+	}{
+		Hostname: hostname,
+	}
+	mock.lockAPIHost.Lock()
+	mock.calls.APIHost = append(mock.calls.APIHost, callInfo)
+	mock.lockAPIHost.Unlock()
+	return mock.APIHostFunc(hostname)
+}
+
+// APIHostCalls gets all the calls that were made to APIHost.
+// Check the length with:
+//
+//	len(mockedConfig.APIHostCalls())
+func (mock *ConfigMock) APIHostCalls() []struct {
+	Hostname string
+} {
+	var calls []struct {
+		Hostname string
+	}
+	mock.lockAPIHost.RLock()
+	calls = mock.calls.APIHost
+	mock.lockAPIHost.RUnlock()
+	return calls
 }
 
 // AccessibleColors calls AccessibleColorsFunc.

--- a/internal/ghcmd/cmd.go
+++ b/internal/ghcmd/cmd.go
@@ -306,6 +306,20 @@ func authRecoveryCommand(cfg gh.Config, httpErr api.HTTPError) string {
 	}
 
 	hostname := ghauth.NormalizeHostname(httpErr.RequestURL.Hostname())
+
+	// The request URL may carry the rewritten api_host rather than the
+	// original host where credentials are stored. Reverse-map it so that
+	// the suggested auth command targets the right host.
+	for _, host := range cfg.Authentication().Hosts() {
+		if strings.EqualFold(host, hostname) {
+			break
+		}
+		if strings.EqualFold(config.ResolveAPIHost(cfg, host), hostname) {
+			hostname = host
+			break
+		}
+	}
+
 	token, source := cfg.Authentication().ActiveToken(hostname)
 	if shared.AuthTokenRefreshable(token, source) {
 		return fmt.Sprintf("gh auth refresh -h %s", hostname)

--- a/internal/ghcmd/cmd_test.go
+++ b/internal/ghcmd/cmd_test.go
@@ -561,6 +561,9 @@ func Test_authRecoveryCommand(t *testing.T) {
 				AuthenticationFunc: func() gh.AuthConfig {
 					return authCfg
 				},
+				APIHostFunc: func(hostname string) string {
+					return ""
+				},
 			}
 
 			var requestURL *url.URL
@@ -585,4 +588,33 @@ func Test_authRecoveryCommand(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_authRecoveryCommand_apiHostReverseMapping(t *testing.T) {
+	authCfg := config.NewBlankConfig().Authentication()
+	authCfg.SetActiveToken("github_pat_abc123", "oauth_token")
+	authCfg.SetHosts([]string{"example.ghe.com"})
+
+	cfg := &ghmock.ConfigMock{
+		AuthenticationFunc: func() gh.AuthConfig {
+			return authCfg
+		},
+		APIHostFunc: func(hostname string) string {
+			if hostname == "example.ghe.com" {
+				return "api-gateway.example.net"
+			}
+			return ""
+		},
+	}
+
+	requestURL, _ := url.Parse("https://api-gateway.example.net/api/v3/user")
+	httpErr := api.HTTPError{
+		HTTPError: &ghAPI.HTTPError{
+			RequestURL: requestURL,
+			StatusCode: 401,
+		},
+	}
+
+	got := authRecoveryCommand(cfg, httpErr)
+	assert.Equal(t, "gh auth login -h example.ghe.com", got)
 }

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -37,6 +37,7 @@ type authEntry struct {
 	Token       string         `json:"token,omitempty"`
 	Scopes      string         `json:"scopes,omitempty"`
 	GitProtocol string         `json:"gitProtocol"`
+	APIHost     string         `json:"apiHost,omitempty"`
 }
 
 type authStatus struct {
@@ -112,6 +113,10 @@ func (e authEntry) String(cs *iostreams.ColorScheme) string {
 		}
 		activeStr := fmt.Sprintf("%v", e.Active)
 		sb.WriteString(fmt.Sprintf("  - Active account: %s\n", cs.Bold(activeStr)))
+	}
+
+	if e.APIHost != "" {
+		sb.WriteString(fmt.Sprintf("  - API host override: %s\n", cs.Bold(e.APIHost)))
 	}
 
 	return sb.String()
@@ -236,6 +241,8 @@ func statusRun(opts *StatusOptions) error {
 			continue
 		}
 
+		apiHost := config.ResolveAPIHost(cfg, hostname)
+
 		var activeUser string
 		gitProtocol := cfg.GitProtocol(hostname).Value
 		activeUserToken, activeUserTokenSource := authCfg.ActiveToken(hostname)
@@ -250,6 +257,7 @@ func statusRun(opts *StatusOptions) error {
 			tokenSource: activeUserTokenSource,
 			username:    activeUser,
 		})
+		entry.APIHost = apiHost
 		statuses.Hosts[hostname] = append(statuses.Hosts[hostname], entry)
 
 		if finalErr == nil && entry.State != authEntryStateSuccess {
@@ -274,6 +282,7 @@ func statusRun(opts *StatusOptions) error {
 				tokenSource: tokenSource,
 				username:    username,
 			})
+			entry.APIHost = apiHost
 			statuses.Hosts[hostname] = append(statuses.Hosts[hostname], entry)
 
 			if finalErr == nil && entry.State != authEntryStateSuccess {

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -360,6 +360,26 @@ func Test_statusRun(t *testing.T) {
 			`),
 		},
 		{
+			name: "api_host configured",
+			opts: StatusOptions{},
+			cfgStubs: func(t *testing.T, c gh.Config) {
+				login(t, c, "ghe.io", "pete", "gho_abc123", "https")
+				c.Set("ghe.io", "api_host", "api-gateway.example.net")
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", "api/v3/"), httpmock.ScopesResponder("repo,read:org"))
+			},
+			wantOut: heredoc.Doc(`
+				ghe.io
+				  ✓ Logged in to ghe.io account pete (GH_CONFIG_DIR/hosts.yml)
+				  - Active account: true
+				  - Git operations protocol: https
+				  - Token: gho_******
+				  - Token scopes: 'repo', 'read:org'
+				  - API host override: api-gateway.example.net
+			`),
+		},
+		{
 			name: "missing hostname",
 			opts: StatusOptions{
 				Hostname: "github.example.com",

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -11,13 +11,16 @@ import (
 	ghContext "github.com/cli/cli/v2/context"
 	"github.com/cli/cli/v2/git"
 	"github.com/cli/cli/v2/internal/browser"
+	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
 	"github.com/cli/cli/v2/internal/gh/ghtelemetry"
+	"github.com/cli/cli/v2/internal/ghinstance"
 	"github.com/cli/cli/v2/internal/ghrepo"
 	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmd/extension"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
+	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 )
 
 var ssoHeader string
@@ -191,6 +194,15 @@ func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams,
 		if err != nil {
 			return nil, err
 		}
+		lookupAPIHost := func(hostname string) (string, error) {
+			v := config.ResolveAPIHost(cfg, hostname)
+			if v != "" {
+				if err := ghinstance.HostnameValidator(v); err != nil {
+					return "", fmt.Errorf("invalid api_host for %s: %q (%w)", hostname, v, err)
+				}
+			}
+			return v, nil
+		}
 		opts := api.HTTPClientOptions{
 			Config:            cfg.Authentication(),
 			Log:               ios.ErrOut,
@@ -198,6 +210,15 @@ func HttpClientFunc(cfgFunc func() (gh.Config, error), ios *iostreams.IOStreams,
 			AppVersion:        appVersion,
 			InvokingAgent:     invokingAgent,
 			TelemetryDisabler: telemetryDisabler,
+			APIHostResolver: func(hostname string) (string, error) {
+				if v, err := lookupAPIHost(hostname); v != "" || err != nil {
+					return v, err
+				}
+				if normalized := ghauth.NormalizeHostname(hostname); normalized != hostname {
+					return lookupAPIHost(normalized)
+				}
+				return "", nil
+			},
 		}
 		client, err := api.NewHTTPClient(opts)
 		if err != nil {

--- a/pkg/cmd/factory/default_test.go
+++ b/pkg/cmd/factory/default_test.go
@@ -438,6 +438,22 @@ func TestNewGitClient(t *testing.T) {
 	}
 }
 
+func TestEncodeHostnameForEnv(t *testing.T) {
+	tests := []struct {
+		hostname string
+		want     string
+	}{
+		{"github.com", "github_com"},
+		{"ghes.example.com", "ghes_example_com"},
+		{"git.corp-internal.io", "git_corp__internal_io"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.hostname, func(t *testing.T) {
+			assert.Equal(t, tt.want, config.EncodeHostnameForEnv(tt.hostname))
+		})
+	}
+}
+
 func defaultConfig() *ghmock.ConfigMock {
 	cfg := config.NewFromString("")
 	cfg.Set("nonsense.com", "oauth_token", "BLAH")

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -54,6 +54,12 @@ var HelpTopics = []helpTopic{
 			authenticated with, the stored credentials will be used. Otherwise, setting %[1]sGH_TOKEN%[1]s or
 			%[1]sGH_ENTERPRISE_TOKEN%[1]s is required, depending on the targeted host.
 
+			%[1]sGH_API_HOST_<host>%[1]s: override the API endpoint for a specific host. The %[1]s<host>%[1]s suffix is
+			the hostname in lowercase, with dots replaced by %[1]s_%[1]s and hyphens by %[1]s__%[1]s. For example,
+			%[1]sGH_API_HOST_example_ghe_com=api-gateway.example.net%[1]s routes API traffic for
+			%[1]sexample.ghe.com%[1]s through the gateway. This is useful for API gateways, reverse proxies,
+			or GHEC data-residency tenants. The equivalent %[1]shosts.yml%[1]s setting is %[1]sapi_host%[1]s.
+
 			%[1]sGH_REPO%[1]s: specify the GitHub repository in the %[1]s[HOST/]OWNER/REPO%[1]s format for commands
 			that otherwise operate on a local repository.
 


### PR DESCRIPTION
Allow routing API traffic to a different endpoint per host, via the `api_host` key in hosts.yml or the `GH_API_HOST_<host>` environment variable. This supports API gateways, reverse proxies, and GHEC data-residency tenants where the organization has no control over the api.* hostname.

The implementation uses an HTTP transport-layer rewriter that swaps the request destination while preserving the original hostname for TLS SNI, the Host header, and — critically — token resolution. The transport stacking order (auth → rewriter → base) ensures auth always sees the original hostname, so credentials are looked up correctly before the request is routed to the gateway.

The resolver also handles the api.* prefix that go-gh prepends to github.com and *.ghe.com hostnames when constructing API URLs, so a user-level config for example.ghe.com correctly matches requests addressed to api.example.ghe.com.

Other approaches tried and abandoned:
- Modifying ghinstance URL construction (RESTPrefix/GraphQLEndpoint) — go-gh reconstructs URLs independently, so changes don't propagate
- Patching AuthConfig.ActiveToken with reverse api_host lookup — requires changes at every auth call site and breaks encapsulation
- Wrapping the go-gh HTTP client at the api.Client level — too late in the chain, misses direct http.Client usage

Fixes #13717
