### PR TITLE
Fix gh api --jq masking HTTP errors on non-JSON responses

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -484,10 +484,11 @@ func processResponse(resp *http.Response, opts *ApiOptions, bodyWriter, headersW
 				return
 			}
 		}
-	} else if !isJSON && resp.StatusCode >= 400 {
-		// A non-JSON error body (e.g. an HTML maintenance page) cannot be
-		// filtered with `--jq` or `--template`; report the HTTP error and
-		// pass the body through raw instead.
+	} else if !isJSON && resp.StatusCode > 299 {
+		// A non-JSON body on a non-2xx response (e.g. an HTML maintenance
+		// page) cannot be filtered with `--jq` or `--template`; report the
+		// HTTP error and pass the body through raw instead. The threshold
+		// matches the serverError fallback below.
 		serverError = fmt.Sprintf("HTTP %d", resp.StatusCode)
 	}
 

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -484,6 +484,11 @@ func processResponse(resp *http.Response, opts *ApiOptions, bodyWriter, headersW
 				return
 			}
 		}
+	} else if !isJSON && resp.StatusCode >= 400 {
+		// A non-JSON error body (e.g. an HTML maintenance page) cannot be
+		// filtered with `--jq` or `--template`; report the HTTP error and
+		// pass the body through raw instead.
+		serverError = fmt.Sprintf("HTTP %d", resp.StatusCode)
 	}
 
 	var bodyCopy *bytes.Buffer

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -642,6 +642,36 @@ func Test_apiRun(t *testing.T) {
 			isatty: false,
 		},
 		{
+			name: "jq filter when non-JSON error",
+			options: ApiOptions{
+				FilterOutput: `.[].name`,
+			},
+			httpResponse: &http.Response{
+				StatusCode: 503,
+				Body:       io.NopCloser(bytes.NewBufferString(`<!DOCTYPE html><html><head><title>Unicorn!</title></head></html>`)),
+				Header:     http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+			},
+			err:    cmdutil.SilentError,
+			stdout: `<!DOCTYPE html><html><head><title>Unicorn!</title></head></html>`,
+			stderr: "gh: HTTP 503\n",
+			isatty: false,
+		},
+		{
+			name: "output template when non-JSON error",
+			options: ApiOptions{
+				Template: `{{.status}}`,
+			},
+			httpResponse: &http.Response{
+				StatusCode: 503,
+				Body:       io.NopCloser(bytes.NewBufferString(`<!DOCTYPE html><html><head><title>Unicorn!</title></head></html>`)),
+				Header:     http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+			},
+			err:    cmdutil.SilentError,
+			stdout: `<!DOCTYPE html><html><head><title>Unicorn!</title></head></html>`,
+			stderr: "gh: HTTP 503\n",
+			isatty: false,
+		},
+		{
 			name: "jq filter outputting JSON to a TTY",
 			options: ApiOptions{
 				FilterOutput: `.`,

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -657,6 +657,21 @@ func Test_apiRun(t *testing.T) {
 			isatty: false,
 		},
 		{
+			name: "jq filter when non-JSON redirect",
+			options: ApiOptions{
+				FilterOutput: `.[].name`,
+			},
+			httpResponse: &http.Response{
+				StatusCode: 301,
+				Body:       io.NopCloser(bytes.NewBufferString(`<html><body>Moved Permanently</body></html>`)),
+				Header:     http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+			},
+			err:    cmdutil.SilentError,
+			stdout: `<html><body>Moved Permanently</body></html>`,
+			stderr: "gh: HTTP 301\n",
+			isatty: false,
+		},
+		{
 			name: "output template when non-JSON error",
 			options: ApiOptions{
 				Template: `{{.status}}`,


### PR DESCRIPTION
Fixes #13901

When the server returns an error with a non-JSON body (e.g. an HTML maintenance page on a 5xx), `gh api --jq` piped the body into the jq evaluator, which failed with "invalid character '<' looking for beginning of value" and hid the underlying HTTP status. The same applied to --template.

Treat non-JSON error responses like JSON ones: skip the filter, pass the body through raw, and report "gh: HTTP <status>" on stderr with a non-zero exit — matching the existing behavior without --jq.