### PR TITLE
Strip ANSI escapes from run logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/cli/go-gh/v2 v2.13.0
 	github.com/cli/go-internal v0.0.0-20241025142207-6c48bcd5ce24
 	github.com/cli/oauth v1.2.2
@@ -82,7 +83,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/ordered v0.1.0 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250630141444-821143405392 // indirect

--- a/pkg/cmd/run/view/view.go
+++ b/pkg/cmd/run/view/view.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	termansi "github.com/charmbracelet/x/ansi"
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/browser"
 	"github.com/cli/cli/v2/internal/ghinstance"
@@ -581,10 +582,14 @@ func displayLogSegments(w io.Writer, segments []logSegment) error {
 }
 
 func copyLogWithLinePrefix(w io.Writer, r io.Reader, prefix string) error {
-	sanitized := transform.NewReader(r, &asciisanitizer.Sanitizer{})
-	scanner := bufio.NewScanner(sanitized)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		fmt.Fprintf(w, "%s%s\n", prefix, scanner.Text())
+		stripped := termansi.Strip(scanner.Text())
+		sanitized, _, err := transform.String(&asciisanitizer.Sanitizer{}, stripped)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "%s%s\n", prefix, sanitized)
 	}
-	return nil
+	return scanner.Err()
 }

--- a/pkg/cmd/run/view/view_test.go
+++ b/pkg/cmd/run/view/view_test.go
@@ -2799,6 +2799,14 @@ func TestCopyLogWithLinePrefix_TerminalEscapeSequences(t *testing.T) {
 	}
 }
 
+func TestCopyLogWithLinePrefix_StripsCSISequences(t *testing.T) {
+	var buf bytes.Buffer
+	err := copyLogWithLinePrefix(&buf, strings.NewReader("\x1b[1;93mcolored text\x1b[0m normal text \x1b[21tafter\n"), "jobname\tstep\t")
+	require.NoError(t, err)
+
+	assert.Equal(t, "jobname\tstep\tcolored text normal text after\n", buf.String())
+}
+
 func TestRunLog(t *testing.T) {
 	t.Run("when the cache dir doesn't exist, exists return false", func(t *testing.T) {
 		cacheDir := t.TempDir() + "/non-existent-dir"


### PR DESCRIPTION
## Summary

Strip terminal ANSI escape sequences from `gh run view --log` output when logs are copied with job and step prefixes.

The line-copying path now removes terminal control sequences with `github.com/charmbracelet/x/ansi` before applying the existing ASCII sanitizer, so colored log output remains readable.

Fixes #13434.

## Validation

- `go test ./pkg/cmd/run/view`