### PR TITLE
Fix `issue list --search` over-fetching on paginated results

### DIFF
--- a/pkg/cmd/issue/list/http.go
+++ b/pkg/cmd/issue/list/http.go
@@ -212,7 +212,7 @@ loop:
 			break
 		}
 		variables["after"] = resp.Search.PageInfo.EndCursor
-		variables["perPage"] = min(perPage, limit-len(ic.Issues))
+		variables["limit"] = min(perPage, limit-len(ic.Issues))
 	}
 
 	return &ic, nil

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -2,8 +2,10 @@ package list
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/api"
@@ -266,4 +268,70 @@ func TestSearchIssues_rejectsPullRequestQualifiers(t *testing.T) {
 			assert.Len(t, reg.Requests, 0)
 		})
 	}
+}
+
+// nodesJSON builds a JSON array of n minimal issue nodes.
+func nodesJSON(n int) string {
+	parts := make([]string, n)
+	for i := 0; i < n; i++ {
+		parts[i] = fmt.Sprintf(`{"title":"issue-%d"}`, i)
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}
+
+func TestSearchIssues_reducesPageSizeOnSubsequentPages(t *testing.T) {
+	reg := &httpmock.Registry{}
+
+	var capturedLimits []interface{}
+
+	// Page 1: return a full page of 100 nodes, hasNextPage=true.
+	reg.Register(
+		httpmock.GraphQL(`query IssueSearch\b`),
+		httpmock.GraphQLQuery(fmt.Sprintf(`
+			{ "data": { "repository": { "hasIssuesEnabled": true },
+			  "search": {
+			    "issueCount": 250,
+			    "nodes": %s,
+			    "pageInfo": { "hasNextPage": true, "endCursor": "CURSOR1" }
+			  } } }`, nodesJSON(100)),
+			func(query string, vars map[string]interface{}) {
+				capturedLimits = append(capturedLimits, vars["limit"])
+			}),
+	)
+
+	// Page 2: return more nodes, hasNextPage=false so the loop ends.
+	reg.Register(
+		httpmock.GraphQL(`query IssueSearch\b`),
+		httpmock.GraphQLQuery(fmt.Sprintf(`
+			{ "data": { "repository": { "hasIssuesEnabled": true },
+			  "search": {
+			    "issueCount": 250,
+			    "nodes": %s,
+			    "pageInfo": { "hasNextPage": false, "endCursor": "CURSOR2" }
+			  } } }`, nodesJSON(100)),
+			func(query string, vars map[string]interface{}) {
+				capturedLimits = append(capturedLimits, vars["limit"])
+			}),
+	)
+
+	httpClient := &http.Client{Transport: reg}
+	client := api.NewClientFromHTTP(httpClient)
+
+	res, err := searchIssues(
+		client,
+		fd.AdvancedIssueSearchSupportedAsOnlyBackend(),
+		ghrepo.New("OWNER", "REPO"),
+		prShared.FilterOptions{State: "open"},
+		150,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, 150, len(res.Issues))
+
+	// Two requests should have been made.
+	assert.Len(t, capturedLimits, 2)
+	// Page 1 asks for a full page.
+	assert.EqualValues(t, 100, capturedLimits[0])
+	// Page 2 should only ask for the remaining 50 items (150 - 100 already collected),
+	// mirroring listIssues in the same file. With the bug it still asks for 100.
+	assert.EqualValues(t, 50, capturedLimits[1])
 }


### PR DESCRIPTION
### Description

`searchIssues` (`gh issue list --search`) writes the per-page size reduction to the wrong GraphQL variable:

```go
variables["perPage"] = min(perPage, limit-len(ic.Issues))
```

The `IssueSearch` operation declares only `$limit` and consumes it at `search(..., last: $limit, ...)` — there is no `$perPage` variable, so this reduction is silently discarded. `variables["limit"]` is seeded once to `min(limit, 100)` and never updated, so every page after the first keeps requesting a full 100 items.

Effect: `gh issue list --search "..." --limit N` with **N > 100** over-fetches up to a full extra page (≈99 nodes) on the final request. The returned count is still correct (the loop truncates at `limit`), so this is an over-fetch/efficiency bug, not wrong output.

`listIssues` in the same file (and every other list command — `pr/list`, `org/list`, `ruleset/shared`, …) correctly writes the reduction back into `variables["limit"]`. `searchIssues` was the lone outlier.

### Fix

One-line change: write to `variables["limit"]` instead of `variables["perPage"]`.

### Test

Added `TestSearchIssues_reducesPageSizeOnSubsequentPages` (httpmock, captures the `limit` variable per page): page 1 requests 100, page 2 requests 50 (150 − 100 already collected). It fails on the old code (page 2 = 100) and passes with the fix. `go test ./pkg/cmd/issue/list/...` and `go vet` pass.
