### PR TITLE
Fix skill picker label wrapping

### DIFF
--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -35,9 +35,9 @@ const (
 	// allSkillsKey is the persistent option label for selecting all skills.
 	allSkillsKey = "(all skills)"
 
-	// multiSelectLabelMargin accounts for the cursor and checkbox before each
-	// option, plus one column to avoid triggering terminal auto-wrap.
-	multiSelectLabelMargin = 7
+	// multiSelectLabelMargin reserves columns for the widest option prefix used
+	// by the available prompters: huh's border, padding, cursor, and checkbox.
+	multiSelectLabelMargin = 8
 
 	// maxSearchResults caps how many skills are shown per search page in
 	// interactive selection, keeping the prompt readable.

--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -35,6 +35,10 @@ const (
 	// allSkillsKey is the persistent option label for selecting all skills.
 	allSkillsKey = "(all skills)"
 
+	// multiSelectLabelMargin accounts for the cursor and checkbox before each
+	// option, plus one column to avoid triggering terminal auto-wrap.
+	multiSelectLabelMargin = 7
+
 	// maxSearchResults caps how many skills are shown per search page in
 	// interactive selection, keeping the prompt readable.
 	maxSearchResults = 30
@@ -721,10 +725,9 @@ func selectSkillsWithSelector(opts *InstallOptions, skills []discovery.Skill, ca
 		sel.fetchDescriptions()
 	}
 
-	tw := opts.IO.TerminalWidth()
-	descWidth := tw - 35
-	if descWidth < 20 {
-		descWidth = 20
+	labelWidth := opts.IO.TerminalWidth() - multiSelectLabelMargin
+	if labelWidth < 1 {
+		labelWidth = 1
 	}
 
 	selected, err := opts.Prompter.MultiSelectWithSearch(
@@ -732,7 +735,7 @@ func selectSkillsWithSelector(opts *InstallOptions, skills []discovery.Skill, ca
 		"Filter skills",
 		nil,
 		[]string{allSkillsKey},
-		skillSearchFunc(skills, descWidth),
+		skillSearchFunc(skills, labelWidth),
 	)
 	if err != nil {
 		return nil, err
@@ -837,7 +840,7 @@ func matchLocalSkillByName(opts *InstallOptions, skills []discovery.Skill) ([]di
 
 // skillSearchFunc returns a search function for MultiSelectWithSearch that
 // filters skills by case-insensitive substring match on name and description.
-func skillSearchFunc(skills []discovery.Skill, descWidth int) func(string) prompter.MultiSelectSearchResult {
+func skillSearchFunc(skills []discovery.Skill, labelWidth int) func(string) prompter.MultiSelectSearchResult {
 	return func(query string) prompter.MultiSelectSearchResult {
 		var matched []discovery.Skill
 		if query == "" {
@@ -862,11 +865,11 @@ func skillSearchFunc(skills []discovery.Skill, descWidth int) func(string) promp
 		labels := make([]string, len(matched))
 		for i, s := range matched {
 			keys[i] = s.DisplayName()
+			label := s.DisplayName()
 			if s.Description != "" {
-				labels[i] = fmt.Sprintf("%s - %s", s.DisplayName(), truncateDescription(s.Description, descWidth))
-			} else {
-				labels[i] = s.DisplayName()
+				label = fmt.Sprintf("%s - %s", label, text.RemoveExcessiveWhitespace(s.Description))
 			}
+			labels[i] = text.Truncate(labelWidth, label)
 		}
 
 		return prompter.MultiSelectSearchResult{
@@ -1036,10 +1039,6 @@ func formatPlanHosts(hosts []*registry.AgentHost) string {
 		names[i] = host.Name
 	}
 	return strings.Join(names, ", ")
-}
-
-func truncateDescription(s string, maxWidth int) string {
-	return text.Truncate(maxWidth, text.RemoveExcessiveWhitespace(s))
 }
 
 func checkOverwrite(opts *InstallOptions, skills []discovery.Skill, targetDir string, canPrompt bool) ([]discovery.Skill, error) {

--- a/pkg/cmd/skills/install/install_test.go
+++ b/pkg/cmd/skills/install/install_test.go
@@ -2498,13 +2498,23 @@ func TestSkillSearchFuncTruncatesLabelsToAvailableWidth(t *testing.T) {
 		},
 	}
 
-	for _, terminalWidth := range []int{40, 60, 80, 120} {
-		t.Run(fmt.Sprintf("terminal width %d", terminalWidth), func(t *testing.T) {
-			labelWidth := terminalWidth - multiSelectLabelMargin
+	tests := []struct {
+		terminalWidth      int
+		expectedLabelWidth int
+	}{
+		{terminalWidth: 40, expectedLabelWidth: 32},
+		{terminalWidth: 60, expectedLabelWidth: 52},
+		{terminalWidth: 80, expectedLabelWidth: 72},
+		{terminalWidth: 120, expectedLabelWidth: 112},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("terminal width %d", tt.terminalWidth), func(t *testing.T) {
+			labelWidth := tt.terminalWidth - multiSelectLabelMargin
 			result := skillSearchFunc(skills, labelWidth)("")
 
 			require.Len(t, result.Labels, 2)
-			assert.Less(t, text.DisplayWidth("> [ ] "+result.Labels[0]), terminalWidth)
+			assert.Equal(t, tt.expectedLabelWidth, text.DisplayWidth(result.Labels[0]))
 			assert.Equal(t, "[plugins] octocat/telemetry-instrumentation", result.Keys[0])
 			assert.True(t, strings.HasSuffix(result.Labels[0], "..."))
 			assert.Equal(t, "achievement-badges", result.Labels[1])

--- a/pkg/cmd/skills/install/install_test.go
+++ b/pkg/cmd/skills/install/install_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cli/cli/v2/internal/skills/discovery"
 	"github.com/cli/cli/v2/internal/skills/registry"
 	"github.com/cli/cli/v2/internal/telemetry"
+	"github.com/cli/cli/v2/internal/text"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -2482,6 +2483,33 @@ func Test_selectSkillsWithSelector_noDisclaimer(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.NotContains(t, stderr.String(), "not verified by GitHub")
+}
+
+func TestSkillSearchFuncTruncatesLabelsToAvailableWidth(t *testing.T) {
+	skills := []discovery.Skill{
+		{
+			Name:        "telemetry-instrumentation",
+			Namespace:   "octocat",
+			Convention:  "plugins",
+			Description: "Add tracing, logging, resource attributes, metrics, dashboards, alerts, sampling, or instrumentation to an application",
+		},
+		{
+			Name: "achievement-badges",
+		},
+	}
+
+	for _, terminalWidth := range []int{40, 60, 80, 120} {
+		t.Run(fmt.Sprintf("terminal width %d", terminalWidth), func(t *testing.T) {
+			labelWidth := terminalWidth - multiSelectLabelMargin
+			result := skillSearchFunc(skills, labelWidth)("")
+
+			require.Len(t, result.Labels, 2)
+			assert.Less(t, text.DisplayWidth("> [ ] "+result.Labels[0]), terminalWidth)
+			assert.Equal(t, "[plugins] octocat/telemetry-instrumentation", result.Keys[0])
+			assert.True(t, strings.HasSuffix(result.Labels[0], "..."))
+			assert.Equal(t, "achievement-badges", result.Labels[1])
+		})
+	}
 }
 
 func TestInstallRun_TelemetryVisibility(t *testing.T) {


### PR DESCRIPTION
Truncates skill picker labels to the available terminal width so descriptions do not wrap onto a separate line.

Adds coverage for multiple terminal widths.

**Before**
<img width="597" height="560" alt="Screenshot 2026-07-24 at 16 07 51" src="https://github.com/user-attachments/assets/2cf4f67e-2e40-435b-8c98-cbce5ba4d9c8" />

**After (Examples with varying terminal width)**
<img width="577" height="560" alt="Screenshot 2026-07-24 at 16 06 22" src="https://github.com/user-attachments/assets/30f29c05-fd19-4672-bc38-c4dfcfe7c60a" />
<img width="856" height="560" alt="Screenshot 2026-07-24 at 16 06 43" src="https://github.com/user-attachments/assets/636db715-823f-487b-80df-4f959ba7a5e3" />
<img width="1285" height="560" alt="Screenshot 2026-07-24 at 16 07 21" src="https://github.com/user-attachments/assets/1e88f7d8-72d8-4037-bed4-ad16b7bfaf96" />
