### PR TITLE
feat(pr create): add --json and --jq flag support (#11247)

### DIFF
--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -73,6 +73,8 @@ type CreateOptions struct {
 	MaintainerCanModify bool
 	Template            string
 
+	Exporter cmdutil.Exporter
+
 	DryRun bool
 }
 
@@ -369,6 +371,8 @@ func NewCmdCreate(f *cmdutil.Factory, runF func(*CreateOptions) error) *cobra.Co
 		}
 		return results, cobra.ShellCompDirectiveNoFileComp
 	})
+
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, api.PullRequestFields)
 
 	return cmd
 }
@@ -1065,14 +1069,17 @@ func submitPR(opts CreateOptions, ctx CreateContext, state shared.IssueMetadataS
 	opts.IO.StartProgressIndicator()
 	pr, err := api.CreatePullRequest(client, ctx.PRRefs.BaseRepo(), params)
 	opts.IO.StopProgressIndicator()
-	if pr != nil {
-		fmt.Fprintln(opts.IO.Out, pr.URL)
-	}
 	if err != nil {
 		if pr != nil {
 			return fmt.Errorf("pull request update failed: %w", err)
 		}
 		return fmt.Errorf("pull request create failed: %w", err)
+	}
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, pr)
+	}
+	if pr != nil {
+		fmt.Fprintln(opts.IO.Out, pr.URL)
 	}
 	return nil
 }

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -270,6 +270,19 @@ func TestNewCmdCreate(t *testing.T) {
 				MaintainerCanModify: true,
 			},
 		},
+		{
+			name:     "json and jq flags",
+			tty:      false,
+			cli:      "--title mytitle --body '' --json number,url --jq .number",
+			wantsErr: false,
+			wantsOpts: CreateOptions{
+				Title:               "mytitle",
+				TitleProvided:       true,
+				Body:                "",
+				BodyProvided:        true,
+				MaintainerCanModify: true,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmdutil/json_flags.go
+++ b/pkg/cmdutil/json_flags.go
@@ -26,8 +26,20 @@ type JSONFlagError struct {
 func AddJSONFlags(cmd *cobra.Command, exportTarget *Exporter, fields []string) {
 	f := cmd.Flags()
 	addJsonFlag(f)
-	addJqFlag(f, "q")
-	addTemplateFlag(f, "t")
+	if f.Lookup("jq") == nil {
+		shorthand := "q"
+		if f.ShorthandLookup("q") != nil {
+			shorthand = ""
+		}
+		addJqFlag(f, shorthand)
+	}
+	if f.Lookup("template") == nil {
+		shorthand := "t"
+		if f.ShorthandLookup("t") != nil {
+			shorthand = ""
+		}
+		addTemplateFlag(f, shorthand)
+	}
 
 	setupJsonFlags(cmd, exportTarget, fields)
 }
@@ -130,14 +142,21 @@ func checkJSONFlags(cmd *cobra.Command) (*jsonExporter, error) {
 			return nil, errors.New("cannot use `--web` with `--json`")
 		}
 		jv := jsonFlag.Value.(pflag.SliceValue)
+		var jqVal, tplVal string
+		if jqFlag != nil {
+			jqVal = jqFlag.Value.String()
+		}
+		if tplFlag != nil && (tplFlag.Shorthand == "t" || tplFlag.Shorthand == "") {
+			tplVal = tplFlag.Value.String()
+		}
 		return &jsonExporter{
 			fields:   jv.GetSlice(),
-			filter:   jqFlag.Value.String(),
-			template: tplFlag.Value.String(),
+			filter:   jqVal,
+			template: tplVal,
 		}, nil
-	} else if jqFlag.Changed {
+	} else if jqFlag != nil && jqFlag.Changed {
 		return nil, errors.New("cannot use `--jq` without specifying `--json`")
-	} else if tplFlag.Changed {
+	} else if tplFlag != nil && (tplFlag.Shorthand == "t" || tplFlag.Shorthand == "") && tplFlag.Changed {
 		return nil, errors.New("cannot use `--template` without specifying `--json`")
 	}
 	return nil, nil


### PR DESCRIPTION
## Summary
Resolves #11247.

Adds `--json` and `--jq` flag support to `gh pr create`:
- Registers `cmdutil.AddJSONFlags` on `NewCmdCreate` using `api.PullRequestFields`.
- Updates `submitPR` to write formatted JSON via `opts.Exporter.Write` when `--json` is provided.
- Updates `cmdutil.AddJSONFlags` to safely check existing flag definitions and avoid flag collision panics.
- Adds test cases in `create_test.go` for `--json` and `--jq`.

## Verification
- Ran `go test ./pkg/cmd/pr/create/...` (passed).
- Ran `go test ./pkg/cmdutil/...` (passed).