### PR TITLE
Fix `gh search code --web` unsatisfiable query with multiple `--repo`/`--owner`

### DIFF
--- a/pkg/cmd/search/code/code_test.go
+++ b/pkg/cmd/search/code/code_test.go
@@ -340,7 +340,7 @@ func TestCodeRun(t *testing.T) {
 				Searcher: search.NewSearcher(nil, "github.com", &fd.DisabledDetectorMock{}),
 				WebMode:  true,
 			},
-			wantBrowse: "https://github.com/search?q=map+path%3Atesting.go&type=code",
+			wantBrowse: "https://github.com/search?q=%28+map+%29+path%3Atesting.go&type=code",
 		},
 		{
 			name: "properly handles extension with dot prefix when converting to path qualifier",
@@ -358,7 +358,7 @@ func TestCodeRun(t *testing.T) {
 				Searcher: search.NewSearcher(nil, "github.com", &fd.DisabledDetectorMock{}),
 				WebMode:  true,
 			},
-			wantBrowse: "https://github.com/search?q=map+path%3Atesting.cpp&type=code",
+			wantBrowse: "https://github.com/search?q=%28+map+%29+path%3Atesting.cpp&type=code",
 		},
 		{
 			name: "does not convert filename and extension qualifiers for GHES web search",

--- a/pkg/search/query.go
+++ b/pkg/search/query.go
@@ -165,6 +165,52 @@ func (q Query) AdvancedIssueSearchString() string {
 	return qualifiers
 }
 
+// CodeSearchString returns the string representation of the query compatible
+// with the GitHub code search backend, which powers the code search GUI (i.e.
+// github.com/search?type=code).
+//
+// Unlike the legacy search backend used for repositories and commits — which
+// implicitly ORs a handful of repeated qualifiers (e.g. repo:, user:) — the
+// code search backend ANDs repeated qualifiers. Multiple repo: or user:
+// qualifiers must therefore be explicitly grouped with an OR operator;
+// otherwise the query is unsatisfiable, since a file cannot belong to two
+// different repositories (or owners) at once. Code search supports the advanced
+// syntax (nested queries and explicit OR), so the special qualifiers are
+// grouped and keywords are bracketed to avoid operator leakage, mirroring
+// AdvancedIssueSearchString.
+//
+// The syntax is documented at https://docs.github.com/en/search-github/github-code-search/understanding-github-code-search-syntax
+func (q Query) CodeSearchString() string {
+	qualifiers := strings.Join(formatQualifiers(q.Qualifiers, formatCodeSearch), " ")
+	keywords := q.ImmutableKeywords
+	if keywords == "" {
+		keywords = strings.Join(formatKeywords(q.Keywords), " ")
+	}
+
+	if qualifiers == "" && keywords == "" {
+		return ""
+	}
+
+	if qualifiers != "" && keywords != "" {
+		// We should surround keywords with brackets to avoid leaking of any operators, especially "OR"s.
+		return fmt.Sprintf("( %s ) %s", keywords, qualifiers)
+	}
+
+	if keywords != "" {
+		return keywords
+	}
+	return qualifiers
+}
+
+func formatCodeSearch(qualifier string, vs []string) (s []string, applicable bool) {
+	switch qualifier {
+	case "user", "repo":
+		return []string{groupWithOR(qualifier, vs)}, true
+	}
+	// Let the default formatting take over
+	return nil, false
+}
+
 func formatAdvancedIssueSearch(qualifier string, vs []string) (s []string, applicable bool) {
 	switch qualifier {
 	case "in":

--- a/pkg/search/query_test.go
+++ b/pkg/search/query_test.go
@@ -238,6 +238,93 @@ func TestAdvancedIssueSearchString(t *testing.T) {
 	}
 }
 
+func TestCodeSearchString(t *testing.T) {
+	tests := []struct {
+		name  string
+		query Query
+		out   string
+	}{
+		{
+			name: "empty query",
+			out:  "",
+		},
+		{
+			name: "keywords only",
+			query: Query{
+				Keywords: []string{"error", "handling"},
+			},
+			out: `error handling`,
+		},
+		{
+			name: "single repo is not grouped",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					Repo: []string{"foo/bar"},
+				},
+			},
+			out: `( keyword ) repo:foo/bar`,
+		},
+		{
+			name: "multiple repos are OR-ed",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					Repo: []string{"foo/bar", "foo/baz"},
+				},
+			},
+			out: `( keyword ) (repo:foo/bar OR repo:foo/baz)`,
+		},
+		{
+			name: "multiple owners are OR-ed",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					User: []string{"microsoft", "google"},
+				},
+			},
+			out: `( keyword ) (user:google OR user:microsoft)`,
+		},
+		{
+			name: "repos and owners are grouped independently, non-special qualifiers untouched",
+			query: Query{
+				Keywords: []string{"keyword"},
+				Qualifiers: Qualifiers{
+					Repo:     []string{"foo/bar", "foo/baz"},
+					User:     []string{"johndoe", "janedoe"},
+					Language: "go",
+					Path:     "cmd/",
+				},
+			},
+			out: `( keyword ) language:go path:cmd/ (repo:foo/bar OR repo:foo/baz) (user:janedoe OR user:johndoe)`,
+		},
+		{
+			name: "immutable keywords are bracketed with qualifiers",
+			query: Query{
+				ImmutableKeywords: "Note",
+				Qualifiers: Qualifiers{
+					Repo: []string{"jitran/fargate-cdk-deployer", "jitran/kubernetes-grafana-dashboards"},
+				},
+			},
+			out: `( Note ) (repo:jitran/fargate-cdk-deployer OR repo:jitran/kubernetes-grafana-dashboards)`,
+		},
+		{
+			name: "qualifiers only, no keywords",
+			query: Query{
+				Qualifiers: Qualifiers{
+					Repo: []string{"foo/bar", "foo/baz"},
+				},
+			},
+			out: `(repo:foo/bar OR repo:foo/baz)`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, tt.query.CodeSearchString())
+		})
+	}
+}
+
 func TestQualifiersMap(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -12,6 +12,7 @@ import (
 
 	fd "github.com/cli/cli/v2/internal/featuredetection"
 	"github.com/cli/cli/v2/internal/ghinstance"
+	ghauth "github.com/cli/go-gh/v2/pkg/auth"
 )
 
 const (
@@ -270,12 +271,26 @@ func (s searcher) URL(query Query) string {
 	qs := url.Values{}
 	qs.Set("type", query.Kind)
 
+	// On GitHub.com, the code search GUI is powered by the code search backend,
+	// which ANDs repeated qualifiers instead of implicitly OR-ing them, so
+	// repo:/user: must be explicitly OR-grouped; otherwise multiple values
+	// produce an unsatisfiable query. See CodeSearchString.
+	//
+	// This is scoped to non-enterprise hosts because GHES may still serve code
+	// search from the legacy backend (which implicitly ORs those qualifiers and
+	// does not support the advanced syntax), mirroring the github.com-only
+	// handling of the `path` qualifier in the code search command.
+	//
 	// TODO advancedSearchFuture
 	// Currently, the global search GUI does not support the advanced issue
 	// search syntax (even for the issues/PRs tab on the sidebar). When the GUI
 	// is updated, we can use feature detection, and, if available, use the
 	// advanced search syntax.
-	qs.Set("q", query.StandardSearchString())
+	if query.Kind == KindCode && !ghauth.IsEnterprise(s.host) {
+		qs.Set("q", query.CodeSearchString())
+	} else {
+		qs.Set("q", query.StandardSearchString())
+	}
 
 	if query.Order != "" {
 		qs.Set(orderKey, query.Order)

--- a/pkg/search/searcher_test.go
+++ b/pkg/search/searcher_test.go
@@ -1256,6 +1256,57 @@ func TestSearcherURL(t *testing.T) {
 			},
 			url: "https://github.com/search?q=%22keyword+with+whitespace%22&type=repositories",
 		},
+		{
+			// https://github.com/cli/cli/issues/9252: the code search backend
+			// ANDs repeated repo: qualifiers, so they must be OR-grouped or the
+			// web query is unsatisfiable.
+			name: "code search OR-groups multiple repos",
+			query: Query{
+				Keywords: []string{"Note"},
+				Kind:     KindCode,
+				Qualifiers: Qualifiers{
+					Repo: []string{"jitran/fargate-cdk-deployer", "jitran/kubernetes-grafana-dashboards"},
+				},
+			},
+			url: "https://github.com/search?q=%28+Note+%29+%28repo%3Ajitran%2Ffargate-cdk-deployer+OR+repo%3Ajitran%2Fkubernetes-grafana-dashboards%29&type=code",
+		},
+		{
+			name: "code search OR-groups multiple owners",
+			query: Query{
+				Keywords: []string{"Note"},
+				Kind:     KindCode,
+				Qualifiers: Qualifiers{
+					User: []string{"microsoft", "google"},
+				},
+			},
+			url: "https://github.com/search?q=%28+Note+%29+%28user%3Agoogle+OR+user%3Amicrosoft%29&type=code",
+		},
+		{
+			name: "code search with a single repo is unchanged apart from keyword bracketing",
+			query: Query{
+				Keywords: []string{"panic"},
+				Kind:     KindCode,
+				Qualifiers: Qualifiers{
+					Repo: []string{"cli/cli"},
+				},
+			},
+			url: "https://github.com/search?q=%28+panic+%29+repo%3Acli%2Fcli&type=code",
+		},
+		{
+			// GHES may still serve code search from the legacy backend, which
+			// implicitly ORs repo:/user:, so we keep the legacy query string
+			// there to avoid regressing enterprise users.
+			name: "code search on an enterprise host keeps the legacy query string",
+			host: "enterprise.com",
+			query: Query{
+				Keywords: []string{"Note"},
+				Kind:     KindCode,
+				Qualifiers: Qualifiers{
+					Repo: []string{"foo/bar", "foo/baz"},
+				},
+			},
+			url: "https://enterprise.com/search?q=Note+repo%3Afoo%2Fbar+repo%3Afoo%2Fbaz&type=code",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #9252.

### Description

`gh search code <keyword> --repo A,B --web` (and `--owner A,B`) opens the code-search GUI with a query like `keyword repo:A repo:B`. GitHub's code-search backend treats adjacent qualifiers as **AND**, so multiple `repo:` (or `user:`) qualifiers make the query unsatisfiable — the GUI shows *"condition is unsatisfiable"* and no results. Per the [code-search syntax docs](https://docs.github.com/en/search-github/github-code-search/understanding-github-code-search-syntax), a set of repositories must be combined with `OR`: `repo:A OR repo:B`.

This adds a `CodeSearchString()` that OR-groups repeated `repo:`/`user:` qualifiers and brackets the keywords, mirroring the existing `AdvancedIssueSearchString()`. `Searcher.URL()` uses it for `KindCode` on non-enterprise hosts:

```
before:  keyword repo:A repo:B          (AND → unsatisfiable)
after:   ( keyword ) (repo:A OR repo:B) (keyword AND (A OR B))
```

The parentheses are load-bearing: without them, `keyword repo:A OR repo:B` parses as `(keyword AND repo:A) OR repo:B` under standard operator precedence, which would return *every* file in the second repo regardless of the keyword.

### Scope / notes

- **REST/API path unchanged.** Only the `--web` URL is affected. The non-`--web` REST code-search API relies on the legacy engine's implicit-OR of `repo:`, so `Searcher.Code()` still uses `StandardSearchString()`.
- **Scoped to non-enterprise hosts.** GHES may still serve code search from the legacy backend (which implicitly ORs those qualifiers and may not support the advanced syntax), so enterprise hosts keep the legacy query string. This mirrors the existing github.com-only handling of the `path` qualifier in `pkg/cmd/search/code`. (Note: `IsEnterprise` is false for GitHub Enterprise Cloud tenants, so those correctly receive the new syntax.)
- **Known follow-up (out of scope):** `--match file,path` still emits `in:file in:path` (ANDed) for the web URL — this is pre-existing behavior, unchanged by this PR, but is the same class of issue and could be OR-grouped in a follow-up.

### How has this been tested?

- New `TestCodeSearchString` covers empty/keywords-only/single-repo/multi-repo/multi-owner/mixed/immutable-keyword/qualifiers-only cases.
- New `TestSearcherURL` cases assert the end-to-end `--web` URL is OR-grouped for github.com and left as the legacy string for an enterprise host.
- Existing `code_test.go` web-search expectations updated for the keyword bracketing; the GHES expectation is unchanged (evidence the enterprise scoping preserves legacy behavior).
- `go build ./...`, `go vet ./pkg/search/ ./pkg/cmd/search/...`, `go test ./pkg/search/ ./pkg/cmd/search/...`, and `gofmt -l` all clean.

<sub>Authored with AI assistance; every change was reviewed and independently verified against the documented code-search syntax before submission.</sub>
