### PR TITLE
fix: preserve percent-encoded path in DisplayURL

### DIFF
--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -77,7 +77,12 @@ func DisplayURL(urlStr string) string {
 	if scheme == "" {
 		scheme = "https"
 	}
-	return scheme + "://" + u.Hostname() + u.Path
+	path := u.Path
+	// Preserve percent-encoding from the original URL path
+	if u.RawPath != "" {
+		path = u.RawPath
+	}
+	return scheme + "://" + u.Hostname() + path
 }
 
 // RemoveDiacritics returns the input value without "diacritics", or accent marks


### PR DESCRIPTION
## Summary

Fixes #13546

`DisplayURL` was using `u.Path` which is the unescaped version of the URL path. This caused branch names with special characters (like quotes) to be displayed incorrectly in the terminal when using `gh pr create --web`.

For example, a branch named `test-"quoted"-branch-pr` would display as:

```
https://github.com/OWNER/REPO/compare/...test-"quoted"-branch-pr
```

Instead of the correct:

```
https://github.com/OWNER/REPO/compare/...test-%22quoted%22-branch-pr
```

## Changes

Uses `u.RawPath` (when available) instead of `u.Path` to preserve the original percent-encoding from the URL.