### PR TITLE
Add android/arm64 release binary for Termux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,6 +45,23 @@ builds:
     ldflags:
       - -s -w -X github.com/cli/cli/v2/internal/build.Version={{.Version}} -X github.com/cli/cli/v2/internal/build.Date={{time "2006-01-02"}}
 
+  # android is cross-built on the linux release job (see #build:linux).
+  # Termux and similar environments need GOOS=android; linux/* binaries can
+  # SIGSYS on Android seccomp (see cli/cli#13924).
+  - id: android #build:linux
+    goos: [android]
+    goarch: [arm64]
+    env:
+      - CGO_ENABLED=0
+    hooks:
+      pre:
+        - cmd: bash ./script/licenses {{ .Os }} {{ .Arch }}
+          output: true
+    binary: bin/gh
+    main: ./cmd/gh
+    ldflags:
+      - -s -w -X github.com/cli/cli/v2/internal/build.Version={{.Version}} -X github.com/cli/cli/v2/internal/build.Date={{time "2006-01-02"}}
+
   - id: windows #build:windows
     goos: [windows]
     goarch: ["386", amd64, arm64]
@@ -64,6 +81,14 @@ archives:
   - id: linux-archive
     ids: [linux]
     name_template: "gh_{{ .Version }}_linux_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    wrap_in_directory: true
+    formats: [tar.gz]
+    files:
+      - LICENSE
+      - ./share/man/man1/gh*.1
+  - id: android-archive
+    ids: [android]
+    name_template: "gh_{{ .Version }}_android_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     wrap_in_directory: true
     formats: [tar.gz]
     files:

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -215,6 +215,8 @@ To install and upgrade:
 pkg install gh
 ```
 
+If you install from [GitHub CLI releases](https://github.com/cli/cli/releases/latest) on Termux (or similar Android environments), use the `android_arm64` archive. The `linux_*` binaries can crash with `SIGSYS` on Android.
+
 ### Arch Linux
 
 The [GitHub CLI package](https://www.archlinux.org/packages/extra/x86_64/github-cli) is supported by the Arch Linux community with updates powered by [Arch Linux packaging](https://gitlab.archlinux.org/archlinux/packaging/packages/github-cli).

--- a/internal/licenses/embed_android_arm64.go
+++ b/internal/licenses/embed_android_arm64.go
@@ -1,0 +1,10 @@
+//go:build android && arm64
+
+package licenses
+
+import "embed"
+
+const rootDir = "embed/android-arm64"
+
+//go:embed all:embed/android-arm64
+var embedFS embed.FS

--- a/internal/licenses/embed_default.go
+++ b/internal/licenses/embed_default.go
@@ -3,7 +3,7 @@
 // would fail due to undefined symbols that are expected to be included in the
 // build.
 
-//go:build !(darwin && (amd64 || arm64)) && !(linux && (386 || amd64 || arm || arm64)) && !(windows && (386 || amd64 || arm64))
+//go:build !(darwin && (amd64 || arm64)) && !(linux && !android && (386 || amd64 || arm || arm64)) && !(android && arm64) && !(windows && (386 || amd64 || arm64))
 
 package licenses
 

--- a/internal/licenses/embed_linux_386.go
+++ b/internal/licenses/embed_linux_386.go
@@ -1,3 +1,5 @@
+//go:build linux && !android
+
 package licenses
 
 import "embed"

--- a/internal/licenses/embed_linux_amd64.go
+++ b/internal/licenses/embed_linux_amd64.go
@@ -1,3 +1,5 @@
+//go:build linux && !android
+
 package licenses
 
 import "embed"

--- a/internal/licenses/embed_linux_arm.go
+++ b/internal/licenses/embed_linux_arm.go
@@ -1,3 +1,5 @@
+//go:build linux && !android
+
 package licenses
 
 import "embed"

--- a/internal/licenses/embed_linux_arm64.go
+++ b/internal/licenses/embed_linux_arm64.go
@@ -1,3 +1,5 @@
+//go:build linux && !android
+
 package licenses
 
 import "embed"

--- a/script/licenses
+++ b/script/licenses
@@ -61,13 +61,13 @@ generate_licenses() {
 if [ "$1" = "--check" ]; then
     # Verify license generation works for all release platforms.
     # This runs the same go-licenses report command that goreleaser pre-build hooks
-    # will run at release time, for all 9 GOOS/GOARCH combinations. Running this in
+    # will run at release time, for all 10 GOOS/GOARCH combinations. Running this in
     # CI on every PR ensures we catch issues (e.g., template errors, go-licenses
     # incompatibilities, dependency resolution failures) before they block a release.
     TEMPDIR="$(mktemp -d)"
     trap "rm -fr ${TEMPDIR}" EXIT
 
-    for platform in linux/386 linux/arm linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/386 windows/amd64 windows/arm64; do
+    for platform in linux/386 linux/arm linux/amd64 linux/arm64 android/arm64 darwin/amd64 darwin/arm64 windows/386 windows/amd64 windows/arm64; do
         goos="${platform%/*}"
         goarch="${platform#*/}"
         generate_licenses "${goos}" "${goarch}" "${TEMPDIR}/${goos}-${goarch}"


### PR DESCRIPTION
## Summary

- Ship an official `GOOS=android GOARCH=arm64` release binary (linux-parity `.tar.gz` with `LICENSE` + man pages) from the existing linux release job.
- Official `linux/*` assets crash on Termux with `SIGSYS` (seccomp) during init before `main` runs; see #13924.
- Add android license embed (and `linux && !android` guards so Go's android-as-linux variant does not double-define embeds), extend `script/licenses --check`, and note in the Android install docs that Termux users should use the `android_arm64` archive from GitHub Releases.

Verified locally with a cross-built `android/arm64` binary on Termux: process starts and basic commands run (no SIGSYS). Networking quirks for Go apps on Termux are out of scope here.

## Test plan

- [x] `CGO_ENABLED=0 GOOS=android GOARCH=arm64 go build ./cmd/gh` succeeds
- [x] Binary runs on Termux without `SIGSYS` (`gh version` / help)
- [ ] Release dry-run / staging produces `gh_*_android_arm64.tar.gz` on the linux job
- [ ] Confirm license embed generation for `android/arm64` in release hooks

Closes #13924