### PR TITLE
Fix --reviewer regression with "@org/team" team slugs

### DIFF
--- a/pkg/cmd/pr/shared/params.go
+++ b/pkg/cmd/pr/shared/params.go
@@ -133,7 +133,9 @@ func AddMetadataToIssueParams(client *api.Client, baseRepo ghrepo.Interface, par
 	var teamReviewers []string
 	for _, r := range tb.Reviewers {
 		if strings.ContainsRune(r, '/') {
-			teamReviewers = append(teamReviewers, r)
+			// Team slugs are canonical as "org/team"; tolerate a leading "@"
+			// (e.g. "@org/team") for backwards compatibility. See #13060.
+			teamReviewers = append(teamReviewers, strings.TrimPrefix(r, "@"))
 		} else if r == api.CopilotReviewerLogin {
 			botReviewers = append(botReviewers, r)
 		} else {

--- a/pkg/cmd/pr/shared/params_test.go
+++ b/pkg/cmd/pr/shared/params_test.go
@@ -624,3 +624,20 @@ func TestWithPrAndIssueQueryParamsProjectsV1Deprecation(t *testing.T) {
 		)
 	})
 }
+
+func TestAddMetadataToIssueParams_stripsAtPrefixFromTeamReviewerSlugs(t *testing.T) {
+	// Regression test for #13060: a team reviewer passed with a leading "@"
+	// (e.g. "@org/team") must reach requestReviewsByLogin as "org/team".
+	tb := &IssueMetadataState{
+		ApiActorsSupported: true,
+		Reviewers:          []string{"@myorg/my-team", "octocat", "otherorg/other-team"},
+		MetadataResult:     &api.RepoMetadataResult{},
+	}
+	params := map[string]interface{}{}
+
+	err := AddMetadataToIssueParams(nil, ghrepo.New("OWNER", "REPO"), params, tb, gh.ProjectsV1Supported)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"myorg/my-team", "otherorg/other-team"}, params["teamReviewerSlugs"])
+	assert.Equal(t, []string{"octocat"}, params["userReviewerLogins"])
+}


### PR DESCRIPTION
Fixes #13060.

### Summary

Since the switch to login-based reviewer requests (#12627), a team reviewer passed with a leading `@` (e.g. `gh pr create --reviewer "@org/team"`) is forwarded verbatim to the `requestReviewsByLogin` mutation as `teamSlugs: ["@org/team"]`, which GitHub cannot resolve:

```
GraphQL: Could not resolve team with slug '@org/team'. (requestReviewsByLogin)
```

Before v2.88.0 the `@` prefix was tolerated, so this is a regression; some CI setups broke when Actions picked up the newer CLI.

### Fix

In `AddMetadataToIssueParams` (`pkg/cmd/pr/shared/params.go`), strip a leading `@` when building team reviewer slugs, so the canonical `org/team` form is sent. Team slugs always contain `/`, so this only affects team reviewers — user and bot handling is unchanged.

### Test

Added a regression test asserting that `--reviewer "@org/team"` yields `teamReviewerSlugs: ["org/team"]` (and that a non-prefixed team slug and a user login are unaffected). It fails before the change (producing `"@org/team"`) and passes after. `go test ./pkg/cmd/pr/shared/`, `gofmt`, and `go vet` are clean.
