### PR TITLE
feat: add --checksum-file to gh release download

### DIFF
--- a/pkg/cmd/release/download/checksum.go
+++ b/pkg/cmd/release/download/checksum.go
@@ -1,0 +1,122 @@
+package download
+
+import (
+	"crypto/sha1" //nolint:gosec // matching publisher-provided checksum files, not a security boundary
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/cli/cli/v2/pkg/iostreams"
+)
+
+type checksumEntry struct {
+	hash string
+	alg  string
+}
+
+// checksumLineRE matches the coreutils `sha256sum`/`sha512sum`/`sha1sum` output format:
+// a hex digest, whitespace, an optional `*` binary-mode marker, then the file name.
+var checksumLineRE = regexp.MustCompile(`^([0-9a-fA-F]+)\s+\*?(.+)$`)
+
+// verifyChecksums reads the downloaded checksum file at dest and confirms that each
+// named asset, also already downloaded to dest, hashes to the value recorded there.
+func verifyChecksums(dest *destinationWriter, checksumFileName string, assetNames []string, io *iostreams.IOStreams) error {
+	data, err := os.ReadFile(dest.makePath(checksumFileName))
+	if err != nil {
+		return fmt.Errorf("reading checksum file %q: %w", checksumFileName, err)
+	}
+
+	checksums := parseChecksumFile(string(data))
+
+	var problems []string
+	for _, name := range assetNames {
+		entry, ok := checksums[name]
+		if !ok {
+			problems = append(problems, fmt.Sprintf("%s: no checksum entry found in %s", name, checksumFileName))
+			continue
+		}
+
+		actual, err := hashFile(dest.makePath(name), entry.alg)
+		if err != nil {
+			return err
+		}
+		if !strings.EqualFold(actual, entry.hash) {
+			problems = append(problems, fmt.Sprintf("%s: checksum mismatch (expected %s, got %s)", name, entry.hash, actual))
+		}
+	}
+
+	if len(problems) > 0 {
+		return fmt.Errorf("checksum verification failed:\n%s", strings.Join(problems, "\n"))
+	}
+
+	fmt.Fprintf(io.Out, "Verified checksums for %d asset(s) against %s\n", len(assetNames), checksumFileName)
+	return nil
+}
+
+// parseChecksumFile parses lines of the form "<hex digest>  <filename>", inferring the
+// hash algorithm from the digest length (40 hex chars = sha1, 64 = sha256, 128 = sha512).
+// Unrecognized or malformed lines are skipped.
+func parseChecksumFile(data string) map[string]checksumEntry {
+	checksums := make(map[string]checksumEntry)
+	for line := range strings.SplitSeq(data, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		matches := checksumLineRE.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+
+		alg := algForDigestLength(len(matches[1]))
+		if alg == "" {
+			continue
+		}
+
+		checksums[matches[2]] = checksumEntry{hash: matches[1], alg: alg}
+	}
+	return checksums
+}
+
+func algForDigestLength(n int) string {
+	switch n {
+	case 40:
+		return "sha1"
+	case 64:
+		return "sha256"
+	case 128:
+		return "sha512"
+	default:
+		return ""
+	}
+}
+
+func hashFile(path, alg string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	var h hash.Hash
+	switch alg {
+	case "sha1":
+		h = sha1.New() //nolint:gosec // matching publisher-provided checksum files, not a security boundary
+	case "sha256":
+		h = sha256.New()
+	case "sha512":
+		h = sha512.New()
+	}
+
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hashing %s: %w", path, err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/pkg/cmd/release/download/checksum_test.go
+++ b/pkg/cmd/release/download/checksum_test.go
@@ -1,0 +1,77 @@
+package download
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseChecksumFile(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want map[string]checksumEntry
+	}{
+		{
+			name: "sha256sum format",
+			data: "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4  windows-32bit.zip\n",
+			want: map[string]checksumEntry{
+				"windows-32bit.zip": {hash: "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4", alg: "sha256"},
+			},
+		},
+		{
+			name: "sha1sum format",
+			data: "da39a3ee5e6b4b0d3255bfef95601890afd80709  empty.txt\n",
+			want: map[string]checksumEntry{
+				"empty.txt": {hash: "da39a3ee5e6b4b0d3255bfef95601890afd80709", alg: "sha1"},
+			},
+		},
+		{
+			name: "binary mode marker is stripped from the filename",
+			data: "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4 *windows-32bit.zip\n",
+			want: map[string]checksumEntry{
+				"windows-32bit.zip": {hash: "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4", alg: "sha256"},
+			},
+		},
+		{
+			name: "blank lines and comments are ignored",
+			data: "\n# checksums\n\n03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4  windows-32bit.zip\n",
+			want: map[string]checksumEntry{
+				"windows-32bit.zip": {hash: "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4", alg: "sha256"},
+			},
+		},
+		{
+			name: "unrecognized digest length is ignored",
+			data: "deadbeef  windows-32bit.zip\n",
+			want: map[string]checksumEntry{},
+		},
+		{
+			name: "empty file",
+			data: "",
+			want: map[string]checksumEntry{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseChecksumFile(tt.data))
+		})
+	}
+}
+
+func TestAlgForDigestLength(t *testing.T) {
+	tests := []struct {
+		length int
+		want   string
+	}{
+		{40, "sha1"},
+		{64, "sha256"},
+		{128, "sha512"},
+		{32, ""},
+		{0, ""},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, algForDigestLength(tt.length))
+	}
+}

--- a/pkg/cmd/release/download/download.go
+++ b/pkg/cmd/release/download/download.go
@@ -33,6 +33,7 @@ type DownloadOptions struct {
 	FilePatterns      []string
 	Destination       string
 	OutputFile        string
+	ChecksumFile      string
 
 	// maximum number of simultaneous downloads
 	Concurrency int
@@ -68,6 +69,9 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 
 			# Download the archive of the source code for a release
 			$ gh release download v1.2.3 --archive=zip
+
+			# Download assets and verify them against a checksum file from the same release
+			$ gh release download v1.2.3 --checksum-file checksums.txt
 		`),
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -95,6 +99,10 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 				return err
 			}
 
+			if err := cmdutil.MutuallyExclusive("specify only one of `--archive` or `--checksum-file`", opts.ArchiveType != "", opts.ChecksumFile != ""); err != nil {
+				return err
+			}
+
 			opts.Concurrency = 5
 
 			if runF != nil {
@@ -110,6 +118,7 @@ func NewCmdDownload(f *cmdutil.Factory, runF func(*DownloadOptions) error) *cobr
 	cmd.Flags().StringVarP(&opts.ArchiveType, "archive", "A", "", "Download the source code archive in the specified `format` (zip or tar.gz)")
 	cmd.Flags().BoolVar(&opts.OverwriteExisting, "clobber", false, "Overwrite existing files of the same name")
 	cmd.Flags().BoolVar(&opts.SkipExisting, "skip-existing", false, "Skip downloading when files of the same name exist")
+	cmd.Flags().StringVar(&opts.ChecksumFile, "checksum-file", "", "Verify downloaded assets against a checksum `file` from the same release")
 
 	cmdutil.DisableAuthCheck(cmd)
 
@@ -210,6 +219,14 @@ func downloadRun(opts *DownloadOptions) error {
 		return errors.New("no assets to download")
 	}
 
+	if opts.ChecksumFile != "" {
+		var err error
+		toDownload, err = addChecksumAsset(release.Assets, toDownload, opts.ChecksumFile)
+		if err != nil {
+			return err
+		}
+	}
+
 	if len(toDownload) > 1 && opts.OutputFile != "" {
 		return fmt.Errorf("unable to write more than one asset with `--output`, got %d assets", len(toDownload))
 	}
@@ -222,7 +239,46 @@ func downloadRun(opts *DownloadOptions) error {
 		stdout:       opts.IO.Out,
 	}
 
-	return downloadAssets(&dest, httpClient, toDownload, opts.Concurrency, isArchive, opts.IO)
+	if err := downloadAssets(&dest, httpClient, toDownload, opts.Concurrency, isArchive, opts.IO); err != nil {
+		return err
+	}
+
+	if opts.ChecksumFile == "" {
+		return nil
+	}
+	return verifyChecksums(&dest, opts.ChecksumFile, assetNamesExcept(toDownload, opts.ChecksumFile), opts.IO)
+}
+
+// addChecksumAsset ensures the named checksum file asset is included in toDownload,
+// appending it if it wasn't already selected by a file pattern.
+func addChecksumAsset(releaseAssets, toDownload []shared.ReleaseAsset, checksumFileName string) ([]shared.ReleaseAsset, error) {
+	for _, a := range toDownload {
+		if a.Name == checksumFileName {
+			return toDownload, nil
+		}
+	}
+
+	for _, a := range releaseAssets {
+		if a.Name != checksumFileName {
+			continue
+		}
+		if runtime.GOOS == "windows" && isWindowsReservedFilename(a.Name) {
+			return nil, fmt.Errorf("unable to download release due to asset with reserved filename %q", a.Name)
+		}
+		return append(toDownload, a), nil
+	}
+
+	return nil, fmt.Errorf("checksum file %q not found among release assets", checksumFileName)
+}
+
+func assetNamesExcept(assets []shared.ReleaseAsset, exclude string) []string {
+	names := make([]string, 0, len(assets))
+	for _, a := range assets {
+		if a.Name != exclude {
+			names = append(names, a.Name)
+		}
+	}
+	return names
 }
 
 func matchAny(patterns []string, name string) bool {

--- a/pkg/cmd/release/download/download_test.go
+++ b/pkg/cmd/release/download/download_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/cli/cli/v2/internal/ghrepo"
@@ -130,6 +131,24 @@ func Test_NewCmdDownload(t *testing.T) {
 			isTTY:   true,
 			wantErr: "specify only one of `--dir` or `--output`",
 		},
+		{
+			name:  "version and checksum file",
+			args:  "v1.2.3 --checksum-file checksums.txt",
+			isTTY: true,
+			want: DownloadOptions{
+				TagName:      "v1.2.3",
+				FilePatterns: []string(nil),
+				Destination:  ".",
+				ChecksumFile: "checksums.txt",
+				Concurrency:  5,
+			},
+		},
+		{
+			name:    "simultaneous archive and checksum file",
+			args:    "v1.2.3 -A zip --checksum-file checksums.txt",
+			isTTY:   true,
+			wantErr: "specify only one of `--archive` or `--checksum-file`",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -169,6 +188,7 @@ func Test_NewCmdDownload(t *testing.T) {
 			assert.Equal(t, tt.want.Destination, opts.Destination)
 			assert.Equal(t, tt.want.Concurrency, opts.Concurrency)
 			assert.Equal(t, tt.want.OutputFile, opts.OutputFile)
+			assert.Equal(t, tt.want.ChecksumFile, opts.ChecksumFile)
 		})
 	}
 }
@@ -308,6 +328,132 @@ func Test_downloadRun(t *testing.T) {
 			wantStdout: ``,
 			wantStderr: ``,
 			wantErr:    "no assets match the file pattern",
+		},
+		{
+			name:  "download all assets and verify checksums",
+			isTTY: true,
+			opts: DownloadOptions{
+				TagName:      "v1.2.3",
+				Destination:  ".",
+				Concurrency:  2,
+				ChecksumFile: "checksums.txt",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{
+					"assets": [
+						{ "name": "windows-32bit.zip", "size": 12,
+						"url": "https://api.github.com/assets/1234" },
+						{ "name": "windows-64bit.zip", "size": 34,
+						"url": "https://api.github.com/assets/3456" },
+						{ "name": "linux.tgz", "size": 56,
+						"url": "https://api.github.com/assets/5678" },
+						{ "name": "checksums.txt", "size": 200,
+						"url": "https://api.github.com/assets/9999" }
+					],
+					"tarball_url": "https://api.github.com/repos/OWNER/REPO/tarball/v1.2.3",
+					"zipball_url": "https://api.github.com/repos/OWNER/REPO/zipball/v1.2.3"
+				}`)
+
+				reg.Register(httpmock.REST("GET", "assets/1234"), httpmock.StringResponse(`1234`))
+				reg.Register(httpmock.REST("GET", "assets/3456"), httpmock.StringResponse(`3456`))
+				reg.Register(httpmock.REST("GET", "assets/5678"), httpmock.StringResponse(`5678`))
+				reg.Register(httpmock.REST("GET", "assets/9999"), httpmock.StringResponse(strings.Join([]string{
+					"03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4  windows-32bit.zip",
+					"ceaa28bba4caba687dc31b1bbe79eca3c70c33f871f1ce8f528cf9ab5cfd76dd  windows-64bit.zip",
+					"f8638b979b2f4f793ddb6dbd197e0ee25a7a6ea32b0ae22f5e3c5d119d839e75  linux.tgz",
+				}, "\n")))
+			},
+			wantStdout: "Verified checksums for 3 asset(s) against checksums.txt\n",
+			wantStderr: ``,
+			wantFiles: []string{
+				"checksums.txt",
+				"linux.tgz",
+				"windows-32bit.zip",
+				"windows-64bit.zip",
+			},
+		},
+		{
+			name:  "download assets fails when a checksum does not match",
+			isTTY: true,
+			opts: DownloadOptions{
+				TagName:      "v1.2.3",
+				Destination:  ".",
+				Concurrency:  2,
+				ChecksumFile: "checksums.txt",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{
+					"assets": [
+						{ "name": "windows-32bit.zip", "size": 12,
+						"url": "https://api.github.com/assets/1234" },
+						{ "name": "checksums.txt", "size": 200,
+						"url": "https://api.github.com/assets/9999" }
+					],
+					"tarball_url": "https://api.github.com/repos/OWNER/REPO/tarball/v1.2.3",
+					"zipball_url": "https://api.github.com/repos/OWNER/REPO/zipball/v1.2.3"
+				}`)
+
+				reg.Register(httpmock.REST("GET", "assets/1234"), httpmock.StringResponse(`1234`))
+				reg.Register(httpmock.REST("GET", "assets/9999"), httpmock.StringResponse(
+					"0000000000000000000000000000000000000000000000000000000000000000  windows-32bit.zip\n",
+				))
+			},
+			wantStdout: ``,
+			wantStderr: ``,
+			wantErr: "checksum verification failed:\n" +
+				"windows-32bit.zip: checksum mismatch (expected 0000000000000000000000000000000000000000000000000000000000000000, " +
+				"got 03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4)",
+		},
+		{
+			name:  "download assets fails when checksum file is missing an entry",
+			isTTY: true,
+			opts: DownloadOptions{
+				TagName:      "v1.2.3",
+				Destination:  ".",
+				Concurrency:  2,
+				ChecksumFile: "checksums.txt",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{
+					"assets": [
+						{ "name": "windows-32bit.zip", "size": 12,
+						"url": "https://api.github.com/assets/1234" },
+						{ "name": "checksums.txt", "size": 200,
+						"url": "https://api.github.com/assets/9999" }
+					],
+					"tarball_url": "https://api.github.com/repos/OWNER/REPO/tarball/v1.2.3",
+					"zipball_url": "https://api.github.com/repos/OWNER/REPO/zipball/v1.2.3"
+				}`)
+
+				reg.Register(httpmock.REST("GET", "assets/1234"), httpmock.StringResponse(`1234`))
+				reg.Register(httpmock.REST("GET", "assets/9999"), httpmock.StringResponse(""))
+			},
+			wantStdout: ``,
+			wantStderr: ``,
+			wantErr:    "checksum verification failed:\nwindows-32bit.zip: no checksum entry found in checksums.txt",
+		},
+		{
+			name:  "download fails when checksum file is not among release assets",
+			isTTY: true,
+			opts: DownloadOptions{
+				TagName:      "v1.2.3",
+				Destination:  ".",
+				Concurrency:  2,
+				ChecksumFile: "checksums.txt",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				shared.StubFetchRelease(t, reg, "OWNER", "REPO", "v1.2.3", `{
+					"assets": [
+						{ "name": "windows-32bit.zip", "size": 12,
+						"url": "https://api.github.com/assets/1234" }
+					],
+					"tarball_url": "https://api.github.com/repos/OWNER/REPO/tarball/v1.2.3",
+					"zipball_url": "https://api.github.com/repos/OWNER/REPO/zipball/v1.2.3"
+				}`)
+			},
+			wantStdout: ``,
+			wantStderr: ``,
+			wantErr:    `checksum file "checksums.txt" not found among release assets`,
 		},
 		{
 			name:  "download archive in zip format into destination directory",


### PR DESCRIPTION
## Summary
- Adds `--checksum-file <file>` to `gh release download`, verifying downloaded assets against a checksum file asset pulled from the same release.
- Supports `sha256sum`/`sha1sum`/`sha512sum`-style checksum files, auto-detecting the algorithm from digest length (40/64/128 hex chars).
- Mutually exclusive with `--archive`, since GitHub-generated source archives aren't typically listed in a project's checksums file.
- On mismatch or missing checksum entries, the command fails and lists every problem; already-downloaded files are left on disk.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/cmd/release/...`
- [x] `golangci-lint run ./pkg/cmd/release/...`
- [x] `go test ./pkg/cmd/release/...`
- [x] Added unit tests for flag parsing/validation, successful verification, checksum mismatch, missing checksum entries, missing checksum-file asset, and the checksum-file parser itself.