### PR TITLE
extension install: honor --pin with --force on already installed extensions

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -379,15 +379,22 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					if ext, err := checkValidExtension(cmd.Root(), m, repo.RepoName(), repo.RepoOwner()); err != nil {
 						// If an existing extension was found and --force was specified, attempt to upgrade.
 						if forceFlag && ext != nil {
-							return upgradeFunc(ext.Name(), forceFlag)
-						}
+							if pinFlag != "" {
+								if err := m.Remove(ext.Name()); err != nil {
+									return err
+								}
+								// continue to m.Install below
+							} else {
+								return upgradeFunc(ext.Name(), forceFlag)
+							}
+						} else {
+							if errors.Is(err, alreadyInstalledError) {
+								fmt.Fprintf(io.ErrOut, "%s Extension %s is already installed\n", cs.WarningIcon(), ghrepo.FullName(repo))
+								return nil
+							}
 
-						if errors.Is(err, alreadyInstalledError) {
-							fmt.Fprintf(io.ErrOut, "%s Extension %s is already installed\n", cs.WarningIcon(), ghrepo.FullName(repo))
-							return nil
+							return err
 						}
-
-						return err
 					}
 
 					io.StartProgressIndicator()


### PR DESCRIPTION
Fixes #13551

When an extension was already installed, running `gh extension install OWNER/REPO --pin <tag> --force` would silently route to `upgradeFunc`, which ignored the `--pin` argument entirely.
This PR fixes it by explicitly checking for the presence of `--pin` when upgrading an existing extension. If `--pin` is provided alongside `--force`, the CLI first removes the existing installation before reinstalling it at the requested pinned version, preventing the CLI from defaulting to the latest version.
