### PR TITLE
Add multi-select field support to gh project

### DIFF
--- a/pkg/cmd/project/field-create/field_create.go
+++ b/pkg/cmd/project/field-create/field_create.go
@@ -18,6 +18,7 @@ type createFieldOpts struct {
 	dataType            string
 	owner               string
 	singleSelectOptions []string
+	multiSelectOptions  []string
 	number              int32
 	projectID           string
 	exporter            cmdutil.Exporter
@@ -35,6 +36,21 @@ type createProjectV2FieldMutation struct {
 	} `graphql:"createProjectV2Field(input:$input)"`
 }
 
+// CreateProjectV2FieldInput is defined locally because the vendored githubv4 lacks multiSelectOptions.
+type CreateProjectV2FieldInput struct {
+	ProjectID           githubv4.ID                                       `json:"projectId"`
+	DataType            githubv4.ProjectV2CustomFieldType                 `json:"dataType"`
+	Name                githubv4.String                                   `json:"name"`
+	SingleSelectOptions *[]githubv4.ProjectV2SingleSelectFieldOptionInput `json:"singleSelectOptions,omitempty"`
+	MultiSelectOptions  *[]ProjectV2MultiSelectFieldOptionInput           `json:"multiSelectOptions,omitempty"`
+}
+
+type ProjectV2MultiSelectFieldOptionInput struct {
+	Name        githubv4.String                                `json:"name"`
+	Color       githubv4.ProjectV2SingleSelectFieldOptionColor `json:"color"`
+	Description githubv4.String                                `json:"description"`
+}
+
 func NewCmdCreateField(f *cmdutil.Factory, runF func(config createFieldConfig) error) *cobra.Command {
 	opts := createFieldOpts{}
 	createFieldCmd := &cobra.Command{
@@ -46,6 +62,9 @@ func NewCmdCreateField(f *cmdutil.Factory, runF func(config createFieldConfig) e
 
 			# Create a field with three options to select from for owner monalisa
 			$ gh project field-create 1 --owner monalisa --name "new field" --data-type "SINGLE_SELECT" --single-select-options "one,two,three"
+
+			# Create a multi-select field with three options for owner monalisa
+			$ gh project field-create 1 --owner monalisa --name "new field" --data-type "MULTI_SELECT" --multi-select-options "one,two,three"
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -71,6 +90,9 @@ func NewCmdCreateField(f *cmdutil.Factory, runF func(config createFieldConfig) e
 			if config.opts.dataType == "SINGLE_SELECT" && len(config.opts.singleSelectOptions) == 0 {
 				return fmt.Errorf("passing `--single-select-options` is required for SINGLE_SELECT data type")
 			}
+			if config.opts.dataType == "MULTI_SELECT" && len(config.opts.multiSelectOptions) == 0 {
+				return fmt.Errorf("passing `--multi-select-options` is required for MULTI_SELECT data type")
+			}
 
 			// allow testing of the command without actually running it
 			if runF != nil {
@@ -82,8 +104,9 @@ func NewCmdCreateField(f *cmdutil.Factory, runF func(config createFieldConfig) e
 
 	createFieldCmd.Flags().StringVar(&opts.owner, "owner", "", "Login of the owner. Use \"@me\" for the current user.")
 	createFieldCmd.Flags().StringVar(&opts.name, "name", "", "Name of the new field")
-	cmdutil.StringEnumFlag(createFieldCmd, &opts.dataType, "data-type", "", "", []string{"TEXT", "SINGLE_SELECT", "DATE", "NUMBER"}, "DataType of the new field.")
+	cmdutil.StringEnumFlag(createFieldCmd, &opts.dataType, "data-type", "", "", []string{"TEXT", "SINGLE_SELECT", "DATE", "NUMBER", "MULTI_SELECT"}, "DataType of the new field.")
 	createFieldCmd.Flags().StringSliceVar(&opts.singleSelectOptions, "single-select-options", []string{}, "Options for SINGLE_SELECT data type")
+	createFieldCmd.Flags().StringSliceVar(&opts.multiSelectOptions, "multi-select-options", []string{}, "Options for MULTI_SELECT data type")
 	cmdutil.AddFormatFlags(createFieldCmd, &opts.exporter)
 
 	_ = createFieldCmd.MarkFlagRequired("name")
@@ -120,7 +143,7 @@ func runCreateField(config createFieldConfig) error {
 }
 
 func createFieldArgs(config createFieldConfig) (*createProjectV2FieldMutation, map[string]interface{}) {
-	input := githubv4.CreateProjectV2FieldInput{
+	input := CreateProjectV2FieldInput{
 		ProjectID: githubv4.ID(config.opts.projectID),
 		DataType:  githubv4.ProjectV2CustomFieldType(config.opts.dataType),
 		Name:      githubv4.String(config.opts.name),
@@ -135,6 +158,17 @@ func createFieldArgs(config createFieldConfig) (*createProjectV2FieldMutation, m
 			})
 		}
 		input.SingleSelectOptions = &opts
+	}
+
+	if len(config.opts.multiSelectOptions) != 0 {
+		opts := make([]ProjectV2MultiSelectFieldOptionInput, 0)
+		for _, opt := range config.opts.multiSelectOptions {
+			opts = append(opts, ProjectV2MultiSelectFieldOptionInput{
+				Name:  githubv4.String(opt),
+				Color: githubv4.ProjectV2SingleSelectFieldOptionColor("GRAY"),
+			})
+		}
+		input.MultiSelectOptions = &opts
 	}
 
 	return &createProjectV2FieldMutation{}, map[string]interface{}{

--- a/pkg/cmd/project/field-create/field_create_test.go
+++ b/pkg/cmd/project/field-create/field_create_test.go
@@ -724,3 +724,93 @@ func TestRunCreateField_JSON(t *testing.T) {
 		`{"id":"Field ID","name":"a name","type":"ProjectV2Field"}`,
 		stdout.String())
 }
+
+func TestRunCreateField_MULTI_SELECT(t *testing.T) {
+	defer gock.Off()
+
+	// get user ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserOrgOwner.*",
+			"variables": map[string]interface{}{
+				"login": "monalisa",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"id": "an ID",
+				},
+			},
+			"errors": []interface{}{
+				map[string]interface{}{
+					"type": "NOT_FOUND",
+					"path": []string{"organization"},
+				},
+			},
+		})
+
+	// get project ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  0,
+				"afterItems":  nil,
+				"firstFields": 0,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"id": "an ID",
+					},
+				},
+			},
+		})
+
+	// create the multi-select field with its options
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation CreateField.*","variables":{"input":{"projectId":"an ID","dataType":"MULTI_SELECT","name":"a name","multiSelectOptions":\[{"name":"one","color":"GRAY","description":""},{"name":"two","color":"GRAY","description":""}\]}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"createProjectV2Field": map[string]interface{}{
+					"projectV2Field": map[string]interface{}{
+						"id": "Field ID",
+					},
+				},
+			},
+		})
+
+	client := queries.NewTestClient()
+
+	ios, _, stdout, _ := iostreams.Test()
+	ios.SetStdoutTTY(true)
+	config := createFieldConfig{
+		opts: createFieldOpts{
+			name:               "a name",
+			owner:              "monalisa",
+			number:             1,
+			dataType:           "MULTI_SELECT",
+			multiSelectOptions: []string{"one", "two"},
+		},
+		client: client,
+		io:     ios,
+	}
+
+	err := runCreateField(config)
+	assert.NoError(t, err)
+	assert.Equal(t, "Created field\n", stdout.String())
+}

--- a/pkg/cmd/project/item-edit/item_edit.go
+++ b/pkg/cmd/project/item-edit/item_edit.go
@@ -30,6 +30,7 @@ type editItemOpts struct {
 	numberChanged        bool
 	date                 string
 	singleSelectOptionID string
+	multiSelectOptionIDs []string
 	iterationID          string
 	clear                bool
 	// name-based resolution
@@ -71,6 +72,23 @@ type ClearProjectV2FieldValue struct {
 	Clear struct {
 		Item queries.ProjectItem `graphql:"projectV2Item"`
 	} `graphql:"clearProjectV2ItemFieldValue(input:$input)"`
+}
+
+// ProjectV2FieldValue is defined locally because the vendored githubv4 lacks multiSelectOptionIds.
+type ProjectV2FieldValue struct {
+	Text                 *githubv4.String `json:"text,omitempty"`
+	Number               *githubv4.Float  `json:"number,omitempty"`
+	Date                 *githubv4.Date   `json:"date,omitempty"`
+	SingleSelectOptionID *githubv4.String `json:"singleSelectOptionId,omitempty"`
+	IterationID          *githubv4.String `json:"iterationId,omitempty"`
+	MultiSelectOptionIDs *[]string        `json:"multiSelectOptionIds,omitempty"`
+}
+
+type UpdateProjectV2ItemFieldValueInput struct {
+	ProjectID githubv4.ID         `json:"projectId"`
+	ItemID    githubv4.ID         `json:"itemId"`
+	FieldID   githubv4.ID         `json:"fieldId"`
+	Value     ProjectV2FieldValue `json:"value"`
 }
 
 func NewCmdEditItem(f *cmdutil.Factory, runF func(config editItemConfig) error) *cobra.Command {
@@ -123,11 +141,12 @@ func NewCmdEditItem(f *cmdutil.Factory, runF func(config editItemConfig) error) 
 			}
 
 			if err := cmdutil.MutuallyExclusive(
-				"only one of `--text`, `--number`, `--date`, `--single-select-option-id`, `--iteration-id` or `--value` may be used",
+				"only one of `--text`, `--number`, `--date`, `--single-select-option-id`, `--multi-select-option-ids`, `--iteration-id` or `--value` may be used",
 				opts.text != "",
 				opts.numberChanged,
 				opts.date != "",
 				opts.singleSelectOptionID != "",
+				len(opts.multiSelectOptionIDs) > 0,
 				opts.iterationID != "",
 				opts.valueChanged,
 			); err != nil {
@@ -151,8 +170,8 @@ func NewCmdEditItem(f *cmdutil.Factory, runF func(config editItemConfig) error) 
 			}
 
 			if err := cmdutil.MutuallyExclusive(
-				"cannot use `--text`, `--number`, `--date`, `--single-select-option-id`, `--iteration-id` or `--value` in conjunction with `--clear`",
-				opts.text != "" || opts.numberChanged || opts.date != "" || opts.singleSelectOptionID != "" || opts.iterationID != "" || opts.valueChanged,
+				"cannot use `--text`, `--number`, `--date`, `--single-select-option-id`, `--multi-select-option-ids`, `--iteration-id` or `--value` in conjunction with `--clear`",
+				opts.text != "" || opts.numberChanged || opts.date != "" || opts.singleSelectOptionID != "" || len(opts.multiSelectOptionIDs) > 0 || opts.iterationID != "" || opts.valueChanged,
 				opts.clear,
 			); err != nil {
 				return err
@@ -216,6 +235,7 @@ func NewCmdEditItem(f *cmdutil.Factory, runF func(config editItemConfig) error) 
 	editItemCmd.Flags().Float64Var(&opts.number, "number", 0, "Number value for the field")
 	editItemCmd.Flags().StringVar(&opts.date, "date", "", "Date value for the field (YYYY-MM-DD)")
 	editItemCmd.Flags().StringVar(&opts.singleSelectOptionID, "single-select-option-id", "", "ID of the single select option value to set on the field")
+	editItemCmd.Flags().StringSliceVar(&opts.multiSelectOptionIDs, "multi-select-option-ids", nil, "IDs of the multi select option values to set on the field")
 	editItemCmd.Flags().StringVar(&opts.iterationID, "iteration-id", "", "ID of the iteration value to set on the field")
 	editItemCmd.Flags().BoolVar(&opts.clear, "clear", false, "Remove field value")
 
@@ -244,7 +264,7 @@ func runEditItem(config editItemConfig) error {
 	}
 
 	// update item values
-	if config.opts.text != "" || config.opts.numberChanged || config.opts.date != "" || config.opts.singleSelectOptionID != "" || config.opts.iterationID != "" {
+	if config.opts.text != "" || config.opts.numberChanged || config.opts.date != "" || config.opts.singleSelectOptionID != "" || len(config.opts.multiSelectOptionIDs) > 0 || config.opts.iterationID != "" {
 		return updateItemValues(config)
 	}
 
@@ -252,6 +272,19 @@ func runEditItem(config editItemConfig) error {
 		return err
 	}
 	return cmdutil.SilentError
+}
+
+// splitOptionNames splits a comma-separated --value into individual option names
+// for multi-select fields, trimming surrounding spaces and dropping empties.
+func splitOptionNames(value string) []string {
+	parts := strings.Split(value, ",")
+	names := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			names = append(names, p)
+		}
+	}
+	return names
 }
 
 // resolveItemEditNames turns the name-based addressing flags into the node IDs
@@ -305,6 +338,12 @@ func resolveItemEditNames(config editItemConfig) (editItemConfig, error) {
 			return config, err
 		}
 		config.opts.singleSelectOptionID = optionID
+	case "MULTI_SELECT":
+		optionIDs, err := queries.ResolveMultiSelectOptionIDs(field, splitOptionNames(config.opts.value))
+		if err != nil {
+			return config, err
+		}
+		config.opts.multiSelectOptionIDs = optionIDs
 	case "TEXT":
 		config.opts.text = config.opts.value
 	case "NUMBER":
@@ -364,31 +403,36 @@ func buildEditDraftIssue(config editItemConfig, currentDraftIssue *queries.Draft
 }
 
 func buildUpdateItem(config editItemConfig, date time.Time) (*UpdateProjectV2FieldValue, map[string]interface{}) {
-	var value githubv4.ProjectV2FieldValue
+	var value ProjectV2FieldValue
 	if config.opts.text != "" {
-		value = githubv4.ProjectV2FieldValue{
+		value = ProjectV2FieldValue{
 			Text: githubv4.NewString(githubv4.String(config.opts.text)),
 		}
 	} else if config.opts.numberChanged {
-		value = githubv4.ProjectV2FieldValue{
+		value = ProjectV2FieldValue{
 			Number: githubv4.NewFloat(githubv4.Float(config.opts.number)),
 		}
 	} else if config.opts.date != "" {
-		value = githubv4.ProjectV2FieldValue{
+		value = ProjectV2FieldValue{
 			Date: githubv4.NewDate(githubv4.Date{Time: date}),
 		}
 	} else if config.opts.singleSelectOptionID != "" {
-		value = githubv4.ProjectV2FieldValue{
+		value = ProjectV2FieldValue{
 			SingleSelectOptionID: githubv4.NewString(githubv4.String(config.opts.singleSelectOptionID)),
 		}
 	} else if config.opts.iterationID != "" {
-		value = githubv4.ProjectV2FieldValue{
+		value = ProjectV2FieldValue{
 			IterationID: githubv4.NewString(githubv4.String(config.opts.iterationID)),
+		}
+	} else if len(config.opts.multiSelectOptionIDs) > 0 {
+		ids := config.opts.multiSelectOptionIDs
+		value = ProjectV2FieldValue{
+			MultiSelectOptionIDs: &ids,
 		}
 	}
 
 	return &UpdateProjectV2FieldValue{}, map[string]interface{}{
-		"input": githubv4.UpdateProjectV2ItemFieldValueInput{
+		"input": UpdateProjectV2ItemFieldValueInput{
 			ProjectID: githubv4.ID(config.opts.projectID),
 			ItemID:    githubv4.ID(config.opts.itemID),
 			FieldID:   githubv4.ID(config.opts.fieldID),

--- a/pkg/cmd/project/item-edit/item_edit_test.go
+++ b/pkg/cmd/project/item-edit/item_edit_test.go
@@ -30,7 +30,7 @@ func TestNewCmdeditItem(t *testing.T) {
 			name:        "invalid-flags",
 			cli:         "--id 123 --text t --date 2023-01-01",
 			wantsErr:    true,
-			wantsErrMsg: "only one of `--text`, `--number`, `--date`, `--single-select-option-id`, `--iteration-id` or `--value` may be used",
+			wantsErrMsg: "only one of `--text`, `--number`, `--date`, `--single-select-option-id`, `--multi-select-option-ids`, `--iteration-id` or `--value` may be used",
 		},
 		{
 			name:        "field and field-id conflict",
@@ -48,7 +48,7 @@ func TestNewCmdeditItem(t *testing.T) {
 			name:        "value and single-select-option-id conflict",
 			cli:         "--url https://github.com/o/r/issues/1 --field Status --value Todo --single-select-option-id OPTION_ID",
 			wantsErr:    true,
-			wantsErrMsg: "only one of `--text`, `--number`, `--date`, `--single-select-option-id`, `--iteration-id` or `--value` may be used",
+			wantsErrMsg: "only one of `--text`, `--number`, `--date`, `--single-select-option-id`, `--multi-select-option-ids`, `--iteration-id` or `--value` may be used",
 		},
 		{
 			name:        "value requires field",
@@ -1534,5 +1534,180 @@ func TestRunItemEdit_ByName_WrongFieldType(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `field "Title" has data type "TITLE"`)
 	assert.Contains(t, err.Error(), "not supported with `--value`")
+	assert.True(t, gock.IsDone())
+}
+
+func TestRunItemEdit_MultiSelect(t *testing.T) {
+	defer gock.Off()
+	// gock.Observe(gock.DumpRequest)
+
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"multiSelectOptionIds":\["opt_ios","opt_android"\]}}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"updateProjectV2ItemFieldValue": map[string]interface{}{
+					"projectV2Item": map[string]interface{}{
+						"id": "item_id",
+						"content": map[string]interface{}{
+							"__typename": "Issue",
+							"title":      "an issue",
+						},
+					},
+				},
+			},
+		})
+
+	client := queries.NewTestClient()
+
+	ios, _, stdout, _ := iostreams.Test()
+	config := editItemConfig{
+		io: ios,
+		opts: editItemOpts{
+			itemID:               "item_id",
+			projectID:            "project_id",
+			fieldID:              "field_id",
+			multiSelectOptionIDs: []string{"opt_ios", "opt_android"},
+		},
+		client: client,
+	}
+
+	err := runEditItem(config)
+	assert.NoError(t, err)
+	assert.Equal(t, "", stdout.String())
+	assert.True(t, gock.IsDone())
+}
+
+func TestRunItemEdit_ByName_MultiSelect(t *testing.T) {
+	defer gock.Off()
+
+	// resolve owner
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		JSON(map[string]interface{}{
+			"query": "query UserOrgOwner.*",
+			"variables": map[string]interface{}{
+				"login": "monalisa",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"id": "user ID",
+				},
+			},
+			"errors": []interface{}{
+				map[string]interface{}{
+					"type": "NOT_FOUND",
+					"path": []string{"organization"},
+				},
+			},
+		})
+
+	// resolve project + fields (Platforms is a multi-select field)
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  queries.LimitMax,
+				"afterItems":  nil,
+				"firstFields": queries.LimitMax,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"id": "project ID",
+						"fields": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"__typename": "ProjectV2MultiSelectField",
+									"id":         "platforms ID",
+									"name":       "Platforms",
+									"dataType":   "MULTI_SELECT",
+									"multiSelectOptions": []map[string]interface{}{
+										{"id": "opt_ios", "name": "iOS"},
+										{"id": "opt_web", "name": "Web"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+	// resolve item by URL
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		JSON(map[string]interface{}{
+			"query": "query GetProjectItemByURL.*",
+			"variables": map[string]interface{}{
+				"url":        "https://github.com/monalisa/repo/issues/1",
+				"firstItems": queries.LimitMax,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"resource": map[string]interface{}{
+					"__typename": "Issue",
+					"projectItems": map[string]interface{}{
+						"nodes": []map[string]interface{}{
+							{"id": "item ID", "project": map[string]interface{}{"id": "project ID"}},
+						},
+					},
+				},
+			},
+		})
+
+	// mutation uses the resolved option IDs, preserving order
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project ID","itemId":"item ID","fieldId":"platforms ID","value":{"multiSelectOptionIds":\["opt_ios","opt_web"\]}}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"updateProjectV2ItemFieldValue": map[string]interface{}{
+					"projectV2Item": map[string]interface{}{
+						"id": "item ID",
+						"content": map[string]interface{}{
+							"__typename": "Issue",
+							"title":      "an issue",
+						},
+					},
+				},
+			},
+		})
+
+	client := queries.NewTestClient()
+
+	ios, _, stdout, _ := iostreams.Test()
+	ios.SetStdoutTTY(true)
+
+	config := editItemConfig{
+		io: ios,
+		opts: editItemOpts{
+			owner:        "monalisa",
+			number32:     1,
+			url:          "https://github.com/monalisa/repo/issues/1",
+			field:        "Platforms",
+			value:        "iOS, Web",
+			valueChanged: true,
+		},
+		client: client,
+	}
+
+	err := runEditItem(config)
+	assert.NoError(t, err)
+	assert.Equal(t, "Edited item \"an issue\"\n", stdout.String())
 	assert.True(t, gock.IsDone())
 }

--- a/pkg/cmd/project/shared/queries/export_data_test.go
+++ b/pkg/cmd/project/shared/queries/export_data_test.go
@@ -365,3 +365,50 @@ func TestJSONProjectItem_DraftIssue_ProjectV2ItemFieldMilestoneValue(t *testing.
 		string(out))
 
 }
+
+func TestJSONProjectItem_ProjectV2ItemFieldMultiSelectValue(t *testing.T) {
+	multiSelectField := ProjectField{TypeName: "ProjectV2MultiSelectField"}
+	multiSelectField.MultiSelectField.ID = "PVTMSF_platforms"
+	multiSelectField.MultiSelectField.Name = "Platforms"
+
+	multiSelectValue := FieldValueNodes{Type: "ProjectV2ItemFieldMultiSelectValue"}
+	multiSelectValue.ProjectV2ItemFieldMultiSelectValue.Field = multiSelectField
+	multiSelectValue.ProjectV2ItemFieldMultiSelectValue.Options = []struct {
+		ID   string
+		Name string
+	}{
+		{ID: "opt_ios", Name: "iOS"},
+		{ID: "opt_android", Name: "Android"},
+	}
+
+	item := ProjectItem{
+		Id: "issueId",
+		Content: ProjectItemContent{
+			TypeName: "Issue",
+			Issue: Issue{
+				Title:  "Issue title",
+				Body:   "a body",
+				Number: 1,
+				URL:    "issue-url",
+				Repository: struct {
+					NameWithOwner string
+				}{
+					NameWithOwner: "cli/go-gh",
+				},
+			},
+		},
+	}
+	item.FieldValues.Nodes = []FieldValueNodes{multiSelectValue}
+
+	p := &Project{}
+	p.Fields.Nodes = []ProjectField{multiSelectField}
+	p.Items.TotalCount = 1
+	p.Items.Nodes = []ProjectItem{item}
+
+	out, err := json.Marshal(p.DetailedItems())
+	assert.NoError(t, err)
+	assert.JSONEq(
+		t,
+		`{"items":[{"platforms":["iOS","Android"],"content":{"type":"Issue","body":"a body","title":"Issue title","number":1,"repository":"cli/go-gh","url":"issue-url"},"id":"issueId"}],"totalCount":1}`,
+		string(out))
+}

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -441,6 +441,13 @@ type FieldValueNodes struct {
 		} `graphql:"reviewers(first: 10)"` // experienced issues with larger limits, 10 seems like enough for now
 		Field ProjectField
 	} `graphql:"... on ProjectV2ItemFieldReviewerValue"`
+	ProjectV2ItemFieldMultiSelectValue struct {
+		Options []struct {
+			ID   string
+			Name string
+		}
+		Field ProjectField
+	} `graphql:"... on ProjectV2ItemFieldMultiSelectValue"`
 }
 
 func (v FieldValueNodes) ID() string {
@@ -467,6 +474,8 @@ func (v FieldValueNodes) ID() string {
 		return v.ProjectV2ItemFieldUserValue.Field.ID()
 	case "ProjectV2ItemFieldReviewerValue":
 		return v.ProjectV2ItemFieldReviewerValue.Field.ID()
+	case "ProjectV2ItemFieldMultiSelectValue":
+		return v.ProjectV2ItemFieldMultiSelectValue.Field.ID()
 	}
 
 	return ""
@@ -940,6 +949,12 @@ type ProjectField struct {
 		DataType string
 		Options  []SingleSelectFieldOptions
 	} `graphql:"... on ProjectV2SingleSelectField"`
+	MultiSelectField struct {
+		ID       string
+		Name     string
+		DataType string
+		Options  []SingleSelectFieldOptions `graphql:"multiSelectOptions"`
+	} `graphql:"... on ProjectV2MultiSelectField"`
 }
 
 // ID is the ID of the project field.
@@ -950,6 +965,8 @@ func (p ProjectField) ID() string {
 		return p.IterationField.ID
 	} else if p.TypeName == "ProjectV2SingleSelectField" {
 		return p.SingleSelectField.ID
+	} else if p.TypeName == "ProjectV2MultiSelectField" {
+		return p.MultiSelectField.ID
 	}
 	return ""
 }
@@ -962,6 +979,8 @@ func (p ProjectField) Name() string {
 		return p.IterationField.Name
 	} else if p.TypeName == "ProjectV2SingleSelectField" {
 		return p.SingleSelectField.Name
+	} else if p.TypeName == "ProjectV2MultiSelectField" {
+		return p.MultiSelectField.Name
 	}
 	return ""
 }
@@ -981,6 +1000,8 @@ func (p ProjectField) DataType() string {
 		return p.IterationField.DataType
 	case "ProjectV2SingleSelectField":
 		return p.SingleSelectField.DataType
+	case "ProjectV2MultiSelectField":
+		return p.MultiSelectField.DataType
 	}
 	return ""
 }
@@ -1001,6 +1022,16 @@ func (p ProjectField) Options() []SingleSelectFieldOptions {
 	if p.TypeName == "ProjectV2SingleSelectField" {
 		var options []SingleSelectFieldOptions
 		for _, o := range p.SingleSelectField.Options {
+			options = append(options, SingleSelectFieldOptions{
+				ID:   o.ID,
+				Name: o.Name,
+			})
+		}
+		return options
+	}
+	if p.TypeName == "ProjectV2MultiSelectField" {
+		var options []SingleSelectFieldOptions
+		for _, o := range p.MultiSelectField.Options {
 			options = append(options, SingleSelectFieldOptions{
 				ID:   o.ID,
 				Name: o.Name,
@@ -1765,6 +1796,12 @@ func projectFieldValueData(v FieldValueNodes) interface{} {
 			} else if p.Type == "User" {
 				names = append(names, p.User.Login)
 			}
+		}
+		return names
+	case "ProjectV2ItemFieldMultiSelectValue":
+		names := make([]string, 0)
+		for _, p := range v.ProjectV2ItemFieldMultiSelectValue.Options {
+			names = append(names, p.Name)
 		}
 		return names
 

--- a/pkg/cmd/project/shared/queries/resolve.go
+++ b/pkg/cmd/project/shared/queries/resolve.go
@@ -114,6 +114,45 @@ func ResolveSingleSelectOptionID(field ProjectField, optionName string) (string,
 	}
 }
 
+// ResolveMultiSelectOptionIDs resolves each name in optionNames to its option ID
+// on a multi-select field, preserving order. It returns a *WrongFieldTypeError
+// if the field is not a multi-select field, and a *OptionNotFoundError or
+// *OptionAmbiguousError for the first name that does not resolve to exactly one
+// option. Matching is case-insensitive, mirroring ResolveSingleSelectOptionID.
+func ResolveMultiSelectOptionIDs(field ProjectField, optionNames []string) ([]string, error) {
+	if field.Type() != "ProjectV2MultiSelectField" {
+		return nil, &WrongFieldTypeError{
+			FieldName: field.Name(),
+			DataType:  field.DataType(),
+			Expected:  "MULTI_SELECT",
+		}
+	}
+
+	ids := make([]string, 0, len(optionNames))
+	for _, name := range optionNames {
+		var matches []string
+		for _, o := range field.Options() {
+			if strings.EqualFold(o.Name, name) {
+				matches = append(matches, o.ID)
+			}
+		}
+
+		switch len(matches) {
+		case 1:
+			ids = append(ids, matches[0])
+		case 0:
+			names := make([]string, 0, len(field.Options()))
+			for _, o := range field.Options() {
+				names = append(names, o.Name)
+			}
+			return nil, &OptionNotFoundError{FieldName: field.Name(), Name: name, Candidates: names}
+		default:
+			return nil, &OptionAmbiguousError{FieldName: field.Name(), Name: name, Candidates: matches}
+		}
+	}
+	return ids, nil
+}
+
 // projectItemByURL resolves an issue or pull request URL to the ID of its
 // corresponding item on the project identified by projectID. It is used to let
 // item-edit address an item by issue/PR URL instead of a project item ID.

--- a/pkg/cmd/project/shared/queries/resolve_fields_test.go
+++ b/pkg/cmd/project/shared/queries/resolve_fields_test.go
@@ -28,6 +28,17 @@ func singleSelectField(id, name string, options []SingleSelectFieldOptions) Proj
 	return f
 }
 
+// multiSelectField builds a ProjectV2MultiSelectField fixture with the given id,
+// name, and options.
+func multiSelectField(id, name string, options []SingleSelectFieldOptions) ProjectField {
+	f := ProjectField{TypeName: "ProjectV2MultiSelectField"}
+	f.MultiSelectField.ID = id
+	f.MultiSelectField.Name = name
+	f.MultiSelectField.DataType = "MULTI_SELECT"
+	f.MultiSelectField.Options = options
+	return f
+}
+
 func TestResolveFieldByName(t *testing.T) {
 	fields := []ProjectField{
 		textField("PVTF_title", "Title"),

--- a/pkg/cmd/project/shared/queries/resolve_test.go
+++ b/pkg/cmd/project/shared/queries/resolve_test.go
@@ -72,6 +72,44 @@ func TestResolveSingleSelectOptionID(t *testing.T) {
 	})
 }
 
+func TestResolveMultiSelectOptionIDs(t *testing.T) {
+	platforms := multiSelectField("PVTMSF_platforms", "Platforms", []SingleSelectFieldOptions{
+		{ID: "opt_ios", Name: "iOS"},
+		{ID: "opt_android", Name: "Android"},
+		{ID: "opt_web", Name: "Web"},
+	})
+
+	t.Run("resolves multiple option names to ids preserving order", func(t *testing.T) {
+		ids, err := ResolveMultiSelectOptionIDs(platforms, []string{"Web", "iOS"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"opt_web", "opt_ios"}, ids)
+	})
+
+	t.Run("resolves case-insensitively", func(t *testing.T) {
+		ids, err := ResolveMultiSelectOptionIDs(platforms, []string{"android"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"opt_android"}, ids)
+	})
+
+	t.Run("unknown option lists candidate option names", func(t *testing.T) {
+		_, err := ResolveMultiSelectOptionIDs(platforms, []string{"iOS", "Desktop"})
+		require.Error(t, err)
+		var nf *OptionNotFoundError
+		require.True(t, errors.As(err, &nf))
+		assert.Equal(t, "Desktop", nf.Name)
+		assert.Equal(t, []string{"iOS", "Android", "Web"}, nf.Candidates)
+	})
+
+	t.Run("wrong field type is rejected", func(t *testing.T) {
+		_, err := ResolveMultiSelectOptionIDs(textField("PVTF_title", "Title"), []string{"iOS"})
+		require.Error(t, err)
+		var wt *WrongFieldTypeError
+		require.True(t, errors.As(err, &wt))
+		assert.Equal(t, "TEXT", wt.DataType)
+		assert.Equal(t, "MULTI_SELECT", wt.Expected)
+	})
+}
+
 func TestProjectItemIDByURL(t *testing.T) {
 	t.Run("returns the item id for the matching project", func(t *testing.T) {
 		defer gock.Off()


### PR DESCRIPTION
Adds support for Projects v2 multi-select fields to the project commands.

What's included:
- Read and JSON export of multi-select values in `gh project item-list --format json`
- Set values with `gh project item-edit`, either by option IDs with `--multi-select-option-ids` or by name with a comma-separated `--value`
- Create a multi-select field with `gh project field-create --data-type MULTI_SELECT --multi-select-options "a,b,c"`
- Name based option resolution, the same way single-select works

The GraphQL input structs are defined locally because the vendored githubv4 does not have the multi-select types yet.

Draft for now. Multi-select is not in the public GraphQL schema yet, so I am holding this until it goes GA.