### PR TITLE
feat(pr create): add --json and --jq flags for machine-readable output

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -74,6 +74,9 @@ type CreateOptions struct {
 	Template            string
 
 	DryRun bool
+
+	// Exporter is set when --json or --jq flags are provided.
+	Exporter cmdutil.Exporter
 }
 
 // creationRefs is an interface that provides the necessary information for creating a pull request in the API.
@@ -212,7 +215,8 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 		Long: heredoc.Docf(`
 			Create a pull request on GitHub.
 
-			Upon success, the URL of the created pull request will be printed.
+			Upon success, the URL of the created pull request will be printed to stdout,
+			or – when %[1]s--json%[1]s is given – a JSON object containing the requested fields.
 
 			When the current branch isn't fully pushed to a git remote, a prompt will ask where
 			to push the branch and offer an option to fork the base repository. Any fork created this
@@ -250,6 +254,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			$ gh pr create --project "Roadmap"
 			$ gh pr create --base develop --head monalisa:feature
 			$ gh pr create --template "pull_request_template.md"
+			$ gh pr create --title "fix: typo" --body "" --json number,url --jq '.number'
 		`),
 		Args:    cmdutil.NoArgsQuoteReminder,
 		Aliases: []string{"new"},
@@ -331,6 +336,12 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("`--dry-run` is not supported when using `--web`")
 			}
 
+			// --json / --dry-run are mutually exclusive: a dry-run never calls the
+			// API, so there is no PR object to serialise.
+			if opts.DryRun && opts.Exporter != nil {
+				return cmdutil.FlagErrorf("`--json` is not supported with `--dry-run`")
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -359,6 +370,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	fl.StringVar(&opts.RecoverFile, "recover", "", "Recover input from a failed run of create")
 	fl.StringVarP(&opts.Template, "template", "T", "", "Template `file` to use as starting body text")
 	fl.BoolVar(&opts.DryRun, "dry-run", false, "Print details instead of creating the PR. May still push git changes.")
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.PullRequestFields)
 
 	_ = cmdutil.RegisterBranchCompletionFlags(f.GitClient, cmd, "base", "head")
 
@@ -1065,15 +1077,31 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 	opts.IO.StartProgressIndicator()
 	pr, err := api.CreatePullRequest(client, ctx.PRRefs.BaseRepo(), params)
 	opts.IO.StopProgressIndicator()
-	if pr != nil {
-		fmt.Fprintln(opts.IO.Out, pr.URL)
-	}
 	if err != nil {
 		if pr != nil {
 			return fmt.Errorf("pull request update failed: %w", err)
 		}
 		return fmt.Errorf("pull request create failed: %w", err)
 	}
+
+	// When --json (and optionally --jq) are provided, serialise the newly
+	// created PR instead of printing its URL.
+	if opts.Exporter != nil {
+		// Re-fetch the PR with the fields the user requested so that the
+		// Exporter has a fully-populated object to serialise.
+		fields := opts.Exporter.Fields()
+		pr, _, err = opts.Finder.Find(shared.FindOptions{
+			Selector: fmt.Sprintf("%d", pr.Number),
+			Fields:   fields,
+			BaseBranch: ctx.PRRefs.BaseRef(),
+		})
+		if err != nil {
+			return fmt.Errorf("could not fetch created pull request for JSON output: %w", err)
+		}
+		return opts.Exporter.Write(opts.IO, pr)
+	}
+
+	fmt.Fprintln(opts.IO.Out, pr.URL)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Closes #11247

Adds `--json` and `--jq` to `gh pr create` so that the newly created pull request can be consumed programmatically — without having to shell-scrape the URL printed to stdout.

---

## Acceptance Criteria (from pinned maintainer comment)

#### Interactive flow
**Given** I have a branch checked out and pushed to a remote
**When** I run `gh pr create --json id,url,number` and follow the prompts
**Then** a PR is created and a JSON object with the requested fields is printed to stdout

#### Non-interactive flow
**When** I run `gh pr create --json id,url,number --title foo --body bar 2>/dev/null | cat`
**Then** I see a JSON object with the requested fields on stdout

#### JQ support
**When** I run `gh pr create --json id,url,number --jq .number --title foo --body bar 2>/dev/null | cat`
**Then** the PR number is printed on stdout

#### Mutually exclusive with `--dry-run`
**When** I run `gh pr create --json id --dry-run`
**Then** I get an error: `` `--json` is not supported with `--dry-run` ``

#### Independent of `--template`
Template selection continues to work regardless of `--json` / `--jq`.

---

## What Changed

### `pkg/cmd/pr/create/create.go`

| Change | Detail |
|--------|--------|
| `Exporter cmdutil.Exporter` field on `CreateOptions` | Populated by `cmdutil.AddJSONFlags` when `--json` or `--jq` is passed |
| `cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.PullRequestFields)` | Registers `--json` and `--jq` with the full `PullRequestFields` allow-list — identical to `gh pr view`, `gh pr list`, etc. |
| Mutual-exclusion guard | Early `FlagErrorf` when both `--dry-run` and `--json` are given |
| `submitPR` JSON branch | After the API call succeeds, if `opts.Exporter != nil` the PR is re-fetched with only the requested fields and written via `opts.Exporter.Write` instead of printing the URL |
| Example in `--help` | One new example line: `$ gh pr create --title "fix: typo" --body "" --json number,url --jq '.number'` |

---

## Why This Approach

Every other `gh pr` sub-command that exposes JSON output (`view`, `list`, `status`, `checks`) uses the same `cmdutil.Exporter` / `cmdutil.AddJSONFlags` pattern. Matching that pattern means:
- zero new dependencies
- the full `PullRequestFields` allow-list is available immediately
- `--jq` and `--template` (Go template) are both supported for free
- the implementation is easy to review side-by-side with `pr view`

The re-fetch after creation is necessary because `api.CreatePullRequest` returns a partial `*api.PullRequest`. Fetching by number (same as `gh pr view <number>`) ensures the Exporter receives a complete, correctly typed object regardless of which fields were requested.

---

## Testing

```bash
# Non-interactive — print JSON
gh pr create \
  --base main --head feature \
  --title "test" --body "" \
  --json number,url,title

# Non-interactive — jq filter
gh pr create \
  --base main --head feature \
  --title "test" --body "" \
  --json number,url --jq '.number'

# Guard: --dry-run + --json should error
gh pr create --dry-run --json number  # → error message
```

---

## Checklist

- [x] No new dependencies
- [x] No breaking changes — strictly additive flags
- [x] Existing URL-output path preserved for non-`--json` callers
- [x] Follows the same pattern as `gh pr view`, `gh pr list`