### PR TITLE
chore: remove dead CODEOWNERS rule for non-existent pkg/cmd/release/attestation/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,6 @@ internal/codespaces/ @cli/codespaces @cli/code-reviewers
 
 # Limit Package Security team ownership to the attestation command package and related integration tests
 pkg/cmd/attestation/ @cli/package-security @cli/code-reviewers
-pkg/cmd/release/attestation/ @cli/package-security @cli/code-reviewers
 pkg/cmd/release/verify/ @cli/package-security @cli/code-reviewers
 pkg/cmd/release/verify-asset/ @cli/package-security @cli/code-reviewers
 pkg/cmd/release/shared/ @cli/package-security @cli/code-reviewers


### PR DESCRIPTION
Hi, and thank you for the GitHub CLI.

Small CODEOWNERS cleanup. `.github/CODEOWNERS` line 8 assigns ownership of `pkg/cmd/release/attestation/`, but that directory doesn't exist:

```
$ gh api repos/cli/cli/contents/pkg/cmd/release/attestation
# → 404 Not Found
$ gh api 'repos/cli/cli/commits?path=pkg/cmd/release/attestation'  # → [] (never existed)
```

The real attestation command lives at `pkg/cmd/attestation/` (line 7, which resolves), and the sibling `release/` entries (verify, verify-asset, shared) all resolve too — so line 8 looks like an oversight. Since it matches nothing, the intended `@cli/package-security` auto-review over that path isn't actually enforced by anything today.

This PR removes the dead line. If a `gh release attestation` command is planned at that path, happy to instead leave it and adjust — just flagging that it currently matches no files. (GitHub doesn't surface this because `codeowners/errors` only validates syntax, not path existence.)

For transparency: I used AI assistance to spot and draft this; I verified the 404 and the git history myself.
