### PR TITLE
Fix duplicated-word typos in comments

### DIFF
--- a/internal/featuredetection/feature_detection.go
+++ b/internal/featuredetection/feature_detection.go
@@ -391,7 +391,7 @@ func (d *detector) SearchFeatures() (SearchFeatures, error) {
 	//
 	// Since there's no schema-wise difference between pre-deprecation and
 	// deprecation periods (i.e. `ISSUE_ADVANCED` is available during both),
-	// we cannot figure out the exact time period. The consensus is to to use
+	// we cannot figure out the exact time period. The consensus is to use
 	// the advanced search syntax during both periods.
 
 	var feature SearchFeatures

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -1360,7 +1360,7 @@ func Test_apiRun_cache(t *testing.T) {
 				AuthenticationFunc: func() gh.AuthConfig {
 					cfg := &config.AuthConfig{}
 					// Required because the http client tries to get the active token and otherwise
-					// this goes down to to go-gh config and panics. Pretty bad solution, it would
+					// this goes down to go-gh config and panics. Pretty bad solution, it would
 					// be better if this were black box.
 					cfg.SetActiveToken("token", "stub")
 					return cfg

--- a/pkg/cmd/workflow/run/run.go
+++ b/pkg/cmd/workflow/run/run.go
@@ -328,7 +328,7 @@ func runRun(opts *RunOptions) error {
 
 	// TODO workflowDispatchRunDetailsCleanup
 	// We will have to always set the `return_run_details` field to true, unless
-	// we opt into the the new REST API version, which will probably return the
+	// we opt into the new REST API version, which will probably return the
 	// details by default.
 	if features.DispatchRunDetails {
 		requestBody["return_run_details"] = true


### PR DESCRIPTION
## Summary
- Fixes three small "duplicated word" typos in code comments ("the the" / "to to") found in `internal/featuredetection/feature_detection.go`, `pkg/cmd/api/api_test.go`, and `pkg/cmd/workflow/run/run.go`.
- Comment-only changes, no behavior change.

## Test plan
- N/A (comment-only changes, no executable code affected)