### PR TITLE
Add Grok skill host support

### DIFF
--- a/internal/skills/registry/registry.go
+++ b/internal/skills/registry/registry.go
@@ -189,6 +189,12 @@ var Agents = []AgentHost{
 		UserDir:    ".config/goose/skills",
 	},
 	{
+		ID:         "grok",
+		Name:       "Grok",
+		ProjectDir: ".grok/skills",
+		UserDir:    ".grok/skills",
+	},
+	{
 		ID:         "iflow-cli",
 		Name:       "iFlow CLI",
 		ProjectDir: ".iflow/skills",

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -23,6 +23,7 @@ func TestFindByID(t *testing.T) {
 		{name: "antigravity", id: "antigravity", wantName: "Antigravity"},
 		{name: "antigravity-cli", id: "antigravity-cli", wantName: "Antigravity CLI"},
 		{name: "antigravity2.0", id: "antigravity2.0", wantName: "Antigravity 2.0"},
+		{name: "grok", id: "grok", wantName: "Grok"},
 		{name: "unknown agent", id: "nonexistent", wantErr: "unknown agent"},
 	}
 	for _, tt := range tests {
@@ -158,6 +159,22 @@ func TestInstallDir(t *testing.T) {
 			gitRoot: "/tmp/monalisa-repo",
 			homeDir: "/home/monalisa",
 			wantDir: filepath.Join("/home/monalisa", ".gemini", "config", "skills"),
+		},
+		{
+			name:    "grok project scope",
+			hostID:  "grok",
+			scope:   ScopeProject,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/tmp/monalisa-repo", ".grok", "skills"),
+		},
+		{
+			name:    "grok user scope",
+			hostID:  "grok",
+			scope:   ScopeUser,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/home/monalisa", ".grok", "skills"),
 		},
 		{
 			// Issue #13494: Universal must use the shared .agents/skills dir

--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -89,7 +89,7 @@ func NewCmdInstall(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, ru
 
 			A wide range of AI coding agents are supported, including GitHub
 			Copilot, Claude Code, Cursor, Codex, Gemini CLI, Antigravity, Amp,
-			Goose, Junie, OpenCode, Windsurf, and many more.
+			Goose, Grok, Junie, OpenCode, Windsurf, and many more.
 
 			Supported %[1]s--agent%[1]s values:
 

--- a/pkg/cmd/skills/update/update.go
+++ b/pkg/cmd/skills/update/update.go
@@ -79,8 +79,8 @@ func NewCmdUpdate(f *cmdutil.Factory, runF func(*UpdateOptions) error) *cobra.Co
 			Checks installed skills for available updates by comparing the local
 			tree SHA (from %[1]sSKILL.md%[1]s frontmatter) against the remote repository.
 
-			Scans all known agent host directories (Copilot, Claude, Cursor, Codex,
-			Gemini, Antigravity, Grok) in both project and user scope automatically.
+			Scans all known agent host directories (including Copilot, Claude, Cursor,
+			Gemini, Antigravity, Grok, and others) in both project and user scope automatically.
 
 			Without arguments, checks all installed skills. With skill names,
 			checks only those specific skills.

--- a/pkg/cmd/skills/update/update.go
+++ b/pkg/cmd/skills/update/update.go
@@ -80,7 +80,7 @@ func NewCmdUpdate(f *cmdutil.Factory, runF func(*UpdateOptions) error) *cobra.Co
 			tree SHA (from %[1]sSKILL.md%[1]s frontmatter) against the remote repository.
 
 			Scans all known agent host directories (Copilot, Claude, Cursor, Codex,
-			Gemini, Antigravity) in both project and user scope automatically.
+			Gemini, Antigravity, Grok) in both project and user scope automatically.
 
 			Without arguments, checks all installed skills. With skill names,
 			checks only those specific skills.


### PR DESCRIPTION
## Summary
- add Grok as a supported `gh skill` agent host
- install project and user skills in `.grok/skills`

Fixes #13846