### PR TITLE
Warn when a token is stored in plain text in gh auth status

### DIFF
--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -37,6 +37,12 @@ type authEntry struct {
 	Token       string         `json:"token,omitempty"`
 	Scopes      string         `json:"scopes,omitempty"`
 	GitProtocol string         `json:"gitProtocol"`
+
+	// plainTextToken is true when the active token for this host is stored in
+	// plain text in the config file rather than the system keyring. It is used
+	// only to render a security warning and is intentionally excluded from JSON
+	// output so the machine-readable schema is unchanged.
+	plainTextToken bool `json:"-"`
 }
 
 type authStatus struct {
@@ -83,6 +89,12 @@ func (e authEntry) String(cs *iostreams.ColorScheme) string {
 					sb.WriteString(fmt.Sprintf("  - To request missing scopes, run: %s\n", cs.Bold(refreshInstructions)))
 				}
 			}
+		}
+
+		if e.plainTextToken {
+			sb.WriteString(fmt.Sprintf("  %s Token stored in plain text\n", cs.WarningIcon()))
+			loginInstructions := fmt.Sprintf("gh auth login -h %s", e.Host)
+			sb.WriteString(fmt.Sprintf("  - To store your token in the system keyring, run: %s\n", cs.Bold(loginInstructions)))
 		}
 
 	case authEntryStateError:
@@ -363,18 +375,22 @@ type buildEntryOptions struct {
 
 func buildEntry(httpClient *http.Client, opts buildEntryOptions) authEntry {
 	tokenSource := opts.tokenSource
-	if tokenSource == "oauth_token" {
+	// A source of "oauth_token" means the token was read from the config file in
+	// plain text rather than from the system keyring, so flag it for a warning.
+	plainTextToken := tokenSource == "oauth_token"
+	if plainTextToken {
 		// The go-gh function TokenForHost returns this value as source for tokens read from the
 		// config file, but we want the file path instead. This attempts to reconstruct it.
 		tokenSource = filepath.Join(config.ConfigDir(), "hosts.yml")
 	}
 	entry := authEntry{
-		Active:      opts.active,
-		Host:        opts.hostname,
-		Login:       opts.username,
-		TokenSource: tokenSource,
-		Token:       opts.token,
-		GitProtocol: opts.gitProtocol,
+		Active:         opts.active,
+		Host:           opts.hostname,
+		Login:          opts.username,
+		TokenSource:    tokenSource,
+		Token:          opts.token,
+		GitProtocol:    opts.gitProtocol,
+		plainTextToken: plainTextToken,
 	}
 
 	// If token is not writeable, then it came from an environment variable and

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -145,6 +145,8 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_******
 				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h ghe.io
 			`),
 		},
 		{
@@ -166,6 +168,8 @@ func Test_statusRun(t *testing.T) {
 				  - Token scopes: 'repo'
 				  ! Missing required token scopes: 'read:org'
 				  - To request missing scopes, run: gh auth refresh -h ghe.io
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h ghe.io
 			`),
 		},
 		{
@@ -208,6 +212,8 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_******
 				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h ghe.io
 			`),
 		},
 		{
@@ -257,6 +263,8 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_******
 				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
 
 				ghe.io
 				  ✓ Logged in to ghe.io account monalisa-ghe (GH_CONFIG_DIR/hosts.yml)
@@ -264,6 +272,8 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: ssh
 				  - Token: gho_******
 				  - Token scopes: none
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h ghe.io
 			`),
 		},
 		{
@@ -306,6 +316,8 @@ func Test_statusRun(t *testing.T) {
 				  - Active account: true
 				  - Git operations protocol: https
 				  - Token: ghs_******
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
 			`),
 		},
 		{
@@ -326,6 +338,48 @@ func Test_statusRun(t *testing.T) {
 				  - Active account: true
 				  - Git operations protocol: https
 				  - Token: github_pat_******
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
+			`),
+		},
+		{
+			name: "token stored in plain text warns",
+			opts: StatusOptions{},
+			cfgStubs: func(t *testing.T, c gh.Config) {
+				// login stores the token in plain text config (source "oauth_token")
+				login(t, c, "github.com", "monalisa", "gho_abc123", "https")
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
+			},
+			wantOut: heredoc.Doc(`
+				github.com
+				  ✓ Logged in to github.com account monalisa (GH_CONFIG_DIR/hosts.yml)
+				  - Active account: true
+				  - Git operations protocol: https
+				  - Token: gho_******
+				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
+			`),
+		},
+		{
+			name: "token stored in keyring does not warn",
+			opts: StatusOptions{},
+			cfgStubs: func(t *testing.T, c gh.Config) {
+				// secureLogin stores the token in the (mock) keyring (source "keyring")
+				secureLogin(t, c, "github.com", "monalisa", "gho_abc123", "https")
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.REST("GET", ""), httpmock.ScopesResponder("repo,read:org"))
+			},
+			wantOut: heredoc.Doc(`
+				github.com
+				  ✓ Logged in to github.com account monalisa (keyring)
+				  - Active account: true
+				  - Git operations protocol: https
+				  - Token: gho_******
+				  - Token scopes: 'repo', 'read:org'
 			`),
 		},
 		{
@@ -350,6 +404,8 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_abc123
 				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
 
 				ghe.io
 				  ✓ Logged in to ghe.io account monalisa-ghe (GH_CONFIG_DIR/hosts.yml)
@@ -357,6 +413,8 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_xyz456
 				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h ghe.io
 			`),
 		},
 		{
@@ -389,12 +447,16 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_******
 				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
 
 				  ✓ Logged in to github.com account monalisa (GH_CONFIG_DIR/hosts.yml)
 				  - Active account: false
 				  - Git operations protocol: https
 				  - Token: gho_******
 				  - Token scopes: 'repo', 'read:org', 'project:read'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
 			`),
 		},
 		{
@@ -428,6 +490,8 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_******
 				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
 
 				  ✓ Logged in to github.com account monalisa (GH_CONFIG_DIR/hosts.yml)
 				  - Active account: false
@@ -436,6 +500,8 @@ func Test_statusRun(t *testing.T) {
 				  - Token scopes: 'repo'
 				  ! Missing required token scopes: 'read:org'
 				  - To request missing scopes, run: gh auth refresh -h github.com
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
 
 				ghe.io
 				  ✓ Logged in to ghe.io account monalisa-ghe-2 (GH_ENTERPRISE_TOKEN)
@@ -470,6 +536,8 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_******
 				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
 			`),
 		},
 		{
@@ -496,6 +564,8 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_******
 				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
 
 				ghe.io
 				  ✓ Logged in to ghe.io account monalisa-ghe-2 (GH_CONFIG_DIR/hosts.yml)
@@ -503,6 +573,8 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: ssh
 				  - Token: gho_******
 				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h ghe.io
 			`),
 		},
 		{
@@ -530,6 +602,8 @@ func Test_statusRun(t *testing.T) {
 				  - Git operations protocol: https
 				  - Token: gho_******
 				  - Token scopes: 'repo', 'read:org'
+				  ! Token stored in plain text
+				  - To store your token in the system keyring, run: gh auth login -h github.com
 
 				ghe.io
 				  X Failed to log in to ghe.io account monalisa-ghe-2 (GH_CONFIG_DIR/hosts.yml)
@@ -765,6 +839,16 @@ func login(t *testing.T, c gh.Config, hostname, username, token, protocol string
 	t.Helper()
 	_, err := c.Authentication().Login(hostname, username, token, protocol, false)
 	require.NoError(t, err)
+}
+
+// secureLogin logs in with secure (keyring) storage rather than plain text
+// config, so the resulting token source is "keyring" instead of "oauth_token".
+// NewIsolatedTestConfig sets up a mock keyring, so this uses it.
+func secureLogin(t *testing.T, c gh.Config, hostname, username, token, protocol string) {
+	t.Helper()
+	insecureUsed, err := c.Authentication().Login(hostname, username, token, protocol, true)
+	require.NoError(t, err)
+	require.False(t, insecureUsed, "expected secure (keyring) storage to be used")
 }
 
 // replaceAll replaces all instances of old with new in s, as well as all instances


### PR DESCRIPTION
Closes #13872

### What this does
When a host's active token is stored in the plaintext `hosts.yml` fallback (source `oauth_token`) rather than the system keyring, `gh auth status` now shows a warning plus a remediation hint:

```
  ! Token stored in plain text
  - To store your token in the system keyring, run: gh auth login -h <host>
```

It mirrors the existing missing-scopes warning idiom (`cs.WarningIcon()` + `cs.Bold(...)`, same indentation and hint prefix).

### Changes
- `pkg/cmd/auth/status/status.go`: added an unexported `plainTextToken bool \`json:"-"\`` field to `authEntry`, set in `buildEntry` from the raw `tokenSource == "oauth_token"` check (before the source string is rewritten to a file path), and rendered in `String()` for the success state.
- `pkg/cmd/auth/status/status_test.go`: added a `secureLogin` helper (stores via the mock keyring) and two cases — plaintext token warns; keyring token does not — plus updated the existing plaintext-login expectations.

### Notes
Display-only: no change to token storage, resolution, or flags, and the `--json` schema is unchanged (the new field is `json:"-"`).

### Testing
`go build ./...`, `go vet ./pkg/cmd/auth/status/...`, and `go test ./pkg/cmd/auth/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)