### PR TITLE
fix: honor --pin flag when upgrading extensions with --force

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -379,15 +379,19 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					if ext, err := checkValidExtension(cmd.Root(), m, repo.RepoName(), repo.RepoOwner()); err != nil {
 						// If an existing extension was found and --force was specified, attempt to upgrade.
 						if forceFlag && ext != nil {
-							return upgradeFunc(ext.Name(), forceFlag)
+							if pinFlag == "" {
+								return upgradeFunc(ext.Name(), forceFlag)
+							}
+							if err := m.Remove(ext.Name()); err != nil {
+								return err
+							}
+						} else {
+							if errors.Is(err, alreadyInstalledError) {
+								fmt.Fprintf(io.ErrOut, "%s Extension %s is already installed\n", cs.WarningIcon(), ghrepo.FullName(repo))
+								return nil
+							}
+							return err
 						}
-
-						if errors.Is(err, alreadyInstalledError) {
-							fmt.Fprintf(io.ErrOut, "%s Extension %s is already installed\n", cs.WarningIcon(), ghrepo.FullName(repo))
-							return nil
-						}
-
-						return err
 					}
 
 					io.StartProgressIndicator()


### PR DESCRIPTION
Fixes #13551

### Description
When an extension is already installed, running `gh extension install OWNER/REPO --pin <tag> --force` routes through the upgrade logic and ignores the pin flag, resulting in the installation of the latest version instead of the pinned version.

This PR fixes this by explicitly checking if a pin flag was specified when attempting to upgrade an existing extension. If it is pinned, the command removes the existing version and proceeds to install the pinned version.

### Testing
Reproduced with:
```sh
$ gh extension install github/gh-aw --pin v0.74.8
$ gh extension list
gh aw	github/gh-aw	v0.74.8

$ gh extension install github/gh-aw --pin v0.75.0 --force
$ gh extension list
gh aw	github/gh-aw	v0.75.0
```
