### PR TITLE
fix(release): fail early on duplicate asset filenames

### DIFF
--- a/pkg/cmd/release/shared/upload.go
+++ b/pkg/cmd/release/shared/upload.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -72,7 +74,33 @@ func AssetsFromArgs(args []string) (assets []*AssetForUpload, err error) {
 			MIMEType: typeForFilename(fi.Name()),
 		})
 	}
+
+	if dupes := duplicateAssetNames(assets); len(dupes) > 0 {
+		return nil, fmt.Errorf("multiple assets have the same filename: %s\n\nRelease asset names must be unique. Rename or remove the duplicates and try again.", strings.Join(dupes, ", "))
+	}
+
 	return
+}
+
+// duplicateAssetNames returns the asset names that appear more than once,
+// deduplicated and sorted. A GitHub release cannot hold two assets with the
+// same name, so callers use this to fail early rather than partway through an
+// upload.
+func duplicateAssetNames(assets []*AssetForUpload) []string {
+	counts := make(map[string]int, len(assets))
+	for _, a := range assets {
+		counts[a.Name]++
+	}
+
+	var dupes []string
+	for name, count := range counts {
+		if count > 1 {
+			dupes = append(dupes, name)
+		}
+	}
+
+	sort.Strings(dupes)
+	return dupes
 }
 
 func typeForFilename(fn string) string {

--- a/pkg/cmd/release/shared/upload_test.go
+++ b/pkg/cmd/release/shared/upload_test.go
@@ -6,7 +6,12 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_typeForFilename(t *testing.T) {
@@ -73,6 +78,111 @@ func Test_typeForFilename(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_duplicateAssetNames(t *testing.T) {
+	asset := func(name string) *AssetForUpload {
+		return &AssetForUpload{Name: name}
+	}
+
+	tests := []struct {
+		name   string
+		assets []*AssetForUpload
+		want   []string
+	}{
+		{
+			name:   "no assets",
+			assets: nil,
+			want:   nil,
+		},
+		{
+			name:   "single asset",
+			assets: []*AssetForUpload{asset("foo.zip")},
+			want:   nil,
+		},
+		{
+			name:   "all unique",
+			assets: []*AssetForUpload{asset("foo.zip"), asset("bar.zip"), asset("baz.zip")},
+			want:   nil,
+		},
+		{
+			name:   "one duplicate pair",
+			assets: []*AssetForUpload{asset("foo.zip"), asset("bar.zip"), asset("foo.zip")},
+			want:   []string{"foo.zip"},
+		},
+		{
+			name:   "multiple duplicates reported sorted",
+			assets: []*AssetForUpload{asset("beta.zip"), asset("alpha.zip"), asset("beta.zip"), asset("alpha.zip")},
+			want:   []string{"alpha.zip", "beta.zip"},
+		},
+		{
+			name:   "same name three times reported once",
+			assets: []*AssetForUpload{asset("dup"), asset("dup"), asset("dup")},
+			want:   []string{"dup"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, duplicateAssetNames(tt.assets))
+		})
+	}
+}
+
+func TestAssetsFromArgs_duplicateFilenames(t *testing.T) {
+	// Two source files in different directories share the same base name, so
+	// they resolve to the same release asset name and must be rejected.
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	dup1 := filepath.Join(dir1, "dup.txt")
+	dup2 := filepath.Join(dir2, "dup.txt")
+	require.NoError(t, os.WriteFile(dup1, []byte("one"), 0600))
+	require.NoError(t, os.WriteFile(dup2, []byte("two"), 0600))
+
+	_, err := AssetsFromArgs([]string{dup1, dup2})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dup.txt")
+	assert.Contains(t, err.Error(), "same filename")
+}
+
+func TestAssetsFromArgs_uniqueFilenames(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.txt")
+	b := filepath.Join(dir, "b.txt")
+	require.NoError(t, os.WriteFile(a, []byte("a"), 0600))
+	require.NoError(t, os.WriteFile(b, []byte("b"), 0600))
+
+	assets, err := AssetsFromArgs([]string{a, b})
+	require.NoError(t, err)
+	require.Len(t, assets, 2)
+	assert.Equal(t, "a.txt", assets[0].Name)
+	assert.Equal(t, "b.txt", assets[1].Name)
+}
+
+func TestAssetsFromArgs_sameFileTwice(t *testing.T) {
+	// Passing the same file twice resolves to the same asset name and must be
+	// rejected, since deduplication is by asset name rather than source path.
+	dir := t.TempDir()
+	f := filepath.Join(dir, "same.txt")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0600))
+
+	_, err := AssetsFromArgs([]string{f, f})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same.txt")
+}
+
+func TestAssetsFromArgs_duplicateNameDifferentLabels(t *testing.T) {
+	// A differing display label does not change the asset name, so files with
+	// the same base name still collide even when labeled distinctly.
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	f1 := filepath.Join(dir1, "asset.txt")
+	f2 := filepath.Join(dir2, "asset.txt")
+	require.NoError(t, os.WriteFile(f1, []byte("1"), 0600))
+	require.NoError(t, os.WriteFile(f2, []byte("2"), 0600))
+
+	_, err := AssetsFromArgs([]string{f1 + "#first", f2 + "#second"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "asset.txt")
 }
 
 func Test_uploadWithDelete_retry(t *testing.T) {


### PR DESCRIPTION
## Summary

`gh release create` and `gh release upload` take multiple asset files as
arguments and derive each release asset name from the file's base name
(`fi.Name()`). When two arguments resolve to the same base name (for example
files with the same name in different directories, or the same file passed
twice), the first asset uploads and the second fails with an opaque HTTP
error. For `gh release create`, the partially-created release is then deleted
on that failure, which is surprising and destructive.

This adds an up-front validation in the shared `AssetsFromArgs` (the single
entry point both commands use during argument parsing) that returns a friendly
error naming the duplicated filenames before any release is created or any
asset is uploaded. GitHub releases cannot hold two assets with the same name,
so this is caught deterministically without a round-trip.

Example:

```
$ gh release create v1.0.0 dist/linux/gh.tar.gz other/gh.tar.gz
multiple assets have the same filename: gh.tar.gz

Release asset names must be unique. Rename or remove the duplicates and try again.
```

## Acceptance Criteria

Implements the acceptance criteria from the issue for both `gh release create`
and `gh release upload`: a friendly error is returned, listing the duplicate
filename(s), before any create/upload attempt is made.

## Testing

- `Test_duplicateAssetNames` — table-driven unit test for the duplicate
  detection helper (no duplicates, one pair, multiple sorted duplicates, a
  name repeated three times reported once).
- `TestAssetsFromArgs_duplicateFilenames` / `TestAssetsFromArgs_uniqueFilenames`
  — end-to-end checks that same-basename inputs are rejected and distinct
  basenames still succeed.
- `go test ./pkg/cmd/release/...`, `go vet ./pkg/cmd/release/shared/...`, and
  `gofmt` all pass.

Fixes #10792