### PR TITLE
pr view: paginate files and commits

### DIFF
--- a/api/queries_pr.go
+++ b/api/queries_pr.go
@@ -55,7 +55,11 @@ type PullRequest struct {
 	PotentialMergeCommit *Commit
 
 	Files struct {
-		Nodes []PullRequestFile
+		Nodes    []PullRequestFile
+		PageInfo struct {
+			HasNextPage bool
+			EndCursor   string
+		}
 	}
 
 	Author              Author
@@ -79,6 +83,10 @@ type PullRequest struct {
 	Commits struct {
 		TotalCount int
 		Nodes      []PullRequestCommit
+		PageInfo   struct {
+			HasNextPage bool
+			EndCursor   string
+		}
 	}
 	StatusCheckRollup struct {
 		Nodes []StatusCheckRollupNode

--- a/api/query_builder.go
+++ b/api/query_builder.go
@@ -151,6 +151,7 @@ var prFiles = shortenQuery(`
 			path,
 			changeType
 		}
+		pageInfo{hasNextPage,endCursor}
 	}
 `)
 
@@ -172,6 +173,7 @@ var prCommits = shortenQuery(`
 				authoredDate
 			}
 		}
+		pageInfo{hasNextPage,endCursor}
 	}
 `)
 

--- a/api/query_builder_test.go
+++ b/api/query_builder_test.go
@@ -26,7 +26,7 @@ func TestPullRequestGraphQL(t *testing.T) {
 		{
 			name:   "compressed query",
 			fields: []string{"files"},
-			want:   "files(first: 100) {nodes {additions,deletions,path,changeType}}",
+			want:   "files(first: 100) {nodes {additions,deletions,path,changeType}pageInfo{hasNextPage,endCursor}}",
 		},
 		{
 			name:   "invalid fields",
@@ -72,7 +72,7 @@ func TestIssueGraphQL(t *testing.T) {
 		{
 			name:   "compressed query",
 			fields: []string{"files"},
-			want:   "files(first: 100) {nodes {additions,deletions,path,changeType}}",
+			want:   "files(first: 100) {nodes {additions,deletions,path,changeType}pageInfo{hasNextPage,endCursor}}",
 		},
 		{
 			name:   "projectItems",

--- a/pkg/cmd/pr/shared/finder.go
+++ b/pkg/cmd/pr/shared/finder.go
@@ -284,6 +284,16 @@ func (f *finder) Find(opts FindOptions) (*api.PullRequest, ghrepo.Interface, err
 			return preloadPrChecks(httpClient, f.baseRefRepo, pr)
 		})
 	}
+	if fields.Contains("files") {
+		g.Go(func() error {
+			return preloadPrFiles(httpClient, f.baseRefRepo, pr)
+		})
+	}
+	if fields.Contains("commits") {
+		g.Go(func() error {
+			return preloadPrCommits(httpClient, f.baseRefRepo, pr)
+		})
+	}
 	if getProjectItems {
 		g.Go(func() error {
 			apiClient := api.NewClientFromHTTP(httpClient)
@@ -610,6 +620,96 @@ func preloadPrChecks(client *http.Client, repo ghrepo.Interface, pr *api.PullReq
 	}
 
 	statusCheckRollup.PageInfo.HasNextPage = false
+	return nil
+}
+
+func preloadPrFiles(client *http.Client, repo ghrepo.Interface, pr *api.PullRequest) error {
+	if !pr.Files.PageInfo.HasNextPage {
+		return nil
+	}
+
+	type response struct {
+		Node struct {
+			PullRequest struct {
+				Files struct {
+					Nodes []api.PullRequestFile
+					PageInfo struct {
+						HasNextPage bool
+						EndCursor   string
+					}
+				} `graphql:"files(first: 100, after: $endCursor)"`
+			} `graphql:"...on PullRequest"`
+		} `graphql:"node(id: $id)"`
+	}
+
+	variables := map[string]interface{}{
+		"id":        githubv4.ID(pr.ID),
+		"endCursor": githubv4.String(pr.Files.PageInfo.EndCursor),
+	}
+
+	gql := api.NewClientFromHTTP(client)
+
+	for {
+		var query response
+		err := gql.Query(repo.RepoHost(), "FilesForPullRequest", &query, variables)
+		if err != nil {
+			return err
+		}
+
+		pr.Files.Nodes = append(pr.Files.Nodes, query.Node.PullRequest.Files.Nodes...)
+
+		if !query.Node.PullRequest.Files.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Node.PullRequest.Files.PageInfo.EndCursor)
+	}
+
+	pr.Files.PageInfo.HasNextPage = false
+	return nil
+}
+
+func preloadPrCommits(client *http.Client, repo ghrepo.Interface, pr *api.PullRequest) error {
+	if !pr.Commits.PageInfo.HasNextPage {
+		return nil
+	}
+
+	type response struct {
+		Node struct {
+			PullRequest struct {
+				Commits struct {
+					Nodes []api.PullRequestCommit
+					PageInfo struct {
+						HasNextPage bool
+						EndCursor   string
+					}
+				} `graphql:"commits(first: 100, after: $endCursor)"`
+			} `graphql:"...on PullRequest"`
+		} `graphql:"node(id: $id)"`
+	}
+
+	variables := map[string]interface{}{
+		"id":        githubv4.ID(pr.ID),
+		"endCursor": githubv4.String(pr.Commits.PageInfo.EndCursor),
+	}
+
+	gql := api.NewClientFromHTTP(client)
+
+	for {
+		var query response
+		err := gql.Query(repo.RepoHost(), "CommitsForPullRequest", &query, variables)
+		if err != nil {
+			return err
+		}
+
+		pr.Commits.Nodes = append(pr.Commits.Nodes, query.Node.PullRequest.Commits.Nodes...)
+
+		if !query.Node.PullRequest.Commits.PageInfo.HasNextPage {
+			break
+		}
+		variables["endCursor"] = githubv4.String(query.Node.PullRequest.Commits.PageInfo.EndCursor)
+	}
+
+	pr.Commits.PageInfo.HasNextPage = false
 	return nil
 }
 

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -90,8 +90,8 @@ const (
 
 // doQueryWithProgressIndicator wraps API calls with a progress indicator.
 // The query name is used in the progress indicator label.
-func (c *Client) doQueryWithProgressIndicator(name string, query interface{}, variables map[string]interface{}) error {
-	c.io.StartProgressIndicatorWithLabel(fmt.Sprintf("Fetching %s", name))
+func (c *Client) doQueryWithProgressIndicator(indicatorMsg string, name string, query interface{}, variables map[string]interface{}) error {
+	c.io.StartProgressIndicatorWithLabel(fmt.Sprintf("Fetching %s", indicatorMsg))
 	defer c.io.StopProgressIndicator()
 	err := c.apiClient.Query(name, query, variables)
 	return handleError(err)
@@ -705,7 +705,7 @@ func (c *Client) ProjectItems(o *Owner, number int32, limit int, queryStr string
 		}
 		queryName = "ViewerProjectWithItems"
 	}
-	err := c.doQueryWithProgressIndicator(queryName, query, variables)
+	err := c.doQueryWithProgressIndicator("draft issue", queryName, query, variables)
 	if err != nil {
 		return project, err
 	}
@@ -910,7 +910,7 @@ func paginateAttributes[N projectAttribute](c *Client, p pager[N], variables map
 
 		// set the cursor to the end of the last page
 		variables[afterKey] = (*githubv4.String)(&cursor)
-		err := c.doQueryWithProgressIndicator(queryName, p, variables)
+		err := c.doQueryWithProgressIndicator("project items", queryName, p, variables)
 		if err != nil {
 			return nodes, err
 		}
@@ -1067,7 +1067,7 @@ func (c *Client) ProjectFields(o *Owner, number int32, limit int) (*Project, err
 		query = &viewerOwnerWithFields{}
 		queryName = "ViewerProjectWithFields"
 	}
-	err := c.doQueryWithProgressIndicator(queryName, query, variables)
+	err := c.doQueryWithProgressIndicator("item fields", queryName, query, variables)
 	if err != nil {
 		return project, err
 	}
@@ -1188,7 +1188,7 @@ const ViewerOwner OwnerType = "VIEWER"
 // ViewerLoginName returns the login name of the viewer.
 func (c *Client) ViewerLoginName() (string, error) {
 	var query viewerLogin
-	err := c.doQueryWithProgressIndicator("Viewer", &query, map[string]interface{}{})
+	err := c.doQueryWithProgressIndicator("owner", "Viewer", &query, map[string]interface{}{})
 	if err != nil {
 		return "", err
 	}
@@ -1199,7 +1199,7 @@ func (c *Client) ViewerLoginName() (string, error) {
 func (c *Client) OwnerIDAndType(login string) (string, OwnerType, error) {
 	if login == "@me" || login == "" {
 		var query viewerLogin
-		err := c.doQueryWithProgressIndicator("ViewerOwner", &query, nil)
+		err := c.doQueryWithProgressIndicator("owner", "ViewerOwner", &query, nil)
 		if err != nil {
 			return "", "", err
 		}
@@ -1220,7 +1220,7 @@ func (c *Client) OwnerIDAndType(login string) (string, OwnerType, error) {
 		} `graphql:"organization(login: $login)"`
 	}
 
-	err := c.doQueryWithProgressIndicator("UserOrgOwner", &query, variables)
+	err := c.doQueryWithProgressIndicator("owner", "UserOrgOwner", &query, variables)
 	if err != nil {
 		// Due to the way the queries are structured, we don't know if a login belongs to a user
 		// or to an org, even though they are unique. To deal with this, we try both - if neither
@@ -1263,7 +1263,7 @@ func (c *Client) IssueOrPullRequestID(rawURL string) (string, error) {
 		"url": githubv4.URI{URL: uri},
 	}
 	var query issueOrPullRequest
-	err = c.doQueryWithProgressIndicator("GetIssueOrPullRequest", &query, variables)
+	err = c.doQueryWithProgressIndicator("issue or pull request", "GetIssueOrPullRequest", &query, variables)
 	if err != nil {
 		return "", err
 	}
@@ -1325,7 +1325,7 @@ func (c *Client) userOrgLogins() ([]loginTypes, error) {
 		"after": (*githubv4.String)(nil),
 	}
 
-	err := c.doQueryWithProgressIndicator("ViewerLoginAndOrgs", &v, variables)
+	err := c.doQueryWithProgressIndicator("owner information", "ViewerLoginAndOrgs", &v, variables)
 	if err != nil {
 		return l, err
 	}
@@ -1363,7 +1363,7 @@ func (c *Client) paginateOrgLogins(l []loginTypes, cursor string) ([]loginTypes,
 		"after": githubv4.String(cursor),
 	}
 
-	err := c.doQueryWithProgressIndicator("ViewerLoginAndOrgs", &v, variables)
+	err := c.doQueryWithProgressIndicator("owner information", "ViewerLoginAndOrgs", &v, variables)
 	if err != nil {
 		return l, err
 	}
@@ -1458,16 +1458,16 @@ func (c *Client) NewProject(canPrompt bool, o *Owner, number int32, fields bool)
 		if o.Type == UserOwner {
 			var query userOwner
 			variables["login"] = githubv4.String(o.Login)
-			err := c.doQueryWithProgressIndicator("UserProject", &query, variables)
+			err := c.doQueryWithProgressIndicator("project", "UserProject", &query, variables)
 			return newProjectFromQueryWithoutItemsQuery(query.Owner.Project), err
 		} else if o.Type == OrgOwner {
 			variables["login"] = githubv4.String(o.Login)
 			var query orgOwner
-			err := c.doQueryWithProgressIndicator("OrgProject", &query, variables)
+			err := c.doQueryWithProgressIndicator("project", "OrgProject", &query, variables)
 			return newProjectFromQueryWithoutItemsQuery(query.Owner.Project), err
 		} else if o.Type == ViewerOwner {
 			var query viewerOwner
-			err := c.doQueryWithProgressIndicator("ViewerProject", &query, variables)
+			err := c.doQueryWithProgressIndicator("project", "ViewerProject", &query, variables)
 			return newProjectFromQueryWithoutItemsQuery(query.Owner.Project), err
 		}
 		return nil, errors.New("unknown owner type")
@@ -1542,7 +1542,7 @@ func (c *Client) Projects(login string, t OwnerType, limit int, fields bool) (Pr
 		// the cost.
 		if t == UserOwner {
 			var query userProjects
-			if err := c.doQueryWithProgressIndicator("UserProjects", &query, variables); err != nil {
+			if err := c.doQueryWithProgressIndicator("projects", "UserProjects", &query, variables); err != nil {
 				return projects, err
 			}
 			for _, p := range query.Owner.Projects.Nodes {
@@ -1553,7 +1553,7 @@ func (c *Client) Projects(login string, t OwnerType, limit int, fields bool) (Pr
 			projects.TotalCount = query.Owner.Projects.TotalCount
 		} else if t == OrgOwner {
 			var query orgProjects
-			if err := c.doQueryWithProgressIndicator("OrgProjects", &query, variables); err != nil {
+			if err := c.doQueryWithProgressIndicator("projects", "OrgProjects", &query, variables); err != nil {
 				return projects, err
 			}
 			for _, p := range query.Owner.Projects.Nodes {
@@ -1564,7 +1564,7 @@ func (c *Client) Projects(login string, t OwnerType, limit int, fields bool) (Pr
 			projects.TotalCount = query.Owner.Projects.TotalCount
 		} else if t == ViewerOwner {
 			var query viewerProjects
-			if err := c.doQueryWithProgressIndicator("ViewerProjects", &query, variables); err != nil {
+			if err := c.doQueryWithProgressIndicator("projects", "ViewerProjects", &query, variables); err != nil {
 				return projects, err
 			}
 			for _, p := range query.Owner.Projects.Nodes {


### PR DESCRIPTION
Fixes #13338

This PR adds pagination support for `gh pr view --json files` and `gh pr view --json commits`. 
Previously, these arrays were silently truncated at 100 items because their GraphQL fragments lacked `pageInfo` and the CLI had no `preloadPrFiles` or `preloadPrCommits` functions in the finder. This follows the exact pagination pattern already used by `preloadPrReviews`, `preloadPrComments`, and `preloadPrClosingIssuesReferences`.
