### PR TITLE
Fix issue search pagination writing reduced page size to wrong var

### DIFF
--- a/pkg/cmd/issue/list/http.go
+++ b/pkg/cmd/issue/list/http.go
@@ -212,7 +212,7 @@ loop:
 			break
 		}
 		variables["after"] = resp.Search.PageInfo.EndCursor
-		variables["perPage"] = min(perPage, limit-len(ic.Issues))
+		variables["limit"] = min(perPage, limit-len(ic.Issues))
 	}
 
 	return &ic, nil

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -215,6 +215,73 @@ func TestSearchIssuesAndAdvancedSearch(t *testing.T) {
 	}
 }
 
+func TestSearchIssues_paginationLimit(t *testing.T) {
+	reg := &httpmock.Registry{}
+	httpClient := &http.Client{}
+	httpmock.ReplaceTripper(httpClient, reg)
+	client := api.NewClientFromHTTP(httpClient)
+
+	issueNode := `{
+		"title": "issue",
+		"labels": { "nodes": [], "totalCount": 0 },
+		"assignees": { "nodes": [], "totalCount": 0 }
+	}`
+	// First page: 100 items, more available
+	firstPageNodes := "[" + issueNode
+	for i := 1; i < 100; i++ {
+		firstPageNodes += "," + issueNode
+	}
+	firstPageNodes += "]"
+
+	reg.Register(
+		httpmock.GraphQL(`query IssueSearch\b`),
+		httpmock.StringResponse(`
+			{ "data": {
+				"repository": { "hasIssuesEnabled": true },
+				"search": {
+					"issueCount": 150,
+					"nodes": `+firstPageNodes+`,
+					"pageInfo": {
+						"hasNextPage": true,
+						"endCursor": "ENDCURSOR"
+					}
+				}
+			} }
+		`),
+	)
+	reg.Register(
+		httpmock.GraphQL(`query IssueSearch\b`),
+		httpmock.GraphQLQuery(`
+			{ "data": {
+				"repository": { "hasIssuesEnabled": true },
+				"search": {
+					"issueCount": 150,
+					"nodes": [`+issueNode+`],
+					"pageInfo": {
+						"hasNextPage": false,
+						"endCursor": "ENDCURSOR2"
+					}
+				}
+			} }
+		`, func(query string, vars map[string]interface{}) {
+			// Second page must request only the remaining 50, not another full 100.
+			assert.Equal(t, float64(50), vars["limit"])
+			assert.Equal(t, "ENDCURSOR", vars["after"])
+		}),
+	)
+
+	_, err := searchIssues(
+		client,
+		fd.AdvancedIssueSearchUnsupported(),
+		ghrepo.New("OWNER", "REPO"),
+		prShared.FilterOptions{State: "open", Search: "sort:created"},
+		150,
+	)
+	assert.NoError(t, err)
+	assert.Len(t, reg.Requests, 2)
+}
+
+
 func TestSearchIssues_rejectsPullRequestQualifiers(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
﻿## Summary
- Write the reduced page size to `variables["limit"]` in `searchIssues` (was incorrectly writing `perPage`, which the GraphQL query ignores).
- Add a regression test that the 2nd page for `--limit 150` requests `limit: 50`.

## Test plan
- [x] `go test ./pkg/cmd/issue/list/ -run "TestSearchIssues_paginationLimit|TestIssueList$"`

Fixes #13906
