### PR TITLE
Add issue field support to gh CLI

### DIFF
--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -54,6 +54,10 @@ type CreateOptions struct {
 	Parent      string
 	BlockedBy   []string
 	Blocking    []string
+
+	IssueFieldName  string
+	IssueFieldID    string
+	IssueFieldValue string
 }
 
 func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Command {
@@ -95,6 +99,7 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 			$ gh issue create --parent 100
 			$ gh issue create --parent https://github.com/cli/go-gh/issues/42
 			$ gh issue create --blocked-by 200,201 --blocking 300
+			$ gh issue create --field "Team" --value "Platform"
 		`),
 		Args:    cmdutil.NoArgsQuoteReminder,
 		Aliases: []string{"new"},
@@ -134,6 +139,20 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 				return cmdutil.FlagErrorf("must provide `--title` and `--body` when not running interactively")
 			}
 
+			if opts.IssueFieldName != "" && opts.IssueFieldID != "" {
+				return cmdutil.FlagErrorf("specify only one of `--field` or `--field-id`")
+			}
+			issueFieldSelected := opts.IssueFieldName != "" || opts.IssueFieldID != ""
+			if issueFieldSelected && !cmd.Flags().Changed("value") {
+				return cmdutil.FlagErrorf("`--value` is required with `--field` or `--field-id`")
+			}
+			if cmd.Flags().Changed("value") && !issueFieldSelected {
+				return cmdutil.FlagErrorf("`--value` requires `--field` or `--field-id`")
+			}
+			if issueFieldSelected && opts.WebMode {
+				return cmdutil.FlagErrorf("`--field` is not supported with `--web`")
+			}
+
 			if runF != nil {
 				return runF(opts)
 			}
@@ -156,6 +175,9 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 	cmd.Flags().StringVar(&opts.Parent, "parent", "", "Add the new issue as a sub-issue of the specified parent `number` or URL")
 	cmd.Flags().StringSliceVar(&opts.BlockedBy, "blocked-by", nil, "Mark the new issue as blocked by these issue `numbers` or URLs")
 	cmd.Flags().StringSliceVar(&opts.Blocking, "blocking", nil, "Mark the new issue as blocking these issue `numbers` or URLs")
+	cmd.Flags().StringVar(&opts.IssueFieldName, "field", "", "Set an issue field value by field `name`")
+	cmd.Flags().StringVar(&opts.IssueFieldID, "field-id", "", "Set an issue field value by field `id`")
+	cmd.Flags().StringVar(&opts.IssueFieldValue, "value", "", "Value for the issue field set with `--field` or `--field-id`")
 
 	return cmd
 }
@@ -419,6 +441,17 @@ func createRun(opts *CreateOptions) (err error) {
 		}
 		if err = api.DeferredUpdateIssue(apiClient, updateOpts); err != nil {
 			return
+		}
+
+		if opts.IssueFieldName != "" || opts.IssueFieldID != "" {
+			var input issueShared.IssueFieldCreateOrUpdateInput
+			input, err = issueShared.BuildIssueFieldValueInput(httpClient, baseRepo, opts.IssueFieldName, opts.IssueFieldID, opts.IssueFieldValue)
+			if err != nil {
+				return
+			}
+			if err = issueShared.UpdateIssueFieldValue(httpClient, baseRepo, newIssue.ID, input); err != nil {
+				return
+			}
 		}
 
 		fmt.Fprintln(opts.IO.Out, newIssue.URL)

--- a/pkg/cmd/issue/edit-field/edit_field.go
+++ b/pkg/cmd/issue/edit-field/edit_field.go
@@ -1,0 +1,211 @@
+package editfield
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmd/issue/shared"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/spf13/cobra"
+)
+
+type EditFieldOptions struct {
+	HttpClient func() (*http.Client, error)
+	IO         *iostreams.IOStreams
+	BaseRepo   func() (ghrepo.Interface, error)
+
+	IssueNumber int
+
+	FieldID              string
+	Text                 string
+	Number               float64
+	NumberChanged        bool
+	Date                 string
+	SingleSelectOptionID string
+	MultiSelectOptionIDs []string
+	Clear                bool
+}
+
+// UpdateIssueFieldValueInput is defined locally because the vendored githubv4 lacks the issue-field types.
+type UpdateIssueFieldValueInput struct {
+	IssueID    string                        `json:"issueId"`
+	IssueField IssueFieldCreateOrUpdateInput `json:"issueField"`
+}
+
+type IssueFieldCreateOrUpdateInput struct {
+	FieldID              string    `json:"fieldId"`
+	TextValue            *string   `json:"textValue,omitempty"`
+	NumberValue          *float64  `json:"numberValue,omitempty"`
+	DateValue            *string   `json:"dateValue,omitempty"`
+	SingleSelectOptionID *string   `json:"singleSelectOptionId,omitempty"`
+	MultiSelectOptionIDs *[]string `json:"multiSelectOptionIds,omitempty"`
+	Delete               *bool     `json:"delete,omitempty"`
+}
+
+func NewCmdEditField(f *cmdutil.Factory, runF func(*EditFieldOptions) error) *cobra.Command {
+	opts := &EditFieldOptions{
+		IO:         f.IOStreams,
+		HttpClient: f.HttpClient,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "edit-field {<number> | <url>} --field-id <id>",
+		Short: "Set an issue field value",
+		Long: heredoc.Docf(`
+			Set or clear a custom issue field value on an issue.
+
+			Issue field values are stored on the issue itself, not on a project item, so
+			they are edited here rather than with %[1]sgh project item-edit%[1]s (just like labels and
+			assignees). Reading these values is still available from a project with
+			%[1]sgh project item-list%[1]s.
+
+			Identify the issue field with %[1]s--field-id%[1]s (the ID of the issue field) and
+			provide exactly one typed value (%[1]s--text%[1]s, %[1]s--number%[1]s, %[1]s--date%[1]s,
+			%[1]s--single-select-option-id%[1]s, or %[1]s--multi-select-option-ids%[1]s), or
+			%[1]s--clear%[1]s to remove the value.
+
+			Editing issue fields requires authorization with the %[1]sproject%[1]s scope.
+			To authorize, run %[1]sgh auth refresh -s project%[1]s.
+		`, "`"),
+		Example: heredoc.Doc(`
+			# Set a text issue field value
+			$ gh issue edit-field 23 --field-id <field-id> --text "Platform"
+
+			# Set a single-select issue field value by option ID
+			$ gh issue edit-field 23 --field-id <field-id> --single-select-option-id <option-id>
+
+			# Set a multi-select issue field value by option IDs
+			$ gh issue edit-field 23 --field-id <field-id> --multi-select-option-ids <id1>,<id2>
+
+			# Clear an issue field value
+			$ gh issue edit-field 23 --field-id <field-id> --clear
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.NumberChanged = cmd.Flags().Changed("number")
+
+			issueNumber, baseRepo, err := shared.ParseIssueFromArg(args[0])
+			if err != nil {
+				return err
+			}
+
+			// If the args provided the base repo then use that directly.
+			if baseRepo, present := baseRepo.Value(); present {
+				opts.BaseRepo = func() (ghrepo.Interface, error) {
+					return baseRepo, nil
+				}
+			} else {
+				// support `-R, --repo` override
+				opts.BaseRepo = f.BaseRepo
+			}
+
+			opts.IssueNumber = issueNumber
+
+			if opts.FieldID == "" {
+				return cmdutil.FlagErrorf("`--field-id` (the ID of the issue field) is required")
+			}
+
+			n := 0
+			if opts.Text != "" {
+				n++
+			}
+			if opts.NumberChanged {
+				n++
+			}
+			if opts.Date != "" {
+				n++
+			}
+			if opts.SingleSelectOptionID != "" {
+				n++
+			}
+			if len(opts.MultiSelectOptionIDs) > 0 {
+				n++
+			}
+			if opts.Clear {
+				n++
+			}
+			if n != 1 {
+				return cmdutil.FlagErrorf("provide exactly one of `--text`, `--number`, `--date`, `--single-select-option-id`, `--multi-select-option-ids`, or `--clear`")
+			}
+
+			if runF != nil {
+				return runF(opts)
+			}
+			return editFieldRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.FieldID, "field-id", "", "ID of the issue field to set")
+	cmd.Flags().StringVar(&opts.Text, "text", "", "Text value for the field")
+	cmd.Flags().Float64Var(&opts.Number, "number", 0, "Number value for the field")
+	cmd.Flags().StringVar(&opts.Date, "date", "", "Date value for the field (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&opts.SingleSelectOptionID, "single-select-option-id", "", "ID of the single select option value to set")
+	cmd.Flags().StringSliceVar(&opts.MultiSelectOptionIDs, "multi-select-option-ids", nil, "IDs of the multi select option values to set")
+	cmd.Flags().BoolVar(&opts.Clear, "clear", false, "Remove the field value")
+
+	return cmd
+}
+
+func editFieldRun(opts *EditFieldOptions) error {
+	httpClient, err := opts.HttpClient()
+	if err != nil {
+		return err
+	}
+
+	baseRepo, err := opts.BaseRepo()
+	if err != nil {
+		return err
+	}
+
+	issue, err := shared.FindIssueOrPR(httpClient, baseRepo, opts.IssueNumber, []string{"id", "number", "title"})
+	if err != nil {
+		return err
+	}
+
+	field := IssueFieldCreateOrUpdateInput{FieldID: opts.FieldID}
+	switch {
+	case opts.Clear:
+		del := true
+		field.Delete = &del
+	case opts.Text != "":
+		field.TextValue = &opts.Text
+	case opts.NumberChanged:
+		field.NumberValue = &opts.Number
+	case opts.Date != "":
+		field.DateValue = &opts.Date
+	case opts.SingleSelectOptionID != "":
+		field.SingleSelectOptionID = &opts.SingleSelectOptionID
+	case len(opts.MultiSelectOptionIDs) > 0:
+		ids := opts.MultiSelectOptionIDs
+		field.MultiSelectOptionIDs = &ids
+	}
+
+	var mutation struct {
+		UpdateIssueFieldValue struct {
+			ClientMutationID string
+		} `graphql:"updateIssueFieldValue(input: $input)"`
+	}
+	variables := map[string]interface{}{
+		"input": UpdateIssueFieldValueInput{
+			IssueID:    issue.ID,
+			IssueField: field,
+		},
+	}
+
+	gql := api.NewClientFromHTTP(httpClient)
+	if err := gql.Mutate(baseRepo.RepoHost(), "UpdateIssueFieldValue", &mutation, variables); err != nil {
+		return err
+	}
+
+	cs := opts.IO.ColorScheme()
+	action := "Set"
+	if opts.Clear {
+		action = "Cleared"
+	}
+	fmt.Fprintf(opts.IO.ErrOut, "%s %s issue field value on %s#%d\n", cs.SuccessIcon(), action, ghrepo.FullName(baseRepo), issue.Number)
+	return nil
+}

--- a/pkg/cmd/issue/edit-field/edit_field_test.go
+++ b/pkg/cmd/issue/edit-field/edit_field_test.go
@@ -1,0 +1,197 @@
+package editfield
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/cli/cli/v2/pkg/cmdutil"
+	"github.com/cli/cli/v2/pkg/httpmock"
+	"github.com/cli/cli/v2/pkg/iostreams"
+	"github.com/google/shlex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdEditField(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		output  EditFieldOptions
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "text value",
+			input: "23 --field-id FIELD_ID --text hello",
+			output: EditFieldOptions{
+				IssueNumber: 23,
+				FieldID:     "FIELD_ID",
+				Text:        "hello",
+			},
+		},
+		{
+			name:  "clear",
+			input: "23 --field-id FIELD_ID --clear",
+			output: EditFieldOptions{
+				IssueNumber: 23,
+				FieldID:     "FIELD_ID",
+				Clear:       true,
+			},
+		},
+		{
+			name:    "field-id required",
+			input:   "23 --text hello",
+			wantErr: true,
+			errMsg:  "`--field-id` (the ID of the issue field) is required",
+		},
+		{
+			name:    "no value",
+			input:   "23 --field-id FIELD_ID",
+			wantErr: true,
+			errMsg:  "provide exactly one of `--text`, `--number`, `--date`, `--single-select-option-id`, `--multi-select-option-ids`, or `--clear`",
+		},
+		{
+			name:    "too many values",
+			input:   "23 --field-id FIELD_ID --text a --clear",
+			wantErr: true,
+			errMsg:  "provide exactly one of `--text`, `--number`, `--date`, `--single-select-option-id`, `--multi-select-option-ids`, or `--clear`",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios, _, _, _ := iostreams.Test()
+			f := &cmdutil.Factory{
+				IOStreams: ios,
+			}
+			argv, err := shlex.Split(tt.input)
+			assert.NoError(t, err)
+
+			var gotOpts *EditFieldOptions
+			cmd := NewCmdEditField(f, func(opts *EditFieldOptions) error {
+				gotOpts = opts
+				return nil
+			})
+
+			cmd.SetArgs(argv)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			_, err = cmd.ExecuteC()
+			if tt.wantErr {
+				assert.EqualError(t, err, tt.errMsg)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.output.IssueNumber, gotOpts.IssueNumber)
+			assert.Equal(t, tt.output.FieldID, gotOpts.FieldID)
+			assert.Equal(t, tt.output.Text, gotOpts.Text)
+			assert.Equal(t, tt.output.Clear, gotOpts.Clear)
+		})
+	}
+}
+
+func TestEditFieldRun(t *testing.T) {
+	issueResponse := `{ "data": { "repository": {
+		"hasIssuesEnabled": true,
+		"issue": { "id": "THE-ID", "number": 23, "title": "An issue" }
+	} } }`
+
+	tests := []struct {
+		name       string
+		opts       *EditFieldOptions
+		httpStubs  func(*httpmock.Registry)
+		wantStderr string
+		wantErr    bool
+		errMsg     string
+	}{
+		{
+			name: "set text value",
+			opts: &EditFieldOptions{
+				IssueNumber: 23,
+				FieldID:     "FIELD_ID",
+				Text:        "Platform",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.GraphQL(`query IssueByNumber\b`), httpmock.StringResponse(issueResponse))
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateIssueFieldValue\b`),
+					httpmock.GraphQLMutation(`{ "data": { "updateIssueFieldValue": { "clientMutationId": "" } } }`,
+						func(inputs map[string]interface{}) {
+							assert.Equal(t, "THE-ID", inputs["issueId"])
+							issueField := inputs["issueField"].(map[string]interface{})
+							assert.Equal(t, "FIELD_ID", issueField["fieldId"])
+							assert.Equal(t, "Platform", issueField["textValue"])
+						}),
+				)
+			},
+			wantStderr: "✓ Set issue field value on OWNER/REPO#23\n",
+		},
+		{
+			name: "set single-select value",
+			opts: &EditFieldOptions{
+				IssueNumber:          23,
+				FieldID:              "FIELD_ID",
+				SingleSelectOptionID: "OPTION_ID",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.GraphQL(`query IssueByNumber\b`), httpmock.StringResponse(issueResponse))
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateIssueFieldValue\b`),
+					httpmock.GraphQLMutation(`{ "data": { "updateIssueFieldValue": { "clientMutationId": "" } } }`,
+						func(inputs map[string]interface{}) {
+							issueField := inputs["issueField"].(map[string]interface{})
+							assert.Equal(t, "FIELD_ID", issueField["fieldId"])
+							assert.Equal(t, "OPTION_ID", issueField["singleSelectOptionId"])
+						}),
+				)
+			},
+			wantStderr: "✓ Set issue field value on OWNER/REPO#23\n",
+		},
+		{
+			name: "clear value",
+			opts: &EditFieldOptions{
+				IssueNumber: 23,
+				FieldID:     "FIELD_ID",
+				Clear:       true,
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(httpmock.GraphQL(`query IssueByNumber\b`), httpmock.StringResponse(issueResponse))
+				reg.Register(
+					httpmock.GraphQL(`mutation UpdateIssueFieldValue\b`),
+					httpmock.GraphQLMutation(`{ "data": { "updateIssueFieldValue": { "clientMutationId": "" } } }`,
+						func(inputs map[string]interface{}) {
+							issueField := inputs["issueField"].(map[string]interface{})
+							assert.Equal(t, "FIELD_ID", issueField["fieldId"])
+							assert.Equal(t, true, issueField["delete"])
+						}),
+				)
+			},
+			wantStderr: "✓ Cleared issue field value on OWNER/REPO#23\n",
+		},
+	}
+	for _, tt := range tests {
+		reg := &httpmock.Registry{}
+		if tt.httpStubs != nil {
+			tt.httpStubs(reg)
+		}
+		tt.opts.HttpClient = func() (*http.Client, error) {
+			return &http.Client{Transport: reg}, nil
+		}
+		ios, _, _, stderr := iostreams.Test()
+		tt.opts.IO = ios
+		tt.opts.BaseRepo = func() (ghrepo.Interface, error) {
+			return ghrepo.FromFullName("OWNER/REPO")
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			defer reg.Verify(t)
+
+			err := editFieldRun(tt.opts)
+			if tt.wantErr {
+				assert.EqualError(t, err, tt.errMsg)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantStderr, stderr.String())
+		})
+	}
+}

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -47,6 +47,10 @@ type EditOptions struct {
 	AddBlocking     []string
 	RemoveBlocking  []string
 
+	IssueFieldName  string
+	IssueFieldID    string
+	IssueFieldValue string
+
 	prShared.Editable
 }
 
@@ -94,6 +98,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 			$ gh issue edit 23 --remove-parent
 			$ gh issue edit 100 --add-sub-issue 123,124
 			$ gh issue edit 123 --add-blocked-by 200 --add-blocking 300,301
+			$ gh issue edit 23 --field "Team" --value "Platform"
 		`),
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -161,6 +166,21 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 				return err
 			}
 
+			if err := cmdutil.MutuallyExclusive(
+				"specify only one of `--field` or `--field-id`",
+				opts.IssueFieldName != "",
+				opts.IssueFieldID != "",
+			); err != nil {
+				return err
+			}
+			issueFieldSelected := opts.IssueFieldName != "" || opts.IssueFieldID != ""
+			if issueFieldSelected && !flags.Changed("value") {
+				return cmdutil.FlagErrorf("`--value` is required with `--field` or `--field-id`")
+			}
+			if flags.Changed("value") && !issueFieldSelected {
+				return cmdutil.FlagErrorf("`--value` requires `--field` or `--field-id`")
+			}
+
 			if flags.Changed("title") {
 				opts.Editable.Title.Edited = true
 			}
@@ -198,7 +218,7 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 				len(opts.AddBlocking) > 0 || len(opts.RemoveBlocking) > 0
 
 			// Drop into interactive mode only if the user passed no edit flags at all.
-			if !opts.Editable.Dirty() && !hasDeferredFlags {
+			if !opts.Editable.Dirty() && !hasDeferredFlags && !issueFieldSelected {
 				opts.Interactive = true
 			}
 
@@ -243,6 +263,9 @@ func NewCmdEdit(f *cmdutil.Factory, runF func(*EditOptions) error) *cobra.Comman
 	cmd.Flags().StringSliceVar(&opts.RemoveBlockedBy, "remove-blocked-by", nil, "Remove 'blocked by' relationships by issue `number` or URL")
 	cmd.Flags().StringSliceVar(&opts.AddBlocking, "add-blocking", nil, "Add 'blocking' relationships by issue `number` or URL")
 	cmd.Flags().StringSliceVar(&opts.RemoveBlocking, "remove-blocking", nil, "Remove 'blocking' relationships by issue `number` or URL")
+	cmd.Flags().StringVar(&opts.IssueFieldName, "field", "", "Set an issue field value by field `name`")
+	cmd.Flags().StringVar(&opts.IssueFieldID, "field-id", "", "Set an issue field value by field `id`")
+	cmd.Flags().StringVar(&opts.IssueFieldValue, "value", "", "Value for the issue field set with `--field` or `--field-id`")
 
 	return cmd
 }
@@ -333,6 +356,16 @@ func editRun(opts *EditOptions) error {
 		return err
 	}
 
+	// Resolve the issue field value once; it is written on each issue below.
+	var issueFieldInput *issueShared.IssueFieldCreateOrUpdateInput
+	if opts.IssueFieldName != "" || opts.IssueFieldID != "" {
+		built, err := issueShared.BuildIssueFieldValueInput(httpClient, baseRepo, opts.IssueFieldName, opts.IssueFieldID, opts.IssueFieldValue)
+		if err != nil {
+			return err
+		}
+		issueFieldInput = &built
+	}
+
 	// Update all issues in parallel.
 	editedIssueChan := make(chan string, len(issues))
 	failedIssueChan := make(chan string, len(issues))
@@ -415,6 +448,13 @@ func editRun(opts *EditOptions) error {
 			if err := api.DeferredUpdateIssue(apiClient, mutations); err != nil {
 				failedIssueChan <- fmt.Sprintf("failed to update %s:\n%s", issue.URL, err)
 				return
+			}
+
+			if issueFieldInput != nil {
+				if err := issueShared.UpdateIssueFieldValue(httpClient, baseRepo, issue.ID, *issueFieldInput); err != nil {
+					failedIssueChan <- fmt.Sprintf("failed to update %s: %s", issue.URL, err)
+					return
+				}
 			}
 
 			editedIssueChan <- issue.URL

--- a/pkg/cmd/issue/issue.go
+++ b/pkg/cmd/issue/issue.go
@@ -8,6 +8,7 @@ import (
 	cmdDelete "github.com/cli/cli/v2/pkg/cmd/issue/delete"
 	cmdDevelop "github.com/cli/cli/v2/pkg/cmd/issue/develop"
 	cmdEdit "github.com/cli/cli/v2/pkg/cmd/issue/edit"
+	cmdEditField "github.com/cli/cli/v2/pkg/cmd/issue/edit-field"
 	cmdList "github.com/cli/cli/v2/pkg/cmd/issue/list"
 	cmdLock "github.com/cli/cli/v2/pkg/cmd/issue/lock"
 	cmdPin "github.com/cli/cli/v2/pkg/cmd/issue/pin"
@@ -54,6 +55,7 @@ func NewCmdIssue(f *cmdutil.Factory) *cobra.Command {
 		cmdClose.NewCmdClose(f, nil),
 		cmdReopen.NewCmdReopen(f, nil),
 		cmdEdit.NewCmdEdit(f, nil),
+		cmdEditField.NewCmdEditField(f, nil),
 		cmdDevelop.NewCmdDevelop(f, nil),
 		cmdLock.NewCmdLock(f, cmd.Name(), nil),
 		cmdLock.NewCmdUnlock(f, cmd.Name(), nil),

--- a/pkg/cmd/issue/shared/issue_fields.go
+++ b/pkg/cmd/issue/shared/issue_fields.go
@@ -1,0 +1,246 @@
+package shared
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/cli/cli/v2/api"
+	"github.com/cli/cli/v2/internal/ghrepo"
+	"github.com/shurcooL/githubv4"
+)
+
+// IssueFieldCreateOrUpdateInput mirrors the GraphQL input of the same name.
+// It is defined locally because the vendored githubv4 lacks the issue-field types.
+type IssueFieldCreateOrUpdateInput struct {
+	FieldID              string    `json:"fieldId"`
+	TextValue            *string   `json:"textValue,omitempty"`
+	NumberValue          *float64  `json:"numberValue,omitempty"`
+	DateValue            *string   `json:"dateValue,omitempty"`
+	SingleSelectOptionID *string   `json:"singleSelectOptionId,omitempty"`
+	MultiSelectOptionIDs *[]string `json:"multiSelectOptionIds,omitempty"`
+	Delete               *bool     `json:"delete,omitempty"`
+}
+
+// issueFieldOption is a single-select or multi-select option.
+type issueFieldOption struct {
+	ID   string
+	Name string
+}
+
+// issueFieldDefinition is a repository issue field, used to resolve a field by
+// name or ID and to dispatch a value by its data type.
+type issueFieldDefinition struct {
+	ID       string
+	Name     string
+	DataType string
+	Options  []issueFieldOption
+}
+
+type issueFieldsQuery struct {
+	Repository struct {
+		IssueFields struct {
+			Nodes []struct {
+				Typename string `graphql:"__typename"`
+				Text     struct {
+					ID       string
+					Name     string
+					DataType string
+				} `graphql:"... on IssueFieldText"`
+				Number struct {
+					ID       string
+					Name     string
+					DataType string
+				} `graphql:"... on IssueFieldNumber"`
+				Date struct {
+					ID       string
+					Name     string
+					DataType string
+				} `graphql:"... on IssueFieldDate"`
+				SingleSelect struct {
+					ID       string
+					Name     string
+					DataType string
+					Options  []issueFieldOption
+				} `graphql:"... on IssueFieldSingleSelect"`
+				MultiSelect struct {
+					ID       string
+					Name     string
+					DataType string
+					Options  []issueFieldOption
+				} `graphql:"... on IssueFieldMultiSelect"`
+			}
+		} `graphql:"issueFields(first: 100)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+// BuildIssueFieldValueInput resolves the issue field identified by fieldName or
+// fieldID against the repository's issue fields and builds an update input with
+// value dispatched by the field's data type. For single-select and multi-select
+// fields, value is an option name (multi-select accepts a comma-separated list).
+func BuildIssueFieldValueInput(httpClient *http.Client, repo ghrepo.Interface, fieldName, fieldID, value string) (IssueFieldCreateOrUpdateInput, error) {
+	fields, err := fetchIssueFields(httpClient, repo)
+	if err != nil {
+		return IssueFieldCreateOrUpdateInput{}, err
+	}
+	return resolveIssueFieldValueInput(fields, fieldName, fieldID, value)
+}
+
+func fetchIssueFields(httpClient *http.Client, repo ghrepo.Interface) ([]issueFieldDefinition, error) {
+	var query issueFieldsQuery
+	variables := map[string]interface{}{
+		"owner": githubv4.String(repo.RepoOwner()),
+		"name":  githubv4.String(repo.RepoName()),
+	}
+
+	client := api.NewClientFromHTTP(httpClient)
+	if err := client.Query(repo.RepoHost(), "RepositoryIssueFields", &query, variables); err != nil {
+		return nil, err
+	}
+
+	var fields []issueFieldDefinition
+	for _, n := range query.Repository.IssueFields.Nodes {
+		switch n.Typename {
+		case "IssueFieldText":
+			fields = append(fields, issueFieldDefinition{ID: n.Text.ID, Name: n.Text.Name, DataType: n.Text.DataType})
+		case "IssueFieldNumber":
+			fields = append(fields, issueFieldDefinition{ID: n.Number.ID, Name: n.Number.Name, DataType: n.Number.DataType})
+		case "IssueFieldDate":
+			fields = append(fields, issueFieldDefinition{ID: n.Date.ID, Name: n.Date.Name, DataType: n.Date.DataType})
+		case "IssueFieldSingleSelect":
+			fields = append(fields, issueFieldDefinition{ID: n.SingleSelect.ID, Name: n.SingleSelect.Name, DataType: n.SingleSelect.DataType, Options: n.SingleSelect.Options})
+		case "IssueFieldMultiSelect":
+			fields = append(fields, issueFieldDefinition{ID: n.MultiSelect.ID, Name: n.MultiSelect.Name, DataType: n.MultiSelect.DataType, Options: n.MultiSelect.Options})
+		}
+	}
+	return fields, nil
+}
+
+func resolveIssueFieldValueInput(fields []issueFieldDefinition, fieldName, fieldID, value string) (IssueFieldCreateOrUpdateInput, error) {
+	field, err := resolveIssueField(fields, fieldName, fieldID)
+	if err != nil {
+		return IssueFieldCreateOrUpdateInput{}, err
+	}
+
+	input := IssueFieldCreateOrUpdateInput{FieldID: field.ID}
+	switch field.DataType {
+	case "TEXT":
+		input.TextValue = &value
+	case "DATE":
+		input.DateValue = &value
+	case "NUMBER":
+		n, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return IssueFieldCreateOrUpdateInput{}, fmt.Errorf("invalid number value %q for field %q", value, field.Name)
+		}
+		input.NumberValue = &n
+	case "SINGLE_SELECT":
+		optionID, err := resolveOptionID(field, value)
+		if err != nil {
+			return IssueFieldCreateOrUpdateInput{}, err
+		}
+		input.SingleSelectOptionID = &optionID
+	case "MULTI_SELECT":
+		var ids []string
+		for _, name := range splitOptionNames(value) {
+			optionID, err := resolveOptionID(field, name)
+			if err != nil {
+				return IssueFieldCreateOrUpdateInput{}, err
+			}
+			ids = append(ids, optionID)
+		}
+		input.MultiSelectOptionIDs = &ids
+	default:
+		return IssueFieldCreateOrUpdateInput{}, fmt.Errorf("field %q has data type %q which is not supported", field.Name, field.DataType)
+	}
+	return input, nil
+}
+
+func resolveIssueField(fields []issueFieldDefinition, fieldName, fieldID string) (issueFieldDefinition, error) {
+	if fieldID != "" {
+		for _, f := range fields {
+			if f.ID == fieldID {
+				return f, nil
+			}
+		}
+		return issueFieldDefinition{}, fmt.Errorf("no issue field found with ID %q", fieldID)
+	}
+
+	var matches []issueFieldDefinition
+	for _, f := range fields {
+		if strings.EqualFold(f.Name, fieldName) {
+			matches = append(matches, f)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		names := make([]string, 0, len(fields))
+		for _, f := range fields {
+			names = append(names, f.Name)
+		}
+		if len(names) == 0 {
+			return issueFieldDefinition{}, fmt.Errorf("issue field %q not found; the repository has no issue fields", fieldName)
+		}
+		return issueFieldDefinition{}, fmt.Errorf("issue field %q not found; available fields: %s", fieldName, strings.Join(names, ", "))
+	default:
+		return issueFieldDefinition{}, fmt.Errorf("issue field %q is ambiguous; use --field-id", fieldName)
+	}
+}
+
+func resolveOptionID(field issueFieldDefinition, optionName string) (string, error) {
+	var matches []string
+	for _, o := range field.Options {
+		if strings.EqualFold(o.Name, optionName) {
+			matches = append(matches, o.ID)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		names := make([]string, 0, len(field.Options))
+		for _, o := range field.Options {
+			names = append(names, o.Name)
+		}
+		return "", fmt.Errorf("option %q not found on field %q; available options: %s", optionName, field.Name, strings.Join(names, ", "))
+	default:
+		return "", fmt.Errorf("option %q is ambiguous on field %q", optionName, field.Name)
+	}
+}
+
+func splitOptionNames(value string) []string {
+	parts := strings.Split(value, ",")
+	names := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			names = append(names, p)
+		}
+	}
+	return names
+}
+
+// UpdateIssueFieldValue writes input on the issue identified by issueID via the
+// updateIssueFieldValue mutation.
+func UpdateIssueFieldValue(httpClient *http.Client, repo ghrepo.Interface, issueID string, input IssueFieldCreateOrUpdateInput) error {
+	var mutation struct {
+		UpdateIssueFieldValue struct {
+			ClientMutationID string
+		} `graphql:"updateIssueFieldValue(input: $input)"`
+	}
+	variables := map[string]interface{}{
+		"input": updateIssueFieldValueInput{
+			IssueID:    issueID,
+			IssueField: input,
+		},
+	}
+	client := api.NewClientFromHTTP(httpClient)
+	return client.Mutate(repo.RepoHost(), "UpdateIssueFieldValue", &mutation, variables)
+}
+
+type updateIssueFieldValueInput struct {
+	IssueID    string                        `json:"issueId"`
+	IssueField IssueFieldCreateOrUpdateInput `json:"issueField"`
+}

--- a/pkg/cmd/issue/shared/issue_fields_test.go
+++ b/pkg/cmd/issue/shared/issue_fields_test.go
@@ -1,0 +1,94 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveIssueFieldValueInput(t *testing.T) {
+	fields := []issueFieldDefinition{
+		{ID: "IF_text", Name: "Team", DataType: "TEXT"},
+		{ID: "IF_num", Name: "Story Points", DataType: "NUMBER"},
+		{ID: "IF_date", Name: "Due", DataType: "DATE"},
+		{ID: "IF_ss", Name: "Priority", DataType: "SINGLE_SELECT", Options: []issueFieldOption{
+			{ID: "opt_hi", Name: "High"},
+			{ID: "opt_lo", Name: "Low"},
+		}},
+		{ID: "IF_ms", Name: "Platforms", DataType: "MULTI_SELECT", Options: []issueFieldOption{
+			{ID: "opt_ios", Name: "iOS"},
+			{ID: "opt_web", Name: "Web"},
+		}},
+	}
+
+	t.Run("text by name", func(t *testing.T) {
+		got, err := resolveIssueFieldValueInput(fields, "Team", "", "Platform")
+		require.NoError(t, err)
+		assert.Equal(t, "IF_text", got.FieldID)
+		require.NotNil(t, got.TextValue)
+		assert.Equal(t, "Platform", *got.TextValue)
+	})
+
+	t.Run("number by name", func(t *testing.T) {
+		got, err := resolveIssueFieldValueInput(fields, "Story Points", "", "5")
+		require.NoError(t, err)
+		require.NotNil(t, got.NumberValue)
+		assert.Equal(t, float64(5), *got.NumberValue)
+	})
+
+	t.Run("date by name", func(t *testing.T) {
+		got, err := resolveIssueFieldValueInput(fields, "Due", "", "2026-01-02")
+		require.NoError(t, err)
+		require.NotNil(t, got.DateValue)
+		assert.Equal(t, "2026-01-02", *got.DateValue)
+	})
+
+	t.Run("single-select resolves option name case-insensitively", func(t *testing.T) {
+		got, err := resolveIssueFieldValueInput(fields, "Priority", "", "high")
+		require.NoError(t, err)
+		require.NotNil(t, got.SingleSelectOptionID)
+		assert.Equal(t, "opt_hi", *got.SingleSelectOptionID)
+	})
+
+	t.Run("multi-select resolves comma-separated option names in order", func(t *testing.T) {
+		got, err := resolveIssueFieldValueInput(fields, "Platforms", "", "iOS, Web")
+		require.NoError(t, err)
+		require.NotNil(t, got.MultiSelectOptionIDs)
+		assert.Equal(t, []string{"opt_ios", "opt_web"}, *got.MultiSelectOptionIDs)
+	})
+
+	t.Run("field by id", func(t *testing.T) {
+		got, err := resolveIssueFieldValueInput(fields, "", "IF_text", "hi")
+		require.NoError(t, err)
+		assert.Equal(t, "IF_text", got.FieldID)
+		require.NotNil(t, got.TextValue)
+		assert.Equal(t, "hi", *got.TextValue)
+	})
+
+	t.Run("field not found lists candidates", func(t *testing.T) {
+		_, err := resolveIssueFieldValueInput(fields, "Nope", "", "x")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `issue field "Nope" not found`)
+		assert.Contains(t, err.Error(), "Team")
+	})
+
+	t.Run("unknown field id", func(t *testing.T) {
+		_, err := resolveIssueFieldValueInput(fields, "", "IF_missing", "x")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `no issue field found with ID "IF_missing"`)
+	})
+
+	t.Run("option not found lists candidates", func(t *testing.T) {
+		_, err := resolveIssueFieldValueInput(fields, "Priority", "", "Nope")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `option "Nope" not found`)
+		assert.Contains(t, err.Error(), "High, Low")
+	})
+
+	t.Run("invalid number", func(t *testing.T) {
+		_, err := resolveIssueFieldValueInput(fields, "Story Points", "", "abc")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid number value")
+	})
+}

--- a/pkg/cmd/project/field-create/field_create.go
+++ b/pkg/cmd/project/field-create/field_create.go
@@ -18,6 +18,7 @@ type createFieldOpts struct {
 	dataType            string
 	owner               string
 	singleSelectOptions []string
+	issueFieldID        string
 	number              int32
 	projectID           string
 	exporter            cmdutil.Exporter
@@ -35,6 +36,19 @@ type createProjectV2FieldMutation struct {
 	} `graphql:"createProjectV2Field(input:$input)"`
 }
 
+// createProjectV2IssueFieldMutation attaches an existing issue field to a project as a new column.
+type createProjectV2IssueFieldMutation struct {
+	CreateProjectV2IssueField struct {
+		Field queries.ProjectField `graphql:"projectV2Field"`
+	} `graphql:"createProjectV2IssueField(input:$input)"`
+}
+
+// CreateProjectV2IssueFieldInput is defined locally because the vendored githubv4 lacks the issue-field types.
+type CreateProjectV2IssueFieldInput struct {
+	ProjectID    string `json:"projectId"`
+	IssueFieldID string `json:"issueFieldId"`
+}
+
 func NewCmdCreateField(f *cmdutil.Factory, runF func(config createFieldConfig) error) *cobra.Command {
 	opts := createFieldOpts{}
 	createFieldCmd := &cobra.Command{
@@ -46,6 +60,9 @@ func NewCmdCreateField(f *cmdutil.Factory, runF func(config createFieldConfig) e
 
 			# Create a field with three options to select from for owner monalisa
 			$ gh project field-create 1 --owner monalisa --name "new field" --data-type "SINGLE_SELECT" --single-select-options "one,two,three"
+
+			# Attach an existing organization issue field to project 1 as a new column
+			$ gh project field-create 1 --owner monalisa --issue-field-id <issue-field-id>
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -68,8 +85,17 @@ func NewCmdCreateField(f *cmdutil.Factory, runF func(config createFieldConfig) e
 				io:     f.IOStreams,
 			}
 
-			if config.opts.dataType == "SINGLE_SELECT" && len(config.opts.singleSelectOptions) == 0 {
-				return fmt.Errorf("passing `--single-select-options` is required for SINGLE_SELECT data type")
+			if config.opts.issueFieldID != "" {
+				if config.opts.name != "" || config.opts.dataType != "" || len(config.opts.singleSelectOptions) > 0 {
+					return cmdutil.FlagErrorf("`--issue-field-id` cannot be combined with `--name`, `--data-type`, or `--single-select-options`")
+				}
+			} else {
+				if config.opts.name == "" || config.opts.dataType == "" {
+					return cmdutil.FlagErrorf("`--name` and `--data-type` are required unless attaching an issue field with `--issue-field-id`")
+				}
+				if config.opts.dataType == "SINGLE_SELECT" && len(config.opts.singleSelectOptions) == 0 {
+					return fmt.Errorf("passing `--single-select-options` is required for SINGLE_SELECT data type")
+				}
 			}
 
 			// allow testing of the command without actually running it
@@ -84,10 +110,8 @@ func NewCmdCreateField(f *cmdutil.Factory, runF func(config createFieldConfig) e
 	createFieldCmd.Flags().StringVar(&opts.name, "name", "", "Name of the new field")
 	cmdutil.StringEnumFlag(createFieldCmd, &opts.dataType, "data-type", "", "", []string{"TEXT", "SINGLE_SELECT", "DATE", "NUMBER"}, "DataType of the new field.")
 	createFieldCmd.Flags().StringSliceVar(&opts.singleSelectOptions, "single-select-options", []string{}, "Options for SINGLE_SELECT data type")
+	createFieldCmd.Flags().StringVar(&opts.issueFieldID, "issue-field-id", "", "ID of an existing issue field to attach to the project as a new column")
 	cmdutil.AddFormatFlags(createFieldCmd, &opts.exporter)
-
-	_ = createFieldCmd.MarkFlagRequired("name")
-	_ = createFieldCmd.MarkFlagRequired("data-type")
 
 	return createFieldCmd
 }
@@ -105,6 +129,10 @@ func runCreateField(config createFieldConfig) error {
 	}
 	config.opts.projectID = project.ID
 
+	if config.opts.issueFieldID != "" {
+		return attachIssueField(config)
+	}
+
 	query, variables := createFieldArgs(config)
 
 	err = config.client.Mutate("CreateField", query, variables)
@@ -117,6 +145,32 @@ func runCreateField(config createFieldConfig) error {
 	}
 
 	return printResults(config, query.CreateProjectV2Field.Field)
+}
+
+// attachIssueField surfaces an existing issue field on the project as a new column.
+func attachIssueField(config createFieldConfig) error {
+	mutation := &createProjectV2IssueFieldMutation{}
+	variables := map[string]interface{}{
+		"input": CreateProjectV2IssueFieldInput{
+			ProjectID:    config.opts.projectID,
+			IssueFieldID: config.opts.issueFieldID,
+		},
+	}
+
+	if err := config.client.Mutate("CreateProjectV2IssueField", mutation, variables); err != nil {
+		return err
+	}
+
+	if config.opts.exporter != nil {
+		return config.opts.exporter.Write(config.io, mutation.CreateProjectV2IssueField.Field)
+	}
+
+	if config.io.IsStdoutTTY() {
+		if _, err := fmt.Fprintf(config.io.Out, "Attached issue field\n"); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func createFieldArgs(config createFieldConfig) (*createProjectV2FieldMutation, map[string]interface{}) {

--- a/pkg/cmd/project/field-create/field_create_test.go
+++ b/pkg/cmd/project/field-create/field_create_test.go
@@ -24,7 +24,7 @@ func TestNewCmdCreateField(t *testing.T) {
 			name:        "missing-name-and-data-type",
 			cli:         "",
 			wantsErr:    true,
-			wantsErrMsg: "required flag(s) \"data-type\", \"name\" not set",
+			wantsErrMsg: "`--name` and `--data-type` are required unless attaching an issue field with `--issue-field-id`",
 		},
 		{
 			name:        "not-a-number",
@@ -723,4 +723,92 @@ func TestRunCreateField_JSON(t *testing.T) {
 		t,
 		`{"id":"Field ID","name":"a name","type":"ProjectV2Field"}`,
 		stdout.String())
+}
+
+func TestRunCreateField_AttachIssueField(t *testing.T) {
+	defer gock.Off()
+
+	// get user ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserOrgOwner.*",
+			"variables": map[string]interface{}{
+				"login": "monalisa",
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"id": "an ID",
+				},
+			},
+			"errors": []interface{}{
+				map[string]interface{}{
+					"type": "NOT_FOUND",
+					"path": []string{"organization"},
+				},
+			},
+		})
+
+	// get project ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  0,
+				"afterItems":  nil,
+				"firstFields": 0,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"id": "an ID",
+					},
+				},
+			},
+		})
+
+	// attach the existing issue field as a project column
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation CreateProjectV2IssueField.*","variables":{"input":{"projectId":"an ID","issueFieldId":"issue_field_id"}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"createProjectV2IssueField": map[string]interface{}{
+					"projectV2Field": map[string]interface{}{
+						"id": "Field ID",
+					},
+				},
+			},
+		})
+
+	client := queries.NewTestClient()
+
+	ios, _, stdout, _ := iostreams.Test()
+	ios.SetStdoutTTY(true)
+	config := createFieldConfig{
+		opts: createFieldOpts{
+			owner:        "monalisa",
+			number:       1,
+			issueFieldID: "issue_field_id",
+		},
+		client: client,
+		io:     ios,
+	}
+
+	err := runCreateField(config)
+	assert.NoError(t, err)
+	assert.Equal(t, "Attached issue field\n", stdout.String())
 }

--- a/pkg/cmd/project/shared/queries/export_data_test.go
+++ b/pkg/cmd/project/shared/queries/export_data_test.go
@@ -365,3 +365,67 @@ func TestJSONProjectItem_DraftIssue_ProjectV2ItemFieldMilestoneValue(t *testing.
 		string(out))
 
 }
+
+func TestJSONProjectItem_Issue_ProjectV2ItemIssueFieldValue(t *testing.T) {
+	// Issue fields surface on a project item as ProjectV2ItemIssueFieldValue,
+	// whose value lives on the issue itself (the ProjectV2IssueFieldValues
+	// union). Each supported value type must serialize to the same shape as its
+	// project-field counterpart.
+	textField := ProjectField{TypeName: "ProjectV2Field"}
+	textField.Field.ID = "issueTextField"
+	textField.Field.Name = "Team"
+
+	selectField := ProjectField{TypeName: "ProjectV2SingleSelectField"}
+	selectField.SingleSelectField.ID = "issueSelectField"
+	selectField.SingleSelectField.Name = "Priority"
+
+	numberField := ProjectField{TypeName: "ProjectV2Field"}
+	numberField.Field.ID = "issueNumberField"
+	numberField.Field.Name = "Story Points"
+
+	textValue := FieldValueNodes{Type: "ProjectV2ItemIssueFieldValue"}
+	textValue.ProjectV2ItemIssueFieldValue.Field = textField
+	textValue.ProjectV2ItemIssueFieldValue.IssueFieldValue.Type = "IssueFieldTextValue"
+	textValue.ProjectV2ItemIssueFieldValue.IssueFieldValue.IssueFieldTextValue.Value = "Platform"
+
+	selectValue := FieldValueNodes{Type: "ProjectV2ItemIssueFieldValue"}
+	selectValue.ProjectV2ItemIssueFieldValue.Field = selectField
+	selectValue.ProjectV2ItemIssueFieldValue.IssueFieldValue.Type = "IssueFieldSingleSelectValue"
+	selectValue.ProjectV2ItemIssueFieldValue.IssueFieldValue.IssueFieldSingleSelectValue.Name = "High"
+
+	numberValue := FieldValueNodes{Type: "ProjectV2ItemIssueFieldValue"}
+	numberValue.ProjectV2ItemIssueFieldValue.Field = numberField
+	numberValue.ProjectV2ItemIssueFieldValue.IssueFieldValue.Type = "IssueFieldNumberValue"
+	numberValue.ProjectV2ItemIssueFieldValue.IssueFieldValue.IssueFieldNumberValue.Value = 5
+
+	issue := ProjectItem{
+		Id: "issueId",
+		Content: ProjectItemContent{
+			TypeName: "Issue",
+			Issue: Issue{
+				Title:  "Issue title",
+				Body:   "a body",
+				Number: 1,
+				URL:    "issue-url",
+				Repository: struct {
+					NameWithOwner string
+				}{
+					NameWithOwner: "cli/go-gh",
+				},
+			},
+		},
+	}
+	issue.FieldValues.Nodes = []FieldValueNodes{textValue, selectValue, numberValue}
+
+	p := &Project{}
+	p.Fields.Nodes = []ProjectField{textField, selectField, numberField}
+	p.Items.TotalCount = 1
+	p.Items.Nodes = []ProjectItem{issue}
+
+	out, err := json.Marshal(p.DetailedItems())
+	assert.NoError(t, err)
+	assert.JSONEq(
+		t,
+		`{"items":[{"team":"Platform","priority":"High","story Points":5,"content":{"type":"Issue","body":"a body","title":"Issue title","number":1,"repository":"cli/go-gh","url":"issue-url"},"id":"issueId"}],"totalCount":1}`,
+		string(out))
+}

--- a/pkg/cmd/project/shared/queries/queries.go
+++ b/pkg/cmd/project/shared/queries/queries.go
@@ -441,6 +441,27 @@ type FieldValueNodes struct {
 		} `graphql:"reviewers(first: 10)"` // experienced issues with larger limits, 10 seems like enough for now
 		Field ProjectField
 	} `graphql:"... on ProjectV2ItemFieldReviewerValue"`
+	ProjectV2ItemIssueFieldValue struct {
+		Field           ProjectField
+		IssueFieldValue struct {
+			Type                string `graphql:"__typename"`
+			IssueFieldTextValue struct {
+				Value string
+			} `graphql:"... on IssueFieldTextValue"`
+			IssueFieldNumberValue struct {
+				Value float64
+			} `graphql:"... on IssueFieldNumberValue"`
+			IssueFieldDateValue struct {
+				Value string
+			} `graphql:"... on IssueFieldDateValue"`
+			IssueFieldSingleSelectValue struct {
+				Name string
+			} `graphql:"... on IssueFieldSingleSelectValue"`
+			IssueFieldMultiSelectValue struct {
+				Value string
+			} `graphql:"... on IssueFieldMultiSelectValue"`
+		} `graphql:"issueFieldValue"`
+	} `graphql:"... on ProjectV2ItemIssueFieldValue"`
 }
 
 func (v FieldValueNodes) ID() string {
@@ -467,6 +488,8 @@ func (v FieldValueNodes) ID() string {
 		return v.ProjectV2ItemFieldUserValue.Field.ID()
 	case "ProjectV2ItemFieldReviewerValue":
 		return v.ProjectV2ItemFieldReviewerValue.Field.ID()
+	case "ProjectV2ItemIssueFieldValue":
+		return v.ProjectV2ItemIssueFieldValue.Field.ID()
 	}
 
 	return ""
@@ -1767,6 +1790,21 @@ func projectFieldValueData(v FieldValueNodes) interface{} {
 			}
 		}
 		return names
+	case "ProjectV2ItemIssueFieldValue":
+		ifv := v.ProjectV2ItemIssueFieldValue.IssueFieldValue
+		switch ifv.Type {
+		case "IssueFieldTextValue":
+			return ifv.IssueFieldTextValue.Value
+		case "IssueFieldNumberValue":
+			return ifv.IssueFieldNumberValue.Value
+		case "IssueFieldDateValue":
+			return ifv.IssueFieldDateValue.Value
+		case "IssueFieldSingleSelectValue":
+			return ifv.IssueFieldSingleSelectValue.Name
+		case "IssueFieldMultiSelectValue":
+			return ifv.IssueFieldMultiSelectValue.Value
+		}
+		return nil
 
 	}
 


### PR DESCRIPTION
Adds support for Projects v2 issue fields.

Issue field values live on the issue itself, like labels and assignees. So the split is:
- Reading works from the project. Values show up in `gh project item-list --format json`.
- Writing has its own issue scoped command: `gh issue edit-field <issue> --field-id <id>` with one of `--text`, `--number`, `--date`, `--single-select-option-id`, `--multi-select-option-ids`, or `--clear`.
- `gh project field-create --issue-field-id <id>` attaches an existing org or repo issue field to a project as a column.

`gh project item-edit` is unchanged, since issue field values are not set on the project item.

The GraphQL input structs are defined locally because the vendored githubv4 does not have the issue field types yet.

Draft for now. Holding until issue fields are GA in the public schema.