### PR TITLE
fix(skills): honor --dir without agent prompt

### DIFF
--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -915,6 +915,8 @@ func resolveHosts(opts *InstallOptions, canPrompt bool) ([]*registry.AgentHost, 
 		return []*registry.AgentHost{h}, nil
 	}
 
+	// --dir fixes the destination in resolveInstallDir regardless of the agent host,
+	// which then only affects post-install hint output; the default is a safe placeholder.
 	if opts.Dir != "" {
 		h, err := registry.FindByID(registry.DefaultAgentID)
 		if err != nil {

--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -915,6 +915,14 @@ func resolveHosts(opts *InstallOptions, canPrompt bool) ([]*registry.AgentHost, 
 		return []*registry.AgentHost{h}, nil
 	}
 
+	if opts.Dir != "" {
+		h, err := registry.FindByID(registry.DefaultAgentID)
+		if err != nil {
+			return nil, err
+		}
+		return []*registry.AgentHost{h}, nil
+	}
+
 	if !canPrompt {
 		h, err := registry.FindByID(registry.DefaultAgentID)
 		if err != nil {

--- a/pkg/cmd/skills/install/install_test.go
+++ b/pkg/cmd/skills/install/install_test.go
@@ -474,6 +474,30 @@ func TestInstallRun(t *testing.T) {
 			wantStdout: "Installed git-commit",
 		},
 		{
+			name:  "remote install with --dir bypasses agent selection",
+			isTTY: true,
+			stubs: func(reg *httpmock.Registry) {
+				stubResolveVersion(reg, "monalisa", "skills-repo", "v1.0.0", "abc123")
+				stubDiscoverTree(reg, "monalisa", "skills-repo", "abc123",
+					singleSkillTreeJSON("git-commit", "treeSHA", "blobSHA"))
+				stubInstallFiles(reg, "monalisa", "skills-repo", "treeSHA", "blobSHA", gitCommitContent)
+			},
+			opts: func(ios *iostreams.IOStreams, reg *httpmock.Registry) *InstallOptions {
+				t.Helper()
+				return &InstallOptions{
+					IO:          ios,
+					HttpClient:  func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+					GitClient:   &git.Client{RepoDir: t.TempDir()},
+					Prompter:    &prompter.PrompterMock{},
+					SkillSource: "monalisa/skills-repo",
+					SkillName:   "git-commit",
+					Scope:       "project",
+					Dir:         t.TempDir(),
+				}
+			},
+			wantStdout: "Installed git-commit",
+		},
+		{
 			name:  "remote install with --force overwrites existing skill",
 			isTTY: true,
 			stubs: func(reg *httpmock.Registry) {


### PR DESCRIPTION
## Summary
- skip the target-agent prompt when `gh skill install` is given `--dir`
- keep using the default agent host internally only for shared post-install messaging / telemetry
- add regression coverage for the interactive `--dir` path

Fixes #13763.

## Testing
- not run locally (avoided local Go test/build in this environment)