### PR TITLE
Fix skill updates for hidden source paths

### DIFF
--- a/pkg/cmd/skills/update/update.go
+++ b/pkg/cmd/skills/update/update.go
@@ -250,9 +250,15 @@ func updateRun(opts *UpdateOptions) error {
 	var pinned []installedSkill
 
 	type repoKey struct{ host, owner, repo string }
+	type skillPathKey struct {
+		repoKey
+		path string
+	}
 	repoSkills := make(map[repoKey][]discovery.Skill)
 	repoRefs := make(map[repoKey]*discovery.ResolvedRef)
 	repoErrors := make(map[repoKey]bool)
+	pathSkills := make(map[skillPathKey]*discovery.Skill)
+	pathErrors := make(map[skillPathKey]error)
 
 	for _, s := range installed {
 		if s.owner == "" || s.repo == "" {
@@ -269,7 +275,7 @@ func updateRun(opts *UpdateOptions) error {
 			continue
 		}
 
-		// Resolve ref and discover skills once per repo
+		// Resolve ref once per repo.
 		if _, ok := repoRefs[key]; !ok {
 			resolved, resolveErr := discovery.ResolveRef(apiClient, s.repoHost, s.owner, s.repo, "")
 			if resolveErr != nil {
@@ -280,35 +286,77 @@ func updateRun(opts *UpdateOptions) error {
 				continue
 			}
 			repoRefs[key] = resolved
-
-			skills, discoverErr := discovery.DiscoverSkills(apiClient, s.repoHost, s.owner, s.repo, resolved.SHA)
-			if discoverErr != nil {
-				repoErrors[key] = true
-				opts.IO.StopProgressIndicator()
-				fmt.Fprintf(opts.IO.ErrOut, "%s Skipping %s: %v\n", cs.WarningIcon(), s.name, discoverErr)
-				opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Checking %d installed skill(s) for updates", len(installed)))
-				continue
-			}
-			repoSkills[key] = skills
 		}
 
 		resolved := repoRefs[key]
-		for _, remote := range repoSkills[key] {
-			matched := false
-			if s.sourcePath != "" {
-				matched = remote.Path == s.sourcePath
-			} else {
-				matched = remote.InstallName() == s.name
+		var remoteSkill *discovery.Skill
+
+		if s.sourcePath != "" && hasHiddenPathSegment(s.sourcePath) {
+			pathKey := skillPathKey{repoKey: key, path: s.sourcePath}
+			if pathErr, ok := pathErrors[pathKey]; ok {
+				opts.IO.StopProgressIndicator()
+				fmt.Fprintf(opts.IO.ErrOut, "%s Skipping %s: %v\n", cs.WarningIcon(), s.name, pathErr)
+				opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Checking %d installed skill(s) for updates", len(installed)))
+				continue
 			}
-			if matched && (remote.TreeSHA != s.treeSHA || opts.Force) {
-				updates = append(updates, pendingUpdate{
-					local:    s,
-					newSHA:   remote.TreeSHA,
-					resolved: resolved,
-					skill:    remote,
-				})
-				break
+
+			skill, ok := pathSkills[pathKey]
+			if !ok {
+				var discoverErr error
+				skill, discoverErr = discovery.DiscoverSkillByPathWithOptions(
+					apiClient,
+					s.repoHost,
+					s.owner,
+					s.repo,
+					resolved.SHA,
+					s.sourcePath,
+					discovery.DiscoverSkillByPathOptions{SkipDescription: true},
+				)
+				if discoverErr != nil {
+					pathErrors[pathKey] = discoverErr
+					opts.IO.StopProgressIndicator()
+					fmt.Fprintf(opts.IO.ErrOut, "%s Skipping %s: %v\n", cs.WarningIcon(), s.name, discoverErr)
+					opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Checking %d installed skill(s) for updates", len(installed)))
+					continue
+				}
+				pathSkills[pathKey] = skill
 			}
+			remoteSkill = skill
+		} else {
+			if _, ok := repoSkills[key]; !ok {
+				skills, discoverErr := discovery.DiscoverSkills(apiClient, s.repoHost, s.owner, s.repo, resolved.SHA)
+				if discoverErr != nil {
+					repoErrors[key] = true
+					opts.IO.StopProgressIndicator()
+					fmt.Fprintf(opts.IO.ErrOut, "%s Skipping %s: %v\n", cs.WarningIcon(), s.name, discoverErr)
+					opts.IO.StartProgressIndicatorWithLabel(fmt.Sprintf("Checking %d installed skill(s) for updates", len(installed)))
+					continue
+				}
+				repoSkills[key] = skills
+			}
+
+			for i := range repoSkills[key] {
+				remote := &repoSkills[key][i]
+				matched := false
+				if s.sourcePath != "" {
+					matched = remote.Path == s.sourcePath
+				} else {
+					matched = remote.InstallName() == s.name
+				}
+				if matched {
+					remoteSkill = remote
+					break
+				}
+			}
+		}
+
+		if remoteSkill != nil && (remoteSkill.TreeSHA != s.treeSHA || opts.Force) {
+			updates = append(updates, pendingUpdate{
+				local:    s,
+				newSHA:   remoteSkill.TreeSHA,
+				resolved: resolved,
+				skill:    *remoteSkill,
+			})
 		}
 	}
 
@@ -636,6 +684,15 @@ func parseInstalledSkill(data []byte, name, dir string, host *registry.AgentHost
 	}
 
 	return s, true
+}
+
+func hasHiddenPathSegment(p string) bool {
+	for _, segment := range strings.Split(p, "/") {
+		if strings.HasPrefix(segment, ".") {
+			return true
+		}
+	}
+	return false
 }
 
 // promptForSkillOrigin asks the user for the source repository of a skill

--- a/pkg/cmd/skills/update/update_test.go
+++ b/pkg/cmd/skills/update/update_test.go
@@ -555,6 +555,64 @@ func TestUpdateRun(t *testing.T) {
 			wantStderr: "All skills are up to date.",
 		},
 		{
+			name: "path-based update finds hidden source path",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				skillDir := filepath.Join(dir, "gh-address-comments")
+				require.NoError(t, os.MkdirAll(skillDir, 0o755))
+				skillContent := `---
+name: gh-address-comments
+metadata:
+  github-repo: https://github.com/openai/skills
+  github-tree-sha: oldtree123
+  github-path: skills/.curated/gh-address-comments
+---
+Installed content
+`
+				require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillContent), 0o644))
+			},
+			stubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.REST("GET", "repos/openai/skills/releases/latest"),
+					httpmock.StringResponse(`{"tag_name": "v1.0.0"}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/openai/skills/git/ref/tags/v1.0.0"),
+					httpmock.StringResponse(`{"object": {"sha": "commitsha123", "type": "commit"}}`),
+				)
+				reg.Register(
+					httpmock.REST("GET", "repos/openai/skills/contents/skills%2F.curated"),
+					httpmock.JSONResponse([]map[string]interface{}{
+						{"name": "gh-address-comments", "path": "skills/.curated/gh-address-comments", "sha": "newtree456", "type": "dir"},
+					}))
+				reg.Register(
+					httpmock.REST("GET", "repos/openai/skills/git/trees/newtree456"),
+					httpmock.JSONResponse(map[string]interface{}{
+						"sha": "newtree456", "truncated": false,
+						"tree": []map[string]interface{}{
+							{"path": "SKILL.md", "type": "blob", "sha": "blobsha2"},
+						},
+					}))
+			},
+			opts: func(ios *iostreams.IOStreams, dir string, reg *httpmock.Registry) *UpdateOptions {
+				ios.SetStdoutTTY(true)
+				ios.SetStderrTTY(true)
+				return &UpdateOptions{
+					IO:     ios,
+					Config: func() (gh.Config, error) { return config.NewBlankConfig(), nil },
+					HttpClient: func() (*http.Client, error) {
+						return &http.Client{Transport: reg}, nil
+					},
+					Prompter:  &prompter.PrompterMock{},
+					GitClient: &git.Client{RepoDir: dir},
+					Dir:       dir,
+					DryRun:    true,
+				}
+			},
+			wantStderr: "1 update(s) available:",
+			wantStdout: "gh-address-comments",
+		},
+		{
 			name: "dry run reports available updates",
 			setup: func(t *testing.T, dir string) {
 				t.Helper()


### PR DESCRIPTION
## Summary

Fixes path-based skill updates for installed skills whose recorded GitHub path contains hidden directory segments such as `.curated`.

When an installed skill has `github-path` metadata with a hidden segment, `gh skill update --all` now resolves that exact path with `DiscoverSkillByPathWithOptions` instead of relying on repository-wide discovery that skips hidden directories by default.

Fixes #13542.

## Validation

- `go test ./internal/skills/discovery ./pkg/cmd/skills/update`