### PR TITLE
fix(extension): honor pin when force installing

### DIFF
--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -377,17 +377,20 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 					cs := io.ColorScheme()
 
 					if ext, err := checkValidExtension(cmd.Root(), m, repo.RepoName(), repo.RepoOwner()); err != nil {
-						// If an existing extension was found and --force was specified, attempt to upgrade.
+						// An explicit pin must be installed rather than treated as an upgrade to latest.
 						if forceFlag && ext != nil {
-							return upgradeFunc(ext.Name(), forceFlag)
-						}
-
-						if errors.Is(err, alreadyInstalledError) {
+							if pinFlag == "" {
+								return upgradeFunc(ext.Name(), forceFlag)
+							}
+							if err := m.Remove(ext.Name()); err != nil {
+								return fmt.Errorf("failed to replace extension %s: %w", ext.Name(), err)
+							}
+						} else if errors.Is(err, alreadyInstalledError) {
 							fmt.Fprintf(io.ErrOut, "%s Extension %s is already installed\n", cs.WarningIcon(), ghrepo.FullName(repo))
 							return nil
+						} else {
+							return err
 						}
-
-						return err
 					}
 
 					io.StartProgressIndicator()

--- a/pkg/cmd/extension/command_test.go
+++ b/pkg/cmd/extension/command_test.go
@@ -898,6 +898,32 @@ func TestNewCmdExtension(t *testing.T) {
 			isTTY:      true,
 			wantStdout: "✓ Successfully checked extension upgrades\n",
 		},
+		{
+			name: "force install with pin when present",
+			args: []string{"install", "owner/gh-hello", "--force", "--pin", "v1.2.3"},
+			managerStubs: func(em *extensions.ExtensionManagerMock) func(*testing.T) {
+				em.ListFunc = func() []extensions.Extension {
+					return []extensions.Extension{
+						&Extension{path: "owner/gh-hello", owner: "owner"},
+					}
+				}
+				em.RemoveFunc = func(name string) error {
+					assert.Equal(t, "hello", name)
+					return nil
+				}
+				em.InstallFunc = func(repo ghrepo.Interface, pin string) error {
+					assert.Equal(t, "gh-hello", repo.RepoName())
+					assert.Equal(t, "v1.2.3", pin)
+					return nil
+				}
+				return func(t *testing.T) {
+					assert.Len(t, em.RemoveCalls(), 1)
+					assert.Len(t, em.InstallCalls(), 1)
+					assert.Empty(t, em.UpgradeCalls())
+				}
+			},
+			wantStdout: "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- re-install an existing extension at the explicitly requested tag or commit when `gh extension install --force --pin ...` is used
- keep the existing upgrade-to-latest behavior for `--force` without `--pin`
- add a regression test covering the replacement install path

## Root cause

The install command sent every existing extension with `--force` to the upgrade path. That path has no pin argument, so a requested pinned version was replaced by the latest available version instead.

## Validation

- `go test ./pkg/cmd/extension -count=1`
- `go test ./...`
- `git diff --check`

Fixes #13551
