### PR TITLE
fix: issue search page limit and env path encoding

### DIFF
--- a/pkg/cmd/issue/list/http.go
+++ b/pkg/cmd/issue/list/http.go
@@ -212,7 +212,8 @@ loop:
 			break
 		}
 		variables["after"] = resp.Search.PageInfo.EndCursor
-		variables["perPage"] = min(perPage, limit-len(ic.Issues))
+		// IssueSearch declares $limit (not $perPage); write the reduced page size back to the variable the query actually uses (#13906).
+		variables["limit"] = min(perPage, limit-len(ic.Issues))
 	}
 
 	return &ic, nil

--- a/pkg/cmd/issue/list/http_test.go
+++ b/pkg/cmd/issue/list/http_test.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -266,4 +267,75 @@ func TestSearchIssues_rejectsPullRequestQualifiers(t *testing.T) {
 			assert.Len(t, reg.Requests, 0)
 		})
 	}
+}
+
+func TestSearchIssues_reducesLimitOnSubsequentPages(t *testing.T) {
+	// Regression for #13906: subsequent IssueSearch pages must shrink $limit,
+	// not write a dead $perPage variable the operation does not declare.
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	page := 0
+	respond := func(req *http.Request) (*http.Response, error) {
+		var bodyData struct {
+			Query     string
+			Variables map[string]interface{}
+		}
+		if err := json.NewDecoder(req.Body).Decode(&bodyData); err != nil {
+			return nil, err
+		}
+		page++
+		switch page {
+		case 1:
+			assert.Equal(t, float64(100), bodyData.Variables["limit"])
+			nodes := make([]map[string]interface{}, 100)
+			for i := range nodes {
+				nodes[i] = map[string]interface{}{"number": i + 1, "title": "x", "url": "https://example.com"}
+			}
+			payload, _ := json.Marshal(map[string]interface{}{
+				"data": map[string]interface{}{
+					"repository": map[string]interface{}{"hasIssuesEnabled": true},
+					"search": map[string]interface{}{
+						"issueCount": 150,
+						"nodes":      nodes,
+						"pageInfo":   map[string]interface{}{"hasNextPage": true, "endCursor": "CURSOR"},
+					},
+				},
+			})
+			return &http.Response{StatusCode: 200, Request: req, Body: io.NopCloser(bytes.NewReader(payload)), Header: make(http.Header)}, nil
+		case 2:
+			assert.Equal(t, float64(50), bodyData.Variables["limit"])
+			_, hasPerPage := bodyData.Variables["perPage"]
+			assert.False(t, hasPerPage, "must not set undeclared $perPage")
+			nodes := make([]map[string]interface{}, 50)
+			for i := range nodes {
+				nodes[i] = map[string]interface{}{"number": 101 + i, "title": "y", "url": "https://example.com"}
+			}
+			payload, _ := json.Marshal(map[string]interface{}{
+				"data": map[string]interface{}{
+					"repository": map[string]interface{}{"hasIssuesEnabled": true},
+					"search": map[string]interface{}{
+						"issueCount": 150,
+						"nodes":      nodes,
+						"pageInfo":   map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+					},
+				},
+			})
+			return &http.Response{StatusCode: 200, Request: req, Body: io.NopCloser(bytes.NewReader(payload)), Header: make(http.Header)}, nil
+		default:
+			t.Fatalf("unexpected extra page %d", page)
+			return nil, nil
+		}
+	}
+	// httpmock stubs are one-shot; register one responder per expected page.
+	reg.Register(httpmock.GraphQL(`query IssueSearch\b`), respond)
+	reg.Register(httpmock.GraphQL(`query IssueSearch\b`), respond)
+
+	httpClient := &http.Client{Transport: reg}
+	client := api.NewClientFromHTTP(httpClient)
+
+	res, err := searchIssues(client, fd.AdvancedIssueSearchSupportedAsOnlyBackend(), ghrepo.New("OWNER", "REPO"), prShared.FilterOptions{State: "open"}, 150)
+	assert.NoError(t, err)
+	assert.Len(t, res.Issues, 150)
+	assert.Equal(t, 2, page)
 }

--- a/pkg/cmd/secret/delete/delete.go
+++ b/pkg/cmd/secret/delete/delete.go
@@ -3,6 +3,7 @@ package delete
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
@@ -130,7 +131,7 @@ func removeRun(opts *DeleteOptions) error {
 		path = fmt.Sprintf("orgs/%s/%s/secrets/%s", orgName, secretApp, opts.SecretName)
 		host, _ = cfg.Authentication().DefaultHost()
 	case shared.Environment:
-		path = fmt.Sprintf("repos/%s/environments/%s/secrets/%s", ghrepo.FullName(baseRepo), envName, opts.SecretName)
+		path = fmt.Sprintf("repos/%s/environments/%s/secrets/%s", ghrepo.FullName(baseRepo), url.PathEscape(envName), opts.SecretName)
 		host = baseRepo.RepoHost()
 	case shared.User:
 		path = fmt.Sprintf("user/codespaces/secrets/%s", opts.SecretName)

--- a/pkg/cmd/secret/list/list.go
+++ b/pkg/cmd/secret/list/list.go
@@ -3,6 +3,7 @@ package list
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"strings"
@@ -279,7 +280,7 @@ func getUserSecrets(client *http.Client, host string, showSelectedRepoInfo bool)
 }
 
 func getEnvSecrets(client *http.Client, repo ghrepo.Interface, envName string) ([]Secret, error) {
-	path := fmt.Sprintf("repos/%s/environments/%s/secrets", ghrepo.FullName(repo), envName)
+	path := fmt.Sprintf("repos/%s/environments/%s/secrets", ghrepo.FullName(repo), url.PathEscape(envName))
 	return getSecrets(client, repo.RepoHost(), path)
 }
 

--- a/pkg/cmd/secret/set/http.go
+++ b/pkg/cmd/secret/set/http.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 
 	"github.com/cli/cli/v2/api"
@@ -54,7 +55,7 @@ func getRepoPubKey(client *api.Client, repo ghrepo.Interface, app shared.App) (*
 
 func getEnvPubKey(client *api.Client, repo ghrepo.Interface, envName string) (*PubKey, error) {
 	return getPubKey(client, repo.RepoHost(), fmt.Sprintf("repos/%s/environments/%s/secrets/public-key",
-		ghrepo.FullName(repo), envName))
+		ghrepo.FullName(repo), url.PathEscape(envName)))
 }
 
 func putSecret(client *api.Client, host, path string, payload interface{}) error {
@@ -111,7 +112,7 @@ func putEnvSecret(client *api.Client, pk *PubKey, repo ghrepo.Interface, envName
 		EncryptedValue: eValue,
 		KeyID:          pk.ID,
 	}
-	path := fmt.Sprintf("repos/%s/environments/%s/secrets/%s", ghrepo.FullName(repo), envName, secretName)
+	path := fmt.Sprintf("repos/%s/environments/%s/secrets/%s", ghrepo.FullName(repo), url.PathEscape(envName), secretName)
 	return putSecret(client, repo.RepoHost(), path, payload)
 }
 

--- a/pkg/cmd/variable/delete/delete.go
+++ b/pkg/cmd/variable/delete/delete.go
@@ -3,6 +3,7 @@ package delete
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
@@ -103,7 +104,7 @@ func removeRun(opts *DeleteOptions) error {
 		path = fmt.Sprintf("orgs/%s/actions/variables/%s", orgName, opts.VariableName)
 		host, _ = cfg.Authentication().DefaultHost()
 	case shared.Environment:
-		path = fmt.Sprintf("repos/%s/environments/%s/variables/%s", ghrepo.FullName(baseRepo), envName, opts.VariableName)
+		path = fmt.Sprintf("repos/%s/environments/%s/variables/%s", ghrepo.FullName(baseRepo), url.PathEscape(envName), opts.VariableName)
 		host = baseRepo.RepoHost()
 	case shared.Repository:
 		path = fmt.Sprintf("repos/%s/actions/variables/%s", ghrepo.FullName(baseRepo), opts.VariableName)

--- a/pkg/cmd/variable/get/get.go
+++ b/pkg/cmd/variable/get/get.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/cli/v2/api"
@@ -104,7 +105,7 @@ func getRun(opts *GetOptions) error {
 		path = fmt.Sprintf("orgs/%s/actions/variables/%s", orgName, opts.VariableName)
 		host, _ = cfg.Authentication().DefaultHost()
 	case shared.Environment:
-		path = fmt.Sprintf("repos/%s/environments/%s/variables/%s", ghrepo.FullName(baseRepo), envName, opts.VariableName)
+		path = fmt.Sprintf("repos/%s/environments/%s/variables/%s", ghrepo.FullName(baseRepo), url.PathEscape(envName), opts.VariableName)
 		host = baseRepo.RepoHost()
 	case shared.Repository:
 		path = fmt.Sprintf("repos/%s/actions/variables/%s", ghrepo.FullName(baseRepo), opts.VariableName)

--- a/pkg/cmd/variable/list/list.go
+++ b/pkg/cmd/variable/list/list.go
@@ -3,6 +3,7 @@ package list
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -197,7 +198,7 @@ func getRepoVariables(client *http.Client, repo ghrepo.Interface) ([]shared.Vari
 }
 
 func getEnvVariables(client *http.Client, repo ghrepo.Interface, envName string) ([]shared.Variable, error) {
-	path := fmt.Sprintf("repos/%s/environments/%s/variables", ghrepo.FullName(repo), envName)
+	path := fmt.Sprintf("repos/%s/environments/%s/variables", ghrepo.FullName(repo), url.PathEscape(envName))
 	return getVariables(client, repo.RepoHost(), path)
 }
 

--- a/pkg/cmd/variable/set/http.go
+++ b/pkg/cmd/variable/set/http.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -107,7 +108,7 @@ func postEnvVariable(client *api.Client, host string, repoID int64, envName, var
 		Name:  variableName,
 		Value: value,
 	}
-	path := fmt.Sprintf(`repositories/%d/environments/%s/variables`, repoID, envName)
+	path := fmt.Sprintf(`repositories/%d/environments/%s/variables`, repoID, url.PathEscape(envName))
 	return postVariable(client, host, path, payload)
 }
 
@@ -143,7 +144,7 @@ func patchEnvVariable(client *api.Client, host string, repoID int64, envName, va
 	payload := setPayload{
 		Value: value,
 	}
-	path := fmt.Sprintf(`repositories/%d/environments/%s/variables/%s`, repoID, envName, variableName)
+	path := fmt.Sprintf(`repositories/%d/environments/%s/variables/%s`, repoID, url.PathEscape(envName), variableName)
 	return patchVariable(client, host, path, payload)
 }
 


### PR DESCRIPTION
## Description

Two small correctness fixes in `gh`:

### 1) `gh issue list --search --limit N` over-fetches after the first page (#13906)

`searchIssues` reduces the next page size into `variables["perPage"]`, but the `IssueSearch` GraphQL operation only declares `$limit` (`search(..., last: $limit, ...)`). The reduction was therefore discarded and every subsequent page still requested a full 100 items.

Fix: write the reduced page size back to `variables["limit"]`, matching `listIssues` / `pr list` / other paginated commands.

### 2) `gh variable` / `gh secret` env names with reserved path characters 404 (#8817)

Environment names were interpolated raw into REST paths like `repos/.../environments/%s/...`. Names containing `/` (and other reserved characters) broke the path and returned HTTP 404.

Fix: `url.PathEscape(envName)` at the environment path call sites for variable and secret list/get/set/delete (and env public-key fetch).

## Test plan

- [x] `go test ./pkg/cmd/issue/list/ ./pkg/cmd/variable/... ./pkg/cmd/secret/...`
- [x] Added `TestSearchIssues_reducesLimitOnSubsequentPages` (asserts page2 `limit=50`, no `$perPage`)

Fixes #13906
Fixes #8817
